### PR TITLE
rocr: Enable Virtio thunk and add fallback support for pointer query

### DIFF
--- a/projects/rocr-runtime/CMakeLists.txt
+++ b/projects/rocr-runtime/CMakeLists.txt
@@ -109,7 +109,7 @@ if (HSA_DEP_ROCPROFILER_REGISTER)
 endif()
 
 if (NOT DEFINED BUILD_THUNK_VIRTIO)
-  set(BUILD_THUNK_VIRTIO OFF)
+  set(BUILD_THUNK_VIRTIO ON)
 endif()
 
 add_rocm_subdir(libhsakmt "${THUNK_DEFINITIONS}")

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -85,6 +85,9 @@
 #include "core/util/memory.h"
 #include "core/util/os.h"
 #include "inc/hsa_ven_amd_aqlprofile.h"
+#ifdef HSAKMT_VIRTIO_ENABLED
+#include "hsakmt/hsakmt_virtio.h"
+#endif
 
 #ifndef HSA_VERSION_MAJOR
 #define HSA_VERSION_MAJOR 1
@@ -1072,19 +1075,19 @@ hsa_status_t Runtime::PtrInfo(const void* ptr, hsa_amd_pointer_info_t* info, voi
     // We don't care if this returns an error code.
     // The type will be HSA_EXT_POINTER_TYPE_UNKNOWN if so.
     auto err = HSAKMT_CALL(hsaKmtQueryPointerInfo(ptr, &thunkInfo));
-    if (err != HSAKMT_STATUS_SUCCESS || thunkInfo.Type == HSA_POINTER_UNKNOWN) {
-      if (retInfo.type == HSA_EXT_POINTER_TYPE_RESERVED_ADDR) {
-        /* This is an address that was reserved using hsa_amd_vmem_address_reserve with
-         * the HSA_AMD_VMEM_ADDRESS_NO_REGISTER flag, but the address was not registered
-         * with hsa_amd_svm_attributes_set. So we return the contents of retInfo that
-         * were previously filled with VMemoryPtrInfo.
-         */
+    bool isUnknown = (err != HSAKMT_STATUS_SUCCESS || thunkInfo.Type == HSA_POINTER_UNKNOWN);
+
+#ifdef HSAKMT_VIRTIO_ENABLED
+    if (isUnknown) {
+        err = vhsaKmtQueryPointerInfo(ptr, &thunkInfo);
+        isUnknown = (err != HSAKMT_STATUS_SUCCESS || thunkInfo.Type == HSA_POINTER_UNKNOWN);
+    }
+#endif
+
+    if (isUnknown) {
+        retInfo.type = HSA_EXT_POINTER_TYPE_UNKNOWN;
         memcpy(info, &retInfo, retInfo.size);
         return HSA_STATUS_SUCCESS;
-      }
-      retInfo.type = HSA_EXT_POINTER_TYPE_UNKNOWN;
-      memcpy(info, &retInfo, retInfo.size);
-      return HSA_STATUS_SUCCESS;
     }
 
     if (returnListData) {


### PR DESCRIPTION
## Motivation

To enable VIRIO driver inROCR

## Technical Details

- Enable BUILD_THUNK_VIRTIO by default in CMakeLists.txt
- Add HSAKMT_VIRTIO_ENABLED support in runtime.cpp
- Implement fallback mechanism to use vhsaKmtQueryPointerInfo when standard hsaKmtQueryPointerInfo fails or returns unknown pointer type
- This enhances compatibility with virtualized environments while maintaining backward compatibility with existing functionality

## Test Plan

OCL CTS
HIP CATCH

## Test Result

all pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
