### PR TITLE
SWDEV-556281 - Alter method of capturing printf results

### DIFF
--- a/projects/hip-tests/catch/unit/kernel/hipPrintfKernel.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipPrintfKernel.cc
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 #define HIP_ENABLE_PRINTF
 
-__global__ void run_printf() { printf("Hello World\n"); }
+__global__ void run_printf() { printf("Hello World"); }
 /**
 * @addtogroup hipLaunchKernelGGL
 * @{
@@ -47,19 +47,20 @@ __global__ void run_printf() { printf("Hello World\n"); }
  */
 TEST_CASE("Unit_kernel_ChkPrintf", "[multigpu]") {
   int device_count = 0;
-  CaptureStream capture(stdout);
   HIP_CHECK(hipGetDeviceCount(&device_count));
-  std::string st = "Hello World";
-  const char* check = st.c_str();
+  CaptureStream capture;
+  std::string check = "Hello World";
   for (int i = 0; i < device_count; ++i) {
     HIP_CHECK(hipSetDevice(i));
     if (!HipTest::isPcieAtomicSupported()) continue;
+
+    capture.beginCapture();
     hipLaunchKernelGGL(run_printf, dim3(1), dim3(1), 0, 0);
     HIP_CHECK(hipDeviceSynchronize());
-    std::vector<char> data(st.size() + 1);  // +1 for null terminator
-    std::ifstream CapturedData = capture.getCapturedData();
-    CapturedData.getline(data.data(), st.size() + 1);
-    int result = strcmp(data.data(), check);
+    capture.endCapture();
+
+    auto CapturedData = capture.getCapturedData();
+    int result = check.compare(CapturedData);
     REQUIRE(result == 0);
   }
 }

--- a/projects/hip-tests/catch/unit/kernel/printf_common.h
+++ b/projects/hip-tests/catch/unit/kernel/printf_common.h
@@ -35,62 +35,66 @@ THE SOFTWARE.
 #include <iostream>
 #include <string>
 
-struct CaptureStream {
-  int saved_fd;
-  int orig_fd;
-  int temp_fd;
-
-  char tempname[13] = "mytestXXXXXX";
-
-  explicit CaptureStream(FILE* original) {
-    orig_fd = fileno(original);
-    saved_fd = dup(orig_fd);
-
-    if ((temp_fd = mkstemp(tempname)) == -1) {
+class CaptureStream {
+ public:
+  CaptureStream() {
+    if (pipe2(pipe, 0) == -1) {
       error(0, errno, "Error");
       assert(false);
     }
 
-    fflush(nullptr);
-    if (dup2(temp_fd, orig_fd) == -1) {
+    orig_fd = dup(fileno(stdout));
+    if (orig_fd == -1) {
       error(0, errno, "Error");
       assert(false);
     }
-    if (close(temp_fd) != 0) {
-      error(0, errno, "Error");
-      assert(false);
-    }
-  }
-
-  void restoreStream() {
-    if (saved_fd == -1) return;
-    fflush(nullptr);
-    if (dup2(saved_fd, orig_fd) == -1) {
-      error(0, errno, "Error");
-      assert(false);
-    }
-    if (close(saved_fd) != 0) {
-      error(0, errno, "Error");
-      assert(false);
-    }
-    saved_fd = -1;
-  }
-
-  const char* getTempFilename() { return (const char*)tempname; }
-
-  std::ifstream getCapturedData() {
-    restoreStream();
-    std::ifstream temp(tempname);
-    return temp;
   }
 
   ~CaptureStream() {
-    restoreStream();
-    if (remove(tempname) != 0) {
+    close(orig_fd);
+    close(pipe[READ]);
+    close(pipe[WRITE]);
+  }
+
+  void beginCapture() {
+    fflush(stdout);
+    if (dup2(pipe[WRITE], fileno(stdout)) == -1) {
       error(0, errno, "Error");
       assert(false);
     }
   }
+
+  void endCapture() {
+    // End Capture
+    fflush(stdout);
+    if (dup2(orig_fd, fileno(stdout)) == -1) {
+      error(0, errno, "Error");
+      assert(false);
+    }
+    result.clear();
+
+    // Get string
+    const int bufSize = 2048;
+    char buf[bufSize];
+    int bytesRead = 0;
+    bytesRead = read(pipe[READ], &buf, bufSize);
+    
+    if (bytesRead < 0) {
+      error(0, errno, "Error reading from pipe");
+      assert(false);
+      result.clear();
+    } else {
+      result = std::string(buf, bytesRead);
+    }
+  }
+
+  std::string getCapturedData() { return result; }
+
+ private:
+  enum PIPES { READ, WRITE };
+  int pipe[2] = {0, 0};
+  int orig_fd;
+  std::string result;
 };
 
 #endif  // _STRESSTEST_PRINTF_COMMON_H_


### PR DESCRIPTION
## Motivation

We test our GPU side printf by capturing the output of stdout in a temporary file. This works fine until the user does not have the necessary permissions to create this file. Then the test produces a false failure.

## Technical Details

This patch replaces capturing stdout in a temporary file with a pipe. We then read the results that have been stored in the pipe and return the string.

## Test Plan

N/A

## Test Result

Passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
