### PR TITLE
[rocprofiler-sdk] Get device lock for dispatch counters: rocm-7.1.1

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
@@ -135,6 +135,9 @@ CounterController::configure_dispatch(rocprofiler_context_id_t                  
                                       rocprofiler_dispatch_counting_record_cb_t  record_callback,
                                       void* record_callback_args)
 {
+    // ensure we attempt to lock all devices only once
+    static std::once_flag flag{};
+
     auto* ctx_p = rocprofiler::context::get_mutable_registered_context(context_id);
     if(!ctx_p) return ROCPROFILER_STATUS_ERROR_CONTEXT_INVALID;
 
@@ -145,9 +148,6 @@ CounterController::configure_dispatch(rocprofiler_context_id_t                  
     // FIXME: Due to the clock gating issue, counter collection and PC sampling service
     // cannot coexist in the same context for now.
     if(ctx.pc_sampler) return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
-
-    // ensure we attempt to lock all devices only once
-    static std::once_flag flag{};
 
     if(!ctx.counter_collection)
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
@@ -31,6 +31,8 @@
 #include <rocprofiler-sdk/dispatch_counting_service.h>
 #include <rocprofiler-sdk/fwd.h>
 
+#include <mutex>
+
 namespace rocprofiler
 {
 namespace counters
@@ -144,26 +146,31 @@ CounterController::configure_dispatch(rocprofiler_context_id_t                  
     // cannot coexist in the same context for now.
     if(ctx.pc_sampler) return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
 
+    // ensure we attempt to lock all devices only once
+    static std::once_flag flag{};
+
     if(!ctx.counter_collection)
     {
-        if(counters::counter_collection_has_device_lock())
-        {
-            /**
-             * Note: This should retrun if the lock fails to aquire in the future. However, this
-             * is a change in the required permissions for rocprofiler and needs to be communicated
-             * with partners before strict enforcement. If the required permissions are not
-             * obtained, those profilers will function as they currently do (without any of the
-             * benefits of the IOCTL).
-             */
-            for(const auto& agent : agent::get_agents())
+        std::call_once(flag, []() {
+            if(counters::counter_collection_has_device_lock())
             {
-                if(agent->type == ROCPROFILER_AGENT_TYPE_GPU)
+                /**
+                 * Note: This should retrun if the lock fails to aquire in the future. However, this
+                 * is a change in the required permissions for rocprofiler and needs to be
+                 * communicated with partners before strict enforcement. If the required permissions
+                 * are not obtained, those profilers will function as they currently do (without any
+                 * of the benefits of the IOCTL).
+                 */
+                for(const auto& agent : agent::get_agents())
                 {
-                    counters::counter_collection_device_lock(
-                        rocprofiler::agent::get_agent(agent->id), false);
+                    if(agent->type == ROCPROFILER_AGENT_TYPE_GPU)
+                    {
+                        counters::counter_collection_device_lock(
+                            rocprofiler::agent::get_agent(agent->id), false);
+                    }
                 }
             }
-        }
+        });
 
         ctx.counter_collection =
             std::make_unique<rocprofiler::context::dispatch_counter_collection_service>();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
@@ -144,27 +144,27 @@ CounterController::configure_dispatch(rocprofiler_context_id_t                  
     // cannot coexist in the same context for now.
     if(ctx.pc_sampler) return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
 
-    if(counters::counter_collection_has_device_lock())
-    {
-        /**
-         * Note: This should retrun if the lock fails to aquire in the future. However, this
-         * is a change in the required permissions for rocprofiler and needs to be communicated
-         * with partners before strict enforcement. If the required permissions are not obtained,
-         * those profilers will function as they currently do (without any of the benefits of the
-         * IOCTL).
-         */
-        for(const auto& agent : agent::get_agents())
-        {
-            if(agent->type == ROCPROFILER_AGENT_TYPE_GPU)
-            {
-                counters::counter_collection_device_lock(rocprofiler::agent::get_agent(agent->id),
-                                                         false);
-            }
-        }
-    }
-
     if(!ctx.counter_collection)
     {
+        if(counters::counter_collection_has_device_lock())
+        {
+            /**
+             * Note: This should retrun if the lock fails to aquire in the future. However, this
+             * is a change in the required permissions for rocprofiler and needs to be communicated
+             * with partners before strict enforcement. If the required permissions are not
+             * obtained, those profilers will function as they currently do (without any of the
+             * benefits of the IOCTL).
+             */
+            for(const auto& agent : agent::get_agents())
+            {
+                if(agent->type == ROCPROFILER_AGENT_TYPE_GPU)
+                {
+                    counters::counter_collection_device_lock(
+                        rocprofiler::agent::get_agent(agent->id), false);
+                }
+            }
+        }
+
         ctx.counter_collection =
             std::make_unique<rocprofiler::context::dispatch_counter_collection_service>();
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 #include "lib/rocprofiler-sdk/counters/controller.hpp"
+#include "lib/rocprofiler-sdk/agent.hpp"
 #include "lib/rocprofiler-sdk/buffer.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
 #include "lib/rocprofiler-sdk/counters/ioctl.hpp"
@@ -142,6 +143,25 @@ CounterController::configure_dispatch(rocprofiler_context_id_t                  
     // FIXME: Due to the clock gating issue, counter collection and PC sampling service
     // cannot coexist in the same context for now.
     if(ctx.pc_sampler) return ROCPROFILER_STATUS_ERROR_CONTEXT_CONFLICT;
+
+    if(counters::counter_collection_has_device_lock())
+    {
+        /**
+         * Note: This should retrun if the lock fails to aquire in the future. However, this
+         * is a change in the required permissions for rocprofiler and needs to be communicated
+         * with partners before strict enforcement. If the required permissions are not obtained,
+         * those profilers will function as they currently do (without any of the benefits of the
+         * IOCTL).
+         */
+        for(const auto& agent : agent::get_agents())
+        {
+            if(agent->type == ROCPROFILER_AGENT_TYPE_GPU)
+            {
+                counters::counter_collection_device_lock(rocprofiler::agent::get_agent(agent->id),
+                                                         false);
+            }
+        }
+    }
 
     if(!ctx.counter_collection)
     {


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Ensure we attempt to get device lock for counter collection during kernel dispatch as well, not just during agent counter collection mode. 

Cherry-pick 68098c4d9007c1682555acb8c29c03eb3ab5ff62...fe62269f302f9b48c83d9e17a7d39e5f54a17c11. Original PR #1781.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Call `counter_collection_device_lock` for dispatch counter collection as well

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
