### PR TITLE
[rocprofiler-systems] Adjust host thread count for OpenMP-VV tests to avoid timeouts

### DIFF
--- a/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
@@ -223,7 +223,7 @@ endif()
 
 set(OMPVV_OPENMP_VERSION 5.0)
 set(OMPVV_TDIR "tests/${OMPVV_OPENMP_VERSION}")
-set(OMPVV_NUM_THREADS_HOST ${ROCPROFSYS_THREAD_COUNT})
+set(OMPVV_NUM_THREADS_HOST 128) # Smallest possible value of ROCPROFSYS_THREAD_COUNT. Avoids very long test times
 set(OMPVV_NUM_TEAMS_DEVICE 8) # default used by ompvv
 set(OMPVV_NUM_THREADS_DEVICE 8) # default used by ompvv
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
OpenMP-VV tests were told to use `ROCPROFSYS_THREAD_COUNT` for the number of openmp threads to spawn during a parallel region. On some machines, this number is so large that binary instrumentation may take upwards of 300 seconds, causing test failures. 

As these tests are for OpenMP and not for thread-limits, I have fixed the value to be 128, which is the smallest possible value of `ROCPROFSYS_THREAD_COUNT`.

Closes SWDEV-565162
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
`set(OMPVV_NUM_THREADS_HOST ${ROCPROFSYS_THREAD_COUNT})` changed to `set(OMPVV_NUM_THREADS_HOST 128)`

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Ran on local system.

## Test Result

<!-- Briefly summarize test outcomes. -->
Longest test takes about 3 to 4 seconds as opposed to 300.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
