### PR TITLE
SWDEV-553099 - remove WITHOUT_HSA_BACKEND usage

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocappprofile.cpp
+++ b/projects/clr/rocclr/device/rocm/rocappprofile.cpp
@@ -18,8 +18,6 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE. */
 
-#ifndef WITHOUT_HSA_BACKEND
-
 #include "top.hpp"
 #include "device/device.hpp"
 #include "device/appprofile.hpp"
@@ -54,5 +52,3 @@ bool AppProfile::ParseApplicationProfile() {
   return true;
 }
 }  // namespace amd::roc
-
-#endif

--- a/projects/clr/rocclr/device/rocm/rocappprofile.hpp
+++ b/projects/clr/rocclr/device/rocm/rocappprofile.hpp
@@ -20,8 +20,6 @@
 
 #pragma once
 
-#ifndef WITHOUT_HSA_BACKEND
-
 namespace amd::roc {
 
 class AppProfile : public amd::AppProfile {
@@ -33,5 +31,3 @@ class AppProfile : public amd::AppProfile {
   virtual bool ParseApplicationProfile();
 };
 }  // namespace amd::roc
-
-#endif

--- a/projects/clr/rocclr/device/rocm/rocdefs.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdefs.hpp
@@ -19,9 +19,6 @@
  THE SOFTWARE. */
 
 #pragma once
-
-#ifndef WITHOUT_HSA_BACKEND
-
 namespace amd::roc {
 
 //! Alignment restriction for the pinned memory
@@ -45,5 +42,3 @@ enum HwQueueEngine : uint32_t {
 };
 
 }  // namespace amd::roc
-
-#endif

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -19,8 +19,6 @@
  THE SOFTWARE. */
 
 #include "cl.h"
-#ifndef WITHOUT_HSA_BACKEND
-
 #include "platform/program.hpp"
 #include "platform/kernel.hpp"
 #include "os/os.hpp"
@@ -62,7 +60,6 @@
 #endif  // ROCCLR_SUPPORT_NUMA_POLICY
 #include <sstream>
 #include <vector>
-#endif  // WITHOUT_HSA_BACKEND
 
 #define OPENCL_VERSION_STR XSTR(OPENCL_MAJOR) "." XSTR(OPENCL_MINOR)
 #define OPENCL_C_VERSION_STR XSTR(OPENCL_C_MAJOR) "." XSTR(OPENCL_C_MINOR)
@@ -78,7 +75,6 @@ static_assert(static_cast<uint32_t>(amd::Device::VmmAccess::kReadWrite) ==
                   static_cast<uint32_t>(HSA_ACCESS_PERMISSION_RW),
               "Vmm Access Flag Read Write mismatch with ROC-runtime!");
 
-#ifndef WITHOUT_HSA_BACKEND
 
 namespace amd::device {
 extern const char* HipExtraSourceCode;
@@ -3622,4 +3618,3 @@ device::UriLocator* Device::createUriLocator() const { return new roc::UriLocato
 #endif
 #endif
 }  // namespace amd::roc
-#endif  // WITHOUT_HSA_BACKEND

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -20,8 +20,6 @@
 
 #pragma once
 
-#ifndef WITHOUT_HSA_BACKEND
-
 #include "top.hpp"
 #include "CL/cl.h"
 #include "device/device.hpp"
@@ -691,4 +689,4 @@ void callbackQueue(hsa_status_t status, hsa_queue_t* queue, void* data);
 /**
  * @}
  */
-#endif /*WITHOUT_HSA_BACKEND*/
+

--- a/projects/clr/rocclr/device/rocm/rocglinterop.cpp
+++ b/projects/clr/rocclr/device/rocm/rocglinterop.cpp
@@ -18,8 +18,6 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE. */
 
-#ifndef WITHOUT_HSA_BACKEND
-
 #include "os/os.hpp"
 #include "utils/debug.hpp"
 #include "utils/flags.hpp"
@@ -195,5 +193,3 @@ bool Export(mesa_glinterop_export_in& in, mesa_glinterop_export_out& out, MESA_I
 }
 }  // namespace MesaInterop
 }  // namespace amd::roc
-
-#endif  // WITHOUT_HSA_BACKEND

--- a/projects/clr/rocclr/device/rocm/rocglinterop.hpp
+++ b/projects/clr/rocclr/device/rocm/rocglinterop.hpp
@@ -20,8 +20,6 @@
 
 #pragma once
 
-#ifndef WITHOUT_HSA_BACKEND
-
 #ifndef _WIN32
 #include <GL/glx.h>
 #include <EGL/egl.h>
@@ -138,4 +136,3 @@ bool Export(mesa_glinterop_export_in& in, mesa_glinterop_export_out& out, MESA_I
 }  // namespace MesaInterop
 }  // namespace amd::roc
 
-#endif /*WITHOUT_HSA_BACKEND*/

--- a/projects/clr/rocclr/device/rocm/rockernel.cpp
+++ b/projects/clr/rocclr/device/rocm/rockernel.cpp
@@ -23,8 +23,6 @@
 
 #include <algorithm>
 
