### PR TITLE
[CI][rocprofiler-sdk][rocprofv3] Disable attachment validation tests when attachment execution test is disabled

### DIFF
--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/CMakeLists.txt
@@ -71,9 +71,16 @@ add_test(
 
 set_tests_properties(
     rocprofv3-test-attachment-attach-once-csv-validate
-    PROPERTIES TIMEOUT 30 LABELS "integration-tests" DEPENDS
-               rocprofv3-test-attachment-attach-once-execute FIXTURES_REQUIRED
-               rocprofv3-test-attachment-attach-once)
+    PROPERTIES TIMEOUT
+               30
+               LABELS
+               "integration-tests"
+               DEPENDS
+               rocprofv3-test-attachment-attach-once-execute
+               FIXTURES_REQUIRED
+               rocprofv3-test-attachment-attach-once
+               DISABLED
+               "${IS_DISABLED}")
 
 add_test(
     NAME rocprofv3-test-attachment-attach-once-json-validate
@@ -87,6 +94,13 @@ add_test(
 
 set_tests_properties(
     rocprofv3-test-attachment-attach-once-json-validate
-    PROPERTIES TIMEOUT 30 LABELS "integration-tests" DEPENDS
-               rocprofv3-test-attachment-attach-once-execute FIXTURES_REQUIRED
-               rocprofv3-test-attachment-attach-once)
+    PROPERTIES TIMEOUT
+               30
+               LABELS
+               "integration-tests"
+               DEPENDS
+               rocprofv3-test-attachment-attach-once-execute
+               FIXTURES_REQUIRED
+               rocprofv3-test-attachment-attach-once
+               DISABLED
+               "${IS_DISABLED}")

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/CMakeLists.txt
@@ -71,9 +71,16 @@ add_test(
 
 set_tests_properties(
     rocprofv3-test-attachment-attach-twice-csv-validate
-    PROPERTIES TIMEOUT 30 LABELS "integration-tests" DEPENDS
-               rocprofv3-test-attachment-attach-twice-execute FIXTURES_REQUIRED
-               rocprofv3-test-attachment-attach-twice)
+    PROPERTIES TIMEOUT
+               30
+               LABELS
+               "integration-tests"
+               DEPENDS
+               rocprofv3-test-attachment-attach-twice-execute
+               FIXTURES_REQUIRED
+               rocprofv3-test-attachment-attach-twice
+               DISABLED
+               "${IS_DISABLED}")
 
 add_test(
     NAME rocprofv3-test-attachment-attach-twice-json-validate
@@ -87,6 +94,13 @@ add_test(
 
 set_tests_properties(
     rocprofv3-test-attachment-attach-twice-json-validate
-    PROPERTIES TIMEOUT 30 LABELS "integration-tests" DEPENDS
-               rocprofv3-test-attachment-attach-twice-execute FIXTURES_REQUIRED
-               rocprofv3-test-attachment-attach-twice)
+    PROPERTIES TIMEOUT
+               30
+               LABELS
+               "integration-tests"
+               DEPENDS
+               rocprofv3-test-attachment-attach-twice-execute
+               FIXTURES_REQUIRED
+               rocprofv3-test-attachment-attach-twice
+               DISABLED
+               "${IS_DISABLED}")


### PR DESCRIPTION
## Motivation

Disable failing attach validation tests when associated execution tests are disabled

## Technical Details

Propagate disable option to validation tests

## Test Plan

Validation tests should not run in sanitizer suites

## Test Result

Attachment validation tests should not run when execution tests are disabled

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
