### PR TITLE
SWDEV-554678 - Navi44 on windows

### DIFF
--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -102,6 +102,7 @@ static constexpr PalDevice supportedPalDevices[] = {
     {11, 0, 3, Pal::GfxIpLevel::GfxIp11_0, "gfx1103", Pal::AsicRevision::HawkPoint2},
     {11, 5, 0, Pal::GfxIpLevel::GfxIp11_5, "gfx1150", Pal::AsicRevision::Strix1},
     {11, 5, 1, Pal::GfxIpLevel::GfxIp11_5, "gfx1151", Pal::AsicRevision::StrixHalo},
+    {12, 0, 0, Pal::GfxIpLevel::GfxIp12, "gfx1200", Pal::AsicRevision::Navi44},
     {12, 0, 1, Pal::GfxIpLevel::GfxIp12, "gfx1201", Pal::AsicRevision::Navi48},
 };
 

--- a/projects/clr/rocclr/device/pal/palsettings.cpp
+++ b/projects/clr/rocclr/device/pal/palsettings.cpp
@@ -161,6 +161,7 @@ bool Settings::create(const Pal::DeviceProperties& palProp,
 
   switch (palProp.revision) {
     // Fall through for Navi4x ...
+    case Pal::AsicRevision::Navi44:
     case Pal::AsicRevision::Navi48:
     // Fall through for Navi3x ...
     case Pal::AsicRevision::Navi33:


### PR DESCRIPTION
## Motivation
Navi44 is not detected correctly. This patch and PAL fixes required to detect Navi44 correctly

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Navi44 is not detected correctly. This patch and PAL fixes required to detect Navi44 correctly

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
hipInfo and  test with simple kernel ion Navi44 windows
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
N/A

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
