### PR TITLE
[ROCProfiler-SDK] Remove Python library dependency from Python bindings

### DIFF
--- a/projects/rocprofiler-sdk/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/CMakeLists.txt
@@ -39,7 +39,8 @@ endif()
 
 find_package(Git)
 
-if(Git_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+if(Git_FOUND AND (EXISTS "${PROJECT_SOURCE_DIR}/../../.git"
+                  OR EXISTS "${PROJECT_SOURCE_DIR}/.git"))
     execute_process(
         COMMAND ${GIT_EXECUTABLE} describe --tags
         OUTPUT_VARIABLE ROCPROFILER_SDK_GIT_DESCRIBE

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_config_packaging.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_config_packaging.cmake
@@ -58,14 +58,15 @@ list(REMOVE_ITEM ROCPROFILER_PACKAGING_COMPONENTS "Development" "Unspecified")
 list(LENGTH ROCPROFILER_PACKAGING_COMPONENTS NUM_ROCPROFILER_PACKAGING_COMPONENTS)
 
 # the packages we will generate
-set(ROCPROFILER_COMPONENT_GROUPS "core" "docs" "tests" "roctx" "rocpd")
+set(ROCPROFILER_COMPONENT_GROUPS "core" "docs" "tests" "roctx" "rocpd" "benchmark")
 
-set(COMPONENT_GROUP_core_COMPONENTS "core" "development" "samples" "tools" "benchmark"
-                                    "Development" "Unspecified")
+set(COMPONENT_GROUP_core_COMPONENTS "core" "development" "samples" "tools" "Development"
+                                    "Unspecified")
 set(COMPONENT_GROUP_docs_COMPONENTS "docs")
 set(COMPONENT_GROUP_tests_COMPONENTS "tests")
 set(COMPONENT_GROUP_roctx_COMPONENTS "roctx")
 set(COMPONENT_GROUP_rocpd_COMPONENTS "rocpd")
+set(COMPONENT_GROUP_benchmark_COMPONENTS "benchmark")
 
 # variables for each component group. Note: eventually we will probably want to separate
 # the core to just be the runtime libraries, development to be the headers and cmake
@@ -76,6 +77,7 @@ set(COMPONENT_NAME_docs "rocprofiler-sdk-docs")
 set(COMPONENT_NAME_tests "rocprofiler-sdk-tests")
 set(COMPONENT_NAME_roctx "rocprofiler-sdk-roctx")
 set(COMPONENT_NAME_rocpd "rocprofiler-sdk-rocpd")
+set(COMPONENT_NAME_benchmark "rocprofiler-sdk-benchmark")
 
 set(COMPONENT_DEP_core "rocprofiler-sdk-roctx (>= ${PROJECT_VERSION})"
                        "rocprofiler-sdk-rocpd (>= ${PROJECT_VERSION})")
@@ -86,12 +88,14 @@ set(COMPONENT_DEP_tests
     "rocprofiler-sdk-rocpd (>= ${PROJECT_VERSION})")
 set(COMPONENT_DEP_roctx "rocprofiler-register")
 set(COMPONENT_DEP_rocpd "")
+set(COMPONENT_DEP_benchmark "rocprofiler-sdk (>= ${PROJECT_VERSION})")
 
 set(COMPONENT_DESC_core "rocprofiler-sdk libraries, headers, samples, and tools")
 set(COMPONENT_DESC_docs "rocprofiler-sdk documentation")
 set(COMPONENT_DESC_tests "rocprofiler-sdk tests")
 set(COMPONENT_DESC_roctx "ROCm Tools Extension library and headers")
 set(COMPONENT_DESC_rocpd "ROCm Profiling Data library and headers")
+set(COMPONENT_DESC_benchmark "rocprofiler-sdk benchmark")
 
 set(EXPECTED_PACKAGING_COMPONENTS 7)
 if(ROCPROFILER_BUILD_DOCS)
@@ -108,13 +112,19 @@ if(NOT NUM_ROCPROFILER_PACKAGING_COMPONENTS EQUAL EXPECTED_PACKAGING_COMPONENTS)
         )
 endif()
 
+# default values
+set(_DEB_PACKAGE_DEPENDS)
+set(_RPM_PACKAGE_REQUIRES)
+
+# append rocm-core dependency if option specified
 if(ROCM_DEP_ROCMCORE OR ROCPROFILER_DEP_ROCMCORE)
-    set(CPACK_DEBIAN_PACKAGE_DEPENDS "rocm-core")
-    set(CPACK_RPM_PACKAGE_REQUIRES "rocm-core")
-else()
-    set(CPACK_DEBIAN_PACKAGE_DEPENDS "")
-    set(CPACK_RPM_PACKAGE_REQUIRES "")
+    set(_DEB_PACKAGE_DEPENDS "rocm-core")
+    set(_RPM_PACKAGE_REQUIRES "rocm-core")
 endif()
+
+# support general cache variables
+list(APPEND _DEB_PACKAGE_DEPENDS ${ROCPROFILER_CPACK_DEBIAN_PACKAGE_DEPENDS})
+list(APPEND _RPM_PACKAGE_REQUIRES ${ROCPROFILER_CPACK_RPM_PACKAGE_REQUIRES})
 
 foreach(COMPONENT_GROUP ${ROCPROFILER_COMPONENT_GROUPS})
     set(_DEP "${COMPONENT_DEP_${COMPONENT_GROUP}}")
@@ -160,27 +170,25 @@ set(CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS ON) # generate list of shared libs prov
                                              # package
 set(CPACK_DEBIAN_TESTS_PACKAGE_SHLIBDEPS OFF) # disable for tests package
 set(CPACK_DEBIAN_TESTS_PACKAGE_GENERATE_SHLIBS OFF) # disable for tests package
-# Python extension modules are loadable modules, not shared libraries - disable shared
-# library processing
-set(CPACK_DEBIAN_ROCPD_PACKAGE_SHLIBDEPS OFF) # Python modules don't need dependency
-                                              # scanning
-set(CPACK_DEBIAN_ROCPD_PACKAGE_GENERATE_SHLIBS OFF) # Python modules don't need SONAME
-set(CPACK_DEBIAN_ROCTX_PACKAGE_SHLIBDEPS OFF) # Python modules don't need dependency
-                                              # scanning
-set(CPACK_DEBIAN_ROCTX_PACKAGE_GENERATE_SHLIBS OFF) # Python modules don't need SONAME
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "${PROJECT_HOMEPAGE_URL}")
 set(CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS_POLICY ">=")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS_PRIVATE_DIRS
     ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}
     ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/${CPACK_PACKAGE_NAME})
