### PR TITLE
Add bounds checks in transpose_a for both load and store so edge tile…

### DIFF
--- a/projects/rocprofiler-systems/examples/transpose/transpose.cpp
+++ b/projects/rocprofiler-systems/examples/transpose/transpose.cpp
@@ -85,13 +85,18 @@ transpose_a(int* in, int* out, int M, int N)
 {
     __shared__ int tile[TILE_DIM][TILE_DIM];
 
-    int idx = (blockIdx.y * blockDim.y + threadIdx.y) * M + blockIdx.x * blockDim.x +
-              threadIdx.x;
-    tile[threadIdx.y][threadIdx.x] = in[idx];
+    int tx = threadIdx.x, ty = threadIdx.y;
+    int x = blockIdx.x * TILE_DIM + tx;
+    int y = blockIdx.y * TILE_DIM + ty;
+
+    int v = 0;
+    if(x < M && y < N) v = in[y * M + x];  // guarded load
+    tile[ty][tx] = v;
     __syncthreads();
-    idx = (blockIdx.x * blockDim.x + threadIdx.y) * N + blockIdx.y * blockDim.y +
-          threadIdx.x;
-    out[idx] = tile[threadIdx.x][threadIdx.y];
+
+    int xt = blockIdx.y * TILE_DIM + tx;
+    int yt = blockIdx.x * TILE_DIM + ty;
+    if(xt < N && yt < M) out[yt * N + xt] = tile[tx][ty];  // guarded store
 }
 
 namespace


### PR DESCRIPTION
…s dont read/write past MxN

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Prevent out-of-bounds (OOB) accesses at tile edges when M/N aren’t exact multiples of TILE_DIM and makes the sample robust across sizes and driver settings.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Add guarded load and store in transpose_a

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Build: ctest --test-dir ./build/debug -V -R transpose-sampling
in mi300 and navi

## Test Result

<!-- Briefly summarize test outcomes. -->
<img width="758" height="333" alt="image" src="https://github.com/user-attachments/assets/a2c5fc86-875a-4139-9dfe-2194027e655e" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
