### PR TITLE
SWDEV-563114 - User stack array instead to avoid delete gets skipped …

### DIFF
--- a/projects/hip-tests/catch/unit/kernel/hipPrintfKernel.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipPrintfKernel.cc
@@ -17,7 +17,7 @@ OUT OF OR INN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 #include <hip_test_common.hh>
-
+#include <vector>
 #include <cstring>
 #include "../kernel/printf_common.h"
 
@@ -56,13 +56,11 @@ TEST_CASE("Unit_kernel_ChkPrintf", "[multigpu]") {
     if (!HipTest::isPcieAtomicSupported()) continue;
     hipLaunchKernelGGL(run_printf, dim3(1), dim3(1), 0, 0);
     HIP_CHECK(hipDeviceSynchronize());
-    char* data = new char[st.size()];
-    ;
+    std::vector<char> data(st.size() + 1);  // +1 for null terminator
     std::ifstream CapturedData = capture.getCapturedData();
-    CapturedData.getline(data, st.size() + 1);
-    int result = strcmp(data, check);
+    CapturedData.getline(data.data(), st.size() + 1);
+    int result = strcmp(data.data(), check);
     REQUIRE(result == 0);
-    delete[] data;
   }
 }
 


### PR DESCRIPTION
…in case of assert failure.

## Motivation

Avoid mem leak in case of test failure.

## Technical Details

Use stack memory instead.

## Test Plan

Test should not see mem leak reported even it fails due to missing support from some lower stack.

## Test Result

Test should not see mem leak reported even it fails due to missing support from some lower stack.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
