### PR TITLE
[SWDEV-558141] Fix rocm-smi --setsclk [0...n] & other clocks in partitions

### DIFF
--- a/projects/rocm-smi-lib/python_smi_tools/rocm_smi.py
+++ b/projects/rocm-smi-lib/python_smi_tools/rocm_smi.py
@@ -1414,20 +1414,20 @@ def setClocks(deviceList, clktype, clk):
                 printLog(device, 'Performance level was set to manual', None)
             else:
                 RETCODE = 1
-                return
+                continue
         if clktype != 'pcie':
             # Validate frequency bitmask
             freq = rsmi_frequencies_t()
             ret = rocmsmi.rsmi_dev_gpu_clk_freq_get(device, rsmi_clk_names_dict[clktype], byref(freq))
             if not rsmi_ret_ok(ret, device, 'get_gpu_clk_freq_' + str(clktype)):
                 RETCODE = 1
-                return
+                continue
             # The freq_bitmask should be less than 2^(freqs.num_supported)
             # For example, num_supported == 3,  the max bitmask is 0111
             if freq_bitmask >= (1 << freq.num_supported):
                 printErrLog(device, 'Invalid clock frequency %s' % hex(freq_bitmask))
                 RETCODE = 1
-                return
+                continue
 
             ret = rocmsmi.rsmi_dev_gpu_clk_freq_set(device, rsmi_clk_names_dict[clktype], freq_bitmask)
             if rsmi_ret_ok(ret, device, 'set_gpu_clk_freq_' + str(clktype)):
@@ -1440,19 +1440,20 @@ def setClocks(deviceList, clktype, clk):
             ret = rocmsmi.rsmi_dev_pci_bandwidth_get(device, byref(bw))
             if not rsmi_ret_ok(ret, device, 'get_PCIe_bandwidth'):
                 RETCODE = 1
-                return
+                continue
             # The freq_bitmask should be less than 2^(bw.transfer_rate.num_supported)
             # For example, num_supported == 3,  the max bitmask is 0111
             if freq_bitmask >= (1 << bw.transfer_rate.num_supported):
                 printErrLog(device, 'Invalid PCIe frequency %s' % hex(freq_bitmask))
                 RETCODE = 1
-                return
+                continue
 
             ret = rocmsmi.rsmi_dev_pci_bandwidth_set(device, freq_bitmask)
             if rsmi_ret_ok(ret, device, 'set_PCIe_bandwidth'):
                 printLog(device, 'Successfully set %s to level bitmask' % (clktype), hex(freq_bitmask))
             else:
                 RETCODE = 1
+            continue
     printLogSpacer()
 
 


### PR DESCRIPTION
Changes:
  - Fix for `rocm-smi --setsclk [0 .. n]` to continue on error.
  - Updates impact other clock settings such as `--setmclk` and `--setpcie`.

## Motivation

Fix `rocm-smi --setsclk [0 .. n]` for multiple devices to continue on fail when
in a partitioned configuration (ex., in DPX/QPX/CPX/etc).

## Technical Details

Discovered in QA validation - SWDEV-558141

Fix `rocm-smi --setsclk [0 .. n]` for multiple devices to continue on fail when
in a partitioned configuration (ex., in DPX/QPX/CPX/etc).

<img width="1113" height="444" alt="image" src="https://github.com/user-attachments/assets/c89dd555-30d3-4a0d-b001-398b5e2fe8e5" />


## Test Plan

Run on Navi to confirm original behavior still works.

Run on MI3x ASICs to confirm modification allows setting sclock, even if
partitioned devices do not allow changing clocks. All devices, should be
successfully set provided the driver supports the user's requested configuration.

## Test Result

