### PR TITLE
[rocprofiler-systems] Make lock init and destroy callback events instant

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -929,9 +929,6 @@ ompt_tracing_callback_start(rocprofiler_callback_tracing_record_t record,
     // Forces omp_parallel begin and end to have same name, allowing perfetto track to
     // connect. This will be changed in the future
     if(record.operation == ROCPROFILER_OMPT_ID_parallel_begin) _name = "omp_parallel";
-    // Although not necessary to connect them, this forces a unified name instead of
-    // the whole track being named omp_lock_init
-    if(record.operation == ROCPROFILER_OMPT_ID_lock_init) _name = "omp_lock";
 
     if(get_use_timemory())
     {
@@ -984,9 +981,6 @@ ompt_tracing_callback_stop(
     // Forces omp_parallel begin and end to have same name, allowing perfetto track to
     // connect. This will be changed in the future
     if(record.operation == ROCPROFILER_OMPT_ID_parallel_end) _name = "omp_parallel";
-    // Although not necessary to connect them, this forces a unified name instead of
-    // the whole track being named omp_lock_init
-    if(record.operation == ROCPROFILER_OMPT_ID_lock_destroy) _name = "omp_lock";
 
     if(get_use_timemory())
     {
@@ -1317,11 +1311,7 @@ tool_tracing_callback(rocprofiler_callback_tracing_record_t record,
                         ompt_tracing_callback_stop(record, user_data, ts, _bt_data);
                         break;
                     case ROCPROFILER_OMPT_ID_lock_init:
-                        ompt_tracing_callback_start(record, user_data, ts);
-                        break;
                     case ROCPROFILER_OMPT_ID_lock_destroy:
-                        ompt_tracing_callback_stop(record, user_data, ts, _bt_data);
-                        break;
                     // Although this has endpoint arg, treat it as instant event
                     case ROCPROFILER_OMPT_ID_nest_lock:
                     case ROCPROFILER_OMPT_ID_dispatch:


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
`ROCPROFILER_OMPT_ID_lock_init` and `ROCPROFILER_OMPT_ID_lock_destroy` callbacks should be considered "instant". This is to fix the case where if init is called on thread `A` and destroy on thread `B`, the full track would be put in thread `A`. 

New change breaks up this track into a start and end, which fixed this problem. 

There is only one downside; if the init and destroy occur on the same thread, they will no longer connect to form a complete lock lifecycle. However, you can still infer the lock lifecycle by finding the destroy with the same `wait_id` (`ompt_wait_id_t`) as the init.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Made `ROCPROFILER_OMPT_ID_lock_init` and `ROCPROFILER_OMPT_ID_lock_destroy` part of the instant event list.
Remove name rewrite for both of these callbacks - use the name that `SDK` returns.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
`mutex.f90` and `lock.f90`

## Test Result

<!-- Briefly summarize test outcomes. -->
Code now behaves as expected

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
