### PR TITLE
SWDEV-1 upgrade catch but retain for windows

### DIFF
--- a/projects/hip-tests/catch/CMakeLists.txt
+++ b/projects/hip-tests/catch/CMakeLists.txt
@@ -10,41 +10,33 @@ if(WIN32)
     endif()
 endif()
 
+if(NOT DEFINED HIP_PATH)
+    if(DEFINED ROCM_PATH)
+        set(HIP_PATH ${ROCM_PATH})
+    else()
+        set(HIP_PATH "/opt/rocm")
+    endif()
+endif()
+
 if(NOT DEFINED ROCM_PATH)
     set(ROCM_PATH "/opt/rocm")
 endif()
-if(NOT DEFINED HIP_PATH)
-    set(HIP_PATH ${ROCM_PATH})
-endif()
 
-if(NOT DEFINED HIPCC_EXEC)
-    if(WIN32)
-        set(HIPCC_EXEC "hipcc.exe")
-    else()
-        set(HIPCC_EXEC "hipcc")
-    endif()
-endif()
-if(NOT DEFINED HIPCONFIG_EXEC)
-    if(WIN32)
-        set(HIPCONFIG_EXEC "hipconfig.exe")
-    else()
-        set(HIPCONFIG_EXEC "hipconfig")
-    endif()
-endif()
-
-# hip-tests only work with HIPCC for now
-# We need to move to amdclang++, for now we enforce hipcc
-# using that as default for hiptests project
-if(NOT DEFINED CMAKE_CXX_COMPILER)
-    set(CMAKE_CXX_COMPILER "${HIP_PATH}/bin/${HIPCC_EXEC}")
-endif()
-if(NOT DEFINED CMAKE_C_COMPILER)
-    set(CMAKE_C_COMPILER "${HIP_PATH}/bin/${HIPCC_EXEC}")
+if (WIN32)
+  set(HIPCC_EXEC "hipcc.exe")
+  set(HIPCONFIG_EXEC "hipconfig.exe")
+else()
+  set(HIPCC_EXEC "hipcc")
+  set(HIPCONFIG_EXEC "hipconfig")
 endif()
 
 # Skip compiler check
 set(CMAKE_C_COMPILER_WORKS 1)
 set(CMAKE_CXX_COMPILER_WORKS 1)
+
+# This needs to be set before project because we might need to compile catch2
+set(CMAKE_C_COMPILER   "${HIP_PATH}/bin/${HIPCC_EXEC}")
+set(CMAKE_CXX_COMPILER "${HIP_PATH}/bin/${HIPCC_EXEC}")
 
 project(hiptests)
 

--- a/projects/hip-tests/catch/CMakeLists.txt
+++ b/projects/hip-tests/catch/CMakeLists.txt
@@ -1,6 +1,48 @@
 cmake_minimum_required(VERSION 3.16.8)
 
-# to skip the simple compiler test
+# Read -DHIP_PATH
+# If not set read env{HIP_PATH} only on Windows
+if(WIN32)
+    if(NOT DEFINED HIP_PATH)
+        if(DEFINED ENV{HIP_PATH})
+            set(HIP_PATH $ENV{HIP_PATH} CACHE STRING "HIP Path")
+        endif()
+    endif()
+endif()
+
+if(NOT DEFINED ROCM_PATH)
+    set(ROCM_PATH "/opt/rocm")
+endif()
+if(NOT DEFINED HIP_PATH)
+    set(HIP_PATH ${ROCM_PATH})
+endif()
+
+if(NOT DEFINED HIPCC_EXEC)
+    if(WIN32)
+        set(HIPCC_EXEC "hipcc.exe")
+    else()
+        set(HIPCC_EXEC "hipcc")
+    endif()
+endif()
+if(NOT DEFINED HIPCONFIG_EXEC)
+    if(WIN32)
+        set(HIPCONFIG_EXEC "hipconfig.exe")
+    else()
+        set(HIPCONFIG_EXEC "hipconfig")
+    endif()
+endif()
+
+# hip-tests only work with HIPCC for now
+# We need to move to amdclang++, for now we enforce hipcc
+# using that as default for hiptests project
+if(NOT DEFINED CMAKE_CXX_COMPILER)
+    set(CMAKE_CXX_COMPILER "${HIP_PATH}/bin/${HIPCC_EXEC}")
+endif()
+if(NOT DEFINED CMAKE_C_COMPILER)
+    set(CMAKE_C_COMPILER "${HIP_PATH}/bin/${HIPCC_EXEC}")
+endif()
+
+# Skip compiler check
 set(CMAKE_C_COMPILER_WORKS 1)
 set(CMAKE_CXX_COMPILER_WORKS 1)
 
@@ -8,8 +50,25 @@ project(hiptests)
 
 option(ENABLE_ADDRESS_SANITIZER "Option to enable ASAN build" OFF)
 option(BUILD_SHARED_LIBS "Option for testing shared libraries" ON)
-
+option(BUILD_UNIT_TESTS "Build unit tests" ON)
+option(BUILD_PERF_TESTS "Build perf tests" OFF)
+option(BUILD_STRESS_TESTS "Build stress tests" OFF)
+option(THEROCK_BUILD_MODE "Option to let hip-tests know if TheRock is being used to build" OFF)
+option(USE_PREBUILT_CATCH "Use the catch version shipped with hip-tests" OFF)
 option(TEST_CLOCK_CYCLE "Option to use clock64" OFF)
+
+if(THEROCK_BUILD_MODE AND WIN32)
+    message(FATAL_ERROR "TheRock Builds are not supported on Windows... yet")
+endif()
+
+if(WIN32)
+    set(USE_PREBUILT_CATCH ON CACHE BOOL "Using catch2v2 shipped with hiptests" FORCE)
+endif()
+
+if(USE_PREBUILT_CATCH)
+    add_compile_definitions(USE_PREBUILT_CATCH)
+endif()
+
 if (TEST_CLOCK_CYCLE)
     add_definitions(-DTEST_CLOCK_CYCLE)
 endif()
@@ -38,41 +97,9 @@ if(HIP_PLATFORM STREQUAL "amd")
     endif()
 endif()
 
-# Read -DHIP_PATH
-# If not set read env{HIP_PATH} only on Windows
-if(WIN32)
-    if(NOT DEFINED HIP_PATH)
-        if(DEFINED ENV{HIP_PATH})
-            set(HIP_PATH $ENV{HIP_PATH} CACHE STRING "HIP Path")
-        endif()
-    endif()
-endif()
-
-if(NOT DEFINED HIP_PATH)
-    if(DEFINED ROCM_PATH)
-        set(HIP_PATH ${ROCM_PATH})
-    else()
-        set(HIP_PATH "/opt/rocm")
-    endif()
-endif()
-
-if(NOT DEFINED ROCM_PATH)
-    set(ROCM_PATH "/opt/rocm")
-endif()
-
 message(STATUS "HIP_PATH: ${HIP_PATH}")
 message(STATUS "ROCM_PATH: ${ROCM_PATH}")
 
-if (WIN32)
-  set(HIPCC_EXEC "hipcc.exe")
-  set(HIPCONFIG_EXEC "hipconfig.exe")
-else()
-  set(HIPCC_EXEC "hipcc")
-  set(HIPCONFIG_EXEC "hipconfig")
-endif()
-
-set(CMAKE_C_COMPILER   "${HIP_PATH}/bin/${HIPCC_EXEC}")
-set(CMAKE_CXX_COMPILER "${HIP_PATH}/bin/${HIPCC_EXEC}")
 execute_process(COMMAND ${HIP_PATH}/bin/${HIPCONFIG_EXEC} --version
                 OUTPUT_VARIABLE HIP_VERSION
                 RESULT_VARIABLE result
@@ -118,14 +145,6 @@ else()
    set(HIP_PACKAGING_VERSION_PATCH ${HIP_VERSION_PATCH}-${HIP_VERSION_GITHASH})
 endif()
 
-if(NOT DEFINED CATCH2_PATH)
-    if(DEFINED ENV{CATCH2_PATH})
-        set(CATCH2_PATH $ENV{CATCH2_PATH} CACHE STRING "Catch2 Path")
-    else()
-        set(CATCH2_PATH "${CMAKE_CURRENT_LIST_DIR}/external/Catch2")
-    endif()
-endif()
-message(STATUS "Catch2 Path: ${CATCH2_PATH}")
 
 # Set JSON Parser path
 if(NOT DEFINED JSON_PARSER)
@@ -136,21 +155,46 @@ if(NOT DEFINED JSON_PARSER)
     endif()
 endif()
 
-message(STATUS "Searching Catch2 in: ${CMAKE_CURRENT_LIST_DIR}/external")
-find_package(Catch2 REQUIRED
-    PATHS
-        ${CMAKE_CURRENT_LIST_DIR}/external
-    PATH_SUFFIXES
-    Catch2/cmake/Catch2
-)
-include(Catch)
+# Use Prebuilt Catch2, this is for windows
+if(USE_PREBUILT_CATCH)
+    find_package(Catch2 CONFIG REQUIRED
+        PATHS
+            ${CMAKE_CURRENT_LIST_DIR}/external
+        PATH_SUFFIXES
+        Catch2/cmake/Catch2
+    )
+    include(Catch)
+    include_directories(${CMAKE_CURRENT_LIST_DIR}/external/Catch2)
+    # path used for generating the *_include.cmake file
+    set(CATCH2_INCLUDE ${CATCH2_PATH}/cmake/Catch2/catch_include.cmake.in)
+    set(CATCH_SCRIPT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CATCH_BUILD_DIR}/script)
+    file(COPY ./external/Catch2/cmake/Catch2/CatchAddTests.cmake
+         DESTINATION ${CATCH_SCRIPT_BINARY_DIR})
+    file(COPY ./external/Catch2/cmake/Catch2/catch_include.cmake
+         DESTINATION ${CATCH_SCRIPT_BINARY_DIR})
+    set(ADD_SCRIPT_PATH ${CATCH_SCRIPT_BINARY_DIR}/CatchAddTests.cmake)
+    set(CATCH_INCLUDE_PATH ${CATCH_SCRIPT_BINARY_DIR}/catch_include.cmake)
+else()
+    if(NOT THEROCK_BUILD_MODE)
+        # Setup catch2 manually
+        include(FetchContent)
+        FetchContent_Declare(
+            Catch2
+            URL "https://rocm-third-party-deps.s3.us-east-2.amazonaws.com/Catch2-3.8.1.tar.gz"
+            DOWNLOAD_EXTRACT_TIMESTAMP OFF
+            URL_HASH SHA256=18b3f70ac80fccc340d8c6ff0f339b2ae64944782f8d2fca2bd705cf47cadb79
+        )
+        FetchContent_MakeAvailable(Catch2)
+    else()
+        # TheRock has already setup Catch2 for us
+        find_package(Catch2 REQUIRED)
+    endif()
+    include(cmake/hip-tests.cmake)
+endif() # USE_PREBUILT_CATCH
+
 include(CTest)
 