+if(rocm_version_DIR)
+    # library directory of ROCm install is treated as private directory for shlibdeps
+    # since most ROCm packages do not set CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS=ON
+    list(APPEND CPACK_DEBIAN_PACKAGE_SHLIBDEPS_PRIVATE_DIRS
+         "${rocm_version_DIR}/${CMAKE_INSTALL_LIBDIR}")
+endif()
 if(DEFINED ENV{CPACK_DEBIAN_PACKAGE_RELEASE})
     set(CPACK_DEBIAN_PACKAGE_RELEASE
         "$ENV{CPACK_DEBIAN_PACKAGE_RELEASE}"
         CACHE STRING "" FORCE)
 endif()
 
-rocprofiler_set_package_depends(CPACK_DEBIAN_PACKAGE_DEPENDS
-                                "${CPACK_DEBIAN_PACKAGE_DEPENDS}" "Debian" OFF)
+rocprofiler_set_package_depends(CPACK_DEBIAN_PACKAGE_DEPENDS "${_DEB_PACKAGE_DEPENDS}"
+                                "Debian" OFF)
 set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
 set(CPACK_DEBIAN_PACKAGE_VERSION "${PROJECT_VERSION}")
 
@@ -202,14 +210,14 @@ set(CPACK_RPM_PACKAGE_AUTOREQ
 set(CPACK_RPM_PACKAGE_AUTOPROV ON) # generate list of shared libs provided by package
 set(CPACK_RPM_TESTS_PACKAGE_AUTOREQ OFF) # disable for tests package
 set(CPACK_RPM_TESTS_PACKAGE_AUTOPROV OFF) # disable for tests package
-# Python extension modules should not have automatic dependency generation
-set(CPACK_RPM_ROCPD_PACKAGE_AUTOPROV OFF) # Python modules don't provide shared libraries
-set(CPACK_RPM_ROCTX_PACKAGE_AUTOPROV OFF) # Python modules don't provide shared libraries
 if(DEFINED ENV{CPACK_RPM_PACKAGE_RELEASE})
     set(CPACK_RPM_PACKAGE_RELEASE
         "$ENV{CPACK_RPM_PACKAGE_RELEASE}"
         CACHE STRING "" FORCE)
 endif()
+
+rocprofiler_set_package_depends(CPACK_RPM_PACKAGE_REQUIRES "${_RPM_PACKAGE_REQUIRES}"
+                                "RedHat" ON)
 
 # Get rpm distro
 if(CPACK_RPM_PACKAGE_RELEASE)

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_config_packaging.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_config_packaging.cmake
@@ -160,6 +160,14 @@ set(CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS ON) # generate list of shared libs prov
                                              # package
 set(CPACK_DEBIAN_TESTS_PACKAGE_SHLIBDEPS OFF) # disable for tests package
 set(CPACK_DEBIAN_TESTS_PACKAGE_GENERATE_SHLIBS OFF) # disable for tests package
+# Python extension modules are loadable modules, not shared libraries - disable shared
+# library processing
+set(CPACK_DEBIAN_ROCPD_PACKAGE_SHLIBDEPS OFF) # Python modules don't need dependency
+                                              # scanning
+set(CPACK_DEBIAN_ROCPD_PACKAGE_GENERATE_SHLIBS OFF) # Python modules don't need SONAME
+set(CPACK_DEBIAN_ROCTX_PACKAGE_SHLIBDEPS OFF) # Python modules don't need dependency
+                                              # scanning
+set(CPACK_DEBIAN_ROCTX_PACKAGE_GENERATE_SHLIBS OFF) # Python modules don't need SONAME
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "${PROJECT_HOMEPAGE_URL}")
 set(CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS_POLICY ">=")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS_PRIVATE_DIRS
