### PR TITLE
SWDEV-550626 - Make atomics test pass with new compiler

### DIFF
--- a/projects/hip-tests/catch/unit/atomics/min_max_common.hh
+++ b/projects/hip-tests/catch/unit/atomics/min_max_common.hh
@@ -456,8 +456,7 @@ void MultipleDeviceMultipleKernelTest(const unsigned int num_devices,
   params.pitch = pitch;
 
   using LA = LinearAllocs;
-  // Here LA::hipHostMalloc means to allocate coherent host pined buffer
-  for (const auto alloc_type : {LA::hipHostMalloc}) {
+  for (const auto alloc_type : {LA::hipMalloc}) {
     params.alloc_type = alloc_type;
     DYNAMIC_SECTION("Allocation type: " << to_string(alloc_type)) {
       TestCore<TestType, operation, false, __HIP_MEMORY_SCOPE_SYSTEM>(params);


### PR DESCRIPTION
Change pinned host memory to device memory so that atomics Min/Max tests can pass with new compiler patch in integer types.

## Motivation

Make atomics Min/Max test pass with new compiler

## Technical Details

The new compiler change will fail on pinned host memory but pass on device memory.
So change the test from  pinned host memory to  device memory.
## Test Plan

Atomics Min/Max test should pass

## Test Result
Pass 


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
