### PR TITLE
remove usage of HIP_RETURN in internal function

### DIFF
--- a/projects/clr/hipamd/src/hip_stream.cpp
+++ b/projects/clr/hipamd/src/hip_stream.cpp
@@ -547,7 +547,7 @@ hipError_t hipStreamQuery_common(hipStream_t stream) {
   if (stream != nullptr) {
     // If still capturing return error
     if (hip::Stream::StreamCaptureOngoing(stream) == true) {
-      HIP_RETURN(hipErrorStreamCaptureUnsupported);
+      return hipErrorStreamCaptureUnsupported;
     }
   }
   bool wait = (stream == nullptr) ? true : false;


### PR DESCRIPTION
## Motivation
HIP_RETURN  macro should be used only at the API level.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Internal functions should use return <status>

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
All tests pass

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
NA

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
