### PR TITLE
fix(rocprof-sys-sample/causal/run): add libomptarget discovery to prevent OpenMP/HIP segfaults

### DIFF
--- a/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
@@ -71,9 +71,10 @@ endif()
 # Use the directory that actually contains the library we found
 get_filename_component(_rocm_llvm_lib "${LIBOMPTARGET_SO}" DIRECTORY)
 set(_rocm_clang_lib "${ROCM_ROOT_DIR}/lib")
-set(_COMMON_RPATH
-    "${_rocm_llvm_lib};${_rocm_clang_lib};${ROCmVersion_DIR}/llvm/lib;$ORIGIN"
-)
+set(_COMMON_RPATH "${_rocm_llvm_lib};${_rocm_clang_lib};$ORIGIN")
+if(ROCmVersion_DIR)
+    list(APPEND _COMMON_RPATH "${ROCmVersion_DIR}/llvm/lib")
+endif()
 list(REMOVE_DUPLICATES _COMMON_RPATH)
 
 message(STATUS "libomptarget found at: ${LIBOMPTARGET_SO}")
@@ -114,7 +115,6 @@ foreach(tgt openmp-target-lib openmp-target)
             "-L${_rocm_llvm_lib}"
             "-Wl,-rpath,${_rocm_llvm_lib}"
             "-Wl,-rpath,${_rocm_clang_lib}"
-            "-Wl,-rpath,'$ORIGIN'"
     )
 endforeach()
 

--- a/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
@@ -51,6 +51,8 @@ message(STATUS "ROCm root inferred from compiler: ${ROCM_ROOT_DIR}")
 
 # Candidate lib directories for libomptarget across ROCm layouts
 set(_LLVM_LIB_HINTS
+    "${ROCmVersion_DIR}/llvm/lib"
+    "${ROCmVersion_DIR}/lib"
     "${ROCM_ROOT_DIR}/lib"
     "${ROCM_ROOT_DIR}/llvm/lib"
     "$ENV{ROCM_PATH}/llvm/lib"
@@ -69,7 +71,9 @@ endif()
 # Use the directory that actually contains the library we found
 get_filename_component(_rocm_llvm_lib "${LIBOMPTARGET_SO}" DIRECTORY)
 set(_rocm_clang_lib "${ROCM_ROOT_DIR}/lib")
-set(_COMMON_RPATH "${_rocm_llvm_lib};${_rocm_clang_lib}")
+set(_COMMON_RPATH
+    "${_rocm_llvm_lib};${_rocm_clang_lib};${ROCmVersion_DIR}/llvm/lib;$ORIGIN"
+)
 list(REMOVE_DUPLICATES _COMMON_RPATH)
 
 message(STATUS "libomptarget found at: ${LIBOMPTARGET_SO}")
@@ -106,9 +110,11 @@ foreach(tgt openmp-target-lib openmp-target)
     target_link_options(
         ${tgt}
         PUBLIC
+            "-Wl,--enable-new-dtags"
             "-L${_rocm_llvm_lib}"
             "-Wl,-rpath,${_rocm_llvm_lib}"
             "-Wl,-rpath,${_rocm_clang_lib}"
+            "-Wl,-rpath,'$ORIGIN'"
     )
 endforeach()
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
@@ -204,6 +204,14 @@ get_initial_environment()
                get_env<int>("ROCPROFSYS_THREAD_POOL_SIZE", 0));
     update_env(_env, "ROCPROFSYS_LAUNCHER", "rocprof-sys-causal");
 
