### PR TITLE
Fix type mismatch for HIP Library API arguments

### DIFF
--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/hip/api_args.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/hip/api_args.h
@@ -3288,25 +3288,25 @@ typedef union rocprofiler_hip_api_args_t
 #if HIP_RUNTIME_API_TABLE_STEP_VERSION >= 15
     struct
     {
-        hipLibrary_t*     library;
-        const void*       code;
-        hipJitOption*     jitOptions;
-        void**            jitOptionsValues;
-        unsigned int      numJitOptions;
-        hipLibraryOption* libraryOptions;
-        void**            libraryOptionValues;
-        unsigned int      numLibraryOptions;
+        hipLibrary_t*      library;
+        const void*        code;
+        hipJitOption**     jitOptions;
+        void**             jitOptionsValues;
+        unsigned int       numJitOptions;
+        hipLibraryOption** libraryOptions;
+        void**             libraryOptionValues;
+        unsigned int       numLibraryOptions;
     } hipLibraryLoadData;
     struct
     {
-        hipLibrary_t*     library;
-        const char*       fileName;
-        hipJitOption*     jitOptions;
-        void**            jitOptionsValues;
-        unsigned int      numJitOptions;
-        hipLibraryOption* libraryOptions;
-        void**            libraryOptionValues;
-        unsigned int      numLibraryOptions;
+        hipLibrary_t*      library;
+        const char*        fileName;
+        hipJitOption**     jitOptions;
+        void**             jitOptionsValues;
+        unsigned int       numJitOptions;
+        hipLibraryOption** libraryOptions;
+        void**             libraryOptionValues;
+        unsigned int       numLibraryOptions;
     } hipLibraryLoadFromFile;
     struct
     {


### PR DESCRIPTION
## Summary
Fix compilation errors in rocprofiler-sdk caused by type mismatches in HIP Library API argument structures.

## Problem
The build was failing with the following compilation errors:
```
error: cannot convert 'hipJitOption**' to 'hipJitOption*' in initialization
error: cannot convert 'hipLibraryOption**' to 'hipLibraryOption*' in initialization
```

These errors occurred in `hip/hip.cpp:153` during template instantiation for:
- `hipLibraryLoadData` (OpIdx 496)
- `hipLibraryLoadFromFile` (OpIdx 497)

## Root Cause
The HIP Runtime API Table version 15 specification changed the signatures of `hipLibraryLoadData` and `hipLibraryLoadFromFile` to use double pointers (`hipJitOption**` and `hipLibraryOption**`) instead of single pointers. However, the rocprofiler-sdk API args structures were not updated to match.

## Solution
Updated the argument structures in `source/include/rocprofiler-sdk/hip/api_args.h` for both functions:
- Changed `hipJitOption* jitOptions` to `hipJitOption** jitOptions`
- Changed `hipLibraryOption* libraryOptions` to `hipLibraryOption** libraryOptions`

## Testing
- Build completes successfully without errors
- All existing functionality preserved

## Files Changed
- `projects/rocprofiler-sdk/source/include/rocprofiler-sdk/hip/api_args.h`