### PR TITLE
[ROCProfiler-SDK] Fixes for clang tidy

### DIFF
--- a/projects/rocprofiler-sdk/cmake/rocprofiler_linting.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_linting.cmake
@@ -22,8 +22,8 @@ function(_rocprofiler_check_clang_tidy_version _OUT _EXE)
         OUTPUT_VARIABLE _CLANG_TIDY_OUT
         RESULT_VARIABLE _CLANG_TIDY_RET
         OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
-    if(_CLANG_TIDY_RET EQUAL 0
-       AND "${_CLANG_TIDY_OUT}" MATCHES "version 1[5-9]\\.([0-9]+)\\.([0-9]+)")
+    if(_CLANG_TIDY_RET EQUAL 0 AND "${_CLANG_TIDY_OUT}" MATCHES
+                                   "version 1[5-9]\\.([0-9]+)\\.([0-9]+)")
         set(${_OUT}
             ON
             PARENT_SCOPE)
@@ -49,8 +49,7 @@ endif()
 
 find_program(
     ROCPROFILER_CLANG_TIDY_EXE ${_TIDY_REQUIRED}
-    NAMES clang-tidy-19 clang-tidy-18 clang-tidy-17
-          clang-tidy-16 clang-tidy-15 clang-tidy
+    NAMES clang-tidy-19 clang-tidy-18 clang-tidy-17 clang-tidy-16 clang-tidy-15 clang-tidy
     PATHS ${_PYTHON_USER_BIN}
     HINTS ${_PYTHON_USER_BIN}
     PATH_SUFFIXES bin)

--- a/projects/rocprofiler-sdk/samples/thread_trace/agent.cpp
+++ b/projects/rocprofiler-sdk/samples/thread_trace/agent.cpp
@@ -259,7 +259,8 @@ query_available_agents(rocprofiler_agent_version_t /* version */,
         auto parameters = std::vector<rocprofiler_thread_trace_parameter_t>{};
         parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_TARGET_CU, {TARGET_CU}});
         parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_BUFFER_SIZE, {BUFFER_SIZE}});
