### PR TITLE
[rocprofv3] MultiKernelDispatch ATT support

### DIFF
--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -795,6 +795,13 @@ For attachment profiling of running processes:
     )
 
     att_options.add_argument(
+        "--att-consecutive-kernels",
+        help="Consecutive kernels to profile with ATT. Default 0",
+        default=None,
+        type=str,
+    )
+
+    att_options.add_argument(
         "--att-buffer-size",
         help="Thread trace buffer size. Default 256MB",
         default=None,
@@ -1625,6 +1632,12 @@ def run(app_args, args, **kwargs):
             update_env(
                 "ROCPROF_ATT_PARAM_SIMD_SELECT",
                 int_auto(args.att_simd_select),
+                overwrite=True,
+            )
+        if args.att_consecutive_kernels:
+            update_env(
+                "ROCPROF_ATT_CONSECUTIVE_KERNELS",
+                int_auto(args.att_consecutive_kernels),
                 overwrite=True,
             )
         if args.att_serialize_all:

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.hpp
@@ -151,6 +151,7 @@ struct config : output_config
     uint64_t att_param_simd_select = get_env<uint64_t>("ROCPROF_ATT_PARAM_SIMD_SELECT", 0xF);
     uint64_t att_param_target_cu   = get_env<uint64_t>("ROCPROF_ATT_PARAM_TARGET_CU", 1);
     uint64_t att_param_perf_ctrl   = get_env<uint64_t>("ROCPROF_ATT_PARAM_PERFCOUNTER_CTRL", 0);
+    uint64_t att_consecutive_kernels = get_env<uint64_t>("ROCPROF_ATT_CONSECUTIVE_KERNELS", 0);
 
     std::string kernel_filter_include   = get_env("ROCPROF_KERNEL_FILTER_INCLUDE_REGEX", ".*");
     std::string kernel_filter_exclude   = get_env("ROCPROF_KERNEL_FILTER_EXCLUDE_REGEX", "");
@@ -303,6 +304,7 @@ config::save(ArchiveT& ar) const
     CFG_SERIALIZE_MEMBER(att_library_path);
     CFG_SERIALIZE_MEMBER(att_param_perfcounters);
     CFG_SERIALIZE_MEMBER(att_param_perf_ctrl);
+    CFG_SERIALIZE_MEMBER(att_consecutive_kernels);
 
     // serialize the base class
     static_cast<const base_type*>(this)->save(ar);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -1433,7 +1433,7 @@ att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t r
     if(record.kind != ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH) return;
     if(record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT) return;
 
-    ROCP_FATAL_IF(record.payload != nullptr)
+    ROCP_FATAL_IF(record.payload == nullptr)
         << fmt::format("Expected record payload to not be null for {}", __FUNCTION__);
     static auto kernel_iteration = common::Synchronized<kernel_iteration_t, true>{};
     auto* rdata = static_cast<rocprofiler_callback_tracing_kernel_dispatch_data_t*>(record.payload);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -1431,7 +1431,7 @@ att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t r
 {
     using capture_ids_set_t = common::Synchronized<std::unordered_set<rocprofiler_dispatch_id_t>>;
     if(record.kind != ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH) return;
-    if(record.phase == ROCPROFILER_CALLBACK_PHASE_NONE) return;
+    if(record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT) return;
 
     assert(record.payload != nullptr);
     static auto kernel_iteration = common::Synchronized<kernel_iteration_t, true>{};
@@ -1487,7 +1487,7 @@ att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t r
         return;
     }
 
-    assert(record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT);
+    assert(record.phase == ROCPROFILER_CALLBACK_PHASE_NONE);
 
     if(!isprofiling) return;
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -263,7 +263,7 @@ auto*      tool_metadata     = as_pointer<tool::metadata>(tool::metadata::inproc
 auto       target_kernels    = common::Synchronized<targeted_kernels_map_t>{};
 auto*      execution_profile = as_pointer<common::Synchronized<tool::execution_profile_data>>();
 auto       counter_collection_ctx             = rocprofiler_context_id_t{0};
-auto       agent_ctx                          = rocprofiler_context_id_t{0};
+auto       att_device_context                 = rocprofiler_context_id_t{0};
 auto       att_consecutive_kernel_dispatch_id = std::atomic<rocprofiler_dispatch_id_t>{0};
 std::mutex att_shader_data;
 
@@ -1393,6 +1393,8 @@ att_shader_data_callback(rocprofiler_agent_id_t  agent,
     std::lock_guard<std::mutex> lock(att_shader_data);
     std::stringstream           filename;
     auto dispatch_id = static_cast<rocprofiler_dispatch_id_t>(userdata.value);
+    // If dispatch_id/userdata.value == 0, then we are in device mode and get dispatch id from
+    // global atomic
     if(dispatch_id == 0) dispatch_id = att_consecutive_kernel_dispatch_id.load();
     filename << fmt::format("{}_shader_engine_{}_{}", agent.handle, se_id, dispatch_id);
 
@@ -1424,7 +1426,7 @@ att_dispatch_callback(rocprofiler_agent_id_t /* agent_id  */,
 void
 att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t record,
                                          rocprofiler_user_data_t* /*user_data*/,
-                                         void* /*userdata*/)
+                                         void* userdata)
 {
     using capture_ids_set_t = common::Synchronized<std::unordered_set<rocprofiler_dispatch_id_t>>;
     if(record.kind != ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH) return;
@@ -1437,57 +1439,51 @@ att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t r
     auto  kernel_id   = rdata->dispatch_info.kernel_id;
 
     // Keep track of number of consecutive kernels
-    const auto                 consecutive_kernels = tool::get_config().att_consecutive_kernels;
-    static std::atomic<size_t> num_consecutive_kernels{0};
-    size_t                     local_count{0};
+    const auto consecutive_kernels = *static_cast<uint64_t*>(CHECK_NOTNULL(userdata));
 
     static std::atomic<bool> isprofiling{false};
-    static std::atomic<bool> stop_profiling{false};
-
-    static std::mutex        mut{};
+    static bool              stop_profiling{false};
+    static size_t            num_consecutive_kernels{0};
     static capture_ids_set_t captured_ids{};
-    auto                     add_capture_id =
-        [](capture_ids_set_t&                      _captured_ids,
-           std::atomic<rocprofiler_dispatch_id_t>& _att_consecutive_kernel_dispatch_id,
-           const rocprofiler_dispatch_id_t         _dispatch_id) {
-            // Keep track of launched dispatch ids
-            _captured_ids.wlock([](std::unordered_set<rocprofiler_dispatch_id_t>& _data,
-                                   rocprofiler_dispatch_id_t _did) { return _data.emplace(_did); },
-                                _dispatch_id);
-            // Store lowest dispatch id for shader callback function
-            rocprofiler_dispatch_id_t _exp{};
-            while((_exp = _att_consecutive_kernel_dispatch_id.load()) > _dispatch_id &&
-                  !_att_consecutive_kernel_dispatch_id.compare_exchange_strong(
-                      _exp, _dispatch_id, std::memory_order_relaxed))
-                ;
-        };
+
     if(record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER)
     {
+        const auto is_target = is_targeted_kernel(kernel_id, kernel_iteration);
         // Reset counter if kernel ID and iteration range matches
-        if(is_targeted_kernel(kernel_id, kernel_iteration))
+        if(is_target || isprofiling)
         {
-            std::unique_lock<std::mutex> lk(mut);
-            num_consecutive_kernels.store(0);
-            bool _exp = false;
-            if(isprofiling.compare_exchange_strong(_exp, true, std::memory_order_relaxed))
-            {
-                ROCPROFILER_CALL(rocprofiler_start_context(agent_ctx), "context start");
-            }
-            add_capture_id(captured_ids, att_consecutive_kernel_dispatch_id, dispatch_id);
-        }
-        else
-        {
-            std::unique_lock<std::mutex> lk(mut);
-            // Increment counter if we are profiling
-            if(isprofiling)
-            {
-                local_count = num_consecutive_kernels.fetch_add(1);
-            }
-            if(isprofiling && local_count < consecutive_kernels)
-            {
-                add_capture_id(captured_ids, att_consecutive_kernel_dispatch_id, dispatch_id);
-            }
-            if(local_count >= consecutive_kernels) stop_profiling.store(true);
+            captured_ids.wlock(
+                [](std::unordered_set<rocprofiler_dispatch_id_t>& _data,
+                   const rocprofiler_dispatch_id_t                _dispatch_id,
+                   const bool                                     _is_target,
+                   const uint64_t                                 _consecutive_kernels) {
+                    // Reset consecutive kernel count and start context if not already started
+                    if(_is_target)
+                    {
+                        num_consecutive_kernels = 0;
+                        bool _exp               = false;
+                        if(isprofiling.compare_exchange_strong(
+                               _exp, true, std::memory_order_relaxed))
+                            ROCPROFILER_CALL(rocprofiler_start_context(att_device_context),
+                                             "context start");
+                    }
+                    const auto local_count = num_consecutive_kernels++;
+                    if(isprofiling && local_count < _consecutive_kernels)
+                    {
+                        // Keep track of launched dispatch ids
+                        _data.emplace(_dispatch_id);
+                        // Store lowest dispatch id for shader callback function
+                        rocprofiler_dispatch_id_t _exp{};
+                        while((_exp = att_consecutive_kernel_dispatch_id.load()) > _dispatch_id &&
+                              !att_consecutive_kernel_dispatch_id.compare_exchange_strong(
+                                  _exp, _dispatch_id, std::memory_order_relaxed))
+                            ;
+                    }
+                    if(local_count >= _consecutive_kernels) stop_profiling = true;
+                },
+                dispatch_id,
+                is_target,
+                consecutive_kernels);
         }
         return;
     }
@@ -1496,22 +1492,20 @@ att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t r
 
     if(!isprofiling) return;
 
-    std::unique_lock<std::mutex> lk(mut);
+    // Stop profiling if all captured dispatches have finished
     captured_ids.wlock(
         [](std::unordered_set<rocprofiler_dispatch_id_t>& _data,
-           rocprofiler_dispatch_id_t _dispatch_id) { return _data.erase(_dispatch_id); },
+           rocprofiler_dispatch_id_t                      _dispatch_id) {
+            _data.erase(_dispatch_id);
+            if(!_data.empty() || !stop_profiling) return;
+
+            bool _exp = true;
+            if(!isprofiling.compare_exchange_strong(_exp, false, std::memory_order_relaxed)) return;
+
+            ROCPROFILER_CALL(rocprofiler_stop_context(att_device_context), "context stop");
+            stop_profiling = false;
+        },
         dispatch_id);
-    if(!captured_ids.rlock([](const std::unordered_set<rocprofiler_dispatch_id_t>& _data) {
-           return _data.empty();
-       }) ||
-       stop_profiling == false)
-        return;
-
-    bool _exp = true;
-    if(!isprofiling.compare_exchange_strong(_exp, false, std::memory_order_relaxed)) return;
-
-    ROCPROFILER_CALL(rocprofiler_stop_context(agent_ctx), "context stop");
-    stop_profiling.store(false);
 }
 
 void
@@ -2183,14 +2177,14 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
         {
             // Use user data pointer to dispatch id to communicate dispatch ID to shader callback
             // function
-            ROCPROFILER_CALL(rocprofiler_create_context(&agent_ctx), "context creation");
+            ROCPROFILER_CALL(rocprofiler_create_context(&att_device_context), "context creation");
             ROCPROFILER_CALL(rocprofiler_configure_callback_tracing_service(
                                  get_client_ctx(),
                                  ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,
                                  nullptr,
                                  0,
                                  callbacks.att_dispatch_consecutive_kernel,
-                                 nullptr),
+                                 static_cast<void*>(&tool::get_config().att_consecutive_kernels)),
                              "dispatch tracing service configure");
         }
 
