### PR TITLE
fix(transpose): correct host allocation and GB/s calculation

### DIFF
--- a/projects/rocprofiler-systems/examples/transpose/transpose.cpp
+++ b/projects/rocprofiler-systems/examples/transpose/transpose.cpp
@@ -116,10 +116,12 @@ run(int rank, int tid, hipStream_t stream, int argc, char** argv)
     std::default_random_engine _engine{ std::random_device{}() * (rank + 1) * (tid + 1) };
     std::uniform_int_distribution<int> _dist{ 0, 1000 };
 
-    size_t size       = sizeof(int) * M * N;
-    int*   inp_matrix = new int[size];
-    int*   out_matrix = new int[size];
-    for(size_t i = 0; i < M * N; i++)
+    const size_t elems      = static_cast<size_t>(M) * static_cast<size_t>(N);
+    const size_t size       = elems * sizeof(int);
+    int*         inp_matrix = new int[elems];
+    int*         out_matrix = new int[elems];
+
+    for(size_t i = 0; i < elems; i++)
     {
         inp_matrix[i] = _dist(_engine);
         out_matrix[i] = 0;
@@ -149,7 +151,7 @@ run(int rank, int tid, hipStream_t stream, int argc, char** argv)
     HIP_API_CALL(hipMemcpyAsync(out_matrix, out, size, hipMemcpyDeviceToHost, stream));
     double time =
         std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1).count();
-    float GB = (float) size * nitr * 2 / (1 << 30);
+    float GB = static_cast<float>(size) * nitr * 2 / (1 << 30);
 
     print_lock.lock();
     std::cout << "[" << rank << "][" << tid << "] Runtime of transpose is " << time


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The transpose sample incorrectly allocated host buffers using new int[size] where size was measured in bytes. 
This could lead to buffer overflows and undefined behavior. The goal of this PR is to fix host allocation and improve type safety in size calculations while 
keeping the algorithm unchanged.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- Introduced elems = static_cast<size_t>(M) * N to distinguish element count from total byte size.
- Changed allocation from new int[size] → new int[elems] to correctly allocate by elements instead of bytes.
- Updated loop bounds to iterate over elems instead of M * N.
- Used static_cast<float>(size) in GB/s calculation to ensure type safety.

These changes are general and not specific to any GPU backend.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Built transpose sample.
Ran ctest --test-dir ./build/debug -V -R transpose-sampling to validate functionality.

## Test Result

<!-- Briefly summarize test outcomes. -->
Verified successful runs on Navi and MI300 GPUs.
<img width="662" height="332" alt="image" src="https://github.com/user-attachments/assets/f3a0d3c7-e0fe-4889-b7d9-f91513c177fb" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
