### PR TITLE
SWDEV-555299 - Fix and enable Unit_Device_modf_modff_Negative_RTC

### DIFF
--- a/projects/hip-tests/catch/hipTestMain/config/config_amd_linux
+++ b/projects/hip-tests/catch/hipTestMain/config/config_amd_linux
@@ -86,7 +86,6 @@
         "Unit_hipLaunchCooperativeKernel_Negative_Parameters",
         "Unit_hipLaunchKernel_Negative_Parameters",
         "Unit_hipModuleLaunchCooperativeKernel_Negative_Parameters",
-        "Unit_Device_modf_modff_Negative_RTC",
         "SWDEV-446588 - Disable graph multi gpu testcases until graph has support for it",
         "=== Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/210 ===",
         "Unit_Assert_Positive_Basic_KernelFail",

--- a/projects/hip-tests/catch/unit/math/remainder_and_rounding_funcs.cc
+++ b/projects/hip-tests/catch/unit/math/remainder_and_rounding_funcs.cc
@@ -150,4 +150,4 @@ TEST_CASE("Unit_Device_modf_Accuracy_Positive - double") {
       PairValidatorBuilderFactory<double>(ULPValidatorBuilderFactory<double>(0)));
 }
 
-TEST_CASE("Unit_Device_modf_modff_Negative_RTC") { NegativeTestRTCWrapper<20>(kModf); }
+TEST_CASE("Unit_Device_modf_modff_Negative_RTC") { NegativeTestRTCWrapper<19>(kModf); }


### PR DESCRIPTION
## Motivation

Fix and enable the test

## Technical Details

__global__ void modf_kernel_v8(double x, float* iptr) { auto result = modf(x, iptr); }

This kernel does not produce a compiler error because x is implicitly cast to float, causing modf to resolve to modf(float, float*). As a result, we see 19 compiler errors(coming from other kernels) instead of 20

## Test Plan

/

## Test Result

/

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