@@ -2218,7 +2212,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
             else
             {
                 ROCPROFILER_CALL(
-                    rocprofiler_configure_device_thread_trace_service(agent_ctx,
+                    rocprofiler_configure_device_thread_trace_service(att_device_context,
                                                                       agent.id,
                                                                       agent_params.data(),
                                                                       agent_params.size(),

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -262,7 +262,10 @@ using kernel_rename_stack_t = std::stack<uint64_t>;
 auto*      tool_metadata     = as_pointer<tool::metadata>(tool::metadata::inprocess{});
 auto       target_kernels    = common::Synchronized<targeted_kernels_map_t>{};
 auto*      execution_profile = as_pointer<common::Synchronized<tool::execution_profile_data>>();
-auto       counter_collection_ctx = rocprofiler_context_id_t{0};
+auto       kernel_iteration  = common::Synchronized<kernel_iteration_t, true>{};
+auto       counter_collection_ctx             = rocprofiler_context_id_t{0};
+auto       agent_ctx                          = rocprofiler_context_id_t{0};
+auto       att_consecutive_kernel_dispatch_id = rocprofiler_dispatch_id_t{0};
 std::mutex att_shader_data;
 
 thread_local auto thread_dispatch_rename      = as_pointer<kernel_rename_stack_t>();
@@ -1390,9 +1393,14 @@ att_shader_data_callback(rocprofiler_agent_id_t  agent,
 {
     std::lock_guard<std::mutex> lock(att_shader_data);
     std::stringstream           filename;
-    filename << fmt::format("{}_shader_engine_{}_{}", agent.handle, se_id, userdata.value);
+    auto                        dispatch_id = 0;
+    const auto handle_consecutive_kernels   = tool::get_config().att_consecutive_kernels > 1;
+    if(handle_consecutive_kernels)
+        dispatch_id = *static_cast<rocprofiler_dispatch_id_t*>(CHECK_NOTNULL(userdata.ptr));
+    else
+        dispatch_id = static_cast<rocprofiler_dispatch_id_t>(userdata.value);
+    filename << fmt::format("{}_shader_engine_{}_{}", agent.handle, se_id, dispatch_id);
 
-    auto        dispatch_id     = static_cast<rocprofiler_dispatch_id_t>(userdata.value);
     auto        output_stream   = get_output_stream(tool::get_config(), filename.str(), ".att");
     std::string output_filename = get_output_filename(tool::get_config(), filename.str(), ".att");
 
@@ -1410,8 +1418,6 @@ att_dispatch_callback(rocprofiler_agent_id_t /* agent_id  */,
                       void* /*userdata_config*/,
                       rocprofiler_user_data_t* userdata_shader)
 {
-    static auto kernel_iteration = common::Synchronized<kernel_iteration_t, true>{};
-
     userdata_shader->value = dispatch_id;
 
     if(is_targeted_kernel(kernel_id, kernel_iteration))
@@ -1420,13 +1426,69 @@ att_dispatch_callback(rocprofiler_agent_id_t /* agent_id  */,
 }
 
 void
+att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t record,
+                                         rocprofiler_user_data_t* /*user_data*/,
+                                         void* userdata)
+{
+    if(record.kind != ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH) return;
+    if(record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT) return;
+
+    assert(record.payload != nullptr);
+    auto* rdata = static_cast<rocprofiler_callback_tracing_kernel_dispatch_data_t*>(record.payload);
+    auto  dispatch_id = rdata->dispatch_info.dispatch_id;
+    // auto  kernel_id = rdata->dispatch_info.kernel_id;
+
+    // Keep track of number of consecutive kernels
+    const auto                 consecutive_kernels = tool::get_config().att_consecutive_kernels;
+    static std::atomic<size_t> num_consecutive_kernels{0};
+    size_t                     local_count = num_consecutive_kernels.fetch_add(1);
+
+    static std::atomic<bool> isprofiling{false};
+    static std::atomic<bool> stop_profiling{false};
+
+    static std::mutex    mut{};
+    static std::set<int> captured_ids{};
+    if(record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER)
+    {
+        if(local_count == 0)
+        {
+            ROCPROFILER_CALL(rocprofiler_start_context(agent_ctx), "context start");
+            isprofiling.store(true);
+        }
+        if(isprofiling && local_count < consecutive_kernels)
+        {
+            std::unique_lock<std::mutex> lk(mut);
+            // Keep track of launched dispatch ids
+            captured_ids.insert(dispatch_id);
+            // Store dispatch id in userdata pointer for shader callback function
+            auto* shader_userdata =
+                CHECK_NOTNULL(static_cast<rocprofiler_dispatch_id_t*>(userdata));
+            *shader_userdata = dispatch_id;
+        }
+        if(local_count >= consecutive_kernels) stop_profiling.store(true);
+        return;
+    }
+
+    assert(record.phase == ROCPROFILER_CALLBACK_PHASE_NONE);
+
+    if(!isprofiling) return;
+
+    std::unique_lock<std::mutex> lk(mut);
+    captured_ids.erase(dispatch_id);
+    if(!captured_ids.empty() || stop_profiling == false) return;
+
+    bool _exp = true;
+    if(!isprofiling.compare_exchange_strong(_exp, false, std::memory_order_relaxed)) return;
+
+    ROCPROFILER_CALL(rocprofiler_stop_context(agent_ctx), "context stop");
+}
+
+void
 counter_dispatch_callback(rocprofiler_dispatch_counting_service_data_t dispatch_data,
                           rocprofiler_counter_config_id_t*             config,
                           rocprofiler_user_data_t*                     user_data,
                           void* /*callback_data_args*/)
 {
-    static auto kernel_iteration = common::Synchronized<kernel_iteration_t, true>{};
-
     auto kernel_id = dispatch_data.dispatch_info.kernel_id;
     auto agent_id  = dispatch_data.dispatch_info.agent_id;
 
@@ -1726,6 +1788,7 @@ struct tracing_callbacks_t
     , att_shader_data{att_shader_data_callback}
     , counter_dispatch{counter_dispatch_callback}
     , counter_record{counter_record_callback}
+    , att_dispatch_consecutive_kernel{att_dispatch_consecutive_kernel_callback}
     {}
 
     explicit tracing_callbacks_t(dummy_callbacks_t)
@@ -1740,17 +1803,18 @@ struct tracing_callbacks_t
     , counter_record{dummy_counter_record_callback}
     {}
 
-    const rocprofiler_callback_tracing_cb_t               code_object_tracing = nullptr;
-    const rocprofiler_callback_tracing_cb_t               cntrl_tracing       = nullptr;
-    const rocprofiler_callback_tracing_cb_t               kernel_rename       = nullptr;
-    const rocprofiler_callback_tracing_cb_t               hip_stream          = nullptr;
-    const rocprofiler_callback_tracing_cb_t               callback_tracing    = nullptr;
-    const rocprofiler_buffer_tracing_cb_t                 buffered_tracing    = nullptr;
-    const rocprofiler_buffer_tracing_cb_t                 pc_sampling         = nullptr;
-    const rocprofiler_thread_trace_dispatch_callback_t    att_dispatch        = nullptr;
-    const rocprofiler_thread_trace_shader_data_callback_t att_shader_data     = nullptr;
-    const rocprofiler_dispatch_counting_service_cb_t      counter_dispatch    = nullptr;
-    const rocprofiler_dispatch_counting_record_cb_t       counter_record      = nullptr;
+    const rocprofiler_callback_tracing_cb_t               code_object_tracing             = nullptr;
+    const rocprofiler_callback_tracing_cb_t               cntrl_tracing                   = nullptr;
+    const rocprofiler_callback_tracing_cb_t               kernel_rename                   = nullptr;
+    const rocprofiler_callback_tracing_cb_t               hip_stream                      = nullptr;
+    const rocprofiler_callback_tracing_cb_t               callback_tracing                = nullptr;
+    const rocprofiler_buffer_tracing_cb_t                 buffered_tracing                = nullptr;
+    const rocprofiler_buffer_tracing_cb_t                 pc_sampling                     = nullptr;
+    const rocprofiler_thread_trace_dispatch_callback_t    att_dispatch                    = nullptr;
+    const rocprofiler_thread_trace_shader_data_callback_t att_shader_data                 = nullptr;
+    const rocprofiler_dispatch_counting_service_cb_t      counter_dispatch                = nullptr;
+    const rocprofiler_dispatch_counting_record_cb_t       counter_record                  = nullptr;
+    const rocprofiler_callback_tracing_cb_t               att_dispatch_consecutive_kernel = nullptr;
 };
 
 auto
@@ -2078,6 +2142,25 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
 
         const auto selecting_by_gpuid = !gpu_idx_set.empty();
 
+        // Use device_thread_trace_service when handling consecutive kernels
+        const auto handle_consecutive_kernels = tool::get_config().att_consecutive_kernels > 1;
+        rocprofiler_user_data_t user{};
+        ROCPROFILER_CALL(rocprofiler_create_context(&agent_ctx), "context creation");
+
+        if(handle_consecutive_kernels)
+        {
+            // Use user data pointer to dispatch id to communicate dispatch ID to shader callback
+            // function
+            ROCPROFILER_CALL(rocprofiler_configure_callback_tracing_service(
+                                 get_client_ctx(),
+                                 ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,
+                                 nullptr,
+                                 0,
+                                 callbacks.att_dispatch_consecutive_kernel,
+                                 static_cast<void*>(&att_consecutive_kernel_dispatch_id)),
+                             "dispatch tracing service configure");
+        }
+
         for(auto& [id, agent] : tool_metadata->agents_map)
         {
             if(agent.type != ROCPROFILER_AGENT_TYPE_GPU) continue;
@@ -2087,16 +2170,30 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
             auto agent_params = global_parameters;
             for(auto& counter : get_att_perfcounter_params(id, att_perf))
                 agent_params.push_back(counter);
-
-            ROCPROFILER_CALL(
-                rocprofiler_configure_dispatch_thread_trace_service(get_client_ctx(),
-                                                                    id,
-                                                                    agent_params.data(),
-                                                                    agent_params.size(),
-                                                                    callbacks.att_dispatch,
-                                                                    callbacks.att_shader_data,
-                                                                    tool_data),
-                "thread trace service configure");
+            if(!handle_consecutive_kernels)
+            {
+                ROCPROFILER_CALL(
+                    rocprofiler_configure_dispatch_thread_trace_service(get_client_ctx(),
+                                                                        id,
+                                                                        agent_params.data(),
+                                                                        agent_params.size(),
+                                                                        callbacks.att_dispatch,
+                                                                        callbacks.att_shader_data,
+                                                                        tool_data),
+                    "thread trace service configure");
+            }
+            else
+            {
+                user.ptr = static_cast<void*>(&att_consecutive_kernel_dispatch_id);
+                ROCPROFILER_CALL(
+                    rocprofiler_configure_device_thread_trace_service(agent_ctx,
+                                                                      agent.id,
+                                                                      agent_params.data(),
+                                                                      agent_params.size(),
+                                                                      callbacks.att_shader_data,
+                                                                      user),
+                    "thread trace service configure");
+            }
         }
 
         // Any agent not removed by above loop was not in the agents_map list

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -1394,7 +1394,7 @@ att_shader_data_callback(rocprofiler_agent_id_t  agent,
     std::lock_guard<std::mutex> lock(att_shader_data);
     std::stringstream           filename;
     auto                        dispatch_id = 0;
-    const auto handle_consecutive_kernels   = tool::get_config().att_consecutive_kernels > 1;
+    const auto handle_consecutive_kernels   = tool::get_config().att_consecutive_kernels >= 1;
     if(handle_consecutive_kernels)
         dispatch_id = *static_cast<rocprofiler_dispatch_id_t*>(CHECK_NOTNULL(userdata.ptr));
     else
@@ -1431,29 +1431,40 @@ att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t r
                                          void* userdata)
 {
     if(record.kind != ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH) return;
-    if(record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT) return;
+    if(record.phase == ROCPROFILER_CALLBACK_PHASE_NONE) return;
 
     assert(record.payload != nullptr);
     auto* rdata = static_cast<rocprofiler_callback_tracing_kernel_dispatch_data_t*>(record.payload);
     auto  dispatch_id = rdata->dispatch_info.dispatch_id;
-    // auto  kernel_id = rdata->dispatch_info.kernel_id;
+    auto  kernel_id   = rdata->dispatch_info.kernel_id;
 
     // Keep track of number of consecutive kernels
     const auto                 consecutive_kernels = tool::get_config().att_consecutive_kernels;
     static std::atomic<size_t> num_consecutive_kernels{0};
-    size_t                     local_count = num_consecutive_kernels.fetch_add(1);
+    size_t                     local_count{0};
 
     static std::atomic<bool> isprofiling{false};
     static std::atomic<bool> stop_profiling{false};
 
-    static std::mutex    mut{};
-    static std::set<int> captured_ids{};
+    static std::mutex                          mut{};
+    static std::set<rocprofiler_dispatch_id_t> captured_ids{};
     if(record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER)
     {
-        if(local_count == 0)
+        // Reset counter if kernel ID and iteration range matches
+        if(is_targeted_kernel(kernel_id, kernel_iteration))
         {
-            ROCPROFILER_CALL(rocprofiler_start_context(agent_ctx), "context start");
-            isprofiling.store(true);
+            num_consecutive_kernels.store(0);
+            bool _exp = false;
+            if(!isprofiling &&
+               isprofiling.compare_exchange_strong(_exp, true, std::memory_order_relaxed))
+            {
+                ROCPROFILER_CALL(rocprofiler_start_context(agent_ctx), "context start");
+            }
+        }
+        // Increment counter if we are profiling
+        else if(isprofiling)
+        {
+            local_count = num_consecutive_kernels.fetch_add(1);
         }
         if(isprofiling && local_count < consecutive_kernels)
         {
@@ -1469,7 +1480,7 @@ att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t r
         return;
     }
 
-    assert(record.phase == ROCPROFILER_CALLBACK_PHASE_NONE);
+    assert(record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT);
 
     if(!isprofiling) return;
 
@@ -2143,14 +2154,14 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
         const auto selecting_by_gpuid = !gpu_idx_set.empty();
 
         // Use device_thread_trace_service when handling consecutive kernels
-        const auto handle_consecutive_kernels = tool::get_config().att_consecutive_kernels > 1;
+        const auto handle_consecutive_kernels = tool::get_config().att_consecutive_kernels >= 1;
         rocprofiler_user_data_t user{};
-        ROCPROFILER_CALL(rocprofiler_create_context(&agent_ctx), "context creation");
 
         if(handle_consecutive_kernels)
         {
             // Use user data pointer to dispatch id to communicate dispatch ID to shader callback
             // function
+            ROCPROFILER_CALL(rocprofiler_create_context(&agent_ctx), "context creation");
             ROCPROFILER_CALL(rocprofiler_configure_callback_tracing_service(
                                  get_client_ctx(),
                                  ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -262,10 +262,9 @@ using kernel_rename_stack_t = std::stack<uint64_t>;
 auto*      tool_metadata     = as_pointer<tool::metadata>(tool::metadata::inprocess{});
 auto       target_kernels    = common::Synchronized<targeted_kernels_map_t>{};
 auto*      execution_profile = as_pointer<common::Synchronized<tool::execution_profile_data>>();
-auto       kernel_iteration  = common::Synchronized<kernel_iteration_t, true>{};
 auto       counter_collection_ctx             = rocprofiler_context_id_t{0};
 auto       agent_ctx                          = rocprofiler_context_id_t{0};
-auto       att_consecutive_kernel_dispatch_id = rocprofiler_dispatch_id_t{0};
+auto       att_consecutive_kernel_dispatch_id = std::atomic<rocprofiler_dispatch_id_t>{0};
 std::mutex att_shader_data;
 
 thread_local auto thread_dispatch_rename      = as_pointer<kernel_rename_stack_t>();
@@ -1393,12 +1392,8 @@ att_shader_data_callback(rocprofiler_agent_id_t  agent,
 {
     std::lock_guard<std::mutex> lock(att_shader_data);
     std::stringstream           filename;
-    auto                        dispatch_id = 0;
-    const auto handle_consecutive_kernels   = tool::get_config().att_consecutive_kernels >= 1;
-    if(handle_consecutive_kernels)
-        dispatch_id = *static_cast<rocprofiler_dispatch_id_t*>(CHECK_NOTNULL(userdata.ptr));
-    else
-        dispatch_id = static_cast<rocprofiler_dispatch_id_t>(userdata.value);
+    auto dispatch_id = static_cast<rocprofiler_dispatch_id_t>(userdata.value);
+    if(dispatch_id == 0) dispatch_id = att_consecutive_kernel_dispatch_id.load();
     filename << fmt::format("{}_shader_engine_{}_{}", agent.handle, se_id, dispatch_id);
 
     auto        output_stream   = get_output_stream(tool::get_config(), filename.str(), ".att");
@@ -1418,7 +1413,8 @@ att_dispatch_callback(rocprofiler_agent_id_t /* agent_id  */,
                       void* /*userdata_config*/,
                       rocprofiler_user_data_t* userdata_shader)
 {
-    userdata_shader->value = dispatch_id;
+    static auto kernel_iteration = common::Synchronized<kernel_iteration_t, true>{};
+    userdata_shader->value       = dispatch_id;
 
     if(is_targeted_kernel(kernel_id, kernel_iteration))
         return ROCPROFILER_THREAD_TRACE_CONTROL_START_AND_STOP;
@@ -1428,12 +1424,13 @@ att_dispatch_callback(rocprofiler_agent_id_t /* agent_id  */,
 void
 att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t record,
                                          rocprofiler_user_data_t* /*user_data*/,
-                                         void* userdata)
+                                         void* /*userdata*/)
 {
     if(record.kind != ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH) return;
     if(record.phase == ROCPROFILER_CALLBACK_PHASE_NONE) return;
 
     assert(record.payload != nullptr);
+    static auto kernel_iteration = common::Synchronized<kernel_iteration_t, true>{};
     auto* rdata = static_cast<rocprofiler_callback_tracing_kernel_dispatch_data_t*>(record.payload);
     auto  dispatch_id = rdata->dispatch_info.dispatch_id;
     auto  kernel_id   = rdata->dispatch_info.kernel_id;
@@ -1446,35 +1443,41 @@ att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t r
     static std::atomic<bool> isprofiling{false};
     static std::atomic<bool> stop_profiling{false};
 
-    static std::mutex                          mut{};
-    static std::set<rocprofiler_dispatch_id_t> captured_ids{};
+    static std::mutex                                                          mut{};
+    static common::Synchronized<std::unordered_set<rocprofiler_dispatch_id_t>> captured_ids{};
     if(record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER)
     {
         // Reset counter if kernel ID and iteration range matches
         if(is_targeted_kernel(kernel_id, kernel_iteration))
         {
+            std::unique_lock<std::mutex> lk(mut);
             num_consecutive_kernels.store(0);
             bool _exp = false;
-            if(!isprofiling &&
-               isprofiling.compare_exchange_strong(_exp, true, std::memory_order_relaxed))
+            if(isprofiling.compare_exchange_strong(_exp, true, std::memory_order_relaxed))
             {
                 ROCPROFILER_CALL(rocprofiler_start_context(agent_ctx), "context start");
             }
         }
+
+        std::unique_lock<std::mutex> lk(mut);
         // Increment counter if we are profiling
-        else if(isprofiling)
+        if(isprofiling)
         {
             local_count = num_consecutive_kernels.fetch_add(1);
         }
         if(isprofiling && local_count < consecutive_kernels)
         {
-            std::unique_lock<std::mutex> lk(mut);
             // Keep track of launched dispatch ids
-            captured_ids.insert(dispatch_id);
-            // Store dispatch id in userdata pointer for shader callback function
-            auto* shader_userdata =
-                CHECK_NOTNULL(static_cast<rocprofiler_dispatch_id_t*>(userdata));
-            *shader_userdata = dispatch_id;
+            captured_ids.wlock(
+                [](std::unordered_set<rocprofiler_dispatch_id_t>& _data,
+                   rocprofiler_dispatch_id_t _dispatch_id) { return _data.emplace(_dispatch_id); },
+                dispatch_id);
+            // Store lowest dispatch id for shader callback function
+            rocprofiler_dispatch_id_t _exp{};
+            while((_exp = att_consecutive_kernel_dispatch_id.load()) > dispatch_id &&
+                  !att_consecutive_kernel_dispatch_id.compare_exchange_strong(
+                      _exp, dispatch_id, std::memory_order_relaxed))
+                ;
         }
         if(local_count >= consecutive_kernels) stop_profiling.store(true);
         return;
@@ -1485,13 +1488,21 @@ att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t r
     if(!isprofiling) return;
 
     std::unique_lock<std::mutex> lk(mut);
-    captured_ids.erase(dispatch_id);
-    if(!captured_ids.empty() || stop_profiling == false) return;
+    captured_ids.wlock(
+        [](std::unordered_set<rocprofiler_dispatch_id_t>& _data,
+           rocprofiler_dispatch_id_t _dispatch_id) { return _data.erase(_dispatch_id); },
+        dispatch_id);
+    if(!captured_ids.rlock([](const std::unordered_set<rocprofiler_dispatch_id_t>& _data) {
+           return _data.empty();
+       }) ||
+       stop_profiling == false)
+        return;
 
     bool _exp = true;
     if(!isprofiling.compare_exchange_strong(_exp, false, std::memory_order_relaxed)) return;
 
     ROCPROFILER_CALL(rocprofiler_stop_context(agent_ctx), "context stop");
+    stop_profiling.store(false);
 }
 
 void
@@ -1500,6 +1511,8 @@ counter_dispatch_callback(rocprofiler_dispatch_counting_service_data_t dispatch_
                           rocprofiler_user_data_t*                     user_data,
                           void* /*callback_data_args*/)
 {
+    static auto kernel_iteration = common::Synchronized<kernel_iteration_t, true>{};
+
     auto kernel_id = dispatch_data.dispatch_info.kernel_id;
     auto agent_id  = dispatch_data.dispatch_info.agent_id;
 
@@ -2155,7 +2168,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
 
         // Use device_thread_trace_service when handling consecutive kernels
         const auto handle_consecutive_kernels = tool::get_config().att_consecutive_kernels >= 1;
-        rocprofiler_user_data_t user{};
+        rocprofiler_user_data_t user{.value = 0};
 
         if(handle_consecutive_kernels)
         {
@@ -2168,7 +2181,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
                                  nullptr,
                                  0,
                                  callbacks.att_dispatch_consecutive_kernel,
-                                 static_cast<void*>(&att_consecutive_kernel_dispatch_id)),
+                                 nullptr),
                              "dispatch tracing service configure");
         }
 
@@ -2195,7 +2208,6 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
             }
             else
             {
-                user.ptr = static_cast<void*>(&att_consecutive_kernel_dispatch_id);
                 ROCPROFILER_CALL(
                     rocprofiler_configure_device_thread_trace_service(agent_ctx,
                                                                       agent.id,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -1451,40 +1451,38 @@ att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t r
     if(record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER)
     {
         const auto is_target = is_targeted_kernel(kernel_id, kernel_iteration);
-        // Reset counter if kernel ID and iteration range matches
-        if(is_target || isprofiling)
-        {
-            captured_ids.wlock(
-                [](std::unordered_set<rocprofiler_dispatch_id_t>& _data,
-                   const rocprofiler_dispatch_id_t                _dispatch_id,
-                   const bool                                     _is_target,
-                   const uint64_t                                 _consecutive_kernels) {
-                    // Reset consecutive kernel count and start context if not already started
-                    if(_is_target)
-                    {
-                        num_consecutive_kernels = 0;
-                        if(!isprofiling.load())
-                        {
-                            ROCPROFILER_CALL(rocprofiler_start_context(att_device_context),
-                                             "context start");
-                            isprofiling.store(true);
-                        }
-                    }
-                    const auto local_count = num_consecutive_kernels++;
-                    if(isprofiling && local_count < _consecutive_kernels)
-                    {
-                        // Keep track of launched dispatch ids
-                        _data.emplace(_dispatch_id);
-                        // Store lowest dispatch id for shader callback function
-                        if(att_consecutive_kernel_dispatch_id.load() > _dispatch_id)
-                            att_consecutive_kernel_dispatch_id.store(_dispatch_id);
-                    }
-                    if(local_count >= _consecutive_kernels) stop_profiling = true;
-                },
-                dispatch_id,
-                is_target,
-                consecutive_kernels);
-        }
+        // Return if kernel is not targeted and we are not profiling currently
+        if(!is_target && !isprofiling.load()) return;
+
+        captured_ids.wlock(
+            [](std::unordered_set<rocprofiler_dispatch_id_t>& _data,
+               const rocprofiler_dispatch_id_t                _dispatch_id,
+               const bool                                     _is_target,
+               const uint64_t                                 _consecutive_kernels) {
+                // Reset consecutive kernel count and start context if not already started
+                if(_is_target) num_consecutive_kernels = 0;
+                // Start context if target and not started already
+                if(_is_target && !isprofiling.load())
+                {
+                    ROCPROFILER_CALL(rocprofiler_start_context(att_device_context),
+                                     "context start");
+                    isprofiling.store(true);
+                }
+                const auto local_count = num_consecutive_kernels++;
+                if(isprofiling && local_count < _consecutive_kernels)
+                {
+                    // Keep track of launched dispatch ids
+                    _data.emplace(_dispatch_id);
+                    // Store lowest dispatch id for shader callback function
+                    if(att_consecutive_kernel_dispatch_id.load() > _dispatch_id)
+                        att_consecutive_kernel_dispatch_id.store(_dispatch_id);
+                }
+                if(local_count >= _consecutive_kernels) stop_profiling = true;
+            },
+            dispatch_id,
+            is_target,
+            consecutive_kernels);
+
         return;
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -1433,7 +1433,8 @@ att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t r
     if(record.kind != ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH) return;
     if(record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT) return;
 
-    assert(record.payload != nullptr);
+    ROCP_FATAL_IF(record.payload != nullptr)
+        << fmt::format("Expected record payload to not be null for {}", __FUNCTION__);
     static auto kernel_iteration = common::Synchronized<kernel_iteration_t, true>{};
     auto* rdata = static_cast<rocprofiler_callback_tracing_kernel_dispatch_data_t*>(record.payload);
     auto  dispatch_id = rdata->dispatch_info.dispatch_id;
@@ -1487,7 +1488,8 @@ att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t r
         return;
     }
 
-    assert(record.phase == ROCPROFILER_CALLBACK_PHASE_NONE);
+    ROCP_CI_LOG_IF(WARNING, record.phase != ROCPROFILER_CALLBACK_PHASE_NONE) << fmt::format(
+        "Expected record phase to be ROCPROFILER_CALLBACK_PHASE_NONE for {}", __FUNCTION__);
 
     if(!isprofiling) return;
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -1426,6 +1426,7 @@ att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t r
                                          rocprofiler_user_data_t* /*user_data*/,
                                          void* /*userdata*/)
 {
+    using capture_ids_set_t = common::Synchronized<std::unordered_set<rocprofiler_dispatch_id_t>>;
     if(record.kind != ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH) return;
     if(record.phase == ROCPROFILER_CALLBACK_PHASE_NONE) return;
 
@@ -1443,8 +1444,23 @@ att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t r
     static std::atomic<bool> isprofiling{false};
     static std::atomic<bool> stop_profiling{false};
 
-    static std::mutex                                                          mut{};
-    static common::Synchronized<std::unordered_set<rocprofiler_dispatch_id_t>> captured_ids{};
+    static std::mutex        mut{};
+    static capture_ids_set_t captured_ids{};
+    auto                     add_capture_id =
+        [](capture_ids_set_t&                      _captured_ids,
+           std::atomic<rocprofiler_dispatch_id_t>& _att_consecutive_kernel_dispatch_id,
+           const rocprofiler_dispatch_id_t         _dispatch_id) {
+            // Keep track of launched dispatch ids
+            _captured_ids.wlock([](std::unordered_set<rocprofiler_dispatch_id_t>& _data,
+                                   rocprofiler_dispatch_id_t _did) { return _data.emplace(_did); },
+                                _dispatch_id);
+            // Store lowest dispatch id for shader callback function
+            rocprofiler_dispatch_id_t _exp{};
+            while((_exp = _att_consecutive_kernel_dispatch_id.load()) > _dispatch_id &&
+                  !_att_consecutive_kernel_dispatch_id.compare_exchange_strong(
+                      _exp, _dispatch_id, std::memory_order_relaxed))
+                ;
+        };
     if(record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER)
     {
         // Reset counter if kernel ID and iteration range matches
@@ -1457,29 +1473,22 @@ att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t r
             {
                 ROCPROFILER_CALL(rocprofiler_start_context(agent_ctx), "context start");
             }
+            add_capture_id(captured_ids, att_consecutive_kernel_dispatch_id, dispatch_id);
         }
-
-        std::unique_lock<std::mutex> lk(mut);
-        // Increment counter if we are profiling
-        if(isprofiling)
+        else
         {
-            local_count = num_consecutive_kernels.fetch_add(1);
+            std::unique_lock<std::mutex> lk(mut);
+            // Increment counter if we are profiling
+            if(isprofiling)
+            {
+                local_count = num_consecutive_kernels.fetch_add(1);
+            }
+            if(isprofiling && local_count < consecutive_kernels)
+            {
+                add_capture_id(captured_ids, att_consecutive_kernel_dispatch_id, dispatch_id);
+            }
+            if(local_count >= consecutive_kernels) stop_profiling.store(true);
         }
-        if(isprofiling && local_count < consecutive_kernels)
-        {
-            // Keep track of launched dispatch ids
-            captured_ids.wlock(
-                [](std::unordered_set<rocprofiler_dispatch_id_t>& _data,
-                   rocprofiler_dispatch_id_t _dispatch_id) { return _data.emplace(_dispatch_id); },
-                dispatch_id);
-            // Store lowest dispatch id for shader callback function
-            rocprofiler_dispatch_id_t _exp{};
-            while((_exp = att_consecutive_kernel_dispatch_id.load()) > dispatch_id &&
-                  !att_consecutive_kernel_dispatch_id.compare_exchange_strong(
-                      _exp, dispatch_id, std::memory_order_relaxed))
-                ;
-        }
-        if(local_count >= consecutive_kernels) stop_profiling.store(true);
         return;
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -259,12 +259,13 @@ using kernel_iteration_t    = std::unordered_map<rocprofiler_kernel_id_t, size_t
 using kernel_rename_map_t   = std::unordered_map<uint64_t, uint64_t>;
 using kernel_rename_stack_t = std::stack<uint64_t>;
 
-auto*      tool_metadata     = as_pointer<tool::metadata>(tool::metadata::inprocess{});
-auto       target_kernels    = common::Synchronized<targeted_kernels_map_t>{};
-auto*      execution_profile = as_pointer<common::Synchronized<tool::execution_profile_data>>();
-auto       counter_collection_ctx             = rocprofiler_context_id_t{0};
-auto       att_device_context                 = rocprofiler_context_id_t{0};
-auto       att_consecutive_kernel_dispatch_id = std::atomic<rocprofiler_dispatch_id_t>{0};
+auto* tool_metadata          = as_pointer<tool::metadata>(tool::metadata::inprocess{});
+auto  target_kernels         = common::Synchronized<targeted_kernels_map_t>{};
+auto* execution_profile      = as_pointer<common::Synchronized<tool::execution_profile_data>>();
+auto  counter_collection_ctx = rocprofiler_context_id_t{0};
+auto  att_device_context     = rocprofiler_context_id_t{0};
+auto  att_consecutive_kernel_dispatch_id =
+    std::atomic<rocprofiler_dispatch_id_t>{std::numeric_limits<uint64_t>::max()};
 std::mutex att_shader_data;
 
 thread_local auto thread_dispatch_rename      = as_pointer<kernel_rename_stack_t>();
@@ -1461,11 +1462,12 @@ att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t r
                     if(_is_target)
                     {
                         num_consecutive_kernels = 0;
-                        bool _exp               = false;
-                        if(isprofiling.compare_exchange_strong(
-                               _exp, true, std::memory_order_relaxed))
+                        if(!isprofiling.load())
+                        {
                             ROCPROFILER_CALL(rocprofiler_start_context(att_device_context),
                                              "context start");
+                            isprofiling.store(true);
+                        }
                     }
                     const auto local_count = num_consecutive_kernels++;
                     if(isprofiling && local_count < _consecutive_kernels)
@@ -1473,11 +1475,8 @@ att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t r
                         // Keep track of launched dispatch ids
                         _data.emplace(_dispatch_id);
                         // Store lowest dispatch id for shader callback function
-                        rocprofiler_dispatch_id_t _exp{};
-                        while((_exp = att_consecutive_kernel_dispatch_id.load()) > _dispatch_id &&
-                              !att_consecutive_kernel_dispatch_id.compare_exchange_strong(
-                                  _exp, _dispatch_id, std::memory_order_relaxed))
-                            ;
+                        if(att_consecutive_kernel_dispatch_id.load() > _dispatch_id)
+                            att_consecutive_kernel_dispatch_id.store(_dispatch_id);
                     }
                     if(local_count >= _consecutive_kernels) stop_profiling = true;
                 },
@@ -1504,6 +1503,7 @@ att_dispatch_consecutive_kernel_callback(rocprofiler_callback_tracing_record_t r
 
             ROCPROFILER_CALL(rocprofiler_stop_context(att_device_context), "context stop");
             stop_profiling = false;
+            att_consecutive_kernel_dispatch_id.store(std::numeric_limits<uint64_t>::max());
         },
         dispatch_id);
 }

--- a/projects/rocprofiler-sdk/tests/rocprofv3/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/CMakeLists.txt
@@ -49,4 +49,8 @@ add_subdirectory(python-bindings)
 add_subdirectory(rocpd)
 add_subdirectory(rocpd-kernel-rename)
 add_subdirectory(attachment)
+<<<<<<< HEAD
 add_subdirectory(rocpd-scratch)
+=======
+add_subdirectory(att-consecutive-kernels)
+>>>>>>> fab529b3d5 (Add test to check that generated stats csv file is not empty)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/CMakeLists.txt
@@ -49,8 +49,5 @@ add_subdirectory(python-bindings)
 add_subdirectory(rocpd)
 add_subdirectory(rocpd-kernel-rename)
 add_subdirectory(attachment)
-<<<<<<< HEAD
 add_subdirectory(rocpd-scratch)
-=======
 add_subdirectory(att-consecutive-kernels)
->>>>>>> fab529b3d5 (Add test to check that generated stats csv file is not empty)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/CMakeLists.txt
@@ -66,7 +66,7 @@ add_test(
     NAME rocprofv3-test-att-consecutive-kernels-execute
     COMMAND
         $<TARGET_FILE:rocprofiler-sdk::rocprofv3> ${ATT_LIB} --att
-        --att-consecutive-kernels 20 -d ${CMAKE_CURRENT_BINARY_DIR}/%tag%-trace -o out --
+        --att-consecutive-kernels 8 -d ${CMAKE_CURRENT_BINARY_DIR}/%tag%-trace -o out --
         $<TARGET_FILE:vector-ops>)
 
 set_tests_properties(

--- a/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/CMakeLists.txt
@@ -66,7 +66,7 @@ add_test(
     NAME rocprofv3-test-att-consecutive-kernels-execute
     COMMAND
         $<TARGET_FILE:rocprofiler-sdk::rocprofv3> ${ATT_LIB} --att
-        --att-consecutive-kernels 10 -d ${CMAKE_CURRENT_BINARY_DIR}/%tag%-trace -o out --
+        --att-consecutive-kernels 20 -d ${CMAKE_CURRENT_BINARY_DIR}/%tag%-trace -o out --
         $<TARGET_FILE:vector-ops>)
 
 set_tests_properties(

--- a/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/CMakeLists.txt
@@ -66,8 +66,8 @@ add_test(
     NAME rocprofv3-test-att-consecutive-kernels-execute
     COMMAND
         $<TARGET_FILE:rocprofiler-sdk::rocprofv3> ${ATT_LIB} --att
-        --att-consecutive-kernels 8 -d ${CMAKE_CURRENT_BINARY_DIR}/%tag%-trace -o out --
-        $<TARGET_FILE:vector-ops>)
+        --att-consecutive-kernels 8 -d ${CMAKE_CURRENT_BINARY_DIR}/%tag%-trace -o out
+        --log-level env -- $<TARGET_FILE:vector-ops>)
 
 set_tests_properties(
     rocprofv3-test-att-consecutive-kernels-execute

--- a/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/CMakeLists.txt
@@ -1,0 +1,91 @@
+# MIT License
+#
+# Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+#
+# rocprofv3 tool test
+#
+cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
+
+include(FindPackageHandleStandardArgs)
+
+project(
+    rocprofiler-sdk-tests-rocprofv3-att
+    LANGUAGES CXX
+    VERSION 0.0.0)
+
+set(CMAKE_MESSAGE_INDENT "[${PROJECT_NAME}] ")
+
+string(REPLACE "LD_PRELOAD=" "ROCPROF_PRELOAD=" PRELOAD_ENV
+               "${ROCPROFILER_MEMCHECK_PRELOAD_ENV}")
+
+rocprofiler_configure_pytest_files(CONFIG pytest.ini COPY validate.py conftest.py)
+
+find_package(rocprofiler-sdk REQUIRED)
+
+find_library(
+    attdecoder_LIBRARY
+    NAMES rocprof-trace-decoder
+    HINTS ${ROCM_PATH}
+    PATHS ${ROCM_PATH}
+    PATH_SUFFIXES lib)
+
+if(attdecoder_LIBRARY)
+    cmake_path(GET attdecoder_LIBRARY PARENT_PATH attdecoder_LIB_DIR)
+endif()
+
+find_package_handle_standard_args(attdecoder REQUIRED_VARS attdecoder_LIB_DIR
+                                                           attdecoder_LIBRARY)
+
+set(IS_DISABLED ON)
+if(attdecoder_FOUND)
+    set(IS_DISABLED OFF)
+    set(ATT_LIB --att-library-path ${attdecoder_LIB_DIR})
+endif()
+
+# consecutive kernel test
+add_test(
+    NAME rocprofv3-test-att-consecutive-kernels-execute
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> ${ATT_LIB} --att
+        --att-consecutive-kernels 10 -d ${CMAKE_CURRENT_BINARY_DIR}/%tag%-trace -o out --
+        $<TARGET_FILE:vector-ops>)
+
+set_tests_properties(
+    rocprofv3-test-att-consecutive-kernels-execute
+    PROPERTIES TIMEOUT 45 LABELS "integration-tests" DISABLED ${IS_DISABLED})
+
+add_test(NAME rocprofv3-test-att-consecutive-kernels-validate
+         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/validate.py
+                 --csv-directory-input ${CMAKE_CURRENT_BINARY_DIR}/vector-ops-trace/)
+
+set_tests_properties(
+    rocprofv3-test-att-consecutive-kernels-validate
+    PROPERTIES TIMEOUT
+               60
+               LABELS
+               "integration-tests"
+               DEPENDS
+               rocprofv3-test-att-consecutive-kernels-execute
+               FAIL_REGULAR_EXPRESSION
+               "AssertionError"
+               DISABLED
+               ${IS_DISABLED})

--- a/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/conftest.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import csv
+import pytest
+import json
+
+from rocprofiler_sdk.pytest_utils.dotdict import dotdict
+from rocprofiler_sdk.pytest_utils import collapse_dict_list
+from rocprofiler_sdk.pytest_utils.perfetto_reader import PerfettoReader
+
+import re
+import os
+
+
+def pytest_addoption(parser):
+
+    parser.addoption(
+        "--csv-directory-input",
+        action="store",
+        help="Path to stats csv file.",
+    )
+
+
+@pytest.fixture
+def csv_data(request):
+    import glob
+
+    directory = request.config.getoption("--csv-directory-input")
+
+    data = []
+    if not os.path.isdir(directory):
+        raise FileExistsError(f"{directory} does not exist")
+
+    stats_glob = os.path.join(directory, "stats*.csv")
+    for filename in glob.glob(stats_glob):
+        file_data = []
+        with open(filename, "r") as inp:
+            reader = csv.DictReader(inp)
+            for row in reader:
+                file_data.append(row)
+        data.append(file_data)
+    return data

--- a/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/pytest.ini
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/pytest.ini
@@ -1,0 +1,27 @@
+# MIT License
+#
+# Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+[pytest]
+addopts = --durations=20 -rA -s -vv
+testpaths = validate.py
+pythonpath = @ROCPROFILER_SDK_TESTS_BINARY_DIR@/pytest-packages

--- a/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/validate.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import sys
+import pytest
+
+
+def test_csv_data(csv_data):
+    assert len(csv_data) > 0, "Expected at least one stats csv file"
+
+    for stats_csv_data in csv_data:
+        assert len(stats_csv_data) > 0, "Expected stats csv file to be non-empty"
+
+
+if __name__ == "__main__":
+    exit_code = pytest.main(["-x", __file__] + sys.argv[1:])
+    sys.exit(exit_code)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/validate.py
@@ -41,7 +41,7 @@ def test_csv_data(csv_data):
             if kernel_pattern.search(row["Source"]):
                 kernel_set.add(row["Source"])
 
-    assert len(kernel_set) == 4, "Expected all vector-ops kernels to be recorded"
+    assert len(kernel_set) >= 4, "Expected all vector-ops kernels to be recorded"
 
 
 if __name__ == "__main__":

--- a/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/att-consecutive-kernels/validate.py
@@ -21,7 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-
+import re
 import sys
 import pytest
 
@@ -29,8 +29,19 @@ import pytest
 def test_csv_data(csv_data):
     assert len(csv_data) > 0, "Expected at least one stats csv file"
 
+    kernel_pattern = re.compile("kernel")
+    MIN_EXPECTED_LINES = 5
+    kernel_set = set()
     for stats_csv_data in csv_data:
-        assert len(stats_csv_data) > 0, "Expected stats csv file to be non-empty"
+        assert (
+            len(stats_csv_data) >= MIN_EXPECTED_LINES
+        ), "Expected stats csv file to be non-empty"
+
+        for row in stats_csv_data:
+            if kernel_pattern.search(row["Source"]):
+                kernel_set.add(row["Source"])
+
+    assert len(kernel_set) == 4, "Expected all vector-ops kernels to be recorded"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

[SWDEV-528705](https://ontrack-internal.amd.com/browse/SWDEV-528705): ROCprof V3 Tool: MultiKernelDispatch ATT support

Currently when dumping ATT traces for a range --kernel-iteration-range [[x,y]], each dispatch is a separate att file. Request to have a multi dispatch ATT file for ROCM.

## Technical Details

- Add a parameter to say how many consecutive kernels to profile (N)
- If N is more than 1, then configure the tool using rocprofiler_configure_device_thread_trace instead of *_dispatch_*
- Keep thread trace active for every matching kernels for the N dispatches

## Test Plan

TBA

## Test Result

TBA

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
