### PR TITLE
SWDEV-541362 - Fix error code mismatch in test

### DIFF
--- a/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
+++ b/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
@@ -120,9 +120,12 @@ TEST_CASE("Unit_hipDrvLaunchKernelEx_NegTsts") {
   invalidConfig.attrs = &invalidAttr;
   invalidConfig.numAttrs = 1;
 
+  hipError_t err = hipErrorInvalidConfiguration;
+#if HT_NVIDIA
+  err = hipErrorInvalidValue;
+#endif
   SECTION("Invalid Kernel config") {
-    HIP_CHECK_ERROR(hipDrvLaunchKernelEx(&invalidConfig, function, kernelParams, NULL),
-                    hipErrorInvalidConfiguration);
+    HIP_CHECK_ERROR(hipDrvLaunchKernelEx(&invalidConfig, function, kernelParams, NULL), err);
   }
 
   HIP_CHECK(hipModuleUnload(module));


### PR DESCRIPTION
## Motivation

Test is failing on nvidia.

## Technical Details

Expected error code is wrong.

## Test Plan

Tests already exist.

## Test Result

PAssed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
