### PR TITLE
SWDEV-553920 - Disable and fix failing tests

### DIFF
--- a/projects/hip-tests/catch/hipTestMain/config/config_amd_linux
+++ b/projects/hip-tests/catch/hipTestMain/config/config_amd_linux
@@ -634,6 +634,8 @@
         "Unit_hipGraphNodeSetEnabled_Functional_MemSet",
         "Unit_hipGraph_PerfCheck_hipGraphExecChildGraphNodeSetParams",
         "Unit_TexObjectCreate_TypePitch2D_IncompleteInit",
+        "=== SWDEV-553920 disabled until multi device graph issues are resolved ===",
+        "Unit_hipGraphUpload_Functional_multidevice_test",
     #endif
     #if defined gfx90a || defined gfx942 || defined gfx950
         "=== SWDEV-443630 : Below test failed in stress test on 19/01/24 ===",

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyPeerAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyPeerAsync.cc
@@ -202,11 +202,9 @@ TEST_CASE("Unit_hipMemcpyPeerAsync_Positive_ZeroSize") {
     HIP_CHECK(hipGetLastError());
 
     constexpr int expected_value = 20;
-    HIP_CHECK(hipSetDevice(dst_device));
     VectorSet<<<block_count, thread_count, 0, stream>>>(dst_alloc.ptr(), expected_value,
                                                         element_count);
     HIP_CHECK(hipGetLastError());
-    HIP_CHECK(hipSetDevice(src_device));
 
     constexpr int set_value_h = 21;
     std::fill_n(result.host_ptr(), element_count, set_value_h);


### PR DESCRIPTION
## Motivation

Tests are failing.

## Technical Details

Kernel can be called only from the device associated with the stream when kernel is called. Multi graph support is not fully added yet, hence disabling the test.

## Test Plan

Running existing tests.

## Test Result

Succeeded. 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
