### PR TITLE
SWDEV-553103 - Remove adobe and afterfx workaround

### DIFF
--- a/projects/clr/rocclr/device/devprogram.cpp
+++ b/projects/clr/rocclr/device/devprogram.cpp
@@ -1186,18 +1186,6 @@ bool Program::linkImplLC(amd::option::Options* options) {
                           options->clangOptions.end());
   }
 
-  // Temporarily disable problematic pass for some Adobe apps.
-  {
-    std::string appName = {};
-    std::string appPathAndName = {};
-    amd::Os::getAppPathAndFileName(appName, appPathAndName);
-    if ((appName == "Adobe Media Encoder.exe") || (appName == "Adobe Premiere Pro.exe") ||
-        (appName == "AfterFX.exe")) {
-      codegenOptions.push_back("-mllvm");
-      codegenOptions.push_back("-disable-branch-fold");
-    }
-  }
-
   // Set whole program mode
   codegenOptions.push_back("-mllvm");
   codegenOptions.push_back("-amdgpu-internalize-symbols");


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Remove workaround for adobe crashes. Use build generated by psdb to test.
## Technical Details
Removed options for disabling branch folding pass.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Send build to triage team to test
## Test Result
N/A
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
