### PR TITLE
[GitHub Actions] Change Auto-Label Trigger

### DIFF
--- a/.github/repos-added-config-release.json
+++ b/.github/repos-added-config-release.json
@@ -1,0 +1,36 @@
+{
+  "repositories": [
+    {
+      "name": "clr",
+      "url": "ROCm/clr",
+      "branch": "release/rocm-rel-7.0",
+      "category": "projects",
+      "auto_subtree_pull": true,
+      "auto_subtree_push": false
+    },
+    {
+      "name": "hip",
+      "url": "ROCm/hip",
+      "branch": "release/rocm-rel-7.0",
+      "category": "projects",
+      "auto_subtree_pull": true,
+      "auto_subtree_push": false
+    },
+    {
+      "name": "hipother",
+      "url": "ROCm/hipother",
+      "branch": "release/rocm-rel-7.0",
+      "category": "projects",
+      "auto_subtree_pull": true,
+      "auto_subtree_push": false
+    },
+    {
+      "name": "hip-tests",
+      "url": "ROCm/hip-tests",
+      "branch": "release/rocm-rel-7.0",
+      "category": "projects",
+      "auto_subtree_pull": true,
+      "auto_subtree_push": false
+    }
+  ]
+}

--- a/.github/repos-added-config.json
+++ b/.github/repos-added-config.json
@@ -1,0 +1,36 @@
+{
+  "repositories": [
+    {
+      "name": "clr",
+      "url": "ROCm/clr",
+      "branch": "amd-staging",
+      "category": "projects",
+      "auto_subtree_pull": true,
+      "auto_subtree_push": false
+    },
+    {
+      "name": "hip",
+      "url": "ROCm/hip",
+      "branch": "amd-staging",
+      "category": "projects",
+      "auto_subtree_pull": true,
+      "auto_subtree_push": false
+    },
+    {
+      "name": "hipother",
+      "url": "ROCm/hipother",
+      "branch": "amd-staging",
+      "category": "projects",
+      "auto_subtree_pull": true,
+      "auto_subtree_push": false
+    },
+    {
+      "name": "hip-tests",
+      "url": "ROCm/hip-tests",
+      "branch": "amd-staging",
+      "category": "projects",
+      "auto_subtree_pull": true,
+      "auto_subtree_push": false
+    }
+  ]
+}

--- a/.github/repos-config-release.json
+++ b/.github/repos-config-release.json
@@ -9,11 +9,43 @@
       "auto_subtree_push": false
     },
     {
+      "name": "clr",
+      "url": "ROCm/clr",
+      "branch": "release/rocm-rel-7.0",
+      "category": "projects",
+      "auto_subtree_pull": true,
+      "auto_subtree_push": false
+    },
+    {
+      "name": "hip",
+      "url": "ROCm/hip",
+      "branch": "release/rocm-rel-7.0",
+      "category": "projects",
+      "auto_subtree_pull": true,
+      "auto_subtree_push": false
+    },
+    {
+      "name": "hipother",
+      "url": "ROCm/hipother",
+      "branch": "release/rocm-rel-7.0",
+      "category": "projects",
+      "auto_subtree_pull": true,
+      "auto_subtree_push": false
+    },
+    {
+      "name": "hip-tests",
+      "url": "ROCm/hip-tests",
+      "branch": "release/rocm-rel-7.0",
+      "category": "projects",
+      "auto_subtree_pull": true,
+      "auto_subtree_push": false
+    },
+    {
       "name": "rdc",
       "url": "ROCm/rdc",
       "branch": "release/rocm-rel-7.0",
       "category": "projects",
-      "auto_subtree_pull": true,
+      "auto_subtree_pull": false,
       "auto_subtree_push": false
     },
     {
@@ -37,7 +69,7 @@
       "url": "ROCm/rocm_smi_lib",
       "branch": "release/rocm-rel-7.0",
       "category": "projects",
-      "auto_subtree_pull": true,
+      "auto_subtree_pull": false,
       "auto_subtree_push": false
     },
     {

--- a/.github/repos-config.json
+++ b/.github/repos-config.json
@@ -9,6 +9,38 @@
       "auto_subtree_push": true
     },
     {
+      "name": "clr",
+      "url": "ROCm/clr",
+      "branch": "amd-staging",
+      "category": "projects",
+      "auto_subtree_pull": true,
+      "auto_subtree_push": false
+    },
+    {
+      "name": "hip",
+      "url": "ROCm/hip",
+      "branch": "amd-staging",
+      "category": "projects",
+      "auto_subtree_pull": true,
+      "auto_subtree_push": false
+    },
+    {
+      "name": "hipother",
+      "url": "ROCm/hipother",
+      "branch": "amd-staging",
+      "category": "projects",
+      "auto_subtree_pull": true,
+      "auto_subtree_push": false
+    },
+    {
+      "name": "hip-tests",
+      "url": "ROCm/hip-tests",
+      "branch": "amd-staging",
+      "category": "projects",
+      "auto_subtree_pull": true,
+      "auto_subtree_push": false
+    },
+    {
       "name": "rdc",
       "url": "ROCm/rdc",
       "branch": "amd-staging",

--- a/.github/workflows/import-prep-workflow-disable.yml
+++ b/.github/workflows/import-prep-workflow-disable.yml
@@ -1,0 +1,44 @@
+# Import Prep: Disable Workflows
+# ------------------------------
+# This GitHub Actions workflow disables all non-Import-related workflows in the repository.
+# This is useful as a preparatory step before performing a bulk import of issues from another repository.
+name: "Import Prep: Disable workflows"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  disable-workflows:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Validate maintainer permissions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Actor is: ${{ github.actor }}"
+          PERMISSION=$(gh api \
+            repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission \
+            --jq .permission)
+          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "maintain" ]]; then
+            echo "❌ User ${{ github.actor }} is not authorized to run this workflow"
+            exit 1
+          fi
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Disable Workflows except Import
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          workflows=$(gh api repos/${{ github.repository }}/actions/workflows --jq '.workflows[] | {id, name}')
+          echo "$workflows" | jq -c '. | select(.name | startswith("Import") | not)' | while read wf; do
+            id=$(echo "$wf" | jq '.id')
+            name=$(echo "$wf" | jq -r '.name')
+            gh api --method PUT repos/${{ github.repository }}/actions/workflows/$id/disable --silent
+          done

