### PR TITLE
SWDEV-553962 - Add p2p check to multidevice virtual memory tests

### DIFF
--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
@@ -276,6 +276,7 @@ TEST_CASE("Unit_hipMemMap_PhysicalMemory_Map2MultVMMs") {
  *    - HIP_VERSION >= 6.1
  */
 TEST_CASE("Unit_hipMemMap_PhysicalMemoryReuse_MultiDev") {
+  CHECK_P2P_SUPPORT
   int devicecount = 0;
   HIP_CHECK(hipGetDeviceCount(&devicecount));
   if (devicecount < 2) {
@@ -423,6 +424,7 @@ TEST_CASE("Unit_hipMemMap_VMMMemoryReuse_SingleGPU") {
  *    - HIP_VERSION >= 6.1
  */
 TEST_CASE("Unit_hipMemMap_VMMMemoryReuse_MultiGPU") {
+  CHECK_P2P_SUPPORT
   int deviceId = 0, devicecount = 0;
   HIP_CHECK(hipGetDeviceCount(&devicecount));
   if (devicecount < 2) {
@@ -432,6 +434,7 @@ TEST_CASE("Unit_hipMemMap_VMMMemoryReuse_MultiGPU") {
   size_t granularity = 0;
   size_t buffer_size = N * sizeof(int);
   hipDevice_t device;
+  HIP_CHECK(hipSetDevice(0));
   HIP_CHECK(hipDeviceGet(&device, deviceId));
   checkVMMSupported(device);
   hipMemAllocationProp prop{};
@@ -451,9 +454,9 @@ TEST_CASE("Unit_hipMemMap_VMMMemoryReuse_MultiGPU") {
   }
   // Allocate a physical memory chunk
   for (int dev = 0; dev < devicecount; dev++) {
-    hipDevice_t device;
-    HIP_CHECK(hipDeviceGet(&device, dev));
-    prop.location.id = device;
+    hipDevice_t dev_handle;
+    HIP_CHECK(hipDeviceGet(&dev_handle, dev));
+    prop.location.id = dev_handle;
     HIP_CHECK(hipMemCreate(&handle[dev], size_mem, &prop, 0));
   }
   // Allocate devicecount virtual address ranges


### PR DESCRIPTION
## Motivation

On multi-GPU architectures, all GPUs need to have P2P support; otherwise, the test will fail.

## Technical Details

A P2P check was added between each pair of devices.

## Test Plan

/

## Test Result

/

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