-#ifndef WITHOUT_HSA_BACKEND
-
 namespace amd::roc {
 
 #if defined(USE_COMGR_LIBRARY)
@@ -163,4 +161,3 @@ bool Kernel::postLoad() {
 #endif  // defined(USE_COMGR_LIBRARY)
 
 }  // namespace amd::roc
-#endif  // WITHOUT_HSA_BACKEND

--- a/projects/clr/rocclr/device/rocm/rockernel.hpp
+++ b/projects/clr/rocclr/device/rocm/rockernel.hpp
@@ -25,8 +25,6 @@
 #include "top.hpp"
 #include "rocprintf.hpp"
 
-#ifndef WITHOUT_HSA_BACKEND
-
 namespace amd::roc {
 
 class Kernel : public device::Kernel {
@@ -68,4 +66,3 @@ class Kernel : public device::Kernel {
 
 }  // namespace amd::roc
 
-#endif  // WITHOUT_HSA_BACKEND

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -18,8 +18,6 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE. */
 
-#ifndef WITHOUT_HSA_BACKEND
-
 #if !defined(_WIN32)
 #include <unistd.h>
 #endif
@@ -1610,4 +1608,4 @@ amd::Image* Image::FindView(cl_image_format format) const {
 }
 
 }  // namespace amd::roc
-#endif  // WITHOUT_HSA_BACKEND
+

--- a/projects/clr/rocclr/device/rocm/rocmemory.hpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.hpp
@@ -20,8 +20,6 @@
 
 #pragma once
 
-#ifndef WITHOUT_HSA_BACKEND
-
 #include "top.hpp"
 #include "platform/memory.hpp"
 #include "utils/debug.hpp"
@@ -271,4 +269,4 @@ class Image : public roc::Memory {
   std::vector<amd::Image*> view_cache_;  //!< Cache of views for fast access
 };
 }  // namespace amd::roc
-#endif
+

--- a/projects/clr/rocclr/device/rocm/rocprogram.cpp
+++ b/projects/clr/rocclr/device/rocm/rocprogram.cpp
@@ -18,8 +18,6 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE. */
 
-#ifndef WITHOUT_HSA_BACKEND
-
 #include "rocprogram.hpp"
 
 #include "utils/options.hpp"
@@ -340,4 +338,3 @@ bool LightningProgram::setKernels(void* binary, size_t binSize, amd::Os::FileDes
 
 }  // namespace amd::roc
 
-#endif  // WITHOUT_HSA_BACKEND

--- a/projects/clr/rocclr/device/rocm/rocprogram.hpp
+++ b/projects/clr/rocclr/device/rocm/rocprogram.hpp
@@ -20,8 +20,6 @@
 
 #pragma once
 
-#ifndef WITHOUT_HSA_BACKEND
-
 #include <string>
 #include <sstream>
 #include <fstream>
@@ -128,4 +126,3 @@ class LightningProgram final : public roc::Program {
 /*@}*/  // namespace amd::roc
 }  // namespace amd::roc
 
-#endif /*WITHOUT_HSA_BACKEND*/

--- a/projects/clr/rocclr/device/rocm/rocregisters.hpp
+++ b/projects/clr/rocclr/device/rocm/rocregisters.hpp
@@ -20,8 +20,6 @@
 
 #pragma once
 
-#ifndef WITHOUT_HSA_BACKEND
-
 #if !defined(LITTLEENDIAN_CPU) && !defined(BIGENDIAN_CPU)
 #error "Must define LITTLEENDIAN_CPU or BIGENDIAN_CPU"
 #endif
@@ -203,4 +201,3 @@ union SQ_IMG_RSRC_WORD7 {
 };
 }  // namespace amd::roc
 
-#endif

--- a/projects/clr/rocclr/device/rocm/rocsettings.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.cpp
@@ -18,8 +18,6 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE. */
 
-#ifndef WITHOUT_HSA_BACKEND
-
 #include "top.hpp"
 #include "os/os.hpp"
 #include "device/device.hpp"
@@ -279,5 +277,3 @@ void Settings::setKernelArgImpl(const amd::Isa& isa, bool isXgmi, bool hasValidH
   ClPrint(amd::LOG_INFO, amd::LOG_INIT, "Using dev kernel arg wa = %d", kernel_arg_impl_);
 }
 }  // namespace amd::roc
-
-#endif  // WITHOUT_HSA_BACKEND

--- a/projects/clr/rocclr/device/rocm/rocsettings.hpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.hpp
@@ -20,8 +20,6 @@
 
 #pragma once
 
-#ifndef WITHOUT_HSA_BACKEND
-
 /*! \addtogroup HSA OCL Stub Implementation
  *  @{
  */
@@ -102,4 +100,3 @@ class Settings : public device::Settings {
 /*@}*/  // namespace amd::roc
 }  // namespace amd::roc
 
-#endif /*WITHOUT_HSA_BACKEND*/


### PR DESCRIPTION
## Motivation
remove WITHOUT_HSA_BACKEND usage. since its used a double negation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
remove WITHOUT_HSA_BACKEND usage. since its used a double negation. WITHOUT_HSA_BACKEND is not defined anywhere. 

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
hip-tests on linux and windows

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
NA

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