--- a/.github/workflows/import-prep-workflow-enable.yml
+++ b/.github/workflows/import-prep-workflow-enable.yml
@@ -1,0 +1,44 @@
+# Import Prep: Enable Workflows
+# ------------------------------
+# This GitHub Actions workflow enables all non-Import-related workflows in the repository.
+# This is useful as a preparatory step before performing a bulk import of issues from another repository.
+name: "Import Prep: Disable workflows"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  disable-workflows:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Validate maintainer permissions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Actor is: ${{ github.actor }}"
+          PERMISSION=$(gh api \
+            repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission \
+            --jq .permission)
+          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "maintain" ]]; then
+            echo "❌ User ${{ github.actor }} is not authorized to run this workflow"
+            exit 1
+          fi
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Enable Workflows except Import
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          workflows=$(gh api repos/${{ github.repository }}/actions/workflows --jq '.workflows[] | {id, name}')
+          echo "$workflows" | jq -c '. | select(.name | startswith("Import") | not)' | while read wf; do
+            id=$(echo "$wf" | jq '.id')
+            name=$(echo "$wf" | jq -r '.name')
+            gh api --method PUT repos/${{ github.repository }}/actions/workflows/$id/enable --silent
+          done

--- a/.github/workflows/new-subtree-setup-release.yml
+++ b/.github/workflows/new-subtree-setup-release.yml
@@ -1,11 +1,11 @@
-name: Setup super-repo
+name: Setup additonal release subtrees for super-repo
 
 on:
   workflow_dispatch:
 
 env:
   SUPER_REPO_URL: github.com/ROCm/rocm-systems.git
-  SUPER_REPO_BRANCH: develop
+  SUPER_REPO_BRANCH: release/rocm-rel-7.0
 
 jobs:
   setup-super-repo:
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ steps.generate-token.outputs.token }}
+          ref: ${{ env.SUPER_REPO_BRANCH }}
 
       - name: Set up Git user and Git LFS
         run: |
@@ -44,11 +45,11 @@ jobs:
 
       - name: Add Repositories to the Super-repo
         run: |
