### PR TITLE
SWDEV-553750 - Fix codeql errors in hip-tests

### DIFF
--- a/projects/hip-tests/catch/unit/memory/mempool_common.hh
+++ b/projects/hip-tests/catch/unit/memory/mempool_common.hh
@@ -636,9 +636,7 @@ public:
     // Construct client address to send this SHareable handle to
     bzero(&cliaddr, sizeof(cliaddr));
     cliaddr.sun_family = AF_UNIX;
-    char temp[10];
-    sprintf(temp, "%u", process);
-    strcpy(cliaddr.sun_path, temp);
+    strcpy(cliaddr.sun_path, std::to_string(process).c_str());
 
     // Send corresponding shareable handle to the client
     int sendfd = (int)shareableHdl;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hip_vmm_common.hh
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hip_vmm_common.hh
@@ -230,9 +230,7 @@ public:
     // Construct client address to send this SHareable handle to
     bzero(&cliaddr, sizeof(cliaddr));
     cliaddr.sun_family = AF_UNIX;
-    char temp[10];
-    sprintf(temp, "%u", process);
-    strcpy(cliaddr.sun_path, temp);
+    strcpy(cliaddr.sun_path, std::to_string(process).c_str());
 
     // Send corresponding shareable handle to the client
     int sendfd = (int)shareableHdl;


### PR DESCRIPTION
## Motivation

Resolve errors in hip-tests reported by codeql

## Technical Details

The maximum integer uses 10 characters plus a null terminator, so a temp[10] array may not be sufficient. I changed the code to use C++ std::to_string.

## Test Plan

/

## Test Result

/

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
