### PR TITLE
[rocprof-compute] fixed function argument dir in apply_filters()

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_webui.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_webui.py
@@ -231,7 +231,7 @@ class webui_analysis(OmniAnalyze_Base):
                         roof_obj.empirical_roofline(
                             ret_df=parser.apply_filters(
                                 workload=base_data[base_run],
-                                dir=self.dest_dir,
+                                dir_path=self.dest_dir,
                                 is_gui=True,
                                 debug=args.debug,
                             )


### PR DESCRIPTION
## Motivation

Noticing errors when utilizing `rocprof-compute analyze --gui ...` where the GUI fails to load with a `TypeError: apply_filters() got an unexpected keyword argument 'dir' exception`.

## Technical Details

Updated the parameter name from `dir` to `dir_path` in the `parser.apply_filters()` call within `analysis_webui.py` to match the updated function signature in `parser.py` that was changed in #787. This basically resolves the parameter mismatch that was causing the web UI callback to crash when filters were applied.

## Test Plan

- Verify that `rocprof-compute analyze -p workloads/*/ --gui` now launches without errors

## Test Result

- `rocprof-compute analyze -p workloads/wgemm/ --gui` launched without any errors, able to navigate around as well.

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
