### PR TITLE
Change amd_smi and cpu_freq modules to use trace cache for rocpd

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.cpp
@@ -42,7 +42,7 @@ namespace trace_cache
 namespace
 {
 constexpr auto CACHE_FILE_FLUSH_TIMEOUT = 10ms;
-constexpr auto NUM_OF_THREADS = 1;
+constexpr auto NUM_OF_THREADS           = 1;
 }  // namespace
 
 buffer_storage::buffer_storage(pid_t _pid)

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.hpp
@@ -83,7 +83,7 @@ public:
             else if constexpr(std::is_same_v<std::decay_t<Type>, std::vector<uint8_t>>)
             {
                 len                              = val.size() + sizeof(size_t);
-                *reinterpret_cast<size_t*>(dest) = val.size();
+                *reinterpret_cast<size_t*>(dest) = static_cast<size_t>(val.size());
                 std::memcpy(dest + sizeof(size_t), val.data(), val.size());
             }
             else

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.hpp
@@ -82,8 +82,9 @@ public:
             }
             else if constexpr(std::is_same_v<std::decay_t<Type>, std::vector<uint8_t>>)
             {
-                len                              = val.size() + sizeof(size_t);
-                *reinterpret_cast<size_t*>(dest) = static_cast<size_t>(val.size());
+                size_t elem_count = val.size();
+                len               = elem_count + sizeof(size_t);
+                std::memcpy(dest, &elem_count, sizeof(size_t));
                 std::memcpy(dest + sizeof(size_t), val.data(), val.size());
             }
             else

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/buffer_storage.hpp
@@ -26,6 +26,7 @@
 #include "PTL/ThreadPool.hh"
 #include "cache_utility.hpp"
 #include "sample_type.hpp"
+#include <PTL/PTL.hh>
 #include <cassert>
 #include <condition_variable>
 #include <cstdlib>
@@ -37,7 +38,6 @@
 #include <string.h>
 #include <thread>
 #include <type_traits>
-#include <PTL/PTL.hh>
 #include <unistd.h>
 
 namespace rocprofsys
@@ -63,7 +63,8 @@ public:
 
         constexpr bool is_supported_type = (supported_types::is_supported<T> && ...);
         static_assert(is_supported_type, "Supported types are const char*, char*, "
-                                         "unsigned long, unsigned int, and int.");
+                                         "unsigned long, unsigned int, long, unsigned "
+                                         "char, std::vector<unsigned char> and int.");
 
         auto   arg_size        = get_size(values...);
         auto   total_size      = arg_size + sizeof(type) + sizeof(size_t);
@@ -78,6 +79,12 @@ public:
             {
                 len = strlen(val) + 1;
                 std::memcpy(dest, val, len);
+            }
+            else if constexpr(std::is_same_v<std::decay_t<Type>, std::vector<uint8_t>>)
+            {
+                len                              = val.size() + sizeof(size_t);
+                *reinterpret_cast<size_t*>(dest) = val.size();
+                std::memcpy(dest + sizeof(size_t), val.data(), val.size());
             }
             else
             {
@@ -110,7 +117,8 @@ private:
             (std::is_same_v<std::decay_t<T>, Types> || ...);
     };
 
-    using supported_types = typelist<const char*, char*, uint64_t, int32_t, uint32_t>;
+    using supported_types = typelist<const char*, char*, uint64_t, int32_t, uint32_t,
+                                     std::vector<uint8_t>, uint8_t, int64_t>;
 
     template <typename T>
     static constexpr bool is_string_literal_v =
@@ -129,6 +137,10 @@ private:
             }
             return ++size;
         }
+        else if constexpr(std::is_same_v<std::decay_t<T>, std::vector<uint8_t>>)
+        {
+            return val.size() + sizeof(size_t);
+        }
         else
         {
             return sizeof(T);
@@ -144,18 +156,18 @@ private:
     }
 
 private:
-    std::mutex                      m_mutex;
-    std::condition_variable         m_exit_condition;
-    bool                            m_exit_finished{ false };
-    bool                            m_running{ true };
-    std::condition_variable         m_shutdown_condition;
+    std::mutex              m_mutex;
+    std::condition_variable m_exit_condition;
+    bool                    m_exit_finished{ false };
+    bool                    m_running{ true };
+    std::condition_variable m_shutdown_condition;
 
-    std::unique_ptr<PTL::ThreadPool>m_thread_pool;
+    std::unique_ptr<PTL::ThreadPool>      m_thread_pool;
     std::unique_ptr<PTL::TaskGroup<void>> m_task_group;
-    size_t                          m_head{ 0 };
-    size_t                          m_tail{ 0 };
-    std::unique_ptr<buffer_array_t> m_buffer{ std::make_unique<buffer_array_t>() };
-    pid_t                           m_created_process;
+    size_t                                m_head{ 0 };
+    size_t                                m_tail{ 0 };
+    std::unique_ptr<buffer_array_t>       m_buffer{ std::make_unique<buffer_array_t>() };
+    pid_t                                 m_created_process;
 };
 
 }  // namespace trace_cache

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/metadata_registry.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/metadata_registry.hpp
@@ -24,6 +24,7 @@
 
 #include "common/synchronized.hpp"
 #include "core/agent.hpp"
+#include "core/categories.hpp"
 
 #include <cassert>
 #include <cstdint>
@@ -53,6 +54,19 @@ struct process
     pid_t       ppid;
     std::string command;
 };
+
+template <typename Category>
+inline std::string
+annotate_category(std::optional<int> first_section  = std::nullopt,
+                  std::optional<int> second_section = std::nullopt)
+{
+    std::stringstream ss;
+    ss << std::string(tim::trait::name<Category>::value);
+    if(first_section) ss << "_" << std::to_string(*first_section);
+    if(second_section) ss << "_" << std::to_string(*second_section);
+    return ss.str();
+}
+
 struct pmc
 {
     agent_type  type;
@@ -107,6 +121,20 @@ struct thread
         return lhs.thread_id < rhs.thread_id;
     }
 };
+
+template <typename Category>
+inline std::string
+annotate_with_device_id(uint32_t           device_id,
+                        std::optional<int> first_section  = std::nullopt,
+                        std::optional<int> second_section = std::nullopt)
+{
+    std::stringstream ss;
+    ss << std::string(tim::trait::name<Category>::value) + " [" +
+              std::to_string(device_id) + "]";
+    if(first_section) ss << "_" << std::to_string(*first_section);
+    if(second_section) ss << "_" << std::to_string(*second_section);
+    return ss.str();
+}
 
 struct track
 {

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/metadata_registry.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/metadata_registry.hpp
@@ -36,6 +36,7 @@
 #    include <rocprofiler-sdk/cxx/name_info.hpp>
 #endif
 #include <set>
+#include <sstream>
 #include <stdint.h>
 #include <string.h>
 #include <string>

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.cpp
@@ -517,6 +517,77 @@ rocpd_post_processing::get_amd_smi_sample_callback() const
         }
     };
 }
+postprocessing_callback
+rocpd_post_processing::get_cpu_freq_sample_callback() const
+{
+    struct core_freq_sample
+    {
+        size_t id;
+        float  value;
+    };
+
+    auto deserialize_freqs = [](std::vector<uint8_t>& data) {
+        std::vector<core_freq_sample> result;
+        size_t                        offset = 0;
+
+        while(offset != data.size())
+        {
+            core_freq_sample core_sample;
+            core_sample.id = *reinterpret_cast<size_t*>(data.data() + offset);
+            offset += sizeof(size_t);
+            core_sample.value = *reinterpret_cast<float*>(data.data() + offset);
+            offset += sizeof(float);
+            result.push_back(core_sample);
+        }
+        return result;
+    };
+
+    return [&](const storage_parsed_type_base& parsed) {
+        auto _cpu_freq_sample = static_cast<const struct cpu_freq_sample&>(parsed);
+
+        auto&       data_processor   = get_data_processor();
+        const auto* _name            = trait::name<category::cpu_freq>::value;
+        auto        name_primary_key = data_processor.insert_string(_name);
+        auto        event_id = data_processor.insert_event(name_primary_key, 0, 0, 0);
+
+        auto device_id = 0;
+
+        auto& agent_mngr = agent_manager::get_instance();
+        auto  base_id =
+            agent_mngr.get_agent_by_type_index(device_id, agent_type::CPU).base_id;
+
+        auto insert_event_and_sample = [&](const char* name, double value) {
+            data_processor.insert_pmc_event(event_id, base_id, name, value);
+            data_processor.insert_sample(name, _cpu_freq_sample.timestamp, event_id);
+        };
+
+        insert_event_and_sample(trait::name<category::process_page>::value,
+                                _cpu_freq_sample.page_rss);
+        insert_event_and_sample(trait::name<category::process_virt>::value,
+                                _cpu_freq_sample.virt_mem_usage);
+        insert_event_and_sample(trait::name<category::process_peak>::value,
+                                _cpu_freq_sample.peak_rss);
+        insert_event_and_sample(trait::name<category::process_context_switch>::value,
+                                _cpu_freq_sample.context_switch_count);
+        insert_event_and_sample(trait::name<category::process_page_fault>::value,
+                                _cpu_freq_sample.page_faults);
+        insert_event_and_sample(trait::name<category::process_user_mode_time>::value,
+                                _cpu_freq_sample.user_mode_time);
+        insert_event_and_sample(trait::name<category::process_kernel_mode_time>::value,
+                                _cpu_freq_sample.kernel_mode_time);
+
+        auto get_track_name = [](const auto& cpu_id) {
+            return std::string(trait::name<category::cpu_freq>::value) + " [" +
+                   std::to_string(cpu_id) + "]";
+        };
+
+        auto core_freq_samples = deserialize_freqs(_cpu_freq_sample.freqs);
+        for(const auto& core : core_freq_samples)
+        {
+            insert_event_and_sample(get_track_name(core.id).c_str(), core.value);
+        }
+    };
+}
 
 rocpd_post_processing::rocpd_post_processing(metadata_registry& md)
 : m_metadata(md)
@@ -544,6 +615,8 @@ rocpd_post_processing::register_parser_callback([[maybe_unused]] storage_parser&
                                   get_pmc_event_with_sample_callback());
     parser.register_type_callback(entry_type::amd_smi_sample,
                                   get_amd_smi_sample_callback());
+    parser.register_type_callback(entry_type::cpu_freq_sample,
+                                  get_cpu_freq_sample_callback());
     ROCPROFSYS_DEBUG("Buffer parser callbacks are registered..");
 #endif
 }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.cpp
@@ -33,6 +33,7 @@
 #include "trace_cache/storage_parser.hpp"
 #include <cstdint>
 #include <limits>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <timemory/utility/demangle.hpp>
@@ -384,43 +385,43 @@ rocpd_post_processing::get_amd_smi_sample_callback() const
         std::vector<uint16_t> jpeg_busy;
     };
 
