### PR TITLE
[rocprofiler-compute] improve profile options

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -59,7 +59,7 @@ from utils.utils import (
 
 class RocProfCompute:
     def __init__(self) -> None:
-        self.__args: argparse.Namespace
+        self.__args: Optional[argparse.Namespace] = None
         self.__profiler_mode = None
         self.__analyze_mode = None
         self.__soc: dict[str, OmniSoC_Base] = {}

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -215,9 +215,9 @@ class RocProfCompute:
 
     def handle_profile_args(self) -> None:
         # Handle list operations first - these are independent and exit immediately
-        if getattr(self.__args, 'list_sets', False):
+        if getattr(self.__args, "list_sets", False):
             return
-        if getattr(self.__args, 'list_available_metrics', False):
+        if getattr(self.__args, "list_available_metrics", False):
             return
 
         # Add --name to workload path if --path is not given
@@ -234,7 +234,9 @@ class RocProfCompute:
                 self.__args.path = str(Path(self.__args.path) / self.__mspec.gpu_model)
             else:
                 self.__args.path = str(Path(self.__args.path) / self.__args.name)
-                console_warning(f"No gpu model found, using default path: {self.__args.path}")
+                console_warning(
+                    f"No gpu model found, using default path: {self.__args.path}"
+                )
 
         # Create workload directory if it does not exist
         p = Path(self.__args.path)
@@ -466,13 +468,18 @@ class RocProfCompute:
             base_path = path_list[0] if isinstance(path_list, list) else path_list
 
             # Determine sysinfo path
-            if analyzer.get_args().nodes is None and not analyzer.get_args().spatial_multiplexing:
+            if (
+                analyzer.get_args().nodes is None
+                and not analyzer.get_args().spatial_multiplexing
+            ):
                 sysinfo_path = base_path
             else:
                 sysinfo_path = file_io.find_1st_sub_dir(base_path)
 
             sys_info = file_io.load_sys_info(f"{sysinfo_path}/sysinfo.csv")
-            sys_info_dict = {key: value[0] for key, value in sys_info.to_dict("list").items()}
+            sys_info_dict = {
+                key: value[0] for key, value in sys_info.to_dict("list").items()
+            }
             self.load_soc_specs(sys_info_dict)
 
         analyzer.set_soc(self.__soc)

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -59,7 +59,7 @@ from utils.utils import (
 
 class RocProfCompute:
     def __init__(self) -> None:
-        self.__args: Optional[argparse.Namespace] = None
+        self.__args: argparse.Namespace
         self.__profiler_mode = None
         self.__analyze_mode = None
         self.__soc: dict[str, OmniSoC_Base] = {}
@@ -214,6 +214,12 @@ class RocProfCompute:
             self.handle_analyze_args()
 
     def handle_profile_args(self) -> None:
+        # Handle list operations first - these are independent and exit immediately
+        if getattr(self.__args, 'list_sets', False):
+            return
+        if getattr(self.__args, 'list_available_metrics', False):
+            return
+
         # Add --name to workload path if --path is not given
         if self.__args.path == str(Path.cwd() / "workloads"):
             if not hasattr(self.__args, "name") or not self.__args.name:
@@ -224,7 +230,11 @@ class RocProfCompute:
             self.__args.path = str(Path(self.__args.path) / socket.gethostname())
         # Or, add gpu model name to workload path
         elif self.__args.subpath == "gpu_model":
-            self.__args.path = str(Path(self.__args.path) / self.__mspec.gpu_model)
+            if self.__mspec.gpu_model:
+                self.__args.path = str(Path(self.__args.path) / self.__mspec.gpu_model)
+            else:
+                self.__args.path = str(Path(self.__args.path) / self.__args.name)
+                console_warning(f"No gpu model found, using default path: {self.__args.path}")
 
         # Create workload directory if it does not exist
         p = Path(self.__args.path)
@@ -245,14 +255,7 @@ class RocProfCompute:
 
     @demarcate
     def list_metrics(self) -> None:
-        self.load_soc_specs()
-
-        for_current_arch = False
-        if (
-            hasattr(self.__args, "list_available_metrics")
-            and self.__args.list_available_metrics
-        ):
-            for_current_arch = True
+        for_current_arch = getattr(self.__args, "list_available_metrics", False)
 
         arch = (
             self.__mspec.gpu_arch
@@ -262,21 +265,15 @@ class RocProfCompute:
         if arch in self.__supported_archs.keys():
             ac = schema.ArchConfig()
             ac.panel_configs = file_io.load_panel_configs([
-                Path(self.__args.config_dir) / arch
+                str(Path(self.__args.config_dir) / arch)
             ])
             sys_info = (
                 self.__mspec.get_class_members().iloc[0] if for_current_arch else None
             )
             parser.build_dfs(arch_configs=ac, filter_metrics=[], sys_info=sys_info)
             for key, value in ac.metric_list.items():
-                prefix = ""
-                if "." not in str(key):
-                    prefix = ""
-                elif str(key).count(".") == 1:
-                    prefix = "\t"
-                else:
-                    prefix = "\t\t"
-                print(prefix + key, "->", value)
+                prefix = "\t" * min(key.count("."), 2)
+                print(f"{prefix}{key} -> {value}")
             sys.exit(0)
         else:
             console_error("Unsupported arch")
@@ -465,18 +462,18 @@ class RocProfCompute:
         analyzer.sanitize()
 
         # Load required SoC(s) from input
-        for d in analyzer.get_args().path:
-            sysinfo_path = (
-                Path(d[0])
-                if analyzer.get_args().nodes is None
-                and not analyzer.get_args().spatial_multiplexing
-                else file_io.find_1st_sub_dir(d[0])
-            )
-            sys_info = file_io.load_sys_info(sysinfo_path / "sysinfo.csv")
+        for path_list in analyzer.get_args().path:
+            base_path = path_list[0] if isinstance(path_list, list) else path_list
 
-            sys_info = sys_info.to_dict("list")
-            sys_info = {key: value[0] for key, value in sys_info.items()}
-            self.load_soc_specs(sys_info)
+            # Determine sysinfo path
+            if analyzer.get_args().nodes is None and not analyzer.get_args().spatial_multiplexing:
+                sysinfo_path = base_path
+            else:
+                sysinfo_path = file_io.find_1st_sub_dir(base_path)
+
+            sys_info = file_io.load_sys_info(f"{sysinfo_path}/sysinfo.csv")
+            sys_info_dict = {key: value[0] for key, value in sys_info.to_dict("list").items()}
+            self.load_soc_specs(sys_info_dict)
 
         analyzer.set_soc(self.__soc)
         analyzer.pre_processing()

--- a/projects/rocprofiler-compute/src/rocprof_compute_tui/analysis_tui.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_tui/analysis_tui.py
@@ -42,10 +42,10 @@ from utils.logger import console_error, demarcate
 
 class tui_analysis(OmniAnalyze_Base):
     def __init__(
-        self, args: argparse.Namespace, supported_archs: dict[str, str], path: Path
+        self, args: argparse.Namespace, supported_archs: dict[str, str], path: str
     ) -> None:
         super().__init__(args, supported_archs)
-        self.path = str(path)
+        self.path = path
         self.args = self.get_args()
         self.raw_dfs: dict[str, dict] = {}
 
@@ -114,7 +114,7 @@ class tui_analysis(OmniAnalyze_Base):
         self, normalization_filter: Optional[str] = None
     ) -> OrderedDict[str, schema.Workload]:
         # Load system info and configure
-        sys_info = file_io.load_sys_info(str(Path(self.path) / "sysinfo.csv"))
+        sys_info = file_io.load_sys_info(f"{self.path}/sysinfo.csv")
         arch = sys_info.iloc[0]["gpu_arch"]
 
         self.generate_configs(

--- a/projects/rocprofiler-compute/src/rocprof_compute_tui/views/main_view.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_tui/views/main_view.py
@@ -133,7 +133,7 @@ class MainView(Horizontal):
 
             # 1. Create and TUI analyzer
             analyzer = tui_analysis(
-                self.app.args, self.app.supported_archs, self.selected_path
+                self.app.args, self.app.supported_archs, str(self.selected_path)
             )
             analyzer.sanitize()
 
@@ -142,7 +142,7 @@ class MainView(Horizontal):
             if not sysinfo_path.exists():
                 raise FileNotFoundError(f"sysinfo.csv not found at {sysinfo_path}")
 
-            sys_info = file_io.load_sys_info(sysinfo_path).iloc[0].to_dict()
+            sys_info = file_io.load_sys_info(str(sysinfo_path)).iloc[0].to_dict()
             self.app.load_soc_specs(sys_info)
             analyzer.set_soc(self.app.soc)
 


### PR DESCRIPTION
## Motivation

#710's improvement for profile args (`--name` and `--path`) disabled options `--list-available-metrics` and `--list-sets` because these two options are blocked by the requirement of `--name`/`--path`.

## Technical Details

- Handle `--list-available-metrics` and `--list-sets` options before requiring `--name`/`--path`
- Convert Path objects to strings consistently across the codebase
- Add safety checks for GPU model name resolution

## Test Plan

Manual test.

## Test Result

Manual test passed for:
- [x] `rocprof-compute profile --list-available-metrics`
- [x] `rocprof-compute profile --list-sets`
- [x] `rocprof-compute profile -n <name> -- <workload>`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
