### PR TITLE
Fix reset_rocprofsys_preload

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
@@ -147,6 +147,16 @@ reset_rocprofsys_preload()
     {
         (void) get_rocprofsys_is_preloaded();
         (void) get_rocprofsys_preload();
+        auto _modified_preload = std::string{};
+        for(const auto& itr : delimit(_preload_libs, ":"))
+        {
+            if(itr.find("librocprof-sys") != std::string::npos) continue;
+            _modified_preload += common::join("", ":", itr);
+        }
+        if(!_modified_preload.empty() && _modified_preload.find(':') == 0)
+            _modified_preload = _modified_preload.substr(1);
+
+        setenv("LD_PRELOAD", _modified_preload.c_str(), 1);
     }
 }
 


### PR DESCRIPTION
## Motivation

SWDEV-552989 - Aims to fix rocprof-sys freezing when profiling a vLLM workload
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Remove librocprof-sys from LD_PRELOAD when resetting rocprofsys_preload  (Reverts the change in https://github.com/ROCm/rocm-systems/commit/1f86010ca2aa5e640276f0eeee33cfaa8317c355)
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
