### PR TITLE
[rocprofiler-register] Fix compilation with libc++

### DIFF
--- a/projects/rocprofiler-register/tests/rocprofiler/rocprofiler.cpp
+++ b/projects/rocprofiler-register/tests/rocprofiler/rocprofiler.cpp
@@ -33,6 +33,7 @@
 #include <pthread.h>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 #include <string_view>
 #include <tuple>
 #include <vector>


### PR DESCRIPTION
`tests/rocprofiler/rocprofiler.cpp` uses `std::string` without including `<string>` directly. This works with libstdc++ due to transitive includes, but fails with libc++.

Closes #1240

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
