### PR TITLE
SWDEV-559166 - Fix potential data race in ReferenceCountedObject::release()

### DIFF
--- a/projects/clr/rocclr/platform/runtime.cpp
+++ b/projects/clr/rocclr/platform/runtime.cpp
@@ -134,7 +134,7 @@ uint ReferenceCountedObject::retain() {
 }
 
 uint ReferenceCountedObject::release() {
-  uint newCount = referenceCount_.fetch_sub(1, std::memory_order_relaxed) - 1;
+  uint newCount = referenceCount_.fetch_sub(1, std::memory_order_acq_rel) - 1;
   if (newCount == 0) {
     if (terminate()) {
       // The destructor should be called with a count==1 for the last thread


### PR DESCRIPTION

## Motivation
This PR addresses a potential data race in ReferenceCountedObject::release() by strengthening the memory ordering semantics of the atomic operation. The change ensures that when the reference count reaches zero and an object is destroyed, the destroying thread properly synchronizes with all prior modifications made by other threads.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Thread sanitizer reports many memory leaks related to ReferenceCountedObject:

<details>
<summary><strong>TSan report (expand)</strong></summary>

```text
==================
WARNING: ThreadSanitizer: data race (pid=20394)
  Write of size 8 at 0x7b5800070208 by thread T119:
    #0 operator delete(void*) ../../.././libsanitizer/tsan/tsan_new_delete.cpp:126 (libtsan.so+0x8ccc8)
    #1 amd::Command::operator delete(void*) /data/iassiour/clr/rocclr/platform/command.cpp:328 (libamdhip64.so.6+0x48f59f)
    #2 amd::FillMemoryCommand::~FillMemoryCommand() /data/iassiour/clr/rocclr/platform/command.hpp:742 (libamdhip64.so.6+0x2a2ac2)
    #3 amd::ReferenceCountedObject::release() /data/iassiour/clr/rocclr/platform/runtime.cpp:161 (libamdhip64.so.6+0x4b2921)
    #4 amd::roc::VirtualGPU::updateCommandsState(amd::Command*) const /data/iassiour/clr/rocclr/device/rocm/rocvirtual.cpp:1627 (libamdhip64.so.6+0x4e876d)
    #5 amd::roc::HsaAmdSignalHandler(long, void*) /data/iassiour/clr/rocclr/device/rocm/rocvirtual.cpp:243 (libamdhip64.so.6+0x4e8c0e)
    #6 rocr::core::Runtime::AsyncEventsLoop(void*) /data/iassiour/ROCR-Runtime/runtime/hsa-runtime/core/runtime/runtime.cpp:1628 (libhsa-runtime64.so.1+0xd2416)
    #7 rocr::os::ThreadTrampoline(void*) /data/iassiour/ROCR-Runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp:87 (libhsa-runtime64.so.1+0x39a36)

  Previous atomic write of size 4 at 0x7b5800070208 by thread T427:
    #0 __tsan_atomic32_fetch_sub ../../.././libsanitizer/tsan/tsan_interface_atomic.cpp:642 (libtsan.so+0x81928)
    #1 std::__atomic_base<unsigned int>::fetch_sub(unsigned int, std::memory_order) /usr/include/c++/10/bits/atomic_base.h:558 (libamdhip64.so.6+0x4b28ba)
    #2 amd::ReferenceCountedObject::release() /data/iassiour/clr/rocclr/platform/runtime.cpp:153 (libamdhip64.so.6+0x4b28ba)
```
</details>
This is because the thread that own the last reference gets the reference count via relaxed memory_order semantics.
That means that terminate() or the destructor may not get the writes from other threads at the object that is about to get destroyed.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
