### PR TITLE
libhsakmt: Support Multi-ctx Using Secondary KFD Context Features

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmtctx.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmtctx.h
@@ -75,6 +75,31 @@ HSAKMTAPI
 hsaKmtCloseKFDCtx( void );
 
 /**
+  Open secondary KFD context
+
+  Creates a new secondary KFD context with an independent communication
+  channel to the kernel driver using a separate file descriptor.
+
+  The secondary context operates independently from the primary context,
+  allowing isolated management of GPU resources and operations specific
+  to this context without interfering with the primary context's state.
+*/
+HSAKMT_STATUS
+HSAKMTAPI
+hsaKmtOpenSecondaryKFDCtx(
+    HsaKFDContext      **pCtx   //IN/OUT
+    );
+
+/**
+  Close secondary KFD context
+*/
+HSAKMT_STATUS
+HSAKMTAPI
+hsaKmtCloseSecondaryKFDCtx(
+    HsaKFDContext      *ctx   //IN
+    );
+
+/**
   The function takes a "snapshot" of the topology information within the KFD
   to avoid any changes during the enumeration process.
 */
@@ -862,6 +887,17 @@ hsaKmtPmcRegisterTraceCtx(
     HSAuint32           NumberOfCounters,   //IN
     HsaCounter*         Counters,           //IN
     HsaPmcTraceRoot*    TraceRoot           //OUT
+    );
+
+/**
+  Unregisters a set of (HW) counters used for tracing/profiling
+*/
+HSAKMT_STATUS
+HSAKMTAPI
+hsaKmtPmcUnregisterTraceCtx(
+    HsaKFDContext      *ctx,                //IN
+    HSAuint32           NodeId,             //IN
+    HSATraceId          TraceId             //IN
     );
 
 /**

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/linux/kfd_ioctl.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/linux/kfd_ioctl.h
@@ -1691,6 +1691,17 @@ struct kfd_ioctl_ais_args {
 	};
 };
 
+/**
+ * kfd_ioctl_create_process_args
+ * Create secondary KFD context ioctl operations
+ *
+ * @flags not use at current.
+ */
+struct kfd_ioctl_create_process_args {
+	__u32 flags; 		/* [IN] */
+	__u32 pad;
+};
+
 #define AMDKFD_IOCTL_BASE 'K'
 #define AMDKFD_IO(nr)			_IO(AMDKFD_IOCTL_BASE, nr)
 #define AMDKFD_IOR(nr, type)		_IOR(AMDKFD_IOCTL_BASE, nr, type)