-        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_SHADER_ENGINE_MASK, {SHADER_MASK}});
+        parameters.push_back(
+            {ROCPROFILER_THREAD_TRACE_PARAMETER_SHADER_ENGINE_MASK, {SHADER_MASK}});
 
         ROCPROFILER_CALL(
             rocprofiler_configure_device_thread_trace_service(agent_ctx,

--- a/projects/rocprofiler-sdk/samples/thread_trace/agent.cpp
+++ b/projects/rocprofiler-sdk/samples/thread_trace/agent.cpp
@@ -257,9 +257,9 @@ query_available_agents(rocprofiler_agent_version_t /* version */,
         if(agent->type != ROCPROFILER_AGENT_TYPE_GPU) continue;
 
         auto parameters = std::vector<rocprofiler_thread_trace_parameter_t>{};
-        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_TARGET_CU, TARGET_CU});
-        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_BUFFER_SIZE, BUFFER_SIZE});
-        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_SHADER_ENGINE_MASK, SHADER_MASK});
+        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_TARGET_CU, {TARGET_CU}});
+        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_BUFFER_SIZE, {BUFFER_SIZE}});
+        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_SHADER_ENGINE_MASK, {SHADER_MASK}});
 
         ROCPROFILER_CALL(
             rocprofiler_configure_device_thread_trace_service(agent_ctx,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/CMakeLists.txt
@@ -67,7 +67,7 @@ set_tests_properties(
 
 add_executable(pcs_bench_test)
 
-target_compile_options(pcs_bench_test PRIVATE "-Ofast")
+target_compile_options(pcs_bench_test PRIVATE "-O3" "-ffast-math")
 target_sources(pcs_bench_test
                PRIVATE ${ROCPROFILER_LIB_PC_SAMPLING_PARSER_BENCH_TEST_SOURCES})
 target_include_directories(pcs_bench_test PRIVATE ${PCTEST_INCLUDE_DIR})
@@ -79,7 +79,7 @@ target_link_libraries(
             GTest::gtest_main)
 
 add_executable(pcs_thread_test)
-target_compile_options(pcs_thread_test PRIVATE "-Ofast")
+target_compile_options(pcs_thread_test PRIVATE "-O3" "-ffast-math")
 
 target_sources(pcs_thread_test
                PRIVATE ${ROCPROFILER_LIB_PC_SAMPLING_PARSER_MULTIGPU_TEST_SOURCES})

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/benchmark_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/benchmark_test.cpp
@@ -30,7 +30,7 @@
 
 /**
  * Benchmarks how fast the parser can process samples on a single threaded case
- * Current: 5600X with -Ofast, up to >140 million samples/s or ~9GB/s R/W (18GB/s bidirectional)
+ * Current: 5600X with -O3 -ffast-math, up to >140 million samples/s or ~9GB/s R/W (18GB/s bidirectional)
  */
 template <typename PcSamplingRecordT>
 static bool

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/benchmark_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/benchmark_test.cpp
@@ -30,7 +30,8 @@
 
 /**
  * Benchmarks how fast the parser can process samples on a single threaded case
- * Current: 5600X with -O3 -ffast-math, up to >140 million samples/s or ~9GB/s R/W (18GB/s bidirectional)
+ * Current: 5600X with -O3 -ffast-math, up to >140 million samples/s or ~9GB/s R/W (18GB/s
+ * bidirectional)
  */
 template <typename PcSamplingRecordT>
 static bool

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/multigpu.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/multigpu.cpp
@@ -78,11 +78,11 @@ multithread_queue_hammer(size_t tid, Latch* latch)
     std::array<std::vector<std::shared_ptr<MockDispatch<PcSamplingRecordT>>>, NUM_QUEUES>
         active_dispatches;
 
-    [[maybe_unused]] int num_reset_queues         = 0;
-    [[maybe_unused]] int num_samples_generated    = 0;
-    [[maybe_unused]] int num_dispatches_generated = 0;
-    double               avg_q_occupancy          = 0;
-    size_t               max_q_occupancy          = 0;
+    int    num_reset_queues         = 0;
+    int    num_samples_generated    = 0;
+    int    num_dispatches_generated = 0;
+    double avg_q_occupancy          = 0;
+    size_t max_q_occupancy          = 0;
 
     for(int i = 0; i < NUM_QUEUES; i++)
         queues[i] = std::make_shared<MockQueue<PcSamplingRecordT>>(QSIZE, buffer);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/multigpu.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/multigpu.cpp
@@ -78,9 +78,9 @@ multithread_queue_hammer(size_t tid, Latch* latch)
     std::array<std::vector<std::shared_ptr<MockDispatch<PcSamplingRecordT>>>, NUM_QUEUES>
         active_dispatches;
 
-    int    num_reset_queues         = 0;
-    int    num_samples_generated    = 0;
-    int    num_dispatches_generated = 0;
+    [[maybe_unused]] int    num_reset_queues         = 0;
+    [[maybe_unused]] int    num_samples_generated    = 0;
+    [[maybe_unused]] int    num_dispatches_generated = 0;
     double avg_q_occupancy          = 0;
     size_t max_q_occupancy          = 0;
 
@@ -156,7 +156,7 @@ multithread_queue_hammer(size_t tid, Latch* latch)
 
 /**
  * Benchmarks how fast the parser can process samples on a single threaded case
- * Current: 5600X with -Ofast, up to >140 million samples/s or ~9GB/s R/W (18GB/s bidirectional)
+ * Current: 5600X with -O3 -ffast-math, up to >140 million samples/s or ~9GB/s R/W (18GB/s bidirectional)
  */
 template <typename PcSamplingRecordT>
 static std::pair<size_t, size_t>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/multigpu.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/multigpu.cpp
@@ -78,11 +78,11 @@ multithread_queue_hammer(size_t tid, Latch* latch)
     std::array<std::vector<std::shared_ptr<MockDispatch<PcSamplingRecordT>>>, NUM_QUEUES>
         active_dispatches;
 
-    [[maybe_unused]] int    num_reset_queues         = 0;
-    [[maybe_unused]] int    num_samples_generated    = 0;
-    [[maybe_unused]] int    num_dispatches_generated = 0;
-    double avg_q_occupancy          = 0;
-    size_t max_q_occupancy          = 0;
+    [[maybe_unused]] int num_reset_queues         = 0;
+    [[maybe_unused]] int num_samples_generated    = 0;
+    [[maybe_unused]] int num_dispatches_generated = 0;
+    double               avg_q_occupancy          = 0;
+    size_t               max_q_occupancy          = 0;
 
     for(int i = 0; i < NUM_QUEUES; i++)
         queues[i] = std::make_shared<MockQueue<PcSamplingRecordT>>(QSIZE, buffer);
@@ -156,7 +156,8 @@ multithread_queue_hammer(size_t tid, Latch* latch)
 
 /**
  * Benchmarks how fast the parser can process samples on a single threaded case
- * Current: 5600X with -O3 -ffast-math, up to >140 million samples/s or ~9GB/s R/W (18GB/s bidirectional)
+ * Current: 5600X with -O3 -ffast-math, up to >140 million samples/s or ~9GB/s R/W (18GB/s
+ * bidirectional)
  */
 template <typename PcSamplingRecordT>
 static std::pair<size_t, size_t>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/att_packet_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/att_packet_test.cpp
@@ -292,7 +292,8 @@ query_available_agents(rocprofiler_agent_version_t /* version */,
             att_param.type      = ROCPROFILER_THREAD_TRACE_PARAMETER_PERFCOUNTER;
             att_param.simd_mask = 0xF;
             for(auto& metric : metrics)
-                if(metric.name() == "SQ_WAVES") rocprofiler_counter_id_t{.handle = metric.id()};
+                if(metric.name() == "SQ_WAVES")
+                    att_param.counter_id = rocprofiler_counter_id_t{.handle = metric.id()};
 
             params.push_back(att_param);
         }

--- a/projects/rocprofiler-sdk/tests/thread-trace/agent.cpp
+++ b/projects/rocprofiler-sdk/tests/thread-trace/agent.cpp
@@ -107,10 +107,10 @@ query_available_agents(rocprofiler_agent_version_t /* version */,
         static uint64_t    buffer_size_mb = (var ? atoi(var) : 96) * 1024ul * 1024ul;
 
         std::vector<rocprofiler_thread_trace_parameter_t> parameters;
-        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_TARGET_CU, 1});
-        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_SIMD_SELECT, 0xF});
-        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_BUFFER_SIZE, buffer_size_mb});
-        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_SHADER_ENGINE_MASK, 0x1});
+        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_TARGET_CU, {1}});
+        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_SIMD_SELECT, {0xF}});
+        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_BUFFER_SIZE, {buffer_size_mb}});
+        parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_SHADER_ENGINE_MASK, {0x1}});
 
         static const bool extra_args =
             std::getenv("ATT_NODETAIL") ? std::stoi(std::getenv("ATT_NODETAIL")) != 0 : false;
