### PR TITLE
[rocprofiler-sdk][rocpd] Ship gotcha with rocpd package

### DIFF
--- a/projects/rocprofiler-sdk/external/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/external/CMakeLists.txt
@@ -324,6 +324,7 @@ if(ROCPROFILER_BUILD_GOTCHA)
         install(
             TARGETS gotcha
             DESTINATION "${CMAKE_INSTALL_LIBDIR}/rocprofiler-sdk"
+            COMPONENT rocpd
             OPTIONAL)
     endfunction()
 


### PR DESCRIPTION
## Motivation

rocprofiler-sdk-1.0.0.99999-1.x86_64.rpm depends on rocprofiler-sdk-rocpd-1.0.0.99999-1.x86_64.rpm package but rocpd has dependency on gotcha with is right now packed with sdk/core package by default, which causes a ring. moving gotcha to be shipped with rocpd package.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
