### PR TITLE
Add clean up fixture for trace cache temporary files

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/cache_manager.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/cache_manager.cpp
@@ -131,29 +131,6 @@ get_cache_files()
     return cache_map;
 }
 
-std::vector<std::string>
-get_all_cache_files()
-{
-    const auto               tmp_files = list_dir_files(tmp_directory);
-    std::vector<std::string> result{};
-    auto                     parse_and_fill_cache = [&](const std::string& filename) {
-        const std::regex buff_regex(R"(buffered_storage.*\.bin)");
-        const std::regex meta_regex(R"(metadata.*\.json)");
-        std::smatch      match;
-
-        if(std::regex_match(filename, match, buff_regex))
-        {
-            result.push_back(tmp_directory + filename);
-        }
-        else if(std::regex_match(filename, match, meta_regex))
-        {
-            result.push_back(tmp_directory + filename);
-        }
-    };
-    std::for_each(tmp_files.begin(), tmp_files.end(), parse_and_fill_cache);
-    return result;
-}
-
 }  // namespace
 
 cache_manager&
@@ -238,13 +215,16 @@ cache_manager::post_process_bulk()
             }
         }
 
-        ROCPROFSYS_PRINT("Removing all cached temporary files...\n");
+        ROCPROFSYS_PRINT("Removing cached temporary files...\n");
 
-        auto all_cache_files = get_all_cache_files();
-        for(const auto& filename : all_cache_files)
+        for(const auto& [pid, files] : _cache_files)
         {
-            ROCPROFSYS_PRINT("Removing cached temporary file: %s\n", filename.c_str());
-            remove_if_exists(filename);
+            ROCPROFSYS_PRINT("Removing cached temporary file: %s\n",
+                             files.buff_storage.c_str());
+            ROCPROFSYS_PRINT("Removing cached temporary file: %s\n",
+                             files.metadata.c_str());
+            remove_if_exists(files.buff_storage.c_str());
+            remove_if_exists(files.metadata.c_str());
         }
     }
 }

--- a/projects/rocprofiler-systems/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/tests/CMakeLists.txt
@@ -62,7 +62,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/rocprof-sys-thread-limit-tests.cmake)
 
 add_test(
     NAME rocprofsys-cleanup-tmp-files
-    COMMAND ${CMAKE_COMMAND} -E rm -f /tmp/buffered_storage*.bin /tmp/metadata*.json
+    COMMAND sh -c "rm -f /tmp/buffered_storage*.bin /tmp/metadata*.json"
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
 )
 

--- a/projects/rocprofiler-systems/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/tests/CMakeLists.txt
@@ -51,3 +51,25 @@ include(${CMAKE_CURRENT_LIST_DIR}/rocprof-sys-roctx-tests.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/rocprof-sys-rocm-hip-stream.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/rocprof-sys-binary-tests.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/rocprof-sys-thread-limit-tests.cmake)
+
+# -------------------------------------------------------------------------------------- #
+#
+# Global cleanup test for temporary files
+# This runs once after ALL tests complete to clean up trace cache temporary files
+# Uses FIXTURES_CLEANUP to ensure it runs after all tests requiring the fixture
+#
+# -------------------------------------------------------------------------------------- #
+
+add_test(
+    NAME rocprofsys-cleanup-tmp-files
+    COMMAND ${CMAKE_COMMAND} -E rm -f /tmp/buffered_storage*.bin /tmp/metadata*.json
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+)
+
+set_tests_properties(
+    rocprofsys-cleanup-tmp-files
+    PROPERTIES
+        FIXTURES_CLEANUP rocprofsys-global-tmp-files
+        LABELS "cleanup;global"
+        TIMEOUT 30
+)

--- a/projects/rocprofiler-systems/tests/rocprof-sys-testing.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-testing.cmake
@@ -789,7 +789,7 @@ function(ROCPROFILER_SYSTEMS_ADD_TEST)
             list(APPEND _environ "ROCPROFSYS_CI_TIMEOUT=${_timeout}")
 
             rocprofiler_systems_check_pass_fail_regex("${TEST_NAME}-${_TEST}"
-                                                      "${_PASS_REGEX}" "${_FAIL_REGEX}"
+                "${_PASS_REGEX}" "${_FAIL_REGEX}"
             )
             if(TEST ${TEST_NAME}-${_TEST})
                 rocprofiler_systems_write_test_config(${TEST_NAME}-${_TEST}.cfg _environ)
@@ -804,6 +804,7 @@ function(ROCPROFILER_SYSTEMS_ADD_TEST)
                         SKIP_REGULAR_EXPRESSION "${${_SKIP_REGEX}}"
                         WILL_FAIL ${TEST_WILL_FAIL}
                         DISABLED ${TEST_DISABLED}
+                        FIXTURES_REQUIRED rocprofsys-global-tmp-files
                         ${_props}
                 )
             endif()
@@ -840,7 +841,7 @@ function(ROCPROFILER_SYSTEMS_ADD_CAUSAL_TEST)
 
     if(NOT DEFINED TEST_CAUSAL_MODE)
         rocprofiler_systems_message(FATAL_ERROR
-                                    "${TEST_NAME} :: CAUSAL_MODE must be defined"
+            "${TEST_NAME} :: CAUSAL_MODE must be defined"
         )
     endif()
 
