### PR TITLE
Fix commands in CONTRIBUTING.md to correctly rebase feature-branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,12 +69,14 @@ cd projects/hipblaslt
 
 ## Keeping Your Branch in Sync
 
-To stay up to date with the latest changes in the super-repo:
+To stay up to date with the latest changes in the super-repo `develop` branch:
 
 ```bash
-git fetch origin
-git rebase origin/develop
+git pull --rebase origin develop
+git push --force
 ```
+
+Force-push is required to avoid adding the unrelated commits to the PR history and requiring additional reviewers.
 
 Avoid using git merge to keep history clean and maintain a linear progression.
 


### PR DESCRIPTION
## Motivation
The suggested commands in CONTRIBUTING.md are resulting in conflicting commits being added to PR history. This pulls in reviewers, not related to the PR, and pollutes history.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
The commands for branch update are replaced with a single pull and a force-push.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
No technical impact on the software part. The new suggested commands were tested while updating https://github.com/ROCm/rocm-systems/pull/635
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Suggested branch update commands correctly leave only relevant commits in history
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
