### PR TITLE
[rocprofiler-systems] Add Fortran OpenMP CTests

### DIFF
--- a/.github/workflows/rocprofiler-systems-debian.yml
+++ b/.github/workflows/rocprofiler-systems-debian.yml
@@ -127,7 +127,7 @@ jobs:
           -DROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs \
           -DROCPROFSYS_PYTHON_ENVS="py3.8;py3.9;py3.10;py3.11;py3.12;py3.13" \
           -DROCPROFSYS_MAX_THREADS=64 \
-          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv" \
+          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv-target" \
           -DROCPROFSYS_BUILD_NUMBER=1 \
           -DUSE_CLANG_OMP=OFF \
           $CMAKE_PREFIX_PATH_ARG \

--- a/.github/workflows/rocprofiler-systems-debian.yml
+++ b/.github/workflows/rocprofiler-systems-debian.yml
@@ -127,7 +127,7 @@ jobs:
           -DROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs \
           -DROCPROFSYS_PYTHON_ENVS="py3.8;py3.9;py3.10;py3.11;py3.12;py3.13" \
           -DROCPROFSYS_MAX_THREADS=64 \
-          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv-target" \
+          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv-offload" \
           -DROCPROFSYS_BUILD_NUMBER=1 \
           -DUSE_CLANG_OMP=OFF \
           $CMAKE_PREFIX_PATH_ARG \

--- a/.github/workflows/rocprofiler-systems-debian.yml
+++ b/.github/workflows/rocprofiler-systems-debian.yml
@@ -127,7 +127,7 @@ jobs:
           -DROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs \
           -DROCPROFSYS_PYTHON_ENVS="py3.8;py3.9;py3.10;py3.11;py3.12;py3.13" \
           -DROCPROFSYS_MAX_THREADS=64 \
-          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target" \
+          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv" \
           -DROCPROFSYS_BUILD_NUMBER=1 \
           -DUSE_CLANG_OMP=OFF \
           $CMAKE_PREFIX_PATH_ARG \

--- a/.github/workflows/rocprofiler-systems-opensuse.yml
+++ b/.github/workflows/rocprofiler-systems-opensuse.yml
@@ -110,7 +110,7 @@ jobs:
           -DROCPROFSYS_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10;py3.11"
           -DROCPROFSYS_CI_MPI_RUN_AS_ROOT=ON
           -DROCPROFSYS_MAX_THREADS=64
-          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;videodecode;jpegdecode"
+          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv;videodecode;jpegdecode"
           -DROCPROFSYS_BUILD_NUMBER=${{ github.run_attempt }}
           --
           -LE "transpose|rccl|videodecode|jpegdecode|network|mpi"

--- a/.github/workflows/rocprofiler-systems-opensuse.yml
+++ b/.github/workflows/rocprofiler-systems-opensuse.yml
@@ -110,7 +110,7 @@ jobs:
           -DROCPROFSYS_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10;py3.11"
           -DROCPROFSYS_CI_MPI_RUN_AS_ROOT=ON
           -DROCPROFSYS_MAX_THREADS=64
-          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv-target;videodecode;jpegdecode"
+          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv-offload;videodecode;jpegdecode"
           -DROCPROFSYS_BUILD_NUMBER=${{ github.run_attempt }}
           --
           -LE "transpose|rccl|videodecode|jpegdecode|network|mpi"

--- a/.github/workflows/rocprofiler-systems-opensuse.yml
+++ b/.github/workflows/rocprofiler-systems-opensuse.yml
@@ -110,7 +110,7 @@ jobs:
           -DROCPROFSYS_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10;py3.11"
           -DROCPROFSYS_CI_MPI_RUN_AS_ROOT=ON
           -DROCPROFSYS_MAX_THREADS=64
-          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv;videodecode;jpegdecode"
+          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv-target;videodecode;jpegdecode"
           -DROCPROFSYS_BUILD_NUMBER=${{ github.run_attempt }}
           --
           -LE "transpose|rccl|videodecode|jpegdecode|network|mpi"

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -128,7 +128,7 @@ jobs:
           -DROCPROFSYS_INSTALL_PERFETTO_TOOLS=OFF
           -DROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs
           -DROCPROFSYS_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10;py3.11"
-          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv-target"
+          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv-offload"
           -DROCPROFSYS_BUILD_NUMBER=${{ github.run_attempt }}
           --
           -LE "transpose|rccl|videodecode|jpegdecode|network"

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -128,7 +128,7 @@ jobs:
           -DROCPROFSYS_INSTALL_PERFETTO_TOOLS=OFF
           -DROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs
           -DROCPROFSYS_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10;py3.11"
-          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target"
+          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv"
           -DROCPROFSYS_BUILD_NUMBER=${{ github.run_attempt }}
           --
           -LE "transpose|rccl|videodecode|jpegdecode|network"

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -128,7 +128,7 @@ jobs:
           -DROCPROFSYS_INSTALL_PERFETTO_TOOLS=OFF
           -DROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs
           -DROCPROFSYS_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10;py3.11"
-          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv"
+          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv-target"
           -DROCPROFSYS_BUILD_NUMBER=${{ github.run_attempt }}
           --
           -LE "transpose|rccl|videodecode|jpegdecode|network"

--- a/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
@@ -132,7 +132,7 @@ jobs:
           -DROCPROFSYS_PYTHON_ENVS="py3.7;py3.8;py3.9;py3.10;py3.11" \
           -DROCPROFSYS_STRIP_LIBRARIES=${{ matrix.strip }} \
           -DROCPROFSYS_MAX_THREADS=64 \
-          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target" \
+          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv" \
           -DROCPROFSYS_BUILD_NUMBER=${{ github.run_attempt }} \
           -DUSE_CLANG_OMP=OFF \
           -- \
@@ -311,7 +311,7 @@ jobs:
           -DROCPROFSYS_PYTHON_ENVS="py3.7;py3.8;py3.9;py3.10;py3.11" \
           -DROCPROFSYS_STRIP_LIBRARIES=${{ matrix.strip }} \
           -DROCPROFSYS_MAX_THREADS=64 \
-          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target" \
+          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv" \
           -DROCPROFSYS_BUILD_NUMBER=${{ github.run_attempt }} \
           -DUSE_CLANG_OMP=OFF \
           -- \

--- a/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
@@ -126,7 +126,7 @@ jobs:
           -DROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs \
           -DROCPROFSYS_PYTHON_ENVS="py3.8;py3.9;py3.10;py3.11;py3.12;py3.13" \
           -DROCPROFSYS_MAX_THREADS=64 \
-          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv;lulesh" \
+          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv-target;lulesh" \
           -DROCPROFSYS_BUILD_NUMBER=1 \
           -DUSE_CLANG_OMP=OFF \
           $CMAKE_PREFIX_PATH_ARG \

--- a/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
@@ -126,7 +126,7 @@ jobs:
           -DROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs \
           -DROCPROFSYS_PYTHON_ENVS="py3.8;py3.9;py3.10;py3.11;py3.12;py3.13" \
           -DROCPROFSYS_MAX_THREADS=64 \
-          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv-target;lulesh" \
+          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv-offload;lulesh" \
           -DROCPROFSYS_BUILD_NUMBER=1 \
           -DUSE_CLANG_OMP=OFF \
           $CMAKE_PREFIX_PATH_ARG \

--- a/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
@@ -126,7 +126,7 @@ jobs:
           -DROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs \
           -DROCPROFSYS_PYTHON_ENVS="py3.8;py3.9;py3.10;py3.11;py3.12;py3.13" \
           -DROCPROFSYS_MAX_THREADS=64 \
-          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;lulesh" \
+          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv;lulesh" \
           -DROCPROFSYS_BUILD_NUMBER=1 \
           -DUSE_CLANG_OMP=OFF \
           $CMAKE_PREFIX_PATH_ARG \

--- a/.gitmodules
+++ b/.gitmodules
@@ -76,3 +76,6 @@
 [submodule "projects/rocprofiler-systems/external/pybind11"]
 	path = projects/rocprofiler-systems/external/pybind11
 	url = https://github.com/jrmadsen/pybind11.git
+[submodule "projects/rocprofiler-systems/examples/openmp/external/ompvv"]
+	path = projects/rocprofiler-systems/examples/openmp/external/ompvv
+	url = https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV.git

--- a/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
@@ -1,71 +1,115 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(rocprofiler-systems-openmp LANGUAGES CXX)
 
 if(ROCPROFSYS_DISABLE_EXAMPLES)
-  get_filename_component(_DIR ${CMAKE_CURRENT_LIST_DIR} NAME)
+    get_filename_component(_DIR ${CMAKE_CURRENT_LIST_DIR} NAME)
 
