### PR TITLE
SWDEV-536287 - [Rocprofiler-systems] Detect SELinux mode and fail-fast

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -399,18 +399,6 @@ rocprofsys_set_mpi_hidden(bool use, bool attached)
     rocprofsys_preinit_hidden();
 }
 
-bool
-is_selinux_enforcing()
-{
-    std::ifstream ifs("/sys/fs/selinux/enforce");
-    if(!ifs.is_open()) return false;  // SELinux disabled or sysfs not mounted
-
-    int mode = 0;
-    if(!(ifs >> mode)) return false;  // Could not read the file
-
-    return mode == 1;
-}
-
 //======================================================================================//
 
 extern "C" void
@@ -422,10 +410,19 @@ rocprofsys_init_library_hidden()
     static bool _once       = false;
     auto        _debug_init = get_debug_init();
 
-    if(is_selinux_enforcing())
+    int _selinux_mode = 0;
     {
-        std::cerr << "SELinux enforcing mode detected. Consider to disable SELinux "
-                  << "or configure a more permissive setting. Aborting.\n";
+        std::ifstream _fenforcing{ "/sys/fs/selinux/enforce" };
+        if(!(_fenforcing >> _selinux_mode)) _selinux_mode = 0;
+        _fenforcing.close();
+    }
+
+    if(_selinux_mode == 1)
+    {
+        ROCPROFSYS_BASIC_VERBOSE(0, "/sys/fs/selinux/enforce has a value of %i. \n",
+                                 _selinux_mode);
+        std::cerr << "SELinux enforcing mode detected. Consider disabling SELinux "
+                  << "or configure permissive mode with 'sudo setenforce 0'. Aborting.\n";
         std::exit(EXIT_FAILURE);
     }
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -399,6 +399,18 @@ rocprofsys_set_mpi_hidden(bool use, bool attached)
     rocprofsys_preinit_hidden();
 }
 
+bool
+is_selinux_enforcing()
+{
+    std::ifstream ifs("/sys/fs/selinux/enforce");
+    if(!ifs.is_open()) return false;  // SELinux disabled or sysfs not mounted
+
+    int mode = 0;
+    if(!(ifs >> mode)) return false;  // Could not read the file
+
+    return mode == 1;
+}
+
 //======================================================================================//
 
 extern "C" void
@@ -409,6 +421,13 @@ rocprofsys_init_library_hidden()
 
     static bool _once       = false;
     auto        _debug_init = get_debug_init();
+
+    if(is_selinux_enforcing())
+    {
+        std::cerr << "SELinux enforcing mode detected. Consider to disable SELinux "
+                  << "or configure a more permissive setting. Aborting.\n";
+        std::exit(EXIT_FAILURE);
+    }
 
     ROCPROFSYS_CONDITIONAL_BASIC_PRINT_F(_debug_init, "State is %s...\n",
                                          std::to_string(get_state()).c_str());

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -1851,14 +1851,11 @@ tool_hip_stream_callback(rocprofiler_callback_tracing_record_t record,
     // STREAM_HANDLE_CREATE and DESTROY are no-ops
     if(record.operation == ROCPROFILER_HIP_STREAM_CREATE)
     {
-        ROCPROFSYS_VERBOSE_F(
-            2, "Entered hip_streams_callback function for ROCPROFILER_HIP_STREAM_CREATE");
+        ROCPROFSYS_VERBOSE_F(3, " operation = ROCPROFILER_HIP_STREAM_CREATE\n");
     }
     else if(record.operation == ROCPROFILER_HIP_STREAM_DESTROY)
     {
-        ROCPROFSYS_VERBOSE_F(
-            2,
-            "Entered hip_streams_callback function for ROCPROFILER_HIP_STREAM_DESTROY");
+        ROCPROFSYS_VERBOSE_F(3, " operation = ROCPROFILER_HIP_STREAM_DESTROY\n");
     }
     else if(record.operation == ROCPROFILER_HIP_STREAM_SET)
     {
@@ -1866,17 +1863,19 @@ tool_hip_stream_callback(rocprofiler_callback_tracing_record_t record,
         // called
         if(record.phase == ROCPROFILER_CALLBACK_PHASE_ENTER)
         {
-            ROCPROFSYS_VERBOSE_F(
-                2, "Entered hip_streams_callback function for ROCPROFILER_HIP_STREAM_SET "
-                   "with ROCPROFILER_CALLBACK_PHASE_ENTER");
+            ROCPROFSYS_VERBOSE_F(3,
+                                 " operation = ROCPROFILER_HIP_STREAM_SET, phase = "
+                                 "ROCPROFILER_CALLBACK_PHASE_ENTER, stream_id=%lu\n",
+                                 (unsigned long) stream_id.handle);
             stream_id_push(stream_id);
         }
         // Pop stream ID off of stream stack after underlying HIP function is completed
         else if(record.phase == ROCPROFILER_CALLBACK_PHASE_EXIT)
         {
-            ROCPROFSYS_VERBOSE_F(
-                2, "Entered hip_stream_callback function for ROCPROFILER_HIP_STREAM_SET "
-                   "with ROCPROFILER_CALLBACK_PHASE_EXIT");
+            ROCPROFSYS_VERBOSE_F(3,
+                                 "operation = ROCPROFILER_HIP_STREAM_SET, phase = "
+                                 "ROCPROFILER_CALLBACK_PHASE_EXIT, stream_id=%lu\n",
+                                 (unsigned long) stream_id.handle);
             stream_id_pop();
         }
     }


### PR DESCRIPTION
## Motivation

RHEL (Red Hat Enterprise Linux) and related distributions of Linux automatically enable a security feature named SELinux (Security-Enhanced Linux) that prevents ROCm Systems Profiler from running correctly and may segfault. 
The SELinux enforcing mode should be detected during initialization and execution should be aborted earlier.

## Technical Details

* Detect SELinux status by reading /sys/fs/selinux/enforce during initialization.
* Fix the verbose mode level for HIP Stream events

## Test Plan

Manual tests to verify the fix were performed on RHEL with and without SELinux enabled. And tests were also performed on an Ubuntu system.

## Test Result

The program will abort with the following message if SELinux with enforcing mode is detected:
SELinux enforcing mode detected. Consider to disable SELinux or configure a more permissive setting. Aborting.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