+    // Ensure libomptarget.so can be found by the target (OpenMP/HIP apps)
+    if(auto llvm_dir =
+           rocprofsys::common::discover_llvm_libdir_for_ompt(get_verbose() > 0);
+       !llvm_dir.empty())
+    {
+        update_env(_env, "LD_LIBRARY_PATH", llvm_dir, /*append=*/true);
+    }
+
     return _env;
 }
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
@@ -359,13 +359,13 @@ update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_va
                     if(_env_var == "LD_PRELOAD")
                     {
                         itr =
-                            strdup(join('=', _env_var, join(_join_delim, _val, _env_val))
+                            strdup(join('=', _env_var, join(_join_delim, _env_val, _val))
                                        .c_str());
                     }
                     else
                     {
                         itr =
-                            strdup(join('=', _env_var, join(_join_delim, _env_val, _val))
+                            strdup(join('=', _env_var, join(_join_delim, _val, _env_val))
                                        .c_str());
                     }
                 }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-run/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-run/impl.cpp
@@ -82,6 +82,7 @@ to_string(bool _v)
 
 namespace
 {
+auto original_envs = std::set<std::string>{};
 std::string
 get_internal_libpath(const std::string& _lib)
 {
@@ -91,22 +92,83 @@ get_internal_libpath(const std::string& _lib)
     if(_pos != std::string_view::npos) _dir = _exe.substr(0, _pos);
     return rocprofsys::common::join("/", _dir, "..", "lib", _lib);
 }
-
-parser_data_t&
-get_initial_environment(parser_data_t& _data)
+std::string
+get_internal_script_path()
 {
-    if(environ != nullptr)
+    auto _exe = std::string_view{ realpath("/proc/self/exe", nullptr) };
+    auto _pos = _exe.find_last_of('/');
+    auto _dir = std::string{ "./" };
+    if(_pos != std::string_view::npos) _dir = _exe.substr(0, _pos);
+
+    auto _script_dir =
+        rocprofsys::common::join("/", _dir, "..", "libexec", "rocprofiler-systems");
+
+    return _script_dir;
+}
+
+std::string
+get_realpath(const std::string& _v)
+{
+    if(auto* _tmp = realpath(_v.c_str(), nullptr))
     {
-        int idx = 0;
-        while(environ[idx] != nullptr)
+        std::string _ret{ _tmp };
+        free(_tmp);
+        return _ret;
+    }
+    return {};
+}
+
+template <typename Tp>
+void
+update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_val,
+           update_mode&& _mode, std::string_view _join_delim = ":")
+{
+    // updated_envs.emplace(_env_var);
+
+    auto _prepend  = (_mode & UPD_PREPEND) == UPD_PREPEND;
+    auto _append   = (_mode & UPD_APPEND) == UPD_APPEND;
+    auto _weak_upd = (_mode & UPD_WEAK) == UPD_WEAK;
+
+    auto _key = join("", _env_var, "=");
+    for(auto& itr : _environ)
+    {
+        if(!itr) continue;
+        if(std::string_view{ itr }.find(_key) == 0)
         {
-            auto* _v = environ[idx++];
-            _data.initial.emplace(_v);
-            _data.current.emplace_back(strdup(_v));
+            if(_weak_upd)
+            {
+                // if the value has changed, do not update but allow overridding the value
+                // inherited from the initial env
+                if(original_envs.find(std::string{ itr }) == original_envs.end()) return;
+            }
+
+            if(_prepend || _append)
+            {
+                if(std::string_view{ itr }.find(join("", _env_val)) ==
+                   std::string_view::npos)
+                {
+                    auto _val = std::string{ itr }.substr(_key.length());
+                    free(itr);
+                    if(_prepend)
+                        itr =
+                            strdup(join('=', _env_var, join(_join_delim, _val, _env_val))
+                                       .c_str());
+                    else
+                        itr =
+                            strdup(join('=', _env_var, join(_join_delim, _env_val, _val))
+                                       .c_str());
+                }
+            }
+            else
+            {
+                free(itr);
+                itr = strdup(rocprofsys::common::join('=', _env_var, _env_val).c_str());
+            }
+            return;
         }
     }
-
-    return _data;
+    _environ.emplace_back(
+        strdup(rocprofsys::common::join('=', _env_var, _env_val).c_str()));
 }
 
 int
@@ -121,13 +183,40 @@ get_verbose(parser_data_t& _data)
     return verbose;
 }
 
