### PR TITLE
Add ROCPROFSYS_PATH variable to environment

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
@@ -254,10 +254,16 @@ prepare_environment_for_run(std::vector<char*>& _env)
 std::string
 get_rocprofsys_root(void)
 {
-    auto _exe = std::string_view{ realpath("/proc/self/exe", nullptr) };
+    char*       _tmp = realpath("/proc/self/exe", nullptr);
+    std::string _exe = (_tmp) ? std::string{ _tmp } : std::string{};
+
+    if(_tmp) free(_tmp);
+
     auto _pos = _exe.find_last_of('/');
     auto _dir = std::string{ "./" };
-    if(_pos != std::string_view::npos) _dir = _exe.substr(0, _pos);
+
+    if(_pos != std::string::npos) _dir = _exe.substr(0, _pos);
+
     return rocprofsys::common::join("/", _dir, "..");
 }
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
@@ -247,31 +247,32 @@ prepare_environment_for_run(std::vector<char*>& _env)
                         get_realpath(get_internal_libpath("librocprof-sys-dl.so"))),
                    true);
         update_env(_env, "ROCPROFSYS_SCRIPT_DIR", get_internal_script_path());
+        update_env(_env, "ROCPROFSYS_ROOT", get_rocprofsys_root());
     }
+}
+
+std::string
+get_rocprofsys_root(void)
+{
+    auto _exe = std::string_view{ realpath("/proc/self/exe", nullptr) };
+    auto _pos = _exe.find_last_of('/');
+    auto _dir = std::string{ "./" };
+    if(_pos != std::string_view::npos) _dir = _exe.substr(0, _pos);
+    return rocprofsys::common::join("/", _dir, "..");
 }
 
 std::string
 get_internal_libpath(const std::string& _lib)
 {
-    auto _exe = std::string_view{ realpath("/proc/self/exe", nullptr) };
-    auto _pos = _exe.find_last_of('/');
-    auto _dir = std::string{ "./" };
-    if(_pos != std::string_view::npos) _dir = _exe.substr(0, _pos);
-    return rocprofsys::common::join("/", _dir, "..", "lib", _lib);
+    auto _root = get_rocprofsys_root();
+    return rocprofsys::common::join("/", _root, "lib", _lib);
 }
 
 std::string
 get_internal_script_path(void)
 {
-    auto _exe = std::string_view{ realpath("/proc/self/exe", nullptr) };
-    auto _pos = _exe.find_last_of('/');
-    auto _dir = std::string{ "./" };
-    if(_pos != std::string_view::npos) _dir = _exe.substr(0, _pos);
-
-    auto _script_dir = get_realpath(
-        rocprofsys::common::join("/", _dir, "..", "libexec", "rocprofiler-systems"));
-
-    return _script_dir;
+    auto _root = get_rocprofsys_root();
+    return rocprofsys::common::join("/", _root, "libexec", "rocprofiler-systems");
 }
 
 void

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/rocprof-sys-causal.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/rocprof-sys-causal.hpp
@@ -53,6 +53,9 @@ void
 prepare_environment_for_run(std::vector<char*>&);
 
 std::string
+get_rocprofsys_root(void);
+
+std::string
 get_internal_libpath(const std::string& _lib);
 
 std::string

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/impl.cpp
@@ -142,10 +142,16 @@ get_initial_environment()
 std::string
 get_rocprofsys_root(void)
 {
-    auto _exe = std::string_view{ realpath("/proc/self/exe", nullptr) };
+    char*       _tmp = realpath("/proc/self/exe", nullptr);
+    std::string _exe = (_tmp) ? std::string{ _tmp } : std::string{};
+
+    if(_tmp) free(_tmp);
+
     auto _pos = _exe.find_last_of('/');
     auto _dir = std::string{ "./" };
-    if(_pos != std::string_view::npos) _dir = _exe.substr(0, _pos);
+
+    if(_pos != std::string::npos) _dir = _exe.substr(0, _pos);
+
     return rocprofsys::common::join("/", _dir, "..");
 }
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/impl.cpp
@@ -125,7 +125,9 @@ get_initial_environment()
     auto _dl_libpath   = get_realpath(get_internal_libpath("librocprof-sys-dl.so"));
     auto _omni_libpath = get_realpath(get_internal_libpath("librocprof-sys.so"));
     auto _libexecpath  = get_realpath(get_internal_script_path());
+    auto _rootpath     = get_realpath(get_rocprofsys_root());
 
+    update_env(_env, "ROCPROFSYS_ROOT", _rootpath, UPD_REPLACE);
     update_env(_env, "LD_PRELOAD", _dl_libpath, UPD_APPEND);
     update_env(_env, "LD_LIBRARY_PATH", tim::filepath::dirname(_dl_libpath), UPD_APPEND);
     update_env(_env, "ROCPROFSYS_SCRIPT_PATH", _libexecpath, UPD_REPLACE);
@@ -138,27 +140,27 @@ get_initial_environment()
 }
 
 std::string
