### PR TITLE
Add comprehensive test suite for perf-dkms counter validation

### DIFF
--- a/projects/perf-dkms/test_apps/.gitignore
+++ b/projects/perf-dkms/test_apps/.gitignore
@@ -1,0 +1,28 @@
+# Build artifacts
+build/
+*.o
+*.a
+
+# Executables
+valu_heavy/valu_heavy
+salu_heavy/salu_heavy
+lds_basic/lds_basic
+lds_conflicts/lds_conflicts
+smem/smem
+buffer_read/buffer_read
+buffer_write/buffer_write
+flat_memory/flat_memory
+mem_sizes/mem_sizes
+cache_hit/cache_hit
+cache_miss/cache_miss
+wave_modes/wave_modes
+waits_stalls/waits_stalls
+basic_activity/basic_activity
+
+# CMake
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+Makefile
+*.cmake
+!CMakeLists.txt

--- a/projects/perf-dkms/test_apps/BUILD_SUCCESS.txt
+++ b/projects/perf-dkms/test_apps/BUILD_SUCCESS.txt
@@ -3,7 +3,7 @@ AMD GPU Performance Counter Test Suite - Build Complete
 ================================================================================
 
 Build Date: $(date)
-Location: /home/ben/rocm-systems/worktrees/test_apps/projects/perf-dkms/test_apps
+Location: <project-root>/projects/perf-dkms/test_apps
 
 BUILD SUMMARY:
 --------------
@@ -51,7 +51,7 @@ All 14 test executables successfully built in build/ directory:
 QUICK START:
 ------------
 To run all tests:
-    cd /home/ben/rocm-systems/worktrees/test_apps/projects/perf-dkms/test_apps
+    cd <path-to-test_apps>
     ./run_all_tests.sh
 
 To run individual test:

--- a/projects/perf-dkms/test_apps/BUILD_SUCCESS.txt
+++ b/projects/perf-dkms/test_apps/BUILD_SUCCESS.txt
@@ -1,0 +1,134 @@
+================================================================================
+AMD GPU Performance Counter Test Suite - Build Complete
+================================================================================
+
+Build Date: $(date)
+Location: /home/ben/rocm-systems/worktrees/test_apps/projects/perf-dkms/test_apps
+
+BUILD SUMMARY:
+--------------
+✓ 14 Test applications created and compiled successfully
+✓ 2 Common infrastructure headers
+✓ 16 CMakeLists.txt files (1 root, 1 common, 14 tests)
+✓ 1 Run script (run_all_tests.sh)
+✓ 2 Documentation files (README.md, QUICKSTART.md)
+
+TEST APPLICATIONS:
+------------------
+1.  valu_heavy      - VALU Heavy (FMA Operations)
+2.  salu_heavy      - SALU Heavy (Scalar Operations)
+3.  lds_basic       - LDS Basic (Sequential Access)
+4.  lds_conflicts   - LDS Conflicts (Bank Conflicts)
+5.  smem            - SMEM (Scalar Memory)
+6.  buffer_read     - Buffer Read (Coalesced Reads)
+7.  buffer_write    - Buffer Write (Coalesced Writes)
+8.  flat_memory     - FLAT Memory (Generic Pointers)
+9.  mem_sizes       - Memory Sizes (32B/64B/128B)
+10. cache_hit       - Cache Hit (L2 Cache Hits)
+11. cache_miss      - Cache Miss (L2 Cache Misses)
+12. wave_modes      - Wave Modes (Wave32/Wave64)
+13. waits_stalls    - Waits/Stalls (Memory Dependencies)
+14. basic_activity  - Basic Activity (Baseline)
+
+EXECUTABLES BUILT:
+------------------
+All 14 test executables successfully built in build/ directory:
+- build/valu_heavy/valu_heavy
+- build/salu_heavy/salu_heavy
+- build/lds_basic/lds_basic
+- build/lds_conflicts/lds_conflicts
+- build/smem/smem
+- build/buffer_read/buffer_read
+- build/buffer_write/buffer_write
+- build/flat_memory/flat_memory
+- build/mem_sizes/mem_sizes
+- build/cache_hit/cache_hit
+- build/cache_miss/cache_miss
+- build/wave_modes/wave_modes
+- build/waits_stalls/waits_stalls
+- build/basic_activity/basic_activity
+
+QUICK START:
+------------
+To run all tests:
+    cd /home/ben/rocm-systems/worktrees/test_apps/projects/perf-dkms/test_apps
+    ./run_all_tests.sh
+
+To run individual test:
+    ./build/valu_heavy/valu_heavy
+
+To rebuild:
+    cd build
+    make clean
+    make -j$(nproc)
+
+DOCUMENTATION:
+--------------
+- README.md        - Comprehensive documentation
+- QUICKSTART.md    - Quick reference guide
+- This file        - Build success summary
+
+INFRASTRUCTURE:
+---------------
+Common infrastructure provides:
+- HIP error checking macros (HIP_CHECK, HIP_CHECK_LAST)
+- Device memory management utilities
+- Test framework base class with timing
+- Kernel runner helper class
+- Result verification utilities
+
+TARGET HARDWARE BLOCKS:
+-----------------------
+- SQ (Shader Quad / Compute Unit)
+  * VALU instructions
+  * SALU instructions
+  * SMEM instructions
+  * FLAT instructions
+  * LDS operations
+
+- GL2C (L2 Cache)
+  * Cache hits/misses
+  * Transaction sizes
+  * Memory traffic
+
+- TA (Texture Addresser)
+  * Memory fetches
+  * Buffer operations
+
+- GRBM (Graphics Register Bus Manager)
+  * GPU activity
+  * Wait states
+  * Stalls
+
+BUILD CONFIGURATION:
+--------------------
+- HIP Path: /opt/rocm
+- HIP Compiler: Clang 20.0.0
+- HIP Standard: C++17
+- Build System: CMake 3.16+
+- Parallel Jobs: 8
+
+SUCCESS CRITERIA MET:
+---------------------
+✓ All tests compile without errors
+✓ All tests link successfully
+✓ CMake build system works correctly
+✓ All executables are runnable
+✓ Documentation is complete
+✓ Run script is executable
+
+NEXT STEPS:
+-----------
+1. Run the test suite to verify GPU functionality:
+   ./run_all_tests.sh
+
+2. Profile individual tests with perf:
+   perf stat -e amd_gpu/SQ_INSTS_VALU/ ./build/valu_heavy/valu_heavy
+
+3. Use tests to validate performance counter implementation
+
+4. Integrate with perf-dkms module testing workflow
+
+================================================================================
+Build completed successfully!
+================================================================================

--- a/projects/perf-dkms/test_apps/CMakeLists.txt
+++ b/projects/perf-dkms/test_apps/CMakeLists.txt
@@ -1,0 +1,69 @@
+cmake_minimum_required(VERSION 3.16)
+project(perf_dkms_test_suite LANGUAGES CXX)
+
+# Find HIP
+if(NOT DEFINED HIP_PATH)
+    if(NOT DEFINED ENV{HIP_PATH})
+        set(HIP_PATH "/opt/rocm" CACHE PATH "Path to HIP installation")
+    else()
+        set(HIP_PATH $ENV{HIP_PATH} CACHE PATH "Path to HIP installation")
+    endif()
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH ${HIP_PATH})
+find_package(hip REQUIRED)
+
+# Enable HIP language
+enable_language(HIP)
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Add common infrastructure
+add_subdirectory(common)
+
+# Add all test applications
+add_subdirectory(valu_heavy)
+add_subdirectory(salu_heavy)
+add_subdirectory(lds_basic)
+add_subdirectory(lds_conflicts)
+add_subdirectory(smem)
+add_subdirectory(buffer_read)
+add_subdirectory(buffer_write)
+add_subdirectory(flat_memory)
+add_subdirectory(mem_sizes)
+add_subdirectory(cache_hit)
+add_subdirectory(cache_miss)
+add_subdirectory(wave_modes)
+add_subdirectory(waits_stalls)
+add_subdirectory(basic_activity)
+
+# Print summary
+message(STATUS "")
+message(STATUS "=============================================================")
+message(STATUS "Perf-DKMS Test Suite Configuration Summary")
+message(STATUS "=============================================================")
+message(STATUS "HIP Path: ${HIP_PATH}")
+message(STATUS "CXX Compiler: ${CMAKE_CXX_COMPILER}")
+message(STATUS "HIP Compiler: ${CMAKE_HIP_COMPILER}")
+message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
+message(STATUS "")
+message(STATUS "Test Applications:")
+message(STATUS "  1. valu_heavy      - VALU compute intensive")
+message(STATUS "  2. salu_heavy      - SALU operations")
+message(STATUS "  3. lds_basic       - Basic LDS operations")
+message(STATUS "  4. lds_conflicts   - LDS bank conflicts")
+message(STATUS "  5. smem            - Scalar memory operations")
+message(STATUS "  6. buffer_read     - Buffer read operations")
+message(STATUS "  7. buffer_write    - Buffer write operations")
+message(STATUS "  8. flat_memory     - FLAT addressing")
+message(STATUS "  9. mem_sizes       - Various memory transaction sizes")
+message(STATUS " 10. cache_hit       - L2 cache hits")
+message(STATUS " 11. cache_miss      - L2 cache misses")
+message(STATUS " 12. wave_modes      - Wave32/Wave64 tests")
+message(STATUS " 13. waits_stalls    - Wait states and stalls")
+message(STATUS " 14. basic_activity  - Basic GPU activity")
+message(STATUS "=============================================================")
+message(STATUS "")

--- a/projects/perf-dkms/test_apps/QUICKSTART.md
+++ b/projects/perf-dkms/test_apps/QUICKSTART.md
@@ -3,7 +3,7 @@
 ## Build Instructions
 
 ```bash
-cd /home/ben/rocm-systems/worktrees/test_apps/projects/perf-dkms/test_apps
+cd <path-to-rocm-systems>/projects/perf-dkms/test_apps
 mkdir -p build && cd build
 cmake ..
 make -j$(nproc)
@@ -12,14 +12,14 @@ make -j$(nproc)
 ## Run All Tests
 
 ```bash
-cd /home/ben/rocm-systems/worktrees/test_apps/projects/perf-dkms/test_apps
+cd <path-to-rocm-systems>/projects/perf-dkms/test_apps
 ./run_all_tests.sh
 ```
 
 ## Run Individual Tests
 
 ```bash
-cd /home/ben/rocm-systems/worktrees/test_apps/projects/perf-dkms/test_apps/build
+cd <path-to-rocm-systems>/projects/perf-dkms/test_apps/build
 
 # Test 1: VALU Heavy
 ./valu_heavy/valu_heavy

