### PR TITLE
kfdtest: Replace pthread with std::thread

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.cpp
@@ -138,7 +138,7 @@ void KFDBaseComponentTest::SetUp() {
     if (g_TestGPUsNum == 1) {
         syslog(LOG_INFO, "[Test on Node#%03d] "
                     "STARTED ========== %s.%s ==========",
-                    g_SelectedNodes.empty() ? 
+                    g_TestNodeId > 0 ? 
                             m_NodeInfo.HsaDefaultGPUNode() : g_SelectedNodes[0],
                     curr_test_info->test_case_name(), curr_test_info->name());
     } else {    
@@ -185,7 +185,7 @@ void KFDBaseComponentTest::TearDown() {
         if (g_TestGPUsNum == 1)
             syslog(LOG_INFO, "[Test on Node#%03d] PASSED"
                              "  ========== %s.%s ==========",
-                g_SelectedNodes.empty() ? 
+                g_TestNodeId > 0 ? 
                             m_NodeInfo.HsaDefaultGPUNode() : g_SelectedNodes[0],
                 curr_test_info->test_case_name(), curr_test_info->name());
         else
@@ -198,7 +198,7 @@ void KFDBaseComponentTest::TearDown() {
         if (g_TestGPUsNum == 1)
             syslog(LOG_WARNING, "[Test on Node#%03d] FAILED"
                                  "  ========== %s.%s ==========",
-                g_SelectedNodes.empty() ? 
+                g_TestNodeId > 0 ? 
                             m_NodeInfo.HsaDefaultGPUNode() : g_SelectedNodes[0],
                 curr_test_info->test_case_name(), curr_test_info->name());
         else
@@ -378,61 +378,13 @@ static void* KFDTest_GPU(void* ptr) {
     pthread_exit(NULL);
 }
 
-HSAKMT_STATUS KFDBaseComponentTest::KFDTestMultiGPU(Test_Function test_function,
-                                        const std::vector<int>& gpuNodes,
-                                        unsigned int gpu_num) {
-    HSAKMT_STATUS r = HSAKMT_STATUS_SUCCESS;
-    int gpu_node;
-    int err = 0;
-    int i, j;
-
-    if (gpuNodes.empty()) 
-        return HSAKMT_STATUS_SUCCESS;
-
-    KFDTEST_GPUPARAMETERS kfdtest_GpuParameters[gpu_num];
-    KFDTEST_PARAMETERS kfdTest_Parameters[gpu_num];
-    pthread_t pThreadGPU[gpu_num];
-
-    for (i = 0; i < gpu_num; i++) {
-
-        gpu_node = gpuNodes.at(i);
-
-        kfdTest_Parameters[i].pTestObject = this;
-        kfdTest_Parameters[i].gpuNode = gpu_node;
-
-        kfdtest_GpuParameters[i].pKFDTest_Parameters = &kfdTest_Parameters[i];
-        kfdtest_GpuParameters[i].pTest_Function = test_function;
-
-        err = pthread_create(&pThreadGPU[i], NULL, KFDTest_GPU,
-                             (void *)&kfdtest_GpuParameters[i]);
-        if (err) {
-            std::cout << "Thread creation for gpu node failed : " << gpu_node
-                      << strerror(err) << std::endl;
-            r = HSAKMT_STATUS_ERROR;
-            goto err_out;
-        }
-    }
-
-err_out:
-   /* wait threads created successully to finish */
-   for (j = 0; j < i; j++) {
-       err = pthread_join(pThreadGPU[j], NULL);
-       if (err) {
-           std::cout << "pthread_join at gpu node failed : " << gpuNodes.at(j)
-                     << strerror(err) << std::endl;
-           r = HSAKMT_STATUS_ERROR;
-       }
-   }
-
-   return r;
-}
-
-HSAKMT_STATUS KFDBaseComponentTest::KFDTestMultiGPUStd(
+HSAKMT_STATUS KFDBaseComponentTest::KFDTestMultiGPU(
                                             std::function<void(int)> test_func, 
                                             const std::vector<int>& gpuNodes,
                                             unsigned int gpu_num) {
     HSAKMT_STATUS r = HSAKMT_STATUS_SUCCESS;
     std::vector<std::thread> threads;
+    std::atomic<bool> test_failed(false);
     threads.reserve(gpu_num);
 
     if (gpuNodes.empty()) return HSAKMT_STATUS_SUCCESS;
@@ -441,11 +393,18 @@ HSAKMT_STATUS KFDBaseComponentTest::KFDTestMultiGPUStd(
         int gpu_node = gpuNodes.at(i);
 
         try {
-            threads.emplace_back([test_func, gpu_node]() {
-                try {
-                    test_func(gpu_node);
-                } catch (...) {
-                    LOG() << "test failed at gpu" << gpu_node << std::endl;
+            threads.emplace_back([test_func, gpu_node, &test_failed]() {
+                const testing::TestInfo* test_info_before = 
+                    ::testing::UnitTest::GetInstance()->current_test_info();
+                bool had_failure_before = test_info_before->result()->Failed();
+                
+                test_func(gpu_node);
+                
+                const testing::TestInfo* test_info_after = 
+                    ::testing::UnitTest::GetInstance()->current_test_info();
+                if (!had_failure_before && test_info_after->result()->Failed()) {
+                    LOG() << "Test failed at gpu " << gpu_node << std::endl;
+                    test_failed = true;
                 }
             });
         } catch (const std::system_error& e) {
@@ -468,12 +427,13 @@ HSAKMT_STATUS KFDBaseComponentTest::KFDTestMultiGPUStd(
         }
     }
 
+    if (test_failed)
+        r = HSAKMT_STATUS_ERROR;
+
     return r;
 }
 
-
-HSAKMT_STATUS KFDBaseComponentTest::KFDTest_Launch(Test_Function test_function) {
-
+HSAKMT_STATUS KFDBaseComponentTest::KFDTestLaunch(std::function<void(int)> test_func) {
     /* test on default GPU only */
     if (g_TestNodeId >= 0) {
         int defaultGPUNode = m_NodeInfo.HsaDefaultGPUNode();
@@ -482,38 +442,16 @@ HSAKMT_STATUS KFDBaseComponentTest::KFDTest_Launch(Test_Function test_function) 
             return HSAKMT_STATUS_INVALID_PARAMETER;
         }
 
-        KFDTEST_PARAMETERS TestParamters;
-        TestParamters.pTestObject = this;
-        TestParamters.gpuNode = defaultGPUNode;
-        try {
-            test_function(&TestParamters);
-        } catch (...) {
-            LOG() << "test failed at gpu" << defaultGPUNode << std::endl;
-        }
-
-        return HSAKMT_STATUS_SUCCESS;
-    }
-
-    /* run test_function on all selected GPUs */
-    HSAKMT_STATUS err = HSAKMT_STATUS_SUCCESS;
-    err = KFDTestMultiGPU(test_function, g_SelectedNodes, g_TestGPUsNum);
-
-    return err;
-}
-
-HSAKMT_STATUS KFDBaseComponentTest::KFDTestLaunchStd(std::function<void(int)> test_func) {
-    /* test on default GPU only */
-    if (g_TestNodeId >= 0) {
-        int defaultGPUNode = m_NodeInfo.HsaDefaultGPUNode();
-        if (defaultGPUNode < 0) {
-            LOG() << "defaultGPUNode is invalid." << defaultGPUNode << std::endl;
-            return HSAKMT_STATUS_INVALID_PARAMETER;
-        }
-
-        try {
-            test_func(defaultGPUNode);
-        } catch (...) {
-            LOG() << "test failed at gpu" << defaultGPUNode << std::endl;
+        const testing::TestInfo* test_info_before = 
+            ::testing::UnitTest::GetInstance()->current_test_info();
+        bool had_failure_before = test_info_before->result()->Failed();
+        
+        test_func(defaultGPUNode);
+        
+        const testing::TestInfo* test_info_after = 
+            ::testing::UnitTest::GetInstance()->current_test_info();
+        if (!had_failure_before && test_info_after->result()->Failed()) {
+            LOG() << "Test failed at gpu " << defaultGPUNode << std::endl;
             return HSAKMT_STATUS_ERROR;
         }
 
@@ -522,7 +460,7 @@ HSAKMT_STATUS KFDBaseComponentTest::KFDTestLaunchStd(std::function<void(int)> te
 
     /* run test_function on all selected GPUs */
     HSAKMT_STATUS err = HSAKMT_STATUS_SUCCESS;
-    err = KFDTestMultiGPUStd(test_func, g_SelectedNodes, g_TestGPUsNum);
+    err = KFDTestMultiGPU(test_func, g_SelectedNodes, g_TestGPUsNum);
 
     return err;
 }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.cpp
@@ -427,13 +427,58 @@ err_out:
    return r;
 }
 
+HSAKMT_STATUS KFDBaseComponentTest::KFDTestMultiGPUStd(
+                                            std::function<void(int)> test_func, 
+                                            const std::vector<int>& gpuNodes,
+                                            unsigned int gpu_num) {
+    HSAKMT_STATUS r = HSAKMT_STATUS_SUCCESS;
+    std::vector<std::thread> threads;
+    threads.reserve(gpu_num);
+
+    if (gpuNodes.empty()) return HSAKMT_STATUS_SUCCESS;
+
+    for (int i = 0; i < gpu_num; i++) {
+        int gpu_node = gpuNodes.at(i);
+
+        try {
+            threads.emplace_back([test_func, gpu_node]() {
+                try {
+                    test_func(gpu_node);
+                } catch (...) {
+                    LOG() << "test failed at gpu" << gpu_node << std::endl;
+                }
+            });
+        } catch (const std::system_error& e) {
+            std::cout << "Thread creation for gpu node failed : " << gpu_node
+                      << " " << e.what() << std::endl;
+            r = HSAKMT_STATUS_ERROR;
+            break;
+        }
+    }
+
+    // Wait for all threads to complete
+    for (auto& thread : threads) {
+        try {
+            if (thread.joinable()) {
+                thread.join();
+            }
+        } catch (const std::system_error& e) {
+            std::cout << "thread join failed: " << e.what() << std::endl;
+            r = HSAKMT_STATUS_ERROR;
+        }
+    }
+
+    return r;
+}
+
+
 HSAKMT_STATUS KFDBaseComponentTest::KFDTest_Launch(Test_Function test_function) {
 
     /* test on default GPU only */
     if (g_TestNodeId >= 0) {
         int defaultGPUNode = m_NodeInfo.HsaDefaultGPUNode();
         if (defaultGPUNode < 0) {
-            LOG() << "defaultGPUNode is invalid." << defaultGPUNode <<std::endl;
+            LOG() << "defaultGPUNode is invalid." << defaultGPUNode << std::endl;
             return HSAKMT_STATUS_INVALID_PARAMETER;
         }
 
@@ -452,6 +497,32 @@ HSAKMT_STATUS KFDBaseComponentTest::KFDTest_Launch(Test_Function test_function) 
     /* run test_function on all selected GPUs */
     HSAKMT_STATUS err = HSAKMT_STATUS_SUCCESS;
     err = KFDTestMultiGPU(test_function, g_SelectedNodes, g_TestGPUsNum);
+
+    return err;
+}
+
+HSAKMT_STATUS KFDBaseComponentTest::KFDTestLaunchStd(std::function<void(int)> test_func) {
+    /* test on default GPU only */
+    if (g_TestNodeId >= 0) {
+        int defaultGPUNode = m_NodeInfo.HsaDefaultGPUNode();
+        if (defaultGPUNode < 0) {
+            LOG() << "defaultGPUNode is invalid." << defaultGPUNode << std::endl;
+            return HSAKMT_STATUS_INVALID_PARAMETER;
+        }
+
+        try {
+            test_func(defaultGPUNode);
+        } catch (...) {
+            LOG() << "test failed at gpu" << defaultGPUNode << std::endl;
+            return HSAKMT_STATUS_ERROR;
+        }
+
+        return HSAKMT_STATUS_SUCCESS;
+    }
+
+    /* run test_function on all selected GPUs */
+    HSAKMT_STATUS err = HSAKMT_STATUS_SUCCESS;
+    err = KFDTestMultiGPUStd(test_func, g_SelectedNodes, g_TestGPUsNum);
 
     return err;
 }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.hpp
@@ -34,6 +34,7 @@
 #include <thread>
 #include <functional>
 #include <algorithm>
+#include <future>
 #include "hsakmt/hsakmt.h"
 #include "OSWrapper.hpp"
 #include "KFDTestUtil.hpp"
@@ -108,17 +109,11 @@ class KFDBaseComponentTest : public testing::Test {
         return m_numSdmaXgmiEngines_GPU[gpuIndex];
     }
 
-    HSAKMT_STATUS KFDTestMultiGPU(Test_Function test_function, 
-                                            const std::vector<int>& gpu_indices,
-                                            unsigned int gpu_num);
-
-    HSAKMT_STATUS KFDTestMultiGPUStd(std::function<void(int)> test_func, 
+    HSAKMT_STATUS KFDTestMultiGPU(std::function<void(int)> test_func, 
                                             const std::vector<int>& gpuNodes, 
                                             unsigned int gpu_num);
 
-    HSAKMT_STATUS KFDTest_Launch(Test_Function test_function);
-
-    HSAKMT_STATUS KFDTestLaunchStd(std::function<void(int)> test_func);
+    HSAKMT_STATUS KFDTestLaunch(std::function<void(int)> test_func);
 
  protected:
     HsaVersionInfo  m_VersionInfo;

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDBaseComponentTest.hpp
@@ -31,6 +31,8 @@
 #include <amdgpu.h>
 #include <amdgpu_drm.h>
 #include <sys/param.h>
+#include <thread>
+#include <functional>
 #include <algorithm>
 #include "hsakmt/hsakmt.h"
 #include "OSWrapper.hpp"
@@ -110,7 +112,13 @@ class KFDBaseComponentTest : public testing::Test {
                                             const std::vector<int>& gpu_indices,
                                             unsigned int gpu_num);
 
+    HSAKMT_STATUS KFDTestMultiGPUStd(std::function<void(int)> test_func, 
+                                            const std::vector<int>& gpuNodes, 
+                                            unsigned int gpu_num);
+
     HSAKMT_STATUS KFDTest_Launch(Test_Function test_function);
+
+    HSAKMT_STATUS KFDTestLaunchStd(std::function<void(int)> test_func);
 
  protected:
     HsaVersionInfo  m_VersionInfo;

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDCWSRTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDCWSRTest.cpp
@@ -157,7 +157,7 @@ void KFDCWSRTest::BasicTest(int gpuNode) {
 TEST_P(KFDCWSRTest, BasicTest) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->BasicTest(gpuNode);
     }));
 
@@ -244,7 +244,7 @@ void KFDCWSRTest::InterruptRestore(int gpuNode) {
 TEST_F(KFDCWSRTest, InterruptRestore) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->InterruptRestore(gpuNode);
     }));
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDCWSRTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDCWSRTest.cpp
@@ -76,19 +76,16 @@ static inline uint32_t checkCWSREnabled() {
  * 3: 1024 work-items (multi-wave), CWSR threshold of 1000
  */
 
-static void BasicTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDCWSRTest::BasicTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDCWSRTest* pKFDCWSRTest = (KFDCWSRTest*)pTestParamters->pTestObject;
-
-    const HSAuint32 m_FamilyId = pKFDCWSRTest->GetFamilyIdFromNodeId(gpuNode);
+    const HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDCWSRTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
-    int num_witems = std::get<0>(pKFDCWSRTest->GetParam());
-    int cwsr_thresh = std::get<1>(pKFDCWSRTest->GetParam());
+    int num_witems = std::get<0>(GetParam());
+    int cwsr_thresh = std::get<1>(GetParam());
     // Increase delay on emulator by this factor.
     const int delayMult = (g_IsEmuMode ? 20 : 1);
 
@@ -160,7 +157,9 @@ static void BasicTest(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_P(KFDCWSRTest, BasicTest) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(BasicTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->BasicTest(gpuNode);
+    }));
 
     TEST_END
 }
@@ -194,15 +193,12 @@ INSTANTIATE_TEST_CASE_P(
  * Preempt runlist. One or both queues must interrupt context restore to preempt.
  */
 
-static void InterruptRestore(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDCWSRTest::InterruptRestore(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDCWSRTest* pKFDCWSRTest = (KFDCWSRTest*)pTestParamters->pTestObject;
-
-    const HSAuint32 m_FamilyId = pKFDCWSRTest->GetFamilyIdFromNodeId(gpuNode);
+    const HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDCWSRTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
    if ((m_FamilyId >= FAMILY_VI) && (checkCWSREnabled())) {
@@ -248,7 +244,9 @@ static void InterruptRestore(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDCWSRTest, InterruptRestore) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(InterruptRestore));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->InterruptRestore(gpuNode);
+    }));
 
     TEST_END
 }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDCWSRTest.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDCWSRTest.hpp
@@ -35,6 +35,9 @@ class KFDCWSRTest : public KFDBaseComponentTest,
     KFDCWSRTest() {}
     ~KFDCWSRTest() {}
 
+    void BasicTest(int gpuNode);
+    void InterruptRestore(int gpuNode);
+
  protected:
     virtual void SetUp();
     virtual void TearDown();

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDEventTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDEventTest.cpp
@@ -56,13 +56,10 @@ void KFDEventTest::TearDown() {
     ROUTINE_END
 }
 
-static void CreateDestroyEvent(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDEventTest::CreateDestroyEvent(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDEventTest* pKFDEventTest = (KFDEventTest*)pTestParamters->pTestObject;
-
-    int gpuIndex = pKFDEventTest->Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
-    HsaEvent* m_pHsaEvent = pKFDEventTest->m_pHsaEventGPU[gpuIndex];
+    int gpuIndex = Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
+    HsaEvent* m_pHsaEvent = m_pHsaEventGPU[gpuIndex];
 
     ASSERT_SUCCESS_GPU(CreateQueueTypeEvent(false, false, gpuNode, &m_pHsaEvent), gpuNode);
     EXPECT_NE_GPU(0, m_pHsaEvent->EventData.HWData2, gpuNode);
@@ -72,17 +69,16 @@ static void CreateDestroyEvent(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDEventTest, CreateDestroyEvent) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(CreateDestroyEvent));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->CreateDestroyEvent(gpuNode);
+    }));
 
     // Destroy event is being called in test TearDown
     TEST_END;
 }
 
 
-static void CreateMaxEvents(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDEventTest* pKFDEventTest = (KFDEventTest*)pTestParamters->pTestObject;
+void KFDEventTest::CreateMaxEvents(int gpuNode) {
 
     static const unsigned int MAX_EVENT_NUMBER = 256;
 
@@ -103,19 +99,18 @@ static void CreateMaxEvents(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDEventTest, CreateMaxEvents) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(CreateMaxEvents));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->CreateMaxEvents(gpuNode);
+    }));
 
     TEST_END;
 }
 
-static void SignalEvent(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDEventTest::SignalEvent(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDEventTest* pKFDEventTest = (KFDEventTest*)pTestParamters->pTestObject;
-
-    int gpuIndex = pKFDEventTest->Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
-    HsaEvent* m_pHsaEvent = pKFDEventTest->m_pHsaEventGPU[gpuIndex];
-    HSAuint32 m_FamilyId = pKFDEventTest->GetFamilyIdFromNodeId(gpuNode);
+    int gpuIndex = Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
+    HsaEvent* m_pHsaEvent = m_pHsaEventGPU[gpuIndex];
+    HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     PM4Queue queue;
     HsaEvent *tmp_event;
@@ -146,27 +141,26 @@ static void SignalEvent(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDEventTest, SignalEvent) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(SignalEvent));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SignalEvent(gpuNode);
+    }));
 
     TEST_END;
 }
 
 /* test event signaling with event age enabled wait */
-static void SignalEventExt(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDEventTest::SignalEventExt(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDEventTest* pKFDEventTest = (KFDEventTest*)pTestParamters->pTestObject;
-
-    int gpuIndex = pKFDEventTest->Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
-    HsaEvent* m_pHsaEvent = pKFDEventTest->m_pHsaEventGPU[gpuIndex];
-    HSAuint32 m_FamilyId = pKFDEventTest->GetFamilyIdFromNodeId(gpuNode);
+    int gpuIndex = Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
+    HsaEvent* m_pHsaEvent = m_pHsaEventGPU[gpuIndex];
+    HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     PM4Queue queue;
     HsaEvent *tmp_event;
     uint64_t event_age;
 
-    if (pKFDEventTest->Get_Version()->KernelInterfaceMajorVersion == 1 &&
-        pKFDEventTest->Get_Version()->KernelInterfaceMinorVersion < 14) {
+    if (Get_Version()->KernelInterfaceMajorVersion == 1 &&
+        Get_Version()->KernelInterfaceMinorVersion < 14) {
         LOG() << "event age tracking isn't supported in KFD. Exiting." << std::endl;
         return;
     }
@@ -221,7 +215,9 @@ static void SignalEventExt(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDEventTest, SignalEventExt) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(SignalEventExt));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SignalEventExt(gpuNode);
+    }));
 
     TEST_END;
 }
@@ -352,10 +348,7 @@ TEST_F(KFDEventTest, DISABLED_MeasureInterruptConsumption) {
     TEST_END;
 }
 
