### PR TITLE
[rocprofiler-systems] Include Fortran MPI CTests

### DIFF
--- a/projects/rocprofiler-systems/docker/Dockerfile.opensuse
+++ b/projects/rocprofiler-systems/docker/Dockerfile.opensuse
@@ -24,7 +24,7 @@ RUN zypper --non-interactive update -y && \
     zypper --non-interactive dist-upgrade -y && \
     zypper --non-interactive install -y -t pattern devel_basis && \
     zypper --non-interactive install -y binutils-gold chrpath cmake curl dpkg-devel \
-        gcc-c++ git iproute2 libdrm-devel libnuma-devel ninja openmpi3-devel python3-pip rpm-build \
+        gcc-c++ gcc-fortran git iproute2 libdrm-devel libnuma-devel ninja openmpi3-devel python3-pip rpm-build \
         sqlite3-devel wget  && \
     python3 -m pip install 'cmake==3.21'
 

--- a/projects/rocprofiler-systems/docker/Dockerfile.opensuse.ci
+++ b/projects/rocprofiler-systems/docker/Dockerfile.opensuse.ci
@@ -28,7 +28,7 @@ RUN zypper --non-interactive update -y && \
     zypper --non-interactive dist-upgrade -y && \
     zypper --non-interactive install -y -t pattern devel_basis && \
     zypper --non-interactive install -y binutils-gold chrpath cmake curl dpkg-devel \
-        gcc-c++ git iproute2 libnuma-devel ninja openmpi3-devel papi-devel python3-pip \
+        gcc-c++ gcc-fortran git iproute2 libnuma-devel ninja openmpi3-devel papi-devel python3-pip \
         rpm-build sqlite3-devel vim wget && \
     zypper --non-interactive clean --all && \
     python3 -m pip install 'cmake==3.21' perfetto

--- a/projects/rocprofiler-systems/docker/Dockerfile.ubuntu
+++ b/projects/rocprofiler-systems/docker/Dockerfile.ubuntu
@@ -29,7 +29,10 @@ RUN apt-get update && \
         python3 -m pip install --break-system-packages 'cmake==3.21'; \
     else \
         python3 -m pip install 'cmake==3.21'; \
-    fi
+    fi; \
+    if [ "${OS_VERSION}" == "20.04" ]; then \
+        apt-get install -y gfortran; \
+    fi;
 
 RUN ROCM_MAJOR=$(echo "${ROCM_VERSION}" | sed 's/\./ /g' | awk '{print $1}') && \
     ROCM_MINOR=$(echo "${ROCM_VERSION}" | sed 's/\./ /g' | awk '{print $2}') && \

--- a/projects/rocprofiler-systems/docker/Dockerfile.ubuntu.ci
+++ b/projects/rocprofiler-systems/docker/Dockerfile.ubuntu.ci
@@ -35,7 +35,10 @@ RUN apt-get update && \
         python3 -m pip install --break-system-packages 'cmake==3.21' perfetto \
     else \
         python3 -m pip install 'cmake==3.21' perfetto; \
-    fi
+    fi; \
+    if [ "${OS_VERSION}" == "20.04" ]; then \
+        apt-get install -y gfortran; \
+    fi;
 
 ARG PYTHON_VERSIONS="6 7 8 9 10 11 12 13"
 

--- a/projects/rocprofiler-systems/examples/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/CMakeLists.txt
@@ -22,7 +22,19 @@
 
 cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
-project(rocprofiler-systems-examples LANGUAGES C CXX)
+find_program(GFORTRAN_EXECUTABLE NAMES gfortran)
+
+if(GFORTRAN_EXECUTABLE)
+    set(ENABLE_FORTRAN_TESTS TRUE CACHE BOOL "Enable Fortran CTest support")
+else()
+    set(ENABLE_FORTRAN_TESTS FALSE CACHE BOOL "Enable Fortran CTest support")
+endif()
+
+if(ENABLE_FORTRAN_TESTS)
+    project(rocprofiler-systems-mpi-examples LANGUAGES C CXX Fortran)
+else()
+    project(rocprofiler-systems-mpi-examples LANGUAGES C CXX)
+endif()
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "")
     set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Build type" FORCE)

