### PR TITLE
Forward ctest labels from the execution test to the validation test.

### DIFF
--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/jpeg-decode/amd-smi-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/jpeg-decode/amd-smi-rules.json
@@ -23,7 +23,8 @@
             ]
         },
         {
-            "min_rows": 500,
+            "_comment": "The actual number of samples will vary depending on the GPU. This validates presence of samples, not the actual number of samples.",
+            "min_rows": 100,
             "name_prefix": "rocpd_pmc_event_",
             "required_columns": [
                 "event_id",
@@ -35,21 +36,21 @@
                     "comparison": "greater_than",
                     "description": "Check for amd-smi monitoring busy times",
                     "error_message": "Less than expected number of captured amd-smi mm-busy samples!",
-                    "expected_result": 50,
+                    "expected_result": 10,
                     "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_busy_mm'"
                 },
                 {
                     "comparison": "greater_than",
                     "description": "Check for amd-smi monitoring GPU memory usage",
                     "error_message": "Less than expected number of captured amd-smi memory-usage samples!",
-                    "expected_result": 50,
+                    "expected_result": 10,
                     "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_memory_usage'"
                 },
                 {
                     "comparison": "greater_than",
                     "description": "Check for amd-smi monitoring JPEG activity",
                     "error_message": "Less than expected activity in amd-smi jpeg-activity samples!",
-                    "expected_result": 50,
+                    "expected_result": 10,
                     "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name LIKE 'device_jpeg_activity_%' and event.value > 0"
                 }
             ]

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/roctx/amd-smi-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/roctx/amd-smi-rules.json
@@ -23,6 +23,7 @@
             ]
         },
         {
+            "_comment": "The actual number of samples will vary depending on the GPU. This validates presence of samples, not the actual number of samples.",
             "min_rows": 100,
             "name_prefix": "rocpd_pmc_event_",
             "required_columns": [

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/video-decode/amd-smi-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/video-decode/amd-smi-rules.json
@@ -23,7 +23,8 @@
             ]
         },
         {
-            "min_rows": 500,
+            "_comment": "The actual number of samples will vary depending on the GPU. This validates presence of samples, not the actual number of samples.",
+            "min_rows": 100,
             "name_prefix": "rocpd_pmc_event_",
             "required_columns": [
                 "event_id",
@@ -35,21 +36,21 @@
                     "comparison": "greater_than",
                     "description": "Check for amd-smi monitoring busy times",
                     "error_message": "Less than expected number of captured amd-smi mm-busy samples!",
-                    "expected_result": 150,
+                    "expected_result": 10,
                     "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_busy_mm'"
                 },
                 {
                     "comparison": "greater_than",
                     "description": "Check for amd-smi monitoring GPU memory usage",
                     "error_message": "Less than expected number of captured amd-smi memory-usage samples!",
-                    "expected_result": 150,
+                    "expected_result": 10,
                     "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_memory_usage'"
                 },
                 {
                     "comparison": "greater_than",
                     "description": "Check for amd-smi monitoring VCN activity",
                     "error_message": "Less than expected activity in amd-smi vcn-activity samples!",
-                    "expected_result": 100,
+                    "expected_result": 10,
                     "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name LIKE 'device_vcn_activity_%' and event.value > 0"
                 }
             ]

--- a/projects/rocprofiler-systems/tests/rocprof-sys-testing.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-testing.cmake
@@ -1227,6 +1227,14 @@ function(ROCPROFILER_SYSTEMS_ADD_VALIDATION_TEST)
         list(APPEND TEST_DEPENDS "${TEST_NAME}-run")
     endif()
 
+    # Add labels from the parent test to the validation test
+    get_test_property(${TEST_NAME} LABELS PARENT_TEST_LABELS)
+    if(PARENT_TEST_LABELS)
+        list(APPEND TEST_LABELS "${PARENT_TEST_LABELS}")
+        list(REMOVE_DUPLICATES TEST_LABELS)
+        list(SORT TEST_LABELS)
+    endif()
+
     if(NOT TEST_PASS_REGEX)
         set(TEST_PASS_REGEX
             "rocprof-sys-tests-output/${TEST_NAME}/(${TEST_TIMEMORY_FILE}|${TEST_PERFETTO_FILE}|${TEST_ROCPD_FILE}) validated"


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
- The data validation tests were not being run by the `rocprofiler-systems-ci` workflow.
- Resolves SWDEV-563836, SWDEV-565114, SWDEV-565615

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Pass the test labels from the "execution" test to the "validation" test. For example, if the label "rocm" is applied to the `transpose-sampling` test, then it will also be added to the `validate-transpose-sampling` test. Now, `ctest -L rocm` will run both `transpose-sampling` and `validate-transpose-sampling`.
- Adjust validation parameters for the rocpd tests. The MI3xx runner is completing quickly, so the minimum number of samples were not collected.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
