### PR TITLE
Prevent duplicated SDK events in rocprofiler-systems rocpd tracing

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -690,8 +690,7 @@ tool_tracing_callback_start(CategoryT, rocprofiler_callback_tracing_record_t rec
 
     if(get_use_timemory())
     {
-        component::category_region<category::rocm_marker_api>::start<quirk::timemory>(
-            _name);
+        tracing::push_timemory(category::rocm_marker_api{}, _name);
     }
 }
 
@@ -761,8 +760,7 @@ tool_tracing_callback_stop(
 
     if(get_use_timemory())
     {
-        component::category_region<category::rocm_marker_api>::stop<quirk::timemory>(
-            _name);
+        tracing::pop_timemory(category::rocm_marker_api{}, _name);
     }
 
     if(get_use_perfetto())
@@ -1102,8 +1100,7 @@ ompt_tracing_callback_start(rocprofiler_callback_tracing_record_t record,
 
     if(get_use_timemory())
     {
-        component::category_region<category::rocm_marker_api>::start<quirk::timemory>(
-            _name);
+        tracing::push_timemory(category::rocm_marker_api{}, _name);
     }
 
     if(get_use_perfetto())
@@ -1149,8 +1146,7 @@ ompt_tracing_callback_stop(
 
     if(get_use_timemory())
     {
-        component::category_region<category::rocm_marker_api>::stop<quirk::timemory>(
-            _name);
+        tracing::pop_timemory(category::rocm_marker_api{}, _name);
     }
 
     if(get_use_perfetto())


### PR DESCRIPTION
## Motivation

Resolves SWDEV-562861
The previous implementation was causing duplicate SDK events to be recorded during timemory tracing operations. 

## Technical Details

Refactored timemory tracing calls in `rocprofiler-sdk.cpp` to use dedicated `tracing::push_timemory()` and `tracing::pop_timemory()` functions instead of directly calling `component::category_region<category::rocm_marker_api>::start/stop<quirk::timemory>()`. This change affects both `tool_tracing_callback` and `ompt_tracing_callback` start/stop functions, ensuring proper event deduplication through a centralized tracing API.

## Test Plan

- Compare event counts before and after the fix to confirm deduplication

## Test Result

SDK events should appear exactly once per occurrence in trace output, with no duplicates. Profiling data should be accurate and consistent across different callback mechanisms.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
