### PR TITLE
SWDEV-556484 - fix stream capture check on null stream

### DIFF
--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -256,7 +256,7 @@ const char* ihipGetErrorName(hipError_t hip_error);
              reinterpret_cast<hip::Stream*>(stream)->GetCaptureStatus() ==                         \
                  hipStreamCaptureStatusInvalidated) {                                              \
     return hipErrorStreamCaptureInvalidated;                                                       \
-  } else {                                                                                         \
+  } else if (stream == nullptr) {                                                                  \
     CHECK_STREAM_CAPTURING()                                                                       \
   }
 


### PR DESCRIPTION
## Motivation
fix stream capture check on null stream
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Run CHECK_STREAM_CAPTURE only for null stream for STREAM_CAPTURE macro
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
400 - Unit_hipStreamBeginCapture_Positive_CapturingFromWithinStrms (Failed)
412 - Unit_hipStreamBeginCapture_StreamSync_OngoingCapture (Failed)
413 - Unit_hipStreamBeginCapture_StreamSync_OngoingCapture_MThread (Exit code 0xc0000409
)
434 - Unit_hipStreamBeginCapture_CapturingFromWithinStrms (Failed)
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Passed.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
