### PR TITLE
clr and hip fixes various build warnings

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
@@ -232,7 +232,7 @@ typedef __hip_internal::int64_t __hip_int64_t;
 
 #define __forceinline__ inline __attribute__((always_inline))
 
-#if __HIP_NO_IMAGE_SUPPORT
+#if defined(__HIP_NO_IMAGE_SUPPORT) && __HIP_NO_IMAGE_SUPPORT
 #define __hip_img_chk__                                                                            \
   __attribute__((unavailable("The image/texture API not supported on the device")))
 #else

--- a/projects/clr/hipamd/src/hip_event.hpp
+++ b/projects/clr/hipamd/src/hip_event.hpp
@@ -220,16 +220,16 @@ class IPCEvent : public Event {
   }
   IPCEvent() : Event(hipEventInterprocess) {}
   bool createIpcEventShmemIfNeeded();
-  hipError_t GetHandle(ihipIpcEventHandle_t* handle);
-  hipError_t OpenHandle(ihipIpcEventHandle_t* handle);
-  hipError_t synchronize();
-  hipError_t query();
+  hipError_t GetHandle(ihipIpcEventHandle_t* handle) override;
+  hipError_t OpenHandle(ihipIpcEventHandle_t* handle) override;
+  hipError_t synchronize() override;
+  hipError_t query() override;
 
-  hipError_t streamWait(hip::Stream* stream, uint flags);
+  hipError_t streamWait(hip::Stream* stream, uint flags) override;
 
   hipError_t recordCommand(amd::Command*& command, amd::HostQueue* queue, uint32_t flags = 0,
                            bool batch_flush = true) override;
-  hipError_t enqueueRecordCommand(hip::Stream* stream, amd::Command* command);
+  hipError_t enqueueRecordCommand(hip::Stream* stream, amd::Command* command) override;
 };
 
 

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -2717,7 +2717,7 @@ class hipGraphExternalSemSignalNode : public GraphNode {
 
   GraphNode* clone() const override { return new hipGraphExternalSemSignalNode(*this); }
 
-  hipError_t CreateCommand(hip::Stream* stream) {
+  hipError_t CreateCommand(hip::Stream* stream) override {
     hipError_t status = GraphNode::CreateCommand(stream);
     if (status != hipSuccess) {
       return status;
@@ -2770,7 +2770,7 @@ class hipGraphExternalSemWaitNode : public GraphNode {
 
   GraphNode* clone() const override { return new hipGraphExternalSemWaitNode(*this); }
 
-  hipError_t CreateCommand(hip::Stream* stream) {
+  hipError_t CreateCommand(hip::Stream* stream) override {
     hipError_t status = GraphNode::CreateCommand(stream);
     if (status != hipSuccess) {
       return status;
@@ -2822,7 +2822,7 @@ class hipGraphBatchMemOpNode : public GraphNode {
 
   GraphNode* clone() const override { return new hipGraphBatchMemOpNode(*this); }
 
-  hipError_t CreateCommand(hip::Stream* stream) {
+  hipError_t CreateCommand(hip::Stream* stream) override {
     hipError_t status = GraphNode::CreateCommand(stream);
     if (status != hipSuccess) {
       return status;

--- a/projects/clr/hipamd/src/hip_mempool.cpp
+++ b/projects/clr/hipamd/src/hip_mempool.cpp
@@ -32,7 +32,7 @@ namespace {
 inline bool IsMemPoolValid(MemoryPool* mem_pool) {
   bool result = false;
   for (auto it : g_devices) {
-    if (result = it->IsMemoryPoolValid(mem_pool) == true) {
+    if ((result = it->IsMemoryPoolValid(mem_pool)) == true) {
       break;
     }
   }

--- a/projects/clr/hipamd/src/hip_prof_gen.py
+++ b/projects/clr/hipamd/src/hip_prof_gen.py
@@ -536,7 +536,7 @@ def generate_prof_header(f, api_map, callback_ids, opts_map):
     f.write('#define INIT_'+ name + '_CB_ARGS_DATA(cb_data) {};\n')
   f.write('\n#define INIT_NONE_CB_ARGS_DATA(cb_data) {};\n')
 
-  f.write('\n#if HIP_PROF_HIP_API_STRING\n')
+  f.write('\n#if defined(HIP_PROF_HIP_API_STRING) && HIP_PROF_HIP_API_STRING\n')
   # Generating the method for the API args filling
   f.write('// HIP API args filling helper\n')
   f.write('static inline void hipApiArgsInit(hip_api_id_t id, hip_api_data_t* data) {\n')

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -502,7 +502,7 @@ class OneMemoryArgCommand : public Command {
     memory_->retain();
   }
 
-  virtual void releaseResources() {
+  virtual void releaseResources() override {
     memory_->release();
     DEBUG_ONLY(memory_ = NULL);
     Command::releaseResources();
@@ -510,14 +510,14 @@ class OneMemoryArgCommand : public Command {
   }
 
   //! Release all pinned memory for this command
-  virtual void ReleasePinnedMemory() {
+  virtual void ReleasePinnedMemory() override {
     for (auto it : pinned_memory_) {
       it->release();
     }
     pinned_memory_.clear();
   }
   //! Release all pinned memory for this command
-  virtual bool IsMemoryPinned() const { return !pinned_memory_.empty(); }
+  virtual bool IsMemoryPinned() const override { return !pinned_memory_.empty(); }
 
   //! Adds pinned memory, used in this command for later release
   virtual void AddPinnedMemory(Memory* pinned) override { pinned_memory_.push_back(pinned); }

--- a/projects/hip/include/hip/hip_common.h
+++ b/projects/hip/include/hip/hip_common.h
@@ -62,7 +62,7 @@ THE SOFTWARE.
 #define HIP_INTERNAL_EXPORTED_API
 #endif
 
-#if __HIP_DEVICE_COMPILE__ == 0
+#if !defined(__HIP_DEVICE_COMPILE__) || ( __HIP_DEVICE_COMPILE__ == 0)
 // 32-bit Atomics
 #define __HIP_ARCH_HAS_GLOBAL_INT32_ATOMICS__ (0)
 #define __HIP_ARCH_HAS_GLOBAL_FLOAT_ATOMIC_EXCH__ (0)


### PR DESCRIPTION
## Motivation

Fix warnings that are caused by the clr and hip-headers when building various projects like clr like MIOpen which
depends from them. These warnings show very frequently on build logs and may make it harder to spot some
more serious warnings in log files that needs to be addressed.

## Technical Details
Examples from the build warnings types fixed. (not are listed)

1) therock/rocm-systems/projects/clr/hipamd/src/hip_event.hpp:223:14: warning: 'GetHandle' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]

2) include/hip/hip_common.h:65:5: warning: '__HIP_DEVICE_COMPILE__' is not defined, evaluates to 0 [-Wundef]
30.9	   65 | #if __HIP_DEVICE_COMPILE__ == 0

3) include/hip/amd_detail/hip_prof_str.h:6711:5: warning: 'HIP_PROF_HIP_API_STRING' is not defined, evaluates to 0 [-Wundef] 30.9	 6711 | #if HIP_PROF_HIP_API_STRING

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Tested by doing a build with this patch applied for different GPU's on TheRock system. This is tested regularly by rocprofiler-system. 

## Test Result

<!-- Briefly summarize test outcomes. -->

Builds passed and warnings disappeared. rocm-systems will also run it's own tests.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
