### PR TITLE
[rocprofiler-systems] Increase timeout for openmp-vv ctests

### DIFF
--- a/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
@@ -107,8 +107,8 @@ if(ROCPROFSYS_OMPVV_HOST_TESTS)
               -e -v 2 --instrument-loops
             RUNTIME_ARGS
               -e -v 1 --label return args -E ^GOMP
-            REWRITE_TIMEOUT 180
-            RUNTIME_TIMEOUT 360
+            SAMPLING_TIMEOUT 300
+            REWRITE_TIMEOUT 300
             ENVIRONMENT
               "${_ompt_environment};ROCPROFSYS_USE_SAMPLING=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_COUT_OUTPUT=ON"
             REWRITE_RUN_PASS_REGEX "${_OMPT_PASS_REGEX}"
@@ -133,6 +133,8 @@ if(ROCPROFSYS_OMPVV_HOST_TESTS)
             GPU ON
             LABELS "openmp;ompvv;openmp-target"
             REWRITE_ARGS -e -v 2
+            SAMPLING_TIMEOUT 300
+            REWRITE_TIMEOUT 300
             ENVIRONMENT
               "${_ompvv_offload_environment}"
             REWRITE_RUN_PASS_REGEX


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
To prevent timeout failure on MI350X, increase `ctest` timeout to `300` seconds.
**Resolves SWDEV-555453**

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Set `SAMPLING_TIMEOUT` and `REWRITE_TIMEOUT` to `300` for `openmp-vv-host` and `openmp-vv-offload` tests.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Ran all `openmp-vv` `ctests` on MI350X.

## Test Result

<!-- Briefly summarize test outcomes. -->
Tests pass and the longest ones take ~`150` seconds.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
