### PR TITLE
SWDEV-554626 - return correct error code

### DIFF
--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -450,12 +450,18 @@ hipError_t StatCO::getStatFunc(hipFunction_t* hfunc, const void* hostFunction, i
 
   // Lazy load
   FatBinaryInfo** module = it->second->moduleInfo();
-  if (*(module) == nullptr) {
+  if (module != nullptr) {
     amd::ScopedLock lock(sclock_);
     if (*(module) == nullptr) {
       hipError_t err = digestFatBinary(module_to_hostModule_[module], *module);
       assert(err == hipSuccess);
+      if (err != hipSuccess) {
+        return err;
+      }
     }
+  } else {
+    // Module was nullptr
+    return hipErrorInvalidDeviceFunction;
   }
 
   return it->second->getStatFunc(hfunc, deviceId);

--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -468,7 +468,7 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
     }
   }
 
-  hipError_t hip_status = hipErrorInvalidImage;
+  hipError_t hip_status = hipErrorNoBinaryForGpu;
   do {
     bool spirv_isa_found = code_obj_map.find(spirv_isa_name) != code_obj_map.end() ||
                            code_obj_map.find(spirv_isa_name_empty) != code_obj_map.end();

--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -468,7 +468,7 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
     }
   }
 
-  hipError_t hip_status = hipErrorNoBinaryForGpu;
+  hipError_t hip_status = hipErrorInvalidImage;
   do {
     bool spirv_isa_found = code_obj_map.find(spirv_isa_name) != code_obj_map.end() ||
                            code_obj_map.find(spirv_isa_name_empty) != code_obj_map.end();

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -702,8 +702,8 @@ hipError_t ihipLaunchKernel(const void* hostFunction, dim3 gridDim, dim3 blockDi
   hipError_t hip_error =
       PlatformState::instance().getStatFunc(&func, hostFunction, deviceId);
 
-  // Handle invalid image
-  if(hip_error == hipErrorInvalidImage) {
+  // Handle no binary for GPU
+  if(hip_error == hipErrorNoBinaryForGpu) {
     return hip_error;
   }
 

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -701,6 +701,12 @@ hipError_t ihipLaunchKernel(const void* hostFunction, dim3 gridDim, dim3 blockDi
 
   hipError_t hip_error =
       PlatformState::instance().getStatFunc(&func, hostFunction, deviceId);
+
+  // Handle invalid image
+  if(hip_error == hipErrorInvalidImage) {
+    return hip_error;
+  }
+
   if ((hip_error != hipSuccess) || (func == nullptr)) {
     // assume its hip function type if we did not get a valid output from static
     // func lookup

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -702,8 +702,8 @@ hipError_t ihipLaunchKernel(const void* hostFunction, dim3 gridDim, dim3 blockDi
   hipError_t hip_error =
       PlatformState::instance().getStatFunc(&func, hostFunction, deviceId);
 
-  // Handle no binary for GPU
-  if(hip_error == hipErrorNoBinaryForGpu) {
+  // Handle Invalid Image
+  if(hip_error == hipErrorInvalidImage) {
     return hip_error;
   }
 


### PR DESCRIPTION
## Motivation

If a function is found but module isn't we return `hipErrorNoBinaryForGpu`. If we do not find the function itself, it can be a kernel function and we try for that.

## Technical Details

After introduction of kernel types, it interoperates with launch kernel API. The pointer can be a hostfunction or a kernel pointer.

## Test Plan

No test required

## Test Result

No test required

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
