### PR TITLE
SWDEV-555638: fix unused default stream in middle of capture

### DIFF
--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -256,7 +256,7 @@ const char* ihipGetErrorName(hipError_t hip_error);
              reinterpret_cast<hip::Stream*>(stream)->GetCaptureStatus() ==                         \
                  hipStreamCaptureStatusInvalidated) {                                              \
     return hipErrorStreamCaptureInvalidated;                                                       \
-  } else {                                                                                         \
+  } else if (stream == nullptr) {                                                                  \
     CHECK_STREAM_CAPTURING()                                                                       \
   }
 


### PR DESCRIPTION
- fix the condition so only null stream cause error

## Motivation

Fix the issue of unused default stream in middle of graph capture

## Technical Details

Fix the issue of unused default stream in middle of graph capture

## Test Plan

hip test coverage

## Test Result

waiting for results

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
