### PR TITLE
SWDEV-553447-[catch2][dtest]-Add hipDeviceMallocUncached to hipMemCreate and hipMemMap flags

### DIFF
--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemCreate.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemCreate.cc
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2023-25 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -58,7 +58,7 @@ static __global__ void square_kernel(int* Buff) {
  *    - unit/virtualMemoryManagement/hipMemCreate.cc
  * Test requirements
  * ------------------------
- *    - HIP_VERSION >= 6.1
+ *    - HIP_VERSION >= 7.0
  */
 TEST_CASE("Unit_hipMemCreate_BasicAllocateDeAlloc_MultGranularity") {
   size_t granularity = 0;
@@ -68,7 +68,17 @@ TEST_CASE("Unit_hipMemCreate_BasicAllocateDeAlloc_MultGranularity") {
   HIP_CHECK(hipDeviceGet(&device, deviceId));
   checkVMMSupported(device);
   hipMemAllocationProp prop{};
-  prop.type = hipMemAllocationTypePinned;
+
+  SECTION("Memory Allocation Type as hipMemAllocationTypePinned") {
+    prop.type = hipMemAllocationTypePinned;
+  }
+
+  #if HT_AMD
+  SECTION("Memory Allocation Type as hipMemAllocationTypeUncached") {
+    prop.type = hipMemAllocationTypeUncached;
+  }
+  #endif
+
   prop.location.type = hipMemLocationTypeDevice;
   prop.location.id = device;  // Current Devices
   HIP_CHECK(
@@ -95,7 +105,7 @@ TEST_CASE("Unit_hipMemCreate_BasicAllocateDeAlloc_MultGranularity") {
  *    - unit/virtualMemoryManagement/hipMemCreate.cc
  * Test requirements
  * ------------------------
- *    - HIP_VERSION >= 6.1
+ *    - HIP_VERSION >= 7.0
  */
 TEST_CASE("Unit_hipMemCreate_ChkDev2HstMemcpy_ReleaseHdlPostUnmap") {
   size_t granularity = 0;
@@ -107,7 +117,17 @@ TEST_CASE("Unit_hipMemCreate_ChkDev2HstMemcpy_ReleaseHdlPostUnmap") {
   HIP_CHECK(hipDeviceGet(&device, deviceId));
   checkVMMSupported(device);
   hipMemAllocationProp prop{};
-  prop.type = hipMemAllocationTypePinned;
+
+  SECTION("Memory Allocation Type as hipMemAllocationTypePinned") {
+    prop.type = hipMemAllocationTypePinned;
+  }
+
+  #if HT_AMD
+  SECTION("Memory Allocation Type as hipMemAllocationTypeUncached") {
+    prop.type = hipMemAllocationTypeUncached;
+  }
+  #endif
+
   prop.location.type = hipMemLocationTypeDevice;
   prop.location.id = device;  // Current Devices
   HIP_CHECK(
@@ -154,7 +174,7 @@ TEST_CASE("Unit_hipMemCreate_ChkDev2HstMemcpy_ReleaseHdlPostUnmap") {
  *    - unit/virtualMemoryManagement/hipMemCreate.cc
  * Test requirements
  * ------------------------
- *    - HIP_VERSION >= 6.1
+ *    - HIP_VERSION >= 7.0
  */
 TEST_CASE("Unit_hipMemCreate_ChkDev2HstMemcpy_ReleaseHdlPreUse") {
   size_t granularity = 0;
@@ -166,7 +186,17 @@ TEST_CASE("Unit_hipMemCreate_ChkDev2HstMemcpy_ReleaseHdlPreUse") {
   HIP_CHECK(hipDeviceGet(&device, deviceId));
   checkVMMSupported(device);
   hipMemAllocationProp prop{};
-  prop.type = hipMemAllocationTypePinned;
+
+  SECTION("Memory Allocation Type as hipMemAllocationTypePinned") {
+    prop.type = hipMemAllocationTypePinned;
+  }
+
+  #if HT_AMD
+  SECTION("Memory Allocation Type as hipMemAllocationTypeUncached") {
+    prop.type = hipMemAllocationTypeUncached;
+  }
+  #endif
+
   prop.location.type = hipMemLocationTypeDevice;
   prop.location.id = device;  // Current Devices
   HIP_CHECK(
@@ -213,7 +243,7 @@ TEST_CASE("Unit_hipMemCreate_ChkDev2HstMemcpy_ReleaseHdlPreUse") {
  *    - unit/virtualMemoryManagement/hipMemCreate.cc
  * Test requirements
  * ------------------------
- *    - HIP_VERSION >= 6.1
+ *    - HIP_VERSION >= 7.0
  */
 TEST_CASE("Unit_hipMemCreate_ChkWithKerLaunch") {
   size_t granularity = 0;
@@ -225,7 +255,17 @@ TEST_CASE("Unit_hipMemCreate_ChkWithKerLaunch") {
   HIP_CHECK(hipDeviceGet(&device, deviceId));
   checkVMMSupported(device);
   hipMemAllocationProp prop{};
-  prop.type = hipMemAllocationTypePinned;
+
+  SECTION("Memory Allocation Type as hipMemAllocationTypePinned") {
+    prop.type = hipMemAllocationTypePinned;
+  }
+
+  #if HT_AMD
+  SECTION("Memory Allocation Type as hipMemAllocationTypeUncached") {
+    prop.type = hipMemAllocationTypeUncached;
+  }
+  #endif
+
   prop.location.type = hipMemLocationTypeDevice;
   prop.location.id = device;  // Current Devices
   HIP_CHECK(
@@ -276,7 +316,7 @@ TEST_CASE("Unit_hipMemCreate_ChkWithKerLaunch") {
  *    - unit/virtualMemoryManagement/hipMemCreate.cc
  * Test requirements
  * ------------------------
- *    - HIP_VERSION >= 6.1
+ *    - HIP_VERSION >= 7.0
  */
 TEST_CASE("Unit_hipMemCreate_MapNonContiguousChunks") {
   size_t granularity = 0;
@@ -289,7 +329,17 @@ TEST_CASE("Unit_hipMemCreate_MapNonContiguousChunks") {
   HIP_CHECK(hipDeviceGet(&device, deviceId));
   checkVMMSupported(device);
   hipMemAllocationProp prop{};
-  prop.type = hipMemAllocationTypePinned;
+
+  SECTION("Memory Allocation Type as hipMemAllocationTypePinned") {
+    prop.type = hipMemAllocationTypePinned;
+  }
+
+  #if HT_AMD
+  SECTION("Memory Allocation Type as hipMemAllocationTypeUncached") {
+    prop.type = hipMemAllocationTypeUncached;
+  }
+  #endif
+
   prop.location.type = hipMemLocationTypeDevice;
   prop.location.id = device;  // Current Devices
   HIP_CHECK(
@@ -350,7 +400,7 @@ TEST_CASE("Unit_hipMemCreate_MapNonContiguousChunks") {
  *    - unit/virtualMemoryManagement/hipMemCreate.cc
  * Test requirements
  * ------------------------
- *    - HIP_VERSION >= 6.1
+ *    - HIP_VERSION >= 7.0
  */
 TEST_CASE("Unit_hipMemCreate_ChkWithMemset") {
   size_t granularity = 0;
@@ -363,7 +413,17 @@ TEST_CASE("Unit_hipMemCreate_ChkWithMemset") {
   HIP_CHECK(hipDeviceGet(&device, deviceId));
   checkVMMSupported(device);
   hipMemAllocationProp prop{};
-  prop.type = hipMemAllocationTypePinned;
+
+  SECTION("Memory Allocation Type as hipMemAllocationTypePinned") {
+    prop.type = hipMemAllocationTypePinned;
+  }
+
+  #if HT_AMD
+  SECTION("Memory Allocation Type as hipMemAllocationTypeUncached") {
+    prop.type = hipMemAllocationTypeUncached;
+  }
+  #endif
+
   prop.location.type = hipMemLocationTypeDevice;
   prop.location.id = device;  // Current Devices
   HIP_CHECK(

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2023-25 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -59,7 +59,7 @@ static __global__ void square_kernel(int* Buff) {
  *    - unit/virtualMemoryManagement/hipMemMap.cc
  * Test requirements
  * ------------------------
- *    - HIP_VERSION >= 6.1
+ *    - HIP_VERSION >= 7.0
  */
 TEST_CASE("Unit_hipMemMap_SameMemoryReuse") {
   constexpr int iterations = 20;
@@ -71,7 +71,17 @@ TEST_CASE("Unit_hipMemMap_SameMemoryReuse") {
   HIP_CHECK(hipDeviceGet(&device, deviceId));
   checkVMMSupported(device);
   hipMemAllocationProp prop{};
-  prop.type = hipMemAllocationTypePinned;
+
+  SECTION("Memory Allocation Type as hipMemAllocationTypePinned") {
+    prop.type = hipMemAllocationTypePinned;
+  }
+
+  #if HT_AMD
+  SECTION("Memory Allocation Type as hipMemAllocationTypeUncached") {
+    prop.type = hipMemAllocationTypeUncached;
+  }
+  #endif
+
   prop.location.type = hipMemLocationTypeDevice;
   prop.location.id = device;  // Current Devices
   HIP_CHECK(
@@ -126,7 +136,7 @@ TEST_CASE("Unit_hipMemMap_SameMemoryReuse") {
  *    - unit/virtualMemoryManagement/hipMemMap.cc
  * Test requirements
  * ------------------------
- *    - HIP_VERSION >= 6.1
+ *    - HIP_VERSION >= 7.0
  */
 TEST_CASE("Unit_hipMemMap_PhysicalMemoryReuse_SingleGPU") {
   size_t granularity = 0;
@@ -137,7 +147,17 @@ TEST_CASE("Unit_hipMemMap_PhysicalMemoryReuse_SingleGPU") {
   HIP_CHECK(hipDeviceGet(&device, deviceId));
   checkVMMSupported(device);
   hipMemAllocationProp prop{};
-  prop.type = hipMemAllocationTypePinned;
+
+  SECTION("Memory Allocation Type as hipMemAllocationTypePinned") {
+    prop.type = hipMemAllocationTypePinned;
+  }
+
+  #if HT_AMD
+  SECTION("Memory Allocation Type as hipMemAllocationTypeUncached") {
+    prop.type = hipMemAllocationTypeUncached;
+  }
+  #endif
+
   prop.location.type = hipMemLocationTypeDevice;
   prop.location.id = device;  // Current Devices
   HIP_CHECK(
@@ -197,7 +217,7 @@ TEST_CASE("Unit_hipMemMap_PhysicalMemoryReuse_SingleGPU") {
  *    - unit/virtualMemoryManagement/hipMemMap.cc
  * Test requirements
  * ------------------------
- *    - HIP_VERSION >= 6.1
+ *    - HIP_VERSION >= 7.0
  */
 TEST_CASE("Unit_hipMemMap_PhysicalMemory_Map2MultVMMs") {
   size_t granularity = 0;
@@ -208,7 +228,17 @@ TEST_CASE("Unit_hipMemMap_PhysicalMemory_Map2MultVMMs") {
   HIP_CHECK(hipDeviceGet(&device, deviceId));
   checkVMMSupported(device);
   hipMemAllocationProp prop{};
-  prop.type = hipMemAllocationTypePinned;
+
+  SECTION("Memory Allocation Type as hipMemAllocationTypePinned") {
+    prop.type = hipMemAllocationTypePinned;
+  }
+
+  #if HT_AMD
+  SECTION("Memory Allocation Type as hipMemAllocationTypeUncached") {
+    prop.type = hipMemAllocationTypeUncached;
+  }
+  #endif
+
   prop.location.type = hipMemLocationTypeDevice;
   prop.location.id = device;  // Current Devices
   HIP_CHECK(
@@ -263,20 +293,7 @@ TEST_CASE("Unit_hipMemMap_PhysicalMemory_Map2MultVMMs") {
   CTX_DESTROY();
 }
 
-/**
- * Test Description
- * ------------------------
- *    - Check if a physical chunk can be mapped/unmapped for
- * multiple vmm addresses. This test validates physical memory
- * reuse using different vmm ranges on multiple devices.
- * ------------------------
- *    - unit/virtualMemoryManagement/hipMemMap.cc
- * Test requirements
- * ------------------------
- *    - HIP_VERSION >= 6.1
- */
-TEST_CASE("Unit_hipMemMap_PhysicalMemoryReuse_MultiDev") {
-  CHECK_P2P_SUPPORT
+void physicalMemoryReuse_MultiDev (hipMemAllocationProp prop) {
   int devicecount = 0;
   HIP_CHECK(hipGetDeviceCount(&devicecount));
   if (devicecount < 2) {
@@ -289,9 +306,6 @@ TEST_CASE("Unit_hipMemMap_PhysicalMemoryReuse_MultiDev") {
     hipDevice_t device;
     HIP_CHECK(hipDeviceGet(&device, devX));
     checkVMMSupported(device);
-    hipMemAllocationProp prop{};
-    prop.type = hipMemAllocationTypePinned;
-    prop.location.type = hipMemLocationTypeDevice;
     prop.location.id = device;  // Current Devices
     HIP_CHECK(
         hipMemGetAllocationGranularity(&granularity, &prop, hipMemAllocationGranularityMinimum));
@@ -336,7 +350,36 @@ TEST_CASE("Unit_hipMemMap_PhysicalMemoryReuse_MultiDev") {
     }
   }
 }
+/**
+ * Test Description
+ * ------------------------
+ *    - Check if a physical chunk can be mapped/unmapped for
+ * multiple vmm addresses. This test validates physical memory
+ * reuse using different vmm ranges on multiple devices.
+ * ------------------------
+ *    - unit/virtualMemoryManagement/hipMemMap.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 7.0
+ */
+TEST_CASE("Unit_hipMemMap_PhysicalMemoryReuse_MultiDev") {
+  CHECK_P2P_SUPPORT
+  SECTION("Memory Allocation Type as hipMemAllocationTypePinned") {
+    hipMemAllocationProp prop{};
+    prop.type = hipMemAllocationTypePinned;
+    prop.location.type = hipMemLocationTypeDevice;
+    physicalMemoryReuse_MultiDev(prop);
+  }
 
+  #if HT_AMD
+  SECTION("Memory Allocation Type as hipMemAllocationTypeUncached") {
+    hipMemAllocationProp prop{};
+    prop.type = hipMemAllocationTypeUncached;
+    prop.location.type = hipMemLocationTypeDevice;
+    physicalMemoryReuse_MultiDev(prop);
+  }
+  #endif
+}
 /**
  * Test Description
  * ------------------------
@@ -347,7 +390,7 @@ TEST_CASE("Unit_hipMemMap_PhysicalMemoryReuse_MultiDev") {
  *    - unit/virtualMemoryManagement/hipMemMap.cc
  * Test requirements
  * ------------------------
- *    - HIP_VERSION >= 6.1
+ *    - HIP_VERSION >= 7.0
  */
 TEST_CASE("Unit_hipMemMap_VMMMemoryReuse_SingleGPU") {
   size_t granularity = 0;
@@ -358,7 +401,17 @@ TEST_CASE("Unit_hipMemMap_VMMMemoryReuse_SingleGPU") {
   HIP_CHECK(hipDeviceGet(&device, deviceId));
   checkVMMSupported(device);
   hipMemAllocationProp prop{};
-  prop.type = hipMemAllocationTypePinned;
+
+  SECTION("Memory Allocation Type as hipMemAllocationTypePinned") {
+    prop.type = hipMemAllocationTypePinned;
+  }
+
+  #if HT_AMD
+  SECTION("Memory Allocation Type as hipMemAllocationTypeUncached") {
+    prop.type = hipMemAllocationTypeUncached;
+  }
+  #endif
+
   prop.location.type = hipMemLocationTypeDevice;
   prop.location.id = device;  // Current Devices
   HIP_CHECK(
@@ -411,20 +464,7 @@ TEST_CASE("Unit_hipMemMap_VMMMemoryReuse_SingleGPU") {
   CTX_DESTROY();
 }
 
-/**
- * Test Description
- * ------------------------
- *    - Check if different physical chunk allocated in different devices
- * can be mapped/unmapped to single vmm address. This test validates VMM
- * memory reuse using different physical ranges.
- * ------------------------
- *    - unit/virtualMemoryManagement/hipMemMap.cc
- * Test requirements
- * ------------------------
- *    - HIP_VERSION >= 6.1
- */
-TEST_CASE("Unit_hipMemMap_VMMMemoryReuse_MultiGPU") {
-  CHECK_P2P_SUPPORT
+void vMMMemoryReuse_MultiGPU (hipMemAllocationProp prop) {
   int deviceId = 0, devicecount = 0;
   HIP_CHECK(hipGetDeviceCount(&devicecount));
   if (devicecount < 2) {
@@ -437,9 +477,6 @@ TEST_CASE("Unit_hipMemMap_VMMMemoryReuse_MultiGPU") {
   HIP_CHECK(hipSetDevice(0));
   HIP_CHECK(hipDeviceGet(&device, deviceId));
   checkVMMSupported(device);
-  hipMemAllocationProp prop{};
-  prop.type = hipMemAllocationTypePinned;
-  prop.location.type = hipMemLocationTypeDevice;
   prop.location.id = device;  // Current Devices
   HIP_CHECK(
       hipMemGetAllocationGranularity(&granularity, &prop, hipMemAllocationGranularityMinimum));
@@ -503,7 +540,36 @@ TEST_CASE("Unit_hipMemMap_VMMMemoryReuse_MultiGPU") {
   }
   HIP_CHECK(hipMemAddressFree(ptrA, size_mem));
 }
+/**
+ * Test Description
+ * ------------------------
+ *    - Check if different physical chunk allocated in different devices
+ * can be mapped/unmapped to single vmm address. This test validates VMM
+ * memory reuse using different physical ranges.
+ * ------------------------
+ *    - unit/virtualMemoryManagement/hipMemMap.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 7.0
+ */
+TEST_CASE("Unit_hipMemMap_VMMMemoryReuse_MultiGPU") {
+  CHECK_P2P_SUPPORT
+  SECTION("Memory Allocation Type as hipMemAllocationTypePinned") {
+    hipMemAllocationProp prop{};
+    prop.type = hipMemAllocationTypePinned;
+    prop.location.type = hipMemLocationTypeDevice;
+    vMMMemoryReuse_MultiGPU(prop);
+  }
 
+  #if HT_AMD
+  SECTION("Memory Allocation Type as hipMemAllocationTypeUncached") {
+    hipMemAllocationProp prop{};
+    prop.type = hipMemAllocationTypeUncached;
+    prop.location.type = hipMemLocationTypeDevice;
+    vMMMemoryReuse_MultiGPU(prop);
+  }
+  #endif
+}
 /**
  * Test Description
  * ------------------------
@@ -513,7 +579,7 @@ TEST_CASE("Unit_hipMemMap_VMMMemoryReuse_MultiGPU") {
  *    - unit/virtualMemoryManagement/hipMemMap.cc
  * Test requirements
  * ------------------------
- *    - HIP_VERSION >= 6.1
+ *    - HIP_VERSION >= 7.0
  */
 TEST_CASE("Unit_hipMemMap_MapPartialVMMMem") {
   int deviceId = 0;
@@ -524,7 +590,17 @@ TEST_CASE("Unit_hipMemMap_MapPartialVMMMem") {
   HIP_CHECK(hipDeviceGet(&device, deviceId));
   checkVMMSupported(device);
   hipMemAllocationProp prop{};
-  prop.type = hipMemAllocationTypePinned;
+
+  SECTION("Memory Allocation Type as hipMemAllocationTypePinned") {
+    prop.type = hipMemAllocationTypePinned;
+  }
+
+  #if HT_AMD
+  SECTION("Memory Allocation Type as hipMemAllocationTypeUncached") {
+    prop.type = hipMemAllocationTypeUncached;
+  }
+  #endif
+
   prop.location.type = hipMemLocationTypeDevice;
   prop.location.id = device;  // Current Devices
   HIP_CHECK(


### PR DESCRIPTION
## Motivation
Need to support uncache memory allocation using hipMemCreate with the enum value hipMemAllocationTypeUncached
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Implementation changes PRs: https://github.com/ROCm/rocm-systems/pull/747, https://github.com/ROCm/rocm-systems/pull/847
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Updated tests of hipMemCreate to work with hipMemAllocationTypeUncached
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
All tests should pass with the newly added enum hipMemAllocationTypeUncached
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
