### PR TITLE
SWDEV-555296 - Fix and enable Unit_hipEventIpc

### DIFF
--- a/projects/hip-tests/catch/hipTestMain/config/config_amd_linux
+++ b/projects/hip-tests/catch/hipTestMain/config/config_amd_linux
@@ -25,7 +25,6 @@
         "Unit_hipStreamPerThread_MultiThread",
         "SWDEV-398981 fails in stress test",
         "Unit_hipStreamCreateWithPriority_MulthreadDefaultflag",
-        "Unit_hipEventIpc",
         "=== Below 2 tests are disable due to defect EXSWHTEC-356 ===",
         "Unit_Device___hisinf2_Accuracy_Positive",
         "Unit_Device___hisnan2_Accuracy_Positive",

--- a/projects/hip-tests/catch/unit/event/Unit_hipEventIpc.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEventIpc.cc
@@ -115,7 +115,7 @@ TEST_CASE("Unit_hipEventIpc") {
 #endif
   HIP_CHECK(hipEventDestroy(start));
   HIP_CHECK(hipEventDestroy(stop));
-#if HT_AMD
+#if HT_WIN
   HIP_CHECK(hipEventDestroy(ipc_event));
 #endif
   HIP_CHECK(hipMemcpy(C_h, C_d, Nbytes, hipMemcpyDeviceToHost));


### PR DESCRIPTION
## Motivation

Fix and enable Unit_hipEventIpc test

## Technical Details

Since hipIpcOpenEventHandle succeeds only on Windows, it should be destroyed only on Windows and not on Linux.

## Test Plan

/

## Test Result

/

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
