### PR TITLE
Fixing ROCPD SQL Inserts with strange text

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -329,7 +329,10 @@ insert_value(std::string_view _name, const Tp& _value, TraitT = {})
                 return sql_insert_value{_name, std::string{"NULL"}};
             }
         }
-        return sql_insert_value{_name, fmt::format("'{}'", _value)};
+        // Sanitize string values before embedding into SQL to escape quotes and remove
+        // problematic control/separator characters.
+        auto _sanitized = sanitize_sql_string(std::string{_value});
+        return sql_insert_value{_name, fmt::format("'{}'", _sanitized)};
     }
     else
     {

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -331,7 +331,7 @@ insert_value(std::string_view _name, const Tp& _value, TraitT = {})
         }
         // Sanitize string values before embedding into SQL to escape quotes and remove
         // problematic control/separator characters.
-        auto _sanitized = sanitize_sql_string(std::string_view{_value});
+        auto _sanitized = sanitize_sql_string(std::string{_value});
         return sql_insert_value{_name, fmt::format("'{}'", _sanitized)};
     }
     else

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -331,7 +331,7 @@ insert_value(std::string_view _name, const Tp& _value, TraitT = {})
         }
         // Sanitize string values before embedding into SQL to escape quotes and remove
         // problematic control/separator characters.
-        auto _sanitized = sanitize_sql_string(std::string{_value});
+        auto _sanitized = sanitize_sql_string(std::string_view{_value});
         return sql_insert_value{_name, fmt::format("'{}'", _sanitized)};
     }
     else


### PR DESCRIPTION
## Motivation

While inserting data into the ROCpd database, I encountered an issue with some names that contain strange characters, which prevented the ROCpd from generating the database files.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Sanitize string values before embedding into SQL to escape quotes and remove problematic control/separator characters.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
