### PR TITLE
rocr: Generalize core::Queue queue descriptor

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aie_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aie_aql_queue.h
@@ -49,6 +49,7 @@
 #include "core/inc/queue.h"
 #include "core/inc/runtime.h"
 #include "core/inc/signal.h"
+#include "inc/amd_hsa_queue.h"
 
 namespace rocr {
 namespace AMD {
@@ -60,6 +61,8 @@ class AieAqlQueue : public core::Queue,
                     private core::LocalSignal,
                     core::DoorbellSignal {
  public:
+  using QueueDescriptorT = amd_queue_v2_t;
+
   static __forceinline bool IsType(core::Signal *signal) {
     return signal->IsType(&rtti_id());
   }
@@ -113,6 +116,15 @@ class AieAqlQueue : public core::Queue,
                   hsa_fence_scope_t acquireFence = HSA_FENCE_SCOPE_NONE,
                   hsa_fence_scope_t releaseFence = HSA_FENCE_SCOPE_NONE,
                   hsa_signal_t *signal = NULL) override;
+  void SetProfiling(bool enabled) override;
+
+  __forceinline std::size_t SharedQueueSize() override { return shared_queue_size_; }
+
+  __forceinline void SetInterceptQueueReadIndex(
+      core::SharedQueue& shared_queue, volatile uint64_t*& read_dispatch_id) const override {
+    read_dispatch_id =
+        &(reinterpret_cast<QueueDescriptorT&>(shared_queue.hsa_interface_queue).read_dispatch_id);
+  }
 
  private:
   HSA_QUEUEID queue_id_ = INVALID_QUEUEID;
@@ -129,6 +141,26 @@ class AieAqlQueue : public core::Queue,
 
   /// @brief Base of the queue's ring buffer storage.
   void *ring_buf_ = nullptr;
+
+  /// @brief This is the total size of the SharedQueue for AieAqlQueue.
+  /// @details The SharedQueue allows for conversion between a pointer to the
+  /// public API queue handle (i.e., hsa_queue_t*) and a core::Queue* instance.
+  /// Each concrete queue type may have its own queue descriptor struct with an
+  /// hsa_queue_t struct embedded at the top. On creation, a queue implementation
+  /// allocates its concrete queue descriptor type, casts it to an hsa_queue_t*,
+  /// then stores it in the SharedQueue. The remaining bytes of its concrete
+  /// queue descriptor struct are implicitly stored at the end of the SharedQueue.
+  /// We could make this more explicit with variable-lenght arrays, but C++ does
+  /// not support them. Thus the total size of the AqlQueue's queue descriptor
+  /// is the following formula. We subtract the sizeof(hsa_queue_t) to avoid double
+  /// counting it.
+  static constexpr std::size_t shared_queue_size_ =
+      sizeof(core::SharedQueue) + sizeof(QueueDescriptorT) - sizeof(hsa_queue_t);
+
+  /// @brief Get a reference to this Queue implementation's queue descriptor.
+  __forceinline QueueDescriptorT& QueueDescriptor() {
+    return *reinterpret_cast<QueueDescriptorT*>(&shared_queue_->hsa_interface_queue);
+  }
 
   /// @brief Called when the doorbell is rung to submit all queued packets.
   void SubmitPackets();

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2025, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -44,18 +44,39 @@
 #define HSA_RUNTIME_CORE_INC_AMD_HW_AQL_COMMAND_PROCESSOR_H_
 
 #include "core/inc/runtime.h"
+#include "core/inc/scratch_cache.h"
 #include "core/inc/signal.h"
 #include "core/inc/queue.h"
-#include "core/inc/amd_gpu_agent.h"
 #include "core/util/locks.h"
+#include "inc/amd_hsa_queue.h"
 
 namespace rocr {
 namespace AMD {
+
+class GpuAgent;
+
 /// @brief Encapsulates HW Aql Command Processor functionality. It
 /// provide the interface for things such as Doorbell register, read,
 /// write pointers and a buffer.
 class AqlQueue : public core::Queue, private core::LocalSignal, public core::DoorbellSignal {
  public:
+  using QueueDescriptorT = amd_queue_v2_t;
+  /// @brief This is the total size of the SharedQueue for AqlQueue.
+  /// @details The SharedQueue allows for conversion between a pointer to the
+  /// public API queue handle (i.e., hsa_queue_t*) and a core::Queue* instance.
+  /// Each concrete queue type may have its own queue descriptor struct with an
+  /// hsa_queue_t struct embedded at the top. On creation, a queue implementation
+  /// allocates its concrete queue descriptor type, casts it to an hsa_queue_t*,
+  /// then stores it in the SharedQueue. The remaining bytes of its concrete
+  /// queue descriptor struct are implicitly stored at the end of the SharedQueue.
+  /// We could make this more explicit with variable-lenght arrays, but C++ does
+  /// not support them. Thus the total size of the AqlQueue's queue descriptor
+  /// is the following formula. We subtract the sizeof(hsa_queue_t) to avoid double
+  /// counting it.
+  static constexpr std::size_t shared_queue_size_ =
+      sizeof(core::SharedQueue) + sizeof(QueueDescriptorT) - sizeof(hsa_queue_t);
+  using ScratchInfo = ScratchCache::ScratchInfo;
+
   static __forceinline bool IsType(core::Signal* signal) {
     return signal->IsType(&rtti_id());
   }
@@ -227,6 +248,19 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   /// @brief Async reclaim alternate scratch memory
   void AsyncReclaimAltScratch();
 
+  __forceinline std::size_t SharedQueueSize() override { return shared_queue_size_; }
+
+  /// @brief Get a reference to this Queue implementation's queue descriptor.
+  __forceinline QueueDescriptorT& QueueDescriptor() {
+    return *reinterpret_cast<QueueDescriptorT*>(&shared_queue_->hsa_interface_queue);
+  }
+
+  __forceinline void SetInterceptQueueReadIndex(
+      core::SharedQueue& shared_queue, volatile uint64_t*& read_dispatch_id) const override {
+    read_dispatch_id =
+        &(reinterpret_cast<QueueDescriptorT&>(shared_queue.hsa_interface_queue).read_dispatch_id);
+  }
+
  protected:
   bool _IsA(Queue::rtti_t id) const override { return id == &rtti_id(); }
 
@@ -284,7 +318,7 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   void* ring_buf_;
 
   // Size of ring_buf_ allocation.
-  // This may be larger than (amd_queue_.hsa_queue.size * sizeof(AqlPacket)).
+  // This may be larger than (hsa_queue.size * sizeof(AqlPacket)).
   uint32_t ring_buf_alloc_bytes_;
 
   // Id of the Queue used in communication with thunk

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/host_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/host_queue.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2025, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -43,15 +43,18 @@
 #ifndef HSA_RUNTIME_CORE_INC_HOST_QUEUE_H_
 #define HSA_RUNTIME_CORE_INC_HOST_QUEUE_H_
 
+#include "core/inc/exceptions.h"
 #include "core/inc/memory_region.h"
 #include "core/inc/queue.h"
 #include "core/inc/runtime.h"
 #include "core/inc/signal.h"
+#include "inc/amd_hsa_queue.h"
 
 namespace rocr {
 namespace core {
 class HostQueue : public Queue {
  public:
+  using QueueDescriptorT = amd_queue_v2_t;
   static __forceinline bool IsType(core::Queue* queue) { return queue->IsType(&rtti_id()); }
 
   HostQueue(core::SharedQueue* shared_queue, hsa_region_t region, uint32_t ring_size,
@@ -65,83 +68,71 @@ class HostQueue : public Queue {
   }
 
   uint64_t LoadReadIndexAcquire() override {
-    return atomic::Load(&amd_queue_.read_dispatch_id,
-                        std::memory_order_acquire);
+    return atomic::Load(&QueueDescriptor().read_dispatch_id, std::memory_order_acquire);
   }
 
   uint64_t LoadReadIndexRelaxed() override {
-    return atomic::Load(&amd_queue_.read_dispatch_id,
-                        std::memory_order_relaxed);
+    return atomic::Load(&QueueDescriptor().read_dispatch_id, std::memory_order_relaxed);
   }
 
   uint64_t LoadWriteIndexAcquire() override {
-    return atomic::Load(&amd_queue_.write_dispatch_id,
-                        std::memory_order_acquire);
+    return atomic::Load(&QueueDescriptor().write_dispatch_id, std::memory_order_acquire);
   }
 
   uint64_t LoadWriteIndexRelaxed() override {
-    return atomic::Load(&amd_queue_.write_dispatch_id,
-                        std::memory_order_relaxed);
+    return atomic::Load(&QueueDescriptor().write_dispatch_id, std::memory_order_relaxed);
   }
 
   void StoreReadIndexRelaxed(uint64_t value) override {
-    atomic::Store(&amd_queue_.read_dispatch_id, value,
-                  std::memory_order_relaxed);
+    atomic::Store(&QueueDescriptor().read_dispatch_id, value, std::memory_order_relaxed);
   }
 
   void StoreReadIndexRelease(uint64_t value) override {
-    atomic::Store(&amd_queue_.read_dispatch_id, value,
-                  std::memory_order_release);
+    atomic::Store(&QueueDescriptor().read_dispatch_id, value, std::memory_order_release);
   }
 
   void StoreWriteIndexRelaxed(uint64_t value) override {
-    atomic::Store(&amd_queue_.write_dispatch_id, value,
-                  std::memory_order_relaxed);
+    atomic::Store(&QueueDescriptor().write_dispatch_id, value, std::memory_order_relaxed);
   }
 
   void StoreWriteIndexRelease(uint64_t value) override {
-    atomic::Store(&amd_queue_.write_dispatch_id, value,
-                  std::memory_order_release);
+    atomic::Store(&QueueDescriptor().write_dispatch_id, value, std::memory_order_release);
   }
 
   uint64_t CasWriteIndexAcqRel(uint64_t expected, uint64_t value) override {
-    return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected,
+    return atomic::Cas(&QueueDescriptor().write_dispatch_id, value, expected,
                        std::memory_order_acq_rel);
   }
 
   uint64_t CasWriteIndexAcquire(uint64_t expected, uint64_t value) override {
-    return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected,
+    return atomic::Cas(&QueueDescriptor().write_dispatch_id, value, expected,
                        std::memory_order_acquire);
   }
 
   uint64_t CasWriteIndexRelaxed(uint64_t expected, uint64_t value) override {
-    return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected,
+    return atomic::Cas(&QueueDescriptor().write_dispatch_id, value, expected,
                        std::memory_order_relaxed);
   }
 
   uint64_t CasWriteIndexRelease(uint64_t expected, uint64_t value) override {
-    return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected,
+    return atomic::Cas(&QueueDescriptor().write_dispatch_id, value, expected,
                        std::memory_order_release);
   }
 
   uint64_t AddWriteIndexAcqRel(uint64_t value) override {
-    return atomic::Add(&amd_queue_.write_dispatch_id, value,
-                       std::memory_order_acq_rel);
+    return atomic::Add(&QueueDescriptor().write_dispatch_id, value, std::memory_order_acq_rel);
   }
 
   uint64_t AddWriteIndexAcquire(uint64_t value) override {
-    return atomic::Add(&amd_queue_.write_dispatch_id, value,
-                       std::memory_order_acquire);
+    return atomic::Add(&QueueDescriptor().write_dispatch_id, value, std::memory_order_acquire);
   }
 
   uint64_t AddWriteIndexRelaxed(uint64_t value) override {
-    return atomic::Add(&amd_queue_.write_dispatch_id, value,
-                       std::memory_order_relaxed);
+    return atomic::Add(&QueueDescriptor().write_dispatch_id, value, std::memory_order_relaxed);
   }
 
   uint64_t AddWriteIndexRelease(uint64_t value) override {
-    return atomic::Add(&amd_queue_.write_dispatch_id, value,
-                       std::memory_order_release);
+    return atomic::Add(&QueueDescriptor().write_dispatch_id, value, std::memory_order_release);
   }
 
   hsa_status_t SetCUMasking(uint32_t num_cu_mask_count, const uint32_t* cu_mask) override {
@@ -159,9 +150,22 @@ class HostQueue : public Queue {
     assert(false && "HostQueue::ExecutePM4 is unimplemented");
   }
 
+  void SetProfiling(bool enabled) override {
+    throw AMD::hsa_exception(static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED),
+                             "HostQueue::SetProfiling is not supported.");
+  }
+
   hsa_status_t GetInfo(hsa_queue_info_attribute_t attribute, void* value) override {
     assert(false && "HostQueue::GetInfo is unimplemented");
     return HSA_STATUS_ERROR_INVALID_QUEUE;
+  }
+
+  __forceinline std::size_t SharedQueueSize() override { return shared_queue_size_; }
+
+  __forceinline void SetInterceptQueueReadIndex(
+      SharedQueue& shared_queue, volatile uint64_t*& read_dispatch_id) const override {
+    read_dispatch_id =
+        &(reinterpret_cast<QueueDescriptorT&>(shared_queue.hsa_interface_queue).read_dispatch_id);
   }
 
   void* operator new(size_t size) {
@@ -182,9 +186,30 @@ class HostQueue : public Queue {
     static int rtti_id_ = 0;
     return rtti_id_;
   }
+
+  /// @brief Get a reference to this Queue implementation's queue descriptor.
+  __forceinline QueueDescriptorT& QueueDescriptor() {
+    return *reinterpret_cast<QueueDescriptorT*>(&shared_queue_->hsa_interface_queue);
+  }
+
   static const size_t kRingAlignment = 256;
   const uint32_t size_;
   void* ring_;
+
+  /// @brief This is the total size of the SharedQueue for HostQueue.
+  /// @details The SharedQueue allows for conversion between a pointer to the
+  /// public API queue handle (i.e., hsa_queue_t*) and a core::Queue* instance.
+  /// Each concrete queue type may have its own queue descriptor struct with an
+  /// hsa_queue_t struct embedded at the top. On creation, a queue implementation
+  /// allocates its concrete queue descriptor type, casts it to an hsa_queue_t*,
+  /// then stores it in the SharedQueue. The remaining bytes of its concrete
+  /// queue descriptor struct are implicitly stored at the end of the SharedQueue.
+  /// We could make this more explicit with variable-lenght arrays, but C++ does
+  /// not support them. Thus the total size of the AqlQueue's queue descriptor
+  /// is the following formula. We subtract the sizeof(hsa_queue_t) to avoid double
+  /// counting it.
+  static constexpr std::size_t shared_queue_size_ =
+      sizeof(core::SharedQueue) + sizeof(QueueDescriptorT) - sizeof(hsa_queue_t);
 
   // Host queue id counter, starting from 0x80000000 to avoid overlaping
   // with aql queue id.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/intercept_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/intercept_queue.h
@@ -141,65 +141,10 @@ class QueueWrapper : public Queue {
   }
 };
 
-// @brief Generic container for a proxy queue.
-// Presents an proxy packet buffer and doorbell signal for an underlying Queue.  Write index
-// operations act on the proxy buffer while all other operations pass through to the underlying
-// queue.
-class QueueProxy : public QueueWrapper {
- public:
-  explicit QueueProxy(std::unique_ptr<Queue> queue) : QueueWrapper(std::move(queue)) {}
-
-  uint64_t LoadReadIndexAcquire() override {
-    return atomic::Load(&amd_queue_.read_dispatch_id, std::memory_order_acquire);
-  }
-  uint64_t LoadReadIndexRelaxed() override {
-    return atomic::Load(&amd_queue_.read_dispatch_id, std::memory_order_relaxed);
-  }
-  void StoreReadIndexRelaxed(uint64_t value) override { assert(false); }
-  void StoreReadIndexRelease(uint64_t value) override { assert(false); }
-
-  uint64_t LoadWriteIndexRelaxed() override {
-    return atomic::Load(&amd_queue_.write_dispatch_id, std::memory_order_relaxed);
-  }
-  uint64_t LoadWriteIndexAcquire() override {
-    return atomic::Load(&amd_queue_.write_dispatch_id, std::memory_order_acquire);
-  }
-  void StoreWriteIndexRelaxed(uint64_t value) override {
-    atomic::Store(&amd_queue_.write_dispatch_id, value, std::memory_order_relaxed);
-  }
-  void StoreWriteIndexRelease(uint64_t value) override {
-    atomic::Store(&amd_queue_.write_dispatch_id, value, std::memory_order_release);
-  }
-  uint64_t CasWriteIndexAcqRel(uint64_t expected, uint64_t value) override {
-    return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected, std::memory_order_acq_rel);
-  }
-  uint64_t CasWriteIndexAcquire(uint64_t expected, uint64_t value) override {
-    return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected, std::memory_order_acquire);
-  }
-  uint64_t CasWriteIndexRelaxed(uint64_t expected, uint64_t value) override {
-    return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected, std::memory_order_relaxed);
-  }
-  uint64_t CasWriteIndexRelease(uint64_t expected, uint64_t value) override {
-    return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected, std::memory_order_release);
-  }
-  uint64_t AddWriteIndexAcqRel(uint64_t value) override {
-    return atomic::Add(&amd_queue_.write_dispatch_id, value, std::memory_order_acq_rel);
-  }
-  uint64_t AddWriteIndexAcquire(uint64_t value) override {
-    return atomic::Add(&amd_queue_.write_dispatch_id, value, std::memory_order_acquire);
-  }
-  uint64_t AddWriteIndexRelaxed(uint64_t value) override {
-    return atomic::Add(&amd_queue_.write_dispatch_id, value, std::memory_order_relaxed);
-  }
-  uint64_t AddWriteIndexRelease(uint64_t value) override {
-    return atomic::Add(&amd_queue_.write_dispatch_id, value, std::memory_order_release);
-  }
-};
-
 // @brief Provides packet intercept and rewrite capability for a queue.
 // Host-side dispatches are processed during doorbell ring.
 // Device-side dispatches are processed as an asynchronous signal event.
-class InterceptQueue : public QueueProxy, private LocalSignal, public DoorbellSignal {
+class InterceptQueue : public QueueWrapper, private LocalSignal, public DoorbellSignal {
  public:
   explicit InterceptQueue(std::unique_ptr<Queue> queue);
   ~InterceptQueue();

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/intercept_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/intercept_queue.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2025, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -43,9 +43,9 @@
 #ifndef HSA_RUNTIME_CORE_INC_INTERCEPT_QUEUE_H_
 #define HSA_RUNTIME_CORE_INC_INTERCEPT_QUEUE_H_
 
-#include <vector>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "core/inc/runtime.h"
 #include "core/inc/queue.h"
@@ -61,19 +61,29 @@ namespace core {
 // Class only has utility as a base type customized Queue wrappers.
 class QueueWrapper : public Queue {
  public:
-  std::unique_ptr<Queue> wrapped;
-
   explicit QueueWrapper(std::unique_ptr<Queue> queue)
       : Queue(static_cast<core::SharedQueue*>(core::Runtime::runtime_singleton_->system_allocator()(
-                  sizeof(core::SharedQueue), 4096, 0, 0)),
+                  queue->SharedQueueSize(), 4096, 0, 0)),
               0),
         wrapped(std::move(queue)) {
-    memcpy(&amd_queue_, &wrapped->amd_queue_, sizeof(amd_queue_));
+    // The queue wrapper only needs to interface with a copy of the wrapped queue's hsa_queue_t
+    // and not its full queue descriptor.
+    std::memcpy(&shared_queue_->hsa_interface_queue, &wrapped->GetSharedQueue().hsa_interface_queue,
+                wrapped->SharedQueueSize());
     wrapped->set_public_handle(wrapped.get(), public_handle_);
   }
 
   ~QueueWrapper() {
     if (shared_queue_) core::Runtime::runtime_singleton_->system_deallocator()(shared_queue_);
+  }
+
+  __forceinline std::size_t SharedQueueSize() override { return wrapped->SharedQueueSize(); }
+
+  __forceinline void SetInterceptQueueReadIndex(
+      SharedQueue& shared_queue, volatile uint64_t*& read_dispatch_id) const override {
+    throw AMD::hsa_exception(HSA_STATUS_ERROR,
+                             "SetInterceptQueueReadIndex should only be called on wrapped queues, "
+                             "and QueueWrappers cannot be wrapped.");
   }
 
   hsa_status_t Inactivate() override { return wrapped->Inactivate(); }
@@ -135,6 +145,7 @@ class QueueWrapper : public Queue {
   void SetProfiling(bool enabled) override { wrapped->SetProfiling(enabled); }
 
  protected:
+  std::unique_ptr<Queue> wrapped;
   void do_set_public_handle(hsa_queue_t* handle) override {
     public_handle_ = handle;
     wrapped->set_public_handle(wrapped.get(), handle);
@@ -190,6 +201,8 @@ class InterceptQueue : public QueueWrapper, private LocalSignal, public Doorbell
   std::vector<std::pair<AMD::callback_t<hsa_amd_queue_intercept_handler>, void*>> interceptors;
 
   static const hsa_signal_value_t DOORBELL_MAX = 0xFFFFFFFFFFFFFFFFull;
+
+  volatile uint64_t* read_dispatch_id = nullptr;
 
   static bool HandleAsyncDoorbell(hsa_signal_value_t value, void* arg);
   static void PacketWriter(const void* pkts, uint64_t pkt_count);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/queue.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2025, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -45,13 +45,13 @@
 #ifndef HSA_RUNTME_CORE_INC_COMMAND_QUEUE_H_
 #define HSA_RUNTME_CORE_INC_COMMAND_QUEUE_H_
 
+#include <cstddef>
 #include <sstream>
 
 #include "core/common/shared.h"
 #include "core/inc/checked.h"
 #include "core/inc/memory_region.h"
 #include "core/util/utils.h"
-#include "inc/amd_hsa_queue.h"
 #include "inc/hsa_ext_amd.h"
 #include "hsakmt/hsakmt.h"
 
@@ -151,11 +151,37 @@ struct AqlPacket {
 
 class Queue;
 
-/// @brief Helper structure to simplify conversion of amd_queue_v2_t and
-/// core::Queue object.
+/// @brief Helper structure to simplify conversion of a core::Queue implementation's
+/// queue descriptor and and core::Queue*.
 struct SharedQueue {
-  amd_queue_v2_t amd_queue;
   Queue* core_queue;
+  /// @brief The handle for HSA queues at the C API level.
+  /// @details This hsa_queue_t is embedded as the base field for all the
+  /// various queue implementations' queue descriptors. This field needs to
+  /// be last in the SharedQueue and is effectively the base of a variable
+  /// length array where the concrete queue implementation allocates the
+  /// SharedQueue* such that its size is sizeof(SharedQueue) +
+  /// sizeof(concrete_queue_descriptor_t) - sizeof(hsa_queue_t).
+  /// concrete_queue_descriptor_t must have hsa_queue_t as its first member.
+  ///
+  /// For example:
+  ///
+  /// struct my_queue_descriptor_t {
+  ///   hsa_queue_t hsa_queue;
+  ///   // More fields after here.
+  /// };
+  ///
+  /// Then to create the SharedQueue* for the implementation class derived from core::Queue:
+  ///
+  /// SharedQueue *shared_queue = allocator()(sizeof(SharedQueue) + sizeof(my_queue_descriptor_t) -
+  ///     sizeof(hsa_queue_t));
+  ///
+  /// // Inside of the implemention derived from core::Queue:
+  /// my_queue_descriptor_t *queue_descriptor =
+  /// reinterpret_cast<my_queue_descriptor_t*>(&shared_queue->hsa_interface_queue);
+  /// // Populate queue_descriptor.
+  hsa_queue_t hsa_interface_queue;
+  /// @warning Do not add any members after @p hsa_queue_interface_queue.
 };
 
 /// @brief Class Queue which encapsulate user mode queues and
@@ -172,8 +198,7 @@ class Queue : public Checked<0xFA3906A679F9DB49> {
       : Queue(shared_queue, queue_flags, false) {}
 
   Queue(SharedQueue* shared_queue, uint64_t queue_flags, bool pcie_write_ordering)
-      : amd_queue_(shared_queue->amd_queue),
-        shared_queue_(shared_queue),
+      : shared_queue_(shared_queue),
         flags_(queue_flags),
         pcie_write_ordering_(pcie_write_ordering) {
     public_handle_ = Convert(this);
@@ -190,7 +215,7 @@ class Queue : public Checked<0xFA3906A679F9DB49> {
   ///
   /// @return hsa_queue_t * Pointer to the public data type of a queue
   static __forceinline hsa_queue_t* Convert(Queue* queue) {
-    return (queue != nullptr) ? &queue->amd_queue_.hsa_queue : nullptr;
+    return (queue != nullptr) ? &queue->shared_queue_->hsa_interface_queue : nullptr;
   }
 
   /// @brief Transform the public data type of a Queue's data type into an
@@ -202,7 +227,8 @@ class Queue : public Checked<0xFA3906A679F9DB49> {
   static __forceinline Queue* Convert(const hsa_queue_t* queue) {
     return (queue != nullptr)
         ? reinterpret_cast<SharedQueue*>(reinterpret_cast<uintptr_t>(queue) -
-                                         offsetof(SharedQueue, amd_queue.hsa_queue))->core_queue
+                                         offsetof(SharedQueue, hsa_interface_queue))
+              ->core_queue
         : nullptr;
   }
 
@@ -356,19 +382,13 @@ class Queue : public Checked<0xFA3906A679F9DB49> {
                           hsa_fence_scope_t releaseFence = HSA_FENCE_SCOPE_NONE,
                           hsa_signal_t* signal = NULL) = 0;
 
-  virtual void SetProfiling(bool enabled) {
-    AMD_HSA_BITS_SET(amd_queue_.queue_properties, AMD_QUEUE_PROPERTIES_ENABLE_PROFILING,
-                     (enabled != 0));
-  }
+  virtual void SetProfiling(bool enabled) = 0;
 
   /// @ brief Returns queue queries about the queue
   virtual hsa_status_t GetInfo(hsa_queue_info_attribute_t attribute, void* value) = 0;
 
   /// @ brief Reports async queue errors to stderr if no other error handler was registered.
   static void DefaultErrorHandler(hsa_status_t status, hsa_queue_t* source, void* data);
-
-  // Handle of AMD Queue struct
-  amd_queue_v2_t& amd_queue_;
 
   hsa_queue_t* public_handle() const { return public_handle_; }
 
@@ -389,6 +409,24 @@ class Queue : public Checked<0xFA3906A679F9DB49> {
 
   bool needsPcieOrdering() const { return pcie_write_ordering_; }
 
+  /// @brief Get the size of the queue implementatin's queue descriptor.
+  virtual std::size_t SharedQueueSize() = 0;
+  __forceinline SharedQueue& GetSharedQueue() { return *shared_queue_; }
+
+  /// @brief Sets the InterceptQueue's read_dispatch_id pointer.
+  /// @details Currently the intercept queue updates its own read_dispatch_id, which
+  /// is technically an illegal operation on the Queue API as it is normally expected
+  /// that the packet processor will update the read pointer. However, because the
+  /// InterceptQueue effectively acts as the packet processor for the outer queue that
+  /// wraps an agent's actual queue, it needs to update the read_dispatch_id itself.
+  /// To avoid having to be aware of each Queue implementations queue descriptor, we
+  /// can use this virtual method so each implementation can provide a pointer the
+  /// read_dispatch_id that external users will see when submitting to a queue.
+  /// @param read_dispatch_id Pointer to the read_dispatch_id pointer in the InterceptQueue
+  /// wrapping an instance of Queue.
+  virtual void SetInterceptQueueReadIndex(SharedQueue& shared_queue,
+                                          volatile uint64_t*& read_dispatch_id) const = 0;
+
  protected:
   static void set_public_handle(Queue* ptr, hsa_queue_t* handle) {
     ptr->do_set_public_handle(handle);
@@ -407,7 +445,6 @@ class Queue : public Checked<0xFA3906A679F9DB49> {
   uint64_t GetQueueId() { return hsa_queue_counter_++; }
 
  private:
-
   // HSA Queue ID - used to bind a unique ID
   static std::atomic<uint64_t> hsa_queue_counter_;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -57,6 +57,7 @@
 #include <cstring>
 
 #include "core/inc/amd_xdna_driver.h"
+#include "core/inc/exceptions.h"
 #include "core/inc/queue.h"
 #include "core/inc/runtime.h"
 #include "core/inc/signal.h"
@@ -88,18 +89,18 @@ AieAqlQueue::AieAqlQueue(core::SharedQueue* shared_queue, AieAgent* agent, size_
   }
 
   // Populate hsa_queue_t fields.
-  amd_queue_.hsa_queue.type = HSA_QUEUE_TYPE_SINGLE;
-  amd_queue_.hsa_queue.id = INVALID_QUEUEID;
-  amd_queue_.hsa_queue.doorbell_signal = Signal::Convert(this);
-  amd_queue_.hsa_queue.size = req_size_pkts;
-  amd_queue_.hsa_queue.base_address = ring_buf_;
+  QueueDescriptor().hsa_queue.type = HSA_QUEUE_TYPE_SINGLE;
+  QueueDescriptor().hsa_queue.id = INVALID_QUEUEID;
+  QueueDescriptor().hsa_queue.doorbell_signal = Signal::Convert(this);
+  QueueDescriptor().hsa_queue.size = req_size_pkts;
+  QueueDescriptor().hsa_queue.base_address = ring_buf_;
   // Populate AMD queue fields.
-  amd_queue_.write_dispatch_id = 0;
-  amd_queue_.read_dispatch_id = 0;
+  QueueDescriptor().write_dispatch_id = 0;
+  QueueDescriptor().read_dispatch_id = 0;
 
   signal_.hardware_doorbell_ptr = nullptr;
   signal_.kind = AMD_SIGNAL_KIND_DOORBELL;
-  signal_.queue_ptr = &amd_queue_;
+  signal_.queue_ptr = &QueueDescriptor();
   active_ = true;
 
   HsaQueueResource queue_resource = {};
@@ -111,7 +112,7 @@ AieAqlQueue::AieAqlQueue(core::SharedQueue* shared_queue, AieAgent* agent, size_
   }
 
   queue_id_ = queue_resource.QueueId;
-  amd_queue_.hsa_queue.id = GetQueueId();
+  QueueDescriptor().hsa_queue.id = GetQueueId();
 }
 
 AieAqlQueue::~AieAqlQueue() {
@@ -143,69 +144,63 @@ void AieAqlQueue::Destroy() { delete this; }
 
 // Atomic Reads/Writes
 uint64_t AieAqlQueue::LoadReadIndexRelaxed() {
-  return atomic::Load(&amd_queue_.read_dispatch_id, std::memory_order_relaxed);
+  return atomic::Load(&QueueDescriptor().read_dispatch_id, std::memory_order_relaxed);
 }
 
 uint64_t AieAqlQueue::LoadReadIndexAcquire() {
-  return atomic::Load(&amd_queue_.read_dispatch_id, std::memory_order_acquire);
+  return atomic::Load(&QueueDescriptor().read_dispatch_id, std::memory_order_acquire);
 }
 
 uint64_t AieAqlQueue::LoadWriteIndexRelaxed() {
-  return atomic::Load(&amd_queue_.write_dispatch_id, std::memory_order_relaxed);
+  return atomic::Load(&QueueDescriptor().write_dispatch_id, std::memory_order_relaxed);
 }
 
 uint64_t AieAqlQueue::LoadWriteIndexAcquire() {
-  return atomic::Load(&amd_queue_.write_dispatch_id, std::memory_order_acquire);
+  return atomic::Load(&QueueDescriptor().write_dispatch_id, std::memory_order_acquire);
 }
 
 void AieAqlQueue::StoreWriteIndexRelaxed(uint64_t value) {
-  atomic::Store(&amd_queue_.write_dispatch_id, value,
-                std::memory_order_relaxed);
+  atomic::Store(&QueueDescriptor().write_dispatch_id, value, std::memory_order_relaxed);
 }
 
 void AieAqlQueue::StoreWriteIndexRelease(uint64_t value) {
-  atomic::Store(&amd_queue_.write_dispatch_id, value,
-                std::memory_order_release);
+  atomic::Store(&QueueDescriptor().write_dispatch_id, value, std::memory_order_release);
 }
 
 uint64_t AieAqlQueue::CasWriteIndexRelaxed(uint64_t expected, uint64_t value) {
-  return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected,
+  return atomic::Cas(&QueueDescriptor().write_dispatch_id, value, expected,
                      std::memory_order_relaxed);
 }
 
 uint64_t AieAqlQueue::CasWriteIndexAcquire(uint64_t expected, uint64_t value) {
-  return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected,
+  return atomic::Cas(&QueueDescriptor().write_dispatch_id, value, expected,
                      std::memory_order_acquire);
 }
 
 uint64_t AieAqlQueue::CasWriteIndexRelease(uint64_t expected, uint64_t value) {
-  return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected,
+  return atomic::Cas(&QueueDescriptor().write_dispatch_id, value, expected,
                      std::memory_order_release);
 }
 
 uint64_t AieAqlQueue::CasWriteIndexAcqRel(uint64_t expected, uint64_t value) {
-  return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected,
+  return atomic::Cas(&QueueDescriptor().write_dispatch_id, value, expected,
                      std::memory_order_acq_rel);
 }
 
 uint64_t AieAqlQueue::AddWriteIndexRelaxed(uint64_t value) {
-  return atomic::Add(&amd_queue_.write_dispatch_id, value,
-                     std::memory_order_relaxed);
+  return atomic::Add(&QueueDescriptor().write_dispatch_id, value, std::memory_order_relaxed);
 }
 
 uint64_t AieAqlQueue::AddWriteIndexAcquire(uint64_t value) {
-  return atomic::Add(&amd_queue_.write_dispatch_id, value,
-                     std::memory_order_acquire);
+  return atomic::Add(&QueueDescriptor().write_dispatch_id, value, std::memory_order_acquire);
 }
 
 uint64_t AieAqlQueue::AddWriteIndexRelease(uint64_t value) {
-  return atomic::Add(&amd_queue_.write_dispatch_id, value,
-                     std::memory_order_release);
+  return atomic::Add(&QueueDescriptor().write_dispatch_id, value, std::memory_order_release);
 }
 
 uint64_t AieAqlQueue::AddWriteIndexAcqRel(uint64_t value) {
-  return atomic::Add(&amd_queue_.write_dispatch_id, value,
-                     std::memory_order_acq_rel);
+  return atomic::Add(&QueueDescriptor().write_dispatch_id, value, std::memory_order_acq_rel);
 }
 
 void AieAqlQueue::StoreRelaxed(hsa_signal_value_t value) { SubmitPackets(); }
@@ -216,7 +211,7 @@ void AieAqlQueue::SubmitPackets() {
   }
 
   auto& driver = static_cast<XdnaDriver&>(agent_.driver());
-  void* queue_base = amd_queue_.hsa_queue.base_address;
+  void* queue_base = QueueDescriptor().hsa_queue.base_address;
 
   uint64_t cur_id = LoadReadIndexRelaxed();
   const uint64_t end = LoadWriteIndexAcquire();
@@ -259,7 +254,7 @@ void AieAqlQueue::SubmitPackets() {
     }
   }
 
-  atomic::Store(&amd_queue_.read_dispatch_id, cur_id, std::memory_order_release);
+  atomic::Store(&QueueDescriptor().read_dispatch_id, cur_id, std::memory_order_release);
 }
 
 void AieAqlQueue::StoreRelease(hsa_signal_value_t value) {
@@ -300,6 +295,11 @@ void AieAqlQueue::ExecutePM4(uint32_t *cmd_data, size_t cmd_size_b,
                              hsa_fence_scope_t releaseFence,
                              hsa_signal_t *signal) {
   assert(false && "AIE AQL queue does not support PM4 packets.");
+}
+
+void AieAqlQueue::SetProfiling(bool enabled) {
+  throw hsa_exception(static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED),
+                      "AieAqlQueue::SetProfiling is not supported.");
 }
 
 } // namespace AMD

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -57,18 +57,19 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "core/inc/runtime.h"
+#include "core/inc/amd_core_dump.hpp"
+#include "core/inc/amd_gpu_agent.h"
+#include "core/inc/amd_gpu_pm4.h"
 #include "core/inc/amd_memory_region.h"
+#include "core/inc/default_signal.h"
+#include "core/inc/hsa_amd_tool_int.hpp"
+#include "core/inc/hsa_ext_amd_impl.h"
+#include "core/inc/interrupt_signal.h"
+#include "core/inc/registers.h"
+#include "core/inc/runtime.h"
 #include "core/inc/signal.h"
 #include "core/inc/queue.h"
 #include "core/util/utils.h"
-#include "core/inc/registers.h"
-#include "core/inc/interrupt_signal.h"
-#include "core/inc/default_signal.h"
-#include "core/inc/hsa_ext_amd_impl.h"
-#include "core/inc/amd_gpu_pm4.h"
-#include "core/inc/hsa_amd_tool_int.hpp"
-#include "core/inc/amd_core_dump.hpp"
 
 namespace rocr {
 namespace AMD {
@@ -122,44 +123,42 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
     (((core::AqlPacket*)ring_buf_)[pkt_id]).dispatch.header = HSA_PACKET_TYPE_INVALID;
   }
 
-  // Zero the amd_queue_ structure to clear RPTR/WPTR before queue attach.
-  memset(&amd_queue_, 0, sizeof(amd_queue_));
+  // Zero the queue descriptor structure to clear RPTR/WPTR before queue attach.
+  memset(&QueueDescriptor(), 0, sizeof(QueueDescriptorT));
 
   // Initialize and map a HW AQL queue.
   HsaQueueResource queue_rsrc = {0};
-  queue_rsrc.Queue_read_ptr_aql = (uint64_t*)&amd_queue_.read_dispatch_id;
+  queue_rsrc.Queue_read_ptr_aql = (uint64_t*)&QueueDescriptor().read_dispatch_id;
 
   // Hardware write pointer supports AQL semantics.
-  queue_rsrc.Queue_write_ptr_aql = (uint64_t*)&amd_queue_.write_dispatch_id;
+  queue_rsrc.Queue_write_ptr_aql = (uint64_t*)&QueueDescriptor().write_dispatch_id;
 
-  // Populate amd_queue_ structure.
-  amd_queue_.hsa_queue.type = HSA_QUEUE_TYPE_MULTI;
-  amd_queue_.hsa_queue.features = HSA_QUEUE_FEATURE_KERNEL_DISPATCH;
-  amd_queue_.hsa_queue.base_address = ring_buf_;
-  amd_queue_.hsa_queue.doorbell_signal = Signal::Convert(this);
-  amd_queue_.hsa_queue.size = queue_size_pkts;
-  amd_queue_.hsa_queue.id = INVALID_QUEUEID;
-  amd_queue_.read_dispatch_id_field_base_byte_offset = uint32_t(
-      uintptr_t(&amd_queue_.read_dispatch_id) - uintptr_t(&amd_queue_));
+  // Populate queue descriptor structure.
+  QueueDescriptor().hsa_queue.type = HSA_QUEUE_TYPE_MULTI;
+  QueueDescriptor().hsa_queue.features = HSA_QUEUE_FEATURE_KERNEL_DISPATCH;
+  QueueDescriptor().hsa_queue.base_address = ring_buf_;
+  QueueDescriptor().hsa_queue.doorbell_signal = Signal::Convert(this);
+  QueueDescriptor().hsa_queue.size = queue_size_pkts;
+  QueueDescriptor().hsa_queue.id = INVALID_QUEUEID;
+  QueueDescriptor().read_dispatch_id_field_base_byte_offset =
+      uint32_t(uintptr_t(&QueueDescriptor().read_dispatch_id) - uintptr_t(&QueueDescriptor()));
   // Initialize the doorbell signal structure.
   memset(&signal_, 0, sizeof(signal_));
   signal_.kind = AMD_SIGNAL_KIND_DOORBELL;
   signal_.hardware_doorbell_ptr = nullptr;
-  signal_.queue_ptr = &amd_queue_;
+  signal_.queue_ptr = &QueueDescriptor();
 
   const auto& props = agent->properties();
-  amd_queue_.max_cu_id = (props.NumFComputeCores / props.NumSIMDPerCU) - 1;
-  amd_queue_.max_wave_id = (props.MaxWavesPerSIMD * props.NumSIMDPerCU) - 1;
+  QueueDescriptor().max_cu_id = (props.NumFComputeCores / props.NumSIMDPerCU) - 1;
+  QueueDescriptor().max_wave_id = (props.MaxWavesPerSIMD * props.NumSIMDPerCU) - 1;
 
 #ifdef HSA_LARGE_MODEL
-  AMD_HSA_BITS_SET(amd_queue_.queue_properties, AMD_QUEUE_PROPERTIES_IS_PTR64,
-                   1);
+  AMD_HSA_BITS_SET(QueueDescriptor().queue_properties, AMD_QUEUE_PROPERTIES_IS_PTR64, 1);
 #else
-  AMD_HSA_BITS_SET(amd_queue_.queue_properties, AMD_QUEUE_PROPERTIES_IS_PTR64,
-                   0);
+  AMD_HSA_BITS_SET(QueueDescriptor().queue_properties, AMD_QUEUE_PROPERTIES_IS_PTR64, 0);
 #endif
 
-  // Set group and private memory apertures in amd_queue_.
+  // Set group and private memory apertures in QueueDescriptor().
   auto& regions = agent->regions();
 
   for (auto region : regions) {
@@ -168,27 +167,25 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
 
     if (amdregion->IsLDS()) {
 #ifdef HSA_LARGE_MODEL
-      amd_queue_.group_segment_aperture_base_hi =
-          uint32_t(uintptr_t(base) >> 32);
+      QueueDescriptor().group_segment_aperture_base_hi = uint32_t(uintptr_t(base) >> 32);
 #else
-      amd_queue_.group_segment_aperture_base_hi = uint32_t(base);
+      QueueDescriptor().group_segment_aperture_base_hi = uint32_t(base);
 #endif
     }
 
     if (amdregion->IsScratch()) {
 #ifdef HSA_LARGE_MODEL
-      amd_queue_.private_segment_aperture_base_hi =
-          uint32_t(uintptr_t(base) >> 32);
+      QueueDescriptor().private_segment_aperture_base_hi = uint32_t(uintptr_t(base) >> 32);
 #else
-      amd_queue_.private_segment_aperture_base_hi = uint32_t(base);
+      QueueDescriptor().private_segment_aperture_base_hi = uint32_t(base);
 #endif
     }
   }
 
-  assert(amd_queue_.group_segment_aperture_base_hi != 0 && "No group region found.");
+  assert(QueueDescriptor().group_segment_aperture_base_hi != 0 && "No group region found.");
 
   if (core::Runtime::runtime_singleton_->flag().check_flat_scratch()) {
-    assert(amd_queue_.private_segment_aperture_base_hi != 0 && "No private region found.");
+    assert(QueueDescriptor().private_segment_aperture_base_hi != 0 && "No private region found.");
   }
 
   if (agent_->supported_isas()[0]->GetMajorVersion() >= 11)
@@ -223,8 +220,8 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
   });
 
   MAKE_NAMED_SCOPE_GUARD(SignalGuard, [&]() {
-    if (amd_queue_.queue_inactive_signal.handle != 0)
-      HSA::hsa_signal_destroy(amd_queue_.queue_inactive_signal);
+    if (QueueDescriptor().queue_inactive_signal.handle != 0)
+      HSA::hsa_signal_destroy(QueueDescriptor().queue_inactive_signal);
     if (exception_signal_ != nullptr) exception_signal_->DestroySignal();
   });
 
@@ -241,14 +238,14 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
     }
     auto Signal = new core::InterruptSignal(0, queue_event());
     assert(Signal != nullptr && "Should have thrown!\n");
-    amd_queue_.queue_inactive_signal = core::InterruptSignal::Convert(Signal);
+    QueueDescriptor().queue_inactive_signal = core::InterruptSignal::Convert(Signal);
     exception_signal_ = new core::InterruptSignal(0, queue_event());
     assert(exception_signal_ != nullptr && "Should have thrown!\n");
   } else {
     EventGuard.Dismiss();
     auto Signal = new core::DefaultSignal(0);
     assert(Signal != nullptr && "Should have thrown!\n");
-    amd_queue_.queue_inactive_signal = core::DefaultSignal::Convert(Signal);
+    QueueDescriptor().queue_inactive_signal = core::DefaultSignal::Convert(Signal);
     exception_signal_ = new core::DefaultSignal(0);
     assert(exception_signal_ != nullptr && "Should have thrown!\n");
   }
@@ -257,7 +254,7 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
   // so that we call hsakmtSetEvent to force hsaKmtWaitOnEvent to return.
   exception_signal_->WaitingInc();
 
-  // Ensure the amd_queue_ is fully initialized before creating the KFD queue.
+  // Ensure the queue descriptor is fully initialized before creating the KFD queue.
   // This ensures that the debugger can access the fields once it detects there
   // is a KFD queue. The debugger may access the aperture addresses, queue
   // scratch base, and queue type.
@@ -280,29 +277,29 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
 
   // Bind Id of Queue such that is unique i.e. it is not re-used by another
   // queue (AQL, HOST) in the same process during its lifetime.
-  amd_queue_.hsa_queue.id = this->GetQueueId();
+  QueueDescriptor().hsa_queue.id = this->GetQueueId();
 
   queue_id_ = queue_rsrc.QueueId;
   MAKE_NAMED_SCOPE_GUARD(QueueGuard, [&]() { agent_->driver().DestroyQueue(queue_id_); });
 
-  amd_queue_.scratch_max_use_index = UINT64_MAX;
-  amd_queue_.alt_scratch_max_use_index = UINT64_MAX;
+  QueueDescriptor().scratch_max_use_index = UINT64_MAX;
+  QueueDescriptor().alt_scratch_max_use_index = UINT64_MAX;
 
   // Set flag to notify CP FW that SW supports the new amd_queue_v2
   if (agent_->AsyncScratchReclaimEnabled())
-    amd_queue_.caps |= AMD_QUEUE_CAPS_SW_ASYNC_RECLAIM;
+    QueueDescriptor().caps |= AMD_QUEUE_CAPS_SW_ASYNC_RECLAIM;
 
   // On the first queue creation, reserve some scratch memory on this agent.
   agent_->ReserveScratch();
 
   // Initialize scratch memory related entities
-  queue_scratch_.queue_retry = amd_queue_.queue_inactive_signal;
+  queue_scratch_.queue_retry = QueueDescriptor().queue_inactive_signal;
   InitScratchSRD();
 
   if (core::Runtime::runtime_singleton_->KfdVersion().supports_exception_debugging) {
-    if (AMD::hsa_amd_signal_async_handler(amd_queue_.queue_inactive_signal, HSA_SIGNAL_CONDITION_NE,
-                                          0, DynamicQueueEventsHandler<false>,
-                                          this) != HSA_STATUS_SUCCESS)
+    if (AMD::hsa_amd_signal_async_handler(
+            QueueDescriptor().queue_inactive_signal, HSA_SIGNAL_CONDITION_NE, 0,
+            DynamicQueueEventsHandler<false>, this) != HSA_STATUS_SUCCESS)
       throw AMD::hsa_exception(HSA_STATUS_ERROR_OUT_OF_RESOURCES,
                                "Queue event handler failed registration.\n");
     if (AMD::hsa_amd_signal_async_handler(core::Signal::Convert(exception_signal_),
@@ -311,9 +308,9 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
       throw AMD::hsa_exception(HSA_STATUS_ERROR_OUT_OF_RESOURCES,
                                "Queue event handler failed registration.\n");
   } else {
-    if (AMD::hsa_amd_signal_async_handler(amd_queue_.queue_inactive_signal, HSA_SIGNAL_CONDITION_NE,
-                                          0, DynamicQueueEventsHandler<true>,
-                                          this) != HSA_STATUS_SUCCESS)
+    if (AMD::hsa_amd_signal_async_handler(
+            QueueDescriptor().queue_inactive_signal, HSA_SIGNAL_CONDITION_NE, 0,
+            DynamicQueueEventsHandler<true>, this) != HSA_STATUS_SUCCESS)
       throw AMD::hsa_exception(HSA_STATUS_ERROR_OUT_OF_RESOURCES,
                                "Queue event handler failed registration.\n");
     exceptionState = ERROR_HANDLER_DONE;
@@ -344,8 +341,8 @@ AqlQueue::~AqlQueue() {
   // Sequences error handler callbacks with queue destroy.
   dynamicScratchState |= ERROR_HANDLER_TERMINATE;
   while ((dynamicScratchState & ERROR_HANDLER_DONE) != ERROR_HANDLER_DONE) {
-    HSA::hsa_signal_store_screlease(amd_queue_.queue_inactive_signal, 0x8000000000000000ull);
-    HSA::hsa_signal_wait_relaxed(amd_queue_.queue_inactive_signal, HSA_SIGNAL_CONDITION_NE,
+    HSA::hsa_signal_store_screlease(QueueDescriptor().queue_inactive_signal, 0x8000000000000000ull);
+    HSA::hsa_signal_wait_relaxed(QueueDescriptor().queue_inactive_signal, HSA_SIGNAL_CONDITION_NE,
                                  0x8000000000000000ull, -1ull, HSA_WAIT_STATE_BLOCKED);
   }
 
@@ -380,7 +377,7 @@ AqlQueue::~AqlQueue() {
 
   exception_signal_->WaitingDec();
   exception_signal_->DestroySignal();
-  HSA::hsa_signal_destroy(amd_queue_.queue_inactive_signal);
+  HSA::hsa_signal_destroy(QueueDescriptor().queue_inactive_signal);
   FreeQueueMemory();
 
   if (core::g_use_interrupt_wait) {
@@ -395,7 +392,7 @@ AqlQueue::~AqlQueue() {
 }
 
 void AqlQueue::Destroy() {
-  if (amd_queue_.hsa_queue.type == HSA_QUEUE_TYPE_COOPERATIVE) {
+  if (QueueDescriptor().hsa_queue.type == HSA_QUEUE_TYPE_COOPERATIVE) {
     agent_->GWSRelease();
     return;
   }
@@ -403,66 +400,60 @@ void AqlQueue::Destroy() {
 }
 
 uint64_t AqlQueue::LoadReadIndexAcquire() {
-  return atomic::Load(&amd_queue_.read_dispatch_id, std::memory_order_acquire);
+  return atomic::Load(&QueueDescriptor().read_dispatch_id, std::memory_order_acquire);
 }
 
 uint64_t AqlQueue::LoadReadIndexRelaxed() {
-  return atomic::Load(&amd_queue_.read_dispatch_id, std::memory_order_relaxed);
+  return atomic::Load(&QueueDescriptor().read_dispatch_id, std::memory_order_relaxed);
 }
 
 uint64_t AqlQueue::LoadWriteIndexAcquire() {
-  return atomic::Load(&amd_queue_.write_dispatch_id, std::memory_order_acquire);
+  return atomic::Load(&QueueDescriptor().write_dispatch_id, std::memory_order_acquire);
 }
 
 uint64_t AqlQueue::LoadWriteIndexRelaxed() {
-  return atomic::Load(&amd_queue_.write_dispatch_id, std::memory_order_relaxed);
+  return atomic::Load(&QueueDescriptor().write_dispatch_id, std::memory_order_relaxed);
 }
 
 void AqlQueue::StoreWriteIndexRelaxed(uint64_t value) {
-  atomic::Store(&amd_queue_.write_dispatch_id, value,
-                std::memory_order_relaxed);
+  atomic::Store(&QueueDescriptor().write_dispatch_id, value, std::memory_order_relaxed);
 }
 
 void AqlQueue::StoreWriteIndexRelease(uint64_t value) {
-  atomic::Store(&amd_queue_.write_dispatch_id, value,
-                std::memory_order_release);
+  atomic::Store(&QueueDescriptor().write_dispatch_id, value, std::memory_order_release);
 }
 
 uint64_t AqlQueue::CasWriteIndexAcqRel(uint64_t expected, uint64_t value) {
-  return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected,
+  return atomic::Cas(&QueueDescriptor().write_dispatch_id, value, expected,
                      std::memory_order_acq_rel);
 }
 uint64_t AqlQueue::CasWriteIndexAcquire(uint64_t expected, uint64_t value) {
-  return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected,
+  return atomic::Cas(&QueueDescriptor().write_dispatch_id, value, expected,
                      std::memory_order_acquire);
 }
 uint64_t AqlQueue::CasWriteIndexRelaxed(uint64_t expected, uint64_t value) {
-  return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected,
+  return atomic::Cas(&QueueDescriptor().write_dispatch_id, value, expected,
                      std::memory_order_relaxed);
 }
 uint64_t AqlQueue::CasWriteIndexRelease(uint64_t expected, uint64_t value) {
-  return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected,
+  return atomic::Cas(&QueueDescriptor().write_dispatch_id, value, expected,
                      std::memory_order_release);
 }
 
 uint64_t AqlQueue::AddWriteIndexAcqRel(uint64_t value) {
-  return atomic::Add(&amd_queue_.write_dispatch_id, value,
-                     std::memory_order_acq_rel);
+  return atomic::Add(&QueueDescriptor().write_dispatch_id, value, std::memory_order_acq_rel);
 }
 
 uint64_t AqlQueue::AddWriteIndexAcquire(uint64_t value) {
-  return atomic::Add(&amd_queue_.write_dispatch_id, value,
-                     std::memory_order_acquire);
+  return atomic::Add(&QueueDescriptor().write_dispatch_id, value, std::memory_order_acquire);
 }
 
 uint64_t AqlQueue::AddWriteIndexRelaxed(uint64_t value) {
-  return atomic::Add(&amd_queue_.write_dispatch_id, value,
-                     std::memory_order_relaxed);
+  return atomic::Add(&QueueDescriptor().write_dispatch_id, value, std::memory_order_relaxed);
 }
 
 uint64_t AqlQueue::AddWriteIndexRelease(uint64_t value) {
-  return atomic::Add(&amd_queue_.write_dispatch_id, value,
-                     std::memory_order_release);
+  return atomic::Add(&QueueDescriptor().write_dispatch_id, value, std::memory_order_release);
 }
 
 void AqlQueue::StoreRelaxed(hsa_signal_value_t value) {
@@ -677,13 +668,13 @@ void AqlQueue::AsyncReclaimMainScratch() {
    * supported
    *
    * Notes:
-   * - CP FW only updates its copy of amd_queue_ (scratch_copy) on queue_connect
-   * so changes to amd_queue_ by ROCr are only visible to CP FW after a queue
+   * - CP FW only updates its copy of queue descriptor (scratch_copy) on queue_connect
+   * so changes to queue descriptor by ROCr are only visible to CP FW after a queue
    * re-map.
    *
    * - CP sets AMD_QUEUE_CAPS_CP_ASYNC_RECLAIM bit to indicate that this version
    * of CP FW supports asynchronous scratch reclaim. But CP will only update
-   * amd_queue_.caps on queue-connect so ROCr assumes that async scratch reclaim
+   * QueueDescriptor().caps on queue-connect so ROCr assumes that async scratch reclaim
    * is supported based on the CP FW version.
    *
    * - ROCR sets AMD_QUEUE_CAPS_SW_ASYNC_RECLAIM bit to indicate to CP that this
@@ -742,7 +733,7 @@ void AqlQueue::AsyncReclaimMainScratch() {
    *     acquire(scratch-mutex)
    *     queue-unmap
    *     // Tell CP that it cannot use scratch after current packet
-   *     queue->scratch_last_used_index = max(amd_queue_->scratch_last_used_index_per_xcc[])
+   *     queue->scratch_last_used_index = max(QueueDescriptor().scratch_last_used_index_per_xcc[])
    *
    *     queue-map
    *     // wait for CP to finish current packet
@@ -756,8 +747,8 @@ void AqlQueue::AsyncReclaimMainScratch() {
   auto getMaxMainScratchUseIndex = [&]() {
     uint64_t max = 0;
     for (int i = 0; i < agent_->properties().NumXcc; i++) {
-      if (amd_queue_.scratch_last_used_index[i].main > max)
-        max = amd_queue_.scratch_last_used_index[i].main;
+      if (QueueDescriptor().scratch_last_used_index[i].main > max)
+        max = QueueDescriptor().scratch_last_used_index[i].main;
     }
     return max;
   };
@@ -767,34 +758,34 @@ void AqlQueue::AsyncReclaimMainScratch() {
     return;
   }
 
-  assert((amd_queue_.caps & AMD_QUEUE_CAPS_CP_ASYNC_RECLAIM) &&
-          "This version of CP FW should support async scratch, but flag is not set");
+  assert((QueueDescriptor().caps & AMD_QUEUE_CAPS_CP_ASYNC_RECLAIM) &&
+         "This version of CP FW should support async scratch, but flag is not set");
 
   tool::notify_event_scratch_async_reclaim_start(public_handle(),
                                                  HSA_AMD_EVENT_SCRATCH_ALLOC_FLAG_NONE);
 
   ScopedAcquire<KernelMutex> lock(&scratch_lock_);
 
-  // Unmap the queue. CP will check amd_queue_ fields on re-map
+  // Unmap the queue. CP will check queue descriptor fields on re-map
   Suspend();
 
   /*
-   * amd_queue_.scratch_last_used_index[*].main is updated by CP FW every time a
+   * QueueDescriptor().scratch_last_used_index[*].main is updated by CP FW every time a
    * dispatch packet is launched and it needs scratch memory.
-   * If amd_queue_.scratch_last_used_index[*].main >= amd_queue_.read_dispatch_id
+   * If QueueDescriptor().scratch_last_used_index[*].main >= QueueDescriptor().read_dispatch_id
    * then this XCC is currently running a dispatch that uses scratch.
-   * Setting max_scratch_use_index to max(amd_queue_.scratch_last_used_index[*].main)
+   * Setting max_scratch_use_index to max(QueueDescriptor().scratch_last_used_index[*].main)
    * prevents CP from trying to use main-scratch after
-   * amd_queue_.scratch_max_use_index. If CP sees a dispatch that needs scratch,
+   * QueueDescriptor().scratch_max_use_index. If CP sees a dispatch that needs scratch,
    * it will raise a new signal. CP may use alt-scratch in the meantime.
    */
-  amd_queue_.scratch_max_use_index = getMaxMainScratchUseIndex();
+  QueueDescriptor().scratch_max_use_index = getMaxMainScratchUseIndex();
 
   Resume();
 
   // If current dispatch is using scratch, wait for it to finish
-  while (amd_queue_.scratch_max_use_index >= LoadReadIndexRelaxed()) {
-    //TODO: if mwaitx supported, //mwaitx(amd_queue_.read_dispatch_id);
+  while (QueueDescriptor().scratch_max_use_index >= LoadReadIndexRelaxed()) {
+    // TODO: if mwaitx supported, //mwaitx(QueueDescriptor().read_dispatch_id);
     os::YieldThread();
   }
 
@@ -828,8 +819,8 @@ void AqlQueue::AsyncReclaimAltScratch() {
   auto getMaxAltScratchUseIndex = [&]() {
     uint64_t max = 0;
     for (int i = 0; i < agent_->properties().NumXcc; i++) {
-      if (amd_queue_.scratch_last_used_index[i].alt > max)
-        max = amd_queue_.scratch_last_used_index[i].alt;
+      if (QueueDescriptor().scratch_last_used_index[i].alt > max)
+        max = QueueDescriptor().scratch_last_used_index[i].alt;
     }
     return max;
   };
@@ -839,24 +830,24 @@ void AqlQueue::AsyncReclaimAltScratch() {
     return;
   }
 
-  assert((amd_queue_.caps & AMD_QUEUE_CAPS_CP_ASYNC_RECLAIM) &&
-          "This version of CP FW should support async scratch, but flag is not set");
+  assert((QueueDescriptor().caps & AMD_QUEUE_CAPS_CP_ASYNC_RECLAIM) &&
+         "This version of CP FW should support async scratch, but flag is not set");
 
   tool::notify_event_scratch_async_reclaim_start(public_handle(),
                                                  HSA_AMD_EVENT_SCRATCH_ALLOC_FLAG_ALT);
 
   ScopedAcquire<KernelMutex> lock(&scratch_lock_);
 
-  // Unmap the queue. CP will check amd_queue_ fields on re-map
+  // Unmap the queue. CP will check queue descriptor fields on re-map
   Suspend();
 
-  amd_queue_.alt_scratch_max_use_index = getMaxAltScratchUseIndex();
+  QueueDescriptor().alt_scratch_max_use_index = getMaxAltScratchUseIndex();
 
   Resume();
 
   // If current dispatch is using alt scratch, wait for it to finish
-  while (amd_queue_.alt_scratch_max_use_index >= LoadReadIndexRelaxed()) {
-    //TODO: if mwaitx supported, //mwaitx(amd_queue_.read_dispatch_id);
+  while (QueueDescriptor().alt_scratch_max_use_index >= LoadReadIndexRelaxed()) {
+    // TODO: if mwaitx supported, //mwaitx(QueueDescriptor().read_dispatch_id);
     os::YieldThread();
   }
 
@@ -910,16 +901,15 @@ void AqlQueue::HandleInsufficientScratch(hsa_signal_value_t& error_code,
   uint64_t dispatch_id = UINT64_MAX;
 
   auto get_dispatch_pkt = [&]() {
-    dispatch_id = amd_queue_.read_dispatch_id;
+    dispatch_id = QueueDescriptor().read_dispatch_id;
     do {
       // On GPUs where EOP is handled in asic, the read_dispatch_id is not
       // updated after each packet so look for the first dispatch that needs
       // scratch
-      const uint64_t pkt_slot_idx =
-          dispatch_id & (amd_queue_.hsa_queue.size - 1);
+      const uint64_t pkt_slot_idx = dispatch_id & (QueueDescriptor().hsa_queue.size - 1);
 
-      core::AqlPacket *dispatch_pkt =
-          &((core::AqlPacket *)amd_queue_.hsa_queue.base_address)[pkt_slot_idx];
+      core::AqlPacket* dispatch_pkt =
+          &((core::AqlPacket*)QueueDescriptor().hsa_queue.base_address)[pkt_slot_idx];
       if (dispatch_pkt->IsDispatchAndNeedsScratch()) return dispatch_pkt;
 
       dispatch_id++;
@@ -948,7 +938,7 @@ void AqlQueue::HandleInsufficientScratch(hsa_signal_value_t& error_code,
                        pkt.dispatch.workgroup_size_y) *
                       ((uint64_t(pkt.dispatch.grid_size_z) + pkt.dispatch.workgroup_size_z - 1) /
                        pkt.dispatch.workgroup_size_z);
-    const uint32_t cu_count = amd_queue_.max_cu_id + 1;
+    const uint32_t cu_count = QueueDescriptor().max_cu_id + 1;
 
     const uint32_t engines = agent_->properties().NumShaderBanks;
 
@@ -978,15 +968,15 @@ void AqlQueue::HandleInsufficientScratch(hsa_signal_value_t& error_code,
   auto calc_device_slots = [&]() {
     // Get the hw maximum scratch slot count taking into consideration asymmetric harvest.
     const uint32_t engines = agent_->properties().NumShaderBanks;
-    const uint32_t cu_count = amd_queue_.max_cu_id + 1;
+    const uint32_t cu_count = QueueDescriptor().max_cu_id + 1;
     return AlignUp(cu_count, engines) * agent_->properties().MaxSlotsScratchCU;
   };
 
   assert(core::Runtime::runtime_singleton_->flag().enable_scratch_async_reclaim() &&
-         (!scratch.async_reclaim || (amd_queue_.caps & AMD_QUEUE_CAPS_CP_ASYNC_RECLAIM)) &&
-          "Asynchronous scratch reclaim capability not set, but this FW version should support it");
+         (!scratch.async_reclaim || (QueueDescriptor().caps & AMD_QUEUE_CAPS_CP_ASYNC_RECLAIM)) &&
+         "Asynchronous scratch reclaim capability not set, but this FW version should support it");
 
-  scratch.cooperative = (amd_queue_.hsa_queue.type == HSA_QUEUE_TYPE_COOPERATIVE);
+  scratch.cooperative = (QueueDescriptor().hsa_queue.type == HSA_QUEUE_TYPE_COOPERATIVE);
 
   pkt = get_dispatch_pkt(); // Sets dispatch_id
   assert((pkt && dispatch_id != UINT64_MAX) &&
@@ -1038,11 +1028,11 @@ void AqlQueue::HandleInsufficientScratch(hsa_signal_value_t& error_code,
       /*
        * Indicate to CP FW that any dispatch may use alt scratch memory.
        * If ROCr wants to reclain scratch memory, it will set
-       * amd_queue_.alt_scratch_max_use_index to a lower value
+       * QueueDescriptor().alt_scratch_max_use_index to a lower value
        */
-      amd_queue_.alt_scratch_max_use_index = UINT64_MAX;
+      QueueDescriptor().alt_scratch_max_use_index = UINT64_MAX;
       // Restart the queue.
-      HSA::hsa_signal_store_screlease(amd_queue_.queue_inactive_signal, 0);
+      HSA::hsa_signal_store_screlease(QueueDescriptor().queue_inactive_signal, 0);
       tool::notify_event_scratch_alloc_end(public_handle(), HSA_AMD_EVENT_SCRATCH_ALLOC_FLAG_ALT,
                                            dispatch_id, scratch.alt_size, dispatch_slots);
       return;
@@ -1084,7 +1074,7 @@ void AqlQueue::HandleInsufficientScratch(hsa_signal_value_t& error_code,
 
   // If we had to reduce number of waves
   if (scratch.large) {
-    amd_queue_.queue_properties |= AMD_QUEUE_PROPERTIES_USE_SCRATCH_ONCE;
+    QueueDescriptor().queue_properties |= AMD_QUEUE_PROPERTIES_USE_SCRATCH_ONCE;
     // Set system release fence to flush scratch stores with older firmware versions.
     if ((agent_->supported_isas()[0]->GetMajorVersion() == 8) && (agent_->GetMicrocodeVersion() < 729)) {
       pkt->dispatch.header &=
@@ -1108,12 +1098,12 @@ void AqlQueue::HandleInsufficientScratch(hsa_signal_value_t& error_code,
   /*
    * Indicate to CP FW that any dispatch may use alt scratch memory.
    * If ROCr wants to reclain scratch memory, it will set
-   * amd_queue_.alt_scratch_max_use_index to a lower value
+   * QueueDescriptor().alt_scratch_max_use_index to a lower value
    */
-  amd_queue_.scratch_max_use_index = UINT64_MAX;
+  QueueDescriptor().scratch_max_use_index = UINT64_MAX;
 
   // Restart the queue.
-  HSA::hsa_signal_store_screlease(amd_queue_.queue_inactive_signal, 0);
+  HSA::hsa_signal_store_screlease(QueueDescriptor().queue_inactive_signal, 0);
 
   auto alloc_flag = (scratch.large) ? HSA_AMD_EVENT_SCRATCH_ALLOC_FLAG_USE_ONCE
                                     : HSA_AMD_EVENT_SCRATCH_ALLOC_FLAG_NONE;
@@ -1136,7 +1126,8 @@ bool AqlQueue::DynamicQueueEventsHandler(hsa_signal_value_t error_code, void* ar
     queue->dynamicScratchState &= ~ERROR_HANDLER_SCRATCH_RETRY;
     changeWait = true;
     waitVal = 0;
-    HSA::hsa_signal_and_relaxed(queue->amd_queue_.queue_inactive_signal, ~0x8000000000000000ull);
+    HSA::hsa_signal_and_relaxed(queue->QueueDescriptor().queue_inactive_signal,
+                                ~0x8000000000000000ull);
     error_code &= ~0x8000000000000000ull;
   }
 
@@ -1154,11 +1145,12 @@ bool AqlQueue::DynamicQueueEventsHandler(hsa_signal_value_t error_code, void* ar
       scratch.main_queue_process_offset = 0;
       queue->InitScratchSRD();
 
-      HSA::hsa_signal_store_relaxed(queue->amd_queue_.queue_inactive_signal, 0);
+      HSA::hsa_signal_store_relaxed(queue->QueueDescriptor().queue_inactive_signal, 0);
       // Resumes queue processing.
-      atomic::Store(&queue->amd_queue_.queue_properties,
-                    queue->amd_queue_.queue_properties & (~AMD_QUEUE_PROPERTIES_USE_SCRATCH_ONCE),
-                    std::memory_order_release);
+      atomic::Store(
+          &queue->QueueDescriptor().queue_properties,
+          queue->QueueDescriptor().queue_properties & (~AMD_QUEUE_PROPERTIES_USE_SCRATCH_ONCE),
+          std::memory_order_release);
       atomic::Fence(std::memory_order_release);
       tool::notify_event_scratch_free_end(queue->public_handle(),
                                           HSA_AMD_EVENT_SCRATCH_ALLOC_FLAG_USE_ONCE);
@@ -1212,13 +1204,13 @@ bool AqlQueue::DynamicQueueEventsHandler(hsa_signal_value_t error_code, void* ar
       }
     } else {
       // Not handling exceptions, clear so that ExceptionHandler can run.
-      HSA::hsa_signal_store_relaxed(queue->amd_queue_.queue_inactive_signal, 0);
+      HSA::hsa_signal_store_relaxed(queue->QueueDescriptor().queue_inactive_signal, 0);
     }
 
     if (errorCode == HSA_STATUS_SUCCESS) {
       if (changeWait) {
         core::Runtime::runtime_singleton_->SetAsyncSignalHandler(
-            queue->amd_queue_.queue_inactive_signal, HSA_SIGNAL_CONDITION_NE, waitVal,
+            queue->QueueDescriptor().queue_inactive_signal, HSA_SIGNAL_CONDITION_NE, waitVal,
             DynamicQueueEventsHandler<HandleExceptions>, queue);
         return false;
       }
@@ -1238,7 +1230,7 @@ bool AqlQueue::DynamicQueueEventsHandler(hsa_signal_value_t error_code, void* ar
   // Copy here is to protect against queue being released between setting the scratch state and
   // updating the signal value.  The signal itself is safe to use because it is ref counted rather
   // than being released with the queue.
-  hsa_signal_t signal = queue->amd_queue_.queue_inactive_signal;
+  hsa_signal_t signal = queue->QueueDescriptor().queue_inactive_signal;
   queue->dynamicScratchState = ERROR_HANDLER_DONE;
   HSA::hsa_signal_store_screlease(signal, -1ull);
   return false;
@@ -1422,7 +1414,8 @@ hsa_status_t AqlQueue::GetCUMasking(uint32_t num_cu_mask_count, uint32_t* cu_mas
 }
 
 void AqlQueue::SetProfiling(bool enabled) {
-  Queue::SetProfiling(enabled);
+  AMD_HSA_BITS_SET(QueueDescriptor().queue_properties, AMD_QUEUE_PROPERTIES_ENABLE_PROFILING,
+                   (enabled != 0));
 
   if (enabled) agent_->CheckClockTicks();
   return;
@@ -1437,20 +1430,18 @@ void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope
   // pm4_ib_buf_ is a shared resource, so mutually exclude here.
   ScopedAcquire<KernelMutex> lock(&pm4_ib_mutex_);
 
-  // Obtain reference to any container queue.
-  core::Queue* queue = core::Queue::Convert(public_handle());
-
   // Obtain a queue slot for a single AQL packet.
-  uint64_t write_idx = queue->AddWriteIndexAcqRel(1);
+  uint64_t write_idx = AddWriteIndexAcqRel(1);
 
-  while ((write_idx - queue->LoadReadIndexRelaxed()) >= queue->amd_queue_.hsa_queue.size) {
+  while ((write_idx - LoadReadIndexRelaxed()) >= QueueDescriptor().hsa_queue.size) {
     os::YieldThread();
   }
 
-  uint32_t slot_idx = uint32_t(write_idx % queue->amd_queue_.hsa_queue.size);
+  uint32_t slot_idx = uint32_t(write_idx % QueueDescriptor().hsa_queue.size);
   constexpr uint32_t slot_size_b = 0x40;
-  uint32_t* queue_slot =
-      (uint32_t*)(uintptr_t(queue->amd_queue_.hsa_queue.base_address) + (slot_idx * slot_size_b));
+  uint32_t* queue_slot = reinterpret_cast<uint32_t*>(
+      reinterpret_cast<uintptr_t>(QueueDescriptor().hsa_queue.base_address) +
+      (slot_idx * slot_size_b));
 
   // Copy client PM4 command into IB.
   assert(cmd_size_b < pm4_ib_size_b_ && "PM4 exceeds IB size");
@@ -1559,13 +1550,11 @@ void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope
   atomic::Store(&queue_slot[0], slot_data[0], std::memory_order_release);
 
   // Submit the packet slot.
-  core::Signal* doorbell = core::Signal::Convert(queue->amd_queue_.hsa_queue.doorbell_signal);
-  doorbell->StoreRelease(write_idx);
+  StoreRelease(write_idx);
 
   // Wait for the packet to be consumed.
   if (agent_->supported_isas()[0]->GetMajorVersion() <= 8) {
-    while (queue->LoadReadIndexRelaxed() <= write_idx)
-      os::YieldThread();
+    while (LoadReadIndexRelaxed() <= write_idx) os::YieldThread();
 
     if (in_signal) hsa_signal_store_screlease(*in_signal, 0);
   } else if (!in_signal) {
@@ -1583,7 +1572,7 @@ void AqlQueue::FillBufRsrcWord0() {
   uintptr_t scratch_base = uintptr_t(queue_scratch_.main_queue_base);
 
   srd0.bits.BASE_ADDRESS = uint32_t(scratch_base);
-  amd_queue_.scratch_resource_descriptor[0] = srd0.u32All;
+  QueueDescriptor().scratch_resource_descriptor[0] = srd0.u32All;
 }
 
 void AqlQueue::FillBufRsrcWord1() {
@@ -1600,7 +1589,7 @@ void AqlQueue::FillBufRsrcWord1() {
   srd1.bits.CACHE_SWIZZLE = 0;
   srd1.bits.SWIZZLE_ENABLE = 1;
 
-  amd_queue_.scratch_resource_descriptor[1] = srd1.u32All;
+  QueueDescriptor().scratch_resource_descriptor[1] = srd1.u32All;
 }
 
 void AqlQueue::FillBufRsrcWord1_Gfx11() {
@@ -1616,7 +1605,7 @@ void AqlQueue::FillBufRsrcWord1_Gfx11() {
   srd1.bits.STRIDE = 0;
   srd1.bits.SWIZZLE_ENABLE = 1;
 
-  amd_queue_.scratch_resource_descriptor[1] = srd1.u32All;
+  QueueDescriptor().scratch_resource_descriptor[1] = srd1.u32All;
 }
 
 void AqlQueue::FillBufRsrcWord2() {
@@ -1627,7 +1616,7 @@ void AqlQueue::FillBufRsrcWord2() {
    // report size per XCC
   srd2.bits.NUM_RECORDS = uint32_t(queue_scratch_.main_size / num_xcc);
 
-  amd_queue_.scratch_resource_descriptor[2] = srd2.u32All;
+  QueueDescriptor().scratch_resource_descriptor[2] = srd2.u32All;
 }
 
 void AqlQueue::FillBufRsrcWord3() {
@@ -1648,7 +1637,7 @@ void AqlQueue::FillBufRsrcWord3() {
   srd3.bits.MTYPE__CI__VI = 0;
   srd3.bits.TYPE = SQ_RSRC_BUF;
 
-  amd_queue_.scratch_resource_descriptor[3] = srd3.u32All;
+  QueueDescriptor().scratch_resource_descriptor[3] = srd3.u32All;
 }
 
 void AqlQueue::FillBufRsrcWord3_Gfx10() {
@@ -1667,7 +1656,7 @@ void AqlQueue::FillBufRsrcWord3_Gfx10() {
   srd3.bits.OOB_SELECT = 2;  // no bounds check in swizzle mode
   srd3.bits.TYPE = SQ_RSRC_BUF;
 
-  amd_queue_.scratch_resource_descriptor[3] = srd3.u32All;
+  QueueDescriptor().scratch_resource_descriptor[3] = srd3.u32All;
 }
 
 void AqlQueue::FillBufRsrcWord3_Gfx11() {
@@ -1685,7 +1674,7 @@ void AqlQueue::FillBufRsrcWord3_Gfx11() {
   srd3.bits.OOB_SELECT = 2;  // no bounds check in swizzle mode
   srd3.bits.TYPE = SQ_RSRC_BUF;
 
-  amd_queue_.scratch_resource_descriptor[3] = srd3.u32All;
+  QueueDescriptor().scratch_resource_descriptor[3] = srd3.u32All;
 }
 
 void AqlQueue::FillBufRsrcWord3_Gfx12() {
@@ -1705,14 +1694,14 @@ void AqlQueue::FillBufRsrcWord3_Gfx12() {
   srd3.bits.OOB_SELECT = 2;  // no bounds check in swizzle mode
   srd3.bits.TYPE = SQ_RSRC_BUF;
 
-  amd_queue_.scratch_resource_descriptor[3] = srd3.u32All;
+  QueueDescriptor().scratch_resource_descriptor[3] = srd3.u32All;
 }
 
 // Set concurrent wavefront limits only when scratch is being used.
 void AqlQueue::FillComputeTmpRingSize() {
   COMPUTE_TMPRING_SIZE tmpring_size = {};
   if (queue_scratch_.main_size == 0) {
-    amd_queue_.compute_tmpring_size = tmpring_size.u32All;
+    QueueDescriptor().compute_tmpring_size = tmpring_size.u32All;
     return;
   }
 
@@ -1735,7 +1724,7 @@ void AqlQueue::FillComputeTmpRingSize() {
       (tmpring_size.bits.WAVESIZE * queue_scratch_.mem_alignment_size);
 
   tmpring_size.bits.WAVES = std::min(num_waves, max_scratch_waves);
-  amd_queue_.compute_tmpring_size = tmpring_size.u32All;
+  QueueDescriptor().compute_tmpring_size = tmpring_size.u32All;
   assert((tmpring_size.bits.WAVES % (agent_props.NumShaderBanks / num_xcc) == 0) &&
          "Invalid scratch wave count.  Must be divisible by #SEs.");
 }
@@ -1744,7 +1733,7 @@ void AqlQueue::FillComputeTmpRingSize() {
 void AqlQueue::FillAltComputeTmpRingSize() {
   COMPUTE_TMPRING_SIZE tmpring_size = {};
   if (queue_scratch_.alt_size == 0) {
-    amd_queue_.alt_compute_tmpring_size = tmpring_size.u32All;
+    QueueDescriptor().alt_compute_tmpring_size = tmpring_size.u32All;
     return;
   }
 
@@ -1767,7 +1756,7 @@ void AqlQueue::FillAltComputeTmpRingSize() {
       (tmpring_size.bits.WAVESIZE * queue_scratch_.mem_alignment_size);
 
   tmpring_size.bits.WAVES = std::min(num_waves, max_scratch_waves);
-  amd_queue_.alt_compute_tmpring_size = tmpring_size.u32All;
+  QueueDescriptor().alt_compute_tmpring_size = tmpring_size.u32All;
   assert((tmpring_size.bits.WAVES % (agent_props.NumShaderBanks / num_xcc) == 0) &&
          "Invalid scratch wave count.  Must be divisible by #SEs.");
 }
@@ -1776,7 +1765,7 @@ void AqlQueue::FillAltComputeTmpRingSize() {
 void AqlQueue::FillComputeTmpRingSize_Gfx11() {
   COMPUTE_TMPRING_SIZE_GFX11 tmpring_size = {};
   if (queue_scratch_.main_size == 0) {
-    amd_queue_.compute_tmpring_size = tmpring_size.u32All;
+    QueueDescriptor().compute_tmpring_size = tmpring_size.u32All;
     return;
   }
 
@@ -1803,7 +1792,7 @@ void AqlQueue::FillComputeTmpRingSize_Gfx11() {
   // For GFX11 we specify number of waves per engine instead of total
   num_waves /= agent_->properties().NumShaderBanks;
   tmpring_size.bits.WAVES = std::min(num_waves, max_scratch_waves);
-  amd_queue_.compute_tmpring_size = tmpring_size.u32All;
+  QueueDescriptor().compute_tmpring_size = tmpring_size.u32All;
 }
 
 // Set concurrent wavefront limits only when scratch is being used.
@@ -1812,7 +1801,7 @@ void AqlQueue::FillComputeTmpRingSize_Gfx12() {
   // Consider refactoring code for GFX11/GFX12 if no other changes.
   COMPUTE_TMPRING_SIZE_GFX12 tmpring_size = {};
   if (queue_scratch_.main_size == 0) {
-    amd_queue_.compute_tmpring_size = tmpring_size.u32All;
+    QueueDescriptor().compute_tmpring_size = tmpring_size.u32All;
     return;
   }
 
@@ -1838,7 +1827,7 @@ void AqlQueue::FillComputeTmpRingSize_Gfx12() {
   // For GFX11 we specify number of waves per engine instead of total
   num_waves /= agent_->properties().NumShaderBanks;
   tmpring_size.bits.WAVES = std::min(num_waves, max_scratch_waves);
-  amd_queue_.compute_tmpring_size = tmpring_size.u32All;
+  QueueDescriptor().compute_tmpring_size = tmpring_size.u32All;
 }
 
 // @brief Define the Scratch Buffer Descriptor and related parameters
@@ -1876,22 +1865,22 @@ void AqlQueue::InitScratchSRD() {
       break;
   }
 
-  // Populate flat scratch parameters in amd_queue_.
-  amd_queue_.scratch_backing_memory_location = queue_scratch_.main_queue_process_offset;
-  amd_queue_.alt_scratch_backing_memory_location = queue_scratch_.alt_queue_process_offset;
+  // Populate flat scratch parameters in QueueDescriptor().
+  QueueDescriptor().scratch_backing_memory_location = queue_scratch_.main_queue_process_offset;
+  QueueDescriptor().alt_scratch_backing_memory_location = queue_scratch_.alt_queue_process_offset;
 
   // For backwards compatibility this field records the per-lane scratch
   // for a 64 lane wavefront. If scratch was allocated for 32 lane waves
   // then the effective size for a 64 lane wave is halved.
-  amd_queue_.scratch_wave64_lane_byte_size =
+  QueueDescriptor().scratch_wave64_lane_byte_size =
       uint32_t((queue_scratch_.main_size_per_thread * queue_scratch_.main_lanes_per_wave) / 64);
 
-  amd_queue_.alt_scratch_wave64_lane_byte_size =
+  QueueDescriptor().alt_scratch_wave64_lane_byte_size =
       uint32_t((queue_scratch_.alt_size_per_thread * queue_scratch_.alt_lanes_per_wave) / 64);
 
-  amd_queue_.alt_scratch_dispatch_limit_x = queue_scratch_.alt_dispatch_limit_x;
-  amd_queue_.alt_scratch_dispatch_limit_y = queue_scratch_.alt_dispatch_limit_y;
-  amd_queue_.alt_scratch_dispatch_limit_z = queue_scratch_.alt_dispatch_limit_z;
+  QueueDescriptor().alt_scratch_dispatch_limit_x = queue_scratch_.alt_dispatch_limit_x;
+  QueueDescriptor().alt_scratch_dispatch_limit_y = queue_scratch_.alt_dispatch_limit_y;
+  QueueDescriptor().alt_scratch_dispatch_limit_z = queue_scratch_.alt_dispatch_limit_z;
 
   return;
 }
@@ -1900,7 +1889,7 @@ hsa_status_t AqlQueue::EnableGWS(int gws_slot_count) {
   uint32_t discard;
   auto status = agent_->driver().AllocQueueGWS(queue_id_, gws_slot_count, &discard);
   if (status != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
-  amd_queue_.hsa_queue.type = HSA_QUEUE_TYPE_COOPERATIVE;
+  QueueDescriptor().hsa_queue.type = HSA_QUEUE_TYPE_COOPERATIVE;
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2023, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2025, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -1762,11 +1762,11 @@ hsa_status_t GpuAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type, u
 
   if (dev_mem_queue_descriptor) {
     shared_queue = static_cast<core::SharedQueue*>(
-        finegrain_allocator()(sizeof(core::SharedQueue), core::MemoryRegion::AllocateUncached));
+        finegrain_allocator()(AqlQueue::shared_queue_size_, core::MemoryRegion::AllocateUncached));
   } else {
     shared_queue =
         static_cast<core::SharedQueue*>(core::Runtime::runtime_singleton_->system_allocator()(
-            sizeof(core::SharedQueue), MemoryRegion::GetPageSize(),
+            AqlQueue::shared_queue_size_, MemoryRegion::GetPageSize(),
             isMES() ? (MemoryRegion::AllocateGTTAccess | MemoryRegion::AllocateNonPaged) : 0,
             node_id()));
   }
@@ -1782,7 +1782,7 @@ hsa_status_t GpuAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type, u
     // Calculate index of the queue doorbell within the doorbell aperture.
     auto doorbell_addr = uintptr_t(aql_queue->signal_.hardware_doorbell_ptr);
     auto doorbell_idx = (doorbell_addr >> 3) & (MAX_NUM_DOORBELLS - 1);
-    doorbell_queue_map_[doorbell_idx] = &aql_queue->amd_queue_;
+    doorbell_queue_map_[doorbell_idx] = &aql_queue->QueueDescriptor();
   }
 
   scratchGuard.Dismiss();
@@ -2266,10 +2266,11 @@ void GpuAgent::BindTrapHandler() {
     AssembleShader("TrapHandler", AssembleTarget::ISA, trap_code_buf_, trap_code_buf_size_);
 
     // Make an empty map from doorbell index to queue.
-    // The trap handler uses this to retrieve a wave's amd_queue_v2_t*.
-    auto doorbell_queue_map_size = MAX_NUM_DOORBELLS * sizeof(amd_queue_v2_t*);
+    // The trap handler uses this to retrieve a wave's queue descriptor*.
+    auto doorbell_queue_map_size = MAX_NUM_DOORBELLS * sizeof(AqlQueue::QueueDescriptorT*);
 
-    doorbell_queue_map_ = (amd_queue_v2_t**)system_allocator()(doorbell_queue_map_size, 0x1000, 0);
+    doorbell_queue_map_ =
+        (AqlQueue::QueueDescriptorT**)system_allocator()(doorbell_queue_map_size, 0x1000, 0);
     assert(doorbell_queue_map_ != NULL && "Doorbell queue map allocation failed");
 
     memset(doorbell_queue_map_, 0, doorbell_queue_map_size);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/host_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/host_queue.cpp
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2025, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -71,22 +71,19 @@ HostQueue::HostQueue(core::SharedQueue* shared_queue, hsa_region_t region, uint3
     (((AqlPacket*)ring_)[pkt_id]).dispatch.header = HSA_PACKET_TYPE_INVALID;
   }
 
-  amd_queue_.hsa_queue.base_address = ring_;
-  amd_queue_.hsa_queue.size = size_;
-  amd_queue_.hsa_queue.doorbell_signal = doorbell_signal;
-  amd_queue_.hsa_queue.id = this->GetQueueId();
-  amd_queue_.hsa_queue.type = type;
-  amd_queue_.hsa_queue.features = features;
+  QueueDescriptor().hsa_queue.base_address = ring_;
+  QueueDescriptor().hsa_queue.size = size_;
+  QueueDescriptor().hsa_queue.doorbell_signal = doorbell_signal;
+  QueueDescriptor().hsa_queue.id = this->GetQueueId();
+  QueueDescriptor().hsa_queue.type = type;
+  QueueDescriptor().hsa_queue.features = features;
 #ifdef HSA_LARGE_MODEL
-  AMD_HSA_BITS_SET(
-      amd_queue_.queue_properties, AMD_QUEUE_PROPERTIES_IS_PTR64, 1);
+  AMD_HSA_BITS_SET(QueueDescriptor().queue_properties, AMD_QUEUE_PROPERTIES_IS_PTR64, 1);
 #else
-  AMD_HSA_BITS_SET(
-      amd_queue_.queue_properties, AMD_QUEUE_PROPERTIES_IS_PTR64, 0);
+  AMD_HSA_BITS_SET(QueueDescriptor().queue_properties, AMD_QUEUE_PROPERTIES_IS_PTR64, 0);
 #endif
-  amd_queue_.write_dispatch_id = amd_queue_.read_dispatch_id = 0;
-  AMD_HSA_BITS_SET(
-      amd_queue_.queue_properties, AMD_QUEUE_PROPERTIES_ENABLE_PROFILING, 0);
+  QueueDescriptor().write_dispatch_id = QueueDescriptor().read_dispatch_id = 0;
+  AMD_HSA_BITS_SET(QueueDescriptor().queue_properties, AMD_QUEUE_PROPERTIES_ENABLE_PROFILING, 0);
 
   bufferGuard.Dismiss();
   registerGuard.Dismiss();

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
@@ -112,7 +112,7 @@ bool InterceptQueue::IsPendingRetryPoint(uint64_t wrapped_current_read_index) co
 }
 
 InterceptQueue::InterceptQueue(std::unique_ptr<Queue> queue)
-    : QueueProxy(std::move(queue)),
+    : QueueWrapper(std::move(queue)),
       LocalSignal(0, false),
       DoorbellSignal(signal()),
       next_packet_(0),

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2014-2025, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -119,17 +119,18 @@ InterceptQueue::InterceptQueue(std::unique_ptr<Queue> queue)
       retry_index_(0),
       quit_(false),
       active_(true) {
+  wrapped->SetInterceptQueueReadIndex(*shared_queue_, read_dispatch_id);
   // Initial retry_index_ value must ensure that
   // InterceptQueue::IsPendingRetryPoint will return false before the first
   // retry barrier packet is inserted.
   assert(!IsPendingRetryPoint(next_packet_) &&
          "Packet intercept error: initial retry index is incompatible with IsPendingRetryPoint.\n");
-  buffer_ = SharedArray<AqlPacket, 4096>(wrapped->amd_queue_.hsa_queue.size);
-  amd_queue_.hsa_queue.base_address = reinterpret_cast<void*>(&buffer_[0]);
+  buffer_ = SharedArray<AqlPacket, 4096>(wrapped->GetSharedQueue().hsa_interface_queue.size);
+  shared_queue_->hsa_interface_queue.base_address = reinterpret_cast<void*>(&buffer_[0]);
 
   // Fill the ring buffer with invalid packet headers.
   // Leave packet content uninitialized to help trigger application errors.
-  for (uint32_t pkt_id = 0; pkt_id < wrapped->amd_queue_.hsa_queue.size; ++pkt_id) {
+  for (uint32_t pkt_id = 0; pkt_id < wrapped->GetSharedQueue().hsa_interface_queue.size; ++pkt_id) {
     buffer_[pkt_id].packet.header = HSA_PACKET_TYPE_INVALID;
   }
 
@@ -142,7 +143,7 @@ InterceptQueue::InterceptQueue(std::unique_ptr<Queue> queue)
     async_doorbell_ = new InterruptSignal(DOORBELL_MAX);
   MAKE_NAMED_SCOPE_GUARD(sigGuard, [&]() { async_doorbell_->DestroySignal(); });
   this->signal_ = async_doorbell_->signal_;
-  amd_queue_.hsa_queue.doorbell_signal = Signal::Convert(this);
+  shared_queue_->hsa_interface_queue.doorbell_signal = Signal::Convert(this);
 
   // Install an async handler for device side dispatches.
   auto err = Runtime::runtime_singleton_->SetAsyncSignalHandler(
@@ -215,13 +216,14 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
     if (IsInterceptMarkerPacket(&packets[i])) ++marker_count;
   }
 
-  AqlPacket* ring = reinterpret_cast<AqlPacket*>(wrapped->amd_queue_.hsa_queue.base_address);
-  uint64_t mask = wrapped->amd_queue_.hsa_queue.size - 1;
+  AqlPacket* ring =
+      reinterpret_cast<AqlPacket*>(wrapped->GetSharedQueue().hsa_interface_queue.base_address);
+  uint64_t mask = wrapped->GetSharedQueue().hsa_interface_queue.size - 1;
 
   while (true) {
     uint64_t write = wrapped->LoadWriteIndexRelaxed();
     uint64_t read = wrapped->LoadReadIndexRelaxed();
-    uint64_t free_slots = wrapped->amd_queue_.hsa_queue.size - (write - read);
+    uint64_t free_slots = wrapped->GetSharedQueue().hsa_interface_queue.size - (write - read);
     bool pending_retry_point = IsPendingRetryPoint(read);
 
     uint64_t submitted_count = count - marker_count;
@@ -230,7 +232,7 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
     // can never submit them all at once. So submit what will fit, leaving one
     // slot free for the retry barrier packet if it is not already on the
     // queue.
-    if (submitted_count >= wrapped->amd_queue_.hsa_queue.size) {
+    if (submitted_count >= wrapped->GetSharedQueue().hsa_interface_queue.size) {
       submitted_count = free_slots - (pending_retry_point ? 0 : 1);
     }
 
@@ -267,7 +269,8 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
       atomic::Store(&ring[barrier & mask].barrier_and.header, kBarrierHeader,
                     std::memory_order_release);
       // Update the wrapped queue's doorbell so it knows there is a new packet in the queue.
-      HSA::hsa_signal_store_screlease(wrapped->amd_queue_.hsa_queue.doorbell_signal, barrier);
+      HSA::hsa_signal_store_screlease(wrapped->GetSharedQueue().hsa_interface_queue.doorbell_signal,
+                                      barrier);
 
       // Record the retry point
       retry_index_ = barrier;
@@ -288,7 +291,7 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
         if (IsInterceptMarkerPacket(&packets[packets_index])) {
           const amd_aql_intercept_marker_t* marker_packet =
               reinterpret_cast<const amd_aql_intercept_marker_t*>(&packets[packets_index]);
-          marker_packet->callback(marker_packet, &wrapped->amd_queue_.hsa_queue,
+          marker_packet->callback(marker_packet, &wrapped->GetSharedQueue().hsa_interface_queue,
                                   write + write_index);
         } else {
           if (write_index == 0) {
@@ -313,8 +316,8 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
         }
         atomic::Store(&ring[write & mask].packet.header, packets[first_written_packet_index].packet.header,
                       std::memory_order_release);
-        HSA::hsa_signal_store_screlease(wrapped->amd_queue_.hsa_queue.doorbell_signal,
-                                        write + write_index - 1);
+        HSA::hsa_signal_store_screlease(
+            wrapped->GetSharedQueue().hsa_interface_queue.doorbell_signal, write + write_index - 1);
       }
       return packets_index;
     }
@@ -350,8 +353,8 @@ void InterceptQueue::StoreRelaxed(hsa_signal_value_t value) {
 
   Cursor.queue = this;
 
-  AqlPacket* ring = reinterpret_cast<AqlPacket*>(amd_queue_.hsa_queue.base_address);
-  uint64_t mask = wrapped->amd_queue_.hsa_queue.size - 1;
+  AqlPacket* ring = reinterpret_cast<AqlPacket*>(shared_queue_->hsa_interface_queue.base_address);
+  uint64_t mask = wrapped->GetSharedQueue().hsa_interface_queue.size - 1;
 
   // Loop over valid packets and process.
   uint64_t end = LoadWriteIndexAcquire();
@@ -359,8 +362,8 @@ void InterceptQueue::StoreRelaxed(hsa_signal_value_t value) {
   // Can only process packets that are occupying slots in the queue buffer. No
   // need to add a barrier packet to ensure the extra packets are processed as
   // the producer must ring the doorbell once the extra packets are made valid.
-  if (end > next_packet_ + amd_queue_.hsa_queue.size)
-    end = next_packet_ + amd_queue_.hsa_queue.size;
+  if (end > next_packet_ + shared_queue_->hsa_interface_queue.size)
+    end = next_packet_ + shared_queue_->hsa_interface_queue.size;
 
   uint64_t i = next_packet_;
   while (i < end) {
@@ -397,7 +400,7 @@ void InterceptQueue::StoreRelaxed(hsa_signal_value_t value) {
 
   next_packet_ = i;
   Cursor.queue = nullptr;
-  atomic::Store(&amd_queue_.read_dispatch_id, next_packet_, std::memory_order_release);
+  atomic::Store(read_dispatch_id, next_packet_, std::memory_order_release);
 }
 
 hsa_status_t InterceptQueue::GetInfo(hsa_queue_info_attribute_t attribute, void* value) {


### PR DESCRIPTION
Add a union to the SharedQueue so different HSA queue implementations can be stored in core::Queue. This will be used to support other queue types, such as the AIE queue which currently uses the amd_queue_v2_t queue descriptor.

## Motivation

Generalizes the core::Queue so it can be used to back non amd_queue_v2_t queue descriptors. amd_queue_v2_t is AMD GPU specific.

The specific queue implementations (e.g., AQL queue) are also generalized so that their queue descriptor type is typedefed.

## Technical Details

Made the SharedQueue use a union that holds the amd_queue_v2_t descriptor. Other queue implementations (e.g., AIE) can add their specific descriptor implementation inside this union.

core::Queue now holds a std::variant with the various queue descriptor types available to make use of the queue descriptor in core C++ a safe union.

## Test Plan

Test various applications in rocm-examples.

## Test Result

Can succesfully run rocm-example applications.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
