### PR TITLE
[rocprof-compute] docs: change jinja template to filter out surrounding single & double…

### DIFF
--- a/projects/rocprofiler-compute/docs/_templates/metrics_table.j2
+++ b/projects/rocprofiler-compute/docs/_templates/metrics_table.j2
@@ -7,6 +7,6 @@
 
     {% for metric, metric_info in data.items() %}
     * - {{ metric }}
-      - {{ metric_info.rst }}
+      - {{ metric_info.rst | trim("'\"") }}
       - {{ metric_info.unit }}
     {% endfor %}


### PR DESCRIPTION
… quotes

## Motivation

Does this fix broken doc pages?

## Technical Details

YAML is auto-adding single & double quotes for text containing special characters.
When JINJA is used to pull these YAMLs in, the quotes are breaking the JINJA code. Trying to filter out these quotes to render the doc pages correctly

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
