### PR TITLE
Add implementation for storing OpenMP traces in rocpd database

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.cpp
@@ -255,48 +255,49 @@ rocpd_post_processing::get_memory_allocate_callback() const
 }
 #endif
 
+#if ROCPROFSYS_USE_ROCM > 0
+static rocprofiler_sdk::function_args_t
+process_event_args(const std::string& arg_str)
+{
+    rocprofiler_sdk::function_args_t args;
+    const std::string                delimiter = ";;";
+
+    auto split = [](const std::string& str, const std::string& delimiter) {
+        std::vector<std::string> tokens;
+        size_t                   start = 0;
+        size_t                   end   = str.find(delimiter);
+
+        while(end != std::string::npos)
+        {
+            tokens.push_back(str.substr(start, end - start));
+            start = end + delimiter.length();
+            end   = str.find(delimiter, start);
+        }
+        return tokens;
+    };
+
+    auto tokens = split(arg_str, delimiter);
+
+    // Ensure the number of tokens is a multiple of 4
+    if(tokens.size() % 4 != 0)
+    {
+        throw std::invalid_argument("Malformed argument string.");
+    }
+
+    for(auto it = tokens.begin(); it != tokens.end(); it += 4)
+    {
+        rocprofiler_sdk::argument_info arg = { static_cast<uint32_t>(std::stoi(*it)),
+                                               *(it + 1), *(it + 2), *(it + 3) };
+        args.push_back(arg);
+    }
+
+    return args;
+}
+#endif
+
 postprocessing_callback
 rocpd_post_processing::get_region_callback() const
 {
-    [[maybe_unused]] auto parse_args = []([[maybe_unused]] const std::string& arg_str) {
-#if ROCPROFSYS_USE_ROCM > 0
-        rocprofiler_sdk::function_args_t args;
-        const std::string                delimiter = ";;";
-
-        auto split = [](const std::string& str, const std::string& _delimiter) {
-            std::vector<std::string> tokens;
-            size_t                   start = 0;
-            size_t                   end   = str.find(_delimiter);
-
-            while(end != std::string::npos)
-            {
-                tokens.push_back(str.substr(start, end - start));
-                start = end + _delimiter.length();
-                end   = str.find(_delimiter, start);
-            }
-
-            return tokens;
-        };
-
-        auto tokens = split(arg_str, delimiter);
-
-        // Ensure the number of tokens is a multiple of 4
-        if(tokens.size() % 4 != 0)
-        {
-            throw std::invalid_argument("Malformed argument string.");
-        }
-
-        for(auto it = tokens.begin(); it != tokens.end(); it += 4)
-        {
-            rocprofiler_sdk::argument_info arg = { static_cast<uint32_t>(std::stoi(*it)),
-                                                   *(it + 1), *(it + 2), *(it + 3) };
-            args.push_back(arg);
-        }
-
-        return args;
-#endif
-    };
-
     return [&]([[maybe_unused]] const storage_parsed_type_base& parsed) {
 #if ROCPROFSYS_USE_ROCM > 0
         auto  _rs            = static_cast<const struct region_sample&>(parsed);
@@ -322,7 +323,7 @@ rocpd_post_processing::get_region_callback() const
             data_processor.insert_event(category_primary_key, stack_id, parent_stack_id,
                                         correlation_id, _rs.call_stack.c_str());
 
-        auto args = parse_args(_rs.args_str);
+        auto args = process_event_args(_rs.args_str);
         for(const auto& arg : args)
         {
             data_processor.insert_args(event_primary_key, arg.arg_number,
@@ -334,6 +335,46 @@ rocpd_post_processing::get_region_callback() const
                                      _rs.start_timestamp, _rs.end_timestamp,
                                      name_primary_key, event_primary_key);
 #endif
+    };
+}
+
+postprocessing_callback
+rocpd_post_processing::get_ompt_callback() const
+{
+    return [&](const storage_parsed_type_base& parsed) {
+        auto  _rs            = static_cast<const struct ompt_region_sample&>(parsed);
+        auto& data_processor = get_data_processor();
+        auto& n_info         = node_info::get_instance();
+        auto  process        = m_metadata.get_process_info();
+        auto  thread_primary_key =
+            data_processor.map_thread_id_to_primary_key(_rs.thread_id);
+
+        auto _name            = _rs.name;
+        auto name_primary_key = data_processor.insert_string(_name.c_str());
+
+        auto category_primary_key =
+            data_processor.insert_string(trait::name<category::ompt>::value);
+
+        size_t stack_id        = 0;
+        size_t parent_stack_id = _rs.correlation_id;
+        size_t correlation_id  = 0;
+
+        auto event_primary_key =
+            data_processor.insert_event(category_primary_key, stack_id, parent_stack_id,
+                                        correlation_id, _rs.call_stack.c_str());
+#if ROCPROFSYS_USE_ROCM > 0
+        auto args = process_event_args(_rs.args_str);
+        for(const auto& arg : args)
+        {
+            data_processor.insert_args(event_primary_key, arg.arg_number,
+                                       arg.arg_type.c_str(), arg.arg_name.c_str(),
+                                       arg.arg_value.c_str());
+        }
+#endif
+
+        data_processor.insert_region(
+            n_info.id, process.pid, thread_primary_key, _rs.start_timestamp,
+            _rs.end_timestamp, name_primary_key, event_primary_key, _rs.extdata.c_str());
     };
 }
 
@@ -399,6 +440,7 @@ rocpd_post_processing::register_parser_callback([[maybe_unused]] storage_parser&
                                   get_in_time_sample_callback());
     parser.register_type_callback(entry_type::pmc_event_with_sample,
                                   get_pmc_event_with_sample_callback());
+    parser.register_type_callback(entry_type::ompt, get_ompt_callback());
     ROCPROFSYS_DEBUG("Buffer parser callbacks are registered..");
 #endif
 }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.hpp
