### PR TITLE
Serialize BLIT Kernels to fix Counter Collection Issues

### DIFF
--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/cxx/utility.hpp
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/cxx/utility.hpp
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <cstdint>
 #include <iomanip>
 #include <sstream>
@@ -46,6 +47,26 @@ as_hex(Tp val, size_t width = 0)
     auto ss = std::stringstream{};
     ss << "0x" << std::hex << std::setfill('0') << std::setw(width) << _uintp_val;
     return ss.str();
+}
+
+template <typename Integral = uint64_t>
+constexpr Integral
+bit_mask(int first, int last)
+{
+    assert(last >= first && "Error: hsa_support::bit_mask -> invalid argument");
+    size_t num_bits = last - first + 1;
+    return ((num_bits >= sizeof(Integral) * 8) ? ~Integral{0}
+                                               /* num_bits exceed the size of Integral */
+                                               : ((Integral{1} << num_bits) - 1))
+           << first;
+}
+
+/* Extract bits [last:first] from t.  */
+template <typename Integral>
+constexpr Integral
+bit_extract(Integral x, int first, int last)
+{
+    return (x >> first) & bit_mask<Integral>(0, last - first);
 }
 }  // namespace utility
 }  // namespace sdk

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dispatch_handlers.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dispatch_handlers.cpp
@@ -36,6 +36,7 @@
 
 #include <rocprofiler-sdk/fwd.h>
 #include <rocprofiler-sdk/rocprofiler.h>
