### PR TITLE
Update dispatch table to move 7.1 new APIs under HIP_RUNTIME_API_TABLE_STEP_VERSION 14

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/hip_api_trace.hpp
+++ b/projects/clr/hipamd/include/hip/amd_detail/hip_api_trace.hpp
@@ -1633,6 +1633,8 @@ struct HipDispatchTable {
 
   // HIP_RUNTIME_API_TABLE_STEP_VERSION = 13
   // removed HIP_MEMSET_NODE_PARAMS replaced by hipMemsetParams
+
+  // HIP_RUNTIME_API_TABLE_STEP_VERSION = 14
   t_hipModuleGetFunctionCount hipModuleGetFunctionCount_fn;
   t_hipMemsetD2D8 hipMemsetD2D8_fn;
   t_hipMemsetD2D8Async hipMemsetD2D8Async_fn;
@@ -1653,10 +1655,8 @@ struct HipDispatchTable {
   t_hipMemAdvise_v2 hipMemAdvise_v2_fn;
   t_hipStreamGetId hipStreamGetId_fn;
 
-  // HIP_RUNTIME_API_TABLE_STEP_VERSION = 14
-
   // DO NOT EDIT ABOVE!
-  // HIP_RUNTIME_API_TABLE_STEP_VERSION == 14
+  // HIP_RUNTIME_API_TABLE_STEP_VERSION == 15
 
   // ******************************************************************************************* //
   //

--- a/projects/clr/hipamd/src/hip_api_trace.cpp
+++ b/projects/clr/hipamd/src/hip_api_trace.cpp
@@ -2042,6 +2042,7 @@ HIP_ENFORCE_ABI(HipDispatchTable, hipDrvLaunchKernelEx_fn, 475);
 // HIP_RUNTIME_API_TABLE_STEP_VERSION == 12
 HIP_ENFORCE_ABI(HipDispatchTable, hipMemGetHandleForAddressRange_fn, 476);
 // HIP_RUNTIME_API_TABLE_STEP_VERSION == 13
+// HIP_RUNTIME_API_TABLE_STEP_VERSION == 14
 HIP_ENFORCE_ABI(HipDispatchTable, hipModuleGetFunctionCount_fn, 477);
 HIP_ENFORCE_ABI(HipDispatchTable, hipMemsetD2D8_fn, 478);
 HIP_ENFORCE_ABI(HipDispatchTable, hipMemsetD2D8Async_fn, 479);


### PR DESCRIPTION
## Motivation
To correct comment for dispatch table
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
7.1 new APIs should go under HIP_RUNTIME_API_TABLE_STEP_VERSION 14
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
N/A
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
N/A
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
