### PR TITLE
CMAKE - Use gersemi instead of cmake-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,8 +28,8 @@ repos:
         entry: clang-format -i -style=file
         files: '\.(c|cpp|cc|h|hpp|m|mm)$'
 
-  - repo: https://github.com/cheshirekow/cmake-format-precommit
-    rev: v0.6.10
+  - repo: https://github.com/BlankSpruce/gersemi
+    # gersemi replaces cmake-format and cmake-lint
+    rev: 0.22.1
     hooks:
-      - id: cmake-format
-      - id: cmake-lint
+      - id: gersemi


### PR DESCRIPTION
cmake-format has been unmaintained for 4+ years now. Please use gersemi
instead.

See RDC changes where we adopted gersemi:
- <https://github.com/ROCm/rdc/commit/680b7a8dd8699ab5264f10f5a3bc0b30410881be>
- <https://github.com/ROCm/rdc/commit/40545dcb49ebcfa0a6fe040a8862cf8b338ad6b5>

I actually just followed rocprofiler-systems https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-systems/.gersemirc in the first place.

Signed-off-by: Galantsev, Dmitrii <dmitrii.galantsev@amd.com>
