### PR TITLE
Enable `MARKER_CORE_RANGE_API` in json-tool

### DIFF
--- a/projects/rocprofiler-sdk/tests/tools/json-tool.cpp
+++ b/projects/rocprofiler-sdk/tests/tools/json-tool.cpp
@@ -1421,6 +1421,15 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
                                                        nullptr),
         "code object tracing service configure");
 
+    ROCPROFILER_CALL(
+        rocprofiler_configure_callback_tracing_service(marker_api_callback_ctx,
+                                                       ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_API,
+                                                       nullptr,
+                                                       0,
+                                                       tool_tracing_callback,
+                                                       nullptr),
+        "marker core api tracing service configure");
+
     ROCPROFILER_CALL(rocprofiler_configure_callback_tracing_service(
                          marker_api_callback_ctx,
                          ROCPROFILER_CALLBACK_TRACING_MARKER_CORE_RANGE_API,
@@ -1765,6 +1774,14 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
     //                                                  0,
     //                                                  hip_api_buffered_buffer),
     //     "buffer tracing service configure");
+
+    ROCPROFILER_CALL(
+        rocprofiler_configure_buffer_tracing_service(marker_api_buffered_ctx,
+                                                     ROCPROFILER_BUFFER_TRACING_MARKER_CORE_API,
+                                                     nullptr,
+                                                     0,
+                                                     marker_api_buffered_buffer),
+        "buffer tracing service configure - MARKER_CORE_API");
 
     ROCPROFILER_CALL(rocprofiler_configure_buffer_tracing_service(
                          marker_api_buffered_ctx,


### PR DESCRIPTION
Replaces #179. 

## Motivation
Enables marker core range API in the json tool and perfetto output for marker ranges. This change should make it easier to debug tests which use marker API. 

This change would be helpful for a memory copy tracing test that I plan to add in the near future because it makes it much easier to both visualize (with perfetto dumps) and walk the call stack with ancestor IDs. 

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

* Add `MARKER_CORE_API` buffer and callback to tracing
* Add perfetto output to json tool

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
