### PR TITLE
Fix for dynamic code object loading in the thread trace sample

### DIFF
--- a/projects/rocprofiler-sdk/samples/thread_trace/agent.cpp
+++ b/projects/rocprofiler-sdk/samples/thread_trace/agent.cpp
@@ -159,6 +159,7 @@ tool_codeobj_tracing_callback(rocprofiler_callback_tracing_record_t record,
 {
     if(record.kind != ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT) return;
     if(record.operation != ROCPROFILER_CODE_OBJECT_LOAD) return;
+    if(record.phase != ROCPROFILER_CALLBACK_PHASE_LOAD) return;
 
     CHECK_NOTNULL(Results::table);
     auto* data = static_cast<rocprofiler_callback_tracing_code_object_load_data_t*>(record.payload);

--- a/projects/rocprofiler-sdk/samples/thread_trace/agent.cpp
+++ b/projects/rocprofiler-sdk/samples/thread_trace/agent.cpp
@@ -157,32 +157,34 @@ tool_codeobj_tracing_callback(rocprofiler_callback_tracing_record_t record,
                               rocprofiler_user_data_t* /* user_data */,
                               void* /* userdata */)
 {
-    if(record.kind != ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT) return;
-    if(record.operation != ROCPROFILER_CODE_OBJECT_LOAD) return;
-    if(record.phase != ROCPROFILER_CALLBACK_PHASE_LOAD) return;
-
-    CHECK_NOTNULL(Results::table);
-    auto* data = static_cast<rocprofiler_callback_tracing_code_object_load_data_t*>(record.payload);
-
-    if(data->storage_type == ROCPROFILER_CODE_OBJECT_STORAGE_TYPE_FILE)
+    if(record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT &&
+       record.operation == ROCPROFILER_CODE_OBJECT_LOAD &&
+       record.phase == ROCPROFILER_CALLBACK_PHASE_LOAD)
     {
+        CHECK_NOTNULL(Results::table);
+        auto* data =
+            static_cast<rocprofiler_callback_tracing_code_object_load_data_t*>(record.payload);
+
+        if(data->storage_type == ROCPROFILER_CODE_OBJECT_STORAGE_TYPE_FILE)
+        {
+            Results::table->addDecoder(
+                data->uri, data->code_object_id, data->load_delta, data->load_size);
+            return;
+        }
+
+        auto* memorybase = reinterpret_cast<const void*>(data->memory_base);
+        CHECK_NOTNULL(memorybase);
+
+        DECODER_CALL(rocprofiler_thread_trace_decoder_codeobj_load(decoder,
+                                                                   data->code_object_id,
+                                                                   data->load_delta,
+                                                                   data->load_size,
+                                                                   memorybase,
+                                                                   data->memory_size));
+
         Results::table->addDecoder(
-            data->uri, data->code_object_id, data->load_delta, data->load_size);
-        return;
+            memorybase, data->memory_size, data->code_object_id, data->load_delta, data->load_size);
     }
-
-    auto* memorybase = reinterpret_cast<const void*>(data->memory_base);
-    CHECK_NOTNULL(memorybase);
-
-    DECODER_CALL(rocprofiler_thread_trace_decoder_codeobj_load(decoder,
-                                                               data->code_object_id,
-                                                               data->load_delta,
-                                                               data->load_size,
-                                                               memorybase,
-                                                               data->memory_size));
-
-    Results::table->addDecoder(
-        memorybase, data->memory_size, data->code_object_id, data->load_delta, data->load_size);
 }
 
 void


### PR DESCRIPTION
## Motivation

Error is seen when the code object is unloading during application execution.
https://ontrack-internal.amd.com/browse/SWDEV-560171

## Technical Details

The sample was not filtering code objects based on the load phase.
There is only one line change, the rest is a formatting refactor.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
