### PR TITLE
SWDEV-1 - Fix condition to check if virtual address matches chunk address

### DIFF
--- a/projects/clr/rocclr/platform/vmheap.cpp
+++ b/projects/clr/rocclr/platform/vmheap.cpp
@@ -239,7 +239,10 @@ address VmHeap::Alloc(size_t size) {
   size_t offset = 0;
   auto hb = AllocBlock(size + block_alignment_);
   if (hb != nullptr) {
-    offset = ((hb->Offset() & ~kChunkSize) == 0) ? hb->Offset() + block_alignment_ : hb->Offset();
+    // Add 256-byte offset if virtual address matches chunk address to avoid map conflicts
+    offset = ((hb->Offset() & (kChunkSize - 1)) == 0)
+               ? hb->Offset() + block_alignment_
+               : hb->Offset();
     ptr = base_address_ + offset;
   } else {
     return nullptr;


### PR DESCRIPTION
## Motivation

Workaround VA to amd::Memory map conflicts by adding a 256-byte offset when virtual addresses align with chunk addresses to prevent overlapping allocations.

## Technical Details

Fixed the condition to check if the virtual address aligns with a chunk address. The previous condition would only check if the virtual address aligned with the first or second chunk.

## Test Plan

Ran memory tests with VMHeap enabled.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
