### PR TITLE
fix: null pointer after delete in get_stream_id

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -185,6 +185,7 @@ get_stream_id(Tp* _record)
         auto _region_id                        = _ecid_data->region_id;
         _record->correlation_id.external.value = _region_id;
         delete _ecid_data;
+        _record->correlation_id.external.ptr = nullptr;
     }
     return _stream_id;
 }


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The `get_stream_id` template function was deleting heap-allocated `kernel_rename_and_stream_data` objects but leaving dangling pointers in the correlation structure, which could lead to memory safety issues if the pointer were accessed after deletion.
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Change: Added `_record->correlation_id.external.ptr = nullptr;` immediately after `delete _ecid_data;` in the `get_stream_id` template function.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Created a simplified version of the get_stream_id function logic
Tested the critical fix: _record->correlation_id.external.ptr = nullptr; after delete _ecid_data;
Verified that the pointer is properly nulled after deletion

## Test Result

<!-- Briefly summarize test outcomes. -->
 Successful Test Output:
<img width="683" height="141" alt="image" src="https://github.com/user-attachments/assets/6f9ee334-6ac7-47dd-a1ff-d3cc23fe31e5" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