-static void SignalMaxEvents(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDEventTest* pKFDEventTest = (KFDEventTest*)pTestParamters->pTestObject;
+void KFDEventTest::SignalMaxEvents(int gpuNode) {
 
     static const unsigned int MAX_EVENT_NUMBER = 4095;
     uint64_t time, latency;
@@ -368,18 +361,17 @@ static void SignalMaxEvents(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDEventTest, SignalMaxEvents) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(SignalMaxEvents));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SignalMaxEvents(gpuNode);
+    }));
 
     TEST_END;
 }
 
-static void SignalMultipleEventsWaitForAll(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDEventTest::SignalMultipleEventsWaitForAll(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDEventTest* pKFDEventTest = (KFDEventTest*)pTestParamters->pTestObject;
-
-    int gpuIndex = pKFDEventTest->Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
-    HSAuint32 m_FamilyId = pKFDEventTest->GetFamilyIdFromNodeId(gpuNode);
+    int gpuIndex = Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
+    HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     static const unsigned int EVENT_NUMBER = 64;  // 64 is the maximum for hsaKmtWaitOnMultipleEvents
     static const unsigned int WAIT_BETWEEN_SUBMISSIONS_MS = 50;
@@ -416,7 +408,9 @@ static void SignalMultipleEventsWaitForAll(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDEventTest, SignalMultipleEventsWaitForAll) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(SignalMultipleEventsWaitForAll));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SignalMultipleEventsWaitForAll(gpuNode);
+    }));
 
     TEST_END;
 }
@@ -425,14 +419,11 @@ TEST_F(KFDEventTest, SignalMultipleEventsWaitForAll) {
  * gracefully and with good performance. On current GPUs and firmware it
  * should be handled on a fast path.
  */
-static void SignalInvalidEvent(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDEventTest::SignalInvalidEvent(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDEventTest* pKFDEventTest = (KFDEventTest*)pTestParamters->pTestObject;
-
-    int gpuIndex = pKFDEventTest->Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
-    HsaEvent* m_pHsaEvent = pKFDEventTest->m_pHsaEventGPU[gpuIndex];
-    HSAuint32 m_FamilyId = pKFDEventTest->GetFamilyIdFromNodeId(gpuNode);
+    int gpuIndex = Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
+    HsaEvent* m_pHsaEvent = m_pHsaEventGPU[gpuIndex];
+    HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     PM4Queue queue;
 
@@ -508,7 +499,9 @@ static void SignalInvalidEvent(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDEventTest, SignalInvalidEvent) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(SignalInvalidEvent));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SignalInvalidEvent(gpuNode);
+    }));
 
     TEST_END;
 }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDEventTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDEventTest.cpp
@@ -69,7 +69,7 @@ void KFDEventTest::CreateDestroyEvent(int gpuNode) {
 TEST_F(KFDEventTest, CreateDestroyEvent) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->CreateDestroyEvent(gpuNode);
     }));
 
@@ -99,7 +99,7 @@ void KFDEventTest::CreateMaxEvents(int gpuNode) {
 TEST_F(KFDEventTest, CreateMaxEvents) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->CreateMaxEvents(gpuNode);
     }));
 
@@ -141,7 +141,7 @@ void KFDEventTest::SignalEvent(int gpuNode) {
 TEST_F(KFDEventTest, SignalEvent) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SignalEvent(gpuNode);
     }));
 
@@ -215,7 +215,7 @@ void KFDEventTest::SignalEventExt(int gpuNode) {
 TEST_F(KFDEventTest, SignalEventExt) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SignalEventExt(gpuNode);
     }));
 
@@ -361,7 +361,7 @@ void KFDEventTest::SignalMaxEvents(int gpuNode) {
 TEST_F(KFDEventTest, SignalMaxEvents) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SignalMaxEvents(gpuNode);
     }));
 
@@ -408,7 +408,7 @@ void KFDEventTest::SignalMultipleEventsWaitForAll(int gpuNode) {
 TEST_F(KFDEventTest, SignalMultipleEventsWaitForAll) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SignalMultipleEventsWaitForAll(gpuNode);
     }));
 
@@ -499,7 +499,7 @@ void KFDEventTest::SignalInvalidEvent(int gpuNode) {
 TEST_F(KFDEventTest, SignalInvalidEvent) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SignalInvalidEvent(gpuNode);
     }));
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDEventTest.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDEventTest.hpp
@@ -31,6 +31,14 @@ class KFDEventTest :  public KFDBaseComponentTest {
     KFDEventTest(void) {}
     ~KFDEventTest(void) {}
 
+    void CreateDestroyEvent(int gpuNode);
+    void CreateMaxEvents(int gpuNode);
+    void SignalEvent(int gpuNode);
+    void SignalEventExt(int gpuNode);
+    void SignalMaxEvents(int gpuNode);
+    void SignalMultipleEventsWaitForAll(int gpuNode);
+    void SignalInvalidEvent(int gpuNode);
+
     // @brief Executed before every test in KFDEventTest.
     virtual void SetUp();
     // @brief Executed after every test in KFDEventTest.

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDExceptionTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDExceptionTest.cpp
@@ -210,7 +210,7 @@ TEST_F(KFDExceptionTest, AddressFault) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->AddressFault(gpuNode);
     }));
 
@@ -263,7 +263,7 @@ TEST_F(KFDExceptionTest, PermissionFault) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->PermissionFault(gpuNode);
     }));
 
@@ -318,7 +318,7 @@ TEST_F(KFDExceptionTest, PermissionFaultUserPointer) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->PermissionFaultUserPointer(gpuNode);
     }));
 
@@ -365,7 +365,7 @@ TEST_F(KFDExceptionTest, FaultStorm) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->FaultStorm(gpuNode);
     }));
 
@@ -426,7 +426,7 @@ TEST_F(KFDExceptionTest, SdmaQueueException) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SdmaQueueException(gpuNode);
     }));
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDExceptionTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDExceptionTest.cpp
@@ -171,12 +171,9 @@ queuefail:
     queue.Destroy();
 }
 
-void AddressFault(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDExceptionTest::AddressFault(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDExceptionTest* pKFDExceptionTest = (KFDExceptionTest*)pTestParamters->pTestObject;
-
-    const HSAuint32 m_FamilyId = pKFDExceptionTest->GetFamilyIdFromNodeId(gpuNode);
+    const HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
     if (m_FamilyId == FAMILY_RV) {
         LOG() << "Skipping test: IOMMU issues on Raven." << std::endl;
         return;
@@ -184,13 +181,13 @@ void AddressFault(KFDTEST_PARAMETERS* pTestParamters) {
 
     pid_t m_ChildPid = fork();
     if (m_ChildPid == 0) {
-        pKFDExceptionTest->TearDown();
-        pKFDExceptionTest->SetUp();
+        TearDown();
+        SetUp();
 
         HsaMemoryBuffer srcBuffer(PAGE_SIZE, gpuNode, false);
 
         srcBuffer.Fill(0xAA55AA55);
-        pKFDExceptionTest->TestMemoryException(gpuNode, srcBuffer.As<HSAuint64>(),
+        TestMemoryException(gpuNode, srcBuffer.As<HSAuint64>(),
                                                0x12345678ULL);
         exit(0);
 
@@ -213,7 +210,9 @@ TEST_F(KFDExceptionTest, AddressFault) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(AddressFault));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->AddressFault(gpuNode);
+    }));
 
     TEST_END
 }
@@ -221,12 +220,9 @@ TEST_F(KFDExceptionTest, AddressFault) {
 /* Allocate Read Only buffer. Test Memory Exception failure by
  * attempting to write to that buffer in the child process.
  */
-void PermissionFault(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDExceptionTest::PermissionFault(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDExceptionTest* pKFDExceptionTest = (KFDExceptionTest*)pTestParamters->pTestObject;
-
-    const HSAuint32 m_FamilyId = pKFDExceptionTest->GetFamilyIdFromNodeId(gpuNode);
+    const HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
     if (m_FamilyId == FAMILY_RV) {
         LOG() << "Skipping test: IOMMU issues on Raven." << std::endl;
         return;
@@ -234,8 +230,8 @@ void PermissionFault(KFDTEST_PARAMETERS* pTestParamters) {
 
     pid_t m_ChildPid = fork();
     if (m_ChildPid == 0) {
-        pKFDExceptionTest->TearDown();
-        pKFDExceptionTest->SetUp();
+        TearDown();
+        SetUp();
 
         HsaMemoryBuffer readOnlyBuffer(PAGE_SIZE, gpuNode, false /*zero*/,
                                        false /*isLocal*/, true /*isExec*/,
@@ -244,7 +240,7 @@ void PermissionFault(KFDTEST_PARAMETERS* pTestParamters) {
 
         srcSysBuffer.Fill(0xAA55AA55);
 
-        pKFDExceptionTest->TestMemoryException(gpuNode, srcSysBuffer.As<HSAuint64>(),
+        TestMemoryException(gpuNode, srcSysBuffer.As<HSAuint64>(),
                             readOnlyBuffer.As<HSAuint64>());
 
         exit(0);
@@ -267,7 +263,9 @@ TEST_F(KFDExceptionTest, PermissionFault) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(PermissionFault));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->PermissionFault(gpuNode);
+    }));
 
     TEST_END
 }
@@ -275,12 +273,9 @@ TEST_F(KFDExceptionTest, PermissionFault) {
 /* Allocate Read Only user pointer buffer. Test Memory Exception failure by
  * attempting to write to that buffer in the child process.
  */
-void PermissionFaultUserPointer(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDExceptionTest::PermissionFaultUserPointer(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDExceptionTest* pKFDExceptionTest = (KFDExceptionTest*)pTestParamters->pTestObject;
-
-    const HSAuint32 m_FamilyId = pKFDExceptionTest->GetFamilyIdFromNodeId(gpuNode);
+    const HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
     if (m_FamilyId == FAMILY_RV) {
         LOG() << "Skipping test: IOMMU issues on Raven." << std::endl;
         return;
@@ -288,8 +283,8 @@ void PermissionFaultUserPointer(KFDTEST_PARAMETERS* pTestParamters) {
 
     pid_t m_ChildPid = fork();
     if (m_ChildPid == 0) {
-        pKFDExceptionTest->TearDown();
-        pKFDExceptionTest->SetUp();
+        TearDown();
+        SetUp();
 
          void *pBuf = mmap(NULL, PAGE_SIZE, PROT_READ,
                       MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
@@ -300,7 +295,7 @@ void PermissionFaultUserPointer(KFDTEST_PARAMETERS* pTestParamters) {
 
          srcSysBuffer.Fill(0xAA55AA55);
 
-         pKFDExceptionTest->TestMemoryException(gpuNode, srcSysBuffer.As<HSAuint64>(),
+         TestMemoryException(gpuNode, srcSysBuffer.As<HSAuint64>(),
                                                 (HSAuint64)pBuf);
 
         exit(0);
@@ -323,7 +318,9 @@ TEST_F(KFDExceptionTest, PermissionFaultUserPointer) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(PermissionFault));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->PermissionFaultUserPointer(gpuNode);
+    }));
 
     TEST_END
 }
@@ -331,12 +328,9 @@ TEST_F(KFDExceptionTest, PermissionFaultUserPointer) {
 /* Test VM fault storm handling by copying to/from invalid pointers
  * with lots of work items at the same time
  */
-void FaultStorm(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDExceptionTest::FaultStorm(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDExceptionTest* pKFDExceptionTest = (KFDExceptionTest*)pTestParamters->pTestObject;
-
-    const HSAuint32 m_FamilyId = pKFDExceptionTest->GetFamilyIdFromNodeId(gpuNode);
+    const HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
     if (m_FamilyId == FAMILY_RV) {
         LOG() << "Skipping test: IOMMU issues on Raven." << std::endl;
         return;
@@ -346,10 +340,10 @@ void FaultStorm(KFDTEST_PARAMETERS* pTestParamters) {
 
     pid_t m_ChildPid = fork();
     if (m_ChildPid == 0) {
-        pKFDExceptionTest->TearDown();
-        pKFDExceptionTest->SetUp();
+        TearDown();
+        SetUp();
 
-        pKFDExceptionTest->TestMemoryException(gpuNode, 0x12345678, 0x76543210, 1024, 1024, 1);
+        TestMemoryException(gpuNode, 0x12345678, 0x76543210, 1024, 1024, 1);
 
         exit(0);
     } else {
@@ -371,19 +365,18 @@ TEST_F(KFDExceptionTest, FaultStorm) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(FaultStorm));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->FaultStorm(gpuNode);
+    }));
 
     TEST_END
 }
 
 /*
  */
-void SdmaQueueException(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDExceptionTest::SdmaQueueException(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDExceptionTest* pKFDExceptionTest = (KFDExceptionTest*)pTestParamters->pTestObject;
-
-    const HSAuint32 m_FamilyId = pKFDExceptionTest->GetFamilyIdFromNodeId(gpuNode);
+    const HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
     if (m_FamilyId == FAMILY_RV) {
         LOG() << "Skipping test: IOMMU issues on Raven." << std::endl;
         return;
@@ -396,8 +389,8 @@ void SdmaQueueException(KFDTEST_PARAMETERS* pTestParamters) {
         unsigned int* pDb = NULL;
         unsigned int *nullPtr = NULL;
 
-        pKFDExceptionTest->TearDown();
-        pKFDExceptionTest->SetUp();
+        TearDown();
+        SetUp();
 
         HsaMemFlags m_MemoryFlags;
         m_MemoryFlags.Value = 0;
@@ -411,7 +404,7 @@ void SdmaQueueException(KFDTEST_PARAMETERS* pTestParamters) {
         ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPU(pDb, PAGE_SIZE, NULL), gpuNode);
         EXPECT_SUCCESS_GPU(hsaKmtUnmapMemoryToGPU(pDb), gpuNode);
 
-        pKFDExceptionTest->TestSdmaException(gpuNode, pDb);
+        TestSdmaException(gpuNode, pDb);
         EXPECT_SUCCESS_GPU(hsaKmtFreeMemory(pDb, PAGE_SIZE), gpuNode);
 
         exit(0);
@@ -433,7 +426,9 @@ TEST_F(KFDExceptionTest, SdmaQueueException) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(SdmaQueueException));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SdmaQueueException(gpuNode);
+    }));
 
     TEST_END
 }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDExceptionTest.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDExceptionTest.hpp
@@ -49,11 +49,11 @@ class KFDExceptionTest : public KFDBaseComponentTest {
         }
     }
 
-    friend void AddressFault(KFDTEST_PARAMETERS* pTestParamters);
-    friend void PermissionFault(KFDTEST_PARAMETERS* pTestParamters);
-    friend void PermissionFaultUserPointer(KFDTEST_PARAMETERS* pTestParamters);
-    friend void FaultStorm(KFDTEST_PARAMETERS* pTestParamters);
-    friend void SdmaQueueException(KFDTEST_PARAMETERS* pTestParamters);
+    void AddressFault(int gpuNode);
+    void PermissionFault(int gpuNode);
+    void PermissionFaultUserPointer(int gpuNode);
+    void FaultStorm(int gpuNode);
+    void SdmaQueueException(int gpuNode);
 
  protected:
     virtual void SetUp();

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDGWSTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDGWSTest.cpp
@@ -42,14 +42,11 @@ void KFDGWSTest::TearDown() {
     ROUTINE_END
 }
 
-static void Allocate(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDGWSTest* pKFDGWSTest = (KFDGWSTest*)pTestParamters->pTestObject;
+void KFDGWSTest::Allocate(int gpuNode) {
 
     HSAuint32 firstGWS;
     PM4Queue queue;
-    HsaNodeInfo* m_NodeInfo = pKFDGWSTest->Get_NodeInfo();
+    HsaNodeInfo* m_NodeInfo = Get_NodeInfo();
     const HsaNodeProperties *pNodeProperties = m_NodeInfo->GetNodeProperties(gpuNode);
 
     if (!pNodeProperties || !pNodeProperties->NumGws) {
@@ -67,17 +64,16 @@ static void Allocate(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDGWSTest, Allocate) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(Allocate));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->Allocate(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void Semaphore(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDGWSTest::Semaphore(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDGWSTest* pKFDGWSTest = (KFDGWSTest*)pTestParamters->pTestObject;
-
-    HsaNodeInfo* m_NodeInfo = pKFDGWSTest->Get_NodeInfo();
+    HsaNodeInfo* m_NodeInfo = Get_NodeInfo();
     const HsaNodeProperties *pNodeProperties = m_NodeInfo->GetNodeProperties(gpuNode);
 
     HSAuint32 firstGWS;
@@ -97,7 +93,7 @@ static void Semaphore(KFDTEST_PARAMETERS* pTestParamters) {
     EXPECT_EQ_GPU(0, firstGWS, gpuNode);
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDGWSTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
     ASSERT_SUCCESS_GPU(m_pAsm->RunAssembleBuf(GwsInitIsa, isaBuffer.As<char*>()), gpuNode);
 
@@ -124,7 +120,9 @@ static void Semaphore(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDGWSTest, Semaphore) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(Semaphore));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->Semaphore(gpuNode);
+    }));
 
     TEST_END
 }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDGWSTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDGWSTest.cpp
@@ -64,7 +64,7 @@ void KFDGWSTest::Allocate(int gpuNode) {
 TEST_F(KFDGWSTest, Allocate) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->Allocate(gpuNode);
     }));
 
@@ -120,7 +120,7 @@ void KFDGWSTest::Semaphore(int gpuNode) {
 TEST_F(KFDGWSTest, Semaphore) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->Semaphore(gpuNode);
     }));
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDGWSTest.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDGWSTest.hpp
@@ -33,6 +33,9 @@ class KFDGWSTest : public KFDBaseComponentTest {
     KFDGWSTest() {}
     ~KFDGWSTest() {}
 
+    void Allocate(int gpuNode);
+    void Semaphore(int gpuNode);
+
  protected:
     virtual void SetUp();
     virtual void TearDown();

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDGraphicsInterop.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDGraphicsInterop.cpp
@@ -26,12 +26,9 @@
 #include "Dispatch.hpp"
 #include "PM4Queue.hpp"
 
-static void RegisterGraphicsHandle(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDGraphicsInterop::RegisterGraphicsHandle(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDGraphicsInterop* pKFDGraphicsInterop = (KFDGraphicsInterop*)pTestParamters->pTestObject;
-
-    HsaNodeInfo* m_NodeInfo = pKFDGraphicsInterop->Get_NodeInfo();
+    HsaNodeInfo* m_NodeInfo = Get_NodeInfo();
     const HsaNodeProperties *pNodeProps = m_NodeInfo->GetNodeProperties(gpuNode);
     const HSAuint32 familyID = FamilyIdFromNode(pNodeProps);
 
@@ -44,7 +41,7 @@ static void RegisterGraphicsHandle(KFDTEST_PARAMETERS* pTestParamters) {
 
     const char metadata[] = "This data is really meta.";
     unsigned metadata_size = strlen(metadata)+1;
-    int rn = pKFDGraphicsInterop->FindDRMRenderNode(gpuNode);
+    int rn = FindDRMRenderNode(gpuNode);
 
     if (rn < 0) {
         LOG() << "Skipping test: Could not find render node for default GPU node." << std::endl;
@@ -61,7 +58,7 @@ static void RegisterGraphicsHandle(KFDTEST_PARAMETERS* pTestParamters) {
     alloc.phys_alignment = PAGE_SIZE;
     alloc.preferred_heap = AMDGPU_GEM_DOMAIN_VRAM;
     alloc.flags = AMDGPU_GEM_CREATE_CPU_ACCESS_REQUIRED;
-    ASSERT_EQ_GPU(0, amdgpu_bo_alloc(pKFDGraphicsInterop->m_RenderNodes[rn].device_handle, &alloc, &handle), gpuNode);
+    ASSERT_EQ_GPU(0, amdgpu_bo_alloc(m_RenderNodes[rn].device_handle, &alloc, &handle), gpuNode);
 
     void *pCpuMap;
     ASSERT_EQ_GPU(0, amdgpu_bo_cpu_map(handle, &pCpuMap), gpuNode);
@@ -103,7 +100,7 @@ static void RegisterGraphicsHandle(KFDTEST_PARAMETERS* pTestParamters) {
     HsaMemoryBuffer isaBuffer(PAGE_SIZE, gpuNode, true/*zero*/, false/*local*/, true/*exec*/);
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDGraphicsInterop->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
     ASSERT_SUCCESS(m_pAsm->RunAssembleBuf(CopyDwordIsa, isaBuffer.As<char*>()));
@@ -136,10 +133,13 @@ static void RegisterGraphicsHandle(KFDTEST_PARAMETERS* pTestParamters) {
     EXPECT_SUCCESS_GPU(hsaKmtDeregisterMemory(info.MemoryAddress), gpuNode);
 
 }
+
 TEST_F(KFDGraphicsInterop, RegisterGraphicsHandle) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(RegisterGraphicsHandle));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->RegisterGraphicsHandle(gpuNode);
+    }));
 
     TEST_END
 }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDGraphicsInterop.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDGraphicsInterop.cpp
@@ -137,7 +137,7 @@ void KFDGraphicsInterop::RegisterGraphicsHandle(int gpuNode) {
 TEST_F(KFDGraphicsInterop, RegisterGraphicsHandle) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->RegisterGraphicsHandle(gpuNode);
     }));
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDGraphicsInterop.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDGraphicsInterop.hpp
@@ -32,6 +32,8 @@ class KFDGraphicsInterop :  public KFDMemoryTest {
  public:
     KFDGraphicsInterop(void) {}
     ~KFDGraphicsInterop(void) {}
+
+    void RegisterGraphicsHandle(int gpuNode);
 };
 
 #endif

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDHWSTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDHWSTest.cpp
@@ -133,7 +133,7 @@ TEST_F(KFDHWSTest, MultiProcessOversubscribed) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->RunTest(gpuNode);
     }));
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDHWSTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDHWSTest.cpp
@@ -124,19 +124,18 @@ timeout:
 
 }
 
-void RunTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDHWSTest::RunTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDHWSTest* pKKFDHWSTest = (KFDHWSTest*)pTestParamters->pTestObject;
-
-    pKKFDHWSTest->RunTest_GPU(gpuNode, 3, 13, 40);
+    RunTest_GPU(gpuNode, 3, 13, 40);
 }
 
 TEST_F(KFDHWSTest, MultiProcessOversubscribed) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(RunTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->RunTest(gpuNode);
+    }));
 
     TEST_END
 }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDHWSTest.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDHWSTest.hpp
