### PR TITLE
cmake(openmp/target): make libomptarget discovery robust across ROCm …

### DIFF
--- a/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
@@ -57,19 +57,39 @@ function(add_offload_flags tgt)
     endforeach()
 endfunction()
 
-get_filename_component(OMP_TARGET_COMPILER_DIR ${OMP_TARGET_COMPILER} PATH)
-get_filename_component(OMP_TARGET_COMPILER_DIR ${OMP_TARGET_COMPILER_DIR} PATH)
+# Derive the ROCm root 
+get_filename_component(_omp_bin_dir "${OMP_TARGET_COMPILER}" DIRECTORY)
+get_filename_component(ROCM_ROOT_DIR "${_omp_bin_dir}" DIRECTORY)
 
 message(STATUS "Using OpenMP target compiler: ${OMP_TARGET_COMPILER}")
-message(STATUS "Using OpenMP target compiler directory: ${OMP_TARGET_COMPILER_DIR}")
+message(STATUS "ROCm root inferred from compiler: ${ROCM_ROOT_DIR}")
 
-set(_rocm_llvm_lib "${OMP_TARGET_COMPILER_DIR}/llvm/lib")
-set(_rocm_clang_lib "${OMP_TARGET_COMPILER_DIR}/lib")
-set(_COMMON_RPATH "${_rocm_llvm_lib};${_rocm_clang_lib}")
+# Candidate lib directories for libomptarget across ROCm layouts
+set(_LLVM_LIB_HINTS
+    "${ROCM_ROOT_DIR}/lib"
+    "${ROCM_ROOT_DIR}/llvm/lib"
+    "$ENV{ROCM_PATH}/llvm/lib"
+    "$ENV{ROCM_PATH}/lib/llvm/lib"
+    "/opt/rocm/llvm/lib"
+    "/opt/rocm/lib/llvm/lib"
+)
 
-if(NOT EXISTS "${_rocm_llvm_lib}/libomptarget.so")
-    message(FATAL_ERROR "Could not find libomptarget.so in ${_rocm_llvm_lib}")
+# Find libomptarget
+find_library(LIBOMPTARGET_SO NAMES omptarget HINTS ${_LLVM_LIB_HINTS})
+
+if(NOT LIBOMPTARGET_SO)
+    message(FATAL_ERROR "Could not find libomptarget in any of:\n  ${_LLVM_LIB_HINTS}")
 endif()
+
+# Use the directory that actually contains the library we found
+get_filename_component(_rocm_llvm_lib "${LIBOMPTARGET_SO}" DIRECTORY)
+set(_rocm_clang_lib "${ROCM_ROOT_DIR}/lib")
+set(_COMMON_RPATH "${_rocm_llvm_lib};${_rocm_clang_lib}")
+list(REMOVE_DUPLICATES _COMMON_RPATH)
+
+message(STATUS "libomptarget found at: ${LIBOMPTARGET_SO}")
+message(STATUS "LLVM libdir: ${_rocm_llvm_lib}")
+message(STATUS "Clang libdir: ${_rocm_clang_lib}")
 
 # Shared library
 

--- a/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
@@ -57,7 +57,7 @@ function(add_offload_flags tgt)
     endforeach()
 endfunction()
 
-# Derive the ROCm root 
+# Derive the ROCm root
 get_filename_component(_omp_bin_dir "${OMP_TARGET_COMPILER}" DIRECTORY)
 get_filename_component(ROCM_ROOT_DIR "${_omp_bin_dir}" DIRECTORY)
 


### PR DESCRIPTION
…layouts

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The OpenMP example (examples/openmp/target) hard-coded the LLVM lib path as ${OMP_TARGET_COMPILER_DIR}/llvm/lib. On systems using the packaged ROCm layout , amdclang++ lives under /opt/rocm/lib/llvm/bin and libomptarget.so is in /opt/rocm/lib/llvm/lib, causing:
Could not find libomptarget.so in /opt/rocm/lib/llvm/llvm/lib

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Derive ROCM_ROOT_DIR from OMP_TARGET_COMPILER (take the parent of …/bin).

Search a small, ordered set of candidate lib directories for libomptarget:
    ${ROCM_ROOT_DIR}/lib 
    ${ROCM_ROOT_DIR}/llvm/lib 
    $ENV{ROCM_PATH}/llvm/lib
    $ENV{ROCM_PATH}/lib/llvm/lib
    /opt/rocm/llvm/lib, /opt/rocm/lib/llvm/lib (final fallbacks)

Use find_library() to locate libomptarget and then:
    Set _rocm_llvm_lib to the directory actually containing the found library.
    Keep _rocm_clang_lib as ${ROCM_ROOT_DIR}/lib.
    Build RPATH from those two and de-duplicate entries.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
1. Configure/built on MI300X
1. Cofigures/built on Navi machine

## Test Result

<!-- Briefly summarize test outcomes. -->
MI300X: unchanged behavior; configure/build succeed; tests pass.
same in Navi machine

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
