### PR TITLE
rocrtst: Add check for SVM support in Runtime

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/svm_memory.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/svm_memory.cc
@@ -301,6 +301,16 @@ void SvmMemoryTestBasic::TestCreateDestroy(hsa_agent_t agent, hsa_amd_memory_poo
 
 void SvmMemoryTestBasic::TestCreateDestroy(void) {
   hsa_status_t err;
+
+  // Check if SVM is supported by the ROCr runtime
+  bool svm_supported = false;
+  err = hsa_system_get_info(HSA_AMD_SYSTEM_INFO_SVM_SUPPORTED, &svm_supported);
+
+  if (err != HSA_STATUS_SUCCESS || !svm_supported) {
+    std::cout << "  *** SVM is not supported - skipping CreateDestroy test ***" << std::endl;
+    return;
+  }
+
   std::vector<std::shared_ptr<rocrtst::agent_pools_t>> agent_pools;
 
   if (verbosity() > 0) {


### PR DESCRIPTION
## Motivation

Add a check for SVM support in ROCm Runtime tests and skip the VM tests as needed.


## Test Result

Tested on Debian 13 and Ubuntu 22 systems with ROCm 7.1