### PR TITLE
SWDEV-555551 - Change NULL to 0

### DIFF
--- a/projects/hip-tests/catch/unit/memory/hipMemGetAddressRange.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemGetAddressRange.cc
@@ -107,7 +107,7 @@ TEST_CASE("Unit_hipMemGetAddressRange_Negative") {
   const int offset = kPageSize;
   LinearAllocGuard<int> dst_alloc(LinearAllocs::hipMalloc, allocation_size);
 
-  hipDeviceptr_t dummy_ptr = NULL;
+  hipDeviceptr_t dummy_ptr = 0;
 
   SECTION("Device pointer is invalid") {
     HIP_CHECK_ERROR(hipMemGetAddressRange(&base_ptr, &mem_size, dummy_ptr), hipErrorNotFound);

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D16.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D16.cc
@@ -126,7 +126,7 @@ TEST_CASE("Unit_hipMemsetD2D16_NegTsts") {
   HIP_CHECK(hipMemAllocPitch(&A_d, &devPitch, width, numH,
                              2 * sizeof(uint16_t)));
   SECTION("nullptr destination") {
-    HIP_CHECK_ERROR(hipMemsetD2D16(NULL, devPitch, memsetval, numW, numH), hipErrorInvalidValue);
+    HIP_CHECK_ERROR(hipMemsetD2D16(0, devPitch, memsetval, numW, numH), hipErrorInvalidValue);
   }
   SECTION("OutOfBound destination") {
     void* outOfBoundsDst{reinterpret_cast<uint16_t*>(A_d) + devPitch * numH + 1};

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D16Async.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D16Async.cc
@@ -135,7 +135,7 @@ TEST_CASE("Unit_hipMemsetD2D16Async_NegTsts") {
   HIP_CHECK(hipMemAllocPitch(&A_d, &devPitch, width, numH,
                              2 * sizeof(uint16_t)));
   SECTION("nullptr destination") {
-    HIP_CHECK_ERROR(hipMemsetD2D16Async(NULL, devPitch, memsetval, numW, numH, stream),
+    HIP_CHECK_ERROR(hipMemsetD2D16Async(0, devPitch, memsetval, numW, numH, stream),
                     hipErrorInvalidValue);
   }
   SECTION("OutOfBound destination") {

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D32.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D32.cc
@@ -123,7 +123,7 @@ TEST_CASE("Unit_hipMemsetD2D32_NegTsts") {
   constexpr int memsetval = static_cast<int>(0x26);
   HIP_CHECK(hipMemAllocPitch(&A_d, &devPitch, width, numH, sizeof(int)));
   SECTION("nullptr destination") {
-    HIP_CHECK_ERROR(hipMemsetD2D32(NULL, devPitch, memsetval, numW, numH), hipErrorInvalidValue);
+    HIP_CHECK_ERROR(hipMemsetD2D32(0, devPitch, memsetval, numW, numH), hipErrorInvalidValue);
   }
   SECTION("OutOfBound destination") {
     void* outOfBoundsDst{reinterpret_cast<int*>(A_d) + devPitch * numH + 1};

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D32Async.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D32Async.cc
@@ -131,7 +131,7 @@ TEST_CASE("Unit_hipMemsetD2D32Async_NegTsts") {
   HIP_CHECK(hipStreamCreate(&stream));
   HIP_CHECK(hipMemAllocPitch(&A_d, &devPitch, width, numH, sizeof(int)));
   SECTION("nullptr destination") {
-    HIP_CHECK_ERROR(hipMemsetD2D32Async(NULL, devPitch, memsetval, numW, numH, stream),
+    HIP_CHECK_ERROR(hipMemsetD2D32Async(0, devPitch, memsetval, numW, numH, stream),
                     hipErrorInvalidValue);
   }
   SECTION("OutOfBound destination") {

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D8.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D8.cc
@@ -125,7 +125,7 @@ TEST_CASE("Unit_hipMemsetD2D8_NegTsts") {
   HIP_CHECK(
       hipMemAllocPitch(&A_d, &devPitch, width, numH, 4 * sizeof(char)));
   SECTION("nullptr destination") {
-    HIP_CHECK_ERROR(hipMemsetD2D8(NULL, devPitch, memsetval, numW, numH), hipErrorInvalidValue);
+    HIP_CHECK_ERROR(hipMemsetD2D8(0, devPitch, memsetval, numW, numH), hipErrorInvalidValue);
   }
   SECTION("OutOfBound destination") {
     void* outOfBoundsDst{reinterpret_cast<char*>(A_d) + devPitch * numH + 1};

--- a/projects/hip-tests/catch/unit/memory/hipMemsetD2D8Async.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetD2D8Async.cc
@@ -137,7 +137,7 @@ TEST_CASE("Unit_hipMemsetD2D8Async_NegTsts") {
   HIP_CHECK(
       hipMemAllocPitch(&A_d, &devPitch, width, numH, 4 * sizeof(char)));
   SECTION("nullptr destination") {
-    HIP_CHECK_ERROR(hipMemsetD2D8Async(NULL, devPitch, memsetval, numW, numH, stream),
+    HIP_CHECK_ERROR(hipMemsetD2D8Async(0, devPitch, memsetval, numW, numH, stream),
                     hipErrorInvalidValue);
   }
   SECTION("OutOfBound destination") {

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMapArrayAsync.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMapArrayAsync.cc
@@ -100,7 +100,7 @@ TEST_CASE("Unit_hipMemMapArrayAsync_Positive_Basic") {
   HIP_CHECK(hipStreamSynchronize(stream.stream()));
 
   map_info_list.memOperationType = hipMemOperationTypeUnmap;
-  map_info_list.memHandle.memHandle = NULL;
+  map_info_list.memHandle.memHandle = 0;
   HIP_CHECK(hipMemMapArrayAsync(&map_info_list, 1, stream.stream()));
   HIP_CHECK(hipStreamSynchronize(stream.stream()));
 


### PR DESCRIPTION
## Motivation
Remove warning for converting non-pointer type from NULL
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Changed NULL to 0.
They are equivalent but integer does not cause conversion warning.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Compile hip-test
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Compiles with no warnings
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
