### PR TITLE
[DRAFT] Replacing build-docker-ci.sh/build-docker.sh scripts with docker/build-push-action@6

### DIFF
--- a/.github/workflows/rocprofiler-systems-containers.yml
+++ b/.github/workflows/rocprofiler-systems-containers.yml
@@ -34,12 +34,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          sparse-checkout: projects/rocprofiler-systems
+          sparse-checkout: projects/rocprofiler-systems/docker
 
       - name: Output data for containers matrix
+        working-directory: projects/rocprofiler-systems/docker
         id: generate_matrix_ci
         run: |
-          pushd projects/rocprofiler-systems/docker
           MATRIX_CONTENT=$(cat containers-ci.yml | yq '.matrix' -I=0 -o=json)
           echo "matrix_data=$MATRIX_CONTENT" >> $GITHUB_OUTPUT
 
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          sparse-checkout: projects/rocprofiler-systems
+          sparse-checkout: projects/rocprofiler-systems/docker
           submodules: recursive
 
       - name: Set up QEMU
@@ -70,31 +70,40 @@ jobs:
           username: ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }}
           password: ${{ secrets.ROCPROF_SYS_DOCKER_TOKEN }}
 
-      - name: Build CI Container (PR - No Push)
-        if: github.event_name == 'pull_request'
-        timeout-minutes: 45
-        uses: nick-fields/retry@v3
+      - name: Set up Docker variables
+        id: setup_vars
+        run: |
+          if [ ${{ matrix.distro }} = "opensuse" ]; then
+            DISTRO_IMAGE="opensuse/leap"
+          elif [ ${{ matrix.distro }} = "rhel" ]; then
+            DISTRO_IMAGE="rockylinux/rockylinux"
+          else
+            DISTRO_IMAGE=${{ matrix.distro }}
+          fi
+          echo "distro_image=${DISTRO_IMAGE}" >> $GITHUB_OUTPUT
+
+          if [ ${{ matrix.distro }} = "debian" ]; then
+            DOCKER_FILE=Dockerfile.ubuntu.ci
+          else
+            DOCKER_FILE=Dockerfile.${{ matrix.distro }}.ci
+          fi
+          echo "docker_file=${DOCKER_FILE}" >> $GITHUB_OUTPUT
+
+      - name: Build & Push (to Docker Hub; cache to GHA)
+        uses: docker/build-push-action@6
         with:
-          retry_wait_seconds: 60
-          timeout_minutes: 45
-          max_attempts: 3
-          command: |
-            pushd projects/rocprofiler-systems/docker
-            ./build-docker-ci.sh --distro ${{ matrix.distro }} --versions ${{ matrix.version }} --user ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }} --jobs 2 --elfutils-version 0.188 --boost-version 1.79.0
-            popd
-      
-      - name: Build CI Container (Push)
-        if: github.event_name != 'pull_request'
-        timeout-minutes: 45
-        uses: nick-fields/retry@v3
-        with:
-          retry_wait_seconds: 60
-          timeout_minutes: 45
-          max_attempts: 3
-          command: |
-            pushd projects/rocprofiler-systems/docker
-            ./build-docker-ci.sh --distro ${{ matrix.distro }} --versions ${{ matrix.version }} --user ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }} --push --jobs 2 --elfutils-version 0.188 --boost-version 1.79.0
-            popd
+          file: projects/rocprofiler-systems/docker/${{ steps.setup_vars.outputs.docker_file }}
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          build-args: |
+            DISTRO=${{ steps.setup_vars.outputs.distro_image }}
+            VERSION=${{ matrix.version }}
+            NJOBS=2
+            PYTHON_VERSIONS="6 7 8 9 10 11 12 13"
+            ELFUTILS_DOWNLOAD_VERSION=0.188
+            BOOST_DOWNLOAD_VERSION=1.79.0
+          tags: |
+            ${{ secrets.ROCPROF_SYS_DOCKER_LOGIN }}/rocprofiler-systems:ci-base-${{ matrix.distro }}-${{ matrix.version }}
 
   prepare_matrix_release:
     if: github.repository == 'ROCm/rocm-systems'
@@ -105,12 +114,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          sparse-checkout: projects/rocprofiler-systems
+          sparse-checkout: projects/rocprofiler-systems/docker
 
       - name: Output data for containers matrix
+        working-directory: projects/rocprofiler-systems/docker
         id: generate_matrix_release
         run: |
-          pushd projects/rocprofiler-systems/docker
           MATRIX_CONTENT=$(cat containers.yml | yq '.matrix' -I=0 -o=json)
           echo "matrix_data=$MATRIX_CONTENT" >> $GITHUB_OUTPUT
           

--- a/.github/workflows/rocprofiler-systems-containers.yml
+++ b/.github/workflows/rocprofiler-systems-containers.yml
@@ -90,7 +90,7 @@ jobs:
           echo "docker_file=${DOCKER_FILE}" >> $GITHUB_OUTPUT
 
       - name: Build CI Container (Does not Push on PR)
-        uses: docker/build-push-action@6
+        uses: docker/build-push-action@v6
         with:
           file: projects/rocprofiler-systems/docker/${{ steps.setup_vars.outputs.docker_file }}
           platforms: linux/amd64

--- a/.github/workflows/rocprofiler-systems-containers.yml
+++ b/.github/workflows/rocprofiler-systems-containers.yml
@@ -99,7 +99,6 @@ jobs:
             DISTRO=${{ steps.setup_vars.outputs.distro_image }}
             VERSION=${{ matrix.version }}
             NJOBS=2
-            PYTHON_VERSIONS="6 7 8 9 10 11 12 13"
             ELFUTILS_DOWNLOAD_VERSION=0.188
             BOOST_DOWNLOAD_VERSION=1.79.0
           tags: |

--- a/.github/workflows/rocprofiler-systems-containers.yml
+++ b/.github/workflows/rocprofiler-systems-containers.yml
@@ -89,7 +89,7 @@ jobs:
           fi
           echo "docker_file=${DOCKER_FILE}" >> $GITHUB_OUTPUT
 
-      - name: Build & Push (to Docker Hub; cache to GHA)
+      - name: Build CI Container (Does not Push on PR)
         uses: docker/build-push-action@6
         with:
           file: projects/rocprofiler-systems/docker/${{ steps.setup_vars.outputs.docker_file }}


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Refactor `rocprofiler-systems-containers.yml` to utilize `docker/build-push-action@6` instead of the `build-docker.sh` scripts.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