@@ -50,6 +50,7 @@ private:
     postprocessing_callback get_memory_allocate_callback() const;
 #endif
     postprocessing_callback get_region_callback() const;
+    postprocessing_callback get_ompt_callback() const;
     postprocessing_callback get_in_time_sample_callback() const;
     postprocessing_callback get_pmc_event_with_sample_callback() const;
 

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
@@ -163,6 +163,32 @@ struct region_sample : storage_parsed_type_base
     std::string category;
 };
 
+struct ompt_region_sample : storage_parsed_type_base
+{
+    ompt_region_sample() = default;
+    ompt_region_sample(std::string _name, uint64_t _thread_id, uint64_t _correlation_id,
+                       uint64_t _start_timestamp, uint64_t _end_timestamp,
+                       std::string _call_stack, std::string _args_str,
+                       std::string _extdata)
+    : name(std::move(_name))
+    , thread_id(_thread_id)
+    , correlation_id(_correlation_id)
+    , start_timestamp(_start_timestamp)
+    , end_timestamp(_end_timestamp)
+    , call_stack(std::move(_call_stack))
+    , args_str(std::move(_args_str))
+    , extdata(std::move(_extdata))
+    {}
+    std::string name;
+    uint64_t    thread_id;
+    uint64_t    correlation_id;
+    uint64_t    start_timestamp;
+    uint64_t    end_timestamp;
+    std::string call_stack;
+    std::string args_str;
+    std::string extdata;
+};
+
 struct in_time_sample : storage_parsed_type_base
 {
     std::string track_name;
@@ -192,6 +218,7 @@ enum class entry_type : uint32_t
 #if(ROCPROFSYS_USE_ROCM && ROCPROFILER_VERSION >= 600)
     memory_alloc = 0x0005,
 #endif
+    ompt             = 0x0006,
     fragmented_space = 0xFFFF
 };
 }  // namespace trace_cache

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser.cpp
@@ -201,6 +201,18 @@ storage_parser::consume_storage()
                 invoke_callbacks(header.type, _pmc_event_with_sample);
                 break;
             }
+            case entry_type::ompt:
+            {
+                ompt_region_sample _ompt_region_sample;
+                parse_data(
+                    sample.data(), _ompt_region_sample.name,
+                    _ompt_region_sample.thread_id, _ompt_region_sample.correlation_id,
+                    _ompt_region_sample.start_timestamp,
+                    _ompt_region_sample.end_timestamp, _ompt_region_sample.call_stack,
+                    _ompt_region_sample.args_str, _ompt_region_sample.extdata);
+                invoke_callbacks(header.type, _ompt_region_sample);
+                break;
+            }
             default: break;
         }
     }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/ompt.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/ompt.cpp
@@ -25,13 +25,20 @@
 #include "core/config.hpp"
 #include "core/debug.hpp"
 #include "core/defines.hpp"
+#include "core/trace_cache/buffer_storage.hpp"
 
+#include <cstddef>
+#include <cstdint>
+#include <string>
 #include <timemory/defines.h>
 
 #if defined(ROCPROFSYS_USE_OMPT) && ROCPROFSYS_USE_OMPT > 0
 
 #    include "binary/link_map.hpp"
 #    include "core/components/fwd.hpp"
+#    include "core/rocpd/data_processor.hpp"
+#    include "core/rocpd/json.hpp"
+#    include "core/trace_cache/cache_manager.hpp"
 #    include "library/components/category_region.hpp"
 #    include "library/tracing.hpp"
 