--- a/projects/perf-dkms/test_apps/QUICKSTART.md
+++ b/projects/perf-dkms/test_apps/QUICKSTART.md
@@ -1,0 +1,158 @@
+# Perf-DKMS Test Suite - Quick Start Guide
+
+## Build Instructions
+
+```bash
+cd /home/ben/rocm-systems/worktrees/test_apps/projects/perf-dkms/test_apps
+mkdir -p build && cd build
+cmake ..
+make -j$(nproc)
+```
+
+## Run All Tests
+
+```bash
+cd /home/ben/rocm-systems/worktrees/test_apps/projects/perf-dkms/test_apps
+./run_all_tests.sh
+```
+
+## Run Individual Tests
+
+```bash
+cd /home/ben/rocm-systems/worktrees/test_apps/projects/perf-dkms/test_apps/build
+
+# Test 1: VALU Heavy
+./valu_heavy/valu_heavy
+
+# Test 2: SALU Heavy
+./salu_heavy/salu_heavy
+
+# Test 3: LDS Basic
+./lds_basic/lds_basic
+
+# Test 4: LDS Conflicts
+./lds_conflicts/lds_conflicts
+
+# Test 5: SMEM
+./smem/smem
+
+# Test 6: Buffer Read
+./buffer_read/buffer_read
+
+# Test 7: Buffer Write
+./buffer_write/buffer_write
+
+# Test 8: FLAT Memory
+./flat_memory/flat_memory
+
+# Test 9: Memory Sizes
+./mem_sizes/mem_sizes
+
+# Test 10: Cache Hit
+./cache_hit/cache_hit
+
+# Test 11: Cache Miss
+./cache_miss/cache_miss
+
+# Test 12: Wave Modes
+./wave_modes/wave_modes
+
+# Test 13: Waits/Stalls
+./waits_stalls/waits_stalls
+
+# Test 14: Basic Activity
+./basic_activity/basic_activity
+```
+
+## Test Suite Summary
+
+| # | Test Name | Purpose | Target Counters |
+|---|-----------|---------|-----------------|
+| 1 | valu_heavy | Float-heavy FMA operations | SQ_INSTS_VALU |
+| 2 | salu_heavy | Scalar integer operations | SQ_INSTS_SALU |
+| 3 | lds_basic | Sequential LDS access | SQ_LDS_* |
+| 4 | lds_conflicts | LDS bank conflicts | SQ_LDS_BANK_CONFLICT |
+| 5 | smem | Constant memory reads | SQ_INSTS_SMEM |
+| 6 | buffer_read | Coalesced memory reads | TA_* |
+| 7 | buffer_write | Coalesced memory writes | Memory write counters |
+| 8 | flat_memory | Generic pointer operations | SQ_INSTS_FLAT |
+| 9 | mem_sizes | 32B/64B/128B transactions | GL2C transaction counters |
+| 10 | cache_hit | L2 cache hits | GL2C hit counters |
+| 11 | cache_miss | L2 cache misses | GL2C miss counters |
+| 12 | wave_modes | Wave32/Wave64 operations | Wave occupancy counters |
+| 13 | waits_stalls | Memory dependencies | GRBM_* wait/stall counters |
+| 14 | basic_activity | Baseline GPU activity | GRBM_GUI_ACTIVE |
+
+## Usage with Perf
+
+Example monitoring a specific test:
+
+```bash
+# Monitor VALU instructions
+perf stat -e amd_gpu/SQ_INSTS_VALU/ ./build/valu_heavy/valu_heavy
+
+# Monitor multiple counters
+perf stat -e amd_gpu/SQ_INSTS_VALU/,amd_gpu/SQ_INSTS_SALU/ ./build/valu_heavy/valu_heavy
+
+# Profile with rocprof
+rocprof --stats ./build/valu_heavy/valu_heavy
+```
+
+## File Structure
+
+```
+test_apps/
+├── CMakeLists.txt          # Root build configuration
+├── README.md               # Detailed documentation
+├── QUICKSTART.md           # This file
+├── run_all_tests.sh        # Script to run all tests
+├── common/                 # Shared infrastructure
+│   ├── hip_utils.hpp       # HIP error checking and utilities
+│   ├── test_framework.hpp  # Base test class framework
+│   └── CMakeLists.txt
+├── valu_heavy/             # Test 1
+│   ├── valu_heavy.cpp
+│   └── CMakeLists.txt
+├── salu_heavy/             # Test 2
+│   ├── salu_heavy.cpp
+│   └── CMakeLists.txt
+... (and so on for all 14 tests)
+└── build/                  # Build output directory
+    ├── valu_heavy/valu_heavy
+    ├── salu_heavy/salu_heavy
+    ... (all test executables)
+```
+
+## Prerequisites
+
+- ROCm/HIP installation (tested with ROCm 5.x+)
+- CMake 3.16 or later
+- C++17 compatible compiler
+- AMD GPU hardware
+
+## Troubleshooting
+
+**Build fails with "HIP not found":**
+```bash
+export HIP_PATH=/opt/rocm
+cmake -DHIP_PATH=/opt/rocm ..
+```
+
+**No HIP devices found at runtime:**
+```bash
+# Verify GPU is detected
+rocminfo
+
+# Check drivers are loaded
+lsmod | grep amdgpu
+```
+
+**Tests crash or hang:**
+- Check GPU status: `rocm-smi`
+- Review dmesg for GPU errors: `dmesg | tail`
+- Ensure sufficient GPU memory
+
+## Support
+
+For detailed information, see README.md in this directory.
+For perf-dkms specific issues, refer to the main project documentation.

--- a/projects/perf-dkms/test_apps/README.md
+++ b/projects/perf-dkms/test_apps/README.md
@@ -1,0 +1,293 @@
+# AMD GPU Performance Counter Test Suite
+
+This directory contains a comprehensive test suite for validating AMD GPU performance counters in the perf-dkms project.
+
+## Overview
+
+The test suite consists of 14 HIP-based GPU applications that exercise specific hardware behaviors to validate that performance counters are working correctly. Each test targets different GPU hardware blocks (GL2C, SQ, TA, GRBM) and specific counter types.
+
+## Directory Structure
+
+```
+test_apps/
+├── common/                  # Shared test infrastructure
+│   ├── test_framework.hpp   # Base test class with timing, error checking
+│   ├── hip_utils.hpp        # HIP error checking macros and utilities
+│   └── CMakeLists.txt       # Build common library
+├── valu_heavy/              # Test #1: VALU compute intensive
+├── salu_heavy/              # Test #2: SALU operations
+├── lds_basic/               # Test #3: Basic LDS operations
+├── lds_conflicts/           # Test #4: LDS bank conflicts
+├── smem/                    # Test #5: Scalar memory operations
+├── buffer_read/             # Test #6: Buffer read operations
+├── buffer_write/            # Test #7: Buffer write operations
+├── flat_memory/             # Test #8: FLAT addressing
+├── mem_sizes/               # Test #9: Various memory transaction sizes
+├── cache_hit/               # Test #10: L2 cache hits
+├── cache_miss/              # Test #11: L2 cache misses
+├── wave_modes/              # Test #12: Wave32/Wave64 tests
+├── waits_stalls/            # Test #13: Wait states and stalls
+├── basic_activity/          # Test #14: Basic GPU activity
+├── CMakeLists.txt           # Root build configuration
+├── run_all_tests.sh         # Script to run all tests
+└── README.md                # This file
+```
+
+## Test Descriptions
+
+### 1. VALU Heavy (`valu_heavy`)
+**Target Counters:** `SQ_INSTS_VALU`
+- Performs intensive floating-point FMA (Fused Multiply-Add) operations
+- Creates high Vector ALU utilization
+- 1M threads × 1000 iterations × 4 FMA ops
+
+### 2. SALU Heavy (`salu_heavy`)
+**Target Counters:** `SQ_INSTS_SALU`
+- Performs scalar integer operations (shifts, masks, logical ops)
+- Uses wave-uniform values for scalar execution
+- 1M threads × 1000 iterations × 6 scalar ops
+
+### 3. LDS Basic (`lds_basic`)
+**Target Counters:** `SQ_LDS_*`
+- Sequential Local Data Share (LDS) access without bank conflicts
+- Simple shared memory read/write patterns
+- 256K threads using 1KB LDS per block
+
+### 4. LDS Conflicts (`lds_conflicts`)
+**Target Counters:** `SQ_LDS_BANK_CONFLICT`
+- Stride-32 access pattern designed to cause LDS bank conflicts
+- Tests LDS banking on AMD GPUs (32 banks)
+- 256K threads using 4KB LDS per block
+
+### 5. SMEM (`smem`)
+**Target Counters:** `SQ_INSTS_SMEM`
+- Scalar memory operations using constant memory
+- Multiple reads from constant cache
+- 1M threads × 200 constant memory reads
+
+### 6. Buffer Read (`buffer_read`)
+**Target Counters:** `TA_*` (Texture Addresser)
+- Coalesced global memory reads
+- Tests memory fetch efficiency
+- 16MB input buffer with 100 reads per thread
+
+### 7. Buffer Write (`buffer_write`)
+**Target Counters:** Memory write counters
+- Coalesced global memory writes
+- Tests memory store efficiency
+- 400MB total writes (100 writes per thread)
+
+### 8. FLAT Memory (`flat_memory`)
+**Target Counters:** `SQ_INSTS_FLAT`
+- Generic pointer operations using FLAT addressing
+- Tests unified address space operations
+- 1M threads × 200 FLAT ops (loads + stores)
+
+### 9. Memory Sizes (`mem_sizes`)
+**Target Counters:** `GL2C` transaction counters
+- Tests 32-byte, 64-byte, and 128-byte transactions
+- Uses int, int2, and int4 data types
+- Validates transaction size detection
+
+### 10. Cache Hit (`cache_hit`)
+**Target Counters:** `GL2C` hit counters
+- Small working set (1MB) to maximize L2 cache hits
+- Repeatedly accesses same data
+- 1M threads × 1000 accesses to small array
+
+### 11. Cache Miss (`cache_miss`)
+**Target Counters:** `GL2C` miss counters
+- Large working set (256MB) for cache misses
+- Streaming access pattern
+- Tests memory subsystem under miss conditions
+
+### 12. Wave Modes (`wave_modes`)
+**Target Counters:** Wave occupancy counters
+- Tests Wave32 and Wave64 execution modes
+- Uses wave shuffle operations
+- Validates wave-level instruction tracking
+
+### 13. Waits/Stalls (`waits_stalls`)
+**Target Counters:** `GRBM_*` wait/stall counters
+- Creates memory dependencies causing pipeline stalls
+- Tests wait state detection
+- Intentional dependencies with synchronization
+
+### 14. Basic Activity (`basic_activity`)
+**Target Counters:** `GRBM_GUI_ACTIVE`
+- Provides baseline GPU activity measurement
+- Simple computation for reference
+- Multiple iterations for stable measurements
+
+## Building the Tests
+
+### Prerequisites
+- ROCm/HIP installation (tested with ROCm 5.x+)
+- CMake 3.16 or later
+- C++17 compatible compiler
+- AMD GPU hardware
+
+### Build Instructions
+
+```bash
+cd /path/to/perf-dkms/test_apps
+mkdir build
+cd build
+cmake ..
+make -j$(nproc)
+```
+
+The build system will:
+1. Find HIP installation
+2. Build common infrastructure library
+3. Compile all 14 test applications
+4. Display configuration summary
+
+### Build Options
+
+```bash
+# Specify HIP path
+cmake -DHIP_PATH=/opt/rocm ..
+
+# Debug build
+cmake -DCMAKE_BUILD_TYPE=Debug ..
+
+# Release build (default)
+cmake -DCMAKE_BUILD_TYPE=Release ..
+```
+
+## Running the Tests
+
+### Run All Tests
+```bash
+cd /path/to/perf-dkms/test_apps
+./run_all_tests.sh
+```
+
+This script will:
+- Run all 14 tests sequentially
+- Report pass/fail status for each
+- Print summary at the end
+- Exit with code 0 if all pass, 1 if any fail
+
+### Run Individual Test
+```bash
+cd /path/to/perf-dkms/test_apps/build
+./valu_heavy/valu_heavy
+./cache_hit/cache_hit
+# ... etc
+```
+
+Each test will:
+1. Print device information
+2. Initialize test parameters
+3. Execute the kernel
+4. Report timing and status
+5. Exit with 0 on success
+
+## Test Output
+
+Each test provides detailed output:
+
+```
+================================================================================
+Test: VALU Heavy - FMA Operations
+================================================================================
+Using device 0: AMD Radeon RX 7900 XTX
+  Compute capability: 11.0
+  Total global memory: 24564 MB
+  Multiprocessors: 96
+  Warp size: 64
+
+Initializing test...
+  Array size: 1048576 elements
+  Iterations per thread: 1000
+  Total VALU operations: 4194304000
+Running test...
+Kernel: valu_heavy_kernel
+  Grid size:  (4096, 1, 1)
+  Block size: (256, 1, 1)
+  Total threads: 1048576
+Kernel execution completed successfully
+Cleaning up...
+
+--------------------------------------------------------------------------------
+Result: PASSED
+Execution time: 145.234 ms
+================================================================================
+```
+
+## Integration with Perf-DKMS
+
+These tests are designed to be used with perf-dkms performance monitoring:
+
+```bash
+# Load the perf-dkms module
+sudo modprobe amd_gpu_perf
+
+# Run a test while monitoring counters
+perf stat -e amd_gpu/SQ_INSTS_VALU/ ./valu_heavy/valu_heavy
+
+# Profile all tests
+for test in build/*/test_*; do
+    perf stat -e amd_gpu/... "$test"
+done
+```
+
+## Validation Methodology
+
+Each test is designed to:
+1. **Exercise specific counters** - Targeted workloads for each counter type
+2. **Produce measurable activity** - Sufficient operations for reliable counting
+3. **Minimize interference** - Clean execution without extraneous operations
+4. **Validate correctness** - Tests run successfully without errors
+
+## Troubleshooting
+
+### Build Issues
+
+**HIP not found:**
+```bash
+export HIP_PATH=/opt/rocm
+cmake -DHIP_PATH=/opt/rocm ..
+```
+
+**Compilation errors:**
+- Ensure ROCm/HIP is properly installed
+- Check that GPU compute capability is supported
+- Verify C++17 support in compiler
+
+### Runtime Issues
+
+**No HIP devices found:**
+- Verify AMD GPU is present: `rocminfo`
+- Check GPU drivers are loaded: `lsmod | grep amdgpu`
+- Ensure user has GPU access permissions
+
+**Out of memory errors:**
+- Reduce array sizes in test source files
+- Test on GPU with more memory
+- Run tests individually instead of in sequence
+
+**Kernel launch failures:**
+- Check dmesg for GPU errors
+- Verify GPU is not hung: `rocm-smi`
+- Reset GPU if needed: `rocm-smi --gpureset`
+
+## Contributing
+
+When adding new tests:
+1. Create a new subdirectory under `test_apps/`
+2. Implement test using `test_framework::TestBase` class
+3. Add CMakeLists.txt for the test
+4. Update root CMakeLists.txt to include new test
+5. Add test to `run_all_tests.sh` script
+6. Document the test purpose and target counters
+
+## License
+
+This test suite is part of the perf-dkms project and follows the same license terms.
+
+## Contact
+
+For issues or questions about the test suite, please refer to the main perf-dkms project documentation.

