### PR TITLE
Change rocprofiler-sdk CMake compatibility to AnyNewerVersion

### DIFF
--- a/projects/rocprofiler-sdk/cmake/rocprofiler_config_install.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_config_install.cmake
@@ -93,7 +93,7 @@ configure_package_config_file(
 write_basic_package_version_file(
     ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake/${PACKAGE_NAME}/${PACKAGE_NAME}-config-version.cmake
     VERSION ${PROJECT_VERSION}
-    COMPATIBILITY AnyNewerVersion)
+    COMPATIBILITY SameMajorVersion)
 
 configure_file(
     ${PROJECT_SOURCE_DIR}/cmake/rocprofiler_config_nolink_target.cmake

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_config_install.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_config_install.cmake
@@ -93,7 +93,7 @@ configure_package_config_file(
 write_basic_package_version_file(
     ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake/${PACKAGE_NAME}/${PACKAGE_NAME}-config-version.cmake
     VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMinorVersion)
+    COMPATIBILITY AnyNewerVersion)
 
 configure_file(
     ${PROJECT_SOURCE_DIR}/cmake/rocprofiler_config_nolink_target.cmake

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_config_install_rocpd.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_config_install_rocpd.cmake
@@ -39,7 +39,7 @@ configure_package_config_file(
 write_basic_package_version_file(
     ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake/${PACKAGE_NAME}/${PACKAGE_NAME}-config-version.cmake
     VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMinorVersion)
+    COMPATIBILITY SameMajorVersion)
 
 install(
     FILES

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_config_install_roctx.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_config_install_roctx.cmake
@@ -39,7 +39,7 @@ configure_package_config_file(
 write_basic_package_version_file(
     ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake/${PACKAGE_NAME}/${PACKAGE_NAME}-config-version.cmake
     VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMinorVersion)
+    COMPATIBILITY SameMajorVersion)
 
 install(
     FILES


### PR DESCRIPTION
## Summary
Update CMake package version compatibility from SameMinorVersion to AnyNewerVersion to allow downstream packages (like RDC) to use newer versions of rocprofiler-sdk without requiring exact minor version match.

This fixes compatibility issues where RDC requests 1.0.0 but finds 1.1.0.

## Changes
- Modified `projects/rocprofiler-sdk/cmake/rocprofiler_config_install.cmake` to use `AnyNewerVersion` compatibility mode

## Test plan
- Verify that downstream packages can successfully find and use rocprofiler-sdk with version mismatches
- Confirm RDC can use rocprofiler-sdk 1.1.0 when requesting 1.0.0