### PR TITLE
Fix regression in hsa_amd_pointer_info for non-registered VA memory

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -929,11 +929,15 @@ Runtime::AddressHandle* Runtime::VMemoryFindReservedAddressHandle(const void* va
   auto reservedAddressIt = reserved_address_map_.upper_bound(va);
   if (reservedAddressIt != reserved_address_map_.begin()) {
     reservedAddressIt--;
-    if ((reservedAddressIt->first <= va) &&
-        ((reinterpret_cast<const uint8_t*>(va)) <=
-         (reinterpret_cast<const uint8_t*>(reservedAddressIt->first) +
-          reservedAddressIt->second.size))) {
-      return &(reservedAddressIt->second);
+
+    auto& addressHandle = reservedAddressIt->second;
+    if (!addressHandle.registered) {
+      return nullptr;
+    }
+    
+    const auto* base = reinterpret_cast<const uint8_t*>(reservedAddressIt->first);
+    if ((base <= va) && ((reinterpret_cast<const uint8_t*>(va)) <= base + addressHandle.size)) {
+      return &(addressHandle);
     }
   }
   return nullptr;


### PR DESCRIPTION
## Motivation

Fix regression after https://github.com/ROCm/rocm-systems/pull/305

## Technical Details

For HMM allocations hip runtime calls hsa_amd_vmem_address_reserve_align with HSA_AMD_VMEM_ADDRESS_NO_REGISTER flag. That inserts the address handle in the reserved_address_map_. Entries for which the registered field is false should therefore be excluded from the lookup in VMemoryPtrInfo.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
