### PR TITLE
SWDEV-558855 - Enable Interop Map Buffer on Windows

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -207,8 +207,7 @@ hsa_status_t Memory::interopMapBuffer(amd::Os::FileDesc fdn) {
   size_t metadata_size = 0;
   void* metadata;
 #if IS_WINDOWS
-  int fd = 0;
-  assert(!"Unimplemented");
+  auto fd = reinterpret_cast<HANDLE>(fdn);
 #else
   auto fd = fdn;
 #endif

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -206,11 +206,7 @@ hsa_status_t Memory::interopMapBuffer(amd::Os::FileDesc fdn) {
   size_t size;
   size_t metadata_size = 0;
   void* metadata;
-#if IS_WINDOWS
-  auto fd = reinterpret_cast<HANDLE>(fdn);
-#else
   auto fd = fdn;
-#endif
   hsa_status_t status = Hsa::interop_map_buffer(1, &agent, fd, 0, &size, &interop_deviceMemory_,
                                                 &metadata_size, (const void**)&metadata);
   ClPrint(amd::LOG_DEBUG, amd::LOG_MEM, "Map Interop memory %p, size 0x%zx", interop_deviceMemory_,

--- a/projects/clr/rocclr/device/rocm/rocrctx.hpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.hpp
@@ -23,10 +23,6 @@
 #include <mutex>
 #include "top.hpp"
 
-#if IS_WINDOWS
-#include <windows.h>
-#endif
-
 #ifdef ROCR_DYN_DLL
 #include "hsa.h"
 #include "hsa_ext_image.h"

--- a/projects/clr/rocclr/device/rocm/rocrctx.hpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.hpp
@@ -23,6 +23,10 @@
 #include <mutex>
 #include "top.hpp"
 
+#if IS_WINDOWS
+#include <windows.h>
+#endif
+
 #ifdef ROCR_DYN_DLL
 #include "hsa.h"
 #include "hsa_ext_image.h"
@@ -386,7 +390,12 @@ class Hsa : public amd::AllStatic {
     return ROCR_DYN(hsa_amd_memory_unlock)(host_ptr);
   }
   static hsa_status_t interop_map_buffer(uint32_t num_agents, hsa_agent_t* agents,
-    int interop_handle, uint32_t flags, size_t* size,
+#if IS_WINDOWS
+    HANDLE interop_handle,
+#else
+    int interop_handle,
+#endif
+    uint32_t flags, size_t* size,
     void** ptr, size_t* metadata_size, const void** metadata) {
     return ROCR_DYN(hsa_amd_interop_map_buffer)(num_agents, agents, interop_handle, flags, size,
                                                 ptr, metadata_size, metadata);

--- a/projects/clr/rocclr/device/rocm/rocrctx.hpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.hpp
@@ -390,11 +390,7 @@ class Hsa : public amd::AllStatic {
     return ROCR_DYN(hsa_amd_memory_unlock)(host_ptr);
   }
   static hsa_status_t interop_map_buffer(uint32_t num_agents, hsa_agent_t* agents,
-#if IS_WINDOWS
-    HANDLE interop_handle,
-#else
-    int interop_handle,
-#endif
+    amd::Os::FileDesc interop_handle,
     uint32_t flags, size_t* size,
     void** ptr, size_t* metadata_size, const void** metadata) {
     return ROCR_DYN(hsa_amd_interop_map_buffer)(num_agents, agents, interop_handle, flags, size,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
@@ -1094,7 +1094,7 @@ hsa_status_t HSA_API
 // Mirrors Amd Extension Apis
 hsa_status_t HSA_API hsa_amd_interop_map_buffer(uint32_t num_agents,
                                         hsa_agent_t* agents,
-                                        int interop_handle,
+                                        hsa_handle_t interop_handle,
                                         uint32_t flags,
                                         size_t* size,
                                         void** ptr,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
@@ -219,7 +219,7 @@ hsa_status_t
 // Mirrors Amd Extension Apis
 hsa_status_t hsa_amd_interop_map_buffer(uint32_t num_agents,
                                         hsa_agent_t* agents,
-                                        int interop_handle,
+                                        hsa_handle_t interop_handle,
                                         uint32_t flags,
                                         size_t* size,
                                         void** ptr,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -346,7 +346,8 @@ class Runtime {
                                      hsa_amd_signal_handler handler, void* arg);
 
   hsa_status_t InteropMap(uint32_t num_agents, Agent** agents,
-                          int interop_handle, uint32_t flags, size_t* size,
+                          hsa_handle_t interop_handle,
+                          uint32_t flags, size_t* size,
                           void** ptr, size_t* metadata_size,
                           const void** metadata);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -993,7 +993,8 @@ hsa_status_t hsa_amd_agent_memory_pool_get_info(
 }
 
 hsa_status_t hsa_amd_interop_map_buffer(uint32_t num_agents,
-                                        hsa_agent_t* agents, int interop_handle,
+                                        hsa_agent_t* agents,
+                                        hsa_handle_t interop_handle,
                                         uint32_t flags, size_t* size,
                                         void** ptr, size_t* metadata_size,
                                         const void** metadata) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -889,7 +889,8 @@ hsa_status_t Runtime::SetAsyncSignalHandler(hsa_signal_t signal,
 }
 
 hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents,
-                                 int interop_handle, uint32_t flags,
+                                 hsa_handle_t interop_handle,
+                                 uint32_t flags,
                                  size_t* size, void** ptr,
                                  size_t* metadata_size, const void** metadata) {
   static const int tinyArraySize=8;
@@ -897,6 +898,11 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents,
 
   HSAuint32 short_nodes[tinyArraySize];
   HSAuint32* nodes = short_nodes;
+
+  static_assert(sizeof(HSAint64) >= sizeof(interop_handle),
+                "HSAint64 too small for interop_handle");
+  HSAint64 resource_handle = reinterpret_cast<HSAint64>(interop_handle);
+
   if (num_agents > tinyArraySize) {
     nodes = new HSAuint32[num_agents];
     if (nodes == NULL) return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
@@ -909,7 +915,7 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents,
     agents[i]->GetInfo((hsa_agent_info_t)HSA_AMD_AGENT_INFO_DRIVER_NODE_ID,
                        &nodes[i]);
 
-  if (HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodes(interop_handle, &info, num_agents,
+  if (HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodes(resource_handle, &info, num_agents,
                                           nodes)) != HSAKMT_STATUS_SUCCESS)
     return HSA_STATUS_ERROR;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -901,7 +901,12 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents,
 
   static_assert(sizeof(HSAint64) >= sizeof(interop_handle),
                 "HSAint64 too small for interop_handle");
-  HSAint64 resource_handle = reinterpret_cast<HSAint64>(interop_handle);
+  HSAint64 resource_handle =
+#ifdef _WIN32
+      static_cast<HSAint64>(reinterpret_cast<uintptr_t>(interop_handle));
+#else
+      static_cast<HSAint64>(interop_handle);
+#endif
 
   if (num_agents > tinyArraySize) {
     nodes = new HSAuint32[num_agents];
@@ -1413,7 +1418,7 @@ hsa_status_t Runtime::IPCCreate(void* ptr, size_t len, hsa_amd_ipc_memory_t* han
 
   if (agent->device_type() == Agent::kAmdGpuDevice) {
 #if defined(__linux__)
-    AMD::GpuAgent* agent_ = reinterpret_cast<AMD::GpuAgent*>(agent);    
+    AMD::GpuAgent* agent_ = reinterpret_cast<AMD::GpuAgent*>(agent);
     amdgpu_bo_import_result res;
 
     srand(static_cast<uint32_t>(std::chrono::high_resolution_clock::now().time_since_epoch().count()));

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa.h
@@ -5683,6 +5683,15 @@ typedef enum {
 } hsa_code_symbol_info_t;
 
 /**
+ * @brief System dependent handle type.
+ */
+#if defined(_WIN32)
+typedef void* hsa_handle_t;
+#else
+typedef int hsa_handle_t;
+#endif
+
+/**
  * @deprecated
  *
  * @brief Get the current value of an attribute for a given code symbol.

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -2321,7 +2321,7 @@ hsa_status_t HSA_API
  */
 hsa_status_t HSA_API hsa_amd_interop_map_buffer(uint32_t num_agents,
                                         hsa_agent_t* agents,
-                                        int interop_handle,
+                                        hsa_handle_t interop_handle,
                                         uint32_t flags,
                                         size_t* size,
                                         void** ptr,


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Currently, interopMapBuffer is invalid on Windows. This patch enables it by using a Windows HANDLE as the interop handle.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Linux file descriptors are 32-bit int's, while Windows HANDLEs are void* and can be 64-bit.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

No verification yet; this patch adds an ROCr interop interface for Windows.

## Test Result

<!-- Briefly summarize test outcomes. -->

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
