### PR TITLE
Cleaned up the cmake script code that sets the LLVM lib path

### DIFF
--- a/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
@@ -7,25 +7,12 @@
 #
 # ----------------------------------------------------------------------------- #
 
-if(ROCmVersion_DIR)
-    set(_rocm_root "${ROCmVersion_DIR}")
-elseif(DEFINED ENV{ROCM_PATH})
-    set(_rocm_root "$ENV{ROCM_PATH}")
-else()
-    set(_rocm_root "/opt/rocm")
-endif()
-
-# Set path to ROCm LLVM library directory containing libomptarget.so
-set(_rocm_llvm_lib "${_rocm_root}/llvm/lib")
-
-set(_rocm_ld_env "LD_LIBRARY_PATH=${_rocm_llvm_lib}:$ENV{LD_LIBRARY_PATH}")
-
-if(NOT EXISTS "${_rocm_llvm_lib}/libomptarget.so" AND ROCPROFSYS_USE_ROCM)
+if(NOT EXISTS "${ROCM_LLVM_LIB_PATH}/libomptarget.so" AND ROCPROFSYS_USE_ROCM)
     message(
         FATAL_ERROR
-        "libomptarget.so not found in ${_rocm_llvm_lib}. "
-        "Verify that ROCm is installed correctly and that _rocm_root "
-        "(${_rocm_root}) points at the right location."
+        "libomptarget.so not found in \"${ROCM_LLVM_LIB_PATH}\". "
+        "Verify that ROCm is installed correctly and that ROCM_PATH "
+        "(${ROCM_PATH}) points at the right location."
     )
 endif()
 

--- a/projects/rocprofiler-systems/tests/rocprof-sys-testing.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-testing.cmake
@@ -69,8 +69,7 @@ if(MAX_CAUSAL_ITERATIONS GREATER 100)
 endif()
 
 if(DEFINED ROCM_PATH)
-    set(ROCM_LLVM_LIB_PATH
-        "${ROCM_PATH}/lib/llvm/lib")
+    set(ROCM_LLVM_LIB_PATH "${ROCM_PATH}/lib/llvm/lib")
     set(_test_library_path
         "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${ROCM_LLVM_LIB_PATH}/:$ENV{LD_LIBRARY_PATH}"
     )

--- a/projects/rocprofiler-systems/tests/rocprof-sys-testing.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-testing.cmake
@@ -68,9 +68,18 @@ if(MAX_CAUSAL_ITERATIONS GREATER 100)
     set(MAX_CAUSAL_ITERATIONS 100)
 endif()
 
-set(_test_library_path
-    "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:$ENV{LD_LIBRARY_PATH}"
-)
+if(DEFINED ROCM_PATH)
+    set(ROCM_LLVM_LIB_PATH
+        "${ROCM_PATH}/lib/llvm/lib")
+    set(_test_library_path
+        "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${ROCM_LLVM_LIB_PATH}/:$ENV{LD_LIBRARY_PATH}"
+    )
+else()
+    set(_test_library_path
+        "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:$ENV{LD_LIBRARY_PATH}"
+    )
+endif()
+
 set(_test_openmp_env "OMP_PROC_BIND=spread" "OMP_PLACES=threads" "OMP_NUM_THREADS=2")
 
 set(_base_environment


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Test openmp-vv-offload-test-target-simd-if-binary-rewrite-run was failing because
libomptarget.so was not in LD_LIBRARY_PATH.
For SWDEV-557500.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Setting _rocm_ld_env to environment setting LD_LIBRARY_PATH=... was overriding a previous setting, so the libraries such as librocprof-sys-rt.so could not be found.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
