### PR TITLE
SWDEV-553757 - add __HIP__ and __clang__ check for __shfl functions

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -617,6 +617,7 @@ __BF16_HOST_DEVICE_STATIC__ __hip_bfloat16 __ushort_as_bfloat16(const unsigned s
   return u.bf16;
 }
 
+#if defined(__clang__) && defined(__HIP__)
 /**
  * \ingroup HIP_INTRINSIC_BFLOAT16_SHFL
  * \brief shfl warp intrinsic for bfloat16
@@ -788,6 +789,7 @@ __BF16_DEVICE_STATIC__ __hip_bfloat162 __shfl_xor_sync(const unsigned long long 
   return u.bf162;
 }
 #endif  // HIP_DISABLE_WARP_SYNC_BUILTINS
+#endif  // defined(__clang__) && defined(__HIP__)
 
 /**
  * \ingroup HIP_INTRINSIC_BFLOAT16_ARITH


### PR DESCRIPTION
## Motivation

We should be able to use bf16 header without linking to hip::device.

## Technical Details

Hide the functions using `warpSize` under `#if defined(__clang__) && defined(__HIP__)`

## Test Plan

No test required

## Test Result

No test requred

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
