### PR TITLE
SWDEV-555551 - fix nvidia hip-test warning

### DIFF
--- a/projects/hip-tests/catch/include/hip_texture_helper.hh
+++ b/projects/hip-tests/catch/include/hip_texture_helper.hh
@@ -42,7 +42,10 @@ template<typename T>
 typename std::enable_if<sizeof(T) / sizeof(decltype(T::x)) == 4, T>::type
 inline __host__ __device__ operator-(const T &a, const T &b)
 {
-  return {a.x - b.x, a.y - b.y, a.z - b.z,  a.w - b.w};
+  return {static_cast<decltype(T::x)>(a.x - b.x), 
+          static_cast<decltype(T::x)>(a.y - b.y), 
+          static_cast<decltype(T::x)>(a.z - b.z), 
+          static_cast<decltype(T::x)>(a.w - b.w)};
 }
 
 template<typename T>

--- a/projects/hip-tests/catch/include/performance_common.hh
+++ b/projects/hip-tests/catch/include/performance_common.hh
@@ -71,17 +71,15 @@ class EventTimer : public Timer {
   }
 
   ~EventTimer() {
-    hipError_t error;  // to avoid compiler warnings
-
-    error = hipEventRecord(stop_, GetStream());
-    error = hipEventSynchronize(stop_);
+    HIP_CHECK(hipEventRecord(stop_, GetStream()));
+    HIP_CHECK(hipEventSynchronize(stop_));
 
     float ms;
-    error = hipEventElapsedTime(&ms, start_, stop_);
+    HIP_CHECK(hipEventElapsedTime(&ms, start_, stop_));
     Record(ms);
 
-    error = hipEventDestroy(start_);
-    error = hipEventDestroy(stop_);
+    HIP_CHECK(hipEventDestroy(start_));
+    HIP_CHECK(hipEventDestroy(stop_));
   }
 
  private:
