### PR TITLE
fix(rocr): Fix Cache::GetInfo() to copy string content for HSA_CACHE_INFO_NAME

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/cache.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/cache.cpp
@@ -42,7 +42,7 @@
 
 #include "core/inc/cache.h"
 #include "assert.h"
-
+#include <cstring>
 namespace rocr {
 namespace core {
 
@@ -52,7 +52,8 @@ hsa_status_t Cache::GetInfo(hsa_cache_info_t attribute, void* value) {
       *(uint32_t*)value = name_.size();
       break;
     case HSA_CACHE_INFO_NAME:
-      *(const char**)value = name_.c_str();
+      memset(value, 0x0, name_.size());
+      memcpy(value, name_.c_str(), name_.size()); 
       break;
     case HSA_CACHE_INFO_LEVEL:
       *(uint8_t*)value = level_;


### PR DESCRIPTION
- Replace pointer assignment with memset + memcpy
- Fixes bug where pointer value was written instead of string content
- Aligns with implementation pattern used in HSA_CODE_SYMBOL_INFO_NAME

## Motivation

The current implementation of `Cache::GetInfo()` contains a critical bug when handling `HSA_CACHE_INFO_NAME`. [hsa.cpp:610-618](https://github.com/ROCm/rocm-systems/blob/develop/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp#L610)

Instead of copying the cache name string content to the user-provided buffer, it writes a pointer value:

```cpp
case HSA_CACHE_INFO_NAME:  
  *(const char**)value = name_.c_str();  // Bug: assigns pointer, not content  
  break;
```
This causes applications to receive memory addresses (e.g., 0x00c3dc58 in little-endian format) instead of readable cache names, violating the HSA API specification which requires a NUL-terminated character array. [hsa.h:1207-1212](https://github.com/ROCm/rocm-systems/blob/develop/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa.h#L1207)

## Technical Details

### Root Cause:

The bug affects both CPU and GPU agent cache initialization:

CPU agents:[amd_cpu_agent.cpp:127-129](https://github.com/ROCm/rocm-systems/blob/develop/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_cpu_agent.cpp#L127)
GPU agents: [amd_gpu_agent.cpp:597-599](https://github.com/ROCm/rocm-systems/blob/develop/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_cpu_agent.cpp#597)
Proposed Fix:

Replace the pointer assignment with proper string content copying:
```cpp
case HSA_CACHE_INFO_NAME:  
  memset(value, 0x0, name_.size());  
  memcpy(value, name_.c_str(), name_.size());  
  break;
```
This approach follows the same pattern used in other similar APIs:

`HSA_CODE_SYMBOL_INFO_NAME`:[amd_hsa_code.cpp:138-142](https://github.com/ROCm/rocm-systems/blob/develop/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_hsa_code.cpp#L138)
`HSA_ISA_INFO_NAME`:[isa.cpp:145-149](https://github.com/ROCm/rocm-systems/blob/develop/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/isa.cpp#L145)
Files Modified:

runtime/hsa-runtime/core/runtime/cache.cpp (or equivalent file containing Cache::GetInfo())

## Test Plan

Reproduction Steps:

Call `hsa_cache_get_info(cache, HSA_CACHE_INFO_NAME_LENGTH, &name_len)` to get length
Allocate buffer: `char* name_str = new char[name_len + 1]`
Call `hsa_cache_get_info(cache, HSA_CACHE_INFO_NAME, name_str)`
Before fix: buffer contains hex values like `58 dc c3 00` (memory address)
After fix: buffer contains readable string like "Hygon C86 7185 32-core Processor L1"
Testing Performed:

Built code successfully with the fix applied
Verified cache name queries now return correct string content
Tested on both CPU and GPU agents
Confirmed no regression in existing functionality

## Test Result

Before Fix:

```shell
DEBUG: name_len = 35  
DEBUG: bytes = 58 dc c3 00 00 00 00 00 00 00 00 00 ...  
name_str: X�� (garbage output)  
```

After Fix:

```shell
DEBUG: name_len = 35  
DEBUG: bytes = 48 79 67 6f 6e 20 43 38 36 20 37 31 38 35 ...  
name_str: Hygon C86 7185 32-core Processor L1 (correct output)  
```


All existing test cases pass without regression.

## Submission Checklist

- [x]  Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests
 Code builds successfully
 - [x]  All existing test cases pass
 - [x]  Verified fix resolves the reported issue
 - [x]  Implementation aligns with similar APIs in the codebase
 - [x]  I agree to license this contribution under the terms of the LICENSE.txt file in this repository