### PR TITLE
[rocprofiler-systems] Add working-directory to gersemi, clang-format, and check-includes steps

### DIFF
--- a/.github/workflows/rocprofiler-systems-formatting.yml
+++ b/.github/workflows/rocprofiler-systems-formatting.yml
@@ -10,6 +10,7 @@ on:
       - 'projects/rocprofiler-systems/**'
   pull_request:
     paths:
+      - '.github/workflows/rocprofiler-systems-formatting.yml'
       - 'projects/rocprofiler-systems/**'
 
 concurrency:

--- a/.github/workflows/rocprofiler-systems-formatting.yml
+++ b/.github/workflows/rocprofiler-systems-formatting.yml
@@ -106,6 +106,7 @@ jobs:
         sudo apt-get install -y python3-pip
         python3 -m pip install gersemi
     - name: gersemi
+      working-directory: projects/rocprofiler-systems/
       run: |
         set +e
         gersemi -i $(find . -type f ! -path '*/external/*' | grep -E 'CMakeLists.txt|\.cmake$')
@@ -132,6 +133,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y software-properties-common wget curl clang-format-18
     - name: clang-format
+      working-directory: projects/rocprofiler-systems/
       run: |
         set +e
         FILES=$(find source examples tests -type f | egrep '\.(h|hpp|c|cpp)(|\.in)$')
@@ -152,6 +154,7 @@ jobs:
       with:
         sparse-checkout: projects/rocprofiler-systems
     - name: check-includes
+      working-directory: projects/rocprofiler-systems/
       run: |
         set +e
         FILES=$(find source examples -type f | egrep '\.(hpp|cpp)(|\.in)$')


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The `rocprofiler-systems-formatting.yml` workflow was unable to perform formatting checks on files since we didn't update these steps to change to the `projects/rocprofiler-systems` directory before scanning.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Updated the `gersemi`, `clang-format`, and `check-includes` steps to have working directory set to `projects/rocprofiler-systems`

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