-    auto deserialize_xcp_metrics = [](const std::vector<uint8_t>& buffer) {
-        std::vector<xcp_metrics_t> metrics_vec;
-        size_t                     offset = 0;
+    auto deserialize_xcp_metrics = [](const std::vector<uint8_t>& data,
+                                      xcp_metrics_t&              result) {
+        constexpr size_t elem_size = sizeof(uint16_t) / sizeof(uint8_t);
 
-        auto read_size_t = [&](size_t& out) {
-            std::memcpy(&out, buffer.data() + offset, sizeof(size_t));
-            offset += sizeof(size_t);
-        };
+        size_t  offset    = 0;
+        uint8_t vcn_size  = 0;
+        uint8_t jpeg_size = 0;
 
-        auto read_uint16_t = [&](uint16_t& out) {
-            std::memcpy(&out, buffer.data() + offset, sizeof(uint16_t));
-            offset += sizeof(uint16_t);
-        };
+        vcn_size = *(data.data() + offset);
+        offset++;
+        offset += vcn_size * elem_size;
 
-        size_t root_size = 0;
-        read_size_t(root_size);
+        jpeg_size = *(data.data() + offset);
 
-        for(size_t i = 0; i < root_size; ++i)
+        if(data.size() != (2 + ((vcn_size + jpeg_size) * elem_size)))
         {
-            xcp_metrics_t metrics;
-
-            size_t vcn_size = 0;
-            read_size_t(vcn_size);
-            metrics.vcn_busy.resize(vcn_size);
-            for(size_t j = 0; j < vcn_size; ++j)
-                read_uint16_t(metrics.vcn_busy[j]);
-
-            size_t jpeg_size = 0;
-            read_size_t(jpeg_size);
-            metrics.jpeg_busy.resize(jpeg_size);
-            for(size_t j = 0; j < jpeg_size; ++j)
-                read_uint16_t(metrics.jpeg_busy[j]);
-
-            metrics_vec.push_back(std::move(metrics));
+            throw std::invalid_argument("XCP metric data is corrupted");
         }
 
-        return metrics_vec;
+        result.vcn_busy.resize(vcn_size);
+        result.jpeg_busy.resize(jpeg_size);
+
+        const auto* vcn_data  = data.data() + 1;
+        const auto* jpeg_data = data.data() + 2 + vcn_size;
+
+        for(size_t i = 0; i < vcn_size; ++i)
+        {
+            result.vcn_busy[i] = static_cast<uint8_t>(*vcn_data) |
+                                 (static_cast<uint8_t>(*(vcn_data + 1)) << 8);
+            vcn_data += elem_size;
+        }
+        for(size_t i = 0; i < jpeg_size; ++i)
+        {
+            result.jpeg_busy[i] = static_cast<uint8_t>(*jpeg_data) |
+                                  (static_cast<uint8_t>(*(jpeg_data + 1)) << 8);
+            jpeg_data += elem_size;
+        }
     };
 
     return [&](const storage_parsed_type_base& parsed) {
@@ -449,9 +450,9 @@ rocpd_post_processing::get_amd_smi_sample_callback() const
         bool           is_temp_enabled = settings_bits.test(static_cast<int>(pos::temp));
         bool is_power_enabled          = settings_bits.test(static_cast<int>(pos::power));
         bool is_mem_usage_enabled = settings_bits.test(static_cast<int>(pos::mem_usage));
-        bool is_vnc_jpeg_enabled =
-            settings_bits.test(static_cast<int>(pos::vcn_activity)) ||
-            settings_bits.test(static_cast<int>(pos::jpeg_activity));
+
+        bool is_vcn_enabled  = settings_bits.test(static_cast<int>(pos::vcn_activity));
+        bool is_jpeg_enabled = settings_bits.test(static_cast<int>(pos::jpeg_activity));
 
         insert_event_and_sample(is_busy_enabled,
                                 trait::name<category::amd_smi_gfx_busy>::value,
@@ -472,6 +473,48 @@ rocpd_post_processing::get_amd_smi_sample_callback() const
         insert_event_and_sample(is_mem_usage_enabled,
                                 trait::name<category::amd_smi_memory_usage>::value,
                                 _amd_smi.mem_usage);
+
+        if(is_vcn_enabled || is_jpeg_enabled)
+        {
+            xcp_metrics_t xcp_metrics;
+            deserialize_xcp_metrics(_amd_smi.xcp_activity, xcp_metrics);
+
+            if(is_vcn_enabled)
+            {
+                for(size_t clk = 0; clk < xcp_metrics.vcn_busy.size(); ++clk)
+                {
+                    const auto value = xcp_metrics.vcn_busy[clk];
+                    if(value == std::numeric_limits<uint16_t>::max())
+                    {
+                        continue;
+                    }
+
+                    std::stringstream ss;
+                    ss << trait::name<category::amd_smi_vcn_activity>::value;
+                    ss << "_" << std::to_string(clk);
+
+                    insert_event_and_sample(is_vcn_enabled, ss.str().c_str(), value);
+                }
+            }
+
+            if(is_jpeg_enabled)
+            {
+                for(size_t clk = 0; clk < xcp_metrics.jpeg_busy.size(); ++clk)
+                {
+                    const auto value = xcp_metrics.jpeg_busy[clk];
+                    if(value == std::numeric_limits<uint16_t>::max())
+                    {
+                        continue;
+                    }
+
+                    std::stringstream ss;
+                    ss << trait::name<category::amd_smi_jpeg_activity>::value;
+                    ss << "_" << std::to_string(clk);
+
+                    insert_event_and_sample(is_jpeg_enabled, ss.str().c_str(), value);
+                }
+            }
+        }
     };
 }
 

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.cpp
@@ -413,25 +413,25 @@ rocpd_post_processing::get_amd_smi_sample_callback() const
         }
 
         auto deserialize_uint16_array = [](const std::vector<uint8_t>& data,
-                                           size_t& offset, int array_size) {
-            std::vector<uint16_t> result;
-            result.reserve(array_size);
+                                           size_t& _offset, int array_size) {
+            std::vector<uint16_t> _result;
+            _result.reserve(array_size);
 
             for(int i = 0; i < array_size; ++i)
             {
-                if(offset + 1 >= data.size())
+                if(_offset + 1 >= data.size())
                 {
                     throw std::runtime_error(
                         "Invalid serialized data: unexpected end of data");
                 }
 
-                uint16_t value = static_cast<uint16_t>(data[offset]) |
-                                 (static_cast<uint16_t>(data[offset + 1]) << 8);
-                result.push_back(value);
-                offset += 2;
+                uint16_t value = static_cast<uint16_t>(data[_offset]) |
+                                 (static_cast<uint16_t>(data[_offset + 1]) << 8);
+                _result.push_back(value);
+                _offset += 2;
             }
 
-            return result;
+            return _result;
         };
 
         result.reserve(chunk_count);

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.cpp
@@ -375,6 +375,106 @@ rocpd_post_processing::get_pmc_event_with_sample_callback() const
     };
 }
 
+postprocessing_callback
+rocpd_post_processing::get_amd_smi_sample_callback() const
+{
+    struct xcp_metrics_t
+    {
+        std::vector<uint16_t> vcn_busy;
+        std::vector<uint16_t> jpeg_busy;
+    };
+
+    auto deserialize_xcp_metrics = [](const std::vector<uint8_t>& buffer) {
+        std::vector<xcp_metrics_t> metrics_vec;
+        size_t                     offset = 0;
+
+        auto read_size_t = [&](size_t& out) {
+            std::memcpy(&out, buffer.data() + offset, sizeof(size_t));
+            offset += sizeof(size_t);
+        };
+
+        auto read_uint16_t = [&](uint16_t& out) {
+            std::memcpy(&out, buffer.data() + offset, sizeof(uint16_t));
+            offset += sizeof(uint16_t);
+        };
+
+        size_t root_size = 0;
+        read_size_t(root_size);
+
+        for(size_t i = 0; i < root_size; ++i)
+        {
+            xcp_metrics_t metrics;
+
+            size_t vcn_size = 0;
+            read_size_t(vcn_size);
+            metrics.vcn_busy.resize(vcn_size);
+            for(size_t j = 0; j < vcn_size; ++j)
+                read_uint16_t(metrics.vcn_busy[j]);
+
+            size_t jpeg_size = 0;
+            read_size_t(jpeg_size);
+            metrics.jpeg_busy.resize(jpeg_size);
+            for(size_t j = 0; j < jpeg_size; ++j)
+                read_uint16_t(metrics.jpeg_busy[j]);
+
+            metrics_vec.push_back(std::move(metrics));
+        }
+
+        return metrics_vec;
+    };
+
+    return [&](const storage_parsed_type_base& parsed) {
+        auto _amd_smi = static_cast<const struct amd_smi_sample&>(parsed);
+
+        auto& data_processor = get_data_processor();
+
+        const auto* _name            = trait::name<category::amd_smi>::value;
+        auto        name_primary_key = data_processor.insert_string(_name);
+        auto        event_id = data_processor.insert_event(name_primary_key, 0, 0, 0);
+
+        auto& _agent_manager = agent_manager::get_instance();
+        auto  base_id =
+            _agent_manager.get_agent_by_type_index(_amd_smi.device_id, agent_type::GPU)
+                .base_id;
+
+        auto insert_event_and_sample = [&](bool enabled, const char* name, double value) {
+            if(!enabled) return;
+            data_processor.insert_pmc_event(event_id, base_id, name, value);
+            data_processor.insert_sample(name, _amd_smi.timestamp, event_id);
+        };
+
+        using pos = trace_cache::amd_smi_sample::settings_positions;
+        std::bitset<8> settings_bits(_amd_smi.settings);
+        bool           is_busy_enabled = settings_bits.test(static_cast<int>(pos::busy));
+        bool           is_temp_enabled = settings_bits.test(static_cast<int>(pos::temp));
+        bool is_power_enabled          = settings_bits.test(static_cast<int>(pos::power));
+        bool is_mem_usage_enabled = settings_bits.test(static_cast<int>(pos::mem_usage));
+        bool is_vnc_jpeg_enabled =
+            settings_bits.test(static_cast<int>(pos::vcn_activity)) ||
+            settings_bits.test(static_cast<int>(pos::jpeg_activity));
+
+        insert_event_and_sample(is_busy_enabled,
+                                trait::name<category::amd_smi_gfx_busy>::value,
+                                _amd_smi.gfx_activity);
+        insert_event_and_sample(is_busy_enabled,
+                                trait::name<category::amd_smi_umc_busy>::value,
+                                _amd_smi.umc_activity);
+        insert_event_and_sample(is_busy_enabled,
+                                trait::name<category::amd_smi_mm_busy>::value,
+                                _amd_smi.mm_activity);
+        insert_event_and_sample(is_temp_enabled,
+                                trait::name<category::amd_smi_temp>::value,
+                                _amd_smi.temperature);
+
+        insert_event_and_sample(is_power_enabled,
+                                trait::name<category::amd_smi_power>::value,
+                                _amd_smi.power);
+        insert_event_and_sample(is_mem_usage_enabled,
+                                trait::name<category::amd_smi_memory_usage>::value,
+                                _amd_smi.mem_usage);
+    };
+}
+
 rocpd_post_processing::rocpd_post_processing(metadata_registry& md)
 : m_metadata(md)
 {}
@@ -399,6 +499,8 @@ rocpd_post_processing::register_parser_callback([[maybe_unused]] storage_parser&
                                   get_in_time_sample_callback());
     parser.register_type_callback(entry_type::pmc_event_with_sample,
                                   get_pmc_event_with_sample_callback());
