### PR TITLE
SWDEV-562431 - Fix Unit_hipBindTexture_Negative failure

### DIFF
--- a/projects/hip-tests/catch/unit/texture/hipBindTexture.cc
+++ b/projects/hip-tests/catch/unit/texture/hipBindTexture.cc
@@ -135,16 +135,10 @@ TEST_CASE("Unit_hipBindTexture_Negative") {
   }
 
   SECTION("Invalid hipChannelFormatDesc") {
-    hipChannelFormatDesc invalid_channel_desc;
-#if HT_AMD
-    HIP_CHECK_ERROR(hipBindTexture(&offset, tex_ref, reinterpret_cast<void*>(tex_buf),
-                                   invalid_channel_desc, N * sizeof(float)),
-                    hipErrorInvalidValue);
-#else
+    hipChannelFormatDesc invalid_channel_desc{-1, -1, -1, -1, hipChannelFormatKindSigned};
     HIP_CHECK_ERROR(hipBindTexture(&offset, tex_ref, reinterpret_cast<void*>(tex_buf),
                                    invalid_channel_desc, N * sizeof(float)),
                     hipErrorInvalidChannelDescriptor);
-#endif
   }
 
   if (tex_buf) {


### PR DESCRIPTION
## Motivation

 Fix Unit_hipBindTexture_Negative random failure

## Technical Details

Some uninitialized parameter has random values that lead to random behavours.

## Test Plan

Make it not random

## Test Result

pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