--- a/projects/perf-dkms/test_apps/basic_activity/CMakeLists.txt
+++ b/projects/perf-dkms/test_apps/basic_activity/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+project(basic_activity_test)
+
+set_source_files_properties(basic_activity.cpp PROPERTIES LANGUAGE HIP)
+add_executable(basic_activity basic_activity.cpp)
+target_link_libraries(basic_activity PRIVATE test_common)
+set_target_properties(basic_activity PROPERTIES
+    HIP_STANDARD 17
+    HIP_STANDARD_REQUIRED ON
+)

--- a/projects/perf-dkms/test_apps/basic_activity/basic_activity.cpp
+++ b/projects/perf-dkms/test_apps/basic_activity/basic_activity.cpp
@@ -1,0 +1,66 @@
+#include "test_framework.hpp"
+#include <vector>
+
+// Basic GPU activity test - simple baseline
+// Provides baseline activity for GRBM_GUI_ACTIVE and other activity counters
+__global__ void basic_activity_kernel(float* output, const float* input) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    // Simple computation
+    float val = input[idx];
+    val = val * 2.0f + 1.0f;
+    val = val / 3.0f;
+
+    output[idx] = val;
+}
+
+class BasicActivityTest : public test_framework::TestBase {
+public:
+    BasicActivityTest() : TestBase("Basic Activity - Baseline GPU Activity") {}
+
+    bool setup() override {
+        size_ = 1024 * 1024;  // 1M elements
+
+        // Allocate device memory
+        d_input_ = hip_utils::allocateDeviceWithValue<float>(size_, 1.0f);
+        d_output_ = hip_utils::allocateDevice<float>(size_);
+
+        std::cout << "  Array size: " << size_ << " elements" << std::endl;
+        std::cout << "  Purpose: Baseline GPU activity measurement" << std::endl;
+
+        return true;
+    }
+
+    bool execute() override {
+        dim3 block_size(256);
+        dim3 grid_size((size_ + block_size.x - 1) / block_size.x);
+
+        test_framework::KernelRunner runner("basic_activity_kernel", grid_size, block_size);
+        runner.launch(basic_activity_kernel, d_output_, d_input_);
+
+        // Run multiple iterations for more consistent measurements
+        std::cout << "  Running 10 iterations for stable measurements..." << std::endl;
+        for (int i = 0; i < 10; i++) {
+            hipLaunchKernelGGL(basic_activity_kernel, grid_size, block_size, 0, 0,
+                              d_output_, d_input_);
+        }
+        HIP_CHECK(hipDeviceSynchronize());
+
+        return true;
+    }
+
+    void cleanup() override {
+        hip_utils::freeDevice(d_input_);
+        hip_utils::freeDevice(d_output_);
+    }
+
+private:
+    float* d_input_ = nullptr;
+    float* d_output_ = nullptr;
+    size_t size_;
+};
+
+int main() {
+    BasicActivityTest test;
+    return test.run();
+}

--- a/projects/perf-dkms/test_apps/buffer_read/CMakeLists.txt
+++ b/projects/perf-dkms/test_apps/buffer_read/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+project(buffer_read_test)
+
+set_source_files_properties(buffer_read.cpp PROPERTIES LANGUAGE HIP)
+add_executable(buffer_read buffer_read.cpp)
+target_link_libraries(buffer_read PRIVATE test_common)
+set_target_properties(buffer_read PROPERTIES
+    HIP_STANDARD 17
+    HIP_STANDARD_REQUIRED ON
+)

--- a/projects/perf-dkms/test_apps/buffer_read/buffer_read.cpp
+++ b/projects/perf-dkms/test_apps/buffer_read/buffer_read.cpp
@@ -1,0 +1,70 @@
+#include "test_framework.hpp"
+#include <vector>
+
+// Coalesced buffer read operations
+// Targets TA_* counters (Texture Addresser - memory fetches)
+__global__ void buffer_read_kernel(float* output, const float* input, int stride) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    float sum = 0.0f;
+
+    // Perform multiple coalesced reads
+    #pragma unroll 4
+    for (int i = 0; i < 100; i++) {
+        int read_idx = idx + i * stride;
+        sum += input[read_idx];
+    }
+
+    output[idx] = sum;
+}
+
+class BufferReadTest : public test_framework::TestBase {
+public:
+    BufferReadTest() : TestBase("Buffer Read - Coalesced Memory Reads") {}
+
+    bool setup() override {
+        size_ = 16 * 1024 * 1024;  // 16M elements for reading
+        output_size_ = 1024 * 1024;  // 1M output elements
+        stride_ = 16;
+
+        // Allocate device memory
+        d_input_ = hip_utils::allocateDeviceWithValue<float>(size_, 1.0f);
+        d_output_ = hip_utils::allocateDevice<float>(output_size_);
+
+        std::cout << "  Input array size: " << size_ << " elements ("
+                  << (size_ * sizeof(float) / (1024*1024)) << " MB)" << std::endl;
+        std::cout << "  Output array size: " << output_size_ << " elements" << std::endl;
+        std::cout << "  Reads per thread: 100" << std::endl;
+        std::cout << "  Total memory reads: " << (output_size_ * 100 * sizeof(float) / (1024*1024))
+                  << " MB" << std::endl;
+
+        return true;
+    }
+
+    bool execute() override {
+        dim3 block_size(256);
+        dim3 grid_size((output_size_ + block_size.x - 1) / block_size.x);
+
+        test_framework::KernelRunner runner("buffer_read_kernel", grid_size, block_size);
+        runner.launch(buffer_read_kernel, d_output_, d_input_, stride_);
+
+        return true;
+    }
+
+    void cleanup() override {
+        hip_utils::freeDevice(d_input_);
+        hip_utils::freeDevice(d_output_);
+    }
+
+private:
+    float* d_input_ = nullptr;
+    float* d_output_ = nullptr;
+    size_t size_;
+    size_t output_size_;
+    int stride_;
+};
+
+int main() {
+    BufferReadTest test;
+    return test.run();
+}

--- a/projects/perf-dkms/test_apps/buffer_write/CMakeLists.txt
+++ b/projects/perf-dkms/test_apps/buffer_write/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+project(buffer_write_test)
+
+set_source_files_properties(buffer_write.cpp PROPERTIES LANGUAGE HIP)
+add_executable(buffer_write buffer_write.cpp)
+target_link_libraries(buffer_write PRIVATE test_common)
+set_target_properties(buffer_write PROPERTIES
+    HIP_STANDARD 17
+    HIP_STANDARD_REQUIRED ON
+)

