### PR TITLE
Fix for thread limit tests

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
@@ -28,6 +28,7 @@
 #include "core/utility.hpp"
 #include "library/causal/delay.hpp"
 #include "library/components/category_region.hpp"
+#include "library/rocprofiler-sdk/counters.hpp"
 #include "library/runtime.hpp"
 #include "library/sampling.hpp"
 #include "library/thread_data.hpp"
@@ -62,7 +63,8 @@ namespace component
 {
 using bundle_t          = tim::lightweight_tuple<comp::wall_clock>;
 using category_region_t = tim::lightweight_tuple<category_region<category::pthread>>;
-
+constexpr size_t allowed_max_threads = tim::operation::set_storage<
+    rocprofsys::rocprofiler_sdk::counter_data_tracker>::max_threads;
 namespace
 {
 auto* is_shutdown   = new bool{ false };  // intentional data leak
@@ -181,7 +183,17 @@ pthread_create_gotcha::wrapper::operator()() const
     auto        _coverage    = (get_mode() == Mode::Coverage);
     const auto& _parent_info = thread_info::get(m_config.parent_tid, InternalTID);
     const auto& _info        = thread_info::init(m_config.offset);
-    auto        _dtor        = [&]() {
+    auto _sequent_value      = _info->index_data ? _info->index_data->sequent_value : -1;
+    if(static_cast<size_t>(_sequent_value) >= allowed_max_threads)
+    {
+        ROCPROFSYS_WARNING_F(1,
+                             "[rocprof-sys][WARNING] Maximum allowed thread limit (%zu) "
+                             "reached. Further thread creation and profiling will be "
+                             "disabled to prevent resource exhaustion.\n",
+                             allowed_max_threads);
+        return nullptr;
+    }
+    auto _dtor = [&]() {
         set_thread_state(ThreadState::Internal);
         if(_is_sampling)
         {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
@@ -28,7 +28,6 @@
 #include "core/utility.hpp"
 #include "library/causal/delay.hpp"
 #include "library/components/category_region.hpp"
-#include "library/rocprofiler-sdk/counters.hpp"
 #include "library/runtime.hpp"
 #include "library/sampling.hpp"
 #include "library/thread_data.hpp"
@@ -63,8 +62,10 @@ namespace component
 {
 using bundle_t          = tim::lightweight_tuple<comp::wall_clock>;
 using category_region_t = tim::lightweight_tuple<category_region<category::pthread>>;
-constexpr size_t allowed_max_threads = tim::operation::set_storage<
-    rocprofsys::rocprofiler_sdk::counter_data_tracker>::max_threads;
+// The maximum limit for the number of threads is set at 4096. declared and stored in the
+// set_storage struct's `types.hpp` file.
+constexpr size_t allowed_max_threads = 4096;
+
 namespace
 {
 auto* is_shutdown   = new bool{ false };  // intentional data leak
@@ -186,12 +187,16 @@ pthread_create_gotcha::wrapper::operator()() const
     auto _sequent_value      = _info->index_data ? _info->index_data->sequent_value : -1;
     if(static_cast<size_t>(_sequent_value) >= allowed_max_threads)
     {
-        ROCPROFSYS_WARNING_F(1,
-                             "[rocprof-sys][WARNING] Maximum allowed thread limit (%zu) "
-                             "reached. Further thread creation and profiling will be "
-                             "disabled to prevent resource exhaustion.\n",
-                             allowed_max_threads);
-        return nullptr;
+        static std::once_flag thread_limit_warning_flag;
+        std::call_once(thread_limit_warning_flag, []() {
+            ROCPROFSYS_WARNING_F(
+                1,
+                "[rocprof-sys][WARNING] Maximum allowed thread limit (%zu) "
+                "reached. Further thread creation and profiling will be "
+                "disabled to prevent resource exhaustion.\n",
+                allowed_max_threads);
+        });
+        return m_routine(m_arg);
     }
     auto _dtor = [&]() {
         set_thread_state(ThreadState::Internal);

--- a/projects/rocprofiler-systems/tests/source/CMakeLists.txt
+++ b/projects/rocprofiler-systems/tests/source/CMakeLists.txt
@@ -41,42 +41,52 @@ set(_thread_limit_environment
     "ROCPROFSYS_TIMEMORY_COMPONENTS=wall_clock,peak_rss,page_rss"
 )
 
-math(EXPR THREAD_LIMIT_TEST_VALUE "${ROCPROFSYS_MAX_THREADS} + 24")
-# Make sure the thread limit is set to the maximum thread size limit, which is
-# 4096, as indicated by the counters.hpp.
+# Test values ought to be maintained above test limits and within allowed bounds. Avoid exact power-of-2 matches to prevent test duplication.
+set(THREAD_VALUES
+    ${ROCPROFSYS_MAX_THREADS}
+    1
+    2049
+    4095
+    4097
+    4120
+)
+
+# Maximum allowed threads
 set(ALLOWED_MAX_THREADS 4096)
-if(${THREAD_LIMIT_TEST_VALUE} GREATER_EQUAL ${ALLOWED_MAX_THREADS})
-    message(
-        WARNING
-        "THREAD_LIMIT_TEST_VALUE has reached or exceeded the max allowed threads (4096)."
+
+# Loop over thread values
+foreach(THREADS IN LISTS THREAD_VALUES)
+    set(THREAD_PASS_VALUE ${THREADS})
+    math(EXPR THREAD_FAIL_VALUE "${THREADS} + 1")
+    if(${THREADS} GREATER_EQUAL ${ALLOWED_MAX_THREADS})
+        math(EXPR THREAD_PASS_VALUE "${ALLOWED_MAX_THREADS} - 1")
+        math(EXPR THREAD_FAIL_VALUE "${THREADS}")
+    endif()
+
+    set(_thread_limit_pass_regex "\\|${THREAD_PASS_VALUE}>>>")
+    set(_thread_limit_fail_regex "\\|${THREAD_FAIL_VALUE}>>>|ROCPROFSYS_ABORT_FAIL_REGEX")
+
+    # Unique test name
+    set(_test_name thread-limit-${THREADS})
+
+    # Add test
+    rocprofiler_systems_add_test(
+        SKIP_BASELINE
+        NAME ${_test_name}
+        TARGET thread-limit
+        LABELS "max-threads"
+        REWRITE_ARGS -e -v 2 -i 1024 --label return args
+        RUNTIME_ARGS -e -v 1 -i 1024 --label return args
+        RUN_ARGS 35 2 ${THREADS}
+        SAMPLING_TIMEOUT 240
+        REWRITE_TIMEOUT 240
+        RUNTIME_TIMEOUT 360
+        RUNTIME_PASS_REGEX "${_thread_limit_pass_regex}"
+        SAMPLING_PASS_REGEX "${_thread_limit_pass_regex}"
+        REWRITE_RUN_PASS_REGEX "${_thread_limit_pass_regex}"
+        RUNTIME_FAIL_REGEX "${_thread_limit_fail_regex}"
+        SAMPLING_FAIL_REGEX "${_thread_limit_fail_regex}"
+        REWRITE_RUN_FAIL_REGEX "${_thread_limit_fail_regex}"
+        ENVIRONMENT "${_thread_limit_environment}"
     )
-    # Establishing the maximum number of permitted threads index.
-    math(EXPR VALID_MAX_THREAD_INDEX "${ALLOWED_MAX_THREADS} - 1")
-    set(THREAD_LIMIT_TEST_VALUE ${VALID_MAX_THREAD_INDEX})
-endif()
-math(EXPR THREAD_LIMIT_TEST_VALUE_PLUS_ONE "${THREAD_LIMIT_TEST_VALUE} + 1")
-
-set(_thread_limit_pass_regex "\\|${THREAD_LIMIT_TEST_VALUE}>>>")
-set(_thread_limit_fail_regex
-    "\\|${THREAD_LIMIT_TEST_VALUE_PLUS_ONE}>>>|ROCPROFSYS_ABORT_FAIL_REGEX"
-)
-
-rocprofiler_systems_add_test(
-    SKIP_BASELINE
-    NAME thread-limit
-    TARGET thread-limit
-    LABELS "max-threads"
-    REWRITE_ARGS -e -v 2 -i 1024 --label return args
-    RUNTIME_ARGS -e -v 1 -i 1024 --label return args
-    RUN_ARGS 35 2 ${THREAD_LIMIT_TEST_VALUE}
-    SAMPLING_TIMEOUT 240
-    REWRITE_TIMEOUT 240
-    RUNTIME_TIMEOUT 360
-    RUNTIME_PASS_REGEX "${_thread_limit_pass_regex}"
-    SAMPLING_PASS_REGEX "${_thread_limit_pass_regex}"
-    REWRITE_RUN_PASS_REGEX "${_thread_limit_pass_regex}"
-    RUNTIME_FAIL_REGEX "${_thread_limit_fail_regex}"
-    SAMPLING_FAIL_REGEX "${_thread_limit_fail_regex}"
-    REWRITE_RUN_FAIL_REGEX "${_thread_limit_fail_regex}"
-    ENVIRONMENT "${_thread_limit_environment}"
-)
+endforeach()

--- a/projects/rocprofiler-systems/tests/source/CMakeLists.txt
+++ b/projects/rocprofiler-systems/tests/source/CMakeLists.txt
@@ -72,8 +72,8 @@ foreach(THREADS IN LISTS THREAD_VALUES)
         REWRITE_ARGS -e -v 2 -i 1024 --label return args
         RUNTIME_ARGS -e -v 1 -i 1024 --label return args
         RUN_ARGS 35 2 ${THREADS}
-        SAMPLING_TIMEOUT 360
-        REWRITE_TIMEOUT 360
+        SAMPLING_TIMEOUT 180
+        REWRITE_TIMEOUT 180
         RUNTIME_TIMEOUT 360
         RUNTIME_PASS_REGEX "${_thread_limit_pass_regex}"
         SAMPLING_PASS_REGEX "${_thread_limit_pass_regex}"

--- a/projects/rocprofiler-systems/tests/source/CMakeLists.txt
+++ b/projects/rocprofiler-systems/tests/source/CMakeLists.txt
@@ -42,6 +42,18 @@ set(_thread_limit_environment
 )
 
 math(EXPR THREAD_LIMIT_TEST_VALUE "${ROCPROFSYS_MAX_THREADS} + 24")
+# Make sure the thread limit is set to the maximum thread size limit, which is
+# 4096, as indicated by the counters.hpp.
+set(ALLOWED_MAX_THREADS 4096)
+if(${THREAD_LIMIT_TEST_VALUE} GREATER_EQUAL ${ALLOWED_MAX_THREADS})
+    message(
+        WARNING
+        "THREAD_LIMIT_TEST_VALUE has reached or exceeded the max allowed threads (4096)."
+    )
+    # Establishing the maximum number of permitted threads index.
+    math(EXPR VALID_MAX_THREAD_INDEX "${ALLOWED_MAX_THREADS} - 1")
+    set(THREAD_LIMIT_TEST_VALUE ${VALID_MAX_THREAD_INDEX})
+endif()
 math(EXPR THREAD_LIMIT_TEST_VALUE_PLUS_ONE "${THREAD_LIMIT_TEST_VALUE} + 1")
 
 set(_thread_limit_pass_regex "\\|${THREAD_LIMIT_TEST_VALUE}>>>")

--- a/projects/rocprofiler-systems/tests/source/CMakeLists.txt
+++ b/projects/rocprofiler-systems/tests/source/CMakeLists.txt
@@ -69,7 +69,8 @@ rocprofiler_systems_add_test(
     REWRITE_ARGS -e -v 2 -i 1024 --label return args
     RUNTIME_ARGS -e -v 1 -i 1024 --label return args
     RUN_ARGS 35 2 ${THREAD_LIMIT_TEST_VALUE}
-    REWRITE_TIMEOUT 180
+    SAMPLING_TIMEOUT 240
+    REWRITE_TIMEOUT 240
     RUNTIME_TIMEOUT 360
     RUNTIME_PASS_REGEX "${_thread_limit_pass_regex}"
     SAMPLING_PASS_REGEX "${_thread_limit_pass_regex}"

--- a/projects/rocprofiler-systems/tests/source/CMakeLists.txt
+++ b/projects/rocprofiler-systems/tests/source/CMakeLists.txt
@@ -40,19 +40,13 @@ set(_thread_limit_environment
     "ROCPROFSYS_VERBOSE=2"
     "ROCPROFSYS_TIMEMORY_COMPONENTS=wall_clock,peak_rss,page_rss"
 )
-
-# Test values ought to be maintained above test limits and within allowed bounds. Avoid exact power-of-2 matches to prevent test duplication.
-set(THREAD_VALUES
-    ${ROCPROFSYS_MAX_THREADS}
-    1
-    2049
-    4095
-    4097
-    4120
-)
-
 # Maximum allowed threads
 set(ALLOWED_MAX_THREADS 4096)
+
+math(EXPR THREAD_VAL_1 "${ROCPROFSYS_MAX_THREADS} + 24")
+math(EXPR THREAD_VAL_2 "${ALLOWED_MAX_THREADS} + 1")
+
+set(THREAD_VALUES ${THREAD_VAL_1} ${THREAD_VAL_2})
 
 # Loop over thread values
 foreach(THREADS IN LISTS THREAD_VALUES)
@@ -78,8 +72,8 @@ foreach(THREADS IN LISTS THREAD_VALUES)
         REWRITE_ARGS -e -v 2 -i 1024 --label return args
         RUNTIME_ARGS -e -v 1 -i 1024 --label return args
         RUN_ARGS 35 2 ${THREADS}
-        SAMPLING_TIMEOUT 240
-        REWRITE_TIMEOUT 240
+        SAMPLING_TIMEOUT 360
+        REWRITE_TIMEOUT 360
         RUNTIME_TIMEOUT 360
         RUNTIME_PASS_REGEX "${_thread_limit_pass_regex}"
         SAMPLING_PASS_REGEX "${_thread_limit_pass_regex}"


### PR DESCRIPTION
Imported PR from https://github.com/ROCm/rocprofiler-systems/pull/312

# rocprofiler-systems Pull Request

## Related Issue
<!-- Please link to the external GitHub issue(s) that this PR addresses. 
  If providing a JIRA ticket, please don't include an internal link -->
- SWDEV-511619

## What type of PR is this? (check all that apply)

- [x] Bug Fix
- [ ] Cherry Pick
- [ ] Continuous Integration
- [ ] Documentation Update
- [ ] Feature
- [ ] Optimization
- [ ] Refactor
- [ ] Other (please specify)

## Technical Details
<!-- Fix for thread limit tests. These are failing because they exceed the number of threads allowed. Now fixed to allow limit 4096-->

## Have you added or updated tests to validate functionality?

- [x] Yes
- [ ] No - does not apply to this PR

## Added / Updated documentation?

- [ ] Yes
- [x] No - does not apply to this PR

## Have you updated CHANGELOG?
<!-- Needed for Release updates for a ROCm release. -->
- [ ] Yes
- [x] No - does not apply to this PR