-# path used for generating the *_include.cmake file
-set(CATCH2_INCLUDE ${CATCH2_PATH}/cmake/Catch2/catch_include.cmake.in)
-
 include_directories(
-    ${CATCH2_PATH}
     "./include"
     "./kernels"
     ${HIP_PATH}/include
@@ -171,13 +215,6 @@ foreach(json IN LISTS JSON_FILES)
     file(COPY ${json}
          DESTINATION ${HIP_TEST_CONFIG_BINARY_DIR})
 endforeach()
-set(CATCH_SCRIPT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CATCH_BUILD_DIR}/script)
-file(COPY ./external/Catch2/cmake/Catch2/CatchAddTests.cmake
-     DESTINATION ${CATCH_SCRIPT_BINARY_DIR})
-file(COPY ./external/Catch2/cmake/Catch2/catch_include.cmake
-     DESTINATION ${CATCH_SCRIPT_BINARY_DIR})
-set(ADD_SCRIPT_PATH ${CATCH_SCRIPT_BINARY_DIR}/CatchAddTests.cmake)
-set(CATCH_INCLUDE_PATH ${CATCH_SCRIPT_BINARY_DIR}/catch_include.cmake)
 
 if (WIN32)
   configure_file(catchProp_in_rc.in ${CMAKE_CURRENT_BINARY_DIR}/catchProp.rc @ONLY)
@@ -198,11 +235,6 @@ endif()
 
 if(HIP_PLATFORM STREQUAL "amd")
     add_compile_options(-Wall -Wextra -Wvla -Werror -Wno-deprecated -Wno-option-ignored)
-endif()
-
-cmake_policy(PUSH)
-if(POLICY CMP0037)
-    cmake_policy(SET CMP0037 OLD)
 endif()
 
 # Turn off CMAKE_HIP_ARCHITECTURES Feature if cmake version is 3.21+
