### PR TITLE
remove option of json output from rocprof

### DIFF
--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -341,7 +341,7 @@ Examples:
         required=False,
         metavar="",
         dest="format_rocprof_output",
-        choices=["json", "csv", "rocpd"],
+        choices=["csv", "rocpd"],
         default="csv",
         help="\t\t\tSet the format of output file of rocprof.",
     )


### PR DESCRIPTION
For rocprof-compute to take JSON output from rocprofv3 or sdk, it's already a very old implementation, in which few optimizations have been done, and its performance is very bad (can be 6 times slower than the using the main csv implementation). 

What's more, due to recent data keys that rocprof sdk has changed, there is test failures for this part of code. These factor means a reimplementation is needed for using json output of rocprofv3. 

Moreover, considering customers don't have high demand for this json parsing part, we decide to turn off this option of json parsing for users for now with this PR.