### PR TITLE
Add flushing of perfetto buffer

### DIFF
--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/](https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/).
 
+## ROCm Systems Profiler 1.3.0 for ROCm 7.2.0
+
+### Added
+
+- Added a `ROCPROFSYS_PERFETTO_FLUSH_PERIOD_MS` configuration setting to set the flush period for Perfetto traces. The default value is 10000 ms (10 seconds).
+
 ## ROCm Systems Profiler 1.2.0 for ROCm 7.1.0
 
 ### Added

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -645,6 +645,10 @@ configure_settings(bool _init)
                               "default to the value of ROCPROFSYS_COLLAPSE_PROCESSES",
                               false, "perfetto", "data", "advanced");
 
+    ROCPROFSYS_CONFIG_SETTING(uint32_t, "ROCPROFSYS_PERFETTO_FLUSH_PERIOD_MS",
+                              "Set Perfetto flush period (in ms)", uint32_t{ 10000 },
+                              "perfetto", "data");
+
     ROCPROFSYS_CONFIG_SETTING(
         std::string, "ROCPROFSYS_PERFETTO_FILL_POLICY",
         "Behavior when perfetto buffer is full. 'discard' will ignore new entries, "
@@ -1995,6 +1999,13 @@ get_perfetto_buffer_size()
 {
     static auto _v = get_config()->find("ROCPROFSYS_PERFETTO_BUFFER_SIZE_KB");
     return static_cast<tim::tsettings<size_t>&>(*_v->second).get();
+}
+
+uint32_t
+get_perfetto_flush_period()
+{
+    static auto _v = get_config()->find("ROCPROFSYS_PERFETTO_FLUSH_PERIOD_MS");
+    return static_cast<tim::tsettings<uint32_t>&>(*_v->second).get();
 }
 
 bool

--- a/projects/rocprofiler-systems/source/lib/core/config.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.hpp
@@ -252,6 +252,9 @@ get_perfetto_shmem_size_hint();
 size_t
 get_perfetto_buffer_size();
 
+uint32_t
+get_perfetto_flush_period();
+
 bool
 get_perfetto_combined_traces();
 

--- a/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
@@ -28,8 +28,6 @@
 #include "utility.hpp"
 
 #include <chrono>
-#include <ratio>
-using namespace std::chrono_literals;
 
 namespace rocprofsys
 {
@@ -80,6 +78,7 @@ setup()
     // environment settings
     auto shmem_size_hint = config::get_perfetto_shmem_size_hint();
     auto buffer_size     = config::get_perfetto_buffer_size();
+    auto flush_period    = config::get_perfetto_flush_period();
 
     auto _policy =
         config::get_perfetto_fill_policy() == "discard"
@@ -96,8 +95,7 @@ setup()
         track_event_cfg.add_disabled_categories(itr);
     }
 
-    cfg.set_flush_period_ms(
-        std::chrono::duration_cast<std::chrono::milliseconds>(10s).count());
+    cfg.set_flush_period_ms(flush_period);
 
     auto* ds_cfg = cfg.add_data_sources()->mutable_config();
     ds_cfg->set_name("track_event");  // this MUST be track_event

--- a/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
@@ -28,6 +28,8 @@
 #include "utility.hpp"
 
 #include <chrono>
+#include <ratio>
+using namespace std::chrono_literals;
 
 namespace rocprofsys
 {
@@ -93,6 +95,9 @@ setup()
                              itr.c_str());
         track_event_cfg.add_disabled_categories(itr);
     }
+
+    cfg.set_flush_period_ms(
+        std::chrono::duration_cast<std::chrono::milliseconds>(10s).count());
 
     auto* ds_cfg = cfg.add_data_sources()->mutable_config();
     ds_cfg->set_name("track_event");  // this MUST be track_event


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR will prevent buffer to be filled and data to be discarded. Resolves SWDEV-518817.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
In Perfetto configuration, flushing period is set to 10 seconds.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Trace workload which will generate larger trace than default perfetto_buffer_size, and be sure that **larger** trace is result of profiling.

## Test Result

<!-- Briefly summarize test outcomes. -->
Without this patch, workload tracing was generating 1.2GB trace and trace result was incomplete, but with this patch, trace was 1.8GB, and trace was full.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