@@ -118,7 +118,7 @@ query_available_agents(rocprofiler_agent_version_t /* version */,
         {
             // Dont generate instruction profiling, only occupancy and shaderdata
             parameters.emplace_back(rocprofiler_thread_trace_parameter_t{
-                ROCPROFILER_THREAD_TRACE_PARAMETER_NO_DETAIL, 1});
+                ROCPROFILER_THREAD_TRACE_PARAMETER_NO_DETAIL, {1}});
         }
 
         ROCPROFILER_CALL(

--- a/projects/rocprofiler-sdk/tests/thread-trace/multi_dispatch.cpp
+++ b/projects/rocprofiler-sdk/tests/thread-trace/multi_dispatch.cpp
@@ -28,7 +28,7 @@
 #include "trace_callbacks.hpp"
 
 [[maybe_unused]] constexpr double WAVE_RATIO_TOLERANCE = 0.05;
-constexpr size_t NUM_KERNELS          = 5;
+constexpr size_t                  NUM_KERNELS          = 5;
 
 namespace ATTTest
 {

--- a/projects/rocprofiler-sdk/tests/thread-trace/multi_dispatch.cpp
+++ b/projects/rocprofiler-sdk/tests/thread-trace/multi_dispatch.cpp
@@ -27,8 +27,7 @@
 
 #include "trace_callbacks.hpp"
 
-[[maybe_unused]] constexpr double WAVE_RATIO_TOLERANCE = 0.05;
-constexpr size_t                  NUM_KERNELS          = 5;
+constexpr size_t NUM_KERNELS = 5;
 
 namespace ATTTest
 {

--- a/projects/rocprofiler-sdk/tests/thread-trace/multi_dispatch.cpp
+++ b/projects/rocprofiler-sdk/tests/thread-trace/multi_dispatch.cpp
@@ -27,7 +27,7 @@
 
 #include "trace_callbacks.hpp"
 
-constexpr double WAVE_RATIO_TOLERANCE = 0.05;
+[[maybe_unused]] constexpr double WAVE_RATIO_TOLERANCE = 0.05;
 constexpr size_t NUM_KERNELS          = 5;
 
 namespace ATTTest
@@ -73,7 +73,7 @@ tool_init(rocprofiler_client_finalize_t /* fini_func */, void* /* tool_data */)
         "code object tracing service configure");
 
     std::vector<rocprofiler_thread_trace_parameter_t> params{};
-    params.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_SERIALIZE_ALL, 1});
+    params.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_SERIALIZE_ALL, {1}});
 
     std::vector<rocprofiler_agent_id_t> agents{};
 

--- a/projects/rocprofiler-sdk/tests/thread-trace/single_dispatch.cpp
+++ b/projects/rocprofiler-sdk/tests/thread-trace/single_dispatch.cpp
@@ -27,7 +27,7 @@
 
 #include "trace_callbacks.hpp"
 
-constexpr double WAVE_RATIO_TOLERANCE = 0.05;
+[[maybe_unused]] constexpr double WAVE_RATIO_TOLERANCE = 0.05;
 
 namespace ATTTest
 {

--- a/projects/rocprofiler-sdk/tests/thread-trace/single_dispatch.cpp
+++ b/projects/rocprofiler-sdk/tests/thread-trace/single_dispatch.cpp
@@ -27,8 +27,6 @@
 
 #include "trace_callbacks.hpp"
 
-[[maybe_unused]] constexpr double WAVE_RATIO_TOLERANCE = 0.05;
-
 namespace ATTTest
 {
 namespace Single


### PR DESCRIPTION
## Motivation

- Clang Tidy was giving some errors and warnings.
- Formatting fixes

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Clang-tidy related cleanups: suppress unused warnings, adjust initialization style, update compilation flags, and fix an unused temporary in a performance counter parameter assignment.

- Add [[maybe_unused]] to quiet unused variable/constant warnings.
- Use braced initialization for thread trace parameters (likely to satisfy clang-tidy/union or narrowing rules) and update benchmark compile flags from -Ofast to -O3 -ffast-math.
- Correct assignment of performance counter ID in att_packet_test (previous temporary object creation became a real assignment).

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