-          for repo in $(cat .github/repos-config.json | jq -r '.repositories[].name'); do
-            repo_name=$(cat .github/repos-config.json | jq -r ".repositories[] | select(.name == \"$repo\") | .reponame")
-            url=$(cat .github/repos-config.json | jq -r ".repositories[] | select(.name == \"$repo\") | .url")
-            branch=$(cat .github/repos-config.json | jq -r ".repositories[] | select(.name == \"$repo\") | .branch")
-            category=$(cat .github/repos-config.json | jq -r ".repositories[] | select(.name == \"$repo\") | .category")
+          for repo in $(cat .github/repos-added-config-.json | jq -r '.repositories[].name'); do
+            repo_name=$(cat .github/repos-added-config.json | jq -r ".repositories[] | select(.name == \"$repo\") | .reponame")
+            url=$(cat .github/repos-added-config.json | jq -r ".repositories[] | select(.name == \"$repo\") | .url")
+            branch=$(cat .github/repos-added-config.json | jq -r ".repositories[] | select(.name == \"$repo\") | .branch")
+            category=$(cat .github/repos-added-config.json | jq -r ".repositories[] | select(.name == \"$repo\") | .category")
 
             git subtree add --prefix "${category}/${repo}" https://github.com/${url}.git "$branch"
           done

--- a/.github/workflows/new-subtree-setup.yml
+++ b/.github/workflows/new-subtree-setup.yml
@@ -1,4 +1,4 @@
-name: Setup super-repo
+name: Setup additonal subtrees for super-repo
 
 on:
   workflow_dispatch:
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ steps.generate-token.outputs.token }}
+          ref: ${{ env.SUPER_REPO_BRANCH }}
 
       - name: Set up Git user and Git LFS
         run: |
@@ -44,11 +45,11 @@ jobs:
 
       - name: Add Repositories to the Super-repo
         run: |
-          for repo in $(cat .github/repos-config.json | jq -r '.repositories[].name'); do
-            repo_name=$(cat .github/repos-config.json | jq -r ".repositories[] | select(.name == \"$repo\") | .reponame")
-            url=$(cat .github/repos-config.json | jq -r ".repositories[] | select(.name == \"$repo\") | .url")
-            branch=$(cat .github/repos-config.json | jq -r ".repositories[] | select(.name == \"$repo\") | .branch")
-            category=$(cat .github/repos-config.json | jq -r ".repositories[] | select(.name == \"$repo\") | .category")
+          for repo in $(cat .github/repos-added-config-.json | jq -r '.repositories[].name'); do
+            repo_name=$(cat .github/repos-added-config.json | jq -r ".repositories[] | select(.name == \"$repo\") | .reponame")
+            url=$(cat .github/repos-added-config.json | jq -r ".repositories[] | select(.name == \"$repo\") | .url")
+            branch=$(cat .github/repos-added-config.json | jq -r ".repositories[] | select(.name == \"$repo\") | .branch")
+            category=$(cat .github/repos-added-config.json | jq -r ".repositories[] | select(.name == \"$repo\") | .category")
 
             git subtree add --prefix "${category}/${repo}" https://github.com/${url}.git "$branch"
           done

--- a/.github/workflows/pr-auto-label-dispatcher.yml
+++ b/.github/workflows/pr-auto-label-dispatcher.yml
@@ -1,0 +1,37 @@
+# Auto Label PR Dispatcher
+# ------------------------
+# This workflow is triggered by pull request events and sends a repository_dispatch event
+# to the pr-auto-label workflow to handle label management.
+# This allows the workflow to support pull requests from forks and main repository branches.
+
+name: Auto Label PR Trigger
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    branches:
+      - develop
+      - release/rocm-rel-7.*
+
+concurrency:
+  group: pr-auto-label-dispatcher-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  trigger-dispatch:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Send repository_dispatch to run labeling logic
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api repos/${{ github.repository }}/dispatches \
+            -f event_type="pr-auto-label" \
+            -f client_payload='{"pr":"${{ github.event.pull_request.number }}"}'

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -2,6 +2,7 @@
 # -------------
 # This GitHub Actions workflow automatically adds or removes labels on a pull request
 # based on a custom Python script that analyzes the PR content and paths.
+# This workflow is triggered by a repository_dispatch event, which is sent from another workflow.
 #
 # Steps:
 #   - Run pr_category_label.py to determine which category labels to add/remove
@@ -11,27 +12,11 @@
 name: Auto Label PR
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
-    branches:
-      - 'develop'
-      - 'staging'
-      - 'main'
-      - 'release-staging/rocm-rel-7.*'
-    # Ignore changes to top-level files and directories
-    # that are not part of the subtree structure
-    paths-ignore:
-      - '.github/**'
-      - 'docs/**'
-      - '*.md'
-
+  repository_dispatch:
+    types: [pr-auto-label]
 # ensure that the workflow is not running for the same PR multiple times at once
 concurrency:
