### PR TITLE
clr: Extend dynamic queues and a var for dedicated nullstream

### DIFF
--- a/projects/clr/hipamd/src/hip_stream.cpp
+++ b/projects/clr/hipamd/src/hip_stream.cpp
@@ -32,7 +32,7 @@ namespace hip {
 Stream::Stream(hip::Device* dev, Priority p, unsigned int f, bool null_stream,
                const std::vector<uint32_t>& cuMask, hipStreamCaptureStatus captureStatus)
     : amd::HostQueue(*dev->asContext(), *dev->devices()[0], 0, amd::CommandQueue::RealTimeDisabled,
-                     convertToQueuePriority(p), cuMask),
+                     convertToQueuePriority(p), cuMask, null_stream),
       lock_("Stream Callback lock"),
       device_(dev),
       priority_(p),

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -175,23 +175,23 @@ bool NullDevice::create(const amd::Isa &isa) {
 }
 
 Device::Device(hsa_agent_t bkendDevice)
-    : mapCacheOps_(nullptr)
-    , mapCache_(nullptr)
-    , bkendDevice_(bkendDevice)
-    , pciDeviceId_(0)
-    , gpuvm_segment_max_alloc_(0)
-    , alloc_granularity_(0)
-    , xferQueue_(nullptr)
-    , freeMem_(0)
-    , vgpusAccess_(true) /* Virtual GPU List Ops Lock */
-    , hsa_exclusive_gpu_access_(false)
-    , queuePool_(QueuePriority::Total)
-    , coopHostcallBuffer_(nullptr)
-    , queueWithCUMaskPool_(QueuePriority::Total)
-    , numOfVgpus_(0)
-    , preferred_numa_node_(0)
-    , maxSdmaReadMask_(0)
-    , maxSdmaWriteMask_(0) {
+    : mapCacheOps_(nullptr),
+      mapCache_(nullptr),
+      bkendDevice_(bkendDevice),
+      pciDeviceId_(0),
+      gpuvm_segment_max_alloc_(0),
+      alloc_granularity_(0),
+      xferQueue_(nullptr),
+      freeMem_(0),
+      vgpusAccess_(true), /* Virtual GPU List Ops Lock */
+      hsa_exclusive_gpu_access_(false),
+      queuePool_(QueuePriority::Total),
+      coopHostcallBuffer_(nullptr),
+      queueWithCUMaskPool_(QueuePriority::Total),
+      numOfVgpus_(0),
+      preferred_numa_node_(0),
+      maxSdmaReadMask_(0),
+      maxSdmaWriteMask_(0) {
   group_segment_.handle = 0;
   system_segment_.handle = 0;
   system_coarse_segment_.handle = 0;
@@ -202,6 +202,14 @@ Device::Device(hsa_agent_t bkendDevice)
   prefetch_signal_.handle = 0;
   isXgmi_ = false;
   cache_state_ = Device::CacheState::kCacheStateInvalid;
+
+  // Initialize queuePool_ and queueWithCUMaskPool_ with proper comparator that has device pointer
+  queuePool_.clear();
+  queueWithCUMaskPool_.clear();
+  for (size_t i = 0; i < QueuePriority::Total; ++i) {
+    queuePool_.emplace_back(QueueCompare(this));
+    queueWithCUMaskPool_.emplace_back(QueueCompare(this));
+  }
 }
 
 void Device::setupCpuAgent() {
@@ -273,6 +281,11 @@ Device::~Device() {
       glb_ctx_ = nullptr;
   }
 
+  // Destroy transfer queue FIRST (before destroying queues in pool)
+  // because its destructor will call releaseQueue()
+  delete xferQueue_;
+  xferQueue_ = nullptr;
+
   for (auto& it : queuePool_) {
     for (auto qIter = it.begin(); qIter != it.end(); ) {
       hsa_queue_t* queue = qIter->first;
@@ -291,8 +304,21 @@ Device::~Device() {
   }
   queuePool_.clear();
 
-  // Destroy transfer queue
-  delete xferQueue_;
+  // Clean up null stream queue and its hostcall buffer if it exists
+  if (nullStreamQueue_) {
+    if (nullStreamHostcallBuffer_) {
+      ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
+              "Deleting hostcall buffer %p for null stream queue %p", nullStreamHostcallBuffer_,
+              nullStreamQueue_->base_address);
+      amd::disableHostcalls(nullStreamHostcallBuffer_);
+      context().svmFree(nullStreamHostcallBuffer_);
+      nullStreamHostcallBuffer_ = nullptr;
+    }
+    ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
+            "Destroying null stream queue %p", nullStreamQueue_->base_address);
+    hsa_queue_destroy(nullStreamQueue_);
+    nullStreamQueue_ = nullptr;
+  }
 
   delete blitProgram_;
 
@@ -1788,6 +1814,7 @@ device::VirtualDevice* Device::createVirtualDevice(amd::CommandQueue* queue) {
 
   bool profiling = (queue != nullptr) && queue->properties().test(CL_QUEUE_PROFILING_ENABLE);
   bool cooperative = false;
+  bool is_null_stream = (queue != nullptr) && queue->isNullStream();
 
   // If amd command queue is null, then it's an internal device queue
   if (queue == nullptr) {
@@ -1799,10 +1826,10 @@ device::VirtualDevice* Device::createVirtualDevice(amd::CommandQueue* queue) {
   // queue creation time.
   const std::vector<uint32_t> defaultCuMask = {};
   bool q = (queue != nullptr);
-  VirtualGPU* virtualDevice = new VirtualGPU(*this, profiling, cooperative,
-                                            q ? queue->cuMask() : defaultCuMask,
-                                            q ? queue->priority()
-                                              : amd::CommandQueue::Priority::Normal);
+  VirtualGPU* virtualDevice =
+      new VirtualGPU(*this, profiling, cooperative, q ? queue->cuMask() : defaultCuMask,
+                     q ? queue->priority() : amd::CommandQueue::Priority::Normal,
+                     is_null_stream);
 
   if (!virtualDevice->create()) {
     delete virtualDevice;
@@ -2917,30 +2944,46 @@ void Device::getHwEventTime(const amd::Event& event, uint64_t* start, uint64_t* 
 }
 
 // ================================================================================================
-hsa_queue_t* Device::getQueueFromPool(const uint qIndex) {
-  // Check if queue with refCount 0 is available to use
-  if (queuePool_[qIndex].size() < GPU_MAX_HW_QUEUES) {
-    for (auto& it : queuePool_[qIndex]) {
-      if (it.second.refCount == 0) {
-        it.second.refCount++;
-        ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Selected queue refCount: %p (%d)",
-                it.first->base_address, it.second.refCount);
-        return it.first;
-      }
+hsa_queue_t* Device::getQueueFromPool(const uint qIndex, bool force_reuse) {
+  // Only reuse queues when we've reached the maximum limit, unless forced
+  // Below the limit, return nullptr to allow creating new queues
+  if (!force_reuse && queuePool_[qIndex].size() < settings().max_hw_queues_) {
+    return nullptr;
+  }
+
+  // We've hit the limit, must reuse - find the queue with lowest load metric
+  if (qIndex < QueuePriority::Total && queuePool_[qIndex].size() > 0) {
+    typedef decltype(queuePool_)::value_type::const_reference PoolRef;
+
+    // Select queue based on dynamic_queues_ mode
+    decltype(queuePool_[qIndex].begin()) lowest;
+    uint32_t mode = settings().dynamic_queues_;
+
+    if (mode == 2) {
+      // Mode 2: Queue depth
+      lowest = std::min_element(queuePool_[qIndex].begin(), queuePool_[qIndex].end(),
+                                [](PoolRef A, PoolRef B) {
+                                  return A.second.GetLoadMetric(A.first) <
+                                         B.second.GetLoadMetric(B.first);
+                                });
+    } else {
+      // Mode 0: Map ordered by hsa_queue_t*
+      // Mode 1: Round-Robin(uses queue->id sort)
+      lowest = std::min_element(
+        queuePool_[qIndex].begin(), queuePool_[qIndex].end(),
+                               [](PoolRef A, PoolRef B) {
+                                   return A.second.refCount < B.second.refCount;
+                                });
     }
-  } else {
-    if (qIndex < QueuePriority::Total && queuePool_[qIndex].size() > 0) {
-      // Search through all available queues for the lowest counter.
-      // Note: the map is sorted in the allocation order for possible round-robin selection
-      typedef decltype(queuePool_)::value_type::const_reference PoolRef;
-      auto lowest = std::min_element(
-          queuePool_[qIndex].begin(), queuePool_[qIndex].end(),
-          [](PoolRef A, PoolRef B) { return A.second.refCount < B.second.refCount; });
-      lowest->second.refCount++;
-      ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Selected queue refCount: %p (%d)",
-              lowest->first->base_address, lowest->second.refCount);
-      return lowest->first;
-    }
+
+    lowest->second.refCount++;
+    ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
+            "Selected queue (mode=%u): %p refCount: %d, depth: %lu, metric: %lu%s",
+            mode, lowest->first->base_address, lowest->second.refCount,
+            QueueInfo::GetHwQueueDepth(lowest->first),
+            lowest->second.GetLoadMetric(lowest->first),
+            force_reuse ? " (forced)" : "");
+    return lowest->first;
   }
   return nullptr;
 }
@@ -2956,20 +2999,8 @@ hsa_queue_t* Device::AcquireActiveNormalQueue() {
 // ================================================================================================
 hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
                                   const std::vector<uint32_t>& cuMask,
-                                  amd::CommandQueue::Priority priority,
-                                  bool managed) {
-  amd::ScopedLock l(active_queue_access_);
-
-  assert(queuePool_[QueuePriority::Low].size() <= GPU_MAX_HW_QUEUES ||
-         queuePool_[QueuePriority::Normal].size() <= GPU_MAX_HW_QUEUES ||
-         queuePool_[QueuePriority::High].size() <= GPU_MAX_HW_QUEUES);
-
-  ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Number of allocated hardware queues with low priority: %d,"
-      " with normal priority: %d, with high priority: %d, maximum per priority is: %d",
-      queuePool_[QueuePriority::Low].size(),
-      queuePool_[QueuePriority::Normal].size(),
-      queuePool_[QueuePriority::High].size(), GPU_MAX_HW_QUEUES);
-
+                                  amd::CommandQueue::Priority priority, bool managed,
+                                  bool is_null_stream) {
   hsa_amd_queue_priority_t queue_priority;
   uint qIndex;
   switch (priority) {
@@ -2989,22 +3020,42 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
       break;
   }
 
-  // If we have reached the max number of queues, reuse an existing queue with the matching queue priority,
-  // choosing the one with the least number of users.
-  // Note: Don't attempt to reuse the cooperative queue, since it's single per device
-  if (!coop_queue && (cuMask.size() == 0) &&
-      ((queuePool_[qIndex].size() == GPU_MAX_HW_QUEUES) || queuePool_[qIndex].size() > 0)) {
-    hsa_queue_t* queue = getQueueFromPool(qIndex);
-    if (queue != nullptr) {
-      if (!managed && (qIndex  == QueuePriority::Normal)) {
-        num_normal_queues_++;
-      }
-      return queue;
-    }
+  // Honor DEBUG_HIP_IGNORE_STREAM_PRIORITY flag - force all streams to normal priority
+  if (DEBUG_HIP_IGNORE_STREAM_PRIORITY) {
+    queue_priority = HSA_AMD_QUEUE_PRIORITY_NORMAL;
+    qIndex = QueuePriority::Normal;
   }
 
-  // Else create a new queue. This also includes the initial state where there
-  // is no queue.
+  { // Lock
+    amd::ScopedLock l(active_queue_access_);
+
+    assert(queuePool_[QueuePriority::Low].size() <= settings().max_hw_queues_ ||
+           queuePool_[QueuePriority::Normal].size() <= settings().max_hw_queues_ ||
+           queuePool_[QueuePriority::High].size() <= settings().max_hw_queues_);
+
+    ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
+            "Number of allocated hardware queues with low priority: %d,"
+            " with normal priority: %d, with high priority: %d, maximum per priority is: %d",
+            queuePool_[QueuePriority::Low].size(), queuePool_[QueuePriority::Normal].size(),
+            queuePool_[QueuePriority::High].size(), settings().max_hw_queues_);
+
+    // If we have reached the max number of queues, reuse an existing queue with the matching queue
+    // priority, choosing the one with the least number of users. Note: Don't attempt to reuse the
+    // cooperative queue, since it's single per device. Also, null streams ALWAYS get a dedicated
+    // queue, never from the pool.
+    if (!coop_queue && !is_null_stream && (cuMask.size() == 0) &&
+        (queuePool_[qIndex].size() >= settings().max_hw_queues_)) {
+      hsa_queue_t* queue = getQueueFromPool(qIndex);
+      if (queue != nullptr) {
+        if (!managed && (qIndex == QueuePriority::Normal)) {
+          num_normal_queues_++;
+        }
+        return queue;
+      }
+    }
+  } // Lock release
+
+  // Create a new queue.
   uint32_t queue_max_packets = 0;
   if (HSA_STATUS_SUCCESS !=
       hsa_agent_get_info(bkendDevice_, HSA_AGENT_INFO_QUEUE_MAX_SIZE, &queue_max_packets)) {
@@ -3026,11 +3077,15 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
                           &queue) != HSA_STATUS_SUCCESS) {
     queue_size >>= 1;
     if (queue_size < 64) {
-      // if a queue with the same requested priority available from the pool, returns it here
-      if (!coop_queue && (cuMask.size() == 0) && (queuePool_[qIndex].size() > 0)) {
-        return getQueueFromPool(qIndex);
+      LogError("Device::acquireQueue: hsa_queue_create failed!");
+      // If we can't create even a small queue, try to reuse any existing queue
+      if (!coop_queue && (cuMask.size() == 0)) {
+        amd::ScopedLock l(active_queue_access_);
+        if (queuePool_[qIndex].size() > 0) {
+          bool kForceReuse = true;
+          return getQueueFromPool(qIndex, kForceReuse);
+        }
       }
-      DevLogError("Device::acquireQueue: hsa_queue_create failed!");
       return nullptr;
     }
   }
@@ -3118,6 +3173,7 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
       return nullptr;
     }
     if (cuMask.size() != 0) {
+      amd::ScopedLock l(active_queue_access_);
       // add queues with custom CU mask into their special pool to keep track
       // of mapping of these queues to their associated queueInfo (i.e., hostcall buffers)
       auto result = queueWithCUMaskPool_[qIndex].emplace(std::make_pair(queue, QueueInfo()));
@@ -3134,14 +3190,26 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
     // per device.
     return queue;
   }
-  auto result = queuePool_[qIndex].emplace(std::make_pair(queue, QueueInfo()));
-  assert(result.second && "QueueInfo already exists");
-  auto &qInfo = result.first->second;
-  qInfo.refCount = 1;
-  ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "acquireQueue refCount: %p (%d)",
-          result.first->first->base_address, result.first->second.refCount);
-  if (!managed && (cuMask.size() == 0) && (qIndex = QueuePriority::Normal)) {
-    num_normal_queues_++;
+
+  // Skip adding null streams to the queue pool - they get their own dedicated queue
+  if (!is_null_stream) {
+    amd::ScopedLock l(active_queue_access_);
+    auto result = queuePool_[qIndex].emplace(std::make_pair(queue, QueueInfo()));
+    assert(result.second && "QueueInfo already exists");
+    auto& qInfo = result.first->second;
+    qInfo.refCount = 1;
+    ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "acquireQueue refCount: %p (%d)",
+            result.first->first->base_address, result.first->second.refCount);
+    if (!managed && (cuMask.size() == 0) && (qIndex == QueuePriority::Normal)) {
+      num_normal_queues_++;
+    }
+  } else {
+    // Track the single null stream queue (not pooled, but need hostcall buffer tracking)
+    amd::ScopedLock l(active_queue_access_);
+    assert(nullStreamQueue_ == nullptr && "Only one null stream queue should exist per device");
+    nullStreamQueue_ = queue;
+    ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
+            "Acquired dedicated queue for null stream: %p (not pooled)", queue->base_address);
   }
   return queue;
 }
@@ -3149,7 +3217,7 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
 // ================================================================================================
 bool Device::ReleaseActiveNormalQueue(hsa_queue_t* queue) {
   // Release a queue if the total number of allocated queues exceeds the max possible
-  if (num_normal_queues_.load() > GPU_MAX_HW_QUEUES) {
+  if (num_normal_queues_.load() > settings().max_hw_queues_) {
     releaseQueue(queue, std::vector<uint32_t>{}, false, true);
     return true;
   } else {
@@ -3158,42 +3226,56 @@ bool Device::ReleaseActiveNormalQueue(hsa_queue_t* queue) {
 }
 
 // ================================================================================================
-void Device::releaseQueue(hsa_queue_t* queue, const std::vector<uint32_t>& cuMask,
-    bool coop_queue, bool managed) {
-  amd::ScopedLock l(active_queue_access_);
-  for (auto& it : cuMask.size() == 0 ? queuePool_ : queueWithCUMaskPool_) {
-    auto qIter = it.find(queue);
-    if (qIter != it.end()) {
-      if (!managed && (cuMask.size() == 0) && (&it == &queuePool_[QueuePriority::Normal])) {
-        num_normal_queues_--;
-      }
-      auto &qInfo = qIter->second;
-      assert(qInfo.refCount > 0);
-      qInfo.refCount--;
-      ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "releaseQueue refCount:%p (%d)",
-              qIter->first->base_address, qIter->second.refCount);
-      // hsa queues with cumask set are not being reused. Hence, if the app uses multiple
-      // such queues it can cause memory leak and those must be destroyed here once the
-      // refcount reaches 0.
-      if ((!cuMask.empty()) && (qInfo.refCount == 0)) {
-        if (qInfo.hostcallBuffer_) {
-          ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
-                  "Deleting hostcall buffer %p for hardware queue %p",
-                  qInfo.hostcallBuffer_, qIter->first->base_address);
-          amd::disableHostcalls(qInfo.hostcallBuffer_);
-          context().svmFree(qInfo.hostcallBuffer_);
+void Device::releaseQueue(hsa_queue_t* queue, const std::vector<uint32_t>& cuMask, bool coop_queue,
+                          bool managed) {
+  // Defer cleanup operations outside the lock
+  void* hostcallBufferToFree = nullptr;
+  bool shouldDestroyQueue = false;
+
+  { // Lock
+    amd::ScopedLock l(active_queue_access_);
+    for (auto& it : cuMask.size() == 0 ? queuePool_ : queueWithCUMaskPool_) {
+      auto qIter = it.find(queue);
+      if (qIter != it.end()) {
+        if (!managed && (cuMask.size() == 0) && (&it == &queuePool_[QueuePriority::Normal])) {
+          num_normal_queues_--;
         }
-        ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting hardware queue %p with refCount 0",
-                queue->base_address);
-        qIter = it.erase(qIter);
-        hsa_queue_destroy(queue);
+        auto& qInfo = qIter->second;
+        assert(qInfo.refCount > 0);
+        qInfo.refCount--;
+        ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "releaseQueue refCount:%p (%d)",
+                qIter->first->base_address, qIter->second.refCount);
+        // hsa queues with cumask set are not being reused. Hence, if the app uses multiple
+        // such queues it can cause memory leak and those must be destroyed here once the
+        // refcount reaches 0.
+        if ((!cuMask.empty()) && (qInfo.refCount == 0)) {
+          hostcallBufferToFree = qInfo.hostcallBuffer_;
+          shouldDestroyQueue = true;
+          ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting hardware queue %p with refCount 0",
+                  queue->base_address);
+          it.erase(qIter);
+        }
+        break;  // Found and processed the queue
       }
     }
+  } // Lock release
+
+  // Perform expensive cleanup operations outside the lock
+  if (shouldDestroyQueue) {
+    if (hostcallBufferToFree) {
+      ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
+              "Deleting hostcall buffer %p for hardware queue %p", hostcallBufferToFree,
+              queue->base_address);
+      amd::disableHostcalls(hostcallBufferToFree);
+      context().svmFree(hostcallBufferToFree);
+    }
+    hsa_queue_destroy(queue);
   }
-  if (coop_queue) { // cooperative queue
-      ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting CG enabled hardware queue %p ",
-               queue->base_address);
-      hsa_queue_destroy(queue);
+
+  if (coop_queue) {  // cooperative queue
+    ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting CG enabled hardware queue %p ",
+            queue->base_address);
+    hsa_queue_destroy(queue);
   }
 
 }
@@ -3201,22 +3283,34 @@ void Device::releaseQueue(hsa_queue_t* queue, const std::vector<uint32_t>& cuMas
 void* Device::getOrCreateHostcallBuffer(hsa_queue_t* queue, bool coop_queue,
                                         const std::vector<uint32_t>& cuMask) {
   decltype(queuePool_)::value_type::iterator qIter;
+  bool found = false;
+  bool is_null_stream_queue = false;
 
   if (!coop_queue) {
-    for (auto &it : cuMask.size() == 0 ? queuePool_ : queueWithCUMaskPool_) {
-      qIter = it.find(queue);
-      if (qIter != it.end()) {
-        break;
+    // Check if this is the null stream queue first
+    {
+      amd::ScopedLock l(active_queue_access_);
+      if (queue == nullStreamQueue_) {
+        is_null_stream_queue = true;
+        if (nullStreamHostcallBuffer_) {
+          return nullStreamHostcallBuffer_;
+        }
       }
     }
-    if (cuMask.size() == 0) {
-      assert(qIter != queuePool_[QueuePriority::High].end());
-    } else {
-      assert(qIter != queueWithCUMaskPool_[QueuePriority::High].end());
-    }
 
-    if (qIter->second.hostcallBuffer_) {
-      return qIter->second.hostcallBuffer_;
+    if (!is_null_stream_queue) {
+      for (auto& it : cuMask.size() == 0 ? queuePool_ : queueWithCUMaskPool_) {
+        qIter = it.find(queue);
+        if (qIter != it.end()) {
+          found = true;
+          break;
+        }
+      }
+      assert(found && "Couldn't find queue");
+
+      if (qIter->second.hostcallBuffer_) {
+        return qIter->second.hostcallBuffer_;
+      }
     }
   } else {
     if (coopHostcallBuffer_) {
@@ -3241,7 +3335,12 @@ void* Device::getOrCreateHostcallBuffer(hsa_queue_t* queue, bool coop_queue,
   ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Created hostcall buffer %p for hardware queue %p", buffer,
           queue->base_address);
   if (!coop_queue) {
-    qIter->second.hostcallBuffer_ = buffer;
+    if (is_null_stream_queue) {
+      amd::ScopedLock l(active_queue_access_);
+      nullStreamHostcallBuffer_ = buffer;
+    } else {
+      qIter->second.hostcallBuffer_ = buffer;
+    }
   } else {
     coopHostcallBuffer_ = buffer;
   }

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -507,10 +507,10 @@ class Device : public NullDevice {
 
   //! Acquire HSA queue. This method can create a new HSA queue or
   //! share previously created
-  hsa_queue_t* acquireQueue(uint32_t queue_size_hint, bool coop_queue = false,
-                            const std::vector<uint32_t>& cuMask = {},
-                            amd::CommandQueue::Priority priority = amd::CommandQueue::Priority::Normal,
-                            bool managed = false);
+  hsa_queue_t* acquireQueue(
+      uint32_t queue_size_hint, bool coop_queue = false, const std::vector<uint32_t>& cuMask = {},
+      amd::CommandQueue::Priority priority = amd::CommandQueue::Priority::Normal,
+      bool managed = false, bool is_null_stream = false);
 
   //! Release HSA queue
   void releaseQueue(hsa_queue_t*, const std::vector<uint32_t>& cuMask = {},
@@ -622,25 +622,51 @@ class Device : public NullDevice {
   struct QueueInfo {
     int refCount;           //! Reference counter. Shows how many time the queue was shared
     void* hostcallBuffer_;  //! Host call buffer for the HSA queue
+
+    // Constructor
+    QueueInfo() : refCount(0), hostcallBuffer_(nullptr) {}
+
+    //! Get the current hardware queue depth (wptr - rptr)
+    static uint64_t GetHwQueueDepth(hsa_queue_t* queue) {
+      uint64_t wptr = hsa_queue_load_write_index_relaxed(queue);
+      uint64_t rptr = hsa_queue_load_read_index_relaxed(queue);
+      return wptr - rptr;
+    }
+
+    //! Get a combined metric for queue selection (lower is better)
+    uint64_t GetLoadMetric(hsa_queue_t* queue) const {
+      // Metric = current_depth + (refCount * 1000)
+      // - A queue with depth=100 and 2 users gets score 102000 (100 + 2 * 1000)
+      // - A queue with depth=500 and 0 users gets score 500 (500 + 0 * 1000)
+      // - Result: pick the 2-user queue
+      return GetHwQueueDepth(queue) + static_cast<uint64_t>(refCount * 1000);
+    }
   };
 
   struct QueueCompare {
+    const Device* device_;
+
+    QueueCompare(const Device* dev = nullptr) : device_(dev) {}
+
     // Customized queue compare operator to make sure the queues are sorted in the creation order
     bool operator()(hsa_queue_t* lhs, hsa_queue_t* rhs) const {
-      if (DEBUG_HIP_DYNAMIC_QUEUES) {
-        return (lhs->id < rhs->id) ? true : false;
+      if (device_ && device_->settings().dynamic_queues_ > 0) {
+        return lhs->id < rhs->id;  // Sort by ID for dynamic queues
       } else {
-        return (lhs < rhs) ? true : false;
+        return lhs < rhs;  // Sort by pointer address for mode 0
       }
     }
   };
   //! a vector for keeping Pool of HSA queues with low, normal and high priorities for recycling
   std::vector<std::map<hsa_queue_t*, QueueInfo, QueueCompare>> queuePool_;
-  amd::Monitor active_queue_access_;                //!< Lock to serialise virtual gpu list access
-  std::atomic<uint32_t> num_normal_queues_{0};      //!< The total number of allocated normal queues
+  //! Track the single null stream queue (not pooled)
+  hsa_queue_t* nullStreamQueue_ = nullptr;
+  void* nullStreamHostcallBuffer_ = nullptr;
+  amd::Monitor active_queue_access_;            //!< Lock to serialise virtual gpu list access
+  std::atomic<uint32_t> num_normal_queues_{0};  //!< The total number of allocated normal queues
 
   //! returns a hsa queue from queuePool with least refCount and updates the refCount as well
-  hsa_queue_t* getQueueFromPool(const uint qIndex);
+  hsa_queue_t* getQueueFromPool(const uint qIndex, bool force_reuse = false);
 
   void* coopHostcallBuffer_;
   //! returns value for corresponding LinkAttrbutes in a vector given Memory pool.

--- a/projects/clr/rocclr/device/rocm/rocsettings.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.cpp
@@ -96,7 +96,14 @@ Settings::Settings() {
   gwsInitSupported_ = true;
   limit_blit_wg_ = 16;
 
-  dynamic_queues_ = amd::IS_HIP ? DEBUG_HIP_DYNAMIC_QUEUES : false;
+  dynamic_queues_ = amd::IS_HIP ? DEBUG_HIP_DYNAMIC_QUEUES : 0;
+  // note: OCL user events don't allow CPU blocking calls in DD mode
+  blocking_blit_ = amd::IS_HIP || !AMD_DIRECT_DISPATCH;
+
+  max_hw_queues_ = GPU_MAX_HW_QUEUES;
+  if (DEBUG_HIP_EXCLUSIVE_NULL_STREAM) {
+    max_hw_queues_ = (GPU_MAX_HW_QUEUES > 1) ? (GPU_MAX_HW_QUEUES - 1) : 1;
+  }
 }
 
 // ================================================================================================

--- a/projects/clr/rocclr/device/rocm/rocsettings.hpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.hpp
@@ -41,17 +41,18 @@ class Settings : public device::Settings {
 
   union {
     struct {
-      uint doublePrecision_ : 1;        //!< Enables double precision support
-      uint enableLocalMemory_ : 1;      //!< Enable GPUVM memory
-      uint enableNCMode_ : 1;           //!< Enable Non Coherent mode for system memory
-      uint imageDMA_ : 1;               //!< Enable direct image DMA transfers
-      uint imageBufferWar_ : 1;         //!< Image buffer workaround for Gfx10
-      uint cpu_wait_for_signal_ : 1;    //!< Wait for HSA signal on CPU
-      uint system_scope_signal_ : 1;    //!< HSA signal is visibile to the entire system
-      uint fgs_kernel_arg_ : 1;         //!< Use fine grain kernel arg segment
-      uint barrier_value_packet_ : 1;   //!< Barrier value packet functionality
-      uint dynamic_queues_ : 1;         //!< Dynamic queues management
-      uint reserved_ : 22;
+      uint doublePrecision_ : 1;       //!< Enables double precision support
+      uint enableLocalMemory_ : 1;     //!< Enable GPUVM memory
+      uint enableNCMode_ : 1;          //!< Enable Non Coherent mode for system memory
+      uint imageDMA_ : 1;              //!< Enable direct image DMA transfers
+      uint imageBufferWar_ : 1;        //!< Image buffer workaround for Gfx10
+      uint cpu_wait_for_signal_ : 1;   //!< Wait for HSA signal on CPU
+      uint system_scope_signal_ : 1;   //!< HSA signal is visibile to the entire system
+      uint fgs_kernel_arg_ : 1;        //!< Use fine grain kernel arg segment
+      uint barrier_value_packet_ : 1;  //!< Barrier value packet functionality
+      uint dynamic_queues_ : 2;        //!< Dynamic queues: 0=off, 1=RR, 2=depth, 3=weighted
+      uint blocking_blit_ : 1;         //!< Blit ops can be blocking on CPU
+      uint reserved_ : 20;
     };
     uint value_;
   };
@@ -73,8 +74,9 @@ class Settings : public device::Settings {
   size_t sdmaCopyThreshold_;  //!< Use SDMA to copy above this size
   size_t sdma_p2p_threshold_; //!< Use SDMA in P2P above this size
 
-  uint32_t  hmmFlags_;        //!< HMM functionality control flags
-  uint32_t  limit_blit_wg_;   //!< The number of workgroups for blit execution
+  uint32_t hmmFlags_;       //!< HMM functionality control flags
+  uint32_t limit_blit_wg_;  //!< The number of workgroups for blit execution
+  uint32_t max_hw_queues_;  //!< Effective maximum HW queues (accounts for null stream reservation)
 
   //! Default constructor
   Settings();

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -916,8 +916,10 @@ bool VirtualGPU::processMemObjects(const amd::Kernel& kernel, const_address para
 
 // ================================================================================================
 uint64_t VirtualGPU::getQueueID() {
-  amd::ScopedLock lock(execution());
-  if (gpu_queue_ == nullptr) {
+
+  // Null streams keep their dedicated queue, never acquire from pool
+  if (!is_null_stream_ && gpu_queue_ == nullptr) {
+    amd::ScopedLock lock(execution());
     gpu_queue_ = roc_device_.AcquireActiveNormalQueue();
   }
   return gpu_queue_->id;
@@ -1409,8 +1411,8 @@ bool VirtualGPU::releaseGpuMemoryFence(bool skip_cpu_wait) {
 
 // ================================================================================================
 VirtualGPU::VirtualGPU(Device& device, bool profiling, bool cooperative,
-                       const std::vector<uint32_t>& cuMask,
-                       amd::CommandQueue::Priority priority)
+                       const std::vector<uint32_t>& cuMask, amd::CommandQueue::Priority priority,
+                       bool is_null_stream)
     : device::VirtualDevice(device),
       state_(0),
       gpu_queue_(nullptr),
@@ -1430,8 +1432,8 @@ VirtualGPU::VirtualGPU(Device& device, bool profiling, bool cooperative,
       copy_command_type_(0),
       fence_state_(Device::CacheState::kCacheStateInvalid),
       fence_dirty_(false),
-      lastUsedSdmaEngineMask_(0)
-{
+      lastUsedSdmaEngineMask_(0),
+      is_null_stream_(is_null_stream) {
   index_ = device.numOfVgpus_++;
   gpu_device_ = device.getBackendDevice();
   printfdbg_ = nullptr;
@@ -1479,7 +1481,8 @@ VirtualGPU::~VirtualGPU() {
 
   if (tracking_created_) {
     amd::ScopedLock l(execution());
-    if (gpu_queue_ == nullptr) {
+    // Null streams keep their dedicated queue, never acquire from pool
+    if (!is_null_stream_ && gpu_queue_ == nullptr) {
       gpu_queue_ = roc_device_.AcquireActiveNormalQueue();
     }
     // Release the resources of signal
@@ -1522,7 +1525,17 @@ VirtualGPU::~VirtualGPU() {
   }
 
   if (gpu_queue_ != nullptr) {
-    roc_device_.releaseQueue(gpu_queue_, cuMask_, cooperative_);
+    // For null streams, just mark it for cleanup but DON'T destroy it here
+    // The Device destructor will handle destroying the null stream queue
+    if (is_null_stream_) {
+      ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
+              "Releasing null stream queue %p (will be destroyed by Device destructor)",
+              gpu_queue_->base_address);
+      // Don't destroy the queue here, just clear our reference
+      gpu_queue_ = nullptr;
+    } else {
+      roc_device_.releaseQueue(gpu_queue_, cuMask_, cooperative_);
+    }
   }
 }
 
@@ -1530,7 +1543,8 @@ VirtualGPU::~VirtualGPU() {
 bool VirtualGPU::create() {
   // Pick a reasonable queue size
   uint32_t queue_size = ROC_AQL_QUEUE_SIZE;
-  gpu_queue_ = roc_device_.acquireQueue(queue_size, cooperative_, cuMask_, priority_);
+  gpu_queue_ = roc_device_.acquireQueue(queue_size, cooperative_, cuMask_, priority_, false,
+                                         is_null_stream_);
   if (!gpu_queue_) return false;
 
   if (!managed_kernarg_buffer_.Create(Device::MemorySegment::kKernArg)) {
@@ -1693,17 +1707,23 @@ address VirtualGPU::allocKernelArguments(size_t size, size_t alignment) {
 // ================================================================================================
 void VirtualGPU::ReleaseAllHwQueues() {
   if (roc_device_.settings().dynamic_queues_ &&
-      (roc_device_.NumNormalQueues() > GPU_MAX_HW_QUEUES)) {
+      (roc_device_.NumNormalQueues() > roc_device_.settings().max_hw_queues_)) {
     // Lock the device to make the following thread safe
-    amd::ScopedLock lock(roc_device_.vgpusAccess());
-    for (uint idx = 0; idx < roc_device_.vgpus().size(); ++idx) {
-      roc_device_.vgpus()[idx]->ReleaseHwQueue();
-    }
+    // amd::ScopedLock lock(roc_device_.vgpusAccess());
+    // for (uint idx = 0; idx < roc_device_.vgpus().size(); ++idx) {
+    //   roc_device_.vgpus()[idx]->ReleaseHwQueue();
+    // }
+    ReleaseHwQueue();
   }
 }
 
 // ================================================================================================
 void VirtualGPU::ReleaseHwQueue() {
+  // Null streams keep their dedicated queue, never release to pool
+  if (is_null_stream_) {
+    return;
+  }
+
   // Try to release normal queue to the pool of active queues
   if (roc_device_.settings().dynamic_queues_ &&
       (priority_ == amd::CommandQueue::Priority::Normal) &&
@@ -1725,7 +1745,8 @@ void VirtualGPU::ReleaseHwQueue() {
 * and then calls start() to get the current host timestamp.
 */
 void VirtualGPU::profilingBegin(amd::Command& command, bool sdmaProfiling) {
-  if (gpu_queue_ == nullptr) {
+  // Null streams keep their dedicated queue, never acquire from pool
+  if (!is_null_stream_ && gpu_queue_ == nullptr) {
     gpu_queue_ = roc_device_.AcquireActiveNormalQueue();
   }
   // Track the current command

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -334,7 +334,8 @@ class VirtualGPU : public device::VirtualDevice {
 
   VirtualGPU(Device& device, bool profiling = false, bool cooperative = false,
              const std::vector<uint32_t>& cuMask = {},
-             amd::CommandQueue::Priority priority = amd::CommandQueue::Priority::Normal);
+             amd::CommandQueue::Priority priority = amd::CommandQueue::Priority::Normal,
+             bool is_null_stream = false);
   ~VirtualGPU();
 
   bool create();
@@ -546,16 +547,35 @@ class VirtualGPU : public device::VirtualDevice {
   //! Returns true if the queue is considered as idle. That means all submitted packets are complete.
   //! Note: it doesn't track the state of caches
   bool IsQueueIdle() const {
-    bool result = false;
-    // Make sure the last packet contained a completion signal
-    if (last_barrier_index_ == last_write_index_) {
-      if ((last_write_index_ == 0) && (last_completion_signal_.handle == 0)) {
-        result = true;
-      } else {
-        result = (hsa_signal_load_relaxed(last_completion_signal_) == 0);
-      }
+    if (gpu_queue_ == nullptr) {
+      return true;
     }
-    return result;
+
+    // Use wptr/rptr to accurately determine if queue has pending work
+    uint64_t wptr = hsa_queue_load_write_index_relaxed(gpu_queue_);
+    uint64_t rptr = hsa_queue_load_read_index_relaxed(gpu_queue_);
+
+    // Queue is idle if read pointer has caught up to write pointer
+    if (wptr == rptr) {
+      return true;
+    }
+
+    // Fallback: check completion signal if available (for backwards compatibility)
+    if (last_barrier_index_ == last_write_index_ && last_completion_signal_.handle != 0) {
+      return (hsa_signal_load_relaxed(last_completion_signal_) == 0);
+    }
+
+    return false;
+  }
+
+  //! Get the current queue depth (number of pending packets)
+  uint64_t GetQueueDepth() const {
+    if (gpu_queue_ == nullptr) {
+      return 0;
+    }
+    uint64_t wptr = hsa_queue_load_write_index_relaxed(gpu_queue_);
+    uint64_t rptr = hsa_queue_load_read_index_relaxed(gpu_queue_);
+    return wptr - rptr;
   }
 
   std::vector<amd::Memory*> pinnedMems_;   //!< Pinned memory list
@@ -614,7 +634,8 @@ class VirtualGPU : public device::VirtualDevice {
 
   //!< bit-vector representing the CU mask. Each active bit represents using one CU
   const std::vector<uint32_t> cuMask_;
-  amd::CommandQueue::Priority priority_; //!< The priority for the hsa queue
+  amd::CommandQueue::Priority priority_;  //!< The priority for the hsa queue
+  bool is_null_stream_;                   //!< TRUE if this VirtualGPU is for a HIP null stream
 
   cl_command_type copy_command_type_;   //!< Type of the copy command, used for ROC profiler
                                         //!< OCL doesn't distinguish diffrent copy types,

--- a/projects/clr/rocclr/platform/commandqueue.cpp
+++ b/projects/clr/rocclr/platform/commandqueue.cpp
@@ -35,9 +35,10 @@
 namespace amd {
 
 HostQueue::HostQueue(Context& context, Device& device, cl_command_queue_properties props,
-                     uint queueRTCUs, Priority priority, const std::vector<uint32_t>& cuMask)
-    : CommandQueue(context, device, props, device.info().queueProperties_, queueRTCUs,
-                   priority, cuMask),
+                     uint queueRTCUs, Priority priority, const std::vector<uint32_t>& cuMask,
+                     bool is_null_stream)
+    : CommandQueue(context, device, props, device.info().queueProperties_, queueRTCUs, priority,
+                   cuMask, is_null_stream),
       lastEnqueueCommand_(nullptr),
       head_(nullptr),
       tail_(nullptr),

--- a/projects/clr/rocclr/platform/commandqueue.hpp
+++ b/projects/clr/rocclr/platform/commandqueue.hpp
@@ -88,6 +88,9 @@ class CommandQueue : public RuntimeObject {
   //! Returns the base class object
   CommandQueue* asCommandQueue() { return this; }
 
+  //! Returns TRUE if this is a null stream (HIP only)
+  bool isNullStream() const { return is_null_stream_; }
+
   virtual ~CommandQueue() {}
 
   //! Returns TRUE if the object was successfully created
@@ -123,7 +126,8 @@ class CommandQueue : public RuntimeObject {
                cl_command_queue_properties propMask,     //!< Queue properties mask
                uint rtCUs = RealTimeDisabled,            //!< Avaialble real time compute units
                Priority priority = Priority::Normal,     //!< Queue priority
-               const std::vector<uint32_t>& cuMask = {}  //!< CU mask
+               const std::vector<uint32_t>& cuMask = {}, //!< CU mask
+               bool is_null_stream = false               //!< TRUE if HIP null stream
                )
       : properties_(propMask, properties),
         rtCUs_(rtCUs),
@@ -132,7 +136,8 @@ class CommandQueue : public RuntimeObject {
         lastCmdLock_(),
         device_(device),
         context_(context),
-        cuMask_(cuMask) {}
+        cuMask_(cuMask),
+        is_null_stream_(DEBUG_HIP_EXCLUSIVE_NULL_STREAM && is_null_stream) {}
 
   Properties properties_;               //!< Queue properties
   uint rtCUs_;                          //!< The number of used RT compute units
@@ -142,6 +147,7 @@ class CommandQueue : public RuntimeObject {
   Device& device_;                      //!< The device
   SharedReference<Context> context_;    //!< The context of this command queue
   const std::vector<uint32_t> cuMask_;  //!< The CU mask
+  bool is_null_stream_ = false;         //!< TRUE if this is a HIP null stream
 
  private:
   //! Disable copy constructor
@@ -213,7 +219,7 @@ class HostQueue : public CommandQueue {
    */
   HostQueue(Context& context, Device& device, cl_command_queue_properties properties,
             uint queueRTCUs = 0, Priority priority = Priority::Normal,
-            const std::vector<uint32_t>& cuMask = {});
+            const std::vector<uint32_t>& cuMask = {}, bool is_null_stream = false);
 
   //! Returns TRUE if this command queue can accept commands.
   virtual bool create() { return thread_.acceptingCommands_; }

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -271,8 +271,12 @@ release(bool, DEBUG_CLR_KERNARG_HDP_FLUSH_WA, false,                          \
         "Toggle kernel arg copy workaround")                                  \
 release(bool, DEBUG_CLR_SKIP_RELEASE_SCOPE, false,                            \
         "Forces release scope to SCOPE_NONE for aql packets")                 \
-release(bool, DEBUG_HIP_DYNAMIC_QUEUES, false,                                \
-        "Forces dynamic queue management")                                    \
+release(uint, DEBUG_HIP_DYNAMIC_QUEUES, 0,                                    \
+        "Dynamic queue management: 0=off, 1=Round-Robin, 2=Queue depth")      \
+release(bool, DEBUG_HIP_EXCLUSIVE_NULL_STREAM, false,                         \
+        "Give null streams dedicated queues, excluded from pool management")  \
+release(bool, DEBUG_HIP_IGNORE_STREAM_PRIORITY, false,                        \
+        "Ignore priority streams")                                            \
 release(uint, HIP_SKIP_ABORT_ON_GPU_ERROR, true,                              \
         "Set this to true, to avoid host side abort for GPU errors")          \
 release(bool, HIP_FORCE_SPIRV_CODEOBJECT, false,                              \


### PR DESCRIPTION
* Use env DEBUG_HIP_EXCLUSIVE_NULL_STREAM, default is 0
* Use env DEBUG_HIP_DYNAMIC_QUEUES for the following behavior
* 0 - Default is disabled
* 1 - Uses simple RR
* 2 - Use QueueDepth as a comparator when acquiring a queue

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
