### PR TITLE
fix(rocr): Remove entry on hsa_amd_interop_unmap_buffer

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -987,10 +987,11 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents, hsa_handle
 hsa_status_t Runtime::InteropUnmap(void* ptr) {
   auto& driver = core::Runtime::runtime_singleton_->AgentDriver(DriverType::KFD);
 
-  ScopedAcquire<KernelSharedMutex> lock(&memory_lock_);
-  const auto& it = allocation_map_.find(ptr);
-  if (it == allocation_map_.end())
-    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  {
+    std::lock_guard<std::shared_mutex> lock(memory_lock_);
+    if (allocation_map_.find(ptr) == allocation_map_.end())
+      return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
 
   hsa_status_t err = driver.MakeMemoryUnresident(ptr);
   if (err != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
@@ -998,7 +999,10 @@ hsa_status_t Runtime::InteropUnmap(void* ptr) {
   err = driver.DeregisterMemory(ptr);
   if (err != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
-  allocation_map_.erase(it);
+  {
+    std::lock_guard<std::shared_mutex> lock(memory_lock_);
+    allocation_map_.erase(ptr);
+  }
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -987,12 +987,18 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents, hsa_handle
 hsa_status_t Runtime::InteropUnmap(void* ptr) {
   auto& driver = core::Runtime::runtime_singleton_->AgentDriver(DriverType::KFD);
 
+  ScopedAcquire<KernelSharedMutex> lock(&memory_lock_);
+  const auto& it = allocation_map_.find(ptr);
+  if (it == allocation_map_.end())
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
   hsa_status_t err = driver.MakeMemoryUnresident(ptr);
   if (err != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
   err = driver.DeregisterMemory(ptr);
   if (err != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
+  allocation_map_.erase(it);
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -931,12 +931,18 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents, hsa_handle
 hsa_status_t Runtime::InteropUnmap(void* ptr) {
   auto& driver = core::Runtime::runtime_singleton_->AgentDriver(DriverType::KFD);
 
+  ScopedAcquire<KernelSharedMutex> lock(&memory_lock_);
+  const auto& it = allocation_map_.find(ptr);
+  if (it == allocation_map_.end())
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
   hsa_status_t err = driver.MakeMemoryUnresident(ptr);
   if (err != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
   err = driver.DeregisterMemory(ptr);
   if (err != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
+  allocation_map_.erase(it);
   return HSA_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
## Summary

Fix issue where entry is not removed from allocation_map_ on hsa_amd_interop_unmap_buffer.

## JIRA ID

JIRA ID : ROCM-26177

## Test plan

- [ ] Exercise hsa_amd_interop_unmap_buffer and confirm allocation_map_ entry is removed.