### PR TITLE
SWDEV-555551 - Set value before used warning

### DIFF
--- a/projects/hip-tests/catch/multiproc/hipIpcMemAccessTest.cc
+++ b/projects/hip-tests/catch/multiproc/hipIpcMemAccessTest.cc
@@ -213,6 +213,7 @@ TEST_CASE("Unit_hipIpcMemAccess_Semaphores") {
 TEST_CASE("Unit_hipIpcMemAccess_ParameterValidation") {
   hipIpcMemHandle_t MemHandle;
   hipIpcMemHandle_t MemHandleUninit;
+  std::memset(&MemHandleUninit, 0xAB, sizeof(MemHandleUninit)); // Fill with a known invalid pattern
   void *Ad{}, *Ad2{};
   hipError_t ret;
 


### PR DESCRIPTION
## Motivation
Set value for MemHandleUninit before used
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Initialize variable with known invalid pattern.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Test compilation and warning
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Compiles with no warning
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
