### PR TITLE
Always Enable Beta PC Sampling in Internal CI

### DIFF
--- a/.github/workflows/rocprofiler-sdk-code_coverage.yml
+++ b/.github/workflows/rocprofiler-sdk-code_coverage.yml
@@ -197,7 +197,6 @@ jobs:
             --slave   /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_COMPILER_VERSION }}
 
     - name: Enable PC Sampling
-      if: ${{ contains(matrix.system.gpu, 'mi200') || contains(matrix.system.gpu, 'mi300a') }}
       shell: bash
       working-directory: projects/rocprofiler-sdk
       run: |

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -201,7 +201,6 @@ jobs:
           ccache-variant: ccache
 
       - name: Enable PC Sampling
-        if: ${{ contains(matrix.system.gpu, 'mi200') || contains(matrix.system.gpu, 'mi300a') }}
         shell: bash
         working-directory: projects/rocprofiler-sdk
         run: echo 'ROCPROFILER_PC_SAMPLING_BETA_ENABLED=1' >> $GITHUB_ENV
@@ -413,7 +412,6 @@ jobs:
           ccache-variant: sccache
 
       - name: Enable PC Sampling
-        if: ${{ contains(matrix.system.gpu, 'mi200') || contains(matrix.system.gpu, 'mi300a') }}
         shell: bash
         working-directory: projects/rocprofiler-sdk
         run:
@@ -540,7 +538,6 @@ jobs:
         python3 -m pip install -U --user cmake==3.24.0
 
     - name: Enable PC Sampling
-      if: ${{ contains(matrix.system.gpu, 'mi200') || contains(matrix.system.gpu, 'mi300a') }}
       shell: bash
       working-directory: projects/rocprofiler-sdk
       run: echo 'ROCPROFILER_PC_SAMPLING_BETA_ENABLED=1' >> $GITHUB_ENV


### PR DESCRIPTION
Internal CI will try running all PC sampling tests. Guards for skipping tests if PC sampling is unsupported are embedded in testing suite.

This PR supersedes the #1076 .

## Motivation

To increase PC sampling robustness, we always enable beta PC sampling in rocprofiler's CI tests.

## Technical Details

If PC sampling is unsupported, then:

- On some architectures, we disabled tests in compile time.
- On others, tests will run and emit message for skipping a test.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
