### PR TITLE
Update TheRock CI to use health status script

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -52,30 +52,34 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
+          ref: 7afbe45f7eaa4f2e9abcb9cd7f1c4042a2d7b638 # 2025-09-24 commit
 
-      - name: Runner Health Settings
+      - name: Install python deps
         run: |
-          echo "CCACHE_DIR=${CCACHE_DIR}"
-          df -h
-          ccache -z
-          mkdir -p $CCACHE_DIR
-          cmake --version
-          echo "Installed Python versions:"
-          ls -d /opt/python
-          echo "python: $(which python), python3: $(which python3)"
-          echo "Git version: $(git --version)"
+          pip install -r TheRock/requirements.txt
+
+      # safe.directory must be set before Runner health status
+      - name: Adjust git config
+        run: |
           git config --global --add safe.directory $PWD
           git config fetch.parallel 10
+
+      - name: Setup ccache
+        run: |
+          ./TheRock/build_tools/setup_ccache.py \
+            --config-preset "github-oss-presubmit" \
+            --dir "$(dirname $CCACHE_CONFIGPATH)" \
+            --local-path "$CACHE_DIR/ccache"
+
+      - name: Runner health status
+        run: |
+          ./TheRock/build_tools/health_status.py
       
       - name: Fetch sources
         timeout-minutes: 30
         run: |
           ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-math-libs
 
-      - name: Install python deps
-        run: |
-          pip install -r TheRock/requirements.txt
-          pip freeze
 
       - name: Configure Projects
         env:

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
+          ref: 7afbe45f7eaa4f2e9abcb9cd7f1c4042a2d7b638 # 2025-09-24 commit
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -80,6 +81,11 @@ jobs:
       # After other installs, so MSVC get priority in the PATH.
       - name: Configure MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
+      - name: Runner health status
+        run: |
+          ccache --zero-stats
+          python ./TheRock/build_tools/health_status.py
 
       - name: Fetch sources
         timeout-minutes: 30


### PR DESCRIPTION
This will update the CI to match TheRocks CI by introducing to use a python script to report on health status. Commands that were in the section that modified the status were moved to separate sections (ccache, git config, ..).

Related PR:
https://github.com/ROCm/TheRock/pull/1516
