### PR TITLE
Add CMake build system for perf-dkms

### DIFF
--- a/projects/perf-dkms/CMakeLists.txt
+++ b/projects/perf-dkms/CMakeLists.txt
@@ -1,0 +1,142 @@
+cmake_minimum_required(VERSION 3.16)
+project(perf-pmu-stub VERSION 1.0.0 LANGUAGES C)
+
+# Add cmake modules to module path
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+
+# Include GNUInstallDirs for standard installation paths
+include(GNUInstallDirs)
+
+#================================================================================
+# Build Options
+#================================================================================
+
+option(BUILD_KERNEL_MODULE "Build the kernel module component" ON)
+option(BUILD_USERSPACE_TOOLS "Build packet_gen_tool and pm4_decoder" ON)
+option(BUILD_TESTS "Build test executables" ON)
+option(ENABLE_DEBUG "Enable debug flags (-DDEBUG, -g)" ON)
+option(ENABLE_DKMS "Enable DKMS installation targets" OFF)
+
+#================================================================================
+# Module Configuration
+#================================================================================
+
+set(MODULE_NAME "perf-pmu-stub" CACHE STRING "Kernel module name")
+set(MODULE_VERSION "${PROJECT_VERSION}" CACHE STRING "Module version")
+
+#================================================================================
+# Kernel Configuration
+#================================================================================
+
+# Find kernel headers if building kernel module
+if(BUILD_KERNEL_MODULE)
+    find_package(KernelHeaders REQUIRED)
+
+    # Set DKMS installation directory
+    if(NOT DKMS_INSTALL_DIR)
+        set(DKMS_INSTALL_DIR "/usr/src" CACHE PATH "DKMS source installation directory")
+    endif()
+endif()
+
+#================================================================================
+# Compiler Configuration
+#================================================================================
+
+# Set C standard for userspace code
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+# Debug flags
+if(ENABLE_DEBUG)
+    add_compile_options(-g -Wall -Wextra)
+    add_compile_definitions(DEBUG)
+endif()
+
+#================================================================================
+# Build Type
+#================================================================================
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING
+        "Choose the type of build: Debug Release RelWithDebInfo MinSizeRel" FORCE)
+endif()
+
+#================================================================================
+# Subdirectories
+#================================================================================
+
+if(BUILD_KERNEL_MODULE)
+    add_subdirectory(src)
+endif()
+
+if(BUILD_USERSPACE_TOOLS)
+    add_subdirectory(src/aql_c/tools)
+endif()
+
+if(BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(src/aql_c/tests)
+endif()
+
+#================================================================================
+# DKMS Targets
+#================================================================================
+
+if(ENABLE_DKMS AND BUILD_KERNEL_MODULE)
+    set(DKMS_SOURCE_PATH "${DKMS_INSTALL_DIR}/${MODULE_NAME}-${MODULE_VERSION}")
+
+    add_custom_target(dkms-add
+        COMMAND ${CMAKE_COMMAND} -E echo "Installing source to ${DKMS_SOURCE_PATH}"
+        COMMAND sudo cp -R ${CMAKE_CURRENT_SOURCE_DIR} ${DKMS_SOURCE_PATH}
+        COMMAND sudo dkms add -m ${MODULE_NAME} -v ${MODULE_VERSION}
+        COMMENT "Adding module to DKMS"
+    )
+
+    add_custom_target(dkms-build
+        COMMAND sudo dkms build -m ${MODULE_NAME} -v ${MODULE_VERSION}
+        DEPENDS dkms-add
+        COMMENT "Building module with DKMS"
+    )
+
+    add_custom_target(dkms-install
+        COMMAND sudo dkms install -m ${MODULE_NAME} -v ${MODULE_VERSION}
+        DEPENDS dkms-build
+        COMMENT "Installing module with DKMS"
+    )
+
+    add_custom_target(dkms-remove
+        COMMAND sudo dkms remove -m ${MODULE_NAME} -v ${MODULE_VERSION} --all || true
+        COMMAND sudo rm -rf ${DKMS_SOURCE_PATH} || true
+        COMMENT "Removing module from DKMS"
+    )
+endif()
+
+#================================================================================
+# Information Display
+#================================================================================
+
+message(STATUS "")
+message(STATUS "============================================")
+message(STATUS "  perf-pmu-stub Build Configuration")
+message(STATUS "============================================")
+message(STATUS "Module Name:           ${MODULE_NAME}")
+message(STATUS "Module Version:        ${MODULE_VERSION}")
+message(STATUS "Build Type:            ${CMAKE_BUILD_TYPE}")
+message(STATUS "")
+message(STATUS "Build Options:")
+message(STATUS "  Kernel Module:       ${BUILD_KERNEL_MODULE}")
+message(STATUS "  Userspace Tools:     ${BUILD_USERSPACE_TOOLS}")
+message(STATUS "  Tests:               ${BUILD_TESTS}")
+message(STATUS "  Debug:               ${ENABLE_DEBUG}")
+message(STATUS "  DKMS:                ${ENABLE_DKMS}")
+if(BUILD_KERNEL_MODULE)
+    message(STATUS "")
+    message(STATUS "Kernel Configuration:")
+    message(STATUS "  Kernel Version:      ${KERNEL_VERSION}")
+    message(STATUS "  Kernel Build Dir:    ${KERNEL_BUILD_DIR}")
+    if(ENABLE_DKMS)
+        message(STATUS "  DKMS Install Dir:    ${DKMS_INSTALL_DIR}")
+    endif()
+endif()
+message(STATUS "============================================")
+message(STATUS "")

--- a/projects/perf-dkms/cmake/modules/FindKernelHeaders.cmake
+++ b/projects/perf-dkms/cmake/modules/FindKernelHeaders.cmake
@@ -1,0 +1,46 @@
+# FindKernelHeaders.cmake
+# Finds Linux kernel headers for building kernel modules
+#
+# This module defines:
+#  KERNEL_BUILD_DIR - Directory containing kernel build files
+#  KERNEL_VERSION - Kernel version string
+#  KernelHeaders_FOUND - Whether kernel headers were found
+
+# Get kernel version if not specified
+if(NOT KERNEL_VERSION)
+    execute_process(
+        COMMAND uname -r
+        OUTPUT_VARIABLE KERNEL_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+endif()
+
+# Find kernel build directory
+if(NOT KERNEL_BUILD_DIR)
+    set(KERNEL_BUILD_DIR "/lib/modules/${KERNEL_VERSION}/build")
+endif()
+
+# Validate that the kernel build directory exists
+if(EXISTS "${KERNEL_BUILD_DIR}")
+    set(KernelHeaders_FOUND TRUE)
+    message(STATUS "Found kernel headers: ${KERNEL_BUILD_DIR}")
+    message(STATUS "Kernel version: ${KERNEL_VERSION}")
+
+    # Verify essential kernel build files exist
+    if(NOT EXISTS "${KERNEL_BUILD_DIR}/Makefile")
+        message(WARNING "Kernel Makefile not found in ${KERNEL_BUILD_DIR}")
+        set(KernelHeaders_FOUND FALSE)
+    endif()
+else()
+    set(KernelHeaders_FOUND FALSE)
+    message(WARNING "Kernel build directory not found: ${KERNEL_BUILD_DIR}")
+endif()
+
+# Standard find_package handling
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(KernelHeaders
+    REQUIRED_VARS KERNEL_BUILD_DIR
+    VERSION_VAR KERNEL_VERSION
+)
+
+mark_as_advanced(KERNEL_BUILD_DIR KERNEL_VERSION)

--- a/projects/perf-dkms/src/CMakeLists.txt
+++ b/projects/perf-dkms/src/CMakeLists.txt
@@ -1,0 +1,134 @@
+# Kernel Module Build
+# CMake wrapper around Kbuild for building the kernel module
+
+set(MODULE_KO "pmu_stub.ko")
+set(KBUILD_CMD ${CMAKE_MAKE_PROGRAM})
+
+# Get the current source directory for the kernel module
+set(KBUILD_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(KBUILD_BIN_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
+# List of source files and headers that need to be linked
+set(KERNEL_MODULE_SOURCES
+    pmu_main.c
+    pmu_events.c
+    pmu_stub.h
+    kfd_test.c
+    kfd_test.h
+    aql_perf.c
+    aql_perf.h
+    aql_packet_ops.c
+    aql_error_recovery.c
+    aql_pmu_integration.c
+    example_kfd_usage.c
+)
+
+# Create symbolic links to source files in build directory
+foreach(src_file ${KERNEL_MODULE_SOURCES})
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E create_symlink
+            ${KBUILD_SRC_DIR}/${src_file}
+            ${KBUILD_BIN_DIR}/${src_file}
+    )
+endforeach()
+
+# Create symbolic link to aql_c directory
+execute_process(
+    COMMAND ${CMAKE_COMMAND} -E create_symlink
+        ${KBUILD_SRC_DIR}/aql_c
+        ${KBUILD_BIN_DIR}/aql_c
+)
+
+# Create Kbuild file from the Makefile (extract only the kernel build parts)
+file(WRITE ${KBUILD_BIN_DIR}/Kbuild
+"# Kernel build configuration
+obj-m := pmu_stub.o
+
+# Include PMU stub, KFD test, and minimal AQL integration
+pmu_stub-y := pmu_main.o pmu_events.o kfd_test.o \\
+              aql_perf.o aql_packet_ops.o aql_error_recovery.o aql_pmu_integration.o \\
+              aql_c/arch_creator.o aql_c/gfx12_creator.o \\
+              aql_c/pm4_packets.o aql_c/counter_registry.o aql_c/gfx12_events.o \\
+              aql_c/packet_generation.o
+
+# Compiler flags
+ccflags-y := -DDEBUG -g -Wall -D__KERNEL__ -I\$(src)/aql_c
+"
+)
+
+# Custom command to build the kernel module
+add_custom_command(
+    OUTPUT ${KBUILD_BIN_DIR}/${MODULE_KO}
+    COMMAND ${CMAKE_COMMAND} -E echo "Building kernel module..."
+    COMMAND ${KBUILD_CMD} -C ${KERNEL_BUILD_DIR} M=${KBUILD_BIN_DIR} modules
+    COMMAND ${CMAKE_COMMAND} -E echo "Verifying module build..."
+    COMMAND test -f ${KBUILD_BIN_DIR}/${MODULE_KO}
+    COMMAND sh -c "strings ${KBUILD_BIN_DIR}/${MODULE_KO} | grep vermagic || echo 'WARNING: No vermagic found'"
+    WORKING_DIRECTORY ${KBUILD_BIN_DIR}
+    DEPENDS
+        ${KBUILD_SRC_DIR}/pmu_main.c
+        ${KBUILD_SRC_DIR}/pmu_events.c
+        ${KBUILD_SRC_DIR}/kfd_test.c
+        ${KBUILD_SRC_DIR}/aql_perf.c
+        ${KBUILD_SRC_DIR}/aql_packet_ops.c
+        ${KBUILD_SRC_DIR}/aql_error_recovery.c
+        ${KBUILD_SRC_DIR}/aql_pmu_integration.c
+        ${KBUILD_SRC_DIR}/aql_c/arch_creator.c
+        ${KBUILD_SRC_DIR}/aql_c/gfx12_creator.c
+        ${KBUILD_SRC_DIR}/aql_c/pm4_packets.c
+        ${KBUILD_SRC_DIR}/aql_c/counter_registry.c
+        ${KBUILD_SRC_DIR}/aql_c/gfx12_events.c
+        ${KBUILD_SRC_DIR}/aql_c/packet_generation.c
+        ${KBUILD_SRC_DIR}/Makefile
+    COMMENT "Building kernel module ${MODULE_KO}"
+    VERBATIM
+)
+
+# Custom target for the kernel module
+add_custom_target(kernel_module ALL
+    DEPENDS ${KBUILD_BIN_DIR}/${MODULE_KO}
+)
+
+# Clean target
+add_custom_target(kernel_module_clean
+    COMMAND ${KBUILD_CMD} -C ${KERNEL_BUILD_DIR} M=${KBUILD_BIN_DIR} clean
+    WORKING_DIRECTORY ${KBUILD_BIN_DIR}
+    COMMENT "Cleaning kernel module build artifacts"
+)
+
+# Install target
+install(
+    FILES ${KBUILD_BIN_DIR}/${MODULE_KO}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/modules/${KERNEL_VERSION}/extra
+    OPTIONAL
+)
+
+# Add post-install script to run depmod
+install(CODE "execute_process(COMMAND depmod -a)")
+
+# Module load/unload helper targets
+add_custom_target(load-module
+    COMMAND sudo insmod ${KBUILD_BIN_DIR}/${MODULE_KO}
+    DEPENDS kernel_module
+    COMMENT "Loading kernel module"
+)
+
+add_custom_target(unload-module
+    COMMAND sudo rmmod pmu_stub || true
+    COMMENT "Unloading kernel module"
+)
+
+add_custom_target(reload-module
+    DEPENDS unload-module kernel_module
+    COMMAND sudo insmod ${KBUILD_BIN_DIR}/${MODULE_KO}
+    COMMENT "Reloading kernel module"
+)
+
+# Module info target
+add_custom_target(module-info
+    COMMAND ${CMAKE_COMMAND} -E echo "Module: ${MODULE_NAME}"
+    COMMAND ${CMAKE_COMMAND} -E echo "Version: ${MODULE_VERSION}"
+    COMMAND ${CMAKE_COMMAND} -E echo "Kernel: ${KERNEL_VERSION}"
+    COMMAND lsmod | grep pmu_stub || echo "Module not loaded"
+    COMMENT "Displaying module information"
+)

--- a/projects/perf-dkms/src/aql_c/tests/CMakeLists.txt
+++ b/projects/perf-dkms/src/aql_c/tests/CMakeLists.txt
@@ -1,0 +1,105 @@
+# AQL C Userspace Tests
+
+# Common include directories
+set(AQL_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+# Common compile options for tests
+set(TEST_COMPILE_OPTIONS -Wall -Wextra -std=c99)
+set(TEST_COMPILE_DEFINITIONS USERSPACE_BUILD)
+
+if(ENABLE_DEBUG)
+    list(APPEND TEST_COMPILE_DEFINITIONS DEBUG)
+endif()
+
+#================================================================================
+# Helper function to create test executables
+#================================================================================
+
+function(add_aql_test TEST_NAME TEST_SOURCE)
+    # Get library sources from ARGN
+    set(LIB_SOURCES ${ARGN})
+
+    # Create object library for the test dependencies
+    set(LIB_NAME ${TEST_NAME}_lib)
+    add_library(${LIB_NAME} OBJECT ${LIB_SOURCES})
+    target_include_directories(${LIB_NAME} PRIVATE ${AQL_INCLUDE_DIRS})
+    target_compile_options(${LIB_NAME} PRIVATE ${TEST_COMPILE_OPTIONS})
+    target_compile_definitions(${LIB_NAME} PRIVATE ${TEST_COMPILE_DEFINITIONS})
+
+    # Create test executable
+    add_executable(${TEST_NAME} ${TEST_SOURCE})
+    target_include_directories(${TEST_NAME} PRIVATE ${AQL_INCLUDE_DIRS})
+    target_compile_options(${TEST_NAME} PRIVATE ${TEST_COMPILE_OPTIONS})
+    target_compile_definitions(${TEST_NAME} PRIVATE ${TEST_COMPILE_DEFINITIONS})
+    target_link_libraries(${TEST_NAME} PRIVATE ${LIB_NAME})
+
+    # Add to CTest
+    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+endfunction()
+
+#================================================================================
+# PM4 Packet Tests
+#================================================================================
+
+add_aql_test(test_pm4
+    test_pm4_packets.c
+    ../pm4_packets.c
+)
+
+#================================================================================
+# Counter Registry Tests
+#================================================================================
+
+add_aql_test(test_counter_registry
+    test_counter_registry.c
+    ../counter_registry.c
+    ../gfx12_events.c
+    ../arch_creator.c
+    ../gfx12_creator.c
+)
+
+#================================================================================
+# Packet Generation Tests
+#================================================================================
+
+add_aql_test(test_packet_generation
+    test_packet_generation.c
+    ../packet_generation.c
+    ../pm4_packets.c
+    ../arch_creator.c
+    ../gfx12_creator.c
+    ../gfx12_events.c
+    ../counter_registry.c
+)
+
+#================================================================================
+# Run all tests target
+#================================================================================
+
+add_custom_target(run-tests
+    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+    DEPENDS test_pm4 test_counter_registry test_packet_generation
+    COMMENT "Running all AQL tests"
+)
+
+#================================================================================
+# Individual test run targets
+#================================================================================
+
+add_custom_target(run-pm4-test
+    COMMAND test_pm4
+    DEPENDS test_pm4
+    COMMENT "Running PM4 packet tests"
+)
+
+add_custom_target(run-counter-test
+    COMMAND test_counter_registry
+    DEPENDS test_counter_registry
+    COMMENT "Running counter registry tests"
+)
+
+add_custom_target(run-packet-test
+    COMMAND test_packet_generation
+    DEPENDS test_packet_generation
+    COMMENT "Running packet generation tests"
+)

--- a/projects/perf-dkms/src/aql_c/tools/CMakeLists.txt
+++ b/projects/perf-dkms/src/aql_c/tools/CMakeLists.txt
@@ -1,0 +1,66 @@
+# Userspace Tools for Packet Generation and Decoding
+
+# Common include directories
+set(AQL_INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_CURRENT_SOURCE_DIR}/../..
+)
+
+# Common compile options for tools
+set(TOOLS_COMPILE_OPTIONS -Wall -Wextra -O2)
+
+#================================================================================
+# Packet Generation Tool
+#================================================================================
+
+set(PACKET_GEN_SOURCES
+    packet_gen_tool.c
+    ../packet_generation.c
+    ../arch_creator.c
+    ../gfx12_creator.c
+    ../pm4_packets.c
+    ../counter_registry.c
+    ../gfx12_events.c
+)
+
+add_executable(packet_gen_tool ${PACKET_GEN_SOURCES})
+
+target_include_directories(packet_gen_tool PRIVATE ${AQL_INCLUDE_DIRS})
+target_compile_options(packet_gen_tool PRIVATE ${TOOLS_COMPILE_OPTIONS})
+target_link_libraries(packet_gen_tool PRIVATE m)
+
+#================================================================================
+# PM4 Decoder Tool
+#================================================================================
+
+set(PM4_DECODER_SOURCES
+    pm4_decoder.c
+)
+
+add_executable(pm4_decoder ${PM4_DECODER_SOURCES})
+
+target_include_directories(pm4_decoder PRIVATE ${AQL_INCLUDE_DIRS})
+target_compile_options(pm4_decoder PRIVATE ${TOOLS_COMPILE_OPTIONS})
+
+#================================================================================
+# Installation
+#================================================================================
+
+install(TARGETS packet_gen_tool pm4_decoder
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+#================================================================================
+# Help target
+#================================================================================
+
+add_custom_target(tools-help
+    COMMAND ${CMAKE_COMMAND} -E echo "Available tools:"
+    COMMAND ${CMAKE_COMMAND} -E echo "  packet_gen_tool - Packet generation tool"
+    COMMAND ${CMAKE_COMMAND} -E echo "  pm4_decoder     - PM4 packet decoder"
+    COMMAND ${CMAKE_COMMAND} -E echo ""
+    COMMAND ${CMAKE_COMMAND} -E echo "Usage examples:"
+    COMMAND ${CMAKE_COMMAND} -E echo "  ./packet_gen_tool gfx12 0x1000000 SQ:0:0x42 SQ:1:0x43"
+    COMMAND ${CMAKE_COMMAND} -E echo "  echo 'c001790000000200e0000000' | ./pm4_decoder"
+    COMMENT "Displaying tools help"
+)


### PR DESCRIPTION
Migrate perf-dkms from Makefile-based build to CMake with the following features:

- Root CMakeLists.txt with configurable build options (kernel module, tools, tests, debug, DKMS)
- FindKernelHeaders.cmake module to locate kernel build directory
- Kernel module build through Kbuild integration with symlinked sources
- Userspace tools build (packet_gen_tool, pm4_decoder)
- Test executables with CTest integration
- Custom targets for module load/unload and test execution
- Configurable paths for kernel headers and DKMS installation

Build options:
- BUILD_KERNEL_MODULE (ON/OFF)
- BUILD_USERSPACE_TOOLS (ON/OFF)
- BUILD_TESTS (ON/OFF)
- ENABLE_DEBUG (ON/OFF)
- ENABLE_DKMS (ON/OFF)

Configurable variables:
- KERNEL_BUILD_DIR - Kernel headers directory
- DKMS_INSTALL_DIR - DKMS source installation directory
- MODULE_NAME - Kernel module name
- MODULE_VERSION - Module version

The original Makefiles remain for users who prefer make-based builds.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