NV:
```console
$ rocm-smi --setsclk 0

============================ ROCm System Management Interface ============================
=================================== Set sclk Frequency ===================================
GPU[0]          : Successfully set sclk bitmask to: 0x1
GPU[1]          : Successfully set sclk bitmask to: 0x1
==========================================================================================
================================== End of ROCm SMI Log ===================================

$ rocm-smi --setsclk 1

============================ ROCm System Management Interface ============================
=================================== Set sclk Frequency ===================================
GPU[0]          : Successfully set sclk bitmask to: 0x2
GPU[1]          : Successfully set sclk bitmask to: 0x2
==========================================================================================
================================== End of ROCm SMI Log ===================================

$ rocm-smi --setsclk 0 1 2

============================ ROCm System Management Interface ============================
=================================== Set sclk Frequency ===================================
GPU[0]          : Successfully set sclk bitmask to: 0x7
ERROR: GPU[1]   : Invalid clock frequency 0x7
==========================================================================================
================================== End of ROCm SMI Log ===================================

$ rocm-smi --setmclk 0

============================ ROCm System Management Interface ============================
=================================== Set mclk Frequency ===================================
GPU[0]          : Successfully set mclk bitmask to: 0x1
GPU[1]          : Successfully set mclk bitmask to: 0x1
==========================================================================================
================================== End of ROCm SMI Log ===================================

$ rocm-smi --setmclk 1

============================ ROCm System Management Interface ============================

=================================== Set mclk Frequency ===================================
GPU[0]          : Successfully set mclk bitmask to: 0x2
GPU[1]          : Successfully set mclk bitmask to: 0x2
==========================================================================================
================================== End of ROCm SMI Log ===================================

$ rocm-smi --setmclk 0 1 2 3

============================ ROCm System Management Interface ============================
=================================== Set mclk Frequency ===================================
GPU[0]          : Successfully set mclk bitmask to: 0xf
GPU[1]          : Successfully set mclk bitmask to: 0xf
==========================================================================================
================================== End of ROCm SMI Log ===================================


$ rocm-smi --setpcie 0

============================ ROCm System Management Interface ============================
=================================== Set pcie Frequency ===================================
GPU[0]          : Successfully set pcie to level bitmask: 0x1
GPU[1]          : Successfully set pcie to level bitmask: 0x1
==========================================================================================
================================== End of ROCm SMI Log ===================================

$ rocm-smi --setpcie 1

============================ ROCm System Management Interface ============================
=================================== Set pcie Frequency ===================================
GPU[0]          : Successfully set pcie to level bitmask: 0x2
GPU[1]          : Successfully set pcie to level bitmask: 0x2
==========================================================================================
================================== End of ROCm SMI Log ===================================

$ rocm-smi --setpcie 0 1

============================ ROCm System Management Interface ============================
=================================== Set pcie Frequency ===================================
GPU[0]          : Successfully set pcie to level bitmask: 0x3
GPU[1]          : Successfully set pcie to level bitmask: 0x3
==========================================================================================
================================== End of ROCm SMI Log ===================================

$ rocm-smi --setpcie 0 1 2

============================ ROCm System Management Interface ============================
=================================== Set pcie Frequency ===================================
ERROR: GPU[0]   : Invalid PCIe frequency 0x7
ERROR: GPU[1]   : Invalid PCIe frequency 0x7
==========================================================================================
================================== End of ROCm SMI Log ===================================

$ rocm-smi --setpcie 3

============================ ROCm System Management Interface ============================
=================================== Set pcie Frequency ===================================
ERROR: GPU[0]   : Invalid PCIe frequency 0x8
ERROR: GPU[1]   : Invalid PCIe frequency 0x8
==========================================================================================
```

