### PR TITLE
SWDEV-561273 - hip samples on TheRock build using HIP LANGUAGE and hi…

### DIFF
--- a/projects/hip-tests/samples/0_Intro/bit_extract/CMakeLists.txt
+++ b/projects/hip-tests/samples/0_Intro/bit_extract/CMakeLists.txt
@@ -18,9 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(bit_extract)
-
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(NOT WIN32 AND NOT DEFINED __HIP_ENABLE_PCH)
   set(__HIP_ENABLE_PCH ON CACHE BOOL "enable/disable pre-compiled hip headers")
@@ -40,14 +38,10 @@ if(UNIX)
   endif()
   # Search for rocm in common locations
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
+  
 endif()
-# Find hip
-find_package(hip)
 
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
+project(bit_extract LANGUAGES CXX HIP)
 
 # Create the excutable
 if(TARGET build_intro)
@@ -55,12 +49,21 @@ set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
 set(EXCLUDE_OPTION )
 endif()
+
+# Mark source file as HIP code (contains __global__ kernels)
+set_source_files_properties(bit_extract.cpp PROPERTIES LANGUAGE HIP)
+
 add_executable(bit_extract ${EXCLUDE_OPTION} bit_extract.cpp)
 
 target_include_directories(bit_extract PRIVATE ../../common)
 
-# Link with HIP
-target_link_libraries(bit_extract hip::host)
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(bit_extract PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 if(TARGET build_intro)
   add_dependencies(build_intro bit_extract)

--- a/projects/hip-tests/samples/0_Intro/generic_target/CMakeLists.txt
+++ b/projects/hip-tests/samples/0_Intro/generic_target/CMakeLists.txt
@@ -18,9 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.10)
-
-project(generic_target)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -34,56 +32,77 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
+project(generic_target LANGUAGES CXX HIP)
+
 # Find hiprtc
-find_package(hiprtc)
-# Find hip
-find_package(hip)
+find_package(hiprtc REQUIRED)
+
+# Find hip (for HIP_PLATFORM check)
+find_package(hip REQUIRED)
 
 if(NOT HIP_PLATFORM MATCHES "amd")
-message("Generic target is only supporte on AMD GPU")
-return()
+  message("Generic target is only supported on AMD GPU")
+  return()
 endif()
-
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
 
 # Create the excutable
 if(TARGET build_intro)
 set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+set(EXCLUDE_OPTION)
 endif()
 
 # Test generic target without feature
 set(OFFLOAD_ARCH_GENERIC_STR "--offload-arch=gfx9-generic --offload-arch=gfx9-4-generic --offload-arch=gfx10-1-generic --offload-arch=gfx10-3-generic --offload-arch=gfx11-generic --offload-arch=gfx12-generic")
+separate_arguments(OFFLOAD_ARCH_GENERIC_LIST UNIX_COMMAND "${OFFLOAD_ARCH_GENERIC_STR}")
+
+# Mark source files as HIP code (contains __global__ kernels and uses HIP APIs)
+set_source_files_properties(square.cpp PROPERTIES LANGUAGE HIP)
+set_source_files_properties(../../../catch/hipTestMain/hip_test_features.cc PROPERTIES LANGUAGE HIP)
 
 add_executable(squareGenericTarget ${EXCLUDE_OPTION} square.cpp ../../../catch/hipTestMain/hip_test_features.cc)
 target_include_directories(squareGenericTarget PRIVATE ../../common ${CMAKE_CURRENT_SOURCE_DIR}/../../../catch/include/)
-set_target_properties(squareGenericTarget PROPERTIES COMPILE_FLAGS "-mcode-object-version=6 -w ${OFFLOAD_ARCH_GENERIC_STR}")
-target_link_libraries(squareGenericTarget hip::host)
+target_compile_options(squareGenericTarget PRIVATE 
+  $<$<COMPILE_LANGUAGE:HIP>:-mcode-object-version=6>
+  $<$<COMPILE_LANGUAGE:HIP>:-w>
+  $<$<COMPILE_LANGUAGE:HIP>:${OFFLOAD_ARCH_GENERIC_LIST}>
+)
 
 # Test generic target with features
 set(OFFLOAD_ARCH_GENERIC_FEATURE_STR "--offload-arch=gfx9-generic --offload-arch=gfx9-4-generic:sramecc+:xnack- --offload-arch=gfx9-4-generic:sramecc-:xnack- --offload-arch=gfx9-4-generic:xnack+ --offload-arch=gfx10-1-generic --offload-arch=gfx10-3-generic --offload-arch=gfx11-generic --offload-arch=gfx12-generic")
+separate_arguments(OFFLOAD_ARCH_GENERIC_FEATURE_LIST UNIX_COMMAND "${OFFLOAD_ARCH_GENERIC_FEATURE_STR}")
 
 add_executable(squareGenericTargetWithFeatures ${EXCLUDE_OPTION} square.cpp ../../../catch/hipTestMain/hip_test_features.cc)
 target_include_directories(squareGenericTargetWithFeatures PRIVATE ../../common ${CMAKE_CURRENT_SOURCE_DIR}/../../../catch/include/)
-set_target_properties(squareGenericTargetWithFeatures PROPERTIES COMPILE_FLAGS "-mcode-object-version=6 -w ${OFFLOAD_ARCH_GENERIC_FEATURE_STR}")
-target_link_libraries(squareGenericTargetWithFeatures hip::host)
+target_compile_options(squareGenericTargetWithFeatures PRIVATE 
+  $<$<COMPILE_LANGUAGE:HIP>:-mcode-object-version=6>
+  $<$<COMPILE_LANGUAGE:HIP>:-w>
+  $<$<COMPILE_LANGUAGE:HIP>:${OFFLOAD_ARCH_GENERIC_FEATURE_LIST}>
+)
 
-# Create the excutable
+# Create the excutable for HIPRTC test
+# Mark source files as HIP code (contains __global__ kernels and uses HIP APIs)
+set_source_files_properties(saxpy.cpp PROPERTIES LANGUAGE HIP)
+# hip_test_features.cc already marked above
+
 add_executable(saxpyGenericTarget ${EXCLUDE_OPTION} saxpy.cpp ../../../catch/hipTestMain/hip_test_features.cc)
+target_include_directories(saxpyGenericTarget PRIVATE ../../common ${CMAKE_CURRENT_SOURCE_DIR}/../../../catch/include/)
 
 # Link with HIPRTC
 target_link_libraries(saxpyGenericTarget hiprtc)
 # Link with HIP
-target_link_libraries(saxpyGenericTarget hip::device)
 
 if(NOT BUILD_SHARED_LIBS)
   target_link_libraries(saxpyGenericTarget hiprtc-builtins)
 endif()
 
-target_include_directories(saxpyGenericTarget PRIVATE ../../common ${CMAKE_CURRENT_SOURCE_DIR}/../../../catch/include/)
+# Set RPATH so executables can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(squareGenericTarget squareGenericTargetWithFeatures saxpyGenericTarget PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 if(TARGET build_intro)
 add_dependencies(build_intro saxpyGenericTarget)

--- a/projects/hip-tests/samples/0_Intro/generic_target/saxpy.cpp
+++ b/projects/hip-tests/samples/0_Intro/generic_target/saxpy.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 #include <cassert>
 #include <cstddef>
+#include <cstring>
 #include <memory>
 #include <iostream>
 #include <iterator>

--- a/projects/hip-tests/samples/0_Intro/module_api/CMakeLists.txt
+++ b/projects/hip-tests/samples/0_Intro/module_api/CMakeLists.txt
@@ -18,11 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(module_api)
-
-cmake_minimum_required(VERSION 3.10)
-
-include_directories(../../common)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -36,41 +32,57 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
-# Find hip
-find_package(hip)
+project(module_api LANGUAGES CXX HIP)
 
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
+# Detect GPU architectures and setup OFFLOAD_ARCH_FLAGS
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../common/DetectGPUArchs.cmake)
 
 # Create the excutable
 if(TARGET build_intro)
 set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+set(EXCLUDE_OPTION)
 endif()
+
+# Mark source files as HIP (they use HIP runtime APIs)
+set_source_files_properties(runKernel.cpp PROPERTIES LANGUAGE HIP)
+set_source_files_properties(launchKernelHcc.cpp PROPERTIES LANGUAGE HIP)
+set_source_files_properties(defaultDriver.cpp PROPERTIES LANGUAGE HIP)
+set_source_files_properties(vcpy_kernel.cpp PROPERTIES LANGUAGE HIP)
 
 add_executable(runKernel.hip.out ${EXCLUDE_OPTION} runKernel.cpp)
 add_executable(launchKernelHcc.hip.out ${EXCLUDE_OPTION} launchKernelHcc.cpp)
 add_executable(defaultDriver.hip.out ${EXCLUDE_OPTION} defaultDriver.cpp)
 
