### PR TITLE
rocr: Set signal memory allocations to NonPaged

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/signal.cpp
@@ -79,11 +79,11 @@ SharedSignal* SharedSignalPool_t::alloc() {
   ScopedAcquire<HybridMutex> lock(&lock_);
   if (free_list_.empty()) {
     SharedSignal* block = reinterpret_cast<SharedSignal*>(
-        allocate_()(block_size_ * sizeof(SharedSignal), __alignof(SharedSignal), 0, 0));
+        allocate_()(block_size_ * sizeof(SharedSignal), __alignof(SharedSignal), core::MemoryRegion::AllocateNonPaged, 0));
     if (block == nullptr) {
       block_size_ = minblock_;
       block = reinterpret_cast<SharedSignal*>(
-          allocate_()(block_size_ * sizeof(SharedSignal), __alignof(SharedSignal), 0, 0));
+          allocate_()(block_size_ * sizeof(SharedSignal), __alignof(SharedSignal), core::MemoryRegion::AllocateNonPaged, 0));
       if (block == nullptr) throw std::bad_alloc();
     }
 


### PR DESCRIPTION
Set memory allocation to non-paged to avoid issues caused when CP tries to access signals after page has been migrated.