### PR TITLE
[att][aqlprofile] Header and fourCC intermittently missing fix

### DIFF
--- a/projects/aqlprofile/src/pm4/sqtt_builder.h
+++ b/projects/aqlprofile/src/pm4/sqtt_builder.h
@@ -342,6 +342,8 @@ class GpuSqttBuilder : public SqttBuilder, protected Primitives {
                                           Primitives::sqtt_mode_on_value());
           base_addr += base_step;
       }
+      // Reset the GRBM to broadcast mode
+      SetGRBMToBroadcast(cmd_buffer);
     } else {
       SetGRBMToBroadcast(cmd_buffer);
       builder.BuildWritePConfigRegPacket(cmd_buffer, Primitives::SQ_THREAD_TRACE_STATUS_ADDR, 0);


### PR DESCRIPTION
## Motivation

- SWDEV-555352 [rocprofiler] [att] Header and fourCC intermittently missing
- It looks like it is missing some of the initial writes to indicate a rocprof id and the version are missing from of the thread-trace files.
- the fourcc and the version writes are only present in the thread-trace from SE3, while they are missing from SE0, 1 and 2.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
