### PR TITLE
SWDEV-555798 - Added sync after graphLaunch for Unit_hipGetProcAddres…

### DIFF
--- a/projects/hip-tests/catch/unit/graph/hipGetProcAddressGraphApis.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGetProcAddressGraphApis.cc
@@ -233,9 +233,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_AddMemcpy1DKernelNodes") {
   hipGraphExec_t graphExec;
   HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
   HIP_CHECK(hipGraphLaunch(graphExec, 0));
-#ifdef _WIN32
   HIP_CHECK(hipStreamSynchronize(0));
-#endif
 
   REQUIRE(validateHostArray(hostMem, N, 101) == true);
 
@@ -536,9 +534,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_SetGetParamsMemsetMemcpy") {
   hipGraphExec_t graphExec;
   HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
   HIP_CHECK(hipGraphLaunch(graphExec, 0));
-#ifdef _WIN32
   HIP_CHECK(hipStreamSynchronize(0));
-#endif
 
   REQUIRE(validateArrayT<char>(hostMemDst1, N, 100) == true);
   REQUIRE(validateArrayT<char>(hostMemDst2, N, 120) == true);
@@ -761,9 +757,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_KernelNodeSetGetAttribute") {
   hipGraphExec_t graphExec;
   HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
   HIP_CHECK(hipGraphLaunch(graphExec, 0));
-#ifdef _WIN32
   HIP_CHECK(hipStreamSynchronize(0));
-#endif
 
   HIP_CHECK(hipGraphExecDestroy(graphExec));
   HIP_CHECK(hipGraphDestroy(graph));
@@ -1063,9 +1057,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_Memcpy1DSetParams") {
     hipGraphExec_t graphExec;
     HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
     HIP_CHECK(hipGraphLaunch(graphExec, 0));
-#ifdef _WIN32
     HIP_CHECK(hipStreamSynchronize(0));
-#endif
 
     REQUIRE(validateDeviceArray(devMem_1, N, 10) == true);
     REQUIRE(validateDeviceArray(devMem_2, N, 20) == true);
@@ -1103,9 +1095,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_Memcpy1DSetParams") {
                                                         Nbytes, hipMemcpyHostToDevice));
 
     HIP_CHECK(hipGraphLaunch(graphExec, 0));
-#ifdef _WIN32
     HIP_CHECK(hipStreamSynchronize(0));
-#endif
 
     REQUIRE(validateDeviceArray(devMem_1, N, 10) == true);
     REQUIRE(validateDeviceArray(devMem_2, N, 20) == true);
@@ -1257,9 +1247,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_MemAllocAndFree") {
   HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
 
   HIP_CHECK(hipGraphLaunch(graphExec, 0));
-#ifdef _WIN32
   HIP_CHECK(hipStreamSynchronize(0));
-#endif
 
   REQUIRE(validateHostArray(hostMem, N, 20) == true);
 
@@ -1384,9 +1372,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_ExecMemsetMemcpySetParams") {
   HIP_CHECK(dyn_hipGraphExecMemcpyNodeSetParams_ptr(graphExec, memcpyNode, &newMemcpyParms));
 
   HIP_CHECK(hipGraphLaunch(graphExec, 0));
-#ifdef _WIN32
   HIP_CHECK(hipStreamSynchronize(0));
-#endif
 
   REQUIRE(validateArrayT<char>(hostMemDst1, N, 100) == true);
   REQUIRE(validateArrayT<char>(hostMemDst2, N, 120) == true);


### PR DESCRIPTION
…s_GraphAPIs tests

## Motivation
This PR removes Windows-specific conditional compilation around stream synchronization calls in HIP graph API unit tests. 
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
The change ensures that hipStreamSynchronize(0) is called after hipGraphLaunch on all platforms, not just Windows.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
The tests used to fail randomly as described in https://ontrack-internal.amd.com/browse/SWDEV-555798. This should no longer happen after this change
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Unit_hipGetProcAddress_GraphAPIs returns success even if run repeatedly
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
