### PR TITLE
rocr: Remove QueueProxy

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/intercept_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/intercept_queue.h
@@ -141,65 +141,10 @@ class QueueWrapper : public Queue {
   }
 };
 
-// @brief Generic container for a proxy queue.
-// Presents an proxy packet buffer and doorbell signal for an underlying Queue.  Write index
-// operations act on the proxy buffer while all other operations pass through to the underlying
-// queue.
-class QueueProxy : public QueueWrapper {
- public:
-  explicit QueueProxy(std::unique_ptr<Queue> queue) : QueueWrapper(std::move(queue)) {}
-
-  uint64_t LoadReadIndexAcquire() override {
-    return atomic::Load(&amd_queue_.read_dispatch_id, std::memory_order_acquire);
-  }
-  uint64_t LoadReadIndexRelaxed() override {
-    return atomic::Load(&amd_queue_.read_dispatch_id, std::memory_order_relaxed);
-  }
-  void StoreReadIndexRelaxed(uint64_t value) override { assert(false); }
-  void StoreReadIndexRelease(uint64_t value) override { assert(false); }
-
-  uint64_t LoadWriteIndexRelaxed() override {
-    return atomic::Load(&amd_queue_.write_dispatch_id, std::memory_order_relaxed);
-  }
-  uint64_t LoadWriteIndexAcquire() override {
-    return atomic::Load(&amd_queue_.write_dispatch_id, std::memory_order_acquire);
-  }
-  void StoreWriteIndexRelaxed(uint64_t value) override {
-    atomic::Store(&amd_queue_.write_dispatch_id, value, std::memory_order_relaxed);
-  }
-  void StoreWriteIndexRelease(uint64_t value) override {
-    atomic::Store(&amd_queue_.write_dispatch_id, value, std::memory_order_release);
-  }
-  uint64_t CasWriteIndexAcqRel(uint64_t expected, uint64_t value) override {
-    return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected, std::memory_order_acq_rel);
-  }
-  uint64_t CasWriteIndexAcquire(uint64_t expected, uint64_t value) override {
-    return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected, std::memory_order_acquire);
-  }
-  uint64_t CasWriteIndexRelaxed(uint64_t expected, uint64_t value) override {
-    return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected, std::memory_order_relaxed);
-  }
-  uint64_t CasWriteIndexRelease(uint64_t expected, uint64_t value) override {
-    return atomic::Cas(&amd_queue_.write_dispatch_id, value, expected, std::memory_order_release);
-  }
-  uint64_t AddWriteIndexAcqRel(uint64_t value) override {
-    return atomic::Add(&amd_queue_.write_dispatch_id, value, std::memory_order_acq_rel);
-  }
-  uint64_t AddWriteIndexAcquire(uint64_t value) override {
-    return atomic::Add(&amd_queue_.write_dispatch_id, value, std::memory_order_acquire);
-  }
-  uint64_t AddWriteIndexRelaxed(uint64_t value) override {
-    return atomic::Add(&amd_queue_.write_dispatch_id, value, std::memory_order_relaxed);
-  }
-  uint64_t AddWriteIndexRelease(uint64_t value) override {
-    return atomic::Add(&amd_queue_.write_dispatch_id, value, std::memory_order_release);
-  }
-};
-
 // @brief Provides packet intercept and rewrite capability for a queue.
 // Host-side dispatches are processed during doorbell ring.
 // Device-side dispatches are processed as an asynchronous signal event.
-class InterceptQueue : public QueueProxy, private LocalSignal, public DoorbellSignal {
+class InterceptQueue : public QueueWrapper, private LocalSignal, public DoorbellSignal {
  public:
   explicit InterceptQueue(std::unique_ptr<Queue> queue);
   ~InterceptQueue();

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
@@ -112,7 +112,7 @@ bool InterceptQueue::IsPendingRetryPoint(uint64_t wrapped_current_read_index) co
 }
 
 InterceptQueue::InterceptQueue(std::unique_ptr<Queue> queue)
-    : QueueProxy(std::move(queue)),
+    : QueueWrapper(std::move(queue)),
       LocalSignal(0, false),
       DoorbellSignal(signal()),
       next_packet_(0),


### PR DESCRIPTION
Because the base QueueWrapper class copies the wrapped queue's amd_queue_v2_t queue descriptor struct the QueueProxy seems superfluous as it will have the same effect as calling the underlying methods on the wrapped queue itself.

Additionally, because the QueueProxy needs to access the wrapped queue's queue descriptor it breaks the Queue API which is meant to abstract the underlying agent's queue implementation.

This makes it easier to generalize the core::Queue as well as the InterceptQueue.

## Motivation

Cleans up and simplifies the InterceptQueue implementation and makes it easier to generalize the core::Queue.

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