@@ -96,8 +94,7 @@ class CpuTimer : public Timer {
   }
 
   ~CpuTimer() {
-    hipError_t error;  // to avoid compiler warnings
-    error = hipStreamSynchronize(GetStream());
+    HIP_CHECK(hipStreamSynchronize(GetStream()));
 
     stop_ = std::chrono::steady_clock::now();
 

--- a/projects/hip-tests/catch/multiproc/hipIpcMemAccessTest.cc
+++ b/projects/hip-tests/catch/multiproc/hipIpcMemAccessTest.cc
@@ -213,6 +213,7 @@ TEST_CASE(Unit_hipIpcMemAccess_Semaphores) {
 TEST_CASE(Unit_hipIpcMemAccess_ParameterValidation) {
   hipIpcMemHandle_t MemHandle;
   hipIpcMemHandle_t MemHandleUninit;
+  std::memset(&MemHandleUninit, 0xAB, sizeof(MemHandleUninit)); // Fill with a known invalid pattern
   void *Ad{}, *Ad2{};
   hipError_t ret;
 

--- a/projects/hip-tests/catch/multiproc/hipMemCoherencyTstMProc.cc
+++ b/projects/hip-tests/catch/multiproc/hipMemCoherencyTstMProc.cc
@@ -55,6 +55,7 @@ __global__ void SquareKrnl(int* ptr) {
   *ptr = (*ptr) * (*ptr);
 }
 
+#if HT_AMD
 // The function tests the coherency of allocated memory
 // Return false on failure, true on success.
 bool static TstCoherency(int* Ptr, bool HmmMem) {
@@ -96,6 +97,7 @@ bool static TstCoherency(int* Ptr, bool HmmMem) {
   fprintf(stderr, "TstCoherency: *Ptr=%u\b", *Ptr);
   return false;
 }
+#endif
 
 /* Test case description: The following test validates if fine grain
    behavior is observed or not with memory allocated using malloc()*/

--- a/projects/hip-tests/catch/multiproc/hipSetGetDeviceMproc.cc
+++ b/projects/hip-tests/catch/multiproc/hipSetGetDeviceMproc.cc
@@ -248,7 +248,7 @@ static void testValidDevices(int numDevices, bool useRocrEnv, int* deviceList,
   REQUIRE(testResult == true);
 }
 
-
+#ifdef __HIP_PLATFORM_AMD__
 static void Initialize(int* deviceList, int numDevices, int count,
                        std::string& min_visibleDeviceString, std::string& max_visibleDeviceString) {
   int* deviceListPtr = deviceList;
@@ -393,6 +393,7 @@ static void testMinRvdMaxHvd(int numDevices, int* deviceList, int count) {
 
   REQUIRE(testResult == true);
 }
+#endif
 
 /**
  * Scenario sets Invalid visible device list and checks behavior.

--- a/projects/hip-tests/catch/performance/stream/hipStreamBasic.cc
+++ b/projects/hip-tests/catch/performance/stream/hipStreamBasic.cc
@@ -42,7 +42,6 @@ class HipDeviceGetStreamPriorityRangeBenchmark
 class HipStreamQueryBenchmark : public Benchmark<HipStreamQueryBenchmark> {
  public:
   void operator()(bool perform_work) {
-    hipError_t error;
     hipStream_t stream;
     HIP_CHECK(hipStreamCreate(&stream));
     void* dptr;
@@ -51,7 +50,9 @@ class HipStreamQueryBenchmark : public Benchmark<HipStreamQueryBenchmark> {
       HIP_CHECK(hipMallocAsync(&dptr, 2048 * 4, stream));
     }
 
-    TIMED_SECTION(kTimerTypeCpu) { error = hipStreamQuery(stream); }
+    TIMED_SECTION(kTimerTypeCpu) { 
+      HIP_CHECK(hipStreamQuery(stream)); 
+    }
 
     if (perform_work) {
       HIP_CHECK(hipFreeAsync(dptr, stream));
@@ -65,11 +66,12 @@ class HipStreamQueryBenchmark : public Benchmark<HipStreamQueryBenchmark> {
 class HipStreamSynchronizeBenchmark : public Benchmark<HipStreamSynchronizeBenchmark> {
  public:
   void operator()() {
-    hipError_t error;
     hipStream_t stream;
     HIP_CHECK(hipStreamCreate(&stream));
 
-    TIMED_SECTION(kTimerTypeCpu) { error = hipStreamSynchronize(stream); }
+    TIMED_SECTION(kTimerTypeCpu) { 
+      HIP_CHECK(hipStreamSynchronize(stream)); 
+    }
 
     HIP_CHECK(hipStreamDestroy(stream));
   }

--- a/projects/hip-tests/catch/unit/compiler/hipClassKernel.cc
+++ b/projects/hip-tests/catch/unit/compiler/hipClassKernel.cc
@@ -126,9 +126,9 @@ __global__ void sizeVirtualClassKernel(bool* result_ecd, refStructSizes structSi
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
   result_ecd[tid] = (structSizes.sizeOftestSizeDV == sizeof(testSizeDV)) &&
                     (structSizes.sizeOftestSizeDerivedDV == sizeof(testSizeDerivedDV)) &&
-                    (structSizes.sizeOftestSizeVirtDer = sizeof(testSizeVirtDer)) &&
-                    (structSizes.sizeOftestSizeVirtDerPack = sizeof(testSizeVirtDerPack)) &&
-                    (structSizes.sizeOftestSizeDerMulti = sizeof(testSizeDerMulti));
+                    (structSizes.sizeOftestSizeVirtDer == sizeof(testSizeVirtDer)) &&
+                    (structSizes.sizeOftestSizeVirtDerPack == sizeof(testSizeVirtDerPack)) &&
+                    (structSizes.sizeOftestSizeDerMulti == sizeof(testSizeDerMulti));
 }
 
 TEST_CASE(Unit_hipClassKernel_Virtual) {

--- a/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_groups_shfl_down_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_groups_shfl_down_old.cc
@@ -143,8 +143,8 @@ static void test_group_partition(unsigned int tileSz) {
     // out-of-bounds error and still evaluate failure case.
     numTiles = (numTiles == 0) ? 1 : numTiles;
 
-    for (int i = 0; i < numTiles; i++) {
-      expectedResult[i] = expectedSum;
+    for (int j = 0; j < numTiles; j++) {
+      expectedResult[j] = expectedSum;
     }
 
     int* dResult = NULL;
@@ -202,13 +202,13 @@ static void test_shfl_down() {
 
     HIPCHECK(hipHostMalloc(&hPtr, arrSize));
     // Fill up the array
-    for (int i = 0; i < WAVE_SIZE; i++) {
-      hPtr[i] = rand() % 1000;
+    for (int j = 0; j < WAVE_SIZE; j++) {
+      hPtr[j] = rand() % 1000;
     }
 
     int* cpuResultsArr = (int*)malloc(group_size_in_bytes);
-    for (int i = 0; i < group_size; i++) {
-      cpuResultsArr[i] = (i + lane_delta >= group_size) ? hPtr[i] : hPtr[i + lane_delta];
+    for (int j = 0; j < group_size; j++) {
+      cpuResultsArr[j] = (j + lane_delta >= group_size) ? hPtr[j] : hPtr[j + lane_delta];
     }
     // printf("Array passed to GPU for computation\n");
     // printResultsCoalescedGroupsShflDown(hPtr, WAVE_SIZE);

--- a/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_groups_shfl_up_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_groups_shfl_up_old.cc
@@ -182,14 +182,14 @@ static void test_shfl_up() {
 
     HIPCHECK(hipHostMalloc(&hPtr, arrSize));
     // Fill up the array
-    for (int i = 0; i < WAVE_SIZE; i++) {
-      hPtr[i] = rand() % 1000;
+    for (int j = 0; j < WAVE_SIZE; j++) {
+      hPtr[j] = rand() % 1000;
     }
     // printResults(hPtr, WAVE_SIZE);
 
     int* cpuResultsArr = (int*)malloc(group_size_in_bytes);
-    for (int i = 0; i < group_size; i++) {
-      cpuResultsArr[i] = (i <= (lane_delta - 1)) ? hPtr[i] : hPtr[i - lane_delta];
+    for (int j = 0; j < group_size; j++) {
+      cpuResultsArr[j] = (j <= (lane_delta - 1)) ? hPtr[j] : hPtr[j - lane_delta];
     }
 
     // printf("Printing cpu results arr\n");

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGCoalescedGroups_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGCoalescedGroups_old.cc
@@ -353,20 +353,20 @@ static void test_shfl_any_to_any() {
 
     HIPCHECK(hipHostMalloc(&hPtr, arrSize));
     // Fill up the array
-    for (int i = 0; i < WAVE_SIZE; i++) {
-      hPtr[i] = rand() % 1000;
+    for (int j = 0; j < WAVE_SIZE; j++) {
+      hPtr[j] = rand() % 1000;
     }
 
     // Fill up the random array
-    for (int i = 0; i < group_size; i++) {
-      srcArr[i] = rand() % 1000;
-      srcArrCpu[i] = srcArr[i] % group_size;
+    for (int j = 0; j < group_size; j++) {
+      srcArr[j] = rand() % 1000;
+      srcArrCpu[j] = srcArr[j] % group_size;
     }
 
     /* Fill cpu results array so that we can verify with gpu computation */
     int* cpuResultsArr = (int*)malloc(group_size_in_bytes);
-    for (int i = 0; i < group_size; i++) {
-      cpuResultsArr[i] = hPtr[srcArrCpu[i]];
+    for (int j = 0; j < group_size; j++) {
+      cpuResultsArr[j] = hPtr[srcArrCpu[j]];
     }
 
     // printf("Array passed to GPU for computation\n");
@@ -430,8 +430,8 @@ static void test_shfl_broadcast() {
 
     HIPCHECK(hipHostMalloc(&hPtr, arrSize));
     // Fill up the array
-    for (int i = 0; i < WAVE_SIZE; i++) {
-      hPtr[i] = rand() % 1000;
+    for (int j = 0; j < WAVE_SIZE; j++) {
+      hPtr[j] = rand() % 1000;
     }
 
 
@@ -439,8 +439,8 @@ static void test_shfl_broadcast() {
     srcLaneCpu = hPtr[srcLane % group_size];
 
     int* cpuResultsArr = (int*)malloc(sizeof(int) * group_size);
-    for (int i = 0; i < group_size; i++) {
-      cpuResultsArr[i] = srcLaneCpu;
+    for (int j = 0; j < group_size; j++) {
+      cpuResultsArr[j] = srcLaneCpu;
     }
     printf("Array passed to GPU for computation\n");
     printResultsSimpleCoalescedGroups(hPtr, WAVE_SIZE);

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGGridGroupType_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGGridGroupType_old.cc
@@ -57,6 +57,7 @@ static __global__ void kernel_cg_grid_group_type(int* size_dev, int* thd_rank_de
   group_dim_dev[gIdx] = gg.group_dim();
 }
 
+#if HT_AMD
 static __global__ void kernel_cg_grid_group_type_via_base_type(int* size_dev, int* thd_rank_dev,
                                                                int* is_valid_dev, int* sync_dev) {
   cg::thread_group tg = cg::this_grid();
@@ -84,6 +85,7 @@ static __global__ void kernel_cg_grid_group_type_via_base_type(int* size_dev, in
   tg.sync();
   sync_dev[gIdx] = gm[1] * gm[0];
 }
+#endif
 
 static __global__ void kernel_cg_grid_group_type_via_public_api(int* size_dev, int* thd_rank_dev,
                                                                 int* is_valid_dev, int* sync_dev,

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGMultiGridGroupType_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGMultiGridGroupType_old.cc
@@ -24,6 +24,10 @@ THE SOFTWARE.
 
 #include "hip_cg_common.hh"
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 1215 // suppress kernel launch warning
+#endif
+
 namespace cg = cooperative_groups;
 
 static __global__ void kernel_cg_multi_grid_group_type(int* grid_rank_dev, int* size_dev,

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipLaunchCooperativeKernelMultiDevice_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipLaunchCooperativeKernelMultiDevice_old.cc
@@ -82,6 +82,10 @@ overlap-allowing flags work as expected.
 #include <hip_test_common.hh>
 #include <hip/hip_cooperative_groups.h>
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 1215 // suppress kernel launch warning
+#endif
+
 namespace cg = cooperative_groups;
 
 static constexpr size_t kBufferLen = 1024 * 1024;

--- a/projects/hip-tests/catch/unit/cooperativeGrps/multi_grid_group.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/multi_grid_group.cc
@@ -23,6 +23,10 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 1215 // suppress kernel launch warning
+#endif
+
 /**
  * @addtogroup multi_grid_group multi_grid_group
  * @{

--- a/projects/hip-tests/catch/unit/device/getUUIDfrmRocinfo_Exe.cc
+++ b/projects/hip-tests/catch/unit/device/getUUIDfrmRocinfo_Exe.cc
@@ -39,7 +39,7 @@ int main(int argc, char** argv) {
   const char* rocmInfo = "rocminfo";
 
   snprintf(command, COMMAND_LEN, "%s", rocmInfo);
-  strncat(command, " | grep -i Uuid:", COMMAND_LEN);
+  strncat(command, " | grep -i Uuid:", COMMAND_LEN - strlen(command) - 1);
   // Execute the rocminfo command and extract the UUID info
   fpipe = popen(command, "r");
   if (fpipe == nullptr) {

--- a/projects/hip-tests/catch/unit/device/hipDeviceEnableDisablePeerAccess.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceEnableDisablePeerAccess.cc
@@ -23,6 +23,9 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <hip_test_helper.hh>
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 68 // suppress implicit conversion warning
+#endif
 /**
  * @addtogroup hipDeviceEnablePeerAccess hipDeviceEnablePeerAccess
  * @{

--- a/projects/hip-tests/catch/unit/device/hipGetDeviceAttribute.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetDeviceAttribute.cc
@@ -51,6 +51,7 @@ static hipError_t test_hipDeviceGetAttribute(int deviceId, hipDeviceAttribute_t 
   return hipSuccess;
 }
 
+#if HT_AMD
 static hipError_t test_hipDeviceGetHdpAddress(int deviceId, hipDeviceAttribute_t attr,
                                               uint32_t* expectedValue) {
   uint32_t* value = 0;
@@ -66,6 +67,7 @@ static hipError_t test_hipDeviceGetHdpAddress(int deviceId, hipDeviceAttribute_t
   }
   return hipSuccess;
 }
+#endif
 
 /**
  * Test Description

--- a/projects/hip-tests/catch/unit/device/hipGetDeviceProperties.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetDeviceProperties.cc
@@ -74,6 +74,7 @@ __global__ void mykernel(int* archProp_d) { getArchValuesFromDevice(archProp_d);
 /*
  * Internal Functions
  */
+#if HT_AMD
 static void validateDeviceMacro(int* archProp_h, hipDeviceProp_t* prop) {
   CHECK_FALSE(prop->arch.hasGlobalInt32Atomics !=
               archProp_h[HIP_ARCH_HAS_GLOBAL_INT32_ATOMICS_IDX]);
@@ -115,6 +116,8 @@ static void validateDeviceMacro(int* archProp_h, hipDeviceProp_t* prop) {
 
   CHECK_FALSE(prop->arch.hasDynamicParallelism != archProp_h[HIP_ARCH_HAS_DYNAMIC_PARALLEL_IDX]);
 }
+#endif
+
 /*
  * Validates value of __HIP_ARCH_*  with deviceProp.arch.has* as follows
  * __HIP_ARCH_HAS_GLOBAL_INT32_ATOMICS__ == hasGlobalInt32Atomics

--- a/projects/hip-tests/catch/unit/deviceLib/DoublePrecisionMathHost.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/DoublePrecisionMathHost.cc
@@ -25,7 +25,7 @@ THE SOFTWARE.
 
 __host__ static void double_precision_math_functions() {
   int iX;
-  double fX, fY;
+  double fX;
 
   acos(1.0);
   acosh(1.0);
@@ -93,6 +93,7 @@ __host__ static void double_precision_math_functions() {
   std::signbit(1.0);
   sin(0.0);
 #ifdef _unix__
+  double fY;
   sincos(0.0, &fX, &fY);
 #endif
   sinh(0.0);

--- a/projects/hip-tests/catch/unit/deviceLib/IntegerIntrinsics.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/IntegerIntrinsics.cc
@@ -20,7 +20,6 @@ THE SOFTWARE.
 #include <hip_test_kernels.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
-#include <hip/device_functions.h>
 #include <algorithm>
 
 #pragma GCC diagnostic ignored "-Wall"

--- a/projects/hip-tests/catch/unit/deviceLib/SinglePrecisionIntrinsics.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/SinglePrecisionIntrinsics.cc
@@ -20,7 +20,6 @@ THE SOFTWARE.
 #include <hip_test_kernels.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_common.hh>
-#include <hip/device_functions.h>
 
 #pragma GCC diagnostic ignored "-Wall"
 #pragma clang diagnostic ignored "-Wunused-variable"

--- a/projects/hip-tests/catch/unit/deviceLib/ballot.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/ballot.cc
@@ -21,8 +21,6 @@ THE SOFTWARE.
 */
 
 #include <hip_test_common.hh>
-#include <hip/device_functions.h>
-
 
 __global__ void gpu_ballot(unsigned int* device_ballot, unsigned Num_Warps_per_Block,
                            unsigned pshift) {

--- a/projects/hip-tests/catch/unit/deviceLib/brev.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/brev.cc
@@ -21,7 +21,6 @@ THE SOFTWARE.
 */
 
 #include <hip_test_common.hh>
-#include <hip/device_functions.h>
 
 #include <assert.h>
 #include <stdio.h>

--- a/projects/hip-tests/catch/unit/deviceLib/clz.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/clz.cc
@@ -21,7 +21,6 @@ THE SOFTWARE.
 */
 
 #include <hip_test_common.hh>
-#include <hip/device_functions.h>
 
 #include <assert.h>
 #include <stdio.h>

--- a/projects/hip-tests/catch/unit/deviceLib/deviceAllocation.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/deviceAllocation.cc
@@ -23,7 +23,6 @@ __device__ static void* dev_mem_glob;
 __device__ struct deviceAllocFunc allocfunc{&deviceAlloc, &deviceWrite, &deviceFree};
 __device__ class derivedAlloc classalloc;
 constexpr auto num_threads = 5;
-static bool thread_results[num_threads];
 __device__ static void* dev_ptr[num_threads][GRIDSIZE];
 
 /**
@@ -434,6 +433,7 @@ template <typename T> static bool TestMemoryAccessInAllThread(int test_type, int
  * Local function: Launch kerAlloc<<<>>>
  */
 template <typename T> static void runTestMemoryAccessInAllThread(int test_type, int thread_idx) {
+  static bool thread_results[num_threads];
   thread_results[thread_idx] = TestMemoryAccessInAllThread<T>(test_type, thread_idx);
 }
 
@@ -1459,6 +1459,8 @@ TEST_CASE(Unit_deviceAllocation_New_MulKernels_MulThreads) {
  * Scenario: This test validates device allocation malloc, access and free
  * in a single kernel launched using threads.
  */
+static bool thread_results[num_threads];
+
 TEST_CASE(Unit_deviceAllocation_Malloc_SingKernels_MulThreads) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));

--- a/projects/hip-tests/catch/unit/deviceLib/ffs.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/ffs.cc
@@ -21,7 +21,6 @@ THE SOFTWARE.
 */
 
 #include <hip_test_common.hh>
-#include <hip/device_functions.h>
 
 #include <assert.h>
 #include <stdio.h>

--- a/projects/hip-tests/catch/unit/deviceLib/funnelshift.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/funnelshift.cc
@@ -21,8 +21,6 @@ THE SOFTWARE.
 */
 
 #include <hip_test_common.hh>
-#include <hip/device_functions.h>
-
 
 #include <assert.h>
 #include <stdio.h>

--- a/projects/hip-tests/catch/unit/deviceLib/hipStdComplex.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/hipStdComplex.cc
@@ -23,8 +23,6 @@ THE SOFTWARE.
 #include <complex>
 
 #pragma clang diagnostic ignored "-Wunused-variable"
-// Tolerance for error
-const double tolerance = 1e-6;
 
 #define LEN 64
 
@@ -86,6 +84,8 @@ template <typename FloatT> __global__ void kernel(std::complex<FloatT>* A, std::
 }
 
 template <typename FloatT> void test() {
+  // Tolerance for error
+  const double tolerance = 1e-6;
   typedef std::complex<FloatT> ComplexT;
 
   ComplexT *A, *Ad, *B, *Bd, *C, *Cd, *D;

--- a/projects/hip-tests/catch/unit/deviceLib/hip_trig.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/hip_trig.cc
@@ -17,7 +17,7 @@ OUT OF OR INN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 #include <hip_test_common.hh>
-#include <hip/device_functions.h>
+
 #define LEN 512
 #define SIZE (LEN << 2)
 __global__ static void kernel_trig(float* In, float* sin_d, float* cos_d, float* tan_d,

--- a/projects/hip-tests/catch/unit/event/Unit_hipEventElapsedTime.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEventElapsedTime.cc
@@ -61,9 +61,9 @@ TEST_CASE(Unit_hipEventElapsedTime_NullCheck) {
   HIP_CHECK(hipEventCreate(&start));
   HIP_CHECK(hipEventCreate(&end));
 
-  float tms = 1.0f;
   HIP_ASSERT(hipEventElapsedTime(nullptr, start, end) == hipErrorInvalidValue);
 #ifndef __HIP_PLATFORM_NVIDIA__
+  float tms = 1.0f;
   // On NVCC platform API throws seg fault hence skipping
   HIP_ASSERT(hipEventElapsedTime(&tms, nullptr, end) == hipErrorInvalidHandle);
   HIP_ASSERT(hipEventElapsedTime(&tms, start, nullptr) == hipErrorInvalidHandle);

--- a/projects/hip-tests/catch/unit/event/hipEventCreateWithFlags.cc
+++ b/projects/hip-tests/catch/unit/event/hipEventCreateWithFlags.cc
@@ -25,11 +25,6 @@ THE SOFTWARE.
 
 #include <stdlib.h>
 
-constexpr size_t buffer_size = (1024 * 1024);
-constexpr int test_iteration_hstvismem = 5;
-constexpr int test_iteration_noncohmem = 10;
-constexpr int block_size = 512;
-
 /**
  * @addtogroup hipEventCreateWithFlags hipEventCreateWithFlags
  * @{
@@ -74,6 +69,11 @@ Since flags hipEventReleaseToSystem, hipEventDisableSystemFence and hipEventRele
 are AMD specific flags, hence the following tests enabled only for AMD.
 */
 #if HT_AMD
+constexpr int test_iteration_hstvismem = 5;
+constexpr size_t buffer_size = (1024 * 1024);
+constexpr int test_iteration_noncohmem = 10;
+constexpr int block_size = 512;
+
 enum class eSyncToTest {
   eStreamSynchronize,
   eDeviceSynchronize,

--- a/projects/hip-tests/catch/unit/graph/hipDeviceGetGraphMemAttribute.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDeviceGetGraphMemAttribute.cc
@@ -24,6 +24,10 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 68 // suppress implicit conversion warning
+#endif
+
 /**
  * @addtogroup hipDeviceGetGraphMemAttribute hipDeviceGetGraphMemAttribute
  * @{

--- a/projects/hip-tests/catch/unit/graph/hipDrvGraphExecMemsetNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipDrvGraphExecMemsetNodeSetParams.cc
@@ -208,7 +208,7 @@ TEST_CASE("Unit_hipDrvGraphExecMemsetNodeSetParams_Negative") {
     memsetParams.height = height;
     memsetParams.value = value;
 
-    HIP_CHECK_ERROR(hipDrvGraphExecMemsetNodeSetParams(graphExec, memsetNode, nullptr, context),
+    HIP_CHECK_ERROR(hipDrvGraphExecMemsetNodeSetParams(graphExec, memsetNode, &memsetParams, context),
                     hipErrorInvalidValue);
   }
 

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddBatchMemOpNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddBatchMemOpNode.cc
@@ -39,6 +39,10 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 6.4
  */
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 68 // suppress implicit conversion warning
+#endif
+
 TEST_CASE("Unit_hipGraphAddBatchMemOpNode_NegativeTsts") {
   HIP_CHECK(hipInit(0));
   hipGraph_t graph;

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddKernelNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddKernelNode.cc
@@ -54,7 +54,6 @@ THE SOFTWARE.
  * - HIP_VERSION >= 5.6
  */
 
-constexpr size_t size = 1 << 12;
 enum fnType { normal, object };
 
 TEST_CASE("Unit_hipGraphAddKernelNode_Negative") {
@@ -131,6 +130,8 @@ TEST_CASE("Unit_hipGraphAddKernelNode_Negative") {
   HIP_CHECK(hipGraphDestroy(graph));
 }
 #if HT_AMD
+constexpr size_t size = 1 << 12;
+
 static __global__ void Add(int* A_d, int* B_d, int* C_d) {
   size_t tx = (blockIdx.x * blockDim.x + threadIdx.x);
   C_d[tx] = A_d[tx] + B_d[tx];

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeToSymbol_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemcpyNodeToSymbol_old.cc
@@ -242,7 +242,7 @@ TEST_CASE("Unit_hipGraphAddMemcpyNodeToSymbol_GlobalMemoryPeerDevice") {
   int canAccessPeer = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices > 1) {
-    hipDeviceCanAccessPeer(&canAccessPeer, 0, 1);
+    HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, 0, 1));
     if (canAccessPeer) {
       hipGraphAddMemcpyNodeToSymbol_GlobalMemory(true, false);
     } else {
@@ -263,7 +263,7 @@ TEST_CASE("Unit_hipGraphAddMemcpyNodeToSymbol_GlobalConstMemoryPeerDevice",
   int canAccessPeer = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices > 1) {
-    hipDeviceCanAccessPeer(&canAccessPeer, 0, 1);
+    HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, 0, 1));
     if (canAccessPeer) {
       hipGraphAddMemcpyNodeToSymbol_GlobalMemory(true, true);
     } else {

--- a/projects/hip-tests/catch/unit/graph/hipGraphBatchMemOpNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphBatchMemOpNodeSetParams.cc
@@ -18,6 +18,10 @@ THE SOFTWARE.
 */
 #include <hip_test_common.hh>
 #include <hip_test_defgroups.hh>
+
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 68 // suppress implicit conversion warning
+#endif
 /**
  * @addtogroup hipGraphBatchMemOpNodeSetParams hipGraphBatchMemOpNodeSetParams
  * @{

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecBatchMemOpNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecBatchMemOpNodeSetParams.cc
@@ -18,6 +18,10 @@ THE SOFTWARE.
 */
 #include <hip_test_common.hh>
 #include <hip_test_defgroups.hh>
+
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 68 // suppress implicit conversion warning
+#endif
 /**
  * @addtogroup hipGraphExecBatchMemOpNodeSetParams
  hipGraphExecBatchMemOpNodeSetParams

--- a/projects/hip-tests/catch/unit/kernel/hipLaunchParm.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipLaunchParm.cc
@@ -796,7 +796,6 @@ TEST_CASE("Unit_hipLaunchParm") {
     hipLaunchKernelStruct_h20.name = 'A';
     hipLaunchKernelStruct_h20.rank = 2;
     hipLaunchKernelStruct_h20.age = 42;
-    bool *result_d20, *result_h20;
 #if ENABLE_OUT_OF_ORDER_INITIALIZATION
     hipLaunchKernelGGL(HIP_KERNEL_NAME(hipLaunchKernelStructFunc20), dim3(BLOCK_DIM_SIZE), dim3(1),
                        0, 0, hipLaunchKernelStruct_h20, result_d);
@@ -809,7 +808,6 @@ TEST_CASE("Unit_hipLaunchParm") {
     hipLaunchKernelStruct_t21 hipLaunchKernelStruct_h21 =
         // out of order initalization
         {2, 0};
-    bool *result_d21, *result_h21;
     hipLaunchKernelGGL(HIP_KERNEL_NAME(hipLaunchKernelStructFunc21), dim3(BLOCK_DIM_SIZE), dim3(1),
                        0, 0, hipLaunchKernelStruct_h21, result_d);
 #if ENABLE_BIT_FIELDS

--- a/projects/hip-tests/catch/unit/kernel/hipTestConstant.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipTestConstant.cc
@@ -54,7 +54,7 @@ TEST_CASE("Unit_kernel_chkConstantViaKernel") {
   int *A, *B, *Ad;
   A = new int[LEN];
   B = new int[LEN];
-  for (unsigned i = 0; i < LEN; i++) {
+  for (int i = 0; i < LEN; i++) {
     A[i] = -1 * i;
     B[i] = 0;
   }

--- a/projects/hip-tests/catch/unit/memory/hipHostAlloc.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostAlloc.cc
@@ -32,6 +32,10 @@ THE SOFTWARE.
 #define BLOCK_SIZE 512
 #define VALUE 32
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 68 // suppress implicit conversion warning
+#endif
+
 enum SYNC_VALUES { SYNC_EVENT, SYNC_STREAM, SYNC_DEVICE };
 
 static constexpr int NUMELEMENTS{1024 * 16};

--- a/projects/hip-tests/catch/unit/memory/hipMallocAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocAsync.cc
@@ -25,7 +25,6 @@
 
 static bool thread_results[NUMBER_OF_THREADS];
 static constexpr auto NUM_ELM{1024 * 1024};
-static constexpr int streamPerAsic = 2;
 
 /**
  * @addtogroup hipMallocAsync hipMallocAsync
@@ -317,6 +316,8 @@ TEST_CASE("Unit_hipMallocAsync_Multidevice", "[multigpu]") {
  *    - HIP_VERSION >= 6.2
  */
 #if HT_AMD
+static constexpr int streamPerAsic = 2;
+
 static void threadQAsyncCommands(streamMemAllocTest* testObj, hipStream_t strm, int idx) {
   HIP_CHECK(hipSetDevice(idx));
   // Create host buffer with test data.

--- a/projects/hip-tests/catch/unit/memory/hipMallocFromPoolAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocFromPoolAsync.cc
@@ -22,7 +22,6 @@
 #include <limits>
 
 static bool thread_results[NUMBER_OF_THREADS];
-static constexpr int streamPerAsic = 2;
 static hipMemPool_t mem_pool_common;
 
 /**
@@ -358,6 +357,7 @@ TEST_CASE("Unit_hipMallocFromPoolAsync_ReleaseThreshold_Mgpu", "[multigpu]") {
 /**
  * Local Thread Functions
  */
+#if HT_AMD
 static void threadQAsyncCommands(streamMemAllocTest* testObj, hipStream_t strm, int idx) {
   HIP_CHECK(hipSetDevice(idx));
   // Create host buffer with test data.
@@ -371,7 +371,7 @@ static void threadQAsyncCommands(streamMemAllocTest* testObj, hipStream_t strm, 
   // Free Buffer Asynchronously on stream.
   testObj->freeDevBuf(strm);
 }
-
+#endif
 static void thread_Test1(hipStream_t stream, int N, enum eTestValue testtype, int threadNum) {
   thread_results[threadNum] = checkMaximumAndDefaultThreshold(stream, N, testtype, 0);
 }
@@ -575,6 +575,8 @@ static bool checkReuseAllowOtherFlags(int N, hipMemPoolAttr attr, enum eTestValu
  *    - HIP_VERSION >= 6.2
  */
 #if HT_AMD
+static constexpr int streamPerAsic = 2;
+
 TEST_CASE("Unit_hipMallocFromPoolAsync_Multidevice_Concurrent", "[multigpu]") {
   auto testType = GENERATE(testdefault, testMaximum);
   constexpr int N = 1 << 20;

--- a/projects/hip-tests/catch/unit/memory/hipMallocHost.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocHost.cc
@@ -22,6 +22,10 @@ THE SOFTWARE.
 
 #include <hip_test_common.hh>
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 68 // suppress implicit conversion warning
+#endif
+
 static __global__ void write_integer(int* memory, int value) { *memory = value; }
 
 TEST_CASE("Unit_hipMallocHost_Positive") {

--- a/projects/hip-tests/catch/unit/memory/hipMemAdvise_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAdvise_old.cc
@@ -395,8 +395,6 @@ TEST_CASE("Unit_hipMemAdvise_ReadMosltyMgpuTst", "[multigpu]") {
           "Hence skipping the test.\n");
     }
     int *Hmm = NULL, NumElms = (1024 * 1024), InitVal = 123, blockSize = 64;
-    int *Hmm1 = NULL, DataMismatch = 0;
-    hipStream_t strm;
     HIP_CHECK(hipMallocManaged(&Hmm, (NumElms * sizeof(int))));
     // Initializing memory
     for (int i = 0; i < NumElms; ++i) {
@@ -406,6 +404,9 @@ TEST_CASE("Unit_hipMemAdvise_ReadMosltyMgpuTst", "[multigpu]") {
     dim3 dimBlock(blockSize, 1, 1);
     dim3 dimGrid((NumElms + blockSize - 1) / blockSize, 1, 1);
 #if HT_AMD
+    int *Hmm1 = NULL, DataMismatch = 0;
+    hipStream_t strm;
+
     SECTION("Launch Kernel on all other gpus") {
       // launching kernel from each one of the gpus
       for (int i = 1; i < Ngpus; ++i) {

--- a/projects/hip-tests/catch/unit/memory/hipMemAllocHost.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemAllocHost.cc
@@ -22,6 +22,10 @@ THE SOFTWARE.
 
 #include <hip_test_common.hh>
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 68 // suppress implicit conversion warning
+#endif
+
 static __global__ void write_integer(int* memory, int value) { *memory = value; }
 
 TEST_CASE("Unit_hipMemAllocHost_Positive") {

--- a/projects/hip-tests/catch/unit/memory/hipMemGetAddressRange.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemGetAddressRange.cc
@@ -107,7 +107,7 @@ TEST_CASE("Unit_hipMemGetAddressRange_Negative") {
   const int offset = kPageSize;
   LinearAllocGuard<int> dst_alloc(LinearAllocs::hipMalloc, allocation_size);
 
-  hipDeviceptr_t dummy_ptr = NULL;
+  hipDeviceptr_t dummy_ptr = 0;
 
   SECTION("Device pointer is invalid") {
     HIP_CHECK_ERROR(hipMemGetAddressRange(&base_ptr, &mem_size, dummy_ptr), hipErrorNotFound);

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArrayAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DFromArrayAsync.cc
@@ -173,13 +173,6 @@ TEST_CASE("Unit_hipMemcpy2DFromArrayAsync_Negative_Parameters") {
 
   const unsigned int flag = hipArrayDefault;
 
-#if HT_NVIDIA
-  constexpr auto InvalidStream = [] {
-    StreamGuard sg(Streams::created);
-    return sg.stream();
-  };
-#endif
-
   ArrayAllocGuard<int> array_alloc(make_hipExtent(width, height, 0), flag);
   LinearAllocGuard2D<int> device_alloc(width, height);
   LinearAllocGuard<int> host_alloc(LinearAllocs::hipHostMalloc, allocation_size);

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArrayAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DToArrayAsync.cc
@@ -167,13 +167,6 @@ TEST_CASE("Unit_hipMemcpy2DToArrayAsync_Negative_Parameters") {
 
   const unsigned int flag = hipArrayDefault;
 
-#if HT_NVIDIA
-  constexpr auto InvalidStream = [] {
-    StreamGuard sg(Streams::created);
-    return sg.stream();
-  };
-#endif
-
   ArrayAllocGuard<int> array_alloc(make_hipExtent(width, height, 0), flag);
   LinearAllocGuard2D<int> device_alloc(width, height);
   LinearAllocGuard<int> host_alloc(LinearAllocs::hipHostMalloc, allocation_size);

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyHtoA.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyHtoA.cc
@@ -86,7 +86,7 @@ TEST_CASE("Unit_hipMemcpyHtoA_Positive_ZeroCount") {
   BEGIN_CAPTURE_SYNC(memcpy_err, false);
   HIP_CHECK_ERROR(hipMemcpyHtoA(array_alloc.ptr(), 0, host_alloc.ptr(), 0), memcpy_err);
   END_CAPTURE_SYNC(memcpy_err);
-  if (memcpy_err = hipErrorStreamCaptureImplicit) {
+  if (memcpy_err == hipErrorStreamCaptureImplicit) {
     return;
   }
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyHtoAAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyHtoAAsync.cc
@@ -24,6 +24,10 @@ THE SOFTWARE.
 
 #define N 32
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 68 // suppress implicit conversion warning
+#endif
+
 TEMPLATE_TEST_CASE("Unit_hipMemcpyHtoAAsync_Basic", "", char, int, float) {
   CHECK_IMAGE_SUPPORT
 

--- a/projects/hip-tests/catch/unit/memory/hipMemcpySync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpySync.cc
@@ -29,6 +29,8 @@ THE SOFTWARE.
 
 using namespace mem_utils;
 
+#if HT_AMD
+
 // value used for memset operations
 constexpr int testValue = 0x11;
 
@@ -175,7 +177,7 @@ static void runMemcpyTests(hipStream_t stream, bool async, allocType type, memTy
   }
 }
 
-#if HT_AMD /* Disabled because frequency based wait is timing out on nvidia platforms */
+/* Disabled because frequency based wait is timing out on nvidia platforms */
 
 TEST_CASE("Unit_hipMemcpySync") {
 #if HT_AMD  // To be removed when EXSWCPHIPT-127 is fixed

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D16.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D16.cc
@@ -20,6 +20,10 @@ THE SOFTWARE.
 #include <hip_test_checkers.hh>
 #include <hip_test_kernels.hh>
 #include <hip_test_defgroups.hh>
+
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 68 // suppress implicit conversion warning
+#endif
 /**
  * @addtogroup hipMemsetD2D16 hipMemsetD2D16
  * @{

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D16.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D16.cc
@@ -126,7 +126,7 @@ TEST_CASE("Unit_hipMemsetD2D16_NegTsts") {
   HIP_CHECK(hipMemAllocPitch(&A_d, &devPitch, width, numH,
                              2 * sizeof(uint16_t)));
   SECTION("nullptr destination") {
-    HIP_CHECK_ERROR(hipMemsetD2D16(NULL, devPitch, memsetval, numW, numH), hipErrorInvalidValue);
+    HIP_CHECK_ERROR(hipMemsetD2D16(0, devPitch, memsetval, numW, numH), hipErrorInvalidValue);
   }
   SECTION("Dst pointer points to Source Memory") {
     hipDeviceptr_t B_d;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D16Async.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D16Async.cc
@@ -42,6 +42,10 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
+
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 68 // suppress implicit conversion warning
+#endif
 TEST_CASE("Unit_hipMemsetD2D16Async_BasicFunctional") {
   constexpr int memsetval = 0x24;
   constexpr size_t numH = 256;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D16Async.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D16Async.cc
@@ -135,7 +135,7 @@ TEST_CASE("Unit_hipMemsetD2D16Async_NegTsts") {
   HIP_CHECK(hipMemAllocPitch(&A_d, &devPitch, width, numH,
                              2 * sizeof(uint16_t)));
   SECTION("nullptr destination") {
-    HIP_CHECK_ERROR(hipMemsetD2D16Async(NULL, devPitch, memsetval, numW, numH, stream),
+    HIP_CHECK_ERROR(hipMemsetD2D16Async(0, devPitch, memsetval, numW, numH, stream),
                     hipErrorInvalidValue);
   }
   SECTION("Dst pointer points to Source Memory") {

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D32.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D32.cc
@@ -20,6 +20,10 @@ THE SOFTWARE.
 #include <hip_test_checkers.hh>
 #include <hip_test_kernels.hh>
 #include <hip_test_defgroups.hh>
+
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 68 // suppress implicit conversion warning
+#endif
 /**
  * @addtogroup hipMemsetD2D32 hipMemsetD2D32
  * @{

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D32.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D32.cc
@@ -123,7 +123,7 @@ TEST_CASE("Unit_hipMemsetD2D32_NegTsts") {
   constexpr int memsetval = static_cast<int>(0x26);
   HIP_CHECK(hipMemAllocPitch(&A_d, &devPitch, width, numH, sizeof(int)));
   SECTION("nullptr destination") {
-    HIP_CHECK_ERROR(hipMemsetD2D32(NULL, devPitch, memsetval, numW, numH), hipErrorInvalidValue);
+    HIP_CHECK_ERROR(hipMemsetD2D32(0, devPitch, memsetval, numW, numH), hipErrorInvalidValue);
   }
   SECTION("OutOfBound destination") {
     void* outOfBoundsDst{reinterpret_cast<int*>(A_d) + devPitch * numH + 1};

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D32Async.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D32Async.cc
@@ -131,7 +131,7 @@ TEST_CASE("Unit_hipMemsetD2D32Async_NegTsts") {
   HIP_CHECK(hipStreamCreate(&stream));
   HIP_CHECK(hipMemAllocPitch(&A_d, &devPitch, width, numH, sizeof(int)));
   SECTION("nullptr destination") {
-    HIP_CHECK_ERROR(hipMemsetD2D32Async(NULL, devPitch, memsetval, numW, numH, stream),
+    HIP_CHECK_ERROR(hipMemsetD2D32Async(0, devPitch, memsetval, numW, numH, stream),
                     hipErrorInvalidValue);
   }
   SECTION("OutOfBound destination") {

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D32Async.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D32Async.cc
@@ -42,6 +42,10 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
+
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 68 // suppress implicit conversion warning
+#endif
 TEST_CASE("Unit_hipMemsetD2D32Async_BasicFunctional") {
   constexpr int memsetval = 0x24;
   constexpr size_t numH = 256;

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D8.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D8.cc
@@ -19,6 +19,10 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <hip_test_checkers.hh>
 #include <hip_test_defgroups.hh>
+
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 68 // suppress implicit conversion warning
+#endif
 /**
  * @addtogroup hipMemsetD2D8 hipMemsetD2D8
  * @{

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D8.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D8.cc
@@ -125,7 +125,7 @@ TEST_CASE("Unit_hipMemsetD2D8_NegTsts") {
   HIP_CHECK(
       hipMemAllocPitch(&A_d, &devPitch, width, numH, 4 * sizeof(char)));
   SECTION("nullptr destination") {
-    HIP_CHECK_ERROR(hipMemsetD2D8(NULL, devPitch, memsetval, numW, numH), hipErrorInvalidValue);
+    HIP_CHECK_ERROR(hipMemsetD2D8(0, devPitch, memsetval, numW, numH), hipErrorInvalidValue);
   }
   SECTION("OutOfBound destination") {
     void* outOfBoundsDst{reinterpret_cast<char*>(A_d) + devPitch * numH + 1};

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D8Async.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D8Async.cc
@@ -137,7 +137,7 @@ TEST_CASE("Unit_hipMemsetD2D8Async_NegTsts") {
   HIP_CHECK(
       hipMemAllocPitch(&A_d, &devPitch, width, numH, 4 * sizeof(char)));
   SECTION("nullptr destination") {
-    HIP_CHECK_ERROR(hipMemsetD2D8Async(NULL, devPitch, memsetval, numW, numH, stream),
+    HIP_CHECK_ERROR(hipMemsetD2D8Async(0, devPitch, memsetval, numW, numH, stream),
                     hipErrorInvalidValue);
   }
   SECTION("OutOfBound destination") {

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D8Async.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D8Async.cc
@@ -20,6 +20,9 @@ THE SOFTWARE.
 #include <hip_test_checkers.hh>
 #include <hip_test_defgroups.hh>
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 68 // suppress implicit conversion warning
+#endif
 /**
  * @addtogroup hipMemsetD2D8Async hipMemsetD2D8Async
  * @{

--- a/projects/hip-tests/catch/unit/memory/hipSVMTestFineGrainSyncBuffers.cpp
+++ b/projects/hip-tests/catch/unit/memory/hipSVMTestFineGrainSyncBuffers.cpp
@@ -26,6 +26,10 @@
 #include "hipSVMCommon.h"
 #define MAX_TARGETS 1024
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 68 // suppress implicit conversion warning
+#endif
+
 __global__ void find_targets(unsigned int* image, unsigned int target,
                              unsigned int* numTargetsFound, unsigned int* targetLocations) {
   size_t i = blockIdx.x * blockDim.x + threadIdx.x;

--- a/projects/hip-tests/catch/unit/memory/mempool_common.hh
+++ b/projects/hip-tests/catch/unit/memory/mempool_common.hh
@@ -599,11 +599,13 @@ public:
     iov[0].iov_len = sizeof(dummy_data);
     msg.msg_iov = iov;
     msg.msg_iovlen = 1;
-
-    if ((n = recvmsg(handle->socket, &msg, 0)) <= 0) {
+    
+    n = recvmsg(handle->socket, &msg, 0);
+    if (n <= 0) {
       perror("Socket failure: Receiving data over socket failed");
       return -1;
     }
+    (void)n; // suppress unused variable warning
 
     if (((cmptr = CMSG_FIRSTHDR(&msg)) != NULL) &&
        (cmptr->cmsg_len == CMSG_LEN(sizeof(int)))) {

--- a/projects/hip-tests/catch/unit/module/kernel_composite_test.cpp
+++ b/projects/hip-tests/catch/unit/module/kernel_composite_test.cpp
@@ -17,7 +17,6 @@ OUT OF OR INN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 #include <hip/hip_runtime.h>
-constexpr int GLOBAL_BUF_SIZE = 2048;
 
 __device__ float deviceGlobalFloat;
 __device__ int deviceGlobalInt1;

--- a/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags.cc
+++ b/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags.cc
@@ -20,6 +20,9 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <limits>
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 68 // suppress implicit conversion warning
+#endif
 /**
  * @addtogroup hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags
  hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags

--- a/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSizeVariableSMemWithFlags.cc
+++ b/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSizeVariableSMemWithFlags.cc
@@ -55,6 +55,7 @@ class functorBlockSizeToDynamicSMemSize {
 
  public:
   explicit functorBlockSizeToDynamicSMemSize(int n) : myconst(n) {}
+  __host__ __device__
   int operator()(int blocksize) const { return (static_cast<size_t>(blocksize * myconst)); }
 };
 
@@ -158,7 +159,7 @@ TEST_CASE("Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Functor") {
 TEST_CASE("Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Lambda") {
   hipDeviceProp_t devProp;
   HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
-  auto testFunc = [](const int blockSize) {
+  auto testFunc = [] __host__ __device__ (const int blockSize) {
     return (static_cast<size_t>(blockSize * SHARED_MEM_CONST));
   };
   // Get current device property
@@ -174,7 +175,7 @@ TEST_CASE("Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Lambda") {
   // Test again by passing the lamda function directly
   ret = hipOccupancyMaxPotentialBlockSizeVariableSMemWithFlags(
       &minGridSize, &blockSize, f1,
-      [](const int blockSize) { return (static_cast<size_t>(blockSize * SHARED_MEM_CONST)); }, 0,
+      [] __host__ __device__ (const int blockSize) { return (static_cast<size_t>(blockSize * SHARED_MEM_CONST)); }, 0,
       0);
   REQUIRE(ret == hipSuccess);
   REQUIRE(minGridSize > 0);

--- a/projects/hip-tests/catch/unit/rtc/includepath.cc
+++ b/projects/hip-tests/catch/unit/rtc/includepath.cc
@@ -24,9 +24,8 @@ TEST_CASE("Unit_hiprtc_includepath") {
   {
     fstream f("saxpy.h", std::ios::in);
     if (f.is_open()) {
-      size_t sizeFile;
       f.seekg(0, fstream::end);
-      size_t size = sizeFile = (size_t)f.tellg();
+      size_t size = (size_t)f.tellg();
       f.seekg(0, fstream::beg);
       saxpy.resize(size, ' ');
       f.read(&saxpy[0], size);

--- a/projects/hip-tests/catch/unit/texture/hipCreateTextureObject_Linear.cc
+++ b/projects/hip-tests/catch/unit/texture/hipCreateTextureObject_Linear.cc
@@ -59,7 +59,6 @@ TEST_CASE("Unit_hipCreateTextureObject_LinearResource") {
   constexpr int xsize = 32;
   hipResourceDesc resDesc;
   hipTextureDesc texDesc;
-  hipResourceViewDesc resViewDesc;
   hipTextureObject_t texObj;
   hipDeviceProp_t devProp;
 
@@ -109,6 +108,8 @@ TEST_CASE("Unit_hipCreateTextureObject_LinearResource") {
 
   SECTION("hipResourceTypeLinear and valid resource view descriptor") {
 #if HT_AMD
+    hipResourceViewDesc resViewDesc;
+
     // Populate resource descriptor
     resDesc.res.linear.devPtr = texBuf;
     resDesc.res.linear.desc = hipCreateChannelDesc(xsize, 0, 0, 0, hipChannelFormatKindFloat);

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMapArrayAsync.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMapArrayAsync.cc
@@ -100,7 +100,7 @@ TEST_CASE("Unit_hipMemMapArrayAsync_Positive_Basic") {
   HIP_CHECK(hipStreamSynchronize(stream.stream()));
 
   map_info_list.memOperationType = hipMemOperationTypeUnmap;
-  map_info_list.memHandle.memHandle = NULL;
+  map_info_list.memHandle.memHandle = 0;
   HIP_CHECK(hipMemMapArrayAsync(&map_info_list, 1, stream.stream()));
   HIP_CHECK(hipStreamSynchronize(stream.stream()));
 

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hip_vmm_common.hh
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hip_vmm_common.hh
@@ -207,10 +207,13 @@ public:
     iov[0].iov_len = sizeof(dummy_data);
     msg.msg_iov = iov;
     msg.msg_iovlen = 1;
-    if ((n = recvmsg(handle->socket, &msg, 0)) <= 0) {
+    
+    n = recvmsg(handle->socket, &msg, 0);
+    if (n <= 0) {
       perror("Socket failure: Receiving data over socket failed");
       return -1;
     }
+    (void)n; // Suppress unused variable warning
     if (((cmptr = CMSG_FIRSTHDR(&msg)) != NULL) &&
        (cmptr->cmsg_len == CMSG_LEN(sizeof(int)))) {
       if ((cmptr->cmsg_level != SOL_SOCKET) || (cmptr->cmsg_type != SCM_RIGHTS)) {

--- a/projects/hip-tests/catch/unit/warp/hipMatchSyncAllTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipMatchSyncAllTests.cc
@@ -20,6 +20,10 @@ THE SOFTWARE.
 #include "warp_common.hh"
 #include <hip_test_common.hh>
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 69 // suppress integer truncation warning
+#endif
+
 template <typename T>
 __global__ void matchAll_1(T* Input, unsigned long long* Output, int* Predicate) {
   auto tid = threadIdx.x;

--- a/projects/hip-tests/catch/unit/warp/hipMatchSyncAnyTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipMatchSyncAnyTests.cc
@@ -20,6 +20,10 @@ THE SOFTWARE.
 #include "warp_common.hh"
 #include <hip_test_common.hh>
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 69 // suppress integer truncation warning
+#endif
+
 template <typename T> __global__ void matchAny_1(T* Input, unsigned long long* Output) {
   auto tid = threadIdx.x;
   Output[tid] = __match_any_sync(AllThreads, Input[tid]);

--- a/projects/hip-tests/catch/unit/warp/hipShflSyncDownTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipShflSyncDownTests.cc
@@ -20,6 +20,10 @@ THE SOFTWARE.
 #include "warp_common.hh"
 #include <hip_test_common.hh>
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 69 // suppress integer truncation warning
+#endif
+
 // For all threads in the warp, shfl the value "down" by three threads. To
 // account for the end of the warp, we set the delta to zero near the warp-32
 // boundary. This also works for warp-64 since it is a multiple.

--- a/projects/hip-tests/catch/unit/warp/hipShflSyncTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipShflSyncTests.cc
@@ -20,6 +20,10 @@ THE SOFTWARE.
 #include "warp_common.hh"
 #include <hip_test_common.hh>
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 69 // suppress integer truncation warning
+#endif
+
 template <typename T> __global__ void shfl_1(T* Input, T* Output) {
   int tid = threadIdx.x;
   // Creates groups consisting of every fourth thread.

--- a/projects/hip-tests/catch/unit/warp/hipShflSyncUpTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipShflSyncUpTests.cc
@@ -20,6 +20,10 @@ THE SOFTWARE.
 #include "warp_common.hh"
 #include <hip_test_common.hh>
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 69 // suppress integer truncation warning
+#endif
+
 template <typename T> __global__ void shflUp_1(T* Input, T* Output) {
   auto tid = threadIdx.x;
   int srcLane = (tid > 3) ? 3 : 0;

--- a/projects/hip-tests/catch/unit/warp/hipShflSyncXorTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipShflSyncXorTests.cc
@@ -20,6 +20,10 @@ THE SOFTWARE.
 #include "warp_common.hh"
 #include <hip_test_common.hh>
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 69 // suppress integer truncation warning
+#endif
+
 template <typename T> __global__ void shflXor_1(T* Input, T* Output) {
   auto tid = threadIdx.x;
   Output[tid] = __shfl_xor_sync(AllThreads, Input[tid], 16);

--- a/projects/hip-tests/catch/unit/warp/hipVoteSyncTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipVoteSyncTests.cc
@@ -20,6 +20,11 @@ THE SOFTWARE.
 #include "warp_common.hh"
 #include <hip_test_common.hh>
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 69 // suppress integer truncation warning
+#pragma nv_diag_suppress 68 // suppress integer conversion change of sign warning
+#endif
+
 __global__ void any_1(int* Input, int* Output) {
   auto tid = threadIdx.x;
   Output[tid] = __any_sync(AllThreads, Input[tid]);

--- a/projects/hip-tests/catch/unit/warp/warp_all.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_all.cc
@@ -21,6 +21,10 @@ THE SOFTWARE.
 
 #include <bitset>
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 1444 // suppress __all deprecated warning
+#endif
+
 /**
  * @addtogroup all all
  * @{

--- a/projects/hip-tests/catch/unit/warp/warp_any.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_any.cc
@@ -21,6 +21,10 @@ THE SOFTWARE.
 
 #include <bitset>
 
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 1444 // suppress __any deprecated warning
+#endif
+
 /**
  * @addtogroup any any
  * @{

--- a/projects/hip-tests/catch/unit/warp/warp_ballot.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_ballot.cc
@@ -20,7 +20,9 @@ THE SOFTWARE.
 #include "warp_vote_common.hh"
 
 #include <bitset>
-
+#ifdef __HIP_PLATFORM_NVIDIA__
+#pragma nv_diag_suppress 1444 // suppress variable unused warning
+#endif
 /**
  * @addtogroup ballot ballot
  * @{

--- a/projects/hipother/hipnv/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
+++ b/projects/hipother/hipnv/include/hip/nvidia_detail/nvidia_hip_runtime_api.h
@@ -30,6 +30,7 @@ THE SOFTWARE.
 
 #include <driver_types.h>
 #include <stdio.h>
+#include <string.h>
 
 #define CUDA_9000 9000
 #define CUDA_10000 10000


### PR DESCRIPTION
## Motivation
Remove hip-test compiler warnings on NVIDIA platform.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
- Add NVCC diagnostic suppression pragmas.
- Move code under respected macro guard.
- Add header and remove unused code.
- Wrap functions in HIP_CHECK.
- Fix incorrect equality operator. 
- Fix duplicate variable and type.
- Change NULL to 0.
- Mark host and device
- Fix unused variable warnings.
- Fix invalid destination address test.
- Buffer overflow warning.
- Fix set value before used.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
- Test compilation in both AMD and NVIDIA platform.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Everything works as expected
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
