### PR TITLE
[rocprofiler-sdk][rocpd] Optional message field in region/sample JSON extdata

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
@@ -376,13 +376,17 @@ write_perfetto(
         {
             for(auto itr : region_gen.get(ditr))
             {
-                auto& track = thread_tracks.at(itr.tid);
-                auto  _name = itr.name;
+                auto& track      = thread_tracks.at(itr.tid);
+                auto  _name      = itr.name;
+                auto  _operation = itr.name;
 
                 if(itr.has_extdata())
                 {
-                    if(auto _extdata = itr.get_extdata(); !_extdata.message.empty())
-                        _name = _extdata.message;
+                    auto _extdata = itr.get_extdata();
+                    if(_extdata.message && !_extdata.message->empty())
+                        _name = _extdata.message.value();
+                    if(_extdata.operation && !_extdata.operation->empty())
+                        _operation = _extdata.operation.value();
                 }
 
                 auto _category = ::perfetto::DynamicCategory{get_category_string(itr.category)};
@@ -402,7 +406,7 @@ write_perfetto(
                                   "kind",
                                   itr.category,
                                   "operation",
-                                  _name,
+                                  _operation,
                                   "corr_id",
                                   itr.stack_id,
                                   "ancestor_id",
@@ -419,13 +423,17 @@ write_perfetto(
         {
             for(auto itr : sample_gen.get(ditr))
             {
-                auto& track = thread_tracks.at(itr.tid);
-                auto  _name = itr.name;
+                auto& track      = thread_tracks.at(itr.tid);
+                auto  _name      = itr.name;
+                auto  _operation = itr.name;
 
                 if(itr.has_extdata())
                 {
-                    if(auto _extdata = itr.get_extdata(); !_extdata.message.empty())
-                        _name = _extdata.message;
+                    auto _extdata = itr.get_extdata();
+                    if(_extdata.message && !_extdata.message->empty())
+                        _name = _extdata.message.value();
+                    if(_extdata.operation && !_extdata.operation->empty())
+                        _operation = _extdata.operation.value();
                 }
 
                 auto _category = ::perfetto::DynamicCategory{get_category_string(itr.category)};
@@ -445,7 +453,7 @@ write_perfetto(
                                     "kind",
                                     itr.category,
                                     "operation",
-                                    _name,
+                                    _operation,
                                     "corr_id",
                                     itr.stack_id,
                                     "ancestor_id",

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/types.hpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/types.hpp
@@ -196,7 +196,8 @@ struct region
 {
     struct decoded_extdata
     {
-        std::string message = {};
+        std::optional<std::string> message   = {};
+        std::optional<std::string> operation = {};
     };
 
     uint64_t                id              = 0;
@@ -222,7 +223,8 @@ struct sample
 {
     struct decoded_extdata
     {
-        std::string message = {};
+        std::optional<std::string> message   = {};
+        std::optional<std::string> operation = {};
     };
 
     uint64_t                id              = 0;
@@ -636,6 +638,7 @@ void
 load(ArchiveT& ar, rocpd::types::region::decoded_extdata& data)
 {
     LOAD_DATA_FIELD(message);
+    LOAD_DATA_FIELD(operation);
 }
 
 template <typename ArchiveT>
@@ -662,6 +665,7 @@ void
 load(ArchiveT& ar, rocpd::types::sample::decoded_extdata& data)
 {
     LOAD_DATA_FIELD(message);
+    LOAD_DATA_FIELD(operation);
 }
 
 template <typename ArchiveT>


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
- Fixes issue when extdata of region/sample is not empty but does not contain "message" key in JSON

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Fixes issue when extdata of region/sample is not empty but does not contain "message" key in JSON
- updates cereal submodule with new support for `std::optional<T>` in `JSONInputArchive` and `JSON*OutputArchive` 

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