+#include <rocprofiler-sdk/cxx/utility.hpp>
 
 namespace rocprofiler
 {
@@ -77,7 +78,12 @@ queue_cb(const context::context*                                         ctx,
     ctx->counter_collection->enabled.rlock(
         [&](const auto& collect_ctx) { is_enabled = collect_ctx; });
 
-    if(!is_enabled || !info->user_cb) return {no_instrumentation(), true};
+    auto packet_type = rocprofiler::sdk::utility::bit_extract(
+        pkt.kernel_dispatch.header,
+        HSA_PACKET_HEADER_TYPE,
+        HSA_PACKET_HEADER_TYPE + HSA_PACKET_HEADER_WIDTH_TYPE - 1);
+    if(!is_enabled || !info->user_cb || packet_type != HSA_PACKET_TYPE_KERNEL_DISPATCH)
+        return {no_instrumentation(), true};
 
     auto _corr_id_v =
         rocprofiler_async_correlation_id_t{.internal = 0, .external = context::null_user_data};

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -120,9 +120,14 @@ AsyncSignalHandler(hsa_signal_value_t /*signal_v*/, void* data)
     auto& shared_ptr_info    = *static_cast<std::shared_ptr<Queue::queue_info_session_t>*>(data);
     auto& queue_info_session = *shared_ptr_info;
 
-    auto dispatch_time = kernel_dispatch::get_dispatch_time(queue_info_session);
+    auto dispatch_time = tracing::profiling_time{.status = HSA_STATUS_ERROR_INVALID_AGENT};
 
-    kernel_dispatch::dispatch_complete(queue_info_session, dispatch_time);
+    if(!queue_info_session.is_blit_kernel)
+    {
+        dispatch_time = kernel_dispatch::get_dispatch_time(queue_info_session);
+
+        kernel_dispatch::dispatch_complete(queue_info_session, dispatch_time);
+    }
 
     // Calls our internal callbacks to callers who need to be notified post
     // kernel execution.
@@ -272,7 +277,11 @@ WriteInterceptor(const void* packets,
         auto        packet_type     = bit_extract(original_packet.header,
                                        HSA_PACKET_HEADER_TYPE,
                                        HSA_PACKET_HEADER_TYPE + HSA_PACKET_HEADER_WIDTH_TYPE - 1);
-        if(packet_type != HSA_PACKET_TYPE_KERNEL_DISPATCH)
+        bool        is_blit_kernel  = packet_type == HSA_PACKET_TYPE_VENDOR_SPECIFIC &&
+                              original_packet.workgroup_size_x > 0 &&
+                              original_packet.workgroup_size_y > 0 &&
+                              original_packet.workgroup_size_z > 0;
+        if(packet_type != HSA_PACKET_TYPE_KERNEL_DISPATCH && !is_blit_kernel)
         {
             transformed_packets.emplace_back(packets_arr[i]);
             continue;
@@ -281,7 +290,7 @@ WriteInterceptor(const void* packets,
         auto*                    corr_id      = context::get_latest_correlation_id();
         context::correlation_id* _corr_id_pop = nullptr;
 
-        if(!corr_id)
+        if(!corr_id && !is_blit_kernel)
         {
             constexpr auto ref_count = 1;
             corr_id                  = context::correlation_tracing_service::construct(ref_count);
@@ -289,8 +298,11 @@ WriteInterceptor(const void* packets,
         }
 
         // increase the reference count to denote that this correlation id is being used in a kernel
-        corr_id->add_ref_count();
-        corr_id->add_kern_count();
+        if(!is_blit_kernel)
+        {
+            corr_id->add_ref_count();
+            corr_id->add_kern_count();
+        }
 
         auto thr_id           = (corr_id) ? corr_id->thread_idx : common::get_tid();
         auto user_data        = rocprofiler_user_data_t{.value = 0};
@@ -307,12 +319,15 @@ WriteInterceptor(const void* packets,
             }
         }};
 
-        tracing::populate_external_correlation_ids(
-            tracing_data_v.external_correlation_ids,
-            thr_id,
-            ROCPROFILER_EXTERNAL_CORRELATION_REQUEST_KERNEL_DISPATCH,
-            ROCPROFILER_KERNEL_DISPATCH_ENQUEUE,
-            internal_corr_id);
+        if(!is_blit_kernel)
+        {
+            tracing::populate_external_correlation_ids(
+                tracing_data_v.external_correlation_ids,
+                thr_id,
+                ROCPROFILER_EXTERNAL_CORRELATION_REQUEST_KERNEL_DISPATCH,
+                ROCPROFILER_KERNEL_DISPATCH_ENQUEUE,
+                internal_corr_id);
+        }
 
         queue.async_started();
 
@@ -334,7 +349,7 @@ WriteInterceptor(const void* packets,
         static_assert(kernel_dispatch_info_rt_size < sizeof(rocprofiler_kernel_dispatch_info_t),
                       "failed to compute size field based on offset of reserved_padding field");
 
-        auto dispatch_id     = ++sequence_counter;
+        auto dispatch_id     = is_blit_kernel ? 0 : ++sequence_counter;
         auto callback_record = callback_record_t{
             sizeof(callback_record_t),
             rocprofiler_timestamp_t{0},
@@ -354,25 +369,27 @@ WriteInterceptor(const void* packets,
                                                 kernel_pkt.kernel_dispatch.grid_size_y,
                                                 kernel_pkt.kernel_dispatch.grid_size_z},
                 .reserved_padding = {0}}};
-
+        if(!is_blit_kernel)
         {
-            auto tracer_data = callback_record;
-            tracing::execute_phase_enter_callbacks(tracing_data_v.callback_contexts,
-                                                   thr_id,
-                                                   internal_corr_id,
-                                                   tracing_data_v.external_correlation_ids,
-                                                   ancestor_corr_id,
-                                                   ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,
-                                                   ROCPROFILER_KERNEL_DISPATCH_ENQUEUE,
-                                                   tracer_data);
-        }
+            {
+                auto tracer_data = callback_record;
+                tracing::execute_phase_enter_callbacks(tracing_data_v.callback_contexts,
+                                                       thr_id,
+                                                       internal_corr_id,
+                                                       tracing_data_v.external_correlation_ids,
+                                                       ancestor_corr_id,
+                                                       ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,
+                                                       ROCPROFILER_KERNEL_DISPATCH_ENQUEUE,
+                                                       tracer_data);
+            }
 
-        // map all the external correlation ids (after enqueue enter phase) for all the contexts
-        // captured by the info session
-        tracing::update_external_correlation_ids(
-            tracing_data_v.external_correlation_ids,
-            thr_id,
-            ROCPROFILER_EXTERNAL_CORRELATION_REQUEST_KERNEL_DISPATCH);
+            // map all the external correlation ids (after enqueue enter phase) for all the contexts
+            // captured by the info session
+            tracing::update_external_correlation_ids(
+                tracing_data_v.external_correlation_ids,
+                thr_id,
+                ROCPROFILER_EXTERNAL_CORRELATION_REQUEST_KERNEL_DISPATCH);
+        }
 
         // If there is a lot of contention for HSA signals, then schedule out the thread
         if(get_balanced_signal_slots().fetch_sub(1) <= 0)
@@ -475,7 +492,7 @@ WriteInterceptor(const void* packets,
             get_core_table()->hsa_signal_store_screlease_fn(completion_signal, 0);
         }
 
-        ROCP_FATAL_IF(packet_type != HSA_PACKET_TYPE_KERNEL_DISPATCH)
+        ROCP_FATAL_IF(packet_type != HSA_PACKET_TYPE_KERNEL_DISPATCH && !is_blit_kernel)
             << "get_kernel_id below might need to be updated";
 
         // Enqueue the signal into the handler. Will call completed_cb when
@@ -492,19 +509,23 @@ WriteInterceptor(const void* packets,
                                                      .kernel_pkt       = kernel_pkt,
                                                      .callback_record  = callback_record,
                                                      .tracing_data     = tracing_data_v,
-                                                     .is_serialized    = bRequest_Serialize};
+                                                     .is_serialized    = bRequest_Serialize,
+                                                     .is_blit_kernel   = is_blit_kernel};
 
             auto shared = std::make_shared<Queue::queue_info_session_t>(std::move(info_session));
 
             queue.signal_async_handler(completion_signal,
                                        new std::shared_ptr<Queue::queue_info_session_t>(shared));
 
-            auto tracer_data = callback_record;
-            tracing::execute_phase_exit_callbacks(tracing_data_v.callback_contexts,
-                                                  tracing_data_v.external_correlation_ids,
-                                                  ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,
-                                                  ROCPROFILER_KERNEL_DISPATCH_ENQUEUE,
-                                                  tracer_data);
+            if(!is_blit_kernel)
+            {
+                auto tracer_data = callback_record;
+                tracing::execute_phase_exit_callbacks(tracing_data_v.callback_contexts,
+                                                      tracing_data_v.external_correlation_ids,
+                                                      ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,
+                                                      ROCPROFILER_KERNEL_DISPATCH_ENQUEUE,
+                                                      tracer_data);
+            }
         }
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -38,6 +38,7 @@
 #include <rocprofiler-sdk/callback_tracing.h>
 #include <rocprofiler-sdk/external_correlation.h>
 #include <rocprofiler-sdk/fwd.h>
+#include <rocprofiler-sdk/cxx/utility.hpp>
 
 #include <hsa/hsa.h>
 #include <hsa/hsa_ext_amd.h>
@@ -127,20 +128,20 @@ AsyncSignalHandler(hsa_signal_value_t /*signal_v*/, void* data)
         dispatch_time = kernel_dispatch::get_dispatch_time(queue_info_session);
 
         kernel_dispatch::dispatch_complete(queue_info_session, dispatch_time);
-    }
 
