### PR TITLE
Propagate errors from amd_topology functions

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_topology.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_topology.h
@@ -43,15 +43,17 @@
 #ifndef HSA_RUNTIME_CORE_INC_AMD_TOPOLOGY_H_
 #define HSA_RUNTIME_CORE_INC_AMD_TOPOLOGY_H_
 
+#include "hsa.h"
+
 namespace rocr {
 namespace AMD {
 /// @brief Initializes the runtime.
 /// Should not be called directly, must be called only from Runtime::Acquire()
-bool Load();
+hsa_status_t Load();
 
 /// @brief Shutdown/cleanup of runtime.
 /// Should not be called directly, must be called only from Runtime::Release()
-bool Unload();
+hsa_status_t Unload();
 }  // namespace amd
 }  // namespace rocr
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_topology.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_topology.cpp
@@ -110,15 +110,16 @@ void DiscoverDrivers() {
   }
 }
 
-bool InitializeDriver(std::unique_ptr<core::Driver>& driver) {
+hsa_status_t InitializeDriver(std::unique_ptr<core::Driver>& driver) {
   MAKE_NAMED_SCOPE_GUARD(driver_guard, [&]() { driver->Close(); });
 
-  if (driver->Init() != HSA_STATUS_SUCCESS) {
-    return false;
+  hsa_status_t status_driver_init = driver->Init();
+  if (status_driver_init != HSA_STATUS_SUCCESS) {
+    return status_driver_init;
   }
 
   driver_guard.Dismiss();
-  return true;
+  return status_driver_init;
 }
 
 void DiscoverCpu(HSAuint32 node_id, HsaNodeProperties& node_prop, core::DriverType driver_type) {
@@ -313,7 +314,7 @@ void SurfaceGpuList(std::vector<int32_t>& gpu_list, bool xnack_mode, bool enable
 ///
 /// @details Topology information includes information about each node in the
 /// topology graph, which includes agents, IO links, memory, and caches.
-bool BuildTopology() {
+hsa_status_t BuildTopology() {
   auto rt = core::Runtime::runtime_singleton_;
   std::unordered_map<core::DriverType, HsaSystemProperties> driver_sys_props;
   std::unordered_map<core::DriverType, std::vector<HsaNodeProperties>> driver_node_props;
@@ -335,8 +336,9 @@ bool BuildTopology() {
   for (const auto& driver : rt->AgentDrivers()) {
     auto &sys_props = driver_sys_props[driver->kernel_driver_type_];
     auto &node_props_vec = driver_node_props[driver->kernel_driver_type_];
-    if (driver->GetSystemProperties(sys_props) != HSA_STATUS_SUCCESS)
-      return false;
+    hsa_status_t driver_get_sys_props_status = driver->GetSystemProperties(sys_props);
+    if (driver_get_sys_props_status != HSA_STATUS_SUCCESS)
+      return driver_get_sys_props_status;
 
     const auto num_nodes = sys_props.NumNodes;
 
@@ -349,8 +351,9 @@ bool BuildTopology() {
     uint32_t node_id = 0;
 
     for (auto& node_props : node_props_vec) {
-      if (driver->GetNodeProperties(node_props, node_id) != HSA_STATUS_SUCCESS) {
-        return false;
+      hsa_status_t driver_get_node_props_status = driver->GetNodeProperties(node_props, node_id);
+      if (driver_get_node_props_status != HSA_STATUS_SUCCESS) {
+        return driver_get_node_props_status;
       }
       ++node_id;
     }
@@ -499,32 +502,36 @@ bool BuildTopology() {
       ((AMD::GpuAgent*)src_gpu)->RegisterRecSdmaEngIdMaskPeer(*dst_gpu, rec_sdma_eng_id_mask);
     }
   }
-  return true;
+  return HSA_STATUS_SUCCESS;
 }
 }  // Anonymous namespace
 
-bool Load() {
+hsa_status_t Load() {
   DiscoverDrivers();
 
-  if (core::Runtime::runtime_singleton_->AgentDrivers().empty()) return false;
+  if (core::Runtime::runtime_singleton_->AgentDrivers().empty()) {
+    return HSA_STATUS_ERROR;
+  }
 
   for (auto& d : core::Runtime::runtime_singleton_->AgentDrivers()) {
     bool is_model_enabled = false;
     d->IsModelEnabled(&is_model_enabled);
     if (is_model_enabled) continue;
-    if (!InitializeDriver(d)) return false;
+    hsa_status_t status_driver_init = InitializeDriver(d);
+    if (status_driver_init != HSA_STATUS_SUCCESS) {
+      return status_driver_init;
+    }
   }
 
   return BuildTopology();
 }
 
-bool Unload() {
+hsa_status_t Unload() {
   for (auto& driver : core::Runtime::runtime_singleton_->AgentDrivers()) {
     hsa_status_t ret = driver->ShutDown();
-    if (ret != HSA_STATUS_SUCCESS) return false;
+    if (ret != HSA_STATUS_SUCCESS) return ret;
   }
-
-  return true;
+  return HSA_STATUS_SUCCESS;
 }
 }  // namespace amd
 }  // namespace rocr

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_topology.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_topology.cpp
@@ -119,7 +119,7 @@ hsa_status_t InitializeDriver(std::unique_ptr<core::Driver>& driver) {
   }
 
   driver_guard.Dismiss();
-  return status_driver_init;
+  return HSA_STATUS_SUCCESS;
 }
 
 void DiscoverCpu(HSAuint32 node_id, HsaNodeProperties& node_prop, core::DriverType driver_type) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -119,7 +119,7 @@ bool g_use_mwaitx;
 Runtime* Runtime::runtime_singleton_ = NULL;
 
 hsa_status_t Runtime::Acquire() {
-  ScopedAcquire<KernelMutex> boot(&bootstrap_lock());S
+  ScopedAcquire<KernelMutex> boot(&bootstrap_lock());
 
   if (runtime_singleton_ == NULL) {
     memset(log_flags, 0, sizeof(log_flags));

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -119,7 +119,7 @@ bool g_use_mwaitx;
 Runtime* Runtime::runtime_singleton_ = NULL;
 
 hsa_status_t Runtime::Acquire() {
-  ScopedAcquire<KernelMutex> boot(&bootstrap_lock());
+  ScopedAcquire<KernelMutex> boot(&bootstrap_lock());S
 
   if (runtime_singleton_ == NULL) {
     memset(log_flags, 0, sizeof(log_flags));
@@ -137,7 +137,7 @@ hsa_status_t Runtime::Acquire() {
     hsa_status_t status = runtime_singleton_->Load();
 
     if (status != HSA_STATUS_SUCCESS) {
-      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+      return status;
     }
   }
 
@@ -2171,8 +2171,11 @@ hsa_status_t Runtime::Load() {
   g_use_interrupt_wait = flag_.enable_interrupt();
   g_use_mwaitx = flag_.check_mwaitx(cpuinfo.mwaitx);
 
-  if (!AMD::Load()) {
-    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  {
+    hsa_status_t amd_load_status = AMD::Load();
+    if (amd_load_status != HSA_STATUS_SUCCESS) {
+      return amd_load_status;
+    }
   }
 
   // Setup system clock frequency for the first time.


### PR DESCRIPTION
## Motivation

This PR changes the `AMD::Load` and `AMD::Unload` functions to use `hsa_status_t` to correctly propagate errors along the call chain.

## Technical Details

The code has been changed to propagate the `hsa_status_t` values, instead of collapsing all failing values to `false`, and interpreter any false as `HSA_STATUS_ERROR_OUT_OF_RESOURCES`. This is similar to past changes like https://github.com/ROCm/rocm-systems/commit/53cd59e689dd0d647713cfe357e703551ce3c22f .

## Test Plan

I tested this in the context of https://github.com/ROCm/rocm-systems/issues/1153, and it fixes the problem for me, but I am not sure about the implication for other workflows. This may change other failing situation that used to return `HSA_STATUS_ERROR_OUT_OF_RESOURCES` to some other error codes, and I am not sure how can I test those (for example, the one that required the timeout in https://github.com/ROCm/rocm-systems/blob/81775169ccd217e286a7b500aef3e5de4ce47b4a/projects/rocminfo/rocm_agent_enumerator#L149-L157 .

## Test Result

This fixes https://github.com/ROCm/rocm-systems/issues/1153 .

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
