### PR TITLE
SWDEV-548417 - Fix Memleaks in Graph

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -802,6 +802,7 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
   ~GraphExec() {
     for (auto stream : parallel_streams_) {
       if (stream != nullptr) {
+        stream->finish();
         constexpr bool kForceDestroy = true;
         hip::Stream::Destroy(stream, kForceDestroy);
       }


### PR DESCRIPTION

## Motivation
Fix Graph Memory leaks

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Command enqueued on the graph internal stream are not released add stream during graphExec release

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Run valgrind on the failing tests.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Ran valgrind on the failing tests in the ticket all the tests report 0 leaks with the patch.

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
