### PR TITLE
[rocprofiler-compute] Update gfx12 counter definitions

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/counter_defs.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/counter_defs.yaml
@@ -1519,10 +1519,12 @@ rocprofiler-sdk:
       - gfx941
       - gfx942
       - gfx950
+      expression: 100*reduce(SQ_LDS_IDX_ACTIVE,sum)/(reduce(GRBM_GUI_ACTIVE,max)*CU_NUM)
+    - architectures:
       - gfx12
       - gfx1200
       - gfx1201
-      expression: 100*reduce(SQ_LDS_IDX_ACTIVE,sum)/(reduce(GRBM_GUI_ACTIVE,max)*CU_NUM)
+      expression: 100*reduce(SQC_LDS_IDX_ACTIVE,sum)/(reduce(GRBM_GUI_ACTIVE,max)*CU_NUM)
   - name: MAX_WAVE_SIZE
     description: Max wave size constant
     properties: []

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/counter_defs.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/counter_defs.yaml
@@ -443,6 +443,9 @@ rocprofiler-sdk:
       - gfx941
       - gfx942
       - gfx950
+      - gfx12
+      - gfx1200
+      - gfx1201
       expression: simd_count/simd_per_cu
   - name: SIMD_NUM
     description: SIMD Number
@@ -467,6 +470,9 @@ rocprofiler-sdk:
       - gfx941
       - gfx942
       - gfx950
+      - gfx12
+      - gfx1200
+      - gfx1201
       expression: simd_count
   - name: CpUtil
     description: 'Unit: percent'
@@ -627,6 +633,9 @@ rocprofiler-sdk:
       - gfx941
       - gfx942
       - gfx950
