### PR TITLE
SWDEV-563752 - Allow hipMemLocationTypeHost in hipMemSetAccess even if memory was created on the device

### DIFF
--- a/projects/clr/hipamd/src/hip_vm.cpp
+++ b/projects/clr/hipamd/src/hip_vm.cpp
@@ -388,10 +388,6 @@ hipError_t hipMemSetAccess(void* ptr, size_t size, const hipMemAccessDesc* desc,
     if (accessLocationType != hipMemLocationTypeDevice && accessLocationType != hipMemLocationTypeHost) {
       HIP_RETURN(hipErrorInvalidValue);
     }
-    if (accessLocationType == hipMemLocationTypeHost &&
-        memLocationType != hipMemLocationTypeHost) {
-      HIP_RETURN(hipErrorInvalidValue)
-    }
 
     if (desc[desc_idx].location.id >= g_devices.size()) {
       HIP_RETURN(hipErrorInvalidValue)

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
@@ -1489,18 +1489,23 @@ TEST_CASE("Unit_hipMemSetAccessHost_devicealloc") {
 
   HIP_CHECK(hipMemMap(addr, mapSize, 0 /*offset*/, handle, 0 /*flags*/));
 
-  // Grant HOST access. 
+  // Grant HOST access.
   hipMemAccessDesc accHost{};
   accHost.flags = hipMemAccessFlagsProtReadWrite;
   accHost.location.type = hipMemLocationTypeHost;
   accHost.location.id = 0;
-  HIP_CHECK_ERROR(hipMemSetAccess(addr, mapSize, &accHost, 1), hipErrorInvalidValue);
+#if HT_AMD
+  // SWDEV-563752: we need to allow setAccess to the host even if location is set to
+  // hipMemLocationTypeDevice in hipMemCreate
+  HIP_CHECK(hipMemSetAccess(addr, mapSize, &accHost, 1));
+#else
+  HIP_CHECK_ERROR(hipMemSetAccess(addr, mapSize, &accHost, 1), hipErrorNotSupported);
+#endif
 
   HIP_CHECK(hipMemUnmap(addr, mapSize));
   HIP_CHECK(hipMemAddressFree(addr, mapSize));
   HIP_CHECK(hipMemRelease(handle));
 }
-
 /**
  * End doxygen group VirtualMemoryManagementTest.
  * @}


### PR DESCRIPTION
## Motivation
This PR removes a validation check in hipMemSetAccess that previously prevented granting host access to device-backed allocations.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Updated the Unit_hipMemSetAccessHost_devicealloc test to expect success on amd and hipErrorNotSupported on nvidia
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Unit_hipMemSetAccessHost_devicealloc
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Unit_hipMemSetAccessHost_devicealloc test should now pass with the changes in this PR.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
