### PR TITLE
[clr] Fix device printf pointer advancement issue with string format specifiers

### DIFF
--- a/projects/clr/rocclr/device/devhcprintf.cpp
+++ b/projects/clr/rocclr/device/devhcprintf.cpp
@@ -67,11 +67,11 @@ static const uint64_t* consumeFloatingPoint(FILE* stream, int* outCount, const s
 template <typename... Args>
 static const uint64_t* consumeCstring(FILE* stream, int* outCount, const std::string& spec,
                                       const uint64_t* ptr, Args... args) {
-  auto str = reinterpret_cast<const char*>(ptr);
-  auto old = *outCount;
+  const char* str = reinterpret_cast<const char*>(ptr);
   checkPrintf(stream, outCount, spec.c_str(), args..., str);
-  auto stringMemSize = *outCount - old + 1;
-  return ptr + (stringMemSize + 7) / 8;
+  size_t payloadBytes = std::strlen(str) + 1;
+  size_t qwords = (payloadBytes + 7) / 8;
+  return ptr + qwords;
 }
 
 template <typename... Args>


### PR DESCRIPTION
## Motivation

Resolves https://github.com/ROCm/ROCm/issues/5425

## Technical Details

The host should advance the pointer by the actual string length in the message, not the formatted output width. The transmitted payload is a null-terminated string padded to an 8-byte boundary:
https://github.com/ROCm/rocm-systems/blob/8751d5861657839db015f9db02cc3415d50ac454/projects/clr/rocclr/device/devhcprintf.cpp#L150

## Test Plan

Tested string format specifiers as per the above linked issue.

Input file:

```
#include <hip/hip_runtime.h>

__global__ void kernel()
{
        printf("device\n");
        printf("  %10s %i\n", "123", 1);
        printf("  %10s %i\n", "12345678", 1);
}

int main()
{
        printf("host\n");
        printf("  %10s %i\n", "123", 1);
        printf("  %10s %i\n", "12345678", 1);
        hipLaunchKernelGGL(kernel, 1, 1, 0, 0);
        hipDeviceSynchronize();
}
```

## Test Result

New output:

```
host
         123 1
    12345678 1
device
         123 1
    12345678 1
```
Previous output (without this PR):

```
host
         123 1
    12345678 1
device
         123     12345678 1
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
