### PR TITLE
Stopping thread creation after max thread limit

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
@@ -28,6 +28,7 @@
 #include "core/utility.hpp"
 #include "library/causal/delay.hpp"
 #include "library/components/category_region.hpp"
+#include "library/rocprofiler-sdk/counters.hpp"
 #include "library/runtime.hpp"
 #include "library/sampling.hpp"
 #include "library/thread_data.hpp"
@@ -62,7 +63,8 @@ namespace component
 {
 using bundle_t          = tim::lightweight_tuple<comp::wall_clock>;
 using category_region_t = tim::lightweight_tuple<category_region<category::pthread>>;
-
+constexpr size_t allowed_max_threads = tim::operation::set_storage<
+    rocprofsys::rocprofiler_sdk::counter_data_tracker>::max_threads;
 namespace
 {
 auto* is_shutdown   = new bool{ false };  // intentional data leak
@@ -173,15 +175,25 @@ pthread_create_gotcha::wrapper::operator()() const
 
     push_thread_state(ThreadState::Internal);
 
-    int64_t     _tid         = -1;
-    void*       _ret         = nullptr;
-    auto        _is_sampling = false;
-    auto        _bundle      = std::shared_ptr<bundle_t>{};
-    auto        _signals     = std::set<int>{};
-    auto        _coverage    = (get_mode() == Mode::Coverage);
-    const auto& _parent_info = thread_info::get(m_config.parent_tid, InternalTID);
-    const auto& _info        = thread_info::init(m_config.offset);
-    auto        _dtor        = [&]() {
+    int64_t     _tid          = -1;
+    void*       _ret          = nullptr;
+    auto        _is_sampling  = false;
+    auto        _bundle       = std::shared_ptr<bundle_t>{};
+    auto        _signals      = std::set<int>{};
+    auto        _coverage     = (get_mode() == Mode::Coverage);
+    const auto& _parent_info  = thread_info::get(m_config.parent_tid, InternalTID);
+    const auto& _info         = thread_info::init(m_config.offset);
+    auto        sequent_value = _info->index_data ? _info->index_data->sequent_value : -1;
+    if(static_cast<size_t>(sequent_value) >= allowed_max_threads)
+    {
+        ROCPROFSYS_WARNING_F(1,
+                             "[rocprof-sys][WARNING] Maximum allowed thread limit (%zu) "
+                             "reached. Further thread creation and profiling will be "
+                             "disabled to prevent resource exhaustion.\n",
+                             allowed_max_threads);
+        return nullptr;
+    }
+    auto _dtor = [&]() {
         set_thread_state(ThreadState::Internal);
         if(_is_sampling)
         {

--- a/projects/rocprofiler-systems/tests/source/CMakeLists.txt
+++ b/projects/rocprofiler-systems/tests/source/CMakeLists.txt
@@ -41,29 +41,52 @@ set(_thread_limit_environment
     "ROCPROFSYS_TIMEMORY_COMPONENTS=wall_clock,peak_rss,page_rss"
 )
 
-math(EXPR THREAD_LIMIT_TEST_VALUE "${ROCPROFSYS_MAX_THREADS} + 24")
-math(EXPR THREAD_LIMIT_TEST_VALUE_PLUS_ONE "${THREAD_LIMIT_TEST_VALUE} + 1")
-
-set(_thread_limit_pass_regex "\\|${THREAD_LIMIT_TEST_VALUE}>>>")
-set(_thread_limit_fail_regex
-    "\\|${THREAD_LIMIT_TEST_VALUE_PLUS_ONE}>>>|ROCPROFSYS_ABORT_FAIL_REGEX"
+# Thread values to test
+set(THREAD_VALUES
+    ${ROCPROFSYS_MAX_THREADS}
+    1
+    2048
+    4095
+    4096
+    4120
 )
 
-rocprofiler_systems_add_test(
-    SKIP_BASELINE
-    NAME thread-limit
-    TARGET thread-limit
-    LABELS "max-threads"
-    REWRITE_ARGS -e -v 2 -i 1024 --label return args
-    RUNTIME_ARGS -e -v 1 -i 1024 --label return args
-    RUN_ARGS 35 2 ${THREAD_LIMIT_TEST_VALUE}
-    REWRITE_TIMEOUT 180
-    RUNTIME_TIMEOUT 360
-    RUNTIME_PASS_REGEX "${_thread_limit_pass_regex}"
-    SAMPLING_PASS_REGEX "${_thread_limit_pass_regex}"
-    REWRITE_RUN_PASS_REGEX "${_thread_limit_pass_regex}"
-    RUNTIME_FAIL_REGEX "${_thread_limit_fail_regex}"
-    SAMPLING_FAIL_REGEX "${_thread_limit_fail_regex}"
-    REWRITE_RUN_FAIL_REGEX "${_thread_limit_fail_regex}"
-    ENVIRONMENT "${_thread_limit_environment}"
-)
+# Maximum allowed threads
+set(ALLOWED_MAX_THREADS 4096)
+
+# Loop over thread values
+foreach(THREADS IN LISTS THREAD_VALUES)
+    set(THREAD_PASS_VALUE ${THREADS})
+    math(EXPR THREAD_FAIL_VALUE "${THREADS} + 1")
+    if(${THREADS} GREATER_EQUAL ${ALLOWED_MAX_THREADS})
+        math(EXPR THREAD_PASS_VALUE "${ALLOWED_MAX_THREADS} - 1")
+        math(EXPR THREAD_FAIL_VALUE "${THREADS}")
+    endif()
+
+    set(_thread_limit_pass_regex "\\|${THREAD_PASS_VALUE}>>>")
+    set(_thread_limit_fail_regex "\\|${THREAD_FAIL_VALUE}>>>|ROCPROFSYS_ABORT_FAIL_REGEX")
+
+    # Unique test name
+    set(_test_name thread-limit-${THREADS})
+
+    # Add test
+    rocprofiler_systems_add_test(
+        SKIP_BASELINE
+        NAME ${_test_name}
+        TARGET thread-limit
+        LABELS "max-threads"
+        REWRITE_ARGS -e -v 2 -i 1024 --label return args
+        RUNTIME_ARGS -e -v 1 -i 1024 --label return args
+        RUN_ARGS 35 2 ${THREADS}
+        SAMPLING_TIMEOUT 240
+        REWRITE_TIMEOUT 240
+        RUNTIME_TIMEOUT 360
+        RUNTIME_PASS_REGEX "${_thread_limit_pass_regex}"
+        SAMPLING_PASS_REGEX "${_thread_limit_pass_regex}"
+        REWRITE_RUN_PASS_REGEX "${_thread_limit_pass_regex}"
+        RUNTIME_FAIL_REGEX "${_thread_limit_fail_regex}"
+        SAMPLING_FAIL_REGEX "${_thread_limit_fail_regex}"
+        REWRITE_RUN_FAIL_REGEX "${_thread_limit_fail_regex}"
+        ENVIRONMENT "${_thread_limit_environment}"
+    )
+endforeach()


### PR DESCRIPTION
## Motivation

When the Maximum allowed thread limit is reached, then further thread creation and profiling will be disabled to prevent resource exhaustion

## Technical Details

<!-- . -->
Add checks when the threads are reached as the allowed limit, then stop creating threads and sampling
## Test Plan

<!-- Added tests for different boundary values -->
Added tests for different boundary values 
## Test Result

<!-- Validated and verified. -->
Validated and verified
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
