### PR TITLE
Set correct clang format version in subprojects

### DIFF
--- a/projects/clr/.github/hooks/clang-format-check.sh
+++ b/projects/clr/.github/hooks/clang-format-check.sh
@@ -52,5 +52,5 @@ for file in $files; do
     diff_output=$(git diff -U0 --cached -- "$file")
   fi
 
-  echo "$diff_output" | "$clang_format_diff" -style=file -fallback-style=none -p1
+  echo "$diff_output" | "$clang_format_diff" -binary=$clang_bin -style=file -fallback-style=none -p1
 done

--- a/projects/clr/.github/workflows/clang-format.yml
+++ b/projects/clr/.github/workflows/clang-format.yml
@@ -13,10 +13,16 @@ jobs:
 
       - name: Install clang-format
         run: |
-          sudo apt update && sudo apt install -y clang-format
+          wget https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/master-b35c5633/clang-format-19_linux-amd64
+          wget https://raw.githubusercontent.com/llvm/llvm-project/refs/heads/main/clang/tools/clang-format/clang-format-diff.py
+          mv clang-format-19_linux-amd64 clang-format
+          chmod +x clang-format
+          chmod +x clang-format-diff.py
 
       - name: Run clang-format-check
         id: clang-format
         run: |
+          export CLANG_FORMAT=$(pwd)/clang-format
+          export CLANG_FORMAT_DIFF=$(pwd)/clang-format-diff.py
           chmod +x .github/hooks/clang-format-check.sh
           ./.github/hooks/clang-format-check.sh --range "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"


### PR DESCRIPTION
## Motivation
This PR fixes the internal formatting workflow by updating clang-format
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Sets a hardcoded version for internal clang-format workflow
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Tested internally in corresponding PR
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Internal clang-format results are corresponding to the public ones
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
