### PR TITLE
SWDEV-555043 - Adding a missing instance where CLR should not wait on…

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3512,7 +3512,8 @@ void Device::RemoveKernel(Kernel& gpuKernel) const {
 // ================================================================================================
 ProfilingSignal::~ProfilingSignal() {
   if (signal_.handle != 0) {
-    if (hsa_signal_load_relaxed(signal_) > 0) {
+    if (hsa_signal_load_relaxed(signal_) > 0
+        && !(HIP_SKIP_ABORT_ON_GPU_ERROR && amd::Device::IsGPUInError())) {
       LogError("Runtime shouldn't destroy a signal that is still busy!");
       if (hsa_signal_wait_scacquire(signal_, HSA_SIGNAL_CONDITION_LT, kInitSignalValueOne,
                                     kUnlimitedWait, HSA_WAIT_STATE_BLOCKED) != 0) {


### PR DESCRIPTION
… signal if GPUERROR is set to true.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Fixing a missing instance where we dont wait on GPU Error on crash.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

When GPUError flag is set, we should not wait on any signal.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

CI testing.

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
