### PR TITLE
[rocprofiler-sdk] Use ROCM_PATH for sdk library path

### DIFF
--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -24,6 +24,7 @@
 ##############################################################################
 
 import argparse
+import os
 import re
 from pathlib import Path
 from typing import Optional
@@ -351,7 +352,9 @@ Examples:
         type=str,
         dest="rocprofiler_sdk_library_path",
         required=False,
-        default="/opt/rocm/lib/librocprofiler-sdk.so",
+        default=str(
+            Path(os.getenv("ROCM_PATH", "/opt/rocm")) / "lib/librocprofiler-sdk.so"
+        ),
         help="\t\t\tSet the path to rocprofiler SDK library.",
     )
     profile_group.add_argument(

--- a/projects/rocprofiler-compute/tests/conftest.py
+++ b/projects/rocprofiler-compute/tests/conftest.py
@@ -23,8 +23,10 @@
 
 ##############################################################################
 
+import os
 import subprocess
 from importlib.machinery import SourceFileLoader
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -45,7 +47,9 @@ def pytest_addoption(parser):
     parser.addoption(
         "--rocprofiler-sdk-library-path",
         type=str,
-        default="/opt/rocm/lib/librocprofiler-sdk.so",
+        default=str(
+            Path(os.getenv("ROCM_PATH", "/opt/rocm")) / "lib/librocprofiler-sdk.so"
+        ),
         help="Path to the rocprofiler-sdk library",
     )
 


### PR DESCRIPTION
## Motivation

Use ROCM_PATH env. var. to get path to rocprofiler sdk library, fallback to /opt/rocm if ROCM_PATH not available

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
