### PR TITLE
[rocprofiler-sdk][CI] Disable HIP/CLR build in CI jobs

### DIFF
--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -228,7 +228,7 @@ jobs:
           echo "✅ ROCProfiler-Register Installation complete!"
 
       - name: Build and Install ROCR-Runtime
-        if: env.ENABLE_ROCR_BUILD
+        if: ${{ env.ENABLE_ROCR_BUILD == 'true' }}
         shell: bash
         working-directory: projects/rocr-runtime
         run: |
@@ -245,7 +245,7 @@ jobs:
           echo "✅ ROCR-Runtime Installation complete!"
 
       - name: Build and Install HIP
-        if: env.ENABLE_HIP_CLR_BUILD
+        if: ${{ env.ENABLE_HIP_CLR_BUILD == 'true' }}
         shell: bash
         working-directory: projects
         run: |
@@ -526,7 +526,7 @@ jobs:
           echo "✅ ROCProfiler-Register Installation complete!"
 
       - name: Build and Install ROCR-Runtime
-        if: env.ENABLE_ROCR_BUILD
+        if: ${{ env.ENABLE_ROCR_BUILD == 'true' }}
         shell: bash
         working-directory: projects/rocr-runtime
         run: |
@@ -546,7 +546,7 @@ jobs:
           echo "✅ ROCR-Runtime Installation complete!"
 
       - name: Build and Install HIP
-        if: env.ENABLE_HIP_CLR_BUILD
+        if: ${{ env.ENABLE_HIP_CLR_BUILD == 'true' }}
         shell: bash
         working-directory: projects
         run: |
@@ -769,7 +769,7 @@ jobs:
         echo "✅ ROCProfiler-Register Installation complete!"
 
     - name: Build and Install ROCR-Runtime
-      if: env.ENABLE_ROCR_BUILD
+      if: ${{ env.ENABLE_ROCR_BUILD == 'true' }}
       shell: bash
       working-directory: projects/rocr-runtime
       run: |
@@ -786,7 +786,7 @@ jobs:
         echo "✅ ROCR-Runtime Installation complete!"
 
     - name: Build and Install HIP
-      if: env.ENABLE_HIP_CLR_BUILD
+      if: ${{ env.ENABLE_HIP_CLR_BUILD == 'true' }}
       shell: bash
       working-directory: projects
       run: |

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -63,7 +63,7 @@ env:
 
   GLOBAL_CMAKE_OPTIONS: ""
   ENABLE_ROCR_BUILD: "true"
-  ENABLE_HIP_CLR_BUILD: "true"
+  ENABLE_HIP_CLR_BUILD: "false"
 
   CI_MODE: ${{ github.event_name == 'schedule' && 'Nightly' || 'Continuous' }}
 


### PR DESCRIPTION
## Motivation
Disable building latest HIP until, new HIP version 17 apis are addressed in sdk side.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
