### PR TITLE
Enabling --kokkos-trace in rocprofiler-compute (for SWDEV-520867, aft…

### DIFF
--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -162,8 +162,8 @@ Examples:
         required=False,
         default=False,
         action="store_true",
-        help=argparse.SUPPRESS,
-        # help="\t\t\tKokkos trace, traces Kokkos API calls.",
+        # help=argparse.SUPPRESS,
+        help="\t\t\tKokkos trace, traces Kokkos API calls.",
     )
     profile_group.add_argument(
         "-k",

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprof_v3.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprof_v3.py
@@ -44,12 +44,6 @@ class rocprof_v3_profiler(RocProfCompute_Base):
         trace_option = "--kernel-trace"
         if self.get_args().kokkos_trace:
             trace_option = "--kokkos-trace"
-            # NOTE: --kokkos-trace feature is incomplete and is disabled for now.
-            console_error(
-                "The option '--kokkos-trace' is not supported in the current "
-                "version of rocprof-compute. This functionality is planned for a "
-                "future release. Please adjust your profiling options accordingly."
-            )
         if self.get_args().hip_trace:
             trace_option = "--hip-trace"
 


### PR DESCRIPTION
…er verifying SWDEV-516561). It was disabled in 9a92c7e1b1b4c9b03c215d8a4566851888a9e8ef

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
