### PR TITLE
Users/dayatsin/swdev 519413 hsa amd pointer info return err shutdown

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -244,6 +244,8 @@ GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xna
 }
 
 GpuAgent::~GpuAgent() {
+  for (auto& blit : blits_) blit.reset();
+
   std::for_each(regions_.begin(), regions_.end(), DeleteObject());
   regions_.clear();
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -151,6 +151,17 @@ hsa_status_t Runtime::Release() {
   if (runtime_singleton_ == nullptr) return HSA_STATUS_ERROR_NOT_INITIALIZED;
 
   if (runtime_singleton_->ref_count_-- == 1) {
+    auto system_event_handlers = runtime_singleton_->GetSystemEventHandlers();
+
+    if (!system_event_handlers.empty()) {
+      hsa_amd_event_t system_shutdown_event = {} ;
+      system_shutdown_event.event_type = HSA_AMD_SYSTEM_SHUTDOWN_EVENT;
+      /* Remaining fields hsa_amd_event_t are empty */
+
+      for (auto& callback : system_event_handlers) {
+        callback.first(&system_shutdown_event, callback.second);
+      }
+    }
     // Release all registered memory, then unload backends
     runtime_singleton_->Unload();
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -150,12 +150,10 @@ hsa_status_t Runtime::Release() {
 
   if (runtime_singleton_ == nullptr) return HSA_STATUS_ERROR_NOT_INITIALIZED;
 
-  if (runtime_singleton_->ref_count_ == 1) {
+  if (runtime_singleton_->ref_count_-- == 1) {
     // Release all registered memory, then unload backends
     runtime_singleton_->Unload();
   }
-
-  runtime_singleton_->ref_count_--;
 
   if (runtime_singleton_->ref_count_ == 0) {
     delete runtime_singleton_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -65,9 +65,10 @@
  * - 1.12 - hsa_amd_pointer_info: HSA_EXT_POINTER_TYPE_HSA_VMEM and HSA_EXT_POINTER_TYPE_RESERVED_ADDR
  * - 1.13 - hsa_amd_pointer_info: Added new registered field to hsa_amd_pointer_info_t
  * - 1.14 - hsa_amd_ais_file_write, hsa_amd_ais_file_read
+ * - 1.15 - hsa_amd_register_system_event_handler: HSA_AMD_SYSTEM_SHUTDOWN
  */
 #define HSA_AMD_INTERFACE_VERSION_MAJOR 1
-#define HSA_AMD_INTERFACE_VERSION_MINOR 14
+#define HSA_AMD_INTERFACE_VERSION_MINOR 15
 
 #ifdef __cplusplus
 extern "C" {
@@ -2665,6 +2666,11 @@ typedef enum hsa_amd_event_type_s {
    AMD GPU memory error.
    */
   HSA_AMD_GPU_MEMORY_ERROR_EVENT,
+  /*
+   System shut down
+    - All other fields in hsa_amd_event_t are unused
+   */
+  HSA_AMD_SYSTEM_SHUTDOWN_EVENT,
 } hsa_amd_event_type_t;
 
 /**


### PR DESCRIPTION
[SWDEV-519413](https://ontrack-internal.amd.com/browse/SWDEV-519413)

Fix reference count so that ROCR API calls made after hsa_shutdown() is called will return error.

Add new event HSA_AMD_SYSTEM_SHUTDOWN_EVENT type for hsa_amd_register_system_event_handler API call.