-std::string
-get_realpath(const std::string& _v)
+parser_data_t&
+get_initial_environment(parser_data_t& _data)
 {
-    auto* _tmp = realpath(_v.c_str(), nullptr);
-    auto  _ret = std::string{ _tmp };
-    free(_tmp);
-    return _ret;
+    if(environ != nullptr)
+    {
+        int idx = 0;
+        while(environ[idx] != nullptr)
+        {
+            auto* _v = environ[idx++];
+            _data.initial.emplace(_v);
+            _data.current.emplace_back(strdup(_v));
+            original_envs.emplace(_v);
+        }
+    }
+
+    auto _libexecpath = get_realpath(get_internal_script_path());
+    if(!_libexecpath.empty())
+    {
+        update_env(_data.current, "ROCPROFSYS_SCRIPT_PATH", _libexecpath, UPD_REPLACE);
+        _data.updated.emplace("ROCPROFSYS_SCRIPT_PATH");
+    }
+
+    const bool verbose = (get_verbose(_data) > 0);
+    if(auto llvm_dir = rocprofsys::common::discover_llvm_libdir_for_ompt(verbose);
+       !llvm_dir.empty())
+    {
+        update_env(_data.current, "LD_LIBRARY_PATH", llvm_dir, UPD_APPEND);
+        _data.updated.emplace("LD_LIBRARY_PATH");
+        auto        current_ld = getenv("LD_LIBRARY_PATH");
+        std::string new_ld     = current_ld ? (llvm_dir + ":" + current_ld) : llvm_dir;
+        setenv("LD_LIBRARY_PATH", new_ld.c_str(), 1);
+    }
+
+    return _data;
 }
 
 auto

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-run/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-run/impl.cpp
@@ -123,8 +123,6 @@ void
 update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_val,
            update_mode&& _mode, std::string_view _join_delim = ":")
 {
-    // updated_envs.emplace(_env_var);
-
     auto _prepend  = (_mode & UPD_PREPEND) == UPD_PREPEND;
     auto _append   = (_mode & UPD_APPEND) == UPD_APPEND;
     auto _weak_upd = (_mode & UPD_WEAK) == UPD_WEAK;

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-run/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-run/impl.cpp
@@ -83,27 +83,42 @@ to_string(bool _v)
 namespace
 {
 auto original_envs = std::set<std::string>{};
+enum update_mode : int
+{
+    UPD_REPLACE = 0,       // no PREPEND/APPEND bits set
+    UPD_PREPEND = 1 << 0,  // 0x01
+    UPD_APPEND  = 1 << 1,  // 0x02
+    UPD_WEAK    = 1 << 2,  // 0x04
+};
+
+std::string
+get_rocprofsys_root(void)
+{
+    char*       _tmp = realpath("/proc/self/exe", nullptr);
+    std::string _exe = (_tmp) ? std::string{ _tmp } : std::string{};
+
+    if(_tmp) free(_tmp);
+
+    auto _pos = _exe.find_last_of('/');
+    auto _dir = std::string{ "./" };
+
+    if(_pos != std::string::npos) _dir = _exe.substr(0, _pos);
+
+    return rocprofsys::common::join("/", _dir, "..");
+}
+
 std::string
 get_internal_libpath(const std::string& _lib)
 {
-    auto _exe = std::string_view{ realpath("/proc/self/exe", nullptr) };
-    auto _pos = _exe.find_last_of('/');
-    auto _dir = std::string{ "./" };
-    if(_pos != std::string_view::npos) _dir = _exe.substr(0, _pos);
-    return rocprofsys::common::join("/", _dir, "..", "lib", _lib);
+    auto _root = get_rocprofsys_root();
+    return rocprofsys::common::join("/", _root, "lib", _lib);
 }
+
 std::string
-get_internal_script_path()
+get_internal_script_path(void)
 {
-    auto _exe = std::string_view{ realpath("/proc/self/exe", nullptr) };
-    auto _pos = _exe.find_last_of('/');
-    auto _dir = std::string{ "./" };
-    if(_pos != std::string_view::npos) _dir = _exe.substr(0, _pos);
-
-    auto _script_dir =
-        rocprofsys::common::join("/", _dir, "..", "libexec", "rocprofiler-systems");
-
-    return _script_dir;
+    auto _root = get_rocprofsys_root();
+    return rocprofsys::common::join("/", _root, "libexec", "rocprofiler-systems");
 }
 
 std::string
@@ -123,9 +138,15 @@ void
 update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_val,
            update_mode&& _mode, std::string_view _join_delim = ":")
 {
-    auto _prepend  = (_mode & UPD_PREPEND) == UPD_PREPEND;
-    auto _append   = (_mode & UPD_APPEND) == UPD_APPEND;
-    auto _weak_upd = (_mode & UPD_WEAK) == UPD_WEAK;
+    auto _prepend  = (_mode & UPD_PREPEND) != 0;
+    auto _append   = (_mode & UPD_APPEND) != 0;
+    auto _weak_upd = (_mode & UPD_WEAK) != 0;
+
+    // if both flags are set, prefer append
+    if(_prepend && _append)
+    {
+        _prepend = false;
+    }
 
     auto _key = join("", _env_var, "=");
     for(auto& itr : _environ)
@@ -149,11 +170,11 @@ update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_va
                     free(itr);
                     if(_prepend)
                         itr =
-                            strdup(join('=', _env_var, join(_join_delim, _val, _env_val))
+                            strdup(join('=', _env_var, join(_join_delim, _env_val, _val))
                                        .c_str());
                     else
                         itr =
-                            strdup(join('=', _env_var, join(_join_delim, _env_val, _val))
+                            strdup(join('=', _env_var, join(_join_delim, _val, _env_val))
                                        .c_str());
                 }
             }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-run/rocprof-sys-run.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-run/rocprof-sys-run.hpp
@@ -32,6 +32,14 @@
 #include <string_view>
 #include <vector>
 
+enum update_mode : int
+{
+    UPD_REPLACE = 0x1,
+    UPD_PREPEND = 0x2,
+    UPD_APPEND  = 0x3,
+    UPD_WEAK    = 0x4,
+};
+
 using parser_data_t = rocprofsys::argparse::parser_data;
 
 void

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-run/rocprof-sys-run.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-run/rocprof-sys-run.hpp
@@ -32,14 +32,6 @@
 #include <string_view>
 #include <vector>
 
-enum update_mode : int
-{
-    UPD_REPLACE = 0x1,
-    UPD_PREPEND = 0x2,
-    UPD_APPEND  = 0x3,
-    UPD_WEAK    = 0x4,
-};
-
 using parser_data_t = rocprofsys::argparse::parser_data;
 
 void

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/impl.cpp
@@ -43,6 +43,7 @@
 #include <string_view>
 #include <unistd.h>
 #include <vector>
+
 namespace color = tim::log::color;
 using namespace timemory::join;
 using tim::get_env;
@@ -131,51 +132,12 @@ get_initial_environment()
     update_env(_env, "LD_LIBRARY_PATH", tim::filepath::dirname(_dl_libpath), UPD_APPEND);
     update_env(_env, "ROCPROFSYS_SCRIPT_PATH", _libexecpath, UPD_REPLACE);
 
-    // libomptarget discovery
-    auto rocm_dir  = get_env<std::string>("ROCM_PATH", "/opt/rocm", false);
-    auto rocmv_dir = get_env<std::string>("ROCmVersion_DIR", "", false);
-
-    // strip one trailing slash if present
-    auto strip = [](std::string s) {
-        if(!s.empty() && s.back() == '/') s.pop_back();
-        return s;
-    };
-    rocm_dir  = strip(rocm_dir);
-    rocmv_dir = strip(rocmv_dir);
-
-    // build candidate libdirs
-    std::vector<std::string> llvm_candidates = {
-        rocmv_dir.empty() ? std::string{} : rocmv_dir + "/llvm/lib",
-        rocmv_dir.empty() ? std::string{} : rocmv_dir + "/lib",
-        rocm_dir + "/llvm/lib",
-        rocm_dir + "/lib/llvm/lib",
-        "/opt/rocm/llvm/lib",
-        "/opt/rocm/lib/llvm/lib",
-    };
-
-    // to check if libomptarget.so exist and is readable
-    auto has_libomptarget = [](const std::string& dir) -> bool {
-        if(dir.empty()) return false;
-        std::string path = dir + "/libomptarget.so";
-        return (::access(path.c_str(), R_OK) == 0);
-    };
-
-    bool added_llvm_dir = false;
-
-    for(const auto& dir : llvm_candidates)
+    // Discover LLVM libdir containing libomptarget.so and append to LD_LIBRARY_PATH
+    if(auto llvm_dir = rocprofsys::common::discover_llvm_libdir_for_ompt(verbose > 0);
+       !llvm_dir.empty())
     {
-        if(has_libomptarget(dir))
-        {
-            update_env(_env, "LD_LIBRARY_PATH", dir, UPD_APPEND);
-            if(verbose >= 1)
-                stream(std::cerr, color::info()) << "Using LLVM libdir: " << dir << "\n";
-            added_llvm_dir = true;
-            break;
-        }
+        update_env(_env, "LD_LIBRARY_PATH", llvm_dir, UPD_APPEND);
     }
-    if(verbose >= 1 && !added_llvm_dir)
-        stream(std::cerr, color::warning())
-            << "libomptarget.so not found in candidate LLVM libdirs\n";
 
     auto _mode = get_env<std::string>("ROCPROFSYS_MODE", "sampling", false);
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/impl.cpp
@@ -43,7 +43,6 @@
 #include <string_view>
 #include <unistd.h>
 #include <vector>
-
 namespace color = tim::log::color;
 using namespace timemory::join;
 using tim::get_env;
@@ -131,6 +130,52 @@ get_initial_environment()
     update_env(_env, "LD_PRELOAD", _dl_libpath, UPD_APPEND);
     update_env(_env, "LD_LIBRARY_PATH", tim::filepath::dirname(_dl_libpath), UPD_APPEND);
     update_env(_env, "ROCPROFSYS_SCRIPT_PATH", _libexecpath, UPD_REPLACE);
+
+    // libomptarget discovery
+    auto rocm_dir  = get_env<std::string>("ROCM_PATH", "/opt/rocm", false);
+    auto rocmv_dir = get_env<std::string>("ROCmVersion_DIR", "", false);
+
+    // strip one trailing slash if present
+    auto strip = [](std::string s) {
+        if(!s.empty() && s.back() == '/') s.pop_back();
+        return s;
+    };
+    rocm_dir  = strip(rocm_dir);
+    rocmv_dir = strip(rocmv_dir);
+
+    // build candidate libdirs
+    std::vector<std::string> llvm_candidates = {
+        rocmv_dir.empty() ? std::string{} : rocmv_dir + "/llvm/lib",
+        rocmv_dir.empty() ? std::string{} : rocmv_dir + "/lib",
+        rocm_dir + "/llvm/lib",
+        rocm_dir + "/lib/llvm/lib",
+        "/opt/rocm/llvm/lib",
+        "/opt/rocm/lib/llvm/lib",
+    };
+
+    // to check if libomptarget.so exist and is readable
+    auto has_libomptarget = [](const std::string& dir) -> bool {
+        if(dir.empty()) return false;
+        std::string path = dir + "/libomptarget.so";
+        return (::access(path.c_str(), R_OK) == 0);
+    };
+
+    bool added_llvm_dir = false;
+
+    for(const auto& dir : llvm_candidates)
+    {
+        if(has_libomptarget(dir))
+        {
+            update_env(_env, "LD_LIBRARY_PATH", dir, UPD_APPEND);
+            if(verbose >= 1)
+                stream(std::cerr, color::info()) << "Using LLVM libdir: " << dir << "\n";
+            added_llvm_dir = true;
+            break;
+        }
+    }
+    if(verbose >= 1 && !added_llvm_dir)
+        stream(std::cerr, color::warning())
+            << "libomptarget.so not found in candidate LLVM libdirs\n";
 
     auto _mode = get_env<std::string>("ROCPROFSYS_MODE", "sampling", false);
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/impl.cpp
@@ -230,9 +230,15 @@ update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_va
 {
     updated_envs.emplace(_env_var);
 
-    auto _prepend  = (_mode & UPD_PREPEND) == UPD_PREPEND;
-    auto _append   = (_mode & UPD_APPEND) == UPD_APPEND;
-    auto _weak_upd = (_mode & UPD_WEAK) == UPD_WEAK;
+    auto _prepend  = (_mode & UPD_PREPEND) != 0;
+    auto _append   = (_mode & UPD_APPEND) != 0;
+    auto _weak_upd = (_mode & UPD_WEAK) != 0;
+
+    // if both flags are set, prefer append
+    if(_prepend && _append)
+    {
+        _prepend = false;
+    }
 
     auto _key = join("", _env_var, "=");
     for(auto& itr : _environ)
@@ -256,11 +262,11 @@ update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_va
                     free(itr);
                     if(_prepend)
                         itr =
-                            strdup(join('=', _env_var, join(_join_delim, _val, _env_val))
+                            strdup(join('=', _env_var, join(_join_delim, _env_val, _val))
                                        .c_str());
                     else
                         itr =
-                            strdup(join('=', _env_var, join(_join_delim, _env_val, _val))
+                            strdup(join('=', _env_var, join(_join_delim, _val, _env_val))
                                        .c_str());
                 }
             }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/rocprof-sys-sample.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/rocprof-sys-sample.hpp
@@ -28,10 +28,10 @@
 
 enum update_mode : int
 {
-    UPD_REPLACE = 0x1,
-    UPD_PREPEND = 0x2,
-    UPD_APPEND  = 0x3,
-    UPD_WEAK    = 0x4,
+    UPD_REPLACE = 0,       // no PREPEND/APPEND bits set
+    UPD_PREPEND = 1 << 0,  // 0x01
+    UPD_APPEND  = 1 << 1,  // 0x02
+    UPD_WEAK    = 1 << 2,  // 0x04
 };
 
 std::string

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -32,6 +32,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <timemory/utility/filepath.hpp>
 #include <type_traits>
 #include <unistd.h>
 
@@ -205,7 +206,7 @@ discover_llvm_libdir_for_ompt(bool verbose = false)
 
     auto has_libomptarget = [](const std::string& dir) {
         const std::string so = dir + "/libomptarget.so";
-        return (::access(so.c_str(), R_OK) == 0);
+        return ::tim::filepath::exists(so);
     };
 
     // Pick the first candidate that contains libomptarget.so

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -24,6 +24,7 @@
 
 #include "common/defines.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -177,5 +178,48 @@ struct ROCPROFSYS_INTERNAL_API env_config
         return setenv(env_name.c_str(), env_value.c_str(), override);
     }
 };
+
+inline std::string
+discover_llvm_libdir_for_ompt(bool verbose = false)
+{
+    auto strip = [](std::string s) {
+        if(!s.empty() && s.back() == '/') s.pop_back();
+        return s;
+    };
+
+    // Common ROCm envs
+    const auto rocm_dir  = strip(get_env<std::string>("ROCM_PATH", "/opt/rocm"));
+    const auto rocmv_dir = strip(get_env<std::string>("ROCmVersion_DIR", ""));
+
+    std::vector<std::string> candidates;
+    candidates.reserve(6);
+    if(!rocmv_dir.empty())
+    {
+        candidates.emplace_back(rocmv_dir + "/llvm/lib");
+        candidates.emplace_back(rocmv_dir + "/lib");
+    }
+    candidates.emplace_back(rocm_dir + "/llvm/lib");
+    candidates.emplace_back(rocm_dir + "/lib/llvm/lib");
+    candidates.emplace_back(std::string{ "/opt/rocm/llvm/lib" });
+    candidates.emplace_back(std::string{ "/opt/rocm/lib/llvm/lib" });
+
+    auto has_libomptarget = [](const std::string& dir) {
+        const std::string so = dir + "/libomptarget.so";
+        return (::access(so.c_str(), R_OK) == 0);
+    };
+
+    // Pick the first candidate that contains libomptarget.so
+    auto it = std::find_if(candidates.begin(), candidates.end(), has_libomptarget);
+    if(it != candidates.end())
+    {
+        ROCPROFSYS_ENVIRON_LOG(verbose, "Using LLVM libdir: %s\n", it->c_str());
+        return *it;
+    }
+
+    ROCPROFSYS_ENVIRON_LOG(verbose,
+                           "libomptarget.so not found in candidate LLVM libdirs\n");
+    return {};
+}
+
 }  // namespace common
 }  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -194,15 +194,22 @@ discover_llvm_libdir_for_ompt(bool verbose = false)
 
     std::vector<std::string> candidates;
     candidates.reserve(6);
