### PR TITLE
Add user_api_active flag to enable/disable user-defined regions

### DIFF
--- a/projects/rocprofiler-systems/docs/conceptual/data-collection-modes.rst
+++ b/projects/rocprofiler-systems/docs/conceptual/data-collection-modes.rst
@@ -30,8 +30,8 @@ ROCm Systems Profiler supports several modes of recording trace and profiling da
 |                             | dynamic library/executable, like ``pthread_mutex_lock`` |
 |                             | in ``libpthread.so`` or ``MPI_Init`` in the MPI library |
 +-----------------------------+---------------------------------------------------------+
-| User API                    | User-defined regions and controls for ROCm Systems      |
-|                             | Profiler                                                |
+| User API                    | User-defined regions and controls for User API ROCm     |
+|                             | Systems Profiler                                        |
 +-----------------------------+---------------------------------------------------------+
 
 The two most generic and important modes are binary instrumentation and statistical sampling.

--- a/projects/rocprofiler-systems/docs/how-to/general-tips-using-rocprof-sys.rst
+++ b/projects/rocprofiler-systems/docs/how-to/general-tips-using-rocprof-sys.rst
@@ -24,7 +24,7 @@ the :doc:`ROCm Systems Profiler glossary <../reference/rocprof-sys-glossary>`.
 * **Use binary instrumentation for characterizing the performance of every invocation of specific functions**
 * **Use statistical sampling to characterize the performance of the entire application while minimizing overhead**
 * Enable statistical sampling after binary instrumentation to help "fill in the gaps" between instrumented regions
-* Use the user API to create custom regions and enable/disable ROCm Systems Profiler for specific processes, threads, and regions
+* Use the user API to create custom regions and enable/disable User API ROCm Systems Profiler for specific processes, threads, and regions
 * Dynamic symbol interception, callback APIs, and the user API are always available with binary instrumentation and sampling
 
   * Dynamic symbol interception and callback APIs are (generally) controlled through ``ROCPROFSYS_USE_<API>``

--- a/projects/rocprofiler-systems/docs/how-to/using-rocprof-sys-api.rst
+++ b/projects/rocprofiler-systems/docs/how-to/using-rocprof-sys-api.rst
@@ -24,9 +24,6 @@ ROCm Systems Profiler API, such as ``rocprofsys_user_push_region`` and
    is disabled at start up, which means ``rocprofsys_user_stop_trace()`` is not
    required at the beginning of ``main``. This behavior
    can be manually controlled by using the ``ROCPROFSYS_INIT_ENABLED`` environment variable.
-   User-defined regions are always
-   recorded, regardless of whether ``rocprofsys_user_start_*`` or
-   ``rocprofsys_user_stop_*`` has been called.
 
 .. code-block:: shell
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
@@ -512,6 +512,13 @@ get_active()
 }
 
 auto&
