### PR TITLE
Re-Enable IPC DMA Bufs by default

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -242,7 +242,8 @@ class Flag {
     enable_mwaitx_ = (var == "1") ? true : false;
 
     var = os::GetEnvVar("HSA_ENABLE_IPC_MODE_LEGACY");
-    enable_ipc_mode_legacy_ = (var == "0") ? false : true; // Legacy mode by default
+    enable_ipc_mode_legacy_ = (var == "1") ? true : false;
+
     if (os::IsEnvVarSet("HSA_PCS_MAX_DEVICE_BUFFER_SIZE")) {
       var = os::GetEnvVar("HSA_PCS_MAX_DEVICE_BUFFER_SIZE");
       char* end;


### PR DESCRIPTION
Let ROCr use the new IPC-DMA bufs path.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
