### PR TITLE
rocr/format: Fix clang-format-diff.py path in format script

### DIFF
--- a/projects/rocr-runtime/format
+++ b/projects/rocr-runtime/format
@@ -2,5 +2,5 @@
 root=`git rev-parse --show-toplevel`
 pushd . > /dev/null
 cd $root
-git diff -U0 HEAD^ | ./clang-format-diff.py -p1 -i -style=file
+git diff -U0 HEAD^ | "${root}/projects/rocr-runtime/clang-format-diff.py" -p1 -i -style=file
 popd > /dev/null


### PR DESCRIPTION
Update the format script to use absolute path for clang-format-diff.py instead of relative path. This ensures the script works correctly regardless of the current working directory when executed.

- Change from './clang-format-diff.py' to '${root}/projects/rocr-runtime/clang-format-diff.py'
- Improves script reliability and portability
