### PR TITLE
SWDEV-523137 - Fix and enable a few negative tests on NV

### DIFF
--- a/projects/hip-tests/catch/hipTestMain/config/config_nvidia_linux.json
+++ b/projects/hip-tests/catch/hipTestMain/config/config_nvidia_linux.json
@@ -10,18 +10,13 @@
         "Unit_atomicExch_system_Positive_Host_And_GPU - float",
         "Unit_hipModuleUnload_Negative_Double_Unload",
         "=== Below tests are failing PSDB ===",
-        "Unit_hipCreateSurfaceObject_Negative_Parameters",
-        "Unit_hipDestroySurfaceObject_Negative_Parameters",
         "Unit_hipModuleLoad_Positive_Basic",
         "Unit_hipModuleLoad_Negative_Load_From_A_File_That_Is_Not_A_Module",
         "Unit_hipModuleLoadData_Positive_Basic",
         "Unit_hipModuleLoadData_Negative_Parameters",
         "Unit_hipModuleLoadDataEx_Positive_Basic",
         "Unit_hipModuleLoadDataEx_Negative_Parameters",
-        "Unit_hipLaunchKernel_Negative_Parameters",
         "Unit_Assert_Positive_Basic_KernelFail",
         "Unit_hipMemMapArrayAsync_Positive_Basic",
-        "=== Disabling tests which no longer behave the same on nvidia platform ===",
-        "Unit_hipGraphInstantiateWithParams_Negative",
     ]
 }

