### PR TITLE
[rocprofiler-sdk] Fix rocm-release compatibility latest

### DIFF
--- a/.github/workflows/rocprofiler-sdk-rocm_release_compatibility.yml
+++ b/.github/workflows/rocprofiler-sdk-rocm_release_compatibility.yml
@@ -80,15 +80,12 @@ jobs:
         cd projects/rocprofiler-sdk
         git config --global --add safe.directory '*'
         apt update
-        apt install -y wget
-        sudo mkdir -p /etc/apt/keyrings
-        wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | gpg --dearmor | tee /etc/apt/keyrings/rocm.gpg > /dev/null
-        tee /etc/apt/sources.list.d/rocm.list << EOF
-        deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/7.0.2 jammy main
-        deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/graphics/7.0.2/ubuntu jammy main
-        EOF
-        apt update
-        apt install -y build-essential cmake g++-11 g++-12 python3-pip libdw-dev libsqlite3-dev rccl-dev rccl-unittests rocjpeg-dev rocjpeg-test rocdecode-dev rocdecode-test
+        apt install -y wget build-essential cmake g++-11 g++-12 python3-pip libdw-dev libsqlite3-dev
+
+        # Older ROCm versions don't provide these packages.
+        apt install -y rccl-dev rccl-unittests || true
+        apt install -y rocjpeg-dev rocjpeg-test rocdecode-dev rocdecode-test || true
+        
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 10 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 20 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12
         python3 -m pip install -U --user -r requirements.txt

--- a/.github/workflows/rocprofiler-sdk-rocm_release_compatibility.yml
+++ b/.github/workflows/rocprofiler-sdk-rocm_release_compatibility.yml
@@ -79,12 +79,15 @@ jobs:
       run: |
         cd projects/rocprofiler-sdk
         git config --global --add safe.directory '*'
-        apt-get update
-        apt-get install -y wget
-        wget -N -P /tmp/ https://repo.radeon.com/amdgpu-install/7.0/ubuntu/jammy/amdgpu-install_7.0.70000-1_all.deb
-        apt-get install -y -o Dpkg::Options::="--force-confnew" /tmp/amdgpu-install_7.0.70000-1_all.deb
-        apt-get update
-        apt-get install -y build-essential cmake g++-11 g++-12 python3-pip libdw-dev libsqlite3-dev rccl-dev rccl-unittests rocjpeg-dev rocjpeg-test rocdecode-dev rocdecode-test
+        apt update
+        apt install wget
+        wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
+        tee /etc/apt/sources.list.d/rocm.list << EOF
+        deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/7.0.2 jammy main
+        deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/graphics/7.0.2/ubuntu jammy main
+        EOF
+        apt update
+        apt install -y build-essential cmake g++-11 g++-12 python3-pip libdw-dev libsqlite3-dev rccl-dev rccl-unittests rocjpeg-dev rocjpeg-test rocdecode-dev rocdecode-test
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 10 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 20 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12
         python3 -m pip install -U --user -r requirements.txt

--- a/.github/workflows/rocprofiler-sdk-rocm_release_compatibility.yml
+++ b/.github/workflows/rocprofiler-sdk-rocm_release_compatibility.yml
@@ -60,20 +60,6 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install requirements
-      if: ${{ matrix.rocm-release == '6.2' }}
-      timeout-minutes: 10
-      shell: bash
-      run: |
-        cd projects/rocprofiler-sdk
-        git config --global --add safe.directory '*'
-        apt-get update
-        apt-get install -y build-essential cmake g++-11 g++-12 python3-pip libdw-dev libsqlite3-dev
-        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 10 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11
-        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 20 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12
-        python3 -m pip install -U --user -r requirements.txt
-
-    - name: Install requirements
-      if: ${{ matrix.rocm-release != '6.2' }}
       timeout-minutes: 10
       shell: bash
       run: |

--- a/.github/workflows/rocprofiler-sdk-rocm_release_compatibility.yml
+++ b/.github/workflows/rocprofiler-sdk-rocm_release_compatibility.yml
@@ -80,8 +80,9 @@ jobs:
         cd projects/rocprofiler-sdk
         git config --global --add safe.directory '*'
         apt update
-        apt install wget
-        wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
+        apt install -y wget
+        sudo mkdir -p /etc/apt/keyrings
+        wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | gpg --dearmor | tee /etc/apt/keyrings/rocm.gpg > /dev/null
         tee /etc/apt/sources.list.d/rocm.list << EOF
         deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/7.0.2 jammy main
         deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/graphics/7.0.2/ubuntu jammy main


### PR DESCRIPTION
## Motivation

refactor Install requirements step in rocm-release compatibility based by adding `|| true` so older rocm releases skips installing pkgs which doesn't provide rocjpeg/decode/rccl packages and doesn't cause to fail.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
