### PR TITLE
libhsakmt: Fix memory leak for events_page metadata

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -4573,7 +4573,6 @@ static void fmm_clear_aperture(manageable_aperture_t *app)
 void hsakmt_fmm_clear_all_mem(void)
 {
 	uint32_t i;
-	void *map_addr;
 
 	/* Close render node FDs. The child process needs to open new ones */
 	for (i = 0; i <= DRM_LAST_RENDER_NODE - DRM_FIRST_RENDER_NODE; i++) {
@@ -4586,6 +4585,14 @@ void hsakmt_fmm_clear_all_mem(void)
 		}
 		drm_render_fds[i] = 0;
 	}
+
+	hsakmt_fmm_clear_all_aperture();
+}
+
+void hsakmt_fmm_clear_all_aperture(void)
+{
+	uint32_t i;
+	void *map_addr;
 
 	fmm_clear_aperture(&mem_handle_aperture);
 	fmm_clear_aperture(&cpuvm_aperture);

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.h
@@ -241,6 +241,7 @@ extern int hsakmt_ioctl(int fd, unsigned long request, void *arg);
 
 void hsakmt_clear_events_page(void);
 void hsakmt_fmm_clear_all_mem(void);
+void hsakmt_fmm_clear_all_aperture(void);
 void hsakmt_clear_process_doorbells(void);
 uint32_t hsakmt_get_num_sysfs_nodes(void);
 

--- a/projects/rocr-runtime/libhsakmt/src/openclose.c
+++ b/projects/rocr-runtime/libhsakmt/src/openclose.c
@@ -266,6 +266,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtCloseKFD(void)
 		if (--hsakmt_kfd_open_count == 0) {
 			hsakmt_destroy_counter_props();
 			hsakmt_destroy_device_debugging_memory();
+			hsakmt_fmm_clear_all_aperture();
 		}
 
 		result = HSAKMT_STATUS_SUCCESS;


### PR DESCRIPTION
Clear events_page when hsaKmtCloseKFD is called.
