### PR TITLE
SWDEV-554626 - return hipErrorInvalidDeviceFunction when module is nullptr

### DIFF
--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -393,12 +393,18 @@ hipError_t StatCO::getStatFunc(hipFunction_t* hfunc, const void* hostFunction, i
 
   // Lazy load
   FatBinaryInfo** module = it->second->moduleInfo();
-  if (*(module) == nullptr) {
+  if (module != nullptr) {
     amd::ScopedLock lock(sclock_);
     if (*(module) == nullptr) {
       hipError_t err = digestFatBinary(module_to_hostModule_[module], *module);
       assert(err == hipSuccess);
+      if (err != hipSuccess) {
+        return err;
+      }
     }
+  } else {
+    // Module was nullptr
+    return hipErrorInvalidDeviceFunction;
   }
 
   return it->second->getStatFunc(hfunc, deviceId);


### PR DESCRIPTION
## Motivation

When user loads module for a different gfx arch type, the function should return `hipErrorInvalidDeviceFunction`.

## Technical Details

This was raised by math lib folks, where the runtime would segfault on mismatching gfx arch type. Ideally we should return a correct error code. Also the original condition was duplicate, there were two module checks.

## Test Plan

No testing required.

## Test Result

No testing required.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