@@ -971,7 +972,7 @@ function(ROCPROFILER_SYSTEMS_ADD_CAUSAL_TEST)
             list(APPEND _environ "ROCPROFSYS_CI_TIMEOUT=${_timeout}")
             rocprofiler_systems_write_test_config(${_NAME}.cfg _environ)
             rocprofiler_systems_check_pass_fail_regex("${_NAME}" "${_PASS_REGEX}"
-                                                      "${_FAIL_REGEX}"
+                "${_FAIL_REGEX}"
             )
             set_tests_properties(
                 ${_NAME}
@@ -982,6 +983,7 @@ function(ROCPROFILER_SYSTEMS_ADD_CAUSAL_TEST)
                     PASS_REGULAR_EXPRESSION "${${_PASS_REGEX}}"
                     FAIL_REGULAR_EXPRESSION "${${_FAIL_REGEX}}"
                     SKIP_REGULAR_EXPRESSION "${${_SKIP_REGEX}}"
+                    FIXTURES_REQUIRED rocprofsys-global-tmp-files
                     ${_props}
             )
         endforeach()
@@ -1096,7 +1098,7 @@ function(ROCPROFILER_SYSTEMS_ADD_PYTHON_TEST)
         set(_FAIL_REGEX TEST_FAIL_REGEX)
 
         rocprofiler_systems_check_pass_fail_regex("${_TEST}" "${_PASS_REGEX}"
-                                                  "${_FAIL_REGEX}"
+            "${_FAIL_REGEX}"
         )
         set_tests_properties(
             ${_TEST}
@@ -1109,6 +1111,7 @@ function(ROCPROFILER_SYSTEMS_ADD_PYTHON_TEST)
                 FAIL_REGULAR_EXPRESSION "${${_FAIL_REGEX}}"
                 SKIP_REGULAR_EXPRESSION "${TEST_SKIP_REGEX}"
                 REQUIRED_FILES "${TEST_FILE}"
+                FIXTURES_REQUIRED rocprofsys-global-tmp-files
                 ${_TEST_PROPERTIES}
         )
     endforeach()
@@ -1132,7 +1135,7 @@ if(NOT ROCPROFSYS_USE_PYTHON)
 
         if(NOT ROCPROFSYS_VALIDATION_PYTHON_PERFETTO EQUAL 0)
             rocprofiler_systems_message(AUTHOR_WARNING
-                                        "Python3 found but perfetto support is disabled"
+                "Python3 found but perfetto support is disabled"
             )
         endif()
     endif()
@@ -1306,7 +1309,7 @@ function(ROCPROFILER_SYSTEMS_ADD_VALIDATION_TEST)
         endif()
 
         rocprofiler_systems_check_pass_fail_regex("${_TEST}" "TEST_PASS_REGEX"
-                                                  "TEST_FAIL_REGEX"
+            "TEST_FAIL_REGEX"
         )
         set_tests_properties(
             ${_TEST}
@@ -1319,6 +1322,7 @@ function(ROCPROFILER_SYSTEMS_ADD_VALIDATION_TEST)
                 FAIL_REGULAR_EXPRESSION "${TEST_FAIL_REGEX}"
                 SKIP_REGULAR_EXPRESSION "${TEST_SKIP_REGEX}"
                 REQUIRED_FILES "${TEST_FILE}"
+                FIXTURES_REQUIRED rocprofsys-global-tmp-files
                 ${TEST_PROPERTIES}
         )
     endforeach()
@@ -1410,6 +1414,7 @@ function(ROCPROFILER_SYSTEMS_ADD_BIN_TEST)
                 PASS_REGULAR_EXPRESSION "${TEST_PASS_REGEX}"
                 FAIL_REGULAR_EXPRESSION "${TEST_FAIL_REGEX}"
                 SKIP_REGULAR_EXPRESSION "${TEST_SKIP_REGEX}"
+                FIXTURES_REQUIRED rocprofsys-global-tmp-files
                 ${TEST_PROPERTIES}
         )
     elseif(TARGET ${TEST_TARGET})
@@ -1429,6 +1434,7 @@ function(ROCPROFILER_SYSTEMS_ADD_BIN_TEST)
                 PASS_REGULAR_EXPRESSION "${TEST_PASS_REGEX}"
                 FAIL_REGULAR_EXPRESSION "${TEST_FAIL_REGEX}"
                 SKIP_REGULAR_EXPRESSION "${TEST_SKIP_REGEX}"
+                FIXTURES_REQUIRED rocprofsys-global-tmp-files
                 ${TEST_PROPERTIES}
         )
     elseif(ROCPROFSYS_BUILD_TESTING)


### PR DESCRIPTION
## Motivation

Tests were leaving temporary trace cache files (`/tmp/buffered_storage_*.bin` and `/tmp/metadata_*.json`) after completion. The previous cleanup mechanism in `cache_manager` was removing all matching files indiscriminately, which could interfere with parallel test execution or other running instances of the profiler (Use case for MPI).

## Technical Details

1. Modified `cache_manager::post_process_bulk()` to only remove trace cache files belonging to the current process (using the existing `_cache_files` map) instead of removing all matching files in `/tmp/`
2. Removed the overly-aggressive `get_all_cache_files()` function that was matching all buffered_storage and metadata files
3. Added CTest fixture-based cleanup mechanism: a global cleanup test runs once after ALL tests complete to remove leftover temporary files
4. Added `FIXTURES_REQUIRED rocprofsys-global-tmp-files` property to all test functions


## Test Plan

1. Run full test suite with `ctest --output-on-failure` and verify no leftover `/tmp/buffered_storage*.bin` or `/tmp/metadata*.json` files remain after completion
2. Interrupt test execution (Ctrl+C) and verify cleanup test executes properly
3. Check that the cleanup test `rocprofsys-cleanup-tmp-files` appears in `ctest -N` output with "cleanup" and "global" labels

## Test Result

- All trace cache temporary files should be removed from `/tmp/` after the test suite completes
- Runtime cleanup should only remove files from the current process, not from parallel executions
- The global cleanup fixture should execute exactly once at the end of all tests

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