+get_user_api_active()
+{
+    static bool* _v = new bool{ false };
+    return *_v;
+}
+
+auto&
 get_enabled()
 {
     static auto* _v = new std::atomic<bool>{ get_env("ROCPROFSYS_INIT_ENABLED", true) };
@@ -797,12 +804,14 @@ extern "C"
     int rocprofsys_user_start_trace_dl(void)
     {
         dl::get_enabled().store(true);
+        dl::get_user_api_active() = true;
         return rocprofsys_user_start_thread_trace_dl();
     }
 
     int rocprofsys_user_stop_trace_dl(void)
     {
         dl::get_enabled().store(false);
+        dl::get_user_api_active() = false;
         return rocprofsys_user_stop_thread_trace_dl();
     }
 
@@ -820,13 +829,13 @@ extern "C"
 
     int rocprofsys_user_push_region_dl(const char* name)
     {
-        if(!dl::get_active()) return 0;
+        if(!dl::get_active() && !dl::get_user_api_active()) return 0;
         return ROCPROFSYS_DL_INVOKE(get_indirect().rocprofsys_push_region_f, name);
     }
 
     int rocprofsys_user_pop_region_dl(const char* name)
     {
-        if(!dl::get_active()) return 0;
+        if(!dl::get_active() && !dl::get_user_api_active()) return 0;
         return ROCPROFSYS_DL_INVOKE(get_indirect().rocprofsys_pop_region_f, name);
     }
 
@@ -840,7 +849,7 @@ extern "C"
                                                  rocprofsys_annotation_t* _annotations,
                                                  size_t _annotation_count)
     {
-        if(!dl::get_active()) return 0;
+        if(!dl::get_active() && !dl::get_user_api_active()) return 0;
         return ROCPROFSYS_DL_INVOKE(get_indirect().rocprofsys_push_category_region_f,
                                     ROCPROFSYS_CATEGORY_USER, name, _annotations,
                                     _annotation_count);
@@ -850,7 +859,7 @@ extern "C"
                                                 rocprofsys_annotation_t* _annotations,
                                                 size_t _annotation_count)
     {
-        if(!dl::get_active()) return 0;
+        if(!dl::get_active() && !dl::get_user_api_active()) return 0;
         return ROCPROFSYS_DL_INVOKE(get_indirect().rocprofsys_pop_category_region_f,
                                     ROCPROFSYS_CATEGORY_USER, name, _annotations,
                                     _annotation_count);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
@@ -514,8 +514,8 @@ get_active()
 auto&
 get_user_api_active()
 {
-    static bool* _v = new bool{ false };
-    return *_v;
+    static bool _v{ false };
+    return _v;
 }
 
 auto&

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-user/rocprofiler-systems/types.h
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-user/rocprofiler-systems/types.h
@@ -55,25 +55,25 @@ extern "C"
         rocprofsys_annotated_region_func_t annotated_progress;
 
         /// @var start_trace
-        /// @brief callback for enabling user defined tracing globally
+        /// @brief Callback for enabling user defined tracing globally.
         /// @var stop_trace
-        /// @brief callback for disabling user defined tracing globally
+        /// @brief Callback for disabling user defined tracing globally.
         /// @var start_thread_trace
-        /// @brief callback for enabling user defined tracing on current thread
+        /// @brief Callback for enabling user defined tracing on the current thread.
         /// @var stop_thread_trace
-        /// @brief callback for disabling user defiend tracing on current thread
+        /// @brief Callback for disabling user defined tracing on the current thread.
         /// @var push_region
-        /// @brief callback for starting user defiend trace region
+        /// @brief Callback for starting a user defined trace region.
         /// @var pop_region
-        /// @brief callback for ending user defined trace region
+        /// @brief Callback for ending a user defined trace region.
         /// @var progress
-        /// @brief callback for marking an causal profiling event
+        /// @brief Callback for marking a causal profiling event.
         /// @var push_annotated_region
-        /// @brief callback for starting user defined trace region + annotations
+        /// @brief Callback for starting a user defined trace region with annotations.
         /// @var pop_annotated_region
-        /// @brief callback for ending user defined trace region + annotations
+        /// @brief Callback for ending a user defined trace region with annotations.
         /// @var annotated_progress
-        /// @brief callback for marking an causal profiling event + annotations
+        /// @brief Callback for marking a causal profiling event with annotations.
     } rocprofsys_user_callbacks_t;
 
     /// @enum ROCPROFSYS_USER_CONFIGURE_MODE
@@ -110,9 +110,7 @@ extern "C"
 
 #ifndef ROCPROFSYS_USER_CALLBACKS_INIT
 #    define ROCPROFSYS_USER_CALLBACKS_INIT                                               \
-        {                                                                                \
-            NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL                   \
-        }
+        { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL }
 #endif
 
 #endif  // ROCPROFSYS_TYPES_H_

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-user/rocprofiler-systems/types.h
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-user/rocprofiler-systems/types.h
@@ -110,7 +110,9 @@ extern "C"
 
 #ifndef ROCPROFSYS_USER_CALLBACKS_INIT
 #    define ROCPROFSYS_USER_CALLBACKS_INIT                                               \
-        { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL }
+        {                                                                                \
+            NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL                   \
+        }
 #endif
 
 #endif  // ROCPROFSYS_TYPES_H_

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-user/rocprofiler-systems/types.h
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-user/rocprofiler-systems/types.h
@@ -55,23 +55,23 @@ extern "C"
         rocprofsys_annotated_region_func_t annotated_progress;
 
         /// @var start_trace
-        /// @brief callback for enabling tracing globally
+        /// @brief callback for enabling user defined tracing globally
         /// @var stop_trace
-        /// @brief callback for disabling tracing globally
+        /// @brief callback for disabling user defined tracing globally
         /// @var start_thread_trace
-        /// @brief callback for enabling tracing on current thread
+        /// @brief callback for enabling user defined tracing on current thread
         /// @var stop_thread_trace
-        /// @brief callback for disabling tracing on current thread
+        /// @brief callback for disabling user defiend tracing on current thread
         /// @var push_region
-        /// @brief callback for starting a trace region
+        /// @brief callback for starting user defiend trace region
         /// @var pop_region
-        /// @brief callback for ending a trace region
+        /// @brief callback for ending user defined trace region
         /// @var progress
         /// @brief callback for marking an causal profiling event
         /// @var push_annotated_region
-        /// @brief callback for starting a trace region + annotations
+        /// @brief callback for starting user defined trace region + annotations
         /// @var pop_annotated_region
-        /// @brief callback for ending a trace region + annotations
+        /// @brief callback for ending user defined trace region + annotations
         /// @var annotated_progress
         /// @brief callback for marking an causal profiling event + annotations
     } rocprofsys_user_callbacks_t;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-user/rocprofiler-systems/user.h
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-user/rocprofiler-systems/user.h
@@ -43,24 +43,26 @@ extern "C"
 
     /// @fn int rocprofsys_user_start_trace(void)
     /// @return rocprofsys_user_error_t value
