### PR TITLE
Ignore unused parameter for boost libraries

### DIFF
--- a/projects/hip-tests/catch/unit/math/special_funcs.cc
+++ b/projects/hip-tests/catch/unit/math/special_funcs.cc
@@ -24,7 +24,10 @@ THE SOFTWARE.
 #include "special_common.hh"
 #include "math_special_func_kernels_rtc.hh"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <boost/math/special_functions.hpp>
+#pragma GCC diagnostic pop
 
 
 /**

--- a/projects/hip-tests/catch/unit/math/trig_funcs.cc
+++ b/projects/hip-tests/catch/unit/math/trig_funcs.cc
@@ -24,7 +24,10 @@ THE SOFTWARE.
 #include "unary_common.hh"
 #include "binary_common.hh"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <boost/math/special_functions.hpp>
+#pragma GCC diagnostic pop
 
 
 MATH_UNARY_WITHIN_ULP_TEST_DEF(sin, std::sin, 2, 2);


### PR DESCRIPTION
## Motivation
The version of Boost, used by theRock build system(1.87.0), is breaking our build due to the unused variables. This PR fixes that compile error.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
This PR disables unused params check for specific boost headers using pragma directives
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Tests should be successfully compiling with Boost 1.87.0 and consequently pass.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Test compilation is fixed, waiting for PSDB to pass.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
