### PR TITLE
Switching from RHEL 8 to RHEL 9

### DIFF
--- a/.github/workflows/aqlprofile-continuous_integration.yml
+++ b/.github/workflows/aqlprofile-continuous_integration.yml
@@ -106,7 +106,7 @@ jobs:
       fail-fast: false
       matrix:
         runner: ['mi300']
-        os: ['rhel-8', 'sles-15']
+        os: ['rhel-9', 'sles-15']
         build-type: ['RelWithDebInfo']
         ci-flags: ['--linter clang-tidy']
 

--- a/.github/workflows/aqlprofile-continuous_integration.yml
+++ b/.github/workflows/aqlprofile-continuous_integration.yml
@@ -10,12 +10,14 @@ on:
       - '!projects/aqlprofile/*.md'
       - '!projects/aqlprofile/CODEOWNERS'
       - '!projects/aqlprofile/source/docs/**'
+      - '.github/workflows/aqlprofile-continuous_integration.yml'
   pull_request:
     paths:
       - 'projects/aqlprofile/**'
       - '!projects/aqlprofile/*.md'
       - '!projects/aqlprofile/CODEOWNERS'
       - '!projects/aqlprofile/source/docs/**'
+      - '.github/workflows/aqlprofile-continuous_integration.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -228,8 +228,7 @@ jobs:
         if [ "${OS_TYPE}" == "rhel-9" ]; then
           dnf makecache
           dnf groupinstall -y "Development Tools"
-          dnf remove -y gcc-c++
-          dnf install -y gcc-toolset-11-gcc-c++ llvm14-devel
+          dnf install -y llvm14-devel
         fi
         python3 -m pip install --upgrade pip
         python3 -m pip install -U --user -r requirements.txt

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -202,7 +202,7 @@ jobs:
       fail-fast: false
       matrix:
         runner: ['mi300']
-        os: ['rhel-8', 'sles-15']
+        os: ['rhel-9', 'sles-15']
         build-type: ['RelWithDebInfo']
         ci-flags: ['']
 
@@ -225,7 +225,7 @@ jobs:
       working-directory: projects/rocprofiler-sdk
       run: |
         git config --global --add safe.directory '*'
-        if [ "${OS_TYPE}" == "rhel-8" ]; then
+        if [ "${OS_TYPE}" == "rhel-9" ]; then
           dnf makecache
           dnf groupinstall -y "Development Tools"
           dnf remove -y gcc-c++
@@ -258,7 +258,6 @@ jobs:
       shell: bash
       working-directory: projects/rocprofiler-sdk
       run:
-        if [ "${OS_TYPE}" == "rhel-8" ]; then source scl_source enable gcc-toolset-11; fi;
         /usr/bin/python3 ./source/scripts/run-ci.py -B build
           --name ${{ github.repository }}-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.runner }}-core
           --build-jobs 16

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
@@ -25,6 +25,7 @@
 
 import argparse
 import os
+import math
 
 from typing import Any, List, Tuple
 from .importer import RocpdImportData, execute_statement
@@ -263,6 +264,8 @@ def create_summary_views(connection: RocpdImportData, by_rank=False) -> None:
         if not required_columns.issubset(columns):
             continue
 
