### PR TITLE
[rocprofiler-sdk] PTL support

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp
@@ -21,11 +21,14 @@
 // SOFTWARE.
 
 #include "lib/rocprofiler-sdk/counters/ioctl.hpp"
+#include "lib/common/logging.hpp"
 #include "lib/rocprofiler-sdk/details/kfd_ioctl.h"
 #include "lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.hpp"
 
+#include <fmt/core.h>
 #include <sys/ioctl.h>
 #include <cerrno>
+#include <cstring>
 
 namespace rocprofiler
 {
@@ -116,5 +119,258 @@ counter_collection_device_lock(const rocprofiler_agent_t* agent, bool all_queues
 
 //     return ROCPROFILER_STATUS_SUCCESS;
 // }
+
+// For MI308, PTL needs to be disabled to collect some counters.
+namespace ptl
+{
+
+namespace
+{
+
+namespace pc_sampling = rocprofiler::pc_sampling;
+
+template <typename T>
+std::pair<int, int>
+check_ioctl(int fd, unsigned long request, T* arg)
+{
+    int ret = ::ioctl(fd, request, static_cast<void*>(arg));
+    if(ret < 0)
+    {
+        return {ret, errno};
+    }
+
+    return {ret, 0};
+}
+
+int
+get_num_sample_infos(int gpu_id)
+{
+    kfd_ioctl_pc_sample_args args{};
+    args.op              = KFD_IOCTL_PCS_OP_QUERY_CAPABILITIES;
+    args.gpu_id          = gpu_id;
+    args.num_sample_info = 0;
+
+    const auto [ret, err] =
+        check_ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PC_SAMPLE, &args);
+    if(err != 0)
+    {
+        ROCP_WARNING << fmt::format("PTL: Querying sample infos for GPU %d failed: errno=%d (%s)",
+                                    gpu_id,
+                                    err,
+                                    std::strerror(err));
+        return -1;
+    }
+
+    return args.num_sample_info;
+}
+
+int
+create_pc_sampling_session(int gpu_id, int ptl_state, int format1, int format2)
+{
+    kfd_pc_sample_info info{};
+    info.method   = KFD_IOCTL_PCS_METHOD_HOSTTRAP;
+    info.type     = KFD_IOCTL_PCS_TYPE_TIME_US;
+    info.interval = 1000;
+    // info.ptl_state    = 0;
+    // info.pref_format1 = 0;
+    // info.pref_format2 = 0;
+    info.ptl_state    = ptl_state;
+    info.pref_format1 = format1;
+    info.pref_format2 = format2;
+
+    kfd_ioctl_pc_sample_args args{};
+    args.op              = KFD_IOCTL_PCS_OP_CREATE;
+    args.gpu_id          = gpu_id;
+    args.num_sample_info = 1;
+    args.sample_info_ptr = (uint64_t) (&info);
+    args.trace_id        = 0;
+
+    const auto [ret, err] =
+        check_ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PC_SAMPLE, &args);
+
+    if(err != 0)
+    {
+        ROCP_WARNING << fmt::format(
+            "PTL: PC Sampling session create for GPU %d failed: errno=%d (%s)",
+            gpu_id,
+            std::strerror(err));
+        return -1;
+    }
+
+    ROCP_INFO << fmt::format("Created PC Sampling session with trace ID: %d", args.trace_id);
+
+    return args.trace_id;
+}
+
+void
+destroy_pc_sampling_session(int gpu_id, int trace_id)
+{
+    kfd_ioctl_pc_sample_args args{};
+    args.op              = KFD_IOCTL_PCS_OP_DESTROY;
+    args.gpu_id          = gpu_id;
+    args.num_sample_info = 1;
+    args.sample_info_ptr = 0;
+    args.trace_id        = trace_id;
+
+    const auto [ret, err] =
+        check_ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PC_SAMPLE, &args);
+
+    ROCP_WARNING_IF(err != 0) << fmt::format(
+        "PTL: Could not destroy PC Sampling session ID %d: errno=%d (%s)",
+        args.trace_id,
+        err,
+        std::strerror(err));
+
+    ROCP_TRACE << fmt::format("PTL: Destroyed PC Sampling session with trace ID: %d",
+                              args.trace_id);
+}
+
+int
+enable_ptl(int gpu_id, int format1, int format2)
+{
+    const auto trace_id = create_pc_sampling_session(gpu_id, 0, format1, format2);
+
+    kfd_pc_sample_info info{};
+    info.ptl_state    = 1;
+    info.pref_format1 = format1;
+    info.pref_format2 = format2;
+
+    kfd_ioctl_pc_sample_args args{};
+    args.op              = KFD_IOCTL_PCS_OP_START_PTL;
+    args.gpu_id          = gpu_id;
+    args.trace_id        = trace_id;
+    args.num_sample_info = 1;
+    args.sample_info_ptr = (uint64_t) (&info);
+
+    auto [ret, err] = check_ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PC_SAMPLE, &args);
+    if(err != 0)
+    {
+        ROCP_WARNING << fmt::format("PTL: Could not enable PTL for GPU %d: errno=%d (%s)\n",
+                                    gpu_id,
+                                    err,
+                                    std::strerror(err));
+    }
+    else if(err == 0)
+    {
+        ROCP_INFO << fmt::format("PTL: PTL state set for GPU %d with format1=%d, format2=%d\n",
+                                 gpu_id,
+                                 format1,
+                                 format2);
+    }
+
+    destroy_pc_sampling_session(gpu_id, trace_id);
+
+    return 0;
+}
+
+int
+disable_ptl(int gpu_id)
+{
+    const auto trace_id = create_pc_sampling_session(gpu_id, 1, 0, 0);
+
+    kfd_ioctl_pc_sample_args args{};
+    args.op              = KFD_IOCTL_PCS_OP_STOP_PTL;
+    args.gpu_id          = gpu_id;
+    args.trace_id        = trace_id;
+    args.num_sample_info = 0;
+    args.sample_info_ptr = 0;
+
+    {
+        auto [ret, err] =
+            check_ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PC_SAMPLE, &args);
+        if(err != 0)
+        {
+            ROCP_WARNING << fmt::format("PTL: Disable PTL failed on GPU %d. Counter collection may "
+                                        "be unavailable: errno=%d (%s): %s\n",
+                                        gpu_id,
+                                        err,
+                                        std::strerror(err));
+        };
+    }
+
+    destroy_pc_sampling_session(gpu_id, trace_id);
+
+    return 0;
+}
+
+}  // namespace
+
+bool
+get_ptl_state(const rocprofiler_agent_t* agent)
+{
+    const auto gpu_id           = agent->gpu_id;
+    const auto num_sample_infos = get_num_sample_infos(gpu_id);
+
+    std::vector<kfd_pc_sample_info> samples(num_sample_infos);
+
+    for(int i = 0; i < num_sample_infos; ++i)
+    {
+        samples[i].ptl_state    = UINT32_MAX;
+        samples[i].pref_format1 = UINT32_MAX;
+        samples[i].pref_format2 = UINT32_MAX;
+    }
+
+    kfd_ioctl_pc_sample_args args{};
+    args.op              = KFD_IOCTL_PCS_OP_QUERY_CAPABILITIES;
+    args.gpu_id          = gpu_id;
+    args.num_sample_info = num_sample_infos;
+    args.sample_info_ptr = (uint64_t) (samples.data());
+
+    auto [ret, err] = check_ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PC_SAMPLE, &args);
+    if(ret != 0)
+    {
+        ROCP_WARNING << fmt::format("PTL: Failed to query PTL state for GPU %d: errno=%d (%s)",
+                                    gpu_id,
+                                    err,
+                                    std::strerror(err));
+    }
+
+    for(int i = 0; i < num_sample_infos; ++i)
+    {
+        ROCP_TRACE << fmt::format("PTL:  Sample [%d]:\n", i);
+        ROCP_TRACE << fmt::format("PTL:      ptl_state:    %u\n", samples[i].ptl_state);
+        ROCP_TRACE << fmt::format("PTL:      pref_format1: %u\n", samples[i].pref_format1);
+        ROCP_TRACE << fmt::format("PTL:      pref_format2: %u\n", samples[i].pref_format2);
+
+        if(samples[i].ptl_state != samples[0].ptl_state)
+        {
+            ROCP_WARNING << fmt::format(
+                "PTL: ptl_state is not the same in all reported samples from KFD");
+        }
+    }
+
+    return samples[0].ptl_state == 1;
+}
+
+static constexpr uint32_t MI308_PCIE_DID = 0x74a2;
+
+void
+enable_ptl(const rocprofiler_agent_t* agent)
+{
+    if(agent->device_id == MI308_PCIE_DID && get_ptl_state(agent))
+    {
+        enable_ptl(agent->gpu_id, 1, 2);  // TODO: Formats
+    }
+    else
+    {
+        ROCP_INFO << "PTL: Ignoring PTL enable request for non-MI308 GPU";
+    }
+}
+
+void
+disable_ptl(const rocprofiler_agent_t* agent)
+{
+    if(agent->device_id == MI308_PCIE_DID && get_ptl_state(agent))
+    {
+        disable_ptl(agent->gpu_id);  // TODO: Formats
+    }
+    else
+    {
+        ROCP_INFO << "PTL: Ignoring PTL disable request for non-MI308 GPU";
+    }
+}
+
+}  // namespace ptl
+
 }  // namespace counters
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp
@@ -120,13 +120,11 @@ counter_collection_device_lock(const rocprofiler_agent_t* agent, bool all_queues
 //     return ROCPROFILER_STATUS_SUCCESS;
 // }
 
-// For MI308, PTL needs to be disabled to collect some counters.
+// For some GPUs, PTL needs to be disabled to collect some counters.
 namespace ptl
 {
-
 namespace
 {
-
 namespace pc_sampling = rocprofiler::pc_sampling;
 
 template <typename T>
@@ -182,8 +180,8 @@ create_pc_sampling_session(int gpu_id, int ptl_state, int format1, int format2)
     args.op              = KFD_IOCTL_PCS_OP_CREATE;
     args.gpu_id          = gpu_id;
     args.num_sample_info = 1;
-    args.sample_info_ptr = (uint64_t) (&info);
-    args.trace_id        = 0;
+    args.sample_info_ptr = (uint64_t)(&info);
+    args.trace_id        = -1;
 
     const auto [ret, err] =
         check_ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PC_SAMPLE, &args);
@@ -221,14 +219,16 @@ destroy_pc_sampling_session(int gpu_id, int trace_id)
         err,
         std::strerror(err));
 
-    ROCP_TRACE << fmt::format("PTL: Destroyed PC Sampling session with trace ID: %d",
-                              args.trace_id);
+    ROCP_INFO << fmt::format("PTL: Destroyed PC Sampling session with trace ID: %d", args.trace_id);
 }
 
 int
 enable_ptl(int gpu_id, int format1, int format2)
 {
     const auto trace_id = create_pc_sampling_session(gpu_id, 0, format1, format2);
+
+    // could not create a session
+    if(trace_id == -1) return -1;
 
     kfd_pc_sample_info info{};
     info.ptl_state    = 1;
@@ -240,9 +240,10 @@ enable_ptl(int gpu_id, int format1, int format2)
     args.gpu_id          = gpu_id;
     args.trace_id        = trace_id;
     args.num_sample_info = 1;
-    args.sample_info_ptr = (uint64_t) (&info);
+    args.sample_info_ptr = (uint64_t)(&info);
 
-    auto [ret, err] = check_ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PC_SAMPLE, &args);
+    const auto [ret, err] =
+        check_ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PC_SAMPLE, &args);
     if(err != 0)
     {
         ROCP_WARNING << fmt::format("PTL: Could not enable PTL for GPU %d: errno=%d (%s)\n",
@@ -260,13 +261,17 @@ enable_ptl(int gpu_id, int format1, int format2)
 
     destroy_pc_sampling_session(gpu_id, trace_id);
 
-    return 0;
+    return err;
 }
 
 int
 disable_ptl(int gpu_id)
 {
+    // Maybe KFD issue. Need to set this to 1 and then disable, create with 0 does not seem to work
     const auto trace_id = create_pc_sampling_session(gpu_id, 1, 0, 0);
+
+    // could not create a session
+    if(trace_id == -1) return -1;
 
     kfd_ioctl_pc_sample_args args{};
     args.op              = KFD_IOCTL_PCS_OP_STOP_PTL;
@@ -275,28 +280,26 @@ disable_ptl(int gpu_id)
     args.num_sample_info = 0;
     args.sample_info_ptr = 0;
 
+    const auto [ret, err] =
+        check_ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PC_SAMPLE, &args);
+    if(err != 0)
     {
-        auto [ret, err] =
-            check_ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PC_SAMPLE, &args);
-        if(err != 0)
-        {
-            ROCP_WARNING << fmt::format("PTL: Disable PTL failed on GPU %d. Counter collection may "
-                                        "be unavailable: errno=%d (%s): %s\n",
-                                        gpu_id,
-                                        err,
-                                        std::strerror(err));
-        };
-    }
+        ROCP_WARNING << fmt::format("PTL: Disable PTL failed on GPU %d. Counter collection may "
+                                    "be unavailable: errno=%d (%s): %s\n",
+                                    gpu_id,
+                                    err,
+                                    std::strerror(err));
+    };
 
     destroy_pc_sampling_session(gpu_id, trace_id);
 