--- a/projects/perf-dkms/test_apps/buffer_write/buffer_write.cpp
+++ b/projects/perf-dkms/test_apps/buffer_write/buffer_write.cpp
@@ -1,0 +1,66 @@
+#include "test_framework.hpp"
+#include <vector>
+
+// Coalesced buffer write operations
+// Targets memory write counters
+__global__ void buffer_write_kernel(float* output, const float* input) {
+    int base_idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    float val = input[base_idx];
+
+    // Perform multiple coalesced writes
+    #pragma unroll 4
+    for (int i = 0; i < 100; i++) {
+        int write_idx = base_idx + i * blockDim.x * gridDim.x;
+        output[write_idx] = val * (1.0f + i * 0.01f);
+    }
+}
+
+class BufferWriteTest : public test_framework::TestBase {
+public:
+    BufferWriteTest() : TestBase("Buffer Write - Coalesced Memory Writes") {}
+
+    bool setup() override {
+        input_size_ = 1024 * 1024;  // 1M input elements
+        output_size_ = 100 * 1024 * 1024;  // 100M output elements
+
+        // Allocate device memory
+        d_input_ = hip_utils::allocateDeviceWithValue<float>(input_size_, 1.0f);
+        d_output_ = hip_utils::allocateDevice<float>(output_size_);
+
+        std::cout << "  Input array size: " << input_size_ << " elements" << std::endl;
+        std::cout << "  Output array size: " << output_size_ << " elements ("
+                  << (output_size_ * sizeof(float) / (1024*1024)) << " MB)" << std::endl;
+        std::cout << "  Writes per thread: 100" << std::endl;
+        std::cout << "  Total memory writes: " << (output_size_ * sizeof(float) / (1024*1024))
+                  << " MB" << std::endl;
+
+        return true;
+    }
+
+    bool execute() override {
+        dim3 block_size(256);
+        dim3 grid_size((input_size_ + block_size.x - 1) / block_size.x);
+
+        test_framework::KernelRunner runner("buffer_write_kernel", grid_size, block_size);
+        runner.launch(buffer_write_kernel, d_output_, d_input_);
+
+        return true;
+    }
+
+    void cleanup() override {
+        hip_utils::freeDevice(d_input_);
+        hip_utils::freeDevice(d_output_);
+    }
+
+private:
+    float* d_input_ = nullptr;
+    float* d_output_ = nullptr;
+    size_t input_size_;
+    size_t output_size_;
+};
+
+int main() {
+    BufferWriteTest test;
+    return test.run();
+}

--- a/projects/perf-dkms/test_apps/cache_hit/CMakeLists.txt
+++ b/projects/perf-dkms/test_apps/cache_hit/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+project(cache_hit_test)
+
+set_source_files_properties(cache_hit.cpp PROPERTIES LANGUAGE HIP)
+add_executable(cache_hit cache_hit.cpp)
+target_link_libraries(cache_hit PRIVATE test_common)
+set_target_properties(cache_hit PROPERTIES
+    HIP_STANDARD 17
+    HIP_STANDARD_REQUIRED ON
+)

--- a/projects/perf-dkms/test_apps/cache_hit/cache_hit.cpp
+++ b/projects/perf-dkms/test_apps/cache_hit/cache_hit.cpp
@@ -1,0 +1,68 @@
+#include "test_framework.hpp"
+#include <vector>
+
+// L2 cache hit test - small working set
+// Targets GL2C hit counters
+__global__ void cache_hit_kernel(float* output, const float* input, int small_size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    float sum = 0.0f;
+
+    // Repeatedly access small working set to maximize cache hits
+    #pragma unroll 4
+    for (int i = 0; i < 1000; i++) {
+        int read_idx = (idx + i) % small_size;  // Small working set
+        sum += input[read_idx];
+    }
+
+    output[idx] = sum;
+}
+
+class CacheHitTest : public test_framework::TestBase {
+public:
+    CacheHitTest() : TestBase("Cache Hit - L2 Cache Hits") {}
+
+    bool setup() override {
+        // Small working set that fits in L2 cache (typical L2: 4-6 MB)
+        small_size_ = 256 * 1024;  // 256K floats = 1 MB
+        output_size_ = 1024 * 1024;  // 1M threads
+
+        // Allocate device memory
+        d_input_ = hip_utils::allocateDeviceWithValue<float>(small_size_, 1.0f);
+        d_output_ = hip_utils::allocateDevice<float>(output_size_);
+
+        std::cout << "  Small working set: " << small_size_ << " floats ("
+                  << (small_size_ * sizeof(float) / (1024*1024)) << " MB)" << std::endl;
+        std::cout << "  Output size: " << output_size_ << " elements" << std::endl;
+        std::cout << "  Accesses per thread: 1000" << std::endl;
+        std::cout << "  Expected behavior: High L2 cache hit rate" << std::endl;
+
+        return true;
+    }
+
+    bool execute() override {
+        dim3 block_size(256);
+        dim3 grid_size((output_size_ + block_size.x - 1) / block_size.x);
+
+        test_framework::KernelRunner runner("cache_hit_kernel", grid_size, block_size);
+        runner.launch(cache_hit_kernel, d_output_, d_input_, small_size_);
+
+        return true;
+    }
+
+    void cleanup() override {
+        hip_utils::freeDevice(d_input_);
+        hip_utils::freeDevice(d_output_);
+    }
+
+private:
+    float* d_input_ = nullptr;
+    float* d_output_ = nullptr;
+    size_t small_size_;
+    size_t output_size_;
+};
+
+int main() {
+    CacheHitTest test;
+    return test.run();
+}

--- a/projects/perf-dkms/test_apps/cache_miss/CMakeLists.txt
+++ b/projects/perf-dkms/test_apps/cache_miss/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+project(cache_miss_test)
+
+set_source_files_properties(cache_miss.cpp PROPERTIES LANGUAGE HIP)
+add_executable(cache_miss cache_miss.cpp)
+target_link_libraries(cache_miss PRIVATE test_common)
+set_target_properties(cache_miss PROPERTIES
+    HIP_STANDARD 17
+    HIP_STANDARD_REQUIRED ON
+)

--- a/projects/perf-dkms/test_apps/cache_miss/cache_miss.cpp
+++ b/projects/perf-dkms/test_apps/cache_miss/cache_miss.cpp
@@ -1,0 +1,69 @@
+#include "test_framework.hpp"
+#include <vector>
+
+// L2 cache miss test - large streaming access
+// Targets GL2C miss counters
+__global__ void cache_miss_kernel(float* output, const float* input, size_t large_size) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    float sum = 0.0f;
+
+    // Streaming access through large array to maximize cache misses
+    size_t stride = blockDim.x * gridDim.x;
+    #pragma unroll 1
+    for (int i = 0; i < 100; i++) {
+        size_t read_idx = (idx + i * stride) % large_size;
+        sum += input[read_idx];
+    }
+
+    output[idx] = sum;
+}
+
+class CacheMissTest : public test_framework::TestBase {
+public:
+    CacheMissTest() : TestBase("Cache Miss - L2 Cache Misses") {}
+
+    bool setup() override {
+        // Large working set that doesn't fit in L2 cache
+        large_size_ = 64 * 1024 * 1024;  // 64M floats = 256 MB
+        output_size_ = 1024 * 1024;  // 1M threads
+
+        // Allocate device memory
+        d_input_ = hip_utils::allocateDeviceWithValue<float>(large_size_, 1.0f);
+        d_output_ = hip_utils::allocateDevice<float>(output_size_);
+
+        std::cout << "  Large working set: " << large_size_ << " floats ("
+                  << (large_size_ * sizeof(float) / (1024*1024)) << " MB)" << std::endl;
+        std::cout << "  Output size: " << output_size_ << " elements" << std::endl;
+        std::cout << "  Access pattern: Streaming (strided)" << std::endl;
+        std::cout << "  Expected behavior: High L2 cache miss rate" << std::endl;
+
+        return true;
+    }
+
+    bool execute() override {
+        dim3 block_size(256);
+        dim3 grid_size((output_size_ + block_size.x - 1) / block_size.x);
+
+        test_framework::KernelRunner runner("cache_miss_kernel", grid_size, block_size);
+        runner.launch(cache_miss_kernel, d_output_, d_input_, large_size_);
+
+        return true;
+    }
+
+    void cleanup() override {
+        hip_utils::freeDevice(d_input_);
+        hip_utils::freeDevice(d_output_);
+    }
+
+private:
+    float* d_input_ = nullptr;
+    float* d_output_ = nullptr;
+    size_t large_size_;
+    size_t output_size_;
+};
+
+int main() {
+    CacheMissTest test;
+    return test.run();
+}

