### PR TITLE
Update rocm_ci_caller.yml - disable the trigger for draft PRs

### DIFF
--- a/.azuredevops/rocm_ci_caller.yml
+++ b/.azuredevops/rocm_ci_caller.yml
@@ -7,6 +7,7 @@ pr:
     include:  
       - projects/*
       - shared/*
+  drafts: false
   
 variables:
   - group: internal


### PR DESCRIPTION
## Motivation

Draft PR will trigger the PSDB and they will overload the build nodes. This is not required

## Technical Details

None

## Test Plan

None

## Test Result

None

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
