### PR TITLE
SWDEV-550667 - Correct the check for availability of __hip_atomic_fetch_add

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_unsafe_atomics.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_unsafe_atomics.h
@@ -182,7 +182,7 @@ __device__ inline float unsafeAtomicMin(float* addr, float val) {
 __device__ inline double unsafeAtomicAdd(double* addr, double value) {
 #if defined(__gfx90a__) && __has_builtin(__builtin_amdgcn_flat_atomic_fadd_f64)
   return __builtin_amdgcn_flat_atomic_fadd_f64(addr, value);
-#elif defined(__hip_atomic_fetch_add)
+#elif __has_builtin(__hip_atomic_fetch_add)
   __HIP_ATOMICS_IGNORE_DENORMAL_MODE {
     return __hip_atomic_fetch_add(addr, value, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
   }


### PR DESCRIPTION
## Motivation
This PR corrects the availability check for the __hip_atomic_fetch_add builtin function by replacing a defined() macro check with a __has_builtin() check. See https://ontrack-internal.amd.com/browse/SWDEV-550667
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
When falling through to the "not M200 or FP64 flat atomic add builtin not avaialble" path, the current implementation produces a system-scope atomic add, because we actually fall through to __atomic_fetch_add(addr, value, __ATOMIC_RELAXED).

 

This is because the check for the availability of __hip_atomic_fetch_add() is done incorrectly for doubles. See the difference between the correctly working float version and the incorrectly working double version:
[Float](https://github.com/ROCm/clr/blob/0ac913e64c988e6b9ea8e86d74292cdf44c5d255/hipamd/include/hip/amd_detail/amd_hip_unsafe_atomics.h#L77 )
[Double](https://github.com/ROCm/clr/blob/0ac913e64c988e6b9ea8e86d74292cdf44c5d255/hipamd/include/hip/amd_detail/amd_hip_unsafe_atomics.h#L191 )

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
N/A
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
N/A
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
