### PR TITLE
Fix the printing of std::string

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Patch rocm-systems
         run: |
-          rm ./TheRock/patches/amd-mainline/rocm-systems/0007-Rollup-of-build-changes-needed-for-compat-with-TheRo.patch
+          rm ./TheRock/patches/amd-mainline/rocm-systems/0010-clr-ClPrint-std-string-to-c-string-fix.patch
           git -c user.name="therockbot" -c "user.email=therockbot@amd.com" am --whitespace=nowarn ./TheRock/patches/amd-mainline/rocm-systems/*.patch
 
       - name: Configure Projects

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Patch rocm-systems
         run: |
-          rm ./TheRock/patches/amd-mainline/rocm-systems/0007-Rollup-of-build-changes-needed-for-compat-with-TheRo.patch
+          rm ./TheRock/patches/amd-mainline/rocm-systems/0010-clr-ClPrint-std-string-to-c-string-fix.patch
           git -c user.name="therockbot" -c "user.email=therockbot@amd.com" am --whitespace=nowarn ./TheRock/patches/amd-mainline/rocm-systems/*.patch
 
       - name: Install requirements

--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -1010,7 +1010,7 @@ bool NumaNode::GetAffinity() {
   std::ifstream file(path);
   if (!file) {
     std::cerr << "Failed to open " << path << "\n";
-    ClPrint(amd::LOG_DEBUG, amd::LOG_RESOURCE, "%s cannot be opened", path);
+    ClPrint(amd::LOG_DEBUG, amd::LOG_RESOURCE, "%s cannot be opened", path.c_str());
     return false;
   }
   std::string line;


### PR DESCRIPTION
## Motivation

Fixes build break detected when integrating latest changes to therock.

## Technical Details

- Debug function expects to get c-style string but std::string is passed.
- Fixes a following error:
```

rocm-systems/projects/clr/rocclr/os/os_posix.cpp:1013:71: error: cannot pass object of non-trivial type 'const std::string' (aka 'const basic_string<char>') through variadic function; call will abort at runtime [-Wnon-pod-varargs]
1013 |     ClPrint(amd::LOG_DEBUG, amd::LOG_RESOURCE, "%s cannot be opened", path);
[hip-clr] rocm-systems/projects/clr/rocclr/os/os_posix.cpp:1013:71:
error: cannot pass object of non-trivial type 'const std::string' (aka 'const basic_string<char>')
through variadic function; call will abort at runtime [-Wnon-pod-varargs]
```

## Test Plan

Check results from the ci-build and verify that there is no a build break anymore.

## Test Result

Build will pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
