### PR TITLE
clr: Handle graphExec updates

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -3084,6 +3084,13 @@ hipError_t hipGraphNodeSetEnabled(hipGraphExec_t hGraphExec, hipGraphNode_t hNod
     HIP_RETURN(hipErrorInvalidValue);
   }
   clonedNode->SetEnabled(isEnabled);
+
+  // Handle packet batch updates if needed
+  hipError_t status = graphExec->HandleNodeEnabledChange(clonedNode);
+  if (status != hipSuccess) {
+    HIP_RETURN(status);
+  }
+
   HIP_RETURN(hipSuccess);
 }
 

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -401,8 +401,9 @@ hipError_t GraphExec::CaptureAndFormPacketsForGraph() {
   nodeCaptureStatus_.clear();
   nodeCaptureStatus_.resize(topoOrder_.size(), false);
 
-  // Clear previous batches
+  // Clear previous batches and node mapping
   packetBatches_.clear();
+  nodeToBatchMap_.clear();
 
   // Process nodes and create batches of consecutive captured nodes
   for (size_t i = 0; i < topoOrder_.size(); ++i) {
@@ -425,8 +426,14 @@ hipError_t GraphExec::CaptureAndFormPacketsForGraph() {
       // Collect packets from consecutive captured nodes
       size_t j = i;
       size_t capturedNodeCount = 0;
+      size_t currentBatchIndex = packetBatches_.size(); // Index of the batch we're about to create
+
       while (j < topoOrder_.size() && topoOrder_[j]->GraphCaptureEnabled()) {
         auto& currentNode = topoOrder_[j];
+
+        // Store the current packet count before adding new packets
+        size_t packetStartOffset = currentBatch.size();
+
         status = currentNode->CaptureAndFormPacket(GetKernelArgManager(), &currentBatch,
                                                              &currentKernelNames);
 
@@ -434,6 +441,18 @@ hipError_t GraphExec::CaptureAndFormPacketsForGraph() {
           LogError("Packet capture failed");
           return status;
         }
+
+        // Calculate how many packets this node generated
+        size_t packetCount = currentBatch.size() - packetStartOffset;
+
+        // Map this node to its batch and offset information
+        nodeToBatchMap_[currentNode] = NodeBatchInfo(
+          currentBatchIndex,    // Index of the batch we're about to create
+          packetStartOffset,    // Offset where this node's packets start
+          packetCount,          // Number of packets for this node
+          j                     // Node index in topoOrder_
+        );
+
         // Mark this node as successfully captured
         nodeCaptureStatus_[j] = true;
         ++j;
@@ -490,11 +509,95 @@ hipError_t GraphExec::CaptureAQLPackets() {
 }
 
 // ================================================================================================
+hipError_t GraphExec::UpdateNodePacketsInBatch(hip::GraphNode* node) {
+  hipError_t status = hipSuccess;
+
+  // Check if this node is in a batch
+  auto it = nodeToBatchMap_.find(node);
+  if (it != nodeToBatchMap_.end()) {
+    // Node is in a batch, update the packet in the batch
+    const NodeBatchInfo& batchInfo = it->second;
+
+    if (batchInfo.batchIndex < packetBatches_.size()) {
+      PacketBatch& batch = packetBatches_[batchInfo.batchIndex];
+
+      // Capture new packet for this node
+      std::vector<uint8_t*> newPackets;
+      std::vector<std::string> newKernelNames;
+
+      status = node->CaptureAndFormPacket(GetKernelArgManager(), &newPackets, &newKernelNames);
+      if (status != hipSuccess) {
+        return status;
+      }
+
+      // Replace the old packets with new ones
+      // Important: Node update should not impact packetCount so there is no need
+      // to resize the batch
+      if (batchInfo.packetStartOffset + batchInfo.packetCount <= batch.packets.size()) {
+        // Replace with new packets
+        for (size_t i = 0; i < newPackets.size() && i < batchInfo.packetCount; ++i) {
+          batch.packets[batchInfo.packetStartOffset + i] = newPackets[i];
+          batch.kernelNames[batchInfo.packetStartOffset + i] = newKernelNames[i];
+        }
+
+        // If new packet count is different, we need to handle the size mismatch
+        if (newPackets.size() != batchInfo.packetCount) {
+          LogWarning("Packet count mismatch during update - some packets may not be updated");
+        }
+      } else {
+        LogError("Invalid packet offset in batch update");
+        return hipErrorInvalidValue;
+      }
+    } else {
+      LogError("Invalid batch index in node mapping");
+      return hipErrorInvalidValue;
+    }
+  }
+
+  return status;
+}
+
+// ================================================================================================
 hipError_t GraphExec::UpdateAQLPacket(hip::GraphNode* node) {
   hipError_t status = hipSuccess;
   if (max_streams_ == 1) {
-    status = node->CaptureAndFormPacket(kernArgManager_);
+    // Try to update packets in batch first
+    status = UpdateNodePacketsInBatch(node);
+    if (status != hipSuccess) {
+      return status;
+    }
+
+    // If node is not in a batch, use the original approach
+    auto it = nodeToBatchMap_.find(node);
+    if (it == nodeToBatchMap_.end()) {
+      // Node is not in a batch
+      status = node->CaptureAndFormPacket(kernArgManager_);
+    }
   }
+  return status;
+}
+
+// ================================================================================================
+hipError_t GraphExec::HandleNodeEnabledChange(hip::GraphNode* node) {
+  hipError_t status = hipSuccess;
+
+  if (max_streams_ == 1) {
+    // Check if this node is in a batch
+    auto it = nodeToBatchMap_.find(node);
+    if (it != nodeToBatchMap_.end()) {
+      // Node is in a batch - we need to handle the enabled/disabled state
+      if (node->GetEnabled()) {
+        // Node was enabled - re-capture its packets and update the batch
+        status = UpdateNodePacketsInBatch(node);
+        if (status != hipSuccess) {
+          return status;
+        }
+      }
+    } else {
+      // Node is not in a batch - no special handling needed
+    }
+  }
+
   return status;
 }
 
@@ -531,13 +634,38 @@ hipError_t GraphExec::EnqueueGraphWithSingleList(hip::Stream* hip_stream) {
       // Node was successfully captured - find which batch it belongs to
       // and dispatch the entire batch
       if (batchIndex < packetBatches_.size()) {
-        // Dispatch this batch
-        bool batchStatus = hip_stream->vdev()->dispatchAqlPacketBatch(
-            packetBatches_[batchIndex].packets, packetBatches_[batchIndex].kernelNames, accumulate);
-        if (!batchStatus) {
-          status = hipErrorUnknown;
-          accumulate->release();
-          return status;
+        // Check if all nodes in this batch are still enabled
+        bool allNodesEnabled = true;
+        size_t batchStartNode = i;
+        size_t batchEndNode = i + packetBatches_[batchIndex].capturedNodeCount;
+
+        for (size_t nodeIdx = batchStartNode; nodeIdx < batchEndNode && nodeIdx < topoOrder_.size(); ++nodeIdx) {
+          if (!topoOrder_[nodeIdx]->GetEnabled()) {
+            allNodesEnabled = false;
+            break;
+          }
+        }
+
+        if (allNodesEnabled) {
+          // All nodes in batch are enabled - dispatch the entire batch
+          bool batchStatus = hip_stream->vdev()->dispatchAqlPacketBatch(
+              packetBatches_[batchIndex].packets, packetBatches_[batchIndex].kernelNames, accumulate);
+          if (!batchStatus) {
+            status = hipErrorUnknown;
+            accumulate->release();
+            return status;
+          }
+        } else {
+          // Some nodes in batch are disabled - execute nodes individually
+          for (size_t nodeIdx = batchStartNode; nodeIdx < batchEndNode && nodeIdx < topoOrder_.size(); ++nodeIdx) {
+            auto& batchNode = topoOrder_[nodeIdx];
+            if (batchNode->GetEnabled()) {
+              // Execute this node individually
+              batchNode->SetStream(hip_stream);
+              status = batchNode->CreateCommand(batchNode->GetQueue());
+              batchNode->EnqueueCommands(hip_stream);
+            }
+          }
         }
 
         // Skip all consecutive captured nodes that belong to this batch

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -861,6 +861,10 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
   // Capture GPU Packets from graph commands
   hipError_t CaptureAQLPackets();
   hipError_t UpdateAQLPacket(hip::GraphNode* node);
+  // Handle node enable/disable changes that may affect packet batches
+  hipError_t HandleNodeEnabledChange(hip::GraphNode* node);
+  // Helper function to update packets for a node in a batch
+  hipError_t UpdateNodePacketsInBatch(hip::GraphNode* node);
   // Kenrel arg manger is for the entire graph.
   // Child graph also shares the same kernel arg manager object. some apps have 100's of
   // child graph nodes and each child graph has only one node.
@@ -895,11 +899,25 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
       : packets(std::move(p)), kernelNames(std::move(k)), capturedNodeCount(nodeCount) {}
   };
 
+  //! Structure to map nodes to their batch and offset information
+  struct NodeBatchInfo {
+    size_t batchIndex;        // Index in packetBatches_
+    size_t packetStartOffset; // Start offset within the batch's packets vector
+    size_t packetCount;       // Number of packets for this node
+    size_t nodeIndex;         // Index in topoOrder_ for verification
+
+    NodeBatchInfo() : batchIndex(0), packetStartOffset(0), packetCount(0), nodeIndex(0) {}
+    NodeBatchInfo(size_t batchIdx, size_t startOffset, size_t pktCount, size_t nodeIdx)
+      : batchIndex(batchIdx), packetStartOffset(startOffset), packetCount(pktCount), nodeIndex(nodeIdx) {}
+  };
+
   //! Batches of accumulated packets and kernel names for batch dispatch optimization
   //! Each batch contains packets from consecutive captured nodes
   std::vector<PacketBatch> packetBatches_;
   //! Track which nodes were successfully captured (true) vs need individual execution (false)
   std::vector<bool> nodeCaptureStatus_;
+  //! Map from node pointer to its batch information for efficient updates
+  std::unordered_map<hip::GraphNode*, NodeBatchInfo> nodeToBatchMap_;
 };
 
 class ChildGraphNode : public GraphNode, public GraphExec {

--- a/projects/clr/rocclr/device/blit.cpp
+++ b/projects/clr/rocclr/device/blit.cpp
@@ -735,6 +735,16 @@ void HostBlitManager::FillBufferInfo::PackInfo(const device::Memory& memory, siz
   guarantee(fill_size >= pattern_size, "Pattern Size: %u cannot be greater than fill size: %u \n",
             pattern_size, fill_size);
 
+  constexpr bool kDisablePackingOptimization = true;
+
+  // Check if packing optimization is disabled
+  if (kDisablePackingOptimization) {
+    // Simple case: create a single FillBufferInfo without alignment optimization
+    FillBufferInfo fill_info(fill_size);
+    packed_info.push_back(fill_info);
+    return;
+  }
+
   // 2. Calculate the next closest dword aligned address for faster processing
   size_t dst_addr = memory.virtualAddress() + fill_origin;
   size_t aligned_dst_addr = amd::alignUp(dst_addr, kExtendedSize);


### PR DESCRIPTION
* If a node is updated in graphExec the batch needs to be updated
* Same process applies for enable/disable node
* Disable memset optimization which can lead upto 3 packets for memset

## Motivation

Bulk packet doorbell ring forms batches beforehand which may need update

## Technical Details

Maintain a map of node to PackeBatch. that helps to locate the packet in the packetBatches_ 
 
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
