### PR TITLE
SWDEV-538789 - Cleanup unused values

### DIFF
--- a/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfBufferCopySpeed.cc
@@ -60,18 +60,7 @@ static void checkData(void* ptr, unsigned int size, char value) {
 
 static bool hipPerfBufferCopySpeed_test(int p_tests) {
   int testIdx = 0;
-  unsigned int bufSize_;
   unsigned int numIter;
-  bool hostMalloc[2] = {false};
-  bool hostRegister[2] = {false};
-  bool unpinnedMalloc[2] = {false};
-  bool deviceMallocUncached[2] = {false};
-  void* memptr[2] = {NULL};
-  void* alignedmemptr[2] = {NULL};
-  void* srcBuffer = NULL;
-  void* dstBuffer = NULL;
-  int numTests = (p_tests == -1) ? (NUM_SIZES * NUM_SUBTESTS * 2 - 1) : p_tests;
-  // int test = (p_tests == -1) ? 0 : p_tests;
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   int test = 0;
@@ -90,7 +79,7 @@ static bool hipPerfBufferCopySpeed_test(int p_tests) {
       HIP_CHECK(hipMalloc(&srcBuffer, bufSize_));
       hipError_t errMemset = hipMemset(srcBuffer, 0xd0, bufSize_);
       if (errMemset != hipSuccess) {
-        hipFree(srcBuffer);
+        HIP_CHECK(hipFree(srcBuffer));
         continue;
       }
       HIP_CHECK(hipSetDevice(1));
@@ -100,9 +89,9 @@ static bool hipPerfBufferCopySpeed_test(int p_tests) {
       HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer10, 1, 0));
       if (!canAccessPeer01 || !canAccessPeer10) {
         HIP_CHECK(hipSetDevice(0));
-        hipDeviceDisablePeerAccess(1);
+        HIP_CHECK(hipDeviceDisablePeerAccess(1));
         HIP_CHECK(hipSetDevice(1));
-        hipDeviceDisablePeerAccess(0);
+        HIP_CHECK(hipDeviceDisablePeerAccess(0));
         HIP_CHECK(hipSetDevice(0));
         HIP_CHECK(hipFree(srcBuffer));
         HIP_CHECK(hipSetDevice(1));
@@ -155,9 +144,9 @@ static bool hipPerfBufferCopySpeed_test(int p_tests) {
       checkData(chkBuf, bufSize_, 0xd0);
       free(temp);
       HIP_CHECK(hipSetDevice(0));
-      hipDeviceDisablePeerAccess(1);
+      HIP_CHECK(hipDeviceDisablePeerAccess(1));
       HIP_CHECK(hipSetDevice(1));
-      hipDeviceDisablePeerAccess(0);
+      HIP_CHECK(hipDeviceDisablePeerAccess(0));
       HIP_CHECK(hipSetDevice(0));
       HIP_CHECK(hipFree(srcBuffer));
       HIP_CHECK(hipSetDevice(1));
@@ -166,8 +155,6 @@ static bool hipPerfBufferCopySpeed_test(int p_tests) {
       ++testIdx;
     }
   }
-  int dstTest = 0;
-  int srcTest = 0;
   // 2. Run all NoCU (intra) for all sizes
   for (int sizeIdx = 0; sizeIdx < NUM_SIZES; ++sizeIdx) {
     if (p_tests != -1 && testIdx != p_tests) {

--- a/projects/hip-tests/catch/perftests/memory/hipPerfDevMemReadSpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfDevMemReadSpeed.cc
@@ -96,7 +96,7 @@ static bool hipPerfDevMemReadSpeed_test() {
 
   if (hDst[0] != (nBytes / sizeof(uint))) {
     DEBUG_PRINT(
-        "hipPerfDevMemReadSpeed - Data validation failed for warm up run! expected %u got %u\n",
+        "hipPerfDevMemReadSpeed - Data validation failed for warm up run! expected %lu got %u\n",
         nBytes / sizeof(uint), hDst[0]);
     return false;
   }

--- a/projects/hip-tests/catch/perftests/memory/hipPerfMemcpyAsyncSpeed.cc
+++ b/projects/hip-tests/catch/perftests/memory/hipPerfMemcpyAsyncSpeed.cc
@@ -124,7 +124,6 @@ TEST_CASE("Perf_hipPerfMemcpyAsyncSpeed_test") {
       const char* strDst = "dM";
       // Double results when src and dst are both on device
       perf *= 2.0;
-      char buf[256];
       CONSOLE_PRINT(
           "hipMemcpyAsync[%d]\t(%8d bytes)\ts:%s d:%s\ti:%4d\t(GB/s) "
           "perf\t%.2f, time per iter(us):\t%.1f, time per iter CPU (us):\t%.1f",


### PR DESCRIPTION
## Motivation

perftests build is treating unused variables as errors

## Technical Details

Removed unused variables in certain tests, fixing build errors

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Built and ran affected perftests locally

## Test Result

All modified perf tests build and run successfully

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