+    parser.register_type_callback(entry_type::amd_smi_sample,
+                                  get_amd_smi_sample_callback());
     ROCPROFSYS_DEBUG("Buffer parser callbacks are registered..");
 #endif
 }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.cpp
@@ -572,16 +572,16 @@ rocpd_post_processing::get_cpu_freq_sample_callback() const
         float  value;
     };
 
-    auto deserialize_freqs = [](std::vector<uint8_t>& data) {
+    auto deserialize_freqs = [](std::vector<uint8_t>& buffer) {
         std::vector<core_freq_sample> result;
         size_t                        offset = 0;
 
-        while(offset + sizeof(float) + sizeof(size_t) <= data.size())
+        while(offset + sizeof(float) + sizeof(size_t) <= buffer.size())
         {
             core_freq_sample core_sample;
-            core_sample.id = *reinterpret_cast<size_t*>(data.data() + offset);
+            std::memcpy(&core_sample.id, buffer.data() + offset, sizeof(size_t));
             offset += sizeof(size_t);
-            core_sample.value = *reinterpret_cast<float*>(data.data() + offset);
+            std::memcpy(&core_sample.value, buffer.data() + offset, sizeof(float));
             offset += sizeof(float);
             result.push_back(core_sample);
         }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.cpp
@@ -385,42 +385,65 @@ rocpd_post_processing::get_amd_smi_sample_callback() const
         std::vector<uint16_t> jpeg_busy;
     };
 
-    auto deserialize_xcp_metrics = [](const std::vector<uint8_t>& data,
-                                      xcp_metrics_t&              result) {
-        constexpr size_t elem_size = sizeof(uint16_t) / sizeof(uint8_t);
-
-        size_t  offset    = 0;
-        uint8_t vcn_size  = 0;
-        uint8_t jpeg_size = 0;
-
-        vcn_size = *(data.data() + offset);
-        offset++;
-        offset += vcn_size * elem_size;
-
-        jpeg_size = *(data.data() + offset);
-
-        if(data.size() != (2 + ((vcn_size + jpeg_size) * elem_size)))
+    auto deserialize_xcp_metrics = [](const std::vector<uint8_t>& serialized_data,
+                                      bool& _is_vcn_supported, bool& _is_jpeg_supported,
+                                      std::vector<xcp_metrics_t>& result) {
+        if(serialized_data.size() < 5)
         {
-            throw std::invalid_argument("XCP metric data is corrupted");
+            throw std::runtime_error("Invalid serialized data: insufficient header size");
         }
 
-        result.vcn_busy.resize(vcn_size);
-        result.jpeg_busy.resize(jpeg_size);
+        size_t offset = 0;
 
-        const auto* vcn_data  = data.data() + 1;
-        const auto* jpeg_data = data.data() + 2 + vcn_size;
+        // Read header
+        _is_vcn_supported   = static_cast<bool>(serialized_data[offset++]);
+        _is_jpeg_supported  = static_cast<bool>(serialized_data[offset++]);
+        uint8_t chunk_count = serialized_data[offset++];
+        uint8_t vcn_count   = serialized_data[offset++];
+        uint8_t jpeg_count  = serialized_data[offset++];
 
-        for(size_t i = 0; i < vcn_size; ++i)
+        constexpr size_t elem_size  = sizeof(uint16_t) / sizeof(uint8_t);
+        const size_t     chunk_size = (vcn_count + jpeg_count) * elem_size;
+
+        // Validate total size
+        const size_t expected_size = 5 + (chunk_count * chunk_size);
+        if(serialized_data.size() != expected_size)
         {
-            result.vcn_busy[i] = static_cast<uint8_t>(*vcn_data) |
-                                 (static_cast<uint8_t>(*(vcn_data + 1)) << 8);
-            vcn_data += elem_size;
+            throw std::runtime_error("Invalid serialized data: size mismatch");
         }
-        for(size_t i = 0; i < jpeg_size; ++i)
+
+        auto deserialize_uint16_array = [](const std::vector<uint8_t>& data,
+                                           size_t& offset, int array_size) {
+            std::vector<uint16_t> result;
+            result.reserve(array_size);
+
+            for(int i = 0; i < array_size; ++i)
+            {
+                if(offset + 1 >= data.size())
+                {
+                    throw std::runtime_error(
+                        "Invalid serialized data: unexpected end of data");
+                }
+
+                uint16_t value = static_cast<uint16_t>(data[offset]) |
+                                 (static_cast<uint16_t>(data[offset + 1]) << 8);
+                result.push_back(value);
+                offset += 2;
+            }
+
+            return result;
+        };
+
+        result.reserve(chunk_count);
+
+        for(size_t count = 0; count < chunk_count; ++count)
         {
-            result.jpeg_busy[i] = static_cast<uint8_t>(*jpeg_data) |
-                                  (static_cast<uint8_t>(*(jpeg_data + 1)) << 8);
-            jpeg_data += elem_size;
+            xcp_metrics_t entry;
+            entry.vcn_busy = deserialize_uint16_array(serialized_data, offset, vcn_count);
+            entry.jpeg_busy =
+                deserialize_uint16_array(serialized_data, offset, jpeg_count);
+
+            result.emplace_back(std::move(entry));
         }
     };
 
@@ -438,10 +461,11 @@ rocpd_post_processing::get_amd_smi_sample_callback() const
             _agent_manager.get_agent_by_type_index(_amd_smi.device_id, agent_type::GPU)
                 .base_id;
 
-        auto insert_event_and_sample = [&](bool enabled, const char* name, double value) {
+        auto insert_event_and_sample = [&](bool enabled, const char* pmc_name,
+                                           const char* track_name, double value) {
             if(!enabled) return;
-            data_processor.insert_pmc_event(event_id, base_id, name, value);
-            data_processor.insert_sample(name, _amd_smi.timestamp, event_id);
+            data_processor.insert_pmc_event(event_id, base_id, pmc_name, value);
+            data_processor.insert_sample(track_name, _amd_smi.timestamp, event_id);
         };
 
         using pos = trace_cache::amd_smi_sample::settings_positions;
@@ -454,69 +478,91 @@ rocpd_post_processing::get_amd_smi_sample_callback() const
         bool is_vcn_enabled  = settings_bits.test(static_cast<int>(pos::vcn_activity));
         bool is_jpeg_enabled = settings_bits.test(static_cast<int>(pos::jpeg_activity));
 
-        insert_event_and_sample(is_busy_enabled,
-                                trait::name<category::amd_smi_gfx_busy>::value,
-                                _amd_smi.gfx_activity);
-        insert_event_and_sample(is_busy_enabled,
-                                trait::name<category::amd_smi_umc_busy>::value,
-                                _amd_smi.umc_activity);
-        insert_event_and_sample(is_busy_enabled,
-                                trait::name<category::amd_smi_mm_busy>::value,
-                                _amd_smi.mm_activity);
-        insert_event_and_sample(is_temp_enabled,
-                                trait::name<category::amd_smi_temp>::value,
-                                _amd_smi.temperature);
+        insert_event_and_sample(
+            is_busy_enabled, trait::name<category::amd_smi_gfx_busy>::value,
+            info::annotate_with_device_id<category::amd_smi_gfx_busy>(_amd_smi.device_id)
+                .c_str(),
+            _amd_smi.gfx_activity);
+        insert_event_and_sample(
+            is_busy_enabled, trait::name<category::amd_smi_umc_busy>::value,
+            info::annotate_with_device_id<category::amd_smi_umc_busy>(_amd_smi.device_id)
+                .c_str(),
+            _amd_smi.umc_activity);
+        insert_event_and_sample(
+            is_busy_enabled, trait::name<category::amd_smi_mm_busy>::value,
+            info::annotate_with_device_id<category::amd_smi_mm_busy>(_amd_smi.device_id)
+                .c_str(),
+            _amd_smi.mm_activity);
+        insert_event_and_sample(
+            is_temp_enabled, trait::name<category::amd_smi_temp>::value,
+            info::annotate_with_device_id<category::amd_smi_temp>(_amd_smi.device_id)
+                .c_str(),
+            _amd_smi.temperature);
 
-        insert_event_and_sample(is_power_enabled,
-                                trait::name<category::amd_smi_power>::value,
-                                _amd_smi.power);
-        insert_event_and_sample(is_mem_usage_enabled,
-                                trait::name<category::amd_smi_memory_usage>::value,
-                                _amd_smi.mem_usage);
+        insert_event_and_sample(
+            is_power_enabled, trait::name<category::amd_smi_power>::value,
+            info::annotate_with_device_id<category::amd_smi_power>(_amd_smi.device_id)
+                .c_str(),
+            _amd_smi.power);
+        insert_event_and_sample(
+            is_mem_usage_enabled, trait::name<category::amd_smi_memory_usage>::value,
+            info::annotate_with_device_id<category::amd_smi_memory_usage>(
+                _amd_smi.device_id)
+                .c_str(),
+            _amd_smi.mem_usage);
 
-        if(is_vcn_enabled || is_jpeg_enabled)
+        if(!is_vcn_enabled && !is_jpeg_enabled)
         {
-            xcp_metrics_t xcp_metrics;
-            deserialize_xcp_metrics(_amd_smi.xcp_activity, xcp_metrics);
+            return;
+        }
 
-            if(is_vcn_enabled)
+        std::vector<xcp_metrics_t> xcp_metrics;
+        bool                       is_vcn_activity_supported;
+        bool                       is_jpeg_activity_supported;
+        deserialize_xcp_metrics(_amd_smi.xcp_activity, is_vcn_activity_supported,
+                                is_jpeg_activity_supported, xcp_metrics);
+
+        auto insert_xcp_metrics = [&](auto category, bool _is_enabled,
+                                      const std::vector<uint16_t>& data,
+                                      std::optional<size_t>        _idx = std::nullopt) {
+            if(!_is_enabled)
             {
-                for(size_t clk = 0; clk < xcp_metrics.vcn_busy.size(); ++clk)
-                {
-                    const auto value = xcp_metrics.vcn_busy[clk];
-                    if(value == std::numeric_limits<uint16_t>::max())
-                    {
-                        continue;
-                    }
-
-                    std::stringstream ss;
-                    ss << trait::name<category::amd_smi_vcn_activity>::value;
-                    ss << "_" << std::to_string(clk);
-
-                    insert_event_and_sample(is_vcn_enabled, ss.str().c_str(), value);
-                }
+                return;
             }
 
-            if(is_jpeg_enabled)
+            using Category = std::decay_t<decltype(category)>;
+
+            for(size_t clk = 0; clk < data.size(); ++clk)
             {
-                for(size_t clk = 0; clk < xcp_metrics.jpeg_busy.size(); ++clk)
+                const auto value = data[clk];
+                if(value == std::numeric_limits<uint16_t>::max())
                 {
-                    const auto value = xcp_metrics.jpeg_busy[clk];
-                    if(value == std::numeric_limits<uint16_t>::max())
-                    {
-                        continue;
-                    }
-
-                    std::stringstream ss;
-                    ss << trait::name<category::amd_smi_jpeg_activity>::value;
-                    ss << "_" << std::to_string(clk);
-
-                    insert_event_and_sample(is_jpeg_enabled, ss.str().c_str(), value);
+                    continue;
                 }
+
+                auto pmc_name   = info::annotate_category<Category>(_idx, clk);
+                auto track_name = info::annotate_with_device_id<Category>(
+                    _amd_smi.device_id, _idx, clk);
+
+                insert_event_and_sample(_is_enabled, pmc_name.c_str(), track_name.c_str(),
+                                        value);
             }
+        };
+
+        for(size_t idx = 0; idx < xcp_metrics.size(); ++idx)
+        {
+            auto dimension =
+                xcp_metrics.size() == 1 ? std::nullopt : std::make_optional<size_t>(idx);
+
+            insert_xcp_metrics(category::amd_smi_vcn_activity{}, is_vcn_enabled,
+                               xcp_metrics[idx].vcn_busy, dimension);
+
+            insert_xcp_metrics(category::amd_smi_jpeg_activity{}, is_jpeg_enabled,
+                               xcp_metrics[idx].jpeg_busy, dimension);
         }
     };
 }
+
 postprocessing_callback
 rocpd_post_processing::get_cpu_freq_sample_callback() const
 {
@@ -530,7 +576,7 @@ rocpd_post_processing::get_cpu_freq_sample_callback() const
         std::vector<core_freq_sample> result;
         size_t                        offset = 0;
 
-        while(offset != data.size())
+        while(offset + sizeof(float) + sizeof(size_t) <= data.size())
         {
             core_freq_sample core_sample;
             core_sample.id = *reinterpret_cast<size_t*>(data.data() + offset);

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.hpp
@@ -53,6 +53,7 @@ private:
     postprocessing_callback get_in_time_sample_callback() const;
     postprocessing_callback get_pmc_event_with_sample_callback() const;
     postprocessing_callback get_amd_smi_sample_callback() const;
+    postprocessing_callback get_cpu_freq_sample_callback() const;
 
     metadata_registry& m_metadata;
 };

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_post_processing.hpp
@@ -52,6 +52,7 @@ private:
     postprocessing_callback get_region_callback() const;
     postprocessing_callback get_in_time_sample_callback() const;
     postprocessing_callback get_pmc_event_with_sample_callback() const;
+    postprocessing_callback get_amd_smi_sample_callback() const;
 
     metadata_registry& m_metadata;
 };

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
@@ -197,7 +197,7 @@ struct amd_smi_sample : storage_parsed_type_base
         jpeg_activity
     };
 