--- a/projects/hip-tests/catch/unit/graph/hipGraphInstantiateWithParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphInstantiateWithParams.cc
@@ -78,8 +78,8 @@ TEST_CASE("Unit_hipGraphInstantiateWithParams_Negative") {
     hipGraph_t graph;
     HIP_CHECK(hipGraphCreate(&graph, 0));
     hipGraphExec_t graphExec;
-    hipGraphInstantiateParams params;
-    params.flags = 10;
+    hipGraphInstantiateParams params{};
+    params.flags = 100;
     REQUIRE(hipGraphInstantiateWithParams(&graphExec, graph, &params) == hipErrorInvalidValue);
     REQUIRE(params.result_out == hipGraphInstantiateError);
     HIP_CHECK(hipGraphDestroy(graph));

--- a/projects/hip-tests/catch/unit/surface/hipCreateSurfaceObject.cc
+++ b/projects/hip-tests/catch/unit/surface/hipCreateSurfaceObject.cc
@@ -72,7 +72,11 @@ TEST_CASE("Unit_hipCreateSurfaceObject_Negative_Parameters") {
 
   SECTION("array handle is nullptr") {
     resc.res.array.array = nullptr;
+#if HT_AMD
+    HIP_CHECK_ERROR(hipCreateSurfaceObject(&surf, &resc), hipErrorInvalidValue);
+#else
     HIP_CHECK_ERROR(hipCreateSurfaceObject(&surf, &resc), hipErrorInvalidHandle);
+#endif
   }
 
   HIP_CHECK(hipFreeArray(array));

--- a/projects/hip-tests/catch/unit/surface/hipCreateSurfaceObject.cc
+++ b/projects/hip-tests/catch/unit/surface/hipCreateSurfaceObject.cc
@@ -63,25 +63,17 @@ TEST_CASE("Unit_hipCreateSurfaceObject_Negative_Parameters") {
 
   SECTION("invalid resource type") {
     resc.resType = hipResourceTypeLinear;
+#if HT_AMD
     HIP_CHECK_ERROR(hipCreateSurfaceObject(&surf, &resc), hipErrorInvalidValue);
+#else
+    HIP_CHECK_ERROR(hipCreateSurfaceObject(&surf, &resc), hipErrorInvalidChannelDescriptor);
+#endif
   }
 
-#if HT_NVIDIA  // DIsalbed due to defect EXSWHTEC-366
   SECTION("array handle is nullptr") {
     resc.res.array.array = nullptr;
     HIP_CHECK_ERROR(hipCreateSurfaceObject(&surf, &resc), hipErrorInvalidHandle);
   }
-#endif
-
-#if HT_NVIDIA  // Disalbed due to defect EXSWHTEC-367
-  SECTION("freed array handle") {
-    hipArray_t invalid_array;
-    HIP_CHECK(hipMallocArray(&invalid_array, &desc, 64, 0, hipArraySurfaceLoadStore));
-    HIP_CHECK(hipFreeArray(invalid_array));
-    resc.res.array.array = invalid_array;
-    HIP_CHECK_ERROR(hipCreateSurfaceObject(&surf, &resc), hipErrorContextIsDestroyed);
-  }
-#endif
 
   HIP_CHECK(hipFreeArray(array));
 }

--- a/projects/hip-tests/catch/unit/surface/hipDestroySurfaceObject.cc
+++ b/projects/hip-tests/catch/unit/surface/hipDestroySurfaceObject.cc
@@ -61,7 +61,11 @@ TEST_CASE("Unit_hipDestroySurfaceObject_Negative_Parameters") {
     HIP_CHECK(hipCreateSurfaceObject(&surf, &resc));
 
     HIP_CHECK(hipDestroySurfaceObject(surf));
+#if HT_AMD
     HIP_CHECK_ERROR(hipDestroySurfaceObject(surf), hipErrorInvalidValue);
+#else
+    HIP_CHECK(hipDestroySurfaceObject(surf));
+#endif
 
     HIP_CHECK(hipFreeArray(array));
   }

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemAddressFree.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemAddressFree.cc
@@ -95,7 +95,7 @@ TEST_CASE("Unit_hipMemAddressFree_Capture") {
 
   size_t reserved_size = ((granularity + buffer_size - 1) / granularity) * granularity;
 
-  hipDeviceptr_t reserved_ptr = nullptr;
+  void* reserved_ptr = nullptr;
   HIP_CHECK(hipMemAddressReserve(&reserved_ptr, reserved_size, 0, nullptr, 0));
 
   hipStream_t stream = nullptr;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemAddressReserve.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemAddressReserve.cc
@@ -158,7 +158,7 @@ TEST_CASE("Unit_hipMemAddressReserve_Capture") {
   constexpr size_t kAlignment = 2;
   constexpr int kDeviceId = 0;
   hipDevice_t device = 0;
-  hipDeviceptr_t device_ptr = nullptr;
+  void* device_ptr = nullptr;
 
   CTX_CREATE();
   HIP_CHECK(hipDeviceGet(&device, kDeviceId));

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
@@ -690,7 +690,7 @@ TEST_CASE("Unit_hipMemMap_Capture") {
   constexpr size_t kAlignment = 2;
   constexpr int kDeviceId = 0;
   hipDevice_t device = 0;
-  hipDeviceptr_t device_ptr = nullptr;
+  void* device_ptr = nullptr;
 
   CTX_CREATE();
   HIP_CHECK(hipDeviceGet(&device, kDeviceId));

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemRetainAllocationHandle.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemRetainAllocationHandle.cc
@@ -160,7 +160,7 @@ TEST_CASE("Unit_hipMemRetainAllocationHandle_Capture") {
 
   size_t allocation_size = ((granularity + buffer_size - 1) / granularity) * granularity;
   hipMemGenericAllocationHandle_t allocation_handle;
-  hipDeviceptr_t device_ptr;
+  void* device_ptr = nullptr;
   HIP_CHECK(hipMemCreate(&allocation_handle, allocation_size, &allocation_prop, 0));
   HIP_CHECK(hipMemAddressReserve(&device_ptr, allocation_size, 0, 0, 0));
   HIP_CHECK(hipMemMap(device_ptr, allocation_size, 0, allocation_handle, 0));

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
@@ -1353,7 +1353,7 @@ TEST_CASE("Unit_hipMemSetGetAccess_Capture") {
   hipMemGenericAllocationHandle_t mem_handle;
   HIP_CHECK(hipMemCreate(&mem_handle, vmm_bytes, &alloc_prop, 0));
 
-  hipDeviceptr_t vmm_ptr = nullptr;
+  void* vmm_ptr = nullptr;
   HIP_CHECK(hipMemAddressReserve(&vmm_ptr, vmm_bytes, 0, 0, 0));
   HIP_CHECK(hipMemMap(vmm_ptr, vmm_bytes, 0, mem_handle, 0));
   HIP_CHECK(hipMemRelease(mem_handle));
@@ -1489,7 +1489,7 @@ TEST_CASE("Unit_hipMemSetAccessHost_devicealloc") {
 
   HIP_CHECK(hipMemMap(addr, mapSize, 0 /*offset*/, handle, 0 /*flags*/));
 
-  // Grant HOST access. 
+  // Grant HOST access.
   hipMemAccessDesc accHost{};
   accHost.flags = hipMemAccessFlagsProtReadWrite;
   accHost.location.type = hipMemLocationTypeHost;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemUnmap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemUnmap.cc
@@ -108,7 +108,7 @@ TEST_CASE("Unit_hipMemUnmap_Capture") {
   size_t mem_size = ((granularity + kBufferSize - 1) / granularity) * granularity;
 
   hipMemGenericAllocationHandle_t allocation_handle;
-  hipDeviceptr_t device_ptr;
+  void* device_ptr = nullptr;
   HIP_CHECK(hipMemCreate(&allocation_handle, mem_size, &allocation_prop, 0));
   HIP_CHECK(hipMemAddressReserve(&device_ptr, mem_size, 0, nullptr, 0));
   HIP_CHECK(hipMemMap(device_ptr, mem_size, 0, allocation_handle, 0));


### PR DESCRIPTION
## Motivation

 - Fix and enable failing tests

## Technical Details

 - Unit_hipGraphInstantiateWithParams_Negative: fixed struct intialization.
 - Removed section in Unit_hipCreateSurfaceObject_Negative_Parameters as it is undefined behavior to use memory after free.

## Test Plan

 - Run tests on AMD an NV platforms

## Test Result

 - All tests passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
