### PR TITLE
SWDEV-549686 - Resolve memory leaks in texture unit-tests

### DIFF
--- a/projects/clr/hipamd/src/hip_texture.cpp
+++ b/projects/clr/hipamd/src/hip_texture.cpp
@@ -200,16 +200,18 @@ hipError_t ihipCreateTextureObject(hipTextureObject_t* pTexObject, const hipReso
     mipFilterMode = hip::getCLFilterMode(pTexDesc->mipmapFilterMode);
   }
 
-  amd::Sampler* sampler = new amd::Sampler(
-      *hip::getCurrentDevice()->asContext(), pTexDesc->normalizedCoords, addressMode, filterMode,
-      mipFilterMode, pTexDesc->minMipmapLevelClamp, pTexDesc->maxMipmapLevelClamp);
+  auto sampler_deleter = [](amd::Sampler* s) { s->release(); };
+  std::unique_ptr<amd::Sampler, decltype(sampler_deleter)> sampler(
+      new amd::Sampler(*hip::getCurrentDevice()->asContext(), pTexDesc->normalizedCoords,
+                       addressMode, filterMode, mipFilterMode, pTexDesc->minMipmapLevelClamp,
+                       pTexDesc->maxMipmapLevelClamp),
+      sampler_deleter);
 
-  if (sampler == nullptr) {
+  if (sampler.get() == nullptr) {
     return hipErrorOutOfMemory;
   }
 
-  if (!sampler->create()) {
-    delete sampler;
+  if (!sampler.get()->create()) {
     return hipErrorOutOfMemory;
   }
 
@@ -370,7 +372,7 @@ hipError_t ihipCreateTextureObject(hipTextureObject_t* pTexObject, const hipReso
     return hipErrorOutOfMemory;
   }
   *pTexObject = new (texObjectBuffer)
-      __hip_texture{image, sampler, *pResDesc, *pTexDesc,
+      __hip_texture{image, sampler.release(), *pResDesc, *pTexDesc,
                     (pResViewDesc != nullptr) ? *pResViewDesc : hipResourceViewDesc{}};
 
   return hipSuccess;

--- a/projects/hip-tests/catch/unit/texture/hipBindTexture2D.cc
+++ b/projects/hip-tests/catch/unit/texture/hipBindTexture2D.cc
@@ -122,6 +122,8 @@ TEST_CASE("Unit_hipBindTexture2D_Negative") {
         hipBindTexture2D(&texture_offset, &tex, device_ptr, &tex.channelDesc, SIZE_W, SIZE_H, 0),
         hipErrorInvalidValue);
   }
+
+  HIP_CHECK(hipFree(device_ptr));
 }
 
 #endif  // __HIP_PLATFORM_AMD__ || CUDA_VERSION < CUDA_12000

--- a/projects/hip-tests/catch/unit/texture/hipTex1DFetchCheckModes.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTex1DFetchCheckModes.cc
@@ -99,6 +99,7 @@ static void runTest(hipTextureAddressMode addressMode, hipTextureFilterMode filt
   HIP_CHECK(hipDestroyTextureObject(texObj));
   HIP_CHECK(hipFree(texBuf));
   HIP_CHECK(hipFree(texBufOut));
+  HIP_CHECK(hipCtxDestroy(HipContext));
 }
 
 

--- a/projects/hip-tests/catch/unit/texture/hipTexObjPitch.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexObjPitch.cc
@@ -119,6 +119,7 @@ TEMPLATE_TEST_CASE("Unit_hipTexObjPitch_texture2D", "", char, unsigned char, sho
   delete[] B;
   HIP_CHECK(hipFree(devPtrA));
   HIP_CHECK(hipFree(devPtrB));
+  HIP_CHECK(hipDestroyTextureObject(texObj));
 }
 
 /**

--- a/projects/hip-tests/catch/unit/texture/hipTexObjectCreate.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexObjectCreate.cc
@@ -506,7 +506,6 @@ TEST_CASE("Unit_TexObjectCreate_TypePitch2D_EdgeCases") {
                     hipErrorInvalidValue);
   }
 
-  HIP_CHECK(hipTexObjectDestroy(tex_object));
   HIP_CHECK(hipFree(tex_buffer));
   CTX_DESTROY();
 }

--- a/projects/hip-tests/catch/unit/texture/hipTexRefSetAddress.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexRefSetAddress.cc
@@ -68,6 +68,9 @@ TEST_CASE("Unit_hipTexRefSetAddress_Positive") {
     HIP_CHECK(
         hipTexRefSetAddress(&offset, tex_ref, reinterpret_cast<hipDeviceptr_t>(tex_buffer), 0));
   }
+
+  HIP_CHECK(hipModuleUnload(module));
+  HIP_CHECK(hipFree(tex_buffer));
 }
 
 TEST_CASE("Unit_hipTexRefSetAddress_Negative") {


### PR DESCRIPTION
## Motivation

A couple of texture based unit tests have memory leaks. 

## Technical Details

- [hip-tests] Added missing cleanups 
- [clr] Release Sampler command in case when API returns an error

## Test Plan

/

## Test Result

/

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
