### PR TITLE
[SWDEV-548312] Fix for rsmitstReadWrite.TestPciReadWrite failure in rsmi-tests on MI200. 

### DIFF
--- a/projects/rocm-smi-lib/tests/rocm_smi_test/functional/pci_read_write.cc
+++ b/projects/rocm-smi-lib/tests/rocm_smi_test/functional/pci_read_write.cc
@@ -159,7 +159,8 @@ void TestPciReadWrite::Run(void) {
     }
     // Verify api support checking functionality is working
     ret = rsmi_dev_pci_bandwidth_get(dv_ind, nullptr);
-    ASSERT_EQ(ret, RSMI_STATUS_INVALID_ARGS);
+    ASSERT_TRUE(ret == RSMI_STATUS_INVALID_ARGS || ret == RSMI_STATUS_NOT_SUPPORTED)
+    << "Expected INVALID_ARGS or NOT_SUPPORTED when passing nullptr to rsmi_dev_pci_bandwidth_get; got: " << ret;
 
     // First set the bitmask to all supported bandwidths
     freq_bitmask = ~(~0u << bw.transfer_rate.num_supported);
@@ -178,7 +179,13 @@ void TestPciReadWrite::Run(void) {
                                                             " ..." << std::endl;
     }
     ret = rsmi_dev_pci_bandwidth_set(dv_ind, freq_bitmask);
-    CHK_ERR_ASRT(ret)
+    if (ret != RSMI_STATUS_NOT_SUPPORTED) {
+      CHK_ERR_ASRT(ret);
+    } else {
+      const char* s = nullptr;
+      rsmi_status_string(ret, &s);
+      std::cout << "\t\t** rsmi_dev_pci_bandwidth_set(): " << (s ? s : "NOT_SUPPORTED") << "\n";
+    }
 
     ret = rsmi_dev_pci_bandwidth_get(dv_ind, &bw);
     CHK_ERR_ASRT(ret)
@@ -189,7 +196,13 @@ void TestPciReadWrite::Run(void) {
       std::cout << "\tResetting mask to all bandwidths." << std::endl;
     }
     ret = rsmi_dev_pci_bandwidth_set(dv_ind, 0xFFFFFFFF);
-    CHK_ERR_ASRT(ret)
+    if (ret != RSMI_STATUS_NOT_SUPPORTED) {
+      CHK_ERR_ASRT(ret);
+    } else {
+      const char* s = nullptr;
+      rsmi_status_string(ret, &s);
+      std::cout << "\t\t** rsmi_dev_pci_bandwidth_set(): " << (s ? s : "NOT_SUPPORTED") << "\n";
+    }
 
     ret = rsmi_dev_perf_level_set(dv_ind, RSMI_DEV_PERF_LEVEL_AUTO);
     CHK_ERR_ASRT(ret)

--- a/projects/rocm-smi-lib/tests/rocm_smi_test/functional/pci_read_write.cc
+++ b/projects/rocm-smi-lib/tests/rocm_smi_test/functional/pci_read_write.cc
@@ -159,8 +159,8 @@ void TestPciReadWrite::Run(void) {
     }
     // Verify api support checking functionality is working
     ret = rsmi_dev_pci_bandwidth_get(dv_ind, nullptr);
-    ASSERT_TRUE(ret == RSMI_STATUS_INVALID_ARGS || ret == RSMI_STATUS_NOT_SUPPORTED)
-    << "Expected INVALID_ARGS or NOT_SUPPORTED when passing nullptr to rsmi_dev_pci_bandwidth_get; got: " << ret;
+    ASSERT_TRUE(ret == RSMI_STATUS_INVALID_ARGS || ret == RSMI_STATUS_NOT_SUPPORTED);
+    std::cout << "Expected INVALID_ARGS or NOT_SUPPORTED when passing nullptr to rsmi_dev_pci_bandwidth_get; got: " << ret;
 
     // First set the bitmask to all supported bandwidths
     freq_bitmask = ~(~0u << bw.transfer_rate.num_supported);
@@ -181,10 +181,6 @@ void TestPciReadWrite::Run(void) {
     ret = rsmi_dev_pci_bandwidth_set(dv_ind, freq_bitmask);
     if (ret != RSMI_STATUS_NOT_SUPPORTED) {
       CHK_ERR_ASRT(ret);
-    } else {
-      const char* s = nullptr;
-      rsmi_status_string(ret, &s);
-      std::cout << "\t\t** rsmi_dev_pci_bandwidth_set(): " << (s ? s : "NOT_SUPPORTED") << "\n";
     }
 
     ret = rsmi_dev_pci_bandwidth_get(dv_ind, &bw);
@@ -198,10 +194,6 @@ void TestPciReadWrite::Run(void) {
     ret = rsmi_dev_pci_bandwidth_set(dv_ind, 0xFFFFFFFF);
     if (ret != RSMI_STATUS_NOT_SUPPORTED) {
       CHK_ERR_ASRT(ret);
-    } else {
-      const char* s = nullptr;
-      rsmi_status_string(ret, &s);
-      std::cout << "\t\t** rsmi_dev_pci_bandwidth_set(): " << (s ? s : "NOT_SUPPORTED") << "\n";
     }
 
     ret = rsmi_dev_perf_level_set(dv_ind, RSMI_DEV_PERF_LEVEL_AUTO);


### PR DESCRIPTION
Before:
<img width="887" height="439" alt="image" src="https://github.com/user-attachments/assets/a5c4760e-b6d6-49ef-a0ad-ea20baa46fee" />

After:
<img width="1201" height="869" alt="Screenshot 2025-11-12 153931" src="https://github.com/user-attachments/assets/d96ccb9d-740b-4fd0-bffb-0768466f85f3" />

This test is unsupported on MI200
