### PR TITLE
[rocprofiler-sdk] Support priority negotiation between rocprofiler-sdk clients when contexts conflict

### DIFF
--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/context.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/context.h
@@ -24,6 +24,7 @@
 
 #include <rocprofiler-sdk/defines.h>
 #include <rocprofiler-sdk/fwd.h>
+#include <rocprofiler-sdk/registration.h>
 
 ROCPROFILER_EXTERN_C_INIT
 
@@ -67,6 +68,40 @@ rocprofiler_start_context(rocprofiler_context_id_t context_id) ROCPROFILER_API;
  */
 rocprofiler_status_t
 rocprofiler_stop_context(rocprofiler_context_id_t context_id) ROCPROFILER_API;
+
+/**
+ * @brief Priority service callback function.
+ *
+ * @param [in] other_client_id Other clients rocprofiler_client_id_t
+ * @param [in] current_context_id Current clients context ID
+ * @param [in] callback_data User data provided when configuring the callback tracing service
+ * @return ::rocprofiler_status_t
+ */
+typedef rocprofiler_status_t (*rocprofiler_callback_context_priority_service_t)(
+    rocprofiler_client_id_t  other_client_id,
+    rocprofiler_context_id_t current_context_id,
+    void*                    callback_data) ROCPROFILER_NONNULL(3);
+
+/**
+ * @brief Configure Context Priority Service. A service which will give you a callback if
+ * another client (i.e. tool) wants to start a context which conflicts with the context you have
+ * started -- the primary example being RDC/Omnistat is collecting HW counters for the job which
+ * would prevent the user from collecting HW counters.
+ *
+ * @param [in] context_id Context to associate the service with
+ * @param [in] callback The callback is invoked when their context is active and another
+ * client wants to start a context which cannot be started while theirs is active.
+ * This gives them an opportunity to either stop their context so the other clients context
+ * can be started or to respond that the other clients context should be blocked from starting
+ * @param [in] callback_args Data provided to every invocation of the callback function
+ * @return ::rocprofiler_status_t
+ *
+ */
+rocprofiler_status_t
+rocprofiler_configure_context_priority_service(
+    rocprofiler_context_id_t                        context_id,
+    rocprofiler_callback_context_priority_service_t callback,
+    void*                                           callback_args) ROCPROFILER_API;
 
 /**
  * @brief Query whether context is currently active.


### PR DESCRIPTION
## Motivation

New feature in rocprofiler-sdk to negotiate priorities between system monitoring tools (RDC/Omnistat/etc.) and user-level profiling tools (rocprofv3/rocprofiler-compute/rocprofiler-systems/etc.).

## Technical Details

- After you have configured your rocprofiler-sdk context, you subscribe to a service which will give you a callback if another client (i.e. tool) wants to start a context which conflicts with the context you have started -- the primary example being RDC/Omnistat is collecting HW counters for the job which would prevent the user from collecting HW counters.
- In your callback, delivered when the client calls rocprofiler_start_context, your tool get info about (A) who the other client is, (B) what service(s) their context are trying to start and which service(s) your context has which conflict.
- You tell rocprofiler-sdk (via the callback) whether you want rocprofiler-sdk to reject their request (and we will return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT to them) or whether we should stop your context and allow their context to be started
- Optionally, we will look into whether we can set something up for rocprofiler-sdk to let the user know when their (conflicting) context is stopped so you can resume your context.

## Test Plan

TBD

## Test Result

TBD

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