@@ -194,6 +202,9 @@ set(CPACK_RPM_PACKAGE_AUTOREQ
 set(CPACK_RPM_PACKAGE_AUTOPROV ON) # generate list of shared libs provided by package
 set(CPACK_RPM_TESTS_PACKAGE_AUTOREQ OFF) # disable for tests package
 set(CPACK_RPM_TESTS_PACKAGE_AUTOPROV OFF) # disable for tests package
+# Python extension modules should not have automatic dependency generation
+set(CPACK_RPM_ROCPD_PACKAGE_AUTOPROV OFF) # Python modules don't provide shared libraries
+set(CPACK_RPM_ROCTX_PACKAGE_AUTOPROV OFF) # Python modules don't provide shared libraries
 if(DEFINED ENV{CPACK_RPM_PACKAGE_RELEASE})
     set(CPACK_RPM_PACKAGE_RELEASE
         "$ENV{CPACK_RPM_PACKAGE_RELEASE}"

--- a/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
+++ b/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
@@ -126,9 +126,8 @@ function(rocprofiler_roctx_python_bindings _VERSION)
         PRIVATE rocprofiler-sdk-roctx::rocprofiler-sdk-roctx-shared-library
                 rocprofiler-sdk::rocprofiler-sdk-pybind11)
 
-    # Sanitizers require explicit linking to libpython because they need all symbols
-    # resolved at link time. For normal builds, we avoid linking to allow manylinux
-    # compatibility.
+    # if "Development" is specified instead of "Development.Module", we need to link to
+    # python libraries
     if("Development" IN_LIST ROCPROFILER_BUILD_Find_Python3_COMPONENTS)
         target_link_libraries(rocprofiler-sdk-roctx-python-bindings-${_VERSION}
                               PRIVATE ${Python3_LIBRARIES})
@@ -212,9 +211,8 @@ function(rocprofiler_rocpd_python_bindings _VERSION)
                 rocprofiler-sdk::rocprofiler-sdk-static-library
                 rocprofiler-sdk::rocprofiler-sdk-rocpd-library)
 
-    # Sanitizers require explicit linking to libpython because they need all symbols
-    # resolved at link time. For normal builds, we avoid linking to allow manylinux
-    # compatibility.
+    # if "Development" is specified instead of "Development.Module", we need to link to
+    # python libraries
     if("Development" IN_LIST ROCPROFILER_BUILD_Find_Python3_COMPONENTS)
         target_link_libraries(rocprofiler-sdk-rocpd-python-bindings-${_VERSION}
                               PRIVATE ${Python3_LIBRARIES})

--- a/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
+++ b/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
@@ -31,10 +31,10 @@ endmacro()
 macro(rocprofiler_find_python3 _VERSION)
     rocprofiler_reset_python3_cache()
 
