### PR TITLE
SWDEV-554174 Added hipHostRegisterIoMemory flag to test cases

### DIFF
--- a/projects/hip-tests/catch/unit/memory/hipFree.cc
+++ b/projects/hip-tests/catch/unit/memory/hipFree.cc
@@ -173,7 +173,8 @@ TEST_CASE("Unit_hipFreeNegativeHost") {
   }
   SECTION("hipHostRegister") {
     char* hostPtr = new char;
-    auto flag = GENERATE(hipHostRegisterDefault, hipHostRegisterPortable, hipHostRegisterMapped);
+    auto flag = GENERATE(hipHostRegisterDefault, hipHostRegisterPortable,
+                         hipHostRegisterMapped, hipHostRegisterIoMemory);
     HIP_CHECK(hipHostRegister((void*)hostPtr, sizeof(char), flag));
     HIP_CHECK_ERROR(hipHostFree(hostPtr), hipErrorInvalidValue);
     delete hostPtr;

--- a/projects/hip-tests/catch/unit/memory/hipFreeHost.cc
+++ b/projects/hip-tests/catch/unit/memory/hipFreeHost.cc
@@ -44,7 +44,8 @@ TEST_CASE("Unit_hipFreeHost_InvalidMemory") {
 
   SECTION("Host registered memory") {
     char* ptr = new char;
-    auto flag = GENERATE(hipHostRegisterDefault, hipHostRegisterPortable, hipHostRegisterMapped);
+    auto flag = GENERATE(hipHostRegisterDefault, hipHostRegisterPortable,
+                         hipHostRegisterMapped, hipHostRegisterIoMemory);
 
     HIP_CHECK(hipHostRegister(ptr, sizeof(char), flag));
     HIP_CHECK_ERROR(hipFreeHost(ptr), hipErrorInvalidValue);

--- a/projects/hip-tests/catch/unit/memory/hipHostFree.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostFree.cc
@@ -44,7 +44,8 @@ TEST_CASE("Unit_hipHostFree_InvalidMemory") {
   SECTION("Host registered memory") {
     const size_t ptr_size = 1024;
     char* ptr = new char[ptr_size];
-    auto flag = GENERATE(hipHostRegisterDefault, hipHostRegisterPortable, hipHostRegisterMapped);
+    auto flag = GENERATE(hipHostRegisterDefault, hipHostRegisterPortable,
+		         hipHostRegisterMapped, hipHostRegisterIoMemory);
 
     HIP_CHECK(hipHostRegister(ptr, ptr_size, flag));
     HIP_CHECK_ERROR(hipHostFree(ptr), hipErrorInvalidValue);

--- a/projects/hip-tests/catch/unit/memory/hipHostFree.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostFree.cc
@@ -45,7 +45,7 @@ TEST_CASE("Unit_hipHostFree_InvalidMemory") {
     const size_t ptr_size = 1024;
     char* ptr = new char[ptr_size];
     auto flag = GENERATE(hipHostRegisterDefault, hipHostRegisterPortable,
-		         hipHostRegisterMapped, hipHostRegisterIoMemory);
+                         hipHostRegisterMapped, hipHostRegisterIoMemory);
 
     HIP_CHECK(hipHostRegister(ptr, ptr_size, flag));
     HIP_CHECK_ERROR(hipHostFree(ptr), hipErrorInvalidValue);

--- a/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
@@ -121,10 +121,11 @@ TEMPLATE_TEST_CASE("Unit_hipHostRegister_ReferenceFromKernelandhipMemset", "", i
   SECTION("hipExtHostRegisterUncached") {
     HIP_CHECK(hipHostRegister(A, sizeBytes, hipExtHostRegisterUncached));
   }
-  SECTION("hipHostRegisterPortable | hipHostRegisterMapped | hipExtHostRegisterUncached") {
+  SECTION("hipHostRgstrPortable|hipHostRgstrMapped|hipExtHostRgstrUncached|hipHostRgstrIoMemory") {
     HIP_CHECK(hipHostRegister(
         A, sizeBytes,
-        hipHostRegisterPortable | hipHostRegisterMapped | hipExtHostRegisterUncached));
+        hipHostRegisterPortable | hipHostRegisterMapped | hipExtHostRegisterUncached | 
+        hipHostRegisterIoMemory));
   }
 #endif
   for (int i = 0; i < LEN; i++) {
@@ -170,7 +171,8 @@ TEMPLATE_TEST_CASE("Unit_hipHostRegister_ReferenceFromKernelandhipMemset", "", i
  *    - HIP_VERSION >= 5.6
  */
 TEMPLATE_TEST_CASE("Unit_hipHostRegister_DirectReferenceFromKernel", "", int, float, double) {
-  auto flags = GENERATE(hipHostRegisterDefault, hipHostRegisterPortable, hipHostRegisterMapped);
+  auto flags = GENERATE(hipHostRegisterDefault, hipHostRegisterPortable, hipHostRegisterMapped,
+                        hipHostRegisterIoMemory);
   // Execute the test only if xnack is supported
   hipDeviceProp_t prop;
   HIP_CHECK(hipGetDeviceProperties(&prop, 0));

--- a/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
@@ -121,7 +121,8 @@ TEMPLATE_TEST_CASE("Unit_hipHostRegister_ReferenceFromKernelandhipMemset", "", i
   SECTION("hipExtHostRegisterUncached") {
     HIP_CHECK(hipHostRegister(A, sizeBytes, hipExtHostRegisterUncached));
   }
-  SECTION("hipHostRgstrPortable|hipHostRgstrMapped|hipExtHostRgstrUncached|hipHostRgstrIoMemory") {
+  SECTION("hipHostRegisterPortable | hipHostRegisterMapped | "
+          "hipExtHostRegisterUncached | hipHostRegisterIoMemory") {
     HIP_CHECK(hipHostRegister(
         A, sizeBytes,
         hipHostRegisterPortable | hipHostRegisterMapped | hipExtHostRegisterUncached | 


### PR DESCRIPTION
## Motivation
Unit test cases for  hipHostRegister api with hipHostRegisterIoMemory  flag support
## Technical Details
hipHostRegisterIoMemory will now create uncached memory

## Test Plan
Added test cases to a flags test to ensure this flag is valid and works
## Test Result
Test cases will pass with new flag hipHostRegisterIoMemory

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
