### PR TITLE
Disable therock summary check, make it always positive

### DIFF
--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -124,7 +124,9 @@ jobs:
             | jq --raw-output \
             'map_values(select(.result!="success" and .result!="skipped")) | keys | join(",")' \
           )"
-          if [[ "${FAILED_JOBS}" != "" ]]; then
-            echo "The following jobs failed: ${FAILED_JOBS}"
-            exit 1
-          fi
+          exit 0
+          # TODO: uncomment when theRock CI is no longer requirement for merge
+          # if [[ "${FAILED_JOBS}" != "" ]]; then
+          #   echo "The following jobs failed: ${FAILED_JOBS}"
+          #   exit 1
+          # fi


### PR DESCRIPTION
## Motivation
TheRock pipeline currently blocks merge for all PRs due to the unrelated build issue in rocprofiler. This PR makes that check always successful.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Comment out check for failed jobs in TheRock summary
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
TheRock summary should switch to green
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Waiting for CI to pass
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
