### PR TITLE
SWDEV-565304 - Pass numa node to migrate pages correctly

### DIFF
--- a/projects/clr/hipamd/src/hip_hmm.cpp
+++ b/projects/clr/hipamd/src/hip_hmm.cpp
@@ -27,21 +27,28 @@
 
 #if defined(__linux__)
 #include <sched.h>
-#include <stdio.h>
+#include <numa.h>
 #endif
 
 namespace hip {
 
 // Get the CPU ID of the current thread
-static int getCurrentCpuId() {
+static int getCurrentNumaId() {
 #if defined(__linux__)
   int cpu = sched_getcpu();
-  if (cpu >= 0) {
-    return cpu;
+  if (cpu < 0) {
+    return hipCpuDeviceId;
   }
-#endif
-  // Default to default if we can't determine the CPU
+
+  int numa_node = numa_node_of_cpu(cpu);
+  if (numa_node < 0) {
+    return hipCpuDeviceId;
+  }
+
+  return numa_node;
+#else
   return hipCpuDeviceId;
+#endif
 }
 
 
@@ -335,7 +342,7 @@ hipError_t ihipMemPrefetchAsync(const void* dev_ptr, size_t count, hipMemLocatio
   if (isHost) {
     targetDevice = hipCpuDeviceId;
   } else if (isHostCurrent) {
-    targetDevice = getCurrentCpuId();
+    targetDevice = getCurrentNumaId();
   } else {
     targetDevice = location.id;
   }
@@ -408,7 +415,7 @@ hipError_t ihipMemAdvise(const void* dev_ptr, size_t count, hipMemoryAdvise advi
       use_cpu = true;
       break;
     case hipMemLocationTypeHostNumaCurrent:
-      targetDevice = getCurrentCpuId();  // Query current thread's CPU ID
+      targetDevice = getCurrentNumaId();  // Query current NUMA node ID
       use_cpu = true;
       break;
     default:

--- a/projects/clr/hipamd/src/hip_hmm.cpp
+++ b/projects/clr/hipamd/src/hip_hmm.cpp
@@ -25,7 +25,25 @@
 #include "platform/command.hpp"
 #include "platform/memory.hpp"
 
+#if defined(__linux__)
+#include <sched.h>
+#include <stdio.h>
+#endif
+
 namespace hip {
+
+// Get the CPU ID of the current thread
+static int getCurrentCpuId() {
+#if defined(__linux__)
+  int cpu = sched_getcpu();
+  if (cpu >= 0) {
+    return cpu;
+  }
+#endif
+  // Default to default if we can't determine the CPU
+  return hipCpuDeviceId;
+}
+
 
 // Forward declaraiton of a function
 hipError_t ihipMallocManaged(void** ptr, size_t size, size_t align = 0, bool use_host_ptr = 0);
@@ -310,9 +328,17 @@ hipError_t ihipMemPrefetchAsync(const void* dev_ptr, size_t count, hipMemLocatio
   const bool cpuAccess = isHost || isHostNuma || isHostCurrent;
 
   // Determine the target device index:
-  //  - for host-prefetch and host-current, always use device 0
+  //  - for host-prefetch, use default CPU agent
+  //  - for host-current, query the current thread's CPU ID
   //  - for host-NUMA or device-prefetch, use the provided id
-  int targetDevice = (isHost || isHostCurrent) ? hipCpuDeviceId : location.id;
+  int targetDevice;
+  if (isHost) {
+    targetDevice = hipCpuDeviceId;
+  } else if (isHostCurrent) {
+    targetDevice = getCurrentCpuId();
+  } else {
+    targetDevice = location.id;
+  }
 
   amd::Device* dev = nullptr;
   if (cpuAccess == false) {
@@ -378,8 +404,11 @@ hipError_t ihipMemAdvise(const void* dev_ptr, size_t count, hipMemoryAdvise advi
       use_cpu = true;
       break;
     case hipMemLocationTypeHost:
-    case hipMemLocationTypeHostNumaCurrent:
       targetDevice = hipCpuDeviceId;
+      use_cpu = true;
+      break;
+    case hipMemLocationTypeHostNumaCurrent:
+      targetDevice = getCurrentCpuId();  // Query current thread's CPU ID
       use_cpu = true;
       break;
     default:

--- a/projects/clr/hipamd/src/hip_hmm.cpp
+++ b/projects/clr/hipamd/src/hip_hmm.cpp
@@ -24,33 +24,9 @@
 #include "platform/context.hpp"
 #include "platform/command.hpp"
 #include "platform/memory.hpp"
-
-#if defined(__linux__)
-#include <sched.h>
-#include <numa.h>
-#endif
+#include "os/os.hpp"
 
 namespace hip {
-
-// Get the CPU ID of the current thread
-static int getCurrentNumaId() {
-#if defined(__linux__)
-  int cpu = sched_getcpu();
-  if (cpu < 0) {
-    return hipCpuDeviceId;
-  }
-
-  int numa_node = numa_node_of_cpu(cpu);
-  if (numa_node < 0) {
-    return hipCpuDeviceId;
-  }
-
-  return numa_node;
-#else
-  return hipCpuDeviceId;
-#endif
-}
-
 
 // Forward declaraiton of a function
 hipError_t ihipMallocManaged(void** ptr, size_t size, size_t align = 0, bool use_host_ptr = 0);
@@ -336,13 +312,15 @@ hipError_t ihipMemPrefetchAsync(const void* dev_ptr, size_t count, hipMemLocatio
 
   // Determine the target device index:
   //  - for host-prefetch, use default CPU agent
-  //  - for host-current, query the current thread's CPU ID
+  //  - for host-current, query the current thread's NUMA node ID
   //  - for host-NUMA or device-prefetch, use the provided id
   int targetDevice;
   if (isHost) {
     targetDevice = hipCpuDeviceId;
   } else if (isHostCurrent) {
-    targetDevice = getCurrentNumaId();
+    uint32_t numa_node = amd::numa::getCurrentNumaNode();
+    targetDevice =
+        (numa_node == static_cast<uint32_t>(-1)) ? hipCpuDeviceId : static_cast<int>(numa_node);
   } else {
     targetDevice = location.id;
   }
@@ -414,10 +392,13 @@ hipError_t ihipMemAdvise(const void* dev_ptr, size_t count, hipMemoryAdvise advi
       targetDevice = hipCpuDeviceId;
       use_cpu = true;
       break;
-    case hipMemLocationTypeHostNumaCurrent:
-      targetDevice = getCurrentNumaId();  // Query current NUMA node ID
+    case hipMemLocationTypeHostNumaCurrent: {
+      uint32_t numa_node = amd::numa::getCurrentNumaNode();
+      targetDevice =
+          (numa_node == static_cast<uint32_t>(-1)) ? hipCpuDeviceId : static_cast<int>(numa_node);
       use_cpu = true;
       break;
+    }
     default:
       return hipErrorInvalidValue;
   }

--- a/projects/clr/rocclr/os/os.hpp
+++ b/projects/clr/rocclr/os/os.hpp
@@ -299,6 +299,9 @@ namespace numa {
 
 static constexpr uint32_t kBitsPerUInt64 = 8 * sizeof(uint64_t);
 
+//! Get the NUMA node ID of the current thread
+uint32_t getCurrentNumaNode();
+
 /*! \brief Manage Numa policy.
  *
  *  \note Works in Linux only, dummy in Windows.

--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -955,6 +955,15 @@ void Os::CxaDemangle(const std::string& name, std::string* result) {
 namespace numa {
 
 // ================================================================================================
+uint32_t getCurrentNumaNode() {
+  unsigned cpu, node;
+  if (syscall(__NR_getcpu, &cpu, &node, nullptr) < 0) {
+    return static_cast<uint32_t>(-1);
+  }
+  return static_cast<uint32_t>(node);
+}
+
+// ================================================================================================
 NumaPolicy::NumaPolicy(const uint32_t numa_node_count) :
   node_map_((numa_node_count + kBitsPerUInt64 - 1) / kBitsPerUInt64, 0) { }
 

--- a/projects/clr/rocclr/os/os_win32.cpp
+++ b/projects/clr/rocclr/os/os_win32.cpp
@@ -705,6 +705,19 @@ void Os::CxaDemangle(const std::string& name, std::string* result) { *result = n
 namespace numa {
 
 // ================================================================================================
+uint32_t getCurrentNumaNode() {
+  PROCESSOR_NUMBER procNumber{};
+  GetCurrentProcessorNumberEx(&procNumber);
+
+  USHORT numa_node = static_cast<USHORT>(-1);
+  if (!GetNumaProcessorNodeEx(&procNumber, &numa_node)) {
+    return static_cast<uint32_t>(-1);
+  }
+
+  return static_cast<uint32_t>(numa_node);
+}
+
+// ================================================================================================
 NumaPolicy::NumaPolicy(const uint32_t numa_node_count) {
 }
 


### PR DESCRIPTION
## Motivation
Bug: For the case of hipMemLocationTypeHostNumaCurrent. default hipCpuDeviceId was passed. 
Fix: We should be passing the NUMA node id which is later indexed into the cpu_agent array in getCpuAgent() correctly.
This allows the migration of pages to the correct NUMA nodes in ROCr. 

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
