### PR TITLE
clr: Remove HeapObject wrapper

### DIFF
--- a/projects/clr/rocclr/device/blit.hpp
+++ b/projects/clr/rocclr/device/blit.hpp
@@ -33,7 +33,7 @@
 namespace amd::device {
 
 //! Blit Manager Abstraction class
-class BlitManager : public amd::HeapObject {
+class BlitManager {
  public:
   //! HW accelerated setup
   union Setup {

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -669,7 +669,7 @@ struct Info : public amd::EmbeddedObject {
 };
 
 //! Device settings
-class Settings : public amd::HeapObject {
+class Settings {
  public:
   enum KernelArgImpl {
     HostKernelArgs = 0,        //!< Kernel Arguments are put into host memory
@@ -734,7 +734,7 @@ class Settings : public amd::HeapObject {
 
 //! Device-independent cache memory, base class for the device-specific
 //! memories. One Memory instance refers to one or more of these.
-class Memory : public amd::HeapObject {
+class Memory {
  public:
   //! Resource map flags
   enum CpuMapFlags {
@@ -760,7 +760,7 @@ class Memory : public amd::HeapObject {
     SyncFlags() : value_(0) {}
   };
 
-  struct WriteMapInfo : public amd::HeapObject {
+  struct WriteMapInfo {
     amd::Coord3D origin_;  //!< Origin of the map location
     amd::Coord3D region_;  //!< Mapped region
     amd::Image* baseMip_;  //!< The base mip level for images
@@ -1000,7 +1000,7 @@ class Memory : public amd::HeapObject {
   Memory(const Memory&) = delete;
 };
 
-class Sampler : public amd::HeapObject {
+class Sampler {
  public:
   //! Constructor
   Sampler() : hwSrd_(0), hwState_(nullptr) {}
@@ -1026,7 +1026,7 @@ class Sampler : public amd::HeapObject {
   Sampler(const Sampler&);
 };
 
-class ClBinary : public amd::HeapObject {
+class ClBinary {
  public:
   enum BinaryImageFormat {
     BIF_VERSION2 = 0,  //!< Binary Image Format version 2.0 (ELF)
@@ -1210,7 +1210,7 @@ inline Program::binary_t Program::binary() {
  *
  *  \brief The device interface class for the performance counters
  */
-class PerfCounter : public amd::HeapObject {
+class PerfCounter {
  public:
   //! Constructor for the device performance
   PerfCounter() {}
@@ -1232,7 +1232,7 @@ class PerfCounter : public amd::HeapObject {
  *
  *  \brief The device interface class for the performance counters
  */
-class ThreadTrace : public amd::HeapObject {
+class ThreadTrace {
  public:
   //! Constructor for the device performance
   ThreadTrace() {}
@@ -1640,7 +1640,7 @@ class Device : public RuntimeObject {
 
   typedef std::list<CommandQueue*> CommandQueues;
 
-  struct BlitProgram : public amd::HeapObject {
+  struct BlitProgram {
     Program* program_;  //!< GPU program object
     Context* context_;  //!< A dummy context
 

--- a/projects/clr/rocclr/device/devkernel.hpp
+++ b/projects/clr/rocclr/device/devkernel.hpp
@@ -194,7 +194,7 @@ struct PrintfInfo {
 };
 
 //! \class DeviceKernel, which will contain the common fields for any device
-class Kernel : public amd::HeapObject {
+class Kernel {
  public:
   typedef std::vector<amd::KernelParameterDescriptor> parameters_t;
 

--- a/projects/clr/rocclr/device/devprogram.hpp
+++ b/projects/clr/rocclr/device/devprogram.hpp
@@ -63,7 +63,7 @@ struct SymbolLoweredName {
 };
 
 //! A program object for a specific device.
-class Program : public amd::HeapObject {
+class Program {
  public:
   typedef std::pair<const void* /* binary_image */, size_t /* binary size */> binary_t;
   typedef std::pair<amd::Os::FileDesc /* file_desc */, size_t /* file_offset */> finfo_t;

--- a/projects/clr/rocclr/device/devsignal.hpp
+++ b/projects/clr/rocclr/device/devsignal.hpp
@@ -29,7 +29,7 @@ class Device;
 namespace amd::device {
 
 // Light abstraction over HSA/PAL signals
-class Signal : public amd::HeapObject {
+class Signal {
  public:
   enum class Condition : uint32_t {
     Eq = 0,

--- a/projects/clr/rocclr/device/pal/palconstbuf.hpp
+++ b/projects/clr/rocclr/device/pal/palconstbuf.hpp
@@ -93,7 +93,7 @@ class ManagedBuffer : public amd::EmbeddedObject {
 };
 
 //! Constant buffer
-class ConstantBuffer : public amd::HeapObject {
+class ConstantBuffer {
  public:
   //! Constructor for the ConstBuffer class
   ConstantBuffer(ManagedBuffer& mbuf,  //!< Managed buffer

--- a/projects/clr/rocclr/device/pal/paldevice.hpp
+++ b/projects/clr/rocclr/device/pal/paldevice.hpp
@@ -247,7 +247,7 @@ class Sampler : public device::Sampler {
 //! A GPU device ordinal (physical GPU device)
 class Device : public NullDevice {
  public:
-  struct QueueRecycleInfo : public amd::HeapObject {
+  struct QueueRecycleInfo {
     int counter_;                    //!< Lock usage counter
     Pal::EngineType engineType_;     //!< Engine type
     uint32_t index_;                 //!< HW queue index for scratch buffer access
@@ -280,7 +280,7 @@ class Device : public NullDevice {
   };
 
   //! Transfer buffers
-  class XferBuffers : public amd::HeapObject {
+  class XferBuffers {
    public:
     static constexpr size_t MaxXferBufListSize = 8;
 
@@ -323,7 +323,7 @@ class Device : public NullDevice {
     const Device& gpuDevice_;         //!< GPU device object
   };
 
-  struct ScratchBuffer : public amd::HeapObject {
+  struct ScratchBuffer {
     Memory* memObj_;   //!< Memory objects for scratch buffers
     uint64_t offset_;  //!< Offset from the global scratch store
     uint64_t size_;    //!< Scratch buffer size on this queue
@@ -339,7 +339,7 @@ class Device : public NullDevice {
   };
 
 
-  class SrdManager : public amd::HeapObject {
+  class SrdManager {
    public:
     SrdManager(const Device& dev, uint srdSize, uint bufSize)
         : dev_(dev),

--- a/projects/clr/rocclr/device/pal/palprintf.hpp
+++ b/projects/clr/rocclr/device/pal/palprintf.hpp
@@ -54,7 +54,7 @@ class Kernel;
 class VirtualGPU;
 class Memory;
 
-class PrintfDbg : public amd::HeapObject {
+class PrintfDbg {
  public:
   //! Debug buffer size per workitem
   static constexpr uint WorkitemDebugSize = 4096;

--- a/projects/clr/rocclr/device/pal/palprogram.hpp
+++ b/projects/clr/rocclr/device/pal/palprogram.hpp
@@ -46,7 +46,7 @@ namespace amd::pal {
 using namespace amd::hsa::loader;
 class Program;
 
-class Segment : public amd::HeapObject {
+class Segment {
  public:
   Segment();
   ~Segment();

--- a/projects/clr/rocclr/device/pal/palresource.hpp
+++ b/projects/clr/rocclr/device/pal/palresource.hpp
@@ -87,7 +87,7 @@ class GpuMemoryReference : public amd::ReferenceCountedObject {
 static constexpr Pal::gpusize MaxGpuAlignment = 4 * Ki;
 
 //! GPU resource
-class Resource : public amd::HeapObject {
+class Resource {
  public:
   enum InteropType {
     InteropTypeless = 0,
@@ -195,7 +195,7 @@ class Resource : public amd::HeapObject {
   };
 
   //! Resource descriptor
-  struct Descriptor : public amd::HeapObject {
+  struct Descriptor {
     MemoryType type_;              //!< Memory type
     size_t width_;                 //!< Resource width
     size_t height_;                //!< Resource height
@@ -535,7 +535,7 @@ class Resource : public amd::HeapObject {
 
 typedef Util::BuddyAllocator<Device> MemBuddyAllocator;
 
-class MemorySubAllocator : public amd::HeapObject {
+class MemorySubAllocator {
  public:
   MemorySubAllocator(Device* device, bool retain_final_chunk = false)
       : device_(device), retain_final_chunk_(retain_final_chunk) {}
@@ -580,7 +580,7 @@ class FineUncachedMemorySubAllocator : public MemorySubAllocator {
   bool CreateChunk(const Pal::IGpuMemory* reserved_va) override;
 };
 
-class ResourceCache : public amd::HeapObject {
+class ResourceCache {
  public:
   //! Default constructor
   ResourceCache(Device* device, size_t cacheSizeLimit)

--- a/projects/clr/rocclr/device/pal/paltimestamp.hpp
+++ b/projects/clr/rocclr/device/pal/paltimestamp.hpp
@@ -34,7 +34,7 @@ class Device;
 class VirtualGPU;
 class Memory;
 
-class TimeStamp : public amd::HeapObject {
+class TimeStamp {
  public:
   //! Enums for the timestamp information
   //! \note *4 is the limitaiton of SDMA HW
@@ -97,7 +97,7 @@ class TimeStamp : public amd::HeapObject {
   volatile uint64_t* values_;  //!< CPU pointer to the timer values
 };
 
-class TimeStampCache : public amd::HeapObject {
+class TimeStampCache {
  public:
   //! Default constructor
   TimeStampCache(VirtualGPU& gpu  //!< Virtual GPU object

--- a/projects/clr/rocclr/device/pal/palvirtual.cpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.cpp
@@ -172,8 +172,9 @@ VirtualGPU::Queue* VirtualGPU::Queue::Create(VirtualGPU& gpu, Pal::QueueType que
   }
 
   size_t allocSize = qSize + max_command_buffers * (cmdSize + fSize);
+  void* queueMem = ::operator new(sizeof(VirtualGPU::Queue) + allocSize);
   VirtualGPU::Queue* queue =
-      new (allocSize) VirtualGPU::Queue(gpu, palDev, residency_limit, max_command_buffers);
+      new (queueMem) VirtualGPU::Queue(gpu, palDev, residency_limit, max_command_buffers);
   if (queue != nullptr) {
     address addrQ = nullptr;
     if (((qCreateInfo.engineType == Pal::EngineTypeCompute) ||
@@ -182,7 +183,8 @@ VirtualGPU::Queue* VirtualGPU::Queue::Create(VirtualGPU& gpu, Pal::QueueType que
       uint32_t index = AllocedQueues(gpu, qCreateInfo.engineType);
       // Create PAL queue object
       if (index < GPU_MAX_HW_QUEUES) {
-        Device::QueueRecycleInfo* info = new (qSize) Device::QueueRecycleInfo(gpu.dev());
+        void* infoMem = ::operator new(sizeof(Device::QueueRecycleInfo) + qSize);
+        Device::QueueRecycleInfo* info = new (infoMem) Device::QueueRecycleInfo(gpu.dev());
         if (info == nullptr) {
           LogError("Could not create QueueRecycleInfo!");
           return nullptr;

--- a/projects/clr/rocclr/device/pal/palvirtual.hpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.hpp
@@ -78,7 +78,7 @@ enum class BarrierType : uint8_t {
 //! Virtual GPU
 class VirtualGPU : public device::VirtualDevice {
  public:
-  class Queue : public amd::HeapObject {
+  class Queue {
    public:
     static constexpr uint MaxCommands = 256;
     static constexpr uint StartCmdBufIdx = 1;
@@ -218,7 +218,7 @@ class VirtualGPU : public device::VirtualDevice {
     uint max_command_buffers_;
   };
 
-  struct CommandBatch : public amd::HeapObject {
+  struct CommandBatch {
     amd::Command* head_;           //!< Command batch head
     GpuEvent events_[AllEngines];  //!< Last known GPU events
     TimeStamp* lastTS_;            //!< TS associated with command batch

--- a/projects/clr/rocclr/device/rocm/rocprintf.hpp
+++ b/projects/clr/rocclr/device/rocm/rocprintf.hpp
@@ -37,7 +37,7 @@ class Kernel;
 class VirtualGPU;
 class Device;
 
-class PrintfDbg : public amd::HeapObject {
+class PrintfDbg {
  public:
   //! Debug buffer size per workitem
   static constexpr uint WorkitemDebugSize = 4096;

--- a/projects/clr/rocclr/include/top.hpp
+++ b/projects/clr/rocclr/include/top.hpp
@@ -164,18 +164,6 @@ class MemoryPoolObject {
   void operator delete(void*, void* address) {}
 };
 
-/*! \brief For objects allocated on the C-heap.
- */
-class HeapObject {
- public:
-  void* operator new(size_t size);
-  void operator delete(void* obj);
-  void* operator new(size_t size, size_t extSize) {
-    return HeapObject::operator new(size + extSize);
-  };
-  void operator delete(void* obj, size_t extSize) { HeapObject::operator delete(obj); }
-};
-
 /*! \brief For all reference counted objects.
  */
 class ReferenceCountedObject {

--- a/projects/clr/rocclr/os/alloc.cpp
+++ b/projects/clr/rocclr/os/alloc.cpp
@@ -77,9 +77,4 @@ void GuardedMemory::deallocate(void* ptr) {
   Os::releaseMemory(static_cast<address>(ptr) - offset, size);
 }
 
-void* HeapObject::operator new(size_t size) { return malloc(size); }
-
-void HeapObject::operator delete(void* obj) { free(obj); }
-
-
 }  // namespace amd

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -67,7 +67,7 @@ class Event : public RuntimeObject {
   typedef void(CL_CALLBACK* CallBackFunction)(cl_event event, int32_t command_exec_status,
                                               void* user_data);
 
-  struct CallBackEntry : public HeapObject {
+  struct CallBackEntry {
     struct CallBackEntry* next_;  //!< the next entry in the callback list.
 
     std::atomic<CallBackFunction> callback_;  //!< callback function pointer.

--- a/projects/clr/rocclr/platform/kernel.hpp
+++ b/projects/clr/rocclr/platform/kernel.hpp
@@ -49,7 +49,7 @@ class Program;
  *  @{
  */
 
-class KernelSignature : public HeapObject {
+class KernelSignature {
  private:
   std::vector<KernelParameterDescriptor> params_;
   std::string attributes_;  //!< The kernel attributes
@@ -117,7 +117,7 @@ class KernelSignature : public HeapObject {
 
 // @todo: look into a copy-on-write model instead of copy-on-read.
 //
-class KernelParameters : protected HeapObject {
+class KernelParameters {
  private:
   //! The signature describing these parameters.
   KernelSignature& signature_;

--- a/projects/clr/rocclr/platform/ndrange.hpp
+++ b/projects/clr/rocclr/platform/ndrange.hpp
@@ -157,7 +157,7 @@ struct HIPLaunchParams : public LaunchParams {
 };
 
 //! A container for the local and global worksizes.
-class NDRangeContainer : public HeapObject {
+class NDRangeContainer {
  private:
   const size_t dimensions_;  //!< Number of dimensions.
   NDRange offset_;           //!< Global work-item offset.

--- a/projects/clr/rocclr/platform/program.hpp
+++ b/projects/clr/rocclr/platform/program.hpp
@@ -50,7 +50,7 @@ namespace amd {
  */
 
 //! A kernel function symbol
-class Symbol : public HeapObject {
+class Symbol {
  public:
   typedef std::unordered_map<const Device*, const device::Kernel*> devicekernels_t;
 

--- a/projects/clr/rocclr/platform/runtime.hpp
+++ b/projects/clr/rocclr/platform/runtime.hpp
@@ -60,7 +60,7 @@ class Runtime : AllStatic {
 
 /*@}*/
 
-class RuntimeTearDown : public HeapObject {
+class RuntimeTearDown {
   static std::vector<ReferenceCountedObject*> external_;
 
  public:

--- a/projects/clr/rocclr/platform/vmheap.hpp
+++ b/projects/clr/rocclr/platform/vmheap.hpp
@@ -32,7 +32,7 @@ class HeapBlock;
 class VmHeap;
 class VmHeapArray;
 
-class HeapBlock : public amd::HeapObject {
+class HeapBlock {
  public:
   friend VmHeap;
   //! Constructor

--- a/projects/clr/rocclr/thread/thread.hpp
+++ b/projects/clr/rocclr/thread/thread.hpp
@@ -44,7 +44,7 @@ namespace amd {
 
 class Monitor;
 
-class Thread : public HeapObject {
+class Thread {
   friend const void* Os::createOsThread(Thread*);
 
  public:

--- a/projects/clr/rocclr/utils/concurrent.hpp
+++ b/projects/clr/rocclr/utils/concurrent.hpp
@@ -66,7 +66,7 @@ template <typename T, int N> struct TaggedPointerHelper {
  * FIXME_lmoriche: Implement the new/delete operators for SimplyLinkedNode
  * using thread-local allocation buffers.
  */
-template <typename T, int N = 5> class ConcurrentLinkedQueue : public HeapObject {
+template <typename T, int N = 5> class ConcurrentLinkedQueue {
   //! A simply-linked node
   struct Node {
     typedef details::TaggedPointerHelper<Node, N> TaggedPointerHelper;


### PR DESCRIPTION
* Remove HeapObject as it breaks alignment (like alignas) and is essentially a wrapper around malloc/free which the new/delete operator do better

## Motivation

Alignments are ignored as it wraps malloc/free

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
