### PR TITLE
[NFC] SWDEV-514499 - add spirv mode to hip-tests

### DIFF
--- a/projects/hip-tests/catch/CMakeLists.txt
+++ b/projects/hip-tests/catch/CMakeLists.txt
@@ -8,6 +8,9 @@ option(BUILD_UNIT_TESTS "Build unit tests" ON)
 option(BUILD_PERF_TESTS "Build perf tests" OFF)
 option(BUILD_STRESS_TESTS "Build stress tests" OFF)
 option(TEST_CLOCK_CYCLE "Option to use clock64" OFF)
+option(RTC_TESTING "Run tests using HIP RTC to compile the kernels" OFF)
+option(ENABLE_SPIRV "Build hip-tests for SPIRV" OFF)
+
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release")
 endif()
@@ -25,6 +28,7 @@ find_package(hiprtc)
 find_package(Git)
 find_package(Python 3 COMPONENTS Interpreter REQUIRED)
 find_program(HIPCONFIG_EXEC hipconfig REQUIRED)
+
 # hip root dir is 3 levels down the hip-config.cmake file path
 set(HIP_PATH ${hip_DIR}/../../../)
 if(NOT DEFINED ROCM_PATH)
@@ -33,14 +37,18 @@ if(NOT DEFINED ROCM_PATH)
         set(ROCM_PATH ${HIP_PATH})
     endif()
 endif()
+
 if(UNIX)
-    find_program(ROCM_AGENT_ENUMERATOR_EXEC rocm_agent_enumerator REQUIRED)
+    if(NOT ENABLE_SPIRV)
+        find_program(ROCM_AGENT_ENUMERATOR_EXEC rocm_agent_enumerator REQUIRED)
+    endif()
     find_program(GCC_EXEC gcc)
     find_program(GXX_EXEC g++)
 else() # Win32
     find_program(LLVM_RC_EXEC NAMES llvm-rc llvm-rc.exe
                  PATHS ${HIP_PATH} ${HIP_PATH}../lc/bin ${ROCM_PATH})
 endif()
+
 find_program(CLANG_CPP_EXEC NAMES clang-cpp clang-cpp.exe
              PATHS ${HIP_PATH} ${HIP_PATH}../lc/bin ${ROCM_PATH}/llvm/bin)
 message(STATUS "HIP Lib path: ${HIP_LIB_INSTALL_DIR}")
@@ -144,7 +152,6 @@ include_directories(
     "${CMAKE_CURRENT_LIST_DIR}/external/picojson"
 )
 
-option(RTC_TESTING "Run tests using HIP RTC to compile the kernels" OFF)
 if (RTC_TESTING)
     add_definitions(-DRTC_TESTING=ON)
 endif()
@@ -177,8 +184,11 @@ endif()
 if(HIP_PLATFORM STREQUAL "amd")
     if(WIN32)
         set(win_disable_warnings ${win_disable_warnings} -Wno-ignored-attributes -Wno-microsoft-cast)
+        # Windows for some reason does not honor the `CMAKE_CXX_STANDARD` we set initially in the file
+        # Which results in errors about missing headers etc
+        set(win_cxx_standard -std=c++17)
     endif()
-    add_compile_options(${HIP_PATH_OPT} -std=c++17 -x hip -Wall -Wextra -Wvla -Wno-deprecated -Wno-option-ignored -Wno-unused-parameter ${win_disable_warnings}) # -Werror)
+    add_compile_options(${HIP_PATH_OPT} ${win_cxx_standard} -x hip -Wall -Wextra -Wvla -Wno-deprecated -Wno-option-ignored -Wno-unused-parameter ${win_disable_warnings})
 endif()
 
 # Turn off CMAKE_HIP_ARCHITECTURES Feature if cmake version is 3.21+
@@ -196,7 +206,9 @@ message(STATUS "CMAKE HIP ARCHITECTURES: ${CMAKE_HIP_ARCHITECTURES}")
 # preference to pass arch -
 # OFFLOAD_ARCH_STR
 # rocm_agent_enumerator
