### PR TITLE
Fix build error on musl

### DIFF
--- a/projects/clr/rocclr/os/os.hpp
+++ b/projects/clr/rocclr/os/os.hpp
@@ -394,7 +394,7 @@ inline void Os::ThreadAffinityMask::clear(uint cpu) { CPU_CLR(cpu, &mask_); }
 inline bool Os::ThreadAffinityMask::isSet(uint cpu) const { return CPU_ISSET(cpu, &mask_); }
 
 inline bool Os::ThreadAffinityMask::isEmpty() const {
-  for (__cpu_mask bits : mask_.__bits) {
+  for (auto bits : mask_.__bits) {
     if (bits != 0) {
       return false;
     }
@@ -418,7 +418,7 @@ inline void Os::ThreadAffinityMask::adjust(cpu_set_t& mask) const {
 
 inline uint Os::ThreadAffinityMask::countSet() const {
   uint count = 0;
-  for (__cpu_mask bits : mask_.__bits) {
+  for (auto bits : mask_.__bits) {
     count += countBitsSet(bits);
   }
   return count;
@@ -426,9 +426,9 @@ inline uint Os::ThreadAffinityMask::countSet() const {
 
 inline uint Os::ThreadAffinityMask::getFirstSet() const {
   uint i = 0;
-  for (__cpu_mask bits : mask_.__bits) {
+  for (auto bits : mask_.__bits) {
     if (bits != 0) {
-      return leastBitSet(bits) + (i * (8 * sizeof(__cpu_mask)));
+      return leastBitSet(bits) + (i * (8 * sizeof(((cpu_set_t *)0)->__bits[0])));
     }
 
     ++i;

--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -40,6 +40,7 @@
 #include <dlfcn.h>
 #include <signal.h>
 #include <cxxabi.h>
+#include <libgen.h>
 
 #include <sys/prctl.h>
 #include <sys/resource.h>


### PR DESCRIPTION
## Motivation

Builds fail on musl due to usage of internal types and missing imports.

## Technical Details

Fixed build errors on musl. See individual commit messages for details.

## Test Plan

Run builds.

## Test Result

Builds work.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Closes: https://github.com/ROCm/clr/pull/258