### PR TITLE
Find and include python libs in LD_LIBRARY_PATH for rocprof-sys-python

### DIFF
--- a/projects/rocprofiler-systems/cmake/Templates/console-script.in
+++ b/projects/rocprofiler-systems/cmake/Templates/console-script.in
@@ -14,4 +14,25 @@ run-script()
     eval $@
 }
 
+add_so_paths_to_ld_library_path()
+{
+    local python_name_version=$(basename ${PYTHON_EXECUTABLE})
+    local libdir=$(dirname $(dirname $PYTHON_EXECUTABLE))/lib/${python_name_version}/site-packages
+
+    if [ -d "$libdir" ]; then
+        local so_dirs=$(find "$libdir" -name "*.so" -type f -exec dirname {} \; 2>/dev/null | sort -u)
+
+        for dir in $so_dirs; do
+            if [ -d "$dir" ] && [[ ":$LD_LIBRARY_PATH:" != *":$dir:"* ]]; then
+                export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${dir}"
+            fi
+        done
+    fi
+}
+
+OLD_LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
+add_so_paths_to_ld_library_path
+
 run-script ${PYTHON_EXECUTABLE} -m @SCRIPT_SUBMODULE@ "$(printf ' %q' "$@")"
+
+export LD_LIBRARY_PATH=${OLD_LD_LIBRARY_PATH}

--- a/projects/rocprofiler-systems/cmake/Templates/console-script.in
+++ b/projects/rocprofiler-systems/cmake/Templates/console-script.in
@@ -24,7 +24,7 @@ add_so_paths_to_ld_library_path()
 
         for dir in $so_dirs; do
             if [ -d "$dir" ] && [[ ":$LD_LIBRARY_PATH:" != *":$dir:"* ]]; then
-                export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${dir}"
+                export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}${dir}"
             fi
         done
     fi

--- a/projects/rocprofiler-systems/cmake/Templates/console-script.in
+++ b/projects/rocprofiler-systems/cmake/Templates/console-script.in
@@ -30,7 +30,7 @@ add_so_paths_to_ld_library_path()
     fi
 }
 
-OLD_LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
+OLD_LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}
 add_so_paths_to_ld_library_path
 
 run-script ${PYTHON_EXECUTABLE} -m @SCRIPT_SUBMODULE@ "$(printf ' %q' "$@")"


### PR DESCRIPTION
## Motivation

This PR fixes a critical issue where PyTorch model profiling with rocprofiler-systems fails due to library loading errors.

## Technical Details

The fix modifies the `console-script.in` template to dynamically discover and add Python site-packages directories containing .so files to LD_LIBRARY_PATH, ensuring PyTorch can find the correct ROCm libraries instead of attempting to load missing libraries.

## Test Plan

Testing was performed using ResNet models from HPCTrainingExamples repository.

## Test Result

After the fix, PyTorch models now initialize successfully under rocprofiler-systems profiling and generate complete perfetto traces with proper kernel information.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
