### PR TITLE
[rocprofiler-systems] Disable OMPT perfetto flows and fix perfetto track names

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/ompt.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/ompt.cpp
@@ -80,11 +80,9 @@ struct ompt : comp::base<ompt, void>
     template <typename... Args>
     void start(const context_info_t& _ctx_info, Args&&...) const
     {
-        category_region<category::ompt>::start<tim::quirk::timemory>(m_prefix);
+        category_region<category::ompt>::start<tim::quirk::timemory>(_ctx_info.label);
 
         auto     _ts = tracing::now();
-        uint64_t _cid =
-            (_ctx_info.target_arguments) ? _ctx_info.target_arguments->host_op_id : 0;
         auto _annotate = [&](::perfetto::EventContext ctx) {
             if(config::get_perfetto_annotations())
             {
@@ -94,28 +92,18 @@ struct ompt : comp::base<ompt, void>
             }
         };
 
-        if(_cid > 0)
-        {
-            category_region<category::ompt>::start<tim::quirk::perfetto>(
-                (_ctx_info.func.empty()) ? m_prefix : _ctx_info.func, _ts,
-                ::perfetto::Flow::ProcessScoped(_cid), std::move(_annotate));
-        }
-        else
-        {
-            category_region<category::ompt>::start<tim::quirk::perfetto>(
-                (_ctx_info.func.empty()) ? m_prefix : _ctx_info.func, _ts,
+        category_region<category::ompt>::start<tim::quirk::perfetto>(
+                _ctx_info.label, _ts,
                 std::move(_annotate));
-        }
+        
     }
 
     template <typename... Args>
     void stop(const context_info_t& _ctx_info, Args&&...) const
     {
-        category_region<category::ompt>::stop<tim::quirk::timemory>(m_prefix);
+        category_region<category::ompt>::stop<tim::quirk::timemory>(_ctx_info.label);
 
         auto     _ts = tracing::now();
-        uint64_t _cid =
-            (_ctx_info.target_arguments) ? _ctx_info.target_arguments->host_op_id : 0;
         auto _annotate = [&](::perfetto::EventContext ctx) {
             if(config::get_perfetto_annotations())
             {
@@ -125,18 +113,11 @@ struct ompt : comp::base<ompt, void>
             }
         };
 
-        if(_cid > 0)
-        {
-            category_region<category::ompt>::stop<tim::quirk::perfetto>(
-                (_ctx_info.func.empty()) ? m_prefix : _ctx_info.func, _ts,
-                std::move(_annotate));
-        }
-        else
-        {
-            category_region<category::ompt>::stop<tim::quirk::perfetto>(
-                (_ctx_info.func.empty()) ? m_prefix : _ctx_info.func, _ts,
-                std::move(_annotate));
-        }
+
+        category_region<category::ompt>::stop<tim::quirk::perfetto>(
+            _ctx_info.label, _ts,
+            std::move(_annotate));
+        
     }
 
     template <typename... Args>


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Currently, flow events with OMPT (using timemory) are incorrect. As a solution in timemory would be too complex and considering the fact that we are planning to move to using `rocprofiler-sdk` for OMPT, we have opted to disable the flows until we make the switch.

Furthermore, OMPT track names in Perfetto were incorrect (in `Fortran`, you would see `_QQMain` as opposed to the relevant ompt track name and in `C++`, you would see `main_dyninst`). This has been fixed.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
 - Switched from using `m_prefix` to `_ctx_info.label` (fixes naming)
 - No longer insert `_cid` into perfetto (disables flow events)
 - Removed redundant `if` statement in `stop()` (code fix)

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Tested naming by using CPU and GPU Fortran code (comparing both the before and after). Also used `openmp-lu-sampling` and `openmp-cg-sampling` traces.

## Test Result

<!-- Briefly summarize test outcomes. -->
 - Naming issue fixed.
 - No more flow events for OMPT.

**NOTE**: While comparing the `openmp-lu-sampling` traces, I noticed:
 1. With this fix, `ompt_parallel` now appears.
 2. With this fix, some new tracks appear (for example, in category `timer_sampling`). I presume this is because of the presence of other tracks being present (such as `ompt_parallel`).

Further investigation into these changes is ongoing. Will talk with the team.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
