### PR TITLE
[rocprofiler-sdk] Make device counting service's queue priority configurable via env var

### DIFF
--- a/projects/rocprofiler-sdk/CHANGELOG.md
+++ b/projects/rocprofiler-sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Full documentation for ROCprofiler-SDK is available at [rocm.docs.amd.com/projects/rocprofiler-sdk](https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/index.html)
 
+## Unreleased
+
+### Added
+
+- Environment variable `ROCPROFILER_DEVICE_COUNTING_QUEUE_PRIORITY` to configure the HSA queue priority used by the device counting service (`low`|`normal`|`high`; default `high`).
+
 ## ROCprofiler-SDK for AFAR I
 
 ### Added

--- a/projects/rocprofiler-sdk/source/docs/api-reference/rocprofiler-sdk_api/modules/device_counting_service.rst
+++ b/projects/rocprofiler-sdk/source/docs/api-reference/rocprofiler-sdk_api/modules/device_counting_service.rst
@@ -7,6 +7,15 @@
 Device counting service
 *******************************************************************************
 
+Queue priority
+--------------
+
+ROCprofiler-SDK uses an internal HSA queue for the device counting service. You can control the priority using the environment variable ``ROCPROFILER_DEVICE_COUNTING_QUEUE_PRIORITY``.
+
+- Accepted values (case-insensitive): ``low``, ``normal``, ``high``
+- Default: ``high``
+- Applied value is logged at INFO level when enabled.
+
 .. doxygengroup:: device_counting_service
    :content-only:
    :project: rocprofiler-sdk

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/agent_cache.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/agent_cache.cpp
@@ -21,9 +21,11 @@
 // THE SOFTWARE.
 
 #include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
+#include "lib/common/environment.hpp"
 #include "lib/common/logging.hpp"
 
 #include <fmt/core.h>
+#include <cctype>
 #include <stdexcept>
 
 #include "lib/rocprofiler-sdk/context/context.hpp"
@@ -151,7 +153,34 @@ AgentCache::init_device_counting_service_queue(const CoreApiTable& api,
         << "HSA Queue is not initialized";
 
     CHECK(ext.hsa_amd_queue_set_priority_fn) << "no hsa_amd_queue_set_priority_fn in api table";
-    ext.hsa_amd_queue_set_priority_fn(m_profile_queue, HSA_AMD_QUEUE_PRIORITY_HIGH);
+
+    // allow to configure queue priority using an environment variable;
+    // accepted values (case-insensitive): "low", "normal", "high"; default: "high"
+    auto priority_str = rocprofiler::common::get_env("ROCPROFILER_DEVICE_COUNTING_QUEUE_PRIORITY",
+                                                     std::string{"high"});
+    for(auto& c : priority_str)
+        c = static_cast<char>(::tolower(static_cast<unsigned char>(c)));
+
+    hsa_amd_queue_priority_t priority = HSA_AMD_QUEUE_PRIORITY_HIGH;
+    if(priority_str == "low")
+        priority = HSA_AMD_QUEUE_PRIORITY_LOW;
+    else if(priority_str == "normal")
+        priority = HSA_AMD_QUEUE_PRIORITY_NORMAL;
+    else if(priority_str == "high")
+        priority = HSA_AMD_QUEUE_PRIORITY_HIGH;
+    else
+    {
+        ROCP_WARNING << "Unknown ROCPROFILER_DEVICE_COUNTING_QUEUE_PRIORITY=\"" << priority_str
+                     << "\"; defaulting to 'high'";
+    }
+
+    // informational logging of selected priority
+    const char* priority_name = (priority == HSA_AMD_QUEUE_PRIORITY_LOW)      ? "low"
+                                : (priority == HSA_AMD_QUEUE_PRIORITY_NORMAL) ? "normal"
+                                                                              : "high";
+    ROCP_INFO << "Device counting queue priority set to '" << priority_name << "'";
+
+    ext.hsa_amd_queue_set_priority_fn(m_profile_queue, priority);
 }
 
 AgentCache::AgentCache(const rocprofiler_agent_t* rocp_agent,


### PR DESCRIPTION
## Motivation

This PR exposes device counting service's internal HSA queue priority via an environment variable `ROCPROFILER_DEVICE_COUNTING_QUEUE_PRIORITY`.  Usage:
- `export ROCPROFILER_DEVICE_COUNTING_QUEUE_PRIORITY=normal`
- Accepted values (case-insensitive): (`low`|`normal`|`high`; default `high`)

This is motivated primarily by a hang observed on Frontier (MI250X system; ROCm 6.4.1) when using a [daemon](https://github.com/scottatchley/rocm-counter-daemon) process to sample hardware counters while an application runs. Decreasing device counting service's queue priority from the default `HSA_AMD_QUEUE_PRIORITY_HIGH` to `HSA_AMD_QUEUE_PRIORITY_NORMAL` robustly avoids the hang, serving as a practical workaround to enable intended usage of the counter daemon.


## Technical Details

`ROCPROFILER_DEVICE_COUNTING_QUEUE_PRIORITY` can be set to accepted values `low`, `normal`, `high`, and defaults to `high` to maintain current default behavior. Invalid values log a warning and fall back to `high`; applied value is logged at `INFO` level. The scope is limited to the device counting service, as this environment variable is not used elsewhere.


## Tests

With the counter-sampling daemon use case, `NORMAL` avoided the hang across multiple runs (1s and 1ms sampling). Reverting to `HIGH` consistently reproduced the hang. Spot checks on `GRBM_COUNT` showed <0.5% mean relative difference at ~1s cadence, at the level of run-to-run variation.


## Documentation

- API reference: device counting service -> queue priority entry
- CHANGELOG: unreleased 'Added' entry


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
