### PR TITLE
clr: Fix condition for taking shader path

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -526,7 +526,7 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
 
       // If requested engine is valid and available, use it
       if (recIdMask != 0 && (freeEngineMask & recIdMask) != 0) {
-        copyMask = recIdMask;
+        copyMask = recIdMask - (recIdMask & (recIdMask - 1));
       } else {
         // Otherwise use first available engine
         copyMask = freeEngineMask - (freeEngineMask & (freeEngineMask - 1));
@@ -2252,17 +2252,29 @@ bool KernelBlitManager::copyBuffer(device::Memory& srcMemory, device::Memory& ds
     }
   }
 
-  bool ipcShared = srcMemory.owner()->ipcShared() || dstMemory.owner()->ipcShared();
+  // Determine if we should use shader copy path based on various conditions
+  bool hwlCopyDisabled = setup_.disableHwlCopyBuffer_;
 
-  bool useShaderCopyPath = setup_.disableHwlCopyBuffer_ ||
-                           (copyMetadata.copyEnginePreference_ ==
-                            amd::CopyMetadata::CopyEnginePreference::BLIT) ||
-                           (sizeIn[0] <= dev().settings().sdmaCopyThreshold_ &&
-                            !(p2p || ipcShared) &&
-                            !srcMemory.isHostMemDirectAccess() &&
-                            !dstMemory.isHostMemDirectAccess() &&
-                            copyMetadata.copyEnginePreference_ !=
-                              amd::CopyMetadata::CopyEnginePreference::SDMA);
+  // Check copy engine preferences
+  bool isSdmaPreference =
+      copyMetadata.copyEnginePreference_ == amd::CopyMetadata::CopyEnginePreference::SDMA;
+  bool isBlitPreference =
+      copyMetadata.copyEnginePreference_ == amd::CopyMetadata::CopyEnginePreference::BLIT;
+
+  // Check memory access patterns
+  bool isP2pOrIpc = p2p || srcMemory.owner()->ipcShared() || dstMemory.owner()->ipcShared();
+  bool neitherMemoryIsHostDirectAccess =
+      !srcMemory.isHostMemDirectAccess() && !dstMemory.isHostMemDirectAccess();
+
+  // Determine shader copy path conditions
+  bool smallSizeWithNonSdmaPreference =
+      sizeIn[0] <= dev().settings().sdmaCopyThreshold_ && !isSdmaPreference;
+
+  bool nonP2PIpcOrDirectAccess =
+      !isP2pOrIpc && neitherMemoryIsHostDirectAccess && !isSdmaPreference;
+
+  const bool useShaderCopyPath = hwlCopyDisabled || smallSizeWithNonSdmaPreference ||
+                                 nonP2PIpcOrDirectAccess || isBlitPreference;
 
   if (!useShaderCopyPath) {
     if (amd::IS_HIP) {


### PR DESCRIPTION
* SWDEV-551080
* Fix condition for taking shader path, the size check was moved incorrectly
* Also account for a bitmask returned for preferred engines

## Motivation

Incorrect condition for taking blit path

## Technical Details
Fix condition that was incorrect, 
Also fix to retrieve a mask from first bit set, simplify code

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