-    /// @brief Enable user defined tracing on this thread and all subsequently created threads
+    /// @brief Enable user defined tracing on this thread and on all subsequently created
+    /// threads.
     extern int rocprofsys_user_start_trace(void) ROCPROFSYS_PUBLIC_API;
 
     /// @fn int rocprofsys_user_stop_trace(void)
     /// @return rocprofsys_user_error_t value
-    /// @brief Disable user defined tracing on this thread and all subsequently created threads
+    /// @brief Disable user defined tracing on this thread and on all subsequently created
+    /// threads.
     extern int rocprofsys_user_stop_trace(void) ROCPROFSYS_PUBLIC_API;
 
     /// @fn int rocprofsys_user_start_thread_trace(void)
     /// @return rocprofsys_user_error_t value
-    /// @brief Enable user defined tracing on this specific thread. Does not apply to subsequently
-    /// created threads
+    /// @brief Enable user defined tracing on this specific thread. Does not apply to
+    /// subsequently created threads.
     extern int rocprofsys_user_start_thread_trace(void) ROCPROFSYS_PUBLIC_API;
 
     /// @fn int rocprofsys_user_stop_thread_trace(void)
     /// @return rocprofsys_user_error_t value
-    /// @brief Disable user defined tracing on this specific thread. Does not apply to subsequently
-    /// created threads
+    /// @brief Disable user defined tracing on this specific thread. Does not apply to
+    /// subsequently created threads.
     extern int rocprofsys_user_stop_thread_trace(void) ROCPROFSYS_PUBLIC_API;
 
     /// @fn int rocprofsys_user_push_region(const char* id)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-user/rocprofiler-systems/user.h
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-user/rocprofiler-systems/user.h
@@ -43,23 +43,23 @@ extern "C"
 
     /// @fn int rocprofsys_user_start_trace(void)
     /// @return rocprofsys_user_error_t value
-    /// @brief Enable tracing on this thread and all subsequently created threads
+    /// @brief Enable user defined tracing on this thread and all subsequently created threads
     extern int rocprofsys_user_start_trace(void) ROCPROFSYS_PUBLIC_API;
 
     /// @fn int rocprofsys_user_stop_trace(void)
     /// @return rocprofsys_user_error_t value
-    /// @brief Disable tracing on this thread and all subsequently created threads
+    /// @brief Disable user defined tracing on this thread and all subsequently created threads
     extern int rocprofsys_user_stop_trace(void) ROCPROFSYS_PUBLIC_API;
 
     /// @fn int rocprofsys_user_start_thread_trace(void)
     /// @return rocprofsys_user_error_t value
-    /// @brief Enable tracing on this specific thread. Does not apply to subsequently
+    /// @brief Enable user defined tracing on this specific thread. Does not apply to subsequently
     /// created threads
     extern int rocprofsys_user_start_thread_trace(void) ROCPROFSYS_PUBLIC_API;
 
     /// @fn int rocprofsys_user_stop_thread_trace(void)
     /// @return rocprofsys_user_error_t value
-    /// @brief Disable tracing on this specific thread. Does not apply to subsequently
+    /// @brief Disable user defined tracing on this specific thread. Does not apply to subsequently
     /// created threads
     extern int rocprofsys_user_stop_thread_trace(void) ROCPROFSYS_PUBLIC_API;
 


### PR DESCRIPTION
# Motivation

User-defined regions were always being recorded regardless of whether `rocprofsys_user_start_trace()` or `rocprofsys_user_stop_trace()` was called, which prevented users from having fine-grained control over when their custom instrumentation should be active. This PR adds proper state tracking to honor user API start/stop calls for user-defined regions.

# Technical details

Introduced a `get_user_api_active()` boolean flag in `dl.cpp` that tracks whether the user has explicitly enabled tracing via `rocprofsys_user_start_trace_dl()` or `rocprofsys_user_stop_trace_dl()`. Modified the push/pop region functions to check both `get_active()` AND `get_user_api_active()` conditions, allowing user-defined regions to be recorded either when general profiling is active OR when user API tracing is explicitly enabled. Updated documentation across RST files and header files to clarify that user API functions control "user defined tracing" specifically, and removed the outdated statement that user regions are always recorded.

# Test plan

- Test that user-defined regions are NOT recorded when neither general profiling nor user API tracing is enabled
- Test that calling `rocprofsys_user_start_trace()` enables recording of user-defined regions even when general profiling is disabled
- Test that calling `rocprofsys_user_stop_trace()` disables recording of user-defined regions
- Test thread-local start/stop variants (`rocprofsys_user_start_thread_trace()`, `rocprofsys_user_stop_thread_trace()`)
- Verify backward compatibility: ensure existing code that doesn't use start/stop calls still works when general profiling is enabled

# Test result

User-defined regions (created via `rocprofsys_user_push_region()`, `rocprofsys_user_pop_region()`, and annotated variants) should only be recorded when either general profiling is active OR when the user has explicitly called `rocprofsys_user_start_trace()` / `rocprofsys_user_start_thread_trace()`. The profiler should honor user API start/stop calls and provide precise control over when custom instrumentation is captured.