### PR TITLE
[rocm-smi-lib] [docs] Fix changelog heading: `ROCm 6.5.0` -> `ROCm 7.0.0`

### DIFF
--- a/projects/rocm-smi-lib/CHANGELOG.md
+++ b/projects/rocm-smi-lib/CHANGELOG.md
@@ -4,7 +4,7 @@ Full documentation for rocm_smi_lib is available at [https://rocm.docs.amd.com/]
 
 ***All information listed below is for reference and subject to change.***
 
-## rocm_smi_lib for ROCm 6.5.0
+## rocm_smi_lib for ROCm 7.0.0
 
 ### Added
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

ROCm 6.5.0 doesn't exist anymore

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
