### PR TITLE
[rocprof-compute] Run roofline test on GPU 0 by default

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -146,6 +146,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 * Default rocprof interface changed from rocprofv3 to rocprofiler-sdk
   * Use ROCPROF=rocprofv3 to use rocprofv3 interface
 
+* Changed default behavior to run roofline on GPU 0 instead of all GPUs
+
 ### Removed
 
 * Usage of `rocm-smi` in favor of `amd-smi`.

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -146,7 +146,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 * Default rocprof interface changed from rocprofv3 to rocprofiler-sdk
   * Use ROCPROF=rocprofv3 to use rocprofv3 interface
 
-* Changed default behavior to run roofline on GPU 0 instead of all GPUs
+* Roofline analysis now runs on GPU 0 by default instead of all GPUs.
 
 ### Removed
 

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -413,9 +413,9 @@ Examples:
         "--device",
         metavar="",
         required=False,
-        default=-1,
+        default=0,
         type=int,
-        help="\t\t\tTarget GPU device ID. (DEFAULT: ALL)",
+        help="\t\t\tTarget GPU device ID. (DEFAULT: 0)",
     )
     roofline_group.add_argument(
         "--kernel-names",


### PR DESCRIPTION
## Motivation

Running the roofline test on all GPUs by default is very costly on multi-GPU systems. By default only run the roofline test on GPU 0.

## Technical Details

Even when running roofline on all GPUs, only the first entry in `roofline.csv` is selected. So default ALL is functionally the same as  `--device 0`.


## Test Plan

Profile workload with and without `--device` argument. Verify roofline test is only run on GPU 0. Verify roofline works as expected.

Profile workload with `--device 1`. Verify roofline is run on GPU 1. Verify roofline works as expected.

## Test Result

Roofline works as expected.

## Submission Checklist

- [ *] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
