### PR TITLE
[SWDEV-551309] Adjusted rocmsmitst and --resetprofile command

### DIFF
--- a/projects/rocm-smi-lib/python_smi_tools/rocm_smi.py
+++ b/projects/rocm-smi-lib/python_smi_tools/rocm_smi.py
@@ -1143,11 +1143,6 @@ def resetProfile(deviceList):
             printLog(device, 'Successfully reset Power Profile', None)
         else:
             printErrLog(device, 'Unable to reset Power Profile')
-        ret = rocmsmi.rsmi_dev_perf_level_set(device, rsmi_dev_perf_level_t(0))
-        if rsmi_ret_ok(ret, device, 'set_perf_level'):
-            printLog(device, 'Successfully reset Performance Level', None)
-        else:
-            printErrLog(device, 'Unable to reset Performance Level')
     printLogSpacer()
 
 

--- a/projects/rocm-smi-lib/src/rocm_smi.cc
+++ b/projects/rocm-smi-lib/src/rocm_smi.cc
@@ -1301,10 +1301,6 @@ static rsmi_status_t get_power_profiles(uint32_t dv_ind,
   }
   assert(val_vec.size() <= RSMI_MAX_NUM_POWER_PROFILES);
   if (val_vec.size() > RSMI_MAX_NUM_POWER_PROFILES + 1 || val_vec.empty()) {
-    // Guest may not have power related information.
-    if (amd::smi::is_vm_guest()) {
-      return RSMI_STATUS_NOT_SUPPORTED;
-    }
     return RSMI_STATUS_UNEXPECTED_SIZE;
   }
   // -1 for the header line, below

--- a/projects/rocm-smi-lib/tests/rocm_smi_test/functional/power_read_write.cc
+++ b/projects/rocm-smi-lib/tests/rocm_smi_test/functional/power_read_write.cc
@@ -189,7 +189,9 @@ void TestPowerReadWrite::Run(void) {
 
     ASSERT_EQ(status.current, new_prof);
 
-    ret = rsmi_dev_perf_level_set(dv_ind, RSMI_DEV_PERF_LEVEL_AUTO);
-    ret = rsmi_dev_power_profile_set(dv_ind, 0, RSMI_PWR_PROF_PRST_BOOTUP_DEFAULT);
+    // Restore original power profile and performance level
+    // assertion check not necessary because we are restoring the original state
+    rsmi_dev_perf_level_set(dv_ind, RSMI_DEV_PERF_LEVEL_AUTO);
+    rsmi_dev_power_profile_set(dv_ind, 0, orig_profile);
   }
 }

--- a/projects/rocm-smi-lib/tests/rocm_smi_test/functional/power_read_write.cc
+++ b/projects/rocm-smi-lib/tests/rocm_smi_test/functional/power_read_write.cc
@@ -132,7 +132,7 @@ void TestPowerReadWrite::Run(void) {
       ASSERT_EQ(ret, RSMI_STATUS_NOT_SUPPORTED);
       continue;
     }
-    CHK_ERR_ASRT(ret)
+    CHK_ERR_ASRT(ret);
 
     // Verify api support checking functionality is working
     ret = rsmi_dev_power_profile_presets_get(dv_ind, 0, nullptr);
@@ -181,24 +181,15 @@ void TestPowerReadWrite::Run(void) {
 
     rsmi_dev_perf_level_t pfl;
     ret = rsmi_dev_perf_level_get(dv_ind, &pfl);
-    CHK_ERR_ASRT(ret)
+    CHK_ERR_ASRT(ret);
     ASSERT_EQ(pfl, RSMI_DEV_PERF_LEVEL_MANUAL);
 
     ret = rsmi_dev_power_profile_presets_get(dv_ind, 0, &status);
-    CHK_ERR_ASRT(ret)
+    CHK_ERR_ASRT(ret);
 
     ASSERT_EQ(status.current, new_prof);
 
     ret = rsmi_dev_perf_level_set(dv_ind, RSMI_DEV_PERF_LEVEL_AUTO);
-    CHK_ERR_ASRT(ret)
-
-    ret = rsmi_dev_perf_level_get(dv_ind, &pfl);
-    CHK_ERR_ASRT(ret)
-    ASSERT_EQ(pfl, RSMI_DEV_PERF_LEVEL_AUTO);
-
-    ret = rsmi_dev_power_profile_presets_get(dv_ind, 0, &status);
-    CHK_ERR_ASRT(ret)
-
-    ASSERT_EQ(status.current, orig_profile);
+    ret = rsmi_dev_power_profile_set(dv_ind, 0, RSMI_PWR_PROF_PRST_BOOTUP_DEFAULT);
   }
 }


### PR DESCRIPTION
## Motivation

Change in driver behavior expectation required update to the test and --resetprofile command

## Technical Details

Power_dpm_performance_level became completely independent from pp_power_profile_mode so rocm-smi was also updated accordingly.

## Test Plan

rocmsmitst should now pass the rsmitstReadWrite.TestPowerReadWrite test

## Test Result

rsmitstReadWrite.TestPowerReadWrite was passed

## Submission Checklist
