### PR TITLE
rdc: Upgrade gRPC v1.67.1 -> v1.76.0

### DIFF
--- a/projects/rdc/CMakeLists.txt
+++ b/projects/rdc/CMakeLists.txt
@@ -163,7 +163,7 @@ set(COMMON_DIR "${CMAKE_CURRENT_SOURCE_DIR}/common")
 
 set(GRPC_ROOT_DEFAULT "/usr")
 set(GRPC_ROOT ${GRPC_ROOT_DEFAULT} CACHE PATH "GRPC installation directory.")
-set(GRPC_DESIRED_VERSION 1.67.1 CACHE STRING "GRPC desired package version.")
+set(GRPC_DESIRED_VERSION 1.76.0 CACHE STRING "GRPC desired package version.")
 
 # add package search paths
 list(APPEND CMAKE_PREFIX_PATH ${GRPC_ROOT} /usr/local)
@@ -316,6 +316,8 @@ set(TESTS_COMPONENT "tests")
 # Standalone only folders
 if(BUILD_STANDALONE)
     # these packages are later used in server and client targets
+    # Note: absl must be found before protobuf/gRPC to resolve transitive dependencies
+    find_package(absl HINTS ${GRPC_ROOT} CONFIG REQUIRED)
     find_package(protobuf HINTS ${GRPC_ROOT} CONFIG REQUIRED)
     find_package(gRPC ${GRPC_DESIRED_VERSION} HINTS ${GRPC_ROOT} CONFIG REQUIRED)
 

--- a/projects/rdc/README.md
+++ b/projects/rdc/README.md
@@ -133,7 +133,13 @@ If you prefer to build RDC from source, follow the steps below.
 
 ### 🔧 Building gRPC and protoc
 
-**Important:** RDC requires gRPC and protoc to be built from source as pre-built packages are not available.
+**Important:** RDC requires gRPC v1.76.0 and protoc to be built from source. Pre-built packages often have:
+- ABI incompatibilities with different compilers
+- Missing or incorrectly configured CMake package dependencies (abseil, protobuf)
+- Static libraries instead of required shared libraries
+- Version mismatches that cause linker errors
+
+Building from source ensures all dependencies (abseil, protobuf, c-ares, re2, zlib) are built together with consistent compiler flags and proper CMake configuration.
 
 1. **Install Required Tools:**
 
@@ -145,7 +151,7 @@ If you prefer to build RDC from source, follow the steps below.
 2. **Clone and Build gRPC:**
 
     ```bash
-    git clone -b v1.67.1 https://github.com/grpc/grpc --depth=1 --shallow-submodules --recurse-submodules
+    git clone -b v1.76.0 https://github.com/grpc/grpc --depth=1 --shallow-submodules --recurse-submodules
     cd grpc
     export GRPC_ROOT=/opt/grpc
     cmake -B build \
@@ -155,6 +161,7 @@ If you prefer to build RDC from source, follow the steps below.
         -DCMAKE_SHARED_LINKER_FLAGS_INIT=-Wl,--enable-new-dtags,--build-id=sha1,--rpath,'$ORIGIN' \
         -DCMAKE_INSTALL_PREFIX="$GRPC_ROOT" \
         -DCMAKE_INSTALL_LIBDIR=lib \
+        -DCMAKE_CXX_STANDARD=17 \
         -DCMAKE_BUILD_TYPE=Release
     make -C build -j $(nproc)
     sudo make -C build install
@@ -596,6 +603,53 @@ The RAS plugin enables monitoring and counting of ECC (Error-Correcting Code) er
 >    ```
 >
 >    - Log out and log back in to apply group changes.
+>
+>#### 🔗 Build Linking Errors with gRPC
+>
+>**Error Messages:**
+>
+>```
+>undefined reference to `google::protobuf::internal::WireFormatLite::VerifyUtf8String(...)`
+>undefined reference to `absl::lts_20250512::log_internal::LogMessage::CopyToEncodedBuffer(...)`
+>```
+>
+>**Causes:**
+>
+>1. **Wrong gRPC Version:**
+>    - RDC requires exactly gRPC v1.76.0
+>    - Using different versions causes ABI incompatibilities
+>
+>2. **Pre-built gRPC Packages:**
+>    - System packages (apt/yum) often have broken CMake configs
+>    - Missing transitive dependencies (abseil, protobuf)
+>
+>3. **Mixed Build Configurations:**
+>    - gRPC built with different compiler flags than RDC
+>    - Static vs shared library mismatches
+>
+>**Solution:**
+>
+>1. **Remove any existing gRPC installations:**
+>
+>    ```bash
+>    sudo rm -rf /usr/grpc /usr/local/grpc /opt/grpc
+>    ```
+>
+>2. **Build gRPC v1.76.0 from source** (see "Building gRPC and protoc" section above)
+>
+>3. **Ensure CMake finds the correct gRPC:**
+>
+>    ```bash
+>    cmake -B build -DGRPC_ROOT=/opt/grpc
+>    ```
+>
+>4. **Verify gRPC installation:**
+>
+>    ```bash
+>    ls /opt/grpc/lib/libgrpc++.so
+>    ls /opt/grpc/lib/libprotobuf.so
+>    ls /opt/grpc/lib/libabsl_*.so
+>    ```
 >
 >### 🐛 Troubleshooting RDCD
 >

--- a/projects/rdc/docs/install/install.rst
+++ b/projects/rdc/docs/install/install.rst
@@ -58,21 +58,23 @@ gRPC and Protoc must be built from source as the prebuilt packages are not avail
    .. code-block:: shell
 
     sudo apt-get update
-    sudo apt-get install automake make g++ unzip build-essential autoconf libtool pkg-config libgflags-dev libgtest-dev clang libc++-dev curl libcap-dev
+    sudo apt-get install automake make cmake g++ unzip build-essential autoconf libtool pkg-config libgflags-dev libgtest-dev clang libc++-dev curl libcap-dev
 
 2. Clone and build gRPC:
 
    .. code-block:: shell
 
-    git clone -b v1.67.1 https://github.com/grpc/grpc --depth=1 --shallow-submodules --recurse-submodules
+    git clone -b v1.76.0 https://github.com/grpc/grpc --depth=1 --shallow-submodules --recurse-submodules
     cd grpc
     export GRPC_ROOT=/opt/grpc
     cmake -B build \
         -DgRPC_INSTALL=ON \
         -DgRPC_BUILD_TESTS=OFF \
         -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_SHARED_LINKER_FLAGS_INIT=-Wl,--enable-new-dtags,--build-id=sha1,--rpath,'$ORIGIN' \
         -DCMAKE_INSTALL_PREFIX="$GRPC_ROOT" \
         -DCMAKE_INSTALL_LIBDIR=lib \
+        -DCMAKE_CXX_STANDARD=17 \
         -DCMAKE_BUILD_TYPE=Release
     make -C build -j $(nproc)
     sudo make -C build install


### PR DESCRIPTION
this bumps the following third party dependencies:
- zlib: v1.3.1
- cares: v1.34.5
- abseil: 20250512.1
- protobuf: v4.31.1
