### PR TITLE
[roctracer] Fix compilation of MatrixTranspose_test.cpp with libc++

### DIFF
--- a/projects/roctracer/test/app/MatrixTranspose_test.cpp
+++ b/projects/roctracer/test/app/MatrixTranspose_test.cpp
@@ -22,13 +22,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#ifdef __cplusplus
-#include <cstdlib>
-using namespace std;
-#else
-#include <stdlib.h>
-#endif
-
 // roctx header file
 #include <roctx.h>
 // roctracer extension API


### PR DESCRIPTION
MatrixTranspose_test.cpp fails to compile with libc++ with error: reference to '__all' is ambiguous.

There is a global namespace `__all` function in clr: https://github.com/ROCm/rocm-systems/blob/98d6d268a0496c017b3d7d0e97c928e6f502b668/projects/clr/hipamd/include/hip/amd_detail/amd_warp_functions.h#L120

and `namespace std { struct __all { ... } }` in libc++:
https://github.com/llvm/llvm-project/blob/69761e761c8d37f4fa96af4483c37c436fa7d295/libcxx/include/__type_traits/conjunction.h#L45

and `using namespace std;` in the test:
https://github.com/ROCm/rocm-systems/blob/98d6d268a0496c017b3d7d0e97c928e6f502b668/projects/roctracer/test/app/MatrixTranspose_test.cpp#L27

This is not an issue of libc++ per https://eel.is/c++draft/lex.name#3.1. It can be fixed in clr, but in reality, `using namespace std;` is just not needed in the test.

Closes #1253.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
