### PR TITLE
SWDEV-543723 - Change agentInfo parameter in hostAlloc to void*

### DIFF
--- a/projects/clr/rocclr/device/pal/paldevice.hpp
+++ b/projects/clr/rocclr/device/pal/paldevice.hpp
@@ -539,7 +539,7 @@ class Device : public NullDevice {
 
   //! host memory alloc
   virtual void* hostAlloc(size_t size, size_t alignment, MemorySegment mem_seg = kNoAtomics,
-                          const void* agentInfo = nullptr) const;
+                          const void* agentInfo = nullptr) const override;
 
   //! SVM allocation
   virtual void* svmAlloc(amd::Context& context, size_t size, size_t alignment,

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -2007,13 +2007,14 @@ hsa_amd_memory_pool_t Device::getHostMemoryPool(MemorySegment mem_seg,
 
 // ================================================================================================
 void* Device::hostAlloc(size_t size, size_t alignment, MemorySegment mem_seg,
-                        const AgentInfo* agentInfo) const {
+                        const void* agentInfo) const {
   void* ptr = nullptr;
   uint32_t memFlags = 0;
   if (mem_seg == kKernArg) {
     memFlags |= HSA_AMD_MEMORY_POOL_EXECUTABLE_FLAG;
   }
-  hsa_amd_memory_pool_t pool = getHostMemoryPool(mem_seg, agentInfo);
+  hsa_amd_memory_pool_t pool =
+      getHostMemoryPool(mem_seg, static_cast<const amd::roc::AgentInfo*>(agentInfo));
   hsa_status_t stat = hsa_amd_memory_pool_allocate(pool, size, memFlags, &ptr);
   ClPrint(amd::LOG_DEBUG, amd::LOG_MEM,
           "Allocate hsa host memory %p, size 0x%zx,"

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -414,7 +414,7 @@ class Device : public NullDevice {
   virtual bool globalFreeMemory(size_t* freeMemory) const;
   virtual void* hostAlloc(size_t size, size_t alignment,
                           MemorySegment mem_seg = MemorySegment::kNoAtomics,
-                          const AgentInfo* agentInfo = nullptr) const;  // nullptr uses default CPU agent
+                          const void* agentInfo = nullptr) const override;  // nullptr uses default CPU agent
   virtual void hostFree(void* ptr, size_t size = 0) const;
 
   bool deviceAllowAccess(void* dst) const;


### PR DESCRIPTION
## Motivation
Fix a regression after https://github.com/ROCm/rocm-systems/pull/728
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
After change https://github.com/ROCm/rocm-systems/pull/728 the hostAlloc argument expects a default argument of type AgentInfo* in rocdevice but in the base device class the default argument is defined as void* type. As a result when the caller does not provide an argument for that parameter, like in GraphKernelArgManager::AllocGraphKernargPool it will end up calling the hostAlloc function in the base device class that is an error. 

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Graph tests should not longer fail in hipGraphInstantiate and should now finish successfully
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Graph tests finish successfully.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
