### PR TITLE
Disable CMAKE_INSTALL_RPATH_USE_LINK_PATH

### DIFF
--- a/projects/rocprofiler-systems/CMakeLists.txt
+++ b/projects/rocprofiler-systems/CMakeLists.txt
@@ -191,7 +191,7 @@ rocprofiler_systems_add_option(CMAKE_CXX_EXTENSIONS
                                "Compiler specific language extensions" OFF
 )
 rocprofiler_systems_add_option(CMAKE_INSTALL_RPATH_USE_LINK_PATH
-                               "Enable rpath to linked libraries" ON
+                               "Enable rpath to linked libraries" OFF
 )
 set(CMAKE_INSTALL_MESSAGE "LAZY" CACHE STRING "Installation message")
 mark_as_advanced(CMAKE_INSTALL_MESSAGE)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Fixing some `check-rpath` errors when generating RPM packages in RHEL 10

```
ERROR 0002: file '/home/gliff/opt/rocprofiler-systems/bin/rocprof-sys-avail' contains an invalid rpath '/opt/rocm-7.0.0/lib' in [$ORIGIN/../lib:$ORIGIN/../lib/rocprofiler-systems:/opt/rocm-7.0.0/lib]
ERROR 0002: file '/home/gliff/opt/rocprofiler-systems/bin/rocprof-sys-causal' contains an invalid rpath '/opt/rocm-7.0.0/lib' in [$ORIGIN/../lib:$ORIGIN/../lib/rocprofiler-systems:/opt/rocm-7.0.0/lib]
ERROR 0002: file '/home/gliff/opt/rocprofiler-systems/bin/rocprof-sys-run' contains an invalid rpath '/opt/rocm-7.0.0/lib' in [$ORIGIN/../lib:$ORIGIN/../lib/rocprofiler-systems:/opt/rocm-7.0.0/lib]
ERROR 0002: file '/home/gliff/opt/rocprofiler-systems/lib/librocprof-sys.so.1.2.0' contains an invalid rpath '/opt/rocm-7.0.0/lib' in [$ORIGIN:$ORIGIN/rocprofiler-systems:/opt/rocm-7.0.0/lib]
```

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Disable CMAKE_INSTALL_RPATH_USE_LINK_PATH in our CMake config

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Running CI workflows
Testing package installers

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