-# Generate code object
-add_custom_target(
-  codeobj
-  COMMAND  ${HIP_HIPCC_EXECUTABLE} --cuda-device-only  ${CMAKE_CURRENT_SOURCE_DIR}/vcpy_kernel.cpp -o vcpy_kernel.code
-  COMMENT "codeobj generated"
+
+# Generate code object using CMake's HIP language support
+# Note: Build for all detected architectures to support multiple GPUs (like hipcc does)
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/vcpy_kernel.code
+  COMMAND ${CMAKE_HIP_COMPILER} -x hip --cuda-device-only ${OFFLOAD_ARCH_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/vcpy_kernel.cpp -o ${CMAKE_CURRENT_BINARY_DIR}/vcpy_kernel.code
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/vcpy_kernel.cpp
+  COMMENT "Generating code object vcpy_kernel.code for ${CMAKE_HIP_ARCHITECTURES}"
+  VERBATIM
 )
+
+add_custom_target(codeobj ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/vcpy_kernel.code)
 
 add_dependencies(runKernel.hip.out codeobj)
 add_dependencies(launchKernelHcc.hip.out codeobj)
 add_dependencies(defaultDriver.hip.out codeobj)
 
-# Link with HIP
-target_link_libraries(runKernel.hip.out hip::host)
-target_link_libraries(launchKernelHcc.hip.out hip::host)
-target_link_libraries(defaultDriver.hip.out hip::host)
+target_include_directories(runKernel.hip.out PRIVATE ../../common)
+target_include_directories(launchKernelHcc.hip.out PRIVATE ../../common)
+target_include_directories(defaultDriver.hip.out PRIVATE ../../common)
+
+# Set RPATH so executables can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(runKernel.hip.out launchKernelHcc.hip.out defaultDriver.hip.out PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 if(TARGET build_intro)
- add_dependencies(build_intro runKernel.hip.out launchKernelHcc.hip.out defaultDriver.hip.out)
+add_dependencies(build_intro runKernel.hip.out launchKernelHcc.hip.out defaultDriver.hip.out)
 endif()

--- a/projects/hip-tests/samples/0_Intro/module_api_global/CMakeLists.txt
+++ b/projects/hip-tests/samples/0_Intro/module_api_global/CMakeLists.txt
@@ -18,9 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(module_api_global)
-
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -34,35 +32,47 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
-# Find hip
-find_package(hip)
+project(module_api_global LANGUAGES CXX HIP)
 
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
+# Detect GPU architectures and setup OFFLOAD_ARCH_FLAGS
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../common/DetectGPUArchs.cmake)
 
 # Create the excutable
 if(TARGET build_intro)
 set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+set(EXCLUDE_OPTION)
 endif()
 
+# Mark source files as HIP (use HIP runtime APIs)
+set_source_files_properties(runKernel.cpp PROPERTIES LANGUAGE HIP)
+set_source_files_properties(vcpy_kernel.cpp PROPERTIES LANGUAGE HIP)
+
 add_executable(runKernel1.hip.out ${EXCLUDE_OPTION} runKernel.cpp)
