### PR TITLE
fix(ci): configure git safe directory before sphinx build

### DIFF
--- a/.github/workflows/rocprofiler-sdk-docs.yml
+++ b/.github/workflows/rocprofiler-sdk-docs.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Create Docs Directory
         run: |
           git config --global --add safe.directory '*'
+          git config --global --add safe.directory /__w/rocm-systems/rocm-systems
           mkdir -p projects/rocprofiler-sdk/docs/_doxygen/rocprofiler-sdk
           mkdir -p projects/rocprofiler-sdk/docs/_doxygen/roctx
       - name: Install documentation dependencies
@@ -60,12 +61,13 @@ jobs:
         shell: bash -el {0}
         working-directory: projects/rocprofiler-sdk/source/docs
         run: |
+          git config --global --add safe.directory '*'
+          git config --global --add safe.directory /__w/rocm-systems/rocm-systems
           conda init
           conda env create -n rocprofiler-docs -f environment.yml
           conda activate rocprofiler-docs
           python3 -m pip install sphinx
           python3 -m pip install doxysphinx rocm-docs-core
-          git config --global --add safe.directory '*'
           ../scripts/update-docs.sh
 
   build-docs-from-source:
@@ -91,6 +93,7 @@ jobs:
         working-directory: projects/rocprofiler-sdk/
         run: |
           git config --global --add safe.directory '*'
+          git config --global --add safe.directory /__w/rocm-systems/rocm-systems
           mkdir -p source/docs/_doxygen/rocprofiler-sdk
           mkdir -p source/docs/_doxygen/roctx
       - name: Install requirements

--- a/.github/workflows/rocprofiler-sdk-docs.yml
+++ b/.github/workflows/rocprofiler-sdk-docs.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Create Docs Directory
         run: |
           git config --global --add safe.directory '*'
-          git config --global --add safe.directory /__w/rocm-systems/rocm-systems
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
           mkdir -p projects/rocprofiler-sdk/docs/_doxygen/rocprofiler-sdk
           mkdir -p projects/rocprofiler-sdk/docs/_doxygen/roctx
       - name: Install documentation dependencies
@@ -62,7 +62,7 @@ jobs:
         working-directory: projects/rocprofiler-sdk/source/docs
         run: |
           git config --global --add safe.directory '*'
-          git config --global --add safe.directory /__w/rocm-systems/rocm-systems
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
           conda init
           conda env create -n rocprofiler-docs -f environment.yml
           conda activate rocprofiler-docs
@@ -93,7 +93,7 @@ jobs:
         working-directory: projects/rocprofiler-sdk/
         run: |
           git config --global --add safe.directory '*'
-          git config --global --add safe.directory /__w/rocm-systems/rocm-systems
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
           mkdir -p source/docs/_doxygen/rocprofiler-sdk
           mkdir -p source/docs/_doxygen/roctx
       - name: Install requirements


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
- Prevents "dubious ownership" error during rocm-docs-core initialization during docs build
## Technical Details
fix(ci): configure git safe directory before sphinx build

- Move git safe.directory configuration earlier in Build Docs step
- Ensures git access is available before Python package installation
- Fixes sphinx ExtensionError when accessing repository metadata

Resolves build failure: "SHA is empty, possible dubious ownership"
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