-    return 0;
+    return err;
 }
 
 }  // namespace
 
 bool
-get_ptl_state(const rocprofiler_agent_t* agent)
+ptl_enabled(const rocprofiler_agent_t* agent)
 {
     const auto gpu_id           = agent->gpu_id;
     const auto num_sample_infos = get_num_sample_infos(gpu_id);
@@ -314,9 +317,10 @@ get_ptl_state(const rocprofiler_agent_t* agent)
     args.op              = KFD_IOCTL_PCS_OP_QUERY_CAPABILITIES;
     args.gpu_id          = gpu_id;
     args.num_sample_info = num_sample_infos;
-    args.sample_info_ptr = (uint64_t) (samples.data());
+    args.sample_info_ptr = (uint64_t)(samples.data());
 
-    auto [ret, err] = check_ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PC_SAMPLE, &args);
+    const auto [ret, err] =
+        check_ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PC_SAMPLE, &args);
     if(ret != 0)
     {
         ROCP_WARNING << fmt::format("PTL: Failed to query PTL state for GPU %d: errno=%d (%s)",
@@ -334,7 +338,7 @@ get_ptl_state(const rocprofiler_agent_t* agent)
 
         if(samples[i].ptl_state != samples[0].ptl_state)
         {
-            ROCP_WARNING << fmt::format(
+            ROCP_ERROR << fmt::format(
                 "PTL: ptl_state is not the same in all reported samples from KFD");
         }
     }
@@ -342,31 +346,33 @@ get_ptl_state(const rocprofiler_agent_t* agent)
     return samples[0].ptl_state == 1;
 }
 
-static constexpr uint32_t MI308_PCIE_DID = 0x74a2;
+static constexpr uint32_t GPU_PCIE_DID = 0x74a2;
 
-void
+bool
 enable_ptl(const rocprofiler_agent_t* agent)
 {
-    if(agent->device_id == MI308_PCIE_DID && get_ptl_state(agent))
+    if(agent->device_id == GPU_PCIE_DID && ptl_enabled(agent))
     {
-        enable_ptl(agent->gpu_id, 1, 2);  // TODO: Formats
+        return enable_ptl(agent->gpu_id, 1, 2) == 0;  // TODO: Formats
     }
     else
     {
-        ROCP_INFO << "PTL: Ignoring PTL enable request for non-MI308 GPU";
+        ROCP_INFO << "PTL: Ignoring PTL enable request for unsupported device";
+        return false;
     }
 }
 
-void
+bool
 disable_ptl(const rocprofiler_agent_t* agent)
 {
-    if(agent->device_id == MI308_PCIE_DID && get_ptl_state(agent))
+    if(agent->device_id == GPU_PCIE_DID && ptl_enabled(agent))
     {
-        disable_ptl(agent->gpu_id);  // TODO: Formats
+        return disable_ptl(agent->gpu_id) == 0;
     }
     else
     {
-        ROCP_INFO << "PTL: Ignoring PTL disable request for non-MI308 GPU";
+        ROCP_INFO << "PTL: Ignoring PTL disable request for unsupported device";
+        return false;
     }
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.hpp
@@ -36,12 +36,14 @@ counter_collection_device_lock(const rocprofiler_agent_t* agent, bool all_queues
 
 namespace ptl
 {
+bool
+ptl_enabled(const rocprofiler_agent_t* agent);
 
 bool
-get_ptl_state(const rocprofiler_agent_t* agent);
-
-void
 enable_ptl(const rocprofiler_agent_t* agent);
+
+bool
+disable_ptl(const rocprofiler_agent_t* agent);
 
 }  // namespace ptl
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.hpp
@@ -34,5 +34,16 @@ counter_collection_has_device_lock();
 rocprofiler_status_t
 counter_collection_device_lock(const rocprofiler_agent_t* agent, bool all_queues);
 
+namespace ptl
+{
+
+bool
+get_ptl_state(const rocprofiler_agent_t* agent);
+
+void
+enable_ptl(const rocprofiler_agent_t* agent);
+
+}  // namespace ptl
+
 }  // namespace counters
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/details/kfd_ioctl.h
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/details/kfd_ioctl.h
@@ -629,7 +629,7 @@ enum KFD_SVM_UNMAP_TRIGGERS
     KFD_SVM_UNMAP_TRIGGER_UNMAP_FROM_CPU      /* Unmap to free the buffer */
 };
 
-#define KFD_SMI_EVENT_MASK_FROM_INDEX(i) (1ULL << ((i) -1))
+#define KFD_SMI_EVENT_MASK_FROM_INDEX(i) (1ULL << ((i) - 1))
 #define KFD_SMI_EVENT_MSG_SIZE           96
 
 struct kfd_ioctl_smi_events_args
@@ -1775,6 +1775,18 @@ enum kfd_ioctl_pc_sample_op
     KFD_IOCTL_PCS_OP_DESTROY,
     KFD_IOCTL_PCS_OP_START,
     KFD_IOCTL_PCS_OP_STOP,
+    KFD_IOCTL_PCS_OP_START_PTL,
+    KFD_IOCTL_PCS_OP_STOP_PTL,
+};
+
+enum psp_gfx_format_type
+{
+    GFX_FTYPE_I8      = 0x00000000,
+    GFX_FTYPE_F16     = 0x00000001,
+    GFX_FTYPE_BF16    = 0x00000002,
+    GFX_FTYPE_F32     = 0x00000003,
+    GFX_FTYPE_F64     = 0x00000004,
+    GFX_FTYPE_INVALID = 0xFFFFFFFF,
 };
 
 /* Values have to be a power of 2*/
