### PR TITLE
SWDEV-550882 - Expect HSA_EXT_POINTER_TYPE_RESERVED_ADDR pointer type…

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -2578,8 +2578,12 @@ bool Device::GetSvmAttributes(void** data, size_t* data_sizes, int* attributes,
       if (status != HSA_STATUS_SUCCESS) {
         LogError("hsa_amd_pointer_info() failed");
       }
+
       // Check if it's a legacy non-HMM allocation and update query
-      if (ptr_info.type != HSA_EXT_POINTER_TYPE_UNKNOWN) {
+      *reinterpret_cast<uint32_t*>(data[i]) = HSA_AMD_SVM_GLOBAL_FLAG_INDETERMINATE;
+      if (ptr_info.type == HSA_EXT_POINTER_TYPE_HSA ||
+          ptr_info.type == HSA_EXT_POINTER_TYPE_LOCKED ||
+          ptr_info.type == HSA_EXT_POINTER_TYPE_IPC) {
         if (ptr_info.global_flags & HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED) {
           *reinterpret_cast<uint32_t*>(data[i]) = HSA_AMD_SVM_GLOBAL_FLAG_COARSE_GRAINED;
         } else if (ptr_info.global_flags & HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED) {
@@ -2617,7 +2621,7 @@ bool Device::GetSvmAttributes(void** data, size_t* data_sizes, int* attributes,
           attr.push_back({HSA_AMD_SVM_ATTRIB_PREFETCH_LOCATION, 0});
           break;
         case amd::MemRangeAttribute::CoherencyMode:
-          if (ptr_info.type == HSA_EXT_POINTER_TYPE_UNKNOWN) {
+          if (*reinterpret_cast<uint32_t*>(data[i]) == HSA_AMD_SVM_GLOBAL_FLAG_INDETERMINATE) {
             attr.push_back({HSA_AMD_SVM_ATTRIB_GLOBAL_FLAG, 0});
           }
           break;
@@ -2721,7 +2725,7 @@ bool Device::GetSvmAttributes(void** data, size_t* data_sizes, int* attributes,
             return false;
           }
           // if ptr is HMM alloc then overwrite the values
-          if (ptr_info.type == HSA_EXT_POINTER_TYPE_UNKNOWN) {
+          if (*reinterpret_cast<uint32_t*>(data[idx]) == HSA_AMD_SVM_GLOBAL_FLAG_INDETERMINATE) {
             // Cast ROCr value into the hip format
             *reinterpret_cast<uint32_t*>(data[idx]) = static_cast<uint32_t>(it.value);
           }
@@ -2734,7 +2738,7 @@ bool Device::GetSvmAttributes(void** data, size_t* data_sizes, int* attributes,
       // Find the next location in the query
       ++idx;
     }
-  } else if (ptr_info.type == HSA_EXT_POINTER_TYPE_UNKNOWN) {
+  } else if (ptr_info.type == HSA_EXT_POINTER_TYPE_RESERVED_ADDR) {
     LogError("GetSvmAttributes() failed, because no HMM support");
     return false;
   }


### PR DESCRIPTION
… from hsa_amd_pointer_info for hmm

## Motivation
After  rocr-runtime change https://github.com/ROCm/rocm-systems/pull/305 rocr returns HSA_EXT_POINTER_TYPE_RESERVED_ADDR type for hmm memory. The logic in clr needs to change in order to set the 
coherency flags correctly

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Currently this check in clr GetSvmAttributes expects HSA_EXT_POINTER_TYPE_UNKNOWN for non HMM allocations

      // Check if it's a legacy non-HMM allocation and update query
      if (ptr_info.type == HSA_EXT_POINTER_TYPE_HSA || ptr_info.type == HSA_EXT_POINTER_TYPE_LOCKED ||
        ptr_info.type == HSA_EXT_POINTER_TYPE_IPC) {
        if (ptr_info.global_flags & HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED) {
          *reinterpret_cast<uint32_t*>(data[i]) = HSA_AMD_SVM_GLOBAL_FLAG_COARSE_GRAINED;
        } else if (ptr_info.global_flags & HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED) {
          *reinterpret_cast<uint32_t*>(data[i]) = HSA_AMD_SVM_GLOBAL_FLAG_FINE_GRAINED;
        }
      }

But rocr now returns HSA_EXT_POINTER_TYPE_RESERVED_ADDR so the above check breaks/

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
The issue comes up in Unit_hipGetProcAddress_MemoryApisManagedMemory in PSDBs and also in QA
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
The Unit_hipGetProcAddress_MemoryApisManagedMemory test passes in PSDB os this PR
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