-    size_t               settings;
+    uint64_t             settings;  // bitfield
     uint32_t             device_id;
     size_t               timestamp;
     uint32_t             gfx_activity;

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
@@ -21,10 +21,13 @@
 // SOFTWARE.
 
 #pragma once
+#include <cstdint>
 #include <stdint.h>
 #include <string>
 #include <unistd.h>
 #include <utility>
+#include <variant>
+#include <vector>
 
 #if ROCPROFSYS_USE_ROCM > 0
 #    include <rocprofiler-sdk/version.h>
@@ -182,6 +185,30 @@ struct pmc_event_with_sample : in_time_sample
     size_t      value;
 };
 
+struct amd_smi_sample : storage_parsed_type_base
+{
+    enum class settings_positions : uint8_t
+    {
+        busy = 0,
+        temp,
+        power,
+        mem_usage,
+        vcn_activity,
+        jpeg_activity
+    };
+
+    size_t               settings;
+    uint32_t             device_id;
+    size_t               timestamp;
+    uint32_t             gfx_activity;
+    uint32_t             umc_activity;
+    uint32_t             mm_activity;
+    uint32_t             power;
+    int64_t              temperature;
+    size_t               mem_usage;
+    std::vector<uint8_t> xcp_activity;
+};
+
 enum class entry_type : uint32_t
 {
     in_time_sample        = 0x0000,
@@ -192,6 +219,7 @@ enum class entry_type : uint32_t
 #if(ROCPROFSYS_USE_ROCM && ROCPROFILER_VERSION >= 600)
     memory_alloc = 0x0005,
 #endif
+    amd_smi_sample   = 0x0006,
     fragmented_space = 0xFFFF
 };
 }  // namespace trace_cache

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_type.hpp
@@ -209,6 +209,19 @@ struct amd_smi_sample : storage_parsed_type_base
     std::vector<uint8_t> xcp_activity;
 };
 
+struct cpu_freq_sample : storage_parsed_type_base
+{
+    size_t               timestamp;
+    int64_t              page_rss;
+    int64_t              virt_mem_usage;
+    int64_t              peak_rss;
+    int64_t              context_switch_count;
+    int64_t              page_faults;
+    int64_t              user_mode_time;
+    int64_t              kernel_mode_time;
+    std::vector<uint8_t> freqs;
+};
+
 enum class entry_type : uint32_t
 {
     in_time_sample        = 0x0000,
@@ -220,6 +233,7 @@ enum class entry_type : uint32_t
     memory_alloc = 0x0005,
 #endif
     amd_smi_sample   = 0x0006,
+    cpu_freq_sample  = 0x0007,
     fragmented_space = 0xFFFF
 };
 }  // namespace trace_cache

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser.cpp
@@ -212,6 +212,19 @@ storage_parser::consume_storage()
                            _amd_smi_sample.temperature, _amd_smi_sample.mem_usage,
                            _amd_smi_sample.xcp_activity);
                 invoke_callbacks(header.type, _amd_smi_sample);
+                break;
+            }
+            case entry_type::cpu_freq_sample:
+            {
+                cpu_freq_sample _cpu_freq_sample;
+                parse_data(sample.data(), _cpu_freq_sample.timestamp,
+                           _cpu_freq_sample.page_rss, _cpu_freq_sample.virt_mem_usage,
+                           _cpu_freq_sample.peak_rss,
+                           _cpu_freq_sample.context_switch_count,
+                           _cpu_freq_sample.page_faults, _cpu_freq_sample.user_mode_time,
+                           _cpu_freq_sample.kernel_mode_time, _cpu_freq_sample.freqs);
+                invoke_callbacks(header.type, _cpu_freq_sample);
+                break;
             }
             default: break;
         }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser.cpp
@@ -23,6 +23,7 @@
 #include "storage_parser.hpp"
 #include "debug.hpp"
 #include "trace_cache/sample_type.hpp"
+#include <cstdint>
 #include <cstdio>
 #include <fstream>
 #include <sstream>
@@ -200,6 +201,17 @@ storage_parser::consume_storage()
                     _pmc_event_with_sample.pmc_info_name, _pmc_event_with_sample.value);
                 invoke_callbacks(header.type, _pmc_event_with_sample);
                 break;
+            }
+            case entry_type::amd_smi_sample:
+            {
+                amd_smi_sample _amd_smi_sample;
+                parse_data(sample.data(), _amd_smi_sample.settings,
+                           _amd_smi_sample.device_id, _amd_smi_sample.timestamp,
+                           _amd_smi_sample.gfx_activity, _amd_smi_sample.umc_activity,
+                           _amd_smi_sample.mm_activity, _amd_smi_sample.power,
+                           _amd_smi_sample.temperature, _amd_smi_sample.mem_usage,
+                           _amd_smi_sample.xcp_activity);
+                invoke_callbacks(header.type, _amd_smi_sample);
             }
             default: break;
         }

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser.hpp
@@ -28,6 +28,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <functional>
+#include <iterator>
 #include <map>
 #include <rocprofiler-systems/categories.h>
 #include <stdint.h>
@@ -65,7 +66,7 @@ private:
             size_t vector_size = *reinterpret_cast<const size_t*>(data_pos);
             data_pos += sizeof(size_t);
             arg.reserve(vector_size);
-            std::memcpy(arg.data(), data_pos, vector_size);
+            std::copy_n(data_pos, vector_size, std::back_inserter(arg));
             data_pos += vector_size;
         }
         else

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/storage_parser.hpp
@@ -60,6 +60,14 @@ private:
             arg = std::string((const char*) data_pos);
             data_pos += arg.size() + 1;
         }
+        else if constexpr(std::is_same_v<T, std::vector<uint8_t>>)
+        {
+            size_t vector_size = *reinterpret_cast<const size_t*>(data_pos);
+            data_pos += sizeof(size_t);
+            arg.reserve(vector_size);
+            std::memcpy(arg.data(), data_pos, vector_size);
+            data_pos += vector_size;
+        }
         else
         {
             arg = *reinterpret_cast<const T*>(data_pos);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -30,6 +30,7 @@
 #include "core/trace_cache/cache_manager.hpp"
 #include "core/trace_cache/cache_utility.hpp"
 #include "core/trace_cache/sample_type.hpp"
+#include <amd_smi/amdsmi.h>
 #if defined(NDEBUG)
 #    undef NDEBUG
 #endif
@@ -75,19 +76,6 @@ using sampler_instances = thread_data<bundle_t, category::amd_smi>;
 
 namespace
 {
-int64_t
-get_tid()
-{
-    static thread_local auto _v = threading::get_id();
-    return _v;
-}
-
-rocpd::data_processor&
-get_data_processor()
-{
-    return rocpd::data_processor::get_instance();
-}
-
 void
 metadata_initialize_category()
 {
@@ -112,6 +100,24 @@ metadata_initialize_smi_tracks()
         { trait::name<category::amd_smi_temp>::value, thread_id, "{}" });
     trace_cache::get_metadata_registry().add_track(
         { trait::name<category::amd_smi_memory_usage>::value, thread_id, "{}" });
+
+    for(auto clk = 0; clk < AMDSMI_MAX_NUM_VCN; ++clk)
+    {
+        std::stringstream name_ss;
+        name_ss << trait::name<category::amd_smi_vcn_activity>::value;
+        name_ss << "_" << std::to_string(clk);
+        trace_cache::get_metadata_registry().add_track(
+            { name_ss.str(), thread_id, "{}" });
+    }
+
+    for(auto clk = 0; clk < AMDSMI_MAX_NUM_JPEG; ++clk)
+    {
+        std::stringstream name_ss;
+        name_ss << trait::name<category::amd_smi_jpeg_activity>::value;
+        name_ss << "_" << std::to_string(clk);
+        trace_cache::get_metadata_registry().add_track(
+            { name_ss.str(), thread_id, "{}" });
+    }
 }
 
 void
@@ -167,39 +173,40 @@ metadata_initialize_smi_pmc(size_t gpu_id)
           trait::name<category::amd_smi_memory_usage>::description, LONG_DESCRIPTION,
           COMPONENT, tim::units::mem_repr(tim::units::megabyte),
           rocprofsys::trace_cache::ABSOLUTE, BLOCK, EXPRESSION, 0, 0 });
-}
 
