### PR TITLE
SWDEV-550882 - Add support for hipIpcMemLazyEnablePeerAccess

### DIFF
--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -3305,6 +3305,7 @@ hipError_t hipIpcGetMemHandle(hipIpcMemHandle_t* handle, void* dev_ptr) {
 
   device = hip::getCurrentDevice()->devices()[0];
   ihandle = reinterpret_cast<amd::MemObjMap::IpcMemHandle*>(handle);
+  ihandle->owners_device_id = hip::getCurrentDevice()->deviceId();
 
   if (!device->IpcCreate(dev_ptr, &(ihandle->psize), ihandle->ipc_handle, &(ihandle->poffset))) {
     LogPrintfError("IPC memory creation failed for memory: 0x%x", dev_ptr);
@@ -3337,6 +3338,13 @@ hipError_t hipIpcOpenMemHandle(void** dev_ptr, hipIpcMemHandle_t handle, unsigne
   if (ihandle->owners_process_id == amd::Os::getProcessId()) {
     HIP_RETURN(hipErrorInvalidContext);
   }
+
+  if (ihandle->owners_device_id >= g_devices.size()) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+
+  amd::Device* peer_device = g_devices[ihandle->owners_device_id]->asContext()->devices()[0];
+  device->enableP2P(peer_device);
 
   amd_mem_obj = amd::MemObjMap::FindIpcHandleMemObj(*ihandle);
   if (amd_mem_obj == nullptr) {

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1392,7 +1392,8 @@ class MemObjMap : public AllStatic {
     size_t psize;                              ///< Total size of the device memory allocation
     size_t poffset;                            ///< Offset within the allocation
     int owners_process_id;                     ///< ID of the process that owns the allocation
-    char reserved[LP64_SWITCH(20, 12)];        ///< Reserved for future extensions
+    int owners_device_id;                      ///< ID of the device that owns the allocation
+    char reserved[LP64_SWITCH(16, 8)];        ///< Reserved for future extensions
 
     bool operator<(const IpcMemHandle& h) const {
       int cmp = std::memcmp(ipc_handle, h.ipc_handle, AMD_IPC_MEM_HANDLE_SIZE);


### PR DESCRIPTION
## Motivation
hipIpcMemLazyEnablePeerAccess should automatically enable peer access between remote devices but this flag seems to be ignored in hip.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Changed hipIpcOpenMemHandle implementation to automatically enable peer access between the current device and the device that owns the allocation.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
After change https://github.com/ROCm/rocm-systems/pull/683 there is a gpu memory access fault in the child process
during memcpy D2D in test Unit_hipIpcMemAccess_Semaphores. The reason for that is that after change https://github.com/ROCm/rocm-systems/pull/683 the copy follows the hsa copy path instead of the blit kernel path.
Because  peer access is not enabled between the devices (hipIpcOpenMemHandle should have enabled it automatically) that leads to a memfault.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Test Unit_hipIpcMemAccess_Semaphores passes after the changes proposed here.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
