### PR TITLE
MPI Fortran push-pop count fix for extra MAIN subroutine

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -738,6 +738,24 @@ rocprofsys_reset_preload_hidden(void)
 }
 
 //======================================================================================//
+bool
+is_fortran_main(const char* name)
+{
+    if(!name) return false;
+    std::string func_name{ name };
+
+    // Common Fortran MAIN function regex patterns
+    static const std::vector<std::regex> patterns = {
+        std::regex(R"(^_?MAIN__\(?\))", std::regex::icase),  // _MAIN__, MAIN__, MAIN__()
+        std::regex(R"(^_?main_)", std::regex::icase)         // main_ and _main_
+    };
+
+    for(const auto& pat : patterns)
+    {
+        if(std::regex_search(func_name, pat)) return true;
+    }
+    return false;
+}
 
 extern "C" void
 rocprofsys_finalize_hidden(void)
@@ -891,6 +909,9 @@ rocprofsys_finalize_hidden(void)
                 ++_pop_count;
                 _lvl = 4;
             }
+            // For fortrain applications with additional MAIN subroutine
+            if(is_fortran_main(itr->back()->key().c_str())) ++_pop_count;
+
             ROCPROFSYS_VERBOSE_F(
                 _lvl,
                 "Warning! instrumentation bundle on thread %zu (TID=%li) "

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
@@ -282,7 +282,10 @@ mpi_gotcha::audit(const gotcha_data_t& _data, audit::incoming)
     rocprofsys::mpi::is_finalized()            = true;
 #else
     if(is_root_process() && rocprofsys::get_state() < rocprofsys::State::Finalized)
+    {
+        rocprofsys_pop_trace_hidden(_data.tool_id.c_str());
         rocprofsys_finalize_hidden();
+    }
 #endif
 }
 


### PR DESCRIPTION
## Motivation

Fix the CI failure for MPI Fortran tests due to MAIN subroutine not getting popped from tracing

## Technical Details

Fix CI assert failure by ensuring extra Fortran MAIN subroutine is popped correctly, preventing push/pop trace count mismatch.
The failure was happening when built with ROCPROFSYS_USE_MPI=ON and not with ROCPROFSYS_USE_MPI_HEADERS=ON. If the finalization call is preceded with an additional pop trace for MPI_Finalize/PMPI_Finalize then the MAIN is popped correctly for the full MPI case with ROCPROFSYS_USE_MPI=ON..

## Test Plan

Manual tests were performed with the fix.

## Test Result

The testing confirms the fix works.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
