### PR TITLE
Fix: Optimize write_perfetto() by replacing find_if() with hashmap lookup to avoid test timeout

### DIFF
--- a/projects/rocprofiler-sdk/tests/tools/json-tool.cpp
+++ b/projects/rocprofiler-sdk/tests/tools/json-tool.cpp
@@ -2367,6 +2367,47 @@ write_perfetto()
         return getenv("ROCPROFILER_TOOL_DISABLE_PERFETTO_ANNOTATIONS") == nullptr;
     }();
 
+    // BUILD LOOKUP MAPS FOR ALL CALLBACK ARGUMENTS
+    auto hsa_args_by_corr_id       = std::unordered_map<uint64_t, callback_arg_array_t>{};
+    auto hip_args_by_corr_id       = std::unordered_map<uint64_t, callback_arg_array_t>{};
+    auto rccl_args_by_corr_id      = std::unordered_map<uint64_t, callback_arg_array_t>{};
+    auto rocdecode_args_by_corr_id = std::unordered_map<uint64_t, callback_arg_array_t>{};
+    auto rocjpeg_args_by_corr_id   = std::unordered_map<uint64_t, callback_arg_array_t>{};
+    auto ompt_args_by_corr_id      = std::unordered_map<uint64_t, callback_arg_array_t>{};
+
+    if(enable_debug_annotations)
+    {
+        // Build HSA API argument lookup map
+        for(const auto& rec : hsa_api_cb_records)
+            if(!rec.args.empty())
+                hsa_args_by_corr_id.try_emplace(rec.record.correlation_id.internal, rec.args);
+
+        // Build HIP API argument lookup map
+        for(const auto& rec : hip_api_cb_records)
+            if(!rec.args.empty())
+                hip_args_by_corr_id.try_emplace(rec.record.correlation_id.internal, rec.args);
+
+        // Build RCCL API argument lookup map
+        for(const auto& rec : rccl_api_cb_records)
+            if(!rec.args.empty())
+                rccl_args_by_corr_id.try_emplace(rec.record.correlation_id.internal, rec.args);
+
+        // Build RocDecode API argument lookup map
+        for(const auto& rec : rocdecode_api_cb_records)
+            if(!rec.args.empty())
+                rocdecode_args_by_corr_id.try_emplace(rec.record.correlation_id.internal, rec.args);
+
+        // Build RocJPEG API argument lookup map
+        for(const auto& rec : rocjpeg_api_cb_records)
+            if(!rec.args.empty())
+                rocjpeg_args_by_corr_id.try_emplace(rec.record.correlation_id.internal, rec.args);
+
+        // Build OMPT argument lookup map
+        for(const auto& rec : ompt_cb_records)
+            if(!rec.args.empty())
+                ompt_args_by_corr_id.try_emplace(rec.record.correlation_id.internal, rec.args);
+    }
+
     // environment settings
     auto shmem_size_hint = size_t{64};
     auto buffer_size_kb  = size_t{1024000};
@@ -2562,14 +2603,18 @@ write_perfetto()
 
             auto _args = callback_arg_array_t{};
             if(enable_debug_annotations)