+
+    auto push_unique = [&](const std::string& p) {
+        if(p.empty()) return;
+        if(std::find(candidates.begin(), candidates.end(), p) == candidates.end())
+            candidates.emplace_back(p);
+    };
+
     if(!rocmv_dir.empty())
     {
-        candidates.emplace_back(rocmv_dir + "/llvm/lib");
-        candidates.emplace_back(rocmv_dir + "/lib");
+        push_unique(rocmv_dir + "/llvm/lib");
+        push_unique(rocmv_dir + "/lib");
     }
-    candidates.emplace_back(rocm_dir + "/llvm/lib");
-    candidates.emplace_back(rocm_dir + "/lib/llvm/lib");
-    candidates.emplace_back(std::string{ "/opt/rocm/llvm/lib" });
-    candidates.emplace_back(std::string{ "/opt/rocm/lib/llvm/lib" });
+    push_unique(rocm_dir + "/llvm/lib");
+    push_unique(rocm_dir + "/lib/llvm/lib");
+    push_unique("/opt/rocm/llvm/lib");
+    push_unique("/opt/rocm/lib/llvm/lib");
 
     auto has_libomptarget = [](const std::string& dir) {
         const std::string so = dir + "/libomptarget.so";

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -87,10 +87,10 @@ get_realpath(const std::string& _path)
 
 enum update_mode : int
 {
-    UPD_REPLACE = 0x1,
-    UPD_PREPEND = 0x2,
-    UPD_APPEND  = 0x3,
-    UPD_WEAK    = 0x4,
+    UPD_REPLACE = 0,       // no PREPEND/APPEND bits set
+    UPD_PREPEND = 1 << 0,  // 0x01
+    UPD_APPEND  = 1 << 1,  // 0x02
+    UPD_WEAK    = 1 << 2,  // 0x04
 };
 
 template <typename Tp>
@@ -100,9 +100,15 @@ update_env(parser_data& _data, std::string_view _env_var, Tp&& _env_val,
 {
     _data.updated.emplace(_env_var);
 
-    auto _prepend  = (_mode & UPD_PREPEND) == UPD_PREPEND;
-    auto _append   = (_mode & UPD_APPEND) == UPD_APPEND;
-    auto _weak_upd = (_mode & UPD_WEAK) == UPD_WEAK;
+    auto _prepend  = (_mode & UPD_PREPEND) != 0;
+    auto _append   = (_mode & UPD_APPEND) != 0;
+    auto _weak_upd = (_mode & UPD_WEAK) != 0;
+
+    // if both flags are set, prefer append
+    if(_prepend && _append)
+    {
+        _prepend = false;
+    }
 
     auto _key = join("", _env_var, "=");
     for(auto& itr : _data.current)
@@ -126,11 +132,11 @@ update_env(parser_data& _data, std::string_view _env_var, Tp&& _env_val,
                     free(itr);
                     if(_prepend)
                         itr =
-                            strdup(join('=', _env_var, join(_join_delim, _val, _env_val))
+                            strdup(join('=', _env_var, join(_join_delim, _env_val, _val))
                                        .c_str());
                     else
                         itr =
-                            strdup(join('=', _env_var, join(_join_delim, _env_val, _val))
+                            strdup(join('=', _env_var, join(_join_delim, _val, _env_val))
                                        .c_str());
                 }
             }

--- a/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
@@ -15,7 +15,7 @@ else()
     set(_rocm_root "/opt/rocm")
 endif()
 
-# Point to LLVM libdir
+# Set path to ROCm LLVM library directory containing libomptarget.so
 set(_rocm_llvm_lib "${_rocm_root}/llvm/lib")
 
 set(_rocm_ld_env "LD_LIBRARY_PATH=${_rocm_llvm_lib}:$ENV{LD_LIBRARY_PATH}")

--- a/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
@@ -15,12 +15,10 @@ else()
     set(_rocm_root "/opt/rocm")
 endif()
 
-set(_rocm_llvm_lib "${_rocm_root}/lib/llvm/lib")
+# Point to LLVM libdir
+set(_rocm_llvm_lib "${_rocm_root}/llvm/lib")
 
-set(_rocm_ld_env
-    "LD_PRELOAD=libomptarget.so"
-    "LD_LIBRARY_PATH=${_rocm_llvm_lib}:$ENV{LD_LIBRARY_PATH}"
-)
+set(_rocm_ld_env "LD_LIBRARY_PATH=${_rocm_llvm_lib}:$ENV{LD_LIBRARY_PATH}")
 
 if(NOT EXISTS "${_rocm_llvm_lib}/libomptarget.so" AND ROCPROFSYS_USE_ROCM)
     message(


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR fixes a segmentation fault seen when running rocprof-sys-sample with multi-process OpenMP/HIP applications.
The crash was caused by missing libomptarget.so on the runtime loader path or incorrect LD_PRELOAD settings.
Goal: make rocprof-sys-sample and OpenMP examples run without users needing to manually export LD_LIBRARY_PATH or LD_PRELOAD.

Fixes SWDEV-552804

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
impl.cpp:

- Added runtime discovery of libomptarget.so by checking multiple candidate ROCm LLVM library directories from ROCmVersion_DIR, ROCM_PATH, and /opt/rocm.
- Automatically appends the first directory containing libomptarget.so to LD_LIBRARY_PATH.
- Added verbose logging to show which path was used (or a warning if not found).

examples/openmp/target/CMakeLists.txt:

- Added ROCmVersion_DIR hints to search for libomptarget.
- Extended RPATH to include ${ROCmVersion_DIR}/llvm/lib and $ORIGIN so binaries run without env setup.
- Enabled --enable-new-dtags for modern RUNPATH support.

rocprof-sys-openmp-tests.cmake:

- Pointed _rocm_llvm_lib to ${_rocm_root}/llvm/lib (cleaner default).
- Removed LD_PRELOAD=libomptarget.so — rely on RPATH or discovered LD_LIBRARY_PATH.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

- Built rocprofiler-systems with the changes using cmake --preset debug.
- Installed into /opt/rocprofiler-systems.
- Ran OpenMP-HIP example (HPCTrainingExamples/HIP-OpenMP/CXX/daxpy).
- Verified with and without source setup-env.sh.
- Ran rocprof-sys-sample -PTHD -o trace -- ./daxpy
- Ran rocprof-sys-run -PTHD -o trace -- ./daxpy
- Ran rocprof-sys-causal -o trace -- ./daxpy

In Navi, mi300, mi308, mi325, mi350 and mi355

## Test Result

<!-- Briefly summarize test outcomes. -->
No segmentation fault observed.
libomptarget.so correctly picked up at runtime.
OpenMP example and other test applications run without additional LD_PRELOAD or LD_LIBRARY_PATH settings.
1. rocprof-sys-sample
<img width="1593" height="807" alt="image" src="https://github.com/user-attachments/assets/dc67850c-3bba-4248-bfe2-8db0232a89c4" />
2. rocprof-sys-run
<img width="1587" height="787" alt="image" src="https://github.com/user-attachments/assets/94074ae8-dae0-46c6-aa7c-6051679d5db5" />
3. rocprof-sys-causal
<img width="1587" height="821" alt="image" src="https://github.com/user-attachments/assets/808f64cc-bb48-4822-ae6a-c927df222b08" />

also ran additional openmp-target ctest which passed on all asics
<img width="443" height="397" alt="image" src="https://github.com/user-attachments/assets/029f62ab-d320-455d-a936-cdb3b402216b" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
