### PR TITLE
Fix the issue when sampling JAX with rocpd

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/metadata_registry.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/metadata_registry.hpp
@@ -171,7 +171,7 @@ struct kernel_symbol_less
         const rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t& rhs)
         const
     {
-        return lhs.kernel_object < rhs.kernel_object;
+        return lhs.kernel_id < rhs.kernel_id;
     }
 };
 #endif


### PR DESCRIPTION
## Motivation

Certain tests running the JAX framework were failing when the ROCpd was used for collecting and storing the tracing data. The causing error was that the rocpd metadata was missing certain information regarding the kernel_dispatch traces. 

Resolves: SWDEV-559639

## Technical Details

Fixed the comparison method when storing the kernel_symbol records into the metadata, which  previously caused certain entries to be dropped from the set.

## Test Plan

Running the reported `ann_test.py` provided within `rocm-jax` repository to validate the change.

## Test Result

Test passing without any errors and/or warnings, 