--- a/projects/perf-dkms/test_apps/common/CMakeLists.txt
+++ b/projects/perf-dkms/test_apps/common/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Common test infrastructure
+add_library(test_common INTERFACE)
+target_include_directories(test_common INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(test_common INTERFACE hip::host)

--- a/projects/perf-dkms/test_apps/common/hip_utils.hpp
+++ b/projects/perf-dkms/test_apps/common/hip_utils.hpp
@@ -1,0 +1,97 @@
+#ifndef HIP_UTILS_HPP
+#define HIP_UTILS_HPP
+
+#include <hip/hip_runtime.h>
+#include <iostream>
+#include <cstdlib>
+#include <vector>
+
+// HIP error checking macro
+#define HIP_CHECK(cmd)                                                         \
+    do {                                                                       \
+        hipError_t error = (cmd);                                              \
+        if (error != hipSuccess) {                                             \
+            std::cerr << "HIP Error: '" << hipGetErrorString(error)            \
+                      << "' (" << error << ") at " << __FILE__ << ":"         \
+                      << __LINE__ << std::endl;                                \
+            exit(EXIT_FAILURE);                                                \
+        }                                                                      \
+    } while (0)
+
+// HIP kernel launch error checking
+#define HIP_CHECK_LAST()                                                       \
+    do {                                                                       \
+        hipError_t error = hipGetLastError();                                  \
+        if (error != hipSuccess) {                                             \
+            std::cerr << "HIP Kernel Launch Error: '"                          \
+                      << hipGetErrorString(error) << "' (" << error            \
+                      << ") at " << __FILE__ << ":" << __LINE__ << std::endl; \
+            exit(EXIT_FAILURE);                                                \
+        }                                                                      \
+    } while (0)
+
+namespace hip_utils {
+
+// Get device properties
+inline void printDeviceInfo() {
+    int deviceCount = 0;
+    HIP_CHECK(hipGetDeviceCount(&deviceCount));
+
+    if (deviceCount == 0) {
+        std::cerr << "No HIP devices found!" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    int device;
+    HIP_CHECK(hipGetDevice(&device));
+
+    hipDeviceProp_t prop;
+    HIP_CHECK(hipGetDeviceProperties(&prop, device));
+
+    std::cout << "Using device " << device << ": " << prop.name << std::endl;
+    std::cout << "  Compute capability: " << prop.major << "." << prop.minor << std::endl;
+    std::cout << "  Total global memory: " << (prop.totalGlobalMem / (1024*1024)) << " MB" << std::endl;
+    std::cout << "  Multiprocessors: " << prop.multiProcessorCount << std::endl;
+    std::cout << "  Warp size: " << prop.warpSize << std::endl;
+}
+
+// Allocate device memory
+template<typename T>
+T* allocateDevice(size_t count) {
+    T* ptr = nullptr;
+    HIP_CHECK(hipMalloc(&ptr, count * sizeof(T)));
+    return ptr;
+}
+
+// Allocate and initialize device memory
+template<typename T>
+T* allocateDeviceWithValue(size_t count, T value) {
+    T* ptr = allocateDevice<T>(count);
+    std::vector<T> host_data(count, value);
+    HIP_CHECK(hipMemcpy(ptr, host_data.data(), count * sizeof(T), hipMemcpyHostToDevice));
+    return ptr;
+}
+
+// Free device memory
+template<typename T>
+void freeDevice(T* ptr) {
+    if (ptr) {
+        HIP_CHECK(hipFree(ptr));
+    }
+}
+
+// Copy from device to host
+template<typename T>
+void copyFromDevice(T* host, const T* device, size_t count) {
+    HIP_CHECK(hipMemcpy(host, device, count * sizeof(T), hipMemcpyDeviceToHost));
+}
+
+// Copy from host to device
+template<typename T>
+void copyToDevice(T* device, const T* host, size_t count) {
+    HIP_CHECK(hipMemcpy(device, host, count * sizeof(T), hipMemcpyHostToDevice));
+}
+
+} // namespace hip_utils
+
+#endif // HIP_UTILS_HPP

--- a/projects/perf-dkms/test_apps/common/test_framework.hpp
+++ b/projects/perf-dkms/test_apps/common/test_framework.hpp
@@ -1,0 +1,134 @@
+#ifndef TEST_FRAMEWORK_HPP
+#define TEST_FRAMEWORK_HPP
+
+#include "hip_utils.hpp"
+#include <chrono>
+#include <string>
+#include <iostream>
+#include <iomanip>
+
+namespace test_framework {
+
+class TestBase {
+public:
+    TestBase(const std::string& name) : test_name_(name) {}
+
+    virtual ~TestBase() = default;
+
+    // Run the test
+    int run() {
+        std::cout << "\n" << std::string(80, '=') << std::endl;
+        std::cout << "Test: " << test_name_ << std::endl;
+        std::cout << std::string(80, '=') << std::endl;
+
+        hip_utils::printDeviceInfo();
+
+        std::cout << "\nInitializing test..." << std::endl;
+        if (!setup()) {
+            std::cerr << "Test setup failed!" << std::endl;
+            return 1;
+        }
+
+        std::cout << "Running test..." << std::endl;
+        auto start = std::chrono::high_resolution_clock::now();
+
+        bool success = execute();
+
+        auto end = std::chrono::high_resolution_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+
+        std::cout << "Cleaning up..." << std::endl;
+        cleanup();
+
+        std::cout << "\n" << std::string(80, '-') << std::endl;
+        if (success) {
+            std::cout << "Result: PASSED" << std::endl;
+        } else {
+            std::cout << "Result: FAILED" << std::endl;
+        }
+        std::cout << "Execution time: " << std::fixed << std::setprecision(3)
+                  << (duration.count() / 1000.0) << " ms" << std::endl;
+        std::cout << std::string(80, '=') << std::endl;
+
+        return success ? 0 : 1;
+    }
+
+protected:
+    // Override these in derived classes
+    virtual bool setup() = 0;
+    virtual bool execute() = 0;
+    virtual void cleanup() = 0;
+
+    std::string test_name_;
+};
+
+// Simple kernel execution helper
+class KernelRunner {
+public:
+    KernelRunner(const std::string& kernel_name,
+                 dim3 grid_size,
+                 dim3 block_size)
+        : kernel_name_(kernel_name)
+        , grid_size_(grid_size)
+        , block_size_(block_size) {}
+
+    void printConfig() const {
+        std::cout << "Kernel: " << kernel_name_ << std::endl;
+        std::cout << "  Grid size:  (" << grid_size_.x << ", "
+                  << grid_size_.y << ", " << grid_size_.z << ")" << std::endl;
+        std::cout << "  Block size: (" << block_size_.x << ", "
+                  << block_size_.y << ", " << block_size_.z << ")" << std::endl;
+
+        size_t total_threads = static_cast<size_t>(grid_size_.x) * grid_size_.y * grid_size_.z *
+                               block_size_.x * block_size_.y * block_size_.z;
+        std::cout << "  Total threads: " << total_threads << std::endl;
+    }
+
+    template<typename KernelFunc, typename... Args>
+    void launch(KernelFunc kernel, Args... args) {
+        printConfig();
+
+        hipLaunchKernelGGL(kernel, grid_size_, block_size_, 0, 0, args...);
+        HIP_CHECK_LAST();
+        HIP_CHECK(hipDeviceSynchronize());
+
+        std::cout << "Kernel execution completed successfully" << std::endl;
+    }
+
+private:
+    std::string kernel_name_;
+    dim3 grid_size_;
+    dim3 block_size_;
+};
+
+// Helper to verify results
+template<typename T>
+bool verifyResults(const T* results, size_t count, T expected, const std::string& name) {
+    bool success = true;
+    size_t errors = 0;
+    const size_t max_errors_to_print = 10;
+
+    for (size_t i = 0; i < count; i++) {
+        if (results[i] != expected) {
+            if (errors < max_errors_to_print) {
+                std::cerr << "Verification error in " << name
+                          << " at index " << i << ": expected "
+                          << expected << ", got " << results[i] << std::endl;
+            }
+            errors++;
+            success = false;
+        }
+    }
+
+    if (errors > 0) {
+        std::cerr << "Total verification errors: " << errors << " out of " << count << std::endl;
+    } else {
+        std::cout << "Verification passed for " << name << " (" << count << " elements)" << std::endl;
+    }
+
+    return success;
+}
+
+} // namespace test_framework
+
+#endif // TEST_FRAMEWORK_HPP

--- a/projects/perf-dkms/test_apps/flat_memory/CMakeLists.txt
+++ b/projects/perf-dkms/test_apps/flat_memory/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+project(flat_memory_test)
+
+set_source_files_properties(flat_memory.cpp PROPERTIES LANGUAGE HIP)
+add_executable(flat_memory flat_memory.cpp)
+target_link_libraries(flat_memory PRIVATE test_common)
+set_target_properties(flat_memory PROPERTIES
+    HIP_STANDARD 17
+    HIP_STANDARD_REQUIRED ON
+)

--- a/projects/perf-dkms/test_apps/flat_memory/flat_memory.cpp
+++ b/projects/perf-dkms/test_apps/flat_memory/flat_memory.cpp
@@ -7,7 +7,8 @@ __global__ void flat_memory_kernel(float* output, float* input, int use_flat) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
 
     // Use FLAT addressing by going through generic pointer
-    float* generic_ptr = use_flat ? input : input;
+    // Cast through void* to force FLAT addressing instead of buffer operations
+    float* generic_ptr = use_flat ? (float*)((void*)input) : input;
     float val = generic_ptr[idx];
 
     // Multiple FLAT operations

--- a/projects/perf-dkms/test_apps/flat_memory/flat_memory.cpp
+++ b/projects/perf-dkms/test_apps/flat_memory/flat_memory.cpp
@@ -1,0 +1,68 @@
+#include "test_framework.hpp"
+#include <vector>
+
+// FLAT memory addressing (generic pointers)
+// Targets SQ_INSTS_FLAT counter
+__global__ void flat_memory_kernel(float* output, float* input, int use_flat) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    // Use FLAT addressing by going through generic pointer
+    float* generic_ptr = use_flat ? input : input;
+    float val = generic_ptr[idx];
+
+    // Multiple FLAT operations
+    for (int i = 0; i < 100; i++) {
+        // FLAT load
+        float tmp = generic_ptr[(idx + i) % (blockDim.x * gridDim.x)];
+        val = val * 0.99f + tmp * 0.01f;
+
+        // FLAT store
+        generic_ptr[idx] = val;
+    }
+
+    output[idx] = val;
+}
+
+class FlatMemoryTest : public test_framework::TestBase {
+public:
+    FlatMemoryTest() : TestBase("FLAT Memory - Generic Pointer Operations") {}
+
+    bool setup() override {
+        size_ = 1024 * 1024;  // 1M elements
+
+        // Allocate device memory
+        d_input_ = hip_utils::allocateDeviceWithValue<float>(size_, 1.0f);
+        d_output_ = hip_utils::allocateDevice<float>(size_);
+
+        std::cout << "  Array size: " << size_ << " elements" << std::endl;
+        std::cout << "  FLAT operations per thread: 200 (100 loads + 100 stores)" << std::endl;
+        std::cout << "  Total FLAT operations: " << (size_ * 200) << std::endl;
+
+        return true;
+    }
+
+    bool execute() override {
+        dim3 block_size(256);
+        dim3 grid_size((size_ + block_size.x - 1) / block_size.x);
+
+        test_framework::KernelRunner runner("flat_memory_kernel", grid_size, block_size);
+        runner.launch(flat_memory_kernel, d_output_, d_input_, 1);
+
+        return true;
+    }
+
+    void cleanup() override {
+        hip_utils::freeDevice(d_input_);
+        hip_utils::freeDevice(d_output_);
+    }
+
+private:
+    float* d_input_ = nullptr;
+    float* d_output_ = nullptr;
+    size_t size_;
+};
+
+int main() {
+    FlatMemoryTest test;
+    return test.run();
+}

--- a/projects/perf-dkms/test_apps/lds_basic/CMakeLists.txt
+++ b/projects/perf-dkms/test_apps/lds_basic/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+project(lds_basic_test)
+
+set_source_files_properties(lds_basic.cpp PROPERTIES LANGUAGE HIP)
+add_executable(lds_basic lds_basic.cpp)
+target_link_libraries(lds_basic PRIVATE test_common)
+set_target_properties(lds_basic PROPERTIES
+    HIP_STANDARD 17
+    HIP_STANDARD_REQUIRED ON
+)

--- a/projects/perf-dkms/test_apps/lds_basic/lds_basic.cpp
+++ b/projects/perf-dkms/test_apps/lds_basic/lds_basic.cpp
@@ -1,0 +1,72 @@
+#include "test_framework.hpp"
+#include <vector>
+
+// Basic LDS operations without conflicts
+// Targets SQ_LDS_* counters
+__global__ void lds_basic_kernel(float* output, const float* input) {
+    __shared__ float shared_mem[256];
+
+    int tid = threadIdx.x;
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    // Sequential LDS write (no bank conflicts)
+    shared_mem[tid] = input[gid];
+    __syncthreads();
+
+    // Sequential LDS read (no bank conflicts)
+    float val = shared_mem[tid];
+
+    // Some computation
+    val = val * 2.0f + 1.0f;
+
+    // Another round of LDS operations
+    shared_mem[tid] = val;
+    __syncthreads();
+
+    val = shared_mem[tid];
+
+    output[gid] = val;
+}
+
+class LDSBasicTest : public test_framework::TestBase {
+public:
+    LDSBasicTest() : TestBase("LDS Basic - Sequential Access") {}
+
+    bool setup() override {
+        size_ = 256 * 1024;  // 256K elements (1024 blocks * 256 threads)
+
+        // Allocate device memory
+        d_input_ = hip_utils::allocateDeviceWithValue<float>(size_, 1.0f);
+        d_output_ = hip_utils::allocateDevice<float>(size_);
+
+        std::cout << "  Array size: " << size_ << " elements" << std::endl;
+        std::cout << "  LDS size per block: 256 floats (1 KB)" << std::endl;
+
+        return true;
+    }
+
+    bool execute() override {
+        dim3 block_size(256);
+        dim3 grid_size(size_ / block_size.x);
+
+        test_framework::KernelRunner runner("lds_basic_kernel", grid_size, block_size);
+        runner.launch(lds_basic_kernel, d_output_, d_input_);
+
+        return true;
+    }
+
+    void cleanup() override {
+        hip_utils::freeDevice(d_input_);
+        hip_utils::freeDevice(d_output_);
+    }
+
+private:
+    float* d_input_ = nullptr;
+    float* d_output_ = nullptr;
+    size_t size_;
+};
+
+int main() {
+    LDSBasicTest test;
+    return test.run();
+}

--- a/projects/perf-dkms/test_apps/lds_conflicts/CMakeLists.txt
+++ b/projects/perf-dkms/test_apps/lds_conflicts/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+project(lds_conflicts_test)
+
+set_source_files_properties(lds_conflicts.cpp PROPERTIES LANGUAGE HIP)
+add_executable(lds_conflicts lds_conflicts.cpp)
+target_link_libraries(lds_conflicts PRIVATE test_common)
+set_target_properties(lds_conflicts PROPERTIES
+    HIP_STANDARD 17
+    HIP_STANDARD_REQUIRED ON
+)

--- a/projects/perf-dkms/test_apps/lds_conflicts/lds_conflicts.cpp
+++ b/projects/perf-dkms/test_apps/lds_conflicts/lds_conflicts.cpp
@@ -1,0 +1,78 @@
+#include "test_framework.hpp"
+#include <vector>
+
+// LDS bank conflict test - stride-32 access pattern
+// Targets SQ_LDS_BANK_CONFLICT counter
+__global__ void lds_conflicts_kernel(float* output, const float* input) {
+    __shared__ float shared_mem[1024];
+
+    int tid = threadIdx.x;
+    int gid = blockIdx.x * blockDim.x + threadIdx.x;
+
+    // Write with stride to cause bank conflicts
+    // On AMD GPUs, LDS has 32 banks
+    int write_idx = (tid * 32) % 1024;
+    shared_mem[write_idx] = input[gid];
+    __syncthreads();
+
+    // Read with stride to cause bank conflicts
+    int read_idx = (tid * 32 + 1) % 1024;
+    float val = shared_mem[read_idx];
+
+    // Multiple rounds of conflicting access
+    for (int i = 0; i < 10; i++) {
+        write_idx = ((tid + i) * 32) % 1024;
+        shared_mem[write_idx] = val * 1.01f;
+        __syncthreads();
+
+        read_idx = ((tid + i + 1) * 32) % 1024;
+        val = shared_mem[read_idx];
+        __syncthreads();
+    }
+
+    output[gid] = val;
+}
+
+class LDSConflictsTest : public test_framework::TestBase {
+public:
+    LDSConflictsTest() : TestBase("LDS Conflicts - Bank Conflicts") {}
+
+    bool setup() override {
+        size_ = 256 * 1024;  // 256K elements
+
+        // Allocate device memory
+        d_input_ = hip_utils::allocateDeviceWithValue<float>(size_, 1.0f);
+        d_output_ = hip_utils::allocateDevice<float>(size_);
+
+        std::cout << "  Array size: " << size_ << " elements" << std::endl;
+        std::cout << "  LDS size per block: 1024 floats (4 KB)" << std::endl;
+        std::cout << "  Access pattern: stride-32 (causes bank conflicts)" << std::endl;
+
+        return true;
+    }
+
+    bool execute() override {
+        dim3 block_size(256);
+        dim3 grid_size(size_ / block_size.x);
+
+        test_framework::KernelRunner runner("lds_conflicts_kernel", grid_size, block_size);
+        runner.launch(lds_conflicts_kernel, d_output_, d_input_);
+
+        return true;
+    }
+
+    void cleanup() override {
+        hip_utils::freeDevice(d_input_);
+        hip_utils::freeDevice(d_output_);
+    }
+
+private:
+    float* d_input_ = nullptr;
+    float* d_output_ = nullptr;
+    size_t size_;
+};
+
+int main() {
+    LDSConflictsTest test;
+    return test.run();
+}

--- a/projects/perf-dkms/test_apps/mem_sizes/CMakeLists.txt
+++ b/projects/perf-dkms/test_apps/mem_sizes/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+project(mem_sizes_test)
+
+set_source_files_properties(mem_sizes.cpp PROPERTIES LANGUAGE HIP)
+add_executable(mem_sizes mem_sizes.cpp)
+target_link_libraries(mem_sizes PRIVATE test_common)
+set_target_properties(mem_sizes PROPERTIES
+    HIP_STANDARD 17
+    HIP_STANDARD_REQUIRED ON
+)

--- a/projects/perf-dkms/test_apps/mem_sizes/mem_sizes.cpp
+++ b/projects/perf-dkms/test_apps/mem_sizes/mem_sizes.cpp
@@ -1,0 +1,100 @@
+#include "test_framework.hpp"
+#include <vector>
+
+// Test various memory transaction sizes (32B, 64B, 128B)
+// Targets GL2C transaction counters
+__global__ void mem_sizes_32b_kernel(int* output, const int* input) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    // 32-byte transactions (8 x 4-byte ints)
+    int val = input[idx];
+    output[idx] = val + 1;
+}
+
+__global__ void mem_sizes_64b_kernel(int2* output, const int2* input) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    // 64-byte transactions (8 x 8-byte int2)
+    int2 val = input[idx];
+    val.x += 1;
+    val.y += 1;
+    output[idx] = val;
+}
+
+__global__ void mem_sizes_128b_kernel(int4* output, const int4* input) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    // 128-byte transactions (8 x 16-byte int4)
+    int4 val = input[idx];
+    val.x += 1;
+    val.y += 1;
+    val.z += 1;
+    val.w += 1;
+    output[idx] = val;
+}
+
+class MemSizesTest : public test_framework::TestBase {
+public:
+    MemSizesTest() : TestBase("Memory Sizes - 32B/64B/128B Transactions") {}
+
+    bool setup() override {
+        size_ = 1024 * 1024;  // 1M elements
+
+        // Allocate for different sizes
+        d_input_32_ = hip_utils::allocateDeviceWithValue<int>(size_, 1);
+        d_output_32_ = hip_utils::allocateDevice<int>(size_);
+
+        d_input_64_ = hip_utils::allocateDeviceWithValue<int2>(size_, make_int2(1, 1));
+        d_output_64_ = hip_utils::allocateDevice<int2>(size_);
+
+        d_input_128_ = hip_utils::allocateDeviceWithValue<int4>(size_, make_int4(1, 1, 1, 1));
+        d_output_128_ = hip_utils::allocateDevice<int4>(size_);
+
+        std::cout << "  Array size: " << size_ << " elements" << std::endl;
+        std::cout << "  Testing 32-byte, 64-byte, and 128-byte transactions" << std::endl;
+
+        return true;
+    }
+
+    bool execute() override {
+        dim3 block_size(256);
+        dim3 grid_size((size_ + block_size.x - 1) / block_size.x);
+
+        // Test 32-byte transactions
+        std::cout << "  Running 32-byte transaction test..." << std::endl;
+        test_framework::KernelRunner runner32("mem_sizes_32b_kernel", grid_size, block_size);
+        runner32.launch(mem_sizes_32b_kernel, d_output_32_, d_input_32_);
+
+        // Test 64-byte transactions
+        std::cout << "  Running 64-byte transaction test..." << std::endl;
+        test_framework::KernelRunner runner64("mem_sizes_64b_kernel", grid_size, block_size);
+        runner64.launch(mem_sizes_64b_kernel, d_output_64_, d_input_64_);
+
+        // Test 128-byte transactions
+        std::cout << "  Running 128-byte transaction test..." << std::endl;
+        test_framework::KernelRunner runner128("mem_sizes_128b_kernel", grid_size, block_size);
+        runner128.launch(mem_sizes_128b_kernel, d_output_128_, d_input_128_);
+
+        return true;
+    }
+
+    void cleanup() override {
+        hip_utils::freeDevice(d_input_32_);
+        hip_utils::freeDevice(d_output_32_);
+        hip_utils::freeDevice(d_input_64_);
+        hip_utils::freeDevice(d_output_64_);
+        hip_utils::freeDevice(d_input_128_);
+        hip_utils::freeDevice(d_output_128_);
+    }
+
+private:
+    int* d_input_32_ = nullptr;
+    int* d_output_32_ = nullptr;
+    int2* d_input_64_ = nullptr;
+    int2* d_output_64_ = nullptr;
+    int4* d_input_128_ = nullptr;
+    int4* d_output_128_ = nullptr;
+    size_t size_;
+};
+
+int main() {
+    MemSizesTest test;
+    return test.run();
+}

