### PR TITLE
Rename "corr_id" to "stack_id" in Perfetto annotations to match new n…

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -784,8 +784,10 @@ tool_tracing_callback_stop(
                 if(config::get_perfetto_annotations())
                 {
                     tracing::add_perfetto_annotation(ctx, "begin_ns", _beg_ts);
-                    tracing::add_perfetto_annotation(ctx, "corr_id",
+                    tracing::add_perfetto_annotation(ctx, "stack_id",
                                                      record.correlation_id.internal);
+                    tracing::add_perfetto_annotation(ctx, "parent_stack_id",
+                                                     record.correlation_id.ancestor);
                     if(stream_id.handle != 0)
                         tracing::add_perfetto_annotation(ctx, "stream_id",
                                                          stream_id.handle);
@@ -1124,8 +1126,10 @@ ompt_tracing_callback_start(rocprofiler_callback_tracing_record_t record,
                 if(config::get_perfetto_annotations())
                 {
                     tracing::add_perfetto_annotation(ctx, "begin_ns", _beg_ts);
-                    tracing::add_perfetto_annotation(ctx, "corr_id",
+                    tracing::add_perfetto_annotation(ctx, "stack_id",
                                                      record.correlation_id.internal);
+                    tracing::add_perfetto_annotation(ctx, "parent_stack_id",
+                                                     record.correlation_id.ancestor);
                     if(stream_id.handle != 0)
                         tracing::add_perfetto_annotation(ctx, "stream_id",
                                                          stream_id.handle);
@@ -1585,7 +1589,7 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
                     get_kernel_symbol_info(record->dispatch_info.kernel_id);
 
                 auto        _name     = tim::demangle(_kern_sym_data->kernel_name);
-                auto        _corr_id  = record->correlation_id.internal;
+                auto        _stack_id = record->correlation_id.internal;
                 auto        _beg_ns   = record->start_timestamp;
                 auto        _end_ns   = record->end_timestamp;
                 auto        _agent_id = record->dispatch_info.agent_id;
@@ -1632,7 +1636,7 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
                         {
                             tracing::add_perfetto_annotation(ctx, "begin_ns", _beg_ns);
                             tracing::add_perfetto_annotation(ctx, "end_ns", _end_ns);
-                            tracing::add_perfetto_annotation(ctx, "corr_id", _corr_id);
+                            tracing::add_perfetto_annotation(ctx, "stack_id", _stack_id);
                             tracing::add_perfetto_annotation(ctx, "stream_id",
                                                              _stream_id);
 
@@ -1678,7 +1682,7 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
 
                         tracing::push_perfetto(category::rocm_kernel_dispatch{},
                                                _name.c_str(), _track, _beg_ns,
-                                               ::perfetto::Flow::ProcessScoped(_corr_id),
+                                               ::perfetto::Flow::ProcessScoped(_stack_id),
                                                add_perfetto_annotations);
 
                         tracing::pop_perfetto(category::rocm_kernel_dispatch{},
@@ -1691,7 +1695,7 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
 
                         tracing::push_perfetto(category::rocm_hip_stream{}, _name.c_str(),
                                                _track, _beg_ns,
-                                               ::perfetto::Flow::ProcessScoped(_corr_id),
+                                               ::perfetto::Flow::ProcessScoped(_stack_id),
                                                add_perfetto_annotations);
 
                         tracing::pop_perfetto(category::rocm_hip_stream{}, _name.c_str(),
@@ -1705,7 +1709,7 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
                     static_cast<rocprofiler_buffer_tracing_memory_copy_record_t*>(
                         header->payload);
 
-                auto        _corr_id      = record->correlation_id.internal;
+                auto        _stack_id     = record->correlation_id.internal;
                 auto        _beg_ns       = record->start_timestamp;
                 auto        _end_ns       = record->end_timestamp;
                 auto        _dst_agent_id = record->dst_agent_id;
@@ -1758,7 +1762,7 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
                         {
                             tracing::add_perfetto_annotation(ctx, "begin_ns", _beg_ns);
                             tracing::add_perfetto_annotation(ctx, "end_ns", _end_ns);
-                            tracing::add_perfetto_annotation(ctx, "corr_id", _corr_id);
+                            tracing::add_perfetto_annotation(ctx, "stack_id", _stack_id);
                             tracing::add_perfetto_annotation(ctx, "stream_id",
                                                              _stream_id);
                             tracing::add_perfetto_annotation(ctx, "dst_agent",
@@ -1783,7 +1787,7 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
 
                         tracing::push_perfetto(category::rocm_memory_copy{}, _name.data(),
                                                _track, _beg_ns,
-                                               ::perfetto::Flow::ProcessScoped(_corr_id),
+                                               ::perfetto::Flow::ProcessScoped(_stack_id),
                                                add_perfetto_annotations);
 
                         tracing::pop_perfetto(category::rocm_memory_copy{}, "", _track,
@@ -1796,7 +1800,7 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
 
                         tracing::push_perfetto(category::rocm_hip_stream{}, _name.data(),
                                                _track, _beg_ns,
-                                               ::perfetto::Flow::ProcessScoped(_corr_id),
+                                               ::perfetto::Flow::ProcessScoped(_stack_id),
                                                add_perfetto_annotations);
 
                         tracing::pop_perfetto(category::rocm_hip_stream{}, "", _track,

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -786,8 +786,6 @@ tool_tracing_callback_stop(
                     tracing::add_perfetto_annotation(ctx, "begin_ns", _beg_ts);
                     tracing::add_perfetto_annotation(ctx, "stack_id",
                                                      record.correlation_id.internal);
-                    tracing::add_perfetto_annotation(ctx, "parent_stack_id",
-                                                     record.correlation_id.ancestor);
                     if(stream_id.handle != 0)
                         tracing::add_perfetto_annotation(ctx, "stream_id",
                                                          stream_id.handle);
@@ -1128,8 +1126,6 @@ ompt_tracing_callback_start(rocprofiler_callback_tracing_record_t record,
                     tracing::add_perfetto_annotation(ctx, "begin_ns", _beg_ts);
                     tracing::add_perfetto_annotation(ctx, "stack_id",
                                                      record.correlation_id.internal);
-                    tracing::add_perfetto_annotation(ctx, "parent_stack_id",
-                                                     record.correlation_id.ancestor);
                     if(stream_id.handle != 0)
                         tracing::add_perfetto_annotation(ctx, "stream_id",
                                                          stream_id.handle);


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Rename "corr_id" to "stack_id" in Perfetto annotations to match new naming in schema

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Renaming string in Perfetto annotations

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Run ctests. Verify that string has been renamed in Perfetto.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