+      - gfx12
+      - gfx1200
+      - gfx1201
       expression: FETCH_SIZE
   - name: FlatLDSInsts
     description: The average number of FLAT instructions that read or write to LDS executed per work item (affected by flow
@@ -1108,6 +1117,11 @@ rocprofiler-sdk:
       - gfx1101
       - gfx1102
       expression: reduce(GL2C_MC_WRREQ_STALL,max)
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      expression: reduce(GL2C_EA_WRREQ_STALL,max)
   - name: GPUBusy
     description: The percentage of time GPU was busy.
     properties: []
@@ -1127,6 +1141,9 @@ rocprofiler-sdk:
       - gfx906
       - gfx908
       - gfx90a
+      - gfx12
+      - gfx1200
+      - gfx1201
       expression: 100*reduce(GRBM_GUI_ACTIVE,max)/reduce(GRBM_COUNT,max)
   - name: GPU_UTIL
     description: Percentage of the time that GUI is active
@@ -1498,6 +1515,13 @@ rocprofiler-sdk:
     definitions:
     - architectures:
       - gfx90a
+      - gfx940
+      - gfx941
+      - gfx942
+      - gfx950
+      - gfx12
+      - gfx1200
+      - gfx1201
       expression: 100*reduce(SQ_LDS_IDX_ACTIVE,sum)/(reduce(GRBM_GUI_ACTIVE,max)*CU_NUM)
   - name: MAX_WAVE_SIZE
     description: Max wave size constant
@@ -1532,6 +1556,9 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
       expression: reduce(SQ_WAVE_CYCLES,sum)/reduce(SQ_BUSY_CYCLES,sum)
     - architectures:
       - gfx90a
@@ -1549,6 +1576,9 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
       expression: reduce(SQ_WAVE_CYCLES,sum)/reduce(GRBM_GUI_ACTIVE,max)/CU_NUM
     - architectures:
       - gfx10
@@ -1576,6 +1606,9 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
       expression: 100*reduce(SQ_WAVE_CYCLES,sum)/reduce(GRBM_GUI_ACTIVE,max)/CU_NUM/32
     - architectures:
       - gfx90a
@@ -1604,6 +1637,9 @@ rocprofiler-sdk:
       - gfx906
       - gfx908
       - gfx90a
+      - gfx12
+      - gfx1200
+      - gfx1201
       expression: 100*reduce(TA_TA_BUSY,max)/reduce(GRBM_GUI_ACTIVE,max)
   - name: MemUnitStalled
     description: 'The percentage of GPUTime the memory unit is stalled. Try reducing the number or size of fetches and writes
@@ -1742,6 +1778,9 @@ rocprofiler-sdk:
       - gfx906
       - gfx908
       - gfx90a
+      - gfx12
+      - gfx1200
+      - gfx1201
       expression: reduce(SQ_INSTS_SALU,sum)/reduce(SQ_WAVES,sum)
   - name: SE_NUM
     description: SE_NUM
@@ -1766,6 +1805,9 @@ rocprofiler-sdk:
       - gfx941
       - gfx942
       - gfx950
+      - gfx12
+      - gfx1200
+      - gfx1201
       expression: array_count/simd_arrays_per_engine
   - name: SFetchInsts
     description: The average number of scalar fetch instructions from the video memory executed per work-item (affected by
@@ -1786,6 +1828,9 @@ rocprofiler-sdk:
       - gfx906
       - gfx908
       - gfx90a
+      - gfx12
+      - gfx1200
+      - gfx1201
       expression: reduce(SQ_INSTS_SMEM,sum)/reduce(SQ_WAVES,sum)
   - name: SPI_CSN_BUSY
     description: Number of clocks with outstanding waves (SPI or SH). Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source,
@@ -2725,6 +2770,12 @@ rocprofiler-sdk:
       - gfx950
       block: SQ
       event: 271
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 302
   - name: SQC_ICACHE_INPUT_VALID_READYB
     description: ' Input stalled by SQC (per-SQ, nondeterministic, unwindowed)'
     properties: []
@@ -2749,6 +2800,12 @@ rocprofiler-sdk:
       - gfx950
       block: SQ
       event: 272
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 303
   - name: SQC_ICACHE_MISSES_DUPLICATE
     description: Number of misses that were duplicates (access to a non-resident, miss pending CL). (per-SQ, per-Bank, nondeterministic)
     properties: []
@@ -2775,6 +2832,12 @@ rocprofiler-sdk:
       - gfx950
       block: SQ
       event: 270
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      block: SQ
+      event: 301
   - name: SQC_LDS_BANK_CONFLICT
     description: Number of cycles LDS is stalled by bank conflicts. (emulated, C1)
     properties: []
@@ -4343,6 +4406,16 @@ rocprofiler-sdk:
       - gfx1201
       block: SQ
       event: 61
+  - name: SQ_INST_CYCLES_VALU
+    description: Number of cycles needed to execute VALU operations (SIMD cycles), where there is overlapping V_OP32_1 and V_OP32_T instruction, count them seperately.
+    properties: []
+    definitions:
+      - architectures:
+        - gfx12
+        - gfx1200
+        - gfx1201
+        block: SQ
+        event: 99
   - name: SQ_INST_CYCLES_SALU
     description: The number of cycles needed to execute non-memory read scalar operations (SALU). This value is returned on
       a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles).
@@ -5233,6 +5306,16 @@ rocprofiler-sdk:
       - gfx950
       block: SQ
       event: 95
+  - name: SQ_INSTS_VEC32_LEVEL_LDS
+    description: Number of in-flight wave32 LDS (indexed, flat) instructions issued.{level, nondeterministic}
+    properties: []
+    definitions:
+      - architectures:
+        - gfx12
+        - gfx1200
+        - gfx1201
+        block: SQ
+        event: 250
   - name: SQ_INSTS_VALU_FLOPS_FP16
     description: Counts FLOPS per instruction on float 16 excluding MFMA/SMFMA.
     properties: []
@@ -8361,6 +8444,26 @@ rocprofiler-sdk:
     - architectures:
       - gfx950
       expression: reduce(TCC_EA0_RDREQ_DRAM_32B,sum)
+  - name: TCP_REQ
+    description: Total cache line accesses
+    properties: []
+    definitions:
+      - architectures:
+        - gfx12
+        - gfx1200
+        - gfx1201
+        block: TCP
+        event: 9
+  - name: TCP_REQ_MISS
+    description: Total cache requests that missed
+    properties: []
+    definitions:
+      - architectures:
+        - gfx12
+        - gfx1200
+        - gfx1201
+        block: TCP
+        event: 17
   - name: TCP_ATOMIC_TAGCONFLICT_STALL_CYCLES
     description: Tagram conflict stall on an atomic
     properties: []
@@ -10192,6 +10295,11 @@ rocprofiler-sdk:
       - gfx942
       - gfx950
       expression: 100*reduce(SQ_ACTIVE_INST_VALU,sum)/CU_NUM/reduce(GRBM_GUI_ACTIVE,max)
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      expression: 100*reduce(SQ_INST_CYCLES_VALU,sum)/CU_NUM/reduce(GRBM_GUI_ACTIVE,max)
   - name: VALUInsts
     description: The average number of vector ALU instructions executed per work-item (affected by flow control).
     properties: []
@@ -10210,6 +10318,9 @@ rocprofiler-sdk:
       - gfx906
       - gfx908
       - gfx90a
+      - gfx12
+      - gfx1200
+      - gfx1201
       expression: reduce(SQ_INSTS_VALU,sum)/reduce(SQ_WAVES,sum)
   - name: VALUUtilization
     description: 'The percentage of active vector ALU threads in a wave. A lower number can mean either more thread divergence
@@ -10288,6 +10399,11 @@ rocprofiler-sdk:
       - gfx941
       - gfx942
       expression: 100*reduce(SQ_ACTIVE_INST_VALU,sum)/(reduce(GRBM_GUI_ACTIVE,max)*CU_NUM)
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      expression: 100*reduce(SQ_INST_CYCLES_VALU,sum)/(reduce(GRBM_GUI_ACTIVE,max)*CU_NUM)
   - name: VmemLatency
     description: 'Unit: cycles'
     properties: []
@@ -10445,6 +10561,9 @@ rocprofiler-sdk:
       - gfx906
       - gfx908
       - gfx90a
+      - gfx12
+      - gfx1200
+      - gfx1201
       expression: reduce(SQ_WAVES,sum)
   - name: WriteSize
     description: The total kilobytes written to the video memory. This is measured with all extra fetches and any cache or
@@ -10483,6 +10602,9 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx12
+      - gfx1200
+      - gfx1201
       expression: 100*GL2C_WRREQ_STALL_max/reduce(GRBM_GUI_ACTIVE,max)
   - name: sL1dCacheHitRate
     description: 'Unit: percent'
@@ -10588,6 +10710,16 @@ rocprofiler-sdk:
       - gfx942
       - gfx950
       expression: TCP_ATOMIC_TAGCONFLICT_STALL_CYCLES_sum/TCP_GATE_EN1_sum
+  - name: L0CacheHit
+    description: The percentage of read requests that hit the data in the L0 cache. The L0 cache contains vector data, which
+      is data that may vary in each thread across the wavefront. Value range 0% (no hit) to 100% (optimal).
+    properties: []
+    definitions:
+    - architectures:
+      - gfx12
+      - gfx1200
+      - gfx1201
+      expression: (1-(reduce(TCP_REQ_MISS,sum)/reduce(TCP_REQ,sum)))*100
   - name: SQC_DCACHE_INFLIGHT_LEVEL
     description: Level count total outstanding transactions in data cache (per-SQ, nondeterministic)
     properties: []


### PR DESCRIPTION
* Add counter defintions for Navi 4

* Made changes per https://github.com/ROCm/rocm-systems/pull/238 and doubled checked register specification

[ ] Find replacement for `simd_per_cu` and `CU_NUM` in gfx12

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
