### PR TITLE
Updated VERSION regex for tarball in Dockerfiles

### DIFF
--- a/projects/rocprofiler-systems/docker/Dockerfile.opensuse.ci
+++ b/projects/rocprofiler-systems/docker/Dockerfile.opensuse.ci
@@ -52,7 +52,7 @@ RUN wget https://github.com/conda-forge/miniforge/releases/latest/download/Minif
 ARG GPU_TYPE=""
 ARG GPU_TARBALL=""
 RUN if [ -n "$GPU_TYPE" ] && [ -n "$GPU_TARBALL" ]; then \
-        VERSION=$(echo "$GPU_TARBALL" | sed -nE 's/.*([0-9]\.[0-9]\.[0-9]).*/\1/p'); \
+        VERSION=$(echo "$GPU_TARBALL" | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p'); \
         if [ -z "$VERSION" ]; then \
             echo "Error: Could not extract version from GPU_TARBALL ('$GPU_TARBALL')." >&2; \
             exit 1; \

--- a/projects/rocprofiler-systems/docker/Dockerfile.rhel.ci
+++ b/projects/rocprofiler-systems/docker/Dockerfile.rhel.ci
@@ -43,7 +43,7 @@ RUN wget https://github.com/conda-forge/miniforge/releases/latest/download/Minif
 ARG GPU_TYPE=""
 ARG GPU_TARBALL=""
 RUN if [ -n "$GPU_TYPE" ] && [ -n "$GPU_TARBALL" ]; then \
-        VERSION=$(echo "$GPU_TARBALL" | sed -nE 's/.*([0-9]\.[0-9]\.[0-9]).*/\1/p'); \
+        VERSION=$(echo "$GPU_TARBALL" | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p'); \
         if [ -z "$VERSION" ]; then \
             echo "Error: Could not extract version from GPU_TARBALL ('$GPU_TARBALL')." >&2; \
             exit 1; \

--- a/projects/rocprofiler-systems/docker/Dockerfile.ubuntu.ci
+++ b/projects/rocprofiler-systems/docker/Dockerfile.ubuntu.ci
@@ -63,7 +63,7 @@ RUN wget https://github.com/conda-forge/miniforge/releases/latest/download/Minif
 ARG GPU_TYPE=""
 ARG GPU_TARBALL=""
 RUN if [ -n "$GPU_TYPE" ] && [ -n "$GPU_TARBALL" ]; then \
-        VERSION=$(echo "$GPU_TARBALL" | sed -nE 's/.*([0-9]\.[0-9]\.[0-9]).*/\1/p'); \
+        VERSION=$(echo "$GPU_TARBALL" | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p'); \
         if [ -z "$VERSION" ]; then \
             echo "Error: Could not extract version from GPU_TARBALL ('$GPU_TARBALL')." >&2; \
             exit 1; \


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Nightly tarball recently got promoted from `7.9.0` to `7.10.0` which broke the current regex pattern for determining ROCm version. Updating the regex to accommodate one or more numbers in major/minor/patch instead of just one number for each.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Changed regex pattern from `([0-9]\.[0-9]\.[0-9]).*/\1/p')` to `([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')`

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
No errors during workflow and docker build.

## Test Result

<!-- Briefly summarize test outcomes. -->
Workflows passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
