### PR TITLE
SWDEV-516613 - Fixes for OpenCL printf conformance test failures

### DIFF
--- a/projects/clr/rocclr/device/pal/palprintf.cpp
+++ b/projects/clr/rocclr/device/pal/palprintf.cpp
@@ -171,6 +171,26 @@ bool PrintfDbg::allocate(bool realloc) {
   return (nullptr != dbgBuffer_) ? true : false;
 }
 
+bool PrintfDbgHSA::createCleanupResource() {
+  // Create a resource for cleanup value
+  if (!cleanValue_.create(Resource::Remote)) return false;
+  uint32_t* value = reinterpret_cast<uint32_t*>(cleanValue_.map(nullptr));
+  if (!value) return false;
+
+  *value = 0;
+  cleanValue_.unmap(nullptr);
+  return true;
+}
+
+bool PrintfDbgHSA::cleanUpDbgBuffer(VirtualGPU& gpu) const {
+  // clear contents of debug buffer
+  if (!cleanValue_.partialMemCopyTo(gpu, amd::Coord3D(0, 0, 0), amd::Coord3D(0, 0, 0),
+                                    amd::Coord3D(dbgBuffer_->size(), 0, 0), *dbgBuffer_)) {
+    return false;
+  }
+  return true;
+}
+
 bool PrintfDbg::checkFloat(const std::string& fmt) const {
   switch (fmt[fmt.size() - 1]) {
     case 'e':
@@ -719,6 +739,8 @@ bool PrintfDbgHSA::output(VirtualGPU& gpu, bool printfEnabled,
     }
 
     dev().xferRead().release(gpu, *xferBufRead_);
+
+    if (!cleanUpDbgBuffer(gpu)) return false;
   }
 
   return true;

--- a/projects/clr/rocclr/device/pal/palprintf.cpp
+++ b/projects/clr/rocclr/device/pal/palprintf.cpp
@@ -211,6 +211,10 @@ int PrintfDbg::checkVectorSpecifier(const std::string& fmt, size_t startPos, siz
     else if ((curPos >= 5) && (fmt[curPos - 5] == 'v')) {
       size = 4;
     }
+    // modifier is "hh" or "hl" with vec size 16
+    else if ((curPos >= 6) && (fmt[curPos - 6] == 'v')) {
+      size = 5;
+    }
     if (size > 0) {
       curPos = size;
       pos -= curPos;
@@ -254,11 +258,9 @@ size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t
   if (checkString(fmt.c_str())) {
     // copiedBytes should be as number of printed chars
     copiedBytes = 0;
-    //(null) should be printed
     if (*(reinterpret_cast<const unsigned char*>(argument)) == 0) {
-      amd::Os::printf(fmt.data(), 0);
-      // copiedBytes = strlen("(null)")
-      copiedBytes = 6;
+      // accounts for null character
+      copiedBytes = 1;
     } else {
       const unsigned char* argumentStr = reinterpret_cast<const unsigned char*>(argument);
       amd::Os::printf(fmt.data(), argumentStr);
@@ -291,7 +293,7 @@ size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t
           const float fArg = size == 2
                                  ? amd::half2float(*(reinterpret_cast<const uint16_t*>(argument)))
                                  : *(reinterpret_cast<const float*>(argument));
-          static const char* fSpecifiers = "eEfgGa";
+          static const char* fSpecifiers = "eEfFgGaA";
           std::string fmtF = fmt;
           size_t posS = fmtF.find_first_of("%");
           size_t posE = fmtF.find_first_of(fSpecifiers);
@@ -319,13 +321,7 @@ size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t
         } else {
           bool hhModifier = (strstr(fmt.c_str(), "hh") != nullptr);
           if (hhModifier) {
-            // current implementation of printf in gcc 4.5.2 runtime libraries, doesn`t recognize
-            // "hh" modifier ==>
-            // argument should be explicitly converted to  unsigned char (uchar) before printing and
-            // fmt should be updated not to contain "hh" modifier
-            std::string hhFmt = fmt;
-            hhFmt.erase(hhFmt.find_first_of("h"), 2);
-            amd::Os::printf(hhFmt.data(), *(reinterpret_cast<const unsigned char*>(argument)));
+            amd::Os::printf(fmt.data(), *(reinterpret_cast<const unsigned char*>(argument)));
           } else if (hlModifier) {
             amd::Os::printf(hlFmt.data(), size == 2
                                               ? *(reinterpret_cast<const uint16_t*>(argument))
@@ -366,7 +362,7 @@ size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t
 
 void PrintfDbg::outputDbgBuffer(const device::PrintfInfo& info, const uint32_t* workitemData,
                                 size_t& i) const {
-  static const char* specifiers = "cdieEfgGaosuxXp";
+  static const char* specifiers = "cdieEfFgGaAosuxXp";
   static const char* modifiers = "hl";
   static const char* special = "%n";
   static const std::string sepStr = "%s";
@@ -479,8 +475,14 @@ void PrintfDbg::outputDbgBuffer(const device::PrintfInfo& info, const uint32_t* 
     }
   }
 
+  // handle '%%' escapes
   if (pos != std::string::npos) {
     fmt = str.substr(pos, str.size() - pos);
+    size_t P = fmt.find("%%");
+    while (P != std::string::npos) {
+      fmt.replace(P, 2, "%");
+      P = fmt.find("%%", P);
+    }
     outputArgument(sepStr, false, ConstStr, fmt.data());
   }
 }

--- a/projects/clr/rocclr/device/pal/palprintf.cpp
+++ b/projects/clr/rocclr/device/pal/palprintf.cpp
@@ -231,7 +231,9 @@ int PrintfDbg::checkVectorSpecifier(const std::string& fmt, size_t startPos, siz
     else if ((curPos >= 5) && (fmt[curPos - 5] == 'v')) {
       size = 4;
     }
-    // modifier is "hh" or "hl" with vec size 16
+    // modifier is "hh" or "hl" with vec size 16. i.e
+    // specifiers such as "%v16hhd", "%v16hld". total size 
+    // of vector spcifier + length modifier would then be 5.
     else if ((curPos >= 6) && (fmt[curPos - 6] == 'v')) {
       size = 5;
     }
@@ -279,7 +281,9 @@ size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t
     // copiedBytes should be as number of printed chars
     copiedBytes = 0;
     if (*(reinterpret_cast<const unsigned char*>(argument)) == 0) {
-      // accounts for null character
+      // accounts for null character, empty strings should not be
+      // printed as "(null)". setting copiedBytes to 1 indicates
+      // null character in the buffer has been consumed.
       copiedBytes = 1;
     } else {
       const unsigned char* argumentStr = reinterpret_cast<const unsigned char*>(argument);

--- a/projects/clr/rocclr/device/pal/palprintf.hpp
+++ b/projects/clr/rocclr/device/pal/palprintf.hpp
@@ -157,7 +157,8 @@ class PrintfDbg : public amd::HeapObject {
 class PrintfDbgHSA : public PrintfDbg {
  public:
   //! Default constructor
-  PrintfDbgHSA(Device& device, FILE* file = NULL) : PrintfDbg(device, file) {}
+  PrintfDbgHSA(Device& device, FILE* file = NULL) : PrintfDbg(device, file),
+                                                    cleanValue_(device, 4) {}
 
   //! Initializes the debug buffer before kernel's execution
   bool init(VirtualGPU& gpu,    //!< Virtual GPU object
@@ -170,12 +171,21 @@ class PrintfDbgHSA : public PrintfDbg {
               const std::vector<device::PrintfInfo>& printfInfo  //!< printf info
   );
 
+  //! create cleanup resource for debug buffer
+  bool createCleanupResource();
+
+  //! Clean up debug buffer after flushing the contents.
+  bool cleanUpDbgBuffer(VirtualGPU& gpu) const;
+
  private:
   //! Disable copy constructor
   PrintfDbgHSA(const PrintfDbgHSA&);
 
   //! Disable assignment
   PrintfDbgHSA& operator=(const PrintfDbgHSA&);
+
+  //! Resource to clear debug buffer
+  Memory cleanValue_;
 };
 
 /*@}*/  // namespace amd::pal

--- a/projects/clr/rocclr/device/pal/palvirtual.cpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.cpp
@@ -990,6 +990,11 @@ bool VirtualGPU::create(bool profiling, uint deviceQueueSize, uint rtCUs,
     return false;
   }
 
+  if (!printfDbgHSA_->createCleanupResource()) {
+    LogError("Could not create cleanup resource for debug buffer!");
+    return false;
+  }
+
   tsCache_ = new TimeStampCache(*this);
   if (nullptr == tsCache_) {
     LogError("Could not create TimeStamp cache!");

--- a/projects/clr/rocclr/device/rocm/rocprintf.cpp
+++ b/projects/clr/rocclr/device/rocm/rocprintf.cpp
@@ -107,7 +107,9 @@ int PrintfDbg::checkVectorSpecifier(const std::string& fmt, size_t startPos, siz
     else if ((curPos >= 5) && (fmt[curPos - 5] == 'v')) {
       size = 4;
     }
-    // modifier is "hh" or "hl" with vec size 16
+    // modifier is "hh" or "hl" with vec size 16. i.e
+    // specifiers such as "%v16hhd", "%v16hld". total size 
+    // of vector spcifier + length modifier would then be 5.
     else if ((curPos >= 6) && (fmt[curPos - 6] == 'v')) {
       size = 5;
     }
@@ -154,7 +156,9 @@ size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t
     // copiedBytes should be as number of printed chars
     copiedBytes = 0;
     if (*(reinterpret_cast<const unsigned char*>(argument)) == 0) {
-      // accounts for null character
+      // accounts for null character, empty strings should not be
+      // printed as "(null)". setting copiedBytes to 1 indicates
+      // null character in the buffer has been consumed.
       copiedBytes = 1;
     } else {
       const unsigned char* argumentStr = reinterpret_cast<const unsigned char*>(argument);
@@ -382,9 +386,10 @@ void PrintfDbg::outputDbgBuffer(const device::PrintfInfo& info, const uint32_t* 
   }
 
   // handle '%%' escapes
+  size_t P = 0;
   if (pos != std::string::npos) {
     fmt = str.substr(pos, str.size() - pos);
-    size_t P = fmt.find("%%", P);
+    P = fmt.find("%%", P);
     while (P != std::string::npos) {
       fmt.replace(P, 2, "%");
       P = fmt.find("%%", P);

--- a/projects/clr/rocclr/device/rocm/rocprintf.cpp
+++ b/projects/clr/rocclr/device/rocm/rocprintf.cpp
@@ -60,6 +60,11 @@ bool PrintfDbg::allocate(bool realloc) {
   return (nullptr != dbgBuffer_) ? true : false;
 }
 
+void PrintfDbg::cleanUpDbgBuffer() const {
+  if (!dbgBuffer_) return;
+  memset(dbgBuffer_, 0, dbgBuffer_size_);
+}
+
 bool PrintfDbg::checkFloat(const std::string& fmt) const {
   switch (fmt[fmt.size() - 1]) {
     case 'e':
@@ -525,6 +530,8 @@ bool PrintfDbg::output(VirtualGPU& gpu, bool printfEnabled,
       dbgBufferPtr += sb / sizeof(uint32_t);
       sb = 0;
     }
+
+    cleanUpDbgBuffer();
   }
 
   return true;

--- a/projects/clr/rocclr/device/rocm/rocprintf.cpp
+++ b/projects/clr/rocclr/device/rocm/rocprintf.cpp
@@ -65,9 +65,11 @@ bool PrintfDbg::checkFloat(const std::string& fmt) const {
     case 'e':
     case 'E':
     case 'f':
+    case 'F':
     case 'g':
     case 'G':
     case 'a':
+    case 'A':
       return true;
       break;
     default:
@@ -99,6 +101,10 @@ int PrintfDbg::checkVectorSpecifier(const std::string& fmt, size_t startPos, siz
     // the modifier is "hh"
     else if ((curPos >= 5) && (fmt[curPos - 5] == 'v')) {
       size = 4;
+    }
+    // modifier is "hh" or "hl" with vec size 16
+    else if ((curPos >= 6) && (fmt[curPos - 6] == 'v')) {
+      size = 5;
     }
     if (size > 0) {
       curPos = size;
@@ -142,11 +148,9 @@ size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t
   if (checkString(fmt.c_str())) {
     // copiedBytes should be as number of printed chars
     copiedBytes = 0;
-    //(null) should be printed
     if (*(reinterpret_cast<const unsigned char*>(argument)) == 0) {
-      amd::Os::printf(fmt.data(), 0);
-      // copiedBytes = strlen("(null)")
-      copiedBytes = 6;
+      // accounts for null character
+      copiedBytes = 1;
     } else {
       const unsigned char* argumentStr = reinterpret_cast<const unsigned char*>(argument);
       amd::Os::printf(fmt.data(), argumentStr);
@@ -179,7 +183,7 @@ size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t
           const float fArg = size == 2
                                  ? amd::half2float(*(reinterpret_cast<const uint16_t*>(argument)))
                                  : *(reinterpret_cast<const float*>(argument));
-          static const char* fSpecifiers = "eEfgGa";
+          static const char* fSpecifiers = "eEfFgGaA";
           std::string fmtF = fmt;
           size_t posS = fmtF.find_first_of("%");
           size_t posE = fmtF.find_first_of(fSpecifiers);
@@ -207,14 +211,7 @@ size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t
         } else {
           bool hhModifier = (strstr(fmt.c_str(), "hh") != nullptr);
           if (hhModifier) {
-            // current implementation of printf in gcc 4.5.2 runtime libraries,
-            // doesn`t recognize "hh" modifier ==>
-            // argument should be explicitly converted to  unsigned char (uchar)
-            // before printing and
-            // fmt should be updated not to contain "hh" modifier
-            std::string hhFmt = fmt;
-            hhFmt.erase(hhFmt.find_first_of("h"), 2);
-            amd::Os::printf(hhFmt.data(), *(reinterpret_cast<const unsigned char*>(argument)));
+            amd::Os::printf(fmt.data(), *(reinterpret_cast<const unsigned char*>(argument)));
           } else if (hlModifier) {
             amd::Os::printf(hlFmt.data(), size == 2
                                               ? *(reinterpret_cast<const uint16_t*>(argument))
@@ -255,7 +252,7 @@ size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t
 
 void PrintfDbg::outputDbgBuffer(const device::PrintfInfo& info, const uint32_t* workitemData,
                                 size_t& i) const {
-  static const char* specifiers = "cdieEfgGaosuxXp";
+  static const char* specifiers = "cdieEfFgGaAosuxXp";
   static const char* modifiers = "hl";
   static const char* special = "%n";
   static const std::string sepStr = "%s";
@@ -379,8 +376,14 @@ void PrintfDbg::outputDbgBuffer(const device::PrintfInfo& info, const uint32_t* 
     }
   }
 
+  // handle '%%' escapes
   if (pos != std::string::npos) {
     fmt = str.substr(pos, str.size() - pos);
+    size_t P = fmt.find("%%", P);
+    while (P != std::string::npos) {
+      fmt.replace(P, 2, "%");
+      P = fmt.find("%%", P);
+    }
     outputArgument(sepStr, false, ConstStr, reinterpret_cast<const uint32_t*>(fmt.data()));
   }
 }

--- a/projects/clr/rocclr/device/rocm/rocprintf.hpp
+++ b/projects/clr/rocclr/device/rocm/rocprintf.hpp
@@ -101,6 +101,8 @@ class PrintfDbg : public amd::HeapObject {
                        size_t& i                        //!< index to the data in the buffer
   ) const;
 
+  void cleanUpDbgBuffer() const;
+
  private:
   //! Disable copy constructor
   PrintfDbg(const PrintfDbg&);


### PR DESCRIPTION
## Motivation

Fixes for OpenCL printf conformance test failures

## Technical Details

PR contains two commits.

**commit 1 [SWDEV-516613 - Fixes for OpenCL printf conformance test failures]**
contains following fixes

support '%F' and '%A' conversion specifiers
handle "hh" or "hl" modifier with vector size 16
handle '%%' escapes in format string
Don't print "(null)" when format string is empty.

**commit 2 [SWDEV-516613 - Cleanup printf debug buffer after flushing to stdout]**
 is intended to cleanup printf buffer after flushing to stdout.
The printf buffer may contain stale changes from previous kernel executions when buffer is shared (situations such as when kernel is executed in a loop on same device). This change enables buffer clean up after each execution.

## Test Plan

Latest version of OpenCL conformance test suite.

## Test Result

Passes tests on windows and linux (Tested with compiler change https://github.com/llvm/llvm-project/pull/148784).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
