### PR TITLE
Fix build failures due to incorrect std::string usage

### DIFF
--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -1003,7 +1003,7 @@ bool NumaNode::GetAffinity() {
   std::ifstream file(path);
   if (!file) {
     std::cerr << "Failed to open " << path << "\n";
-    ClPrint(amd::LOG_DEBUG, amd::LOG_RESOURCE, "%s cannot be opened", path);
+    ClPrint(amd::LOG_DEBUG, amd::LOG_RESOURCE, "%s cannot be opened", path.c_str());
     return false;
   }
   std::string line;


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
clr builds are failing due to missing `c_str()` call on `std::string`
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Add `.c_str()` call
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Doesn't apply
## Test Result

<!-- Briefly summarize test outcomes. -->
Doesn't apply
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
