### PR TITLE
SWDEV-1 fix issues seen due to test sharding

### DIFF
--- a/projects/hip-tests/catch/multiproc/hipDeviceGetPCIBusIdMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipDeviceGetPCIBusIdMproc.cc
@@ -172,7 +172,30 @@ TEST_CASE("Unit_hipDeviceGetPCIBusId_MaskedDevices") {
 /* Compare {pciDomainID, pciBusID, pciDeviceID} values
  * hipDeviceGetPCIBusId vs lspci
  */
+
 TEST_CASE("Unit_hipDeviceGetPCIBusId_CheckPciBusIDWithLspci") {
+  auto are_devices_hidden = []() -> bool {
+#if HT_AMD
+    auto env_res = std::getenv("HIP_VISIBLE_DEVICES");
+    if (env_res == nullptr) {
+      env_res = std::getenv("ROCR_VISIBLE_DEVICES");
+      if (env_res == nullptr) {
+        return false;
+      }
+    }
+    return true;
+#else
+    auto env_res = std::getenv("HIP_VISIBLE_DEVICES");
+    return env_res != nullptr;
+#endif
+  }();
+
+  if (are_devices_hidden) {
+    HipTest::HIP_SKIP_TEST(
+        "There are hidden devices, which means lscpi might report something different than what we "
+        "have here");
+  }
+
   FILE* fpipe;
   {
     // Check if lspci is installed, if not, don't proceed

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetName.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetName.cc
@@ -179,6 +179,25 @@ TEST_CASE("Unit_hipDeviceGetName_PartialFill") {
 #if HT_AMD
 #define BUFFER_LEN 512
 
+static inline std::vector<int> parseVisibleDevices() {
+  std::vector<int> res;
+  auto env_res = std::getenv("HIP_VISIBLE_DEVICES");
+  if (env_res == nullptr) {
+    env_res = std::getenv("ROCR_VISIBLE_DEVICES");
+    if (env_res == nullptr) {
+      return res;
+    }
+  }
+
+  std::stringstream ss(std::string{env_res});
+  std::string item;
+  while (std::getline(ss, item, ',')) {
+    res.push_back(std::stoi(item));
+  }
+
+  return res;
+}
+
 /**
  * Test Description
  * ------------------------
@@ -221,6 +240,17 @@ TEST_CASE("Unit_hipDeviceName_gcnArchName_And_rocm_agent_enumerator") {
       dNameMap[j] = dName;
     }
     j++;
+  }
+
+  auto visible_devices = parseVisibleDevices();
+  if (visible_devices.size() > 0) {
+    // We have visible devices set, basically parse the visible devices and remove the entries
+    size_t start = 0;  // The devices will be reported from 0..
+    std::map<int, std::vector<char>> dNameMapCopy;
+    for (auto device : visible_devices) {
+      dNameMapCopy[start] = dNameMap[device];
+    }
+    dNameMap = dNameMapCopy;
   }
 
   for (const auto& i : dNameMap) {

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
@@ -114,6 +114,26 @@ TEST_CASE("Unit_hipDeviceGetUuid_Negative") {
 }
 #ifdef __linux__
 #if HT_AMD
+
+static inline std::vector<int> parseVisibleDevices() {
+  std::vector<int> res;
+  auto env_res = std::getenv("HIP_VISIBLE_DEVICES");
+  if (env_res == nullptr) {
+    env_res = std::getenv("ROCR_VISIBLE_DEVICES");
+    if (env_res == nullptr) {
+      return res;
+    }
+  }
+
+  std::stringstream ss(std::string{env_res});
+  std::string item;
+  while (std::getline(ss, item, ',')) {
+    res.push_back(std::stoi(item));
+  }
+
+  return res;
+}
+
 /**
  * Test Description
  * ------------------------
@@ -159,6 +179,17 @@ TEST_CASE("Unit_hipDeviceGetUuid_From_RocmInfo") {
       }
     }
     j++;
+  }
+
+  auto visible_devices = parseVisibleDevices();
+  if (visible_devices.size() > 0) {
+    // We have visible devices set, basically parse the visible devices and remove the entries
+    size_t start = 0;  // The devices will be reported from 0..
+    std::map<int, std::vector<char>> uuid_map_copy;
+    for (auto device : visible_devices) {
+      uuid_map_copy[start] = uuid_map[device];
+    }
+    uuid_map = uuid_map_copy;
   }
 
   for (const auto& i : uuid_map) {


### PR DESCRIPTION
## Motivation

We are seeing CI failures, due to test sharding.

## Technical Details

Some tests probe two layers and validate results, one in HIP and other at OS level, some environment variables can modify the HIP results, which can lead to mismatch and failure of tests.

## Test Plan

Existing tests should pass.

## Test Result

Tested on gfx950, the tests where were failing on CI.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
