### PR TITLE
Removing `jlumbroso/free-disk-space` action

### DIFF
--- a/.github/workflows/rocprofiler-systems-debian.yml
+++ b/.github/workflows/rocprofiler-systems-debian.yml
@@ -55,16 +55,6 @@ jobs:
       ROCPROFSYS_CI: 'ON'
 
     steps:
-    - name: Free Disk Space
-      uses: jlumbroso/free-disk-space@v1.3.0
-      with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
-
     - uses: actions/checkout@v4
       with:
         sparse-checkout: projects/rocprofiler-systems/

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -49,16 +49,6 @@ jobs:
         build-type: ['Release']
 
     steps:
-    - name: Free Disk Space
-      uses: jlumbroso/free-disk-space@v1.3.0
-      with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
-
     - uses: actions/checkout@v4
       with:
         sparse-checkout: projects/rocprofiler-systems/

--- a/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
@@ -59,16 +59,6 @@ jobs:
       ROCPROFSYS_CI: 'ON'
 
     steps:
-    - name: Free Disk Space
-      uses: jlumbroso/free-disk-space@v1.3.0
-      with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
-
     - uses: actions/checkout@v4
       with:
         sparse-checkout: projects/rocprofiler-systems/
@@ -225,16 +215,6 @@ jobs:
       ROCPROFSYS_CI: 'ON'
 
     steps:
-    - name: Free Disk Space
-      uses: jlumbroso/free-disk-space@v1.3.0
-      with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
-
     - uses: actions/checkout@v4
       with:
         sparse-checkout: projects/rocprofiler-systems/
@@ -417,16 +397,6 @@ jobs:
       ROCPROFSYS_CI: 'ON'
 
     steps:
-    - name: Free Disk Space
-      uses: jlumbroso/free-disk-space@v1.3.0
-      with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
-
     - uses: actions/checkout@v4
       with:
         sparse-checkout: projects/rocprofiler-systems/

--- a/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
@@ -54,16 +54,6 @@ jobs:
       ROCPROFSYS_CI: 'ON'
 
     steps:
-    - name: Free Disk Space
-      uses: jlumbroso/free-disk-space@v1.3.0
-      with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          swap-storage: true
-
     - uses: actions/checkout@v4
       with:
         sparse-checkout: projects/rocprofiler-systems/


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The `jlumbroso/free-disk-space` action was not running properly and causing warnings in the workflows.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Partially reverts https://github.com/ROCm/rocm-systems/pull/1693

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
