### PR TITLE
Disable KFDDBGTest.HitMemoryViolation for navi 10

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/kfdtest.exclude
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/kfdtest.exclude
@@ -250,7 +250,8 @@ FILTER[aldebaran]=\
 FILTER[navi10]=\
 "$BLACKLIST_ALL_ASICS:"\
 "$BLACKLIST_GFX10:"\
-"KFDMemoryTest.MMBench"
+"KFDMemoryTest.MMBench:"\
+"KFDDBGTest.HitMemoryViolation"
 
 # Need to verify the following failed tests on another machine:
 # Exceptions not being received during exception tests


### PR DESCRIPTION
 - Filter out KFDDBGTest.HitMemoryViolation for navi10, which is currently failing

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
