### PR TITLE
hsakmt: Update udmabuf.h License Identifier Header

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/linux/udmabuf.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/linux/udmabuf.h
@@ -1,8 +1,7 @@
-/* GPL-2.0 WITH Linux-syscall-note */
-/*
- * This file was copied from inux-libc-dev package
- * This header provides interface to linux kernel udmabuf drver
- * Modifications may have been made.
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
+ * This file was copied from Linux Kernel Source code
+ * This header provides interface to linux kernel udmabuf driver
+ * Minor modifications may have been made.
  */
 #ifndef _THUNK_UDMABUF_H
 #define _THUNK_UDMABUF_H


### PR DESCRIPTION
## Motivation
Fix typos, and update the license header to include SPDX license identifier.