### PR TITLE
[rocprofiler-compute] Update grafana deprecation message

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -415,7 +415,7 @@ class RocProfCompute:
 
         console_warning(
             "Database update mode is deprecated and will "
-            "be removed in a future release "
+            "be removed in ROCm 7.2 "
             "and no fixes will be made for this mode."
         )
 


### PR DESCRIPTION
## Motivation

The grafana UI mode of analysis must be removed eventually in ROCm 7.2, including proper documentation in ROCm 7.1

## Technical Details

Adds specific ROCm 7.2 version information to the deprecation warning message

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