@@ -318,7 +350,6 @@ file(COPY ./unit/compileAndCaptureOutput.py
 
 file(COPY ./include/hip_test_common.hh DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/${CATCH_BUILD_DIR}/${CATCH_INCLUDE_DIR})
 file(COPY ./include/hip_test_context.hh DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/${CATCH_BUILD_DIR}/${CATCH_INCLUDE_DIR})
-file(COPY ./external/Catch2/catch.hpp DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/${CATCH_BUILD_DIR}/${CATCH_INCLUDE_DIR})
 
 # Enable device lambda on nvidia platforms
 if(HIP_PLATFORM STREQUAL "nvidia")
@@ -331,15 +362,21 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 add_custom_target(build_tests)
 
 # Tests folder
-add_subdirectory(unit ${CATCH_BUILD_DIR}/unit)
-add_subdirectory(ABM ${CATCH_BUILD_DIR}/ABM)
-add_subdirectory(kernels ${CATCH_BUILD_DIR}/kernels)
-add_subdirectory(hipTestMain ${CATCH_BUILD_DIR}/hipTestMain)
-add_subdirectory(stress ${CATCH_BUILD_DIR}/stress)
-add_subdirectory(TypeQualifiers ${CATCH_BUILD_DIR}/TypeQualifiers)
-add_subdirectory(perftests ${CATCH_BUILD_DIR}/perftests)
-add_subdirectory(multiproc ${CATCH_BUILD_DIR}/multiproc)
-add_subdirectory(performance ${CATCH_BUILD_DIR}/performance)
+if(BUILD_UNIT_TESTS)
+    add_subdirectory(unit ${CATCH_BUILD_DIR}/unit)
+    add_subdirectory(ABM ${CATCH_BUILD_DIR}/ABM)
+    add_subdirectory(kernels ${CATCH_BUILD_DIR}/kernels)
+    add_subdirectory(hipTestMain ${CATCH_BUILD_DIR}/hipTestMain)
+    add_subdirectory(TypeQualifiers ${CATCH_BUILD_DIR}/TypeQualifiers)
+    add_subdirectory(multiproc ${CATCH_BUILD_DIR}/multiproc)
+endif()
+if(BUILD_PERF_TESTS)
+    add_subdirectory(perftests ${CATCH_BUILD_DIR}/perftests)
+    add_subdirectory(performance ${CATCH_BUILD_DIR}/performance)
+endif()
+if(BUILD_STRESS_TESTS)
+    add_subdirectory(stress ${CATCH_BUILD_DIR}/stress)
+endif()
 
 add_custom_target(gen_coverage
                   COMMAND ${CMAKE_COMMAND} -B build/
@@ -347,8 +384,6 @@ add_custom_target(gen_coverage
                   COMMAND ./build/generateHipAPICoverage ${HIP_PATH}/include
                   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../utils/coverage
                   COMMENT "Generating Test Coverage Report")
-
-cmake_policy(POP)
 
 # packaging the tests
 # make package_test to generate packages for test

--- a/projects/hip-tests/catch/cmake/hip-tests.cmake
+++ b/projects/hip-tests/catch/cmake/hip-tests.cmake
@@ -1,0 +1,157 @@
+include(Catch)
+
+function(hip_add_exe_to_target_compile_time_detection)
+  set(options)
+  # NAME EventTest, TEST_SRC src, TEST_TARGET_NAME build_tests
+  set(args NAME TEST_TARGET_NAME PLATFORM COMPILE_OPTIONS)
+  set(list_args TEST_SRC LINKER_LIBS COMMON_SHARED_SRC PROPERTY)
+  cmake_parse_arguments(
+    PARSE_ARGV 0
+    "" # variable prefix
+    "${options}"
+    "${args}"
+    "${list_args}"
+  )
+
+  foreach(SRC_NAME ${TEST_SRC})
+    if(NOT STANDALONE_TESTS EQUAL "1")
+      set(_EXE_NAME ${_NAME})
+      # take the entire source set for building the executable
+      set(SRC_NAME ${TEST_SRC})
+    else()
+      # strip extension of src and use exe name as src name
+      get_filename_component(_EXE_NAME ${SRC_NAME} NAME_WLE)
+    endif()
+
+    if(NOT RTC_TESTING)
+      add_executable(${_EXE_NAME} EXCLUDE_FROM_ALL ${SRC_NAME} ${COMMON_SHARED_SRC} $<TARGET_OBJECTS:Main_Object> $<TARGET_OBJECTS:KERNELS>)
+    else ()
+      add_executable(${_EXE_NAME} EXCLUDE_FROM_ALL ${SRC_NAME} ${COMMON_SHARED_SRC} $<TARGET_OBJECTS:Main_Object>)
+      if(HIP_PLATFORM STREQUAL "amd")
+          target_link_libraries(${_EXE_NAME} hiprtc)
+      else()
+          target_link_libraries(${_EXE_NAME} nvrtc)
+      endif()
+    endif()
+
+
+
+    if(UNIX)
+      set(_LINKER_LIBS ${_LINKER_LIBS} stdc++fs)
+      set(_LINKER_LIBS ${_LINKER_LIBS} -ldl)
+    else()
+      # res files are built resource files using rc files.
+      # use llvm-rc exe to build the res files
+      # Thes are used to populate the properties of the built executables
+      if(EXISTS "${PROP_RC}/catchProp.res")
+        set(_LINKER_LIBS ${_LINKER_LIBS} "${PROP_RC}/catchProp.res")
+      endif()
+      #set(_LINKER_LIBS ${_LINKER_LIBS} -noAutoResponse)
+    endif()
+
+    if(DEFINED _LINKER_LIBS)
+      target_link_libraries(${_EXE_NAME} ${_LINKER_LIBS})
+    endif()
+
+    # Add dependency on build_tests to build it on this custom target
+    add_dependencies(${_TEST_TARGET_NAME} ${_EXE_NAME})
+
+    if (DEFINED _PROPERTY)
+      set_property(TARGET ${_EXE_NAME} PROPERTY ${_PROPERTY})
+    endif()
+
+    if (DEFINED _COMPILE_OPTIONS)
+      target_compile_options(${_EXE_NAME} PUBLIC ${_COMPILE_OPTIONS})
+    endif()
+    foreach(arg IN LISTS _UNPARSED_ARGUMENTS)
+        message(WARNING "Unparsed arguments: ${arg}")
+    endforeach()
+    get_property(crosscompiling_emulator
+      TARGET ${_EXE_NAME}
+      PROPERTY CROSSCOMPILING_EMULATOR
+    )
+    set(_EXE_NAME_LIST ${_EXE_NAME_LIST} ${_EXE_NAME})
+    if(NOT STANDALONE_TESTS EQUAL "1")
+      break()
+    endif()
+  endforeach()
+  catch_discover_tests("${_EXE_NAME_LIST}" "${_NAME}" PROPERTIES  SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST")
+endfunction()
+
+###############################################################################
+# current staging
+# function to be called by all tests
+function(hip_add_exe_to_target)
+  set(options)
+  set(args NAME TEST_TARGET_NAME PLATFORM COMPILE_OPTIONS)
+  set(list_args TEST_SRC LINKER_LIBS COMMON_SHARED_SRC PROPERTY)
+  cmake_parse_arguments(
+    PARSE_ARGV 0
+    "" # variable prefix
+    "${options}"
+    "${args}"
+    "${list_args}"
+  )
+  foreach(SRC_NAME ${TEST_SRC})
+
+    if(NOT STANDALONE_TESTS EQUAL "1")
+      set(_EXE_NAME ${_NAME})
+      set(SRC_NAME ${TEST_SRC})
+    else()
+      # strip extension of src and use exe name as src name
+      get_filename_component(_EXE_NAME ${SRC_NAME} NAME_WLE)
+    endif()
+
+    # Create shared lib of all tests
+    if(NOT RTC_TESTING)
+      add_executable(${_EXE_NAME} EXCLUDE_FROM_ALL ${SRC_NAME} ${COMMON_SHARED_SRC} $<TARGET_OBJECTS:Main_Object> $<TARGET_OBJECTS:KERNELS>)
+    else ()
+      add_executable(${_EXE_NAME} EXCLUDE_FROM_ALL ${SRC_NAME} ${COMMON_SHARED_SRC} $<TARGET_OBJECTS:Main_Object>)
+      if(HIP_PLATFORM STREQUAL "amd")
+        target_link_libraries(${_EXE_NAME} hiprtc)
+      else()
+        target_link_libraries(${_EXE_NAME} nvrtc)
+      endif()
+    endif()
+    if (DEFINED _PROPERTY)
+      set_property(TARGET ${_EXE_NAME} PROPERTY ${_PROPERTY})
+    endif()
+    if(UNIX)
+      set(_LINKER_LIBS ${_LINKER_LIBS} stdc++fs)
+      set(_LINKER_LIBS ${_LINKER_LIBS} -ldl)
+      set(_LINKER_LIBS ${_LINKER_LIBS} pthread)
+      set(_LINKER_LIBS ${_LINKER_LIBS} rt)
+    else()
+      # res files are built resource files using rc files.
+      # use llvm-rc exe to build the res files
+      # Thes are used to populate the properties of the built executables
+      if(EXISTS "${PROP_RC}/catchProp.res")
+        set(_LINKER_LIBS ${_LINKER_LIBS} "${PROP_RC}/catchProp.res")
+      endif()
+    endif()
+
+    if(DEFINED _LINKER_LIBS)
+      target_link_libraries(${_EXE_NAME} ${_LINKER_LIBS})
+    endif()
+
+    # Add dependency on build_tests to build it on this custom target
+    add_dependencies(${_TEST_TARGET_NAME} ${_EXE_NAME})
+
+    if (DEFINED _COMPILE_OPTIONS)
+      target_compile_options(${_EXE_NAME} PUBLIC ${_COMPILE_OPTIONS})
+    endif()
+    target_link_libraries(${_EXE_NAME} Catch2::Catch2)
+
+    foreach(arg IN LISTS _UNPARSED_ARGUMENTS)
+        message(WARNING "Unparsed arguments: ${arg}")
+    endforeach()
+    # add binary to global list of binaries to install
+    set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS ${_EXE_NAME})
+    catch_discover_tests("${_EXE_NAME}" PROPERTIES SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST")
+
+    if(NOT STANDALONE_TESTS EQUAL "1")
+      break()
+    endif()
+  endforeach()
+endfunction()
+

--- a/projects/hip-tests/catch/hipTestMain/CMakeLists.txt
+++ b/projects/hip-tests/catch/hipTestMain/CMakeLists.txt
@@ -28,3 +28,7 @@ if(HIP_PLATFORM MATCHES "amd")
 else()
     target_compile_options(Main_Object PUBLIC -std=c++17)
 endif()
+
+if(NOT USE_PREBUILT_CATCH)
+    target_link_libraries(Main_Object PRIVATE Catch2::Catch2)
+endif()

--- a/projects/hip-tests/catch/hipTestMain/main.cc
+++ b/projects/hip-tests/catch/hipTestMain/main.cc
@@ -36,7 +36,11 @@ int main(int argc, char** argv) {
 
   Catch::Session session;
 
+#if defined(USE_PREBUILT_CATCH)
   using namespace Catch::clara;
+#else
+  using namespace Catch::Clara;
+#endif
   // clang-format off
   auto cli = session.cli()
     | Opt(cmd_options.iterations, "iterations")

--- a/projects/hip-tests/catch/include/hip_test_common.hh
+++ b/projects/hip-tests/catch/include/hip_test_common.hh
@@ -24,7 +24,11 @@ THE SOFTWARE.
 #pragma clang diagnostic ignored "-Wsign-compare"
 #include "hip_test_context.hh"
 
+#if defined(USE_PREBUILT_CATCH)
 #include <catch.hpp>
+#else
+#include <catch2/catch_all.hpp>
+#endif
 #include <atomic>
 #include <chrono>
 #include <cstring>

--- a/projects/hip-tests/catch/include/hip_test_rtc.hh
+++ b/projects/hip-tests/catch/include/hip_test_rtc.hh
@@ -24,7 +24,6 @@ THE SOFTWARE.
 #include <hip/hip_runtime.h>
 #include <hip/hiprtc.h>
 #include <kernel_mapping.hh>
-#include <catch.hpp>
 #include <string>
 #include <vector>
 #include <iostream>
@@ -126,7 +125,7 @@ inline hiprtcProgram compileRTC(std::string& rtcKernel, std::string& kernelNameE
   kernelFile.close();
 
   std::string kernelCode{stringStream.str()};
-  INFO("RTC Kernel Code:\n" << kernelCode)
+  INFO("RTC Kernel Code:\n" << kernelCode);
 
   hiprtcProgram rtcProgram;
   hiprtcCreateProgram(&rtcProgram, kernelCode.c_str(), (fileName + ".cu").c_str(), 0, nullptr,

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <hip/hip_cooperative_groups.h>
 #include <hip/hip_fp16.h>
-#include <limits>
+#include <random>
 #include <cmath>
 #include <iostream>
 #include <ios>

--- a/projects/hip-tests/catch/kernels/CMakeLists.txt
+++ b/projects/hip-tests/catch/kernels/CMakeLists.txt
@@ -5,4 +5,7 @@ if(NOT RTC_TESTING)
 
     add_library(KERNELS EXCLUDE_FROM_ALL OBJECT ${TEST_SRC})
     target_compile_options(KERNELS PUBLIC -std=c++17)
+    if(NOT USE_PREBUILT_CATCH)
+        target_link_libraries(KERNELS PRIVATE Catch2::Catch2)
+    endif()
 endif()

--- a/projects/hip-tests/catch/unit/callback/hipApiName.cc
+++ b/projects/hip-tests/catch/unit/callback/hipApiName.cc
@@ -74,8 +74,10 @@ TEST_CASE("Unit_hipApiName_Positive_Basic") {
  *  - Platform specific (AMD)
  */
 TEST_CASE("Unit_hipApiName_Negative_ReservedIds") {
-  REQUIRE_THAT(hipApiName(std::numeric_limits<uint32_t>::min()), Catch::Equals(kUnknownApi));
-  REQUIRE_THAT(hipApiName(std::numeric_limits<uint32_t>::max()), Catch::Equals(kUnknownApi));
+  REQUIRE_THAT(hipApiName(std::numeric_limits<uint32_t>::min()),
+               Catch::Matchers::Equals(kUnknownApi));
+  REQUIRE_THAT(hipApiName(std::numeric_limits<uint32_t>::max()),
+               Catch::Matchers::Equals(kUnknownApi));
 }
 
 /**

--- a/projects/hip-tests/catch/unit/compiler/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/compiler/CMakeLists.txt
@@ -37,28 +37,23 @@ if(HIP_PLATFORM MATCHES "amd")
         set(LIBFS -lstdc++fs)
     endif()
 
-    add_custom_target(hipSquareGenericTargetOnly ALL
-                    COMMAND ${CMAKE_CXX_COMPILER} -DNO_GENERIC_TARGET_ONLY_TEST --std=c++17 -mcode-object-version=6 -w "${OFFLOAD_ARCH_GENERIC_STR}"
-                    ${CMAKE_CURRENT_SOURCE_DIR}/hipSquareGenericTarget.cc
-                    ${CMAKE_CURRENT_SOURCE_DIR}/../../hipTestMain/hip_test_context.cc
-                    ${CMAKE_CURRENT_SOURCE_DIR}/../../hipTestMain/hip_test_features.cc
-                    ${CMAKE_CURRENT_SOURCE_DIR}/../../hipTestMain/main.cc
-                    -o ${CMAKE_CURRENT_BINARY_DIR}/${GENERIC_TARGET_ONLY_EXE}
-                    -I${HIP_PATH}/include/ --hip-path=${HIP_PATH}
-                    -I${CMAKE_CURRENT_SOURCE_DIR}/../../include
-                    -I${CMAKE_CURRENT_SOURCE_DIR}/../../external/Catch2
-                    -I${CMAKE_CURRENT_SOURCE_DIR}/../../external/picojson ${LIBFS})
-    add_custom_target(hipSquareGenericTargetOnlyCompressed ALL
-                    COMMAND ${CMAKE_CXX_COMPILER} -DNO_GENERIC_TARGET_ONLY_TEST -DGENERIC_COMPRESSED --std=c++17 -mcode-object-version=6 --offload-compress -w "${OFFLOAD_ARCH_GENERIC_STR}"
-                    ${CMAKE_CURRENT_SOURCE_DIR}/hipSquareGenericTarget.cc
-                    ${CMAKE_CURRENT_SOURCE_DIR}/../../hipTestMain/hip_test_context.cc
-                    ${CMAKE_CURRENT_SOURCE_DIR}/../../hipTestMain/hip_test_features.cc
-                    ${CMAKE_CURRENT_SOURCE_DIR}/../../hipTestMain/main.cc
-                    -o ${CMAKE_CURRENT_BINARY_DIR}/${GENERIC_TARGET_ONLY_COMPRESSED_EXE}
-                    -I${HIP_PATH}/include/ --hip-path=${HIP_PATH}
-                    -I${CMAKE_CURRENT_SOURCE_DIR}/../../include
-                    -I${CMAKE_CURRENT_SOURCE_DIR}/../../external/Catch2
-                    -I${CMAKE_CURRENT_SOURCE_DIR}/../../external/picojson ${LIBFS})
+    add_executable(${GENERIC_TARGET_ONLY_EXE}
+      hipSquareGenericTarget.cc
+      $<TARGET_OBJECTS:Main_Object>)
+    target_compile_options(${GENERIC_TARGET_ONLY_EXE} PUBLIC -w ${OFFLOAD_ARCH_GENERIC_STR})
+    target_compile_definitions(${GENERIC_TARGET_ONLY_EXE} PRIVATE NO_GENERIC_TARGET_ONLY_TEST)
+    if(NOT USE_PREBUILT_CATCH)
+      target_link_libraries(${GENERIC_TARGET_ONLY_EXE} Catch2::Catch2WithMain)
+    endif()
+
+    add_executable(${GENERIC_TARGET_ONLY_COMPRESSED_EXE}
+      hipSquareGenericTarget.cc
+      $<TARGET_OBJECTS:Main_Object>)
+    target_compile_definitions(${GENERIC_TARGET_ONLY_COMPRESSED_EXE} PRIVATE GENERIC_COMPRESSED NO_GENERIC_TARGET_ONLY_TEST)
+    target_compile_options(${GENERIC_TARGET_ONLY_COMPRESSED_EXE} PUBLIC --offload-compress -w ${OFFLOAD_ARCH_GENERIC_STR})
+    if(NOT USE_PREBUILT_CATCH)
+      target_link_libraries(${GENERIC_TARGET_ONLY_COMPRESSED_EXE} Catch2::Catch2WithMain)
+    endif()
     set_property(GLOBAL APPEND PROPERTY G_INSTALL_CUSTOM_TARGETS ${CMAKE_CURRENT_BINARY_DIR}/${GENERIC_TARGET_ONLY_EXE})
     set_property(GLOBAL APPEND PROPERTY G_INSTALL_CUSTOM_TARGETS ${CMAKE_CURRENT_BINARY_DIR}/${GENERIC_TARGET_ONLY_COMPRESSED_EXE})
   else()
@@ -92,7 +87,8 @@ if(HIP_PLATFORM MATCHES "amd")
                     ${CMAKE_CURRENT_SOURCE_DIR}/../../hipTestMain/hip_test_context.cc
                     ${CMAKE_CURRENT_SOURCE_DIR}/../../hipTestMain/main.cc
                     -I${CMAKE_CURRENT_SOURCE_DIR}/../../include
-                    -I${CMAKE_CURRENT_SOURCE_DIR}/../../external/Catch2
+                    -I${Catch2_SOURCE_DIR}/src
+                    -I${Catch2_BINARY_DIR}/generated-includes
                     -I${CMAKE_CURRENT_SOURCE_DIR}/../../external/picojson
                     -I${HIP_PATH}/include/ --hip-path=${HIP_PATH} --offload-arch=amdgcnspirv
                     -o ${CMAKE_CURRENT_BINARY_DIR}/../../unit/compiler/hipSpirvTest)

--- a/projects/hip-tests/catch/unit/compiler/hipSquareGenericTarget.cc
+++ b/projects/hip-tests/catch/unit/compiler/hipSquareGenericTarget.cc
@@ -107,9 +107,9 @@ TEST_CASE("Unit_test_generic_target_only_in_compressed_fatbin") {
 #else  // else GENERIC_COMPRESSED
 TEST_CASE("Unit_test_generic_target_only_in_regular_fatbin ") {
 #ifdef __linux__
-  char* cmd = "chmod  u+x ./hipSquareGenericTargetOnly && ./hipSquareGenericTargetOnly";
+  const char* cmd = "chmod  u+x ./hipSquareGenericTargetOnly && ./hipSquareGenericTargetOnly";
 #else
-  char* cmd = "hipSquareGenericTargetOnly.exe";
+  const char* cmd = "hipSquareGenericTargetOnly.exe";
 #endif
 #endif  // GENERIC_COMPRESSED
 

--- a/projects/hip-tests/catch/unit/complex/complex_basic_common.hh
+++ b/projects/hip-tests/catch/unit/complex/complex_basic_common.hh
@@ -69,6 +69,6 @@ __global__ void CastComplexTypeKernel(T1* const output_val, T2 const input_val) 
 
 template <typename T> void CompareValues(T actual_val, T ref_val, double margin) {
   if (!std::isnan(ref_val)) {
-    REQUIRE_THAT(actual_val, Catch::WithinAbs(ref_val, margin));
+    REQUIRE_THAT(actual_val, Catch::Matchers::WithinAbs(ref_val, margin));
   }
 }

--- a/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_group.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_group.cc
@@ -19,6 +19,8 @@ THE SOFTWARE.
 #include "cooperative_groups_common.hh"
 #include "cg_common_kernels.hh"
 
+#include <random>
+
 #include <cmd_options.hh>
 #include <cpu_grid.h>
 #include <resource_guards.hh>

--- a/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_group_tiled_partition.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_group_tiled_partition.cc
@@ -20,6 +20,7 @@ THE SOFTWARE.
 #include "cooperative_groups_common.hh"
 #include "cg_common_kernels.hh"
 
+#include <random>
 #include <bitset>
 #include <optional>
 #include <resource_guards.hh>

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block.cc
@@ -24,6 +24,7 @@ THE SOFTWARE.
 #include <optional>
 #include <resource_guards.hh>
 #include <utils.hh>
+#include <random>
 
 #include <cmd_options.hh>
 

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -20,8 +20,8 @@ THE SOFTWARE.
 #include "cooperative_groups_common.hh"
 #include "cg_common_kernels.hh"
 
-#include <bitset>
 #include <array>
+#include <random>
 
 #include <cmd_options.hh>
 #include <cpu_grid.h>

--- a/projects/hip-tests/catch/unit/device/hipIpcGetMemHandle.cc
+++ b/projects/hip-tests/catch/unit/device/hipIpcGetMemHandle.cc
@@ -65,34 +65,6 @@ TEST_CASE("Unit_hipIpcGetMemHandle_Positive_Unique_Handles_Separate_Allocations"
 /**
  * Test Description
  * ------------------------
- *  - Check that unique handles are returned for the same address,
- *    but separate allocations.
- * Test source
- * ------------------------
- *  - unit/device/hipIpcGetMemHandle.cc
- * Test requirements
- * ------------------------
- *  - Host specific (LINUX)
- *  - HIP_VERSION >= 5.2
- */
-TEST_CASE("Unit_hipIpcGetMemHandle_Positive_Unique_Handles_Reused_Memory") {
-  void *ptr1 = nullptr, *ptr2 = nullptr;
-  hipIpcMemHandle_t handle1, handle2;
-  HIP_CHECK(hipMalloc(&ptr1, 1024));
-  HIP_CHECK(hipIpcGetMemHandle(&handle1, ptr1));
-  HIP_CHECK(hipFree(ptr1));
-
-  HIP_CHECK(hipMalloc(&ptr2, 1024));
-  HIP_CHECK(hipIpcGetMemHandle(&handle2, ptr2));
-
-  if (ptr1 == ptr2) CHECK(memcmp(&handle1, &handle2, sizeof(handle1)) != 0);
-
-  HIP_CHECK(hipFree(ptr2));
-}
-
-/**
- * Test Description
- * ------------------------
  *  - Test if previously freed memory will generate an invalid handle:
  *    -# When memory is freed before getting handle
  *      - Expected output: return `hipErrorInvalidValue

--- a/projects/hip-tests/catch/unit/deviceLib/AtomicsWithRandomActiveLanesInWavefront.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/AtomicsWithRandomActiveLanesInWavefront.cc
@@ -38,7 +38,7 @@ THE SOFTWARE.
 
 using namespace std;
 #if !defined(USE_PREBUILT_CATCH)
-  using namespace Catch;
+using namespace Catch;
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/projects/hip-tests/catch/unit/deviceLib/AtomicsWithRandomActiveLanesInWavefront.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/AtomicsWithRandomActiveLanesInWavefront.cc
@@ -37,6 +37,9 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 
 using namespace std;
+#if !defined(USE_PREBUILT_CATCH)
+  using namespace Catch;
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // Auto-Verification Code

--- a/projects/hip-tests/catch/unit/deviceLib/fp16_ops.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp16_ops.cc
@@ -28,7 +28,7 @@ THE SOFTWARE.
 #include <limits>
 
 #if !defined(USE_PREBUILT_CATCH)
-  using namespace Catch;
+using namespace Catch;
 #endif
 
 __global__ void fp16_arith_gpu(float* a, float* b, float* c) {

--- a/projects/hip-tests/catch/unit/deviceLib/fp16_ops.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp16_ops.cc
@@ -27,6 +27,10 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <limits>
 
+#if !defined(USE_PREBUILT_CATCH)
+  using namespace Catch;
+#endif
+
 __global__ void fp16_arith_gpu(float* a, float* b, float* c) {
   c[0] = __half2float(__hadd(__float2half_rn(a[0]), __float2half_rn(b[0])));
   c[1] = __half2float(__hsub(__float2half_rn(a[1]), __float2half_rn(b[1])));
@@ -73,7 +77,11 @@ void fp16_arith_cpu(const std::vector<float>& a, const std::vector<float>& b,
 TEST_CASE("Unit_fp16_arith") {
   constexpr size_t num_of_ops = 18;
   constexpr size_t iters = 100;
+#if defined(USE_PREBUILT_CATCH)
   Catch::Generators::RandomFloatingGenerator<float> input1_gen(2.2f, 10.f);
+#else
+  Catch::Generators::RandomFloatingGenerator<float> input1_gen(2.2f, 10.f, /*seed*/ 0x1234);
+#endif
   constexpr float input2 = 1.1f;
   for (size_t iter = 0; iter < iters; iter++) {
     auto input1 = input1_gen.get();
@@ -153,7 +161,11 @@ void fp162_arith_cpu(std::vector<float2>& a, std::vector<float2>& b, std::vector
 TEST_CASE("Unit_fp162_arith") {
   constexpr size_t num_of_ops = 18;
   constexpr size_t iters = 100;
+#if defined(USE_PREBUILT_CATCH)
   Catch::Generators::RandomFloatingGenerator<float> input1_gen(2.2f, 10.f);
+#else
+  Catch::Generators::RandomFloatingGenerator<float> input1_gen(2.2f, 10.f, /* seed */ 0x1234);
+#endif
   for (size_t iter = 0; iter < iters; iter++) {
     auto input1 = input1_gen.get();
     auto input2 = input1_gen.get();

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_fnuz.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_fnuz.cc
@@ -30,6 +30,10 @@ THE SOFTWARE.
 #define __gfx94plus_local__
 #endif
 
+#if !defined(USE_PREBUILT_CATCH)
+using namespace Catch;
+#endif
+
 /*
  * This catch test is meant for FP8 FNUZ conversion checking
  * tests only supported on gfx942 archs.

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_host.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_host.cc
@@ -27,6 +27,11 @@ THE SOFTWARE.
 #include <vector>
 #include <bitset>
 
+#if !defined(USE_PREBUILT_CATCH)
+  using namespace Catch;
+#endif
+
+
 /*
  * Tests for fp8 conversions on host
  * Both FNUZ and OCP types are supported on host

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_host.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_host.cc
@@ -28,7 +28,7 @@ THE SOFTWARE.
 #include <bitset>
 
 #if !defined(USE_PREBUILT_CATCH)
-  using namespace Catch;
+using namespace Catch;
 #endif
 
 

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_ocp.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_ocp.cc
@@ -28,7 +28,7 @@ THE SOFTWARE.
 #include <bitset>
 
 #if !defined(USE_PREBUILT_CATCH)
-  using namespace Catch;
+using namespace Catch;
 #endif
 
 

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_ocp.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_ocp.cc
@@ -27,6 +27,11 @@ THE SOFTWARE.
 #include <vector>
 #include <bitset>
 
+#if !defined(USE_PREBUILT_CATCH)
+  using namespace Catch;
+#endif
+
+
 /*
  * This catch test is meant for FP8 OCP conversions
  * tests only supported on gfx1200 and gfx1201 archs

--- a/projects/hip-tests/catch/unit/deviceLib/hipVectorTypesHost.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/hipVectorTypesHost.cc
@@ -92,41 +92,41 @@ template <typename V> bool TestVectorType() {
   V f1 = MakeVector<V>(1);
   V f2 = MakeVector<V>(1);
   V f3 = f1 + f2;
-  REQUIRE(f3 == v2);
+  REQUIRE((f3 == v2));
   f2 = f3 - f1;
-  REQUIRE(f2 == v1);
+  REQUIRE((f2 == v1));
   f1 = f2 * f3;
-  REQUIRE(f1 == v2);
+  REQUIRE((f1 == v2));
   f2 = f1 / f3;
-  REQUIRE(f2 == v1);
+  REQUIRE((f2 == v1));
   integer_binary_tests(f1, f2, f3);
 
   f1 = MakeVector<V>(2);
   f2 = MakeVector<V>(1);
   f1 += f2;
-  REQUIRE(f1 == v3);
+  REQUIRE((f1 == v3));
   f1 -= f2;
-  REQUIRE(f1 == v2);
+  REQUIRE((f1 == v2));
   f1 *= f2;
-  REQUIRE(f1 == v2);
+  REQUIRE((f1 == v2));
   f1 /= f2;
-  REQUIRE(f1 == v2);
+  REQUIRE((f1 == v2));
 
   integer_unary_tests(f1, f2);
 
   f1 = v2;
   f2 = f1++;
-  REQUIRE(f1 == v3);
-  REQUIRE(f2 == v2);
+  REQUIRE((f1 == v3));
+  REQUIRE((f2 == v2));
   f2 = f1--;
-  REQUIRE(f2 == v3);
-  REQUIRE(f1 == v2);
+  REQUIRE((f2 == v3));
+  REQUIRE((f1 == v2));
   f2 = ++f1;
-  REQUIRE(f1 == v3);
-  REQUIRE(f2 == v3);
+  REQUIRE((f1 == v3));
+  REQUIRE((f2 == v3));
   f2 = --f1;
-  REQUIRE(f1 == v2);
-  REQUIRE(f2 == v2);
+  REQUIRE((f1 == v2));
+  REQUIRE((f2 == v2));
 
   REQUIRE(constructor_tests<V>() == true);
 
@@ -134,7 +134,7 @@ template <typename V> bool TestVectorType() {
   f2 = v4;
   f3 = v3;
   REQUIRE(!(f1 == f2));
-  REQUIRE(f1 != f2);
+  REQUIRE((f1 != f2));
 
   using T = typename V::value_type;
 

--- a/projects/hip-tests/catch/unit/dynamicLoading/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/dynamicLoading/CMakeLists.txt
@@ -32,9 +32,9 @@ hip_add_exe_to_target(NAME dynamicLoading
                       TEST_TARGET_NAME build_tests)
 
 if(HIP_PLATFORM MATCHES "amd")
-add_custom_target(libLazyLoad.so COMMAND ${CMAKE_CXX_COMPILER} -fPIC -lpthread -shared ${OFFLOAD_ARCH_STR} ${CMAKE_CURRENT_SOURCE_DIR}/liblazyLoad.cc -I${CMAKE_CURRENT_SOURCE_DIR}/../../include -I${CMAKE_CURRENT_SOURCE_DIR}/../../external/Catch2 -L${HIP_PATH}/${CMAKE_INSTALL_LIBDIR} --hip-path=${HIP_PATH} -o libLazyLoad.so)
+add_custom_target(libLazyLoad.so COMMAND ${CMAKE_CXX_COMPILER} -fPIC -lpthread -shared ${OFFLOAD_ARCH_STR} ${CMAKE_CURRENT_SOURCE_DIR}/liblazyLoad.cc -I${CMAKE_CURRENT_SOURCE_DIR}/../../include -I${Catch2_SOURCE_DIR}/src -I${Catch2_BINARY_DIR}/generated-includes -L${HIP_PATH}/${CMAKE_INSTALL_LIBDIR} --hip-path=${HIP_PATH} -o libLazyLoad.so)
 elseif(HIP_PLATFORM MATCHES "nvidia")
-add_custom_target(libLazyLoad.so COMMAND ${CMAKE_CXX_COMPILER} -Xcompiler -fPIC -lpthread -shared ${CMAKE_CURRENT_SOURCE_DIR}/liblazyLoad.cc -I${CMAKE_CURRENT_SOURCE_DIR}/../../include -I${CMAKE_CURRENT_SOURCE_DIR}/../../external/Catch2 -I${HIP_PATH}/include/ -o libLazyLoad.so)
+add_custom_target(libLazyLoad.so COMMAND ${CMAKE_CXX_COMPILER} -Xcompiler -fPIC -lpthread -shared ${CMAKE_CURRENT_SOURCE_DIR}/liblazyLoad.cc -I${CMAKE_CURRENT_SOURCE_DIR}/../../include -I${Catch2_SOURCE_DIR}/src -I${Catch2_BINARY_DIR}/generated-includes -I${HIP_PATH}/include/ -o libLazyLoad.so)
 endif()
 
 add_custom_target(bit_extract_kernel.code COMMAND ${CMAKE_CXX_COMPILER} --genco ${OFFLOAD_ARCH_STR} ${CMAKE_CURRENT_SOURCE_DIR}/bit_extract_kernel.cpp -o ${CMAKE_CURRENT_BINARY_DIR}/../dynamicLoading/bit_extract_kernel.code -I${HIP_PATH}/include/ -I${CMAKE_CURRENT_SOURCE_DIR}/../../include --hip-path=${HIP_PATH} -L${HIP_PATH}/${CMAKE_INSTALL_LIBDIR})

--- a/projects/hip-tests/catch/unit/dynamicLoading/liblazyLoad.cc
+++ b/projects/hip-tests/catch/unit/dynamicLoading/liblazyLoad.cc
@@ -139,7 +139,7 @@ static int cooperativeKernelTest() {
   int64_t* Ah;
 
   hipDeviceProp_t deviceProp;
-  hipGetDeviceProperties(&deviceProp, 0);
+  CHECK_RET_VAL(hipGetDeviceProperties(&deviceProp, 0));
 
   if (!deviceProp.cooperativeLaunch) {
     return testResult;
@@ -170,8 +170,8 @@ static int cooperativeKernelTest() {
     dimBlock.x = workgroups[i];
     /* Calculate the device occupancy to know how many blocks can be
        run concurrently */
-    hipOccupancyMaxActiveBlocksPerMultiprocessor(
-        &numBlocks, test_gws, dimBlock.x * dimBlock.y * dimBlock.z, dimBlock.x * sizeof(int64_t));
+    CHECK_RET_VAL(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+        &numBlocks, test_gws, dimBlock.x * dimBlock.y * dimBlock.z, dimBlock.x * sizeof(int64_t)));
     dimGrid.x = deviceProp.multiProcessorCount * std::min(numBlocks, 32);
     CHECK_RET_VAL(hipMalloc(reinterpret_cast<void**>(&dB), dimGrid.x * sizeof(int64_t)));
 

--- a/projects/hip-tests/catch/unit/errorHandling/hipGetErrorName.cc
+++ b/projects/hip-tests/catch/unit/errorHandling/hipGetErrorName.cc
@@ -74,9 +74,9 @@ TEST_CASE("Unit_hipGetErrorName_Negative_Parameters") {
   const char* error_string = hipGetErrorName(static_cast<hipError_t>(-1));
   REQUIRE(error_string != nullptr);
 #if HT_NVIDIA
-  REQUIRE_THAT(error_string, Catch::Equals("cudaErrorUnknown"));
+  REQUIRE_THAT(error_string, Catch::Matchers::Equals("cudaErrorUnknown"));
 #elif HT_AMD
-  REQUIRE_THAT(error_string, Catch::Equals("hipErrorUnknown"));
+  REQUIRE_THAT(error_string, Catch::Matchers::Equals("hipErrorUnknown"));
 #endif
 }
 

--- a/projects/hip-tests/catch/unit/graph/graph_memcpy_to_from_symbol_common.hh
+++ b/projects/hip-tests/catch/unit/graph/graph_memcpy_to_from_symbol_common.hh
@@ -61,7 +61,7 @@ void MemcpyFromSymbolShell(F f, const void* symbol, size_t offset, const std::ve
 
   std::vector<T> symbol_values(expected.size());
   HIP_CHECK(hipMemcpy(symbol_values.data(), dst_alloc.ptr(), size, hipMemcpyDefault));
-  REQUIRE_THAT(expected, Catch::Equals(symbol_values));
+  REQUIRE_THAT(expected, Catch::Matchers::Equals(symbol_values));
 }
 
 template <typename T, typename F>
@@ -82,7 +82,7 @@ void MemcpyToSymbolShell(F f, const void* symbol, size_t offset, const std::vect
 
   std::vector<T> symbol_values(set_values.size());
   HIP_CHECK(hipMemcpyFromSymbol(symbol_values.data(), symbol, size, offset * sizeof(T)));
-  REQUIRE_THAT(set_values, Catch::Equals(symbol_values));
+  REQUIRE_THAT(set_values, Catch::Matchers::Equals(symbol_values));
 }
 
 template <typename F>

--- a/projects/hip-tests/catch/unit/graph/hipGetProcAddressGraphApis.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGetProcAddressGraphApis.cc
@@ -634,7 +634,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_KernelNodeSetGetParams") {
   // Validating hipGraphKernelNodeGetParams API
   HIP_CHECK(dyn_hipGraphKernelNodeGetParams_ptr(kernelNode, &receivedKernelNodeParams));
 
-  REQUIRE(receivedKernelNodeParams.func == addOneKernel);
+  REQUIRE((receivedKernelNodeParams.func == addOneKernel));
   REQUIRE(receivedKernelNodeParams.gridDim.x == 1);
   REQUIRE(receivedKernelNodeParams.gridDim.y == 1);
   REQUIRE(receivedKernelNodeParams.gridDim.z == 1);
@@ -661,7 +661,7 @@ TEST_CASE("Unit_hipGetProcAddress_GraphAPIs_KernelNodeSetGetParams") {
 
   HIP_CHECK(dyn_hipGraphKernelNodeGetParams_ptr(kernelNode, &receivedKernelNodeParams));
 
-  REQUIRE(receivedKernelNodeParams.func == addTwoKernel);
+  REQUIRE((receivedKernelNodeParams.func == addTwoKernel));
   REQUIRE(receivedKernelNodeParams.gridDim.x == 2);
   REQUIRE(receivedKernelNodeParams.gridDim.y == 1);
   REQUIRE(receivedKernelNodeParams.gridDim.z == 1);

--- a/projects/hip-tests/catch/unit/graph/hipGraphDebugDotPrint.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphDebugDotPrint.cc
@@ -29,13 +29,14 @@ THE SOFTWARE.
 #include <hip_test_checkers.hh>
 #include <hip_test_kernels.hh>
 
+#include <numeric>
+
 #define N 1024
 
 #ifdef __linux__
 #include <unistd.h>
 #include <fstream>
 #include <iterator>
-#include <algorithm>
 #include <string>
 
 __device__ int globalIn[N];

--- a/projects/hip-tests/catch/unit/math/unary_common.hh
+++ b/projects/hip-tests/catch/unit/math/unary_common.hh
@@ -26,6 +26,8 @@ THE SOFTWARE.
 
 #include <hip/hip_cooperative_groups.h>
 
+#include <random>
+
 namespace cg = cooperative_groups;
 
 #define MATH_UNARY_KERNEL_DEF(func_name)                                                           \

--- a/projects/hip-tests/catch/unit/math/validators.hh
+++ b/projects/hip-tests/catch/unit/math/validators.hh
@@ -22,12 +22,13 @@ THE SOFTWARE.
 
 #pragma once
 
-#include <catch.hpp>
+#include <catch2/catch_all.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 // Define a new MatcherBase class with a public 'describe' member function because
 // Catch::MatcherBase::describe is protected and thus can't be used via a pointer to
 // Catch::MatcherBase.
-template <typename T> class MatcherBase : public Catch::MatcherBase<T> {
+template <typename T> class MatcherBase : public Catch::Matchers::MatcherBase<T> {
  public:
   virtual std::string describe() const = 0;
   virtual ~MatcherBase() = default;
@@ -62,22 +63,22 @@ template <typename T, typename Matcher> class ValidatorBase : public MatcherBase
 
 template <typename T> auto ULPValidatorBuilderFactory(int64_t ulps) {
   return [=](T target, auto&&...) {
-    return std::make_unique<ValidatorBase<T, Catch::Matchers::Floating::WithinUlpsMatcher>>(
-        target, Catch::WithinULP(target, ulps));
+    return std::make_unique<ValidatorBase<T, Catch::Matchers::WithinUlpsMatcher>>(
+        target, Catch::Matchers::WithinULP(target, ulps));
   };
 };
 
 template <typename T> auto AbsValidatorBuilderFactory(double margin) {
   return [=](T target, auto&&...) {
-    return std::make_unique<ValidatorBase<T, Catch::Matchers::Floating::WithinAbsMatcher>>(
-        target, Catch::WithinAbs(target, margin));
+    return std::make_unique<ValidatorBase<T, Catch::Matchers::WithinAbsMatcher>>(
+        target, Catch::Matchers::WithinAbs(target, margin));
   };
 }
 
 template <typename T> auto RelValidatorBuilderFactory(T margin) {
   return [=](T target, auto&&...) {
-    return std::make_unique<ValidatorBase<T, Catch::Matchers::Floating::WithinRelMatcher>>(
-        target, Catch::WithinRel(target, margin));
+    return std::make_unique<ValidatorBase<T, Catch::Matchers::WithinRelMatcher>>(
+        target, Catch::Matchers::WithinRel(target, margin));
   };
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipArrayCreate.cc
+++ b/projects/hip-tests/catch/unit/memory/hipArrayCreate.cc
@@ -370,7 +370,7 @@ TEST_CASE("Unit_hipArrayCreate_BadNumberChannelElement") {
   hipArray_t array;
 
   INFO("Format: " << formatToString(desc.Format) << " NumChannels: " << desc.NumChannels
-                  << " Height: " << desc.Height)
+                  << " Height: " << desc.Height);
   HIP_CHECK_ERROR(hipArrayCreate(&array, &desc), hipErrorInvalidValue);
 }
 
@@ -400,6 +400,6 @@ TEST_CASE("Unit_hipArrayCreate_BadChannelFormat") {
 
   hipArray_t array;
 
-  INFO("Format: " << formatToString(desc.Format) << " Height: " << desc.Height)
+  INFO("Format: " << formatToString(desc.Format) << " Height: " << desc.Height);
   HIP_CHECK_ERROR(hipArrayCreate(&array, &desc), hipErrorInvalidValue);
 }

--- a/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
+++ b/projects/hip-tests/catch/unit/memory/hipGetProcAddressMemoryApis.cc
@@ -679,6 +679,7 @@ TEST_CASE("Unit_hipGetProcAddress_MemoryApisArrayRelated") {
   desc3d.Width = 8;
   desc3d.Height = 4;
   desc3d.Depth = 2;
+  desc3d.Flags = 0;
 
   HIP_CHECK(hipArray3DCreate(&array3d, &desc3d));
   HIP_CHECK(dyn_hipArray3DCreate_ptr(&array3d_ptr, &desc3d));
@@ -715,6 +716,7 @@ TEST_CASE("Unit_hipGetProcAddress_MemoryApisArrayRelated") {
   gd_desc3d.Width = 16;
   gd_desc3d.Height = 4;
   gd_desc3d.Depth = 8;
+  gd_desc3d.Flags = 0;
 
   HIP_CHECK(hipArray3DCreate(&gd_array3d, &gd_desc3d));
   HIP_CHECK(hipArray3DCreate(&gd_array3d_ptr, &gd_desc3d));

--- a/projects/hip-tests/catch/unit/memory/hipMallocPitch.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocPitch.cc
@@ -27,6 +27,7 @@ THE SOFTWARE.
 #include <cstring>
 #include <vector>
 #include <limits>
+#include <random>
 #include <hip_test_checkers.hh>
 #include <hip_test_kernels.hh>
 #ifdef __HIP_PLATFORM_NVIDIA__

--- a/projects/hip-tests/catch/unit/memory/hipMemsetFunctional.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetFunctional.cc
@@ -97,37 +97,37 @@ void checkMemset(T value, size_t count, MemsetType memsetType, bool async = fals
   switch (memsetType) {
     case hipMemsetTypeDefault:
       if (!async) {
-        INFO("Testing hipMemset call")
+        INFO("Testing hipMemset call");
         HIP_MEMSET_CHECK(hipMemset, devPtr, value, count, false);
       } else {
-        INFO("Testing hipMemsetAsync call")
+        INFO("Testing hipMemsetAsync call");
         HIP_MEMSET_CHECK(hipMemsetAsync, devPtr, value, count, true);
       }
       break;
     case hipMemsetTypeD8:
       if (!async) {
-        INFO("Testing hipMemsetD8 call")
+        INFO("Testing hipMemsetD8 call");
         HIP_MEMSET_CHECK_DTYPE(hipMemsetD8, devPtr, value, count, false);
       } else {
-        INFO("Testing hipMemsetD8Async call")
+        INFO("Testing hipMemsetD8Async call");
         HIP_MEMSET_CHECK_DTYPE(hipMemsetD8Async, devPtr, value, count, true);
       }
       break;
     case hipMemsetTypeD16:
       if (!async) {
-        INFO("Testing hipMemsetD16 call")
+        INFO("Testing hipMemsetD16 call");
         HIP_MEMSET_CHECK_DTYPE(hipMemsetD16, devPtr, value, count, false);
       } else {
-        INFO("Testing hipMemsetD16Async call")
+        INFO("Testing hipMemsetD16Async call");
         HIP_MEMSET_CHECK_DTYPE(hipMemsetD16Async, devPtr, value, count, true);
       }
       break;
     case hipMemsetTypeD32:
       if (!async) {
-        INFO("Testing hipMemsetD32 call")
+        INFO("Testing hipMemsetD32 call");
         HIP_MEMSET_CHECK_DTYPE(hipMemsetD32, devPtr, value, count, false);
       } else {
-        INFO("Testing hipMemsetD32Async call")
+        INFO("Testing hipMemsetD32Async call");
         HIP_MEMSET_CHECK_DTYPE(hipMemsetD32Async, devPtr, value, count, true);
       }
       break;
@@ -262,10 +262,10 @@ template <typename T> void checkMemset2D(T value, size_t width, size_t height, b
   }
 
   if (!async) {
-    INFO("Testing hipMemset2D call")
+    INFO("Testing hipMemset2D call");
     HIP_CHECK(hipMemset2D(devPtr, pitch, value, width * elementSize, height));
   } else {
-    INFO("Testing hipMemset2DAsync call")
+    INFO("Testing hipMemset2DAsync call");
     HIP_CHECK(hipMemset2DAsync(devPtr, pitch, value, width * elementSize, height, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
   }
@@ -355,7 +355,7 @@ template <typename T> void partialMemsetTest2D(T valA, T valB, size_t width, siz
   checkMemset2D(valA, width, height, async, pitch, devPtr);
 
   // Set partial region to be second value.
-  INFO("Setting partial square region")
+  INFO("Setting partial square region");
   checkMemset2D(valB, subWidth, subHeight, async, pitch, devPtr);
 
   auto hostPtr = get_device_data_2D<T>(devPtr, pitch, width, height);
@@ -424,7 +424,7 @@ void check_device_data_3D(hipPitchedPtr& devPitchedPtr, T value, hipExtent exten
     for (size_t j = 0; j < height; j++) {
       for (size_t i = 0; i < width; i++) {
         idx = devPitchedPtr.pitch * height * k + devPitchedPtr.pitch * j + i;
-        INFO("idx=" << idx << " hostPtr[idx]=" << hostPtr[idx] << " value=" << value)
+        INFO("idx=" << idx << " hostPtr[idx]=" << hostPtr[idx] << " value=" << value);
         HIP_ASSERT(hostPtr[idx] == value);
       }
     }
@@ -441,10 +441,10 @@ void checkMemset3D(hipPitchedPtr& devPitchedPtr, T value, hipExtent extent, bool
     HIP_CHECK(hipMalloc3D(&devPitchedPtr, extent));
   }
   if (!async) {
-    INFO("Testing hipMemset3D call")
+    INFO("Testing hipMemset3D call");
     HIP_CHECK(hipMemset3D(devPitchedPtr, value, extent));
   } else {
-    INFO("Testing hipMemset3DAsync call")
+    INFO("Testing hipMemset3DAsync call");
     HIP_CHECK(hipMemset3DAsync(devPitchedPtr, value, extent, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
   }
@@ -531,9 +531,13 @@ void partialMemsetTest3D(T valA, T valB, size_t width, size_t height, size_t dep
   hipExtent subExtent = make_hipExtent(subWidth * sizeof(T), subHeight, subDepth);
 
   // Set entire region to be first value.
-  INFO("Setting full cuboid region") { checkMemset3D(devPitchedPtr, valA, extent, async); }
+  INFO("Setting full cuboid region");
+  checkMemset3D(devPitchedPtr, valA, extent, async);
+
   // Set partial region to be second value.
-  INFO("Setting partial cuboid region") { checkMemset3D(devPitchedPtr, valB, subExtent, async); }
+  INFO("Setting partial cuboid region");
+  checkMemset3D(devPitchedPtr, valB, subExtent, async);
+
   auto pitch = devPitchedPtr.pitch;
   auto hostPtr = get_device_data_3D<T>(devPitchedPtr, extent);
   T comparVal{0};

--- a/projects/hip-tests/catch/unit/module/hipExtLaunchMultiKernelMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/module/hipExtLaunchMultiKernelMultiDevice.cc
@@ -113,7 +113,7 @@ TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Functional") {
     launchParamsList[i].args = args + i * NUM_KERNEL_ARGS;
   }
 
-  INFO("info: launch vector_square kernel with")
+  INFO("info: launch vector_square kernel with");
   INFO("hipExtLaunchMultiKernelMultiDevice API\n");
   HIP_CHECK(hipExtLaunchMultiKernelMultiDevice(launchParamsList, nGpu, 0));
 

--- a/projects/hip-tests/catch/unit/rtc/hiprtcComplrOptnTesting.cc
+++ b/projects/hip-tests/catch/unit/rtc/hiprtcComplrOptnTesting.cc
@@ -37,177 +37,177 @@ HIPRTC supported compiler option idividually.
 // SINGLE COMPILER OPTION TESTING
 const char** null = {};
 TEST_CASE("Unit_hiprtcGpuArchComplrOptnTst") {
-  INFO("Testing '--gpu-architecture=gfx906:sramecc+:xnack-' compiler opt")
+  INFO("Testing '--gpu-architecture=gfx906:sramecc+:xnack-' compiler opt");
   REQUIRE(check_architecture(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcGpuRdcComplrOptnTst") {
-  INFO("Testing '-fgpu-rdc' compiler option")
+  INFO("Testing '-fgpu-rdc' compiler option");
   REQUIRE(check_rdc(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcEnabledDenormalsComplrOptnTst") {
-  INFO("Testing '-fgpu-flush-denormals-to-zero' compiler option")
+  INFO("Testing '-fgpu-flush-denormals-to-zero' compiler option");
   REQUIRE(check_denormals_enabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcDisabledDenormalsComplrOptnTst") {
-  INFO("Testing '-fno-gpu-flush-denormals-to-zero' compiler option")
+  INFO("Testing '-fno-gpu-flush-denormals-to-zero' compiler option");
   REQUIRE(check_denormals_disabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcOff_ffpContractComplrOptnTst") {
-  INFO("Testing '-ffp-contract=off' compiler option")
+  INFO("Testing '-ffp-contract=off' compiler option");
   REQUIRE(check_ffp_contract_off(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcOnffpContractComplrOptnTst") {
-  INFO("Testing '-ffp-contract=on' compiler option")
+  INFO("Testing '-ffp-contract=on' compiler option");
   REQUIRE(check_ffp_contract_on(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcFastffpContractComplrOptnTst") {
-  INFO("Testing '-ffp-contract=fast' compiler option")
+  INFO("Testing '-ffp-contract=fast' compiler option");
   REQUIRE(check_ffp_contract_fast(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcEnabledFastMathComplrOptnTst") {
-  INFO("Testing '-ffast-math' compiler option")
+  INFO("Testing '-ffast-math' compiler option");
   REQUIRE(check_fast_math_enabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcDisabledFastMathComplrOptnTst") {
-  INFO("Testing '-fno-fast-math' compiler option")
+  INFO("Testing '-fno-fast-math' compiler option");
   REQUIRE(check_fast_math_disabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcEnabledSlpVectorizeComplrOptnTst") {
-  INFO("Testing '-fslp-vectorize' compiler option")
+  INFO("Testing '-fslp-vectorize' compiler option");
   REQUIRE(check_slp_vectorize_enabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcDisabledSlpVectorizeComplrOptnTst") {
-  INFO("Testing '-fno-slp-vectorize' compiler option")
+  INFO("Testing '-fno-slp-vectorize' compiler option");
   REQUIRE(check_slp_vectorize_disabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcDefineMacroComplrOptnTst") {
-  INFO("Testing '-D' compiler option")
+  INFO("Testing '-D' compiler option");
   REQUIRE(check_macro(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcUndefMacroComplrOptnTst") {
-  INFO("Testing '-U' compiler option")
+  INFO("Testing '-U' compiler option");
   REQUIRE(check_undef_macro(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcHeaderDirectoryComplrOptnTst") {
-  INFO("Testing '-I' compiler option")
+  INFO("Testing '-I' compiler option");
   REQUIRE(check_header_dir(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcWarningComplrOptnTst") {
-  INFO("Testing '-w' compiler option")
+  INFO("Testing '-w' compiler option");
   REQUIRE(check_warning(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcRpassInlineComplrOptnTst") {
-  INFO("Testing '-Rpass=inline' compiler option")
+  INFO("Testing '-Rpass=inline' compiler option");
   REQUIRE(check_Rpass_inline(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcEnabledConversionErrComplrOptnTst") {
-  INFO("Testing '-Werror=conversion' compiler option")
+  INFO("Testing '-Werror=conversion' compiler option");
   REQUIRE(check_conversionerror_enabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcDisabledConversionErrComplrOptnTst") {
-  INFO("Testing '-Wno-error=conversion' compiler option")
+  INFO("Testing '-Wno-error=conversion' compiler option");
   REQUIRE(check_conversionerror_disabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcEnabledConversionWarningComplrOptnTst") {
-  INFO("Testing '-Wconversion' compiler option")
+  INFO("Testing '-Wconversion' compiler option");
   REQUIRE(check_conversionwarning_enabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcDisabledConversionWarningComplrOptnTst") {
-  INFO("Testing '-Wno-conversion' compiler option")
+  INFO("Testing '-Wno-conversion' compiler option");
   REQUIRE(check_conversionwarning_disabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcGpuMaxThreadPerBlockComplrOptnTst") {
-  INFO("Testing '--gpu-max-threads-per-block=n' compiler option")
+  INFO("Testing '--gpu-max-threads-per-block=n' compiler option");
   REQUIRE(check_max_thread(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcEnabledUnsafeAtomicComplrOptnTst") {
-  INFO("Testing '-munsafe-fp-atomics' compiler option")
+  INFO("Testing '-munsafe-fp-atomics' compiler option");
   REQUIRE(check_unsafe_atomic_enabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcDisabledUnsafeAtomicComplrOptnTst") {
-  INFO("Testing '-mno-unsafe-fp-atomics' compiler option")
+  INFO("Testing '-mno-unsafe-fp-atomics' compiler option");
   REQUIRE(check_unsafe_atomic_disabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcEnabledInfiniteNumComplrOptnTst") {
-  INFO("Testing '-fhonor-infinities' compiler option")
+  INFO("Testing '-fhonor-infinities' compiler option");
   REQUIRE(check_infinite_num_enabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcDisabledInfiniteNumComplrOptnTst") {
-  INFO("Testing '-fno-honor-infinities' compiler option")
+  INFO("Testing '-fno-honor-infinities' compiler option");
   REQUIRE(check_infinite_num_disabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcEnabledNANComplrOptnTst") {
-  INFO("Testing '-fhonor-nans' compiler option")
+  INFO("Testing '-fhonor-nans' compiler option");
   REQUIRE(check_NAN_num_enabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcDisabledNANComplrOptnTst") {
-  INFO("Testing '-fno-honor-nans' compiler option")
+  INFO("Testing '-fno-honor-nans' compiler option");
   REQUIRE(check_NAN_num_disabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcEnabledFiniteMathComplrOptnTst") {
-  INFO("Testing '-ffinite-math-only' compiler option")
+  INFO("Testing '-ffinite-math-only' compiler option");
   REQUIRE(check_finite_math_enabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcDisabledFiniteMathComplrOptnTst") {
-  INFO("Testing '-fno-finite-math-only' compiler option")
+  INFO("Testing '-fno-finite-math-only' compiler option");
   REQUIRE(check_finite_math_disabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcEnabledAssociativeMathComplrOptnTst") {
-  INFO("Testing '-fassociative-math' compiler option")
+  INFO("Testing '-fassociative-math' compiler option");
   REQUIRE(check_associative_math_enabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcDisabledAssociativeMathComplrOptnTst") {
-  INFO("Testing '-fno-associative-math' compiler option")
+  INFO("Testing '-fno-associative-math' compiler option");
   REQUIRE(check_associative_math_disabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcEnabledSignedZerosComplrOptnTst") {
-  INFO("Testing '-fsigned-zeros' compiler option")
+  INFO("Testing '-fsigned-zeros' compiler option");
   REQUIRE(check_signed_zeros_enabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcDisabledSignedZerosComplrOptnTst") {
-  INFO("Testing '-fno-signed-zeros' compiler option")
+  INFO("Testing '-fno-signed-zeros' compiler option");
   REQUIRE(check_signed_zeros_disabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcEnabledTrappingMathComplrOptnTst") {
-  INFO("Testing '-ftrapping-math' compiler option")
+  INFO("Testing '-ftrapping-math' compiler option");
   REQUIRE(check_trapping_math_enabled(null, -1, -1, -1));
 }
 
 TEST_CASE("Unit_hiprtcDisabledTrappingMathComplrOptnTst") {
-  INFO("Testing '-fno-trapping-math' compiler option")
+  INFO("Testing '-fno-trapping-math' compiler option");
   REQUIRE(check_trapping_math_disabled(null, -1, -1, -1));
 }
 

--- a/projects/hip-tests/catch/unit/rtc/rtc_reduce.cc
+++ b/projects/hip-tests/catch/unit/rtc/rtc_reduce.cc
@@ -24,7 +24,6 @@ THE SOFTWARE.
 #include <tuple>
 #include <cmd_options.hh>
 #include <functional>
-#include <algorithm>
 
 #define NELEMS(array) (sizeof(array) / sizeof(array[0]))
 

--- a/projects/hip-tests/catch/unit/stream/hipMultiStream.cc
+++ b/projects/hip-tests/catch/unit/stream/hipMultiStream.cc
@@ -19,6 +19,12 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <iostream>
 #include <vector>
+
+#if !defined(USE_PREBUILT_CATCH)
+  using namespace Catch;
+#endif
+
+
 constexpr int NN = 1 << 21;
 __global__ void kernel_do_nothing(__attribute__((unused)) int a) {
   // empty kernel

--- a/projects/hip-tests/catch/unit/stream/hipMultiStream.cc
+++ b/projects/hip-tests/catch/unit/stream/hipMultiStream.cc
@@ -21,7 +21,7 @@ THE SOFTWARE.
 #include <vector>
 
 #if !defined(USE_PREBUILT_CATCH)
-  using namespace Catch;
+using namespace Catch;
 #endif
 
 

--- a/projects/hip-tests/catch/unit/texture/hipBindTexture.cc
+++ b/projects/hip-tests/catch/unit/texture/hipBindTexture.cc
@@ -136,15 +136,9 @@ TEST_CASE("Unit_hipBindTexture_Negative") {
 
   SECTION("Invalid hipChannelFormatDesc") {
     hipChannelFormatDesc invalid_channel_desc;
-#if HT_AMD
-    HIP_CHECK_ERROR(hipBindTexture(&offset, tex_ref, reinterpret_cast<void*>(tex_buf),
-                                   invalid_channel_desc, N * sizeof(float)),
-                    hipErrorInvalidValue);
-#else
     HIP_CHECK_ERROR(hipBindTexture(&offset, tex_ref, reinterpret_cast<void*>(tex_buf),
                                    invalid_channel_desc, N * sizeof(float)),
                     hipErrorInvalidChannelDescriptor);
-#endif
   }
 
   if (tex_buf) {

--- a/projects/hip-tests/catch/unit/texture/tex1Dfetch.cc
+++ b/projects/hip-tests/catch/unit/texture/tex1Dfetch.cc
@@ -91,7 +91,7 @@ TEMPLATE_TEST_CASE("Unit_tex1Dfetch_Positive_ReadModeElementType", "", char, uns
   for (auto i = 0u; i < out_alloc_h.size(); ++i) {
     INFO("Index: " << i);
     const auto ref_val = tex_h[i];
-    REQUIRE(out_alloc_h[i] == ref_val);
+    REQUIRE((out_alloc_h[i] == ref_val));
   }
 }
 
@@ -153,7 +153,7 @@ TEMPLATE_TEST_CASE("Unit_tex1Dfetch_Positive_ReadModeNormalizedFloat", "", char,
   for (auto i = 0u; i < out_alloc_h.size(); ++i) {
     INFO("Index: " << i);
     const auto ref_val = Vec4Map(tex_h[i]);
-    REQUIRE(out_alloc_h[i] == ref_val);
+    REQUIRE((out_alloc_h[i] == ref_val));
   }
 }
 


### PR DESCRIPTION
## Motivation

Upgrade catch2 from v2 to v3.8.1
Retain for windows, add conditions to cater for both

## Technical Details

Use the AWS hosted catch2 to use for hiptests builds.
Also fix all issues seen with the upgrade.

## Test Plan

Existing tests should pass with the upgrade.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
