### PR TITLE
SWDEV-562996 - Build fix: Ubertrace callback calling convention mismatch on x86

### DIFF
--- a/projects/clr/rocclr/device/pal/palubercapturemgr.cpp
+++ b/projects/clr/rocclr/device/pal/palubercapturemgr.cpp
@@ -57,9 +57,9 @@ UberTraceCaptureMgr* UberTraceCaptureMgr::Create(Pal::IPlatform* platform, const
   return mgr;
 }
 
-static void UberTraceStateChangeCallback(const GpuUtil::TraceSession& pTraceSession,
-                                         GpuUtil::TraceSessionState newState,
-                                         void* pPrivateData)
+static void PAL_STDCALL UberTraceStateChangeCallback(const GpuUtil::TraceSession& pTraceSession,
+                                                     GpuUtil::TraceSessionState newState,
+                                                     void* pPrivateData)
 {
     UberTraceCaptureMgr* mgr = static_cast<UberTraceCaptureMgr*>(pPrivateData);
 


### PR DESCRIPTION
## Motivation

Build error when building for x86.

## Technical Details

Mismatched calling convention resulted in a build error, because the callback function in CLR defaulted to `cdecl` calling convention and needed to match `stdcall` as specified by PAL.

## Test Plan

Local build test.
RDP Capture, with tracing to confirm the callback is called ok (x64)

## Test Result

Local build test: Build now passes.
RDP Capture, with tracing to confirm the callback is called ok (x64): OK

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.