### PR TITLE
SWDEV-550626 - Fix some atomic test failures

### DIFF
--- a/projects/hip-tests/catch/unit/atomics/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/atomics/CMakeLists.txt
@@ -59,6 +59,16 @@ if(HIP_PLATFORM MATCHES "amd")
       atomicDec.cc
     )
 
+  set_source_files_properties(atomicAnd_system.cc PROPERTIES COMPILE_FLAGS "-fatomic-fine-grained-memory -fatomic-remote-memory")
+  set_source_files_properties(atomicOr_system.cc PROPERTIES COMPILE_FLAGS "-fatomic-fine-grained-memory -fatomic-remote-memory")
+  set_source_files_properties(atomicXor_system.cc PROPERTIES COMPILE_FLAGS "-fatomic-fine-grained-memory -fatomic-remote-memory")
+  set_source_files_properties(atomicMin_system.cc PROPERTIES COMPILE_FLAGS "-fatomic-fine-grained-memory -fatomic-remote-memory")
+  set_source_files_properties(atomicMax_system.cc PROPERTIES COMPILE_FLAGS "-fatomic-fine-grained-memory -fatomic-remote-memory")
+  set_source_files_properties(atomicAdd_system.cc PROPERTIES COMPILE_FLAGS "-fatomic-fine-grained-memory -fatomic-remote-memory")
+  set_source_files_properties(atomicSub_system.cc PROPERTIES COMPILE_FLAGS "-fatomic-fine-grained-memory -fatomic-remote-memory")
+  set_source_files_properties(atomicCAS_system.cc PROPERTIES COMPILE_FLAGS "-fatomic-fine-grained-memory -fatomic-remote-memory")
+  set_source_files_properties(atomicExch_system.cc PROPERTIES COMPILE_FLAGS "-fatomic-fine-grained-memory -fatomic-remote-memory")
+
   hip_add_exe_to_target(NAME AtomicsTest
                         TEST_SRC ${TEST_SRC}
                         TEST_TARGET_NAME build_tests

--- a/projects/hip-tests/catch/unit/atomics/arithmetic_common.hh
+++ b/projects/hip-tests/catch/unit/atomics/arithmetic_common.hh
@@ -484,7 +484,7 @@ inline dim3 GenerateThreadDimensions() { return dim3(16); }
 inline dim3 GenerateBlockDimensions() {
   int sm_count = 0;
   HIP_CHECK(hipDeviceGetAttribute(&sm_count, hipDeviceAttributeMultiprocessorCount, 0));
-  return dim3(sm_count);
+  return dim3(sm_count/10);
 }
 
 // Configures and creates the TestCore for a single device, and a single kernel launch
@@ -615,7 +615,7 @@ void MultipleDeviceMultipleKernelAndHostTest(const unsigned int num_devices,
   params.host_thread_count = host_thread_count;
 
   using LA = LinearAllocs;
-  for (const auto alloc_type : {LA::hipMalloc}) {
+  for (const auto alloc_type : {LA::hipHostMalloc}) {
     params.alloc_type = alloc_type;
     DYNAMIC_SECTION("Allocation type: " << to_string(alloc_type)) {
       TestCore<TestType, operation, false, __HIP_MEMORY_SCOPE_SYSTEM>(params);

--- a/projects/hip-tests/catch/unit/atomics/bitwise_common.hh
+++ b/projects/hip-tests/catch/unit/atomics/bitwise_common.hh
@@ -296,12 +296,12 @@ void TestCore(const TestParams& p) {
   Verify<TestType, operation>(p, res_vals, old_vals);
 }
 
-inline dim3 GenerateThreadDimensions() { return GENERATE(dim3(16), dim3(1024)); }
+inline dim3 GenerateThreadDimensions() { return GENERATE(dim3(128)); }
 
 inline dim3 GenerateBlockDimensions() {
   int sm_count = 0;
   HIP_CHECK(hipDeviceGetAttribute(&sm_count, hipDeviceAttributeMultiprocessorCount, 0));
-  return GENERATE_COPY(dim3(sm_count));
+  return GENERATE_COPY(dim3(sm_count/10));
 }
 
 template <typename TestType, AtomicOperation operation, int memory_scope = __HIP_MEMORY_SCOPE_AGENT>
@@ -427,7 +427,7 @@ void MultipleDeviceMultipleKernelTest(const unsigned int num_devices,
   params.pitch = pitch;
 
   using LA = LinearAllocs;
-  for (const auto alloc_type : {LA::hipMalloc}) {
+  for (const auto alloc_type : {LA::hipHostMalloc}) {
     params.alloc_type = alloc_type;
     DYNAMIC_SECTION("Allocation type: " << to_string(alloc_type)) {
       TestCore<TestType, operation, false, __HIP_MEMORY_SCOPE_SYSTEM>(params);

--- a/projects/hip-tests/catch/unit/atomics/min_max_common.hh
+++ b/projects/hip-tests/catch/unit/atomics/min_max_common.hh
@@ -326,12 +326,12 @@ void TestCore(const TestParams& p) {
   Verify<TestType, operation>(p, res_vals, old_vals);
 }
 
-inline dim3 GenerateThreadDimensions() { return GENERATE(dim3(16), dim3(1024)); }
+inline dim3 GenerateThreadDimensions() { return GENERATE(dim3(128)); }
 
 inline dim3 GenerateBlockDimensions() {
   int sm_count = 0;
   HIP_CHECK(hipDeviceGetAttribute(&sm_count, hipDeviceAttributeMultiprocessorCount, 0));
-  return dim3(sm_count);
+  return dim3(sm_count/10);
 }
 
 template <typename TestType, AtomicOperation operation, int memory_scope = __HIP_MEMORY_SCOPE_AGENT>


### PR DESCRIPTION
1.Fix some atomics test failures on pinned host memory by compiling flags
 "-fatomic-fine-grained-memory -fatomic-remote-memory"

2.Reduce blocks and threads numbers to reduce test time.

3.Make system scoped tests run on pinned host memory.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fix some atomics test failures
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Use compiling flags "-fatomic-fine-grained-memory -fatomic-remote-memory"

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->
Pass
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
