### PR TITLE
[rocprofiler-sdk] ROCpd GOTCHA Fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -49,7 +49,7 @@
 	url = https://github.com/pybind/pybind11.git
 [submodule "projects/rocprofiler-sdk/external/gotcha"]
 	path = projects/rocprofiler-sdk/external/gotcha
-	url = https://jrmadsen@github.com/jrmadsen/GOTCHA
+	url = https://github.com/ROCm/GOTCHA
 [submodule "projects/rocprofiler-systems/external/timemory"]
 	path = projects/rocprofiler-systems/external/timemory
 	url = https://github.com/ROCm/timemory.git

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/__init__.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/__init__.py
@@ -32,6 +32,13 @@ try:
 except Exception:
     pass
 
+try:
+    import sqlite3
+
+    sqlite3.connect(":memory:")  # Test if sqlite3 is available
+except Exception:
+    pass
+
 from . import libpyrocpd
 from .importer import RocpdImportData
 

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/interop.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/interop.cpp
@@ -161,6 +161,22 @@ auto bindings = std::array<gotcha_binding_t, 4>{
 void
 activate_gotcha_bindings()
 {
+#if defined(GOTCHA_INIT) && GOTCHA_INIT > 0
+    // initialize gotcha
+    gotcha_init_config_t gotcha_cfg = {
+        .size = sizeof(gotcha_init_config_t), .dl_open_bind = 0, .dl_sym_bind = 0};
+    gotcha_init(&gotcha_cfg);
+#endif
+
+    // this ensures that the sqlite3 module is imported and the sqlite3_open_v2 and sqlite3_close_v2
+    // in lib-dynload/_sqlite3.cpython-*.so are remapped to the gotcha bindings.
+    // this is needed to ensure that the sqlite3 connections are captured by gotcha
+    {
+        auto sqlite3_mod = py::module_::import("sqlite3");
+        auto ret         = sqlite3_mod.attr("connect")(":memory:");
+        ret.attr("close")();
+    }
+
     // activate the gotcha wrappers
     auto _err = gotcha_wrap(bindings.data(), bindings.size(), "rocpd.sqlite3");
     ROCP_WARNING_IF(_err != GOTCHA_SUCCESS) << "gotcha error for rocpd.sqlite3";


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
- Fixes issue with rocpd segfaulting on certain systems

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- On some systems, for some unknown reason, GOTCHA segfaults when trying to wrap `dlopen` / `dlsym`
  - https://github.com/LLNL/GOTCHA/issues/167
- In order to work around this, in the https://github.com/ROCm/GOTCHA fork, we created a `gotcha_init` function which allows specifying to not wrap `dlopen` / `dlsym`. 
  - As a consequence of not wrapping the `dlopen` / `dlsym` functions, if a library making calls to `sqlite3_open_v2`, `sqlite3_close` , etc. is not loaded when we call `gotcha_wrap`, when it is subsequently loaded, the function calls in that library are not automatically wrapped. To combat this, internally, ROCpd makes a call to `sqlite3.connect` so these symbols are loaded.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Since we don't know the root cause of this issue yet and this is a workaround, creating a test is difficult. However, this issue was able to be reproduced locally and the patch does indeed solve it. We need verification for CQE and QA.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

CC: @bgopesh 