### PR TITLE
SWDEV-551218 -  Fix hip on nvidia build failures

### DIFF
--- a/projects/hipother/hipnv/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
+++ b/projects/hipother/hipnv/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
@@ -2060,11 +2060,11 @@ inline static hipError_t hipMemPrefetchAsync_v2(const void* dev_ptr, size_t coun
 inline static hipError_t hipMemAdvise_v2(const void* dev_ptr, size_t count, hipMemoryAdvise advice,
                                          hipMemLocation location) {
 #if CUDA_VERSION >= 13000
-    return hipCUDAErrorTohipError(cudaMemAdvise(dev_ptr, count,
-        hipMemoryAdviseTocudaMemoryAdvise(advice), location));
+  return hipCUDAErrorTohipError(cudaMemAdvise(dev_ptr, count,
+      hipMemoryAdviseTocudaMemoryAdvise(advice), location));
 #else
-    return hipCUDAErrorTohipError(cudaMemAdvise_v2(dev_ptr, count,
-        hipMemoryAdviseTocudaMemoryAdvise(advice), location));
+  return hipCUDAErrorTohipError(cudaMemAdvise_v2(dev_ptr, count,
+      hipMemoryAdviseTocudaMemoryAdvise(advice), location));
 #endif
 }
 

--- a/projects/hipother/hipnv/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
+++ b/projects/hipother/hipnv/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
@@ -2060,9 +2060,11 @@ inline static hipError_t hipMemPrefetchAsync_v2(const void* dev_ptr, size_t coun
 inline static hipError_t hipMemAdvise_v2(const void* dev_ptr, size_t count, hipMemoryAdvise advice,
                                          hipMemLocation location) {
 #if CUDA_VERSION >= 13000
-  return hipCUDAErrorTohipError(cudaMemAdvise(dev_ptr, count, advice, location));
+    return hipCUDAErrorTohipError(cudaMemAdvise(dev_ptr, count,
+        hipMemoryAdviseTocudaMemoryAdvise(advice), location));
 #else
-  return hipCUDAErrorTohipError(cudaMemAdvise_v2(dev_ptr, count, advice, location));
+    return hipCUDAErrorTohipError(cudaMemAdvise_v2(dev_ptr, count,
+        hipMemoryAdviseTocudaMemoryAdvise(advice), location));
 #endif
 }
 
@@ -2167,10 +2169,6 @@ inline static hipError_t hipHostFree(void* ptr) {
 
 inline static hipError_t hipSetDevice(int device) {
   return hipCUDAErrorTohipError(cudaSetDevice(device));
-}
-
-inline static hipError_t hipSetValidDevices(int* device_arr, int len) {
-  return hipCUDAErrorTohipError(cudaSetValidDevices(device_arr, len));
 }
 
 inline static hipError_t hipChooseDevice(int* device, const hipDeviceProp_t* prop) {


### PR DESCRIPTION
## Motivation

Fixes the hip on nvidia build failures

## Technical Details

- Removes the double definition of hipSetValidDevices
- corrects the hipMemAdvise_v2 call in nvidia headers

## Test Plan

Tested locally that catch tests were building fine with this fix.

## Test Result

Tests build fine

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
