### PR TITLE
rocprofv3-avail fix to exit without error when no counters supported

### DIFF
--- a/projects/rocprofiler-sdk/source/bin/rocprofv3-avail.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3-avail.py
@@ -73,7 +73,6 @@ def parse_arguments(args=None):
 %(prog)s, e.g.
 
     $ rocprofv3-avail [<rocprofv3-avail-option> ...]
-    $ rocprofv3-avail -- avail-hw-counters
 
 """
 
@@ -198,6 +197,10 @@ def list_basic_agent(args, list_counters):
     from rocprofv3 import avail
 
     def print_agent_counter(counters):
+        if len(counters) == 0:
+            msg = "No PMC counters supported"
+            print("{:30}\n".format(msg))
+            return
         names_len = [len(counter.name) for counter in counters]
         names = [
             "{name:{width}}".format(name=counter.name, width=max(names_len))
@@ -275,6 +278,10 @@ def listing(args):
     from rocprofv3 import avail
 
     def print_agent_counter(counters):
+        if len(counters) == 0:
+            msg = "No PMC counters supported"
+            print("{:30}\n".format(msg))
+            return
         names_len = [len(counter.name) for counter in counters]
         names = [
             "{name:{width}}".format(name=counter.name, width=max(names_len))


### PR DESCRIPTION
## Motivation

 Fix to exit without error in case of no counters supported. 

## Technical Details

Handles the case when no counters are supported.
Adds an if condition in the print_agent function

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