@@ -34,8 +34,8 @@ class KFDHWSTest : public KFDMultiProcessTest {
  public:
     KFDHWSTest() {}
     ~KFDHWSTest() {}
+    void RunTest(int gpuNode);
 
-    friend void RunTest(KFDTEST_PARAMETERS* pTestParamters);
  protected:
     virtual void SetUp();
     virtual void TearDown();

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDLocalMemoryTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDLocalMemoryTest.cpp
@@ -44,15 +44,13 @@ void KFDLocalMemoryTest::TearDown() {
     ROUTINE_END
 }
 
-static void AccessLocalMem(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDLocalMemoryTest::AccessLocalMem(int gpuNode) {
 
     /* Skip test if not on dGPU path, which the test depends on */
     if (!hsakmt_is_dgpu()) {
         LOG() << "Not dGPU path, skipping the test" << std::endl;
         return;
     }
-
-    int gpuNode = pTestParamters->gpuNode;
 
     //local memory
     HsaMemoryBuffer destBuf(PAGE_SIZE, gpuNode, false, true);
@@ -75,23 +73,22 @@ static void AccessLocalMem(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDLocalMemoryTest, AccessLocalMem) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(AccessLocalMem));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->AccessLocalMem(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void BasicTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDLocalMemoryTest::BasicTest(int gpuNode) {
 
     PM4Queue queue;
     HSAuint64 AlternateVAGPU;
     unsigned int BufferSize = PAGE_SIZE;
     HsaMemMapFlags mapFlags = {0};
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDLocalMemoryTest* pKFDLocalMemoryTest = (KFDLocalMemoryTest*)pTestParamters->pTestObject;
-
     Assembler* m_pAsm;
-    m_pAsm = pKFDLocalMemoryTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
     HsaMemoryBuffer isaBuffer(PAGE_SIZE, gpuNode, true/*zero*/, false/*local*/, true/*exec*/);
@@ -138,23 +135,22 @@ TEST_F(KFDLocalMemoryTest, BasicTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(BasicTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->BasicTest(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void VerifyContentsAfterUnmapAndMap(KFDTEST_PARAMETERS* pTestParamters)
+void KFDLocalMemoryTest::VerifyContentsAfterUnmapAndMap(int gpuNode)
 {
     PM4Queue queue;
     HSAuint64 AlternateVAGPU;
     unsigned int BufferSize = PAGE_SIZE;
     HsaMemMapFlags mapFlags = {0};
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDLocalMemoryTest* pKFDLocalMemoryTest = (KFDLocalMemoryTest*)pTestParamters->pTestObject;
-
     Assembler* m_pAsm;
-    m_pAsm = pKFDLocalMemoryTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
     HsaMemoryBuffer isaBuffer(PAGE_SIZE, gpuNode, true/*zero*/, false/*local*/, true/*exec*/);
@@ -197,7 +193,9 @@ TEST_F(KFDLocalMemoryTest, VerifyContentsAfterUnmapAndMap) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(VerifyContentsAfterUnmapAndMap));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->VerifyContentsAfterUnmapAndMap(gpuNode);
+    }));
 
     TEST_END
 }
@@ -271,14 +269,11 @@ TEST_F(KFDLocalMemoryTest, VerifyContentsAfterUnmapAndMap) {
  *    20 |    1M |   4G |   10G |   40G |  10
  */
 
-static void Fragmentation(KFDTEST_PARAMETERS* pTestParamters){
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDLocalMemoryTest* pKFDLocalMemoryTest = (KFDLocalMemoryTest*)pTestParamters->pTestObject;
+void KFDLocalMemoryTest::Fragmentation(int gpuNode){
 
     HSAuint64 fbSize;
 
-    fbSize = pKFDLocalMemoryTest->GetVramSize(gpuNode);
+    fbSize = GetVramSize(gpuNode);
 
     if (!fbSize) {
         LOG() << "Skipping test: No VRAM found." << std::endl;
@@ -311,7 +306,7 @@ static void Fragmentation(KFDTEST_PARAMETERS* pTestParamters){
     HsaMemoryBuffer isaBuffer(PAGE_SIZE, gpuNode, true/*zero*/, false/*local*/, true/*exec*/);
 
     /* instantiate Assembler for gpuNode */
-    HsaNodeInfo* m_NodeInfo = pKFDLocalMemoryTest->Get_NodeInfo();
+    HsaNodeInfo* m_NodeInfo = Get_NodeInfo();
     const HsaNodeProperties *nodeProperties = m_NodeInfo->GetNodeProperties(gpuNode);
     Assembler* m_pAsm = new Assembler(GetGfxVersion(nodeProperties));
 
@@ -439,18 +434,17 @@ TEST_F(KFDLocalMemoryTest, DISABLED_Fragmentation) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(Fragmentation));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->Fragmentation(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void CheckZeroInitializationVram(KFDTEST_PARAMETERS* pTestParamters){
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDLocalMemoryTest* pKFDLocalMemoryTest = (KFDLocalMemoryTest*)pTestParamters->pTestObject;
+void KFDLocalMemoryTest::CheckZeroInitializationVram(int gpuNode){
 
     /* Testing VRAM */
-    HSAuint64 vramSizeMB = pKFDLocalMemoryTest->GetVramSize(gpuNode) >> 20;
+    HSAuint64 vramSizeMB = GetVramSize(gpuNode) >> 20;
 
    if (!vramSizeMB) {
         LOG() << "Skipping test: No VRAM found." << std::endl;
@@ -501,7 +495,9 @@ TEST_F(KFDLocalMemoryTest, CheckZeroInitializationVram) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(CheckZeroInitializationVram));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->CheckZeroInitializationVram(gpuNode);
+    }));
 
     TEST_END
 }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDLocalMemoryTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDLocalMemoryTest.cpp
@@ -73,7 +73,7 @@ void KFDLocalMemoryTest::AccessLocalMem(int gpuNode) {
 TEST_F(KFDLocalMemoryTest, AccessLocalMem) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->AccessLocalMem(gpuNode);
     }));
 
@@ -135,7 +135,7 @@ TEST_F(KFDLocalMemoryTest, BasicTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->BasicTest(gpuNode);
     }));
 
@@ -193,7 +193,7 @@ TEST_F(KFDLocalMemoryTest, VerifyContentsAfterUnmapAndMap) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->VerifyContentsAfterUnmapAndMap(gpuNode);
     }));
 
@@ -434,7 +434,7 @@ TEST_F(KFDLocalMemoryTest, DISABLED_Fragmentation) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->Fragmentation(gpuNode);
     }));
 
@@ -495,7 +495,7 @@ TEST_F(KFDLocalMemoryTest, CheckZeroInitializationVram) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->CheckZeroInitializationVram(gpuNode);
     }));
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDLocalMemoryTest.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDLocalMemoryTest.hpp
@@ -32,6 +32,11 @@ class KFDLocalMemoryTest : public KFDBaseComponentTest {
  public:
     KFDLocalMemoryTest() {}
     ~KFDLocalMemoryTest() {}
+    void AccessLocalMem(int gpuNode);
+    void BasicTest(int gpuNode);
+    void VerifyContentsAfterUnmapAndMap(int gpuNode);
+    void Fragmentation(int gpuNode);
+    void CheckZeroInitializationVram(int gpuNode);
 
  protected:
     virtual void SetUp();

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.cpp
@@ -131,7 +131,7 @@ TEST_F(KFDMemoryTest, MMapLarge) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->MMapLarge(gpuNode);
     }));
 
@@ -214,7 +214,7 @@ void KFDMemoryTest::MapUnmapToNodes(int gpuNode) {
 TEST_F(KFDMemoryTest, MapUnmapToNodes) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         MapUnmapToNodes(gpuNode);
     }));
 
@@ -240,7 +240,7 @@ void KFDMemoryTest::MapMemoryToGPU(int gpuNode) {
 TEST_F(KFDMemoryTest, MapMemoryToGPU) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->MapMemoryToGPU(gpuNode);
     }));
 
@@ -318,7 +318,7 @@ void KFDMemoryTest::MemoryAllocAll(int gpuNode) {
 TEST_F(KFDMemoryTest, MemoryAllocAll) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->MemoryAllocAll(gpuNode);
     }));
 
@@ -366,7 +366,7 @@ void KFDMemoryTest::AccessPPRMem(int gpuNode) {
 TEST_F(KFDMemoryTest, AccessPPRMem) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->AccessPPRMem(gpuNode);
     }));
 
@@ -478,7 +478,7 @@ void KFDMemoryTest::MemoryRegister(int gpuNode) {
 TEST_F(KFDMemoryTest, MemoryRegister) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->MemoryRegister(gpuNode);
     }));
 
@@ -553,7 +553,7 @@ void KFDMemoryTest::MemoryRegisterSamePtr(int gpuNode) {
 TEST_F(KFDMemoryTest, MemoryRegisterSamePtr) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->MemoryRegisterSamePtr(gpuNode);
     }));
 
@@ -672,7 +672,7 @@ void KFDMemoryTest::FlatScratchAccess(int gpuNode) {
 TEST_F(KFDMemoryTest, FlatScratchAccess) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->FlatScratchAccess(gpuNode);
     }));
 
@@ -712,7 +712,7 @@ void KFDMemoryTest::GetTileConfigTest(int gpuNode) {
 TEST_F(KFDMemoryTest, GetTileConfigTest) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->GetTileConfigTest(gpuNode);
     }));
 
@@ -814,7 +814,7 @@ TEST_F(KFDMemoryTest, LargestSysBufferTest) {
      TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	 TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->LargestSysBufferTest(gpuNode);
     }));
 
@@ -860,7 +860,7 @@ TEST_F(KFDMemoryTest, LargestVramBufferTest) {
      TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	 TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->LargestVramBufferTest(gpuNode);
     }));
 
@@ -927,7 +927,7 @@ TEST_F(KFDMemoryTest, BigSysBufferStressTest) {
      TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	 TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->BigSysBufferStressTest(gpuNode);
     }));
 
@@ -1171,7 +1171,7 @@ TEST_F(KFDMemoryTest, MMBench) {
      TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	 TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->MMBench(gpuNode);
     }));
 
@@ -1275,7 +1275,7 @@ TEST_F(KFDMemoryTest, QueryPointerInfo) {
 
 	 TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
             this->QueryPointerInfo(gpuNode);
     }));
 
@@ -1430,7 +1430,7 @@ void KFDMemoryTest::PtraceAccess(int gpuNode) {
 TEST_F(KFDMemoryTest, PtraceAccess) {
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->PtraceAccess(gpuNode);
     }));
 
@@ -1586,7 +1586,7 @@ void KFDMemoryTest::PtraceAccessInvisibleVram(int gpuNode) {
 TEST_F(KFDMemoryTest, PtraceAccessInvisibleVram) {
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->PtraceAccessInvisibleVram(gpuNode);
     }));
 
@@ -1677,7 +1677,7 @@ void KFDMemoryTest::SignalHandling(int gpuNode) {
 TEST_F(KFDMemoryTest, SignalHandling) {
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SignalHandling(gpuNode);
     }));
 
@@ -1748,7 +1748,7 @@ TEST_F(KFDMemoryTest, CheckZeroInitializationSysMem) {
 	TEST_START(TESTPROFILE_RUNALL);
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->CheckZeroInitializationSysMem(gpuNode);
     }));
 
@@ -1906,7 +1906,7 @@ TEST_F(KFDMemoryTest, MMBandWidth) {
 	TEST_START(TESTPROFILE_RUNALL);
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->MMBandWidth(gpuNode);
     }));
 
@@ -2010,7 +2010,7 @@ TEST_F(KFDMemoryTest, HostHdpFlush) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->HostHdpFlush(gpuNode);
     }));
 
@@ -2167,7 +2167,7 @@ TEST_F(KFDMemoryTest, DeviceHdpFlush) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->DeviceHdpFlush(gpuNode);
     }));
 
@@ -2236,7 +2236,7 @@ TEST_F(KFDMemoryTest, CacheInvalidateOnSdmaWrite) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->CacheInvalidateOnSdmaWrite(gpuNode);
     }));
 
@@ -2302,7 +2302,7 @@ TEST_F(KFDMemoryTest, CacheInvalidateOnCPUWrite) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->CacheInvalidateOnCPUWrite(gpuNode);
     }));
 
@@ -2390,7 +2390,7 @@ TEST_F(KFDMemoryTest, CacheInvalidateOnRemoteWrite) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->CacheInvalidateOnRemoteWrite(gpuNode);
     }));
 
@@ -2487,7 +2487,7 @@ TEST_F(KFDMemoryTest, VramCacheCoherenceWithRemoteGPU) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->VramCacheCoherenceWithRemoteGPU(gpuNode); 
     }));
 
@@ -2563,7 +2563,7 @@ TEST_F(KFDMemoryTest, VramCacheCoherenceWithCPU) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->VramCacheCoherenceWithCPU(gpuNode);
     }));
 
@@ -2642,7 +2642,7 @@ TEST_F(KFDMemoryTest, SramCacheCoherenceWithGPU) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SramCacheCoherenceWithGPU(gpuNode);
     }));
 
@@ -3137,7 +3137,7 @@ TEST_F(KFDMemoryTest, ExportDMABufTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->ExportDMABufTest(gpuNode);
     }));
 
@@ -3193,7 +3193,7 @@ TEST_F(KFDMemoryTest, VA_VRAM_Only_AllocTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->VA_VRAM_Only_AllocTest(gpuNode);
     }));
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.cpp
@@ -70,10 +70,7 @@ void KFDMemoryTest::TearDown() {
  * NOTICE: There are memory usage limit checks in hsa/kfd according to the total
  * physical system memory.
  */
-static void MMapLarge(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::MMapLarge(int gpuNode) {
 
     if (!hsakmt_is_dgpu()) {
         LOG() << "Skipping test: Test not supported on APU." << std::endl;
@@ -134,7 +131,9 @@ TEST_F(KFDMemoryTest, MMapLarge) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(MMapLarge));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->MMapLarge(gpuNode);
+    }));
 
     TEST_END
 }
@@ -156,11 +155,9 @@ TEST_F(KFDMemoryTest, MMapLarge) {
  * is a gpu vm fault while running rocr conformance test. Here we try to simulate the
  * same test behaviour.
  */
-static void MapUnmapToNodes(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDMemoryTest::MapUnmapToNodes(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
-	HSAuint32 m_FamilyId = pKFDMemoryTest->GetFamilyIdFromNodeId(gpuNode);
+	HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     if (m_FamilyId < FAMILY_AI) {
         LOG() << "Skipping test: Test requires gfx9 and later asics." << std::endl;
@@ -168,10 +165,10 @@ static void MapUnmapToNodes(KFDTEST_PARAMETERS* pTestParamters) {
     }
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDMemoryTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
-    const std::vector<int> gpuNodes = pKFDMemoryTest->Get_NodeInfo()->GetNodesWithGPU();
+    const std::vector<int> gpuNodes = Get_NodeInfo()->GetNodesWithGPU();
     if (gpuNodes.size() < 2) {
         LOG() << "Skipping test: At least two GPUs are required." << std::endl;
         return;
@@ -217,21 +214,20 @@ static void MapUnmapToNodes(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDMemoryTest, MapUnmapToNodes) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(MapUnmapToNodes));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        MapUnmapToNodes(gpuNode);
+    }));
 
     TEST_END
 }
 
 // Basic test of hsaKmtMapMemoryToGPU and hsaKmtUnmapMemoryToGPU
-static void MapMemoryToGPU(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::MapMemoryToGPU(int gpuNode) {
 
     unsigned int *nullPtr = NULL;
     unsigned int* pDb = NULL;
 
-    ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(gpuNode /* system */, PAGE_SIZE, pKFDMemoryTest->GetHsaMemFlags(),
+    ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(gpuNode /* system */, PAGE_SIZE, GetHsaMemFlags(),
                    reinterpret_cast<void**>(&pDb)), gpuNode);
     // verify that pDb is not null before it's being used
     ASSERT_NE_GPU(nullPtr, pDb, gpuNode) << "hsaKmtAllocMemory returned a null pointer";
@@ -244,7 +240,9 @@ static void MapMemoryToGPU(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDMemoryTest, MapMemoryToGPU) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(MapMemoryToGPU));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->MapMemoryToGPU(gpuNode);
+    }));
 
     TEST_END
 }
@@ -282,16 +280,13 @@ TEST_F(KFDMemoryTest, MemoryAlloc) {
 }
 
 // Basic test for hsaKmtAllocMemory
