### PR TITLE
Updating documentation

### DIFF
--- a/projects/rocprofiler-systems/docs/conceptual/rocprof-sys-feature-set.rst
+++ b/projects/rocprofiler-systems/docs/conceptual/rocprof-sys-feature-set.rst
@@ -87,17 +87,6 @@ CPU metrics
 * I/O metrics
 * Many others
 
-Third-party API support
-========================================
-
-* TAU
-* LIKWID
-* Caliper
-* CrayPAT
-* VTune
-* NVTX
-* ROCTX
-
 ROCm Systems Profiler use cases
 ========================================
 

--- a/projects/rocprofiler-systems/docs/how-to/configuring-runtime-options.rst
+++ b/projects/rocprofiler-systems/docs/how-to/configuring-runtime-options.rst
@@ -81,12 +81,7 @@ data and resources. By default, with ``ROCPROFSYS_PROFILE=ON``, ROCm Systems Pro
 timing values. However, by modifying the ``ROCPROFSYS_TIMEMORY_COMPONENTS`` setting,
 ROCm Systems Profiler can be configured to
 collect hardware counters, CPU-clock timers, memory usage, context switches, page faults, network statistics,
-and much more. ROCm Systems Profiler can even be used as a dynamic instrumentation vehicle
-for other third-party profiling
-APIs such as `Caliper <https://github.com/LLNL/Caliper>`_ and `LIKWID <https://github.com/RRZE-HPC/likwid>`_.
-To leverage this capability, build ROCm Systems Profiler from source with the CMake
-options ``TIMEMORY_USE_CALIPER=ON`` or ``TIMEMORY_USE_LIKWID=ON`` and then add
-``caliper_marker``, ``likwid_marker``, or both to ``ROCPROFSYS_TIMEMORY_COMPONENTS``.
+and much more.
 
 To view all possible components and their descriptions:
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Removing references to third party API support from documentation. This was a feature of the underlying Timemory module. It could be compiled in but isn't by default, leading to confusing documentation. Further, the ability to instrument an application with `rocprof-sys-instrument` and then launch that instrumented application in another profiler is no longer the focus of `rocprof-sys`.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Update documentation.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
