### PR TITLE
[AQLProfile] Fix caching of agents with new available data

### DIFF
--- a/projects/aqlprofile/src/core/pm4_factory.h
+++ b/projects/aqlprofile/src/core/pm4_factory.h
@@ -257,7 +257,9 @@ class Pm4Factory {
   // PM4 factory instance map type
   struct instances_fncomp_t {
     bool operator()(const AgentInfo& a, const AgentInfo& b) const {
-      int cmp = strcmp(a.gfxip, b.gfxip);
+      // using name instead of gfxip due to backward compatability with rocprofv2, 
+      // as in newer api which rocprofv3 uses both name and gfxip strings are same for a agent.
+      int cmp = strcmp(a.name, b.name); 
       if (cmp < 0) return true;
       if (cmp > 0) return false;
       // If gfxip strings are equal, compare cu_num

--- a/projects/aqlprofile/src/core/pm4_factory.h
+++ b/projects/aqlprofile/src/core/pm4_factory.h
@@ -256,11 +256,15 @@ class Pm4Factory {
  private:
   // PM4 factory instance map type
   struct instances_fncomp_t {
-    bool operator()(const hsa_agent_t& a, const hsa_agent_t& b) const {
-      return a.handle < b.handle;
+    bool operator()(const AgentInfo& a, const AgentInfo& b) const {
+      int cmp = strcmp(a.gfxip, b.gfxip);
+      if (cmp < 0) return true;
+      if (cmp > 0) return false;
+      // If gfxip strings are equal, compare cu_num
+      return a.cu_num < b.cu_num;
     }
   };
-  typedef std::map<hsa_agent_t, Pm4Factory*, instances_fncomp_t> instances_t;
+  typedef std::map<AgentInfo, Pm4Factory*, instances_fncomp_t> instances_t;
 
   // Create GFX9 generic factory
   static Pm4Factory* Gfx9Create(const AgentInfo* agent_info);
@@ -295,7 +299,7 @@ inline Pm4Factory* Pm4Factory::Create(const AgentInfo* agent_info, gpu_id_t gpu_
                                       bool concurrent) {
   // Check if we have the instance already created
   if (instances_ == NULL) instances_ = new instances_t;
-  const auto ret = instances_->insert({agent_info->dev_id, NULL});
+  const auto ret = instances_->insert({*agent_info, NULL});
   instances_t::iterator it = ret.first;
 
   concurrent_create_mode_ = concurrent;


### PR DESCRIPTION
## Motivation
hsa_agent not provided by new api/rocprofiler-sdk and causes every device to have same id, in cases where gfxip is same but different CU config, pm4factory doesn't know the difference. This fix uses gfxip and CU count as a key for cache.

## Technical Details

https://github.com/ROCm/rocm-systems/blob/develop/projects/aqlprofile/src/core/pm4_factory.cpp#L54
https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp#L942

From rocprofiler-sdk we never get hsa_agent and it remains to be set with handle=0.
aqlprofile V1 API receives hsa_agent handle(https://github.com/ROCm/rocm-systems/blob/develop/projects/aqlprofile/src/core/aql_profile.cpp#L558). the newer API which rocprofiler-sdk doesn't take hsa_agent(https://github.com/ROCm/rocm-systems/blob/develop/projects/aqlprofile/src/core/counters.cpp#L322).

Alternate Solutions: 
- remove instances_t from Pm4Factory (not sure about performance impact.)
- add UUID(https://github.com/ROCm/rocm-systems/blob/develop/projects/aqlprofile/src/core/include/aqlprofile-sdk/aql_profile_v2.h#L165)

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