-            {
-                auto ritr = std::find_if(
-                    hsa_api_cb_records.begin(), hsa_api_cb_records.end(), [&itr](const auto& citr) {
-                        return (citr.record.correlation_id.internal ==
-                                    itr.correlation_id.internal &&
-                                !citr.args.empty());
-                    });
-                if(ritr != hsa_api_cb_records.end()) _args = ritr->args;
+            {  // The lookup with find_if which runs a linear search
+                // auto ritr = std::find_if(
+                //     hsa_api_cb_records.begin(), hsa_api_cb_records.end(), [&itr](const auto&
+                //     citr) {
+                //         return (citr.record.correlation_id.internal ==
+                //                     itr.correlation_id.internal &&
+                //                 !citr.args.empty());
+                //     });
+                // if(ritr != hsa_api_cb_records.end()) _args = ritr->args;
+
+                auto args_it = hsa_args_by_corr_id.find(itr.correlation_id.internal);
+                if(args_it != hsa_args_by_corr_id.end()) _args = args_it->second;
             }
 
             TRACE_EVENT_BEGIN(sdk::perfetto_category<sdk::category::hsa_api>::name,
@@ -2608,13 +2653,8 @@ write_perfetto()
             auto _args = callback_arg_array_t{};
             if(enable_debug_annotations)
             {
-                auto ritr = std::find_if(
-                    hip_api_cb_records.begin(), hip_api_cb_records.end(), [&itr](const auto& citr) {
-                        return (citr.record.correlation_id.internal ==
-                                    itr.correlation_id.internal &&
-                                !citr.args.empty());
-                    });
-                if(ritr != hip_api_cb_records.end()) _args = ritr->args;
+                auto args_it = hip_args_by_corr_id.find(itr.correlation_id.internal);
+                if(args_it != hip_args_by_corr_id.end()) _args = args_it->second;
             }
 
             TRACE_EVENT_BEGIN(sdk::perfetto_category<sdk::category::hip_api>::name,
@@ -2653,14 +2693,8 @@ write_perfetto()
             auto _args = callback_arg_array_t{};
             if(enable_debug_annotations)
             {
-                auto ritr = std::find_if(rccl_api_cb_records.begin(),
-                                         rccl_api_cb_records.end(),
-                                         [&itr](const auto& citr) {
-                                             return (citr.record.correlation_id.internal ==
-                                                         itr.correlation_id.internal &&
-                                                     !citr.args.empty());
-                                         });
-                if(ritr != rccl_api_cb_records.end()) _args = ritr->args;
+                auto args_it = rccl_args_by_corr_id.find(itr.correlation_id.internal);
+                if(args_it != rccl_args_by_corr_id.end()) _args = args_it->second;
             }
 
             TRACE_EVENT_BEGIN(sdk::perfetto_category<sdk::category::rccl_api>::name,
@@ -2699,14 +2733,8 @@ write_perfetto()
             auto _args = callback_arg_array_t{};
             if(enable_debug_annotations)
             {
-                auto ritr = std::find_if(rocdecode_api_cb_records.begin(),
-                                         rocdecode_api_cb_records.end(),
-                                         [&itr](const auto& citr) {
-                                             return (citr.record.correlation_id.internal ==
-                                                         itr.correlation_id.internal &&
-                                                     !citr.args.empty());
-                                         });
-                if(ritr != rocdecode_api_cb_records.end()) _args = ritr->args;
+                auto args_it = rocdecode_args_by_corr_id.find(itr.correlation_id.internal);
+                if(args_it != rocdecode_args_by_corr_id.end()) _args = args_it->second;
             }
 
             TRACE_EVENT_BEGIN(sdk::perfetto_category<sdk::category::rocdecode_api>::name,
@@ -2745,14 +2773,8 @@ write_perfetto()
             auto _args = callback_arg_array_t{};
             if(enable_debug_annotations)
             {
-                auto ritr = std::find_if(rocjpeg_api_cb_records.begin(),
-                                         rocjpeg_api_cb_records.end(),
-                                         [&itr](const auto& citr) {
-                                             return (citr.record.correlation_id.internal ==
-                                                         itr.correlation_id.internal &&
-                                                     !citr.args.empty());
-                                         });
-                if(ritr != rocjpeg_api_cb_records.end()) _args = ritr->args;
+                auto args_it = rocjpeg_args_by_corr_id.find(itr.correlation_id.internal);
+                if(args_it != rocjpeg_args_by_corr_id.end()) _args = args_it->second;
             }
 
             TRACE_EVENT_BEGIN(sdk::perfetto_category<sdk::category::rocjpeg_api>::name,
@@ -2791,13 +2813,8 @@ write_perfetto()
             auto _args = callback_arg_array_t{};
             if(enable_debug_annotations)
             {
-                auto ritr = std::find_if(
-                    ompt_cb_records.begin(), ompt_cb_records.end(), [&itr](const auto& citr) {
-                        return (citr.record.correlation_id.internal ==
-                                    itr.correlation_id.internal &&
-                                !citr.args.empty());
-                    });
-                if(ritr != ompt_cb_records.end()) _args = ritr->args;
+                auto args_it = ompt_args_by_corr_id.find(itr.correlation_id.internal);
+                if(args_it != ompt_args_by_corr_id.end()) _args = args_it->second;
             }
 
             TRACE_EVENT_BEGIN(sdk::perfetto_category<sdk::category::openmp>::name,


### PR DESCRIPTION
## Motivation

This PR aims to resolve intermittent timeouts in the test-kernel-tracing-execute CTest by optimizing debug_annotations. Here find_if() which uses a linear search is replaced with hash map lookups in Perfetto trace generation. 

## Technical Details

Modified tests/tools/json-tool.cpp::write_perfetto():

1. Pre-built lookup maps: Added std::unordered_map<uint64_t, callback_arg_array_t> construction at function start for each API type (HSA, HIP, RCCL, RocDecode, RocJPEG, OMPT) when enable_debug_annotations is enabled.

2. Replaced O(N) searches: Converted all std::find_if() calls in buffer record processing loops to O(1) hash map lookups using correlation_id.internal as the key.

3. Preserved correctness: Used try_emplace() for first-write-wins semantics matching original behavior as found in find_if()
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
A custom validation script was used to ensure the correctness of the hashmap optimization by comparing Perfetto trace output with JSON records across multiple checks:

1. Record Count: Confirms matching record counts for all API categories (HIP, HSA, RCCL, RocDecode, RocJPEG, OMPT, kernel dispatch, memory copy).
2. Timestamp Accuracy: Verifies the start and end timestamps using correlation ID lookups.
3. Correlation Integrity: Ensures every call chains are preserved for call stack traceability.
4. Operation Correctness: Validates operation IDs to prevent semantic mismatches.

The script also used a hash-based lookups to cross-reference records, confirming that the optimized approach produces identical results to the original linear search.

## Test Result

The CTest _test-kernel-trace-execute_ completed successfully without any timeout
The custom validation script confirmed that the hashmap-based optimization functions correctly. 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
