### PR TITLE
SWDEV-536360 - fix formatting of reduce sync operations documentation section

### DIFF
--- a/projects/hip/docs/how-to/hip_cpp_language_extensions.rst
+++ b/projects/hip/docs/how-to/hip_cpp_language_extensions.rst
@@ -998,8 +998,9 @@ Arithmetic reduces:
   T __reduce_max_sync (unsigned long long mask, T var);
 
 ``T`` can be:
-- On Nvidia platform: ``int`` or ``unsigned int``
-- On AMD platform: ``int`` or ``unsigned int``; if the user defines the macro ``HIP_ENABLE_EXTRA_WARP_SYNC_TYPES``, then: ``unsigned long long``, ``long long``, ``half``/``single``/``double`` precision floating
+* On Nvidia platform: ``int`` or ``unsigned int``
+
+* On AMD platform: ``int`` or ``unsigned int``; if the user defines the macro ``HIP_ENABLE_EXTRA_WARP_SYNC_TYPES``, then: ``unsigned long long``, ``long long``, ``half``/``single``/``double`` precision floating
 point types are also be supported.
 
 Returns the aggregated result of the arithmetic operation, where each of the participating threads
@@ -1017,8 +1018,9 @@ Logical reduces:
   T __reduce_xor_sync (unsigned long long mask, T var);
 
 ``T`` can be:
-- On Nvidia platform: ``unsigned int``
-- On AMD platform: ``unsigned int``, and if the user defines the macro ``HIP_ENABLE_EXTRA_WARP_SYNC_TYPES``, then ``int``, ``unsigned long long`` or ``long long`` are also supported
+* On Nvidia platform: ``unsigned int``
+
+* On AMD platform: ``unsigned int``, and if the user defines the macro ``HIP_ENABLE_EXTRA_WARP_SYNC_TYPES``, then ``int``, ``unsigned long long`` or ``long long`` are also supported
 
 Returns the result of the aggregated logical AND/OR/XOR operation where each of the participating threads
 (i.e. the ones mentioned on the mask) contribute ``var``.
@@ -1032,7 +1034,7 @@ Informational note: On the AMD platform, **masks that start from lane zero and h
 exhibit better performance** than masks with "holes" (example of mask with no holes: 0xFF and with holes: 0xFB;
 the reduction with 0xFF is faster).
 
-These functiones do not provide a memory barrier on any platform.
+These functions do not provide a memory barrier on any platform.
 
 Warp matrix functions
 --------------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation
The formatting looks wrong in browsers for the new reduce sync operations section: line breaks are missing, see:

<img width="1224" height="92" alt="image" src="https://github.com/user-attachments/assets/7635c733-234a-4744-9229-0860691b1526" />


## Technical Details

Use the * character as other list enumerations in the same page do

## Test Plan

Not needed; cosmetic changes.

## Test Result

N/A

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
