### PR TITLE
SWDEV-558078 - Fix use-after-free in graph tests due to AsyncEventHandler

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -825,7 +825,6 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
     for (auto streams : parallel_streams_) {
       for (auto stream : streams.second) {
         if (stream != nullptr) {
-        stream->finish();
           constexpr bool kForceDestroy = true;
           hip::Stream::Destroy(stream, kForceDestroy);
         }

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1280,7 +1280,7 @@ class ThreadTrace : public amd::HeapObject {
 };
 
 //! A device execution environment.
-class VirtualDevice : public amd::HeapObject {
+class VirtualDevice : public amd::ReferenceCountedObject {
  public:
   //! Construct a new virtual device for the given physical device.
   VirtualDevice(amd::Device& device)

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -247,6 +247,7 @@ bool HsaAmdSignalHandler(hsa_signal_value_t value, void* arg) {
   }
 
   // Return false, so the callback will not be called again for this signal
+  gpu->release();
   return false;
 }
 
@@ -552,6 +553,7 @@ hsa_signal_t VirtualGPU::HwQueueTracker::ActiveSignal(hsa_signal_value_t init_va
           }
         }
         gpu_.QueuedAsyncHandlers()++;
+        ts->gpu()->retain();
         hsa_status_t result = Hsa::signal_async_handler(
             prof_signal->signal_, HSA_SIGNAL_CONDITION_LT, init_value, &HsaAmdSignalHandler, ts);
         if (HSA_STATUS_SUCCESS != result) {

--- a/projects/clr/rocclr/platform/commandqueue.hpp
+++ b/projects/clr/rocclr/platform/commandqueue.hpp
@@ -184,7 +184,7 @@ class HostQueue : public CommandQueue {
       }
     }
 
-    void Release() const { delete virtualDevice_; }
+    void Release() const { virtualDevice_->release(); }
 
     //! Get virtual device for the current thread
     device::VirtualDevice* vdev() const { return virtualDevice_; }


### PR DESCRIPTION
## Motivation
This PR fixes a use-after-free issue in graph tests by implementing proper reference counting for VirtualDevice objects used in asynchronous event handlers. The core issue was that VirtualDevice objects could be destroyed while still referenced by pending async signal handlers, leading to memory corruption.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Changed VirtualDevice base class from HeapObject to ReferenceCountedObject to enable reference counting.
Added retain()/release() calls around async signal handler lifecycle to prevent premature deletion.
Updated HostQueue::Release() to use reference counting instead of direct deletion.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
The invalid memory read shows up in test Unit_hipExtGetLastError_with_hipStreamBegin_EndCapture under valgrind.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
No more valgrind warning should show up after the fix in graph test,
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
