### PR TITLE
Round the sum of percentages before validating to account for floating point errors

### DIFF
--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/python/python-builtin-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/python/python-builtin-rules.json
@@ -36,7 +36,7 @@
                     "description": "Verify that percentages sum to 100.",
                     "error_message": "Percentages do not sum to 100.",
                     "expected_result": 100,
-                    "query": "SELECT SUM(percentage) FROM top;"
+                    "query": "SELECT ROUND(SUM(percentage), 1) FROM top;"
                 }
             ]
         },

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/python/python-source-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/python/python-source-rules.json
@@ -50,7 +50,7 @@
                     "description": "Verify that percentages sum to 100.",
                     "error_message": "Percentages do not sum to 100.",
                     "expected_result": 100,
-                    "query": "SELECT SUM(percentage) FROM top;"
+                    "query": "SELECT ROUND(SUM(percentage), 1) FROM top;"
                 }
             ]
         },


### PR DESCRIPTION
## Motivation

Fix `python-source-validate-rocpd` test.

## Technical Details

- The failing test validates that percentages in "top" sum to 100. However, due to possible rounding errors, the sum could be:
    - `99.99999999999999`
    - `100.00000000000001`
- Add a ROUND(x,1) to the SQL query

## Test Plan

Re-run test on failing system (MI300)

## Test Result

Test now passes on failing system.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
