### PR TITLE
fix: incorrect parameter docs for hipMemcpy2D

### DIFF
--- a/projects/hip/include/hip/hip_runtime_api.h
+++ b/projects/hip/include/hip/hip_runtime_api.h
@@ -5440,8 +5440,8 @@ hipError_t hipArray3DGetDescriptor(HIP_ARRAY3D_DESCRIPTOR* pArrayDescriptor, hip
  *  @param[in]   dpitch Pitch size in bytes of destination memory
  *  @param[in]   src    Source memory address
  *  @param[in]   spitch Pitch size in bytes of source memory
- *  @param[in]   width  Width size in bytes of matrix transfer (columns)
- *  @param[in]   height Height size in bytes of matrix transfer (rows)
+ *  @param[in]   width  Width of matrix transfer (columns in bytes)
+ *  @param[in]   height Height of matrix transfer (rows)
  *  @param[in]   kind   Type of transfer
  *  @returns     #hipSuccess, #hipErrorInvalidValue, #hipErrorInvalidPitchValue,
  * #hipErrorInvalidDevicePointer, #hipErrorInvalidMemcpyDirection


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Documentation for `hipMemcpy2D()`  in the header file is mismatched and incorrect compared to the official documentation and usage. Fixing it for clarity.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

`hipMemcpy2D()` documentation changed for `height` parameter to rows rather than size in bytes, and `width` parameter reworded to match the official documentation.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

No testing, minimal header documentation fix.

## Test Result

<!-- Briefly summarize test outcomes. -->

N/A

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
