### PR TITLE
Split profile_general_misc tests

### DIFF
--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -241,6 +241,20 @@ add_test(
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 add_test(
+    NAME test_profile_path
+    COMMAND ${Python3_EXECUTABLE} -m pytest -m path --junitxml=tests/test_profile_path.xml
+            ${COV_OPTION} ${PROJECT_SOURCE_DIR}/tests/test_profile_general.py
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+
+add_test(
+    NAME test_profile_roofline
+    COMMAND
+        ${Python3_EXECUTABLE} -m pytest -m roofline
+        --junitxml=tests/test_profile_roofline.xml ${COV_OPTION}
+        ${PROJECT_SOURCE_DIR}/tests/test_profile_general.py
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+
+add_test(
     NAME test_profile_section
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -m section
@@ -265,9 +279,15 @@ add_test(
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 set_tests_properties(
-    test_profile_kernel_execution test_profile_dispatch test_profile_mem test_profile_join
-    test_profile_sort test_profile_misc PROPERTIES LABELS "profile" RESOURCE_GROUPS
-                                                   gpus:1)
+    test_profile_kernel_execution
+    test_profile_dispatch
+    test_profile_mem
+    test_profile_join
+    test_profile_sort
+    test_profile_misc
+    test_profile_path
+    test_profile_roofline
+    PROPERTIES LABELS "profile" RESOURCE_GROUPS gpus:1)
 
 # ---------------------------
 # analysis command tests
@@ -367,6 +387,8 @@ if(${ENABLE_COVERAGE})
         test_profile_join
         test_profile_sort
         test_profile_misc
+        test_profile_path
+        test_profile_roofline
         test_profile_section
         test_profile_sets_func
         test_analyze_commands

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -556,7 +556,7 @@ def validate(test_name, workload_dir, file_dict, args=[]):
 # --
 
 
-@pytest.mark.misc
+@pytest.mark.path
 def test_path(binary_handler_profile_rocprof_compute):
     workload_dir = test_utils.get_output_dir()
     binary_handler_profile_rocprof_compute(config, workload_dir)
@@ -588,7 +588,7 @@ def test_path(binary_handler_profile_rocprof_compute):
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
-@pytest.mark.misc
+@pytest.mark.path
 def test_path_rocpd(
     binary_handler_profile_rocprof_compute, binary_handler_analyze_rocprof_compute
 ):
@@ -608,7 +608,7 @@ def test_path_rocpd(
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
-@pytest.mark.misc
+@pytest.mark.roofline
 def test_roof_kernel_names(binary_handler_profile_rocprof_compute):
     if soc in ("MI100"):
         # roofline is not supported on MI100
@@ -645,7 +645,7 @@ def test_roof_kernel_names(binary_handler_profile_rocprof_compute):
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
-@pytest.mark.misc
+@pytest.mark.roofline
 def test_roof_multiple_data_types(binary_handler_profile_rocprof_compute):
     """Test roofline with multiple data types"""
     if soc in ("MI100"):
@@ -688,7 +688,7 @@ def test_roof_multiple_data_types(binary_handler_profile_rocprof_compute):
             test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
-@pytest.mark.misc
+@pytest.mark.roofline
 def test_roof_invalid_data_type(binary_handler_profile_rocprof_compute):
     """Test roofline with invalid data type"""
     if soc in ("MI100"):
@@ -718,7 +718,7 @@ def test_roof_invalid_data_type(binary_handler_profile_rocprof_compute):
         test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
-@pytest.mark.misc
+@pytest.mark.roofline
 def test_roof_file_validation(binary_handler_profile_rocprof_compute):
     """Test file validation paths in roofline"""
     if soc in ("MI100"):
@@ -747,7 +747,7 @@ def test_roof_file_validation(binary_handler_profile_rocprof_compute):
         test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
-@pytest.mark.misc
+@pytest.mark.roofline
 def test_roof_rocpd(binary_handler_profile_rocprof_compute):
     if soc == "MI100":
         pytest.skip("Roofline not supported on MI100")
@@ -793,7 +793,7 @@ def test_analyze_rocpd(
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
-@pytest.mark.misc
+@pytest.mark.roofline
 def test_roofline_workload_dir_not_set_error():
     """
     Test roof_setup() error: "Workload directory is not set. Cannot perform setup."
@@ -852,7 +852,7 @@ def test_roofline_workload_dir_not_set_error():
         pytest.skip("Could not import roofline module for direct testing")
 
 
-@pytest.mark.misc
+@pytest.mark.roofline
 def test_roof_workload_dir_validation(binary_handler_profile_rocprof_compute):
     if soc in ("MI100"):
         assert True
@@ -876,7 +876,7 @@ def test_roof_workload_dir_validation(binary_handler_profile_rocprof_compute):
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
-@pytest.mark.misc
+@pytest.mark.roofline
 def test_roofline_empty_kernel_names_handling(binary_handler_profile_rocprof_compute):
     """
     Test empirical_roofline() when num_kernels == 0
@@ -903,7 +903,7 @@ def test_roofline_empty_kernel_names_handling(binary_handler_profile_rocprof_com
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
-@pytest.mark.misc
+@pytest.mark.roofline
 def test_roofline_kernel_filter(binary_handler_profile_rocprof_compute):
     """
     Test roofline multi-attempt profiling with `--kernel`
@@ -942,7 +942,7 @@ def test_roofline_kernel_filter(binary_handler_profile_rocprof_compute):
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
-@pytest.mark.misc
+@pytest.mark.roofline
 def test_roofline_unsupported_datatype_error(binary_handler_profile_rocprof_compute):
     """
     Test datatype validation error in empirical_roofline()
@@ -968,7 +968,7 @@ def test_roofline_unsupported_datatype_error(binary_handler_profile_rocprof_comp
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
-@pytest.mark.misc
+@pytest.mark.roofline
 def test_roof_plot_modes(binary_handler_profile_rocprof_compute):
     if soc in ("MI100"):
         assert True
@@ -1016,7 +1016,7 @@ def test_roof_plot_modes(binary_handler_profile_rocprof_compute):
         test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
-@pytest.mark.misc
+@pytest.mark.roofline
 def test_roof_cli_plot_generation(binary_handler_profile_rocprof_compute):
     if soc in ("MI100"):
         assert True
@@ -1042,7 +1042,7 @@ def test_roof_cli_plot_generation(binary_handler_profile_rocprof_compute):
         pytest.skip("plotext not available for CLI testing")
 
 
-@pytest.mark.misc
+@pytest.mark.roofline
 def test_roof_error_handling(binary_handler_profile_rocprof_compute):
     if soc in ("MI100"):
         assert True
@@ -1062,7 +1062,7 @@ def test_roof_error_handling(binary_handler_profile_rocprof_compute):
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
-@pytest.mark.misc
+@pytest.mark.roofline
 def test_roofline_missing_file_handling(binary_handler_profile_rocprof_compute):
     """
     Test handling of missing roofline.csv file
@@ -1116,7 +1116,7 @@ def test_roofline_missing_file_handling(binary_handler_profile_rocprof_compute):
         pytest.skip("Could not import roofline module for direct testing")
 
 
-@pytest.mark.misc
+@pytest.mark.roofline
 def test_roofline_invalid_datatype_cli(binary_handler_profile_rocprof_compute):
     """
     Test CLI plot generation with invalid datatype
@@ -1168,7 +1168,7 @@ def test_roofline_invalid_datatype_cli(binary_handler_profile_rocprof_compute):
         pytest.skip("Could not import roofline module for direct testing")
 
 
-@pytest.mark.misc
+@pytest.mark.roofline
 def test_roofline_ceiling_data_validation(binary_handler_profile_rocprof_compute):
     """
     Test ceiling data validation in generate_plot()
@@ -1763,7 +1763,7 @@ def test_list_available_metrics_with_block(
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
-@pytest.mark.misc
+@pytest.mark.path
 def test_comprehensive_error_paths():
     """Simplified test for error path coverage"""
     import sys


### PR DESCRIPTION
## Motivation

The tests are failing as the cumulative execution time of the tests is more than the timeout.  This PR aims to fix the failing tests and concurrently improve parallel run time of the tests.

## Technical Details

- [X] Split profile_general_misc into profile_general_misc, profile_general_path and profile_general_roofline.

## Test Plan

- [X] Run the above-mentioned tests

## Test Result

- [X] Passing on MI308
- [ ] Waiting for MI250 slot

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
