### PR TITLE
[Ex CI] Disable hip-tests pipeline

### DIFF
--- a/.github/scripts/azure_resolve_subtree_deps.py
+++ b/.github/scripts/azure_resolve_subtree_deps.py
@@ -80,7 +80,7 @@ def main(argv=None) -> None:
     definition_ids = {
         "projects/aqlprofile": 365,
         "projects/clr": 335,
-        "projects/hip-tests": 362,
+        #"projects/hip-tests": 362,
         "projects/hip": 335,
         "projects/hipother": 335,
         "projects/rdc": 360,


### PR DESCRIPTION
## Motivation
The current pipeline for hip-tests is failing due to a missing pipeline for spirv-llvm-translator. Temporarily disabling the Azure pipeline.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
