### PR TITLE
SWDEV-555551 - buffer overflow warning

### DIFF
--- a/projects/hip-tests/catch/unit/device/getUUIDfrmRocinfo_Exe.cc
+++ b/projects/hip-tests/catch/unit/device/getUUIDfrmRocinfo_Exe.cc
@@ -39,7 +39,7 @@ int main(int argc, char** argv) {
   const char* rocmInfo = "rocminfo";
 
   snprintf(command, COMMAND_LEN, "%s", rocmInfo);
-  strncat(command, " | grep -i Uuid:", COMMAND_LEN);
+  strncat(command, " | grep -i Uuid:", COMMAND_LEN - strlen(command) - 1);
   // Execute the rocminfo command and extract the UUID info
   fpipe = popen(command, "r");
   if (fpipe == nullptr) {


### PR DESCRIPTION
## Motivation
Make sure buffer overflow cannot happen.
Removes buffer overflow warning.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Makes sure that strncat only appends as many characters as will fit in the buffer.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Compile with changes
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Compiles and removes warning
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