-void
-rocpd_process_smi_pmc_events(const uint32_t device_id, const amd_smi::settings& settings,
-                             uint64_t timestamp, double busy, double temp, double power,
-                             double usage)
-{
-    if(!(settings.busy || settings.temp || settings.power || settings.mem_usage)) return;
+    for(auto clk = 0; clk < AMDSMI_MAX_NUM_VCN; ++clk)
+    {
+        std::stringstream name_ss;
+        name_ss << trait::name<category::amd_smi_vcn_activity>::value;
+        name_ss << "_" << std::to_string(clk);
 
-    auto& data_processor = get_data_processor();
+        std::stringstream symbol_ss;
+        symbol_ss << "VcnAct" << "_" << std::to_string(clk);
 
-    const auto* _name            = trait::name<category::amd_smi>::value;
-    auto        name_primary_key = data_processor.insert_string(_name);
-    auto        event_id         = data_processor.insert_event(name_primary_key, 0, 0, 0);
+        trace_cache::get_metadata_registry().add_pmc_info(
+            { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+              name_ss.str(), symbol_ss.str(),
+              trait::name<category::amd_smi_vcn_activity>::description, LONG_DESCRIPTION,
+              COMPONENT, trace_cache::PERCENTAGE, rocprofsys::trace_cache::ABSOLUTE,
+              BLOCK, EXPRESSION, 0, 0 });
+    }
 
-    auto& _agent_manager = agent_manager::get_instance();
-    auto  base_id =
-        _agent_manager.get_agent_by_type_index(device_id, agent_type::GPU).base_id;
+    for(auto clk = 0; clk < AMDSMI_MAX_NUM_JPEG; ++clk)
+    {
+        std::stringstream name_ss;
+        name_ss << trait::name<category::amd_smi_jpeg_activity>::value;
+        name_ss << "_" << std::to_string(clk);
 
-    auto insert_event_and_sample = [&](bool enabled, const char* name, double value) {
-        if(!enabled) return;
-        data_processor.insert_pmc_event(event_id, base_id, name, value);
-        data_processor.insert_sample(name, timestamp, event_id);
-    };
+        std::stringstream symbol_ss;
+        symbol_ss << "JpegAct" << "_" << std::to_string(clk);
 
-    insert_event_and_sample(settings.busy, trait::name<category::amd_smi_mm_busy>::value,
-                            busy);
-    insert_event_and_sample(settings.temp, trait::name<category::amd_smi_temp>::value,
-                            temp);
-    insert_event_and_sample(settings.power, trait::name<category::amd_smi_power>::value,
-                            power);
-    insert_event_and_sample(settings.mem_usage,
-                            trait::name<category::amd_smi_memory_usage>::value, usage);
+        trace_cache::get_metadata_registry().add_pmc_info(
+            { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+              name_ss.str(), symbol_ss.str(),
+              trait::name<category::amd_smi_jpeg_activity>::description, LONG_DESCRIPTION,
+              COMPONENT, trace_cache::PERCENTAGE, rocprofsys::trace_cache::ABSOLUTE,
+              BLOCK, EXPRESSION, 0, 0 });
+    }
 }
 
 auto&
@@ -262,40 +269,64 @@ get_state()
 }
 
 std::vector<uint8_t>
-serialize_xcp_metrics(const std::vector<data::xcp_metrics_t>& metrics_vec)
+serialize_xcp_metrics(const amdsmi_gpu_metrics_t& gpu_metrics)
 {
-    size_t total_size = sizeof(size_t);  // for root vector size
-    for(const auto& metrics : metrics_vec)
+    constexpr size_t vcn_count  = AMDSMI_MAX_NUM_VCN;
+    constexpr size_t jpeg_count = AMDSMI_MAX_NUM_JPEG;
+    constexpr size_t elem_size  = sizeof(uint16_t) / sizeof(uint8_t);
+    constexpr size_t total_size = 2 + ((vcn_count + jpeg_count) * elem_size);
+    // (size of vcn + size of jpeg) (2) + ((count of elements in vcn + count of elements
+    // in jpeg) * element store size)
+
+    std::vector<uint8_t> result;
+    result.reserve(total_size);
+
+    result.push_back(static_cast<uint8_t>(vcn_count));
+
+    for(const auto& val : gpu_metrics.vcn_activity)
     {
-        total_size += sizeof(size_t) + metrics.vcn_busy.size() * sizeof(uint16_t);
-        total_size += sizeof(size_t) + metrics.jpeg_busy.size() * sizeof(uint16_t);
+        result.push_back(static_cast<uint8_t>(val & 0xFF));
+        result.push_back(static_cast<uint8_t>((val >> 8) & 0xFF));
     }
 
-    std::vector<uint8_t> buffer;
-    buffer.reserve(total_size);
+    result.push_back(static_cast<uint8_t>(jpeg_count));
 
-    size_t offset = 0;
-    auto   append = [&](auto value) {
-        size_t sz = sizeof(value);
-        std::memcpy(buffer.data() + offset, &value, sz);
-        offset += sz;
-    };
-
-    append(static_cast<size_t>(metrics_vec.size()));
-
-    for(const auto& metrics : metrics_vec)
+    for(const auto& val : gpu_metrics.jpeg_activity)
     {
-        append(static_cast<size_t>(metrics.vcn_busy.size()));
-        for(uint16_t v : metrics.vcn_busy)
-            append(v);
-
-        append(static_cast<size_t>(metrics.jpeg_busy.size()));
-        for(uint16_t j : metrics.jpeg_busy)
-            append(j);
+        result.push_back(static_cast<uint8_t>(val & 0xFF));
+        result.push_back(static_cast<uint8_t>((val >> 8) & 0xFF));
     }
 
-    return buffer;
+    return result;
 }
+
+size_t
+serialize_settings(uint32_t _device_id)
+{
+    auto           settings = get_settings(_device_id);
+    std::bitset<8> settings_bits;
+    settings_bits.reset();
+    settings_bits.set(
+        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::busy),
+        settings.busy);
+    settings_bits.set(
+        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::temp),
+        settings.power);
+    settings_bits.set(
+        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::power),
+        settings.temp);
+    settings_bits.set(
+        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::mem_usage),
+        settings.mem_usage);
+    settings_bits.set(
+        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::vcn_activity),
+        settings.vcn_activity);
+    settings_bits.set(
+        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::jpeg_activity),
+        settings.jpeg_activity);
+    return settings_bits.to_ulong();
+}
+
 }  // namespace
 
 //--------------------------------------------------------------------------------------//
@@ -411,35 +442,11 @@ data::sample(uint32_t _device_id)
     }
 #undef ROCPROFSYS_AMDSMI_GET
 
-    // write settings also
-
-    auto           settings = get_settings(m_dev_id);
-    std::bitset<8> settings_bits;
-    settings_bits.reset();
-    settings_bits.set(
-        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::busy),
-        settings.busy);
-    settings_bits.set(
-        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::temp),
-        settings.power);
-    settings_bits.set(
-        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::power),
-        settings.temp);
-    settings_bits.set(
-        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::mem_usage),
-        settings.mem_usage);
-    settings_bits.set(
-        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::vcn_activity),
-        settings.vcn_activity);
-    settings_bits.set(
-        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::jpeg_activity),
-        settings.jpeg_activity);
-
     trace_cache::get_buffer_storage().store(
-        trace_cache::entry_type::amd_smi_sample, settings_bits.to_ulong(), _device_id,
+        trace_cache::entry_type::amd_smi_sample, serialize_settings(m_dev_id), _device_id,
         _timestamp, m_busy_perc.gfx_activity, m_busy_perc.umc_activity,
         m_busy_perc.mm_activity, m_power.current_socket_power, m_temp, m_mem_usage,
-        serialize_xcp_metrics(m_xcp_metrics));
+        serialize_xcp_metrics(_gpu_metrics));
 }
 
 void

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -335,7 +335,7 @@ get_state()
 }
 
 std::vector<uint8_t>
