### PR TITLE
SWDEV-552741 - Exclude OCLGetQueueThreadID from ocl tests

### DIFF
--- a/projects/clr/opencl/tests/ocltst/module/runtime/oclruntime.exclude
+++ b/projects/clr/opencl/tests/ocltst/module/runtime/oclruntime.exclude
@@ -9,3 +9,6 @@ OCLRegionDeviceQueries
 OCLDynamicBLines
 
 OCLAtomicCounter
+
+OCLGetQueueThreadID
+	


### PR DESCRIPTION
## Motivation
The tests uses AMD OCL extension to check the queue thread id, but there is no queue thread with DD

## Technical Details
Direct dispatch can't support this extension

## Test Plan
NA

## Test Result
NA

## Submission Checklist
NA