-static void MemoryAllocAll(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::MemoryAllocAll(int gpuNode) {
 
     HsaMemFlags memFlags = {0};
     memFlags.ui32.NonPaged = 1; // sys mem vs vram
     HSAuint64 available;
 
-    if (pKFDMemoryTest->Get_Version()->KernelInterfaceMinorVersion < 9) {
+    if (Get_Version()->KernelInterfaceMinorVersion < 9) {
         LOG() << "Available memory IOCTL not present in KFD. Exiting." << std::endl;
         return;
     }
@@ -323,15 +318,14 @@ static void MemoryAllocAll(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDMemoryTest, MemoryAllocAll) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(MemoryAllocAll));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->MemoryAllocAll(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void AccessPPRMem(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::AccessPPRMem(int gpuNode) {
 
     if (hsakmt_is_dgpu()) {
         LOG() << "Skipping test: Test requires APU." << std::endl;
@@ -372,22 +366,21 @@ static void AccessPPRMem(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDMemoryTest, AccessPPRMem) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(AccessPPRMem));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->AccessPPRMem(gpuNode);
+    }));
 
     TEST_END
 }
 
 // Linux OS-specific Test for registering OS allocated memory
-static void MemoryRegister(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::MemoryRegister(int gpuNode) {
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDMemoryTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
-	const HsaNodeProperties *pNodeProperties = pKFDMemoryTest->Get_NodeInfo()->GetNodeProperties(gpuNode);
+	const HsaNodeProperties *pNodeProperties = Get_NodeInfo()->GetNodeProperties(gpuNode);
 
     /* Different unaligned memory locations to be mapped for GPU
      * access:
@@ -485,28 +478,27 @@ static void MemoryRegister(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDMemoryTest, MemoryRegister) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(MemoryRegister));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->MemoryRegister(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void MemoryRegisterSamePtr(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::MemoryRegisterSamePtr(int gpuNode) {
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDMemoryTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
-	HSAuint32 m_FamilyId = pKFDMemoryTest->GetFamilyIdFromNodeId(gpuNode);
+	HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     if (!hsakmt_is_dgpu()) {
         LOG() << "Skipping test: Will run on APU once APU+dGPU supported." << std::endl;
         return;
     }
 
-    const std::vector<int> gpuNodes = pKFDMemoryTest->Get_NodeInfo()->GetNodesWithGPU();
+    const std::vector<int> gpuNodes = Get_NodeInfo()->GetNodesWithGPU();
     HSAuint64 nGPU = gpuNodes.size();  // number of gpu nodes
     static volatile HSAuint32 mem[4];
     HSAuint64 gpuva1, gpuva2;
@@ -561,7 +553,9 @@ static void MemoryRegisterSamePtr(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDMemoryTest, MemoryRegisterSamePtr) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(MemoryRegisterSamePtr));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->MemoryRegisterSamePtr(gpuNode);
+    }));
 
     TEST_END
 }
@@ -577,19 +571,16 @@ TEST_F(KFDMemoryTest, MemoryRegisterSamePtr) {
 #define SCRATCH_SIZE (SCRATCH_SLICE_NUM * SCRATCH_SLICE_SIZE)
 #define SCRATCH_SLICE_OFFSET(i) ((i) * SCRATCH_SLICE_SIZE)
 
-static void FlatScratchAccess(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDMemoryTest::FlatScratchAccess(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
-
-	HSAuint32 m_FamilyId = pKFDMemoryTest->GetFamilyIdFromNodeId(gpuNode);
+	HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
     if (m_FamilyId == FAMILY_CI || m_FamilyId == FAMILY_KV) {
         LOG() << "Skipping test: VI-based shader not supported on other ASICs." << std::endl;
         return;
     }
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDMemoryTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
     HsaMemoryBuffer isaBuffer(PAGE_SIZE, gpuNode, true/*zero*/, false/*local*/, true/*exec*/);
@@ -622,7 +613,7 @@ static void FlatScratchAccess(KFDTEST_PARAMETERS* pTestParamters) {
 
     ASSERT_SUCCESS_GPU(m_pAsm->RunAssembleBuf(ScratchCopyDwordIsa, isaBuffer.As<char*>()), gpuNode);
 
-    const HsaNodeProperties *pNodeProperties = pKFDMemoryTest->Get_NodeInfo()->GetNodeProperties(gpuNode);
+    const HsaNodeProperties *pNodeProperties = Get_NodeInfo()->GetNodeProperties(gpuNode);
 
     /* TODO: Add support to all GPU Nodes.
      * The loop over the system nodes is removed as the test can be executed only on GPU nodes. This
@@ -681,15 +672,14 @@ static void FlatScratchAccess(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDMemoryTest, FlatScratchAccess) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(FlatScratchAccess));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->FlatScratchAccess(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void GetTileConfigTest(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::GetTileConfigTest(int gpuNode) {
 
     HSAuint32 tile_config[32] = {0};
     HSAuint32 macro_tile_config[16] = {0};
@@ -722,12 +712,14 @@ static void GetTileConfigTest(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDMemoryTest, GetTileConfigTest) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(GetTileConfigTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->GetTileConfigTest(gpuNode);
+    }));
 
     TEST_END
 }
 
-void SearchLargestBuffer(int allocNode, const HsaMemFlags &memFlags,
+void KFDMemoryTest::SearchLargestBuffer(int allocNode, const HsaMemFlags &memFlags,
                                         HSAuint64 highMB, int nodeToMap,
                                         HSAuint64 *lastSizeMB) {
     int ret;
@@ -788,17 +780,14 @@ void SearchLargestBuffer(int allocNode, const HsaMemFlags &memFlags,
  * In that situation, it will take too much time to finish the test because of
  * the onerous memory swap operation. So we limit the buffer size that way.
  */
-static void LargestSysBufferTest(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::LargestSysBufferTest(int gpuNode) {
 
     if (!hsakmt_is_dgpu()) {
         LOG() << "Skipping test: Running on APU fails and locks the system." << std::endl;
         return;
     }
 
-    int gpuNum = pKFDMemoryTest->Get_NodeInfo()->GetNodesWithGPU().size();
+    int gpuNum = Get_NodeInfo()->GetNodesWithGPU().size();
 
 	/* if no gpu node */
 	if (gpuNum <= 0)
@@ -807,14 +796,14 @@ static void LargestSysBufferTest(KFDTEST_PARAMETERS* pTestParamters) {
     HSAuint64 lastTestedSizeMB = 0;
 
     HSAuint64 sysMemSizeMB;
-    sysMemSizeMB = pKFDMemoryTest->GetSysMemSize() >> 20;
+    sysMemSizeMB = GetSysMemSize() >> 20;
 
     sysMemSizeMB/=gpuNum;
 
     LOG() << "Found System Memory of " << std::dec << sysMemSizeMB
                     << "MB. Using 95% of that for the test" << std::endl;
 
-    SearchLargestBuffer(0, pKFDMemoryTest->GetHsaMemFlags(), sysMemSizeMB*0.95, gpuNode,
+    SearchLargestBuffer(0, GetHsaMemFlags(), sysMemSizeMB*0.95, gpuNode,
                     &lastTestedSizeMB);
 
     LOG() << "The largest allocated system buffer is " << std::dec
@@ -825,15 +814,14 @@ TEST_F(KFDMemoryTest, LargestSysBufferTest) {
      TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	 TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(LargestSysBufferTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->LargestSysBufferTest(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void LargestVramBufferTest(KFDTEST_PARAMETERS* pTestParamters) {
-
-   int gpuNode = pTestParamters->gpuNode;
-   KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::LargestVramBufferTest(int gpuNode) {
 
     if (!hsakmt_is_dgpu()) {
         LOG() << "Skipping test: Running on APU fails and locks the system." << std::endl;
@@ -847,7 +835,7 @@ static void LargestVramBufferTest(KFDTEST_PARAMETERS* pTestParamters) {
     memFlags.ui32.NonPaged = 1;
 
     HSAuint64 vramSizeMB;
-    vramSizeMB = pKFDMemoryTest->GetVramSize(gpuNode) >> 20;
+    vramSizeMB = GetVramSize(gpuNode) >> 20;
 
     LOG() << "Found VRAM of " << std::dec << vramSizeMB << "MB." << std::endl;
 
@@ -872,7 +860,9 @@ TEST_F(KFDMemoryTest, LargestVramBufferTest) {
      TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	 TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(LargestVramBufferTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->LargestVramBufferTest(gpuNode);
+    }));
 
     TEST_END
 }
@@ -881,10 +871,7 @@ TEST_F(KFDMemoryTest, LargestVramBufferTest) {
  * fails, then unmaps and frees them afterwards. Meanwhile, a queue task is
  * performed on each buffer.
  */
-static void BigSysBufferStressTest(KFDTEST_PARAMETERS* pTestParamters) {
-
-   int gpuNode = pTestParamters->gpuNode;
-   KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::BigSysBufferStressTest(int gpuNode) {
 
     if (!hsakmt_is_dgpu()) {
         LOG() << "Skipping test: Running on APU fails and locks the system." << std::endl;
@@ -909,7 +896,7 @@ static void BigSysBufferStressTest(KFDTEST_PARAMETERS* pTestParamters) {
     for (int repeat = 1; repeat < 5; repeat++) {
 
         for (i = 0; i < ARRAY_ENTRIES; i++) {
-            ret = hsaKmtAllocMemory(0 /* system */, block_size, pKFDMemoryTest->GetHsaMemFlags(),
+            ret = hsaKmtAllocMemory(0 /* system */, block_size, GetHsaMemFlags(),
                     reinterpret_cast<void**>(&pDb_array[i]));
             if (ret)
                 break;
@@ -940,16 +927,15 @@ TEST_F(KFDMemoryTest, BigSysBufferStressTest) {
      TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	 TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(LargestVramBufferTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->BigSysBufferStressTest(gpuNode);
+    }));
 
     TEST_END
 }
 
 #define VRAM_ALLOCATION_ALIGN (1 << 21)  //Align VRAM allocations to 2MB
-static void MMBench(KFDTEST_PARAMETERS* pTestParamters) {
-
-   int gpuNode = pTestParamters->gpuNode;
-   KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::MMBench(int gpuNode) {
 
     unsigned testIndex, sizeIndex, memType, nMemTypes;
     const char *memTypeStrings[2] = {"SysMem", "VRAM"};
@@ -982,13 +968,13 @@ static void MMBench(KFDTEST_PARAMETERS* pTestParamters) {
     HsaMemMapFlags mapFlags = {0};
     HSAuint64 altVa;
 
-    HSAuint64 vramSizeMB = pKFDMemoryTest->GetVramSize(gpuNode) >> 20;
+    HSAuint64 vramSizeMB = GetVramSize(gpuNode) >> 20;
 
-    const std::vector<int> gpuNodes = pKFDMemoryTest->Get_NodeInfo()->GetNodesWithGPU();
+    const std::vector<int> gpuNodes = Get_NodeInfo()->GetNodesWithGPU();
     bool is_all_large_bar = true;
 
     for (unsigned i = 0; i < gpuNodes.size(); i++) {
-        if (!pKFDMemoryTest->Get_NodeInfo()->IsGPUNodeLargeBar(gpuNodes.at(i))) {
+        if (!Get_NodeInfo()->IsGPUNodeLargeBar(gpuNodes.at(i))) {
                 is_all_large_bar = false;
                 break;
         }
@@ -1185,19 +1171,18 @@ TEST_F(KFDMemoryTest, MMBench) {
      TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	 TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(MMBench));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->MMBench(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void QueryPointerInfo(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::QueryPointerInfo(int gpuNode) {
 
     unsigned int bufSize = PAGE_SIZE * 8;  // CZ and Tonga need 8 pages
     HsaPointerInfo ptrInfo;
-    const std::vector<int> gpuNodes = pKFDMemoryTest->Get_NodeInfo()->GetNodesWithGPU();
+    const std::vector<int> gpuNodes = Get_NodeInfo()->GetNodesWithGPU();
     HSAuint64 nGPU = gpuNodes.size();  // number of gpu nodes
 
     /* GraphicHandle is tested at KFDGraphicsInterop.RegisterGraphicsHandle */
@@ -1221,7 +1206,7 @@ static void QueryPointerInfo(KFDTEST_PARAMETERS* pTestParamters) {
     EXPECT_EQ_GPU((HSAuint64)ptrInfo.NMappedNodes, 0, gpuNode);
 
     /* Skip testing local memory if the platform does not have it */
-    if (pKFDMemoryTest->GetVramSize(gpuNode)) {
+    if (GetVramSize(gpuNode)) {
         HsaMemoryBuffer localBuffer(bufSize, gpuNode, false, true);
         EXPECT_SUCCESS_GPU(hsaKmtQueryPointerInfo(localBuffer.As<void*>(), &ptrInfo), gpuNode);
         EXPECT_EQ_GPU(ptrInfo.Type, HSA_POINTER_ALLOCATED, gpuNode);
@@ -1290,7 +1275,9 @@ TEST_F(KFDMemoryTest, QueryPointerInfo) {
 
 	 TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(QueryPointerInfo));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+            this->QueryPointerInfo(gpuNode);
+    }));
 
     TEST_END
 }
@@ -1305,10 +1292,7 @@ TEST_F(KFDMemoryTest, QueryPointerInfo) {
  * the child terminates, the parent checks that the copy was
  * successful.
  */
-static void PtraceAccess(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::PtraceAccess(int gpuNode) {
 
     HsaMemFlags memFlags = {0};
     memFlags.ui32.PageSize = HSA_PAGE_SIZE_4KB;
@@ -1335,7 +1319,7 @@ static void PtraceAccess(KFDTEST_PARAMETERS* pTestParamters) {
 
     // Try to alloc local memory from GPU node
     memFlags.ui32.NonPaged = 1;
-    if (pKFDMemoryTest->Get_NodeInfo()->IsGPUNodeLargeBar(gpuNode)) {
+    if (Get_NodeInfo()->IsGPUNodeLargeBar(gpuNode)) {
         EXPECT_SUCCESS_GPU(hsaKmtAllocMemory(gpuNode, PAGE_SIZE*2 + (4 << 20),
                                             memFlags, &mem[1]), gpuNode);
         mem[1] = reinterpret_cast<void *>(reinterpret_cast<HSAuint8 *>(mem[1]) + VRAM_OFFSET);
@@ -1446,21 +1430,20 @@ static void PtraceAccess(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDMemoryTest, PtraceAccess) {
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(PtraceAccess));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->PtraceAccess(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void PtraceAccessInvisibleVram(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::PtraceAccessInvisibleVram(int gpuNode) {
 
 	Assembler* m_pAsm;
-	m_pAsm = pKFDMemoryTest->GetAssemblerFromNodeId(gpuNode);
+	m_pAsm = GetAssemblerFromNodeId(gpuNode);
 	ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
-    HSAuint32 m_FamilyId = pKFDMemoryTest->GetFamilyIdFromNodeId(gpuNode);
+    HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     char *hsaDebug = getenv("HSA_DEBUG");
 
@@ -1603,7 +1586,9 @@ static void PtraceAccessInvisibleVram(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDMemoryTest, PtraceAccessInvisibleVram) {
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(PtraceAccessInvisibleVram));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->PtraceAccessInvisibleVram(gpuNode);
+    }));
 
     TEST_END
 }
@@ -1614,10 +1599,7 @@ void CatchSignal(int IntrSignal) {
     IntrSignalReceviced = IntrSignal;
 }
 
-static void SignalHandling(KFDTEST_PARAMETERS* pTestParamters) {
-
-	int gpuNode = pTestParamters->gpuNode;
-	KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::SignalHandling(int gpuNode) {
 
     if (!hsakmt_is_dgpu()) {
         LOG() << "Skipping test: Test not supported on APU." << std::endl;
@@ -1636,7 +1618,7 @@ static void SignalHandling(KFDTEST_PARAMETERS* pTestParamters) {
     pid_t ParentPid = getpid();
     EXPECT_EQ(0, sigaction(SIGUSR1, &sa, NULL)) << "An error occurred while setting a signal handler";
 
-    sysMemSize = pKFDMemoryTest->GetSysMemSize();
+    sysMemSize = GetSysMemSize();
 
     /* System (kernel) memory are limited to 3/8th System RAM
      * Try to allocate 1/4th System RAM
@@ -1649,8 +1631,8 @@ static void SignalHandling(KFDTEST_PARAMETERS* pTestParamters) {
      */
     size = size > (3ULL << 30) ? (3ULL << 30) : size;
 
-    pKFDMemoryTest->GetHsaMemFlags().ui32.NoNUMABind = 1;
-    ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(0 /* system */, size, pKFDMemoryTest->GetHsaMemFlags(), reinterpret_cast<void**>(&pDb)), gpuNode);
+    GetHsaMemFlags().ui32.NoNUMABind = 1;
+    ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(0 /* system */, size, GetHsaMemFlags(), reinterpret_cast<void**>(&pDb)), gpuNode);
     // Verify that pDb is not null before it's being used
     EXPECT_NE_GPU(nullPtr, pDb, gpuNode) << "hsaKmtAllocMemory returned a null pointer";
 
@@ -1695,25 +1677,24 @@ static void SignalHandling(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDMemoryTest, SignalHandling) {
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(SignalHandling));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SignalHandling(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void CheckZeroInitializationSysMem(KFDTEST_PARAMETERS* pTestParamters) {
-
-	int gpuNode = pTestParamters->gpuNode;
-	KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::CheckZeroInitializationSysMem(int gpuNode) {
 
     int ret;
 
-    int gpuNum = pKFDMemoryTest->Get_NodeInfo()->GetNodesWithGPU().size();
+    int gpuNum = Get_NodeInfo()->GetNodesWithGPU().size();
 
 	/* if no gpu node */
 	if (gpuNum <= 0)
 		return;
 
-    HSAuint64 sysMemSizeMB = pKFDMemoryTest->GetSysMemSize() >> 20;
+    HSAuint64 sysMemSizeMB = GetSysMemSize() >> 20;
 
     /* Testing system memory */
     HSAuint64 * pDb = NULL;
@@ -1733,10 +1714,10 @@ static void CheckZeroInitializationSysMem(KFDTEST_PARAMETERS* pTestParamters) {
     unsigned int offset = 257;  // a constant offset, should be smaller than 512.
     unsigned int size = sysBufSizePerGPU / sizeof(*pDb);
 
-    pKFDMemoryTest->GetHsaMemFlags().ui32.NoNUMABind = 1;
+    GetHsaMemFlags().ui32.NoNUMABind = 1;
 
     while (count--) {
-        ret = hsaKmtAllocMemory(0 /* system */, sysBufSizePerGPU, pKFDMemoryTest->GetHsaMemFlags(),
+        ret = hsaKmtAllocMemory(0 /* system */, sysBufSizePerGPU, GetHsaMemFlags(),
                                 reinterpret_cast<void**>(&pDb));
         if (ret) {
             LOG() << "Failed to allocate system buffer of" << std::dec << sysBufSizeMB
@@ -1767,7 +1748,9 @@ TEST_F(KFDMemoryTest, CheckZeroInitializationSysMem) {
 	TEST_START(TESTPROFILE_RUNALL);
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 
-    ASSERT_SUCCESS(KFDTest_Launch(CheckZeroInitializationSysMem));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->CheckZeroInitializationSysMem(gpuNode);
+    }));
 
     TEST_END
 }
@@ -1790,10 +1773,7 @@ static inline void access(volatile void *sd, int size, int rw) {
  * On large-bar system, test the visible vram access speed.
  * KFD is not allowed to alloc visible vram on non-largebar system.
  */
-static void MMBandWidth(KFDTEST_PARAMETERS* pTestParamters) {
-
-	int gpuNode = pTestParamters->gpuNode;
-	KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::MMBandWidth(int gpuNode) {
 
     unsigned nBufs = 1000; /* measure us, report ns */
     unsigned testIndex, sizeIndex, memType;
@@ -1813,11 +1793,11 @@ static void MMBandWidth(KFDTEST_PARAMETERS* pTestParamters) {
     HsaMemFlags memFlags = {0};
     HsaMemMapFlags mapFlags = {0};
 
-    HSAuint64 vramSizeMB = pKFDMemoryTest->GetVramSize(gpuNode) >> 20;
+    HSAuint64 vramSizeMB = GetVramSize(gpuNode) >> 20;
 
     LOG() << "Found VRAM of " << std::dec << vramSizeMB << "MB." << std::endl;
 
-    if (!pKFDMemoryTest->Get_NodeInfo()->IsGPUNodeLargeBar(gpuNode) || !vramSizeMB) {
+    if (!Get_NodeInfo()->IsGPUNodeLargeBar(gpuNode) || !vramSizeMB) {
         LOG() << "Skipping test: Test requires a large bar GPU." << std::endl;
         return;
     }
@@ -1926,7 +1906,9 @@ TEST_F(KFDMemoryTest, MMBandWidth) {
 	TEST_START(TESTPROFILE_RUNALL);
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 
-    ASSERT_SUCCESS(KFDTest_Launch(MMBandWidth));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->MMBandWidth(gpuNode);
+    }));
 
     TEST_END
 }
@@ -1938,23 +1920,20 @@ TEST_F(KFDMemoryTest, MMBandWidth) {
  * HDP flush so only run on vega10 and after.
  * This should only run on large bar system.
  */
-static void HostHdpFlush(KFDTEST_PARAMETERS* pTestParamters) {
-
-	int gpuNode = pTestParamters->gpuNode;
-	KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::HostHdpFlush(int gpuNode) {
 
 	Assembler* m_pAsm;
-	m_pAsm = pKFDMemoryTest->GetAssemblerFromNodeId(gpuNode);
+	m_pAsm = GetAssemblerFromNodeId(gpuNode);
 	ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
-	HSAuint32 m_FamilyId = pKFDMemoryTest->GetFamilyIdFromNodeId(gpuNode);
+	HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
-    HsaMemFlags memoryFlags = pKFDMemoryTest->GetHsaMemFlags();
+    HsaMemFlags memoryFlags = GetHsaMemFlags();
     /* buffer[0]: signal; buffer[1]: Input to shader; buffer[2]: Output to
      * shader
      */
     unsigned int *buffer = NULL;
-    const HsaNodeProperties *pNodeProperties = pKFDMemoryTest->Get_NodeInfo()->GetNodeProperties(gpuNode);
+    const HsaNodeProperties *pNodeProperties = Get_NodeInfo()->GetNodeProperties(gpuNode);
     HSAuint32 *mmioBase = NULL;
     unsigned int *nullPtr = NULL;
 
@@ -1967,9 +1946,9 @@ static void HostHdpFlush(KFDTEST_PARAMETERS* pTestParamters) {
         LOG() << "Skipping test: Test requires gfx9 and later asics." << std::endl;
         return;
     }
-    HSAuint64 vramSizeMB = pKFDMemoryTest->GetVramSize(gpuNode) >> 20;
+    HSAuint64 vramSizeMB = GetVramSize(gpuNode) >> 20;
 
-    if (!pKFDMemoryTest->Get_NodeInfo()->IsGPUNodeLargeBar(gpuNode) || !vramSizeMB) {
+    if (!Get_NodeInfo()->IsGPUNodeLargeBar(gpuNode) || !vramSizeMB) {
         LOG() << "Skipping test: Test requires a large bar GPU." << std::endl;
         return;
     }
@@ -2031,7 +2010,9 @@ TEST_F(KFDMemoryTest, HostHdpFlush) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(HostHdpFlush));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->HostHdpFlush(gpuNode);
+    }));
 
     TEST_END
 }
@@ -2045,17 +2026,14 @@ TEST_F(KFDMemoryTest, HostHdpFlush) {
  * This should only run on system with at least one
  * large bar node (which is used as device 0).
  */
-static void DeviceHdpFlush(KFDTEST_PARAMETERS* pTestParamters) {
-
-	int gpuNode = pTestParamters->gpuNode;
-	KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::DeviceHdpFlush(int gpuNode) {
 
 	Assembler* m_pAsm;
-	m_pAsm = pKFDMemoryTest->GetAssemblerFromNodeId(gpuNode);
+	m_pAsm = GetAssemblerFromNodeId(gpuNode);
 	ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
-	HSAuint32 m_FamilyId = pKFDMemoryTest->GetFamilyIdFromNodeId(gpuNode);
-    HsaMemFlags memoryFlags = pKFDMemoryTest->GetHsaMemFlags();
+	HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
+    HsaMemFlags memoryFlags = GetHsaMemFlags();
     /* buffer is physically on device 0.
      * buffer[0]: Use as signaling b/t devices;
      * buffer[1]: Device 1 write to buffer[1] and device 0 read it
@@ -2068,7 +2046,7 @@ static void DeviceHdpFlush(KFDTEST_PARAMETERS* pTestParamters) {
     std::vector<int> nodes;
     int numPeers;
 
-    const std::vector<int> gpuNodes = pKFDMemoryTest->Get_NodeInfo()->GetNodesWithGPU();
+    const std::vector<int> gpuNodes = Get_NodeInfo()->GetNodesWithGPU();
     if (gpuNodes.size() < 2) {
         LOG() << "Skipping test: At least two GPUs are required." << std::endl;
         return;
@@ -2079,7 +2057,7 @@ static void DeviceHdpFlush(KFDTEST_PARAMETERS* pTestParamters) {
         nodes.push_back(g_TestNodeId);
         nodes.push_back(g_TestDstNodeId);
 
-        if (!pKFDMemoryTest->Get_NodeInfo()->IsPeerAccessibleByNode(g_TestDstNodeId, g_TestNodeId)) {
+        if (!Get_NodeInfo()->IsPeerAccessibleByNode(g_TestDstNodeId, g_TestNodeId)) {
             LOG() << "Skipping test: first GPU specified is not peer-accessible." << std::endl;
             return;
         }
@@ -2089,7 +2067,7 @@ static void DeviceHdpFlush(KFDTEST_PARAMETERS* pTestParamters) {
             return;
         }
     } else {
-        pKFDMemoryTest->Get_NodeInfo()->FindAccessiblePeers(&nodes, gpuNode);
+        Get_NodeInfo()->FindAccessiblePeers(&nodes, gpuNode);
         if (nodes.size() < 2) {
             LOG() << "Skipping test: Test requires at least one large bar GPU." << std::endl;
             LOG() << "               or two GPUs are XGMI connected." << std::endl;
@@ -2100,8 +2078,8 @@ static void DeviceHdpFlush(KFDTEST_PARAMETERS* pTestParamters) {
     const HsaNodeProperties *pNodePropertiesDev1 = NULL;
     unsigned int m_FamilyIdDev1 = 0;
 
-    pNodeProperties = pKFDMemoryTest->Get_NodeInfo()->GetNodeProperties(nodes[0]);
-    pNodePropertiesDev1 = pKFDMemoryTest->Get_NodeInfo()->GetNodeProperties(nodes[1]);
+    pNodeProperties = Get_NodeInfo()->GetNodeProperties(nodes[0]);
+    pNodePropertiesDev1 = Get_NodeInfo()->GetNodeProperties(nodes[1]);
     if (!pNodeProperties || !pNodePropertiesDev1) {
         LOG() << "Failed to get gpu node properties." << std::endl;
         return;
@@ -2114,12 +2092,12 @@ static void DeviceHdpFlush(KFDTEST_PARAMETERS* pTestParamters) {
         return;
     }
 
-    if (pKFDMemoryTest->Get_NodeInfo()->IsNodeXGMItoCPU(nodes[0])) {
+    if (Get_NodeInfo()->IsNodeXGMItoCPU(nodes[0])) {
         LOG() << "Skipping test: PCIe link to CPU is required." << std::endl;
         return;
     }
 
-    if (!pKFDMemoryTest->Get_NodeInfo()->IsGPUNodeLargeBar(nodes[0])) {
+    if (!Get_NodeInfo()->IsGPUNodeLargeBar(nodes[0])) {
         LOG() << "Skipping test: Test requires device 0 large bar GPU." << std::endl;
         return;
     }
@@ -2189,7 +2167,9 @@ TEST_F(KFDMemoryTest, DeviceHdpFlush) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(DeviceHdpFlush));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->DeviceHdpFlush(gpuNode);
+    }));
 
     TEST_END
 }
@@ -2202,16 +2182,13 @@ TEST_F(KFDMemoryTest, DeviceHdpFlush) {
  * since the cache should be invalidated on write and second read
  * should go to physical VRAM instead of cache.
  */
-static void CacheInvalidateOnSdmaWrite(KFDTEST_PARAMETERS* pTestParamters) {
-
-	int gpuNode = pTestParamters->gpuNode;
-	KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::CacheInvalidateOnSdmaWrite(int gpuNode) {
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDMemoryTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
-    HSAuint32 m_FamilyId = pKFDMemoryTest->GetFamilyIdFromNodeId(gpuNode);
+    HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     HsaMemoryBuffer tmpBuffer(PAGE_SIZE, 0, true /* zero */);
     volatile HSAuint32 *tmp = tmpBuffer.As<volatile HSAuint32 *>();
@@ -2259,28 +2236,27 @@ TEST_F(KFDMemoryTest, CacheInvalidateOnSdmaWrite) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(CacheInvalidateOnSdmaWrite));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->CacheInvalidateOnSdmaWrite(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void CacheInvalidateOnCPUWrite(KFDTEST_PARAMETERS* pTestParamters) {
-
-	int gpuNode = pTestParamters->gpuNode;
-	KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::CacheInvalidateOnCPUWrite(int gpuNode) {
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDMemoryTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
-    HSAuint32 m_FamilyId = pKFDMemoryTest->GetFamilyIdFromNodeId(gpuNode);
+    HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     if (m_FamilyId != FAMILY_AR) {
         LOG() << "Skipping test: Test requires arcturus series asics." << std::endl;
         return;
     }
 
-    if (!pKFDMemoryTest->Get_NodeInfo()->IsGPUNodeLargeBar(gpuNode)) {
+    if (!Get_NodeInfo()->IsGPUNodeLargeBar(gpuNode)) {
         LOG() << "Skipping test: Test requires a large bar GPU." << std::endl;
         return;
     }
@@ -2326,21 +2302,20 @@ TEST_F(KFDMemoryTest, CacheInvalidateOnCPUWrite) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(CacheInvalidateOnCPUWrite));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->CacheInvalidateOnCPUWrite(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void CacheInvalidateOnRemoteWrite(KFDTEST_PARAMETERS* pTestParamters) {
-
-	int gpuNode = pTestParamters->gpuNode;
-	KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::CacheInvalidateOnRemoteWrite(int gpuNode) {
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDMemoryTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
-    HSAuint32 m_FamilyId = pKFDMemoryTest->GetFamilyIdFromNodeId(gpuNode);
+    HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     HsaMemoryBuffer tmpBuffer(PAGE_SIZE, 0, true /* zero */);
     volatile HSAuint32 *tmp = tmpBuffer.As<volatile HSAuint32 *>();
@@ -2352,7 +2327,7 @@ static void CacheInvalidateOnRemoteWrite(KFDTEST_PARAMETERS* pTestParamters) {
         return;
     }
 
-    const std::vector<int> gpuNodes = pKFDMemoryTest->Get_NodeInfo()->GetNodesWithGPU();
+    const std::vector<int> gpuNodes = Get_NodeInfo()->GetNodesWithGPU();
     if (gpuNodes.size() < 2) {
         LOG() << "Skipping test: At least two GPUs are required." << std::endl;
         return;
@@ -2415,7 +2390,9 @@ TEST_F(KFDMemoryTest, CacheInvalidateOnRemoteWrite) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(CacheInvalidateOnRemoteWrite));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->CacheInvalidateOnRemoteWrite(gpuNode);
+    }));
 
     TEST_END
 }
@@ -2423,16 +2400,13 @@ TEST_F(KFDMemoryTest, CacheInvalidateOnRemoteWrite) {
 /* Test is for new cache coherence on Aldebaran. It is to verify
  * two GPUs can coherently share a fine grain FB.
  */
-static void VramCacheCoherenceWithRemoteGPU(KFDTEST_PARAMETERS* pTestParamters) {
-
-	int gpuNode = pTestParamters->gpuNode;
-	KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::VramCacheCoherenceWithRemoteGPU(int gpuNode) {
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDMemoryTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
-    HSAuint32 m_FamilyId = pKFDMemoryTest->GetFamilyIdFromNodeId(gpuNode);
+    HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     HsaMemoryBuffer tmpBuffer(PAGE_SIZE, 0, true /* zero */);
     volatile HSAuint32 *tmp = tmpBuffer.As<volatile HSAuint32 *>();
@@ -2444,7 +2418,7 @@ static void VramCacheCoherenceWithRemoteGPU(KFDTEST_PARAMETERS* pTestParamters) 
         return;
     }
 
-    const std::vector<int> gpuNodes = pKFDMemoryTest->Get_NodeInfo()->GetNodesWithGPU();
+    const std::vector<int> gpuNodes = Get_NodeInfo()->GetNodesWithGPU();
     if (gpuNodes.size() < 2) {
         LOG() << "Skipping test: At least two GPUs are required." << std::endl;
         return;
@@ -2513,7 +2487,9 @@ TEST_F(KFDMemoryTest, VramCacheCoherenceWithRemoteGPU) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(VramCacheCoherenceWithRemoteGPU));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->VramCacheCoherenceWithRemoteGPU(gpuNode); 
+    }));
 
     TEST_END
 }
@@ -2522,16 +2498,13 @@ TEST_F(KFDMemoryTest, VramCacheCoherenceWithRemoteGPU) {
  * new XGMI coherence HW link in caches between CPU and GPUs
  * in local FB with fine grain mode.
  */
-static void VramCacheCoherenceWithCPU(KFDTEST_PARAMETERS* pTestParamters) {
-
-	int gpuNode = pTestParamters->gpuNode;
-	KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::VramCacheCoherenceWithCPU(int gpuNode) {
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDMemoryTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
-    HSAuint32 m_FamilyId = pKFDMemoryTest->GetFamilyIdFromNodeId(gpuNode);
+    HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     if (m_FamilyId != FAMILY_AL && m_FamilyId != FAMILY_AV) {
         LOG() << "Skipping test: Test requires aldebaran or aqua vanjaram series asics." << std::endl;
@@ -2540,7 +2513,7 @@ static void VramCacheCoherenceWithCPU(KFDTEST_PARAMETERS* pTestParamters) {
 
     const int dwLocation = 0x80;
 
-    if (!pKFDMemoryTest->Get_NodeInfo()->IsNodeXGMItoCPU(gpuNode)) {
+    if (!Get_NodeInfo()->IsNodeXGMItoCPU(gpuNode)) {
         LOG() << "Skipping test: XGMI link to CPU is required." << std::endl;
         return;
     }
@@ -2590,7 +2563,9 @@ TEST_F(KFDMemoryTest, VramCacheCoherenceWithCPU) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(VramCacheCoherenceWithCPU));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->VramCacheCoherenceWithCPU(gpuNode);
+    }));
 
     TEST_END
 }
@@ -2599,16 +2574,13 @@ TEST_F(KFDMemoryTest, VramCacheCoherenceWithCPU) {
  * new XGMI coherence HW link in caches between CPU and GPUs
  * in system RAM.
  */
-static void SramCacheCoherenceWithGPU(KFDTEST_PARAMETERS* pTestParamters) {
-
-	int gpuNode = pTestParamters->gpuNode;
-	KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::SramCacheCoherenceWithGPU(int gpuNode) {
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDMemoryTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
-    HSAuint32 m_FamilyId = pKFDMemoryTest->GetFamilyIdFromNodeId(gpuNode);
+    HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     if (m_FamilyId != FAMILY_AL && m_FamilyId != FAMILY_AV) {
         LOG() << "Skipping test: Test requires aldebaran or aqua vanjaram series asics." << std::endl;
@@ -2617,7 +2589,7 @@ static void SramCacheCoherenceWithGPU(KFDTEST_PARAMETERS* pTestParamters) {
 
     const int dwLocation = 0x80;
 
-    if (!pKFDMemoryTest->Get_NodeInfo()->IsNodeXGMItoCPU(gpuNode)) {
+    if (!Get_NodeInfo()->IsNodeXGMItoCPU(gpuNode)) {
         LOG() << "Skipping test: XGMI link to CPU is required." << std::endl;
         return;
     }
@@ -2625,7 +2597,7 @@ static void SramCacheCoherenceWithGPU(KFDTEST_PARAMETERS* pTestParamters) {
     unsigned int *fineBuffer = NULL;
     unsigned int tmp;
 
-    ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(gpuNode /* system */, PAGE_SIZE, pKFDMemoryTest->GetHsaMemFlags(),
+    ASSERT_SUCCESS_GPU(hsaKmtAllocMemory(gpuNode /* system */, PAGE_SIZE, GetHsaMemFlags(),
                        reinterpret_cast<void**>(&fineBuffer)), gpuNode);
     ASSERT_SUCCESS_GPU(hsaKmtMapMemoryToGPU(fineBuffer, PAGE_SIZE, NULL), gpuNode);
     fineBuffer[0] = 0;
@@ -2670,7 +2642,9 @@ TEST_F(KFDMemoryTest, SramCacheCoherenceWithGPU) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(SramCacheCoherenceWithGPU));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SramCacheCoherenceWithGPU(gpuNode);
+    }));
 
     TEST_END
 }
@@ -3082,16 +3056,13 @@ TEST_F(KFDMemoryTest, MultiThreadRegisterUserptrTest) {
     TEST_END
 }
 
-static void ExportDMABufTest(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::ExportDMABufTest(int gpuNode) {
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDMemoryTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
-    if (pKFDMemoryTest->Get_Version()->KernelInterfaceMinorVersion < 12) {
+    if (Get_Version()->KernelInterfaceMinorVersion < 12) {
         LOG() << "Skipping test, requires KFD ioctl version 1.12 or newer" << std::endl;
         return;
     }
@@ -3099,7 +3070,7 @@ static void ExportDMABufTest(KFDTEST_PARAMETERS* pTestParamters) {
     // Use a GTT BO for export because it's conveniently CPU accessible.
     // On multi-GPU systems this also checks for interactions with driver-
     // internal DMA buf use for DMA attachment to multiple GPUs
-    HsaMemFlags memFlags = pKFDMemoryTest->GetHsaMemFlags();
+    HsaMemFlags memFlags = GetHsaMemFlags();
     memFlags.ui32.NonPaged = 1;
 
     HSAuint32 *buf;
@@ -3166,26 +3137,25 @@ TEST_F(KFDMemoryTest, ExportDMABufTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(ExportDMABufTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->ExportDMABufTest(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void VA_VRAM_Only_AllocTest(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDMemoryTest* pKFDMemoryTest = (KFDMemoryTest*)pTestParamters->pTestObject;
+void KFDMemoryTest::VA_VRAM_Only_AllocTest(int gpuNode) {
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDMemoryTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
-   if (pKFDMemoryTest->Get_Version()->KernelInterfaceMinorVersion < 12) {
+   if (Get_Version()->KernelInterfaceMinorVersion < 12) {
         LOG() << "Skipping test, requires KFD ioctl version 1.12 or newer" << std::endl;
         return;
     }
 
-    HsaMemFlags memFlags = pKFDMemoryTest->GetHsaMemFlags();
+    HsaMemFlags memFlags = GetHsaMemFlags();
     memFlags.ui32.NonPaged = 1;
     memFlags.ui32.HostAccess = 0;
 
@@ -3223,7 +3193,9 @@ TEST_F(KFDMemoryTest, VA_VRAM_Only_AllocTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
 	TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(VA_VRAM_Only_AllocTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->VA_VRAM_Only_AllocTest(gpuNode);
+    }));
 
     TEST_END
 }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.hpp
@@ -34,12 +34,44 @@ class KFDMemoryTest :  public KFDBaseComponentTest {
  public:
     KFDMemoryTest(void) {}
     ~KFDMemoryTest(void) {}
+
+    void MMapLarge(int gpuNode);
+    void MapUnmapToNodes(int gpuNode);
+    void MapMemoryToGPU(int gpuNode);
+    void MemoryAllocAll(int gpuNode);
+    void AccessPPRMem(int gpuNode);
+    void MemoryRegister(int gpuNode);
+    void MemoryRegisterSamePtr(int gpuNode);
+    void FlatScratchAccess(int gpuNode);
+    void GetTileConfigTest(int gpuNode);
+    void LargestSysBufferTest(int gpuNode);
+    void LargestVramBufferTest(int gpuNode);
+    void BigSysBufferStressTest(int gpuNode);
+    void MMBench(int gpuNode);
+    void QueryPointerInfo(int gpuNode);
+    void PtraceAccess(int gpuNode);
+    void PtraceAccessInvisibleVram(int gpuNode);
+    void SignalHandling(int gpuNode);
+    void CheckZeroInitializationSysMem(int gpuNode);
+    void MMBandWidth(int gpuNode);
+    void HostHdpFlush(int gpuNode);
+    void DeviceHdpFlush(int gpuNode);
+    void CacheInvalidateOnSdmaWrite(int gpuNode);
+    void CacheInvalidateOnCPUWrite(int gpuNode);
+    void CacheInvalidateOnRemoteWrite(int gpuNode);
+    void VramCacheCoherenceWithRemoteGPU(int gpuNode);
+    void VramCacheCoherenceWithCPU(int gpuNode);
+    void SramCacheCoherenceWithGPU(int gpuNode);
+    void ExportDMABufTest(int gpuNode);
+    void VA_VRAM_Only_AllocTest(int gpuNode);
+      
+
  protected:
     virtual void SetUp();
     virtual void TearDown();
 
  protected:
-    friend void SearchLargestBuffer(int allocNode, const HsaMemFlags &memFlags,
+    void SearchLargestBuffer(int allocNode, const HsaMemFlags &memFlags,
                                             HSAuint64 highMB, int nodeToMap,
                                             HSAuint64 *lastSizeMB);
     void AcquireReleaseTestRunCPU(HSAuint32 acquireNode, bool scalar);

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDPerfCounters.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDPerfCounters.cpp
@@ -93,11 +93,7 @@ static void GetBlockName(HSA_UUID uuid, char *name, uint32_t name_len,
                  uuid.Data4[6], uuid.Data4[7]);
 }
 
-static void GetCounterProperties(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDPerfCountersTest* pKFDPerfCountersTest =
-                         (KFDPerfCountersTest*)pTestParamters->pTestObject;
+void KFDPerfCountersTest::GetCounterProperties(int gpuNode) {
 
     HsaCounterProperties* pProps = NULL;
     ASSERT_SUCCESS(hsaKmtPmcGetCounterProperties(gpuNode, &pProps));
@@ -141,18 +137,16 @@ static void GetCounterProperties(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDPerfCountersTest, GetCounterProperties) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(GetCounterProperties));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->GetCounterProperties(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void RegisterTrace(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDPerfCountersTest::RegisterTrace(int gpuNode) {
 
     HsaCounterProperties* pProps;
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDPerfCountersTest* pKFDPerfCountersTest =
-                         (KFDPerfCountersTest*)pTestParamters->pTestObject;
 
     HsaPmcTraceRoot root;
 
@@ -189,21 +183,19 @@ static void RegisterTrace(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDPerfCountersTest, RegisterTrace) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(RegisterTrace));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->RegisterTrace(gpuNode);
+    }));
 
     TEST_END
 }
 
 static const unsigned int START_STOP_DELAY = 10000;     // 10 sec tracing
 
-static void StartStopQueryTrace(KFDTEST_PARAMETERS* pTestParamters){
+void KFDPerfCountersTest::StartStopQueryTrace(int gpuNode) {
 
     HsaPmcTraceRoot root;
     HsaCounterProperties* pProps;
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDPerfCountersTest* pKFDPerfCountersTest =
-                         (KFDPerfCountersTest*)pTestParamters->pTestObject;
 
     pProps = NULL;
     ASSERT_SUCCESS(hsaKmtPmcGetCounterProperties(gpuNode, &pProps));
@@ -270,16 +262,14 @@ static void StartStopQueryTrace(KFDTEST_PARAMETERS* pTestParamters){
 TEST_F(KFDPerfCountersTest, StartStopQueryTrace) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(RegisterTrace));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->StartStopQueryTrace(gpuNode); 
+    }));
 
     TEST_END
 }
 
-static void ClockCountersBasicTest(KFDTEST_PARAMETERS* pTestParamters){
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDPerfCountersTest* pKFDPerfCountersTest =
-					  (KFDPerfCountersTest*)pTestParamters->pTestObject;
+void KFDPerfCountersTest::ClockCountersBasicTest(int gpuNode) {
 
     HsaClockCounters counters1;
     HsaClockCounters counters2;
@@ -303,7 +293,9 @@ static void ClockCountersBasicTest(KFDTEST_PARAMETERS* pTestParamters){
 TEST_F(KFDPerfCountersTest, ClockCountersBasicTest) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(ClockCountersBasicTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->ClockCountersBasicTest(gpuNode);
+    }));
 
     TEST_END
 }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDPerfCounters.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDPerfCounters.cpp
@@ -137,7 +137,7 @@ void KFDPerfCountersTest::GetCounterProperties(int gpuNode) {
 TEST_F(KFDPerfCountersTest, GetCounterProperties) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->GetCounterProperties(gpuNode);
     }));
 
@@ -183,7 +183,7 @@ void KFDPerfCountersTest::RegisterTrace(int gpuNode) {
 TEST_F(KFDPerfCountersTest, RegisterTrace) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->RegisterTrace(gpuNode);
     }));
 
@@ -262,7 +262,7 @@ void KFDPerfCountersTest::StartStopQueryTrace(int gpuNode) {
 TEST_F(KFDPerfCountersTest, StartStopQueryTrace) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->StartStopQueryTrace(gpuNode); 
     }));
 
@@ -293,7 +293,7 @@ void KFDPerfCountersTest::ClockCountersBasicTest(int gpuNode) {
 TEST_F(KFDPerfCountersTest, ClockCountersBasicTest) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->ClockCountersBasicTest(gpuNode);
     }));
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDPerfCounters.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDPerfCounters.hpp
@@ -31,6 +31,10 @@ class KFDPerfCountersTest : public KFDBaseComponentTest {
  public:
     KFDPerfCountersTest() {}
     ~KFDPerfCountersTest() {}
+    void GetCounterProperties(int gpuNode);
+    void RegisterTrace(int gpuNode);
+    void StartStopQueryTrace(int gpuNode);
+    void ClockCountersBasicTest(int gpuNode);
 
  protected:
     virtual void SetUp();

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDQMTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDQMTest.cpp
@@ -54,11 +54,7 @@ void KFDQMTest::TearDown() {
 
     ROUTINE_END
 }
-
-static void CreateDestroyCpQueue(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
+void KFDQMTest::CreateDestroyCpQueue(int gpuNode) {
 
     PM4Queue queue;
 
@@ -70,16 +66,14 @@ static void CreateDestroyCpQueue(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, CreateDestroyCpQueue) {
     TEST_START(TESTPROFILE_RUNALL)
 
-   ASSERT_SUCCESS(KFDTest_Launch(CreateDestroyCpQueue));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->CreateDestroyCpQueue(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void SubmitNopCpQueue(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
-
+void KFDQMTest::SubmitNopCpQueue(int gpuNode) {
     PM4Queue queue;
     HsaEvent *event;
     ASSERT_SUCCESS_GPU(CreateQueueTypeEvent(false, false, gpuNode, &event), gpuNode);
@@ -98,16 +92,15 @@ static void SubmitNopCpQueue(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, SubmitNopCpQueue) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(SubmitNopCpQueue));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SubmitNopCpQueue(gpuNode);
+    }));
+
 
     TEST_END
 }
 
-static void SubmitPacketCpQueue(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
-
+void KFDQMTest::SubmitPacketCpQueue(int gpuNode) {
     HsaMemoryBuffer destBuf(PAGE_SIZE, gpuNode, false);
 
     destBuf.Fill(0xFF);
@@ -130,23 +123,22 @@ static void SubmitPacketCpQueue(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, SubmitPacketCpQueue) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(SubmitPacketCpQueue));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SubmitPacketCpQueue(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void AllCpQueues(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
-    int gpuIndex = pKFDQMTest->Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
-    HSAuint32 m_FamilyId = pKFDQMTest->GetFamilyIdFromNodeId(gpuNode);
+void KFDQMTest::AllCpQueues(int gpuNode) {
+    int gpuIndex = Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
+    HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     HsaMemoryBuffer destBuf(PAGE_SIZE, gpuNode, false);
 
     destBuf.Fill(0xFF);
 
-    unsigned int  m_numCpQueues = pKFDQMTest->Get_NumCpQueues(gpuIndex);
+    unsigned int  m_numCpQueues = Get_NumCpQueues(gpuIndex);
     std::vector<PM4Queue> queues(m_numCpQueues);
 
     for (unsigned int qidx = 0; qidx < m_numCpQueues; ++qidx)
@@ -167,15 +159,14 @@ static void AllCpQueues(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, AllCpQueues) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(AllCpQueues));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->AllCpQueues(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void CreateDestroySdmaQueue(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-
+void KFDQMTest::CreateDestroySdmaQueue(int gpuNode) {
     SDMAQueue queue;
 
     ASSERT_SUCCESS_GPU(queue.Create(gpuNode), gpuNode);
@@ -187,14 +178,14 @@ static void CreateDestroySdmaQueue(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, CreateDestroySdmaQueue) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(CreateDestroySdmaQueue));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->CreateDestroySdmaQueue(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void SubmitNopSdmaQueue(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
+void KFDQMTest::SubmitNopSdmaQueue(int gpuNode) {
 
     SDMAQueue queue;
 
@@ -211,14 +202,14 @@ static void SubmitNopSdmaQueue(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, SubmitNopSdmaQueue) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(SubmitNopSdmaQueue));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SubmitNopSdmaQueue(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void SubmitPacketSdmaQueue(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
+void KFDQMTest::SubmitPacketSdmaQueue(int gpuNode) {
 
     HsaMemoryBuffer destBuf(PAGE_SIZE, gpuNode, false);
 
@@ -240,19 +231,18 @@ static void SubmitPacketSdmaQueue(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, SubmitPacketSdmaQueue) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(SubmitPacketSdmaQueue));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SubmitPacketSdmaQueue(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void AllSdmaQueues(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDQMTest::AllSdmaQueues(int gpuNode) {
+    int gpuIndex = Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
-    int gpuIndex = pKFDQMTest->Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
-
-    unsigned int m_numSdmaEngines = pKFDQMTest->Get_NumSdmaEngines(gpuIndex);
-    unsigned int m_numSdmaQueuesPerEngine = pKFDQMTest->Get_NumSdmaSdmaQueuesPerEngine(gpuIndex);
+    unsigned int m_numSdmaEngines = Get_NumSdmaEngines(gpuIndex);
+    unsigned int m_numSdmaQueuesPerEngine = Get_NumSdmaSdmaQueuesPerEngine(gpuIndex);
 
     int bufSize = PAGE_SIZE;
     const unsigned int numSdmaQueues = m_numSdmaEngines * m_numSdmaQueuesPerEngine;
@@ -293,18 +283,17 @@ static void AllSdmaQueues(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, AllSdmaQueues) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(AllSdmaQueues));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->AllSdmaQueues(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void AllXgmiSdmaQueues(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
-    int gpuIndex = pKFDQMTest->Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
-    unsigned int m_numSdmaXgmiEngines = pKFDQMTest->Get_NumSdmaSdmaXgmiEngines(gpuIndex);
-    unsigned int m_numSdmaQueuesPerEngine = pKFDQMTest->Get_NumSdmaSdmaQueuesPerEngine(gpuIndex);
+void KFDQMTest::AllXgmiSdmaQueues(int gpuNode) {
+    int gpuIndex = Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
+    unsigned int m_numSdmaXgmiEngines = Get_NumSdmaSdmaXgmiEngines(gpuIndex);
+    unsigned int m_numSdmaQueuesPerEngine = Get_NumSdmaSdmaQueuesPerEngine(gpuIndex);
 
     int bufSize = PAGE_SIZE;
     int j;
@@ -350,23 +339,22 @@ static void AllXgmiSdmaQueues(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, AllXgmiSdmaQueues) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(AllXgmiSdmaQueues));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->AllXgmiSdmaQueues(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void AllQueues(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDQMTest::AllQueues(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
+    int gpuIndex = Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
+    HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
-    int gpuIndex = pKFDQMTest->Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
-    HSAuint32 m_FamilyId = pKFDQMTest->GetFamilyIdFromNodeId(gpuNode);
-
-    unsigned int m_numSdmaXgmiEngines = pKFDQMTest->Get_NumSdmaSdmaXgmiEngines(gpuIndex);
-    unsigned int m_numSdmaQueuesPerEngine = pKFDQMTest->Get_NumSdmaSdmaQueuesPerEngine(gpuIndex);
-    unsigned int m_numSdmaEngines = pKFDQMTest->Get_NumSdmaEngines(gpuIndex);
-    unsigned int m_numCpQueues = pKFDQMTest->Get_NumCpQueues(gpuIndex);
+    unsigned int m_numSdmaXgmiEngines = Get_NumSdmaSdmaXgmiEngines(gpuIndex);
+    unsigned int m_numSdmaQueuesPerEngine = Get_NumSdmaSdmaQueuesPerEngine(gpuIndex);
+    unsigned int m_numSdmaEngines = Get_NumSdmaEngines(gpuIndex);
+    unsigned int m_numCpQueues = Get_NumCpQueues(gpuIndex);
 
     int bufSize = PAGE_SIZE;
     unsigned int i, j;
@@ -455,7 +443,9 @@ static void AllQueues(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, AllQueues) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(AllQueues));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->AllQueues(gpuNode);
+    }));
 
     TEST_END
 }
@@ -466,13 +456,9 @@ TEST_F(KFDQMTest, AllQueues) {
  * seems to be PCIe speed switching. The problem can be worked around
  * by disabling the lowest DPM level on Fiji.
  */
-static void SdmaConcurrentCopies(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
-
-    int gpuIndex = pKFDQMTest->Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
-    HSAuint32 m_FamilyId = pKFDQMTest->GetFamilyIdFromNodeId(gpuNode);
+void KFDQMTest::SdmaConcurrentCopies(int gpuNode) {
+    int gpuIndex = Get_NodeInfo()->HsaGPUindexFromGpuNode(gpuNode);
+    HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
 #define BUFFER_SIZE (64*1024)
 #define NPACKETS 1
@@ -526,15 +512,14 @@ static void SdmaConcurrentCopies(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, SdmaConcurrentCopies) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(SdmaConcurrentCopies));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SdmaConcurrentCopies(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void DisableCpQueueByUpdateWithNullAddress(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
+void KFDQMTest::DisableCpQueueByUpdateWithNullAddress(int gpuNode) {
 
     HsaMemoryBuffer destBuf(PAGE_SIZE, gpuNode, false);
 
@@ -579,15 +564,14 @@ static void DisableCpQueueByUpdateWithNullAddress(KFDTEST_PARAMETERS* pTestParam
 TEST_F(KFDQMTest, DisableCpQueueByUpdateWithNullAddress) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(DisableCpQueueByUpdateWithNullAddress));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->DisableCpQueueByUpdateWithNullAddress(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void DisableSdmaQueueByUpdateWithNullAddress(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-
+void KFDQMTest::DisableSdmaQueueByUpdateWithNullAddress(int gpuNode) {
     HsaMemoryBuffer destBuf(PAGE_SIZE, gpuNode, false);
 
     destBuf.Fill(0xFFFFFFFF);
@@ -625,15 +609,14 @@ static void DisableSdmaQueueByUpdateWithNullAddress(KFDTEST_PARAMETERS* pTestPar
 TEST_F(KFDQMTest, DisableSdmaQueueByUpdateWithNullAddress) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(DisableSdmaQueueByUpdateWithNullAddress));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->DisableSdmaQueueByUpdateWithNullAddress(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void DisableCpQueueByUpdateWithZeroPercentage(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-
+void KFDQMTest::DisableCpQueueByUpdateWithZeroPercentage(int gpuNode) {
     HsaMemoryBuffer destBuf(PAGE_SIZE, gpuNode, false);
 
     destBuf.Fill(0xFFFFFFFF);
@@ -681,14 +664,14 @@ static void DisableCpQueueByUpdateWithZeroPercentage(KFDTEST_PARAMETERS* pTestPa
 TEST_F(KFDQMTest, DisableCpQueueByUpdateWithZeroPercentage) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(DisableCpQueueByUpdateWithZeroPercentage));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->DisableCpQueueByUpdateWithZeroPercentage(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void CreateQueueStressSingleThreaded(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
+void KFDQMTest::CreateQueueStressSingleThreaded(int gpuNode) {
 
     static const HSAuint64 TEST_TIME_SEC = 15;
 
@@ -727,16 +710,16 @@ static void CreateQueueStressSingleThreaded(KFDTEST_PARAMETERS* pTestParamters) 
 TEST_F(KFDQMTest, CreateQueueStressSingleThreaded) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(CreateQueueStressSingleThreaded));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->CreateQueueStressSingleThreaded(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void OverSubscribeCpQueues(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDQMTest::OverSubscribeCpQueues(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
-    const HSAuint32 m_FamilyId = pKFDQMTest->GetFamilyIdFromNodeId(gpuNode);
+    const HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     if (m_FamilyId == FAMILY_CI || m_FamilyId == FAMILY_KV) {
         LOG() << "Skipping test: CI doesn't have HW scheduling." << std::endl;
@@ -787,7 +770,9 @@ static void OverSubscribeCpQueues(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, OverSubscribeCpQueues) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(OverSubscribeCpQueues));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->OverSubscribeCpQueues(gpuNode);
+    }));
 
     TEST_END
 }
@@ -850,14 +835,11 @@ HSAint64 KFDQMTest::GetAverageTimeConsumedwithCUMask(int node, uint32_t* mask, u
  * Apply CU masking in a linear fashion, adding 1 CU per iteration
  * until all Shader Engines are full
  */
-void BasicCuMaskingLinear(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
-    const HSAuint32 m_FamilyId = pKFDQMTest->GetFamilyIdFromNodeId(gpuNode);
+void KFDQMTest::BasicCuMaskingLinear(int gpuNode) {
+    const HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     if (m_FamilyId >= FAMILY_VI) {
-        const HsaNodeProperties *pNodeProperties = pKFDQMTest->Get_NodeInfo()->GetNodeProperties(gpuNode);
+        const HsaNodeProperties *pNodeProperties = Get_NodeInfo()->GetNodeProperties(gpuNode);
         uint32_t ActiveCU = (pNodeProperties->NumFComputeCores / pNodeProperties->NumSIMDPerCU);
         uint32_t numSEs = pNodeProperties->NumShaderBanks;
         LOG() << std::dec << "# Compute cores: " << pNodeProperties->NumFComputeCores << std::endl;
@@ -875,23 +857,23 @@ void BasicCuMaskingLinear(KFDTEST_PARAMETERS* pTestParamters) {
             mask[i] = 0x0;
 
         /* Execute once to get any HW optimizations out of the way */
-        pKFDQMTest->TimeConsumedwithCUMask(gpuNode, mask, maskNumBits);
+        TimeConsumedwithCUMask(gpuNode, mask, maskNumBits);
 
         LOG() << "Getting baseline performance numbers (CU Mask: 0x1)" << std::endl;
-        TimewithCU1 = pKFDQMTest->GetAverageTimeConsumedwithCUMask(gpuNode, mask, maskNumBits, 3);
+        TimewithCU1 = GetAverageTimeConsumedwithCUMask(gpuNode, mask, maskNumBits, 3);
 
         for (int nCUs = 2; nCUs <= ActiveCU; nCUs++) {
             int maskIndex = (nCUs - 1) / 32;
             mask[maskIndex] |= 1 << ((nCUs - 1) % 32);
 
-            TimewithCU = pKFDQMTest->TimeConsumedwithCUMask(gpuNode, mask, maskNumBits);
+            TimewithCU = TimeConsumedwithCUMask(gpuNode, mask, maskNumBits);
             ratio = (double)(TimewithCU1) / ((double)(TimewithCU) * nCUs);
 
             LOG() << "Expected performance of " << nCUs << " CUs vs 1 CU:" << std::endl;
-            LOG() << std::setprecision(2) << pKFDQMTest->CuNegVariance << " <= " << std::fixed << std::setprecision(8)
-                  << ratio << " <= " << std::setprecision(2) << pKFDQMTest->CuPosVariance << std::endl;
+            LOG() << std::setprecision(2) << CuNegVariance << " <= " << std::fixed << std::setprecision(8)
+                  << ratio << " <= " << std::setprecision(2) << CuPosVariance << std::endl;
 
-            EXPECT_TRUE((ratio >= pKFDQMTest->CuNegVariance) && (ratio <= pKFDQMTest->CuPosVariance));
+            EXPECT_TRUE((ratio >= CuNegVariance) && (ratio <= CuPosVariance));
 
             RECORD(ratio) << "Ratio-" << nCUs << "-CUs";
         }
@@ -903,7 +885,9 @@ void BasicCuMaskingLinear(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, BasicCuMaskingLinear) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(BasicCuMaskingLinear));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->BasicCuMaskingLinear(gpuNode);
+    }));
 
     TEST_END
 }
@@ -1249,18 +1233,16 @@ static bool testCUMask(int gpuNode, uint32_t *pMask, mask_config_t maskConfig, H
  * 3) Changes to validation code.
  *
  */
-static void extendedCuMasking(KFDTEST_PARAMETERS* pTestParameters) {
+void KFDQMTest::extendedCuMasking(int gpuNode) {
 
-    int gpuNode = pTestParameters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParameters->pTestObject;
-    const HSAuint32 m_FamilyId = pKFDQMTest->GetFamilyIdFromNodeId(gpuNode);
+    const HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     if (m_FamilyId >= FAMILY_GFX12) {  // Supporting GFX12 and up for now
 
         // Lock to prevent interleave of logging on multigpu (multithreaded) testing
         static std::mutex logMutex;
 
-        const HsaNodeProperties *pProps = pKFDQMTest->Get_NodeInfo()->GetNodeProperties(gpuNode);
+        const HsaNodeProperties *pProps = Get_NodeInfo()->GetNodeProperties(gpuNode);
         const uint32_t activeCU = (pProps->NumFComputeCores / pProps->NumSIMDPerCU);
         const uint32_t numSEs = pProps->NumShaderBanks;
         const uint32_t numSAperSE = pProps->NumArrays;
@@ -1335,7 +1317,7 @@ static void extendedCuMasking(KFDTEST_PARAMETERS* pTestParameters) {
         out_data_t *pOutput = outputBuffer.As<out_data_t *>();
 
         // Assemble shader
-        Assembler *pAsm = pKFDQMTest->GetAssemblerFromNodeId(gpuNode);
+        Assembler *pAsm = GetAssemblerFromNodeId(gpuNode);
         ASSERT_NOTNULL_GPU(pAsm, gpuNode);
         ASSERT_SUCCESS_GPU(pAsm->RunAssembleBuf(CheckCuMaskIsa, programBuffer.As<char*>()), gpuNode);
 
@@ -1505,7 +1487,9 @@ static void extendedCuMasking(KFDTEST_PARAMETERS* pTestParameters) {
 TEST_F(KFDQMTest, ExtendedCuMasking) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(extendedCuMasking));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->extendedCuMasking(gpuNode);
+    }));
 
     TEST_END
 }
@@ -1524,14 +1508,12 @@ TEST_F(KFDQMTest, ExtendedCuMasking) {
  * will not yield viable results when an uneven distribution of CUs is used over multiple
  * shader engines (e.g. 0x1000100030003), until the HW changes how it schedules work.
  */
-void BasicCuMaskingEven(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDQMTest::BasicCuMaskingEven(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
-    const HSAuint32 m_FamilyId = pKFDQMTest->GetFamilyIdFromNodeId(gpuNode);
+    const HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     if (m_FamilyId >= FAMILY_VI) {
-        const HsaNodeProperties *pNodeProperties = pKFDQMTest->Get_NodeInfo()->GetNodeProperties(gpuNode);
+        const HsaNodeProperties *pNodeProperties = Get_NodeInfo()->GetNodeProperties(gpuNode);
         uint32_t ActiveCU = (pNodeProperties->NumFComputeCores / pNodeProperties->NumSIMDPerCU);
         uint32_t numShaderEngines = pNodeProperties->NumShaderBanks;
         if (numShaderEngines == 1) {
@@ -1565,10 +1547,10 @@ void BasicCuMaskingEven(KFDTEST_PARAMETERS* pTestParamters) {
         }
 
         /* Execute once to get any HW optimizations out of the way */
-        pKFDQMTest->TimeConsumedwithCUMask(gpuNode, mask, maskNumBits);
+        TimeConsumedwithCUMask(gpuNode, mask, maskNumBits);
 
         LOG() << "Getting baseline performance numbers (1 CU per SE)" << std::endl;
-        TimewithCU1 = pKFDQMTest->GetAverageTimeConsumedwithCUMask(gpuNode, mask, maskNumBits, 3);
+        TimewithCU1 = GetAverageTimeConsumedwithCUMask(gpuNode, mask, maskNumBits, 3);
 
         /* Each loop will add 1 more CU per SE. We use the mod and divide to handle
          * when SEs aren't distributed in multiples of 32 (e.g. Tonga)
@@ -1582,14 +1564,14 @@ void BasicCuMaskingEven(KFDTEST_PARAMETERS* pTestParamters) {
             }
             int nCUs = x + 1;
 
-            TimewithCU = pKFDQMTest->TimeConsumedwithCUMask(gpuNode, mask, maskNumBits);
+            TimewithCU = TimeConsumedwithCUMask(gpuNode, mask, maskNumBits);
             ratio = (double)(TimewithCU1) / ((double)(TimewithCU) * nCUs);
 
             LOG() << "Expected performance of " << nCUs << " CU(s)/SE vs 1 CU/SE:" << std::endl;
-            LOG() << std::setprecision(2) << pKFDQMTest->CuNegVariance << " <= " << std::fixed << std::setprecision(8)
-                  << ratio << " <= " << std::setprecision(2) << pKFDQMTest->CuPosVariance << std::endl;
+            LOG() << std::setprecision(2) << CuNegVariance << " <= " << std::fixed << std::setprecision(8)
+                  << ratio << " <= " << std::setprecision(2) << CuPosVariance << std::endl;
 
-            EXPECT_TRUE_GPU((ratio >= pKFDQMTest->CuNegVariance) && (ratio <= pKFDQMTest->CuPosVariance), gpuNode);
+            EXPECT_TRUE_GPU((ratio >= CuNegVariance) && (ratio <= CuPosVariance), gpuNode);
 
             RECORD(ratio) << "Ratio-" << nCUs << "-CUs";
         }
@@ -1601,19 +1583,19 @@ void BasicCuMaskingEven(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, BasicCuMaskingEven) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(BasicCuMaskingEven));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->BasicCuMaskingEven(gpuNode);
+    }));
 
     TEST_END
 }
 
-void testQueuePriority(KFDTEST_PARAMETERS* pTestParamters, bool isSamePipe)
+void KFDQMTest::testQueuePriority(int gpuNode, bool isSamePipe)
 {
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
-    const HSAuint32 m_FamilyId = pKFDQMTest->GetFamilyIdFromNodeId(gpuNode);
+    const HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDQMTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
     if (m_FamilyId < FAMILY_VI) {
@@ -1699,28 +1681,32 @@ void testQueuePriority(KFDTEST_PARAMETERS* pTestParamters, bool isSamePipe)
     }
 }
 
-static void QueuePriorityOnDifferentPipe(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDQMTest::QueuePriorityOnDifferentPipe(int gpuNode) {
 
-	testQueuePriority(pTestParamters, false);
+	testQueuePriority(gpuNode, false);
 }
 
 TEST_F(KFDQMTest, QueuePriorityOnDifferentPipe) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(QueuePriorityOnDifferentPipe));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->QueuePriorityOnDifferentPipe(gpuNode);
+    }));
 
     TEST_END
 }
 
-void QueuePriorityOnSamePipe(KFDTEST_PARAMETERS* pTestParamters) {
+void  KFDQMTest::QueuePriorityOnSamePipe(int gpuNode) {
 
-    testQueuePriority(pTestParamters, true);
+    testQueuePriority(gpuNode, true);
 }
 
 TEST_F(KFDQMTest, QueuePriorityOnSamePipe) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(QueuePriorityOnSamePipe));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->QueuePriorityOnSamePipe(gpuNode);
+    }));
 
     TEST_END
 }
@@ -1745,38 +1731,34 @@ void KFDQMTest::SyncDispatch(const HsaMemoryBuffer& isaBuffer, void* pSrcBuf, vo
     EXPECT_SUCCESS_GPU(queue.Destroy(), node);
 }
 
-void EmptyDispatch(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
+void KFDQMTest::EmptyDispatch(int gpuNode) {
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDQMTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
     HsaMemoryBuffer isaBuffer(PAGE_SIZE, gpuNode, true/*zero*/, false/*local*/, true/*exec*/);
 
     ASSERT_SUCCESS_GPU(m_pAsm->RunAssembleBuf(NoopIsa, isaBuffer.As<char*>()), gpuNode);
 
-    pKFDQMTest->SyncDispatch(isaBuffer, NULL, NULL, gpuNode);
+    SyncDispatch(isaBuffer, NULL, NULL, gpuNode);
 
 }
 
 TEST_F(KFDQMTest, EmptyDispatch) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(EmptyDispatch));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->EmptyDispatch(gpuNode);
+    }));
 
     TEST_END
 }
 
-void SimpleWriteDispatch(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
+void KFDQMTest::SimpleWriteDispatch(int gpuNode) {
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDQMTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
     HsaMemoryBuffer isaBuffer(PAGE_SIZE, gpuNode, true/*zero*/, false/*local*/, true/*exec*/);
@@ -1787,7 +1769,7 @@ void SimpleWriteDispatch(KFDTEST_PARAMETERS* pTestParamters) {
 
     ASSERT_SUCCESS_GPU(m_pAsm->RunAssembleBuf(CopyDwordIsa, isaBuffer.As<char*>()),gpuNode);
 
-    pKFDQMTest->SyncDispatch(isaBuffer, srcBuffer.As<void*>(), destBuffer.As<void*>(), gpuNode);
+    SyncDispatch(isaBuffer, srcBuffer.As<void*>(), destBuffer.As<void*>(), gpuNode);
 
     EXPECT_EQ(destBuffer.As<unsigned int*>()[0], 0x01010101);
 
@@ -1796,18 +1778,17 @@ void SimpleWriteDispatch(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, SimpleWriteDispatch) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(SimpleWriteDispatch));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SimpleWriteDispatch(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void MultipleCpQueuesStressDispatch(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
+void KFDQMTest::MultipleCpQueuesStressDispatch(int gpuNode) {
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDQMTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
     static const unsigned int MAX_CP_QUEUES = 16;
@@ -1867,15 +1848,14 @@ static void MultipleCpQueuesStressDispatch(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, MultipleCpQueuesStressDispatch) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(MultipleCpQueuesStressDispatch));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->MultipleCpQueuesStressDispatch(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void CpuWriteCoherence(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
+void KFDQMTest::CpuWriteCoherence(int gpuNode) {
 
     PM4Queue queue;
 
@@ -1915,15 +1895,14 @@ static void CpuWriteCoherence(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, CpuWriteCoherence) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(CpuWriteCoherence));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->CpuWriteCoherence(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void CreateAqlCpQueue(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
+void KFDQMTest::CreateAqlCpQueue(int gpuNode) {
 
     AqlQueue queue;
 
@@ -1937,16 +1916,16 @@ static void CreateAqlCpQueue(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, CreateAqlCpQueue) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(CreateAqlCpQueue));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->CreateAqlCpQueue(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void QueueLatency(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDQMTest::QueueLatency(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
-    HSAuint32 m_FamilyId = pKFDQMTest->GetFamilyIdFromNodeId(gpuNode);
+    HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     PM4Queue queue;
     const int queueSize = PAGE_SIZE * 2;
@@ -2077,15 +2056,14 @@ static void QueueLatency(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, QueueLatency) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(QueueLatency));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->QueueLatency(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void CpQueueWraparound(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
+void KFDQMTest::CpQueueWraparound(int gpuNode) {
 
     PM4Queue queue;
 
@@ -2116,15 +2094,14 @@ static void CpQueueWraparound(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, CpQueueWraparound) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(CpQueueWraparound));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->CpQueueWraparound(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void SdmaQueueWraparound(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
+void KFDQMTest::SdmaQueueWraparound(int gpuNode) {
 
     int bufSize = PAGE_SIZE;
 
@@ -2162,7 +2139,9 @@ static void SdmaQueueWraparound(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, SdmaQueueWraparound) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(SdmaQueueWraparound));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SdmaQueueWraparound(gpuNode);
+    }));
 
     TEST_END
 }
@@ -2186,13 +2165,10 @@ unsigned int AtomicIncThread(void* pCtx) {
     return 0;
 }
 
-static void Atomics(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
+void KFDQMTest::Atomics(int gpuNode) {
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDQMTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
     if (!hasPciAtomicsSupport(gpuNode)) {
@@ -2249,7 +2225,9 @@ static void Atomics(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, Atomics) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(Atomics));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->Atomics(gpuNode);
+    }));
 
     TEST_END
 }
@@ -2435,11 +2413,9 @@ TEST_F(KFDQMTest, P2PTest) {
     TEST_END
 }
 
-static void PM4EventInterrupt(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDQMTest::PM4EventInterrupt(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
-    HSAuint32 m_FamilyId = pKFDQMTest->GetFamilyIdFromNodeId(gpuNode);
+    HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     const HSAuint64 bufSize = PAGE_SIZE;
     const int packetCount = bufSize / sizeof(unsigned int);
@@ -2502,16 +2478,15 @@ static void PM4EventInterrupt(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, PM4EventInterrupt) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(PM4EventInterrupt));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->PM4EventInterrupt(gpuNode);
+    }));
 
     TEST_END
 }
 
 #include "KFDTestUtilQueue.hpp"
-static void SdmaEventInterrupt(KFDTEST_PARAMETERS* pTestParamters) {
-
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
+void KFDQMTest::SdmaEventInterrupt(int gpuNode) {
 
     const HSAuint64 bufSize = 4 << 20;
     HsaMemoryBuffer srcBuf(bufSize, 0); // System memory.
@@ -2613,17 +2588,17 @@ static void SdmaEventInterrupt(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, SdmaEventInterrupt) {
     TEST_START(TESTPROFILE_RUNALL)
 
-     ASSERT_SUCCESS(KFDTest_Launch(SdmaEventInterrupt));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SdmaEventInterrupt(gpuNode);
+    }));
 
     TEST_END
 }
 
 #define DOORBELL_WRITE_USE_SDMA
-static void GPUDoorbellWrite(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDQMTest::GPUDoorbellWrite(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDQMTest* pKFDQMTest = (KFDQMTest*)pTestParamters->pTestObject;
-    HSAuint32 m_FamilyId = pKFDQMTest->GetFamilyIdFromNodeId(gpuNode);
+    HSAuint32 m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
 
     HsaMemoryBuffer destBuf(PAGE_SIZE, 0, true);
     PM4Queue pm4Queue;
@@ -2708,7 +2683,9 @@ static void GPUDoorbellWrite(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_F(KFDQMTest, GPUDoorbellWrite) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(GPUDoorbellWrite));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->GPUDoorbellWrite(gpuNode);
+    }));
 
     TEST_END
 }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDQMTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDQMTest.cpp
@@ -66,7 +66,7 @@ void KFDQMTest::CreateDestroyCpQueue(int gpuNode) {
 TEST_F(KFDQMTest, CreateDestroyCpQueue) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->CreateDestroyCpQueue(gpuNode);
     }));
 
@@ -92,7 +92,7 @@ void KFDQMTest::SubmitNopCpQueue(int gpuNode) {
 TEST_F(KFDQMTest, SubmitNopCpQueue) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SubmitNopCpQueue(gpuNode);
     }));
 
@@ -123,7 +123,7 @@ void KFDQMTest::SubmitPacketCpQueue(int gpuNode) {
 TEST_F(KFDQMTest, SubmitPacketCpQueue) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SubmitPacketCpQueue(gpuNode);
     }));
 
@@ -159,7 +159,7 @@ void KFDQMTest::AllCpQueues(int gpuNode) {
 TEST_F(KFDQMTest, AllCpQueues) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->AllCpQueues(gpuNode);
     }));
 
@@ -178,7 +178,7 @@ void KFDQMTest::CreateDestroySdmaQueue(int gpuNode) {
 TEST_F(KFDQMTest, CreateDestroySdmaQueue) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->CreateDestroySdmaQueue(gpuNode);
     }));
 
@@ -202,7 +202,7 @@ void KFDQMTest::SubmitNopSdmaQueue(int gpuNode) {
 TEST_F(KFDQMTest, SubmitNopSdmaQueue) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SubmitNopSdmaQueue(gpuNode);
     }));
 
@@ -231,7 +231,7 @@ void KFDQMTest::SubmitPacketSdmaQueue(int gpuNode) {
 TEST_F(KFDQMTest, SubmitPacketSdmaQueue) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SubmitPacketSdmaQueue(gpuNode);
     }));
 
@@ -283,7 +283,7 @@ void KFDQMTest::AllSdmaQueues(int gpuNode) {
 TEST_F(KFDQMTest, AllSdmaQueues) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->AllSdmaQueues(gpuNode);
     }));
 
@@ -339,7 +339,7 @@ void KFDQMTest::AllXgmiSdmaQueues(int gpuNode) {
 TEST_F(KFDQMTest, AllXgmiSdmaQueues) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->AllXgmiSdmaQueues(gpuNode);
     }));
 
@@ -443,7 +443,7 @@ void KFDQMTest::AllQueues(int gpuNode) {
 TEST_F(KFDQMTest, AllQueues) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->AllQueues(gpuNode);
     }));
 
@@ -512,7 +512,7 @@ void KFDQMTest::SdmaConcurrentCopies(int gpuNode) {
 TEST_F(KFDQMTest, SdmaConcurrentCopies) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SdmaConcurrentCopies(gpuNode);
     }));
 
@@ -564,7 +564,7 @@ void KFDQMTest::DisableCpQueueByUpdateWithNullAddress(int gpuNode) {
 TEST_F(KFDQMTest, DisableCpQueueByUpdateWithNullAddress) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->DisableCpQueueByUpdateWithNullAddress(gpuNode);
     }));
 
@@ -609,7 +609,7 @@ void KFDQMTest::DisableSdmaQueueByUpdateWithNullAddress(int gpuNode) {
 TEST_F(KFDQMTest, DisableSdmaQueueByUpdateWithNullAddress) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->DisableSdmaQueueByUpdateWithNullAddress(gpuNode);
     }));
 
@@ -664,7 +664,7 @@ void KFDQMTest::DisableCpQueueByUpdateWithZeroPercentage(int gpuNode) {
 TEST_F(KFDQMTest, DisableCpQueueByUpdateWithZeroPercentage) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->DisableCpQueueByUpdateWithZeroPercentage(gpuNode);
     }));
 
@@ -710,7 +710,7 @@ void KFDQMTest::CreateQueueStressSingleThreaded(int gpuNode) {
 TEST_F(KFDQMTest, CreateQueueStressSingleThreaded) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->CreateQueueStressSingleThreaded(gpuNode);
     }));
 
@@ -770,7 +770,7 @@ void KFDQMTest::OverSubscribeCpQueues(int gpuNode) {
 TEST_F(KFDQMTest, OverSubscribeCpQueues) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->OverSubscribeCpQueues(gpuNode);
     }));
 
@@ -885,7 +885,7 @@ void KFDQMTest::BasicCuMaskingLinear(int gpuNode) {
 TEST_F(KFDQMTest, BasicCuMaskingLinear) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->BasicCuMaskingLinear(gpuNode);
     }));
 
@@ -1487,7 +1487,7 @@ void KFDQMTest::extendedCuMasking(int gpuNode) {
 TEST_F(KFDQMTest, ExtendedCuMasking) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->extendedCuMasking(gpuNode);
     }));
 
@@ -1583,7 +1583,7 @@ void KFDQMTest::BasicCuMaskingEven(int gpuNode) {
 TEST_F(KFDQMTest, BasicCuMaskingEven) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->BasicCuMaskingEven(gpuNode);
     }));
 
@@ -1689,7 +1689,7 @@ void KFDQMTest::QueuePriorityOnDifferentPipe(int gpuNode) {
 TEST_F(KFDQMTest, QueuePriorityOnDifferentPipe) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->QueuePriorityOnDifferentPipe(gpuNode);
     }));
 
@@ -1704,7 +1704,7 @@ void  KFDQMTest::QueuePriorityOnSamePipe(int gpuNode) {
 TEST_F(KFDQMTest, QueuePriorityOnSamePipe) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->QueuePriorityOnSamePipe(gpuNode);
     }));
 
@@ -1748,7 +1748,7 @@ void KFDQMTest::EmptyDispatch(int gpuNode) {
 TEST_F(KFDQMTest, EmptyDispatch) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->EmptyDispatch(gpuNode);
     }));
 
@@ -1778,7 +1778,7 @@ void KFDQMTest::SimpleWriteDispatch(int gpuNode) {
 TEST_F(KFDQMTest, SimpleWriteDispatch) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SimpleWriteDispatch(gpuNode);
     }));
 
@@ -1848,7 +1848,7 @@ void KFDQMTest::MultipleCpQueuesStressDispatch(int gpuNode) {
 TEST_F(KFDQMTest, MultipleCpQueuesStressDispatch) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->MultipleCpQueuesStressDispatch(gpuNode);
     }));
 
@@ -1895,7 +1895,7 @@ void KFDQMTest::CpuWriteCoherence(int gpuNode) {
 TEST_F(KFDQMTest, CpuWriteCoherence) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->CpuWriteCoherence(gpuNode);
     }));
 
@@ -1916,7 +1916,7 @@ void KFDQMTest::CreateAqlCpQueue(int gpuNode) {
 TEST_F(KFDQMTest, CreateAqlCpQueue) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->CreateAqlCpQueue(gpuNode);
     }));
 
@@ -2056,7 +2056,7 @@ void KFDQMTest::QueueLatency(int gpuNode) {
 TEST_F(KFDQMTest, QueueLatency) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->QueueLatency(gpuNode);
     }));
 
@@ -2094,7 +2094,7 @@ void KFDQMTest::CpQueueWraparound(int gpuNode) {
 TEST_F(KFDQMTest, CpQueueWraparound) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->CpQueueWraparound(gpuNode);
     }));
 
@@ -2139,7 +2139,7 @@ void KFDQMTest::SdmaQueueWraparound(int gpuNode) {
 TEST_F(KFDQMTest, SdmaQueueWraparound) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SdmaQueueWraparound(gpuNode);
     }));
 
@@ -2225,7 +2225,7 @@ void KFDQMTest::Atomics(int gpuNode) {
 TEST_F(KFDQMTest, Atomics) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->Atomics(gpuNode);
     }));
 
@@ -2478,7 +2478,7 @@ void KFDQMTest::PM4EventInterrupt(int gpuNode) {
 TEST_F(KFDQMTest, PM4EventInterrupt) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->PM4EventInterrupt(gpuNode);
     }));
 
@@ -2588,7 +2588,7 @@ void KFDQMTest::SdmaEventInterrupt(int gpuNode) {
 TEST_F(KFDQMTest, SdmaEventInterrupt) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SdmaEventInterrupt(gpuNode);
     }));
 
@@ -2683,7 +2683,7 @@ void KFDQMTest::GPUDoorbellWrite(int gpuNode) {
 TEST_F(KFDQMTest, GPUDoorbellWrite) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->GPUDoorbellWrite(gpuNode);
     }));
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDQMTest.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDQMTest.hpp
@@ -69,10 +69,39 @@ class KFDQMTest : public KFDBaseComponentTest {
 
     ~KFDQMTest() {}
 
-    friend void BasicCuMaskingLinear(KFDTEST_PARAMETERS* pTestParamters);
-    friend void BasicCuMaskingEven(KFDTEST_PARAMETERS* pTestParamters);
-    friend void EmptyDispatch(KFDTEST_PARAMETERS* pTestParamters) ;
-    friend void SimpleWriteDispatch(KFDTEST_PARAMETERS* pTestParamters);
+    void CreateDestroyCpQueue(int gpuNode);
+    void SubmitNopCpQueue(int gpuNode);
+    void SubmitPacketCpQueue(int gpuNode);
+    void AllCpQueues(int gpuNode);
+    void CreateDestroySdmaQueue(int gpuNode);
+    void SubmitNopSdmaQueue(int gpuNode);
+    void SubmitPacketSdmaQueue(int gpuNode);
+    void AllSdmaQueues(int gpuNode);
+    void AllXgmiSdmaQueues(int gpuNode);
+    void AllQueues(int gpuNode);
+    void SdmaConcurrentCopies(int gpuNode);
+    void DisableCpQueueByUpdateWithNullAddress(int gpuNode);
+    void DisableSdmaQueueByUpdateWithNullAddress(int gpuNode);
+    void DisableCpQueueByUpdateWithZeroPercentage(int gpuNode);
+    void CreateQueueStressSingleThreaded(int gpuNode);
+    void OverSubscribeCpQueues(int gpuNode);
+    void BasicCuMaskingLinear(int gpuNode);
+    void extendedCuMasking(int gpuNode);
+    void BasicCuMaskingEven(int gpuNode);
+    void QueuePriorityOnDifferentPipe(int gpuNode);
+    void QueuePriorityOnSamePipe(int gpuNode);
+    void EmptyDispatch(int gpuNode);
+    void SimpleWriteDispatch(int gpuNode);
+    void MultipleCpQueuesStressDispatch(int gpuNode);
+    void CpuWriteCoherence(int gpuNode);
+    void CreateAqlCpQueue(int gpuNode);
+    void QueueLatency(int gpuNode);
+    void CpQueueWraparound(int gpuNode);
+    void SdmaQueueWraparound(int gpuNode);
+    void Atomics(int gpuNode);
+    void PM4EventInterrupt(int gpuNode);
+    void SdmaEventInterrupt(int gpuNode);
+    void GPUDoorbellWrite(int gpuNode);
 
  protected:
     virtual void SetUp();
@@ -81,7 +110,7 @@ class KFDQMTest : public KFDBaseComponentTest {
     void SyncDispatch(const HsaMemoryBuffer& isaBuffer, void* pSrcBuf, void* pDstBuf, int node = -1);
     HSAint64 TimeConsumedwithCUMask(int node, uint32_t *mask, uint32_t mask_count);
     HSAint64 GetAverageTimeConsumedwithCUMask(int node, uint32_t *mask, uint32_t mask_count, int iterations);
-    friend void testQueuePriority(KFDTEST_PARAMETERS* pTestParamters, bool isSamePipe);
+    void testQueuePriority(int gpuNode, bool isSamePipe);
 
  protected:  // Members
     /* Acceptable performance for CU Masking should be within 5% of linearly-predicted performance */

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
@@ -96,7 +96,7 @@ TEST_P(KFDSVMRangeTest, BasicSystemMemTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->BasicSystemMemTest(gpuNode);
     }));
 
@@ -182,7 +182,7 @@ TEST_P(KFDSVMRangeTest, SetGetAttributesTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SetGetAttributesTest(gpuNode);
     }));
 