-serialize_xcp_metrics(const bool& is_vcn_supported, const bool& is_jpeg_supported,
+serialize_xcp_metrics(const bool& use_vcn_activity, const bool& use_jpeg_activity,
                       const amdsmi_gpu_metrics_t& gpu_metrics)
 {
     // Chunk:
@@ -373,14 +373,14 @@ serialize_xcp_metrics(const bool& is_vcn_supported, const bool& is_jpeg_supporte
 
     std::vector<uint8_t> result;
 
-    const bool   is_vcn_jpeg_supporetd = (is_vcn_supported || is_jpeg_supported);
-    const size_t chunk_count           = is_vcn_jpeg_supporetd ? 1 : xcp_count;
+    const bool   is_vcn_jpeg_supported = (use_vcn_activity || use_jpeg_activity);
+    const size_t chunk_count           = is_vcn_jpeg_supported ? 1 : xcp_count;
     const size_t total_size = serialized_data_headers + (chunk_count * chunk_size);
 
     result.reserve(total_size);
 
-    result.push_back((uint8_t) is_vcn_supported);
-    result.push_back((uint8_t) is_jpeg_supported);
+    result.push_back((uint8_t) use_vcn_activity);
+    result.push_back((uint8_t) use_jpeg_activity);
     result.push_back(chunk_count);
     result.push_back(vcn_count);
     result.push_back(jpeg_count);
@@ -388,10 +388,10 @@ serialize_xcp_metrics(const bool& is_vcn_supported, const bool& is_jpeg_supporte
     for(size_t count = 0; count < chunk_count; ++count)
     {
         const auto* vcn_data =
-            (is_vcn_jpeg_supporetd ? gpu_metrics.vcn_activity
+            (is_vcn_jpeg_supported ? gpu_metrics.vcn_activity
                                    : gpu_metrics.xcp_stats[count].vcn_busy);
         const auto* jpeg_data =
-            (is_vcn_jpeg_supporetd ? gpu_metrics.jpeg_activity
+            (is_vcn_jpeg_supported ? gpu_metrics.jpeg_activity
                                    : gpu_metrics.xcp_stats[count].jpeg_busy);
 
         serialize_uint16_array(result, vcn_data, vcn_count);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -29,6 +29,7 @@
 #include "core/agent.hpp"
 #include "core/trace_cache/cache_manager.hpp"
 #include "core/trace_cache/cache_utility.hpp"
+#include "core/trace_cache/sample_type.hpp"
 #if defined(NDEBUG)
 #    undef NDEBUG
 #endif
@@ -100,6 +101,10 @@ metadata_initialize_smi_tracks()
     const auto thread_id = std::nullopt;
 
     trace_cache::get_metadata_registry().add_track(
+        { trait::name<category::amd_smi_gfx_busy>::value, thread_id, "{}" });
+    trace_cache::get_metadata_registry().add_track(
+        { trait::name<category::amd_smi_umc_busy>::value, thread_id, "{}" });
+    trace_cache::get_metadata_registry().add_track(
         { trait::name<category::amd_smi_mm_busy>::value, thread_id, "{}" });
     trace_cache::get_metadata_registry().add_track(
         { trait::name<category::amd_smi_power>::value, thread_id, "{}" });
@@ -125,7 +130,21 @@ metadata_initialize_smi_pmc(size_t gpu_id)
 
     trace_cache::get_metadata_registry().add_pmc_info(
         { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
-          trait::name<category::amd_smi_mm_busy>::value, "Busy",
+          trait::name<category::amd_smi_gfx_busy>::value, "GFX Busy",
+          trait::name<category::amd_smi_gfx_busy>::description, LONG_DESCRIPTION,
+          COMPONENT, trace_cache::PERCENTAGE, rocprofsys::trace_cache::ABSOLUTE, BLOCK,
+          EXPRESSION, 0, 0, "{}" });
+
+    trace_cache::get_metadata_registry().add_pmc_info(
+        { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+          trait::name<category::amd_smi_umc_busy>::value, "UMC Busy",
+          trait::name<category::amd_smi_umc_busy>::description, LONG_DESCRIPTION,
+          COMPONENT, trace_cache::PERCENTAGE, rocprofsys::trace_cache::ABSOLUTE, BLOCK,
+          EXPRESSION, 0, 0, "{}" });
+
+    trace_cache::get_metadata_registry().add_pmc_info(
+        { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+          trait::name<category::amd_smi_mm_busy>::value, "MM Busy",
           trait::name<category::amd_smi_mm_busy>::description, LONG_DESCRIPTION,
           COMPONENT, trace_cache::PERCENTAGE, rocprofsys::trace_cache::ABSOLUTE, BLOCK,
           EXPRESSION, 0, 0, "{}" });
@@ -241,6 +260,42 @@ get_state()
     static std::atomic<State> _v{ State::PreInit };
     return _v;
 }
+
+std::vector<uint8_t>
+serialize_xcp_metrics(const std::vector<data::xcp_metrics_t>& metrics_vec)
+{
+    size_t total_size = sizeof(size_t);  // for root vector size
+    for(const auto& metrics : metrics_vec)
+    {
+        total_size += sizeof(size_t) + metrics.vcn_busy.size() * sizeof(uint16_t);
+        total_size += sizeof(size_t) + metrics.jpeg_busy.size() * sizeof(uint16_t);
+    }
+
+    std::vector<uint8_t> buffer;
+    buffer.reserve(total_size);
+
+    size_t offset = 0;
+    auto   append = [&](auto value) {
+        size_t sz = sizeof(value);
+        std::memcpy(buffer.data() + offset, &value, sz);
+        offset += sz;
+    };
+
+    append(static_cast<size_t>(metrics_vec.size()));
+
+    for(const auto& metrics : metrics_vec)
+    {
+        append(static_cast<size_t>(metrics.vcn_busy.size()));
+        for(uint16_t v : metrics.vcn_busy)
+            append(v);
+
+        append(static_cast<size_t>(metrics.jpeg_busy.size()));
+        for(uint16_t j : metrics.jpeg_busy)
+            append(j);
+    }
+
+    return buffer;
+}
 }  // namespace
 
 //--------------------------------------------------------------------------------------//
@@ -252,12 +307,12 @@ std::unique_ptr<data::promise_t> data::polling_finished = {};
 data::data(uint32_t _dev_id) { sample(_dev_id); }
 
 void
-data::sample(uint32_t _dev_id)
+data::sample(uint32_t _device_id)
 {
     if(is_child_process()) return;
 
-    auto _ts = tim::get_clock_real_now<size_t, std::nano>();
-    assert(_ts < std::numeric_limits<int64_t>::max());
+    auto _timestamp = tim::get_clock_real_now<size_t, std::nano>();
+    assert(_timestamp < std::numeric_limits<int64_t>::max());
     amdsmi_gpu_metrics_t _gpu_metrics;
     bool                 _vcn_or_jpeg_activity_enabled = false;
 
@@ -265,8 +320,8 @@ data::sample(uint32_t _dev_id)
 
     if(_state != State::Active) return;
 
-    m_dev_id = _dev_id;
-    m_ts     = _ts;
+    m_dev_id = _device_id;
+    m_ts     = _timestamp;
 
 #define ROCPROFSYS_AMDSMI_GET(OPTION, FUNCTION, ...)                                     \
     if(OPTION)                                                                           \
@@ -283,7 +338,7 @@ data::sample(uint32_t _dev_id)
         }                                                                                \
     }
 
-    amdsmi_processor_handle sample_handle = gpu::get_handle_from_id(_dev_id);
+    amdsmi_processor_handle sample_handle = gpu::get_handle_from_id(_device_id);
     ROCPROFSYS_AMDSMI_GET(get_settings(m_dev_id).busy, amdsmi_get_gpu_activity,
                           sample_handle, &m_busy_perc);
     ROCPROFSYS_AMDSMI_GET(get_settings(m_dev_id).temp, amdsmi_get_temp_metric,
@@ -354,8 +409,37 @@ data::sample(uint32_t _dev_id)
             }
         }
     }
-
 #undef ROCPROFSYS_AMDSMI_GET
+
+    // write settings also
+
+    auto           settings = get_settings(m_dev_id);
+    std::bitset<8> settings_bits;
+    settings_bits.reset();
+    settings_bits.set(
+        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::busy),
+        settings.busy);
+    settings_bits.set(
+        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::temp),
+        settings.power);
+    settings_bits.set(
+        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::power),
+        settings.temp);
+    settings_bits.set(
+        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::mem_usage),
+        settings.mem_usage);
+    settings_bits.set(
+        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::vcn_activity),
+        settings.vcn_activity);
+    settings_bits.set(
+        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::jpeg_activity),
+        settings.jpeg_activity);
+
+    trace_cache::get_buffer_storage().store(
+        trace_cache::entry_type::amd_smi_sample, settings_bits.to_ulong(), _device_id,
+        _timestamp, m_busy_perc.gfx_activity, m_busy_perc.umc_activity,
+        m_busy_perc.mm_activity, m_power.current_socket_power, m_temp, m_mem_usage,
+        serialize_xcp_metrics(m_xcp_metrics));
 }
 
 void
@@ -486,7 +570,6 @@ data::post_process(uint32_t _dev_id)
     auto _settings = get_settings(_dev_id);
 
     auto use_perfetto = get_use_perfetto();
-    auto use_rocpd    = get_use_rocpd();
 
     for(auto& itr : _amd_smi)
     {
@@ -660,12 +743,6 @@ data::post_process(uint32_t _dev_id)
         {
             setup_perfetto_counter_tracks();
             write_perfetto_metrics();
-        }
-
-        if(use_rocpd)
-        {
-            rocpd_process_smi_pmc_events(_dev_id, _settings, _ts, _mmbusy, _temp, _power,
-                                         _usage);
         }
     }
 }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -254,7 +254,7 @@ metadata_initialize_smi_pmc(size_t gpu_id)
     {
         add_vcn_pmc(std::nullopt);
     }
-    else if(gpu::is_vcn_busy_supported(gpu_id))
+    else
     {
         for(int xcp = 0; xcp < AMDSMI_MAX_NUM_XCP; ++xcp)
         {
@@ -266,7 +266,7 @@ metadata_initialize_smi_pmc(size_t gpu_id)
     {
         add_jpeg_pmc(std::nullopt);
     }
-    else if(gpu::is_jpeg_busy_supported(gpu_id))
+    else
     {
         for(auto xcp = 0; xcp < AMDSMI_MAX_NUM_XCP; ++xcp)
         {
@@ -601,6 +601,9 @@ void
 sample()
 {
     auto_lock_t _lk{ type_mutex<category::amd_smi>() };
+
+    // TODO: Reorganize amd_smi::data and sampling mechanism not to store same data in
+    // bundle_data and in trace_cache
 
     for(auto itr : data::device_list)
     {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -31,11 +31,11 @@
 #include "core/trace_cache/cache_utility.hpp"
 #include "core/trace_cache/sample_type.hpp"
 #include <amd_smi/amdsmi.h>
+#include <cstdint>
 #if defined(NDEBUG)
 #    undef NDEBUG
 #endif
 
-#include "core/agent_manager.hpp"
 #include "core/common.hpp"
 #include "core/components/fwd.hpp"
 #include "core/config.hpp"
@@ -43,7 +43,6 @@
 #include "core/gpu.hpp"
 #include "core/node_info.hpp"
 #include "core/perfetto.hpp"
-#include "core/rocpd/data_processor.hpp"
 #include "core/state.hpp"
 #include "core/trace_cache/metadata_registry.hpp"
 #include "library/amd_smi.hpp"
@@ -84,39 +83,72 @@ metadata_initialize_category()
 }
 
 void
-metadata_initialize_smi_tracks()
+metadata_initialize_smi_tracks(size_t gpu_id)
 {
     const auto thread_id = std::nullopt;
 
     trace_cache::get_metadata_registry().add_track(
-        { trait::name<category::amd_smi_gfx_busy>::value, thread_id, "{}" });
+        { trace_cache::info::annotate_with_device_id<category::amd_smi_gfx_busy>(gpu_id),
+          thread_id, "{}" });
     trace_cache::get_metadata_registry().add_track(
-        { trait::name<category::amd_smi_umc_busy>::value, thread_id, "{}" });
+        { trace_cache::info::annotate_with_device_id<category::amd_smi_umc_busy>(gpu_id),
+          thread_id, "{}" });
     trace_cache::get_metadata_registry().add_track(
-        { trait::name<category::amd_smi_mm_busy>::value, thread_id, "{}" });
+        { trace_cache::info::annotate_with_device_id<category::amd_smi_mm_busy>(gpu_id),
+          thread_id, "{}" });
     trace_cache::get_metadata_registry().add_track(
-        { trait::name<category::amd_smi_power>::value, thread_id, "{}" });
+        { trace_cache::info::annotate_with_device_id<category::amd_smi_power>(gpu_id),
+          thread_id, "{}" });
     trace_cache::get_metadata_registry().add_track(
-        { trait::name<category::amd_smi_temp>::value, thread_id, "{}" });
+        { trace_cache::info::annotate_with_device_id<category::amd_smi_temp>(gpu_id),
+          thread_id, "{}" });
     trace_cache::get_metadata_registry().add_track(
-        { trait::name<category::amd_smi_memory_usage>::value, thread_id, "{}" });
+        { trace_cache::info::annotate_with_device_id<category::amd_smi_memory_usage>(
+              gpu_id),
+          thread_id, "{}" });
 
-    for(auto clk = 0; clk < AMDSMI_MAX_NUM_VCN; ++clk)
+    auto add_vcn_track = [&](std::optional<int> xcp_idx) {
+        for(auto clk = 0; clk < AMDSMI_MAX_NUM_VCN; ++clk)
+        {
+            auto name = trace_cache::info::annotate_with_device_id<
+                category::amd_smi_vcn_activity>(gpu_id, xcp_idx, clk);
+            trace_cache::get_metadata_registry().add_track(
+                { name.c_str(), thread_id, "{}" });
+        }
+    };
+
+    auto add_jpeg_track = [&](std::optional<int> xcp_idx) {
+        for(auto clk = 0; clk < AMDSMI_MAX_NUM_JPEG; ++clk)
+        {
+            auto name = trace_cache::info::annotate_with_device_id<
+                category::amd_smi_jpeg_activity>(gpu_id, xcp_idx, clk);
+            trace_cache::get_metadata_registry().add_track(
+                { name.c_str(), thread_id, "{}" });
+        }
+    };
+
+    if(gpu::is_vcn_activity_supported(gpu_id))
     {
-        std::stringstream name_ss;
-        name_ss << trait::name<category::amd_smi_vcn_activity>::value;
-        name_ss << "_" << std::to_string(clk);
-        trace_cache::get_metadata_registry().add_track(
-            { name_ss.str(), thread_id, "{}" });
+        add_vcn_track(std::nullopt);
+    }
+    else
+    {
+        for(int xcp = 0; xcp < AMDSMI_MAX_NUM_XCP; ++xcp)
+        {
+            add_vcn_track(xcp);
+        }
     }
 
