### PR TITLE
SWDEV-550882 - Fix hang in Unit_hipIpcMemAccess_Semaphores

### DIFF
--- a/projects/hip-tests/catch/multiproc/hipIpcMemAccessTest.cc
+++ b/projects/hip-tests/catch/multiproc/hipIpcMemAccessTest.cc
@@ -138,9 +138,11 @@ TEST_CASE("Unit_hipIpcMemAccess_Semaphores") {
         }
       }
       for (int i = 0; i < Num_devices; ++i) {
-        HIP_CHECK(hipSetDevice(i));
+        
         HIP_CHECK(hipDeviceCanAccessPeer(&CanAccessPeer, i, shrd_mem->device));
         if (CanAccessPeer == 1) {
+          HIP_CHECK(hipDeviceEnablePeerAccess(i, 0));
+          HIP_CHECK(hipSetDevice(i));
           HIP_CHECK(hipMalloc(&C_d, Nbytes));
           HIP_CHECK(hipIpcOpenMemHandle(reinterpret_cast<void**>(&B_d), shrd_mem->memHandle,
                                         hipIpcMemLazyEnablePeerAccess));


### PR DESCRIPTION
## Motivation
The purpose of the PR is to fix a hang in Unit_hipIpcMemAccess_Semaphores
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
## Technical Details
After change https://github.com/ROCm/rocm-systems/pull/683 there is a gpu memory access fault in the child process
during memcpy D2D. The source is memory allocated on a different device and imported via IPC. After change https://github.com/ROCm/rocm-systems/pull/683 the copy follows the hsa copy path instead of submitting a blit kernel. 
This seems to expose an issue with the test as peer access is not enabled between the devices. 
Peer access should have been automatically enabled in hipIpcOpenMemHandle as the hipIpcMemLazyEnablePeerAccess is passed as an argument but this functionality seems to be currently missing in clr. 

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Unit_hipIpcMemAccess_Semaphores test should pass after the changes to explicitly enable peer access between the exporter and the importer devices.
<!-- Explain any relevant testing done to verify this PR. -->
Unit_hipIpcMemAccess_Semaphores test  passes
## Test Result
Unit_hipIpcMemAccess_Semaphores shows no hang after the changes proposed here.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
