### PR TITLE
Added SQLite3 as a external submodule to rocprofiler-systems

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -76,6 +76,9 @@
 [submodule "projects/rocprofiler-systems/external/pybind11"]
 	path = projects/rocprofiler-systems/external/pybind11
 	url = https://github.com/jrmadsen/pybind11.git
+[submodule "projects/rocprofiler-systems/external/sqlite"]
+	path = projects/rocprofiler-systems/external/sqlite
+	url = https://github.com/sqlite/sqlite
 [submodule "projects/rocprofiler-systems/examples/openmp/external/ompvv"]
 	path = projects/rocprofiler-systems/examples/openmp/external/ompvv
 	url = https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV.git


### PR DESCRIPTION
## Motivation

SQLite3 submodule was missing from the `.gitmodules` for rocprofiler-systems, which caused the build failure when `ROCPROFILER_BUILD_SQLITE3` option was set.

## Technical Details

Updated `.gitmodules`.

## Test Plan

Build the project with corresponding build option set.

## Test Result

Configuration and Build are successfully executed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
