### PR TITLE
[SWDEV-560681] Allowed GPU enumeration to continue with non-contiguous render nodes

### DIFF
--- a/projects/rocm-smi-lib/src/rocm_smi_kfd.cc
+++ b/projects/rocm-smi-lib/src/rocm_smi_kfd.cc
@@ -693,7 +693,7 @@ KFDNode::Initialize(void) {
     node_to = it->first;
     link = it->second;
     ret = ReadKFDGpuId(node_to, &node_to_gpu_id);
-    if (ret) {return ret;}
+    if (ret) {continue;}
     if (node_to_gpu_id == 0) {  //  CPU node
       if (numa_node_found) {
         if (numa_node_weight_ > link->weight()) {

--- a/projects/rocm-smi-lib/src/rocm_smi_kfd.cc
+++ b/projects/rocm-smi-lib/src/rocm_smi_kfd.cc
@@ -685,7 +685,7 @@ KFDNode::Initialize(void) {
 
   std::map<uint32_t, std::shared_ptr<IOLink>>::iterator it;
   uint32_t node_to;
-  uint64_t node_to_gpu_id;
+  uint64_t node_to_gpu_id = 0;
   std::shared_ptr<IOLink> link;
   bool numa_node_found = false;
   for (it = io_link_map_tmp.begin(); it != io_link_map_tmp.end(); it++) {


### PR DESCRIPTION
## Motivation

This patch addresses an issue with getting topology information in container environments where assigning non-contiguous nodes to a container displayed incorrect topology information.

## Technical Details

This patch fixes the issue by ensuring that all devices visible are accounted for rather than prematurely returning.

## Test Plan

Developer verified results against expected results given on Ticket mentioned in title.

## Test Result

Test results matched

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