-    for(auto clk = 0; clk < AMDSMI_MAX_NUM_JPEG; ++clk)
+    if(gpu::is_jpeg_activity_supported(gpu_id))
     {
-        std::stringstream name_ss;
-        name_ss << trait::name<category::amd_smi_jpeg_activity>::value;
-        name_ss << "_" << std::to_string(clk);
-        trace_cache::get_metadata_registry().add_track(
-            { name_ss.str(), thread_id, "{}" });
+        add_jpeg_track(std::nullopt);
+    }
+    else
+    {
+        for(auto xcp = 0; xcp < AMDSMI_MAX_NUM_XCP; ++xcp)
+        {
+            add_jpeg_track(xcp);
+        }
     }
 }
 
@@ -174,38 +206,72 @@ metadata_initialize_smi_pmc(size_t gpu_id)
           COMPONENT, tim::units::mem_repr(tim::units::megabyte),
           rocprofsys::trace_cache::ABSOLUTE, BLOCK, EXPRESSION, 0, 0 });
 
-    for(auto clk = 0; clk < AMDSMI_MAX_NUM_VCN; ++clk)
+    auto add_vcn_pmc = [&](std::optional<int> xcp_idx) {
+        for(int clk = 0; clk < AMDSMI_MAX_NUM_VCN; ++clk)
+        {
+            std::stringstream name_ss;
+            name_ss << trait::name<category::amd_smi_vcn_activity>::value;
+            if(xcp_idx) name_ss << "_" << *xcp_idx;
+            name_ss << "_" << clk;
+
+            std::stringstream symbol_ss;
+            symbol_ss << "VcnAct";
+            if(xcp_idx) symbol_ss << "_" << *xcp_idx;
+            symbol_ss << "_" << clk;
+
+            trace_cache::get_metadata_registry().add_pmc_info(
+                { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+                  name_ss.str(), symbol_ss.str(),
+                  trait::name<category::amd_smi_vcn_activity>::description,
+                  LONG_DESCRIPTION, COMPONENT, trace_cache::PERCENTAGE,
+                  rocprofsys::trace_cache::ABSOLUTE, BLOCK, EXPRESSION, 0, 0 });
+        }
+    };
+
+    auto add_jpeg_pmc = [&](std::optional<int> xcp_idx) {
+        for(auto clk = 0; clk < AMDSMI_MAX_NUM_JPEG; ++clk)
+        {
+            std::stringstream name_ss;
+            name_ss << trait::name<category::amd_smi_jpeg_activity>::value;
+            if(xcp_idx) name_ss << "_" << *xcp_idx;
+            name_ss << "_" << std::to_string(clk);
+
+            std::stringstream symbol_ss;
+            symbol_ss << "JpegAct";
+            if(xcp_idx) symbol_ss << "_" << *xcp_idx;
+            symbol_ss << "_" << std::to_string(clk);
+
+            trace_cache::get_metadata_registry().add_pmc_info(
+                { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+                  name_ss.str(), symbol_ss.str(),
+                  trait::name<category::amd_smi_jpeg_activity>::description,
+                  LONG_DESCRIPTION, COMPONENT, trace_cache::PERCENTAGE,
+                  rocprofsys::trace_cache::ABSOLUTE, BLOCK, EXPRESSION, 0, 0 });
+        }
+    };
+
+    if(gpu::is_vcn_activity_supported(gpu_id))
     {
-        std::stringstream name_ss;
-        name_ss << trait::name<category::amd_smi_vcn_activity>::value;
-        name_ss << "_" << std::to_string(clk);
-
-        std::stringstream symbol_ss;
-        symbol_ss << "VcnAct" << "_" << std::to_string(clk);
-
-        trace_cache::get_metadata_registry().add_pmc_info(
-            { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
-              name_ss.str(), symbol_ss.str(),
-              trait::name<category::amd_smi_vcn_activity>::description, LONG_DESCRIPTION,
-              COMPONENT, trace_cache::PERCENTAGE, rocprofsys::trace_cache::ABSOLUTE,
-              BLOCK, EXPRESSION, 0, 0 });
+        add_vcn_pmc(std::nullopt);
+    }
+    else if(gpu::is_vcn_busy_supported(gpu_id))
+    {
+        for(int xcp = 0; xcp < AMDSMI_MAX_NUM_XCP; ++xcp)
+        {
+            add_vcn_pmc(xcp);
+        }
     }
 
-    for(auto clk = 0; clk < AMDSMI_MAX_NUM_JPEG; ++clk)
+    if(gpu::is_jpeg_activity_supported(gpu_id))
     {
-        std::stringstream name_ss;
-        name_ss << trait::name<category::amd_smi_jpeg_activity>::value;
-        name_ss << "_" << std::to_string(clk);
-
-        std::stringstream symbol_ss;
-        symbol_ss << "JpegAct" << "_" << std::to_string(clk);
-
-        trace_cache::get_metadata_registry().add_pmc_info(
-            { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
-              name_ss.str(), symbol_ss.str(),
-              trait::name<category::amd_smi_jpeg_activity>::description, LONG_DESCRIPTION,
-              COMPONENT, trace_cache::PERCENTAGE, rocprofsys::trace_cache::ABSOLUTE,
-              BLOCK, EXPRESSION, 0, 0 });
+        add_jpeg_pmc(std::nullopt);
+    }
+    else if(gpu::is_jpeg_busy_supported(gpu_id))
+    {
+        for(auto xcp = 0; xcp < AMDSMI_MAX_NUM_XCP; ++xcp)
+        {
+            add_jpeg_pmc(xcp);
+        }
     }
 }
 
@@ -269,32 +335,67 @@ get_state()
 }
 
 std::vector<uint8_t>
-serialize_xcp_metrics(const amdsmi_gpu_metrics_t& gpu_metrics)
+serialize_xcp_metrics(const bool& is_vcn_supported, const bool& is_jpeg_supported,
+                      const amdsmi_gpu_metrics_t& gpu_metrics)
 {
-    constexpr size_t vcn_count  = AMDSMI_MAX_NUM_VCN;
-    constexpr size_t jpeg_count = AMDSMI_MAX_NUM_JPEG;
-    constexpr size_t elem_size  = sizeof(uint16_t) / sizeof(uint8_t);
-    constexpr size_t total_size = 2 + ((vcn_count + jpeg_count) * elem_size);
-    // (size of vcn + size of jpeg) (2) + ((count of elements in vcn + count of elements
-    // in jpeg) * element store size)
+    // Chunk:
+    // <vcn_data_0>..<vcn_data_[vcn_count]> // lower and higher byte
+    // <jpeg_data_0>..<jpeg_data_[jpeg_count]> // lower and higher byte
+
+    // Serialized:
+    // <is_vcn_supported>
+    // <is_jpeg_supported>
+    // <xcp_count>
+    // <vcn_count>
+    // <jpeg_count>
+    // Chunk_0
+    // ...
+    // Chunk_[xcp_count]
+
+    constexpr uint8_t vcn_count          = AMDSMI_MAX_NUM_VCN;
+    constexpr uint8_t jpeg_count         = AMDSMI_MAX_NUM_JPEG;
+    constexpr uint8_t xcp_count          = AMDSMI_MAX_NUM_XCP;
+    constexpr size_t  elem_size          = sizeof(uint16_t) / sizeof(uint8_t);
+    constexpr uint8_t vector_size_header = sizeof(uint8_t);
+    constexpr uint8_t serialized_data_headers =
+        5 * vector_size_header;  // is_vcn_supported + is_jpeg_supported + xcp_count +
+                                 // vcn_count + jpeg_count
+    constexpr size_t chunk_size = ((vcn_count + jpeg_count) * elem_size);
+
+    auto serialize_uint16_array = [](std::vector<uint8_t>& data, const uint16_t* arr,
+                                     int array_size) {
+        for(int i = 0; i < array_size; ++i)
+        {
+            data.push_back(static_cast<uint8_t>(arr[i] & 0xFF));
+            data.push_back(static_cast<uint8_t>((arr[i] >> 8) & 0xFF));
+        }
+    };
 
     std::vector<uint8_t> result;
+
+    const bool   is_vcn_jpeg_supporetd = (is_vcn_supported || is_jpeg_supported);
+    const size_t chunk_count           = is_vcn_jpeg_supporetd ? 1 : xcp_count;
+    const size_t total_size = serialized_data_headers + (chunk_count * chunk_size);
+
     result.reserve(total_size);
 
-    result.push_back(static_cast<uint8_t>(vcn_count));
+    result.push_back((uint8_t) is_vcn_supported);
+    result.push_back((uint8_t) is_jpeg_supported);
+    result.push_back(chunk_count);
+    result.push_back(vcn_count);
+    result.push_back(jpeg_count);
 
-    for(const auto& val : gpu_metrics.vcn_activity)
+    for(size_t count = 0; count < chunk_count; ++count)
     {
-        result.push_back(static_cast<uint8_t>(val & 0xFF));
-        result.push_back(static_cast<uint8_t>((val >> 8) & 0xFF));
-    }
+        const auto* vcn_data =
+            (is_vcn_jpeg_supporetd ? gpu_metrics.vcn_activity
+                                   : gpu_metrics.xcp_stats[count].vcn_busy);
+        const auto* jpeg_data =
+            (is_vcn_jpeg_supporetd ? gpu_metrics.jpeg_activity
+                                   : gpu_metrics.xcp_stats[count].jpeg_busy);
 
-    result.push_back(static_cast<uint8_t>(jpeg_count));
-
-    for(const auto& val : gpu_metrics.jpeg_activity)
-    {
-        result.push_back(static_cast<uint8_t>(val & 0xFF));
-        result.push_back(static_cast<uint8_t>((val >> 8) & 0xFF));
+        serialize_uint16_array(result, vcn_data, vcn_count);
+        serialize_uint16_array(result, jpeg_data, jpeg_count);
     }
 
     return result;
@@ -311,10 +412,10 @@ serialize_settings(uint32_t _device_id)
         settings.busy);
     settings_bits.set(
         static_cast<int>(trace_cache::amd_smi_sample::settings_positions::temp),
-        settings.power);
+        settings.temp);
     settings_bits.set(
         static_cast<int>(trace_cache::amd_smi_sample::settings_positions::power),
-        settings.temp);
+        settings.power);
     settings_bits.set(
         static_cast<int>(trace_cache::amd_smi_sample::settings_positions::mem_usage),
         settings.mem_usage);
@@ -446,7 +547,8 @@ data::sample(uint32_t _device_id)
         trace_cache::entry_type::amd_smi_sample, serialize_settings(m_dev_id), _device_id,
         _timestamp, m_busy_perc.gfx_activity, m_busy_perc.umc_activity,
         m_busy_perc.mm_activity, m_power.current_socket_power, m_temp, m_mem_usage,
-        serialize_xcp_metrics(_gpu_metrics));
+        serialize_xcp_metrics(gpu::is_vcn_activity_supported(m_dev_id),
+                              gpu::is_jpeg_activity_supported(m_dev_id), _gpu_metrics));
 }
 
 void
@@ -487,10 +589,10 @@ config()
         data::get_initial().at(itr).sample(itr);
 
     metadata_initialize_category();
