### PR TITLE
[rocpd] Convert rocprof-sys sample database to perfetto fails to generate output

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/types.hpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/types.hpp
@@ -635,7 +635,13 @@ template <typename ArchiveT>
 void
 load(ArchiveT& ar, rocpd::types::region::decoded_extdata& data)
 {
-    LOAD_DATA_FIELD(message);
+    try
+    {
+        LOAD_DATA_FIELD(message);
+    } catch(const cereal::Exception& e)
+    {
+        std::cerr << "Error reading \"extdata:message\" from \"region\": " << e.what() << '\n';
+    }
 }
 
 template <typename ArchiveT>
@@ -661,7 +667,13 @@ template <typename ArchiveT>
 void
 load(ArchiveT& ar, rocpd::types::sample::decoded_extdata& data)
 {
-    LOAD_DATA_FIELD(message);
+    try
+    {
+        LOAD_DATA_FIELD(message);
+    } catch(const cereal::Exception& e)
+    {
+        std::cerr << "Error reading \"extdata:message\" from \"sample\": " << e.what() << '\n';
+    }
 }
 
 template <typename ArchiveT>

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/types.hpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/types.hpp
@@ -482,7 +482,16 @@ struct pmc_info
 
 namespace cereal
 {
-#define LOAD_DATA_FIELD(FIELD)       ar(make_nvp(#FIELD, data.FIELD))
+#define LOAD_DATA_FIELD(FIELD) ar(make_nvp(#FIELD, data.FIELD))
+#define LOAD_DATA_FIELD_OPTIONAL(FIELD)                                                            \
+    try                                                                                            \
+    {                                                                                              \
+        ar(make_nvp(#FIELD, data.FIELD));                                                          \
+    } catch(const cereal::Exception&)                                                              \
+    {                                                                                              \
+        /* Skip optional filed */                                                                  \
+        data.FIELD = decltype(data.FIELD){};                                                       \
+    }
 #define LOAD_DATA_NAMED(NAME, FIELD) ar(make_nvp(NAME, data.FIELD))
 #define LOAD_DATA_VALUE(NAME, ARG)   ar(make_nvp(NAME, ARG))
 
@@ -637,13 +646,7 @@ template <typename ArchiveT>
 void
 load(ArchiveT& ar, rocpd::types::region::decoded_extdata& data)
 {
-    try
-    {
-        LOAD_DATA_FIELD(message);
-    } catch(const cereal::Exception&)
-    {
-        // extdata:message is not present in the region table
-    }
+    LOAD_DATA_FIELD_OPTIONAL(message);
 }
 
 template <typename ArchiveT>
@@ -669,13 +672,7 @@ template <typename ArchiveT>
 void
 load(ArchiveT& ar, rocpd::types::sample::decoded_extdata& data)
 {
-    try
-    {
-        LOAD_DATA_FIELD(message);
-    } catch(const cereal::Exception&)
-    {
-        // extdata:message is not present in the sample table
-    }
+    LOAD_DATA_FIELD_OPTIONAL(message);
 }
 
 template <typename ArchiveT>

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/types.hpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/types.hpp
@@ -640,9 +640,9 @@ load(ArchiveT& ar, rocpd::types::region::decoded_extdata& data)
     try
     {
         LOAD_DATA_FIELD(message);
-    } catch(const cereal::Exception& e)
+    } catch(const cereal::Exception&)
     {
-        std::cerr << "Error reading \"extdata:message\" from \"region\": " << e.what() << '\n';
+        // extdata:message is not present in the region table
     }
 }
 
@@ -672,9 +672,9 @@ load(ArchiveT& ar, rocpd::types::sample::decoded_extdata& data)
     try
     {
         LOAD_DATA_FIELD(message);
-    } catch(const cereal::Exception& e)
+    } catch(const cereal::Exception&)
     {
-        std::cerr << "Error reading \"extdata:message\" from \"sample\": " << e.what() << '\n';
+        // extdata:message is not present in the sample table
     }
 }
 

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/types.hpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/types.hpp
@@ -141,6 +141,7 @@ struct agent : public base_class<tool::agent_info>
     uint64_t    nid            = 0;
     uint64_t    absolute_index = 0;
     std::string type           = {};
+    std::string name           = {};
     std::string user_name      = {};
     std::string extdata        = {};
 
@@ -555,6 +556,7 @@ load(ArchiveT& ar, rocpd::types::agent& data)
     LOAD_DATA_FIELD(nid);
     LOAD_DATA_FIELD(absolute_index);
     LOAD_DATA_FIELD(type);
+    LOAD_DATA_FIELD(name);
     LOAD_DATA_FIELD(user_name);
     LOAD_DATA_FIELD(extdata);
 


### PR DESCRIPTION
# PR Details

## Associated Jira Ticket Number/Link
SWDEV-554687
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## Technical details

if extdata is present in the region or sample table, it is expected that it has a "message" field. If there is no "message" filed an exception is thrown and the fix intercepts it. If extdata is present in agent info, it is expected that it has a "name" filed. As the filed provides the same data as it is in the table, the fix changes the logic to use the table field instead.

## Added/updated tests?

<!-- We encourage you to keep the code coverage percentage at 80% and above. -->

- [ ] Yes
- [x] No, Does not apply to this PR.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.