@@ -1805,6 +1817,9 @@ struct kfd_pc_sample_info
     __u64 flags;        /* [OUT] indicate potential restrictions e.g FLAG_POWER_OF_2 */
     __u32 method;       /* [IN/OUT] kfd_ioctl_pc_sample_method */
     __u32 type;         /* [IN/OUT] kfd_ioctl_pc_sample_type */
+    __u32 ptl_state;    /* [IN/OUT] */
+    __u32 pref_format1; /* [IN/OUT] */
+    __u32 pref_format2; /* [IN/OUT] */
 };
 
 #define KFD_IOCTL_PCS_QUERY_TYPE_FULL (1 << 0) /* If not set, return current */

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/details/kfd_ioctl.h
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/details/kfd_ioctl.h
@@ -629,7 +629,7 @@ enum KFD_SVM_UNMAP_TRIGGERS
     KFD_SVM_UNMAP_TRIGGER_UNMAP_FROM_CPU      /* Unmap to free the buffer */
 };
 
-#define KFD_SMI_EVENT_MASK_FROM_INDEX(i) (1ULL << ((i) - 1))
+#define KFD_SMI_EVENT_MASK_FROM_INDEX(i) (1ULL << ((i) -1))
 #define KFD_SMI_EVENT_MSG_SIZE           96
 
 struct kfd_ioctl_smi_events_args


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

KFD added support for toggling PTL (Platform TOPS Limit) through PC Sampling IOCTL. Some counters are unavailable when GPU is in PTL enable mode. To collect these counters, PTL must be disabled, which sets the device into ALT mode.  

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Currently a draft. This PR updates `kfd_ioctl.h` with the new API from KFD to enable/disable PTL. These functions are not used. Will update this after code review.  

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
