### PR TITLE
SWDEV-548417 - Fixed memleak in capturehipMemcpy

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -759,7 +759,7 @@ hipError_t capturehipMemcpy(hipStream_t stream, void* dst, const void* src, size
   std::vector<hip::GraphNode*> pDependencies = s->GetLastCapturedNodes();
   size_t numDependencies = s->GetLastCapturedNodes().size();
   hip::Graph* graph = s->GetCaptureGraph();
-  hip::GraphNode* node = new hip::GraphMemcpyNode1D(dst, src, sizeBytes, kind);
+  hip::GraphNode* node = nullptr;
   hipError_t status = ihipGraphAddMemcpyNode1D(&node, graph, pDependencies.data(), numDependencies,
                                                dst, src, sizeBytes, kind, true, s->DeviceId());
   if (status != hipSuccess) {


### PR DESCRIPTION
## Motivation
This PR fixes a memory leak in the capturehipMemcpy function.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
capturehipMemcpy function is allocating a hip::GraphMemcpyNode1D object, which was being leaked when ihipGraphAddMemcpyNode1D creates its own node allocation.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
The leak was shown when running test Unit_hipExtGetLastError_with_hipStreamBegin_EndCapture with valgrind --leak-check=full
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
No more valgrind memleak warnings when running Unit_hipExtGetLastError_with_hipStreamBegin_EndCapture
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