+        connection.create_function('SQRT', 1, math.sqrt)
+
         # Create regular summary view
         summary_view_name, summary_query = generate_summary_query(
             view_name, name_column=NAME_COLUMN_MAP.get(view_name, "name")
@@ -298,6 +301,8 @@ def create_summary_region_views(
         for cat in region_categories
         if "MARKER" not in cat.upper()
     }
+
+    connection.create_function('SQRT', 1, math.sqrt)
 
     for k, v in category_map.items():
         if len(v) > 0:

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
@@ -48,8 +48,7 @@ def check_function_availability(connection, function_name):
 
     # Query pragma_function_list to check for the function
     cursor.execute(
-        "SELECT EXISTS(SELECT 1 FROM pragma_function_list WHERE name=?)",
-        (function_name,)
+        "SELECT EXISTS(SELECT 1 FROM pragma_function_list WHERE name=?)", (function_name,)
     )
     result = cursor.fetchone()[0]
 

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
@@ -44,19 +44,16 @@ def check_function_availability(connection, function_name):
     Returns:
         bool: True if the function exists, False otherwise.
     """
-    try:
-        cursor = connection.cursor()
+    cursor = connection.cursor()
 
-        # Query pragma_function_list to check for the function
-        cursor.execute(
-            "SELECT EXISTS(SELECT 1 FROM pragma_function_list WHERE name = ?)",
-            (function_name,),
-        )
-        result = cursor.fetchone()[0]
+    # Query pragma_function_list to check for the function
+    cursor.execute(
+        "SELECT EXISTS(SELECT 1 FROM pragma_function_list WHERE name = ?)",
+        (function_name,),
+    )
+    result = cursor.fetchone()[0]
 
-        return bool(result)
-    except:
-        return False
+    return bool(result)
 
 
 def get_temp_view_names(connection: RocpdImportData) -> List[str]:

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
@@ -48,8 +48,9 @@ def check_function_availability(connection, function_name):
 
     # Query pragma_function_list to check for the function
     cursor.execute(
-        "SELECT EXISTS(SELECT 1 FROM pragma_function_list WHERE name = ?)",
-        (function_name,),
+        "SELECT EXISTS(SELECT 1 FROM pragma_function_list WHERE name='{}')".format(
+            function_name
+        )
     )
     result = cursor.fetchone()[0]
 
@@ -287,9 +288,6 @@ def create_summary_views(connection: RocpdImportData, by_rank=False) -> None:
         if not required_columns.issubset(columns):
             continue
 
-        if check_function_availability(connection, "SQRT") is False:
-            connection.create_function("SQRT", 1, math.sqrt)
-
         # Create regular summary view
         summary_view_name, summary_query = generate_summary_query(
             view_name, name_column=NAME_COLUMN_MAP.get(view_name, "name")
@@ -325,9 +323,6 @@ def create_summary_region_views(
         for cat in region_categories
         if "MARKER" not in cat.upper()
     }
-
-    if check_function_availability(connection, "SQRT") is False:
-        connection.create_function("SQRT", 1, math.sqrt)
 
     for k, v in category_map.items():
         if len(v) > 0:
@@ -403,6 +398,11 @@ def generate_all_summaries(connection: RocpdImportData, **kwargs: Any) -> None:
     output_path = kwargs.get("output_path", "./rocpd-output-data")
     region_categories = kwargs.get("region_categories", None)
     output_format = kwargs.get("format", "console")
+
+    if check_function_availability(connection, "sqrt") is False:
+        connection.create_function(
+            "sqrt", 1, lambda x: math.sqrt(x) if x is not None and x >= 0 else None
+        )
 
     # create the temporary summary views
     create_summary_views(connection, by_rank)

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
@@ -287,7 +287,7 @@ def create_summary_views(connection: RocpdImportData, by_rank=False) -> None:
         if not required_columns.issubset(columns):
             continue
 
-        if check_function_availability(connection, "SQRT") == False:
+        if check_function_availability(connection, "SQRT") is False:
             connection.create_function("SQRT", 1, math.sqrt)
 
         # Create regular summary view
@@ -326,7 +326,7 @@ def create_summary_region_views(
         if "MARKER" not in cat.upper()
     }
 
-    if check_function_availability(connection, "SQRT") == False:
+    if check_function_availability(connection, "SQRT") is False:
         connection.create_function("SQRT", 1, math.sqrt)
 
     for k, v in category_map.items():

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
@@ -48,9 +48,6 @@ def check_function_availability(connection, function_name):
 
     # Query pragma_function_list to check for the function
     cursor.execute(
-        "SELECT EXISTS(SELECT 1 FROM pragma_function_list WHERE name='{}')".format(
-            function_name
-        )
         "SELECT EXISTS(SELECT 1 FROM pragma_function_list WHERE name=?)",
         (function_name,)
     )

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
@@ -397,10 +397,10 @@ def generate_all_summaries(connection: RocpdImportData, **kwargs: Any) -> None:
     region_categories = kwargs.get("region_categories", None)
     output_format = kwargs.get("format", "console")
 
-    if check_function_availability(connection, "sqrt") is False:
     if not check_function_availability(connection, "sqrt"):
-            "sqrt", 1, lambda x: math.sqrt(x) if x is not None and x >= 0 else None
+        connection.create_function(
             "sqrt", 1, lambda x: math.sqrt(x) if x is not None and isinstance(x, (int, float)) and x >= 0 else None
+        )
 
     # create the temporary summary views
     create_summary_views(connection, by_rank)

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
@@ -398,7 +398,7 @@ def generate_all_summaries(connection: RocpdImportData, **kwargs: Any) -> None:
     output_format = kwargs.get("format", "console")
 
     if check_function_availability(connection, "sqrt") is False:
-        connection.create_function(
+    if not check_function_availability(connection, "sqrt"):
             "sqrt", 1, lambda x: math.sqrt(x) if x is not None and x >= 0 else None
         )
 

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
@@ -51,6 +51,8 @@ def check_function_availability(connection, function_name):
         "SELECT EXISTS(SELECT 1 FROM pragma_function_list WHERE name='{}')".format(
             function_name
         )
+        "SELECT EXISTS(SELECT 1 FROM pragma_function_list WHERE name=?)",
+        (function_name,)
     )
     result = cursor.fetchone()[0]
 

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
@@ -33,6 +33,32 @@ from .query import export_sqlite_query
 from . import output_config
 
 
+def check_function_availability(connection, function_name):
+    """
+    Checks if a given function exists in the SQLite database.
+
+    Args:
+        connection (sqlite3 db connection): The SQLite database connection handler.
+        function_name (str): The name of the function to check.
+
+    Returns:
+        bool: True if the function exists, False otherwise.
+    """
+    try:
+        cursor = connection.cursor()
+
+        # Query pragma_function_list to check for the function
+        cursor.execute(
+            "SELECT EXISTS(SELECT 1 FROM pragma_function_list WHERE name = ?)",
+            (function_name,),
+        )
+        result = cursor.fetchone()[0]
+
+        return bool(result)
+    except sqlite3.Error as e:
+        return False
+
+
 def get_temp_view_names(connection: RocpdImportData) -> List[str]:
     """Return the names of all temporary views in the SQLite connection."""
     return [
@@ -264,7 +290,8 @@ def create_summary_views(connection: RocpdImportData, by_rank=False) -> None:
         if not required_columns.issubset(columns):
             continue
 
-        connection.create_function('SQRT', 1, math.sqrt)
+        if check_function_availability(connection, "SQRT") == False:
+            connection.create_function("SQRT", 1, math.sqrt)
 
         # Create regular summary view
         summary_view_name, summary_query = generate_summary_query(
@@ -302,7 +329,8 @@ def create_summary_region_views(
         if "MARKER" not in cat.upper()
     }
 
-    connection.create_function('SQRT', 1, math.sqrt)
+    if check_function_availability(connection, "SQRT") == False:
+        connection.create_function("SQRT", 1, math.sqrt)
 
     for k, v in category_map.items():
         if len(v) > 0:

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
@@ -399,7 +399,13 @@ def generate_all_summaries(connection: RocpdImportData, **kwargs: Any) -> None:
 
     if not check_function_availability(connection, "sqrt"):
         connection.create_function(
-            "sqrt", 1, lambda x: math.sqrt(x) if x is not None and isinstance(x, (int, float)) and x >= 0 else None
+            "sqrt",
+            1,
+            lambda x: (
+                math.sqrt(x)
+                if x is not None and isinstance(x, (int, float)) and x >= 0
+                else None
+            ),
         )
 
     # create the temporary summary views

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
@@ -55,7 +55,7 @@ def check_function_availability(connection, function_name):
         result = cursor.fetchone()[0]
 
         return bool(result)
-    except sqlite3.Error as e:
+    except:
         return False
 
 

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/summary.py
@@ -400,7 +400,7 @@ def generate_all_summaries(connection: RocpdImportData, **kwargs: Any) -> None:
     if check_function_availability(connection, "sqrt") is False:
     if not check_function_availability(connection, "sqrt"):
             "sqrt", 1, lambda x: math.sqrt(x) if x is not None and x >= 0 else None
-        )
+            "sqrt", 1, lambda x: math.sqrt(x) if x is not None and isinstance(x, (int, float)) and x >= 0 else None
 
     # create the temporary summary views
     create_summary_views(connection, by_rank)


### PR DESCRIPTION
## Motivation

The goal is to address the old versions of Python included with RHEL 8.8 and RHEL 9.1, which lack the SQRT function for SQL queries.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

1- Updates OS matrix from rhel-8 to rhel-9 and removes gcc-toolset-11 dependencies for ROCProfiler-SDK CI
2- Updates OS matrix from rhel-8 to rhel-9 and adds workflow file to trigger paths for AQLProfile CI
3- Adds SQLite function availability checking and sqrt function registration for rocpd summary

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Already being tested by the current rocprofv3 rocpd tests.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Passed

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
