### PR TITLE
[rocprofiler-sdk] Improve error message for invalid extra counters YAML format

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -141,6 +141,23 @@ loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)
                 header.push_back(counter);
             }
         }
+        else
+        {
+            ROCP_ERROR << "Invalid extra counters YAML format. Expected structure:\n"
+                       << "rocprofiler-sdk:\n"
+                       << "  counters-schema-version: 1\n"
+                       << "  counters:\n"
+                       << "  - name: COUNTER_NAME\n"
+                       << "    description: 'Counter description'\n"
+                       << "    properties: []\n"
+                       << "    definitions:\n"
+                       << "    - architectures:\n"
+                       << "      - gfx942\n"
+                       << "      block: BLOCK_NAME\n"
+                       << "      event: EVENT_ID\n"
+                       << "Got:\n"
+                       << override.data;
+        }
     }
 
     for(const auto& counter : header)


### PR DESCRIPTION
When users provide an incorrectly formatted YAML file to the -E/--extra-counters option in rocprofv3, they now receive a clear error message showing:

- What went wrong (invalid YAML format)
- The correct rocprofiler-sdk YAML structure with example
- The actual content that failed to parse

This addresses confusion where users might use the legacy ROCProfiler YAML format instead of the new rocprofiler-sdk schema format.