### PR TITLE
SWDEV-550221 - Skip Unit_hipExtLaunchMultiKernelMultiDevice_Negative_…

### DIFF
--- a/projects/hip-tests/catch/unit/executionControl/hipExtLaunchMultiKernelMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipExtLaunchMultiKernelMultiDevice.cc
@@ -122,6 +122,12 @@ TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Negative_Parameters") {
 }
 
 TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Negative_MultiKernelSameDevice") {
+
+  if (HipTest::getDeviceCount() < 2) {
+    HipTest::HIP_SKIP_TEST("This test requires 2 GPUs. Skipping test");
+    return;
+  }
+
   HIP_CHECK(hipSetDevice(0));
 
   std::vector<hipLaunchParams> params_list(2);


### PR DESCRIPTION
…MultiKernelSameDevice for ndevices < 2

## Motivation
The Unit_hipExtLaunchMultiKernelMultiDevice_Negative_MultiKernelSameDevice  test is not valid for ndevices < 2
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Skip the test if ndevices < 2
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Tried Unit_hipExtLaunchMultiKernelMultiDevice_Negative_MultiKernelSameDevice on strix halo and verified its skipped
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Test is skipped on strix halo
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