--- a/projects/rocprofiler-systems/examples/mpi/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/mpi/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
-project(rocprofiler-systems-mpi-examples LANGUAGES C CXX)
+if(ENABLE_FORTRAN_TESTS)
+    project(rocprofiler-systems-mpi-examples LANGUAGES C CXX Fortran)
+else()
+    project(rocprofiler-systems-mpi-examples LANGUAGES C CXX)
+endif()
 
 if(ROCPROFSYS_DISABLE_EXAMPLES)
     get_filename_component(_DIR ${CMAKE_CURRENT_LIST_DIR} NAME)
@@ -61,6 +65,54 @@ target_link_libraries(mpi-send-recv PRIVATE mpi-c-interface-library)
 
 add_executable(mpi-allreduce allreduce.c)
 target_link_libraries(mpi-allreduce PRIVATE mpi-c-interface-library m)
+
+if(MPI_FOUND AND ENABLE_FORTRAN_TESTS)
+    find_package(MPI REQUIRED Fortran) # Ensure MPI Fortran bindings are found
+    add_library(mpi-fortran-interface-library INTERFACE)
+    target_link_libraries(
+        mpi-fortran-interface-library
+        INTERFACE
+            Threads::Threads
+            MPI::MPI_Fortran
+            $<TARGET_NAME_IF_EXISTS:rocprofiler-systems::rocprofiler-systems-compile-options>
+    )
+    execute_process(
+        COMMAND ${GFORTRAN_EXECUTABLE} -dumpversion
+        OUTPUT_VARIABLE GFORTRAN_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(GFORTRAN_VERSION VERSION_GREATER_EQUAL "10")
+        set(MPI_FORTRAN_COMPILE_FLAGS "-w;-fallow-argument-mismatch")
+    else()
+        set(MPI_FORTRAN_COMPILE_FLAGS "-w;-Wno-argument-mismatch")
+    endif()
+
+    add_executable(mpi-fortran-array mpi_array.f)
+    target_compile_options(mpi-fortran-array PRIVATE ${MPI_FORTRAN_COMPILE_FLAGS})
+    target_link_libraries(mpi-fortran-array PRIVATE mpi-fortran-interface-library)
+
+    add_executable(mpi-fortran-mm mpi_mm.f)
+    target_compile_options(mpi-fortran-mm PRIVATE ${MPI_FORTRAN_COMPILE_FLAGS})
+    target_link_libraries(mpi-fortran-mm PRIVATE mpi-fortran-interface-library)
+
+    if(ROCPROFSYS_INSTALL_EXAMPLES)
+        install(
+            TARGETS mpi-fortran-array mpi-fortran-mm
+            DESTINATION bin
+            COMPONENT rocprofiler-systems-examples
+        )
+    endif()
+else()
+    if("${CMAKE_PROJECT_NAME}" STREQUAL "rocprofiler-systems" AND "$ENV{ROCPROFSYS_CI}")
+        set(_MSG_TYPE STATUS) # don't generate warnings during CI
+    else()
+        set(_MSG_TYPE AUTHOR_WARNING)
+    endif()
+    message(
+        ${_MSG_TYPE}
+        "Fortran MPI support is disabled. No Fortran MPI examples will be built."
+    )
+endif()
 
 set(CMAKE_BUILD_TYPE "Release")
 

--- a/projects/rocprofiler-systems/examples/mpi/mpi_array.f
+++ b/projects/rocprofiler-systems/examples/mpi/mpi_array.f
@@ -1,0 +1,152 @@
+C *****************************************************************************
+C FILE: mpi_array.f
+C DESCRIPTION:
+C   MPI Example - Array Assignment - Fortran Version
+C   This program demonstrates a simple data decomposition. The master task
+C   first initializes an array and then distributes an equal portion that
+C   array to the other tasks. After the other tasks receive their portion
+C   of the array, they perform an addition operation to each array element.
+C   They also maintain a sum for their portion of the array. The master task
+C   does likewise with its portion of the array and any leftover elements.
+C   As each of the non-master tasks finish, they send their updated portion
+C   of the array to the master. An MPI collective communication call is used
+C   to collect the sums maintained by each task.  Finally, the master
+C   task displays selected parts of the final array and the global sum of
+C   all array elements.
+C AUTHOR: Blaise Barney
+C LAST REVISED: 07/03/19
+C **************************************************************************
+
+      program array
+      include 'mpif.h'
+
+      integer   ARRAYSIZE, MASTER
+      parameter (ARRAYSIZE = 20000000)
+      parameter (MASTER = 0)
+
+      integer  numtasks, taskid, ierr, dest, offset, i, tag1,
+     &         tag2, source, chunksize, leftover
+      real*8   mysum, sum, data(ARRAYSIZE)
+      integer  status(MPI_STATUS_SIZE)
+      common   /a/ data
+
+C ***** Initializations *****
+      call MPI_INIT(ierr)
+      call MPI_COMM_SIZE(MPI_COMM_WORLD, numtasks, ierr)
+
+c     i = MOD(numtasks, 4)
+c     if (i .ne. 0) then
+c       call MPI_Abort(MPI_COMM_WORLD,ierr)
+c       stop
+c     end if
+
+      call MPI_COMM_RANK(MPI_COMM_WORLD, taskid, ierr)
+      write(*,10) taskid
+  10  format('MPI task ',I4,' has started...  '$)
+      chunksize = (ARRAYSIZE / numtasks)
+      leftover = MOD(ARRAYSIZE, numtasks)
+      tag2 = 1
+      tag1 = 2
+
+C***** Master task only ******
+      if (taskid .eq. MASTER) then
+
+C       Initialize the array
+        sum = 0.0
+        do i=1, ARRAYSIZE
+          data(i) = i * 1.0
+          sum = sum + data(i)
+        end do
+        write(*,20) sum
+        write(*,21) numtasks, chunksize, leftover
+  20    format('Initialized array sum = ',E14.6)
+  21    format('numtasks= ',I4,'  chunksize= ',I8,'  leftover= ',I4)
+
+C       Send each task its portion of the array - master keeps 1st part
+C       plus leftover elements
+        offset = chunksize + leftover + 1
+        do dest=1, numtasks-1
+          call MPI_SEND(offset, 1, MPI_INTEGER, dest, tag1,
+     &      MPI_COMM_WORLD, ierr)
+          call MPI_SEND(data(offset), chunksize, MPI_REAL8, dest,
+     &      tag2, MPI_COMM_WORLD, ierr)
+          write(*,22) chunksize, dest, offset
+  22      format('Sent ',I8,' elements to task ',I4,' offset= ',I10)
+          offset = offset + chunksize
+        end do
+
+C       Master does its part of the work
+        offset = 1
+        call update(offset, chunksize + leftover, taskid, mysum)
+
+C       Wait to receive results from each task
+        do i=1, numtasks-1
+          source = i
+          call MPI_RECV(offset, 1, MPI_INTEGER, source, tag1,
+     &      MPI_COMM_WORLD, status, ierr)
+          call MPI_RECV(data(offset), chunksize, MPI_REAL8,
+     &      source, tag2, MPI_COMM_WORLD, status, ierr)
+        end do
+
+C       Get final sum and print sample results
+        call MPI_Reduce(mysum, sum, 1, MPI_REAL8, MPI_SUM, MASTER,
+     &    MPI_COMM_WORLD, ierr)
+        print *, 'Sample results:'
+        offset = 1
+        do i=1, numtasks
+          write (*,30) data(offset:offset+4)
+  30      format(5E14.6)
+          offset = offset + chunksize
+        end do
+        write(*,40) sum
+  40    format('*** Final sum= ',E14.6,' ***')
+
+      end if
+
+
+C***** Non-master tasks only *****
+
+      if (taskid .gt. MASTER) then
+
+C       Receive my portion of array from the master task */
+        call MPI_RECV(offset, 1, MPI_INTEGER, MASTER, tag1,
+     &    MPI_COMM_WORLD, status, ierr)
+        call MPI_RECV(data(offset), chunksize, MPI_REAL8, MASTER,
+     &    tag2, MPI_COMM_WORLD, status, ierr)
+
+C       Do my part of the work
+        call update(offset, chunksize, taskid, mysum)
+
+C       Send my results back to the master
+        call MPI_SEND(offset, 1, MPI_INTEGER, MASTER, tag1,
+     &    MPI_COMM_WORLD, ierr)
+        call MPI_SEND(data(offset), chunksize, MPI_REAL8, MASTER,
+     &    tag2, MPI_COMM_WORLD, ierr)
+
+C       Use sum reduction operation to obtain final sum
+        call MPI_Reduce(mysum, sum, 1, MPI_REAL8, MPI_SUM, MASTER,
+     &    MPI_COMM_WORLD, ierr)
+
+      endif
+
+
+      call MPI_FINALIZE(ierr)
+
+
+      end
+
+
+      subroutine update(myoffset, chunksize, myid, mysum)
+        integer   ARRAYSIZE, myoffset, chunksize, myid, i
+        parameter (ARRAYSIZE = 20000000)
+        real*8 mysum, data(ARRAYSIZE)
+        common /a/ data
+C       Perform addition to each of my array elements and keep my sum
+        mysum = 0
+        do i=myoffset, myoffset + chunksize-1
+          data(i) = data(i) + (i * 1.0)
+          mysum = mysum + data(i)
+        end do
+        write(*,50) myid,mysum
+  50    format('Task',I4,' mysum = ',E14.6)
+      end subroutine update

--- a/projects/rocprofiler-systems/examples/mpi/mpi_mm.f
+++ b/projects/rocprofiler-systems/examples/mpi/mpi_mm.f
@@ -1,0 +1,125 @@
+C******************************************************************************
+C FILE: mpi_mm.f
+C DESCRIPTION:
+C   MPI Matrix Multiply - Fortran Version
+C   In this code, the master task distributes a matrix multiply
+C   operation to numtasks-1 worker tasks.
+C   NOTE1:  C and Fortran versions of this code differ because of the way
+C   arrays are stored/passed.  C arrays are row-major order but Fortran
+C   arrays are column-major order.
+C AUTHOR: Blaise Barney. Adapted from Ros Leibensperger, Cornell Theory
+C   Center. Converted to MPI: George L. Gusciora, MHPCC (1/95)
+C LAST REVISED: 04/02/05
+C******************************************************************************
+
+      program mm
+      include 'mpif.h'
+
+      parameter (NRA = 62)
+      parameter (NCA = 15)
+      parameter (NCB = 7)
+      parameter (MASTER = 0)
+      parameter (FROM_MASTER = 1)
+      parameter (FROM_WORKER = 2)
+
+      integer 	numtasks,taskid,numworkers,source,dest,mtype,
+     &          cols,avecol,extra, offset,i,j,k,ierr
+      integer status(MPI_STATUS_SIZE)
+      real*8	a(NRA,NCA), b(NCA,NCB), c(NRA,NCB)
+
+      call MPI_INIT( ierr )
+      call MPI_COMM_RANK( MPI_COMM_WORLD, taskid, ierr )
+      call MPI_COMM_SIZE( MPI_COMM_WORLD, numtasks, ierr )
+      numworkers = numtasks-1
+      print *, 'task ID= ',taskid
+
+C *************************** master task *************************************
+      if (taskid .eq. MASTER) then
+
+C     Initialize A and B
+        do 30 i=1, NRA
+          do 30 j=1, NCA
+          a(i,j) = (i-1)+(j-1)
+ 30     continue
+        do 40 i=1, NCA
+          do 40 j=1, NCB
+	    b(i,j) = (i-1)*(j-1)
+ 40     continue
+
+C     Send matrix data to the worker tasks
+        avecol = NCB/numworkers
+        extra = mod(NCB, numworkers)
+        offset = 1
+        mtype = FROM_MASTER
+        do 50 dest=1, numworkers
+          if (dest .le. extra) then
+            cols = avecol + 1
+          else
+            cols = avecol
+          endif
+          write(*,*)'   sending',cols,' cols to task',dest
+          call MPI_SEND( offset, 1, MPI_INTEGER, dest, mtype,
+     &                   MPI_COMM_WORLD, ierr )
+          call MPI_SEND( cols, 1, MPI_INTEGER, dest, mtype,
+     &                   MPI_COMM_WORLD, ierr )
+          call MPI_SEND( a, NRA*NCA, MPI_DOUBLE_PRECISION, dest, mtype,
+     &                   MPI_COMM_WORLD, ierr )
+          call MPI_SEND( b(:,offset), cols*NCA, MPI_DOUBLE_PRECISION,
+     &                   dest, mtype, MPI_COMM_WORLD, ierr )
+          offset = offset + cols
+ 50     continue
+
+C     Receive results from worker tasks
+        mtype = FROM_WORKER
+        do 60 i=1, numworkers
+          source = i
+          call MPI_RECV( offset, 1, MPI_INTEGER, source,
+     &                   mtype, MPI_COMM_WORLD, status, ierr )
+          call MPI_RECV( cols, 1, MPI_INTEGER, source,
+     &                   mtype, MPI_COMM_WORLD, status, ierr )
+          call MPI_RECV( c(:,offset), cols*NRA, MPI_DOUBLE_PRECISION,
+     &                   source, mtype, MPI_COMM_WORLD, status, ierr )
+ 60     continue
+
+C     Print results
+        do 90 i=1, NRA
+          do 80 j = 1, NCB
+            write(*,70)c(i,j)
+  70        format(2x,f8.2,$)
+  80      continue
+          print *, ' '
+  90    continue
+      endif
+
+C *************************** worker task *************************************
+      if (taskid > MASTER) then
+C     Receive matrix data from master task
+        mtype = FROM_MASTER
+        call MPI_RECV( offset, 1, MPI_INTEGER, MASTER,
+     &                 mtype, MPI_COMM_WORLD, status, ierr )
+        call MPI_RECV( cols, 1, MPI_INTEGER, MASTER,
+     &                 mtype, MPI_COMM_WORLD, status, ierr )
+        call MPI_RECV( a, NRA*NCA, MPI_DOUBLE_PRECISION, MASTER,
+     &                 mtype, MPI_COMM_WORLD, status, ierr )
+        call MPI_RECV( b, cols*NCA, MPI_DOUBLE_PRECISION, MASTER,
+     &                 mtype, MPI_COMM_WORLD, status, ierr )
+
+C     Do matrix multiply
+        do 100 k=1, cols
+          do 100 i=1, NRA
+            c(i,k) = 0.0
+            do 100 j=1, NCA
+              c(i,k) = c(i,k) + a(i,j) * b(j,k)
+  100   continue
+
+C     Send results back to master task
+        mtype = FROM_WORKER
+        call MPI_SEND( offset, 1, MPI_INTEGER, MASTER, mtype,
+     &                 MPI_COMM_WORLD, ierr )
+        call MPI_SEND( cols, 1, MPI_INTEGER, MASTER, mtype,
+     &                 MPI_COMM_WORLD, ierr )
+        call MPI_SEND( c, cols*NRA, MPI_DOUBLE_PRECISION, MASTER,
+     &                  mtype, MPI_COMM_WORLD, ierr )
+      endif
+      call MPI_FINALIZE(ierr)
+      end

--- a/projects/rocprofiler-systems/tests/rocprof-sys-mpi-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-mpi-tests.cmake
@@ -99,6 +99,49 @@ rocprofiler_systems_add_test(
         ">>> mpi-flat.inst(.*\n.*)>>> MPI_Init_thread(.*\n.*)>>> pthread_create(.*\n.*)>>> MPI_Comm_size(.*\n.*)>>> MPI_Comm_rank(.*\n.*)>>> MPI_Barrier(.*\n.*)>>> MPI_Alltoall"
 )
 
+if(ENABLE_FORTRAN_TESTS)
+    rocprofiler_systems_add_test(
+        NAME "mpi-fortran-array"
+        TARGET mpi-fortran-array
+        MPI ON
+        NUM_PROCS 2
+        LABELS "fortran"
+        REWRITE_ARGS
+            -e
+            -v
+            2
+            --label
+            file
+            line
+            args
+            --min-instructions
+            0
+        ENVIRONMENT "${_mpip_environment};"
+        BASELINE_PASS_REGEX "Final sum= *0\\.400000E\\+15"
+    )
+
+    rocprofiler_systems_add_test(
+        SKIP_RUNTIME # Runtime needs to be skipped
+        NAME "mpi-fortran-mm"
+        TARGET mpi-fortran-mm
+        MPI ON
+        NUM_PROCS 2
+        LABELS "fortran"
+        REWRITE_ARGS
+            -e
+            -v
+            2
+            --label
+            file
+            line
+            args
+            --min-instructions
+            0
+        ENVIRONMENT "${_mpip_environment};"
+        BASELINE_PASS_REGEX "1015\\.00.*44520\\.00"
+    )
+endif()
+
 set(_mpip_environment
     "ROCPROFSYS_TRACE=ON"
     "ROCPROFSYS_PROFILE=ON"


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Introduces CTests that cover MPI Fortran code. This is part of an initiative for better Fortran support in rocprofiler-systems.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
 - Added `gcc-fortran`/`gfortran` to the dockerfiles so that the tests will be enabled by default.
 - Uses two Fortran parallel programs to test runtime, instrument, and binary-rewrite.

**Note:** The tests will *fail* if `ROCPROFSYS_USE_MPI=ON`. However, this is usually disabled by default and users should use `ROCPROFSYS_USE_MPI_HEADERS` instead.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Testing was done on workflows from `rocprofiler-systems` repo before the merger.

## Test Result

<!-- Briefly summarize test outcomes. -->
 All but one workflow passed when ran on `rocprofiler-systems` old repo. The one that failed had set `ROCPROFSYS_USE_MPI=ON`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
