### PR TITLE
SWDEV-562762 - Add emulation tags to device directory tests

### DIFF
--- a/projects/hip-tests/catch/unit/device/hipChooseDevice.cc
+++ b/projects/hip-tests/catch/unit/device/hipChooseDevice.cc
@@ -41,7 +41,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipChooseDevice_ValidateDevId") {
+TEST_CASE("Unit_hipChooseDevice_ValidateDevId", "[emulation][device]") {
   hipDeviceProp_t prop;
   HIP_CHECK(hipGetDeviceProperties(&prop, 0));
   int numDevices = 0;
@@ -67,7 +67,7 @@ TEST_CASE("Unit_hipChooseDevice_ValidateDevId") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipChooseDevice_NegTst") {
+TEST_CASE("Unit_hipChooseDevice_NegTst", "[emulation][device]") {
   hipDeviceProp_t prop;
   int dev = -1;
 

--- a/projects/hip-tests/catch/unit/device/hipDeviceAPUCheck.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceAPUCheck.cc
@@ -41,7 +41,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipDeviceAPUCheck") {
+TEST_CASE("Unit_hipDeviceAPUCheck", "[emulation][device]") {
   hipDeviceProp_t prop;
   HIP_CHECK(hipGetDeviceProperties(&prop, 0));
   if (!prop.integrated) {

--- a/projects/hip-tests/catch/unit/device/hipDeviceCanAccessPeer.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceCanAccessPeer.cc
@@ -43,7 +43,7 @@ THE SOFTWARE.
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceCanAccessPeer_positive") {
+TEST_CASE("Unit_hipDeviceCanAccessPeer_positive", "[emulation][multigpu][p2p][device]") {
   int canAccessPeer = 0;
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
@@ -87,7 +87,7 @@ TEST_CASE("Unit_hipDeviceCanAccessPeer_positive") {
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceCanAccessPeer_negative") {
+TEST_CASE("Unit_hipDeviceCanAccessPeer_negative", "[emulation][multigpu][p2p][device]") {
   int canAccessPeer = 0;
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {

--- a/projects/hip-tests/catch/unit/device/hipDeviceComputeCapability.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceComputeCapability.cc
@@ -46,7 +46,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceComputeCapability_Negative") {
+TEST_CASE("Unit_hipDeviceComputeCapability_Negative", "[emulation][device]") {
   int major, minor, numDevices;
   hipDevice_t device;
 
@@ -88,7 +88,7 @@ TEST_CASE("Unit_hipDeviceComputeCapability_Negative") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceComputeCapability_ValidateVersion") {
+TEST_CASE("Unit_hipDeviceComputeCapability_ValidateVersion", "[emulation][device]") {
   int major, minor;
   hipDevice_t device;
   int numDevices = -1;

--- a/projects/hip-tests/catch/unit/device/hipDeviceEnableDisablePeerAccess.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceEnableDisablePeerAccess.cc
@@ -46,7 +46,7 @@ THE SOFTWARE.
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceEnableDisablePeerAccess_positive") {
+TEST_CASE("Unit_hipDeviceEnableDisablePeerAccess_positive", "[emulation][multigpu][p2p][device]") {
   int canAccessPeer = 0;
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
@@ -95,7 +95,7 @@ TEST_CASE("Unit_hipDeviceEnableDisablePeerAccess_positive") {
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceEnablePeerAccess_negative") {
+TEST_CASE("Unit_hipDeviceEnablePeerAccess_negative", "[emulation][multigpu][p2p][device]") {
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");
@@ -159,7 +159,7 @@ TEST_CASE("Unit_hipDeviceEnablePeerAccess_negative") {
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceDisablePeerAccess_negative") {
+TEST_CASE("Unit_hipDeviceDisablePeerAccess_negative", "[emulation][multigpu][p2p][device]") {
   int deviceCount = HipTest::getGeviceCount();
   if (deviceCount < 2) {
     HipTest::HIP_SKIP_TEST("Skipping because devices < 2");

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetByPCIBusId.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetByPCIBusId.cc
@@ -42,7 +42,7 @@
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetByPCIBusId_Functional") {
+TEST_CASE("Unit_hipDeviceGetByPCIBusId_Functional", "[emulation][device]") {
   char pciBusId[SIZE]{};
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
@@ -80,7 +80,7 @@ TEST_CASE("Unit_hipDeviceGetByPCIBusId_Functional") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetByPCIBusId_NegativeNullChk") {
+TEST_CASE("Unit_hipDeviceGetByPCIBusId_NegativeNullChk", "[emulation][device]") {
   int device = -1;
   hipError_t ret;
   char pciBusIdstr[SIZE]{};
@@ -106,7 +106,7 @@ TEST_CASE("Unit_hipDeviceGetByPCIBusId_NegativeNullChk") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetByPCIBusId_NegativeInputString") {
+TEST_CASE("Unit_hipDeviceGetByPCIBusId_NegativeInputString", "[emulation][device]") {
   int device = -1;
   hipError_t ret;
   ret = hipDeviceGetByPCIBusId(&device, "");
@@ -129,7 +129,7 @@ TEST_CASE("Unit_hipDeviceGetByPCIBusId_NegativeInputString") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetByPCIBusId_WrongBusID") {
+TEST_CASE("Unit_hipDeviceGetByPCIBusId_WrongBusID", "[emulation][device]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   HIP_ASSERT(deviceCount != 0);

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetDefaultMemPool.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetDefaultMemPool.cc
@@ -42,7 +42,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetDefaultMemPool_Positive_Basic") {
+TEST_CASE("Unit_hipDeviceGetDefaultMemPool_Positive_Basic", "[emulation][device]") {
   const int device = GENERATE(range(0, HipTest::getDeviceCount()));
 
   int mem_pool_support = 0;
@@ -75,7 +75,7 @@ TEST_CASE("Unit_hipDeviceGetDefaultMemPool_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetDefaultMemPool_Negative_Parameters") {
+TEST_CASE("Unit_hipDeviceGetDefaultMemPool_Negative_Parameters", "[emulation][device]") {
   hipMemPool_t mem_pool;
 
   SECTION("mem_pool == nullptr") {

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetName.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetName.cc
@@ -55,7 +55,7 @@ constexpr size_t LEN = 256;
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetName_NegTst") {
+TEST_CASE("Unit_hipDeviceGetName_NegTst", "[emulation][device]") {
   std::array<char, LEN> name;
 
   int numDevices = 0;
@@ -114,7 +114,7 @@ TEST_CASE("Unit_hipDeviceGetName_NegTst") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetName_CheckPropName") {
+TEST_CASE("Unit_hipDeviceGetName_CheckPropName", "[emulation][device]") {
   int numDevices = 0;
   std::array<char, LEN> name;
   hipDevice_t device;
@@ -142,7 +142,7 @@ TEST_CASE("Unit_hipDeviceGetName_CheckPropName") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetName_PartialFill") {
+TEST_CASE("Unit_hipDeviceGetName_PartialFill", "[emulation][device]") {
 #if HT_AMD
   HipTest::HIP_SKIP_TEST("EXSWCPHIPT-108");
   return;
@@ -210,7 +210,7 @@ static inline std::vector<int> parseVisibleDevices() {
  * ------------------------
  *  - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipDeviceName_gcnArchName_And_rocm_agent_enumerator") {
+TEST_CASE("Unit_hipDeviceName_gcnArchName_And_rocm_agent_enumerator", "[emulation][device]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount <= 0) {

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetPCIBusId.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetPCIBusId.cc
@@ -56,7 +56,7 @@ void getPciBusId(int deviceCount, char** hipDeviceList) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetPCIBusId_Check_PciBusID_WithAttr") {
+TEST_CASE("Unit_hipDeviceGetPCIBusId_Check_PciBusID_WithAttr", "[emulation][device]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   REQUIRE_FALSE(deviceCount == 0);
@@ -102,7 +102,7 @@ TEST_CASE("Unit_hipDeviceGetPCIBusId_Check_PciBusID_WithAttr") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetPCIBusId_Negative_PartialFill") {
+TEST_CASE("Unit_hipDeviceGetPCIBusId_Negative_PartialFill", "[emulation][device]") {
   std::array<char, MAX_DEVICE_LENGTH> busID;
 
   const int device = GENERATE(range(0, HipTest::getDeviceCount()));
@@ -147,7 +147,7 @@ TEST_CASE("Unit_hipDeviceGetPCIBusId_Negative_PartialFill") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetPCIBusId_NegTst") {
+TEST_CASE("Unit_hipDeviceGetPCIBusId_NegTst", "[emulation][device]") {
   char pciBusId[MAX_DEVICE_LENGTH];
   int device;
   HIP_CHECK(hipGetDevice(&device));

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
@@ -61,7 +61,7 @@ std::atomic<int> tState{1};  // 0:fail, 1:pass, 2:skip
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetUuid_Positive") {
+TEST_CASE("Unit_hipDeviceGetUuid_Positive", "[emulation][device]") {
   hipDevice_t device;
   hipUUID uuid{0};
   bool uuidValid = false;
@@ -99,7 +99,7 @@ TEST_CASE("Unit_hipDeviceGetUuid_Positive") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetUuid_Negative") {
+TEST_CASE("Unit_hipDeviceGetUuid_Negative", "[emulation][device]") {
   int numDevices = 0;
   hipDevice_t device;
   hipUUID uuid;
@@ -145,7 +145,7 @@ static inline std::vector<int> parseVisibleDevices() {
  * ------------------------
  *  - HIP_VERSION >= 5.7
  */
-TEST_CASE("Unit_hipDeviceGetUuid_From_RocmInfo") {
+TEST_CASE("Unit_hipDeviceGetUuid_From_RocmInfo", "[emulation][device]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   assert(deviceCount > 0);
@@ -219,7 +219,7 @@ TEST_CASE("Unit_hipDeviceGetUuid_From_RocmInfo") {
  */
 // Guarding it against NVIDIA as this test is faling on it.
 #if HT_AMD
-TEST_CASE("Unit_hipDeviceGetUuid_VerifyUuidFrm_hipGetDeviceProperties") {
+TEST_CASE("Unit_hipDeviceGetUuid_VerifyUuidFrm_hipGetDeviceProperties", "[emulation][device]") {
   int deviceCount = 0;
   hipDevice_t device;
   hipDeviceProp_t prop;
@@ -307,7 +307,7 @@ auto getUUIDlistWithoutRocmInfo() {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
+TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES", "[emulation][device]") {
   std::map<int, std::vector<char>> uuid_map;
 #ifdef __linux__
   uuid_map = getUUIDlistFromRocmInfo();
@@ -536,7 +536,7 @@ void setEnv() {
  *  - HIP_VERSION >= 6.2
  */
 
-TEST_CASE("Unit_UUID_setEnv_Thread") {
+TEST_CASE("Unit_UUID_setEnv_Thread", "[emulation][device]") {
   // Create Thread one
   std::thread t1(setEnv);
   t1.join();

--- a/projects/hip-tests/catch/unit/device/hipDeviceReset.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceReset.cc
@@ -46,7 +46,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceReset_Positive_Basic") {
+TEST_CASE("Unit_hipDeviceReset_Positive_Basic", "[emulation][device]") {
   const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
   HIP_CHECK(hipSetDevice(device));
   INFO("Current device is: " << device);
@@ -111,7 +111,7 @@ TEST_CASE("Unit_hipDeviceReset_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceReset_Positive_Threaded") {
+TEST_CASE("Unit_hipDeviceReset_Positive_Threaded", "[emulation][device]") {
   HIP_CHECK(hipSetDevice(0));
   INFO("Current device is: " << 0);
 

--- a/projects/hip-tests/catch/unit/device/hipDeviceSetGetCacheConfig.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceSetGetCacheConfig.cc
@@ -46,7 +46,7 @@ constexpr std::array<hipFuncCache_t, 4> kCacheConfigs{
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceSetCacheConfig_Positive_Basic") {
+TEST_CASE("Unit_hipDeviceSetCacheConfig_Positive_Basic", "[emulation][device]") {
   const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
   HIP_CHECK(hipSetDevice(device));
   INFO("Current device is: " << device);
@@ -81,7 +81,7 @@ TEST_CASE("Unit_hipDeviceSetCacheConfig_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetCacheConfig_Positive_Default") {
+TEST_CASE("Unit_hipDeviceGetCacheConfig_Positive_Default", "[emulation][device]") {
   const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
   HIP_CHECK(hipSetDevice(device));
   INFO("Current device is: " << device);

--- a/projects/hip-tests/catch/unit/device/hipDeviceSetGetLimit.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceSetGetLimit.cc
@@ -54,7 +54,7 @@ void DeviceSetLimitTest(hipLimit_t limit) {
  * ------------------------
  *  - HIP_VERSION >= 5.3
  */
-TEST_CASE("Unit_hipDeviceSetLimit_Positive_StackSize") { DeviceSetLimitTest(hipLimitStackSize); }
+TEST_CASE("Unit_hipDeviceSetLimit_Positive_StackSize", "[emulation][device]") { DeviceSetLimitTest(hipLimitStackSize); }
 
 #if HT_NVIDIA
 
@@ -71,7 +71,7 @@ __device__ __managed__ bool stop = false;
  * ------------------------
  *  - HIP_VERSION >= 5.3
  */
-TEST_CASE("Unit_hipDeviceSetLimit_Positive_PrintfFifoSize") {
+TEST_CASE("Unit_hipDeviceSetLimit_Positive_PrintfFifoSize", "[emulation][device]") {
   DeviceSetLimitTest(hipLimitPrintfFifoSize);
 }
 
@@ -91,7 +91,7 @@ __global__ void PrintfKernel() {
  * ------------------------
  *  - HIP_VERSION >= 5.3
  */
-TEST_CASE("Unit_hipDeviceSetLimit_Negative_PrintfFifoSize") {
+TEST_CASE("Unit_hipDeviceSetLimit_Negative_PrintfFifoSize", "[emulation][device]") {
   PrintfKernel<<<1, 1>>>();
   HIP_CHECK_ERROR(hipDeviceSetLimit(hipLimitPrintfFifoSize, 1024), hipErrorInvalidValue);
   stop = true;
@@ -110,7 +110,7 @@ TEST_CASE("Unit_hipDeviceSetLimit_Negative_PrintfFifoSize") {
  * ------------------------
  *  - HIP_VERSION >= 5.3
  */
-TEST_CASE("Unit_hipDeviceSetLimit_Positive_MallocHeapSize") {
+TEST_CASE("Unit_hipDeviceSetLimit_Positive_MallocHeapSize", "[emulation][device]") {
   DeviceSetLimitTest(hipLimitMallocHeapSize);
 }
 
@@ -130,7 +130,7 @@ __global__ void MallocKernel() {
  * ------------------------
  *  - HIP_VERSION >= 5.3
  */
-TEST_CASE("Unit_hipDeviceSetLimit_Negative_MallocHeapSize") {
+TEST_CASE("Unit_hipDeviceSetLimit_Negative_MallocHeapSize", "[emulation][device]") {
   MallocKernel<<<1, 1>>>();
   HIP_CHECK_ERROR(hipDeviceSetLimit(hipLimitMallocHeapSize, 1024), hipErrorInvalidValue);
   stop = true;
@@ -151,7 +151,7 @@ TEST_CASE("Unit_hipDeviceSetLimit_Negative_MallocHeapSize") {
  * ------------------------
  *  - HIP_VERSION >= 5.3
  */
-TEST_CASE("Unit_hipDeviceSetLimit_Negative_Parameters") {
+TEST_CASE("Unit_hipDeviceSetLimit_Negative_Parameters", "[emulation][device]") {
   HIP_CHECK_ERROR(hipDeviceSetLimit(static_cast<hipLimit_t>(-1), 1024), hipErrorUnsupportedLimit);
 }
 
@@ -179,7 +179,7 @@ TEST_CASE("Unit_hipDeviceSetLimit_Negative_Parameters") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetLimit_Negative_Parameters") {
+TEST_CASE("Unit_hipDeviceGetLimit_Negative_Parameters", "[emulation][device]") {
   SECTION("nullptr") {
     HIP_CHECK_ERROR(hipDeviceGetLimit(nullptr, hipLimitStackSize), hipErrorInvalidValue);
   }
@@ -222,7 +222,7 @@ bool isSetScratchLimitSupported() {
  * ------------------------
  *  - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_Negative") {
+TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_Negative", "[emulation][device]") {
   size_t value = 0;
   SECTION("With hipLimitRange") {
     HIP_CHECK_ERROR(hipDeviceGetLimit(&value, hipLimitRange), hipErrorInvalidValue);
@@ -252,7 +252,7 @@ TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_Negative") {
  * ------------------------
  *  - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_SetMinAndMaxAsCurrent") {
+TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_SetMinAndMaxAsCurrent", "[emulation][device]") {
   if (!isSetScratchLimitSupported()) {
     HipTest::HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
@@ -292,7 +292,7 @@ TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_SetMinAndMaxAsCurrent") {
  * ------------------------
  *  - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_DecreaseIncrease") {
+TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_DecreaseIncrease", "[emulation][device]") {
   if (!isSetScratchLimitSupported()) {
     HipTest::HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
@@ -371,7 +371,7 @@ __global__ void addOneKernelUseScratch(int* arr) {
  * ------------------------
  *  - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_SetBeforeKernelLaunch") {
+TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_SetBeforeKernelLaunch", "[emulation][device]") {
   if (!isSetScratchLimitSupported()) {
     HipTest::HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
@@ -454,7 +454,7 @@ void getMinMaxCurrentAndSetCurrent() {
  * ------------------------
  *  - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_MultiDevice") {
+TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_MultiDevice", "[emulation][multigpu][device]") {
   int deviceCount = 0;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
   if (deviceCount < 2) {
@@ -490,7 +490,7 @@ TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_MultiDevice") {
  * ------------------------
  *  - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_InThread") {
+TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_InThread", "[emulation][device]") {
   if (!isSetScratchLimitSupported()) {
     HipTest::HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
@@ -516,7 +516,7 @@ TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_InThread") {
  * ------------------------
  *  - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_InChildProcess") {
+TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_InChildProcess", "[multiprocess][device]") {
   if (!isSetScratchLimitSupported()) {
     HipTest::HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."
@@ -562,7 +562,7 @@ void getScratchCurrent(size_t checkValue) {
  * ------------------------
  *  - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_SetGetThreads") {
+TEST_CASE("Unit_hipDeviceGetSetLimit_Scratch_SetGetThreads", "[emulation][device]") {
   if (!isSetScratchLimitSupported()) {
     HipTest::HIP_SKIP_TEST(
         "Set Scratch Limit Not Supported on Current Device."

--- a/projects/hip-tests/catch/unit/device/hipDeviceSetGetMemPool.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceSetGetMemPool.cc
@@ -72,7 +72,7 @@ static inline hipMemPool_t CreateMemPool(const int device) {
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceSetMemPool_Positive_Basic") {
+TEST_CASE("Unit_hipDeviceSetMemPool_Positive_Basic", "[emulation][device]") {
   const int device = GENERATE(range(0, HipTest::getDeviceCount()));
 
   if (!CheckMemPoolSupport(device)) {
@@ -103,7 +103,7 @@ TEST_CASE("Unit_hipDeviceSetMemPool_Positive_Basic") {
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceSetMemPool_Negative_Parameters") {
+TEST_CASE("Unit_hipDeviceSetMemPool_Negative_Parameters", "[emulation][device]") {
   hipMemPool_t mem_pool;
   HIP_CHECK(hipDeviceGetDefaultMemPool(&mem_pool, 0));
 
@@ -145,7 +145,7 @@ TEST_CASE("Unit_hipDeviceSetMemPool_Negative_Parameters") {
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetMemPool_Positive_Default") {
+TEST_CASE("Unit_hipDeviceGetMemPool_Positive_Default", "[emulation][device]") {
   const int device = GENERATE(range(0, HipTest::getDeviceCount()));
 
   if (!CheckMemPoolSupport(device)) {
@@ -173,7 +173,7 @@ TEST_CASE("Unit_hipDeviceGetMemPool_Positive_Default") {
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetMemPool_Positive_Basic") {
+TEST_CASE("Unit_hipDeviceGetMemPool_Positive_Basic", "[emulation][device]") {
   const int device = GENERATE(range(0, HipTest::getDeviceCount()));
 
   if (!CheckMemPoolSupport(device)) {
@@ -203,7 +203,7 @@ TEST_CASE("Unit_hipDeviceGetMemPool_Positive_Basic") {
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetMemPool_Positive_Threaded") {
+TEST_CASE("Unit_hipDeviceGetMemPool_Positive_Threaded", "[emulation][device]") {
   class HipDeviceGetMemPoolTest : public ThreadedZigZagTest<HipDeviceGetMemPoolTest> {
    public:
     void TestPart2() {
@@ -248,7 +248,7 @@ TEST_CASE("Unit_hipDeviceGetMemPool_Positive_Threaded") {
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetMemPool_Negative_Parameters") {
+TEST_CASE("Unit_hipDeviceGetMemPool_Negative_Parameters", "[emulation][device]") {
   hipMemPool_t mem_pool;
 
   SECTION("mem_pool == nullptr") {

--- a/projects/hip-tests/catch/unit/device/hipDeviceSetGetSharedMemConfig.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceSetGetSharedMemConfig.cc
@@ -48,7 +48,7 @@ constexpr std::array<hipSharedMemConfig, 3> kMemConfigs{
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceSetSharedMemConfig_Positive_Basic") {
+TEST_CASE("Unit_hipDeviceSetSharedMemConfig_Positive_Basic", "[emulation][device]") {
   const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
   const auto mem_config = GENERATE(from_range(std::begin(kMemConfigs), std::end(kMemConfigs)));
   HIP_CHECK(hipSetDevice(device));
@@ -71,7 +71,7 @@ TEST_CASE("Unit_hipDeviceSetSharedMemConfig_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceSetSharedMemConfig_Negative_Parameters") {
+TEST_CASE("Unit_hipDeviceSetSharedMemConfig_Negative_Parameters", "[emulation][device]") {
   HIP_CHECK_ERROR(hipDeviceSetSharedMemConfig(static_cast<hipSharedMemConfig>(-1)),
                   hipErrorInvalidValue);
 }
@@ -100,7 +100,7 @@ TEST_CASE("Unit_hipDeviceSetSharedMemConfig_Negative_Parameters") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetSharedMemConfig_Positive_Default") {
+TEST_CASE("Unit_hipDeviceGetSharedMemConfig_Positive_Default", "[emulation][device]") {
   const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
   HIP_CHECK(hipSetDevice(device));
   INFO("Current device is " << device);
@@ -122,7 +122,7 @@ TEST_CASE("Unit_hipDeviceGetSharedMemConfig_Positive_Default") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetSharedMemConfig_Positive_Basic") {
+TEST_CASE("Unit_hipDeviceGetSharedMemConfig_Positive_Basic", "[emulation][device]") {
   const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
   const auto mem_config = GENERATE(from_range(std::begin(kMemConfigs), std::end(kMemConfigs)));
   HIP_CHECK(hipSetDevice(device));
@@ -156,7 +156,7 @@ TEST_CASE("Unit_hipDeviceGetSharedMemConfig_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetSharedMemConfig_Positive_Threaded") {
+TEST_CASE("Unit_hipDeviceGetSharedMemConfig_Positive_Threaded", "[emulation][device]") {
   class HipDeviceGetSharedMemConfigTest
       : public ThreadedZigZagTest<HipDeviceGetSharedMemConfigTest> {
    public:
@@ -202,6 +202,6 @@ TEST_CASE("Unit_hipDeviceGetSharedMemConfig_Positive_Threaded") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetSharedMemConfig_Negative_Parameters") {
+TEST_CASE("Unit_hipDeviceGetSharedMemConfig_Negative_Parameters", "[emulation][device]") {
   HIP_CHECK_ERROR(hipDeviceGetSharedMemConfig(nullptr), hipErrorInvalidValue);
 }

--- a/projects/hip-tests/catch/unit/device/hipDeviceSynchronize.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceSynchronize.cc
@@ -60,7 +60,7 @@ static __global__ void Iter(int* Ad, int num) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceSynchronize_Positive_Empty_Streams") {
+TEST_CASE("Unit_hipDeviceSynchronize_Positive_Empty_Streams", "[emulation][device]") {
   const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
   HIP_CHECK(hipSetDevice(device));
   INFO("Current device: " << device);
@@ -83,7 +83,7 @@ TEST_CASE("Unit_hipDeviceSynchronize_Positive_Empty_Streams") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceSynchronize_Positive_Nullstream") {
+TEST_CASE("Unit_hipDeviceSynchronize_Positive_Nullstream", "[emulation][device]") {
   const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
   HIP_CHECK(hipSetDevice(device));
   INFO("Current device: " << device);
@@ -120,7 +120,7 @@ TEST_CASE("Unit_hipDeviceSynchronize_Positive_Nullstream") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceSynchronize_Functional") {
+TEST_CASE("Unit_hipDeviceSynchronize_Functional", "[emulation][device]") {
   int* A[NUM_STREAMS];
   int* Ad[NUM_STREAMS];
   hipStream_t stream[NUM_STREAMS];

--- a/projects/hip-tests/catch/unit/device/hipDeviceTotalMem.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceTotalMem.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceTotalMem_NegTst") {
+TEST_CASE("Unit_hipDeviceTotalMem_NegTst", "[emulation][device]") {
 #if HT_NVIDIA
   HIP_CHECK(hipInit(0));
 #endif
@@ -79,7 +79,7 @@ TEST_CASE("Unit_hipDeviceTotalMem_NegTst") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceTotalMem_ValidateTotalMem") {
+TEST_CASE("Unit_hipDeviceTotalMem_ValidateTotalMem", "[emulation][device]") {
   size_t totMem;
   int numDevices = 0;
 
@@ -115,7 +115,7 @@ TEST_CASE("Unit_hipDeviceTotalMem_ValidateTotalMem") {
  *  - Multi-device test
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceTotalMem_NonSelectedDevice") {
+TEST_CASE("Unit_hipDeviceTotalMem_NonSelectedDevice", "[emulation][device]") {
   auto deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
     HipTest::HIP_SKIP_TEST("Multi Device Test, will not run on single gpu systems. Skipping.");

--- a/projects/hip-tests/catch/unit/device/hipDriverGetVersion.cc
+++ b/projects/hip-tests/catch/unit/device/hipDriverGetVersion.cc
@@ -41,7 +41,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDriverGetVersion_Positive") {
+TEST_CASE("Unit_hipDriverGetVersion_Positive", "[emulation][device]") {
   int driverVersion = -1;
   HIP_CHECK(hipDriverGetVersion(&driverVersion));
   REQUIRE(driverVersion > 0);
@@ -61,7 +61,7 @@ TEST_CASE("Unit_hipDriverGetVersion_Positive") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDriverGetVersion_Negative") {
+TEST_CASE("Unit_hipDriverGetVersion_Negative", "[emulation][device]") {
   // If initialization is attempted with nullptr, error shall be reported
   HIP_CHECK_ERROR(hipDriverGetVersion(nullptr), hipErrorInvalidValue);
 }

--- a/projects/hip-tests/catch/unit/device/hipExtGetLinkTypeAndHopCount.cc
+++ b/projects/hip-tests/catch/unit/device/hipExtGetLinkTypeAndHopCount.cc
@@ -45,7 +45,7 @@ THE SOFTWARE.
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipExtGetLinkTypeAndHopCount_Positive_Basic") {
+TEST_CASE("Unit_hipExtGetLinkTypeAndHopCount_Positive_Basic", "[emulation][multigpu][device]") {
   const auto device1 = GENERATE(range(0, HipTest::getDeviceCount()));
   const auto device2 = GENERATE(range(0, HipTest::getDeviceCount()));
 
@@ -107,7 +107,7 @@ TEST_CASE("Unit_hipExtGetLinkTypeAndHopCount_Positive_Basic") {
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipExtGetLinkTypeAndHopCount_Negative_Parameters") {
+TEST_CASE("Unit_hipExtGetLinkTypeAndHopCount_Negative_Parameters", "[emulation][device]") {
   uint32_t link_type, hop_count;
   SECTION("same device") {
     HIP_CHECK_ERROR(hipExtGetLinkTypeAndHopCount(0, 0, &link_type, &hop_count),

--- a/projects/hip-tests/catch/unit/device/hipGetDeviceAttribute.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetDeviceAttribute.cc
@@ -79,7 +79,7 @@ static hipError_t test_hipDeviceGetHdpAddress(int deviceId, hipDeviceAttribute_t
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetDeviceAttribute_CheckAttrValues") {
+TEST_CASE("Unit_hipGetDeviceAttribute_CheckAttrValues", "[emulation][device]") {
   int deviceId;
   HIP_CHECK(hipGetDevice(&deviceId));
   hipDeviceProp_t props;
@@ -212,7 +212,7 @@ TEST_CASE("Unit_hipGetDeviceAttribute_CheckAttrValues") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGetAttribute_NegTst") {
+TEST_CASE("Unit_hipDeviceGetAttribute_NegTst", "[emulation][device]") {
   int deviceCount = 0;
   int pi = -1;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
@@ -416,7 +416,7 @@ void printAttributes(const AttributeToStringMap<n>& attributes, const int device
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Print_Out_Attributes") {
+TEST_CASE("Print_Out_Attributes", "[emulation][device]") {
   const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
   hipDeviceProp_t properties;
   HIP_CHECK(hipGetDeviceProperties(&properties, device));
@@ -457,7 +457,7 @@ TEST_CASE("Print_Out_Attributes") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipGetDeviceAttribute_hipDevAttrHostRegisterSupported") {
+TEST_CASE("Unit_hipGetDeviceAttribute_hipDevAttrHostRegisterSupported", "[emulation][device]") {
   hipError_t ret_val;
   int hipDevAttr = 0;
   ret_val = hipDeviceGetAttribute(&hipDevAttr, hipDeviceAttributeHostRegisterSupported, 0);

--- a/projects/hip-tests/catch/unit/device/hipGetDeviceCount.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetDeviceCount.cc
@@ -42,7 +42,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetDeviceCount_NegTst") {
+TEST_CASE("Unit_hipGetDeviceCount_NegTst", "[emulation][device]") {
   REQUIRE_FALSE(hipGetDeviceCount(nullptr) == hipSuccess);
 }
 
@@ -59,7 +59,7 @@ TEST_CASE("Unit_hipGetDeviceCount_NegTst") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetDeviceCount_HideDevices") {
+TEST_CASE("Unit_hipGetDeviceCount_HideDevices", "[emulation][device]") {
   int deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
     HipTest::HIP_SKIP_TEST("This test requires more than 2 GPUs. Skipping.");
@@ -92,7 +92,7 @@ TEST_CASE("Unit_hipGetDeviceCount_HideDevices") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Print_Out_Device_Count") {
+TEST_CASE("Print_Out_Device_Count", "[emulation][device]") {
   std::cout << "Device Count: " << HipTest::getDeviceCount() << std::endl;
 }
 

--- a/projects/hip-tests/catch/unit/device/hipGetDeviceProperties.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetDeviceProperties.cc
@@ -148,7 +148,7 @@ static void validateDeviceMacro(int* archProp_h, hipDeviceProp_t* prop) {
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetDeviceProperties_ArchPropertiesTst") {
+TEST_CASE("Unit_hipGetDeviceProperties_ArchPropertiesTst", "[emulation][device]") {
   int *archProp_h, *archProp_d;
   archProp_h = new int[NUM_OF_ARCHPROP];
   hipDeviceProp_t prop;
@@ -195,7 +195,7 @@ TEST_CASE("Unit_hipGetDeviceProperties_ArchPropertiesTst") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetDeviceProperties_NegTst") {
+TEST_CASE("Unit_hipGetDeviceProperties_NegTst", "[emulation][device]") {
   hipDeviceProp_t prop;
 
   SECTION("props is nullptr") {
@@ -225,7 +225,7 @@ TEST_CASE("Unit_hipGetDeviceProperties_NegTst") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Print_Out_Properties") {
+TEST_CASE("Print_Out_Properties", "[emulation][device]") {
   constexpr int w = 42;
   const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
 
@@ -354,7 +354,7 @@ TEST_CASE("Print_Out_Properties") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Print_Out_Properties_6.0") {
+TEST_CASE("Print_Out_Properties_6.0", "[emulation][device]") {
   constexpr int w = 42;
   const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
 

--- a/projects/hip-tests/catch/unit/device/hipGetDriverEntryPoint.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetDriverEntryPoint.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipGetDriverEntryPoint_Positive") {
+TEST_CASE("Unit_hipGetDriverEntryPoint_Positive", "[emulation][device]") {
   void* funcPtr = nullptr;
   hipDriverEntryPointQueryResult status;
 
@@ -90,7 +90,7 @@ TEST_CASE("Unit_hipGetDriverEntryPoint_Positive") {
  *  - HIP_VERSION >= 7.1
  */
 
-TEST_CASE("Unit_hipGetDriverEntryPoint_Negative") {
+TEST_CASE("Unit_hipGetDriverEntryPoint_Negative", "[emulation][device]") {
   void* funcPtr = nullptr;
   hipDriverEntryPointQueryResult status;
 
@@ -136,7 +136,7 @@ TEST_CASE("Unit_hipGetDriverEntryPoint_Negative") {
  *  - HIP_VERSION >= 7.1
  */
 
-TEST_CASE("Unit_hipGetDriverEntryPoint_spt_Positive") {
+TEST_CASE("Unit_hipGetDriverEntryPoint_spt_Positive", "[emulation][device]") {
   void* funcPtr = nullptr;
   hipDriverEntryPointQueryResult status;
 
@@ -182,7 +182,7 @@ TEST_CASE("Unit_hipGetDriverEntryPoint_spt_Positive") {
  *  - HIP_VERSION >= 7.1
  */
 
-TEST_CASE("Unit_hipGetDriverEntryPoint_spt_Negative") {
+TEST_CASE("Unit_hipGetDriverEntryPoint_spt_Negative", "[emulation][device]") {
   void* funcPtr = nullptr;
   hipDriverEntryPointQueryResult status;
 

--- a/projects/hip-tests/catch/unit/device/hipGetProcAddressDevMgmt.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetProcAddressDevMgmt.cc
@@ -50,7 +50,7 @@ void CreateMemPool(int device, hipMemPool_t& mem_pool) {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_ValidateDeviceApis") {
+TEST_CASE("Unit_hipGetProcAddress_ValidateDeviceApis", "[emulation][device]") {
   void* hipGetDeviceCount_ptr = nullptr;
   void* hipRuntimeGetVersion_ptr = nullptr;
   void* hipDeviceGetLimit_ptr = nullptr;
@@ -372,7 +372,7 @@ TEST_CASE("Unit_hipGetProcAddress_ValidateDeviceApis") {
  *  - HIP_VERSION >= 6.2
  */
 
-TEST_CASE("Unit_hipGetProcAddress_PeerDeviceAccessAPIs") {
+TEST_CASE("Unit_hipGetProcAddress_PeerDeviceAccessAPIs", "[emulation][device]") {
   void* hipDeviceCanAccessPeer_ptr = nullptr;
   void* hipSetDevice_ptr = nullptr;
   void* hipGetDevice_ptr = nullptr;
@@ -453,7 +453,7 @@ bool CheckMemPoolSupport(const int device) {
   return true;
 }
 
-TEST_CASE("Unit_hipGetProcAddress_SetGetMemPoolAPIs") {
+TEST_CASE("Unit_hipGetProcAddress_SetGetMemPoolAPIs", "[emulation][device]") {
   void* hipDeviceSetMemPool_ptr = nullptr;
   void* hipDeviceGetMemPool_ptr = nullptr;
   int currentHipVersion = 0;

--- a/projects/hip-tests/catch/unit/device/hipGetProcAddressIpcApis.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetProcAddressIpcApis.cc
@@ -40,7 +40,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_IPC_Memory") {
+TEST_CASE("Unit_hipGetProcAddress_IPC_Memory", "[ipc][multiprocess][device]") {
   int N = 40;
   int Nbytes = N * sizeof(int);
 
@@ -137,7 +137,7 @@ TEST_CASE("Unit_hipGetProcAddress_IPC_Memory") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_IPC_Event") {
+TEST_CASE("Unit_hipGetProcAddress_IPC_Event", "[ipc][multiprocess][device]") {
   int fd[2];
   REQUIRE(pipe(fd) == 0);
 

--- a/projects/hip-tests/catch/unit/device/hipGetSetDeviceFlags.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetSetDeviceFlags.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetSetDeviceFlags_NullptrFlag") {
+TEST_CASE("Unit_hipGetSetDeviceFlags_NullptrFlag", "[emulation][device]") {
   HIP_CHECK_ERROR(hipGetDeviceFlags(nullptr), hipErrorInvalidValue);
 }
 
@@ -80,7 +80,7 @@ std::array<unsigned int, 16> getValidFlags() {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetSetDeviceFlags_ValidFlag") {
+TEST_CASE("Unit_hipGetSetDeviceFlags_ValidFlag", "[emulation][device]") {
   auto validFlags = getValidFlags();
 
   unsigned int flag = 0;
@@ -101,7 +101,7 @@ TEST_CASE("Unit_hipGetSetDeviceFlags_ValidFlag") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetSetDeviceFlags_SetThenGet") {
+TEST_CASE("Unit_hipGetSetDeviceFlags_SetThenGet", "[emulation][device]") {
   auto validFlags = getValidFlags();
 
   auto devNo = GENERATE(range(0, HipTest::getDeviceCount()));
@@ -132,7 +132,7 @@ TEST_CASE("Unit_hipGetSetDeviceFlags_SetThenGet") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetSetDeviceFlags_Threaded") {
+TEST_CASE("Unit_hipGetSetDeviceFlags_Threaded", "[emulation][device]") {
   auto validFlags = getValidFlags();
 
   auto devNo = GENERATE(range(0, HipTest::getDeviceCount()));
@@ -182,7 +182,7 @@ TEST_CASE("Unit_hipGetSetDeviceFlags_Threaded") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetDeviceFlags_Positive_Context") {
+TEST_CASE("Unit_hipGetDeviceFlags_Positive_Context", "[emulation][device]") {
   auto validFlags = getValidFlags();
   const unsigned int flags =
       GENERATE_COPY(from_range(std::begin(validFlags), std::end(validFlags)));
@@ -232,7 +232,7 @@ TEST_CASE("Unit_hipGetDeviceFlags_Positive_Context") {
  *  - Platform specific (NVIDIA)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetSetDeviceFlags_InvalidFlag") {
+TEST_CASE("Unit_hipGetSetDeviceFlags_InvalidFlag", "[emulation][device]") {
 #if HT_AMD
   HipTest::HIP_SKIP_TEST("EXSWCPHIPT-115");
   return;

--- a/projects/hip-tests/catch/unit/device/hipInit.cc
+++ b/projects/hip-tests/catch/unit/device/hipInit.cc
@@ -41,7 +41,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipInit_Positive") {
+TEST_CASE("Unit_hipInit_Positive", "[emulation][device]") {
   HIP_CHECK(hipInit(0));
 
   // Verify that HIP runtime is successfully initialized by calling a HIP API
@@ -63,7 +63,7 @@ TEST_CASE("Unit_hipInit_Positive") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipInit_Negative") {
+TEST_CASE("Unit_hipInit_Negative", "[emulation][device]") {
   // If initialization is attempted with invalid flag, error shall be reported
   unsigned int invalid_flag = 1;
   HIP_CHECK_ERROR(hipInit(invalid_flag), hipErrorInvalidValue);

--- a/projects/hip-tests/catch/unit/device/hipIpcCloseMemHandle.cc
+++ b/projects/hip-tests/catch/unit/device/hipIpcCloseMemHandle.cc
@@ -53,7 +53,7 @@ THE SOFTWARE.
  *  - Host specific (LINUX)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipIpcCloseMemHandle_Positive_Reference_Counting") {
+TEST_CASE("Unit_hipIpcCloseMemHandle_Positive_Reference_Counting", "[ipc][device]") {
   int fd[2];
   REQUIRE(pipe(fd) == 0);
 
@@ -118,7 +118,7 @@ TEST_CASE("Unit_hipIpcCloseMemHandle_Positive_Reference_Counting") {
  *  - Host specific (LINUX)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipIpcCloseMemHandle_Negative_Close_In_Originating_Process") {
+TEST_CASE("Unit_hipIpcCloseMemHandle_Negative_Close_In_Originating_Process", "[ipc][device]") {
   void* ptr;
   hipIpcMemHandle_t handle;
   HIP_CHECK(hipMalloc(&ptr, 1024));

--- a/projects/hip-tests/catch/unit/device/hipIpcGetMemHandle.cc
+++ b/projects/hip-tests/catch/unit/device/hipIpcGetMemHandle.cc
@@ -48,7 +48,7 @@ THE SOFTWARE.
  *  - Host specific (LINUX)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipIpcGetMemHandle_Positive_Unique_Handles_Separate_Allocations") {
+TEST_CASE("Unit_hipIpcGetMemHandle_Positive_Unique_Handles_Separate_Allocations", "[ipc][device]") {
   void *ptr1, *ptr2;
   hipIpcMemHandle_t handle1, handle2;
   HIP_CHECK(hipMalloc(&ptr1, 1024));
@@ -75,7 +75,7 @@ TEST_CASE("Unit_hipIpcGetMemHandle_Positive_Unique_Handles_Separate_Allocations"
  *  - Host specific (LINUX)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipIpcGetMemHandle_Positive_Unique_Handles_Reused_Memory") {
+TEST_CASE("Unit_hipIpcGetMemHandle_Positive_Unique_Handles_Reused_Memory", "[ipc][device]") {
   void *ptr1 = nullptr, *ptr2 = nullptr;
   hipIpcMemHandle_t handle1, handle2;
   HIP_CHECK(hipMalloc(&ptr1, 1024));
@@ -104,7 +104,7 @@ TEST_CASE("Unit_hipIpcGetMemHandle_Positive_Unique_Handles_Reused_Memory") {
  *  - Host specific (LINUX)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipIpcGetMemHandle_Negative_Handle_For_Freed_Memory") {
+TEST_CASE("Unit_hipIpcGetMemHandle_Negative_Handle_For_Freed_Memory", "[ipc][device]") {
   void* ptr;
   hipIpcMemHandle_t handle;
   HIP_CHECK(hipMalloc(&ptr, 1024));
@@ -126,7 +126,7 @@ TEST_CASE("Unit_hipIpcGetMemHandle_Negative_Handle_For_Freed_Memory") {
  *  - Host specific (LINUX)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipIpcGetMemHandle_Negative_Out_Of_Bound_Pointer") {
+TEST_CASE("Unit_hipIpcGetMemHandle_Negative_Out_Of_Bound_Pointer", "[ipc][device]") {
   int* ptr;
   constexpr size_t n = 1024;
   hipIpcMemHandle_t handle;

--- a/projects/hip-tests/catch/unit/device/hipIpcOpenMemHandle.cc
+++ b/projects/hip-tests/catch/unit/device/hipIpcOpenMemHandle.cc
@@ -52,7 +52,7 @@ THE SOFTWARE.
  *  - Host specific (LINUX)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipIpcOpenMemHandle_Negative_Open_In_Creating_Process") {
+TEST_CASE("Unit_hipIpcOpenMemHandle_Negative_Open_In_Creating_Process", "[ipc][device]") {
   hipDeviceptr_t ptr1, ptr2;
   hipIpcMemHandle_t handle;
   HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&ptr1), 1024));
@@ -78,7 +78,7 @@ TEST_CASE("Unit_hipIpcOpenMemHandle_Negative_Open_In_Creating_Process") {
  *  - Host specific (LINUX)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipIpcOpenMemHandle_Negative_Open_In_Two_Contexts_Same_Device") {
+TEST_CASE("Unit_hipIpcOpenMemHandle_Negative_Open_In_Two_Contexts_Same_Device", "[ipc][device]") {
   int fd[2];
   REQUIRE(pipe(fd) == 0);
 

--- a/projects/hip-tests/catch/unit/device/hipRuntimeGetVersion.cc
+++ b/projects/hip-tests/catch/unit/device/hipRuntimeGetVersion.cc
@@ -42,7 +42,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipRuntimeGetVersion_Positive") {
+TEST_CASE("Unit_hipRuntimeGetVersion_Positive", "[emulation][device]") {
   int runtimeVersion = -1;
   HIP_CHECK(hipRuntimeGetVersion(&runtimeVersion));
   REQUIRE(runtimeVersion > 0);
@@ -62,7 +62,7 @@ TEST_CASE("Unit_hipRuntimeGetVersion_Positive") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipRuntimeGetVersion_Negative") {
+TEST_CASE("Unit_hipRuntimeGetVersion_Negative", "[emulation][device]") {
   // If initialization is attempted with nullptr, error shall be reported
   CHECK_FALSE(hipRuntimeGetVersion(nullptr) == hipSuccess);
 }

--- a/projects/hip-tests/catch/unit/device/hipSetGetDevice.cc
+++ b/projects/hip-tests/catch/unit/device/hipSetGetDevice.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipSetDevice_BasicSetGet") {
+TEST_CASE("Unit_hipSetDevice_BasicSetGet", "[emulation][device]") {
   int numDevices = 0;
   int device{};
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -73,7 +73,7 @@ TEST_CASE("Unit_hipSetDevice_BasicSetGet") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipGetSetDevice_MultiThreaded") {
+TEST_CASE("Unit_hipGetSetDevice_MultiThreaded", "[emulation][device]") {
   auto maxThreads = std::thread::hardware_concurrency();
   auto deviceCount = HipTest::getDeviceCount();
 
@@ -126,7 +126,7 @@ TEST_CASE("Unit_hipGetSetDevice_MultiThreaded") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipSetGetDevice_Positive_Threaded_Basic") {
+TEST_CASE("Unit_hipSetGetDevice_Positive_Threaded_Basic", "[emulation][device]") {
   class HipSetGetDeviceThreadedTest : public ThreadedZigZagTest<HipSetGetDeviceThreadedTest> {
    public:
     void TestPart1() { HIP_CHECK(hipSetDevice(0)); }
@@ -181,7 +181,7 @@ TEST_CASE("Unit_hipSetGetDevice_Positive_Threaded_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipSetGetDevice_Negative") {
+TEST_CASE("Unit_hipSetGetDevice_Negative", "[emulation][device]") {
   SECTION("Get Device - nullptr") { HIP_CHECK_ERROR(hipGetDevice(nullptr), hipErrorInvalidValue); }
 
   SECTION("Set Device - -1") { HIP_CHECK_ERROR(hipSetDevice(-1), hipErrorInvalidDevice); }
@@ -243,7 +243,7 @@ TEST_CASE("Unit_hipSetGetDevice_Negative") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipDeviceGet_Negative") {
+TEST_CASE("Unit_hipDeviceGet_Negative", "[emulation][device]") {
   // TODO enable after EXSWCPHIPT-104 is fixed
 #if HT_NVIDIA
   HIP_CHECK(hipInit(0));

--- a/projects/hip-tests/catch/unit/device/hipSetValidDevices.cc
+++ b/projects/hip-tests/catch/unit/device/hipSetValidDevices.cc
@@ -99,7 +99,7 @@ static void performOperations() {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipSetValidDevices_Negative") {
+TEST_CASE("Unit_hipSetValidDevices_Negative", "[emulation][device]") {
   auto totalDevices = HipTest::getDeviceCount();
   int device_arr1[] = {0};
   int device_arr2[] = {totalDevices};
@@ -130,7 +130,7 @@ TEST_CASE("Unit_hipSetValidDevices_Negative") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipSetValidDevices_Negative_Length_Lessthan_DeviceArrSize") {
+TEST_CASE("Unit_hipSetValidDevices_Negative_Length_Lessthan_DeviceArrSize", "[emulation][device]") {
   int deviceCount = HipTest::getDeviceCount();
 
   SECTION("length < 0 and valid dev arr") {
@@ -158,7 +158,7 @@ TEST_CASE("Unit_hipSetValidDevices_Negative_Length_Lessthan_DeviceArrSize") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipSetValidDevices_Positive_Basic") {
+TEST_CASE("Unit_hipSetValidDevices_Positive_Basic", "[emulation][device]") {
   int totalDevices = HipTest::getDeviceCount();
   if (totalDevices < 2) {
     HipTest::HIP_SKIP_TEST("This test requires 2 or more GPUs. Skipping.");
@@ -212,7 +212,7 @@ TEST_CASE("Unit_hipSetValidDevices_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipSetValidDevices_WithAllDevicesInSystem") {
+TEST_CASE("Unit_hipSetValidDevices_WithAllDevicesInSystem", "[emulation][device]") {
   int deviceCount;
   HIP_CHECK(hipGetDeviceCount(&deviceCount));
 
@@ -260,7 +260,7 @@ TEST_CASE("Unit_hipSetValidDevices_WithAllDevicesInSystem") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipSetValidDevices_Positive_Cases") {
+TEST_CASE("Unit_hipSetValidDevices_Positive_Cases", "[emulation][device]") {
   int deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
     HipTest::HIP_SKIP_TEST("Skipping, as this test requires more than 2 GPUs");
@@ -316,7 +316,7 @@ TEST_CASE("Unit_hipSetValidDevices_Positive_Cases") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipSetValidDevices_MultiProcess") {
+TEST_CASE("Unit_hipSetValidDevices_MultiProcess", "[multiprocess][device]") {
   int deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
     HipTest::HIP_SKIP_TEST("Skipping, as this test requires more than 2 GPUs");
@@ -382,7 +382,7 @@ void launchFunction(int deviceId) {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipSetValidDevices_MultiThread") {
+TEST_CASE("Unit_hipSetValidDevices_MultiThread", "[emulation][device]") {
   int deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
     HipTest::HIP_SKIP_TEST("Skipping, as this test requires more than 2 GPUs");
@@ -424,7 +424,7 @@ TEST_CASE("Unit_hipSetValidDevices_MultiThread") {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEST_CASE("Unit_hipSetValidDevices_with_hipMemcpyPeer") {
+TEST_CASE("Unit_hipSetValidDevices_with_hipMemcpyPeer", "[emulation][multigpu][device]") {
   int deviceCount = HipTest::getDeviceCount();
   if (deviceCount < 2) {
     HipTest::HIP_SKIP_TEST("Skipping, as this test requires more than 2 GPUs");


### PR DESCRIPTION
Tagged all 33 test files in catch/unit/device/ with Catch2 tags to identify emulation-safe tests for use in emulation environments.

- Total test cases: 121
- Emulation-safe: 108 tests (89.3%)
  - [emulation]: 102 tests
  - [emulation][multigpu]: 6 tests
- Not emulation-safe: 13 tests (10.7%)
  - [!emulation][ipc]: 8 tests
  - [!emulation][multiprocess]: 5 tests

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