-if(DEFINED OFFLOAD_ARCH_STR)
+if(ENABLE_SPIRV)
+    set(OFFLOAD_ARCH_STR "--offload-arch=amdgcnspirv")
+elseif(DEFINED OFFLOAD_ARCH_STR)
     string(REPLACE "--offload-arch=" "" HIP_GPU_ARCH_LIST ${OFFLOAD_ARCH_STR})
 elseif(DEFINED GPU_TARGETS)
     foreach(_hip_gpu_arch ${GPU_TARGETS})
@@ -308,12 +320,14 @@ file(COPY ./include/hip_test_context.hh DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/
 
 # Enable device lambda on nvidia platforms
 if(HIP_PLATFORM STREQUAL "nvidia")
+    # SPIRV is not supported on it
+    if(ENABLE_SPIRV)
+        message(FATAL_ERROR "SPIRV is not supported on this platform")
+    endif()
+
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --extended-lambda")
     add_compile_options(-Xcompiler=-Wno-deprecated-declarations)
 endif()
-
-# Disable CXX extensions (gnu++11 etc)
-set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_custom_target(build_tests ALL)
 

--- a/projects/hip-tests/catch/README.md
+++ b/projects/hip-tests/catch/README.md
@@ -22,6 +22,7 @@ Running Subtest: ctest –R “...” (Regex to match the subtest name)
 - Json file supports regex. Ex: All tests which has the word ‘Memset’ can be skipped using ‘*Memset*’
 - Support multiple skip test list which can be set via environment variable, so you can have multiple files containing different skip test lists and can pick and choose among them depending on your platform and os.
 - Better CI integration via xunit compatible output
+- hip-tests can be built in SPIRV, where all kernels are compiled in SPIRV, enable with cmake flag `-DENABLE_SPIRV=ON`. By default its `OFF`.
 
 ## Testing Context
 HIP testing framework gives you a context for each test. This context will have useful information about the environment your test is running.

--- a/projects/hip-tests/catch/hipTestMain/CMakeLists.txt
+++ b/projects/hip-tests/catch/hipTestMain/CMakeLists.txt
@@ -28,5 +28,7 @@ set(MAIN_SRC
     hip_test_features.cc)
 add_library(Main_Object EXCLUDE_FROM_ALL OBJECT ${MAIN_SRC})
 set_source_files_properties(${MAIN_SRC} PROPERTIES LANGUAGE HIP)
-#set_property(TARGET Main_Object PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded")
+if(ENABLE_SPIRV)
+    target_compile_definitions(Main_Object PRIVATE ENABLE_SPIRV)
+endif()
 target_link_libraries(Main_Object PRIVATE Catch2::Catch2)

--- a/projects/hip-tests/catch/hipTestMain/config/config_amd_linux
+++ b/projects/hip-tests/catch/hipTestMain/config/config_amd_linux
@@ -138,7 +138,7 @@
         "=== Test does not reflect a valid use case - SWDEV-569454",
         "Unit_hipStreamPerThread_MultiThread",
     #endif
-    #if defined gfx90a || defined gfx942 || defined gfx950
+    #if defined gfx90a || defined gfx942 || defined gfx950 || defined amdgcnspirv
         "Unit_Warp_Shfl_Up_Positive_Basic - int",
         "Unit_Warp_Shfl_Up_Positive_Basic - unsigned int",
         "Unit_Warp_Shfl_Up_Positive_Basic - long",
@@ -160,7 +160,7 @@
         "Unit_Warp_Shfl_Down_Positive_Basic - __half",
         "Unit_Warp_Shfl_Down_Positive_Basic - __half2",
     #endif
-    #if defined gfx1200 || defined gfx1201
+    #if defined gfx1200 || defined gfx1201 || defined amdgcnspirv
         "=== SWDEV-470751 : Fine Grain memory is MTYPE_NC due to HW bug.",
         "Unit_hipEventCreateWithFlags_DisableSystemFence_CohHstMem",
     #endif

--- a/projects/hip-tests/catch/hipTestMain/hip_test_context.cc
+++ b/projects/hip-tests/catch/hipTestMain/hip_test_context.cc
@@ -154,7 +154,11 @@ std::string TestContext::getCurrentArch() {
 std::string TestContext::getMatchingConfigFile(std::string config_dir) {
   std::string configFileToUse = "";
   if (isLinux() && isAmd()) {
+#if defined(ENABLE_SPIRV)
+    std::string cur_arch = "amdgcnspirv";
+#else
     std::string cur_arch = getCurrentArch();
+#endif
     LogPrintf("The arch present: %s", cur_arch.c_str());
     configFileToUse = config_dir + "/config_" + getConfig().platform + "_" + getConfig().os + "_" +
                       cur_arch + ".json";

--- a/projects/hip-tests/catch/unit/atomics/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/atomics/CMakeLists.txt
@@ -19,7 +19,7 @@
 # THE SOFTWARE.
 
 if(HIP_PLATFORM MATCHES "amd")
-    set(TEST_SRC
+  set(TEST_SRC
       atomicAnd.cc
       atomicAnd_system.cc
       atomicOr.cc
@@ -30,9 +30,7 @@ if(HIP_PLATFORM MATCHES "amd")
       atomicMin_system.cc
       atomicMax.cc
       atomicMax_system.cc
-      safeAtomicMin.cc
       unsafeAtomicMin.cc
-      safeAtomicMax.cc
       unsafeAtomicMax.cc
       __hip_atomic_fetch_min.cc
       __hip_atomic_fetch_max.cc
@@ -41,7 +39,6 @@ if(HIP_PLATFORM MATCHES "amd")
       sequential_consistency.cc
       atomicAdd.cc
       atomicAdd_system.cc
-      unsafeAtomicAdd.cc
       safeAtomicAdd.cc
       atomicSub.cc
       atomicSub_system.cc
@@ -59,15 +56,24 @@ if(HIP_PLATFORM MATCHES "amd")
       atomicDec.cc
     )
 
+ if(NOT ENABLE_SPIRV)
+    set(SPIRV_INCOMPATIBLE_TESTS
+      safeAtomicMin.cc
+      safeAtomicMax.cc
+      unsafeAtomicAdd.cc
+    )
+    set(TEST_SRC ${TEST_SRC} ${SPIRV_INCOMPATIBLE_TESTS})
+  endif()
+
   hip_add_exe_to_target(NAME AtomicsTest
                         TEST_SRC ${TEST_SRC}
                         TEST_TARGET_NAME build_tests
                         LINKER_LIBS hiprtc::hiprtc)
 
-if(UNIX)
-  set(EXPECTED_ERRORS 40)
+  if(UNIX)
+    set(EXPECTED_ERRORS 40)
 
-  file(GLOB NEGATIVE_TEST_SRC
+    file(GLOB NEGATIVE_TEST_SRC
         "atomicAnd_negative_kernels.cc"
         "atomicOr_negative_kernels.cc"
         "atomicXor_negative_kernels.cc"
@@ -82,69 +88,7 @@ if(UNIX)
         "atomicExch_negative_kernels.cc"
         "atomicExch_system_negative_kernels.cc")
 
-  file(COPY ${NEGATIVE_TEST_SRC} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/src)
-  set_property(GLOBAL APPEND PROPERTY G_INSTALL_SRC_FILES ${NEGATIVE_TEST_SRC})
- # add_test(NAME Unit_atomicAnd_Negative_Parameters
- #         COMMAND ${Python3_EXECUTABLE} ../compileAndCaptureOutput.py
- #         ./src ${HIP_PLATFORM} ${HIP_PATH}
- #         atomicAnd_negative_kernels.cc ${EXPECTED_ERRORS})
-
- # add_test(NAME Unit_atomicOr_Negative_Parameters
- #         COMMAND ${Python3_EXECUTABLE} ../compileAndCaptureOutput.py
- #         ./src ${HIP_PLATFORM} ${HIP_PATH}
- #         atomicOr_negative_kernels.cc ${EXPECTED_ERRORS})
-
- # add_test(NAME Unit_atomicXor_Negative_Parameters
- #         COMMAND ${Python3_EXECUTABLE} ../compileAndCaptureOutput.py
- #         ./src ${HIP_PLATFORM} ${HIP_PATH}
- #         atomicXor_negative_kernels.cc ${EXPECTED_ERRORS})
-
- # add_test(NAME Unit_atomicMin_Negative_Parameters
- #         COMMAND ${Python3_EXECUTABLE} ../compileAndCaptureOutput.py
- #         ./src ${HIP_PLATFORM} ${HIP_PATH}
- #         atomicMin_negative_kernels.cc 42)
-
- # add_test(NAME Unit_atomicMax_Negative_Parameters
- #         COMMAND ${Python3_EXECUTABLE} ../compileAndCaptureOutput.py
- #         ./src ${HIP_PLATFORM} ${HIP_PATH}
- #         atomicMax_negative_kernels.cc 42)
-
-	#add_test(NAME Unit_AtomicBuiltins_Negative_Parameters
- #         COMMAND ${Python3_EXECUTABLE} ../compileAndCaptureOutput.py
- #         ./src ${HIP_PLATFORM} ${HIP_PATH}
- #         atomic_builtin_kernels.cc 60 27)
-
- #         add_test(NAME Unit_atomicAdd_Negative_Parameters
- #         COMMAND ${Python3_EXECUTABLE} ../compileAndCaptureOutput.py
- #         ./src ${HIP_PLATFORM} ${HIP_PATH}
- #         atomicAdd_negative_kernels.cc 48)
- # add_test(NAME Unit_atomicSub_Negative_Parameters
- #         COMMAND ${Python3_EXECUTABLE} ../compileAndCaptureOutput.py
- #         ./src ${HIP_PLATFORM} ${HIP_PATH}
- #         atomicSub_negative_kernels.cc 48)
- # add_test(NAME Unit_atomicInc_Negative_Parameters
- #         COMMAND ${Python3_EXECUTABLE} ../compileAndCaptureOutput.py
- #         ./src ${HIP_PLATFORM} ${HIP_PATH}
- #         atomicInc_negative_kernels.cc 8)
-
- # add_test(NAME Unit_atomicDec_Negative_Parameters
- #         COMMAND ${Python3_EXECUTABLE} ../compileAndCaptureOutput.py
- #         ./src ${HIP_PLATFORM} ${HIP_PATH}
- #         atomicDec_negative_kernels.cc 8)
-
- # add_test(NAME Unit_atomicCAS_Negative_Parameters
- #         COMMAND ${Python3_EXECUTABLE} ../compileAndCaptureOutput.py
- #         ./src ${HIP_PLATFORM} ${HIP_PATH}
- #         atomicCAS_negative_kernels.cc 48)
-
- # add_test(NAME Unit_atomicExch_Negative_Parameters
- #          COMMAND ${Python3_EXECUTABLE} ../compileAndCaptureOutput.py
- #          ./src ${HIP_PLATFORM} ${HIP_PATH}
- #          atomicExch_negative_kernels.cc 40)
-
- # add_test(NAME Unit_atomicExch_system_Negative_Parameters
- #          COMMAND ${Python3_EXECUTABLE} ../compileAndCaptureOutput.py
- #          ./src ${HIP_PLATFORM} ${HIP_PATH}
- #          atomicExch_system_negative_kernels.cc 40)
-endif()
+    file(COPY ${NEGATIVE_TEST_SRC} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/src)
+    set_property(GLOBAL APPEND PROPERTY G_INSTALL_SRC_FILES ${NEGATIVE_TEST_SRC})
+  endif()
 endif()


### PR DESCRIPTION
## Motivation

Enable building hip-tests in SPIRV mode.

## Technical Details

with the cmake flag `-DENABLE_SPIRV=ON` users can now build all of hip-tests in SPIRV mode. by default its off.

## JIRA ID

NA

## Test Plan

Existing tests should run fine without any failures.

## Test Result

Existing tests should run fine.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