-  group: pr-auto-label-${{ github.event.pull_request.number || github.run_id }}
+  group: pr-auto-label-${{ github.event.client_payload.pr }}
   cancel-in-progress: false
 
 env:
@@ -42,10 +27,12 @@ env:
 jobs:
   auto-label-pr:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
-      - name: Generate GitHub App token (only for branch PRs)
+      - name: Generate GitHub App token
         id: generate-token
-        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
           app-id: ${{ secrets.APP_ID }}
@@ -55,9 +42,9 @@ jobs:
       - name: Checkout workflows
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
           sparse-checkout: '.github'
-          token: ${{ github.event.pull_request.head.repo.fork && secrets.GITHUB_TOKEN || steps.generate-token.outputs.token }}
+          token: ${{ steps.generate-token.outputs.token }}
+          # ref will be default branch of the repository
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -77,47 +64,33 @@ jobs:
       - name: Compute Category Labels for PR
         id: compute_labels
         env:
-          # this env clause gets repeated, but it is safer than echo'ing secrets in the workflow
-          GH_TOKEN: ${{ github.event.pull_request.head.repo.fork && secrets.GITHUB_TOKEN || steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           python .github/scripts/pr_category_label.py \
             --repo ${{ github.repository }} \
-            --pr ${{ github.event.pull_request.number }}
+            --pr "${{ github.event.client_payload.pr }}"
 
       - name: Update labels
         env:
-          # this env clause gets repeated, but it is safer than echo'ing secrets in the workflow
-          GH_TOKEN: ${{ github.event.pull_request.head.repo.fork && secrets.GITHUB_TOKEN || steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           if [ -n "${{ steps.compute_labels.outputs.label_add }}" ]; then
-            gh pr edit "${{ github.event.pull_request.number }}" --add-label "${{ steps.compute_labels.outputs.label_add }}"
+            gh pr edit "${{ github.event.client_payload.pr }}" --add-label "${{ steps.compute_labels.outputs.label_add }}"
           fi
 
       - name: Check if PR creator is in org or collaborator and label accordingly
         env:
-          # this env clause gets repeated, but it is safer than echo'ing secrets in the workflow
-          GH_TOKEN: ${{ github.event.pull_request.head.repo.fork && secrets.GITHUB_TOKEN || steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          if gh pr view "${{ github.event.pull_request.number }}" --json labels -q '.labels[].name' | grep -qFx "imported pr"; then
+          if gh pr view "${{ github.event.client_payload.pr }}" --json labels -q '.labels[].name' | grep -qFx "imported pr"; then
             echo "Skipping org membership labeling for imported pull request."
             exit 0
           fi
 
-          PR_USER=$(gh pr view "${{ github.event.pull_request.number }}" --json author -q .author.login)
-
-          if [ "${{ github.event.pull_request.head.repo.fork }}" = true ]; then
-            # For fork PRs: check if user has any collaborator permission on the repo
-            PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/$PR_USER/permission --jq '.permission')
-            if [ "$PERMISSION" = "admin" ] || [ "$PERMISSION" = "write" ] || [ "$PERMISSION" = "maintain" ]; then
-              gh pr edit "${{ github.event.pull_request.number }}" --add-label "${{ env.ORG_LABEL }}"
-            else
-              gh pr edit "${{ github.event.pull_request.number }}" --add-label "${{ env.EXTERNAL_LABEL }}"
-            fi
-          else
-            # For branch PRs (non-forks): check org membership via GitHub App token
+          PR_USER=$(gh pr view "${{ github.event.client_payload.pr }}" --json author -q .author.login)
             if gh api orgs/${{ env.ORG_TO_CHECK }}/members/$PR_USER --silent; then
-              gh pr edit "${{ github.event.pull_request.number }}" --add-label "${{ env.ORG_LABEL }}"
+              gh pr edit "${{ github.event.client_payload.pr }}" --add-label "${{ env.ORG_LABEL }}"
             else
-              gh pr edit "${{ github.event.pull_request.number }}" --add-label "${{ env.EXTERNAL_LABEL }}"
+              gh pr edit "${{ github.event.client_payload.pr }}" --add-label "${{ env.EXTERNAL_LABEL }}"
             fi
           fi


### PR DESCRIPTION
- The execution of applying labels is now in a dispatched workflow that executes from the default branch and has access to the GitHub App to be able to write labels.
- New GitHub Actions to enable/toggle workflows from activating during import of subprojects.
- Workflows to add new subtrees to develop and release branches.