### PR TITLE
[Rocprof-Systems]: Fix argument option for sampling mode and overflow sampling

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/impl.cpp
@@ -360,6 +360,15 @@ parse_args(int argc, char** argv, std::vector<char*>& _env)
     %{INDENT}%   to consume more resources since, while idle, the real-clock time increases (and therefore triggers taking samples)
     %{INDENT}%   whereas the CPU-clock time does not.)";
 
+    const auto* _overflow_desc =
+        R"(Sample based on an overflow event. Accepts zero or more arguments:
+    %{INDENT}%0. Enables sampling based on overflow.
+    %{INDENT}%1. Overflow metric, e.g. PERF_COUNT_HW_INSTRUCTIONS
+    %{INDENT}%2. Overflow value. E.g., if metric == PERF_COUNT_HW_INSTRUCTIONS, then 10000000 == sample every 10,000,000 instructions.
+    %{INDENT}%3+ Thread IDs to target for sampling, starting at 0 (the main thread).
+    %{INDENT}%   May be specified as index or range, e.g., '0 2-4' will be interpreted as:
+    %{INDENT}%      sample the main thread (0), do not sample the first child thread but sample the 2nd, 3rd, and 4th child threads)";
+
     const auto* _hsa_interrupt_desc =
         R"(Set the value of the HSA_ENABLE_INTERRUPT environment variable.
 %{INDENT}%  ROCm version 5.2 and older have a bug which will cause a deadlock if a sample is taken while waiting for the signal
@@ -743,6 +752,28 @@ parse_args(int argc, char** argv, std::vector<char*>& _env)
             if(!_v.empty())
             {
                 update_env(_env, "ROCPROFSYS_SAMPLING_REALTIME_TIDS",
+                           join(array_config{ "," }, _v));
+            }
+        });
+
+    parser.add_argument({ "--overflow" }, _overflow_desc)
+        .min_count(0)
+        .action([&](parser_t& p) {
+            auto _v = p.get<std::deque<std::string>>("overflow");
+            update_env(_env, "ROCPROFSYS_SAMPLING_OVERFLOW", true);
+            if(!_v.empty())
+            {
+                update_env(_env, "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT", _v.front());
+                _v.pop_front();
+            }
+            if(!_v.empty())
+            {
+                update_env(_env, "ROCPROFSYS_SAMPLING_OVERFLOW_FREQ", _v.front());
+                _v.pop_front();
+            }
+            if(!_v.empty())
+            {
+                update_env(_env, "ROCPROFSYS_SAMPLING_OVERFLOW_TIDS",
                            join(array_config{ "," }, _v));
             }
         });

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -264,7 +264,7 @@ configure_settings(bool _init)
         "Data collection mode. Used to set default values for ROCPROFSYS_USE_* options. "
         "Typically set by rocprof-sys binary instrumenter.",
         std::string{ "trace" }, "backend", "advanced", "mode")
-        ->set_choices({ "trace", "sampling", "causal", "coverage" });
+        ->set_choices({ "trace", "sampling", "causal", "coverage", "profiling" });
 
     ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_CI",
                               "Enable some runtime validation checks (typically enabled "
@@ -1128,6 +1128,14 @@ configure_mode_settings(const std::shared_ptr<settings>& _config)
         set_default_setting_value("ROCPROFSYS_USE_SAMPLING", true);
         set_default_setting_value("ROCPROFSYS_USE_PROCESS_SAMPLING", true);
     }
+    else if(get_mode() == Mode::Profiling)
+    {
+        _set("ROCPROFSYS_TRACE", false);
+        _set("ROCPROFSYS_PROFILE", true);
+        _set("ROCPROFSYS_USE_CAUSAL", false);
+        _set("ROCPROFSYS_USE_SAMPLING", false);
+        _set("ROCPROFSYS_USE_PROCESS_SAMPLING", false);
+    }
 
     if(gpu::device_count() == 0)
     {
@@ -1709,20 +1717,23 @@ get_mode()
     if(!settings_are_configured())
     {
         auto _mode = tim::get_env_choice<std::string>(
-            "ROCPROFSYS_MODE", "trace", { "trace", "sampling", "causal", "coverage" });
+            "ROCPROFSYS_MODE", "trace", { "trace", "sampling", "causal", "coverage", "profiling" });
         if(_mode == "sampling")
             return Mode::Sampling;
         else if(_mode == "causal")
             return Mode::Causal;
         else if(_mode == "coverage")
             return Mode::Coverage;
+        else if(_mode == "profiling")
+            return Mode::Profiling;
         return Mode::Trace;
     }
     static auto _m =
         std::unordered_map<std::string_view, Mode>{ { "trace", Mode::Trace },
                                                     { "causal", Mode::Causal },
                                                     { "sampling", Mode::Sampling },
-                                                    { "coverage", Mode::Coverage } };
+                                                    { "coverage", Mode::Coverage },
+                                                    { "profiling", Mode::Profiling } };
     static auto _v = get_config()->find("ROCPROFSYS_MODE");
     try
     {

--- a/projects/rocprofiler-systems/source/lib/core/state.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/state.cpp
@@ -160,6 +160,7 @@ to_string(rocprofsys::Mode _v)
         case rocprofsys::Mode::Sampling: return "Sampling";
         case rocprofsys::Mode::Causal: return "Causal";
         case rocprofsys::Mode::Coverage: return "Coverage";
+        case rocprofsys::Mode::Profiling: return "Profiling";
     }
     return {};
 }

--- a/projects/rocprofiler-systems/source/lib/core/state.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/state.hpp
@@ -54,7 +54,8 @@ enum class Mode : unsigned short
     Trace = 0,
     Sampling,
     Causal,
-    Coverage
+    Coverage,
+    Profiling
 };
 
 enum class CausalBackend : unsigned short


### PR DESCRIPTION
## Motivation

1. ROCPROFSYS_MODE currently accepts trace, sampling, causal, coverage. Add profile as an option to the Mode.

2. Add an --overflow option to rocprof-sys-sample. Similar to --sample-overflow which can be specified to rocprof-sys-run.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Manual tests for new options/arguments.

## Test Result

Confirms to the expected result.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
