### PR TITLE
Fix VulkanTest::CreateMappedStorage _WIN64 segfault

### DIFF
--- a/projects/hip-tests/catch/unit/vulkan_interop/vulkan_test.hh
+++ b/projects/hip-tests/catch/unit/vulkan_interop/vulkan_test.hh
@@ -305,7 +305,7 @@ VulkanTest::MappedBuffer<T> VulkanTest::CreateMappedStorage(uint32_t count,
   VkExportMemoryWin32HandleInfoKHR vulkanExportMemoryWin32HandleInfoKHR = {};
 #endif
 
-if (external) {
+  if (external) {
     vulkan_export_memory_allocate_info.sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_KHR;
     vulkan_export_memory_allocate_info.handleTypes = _mem_handle_type;
 

--- a/projects/hip-tests/catch/unit/vulkan_interop/vulkan_test.hh
+++ b/projects/hip-tests/catch/unit/vulkan_interop/vulkan_test.hh
@@ -300,14 +300,16 @@ VulkanTest::MappedBuffer<T> VulkanTest::CreateMappedStorage(uint32_t count,
   }
 
   VkExportMemoryAllocateInfoKHR vulkan_export_memory_allocate_info = {};
-  if (external) {
+#ifdef _WIN64
+  WindowsSecurityAttributes winSecurityAttributes;
+  VkExportMemoryWin32HandleInfoKHR vulkanExportMemoryWin32HandleInfoKHR = {};
+#endif
+
+if (external) {
     vulkan_export_memory_allocate_info.sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_KHR;
     vulkan_export_memory_allocate_info.handleTypes = _mem_handle_type;
 
 #ifdef _WIN64
-    WindowsSecurityAttributes winSecurityAttributes;
-
-    VkExportMemoryWin32HandleInfoKHR vulkanExportMemoryWin32HandleInfoKHR = {};
     vulkanExportMemoryWin32HandleInfoKHR.sType =
         VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR;
     vulkanExportMemoryWin32HandleInfoKHR.pNext = NULL;
@@ -321,6 +323,7 @@ VulkanTest::MappedBuffer<T> VulkanTest::CreateMappedStorage(uint32_t count,
         ? &vulkanExportMemoryWin32HandleInfoKHR
         : NULL;
 #endif
+
     allocate_info.pNext = &vulkan_export_memory_allocate_info;
   }
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

The hip-tests vulkan_interop test case crashes on Windows.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

winSecurityAttributes and vulkanExportMemoryWin32HandleInfoKHR go out of scope before being used, causing a segfault.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Run the hip-test vulkan_interop tests on Windows.

## Test Result

<!-- Briefly summarize test outcomes. -->

The tests run without a segfault in vkAllocateMemory.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
