### PR TITLE
[hip-tests] Tag multigpu tests with Catch2 tags

### DIFF
--- a/projects/hip-tests/catch/unit/atomics/atomicAdd_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicAdd_system.cc
@@ -54,8 +54,9 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicAdd_system_Positive_Peer_GPUs", "", int, unsigned int, unsigned long,
-                   unsigned long long, float, double) {
+TEMPLATE_TEST_CASE("Unit_atomicAdd_system_Positive_Peer_GPUs", "[multigpu]",
+                   int, unsigned int, unsigned long, unsigned long long, float,
+                   double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
@@ -103,8 +104,9 @@ TEMPLATE_TEST_CASE("Unit_atomicAdd_system_Positive_Peer_GPUs", "", int, unsigned
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicAdd_system_Positive_Host_And_GPU", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE("Unit_atomicAdd_system_Positive_Host_And_GPU", "[multigpu]",
+                   int, unsigned int, unsigned long, unsigned long long, float,
+                   double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
@@ -152,8 +154,9 @@ TEMPLATE_TEST_CASE("Unit_atomicAdd_system_Positive_Host_And_GPU", "", int, unsig
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicAdd_system_Positive_Host_And_Peer_GPUs", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE("Unit_atomicAdd_system_Positive_Host_And_Peer_GPUs",
+                   "[multigpu]", int, unsigned int, unsigned long,
+                   unsigned long long, float, double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;

--- a/projects/hip-tests/catch/unit/atomics/atomicAnd_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicAnd_system.cc
@@ -45,8 +45,9 @@ THE SOFTWARE.
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicAnd_system_Positive_Peer_GPUs_Same_Address", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit_atomicAnd_system_Positive_Peer_GPUs_Same_Address",
+                   "[multigpu]", int, unsigned int, unsigned long,
+                   unsigned long long) {
   for (auto current = 0; current < 1; ++current) {
     DYNAMIC_SECTION("Same address " << current) {
       Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAndSystem>(
@@ -68,8 +69,9 @@ TEMPLATE_TEST_CASE("Unit_atomicAnd_system_Positive_Peer_GPUs_Same_Address", "", 
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicAnd_system_Positive_Peer_GPUs_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE(
+    "Unit_atomicAnd_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]",
+    int, unsigned int, unsigned long, unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
 
@@ -94,8 +96,9 @@ TEMPLATE_TEST_CASE("Unit_atomicAnd_system_Positive_Peer_GPUs_Adjacent_Addresses"
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicAnd_system_Positive_Peer_GPUs_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE(
+    "Unit_atomicAnd_system_Positive_Peer_GPUs_Scattered_Addresses",
+    "[multigpu]", int, unsigned int, unsigned long, unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;

--- a/projects/hip-tests/catch/unit/atomics/atomicCAS_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicCAS_system.cc
@@ -60,8 +60,9 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicCAS_system_Positive_Peer_GPUs", "", int, unsigned int,
-                   unsigned long long, unsigned short int TYPES) {
+TEMPLATE_TEST_CASE("Unit_atomicCAS_system_Positive_Peer_GPUs", "[multigpu]",
+                   int, unsigned int, unsigned long long,
+                   unsigned short int TYPES) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
@@ -110,8 +111,9 @@ TEMPLATE_TEST_CASE("Unit_atomicCAS_system_Positive_Peer_GPUs", "", int, unsigned
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicCAS_system_Positive_Host_And_GPU", "", int, unsigned int,
-                   unsigned long long, unsigned short int TYPES) {
+TEMPLATE_TEST_CASE("Unit_atomicCAS_system_Positive_Host_And_GPU", "[multigpu]",
+                   int, unsigned int, unsigned long long,
+                   unsigned short int TYPES) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
@@ -160,8 +162,9 @@ TEMPLATE_TEST_CASE("Unit_atomicCAS_system_Positive_Host_And_GPU", "", int, unsig
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicCAS_system_Positive_Host_And_Peer_GPUs", "", int, unsigned int,
-                   unsigned long long, unsigned short int TYPES) {
+TEMPLATE_TEST_CASE("Unit_atomicCAS_system_Positive_Host_And_Peer_GPUs",
+                   "[multigpu]", int, unsigned int, unsigned long long,
+                   unsigned short int TYPES) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;

--- a/projects/hip-tests/catch/unit/atomics/atomicExch_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicExch_system.cc
@@ -55,11 +55,12 @@ THE SOFTWARE.
  *    - HIP_VERSION >= 5.2
  */
 #if HT_NVIDIA
-TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Peer_GPUs", "", int, unsigned int,
-                   unsigned long long, float) {
+TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Peer_GPUs", "[multigpu]",
+                   int, unsigned int, unsigned long long, float) {
 #else
-TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Peer_GPUs", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Peer_GPUs", "[multigpu]",
+                   int, unsigned int, unsigned long, unsigned long long, float,
+                   double) {
 #endif  // HT_NVIDIA
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
@@ -109,12 +110,13 @@ TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Peer_GPUs", "", int, unsigne
  *    - HIP_VERSION >= 5.2
  */
 #if HT_NVIDIA
-TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Host_And_GPU", "", int, unsigned int,
-                   unsigned long long, float) {
+TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Host_And_GPU", "[multigpu]",
+                   int, unsigned int, unsigned long long, float) {
 #else
-TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Host_And_GPU", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
-#endif  // HT_NVIDIA
+TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Host_And_GPU", "[multigpu]",
+                   int, unsigned int, unsigned long, unsigned long long, float,
+                   double) {
+#endif // HT_NVIDIA
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
@@ -164,11 +166,12 @@ TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Host_And_GPU", "", int, unsi
  *    - HIP_VERSION >= 5.2
  */
 #if HT_NVIDIA
-TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Host_And_Peer_GPUs", "", int, unsigned int,
-                   unsigned long long, float) {
+TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Host_And_Peer_GPUs",
+                   "[multigpu]", int, unsigned int, unsigned long long, float) {
 #else
-TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Host_And_Peer_GPUs", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Host_And_Peer_GPUs",
+                   "[multigpu]", int, unsigned int, unsigned long,
+                   unsigned long long, float, double) {
 #endif  // HT_NVIDIA
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));

--- a/projects/hip-tests/catch/unit/atomics/atomicMax_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicMax_system.cc
@@ -46,11 +46,13 @@ THE SOFTWARE.
  *  - HIP_VERSION >= 5.2
  */
 #if HT_AMD
-TEMPLATE_TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs_Same_Address", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs_Same_Address",
+                   "[multigpu]", int, unsigned int, unsigned long,
+                   unsigned long long, float, double) {
 #else
-TEMPLATE_TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs_Same_Address", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs_Same_Address",
+                   "[multigpu]", int, unsigned int, unsigned long,
+                   unsigned long long) {
 #endif
   for (auto current = 0; current < 1; ++current) {
     DYNAMIC_SECTION("Same address " << current) {
@@ -74,11 +76,13 @@ TEMPLATE_TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs_Same_Address", "", 
  *  - HIP_VERSION >= 5.2
  */
 #if HT_AMD
-TEMPLATE_TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE(
+    "Unit_atomicMax_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]",
+    int, unsigned int, unsigned long, unsigned long long, float, double) {
 #else
-TEMPLATE_TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE(
+    "Unit_atomicMax_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]",
+    int, unsigned int, unsigned long, unsigned long long) {
 #endif
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
@@ -105,11 +109,14 @@ TEMPLATE_TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs_Adjacent_Addresses"
  *  - HIP_VERSION >= 5.2
  */
 #if HT_AMD
-TEMPLATE_TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE(
+    "Unit_atomicMax_system_Positive_Peer_GPUs_Scattered_Addresses",
+    "[multigpu]", int, unsigned int, unsigned long, unsigned long long, float,
+    double) {
 #else
-TEMPLATE_TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE(
+    "Unit_atomicMax_system_Positive_Peer_GPUs_Scattered_Addresses",
+    "[multigpu]", int, unsigned int, unsigned long, unsigned long long) {
 #endif
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));

--- a/projects/hip-tests/catch/unit/atomics/atomicMin_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicMin_system.cc
@@ -46,11 +46,13 @@ THE SOFTWARE.
  *  - HIP_VERSION >= 5.2
  */
 #if HT_AMD
-TEMPLATE_TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs_Same_Address", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs_Same_Address",
+                   "[multigpu]", int, unsigned int, unsigned long,
+                   unsigned long long, float, double) {
 #else
-TEMPLATE_TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs_Same_Address", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs_Same_Address",
+                   "[multigpu]", int, unsigned int, unsigned long,
+                   unsigned long long) {
 #endif
   for (auto current = 0; current < 1; ++current) {
     DYNAMIC_SECTION("Same address " << current) {
@@ -74,11 +76,13 @@ TEMPLATE_TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs_Same_Address", "", 
  *  - HIP_VERSION >= 5.2
  */
 #if HT_AMD
-TEMPLATE_TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE(
+    "Unit_atomicMin_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]",
+    int, unsigned int, unsigned long, unsigned long long, float, double) {
 #else
-TEMPLATE_TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE(
+    "Unit_atomicMin_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]",
+    int, unsigned int, unsigned long, unsigned long long) {
 #endif
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
@@ -105,11 +109,14 @@ TEMPLATE_TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs_Adjacent_Addresses"
  *  - HIP_VERSION >= 5.2
  */
 #if HT_AMD
-TEMPLATE_TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE(
+    "Unit_atomicMin_system_Positive_Peer_GPUs_Scattered_Addresses",
+    "[multigpu]", int, unsigned int, unsigned long, unsigned long long, float,
+    double) {
 #else
-TEMPLATE_TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE(
+    "Unit_atomicMin_system_Positive_Peer_GPUs_Scattered_Addresses",
+    "[multigpu]", int, unsigned int, unsigned long, unsigned long long) {
 #endif
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));

--- a/projects/hip-tests/catch/unit/atomics/atomicOr_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicOr_system.cc
@@ -45,8 +45,9 @@ THE SOFTWARE.
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicOr_system_Positive_Peer_GPUs_Same_Address", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit_atomicOr_system_Positive_Peer_GPUs_Same_Address",
+                   "[multigpu]", int, unsigned int, unsigned long,
+                   unsigned long long) {
   for (auto current = 0; current < 1; ++current) {
     DYNAMIC_SECTION("Same address " << current) {
       Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOrSystem>(
@@ -68,8 +69,9 @@ TEMPLATE_TEST_CASE("Unit_atomicOr_system_Positive_Peer_GPUs_Same_Address", "", i
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicOr_system_Positive_Peer_GPUs_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit_atomicOr_system_Positive_Peer_GPUs_Adjacent_Addresses",
+                   "[multigpu]", int, unsigned int, unsigned long,
+                   unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
 
@@ -94,8 +96,9 @@ TEMPLATE_TEST_CASE("Unit_atomicOr_system_Positive_Peer_GPUs_Adjacent_Addresses",
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicOr_system_Positive_Peer_GPUs_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE(
+    "Unit_atomicOr_system_Positive_Peer_GPUs_Scattered_Addresses", "[multigpu]",
+    int, unsigned int, unsigned long, unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;

--- a/projects/hip-tests/catch/unit/atomics/atomicSub_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicSub_system.cc
@@ -54,8 +54,9 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicSub_system_Positive_Peer_GPUs", "", int, unsigned int, unsigned long,
-                   unsigned long long, float, double) {
+TEMPLATE_TEST_CASE("Unit_atomicSub_system_Positive_Peer_GPUs", "[multigpu]",
+                   int, unsigned int, unsigned long, unsigned long long, float,
+                   double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
@@ -103,8 +104,9 @@ TEMPLATE_TEST_CASE("Unit_atomicSub_system_Positive_Peer_GPUs", "", int, unsigned
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicSub_system_Positive_Host_And_GPU", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE("Unit_atomicSub_system_Positive_Host_And_GPU", "[multigpu]",
+                   int, unsigned int, unsigned long, unsigned long long, float,
+                   double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
@@ -152,8 +154,9 @@ TEMPLATE_TEST_CASE("Unit_atomicSub_system_Positive_Host_And_GPU", "", int, unsig
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicSub_system_Positive_Host_And_Peer_GPUs", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE("Unit_atomicSub_system_Positive_Host_And_Peer_GPUs",
+                   "[multigpu]", int, unsigned int, unsigned long,
+                   unsigned long long, float, double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;

--- a/projects/hip-tests/catch/unit/atomics/atomicXor_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicXor_system.cc
@@ -45,8 +45,9 @@ THE SOFTWARE.
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicXor_system_Positive_Peer_GPUs_Same_Address", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit_atomicXor_system_Positive_Peer_GPUs_Same_Address",
+                   "[multigpu]", int, unsigned int, unsigned long,
+                   unsigned long long) {
   for (auto current = 0; current < 1; ++current) {
     DYNAMIC_SECTION("Same address " << current) {
       Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXorSystem>(
@@ -68,8 +69,9 @@ TEMPLATE_TEST_CASE("Unit_atomicXor_system_Positive_Peer_GPUs_Same_Address", "", 
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicXor_system_Positive_Peer_GPUs_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE(
+    "Unit_atomicXor_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]",
+    int, unsigned int, unsigned long, unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
 
@@ -94,8 +96,9 @@ TEMPLATE_TEST_CASE("Unit_atomicXor_system_Positive_Peer_GPUs_Adjacent_Addresses"
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicXor_system_Positive_Peer_GPUs_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE(
+    "Unit_atomicXor_system_Positive_Peer_GPUs_Scattered_Addresses",
+    "[multigpu]", int, unsigned int, unsigned long, unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;

--- a/projects/hip-tests/catch/unit/callback/hipGetStreamDeviceId.cc
+++ b/projects/hip-tests/catch/unit/callback/hipGetStreamDeviceId.cc
@@ -65,7 +65,8 @@ TEST_CASE("Unit_hipGetStreamDeviceId_Positive_Threaded_Basic") {
  *  - Platform specific (AMD)
  *  - Multithreaded GPU
  */
-TEST_CASE("Unit_hipGetStreamDeviceId_Positive_Multithreaded_Basic") {
+TEST_CASE("Unit_hipGetStreamDeviceId_Positive_Multithreaded_Basic",
+          "[multigpu]") {
   const unsigned int max_threads = std::thread::hardware_concurrency();
   const int device_count = HipTest::getDeviceCount();
 

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGMultiGridGroupType_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGMultiGridGroupType_old.cc
@@ -378,7 +378,7 @@ template <typename F> static void test_cg_multi_grid_group_type(F kernel_func, i
   }
 }
 
-TEST_CASE("Unit_hipCGMultiGridGroupType_Basic") {
+TEST_CASE("Unit_hipCGMultiGridGroupType_Basic", "[multigpu]") {
   int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   num_devices = min(num_devices, MaxGPUs);
@@ -425,7 +425,7 @@ TEST_CASE("Unit_hipCGMultiGridGroupType_Basic") {
   }
 }
 
-TEST_CASE("Unit_hipCGMultiGridGroupType_Barrier") {
+TEST_CASE("Unit_hipCGMultiGridGroupType_Barrier", "[multigpu]") {
   int num_devices = 0;
   uint32_t loops = GENERATE(1, 2, 3, 4);
   uint32_t warps = GENERATE(4, 8, 16, 32);

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipLaunchCooperativeKernelMultiDevice_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipLaunchCooperativeKernelMultiDevice_old.cc
@@ -130,7 +130,7 @@ __global__ void test_gws(uint* buf, uint buf_size, long* tmp_buf, long* result) 
   }
 }
 
-TEST_CASE("Unit_hipLaunchCooperativeKernelMultiDevice_Basic") {
+TEST_CASE("Unit_hipLaunchCooperativeKernelMultiDevice_Basic", "[multigpu]") {
   constexpr uint num_kernel_args = 4;
 
   int device_num = 0;

--- a/projects/hip-tests/catch/unit/cooperativeGrps/multi_grid_group.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/multi_grid_group.cc
@@ -154,7 +154,7 @@ static void get_multi_grid_dims(dim3& grid_dim, dim3& block_dim, unsigned int de
  *  - HIP_VERSION >= 5.2
  *  - Devices support cooperative multi device launch
  */
-TEST_CASE("Unit_Multi_Grid_Group_Getters_Positive_Basic") {
+TEST_CASE("Unit_Multi_Grid_Group_Getters_Positive_Basic", "[multigpu]") {
   int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   num_devices = min(num_devices, kMaxGPUs);
@@ -302,7 +302,7 @@ TEST_CASE("Unit_Multi_Grid_Group_Getters_Positive_Basic") {
  *  - HIP_VERSION >= 5.2
  *  - Devices support cooperative multi device launch
  */
-TEST_CASE("Unit_Multi_Grid_Group_Getters_Positive_Base_Type") {
+TEST_CASE("Unit_Multi_Grid_Group_Getters_Positive_Base_Type", "[multigpu]") {
   int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   num_devices = min(num_devices, kMaxGPUs);
@@ -423,7 +423,8 @@ TEST_CASE("Unit_Multi_Grid_Group_Getters_Positive_Base_Type") {
  *  - HIP_VERSION >= 5.2
  *  - Devices support cooperative multi device launch
  */
-TEST_CASE("Unit_Multi_Grid_Group_Getters_Positive_Non_Member_Functions") {
+TEST_CASE("Unit_Multi_Grid_Group_Getters_Positive_Non_Member_Functions",
+          "[multigpu]") {
   int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   num_devices = min(num_devices, kMaxGPUs);
@@ -535,7 +536,7 @@ TEST_CASE("Unit_Multi_Grid_Group_Getters_Positive_Non_Member_Functions") {
  *  - HIP_VERSION >= 5.2
  *  - Devices support cooperative multi device launch
  */
-TEST_CASE("Unit_Multi_Grid_Group_Positive_Sync") {
+TEST_CASE("Unit_Multi_Grid_Group_Positive_Sync", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
   int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));

--- a/projects/hip-tests/catch/unit/device/hipDeviceEnableDisablePeerAccess.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceEnableDisablePeerAccess.cc
@@ -46,7 +46,7 @@ THE SOFTWARE.
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceEnableDisablePeerAccess_positive") {
+TEST_CASE("Unit_hipDeviceEnableDisablePeerAccess_positive", "[multigpu]") {
   int canAccessPeer = 0;
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
@@ -95,7 +95,7 @@ TEST_CASE("Unit_hipDeviceEnableDisablePeerAccess_positive") {
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceEnablePeerAccess_negative") {
+TEST_CASE("Unit_hipDeviceEnablePeerAccess_negative", "[multigpu]") {
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");
@@ -159,7 +159,7 @@ TEST_CASE("Unit_hipDeviceEnablePeerAccess_negative") {
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceDisablePeerAccess_negative") {
+TEST_CASE("Unit_hipDeviceDisablePeerAccess_negative", "[multigpu]") {
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetName.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetName.cc
@@ -210,7 +210,8 @@ static inline std::vector<int> parseVisibleDevices() {
  * ------------------------
  *  - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipDeviceName_gcnArchName_And_rocm_agent_enumerator") {
+TEST_CASE("Unit_hipDeviceName_gcnArchName_And_rocm_agent_enumerator",
+          "[multigpu]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount <= 0) {

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
@@ -145,7 +145,7 @@ static inline std::vector<int> parseVisibleDevices() {
  * ------------------------
  *  - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipDeviceGetUuid_From_RocmInfo") {
+TEST_CASE("Unit_hipDeviceGetUuid_From_RocmInfo", "[multigpu]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   assert(deviceCount > 0);
@@ -219,7 +219,8 @@ TEST_CASE("Unit_hipDeviceGetUuid_From_RocmInfo") {
  */
 // Guarding it against NVIDIA as this test is faling on it.
 #if HT_AMD
-TEST_CASE("Unit_hipDeviceGetUuid_VerifyUuidFrm_hipGetDeviceProperties") {
+TEST_CASE("Unit_hipDeviceGetUuid_VerifyUuidFrm_hipGetDeviceProperties",
+          "[multigpu]") {
   int deviceCount = 0;
   hipDevice_t device;
   hipDeviceProp_t prop;

--- a/projects/hip-tests/catch/unit/device/hipDeviceSetGetLimit.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceSetGetLimit.cc
@@ -462,7 +462,7 @@ void getMinMaxCurrentAndSetCurrent() {
  * ------------------------
  *  - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_MultiDevice") {
+TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_MultiDevice", "[multigpu]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {

--- a/projects/hip-tests/catch/unit/device/hipDeviceSetLimit_old.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceSetLimit_old.cc
@@ -65,7 +65,7 @@ static bool testSetLimitFunc(hipLimit_t limit_to_test) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceSetLimit_SetGet") {
+TEST_CASE("Unit_hipDeviceSetLimit_SetGet", "[multigpu]") {
   size_t value = 0;
   // Scenario1
   SECTION("Set Get Test hipLimitStackSize") {

--- a/projects/hip-tests/catch/unit/device/hipDeviceTotalMem.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceTotalMem.cc
@@ -115,7 +115,7 @@ TEST_CASE("Unit_hipDeviceTotalMem_ValidateTotalMem") {
  *  - Multi-device test
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceTotalMem_NonSelectedDevice") {
+TEST_CASE("Unit_hipDeviceTotalMem_NonSelectedDevice", "[multigpu]") {
   auto deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
     HipTest::HIP_SKIP_TEST("Multi Device Test, will not run on single gpu systems. Skipping.");

--- a/projects/hip-tests/catch/unit/device/hipGetDeviceProperties.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetDeviceProperties.cc
@@ -148,7 +148,7 @@ static void validateDeviceMacro(int* archProp_h, hipDeviceProp_t* prop) {
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetDeviceProperties_ArchPropertiesTst") {
+TEST_CASE("Unit_hipGetDeviceProperties_ArchPropertiesTst", "[multigpu]") {
   int *archProp_h, *archProp_d;
   archProp_h = new int[NUM_OF_ARCHPROP];
   hipDeviceProp_t prop;

--- a/projects/hip-tests/catch/unit/device/hipGetProcAddressDevMgmt.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetProcAddressDevMgmt.cc
@@ -372,7 +372,7 @@ TEST_CASE("Unit_hipGetProcAddress_ValidateDeviceApis") {
  *  - HIP_VERSION >= 6.2
  */
 
-TEST_CASE("Unit_hipGetProcAddress_PeerDeviceAccessAPIs") {
+TEST_CASE("Unit_hipGetProcAddress_PeerDeviceAccessAPIs", "[multigpu]") {
   void* hipDeviceCanAccessPeer_ptr = nullptr;
   void* hipSetDevice_ptr = nullptr;
   void* hipGetDevice_ptr = nullptr;
@@ -453,7 +453,7 @@ bool CheckMemPoolSupport(const int device) {
   return true;
 }
 
-TEST_CASE("Unit_hipGetProcAddress_SetGetMemPoolAPIs") {
+TEST_CASE("Unit_hipGetProcAddress_SetGetMemPoolAPIs", "[multigpu]") {
   void* hipDeviceSetMemPool_ptr = nullptr;
   void* hipDeviceGetMemPool_ptr = nullptr;
   int currentHipVersion = 0;

--- a/projects/hip-tests/catch/unit/device/hipSetGetDevice.cc
+++ b/projects/hip-tests/catch/unit/device/hipSetGetDevice.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipSetDevice_BasicSetGet") {
+TEST_CASE("Unit_hipSetDevice_BasicSetGet", "[multigpu]") {
   int numDevices = 0;
   int device{};
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -73,7 +73,7 @@ TEST_CASE("Unit_hipSetDevice_BasicSetGet") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetSetDevice_MultiThreaded") {
+TEST_CASE("Unit_hipGetSetDevice_MultiThreaded", "[multigpu]") {
   auto maxThreads = std::thread::hardware_concurrency();
   auto deviceCount = HipTest::getDeviceCount();
 
@@ -126,7 +126,7 @@ TEST_CASE("Unit_hipGetSetDevice_MultiThreaded") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipSetGetDevice_Positive_Threaded_Basic") {
+TEST_CASE("Unit_hipSetGetDevice_Positive_Threaded_Basic", "[multigpu]") {
   class HipSetGetDeviceThreadedTest : public ThreadedZigZagTest<HipSetGetDeviceThreadedTest> {
    public:
     void TestPart1() { HIP_CHECK(hipSetDevice(0)); }

--- a/projects/hip-tests/catch/unit/device/hipSetValidDevices.cc
+++ b/projects/hip-tests/catch/unit/device/hipSetValidDevices.cc
@@ -158,7 +158,7 @@ TEST_CASE("Unit_hipSetValidDevices_Negative_Length_Lessthan_DeviceArrSize") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipSetValidDevices_Positive_Basic") {
+TEST_CASE("Unit_hipSetValidDevices_Positive_Basic", "[multigpu]") {
   int totalDevices = HipTest::getDeviceCount();
   if (totalDevices < 2) {
     HipTest::HIP_SKIP_TEST("This test requires 2 or more GPUs. Skipping.");

--- a/projects/hip-tests/catch/unit/deviceLib/threadfence_system.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/threadfence_system.cc
@@ -51,7 +51,7 @@ __global__ void gpu_round_robin(const int id, const int num_dev, const int num_i
   round_robin(id, num_dev, num_iter, data, flag);
 }
 
-TEST_CASE("Unit_threadfence_system") {
+TEST_CASE("Unit_threadfence_system", "[multigpu]") {
   int num_gpus = 0;
   HIP_CHECK(hipGetDeviceCount(&num_gpus));
   REQUIRE(num_gpus > 0);

--- a/projects/hip-tests/catch/unit/errorHandling/hipExtGetLastError.cc
+++ b/projects/hip-tests/catch/unit/errorHandling/hipExtGetLastError.cc
@@ -93,7 +93,7 @@ TEST_CASE("Unit_hipExtGetLastError_Positive_Threaded") {
  *  - HIP_VERSION >= 6.4
  */
 
-TEST_CASE("Unit_hipExtGetLastError_with_hipMemcpyPeerAsync") {
+TEST_CASE("Unit_hipExtGetLastError_with_hipMemcpyPeerAsync", "[multigpu]") {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");

--- a/projects/hip-tests/catch/unit/errorHandling/hipGetLastError.cc
+++ b/projects/hip-tests/catch/unit/errorHandling/hipGetLastError.cc
@@ -94,7 +94,7 @@ TEST_CASE("Unit_hipGetLastError_Positive_Threaded") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipGetLastError_with_hipMemcpyPeerAsync") {
+TEST_CASE("Unit_hipGetLastError_with_hipMemcpyPeerAsync", "[multigpu]") {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");

--- a/projects/hip-tests/catch/unit/errorHandling/hipGetLastErrorOnAbort.cc
+++ b/projects/hip-tests/catch/unit/errorHandling/hipGetLastErrorOnAbort.cc
@@ -102,7 +102,7 @@ TEST_CASE("Unit_hipGetLastError_KernelFailure_ValidAndInvalidOperations") {
  * ------------------------
  *  - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipGetLastError_KernelFailure_TwoDevices") {
+TEST_CASE("Unit_hipGetLastError_KernelFailure_TwoDevices", "[multigpu]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {

--- a/projects/hip-tests/catch/unit/event/Unit_hipEventElapsedTime.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEventElapsedTime.cc
@@ -108,7 +108,7 @@ TEST_CASE("Unit_hipEventElapsedTime_DisableTiming") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipEventElapsedTime_DifferentDevices") {
+TEST_CASE("Unit_hipEventElapsedTime_DifferentDevices", "[multigpu]") {
   int devCount = 0;
   HIP_CHECK(hipGetDeviceCount(&devCount));
   if (devCount > 1) {

--- a/projects/hip-tests/catch/unit/event/Unit_hipEventMGpuMThreads.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEventMGpuMThreads.cc
@@ -217,7 +217,7 @@ TEST_CASE("Unit_hipEventMGpuMThreads_1") { testEventMGpuMThreads(1); }
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipEventMGpuMThreads_2") {
+TEST_CASE("Unit_hipEventMGpuMThreads_2", "[multigpu]") {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices > 1) {
@@ -238,7 +238,7 @@ TEST_CASE("Unit_hipEventMGpuMThreads_2") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipEventMGpuMThreads_3") {
+TEST_CASE("Unit_hipEventMGpuMThreads_3", "[multigpu]") {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices > 1) {

--- a/projects/hip-tests/catch/unit/event/Unit_hipEventQuery.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEventQuery.cc
@@ -41,7 +41,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipEventQuery_DifferentDevice") {
+TEST_CASE("Unit_hipEventQuery_DifferentDevice", "[multigpu]") {
   hipEvent_t event1{}, event2{};
   HIP_CHECK(hipEventCreate(&event1));
   HIP_CHECK(hipEventCreate(&event2));

--- a/projects/hip-tests/catch/unit/event/Unit_hipEventRecord.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEventRecord.cc
@@ -158,7 +158,7 @@ TEST_CASE("Unit_hipEventRecord") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipEventRecord_Negative") {
+TEST_CASE("Unit_hipEventRecord_Negative", "[multigpu]") {
   SECTION("Nullptr event") {
     HIP_CHECK_ERROR(hipEventRecord(nullptr, nullptr), hipErrorInvalidResourceHandle);
   }

--- a/projects/hip-tests/catch/unit/executionControl/hipExtLaunchMultiKernelMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipExtLaunchMultiKernelMultiDevice.cc
@@ -27,7 +27,8 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Positive_Basic") {
+TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Positive_Basic",
+          "[multigpu]") {
   const auto device_count = HipTest::getDeviceCount();
 
   std::vector<hipLaunchParams> params_list(device_count);
@@ -54,7 +55,8 @@ TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Positive_Basic") {
   }
 }
 
-TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Negative_Parameters") {
+TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Negative_Parameters",
+          "[multigpu]") {
   const auto device_count = HipTest::getDeviceCount();
 
   std::vector<hipLaunchParams> params_list(device_count);

--- a/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernelMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernelMultiDevice.cc
@@ -27,7 +27,8 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipLaunchCooperativeKernelMultiDevice_Positive_Basic") {
+TEST_CASE("Unit_hipLaunchCooperativeKernelMultiDevice_Positive_Basic",
+          "[multigpu]") {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -59,7 +60,8 @@ TEST_CASE("Unit_hipLaunchCooperativeKernelMultiDevice_Positive_Basic") {
   }
 }
 
-TEST_CASE("Unit_hipLaunchCooperativeKernelMultiDevice_Negative_Parameters") {
+TEST_CASE("Unit_hipLaunchCooperativeKernelMultiDevice_Negative_Parameters",
+          "[multigpu]") {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;

--- a/projects/hip-tests/catch/unit/graph/hipDeviceGetGraphMemAttribute.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDeviceGetGraphMemAttribute.cc
@@ -309,7 +309,8 @@ TEST_CASE("Unit_hipDeviceGetGraphMemAttribute_Functional") {
   Unit_hipDeviceGetGraphMemAttribute_Functional();
 }
 
-TEST_CASE("Unit_hipDeviceGetGraphMemAttribute_Functional_Multi_Device") {
+TEST_CASE("Unit_hipDeviceGetGraphMemAttribute_Functional_Multi_Device",
+          "[multigpu]") {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 

--- a/projects/hip-tests/catch/unit/graph/hipDrvGraphAddMemcpyNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDrvGraphAddMemcpyNode.cc
@@ -368,7 +368,7 @@ TEST_CASE("Unit_hipDrvGraphAddMemcpyNode_test") {
  *  - HIP_VERSION >= 6.1
  */
 
-TEST_CASE("Unit_hipDrvGraphAddMemcpyNode_MulitDevice") {
+TEST_CASE("Unit_hipDrvGraphAddMemcpyNode_MulitDevice", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddChildGraphNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddChildGraphNode.cc
@@ -1079,7 +1079,7 @@ TEST_CASE("Unit_hipGraphAddChildGraphNode_MultGraphsAsSingleGraph") {
  in multi GPU environment. Create one nested graph per GPU context. Execute
  all the created graphs in their respective GPUs and validate the output.
  */
-TEST_CASE("Unit_hipGraphAddChildGraphNode_CmplxNstGrph_MultGPU") {
+TEST_CASE("Unit_hipGraphAddChildGraphNode_CmplxNstGrph_MultGPU", "[multigpu]") {
   int devcount = 0;
   HIP_CHECK(hipGetDeviceCount(&devcount));
   // If only single GPU is detected then return

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemAllocNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemAllocNode.cc
@@ -584,7 +584,7 @@ TEST_CASE("Unit_hipGraphAddMemAllocNode_Functional_1") {
 * ------------------------
 *  - HIP_VERSION >= 6.1
 */
-TEST_CASE("Unit_hipGraphAddMemAllocNode_Functional_2") {
+TEST_CASE("Unit_hipGraphAddMemAllocNode_Functional_2", "[multigpu]") {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
@@ -653,7 +653,7 @@ TEST_CASE("Unit_hipGraphAddMemAllocNode_Functional_2") {
  * ------------------------
  * - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraphAddMemAllocNode_Functional_3") {
+TEST_CASE("Unit_hipGraphAddMemAllocNode_Functional_3", "[multigpu]") {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {
@@ -727,7 +727,7 @@ TEST_CASE("Unit_hipGraphAddMemAllocNode_Functional_3") {
  * ------------------------
  * - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraphAddMemAllocNode_Functional_4") {
+TEST_CASE("Unit_hipGraphAddMemAllocNode_Functional_4", "[multigpu]") {
   int mem_pool_support = 0;
   HIP_CHECK(hipDeviceGetAttribute(&mem_pool_support, hipDeviceAttributeMemoryPoolsSupported, 0));
   if (!mem_pool_support) {

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNode1D_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNode1D_old.cc
@@ -115,7 +115,7 @@ static void validateMemcpyNode1DArray(bool peerAccess,
  * For Peer device test: Memory allocations happen on device(0) and memcpy operations
  * are performed from device(1).
  */
-TEST_CASE("Unit_hipGraphAddMemcpyNode1D_Functional") {
+TEST_CASE("Unit_hipGraphAddMemcpyNode1D_Functional", "[multigpu]") {
   SECTION("Memcpy with 1D array on default device") { validateMemcpyNode1DArray(false); }
   SECTION("Memcpy with 1D array using DeviceToDeviceNoCU") {
     validateMemcpyNode1DArray(false, hipMemcpyDeviceToDeviceNoCU);

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeFromSymbol_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeFromSymbol_old.cc
@@ -255,7 +255,8 @@ in GPU-0 and add the MemcpyNodeFromSymbol node to the graph and
 verifying the result in GPU-1
 */
 #if HT_NVIDIA
-TEST_CASE("Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemoryPeerDevice") {
+TEST_CASE("Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemoryPeerDevice",
+          "[multigpu]") {
   int numDevices = 0;
   int canAccessPeer = 0;
   if (numDevices > 1) {
@@ -276,7 +277,8 @@ in GPU-0 and add the MemcpyNodeFromSymbol node to the graph and
 verifying the result in GPU-1
 */
 
-TEST_CASE("Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalConstMemoryPeerDevice") {
+TEST_CASE("Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalConstMemoryPeerDevice",
+          "[multigpu]") {
   int numDevices = 0;
   int canAccessPeer = 0;
   if (numDevices > 1) {

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeToSymbol_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeToSymbol_old.cc
@@ -257,7 +257,8 @@ This testcase verifies allocating global const symbol memory and device variable
 in GPU-0 and add the MemcpyNodeToSymbol node to the graph and
 verifying the result in GPU-1
 */
-TEST_CASE("Unit_hipGraphAddMemcpyNodeToSymbol_GlobalConstMemoryPeerDevice") {
+TEST_CASE("Unit_hipGraphAddMemcpyNodeToSymbol_GlobalConstMemoryPeerDevice",
+          "[multigpu]") {
   int numDevices = 0;
   int canAccessPeer = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -278,7 +279,8 @@ This testcaser verifies allocating global memory,
 Add MemcpyToSymbolNode,KernelNode and memcpynode and validating
 the behaviour
 */
-TEST_CASE("Unit_hipGraphAddMemcpyNodeToSymbol_MemcpyToSymbolNodeWithKernel") {
+TEST_CASE("Unit_hipGraphAddMemcpyNodeToSymbol_MemcpyToSymbolNodeWithKernel",
+          "[multigpu]") {
   constexpr size_t Nbytes = SIZE * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
   constexpr auto threadsPerBlock = 256;

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNode_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNode_old.cc
@@ -484,7 +484,7 @@ TEST_CASE("Unit_hipGraphAddMemcpyNode_BasicFunctional") {
  * are performed from device(1).
  * Tests also verify memcpy node addition with 1D, 2D and 3D objects.
  */
-TEST_CASE("Unit_hipGraphAddMemcpyNode_PeerAccessFunctional") {
+TEST_CASE("Unit_hipGraphAddMemcpyNode_PeerAccessFunctional", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   int numDevices{}, peerAccess{};

--- a/projects/hip-tests/catch/unit/graph/hipGraphClone.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphClone.cc
@@ -229,7 +229,7 @@ This testcase verifies following scenarios
    validate the result of the cloned graph
 3. Device context change for cloned graph
 */
-TEST_CASE("Unit_hipGraphClone_Functional") {
+TEST_CASE("Unit_hipGraphClone_Functional", "[multigpu]") {
   SECTION("hipGraphClone Basic Functionality") { hipGraphClone_Func(); }
   SECTION("hipGraphClone Modify Original graph") { hipGraphClone_Func(true); }
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphCloneComplx.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphCloneComplx.cc
@@ -1490,7 +1490,7 @@ TEST_CASE("Unit_hipGraphClone_Test_hipGraphEventWaitNodeSetEvent_and_Exec") {
  Execute both original graph and cloned graph in loop: with multiple device.
  Loop: Update input data -> Launch Graph -> Validate output data -> Goto Loop */
 
-TEST_CASE("Unit_hipGraphClone_address_change_in_loop") {
+TEST_CASE("Unit_hipGraphClone_address_change_in_loop", "[multigpu]") {
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
   constexpr auto threadsPerBlock = 256;
@@ -1644,7 +1644,7 @@ static void hipGraphClone_address_change_in_thread(hipGraph_t* graph, hipGraphNo
  memory addresses in each Node and create executable graphs.
  Launch the graphs in their respective GPUs. Validate the outputs. */
 
-TEST_CASE("Unit_hipGraphClone_address_change_in_thread") {
+TEST_CASE("Unit_hipGraphClone_address_change_in_thread", "[multigpu]") {
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
   constexpr auto threadsPerBlock = 256;
@@ -1735,7 +1735,7 @@ static void hipGraphClone_Test_All_API(int dev) {
  Create a graph with Memcpy and Kernel nodes. and its cloned graph.
  Run all the above writen test cases for multiple GPU scenarios */
 
-TEST_CASE("Unit_hipGraphClone_multi_GPU_test") {
+TEST_CASE("Unit_hipGraphClone_multi_GPU_test", "[multigpu]") {
   // FIXME: This test tests 3D as well, decouple it
   CHECK_IMAGE_SUPPORT
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecEventRecordNodeSetEvent.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecEventRecordNodeSetEvent.cc
@@ -187,7 +187,8 @@ TEST_CASE("Unit_hipGraphExecEventRecordNodeSetEvent_VerifyEventNotChanged") {
  * Scenario 3: This test verifies event in node of the executable graph can be changed to event on
  * different device
  */
-TEST_CASE("Unit_hipGraphExecEventRecordNodeSetEvent_Positive_DifferentDevices") {
+TEST_CASE("Unit_hipGraphExecEventRecordNodeSetEvent_Positive_DifferentDevices",
+          "[multigpu]") {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParamsToSymbol.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParamsToSymbol.cc
@@ -142,7 +142,8 @@ TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Negative_Parameters") {
+TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Negative_Parameters",
+          "[multigpu]") {
   using namespace std::placeholders;
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecMemsetNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecMemsetNodeSetParams.cc
@@ -129,7 +129,8 @@ TEMPLATE_TEST_CASE("Unit_hipGraphExecMemsetNodeSetParams_Positive_Basic", "", ui
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGraphExecMemsetNodeSetParams_Negative_Parameters") {
+TEST_CASE("Unit_hipGraphExecMemsetNodeSetParams_Negative_Parameters",
+          "[multigpu]") {
   // FIXME: this test tests 1D/2D/3D stuff in one single go, need to decouple it so that it can run
   // on devices with no image support
   CHECK_IMAGE_SUPPORT

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecUpdate.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecUpdate.cc
@@ -638,7 +638,8 @@ TEST_CASE("Unit_hipGraphExecUpdate_Negative_NodeType_Changed") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipGraphExecUpdate_Negative_MultiDevice_Context_Changed") {
+TEST_CASE("Unit_hipGraphExecUpdate_Negative_MultiDevice_Context_Changed",
+          "[multigpu]") {
   constexpr size_t N = 1024;
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency

--- a/projects/hip-tests/catch/unit/graph/hipGraphInstantiateWithFlags.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphInstantiateWithFlags.cc
@@ -267,7 +267,8 @@ This testcase verifies hipGraphInstantiateWithFlags API
 by creating dependency graph on GPU-0 and instantiate, launching and verifying
 the result on GPU-1
 */
-TEST_CASE("Unit_hipGraphInstantiateWithFlags_DependencyGraphDeviceCtxtChg") {
+TEST_CASE("Unit_hipGraphInstantiateWithFlags_DependencyGraphDeviceCtxtChg",
+          "[multigpu]") {
   int numDevices = 0;
   int canAccessPeer = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -309,7 +310,8 @@ This testcase verifies hipGraphInstantiateWithFlags API
 by creating capture graph on GPU-0 and instantiate, launching and verifying
 the result on GPU-1
 */
-TEST_CASE("Unit_hipGraphInstantiateWithFlags_StreamCaptureDeviceContextChg") {
+TEST_CASE("Unit_hipGraphInstantiateWithFlags_StreamCaptureDeviceContextChg",
+          "[multigpu]") {
   int numDevices = 0;
   int canAccessPeer = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));

--- a/projects/hip-tests/catch/unit/graph/hipGraphLaunch_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphLaunch_old.cc
@@ -254,7 +254,7 @@ static void hipGraphLaunch_test() {
   HIP_CHECK(hipStreamDestroy(streamForGraph));
 }
 
-TEST_CASE("Unit_hipGraphLaunch_Functional_multidevice_test") {
+TEST_CASE("Unit_hipGraphLaunch_Functional_multidevice_test", "[multigpu]") {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphMemAllocNodeGetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMemAllocNodeGetParams.cc
@@ -135,7 +135,8 @@ TEST_CASE("Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional") {
   hipGraphMemAllocNodeGetParams_Functional();
 }
 
-TEST_CASE("Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_MultiDevice") {
+TEST_CASE("Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_MultiDevice",
+          "[multigpu]") {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphPerf.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphPerf.cc
@@ -614,7 +614,8 @@ static void hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams(const hipStream_t
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams") {
+TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams",
+          "[multigpu]") {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -732,7 +733,8 @@ static void hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams_inLoop(const hipS
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams_inLoop") {
+TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams_inLoop",
+          "[multigpu]") {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -954,7 +956,8 @@ static void hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams_inLoop(const hipS
  *  - HIP_VERSION >= 6.1
  */
 
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams_inLoop") {
+TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams_inLoop",
+          "[multigpu]") {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -1070,7 +1073,8 @@ static void hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams1D_inLoop(const hi
  *  - HIP_VERSION >= 6.1
  */
 
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams1D_inLoop") {
+TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams1D_inLoop",
+          "[multigpu]") {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -1178,7 +1182,8 @@ static void hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsFrmSymbol(const hi
  *  - HIP_VERSION >= 6.1
  */
 
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsFrmSymbol") {
+TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsFrmSymbol",
+          "[multigpu]") {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -1285,7 +1290,8 @@ static void hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsToSymbol(const hip
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsToSymbol") {
+TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsToSymbol",
+          "[multigpu]") {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -1438,7 +1444,8 @@ static void hipGraph_PerfCheck_hipGraphExecMemsetNodeSetParams(const hipStream_t
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecMemsetNodeSetParams") {
+TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecMemsetNodeSetParams",
+          "[multigpu]") {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -1871,7 +1878,8 @@ static void hipGraph_PerfCheck_hipGraphExecChildGraphNodeSetParams_mKernel(
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecChildGraphNodeSetParams") {
+TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecChildGraphNodeSetParams",
+          "[multigpu]") {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -2018,7 +2026,8 @@ static void hipGraph_PerfCheck_hipGraphExecEventRecordNodeSetEvent(const hipStre
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecEventRecordNodeSetEvent") {
+TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecEventRecordNodeSetEvent",
+          "[multigpu]") {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -2205,7 +2214,8 @@ static void hipGraph_PerfCheck_hipGraphExecEventWaitNodeSetEvent(const hipStream
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecEventWaitNodeSetEvent") {
+TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecEventWaitNodeSetEvent",
+          "[multigpu]") {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -2359,7 +2369,8 @@ static void hipGraph_PerfCheck_hipGraphExecHostNodeSetParams(const hipStream_t& 
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecHostNodeSetParams") {
+TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecHostNodeSetParams",
+          "[multigpu]") {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -2482,7 +2493,7 @@ static void hipGraph_PerfCheck_hipGraphExecUpdate(const hipStream_t& stream) {
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecUpdate") {
+TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecUpdate", "[multigpu]") {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "
@@ -2626,7 +2637,8 @@ static void hipGraph_PerfCheck_hipGraphExecUpdate_kernel_inLoop(const hipStream_
  * ------------------------
  *  - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecUpdate_kernel_inLoop") {
+TEST_CASE("Unit_hipGraph_PerfCheck_hipGraphExecUpdate_kernel_inLoop",
+          "[multigpu]") {
   if ((setenv("DEBUG_CLR_GRAPH_PACKET_CAPTURE", "true", 1)) != 0) {
     HipTest::HIP_SKIP_TEST(
         "Unable to turn on "

--- a/projects/hip-tests/catch/unit/graph/hipGraphUpload.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphUpload.cc
@@ -152,7 +152,7 @@ TEST_CASE("Unit_hipGraphUpload_Functional") {
   }
 }
 
-TEST_CASE("Unit_hipGraphUpload_Functional_multidevice_test") {
+TEST_CASE("Unit_hipGraphUpload_Functional_multidevice_test", "[multigpu]") {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
 

--- a/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture.cc
@@ -1024,7 +1024,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_Negative_EndingCapwhenCapInProg") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipStreamBeginCapture_Positive_MultiGPU") {
+TEST_CASE("Unit_hipStreamBeginCapture_Positive_MultiGPU", "[multigpu]") {
   int devcount = 0;
   HIP_CHECK(hipGetDeviceCount(&devcount));
   // If only single GPU is detected then return

--- a/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture_old.cc
@@ -909,7 +909,7 @@ TEST_CASE("Unit_hipStreamBeginCapture_EndingCapturewhenCaptureInProgress") {
 
 /* Test scenario 15
  */
-TEST_CASE("Unit_hipStreamBeginCapture_MultiGPU") {
+TEST_CASE("Unit_hipStreamBeginCapture_MultiGPU", "[multigpu]") {
   int devcount = 0;
   HIP_CHECK(hipGetDeviceCount(&devcount));
   // If only single GPU is detected then return

--- a/projects/hip-tests/catch/unit/kernel/hipPrintfKernel.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipPrintfKernel.cc
@@ -45,7 +45,7 @@ __global__ void run_printf() { printf("Hello World\n"); }
  * ------------------------
  * - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_kernel_ChkPrintf") {
+TEST_CASE("Unit_kernel_ChkPrintf", "[multigpu]") {
   int device_count = 0;
   CaptureStream capture(stdout);
   HIP_CHECK(hipGetDeviceCount(&device_count));

--- a/projects/hip-tests/catch/unit/memory/hipArrayCreate.cc
+++ b/projects/hip-tests/catch/unit/memory/hipArrayCreate.cc
@@ -85,7 +85,7 @@ This testcase verifies the hipArrayCreate API in multithreaded
 scenario by launching threads in parallel on multiple GPUs
 and verifies the hipArrayCreate API with small and big chunks data
 */
-TEST_CASE("Unit_hipArrayCreate_MultiThread") {
+TEST_CASE("Unit_hipArrayCreate_MultiThread", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   std::vector<std::thread> threadlist;

--- a/projects/hip-tests/catch/unit/memory/hipArrayGetDescriptor.cc
+++ b/projects/hip-tests/catch/unit/memory/hipArrayGetDescriptor.cc
@@ -233,7 +233,7 @@ float* funcToChkArray(hipArray_t array) {
  * ------------------------
  * - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipArrayGetDescriptor_1D_2D_ArrayParameterChk") {
+TEST_CASE("Unit_hipArrayGetDescriptor_1D_2D_ArrayParameterChk", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -318,7 +318,8 @@ TEST_CASE("Unit_hipArrayGetDescriptor_1D_2D_ArrayParameterChk") {
  * ------------------------
  * - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipArrayGetDescriptor_MultiThreadScenarioFor1D_2D_Array") {
+TEST_CASE("Unit_hipArrayGetDescriptor_MultiThreadScenarioFor1D_2D_Array",
+          "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -368,7 +369,7 @@ TEST_CASE("Unit_hipArrayGetDescriptor_MultiThreadScenarioFor1D_2D_Array") {
  * ------------------------
  * - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipArrayGetDescriptor_Host2Array_Array2Host") {
+TEST_CASE("Unit_hipArrayGetDescriptor_Host2Array_Array2Host", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipDeviceGetMemPool.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDeviceGetMemPool.cc
@@ -137,7 +137,7 @@ TEST_CASE("Unit_hipDeviceGetMemPool_Functional") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipDeviceGetMemPool_Multidevice") {
+TEST_CASE("Unit_hipDeviceGetMemPool_Multidevice", "[multigpu]") {
   int num_devices;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
 

--- a/projects/hip-tests/catch/unit/memory/hipDeviceSetMemPool.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDeviceSetMemPool.cc
@@ -108,7 +108,7 @@ TEST_CASE("Unit_hipDeviceSetMemPool_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipDeviceSetMemPool_DestroyCurrentMempool") {
+TEST_CASE("Unit_hipDeviceSetMemPool_DestroyCurrentMempool", "[multigpu]") {
   int num_devices;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   for (int dev = 0; dev < num_devices; dev++) {

--- a/projects/hip-tests/catch/unit/memory/hipDrvMemcpy2DUnaligned.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvMemcpy2DUnaligned.cc
@@ -269,7 +269,7 @@ TEST_CASE("Unit_hipDrvMemcpy2DUnaligned_FuncTst") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipDrvMemcpy2DUnaligned_Positive_Basic") {
+TEST_CASE("Unit_hipDrvMemcpy2DUnaligned_Positive_Basic", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   SECTION("Device to Device") {

--- a/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3DAsync_old.cc
@@ -542,7 +542,7 @@ TEST_CASE("Unit_hipDrvMemcpy3DAsync_ExtentValidation") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipDrvMemcpy3DAsync_H2DDeviceContextChange") {
+TEST_CASE("Unit_hipDrvMemcpy3DAsync_H2DDeviceContextChange", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -567,7 +567,8 @@ TEST_CASE("Unit_hipDrvMemcpy3DAsync_H2DDeviceContextChange") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipDrvMemcpy3DAsync_Host2ArrayDeviceContextChange") {
+TEST_CASE("Unit_hipDrvMemcpy3DAsync_Host2ArrayDeviceContextChange",
+          "[multigpu]") {
   CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -595,7 +596,8 @@ TEST_CASE("Unit_hipDrvMemcpy3DAsync_Host2ArrayDeviceContextChange") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipDrvMemcpy3DAsync_multiDevice_Basic_Size_Test") {
+TEST_CASE("Unit_hipDrvMemcpy3DAsync_multiDevice_Basic_Size_Test",
+          "[multigpu]") {
   CHECK_IMAGE_SUPPORT
   constexpr int size_128b = 128, size_256b = 256;
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3D_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3D_old.cc
@@ -524,7 +524,7 @@ TEST_CASE("Unit_hipDrvMemcpy3D_ExtentValidation") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipDrvMemcpy3D_H2DDeviceContextChange") {
+TEST_CASE("Unit_hipDrvMemcpy3D_H2DDeviceContextChange", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -549,7 +549,7 @@ TEST_CASE("Unit_hipDrvMemcpy3D_H2DDeviceContextChange") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipDrvMemcpy3D_Host2ArrayDeviceContextChange") {
+TEST_CASE("Unit_hipDrvMemcpy3D_Host2ArrayDeviceContextChange", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -577,7 +577,7 @@ TEST_CASE("Unit_hipDrvMemcpy3D_Host2ArrayDeviceContextChange") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipDrvMemcpy3D_multiDevice_Basic_Size_Test") {
+TEST_CASE("Unit_hipDrvMemcpy3D_multiDevice_Basic_Size_Test", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
   constexpr int size_128b = 128, size_256b = 256;
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
+++ b/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
@@ -2705,7 +2705,7 @@ TEST_CASE("Unit_hipGetProcAddress_MemoryApisGetMemInfoRelated") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_MemoryApisMemcpy2DRelated") {
+TEST_CASE("Unit_hipGetProcAddress_MemoryApisMemcpy2DRelated", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   void* hipMemcpy2D_ptr = nullptr;
@@ -6008,7 +6008,7 @@ TEST_CASE("Unit_hipGetProcAddress_MemoryApisStreamOrderedMemory") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_MemoryApisPeerToPeer") {
+TEST_CASE("Unit_hipGetProcAddress_MemoryApisPeerToPeer", "[multigpu]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
 

--- a/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
@@ -107,7 +107,8 @@ void doMemCopy(size_t numElements, int offset, T* A, T* Bh, T* Bd, bool internal
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_hipHostRegister_ReferenceFromKernelandhipMemset", "", int, float, double) {
+TEMPLATE_TEST_CASE("Unit_hipHostRegister_ReferenceFromKernelandhipMemset",
+                   "[multigpu]", int, float, double) {
   size_t sizeBytes{LEN * sizeof(TestType)};
   TestType *A, **Ad;
   int num_devices = 0;
@@ -214,7 +215,8 @@ TEMPLATE_TEST_CASE("Unit_hipHostRegister_DirectReferenceFromKernel", "", int, fl
  * ------------------------
  *    - HIP_VERSION >= 5.6
  */
-TEMPLATE_TEST_CASE("Unit_hipHostRegister_DirectReferenceMultGpu", "", int, float, double) {
+TEMPLATE_TEST_CASE("Unit_hipHostRegister_DirectReferenceMultGpu", "[multigpu]",
+                   int, float, double) {
   // 1 refers to doing hipHostRegister once for all devices
   // 0 refers to doing hipHostRegister for each device
   auto register_once = GENERATE(0, 1);

--- a/projects/hip-tests/catch/unit/memory/hipMalloc3D.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMalloc3D.cc
@@ -127,7 +127,7 @@ This testcase verifies the hipMalloc3D API in multithreaded
 scenario by launching threads in parallel on multiple GPUs
 and verifies the hipMalloc3D API with small and big chunks data
 */
-TEST_CASE("Unit_hipMalloc3D_MultiThread") {
+TEST_CASE("Unit_hipMalloc3D_MultiThread", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   std::vector<std::thread> threadlist;

--- a/projects/hip-tests/catch/unit/memory/hipMalloc3DArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMalloc3DArray.cc
@@ -78,7 +78,7 @@ This testcase verifies the hipMalloc3DArray API in multithreaded
 scenario by launching threads in parallel on multiple GPUs
 and verifies the hipMalloc3DArray API with small and big chunks data
 */
-TEST_CASE("Unit_hipMalloc3DArray_MultiThread") {
+TEST_CASE("Unit_hipMalloc3DArray_MultiThread", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   std::vector<std::thread> threadlist;

--- a/projects/hip-tests/catch/unit/memory/hipMallocArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocArray.cc
@@ -80,7 +80,7 @@ This testcase verifies the hipMallocArray API in multithreaded
 scenario by launching threads in parallel on multiple GPUs
 and verifies the hipMallocArray API with small and big chunks data
 */
-TEST_CASE("Unit_hipMallocArray_MultiThread") {
+TEST_CASE("Unit_hipMallocArray_MultiThread", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   std::vector<std::thread> threadlist;

--- a/projects/hip-tests/catch/unit/memory/hipMallocAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocAsync.cc
@@ -290,7 +290,7 @@ TEST_CASE("Unit_hipMallocAsync_StreamEvent_CrissCross") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocAsync_Multidevice") {
+TEST_CASE("Unit_hipMallocAsync_Multidevice", "[multigpu]") {
   int num_devices;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   for (int i = 0; i < num_devices; i++) {
@@ -330,7 +330,7 @@ static void threadQAsyncCommands(streamMemAllocTest* testObj, hipStream_t strm, 
   testObj->freeDevBuf(strm);
 }
 
-TEST_CASE("Unit_hipMallocAsync_Multidevice_Concurrent") {
+TEST_CASE("Unit_hipMallocAsync_Multidevice_Concurrent", "[multigpu]") {
   int num_devices;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   checkIfMultiDev(num_devices) hipStream_t* stream_buf = new hipStream_t[num_devices];
@@ -379,7 +379,7 @@ TEST_CASE("Unit_hipMallocAsync_Multidevice_Concurrent") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocAsync_Multidevice_MultiStream") {
+TEST_CASE("Unit_hipMallocAsync_Multidevice_MultiStream", "[multigpu]") {
   int num_devices;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   checkIfMultiDev(num_devices)

--- a/projects/hip-tests/catch/unit/memory/hipMallocConcurrency.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocConcurrency.cc
@@ -303,7 +303,7 @@ TEST_CASE("Unit_hipMalloc_AllocateAndPoolBuffers") {
  * Exercise hipMalloc() api parellely on all gpus from
  * multiple threads and regress the api.
  */
-TEST_CASE("Unit_hipMalloc_Multithreaded_MultiGPU") {
+TEST_CASE("Unit_hipMalloc_Multithreaded_MultiGPU", "[multigpu]") {
   std::vector<std::thread> threadlist;
   int devCnt;
 

--- a/projects/hip-tests/catch/unit/memory/hipMallocFromPoolAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocFromPoolAsync.cc
@@ -340,7 +340,7 @@ TEST_CASE("Unit_hipMallocFromPoolAsync_hipStreamPerThread") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_ReleaseThreshold_Mgpu") {
+TEST_CASE("Unit_hipMallocFromPoolAsync_ReleaseThreshold_Mgpu", "[multigpu]") {
   constexpr int N = 1 << 20;
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -575,7 +575,7 @@ static bool checkReuseAllowOtherFlags(int N, hipMemPoolAttr attr, enum eTestValu
  *    - HIP_VERSION >= 6.2
  */
 #if HT_AMD
-TEST_CASE("Unit_hipMallocFromPoolAsync_Multidevice_Concurrent") {
+TEST_CASE("Unit_hipMallocFromPoolAsync_Multidevice_Concurrent", "[multigpu]") {
   auto testType = GENERATE(testdefault, testMaximum);
   constexpr int N = 1 << 20;
   int num_devices;
@@ -627,7 +627,7 @@ TEST_CASE("Unit_hipMallocFromPoolAsync_Multidevice_Concurrent") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMallocFromPoolAsync_Multidevice_MultiStream") {
+TEST_CASE("Unit_hipMallocFromPoolAsync_Multidevice_MultiStream", "[multigpu]") {
   int num_devices;
   auto testType = GENERATE(testdefault, testMaximum);
   constexpr int N = 1 << 20;

--- a/projects/hip-tests/catch/unit/memory/hipMallocManagedFlagsTst.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocManagedFlagsTst.cc
@@ -31,7 +31,7 @@ __global__ void MallcMangdFlgTst(int n, float* x, float* y) {
 }
 
 // The following section tests working of hipMallocManaged with flag parameters
-TEST_CASE("Unit_hipMallocManaged_FlgParam") {
+TEST_CASE("Unit_hipMallocManaged_FlgParam", "[multigpu]") {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");
@@ -119,7 +119,7 @@ TEST_CASE("Unit_hipMallocManaged_FlgParam") {
 
 // The following function tests Memory access allocated using hipMallocManaged
 // in multiple streams
-TEST_CASE("Unit_hipMallocManaged_AccessMultiStream") {
+TEST_CASE("Unit_hipMallocManaged_AccessMultiStream", "[multigpu]") {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");

--- a/projects/hip-tests/catch/unit/memory/hipMallocManaged_MultiScenario.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocManaged_MultiScenario.cc
@@ -161,7 +161,7 @@ TEST_CASE("Unit_hipMallocManaged_MultiChunkSingleDevice") {
 // Equal parts of Hmm is accessed on available gpus and
 // kernel is launched on acessed chunk of hmm memory
 // and checks if there are any inconsistencies or access issues
-TEST_CASE("Unit_hipMallocManaged_MultiChunkMultiDevice") {
+TEST_CASE("Unit_hipMallocManaged_MultiChunkMultiDevice", "[multigpu]") {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");
@@ -304,7 +304,8 @@ TEST_CASE("Unit_hipMallocManaged_Negative") {
 // Allocate two pointers using hipMallocManaged(), initialize,
 // then launch kernel using these pointers directly and
 // later validate the content without using any Memcpy.
-TEMPLATE_TEST_CASE("Unit_hipMallocManaged_TwoPointers", "", int, float, double) {
+TEMPLATE_TEST_CASE("Unit_hipMallocManaged_TwoPointers", "[multigpu]", int,
+                   float, double) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");
@@ -344,8 +345,8 @@ TEMPLATE_TEST_CASE("Unit_hipMallocManaged_TwoPointers", "", int, float, double) 
 // to all other devices. This include verification and Device two Device
 // transfers and kernel launch o discover if there any access issues.
 
-TEMPLATE_TEST_CASE("Unit_hipMallocManaged_DeviceContextChange", "", unsigned char, int, float,
-                   double) {
+TEMPLATE_TEST_CASE("Unit_hipMallocManaged_DeviceContextChange", "[multigpu]",
+                   unsigned char, int, float, double) {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");

--- a/projects/hip-tests/catch/unit/memory/hipMallocMipmappedArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocMipmappedArray.cc
@@ -85,7 +85,7 @@ This testcase verifies the hipMallocMipmappedArray API in multithreaded
 scenario by launching threads in parallel on multiple GPUs
 and verifies the hipMallocMipmappedArray API with small and big chunks data
 */
-TEST_CASE("Unit_hipMallocMipmappedArray_MultiThread") {
+TEST_CASE("Unit_hipMallocMipmappedArray_MultiThread", "[multigpu]") {
   std::vector<std::thread> threadlist;
   int devCnt = 0;
   devCnt = HipTest::getDeviceCount();

--- a/projects/hip-tests/catch/unit/memory/hipMallocMngdMultiThread.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocMngdMultiThread.cc
@@ -297,7 +297,7 @@ static void AllocateHmmMemory(int flag, int device) {
   }
 }
 
-TEST_CASE("Unit_hipMallocManaged_MultiThread") {
+TEST_CASE("Unit_hipMallocManaged_MultiThread", "[multigpu]") {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");
@@ -351,7 +351,7 @@ TEST_CASE("Unit_hipMallocManaged_MultiThread") {
 
 // The following test checks what happens when same Hmm memory is used to
 // launch multiple threads over multiple gpus
-TEST_CASE("Unit_hipMallocManaged_MGpuMThread") {
+TEST_CASE("Unit_hipMallocManaged_MGpuMThread", "[multigpu]") {
   auto managed = HmmAttrPrint();
   if (managed != 1) {
     HipTest::HIP_SKIP_TEST("GPU doesn't support managed memory so skipping test.");

--- a/projects/hip-tests/catch/unit/memory/hipMallocPitch.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocPitch.cc
@@ -459,7 +459,7 @@ scenario by launching threads in parallel on multiple GPUs
 and verifies the hipMallocPitch API with small and big chunks data
 */
 
-TEST_CASE("Unit_hipMallocPitch_MultiThread", "") {
+TEST_CASE("Unit_hipMallocPitch_MultiThread", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   std::vector<std::thread> threadlist;

--- a/projects/hip-tests/catch/unit/memory/hipMemAdvise.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAdvise.cc
@@ -181,7 +181,7 @@ TEST_CASE("Unit_hipMemAdvise_Flags_Do_Not_Cause_Prefetch") {
 #endif
 }
 
-TEST_CASE("Unit_hipMemAdvise_Read_Write_After_Advise") {
+TEST_CASE("Unit_hipMemAdvise_Read_Write_After_Advise", "[multigpu]") {
   auto supported_devices = GetDevicesWithAdviseSupport();
   if (supported_devices.empty()) {
     HipTest::HIP_SKIP_TEST("Test needs at least 1 device that supports managed memory");

--- a/projects/hip-tests/catch/unit/memory/hipMemAdvise_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAdvise_old.cc
@@ -243,7 +243,7 @@ TEST_CASE("Unit_hipMemAdvise_NegtveTsts") {
 
 // The following function tests various scenarios around the flag
 // 'hipMemAdviseSetPreferredLocation' using HMM memory and hipMemAdvise() api
-TEST_CASE("Unit_hipMemAdvise_PrefrdLoc") {
+TEST_CASE("Unit_hipMemAdvise_PrefrdLoc", "[multigpu]") {
   int MangdMem = HmmAttrPrint();
   if (MangdMem == 1) {
     // Check that when a page fault occurs for the memory region set to devPtr,
@@ -428,7 +428,7 @@ TEST_CASE("Unit_hipMemAdvise_TstFlgOverrideEffect") {
 // The following function tests if peers can set hipMemAdviseSetAccessedBy flag
 // on HMM memory prefetched on each of the other gpus
 #if HT_AMD
-TEST_CASE("Unit_hipMemAdvise_TstAccessedByPeer") {
+TEST_CASE("Unit_hipMemAdvise_TstAccessedByPeer", "[multigpu]") {
   int MangdMem = HmmAttrPrint();
   if (MangdMem == 1) {
     bool IfTestPassed = true;
@@ -732,7 +732,7 @@ TEST_CASE("Unit_hipMemAdvise_TstMemAdvisePrefrdLoc") {
    to device1, probe for hipMemRangeAttributeLastPrefetchLocation using
    hipMemRangeGetAttribute(), we should get 1*/
 
-TEST_CASE("Unit_hipMemAdvise_TstMemAdviseLstPreftchLoc") {
+TEST_CASE("Unit_hipMemAdvise_TstMemAdviseLstPreftchLoc", "[multigpu]") {
   int NumDevs = 0;
   HIP_CHECK(hipGetDeviceCount(&NumDevs));
   if (NumDevs >= 2) {
@@ -802,7 +802,7 @@ TEST_CASE("Unit_hipMemAdvise_TstMemAdviseMultiFlag") {
   access denial case arising due to setting ReadMostly only to a particular
   gpu*/
 
-TEST_CASE("Unit_hipMemAdvise_ReadMosltyMgpuTst") {
+TEST_CASE("Unit_hipMemAdvise_ReadMosltyMgpuTst", "[multigpu]") {
   int managed = HmmAttrPrint();
   if (managed == 1) {
     int Ngpus = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemAdvise_v2.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAdvise_v2.cc
@@ -70,7 +70,7 @@ static std::vector<int> getSupportedDevices() {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemAdvise_v2_Device_Host") {
+TEST_CASE("Unit_hipMemAdvise_v2_Device_Host", "[multigpu]") {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty()) {
     HipTest::HIP_SKIP_TEST(

--- a/projects/hip-tests/catch/unit/memory/hipMemAllocHost.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAllocHost.cc
@@ -93,7 +93,7 @@ TEST_CASE("Unit_hipMemAllocHost_Negative") {
 /*
  * Verify that a device can read/write to the memory of another device
  */
-TEST_CASE("Unit_hipMemAllocHost_VerifyAccess") {
+TEST_CASE("Unit_hipMemAllocHost_VerifyAccess", "[multigpu]") {
   int devices_number = 0;
   HIP_CHECK(hipGetDeviceCount(&devices_number));
   std::vector<int*> devices_memories(devices_number);

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolCreate.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolCreate.cc
@@ -157,7 +157,7 @@ static __global__ void setKer(int* devptr) {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolCreate_DeviceTest") {
+TEST_CASE("Unit_hipMemPoolCreate_DeviceTest", "[multigpu]") {
   checkMempoolSupported(0) int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   checkIfMultiDev(num_devices)

--- a/projects/hip-tests/catch/unit/memory/hipMemPoolSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolSetGetAccess.cc
@@ -98,7 +98,7 @@ int CheckP2PMemPoolSupport(int src_device, int dst_device) {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolSetGetAccess_Positive_MultipleGPU") {
+TEST_CASE("Unit_hipMemPoolSetGetAccess_Positive_MultipleGPU", "[multigpu]") {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");
@@ -212,7 +212,7 @@ void MemPoolSetGetAccess_P2P(const MemPools mempool_type) {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolSetGetAccess_Positive_P2P") {
+TEST_CASE("Unit_hipMemPoolSetGetAccess_Positive_P2P", "[multigpu]") {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");
@@ -406,7 +406,7 @@ static void getDevicePairs(std::vector<std::pair<int, int>>* p2p_pairs, int numD
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemPoolSetAccess_SetAccess") {
+TEST_CASE("Unit_hipMemPoolSetAccess_SetAccess", "[multigpu]") {
   constexpr int N = 1 << 14;
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));

--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsync.cc
@@ -47,7 +47,7 @@ __global__ void MemPrefetchAsyncKernel(int* C_d, const int* A_d, size_t N) {
   }
 }
 
-TEST_CASE("Unit_hipMemPrefetchAsync_Basic") {
+TEST_CASE("Unit_hipMemPrefetchAsync_Basic", "[multigpu]") {
   const auto supported_devices = GetDevicesWithPrefetchSupport();
   if (supported_devices.empty()) {
     HipTest::HIP_SKIP_TEST("Test need at least one device with managed memory support");

--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsync_v2.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchAsync_v2.cc
@@ -70,7 +70,7 @@ static std::vector<int> getSupportedDevices() {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipMemPrefetchAsync_v2_Device_Host") {
+TEST_CASE("Unit_hipMemPrefetchAsync_v2_Device_Host", "[multigpu]") {
   auto supportedDevices = getSupportedDevices();
   if (supportedDevices.empty()) {
     HipTest::HIP_SKIP_TEST(

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2D.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2D.cc
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipMemcpy2D_Positive_Basic") {
+TEST_CASE("Unit_hipMemcpy2D_Positive_Basic", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
   constexpr bool async = false;
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync.cc
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipMemcpy2DAsync_Positive_Basic") {
+TEST_CASE("Unit_hipMemcpy2DAsync_Positive_Basic", "[multigpu]") {
   using namespace std::placeholders;
 
   constexpr bool async = true;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync_old.cc
@@ -172,7 +172,8 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy2DAsync_Host&PinnedMem", "", int, float, doubl
  *  - HIP_VERSION >= 5.2
  */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpy2DAsync_multiDevice-Host&PinnedMem", "", int, float, double) {
+TEMPLATE_TEST_CASE("Unit_hipMemcpy2DAsync_multiDevice-Host&PinnedMem",
+                   "[multigpu]", int, float, double) {
   CHECK_IMAGE_SUPPORT
   auto mem_type = GENERATE(0, 1);
   int numDevices = 0;
@@ -264,7 +265,8 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy2DAsync_multiDevice-Host&PinnedMem", "", int, 
  *  - HIP_VERSION >= 5.2
  */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpy2DAsync_multiDevice-StreamOnDiffDevice", "", int, float, double) {
+TEMPLATE_TEST_CASE("Unit_hipMemcpy2DAsync_multiDevice-StreamOnDiffDevice",
+                   "[multigpu]", int, float, double) {
   CHECK_IMAGE_SUPPORT
   auto mem_type = GENERATE(0, 1);
   int numDevices = 0;
@@ -506,7 +508,7 @@ static void hipMemcpy2DAsync_Basic_Size_Test(size_t inc) {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipMemcpy2DAsync_multiDevice_Basic_Size_Test") {
+TEST_CASE("Unit_hipMemcpy2DAsync_multiDevice_Basic_Size_Test", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
   size_t input = 1 << 20;
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArray.cc
@@ -34,8 +34,7 @@ invalid
 #include <resource_guards.hh>
 #include <utils.hh>
 
-
-TEST_CASE("Unit_hipMemcpy2DFromArray_Positive_Default") {
+TEST_CASE("Unit_hipMemcpy2DFromArray_Positive_Default", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArrayAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArrayAsync.cc
@@ -34,7 +34,7 @@ of hipMemcpy2DFromArrayAsync api when parameters are invalid
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_Positive_Default") {
+TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_Positive_Default", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArrayAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArrayAsync_old.cc
@@ -195,7 +195,8 @@ TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_PinnedHostMemSameGpu") {
            then A_d-->E_h  in GPU1
  * OUTPUT: validating the result by comparing A_h and E_h
  */
-TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_multiDevicePinnedHostMem") {
+TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_multiDevicePinnedHostMem",
+          "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -254,7 +255,8 @@ TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_multiDevicePinnedHostMem") {
  *         --> A_h host variable
  *         and verifying A_h with Phi
  * */
-TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_multiDeviceContextChange") {
+TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_multiDeviceContextChange",
+          "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArray_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArray_old.cc
@@ -165,7 +165,8 @@ TEST_CASE("Unit_hipMemcpy2DFromArray_PinnedMemSameGPU") {
  *         --> E_h host variable
  *         and verifying A_h with E_h
  */
-TEST_CASE("Unit_hipMemcpy2DFromArray_multiDevicePinnedMemPeerGpu") {
+TEST_CASE("Unit_hipMemcpy2DFromArray_multiDevicePinnedMemPeerGpu",
+          "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -218,7 +219,7 @@ TEST_CASE("Unit_hipMemcpy2DFromArray_multiDevicePinnedMemPeerGpu") {
  *         --> A_h host variable
  *         and verifying A_h with Phi
  * */
-TEST_CASE("Unit_hipMemcpy2DFromArray_multiDeviceContextChange") {
+TEST_CASE("Unit_hipMemcpy2DFromArray_multiDeviceContextChange", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArray.cc
@@ -33,8 +33,7 @@ unsuccessful execution of hipMemcpy2DToArray api when parameters are invalid
 #include <resource_guards.hh>
 #include <utils.hh>
 
-
-TEST_CASE("Unit_hipMemcpy2DToArray_Positive_Default") {
+TEST_CASE("Unit_hipMemcpy2DToArray_Positive_Default", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArrayAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArrayAsync.cc
@@ -34,8 +34,7 @@ of hipMemcpy2DToArrayAsync api when parameters are invalid
 #include <resource_guards.hh>
 #include <utils.hh>
 
-
-TEST_CASE("Unit_hipMemcpy2DToArrayAsync_Positive_Default") {
+TEST_CASE("Unit_hipMemcpy2DToArrayAsync_Positive_Default", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   using namespace std::placeholders;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArrayAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArrayAsync_old.cc
@@ -194,7 +194,8 @@ TEST_CASE("Unit_hipMemcpy2DToArrayAsync_PinnedHostMemSameGpu") {
  *         --> A_h host variable
  *         and verifying A_h with E_h[0]+i(i.e., 10+i)
  */
-TEST_CASE("Unit_hipMemcpy2DToArrayAsync_multiDevicePinnedHostMem") {
+TEST_CASE("Unit_hipMemcpy2DToArrayAsync_multiDevicePinnedHostMem",
+          "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -254,7 +255,8 @@ TEST_CASE("Unit_hipMemcpy2DToArrayAsync_multiDevicePinnedHostMem") {
  *         --> A_h host variable
  *         and verifying A_h with Phi
  * */
-TEST_CASE("Unit_hipMemcpy2DToArrayAsync_multiDeviceDeviceContextChange") {
+TEST_CASE("Unit_hipMemcpy2DToArrayAsync_multiDeviceDeviceContextChange",
+          "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArray_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArray_old.cc
@@ -164,7 +164,7 @@ TEST_CASE("Unit_hipMemcpy2DToArray_PinnedMemSameGPU") {
  *         --> A_h host variable
  *         and verifying A_h with E_h[0]+i(i.e., 10+i)
  */
-TEST_CASE("Unit_hipMemcpy2DToArray_multiDevicePinnedMemPeerGpu") {
+TEST_CASE("Unit_hipMemcpy2DToArray_multiDevicePinnedMemPeerGpu", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -218,7 +218,8 @@ TEST_CASE("Unit_hipMemcpy2DToArray_multiDevicePinnedMemPeerGpu") {
  *         --> A_h host variable
  *         and verifying A_h with Phi
  * */
-TEST_CASE("Unit_hipMemcpy2DToArray_multiDeviceDeviceContextChange") {
+TEST_CASE("Unit_hipMemcpy2DToArray_multiDeviceDeviceContextChange",
+          "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2D_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2D_old.cc
@@ -309,7 +309,8 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy2D_H2D-D2D-D2H_Managed_WithOffset", "", int, f
  *  - HIP_VERSION >= 6.0
  */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpy2D_multiDevice-D2D", "", int, float, double) {
+TEMPLATE_TEST_CASE("Unit_hipMemcpy2D_multiDevice-D2D", "[multigpu]", int, float,
+                   double) {
   CHECK_IMAGE_SUPPORT
   auto mem_type = GENERATE(0, 1);
   int numDevices = 0;
@@ -524,7 +525,7 @@ static void hipMemcpy2D_Basic_Size_Test(size_t inc) {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipMemcpy2D_multiDevice_Basic_Size_Test") {
+TEST_CASE("Unit_hipMemcpy2D_multiDevice_Basic_Size_Test", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
   size_t input = 1 << 20;
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3DAsync_old.cc
@@ -715,7 +715,7 @@ TEST_CASE("Unit_hipMemcpy3DAsync_multiDevice-Negative") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipMemcpy3DAsync_multiDevice-D2D") {
+TEST_CASE("Unit_hipMemcpy3DAsync_multiDevice-D2D", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -747,7 +747,7 @@ TEST_CASE("Unit_hipMemcpy3DAsync_multiDevice-D2D") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipMemcpy3DAsync_multiDevice-DiffStream") {
+TEST_CASE("Unit_hipMemcpy3DAsync_multiDevice-DiffStream", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3D_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3D_old.cc
@@ -609,7 +609,7 @@ TEST_CASE("Unit_hipMemcpy3D_multiDevice-Negative") {
  *  - HIP_VERSION >= 5.2
  */
 
-TEST_CASE("Unit_hipMemcpy3D_multiDevice-OnPeerDevice") {
+TEST_CASE("Unit_hipMemcpy3D_multiDevice-OnPeerDevice", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -644,7 +644,7 @@ TEST_CASE("Unit_hipMemcpy3D_multiDevice-OnPeerDevice") {
  *  - HIP_VERSION >= 6.0
  */
 
-TEST_CASE("Unit_hipMemcpy3D_multiDevice_Basic_Size_Test") {
+TEST_CASE("Unit_hipMemcpy3D_multiDevice_Basic_Size_Test", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
   constexpr int size_128b = 128, size_256b = 256;
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_old.cc
@@ -128,7 +128,8 @@ This testcase verifies the following scenarios
 4. Device context change
 5. H2D-D2D-D2H peer GPU
 */
-TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_H2H-H2D-D2H-H2PinMem", "", char, int, float, double) {
+TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_H2H-H2D-D2H-H2PinMem", "[multigpu]",
+                   char, int, float, double) {
   TestType *A_d{nullptr}, *B_d{nullptr};
   TestType *A_h{nullptr}, *B_h{nullptr};
   TestType *A_Ph{nullptr}, *B_Ph{nullptr};
@@ -288,7 +289,8 @@ This testcase verifies hipMemcpy API with pinnedMemory and hostRegister
 along with kernel launches
 */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_PinnedRegMemWithKernelLaunch", "", int, float, double) {
+TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_PinnedRegMemWithKernelLaunch",
+                   "[multigpu]", int, float, double) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAtoH_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAtoH_old.cc
@@ -90,8 +90,8 @@ Output:"B_h" host variable output of hipMemcpyAtoH API
         is then validated with "hData"
 */
 #if HT_AMD
-TEMPLATE_TEST_CASE("Unit_hipMemcpyAtoH_multiDevice-PeerDeviceContext", "[hipMemcpyAtoH]", char, int,
-                   float) {
+TEMPLATE_TEST_CASE("Unit_hipMemcpyAtoH_multiDevice-PeerDeviceContext",
+                   "[hipMemcpyAtoH][multigpu]", char, int, float) {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyDtoD.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyDtoD.cc
@@ -38,7 +38,8 @@ This testcase verifies hipMemcpyDtoD API
 6.Kernel Launch
 7.DtoH copy and validating the result
 */
-TEMPLATE_TEST_CASE("Unit_hipMemcpyDtoD_Basic", "", int, float, double) {
+TEMPLATE_TEST_CASE("Unit_hipMemcpyDtoD_Basic", "[multigpu]", int, float,
+                   double) {
   size_t Nbytes = NUM_ELM * sizeof(TestType);
   int numDevices = 0;
   TestType *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr}, *X_d{nullptr}, *Y_d{nullptr}, *Z_d{nullptr};

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyDtoDAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyDtoDAsync.cc
@@ -40,7 +40,8 @@ This testcase verifies hipMemcpyDtoDAsync API
 7.DtoH copy and validating the result
 */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpyDtoDAsync_Basic", "", int, float, double) {
+TEMPLATE_TEST_CASE("Unit_hipMemcpyDtoDAsync_Basic", "[multigpu]", int, float,
+                   double) {
   size_t Nbytes = NUM_ELM * sizeof(TestType);
   int numDevices = 0;
   TestType *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr}, *X_d{nullptr}, *Y_d{nullptr}, *Z_d{nullptr};

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyHtoAAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyHtoAAsync.cc
@@ -166,7 +166,7 @@ TEST_CASE("Unit_hipMemcpyHtoAAsync_BasicTstsWithDiffStreams") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipMemcpyHtoAAsync_MultiDevice") {
+TEST_CASE("Unit_hipMemcpyHtoAAsync_MultiDevice", "[multigpu]") {
 #if HT_NVIDIA
   HipTest::HIP_SKIP_TEST("API currently unsupported on nvidia, skipping...");
   return;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyHtoA_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyHtoA_old.cc
@@ -93,8 +93,8 @@ Output: "A_d" output of hipMemcpyHtoA is copied to "hData" host variable
         validated the result with "B_h"
 */
 #if HT_AMD
-TEMPLATE_TEST_CASE("Unit_hipMemcpyHtoA_multiDevice-PeerDeviceContext", "[hipMemcpyHtoA]", char, int,
-                   float) {
+TEMPLATE_TEST_CASE("Unit_hipMemcpyHtoA_multiDevice-PeerDeviceContext",
+                   "[hipMemcpyHtoA][multigpu]", char, int, float) {
   CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyParam2D.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyParam2D.cc
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipMemcpyParam2D_Positive_Basic") {
+TEST_CASE("Unit_hipMemcpyParam2D_Positive_Basic", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
   constexpr bool async = false;
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyParam2DAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyParam2DAsync.cc
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipMemcpyParam2DAsync_Positive_Basic") {
+TEST_CASE("Unit_hipMemcpyParam2DAsync_Positive_Basic", "[multigpu]") {
   using namespace std::placeholders;
 
   constexpr bool async = true;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyParam2DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyParam2DAsync_old.cc
@@ -44,7 +44,8 @@ static constexpr size_t NUM_H{10};
  *
  */
 TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2DAsync_multiDevice-StreamOnDiffDevice",
-                   "[hipMemcpyParam2DAsync]", char, float, int, double, long double) {
+                   "[hipMemcpyParam2DAsync][multigpu]", char, float, int,
+                   double, long double) {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -118,8 +119,9 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2DAsync_multiDevice-StreamOnDiffDevice",
  * it with the initalized data "C_h".
  *
  */
-TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2DAsync_multiDevice-D2D", "[hipMemcpyParam2DAsync]", char,
-                   int, float, double, long double) {
+TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2DAsync_multiDevice-D2D",
+                   "[hipMemcpyParam2DAsync][multigpu]", char, int, float,
+                   double, long double) {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -195,8 +197,9 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2DAsync_multiDevice-D2D", "[hipMemcpyPara
  *
  * Validating the result by comparing "A_h" to "C_h"
  */
-TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2DAsync_multiDevice-H2D-D2H", "[hipMemcpyParam2DAsync]",
-                   char, int, float, double, long double) {
+TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2DAsync_multiDevice-H2D-D2H",
+                   "[hipMemcpyParam2DAsync][multigpu]", char, int, float,
+                   double, long double) {
   CHECK_IMAGE_SUPPORT
 
   // 1 refers to pinned host memory and 0 refers

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyParam2D_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyParam2D_old.cc
@@ -39,8 +39,9 @@ static constexpr size_t NUM_H{10};
  * it with the initalized data "C_h".
  *
  */
-TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2D_multiDevice-D2D", "[hipMemcpyParam2D]", char, float, int,
-                   double, long double) {
+TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2D_multiDevice-D2D",
+                   "[hipMemcpyParam2D][multigpu]", char, float, int, double,
+                   long double) {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyPeer.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyPeer.cc
@@ -45,7 +45,7 @@ THE SOFTWARE.
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipMemcpyPeer_Positive_Default") {
+TEST_CASE("Unit_hipMemcpyPeer_Positive_Default", "[multigpu]") {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");
@@ -110,7 +110,8 @@ TEST_CASE("Unit_hipMemcpyPeer_Positive_Default") {
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipMemcpyPeer_Positive_Synchronization_Behavior") {
+TEST_CASE("Unit_hipMemcpyPeer_Positive_Synchronization_Behavior",
+          "[multigpu]") {
   HIP_CHECK(hipDeviceSynchronize());
 
   const auto device_count = HipTest::getDeviceCount();
@@ -158,7 +159,7 @@ TEST_CASE("Unit_hipMemcpyPeer_Positive_Synchronization_Behavior") {
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipMemcpyPeer_Positive_ZeroSize") {
+TEST_CASE("Unit_hipMemcpyPeer_Positive_ZeroSize", "[multigpu]") {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");
@@ -241,7 +242,7 @@ TEST_CASE("Unit_hipMemcpyPeer_Positive_ZeroSize") {
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipMemcpyPeer_Negative_Parameters") {
+TEST_CASE("Unit_hipMemcpyPeer_Negative_Parameters", "[multigpu]") {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyPeerAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyPeerAsync.cc
@@ -45,7 +45,7 @@ THE SOFTWARE.
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipMemcpyPeerAsync_Positive_Default") {
+TEST_CASE("Unit_hipMemcpyPeerAsync_Positive_Default", "[multigpu]") {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");
@@ -114,7 +114,8 @@ TEST_CASE("Unit_hipMemcpyPeerAsync_Positive_Default") {
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipMemcpyPeerAsync_Positive_Synchronization_Behavior") {
+TEST_CASE("Unit_hipMemcpyPeerAsync_Positive_Synchronization_Behavior",
+          "[multigpu]") {
   HIP_CHECK(hipDeviceSynchronize());
 
   const auto device_count = HipTest::getDeviceCount();
@@ -165,7 +166,7 @@ TEST_CASE("Unit_hipMemcpyPeerAsync_Positive_Synchronization_Behavior") {
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipMemcpyPeerAsync_Positive_ZeroSize") {
+TEST_CASE("Unit_hipMemcpyPeerAsync_Positive_ZeroSize", "[multigpu]") {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");
@@ -250,7 +251,7 @@ TEST_CASE("Unit_hipMemcpyPeerAsync_Positive_ZeroSize") {
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipMemcpyPeerAsync_Negative_Parameters") {
+TEST_CASE("Unit_hipMemcpyPeerAsync_Negative_Parameters", "[multigpu]") {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyPeerAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyPeerAsync_old.cc
@@ -32,7 +32,7 @@ This testfile verifies the following scenarios of hipMemcpyPeerAsync API
 
 /*This testcase verifies the negative scenarios of hipmemcpypeerAsync
  */
-TEST_CASE("Unit_hipMemcpyPeerAsync_Negative") {
+TEST_CASE("Unit_hipMemcpyPeerAsync_Negative", "[multigpu]") {
   constexpr auto numElements{10};
   constexpr auto copy_bytes{numElements * sizeof(int)};
   int numDevices = 0;
@@ -99,7 +99,7 @@ TEST_CASE("Unit_hipMemcpyPeerAsync_Negative") {
  * Then performs the addition and validates the sum
  */
 
-TEST_CASE("Unit_hipMemcpyPeerAsync_Basic") {
+TEST_CASE("Unit_hipMemcpyPeerAsync_Basic", "[multigpu]") {
   constexpr auto numElements{10};
   constexpr auto copy_bytes{numElements * sizeof(int)};
 
@@ -175,7 +175,7 @@ TEST_CASE("Unit_hipMemcpyPeerAsync_Basic") {
  * where stream is created in GPU-1
  * Then performs the addition and validates the sum
  */
-TEST_CASE("Unit_hipMemcpyPeerAsync_StreamOnDiffDevice") {
+TEST_CASE("Unit_hipMemcpyPeerAsync_StreamOnDiffDevice", "[multigpu]") {
   constexpr auto numElements{10};
   constexpr auto copy_bytes{numElements * sizeof(int)};
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyPeer_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyPeer_old.cc
@@ -28,7 +28,7 @@ This testfile verifies the following scenarios of hipMemcpyPeer API
 
 /*This testcase verifies the negative scenarios of hipmemcpypeer
  */
-TEST_CASE("Unit_hipMemcpyPeer_Negative") {
+TEST_CASE("Unit_hipMemcpyPeer_Negative", "[multigpu]") {
   constexpr auto numElements{10};
   constexpr auto copy_bytes{numElements * sizeof(int)};
   int numDevices = 0;
@@ -91,7 +91,7 @@ TEST_CASE("Unit_hipMemcpyPeer_Negative") {
  * Copies the data from GPU-0 to GPU-1 using hipMemcpyPeer API
  * Then performs the addition and validates the sum
  */
-TEST_CASE("Unit_hipMemcpyPeer_Basic") {
+TEST_CASE("Unit_hipMemcpyPeer_Basic", "[multigpu]") {
   constexpr auto numElements{10};
   constexpr auto copy_bytes{numElements * sizeof(int)};
   int numDevices = 0;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyWithStreamMultiThread.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyWithStreamMultiThread.cc
@@ -580,7 +580,7 @@ void HipMemcpyWithStreamMultiThreadtests::TestkindHtoH(bool& val_res) {
   HIP_CHECK_THREAD(hipStreamDestroy(stream));
 }
 
-TEST_CASE("Unit_hipMemcpyWithStream_MultiThread") {
+TEST_CASE("Unit_hipMemcpyWithStream_MultiThread", "[multigpu]") {
   const auto Threadcount{10};
   bool ret_val[Threadcount];
   std::thread th[Threadcount];

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyWithStream_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyWithStream_old.cc
@@ -520,13 +520,20 @@ TEST_CASE("Unit_hipMemcpyWithStream_TestkindDtoH") { TestkindDtoH(); }
 
 TEST_CASE("Unit_hipMemcpyWithStream_TestkindHtoH") { TestkindHtoH(); }
 
-TEST_CASE("Unit_hipMemcpyWithStream_TestkindDtoD") { TestkindDtoD(); }
+TEST_CASE("Unit_hipMemcpyWithStream_TestkindDtoD", "[multigpu]") {
+  TestkindDtoD();
+}
 
-TEST_CASE("Unit_hipMemcpyWithStream_TestOnMultiGPUwithOneStream") { TestOnMultiGPUwithOneStream(); }
+TEST_CASE("Unit_hipMemcpyWithStream_TestOnMultiGPUwithOneStream",
+          "[multigpu]") {
+  TestOnMultiGPUwithOneStream();
+}
 
 TEST_CASE("Unit_hipMemcpyWithStream_TestkindDefault") { TestkindDefault(); }
 #ifndef __HIP_PLATFORM_NVIDIA__
-TEST_CASE("Unit_hipMemcpyWithStream_TestkindDefaultForDtoD") { TestkindDefaultForDtoD(); }
+TEST_CASE("Unit_hipMemcpyWithStream_TestkindDefaultForDtoD", "[multigpu]") {
+  TestkindDefaultForDtoD();
+}
 #endif
 
 TEST_CASE("Unit_hipMemcpyWithStream_TestDtoDonSameDevice") { TestDtoDonSameDevice(); }

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy_EdgeCases.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy_EdgeCases.cc
@@ -399,7 +399,8 @@ This testcase verifies the following scenarios
 4. Device context change
 5. H2D-D2D-D2H peer GPU
 */
-TEMPLATE_TEST_CASE("Unit_hipMemcpy_H2H-H2D-D2H-H2PinMem", "", int, float, double) {
+TEMPLATE_TEST_CASE("Unit_hipMemcpy_H2H-H2D-D2H-H2PinMem", "[multigpu]", int,
+                   float, double) {
   TestType *A_d{nullptr}, *B_d{nullptr};
   TestType *A_h{nullptr}, *B_h{nullptr};
   TestType *A_Ph{nullptr}, *B_Ph{nullptr};
@@ -495,7 +496,8 @@ This testcase verifies hipMemcpy API with pinnedMemory and hostRegister
 along with kernel launches
 */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpy_PinnedRegMemWithKernelLaunch", "", int, float, double) {
+TEMPLATE_TEST_CASE("Unit_hipMemcpy_PinnedRegMemWithKernelLaunch", "[multigpu]",
+                   int, float, double) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy_MultiThread.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy_MultiThread.cc
@@ -280,7 +280,7 @@ void Thread_func(bool& ret_val) {
 }
 
 
-TEST_CASE("Unit_hipMemcpy_MultiThread-AllAPIs") {
+TEST_CASE("Unit_hipMemcpy_MultiThread-AllAPIs", "[multigpu]") {
   std::thread Thrd[NUM_THREADS];
   bool ret_val[NUM_THREADS];
   for (int i = 0; i < NUM_THREADS; i++) Thrd[i] = std::thread(Thread_func, std::ref(ret_val[i]));

--- a/projects/hip-tests/catch/unit/memory/hipMemset3DRegressMultiThread.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemset3DRegressMultiThread.cc
@@ -186,7 +186,7 @@ bool loopRegression(bool bAsync) {
  * Perform regression of hipMemset3D api with device memory allocated
  * on different gpus.
  */
-TEST_CASE("Unit_hipMemset3D_RegressInLoop") {
+TEST_CASE("Unit_hipMemset3D_RegressInLoop", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   bool TestPassed = false;
@@ -199,7 +199,7 @@ TEST_CASE("Unit_hipMemset3D_RegressInLoop") {
  * Perform regression of hipMemset3DAsync api with device memory allocated
  * on different gpus.
  */
-TEST_CASE("Unit_hipMemset3DAsync_RegressInLoop") {
+TEST_CASE("Unit_hipMemset3DAsync_RegressInLoop", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   bool TestPassed = false;

--- a/projects/hip-tests/catch/unit/memory/hipPointerGetAttribute.cc
+++ b/projects/hip-tests/catch/unit/memory/hipPointerGetAttribute.cc
@@ -150,7 +150,7 @@ TEST_CASE("Unit_hipPointerGetAttribute_KernelUpdation") {
  * from peer GPU device.It validates the memory type and
  * device ordinal in peer GPU
  */
-TEST_CASE("Unit_hipPointerGetAttribute_PeerGPU") {
+TEST_CASE("Unit_hipPointerGetAttribute_PeerGPU", "[multigpu]") {
   HIP_CHECK(hipSetDevice(0));
   size_t Nbytes = 0;
   Nbytes = N * sizeof(int);

--- a/projects/hip-tests/catch/unit/memory/hipPointerGetAttributes.cc
+++ b/projects/hip-tests/catch/unit/memory/hipPointerGetAttributes.cc
@@ -310,7 +310,7 @@ TEST_CASE("Unit_hipPointerGetAttributes_Basic") {
  *  - HIP_VERSION >= 5.7
  */
 
-TEST_CASE("Unit_hipPointerGetAttributes_ClusterAlloc") {
+TEST_CASE("Unit_hipPointerGetAttributes_ClusterAlloc", "[multigpu]") {
   srand(0x100);
   printf("\n=============================================\n");
   clusterAllocs(100, 1024 * 1, 1024 * 1024);
@@ -327,7 +327,7 @@ TEST_CASE("Unit_hipPointerGetAttributes_ClusterAlloc") {
  *  - HIP_VERSION >= 5.7
  */
 
-TEST_CASE("Unit_hipPointerGetAttributes_TinyClusterAlloc") {
+TEST_CASE("Unit_hipPointerGetAttributes_TinyClusterAlloc", "[multigpu]") {
   srand(0x200);
   printf("\n=============================================\n");
   clusterAllocs(1000, 1, 10);  //  Many tiny allocations;
@@ -337,7 +337,7 @@ TEST_CASE("Unit_hipPointerGetAttributes_TinyClusterAlloc") {
 // IN : serialize will force the test to run in serial fashion.
 #if 0  // FIXME_jatinx These need to be ported to HIP_CHECK_THREAD.
 Disabling it for now
-TEST_CASE("Unit_hipPointerGetAttributes_MultiThread") {
+TEST_CASE("Unit_hipPointerGetAttributes_MultiThread", "[multigpu]") {
   srand(0x300);
   auto serialize = 1;
   printf("\n=============================================\n");
@@ -393,7 +393,7 @@ TEST_CASE("Unit_hipPointerGetAttributes_Negative") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipPointerGetAttributes_GpuIter") {
+TEST_CASE("Unit_hipPointerGetAttributes_GpuIter", "[multigpu]") {
   int deviceCount{0};
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   REQUIRE(deviceCount != 0);
@@ -453,7 +453,8 @@ TEST_CASE("Unit_hipPointerGetAttributes_GpuIter") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipPointerGetAttributes_GpuIter_Managed__Memory") {
+TEST_CASE("Unit_hipPointerGetAttributes_GpuIter_Managed__Memory",
+          "[multigpu]") {
   int deviceCount{0};
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   REQUIRE(deviceCount != 0);
@@ -490,7 +491,8 @@ TEST_CASE("Unit_hipPointerGetAttributes_GpuIter_Managed__Memory") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipPointerGetAttributes_GpuIter_Unregistered_Memory") {
+TEST_CASE("Unit_hipPointerGetAttributes_GpuIter_Unregistered_Memory",
+          "[multigpu]") {
   int deviceCount{0};
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   REQUIRE(deviceCount != 0);

--- a/projects/hip-tests/catch/unit/memory/hipPtrGetAttribute.cc
+++ b/projects/hip-tests/catch/unit/memory/hipPtrGetAttribute.cc
@@ -29,7 +29,7 @@ THE SOFTWARE.
 #include <string>
 
 // Run few simple cases including  host pointer arithmetic:
-TEST_CASE("Unit_hipPtrGetAttribute_Simple") {
+TEST_CASE("Unit_hipPtrGetAttribute_Simple", "[multigpu]") {
   HIP_CHECK(hipSetDevice(0));
   size_t Nbytes = 0;
   constexpr size_t N{1000000};

--- a/projects/hip-tests/catch/unit/memory/hipSVMTestByteGranularity.cpp
+++ b/projects/hip-tests/catch/unit/memory/hipSVMTestByteGranularity.cpp
@@ -72,7 +72,7 @@ __global__ void sum_neighbor_locations(char* a, unsigned int num_devices,
 *  - Fine grain access and atomics supported on devices
 *  - HIP_VERSION >= 5.7
 */
-TEST_CASE("test_svm_byte_granularity") {
+TEST_CASE("test_svm_byte_granularity", "[multigpu]") {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {

--- a/projects/hip-tests/catch/unit/memory/hipSVMTestFineGrainMemoryConsistency.cpp
+++ b/projects/hip-tests/catch/unit/memory/hipSVMTestFineGrainMemoryConsistency.cpp
@@ -227,7 +227,7 @@ void launch_kernels_and_verify(std::vector<hipStream_t>& streams, unsigned int n
 *  - Fine grain access and atomics supported on devices and host
 *  - HIP_VERSION >= 5.7
 */
-TEST_CASE("test_svm_fine_grain_memory_consistency") {
+TEST_CASE("test_svm_fine_grain_memory_consistency", "[multigpu]") {
   int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
 

--- a/projects/hip-tests/catch/unit/memory/hipSVMTestSharedAddressSpaceFineGrain.cpp
+++ b/projects/hip-tests/catch/unit/memory/hipSVMTestSharedAddressSpaceFineGrain.cpp
@@ -157,7 +157,7 @@ void verify_linked_lists_on_device(hipStream_t stream, Node* pNodes, unsigned in
 *  - Fine grain access supported on devices and host
 *  - HIP_VERSION >= 5.7
 */
-TEST_CASE("test_svm_shared_address_space_fine_grain_buffers") {
+TEST_CASE("test_svm_shared_address_space_fine_grain_buffers", "[multigpu]") {
   const unsigned int num_elements = 1024;
   int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
@@ -247,7 +247,7 @@ TEST_CASE("test_svm_shared_address_space_fine_grain_buffers") {
 *  - System fine grain access supported on devices
 *  - HIP_VERSION >= 5.7
 */
-TEST_CASE("test_svm_shared_address_space_fine_grain_system") {
+TEST_CASE("test_svm_shared_address_space_fine_grain_system", "[multigpu]") {
   int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
 

--- a/projects/hip-tests/catch/unit/memory/hipStreamAttachMemAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipStreamAttachMemAsync.cc
@@ -61,7 +61,7 @@ TEST_CASE("Unit_hipStreamAttachMemAsync_Positive_Pageable") {
 // CUDA docs:
 // If the cudaMemAttachGlobal flag is specified, the memory can be accessed by any stream on any
 // device.
-TEST_CASE("Unit_hipStreamAttachMemAsync_Positive_AttachGlobal") {
+TEST_CASE("Unit_hipStreamAttachMemAsync_Positive_AttachGlobal", "[multigpu]") {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeManagedMemory)) {
     HipTest::HIP_SKIP_TEST("Managed memory is not supported");
     return;

--- a/projects/hip-tests/catch/unit/module/hipExtLaunchMultiKernelMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/module/hipExtLaunchMultiKernelMultiDevice.cc
@@ -53,7 +53,7 @@ __global__ void vector_square(float* C_d, float* A_d, size_t N) {
   }
 }
 
-TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Functional") {
+TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Functional", "[multigpu]") {
   constexpr int MAX_GPUS = 8;
   float *A_d[MAX_GPUS], *C_d[MAX_GPUS];
   float *A_h, *C_h;

--- a/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
+++ b/projects/hip-tests/catch/unit/module/hipExtModuleLaunchKernel.cc
@@ -277,7 +277,7 @@ TEST_CASE("Unit_hipExtModuleLaunchKernel_Positive_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipExtModuleLaunchKernel_Negative_Parameters") {
+TEST_CASE("Unit_hipExtModuleLaunchKernel_Negative_Parameters", "[multigpu]") {
   ModuleLaunchKernelNegativeParameters<hipExtModuleLaunchKernel>(true);
 }
 /**

--- a/projects/hip-tests/catch/unit/module/hipGetFuncBySymbol.cc
+++ b/projects/hip-tests/catch/unit/module/hipGetFuncBySymbol.cc
@@ -207,7 +207,7 @@ TEST_CASE("Unit_hipGetFuncBySymbol_InChildProcess") {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetFuncBySymbol_MultiDev") {
+TEST_CASE("Unit_hipGetFuncBySymbol_MultiDev", "[multigpu]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
@@ -323,7 +323,7 @@ void MultiThreadMultiDevFunc(int DevId) {
  * ------------------------
  *    - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetFuncBySymbol_MultiDevMultiThread") {
+TEST_CASE("Unit_hipGetFuncBySymbol_MultiDevMultiThread", "[multigpu]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {

--- a/projects/hip-tests/catch/unit/module/hipGetProcAddressModuleApis.cc
+++ b/projects/hip-tests/catch/unit/module/hipGetProcAddressModuleApis.cc
@@ -328,7 +328,7 @@ TEST_CASE("Unit_hipGetProcAddress_ModuleApisLoadData") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_ModuleApisCooperativeKernels") {
+TEST_CASE("Unit_hipGetProcAddress_ModuleApisCooperativeKernels", "[multigpu]") {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;

--- a/projects/hip-tests/catch/unit/module/hipManagedKeyword.cc
+++ b/projects/hip-tests/catch/unit/module/hipManagedKeyword.cc
@@ -43,7 +43,7 @@ constexpr auto fileName = "managed_kernel.code";
  * - HIP_VERSION >= 5.6
 */
 
-TEST_CASE("Unit_hipModuleGetGlobal_Functional") {
+TEST_CASE("Unit_hipModuleGetGlobal_Functional", "[multigpu]") {
   bool testStatus = true;
   int numDevices = 0;
   hipDeviceptr_t x;

--- a/projects/hip-tests/catch/unit/module/hipModuleGetFunction.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleGetFunction.cc
@@ -71,7 +71,7 @@ TEST_CASE("Unit_hipModuleGetFunction_Negative_Parameters") {
 
 // Test description: Loading kernel function from different device than the one on which the module
 // is loaded
-TEST_CASE("Unit_hipModuleGetFunction_DiffDevice") {
+TEST_CASE("Unit_hipModuleGetFunction_DiffDevice", "[multigpu]") {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {

--- a/projects/hip-tests/catch/unit/module/hipModuleGetGlobal.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleGetGlobal.cc
@@ -148,7 +148,7 @@ TEST_CASE("Unit_hipModuleGetGlobal_Negative_Dptr_And_Bytes_Are_Nullptr") {
 
 // Test description: Loading device ptr from different device than the one on which the module
 // is loaded
-TEST_CASE("Unit_hipModuleGetGlobal_DiffDevice") {
+TEST_CASE("Unit_hipModuleGetGlobal_DiffDevice", "[multigpu]") {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {

--- a/projects/hip-tests/catch/unit/module/hipModuleLaunchCooperativeKernelMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleLaunchCooperativeKernelMultiDevice.cc
@@ -48,7 +48,8 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.5
  */
-TEST_CASE("Unit_hipModuleLaunchCooperativeKernelMultiDevice_Positive_Basic") {
+TEST_CASE("Unit_hipModuleLaunchCooperativeKernelMultiDevice_Positive_Basic",
+          "[multigpu]") {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
@@ -106,7 +107,9 @@ TEST_CASE("Unit_hipModuleLaunchCooperativeKernelMultiDevice_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 5.5
  */
-TEST_CASE("Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_Parameters") {
+TEST_CASE(
+    "Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_Parameters",
+    "[multigpu]") {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
@@ -230,7 +233,9 @@ TEST_CASE("Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_Parameters"
  * ------------------------
  *  - HIP_VERSION >= 5.5
  */
-TEST_CASE("Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_MultiKernelSameDevice") {
+TEST_CASE("Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_"
+          "MultiKernelSameDevice",
+          "[multigpu]") {
   auto mg = ModuleGuard::InitModule("launch_kernel_module.code");
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");

--- a/projects/hip-tests/catch/unit/module/hipModuleLaunchKernel.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleLaunchKernel.cc
@@ -42,7 +42,7 @@ TEST_CASE("Unit_hipModuleLaunchKernel_Positive_Parameters") {
   ModuleLaunchKernelPositiveParameters<hipModuleLaunchKernelWrapper>();
 }
 
-TEST_CASE("Unit_hipModuleLaunchKernel_Negative_Parameters") {
+TEST_CASE("Unit_hipModuleLaunchKernel_Negative_Parameters", "[multigpu]") {
   HIP_CHECK(hipFree(nullptr));
   ModuleLaunchKernelNegativeParameters<hipModuleLaunchKernelWrapper>();
 }

--- a/projects/hip-tests/catch/unit/module/hipModuleLoadMultProcessOnMultGPU.cc
+++ b/projects/hip-tests/catch/unit/module/hipModuleLoadMultProcessOnMultGPU.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  * - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_hipModuleLoad_MultProcess_MultGPU") {
+TEST_CASE("Unit_hipModuleLoad_MultProcess_MultGPU", "[multigpu]") {
   int deviceCount{0};
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   REQUIRE(deviceCount != 0);

--- a/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSizeVariableSMemWithFlags.cc
+++ b/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSizeVariableSMemWithFlags.cc
@@ -108,7 +108,8 @@ TEST_CASE("Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_chkRange") {
   - for 0 < block_size_limit < attr.maxThreadsPerBlock
   - for block_size_limit > attr.maxThreadsPerBlock
 */
-TEST_CASE("Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_mgpu") {
+TEST_CASE("Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_mgpu",
+          "[multigpu]") {
   int devcount = 0;
   HIP_CHECK(hipGetDeviceCount(&devcount));
   // If only single GPU is detected then return

--- a/projects/hip-tests/catch/unit/printf/hipPrintfManyDevices.cc
+++ b/projects/hip-tests/catch/unit/printf/hipPrintfManyDevices.cc
@@ -47,7 +47,7 @@ __global__ void print_things() {
  * ------------------------
  * - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_Printf_ManyDevicesTest") {
+TEST_CASE("Unit_Printf_ManyDevicesTest", "[multigpu]") {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {

--- a/projects/hip-tests/catch/unit/stream/hipLaunchHostFunc.cc
+++ b/projects/hip-tests/catch/unit/stream/hipLaunchHostFunc.cc
@@ -313,7 +313,7 @@ TEST_CASE("Unit_hipLaunchHostFunc_KernelHost") {
 // Test scenario 5
 // scenario that validates the host launch function on multi device
 // environment.
-TEST_CASE("Unit_hipLaunchHostFunc_multidevice") {
+TEST_CASE("Unit_hipLaunchHostFunc_multidevice", "[multigpu]") {
   int num_devices;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   if (num_devices < 2) {

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetDevice.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetDevice.cc
@@ -74,7 +74,7 @@ TEST_CASE("Unit_hipStreamGetDevice_Negative") {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipStreamGetDevice_Usecase") {
+TEST_CASE("Unit_hipStreamGetDevice_Usecase", "[multigpu]") {
   int device_count = 0;
   HIP_CHECK(hipGetDeviceCount(&device_count));
   REQUIRE(device_count != 0);
@@ -186,7 +186,7 @@ TEST_CASE("Unit_hipStreamGetDevice_MThread") { REQUIRE(true == test_hipStreamGet
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipStreamGetDevice_SetDiffDevice") {
+TEST_CASE("Unit_hipStreamGetDevice_SetDiffDevice", "[multigpu]") {
   hipDevice_t device_from_stream;
   int device_count = 0;
   HIP_CHECK(hipGetDeviceCount(&device_count));
@@ -225,7 +225,7 @@ TEST_CASE("Unit_hipStreamGetDevice_SetDiffDevice") {
  *      Test to be run only on AMD machine as it's failing in CUDA.
  */
 #if HT_AMD
-TEST_CASE("Unit_hipStreamGetDevice_NullStream") {
+TEST_CASE("Unit_hipStreamGetDevice_NullStream", "[multigpu]") {
   int device_count = 0;
   HIP_CHECK(hipGetDeviceCount(&device_count));
   REQUIRE(device_count != 0);

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetId.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetId.cc
@@ -191,7 +191,7 @@ TEST_CASE("Unit_hipStreamGetId_MultipleThreads") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipStreamGetId_MultiDevice") {
+TEST_CASE("Unit_hipStreamGetId_MultiDevice", "[multigpu]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {

--- a/projects/hip-tests/catch/unit/stream/hipStreamLegacy_Ext.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamLegacy_Ext.cc
@@ -295,7 +295,7 @@ TEST_CASE("Unit_hipStreamLegacy_WithStreamPerThread") {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_MultiDevice") {
+TEST_CASE("Unit_hipStreamLegacy_MultiDevice", "[multigpu]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
@@ -418,7 +418,7 @@ TEST_CASE("Unit_hipStreamLegacy_H2H_H2D_D2D_D2H_Default") {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_MultiDeviceMultiOperation") {
+TEST_CASE("Unit_hipStreamLegacy_MultiDeviceMultiOperation", "[multigpu]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
@@ -594,7 +594,7 @@ TEST_CASE("Unit_hipStreamLegacy_TwoThreadsEachOneDiffOperation") {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_TwoDevicesEachOneDiffOperation") {
+TEST_CASE("Unit_hipStreamLegacy_TwoDevicesEachOneDiffOperation", "[multigpu]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
@@ -679,7 +679,8 @@ static void operationsInDev1(int* devArrDev1, int* hostArrDst) {
  * ------------------------
  *  - HIP_VERSION >= 6.3
  */
-TEST_CASE("Unit_hipStreamLegacy_TwoThreadsInTwoDevicesEachOneDiffOperation") {
+TEST_CASE("Unit_hipStreamLegacy_TwoThreadsInTwoDevicesEachOneDiffOperation",
+          "[multigpu]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {

--- a/projects/hip-tests/catch/unit/synchronization/cache_coherency_gpu_gpu.cc
+++ b/projects/hip-tests/catch/unit/synchronization/cache_coherency_gpu_gpu.cc
@@ -284,7 +284,7 @@ static bool gpu_to_gpu_coherency() {
  *    - Test to be run only on AMD.
  */
 
-TEST_CASE("Unit_cache_coherency_gpu_gpu") {
+TEST_CASE("Unit_cache_coherency_gpu_gpu", "[multigpu]") {
   bool passed = true;
   // Coherency between GPUs accessing local or remote FB.
   REQUIRE(passed == gpu_to_gpu_coherency());

--- a/projects/hip-tests/catch/unit/threadfence/__threadfence.cc
+++ b/projects/hip-tests/catch/unit/threadfence/__threadfence.cc
@@ -164,7 +164,7 @@ TEST_CASE("Unit___threadfence_Positive_Basic_Managed") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_Positive_Basic_Peer") {
+TEST_CASE("Unit___threadfence_Positive_Basic_Peer", "[multigpu]") {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("At least 2 devices are required");

--- a/projects/hip-tests/catch/unit/threadfence/__threadfence_block.cc
+++ b/projects/hip-tests/catch/unit/threadfence/__threadfence_block.cc
@@ -164,7 +164,7 @@ TEST_CASE("Unit___threadfence_block_Positive_Basic_Managed") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_block_Positive_Basic_Peer") {
+TEST_CASE("Unit___threadfence_block_Positive_Basic_Peer", "[multigpu]") {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("At least 2 devices are required");

--- a/projects/hip-tests/catch/unit/threadfence/__threadfence_system.cc
+++ b/projects/hip-tests/catch/unit/threadfence/__threadfence_system.cc
@@ -60,7 +60,7 @@ __global__ void ReadKernel(int* out, int* in) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_system_Positive_Basic_Peer") {
+TEST_CASE("Unit___threadfence_system_Positive_Basic_Peer", "[multigpu]") {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("At least 2 devices are required");

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemGetHandleForAddressRange.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemGetHandleForAddressRange.cc
@@ -362,7 +362,8 @@ TEST_CASE("Unit_hipMemGetHandleForAddressRange_VM") {
  * ------------------------
  *  - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemGetHandleForAddressRange_DeviceMemory_InAnotherDevice") {
+TEST_CASE("Unit_hipMemGetHandleForAddressRange_DeviceMemory_InAnotherDevice",
+          "[multigpu]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
@@ -414,7 +415,8 @@ TEST_CASE("Unit_hipMemGetHandleForAddressRange_DeviceMemory_InAnotherDevice") {
  * ------------------------
  *  - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemGetHandleForAddressRange_VM_InAnotherDevice") {
+TEST_CASE("Unit_hipMemGetHandleForAddressRange_VM_InAnotherDevice",
+          "[multigpu]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
@@ -364,7 +364,7 @@ void physicalMemoryReuse_MultiDev (hipMemAllocationProp prop) {
  * ------------------------
  *    - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemMap_PhysicalMemoryReuse_MultiDev") {
+TEST_CASE("Unit_hipMemMap_PhysicalMemoryReuse_MultiDev", "[multigpu]") {
   CHECK_P2P_SUPPORT
   SECTION("Memory Allocation Type as hipMemAllocationTypePinned") {
     hipMemAllocationProp prop{};
@@ -554,7 +554,7 @@ void vMMMemoryReuse_MultiGPU (hipMemAllocationProp prop) {
  * ------------------------
  *    - HIP_VERSION >= 7.0
  */
-TEST_CASE("Unit_hipMemMap_VMMMemoryReuse_MultiGPU") {
+TEST_CASE("Unit_hipMemMap_VMMMemoryReuse_MultiGPU", "[multigpu]") {
   CHECK_P2P_SUPPORT
   SECTION("Memory Allocation Type as hipMemAllocationTypePinned") {
     hipMemAllocationProp prop{};

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
@@ -340,7 +340,7 @@ TEST_CASE("Unit_hipMemGetAccess_NegTst") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemSetAccess_FuncTstOnMultDev") {
+TEST_CASE("Unit_hipMemSetAccess_FuncTstOnMultDev", "[multigpu]") {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -638,7 +638,7 @@ TEST_CASE("Unit_hipMemSetAccess_Vmm2DevMemCpy") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemSetAccess_Vmm2PeerDevMemCpy") {
+TEST_CASE("Unit_hipMemSetAccess_Vmm2PeerDevMemCpy", "[multigpu]") {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -729,7 +729,7 @@ TEST_CASE("Unit_hipMemSetAccess_Vmm2PeerDevMemCpy") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemSetAccess_Vmm2PeerPeerMemCpy") {
+TEST_CASE("Unit_hipMemSetAccess_Vmm2PeerPeerMemCpy", "[multigpu]") {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
@@ -891,7 +891,7 @@ TEST_CASE("Unit_hipMemSetAccess_Vmm2VMMMemCpy") {
  * ------------------------
  *    - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_hipMemSetAccess_Vmm2VMMInterDevMemCpy") {
+TEST_CASE("Unit_hipMemSetAccess_Vmm2VMMInterDevMemCpy", "[multigpu]") {
   size_t granularity = 0;
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);


### PR DESCRIPTION
## Motivation

Tag all unit test cases that are dependent on multiple GPUs

## Technical Details

All cases tagged using Catch2 built-in tagging feature

## Test Plan

Ensure build passes. Later run all tests except ones dependent on multiple GPUs using the tag

## Test Result

Local build passed. Listed test cases using the tag

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
