### PR TITLE
[Ex CI] create hip/clr/hipother trigger

### DIFF
--- a/.azuredevops/hip-clr.yml
+++ b/.azuredevops/hip-clr.yml
@@ -1,0 +1,57 @@
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+parameters:
+- name: pipelinesRepoRef
+  type: string
+  default: refs/heads/develop
+- name: triggerDownstreamJobs
+  type: boolean
+  default: true
+
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+    ref: ${{ parameters.pipelinesRepoRef }}
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - develop
+  paths:
+    include:
+    - projects/clr
+    - projects/hip
+    - projects/hipother
+    exclude:
+    - projects/clr/CODEOWNERS
+    - projects/clr/LICENCE
+    - projects/clr/**/*.md
+    - projects/hip/docs
+    - projects/hip/.github
+    - projects/hip/.jenkins
+    - projects/hip/.*.yaml
+    - projects/hip/CODEOWNERS
+    - projects/hip/Jenkinsfile
+    - projects/hip/LICENSE.txt
+    - projects/hip/**/*.md
+    - projects/hip/VERSION
+    - projects/hipother/.github
+    - projects/hipother/CODEOWNERS
+    - projects/hipother/LICENSE.txt
+    - projects/hipother/**/*.md
+
+pr: none
+
+stages:
+- stage: hip_clr
+  jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/HIP.yml@pipelines_repo
+    parameters:
+      triggerDownstreamJobs: ${{ parameters.triggerDownstreamJobs }}
+- template: templates/report-summary-check-wrapper.yml


### PR DESCRIPTION
## Motivation

Creates a trigger file for hip/clr/hipother.

## Technical Details

The old hip/clr/hipother pipelines were technically separate, but they all called the same pipeline template. This trigger file consolidates the three pipelines into one, which is triggered whenever changes are made to any of the three components.

There will only be a single `hip-clr` pipeline going forward, and other pipelines will pull artifacts from it. This also removes the need  for the copyHIP template.

No sparse checkout directory is set, since the pipeline needs all three components.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=45939&view=results

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
