### PR TITLE
SWDEV-558848 - vmm api support for rocr on windows

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
@@ -548,6 +548,17 @@ hsaKmtExportDMABufHandle(
     );
 
 /**
+  Export GPU Memory handle
+*/
+HSAKMT_STATUS
+HSAKMTAPI
+hsaKmtGetMemoryHandle(
+	void                  *MemoryAddress,     // IN
+	HSAuint64             SizeInBytes,        // IN
+	uint64_t              *SharedMemoryHandle // OUT
+);
+
+/**
  Export a memory buffer for sharing with other processes
 
  NOTE: for the current revision of the thunk spec, SizeInBytes

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
@@ -553,9 +553,9 @@ hsaKmtExportDMABufHandle(
 HSAKMT_STATUS
 HSAKMTAPI
 hsaKmtGetMemoryHandle(
-	void                  *MemoryAddress,     // IN
-	HSAuint64             SizeInBytes,        // IN
-	uint64_t              *SharedMemoryHandle // OUT
+    void* MemoryAddress,          // IN
+    HSAuint64 SizeInBytes,        // IN
+    uint64_t* SharedMemoryHandle  // OUT
 );
 
 /**

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.ver
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.ver
@@ -90,6 +90,7 @@ hsaKmtPcSamplingStart;
 hsaKmtPcSamplingStop;
 hsaKmtPcSamplingSupport;
 hsaKmtAisReadWriteFile;
+hsaKmtGetMemoryHandle;
 local: *;
 };
 

--- a/projects/rocr-runtime/libhsakmt/src/memory.c
+++ b/projects/rocr-runtime/libhsakmt/src/memory.c
@@ -929,3 +929,11 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtGetAMDGPUDeviceHandle(HSAuint32 NodeId,
 
 	return hsaKmtGetAMDGPUDeviceHandleCtx(&hsakmt_primary_kfd_ctx, NodeId, DeviceHandle);
 }
+
+HSAKMT_STATUS HSAKMTAPI
+hsaKmtGetMemoryHandle(void *MemoryAddress, HSAuint64 SizeInBytes,
+                      uint64_t *SharedMemoryHandle) {
+	CHECK_KFD_OPEN();
+
+	return HSAKMT_STATUS_NOT_SUPPORTED;
+}

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -444,12 +444,11 @@ hsa_status_t KfdDriver::ExportDMABuf(void *mem, size_t size, int *dmabuf_fd,
 
 hsa_status_t KfdDriver::ImportDMABuf(int dmabuf_fd, core::Agent &agent,
                                      core::ShareableHandle &handle) {
-  auto &gpu_agent = static_cast<GpuAgent &>(agent);
+  auto& gpu_agent = static_cast<GpuAgent&>(agent);
   amdgpu_bo_import_result res;
-  auto ret = DRM_CALL(amdgpu_bo_import(
-      gpu_agent.libDrmDev(), amdgpu_bo_handle_type_dma_buf_fd, dmabuf_fd, &res));
-  if (ret)
-    return HSA_STATUS_ERROR;
+  auto ret = DRM_CALL(
+      amdgpu_bo_import(gpu_agent.libDrmDev(), amdgpu_bo_handle_type_dma_buf_fd, dmabuf_fd, &res));
+  if (ret) return HSA_STATUS_ERROR;
 
   handle.handle = reinterpret_cast<uint64_t>(res.buf_handle);
   return HSA_STATUS_SUCCESS;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -71,6 +71,7 @@ static_assert(
     (sizeof(core::ShareableHandle::handle) >= sizeof(amdgpu_bo_handle)) &&
         (alignof(core::ShareableHandle::handle) >= alignof(amdgpu_bo_handle)),
     "ShareableHandle cannot store a amdgpu_bo_handle");
+#endif
 
 namespace {
 
@@ -89,7 +90,6 @@ __forceinline uint64_t drm_perm(hsa_access_permission_t perm) {
 }
 
 } // namespace
-#endif
 
 KfdDriver::KfdDriver(std::string devnode_name)
     : core::Driver(core::DriverType::KFD, std::move(devnode_name)) {}
@@ -436,7 +436,7 @@ hsa_status_t KfdDriver::ExportDMABuf(void *mem, size_t size, int *dmabuf_fd,
 
 hsa_status_t KfdDriver::ImportDMABuf(int dmabuf_fd, core::Agent &agent,
                                      core::ShareableHandle &handle) {
-#if defined(__linux__)
+  if (dmabuf_fd != -1) {
   auto &gpu_agent = static_cast<GpuAgent &>(agent);
   amdgpu_bo_import_result res;
   auto ret = DRM_CALL(amdgpu_bo_import(
@@ -445,16 +445,13 @@ hsa_status_t KfdDriver::ImportDMABuf(int dmabuf_fd, core::Agent &agent,
     return HSA_STATUS_ERROR;
 
   handle.handle = reinterpret_cast<uint64_t>(res.buf_handle);
-#else
-  assert(!"Unimplemented!");
-#endif
+  } 
   return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t KfdDriver::Map(core::ShareableHandle handle, void *mem,
                             size_t offset, size_t size,
                             hsa_access_permission_t perms) {
-#if defined(__linux__)
   const auto ldrm_bo = reinterpret_cast<amdgpu_bo_handle>(handle.handle);
   if (!ldrm_bo)
     return HSA_STATUS_ERROR;
@@ -462,15 +459,11 @@ hsa_status_t KfdDriver::Map(core::ShareableHandle handle, void *mem,
   if (DRM_CALL(amdgpu_bo_va_op(ldrm_bo, offset, size, reinterpret_cast<uint64_t>(mem),
                       drm_perm(perms), AMDGPU_VA_OP_MAP)) != 0)
     return HSA_STATUS_ERROR;
-#else
-  assert(!"Unimplemented!");
-#endif
   return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t KfdDriver::Unmap(core::ShareableHandle handle, void *mem,
                               size_t offset, size_t size) {
-#if defined(__linux__)
   const auto ldrm_bo = reinterpret_cast<amdgpu_bo_handle>(handle.handle);
   if (!ldrm_bo)
     return HSA_STATUS_ERROR;
@@ -478,14 +471,10 @@ hsa_status_t KfdDriver::Unmap(core::ShareableHandle handle, void *mem,
   if (DRM_CALL(amdgpu_bo_va_op(ldrm_bo, offset, size, reinterpret_cast<uint64_t>(mem), 0,
                       AMDGPU_VA_OP_UNMAP)) != 0)
     return HSA_STATUS_ERROR;
-#else
-  assert(!"Unimplemented!");
-#endif
   return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t KfdDriver::ReleaseShareableHandle(core::ShareableHandle &handle) {
-#if defined(__linux__)
   const auto ldrm_bo = reinterpret_cast<amdgpu_bo_handle>(handle.handle);
   if (!ldrm_bo)
     return HSA_STATUS_ERROR;
@@ -495,9 +484,6 @@ hsa_status_t KfdDriver::ReleaseShareableHandle(core::ShareableHandle &handle) {
     return HSA_STATUS_ERROR;
 
   handle = {};
-#else
-  assert(!"Unimplemented!");
-#endif
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -414,7 +414,15 @@ hsa_status_t KfdDriver::AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_gws,
   }
   return HSA_STATUS_SUCCESS;
 }
-
+hsa_status_t KfdDriver::GetShareableHandle(void *mem, size_t size, core::ShareableHandle &handle) {
+  uint64_t mem_handle;
+  HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtGetMemoryHandle(mem, size, &mem_handle));
+  if (status != HSAKMT_STATUS_SUCCESS) {
+    return HSA_STATUS_ERROR;
+  }
+  handle.handle = mem_handle;
+  return HSA_STATUS_SUCCESS;
+}
 hsa_status_t KfdDriver::ExportDMABuf(void *mem, size_t size, int *dmabuf_fd,
                                      size_t *offset) {
   int dmabuf_fd_res = -1;
@@ -445,7 +453,7 @@ hsa_status_t KfdDriver::ImportDMABuf(int dmabuf_fd, core::Agent &agent,
     return HSA_STATUS_ERROR;
 
   handle.handle = reinterpret_cast<uint64_t>(res.buf_handle);
-  } 
+  }
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -414,13 +414,13 @@ hsa_status_t KfdDriver::AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_gws,
   }
   return HSA_STATUS_SUCCESS;
 }
-hsa_status_t KfdDriver::GetShareableHandle(void *mem, size_t size, core::ShareableHandle &handle) {
+hsa_status_t KfdDriver::GetShareableHandle(void *mem, size_t size, core::ShareableHandle* handle) {
   uint64_t mem_handle;
   HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtGetMemoryHandle(mem, size, &mem_handle));
   if (status != HSAKMT_STATUS_SUCCESS) {
     return HSA_STATUS_ERROR;
   }
-  handle.handle = mem_handle;
+  handle->handle = mem_handle;
   return HSA_STATUS_SUCCESS;
 }
 hsa_status_t KfdDriver::ExportDMABuf(void *mem, size_t size, int *dmabuf_fd,
@@ -445,14 +445,14 @@ hsa_status_t KfdDriver::ExportDMABuf(void *mem, size_t size, int *dmabuf_fd,
 hsa_status_t KfdDriver::ImportDMABuf(int dmabuf_fd, core::Agent &agent,
                                      core::ShareableHandle &handle) {
   if (dmabuf_fd != -1) {
-  auto &gpu_agent = static_cast<GpuAgent &>(agent);
-  amdgpu_bo_import_result res;
-  auto ret = DRM_CALL(amdgpu_bo_import(
-      gpu_agent.libDrmDev(), amdgpu_bo_handle_type_dma_buf_fd, dmabuf_fd, &res));
-  if (ret)
-    return HSA_STATUS_ERROR;
+    auto &gpu_agent = static_cast<GpuAgent &>(agent);
+    amdgpu_bo_import_result res;
+    auto ret = DRM_CALL(amdgpu_bo_import(
+        gpu_agent.libDrmDev(), amdgpu_bo_handle_type_dma_buf_fd, dmabuf_fd, &res));
+    if (ret)
+      return HSA_STATUS_ERROR;
 
-  handle.handle = reinterpret_cast<uint64_t>(res.buf_handle);
+    handle.handle = reinterpret_cast<uint64_t>(res.buf_handle);
   }
   return HSA_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -414,7 +414,7 @@ hsa_status_t KfdDriver::AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_gws,
   }
   return HSA_STATUS_SUCCESS;
 }
-hsa_status_t KfdDriver::GetShareableHandle(void *mem, size_t size, core::ShareableHandle* handle) {
+hsa_status_t KfdDriver::GetShareableHandle(void* mem, size_t size, core::ShareableHandle* handle) {
   uint64_t mem_handle;
   HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtGetMemoryHandle(mem, size, &mem_handle));
   if (status != HSAKMT_STATUS_SUCCESS) {
@@ -444,16 +444,14 @@ hsa_status_t KfdDriver::ExportDMABuf(void *mem, size_t size, int *dmabuf_fd,
 
 hsa_status_t KfdDriver::ImportDMABuf(int dmabuf_fd, core::Agent &agent,
                                      core::ShareableHandle &handle) {
-  if (dmabuf_fd != -1) {
-    auto &gpu_agent = static_cast<GpuAgent &>(agent);
-    amdgpu_bo_import_result res;
-    auto ret = DRM_CALL(amdgpu_bo_import(
-        gpu_agent.libDrmDev(), amdgpu_bo_handle_type_dma_buf_fd, dmabuf_fd, &res));
-    if (ret)
-      return HSA_STATUS_ERROR;
+  auto &gpu_agent = static_cast<GpuAgent &>(agent);
+  amdgpu_bo_import_result res;
+  auto ret = DRM_CALL(amdgpu_bo_import(
+      gpu_agent.libDrmDev(), amdgpu_bo_handle_type_dma_buf_fd, dmabuf_fd, &res));
+  if (ret)
+    return HSA_STATUS_ERROR;
 
-    handle.handle = reinterpret_cast<uint64_t>(res.buf_handle);
-  }
+  handle.handle = reinterpret_cast<uint64_t>(res.buf_handle);
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -414,6 +414,7 @@ hsa_status_t KfdDriver::AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_gws,
   }
   return HSA_STATUS_SUCCESS;
 }
+
 hsa_status_t KfdDriver::GetShareableHandle(void* mem, size_t size, core::ShareableHandle* handle) {
   uint64_t mem_handle;
   HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtGetMemoryHandle(mem, size, &mem_handle));
@@ -423,6 +424,7 @@ hsa_status_t KfdDriver::GetShareableHandle(void* mem, size_t size, core::Shareab
   handle->handle = mem_handle;
   return HSA_STATUS_SUCCESS;
 }
+
 hsa_status_t KfdDriver::ExportDMABuf(void *mem, size_t size, int *dmabuf_fd,
                                      size_t *offset) {
   int dmabuf_fd_res = -1;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -1029,7 +1029,7 @@ hsa_status_t XdnaDriver::MakeMemoryResident(const void* mem, size_t size, uint64
 
 hsa_status_t XdnaDriver::MakeMemoryUnresident(const void* mem) const { return HSA_STATUS_ERROR; }
 
-hsa_status_t XdnaDriver::GetShareableHandle(void *mem, size_t size, core::ShareableHandle* handle) {
+hsa_status_t XdnaDriver::GetShareableHandle(void* mem, size_t size, core::ShareableHandle* handle) {
   return HSA_STATUS_ERROR;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -1029,7 +1029,7 @@ hsa_status_t XdnaDriver::MakeMemoryResident(const void* mem, size_t size, uint64
 
 hsa_status_t XdnaDriver::MakeMemoryUnresident(const void* mem) const { return HSA_STATUS_ERROR; }
 
-hsa_status_t XdnaDriver::GetShareableHandle(void *mem, size_t size, core::ShareableHandle &handle) {
+hsa_status_t XdnaDriver::GetShareableHandle(void *mem, size_t size, core::ShareableHandle* handle) {
   return HSA_STATUS_ERROR;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -1029,5 +1029,9 @@ hsa_status_t XdnaDriver::MakeMemoryResident(const void* mem, size_t size, uint64
 
 hsa_status_t XdnaDriver::MakeMemoryUnresident(const void* mem) const { return HSA_STATUS_ERROR; }
 
+hsa_status_t XdnaDriver::GetShareableHandle(void *mem, size_t size, core::ShareableHandle &handle) {
+  return HSA_STATUS_ERROR;
+}
+
 } // namespace AMD
 } // namespace rocr

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -116,7 +116,7 @@ public:
   hsa_status_t Unmap(core::ShareableHandle handle, void *mem, size_t offset,
                      size_t size) override;
   hsa_status_t ReleaseShareableHandle(core::ShareableHandle &handle) override;
-  hsa_status_t GetShareableHandle(void *mem, size_t size,
+  hsa_status_t GetShareableHandle(void* mem, size_t size,
                                   core::ShareableHandle* handle) override;
   hsa_status_t SPMAcquire(uint32_t preferred_node_id) const override;
   hsa_status_t SPMRelease(uint32_t preferred_node_id) const override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -116,8 +116,7 @@ public:
   hsa_status_t Unmap(core::ShareableHandle handle, void *mem, size_t offset,
                      size_t size) override;
   hsa_status_t ReleaseShareableHandle(core::ShareableHandle &handle) override;
-  hsa_status_t GetShareableHandle(void* mem, size_t size,
-                                  core::ShareableHandle* handle) override;
+  hsa_status_t GetShareableHandle(void* mem, size_t size, core::ShareableHandle* handle) override;
   hsa_status_t SPMAcquire(uint32_t preferred_node_id) const override;
   hsa_status_t SPMRelease(uint32_t preferred_node_id) const override;
   hsa_status_t SPMSetDestBuffer(uint32_t preferred_node_id, uint32_t size_bytes, uint32_t* timeout,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -116,7 +116,8 @@ public:
   hsa_status_t Unmap(core::ShareableHandle handle, void *mem, size_t offset,
                      size_t size) override;
   hsa_status_t ReleaseShareableHandle(core::ShareableHandle &handle) override;
-
+  hsa_status_t GetShareableHandle(void *mem, size_t size,
+                                  core::ShareableHandle &handle) override;
   hsa_status_t SPMAcquire(uint32_t preferred_node_id) const override;
   hsa_status_t SPMRelease(uint32_t preferred_node_id) const override;
   hsa_status_t SPMSetDestBuffer(uint32_t preferred_node_id, uint32_t size_bytes, uint32_t* timeout,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -117,7 +117,7 @@ public:
                      size_t size) override;
   hsa_status_t ReleaseShareableHandle(core::ShareableHandle &handle) override;
   hsa_status_t GetShareableHandle(void *mem, size_t size,
-                                  core::ShareableHandle &handle) override;
+                                  core::ShareableHandle* handle) override;
   hsa_status_t SPMAcquire(uint32_t preferred_node_id) const override;
   hsa_status_t SPMRelease(uint32_t preferred_node_id) const override;
   hsa_status_t SPMSetDestBuffer(uint32_t preferred_node_id, uint32_t size_bytes, uint32_t* timeout,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -225,6 +225,8 @@ public:
                    size_t size, hsa_access_permission_t perms) override;
   hsa_status_t Unmap(core::ShareableHandle handle, void *mem, size_t offset,
                      size_t size) override;
+  hsa_status_t GetShareableHandle(void *mem, size_t size,
+                                  core::ShareableHandle &handle) override;
   hsa_status_t ReleaseShareableHandle(core::ShareableHandle &handle) override;
 
   /// @brief Submits @p num_pkts packets in a command chain.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -225,7 +225,7 @@ public:
                    size_t size, hsa_access_permission_t perms) override;
   hsa_status_t Unmap(core::ShareableHandle handle, void *mem, size_t offset,
                      size_t size) override;
-  hsa_status_t GetShareableHandle(void *mem, size_t size,
+  hsa_status_t GetShareableHandle(void* mem, size_t size,
                                   core::ShareableHandle* handle) override;
   hsa_status_t ReleaseShareableHandle(core::ShareableHandle &handle) override;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -226,7 +226,7 @@ public:
   hsa_status_t Unmap(core::ShareableHandle handle, void *mem, size_t offset,
                      size_t size) override;
   hsa_status_t GetShareableHandle(void *mem, size_t size,
-                                  core::ShareableHandle &handle) override;
+                                  core::ShareableHandle* handle) override;
   hsa_status_t ReleaseShareableHandle(core::ShareableHandle &handle) override;
 
   /// @brief Submits @p num_pkts packets in a command chain.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -225,8 +225,7 @@ public:
                    size_t size, hsa_access_permission_t perms) override;
   hsa_status_t Unmap(core::ShareableHandle handle, void *mem, size_t offset,
                      size_t size) override;
-  hsa_status_t GetShareableHandle(void* mem, size_t size,
-                                  core::ShareableHandle* handle) override;
+  hsa_status_t GetShareableHandle(void* mem, size_t size, core::ShareableHandle* handle) override;
   hsa_status_t ReleaseShareableHandle(core::ShareableHandle &handle) override;
 
   /// @brief Submits @p num_pkts packets in a command chain.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -237,7 +237,7 @@ public:
   /// @param[in] mem  physical memory handle
   /// @param[in] size size of memory allocated in bytes
   /// @param[in] handle handle of the memory object
-  virtual hsa_status_t GetShareableHandle(void *mem, size_t size,
+  virtual hsa_status_t GetShareableHandle(void* mem, size_t size,
                                   core::ShareableHandle* handle) = 0;
   /// @brief Releases the object associated with the handle.
   ///

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -239,6 +239,7 @@ public:
   /// @param[out] handle handle of the memory object
   virtual hsa_status_t GetShareableHandle(void* mem, size_t size,
                                           core::ShareableHandle* handle) = 0;
+
   /// @brief Releases the object associated with the handle.
   ///
   /// @param[in] handle handle of the object to release

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -234,11 +234,11 @@ public:
 
   /// @brief Get Shareable Memory Handle for physical memory
   ///
-  /// @param[in] mem virtual address associated with handle
+  /// @param[in] mem  physical memory handle
   /// @param[in] size size of memory allocated in bytes
   /// @param[in] handle handle of the memory object
   virtual hsa_status_t GetShareableHandle(void *mem, size_t size,
-                                  core::ShareableHandle &handle) = 0;
+                                  core::ShareableHandle* handle) = 0;
   /// @brief Releases the object associated with the handle.
   ///
   /// @param[in] handle handle of the object to release

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -236,9 +236,9 @@ public:
   ///
   /// @param[in] mem  physical memory handle
   /// @param[in] size size of memory allocated in bytes
-  /// @param[in] handle handle of the memory object
+  /// @param[out] handle handle of the memory object
   virtual hsa_status_t GetShareableHandle(void* mem, size_t size,
-                                  core::ShareableHandle* handle) = 0;
+                                          core::ShareableHandle* handle) = 0;
   /// @brief Releases the object associated with the handle.
   ///
   /// @param[in] handle handle of the object to release

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -232,6 +232,13 @@ public:
   virtual hsa_status_t Unmap(core::ShareableHandle handle, void *mem,
                              size_t offset, size_t size) = 0;
 
+  /// @brief Get Shareable Memory Handle for physical memory
+  ///
+  /// @param[in] mem virtual address associated with handle
+  /// @param[in] size size of memory allocated in bytes
+  /// @param[in] handle handle of the memory object
+  virtual hsa_status_t GetShareableHandle(void *mem, size_t size,
+                                  core::ShareableHandle &handle) = 0;
   /// @brief Releases the object associated with the handle.
   ///
   /// @param[in] handle handle of the object to release

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
@@ -332,7 +332,9 @@ class ThunkLoader {
                                       HsaAisFlags flags, \
                                       HSAuint64 *SizeCopiedInBytes, \
                                       HSAint32 *status);
-
+    typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtGetMemoryHandle))(void *MemoryAddress, \
+                                      HSAuint64 SizeInBytes, \
+                                      uint64_t  *SharedMemoryHandle);
     /* drm API */
     typedef int (DRM_DEF(amdgpu_device_initialize))(int fd, \
                                       uint32_t *major_version, \
@@ -480,6 +482,7 @@ class ThunkLoader {
     HSAKMT_DEF(hsaKmtModelEnabled)* HSAKMT_PFN(hsaKmtModelEnabled);
     HSAKMT_DEF(hsaKmtQueueRingDoorbell)* HSAKMT_PFN(hsaKmtQueueRingDoorbell);
     HSAKMT_DEF(hsaKmtAisReadWriteFile)* HSAKMT_PFN(hsaKmtAisReadWriteFile);
+    HSAKMT_DEF(hsaKmtGetMemoryHandle)* HSAKMT_PFN(hsaKmtGetMemoryHandle);
 
     DRM_DEF(amdgpu_device_initialize)* DRM_PFN(amdgpu_device_initialize);
     DRM_DEF(amdgpu_device_deinitialize)* DRM_PFN(amdgpu_device_deinitialize);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -3808,11 +3808,17 @@ Runtime::MappedHandleAllowedAgent::~MappedHandleAllowedAgent() {
 
 hsa_status_t Runtime::MappedHandleAllowedAgent::EnableAccess(hsa_access_permission_t perms) {
   if (targetAgent->device_type() == core::Agent::DeviceType::kAmdCpuDevice) {
+<<<<<<< HEAD
     if (!core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) {
       if (!rocr::os::MapMemory(va, size, PermissionsToMemProt(perms), mappedHandle->drm_fd,
                              reinterpret_cast<uint64_t>(mappedHandle->drm_cpu_addr))) {
         return HSA_STATUS_ERROR;
       }
+=======
+    if (!rocr::os::MapMemory(va, size, PermissionsToMemProt(perms), mappedHandle->drm_fd,
+                                reinterpret_cast<uint64_t>(mappedHandle->drm_cpu_addr))) {
+      return HSA_STATUS_ERROR;
+>>>>>>> ea2c50bcbb5e (Update os specific map/unmap memory calls)
     }
   } else {
     hsa_status_t status = targetAgent->driver().Map(
@@ -3827,6 +3833,7 @@ hsa_status_t Runtime::MappedHandleAllowedAgent::EnableAccess(hsa_access_permissi
 hsa_status_t Runtime::MappedHandleAllowedAgent::RemoveAccess() {
   if (targetAgent->device_type() == core::Agent::DeviceType::kAmdCpuDevice) {
     if (permissions != HSA_ACCESS_PERMISSION_NONE) {
+<<<<<<< HEAD
 #if defined(__linux__)
       if (munmap(va, size) != 0) return HSA_STATUS_ERROR;
 
@@ -3842,6 +3849,17 @@ hsa_status_t Runtime::MappedHandleAllowedAgent::RemoveAccess() {
       }
 #endif
       permissions = HSA_ACCESS_PERMISSION_NONE;
+=======
+      hsa_access_permission_t perms = HSA_ACCESS_PERMISSION_NONE;
+      if (!rocr::os::UnmapMemory(va, size)) {
+        return HSA_STATUS_ERROR;
+      }
+      if (!rocr::os::MapMemory(va, size, PermissionsToMemProt(perms), mappedHandle->drm_fd,
+                                reinterpret_cast<uint64_t>(mappedHandle->drm_cpu_addr))) {
+        return HSA_STATUS_ERROR;
+      }
+      permissions = perms;
+>>>>>>> ea2c50bcbb5e (Update os specific map/unmap memory calls)
     }
   } else {
     return targetAgent->driver().Unmap(
@@ -3859,6 +3877,10 @@ Runtime::MappedHandle::MappedHandle(MemoryHandle *mem_handle, AddressHandle *add
 {
   /* Create a CPU mapping with PROT_NONE */
   auto cpu_agent = static_cast<AMD::GpuAgent*>(agentOwner())->GetNearestCpuAgent();
+<<<<<<< HEAD
+=======
+
+>>>>>>> ea2c50bcbb5e (Update os specific map/unmap memory calls)
   auto agentPermsIt = allowed_agents.emplace(std::piecewise_construct,
                        std::forward_as_tuple(cpu_agent),
                        std::forward_as_tuple(this, cpu_agent, va,
@@ -3868,6 +3890,7 @@ Runtime::MappedHandle::MappedHandle(MemoryHandle *mem_handle, AddressHandle *add
   auto ret = agentPermsIt->second.EnableAccess(HSA_ACCESS_PERMISSION_NONE);
   if (ret != HSA_STATUS_SUCCESS)
     throw AMD::hsa_exception(ret, "Failed to create default CPU mapping");
+  #endif
 }
 
 // Note: VMemorySetAccessPerHandle should be called with &memory_lock_ held

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -2628,7 +2628,7 @@ void Runtime::CheckVirtualMemApiSupport() {
       virtual_mem_api_supported_ = true;
     }
   #else
-    virtual_mem_api_supported_ = false;
+    virtual_mem_api_supported_ = true;
   #endif
   }
 }
@@ -3672,11 +3672,17 @@ hsa_status_t Runtime::VMemoryHandleMap(void* va, size_t size, size_t in_offset,
   if (status != HSA_STATUS_SUCCESS)
     return status;
 
-  close(dmabuf_fd);
+  if (dmabuf_fd != -1) {
+    close(dmabuf_fd);
+  }
 
   // Get address that memory is mapped to
-  ret = GetAmdgpuDeviceArgs(agent, shareable_handle, &drm_fd, &drm_cpu_addr);
-  if (ret) return HSA_STATUS_ERROR;
+  if (shareable_handle.IsValid()) {
+    ret = GetAmdgpuDeviceArgs(agent, shareable_handle, &drm_fd, &drm_cpu_addr);
+    if (ret) return HSA_STATUS_ERROR;
+  } else {
+    drm_cpu_addr = reinterpret_cast<uint64_t>(va);
+  }
 
   mapped_handle_map_.emplace(
       std::piecewise_construct, std::forward_as_tuple(va),
@@ -3795,22 +3801,17 @@ Runtime::MappedHandleAllowedAgent::~MappedHandleAllowedAgent() {
 
 hsa_status_t Runtime::MappedHandleAllowedAgent::EnableAccess(hsa_access_permission_t perms) {
   if (targetAgent->device_type() == core::Agent::DeviceType::kAmdCpuDevice) {
-  #if defined(__linux__)
     if (!core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) {
-      void* mapped_ptr =
-        mmap(va, size, PermissionsToMmapFlags(perms), MAP_SHARED | MAP_FIXED, mappedHandle->drm_fd,
-             reinterpret_cast<uint64_t>(mappedHandle->drm_cpu_addr));
-      if (mapped_ptr != va)
+      if (!rocr::os::MapMemory(va, size, PermissionsToMemProt(perms), mappedHandle->drm_fd,
+                             reinterpret_cast<uint64_t>(mappedHandle->drm_cpu_addr))) {
         return HSA_STATUS_ERROR;
+      }
     }
   } else {
     hsa_status_t status = targetAgent->driver().Map(
         shareable_handle, va, mappedHandle->offset, size, perms);
     if (status != HSA_STATUS_SUCCESS)
       return status;
-#else
-    assert(!"Unimplemented!");
-#endif
   }
   permissions = perms;
   return HSA_STATUS_SUCCESS;
@@ -3828,12 +3829,12 @@ hsa_status_t Runtime::MappedHandleAllowedAgent::RemoveAccess() {
                 reinterpret_cast<uint64_t>(mappedHandle->drm_cpu_addr));
       if (mapped_ptr != va)
         return HSA_STATUS_ERROR;
-
-      permissions = HSA_ACCESS_PERMISSION_NONE;
-#else
-      assert(!"Unimplemented!");
+#elif defined(_WIN32)
+      if (!rocr::os::ProtectMemory(va, size, rocr::os::MEM_PROT_NONE)) {
+        return HSA_STATUS_ERROR;
+      }
 #endif
-
+      permissions = HSA_ACCESS_PERMISSION_NONE;
     }
   } else {
     return targetAgent->driver().Unmap(

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -3681,13 +3681,10 @@ hsa_status_t Runtime::VMemoryHandleMap(void* va, size_t size, size_t in_offset,
     ret = GetAmdgpuDeviceArgs(agent, shareable_handle, &drm_fd, &drm_cpu_addr);
     if (ret) return HSA_STATUS_ERROR;
   } else {
-<<<<<<< HEAD
-=======
     hsa_status_t status = agent_driver.GetShareableHandle(memoryHandleIt->first, size, &shareable_handle);
     if (status != HSA_STATUS_SUCCESS) {
       return status;
     }
->>>>>>> ee69fc79d290 (Fix GetShareableHandle to use pointer for shareable handle)
     drm_cpu_addr = reinterpret_cast<uint64_t>(va);
   }
 
@@ -3808,17 +3805,11 @@ Runtime::MappedHandleAllowedAgent::~MappedHandleAllowedAgent() {
 
 hsa_status_t Runtime::MappedHandleAllowedAgent::EnableAccess(hsa_access_permission_t perms) {
   if (targetAgent->device_type() == core::Agent::DeviceType::kAmdCpuDevice) {
-<<<<<<< HEAD
     if (!core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) {
       if (!rocr::os::MapMemory(va, size, PermissionsToMemProt(perms), mappedHandle->drm_fd,
                              reinterpret_cast<uint64_t>(mappedHandle->drm_cpu_addr))) {
         return HSA_STATUS_ERROR;
       }
-=======
-    if (!rocr::os::MapMemory(va, size, PermissionsToMemProt(perms), mappedHandle->drm_fd,
-                                reinterpret_cast<uint64_t>(mappedHandle->drm_cpu_addr))) {
-      return HSA_STATUS_ERROR;
->>>>>>> ea2c50bcbb5e (Update os specific map/unmap memory calls)
     }
   } else {
     hsa_status_t status = targetAgent->driver().Map(
@@ -3833,23 +3824,6 @@ hsa_status_t Runtime::MappedHandleAllowedAgent::EnableAccess(hsa_access_permissi
 hsa_status_t Runtime::MappedHandleAllowedAgent::RemoveAccess() {
   if (targetAgent->device_type() == core::Agent::DeviceType::kAmdCpuDevice) {
     if (permissions != HSA_ACCESS_PERMISSION_NONE) {
-<<<<<<< HEAD
-#if defined(__linux__)
-      if (munmap(va, size) != 0) return HSA_STATUS_ERROR;
-
-      /* We need to keep the CPU mapping. So change it to PROT_NONE */
-      void* mapped_ptr = mmap(va, mappedHandle->size, PROT_NONE, MAP_SHARED | MAP_FIXED,
-                mappedHandle->drm_fd,
-                reinterpret_cast<uint64_t>(mappedHandle->drm_cpu_addr));
-      if (mapped_ptr != va)
-        return HSA_STATUS_ERROR;
-#elif defined(_WIN32)
-      if (!rocr::os::ProtectMemory(va, size, rocr::os::MEM_PROT_NONE)) {
-        return HSA_STATUS_ERROR;
-      }
-#endif
-      permissions = HSA_ACCESS_PERMISSION_NONE;
-=======
       hsa_access_permission_t perms = HSA_ACCESS_PERMISSION_NONE;
       if (!rocr::os::UnmapMemory(va, size)) {
         return HSA_STATUS_ERROR;
@@ -3859,7 +3833,6 @@ hsa_status_t Runtime::MappedHandleAllowedAgent::RemoveAccess() {
         return HSA_STATUS_ERROR;
       }
       permissions = perms;
->>>>>>> ea2c50bcbb5e (Update os specific map/unmap memory calls)
     }
   } else {
     return targetAgent->driver().Unmap(
@@ -3876,11 +3849,8 @@ Runtime::MappedHandle::MappedHandle(MemoryHandle *mem_handle, AddressHandle *add
     shareable_handle(shareable_handle)
 {
   /* Create a CPU mapping with PROT_NONE */
+  #if defined(__linux__)
   auto cpu_agent = static_cast<AMD::GpuAgent*>(agentOwner())->GetNearestCpuAgent();
-<<<<<<< HEAD
-=======
-
->>>>>>> ea2c50bcbb5e (Update os specific map/unmap memory calls)
   auto agentPermsIt = allowed_agents.emplace(std::piecewise_construct,
                        std::forward_as_tuple(cpu_agent),
                        std::forward_as_tuple(this, cpu_agent, va,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -3681,6 +3681,13 @@ hsa_status_t Runtime::VMemoryHandleMap(void* va, size_t size, size_t in_offset,
     ret = GetAmdgpuDeviceArgs(agent, shareable_handle, &drm_fd, &drm_cpu_addr);
     if (ret) return HSA_STATUS_ERROR;
   } else {
+<<<<<<< HEAD
+=======
+    hsa_status_t status = agent_driver.GetShareableHandle(memoryHandleIt->first, size, &shareable_handle);
+    if (status != HSA_STATUS_SUCCESS) {
+      return status;
+    }
+>>>>>>> ee69fc79d290 (Fix GetShareableHandle to use pointer for shareable handle)
     drm_cpu_addr = reinterpret_cast<uint64_t>(va);
   }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
@@ -390,6 +390,9 @@ namespace core {
       HSAKMT_PFN(hsaKmtAisReadWriteFile) = (HSAKMT_DEF(hsaKmtAisReadWriteFile)*)dlsym(thunk_handle, "hsaKmtAisReadWriteFile");
       if (HSAKMT_PFN(hsaKmtAisReadWriteFile) == NULL) goto ERROR;
 
+      HSAKMT_PFN(hsaKmtGetMemoryHandle) = (HSAKMT_DEF(hsaKmtGetMemoryHandle)*)dlsym(thunk_handle, "hsaKmtGetMemoryHandle");
+      if (HSAKMT_PFN(hsaKmtGetMemoryHandle) == NULL) goto ERROR;
+
       DRM_PFN(amdgpu_device_deinitialize) = (DRM_DEF(amdgpu_device_deinitialize)*)dlsym(thunk_handle, "amdgpu_device_deinitialize");
       if (DRM_PFN(amdgpu_device_deinitialize) == NULL) goto ERROR;
 
@@ -521,6 +524,7 @@ ERROR:
 #endif
       HSAKMT_PFN(hsaKmtModelEnabled) = (HSAKMT_DEF(hsaKmtModelEnabled)*)(&hsaKmtModelEnabled);
       HSAKMT_PFN(hsaKmtAisReadWriteFile) = (HSAKMT_DEF(hsaKmtAisReadWriteFile)*)(&hsaKmtAisReadWriteFile);
+      HSAKMT_PFN(hsaKmtGetMemoryHandle) = (HSAKMT_DEF(hsaKmtGetMemoryHandle)*)(&hsaKmtGetMemoryHandle);
 
       DRM_PFN(amdgpu_device_initialize) = (DRM_DEF(amdgpu_device_initialize)*)(&amdgpu_device_initialize);
       DRM_PFN(amdgpu_device_deinitialize) = (DRM_DEF(amdgpu_device_deinitialize)*)(&amdgpu_device_deinitialize);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
@@ -849,6 +849,17 @@ size_t PageSize() {
   return g_page_size_;
 }
 
+bool ProtectMemory(void* va, size_t size, MemProt perms, int fd, uint64_t cpu_addr) {
+  if (perms == MEM_PROT_NONE && munmap(va, size) != 0) {
+    return false;
+  }
+  void* mapped_ptr =
+        mmap(va, size, MemProtToOsProt(perms), MAP_SHARED | MAP_FIXED, fd, cpu_addr);
+  if (mapped_ptr != va)
+      return false;
+  return true;
+}
+
 void* ReserveMemory(void* start, size_t size, size_t alignment, MemProt prot) {
   size = AlignUp(size, PageSize());
   // check for invalid input size

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
@@ -849,10 +849,11 @@ size_t PageSize() {
   return g_page_size_;
 }
 
-bool ProtectMemory(void* va, size_t size, MemProt perms, int fd, uint64_t cpu_addr) {
-  if (perms == MEM_PROT_NONE && munmap(va, size) != 0) {
-    return false;
-  }
+bool UnmapMemory(void* va, size_t size) {
+  return ::munmap(va, size) == 0;
+}
+
+bool MapMemory(void* va, size_t size, MemProt perms, int fd, uint64_t cpu_addr) {
   void* mapped_ptr =
         mmap(va, size, MemProtToOsProt(perms), MAP_SHARED | MAP_FIXED, fd, cpu_addr);
   if (mapped_ptr != va)

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
@@ -849,9 +849,7 @@ size_t PageSize() {
   return g_page_size_;
 }
 
-bool UnmapMemory(void* va, size_t size) {
-  return ::munmap(va, size) == 0;
-}
+bool UnmapMemory(void* va, size_t size) { return ::munmap(va, size) == 0; }
 
 bool MapMemory(void* va, size_t size, MemProt perms, int fd, uint64_t cpu_addr) {
   void* mapped_ptr =

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/memory.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/memory.h
@@ -69,7 +69,7 @@ __forceinline int PermissionsToMmapFlags(hsa_access_permission_t perms) {
       return PROT_NONE;
   }
 }
-#elif defined(_WIN32)
+#endif
 __forceinline rocr::os::MemProt PermissionsToMemProt(hsa_access_permission_t perms) {
   switch (perms) {
     case HSA_ACCESS_PERMISSION_RO:
@@ -84,8 +84,6 @@ __forceinline rocr::os::MemProt PermissionsToMemProt(hsa_access_permission_t per
       return rocr::os::MEM_PROT_NONE;
   }
 }
-#endif
-
 }  // namespace rocr
 
 #endif  // HSA_RUNTIME_CORE_UTIL_MEMORY_H_

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/memory.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/memory.h
@@ -50,9 +50,10 @@
 #include <sys/mman.h>
 #endif
 
+#include "os.h"
 namespace rocr {
 
-#ifdef __linux__
+#if defined(__linux__)
 /// @brief Converts @ref hsa_access_permission_t to mmap memory protection
 ///        flags.
 __forceinline int PermissionsToMmapFlags(hsa_access_permission_t perms) {
@@ -66,6 +67,21 @@ __forceinline int PermissionsToMmapFlags(hsa_access_permission_t perms) {
     case HSA_ACCESS_PERMISSION_NONE:
     default:
       return PROT_NONE;
+  }
+}
+#elif defined(_WIN32)
+__forceinline rocr::os::MemProt PermissionsToMemProt(hsa_access_permission_t perms) {
+  switch (perms) {
+    case HSA_ACCESS_PERMISSION_RO:
+      return rocr::os::MEM_PROT_READ;
+    case HSA_ACCESS_PERMISSION_WO:
+      return rocr::os::MEM_PROT_RW;
+    case HSA_ACCESS_PERMISSION_RW:
+      return rocr::os::MEM_PROT_RW;
+    case HSA_ACCESS_PERMISSION_NONE:
+      return rocr::os::MEM_PROT_NONE;
+    default:
+      return rocr::os::MEM_PROT_NONE;
   }
 }
 #endif

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/os.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/os.h
@@ -352,7 +352,8 @@ bool CommitMemory(void* addr, size_t size, MemProt prot = MEM_PROT_NONE);
 /// Uncommit a chunk of memory previously committed with commitMemory.
 bool UncommitMemory(void* addr, size_t size);
 /// Changes the Protection of a region of committed pages in virtual address space
-bool ProtectMemory(void* addr, size_t size, MemProt prot, int fd, uint64_t cpu_addr);
+bool UnmapMemory(void* addr, size_t size);
+bool MapMemory(void* addr, size_t size, MemProt prot, int fd, uint64_t cpu_addr);
 
 uint64_t HostTotalPhysicalMemory();
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/os.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/os.h
@@ -351,6 +351,8 @@ bool ReleaseMemory(void* addr, size_t size);
 bool CommitMemory(void* addr, size_t size, MemProt prot = MEM_PROT_NONE);
 /// Uncommit a chunk of memory previously committed with commitMemory.
 bool UncommitMemory(void* addr, size_t size);
+/// Changes the Protection of a region of committed pages in virtual address space 
+bool ProtectMemory(void* addr, size_t size, MemProt prot);
 
 uint64_t HostTotalPhysicalMemory();
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/os.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/os.h
@@ -351,8 +351,8 @@ bool ReleaseMemory(void* addr, size_t size);
 bool CommitMemory(void* addr, size_t size, MemProt prot = MEM_PROT_NONE);
 /// Uncommit a chunk of memory previously committed with commitMemory.
 bool UncommitMemory(void* addr, size_t size);
-/// Changes the Protection of a region of committed pages in virtual address space 
-bool ProtectMemory(void* addr, size_t size, MemProt prot);
+/// Changes the Protection of a region of committed pages in virtual address space
+bool ProtectMemory(void* addr, size_t size, MemProt prot, int fd, uint64_t cpu_addr);
 
 uint64_t HostTotalPhysicalMemory();
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
@@ -459,9 +459,10 @@ uint64_t HostTotalPhysicalMemory() {
   return totalPhys;
 }
 
-bool ProtectMemory(void* addr, size_t size, MemProt prot) {
+bool ProtectMemory(void* addr, size_t size, MemProt perms, int fd [[maybe_unused]],
+                  uint64_t cpu_addr [[maybe_unused]]) {
   DWORD OldProtect;
-  return VirtualProtect(addr, size, memProtToOsProt(prot), &OldProtect) != 0;
+  return VirtualProtect(addr, size, memProtToOsProt(perms), &OldProtect) != 0;
 }
 
 int Ffs(int i) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
@@ -459,6 +459,11 @@ uint64_t HostTotalPhysicalMemory() {
   return totalPhys;
 }
 
+bool ProtectMemory(void* addr, size_t size, MemProt prot) {
+  DWORD OldProtect;
+  return VirtualProtect(addr, size, memProtToOsProt(prot), &OldProtect) != 0;
+}
+
 int Ffs(int i) {
   int res = 0;
   unsigned long index;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
@@ -459,12 +459,10 @@ uint64_t HostTotalPhysicalMemory() {
   return totalPhys;
 }
 
-bool UnmapMemory(void* addr, size_t size) {
-  return VirtualFree(addr, size, MEM_RELEASE) != 0;
-}
+bool UnmapMemory(void* addr, size_t size) { return VirtualFree(addr, size, MEM_RELEASE) != 0; }
 
 bool MapMemory(void* addr, size_t size, MemProt perms, int fd [[maybe_unused]],
-                  uint64_t cpu_addr [[maybe_unused]]) {
+               uint64_t cpu_addr [[maybe_unused]]) {
   DWORD OldProtect;
   return VirtualProtect(addr, size, memProtToOsProt(perms), &OldProtect) != 0;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
@@ -459,7 +459,11 @@ uint64_t HostTotalPhysicalMemory() {
   return totalPhys;
 }
 
-bool ProtectMemory(void* addr, size_t size, MemProt perms, int fd [[maybe_unused]],
+bool UnmapMemory(void* addr, size_t size) {
+  return VirtualFree(addr, size, MEM_RELEASE) != 0;
+}
+
+bool MapMemory(void* addr, size_t size, MemProt perms, int fd [[maybe_unused]],
                   uint64_t cpu_addr [[maybe_unused]]) {
   DWORD OldProtect;
   return VirtualProtect(addr, size, memProtToOsProt(perms), &OldProtect) != 0;


### PR DESCRIPTION
## Motivation

VMM API enable for rocr-on-windows

## Technical Details

- Get Handle for GPU Memory Object to be used for set/get access
- add cpu set/get access using VirtualProtect for windows
- reuse DRM calls for windows to access thunk

## Test Plan

- Use existing VMM API tests in hip

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
