### PR TITLE
Fix rocprofiler-sdk-build-ci-docker-images.yml 

### DIFF
--- a/.github/workflows/rocprofiler-sdk-build-ci-docker-images.yml
+++ b/.github/workflows/rocprofiler-sdk-build-ci-docker-images.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Get the latest therock build
         id: therock
         run: |
+          sudo apt-get update
           sudo apt-get install -y python3-pip
           python3 -m pip install -U pip
           python3 -m pip install -U awscli


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
404 Not Found errors when trying to download dependencies in the `Get the latest therock build` step. Adding `sudo apt-get update` command first to avoid this.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Added `sudo apt-get update` to the `rocprofiler-sdk-build-ci-docker-images.yml` workflow.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Ensure Docker can build in PR

## Test Result

<!-- Briefly summarize test outcomes. -->
Workflow passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