--- a/projects/perf-dkms/test_apps/run_all_tests.sh
+++ b/projects/perf-dkms/test_apps/run_all_tests.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+# Script to run all perf-dkms test applications
+# This runs each test sequentially and reports results
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Get the directory where the script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/build"
+
+# Check if build directory exists
+if [ ! -d "${BUILD_DIR}" ]; then
+    echo -e "${RED}Error: Build directory not found at ${BUILD_DIR}${NC}"
+    echo "Please build the tests first:"
+    echo "  cd ${SCRIPT_DIR}"
+    echo "  mkdir build && cd build"
+    echo "  cmake .."
+    echo "  make"
+    exit 1
+fi
+
+# List of all test executables
+TESTS=(
+    "valu_heavy/valu_heavy"
+    "salu_heavy/salu_heavy"
+    "lds_basic/lds_basic"
+    "lds_conflicts/lds_conflicts"
+    "smem/smem"
+    "buffer_read/buffer_read"
+    "buffer_write/buffer_write"
+    "flat_memory/flat_memory"
+    "mem_sizes/mem_sizes"
+    "cache_hit/cache_hit"
+    "cache_miss/cache_miss"
+    "wave_modes/wave_modes"
+    "waits_stalls/waits_stalls"
+    "basic_activity/basic_activity"
+)
+
+# Test descriptions
+declare -A TEST_DESCRIPTIONS=(
+    ["valu_heavy"]="VALU Heavy - FMA Operations"
+    ["salu_heavy"]="SALU Heavy - Scalar Operations"
+    ["lds_basic"]="LDS Basic - Sequential Access"
+    ["lds_conflicts"]="LDS Conflicts - Bank Conflicts"
+    ["smem"]="SMEM - Scalar Memory (Constant Memory)"
+    ["buffer_read"]="Buffer Read - Coalesced Memory Reads"
+    ["buffer_write"]="Buffer Write - Coalesced Memory Writes"
+    ["flat_memory"]="FLAT Memory - Generic Pointer Operations"
+    ["mem_sizes"]="Memory Sizes - 32B/64B/128B Transactions"
+    ["cache_hit"]="Cache Hit - L2 Cache Hits"
+    ["cache_miss"]="Cache Miss - L2 Cache Misses"
+    ["wave_modes"]="Wave Modes - Wave32/Wave64 Operations"
+    ["waits_stalls"]="Waits/Stalls - Memory Dependencies"
+    ["basic_activity"]="Basic Activity - Baseline GPU Activity"
+)
+
+# Counters
+TOTAL_TESTS=${#TESTS[@]}
+PASSED_TESTS=0
+FAILED_TESTS=0
+declare -a FAILED_TEST_NAMES
+
+echo -e "${BLUE}================================================================================${NC}"
+echo -e "${BLUE}  AMD GPU Performance Counter Test Suite${NC}"
+echo -e "${BLUE}================================================================================${NC}"
+echo ""
+echo "Running ${TOTAL_TESTS} tests from: ${BUILD_DIR}"
+echo ""
+
+# Run each test
+TEST_NUM=1
+for TEST_PATH in "${TESTS[@]}"; do
+    TEST_EXECUTABLE="${BUILD_DIR}/${TEST_PATH}"
+    TEST_NAME=$(basename "${TEST_PATH}")
+    TEST_DESC="${TEST_DESCRIPTIONS[${TEST_NAME}]}"
+
+    echo -e "${BLUE}[${TEST_NUM}/${TOTAL_TESTS}]${NC} Running: ${YELLOW}${TEST_NAME}${NC}"
+    echo -e "      Description: ${TEST_DESC}"
+
+    if [ ! -f "${TEST_EXECUTABLE}" ]; then
+        echo -e "${RED}      ERROR: Executable not found: ${TEST_EXECUTABLE}${NC}"
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+        FAILED_TEST_NAMES+=("${TEST_NAME} (not found)")
+        echo ""
+        TEST_NUM=$((TEST_NUM + 1))
+        continue
+    fi
+
+    # Run the test
+    if "${TEST_EXECUTABLE}" > /dev/null 2>&1; then
+        echo -e "${GREEN}      PASSED${NC}"
+        PASSED_TESTS=$((PASSED_TESTS + 1))
+    else
+        EXIT_CODE=$?
+        echo -e "${RED}      FAILED (exit code: ${EXIT_CODE})${NC}"
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+        FAILED_TEST_NAMES+=("${TEST_NAME}")
+    fi
+
+    echo ""
+    TEST_NUM=$((TEST_NUM + 1))
+done
+
+# Print summary
+echo -e "${BLUE}================================================================================${NC}"
+echo -e "${BLUE}  Test Summary${NC}"
+echo -e "${BLUE}================================================================================${NC}"
+echo ""
+echo "Total tests:  ${TOTAL_TESTS}"
+echo -e "Passed:       ${GREEN}${PASSED_TESTS}${NC}"
+echo -e "Failed:       ${RED}${FAILED_TESTS}${NC}"
+echo ""
+
+if [ ${FAILED_TESTS} -gt 0 ]; then
+    echo -e "${RED}Failed tests:${NC}"
+    for FAILED_TEST in "${FAILED_TEST_NAMES[@]}"; do
+        echo "  - ${FAILED_TEST}"
+    done
+    echo ""
+    echo -e "${RED}Some tests failed!${NC}"
+    exit 1
+else
+    echo -e "${GREEN}All tests passed successfully!${NC}"
+    exit 0
+fi

--- a/projects/perf-dkms/test_apps/salu_heavy/CMakeLists.txt
+++ b/projects/perf-dkms/test_apps/salu_heavy/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+project(salu_heavy_test)
+
+set_source_files_properties(salu_heavy.cpp PROPERTIES LANGUAGE HIP)
+add_executable(salu_heavy salu_heavy.cpp)
+target_link_libraries(salu_heavy PRIVATE test_common)
+set_target_properties(salu_heavy PROPERTIES
+    HIP_STANDARD 17
+    HIP_STANDARD_REQUIRED ON
+)

--- a/projects/perf-dkms/test_apps/salu_heavy/salu_heavy.cpp
+++ b/projects/perf-dkms/test_apps/salu_heavy/salu_heavy.cpp
@@ -1,0 +1,77 @@
+#include "test_framework.hpp"
+#include <vector>
+
+// SALU-heavy kernel: Scalar operations
+// Targets SQ_INSTS_SALU counter
+__global__ void salu_heavy_kernel(int* output, const int* input, int iterations) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    // Scalar operations using __lane_id() and wave-uniform values
+    int lane = __lane_id();
+    int scalar_val = blockIdx.x;  // Scalar uniform across wavefront
+
+    int result = input[idx];
+
+    // Perform many scalar operations
+    #pragma unroll 4
+    for (int i = 0; i < iterations; i++) {
+        // Scalar ALU operations
+        scalar_val = scalar_val + 1;
+        scalar_val = scalar_val << 1;
+        scalar_val = scalar_val ^ 0xABCD;
+        scalar_val = scalar_val >> 1;
+        scalar_val = scalar_val & 0xFFFF;
+        scalar_val = scalar_val | 0x1000;
+
+        // Use scalar value with vector
+        result += scalar_val;
+    }
+
+    output[idx] = result + lane;
+}
+
+class SALUHeavyTest : public test_framework::TestBase {
+public:
+    SALUHeavyTest() : TestBase("SALU Heavy - Scalar Operations") {}
+
+    bool setup() override {
+        size_ = 1024 * 1024;  // 1M elements
+        iterations_ = 1000;
+
+        // Allocate device memory
+        d_input_ = hip_utils::allocateDeviceWithValue<int>(size_, 1);
+        d_output_ = hip_utils::allocateDevice<int>(size_);
+
+        std::cout << "  Array size: " << size_ << " elements" << std::endl;
+        std::cout << "  Iterations per thread: " << iterations_ << std::endl;
+        std::cout << "  Total SALU operations: " << (size_ * iterations_ * 6) << std::endl;
+
+        return true;
+    }
+
+    bool execute() override {
+        dim3 block_size(256);
+        dim3 grid_size((size_ + block_size.x - 1) / block_size.x);
+
+        test_framework::KernelRunner runner("salu_heavy_kernel", grid_size, block_size);
+        runner.launch(salu_heavy_kernel, d_output_, d_input_, iterations_);
+
+        return true;
+    }
+
+    void cleanup() override {
+        hip_utils::freeDevice(d_input_);
+        hip_utils::freeDevice(d_output_);
+    }
+
+private:
+    int* d_input_ = nullptr;
+    int* d_output_ = nullptr;
+    size_t size_;
+    int iterations_;
+};
+
+int main() {
+    SALUHeavyTest test;
+    return test.run();
+}

