### PR TITLE
SWDEV-550582 - Ensure kernel launched to correct device in hip-tests

### DIFF
--- a/projects/hip-tests/catch/unit/memory/hipSVMTestSharedAddressSpaceFineGrain.cpp
+++ b/projects/hip-tests/catch/unit/memory/hipSVMTestSharedAddressSpaceFineGrain.cpp
@@ -213,6 +213,7 @@ TEST_CASE("test_svm_shared_address_space_fine_grain_buffers") {
     }
   }
 
+  HIP_CHECK(hipSetDevice(0));
   HIP_CHECK(hipHostFree(pNodes));
   HIP_CHECK(hipHostFree(pAllocator));
   HIP_CHECK(hipHostFree(pNumCorrect));
@@ -297,16 +298,20 @@ TEST_CASE("test_svm_shared_address_space_fine_grain_system") {
       {
         create_linked_lists_on_host(pNodes, numLists, ListLength);
       } else {
+        HIP_CHECK(hipSetDevice(ci));
         create_linked_lists_on_device(streams[ci], pNodes, pAllocator, numLists, ListLength);
       }
 
       if (vi == num_devices) {
         verify_linked_lists_on_host(pNodes, numLists, ListLength);
       } else {
+        HIP_CHECK(hipSetDevice(vi));
         verify_linked_lists_on_device(streams[vi], pNodes, pNumCorrect, numLists, ListLength);
       }
     }
   }
+
+  HIP_CHECK(hipSetDevice(0));
   align_free(pNodes);
   align_free(pAllocator);
   align_free(pNumCorrect);


### PR DESCRIPTION
## Motivation

Fix [SWDEV-550582](https://ontrack-internal.amd.com/browse/SWDEV-550582)

## Technical Details

Recent change on hip runtime will return hipErrorInvalidResourceHandle if a kernel launch is issued to a stream that is not associated to the current device. Failure on test_svm_shared_address_space_fine_grain_system test was due to launching kernel to a stream not associated with current device.

## Test Plan

Tested locally on MI350 and MI300

## Test Result

Test passed on affected tests

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
