### PR TITLE
[rocprofiler-systems] Update containers workflow to not push on PR

### DIFF
--- a/.github/workflows/rocprofiler-systems-containers.yml
+++ b/.github/workflows/rocprofiler-systems-containers.yml
@@ -78,8 +78,8 @@ jobs:
           max_attempts: 3
           command: |
             pushd projects/rocprofiler-systems/docker
-            PUSH_COMMAND="--push"
-            if [ ${{ github.event_name == 'pull_request' }} ]; then PUSH_COMMAND=""; fi
+            PUSH_COMMAND=${{ github.event_name == 'pull_request' && '--push' || '' }}
+            echo $PUSH_COMMAND
             ./build-docker-ci.sh --distro ${{ matrix.distro }} --versions ${{ matrix.version }} --user ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }} ${PUSH_COMMAND} --jobs 2 --elfutils-version 0.188 --boost-version 1.79.0
             popd
 
@@ -135,7 +135,7 @@ jobs:
           max_attempts: 3
           command: |
             pushd projects/rocprofiler-systems/docker
-            PUSH_COMMAND="--push"
-            if [ ${{ github.event_name == 'pull_request' }} ]; then PUSH_COMMAND=""; fi
+            PUSH_COMMAND=${{ github.event_name == 'pull_request' && '--push' || '' }}
+            echo $PUSH_COMMAND
             ./build-docker.sh --distro ${{ matrix.os-distro }} --versions ${{ matrix.os-version }} --rocm-versions ${{ matrix.rocm-version }} --user ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }} ${PUSH_COMMAND}
             popd

--- a/.github/workflows/rocprofiler-systems-containers.yml
+++ b/.github/workflows/rocprofiler-systems-containers.yml
@@ -83,7 +83,7 @@ jobs:
             popd
       
       - name: Build CI Container (Push)
-        if: ${{ github.event_name != 'pull_request' }}
+        if: github.event_name != 'pull_request'
         timeout-minutes: 45
         uses: nick-fields/retry@v3
         with:

--- a/.github/workflows/rocprofiler-systems-containers.yml
+++ b/.github/workflows/rocprofiler-systems-containers.yml
@@ -78,8 +78,7 @@ jobs:
           max_attempts: 3
           command: |
             pushd projects/rocprofiler-systems/docker
-            PUSH_COMMAND=${{ github.event_name == 'pull_request' && '--push' || '' }}
-            echo $PUSH_COMMAND
+            PUSH_COMMAND=${{ github.event_name == 'pull_request' && '' || '--push' }}
             ./build-docker-ci.sh --distro ${{ matrix.distro }} --versions ${{ matrix.version }} --user ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }} ${PUSH_COMMAND} --jobs 2 --elfutils-version 0.188 --boost-version 1.79.0
             popd
 
@@ -135,7 +134,6 @@ jobs:
           max_attempts: 3
           command: |
             pushd projects/rocprofiler-systems/docker
-            PUSH_COMMAND=${{ github.event_name == 'pull_request' && '--push' || '' }}
-            echo $PUSH_COMMAND
+            PUSH_COMMAND=${{ github.event_name == 'pull_request' && '' || '--push' }}
             ./build-docker.sh --distro ${{ matrix.os-distro }} --versions ${{ matrix.os-version }} --rocm-versions ${{ matrix.rocm-version }} --user ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }} ${PUSH_COMMAND}
             popd

--- a/.github/workflows/rocprofiler-systems-containers.yml
+++ b/.github/workflows/rocprofiler-systems-containers.yml
@@ -26,6 +26,7 @@ env:
 
 jobs:
   prepare_matrix_ci:
+    if: github.repository == 'ROCm/rocm-systems'
     runs-on: ubuntu-latest
     outputs:
       matrix_data: ${{ steps.generate_matrix_ci.outputs.matrix_data }}
@@ -96,6 +97,7 @@ jobs:
             popd
 
   prepare_matrix_release:
+    if: github.repository == 'ROCm/rocm-systems'
     runs-on: ubuntu-latest
     outputs:
       matrix_data: ${{ steps.generate_matrix_release.outputs.matrix_data }}

--- a/.github/workflows/rocprofiler-systems-containers.yml
+++ b/.github/workflows/rocprofiler-systems-containers.yml
@@ -70,7 +70,7 @@ jobs:
           password: ${{ secrets.ROCPROF_SYS_DOCKER_TOKEN }}
 
       - name: Build CI Container (PR - No Push)