--- a/projects/perf-dkms/test_apps/smem/CMakeLists.txt
+++ b/projects/perf-dkms/test_apps/smem/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+project(smem_test)
+
+set_source_files_properties(smem.cpp PROPERTIES LANGUAGE HIP)
+add_executable(smem smem.cpp)
+target_link_libraries(smem PRIVATE test_common)
+set_target_properties(smem PROPERTIES
+    HIP_STANDARD 17
+    HIP_STANDARD_REQUIRED ON
+)

--- a/projects/perf-dkms/test_apps/smem/smem.cpp
+++ b/projects/perf-dkms/test_apps/smem/smem.cpp
@@ -1,0 +1,75 @@
+#include "test_framework.hpp"
+#include <vector>
+
+// Constant memory for scalar memory operations
+__constant__ float const_data[1024];
+
+// Scalar memory operations - constant memory reads
+// Targets SQ_INSTS_SMEM counter
+__global__ void smem_kernel(float* output, const float* input) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    float val = input[idx];
+
+    // Multiple scalar memory reads from constant memory
+    #pragma unroll 8
+    for (int i = 0; i < 100; i++) {
+        int const_idx = (idx + i) % 1024;
+        val += const_data[const_idx];
+        val *= const_data[(const_idx + 1) % 1024];
+    }
+
+    output[idx] = val;
+}
+
+class SMEMTest : public test_framework::TestBase {
+public:
+    SMEMTest() : TestBase("SMEM - Scalar Memory (Constant Memory)") {}
+
+    bool setup() override {
+        size_ = 1024 * 1024;  // 1M elements
+
+        // Initialize constant memory
+        std::vector<float> h_const(1024);
+        for (int i = 0; i < 1024; i++) {
+            h_const[i] = 1.0f + i * 0.001f;
+        }
+        HIP_CHECK(hipMemcpyToSymbol(const_data, h_const.data(),
+                                     1024 * sizeof(float), 0, hipMemcpyHostToDevice));
+
+        // Allocate device memory
+        d_input_ = hip_utils::allocateDeviceWithValue<float>(size_, 1.0f);
+        d_output_ = hip_utils::allocateDevice<float>(size_);
+
+        std::cout << "  Array size: " << size_ << " elements" << std::endl;
+        std::cout << "  Constant memory size: 1024 floats" << std::endl;
+        std::cout << "  Scalar memory reads per thread: 200" << std::endl;
+
+        return true;
+    }
+
+    bool execute() override {
+        dim3 block_size(256);
+        dim3 grid_size((size_ + block_size.x - 1) / block_size.x);
+
+        test_framework::KernelRunner runner("smem_kernel", grid_size, block_size);
+        runner.launch(smem_kernel, d_output_, d_input_);
+
+        return true;
+    }
+
+    void cleanup() override {
+        hip_utils::freeDevice(d_input_);
+        hip_utils::freeDevice(d_output_);
+    }
+
+private:
+    float* d_input_ = nullptr;
+    float* d_output_ = nullptr;
+    size_t size_;
+};
+
+int main() {
+    SMEMTest test;
+    return test.run();
+}

--- a/projects/perf-dkms/test_apps/valu_heavy/CMakeLists.txt
+++ b/projects/perf-dkms/test_apps/valu_heavy/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+project(valu_heavy_test)
+
+set_source_files_properties(valu_heavy.cpp PROPERTIES LANGUAGE HIP)
+add_executable(valu_heavy valu_heavy.cpp)
+target_link_libraries(valu_heavy PRIVATE test_common)
+set_target_properties(valu_heavy PROPERTIES
+    HIP_STANDARD 17
+    HIP_STANDARD_REQUIRED ON
+)

--- a/projects/perf-dkms/test_apps/valu_heavy/valu_heavy.cpp
+++ b/projects/perf-dkms/test_apps/valu_heavy/valu_heavy.cpp
@@ -1,0 +1,69 @@
+#include "test_framework.hpp"
+#include <vector>
+
+// VALU-heavy kernel: FMA (Fused Multiply-Add) operations
+// Targets SQ_INSTS_VALU counter
+__global__ void valu_heavy_kernel(float* output, const float* input, int iterations) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    float a = input[idx];
+    float b = 1.00001f;
+    float c = 0.99999f;
+
+    // Perform many VALU operations (FMA)
+    #pragma unroll 8
+    for (int i = 0; i < iterations; i++) {
+        a = a * b + c;      // FMA
+        a = a * c + b;      // FMA
+        a = a * b + c;      // FMA
+        a = a * c + b;      // FMA
+    }
+
+    output[idx] = a;
+}
+
+class VALUHeavyTest : public test_framework::TestBase {
+public:
+    VALUHeavyTest() : TestBase("VALU Heavy - FMA Operations") {}
+
+    bool setup() override {
+        size_ = 1024 * 1024;  // 1M elements
+        iterations_ = 1000;
+
+        // Allocate device memory
+        d_input_ = hip_utils::allocateDeviceWithValue<float>(size_, 1.0f);
+        d_output_ = hip_utils::allocateDevice<float>(size_);
+
+        std::cout << "  Array size: " << size_ << " elements" << std::endl;
+        std::cout << "  Iterations per thread: " << iterations_ << std::endl;
+        std::cout << "  Total VALU operations: " << (size_ * iterations_ * 4) << std::endl;
+
+        return true;
+    }
+
+    bool execute() override {
+        dim3 block_size(256);
+        dim3 grid_size((size_ + block_size.x - 1) / block_size.x);
+
+        test_framework::KernelRunner runner("valu_heavy_kernel", grid_size, block_size);
+        runner.launch(valu_heavy_kernel, d_output_, d_input_, iterations_);
+
+        return true;
+    }
+
+    void cleanup() override {
+        hip_utils::freeDevice(d_input_);
+        hip_utils::freeDevice(d_output_);
+    }
+
+private:
+    float* d_input_ = nullptr;
+    float* d_output_ = nullptr;
+    size_t size_;
+    int iterations_;
+};
+
+int main() {
+    VALUHeavyTest test;
+    return test.run();
+}

