### PR TITLE
[SWDEV-540377] Fixed segfault in --showevent command

### DIFF
--- a/projects/rocm-smi-lib/.github/CODEOWNERS
+++ b/projects/rocm-smi-lib/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @bill-shuzhou-liu @dmitrii-galantsev @charis-poag-amd @oliveiradan
+* @bill-shuzhou-liu @dmitrii-galantsev @charis-poag-amd @oliveiradan @marifamd @gabrpham
 
 docs/* @ROCm/rocm-documentation
 *.md @ROCm/rocm-documentation

--- a/projects/rocm-smi-lib/python_smi_tools/rocm_smi.py
+++ b/projects/rocm-smi-lib/python_smi_tools/rocm_smi.py
@@ -921,7 +921,10 @@ def printLog(device, metricName, value=None, extraSpace=False, useItalics=False,
             print('\n', end='')
 
         # Handle non UTF-8 locale
-        print(logstr.encode('ascii', 'ignore').decode('ascii'))
+        try:
+            print(logstr.encode('utf-8', 'ignore').decode('utf-8'))
+        except UnicodeError:
+            print(logstr.encode('ascii', 'ignore').decode('ascii'))
 
         sys.stdout.flush()
     # when piped into programs like 'head' - print throws an error.

--- a/projects/rocm-smi-lib/python_smi_tools/rocm_smi.py
+++ b/projects/rocm-smi-lib/python_smi_tools/rocm_smi.py
@@ -877,6 +877,9 @@ def printEventList(device, delay, eventList):
         if len(data.message) > 0:
             print2DArray([['\rGPU[%d]:\t' % (data.dv_ind), ctime().split()[3], notification_type_names[data.event.value - 1],
                            data.message.decode('utf8') + '\r']])
+    ret = rocmsmi.rsmi_event_notification_stop(device)
+    if not rsmi_ret_ok(ret, device, 'stop_event_notification'):
+        printErrLog(device, 'Unable to end event notifications.')
 
 def printLog(device, metricName, value=None, extraSpace=False, useItalics=False, xcp=None):
     """ Print out to the SMI log
@@ -918,10 +921,7 @@ def printLog(device, metricName, value=None, extraSpace=False, useItalics=False,
             print('\n', end='')
 
         # Handle non UTF-8 locale
-        try:
-            print(logstr + '\n', end='')
-        except UnicodeEncodeError:
-            print(logstr.encode('ascii', 'ignore').decode('ascii'))
+        print(logstr.encode('ascii', 'ignore').decode('ascii'))
 
         sys.stdout.flush()
     # when piped into programs like 'head' - print throws an error.
@@ -3007,7 +3007,7 @@ def showEvents(deviceList, eventTypes):
     :param eventTypes: List of event type names (can be a single-item list)
     """
     printLogSpacer(' Show Events ')
-    printLog(None, 'press \'q\' or \'ctrl + c\' to quit', None)
+    printLog(None, 'press \'q\' or \'ctrl + c\' and then \'Enter\' to quit', None)
     eventTypeList = []
     thread_list = []
     for event in eventTypes:  # Cleaning list from wrong values
@@ -3022,23 +3022,18 @@ def showEvents(deviceList, eventTypes):
         for device in deviceList:
             try:
                 thread = threading.Thread(target=printEventList, args=(device, 1000, eventTypeList))
-                thread.start()
                 thread_list.append(thread)
+                thread.start()
                 time.sleep(0.25)
             except Exception as e:
                 printErrLog(device, 'Unable to start new thread. %s' % (e))
                 return
-    while 1:  # Exit condition from user keyboard input of 'q' or 'ctrl + c'
-        getch = _Getch()
-        user_input = getch()
+    while 1:  # Exit condition from user keyboard input of 'q' or 'ctrl + c' and then 'Enter'
+        user_input = input()
         # Catch user input for q or Ctrl + c
-        global stop_threads
-        stop_threads = True
         if user_input == 'q' or user_input == '\x03':
-            for device in deviceList:
-                ret = rocmsmi.rsmi_event_notification_stop(device)
-                if not rsmi_ret_ok(ret, device, 'stop_event_notification'):
-                    printErrLog(device, 'Unable to end event notifications.')
+            global stop_threads
+            stop_threads = True
             print('\r')
             break
     for thread in thread_list:

--- a/projects/rocm-smi-lib/python_smi_tools/rsmiBindings.py
+++ b/projects/rocm-smi-lib/python_smi_tools/rsmiBindings.py
@@ -108,7 +108,19 @@ class rsmi_dev_perf_level_t(c_int):
     RSMI_DEV_PERF_LEVEL_UNKNOWN = 0x100
 
 
-notification_type_names = ['VM_FAULT', 'THERMAL_THROTTLE', 'GPU_PRE_RESET', 'GPU_POST_RESET', 'RING_HANG']
+notification_type_names = [
+    'VM_FAULT',
+    'THERMAL_THROTTLE',
+    'GPU_PRE_RESET',
+    'GPU_POST_RESET',
+    'MIGRATE_START',
+    'MIGRATE_END',
+    'PAGE_FAULT_START',
+    'PAGE_FAULT_END',
+    'QUEUE_EVICTION',
+    'QUEUE_RESTORE',
+    'UNMAP_FROM_GPU'
+]
 
 
 class rsmi_evt_notification_type_t(c_int):
@@ -118,8 +130,14 @@ class rsmi_evt_notification_type_t(c_int):
     RSMI_EVT_NOTIF_THERMAL_THROTTLE = 2
     RSMI_EVT_NOTIF_GPU_PRE_RESET = 3
     RSMI_EVT_NOTIF_GPU_POST_RESET = 4
-    RSMI_EVT_NOTIF_RING_HANG = 5
-    RSMI_EVT_NOTIF_LAST = RSMI_EVT_NOTIF_RING_HANG
+    RSMI_EVT_NOTIF_MIGRATE_START = 5
+    RSMI_EVT_NOTIF_MIGRATE_END = 6
+    RSMI_EVT_NOTIF_PAGE_FAULT_START = 7
+    RSMI_EVT_NOTIF_PAGE_FAULT_END = 8
+    RSMI_EVT_NOTIF_QUEUE_EVICTION = 9
+    RSMI_EVT_NOTIF_QUEUE_RESTORE = 10
+    RSMI_EVT_NOTIF_UNMAP_FROM_GPU = 11
+    RSMI_EVT_NOTIF_LAST = RSMI_EVT_NOTIF_UNMAP_FROM_GPU
 
 
 class rsmi_voltage_metric_t(c_int):
@@ -545,11 +563,12 @@ class rsmi_error_count_t(Structure):
     _fields_ = [('correctable_err', c_uint64),
                 ('uncorrectable_err', c_uint64)]
 
+MAX_EVENT_NOTIFICATION_MSG_SIZE = 96
 
 class rsmi_evt_notification_data_t(Structure):
     _fields_ = [('dv_ind', c_uint32),
                 ('event', rsmi_evt_notification_type_t),
-                ('message', c_char*64)]
+                ('message', c_char*MAX_EVENT_NOTIFICATION_MSG_SIZE)]
 
 
 class rsmi_process_info_t(Structure):


### PR DESCRIPTION
This patch also addresses [SWDEV-540223]

## Motivation

Rocm-smi would often throw a segmentation fault when receiving gpu reset events. This PR is aimed at fixing that behavior.

## Technical Details

This patch updates several areas where there were potential segmentation faults and also updates the bindings for kfd event notifications to use the correct events.

## Test Plan

Rocm-smi was run with the --showevent command and gpu reset events were sent by using `amd-smi reset -G`. This is repeated several times to confirm that segmentation faults were not occurring at any point.

## Test Result

Pass.

## Submission Checklist

