### PR TITLE
Consistent Queue IDs for Track Names and Metdata in Perfetto

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
@@ -276,6 +276,9 @@ write_perfetto(
             auto _namess = std::stringstream{};
             auto agent_index_info =
                 tool_metadata.get_agent_index(_agent->id, ocfg.agent_index_value);
+            ROCP_WARNING_IF(qitr.handle == 0) << fmt::format(
+                "Queue ID handle should be a positive int greater than 0, but it is {}",
+                qitr.handle);
             _namess << "COMPUTE " << agent_index_info.label << " [" << agent_index_info.index
                     << "] QUEUE [" << (qitr.handle > 0 ? qitr.handle - 1 : 0) << "] ";
             _namess << agent_index_info.type;

--- a/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
@@ -277,7 +277,7 @@ write_perfetto(
             auto agent_index_info =
                 tool_metadata.get_agent_index(_agent->id, ocfg.agent_index_value);
             _namess << "COMPUTE " << agent_index_info.label << " [" << agent_index_info.index
-                    << "] QUEUE [" << qitr.handle - 1 << "] ";
+                    << "] QUEUE [" << (qitr.handle > 0 ? qitr.handle - 1 : 0) << "] ";
             _namess << agent_index_info.type;
 
             auto _track = ::perfetto::Track{get_hash_id(_namess.str())};

--- a/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
@@ -269,7 +269,6 @@ write_perfetto(
 
     for(const auto& aitr : agent_queue_ids)
     {
-        uint32_t nqueue = 0;
         for(auto qitr : aitr.second)
         {
             const auto* _agent = _get_agent(aitr.first);
@@ -278,7 +277,7 @@ write_perfetto(
             auto agent_index_info =
                 tool_metadata.get_agent_index(_agent->id, ocfg.agent_index_value);
             _namess << "COMPUTE " << agent_index_info.label << " [" << agent_index_info.index
-                    << "] QUEUE [" << nqueue++ << "] ";
+                    << "] QUEUE [" << qitr.handle - 1 << "] ";
             _namess << agent_index_info.type;
 
             auto _track = ::perfetto::Track{get_hash_id(_namess.str())};


### PR DESCRIPTION
## Motivation

[SWDEV-562180](https://ontrack-internal.amd.com/browse/SWDEV-562180) rocprofv3 --group-by-queue shows inconsistent queue-IDs between the track and the metadata panel

Queue IDs are inconsistent between track names and the metadata panel as detailed in the linked JIRA ticket. This PR fixes the issue making the queue ID track name correctly correspond to the metadata panel when grouping by queues.

## Technical Details

Sorts tracks by qitr rather than a local variable that's incremented.

## Test Plan

Existing tests should pass. I can't seem to inspect the metadata panel in the pytest, so I'm not sure if we can add an automated test for this change.

## Test Result

Existing tests should pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
