### PR TITLE
rocr: Make DestroyAgents idempotent in runtime

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -527,6 +527,9 @@ class Runtime {
   static void AsyncEventsLoop(void*);
   static void AsyncIPCSockServerConnLoop(void*);
 
+  // Add this flag to make DestroyAgents idempotent
+  bool agents_destroyed_ = false;
+
   struct AllocationRegion {
     AllocationRegion()
         : region(NULL),

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -234,6 +234,9 @@ void Runtime::RegisterDriver(std::unique_ptr<Driver> driver) {
 }
 
 void Runtime::DestroyAgents() {
+  if (agents_destroyed_) return; // <-- Prevent double execution
+  agents_destroyed_ = true;      // <-- Mark as destroyed
+
   agents_by_node_.clear();
 
   std::for_each(gpu_agents_.begin(), gpu_agents_.end(), DeleteObject());
@@ -2074,7 +2077,8 @@ Runtime::Runtime()
       internal_queue_create_notifier_user_data_(nullptr),
       ref_count_(0),
       kfd_version{},
-      ipc_sock_server_fd_(0) {
+      ipc_sock_server_fd_(0),
+      agents_destroyed_(false) {
 
   virtual_mem_api_supported_ = false;
   ipc_dmabuf_supported_ = false;


### PR DESCRIPTION
add check for destroyed agents to make sure any
process tears down smoothly after completion