-    # Sanitizers need Development (full) to get Python3_LIBRARIES for linking Otherwise
-    # use Development.Module for manylinux compatibility (CMake 3.18+)
+    # Sanitizers need Development (full) to get Python3_LIBRARIES for linking otherwise
+    # use Development.Module for manylinux compatibility
     if("${_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
-        if(ROCPROFILER_MEMCHECK OR CMAKE_VERSION VERSION_LESS "3.18")
+        if(ROCPROFILER_MEMCHECK)
             find_package(Python3 ${_VERSION} EXACT ${ARGN} REQUIRED MODULE
                          COMPONENTS Interpreter Development)
         else()
@@ -42,7 +42,7 @@ macro(rocprofiler_find_python3 _VERSION)
                          COMPONENTS Interpreter Development.Module)
         endif()
     elseif("${_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)$")
-        if(ROCPROFILER_MEMCHECK OR CMAKE_VERSION VERSION_LESS "3.18")
+        if(ROCPROFILER_MEMCHECK)
             find_package(Python3 ${_VERSION}.0...${_VERSION}.999 ${ARGN} REQUIRED MODULE
                          COMPONENTS Interpreter Development)
         else()

--- a/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
+++ b/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
@@ -68,7 +68,7 @@ function(get_default_python_versions _VAR)
     set(_PYTHON_FOUND_VERSIONS)
 
     foreach(_VER IN LISTS ROCPROFILER_PYTHON_VERSION_CANDIDATES)