-# Generate code object
-add_custom_target(
-  codeobj1
-  COMMAND  ${HIP_HIPCC_EXECUTABLE} --cuda-device-only  ${CMAKE_CURRENT_SOURCE_DIR}/vcpy_kernel.cpp -o vcpy_kernel.code
-  COMMENT "codeobj1 generated"
+
+# Generate code object using CMake's HIP language support
+# Note: Build for all detected architectures to support multiple GPUs (like hipcc does)
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/vcpy_kernel.code
+  COMMAND ${CMAKE_HIP_COMPILER} -x hip --cuda-device-only ${OFFLOAD_ARCH_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/vcpy_kernel.cpp -o ${CMAKE_CURRENT_BINARY_DIR}/vcpy_kernel.code
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/vcpy_kernel.cpp
+  COMMENT "Generating code object vcpy_kernel.code for ${CMAKE_HIP_ARCHITECTURES}"
+  VERBATIM
 )
+
+add_custom_target(codeobj1 ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/vcpy_kernel.code)
 
 add_dependencies(runKernel1.hip.out codeobj1)
 
 target_include_directories(runKernel1.hip.out PRIVATE ../../common)
 
-# Link with HIP
-target_link_libraries(runKernel1.hip.out hip::host)
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(runKernel1.hip.out PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 if(TARGET build_intro)
 add_dependencies(build_intro runKernel1.hip.out)

--- a/projects/hip-tests/samples/0_Intro/square/CMakeLists.txt
+++ b/projects/hip-tests/samples/0_Intro/square/CMakeLists.txt
@@ -20,9 +20,7 @@
 
 #Follow "README.md" to generate square.cpp if it's missing
 
-project(square)
-
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -36,27 +34,31 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
+project(square LANGUAGES CXX HIP)
+
 # create square.cpp
 execute_process(COMMAND sh -c "${ROCM_PATH}/bin/hipify-perl \
          ${CMAKE_CURRENT_SOURCE_DIR}/square.cu > ${CMAKE_CURRENT_BINARY_DIR}/square.cpp")
-
-# Find hip
-find_package(hip)
-
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
 
 # Create the excutable
 if(TARGET build_intro)
 set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+set(EXCLUDE_OPTION)
 endif()
+
+# Mark source file as HIP code (contains __global__ kernels)
+set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/square.cpp PROPERTIES LANGUAGE HIP)
+
 add_executable(square ${EXCLUDE_OPTION} ${CMAKE_CURRENT_BINARY_DIR}/square.cpp)
 
-# Link with HIP
-target_link_libraries(square hip::host)
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(square PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 if(TARGET build_intro)
 add_dependencies(build_intro square)

--- a/projects/hip-tests/samples/1_Utils/hipDispatchLatency/CMakeLists.txt
+++ b/projects/hip-tests/samples/1_Utils/hipDispatchLatency/CMakeLists.txt
@@ -18,11 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(hipDispatchLatency)
-
-cmake_minimum_required(VERSION 3.10)
-
-include_directories(../../common)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -36,39 +32,55 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
-# Find hip
-find_package(hip)
+project(hipDispatchLatency LANGUAGES CXX HIP)
 
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
 set(CMAKE_BUILD_TYPE Release)
+
+# Detect GPU architectures and setup OFFLOAD_ARCH_FLAGS
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../common/DetectGPUArchs.cmake)
 
 # Create the excutable
 if(TARGET build_utils)
-set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
+  set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+  set(EXCLUDE_OPTION)
 endif()
+
+# Mark source files as HIP code
+set_source_files_properties(hipDispatchLatency.cpp PROPERTIES LANGUAGE HIP)
+set_source_files_properties(hipDispatchEnqueueRateMT.cpp PROPERTIES LANGUAGE HIP)
+set_source_files_properties(test_kernel.cpp PROPERTIES LANGUAGE HIP)
+
 add_executable(hipDispatchLatency ${EXCLUDE_OPTION} hipDispatchLatency.cpp)
 add_executable(hipDispatchEnqueueRateMT ${EXCLUDE_OPTION} hipDispatchEnqueueRateMT.cpp)
 
-# Generate code object
-add_custom_target(
-  codeobj2
-  COMMAND  ${HIP_HIPCC_EXECUTABLE} --cuda-device-only  ${CMAKE_CURRENT_SOURCE_DIR}/test_kernel.cpp -o test_kernel.code
-  COMMENT "codeobj2 generated"
+# Generate code object using CMake's HIP language support
+# Note: Build for all detected architectures to support multiple GPUs (like hipcc does)
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/test_kernel.code
+  COMMAND ${CMAKE_HIP_COMPILER} -x hip --cuda-device-only ${OFFLOAD_ARCH_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/test_kernel.cpp -o ${CMAKE_CURRENT_BINARY_DIR}/test_kernel.code
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/test_kernel.cpp
+  COMMENT "Generating code object test_kernel.code for ${CMAKE_HIP_ARCHITECTURES}"
+  VERBATIM
 )
+
+add_custom_target(codeobj2 ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/test_kernel.code)
 
 add_dependencies(hipDispatchLatency codeobj2)
 add_dependencies(hipDispatchEnqueueRateMT codeobj2)
 
-# Link with HIP
-target_link_libraries(hipDispatchLatency hip::host)
-target_link_libraries(hipDispatchEnqueueRateMT hip::host)
+target_include_directories(hipDispatchLatency PRIVATE ../../common)
+target_include_directories(hipDispatchEnqueueRateMT PRIVATE ../../common)
+
 if(UNIX)
   target_link_libraries(hipDispatchEnqueueRateMT pthread)
+  # Set RPATH so executables can find HIP libraries at runtime
+  set_target_properties(hipDispatchLatency hipDispatchEnqueueRateMT PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
 endif()
+
 set_property(TARGET hipDispatchLatency PROPERTY CXX_STANDARD 11)
 set_property(TARGET hipDispatchEnqueueRateMT PROPERTY CXX_STANDARD 11)
 

--- a/projects/hip-tests/samples/1_Utils/hipInfo/CMakeLists.txt
+++ b/projects/hip-tests/samples/1_Utils/hipInfo/CMakeLists.txt
@@ -17,12 +17,9 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-project(hipInfo)
 
-# flag is set to ON in compute build for windows
-option(HIPINFO_INTERNAL_BUILD "Enable building hipInfo from compute" OFF)
+cmake_minimum_required(VERSION 3.21)
 
-cmake_minimum_required(VERSION 3.10)
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
     if(DEFINED ENV{ROCM_PATH})
@@ -35,25 +32,54 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --hip-path=${CMAKE_PREFIX_PATH}")
-# Find hip
-find_package(hip)
+# flag is set to ON in compute build for windows
+option(HIPINFO_INTERNAL_BUILD "Enable building hipInfo from compute" OFF)
 
-# Set compiler and linker
+# Windows internal build: Configure HIP compiler before project() to bypass CMake's auto-detection
+# HIPINFO_INTERNAL_BUILD is set by amd_build.py when building as part of compute project
+if(WIN32 AND HIPINFO_INTERNAL_BUILD)
+  # Set HIP compiler to use same as CXX compiler (set by amd_build.py)
+  if(CMAKE_CXX_COMPILER)
+    set(CMAKE_HIP_COMPILER "${CMAKE_CXX_COMPILER}" CACHE FILEPATH "HIP compiler")
+  endif()
+  # Disable CMake's HIP architecture auto-detection (which fails on Windows)
+  set(CMAKE_HIP_ARCHITECTURES OFF CACHE STRING "Disable HIP architecture detection")
+  # Skip CMake's HIP compiler testing phase
+  set(CMAKE_HIP_COMPILER_FORCED TRUE CACHE BOOL "Skip HIP compiler test")
+endif()
+
+project(hipInfo LANGUAGES CXX HIP)
+
 set(CMAKE_BUILD_TYPE Release)
 
 # Create the excutable
 if(TARGET build_utils)
-set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
+  set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+  set(EXCLUDE_OPTION)
 endif()
+
+# Mark source file as HIP code
+set_source_files_properties(hipInfo.cpp PROPERTIES LANGUAGE HIP)
+
 add_executable(hipInfo ${EXCLUDE_OPTION} hipInfo.cpp)
 
-# Link with HIP
-target_link_libraries(hipInfo hip::host)
-
 target_include_directories(hipInfo PRIVATE ../../common)
+
+# Windows: Add HIP compile options since CMAKE_HIP_ARCHITECTURES=OFF disables automatic flag handling
+if(WIN32 AND HIPINFO_INTERNAL_BUILD)
+  target_compile_options(hipInfo PRIVATE $<$<COMPILE_LANGUAGE:HIP>:-x hip --hip-path=${CMAKE_PREFIX_PATH}>)
+  target_link_directories(hipInfo PRIVATE ${CMAKE_PREFIX_PATH}/lib)
+  target_link_libraries(hipInfo PRIVATE amdhip64)
+endif()
+
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(hipInfo PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 # Used only when make install is called
 # when hipInfo is built as part of compute project
@@ -63,5 +89,5 @@ if (WIN32 AND HIPINFO_INTERNAL_BUILD)
 endif()
 
 if(TARGET build_utils)
-add_dependencies(build_utils hipInfo)
+  add_dependencies(build_utils hipInfo)
 endif()

--- a/projects/hip-tests/samples/2_Cookbook/0_MatrixTranspose/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/0_MatrixTranspose/CMakeLists.txt
@@ -18,9 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(MatrixTranspose)
-
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -34,27 +32,32 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
-# Find hip
-find_package(hip)
+project(MatrixTranspose LANGUAGES CXX HIP)
 
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
 set(CMAKE_BUILD_TYPE Release)
 
 # Create the excutable
 if(TARGET build_cookbook)
-set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
+  set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+  set(EXCLUDE_OPTION)
 endif()
+
+# Mark source file as HIP code (contains __global__ kernels)
+set_source_files_properties(MatrixTranspose.cpp PROPERTIES LANGUAGE HIP)
+
 add_executable(MatrixTranspose ${EXCLUDE_OPTION} MatrixTranspose.cpp)
 
 target_include_directories(MatrixTranspose PRIVATE ../../common)
 
-# Link with HIP
-target_link_libraries(MatrixTranspose hip::host)
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(MatrixTranspose PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 if(TARGET build_cookbook)
-add_dependencies(build_cookbook MatrixTranspose)
+  add_dependencies(build_cookbook MatrixTranspose)
 endif()

--- a/projects/hip-tests/samples/2_Cookbook/10_inline_asm/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/10_inline_asm/CMakeLists.txt
@@ -18,9 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(inline_asm)
-
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -34,27 +32,32 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
-# Find hip
-find_package(hip)
+project(inline_asm LANGUAGES CXX HIP)
 
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
 set(CMAKE_BUILD_TYPE Release)
 
 # Create the excutable
 if(TARGET build_cookbook)
-set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
+  set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+  set(EXCLUDE_OPTION)
 endif()
+
+# Mark source file as HIP code (contains __global__ kernels)
+set_source_files_properties(inline_asm.cpp PROPERTIES LANGUAGE HIP)
+
 add_executable(inline_asm ${EXCLUDE_OPTION} inline_asm.cpp)
 
 target_include_directories(inline_asm PRIVATE ../../common)
 
-# Link with HIP
-target_link_libraries(inline_asm hip::host)
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(inline_asm PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 if(TARGET build_cookbook)
-add_dependencies(build_cookbook inline_asm)
+  add_dependencies(build_cookbook inline_asm)
 endif()

--- a/projects/hip-tests/samples/2_Cookbook/11_texture_driver/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/11_texture_driver/CMakeLists.txt
@@ -18,9 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(texture2dDrv)
-
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -34,36 +32,50 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
-# Find hip
-find_package(hip)
+project(texture2dDrv LANGUAGES CXX HIP)
 
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
 set(CMAKE_BUILD_TYPE Release)
+
+# Detect GPU architectures and setup OFFLOAD_ARCH_FLAGS
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../common/DetectGPUArchs.cmake)
 
 # Create the excutable
 if(TARGET build_cookbook)
-set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
+  set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+  set(EXCLUDE_OPTION)
 endif()
+
+# Mark source files as HIP code  
+set_source_files_properties(texture2dDrv.cpp PROPERTIES LANGUAGE HIP)
+set_source_files_properties(tex2dKernel.cpp PROPERTIES LANGUAGE HIP)
+
 add_executable(texture2dDrv ${EXCLUDE_OPTION} texture2dDrv.cpp)
 
-# Generate code object
-add_custom_target(
-  codeobj3
-  COMMAND  ${HIP_HIPCC_EXECUTABLE} --cuda-device-only  ${CMAKE_CURRENT_SOURCE_DIR}/tex2dKernel.cpp -o tex2dKernel.code
-  COMMENT "codeobj3 generated"
+# Generate code object using CMake's HIP language support
+# Note: Build for all detected architectures to support multiple GPUs (like hipcc does)
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/tex2dKernel.code
+  COMMAND ${CMAKE_HIP_COMPILER} -x hip --cuda-device-only ${OFFLOAD_ARCH_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/tex2dKernel.cpp -o ${CMAKE_CURRENT_BINARY_DIR}/tex2dKernel.code
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/tex2dKernel.cpp
+  COMMENT "Generating code object tex2dKernel.code for ${CMAKE_HIP_ARCHITECTURES}"
+  VERBATIM
 )
+
+add_custom_target(codeobj3 ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tex2dKernel.code)
 
 add_dependencies(texture2dDrv codeobj3)
 
 target_include_directories(texture2dDrv PRIVATE ../../common)
 
-# Link with HIP
-target_link_libraries(texture2dDrv hip::host)
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(texture2dDrv PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 if(TARGET build_cookbook)
-add_dependencies(build_cookbook texture2dDrv)
+  add_dependencies(build_cookbook texture2dDrv)
 endif()

--- a/projects/hip-tests/samples/2_Cookbook/11_texture_driver/texture2dDrv.cpp
+++ b/projects/hip-tests/samples/2_Cookbook/11_texture_driver/texture2dDrv.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 #include <iostream>
 #include <fstream>
 #include <vector>
+#include <cstring>
 #include "hip_helper.h"
 
 #define fileName "tex2dKernel.code"
@@ -119,7 +120,7 @@ template <typename T> bool runTest(hipModule_t& module, const char* refName, con
   unsigned int height = 256;
   unsigned int size = width * height * sizeof(T);
   T* hData = (T*)malloc(size);
-  memset(hData, 0, size);
+  std::memset(hData, 0, size);
   for (int i = 0; i < height; i++) {
     for (int j = 0; j < width; j++) {
       initVal(hData[i * width + j]);
@@ -136,12 +137,12 @@ template <typename T> bool runTest(hipModule_t& module, const char* refName, con
                                     hipMemcpyHostToDevice));
 
   hipResourceDesc resDesc;
-  memset(&resDesc, 0, sizeof(resDesc));
+  std::memset(&resDesc, 0, sizeof(resDesc));
   resDesc.resType = hipResourceTypeArray;
   resDesc.res.array.array = array;
 
   hipTextureDesc texDesc;
-  memset(&texDesc, 0, sizeof(texDesc));
+  std::memset(&texDesc, 0, sizeof(texDesc));
   texDesc.addressMode[0] = hipAddressModeClamp;
   texDesc.addressMode[1] = hipAddressModeClamp;
   texDesc.filterMode = hipFilterModePoint;
@@ -180,7 +181,7 @@ template <typename T> bool runTest(hipModule_t& module, const char* refName, con
   checkHipErrors(hipDeviceSynchronize());
 
   T* hOutputData = (T*)malloc(size);
-  memset(hOutputData, 0, size);
+  std::memset(hOutputData, 0, size);
   checkHipErrors(hipMemcpy(hOutputData, dData, size, hipMemcpyDeviceToHost));
 
   for (int i = 0; i < height; i++) {

--- a/projects/hip-tests/samples/2_Cookbook/12_cmake_hip_add_executable/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/12_cmake_hip_add_executable/CMakeLists.txt
@@ -41,6 +41,12 @@ list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 
 set(CMAKE_MODULE_PATH "${HIP_PATH}/lib/cmake/hip/" ${CMAKE_MODULE_PATH})
 set(CMAKE_HIP_ARCHITECTURES OFF)
+
+# Set RPATH for all executables built with hip_add_executable
+if(UNIX)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath,${ROCM_PATH}/lib")
+endif()
+
 project(12_cmake)
 
 set(HIP_CLANG_NUM_PARALLEL_JOBS 2)

--- a/projects/hip-tests/samples/2_Cookbook/13_occupancy/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/13_occupancy/CMakeLists.txt
@@ -18,9 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(occupancy)
-
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -34,27 +32,32 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
-# Find hip
-find_package(hip)
+project(occupancy LANGUAGES CXX HIP)
 
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
 set(CMAKE_BUILD_TYPE Release)
 
 # Create the excutable
 if(TARGET build_cookbook)
-set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
+  set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+  set(EXCLUDE_OPTION)
 endif()
+
+# Mark source file as HIP code (contains __global__ kernels)
+set_source_files_properties(occupancy.cpp PROPERTIES LANGUAGE HIP)
+
 add_executable(occupancy ${EXCLUDE_OPTION} occupancy.cpp)
 
 target_include_directories(occupancy PRIVATE ../../common)
 
-# Link with HIP
-target_link_libraries(occupancy hip::host)
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(occupancy PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 if(TARGET build_cookbook)
-add_dependencies(build_cookbook occupancy)
+  add_dependencies(build_cookbook occupancy)
 endif()

--- a/projects/hip-tests/samples/2_Cookbook/14_gpu_arch/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/14_gpu_arch/CMakeLists.txt
@@ -18,9 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(gpuarch)
-
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -34,27 +32,32 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
-# Find hip
-find_package(hip)
+project(gpuarch LANGUAGES CXX HIP)
 
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
 set(CMAKE_BUILD_TYPE Release)
 
 # Create the excutable
 if(TARGET build_cookbook)
-set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
+  set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+  set(EXCLUDE_OPTION)
 endif()
+
+# Mark source file as HIP code (contains __global__ kernels)
+set_source_files_properties(gpuarch.cpp PROPERTIES LANGUAGE HIP)
+
 add_executable(gpuarch ${EXCLUDE_OPTION} gpuarch.cpp)
 
 target_include_directories(gpuarch PRIVATE ../../common)
 
-# Link with HIP
-target_link_libraries(gpuarch hip::host)
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(gpuarch PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 if(TARGET build_cookbook)
-add_dependencies(build_cookbook gpuarch)
+  add_dependencies(build_cookbook gpuarch)
 endif()

--- a/projects/hip-tests/samples/2_Cookbook/15_static_library/device_functions/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/15_static_library/device_functions/CMakeLists.txt
@@ -1,6 +1,24 @@
-project(static_lib)
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -14,18 +32,14 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
-# Find hip
-find_package(hip REQUIRED)
+project(static_lib LANGUAGES CXX HIP)
 
 # For windows, AR is MS Librarian and that is picked by Visual Studio's command prompt.
-if (WIN32)
+if(WIN32)
   find_program(libpath NAMES lib.exe)
-  set (CMAKE_AR ${libpath})
+  set(CMAKE_AR ${libpath})
 endif()
 
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
 set(CMAKE_BUILD_TYPE Release)
 
 # Turn static library generation ON
@@ -34,15 +48,19 @@ option(BUILD_SHARED_LIBS "Build as a shared library" OFF)
 set(CPP_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/hipDevice.cpp)
 
 # For windows, We need to tell cmake how to create static library.
-if (WIN32)
-  set (CMAKE_CXX_CREATE_STATIC_LIBRARY "<CMAKE_AR> /out:<TARGET> <LINK_FLAGS> <OBJECTS>")
+if(WIN32)
+  set(CMAKE_CXX_CREATE_STATIC_LIBRARY "<CMAKE_AR> /out:<TARGET> <LINK_FLAGS> <OBJECTS>")
 endif()
 
 if(TARGET build_cookbook)
   set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-  set(EXCLUDE_OPTION )
+  set(EXCLUDE_OPTION)
 endif()
+
+# Mark source files as HIP code (contains __device__ functions)
+set_source_files_properties(hipDevice.cpp PROPERTIES LANGUAGE HIP)
+set_source_files_properties(hipMain2.cpp PROPERTIES LANGUAGE HIP)
 
 # Generate static lib libHipDevice.a
 add_library(HipDevice ${EXCLUDE_OPTION} STATIC ${CPP_SOURCES})
@@ -59,13 +77,21 @@ add_dependencies(test_device_static HipDevice)
 target_compile_options(test_device_static PRIVATE -fgpu-rdc)
 
 # For windows, Change in a way to pass lib details
-if (WIN32)
+if(WIN32)
   target_link_libraries(test_device_static PRIVATE -lHipDevice -L${CMAKE_CURRENT_BINARY_DIR})
 else()
   target_link_libraries(test_device_static PRIVATE HipDevice)
 endif()
 
-target_link_libraries(test_device_static PRIVATE -fgpu-rdc hip::amdhip64 amd_comgr)
+target_link_libraries(test_device_static PRIVATE -fgpu-rdc amdhip64 amd_comgr)
+
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(test_device_static PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 if(TARGET build_cookbook)
 add_dependencies(build_cookbook HipDevice test_device_static)

--- a/projects/hip-tests/samples/2_Cookbook/15_static_library/host_functions/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/15_static_library/host_functions/CMakeLists.txt
@@ -1,6 +1,24 @@
-project(static_lib)
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -14,18 +32,14 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
-# Find hip
-find_package(hip REQUIRED)
+project(static_lib LANGUAGES CXX HIP)
 
-# For windows, AR is MS Librarian and that is pickedby Visual Studio's command prompt.
-if (WIN32)
+# For windows, AR is MS Librarian and that is picked by Visual Studio's command prompt.
+if(WIN32)
   find_program(libpath NAMES lib.exe)
-  set (CMAKE_AR ${libpath})
+  set(CMAKE_AR ${libpath})
 endif()
 
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
 set(CMAKE_BUILD_TYPE Release)
 
 # Turn static library generation ON
@@ -34,22 +48,26 @@ option(BUILD_SHARED_LIBS "Build as a shared library" OFF)
 set(CPP_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/hipOptLibrary.cpp)
 
 # For windows, We need to tell cmake how to create static library.
-if (WIN32)
-  set (CMAKE_CXX_CREATE_STATIC_LIBRARY "<CMAKE_AR> /out:<TARGET> <LINK_FLAGS> <OBJECTS>")
+if(WIN32)
+  set(CMAKE_CXX_CREATE_STATIC_LIBRARY "<CMAKE_AR> /out:<TARGET> <LINK_FLAGS> <OBJECTS>")
 endif()
 
 if(TARGET build_cookbook)
   set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-  set(EXCLUDE_OPTION )
+  set(EXCLUDE_OPTION)
 endif()
 
 set(TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/hipMain1.cpp)
 
-# Generate static lib libHipOptLibrary.a.
+# Mark source files as HIP code
+set_source_files_properties(hipOptLibrary.cpp PROPERTIES LANGUAGE HIP)
+set_source_files_properties(hipMain1.cpp PROPERTIES LANGUAGE HIP)
+
+# Generate static lib libHipOptLibrary.a
 add_library(HipOptLibrary ${EXCLUDE_OPTION} STATIC ${CPP_SOURCES})
 
-# Set-up the correct flags to generate the static library.
+# Set-up the correct flags to generate the static library
 target_link_options(HipOptLibrary PRIVATE --emit-static-lib)
 target_include_directories(HipOptLibrary PRIVATE /opt/rocm/hsa/include)
 
@@ -58,10 +76,18 @@ add_executable(test_opt_static ${EXCLUDE_OPTION} ${TEST_SOURCES})
 add_dependencies(test_opt_static HipOptLibrary)
 target_link_libraries(test_opt_static PRIVATE -lHipOptLibrary -L${CMAKE_CURRENT_BINARY_DIR})
 
-if (WIN32)
+if(WIN32)
   target_link_libraries(test_opt_static PRIVATE amdhip64 amd_comgr)
 else()
-  target_link_libraries(test_opt_static PRIVATE amdhip64 amd_comgr hsa-runtime64::hsa-runtime64)
+  target_link_libraries(test_opt_static PRIVATE amdhip64 amd_comgr hsa-runtime64)
+endif()
+
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(test_opt_static PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
 endif()
 
 if(TARGET build_cookbook)

--- a/projects/hip-tests/samples/2_Cookbook/16_assembly_to_executable/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/16_assembly_to_executable/CMakeLists.txt
@@ -1,6 +1,24 @@
-project(asm_to_exe)
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -11,24 +29,25 @@ if(UNIX)
     endif()
   endif()
   if(NOT DEFINED HIP_PATH)
-  if(NOT DEFINED ENV{HIP_PATH})
+    if(NOT DEFINED ENV{HIP_PATH})
       set(HIP_PATH ${ROCM_PATH} CACHE PATH "Path to which HIP has been installed")
-  else()
+    else()
       set(HIP_PATH $ENV{HIP_PATH} CACHE PATH "Path to which HIP has been installed")
-  endif()
+    endif()
   endif()
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
+project(asm_to_exe LANGUAGES CXX HIP)
 
-# Find hip
+# Find hip (for HIP_PLATFORM check)
 find_package(hip REQUIRED)
 
-# Set compiler and linker
-set(HIPCC ${HIP_HIPCC_EXECUTABLE})
-set(CLANG   ${HIP_PATH}/llvm/bin/clang)
-set(LLVM_MC   ${HIP_PATH}/llvm/bin/llvm-mc)
-set(CLANG_OFFLOAD_BUNDLER   ${HIP_PATH}/llvm/bin/clang-offload-bundler)
+# Set compiler and toolchain paths - using amdclang++ directly
+set(HIP_CLANG ${CMAKE_HIP_COMPILER})
+set(CLANG ${HIP_PATH}/llvm/bin/clang)
+set(LLVM_MC ${HIP_PATH}/llvm/bin/llvm-mc)
+set(CLANG_OFFLOAD_BUNDLER ${HIP_PATH}/llvm/bin/clang-offload-bundler)
 
 set(INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../../common)
 
@@ -36,56 +55,57 @@ set(SRCS ${CMAKE_CURRENT_SOURCE_DIR}/square.cpp)
 set(SQ_HOST_ASM ${CMAKE_CURRENT_BINARY_DIR}/square_host.s)
 set(SQ_HOST_OBJ ${CMAKE_CURRENT_BINARY_DIR}/square_host.o)
 set(SQ_DEVICE_HIPFB ${CMAKE_CURRENT_BINARY_DIR}/offload_bundle.hipfb)
-set(SQ_DEVICE_OBJ   ${CMAKE_CURRENT_BINARY_DIR}/square_device.o)
+set(SQ_DEVICE_OBJ ${CMAKE_CURRENT_BINARY_DIR}/square_device.o)
 set(SQ_ASM_EXE ${CMAKE_CURRENT_BINARY_DIR}/square_asm.out)
 
 set(MCIN_OBJ_GEN ${CMAKE_CURRENT_SOURCE_DIR}/hip_obj_gen.mcin)
 
-# Append Current device arch from rocm_agent_enumerator
-# if rocm_agent_enumerator is not found, support --offload-arch
-# to pass arch use format like -DOFFLOAD_ARCH_STR="--offload-arch=gfx1032  --offload-arch=gfx1031"
+# Append Current device arch from amdgpu-arch
+# if amdgpu-arch is not found, support --offload-arch
+# to pass arch use format like -DOFFLOAD_ARCH_STR="--offload-arch=gfx1032 --offload-arch=gfx1031"
 if(UNIX)
-set(ARCH_PATH "${ROCM_PATH}/llvm/bin/amdgpu-arch")
+  set(ARCH_PATH "${ROCM_PATH}/llvm/bin/amdgpu-arch")
 else()
-set(ARCH_PATH "${ROCM_PATH}/bin/amdgpu-arch")
+  set(ARCH_PATH "${ROCM_PATH}/bin/amdgpu-arch")
 endif()
 
 if(NOT DEFINED OFFLOAD_ARCH_STR
    AND EXISTS "${ARCH_PATH}"
    AND HIP_PLATFORM STREQUAL "amd")
-    execute_process(COMMAND "${ARCH_PATH}"
-         OUTPUT_VARIABLE HIP_GPU_ARCH
-         RESULT_VARIABLE ROCM_AGENT_ENUM_RESULT
-         OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if (NOT HIP_GPU_ARCH STREQUAL "")
-          string(REGEX REPLACE "\n" ";" HIP_GPU_ARCH_LIST "${HIP_GPU_ARCH}")
-          list(REMOVE_DUPLICATES  HIP_GPU_ARCH_LIST)
-          foreach(_hip_gpu_arch ${HIP_GPU_ARCH_LIST})
-              list(APPEND GPU_ARCH ${_hip_gpu_arch})
-          endforeach()
-    else()
-          message(STATUS "ROCm Agent Enumerator found no valid architectures")
-    endif()
-elseif(DEFINED OFFLOAD_ARCH_STR)
-    string(REPLACE "--offload-arch=" ""  HIP_GPU_ARCH_LIST ${OFFLOAD_ARCH_STR})
-    string(REGEX REPLACE " " ";" HIP_GPU_ARCH_LIST "${HIP_GPU_ARCH_LIST}")
+  execute_process(COMMAND "${ARCH_PATH}"
+    OUTPUT_VARIABLE HIP_GPU_ARCH
+    RESULT_VARIABLE ROCM_AGENT_ENUM_RESULT
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(NOT HIP_GPU_ARCH STREQUAL "")
+    string(REGEX REPLACE "\n" ";" HIP_GPU_ARCH_LIST "${HIP_GPU_ARCH}")
+    list(REMOVE_DUPLICATES HIP_GPU_ARCH_LIST)
     foreach(_hip_gpu_arch ${HIP_GPU_ARCH_LIST})
-          list(APPEND GPU_ARCH ${_hip_gpu_arch})
+      list(APPEND GPU_ARCH ${_hip_gpu_arch})
     endforeach()
+  else()
+    message(STATUS "amdgpu-arch found no valid architectures")
+  endif()
+elseif(DEFINED OFFLOAD_ARCH_STR)
+  string(REPLACE "--offload-arch=" "" HIP_GPU_ARCH_LIST ${OFFLOAD_ARCH_STR})
+  string(REGEX REPLACE " " ";" HIP_GPU_ARCH_LIST "${HIP_GPU_ARCH_LIST}")
+  foreach(_hip_gpu_arch ${HIP_GPU_ARCH_LIST})
+    list(APPEND GPU_ARCH ${_hip_gpu_arch})
+  endforeach()
 endif()
 
 if(TARGET build_cookbook)
-set(ALL_OPTION )
+  set(ALL_OPTION)
 else()
-set(ALL_OPTION ALL )
+  set(ALL_OPTION ALL)
 endif()
 
 list(JOIN GPU_ARCH "," OFFLOAD_ARCH)
-add_custom_target(src_to_asm ${ALL_OPTION}  COMMAND ${HIPCC} -c -S -I${INCLUDES} --cuda-host-only -fuse-cuid=none -target x86_64-linux-gnu -o ${SQ_HOST_ASM} ${SRCS}
-                               COMMAND ${HIPCC} -c -S -I${INCLUDES} --cuda-device-only --offload-arch=${OFFLOAD_ARCH} ${SRCS})
+add_custom_target(src_to_asm ${ALL_OPTION}
+  COMMAND ${HIP_CLANG} -x hip -c -S -I${INCLUDES} --cuda-host-only -fuse-cuid=none -target x86_64-linux-gnu -o ${SQ_HOST_ASM} ${SRCS}
+  COMMAND ${HIP_CLANG} -x hip -c -S -I${INCLUDES} --cuda-device-only --offload-arch=${OFFLOAD_ARCH} ${SRCS}
+)
 
-
-add_custom_command(OUTPUT host_obj COMMAND ${HIPCC} -c ${SQ_HOST_ASM} -o ${SQ_HOST_OBJ})
+add_custom_command(OUTPUT host_obj COMMAND ${HIP_CLANG} -c ${SQ_HOST_ASM} -o ${SQ_HOST_OBJ})
 
 foreach(ARCH ${GPU_ARCH})
   list(APPEND TARGETS hip-amdgcn-amd-amdhsa--${ARCH})
@@ -98,10 +118,11 @@ endforeach()
 list(JOIN TARGETS "," TARGET_STR)
 list(TRANSFORM INPUTS PREPEND "-input=")
 add_custom_target(asm_to_exec ${ALL_OPTION} DEPENDS src_to_asm host_obj ${arch_obj_targets}
-                               COMMAND ${CLANG_OFFLOAD_BUNDLER} -type=o -bundle-align=4096 -targets=host-x86_64-unknown--linux,${TARGET_STR} -input=/dev/null ${INPUTS} -output=${SQ_DEVICE_HIPFB}
-                               COMMAND ${LLVM_MC} ${MCIN_OBJ_GEN} -o ${SQ_DEVICE_OBJ} --filetype=obj
-                               COMMAND ${HIPCC} ${SQ_HOST_OBJ} ${SQ_DEVICE_OBJ} -o ${SQ_ASM_EXE})
+  COMMAND ${CLANG_OFFLOAD_BUNDLER} -type=o -bundle-align=4096 -targets=host-x86_64-unknown--linux,${TARGET_STR} -input=/dev/null ${INPUTS} -output=${SQ_DEVICE_HIPFB}
+  COMMAND ${LLVM_MC} ${MCIN_OBJ_GEN} -o ${SQ_DEVICE_OBJ} --filetype=obj
+  COMMAND ${HIP_CLANG} ${SQ_HOST_OBJ} ${SQ_DEVICE_OBJ} -o ${SQ_ASM_EXE} -L${ROCM_PATH}/lib -lamdhip64 -Wl,-rpath,${ROCM_PATH}/lib
+)
 
 if(TARGET build_cookbook)
-add_dependencies(build_cookbook src_to_asm asm_to_exec)
+  add_dependencies(build_cookbook src_to_asm asm_to_exec)
 endif()

--- a/projects/hip-tests/samples/2_Cookbook/17_llvm_ir_to_executable/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/17_llvm_ir_to_executable/CMakeLists.txt
@@ -1,6 +1,24 @@
-project(llvm_ir_to_exe)
+# Copyright (c) 2020 - 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -11,24 +29,25 @@ if(UNIX)
     endif()
   endif()
   if(NOT DEFINED HIP_PATH)
-  if(NOT DEFINED ENV{HIP_PATH})
+    if(NOT DEFINED ENV{HIP_PATH})
       set(HIP_PATH ${ROCM_PATH} CACHE PATH "Path to which HIP has been installed")
-  else()
+    else()
       set(HIP_PATH $ENV{HIP_PATH} CACHE PATH "Path to which HIP has been installed")
-  endif()
+    endif()
   endif()
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
+project(llvm_ir_to_exe LANGUAGES CXX HIP)
 
-# Find hip
+# Find hip (for HIP_PLATFORM check)
 find_package(hip REQUIRED)
 
-# Set compiler and linker
-set(HIPCC ${HIP_HIPCC_EXECUTABLE})
-set(CLANG   ${HIP_PATH}/llvm/bin/clang)
-set(LLVM_MC   ${HIP_PATH}/llvm/bin/llvm-mc)
-set(CLANG_OFFLOAD_BUNDLER   ${HIP_PATH}/llvm/bin/clang-offload-bundler)
+# Set compiler and toolchain paths - using amdclang++ directly
+set(HIP_CLANG ${CMAKE_HIP_COMPILER})
+set(CLANG ${HIP_PATH}/llvm/bin/clang)
+set(LLVM_MC ${HIP_PATH}/llvm/bin/llvm-mc)
+set(CLANG_OFFLOAD_BUNDLER ${HIP_PATH}/llvm/bin/clang-offload-bundler)
 set(LLVM_AS ${HIP_PATH}/llvm/bin/llvm-as)
 set(LLVM_DIS ${HIP_PATH}/llvm/bin/llvm-dis)
 
@@ -39,54 +58,56 @@ set(SQ_HOST_BC ${CMAKE_CURRENT_BINARY_DIR}/square_host.bc)
 set(SQ_HOST_LL ${CMAKE_CURRENT_BINARY_DIR}/square_host.ll)
 set(SQ_HOST_OBJ ${CMAKE_CURRENT_BINARY_DIR}/square_host.o)
 set(SQ_DEVICE_HIPFB ${CMAKE_CURRENT_BINARY_DIR}/offload_bundle.hipfb)
-set(SQ_DEVICE_OBJ   ${CMAKE_CURRENT_BINARY_DIR}/square_device.o)
+set(SQ_DEVICE_OBJ ${CMAKE_CURRENT_BINARY_DIR}/square_device.o)
 set(SQ_IR_EXE ${CMAKE_CURRENT_BINARY_DIR}/square_ir.out)
 
 set(MCIN_OBJ_GEN ${CMAKE_CURRENT_SOURCE_DIR}/hip_obj_gen.mcin)
 
-# Append Current device arch from rocm_agent_enumerator
-# if rocm_agent_enumerator is not found, support --offload-arch
-# to pass arch use format like -DOFFLOAD_ARCH_STR="--offload-arch=gfx1032  --offload-arch=gfx1031"
+# Append Current device arch from amdgpu-arch
+# if amdgpu-arch is not found, support --offload-arch
+# to pass arch use format like -DOFFLOAD_ARCH_STR="--offload-arch=gfx1032 --offload-arch=gfx1031"
 
 if(UNIX)
-set(ARCH_PATH "${ROCM_PATH}/llvm/bin/amdgpu-arch")
+  set(ARCH_PATH "${ROCM_PATH}/llvm/bin/amdgpu-arch")
 else()
-set(ARCH_PATH "${ROCM_PATH}/bin/amdgpu-arch")
+  set(ARCH_PATH "${ROCM_PATH}/bin/amdgpu-arch")
 endif()
 
 if(NOT DEFINED OFFLOAD_ARCH_STR
    AND EXISTS "${ARCH_PATH}"
    AND HIP_PLATFORM STREQUAL "amd")
-    execute_process(COMMAND "${ARCH_PATH}"
-         OUTPUT_VARIABLE HIP_GPU_ARCH
-         RESULT_VARIABLE ROCM_AGENT_ENUM_RESULT
-         OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if (NOT HIP_GPU_ARCH STREQUAL "")
-          string(REGEX REPLACE "\n" ";" HIP_GPU_ARCH_LIST "${HIP_GPU_ARCH}")
-          list(REMOVE_DUPLICATES  HIP_GPU_ARCH_LIST)
-          foreach(_hip_gpu_arch ${HIP_GPU_ARCH_LIST})
-              list(APPEND GPU_ARCH ${_hip_gpu_arch})
-          endforeach()
-    else()
-          message(STATUS "ROCm Agent Enumerator found no valid architectures")
-    endif()
-elseif(DEFINED OFFLOAD_ARCH_STR)
-    string(REPLACE "--offload-arch=" ""  HIP_GPU_ARCH_LIST ${OFFLOAD_ARCH_STR})
-    string(REGEX REPLACE " " ";" HIP_GPU_ARCH_LIST "${HIP_GPU_ARCH_LIST}")
+  execute_process(COMMAND "${ARCH_PATH}"
+    OUTPUT_VARIABLE HIP_GPU_ARCH
+    RESULT_VARIABLE ROCM_AGENT_ENUM_RESULT
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(NOT HIP_GPU_ARCH STREQUAL "")
+    string(REGEX REPLACE "\n" ";" HIP_GPU_ARCH_LIST "${HIP_GPU_ARCH}")
+    list(REMOVE_DUPLICATES HIP_GPU_ARCH_LIST)
     foreach(_hip_gpu_arch ${HIP_GPU_ARCH_LIST})
-          list(APPEND GPU_ARCH ${_hip_gpu_arch})
+      list(APPEND GPU_ARCH ${_hip_gpu_arch})
     endforeach()
+  else()
+    message(STATUS "amdgpu-arch found no valid architectures")
+  endif()
+elseif(DEFINED OFFLOAD_ARCH_STR)
+  string(REPLACE "--offload-arch=" "" HIP_GPU_ARCH_LIST ${OFFLOAD_ARCH_STR})
+  string(REGEX REPLACE " " ";" HIP_GPU_ARCH_LIST "${HIP_GPU_ARCH_LIST}")
+  foreach(_hip_gpu_arch ${HIP_GPU_ARCH_LIST})
+    list(APPEND GPU_ARCH ${_hip_gpu_arch})
+  endforeach()
 endif()
 
 if(TARGET build_cookbook)
-set(ALL_OPTION )
+  set(ALL_OPTION)
 else()
-set(ALL_OPTION ALL )
+  set(ALL_OPTION ALL)
 endif()
 
 list(JOIN GPU_ARCH "," OFFLOAD_ARCH)
-add_custom_target(src_to_ir ${ALL_OPTION} COMMAND ${HIPCC} -c -emit-llvm -I${INCLUDES} --cuda-host-only -fuse-cuid=none -target x86_64-linux-gnu -o ${SQ_HOST_BC} ${SRCS}
-                                COMMAND ${HIPCC} -c -emit-llvm -I${INCLUDES} --cuda-device-only --offload-arch=${OFFLOAD_ARCH} ${SRCS})
+add_custom_target(src_to_ir ${ALL_OPTION}
+  COMMAND ${HIP_CLANG} -x hip -c -emit-llvm -I${INCLUDES} --cuda-host-only -fuse-cuid=none -target x86_64-linux-gnu -o ${SQ_HOST_BC} ${SRCS}
+  COMMAND ${HIP_CLANG} -x hip -c -emit-llvm -I${INCLUDES} --cuda-device-only --offload-arch=${OFFLOAD_ARCH} ${SRCS}
+)
 
 # Target for BC to LL
 add_custom_command(OUTPUT ll_obj COMMAND ${LLVM_DIS} ${SQ_HOST_BC} -o ${SQ_HOST_LL})
@@ -110,11 +131,11 @@ endforeach()
 add_custom_target(ll_to_bc ${ALL_OPTION} DEPENDS bc_to_ll bc_obj ${arch_bc_obj})
 
 # Target for IR to EXEC
-add_custom_command(OUTPUT host_obj COMMAND ${HIPCC} -c ${SQ_HOST_BC} -o ${SQ_HOST_OBJ})
+add_custom_command(OUTPUT host_obj COMMAND ${HIP_CLANG} -c ${SQ_HOST_BC} -o ${SQ_HOST_OBJ})
 
 foreach(ARCH ${GPU_ARCH})
   set(arch_obj ${ARCH}_obj)
-  add_custom_command(OUTPUT ${arch_obj}  COMMAND ${CLANG} -target amdgcn-amd-amdhsa -mcpu=${ARCH} square-hip-amdgcn-amd-amdhsa-${ARCH}.bc -o square-hip-amdgcn-amd-amdhsa-${ARCH}.o)
+  add_custom_command(OUTPUT ${arch_obj} COMMAND ${CLANG} -target amdgcn-amd-amdhsa -mcpu=${ARCH} square-hip-amdgcn-amd-amdhsa-${ARCH}.bc -o square-hip-amdgcn-amd-amdhsa-${ARCH}.o)
   list(APPEND arch_obj_list ${arch_obj})
   list(APPEND TARGETS hip-amdgcn-amd-amdhsa--${ARCH})
   list(APPEND INPUTS square-hip-amdgcn-amd-amdhsa-${ARCH}.o)
@@ -123,10 +144,11 @@ endforeach()
 list(JOIN TARGETS "," TARGET_STR)
 list(TRANSFORM INPUTS PREPEND "-input=")
 add_custom_target(ir_to_exec ${ALL_OPTION} DEPENDS ll_to_bc host_obj ${arch_obj_list}
-                            COMMAND ${CLANG_OFFLOAD_BUNDLER} -type=o -bundle-align=4096 -targets=host-x86_64-unknown--linux,${TARGET_STR} -input=/dev/null ${INPUTS} -output=${SQ_DEVICE_HIPFB}
-                            COMMAND ${LLVM_MC} ${MCIN_OBJ_GEN} -o ${SQ_DEVICE_OBJ} --filetype=obj
-                            COMMAND ${HIPCC} ${SQ_HOST_OBJ} ${SQ_DEVICE_OBJ} -o ${SQ_IR_EXE})
+  COMMAND ${CLANG_OFFLOAD_BUNDLER} -type=o -bundle-align=4096 -targets=host-x86_64-unknown--linux,${TARGET_STR} -input=/dev/null ${INPUTS} -output=${SQ_DEVICE_HIPFB}
+  COMMAND ${LLVM_MC} ${MCIN_OBJ_GEN} -o ${SQ_DEVICE_OBJ} --filetype=obj
+  COMMAND ${HIP_CLANG} ${SQ_HOST_OBJ} ${SQ_DEVICE_OBJ} -o ${SQ_IR_EXE} -L${ROCM_PATH}/lib -lamdhip64 -Wl,-rpath,${ROCM_PATH}/lib
+)
 
 if(TARGET build_cookbook)
-add_dependencies(build_cookbook src_to_ir bc_to_ll ll_to_bc ir_to_exec)
+  add_dependencies(build_cookbook src_to_ir bc_to_ll ll_to_bc ir_to_exec)
 endif()

--- a/projects/hip-tests/samples/2_Cookbook/1_hipEvent/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/1_hipEvent/CMakeLists.txt
@@ -18,9 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(hipEvent)
-
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -34,27 +32,32 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
-# Find hip
-find_package(hip)
+project(hipEvent LANGUAGES CXX HIP)
 
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
 set(CMAKE_BUILD_TYPE Release)
 
 # Create the excutable
 if(TARGET build_cookbook)
-set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
+  set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+  set(EXCLUDE_OPTION)
 endif()
+
+# Mark source file as HIP code (contains __global__ kernels)
+set_source_files_properties(hipEvent.cpp PROPERTIES LANGUAGE HIP)
+
 add_executable(hipEvent ${EXCLUDE_OPTION} hipEvent.cpp)
 
 target_include_directories(hipEvent PRIVATE ../../common)
 
-# Link with HIP
-target_link_libraries(hipEvent hip::host)
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(hipEvent PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 if(TARGET build_cookbook)
-add_dependencies(build_cookbook hipEvent)
+  add_dependencies(build_cookbook hipEvent)
 endif()

--- a/projects/hip-tests/samples/2_Cookbook/22_cmake_hip_lang/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/22_cmake_hip_lang/CMakeLists.txt
@@ -47,6 +47,14 @@ add_executable(square2 ${EXCLUDE_OPTION} square.hip)
 
 target_include_directories(square2 PRIVATE ../../common)
 
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(square2 PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
+
 if(TARGET build_cookbook)
 add_dependencies(build_cookbook square2)
 endif()

--- a/projects/hip-tests/samples/2_Cookbook/3_shared_memory/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/3_shared_memory/CMakeLists.txt
@@ -18,9 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(sharedMemory)
-
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -34,27 +32,32 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
-# Find hip
-find_package(hip)
+project(sharedMemory LANGUAGES CXX HIP)
 
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
 set(CMAKE_BUILD_TYPE Release)
 
 # Create the excutable
 if(TARGET build_cookbook)
-set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
+  set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+  set(EXCLUDE_OPTION)
 endif()
+
+# Mark source file as HIP code (contains __global__ kernels)
+set_source_files_properties(sharedMemory.cpp PROPERTIES LANGUAGE HIP)
+
 add_executable(sharedMemory ${EXCLUDE_OPTION} sharedMemory.cpp)
 
 target_include_directories(sharedMemory PRIVATE ../../common)
 
-# Link with HIP
-target_link_libraries(sharedMemory hip::host)
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(sharedMemory PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 if(TARGET build_cookbook)
-add_dependencies(build_cookbook sharedMemory)
+  add_dependencies(build_cookbook sharedMemory)
 endif()

--- a/projects/hip-tests/samples/2_Cookbook/4_shfl/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/4_shfl/CMakeLists.txt
@@ -18,9 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(shfl)
-
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -34,27 +32,32 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
-# Find hip
-find_package(hip)
+project(shfl LANGUAGES CXX HIP)
 
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
 set(CMAKE_BUILD_TYPE Release)
 
 # Create the excutable
 if(TARGET build_cookbook)
-set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
+  set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+  set(EXCLUDE_OPTION)
 endif()
+
+# Mark source file as HIP code (contains __global__ kernels)
+set_source_files_properties(shfl.cpp PROPERTIES LANGUAGE HIP)
+
 add_executable(shfl ${EXCLUDE_OPTION} shfl.cpp)
 
 target_include_directories(shfl PRIVATE ../../common)
 
-# Link with HIP
-target_link_libraries(shfl hip::host)
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(shfl PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 if(TARGET build_cookbook)
-add_dependencies(build_cookbook shfl)
+  add_dependencies(build_cookbook shfl)
 endif()

--- a/projects/hip-tests/samples/2_Cookbook/5_2dshfl/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/5_2dshfl/CMakeLists.txt
@@ -18,9 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(2dshfl)
-
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -34,26 +32,30 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
-# Find hip
-find_package(hip)
-
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
+project(2dshfl LANGUAGES CXX HIP)
 
 # Create the excutable
 if(TARGET build_cookbook)
-set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
+  set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+  set(EXCLUDE_OPTION)
 endif()
+
+# Mark source file as HIP code (contains __global__ kernels)
+set_source_files_properties(2dshfl.cpp PROPERTIES LANGUAGE HIP)
+
 add_executable(2dshfl ${EXCLUDE_OPTION} 2dshfl.cpp)
 
 target_include_directories(2dshfl PRIVATE ../../common)
 
-# Link with HIP
-target_link_libraries(2dshfl hip::host)
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(2dshfl PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 if(TARGET build_cookbook)
-add_dependencies(build_cookbook 2dshfl)
+  add_dependencies(build_cookbook 2dshfl)
 endif()

--- a/projects/hip-tests/samples/2_Cookbook/6_dynamic_shared/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/6_dynamic_shared/CMakeLists.txt
@@ -18,11 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(dynamic_shared)
-
-cmake_minimum_required(VERSION 3.10)
-
-include_directories(../../common)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -36,26 +32,30 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
-# Find hip
-find_package(hip)
-
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
+project(dynamic_shared LANGUAGES CXX HIP)
 
 # Create the excutable
 if(TARGET build_cookbook)
-set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
+  set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+  set(EXCLUDE_OPTION)
 endif()
+
+# Mark source file as HIP code (contains __global__ kernels)
+set_source_files_properties(dynamic_shared.cpp PROPERTIES LANGUAGE HIP)
+
 add_executable(dynamic_shared ${EXCLUDE_OPTION} dynamic_shared.cpp)
 
 target_include_directories(dynamic_shared PRIVATE ../../common)
 
-# Link with HIP
-target_link_libraries(dynamic_shared hip::host)
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(dynamic_shared PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 if(TARGET build_cookbook)
-add_dependencies(build_cookbook dynamic_shared)
+  add_dependencies(build_cookbook dynamic_shared)
 endif()

--- a/projects/hip-tests/samples/2_Cookbook/7_streams/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/7_streams/CMakeLists.txt
@@ -18,9 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(stream)
-
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -34,26 +32,30 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
-# Find hip
-find_package(hip)
-
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
+project(stream LANGUAGES CXX HIP)
 
 # Create the excutable
 if(TARGET build_cookbook)
-set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
+  set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+  set(EXCLUDE_OPTION)
 endif()
+
+# Mark source file as HIP code (contains __global__ kernels)
+set_source_files_properties(stream.cpp PROPERTIES LANGUAGE HIP)
+
 add_executable(stream ${EXCLUDE_OPTION} stream.cpp)
 
 target_include_directories(stream PRIVATE ../../common)
 
-# Link with HIP
-target_link_libraries(stream hip::host)
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(stream PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
-if(TARGET cookbook)
-add_dependencies(build_cookbook stream)
+if(TARGET build_cookbook)
+  add_dependencies(build_cookbook stream)
 endif()

--- a/projects/hip-tests/samples/2_Cookbook/8_peer2peer/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/8_peer2peer/CMakeLists.txt
@@ -18,9 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(peer2peer)
-
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -33,24 +31,29 @@ if(UNIX)
   # Search for rocm in common locations
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
-# Find hip
-find_package(hip)
 
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
+project(peer2peer LANGUAGES CXX HIP)
 
 # Create the excutable
 if(TARGET build_cookbook)
-set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
+  set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+  set(EXCLUDE_OPTION)
 endif()
+
+# Mark source file as HIP code (contains __global__ kernels)
+set_source_files_properties(peer2peer.cpp PROPERTIES LANGUAGE HIP)
+
 add_executable(peer2peer ${EXCLUDE_OPTION} peer2peer.cpp)
 
-# Link with HIP
-target_link_libraries(peer2peer hip::host)
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(peer2peer PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 if(TARGET build_cookbook)
-add_dependencies(build_cookbook peer2peer)
+  add_dependencies(build_cookbook peer2peer)
 endif()

--- a/projects/hip-tests/samples/2_Cookbook/9_unroll/CMakeLists.txt
+++ b/projects/hip-tests/samples/2_Cookbook/9_unroll/CMakeLists.txt
@@ -18,9 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-project(unroll)
-
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 if(UNIX)
   if(NOT DEFINED ROCM_PATH)
@@ -34,26 +32,30 @@ if(UNIX)
   list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})
 endif()
 
-# Find hip
-find_package(hip)
-
-# Set compiler and linker
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-set(CMAKE_CXX_LINKER   ${HIP_HIPCC_EXECUTABLE})
+project(unroll LANGUAGES CXX HIP)
 
 # Create the excutable
 if(TARGET build_cookbook)
-set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
+  set(EXCLUDE_OPTION EXCLUDE_FROM_ALL)
 else()
-set(EXCLUDE_OPTION )
+  set(EXCLUDE_OPTION)
 endif()
+
+# Mark source file as HIP code (contains __global__ kernels)
+set_source_files_properties(unroll.cpp PROPERTIES LANGUAGE HIP)
+
 add_executable(unroll ${EXCLUDE_OPTION} unroll.cpp)
 
 target_include_directories(unroll PRIVATE ../../common)
 
-# Link with HIP
-target_link_libraries(unroll hip::host)
+# Set RPATH so executable can find HIP libraries at runtime
+if(UNIX)
+  set_target_properties(unroll PROPERTIES
+    BUILD_RPATH "${ROCM_PATH}/lib"
+    INSTALL_RPATH "${ROCM_PATH}/lib"
+  )
+endif()
 
 if(TARGET build_cookbook)
-add_dependencies(build_cookbook unroll)
+  add_dependencies(build_cookbook unroll)
 endif()

--- a/projects/hip-tests/samples/common/DetectGPUArchs.cmake
+++ b/projects/hip-tests/samples/common/DetectGPUArchs.cmake
@@ -1,0 +1,71 @@
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# Detect unique GPU architectures for add_custom_command
+if(NOT DEFINED HIP_ARCH_DETECTION_DONE)
+  set(HIP_ARCH_DETECTION_DONE TRUE CACHE INTERNAL "HIP architecture detection completed")
+  
+  # Detect GPU architectures for code object generation
+  # Note: CMake's HIP language support may not deduplicate architectures
+  # Fix any duplicates in CMAKE_HIP_ARCHITECTURES if already set
+  if(DEFINED CMAKE_HIP_ARCHITECTURES AND CMAKE_HIP_ARCHITECTURES)
+    # Convert to list and remove duplicates
+    string(REPLACE ";" ";" GPU_ARCH_LIST "${CMAKE_HIP_ARCHITECTURES}")
+    list(REMOVE_ITEM GPU_ARCH_LIST "gfx000" "")
+    list(REMOVE_DUPLICATES GPU_ARCH_LIST)
+    set(CMAKE_HIP_ARCHITECTURES "${GPU_ARCH_LIST}" CACHE STRING "HIP architectures" FORCE)
+    message(STATUS "Deduplicated HIP architectures: ${CMAKE_HIP_ARCHITECTURES}")
+  elseif(NOT DEFINED CMAKE_HIP_ARCHITECTURES OR NOT CMAKE_HIP_ARCHITECTURES)
+    # Auto-detect if not set
+    if(NOT DEFINED ROCM_PATH)
+      if(DEFINED ENV{ROCM_PATH})
+        set(ROCM_PATH $ENV{ROCM_PATH})
+      else()
+        set(ROCM_PATH "/opt/rocm")
+      endif()
+    endif()
+    
+    execute_process(
+      COMMAND ${ROCM_PATH}/bin/rocm_agent_enumerator
+      OUTPUT_VARIABLE DETECTED_GPUS
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+    )
+    
+    if(DETECTED_GPUS)
+      string(REPLACE "\n" ";" GPU_ARCH_LIST "${DETECTED_GPUS}")
+      list(REMOVE_ITEM GPU_ARCH_LIST "gfx000" "")
+      list(REMOVE_DUPLICATES GPU_ARCH_LIST)
+      set(CMAKE_HIP_ARCHITECTURES "${GPU_ARCH_LIST}" CACHE STRING "HIP architectures" FORCE)
+      message(STATUS "Detected HIP architectures: ${CMAKE_HIP_ARCHITECTURES}")
+    else()
+      set(CMAKE_HIP_ARCHITECTURES "gfx90a" CACHE STRING "HIP architectures" FORCE)
+      message(STATUS "Could not detect GPU, using default: ${CMAKE_HIP_ARCHITECTURES}")
+    endif()
+  endif()
+endif()
+
+# For custom commands that need --offload-arch flags, convert the list to multiple flags
+# This needs to be regenerated each time in case CMAKE_HIP_ARCHITECTURES changed
+set(OFFLOAD_ARCH_FLAGS "")
+foreach(arch ${CMAKE_HIP_ARCHITECTURES})
+  list(APPEND OFFLOAD_ARCH_FLAGS "--offload-arch=${arch}")
+endforeach()
+

--- a/projects/hip-tests/samples/common/hip_helper.h
+++ b/projects/hip-tests/samples/common/hip_helper.h
@@ -20,6 +20,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#include <cstdio>
+#include <cstdlib>
 #include "hip/hip_runtime.h"
 
 #ifndef checkHipErrors


### PR DESCRIPTION
…p-lang package.

## Motivation

Enable hip samples to compile & run on TheRock release build

## Technical Details

Applied CMAKE LANGAUGE HIP (amdclang), Use of modern package "hip-lang" instead of legacy "hip" wherever applicable

## Test Plan

Compile and run samples with these changes in TheRock release build#29 docker container

## Test Result

Samples compile and run fine in TheRock release build#29 docker container

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