-get_internal_libpath(const std::string& _lib)
+get_rocprofsys_root(void)
 {
     auto _exe = std::string_view{ realpath("/proc/self/exe", nullptr) };
     auto _pos = _exe.find_last_of('/');
     auto _dir = std::string{ "./" };
     if(_pos != std::string_view::npos) _dir = _exe.substr(0, _pos);
-    return rocprofsys::common::join("/", _dir, "..", "lib", _lib);
+    return rocprofsys::common::join("/", _dir, "..");
+}
+
+std::string
+get_internal_libpath(const std::string& _lib)
+{
+    auto _root = get_rocprofsys_root();
+    return rocprofsys::common::join("/", _root, "lib", _lib);
 }
 
 std::string
 get_internal_script_path(void)
 {
-    auto _exe = std::string_view{ realpath("/proc/self/exe", nullptr) };
-    auto _pos = _exe.find_last_of('/');
-    auto _dir = std::string{ "./" };
-    if(_pos != std::string_view::npos) _dir = _exe.substr(0, _pos);
-
-    auto _script_dir =
-        rocprofsys::common::join("/", _dir, "..", "libexec", "rocprofiler-systems");
-
-    return _script_dir;
+    auto _root = get_rocprofsys_root();
+    return rocprofsys::common::join("/", _root, "libexec", "rocprofiler-systems");
 }
 
 void

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/rocprof-sys-sample.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/rocprof-sys-sample.hpp
@@ -47,6 +47,9 @@ std::vector<char*>
 get_initial_environment();
 
 std::string
+get_rocprofsys_root(void);
+
+std::string
 get_internal_libpath(const std::string& _lib);
 
 std::string

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -165,27 +165,27 @@ remove_env(parser_data& _data, std::string_view _env_var)
 }
 
 std::string
-get_internal_libpath(const std::string& _lib)
-{
-    auto _exe = filepath::realpath("/proc/self/exe", nullptr, false);
-    auto _pos = _exe.find_last_of('/');
-    auto _dir = filepath::get_cwd();
-    if(_pos != std::string_view::npos) _dir = _exe.substr(0, _pos);
-    return filepath::realpath(rocprofsys::common::join("/", _dir, "..", "lib", _lib),
-                              nullptr, false);
-}
-std::string
-get_internal_script_path(void)
+get_rocprofsys_root(void)
 {
     auto _exe = std::string_view{ realpath("/proc/self/exe", nullptr) };
     auto _pos = _exe.find_last_of('/');
     auto _dir = std::string{ "./" };
     if(_pos != std::string_view::npos) _dir = _exe.substr(0, _pos);
+    return rocprofsys::common::join("/", _dir, "..");
+}
 
-    auto _script_dir =
-        rocprofsys::common::join("/", _dir, "..", "libexec", "rocprofiler-systems");
+std::string
+get_internal_libpath(const std::string& _lib)
+{
+    auto _root = get_rocprofsys_root();
+    return rocprofsys::common::join("/", _root, "lib", _lib);
+}
 
-    return _script_dir;
+std::string
+get_internal_script_path(void)
+{
+    auto _root = get_rocprofsys_root();
+    return rocprofsys::common::join("/", _root, "libexec", "rocprofiler-systems");
 }
 
 }  // namespace
@@ -238,6 +238,9 @@ init_parser(parser_data& _data)
 
     auto _libexecpath = get_realpath(get_internal_script_path());
     update_env(_data, "ROCPROFSYS_SCRIPT_PATH", _libexecpath, UPD_REPLACE);
+
+    auto _rootpath = get_realpath(get_rocprofsys_root());
+    update_env(_data, "ROCPROFSYS_ROOT", _rootpath, UPD_REPLACE);
 
     return _data;
 }

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -167,10 +167,16 @@ remove_env(parser_data& _data, std::string_view _env_var)
 std::string
 get_rocprofsys_root(void)
 {
-    auto _exe = std::string_view{ realpath("/proc/self/exe", nullptr) };
+    char*       _tmp = realpath("/proc/self/exe", nullptr);
+    std::string _exe = (_tmp) ? std::string{ _tmp } : std::string{};
+
+    if(_tmp) free(_tmp);
+
     auto _pos = _exe.find_last_of('/');
     auto _dir = std::string{ "./" };
-    if(_pos != std::string_view::npos) _dir = _exe.substr(0, _pos);
+
+    if(_pos != std::string::npos) _dir = _exe.substr(0, _pos);
+
     return rocprofsys::common::join("/", _dir, "..");
 }
 


### PR DESCRIPTION
## Motivation
Fixes SWDEV-556903. Removes the dependency on the user running `source /opt/rocm/share/rocprofiler-systems/setup-env.sh` before capturing a trace.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Add a `ROCPROFSYS_ROOT` environment variable when the tool setups up its environment.
Refactored some of the other helper functions to use this new helper function.

## Test Plan

Running the rocpd tests included in https://github.com/ROCm/rocm-systems/pull/834 to verify tests pass without the use of the setupenv.sh script.

## Test Result

<img width="1543" height="149" alt="image" src="https://github.com/user-attachments/assets/2b093222-2e1a-446d-bc8d-dcd303112a87" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
