### PR TITLE
SWDEV-555178 - Fix and enable Unit_hipMemVmm_Uncached

### DIFF
--- a/projects/hip-tests/catch/hipTestMain/config/config_amd_windows
+++ b/projects/hip-tests/catch/hipTestMain/config/config_amd_windows
@@ -989,7 +989,6 @@
         "Unit_hipGraphAddMemAllocNode_Negative_Free_Alloc_Memory_Again",
         "====================================================",
          "==================SWDEV-555665==================================",
-        "Unit_hipMemVmm_Uncached",
         "Unit_TexObjectCreate_TypePitch2D",
         "Unit_hipTexRefSetGetMipmappedArray",
         "Unit_test_generic_target_only_in_regular_fatbin",

--- a/projects/hip-tests/catch/unit/memory/hipMemVmm.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemVmm.cc
@@ -118,9 +118,9 @@ TEST_CASE("Unit_hipMemVmm_Uncached") {
   HIP_CHECK(hipMemGetAllocationGranularity(&granularity, &memAllocationProp,
                                            hipMemAllocationGranularityRecommended));
 
-  size_t size = 4 * 1024;
+  size_t size = granularity * 4;
   void* reservedAddress{nullptr};
-  HIP_CHECK(hipMemAddressReserve(&reservedAddress, size, granularity, nullptr, 0));
+  HIP_CHECK(hipMemAddressReserve(&reservedAddress, size, 0, nullptr, 0));
 
   hipMemGenericAllocationHandle_t gaHandle{nullptr};
   HIP_CHECK(hipMemCreate(&gaHandle, size, &memAllocationProp, 0));


### PR DESCRIPTION
## Motivation

Fix and enable failing test

## Technical Details

hipMemAddressReserve must be called with a size that is a multiple of the granularity

## Test Plan

/

## Test Result

/

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
