### PR TITLE
SWDEV-545950 - Update indentation in hip_prof_str.h for hipStreamCopyAttributes

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/hip_prof_str.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/hip_prof_str.h
@@ -11587,7 +11587,7 @@ static inline const char* hipApiString(hip_api_id_t id, const hip_api_data_t* da
       oss << ", mode="; roctracer::hip_support::detail::operator<<(oss, data->args.hipStreamBeginCaptureToGraph.mode);
       oss << ")";
     break;
-     case HIP_API_ID_hipStreamCopyAttributes:
+    case HIP_API_ID_hipStreamCopyAttributes:
       oss << "hipStreamCopyAttributes(";
       oss << "dst="; roctracer::hip_support::detail::operator<<(oss, data->args.hipStreamCopyAttributes.dst);
       oss << ", src="; roctracer::hip_support::detail::operator<<(oss, data->args.hipStreamCopyAttributes.src);


### PR DESCRIPTION
## Motivation

To address an issue with indentation in hip_prof_str.h which was introduced when adding hipStreamCopyAttributes API

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Fixes the indentation or extra space which got added in the hip_prof_str.h file.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
