### PR TITLE
SWDEV-561284 - Fix use of uninitialized memory in Unit_hipMemVmm_Basic and Unit_hipMemVmm_Uncached

### DIFF
--- a/projects/hip-tests/catch/unit/memory/hipMemVmm.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemVmm.cc
@@ -50,7 +50,7 @@ TEST_CASE("Unit_hipMemVmm_Basic") {
 
   size_t granularity = 0;
 
-  hipMemAllocationProp memAllocationProp;
+  hipMemAllocationProp memAllocationProp{};
   memAllocationProp.type = hipMemAllocationTypePinned;
   memAllocationProp.location.id = 0;
   memAllocationProp.location.type = hipMemLocationTypeDevice;
@@ -110,7 +110,7 @@ TEST_CASE("Unit_hipMemVmm_Uncached") {
 
   size_t granularity = 0;
 
-  hipMemAllocationProp memAllocationProp;
+  hipMemAllocationProp memAllocationProp{};
   memAllocationProp.type = hipMemAllocationTypeUncached;
   memAllocationProp.location.id = 0;
   memAllocationProp.location.type = hipMemLocationTypeDevice;


### PR DESCRIPTION
## Motivation
Fix these failures on Strix Halo:

```
[2025-10-13T16:37:35.531Z]           Start 1140: Unit_hipMemVmm_Basic
[2025-10-13T16:37:35.531Z] 1140/5468 Test #1140: Unit_hipMemVmm_Basic ........................................................................***Failed    0.11 sec
[2025-10-13T16:37:35.531Z]           Start 1141: Unit_hipMemVmm_Uncached
[2025-10-13T16:37:35.531Z] 1141/5468 Test #1141: Unit_hipMemVmm_Uncached .....................................................................***Failed    0.09 sec
```

## Technical Details

There are failures on Navi48 too on those tests. This PR makes sure hipMemAllocationProp is default initialized.

## Test Plan
Execute the new code on Navi48

## Test Result

The fix makes the tests pass on Navi48

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
