### PR TITLE
[ROCProfiler-SDK] Fix SWDEV-556922: Handle comments in pmc: input file

### DIFF
--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -933,12 +933,18 @@ def parse_json(json_file):
 
 def parse_text(text_file):
     def process_line(line):
-        if "pmc:" not in line:
-            return ""
+        # Strip leading/trailing whitespace
         line = line.strip()
+        # Remove comments first (before checking for pmc:)
         pos = line.find("#")
         if pos >= 0:
             line = line[0:pos]
+        # Trim again after comment removal
+        line = line.strip()
+
+        # Now check if line contains pmc: (after comment removal)
+        if "pmc:" not in line:
+            return ""
 
         def _dedup(_line, _sep):
             for itr in _sep:


### PR DESCRIPTION
## Motivation:
ROCm commit : https://github.com/ROCm/rocm-systems/commit/d7eefc6f29542c1da873a7dd35a354406540eff3
When rocprofv3 is called with the -i argument, lines starting with '#' (comment character) that contain 'pmc:' are incorrectly parsed as valid counter collection directives, causing multiple profiling passes.

## Technical Details:
- Reordered process_line() logic in projects/rocprofiler-sdk/source/bin/rocprofv3.py
- Now removes comments BEFORE checking for 'pmc:' keyword
- Modified code in parse_text() function

## Test Plan:
1. Created input file with commented pmc line: #pmc: COUNTER1 COUNTER2
2. Created input file with valid pmc line: pmc: COUNTER3 COUNTER4
3. Ran rocprofv3 with both input files
4. Tested multiple comment format variations
5. Verified no regression in command line --pmc usage

## Test Result: 
Locally tests passed successfully.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