@@ -245,7 +245,7 @@ void KFDSVMRangeTest::InvalidRangeTest(int gpuNode) {
 TEST_P(KFDSVMRangeTest, InvalidRangeTest) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->InvalidRangeTest(gpuNode);
     }));
 
@@ -346,7 +346,7 @@ void KFDSVMRangeTest::SplitSystemRangeTest(int gpuNode) {
 TEST_P(KFDSVMRangeTest, SplitSystemRangeTest) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SplitSystemRangeTest(gpuNode);
     }));
 
@@ -458,7 +458,7 @@ void KFDSVMRangeTest::EvictSystemRangeTest(int gpuNode) {
 TEST_P(KFDSVMRangeTest, EvictSystemRangeTest) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->EvictSystemRangeTest(gpuNode);
     }));
 
@@ -523,7 +523,7 @@ TEST_P(KFDSVMRangeTest, PartialUnmapSysMemTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->PartialUnmapSysMemTest(gpuNode);
     }));
 
@@ -581,7 +581,7 @@ TEST_P(KFDSVMRangeTest, BasicVramTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->BasicVramTest(gpuNode);
     }));
 
@@ -606,7 +606,7 @@ void KFDSVMRangeTest::SplitVramRangeTest(int gpuNode) {
 TEST_P(KFDSVMRangeTest, SplitVramRangeTest) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->SplitVramRangeTest(gpuNode);
     }));
 