-    metadata_initialize_smi_tracks();
 
     for(const auto& _dev_id : data::device_list)
     {
+        metadata_initialize_smi_tracks(_dev_id);
         metadata_initialize_smi_pmc(_dev_id);
     }
 }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/cpu_freq.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/cpu_freq.cpp
@@ -43,6 +43,7 @@
 
 #include <cstddef>
 #include <cstdlib>
+#include <cstring>
 #include <string>
 #include <sys/resource.h>
 #include <tuple>
@@ -199,10 +200,10 @@ serialize_freqs(const component::cpu_freq& freq)
 
     size_t offset = 0;
     do_for_enabled_cpus([&](const auto& idx) {
-        auto value                                         = freq.at(idx);
-        *reinterpret_cast<size_t*>(result.data() + offset) = idx;
+        auto value = freq.at(idx);
+        std::memcpy(result.data() + offset, &idx, sizeof(size_t));
         offset += sizeof(size_t);
-        *reinterpret_cast<float*>(result.data() + offset) = value;
+        std::memcpy(result.data() + offset, &value, sizeof(float));
         offset += sizeof(float);
     });
     return result;
@@ -258,6 +259,7 @@ sample()
     auto _rcache = tim::rusage_cache{ RUSAGE_SELF };
     auto _freqs  = component::cpu_freq{}.sample();
 
+    // user and kernel mode times are in microseconds
     trace_cache::get_buffer_storage().store(
         trace_cache::entry_type::cpu_freq_sample, _timestamp, tim::get_page_rss(),
         tim::get_virt_mem(), _rcache.get_peak_rss(),
@@ -267,7 +269,6 @@ sample()
         _rcache.get_user_mode_time() * 1000, _rcache.get_kernel_mode_time() * 1000,
         serialize_freqs(_freqs));
 
-    // user and kernel mode times are in microseconds
     data.emplace_back(
         _timestamp, tim::get_page_rss(), tim::get_virt_mem(), _rcache.get_peak_rss(),
         _rcache.get_num_priority_context_switch() +

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/cpu_freq.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/cpu_freq.cpp
@@ -28,9 +28,9 @@
 #include "core/debug.hpp"
 #include "core/node_info.hpp"
 #include "core/perfetto.hpp"
-#include "core/rocpd/data_processor.hpp"
 #include "core/timemory.hpp"
 #include "core/trace_cache/cache_manager.hpp"
+#include "core/trace_cache/sample_type.hpp"
 #include "library/components/cpu_freq.hpp"
 #include "library/thread_info.hpp"
 
@@ -46,6 +46,7 @@
 #include <sys/resource.h>
 #include <tuple>
 #include <utility>
+#include <vector>
 
 namespace rocprofsys
 {
@@ -84,12 +85,6 @@ do_for_enabled_cpus(Func&& func)
     {
         func(cpu);
     }
-}
-
-rocpd::data_processor&
-get_data_processor()
-{
-    return rocpd::data_processor::get_instance();
 }
 
 void
@@ -195,41 +190,27 @@ metadata_initialize_cpu_freq_pmc(size_t dev_id)
           COMPONENT, TIME, rocprofsys::trace_cache::ABSOLUTE, BLOCK, EXPRESSION, 0, 0 });
 }
 
-void
-rocpd_process_cpu_usage_events(const uint32_t device_id, uint64_t timestamp,
-                               const component::cpu_freq& freq, double mem_page,
-                               double virt_mem_page, double peak_mem,
-                               double context_switch, double page_fault, double user_time,
-                               double kernel_time)
+std::vector<uint8_t>
+serialize_freqs(const component::cpu_freq& freq)
 {
-    auto&       data_processor   = get_data_processor();
-    const auto* _name            = trait::name<category::cpu_freq>::value;
-    auto        name_primary_key = data_processor.insert_string(_name);
-    auto        event_id         = data_processor.insert_event(name_primary_key, 0, 0, 0);
+    constexpr size_t idx_elements   = sizeof(size_t) / sizeof(uint8_t);
+    constexpr size_t value_elements = sizeof(float) / sizeof(uint8_t);
 
-    auto& agent_mngr = agent_manager::get_instance();
-    auto base_id = agent_mngr.get_agent_by_type_index(device_id, agent_type::CPU).base_id;
+    std::vector<uint8_t> result;
+    const auto enabled_cpus_size = component::cpu_freq::get_enabled_cpus().size();
+    const auto result_size       = enabled_cpus_size * (idx_elements + value_elements);
+    result.resize(result_size);
+    result.assign(result_size, 0);
 
-    auto insert_event_and_sample = [&](const char* name, double value) {
-        data_processor.insert_pmc_event(event_id, base_id, name, value);
-        data_processor.insert_sample(name, timestamp, event_id);
-    };
-
-    do_for_enabled_cpus([&](size_t cpu_id) {
-        insert_event_and_sample(
-            get_cpu_freq_track_name<category::cpu_freq>(cpu_id).c_str(), freq.at(cpu_id));
+    size_t offset = 0;
+    do_for_enabled_cpus([&](const auto& idx) {
+        auto value                                         = freq.at(idx);
+        *reinterpret_cast<size_t*>(result.data() + offset) = idx;
+        offset += sizeof(size_t);
+        *reinterpret_cast<float*>(result.data() + offset) = value;
+        offset += sizeof(float);
     });
-
-    insert_event_and_sample(trait::name<category::process_page>::value, mem_page);
-    insert_event_and_sample(trait::name<category::process_virt>::value, virt_mem_page);
-    insert_event_and_sample(trait::name<category::process_peak>::value, peak_mem);
-    insert_event_and_sample(trait::name<category::process_context_switch>::value,
-                            context_switch);
-    insert_event_and_sample(trait::name<category::process_page_fault>::value, page_fault);
-    insert_event_and_sample(trait::name<category::process_user_mode_time>::value,
-                            user_time);
-    insert_event_and_sample(trait::name<category::process_kernel_mode_time>::value,
-                            kernel_time);
+    return result;
 }
 
 }  // namespace
@@ -251,9 +232,15 @@ setup()
                       category::process_page_fault, category::process_user_mode_time,
                       category::process_kernel_mode_time>{});
     }
-
     metadata_initialize_cpu_freq_category();
     metadata_initialize_cpu_usage_tracks();
+}
+
+void
+config()
+{
+    component::cpu_freq::configure();
+
     metadata_initialize_cpu_freq_tracks();
 
     // `get_enabled_cpus()` returns the number of cores enabled for monitoring but
@@ -269,22 +256,25 @@ setup()
 }
 
 void
-config()
-{
-    component::cpu_freq::configure();
-}
-
-void
 sample()
 {
-    auto _ts = tim::get_clock_real_now<size_t, std::nano>();
+    auto _timestamp = tim::get_clock_real_now<size_t, std::nano>();
 
     auto _rcache = tim::rusage_cache{ RUSAGE_SELF };
     auto _freqs  = component::cpu_freq{}.sample();
 
+    trace_cache::get_buffer_storage().store(
+        trace_cache::entry_type::cpu_freq_sample, _timestamp, tim::get_page_rss(),
+        tim::get_virt_mem(), _rcache.get_peak_rss(),
+        _rcache.get_num_priority_context_switch() +
+            _rcache.get_num_voluntary_context_switch(),
+        _rcache.get_num_major_page_faults() + _rcache.get_num_minor_page_faults(),
+        _rcache.get_user_mode_time() * 1000, _rcache.get_kernel_mode_time() * 1000,
+        serialize_freqs(_freqs));
+
     // user and kernel mode times are in microseconds
     data.emplace_back(
-        _ts, tim::get_page_rss(), tim::get_virt_mem(), _rcache.get_peak_rss(),
+        _timestamp, tim::get_page_rss(), tim::get_virt_mem(), _rcache.get_peak_rss(),
         _rcache.get_num_priority_context_switch() +
             _rcache.get_num_voluntary_context_switch(),
         _rcache.get_num_major_page_faults() + _rcache.get_num_minor_page_faults(),
@@ -419,12 +409,6 @@ post_process()
                                                                                _user);
                 write_perfetto_counter_track<category::process_kernel_mode_time>(_ts,
                                                                                  _kern);
-            }
-            if(get_use_rocpd())
-            {
-                const auto& freq_data = std::get<8>(itr);
-                rocpd_process_cpu_usage_events(0, _ts, freq_data, _page, _virt, _peak,
-                                               _cntx, _flts, _user, _kern);
             }
         }
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/cpu_freq.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/cpu_freq.cpp
@@ -30,6 +30,7 @@
 #include "core/perfetto.hpp"
 #include "core/timemory.hpp"
 #include "core/trace_cache/cache_manager.hpp"
+#include "core/trace_cache/metadata_registry.hpp"
 #include "core/trace_cache/sample_type.hpp"
 #include "library/components/cpu_freq.hpp"
 #include "library/thread_info.hpp"
@@ -68,14 +69,6 @@ init_perfetto_counter_tracks(type_list<Types...>)
     (perfetto_counter_track<Types>::init(), ...);
 }
 
-template <typename Category>
-inline std::string
-get_cpu_freq_track_name(uint64_t cpu_id)
-{
-    return std::string(trait::name<Category>::value) + " [" + std::to_string(cpu_id) +
-           "]";
-}
-
 template <typename Func>
 void
 do_for_enabled_cpus(Func&& func)
@@ -99,8 +92,9 @@ metadata_initialize_cpu_freq_tracks()
 {
     do_for_enabled_cpus([&](size_t cpu_id) {
         trace_cache::get_metadata_registry().add_track(
-            { get_cpu_freq_track_name<category::cpu_freq>(cpu_id).c_str(), std::nullopt,
-              "{}" });
+            { trace_cache::info::annotate_with_device_id<category::cpu_freq>(cpu_id)
+                  .c_str(),
+              std::nullopt, "{}" });
     });
 }
 
@@ -141,9 +135,10 @@ metadata_initialize_cpu_freq_pmc(size_t dev_id)
     do_for_enabled_cpus([&](size_t cpu_id) {
         trace_cache::get_metadata_registry().add_pmc_info(
             { agent_type::CPU, dev_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
-              get_cpu_freq_track_name<category::cpu_freq>(cpu_id).c_str(), "Frequency",
-              trait::name<category::cpu_freq>::description, LONG_DESCRIPTION, COMPONENT,
-              component::cpu_freq::display_unit().c_str(),
+              trace_cache::info::annotate_with_device_id<category::cpu_freq>(cpu_id)
+                  .c_str(),
+              "Frequency", trait::name<category::cpu_freq>::description, LONG_DESCRIPTION,
+              COMPONENT, component::cpu_freq::display_unit().c_str(),
               rocprofsys::trace_cache::ABSOLUTE, BLOCK, EXPRESSION, 0, 0 });
     });
 


### PR DESCRIPTION
## Motivation
To change amd_smi and cpu_freq module to use trace cache mechanism. This will enable us to insert pmc data into rocpd in the postprocessing phase.

## Technical Details
- Change amd_smi to use trace_cache for storing data for rocpd
- Add VCN and JPEG activity to rocpd
- Change cpu_freq to use trace_cache for storing data for rocpd