--- a/projects/perf-dkms/test_apps/waits_stalls/CMakeLists.txt
+++ b/projects/perf-dkms/test_apps/waits_stalls/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+project(waits_stalls_test)
+
+set_source_files_properties(waits_stalls.cpp PROPERTIES LANGUAGE HIP)
+add_executable(waits_stalls waits_stalls.cpp)
+target_link_libraries(waits_stalls PRIVATE test_common)
+set_target_properties(waits_stalls PROPERTIES
+    HIP_STANDARD 17
+    HIP_STANDARD_REQUIRED ON
+)

--- a/projects/perf-dkms/test_apps/waits_stalls/waits_stalls.cpp
+++ b/projects/perf-dkms/test_apps/waits_stalls/waits_stalls.cpp
@@ -1,0 +1,79 @@
+#include "test_framework.hpp"
+#include <vector>
+
+// Kernel designed to create memory wait states and stalls
+// Targets GRBM_* wait/stall counters
+__global__ void waits_stalls_kernel(float* output, const float* input, int iterations) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    float val = 0.0f;
+
+    // Create memory dependencies that cause stalls
+    for (int i = 0; i < iterations; i++) {
+        // Read that creates dependency
+        float temp = input[(idx + i) % (blockDim.x * gridDim.x)];
+
+        // Immediate use creates stall waiting for memory
+        val = temp * temp + temp;
+
+        // Another dependent read
+        temp = input[(idx + (int)(val * 13)) % (blockDim.x * gridDim.x)];
+
+        // More dependency
+        val = val + temp;
+
+        // Write that depends on previous operations
+        output[idx] = val;
+
+        // Sync to create more stalls
+        __syncthreads();
+    }
+
+    output[idx] = val;
+}
+
+class WaitsStallsTest : public test_framework::TestBase {
+public:
+    WaitsStallsTest() : TestBase("Waits/Stalls - Memory Dependencies") {}
+
+    bool setup() override {
+        size_ = 256 * 1024;  // 256K elements
+        iterations_ = 100;
+
+        // Allocate device memory
+        d_input_ = hip_utils::allocateDeviceWithValue<float>(size_, 1.0f);
+        d_output_ = hip_utils::allocateDevice<float>(size_);
+
+        std::cout << "  Array size: " << size_ << " elements" << std::endl;
+        std::cout << "  Iterations: " << iterations_ << std::endl;
+        std::cout << "  Expected behavior: Memory wait states and stalls" << std::endl;
+
+        return true;
+    }
+
+    bool execute() override {
+        dim3 block_size(256);
+        dim3 grid_size((size_ + block_size.x - 1) / block_size.x);
+
+        test_framework::KernelRunner runner("waits_stalls_kernel", grid_size, block_size);
+        runner.launch(waits_stalls_kernel, d_output_, d_input_, iterations_);
+
+        return true;
+    }
+
+    void cleanup() override {
+        hip_utils::freeDevice(d_input_);
+        hip_utils::freeDevice(d_output_);
+    }
+
+private:
+    float* d_input_ = nullptr;
+    float* d_output_ = nullptr;
+    size_t size_;
+    int iterations_;
+};
+
+int main() {
+    WaitsStallsTest test;
+    return test.run();
+}

--- a/projects/perf-dkms/test_apps/wave_modes/CMakeLists.txt
+++ b/projects/perf-dkms/test_apps/wave_modes/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+project(wave_modes_test)
+
+set_source_files_properties(wave_modes.cpp PROPERTIES LANGUAGE HIP)
+add_executable(wave_modes wave_modes.cpp)
+target_link_libraries(wave_modes PRIVATE test_common)
+set_target_properties(wave_modes PROPERTIES
+    HIP_STANDARD 17
+    HIP_STANDARD_REQUIRED ON
+)

--- a/projects/perf-dkms/test_apps/wave_modes/wave_modes.cpp
+++ b/projects/perf-dkms/test_apps/wave_modes/wave_modes.cpp
@@ -1,7 +1,7 @@
 #include "test_framework.hpp"
 #include <vector>
 
-// Wave32 kernel - compile with -mwavefrontsize64 or wave32
+// Wave32 kernel - compile with -mwavefrontsize32 for wave32 mode
 __global__ void wave32_kernel(float* output, const float* input) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
 

--- a/projects/perf-dkms/test_apps/wave_modes/wave_modes.cpp
+++ b/projects/perf-dkms/test_apps/wave_modes/wave_modes.cpp
@@ -1,0 +1,102 @@
+#include "test_framework.hpp"
+#include <vector>
+
+// Wave32 kernel - compile with -mwavefrontsize64 or wave32
+__global__ void wave32_kernel(float* output, const float* input) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    float val = input[idx];
+
+    // Wave-level operations
+    int lane = __lane_id();
+
+    // Wave shuffle operations (different behavior in wave32 vs wave64)
+    #pragma unroll 4
+    for (int i = 0; i < 100; i++) {
+        val += __shfl_xor(val, 1);
+        val += __shfl_xor(val, 2);
+        val += __shfl_xor(val, 4);
+        val += __shfl_xor(val, 8);
+    }
+
+    output[idx] = val + lane;
+}
+
+// Wave64 kernel
+__global__ void wave64_kernel(float* output, const float* input) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    float val = input[idx];
+
+    int lane = __lane_id();
+
+    // Wave shuffle operations
+    #pragma unroll 4
+    for (int i = 0; i < 100; i++) {
+        val += __shfl_xor(val, 1);
+        val += __shfl_xor(val, 2);
+        val += __shfl_xor(val, 4);
+        val += __shfl_xor(val, 8);
+        val += __shfl_xor(val, 16);
+        val += __shfl_xor(val, 32);
+    }
+
+    output[idx] = val + lane;
+}
+
+class WaveModesTest : public test_framework::TestBase {
+public:
+    WaveModesTest() : TestBase("Wave Modes - Wave32/Wave64 Operations") {}
+
+    bool setup() override {
+        size_ = 1024 * 1024;  // 1M elements
+
+        // Allocate device memory
+        d_input_ = hip_utils::allocateDeviceWithValue<float>(size_, 1.0f);
+        d_output_ = hip_utils::allocateDevice<float>(size_);
+
+        // Get device properties to determine native wave size
+        int device;
+        HIP_CHECK(hipGetDevice(&device));
+        hipDeviceProp_t prop;
+        HIP_CHECK(hipGetDeviceProperties(&prop, device));
+
+        std::cout << "  Array size: " << size_ << " elements" << std::endl;
+        std::cout << "  Native warp size: " << prop.warpSize << std::endl;
+        std::cout << "  Testing wave shuffle operations" << std::endl;
+
+        return true;
+    }
+
+    bool execute() override {
+        dim3 block_size(256);
+        dim3 grid_size((size_ + block_size.x - 1) / block_size.x);
+
+        // Test with wave32-style kernel
+        std::cout << "  Running wave32-style kernel..." << std::endl;
+        test_framework::KernelRunner runner32("wave32_kernel", grid_size, block_size);
+        runner32.launch(wave32_kernel, d_output_, d_input_);
+
+        // Test with wave64-style kernel
+        std::cout << "  Running wave64-style kernel..." << std::endl;
+        test_framework::KernelRunner runner64("wave64_kernel", grid_size, block_size);
+        runner64.launch(wave64_kernel, d_output_, d_input_);
+
+        return true;
+    }
+
+    void cleanup() override {
+        hip_utils::freeDevice(d_input_);
+        hip_utils::freeDevice(d_output_);
+    }
+
+private:
+    float* d_input_ = nullptr;
+    float* d_output_ = nullptr;
+    size_t size_;
+};
+
+int main() {
+    WaveModesTest test;
+    return test.run();
+}


### PR DESCRIPTION
## Summary

This PR introduces a complete test suite for validating AMD GPU performance counters exposed by the perf-dkms driver. The suite consists of 14 HIP-based applications that target specific hardware blocks and counter behaviors.

## Motivation

The perf-dkms driver exposes 35 performance counters for GFX12 across multiple hardware blocks (GL2C, SQ, TA, GRBM). To ensure these counters are functioning correctly, we need test applications that exercise specific GPU behaviors in predictable, measurable ways.

## Test Applications

The suite includes 14 tests covering all counter categories:

### Compute & Instruction Counters
- **valu_heavy**: FMA-intensive VALU operations
- **salu_heavy**: Scalar ALU operations  
- **wave_modes**: Wave32/Wave64 execution patterns

### Memory Subsystem
- **buffer_read**: Coalesced buffer read operations
- **buffer_write**: Coalesced buffer write operations
- **flat_memory**: FLAT addressing (generic pointers)
- **mem_sizes**: Transaction size validation (32B/64B/128B)

### Cache Behavior
- **cache_hit**: Small working set for high L2 hit rate
- **cache_miss**: Large streaming access for misses

### Local Data Share (LDS)
- **lds_basic**: Sequential LDS access without conflicts
- **lds_conflicts**: Stride-32 access pattern for bank conflicts
- **smem**: Scalar memory (constant cache) operations

### Performance Analysis
- **waits_stalls**: Memory dependencies causing stalls
- **basic_activity**: Baseline GPU activity measurement

## Counter Coverage

- **GL2C Block** (9 counters): L2 cache hits/misses, memory read/write requests, transaction sizes
- **SQ Block** (21 counters): Wave counts, instruction types (VALU/SALU/LDS/etc), busy cycles, wait states
- **TA Block** (3 counters): Buffer operations, texture addressing busy time
- **GRBM Block** (2 counters): GPU activity cycles, reference clock

## Build System

- CMake-based with HIP language support
- Modular structure with shared test infrastructure (`common/`)
- Individual CMakeLists.txt for each test
- Comprehensive documentation (README.md, QUICKSTART.md)

## Usage

```bash
cd projects/perf-dkms/test_apps
mkdir build && cd build
cmake .. && make -j
./run_all_tests.sh
```

Individual tests can be profiled with perf:
```bash
perf stat -e amd_gpu/sq_waves/,amd_gpu/sq_insts_valu/ ./build/valu_heavy/valu_heavy
```

## Testing

All 14 tests compile and execute successfully. They serve as functional validation that GPU kernels execute correctly. When used with perf, they enable validation of counter behavior:

- Counter increments (did it count anything?)
- Relative magnitudes (VALU test shows high VALU counts)
- Ratios (cache hit test shows high hit rate)
- Comparisons (LDS conflict test vs baseline)

## Future Work

A follow-up PR could add perf integration to `run_all_tests.sh` for automated counter validation with expected value checking.