-  if(${PROJECT_NAME} IN_LIST ROCPROFSYS_DISABLE_EXAMPLES
-     OR ${_DIR} IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
-    return()
-  endif()
+    if(
+        ${PROJECT_NAME} IN_LIST ROCPROFSYS_DISABLE_EXAMPLES
+        OR ${_DIR} IN_LIST ROCPROFSYS_DISABLE_EXAMPLES
+    )
+        return()
+    endif()
 endif()
 
 file(GLOB common_source ${CMAKE_CURRENT_SOURCE_DIR}/common/*.cpp)
 add_library(openmp-common OBJECT ${common_source})
-target_include_directories(openmp-common
-                           PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/common)
+target_include_directories(openmp-common PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/common)
 
-add_executable(openmp-cg ${CMAKE_CURRENT_SOURCE_DIR}/CG/cg.cpp
-                         $<TARGET_OBJECTS:openmp-common>)
-add_executable(openmp-lu ${CMAKE_CURRENT_SOURCE_DIR}/LU/lu.cpp
-                         $<TARGET_OBJECTS:openmp-common>)
+add_executable(
+    openmp-cg
+    ${CMAKE_CURRENT_SOURCE_DIR}/CG/cg.cpp
+    $<TARGET_OBJECTS:openmp-common>
+)
+add_executable(
+    openmp-lu
+    ${CMAKE_CURRENT_SOURCE_DIR}/LU/lu.cpp
+    $<TARGET_OBJECTS:openmp-common>
+)
 
 option(USE_CLANG_OMP "Use the clang OpenMP if available" ON)
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  find_package(OpenMP REQUIRED)
-  target_link_libraries(openmp-common PUBLIC OpenMP::OpenMP_CXX)
-  set(ROCPROFSYS_OPENMP_USING_LIBOMP_LIBRARY
-      ON
-      CACHE INTERNAL "Used by rocprofiler-systems testing" FORCE)
-else()
-  find_program(CLANGXX_EXECUTABLE NAMES clang++)
-  find_library(
-    LIBOMP_LIBRARY
-    NAMES omp omp5
-          ${CMAKE_SHARED_LIBRARY_PREFIX}omp${CMAKE_SHARED_LIBRARY_SUFFIX}.5)
-  if(CLANGXX_EXECUTABLE
-     AND LIBOMP_LIBRARY
-     AND COMMAND rocprofiler_systems_custom_compilation
-     AND USE_CLANG_OMP)
-    target_compile_options(openmp-common PUBLIC -W -Wall -fopenmp=libomp)
-    target_link_libraries(openmp-common PUBLIC ${LIBOMP_LIBRARY})
-    rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE}
-                                           TARGET openmp-common)
-    rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE}
-                                           TARGET openmp-cg)
-    rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE}
-                                           TARGET openmp-lu)
-    set(ROCPROFSYS_OPENMP_USING_LIBOMP_LIBRARY
-        ON
-        CACHE INTERNAL "Used by rocprofiler-systems testing" FORCE)
-  else()
     find_package(OpenMP REQUIRED)
     target_link_libraries(openmp-common PUBLIC OpenMP::OpenMP_CXX)
     set(ROCPROFSYS_OPENMP_USING_LIBOMP_LIBRARY
-        OFF
-        CACHE INTERNAL "Used by rocprofiler-systems testing" FORCE)
-  endif()
+        ON
+        CACHE INTERNAL
+        "Used by rocprofiler-systems testing"
+        FORCE
+    )
+else()
+    find_program(CLANGXX_EXECUTABLE NAMES clang++)
+    find_library(
+        LIBOMP_LIBRARY
+        NAMES omp omp5 ${CMAKE_SHARED_LIBRARY_PREFIX}omp${CMAKE_SHARED_LIBRARY_SUFFIX}.5
+    )
+    if(
+        CLANGXX_EXECUTABLE
+        AND LIBOMP_LIBRARY
+        AND COMMAND rocprofiler_systems_custom_compilation
+        AND USE_CLANG_OMP
+    )
+        target_compile_options(openmp-common PUBLIC -W -Wall -fopenmp=libomp)
+        target_link_libraries(openmp-common PUBLIC ${LIBOMP_LIBRARY})
+        rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE}
+                                               TARGET openmp-common
+        )
+        rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE}
+                                               TARGET openmp-cg
+        )
+        rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE}
+                                               TARGET openmp-lu
+        )
+        set(ROCPROFSYS_OPENMP_USING_LIBOMP_LIBRARY
+            ON
+            CACHE INTERNAL
+            "Used by rocprofiler-systems testing"
+            FORCE
+        )
+    else()
+        find_package(OpenMP REQUIRED)
+        target_link_libraries(openmp-common PUBLIC OpenMP::OpenMP_CXX)
+        set(ROCPROFSYS_OPENMP_USING_LIBOMP_LIBRARY
+            OFF
+            CACHE INTERNAL
+            "Used by rocprofiler-systems testing"
+            FORCE
+        )
+    endif()
 endif()
 
 target_link_libraries(openmp-cg PRIVATE openmp-common)
 target_link_libraries(openmp-lu PRIVATE openmp-common)
 
 if(ROCPROFSYS_INSTALL_EXAMPLES)
-  install(
-    TARGETS openmp-cg openmp-lu
-    DESTINATION bin
-    COMPONENT rocprofiler-systems-examples)
+    install(
+        TARGETS openmp-cg openmp-lu
+        DESTINATION bin
+        COMPONENT rocprofiler-systems-examples
+    )
 endif()
 
 set(DEFAULT_GPU_TARGETS
@@ -81,25 +125,24 @@ set(DEFAULT_GPU_TARGETS
     "gfx1010"
     "gfx1100"
     "gfx1101"
-    "gfx1102")
+    "gfx1102"
+)
 
-set(GPU_TARGETS
-    "${DEFAULT_GPU_TARGETS}"
-    CACHE STRING "GPU targets to compile for")
+set(GPU_TARGETS "${DEFAULT_GPU_TARGETS}" CACHE STRING "GPU targets to compile for")
 
 if(ROCPROFSYS_USE_ROCM)
-  add_subdirectory(external)
+    add_subdirectory(external)
 else()
-  rocprofiler_systems_message(
-    WARNING
-    "ROCPROFSYS OMPVV CTests requires ROCm to be installed. Disabling OMPVV CTests..."
-  )
+    rocprofiler_systems_message(
+      WARNING
+      "ROCPROFSYS OMPVV CTests requires ROCm to be installed. Disabling OMPVV CTests..."
+    )
 endif()
 
 if(ROCPROFSYS_DISABLE_EXAMPLES)
-  if(NOT "openmp-target" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
-    add_subdirectory(target)
-  endif()
+    if(NOT "openmp-target" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
+        add_subdirectory(target)
+    endif()
 else()
-  add_subdirectory(target)
+    add_subdirectory(target)
 endif()

--- a/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright Advanced Micro Devices, Inc.
+# Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)

--- a/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
@@ -86,7 +86,15 @@ set(DEFAULT_GPU_TARGETS
 set(GPU_TARGETS
     "${DEFAULT_GPU_TARGETS}"
     CACHE STRING "GPU targets to compile for")
-add_subdirectory(external)
+
+if(ROCPROFSYS_USE_ROCM)
+  add_subdirectory(external)
+else()
+  rocprofiler_systems_message(
+    WARNING
+    "ROCPROFSYS OMPVV CTests requires ROCm to be installed. Disabling OMPVV CTests..."
+  )
+endif()
 
 if(ROCPROFSYS_DISABLE_EXAMPLES)
   if(NOT "openmp-target" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)

--- a/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
@@ -1,24 +1,5 @@
-# MIT License
-#
-# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 

--- a/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
@@ -90,10 +90,32 @@ if(ROCPROFSYS_INSTALL_EXAMPLES)
     )
 endif()
 
+set(DEFAULT_GPU_TARGETS
+    "gfx900"
+    "gfx906"
+    "gfx908"
+    "gfx90a"
+    "gfx940"
+    "gfx941"
+    "gfx942"
+    "gfx950"
+    "gfx1030"
+    "gfx1010"
+    "gfx1100"
+    "gfx1101"
+    "gfx1102"
+)
+
+set(GPU_TARGETS "${DEFAULT_GPU_TARGETS}" CACHE STRING "GPU targets to compile for")
+
 if(ROCPROFSYS_DISABLE_EXAMPLES)
     if(NOT "openmp-target" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
         add_subdirectory(target)
     endif()
+    if(NOT "openmp-vv" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
+        add_subdirectory(external)
+    endif()
 else()
     add_subdirectory(target)
+    add_subdirectory(external)
 endif()

--- a/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
@@ -3,91 +3,69 @@ cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(rocprofiler-systems-openmp LANGUAGES CXX)
 
 if(ROCPROFSYS_DISABLE_EXAMPLES)
-    get_filename_component(_DIR ${CMAKE_CURRENT_LIST_DIR} NAME)
+  get_filename_component(_DIR ${CMAKE_CURRENT_LIST_DIR} NAME)
 
-    if(
-        ${PROJECT_NAME} IN_LIST ROCPROFSYS_DISABLE_EXAMPLES
-        OR ${_DIR} IN_LIST ROCPROFSYS_DISABLE_EXAMPLES
-    )
-        return()
-    endif()
+  if(${PROJECT_NAME} IN_LIST ROCPROFSYS_DISABLE_EXAMPLES
+     OR ${_DIR} IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
+    return()
+  endif()
 endif()
 
 file(GLOB common_source ${CMAKE_CURRENT_SOURCE_DIR}/common/*.cpp)
 add_library(openmp-common OBJECT ${common_source})
-target_include_directories(openmp-common PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/common)
+target_include_directories(openmp-common
+                           PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/common)
 
-add_executable(
-    openmp-cg
-    ${CMAKE_CURRENT_SOURCE_DIR}/CG/cg.cpp
-    $<TARGET_OBJECTS:openmp-common>
-)
-add_executable(
-    openmp-lu
-    ${CMAKE_CURRENT_SOURCE_DIR}/LU/lu.cpp
-    $<TARGET_OBJECTS:openmp-common>
-)
+add_executable(openmp-cg ${CMAKE_CURRENT_SOURCE_DIR}/CG/cg.cpp
+                         $<TARGET_OBJECTS:openmp-common>)
+add_executable(openmp-lu ${CMAKE_CURRENT_SOURCE_DIR}/LU/lu.cpp
+                         $<TARGET_OBJECTS:openmp-common>)
 
 option(USE_CLANG_OMP "Use the clang OpenMP if available" ON)
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  find_package(OpenMP REQUIRED)
+  target_link_libraries(openmp-common PUBLIC OpenMP::OpenMP_CXX)
+  set(ROCPROFSYS_OPENMP_USING_LIBOMP_LIBRARY
+      ON
+      CACHE INTERNAL "Used by rocprofiler-systems testing" FORCE)
+else()
+  find_program(CLANGXX_EXECUTABLE NAMES clang++)
+  find_library(
+    LIBOMP_LIBRARY
+    NAMES omp omp5
+          ${CMAKE_SHARED_LIBRARY_PREFIX}omp${CMAKE_SHARED_LIBRARY_SUFFIX}.5)
+  if(CLANGXX_EXECUTABLE
+     AND LIBOMP_LIBRARY
+     AND COMMAND rocprofiler_systems_custom_compilation
+     AND USE_CLANG_OMP)
+    target_compile_options(openmp-common PUBLIC -W -Wall -fopenmp=libomp)
+    target_link_libraries(openmp-common PUBLIC ${LIBOMP_LIBRARY})
+    rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE}
+                                           TARGET openmp-common)
+    rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE}
+                                           TARGET openmp-cg)
+    rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE}
+                                           TARGET openmp-lu)
+    set(ROCPROFSYS_OPENMP_USING_LIBOMP_LIBRARY
+        ON
+        CACHE INTERNAL "Used by rocprofiler-systems testing" FORCE)
+  else()
     find_package(OpenMP REQUIRED)
     target_link_libraries(openmp-common PUBLIC OpenMP::OpenMP_CXX)
     set(ROCPROFSYS_OPENMP_USING_LIBOMP_LIBRARY
-        ON
-        CACHE INTERNAL
-        "Used by rocprofiler-systems testing"
-        FORCE
-    )
-else()
-    find_program(CLANGXX_EXECUTABLE NAMES clang++)
-    find_library(
-        LIBOMP_LIBRARY
-        NAMES omp omp5 ${CMAKE_SHARED_LIBRARY_PREFIX}omp${CMAKE_SHARED_LIBRARY_SUFFIX}.5
-    )
-    if(
-        CLANGXX_EXECUTABLE
-        AND LIBOMP_LIBRARY
-        AND COMMAND rocprofiler_systems_custom_compilation
-        AND USE_CLANG_OMP
-    )
-        target_compile_options(openmp-common PUBLIC -W -Wall -fopenmp=libomp)
-        target_link_libraries(openmp-common PUBLIC ${LIBOMP_LIBRARY})
-        rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE}
-                                               TARGET openmp-common
-        )
-        rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE}
-                                               TARGET openmp-cg
-        )
-        rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE}
-                                               TARGET openmp-lu
-        )
-        set(ROCPROFSYS_OPENMP_USING_LIBOMP_LIBRARY
-            ON
-            CACHE INTERNAL
-            "Used by rocprofiler-systems testing"
-            FORCE
-        )
-    else()
-        find_package(OpenMP REQUIRED)
-        target_link_libraries(openmp-common PUBLIC OpenMP::OpenMP_CXX)
-        set(ROCPROFSYS_OPENMP_USING_LIBOMP_LIBRARY
-            OFF
-            CACHE INTERNAL
-            "Used by rocprofiler-systems testing"
-            FORCE
-        )
-    endif()
+        OFF
+        CACHE INTERNAL "Used by rocprofiler-systems testing" FORCE)
+  endif()
 endif()
 
 target_link_libraries(openmp-cg PRIVATE openmp-common)
 target_link_libraries(openmp-lu PRIVATE openmp-common)
 
 if(ROCPROFSYS_INSTALL_EXAMPLES)
-    install(
-        TARGETS openmp-cg openmp-lu
-        DESTINATION bin
-        COMPONENT rocprofiler-systems-examples
-    )
+  install(
+    TARGETS openmp-cg openmp-lu
+    DESTINATION bin
+    COMPONENT rocprofiler-systems-examples)
 endif()
 
 set(DEFAULT_GPU_TARGETS
@@ -103,19 +81,17 @@ set(DEFAULT_GPU_TARGETS
     "gfx1010"
     "gfx1100"
     "gfx1101"
-    "gfx1102"
-)
+    "gfx1102")
 
-set(GPU_TARGETS "${DEFAULT_GPU_TARGETS}" CACHE STRING "GPU targets to compile for")
+set(GPU_TARGETS
+    "${DEFAULT_GPU_TARGETS}"
+    CACHE STRING "GPU targets to compile for")
+add_subdirectory(external)
 
 if(ROCPROFSYS_DISABLE_EXAMPLES)
-    if(NOT "openmp-target" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
-        add_subdirectory(target)
-    endif()
-    if(NOT "openmp-vv" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
-        add_subdirectory(external)
-    endif()
-else()
+  if(NOT "openmp-target" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
     add_subdirectory(target)
-    add_subdirectory(external)
+  endif()
+else()
+  add_subdirectory(target)
 endif()

--- a/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
@@ -8,16 +8,16 @@
 #   implemented. Only a subset of tests can be compiled.
 # ----------------------------------------------------------------------------------------#
 
-set(OMPVV_USE_TARGET_TESTS FALSE)
+set(OMPVV_USE_OFFLOAD_TESTS FALSE)
 if(ROCPROFSYS_DISABLE_EXAMPLES)
   if("openmp-vv" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
     return()
   endif()
-  if(NOT "openmp-vv-target" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
-    set(OMPVV_USE_TARGET_TESTS TRUE)
+  if(NOT "openmp-vv-offload" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
+    set(OMPVV_USE_OFFLOAD_TESTS TRUE)
   endif()
 else()
-  set(OMPVV_USE_TARGET_TESTS TRUE)
+  set(OMPVV_USE_OFFLOAD_TESTS TRUE)
 endif()
 
 rocprofiler_systems_message(STATUS "Configuring OMPVV...")
@@ -136,9 +136,9 @@ set(OMPVV_HOST_TESTS_TO_COMPILE
 
 # Set of offloading tests to be compiled (excluding reduction and simd_atomic
 # tests due to OMPVV test failure)
-set(OMPVV_TARGET_TESTS_TO_COMPILE "")
-if(OMPVV_USE_TARGET_TESTS)
-  set(OMPVV_TARGET_TESTS_TO_COMPILE
+set(OMPVV_OFFLOAD_TESTS_TO_COMPILE "")
+if(OMPVV_USE_OFFLOAD_TESTS)
+  set(OMPVV_OFFLOAD_TESTS_TO_COMPILE
       "${OMPVV_TDIR}/target_simd/test_target_simd_if.F90"
       "${OMPVV_TDIR}/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_collapse.F90"
   )
@@ -161,14 +161,14 @@ set(OMPVV_HOST_FOFFLOADING_FLAGS "-fopenmp --offload-host-only")
 update_make_def_foffloading("${OMPVV_HOST_FOFFLOADING_FLAGS}")
 compile_ompvv_tests(OMPVV_HOST_TESTS_TO_COMPILE)
 
-if(OMPVV_USE_TARGET_TESTS)
-  set(OMPVV_TARGET_FOFFLOADING_FLAGS "-fopenmp")
+if(OMPVV_USE_OFFLOAD_TESTS)
+  set(OMPVV_OFFLOAD_FOFFLOADING_FLAGS "-fopenmp")
   foreach(arch IN LISTS DEFAULT_GPU_TARGETS)
-    set(OMPVV_TARGET_FOFFLOADING_FLAGS
-        "${OMPVV_TARGET_FOFFLOADING_FLAGS} --offload-arch=${arch}")
+    set(OMPVV_OFFLOAD_FOFFLOADING_FLAGS
+        "${OMPVV_OFFLOAD_FOFFLOADING_FLAGS} --offload-arch=${arch}")
   endforeach()
-  update_make_def_foffloading("${OMPVV_TARGET_FOFFLOADING_FLAGS}")
-  compile_ompvv_tests(OMPVV_TARGET_TESTS_TO_COMPILE)
+  update_make_def_foffloading("${OMPVV_OFFLOAD_FOFFLOADING_FLAGS}")
+  compile_ompvv_tests(OMPVV_OFFLOAD_TESTS_TO_COMPILE)
 endif()
 
 # ---------------------------------------------------------------------------------------#
@@ -179,7 +179,7 @@ set(OMPVV_BIN_SOURCE "${PROJECT_SOURCE_DIR}/external/ompvv/bin")
 set(OMPVV_BIN_DEST "${CMAKE_BINARY_DIR}")
 
 set(ROCPROFSYS_OMPVV_HOST_TESTS "")
-set(ROCPROFSYS_OMPVV_TARGET_TESTS "")
+set(ROCPROFSYS_OMPVV_OFFLOAD_TESTS "")
 
 file(GLOB OMPVV_BINARIES "${OMPVV_BIN_SOURCE}/*")
 
@@ -188,7 +188,7 @@ foreach(OMPVV_BIN ${OMPVV_BINARIES})
 
   # Determine type of test
   set(IS_HOST_TEST FALSE)
-  set(IS_TARGET_TEST FALSE)
+  set(IS_OFFLOAD_TEST FALSE)
   foreach(host_test IN LISTS OMPVV_HOST_TESTS_TO_COMPILE)
     get_filename_component(HOST_TEST_NAME ${host_test} NAME_WE)
     if(BIN_NAME STREQUAL HOST_TEST_NAME)
@@ -197,17 +197,17 @@ foreach(OMPVV_BIN ${OMPVV_BINARIES})
     endif()
   endforeach()
 
-  if(NOT IS_HOST_TEST AND OMPVV_USE_TARGET_TESTS)
-    foreach(target_test IN LISTS OMPVV_TARGET_TESTS_TO_COMPILE)
-      get_filename_component(TARGET_TEST_NAME ${target_test} NAME_WE)
-      if(BIN_NAME STREQUAL TARGET_TEST_NAME)
-        set(IS_TARGET_TEST TRUE)
+  if(NOT IS_HOST_TEST AND OMPVV_USE_OFFLOAD_TESTS)
+    foreach(offload_test IN LISTS OMPVV_OFFLOAD_TESTS_TO_COMPILE)
+      get_filename_component(OFFLOAD_TEST_NAME ${offload_test} NAME_WE)
+      if(BIN_NAME STREQUAL OFFLOAD_TEST_NAME)
+        set(IS_OFFLOAD_TEST TRUE)
         break()
       endif()
     endforeach()
   endif()
 
-  if(NOT IS_HOST_TEST AND NOT IS_TARGET_TEST)
+  if(NOT IS_HOST_TEST AND NOT IS_OFFLOAD_TEST)
     continue()
   endif()
 
@@ -220,9 +220,9 @@ foreach(OMPVV_BIN ${OMPVV_BINARIES})
   if(IS_HOST_TEST)
     set(TARGET_NAME "openmp-vv-host-${NEW_BIN_NAME}")
     list(APPEND ROCPROFSYS_OMPVV_HOST_TESTS ${TARGET_NAME})
-  elseif(IS_TARGET_TEST)
-    set(TARGET_NAME "openmp-vv-target-${NEW_BIN_NAME}")
-    list(APPEND ROCPROFSYS_OMPVV_TARGET_TESTS ${TARGET_NAME})
+  elseif(IS_OFFLOAD_TEST)
+    set(TARGET_NAME "openmp-vv-offload-${NEW_BIN_NAME}")
+    list(APPEND ROCPROFSYS_OMPVV_OFFLOAD_TESTS ${TARGET_NAME})
   endif()
 
   file(RENAME "${OMPVV_BIN_DEST}/${BIN_NAME}.F90.o"
@@ -238,9 +238,9 @@ set(ROCPROFSYS_OMPVV_HOST_TESTS
     "${ROCPROFSYS_OMPVV_HOST_TESTS}"
     CACHE STRING "Internal variable used to generate OMPVV Host CTests" FORCE)
 
-set(ROCPROFSYS_OMPVV_TARGET_TESTS
-    "${ROCPROFSYS_OMPVV_TARGET_TESTS}"
-    CACHE STRING "Internal variable used to generate OMPVV Target CTests" FORCE)
+set(ROCPROFSYS_OMPVV_OFFLOAD_TESTS
+    "${ROCPROFSYS_OMPVV_OFFLOAD_TESTS}"
+    CACHE STRING "Internal variable used to generate OMPVV Offload CTests" FORCE)
 
 rocprofiler_systems_message(STATUS
                             "Successfully built and compiled OMPVV tests")

--- a/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
@@ -2,24 +2,26 @@
 #
 # OMPVV (OpenMP Validation and Verification) submodule
 #
-# - Currently, GNU's libgomp cannot be used to capture traces
-#    Only LLVM's libomp can be used
-#
+# * Currently, GNU's libgomp cannot be used to capture traces Only LLVM's LIBOMP
+#   can be used
+# * amdflang uses LIBOMP 201611 (5.0), but not all features are implemented.
+#   Only a subset of tests can be compiled.
 # ----------------------------------------------------------------------------------------#
 
-rocprofiler_systems_message(
-    STATUS
-    "Configuring OMPVV..."
-)
+rocprofiler_systems_message(STATUS "Configuring OMPVV...")
 
 # Master branch contains stable releases
 rocprofiler_systems_checkout_git_submodule(
-    RELATIVE_PATH external/ompvv
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    TEST_FILE Makefile
-    REPO_URL https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV.git
-    REPO_BRANCH "master"
-)
+  RELATIVE_PATH
+  external/ompvv
+  WORKING_DIRECTORY
+  ${PROJECT_SOURCE_DIR}
+  TEST_FILE
+  Makefile
+  REPO_URL
+  https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV.git
+  REPO_BRANCH
+  "master")
 
 # ---------------------------------------------------------------------------------------#
 # Compiler
@@ -27,67 +29,48 @@ rocprofiler_systems_checkout_git_submodule(
 
 # OMPVV requires amdclang++
 find_program(
-    amdclangpp_EXECUTABLE
-    NAMES amdclang++
-    HINTS ${ROCM_PATH}
-    ENV ROCM_PATH
-    /opt/rocm
-    PATHS ${ROCM_PATH}
-    ENV ROCM_PATH
-    /opt/rocm
-    PATH_SUFFIXES bin llvm/bin
-)
+  amdclangpp_EXECUTABLE
+  NAMES amdclang++
+  HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+  PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+  PATH_SUFFIXES bin llvm/bin)
 mark_as_advanced(amdclangpp_EXECUTABLE)
 
 if(NOT amdclangpp_EXECUTABLE)
-    rocprofiler_systems_message(FATAL_ERROR
-    "Could not find amdclang++. This is required for OMPVV."
-    )
+  rocprofiler_systems_message(
+    FATAL_ERROR
+    "Could not find amdclang++. This is required for the OMPVV tests.")
 endif()
 
 find_program(
-    amdflang_EXECUTABLE
-    NAMES amdflang
-    HINTS ${ROCM_PATH}
-    ENV ROCM_PATH
-    /opt/rocm
-    PATHS ${ROCM_PATH}
-    ENV ROCM_PATH
-    /opt/rocm
-    PATH_SUFFIXES bin llvm/bin
-)
+  amdflang_EXECUTABLE
+  NAMES amdflang
+  HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+  PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+  PATH_SUFFIXES bin llvm/bin)
 mark_as_advanced(amdflang_EXECUTABLE)
 
 if(NOT amdflang_EXECUTABLE)
-    rocprofiler_systems_message(FATAL_ERROR
-    "Could not find amdflang. This is required for OMPVV."
-    )
+  rocprofiler_systems_message(
+    FATAL_ERROR
+    "Could not find amdflang. This is required for the OMPVV tests.")
 endif()
-
-set(OMPVV_COMPILER
-    "${amdflang_EXECUTABLE}"
-    CACHE FILEPATH
-    "Fortran compiler used for OMPVV tests"
-)
-set(OMPVV_FC "amdflang")
 
 # ---------------------------------------------------------------------------------------#
 # Variables
 # ---------------------------------------------------------------------------------------#
 
-# amdflang uses LIBOMP 201611 (5.0), but not all features are fully implemented
 set(OMPVV_OPENMP_VERSION 5.0)
 set(OMPVV_NUM_THREADS_HOST ${ROCPROFSYS_THREAD_COUNT})
 set(OMPVV_NUM_TEAMS_DEVICE 8) # default used by ompvv
 set(OMPVV_NUM_THREADS_DEVICE 8) # default used by ompvv
 
-# Set the tests to be compiled
-#   Tests present are the ones that compile (excluding reduction due to OMPVV test failure)
-#   If any tests are added/removed, must entirely rebuild
+# Set the tests to be compiled Tests listed are the ones that compile (excluding
+# reduction due to OMPVV test failure) If any tests are added/removed, a
+# complete rebuild is required
 set(OMPVV_TESTS_TO_COMPILE
     "atomic/test_atomic_acquire_release.F90"
-    # "atomic/test_atomic_hint.F90"
-    # "atomic/test_atomic_num_hint_device.F90"
+    # "atomic/test_atomic_hint.F90" "atomic/test_atomic_num_hint_device.F90"
     # "atomic/test_atomic_num_hint.F90"
     # "declare_target/test_declare_target_device_type_any.F90"
     # "declare_target/test_declare_target_device_type_host.F90"
@@ -95,26 +78,24 @@ set(OMPVV_TESTS_TO_COMPILE
     "requires/test_requires_atomic_default_mem_order_relaxed.F90"
     # "requires/test_requires_atomic_default_mem_order_acq_rel.F90"
     # "requires/test_requires_atomic_default_mem_order_seq_cst.F90"
-    # "simd/test_simd_if.F90"
-    # "simd/test_simd_nontemporal.F90"
+    # "simd/test_simd_if.F90" "simd/test_simd_nontemporal.F90"
     # "simd/test_simd_order_concurrent.F90"
     # "target_simd/test_target_simd_order_concurrent.F90"
     # "target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_collapse.F90"
     # "target_teams_distribute_parallel_for_simd/test_target_teams_distribute_parallel_for_simd_atomic.F90"
-    # "task/test_task_detach.F90"
-    # "teams/test_team_default_shared.F90"
-    # "teams/test_teams.F90" # Cannot be used until detach_task bug is fixed
+    # "task/test_task_detach.F90" "teams/test_team_default_shared.F90"
+    # "teams/test_teams.F90" # Bug due to task_detach callback failure
 )
 
 set(OMPVV_SRC_PREFIX "tests/${OMPVV_OPENMP_VERSION}")
 set(OMPVV_SOURCES_LIST "")
 foreach(TEST IN LISTS OMPVV_TESTS_TO_COMPILE)
-    list(APPEND OMPVV_SOURCES_LIST "${OMPVV_SRC_PREFIX}/${TEST}")
+  list(APPEND OMPVV_SOURCES_LIST "${OMPVV_SRC_PREFIX}/${TEST}")
 endforeach()
 
 set(OMPVV_FOFFLOADING "-fopenmp")
 foreach(arch IN LISTS DEFAULT_GPU_TARGETS)
-    set(OMPVV_FOFFLOADING "${OMPVV_FOFFLOADING} --offload-arch=${arch}")
+  set(OMPVV_FOFFLOADING "${OMPVV_FOFFLOADING} --offload-arch=${arch}")
 endforeach()
 
 # ---------------------------------------------------------------------------------------#
@@ -123,20 +104,22 @@ endforeach()
 #
 # ---------------------------------------------------------------------------------------#
 
-file(READ ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def MAKE_DEF_CONTENT)
+file(READ ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def
+     MAKE_DEF_CONTENT)
 
 # Replace FOFFLOADING
 string(
-    REGEX REPLACE
+  REGEX
+  REPLACE
     "(ifeq \\(\\$\\(OMPVV_USED_FC\\), amdflang\\).*FOFFLOADING[ ]*=[ ]*)-fopenmp --offload-arch=gfx90a"
     "\\1${OMPVV_FOFFLOADING}"
     MAKE_DEF_CONTENT
-    "${MAKE_DEF_CONTENT}"
-)
+    "${MAKE_DEF_CONTENT}")
 # Remove all -O3 flags to prevent function inlining
 string(REGEX REPLACE "-O3[ \t]*" "" MAKE_DEF_CONTENT "${MAKE_DEF_CONTENT}")
 
-file(WRITE ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def "${MAKE_DEF_CONTENT}")
+file(WRITE ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def
+     "${MAKE_DEF_CONTENT}")
 
 # ---------------------------------------------------------------------------------------#
 #
@@ -144,30 +127,27 @@ file(WRITE ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def "${MAKE_DEF_CO
 #
 # ---------------------------------------------------------------------------------------#
 
-# OMPVV doesn't support building subsets of a test folder, so we compile each test individually
+# OMPVV doesn't support building subsets of a test folder. Compile each test
+# individually
 foreach(test IN LISTS OMPVV_SOURCES_LIST)
-    rocprofiler_systems_message(STATUS "Compiling OMPVV test: ${test}")
+  rocprofiler_systems_message(STATUS "Compiling OMPVV test: ${test}")
 
-    execute_process(
-        COMMAND
-            make FC=${OMPVV_FC} DEVICE_TYPE=amd OMP_VERSION=${OMPVV_OPENMP_VERSION}
-            NUM_THREADS_HOST=${OMPVV_NUM_THREADS_HOST}
-            NUM_THREADS_DEVICE=${OMPVV_NUM_THREADS_DEVICE}
-            NUM_TEAMS_DEVICE=${OMPVV_NUM_TEAMS_DEVICE} "SOURCES=${test}" compile
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/external/ompvv
-        RESULT_VARIABLE OMPVV_BUILD_RESULT
-        OUTPUT_VARIABLE OMPVV_BUILD_OUTPUT
-        ERROR_VARIABLE OMPVV_BUILD_ERROR
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_STRIP_TRAILING_WHITESPACE
-    )
+  execute_process(
+    COMMAND
+      make FC=${OMPVV_FC} DEVICE_TYPE=amd OMP_VERSION=${OMPVV_OPENMP_VERSION}
+      NUM_THREADS_HOST=${OMPVV_NUM_THREADS_HOST}
+      NUM_THREADS_DEVICE=${OMPVV_NUM_THREADS_DEVICE}
+      NUM_TEAMS_DEVICE=${OMPVV_NUM_TEAMS_DEVICE} "SOURCES=${test}" compile
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/external/ompvv
+    RESULT_VARIABLE OMPVV_BUILD_RESULT
+    OUTPUT_VARIABLE OMPVV_BUILD_OUTPUT
+    ERROR_VARIABLE OMPVV_BUILD_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE)
 
-    if(NOT OMPVV_BUILD_RESULT EQUAL 0)
-        rocprofiler_systems_message(
-            FATAL_ERROR
-            "OMPVV build failed for ${test}: ${OMPVV_BUILD_ERROR}"
-        )
-    endif()
+  if(NOT OMPVV_BUILD_RESULT EQUAL 0)
+    rocprofiler_systems_message(
+      FATAL_ERROR "OMPVV build failed for ${test}: ${OMPVV_BUILD_ERROR}")
+  endif()
 endforeach()
 
 # ---------------------------------------------------------------------------------------#
@@ -184,32 +164,26 @@ file(GLOB OMPVV_BIN_FILES "${OMPVV_BIN_SOURCE}/*")
 
 # Create imported executable - required for rocprofiler_systems_add_test
 foreach(OMPVV_BIN_FILE ${OMPVV_BIN_FILES})
-    get_filename_component(FILENAME ${OMPVV_BIN_FILE} NAME)
+  get_filename_component(FILENAME ${OMPVV_BIN_FILE} NAME)
 
-    # For consistent naming with other tests
-    string(REGEX REPLACE "\\.F90\\.o$" "" BIN_NAME ${FILENAME})
-    string(REPLACE "_" "-" BIN_NAME ${BIN_NAME})
-    file(COPY "${OMPVV_BIN_FILE}" DESTINATION "${OMPVV_BIN_DEST}")
-    file(RENAME "${OMPVV_BIN_DEST}/${FILENAME}" "${OMPVV_BIN_DEST}/openmp-vv-${BIN_NAME}")
+  # For consistent naming with other tests
+  string(REGEX REPLACE "\\.F90\\.o$" "" BIN_NAME ${FILENAME})
+  string(REPLACE "_" "-" BIN_NAME ${BIN_NAME})
+  file(COPY "${OMPVV_BIN_FILE}" DESTINATION "${OMPVV_BIN_DEST}")
+  file(RENAME "${OMPVV_BIN_DEST}/${FILENAME}"
+       "${OMPVV_BIN_DEST}/openmp-vv-${BIN_NAME}")
 
-    set(TARGET_NAME "openmp-vv-${BIN_NAME}")
-    add_executable(${TARGET_NAME} IMPORTED GLOBAL)
-    set_target_properties(
-        ${TARGET_NAME}
-        PROPERTIES IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/openmp-vv-${BIN_NAME}"
-    )
+  set(TARGET_NAME "openmp-vv-${BIN_NAME}")
+  add_executable(${TARGET_NAME} IMPORTED GLOBAL)
+  set_target_properties(
+    ${TARGET_NAME} PROPERTIES IMPORTED_LOCATION
+                              "${CMAKE_BINARY_DIR}/openmp-vv-${BIN_NAME}")
 
-    list(APPEND OMPVV_TESTS ${BIN_NAME})
+  list(APPEND OMPVV_TESTS ${BIN_NAME})
 endforeach()
 
 set(OMPVV_TESTS
     "${OMPVV_TESTS}"
-    CACHE STRING
-    "Internal variable used to generate OMPVV CTests"
-    FORCE
-)
+    CACHE STRING "Internal variable used to generate OMPVV CTests" FORCE)
 
-rocprofiler_systems_message(
-    STATUS
-    "Succesfully built and compiled OMPVV tests"
-)
+rocprofiler_systems_message(STATUS "Succesfully built and compiled OMPVV tests")

--- a/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
@@ -240,7 +240,8 @@ set(ROCPROFSYS_OMPVV_HOST_TESTS
 
 set(ROCPROFSYS_OMPVV_OFFLOAD_TESTS
     "${ROCPROFSYS_OMPVV_OFFLOAD_TESTS}"
-    CACHE STRING "Internal variable used to generate OMPVV Offload CTests" FORCE)
+    CACHE STRING "Internal variable used to generate OMPVV Offload CTests"
+          FORCE)
 
 rocprofiler_systems_message(STATUS
                             "Successfully built and compiled OMPVV tests")

--- a/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright Advanced Micro Devices, Inc.
+# Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
 # ----------------------------------------------------------------------------------------#

--- a/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
@@ -1,0 +1,215 @@
+# ----------------------------------------------------------------------------------------#
+#
+# OMPVV (OpenMP Validation and Verification) submodule
+#
+# - Currently, GNU's libgomp cannot be used to capture traces
+#    Only LLVM's libomp can be used
+#
+# ----------------------------------------------------------------------------------------#
+
+rocprofiler_systems_message(
+    STATUS
+    "Configuring OMPVV..."
+)
+
+# Master branch contains stable releases
+rocprofiler_systems_checkout_git_submodule(
+    RELATIVE_PATH external/ompvv
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    TEST_FILE Makefile
+    REPO_URL https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV.git
+    REPO_BRANCH "master"
+)
+
+# ---------------------------------------------------------------------------------------#
+# Compiler
+# ---------------------------------------------------------------------------------------#
+
+# OMPVV requires amdclang++
+find_program(
+    amdclangpp_EXECUTABLE
+    NAMES amdclang++
+    HINTS ${ROCM_PATH}
+    ENV ROCM_PATH
+    /opt/rocm
+    PATHS ${ROCM_PATH}
+    ENV ROCM_PATH
+    /opt/rocm
+    PATH_SUFFIXES bin llvm/bin
+)
+mark_as_advanced(amdclangpp_EXECUTABLE)
+
+if(NOT amdclangpp_EXECUTABLE)
+    rocprofiler_systems_message(FATAL_ERROR
+    "Could not find amdclang++. This is required for OMPVV."
+    )
+endif()
+
+find_program(
+    amdflang_EXECUTABLE
+    NAMES amdflang
+    HINTS ${ROCM_PATH}
+    ENV ROCM_PATH
+    /opt/rocm
+    PATHS ${ROCM_PATH}
+    ENV ROCM_PATH
+    /opt/rocm
+    PATH_SUFFIXES bin llvm/bin
+)
+mark_as_advanced(amdflang_EXECUTABLE)
+
+if(NOT amdflang_EXECUTABLE)
+    rocprofiler_systems_message(FATAL_ERROR
+    "Could not find amdflang. This is required for OMPVV."
+    )
+endif()
+
+set(OMPVV_COMPILER
+    "${amdflang_EXECUTABLE}"
+    CACHE FILEPATH
+    "Fortran compiler used for OMPVV tests"
+)
+set(OMPVV_FC "amdflang")
+
+# ---------------------------------------------------------------------------------------#
+# Variables
+# ---------------------------------------------------------------------------------------#
+
+# amdflang uses LIBOMP 201611 (5.0), but not all features are fully implemented
+set(OMPVV_OPENMP_VERSION 5.0)
+set(OMPVV_NUM_THREADS_HOST ${ROCPROFSYS_THREAD_COUNT})
+set(OMPVV_NUM_TEAMS_DEVICE 8) # default used by ompvv
+set(OMPVV_NUM_THREADS_DEVICE 8) # default used by ompvv
+
+# Set the tests to be compiled
+#   Tests present are the ones that compile (excluding reduction due to OMPVV test failure)
+#   If any tests are added/removed, must entirely rebuild
+set(OMPVV_TESTS_TO_COMPILE
+    "atomic/test_atomic_acquire_release.F90"
+    # "atomic/test_atomic_hint.F90"
+    # "atomic/test_atomic_num_hint_device.F90"
+    # "atomic/test_atomic_num_hint.F90"
+    # "declare_target/test_declare_target_device_type_any.F90"
+    # "declare_target/test_declare_target_device_type_host.F90"
+    # "parallel_for_simd/test_parallel_for_simd_atomic.F90"
+    "requires/test_requires_atomic_default_mem_order_relaxed.F90"
+    # "requires/test_requires_atomic_default_mem_order_acq_rel.F90"
+    # "requires/test_requires_atomic_default_mem_order_seq_cst.F90"
+    # "simd/test_simd_if.F90"
+    # "simd/test_simd_nontemporal.F90"
+    # "simd/test_simd_order_concurrent.F90"
+    # "target_simd/test_target_simd_order_concurrent.F90"
+    # "target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_collapse.F90"
+    # "target_teams_distribute_parallel_for_simd/test_target_teams_distribute_parallel_for_simd_atomic.F90"
+    # "task/test_task_detach.F90"
+    # "teams/test_team_default_shared.F90"
+    # "teams/test_teams.F90" # Cannot be used until detach_task bug is fixed
+)
+
+set(OMPVV_SRC_PREFIX "tests/${OMPVV_OPENMP_VERSION}")
+set(OMPVV_SOURCES_LIST "")
+foreach(TEST IN LISTS OMPVV_TESTS_TO_COMPILE)
+    list(APPEND OMPVV_SOURCES_LIST "${OMPVV_SRC_PREFIX}/${TEST}")
+endforeach()
+
+set(OMPVV_FOFFLOADING "-fopenmp")
+foreach(arch IN LISTS DEFAULT_GPU_TARGETS)
+    set(OMPVV_FOFFLOADING "${OMPVV_FOFFLOADING} --offload-arch=${arch}")
+endforeach()
+
+# ---------------------------------------------------------------------------------------#
+#
+# modify make.def file
+#
+# ---------------------------------------------------------------------------------------#
+
+file(READ ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def MAKE_DEF_CONTENT)
+
+# Replace FOFFLOADING
+string(
+    REGEX REPLACE
+    "(ifeq \\(\\$\\(OMPVV_USED_FC\\), amdflang\\).*FOFFLOADING[ ]*=[ ]*)-fopenmp --offload-arch=gfx90a"
+    "\\1${OMPVV_FOFFLOADING}"
+    MAKE_DEF_CONTENT
+    "${MAKE_DEF_CONTENT}"
+)
+# Remove all -O3 flags to prevent function inlining
+string(REGEX REPLACE "-O3[ \t]*" "" MAKE_DEF_CONTENT "${MAKE_DEF_CONTENT}")
+
+file(WRITE ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def "${MAKE_DEF_CONTENT}")
+
+# ---------------------------------------------------------------------------------------#
+#
+# build
+#
+# ---------------------------------------------------------------------------------------#
+
+# OMPVV doesn't support building subsets of a test folder, so we compile each test individually
+foreach(test IN LISTS OMPVV_SOURCES_LIST)
+    rocprofiler_systems_message(STATUS "Compiling OMPVV test: ${test}")
+
+    execute_process(
+        COMMAND
+            make FC=${OMPVV_FC} DEVICE_TYPE=amd OMP_VERSION=${OMPVV_OPENMP_VERSION}
+            NUM_THREADS_HOST=${OMPVV_NUM_THREADS_HOST}
+            NUM_THREADS_DEVICE=${OMPVV_NUM_THREADS_DEVICE}
+            NUM_TEAMS_DEVICE=${OMPVV_NUM_TEAMS_DEVICE} "SOURCES=${test}" compile
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/external/ompvv
+        RESULT_VARIABLE OMPVV_BUILD_RESULT
+        OUTPUT_VARIABLE OMPVV_BUILD_OUTPUT
+        ERROR_VARIABLE OMPVV_BUILD_ERROR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_STRIP_TRAILING_WHITESPACE
+    )
+
+    if(NOT OMPVV_BUILD_RESULT EQUAL 0)
+        rocprofiler_systems_message(
+            FATAL_ERROR
+            "OMPVV build failed for ${test}: ${OMPVV_BUILD_ERROR}"
+        )
+    endif()
+endforeach()
+
+# ---------------------------------------------------------------------------------------#
+#
+# copy over generated binaries to build folder for tests
+#
+# ---------------------------------------------------------------------------------------#
+
+set(OMPVV_BIN_SOURCE "${PROJECT_SOURCE_DIR}/external/ompvv/bin")
+set(OMPVV_BIN_DEST "${CMAKE_BINARY_DIR}")
+set(OMPVV_TESTS "")
+
+file(GLOB OMPVV_BIN_FILES "${OMPVV_BIN_SOURCE}/*")
+
+# Create imported executable - required for rocprofiler_systems_add_test
+foreach(OMPVV_BIN_FILE ${OMPVV_BIN_FILES})
+    get_filename_component(FILENAME ${OMPVV_BIN_FILE} NAME)
+
+    # For consistent naming with other tests
+    string(REGEX REPLACE "\\.F90\\.o$" "" BIN_NAME ${FILENAME})
+    string(REPLACE "_" "-" BIN_NAME ${BIN_NAME})
+    file(COPY "${OMPVV_BIN_FILE}" DESTINATION "${OMPVV_BIN_DEST}")
+    file(RENAME "${OMPVV_BIN_DEST}/${FILENAME}" "${OMPVV_BIN_DEST}/openmp-vv-${BIN_NAME}")
+
+    set(TARGET_NAME "openmp-vv-${BIN_NAME}")
+    add_executable(${TARGET_NAME} IMPORTED GLOBAL)
+    set_target_properties(
+        ${TARGET_NAME}
+        PROPERTIES IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/openmp-vv-${BIN_NAME}"
+    )
+
+    list(APPEND OMPVV_TESTS ${BIN_NAME})
+endforeach()
+
+set(OMPVV_TESTS
+    "${OMPVV_TESTS}"
+    CACHE STRING
+    "Internal variable used to generate OMPVV CTests"
+    FORCE
+)
+
+rocprofiler_systems_message(
+    STATUS
+    "Succesfully built and compiled OMPVV tests"
+)

--- a/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 # ----------------------------------------------------------------------------------------#
 #
 # OMPVV (OpenMP Validation and Verification) submodule
@@ -10,14 +32,14 @@
 
 set(OMPVV_USE_OFFLOAD_TESTS FALSE)
 if(ROCPROFSYS_DISABLE_EXAMPLES)
-  if("openmp-vv" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
-    return()
-  endif()
-  if(NOT "openmp-vv-offload" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
-    set(OMPVV_USE_OFFLOAD_TESTS TRUE)
-  endif()
+    if("openmp-vv" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
+        return()
+    endif()
+    if(NOT "openmp-vv-offload" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
+        set(OMPVV_USE_OFFLOAD_TESTS TRUE)
+    endif()
 else()
-  set(OMPVV_USE_OFFLOAD_TESTS TRUE)
+    set(OMPVV_USE_OFFLOAD_TESTS TRUE)
 endif()
 
 rocprofiler_systems_message(STATUS "Configuring OMPVV...")
@@ -33,7 +55,8 @@ rocprofiler_systems_checkout_git_submodule(
   REPO_URL
   https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV.git
   REPO_BRANCH
-  "master")
+  "master"
+)
 
 # ---------------------------------------------------------------------------------------#
 # helper functions
@@ -41,43 +64,50 @@ rocprofiler_systems_checkout_git_submodule(
 
 # Updates the make.def FOFFLOADING flag. First call should remove O3 flags
 function(update_make_def_foffloading FOFFLOADING_FLAGS)
-  file(READ ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def
-       MAKE_DEF_CONTENT)
+    file(READ ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def MAKE_DEF_CONTENT)
 
-  # Replaces all FOFFLOADING lines
-  string(
-    REGEX
-    REPLACE "FOFFLOADING[ \t]*=[ \t]*-fopenmp[^\n\r]*"
-            "FOFFLOADING   =  ${FOFFLOADING_FLAGS}" MAKE_DEF_CONTENT
-            "${MAKE_DEF_CONTENT}")
+    # Replaces all FOFFLOADING lines
+    string(
+        REGEX REPLACE
+        "FOFFLOADING[ \t]*=[ \t]*-fopenmp[^\n\r]*"
+        "FOFFLOADING   =  ${FOFFLOADING_FLAGS}"
+        MAKE_DEF_CONTENT
+        "${MAKE_DEF_CONTENT}"
+    )
 
-  file(WRITE ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def
-       "${MAKE_DEF_CONTENT}")
+    file(
+        WRITE
+        ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def
+        "${MAKE_DEF_CONTENT}"
+    )
 endfunction()
 
 # Individually compiles a given list of tests
 function(compile_ompvv_tests TEST_LIST_VAR)
-  # OMPVV doesn't support building subsets of test folders
-  foreach(test IN LISTS ${TEST_LIST_VAR})
-    rocprofiler_systems_message(STATUS "Compiling OMPVV test: ${test}")
+    # OMPVV doesn't support building subsets of test folders
+    foreach(test IN LISTS ${TEST_LIST_VAR})
+        rocprofiler_systems_message(STATUS "Compiling OMPVV test: ${test}")
 
-    execute_process(
-      COMMAND
-        make FC=${OMPVV_FC} DEVICE_TYPE=amd OMP_VERSION=${OMPVV_OPENMP_VERSION}
-        NUM_THREADS_HOST=${OMPVV_NUM_THREADS_HOST}
-        NUM_THREADS_DEVICE=${OMPVV_NUM_THREADS_DEVICE}
-        NUM_TEAMS_DEVICE=${OMPVV_NUM_TEAMS_DEVICE} "SOURCES=${test}" compile
-      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/external/ompvv
-      RESULT_VARIABLE OMPVV_BUILD_RESULT
-      OUTPUT_VARIABLE OMPVV_BUILD_OUTPUT
-      ERROR_VARIABLE OMPVV_BUILD_ERROR
-      OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE)
+        execute_process(
+            COMMAND
+                make FC=${OMPVV_FC} DEVICE_TYPE=amd OMP_VERSION=${OMPVV_OPENMP_VERSION}
+                NUM_THREADS_HOST=${OMPVV_NUM_THREADS_HOST}
+                NUM_THREADS_DEVICE=${OMPVV_NUM_THREADS_DEVICE}
+                NUM_TEAMS_DEVICE=${OMPVV_NUM_TEAMS_DEVICE} "SOURCES=${test}" compile
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/external/ompvv
+            RESULT_VARIABLE OMPVV_BUILD_RESULT
+            OUTPUT_VARIABLE OMPVV_BUILD_OUTPUT
+            ERROR_VARIABLE OMPVV_BUILD_ERROR
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_STRIP_TRAILING_WHITESPACE
+        )
 
-    if(NOT OMPVV_BUILD_RESULT EQUAL 0)
-      rocprofiler_systems_message(
-        FATAL_ERROR "OMPVV build failed for ${test}: ${OMPVV_BUILD_ERROR}")
-    endif()
-  endforeach()
+        if(NOT OMPVV_BUILD_RESULT EQUAL 0)
+            rocprofiler_systems_message(
+              FATAL_ERROR "OMPVV build failed for ${test}: ${OMPVV_BUILD_ERROR}"
+            )
+        endif()
+    endforeach()
 endfunction()
 
 # ---------------------------------------------------------------------------------------#
@@ -86,36 +116,50 @@ endfunction()
 
 # OMPVV requires amdclang++
 find_program(
-  amdclangpp_EXECUTABLE
-  NAMES amdclang++
-  HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
-  PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
-  PATH_SUFFIXES bin llvm/bin)
+    amdclangpp_EXECUTABLE
+    NAMES amdclang++
+    HINTS ${ROCM_PATH}
+    ENV ROCM_PATH
+    /opt/rocm
+    PATHS ${ROCM_PATH}
+    ENV ROCM_PATH
+    /opt/rocm
+    PATH_SUFFIXES bin llvm/bin
+)
 mark_as_advanced(amdclangpp_EXECUTABLE)
 
 if(NOT amdclangpp_EXECUTABLE)
-  rocprofiler_systems_message(
-    FATAL_ERROR
-    "Could not find amdclang++. This is required for the OMPVV tests.")
+    rocprofiler_systems_message(
+      FATAL_ERROR
+      "Could not find amdclang++. This is required for the OMPVV tests."
+    )
 endif()
 
 find_program(
-  amdflang_EXECUTABLE
-  NAMES amdflang
-  HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
-  PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
-  PATH_SUFFIXES bin llvm/bin)
+    amdflang_EXECUTABLE
+    NAMES amdflang
+    HINTS ${ROCM_PATH}
+    ENV ROCM_PATH
+    /opt/rocm
+    PATHS ${ROCM_PATH}
+    ENV ROCM_PATH
+    /opt/rocm
+    PATH_SUFFIXES bin llvm/bin
+)
 mark_as_advanced(amdflang_EXECUTABLE)
 
 if(NOT amdflang_EXECUTABLE)
-  rocprofiler_systems_message(
-    FATAL_ERROR
-    "Could not find amdflang. This is required for the OMPVV tests.")
+    rocprofiler_systems_message(
+      FATAL_ERROR
+      "Could not find amdflang. This is required for the OMPVV tests."
+    )
 endif()
 
 set(OMPVV_COMPILER
     "${amdflang_EXECUTABLE}"
-    CACHE FILEPATH "Fortran compiler used for OMPVV tests")
+    CACHE FILEPATH
+    "Fortran compiler used for OMPVV tests"
+)
 set(OMPVV_FC "amdflang")
 
 # ---------------------------------------------------------------------------------------#
@@ -132,16 +176,17 @@ set(OMPVV_NUM_THREADS_DEVICE 8) # default used by ompvv
 # and 19.0 Set of host only tests to be compiled
 set(OMPVV_HOST_TESTS_TO_COMPILE
     "${OMPVV_TDIR}/teams/test_team_default_shared.F90"
-    "${OMPVV_TDIR}/parallel_for_simd/test_parallel_for_simd_atomic.F90")
+    "${OMPVV_TDIR}/parallel_for_simd/test_parallel_for_simd_atomic.F90"
+)
 
 # Set of offloading tests to be compiled (excluding reduction and simd_atomic
 # tests due to OMPVV test failure)
 set(OMPVV_OFFLOAD_TESTS_TO_COMPILE "")
 if(OMPVV_USE_OFFLOAD_TESTS)
-  set(OMPVV_OFFLOAD_TESTS_TO_COMPILE
-      "${OMPVV_TDIR}/target_simd/test_target_simd_if.F90"
-      "${OMPVV_TDIR}/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_collapse.F90"
-  )
+    set(OMPVV_OFFLOAD_TESTS_TO_COMPILE
+        "${OMPVV_TDIR}/target_simd/test_target_simd_if.F90"
+        "${OMPVV_TDIR}/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_collapse.F90"
+    )
 endif()
 
 # ---------------------------------------------------------------------------------------#
@@ -149,11 +194,9 @@ endif()
 # ---------------------------------------------------------------------------------------#
 
 # Remove all -O3 flags to prevent function inlining
-file(READ ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def
-     MAKE_DEF_CONTENT)
+file(READ ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def MAKE_DEF_CONTENT)
 string(REGEX REPLACE "-O3[ \t]*" "" MAKE_DEF_CONTENT "${MAKE_DEF_CONTENT}")
-file(WRITE ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def
-     "${MAKE_DEF_CONTENT}")
+file(WRITE ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def "${MAKE_DEF_CONTENT}")
 
 # OMPVV makefile option NO_OFFLOADING not supported for amdflang, must manually
 # do it
@@ -162,13 +205,14 @@ update_make_def_foffloading("${OMPVV_HOST_FOFFLOADING_FLAGS}")
 compile_ompvv_tests(OMPVV_HOST_TESTS_TO_COMPILE)
 
 if(OMPVV_USE_OFFLOAD_TESTS)
-  set(OMPVV_OFFLOAD_FOFFLOADING_FLAGS "-fopenmp")
-  foreach(arch IN LISTS DEFAULT_GPU_TARGETS)
-    set(OMPVV_OFFLOAD_FOFFLOADING_FLAGS
-        "${OMPVV_OFFLOAD_FOFFLOADING_FLAGS} --offload-arch=${arch}")
-  endforeach()
-  update_make_def_foffloading("${OMPVV_OFFLOAD_FOFFLOADING_FLAGS}")
-  compile_ompvv_tests(OMPVV_OFFLOAD_TESTS_TO_COMPILE)
+    set(OMPVV_OFFLOAD_FOFFLOADING_FLAGS "-fopenmp")
+    foreach(arch IN LISTS DEFAULT_GPU_TARGETS)
+        set(OMPVV_OFFLOAD_FOFFLOADING_FLAGS
+            "${OMPVV_OFFLOAD_FOFFLOADING_FLAGS} --offload-arch=${arch}"
+        )
+    endforeach()
+    update_make_def_foffloading("${OMPVV_OFFLOAD_FOFFLOADING_FLAGS}")
+    compile_ompvv_tests(OMPVV_OFFLOAD_TESTS_TO_COMPILE)
 endif()
 
 # ---------------------------------------------------------------------------------------#
@@ -184,64 +228,69 @@ set(ROCPROFSYS_OMPVV_OFFLOAD_TESTS "")
 file(GLOB OMPVV_BINARIES "${OMPVV_BIN_SOURCE}/*")
 
 foreach(OMPVV_BIN ${OMPVV_BINARIES})
-  get_filename_component(BIN_NAME ${OMPVV_BIN} NAME_WE)
+    get_filename_component(BIN_NAME ${OMPVV_BIN} NAME_WE)
 
-  # Determine type of test
-  set(IS_HOST_TEST FALSE)
-  set(IS_OFFLOAD_TEST FALSE)
-  foreach(host_test IN LISTS OMPVV_HOST_TESTS_TO_COMPILE)
-    get_filename_component(HOST_TEST_NAME ${host_test} NAME_WE)
-    if(BIN_NAME STREQUAL HOST_TEST_NAME)
-      set(IS_HOST_TEST TRUE)
-      break()
-    endif()
-  endforeach()
-
-  if(NOT IS_HOST_TEST AND OMPVV_USE_OFFLOAD_TESTS)
-    foreach(offload_test IN LISTS OMPVV_OFFLOAD_TESTS_TO_COMPILE)
-      get_filename_component(OFFLOAD_TEST_NAME ${offload_test} NAME_WE)
-      if(BIN_NAME STREQUAL OFFLOAD_TEST_NAME)
-        set(IS_OFFLOAD_TEST TRUE)
-        break()
-      endif()
+    # Determine type of test
+    set(IS_HOST_TEST FALSE)
+    set(IS_OFFLOAD_TEST FALSE)
+    foreach(host_test IN LISTS OMPVV_HOST_TESTS_TO_COMPILE)
+        get_filename_component(HOST_TEST_NAME ${host_test} NAME_WE)
+        if(BIN_NAME STREQUAL HOST_TEST_NAME)
+            set(IS_HOST_TEST TRUE)
+            break()
+        endif()
     endforeach()
-  endif()
 
-  if(NOT IS_HOST_TEST AND NOT IS_OFFLOAD_TEST)
-    continue()
-  endif()
+    if(NOT IS_HOST_TEST AND OMPVV_USE_OFFLOAD_TESTS)
+        foreach(offload_test IN LISTS OMPVV_OFFLOAD_TESTS_TO_COMPILE)
+            get_filename_component(OFFLOAD_TEST_NAME ${offload_test} NAME_WE)
+            if(BIN_NAME STREQUAL OFFLOAD_TEST_NAME)
+                set(IS_OFFLOAD_TEST TRUE)
+                break()
+            endif()
+        endforeach()
+    endif()
 
-  # For consistent naming with other tests
-  string(REGEX REPLACE "\\.F90$" "" NEW_BIN_NAME ${BIN_NAME})
-  string(REPLACE "_" "-" NEW_BIN_NAME ${NEW_BIN_NAME})
+    if(NOT IS_HOST_TEST AND NOT IS_OFFLOAD_TEST)
+        continue()
+    endif()
 
-  file(COPY "${OMPVV_BIN}" DESTINATION "${OMPVV_BIN_DEST}")
+    # For consistent naming with other tests
+    string(REGEX REPLACE "\\.F90$" "" NEW_BIN_NAME ${BIN_NAME})
+    string(REPLACE "_" "-" NEW_BIN_NAME ${NEW_BIN_NAME})
 
-  if(IS_HOST_TEST)
-    set(TARGET_NAME "openmp-vv-host-${NEW_BIN_NAME}")
-    list(APPEND ROCPROFSYS_OMPVV_HOST_TESTS ${TARGET_NAME})
-  elseif(IS_OFFLOAD_TEST)
-    set(TARGET_NAME "openmp-vv-offload-${NEW_BIN_NAME}")
-    list(APPEND ROCPROFSYS_OMPVV_OFFLOAD_TESTS ${TARGET_NAME})
-  endif()
+    file(COPY "${OMPVV_BIN}" DESTINATION "${OMPVV_BIN_DEST}")
 
-  file(RENAME "${OMPVV_BIN_DEST}/${BIN_NAME}.F90.o"
-       "${OMPVV_BIN_DEST}/${TARGET_NAME}")
-  add_executable(${TARGET_NAME} IMPORTED GLOBAL)
-  set_target_properties(
-    ${TARGET_NAME} PROPERTIES IMPORTED_LOCATION
-                              "${OMPVV_BIN_DEST}/${TARGET_NAME}")
+    if(IS_HOST_TEST)
+        set(TARGET_NAME "openmp-vv-host-${NEW_BIN_NAME}")
+        list(APPEND ROCPROFSYS_OMPVV_HOST_TESTS ${TARGET_NAME})
+    elseif(IS_OFFLOAD_TEST)
+        set(TARGET_NAME "openmp-vv-offload-${NEW_BIN_NAME}")
+        list(APPEND ROCPROFSYS_OMPVV_OFFLOAD_TESTS ${TARGET_NAME})
+    endif()
 
+    file(RENAME "${OMPVV_BIN_DEST}/${BIN_NAME}.F90.o" "${OMPVV_BIN_DEST}/${TARGET_NAME}")
+    add_executable(${TARGET_NAME} IMPORTED GLOBAL)
+    set_target_properties(
+        ${TARGET_NAME}
+        PROPERTIES IMPORTED_LOCATION "${OMPVV_BIN_DEST}/${TARGET_NAME}"
+    )
 endforeach()
 
 set(ROCPROFSYS_OMPVV_HOST_TESTS
     "${ROCPROFSYS_OMPVV_HOST_TESTS}"
-    CACHE STRING "Internal variable used to generate OMPVV Host CTests" FORCE)
+    CACHE STRING
+    "Internal variable used to generate OMPVV Host CTests"
+    FORCE
+)
 
 set(ROCPROFSYS_OMPVV_OFFLOAD_TESTS
     "${ROCPROFSYS_OMPVV_OFFLOAD_TESTS}"
-    CACHE STRING "Internal variable used to generate OMPVV Offload CTests"
-          FORCE)
+    CACHE STRING
+    "Internal variable used to generate OMPVV Offload CTests"
+    FORCE
+)
 
 rocprofiler_systems_message(STATUS
-                            "Successfully built and compiled OMPVV tests")
+                            "Successfully built and compiled OMPVV tests"
+)

--- a/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
@@ -2,11 +2,23 @@
 #
 # OMPVV (OpenMP Validation and Verification) submodule
 #
-# * Currently, GNU's libgomp cannot be used to capture traces. Only LLVM's LIBOMP
-#   can be used for trace capture
-# * amdflang uses LIBOMP 201611 (5.0), but not all OpenMP 5.0 features are implemented.
-#   Only a subset of tests can be compiled.
+# * Currently, GNU's libgomp cannot be used to capture traces. Only LLVM's
+#   LIBOMP can be used for trace capture
+# * amdflang uses LIBOMP 201611 (5.0), but not all OpenMP 5.0 features are
+#   implemented. Only a subset of tests can be compiled.
 # ----------------------------------------------------------------------------------------#
+
+set(OMPVV_USE_TARGET_TESTS FALSE)
+if(ROCPROFSYS_DISABLE_EXAMPLES)
+  if("openmp-vv" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
+    return()
+  endif()
+  if(NOT "openmp-vv-target" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
+    set(OMPVV_USE_TARGET_TESTS TRUE)
+  endif()
+else()
+  set(OMPVV_USE_TARGET_TESTS TRUE)
+endif()
 
 rocprofiler_systems_message(STATUS "Configuring OMPVV...")
 
@@ -21,8 +33,52 @@ rocprofiler_systems_checkout_git_submodule(
   REPO_URL
   https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV.git
   REPO_BRANCH
-  "master"
-)
+  "master")
+
+# ---------------------------------------------------------------------------------------#
+# helper functions
+# ---------------------------------------------------------------------------------------#
+
+# Updates the make.def FOFFLOADING flag. First call should remove O3 flags
+function(update_make_def_foffloading FOFFLOADING_FLAGS)
+  file(READ ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def
+       MAKE_DEF_CONTENT)
+
+  # Replaces all FOFFLOADING lines
+  string(
+    REGEX
+    REPLACE "FOFFLOADING[ \t]*=[ \t]*-fopenmp[^\n\r]*"
+            "FOFFLOADING   =  ${FOFFLOADING_FLAGS}" MAKE_DEF_CONTENT
+            "${MAKE_DEF_CONTENT}")
+
+  file(WRITE ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def
+       "${MAKE_DEF_CONTENT}")
+endfunction()
+
+# Individually compiles a given list of tests
+function(compile_ompvv_tests TEST_LIST_VAR)
+  # OMPVV doesn't support building subsets of test folders
+  foreach(test IN LISTS ${TEST_LIST_VAR})
+    rocprofiler_systems_message(STATUS "Compiling OMPVV test: ${test}")
+
+    execute_process(
+      COMMAND
+        make FC=${OMPVV_FC} DEVICE_TYPE=amd OMP_VERSION=${OMPVV_OPENMP_VERSION}
+        NUM_THREADS_HOST=${OMPVV_NUM_THREADS_HOST}
+        NUM_THREADS_DEVICE=${OMPVV_NUM_THREADS_DEVICE}
+        NUM_TEAMS_DEVICE=${OMPVV_NUM_TEAMS_DEVICE} "SOURCES=${test}" compile
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/external/ompvv
+      RESULT_VARIABLE OMPVV_BUILD_RESULT
+      OUTPUT_VARIABLE OMPVV_BUILD_OUTPUT
+      ERROR_VARIABLE OMPVV_BUILD_ERROR
+      OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE)
+
+    if(NOT OMPVV_BUILD_RESULT EQUAL 0)
+      rocprofiler_systems_message(
+        FATAL_ERROR "OMPVV build failed for ${test}: ${OMPVV_BUILD_ERROR}")
+    endif()
+  endforeach()
+endfunction()
 
 # ---------------------------------------------------------------------------------------#
 # compiler
@@ -30,50 +86,36 @@ rocprofiler_systems_checkout_git_submodule(
 
 # OMPVV requires amdclang++
 find_program(
-    amdclangpp_EXECUTABLE
-    NAMES amdclang++
-    HINTS ${ROCM_PATH}
-    ENV ROCM_PATH
-    /opt/rocm
-    PATHS ${ROCM_PATH}
-    ENV ROCM_PATH
-    /opt/rocm
-    PATH_SUFFIXES bin llvm/bin
-)
+  amdclangpp_EXECUTABLE
+  NAMES amdclang++
+  HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+  PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+  PATH_SUFFIXES bin llvm/bin)
 mark_as_advanced(amdclangpp_EXECUTABLE)
 
 if(NOT amdclangpp_EXECUTABLE)
-    rocprofiler_systems_message(
-      FATAL_ERROR
-      "Could not find amdclang++. This is required for the OMPVV tests."
-    )
+  rocprofiler_systems_message(
+    FATAL_ERROR
+    "Could not find amdclang++. This is required for the OMPVV tests.")
 endif()
 
 find_program(
-    amdflang_EXECUTABLE
-    NAMES amdflang
-    HINTS ${ROCM_PATH}
-    ENV ROCM_PATH
-    /opt/rocm
-    PATHS ${ROCM_PATH}
-    ENV ROCM_PATH
-    /opt/rocm
-    PATH_SUFFIXES bin llvm/bin
-)
+  amdflang_EXECUTABLE
+  NAMES amdflang
+  HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+  PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+  PATH_SUFFIXES bin llvm/bin)
 mark_as_advanced(amdflang_EXECUTABLE)
 
 if(NOT amdflang_EXECUTABLE)
-    rocprofiler_systems_message(
-      FATAL_ERROR
-      "Could not find amdflang. This is required for the OMPVV tests."
-    )
+  rocprofiler_systems_message(
+    FATAL_ERROR
+    "Could not find amdflang. This is required for the OMPVV tests.")
 endif()
 
 set(OMPVV_COMPILER
     "${amdflang_EXECUTABLE}"
-    CACHE FILEPATH
-    "Fortran compiler used for OMPVV tests"
-)
+    CACHE FILEPATH "Fortran compiler used for OMPVV tests")
 set(OMPVV_FC "amdflang")
 
 # ---------------------------------------------------------------------------------------#
@@ -81,132 +123,124 @@ set(OMPVV_FC "amdflang")
 # ---------------------------------------------------------------------------------------#
 
 set(OMPVV_OPENMP_VERSION 5.0)
+set(OMPVV_TDIR "tests/${OMPVV_OPENMP_VERSION}")
 set(OMPVV_NUM_THREADS_HOST ${ROCPROFSYS_THREAD_COUNT})
 set(OMPVV_NUM_TEAMS_DEVICE 8) # default used by ompvv
 set(OMPVV_NUM_THREADS_DEVICE 8) # default used by ompvv
 
-# Set the tests to be compiled Tests listed are the ones that compile (excluding
-# reduction tests due to OMPVV test failure) If any tests are added/removed, a
-# complete rebuild is required
-set(OMPVV_TESTS_TO_COMPILE
-    "atomic/test_atomic_acquire_release.F90"
-    # "atomic/test_atomic_hint.F90" "atomic/test_atomic_num_hint_device.F90"
-    # "atomic/test_atomic_num_hint.F90"
-    # "declare_target/test_declare_target_device_type_any.F90"
-    # "declare_target/test_declare_target_device_type_host.F90"
-    # "parallel_for_simd/test_parallel_for_simd_atomic.F90"
-    "requires/test_requires_atomic_default_mem_order_relaxed.F90"
-    # "requires/test_requires_atomic_default_mem_order_acq_rel.F90"
-    # "requires/test_requires_atomic_default_mem_order_seq_cst.F90"
-    # "simd/test_simd_if.F90" "simd/test_simd_nontemporal.F90"
-    # "simd/test_simd_order_concurrent.F90"
-    # "target_simd/test_target_simd_order_concurrent.F90"
-    # "target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_collapse.F90"
-    # "target_teams_distribute_parallel_for_simd/test_target_teams_distribute_parallel_for_simd_atomic.F90"
-    # "task/test_task_detach.F90" "teams/test_team_default_shared.F90"
-    # "teams/test_teams.F90" # Bug due to task_detach callback failure
-)
+# Files listed below are OpenMP 5.0 tests that compile for both amdflang 20.0
+# and 19.0 Set of host only tests to be compiled
+set(OMPVV_HOST_TESTS_TO_COMPILE
+    "${OMPVV_TDIR}/teams/test_team_default_shared.F90"
+    "${OMPVV_TDIR}/parallel_for_simd/test_parallel_for_simd_atomic.F90")
 
-set(OMPVV_SRC_PREFIX "tests/${OMPVV_OPENMP_VERSION}")
-set(OMPVV_SOURCES_LIST "")
-foreach(TEST IN LISTS OMPVV_TESTS_TO_COMPILE)
-    list(APPEND OMPVV_SOURCES_LIST "${OMPVV_SRC_PREFIX}/${TEST}")
-endforeach()
-
-set(OMPVV_FOFFLOADING "-fopenmp")
-foreach(arch IN LISTS DEFAULT_GPU_TARGETS)
-    set(OMPVV_FOFFLOADING "${OMPVV_FOFFLOADING} --offload-arch=${arch}")
-endforeach()
+# Set of offloading tests to be compiled (excluding reduction and simd_atomic
+# tests due to OMPVV test failure)
+set(OMPVV_TARGET_TESTS_TO_COMPILE "")
+if(OMPVV_USE_TARGET_TESTS)
+  set(OMPVV_TARGET_TESTS_TO_COMPILE
+      "${OMPVV_TDIR}/target_simd/test_target_simd_if.F90"
+      "${OMPVV_TDIR}/target_teams_distribute_parallel_for/test_target_teams_distribute_parallel_for_collapse.F90"
+  )
+endif()
 
 # ---------------------------------------------------------------------------------------#
-#
-# modify make.def file
-#
+# compile tests
 # ---------------------------------------------------------------------------------------#
 
-file(READ ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def MAKE_DEF_CONTENT)
-
-# Replace FOFFLOADING
-string(
-    REGEX REPLACE
-    "(ifeq \\(\\$\\(OMPVV_USED_FC\\), amdflang\\).*FOFFLOADING[ ]*=[ ]*)-fopenmp --offload-arch=gfx90a"
-    "\\1${OMPVV_FOFFLOADING}"
-    MAKE_DEF_CONTENT
-    "${MAKE_DEF_CONTENT}"
-)
 # Remove all -O3 flags to prevent function inlining
+file(READ ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def
+     MAKE_DEF_CONTENT)
 string(REGEX REPLACE "-O3[ \t]*" "" MAKE_DEF_CONTENT "${MAKE_DEF_CONTENT}")
+file(WRITE ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def
+     "${MAKE_DEF_CONTENT}")
 
-file(WRITE ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def "${MAKE_DEF_CONTENT}")
+# OMPVV makefile option NO_OFFLOADING not supported for amdflang, must manually
+# do it
+set(OMPVV_HOST_FOFFLOADING_FLAGS "-fopenmp --offload-host-only")
+update_make_def_foffloading("${OMPVV_HOST_FOFFLOADING_FLAGS}")
+compile_ompvv_tests(OMPVV_HOST_TESTS_TO_COMPILE)
 
-# ---------------------------------------------------------------------------------------#
-#
-# build
-#
-# ---------------------------------------------------------------------------------------#
-
-# OMPVV doesn't support building subsets of test folders. Compiling each test individually.
-foreach(test IN LISTS OMPVV_SOURCES_LIST)
-    rocprofiler_systems_message(STATUS "Compiling OMPVV test: ${test}")
-
-    execute_process(
-        COMMAND
-            make FC=${OMPVV_FC} DEVICE_TYPE=amd OMP_VERSION=${OMPVV_OPENMP_VERSION}
-            NUM_THREADS_HOST=${OMPVV_NUM_THREADS_HOST}
-            NUM_THREADS_DEVICE=${OMPVV_NUM_THREADS_DEVICE}
-            NUM_TEAMS_DEVICE=${OMPVV_NUM_TEAMS_DEVICE} "SOURCES=${test}" compile
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/external/ompvv
-        RESULT_VARIABLE OMPVV_BUILD_RESULT
-        OUTPUT_VARIABLE OMPVV_BUILD_OUTPUT
-        ERROR_VARIABLE OMPVV_BUILD_ERROR
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_STRIP_TRAILING_WHITESPACE
-    )
-
-    if(NOT OMPVV_BUILD_RESULT EQUAL 0)
-        rocprofiler_systems_message(
-          FATAL_ERROR "OMPVV build failed for ${test}: ${OMPVV_BUILD_ERROR}"
-        )
-    endif()
-endforeach()
+if(OMPVV_USE_TARGET_TESTS)
+  set(OMPVV_TARGET_FOFFLOADING_FLAGS "-fopenmp")
+  foreach(arch IN LISTS DEFAULT_GPU_TARGETS)
+    set(OMPVV_TARGET_FOFFLOADING_FLAGS
+        "${OMPVV_TARGET_FOFFLOADING_FLAGS} --offload-arch=${arch}")
+  endforeach()
+  update_make_def_foffloading("${OMPVV_TARGET_FOFFLOADING_FLAGS}")
+  compile_ompvv_tests(OMPVV_TARGET_TESTS_TO_COMPILE)
+endif()
 
 # ---------------------------------------------------------------------------------------#
-#
 # copy generated binaries to build folder for tests
-#
 # ---------------------------------------------------------------------------------------#
 
 set(OMPVV_BIN_SOURCE "${PROJECT_SOURCE_DIR}/external/ompvv/bin")
 set(OMPVV_BIN_DEST "${CMAKE_BINARY_DIR}")
-set(OMPVV_TESTS "")
 
-file(GLOB OMPVV_BIN_FILES "${OMPVV_BIN_SOURCE}/*")
+set(ROCPROFSYS_OMPVV_HOST_TESTS "")
+set(ROCPROFSYS_OMPVV_TARGET_TESTS "")
 
-# Create imported executable - required for rocprofiler_systems_add_test
-foreach(OMPVV_BIN_FILE ${OMPVV_BIN_FILES})
-    get_filename_component(FILENAME ${OMPVV_BIN_FILE} NAME)
+file(GLOB OMPVV_BINARIES "${OMPVV_BIN_SOURCE}/*")
 
-    # For consistent naming with other tests
-    string(REGEX REPLACE "\\.F90\\.o$" "" BIN_NAME ${FILENAME})
-    string(REPLACE "_" "-" BIN_NAME ${BIN_NAME})
-    file(COPY "${OMPVV_BIN_FILE}" DESTINATION "${OMPVV_BIN_DEST}")
-    file(RENAME "${OMPVV_BIN_DEST}/${FILENAME}" "${OMPVV_BIN_DEST}/openmp-vv-${BIN_NAME}")
+foreach(OMPVV_BIN ${OMPVV_BINARIES})
+  get_filename_component(BIN_NAME ${OMPVV_BIN} NAME_WE)
 
-    set(TARGET_NAME "openmp-vv-${BIN_NAME}")
-    add_executable(${TARGET_NAME} IMPORTED GLOBAL)
-    set_target_properties(
-        ${TARGET_NAME}
-        PROPERTIES IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/openmp-vv-${BIN_NAME}"
-    )
+  # Determine type of test
+  set(IS_HOST_TEST FALSE)
+  set(IS_TARGET_TEST FALSE)
+  foreach(host_test IN LISTS OMPVV_HOST_TESTS_TO_COMPILE)
+    get_filename_component(HOST_TEST_NAME ${host_test} NAME_WE)
+    if(BIN_NAME STREQUAL HOST_TEST_NAME)
+      set(IS_HOST_TEST TRUE)
+      break()
+    endif()
+  endforeach()
 
-    list(APPEND OMPVV_TESTS ${BIN_NAME})
+  if(NOT IS_HOST_TEST AND OMPVV_USE_TARGET_TESTS)
+    foreach(target_test IN LISTS OMPVV_TARGET_TESTS_TO_COMPILE)
+      get_filename_component(TARGET_TEST_NAME ${target_test} NAME_WE)
+      if(BIN_NAME STREQUAL TARGET_TEST_NAME)
+        set(IS_TARGET_TEST TRUE)
+        break()
+      endif()
+    endforeach()
+  endif()
+
+  if(NOT IS_HOST_TEST AND NOT IS_TARGET_TEST)
+    continue()
+  endif()
+
+  # For consistent naming with other tests
+  string(REGEX REPLACE "\\.F90$" "" NEW_BIN_NAME ${BIN_NAME})
+  string(REPLACE "_" "-" NEW_BIN_NAME ${NEW_BIN_NAME})
+
+  file(COPY "${OMPVV_BIN}" DESTINATION "${OMPVV_BIN_DEST}")
+
+  if(IS_HOST_TEST)
+    set(TARGET_NAME "openmp-vv-host-${NEW_BIN_NAME}")
+    list(APPEND ROCPROFSYS_OMPVV_HOST_TESTS ${TARGET_NAME})
+  elseif(IS_TARGET_TEST)
+    set(TARGET_NAME "openmp-vv-target-${NEW_BIN_NAME}")
+    list(APPEND ROCPROFSYS_OMPVV_TARGET_TESTS ${TARGET_NAME})
+  endif()
+
+  file(RENAME "${OMPVV_BIN_DEST}/${BIN_NAME}.F90.o"
+       "${OMPVV_BIN_DEST}/${TARGET_NAME}")
+  add_executable(${TARGET_NAME} IMPORTED GLOBAL)
+  set_target_properties(
+    ${TARGET_NAME} PROPERTIES IMPORTED_LOCATION
+                              "${OMPVV_BIN_DEST}/${TARGET_NAME}")
+
 endforeach()
 
-set(OMPVV_TESTS
-    "${OMPVV_TESTS}"
-    CACHE STRING
-    "Internal variable used to generate OMPVV CTests"
-    FORCE
-)
+set(ROCPROFSYS_OMPVV_HOST_TESTS
+    "${ROCPROFSYS_OMPVV_HOST_TESTS}"
+    CACHE STRING "Internal variable used to generate OMPVV Host CTests" FORCE)
 
-rocprofiler_systems_message(STATUS "Successfully built and compiled OMPVV tests")
+set(ROCPROFSYS_OMPVV_TARGET_TESTS
+    "${ROCPROFSYS_OMPVV_TARGET_TESTS}"
+    CACHE STRING "Internal variable used to generate OMPVV Target CTests" FORCE)
+
+rocprofiler_systems_message(STATUS
+                            "Successfully built and compiled OMPVV tests")

--- a/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
@@ -42,8 +42,6 @@ else()
     set(OMPVV_USE_OFFLOAD_TESTS TRUE)
 endif()
 
-rocprofiler_systems_message(STATUS "Configuring OMPVV...")
-
 # Master branch contains stable releases
 rocprofiler_systems_checkout_git_submodule(
   RELATIVE_PATH
@@ -58,13 +56,17 @@ rocprofiler_systems_checkout_git_submodule(
   "master"
 )
 
+set(ROCPROFSYS_OMPVV_SUBMODULE_DIR "${PROJECT_SOURCE_DIR}/external/ompvv")
+set(ROCPROFSYS_OMPVV_SOURCE_DIR "${CMAKE_BINARY_DIR}/examples/openmp/external/ompvv")
+set(OMPVV_MAKEDEF_FILE "sys/make/make.def")
+
 # ---------------------------------------------------------------------------------------#
 # helper functions
 # ---------------------------------------------------------------------------------------#
 
-# Updates the make.def FOFFLOADING flag. First call should remove O3 flags
+# Updates the make.def FOFFLOADING flag.
 function(update_make_def_foffloading FOFFLOADING_FLAGS)
-    file(READ ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def MAKE_DEF_CONTENT)
+    file(READ ${ROCPROFSYS_OMPVV_SOURCE_DIR}/${OMPVV_MAKEDEF_FILE} MAKE_DEF_CONTENT)
 
     # Replaces all FOFFLOADING lines
     string(
@@ -75,11 +77,7 @@ function(update_make_def_foffloading FOFFLOADING_FLAGS)
         "${MAKE_DEF_CONTENT}"
     )
 
-    file(
-        WRITE
-        ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def
-        "${MAKE_DEF_CONTENT}"
-    )
+    file(WRITE ${ROCPROFSYS_OMPVV_SOURCE_DIR}/${OMPVV_MAKEDEF_FILE} "${MAKE_DEF_CONTENT}")
 endfunction()
 
 # Individually compiles a given list of tests
@@ -94,7 +92,7 @@ function(compile_ompvv_tests TEST_LIST_VAR)
                 NUM_THREADS_HOST=${OMPVV_NUM_THREADS_HOST}
                 NUM_THREADS_DEVICE=${OMPVV_NUM_THREADS_DEVICE}
                 NUM_TEAMS_DEVICE=${OMPVV_NUM_TEAMS_DEVICE} "SOURCES=${test}" compile
-            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/external/ompvv
+            WORKING_DIRECTORY ${ROCPROFSYS_OMPVV_SOURCE_DIR}
             RESULT_VARIABLE OMPVV_BUILD_RESULT
             OUTPUT_VARIABLE OMPVV_BUILD_OUTPUT
             ERROR_VARIABLE OMPVV_BUILD_ERROR
@@ -109,6 +107,18 @@ function(compile_ompvv_tests TEST_LIST_VAR)
         endif()
     endforeach()
 endfunction()
+
+# ---------------------------------------------------------------------------------------#
+# Copy OMPVV to build folder
+# ---------------------------------------------------------------------------------------#
+
+if(NOT EXISTS "${ROCPROFSYS_OMPVV_SOURCE_DIR}")
+    execute_process(
+        COMMAND
+            ${CMAKE_COMMAND} -E copy_directory ${ROCPROFSYS_OMPVV_SUBMODULE_DIR}
+            ${ROCPROFSYS_OMPVV_SOURCE_DIR}
+    )
+endif()
 
 # ---------------------------------------------------------------------------------------#
 # compiler
@@ -172,8 +182,9 @@ set(OMPVV_NUM_THREADS_HOST ${ROCPROFSYS_THREAD_COUNT})
 set(OMPVV_NUM_TEAMS_DEVICE 8) # default used by ompvv
 set(OMPVV_NUM_THREADS_DEVICE 8) # default used by ompvv
 
-# Files listed below are OpenMP 5.0 tests that compile for both amdflang 20.0
-# and 19.0 Set of host only tests to be compiled
+# Files listed below are OpenMP 5.0 tests that compile for
+# both amdflang 20.0 and 19.0.
+# Set of host only tests to be compiled
 set(OMPVV_HOST_TESTS_TO_COMPILE
     "${OMPVV_TDIR}/teams/test_team_default_shared.F90"
     "${OMPVV_TDIR}/parallel_for_simd/test_parallel_for_simd_atomic.F90"
@@ -194,12 +205,12 @@ endif()
 # ---------------------------------------------------------------------------------------#
 
 # Remove all -O3 flags to prevent function inlining
-file(READ ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def MAKE_DEF_CONTENT)
+file(READ ${ROCPROFSYS_OMPVV_SOURCE_DIR}/${OMPVV_MAKEDEF_FILE} MAKE_DEF_CONTENT)
 string(REGEX REPLACE "-O3[ \t]*" "" MAKE_DEF_CONTENT "${MAKE_DEF_CONTENT}")
-file(WRITE ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def "${MAKE_DEF_CONTENT}")
+file(WRITE ${ROCPROFSYS_OMPVV_SOURCE_DIR}/${OMPVV_MAKEDEF_FILE} "${MAKE_DEF_CONTENT}")
 
-# OMPVV makefile option NO_OFFLOADING not supported for amdflang, must manually
-# do it
+# OMPVV makefile option NO_OFFLOADING not supported for amdflang,
+# must manually do it
 set(OMPVV_HOST_FOFFLOADING_FLAGS "-fopenmp --offload-host-only")
 update_make_def_foffloading("${OMPVV_HOST_FOFFLOADING_FLAGS}")
 compile_ompvv_tests(OMPVV_HOST_TESTS_TO_COMPILE)
@@ -216,10 +227,10 @@ if(OMPVV_USE_OFFLOAD_TESTS)
 endif()
 
 # ---------------------------------------------------------------------------------------#
-# copy generated binaries to build folder for tests
+# copy generated binaries to top level of build folder
 # ---------------------------------------------------------------------------------------#
 
-set(OMPVV_BIN_SOURCE "${PROJECT_SOURCE_DIR}/external/ompvv/bin")
+set(OMPVV_BIN_SOURCE "${ROCPROFSYS_OMPVV_SOURCE_DIR}/bin")
 set(OMPVV_BIN_DEST "${CMAKE_BINARY_DIR}")
 
 set(ROCPROFSYS_OMPVV_HOST_TESTS "")

--- a/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
@@ -1,24 +1,5 @@
-# MIT License
-#
-# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
 
 # ----------------------------------------------------------------------------------------#
 #

--- a/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
@@ -184,10 +184,6 @@ if(NOT AMDFLANG_FULL_VERSION)
     rocprofiler_systems_message(FATAL_ERROR "Failed to detect amdflang version.")
 endif()
 
-if(AMDFLANG_VERSION_MAJOR LESS 19)
-    rocprofiler_systems_message(FATAL_ERROR "OMPVV tests require amdflang version 19.0.0 or above. Current: ${AMDFLANG_FULL_VERSION}")
-endif()
-
 # ---------------------------------------------------------------------------------------#
 # Variables
 # ---------------------------------------------------------------------------------------#
@@ -199,7 +195,7 @@ set(OMPVV_NUM_TEAMS_DEVICE 8) # default used by ompvv
 set(OMPVV_NUM_THREADS_DEVICE 8) # default used by ompvv
 
 # Files listed below are OpenMP 5.0 tests that compile for
-# both amdflang 20.0 and 19.0.
+# amdflang 20.0, 19.0 and 18.0.
 # Set of host only tests to be compiled
 set(OMPVV_HOST_TESTS_TO_COMPILE
     "${OMPVV_TDIR}/teams/test_team_default_shared.F90"

--- a/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
@@ -23,6 +23,8 @@ else()
     set(OMPVV_USE_OFFLOAD_TESTS TRUE)
 endif()
 
+rocprofiler_systems_message(STATUS "Configuring OMPVV...")
+
 # Master branch contains stable releases
 rocprofiler_systems_checkout_git_submodule(
   RELATIVE_PATH
@@ -42,14 +44,13 @@ set(ROCPROFSYS_OMPVV_SOURCE_DIR "${CMAKE_BINARY_DIR}/examples/openmp/external/om
 set(OMPVV_MAKEDEF_FILE "sys/make/make.def")
 
 # ---------------------------------------------------------------------------------------#
-# helper functions
+# Helper functions
 # ---------------------------------------------------------------------------------------#
 
-# Updates the make.def FOFFLOADING flag.
+# Updates the make.def FOFFLOADING flag
 function(update_make_def_foffloading FOFFLOADING_FLAGS)
     file(READ ${ROCPROFSYS_OMPVV_SOURCE_DIR}/${OMPVV_MAKEDEF_FILE} MAKE_DEF_CONTENT)
 
-    # Replaces all FOFFLOADING lines
     string(
         REGEX REPLACE
         "FOFFLOADING[ \t]*=[ \t]*-fopenmp[^\n\r]*"
@@ -102,7 +103,7 @@ if(NOT EXISTS "${ROCPROFSYS_OMPVV_SOURCE_DIR}")
 endif()
 
 # ---------------------------------------------------------------------------------------#
-# compiler
+# Compiler setup
 # ---------------------------------------------------------------------------------------#
 
 # OMPVV requires amdclang++
@@ -153,8 +154,42 @@ set(OMPVV_COMPILER
 )
 set(OMPVV_FC "amdflang")
 
+execute_process(
+    COMMAND ${amdflang_EXECUTABLE} --version
+    OUTPUT_VARIABLE AMDFLANG_VERSION_CMD_OUTPUT
+    RESULT_VARIABLE AMDFLANG_VERSION_CMD_RESULT
+)
+
+set(AMDFLANG_FULL_VERSION "")
+
+if(AMDFLANG_VERSION_CMD_RESULT EQUAL 0)
+    string(
+        REGEX MATCH
+        "version ([0-9]+)\\.([0-9]+)\\.([0-9]+)"
+        VERSION_MATCH
+        "${AMDFLANG_VERSION_CMD_OUTPUT}"
+    )
+    if(VERSION_MATCH)
+        set(AMDFLANG_VERSION_MAJOR "${CMAKE_MATCH_1}")
+        set(AMDFLANG_VERSION_MINOR "${CMAKE_MATCH_2}")
+        set(AMDFLANG_VERSION_PATCH "${CMAKE_MATCH_3}")
+        set(AMDFLANG_FULL_VERSION
+            "${AMDFLANG_VERSION_MAJOR}.${AMDFLANG_VERSION_MINOR}.${AMDFLANG_VERSION_PATCH}"
+        )
+        rocprofiler_systems_message(STATUS "Detected amdflang version: ${AMDFLANG_FULL_VERSION}")
+    endif()
+endif()
+
+if(NOT AMDFLANG_FULL_VERSION)
+    rocprofiler_systems_message(FATAL_ERROR "Failed to detect amdflang version.")
+endif()
+
+if(AMDFLANG_VERSION_MAJOR LESS 19)
+    rocprofiler_systems_message(FATAL_ERROR "OMPVV tests require amdflang version 19.0.0 or above. Current: ${AMDFLANG_FULL_VERSION}")
+endif()
+
 # ---------------------------------------------------------------------------------------#
-# variables
+# Variables
 # ---------------------------------------------------------------------------------------#
 
 set(OMPVV_OPENMP_VERSION 5.0)
@@ -181,8 +216,14 @@ if(OMPVV_USE_OFFLOAD_TESTS)
     )
 endif()
 
+# if(AMDFLANG_VERSION_MAJOR EQUAL 20)
+#     list(APPEND OMPVV_HOST_TESTS_TO_COMPILE
+#         "${OMPVV_TDIR}/task/test_task_detach.F90"
+#     )
+# endif()
+
 # ---------------------------------------------------------------------------------------#
-# compile tests
+# Compile tests
 # ---------------------------------------------------------------------------------------#
 
 # Remove all -O3 flags to prevent function inlining
@@ -208,7 +249,7 @@ if(OMPVV_USE_OFFLOAD_TESTS)
 endif()
 
 # ---------------------------------------------------------------------------------------#
-# copy generated binaries to top level of build folder
+# Copy generated binaries to top level of build folder
 # ---------------------------------------------------------------------------------------#
 
 set(OMPVV_BIN_SOURCE "${ROCPROFSYS_OMPVV_SOURCE_DIR}/bin")

--- a/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
@@ -56,6 +56,11 @@ if(NOT amdflang_EXECUTABLE)
     "Could not find amdflang. This is required for the OMPVV tests.")
 endif()
 
+set(OMPVV_COMPILER
+    "${amdflang_EXECUTABLE}"
+    CACHE FILEPATH "Fortran compiler used for OMPVV tests")
+set(OMPVV_FC "amdflang")
+
 # ---------------------------------------------------------------------------------------#
 # Variables
 # ---------------------------------------------------------------------------------------#

--- a/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
@@ -2,9 +2,9 @@
 #
 # OMPVV (OpenMP Validation and Verification) submodule
 #
-# * Currently, GNU's libgomp cannot be used to capture traces Only LLVM's LIBOMP
-#   can be used
-# * amdflang uses LIBOMP 201611 (5.0), but not all features are implemented.
+# * Currently, GNU's libgomp cannot be used to capture traces. Only LLVM's LIBOMP
+#   can be used for trace capture
+# * amdflang uses LIBOMP 201611 (5.0), but not all OpenMP 5.0 features are implemented.
 #   Only a subset of tests can be compiled.
 # ----------------------------------------------------------------------------------------#
 
@@ -21,48 +21,63 @@ rocprofiler_systems_checkout_git_submodule(
   REPO_URL
   https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV.git
   REPO_BRANCH
-  "master")
+  "master"
+)
 
 # ---------------------------------------------------------------------------------------#
-# Compiler
+# compiler
 # ---------------------------------------------------------------------------------------#
 
 # OMPVV requires amdclang++
 find_program(
-  amdclangpp_EXECUTABLE
-  NAMES amdclang++
-  HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
-  PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
-  PATH_SUFFIXES bin llvm/bin)
+    amdclangpp_EXECUTABLE
+    NAMES amdclang++
+    HINTS ${ROCM_PATH}
+    ENV ROCM_PATH
+    /opt/rocm
+    PATHS ${ROCM_PATH}
+    ENV ROCM_PATH
+    /opt/rocm
+    PATH_SUFFIXES bin llvm/bin
+)
 mark_as_advanced(amdclangpp_EXECUTABLE)
 
 if(NOT amdclangpp_EXECUTABLE)
-  rocprofiler_systems_message(
-    FATAL_ERROR
-    "Could not find amdclang++. This is required for the OMPVV tests.")
+    rocprofiler_systems_message(
+      FATAL_ERROR
+      "Could not find amdclang++. This is required for the OMPVV tests."
+    )
 endif()
 
 find_program(
-  amdflang_EXECUTABLE
-  NAMES amdflang
-  HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
-  PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
-  PATH_SUFFIXES bin llvm/bin)
+    amdflang_EXECUTABLE
+    NAMES amdflang
+    HINTS ${ROCM_PATH}
+    ENV ROCM_PATH
+    /opt/rocm
+    PATHS ${ROCM_PATH}
+    ENV ROCM_PATH
+    /opt/rocm
+    PATH_SUFFIXES bin llvm/bin
+)
 mark_as_advanced(amdflang_EXECUTABLE)
 
 if(NOT amdflang_EXECUTABLE)
-  rocprofiler_systems_message(
-    FATAL_ERROR
-    "Could not find amdflang. This is required for the OMPVV tests.")
+    rocprofiler_systems_message(
+      FATAL_ERROR
+      "Could not find amdflang. This is required for the OMPVV tests."
+    )
 endif()
 
 set(OMPVV_COMPILER
     "${amdflang_EXECUTABLE}"
-    CACHE FILEPATH "Fortran compiler used for OMPVV tests")
+    CACHE FILEPATH
+    "Fortran compiler used for OMPVV tests"
+)
 set(OMPVV_FC "amdflang")
 
 # ---------------------------------------------------------------------------------------#
-# Variables
+# variables
 # ---------------------------------------------------------------------------------------#
 
 set(OMPVV_OPENMP_VERSION 5.0)
@@ -71,7 +86,7 @@ set(OMPVV_NUM_TEAMS_DEVICE 8) # default used by ompvv
 set(OMPVV_NUM_THREADS_DEVICE 8) # default used by ompvv
 
 # Set the tests to be compiled Tests listed are the ones that compile (excluding
-# reduction due to OMPVV test failure) If any tests are added/removed, a
+# reduction tests due to OMPVV test failure) If any tests are added/removed, a
 # complete rebuild is required
 set(OMPVV_TESTS_TO_COMPILE
     "atomic/test_atomic_acquire_release.F90"
@@ -95,12 +110,12 @@ set(OMPVV_TESTS_TO_COMPILE
 set(OMPVV_SRC_PREFIX "tests/${OMPVV_OPENMP_VERSION}")
 set(OMPVV_SOURCES_LIST "")
 foreach(TEST IN LISTS OMPVV_TESTS_TO_COMPILE)
-  list(APPEND OMPVV_SOURCES_LIST "${OMPVV_SRC_PREFIX}/${TEST}")
+    list(APPEND OMPVV_SOURCES_LIST "${OMPVV_SRC_PREFIX}/${TEST}")
 endforeach()
 
 set(OMPVV_FOFFLOADING "-fopenmp")
 foreach(arch IN LISTS DEFAULT_GPU_TARGETS)
-  set(OMPVV_FOFFLOADING "${OMPVV_FOFFLOADING} --offload-arch=${arch}")
+    set(OMPVV_FOFFLOADING "${OMPVV_FOFFLOADING} --offload-arch=${arch}")
 endforeach()
 
 # ---------------------------------------------------------------------------------------#
@@ -109,22 +124,20 @@ endforeach()
 #
 # ---------------------------------------------------------------------------------------#
 
-file(READ ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def
-     MAKE_DEF_CONTENT)
+file(READ ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def MAKE_DEF_CONTENT)
 
 # Replace FOFFLOADING
 string(
-  REGEX
-  REPLACE
+    REGEX REPLACE
     "(ifeq \\(\\$\\(OMPVV_USED_FC\\), amdflang\\).*FOFFLOADING[ ]*=[ ]*)-fopenmp --offload-arch=gfx90a"
     "\\1${OMPVV_FOFFLOADING}"
     MAKE_DEF_CONTENT
-    "${MAKE_DEF_CONTENT}")
+    "${MAKE_DEF_CONTENT}"
+)
 # Remove all -O3 flags to prevent function inlining
 string(REGEX REPLACE "-O3[ \t]*" "" MAKE_DEF_CONTENT "${MAKE_DEF_CONTENT}")
 
-file(WRITE ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def
-     "${MAKE_DEF_CONTENT}")
+file(WRITE ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def "${MAKE_DEF_CONTENT}")
 
 # ---------------------------------------------------------------------------------------#
 #
@@ -132,32 +145,34 @@ file(WRITE ${PROJECT_SOURCE_DIR}/external/ompvv/sys/make/make.def
 #
 # ---------------------------------------------------------------------------------------#
 
-# OMPVV doesn't support building subsets of a test folder. Compile each test
-# individually
+# OMPVV doesn't support building subsets of test folders. Compiling each test individually.
 foreach(test IN LISTS OMPVV_SOURCES_LIST)
-  rocprofiler_systems_message(STATUS "Compiling OMPVV test: ${test}")
+    rocprofiler_systems_message(STATUS "Compiling OMPVV test: ${test}")
 
-  execute_process(
-    COMMAND
-      make FC=${OMPVV_FC} DEVICE_TYPE=amd OMP_VERSION=${OMPVV_OPENMP_VERSION}
-      NUM_THREADS_HOST=${OMPVV_NUM_THREADS_HOST}
-      NUM_THREADS_DEVICE=${OMPVV_NUM_THREADS_DEVICE}
-      NUM_TEAMS_DEVICE=${OMPVV_NUM_TEAMS_DEVICE} "SOURCES=${test}" compile
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/external/ompvv
-    RESULT_VARIABLE OMPVV_BUILD_RESULT
-    OUTPUT_VARIABLE OMPVV_BUILD_OUTPUT
-    ERROR_VARIABLE OMPVV_BUILD_ERROR
-    OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE)
+    execute_process(
+        COMMAND
+            make FC=${OMPVV_FC} DEVICE_TYPE=amd OMP_VERSION=${OMPVV_OPENMP_VERSION}
+            NUM_THREADS_HOST=${OMPVV_NUM_THREADS_HOST}
+            NUM_THREADS_DEVICE=${OMPVV_NUM_THREADS_DEVICE}
+            NUM_TEAMS_DEVICE=${OMPVV_NUM_TEAMS_DEVICE} "SOURCES=${test}" compile
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/external/ompvv
+        RESULT_VARIABLE OMPVV_BUILD_RESULT
+        OUTPUT_VARIABLE OMPVV_BUILD_OUTPUT
+        ERROR_VARIABLE OMPVV_BUILD_ERROR
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_STRIP_TRAILING_WHITESPACE
+    )
 
-  if(NOT OMPVV_BUILD_RESULT EQUAL 0)
-    rocprofiler_systems_message(
-      FATAL_ERROR "OMPVV build failed for ${test}: ${OMPVV_BUILD_ERROR}")
-  endif()
+    if(NOT OMPVV_BUILD_RESULT EQUAL 0)
+        rocprofiler_systems_message(
+          FATAL_ERROR "OMPVV build failed for ${test}: ${OMPVV_BUILD_ERROR}"
+        )
+    endif()
 endforeach()
 
 # ---------------------------------------------------------------------------------------#
 #
-# copy over generated binaries to build folder for tests
+# copy generated binaries to build folder for tests
 #
 # ---------------------------------------------------------------------------------------#
 
@@ -169,26 +184,29 @@ file(GLOB OMPVV_BIN_FILES "${OMPVV_BIN_SOURCE}/*")
 
 # Create imported executable - required for rocprofiler_systems_add_test
 foreach(OMPVV_BIN_FILE ${OMPVV_BIN_FILES})
-  get_filename_component(FILENAME ${OMPVV_BIN_FILE} NAME)
+    get_filename_component(FILENAME ${OMPVV_BIN_FILE} NAME)
 
-  # For consistent naming with other tests
-  string(REGEX REPLACE "\\.F90\\.o$" "" BIN_NAME ${FILENAME})
-  string(REPLACE "_" "-" BIN_NAME ${BIN_NAME})
-  file(COPY "${OMPVV_BIN_FILE}" DESTINATION "${OMPVV_BIN_DEST}")
-  file(RENAME "${OMPVV_BIN_DEST}/${FILENAME}"
-       "${OMPVV_BIN_DEST}/openmp-vv-${BIN_NAME}")
+    # For consistent naming with other tests
+    string(REGEX REPLACE "\\.F90\\.o$" "" BIN_NAME ${FILENAME})
+    string(REPLACE "_" "-" BIN_NAME ${BIN_NAME})
+    file(COPY "${OMPVV_BIN_FILE}" DESTINATION "${OMPVV_BIN_DEST}")
+    file(RENAME "${OMPVV_BIN_DEST}/${FILENAME}" "${OMPVV_BIN_DEST}/openmp-vv-${BIN_NAME}")
 
-  set(TARGET_NAME "openmp-vv-${BIN_NAME}")
-  add_executable(${TARGET_NAME} IMPORTED GLOBAL)
-  set_target_properties(
-    ${TARGET_NAME} PROPERTIES IMPORTED_LOCATION
-                              "${CMAKE_BINARY_DIR}/openmp-vv-${BIN_NAME}")
+    set(TARGET_NAME "openmp-vv-${BIN_NAME}")
+    add_executable(${TARGET_NAME} IMPORTED GLOBAL)
+    set_target_properties(
+        ${TARGET_NAME}
+        PROPERTIES IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/openmp-vv-${BIN_NAME}"
+    )
 
-  list(APPEND OMPVV_TESTS ${BIN_NAME})
+    list(APPEND OMPVV_TESTS ${BIN_NAME})
 endforeach()
 
 set(OMPVV_TESTS
     "${OMPVV_TESTS}"
-    CACHE STRING "Internal variable used to generate OMPVV CTests" FORCE)
+    CACHE STRING
+    "Internal variable used to generate OMPVV CTests"
+    FORCE
+)
 
-rocprofiler_systems_message(STATUS "Succesfully built and compiled OMPVV tests")
+rocprofiler_systems_message(STATUS "Successfully built and compiled OMPVV tests")

--- a/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
@@ -30,24 +30,6 @@ project(rocprofiler-systems-example-openmp-target-lib LANGUAGES CXX)
 
 set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 
-set(DEFAULT_GPU_TARGETS
-    "gfx900"
-    "gfx906"
-    "gfx908"
-    "gfx90a"
-    "gfx940"
-    "gfx941"
-    "gfx942"
-    "gfx950"
-    "gfx1030"
-    "gfx1010"
-    "gfx1100"
-    "gfx1101"
-    "gfx1102"
-)
-
-set(GPU_TARGETS "${DEFAULT_GPU_TARGETS}" CACHE STRING "GPU targets to compile for")
-
 find_package(Threads REQUIRED)
 
 function(add_offload_flags tgt)

--- a/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright Advanced Micro Devices, Inc.
+# Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)

--- a/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 if(NOT OMP_TARGET_COMPILER)

--- a/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
@@ -117,7 +117,7 @@ if(ROCPROFSYS_OMPVV_HOST_TESTS)
     endforeach()
 
     set(_ompvv_offload_environment
-        "${ompt_environment}"
+        "${_ompt_environment}"
         "${_rocm_ld_env}"
         "ROCPROFSYS_USE_SAMPLING=ON"
         "ROCPROFSYS_SAMPLING_FREQ=50"

--- a/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
@@ -117,6 +117,21 @@ rocprofiler_systems_add_validation_test(
          -p
 )
 
+# OpenMP tests generated using OMPVV binaries
+if(OMPVV_TESTS)
+    foreach(TEST_NAME ${OMPVV_TESTS})
+        rocprofiler_systems_add_test(
+            SKIP_RUNTIME
+            NAME openmp-vv-${TEST_NAME}
+            TARGET openmp-vv-${TEST_NAME}
+            GPU ON
+            LABELS "openmp"
+            ENVIRONMENT
+                "${_ompt_environment};${_rocm_ld_env};ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,kernel_dispatch,memory_copy,scratch_memory,hsa_api"
+        )
+    endforeach()
+endif()
+
 set(_ompt_sampling_environ
     "${_ompt_environment}"
     "ROCPROFSYS_VERBOSE=2"

--- a/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
@@ -20,13 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# --------------------------------------------------------------------------------------
-# #
+# ----------------------------------------------------------------------------- #
 #
 # openmp tests
 #
-# --------------------------------------------------------------------------------------
-# #
+# ----------------------------------------------------------------------------- #
 
 if(ROCmVersion_DIR)
     set(_rocm_root "${ROCmVersion_DIR}")
@@ -61,149 +59,79 @@ else()
 endif()
 
 rocprofiler_systems_add_test(
-  NAME
-  openmp-cg
-  TARGET
-  openmp-cg
-  LABELS
-  "openmp"
-  REWRITE_ARGS
-  -e
-  -v
-  2
-  --instrument-loops
-  RUNTIME_ARGS
-  -e
-  -v
-  1
-  --label
-  return
-  args
-  REWRITE_TIMEOUT
-  180
-  RUNTIME_TIMEOUT
-  360
-  ENVIRONMENT
-  "${_ompt_environment};ROCPROFSYS_USE_SAMPLING=OFF;ROCPROFSYS_COUT_OUTPUT=ON"
-  REWRITE_RUN_PASS_REGEX
-  "${_OMPT_PASS_REGEX}"
-  RUNTIME_PASS_REGEX
-  "${_OMPT_PASS_REGEX}"
-  REWRITE_FAIL_REGEX
-  "0 instrumented loops in procedure"
+    NAME openmp-cg
+    TARGET openmp-cg
+    LABELS "openmp"
+    REWRITE_ARGS -e -v 2 --instrument-loops
+    RUNTIME_ARGS -e -v 1 --label return args
+    REWRITE_TIMEOUT 180
+    RUNTIME_TIMEOUT 360
+    ENVIRONMENT
+      "${_ompt_environment};ROCPROFSYS_USE_SAMPLING=OFF;ROCPROFSYS_COUT_OUTPUT=ON"
+    REWRITE_RUN_PASS_REGEX "${_OMPT_PASS_REGEX}"
+    RUNTIME_PASS_REGEX "${_OMPT_PASS_REGEX}"
+    REWRITE_FAIL_REGEX "0 instrumented loops in procedure"
 )
 
 rocprofiler_systems_add_test(
-  SKIP_RUNTIME
-  NAME
-  openmp-lu
-  TARGET
-  openmp-lu
-  LABELS
-  "openmp"
-  REWRITE_ARGS
-  -e
-  -v
-  2
-  --instrument-loops
-  RUNTIME_ARGS
-  -e
-  -v
-  1
-  --label
-  return
-  args
-  -E
-  ^GOMP
-  REWRITE_TIMEOUT
-  180
-  RUNTIME_TIMEOUT
-  360
-  ENVIRONMENT
-  "${_ompt_environment};ROCPROFSYS_USE_SAMPLING=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_COUT_OUTPUT=ON"
-  REWRITE_RUN_PASS_REGEX
-  "${_OMPT_PASS_REGEX}"
-  REWRITE_FAIL_REGEX
-  "0 instrumented loops in procedure"
+    SKIP_RUNTIME
+    NAME openmp-lu
+    TARGET openmp-lu
+    LABELS "openmp"
+    REWRITE_ARGS -e -v 2 --instrument-loops
+    RUNTIME_ARGS -e -v 1 --label return args -E ^GOMP
+    REWRITE_TIMEOUT 180
+    RUNTIME_TIMEOUT 360
+    ENVIRONMENT
+      "${_ompt_environment};ROCPROFSYS_USE_SAMPLING=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_COUT_OUTPUT=ON"
+    REWRITE_RUN_PASS_REGEX "${_OMPT_PASS_REGEX}"
+    REWRITE_FAIL_REGEX "0 instrumented loops in procedure"
 )
 
 rocprofiler_systems_add_test(
-  SKIP_RUNTIME
-  SKIP_REWRITE
-  NAME
-  openmp-target
-  TARGET
-  openmp-target
-  GPU
-  ON
-  LABELS
-  "openmp;openmp-target"
-  ENVIRONMENT
-  "${_ompt_environment};${_rocm_ld_env};ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch"
+    SKIP_RUNTIME SKIP_REWRITE
+    NAME openmp-target
+    TARGET openmp-target
+    GPU ON
+    LABELS "openmp;openmp-target"
+    ENVIRONMENT
+      "${_ompt_environment};${_rocm_ld_env};ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch"
 )
 
 rocprofiler_systems_add_validation_test(
-  NAME
-  openmp-target-sampling
-  PERFETTO_METRIC
-  "rocm_kernel_dispatch"
-  PERFETTO_FILE
-  "perfetto-trace.proto"
-  LABELS
-  "openmp;openmp-target"
-  ENVIRONMENT
-  "${_rocm_ld_env}"
-  ARGS
-  --label-substrings
-  Z4vmulIiEvPT_S1_S1_i_l51.kd
-  Z4vmulIfEvPT_S1_S1_i_l51.kd
-  Z4vmulIdEvPT_S1_S1_i_l51.kd
-  -c
-  4
-  4
-  4
-  -d
-  0
-  0
-  0
-  -p
+    NAME openmp-target-sampling
+    PERFETTO_METRIC "rocm_kernel_dispatch"
+    PERFETTO_FILE "perfetto-trace.proto"
+    LABELS "openmp;openmp-target"
+    ENVIRONMENT "${_rocm_ld_env}"
+    ARGS
+      --label-substrings
+      Z4vmulIiEvPT_S1_S1_i_l51.kd
+      Z4vmulIfEvPT_S1_S1_i_l51.kd
+      Z4vmulIdEvPT_S1_S1_i_l51.kd
+      -c 4 4 4
+      -d 0 0 0
+      -p
 )
 
 # OpenMP tests generated using OMPVV binaries
 if(ROCPROFSYS_OMPVV_HOST_TESTS)
     foreach(HOST_TEST_NAME ${ROCPROFSYS_OMPVV_HOST_TESTS})
         rocprofiler_systems_add_test(
-          SKIP_RUNTIME
-          NAME
-          ${HOST_TEST_NAME}
-          TARGET
-          ${HOST_TEST_NAME}
-          LABELS
-          "openmp"
-          REWRITE_ARGS
-          -e
-          -v
-          2
-          --instrument-loops
-          RUNTIME_ARGS
-          -e
-          -v
-          1
-          --label
-          return
-          args
-          -E
-          ^GOMP
-          REWRITE_TIMEOUT
-          180
-          RUNTIME_TIMEOUT
-          360
-          ENVIRONMENT
-          "${_ompt_environment};ROCPROFSYS_USE_SAMPLING=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_COUT_OUTPUT=ON"
-          REWRITE_RUN_PASS_REGEX
-          "${_OMPT_PASS_REGEX}"
-          REWRITE_FAIL_REGEX
-          "0 instrumented loops in procedure"
+            SKIP_RUNTIME
+            NAME ${HOST_TEST_NAME}
+            TARGET ${HOST_TEST_NAME}
+            LABELS "openmp"
+            REWRITE_ARGS
+              -e -v 2 --instrument-loops
+            RUNTIME_ARGS
+              -e -v 1 --label return args -E ^GOMP
+            REWRITE_TIMEOUT 180
+            RUNTIME_TIMEOUT 360
+            ENVIRONMENT
+              "${_ompt_environment};ROCPROFSYS_USE_SAMPLING=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_COUT_OUTPUT=ON"
+            REWRITE_RUN_PASS_REGEX "${_OMPT_PASS_REGEX}"
+            REWRITE_FAIL_REGEX "0 instrumented loops in procedure"
         )
     endforeach()
 endif()
@@ -211,23 +139,16 @@ endif()
 if(ROCPROFSYS_OMPVV_OFFLOAD_TESTS)
     foreach(OFFLOAD_TEST_NAME ${ROCPROFSYS_OMPVV_OFFLOAD_TESTS})
         rocprofiler_systems_add_test(
-          SKIP_RUNTIME
-          NAME
-          ${OFFLOAD_TEST_NAME}
-          TARGET
-          ${OFFLOAD_TEST_NAME}
-          GPU
-          ON
-          LABELS
-          "openmp"
-          REWRITE_ARGS
-          -e
-          -v
-          2
-          ENVIRONMENT
-          "${_ompt_environment};${_rocm_ld_env};ROCPROFSYS_USE_SAMPLING=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_COUT_OUTPUT=ON;ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,kernel_dispatch,memory_copy,scratch_memory,hsa_api"
-          REWRITE_RUN_PASS_REGEX
-          "${_OMPVV_OFFLOAD_PASS_REGEX}"
+            SKIP_RUNTIME
+            NAME ${OFFLOAD_TEST_NAME}
+            TARGET ${OFFLOAD_TEST_NAME}
+            GPU ON
+            LABELS "openmp"
+            REWRITE_ARGS -e -v 2
+            ENVIRONMENT
+              "${_ompt_environment};${_rocm_ld_env};ROCPROFSYS_USE_SAMPLING=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_COUT_OUTPUT=ON;ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,kernel_dispatch,memory_copy,scratch_memory,hsa_api"
+            REWRITE_RUN_PASS_REGEX
+              "${_OMPVV_OFFLOAD_PASS_REGEX}"
         )
     endforeach()
 endif()
@@ -272,49 +193,28 @@ set(_notmp_sampling_file_regex
 )
 
 rocprofiler_systems_add_test(
-  SKIP_BASELINE
-  SKIP_RUNTIME
-  SKIP_REWRITE
-  NAME
-  openmp-cg-sampling-duration
-  TARGET
-  openmp-cg
-  LABELS
-  "openmp;sampling-duration"
-  ENVIRONMENT
-  "${_ompt_sampling_environ}"
-  SAMPLING_PASS_REGEX
-  "${_ompt_sampling_samp_regex}(.*)${_ompt_sampling_file_regex}"
+    SKIP_BASELINE SKIP_RUNTIME SKIP_REWRITE
+    NAME openmp-cg-sampling-duration
+    TARGET openmp-cg
+    LABELS "openmp;sampling-duration"
+    ENVIRONMENT "${_ompt_sampling_environ}"
+    SAMPLING_PASS_REGEX "${_ompt_sampling_samp_regex}(.*)${_ompt_sampling_file_regex}"
 )
 
 rocprofiler_systems_add_test(
-  SKIP_BASELINE
-  SKIP_RUNTIME
-  SKIP_REWRITE
-  NAME
-  openmp-lu-sampling-duration
-  TARGET
-  openmp-lu
-  LABELS
-  "openmp;sampling-duration"
-  ENVIRONMENT
-  "${_ompt_sampling_environ}"
-  SAMPLING_PASS_REGEX
-  "${_ompt_sampling_samp_regex}(.*)${_ompt_sampling_file_regex}"
+    SKIP_BASELINE SKIP_RUNTIME SKIP_REWRITE
+    NAME openmp-lu-sampling-duration
+    TARGET openmp-lu
+    LABELS "openmp;sampling-duration"
+    ENVIRONMENT "${_ompt_sampling_environ}"
+    SAMPLING_PASS_REGEX "${_ompt_sampling_samp_regex}(.*)${_ompt_sampling_file_regex}"
 )
 
 rocprofiler_systems_add_test(
-  SKIP_BASELINE
-  SKIP_RUNTIME
-  SKIP_REWRITE
-  NAME
-  openmp-cg-sampling-no-tmp-files
-  TARGET
-  openmp-cg
-  LABELS
-  "openmp;no-tmp-files"
-  ENVIRONMENT
-  "${_ompt_sample_no_tmpfiles_environ}"
-  SAMPLING_PASS_REGEX
-  "${_notmp_sampling_file_regex}"
+    SKIP_BASELINE SKIP_RUNTIME SKIP_REWRITE
+    NAME openmp-cg-sampling-no-tmp-files
+    TARGET openmp-cg
+    LABELS "openmp;no-tmp-files"
+    ENVIRONMENT "${_ompt_sample_no_tmpfiles_environ}"
+    SAMPLING_PASS_REGEX "${_notmp_sampling_file_regex}"
 )

--- a/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
@@ -51,10 +51,10 @@ endif()
 
 if(ROCPROFSYS_OPENMP_USING_LIBOMP_LIBRARY AND ROCPROFSYS_USE_OMPT)
   set(_OMPT_PASS_REGEX "\\|_omp_")
-  set(_OMPVV_TARGET_PASS_REGEX "\\|_omp_target_")
+  set(_OMPVV_TARGET_PASS_REGEX "_+omp_offloading")
 else()
   set(_OMPT_PASS_REGEX "")
-  set(_OMPVV_TARGET_PASS_REGEX "")
+  set(_OMPVV_OFFLOAD_PASS_REGEX "")
 endif()
 
 rocprofiler_systems_add_test(
@@ -201,14 +201,14 @@ if(ROCPROFSYS_OMPVV_HOST_TESTS)
   endforeach()
 endif()
 
-if(ROCPROFSYS_OMPVV_TARGET_TESTS)
-  foreach(TARGET_TEST_NAME ${ROCPROFSYS_OMPVV_TARGET_TESTS})
+if(ROCPROFSYS_OMPVV_OFFLOAD_TESTS)
+  foreach(OFFLOAD_TEST_NAME ${ROCPROFSYS_OMPVV_OFFLOAD_TESTS})
     rocprofiler_systems_add_test(
       SKIP_RUNTIME
       NAME
-      ${TARGET_TEST_NAME}
+      ${OFFLOAD_TEST_NAME}
       TARGET
-      ${TARGET_TEST_NAME}
+      ${OFFLOAD_TEST_NAME}
       GPU
       ON
       LABELS
@@ -220,7 +220,7 @@ if(ROCPROFSYS_OMPVV_TARGET_TESTS)
       ENVIRONMENT
       "${_ompt_environment};${_rocm_ld_env};ROCPROFSYS_USE_SAMPLING=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_COUT_OUTPUT=ON;ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,kernel_dispatch,memory_copy,scratch_memory,hsa_api"
       REWRITE_RUN_PASS_REGEX
-      "${_OMPVV_TARGET_PASS_REGEX}")
+      "${_OMPVV_OFFLOAD_PASS_REGEX}")
   endforeach()
 endif()
 

--- a/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
@@ -1,24 +1,5 @@
-# MIT License
-#
-# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
 
 # ----------------------------------------------------------------------------- #
 #

--- a/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
@@ -121,7 +121,7 @@ if(ROCPROFSYS_OMPVV_HOST_TESTS)
             SKIP_RUNTIME
             NAME ${HOST_TEST_NAME}
             TARGET ${HOST_TEST_NAME}
-            LABELS "openmp"
+            LABELS "openmp;ompvv"
             REWRITE_ARGS
               -e -v 2 --instrument-loops
             RUNTIME_ARGS
@@ -134,19 +134,26 @@ if(ROCPROFSYS_OMPVV_HOST_TESTS)
             REWRITE_FAIL_REGEX "0 instrumented loops in procedure"
         )
     endforeach()
-endif()
 
-if(ROCPROFSYS_OMPVV_OFFLOAD_TESTS)
+    set(_ompvv_offload_environment
+        "${ompt_environment}"
+        "${_rocm_ld_env}"
+        "ROCPROFSYS_USE_SAMPLING=ON"
+        "ROCPROFSYS_SAMPLING_FREQ=50"
+        "ROCPROFSYS_COUT_OUTPUT=ON"
+        "ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,kernel_dispatch,memory_copy,scratch_memory,hsa_api"
+    )
+
     foreach(OFFLOAD_TEST_NAME ${ROCPROFSYS_OMPVV_OFFLOAD_TESTS})
         rocprofiler_systems_add_test(
             SKIP_RUNTIME
             NAME ${OFFLOAD_TEST_NAME}
             TARGET ${OFFLOAD_TEST_NAME}
             GPU ON
-            LABELS "openmp"
+            LABELS "openmp;ompvv;openmp-target"
             REWRITE_ARGS -e -v 2
             ENVIRONMENT
-              "${_ompt_environment};${_rocm_ld_env};ROCPROFSYS_USE_SAMPLING=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_COUT_OUTPUT=ON;ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,kernel_dispatch,memory_copy,scratch_memory,hsa_api"
+              "${_ompvv_offload_environment}"
             REWRITE_RUN_PASS_REGEX
               "${_OMPVV_OFFLOAD_PASS_REGEX}"
         )

--- a/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
@@ -1,4 +1,4 @@
-# Copyright Advanced Micro Devices, Inc.
+# Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
 # ----------------------------------------------------------------------------- #

--- a/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
@@ -29,32 +29,35 @@
 # #
 
 if(ROCmVersion_DIR)
-  set(_rocm_root "${ROCmVersion_DIR}")
+    set(_rocm_root "${ROCmVersion_DIR}")
 elseif(DEFINED ENV{ROCM_PATH})
-  set(_rocm_root "$ENV{ROCM_PATH}")
+    set(_rocm_root "$ENV{ROCM_PATH}")
 else()
-  set(_rocm_root "/opt/rocm")
+    set(_rocm_root "/opt/rocm")
 endif()
 
 set(_rocm_llvm_lib "${_rocm_root}/lib/llvm/lib")
 
-set(_rocm_ld_env "LD_PRELOAD=libomptarget.so"
-                 "LD_LIBRARY_PATH=${_rocm_llvm_lib}:$ENV{LD_LIBRARY_PATH}")
+set(_rocm_ld_env
+    "LD_PRELOAD=libomptarget.so"
+    "LD_LIBRARY_PATH=${_rocm_llvm_lib}:$ENV{LD_LIBRARY_PATH}"
+)
 
 if(NOT EXISTS "${_rocm_llvm_lib}/libomptarget.so" AND ROCPROFSYS_USE_ROCM)
-  message(
-    FATAL_ERROR
-      "libomptarget.so not found in ${_rocm_llvm_lib}. "
-      "Verify that ROCm is installed correctly and that _rocm_root "
-      "(${_rocm_root}) points at the right location.")
+    message(
+        FATAL_ERROR
+        "libomptarget.so not found in ${_rocm_llvm_lib}. "
+        "Verify that ROCm is installed correctly and that _rocm_root "
+        "(${_rocm_root}) points at the right location."
+    )
 endif()
 
 if(ROCPROFSYS_OPENMP_USING_LIBOMP_LIBRARY AND ROCPROFSYS_USE_OMPT)
-  set(_OMPT_PASS_REGEX "\\|_omp_")
-  set(_OMPVV_TARGET_PASS_REGEX "_+omp_offloading")
+    set(_OMPT_PASS_REGEX "\\|_omp_")
+    set(_OMPVV_TARGET_PASS_REGEX "_+omp_offloading")
 else()
-  set(_OMPT_PASS_REGEX "")
-  set(_OMPVV_OFFLOAD_PASS_REGEX "")
+    set(_OMPT_PASS_REGEX "")
+    set(_OMPVV_OFFLOAD_PASS_REGEX "")
 endif()
 
 rocprofiler_systems_add_test(
@@ -87,7 +90,8 @@ rocprofiler_systems_add_test(
   RUNTIME_PASS_REGEX
   "${_OMPT_PASS_REGEX}"
   REWRITE_FAIL_REGEX
-  "0 instrumented loops in procedure")
+  "0 instrumented loops in procedure"
+)
 
 rocprofiler_systems_add_test(
   SKIP_RUNTIME
@@ -120,7 +124,8 @@ rocprofiler_systems_add_test(
   REWRITE_RUN_PASS_REGEX
   "${_OMPT_PASS_REGEX}"
   REWRITE_FAIL_REGEX
-  "0 instrumented loops in procedure")
+  "0 instrumented loops in procedure"
+)
 
 rocprofiler_systems_add_test(
   SKIP_RUNTIME
@@ -161,67 +166,70 @@ rocprofiler_systems_add_validation_test(
   0
   0
   0
-  -p)
+  -p
+)
 
 # OpenMP tests generated using OMPVV binaries
 if(ROCPROFSYS_OMPVV_HOST_TESTS)
-  foreach(HOST_TEST_NAME ${ROCPROFSYS_OMPVV_HOST_TESTS})
-    rocprofiler_systems_add_test(
-      SKIP_RUNTIME
-      NAME
-      ${HOST_TEST_NAME}
-      TARGET
-      ${HOST_TEST_NAME}
-      LABELS
-      "openmp"
-      REWRITE_ARGS
-      -e
-      -v
-      2
-      --instrument-loops
-      RUNTIME_ARGS
-      -e
-      -v
-      1
-      --label
-      return
-      args
-      -E
-      ^GOMP
-      REWRITE_TIMEOUT
-      180
-      RUNTIME_TIMEOUT
-      360
-      ENVIRONMENT
-      "${_ompt_environment};ROCPROFSYS_USE_SAMPLING=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_COUT_OUTPUT=ON"
-      REWRITE_RUN_PASS_REGEX
-      "${_OMPT_PASS_REGEX}"
-      REWRITE_FAIL_REGEX
-      "0 instrumented loops in procedure")
-  endforeach()
+    foreach(HOST_TEST_NAME ${ROCPROFSYS_OMPVV_HOST_TESTS})
+        rocprofiler_systems_add_test(
+          SKIP_RUNTIME
+          NAME
+          ${HOST_TEST_NAME}
+          TARGET
+          ${HOST_TEST_NAME}
+          LABELS
+          "openmp"
+          REWRITE_ARGS
+          -e
+          -v
+          2
+          --instrument-loops
+          RUNTIME_ARGS
+          -e
+          -v
+          1
+          --label
+          return
+          args
+          -E
+          ^GOMP
+          REWRITE_TIMEOUT
+          180
+          RUNTIME_TIMEOUT
+          360
+          ENVIRONMENT
+          "${_ompt_environment};ROCPROFSYS_USE_SAMPLING=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_COUT_OUTPUT=ON"
+          REWRITE_RUN_PASS_REGEX
+          "${_OMPT_PASS_REGEX}"
+          REWRITE_FAIL_REGEX
+          "0 instrumented loops in procedure"
+        )
+    endforeach()
 endif()
 
 if(ROCPROFSYS_OMPVV_OFFLOAD_TESTS)
-  foreach(OFFLOAD_TEST_NAME ${ROCPROFSYS_OMPVV_OFFLOAD_TESTS})
-    rocprofiler_systems_add_test(
-      SKIP_RUNTIME
-      NAME
-      ${OFFLOAD_TEST_NAME}
-      TARGET
-      ${OFFLOAD_TEST_NAME}
-      GPU
-      ON
-      LABELS
-      "openmp"
-      REWRITE_ARGS
-      -e
-      -v
-      2
-      ENVIRONMENT
-      "${_ompt_environment};${_rocm_ld_env};ROCPROFSYS_USE_SAMPLING=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_COUT_OUTPUT=ON;ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,kernel_dispatch,memory_copy,scratch_memory,hsa_api"
-      REWRITE_RUN_PASS_REGEX
-      "${_OMPVV_OFFLOAD_PASS_REGEX}")
-  endforeach()
+    foreach(OFFLOAD_TEST_NAME ${ROCPROFSYS_OMPVV_OFFLOAD_TESTS})
+        rocprofiler_systems_add_test(
+          SKIP_RUNTIME
+          NAME
+          ${OFFLOAD_TEST_NAME}
+          TARGET
+          ${OFFLOAD_TEST_NAME}
+          GPU
+          ON
+          LABELS
+          "openmp"
+          REWRITE_ARGS
+          -e
+          -v
+          2
+          ENVIRONMENT
+          "${_ompt_environment};${_rocm_ld_env};ROCPROFSYS_USE_SAMPLING=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_COUT_OUTPUT=ON;ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,kernel_dispatch,memory_copy,scratch_memory,hsa_api"
+          REWRITE_RUN_PASS_REGEX
+          "${_OMPVV_OFFLOAD_PASS_REGEX}"
+        )
+    endforeach()
 endif()
 
 set(_ompt_sampling_environ
@@ -237,7 +245,8 @@ set(_ompt_sampling_environ
     "ROCPROFSYS_SAMPLING_REALTIME=ON"
     "ROCPROFSYS_SAMPLING_CPUTIME_FREQ=1000"
     "ROCPROFSYS_SAMPLING_REALTIME_FREQ=500"
-    "ROCPROFSYS_MONOCHROME=ON")
+    "ROCPROFSYS_MONOCHROME=ON"
+)
 
 set(_ompt_sample_no_tmpfiles_environ
     "${_ompt_environment}"
@@ -249,7 +258,8 @@ set(_ompt_sample_no_tmpfiles_environ
     "ROCPROFSYS_SAMPLING_REALTIME=OFF"
     "ROCPROFSYS_SAMPLING_CPUTIME_FREQ=700"
     "ROCPROFSYS_USE_TEMPORARY_FILES=OFF"
-    "ROCPROFSYS_MONOCHROME=ON")
+    "ROCPROFSYS_MONOCHROME=ON"
+)
 
 set(_ompt_sampling_samp_regex
     "Sampler for thread 0 will be triggered 1000.0x per second of CPU-time(.*)Sampler for thread 0 will be triggered 500.0x per second of wall-time(.*)Sampling will be disabled after 0.250000 seconds(.*)Sampling duration of 0.250000 seconds has elapsed. Shutting down sampling"
@@ -274,7 +284,8 @@ rocprofiler_systems_add_test(
   ENVIRONMENT
   "${_ompt_sampling_environ}"
   SAMPLING_PASS_REGEX
-  "${_ompt_sampling_samp_regex}(.*)${_ompt_sampling_file_regex}")
+  "${_ompt_sampling_samp_regex}(.*)${_ompt_sampling_file_regex}"
+)
 
 rocprofiler_systems_add_test(
   SKIP_BASELINE
@@ -289,7 +300,8 @@ rocprofiler_systems_add_test(
   ENVIRONMENT
   "${_ompt_sampling_environ}"
   SAMPLING_PASS_REGEX
-  "${_ompt_sampling_samp_regex}(.*)${_ompt_sampling_file_regex}")
+  "${_ompt_sampling_samp_regex}(.*)${_ompt_sampling_file_regex}"
+)
 
 rocprofiler_systems_add_test(
   SKIP_BASELINE
@@ -304,4 +316,5 @@ rocprofiler_systems_add_test(
   ENVIRONMENT
   "${_ompt_sample_no_tmpfiles_environ}"
   SAMPLING_PASS_REGEX
-  "${_notmp_sampling_file_regex}")
+  "${_notmp_sampling_file_regex}"
+)

--- a/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
@@ -9,127 +9,219 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
-# -------------------------------------------------------------------------------------- #
+# --------------------------------------------------------------------------------------
+# #
 #
 # openmp tests
 #
-# -------------------------------------------------------------------------------------- #
+# --------------------------------------------------------------------------------------
+# #
 
 if(ROCmVersion_DIR)
-    set(_rocm_root "${ROCmVersion_DIR}")
+  set(_rocm_root "${ROCmVersion_DIR}")
 elseif(DEFINED ENV{ROCM_PATH})
-    set(_rocm_root "$ENV{ROCM_PATH}")
+  set(_rocm_root "$ENV{ROCM_PATH}")
 else()
-    set(_rocm_root "/opt/rocm")
+  set(_rocm_root "/opt/rocm")
 endif()
 
 set(_rocm_llvm_lib "${_rocm_root}/lib/llvm/lib")
 
-set(_rocm_ld_env
-    "LD_PRELOAD=libomptarget.so"
-    "LD_LIBRARY_PATH=${_rocm_llvm_lib}:$ENV{LD_LIBRARY_PATH}"
-)
+set(_rocm_ld_env "LD_PRELOAD=libomptarget.so"
+                 "LD_LIBRARY_PATH=${_rocm_llvm_lib}:$ENV{LD_LIBRARY_PATH}")
 
 if(NOT EXISTS "${_rocm_llvm_lib}/libomptarget.so" AND ROCPROFSYS_USE_ROCM)
-    message(
-        FATAL_ERROR
-        "libomptarget.so not found in ${_rocm_llvm_lib}. "
-        "Verify that ROCm is installed correctly and that _rocm_root "
-        "(${_rocm_root}) points at the right location."
-    )
+  message(
+    FATAL_ERROR
+      "libomptarget.so not found in ${_rocm_llvm_lib}. "
+      "Verify that ROCm is installed correctly and that _rocm_root "
+      "(${_rocm_root}) points at the right location.")
 endif()
 
 if(ROCPROFSYS_OPENMP_USING_LIBOMP_LIBRARY AND ROCPROFSYS_USE_OMPT)
-    set(_OMPT_PASS_REGEX "\\|_omp_")
+  set(_OMPT_PASS_REGEX "\\|_omp_")
+  set(_OMPVV_TARGET_PASS_REGEX "\\|_omp_target_")
 else()
-    set(_OMPT_PASS_REGEX "")
+  set(_OMPT_PASS_REGEX "")
+  set(_OMPVV_TARGET_PASS_REGEX "")
 endif()
 
 rocprofiler_systems_add_test(
-    NAME openmp-cg
-    TARGET openmp-cg
-    LABELS "openmp"
-    REWRITE_ARGS -e -v 2 --instrument-loops
-    RUNTIME_ARGS -e -v 1 --label return args
-    REWRITE_TIMEOUT 180
-    RUNTIME_TIMEOUT 360
-    ENVIRONMENT
-        "${_ompt_environment};ROCPROFSYS_USE_SAMPLING=OFF;ROCPROFSYS_COUT_OUTPUT=ON"
-    REWRITE_RUN_PASS_REGEX "${_OMPT_PASS_REGEX}"
-    RUNTIME_PASS_REGEX "${_OMPT_PASS_REGEX}"
-    REWRITE_FAIL_REGEX "0 instrumented loops in procedure"
-)
+  NAME
+  openmp-cg
+  TARGET
+  openmp-cg
+  LABELS
+  "openmp"
+  REWRITE_ARGS
+  -e
+  -v
+  2
+  --instrument-loops
+  RUNTIME_ARGS
+  -e
+  -v
+  1
+  --label
+  return
+  args
+  REWRITE_TIMEOUT
+  180
+  RUNTIME_TIMEOUT
+  360
+  ENVIRONMENT
+  "${_ompt_environment};ROCPROFSYS_USE_SAMPLING=OFF;ROCPROFSYS_COUT_OUTPUT=ON"
+  REWRITE_RUN_PASS_REGEX
+  "${_OMPT_PASS_REGEX}"
+  RUNTIME_PASS_REGEX
+  "${_OMPT_PASS_REGEX}"
+  REWRITE_FAIL_REGEX
+  "0 instrumented loops in procedure")
 
 rocprofiler_systems_add_test(
-    SKIP_RUNTIME
-    NAME openmp-lu
-    TARGET openmp-lu
-    LABELS "openmp"
-    REWRITE_ARGS -e -v 2 --instrument-loops
-    RUNTIME_ARGS -e -v 1 --label return args -E ^GOMP
-    REWRITE_TIMEOUT 180
-    RUNTIME_TIMEOUT 360
-    ENVIRONMENT
-        "${_ompt_environment};ROCPROFSYS_USE_SAMPLING=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_COUT_OUTPUT=ON"
-    REWRITE_RUN_PASS_REGEX "${_OMPT_PASS_REGEX}"
-    REWRITE_FAIL_REGEX "0 instrumented loops in procedure"
-)
+  SKIP_RUNTIME
+  NAME
+  openmp-lu
+  TARGET
+  openmp-lu
+  LABELS
+  "openmp"
+  REWRITE_ARGS
+  -e
+  -v
+  2
+  --instrument-loops
+  RUNTIME_ARGS
+  -e
+  -v
+  1
+  --label
+  return
+  args
+  -E
+  ^GOMP
+  REWRITE_TIMEOUT
+  180
+  RUNTIME_TIMEOUT
+  360
+  ENVIRONMENT
+  "${_ompt_environment};ROCPROFSYS_USE_SAMPLING=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_COUT_OUTPUT=ON"
+  REWRITE_RUN_PASS_REGEX
+  "${_OMPT_PASS_REGEX}"
+  REWRITE_FAIL_REGEX
+  "0 instrumented loops in procedure")
 
 rocprofiler_systems_add_test(
-    SKIP_RUNTIME SKIP_REWRITE
-    NAME openmp-target
-    TARGET openmp-target
-    GPU ON
-    LABELS "openmp;openmp-target"
-    ENVIRONMENT
-        "${_ompt_environment};${_rocm_ld_env};ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch"
+  SKIP_RUNTIME
+  SKIP_REWRITE
+  NAME
+  openmp-target
+  TARGET
+  openmp-target
+  GPU
+  ON
+  LABELS
+  "openmp;openmp-target"
+  ENVIRONMENT
+  "${_ompt_environment};${_rocm_ld_env};ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch"
 )
 
 rocprofiler_systems_add_validation_test(
-    NAME openmp-target-sampling
-    PERFETTO_METRIC "rocm_kernel_dispatch"
-    PERFETTO_FILE "perfetto-trace.proto"
-    LABELS "openmp;openmp-target"
-    ENVIRONMENT "${_rocm_ld_env}"
-    ARGS --label-substrings
-         Z4vmulIiEvPT_S1_S1_i_l51.kd
-         Z4vmulIfEvPT_S1_S1_i_l51.kd
-         Z4vmulIdEvPT_S1_S1_i_l51.kd
-         -c
-         4
-         4
-         4
-         -d
-         0
-         0
-         0
-         -p
-)
+  NAME
+  openmp-target-sampling
+  PERFETTO_METRIC
+  "rocm_kernel_dispatch"
+  PERFETTO_FILE
+  "perfetto-trace.proto"
+  LABELS
+  "openmp;openmp-target"
+  ENVIRONMENT
+  "${_rocm_ld_env}"
+  ARGS
+  --label-substrings
+  Z4vmulIiEvPT_S1_S1_i_l51.kd
+  Z4vmulIfEvPT_S1_S1_i_l51.kd
+  Z4vmulIdEvPT_S1_S1_i_l51.kd
+  -c
+  4
+  4
+  4
+  -d
+  0
+  0
+  0
+  -p)
 
 # OpenMP tests generated using OMPVV binaries
-if(OMPVV_TESTS)
-    foreach(TEST_NAME ${OMPVV_TESTS})
-        rocprofiler_systems_add_test(
-            SKIP_RUNTIME
-            NAME openmp-vv-${TEST_NAME}
-            TARGET openmp-vv-${TEST_NAME}
-            GPU ON
-            LABELS "openmp"
-            ENVIRONMENT
-                "${_ompt_environment};${_rocm_ld_env};ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,kernel_dispatch,memory_copy,scratch_memory,hsa_api"
-        )
-    endforeach()
+if(ROCPROFSYS_OMPVV_HOST_TESTS)
+  foreach(HOST_TEST_NAME ${ROCPROFSYS_OMPVV_HOST_TESTS})
+    rocprofiler_systems_add_test(
+      SKIP_RUNTIME
+      NAME
+      ${HOST_TEST_NAME}
+      TARGET
+      ${HOST_TEST_NAME}
+      LABELS
+      "openmp"
+      REWRITE_ARGS
+      -e
+      -v
+      2
+      --instrument-loops
+      RUNTIME_ARGS
+      -e
+      -v
+      1
+      --label
+      return
+      args
+      -E
+      ^GOMP
+      REWRITE_TIMEOUT
+      180
+      RUNTIME_TIMEOUT
+      360
+      ENVIRONMENT
+      "${_ompt_environment};ROCPROFSYS_USE_SAMPLING=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_COUT_OUTPUT=ON"
+      REWRITE_RUN_PASS_REGEX
+      "${_OMPT_PASS_REGEX}"
+      REWRITE_FAIL_REGEX
+      "0 instrumented loops in procedure")
+  endforeach()
+endif()
+
+if(ROCPROFSYS_OMPVV_TARGET_TESTS)
+  foreach(TARGET_TEST_NAME ${ROCPROFSYS_OMPVV_TARGET_TESTS})
+    rocprofiler_systems_add_test(
+      SKIP_RUNTIME
+      NAME
+      ${TARGET_TEST_NAME}
+      TARGET
+      ${TARGET_TEST_NAME}
+      GPU
+      ON
+      LABELS
+      "openmp"
+      REWRITE_ARGS
+      -e
+      -v
+      2
+      ENVIRONMENT
+      "${_ompt_environment};${_rocm_ld_env};ROCPROFSYS_USE_SAMPLING=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_COUT_OUTPUT=ON;ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,marker_api,kernel_dispatch,memory_copy,scratch_memory,hsa_api"
+      REWRITE_RUN_PASS_REGEX
+      "${_OMPVV_TARGET_PASS_REGEX}")
+  endforeach()
 endif()
 
 set(_ompt_sampling_environ
@@ -145,8 +237,7 @@ set(_ompt_sampling_environ
     "ROCPROFSYS_SAMPLING_REALTIME=ON"
     "ROCPROFSYS_SAMPLING_CPUTIME_FREQ=1000"
     "ROCPROFSYS_SAMPLING_REALTIME_FREQ=500"
-    "ROCPROFSYS_MONOCHROME=ON"
-)
+    "ROCPROFSYS_MONOCHROME=ON")
 
 set(_ompt_sample_no_tmpfiles_environ
     "${_ompt_environment}"
@@ -158,8 +249,7 @@ set(_ompt_sample_no_tmpfiles_environ
     "ROCPROFSYS_SAMPLING_REALTIME=OFF"
     "ROCPROFSYS_SAMPLING_CPUTIME_FREQ=700"
     "ROCPROFSYS_USE_TEMPORARY_FILES=OFF"
-    "ROCPROFSYS_MONOCHROME=ON"
-)
+    "ROCPROFSYS_MONOCHROME=ON")
 
 set(_ompt_sampling_samp_regex
     "Sampler for thread 0 will be triggered 1000.0x per second of CPU-time(.*)Sampler for thread 0 will be triggered 500.0x per second of wall-time(.*)Sampling will be disabled after 0.250000 seconds(.*)Sampling duration of 0.250000 seconds has elapsed. Shutting down sampling"
@@ -172,28 +262,46 @@ set(_notmp_sampling_file_regex
 )
 
 rocprofiler_systems_add_test(
-    SKIP_BASELINE SKIP_RUNTIME SKIP_REWRITE
-    NAME openmp-cg-sampling-duration
-    TARGET openmp-cg
-    LABELS "openmp;sampling-duration"
-    ENVIRONMENT "${_ompt_sampling_environ}"
-    SAMPLING_PASS_REGEX "${_ompt_sampling_samp_regex}(.*)${_ompt_sampling_file_regex}"
-)
+  SKIP_BASELINE
+  SKIP_RUNTIME
+  SKIP_REWRITE
+  NAME
+  openmp-cg-sampling-duration
+  TARGET
+  openmp-cg
+  LABELS
+  "openmp;sampling-duration"
+  ENVIRONMENT
+  "${_ompt_sampling_environ}"
+  SAMPLING_PASS_REGEX
+  "${_ompt_sampling_samp_regex}(.*)${_ompt_sampling_file_regex}")
 
 rocprofiler_systems_add_test(
-    SKIP_BASELINE SKIP_RUNTIME SKIP_REWRITE
-    NAME openmp-lu-sampling-duration
-    TARGET openmp-lu
-    LABELS "openmp;sampling-duration"
-    ENVIRONMENT "${_ompt_sampling_environ}"
-    SAMPLING_PASS_REGEX "${_ompt_sampling_samp_regex}(.*)${_ompt_sampling_file_regex}"
-)
+  SKIP_BASELINE
+  SKIP_RUNTIME
+  SKIP_REWRITE
+  NAME
+  openmp-lu-sampling-duration
+  TARGET
+  openmp-lu
+  LABELS
+  "openmp;sampling-duration"
+  ENVIRONMENT
+  "${_ompt_sampling_environ}"
+  SAMPLING_PASS_REGEX
+  "${_ompt_sampling_samp_regex}(.*)${_ompt_sampling_file_regex}")
 
 rocprofiler_systems_add_test(
-    SKIP_BASELINE SKIP_RUNTIME SKIP_REWRITE
-    NAME openmp-cg-sampling-no-tmp-files
-    TARGET openmp-cg
-    LABELS "openmp;no-tmp-files"
-    ENVIRONMENT "${_ompt_sample_no_tmpfiles_environ}"
-    SAMPLING_PASS_REGEX "${_notmp_sampling_file_regex}"
-)
+  SKIP_BASELINE
+  SKIP_RUNTIME
+  SKIP_REWRITE
+  NAME
+  openmp-cg-sampling-no-tmp-files
+  TARGET
+  openmp-cg
+  LABELS
+  "openmp;no-tmp-files"
+  ENVIRONMENT
+  "${_ompt_sample_no_tmpfiles_environ}"
+  SAMPLING_PASS_REGEX
+  "${_notmp_sampling_file_regex}")


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Currently, no Fortran CTests exist for OpenMP. With support now existing for OpenMP tracing thanks to SDK, more test coverage is required.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

 - OMPVV (OpenMP Validation and Verification) has been added as a submodule of the project.
     - Since `libomp` does not support the full OpenMP 5.0 specification, many tests fail to compile. However, as the `llvm` project grows, the module can be used to add more coverage for other OpenMP constructs as needed. 
 - Added 12 new CTests based on four OMPVV programs:
     - test_team_default_shared (CPU)
     - test_parallel_for_simd_atomic (CPU)
     - test_target_simd_if (GPU)
     - test_target_teams_distribute_parallel_for_collapse (GPU)

 - The four tests above were not chosen due to the constructs they tested but instead because they would compile and work for both `amdflang` 20.0 and 19.0.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

 - CPU ones tested on workflows. Others tested on personal machine.

## Test Result

<!-- Briefly summarize test outcomes. -->
- Personal Work Machine: All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
