### PR TITLE
SWDEV-562708 - change default maximum SVM size to 256GB

### DIFF
--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -118,7 +118,7 @@ release(bool, DISABLE_DEFERRED_ALLOC, false,                                  \
         "Disables deferred memory allocation on device")                      \
 release(int, AMD_GPU_FORCE_SINGLE_FP_DENORM, -1,                              \
         "Force denorm for single precision: -1 - don't force, 0 - disable, 1 - enable") \
-release(uint, OCL_SET_SVM_SIZE, 4*16384,                                      \
+release(uint, OCL_SET_SVM_SIZE, 256*1024,                                     \
         "set SVM space size for discrete GPU")                                \
 release(uint, GPU_WAVES_PER_SIMD, 0,                                          \
         "Force the number of waves per SIMD (1-10)")                          \


### PR DESCRIPTION
## Motivation
change the default maximum SVM size to 256GB from 64GB
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
set the default value of OCL_SET_SVM_SIZE to 256*1024 (MiB)
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
72G hipMalloc test from SWDEV-562708
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Passed.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
