### PR TITLE
SWDEV-541478 - return hipSuccess for hipTexObjectCreate TypePitch2D with zero width or height

### DIFF
--- a/projects/clr/hipamd/src/hip_texture.cpp
+++ b/projects/clr/hipamd/src/hip_texture.cpp
@@ -1491,6 +1491,11 @@ hipError_t hipTexObjectCreate(hipTextureObject_t* pTexObject, const HIP_RESOURCE
     HIP_RETURN(hipErrorInvalidValue);
   }
 
+  if (static_cast<hipResourceType>(pResDesc->resType) == hipResourceTypePitch2D &&
+      ((pResDesc->res.pitch2D.width == 0) || (pResDesc->res.pitch2D.height == 0))) {
+    HIP_RETURN(hipSuccess);
+  }
+
   hipResourceDesc resDesc = hip::getResourceDesc(*pResDesc);
   hipTextureDesc texDesc = hip::getTextureDesc(*pTexDesc);
 


### PR DESCRIPTION
## Motivation
Fix hipTexObjectCreate TypePitch2D
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
To return success for hipTexObjectCreate TypePitch2D when called with zero width or height
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
TextureTest.exe Unit_TexObjectCreate_TypePitch2D
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Passed.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
