### PR TITLE
Reducing the number of iterations for lulesh tests so they don't time out

### DIFF
--- a/projects/rocprofiler-systems/tests/rocprof-sys-kokkos-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-kokkos-tests.cmake
@@ -46,7 +46,7 @@ rocprofiler_systems_add_test(
         -ME
         [==[lib(gomp|m-)]==]
     LABELS "kokkos;kokkos-profile-library"
-    RUN_ARGS -i 25 -s 20 -p
+    RUN_ARGS -i 5 -s 20 -p
     ENVIRONMENT
         "${_base_environment};ROCPROFSYS_USE_KOKKOSP=ON;ROCPROFSYS_COUT_OUTPUT=ON;ROCPROFSYS_SAMPLING_FREQ=50;ROCPROFSYS_KOKKOSP_PREFIX=[kokkos];KOKKOS_TOOLS_LIBS=librocprof-sys-dl.so"
     REWRITE_RUN_PASS_REGEX "\\|_\\[kokkos\\] [a-zA-Z]"
@@ -146,7 +146,7 @@ rocprofiler_systems_add_test(
         [==[libgomp]==]
         --env
         ROCPROFSYS_TIMEMORY_COMPONENTS="wall_clock peak_rss"
-    RUN_ARGS -i 10 -s 20 -p
+    RUN_ARGS -i 2 -s 20 -p
     ENVIRONMENT "${_timemory_environment};ROCPROFSYS_USE_KOKKOSP=OFF"
     REWRITE_FAIL_REGEX "0 instrumented loops in procedure"
 )


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Some lulesh tests time out because the time limit is 120s and 300s (depending on the test).

## Technical Details
Reducing the number of iterations (-i command line parameter) so lulesh tests can finish faster.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [+] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
