### PR TITLE
Fix decoder description

### DIFF
--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/thread-trace/trace_decoder_types.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/thread-trace/trace_decoder_types.h
@@ -205,7 +205,7 @@ typedef struct rocprofiler_thread_trace_decoder_shaderdata_t
 {
     int64_t  time;
     uint64_t value;    ///< Value written from M0/IMM
-    uint8_t  cu;       ///< CU id (gfx9) or wgp id (gfx10+). This is always the target_cu.
+    uint8_t  cu;       ///< CU id (gfx9) or wgp id (gfx10+).
     uint8_t  simd;     ///< SIMD ID [0,3].
     uint8_t  wave_id;  ///< Wave slot ID within SIMD.
     uint8_t  flags;    ///< bitmask of rocprofiler_thread_trace_decoder_shaderdata_flags_t


### PR DESCRIPTION
## Motivation

The description for shaderdata_t says: "This is always the target_cu."
It's incorrect, shaderdata is collected for all CUs.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