@@ -657,7 +657,7 @@ void KFDSVMRangeTest::PrefetchTest(int gpuNode) {
 TEST_P(KFDSVMRangeTest, PrefetchTest) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->PrefetchTest(gpuNode);
     }));
 
@@ -740,7 +740,7 @@ TEST_P(KFDSVMRangeTest, MigrateTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->MigrateTest(gpuNode);
     }));
 
@@ -803,7 +803,7 @@ TEST_P(KFDSVMRangeTest, MigrateAccessInPlaceTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->MigrateAccessInPlaceTest(gpuNode);
     }));
 
@@ -883,7 +883,7 @@ TEST_P(KFDSVMRangeTest, MigrateGranularityTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->MigrateGranularityTest(gpuNode);
     }));
 
@@ -984,7 +984,7 @@ TEST_P(KFDSVMRangeTest, MigrateLargeBufTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->MigrateLargeBufTest(gpuNode);
     }));
 
@@ -1079,7 +1079,7 @@ TEST_P(KFDSVMRangeTest, MigratePolicyTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->MigratePolicyTest(gpuNode);
     }));
 
@@ -1339,7 +1339,7 @@ TEST_P(KFDSVMRangeTest, MultiThreadMigrationTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->MultiThreadMigrationTest(gpuNode);
     }));
 
