### PR TITLE
[Documentation] Repo location and limitation update

### DIFF
--- a/projects/rocprofiler-sdk/README.md
+++ b/projects/rocprofiler-sdk/README.md
@@ -130,7 +130,7 @@ Please report issues on GitHub OR send an email to <dl.ROCm-Profiler.support@amd
           NUM_COMPUTE_UNITS: 28
           TARGET_GRAPHICS_VERSION: gfx1102
   ```
-- On `RHEL8.X` or similar distributions, there could be missing dependency for `libsqlite3x-devel`. To workaround this for now, user can:
+- On `RHEL8.X` or similar distributions, there could be a missing dependency for `libsqlite3x-devel`. To workaround this for now, user can:
   ```bash
     sudo dnf install libsqlite3x-devel
     sudo ln -s /lib64/libsqlite3.so /usr/local/lib/libsqlite3.so

--- a/projects/rocprofiler-sdk/README.md
+++ b/projects/rocprofiler-sdk/README.md
@@ -130,3 +130,8 @@ Please report issues on GitHub OR send an email to <dl.ROCm-Profiler.support@amd
           NUM_COMPUTE_UNITS: 28
           TARGET_GRAPHICS_VERSION: gfx1102
   ```
+- On `RHEL8.X` or similar distributions, there could be missing dependency for `libsqlite3x-devel`. To workaround this for now, user can:
+  ```bash
+    sudo dnf install libsqlite3x-devel
+    sudo ln -s /lib64/libsqlite3.so /usr/local/lib/libsqlite3.so
+  ```

--- a/projects/rocprofiler-sdk/source/docs/index.rst
+++ b/projects/rocprofiler-sdk/source/docs/index.rst
@@ -15,7 +15,7 @@ The ROCprofiler-SDK library provides runtime-independent APIs for tracing runtim
 In summary, ROCprofiler-SDK combines `ROCProfiler <https://rocm.docs.amd.com/projects/rocprofiler/en/latest/index.html>`_ and `ROCTracer <https://rocm.docs.amd.com/projects/roctracer/en/latest/index.html>`_.
 You can utilize the ROCprofiler-SDK to develop a tool for profiling and tracing HIP applications on ROCm software.
 
-The code is open source and hosted at `<https://github.com/ROCm/rocm-systems/tree/develop/projects/rocprofiler-sdk>`_ .
+The code is open source and hosted at `<https://github.com/ROCm/rocm-systems/tree/develop/projects/rocprofiler-sdk>`_.
 
 .. note::
   

--- a/projects/rocprofiler-sdk/source/docs/index.rst
+++ b/projects/rocprofiler-sdk/source/docs/index.rst
@@ -19,7 +19,7 @@ The code is open source and hosted at `<https://github.com/ROCm/rocm-systems/tre
 
 .. note::
   
-  The rocprofiler-sdk repository for ROCm 7.0 and earlier is located at `<https://github.com/ROCm/rocprofiler-sdk>`_.
+  The ROCprofiler-SDK repository for ROCm 7.0 and earlier is located at `<https://github.com/ROCm/rocprofiler-sdk>`_.
 
 ROCprofiler-SDK uses a companion library called `AQLprofile <https://rocm.docs.amd.com/projects/aqlprofile/en/latest/index.html>`__ that generates profiling command packets (AQL/PM4) for performance counters and SQ thread trace. See the `AQLprofile docs <https://rocm.docs.amd.com/projects/aqlprofile/en/latest/index.html>`__ for more info.
 

--- a/projects/rocprofiler-sdk/source/docs/index.rst
+++ b/projects/rocprofiler-sdk/source/docs/index.rst
@@ -15,7 +15,11 @@ The ROCprofiler-SDK library provides runtime-independent APIs for tracing runtim
 In summary, ROCprofiler-SDK combines `ROCProfiler <https://rocm.docs.amd.com/projects/rocprofiler/en/latest/index.html>`_ and `ROCTracer <https://rocm.docs.amd.com/projects/roctracer/en/latest/index.html>`_.
 You can utilize the ROCprofiler-SDK to develop a tool for profiling and tracing HIP applications on ROCm software.
 
-The code is open and hosted at `<https://github.com/ROCm/rocprofiler-sdk>`_.
+The code is open source and hosted at `<https://github.com/ROCm/rocm-systems/tree/develop/projects/rocprofiler-sdk>`_ .
+
+.. note::
+  
+  The rocprofiler-sdk repository for ROCm 7.0 and earlier is located at `<https://github.com/ROCm/rocprofiler-sdk>`_.
 
 ROCprofiler-SDK uses a companion library called `AQLprofile <https://rocm.docs.amd.com/projects/aqlprofile/en/latest/index.html>`__ that generates profiling command packets (AQL/PM4) for performance counters and SQ thread trace. See the `AQLprofile docs <https://rocm.docs.amd.com/projects/aqlprofile/en/latest/index.html>`__ for more info.
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR updates documentation to reflect the repository location change for ROCprofiler-SDK and adds information about a known limitation on RHEL distributions.

Updated repository URL to point to the new location in the rocm-systems monorepo
Added note about the legacy repository location for ROCm 7.0 and earlier versions
Documented workaround for missing libsqlite3x-devel dependency on RHEL8.X distributions
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
