### PR TITLE
rocr: Return error on signal alloc failure

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -565,6 +565,9 @@ hsa_status_t hsa_amd_signal_create(hsa_signal_value_t initial_value, uint32_t nu
     ret = new core::InterruptSignal(initial_value);
   }
 
+  if (ret == nullptr)
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+
   *hsa_signal = core::Signal::Convert(ret);
   return HSA_STATUS_SUCCESS;
   CATCH;


### PR DESCRIPTION
Return HSA_STATUS_ERROR_OUT_OF_RESOURCES when signal allocation fails.