### PR TITLE
libhsakmt: Add support for batch SVM range registration API

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
@@ -500,6 +500,18 @@ hsaKmtRegisterMemoryWithFlags(
     );
 
 /**
+  Register with KFD memory ranges with memory attributes
+ */
+HSAKMT_STATUS
+HSAKMTAPI
+hsaKmtRegisterRangesWithFlags(
+  void *MemoryAddress,
+  HSAuint64 MemorySizeInBytes,
+  HsaMemoryRange *MemoryRanges,
+  HSAuint64 RangesCount,
+  HsaMemFlags MemFlags);
+
+/**
   Registers with KFD a graphics buffer and returns graphics metadata
 */
 

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
@@ -1419,7 +1419,8 @@ typedef enum _HSA_SVM_ATTR_TYPE {
                                      // by the attribute value
 	HSA_SVM_ATTR_SET_FLAGS,      // bitmask of flags to set (see HSA_SVM_FLAGS)
 	HSA_SVM_ATTR_CLR_FLAGS,      // bitmask of flags to clear
-	HSA_SVM_ATTR_GRANULARITY     // migration granularity (log2 num pages)
+	HSA_SVM_ATTR_GRANULARITY,    // migration granularity (log2 num pages)
+    HSA_SVM_ATTR_MAPPED
 } HSA_SVM_ATTR_TYPE;
 
 typedef struct _HSA_SVM_ATTRIBUTE {

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/linux/kfd_ioctl.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/linux/kfd_ioctl.h
@@ -1516,6 +1516,47 @@ struct kfd_ioctl_svm_args {
 };
 
 /**
+ * kfd_ioctl_svm_range - SVM range descriptor
+ *
+ * @addr: starting virtual address of the SVM range
+ * @size: size of the SVM range in bytes
+ *
+ */
+struct kfd_ioctl_svm_range {
+	__u64 addr;
+	__u64 size;
+};
+
+/**
+ * kfd_ioctl_svm_ranges_args - Arguments for SVM register ranges ioctl
+ *
+ * @nranges: number of ranges in the @ranges array
+ * @op: operation to perform (see enum @kfd_ioctl_svm_op)
+ * @nattr: number of attributes in the @attrs array
+ * @ranges: variable length array of ranges
+ * @attrs: variable length array of attributes
+ *
+ * This ioctl allows registering multiple SVM ranges with the same
+ * set of attributes. This is more efficient than calling the SVM
+ * ioctl multiple times for each range.
+ *
+ * The semantics of the operations and attributes are the same as
+ * for kfd_ioctl_svm_args.
+ */
+struct kfd_ioctl_svm_ranges_args {
+	__u64 start_addr;
+	__u64 size;
+	__u32 op;
+	__u32 nattr;
+	/* Variable length array of attributes */
+	__u64 attrs_ptr;
+	__u32 nranges;
+	__u32 pad;
+	/* Variable length array of ranges */
+	__u64 ranges_ptr;
+};
+
+/**
  * kfd_ioctl_set_xnack_mode_args - Arguments for set_xnack_mode
  *
  * @xnack_enabled:       [in/out] Whether to enable XNACK mode for this process
@@ -1811,8 +1852,11 @@ struct kfd_ioctl_ais_args {
 #define AMDKFD_IOC_DBG_TRAP			\
 		AMDKFD_IOWR(0x26, struct kfd_ioctl_dbg_trap_args)
 
+#define AMDKFD_IOC_SVM_RANGES		\
+		AMDKFD_IOWR(0x27, struct kfd_ioctl_svm_ranges_args)
+
 #define AMDKFD_COMMAND_START		0x01
-#define AMDKFD_COMMAND_END		0x27
+#define AMDKFD_COMMAND_END		0x28
 
 /* non-upstream ioctls */
 #define AMDKFD_IOC_IPC_IMPORT_HANDLE                                    \

--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -1129,6 +1129,64 @@ static HSAKMT_STATUS fmm_register_mem_svm_api(HsaKFDContext *ctx,
 	return HSAKMT_STATUS_SUCCESS;
 }
 
+HSAKMT_STATUS fmm_register_mem_ranges_svm_api(HsaKFDContext* ctx, void* address, uint64_t size,
+                                              struct kfd_ioctl_svm_range* ranges,
+                                              uint64_t nranges,
+                                              bool coarse_grain,
+											  bool ext_coherent) {
+  struct kfd_ioctl_svm_ranges_args args;
+  struct kfd_ioctl_svm_attribute attrs[3];
+  HSAuint32 page_offset = (HSAuint64)address & (PAGE_SIZE - 1);
+  HSAuint64 aligned_addr = (HSAuint64)address - page_offset;
+  HSAuint64 aligned_size = PAGE_ALIGN_UP(page_offset + size);
+  struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
+
+	if (!fmm_ctx->first_gpu_mem)
+		return HSAKMT_STATUS_ERROR;
+
+  if (!ranges || !nranges) return HSAKMT_STATUS_INVALID_PARAMETER;
+
+  args.start_addr = aligned_addr;
+  args.size = aligned_size;
+  args.op = KFD_IOCTL_SVM_OP_SET_ATTR;
+  args.nattr = 3;
+  attrs[0].type = coarse_grain ? HSA_SVM_ATTR_CLR_FLAGS : HSA_SVM_ATTR_SET_FLAGS;
+  attrs[0].value = HSA_SVM_FLAG_COHERENT;
+  attrs[1].type = ext_coherent ? HSA_SVM_ATTR_SET_FLAGS : HSA_SVM_ATTR_CLR_FLAGS;
+  attrs[1].value = HSA_SVM_FLAG_EXT_COHERENT;
+  attrs[2].type = HSA_SVM_ATTR_MAPPED;
+  attrs[2].value = 1;
+  args.attrs_ptr = (HSAuint64)&attrs[0];
+
+  args.ranges_ptr = (HSAuint64)ranges;
+  args.nranges = nranges;
+
+  pr_debug("Registering ranges to SVM %p size: %ld\n", (void*)aligned_addr, aligned_size);
+  /* Driver does one copy_from_user, with extra attrs size */
+  if (hsakmt_ioctl(ctx->fd, AMDKFD_IOC_SVM_RANGES + (0 << _IOC_SIZESHIFT), &args)) {
+    pr_debug("op set range attrs failed %s\n", strerror(errno));
+    return HSAKMT_STATUS_ERROR;
+  }
+
+  return HSAKMT_STATUS_SUCCESS;
+}
+
+HSAKMT_STATUS hsakmt_fmm_register_ranges(HsaKFDContext* ctx, void* address, uint64_t size_in_bytes,
+                                         struct kfd_ioctl_svm_range* ranges,
+                                         uint64_t nranges,
+                                         bool coarse_grain, bool ext_coherent) {
+  HSAKMT_STATUS ret;
+
+  if (coarse_grain && ext_coherent) return HSAKMT_STATUS_INVALID_PARAMETER;
+
+  if (!hsakmt_is_svm_api_supported) return HSAKMT_STATUS_NOT_SUPPORTED;
+
+  ret = fmm_register_mem_ranges_svm_api(ctx, address, size_in_bytes, ranges, nranges, coarse_grain,
+                                        ext_coherent);
+
+  return ret;
+}
+
 static HSAKMT_STATUS fmm_map_mem_svm_api(HsaKFDContext *ctx,
 					      void *address,
 					      uint64_t size,
@@ -1144,6 +1202,8 @@ static HSAKMT_STATUS fmm_map_mem_svm_api(HsaKFDContext *ctx,
 		return HSAKMT_STATUS_ERROR;
 
 	nattr = nodes_array_size;
+	if (hsakmt_allow_mapped_userptr)
+		nattr += 1;
 	s_attr = sizeof(struct kfd_ioctl_svm_attribute) * nattr;
 	args = alloca(sizeof(*args) + s_attr);
 
@@ -1154,6 +1214,10 @@ static HSAKMT_STATUS fmm_map_mem_svm_api(HsaKFDContext *ctx,
 	for (i = 0; i < nodes_array_size; i++) {
 		args->attrs[i].type = HSA_SVM_ATTR_ACCESS_IN_PLACE;
 		args->attrs[i].value = nodes_to_map[i];
+	}
+	if (hsakmt_allow_mapped_userptr) {
+		args->attrs[nattr-1].type = HSA_SVM_ATTR_MAPPED;
+		args->attrs[nattr-1].value = 1;
 	}
 	/* Driver does one copy_from_user, with extra attrs size */
 	if (hsakmt_ioctl(ctx->fd, AMDKFD_IOC_SVM + (s_attr << _IOC_SIZESHIFT), args)) {

--- a/projects/rocr-runtime/libhsakmt/src/fmm.h
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.h
@@ -141,6 +141,12 @@ HSAKMT_STATUS hsakmt_fmm_get_mem_info(HsaKFDContext *ctx,
 HSAKMT_STATUS hsakmt_fmm_set_mem_user_data(HsaKFDContext *ctx,
 						const void *mem,
 						void *usr_data);
+HSAKMT_STATUS hsakmt_fmm_register_ranges(HsaKFDContext* ctx, void* address, uint64_t size_in_bytes,
+                                         struct kfd_ioctl_svm_range* ranges, uint64_t nranges,
+                                         bool coarse_grain, bool ext_coherent);
+HSAKMT_STATUS fmm_register_mem_ranges_svm_api(HsaKFDContext* ctx, void* address, uint64_t size,
+                                              struct kfd_ioctl_svm_range* ranges, uint64_t nranges,
+                                              bool coarse_grain, bool ext_coherent);
 #ifdef SANITIZER_AMDGPU
 HSAKMT_STATUS hsakmt_fmm_replace_asan_header_page(HsaKFDContext *ctx, void* address);
 HSAKMT_STATUS hsakmt_fmm_return_asan_header_page(HsaKFDContext *ctx, void* address);

--- a/projects/rocr-runtime/libhsakmt/src/globals.c
+++ b/projects/rocr-runtime/libhsakmt/src/globals.c
@@ -39,3 +39,4 @@ int hsakmt_page_shift;
 bool hsakmt_is_svm_api_supported;
 /* zfb is mainly used during emulation */
 int hsakmt_zfb_support;
+bool hsakmt_allow_mapped_userptr;

--- a/projects/rocr-runtime/libhsakmt/src/hsakmtctx.h
+++ b/projects/rocr-runtime/libhsakmt/src/hsakmtctx.h
@@ -509,6 +509,20 @@ hsaKmtRegisterMemoryWithFlagsCtx(
     );
 
 /**
+  Registers with KFD a memory buffer with multiple memory ranges and attributes
+*/
+HSAKMT_STATUS
+HSAKMTAPI
+hsaKmtRegisterRangesWithFlagsCtx(
+    HsaKFDContext    *ctx,                //IN
+    void             *MemoryAddress,      //IN
+    HSAuint64        MemorySizeInBytes,   //IN
+    HsaMemoryRange   *MemoryRanges,       //IN
+    HSAuint64        RangesCount,         //IN
+    HsaMemFlags      MemFlags             //IN
+    );
+
+/**
   Registers with KFD a graphics buffer and returns graphics metadata
 */
 

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.h
@@ -41,6 +41,7 @@ extern pthread_mutex_t hsakmt_mutex;
 extern bool hsakmt_is_dgpu;
 extern bool hsakmt_is_svm_api_supported;
 extern int hsakmt_zfb_support;
+extern bool hsakmt_allow_mapped_userptr;
 
 extern HsaVersionInfo hsakmt_kfd_version_info;
 extern HsaKFDContext hsakmt_primary_kfd_ctx;

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.ver
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.ver
@@ -90,6 +90,7 @@ hsaKmtPcSamplingStart;
 hsaKmtPcSamplingStop;
 hsaKmtPcSamplingSupport;
 hsaKmtAisReadWriteFile;
+hsaKmtRegisterMemoryRangesWithFlags;
 local: *;
 };
 

--- a/projects/rocr-runtime/libhsakmt/src/memory.c
+++ b/projects/rocr-runtime/libhsakmt/src/memory.c
@@ -348,6 +348,33 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtRegisterMemoryWithFlagsCtx(HsaKFDContext *ctx,
 	return ret;
 }
 
+HSAKMT_STATUS HSAKMTAPI hsaKmtRegisterRangesWithFlagsCtx(HsaKFDContext *ctx,
+							void *MemoryAddress,
+							HSAuint64 MemorySizeInBytes,
+							HsaMemoryRange *MemoryRanges,
+							HSAuint64 RangesCount,
+							HsaMemFlags MemFlags)
+{
+	CHECK_KFD_OPEN();
+	HSAKMT_STATUS ret = HSAKMT_STATUS_SUCCESS;
+
+	pr_debug("[%s] address %p\n",
+		__func__, MemoryAddress);
+
+	// Registered memory should be ordinary paged host memory.
+	if ((MemFlags.ui32.HostAccess != 1) || (MemFlags.ui32.NonPaged == 1))
+		return HSAKMT_STATUS_NOT_SUPPORTED;
+
+	if (!hsakmt_is_dgpu || !hsakmt_allow_mapped_userptr)
+		return HSAKMT_STATUS_NOT_SUPPORTED;
+
+	ret = hsakmt_fmm_register_ranges(ctx, MemoryAddress, MemorySizeInBytes,
+									(struct kfd_ioctl_svm_range*)MemoryRanges, RangesCount,
+									MemFlags.ui32.CoarseGrain, MemFlags.ui32.ExtendedCoherent);
+
+	return ret;
+}
+
 HSAKMT_STATUS HSAKMTAPI hsaKmtRegisterGraphicsHandleToNodesCtx(HsaKFDContext *ctx,
 							    HSAuint64 GraphicsResourceHandle,
 							    HsaGraphicsResourceInfo *GraphicsResourceInfo,
@@ -779,6 +806,18 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtRegisterMemoryWithFlags(void *MemoryAddress,
 {
 	return hsaKmtRegisterMemoryWithFlagsCtx(&hsakmt_primary_kfd_ctx,
 					      MemoryAddress, MemorySizeInBytes, MemFlags);
+}
+
+HSAKMT_STATUS HSAKMTAPI hsaKmtRegisterRangesWithFlags(void* MemoryAddress, 
+							HSAuint64 MemorySizeInBytes,
+							HsaMemoryRange* MemoryRanges,
+							HSAuint64 RangesCount,
+							HsaMemFlags MemFlags)
+{
+
+	return hsaKmtRegisterRangesWithFlagsCtx(&hsakmt_primary_kfd_ctx,
+					      MemoryAddress, MemorySizeInBytes,
+					      MemoryRanges, RangesCount, MemFlags);
 }
 
 HSAKMT_STATUS HSAKMTAPI hsaKmtRegisterGraphicsHandleToNodes(HSAuint64 GraphicsResourceHandle,

--- a/projects/rocr-runtime/libhsakmt/src/openclose.c
+++ b/projects/rocr-runtime/libhsakmt/src/openclose.c
@@ -133,6 +133,8 @@ static HSAKMT_STATUS init_vars_from_env(void)
 	char *envvar;
 	int debug_level;
 
+	hsakmt_allow_mapped_userptr = 1; /* default to allow mapped userptr */
+
 	/* Normally libraries don't print messages. For debugging purpose, we'll
 	 * print messages if an environment variable, HSAKMT_DEBUG_LEVEL, is set.
 	 */
@@ -150,6 +152,10 @@ static HSAKMT_STATUS init_vars_from_env(void)
 	envvar = getenv("HSA_ZFB");
 	if (envvar)
 		hsakmt_zfb_support = atoi(envvar);
+
+	envvar = getenv("HSA_ALLOW_MAPPED_USERPTR");
+	if (envvar)
+		hsakmt_allow_mapped_userptr = atoi(envvar) != 0;
 
 	return HSAKMT_STATUS_SUCCESS;
 }


### PR DESCRIPTION
## Motivation
This commit introduces a new API to register multiple SVM (Shared Virtual Memory) ranges with the same set of attributes in a single call, improving efficiency over multiple individual registration calls.



## Technical Details

Key changes:
- Add new public API hsaKmtRegisterRangesWithFlags() and context-aware variant hsaKmtRegisterRangesWithFlagsCtx() for batch registration of memory ranges
- Introduce AMDKFD_IOC_SVM_RANGES ioctl (0x27) with kfd_ioctl_svm_ranges_args structure to support kernel-level batch operations
- Add HSA_SVM_ATTR_MAPPED attribute type to HSA_SVM_ATTR_TYPE enum
- Implement hsakmt_fmm_register_ranges() and fmm_register_mem_ranges_svm_api() to handle the batch registration logic with SVM API
- Add HSA_ALLOW_MAPPED_USERPTR environment variable to control mapped userptr feature (default: enabled)
- Export new API symbol in libhsakmt.ver for library ABI

## Test Plan

OCL CTS
HIP CATCH
AI applications

## Test Result

quick OCL CTS passed
HIP catch passed


## Submission Checklist

