### PR TITLE
Update rocprofiler-compute workflows to use public ROCm dev images

### DIFF
--- a/.github/workflows/rocprofiler-compute-rhel-8.yml
+++ b/.github/workflows/rocprofiler-compute-rhel-8.yml
@@ -34,13 +34,14 @@ concurrency:
 jobs:
   build:
     # The type of runner that the job will run on
-    # https://hub.docker.com/r/rocm/dev-almalinux-8/tags
+    # Using rocprofiler-systems images and later installing rocm, the official rocm images for al8 red hat variant are too large- this is a workaround.
     runs-on: ubuntu-latest
     container:
-      image: rocm/dev-almalinux-8:7.1-complete
+      image: dgaliffiamd/rocprofiler-systems:ci-base-rhel-${{ matrix.os-release }}
     strategy:
       fail-fast: false
       matrix:
+        os-release: [ '8.10', '9.4' ]
         build-type: ['Release']
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -54,6 +55,16 @@ jobs:
           yum -y install cmake3
           yum -y install which
           yum -y install glibc-langpack-en
+      - name: Install ROCm Packages
+        timeout-minutes: 30
+        uses: nick-fields/retry@v3
+        with:
+          retry_wait_seconds: 30
+          timeout_minutes: 30
+          max_attempts: 3
+          command: |
+            yum install -y https://repo.radeon.com/amdgpu-install/latest/rhel/${{ matrix.os-release }}/amdgpu-install-7.1.70100-1.el8.noarch.rpm
+            yum install -y rocm-dev
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/rocprofiler-compute-rhel-8.yml
+++ b/.github/workflows/rocprofiler-compute-rhel-8.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - develop
     paths:
+      - '.github/workflows/rocprofiler-compute-rhel-8.yml'
       - 'projects/rocprofiler-compute/**'
       - '!projects/rocprofiler-compute/*.md'
       - '!projects/rocprofiler-compute/.github/**/*.md'
@@ -15,6 +16,7 @@ on:
       - '!projects/rocprofiler-compute/docker/**'
   pull_request:
     paths:
+      - '.github/workflows/rocprofiler-compute-rhel-8.yml'
       - 'projects/rocprofiler-compute/**'
       - '!projects/rocprofiler-compute/*.md'
       - '!projects/rocprofiler-compute/.github/**/*.md'

--- a/.github/workflows/rocprofiler-compute-rhel-8.yml
+++ b/.github/workflows/rocprofiler-compute-rhel-8.yml
@@ -32,13 +32,13 @@ concurrency:
 jobs:
   build:
     # The type of runner that the job will run on
+    # https://hub.docker.com/r/rocm/dev-almalinux-8/tags
     runs-on: ubuntu-latest
     container:
-      image: dgaliffiamd/rocprofiler-systems:ci-base-rhel-${{ matrix.os-release }}
+      image: rocm/dev-almalinux-8:7.1-complete
     strategy:
       fail-fast: false
       matrix:
-        os-release: [ '8.10', '9.3']
         build-type: ['Release']
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/rocprofiler-compute-rhel-8.yml
+++ b/.github/workflows/rocprofiler-compute-rhel-8.yml
@@ -68,7 +68,11 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           command: |
-            yum install -y https://repo.radeon.com/amdgpu-install/latest/rhel/${{ matrix.os-release }}/amdgpu-install-7.1.70100-1.el8.noarch.rpm
+            if [ ${{ matrix.os-release }} == "8.10" ]; then
+              yum install -y https://repo.radeon.com/amdgpu-install/latest/rhel/8.10/amdgpu-install-7.1.70100-1.el8.noarch.rpm
+            else
+              yum install -y https://repo.radeon.com/amdgpu-install/latest/rhel/9.4/amdgpu-install-7.1.70100-1.el9.noarch.rpm
+            fi
             yum install -y rocm-dev
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/rocprofiler-compute-rhel-8.yml
+++ b/.github/workflows/rocprofiler-compute-rhel-8.yml
@@ -44,15 +44,19 @@ jobs:
         os-release: [ '8.10', '9.4' ]
         build-type: ['Release']
     # Steps represent a sequence of tasks that will be executed as part of the job
+    # Note- RHEL8 references python3.9 as python39, whereas RHEL9 default version is already 3.9, so we only need to call it as python3
     steps:
       - name: Install baseline OS dependencies
         run: |
           yum clean all
           yum makecache
-          yum -y update
           yum -y install git
-          yum -y install python39
-          yum -y install python39-devel
+          if [ ${{ matrix.os-release }} == "8.10" ]; then
+            yum -y install python39
+            yum -y install python39-devel
+          else
+            yum -y install python3-devel
+          fi
           yum -y install cmake3
           yum -y install which
           yum -y install glibc-langpack-en

--- a/.github/workflows/rocprofiler-compute-rhel-8.yml
+++ b/.github/workflows/rocprofiler-compute-rhel-8.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           yum clean all
           yum makecache
+          yum -y update
           yum -y install git
           yum -y install python39
           yum -y install python39-devel

--- a/.github/workflows/rocprofiler-compute-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-compute-ubuntu-jammy.yml
@@ -30,9 +30,10 @@ concurrency:
 jobs:
   build:
     # The type of runner that the job will run on
+    # https://hub.docker.com/r/rocm/dev-ubuntu-22.04/tags
     runs-on: ubuntu-latest
     container:
-      image: dgaliffiamd/rocprofiler-systems:ci-base-ubuntu-22.04
+      image: rocm/dev-ubuntu-22.04:7.1
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Install baseline OS dependencies

--- a/.github/workflows/rocprofiler-compute-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-compute-ubuntu-jammy.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - develop
     paths:
+      - '.github/workflows/rocprofiler-compute-ubuntu-jammy.yml'
       - 'projects/rocprofiler-compute/**'
       - '!projects/rocprofiler-compute/*.md'
       - '!projects/rocprofiler-compute/.github/**/*.md'
@@ -14,6 +15,7 @@ on:
       - '!projects/rocprofiler-compute/docker/**'
   pull_request:
     paths:
+      - '.github/workflows/rocprofiler-compute-ubuntu-jammy.yml'
       - 'projects/rocprofiler-compute/**'
       - '!projects/rocprofiler-compute/*.md'
       - '!projects/rocprofiler-compute/.github/**/*.md'


### PR DESCRIPTION
## Motivation

Old method was to borrow rocprofiler-systems images but they do not contain rocm install.

## Technical Details

Updating images to point to the general public ROCm developer builds for ubuntu22.04 and al8. 

## Test Plan

Workflow checks should start passing, we have been caught at the same point during cmake not finding rocm directory. Passing means image contains rocm install.

## Test Result


## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