MI3x in DPX:
```console
$ rocm-smi

============================================== ROCm System Management Interface ==============================================
======================================================== Concise Info ========================================================
Device  Node  IDs              Temp        Power     Partitions          SCLK     MCLK     Fan  Perf    PwrCap   VRAM%  GPU%
              (DID,     GUID)  (Junction)  (Socket)  (Mem, Compute, ID)
==============================================================================================================================
0       2     0x75a0,   24959  60.0°C      319.0W    NPS1, DPX, 0        2203Mhz  1900Mhz  0%   manual  1000.0W  0%     0%
1       3     0x75a0,   20862  N/A         N/A       N/A, N/A, 1         N/A      N/A      0%   n/a     N/A      0%     N/A
2       4     0x75a0,   44402  62.0°C      299.0W    NPS1, DPX, 0        2186Mhz  1900Mhz  0%   manual  1000.0W  0%     0%
3       5     0x75a0,   40307  N/A         N/A       N/A, N/A, 1         N/A      N/A      0%   n/a     N/A      0%     N/A
4       6     0x75a0,   18775  58.0°C      304.0W    NPS1, DPX, 0        2198Mhz  1900Mhz  0%   manual  1000.0W  0%     0%
5       7     0x75a0,   31062  N/A         N/A       N/A, N/A, 1         N/A      N/A      0%   n/a     N/A      0%     N/A
6       8     0x75a0,   34138  64.0°C      309.0W    NPS1, DPX, 0        2206Mhz  1900Mhz  0%   manual  1000.0W  0%     0%
7       9     0x75a0,   46427  N/A         N/A       N/A, N/A, 1         N/A      N/A      0%   n/a     N/A      0%     N/A
8       10    0x75a0,   49438  59.0°C      311.0W    NPS1, DPX, 0        2189Mhz  1900Mhz  0%   manual  1000.0W  0%     0%
9       11    0x75a0,   61727  N/A         N/A       N/A, N/A, 1         N/A      N/A      0%   n/a     N/A      0%     N/A
10      12    0x75a0,   3347   65.0°C      314.0W    NPS1, DPX, 0        2200Mhz  1900Mhz  0%   manual  1000.0W  0%     0%
11      13    0x75a0,   15634  N/A         N/A       N/A, N/A, 1         N/A      N/A      0%   n/a     N/A      0%     N/A
12      14    0x75a0,   59702  59.0°C      305.0W    NPS1, DPX, 0        2191Mhz  1900Mhz  0%   manual  1000.0W  0%     0%
13      15    0x75a0,   55607  N/A         N/A       N/A, N/A, 1         N/A      N/A      0%   n/a     N/A      0%     N/A
14      16    0x75a0,   9531   62.0°C      304.0W    NPS1, DPX, 0        2191Mhz  1900Mhz  0%   manual  1000.0W  0%     0%
15      17    0x75a0,   5434   N/A         N/A       N/A, N/A, 1         N/A      N/A      0%   n/a     N/A      0%     N/A
==============================================================================================================================
==================================================== End of ROCm SMI Log =====================================================


$ rocm-smi --setsclk 0 1

============================ ROCm System Management Interface ============================
=================================== Set sclk Frequency ===================================
GPU[0]          : Successfully set sclk bitmask to: 0x3
GPU[1]          : get_perf_level, Not supported on the given system
GPU[1]          : set_perf_level_manual, Not supported on the given system
GPU[2]          : Successfully set sclk bitmask to: 0x3
GPU[3]          : get_perf_level, Not supported on the given system
GPU[3]          : set_perf_level_manual, Not supported on the given system
GPU[4]          : Successfully set sclk bitmask to: 0x3
GPU[5]          : get_perf_level, Not supported on the given system
GPU[5]          : set_perf_level_manual, Not supported on the given system
GPU[6]          : Successfully set sclk bitmask to: 0x3
GPU[7]          : get_perf_level, Not supported on the given system
GPU[7]          : set_perf_level_manual, Not supported on the given system
GPU[8]          : Successfully set sclk bitmask to: 0x3
GPU[9]          : get_perf_level, Not supported on the given system
GPU[9]          : set_perf_level_manual, Not supported on the given system
GPU[10]         : Successfully set sclk bitmask to: 0x3
GPU[11]         : get_perf_level, Not supported on the given system
GPU[11]         : set_perf_level_manual, Not supported on the given system
GPU[12]         : Successfully set sclk bitmask to: 0x3
GPU[13]         : get_perf_level, Not supported on the given system
GPU[13]         : set_perf_level_manual, Not supported on the given system
GPU[14]         : Successfully set sclk bitmask to: 0x3
GPU[15]         : get_perf_level, Not supported on the given system
GPU[15]         : set_perf_level_manual, Not supported on the given system
==========================================================================================
================================== End of ROCm SMI Log ===================================

$ rocm-smi --setsclk 0

============================ ROCm System Management Interface ============================
=================================== Set sclk Frequency ===================================
GPU[0]          : Successfully set sclk bitmask to: 0x1
GPU[1]          : get_perf_level, Not supported on the given system
GPU[1]          : set_perf_level_manual, Not supported on the given system
GPU[2]          : Successfully set sclk bitmask to: 0x1
GPU[3]          : get_perf_level, Not supported on the given system
GPU[3]          : set_perf_level_manual, Not supported on the given system
GPU[4]          : Successfully set sclk bitmask to: 0x1
GPU[5]          : get_perf_level, Not supported on the given system
GPU[5]          : set_perf_level_manual, Not supported on the given system
GPU[6]          : Successfully set sclk bitmask to: 0x1
GPU[7]          : get_perf_level, Not supported on the given system
GPU[7]          : set_perf_level_manual, Not supported on the given system
GPU[8]          : Successfully set sclk bitmask to: 0x1
GPU[9]          : get_perf_level, Not supported on the given system
GPU[9]          : set_perf_level_manual, Not supported on the given system
GPU[10]         : Successfully set sclk bitmask to: 0x1
GPU[11]         : get_perf_level, Not supported on the given system
GPU[11]         : set_perf_level_manual, Not supported on the given system
GPU[12]         : Successfully set sclk bitmask to: 0x1
GPU[13]         : get_perf_level, Not supported on the given system
GPU[13]         : set_perf_level_manual, Not supported on the given system
GPU[14]         : Successfully set sclk bitmask to: 0x1
GPU[15]         : get_perf_level, Not supported on the given system
GPU[15]         : set_perf_level_manual, Not supported on the given system
==========================================================================================
================================== End of ROCm SMI Log ===================================

$ rocm-smi --setsclk 0 1

============================ ROCm System Management Interface ============================
=================================== Set sclk Frequency ===================================
GPU[0]          : Successfully set sclk bitmask to: 0x3
GPU[1]          : get_perf_level, Not supported on the given system
GPU[1]          : set_perf_level_manual, Not supported on the given system
GPU[2]          : Successfully set sclk bitmask to: 0x3
GPU[3]          : get_perf_level, Not supported on the given system
GPU[3]          : set_perf_level_manual, Not supported on the given system
GPU[4]          : Successfully set sclk bitmask to: 0x3
GPU[5]          : get_perf_level, Not supported on the given system
GPU[5]          : set_perf_level_manual, Not supported on the given system
GPU[6]          : Successfully set sclk bitmask to: 0x3
GPU[7]          : get_perf_level, Not supported on the given system
GPU[7]          : set_perf_level_manual, Not supported on the given system
GPU[8]          : Successfully set sclk bitmask to: 0x3
GPU[9]          : get_perf_level, Not supported on the given system
GPU[9]          : set_perf_level_manual, Not supported on the given system
GPU[10]         : Successfully set sclk bitmask to: 0x3
GPU[11]         : get_perf_level, Not supported on the given system
GPU[11]         : set_perf_level_manual, Not supported on the given system
GPU[12]         : Successfully set sclk bitmask to: 0x3
GPU[13]         : get_perf_level, Not supported on the given system
GPU[13]         : set_perf_level_manual, Not supported on the given system
GPU[14]         : Successfully set sclk bitmask to: 0x3
GPU[15]         : get_perf_level, Not supported on the given system
GPU[15]         : set_perf_level_manual, Not supported on the given system
==========================================================================================
================================== End of ROCm SMI Log ===================================

$ rocm-smi --setsclk 2

============================ ROCm System Management Interface ============================
=================================== Set sclk Frequency ===================================
GPU[0]          : set_gpu_clk_freq_sclk, Not supported on the given system
GPU[1]          : get_perf_level, Not supported on the given system
GPU[1]          : set_perf_level_manual, Not supported on the given system
GPU[2]          : set_gpu_clk_freq_sclk, Not supported on the given system
GPU[3]          : get_perf_level, Not supported on the given system
GPU[3]          : set_perf_level_manual, Not supported on the given system
ERROR: GPU[4]   : Invalid clock frequency 0x4
GPU[5]          : get_perf_level, Not supported on the given system
GPU[5]          : set_perf_level_manual, Not supported on the given system
ERROR: GPU[6]   : Invalid clock frequency 0x4
GPU[7]          : get_perf_level, Not supported on the given system
GPU[7]          : set_perf_level_manual, Not supported on the given system
GPU[8]          : set_gpu_clk_freq_sclk, Not supported on the given system
GPU[9]          : get_perf_level, Not supported on the given system
GPU[9]          : set_perf_level_manual, Not supported on the given system
GPU[10]         : set_gpu_clk_freq_sclk, Not supported on the given system
GPU[11]         : get_perf_level, Not supported on the given system
GPU[11]         : set_perf_level_manual, Not supported on the given system
GPU[12]         : set_gpu_clk_freq_sclk, Not supported on the given system
GPU[13]         : get_perf_level, Not supported on the given system
GPU[13]         : set_perf_level_manual, Not supported on the given system
GPU[14]         : set_gpu_clk_freq_sclk, Not supported on the given system
GPU[15]         : get_perf_level, Not supported on the given system
GPU[15]         : set_perf_level_manual, Not supported on the given system
==========================================================================================
================================== End of ROCm SMI Log ===================================

$ rocm-smi --setmclk 0

============================ ROCm System Management Interface ============================
=================================== Set mclk Frequency ===================================
GPU[0]          : set_gpu_clk_freq_mclk, Not supported on the given system
GPU[1]          : get_perf_level, Not supported on the given system
GPU[1]          : set_perf_level_manual, Not supported on the given system
GPU[2]          : set_gpu_clk_freq_mclk, Not supported on the given system
GPU[3]          : get_perf_level, Not supported on the given system
GPU[3]          : set_perf_level_manual, Not supported on the given system
GPU[4]          : set_gpu_clk_freq_mclk, Not supported on the given system
GPU[5]          : get_perf_level, Not supported on the given system
GPU[5]          : set_perf_level_manual, Not supported on the given system
GPU[6]          : set_gpu_clk_freq_mclk, Not supported on the given system
GPU[7]          : get_perf_level, Not supported on the given system
GPU[7]          : set_perf_level_manual, Not supported on the given system
GPU[8]          : set_gpu_clk_freq_mclk, Not supported on the given system
GPU[9]          : get_perf_level, Not supported on the given system
GPU[9]          : set_perf_level_manual, Not supported on the given system
GPU[10]         : set_gpu_clk_freq_mclk, Not supported on the given system
GPU[11]         : get_perf_level, Not supported on the given system
GPU[11]         : set_perf_level_manual, Not supported on the given system
GPU[12]         : set_gpu_clk_freq_mclk, Not supported on the given system
GPU[13]         : get_perf_level, Not supported on the given system
GPU[13]         : set_perf_level_manual, Not supported on the given system
GPU[14]         : set_gpu_clk_freq_mclk, Not supported on the given system
GPU[15]         : get_perf_level, Not supported on the given system
GPU[15]         : set_perf_level_manual, Not supported on the given system
==========================================================================================
================================== End of ROCm SMI Log ===================================

$ rocm-smi --setpcie 0

============================ ROCm System Management Interface ============================
=================================== Set pcie Frequency ===================================
GPU[0]          : get_PCIe_bandwidth, Unexpected data received
GPU[1]          : get_perf_level, Not supported on the given system
GPU[1]          : set_perf_level_manual, Not supported on the given system
GPU[2]          : get_PCIe_bandwidth, Unexpected data received
GPU[3]          : get_perf_level, Not supported on the given system
GPU[3]          : set_perf_level_manual, Not supported on the given system
GPU[4]          : get_PCIe_bandwidth, Unexpected data received
GPU[5]          : get_perf_level, Not supported on the given system
GPU[5]          : set_perf_level_manual, Not supported on the given system
GPU[6]          : get_PCIe_bandwidth, Unexpected data received
GPU[7]          : get_perf_level, Not supported on the given system
GPU[7]          : set_perf_level_manual, Not supported on the given system
GPU[8]          : get_PCIe_bandwidth, Unexpected data received
GPU[9]          : get_perf_level, Not supported on the given system
GPU[9]          : set_perf_level_manual, Not supported on the given system
GPU[10]         : get_PCIe_bandwidth, Unexpected data received
GPU[11]         : get_perf_level, Not supported on the given system
GPU[11]         : set_perf_level_manual, Not supported on the given system
GPU[12]         : get_PCIe_bandwidth, Unexpected data received
GPU[13]         : get_perf_level, Not supported on the given system
GPU[13]         : set_perf_level_manual, Not supported on the given system
GPU[14]         : get_PCIe_bandwidth, Unexpected data received
GPU[15]         : get_perf_level, Not supported on the given system
GPU[15]         : set_perf_level_manual, Not supported on the given system
==========================================================================================
================================== End of ROCm SMI Log ===================================
```


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