-        if(ROCPROFILER_MEMCHECK OR CMAKE_VERSION VERSION_LESS "3.18")
+        if(ROCPROFILER_MEMCHECK)
             find_package(Python3 ${_VER} EXACT QUIET COMPONENTS Interpreter Development)
         else()
             find_package(Python3 ${_VER} EXACT QUIET COMPONENTS Interpreter
@@ -82,7 +82,7 @@ function(get_default_python_versions _VAR)
 
     # If none found, do one last check for 3.6 (no EXACT)
     if(NOT _PYTHON_FOUND_VERSIONS)
-        if(ROCPROFILER_MEMCHECK OR CMAKE_VERSION VERSION_LESS "3.18")
+        if(ROCPROFILER_MEMCHECK)
             find_package(Python3 3.6 COMPONENTS Interpreter Development)
         else()
             find_package(Python3 3.6 COMPONENTS Interpreter Development.Module)

--- a/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
+++ b/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
@@ -33,10 +33,10 @@ macro(rocprofiler_find_python3 _VERSION)
 
     if("${_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
         find_package(Python3 ${_VERSION} EXACT ${ARGN} REQUIRED MODULE
-                     COMPONENTS Interpreter Development)
+                     COMPONENTS Interpreter Development.Module)
     elseif("${_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)$")
         find_package(Python3 ${_VERSION}.0...${_VERSION}.999 ${ARGN} REQUIRED MODULE
-                     COMPONENTS Interpreter Development)
+                     COMPONENTS Interpreter Development.Module)
     else()
         message(
             FATAL_ERROR
@@ -56,7 +56,8 @@ function(get_default_python_versions _VAR)
     set(_PYTHON_FOUND_VERSIONS)
 
     foreach(_VER IN LISTS ROCPROFILER_PYTHON_VERSION_CANDIDATES)
-        find_package(Python3 ${_VER} EXACT QUIET COMPONENTS Interpreter Development)
+        find_package(Python3 ${_VER} EXACT QUIET COMPONENTS Interpreter
+                                                            Development.Module)
         if(Python3_FOUND)
             list(APPEND _PYTHON_FOUND_VERSIONS
                  "${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}")
@@ -65,7 +66,7 @@ function(get_default_python_versions _VAR)
 
     # If none found, do one last check for 3.6 (no EXACT)
     if(NOT _PYTHON_FOUND_VERSIONS)
-        find_package(Python3 3.6 COMPONENTS Interpreter Development)
+        find_package(Python3 3.6 COMPONENTS Interpreter Development.Module)
         if(Python3_FOUND)
             list(APPEND _PYTHON_FOUND_VERSIONS
                  "${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}")
@@ -112,7 +113,7 @@ function(rocprofiler_roctx_python_bindings _VERSION)
     target_link_libraries(
         rocprofiler-sdk-roctx-python-bindings-${_VERSION}
         PRIVATE rocprofiler-sdk-roctx::rocprofiler-sdk-roctx-shared-library
-                rocprofiler-sdk::rocprofiler-sdk-pybind11 ${Python3_LIBRARIES})
+                rocprofiler-sdk::rocprofiler-sdk-pybind11)
 
     set_target_properties(
         rocprofiler-sdk-roctx-python-bindings-${_VERSION}
@@ -190,8 +191,7 @@ function(rocprofiler_rocpd_python_bindings _VERSION)
                 rocprofiler-sdk::rocprofiler-sdk-gotcha
                 rocprofiler-sdk::rocprofiler-sdk-dw
                 rocprofiler-sdk::rocprofiler-sdk-static-library
-                rocprofiler-sdk::rocprofiler-sdk-rocpd-library
-                ${Python3_LIBRARIES})
+                rocprofiler-sdk::rocprofiler-sdk-rocpd-library)
 
     set_target_properties(
         rocprofiler-sdk-rocpd-python-bindings-${_VERSION}

--- a/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
+++ b/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
@@ -31,12 +31,24 @@ endmacro()
 macro(rocprofiler_find_python3 _VERSION)
     rocprofiler_reset_python3_cache()
 
+    # Sanitizers need Development (full) to get Python3_LIBRARIES for linking Otherwise
+    # use Development.Module for manylinux compatibility (CMake 3.18+)
     if("${_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
-        find_package(Python3 ${_VERSION} EXACT ${ARGN} REQUIRED MODULE
-                     COMPONENTS Interpreter Development.Module)
+        if(ROCPROFILER_MEMCHECK OR CMAKE_VERSION VERSION_LESS "3.18")
+            find_package(Python3 ${_VERSION} EXACT ${ARGN} REQUIRED MODULE
+                         COMPONENTS Interpreter Development)
+        else()
+            find_package(Python3 ${_VERSION} EXACT ${ARGN} REQUIRED MODULE
+                         COMPONENTS Interpreter Development.Module)
+        endif()
     elseif("${_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)$")
-        find_package(Python3 ${_VERSION}.0...${_VERSION}.999 ${ARGN} REQUIRED MODULE
-                     COMPONENTS Interpreter Development.Module)
+        if(ROCPROFILER_MEMCHECK OR CMAKE_VERSION VERSION_LESS "3.18")
+            find_package(Python3 ${_VERSION}.0...${_VERSION}.999 ${ARGN} REQUIRED MODULE
+                         COMPONENTS Interpreter Development)
+        else()
+            find_package(Python3 ${_VERSION}.0...${_VERSION}.999 ${ARGN} REQUIRED MODULE
+                         COMPONENTS Interpreter Development.Module)
+        endif()
     else()
         message(
             FATAL_ERROR
@@ -56,8 +68,12 @@ function(get_default_python_versions _VAR)
     set(_PYTHON_FOUND_VERSIONS)
 
     foreach(_VER IN LISTS ROCPROFILER_PYTHON_VERSION_CANDIDATES)
-        find_package(Python3 ${_VER} EXACT QUIET COMPONENTS Interpreter
-                                                            Development.Module)
+        if(ROCPROFILER_MEMCHECK OR CMAKE_VERSION VERSION_LESS "3.18")
+            find_package(Python3 ${_VER} EXACT QUIET COMPONENTS Interpreter Development)
+        else()
+            find_package(Python3 ${_VER} EXACT QUIET COMPONENTS Interpreter
+                                                                Development.Module)
+        endif()
         if(Python3_FOUND)
             list(APPEND _PYTHON_FOUND_VERSIONS
                  "${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}")
@@ -66,7 +82,11 @@ function(get_default_python_versions _VAR)
 
     # If none found, do one last check for 3.6 (no EXACT)
     if(NOT _PYTHON_FOUND_VERSIONS)
-        find_package(Python3 3.6 COMPONENTS Interpreter Development.Module)
+        if(ROCPROFILER_MEMCHECK OR CMAKE_VERSION VERSION_LESS "3.18")
+            find_package(Python3 3.6 COMPONENTS Interpreter Development)
+        else()
+            find_package(Python3 3.6 COMPONENTS Interpreter Development.Module)
+        endif()
         if(Python3_FOUND)
             list(APPEND _PYTHON_FOUND_VERSIONS
                  "${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}")
@@ -114,6 +134,14 @@ function(rocprofiler_roctx_python_bindings _VERSION)
         rocprofiler-sdk-roctx-python-bindings-${_VERSION}
         PRIVATE rocprofiler-sdk-roctx::rocprofiler-sdk-roctx-shared-library
                 rocprofiler-sdk::rocprofiler-sdk-pybind11)
+
+    # Sanitizers require explicit linking to libpython because they need all symbols
+    # resolved at link time. For normal builds, we avoid linking to allow manylinux
+    # compatibility.
+    if(ROCPROFILER_MEMCHECK)
+        target_link_libraries(rocprofiler-sdk-roctx-python-bindings-${_VERSION}
+                              PRIVATE ${Python3_LIBRARIES})
+    endif()
 
     set_target_properties(
         rocprofiler-sdk-roctx-python-bindings-${_VERSION}
@@ -192,6 +220,14 @@ function(rocprofiler_rocpd_python_bindings _VERSION)
                 rocprofiler-sdk::rocprofiler-sdk-dw
                 rocprofiler-sdk::rocprofiler-sdk-static-library
                 rocprofiler-sdk::rocprofiler-sdk-rocpd-library)
+
+    # Sanitizers require explicit linking to libpython because they need all symbols
+    # resolved at link time. For normal builds, we avoid linking to allow manylinux
+    # compatibility.
+    if(ROCPROFILER_MEMCHECK)
+        target_link_libraries(rocprofiler-sdk-rocpd-python-bindings-${_VERSION}
+                              PRIVATE ${Python3_LIBRARIES})
+    endif()
 
     set_target_properties(
         rocprofiler-sdk-rocpd-python-bindings-${_VERSION}

--- a/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
+++ b/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
@@ -28,27 +28,26 @@ macro(rocprofiler_reset_python3_cache)
     endforeach()
 endmacro()
 
+# use Development.Module for manylinux compatibility
+set(ROCPROFILER_BUILD_Find_Python3_COMPONENTS
+    "Interpreter;Development.Module"
+    CACHE STRING "Components to find for Python3")
+
+if(ROCPROFILER_MEMCHECK)
+    # override with local variable for sanitizers. Sanitizers need Development (full) to
+    # get Python3_LIBRARIES for linking
+    set(ROCPROFILER_BUILD_Find_Python3_COMPONENTS "Interpreter" "Development")
+endif()
+
 macro(rocprofiler_find_python3 _VERSION)
     rocprofiler_reset_python3_cache()
 
-    # Sanitizers need Development (full) to get Python3_LIBRARIES for linking otherwise
-    # use Development.Module for manylinux compatibility
     if("${_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
-        if(ROCPROFILER_MEMCHECK)
-            find_package(Python3 ${_VERSION} EXACT ${ARGN} REQUIRED MODULE
-                         COMPONENTS Interpreter Development)
-        else()
-            find_package(Python3 ${_VERSION} EXACT ${ARGN} REQUIRED MODULE
-                         COMPONENTS Interpreter Development.Module)
-        endif()
+        find_package(Python3 ${_VERSION} EXACT ${ARGN} REQUIRED MODULE
+                     COMPONENTS ${ROCPROFILER_BUILD_Find_Python3_COMPONENTS})
     elseif("${_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)$")
-        if(ROCPROFILER_MEMCHECK)
-            find_package(Python3 ${_VERSION}.0...${_VERSION}.999 ${ARGN} REQUIRED MODULE
-                         COMPONENTS Interpreter Development)
-        else()
-            find_package(Python3 ${_VERSION}.0...${_VERSION}.999 ${ARGN} REQUIRED MODULE
-                         COMPONENTS Interpreter Development.Module)
-        endif()
+        find_package(Python3 ${_VERSION}.0...${_VERSION}.999 ${ARGN} REQUIRED MODULE
+                     COMPONENTS ${ROCPROFILER_BUILD_Find_Python3_COMPONENTS})
     else()
         message(
             FATAL_ERROR
@@ -68,12 +67,8 @@ function(get_default_python_versions _VAR)
     set(_PYTHON_FOUND_VERSIONS)
 
     foreach(_VER IN LISTS ROCPROFILER_PYTHON_VERSION_CANDIDATES)
-        if(ROCPROFILER_MEMCHECK)
-            find_package(Python3 ${_VER} EXACT QUIET COMPONENTS Interpreter Development)
-        else()
-            find_package(Python3 ${_VER} EXACT QUIET COMPONENTS Interpreter
-                                                                Development.Module)
-        endif()
+        find_package(Python3 ${_VER} EXACT QUIET
+                     COMPONENTS ${ROCPROFILER_BUILD_Find_Python3_COMPONENTS})
         if(Python3_FOUND)
             list(APPEND _PYTHON_FOUND_VERSIONS
                  "${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}")
@@ -82,11 +77,7 @@ function(get_default_python_versions _VAR)
 
     # If none found, do one last check for 3.6 (no EXACT)
     if(NOT _PYTHON_FOUND_VERSIONS)
-        if(ROCPROFILER_MEMCHECK)
-            find_package(Python3 3.6 COMPONENTS Interpreter Development)
-        else()
-            find_package(Python3 3.6 COMPONENTS Interpreter Development.Module)
-        endif()
+        find_package(Python3 3.6 COMPONENTS ${ROCPROFILER_BUILD_Find_Python3_COMPONENTS})
         if(Python3_FOUND)
             list(APPEND _PYTHON_FOUND_VERSIONS
                  "${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}")

--- a/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
+++ b/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
@@ -129,7 +129,7 @@ function(rocprofiler_roctx_python_bindings _VERSION)
     # Sanitizers require explicit linking to libpython because they need all symbols
     # resolved at link time. For normal builds, we avoid linking to allow manylinux
     # compatibility.
-    if(ROCPROFILER_MEMCHECK)
+    if("Development" IN_LIST ROCPROFILER_BUILD_Find_Python3_COMPONENTS)
         target_link_libraries(rocprofiler-sdk-roctx-python-bindings-${_VERSION}
                               PRIVATE ${Python3_LIBRARIES})
     endif()
@@ -215,7 +215,7 @@ function(rocprofiler_rocpd_python_bindings _VERSION)
     # Sanitizers require explicit linking to libpython because they need all symbols
     # resolved at link time. For normal builds, we avoid linking to allow manylinux
     # compatibility.
-    if(ROCPROFILER_MEMCHECK)
+    if("Development" IN_LIST ROCPROFILER_BUILD_Find_Python3_COMPONENTS)
         target_link_libraries(rocprofiler-sdk-rocpd-python-bindings-${_VERSION}
                               PRIVATE ${Python3_LIBRARIES})
     endif()


### PR DESCRIPTION
## Motivation

Modified CMake configuration to build Python extension modules without linking against libpython, enabling compatibility with manylinux containers and Python installations that don't provide shared Python libraries.

In ManyLinux_2.28, if `-DROCPROFILER_PYTHON_VERSIONS="3.8;3.9;3.10;3.11;3.12;3.13;3.14"`is used, then we will have rocpd and roctx compatible with Python version 3.8 or higher.

This solution addresses [Issue #1808](https://github.com/ROCm/TheRock/issues/1808)

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

- Changed `FindPython3` component from "Development" to "Development.Module" to only require Python headers, not the shared library
- Added a fallback to the old way of finding the Python3 Development component for sanitizers as well.
- Removed `${Python3_LIBRARIES}` from `target_link_libraries` for both `rocprofiler-sdk-roctx-python-bindings` and `rocprofiler-sdk-rocpd-python-bindings` in case if sanitizers are not enabled
- Python symbols are now resolved at runtime from the interpreter rather than linked at build time
- General Improvements to packaging 

Benefits:
  - Python bindings can now be built in manylinux containers without installing `python3-dev/devel` packages for each Python version
  - Bindings work with Python installations that lack `libpython.so` (standard in manylinux base images)
  - Reduced build dependencies while maintaining full functionality

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

- Tested manually using `quay.io/pypa/manylinux_2_28_x86_64` docker image, which is similar to what is used in the Rock CI system, I used the following cmake configuration: 

```bash
cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=$(realpath /opt/rocm) -DROCPROFILER_BUILD_{CI,SAMPLES,TESTS}=ON -DPython3_EXECUTABLE=$(which python3.8) -DROCPROFILER_PYTHON_VERSIONS="3.8;3.9;3.10;3.11;3.12;3.13;3.14" -DCPACK_GENERATOR='DEB;RPM;TGZ' -DCPACK_PACKAGING_INSTALL_PREFIX="$(realpath /opt/rocm)" .
```

- The Rock CI System will be able to make sure that this is being packaged and produced correctly every time.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

- Verified no libpython in ldd output for built modules
- Confirmed modules load successfully with Python 3.8
- DEB, RPM, and TGZ packages built successfully
- Tests successfully passed locally

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
