### PR TITLE
[rocprofiler-compute] Fix amd_smi lookup logic

### DIFF
--- a/projects/rocprofiler-compute/src/utils/specs.py
+++ b/projects/rocprofiler-compute/src/utils/specs.py
@@ -170,19 +170,29 @@ def generate_machine_specs(args, sysinfo: dict = None):
 
     vbios = gpu_data.get("vbios", {}).get("part_number")
 
-    # Get partition values with fallback for older amd-smi
-    compute_partition = gpu_data.get("partition", {}).get(
-        "accelerator_partition"
-    ) or gpu_data.get("partition", {}).get("compute_partition")
-    memory_partition = gpu_data.get("partition", {}).get("memory_partition")
+    # Load amd-smi partition data for GPU 0 (amd-smi >= 26.0.0)
+    partition_data = json.loads(
+        run(["amd-smi", "partition", "--gpu=0", "--json"], exit_on_error=False)
+    )
+    current_partition = partition_data.get("current_partition", [{}])[0]
+
+    # Extract partition values with gpu_data fallback (amd-smi < 26.0.0)
+    compute_partition = (
+        current_partition.get("accelerator_type")
+        or gpu_data.get("partition", {}).get("accelerator_partition")
+        or gpu_data.get("partition", {}).get("compute_partition")
+    )
+    memory_partition = current_partition.get("memory") or gpu_data.get(
+        "partition", {}
+    ).get("memory_partition")
 
     # Apply defaults and warnings
-    if compute_partition is None:
+    if not compute_partition:
         console_warning("Cannot detect accelerator partition from amd-smi.")
         console_warning("Applying default accelerator partition: SPX")
         compute_partition = "SPX"
 
-    if memory_partition is None:
+    if not memory_partition:
         console_warning("Cannot detect memory partition from amd-smi.")
 
     console_debug(


### PR DESCRIPTION
## Motivation

Fix `amd-smi` look up logic in #223, to account for `amd-smi` >= 26.0.0

## Technical Details

Correctly look up partition data in `amd-smi` >= 26.0.0

## Test Plan

Tested on mi300x with `amd-smi` >= 26.0.0
Tested on mi250 with `amd-smi` < 26.0.0 (for backward support)

## Test Result

Passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
