### PR TITLE
SWDEV-558095 - SMI test return if no devices available

### DIFF
--- a/projects/rocm-smi-lib/tests/rocm_smi_test/test_base.cc
+++ b/projects/rocm-smi-lib/tests/rocm_smi_test/test_base.cc
@@ -114,6 +114,7 @@ void TestBase::SetUp(uint64_t init_flags) {
       std::cout << "No monitor devices found on this machine." << std::endl;
       std::cout << "No ROCm SMI tests can be run." << std::endl;
     }
+    return;
   }
 }
 
@@ -126,9 +127,16 @@ void TestBase::PrintDeviceHeader(uint32_t dv_ind) {
     std::cout << "\t**Device index: " << dv_ind << std::endl;
   }
   err = rsmi_dev_id_get(dv_ind, &val_ui16);
-  CHK_ERR_ASRT(err)
-  IF_VERB(STANDARD) {
-    std::cout << "\t**Device ID: 0x" << std::hex << val_ui16 << std::endl;
+  if (err == RSMI_STATUS_NOT_SUPPORTED) {
+    IF_VERB(STANDARD) {
+      std::cout << "	**Device ID:" "N/A" << std::endl;
+    }
+    return;
+  } else {
+    CHK_ERR_ASRT(err)
+    IF_VERB(STANDARD) {
+      std::cout << "\t**Device ID: 0x" << std::hex << val_ui16 << std::endl;
+    }
   }
   err = rsmi_dev_revision_get(dv_ind, &val_ui16);
   if (err == RSMI_STATUS_NOT_SUPPORTED) {


### PR DESCRIPTION
Return from Setup if no monitor devices are available.

## Motivation

rsmitsts continues even if monitor devices were not available.

## Technical Details

Updated to return from Setup if device is not available.

## Test Plan

Run rocmsmitst with expectations of all Pass outputs.

## Test Result

rocmsmitst output all Pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