-        if: ${{ github.event_name == 'pull_request' }}
+        if: github.event_name == 'pull_request'
         timeout-minutes: 45
         uses: nick-fields/retry@v3
         with:
@@ -139,7 +139,7 @@ jobs:
           password: ${{ secrets.ROCPROF_SYS_DOCKER_TOKEN }}
 
       - name: Build Base Container (PR - No Push)
-        if: ${{ github.event_name == 'pull_request' }}
+        if: github.event_name == 'pull_request'
         timeout-minutes: 45
         uses: nick-fields/retry@v3
         with:
@@ -152,7 +152,7 @@ jobs:
             popd
       
       - name: Build Base Container (Push)
-        if: ${{ github.event_name != 'pull_request' }}
+        if: github.event_name != 'pull_request'
         timeout-minutes: 45
         uses: nick-fields/retry@v3
         with:

--- a/.github/workflows/rocprofiler-systems-containers.yml
+++ b/.github/workflows/rocprofiler-systems-containers.yml
@@ -69,7 +69,8 @@ jobs:
           username: ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }}
           password: ${{ secrets.ROCPROF_SYS_DOCKER_TOKEN }}
 
-      - name: Build CI Container
+      - name: Build CI Container (PR - No Push)
+        if: ${{ github.event_name == 'pull_request' }}
         timeout-minutes: 45
         uses: nick-fields/retry@v3
         with:
@@ -78,8 +79,20 @@ jobs:
           max_attempts: 3
           command: |
             pushd projects/rocprofiler-systems/docker
-            PUSH_COMMAND=${{ github.event_name == 'pull_request' && '' || '--push' }}
-            ./build-docker-ci.sh --distro ${{ matrix.distro }} --versions ${{ matrix.version }} --user ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }} ${PUSH_COMMAND} --jobs 2 --elfutils-version 0.188 --boost-version 1.79.0
+            ./build-docker-ci.sh --distro ${{ matrix.distro }} --versions ${{ matrix.version }} --user ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }} --jobs 2 --elfutils-version 0.188 --boost-version 1.79.0
+            popd
+      
+      - name: Build CI Container (Push)
+        if: ${{ github.event_name != 'pull_request' }}
+        timeout-minutes: 45
+        uses: nick-fields/retry@v3
+        with:
+          retry_wait_seconds: 60
+          timeout_minutes: 45
+          max_attempts: 3
+          command: |
+            pushd projects/rocprofiler-systems/docker
+            ./build-docker-ci.sh --distro ${{ matrix.distro }} --versions ${{ matrix.version }} --user ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }} --push --jobs 2 --elfutils-version 0.188 --boost-version 1.79.0
             popd
 
   prepare_matrix_release:
@@ -125,7 +138,8 @@ jobs:
           username: ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }}
           password: ${{ secrets.ROCPROF_SYS_DOCKER_TOKEN }}
 
-      - name: Build Base Container
+      - name: Build Base Container (PR - No Push)
+        if: ${{ github.event_name == 'pull_request' }}
         timeout-minutes: 45
         uses: nick-fields/retry@v3
         with:
@@ -134,6 +148,18 @@ jobs:
           max_attempts: 3
           command: |
             pushd projects/rocprofiler-systems/docker
-            PUSH_COMMAND=${{ github.event_name == 'pull_request' && '' || '--push' }}
-            ./build-docker.sh --distro ${{ matrix.os-distro }} --versions ${{ matrix.os-version }} --rocm-versions ${{ matrix.rocm-version }} --user ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }} ${PUSH_COMMAND}
+            ./build-docker.sh --distro ${{ matrix.os-distro }} --versions ${{ matrix.os-version }} --rocm-versions ${{ matrix.rocm-version }} --user ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }}
+            popd
+      
+      - name: Build Base Container (Push)
+        if: ${{ github.event_name != 'pull_request' }}
+        timeout-minutes: 45
+        uses: nick-fields/retry@v3
+        with:
+          retry_wait_seconds: 60
+          timeout_minutes: 45
+          max_attempts: 3
+          command: |
+            pushd projects/rocprofiler-systems/docker
+            ./build-docker.sh --distro ${{ matrix.os-distro }} --versions ${{ matrix.os-version }} --rocm-versions ${{ matrix.rocm-version }} --user ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }} --push
             popd


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Recent change to `rocprofiler-systems-containers.yml` is making it so that it doesn't push the Docker image on the nightly schedule.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Change the logic such that it will properly run the push on non-PR events.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
