### PR TITLE
Force gzip to overwrite an existing changelog

### DIFF
--- a/projects/rocm-core/utils.cmake
+++ b/projects/rocm-core/utils.cmake
@@ -229,7 +229,7 @@ function( configure_debian_pkg PACKAGE_NAME_T COMPONENT_NAME_T PACKAGE_VERSION_T
       find_program ( DEB_GZIP_EXEC gzip )
       if(EXISTS "${CMAKE_BINARY_DIR}/DEBIAN/changelog.Debian" )
         execute_process(
-          COMMAND ${DEB_GZIP_EXEC} -n -9 "${CMAKE_BINARY_DIR}/DEBIAN/changelog.Debian"
+          COMMAND ${DEB_GZIP_EXEC} -f -n -9 "${CMAKE_BINARY_DIR}/DEBIAN/changelog.Debian"
           WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/DEBIAN"
           RESULT_VARIABLE result
           OUTPUT_VARIABLE output


### PR DESCRIPTION
## Motivation

Reconfiguring the projects fails if a changelog exists from a previous build. Adds `-f` to force overwriting.

## Technical Details

If a compressed changelog exists from a previous build, reconfiguring the project fails with
```
[rocm-core configure] CMake Error at utils.cmake:213 (message):
[rocm-core configure]   Failed to compress: gzip:
[rocm-core configure]   /TheRock/build/base/rocm-core/build/DEBIAN/changelog.Debian.gz
[rocm-core configure]   already exists; not overwritten
```

This is revolved by adding `-f` to force overwriting.

The patch is locally carried in TheRock: https://github.com/ROCm/TheRock/blob/5f35280878ca80755c5456dfdb527c29d3f5058c/patches/amd-mainline/rocm-core/0002-Force-gzip-to-overwrite-an-existing-changelog.patch

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
