### PR TITLE
Fix bug in rocprof-compute parsing

### DIFF
--- a/projects/rocprofiler-compute/src/utils/parser.py
+++ b/projects/rocprofiler-compute/src/utils/parser.py
@@ -346,7 +346,7 @@ class MetricEvaluator:
                 local_expr_context,
             )
 
-            if np.isnan(eval_result).any():
+            if eval_result is None or np.isnan(eval_result).any():
                 return ""
             else:
                 return eval_result


### PR DESCRIPTION

## Motivation

Fix bug that causes warnings to be displayed

## Technical Details

Were not handling the case where the eval result is `None` Some columns have an empty `peak` column, so we use `'None'`, which evaluates to the `None` object


This resulted in warnings being displayed:

<img width="1756" height="421" alt="image" src="https://github.com/user-attachments/assets/3d279344-551c-44c2-8ce9-268ee8a6f406" />

Check for `None` and return empty string.

## Test Plan

Run analysis.

- Verify warnings do not appear

- Verify cells that are `None` are empty.

## Test Result

Works as expected

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
