### PR TITLE
Temporary declare stochastic exec-mask tests unstable

### DIFF
--- a/projects/rocprofiler-sdk/tests/pc_sampling/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/pc_sampling/CMakeLists.txt
@@ -64,6 +64,13 @@ target_link_libraries(
 # Check if PC sampling is disabled and whether we should disable the test
 rocprofiler_sdk_pc_sampling_disabled(IS_PC_SAMPLING_DISABLED)
 
+# Temporary disable the test until the SWDEV-548078 is fixed
+rocprofiler_sdk_pc_sampling_stochastic_disabled(IS_PC_SAMPLING_STOCHASTIC_DISABLED)
+if(ROCPROFILER_DISABLE_UNSTABLE_CTESTS AND NOT IS_PC_SAMPLING_STOCHASTIC_DISABLED)
+    # Disabling only if the underlying architecture support stochastic PC sampling
+    set(IS_PC_SAMPLING_DISABLED ON)
+endif()
+
 add_test(NAME pc-sampling-integration-test
          COMMAND $<TARGET_FILE:pc-sampling-integration-test>)
 

--- a/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/stochastic/exec-mask-manipulation/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/stochastic/exec-mask-manipulation/CMakeLists.txt
@@ -35,6 +35,11 @@ find_package(rocprofiler-sdk REQUIRED)
 # Checking whether stochastic PC sampling is disabled. If so, skip the tests.
 rocprofiler_sdk_pc_sampling_stochastic_disabled(IS_PC_SAMPLING_STOCHASTIC_DISABLED)
 
+# Temporary disable tests until the SWDEV-548078 is fixed
+if(ROCPROFILER_DISABLE_UNSTABLE_CTESTS)
+    set(IS_PC_SAMPLING_STOCHASTIC_DISABLED ON)
+endif()
+
 rocprofiler_configure_pytest_files(CONFIG pytest.ini COPY validate.py conftest.py
                                                           input.json input.yml)
 


### PR DESCRIPTION
Due to trap handler latency (SWDEV-548078), some samples have incorrect no issue reason (stall reason).
Thus, declaring the exec-mask-manipulation
stochastic tests as unstable, until the real cause is fixed.

## Motivation

Backup plan for the #1109 .

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
