### PR TITLE
[Rocprofiler-systems] : Refactor papi enumeration to fix a hang on Intel systems

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
@@ -161,6 +161,7 @@ main(int argc, char** argv)
     }
     _category_options.emplace("hw_counters::CPU");
     _category_options.emplace("hw_counters::GPU");
+    _category_options.emplace("hw_counters::overflow");
 
     array_t<bool, TOTAL> options    = { false, false, false, false, false, false, false };
     array_t<string_t, TOTAL> fields = {};
@@ -1075,18 +1076,30 @@ write_hw_counter_info(std::ostream& os, const array_t<bool, N>& options,
     using width_bool       = array_t<bool, N>;
     using hwcounter_info_t = std::vector<tim::hardware_counters::info>;
 
-    auto _papi_events = tim::papi::available_events_info();
+    auto _papi_events = tim::papi::available_events_info({ "perf_event_uncore" });
     auto _rocm_events =
         (gpu_count > 0) ? rocprofsys::rocm::rocm_events() : hwcounter_info_t{};
 
-    if(alphabetical)
+    // Filter PAPI events for overflow sampling (perf events matching PERF_COUNT pattern)
+    auto _overflow_events = hwcounter_info_t{};
     {
-        auto _sorter = [](const auto& lhs, const auto& rhs) {
-            return (lhs.symbol() < rhs.symbol());
-        };
-        std::sort(_papi_events.begin(), _papi_events.end(), _sorter);
-        std::sort(_rocm_events.begin(), _rocm_events.end(), _sorter);
+        namespace regex_const = ::std::regex_constants;
+        auto _regex =
+            std::regex{ "^(perf::|)PERF_COUNT_(HW|SW|HW_CACHE)_([A-Z_]+)(|:[A-Z]+)$",
+                        regex_const::optimize };
+        for(const auto& itr : _papi_events)
+        {
+            if(std::regex_match(itr.symbol(), _regex)) _overflow_events.emplace_back(itr);
+        }
     }
+
+    // sort the events alphabetically
+    auto _sorter = [](const auto& lhs, const auto& rhs) {
+        return (lhs.symbol() < rhs.symbol());
+    };
+    std::sort(_papi_events.begin(), _papi_events.end(), _sorter);
+    std::sort(_rocm_events.begin(), _rocm_events.end(), _sorter);
+    std::sort(_overflow_events.begin(), _overflow_events.end(), _sorter);
 
     auto _process_counters = [](auto& _events_v, int32_t _offset_v) {
         for(auto& iitr : _events_v)
@@ -1097,10 +1110,11 @@ write_hw_counter_info(std::ostream& os, const array_t<bool, N>& options,
     int32_t _offset = 0;
     _offset += _process_counters(_papi_events, _offset);
     _offset += _process_counters(_rocm_events, _offset);
+    _offset += _process_counters(_overflow_events, _offset);
 
-    auto fields =
-        std::vector<std::pair<std::string, hwcounter_info_t>>{ { "CPU", _papi_events },
-                                                               { "GPU", _rocm_events } };
+    auto fields = std::vector<std::pair<std::string, hwcounter_info_t>>{
+        { "CPU", _papi_events }, { "GPU", _rocm_events }, { "overflow", _overflow_events }
+    };
     array_t<string_t, N> _labels = { "HARDWARE COUNTER", "DEVICE", "AVAILABLE", "SUMMARY",
                                      "DESCRIPTION" };
     array_t<bool, N>     _center = { false, true, true, false, false };

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
@@ -161,7 +161,6 @@ main(int argc, char** argv)
     }
     _category_options.emplace("hw_counters::CPU");
     _category_options.emplace("hw_counters::GPU");
-    _category_options.emplace("hw_counters::overflow");
 
     array_t<bool, TOTAL> options    = { false, false, false, false, false, false, false };
     array_t<string_t, TOTAL> fields = {};
@@ -1080,16 +1079,19 @@ write_hw_counter_info(std::ostream& os, const array_t<bool, N>& options,
     auto _rocm_events =
         (gpu_count > 0) ? rocprofsys::rocm::rocm_events() : hwcounter_info_t{};
 
-    // Filter PAPI events for overflow sampling (perf events matching PERF_COUNT pattern)
-    auto _overflow_events = hwcounter_info_t{};
+    // Tag overflow events by modifying both short and long descriptions upfront
     {
         namespace regex_const = ::std::regex_constants;
         auto _regex =
             std::regex{ "^(perf::|)PERF_COUNT_(HW|SW|HW_CACHE)_([A-Z_]+)(|:[A-Z]+)$",
                         regex_const::optimize };
-        for(const auto& itr : _papi_events)
+        for(auto& itr : _papi_events)
         {
-            if(std::regex_match(itr.symbol(), _regex)) _overflow_events.emplace_back(itr);
+            if(std::regex_match(itr.symbol(), _regex))
+            {
+                itr.short_description() += " (overflow event)";
+                itr.long_description() += " (overflow event)";
+            }
         }
     }
 
@@ -1099,7 +1101,6 @@ write_hw_counter_info(std::ostream& os, const array_t<bool, N>& options,
     };
     std::sort(_papi_events.begin(), _papi_events.end(), _sorter);
     std::sort(_rocm_events.begin(), _rocm_events.end(), _sorter);
-    std::sort(_overflow_events.begin(), _overflow_events.end(), _sorter);
 
     auto _process_counters = [](auto& _events_v, int32_t _offset_v) {
         for(auto& iitr : _events_v)
@@ -1110,11 +1111,10 @@ write_hw_counter_info(std::ostream& os, const array_t<bool, N>& options,
     int32_t _offset = 0;
     _offset += _process_counters(_papi_events, _offset);
     _offset += _process_counters(_rocm_events, _offset);
-    _offset += _process_counters(_overflow_events, _offset);
 
-    auto fields = std::vector<std::pair<std::string, hwcounter_info_t>>{
-        { "CPU", _papi_events }, { "GPU", _rocm_events }, { "overflow", _overflow_events }
-    };
+    auto fields =
+        std::vector<std::pair<std::string, hwcounter_info_t>>{ { "CPU", _papi_events },
+                                                               { "GPU", _rocm_events } };
     array_t<string_t, N> _labels = { "HARDWARE COUNTER", "DEVICE", "AVAILABLE", "SUMMARY",
                                      "DESCRIPTION" };
     array_t<bool, N>     _center = { false, true, true, false, false };
@@ -1188,7 +1188,7 @@ write_hw_counter_info(std::ostream& os, const array_t<bool, N>& options,
     {
         for(const auto& itr : fitr.second)
         {
-            width_type _w = { { (int64_t) itr.symbol().length(), (int64_t) 4, (int64_t) 6,
+            width_type _w = { { (int64_t) itr.symbol().length(), (int64_t) 8, (int64_t) 6,
                                 (int64_t) itr.short_description().length(),
                                 (int64_t) itr.long_description().length() } };
             for(auto& witr : _w)

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
@@ -1188,7 +1188,7 @@ write_hw_counter_info(std::ostream& os, const array_t<bool, N>& options,
     {
         for(const auto& itr : fitr.second)
         {
-            width_type _w = { { (int64_t) itr.symbol().length(), (int64_t) 8, (int64_t) 6,
+            width_type _w = { { (int64_t) itr.symbol().length(), (int64_t) 4, (int64_t) 6,
                                 (int64_t) itr.short_description().length(),
                                 (int64_t) itr.long_description().length() } };
             for(auto& witr : _w)

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
@@ -310,10 +310,11 @@ process_categories(parser_t& p, const str_set_t& _category_options)
     std::vector<std::function<void()>> _shorthand_patches{};
 
     // Helper to do case-insensitive string comparison
-    auto _tolower = [](const std::string& str) {
-        std::transform(str.begin(), str.end(), str.begin(),
+    auto _tolower = [](const std::string& in) {
+        std::string out = in;
+        std::transform(out.begin(), out.end(), out.begin(),
                        [](unsigned char c) { return std::tolower(c); });
-        return str;
+        return out;
     };
 
     // Helper to find case-insensitive match in category options

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
@@ -310,7 +310,7 @@ process_categories(parser_t& p, const str_set_t& _category_options)
     std::vector<std::function<void()>> _shorthand_patches{};
 
     // Helper to do case-insensitive string comparison
-    auto _tolower = [](std::string str) {
+    auto _tolower = [](const std::string& str) {
         std::transform(str.begin(), str.end(), str.begin(),
                        [](unsigned char c) { return std::tolower(c); });
         return str;

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
@@ -27,8 +27,11 @@
 #include <timemory/variadic/macros.hpp>
 
 #include <algorithm>
+#include <array>
 #include <string>
+#include <string_view>
 #include <sys/stat.h>
+#include <unordered_map>
 
 using settings = ::tim::settings;
 
@@ -310,58 +313,72 @@ process_categories(parser_t& p, const str_set_t& _category_options)
     std::vector<std::function<void()>> _shorthand_patches{};
 
     // Helper to do case-insensitive string comparison
-    auto _tolower = [](const std::string& in) {
-        std::string out = in;
+    auto _tolower = [](std::string_view in) {
+        std::string out(in);
         std::transform(out.begin(), out.end(), out.begin(),
                        [](unsigned char c) { return std::tolower(c); });
         return out;
     };
 
-    // Helper to find case-insensitive match in category options
-    auto _find_category = [&_category_options,
-                           &_tolower](const std::string& input) -> std::string {
-        auto input_lower = _tolower(input);
-        for(const auto& opt : _category_options)
+    // Cache lowercase -> original category mapping to avoid repeated string conversions
+    // Also pre-compute shorthand mappings (e.g., "wallclock" -> "component::WallClock")
+    std::unordered_map<std::string, std::string> _category_map;
+    constexpr std::array<std::string_view, 3> _prefixes = { "component::", "settings::",
+                                                            "hw_counters::" };
+
+    for(const auto& opt : _category_options)
+    {
+        auto opt_lower           = _tolower(opt);
+        _category_map[opt_lower] = opt;
+
+        // Add shorthand mappings if the option starts with a known prefix
+        for(auto prefix : _prefixes)
         {
-            if(_tolower(opt) == input_lower) return opt;
+            if(opt_lower.size() > prefix.size() &&
+               opt_lower.compare(0, prefix.size(), _tolower(prefix)) == 0)
+            {
+                // Map the shorthand (without prefix) to the full canonical form
+                auto shorthand           = opt_lower.substr(prefix.size());
+                _category_map[shorthand] = opt;
+                break;
+            }
         }
+    }
+
+    // Helper to find case-insensitive match in category options
+    auto _find_category = [&_category_map,
+                           &_tolower](std::string_view input) -> std::string_view {
+        auto input_lower = _tolower(input);
+        auto it          = _category_map.find(input_lower);
+        if(it != _category_map.end()) return it->second;
         return "";
     };
 
+    // Process categories - now handles both full names and shorthands via the pre-built
+    // map
     for(const auto& itr : category_view)
     {
-        auto _is_shorthand = [&_shorthand_patches, &_find_category,
-                              itr](const std::string& _prefix) {
-            auto _opt     = TIMEMORY_JOIN("::", _prefix, itr);
-            auto _matched = _find_category(_opt);
-            if(!_matched.empty())
-            {
-                _shorthand_patches.emplace_back([itr, _matched]() {
-                    category_view.erase(itr);
-                    category_view.emplace(_matched);
-                });
-                return true;
-            }
-            return false;
-        };
-
-        // Try case-insensitive match
         auto _matched = _find_category(itr);
         if(!_matched.empty())
         {
-            _shorthand_patches.emplace_back([itr, _matched]() {
-                category_view.erase(itr);
-                category_view.emplace(_matched);
-            });
-            continue;
+            // Only create patch if the matched form differs from input (normalization
+            // needed)
+            if(_matched != itr)
+            {
+                // Explicitly convert string_view to string for safe capture
+                std::string _matched_str(_matched);
+                _shorthand_patches.emplace_back([itr, _matched_str]() {
+                    category_view.erase(itr);
+                    category_view.emplace(_matched_str);
+                });
+            }
         }
-
-        // Try shorthand notation
-        if(!_is_shorthand("component") && !_is_shorthand("settings") &&
-           !_is_shorthand("hw_counters"))
+        else
+        {
             throw std::runtime_error(
                 itr + " is not a valid category. Use --list-categories to view "
                       "valid categories");
+        }
     }
     for(auto&& itr : _shorthand_patches)
         itr();

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
@@ -26,6 +26,7 @@
 #include <timemory/settings/settings.hpp>
 #include <timemory/variadic/macros.hpp>
 
+#include <algorithm>
 #include <string>
 #include <sys/stat.h>
 
@@ -307,30 +308,59 @@ process_categories(parser_t& p, const str_set_t& _category_options)
 {
     category_view = p.get<str_set_t>("categories");
     std::vector<std::function<void()>> _shorthand_patches{};
+
+    // Helper to do case-insensitive string comparison
+    auto _tolower = [](std::string str) {
+        std::transform(str.begin(), str.end(), str.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+        return str;
+    };
+
+    // Helper to find case-insensitive match in category options
+    auto _find_category = [&_category_options,
+                           &_tolower](const std::string& input) -> std::string {
+        auto input_lower = _tolower(input);
+        for(const auto& opt : _category_options)
+        {
+            if(_tolower(opt) == input_lower) return opt;
+        }
+        return "";
+    };
+
     for(const auto& itr : category_view)
     {
-        auto _is_shorthand = [&_shorthand_patches, &_category_options,
+        auto _is_shorthand = [&_shorthand_patches, &_find_category,
                               itr](const std::string& _prefix) {
-            auto _opt = TIMEMORY_JOIN("::", _prefix, itr);
-            if(_category_options.count(_opt) > 0)
+            auto _opt     = TIMEMORY_JOIN("::", _prefix, itr);
+            auto _matched = _find_category(_opt);
+            if(!_matched.empty())
             {
-                _shorthand_patches.emplace_back([itr, _opt]() {
+                _shorthand_patches.emplace_back([itr, _matched]() {
                     category_view.erase(itr);
-                    category_view.emplace(_opt);
+                    category_view.emplace(_matched);
                 });
                 return true;
             }
             return false;
         };
 
-        if(_category_options.count(itr) == 0)
+        // Try case-insensitive match
+        auto _matched = _find_category(itr);
+        if(!_matched.empty())
         {
-            if(!_is_shorthand("component") && !_is_shorthand("settings") &&
-               !_is_shorthand("hw_counters"))
-                throw std::runtime_error(
-                    itr + " is not a valid category. Use --list-categories to view "
-                          "valid categories");
+            _shorthand_patches.emplace_back([itr, _matched]() {
+                category_view.erase(itr);
+                category_view.emplace(_matched);
+            });
+            continue;
         }
+
+        // Try shorthand notation
+        if(!_is_shorthand("component") && !_is_shorthand("settings") &&
+           !_is_shorthand("hw_counters"))
+            throw std::runtime_error(
+                itr + " is not a valid category. Use --list-categories to view "
+                      "valid categories");
     }
     for(auto&& itr : _shorthand_patches)
         itr();

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -626,7 +626,7 @@ configure_settings(bool _init)
     ROCPROFSYS_CONFIG_SETTING(
         std::string, "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT",
         "Metric for overflow sampling. Defaults to perf::PERF_COUNT_HW_CACHE_REFERENCES. "
-        "For full list of events see: rocprof-sys-avail -H -c overflow",
+        "For full list of events see: rocprof-sys-avail -H -c CPU -r overflow",
         std::string{ "perf::PERF_COUNT_HW_CACHE_REFERENCES" }, "sampling",
         "hardware_counters");
 

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -948,7 +948,8 @@ configure_settings(bool _init)
            !_config->get_papi_events().empty())
         {
             std::vector<std::string> _papi_choices = {};
-            for(auto itr : tim::papi::available_events_info({ "perf_event_uncore" }))
+            for(const auto& itr :
+                tim::papi::available_events_info({ "perf_event_uncore" }))
             {
                 if(itr.available()) _papi_choices.emplace_back(itr.symbol());
             }

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -623,11 +623,12 @@ configure_settings(bool _init)
         "the same signal (SIGRTMIN + 1)",
         SIGRTMIN + 1, "sampling", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT",
-                              "Metric for overflow sampling",
-                              std::string{ "perf::PERF_COUNT_HW_CACHE_REFERENCES" },
-                              "sampling", "hardware_counters")
-        ->set_choices(perf::get_config_choices());
+    ROCPROFSYS_CONFIG_SETTING(
+        std::string, "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT",
+        "Metric for overflow sampling. Defaults to perf::PERF_COUNT_HW_CACHE_REFERENCES. "
+        "For full list of events see: rocprof-sys-avail -H -c overflow",
+        std::string{ "perf::PERF_COUNT_HW_CACHE_REFERENCES" }, "sampling",
+        "hardware_counters");
 
     rocprofiler_sdk::config_settings(_config);
     amd_smi::config_settings(_config);
@@ -942,12 +943,17 @@ configure_settings(bool _init)
     {
         auto _papi_events = _config->find("ROCPROFSYS_PAPI_EVENTS");
         _add_rocprofsys_category(_papi_events);
-        std::vector<std::string> _papi_choices = {};
-        for(auto itr : tim::papi::available_events_info())
+        // Only enumerate PAPI events if the user has specified them
+        if(_papi_events->second->get_config_updated() ||
+           !_config->get_papi_events().empty())
         {
-            if(itr.available()) _papi_choices.emplace_back(itr.symbol());
+            std::vector<std::string> _papi_choices = {};
+            for(auto itr : tim::papi::available_events_info({ "perf_event_uncore" }))
+            {
+                if(itr.available()) _papi_choices.emplace_back(itr.symbol());
+            }
+            _papi_events->second->set_choices(_papi_choices);
         }
-        _papi_events->second->set_choices(_papi_choices);
     }
 #else
     _config->find("ROCPROFSYS_PAPI_EVENTS")->second->set_hidden(true);

--- a/projects/rocprofiler-systems/source/lib/core/perf.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/perf.cpp
@@ -31,35 +31,6 @@ namespace perf
 {
 namespace units = ::tim::units;
 
-std::vector<std::string>
-get_config_choices()
-{
-    namespace regex_const = ::std::regex_constants;
-
-    auto       _data        = std::vector<std::string>{};
-    auto       _papi_events = tim::papi::available_events_info();
-    const auto _prefix      = std::string_view{ "perf::" };
-    auto       _regex =
-        std::regex{ "^(perf::|)PERF_COUNT_(HW|SW|HW_CACHE)_([A-Z_]+)(|:[A-Z]+)$",
-                    regex_const::optimize };
-
-    for(const auto& itr : _papi_events)
-    {
-        if(std::regex_match(itr.symbol(), _regex))
-        {
-            auto _symbol = itr.symbol();
-            auto _pos    = _symbol.find(_prefix);
-            if(_pos == 0) _symbol = _symbol.substr(_prefix.length());
-            _data.emplace_back(_symbol);
-        }
-    }
-
-    std::sort(_data.begin(), _data.end());
-    _data.erase(std::unique(_data.begin(), _data.end()), _data.end());
-
-    return _data;
-}
-
 event_type
 get_event_type(std::string_view _v)
 {

--- a/projects/rocprofiler-systems/source/lib/core/perf.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/perf.hpp
@@ -277,9 +277,6 @@ enum class record_type
 #endif
 };
 
-std::vector<std::string>
-get_config_choices();
-
 event_type get_event_type(std::string_view);
 hw_config  get_hw_config(std::string_view);
 sw_config  get_sw_config(std::string_view);


### PR DESCRIPTION
## Motivation

Resolves: SWDEV-563681

When profiling with PAPI_enum_cmp_event() or initializing PAPI components, the application appeared to “hang” on Intel systems but completed normally on AMD EPYC systems.
PAPI uses libpfm4 and the Linux perf_event subsystem to enumerate available hardware counters from /sys/devices/.

On Intel system exposes a very large number of uncore performance monitoring units (PMUs) under /sys/devices/,
The PAPI perf_event_uncore component attempts to enumerate every one of these uncore PMUs and their associated events through libpfm.
On AMD EPYC systems, /sys/devices/ only contains a few entries such as amd_iommu_* and no uncore PMU directories, so enumeration completes almost instantly.

Enumerating through this large number of perf_event_uncore events cause a hang like situation for a long time.

## Technical Details

- Add an exclude argument to available_events_info() for perf_event_uncore causing hang like case on Intel systems with large number of uncore events.
- Enumerate papi available events only when papi events are specified by users inside early initialization logic
- Move papi available event query for ROCPROFSYS_SAMPLING_OVERFLOW_EVENT config setting to the avail component, to move the heavy logic outside initialization.
- Make category option for rocprof-sys-avail -H -c case insensitive
- Sort the output of the hardware counter output alphabetically.
- Provide new option to query available overflow events that can be specified for ROCPROFSYS_SAMPLING_OVERFLOW_EVENT using new command option rocprof-sys-avail -H -c overflow

## Test Plan

Manual tests performed.

## Test Result

Expected test results achieved

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
