### PR TITLE
Disable PCSampling on upstream branches.

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/kfdtest.exclude
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/kfdtest.exclude
@@ -360,4 +360,5 @@ FILTER[RHEL9]=\
 "KFDPCSamplingTest.*"
 
 FILTER[upstream]=\
-"KFDIPCTest.*"
+"KFDIPCTest.*:"\
+"KFDPCSamplingTest.*"


### PR DESCRIPTION
 - PC Sampling ioctls/tests are not up-streamed. They should be skipped for any and all upstream branches.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
