### PR TITLE
thunk: Correct kfd_ioctl_create_queue_args comment

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/linux/kfd_ioctl.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/linux/kfd_ioctl.h
@@ -65,8 +65,8 @@ struct kfd_ioctl_get_version_args {
 
 struct kfd_ioctl_create_queue_args {
 	__u64 ring_base_address;	/* to KFD */
-	__u64 write_pointer_address;	/* from KFD */
-	__u64 read_pointer_address;	/* from KFD */
+	__u64 write_pointer_address;	/* to KFD */
+	__u64 read_pointer_address;	/* to KFD */
 	__u64 doorbell_offset;	/* from KFD */
 
 	__u32 ring_size;		/* to KFD */

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -1030,6 +1030,10 @@ hsa_status_t Runtime::PtrInfo(const void* ptr, hsa_amd_pointer_info_t* info, voi
 
   bool allocation_map_entry_found = false;
 
+  if (!bootstrap_lock().IsAvailableHint()) {
+    return HSA_STATUS_ERROR;
+  }
+
   {  // memory_lock protects access to the NMappedNodes array and fragment user data since these may
      // change with calls to memory APIs.
     ScopedAcquire<KernelSharedMutex> lock(&memory_lock_);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/locks.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/locks.h
@@ -114,6 +114,16 @@ class KernelMutex {
   bool Acquire() { return os::AcquireMutex(lock_); }
   void Release() { os::ReleaseMutex(lock_); }
 
+  // Check whether lock is available or not. The lock may not be available
+  // by the time the caller tries to acquire it, so it should only be used
+  // as a hint.
+  bool IsAvailableHint() {
+    if (Try()) {
+      Release();
+      return true;
+    }
+    return false;
+  }
  private:
   os::Mutex lock_;
 


### PR DESCRIPTION
When ASAN instrumented, ASAN functions may call PtrInfo after
shutdown has started, in which case, ROCr asserts. Now, PtrInfo
will return an error in this scenario allowing ASAN to gracefully
handle it.## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
When ASAN instrumented, ASAN functions may call PtrInfo after
shutdown has started, in which case, ROCr asserts. Now, PtrInfo
will return an error in this scenario allowing ASAN to gracefully
handle it.