### PR TITLE
Revert "SWDEV-547589 - Add hipDeviceMallocUncached to hipMemCreate (#…

### DIFF
--- a/projects/clr/hipamd/src/hip_vm.cpp
+++ b/projects/clr/hipamd/src/hip_vm.cpp
@@ -85,12 +85,8 @@ hipError_t hipMemCreate(hipMemGenericAllocationHandle_t* handle, size_t size,
   HIP_INIT_API(hipMemCreate, handle, size, prop, flags);
 
   //  Currently we do not support Pinned memory
-  if (handle == nullptr || size == 0 || prop == nullptr ||
+  if (handle == nullptr || size == 0 || flags != 0 || prop == nullptr ||
       prop->type != hipMemAllocationTypePinned || prop->location.type != hipMemLocationTypeDevice) {
-    HIP_RETURN(hipErrorInvalidValue);
-  }
-
-  if (flags != hipDeviceMallocUncached && flags != 0) {
     HIP_RETURN(hipErrorInvalidValue);
   }
 
@@ -116,12 +112,8 @@ hipError_t hipMemCreate(hipMemGenericAllocationHandle_t* handle, size_t size,
   amd::Context* amdContext = g_devices[prop->location.id]->asContext();
 
   // When ROCCLR_MEM_PHYMEM is set, ROCr impl gets and stores unique hsa handle. Flag no-op on PAL.
-  uint64_t ihipFlags = ROCCLR_MEM_PHYMEM;
-  if (flags == hipDeviceMallocUncached) {
-    ihipFlags |= ROCCLR_MEM_HSA_UNCACHED | CL_MEM_SVM_ATOMICS;
-  }
-  void* ptr =
-      amd::SvmBuffer::malloc(*amdContext, ihipFlags, size, dev_info.memBaseAddrAlign_, nullptr);
+  void* ptr = amd::SvmBuffer::malloc(*amdContext, ROCCLR_MEM_PHYMEM, size,
+                                     dev_info.memBaseAddrAlign_, nullptr);
 
   // Handle out of memory cases,
   if (ptr == nullptr) {

--- a/projects/hip/include/hip/hip_runtime_api.h
+++ b/projects/hip/include/hip/hip_runtime_api.h
@@ -9137,7 +9137,7 @@ hipError_t hipMemAddressReserve(void** ptr, size_t size, size_t alignment, void*
  * @param [out] handle - value of the returned handle.
  * @param [in] size - size of the allocation.
  * @param [in] prop - properties of the allocation.
- * @param [in] flags - hipDeviceMallocUncached for uncached allocation, or 0 for default
+ * @param [in] flags - currently unused, must be zero.
  * @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorNotSupported
  * @warning This API is marked as Beta. While this feature is complete, it can
  *          change and might have outstanding issues.


### PR DESCRIPTION
…815)"

This reverts commit 5ce7103555c8483e04d84ad314fb86dd98b7afdc.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Original implementation is not cuda friendly

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Revert to allow implementation for cuda friendly behavior, discussed in ticket

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
