### PR TITLE
SWDEV-559867 - Fix CU mask printing

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3013,7 +3013,7 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
 
 
     for (int i = mask.size() - 1; i >= 0; i--) {
-      ss << std::setfill('0') << std::setw(4) << mask[i];
+      ss << std::setfill('0') << std::setw(8) << mask[i];
     }
     ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Setting CU mask 0x%s for hardware queue %p",
             ss.str().c_str(), queue->base_address);


### PR DESCRIPTION
## Motivation

CU mask printed in logs are incorrect

## Technical Details

log prints each uint32_t with setw(4), but we need 8 hex digits to represent a 4-byte int.

## Test Plan

verify correct mask printed in the logs

## Test Result

CU mask was printed correctly in the logs after the change.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