@@ -1406,7 +1406,7 @@ TEST_P(KFDSVMRangeTest, MigrateFileBackedRangeTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->MigrateFileBackedRangeTest(gpuNode);
     }));
 
@@ -1661,7 +1661,7 @@ TEST_P(KFDSVMRangeTest, HMMProfilingEvent) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->HMMProfilingEvent(gpuNode);
     }));
 
@@ -1731,7 +1731,7 @@ TEST_P(KFDSVMRangeTest, VramOvercommitTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->VramOvercommitTest(gpuNode);
     }));
 
@@ -1842,7 +1842,7 @@ TEST_P(KFDSVMRangeTest, PrefaultPartialRangeTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
         this->PrefaultPartialRangeTest(gpuNode);
     }));
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
@@ -52,19 +52,16 @@ void KFDSVMRangeTest::TearDown() {
     ROUTINE_END
 }
 
-static void BasicSystemMemTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::BasicSystemMemTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
     PM4Queue queue;
     HSAuint64 AlternateVAGPU;
     unsigned int BufferSize = PAGE_SIZE;
 
-    if (!pKFDSVMRangeTest->GetVramSize(gpuNode)) {
+    if (!GetVramSize(gpuNode)) {
         LOG() << "Skipping test: No VRAM found." << std::endl;
         return;
     }
@@ -74,7 +71,7 @@ static void BasicSystemMemTest(KFDTEST_PARAMETERS* pTestParamters) {
     HsaSVMRange destSysBuffer(BufferSize,gpuNode);
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDSVMRangeTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
     srcSysBuffer.Fill(0x01010101);
@@ -99,20 +96,19 @@ TEST_P(KFDSVMRangeTest, BasicSystemMemTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(BasicSystemMemTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->BasicSystemMemTest(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void SetGetAttributesTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::SetGetAttributesTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
-    unsigned int m_FamilyId = pKFDSVMRangeTest->GetFamilyIdFromNodeId(gpuNode);
+    unsigned int m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
     if (m_FamilyId < FAMILY_AI) {
         LOG() << std::hex << "Skipping test: No svm range support for family ID 0x" << m_FamilyId << "." << std::endl;
         return;
@@ -186,7 +182,9 @@ TEST_P(KFDSVMRangeTest, SetGetAttributesTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(SetGetAttributesTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SetGetAttributesTest(gpuNode);
+    }));
 
     TEST_END
 }
@@ -229,15 +227,12 @@ TEST_P(KFDSVMRangeTest, XNACKModeTest) {
     TEST_END
 }
 
-static void InvalidRangeTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::InvalidRangeTest(int gpuNode) {
 
     HSAuint32 Flags;;
     HSAKMT_STATUS ret;
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
     Flags = HSA_SVM_FLAG_HOST_ACCESS | HSA_SVM_FLAG_COHERENT;
@@ -250,7 +245,9 @@ static void InvalidRangeTest(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_P(KFDSVMRangeTest, InvalidRangeTest) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(InvalidRangeTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->InvalidRangeTest(gpuNode);
+    }));
 
     TEST_END
 }
@@ -331,48 +328,44 @@ void KFDSVMRangeTest::SplitRangeTest(int gpuNode, int prefetch_location) {
     delete sysBuffer;
 }
 
-static void SplitSystemRangeTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::SplitSystemRangeTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    unsigned int m_FamilyId = pKFDSVMRangeTest->GetFamilyIdFromNodeId(gpuNode);
+    unsigned int m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
     if (m_FamilyId < FAMILY_AI) {
         LOG() << std::hex << "Skipping test: No svm range support for family ID 0x" << m_FamilyId << "." << std::endl;
         return;
     }
 
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
-    pKFDSVMRangeTest->SplitRangeTest(gpuNode, 0);
+    SplitRangeTest(gpuNode, 0);
 
 }
 
 TEST_P(KFDSVMRangeTest, SplitSystemRangeTest) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(SplitSystemRangeTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SplitSystemRangeTest(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void EvictSystemRangeTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::EvictSystemRangeTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    unsigned int m_FamilyId = pKFDSVMRangeTest->GetFamilyIdFromNodeId(gpuNode);
+    unsigned int m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
     if (m_FamilyId < FAMILY_AI) {
         LOG() << std::hex << "Skipping test: No svm range support for family ID 0x" << m_FamilyId << "." << std::endl;
         return;
     }
 
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDSVMRangeTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
     HSAuint32 stackData[2 * PAGE_SIZE] = {0};
@@ -465,21 +458,20 @@ static void EvictSystemRangeTest(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_P(KFDSVMRangeTest, EvictSystemRangeTest) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(EvictSystemRangeTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->EvictSystemRangeTest(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void PartialUnmapSysMemTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::PartialUnmapSysMemTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDSVMRangeTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
     unsigned int BufSize = 16 * PAGE_SIZE;
@@ -531,28 +523,27 @@ TEST_P(KFDSVMRangeTest, PartialUnmapSysMemTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-   ASSERT_SUCCESS(KFDTest_Launch(PartialUnmapSysMemTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->PartialUnmapSysMemTest(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void BasicVramTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::BasicVramTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
     Assembler* m_pAsm;
-    m_pAsm = pKFDSVMRangeTest->GetAssemblerFromNodeId(gpuNode);
+    m_pAsm = GetAssemblerFromNodeId(gpuNode);
     ASSERT_NOTNULL_GPU(m_pAsm, gpuNode);
 
     PM4Queue queue;
     HSAuint64 AlternateVAGPU;
     unsigned int BufferSize = PAGE_SIZE;
 
-    if (!pKFDSVMRangeTest->GetVramSize(gpuNode)) {
+    if (!GetVramSize(gpuNode)) {
         LOG() << "Skipping test: No VRAM found." << std::endl;
         return;
     }
@@ -590,43 +581,41 @@ TEST_P(KFDSVMRangeTest, BasicVramTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(BasicVramTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->BasicVramTest(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void SplitVramRangeTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::SplitVramRangeTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
-    unsigned int m_FamilyId = pKFDSVMRangeTest->GetFamilyIdFromNodeId(gpuNode);
+    unsigned int m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
     if (m_FamilyId < FAMILY_AI) {
         LOG() << std::hex << "Skipping test: No svm range support for family ID 0x" << m_FamilyId << "." << std::endl;
         return;
     }
 
-    pKFDSVMRangeTest->SplitRangeTest(gpuNode, gpuNode);
+    SplitRangeTest(gpuNode, gpuNode);
 
 }
 
 TEST_P(KFDSVMRangeTest, SplitVramRangeTest) {
     TEST_START(TESTPROFILE_RUNALL)
 
-    ASSERT_SUCCESS(KFDTest_Launch(SplitVramRangeTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->SplitVramRangeTest(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void PrefetchTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::PrefetchTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
     unsigned int BufSize = 16 << 10;
@@ -668,26 +657,25 @@ static void PrefetchTest(KFDTEST_PARAMETERS* pTestParamters) {
 TEST_P(KFDSVMRangeTest, PrefetchTest) {
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(PrefetchTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->PrefetchTest(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void MigrateTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::MigrateTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
-    unsigned int m_FamilyId = pKFDSVMRangeTest->GetFamilyIdFromNodeId(gpuNode);
+    unsigned int m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
     if (m_FamilyId < FAMILY_AI) {
         LOG() << std::hex << "Skipping test: No svm range support for family ID 0x" << m_FamilyId << "." << std::endl;
         return;
     }
 
-    if (!pKFDSVMRangeTest->GetVramSize(gpuNode)) {
+    if (!GetVramSize(gpuNode)) {
         LOG() << "Skipping test: No VRAM found." << std::endl;
         return;
     }
@@ -752,31 +740,30 @@ TEST_P(KFDSVMRangeTest, MigrateTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(MigrateTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->MigrateTest(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void MigrateAccessInPlaceTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::MigrateAccessInPlaceTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
-    unsigned int m_FamilyId = pKFDSVMRangeTest->GetFamilyIdFromNodeId(gpuNode);
+    unsigned int m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
     if (m_FamilyId < FAMILY_AI) {
         LOG() << std::hex << "Skipping test: No svm range support for family ID 0x" << m_FamilyId << "." << std::endl;
         return;
     }
 
-    if (!pKFDSVMRangeTest->GetVramSize(gpuNode)) {
+    if (!GetVramSize(gpuNode)) {
         LOG() << "Skipping test: No VRAM found." << std::endl;
         return;
     }
 
-    unsigned int BufferSize = MIN(256ULL << 20, pKFDSVMRangeTest->GetVramSize(gpuNode) / 2);
+    unsigned int BufferSize = MIN(256ULL << 20, GetVramSize(gpuNode) / 2);
     SDMAQueue sdmaQueue;
     ASSERT_SUCCESS_GPU(sdmaQueue.Create(gpuNode),gpuNode);
 
@@ -816,7 +803,9 @@ TEST_P(KFDSVMRangeTest, MigrateAccessInPlaceTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(MigrateAccessInPlaceTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->MigrateAccessInPlaceTest(gpuNode);
+    }));
 
     TEST_END
 }
@@ -840,21 +829,18 @@ TEST_P(KFDSVMRangeTest, MigrateAccessInPlaceTest) {
  * [  292.730931] amdgpu:svm_migrate_to_ram:744: CPU page fault address 0x7f22597f2000
  */
 
-static void MigrateGranularityTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::MigrateGranularityTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
-    unsigned int m_FamilyId = pKFDSVMRangeTest->GetFamilyIdFromNodeId(gpuNode);
+    unsigned int m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
     if (m_FamilyId < FAMILY_AI) {
         LOG() << std::hex << "Skipping test on gpuNode: No svm range support for family ID 0x" << gpuNode << m_FamilyId << "." << std::endl;
         return;
     }
 
-    if (!pKFDSVMRangeTest->GetVramSize(gpuNode)) {
+    if (!GetVramSize(gpuNode)) {
         LOG() << "Skipping test: No VRAM found on gpuNode." << gpuNode << std::endl;
         return;
     }
@@ -897,17 +883,16 @@ TEST_P(KFDSVMRangeTest, MigrateGranularityTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(MigrateGranularityTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->MigrateGranularityTest(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void MigrateLargeBufTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::MigrateLargeBufTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
     PM4Queue queue;
@@ -918,7 +903,7 @@ static void MigrateLargeBufTest(KFDTEST_PARAMETERS* pTestParamters) {
     unsigned long Size, i;
 
     HSAuint64 vramSize;
-    vramSize = pKFDSVMRangeTest->GetVramSize(gpuNode);
+    vramSize = GetVramSize(gpuNode);
     if (!vramSize) {
         LOG() << "Skipping test: No VRAM found." << std::endl;
         return;
@@ -929,7 +914,7 @@ static void MigrateLargeBufTest(KFDTEST_PARAMETERS* pTestParamters) {
     /* Check if the system memory size is sufficient
      * to register the system buffer and system buffer 2
      */
-    if(BufferSize * 2 > pKFDSVMRangeTest->GetSysMemSize() / 2) {
+    if(BufferSize * 2 > GetSysMemSize() / 2) {
         LOG() << "Skipping test: Not enough system memory." << std::endl;
         return;
     }
@@ -999,26 +984,25 @@ TEST_P(KFDSVMRangeTest, MigrateLargeBufTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(MigrateLargeBufTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->MigrateLargeBufTest(gpuNode);
+    }));
 
     TEST_END
 }
 
-static void MigratePolicyTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::MigratePolicyTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
-    unsigned int m_FamilyId = pKFDSVMRangeTest->GetFamilyIdFromNodeId(gpuNode);
+    unsigned int m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
     if (m_FamilyId < FAMILY_AI) {
         LOG() << std::hex << "Skipping test on gpuNode: No svm range support for family ID 0x" << gpuNode << m_FamilyId << "." << std::endl;
         return;
     }
 
-    if (!pKFDSVMRangeTest->GetVramSize(gpuNode)) {
+    if (!GetVramSize(gpuNode)) {
         LOG() << "Skipping test: No VRAM found." << std::endl;
         return;
     }
@@ -1095,7 +1079,9 @@ TEST_P(KFDSVMRangeTest, MigratePolicyTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(MigratePolicyTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->MigratePolicyTest(gpuNode);
+    }));
 
     TEST_END
 }
@@ -1301,15 +1287,12 @@ unsigned int GpuReadThread(void* p) {
     return 0;
 }
 
-static void MultiThreadMigrationTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::MultiThreadMigrationTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
-    unsigned int m_FamilyId = pKFDSVMRangeTest->GetFamilyIdFromNodeId(gpuNode);
+    unsigned int m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
     if (m_FamilyId < FAMILY_AI) {
         LOG() << std::hex << "Skipping test on gpuNode: No svm range support for family ID 0x" << gpuNode << m_FamilyId << "." << std::endl;
         return;
@@ -1356,7 +1339,9 @@ TEST_P(KFDSVMRangeTest, MultiThreadMigrationTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(MultiThreadMigrationTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->MultiThreadMigrationTest(gpuNode);
+    }));
 
     TEST_END
 }
@@ -1369,15 +1354,12 @@ TEST_P(KFDSVMRangeTest, MultiThreadMigrationTest) {
  * Use sdma to write data to memory, should write to file
  * Close file, and then check if file data is updated correctly
  */
-static void MigrateFileBackedRangeTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::MigrateFileBackedRangeTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
-    unsigned int m_FamilyId = pKFDSVMRangeTest->GetFamilyIdFromNodeId(gpuNode);
+    unsigned int m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
     if (m_FamilyId < FAMILY_AI) {
         LOG() << std::hex << "Skipping test on gpuNode: No svm range support for family ID 0x"
             << gpuNode << m_FamilyId << "." << std::endl;
@@ -1424,7 +1406,9 @@ TEST_P(KFDSVMRangeTest, MigrateFileBackedRangeTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(MigrateFileBackedRangeTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->MigrateFileBackedRangeTest(gpuNode);
+    }));
 
     TEST_END
 }
@@ -1629,30 +1613,27 @@ unsigned int ReadSMIEventThread(void* p) {
     return 0;
 }
 
-static void HMMProfilingEvent(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::HMMProfilingEvent(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
-    if (pKFDSVMRangeTest->Get_Version()->KernelInterfaceMinorVersion < 10)
+    if (Get_Version()->KernelInterfaceMinorVersion < 10)
         return;
 
     const HsaNodeProperties *pNodeProperties =
-        pKFDSVMRangeTest->Get_NodeInfo()->GetNodeProperties(gpuNode);
+        Get_NodeInfo()->GetNodeProperties(gpuNode);
     if (pNodeProperties->Integrated) {
         LOG() << "Skipping test on APU." << std::endl;
         return;
     }
 
-    if (!pKFDSVMRangeTest->GetVramSize(gpuNode)) {
+    if (!GetVramSize(gpuNode)) {
         LOG() << "Skipping test: No VRAM found." << std::endl;
         return;
     }
 
-    if (pKFDSVMRangeTest->Get_NodeInfo()->IsAppAPU(gpuNode)) {
+    if (Get_NodeInfo()->IsAppAPU(gpuNode)) {
         LOG() << "Skipping test on AppAPU." << std::endl;
         return;
     }
@@ -1680,7 +1661,9 @@ TEST_P(KFDSVMRangeTest, HMMProfilingEvent) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(HMMProfilingEvent));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->HMMProfilingEvent(gpuNode);
+    }));
 
     TEST_END
 }
@@ -1692,21 +1675,18 @@ TEST_P(KFDSVMRangeTest, HMMProfilingEvent) {
  * KFD should support VRAM overcommitment by evicting SVM ranges to system memory to alloc
  * VRAM for new ranges.
  */
-static void VramOvercommitTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::VramOvercommitTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
-    unsigned int m_FamilyId = pKFDSVMRangeTest->GetFamilyIdFromNodeId(gpuNode);
+    unsigned int m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
     if (m_FamilyId < FAMILY_AI) {
         LOG() << std::hex << "Skipping test on gpuNode: No svm range support for family ID 0x" << gpuNode << m_FamilyId << "." << std::endl;
         return;
     }
 
-    HSAuint64 vramSize = pKFDSVMRangeTest->GetVramSize(gpuNode);
+    HSAuint64 vramSize = GetVramSize(gpuNode);
     if (!vramSize) {
         LOG() << "Skipping test: No VRAM found." << std::endl;
         return;
@@ -1715,11 +1695,11 @@ static void VramOvercommitTest(KFDTEST_PARAMETERS* pTestParamters) {
     unsigned long overCommitSize = 1UL << 30;
 
     /* With XNACK off, KFD checks that all SVM memory will fit into system memory */
-	if (!g_TestGPUsNum && vramSize + overCommitSize > pKFDSVMRangeTest->GetSysMemSize() / 2) {
+	if (!g_TestGPUsNum && vramSize + overCommitSize > GetSysMemSize() / 2) {
         LOG() << "Skipping test: Not enough system memory." << std::endl;
         return;
 	} else if (g_TestGPUsNum && g_TestGPUsNum *(vramSize + overCommitSize)
-			    > pKFDSVMRangeTest->GetSysMemSize() / 2) {
+			    > GetSysMemSize() / 2) {
         LOG() << "Skipping test: Not enough system memory." << std::endl;
         return;
 	}
@@ -1751,7 +1731,9 @@ TEST_P(KFDSVMRangeTest, VramOvercommitTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(VramOvercommitTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->VramOvercommitTest(gpuNode);
+    }));
 
     TEST_END
 }
@@ -1814,15 +1796,12 @@ TEST_P(KFDSVMRangeTest, VramOvercommitGiantRangeTest) {
  * use sdma to memset the rest 2 pages, each page has different value 0x1, 0x2, 0x3, 0x4
  * then check if all page have the specific value after migrating 4 pages to system memory.
  */
-static void PrefaultPartialRangeTest(KFDTEST_PARAMETERS* pTestParamters) {
+void KFDSVMRangeTest::PrefaultPartialRangeTest(int gpuNode) {
 
-    int gpuNode = pTestParamters->gpuNode;
-    KFDSVMRangeTest* pKFDSVMRangeTest = (KFDSVMRangeTest*)pTestParamters->pTestObject;
-
-    if (!pKFDSVMRangeTest->SVMAPISupported_GPU(gpuNode))
+    if (!SVMAPISupported_GPU(gpuNode))
         return;
 
-    unsigned int m_FamilyId = pKFDSVMRangeTest->GetFamilyIdFromNodeId(gpuNode);
+    unsigned int m_FamilyId = GetFamilyIdFromNodeId(gpuNode);
     if (m_FamilyId < FAMILY_AI) {
         LOG() << std::hex << "Skipping test on gpuNode: No svm range support for family ID 0x" << gpuNode << m_FamilyId << "." << std::endl;
         return;
@@ -1863,7 +1842,9 @@ TEST_P(KFDSVMRangeTest, PrefaultPartialRangeTest) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);
 
-    ASSERT_SUCCESS(KFDTest_Launch(PrefaultPartialRangeTest));
+    ASSERT_SUCCESS(KFDTestLaunchStd([this](int gpuNode) {
+        this->PrefaultPartialRangeTest(gpuNode);
+    }));
 
     TEST_END
 }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.hpp
@@ -34,6 +34,25 @@ class KFDSVMRangeTest : public KFDBaseComponentTest,
     KFDSVMRangeTest() {}
     ~KFDSVMRangeTest() {}
     void SplitRangeTest(int defaultGPUNode, int prefetch_location);
+    void BasicSystemMemTest(int gpuNode);
+    void SetGetAttributesTest(int gpuNode);
+    void InvalidRangeTest(int gpuNode);
+    void SplitSystemRangeTest(int gpuNode);
+    void EvictSystemRangeTest(int gpuNode);
+    void PartialUnmapSysMemTest(int gpuNode);
+    void BasicVramTest(int gpuNode);
+    void SplitVramRangeTest(int gpuNode);
+    void PrefetchTest(int gpuNode);
+    void MigrateTest(int gpuNode);
+    void MigrateAccessInPlaceTest(int gpuNode);
+    void MigrateGranularityTest(int gpuNode);
+    void MigrateLargeBufTest(int gpuNode);
+    void MigratePolicyTest(int gpuNode);
+    void MultiThreadMigrationTest(int gpuNode);
+    void MigrateFileBackedRangeTest(int gpuNode);
+    void HMMProfilingEvent(int gpuNode);
+    void VramOvercommitTest(int gpuNode);
+    void PrefaultPartialRangeTest(int gpuNode);
 
  protected:
     virtual void SetUp();


### PR DESCRIPTION
Modify concurrent kfdtest to use std::thread
instead of pthread, eventually modify KFDTestLaunch to take in a member function of test instance
instead of static function.

Convert KFDQMTest to pass in member function for
multi-gpu kfdtest.

## Motivation

Part of kfdtest improvement plan.
