### PR TITLE
[rocprofiler-compute] make pmc files deterministic

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -587,8 +587,8 @@ class OmniSoC_Base:
 
         # Create separate perfmon file for LEVEL counters without _sum suffix
         # TCC LEVEL counters are handled channel wise, so ignore them
-        # Convert set to list for determinism in pmc txt files
-        counters = list(counters)
+        # Convert set to sorted list for determinism in pmc txt files
+        counters = sorted(list(counters))
         for counter in counters.copy():
             if (
                 "LEVEL" in counter

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -587,6 +587,8 @@ class OmniSoC_Base:
 
         # Create separate perfmon file for LEVEL counters without _sum suffix
         # TCC LEVEL counters are handled channel wise, so ignore them
+        # Convert set to list for determinism in pmc txt files
+        counters = list(counters)
         for counter in counters.copy():
             if (
                 "LEVEL" in counter


### PR DESCRIPTION
## Motivation

Making perfmon text files deterministic makes debugging easier and allows for consistent counter collection.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Use sorted list instead of sets for ordering guarantee

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Run tests cases locally

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Tests passing 100%

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
