### PR TITLE
Revert "rocr: Workaround for peak SDMA b/w on gfx94x (#626)"

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1244,30 +1244,11 @@ hsa_status_t GpuAgent::DmaCopyStatus(core::Agent& dst_agent, core::Agent& src_ag
 
 hsa_status_t GpuAgent::DmaPreferredEngine(core::Agent& dst_agent, core::Agent& src_agent,
                                           uint32_t *recommended_ids_mask) {
-  // From the collected data, gfx94x performance is better only for first 3 SDMA engines
-  bool isGfx94x = (isa_->GetMajorVersion() == 9 &&
-                  (isa_->GetMinorVersion() == 4 || isa_->GetMinorVersion() == 5));
+  assert(((src_agent.device_type() == core::Agent::kAmdGpuDevice) ||
+          (dst_agent.device_type() == core::Agent::kAmdGpuDevice)) &&
+         ("Both devices are CPU agents which is not expected"));
 
-  if (isGfx94x &&
-      ((src_agent.device_type() == core::Agent::kAmdCpuDevice &&
-        dst_agent.device_type() == core::Agent::kAmdGpuDevice) ||
-        (src_agent.device_type() == core::Agent::kAmdGpuDevice &&
-        dst_agent.device_type() == core::Agent::kAmdCpuDevice))) {
-
-    if (src_agent.device_type() == core::Agent::kAmdCpuDevice) {
-      // Host to Device: Use SDMA engine 0 if available
-      *recommended_ids_mask = HSA_AMD_SDMA_ENGINE_0;
-    } else {
-      // Device to Host: Use SDMA engines 1 and 2 if available
-      *recommended_ids_mask = HSA_AMD_SDMA_ENGINE_1;
-
-      if (properties_.NumSdmaEngines + properties_.NumSdmaXgmiEngines > 2) {
-        *recommended_ids_mask |= HSA_AMD_SDMA_ENGINE_2;
-      }
-    }
-  } else {
-    *recommended_ids_mask = rec_sdma_eng_id_peers_info_[dst_agent.public_handle().handle];
-  }
+  *recommended_ids_mask = rec_sdma_eng_id_peers_info_[dst_agent.public_handle().handle];
 
   return HSA_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -605,6 +605,10 @@ hsa_status_t Runtime::CopyMemoryStatus(core::Agent* dst_agent, core::Agent* src_
   const bool src_gpu = (src_agent->device_type() == core::Agent::DeviceType::kAmdGpuDevice);
   core::Agent* copy_agent = (src_gpu) ? src_agent : dst_agent;
 
+  if (dst_agent == src_agent) {
+    return HSA_STATUS_ERROR_INVALID_AGENT;
+  }
+
   return copy_agent->DmaCopyStatus(*dst_agent, *src_agent, engine_ids_mask);
 }
 
@@ -612,6 +616,10 @@ hsa_status_t Runtime::GetPreferredEngine(core::Agent* dst_agent, core::Agent* sr
                                          uint32_t* recommended_ids_mask) {
   const bool src_gpu = (src_agent->device_type() == core::Agent::DeviceType::kAmdGpuDevice);
   core::Agent* copy_agent = (src_gpu) ? src_agent : dst_agent;
+
+  if (dst_agent == src_agent) {
+    return HSA_STATUS_ERROR_INVALID_AGENT;
+  }
 
   return copy_agent->DmaPreferredEngine(*dst_agent, *src_agent, recommended_ids_mask);
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -1810,6 +1810,8 @@ hsa_status_t HSA_API
  *
  * @retval ::HSA_STATUS_ERROR_OUT_OF_RESOURCES Agent does not have available SDMA engines.
  *
+ * @retval ::HSA_STATUS_ERROR_INVALID_AGENT dst_agent and src_agent are the same as
+ * dst_agent == src_agent is generally used for shader copies.
  */
 hsa_status_t HSA_API
 hsa_amd_memory_copy_engine_status(hsa_agent_t dst_agent, hsa_agent_t src_agent,
@@ -1826,6 +1828,8 @@ hsa_amd_memory_copy_engine_status(hsa_agent_t dst_agent, hsa_agent_t src_agent,
  *
  * @retval ::HSA_STATUS_SUCCESS For mask returned
  *
+ * @retval ::HSA_STATUS_ERROR_INVALID_AGENT dst_agent and src_agent are the same as
+ * dst_agent == src_agent is generally used for shader copies.
  */
 hsa_status_t HSA_API
 hsa_amd_memory_get_preferred_copy_engine(hsa_agent_t dst_agent, hsa_agent_t src_agent,


### PR DESCRIPTION
This reverts commit 230a22b395286ddfd958d6785e5a0089937638a4.

## Motivation

Reverting because this is causing regressions for rocprof.

https://ontrack-internal.amd.com/browse/SWDEV-553326