### PR TITLE
[rocprof-compute] update TCC_EA0_RDREQ_sum counter def

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/counter_defs.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/counter_defs.yaml
@@ -6667,7 +6667,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_EA0_RDREQ_LEVEL,sum)
   - name: TCC_EA0_RDREQ_sum
-    description: Number of TCC/EA read requests (either 32-byte or 64-byte) Sum over TCC instances.
+    description: Number of TCC/EA read requests (either 32-byte or 64-byte or 128-byte) Sum over TCC instances.
     properties: []
     definitions:
     - architectures:


### PR DESCRIPTION
## Motivation

Update the definition of the TCC_EA0_RDREQ_sum counter in counter_defs.yaml to reflect its correct purpose on MI300 arch. The current definition in counter_defs.yaml is inaccurate to what the actual counter collects as defined in MI300 register specification.

As defined in the register specification for MI300:
`Number of TCC/EA read requests (either 32-byte or 64-byte or 128-byte)`

## Technical Details

This modifies the counter_defs.yaml file to update the description of TCC_EA0_RDREQ_sum. The new description clarifies that this counter includes 128B reads in its total count. By accurately defining this counter, the formula for calculating 64B reads `(TCC_EA0_RDREQ_sum - TCC_BUBBLE_sum - TCC_EA0_RDREQ_32B_sum)` reflects their respective counter definitions.

This addresses the issue documented in the ticket 4462.

## Test Plan

No functional changes

## Test Result

N/A

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
