### PR TITLE
Fix VMM type errors on Nvidia

### DIFF
--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemAddressFree.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemAddressFree.cc
@@ -95,7 +95,7 @@ TEST_CASE("Unit_hipMemAddressFree_Capture") {
 
   size_t reserved_size = ((granularity + buffer_size - 1) / granularity) * granularity;
 
-  hipDeviceptr_t reserved_ptr = nullptr;
+  void* reserved_ptr = nullptr;
   HIP_CHECK(hipMemAddressReserve(&reserved_ptr, reserved_size, 0, nullptr, 0));
 
   hipStream_t stream = nullptr;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemAddressReserve.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemAddressReserve.cc
@@ -158,7 +158,7 @@ TEST_CASE("Unit_hipMemAddressReserve_Capture") {
   constexpr size_t kAlignment = 2;
   constexpr int kDeviceId = 0;
   hipDevice_t device = 0;
-  hipDeviceptr_t device_ptr = nullptr;
+  void* device_ptr = nullptr;
 
   CTX_CREATE();
   HIP_CHECK(hipDeviceGet(&device, kDeviceId));

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
@@ -690,7 +690,7 @@ TEST_CASE("Unit_hipMemMap_Capture") {
   constexpr size_t kAlignment = 2;
   constexpr int kDeviceId = 0;
   hipDevice_t device = 0;
-  hipDeviceptr_t device_ptr = nullptr;
+  void* device_ptr = nullptr;
 
   CTX_CREATE();
   HIP_CHECK(hipDeviceGet(&device, kDeviceId));

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemRetainAllocationHandle.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemRetainAllocationHandle.cc
@@ -160,7 +160,7 @@ TEST_CASE("Unit_hipMemRetainAllocationHandle_Capture") {
 
   size_t allocation_size = ((granularity + buffer_size - 1) / granularity) * granularity;
   hipMemGenericAllocationHandle_t allocation_handle;
-  hipDeviceptr_t device_ptr;
+  void* device_ptr;
   HIP_CHECK(hipMemCreate(&allocation_handle, allocation_size, &allocation_prop, 0));
   HIP_CHECK(hipMemAddressReserve(&device_ptr, allocation_size, 0, 0, 0));
   HIP_CHECK(hipMemMap(device_ptr, allocation_size, 0, allocation_handle, 0));
@@ -171,7 +171,7 @@ TEST_CASE("Unit_hipMemRetainAllocationHandle_Capture") {
 
   GENERATE_CAPTURE();
   BEGIN_CAPTURE(stream);
-  HIP_CHECK(hipMemRetainAllocationHandle(&retained_handle, reinterpret_cast<void*>(device_ptr)));
+  HIP_CHECK(hipMemRetainAllocationHandle(&retained_handle, device_ptr));
   END_CAPTURE(stream);
 
   HIP_CHECK(hipStreamDestroy(stream));

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
@@ -1353,7 +1353,7 @@ TEST_CASE("Unit_hipMemSetGetAccess_Capture") {
   hipMemGenericAllocationHandle_t mem_handle;
   HIP_CHECK(hipMemCreate(&mem_handle, vmm_bytes, &alloc_prop, 0));
 
-  hipDeviceptr_t vmm_ptr = nullptr;
+  void* vmm_ptr = nullptr;
   HIP_CHECK(hipMemAddressReserve(&vmm_ptr, vmm_bytes, 0, 0, 0));
   HIP_CHECK(hipMemMap(vmm_ptr, vmm_bytes, 0, mem_handle, 0));
   HIP_CHECK(hipMemRelease(mem_handle));

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemUnmap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemUnmap.cc
@@ -108,7 +108,7 @@ TEST_CASE("Unit_hipMemUnmap_Capture") {
   size_t mem_size = ((granularity + kBufferSize - 1) / granularity) * granularity;
 
   hipMemGenericAllocationHandle_t allocation_handle;
-  hipDeviceptr_t device_ptr;
+  void* device_ptr;
   HIP_CHECK(hipMemCreate(&allocation_handle, mem_size, &allocation_prop, 0));
   HIP_CHECK(hipMemAddressReserve(&device_ptr, mem_size, 0, nullptr, 0));
   HIP_CHECK(hipMemMap(device_ptr, mem_size, 0, allocation_handle, 0));


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fix VirtualMemoryManagement build errors on NVIDIA.
## Technical Details
Changed pointer types to match API pointer types.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Test compilation and run tests on both AMD and NVIDIA platform.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Compilation works on both AMD and NVIDIA.
No new tests fail due to changes.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
