### PR TITLE
add skip for windows ci

### DIFF
--- a/.azuredevops/rocm_ci_caller.yml
+++ b/.azuredevops/rocm_ci_caller.yml
@@ -50,15 +50,22 @@ jobs:
         cat ../changed_files.txt
 
         MATCH_FOUND=false
+        WINDOWS_SKIP=true
         while read file; do
           if [[ "$file" == projects/* ]]; then
             MATCH_FOUND=true
+          fi
+          if [[ "$file" == projects/clr/* || "$file" == projects/hip/* || "$file" == projects/hip-tests/* ]]; then
+            WINDOWS_SKIP=false
+          fi
+          if [[ "$MATCH_FOUND" == true && "$WINDOWS_SKIP" == false ]]; then
             break
           fi
         done < ../changed_files.txt
 
         echo "Match found: $MATCH_FOUND"
         echo "##vso[task.setvariable variable=match_found;isOutput=true]$MATCH_FOUND"
+        echo "##vso[task.setvariable variable=windows_skip;isOutput=true]$WINDOWS_SKIP"
       name: detectChanges
       displayName: Detect path changes
 
@@ -69,6 +76,7 @@ jobs:
   pool: rocm-ci-caller
   variables:
     match_found: $[ dependencies.Determine_Changes.outputs['detectChanges.match_found'] ]
+    windows_skip: $[ dependencies.Determine_Changes.outputs['detectChanges.windows_skip'] ]
   steps:
     - checkout: none
     
@@ -76,6 +84,21 @@ jobs:
         echo "DEBUG: match_found = '$(match_found)'"
       displayName: 'Debug match_found variable'
 
+    - script: |
+        echo "DEBUG: windows_skip = '$(windows_skip)'"
+      displayName: 'Debug windows_skip variable'
+
+    - script: |
+        echo "Changes outside monitored paths (clr, hip, hip-tests). Skipping WindowsCI - Internal."
+        echo "Sending success status for WindowsCI - Internal..."
+        export GH_TOKEN=$(GH_PAT)
+        gh api repos/$(REPOSITORY_NAME)/statuses/$(HEAD_SHA) \
+          -f state=success \
+          -f context="WindowsCI - Internal" \
+          -f description="Windows PSDB skipped"
+      displayName: 'Skip WindowsCI - Internal'
+      condition: eq(variables.windows_skip, 'true')
+    
     - script: |
         rm -rf $(repo_name)
         git clone $(gh_repo)


### PR DESCRIPTION
## Motivation
Add skips to Windows CI - Internal psdb for projects outside the test scope. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Testing CI in azure pipeline to ensure Windows skips work correctly

## Test Result
without relevant change (commenting out remaining steps): https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=51626&view=logs&j=d0304905-36c6-5697-a713-8fc746d23d63&t=1eaf7665-6bcb-5e03-7961-822ff63eb6a5 (`Skip WindowsCI - Internal` step is run)
<img width="1376" height="699" alt="image" src="https://github.com/user-attachments/assets/0211815d-7f2a-4d27-b2f2-3061dabf91a3" />

With relevant change (commenting out remaining steps): https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=51630&view=logs&jobId=d0304905-36c6-5697-a713-8fc746d23d63&j=d0304905-36c6-5697-a713-8fc746d23d63&t=1eaf7665-6bcb-5e03-7961-822ff63eb6a5 (`Skip WindowsCI - Internal` step is skipped)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