@@ -58,6 +65,92 @@ using api_t = tim::project::rocprofsys;
 
 namespace rocprofsys
 {
+namespace
+{
+void
+cache_category()
+{
+    trace_cache::get_metadata_registry().add_string(trait::name<category::ompt>::value);
+}
+
+void
+cache_thread_info(size_t tid)
+{
+    const auto& _thread_info = thread_info::get(tid, SequentTID);
+    ROCPROFSYS_CI_THROW(!_thread_info, "No valid thread info for tid=%li\n", tid);
+    if(!_thread_info)
+    {
+        ROCPROFSYS_WARNING(3, "No valid thread info for tid=%li\n", tid);
+        trace_cache::get_metadata_registry().add_thread_info(
+            { getppid(), getpid(), tid, 0, 0, "{}" });
+        return;
+    }
+
+    trace_cache::get_metadata_registry().add_thread_info(
+        { getppid(), getpid(),
+          static_cast<size_t>(_thread_info->index_data->system_value),
+          static_cast<uint32_t>(_thread_info->get_start()),
+          static_cast<uint32_t>(_thread_info->get_stop()), "{}" });
+}
+
+void
+cache_track(int64_t tid, const std::string& track_name)
+{
+    const auto& _thread_info = thread_info::get(tid, SequentTID);
+    ROCPROFSYS_CI_THROW(!_thread_info, "No valid thread info for tid=%li\n", tid);
+    if(!_thread_info) return;
+
+    size_t thread_id = _thread_info->index_data->system_value;
+
+    trace_cache::get_metadata_registry().add_track({ track_name, thread_id, "{}" });
+}
+
+const std::string
+format_event_args(const tim::openmp::argument_array_t& args)
+{
+    std::string args_str;
+    if(args.empty())
+    {
+        return args_str;
+    }
+
+    auto pos{ 0 };
+    std::for_each(args.begin(), args.end(),
+                  [&](const tim::openmp::labeled_argument& arg) {
+                      const auto*       delimiter = ";;";
+                      std::stringstream ss;
+                      ss << pos++ << delimiter << arg.type << delimiter
+                         << std::string(arg.label) << delimiter << arg.value << delimiter;
+                      args_str.append(ss.str());
+                  });
+
+    return args_str;
+}
+
+void
+cache_ompt_region(std::string name, uint64_t thread_id, uint64_t correlation_id,
+                  uint64_t start_timestamp, uint64_t end_timestamp,
+                  std::string call_stack, std::string args_str, std::string extdata)
+
+{
+    trace_cache::get_buffer_storage().store(trace_cache::entry_type::ompt, name.c_str(),
+                                            thread_id, correlation_id, start_timestamp,
+                                            end_timestamp, call_stack.c_str(),
+                                            args_str.c_str(), extdata.c_str());
+}
+
+const std::string
+get_call_stack(const tim::openmp::context_info& _ctx_info)
+{
+    auto call_stack = ::rocpd::json::create();
+
+    call_stack->set("file", _ctx_info.file);
+    call_stack->set("line_info", _ctx_info.line);
+
+    return call_stack->to_string();
+}
+
+}  // namespace
 namespace component
 {
 struct ompt : comp::base<ompt, void>
@@ -82,7 +175,12 @@ struct ompt : comp::base<ompt, void>
     {
         category_region<category::ompt>::start<tim::quirk::timemory>(m_prefix);
 
-        auto     _ts = tracing::now();
+        auto _ts = tracing::now();
+        if(get_use_rocpd())
+        {
+            auto ctx_hash                 = compute_context_hash(_ctx_info);
+            get_timestamp_map()[ctx_hash] = _ts;
+        }
         uint64_t _cid =
             (_ctx_info.target_arguments) ? _ctx_info.target_arguments->host_op_id : 0;
         auto _annotate = [&](::perfetto::EventContext ctx) {
@@ -113,9 +211,33 @@ struct ompt : comp::base<ompt, void>
     {
         category_region<category::ompt>::stop<tim::quirk::timemory>(m_prefix);
 
-        auto     _ts = tracing::now();
+        auto _ts = tracing::now();
+
         uint64_t _cid =
             (_ctx_info.target_arguments) ? _ctx_info.target_arguments->host_op_id : 0;
+
+        if(get_use_rocpd())
+        {
+            auto  ctx_hash = compute_context_hash(_ctx_info);
+            auto& _ctx_map = get_timestamp_map();
+            auto  _it      = _ctx_map.find(ctx_hash);
+
+            if(_it != _ctx_map.end())
+            {
+                auto        _start_ts = _it->second;
+                auto        _thrd_id  = extract_thread_num_from_args(_ctx_info.arguments);
+                const auto& _thread_info = thread_info::get(_thrd_id, SequentTID);
+                auto        _call_stack  = get_call_stack(_ctx_info);
+                auto        _args        = format_event_args(_ctx_info.arguments);
+
+                cache_thread_info(_thrd_id);
+                cache_ompt_region(
+                    ((_ctx_info.func.empty()) ? std::string(m_prefix) : _ctx_info.func),
+                    static_cast<size_t>(_thread_info->index_data->system_value), _cid,
+                    _start_ts, _ts, _call_stack, _args, "{}");
+            }
+        }
+
         auto _annotate = [&](::perfetto::EventContext ctx) {
             if(config::get_perfetto_annotations())
             {
@@ -177,6 +299,66 @@ struct ompt : comp::base<ompt, void>
 
 private:
     std::string_view m_prefix = {};
+
+    std::unordered_map<uint64_t, uint64_t>& get_timestamp_map() const
+    {
+        static thread_local std::unordered_map<uint64_t, uint64_t> map;
+        return map;
+    }
+
+    uint64_t compute_context_hash(const context_info_t& _ctx_info) const
+    {
+        std::hash<std::string> string_hasher;
+        std::hash<uint64_t>    uint64_hasher;
+
+        uint64_t           hash       = 0;
+        constexpr uint64_t hash_magic = 0x9e3779b9;
+
+        auto combine_hash = [&hash](uint64_t value) {
+            hash ^= value + hash_magic + (hash << 6) + (hash >> 2);
+        };
+
+        if(_ctx_info.target_arguments)
+        {
+            combine_hash(uint64_hasher(_ctx_info.target_arguments->host_op_id));
+            combine_hash(uint64_hasher(_ctx_info.target_arguments->target_id));
+        }
+
+        if(!_ctx_info.label.empty())
+        {
+            combine_hash(string_hasher(std::string(_ctx_info.label)));
+        }
+
+        if(!_ctx_info.func.empty())
+        {
+            combine_hash(string_hasher(_ctx_info.func));
+        }
+
+        uint64_t thread_id = extract_thread_num_from_args(_ctx_info.arguments);
+        if(thread_id != 0)
+        {
+            combine_hash(uint64_hasher(thread_id));
+        }
+
+        if(!m_prefix.empty())
+        {
+            combine_hash(string_hasher(std::string(m_prefix)));
+        }
+
+        return hash;
+    }
+
+    uint64_t extract_thread_num_from_args(const tim::openmp::argument_array_t& args) const
+    {
+        for(const auto& arg : args)
+        {
+            if(arg.label == "thread_num")
+            {
+                return static_cast<uint64_t>(std::stoull(arg.value));
+            }
+        }
+        return 0;
+    }
 };
 }  // namespace component
 }  // namespace rocprofsys
@@ -219,6 +401,11 @@ setup()
     tim::auto_lock_t lk{ tim::type_mutex<ompt_handle_t>() };
     f_bundle = std::make_unique<ompt_bundle_t>("rocprofsys/ompt",
                                                quirk::config<quirk::auto_start>{});
+
+    if(get_use_rocpd())
+    {
+        cache_category();
+    }
 }
 
 void
@@ -435,6 +622,17 @@ tool_initialize(ompt_function_lookup_t lookup, int initial_device_num,
                             component::ompt::record(
                                 _name, id, beg_time, end_time, _thrd_id, _targ_id,
                                 tim::openmp::context_info{ _name, nullptr, _ctx_info });
+
+                            if(get_use_rocpd())
+                            {
+                                cache_thread_info(_thrd_id);
+                                cache_track(_thrd_id,
+                                            JOIN("", "OMPT Kernel Submit - Thread [ ",
+                                                 _thrd_id, " ]")
+                                                .c_str());
+                                cache_ompt_region(_name, _thrd_id, id, beg_time, end_time,
+                                                  "", format_event_args(_ctx_info), "");
+                            }
                         }
                         else if(_record->type == ompt_callback_target_data_op)
                         {
@@ -462,6 +660,17 @@ tool_initialize(ompt_function_lookup_t lookup, int initial_device_num,
                             component::ompt::record(
                                 _opname, id, beg_time, end_time, _thrd_id, _targ_id,
                                 tim::openmp::context_info{ _name, nullptr, _ctx_info });
+
+                            if(get_use_rocpd())
+                            {
+                                cache_thread_info(_thrd_id);
+                                cache_track(_thrd_id,
+                                            JOIN("", "OMPT Target Data Op - Thread [ ",
+                                                 _thrd_id, " ]")
+                                                .c_str());
+                                cache_ompt_region(_name, _thrd_id, id, beg_time, end_time,
+                                                  "", format_event_args(_ctx_info), "");
+                            }
                         }
 
                         ROCPROFSYS_VERBOSE(


### PR DESCRIPTION
## Motivation

Enable OpenMP trace captures in rocpd.

## Technical Details

 - Implemented all relevant and needed ompt types and callbacks in `trace_cache` module
 - Added caching for ompt traces
 - Implemented helper methods for capturing continuous regions of ompt callbacks

## Test Plan

- Tests for database validation are still in progress and are being developed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