@@ -1811,8 +1822,11 @@ struct kfd_ioctl_ais_args {
 #define AMDKFD_IOC_DBG_TRAP			\
 		AMDKFD_IOWR(0x26, struct kfd_ioctl_dbg_trap_args)
 
+#define AMDKFD_IOC_CREATE_PROCESS		\
+		AMDKFD_IOWR(0x27, struct kfd_ioctl_create_process_args)
+
 #define AMDKFD_COMMAND_START		0x01
-#define AMDKFD_COMMAND_END		0x27
+#define AMDKFD_COMMAND_END		0x28
 
 /* non-upstream ioctls */
 #define AMDKFD_IOC_IPC_IMPORT_HANDLE                                    \

--- a/projects/rocr-runtime/libhsakmt/src/debug.c
+++ b/projects/rocr-runtime/libhsakmt/src/debug.c
@@ -319,6 +319,10 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtCheckRuntimeDebugSupportCtx(HsaKFDContext *ctx) {
 	HsaSystemProperties props = {0};
 	HsaVersionInfo versionInfo = {0};
 
+	//secondary context doesn't support the debugger
+	if (!ctx->hsakmt_is_primary_ctx)
+		return HSAKMT_STATUS_NOT_SUPPORTED;
+
 	memset(&node, 0x00, sizeof(node));
 	memset(&props, 0x00, sizeof(props));
 	if (hsaKmtAcquireSystemPropertiesCtx(ctx, &props))

--- a/projects/rocr-runtime/libhsakmt/src/events.c
+++ b/projects/rocr-runtime/libhsakmt/src/events.c
@@ -45,6 +45,10 @@ struct hsa_kfd_event_context
 struct hsa_kfd_event_context *hsakmt_kfdcontext_get_event_context(HsaKFDContext *ctx)
 {
 	assert(ctx);
+	if (!ctx) {
+		pr_err("Expected a non-null ptr for HsaKFDContext");
+		return NULL;
+	}
 
 	if (ctx->event_context)
 		return ctx->event_context;
@@ -276,9 +280,9 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtWaitOnEvent_ExtCtx(HsaKFDContext *ctx,
 static HSAKMT_STATUS get_mem_info_svm_api(HsaKFDContext *ctx, uint64_t address, uint32_t gpu_id)
 {
 	struct kfd_ioctl_svm_args *args;
-        uint32_t node_id = 0;
-        HSAuint32 s_attr;
-        HSAuint32 i;
+	uint32_t node_id = 0;
+	HSAuint32 s_attr;
+	HSAuint32 i;
 	HSA_SVM_ATTRIBUTE attrs[] = {
 					{HSA_SVM_ATTR_PREFERRED_LOC, 0},
 					{HSA_SVM_ATTR_PREFETCH_LOC, 0},

--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -293,6 +293,10 @@ struct hsa_kfd_fmm_context
 struct hsa_kfd_fmm_context *hsakmt_kfdcontext_get_fmm_context(HsaKFDContext *ctx)
 {
 	assert(ctx);
+	if (!ctx) {
+		pr_err("Expected a non-null ptr for HsaKFDContext");
+		return NULL;
+	}
 
 	if (ctx->fmm_context)
 		return ctx->fmm_context;
@@ -2265,7 +2269,7 @@ HSAKMT_STATUS hsakmt_fmm_release(HsaKFDContext *ctx, void *address)
 	object = vm_find_object(fmm_ctx, address, 0, &aperture);
 
 	if (!object)
-		return hsakmt_is_svm_api_supported ?
+		return ctx->hsakmt_is_svm_api_supported ?
 			HSAKMT_STATUS_SUCCESS :
 			HSAKMT_STATUS_MEMORY_NOT_REGISTERED;
 
@@ -2351,7 +2355,7 @@ static HSAKMT_STATUS get_process_apertures(HsaKFDContext *ctx,
 int hsakmt_open_drm_render_device(HsaKFDContext *ctx, int minor)
 {
 	char path[128];
-	int index, fd;
+	int index, fd, dev_init_ret;
 	uint32_t major_drm, minor_drm;
 	struct amdgpu_device **device_handle;
 	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
@@ -2385,7 +2389,28 @@ int hsakmt_open_drm_render_device(HsaKFDContext *ctx, int minor)
 	fmm_ctx->drm_render_fds[index] = fd;
 
 	device_handle = &fmm_ctx->amdgpu_handle[index];
-	if (!amdgpu_device_initialize(fd, &major_drm, &minor_drm, device_handle)) {
+	/* -Primary context: amdgpu_device_initialize()
+	 *    Enables device deduplication for some resources sharing.
+	 * -Secondary context: amdgpu_device_initialize2(fd, false, ...)
+	 *    Disables device deduplication.
+	 *    The goal is to get a different drm_file for each application
+	 *    inside the guest so we get inter-application implicit synchronisation
+	 *    handled for us by the kernel.
+	 *    This also makes the application completely separate (e.g.: each one gets
+	 *    its own VM space).
+	*/
+	if (ctx->hsakmt_is_primary_ctx)
+		dev_init_ret = amdgpu_device_initialize(fd, &major_drm, &minor_drm, device_handle);
+	else if (hsakmt_fn_amdgpu_device_initialize2)
+		dev_init_ret = hsakmt_fn_amdgpu_device_initialize2(fd, false, &major_drm, &minor_drm,
+						    (HsaAMDGPUDeviceHandle *)device_handle);
+	else {
+		pr_err("Secondary context amdgpu device init failed: libdrm version < 2.4.121\n");
+		dev_init_ret = -1;
+		*device_handle = 0;
+	}
+
+	if (!dev_init_ret) {
 		/* if amdgpu_device_get_fd available query render fd that libdrm uses,
 		 * then close drm_render_fds above, replace it by fd libdrm uses.
 		 */
@@ -2833,7 +2858,7 @@ HSAKMT_STATUS hsakmt_fmm_init_process_apertures(HsaKFDContext *ctx,
 	pagedUserptr = getenv("HSA_USERPTR_FOR_PAGED_MEM");
 	fmm_ctx->svm.userptr_for_paged_mem = (!pagedUserptr || strcmp(pagedUserptr, "0"));
 
-	if (hsakmt_use_model)
+	if (hsakmt_use_model || !ctx->hsakmt_is_primary_ctx)
 		fmm_ctx->svm.userptr_for_paged_mem = false;
 	/* If HSA_CHECK_USERPTR is set to a non-0 value, check all userptrs
 	 * when they are registered
@@ -2925,7 +2950,7 @@ HSAKMT_STATUS hsakmt_fmm_init_process_apertures(HsaKFDContext *ctx,
 			gpu_mem[gpu_mem_count].local_mem_size = props.LocalMemSize;
 			gpu_mem[gpu_mem_count].device_id = props.DeviceId;
 			gpu_mem[gpu_mem_count].node_id = i;
-			hsakmt_is_svm_api_supported &= props.Capability.ui32.SVMAPISupported;
+			ctx->hsakmt_is_svm_api_supported &= props.Capability.ui32.SVMAPISupported;
 
 			gpu_mem[gpu_mem_count].scratch_physical.align = PAGE_SIZE;
 			gpu_mem[gpu_mem_count].scratch_physical.ops = &reserved_aperture_ops;
@@ -3488,7 +3513,7 @@ static HSAKMT_STATUS _fmm_map_to_gpu_userptr(HsaKFDContext *ctx,
 	/* Map and return the GPUVM address adjusted by the offset
 	 * from the start of the page
 	 */
-	if (!object && hsakmt_is_svm_api_supported) {
+	if (!object && ctx->hsakmt_is_svm_api_supported) {
 		svm_addr = (void*)((HSAuint64)addr - page_offset);
 		if (!nodes_to_map) {
 			nodes_to_map = fmm_ctx->all_gpu_id_array;
@@ -3532,7 +3557,7 @@ HSAKMT_STATUS hsakmt_fmm_map_to_gpu(HsaKFDContext *ctx,
 	}
 
 	object = vm_find_object(fmm_ctx, address, size, &aperture);
-	if (!object && !hsakmt_is_svm_api_supported) {
+	if (!object && !ctx->hsakmt_is_svm_api_supported) {
 		if (!hsakmt_is_dgpu) {
 			/* Prefetch memory on APUs with dummy-reads */
 			fmm_check_user_memory(address, size);
@@ -3559,7 +3584,7 @@ HSAKMT_STATUS hsakmt_fmm_map_to_gpu(HsaKFDContext *ctx,
 		/* Prefetch memory on APUs with dummy-reads */
 		fmm_check_user_memory(address, size);
 		ret = HSAKMT_STATUS_SUCCESS;
-	} else if ((hsakmt_is_svm_api_supported && !object) || (object && (object->userptr))) {
+	} else if ((ctx->hsakmt_is_svm_api_supported && !object) || (object && (object->userptr))) {
 		ret = _fmm_map_to_gpu_userptr(ctx, address, size, gpuvm_address, object, NULL, 0);
 	} else if (aperture) {
 		ret = _fmm_map_to_gpu(ctx, aperture, address, size, object, NULL, 0);
@@ -3749,7 +3774,7 @@ int hsakmt_fmm_unmap_from_gpu(HsaKFDContext *ctx, void *address)
 	object = vm_find_object(fmm_ctx, address, 0, &aperture);
 	if (!object)
 		/* On APUs GPU unmapping of system memory is a no-op */
-		return (!hsakmt_is_dgpu || hsakmt_is_svm_api_supported) ? 0 : -EINVAL;
+		return (!hsakmt_is_dgpu || ctx->hsakmt_is_svm_api_supported) ? 0 : -EINVAL;
 	/* Successful vm_find_object returns with the aperture locked */
 
 	if (aperture == &fmm_ctx->cpuvm_aperture)
@@ -3925,7 +3950,7 @@ HSAKMT_STATUS hsakmt_fmm_register_memory(HsaKFDContext *ctx,
 			return HSAKMT_STATUS_SUCCESS;
 
 		/* Register a new user ptr */
-		if (hsakmt_is_svm_api_supported) {
+		if (ctx->hsakmt_is_svm_api_supported) {
 			ret = fmm_register_mem_svm_api(ctx, address, size_in_bytes, flags);
 			if (ret == HSAKMT_STATUS_SUCCESS)
 				return ret;
@@ -4323,7 +4348,7 @@ HSAKMT_STATUS hsakmt_fmm_deregister_memory(HsaKFDContext *ctx, void *address)
 		/* On APUs we assume it's a random system memory address
 		 * where registration and dergistration is a no-op
 		 */
-		return (!hsakmt_is_dgpu || hsakmt_is_svm_api_supported) ?
+		return (!hsakmt_is_dgpu || ctx->hsakmt_is_svm_api_supported) ?
 			HSAKMT_STATUS_SUCCESS :
 			HSAKMT_STATUS_MEMORY_NOT_REGISTERED;
 	/* Successful vm_find_object returns with aperture locked */
@@ -4389,7 +4414,7 @@ HSAKMT_STATUS hsakmt_fmm_map_to_gpu_nodes(HsaKFDContext *ctx,
 		return HSAKMT_STATUS_INVALID_PARAMETER;
 
 	object = vm_find_object(fmm_ctx, address, size, &aperture);
-	if (!object && !hsakmt_is_svm_api_supported)
+	if (!object && !ctx->hsakmt_is_svm_api_supported)
 		return HSAKMT_STATUS_ERROR;
 	/* Successful vm_find_object returns with aperture locked */
 
@@ -4412,7 +4437,7 @@ HSAKMT_STATUS hsakmt_fmm_map_to_gpu_nodes(HsaKFDContext *ctx,
 		return HSAKMT_STATUS_ERROR;
 	}
 
-	if ((hsakmt_is_svm_api_supported && !object) || object->userptr) {
+	if ((ctx->hsakmt_is_svm_api_supported && !object) || object->userptr) {
 		retcode = _fmm_map_to_gpu_userptr(ctx, address, size, gpuvm_address,
 				object, nodes_to_map, num_of_nodes * sizeof(uint32_t));
 		if (object)

--- a/projects/rocr-runtime/libhsakmt/src/fmm.h
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.h
@@ -156,4 +156,9 @@ void *hsakmt_mmap_allocate_aligned(int prot, int flags, uint64_t size, uint64_t 
 			    uint64_t guard_size, void *aper_base, void *aper_limit, int fd);
 
 extern int (*hsakmt_fn_amdgpu_device_get_fd)(HsaAMDGPUDeviceHandle device_handle);
+extern int (*hsakmt_fn_amdgpu_device_initialize2)(int fd,
+							 bool deduplicate_device,
+							 uint32_t *major_version,
+							 uint32_t *minor_version,
+							 HsaAMDGPUDeviceHandle *device_handle);
 #endif /* FMM_H_ */

--- a/projects/rocr-runtime/libhsakmt/src/globals.c
+++ b/projects/rocr-runtime/libhsakmt/src/globals.c
@@ -35,7 +35,5 @@ bool hsakmt_is_dgpu;
 int hsakmt_page_size;
 int hsakmt_page_shift;
 
-/* whether to check all dGPUs in the topology support SVM API */
-bool hsakmt_is_svm_api_supported;
 /* zfb is mainly used during emulation */
 int hsakmt_zfb_support;

--- a/projects/rocr-runtime/libhsakmt/src/kfdcontext.h
+++ b/projects/rocr-runtime/libhsakmt/src/kfdcontext.h
@@ -27,6 +27,7 @@
 #define _KFDCONTEXT_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 
 struct hsa_kfd_topology_context;
 struct hsa_kfd_queue_context;
@@ -54,6 +55,14 @@ typedef struct _HsaKFDContext
 {
     /* File descriptor for the KFD device */
     int fd;
+    /*
+     * Primary kfd context flag.
+     * There is only one primary context per-process.
+     */
+    bool hsakmt_is_primary_ctx;
+
+    /* whether to check all dGPUs in the topology support SVM API */
+    bool hsakmt_is_svm_api_supported;
 
     /* Topology context for managing system topology information */
     struct hsa_kfd_topology_context *topology_context;

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.h
@@ -29,7 +29,7 @@
 #include "hsakmt/linux/kfd_ioctl.h"
 #include "hsakmt/hsakmt.h"
 #include "kfdcontext.h"
-#include "hsakmtctx.h"
+#include "hsakmt/hsakmtctx.h"
 #include <pthread.h>
 #include <stdint.h>
 #include <limits.h>
@@ -39,7 +39,6 @@ extern unsigned long hsakmt_kfd_open_count;
 extern bool hsakmt_forked;
 extern pthread_mutex_t hsakmt_mutex;
 extern bool hsakmt_is_dgpu;
-extern bool hsakmt_is_svm_api_supported;
 extern int hsakmt_zfb_support;
 
 extern HsaVersionInfo hsakmt_kfd_version_info;

--- a/projects/rocr-runtime/libhsakmt/src/openclose.c
+++ b/projects/rocr-runtime/libhsakmt/src/openclose.c
@@ -44,6 +44,11 @@
 #include <string.h>
 
 int (*hsakmt_fn_amdgpu_device_get_fd)(HsaAMDGPUDeviceHandle device_handle);
+int (*hsakmt_fn_amdgpu_device_initialize2)(int fd,
+					 bool deduplicate_device,
+					 uint32_t *major_version,
+					 uint32_t *minor_version,
+					 HsaAMDGPUDeviceHandle *device_handle);
 
 static const char kfd_device_name[] = "/dev/kfd";
 static const char kfd_udmabuf_device_name[] = "/dev/udmabuf";
@@ -51,7 +56,11 @@ static pid_t parent_pid = -1;
 int hsakmt_debug_level;
 bool hsakmt_forked;
 
-HsaKFDContext hsakmt_primary_kfd_ctx = {.fd = -1};
+HsaKFDContext hsakmt_primary_kfd_ctx = {
+	.fd = -1,
+	.hsakmt_is_primary_ctx = true,
+	.hsakmt_is_svm_api_supported = false,
+};
 
 /* hsakmt_is_forked_child detects when the process has forked since the last
  * time this function was called. We cannot rely on pthread_atfork
@@ -110,8 +119,8 @@ static void clear_after_fork(HsaKFDContext *ctx)
 
 	int fd = ctx->fd;
 	if (fd >= 0) {
-		hsakmt_kfdcontext_clear_context(ctx);
 		close(fd);
+		hsakmt_kfdcontext_clear_context(ctx);
  	}
 	if (hsakmt_udmabuf_dev_fd > 0) {
 		close(hsakmt_udmabuf_dev_fd);
@@ -181,6 +190,12 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtOpenKFDCtx(HsaKFDContext **pCtx)
 		else
 			pr_info("amdgpu_device_get_fd is available %p\n", hsakmt_fn_amdgpu_device_get_fd);
 
+		hsakmt_fn_amdgpu_device_initialize2 = dlsym(RTLD_DEFAULT, "amdgpu_device_initialize2");
+		if ((error = dlerror()) != NULL)
+			pr_err("amdgpu_device_initialize2 is not available: %s\n", error);
+		else
+			pr_info("amdgpu_device_initialize2 is available %p\n", hsakmt_fn_amdgpu_device_initialize2);
+
 		result = init_vars_from_env();
 		if (result != HSAKMT_STATUS_SUCCESS)
 			goto open_failed;
@@ -217,7 +232,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtOpenKFDCtx(HsaKFDContext **pCtx)
 			pr_debug("udmabuf is not enabled\n");
 
 		useSvmStr = getenv("HSA_USE_SVM");
-		hsakmt_is_svm_api_supported = !(useSvmStr && !strcmp(useSvmStr, "0"));
+		hsakmt_primary_kfd_ctx.hsakmt_is_svm_api_supported = !(useSvmStr && !strcmp(useSvmStr, "0"));
 		if(!hsakmt_use_model)
 			result = hsakmt_topology_sysfs_get_system_props(&hsakmt_primary_kfd_ctx, &sys_props);
 
@@ -292,4 +307,69 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtOpenKFD(void)
 HSAKMT_STATUS HSAKMTAPI hsaKmtCloseKFD(void)
 {
 	return hsaKmtCloseKFDCtx();
+}
+
+HSAKMT_STATUS HSAKMTAPI hsaKmtOpenSecondaryKFDCtx(HsaKFDContext **pCtx)
+{
+	HSAKMT_STATUS result = HSAKMT_STATUS_SUCCESS;
+	int kfd_fd = -1;
+	HsaKFDContext *new_ctx = NULL;
+
+	CHECK_KFD_OPEN();
+	pthread_mutex_lock(&hsakmt_mutex);
+
+	kfd_fd = open(kfd_device_name, O_RDWR | O_CLOEXEC);
+	if (kfd_fd < 0) {
+		result = HSAKMT_STATUS_KERNEL_IO_CHANNEL_NOT_OPENED;
+	} else {
+		struct kfd_ioctl_create_process_args args = {};
+		if (hsakmt_ioctl(kfd_fd, AMDKFD_IOC_CREATE_PROCESS, &args)) {
+			goto create_process_failed;
+		} else {
+			new_ctx = calloc(1, sizeof(HsaKFDContext));
+			if (!new_ctx) {
+				result = HSAKMT_STATUS_NO_MEMORY;
+				goto create_process_failed;
+			}
+			hsakmt_kfdcontext_init_context(kfd_fd, new_ctx);
+			new_ctx->hsakmt_is_primary_ctx = false;
+			new_ctx->hsakmt_is_svm_api_supported = false;
+
+			*pCtx = new_ctx;
+		}
+	}
+
+	pthread_mutex_unlock(&hsakmt_mutex);
+	return result;
+
+create_process_failed:
+	if (kfd_fd >= 0)
+		close(kfd_fd);
+
+	pthread_mutex_unlock(&hsakmt_mutex);
+	return result;
+}
+
+HSAKMT_STATUS HSAKMTAPI hsaKmtCloseSecondaryKFDCtx(HsaKFDContext *ctx)
+{
+	HSAKMT_STATUS result = HSAKMT_STATUS_INVALID_PARAMETER;
+
+	pthread_mutex_lock(&hsakmt_mutex);
+
+	if (ctx && !ctx->hsakmt_is_primary_ctx && ctx->fd >= 0) {
+		hsakmt_clear_events_page(ctx);
+		hsakmt_destroy_counter_props(ctx);
+		hsakmt_destroy_device_debugging_memory(ctx);
+		hsakmt_fmm_clear_all_aperture(ctx);
+
+		close(ctx->fd);
+		hsakmt_kfdcontext_clear_context(ctx);
+		free(ctx);
+
+		result = HSAKMT_STATUS_SUCCESS;
+	}
+
+	pthread_mutex_unlock(&hsakmt_mutex);
+
+	return result;
 }

--- a/projects/rocr-runtime/libhsakmt/src/queues.c
+++ b/projects/rocr-runtime/libhsakmt/src/queues.c
@@ -90,6 +90,10 @@ struct hsa_kfd_queue_context
 struct hsa_kfd_queue_context *hsakmt_kfdcontext_get_queue_context(HsaKFDContext *ctx)
 {
 	assert(ctx);
+	if (!ctx) {
+		pr_err("Expected a non-null ptr for HsaKFDContext");
+		return NULL;
+	}
 
 	if (ctx->queue_context)
 		return ctx->queue_context;
@@ -580,7 +584,7 @@ static int handle_concrete_asic(HsaKFDContext *ctx,
 		/* Allocate unified memory for context save restore
 		 * area on dGPU.
 		 */
-		if (!q->use_ats && hsakmt_is_svm_api_supported) {
+		if (!q->use_ats && ctx->hsakmt_is_svm_api_supported) {
 			uint32_t size = PAGE_ALIGN_UP(q->total_mem_alloc_size);
 
 			pr_info("Allocating GTT for CWSR\n");

--- a/projects/rocr-runtime/libhsakmt/src/topology.c
+++ b/projects/rocr-runtime/libhsakmt/src/topology.c
@@ -1257,7 +1257,7 @@ static HSAKMT_STATUS topology_sysfs_get_node_props(HsaKFDContext *ctx,
 			gfxv = (uint32_t)prop_val;
 	}
 
-	if (!hsakmt_is_svm_api_supported)
+	if (!ctx->hsakmt_is_svm_api_supported)
 		props->Capability.ui32.SVMAPISupported = 0;
 
 	/* Bail out early, if a CPU node */
@@ -2278,7 +2278,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtAcquireSystemPropertiesCtx(HsaKFDContext *ctx,
 
 	*SystemProperties = *topology_ctx->system_props;
 
-	for (int node = 0; node < topology_ctx->system_props->NumNodes; node++) {
+	for (unsigned int node = 0; node < topology_ctx->system_props->NumNodes; node++) {
 		if (hsakmt_get_gfxv_by_node_id(ctx, node) == GFX_VERSION_GFX1151 &&
 		    hsakmt_kfd_version_info.KernelInterfaceMajorVersion == 1 &&
 		    hsakmt_kfd_version_info.KernelInterfaceMinorVersion < 20)


### PR DESCRIPTION
## Motivation
**This PR introduces interfaces tailored for creating a secondary - type kfd context. These interfaces enable true multi - ctx operation within a single process**.

- **Interface Addition:** Add open/close interfaces for the secondary kfd context, enabling the implementation of true multi-ctx usage.

- **Test Suite Modification:** Synchronously modify the kfdtest test suite. While ensuring the ability to test the original hasKmt public interfaces, add tests for the context-aware interfaces. Also, enable the distinction between whether the tested context is primary or secondary.

- **Calling Flow of Refactored Context-aware Ctx Functions**
The new calling flow for the refactored context-aware functions, presented for the cases of a single primary context versus one primary context plus two secondary contexts, is as follows. Note that the primary context must close after the secondary contexts.
<img width="1140" height="467" alt="rocr-secondary" src="https://github.com/user-attachments/assets/b2bb61f9-9710-4f60-8623-5f2fc1d3dfe1" />

## Refactoring Details
- **Key Implementations:**
      - Add secondary KFD Context APIs: `hsaKmtOpenSecondaryKFDCtx`/`hsaKmtCloseSecondaryKFDCtx` for creating independent contexts with isolated kernel communication channels.
      - Replace `amdgpu_device_initialize` with `amdgpu_device_initialize2` for GPU VM isolation when create secondary contexts.

 - **Macro-Controlled Testing:** The HSAKMT_CTX macro definition controls whether to test the Ctx interface version or the original interface version. If this macro is defined, the Ctx version is tested; otherwise, the original version is tested. Given that HSAKMT_CTX is already defined, if HSAKMT_SECONDARY_CTX is defined, then the secondary context is tested; otherwise, the primary context is tested.

- **Test Suite Modification--Commit Strategy:** In the test suite modification, each hsaKmt** interface is wrapped in the HSAKMT_CALL macro. This unifies the calling method for both the original and context-aware versions.
Since nearly all modifications follow this pattern, although it seems that almost all files have been changed, it is not overly difficult to understand. Therefore, instead of splitting into smaller commits, I made a single commit.

- **kfdtest Modifications:** The modifications related to kfdtest have been submitted in the branch `users/junhshen/libhsakmt-add-sec-ctx-kfdtest`.

## Precautions
- **Feature Limitations:** 
  - Currently, the KFD driver in the Linux kernel does not support SVM (Shared Virtual Memory), user pointers, and debug functions within the secondary KFD context. As a result, I disabled these functions in the secondary context while keeping them enabled for the primary context.

- **Dependencies:** 
   - This PR is reliant on: **[rocm-systems/pr-2405](https://github.com/ROCm/rocm-systems/pull/2405)**(already merged) .

    - The functionality of the secondary context requires synchronous support from the AMD KFD driver in the Linux kernel. For modifications to this driver, please refer to the **[PR in AMD KFD](https://lore.kernel.org/amd-gfx/20251106060739.2281-1-lingshan.zhu@amd.com/)**--The relevant code has already entered the drm-next branch.

## Test Plan
kfdtest

## Test Result
kfdtest passed.