### PR TITLE
fixes to therock build when bumping to rocm-systems version from 20250626

### DIFF
--- a/projects/clr/rocclr/device/pal/palubercapturemgr.cpp
+++ b/projects/clr/rocclr/device/pal/palubercapturemgr.cpp
@@ -57,37 +57,6 @@ UberTraceCaptureMgr* UberTraceCaptureMgr::Create(Pal::IPlatform* platform, const
   return mgr;
 }
 
-static void UberTraceStateChangeCallback(const GpuUtil::TraceSession& pTraceSession,
-                                         GpuUtil::TraceSessionState newState,
-                                         void* pPrivateData)
-{
-    UberTraceCaptureMgr* mgr = static_cast<UberTraceCaptureMgr*>(pPrivateData);
-
-    switch (newState)
-    {
-        // boundary for prepare-phase dispatches
-        case GpuUtil::TraceSessionState::Preparing:
-        // boundary for detailed capture
-        case GpuUtil::TraceSessionState::Running:
-        // boundary for end of detailed trace
-#if (PAL_CLIENT_INTERFACE_MAJOR_VERSION >= 939)
-        case GpuUtil::TraceSessionState::Postamble:
-#endif
-        // boundary for end of trace
-        case GpuUtil::TraceSessionState::Waiting:
-        {
-            VirtualGPU* current_gpu = mgr->GetCurrentGPU();
-            if (current_gpu != nullptr) {
-                bool flush_success = current_gpu->queue(MainEngine).flush();
-                assert(flush_success);
-            }
-            break;
-        }
-        default:
-            break;
-    }
-}
-
 // ================================================================================================
 UberTraceCaptureMgr::UberTraceCaptureMgr(Pal::IPlatform* platform, const Device& device)
     : device_(device),
@@ -98,8 +67,7 @@ UberTraceCaptureMgr::UberTraceCaptureMgr(Pal::IPlatform* platform, const Device&
       trace_session_(platform->GetTraceSession()),
       trace_controller_(nullptr),
       code_object_trace_source_(nullptr),
-      queue_timings_trace_source_(nullptr),
-      registered_trace_state_callback_(false) {}
+      queue_timings_trace_source_(nullptr) {}
 
 // ================================================================================================
 UberTraceCaptureMgr::~UberTraceCaptureMgr() { DestroyUberTraceResources(); }
@@ -148,13 +116,6 @@ bool UberTraceCaptureMgr::CreateUberTraceResources(Pal::IPlatform* platform) {
       break;
     }
 
-    result = trace_session_->RegisterTraceStateChangeCallback(UberTraceStateChangeCallback, this);
-    if (result != Pal::Result::Success) {
-      break;
-    }
-
-    registered_trace_state_callback_ = true;
-
     success = true;
   } while (false);
 
@@ -189,11 +150,6 @@ void UberTraceCaptureMgr::DestroyUberTraceResources() {
     delete queue_timings_trace_source_;
     queue_timings_trace_source_ = nullptr;
   }
-
-  if (registered_trace_state_callback_) {
-    trace_session_->UnregisterTraceStateChangeCallback(UberTraceStateChangeCallback, this);
-    registered_trace_state_callback_ = false;
-  }
 }
 
 // ================================================================================================
@@ -226,9 +182,7 @@ void UberTraceCaptureMgr::PreDispatch(VirtualGPU* gpu, const pal::Kernel& kernel
   GpuUtil::RenderOpCounts opCounts = {
       .dispatchCount = 1u,
   };
-  current_gpu_ = gpu;
   trace_controller_->RecordRenderOps(pQueue, opCounts);
-  current_gpu_ = nullptr;
 
   if (trace_session_->GetTraceSessionState() == GpuUtil::TraceSessionState::Running) {
     RgpSqttMarkerEventType apiEvent = RgpSqttMarkerEventType::CmdNDRangeKernel;

--- a/projects/clr/rocclr/device/pal/palubercapturemgr.hpp
+++ b/projects/clr/rocclr/device/pal/palubercapturemgr.hpp
@@ -67,10 +67,6 @@ class UberTraceCaptureMgr final : public ICaptureMgr {
                         size_t elf_binary_size, Pal::IGpuMemory* pGpuMemory,
                         size_t offset) override;
 
-  VirtualGPU* GetCurrentGPU() {
-      return current_gpu_;
-  }
-
  private:
   UberTraceCaptureMgr(Pal::IPlatform* platform, const Device& device);
   bool Init(Pal::IPlatform* platform);
@@ -99,9 +95,6 @@ class UberTraceCaptureMgr final : public ICaptureMgr {
   GpuUtil::RenderOpTraceController* trace_controller_;
   GpuUtil::CodeObjectTraceSource* code_object_trace_source_;
   GpuUtil::QueueTimingsTraceSource* queue_timings_trace_source_;
-
-  VirtualGPU*                       current_gpu_;
-  bool                              registered_trace_state_callback_;
 
   PAL_DISALLOW_DEFAULT_CTOR(UberTraceCaptureMgr);
   PAL_DISALLOW_COPY_AND_ASSIGN(UberTraceCaptureMgr);

--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -1003,7 +1003,7 @@ bool NumaNode::GetAffinity() {
   std::ifstream file(path);
   if (!file) {
     std::cerr << "Failed to open " << path << "\n";
-    ClPrint(amd::LOG_DEBUG, amd::LOG_RESOURCE, "%s cannot be opened", path);
+    ClPrint(amd::LOG_DEBUG, amd::LOG_RESOURCE, "%s cannot be opened", path.c_str());
     return false;
   }
   std::string line;


### PR DESCRIPTION
## Motivation

This fixes problems detected by therock CI when doing Linux and Windows builds.

## Technical Details

1) Add one patch to fix build error:
- add one line printout fix for problem where the std:string where passed to printout expecting c-style string
2) Revert 2 patches:
- revert of rockprofiler-sdk patch broking build on therock ubuntu CI. Patch triggered something to expect the Ubuntu build machine to have python 3.14 installed but was not then able to find it
- revert the patch which broke windows build by trying to use functions which were not  available on windows-interoperaribility library

## Test Plan

Tested by therock ci build

## Test Result

With these changes included with the rocm-systems version from 20251026, therock linux and windows builds passed

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