-    // Calls our internal callbacks to callers who need to be notified post
-    // kernel execution.
-    queue_info_session.queue.signal_callback([&](const auto& map) {
-        for(const auto& [client_id, cb_pair] : map)
-        {
-            cb_pair.second(queue_info_session.queue,
-                           queue_info_session.kernel_pkt,
-                           shared_ptr_info,
-                           queue_info_session.inst_pkt,
-                           dispatch_time);
-        }
-    });
+        // Calls our internal callbacks to callers who need to be notified post
+        // kernel execution.
+        queue_info_session.queue.signal_callback([&](const auto& map) {
+            for(const auto& [client_id, cb_pair] : map)
+            {
+                cb_pair.second(queue_info_session.queue,
+                               queue_info_session.kernel_pkt,
+                               shared_ptr_info,
+                               queue_info_session.inst_pkt,
+                               dispatch_time);
+            }
+        });
+    }
 
     if(queue_info_session.is_serialized)
     {
@@ -184,26 +185,6 @@ AsyncSignalHandler(hsa_signal_value_t /*signal_v*/, void* data)
     delete &shared_ptr_info;
 
     return false;
-}
-
-template <typename Integral = uint64_t>
-constexpr Integral
-bit_mask(int first, int last)
-{
-    assert(last >= first && "Error: hsa_support::bit_mask -> invalid argument");
-    size_t num_bits = last - first + 1;
-    return ((num_bits >= sizeof(Integral) * 8) ? ~Integral{0}
-                                               /* num_bits exceed the size of Integral */
-                                               : ((Integral{1} << num_bits) - 1))
-           << first;
-}
-
-/* Extract bits [last:first] from t.  */
-template <typename Integral>
-constexpr Integral
-bit_extract(Integral x, int first, int last)
-{
-    return (x >> first) & bit_mask<Integral>(0, last - first);
 }
 
 /**
@@ -274,10 +255,11 @@ WriteInterceptor(const void* packets,
     for(size_t i = 0; i < pkt_count; ++i)
     {
         const auto& original_packet = packets_arr[i].kernel_dispatch;
-        auto        packet_type     = bit_extract(original_packet.header,
-                                       HSA_PACKET_HEADER_TYPE,
-                                       HSA_PACKET_HEADER_TYPE + HSA_PACKET_HEADER_WIDTH_TYPE - 1);
-        bool        is_blit_kernel  = packet_type == HSA_PACKET_TYPE_VENDOR_SPECIFIC &&
+        auto        packet_type     = rocprofiler::sdk::utility::bit_extract(
+            original_packet.header,
+            HSA_PACKET_HEADER_TYPE,
+            HSA_PACKET_HEADER_TYPE + HSA_PACKET_HEADER_WIDTH_TYPE - 1);
+        bool is_blit_kernel = packet_type == HSA_PACKET_TYPE_VENDOR_SPECIFIC &&
                               original_packet.workgroup_size_x > 0 &&
                               original_packet.workgroup_size_y > 0 &&
                               original_packet.workgroup_size_z > 0;
@@ -287,7 +269,7 @@ WriteInterceptor(const void* packets,
             continue;
         }
 
-        auto*                    corr_id      = context::get_latest_correlation_id();
+        auto* corr_id = is_blit_kernel ? nullptr : context::get_latest_correlation_id();
         context::correlation_id* _corr_id_pop = nullptr;
 
         if(!corr_id && !is_blit_kernel)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_info_session.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_info_session.hpp
@@ -65,6 +65,7 @@ struct queue_info_session
     callback_record_t        callback_record  = {};
     tracing::tracing_data    tracing_data     = {};
     bool                     is_serialized    = false;
+    bool                     is_blit_kernel   = false;
 };
 }  // namespace hsa
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -32,6 +32,7 @@
 #include <rocprofiler-sdk/fwd.h>
 #include <rocprofiler-sdk/hsa.h>
 #include <rocprofiler-sdk/intercept_table.h>
+#include <rocprofiler-sdk/cxx/utility.hpp>
 
 #include <hsa/hsa_api_trace.h>
 
@@ -317,6 +318,7 @@ DispatchThreadTracer::resource_deinit()
  */
 hsa::Queue::pkt_and_serialize_t
 DispatchThreadTracer::pre_kernel_call(const hsa::Queue&              queue,
+                                      const hsa::rocprofiler_packet& pkt,
                                       rocprofiler_kernel_id_t        kernel_id,
                                       rocprofiler_dispatch_id_t      dispatch_id,
                                       rocprofiler_user_data_t*       user_data,
@@ -330,12 +332,17 @@ DispatchThreadTracer::pre_kernel_call(const hsa::Queue&              queue,
         rocprof_corr_id.internal = corr_id->internal;
     }
     // TODO: Get external
+    auto packet_type = rocprofiler::sdk::utility::bit_extract(
+        pkt.kernel_dispatch.header,
+        HSA_PACKET_HEADER_TYPE,
+        HSA_PACKET_HEADER_TYPE + HSA_PACKET_HEADER_WIDTH_TYPE - 1);
+    auto is_kernel_dispatch = packet_type != HSA_PACKET_TYPE_KERNEL_DISPATCH;
 
     std::shared_lock<std::shared_mutex> lk(agents_map_mut);
 
     auto it = agents.find(queue.get_agent().get_hsa_agent());
 
-    if(it == agents.end()) return {nullptr, false};
+    if(it == agents.end() || !is_kernel_dispatch) return {nullptr, false};
 
     auto&       agent      = *CHECK_NOTNULL(it->second);
     const auto& parameters = agent.params;
@@ -391,26 +398,26 @@ DispatchThreadTracer::start_context()
     client.wlock([&](auto& client_id) {
         if(client_id) return;
 
-        client_id =
-            CHECK_NOTNULL(hsa::get_queue_controller())
-                ->add_callback(
-                    std::nullopt,
-                    [=](const hsa::Queue& q,
-                        const hsa::rocprofiler_packet& /* kern_pkt */,
-                        rocprofiler_kernel_id_t   kernel_id,
-                        rocprofiler_dispatch_id_t dispatch_id,
-                        rocprofiler_user_data_t*  user_data,
-                        const corr_id_map_t& /* extern_corr_ids */,
-                        const context::correlation_id* corr_id) {
-                        return this->pre_kernel_call(q, kernel_id, dispatch_id, user_data, corr_id);
-                    },
-                    [=](const hsa::Queue& /* q */,
-                        hsa::rocprofiler_packet /* kern_pkt */,
-                        std::shared_ptr<hsa::Queue::queue_info_session_t>& session,
-                        inst_pkt_t&                                        aql,
-                        kernel_dispatch::profiling_time) {
-                        this->post_kernel_call(aql, *session);
-                    });
+        client_id = CHECK_NOTNULL(hsa::get_queue_controller())
+                        ->add_callback(
+                            std::nullopt,
+                            [=](const hsa::Queue&              q,
+                                const hsa::rocprofiler_packet& kern_pkt,
+                                rocprofiler_kernel_id_t        kernel_id,
+                                rocprofiler_dispatch_id_t      dispatch_id,
+                                rocprofiler_user_data_t*       user_data,
+                                const corr_id_map_t& /* extern_corr_ids */,
+                                const context::correlation_id* corr_id) {
+                                return this->pre_kernel_call(
+                                    q, kern_pkt, kernel_id, dispatch_id, user_data, corr_id);
+                            },
+                            [=](const hsa::Queue& /* q */,
+                                hsa::rocprofiler_packet /* kern_pkt */,
+                                std::shared_ptr<hsa::Queue::queue_info_session_t>& session,
+                                inst_pkt_t&                                        aql,
+                                kernel_dispatch::profiling_time) {
+                                this->post_kernel_call(aql, *session);
+                            });
     });
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.hpp
@@ -145,6 +145,7 @@ public:
     }
 
     hsa::Queue::pkt_and_serialize_t pre_kernel_call(const hsa::Queue&              queue,
+                                                    const hsa::rocprofiler_packet& pkt,
                                                     uint64_t                       kernel_id,
                                                     rocprofiler_dispatch_id_t      dispatch_id,
                                                     rocprofiler_user_data_t*       user_data,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -707,8 +707,7 @@ core::Queue* GpuAgent::CreateInterceptibleQueue(void (*callback)(hsa_status_t st
   auto _q = core::Queue::Convert(queue);
   hsa_queue_create(this->public_handle(), size, HSA_QUEUE_TYPE_MULTI, callback, data, 0, 0, &_q);
   queue = core::Queue::Convert(_q);
-  // QueueCreate(size, HSA_QUEUE_TYPE_MULTI, HSA_AMD_QUEUE_CREATE_SYSTEM_MEM, callback, data, 0, 0,
-              // &queue);
+
   if (queue != nullptr)
     core::Runtime::runtime_singleton_->InternalQueueCreateNotify(core::Queue::Convert(queue),
                                                                  this->public_handle());

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -704,9 +704,11 @@ core::Queue* GpuAgent::CreateInterceptibleQueue(void (*callback)(hsa_status_t st
   core::Queue* queue = nullptr;
   uint32_t size = std::max(in_size, minAqlSize_);
   size = std::min(size, maxAqlSize_);
-
-  QueueCreate(size, HSA_QUEUE_TYPE_MULTI, HSA_AMD_QUEUE_CREATE_SYSTEM_MEM, callback, data, 0, 0,
-              &queue);
+  auto _q = core::Queue::Convert(queue);
+  hsa_queue_create(this->public_handle(), size, HSA_QUEUE_TYPE_MULTI, callback, data, 0, 0, &_q);
+  queue = core::Queue::Convert(_q);
+  // QueueCreate(size, HSA_QUEUE_TYPE_MULTI, HSA_AMD_QUEUE_CREATE_SYSTEM_MEM, callback, data, 0, 0,
+              // &queue);
   if (queue != nullptr)
     core::Runtime::runtime_singleton_->InternalQueueCreateNotify(core::Queue::Convert(queue),
                                                                  this->public_handle());


### PR DESCRIPTION
## Motivation

[SWDEV-534237](https://ontrack-internal.amd.com/browse/SWDEV-534237) [rocprofv3] Incorrect counter values in multi-stream programs

Counter collection for rocprofv3 is incorrect due to BLIT kernels not being serialized in the rocprofiler-sdk. This PR serializes, but does not track BLIT kernels.

## Technical Details

Adds code to ROCR runtime to set up intercept queue, and the adds extra checks for WriteInterceptor to handle BLIT kernels. BLIT kernels are entered via the `amd_aql_queue.cpp` file with `HSA_PACKET_TYPE_VENDOR_SPECIFIC`. If a BLIT kernel is detected, then it's serialized like normal kernels, but not tracked.

## Test Plan

Unfortunately, the ctest seems to affect the SQ_WAVES counter collection, so I cannot add a test to verify that the SQ_WAVES are all equal for multiple streams.

## Test Result

CI Tests should pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
