### PR TITLE
SWDEV-559166 - Remove obsolete member execInfoOffset from KernelParameters

### DIFF
--- a/projects/clr/rocclr/device/pal/palvirtual.cpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.cpp
@@ -3590,7 +3590,7 @@ bool VirtualGPU::processMemObjectsHSA(const amd::Kernel& kernel, const_address p
     }
     // get svm non arugment information
     void* const* svmPtrArray =
-        reinterpret_cast<void* const*>(params + kernelParams.getExecInfoOffset());
+        reinterpret_cast<void* const*>(params + kernelParams.getTotalSize());
     for (size_t i = 0; i < count; i++) {
       amd::Memory* memory = amd::MemObjMap::FindMemObj(svmPtrArray[i]);
       if (nullptr == memory) {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -710,7 +710,7 @@ bool VirtualGPU::processMemObjects(const amd::Kernel& kernel, const_address para
   }
 
   size_t count = kernelParams.getNumberOfSvmPtr();
-  size_t execInfoOffset = kernelParams.getExecInfoOffset();
+  size_t execInfoOffset = kernelParams.getTotalSize();
   bool sync = true;
 
   amd::Memory* memory = nullptr;

--- a/projects/clr/rocclr/platform/kernel.cpp
+++ b/projects/clr/rocclr/platform/kernel.cpp
@@ -304,8 +304,7 @@ address KernelParameters::capture(device::VirtualDevice& vDev, uint64_t lclMemSi
       }
     }
 
-    execInfoOffset_ = totalSize_;
-    address last = mem + execInfoOffset_;
+    address last = mem + totalSize_;
     if (0 != execInfoSize) {
       ::memcpy(last, &execSvmPtr_[0], execInfoSize);
     }

--- a/projects/clr/rocclr/platform/kernel.hpp
+++ b/projects/clr/rocclr/platform/kernel.hpp
@@ -123,7 +123,6 @@ class KernelParameters : protected HeapObject {
   KernelSignature& signature_;
 
   address values_;                      //!< pointer to the base of the values stack.
-  uint32_t execInfoOffset_;             //!< The offset of execInfo
   std::vector<void*> execSvmPtr_;       //!< The non argument svm pointers for kernel
   FGSStatus svmSystemPointersSupport_;  //!< The flag for the status of the kernel
                                         //   support of fine-grain system sharing.
@@ -148,7 +147,6 @@ class KernelParameters : protected HeapObject {
   //! Construct a new instance of parameters for the given signature.
   KernelParameters(KernelSignature& signature)
       : signature_(signature),
-        execInfoOffset_(0),
         svmSystemPointersSupport_(FGS_DEFAULT),
         memoryObjects_(nullptr),
         samplerObjects_(nullptr),
@@ -168,14 +166,12 @@ class KernelParameters : protected HeapObject {
     samplerObjects_ = reinterpret_cast<amd::Sampler**>(values_ + samplerObjOffset_);
     queueObjOffset_ = samplerObjOffset_ + signature_.numSamplers() * sizeof(amd::Sampler*);
     queueObjects_ = reinterpret_cast<amd::DeviceQueue**>(values_ + queueObjOffset_);
-    execInfoOffset_ = totalSize_;
     address limit = reinterpret_cast<address>(&queueObjects_[signature_.numQueues()]);
     ::memset(values_, '\0', limit - values_);
   }
 
   explicit KernelParameters(const KernelParameters& rhs)
       : signature_(rhs.signature_),
-        execInfoOffset_(rhs.execInfoOffset_),
         execSvmPtr_(rhs.execSvmPtr_),
         svmSystemPointersSupport_(rhs.svmSystemPointersSupport_),
         memoryObjects_(nullptr),
@@ -255,7 +251,7 @@ class KernelParameters : protected HeapObject {
   size_t getNumberOfSvmPtr() const { return execSvmPtr_.size(); }
 
   //! get the offset of svmPtr in the parameters
-  uint32_t getExecInfoOffset() const { return execInfoOffset_; }
+  uint32_t getTotalSize() const { return totalSize_; }
 
   //! get the offset of memory objects in the parameters
   uint32_t memoryObjOffset() const { return memoryObjOffset_; }

--- a/projects/clr/rocclr/platform/kernel.hpp
+++ b/projects/clr/rocclr/platform/kernel.hpp
@@ -250,7 +250,7 @@ class KernelParameters : protected HeapObject {
   //! get the number of svmPtr in the execInfo container
   size_t getNumberOfSvmPtr() const { return execSvmPtr_.size(); }
 
-  //! get the offset of svmPtr in the parameters
+  //! Get the total size of parameters / offset where execInfo (SVM pointers) are stored
   uint32_t getTotalSize() const { return totalSize_; }
 
   //! get the offset of memory objects in the parameters


### PR DESCRIPTION
## Motivation
This PR removes the obsolete execInfoOffset_ member variable from the KernelParameters class, simplifying the code by eliminating redundancy. The execInfoOffset_ always held the same value as totalSize_, making it unnecessary.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
## Technical Details

    Removed the redundant execInfoOffset_ member variable and its initializations
    Replaced getExecInfoOffset() method with getTotalSize() to return the offset directly from totalSize_
    Updated all call sites to use the new method name
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
PSDBs should pass
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
PSDB passes
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
