### PR TITLE
Fix segfault when forked child processes call exit()

### DIFF
--- a/projects/rocprofiler-systems/examples/fork/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/fork/CMakeLists.txt
@@ -8,6 +8,8 @@ list(APPEND _FLAGS -fno-inline)
 
 find_package(Threads REQUIRED)
 find_package(rocprofiler-systems REQUIRED COMPONENTS user)
+
+# Basic fork example
 add_executable(fork-example fork.cpp)
 target_link_libraries(
     fork-example
@@ -17,4 +19,84 @@ target_compile_options(fork-example PRIVATE ${_FLAGS})
 
 if(ROCPROFSYS_INSTALL_EXAMPLES)
     install(TARGETS fork-example DESTINATION bin COMPONENT rocprofiler-systems-examples)
+endif()
+
+# HIP fork example (multi-process concurrency test)
+find_package(hip QUIET HINTS ${ROCmVersion_DIR} PATHS ${ROCmVersion_DIR})
+
+find_program(
+    HIPCC_EXECUTABLE
+    NAMES hipcc
+    HINTS ${ROCmVersion_DIR} ${ROCM_PATH}
+    ENV ROCM_PATH
+    /opt/rocm
+    PATHS ${ROCmVersion_DIR} ${ROCM_PATH}
+    ENV ROCM_PATH
+    /opt/rocm
+    NO_CACHE
+)
+mark_as_advanced(HIPCC_EXECUTABLE)
+
+if(HIPCC_EXECUTABLE)
+    if(NOT CMAKE_CXX_COMPILER_IS_HIPCC AND HIPCC_EXECUTABLE)
+        if(
+            CMAKE_CXX_COMPILER STREQUAL HIPCC_EXECUTABLE
+            OR "${CMAKE_CXX_COMPILER}" MATCHES "hipcc"
+        )
+            set(CMAKE_CXX_COMPILER_IS_HIPCC 1 CACHE BOOL "HIP compiler")
+        endif()
+    endif()
+
+    if(
+        CMAKE_CXX_COMPILER_IS_HIPCC
+        OR hip_FOUND
+        OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND HIPCC_EXECUTABLE)
+        OR COMMAND rocprofiler_systems_custom_compilation
+    )
+        add_executable(hipMallocConcurrencyMproc hipMallocConcurrencyMproc.cpp)
+        target_link_libraries(hipMallocConcurrencyMproc PRIVATE Threads::Threads)
+
+        if(
+            CMAKE_CXX_COMPILER_ID MATCHES "Clang"
+            AND NOT CMAKE_CXX_COMPILER_IS_HIPCC
+            AND NOT HIPCC_EXECUTABLE
+        )
+            target_link_libraries(
+                hipMallocConcurrencyMproc
+                PRIVATE
+                    $<TARGET_NAME_IF_EXISTS:rocprofiler-systems::rocprofiler-systems-compile-options>
+                    $<TARGET_NAME_IF_EXISTS:hip::host>
+                    $<TARGET_NAME_IF_EXISTS:hip::device>
+            )
+        else()
+            target_compile_options(hipMallocConcurrencyMproc PRIVATE -W -Wall)
+        endif()
+
+        if("${CMAKE_BUILD_TYPE}" MATCHES "Release")
+            target_compile_options(hipMallocConcurrencyMproc PRIVATE -g1)
+        endif()
+
+        if(NOT CMAKE_CXX_COMPILER_IS_HIPCC AND HIPCC_EXECUTABLE)
+            # defined in MacroUtilities.cmake
+            rocprofiler_systems_custom_compilation(COMPILER ${HIPCC_EXECUTABLE} TARGET hipMallocConcurrencyMproc)
+        endif()
+
+        if(ROCPROFSYS_INSTALL_EXAMPLES)
+            install(
+                TARGETS hipMallocConcurrencyMproc
+                DESTINATION bin
+                COMPONENT rocprofiler-systems-examples
+            )
+        endif()
+    else()
+        message(
+            AUTHOR_WARNING
+            "hipMallocConcurrencyMproc target could not be built (missing HIP support)"
+        )
+    endif()
+else()
+    message(
+        AUTHOR_WARNING
+        "hipcc could not be found. Cannot build hipMallocConcurrencyMproc target"
+    )
 endif()

--- a/projects/rocprofiler-systems/examples/fork/hipMallocConcurrencyMproc.cpp
+++ b/projects/rocprofiler-systems/examples/fork/hipMallocConcurrencyMproc.cpp
@@ -1,0 +1,424 @@
+#include "hip/hip_runtime.h"
+#include <assert.h>
+#include <iostream>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define REQUIRE assert
+#define HIP_CHECK(cmd)                                                                   \
+    {                                                                                    \
+        hipError_t error = cmd;                                                          \
+        if(error != hipSuccess)                                                          \
+        {                                                                                \
+            fprintf(stderr, "error: '%s'(%d) at %s:%d\n", hipGetErrorString(error),      \
+                    error, __FILE__, __LINE__);                                          \
+            exit(EXIT_FAILURE);                                                          \
+        }                                                                                \
+    }
+#define TOL 0.001
+
+namespace HipTest
+{
+// Setters and Memory Management
+
+template <typename T>
+void
+setDefaultData(size_t numElements, T* A_h, T* B_h, T* C_h)
+{
+    // Initialize the host data:
+
+    for(size_t i = 0; i < numElements; i++)
+    {
+        if(std::is_same<T, int>::value || std::is_same<T, unsigned int>::value)
+        {
+            if(A_h) A_h[i] = 3;
+            if(B_h) B_h[i] = 4;
+            if(C_h) C_h[i] = 5;
+        }
+        else if(std::is_same<T, char>::value || std::is_same<T, unsigned char>::value)
+        {
+            if(A_h) A_h[i] = 'a';
+            if(B_h) B_h[i] = 'b';
+            if(C_h) C_h[i] = 'c';
+        }
+        else
+        {
+            if(A_h) A_h[i] = 3.146f + i;
+            if(B_h) B_h[i] = 1.618f + i;
+            if(C_h) C_h[i] = 1.4f + i;
+        }
+    }
+}
+
+template <typename T>
+bool
+initArraysForHost(T** A_h, T** B_h, T** C_h, size_t N, bool usePinnedHost = false)
+{
+    size_t Nbytes = N * sizeof(T);
+
+    if(usePinnedHost)
+    {
+        if(A_h)
+        {
+            HIP_CHECK(hipHostMalloc((void**) A_h, Nbytes));
+        }
+        if(B_h)
+        {
+            HIP_CHECK(hipHostMalloc((void**) B_h, Nbytes));
+        }
+        if(C_h)
+        {
+            HIP_CHECK(hipHostMalloc((void**) C_h, Nbytes));
+        }
+    }
+    else
+    {
+        if(A_h)
+        {
+            *A_h = (T*) malloc(Nbytes);
+            REQUIRE(*A_h != nullptr);
+        }
+
+        if(B_h)
+        {
+            *B_h = (T*) malloc(Nbytes);
+            REQUIRE(*B_h != nullptr);
+        }
+
+        if(C_h)
+        {
+            *C_h = (T*) malloc(Nbytes);
+            REQUIRE(*C_h != nullptr);
+        }
+    }
+
+    setDefaultData(N, A_h ? *A_h : nullptr, B_h ? *B_h : nullptr, C_h ? *C_h : nullptr);
+    return true;
+}
+
+template <typename T>
+bool
+initArrays(T** A_d, T** B_d, T** C_d, T** A_h, T** B_h, T** C_h, size_t N,
+           bool usePinnedHost = false)
+{
+    size_t Nbytes = N * sizeof(T);
+
+    if(A_d)
+    {
+        HIP_CHECK(hipMalloc(A_d, Nbytes));
+    }
+    if(B_d)
+    {
+        HIP_CHECK(hipMalloc(B_d, Nbytes));
+    }
+    if(C_d)
+    {
+        HIP_CHECK(hipMalloc(C_d, Nbytes));
+    }
+
+    return initArraysForHost(A_h, B_h, C_h, N, usePinnedHost);
+}
+
+template <typename T>
+bool
+freeArraysForHost(T* A_h, T* B_h, T* C_h, bool usePinnedHost)
+{
+    if(usePinnedHost)
+    {
+        if(A_h)
+        {
+            HIP_CHECK(hipHostFree(A_h));
+        }
+        if(B_h)
+        {
+            HIP_CHECK(hipHostFree(B_h));
+        }
+        if(C_h)
+        {
+            HIP_CHECK(hipHostFree(C_h));
+        }
+    }
+    else
+    {
+        if(A_h)
+        {
+            free(A_h);
+        }
+        if(B_h)
+        {
+            free(B_h);
+        }
+        if(C_h)
+        {
+            free(C_h);
+        }
+    }
+    return true;
+}
+
+template <typename T>
+bool
+freeArrays(T* A_d, T* B_d, T* C_d, T* A_h, T* B_h, T* C_h, bool usePinnedHost)
+{
+    if(A_d)
+    {
+        HIP_CHECK(hipFree(A_d));
+    }
+    if(B_d)
+    {
+        HIP_CHECK(hipFree(B_d));
+    }
+    if(C_d)
+    {
+        HIP_CHECK(hipFree(C_d));
+    }
+
+    return freeArraysForHost(A_h, B_h, C_h, usePinnedHost);
+}
+
+static inline unsigned
+setNumBlocks(unsigned blocksPerCU, unsigned threadsPerBlock, size_t N)
+{
+    int device{ 0 };
+    HIP_CHECK(hipGetDevice(&device));
+    hipDeviceProp_t props{};
+    HIP_CHECK(hipGetDeviceProperties(&props, device));
+
+    unsigned blocks = props.multiProcessorCount * blocksPerCU;
+    if(blocks * threadsPerBlock < N)
+    {
+        blocks = (N + threadsPerBlock - 1) / threadsPerBlock;
+    }
+
+    return blocks;
+}
+
+template <typename T>
+__global__ void
+vectorADD(const T* A_d, const T* B_d, T* C_d, size_t NELEM)
+{
+    size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
+    size_t stride = blockDim.x * gridDim.x;
+
+    for(size_t i = offset; i < NELEM; i += stride)
+    {
+        C_d[i] = A_d[i] + B_d[i];
+    }
+}
+
+template <typename T>
+size_t
+checkVectors(T* A, T* B, T* Out, size_t N, T (*F)(T a, T b), bool expectMatch = true,
+             bool reportMismatch = true)
+{
+    size_t mismatchCount     = 0;
+    size_t firstMismatch     = 0;
+    size_t mismatchesToPrint = 10;
+    for(size_t i = 0; i < N; i++)
+    {
+        T expected = F(A[i], B[i]);
+        if(std::fabs(Out[i] - expected) > TOL)
+        {
+            if(mismatchCount == 0)
+            {
+                firstMismatch = i;
+            }
+            mismatchCount++;
+            if((mismatchCount <= mismatchesToPrint) && expectMatch)
+            {
+                std::cout << "Mismatch at " << i << " Computed: " << Out[i]
+                          << " Expeted: " << expected << std::endl;
+                REQUIRE(false);
+            }
+        }
+    }
+
+    if(reportMismatch)
+    {
+        if(expectMatch)
+        {
+            if(mismatchCount)
+            {
+                std::cout << mismatchCount
+                          << " Mismatches  First Mismatch at index : " << firstMismatch
+                          << std::endl;
+                REQUIRE(false);
+            }
+        }
+        else
+        {
+            if(mismatchCount == 0)
+            {
+                std::cout << "Expected Mismatch but not found any" << std::endl;
+                REQUIRE(false);
+            }
+        }
+    }
+
+    return mismatchCount;
+}
+template <typename T>  // pointer type
+bool
+checkArray(T* hData, T* hOutputData, size_t width, size_t height, size_t depth = 1)
+{
+    for(size_t i = 0; i < depth; i++)
+    {
+        for(size_t j = 0; j < height; j++)
+        {
+            for(size_t k = 0; k < width; k++)
+            {
+                int offset = i * width * height + j * width + k;
+                if(!isEqual(hData[offset], hOutputData[offset]))
+                {
+                    std::cout << "Mismatch at [" << i << "," << j << "," << k
+                              << "]:" << getString(hData[offset]) << "----"
+                              << getString(hOutputData[offset]) << std::endl;
+                    return false;
+                }
+            }
+        }
+    }
+    return true;
+}
+
+template <typename T>
+size_t
+checkVectorADD(T* A_h, T* B_h, T* result_H, size_t N, bool expectMatch = true,
+               bool reportMismatch = true)
+{
+    return checkVectors<T>(
+        A_h, B_h, result_H, N, [](T a, T b) { return a + b; }, expectMatch,
+        reportMismatch);
+}
+}  // namespace HipTest
+
+/**
+ * Validates data consistency on supplied gpu
+ */
+static bool
+validateMemoryOnGPU(int gpu, bool concurOnOneGPU = false)
+{
+    int *          A_d, *B_d, *C_d;
+    int *          A_h, *B_h, *C_h;
+    size_t         prevAvl, prevTot, curAvl, curTot;
+    bool           TestPassed      = true;
+    constexpr auto N               = 4 * 1024 * 1024;
+    constexpr auto blocksPerCU     = 6;  // to hide latency
+    constexpr auto threadsPerBlock = 256;
+    size_t         Nbytes          = N * sizeof(int);
+
+    HIP_CHECK(hipSetDevice(gpu));
+    HIP_CHECK(hipMemGetInfo(&prevAvl, &prevTot));
+    HipTest::initArrays(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, N, false);
+    HIP_CHECK(hipMemGetInfo(&curAvl, &curTot));
+
+    if(!concurOnOneGPU && (prevAvl < curAvl || prevTot != curTot))
+    {
+        // In concurrent calls on one GPU, we cannot verify leaking in this way
+        printf("%s : Memory allocation mismatch observed."
+               "Possible memory leak.\n",
+               __func__);
+        TestPassed &= false;
+    }
+
+    unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, N);
+
+    HIP_CHECK(hipMemcpy(A_d, A_h, Nbytes, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(B_d, B_h, Nbytes, hipMemcpyHostToDevice));
+
+    hipLaunchKernelGGL(HipTest::vectorADD, dim3(blocks), dim3(threadsPerBlock), 0, 0,
+                       static_cast<const int*>(A_d), static_cast<const int*>(B_d), C_d,
+                       N);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipMemcpy(C_h, C_d, Nbytes, hipMemcpyDeviceToHost));
+
+    if(!HipTest::checkVectorADD(A_h, B_h, C_h, N))
+    {
+        printf("Validation PASSED for gpu %d from pid %d\n", gpu, getpid());
+    }
+    else
+    {
+        printf("Validation FAILED for gpu %d from pid %d\n", gpu, getpid());
+        TestPassed = false;
+    }
+
+    HIP_CHECK(hipMemGetInfo(&prevAvl, &prevTot));
+    HipTest::freeArrays(A_d, B_d, C_d, A_h, B_h, C_h, false);
+    HIP_CHECK(hipMemGetInfo(&curAvl, &curTot));
+
+    if(!concurOnOneGPU && (curAvl < prevAvl || prevTot != curTot))
+    {
+        // In concurrent calls on one GPU, we cannot verify leaking in this way
+        std::cout << "validateMemoryOnGPU : Memory allocation mismatch observed."
+                  << "Possible memory leak." << std::endl;
+        TestPassed = false;
+    }
+
+    if(!concurOnOneGPU && (prevAvl != curAvl || prevTot != curTot))
+    {
+        // In concurrent calls on one GPU, we cannot verify leaking in this way
+        printf("%s : Memory allocation mismatch observed."
+               "Possible memory leak.\n",
+               __func__);
+        TestPassed = false;
+    }
+
+    return TestPassed;
+}
+
+/**
+ * Parallel execution of parent and child on gpu0
+ */
+void
+Unit_hipMalloc_ChildConcurrencyDefaultGpu()
+{
+    int            pid        = 0;
+    constexpr auto resSuccess = 0, resFailure = 1;
+
+    if((pid = fork()) < 0)
+    {
+        std::cout << "Child_Concurrency_DefaultGpu : fork() returned error : " << pid
+                  << std::endl;
+        REQUIRE(false);
+    }
+    else if(!pid)
+    {  // Child process
+        bool TestPassedChild = false;
+
+        // Allocates and validates memory on Gpu0 simultaneously with parent
+        TestPassedChild = validateMemoryOnGPU(0, true);
+
+        if(TestPassedChild)
+        {
+            exit(resSuccess);  // child exit with success status
+        }
+        else
+        {
+            exit(resFailure);  // child exit with failure status
+        }
+    }
+    else
+    {  // Parent process
+        int exitStatus;
+
+        // Allocates and validates memory on Gpu0 simultaneously with child
+        bool TestPassed = validateMemoryOnGPU(0, true);
+
+        // Wait and get result from child
+        pid = wait(&exitStatus);
+        if((WEXITSTATUS(exitStatus) == resFailure) || (pid < 0)) TestPassed = false;
+
+        // Explicitly use the variable to avoid compiler warning
+        (void) TestPassed;
+        REQUIRE(TestPassed == true);
+    }
+}
+
+int
+main()
+{
+    Unit_hipMalloc_ChildConcurrencyDefaultGpu();
+    std::cout << "Unit_hipMalloc_ChildConcurrencyDefaultGpu PASSED!" << std::endl;
+    return 0;
+}

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -41,6 +41,7 @@
 #include "core/config.hpp"
 #include "core/debug.hpp"
 #include "core/gpu.hpp"
+#include "core/gpu_metrics.hpp"
 #include "core/node_info.hpp"
 #include "core/perfetto.hpp"
 #include "core/state.hpp"
@@ -127,7 +128,7 @@ metadata_initialize_smi_tracks(size_t gpu_id)
         }
     };
 
-    if(gpu::is_vcn_activity_supported(gpu_id))
+    if(gpu::vcn_is_device_level_only(gpu_id))
     {
         add_vcn_track(std::nullopt);
     }
@@ -139,7 +140,7 @@ metadata_initialize_smi_tracks(size_t gpu_id)
         }
     }
 
-    if(gpu::is_jpeg_activity_supported(gpu_id))
+    if(gpu::jpeg_is_device_level_only(gpu_id))
     {
         add_jpeg_track(std::nullopt);
     }
@@ -150,6 +151,49 @@ metadata_initialize_smi_tracks(size_t gpu_id)
             add_jpeg_track(xcp);
         }
     }
+
+    // Add XGMI tracks using specific categories for each metric type
+    trace_cache::get_metadata_registry().add_track(
+        { trace_cache::info::annotate_with_device_id<category::amd_smi_xgmi_link_width>(
+              gpu_id),
+          thread_id, "{}" });
+    trace_cache::get_metadata_registry().add_track(
+        { trace_cache::info::annotate_with_device_id<category::amd_smi_xgmi_link_speed>(
+              gpu_id),
+          thread_id, "{}" });
+
+    for(size_t i = 0; i < AMDSMI_MAX_NUM_XGMI_LINKS; ++i)
+    {
+        auto read_name =
+            trace_cache::info::annotate_with_device_id<category::amd_smi_xgmi_read_data>(
+                gpu_id, std::nullopt, i);
+        trace_cache::get_metadata_registry().add_track(
+            { read_name.c_str(), thread_id, "{}" });
+
+        auto write_name =
+            trace_cache::info::annotate_with_device_id<category::amd_smi_xgmi_write_data>(
+                gpu_id, std::nullopt, i);
+        trace_cache::get_metadata_registry().add_track(
+            { write_name.c_str(), thread_id, "{}" });
+    }
+
+    // Add PCIe tracks using specific categories for each metric
+    trace_cache::get_metadata_registry().add_track(
+        { trace_cache::info::annotate_with_device_id<category::amd_smi_pcie_link_width>(
+              gpu_id),
+          thread_id, "{}" });
+    trace_cache::get_metadata_registry().add_track(
+        { trace_cache::info::annotate_with_device_id<category::amd_smi_pcie_link_speed>(
+              gpu_id),
+          thread_id, "{}" });
+    trace_cache::get_metadata_registry().add_track(
+        { trace_cache::info::annotate_with_device_id<
+              category::amd_smi_pcie_bandwidth_acc>(gpu_id),
+          thread_id, "{}" });
+    trace_cache::get_metadata_registry().add_track(
+        { trace_cache::info::annotate_with_device_id<
+              category::amd_smi_pcie_bandwidth_inst>(gpu_id),
+          thread_id, "{}" });
 }
 
 void
@@ -250,7 +294,7 @@ metadata_initialize_smi_pmc(size_t gpu_id)
         }
     };
 
-    if(gpu::is_vcn_activity_supported(gpu_id))
+    if(gpu::vcn_is_device_level_only(gpu_id))
     {
         add_vcn_pmc(std::nullopt);
     }
@@ -262,7 +306,7 @@ metadata_initialize_smi_pmc(size_t gpu_id)
         }
     }
 
-    if(gpu::is_jpeg_activity_supported(gpu_id))
+    if(gpu::jpeg_is_device_level_only(gpu_id))
     {
         add_jpeg_pmc(std::nullopt);
     }
@@ -273,6 +317,75 @@ metadata_initialize_smi_pmc(size_t gpu_id)
             add_jpeg_pmc(xcp);
         }
     }
+
+    // Add XGMI PMC info using specific categories for each metric type
+    trace_cache::get_metadata_registry().add_pmc_info(
+        { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+          trait::name<category::amd_smi_xgmi_link_width>::value, "XgmiLinkWidth",
+          trait::name<category::amd_smi_xgmi_link_width>::description, LONG_DESCRIPTION,
+          COMPONENT, "bits", rocprofsys::trace_cache::ABSOLUTE, BLOCK, EXPRESSION, 0,
+          0 });
+
+    trace_cache::get_metadata_registry().add_pmc_info(
+        { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+          trait::name<category::amd_smi_xgmi_link_speed>::value, "XgmiLinkSpeed",
+          trait::name<category::amd_smi_xgmi_link_speed>::description, LONG_DESCRIPTION,
+          COMPONENT, "GT/s", rocprofsys::trace_cache::ABSOLUTE, BLOCK, EXPRESSION, 0,
+          0 });
+
+    for(size_t i = 0; i < AMDSMI_MAX_NUM_XGMI_LINKS; ++i)
+    {
+        std::stringstream read_name_ss, read_symbol_ss;
+        read_name_ss << trait::name<category::amd_smi_xgmi_read_data>::value << "_" << i;
+        read_symbol_ss << "XgmiRead_" << i;
+
+        trace_cache::get_metadata_registry().add_pmc_info(
+            { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+              read_name_ss.str(), read_symbol_ss.str(),
+              trait::name<category::amd_smi_xgmi_read_data>::description,
+              LONG_DESCRIPTION, COMPONENT, "KB", rocprofsys::trace_cache::ABSOLUTE, BLOCK,
+              EXPRESSION, 0, 0 });
+
+        std::stringstream write_name_ss, write_symbol_ss;
+        write_name_ss << trait::name<category::amd_smi_xgmi_write_data>::value << "_"
+                      << i;
+        write_symbol_ss << "XgmiWrite_" << i;
+
+        trace_cache::get_metadata_registry().add_pmc_info(
+            { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+              write_name_ss.str(), write_symbol_ss.str(),
+              trait::name<category::amd_smi_xgmi_write_data>::description,
+              LONG_DESCRIPTION, COMPONENT, "KB", rocprofsys::trace_cache::ABSOLUTE, BLOCK,
+              EXPRESSION, 0, 0 });
+    }
+
+    // Add PCIe PMC info using specific categories for each metric
+    trace_cache::get_metadata_registry().add_pmc_info(
+        { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+          trait::name<category::amd_smi_pcie_link_width>::value, "PcieLinkWidth",
+          trait::name<category::amd_smi_pcie_link_width>::description, LONG_DESCRIPTION,
+          COMPONENT, "", rocprofsys::trace_cache::ABSOLUTE, BLOCK, EXPRESSION, 0, 0 });
+
+    trace_cache::get_metadata_registry().add_pmc_info(
+        { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+          trait::name<category::amd_smi_pcie_link_speed>::value, "PcieLinkSpeed",
+          trait::name<category::amd_smi_pcie_link_speed>::description, LONG_DESCRIPTION,
+          COMPONENT, "GT/s", rocprofsys::trace_cache::ABSOLUTE, BLOCK, EXPRESSION, 0,
+          0 });
+
+    trace_cache::get_metadata_registry().add_pmc_info(
+        { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+          trait::name<category::amd_smi_pcie_bandwidth_acc>::value, "PcieBwAcc",
+          trait::name<category::amd_smi_pcie_bandwidth_acc>::description,
+          LONG_DESCRIPTION, COMPONENT, "MB", rocprofsys::trace_cache::ABSOLUTE, BLOCK,
+          EXPRESSION, 0, 0 });
+
+    trace_cache::get_metadata_registry().add_pmc_info(
+        { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+          trait::name<category::amd_smi_pcie_bandwidth_inst>::value, "PcieBwInst",
+          trait::name<category::amd_smi_pcie_bandwidth_inst>::description,
+          LONG_DESCRIPTION, COMPONENT, "MB/s", rocprofsys::trace_cache::ABSOLUTE, BLOCK,
+          EXPRESSION, 0, 0 });
 }
 
 auto&
@@ -335,70 +448,21 @@ get_state()
 }
 
 std::vector<uint8_t>
-serialize_xcp_metrics(const bool& use_vcn_activity, const bool& use_jpeg_activity,
-                      const amdsmi_gpu_metrics_t& gpu_metrics)
+serialize_gpu_metrics(uint32_t device_id, const data::gpu_metrics_t& metrics,
+                      const gpu::gpu_metrics_capabilities_t& capabilities)
 {
-    // Chunk:
-    // <vcn_data_0>..<vcn_data_[vcn_count]> // lower and higher byte
-    // <jpeg_data_0>..<jpeg_data_[jpeg_count]> // lower and higher byte
+    // Get settings for this device
+    auto settings = get_settings(device_id);
 
-    // Serialized:
-    // <is_vcn_supported>
-    // <is_jpeg_supported>
-    // <xcp_count>
-    // <vcn_count>
-    // <jpeg_count>
-    // Chunk_0
-    // ...
-    // Chunk_[xcp_count]
+    // Convert amd_smi::settings to gpu::gpu_metrics_settings_t
+    gpu::gpu_metrics_settings_t gpu_settings;
+    gpu_settings.vcn_activity  = settings.vcn_activity;
+    gpu_settings.jpeg_activity = settings.jpeg_activity;
+    gpu_settings.xgmi          = settings.xgmi;
+    gpu_settings.pcie          = settings.pcie;
 
-    constexpr uint8_t vcn_count          = AMDSMI_MAX_NUM_VCN;
-    constexpr uint8_t jpeg_count         = AMDSMI_MAX_NUM_JPEG;
-    constexpr uint8_t xcp_count          = AMDSMI_MAX_NUM_XCP;
-    constexpr size_t  elem_size          = sizeof(uint16_t) / sizeof(uint8_t);
-    constexpr uint8_t vector_size_header = sizeof(uint8_t);
-    constexpr uint8_t serialized_data_headers =
-        5 * vector_size_header;  // is_vcn_supported + is_jpeg_supported + xcp_count +
-                                 // vcn_count + jpeg_count
-    constexpr size_t chunk_size = ((vcn_count + jpeg_count) * elem_size);
-
-    auto serialize_uint16_array = [](std::vector<uint8_t>& data, const uint16_t* arr,
-                                     int array_size) {
-        for(int i = 0; i < array_size; ++i)
-        {
-            data.push_back(static_cast<uint8_t>(arr[i] & 0xFF));
-            data.push_back(static_cast<uint8_t>((arr[i] >> 8) & 0xFF));
-        }
-    };
-
-    std::vector<uint8_t> result;
-
-    const bool   is_vcn_jpeg_supported = (use_vcn_activity || use_jpeg_activity);
-    const size_t chunk_count           = is_vcn_jpeg_supported ? 1 : xcp_count;
-    const size_t total_size = serialized_data_headers + (chunk_count * chunk_size);
-
-    result.reserve(total_size);
-
-    result.push_back((uint8_t) use_vcn_activity);
-    result.push_back((uint8_t) use_jpeg_activity);
-    result.push_back(chunk_count);
-    result.push_back(vcn_count);
-    result.push_back(jpeg_count);
-
-    for(size_t count = 0; count < chunk_count; ++count)
-    {
-        const auto* vcn_data =
-            (is_vcn_jpeg_supported ? gpu_metrics.vcn_activity
-                                   : gpu_metrics.xcp_stats[count].vcn_busy);
-        const auto* jpeg_data =
-            (is_vcn_jpeg_supported ? gpu_metrics.jpeg_activity
-                                   : gpu_metrics.xcp_stats[count].jpeg_busy);
-
-        serialize_uint16_array(result, vcn_data, vcn_count);
-        serialize_uint16_array(result, jpeg_data, jpeg_count);
-    }
-
-    return result;
+    // Use the shared serialization function
+    return gpu::serialize_gpu_metrics(metrics, capabilities, gpu_settings);
 }
 
 size_t
@@ -425,6 +489,12 @@ serialize_settings(uint32_t _device_id)
     settings_bits.set(
         static_cast<int>(trace_cache::amd_smi_sample::settings_positions::jpeg_activity),
         settings.jpeg_activity);
+    settings_bits.set(
+        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::xgmi),
+        settings.xgmi);
+    settings_bits.set(
+        static_cast<int>(trace_cache::amd_smi_sample::settings_positions::pcie),
+        settings.pcie);
     return settings_bits.to_ulong();
 }
 
@@ -446,7 +516,7 @@ data::sample(uint32_t _device_id)
     auto _timestamp = tim::get_clock_real_now<size_t, std::nano>();
     assert(_timestamp < std::numeric_limits<int64_t>::max());
     amdsmi_gpu_metrics_t _gpu_metrics;
-    bool                 _vcn_or_jpeg_activity_enabled = false;
+    bool                 _gpu_metrics_needed = false;
 
     auto _state = get_state().load();
 
@@ -487,68 +557,153 @@ data::sample(uint32_t _device_id)
 #endif
     ROCPROFSYS_AMDSMI_GET(get_settings(m_dev_id).mem_usage, amdsmi_get_gpu_memory_usage,
                           sample_handle, AMDSMI_MEM_TYPE_VRAM, &m_mem_usage);
-    _vcn_or_jpeg_activity_enabled =
-        get_settings(m_dev_id).vcn_activity || get_settings(m_dev_id).jpeg_activity;
-    ROCPROFSYS_AMDSMI_GET(_vcn_or_jpeg_activity_enabled, amdsmi_get_gpu_metrics_info,
-                          sample_handle, &_gpu_metrics);
 
-    // Process metrics if either VCN or JPEG activity is enabled
-    if(_vcn_or_jpeg_activity_enabled)
+    // Check if GPU metrics are needed for VCN, JPEG, XGMI, or PCIe
+    _gpu_metrics_needed = get_settings(m_dev_id).vcn_activity ||
+                          get_settings(m_dev_id).jpeg_activity ||
+                          get_settings(m_dev_id).xgmi || get_settings(m_dev_id).pcie;
+
+    ROCPROFSYS_AMDSMI_GET(_gpu_metrics_needed, amdsmi_get_gpu_metrics_info, sample_handle,
+                          &_gpu_metrics);
+
+    // Determine if basic metrics are enabled
+    bool _basic_metrics_enabled =
+        get_settings(m_dev_id).busy || get_settings(m_dev_id).temp ||
+        get_settings(m_dev_id).power || get_settings(m_dev_id).mem_usage;
+
+    // Process GPU metrics if needed
+    if(_gpu_metrics_needed || _basic_metrics_enabled)
     {
-        // Helper lambda to fill busy metrics from a source array
-        auto fill_busy_metrics = [](auto& dest, const auto& src) {
-            for(const auto& val : src)
-            {
-                if(val != UINT16_MAX) dest.push_back(val);
-            }
-        };
+        gpu_metrics_t                   metrics;
+        bool                            has_data = false;
+        gpu::gpu_metrics_capabilities_t capabilities;
 
-        if(gpu::is_vcn_activity_supported(m_dev_id) &&
-           gpu::is_jpeg_activity_supported(m_dev_id))
+        if(_gpu_metrics_needed)
         {
-            // Both VCN and JPEG are supported - create one entry with both metrics
-            xcp_metrics_t metrics;
-            fill_busy_metrics(metrics.vcn_busy, _gpu_metrics.vcn_activity);
-            fill_busy_metrics(metrics.jpeg_busy, _gpu_metrics.jpeg_activity);
-            if(!metrics.vcn_busy.empty() || !metrics.jpeg_busy.empty())
-                m_xcp_metrics.push_back(metrics);
-        }
-        else if(gpu::is_vcn_activity_supported(m_dev_id))
-        {
-            // Only VCN is supported
-            xcp_metrics_t metrics;
-            fill_busy_metrics(metrics.vcn_busy, _gpu_metrics.vcn_activity);
-            if(!metrics.vcn_busy.empty()) m_xcp_metrics.push_back(metrics);
-        }
-        else if(gpu::is_jpeg_activity_supported(m_dev_id))
-        {
-            // Only JPEG is supported
-            xcp_metrics_t metrics;
-            fill_busy_metrics(metrics.jpeg_busy, _gpu_metrics.jpeg_activity);
-            if(!metrics.jpeg_busy.empty()) m_xcp_metrics.push_back(metrics);
-        }
-        else
-        {
-            // Neither is supported - use XCP stats
-            // Each XCP gets one entry with both its VCN and JPEG metrics
-            for(const auto& xcp : _gpu_metrics.xcp_stats)
+            capabilities.flags.vcn_is_device_level_only =
+                gpu::vcn_is_device_level_only(m_dev_id);
+            capabilities.flags.jpeg_is_device_level_only =
+                gpu::jpeg_is_device_level_only(m_dev_id);
+
+            // Helper lambda to filter max uint values (unsupported) - returns 0 if max,
+            // otherwise the value
+            auto filter_max_uint_value = [](const auto& value) {
+                using ValueType = std::decay_t<decltype(value)>;
+                return (value == std::numeric_limits<ValueType>::max()) ? ValueType{ 0 }
+                                                                        : value;
+            };
+
+            auto fill_gpu_metrics = [](auto& dest, const auto& src, auto max_val) {
+                for(const auto& val : src)
+                {
+                    if(val != max_val) dest.push_back(val);
+                }
+            };
+
+            if(get_settings(m_dev_id).vcn_activity)
             {
-                xcp_metrics_t metrics;
-                fill_busy_metrics(metrics.vcn_busy, xcp.vcn_busy);
-                fill_busy_metrics(metrics.jpeg_busy, xcp.jpeg_busy);
-                if(!metrics.vcn_busy.empty() || !metrics.jpeg_busy.empty())
-                    m_xcp_metrics.push_back(metrics);
+                if(capabilities.flags.vcn_is_device_level_only)
+                {
+                    fill_gpu_metrics(metrics.vcn_activity, _gpu_metrics.vcn_activity,
+                                     UINT16_MAX);
+                    if(!metrics.vcn_activity.empty()) has_data = true;
+                }
+                else
+                {
+                    for(const auto& xcp : _gpu_metrics.xcp_stats)
+                    {
+                        std::vector<uint16_t> xcp_vcn_data;
+                        fill_gpu_metrics(xcp_vcn_data, xcp.vcn_busy, UINT16_MAX);
+                        if(!xcp_vcn_data.empty())
+                        {
+                            metrics.vcn_busy.push_back(std::move(xcp_vcn_data));
+                            has_data = true;
+                        }
+                    }
+                }
             }
+
+            if(get_settings(m_dev_id).jpeg_activity)
+            {
+                if(capabilities.flags.jpeg_is_device_level_only)
+                {
+                    fill_gpu_metrics(metrics.jpeg_activity, _gpu_metrics.jpeg_activity,
+                                     UINT16_MAX);
+                    if(!metrics.jpeg_activity.empty()) has_data = true;
+                }
+                else
+                {
+                    for(const auto& xcp : _gpu_metrics.xcp_stats)
+                    {
+                        std::vector<uint16_t> xcp_jpeg_data;
+                        fill_gpu_metrics(xcp_jpeg_data, xcp.jpeg_busy, UINT16_MAX);
+                        if(!xcp_jpeg_data.empty())
+                        {
+                            metrics.jpeg_busy.push_back(std::move(xcp_jpeg_data));
+                            has_data = true;
+                        }
+                    }
+                }
+            }
+
+            // Process XGMI metrics if enabled
+            if(get_settings(m_dev_id).xgmi)
+            {
+                // Filter scalar values - returns 0 if unsupported (max value)
+                metrics.xgmi_link_width =
+                    filter_max_uint_value(_gpu_metrics.xgmi_link_width);
+                metrics.xgmi_link_speed =
+                    filter_max_uint_value(_gpu_metrics.xgmi_link_speed);
+
+                // Vector values filtered by fill_gpu_metrics
+                fill_gpu_metrics(metrics.xgmi_read_data_acc,
+                                 _gpu_metrics.xgmi_read_data_acc, UINT64_MAX);
+                fill_gpu_metrics(metrics.xgmi_write_data_acc,
+                                 _gpu_metrics.xgmi_write_data_acc, UINT64_MAX);
+
+                if(metrics.xgmi_link_width != 0 || metrics.xgmi_link_speed != 0 ||
+                   !metrics.xgmi_read_data_acc.empty() ||
+                   !metrics.xgmi_write_data_acc.empty())
+                {
+                    has_data = true;
+                }
+            }
+
+            // Process PCIe metrics if enabled
+            if(get_settings(m_dev_id).pcie)
+            {
+                // Filter scalar values - returns 0 if unsupported (max value)
+                metrics.pcie_link_width =
+                    filter_max_uint_value(_gpu_metrics.pcie_link_width);
+                metrics.pcie_link_speed =
+                    filter_max_uint_value(_gpu_metrics.pcie_link_speed);
+                metrics.pcie_bandwidth_acc =
+                    filter_max_uint_value(_gpu_metrics.pcie_bandwidth_acc);
+                metrics.pcie_bandwidth_inst =
+                    filter_max_uint_value(_gpu_metrics.pcie_bandwidth_inst);
+
+                if(metrics.pcie_link_width != 0 || metrics.pcie_link_speed != 0 ||
+                   metrics.pcie_bandwidth_acc != 0 || metrics.pcie_bandwidth_inst != 0)
+                {
+                    has_data = true;
+                }
+            }
+        }
+
+        // Store samples if basic metrics are enabled OR if there's advanced metric data
+        if(_basic_metrics_enabled || has_data)
+        {
+            trace_cache::get_buffer_storage().store(
+                trace_cache::entry_type::amd_smi_sample, serialize_settings(m_dev_id),
+                _device_id, _timestamp, m_busy_perc.gfx_activity,
+                m_busy_perc.umc_activity, m_busy_perc.mm_activity,
+                m_power.current_socket_power, m_temp, m_mem_usage,
+                serialize_gpu_metrics(m_dev_id, metrics, capabilities));
+
+            if(has_data) m_gpu_metrics.push_back(metrics);
         }
     }
 #undef ROCPROFSYS_AMDSMI_GET
-
-    trace_cache::get_buffer_storage().store(
-        trace_cache::entry_type::amd_smi_sample, serialize_settings(m_dev_id), _device_id,
-        _timestamp, m_busy_perc.gfx_activity, m_busy_perc.umc_activity,
-        m_busy_perc.mm_activity, m_power.current_socket_power, m_temp, m_mem_usage,
-        serialize_xcp_metrics(gpu::is_vcn_activity_supported(m_dev_id),
-                              gpu::is_jpeg_activity_supported(m_dev_id), _gpu_metrics));
 }
 
 void
@@ -741,25 +896,28 @@ data::post_process(uint32_t _dev_id)
             }
             if(_settings.vcn_activity)
             {
-                if(itr.m_xcp_metrics.empty())
+                if(itr.m_gpu_metrics.empty())
                 {
                     ROCPROFSYS_VERBOSE(
                         1, "No VCN activity data collected from device %u\n", _dev_id);
                 }
-                else if(gpu::is_vcn_activity_supported(_dev_id))
+                else if(gpu::vcn_is_device_level_only(_dev_id))
                 {
-                    // For VCN activity, use simple indexing
-                    for(std::size_t i = 0; i < std::size(itr.m_xcp_metrics[0].vcn_busy);
-                        ++i)
+                    // For VCN activity supported: use vcn_activity vector
+                    for(std::size_t i = 0;
+                        i < std::size(itr.m_gpu_metrics[0].vcn_activity); ++i)
                         counter_track::emplace(_dev_id, addendum_blk(i, "VCN Activity"),
                                                "%");
                 }
                 else
                 {
-                    for(std::size_t xcp = 0; xcp < std::size(itr.m_xcp_metrics); ++xcp)
+                    // For VCN activity NOT supported: use vcn_busy vector with per-XCP
+                    // organization
+                    for(size_t xcp = 0; xcp < itr.m_gpu_metrics[0].vcn_busy.size(); ++xcp)
                     {
-                        for(std::size_t i = 0;
-                            i < std::size(itr.m_xcp_metrics[xcp].vcn_busy); ++i)
+                        // Loop through each XCP's VCN busy values
+                        for(size_t i = 0; i < itr.m_gpu_metrics[0].vcn_busy[xcp].size();
+                            ++i)
                         {
                             counter_track::emplace(
                                 _dev_id, addendum_blk(i, "VCN Activity", xcp), "%");
@@ -769,27 +927,71 @@ data::post_process(uint32_t _dev_id)
             }
             if(_settings.jpeg_activity)
             {
-                if(itr.m_xcp_metrics.empty())
+                if(itr.m_gpu_metrics.empty())
                 {
                     ROCPROFSYS_VERBOSE(
                         1, "No JPEG activity data collected from device %u\n", _dev_id);
                 }
-                else if(gpu::is_jpeg_activity_supported(_dev_id))
+                else if(gpu::jpeg_is_device_level_only(_dev_id))
                 {
-                    for(std::size_t i = 0; i < std::size(itr.m_xcp_metrics[0].jpeg_busy);
-                        ++i)
+                    // For JPEG activity supported: use jpeg_activity vector
+                    for(std::size_t i = 0;
+                        i < std::size(itr.m_gpu_metrics[0].jpeg_activity); ++i)
                         counter_track::emplace(_dev_id, addendum_blk(i, "JPEG Activity"),
                                                "%");
                 }
                 else
                 {
-                    for(std::size_t xcp = 0; xcp < std::size(itr.m_xcp_metrics); ++xcp)
+                    // For JPEG activity NOT supported: use jpeg_busy vector with per-XCP
+                    // organization
+                    for(size_t xcp = 0; xcp < itr.m_gpu_metrics[0].jpeg_busy.size();
+                        ++xcp)
                     {
-                        for(std::size_t i = 0;
-                            i < std::size(itr.m_xcp_metrics[xcp].jpeg_busy); ++i)
+                        // Loop through each XCP's JPEG busy values
+                        for(size_t i = 0; i < itr.m_gpu_metrics[0].jpeg_busy[xcp].size();
+                            ++i)
+                        {
                             counter_track::emplace(
                                 _dev_id, addendum_blk(i, "JPEG Activity", xcp), "%");
+                        }
                     }
+                }
+            }
+            if(_settings.xgmi)
+            {
+                if(itr.m_gpu_metrics.empty())
+                {
+                    ROCPROFSYS_VERBOSE(
+                        1, "No XGMI activity data collected from device %u\n", _dev_id);
+                }
+                else
+                {
+                    counter_track::emplace(_dev_id, addendum("XGMI Link Width"), "bits");
+                    counter_track::emplace(_dev_id, addendum("XGMI Link Speed"), "GT/s");
+                    for(std::size_t i = 0;
+                        i < std::size(itr.m_gpu_metrics[0].xgmi_read_data_acc); ++i)
+                        counter_track::emplace(_dev_id, addendum_blk(i, "XGMI Read Data"),
+                                               "KB");
+                    for(std::size_t i = 0;
+                        i < std::size(itr.m_gpu_metrics[0].xgmi_write_data_acc); ++i)
+                        counter_track::emplace(_dev_id,
+                                               addendum_blk(i, "XGMI Write Data"), "KB");
+                }
+            }
+            if(_settings.pcie)
+            {
+                if(itr.m_gpu_metrics.empty())
+                {
+                    ROCPROFSYS_VERBOSE(
+                        1, "No PCIe activity data collected from device %u\n", _dev_id);
+                }
+                else
+                {
+                    counter_track::emplace(_dev_id, addendum("PCIe Link Width"), "");
+                    counter_track::emplace(_dev_id, addendum("PCIe Link Speed"), "GT/s");
+                    counter_track::emplace(_dev_id, addendum("PCIe Bandwidth Acc"), "MB");
+                    counter_track::emplace(_dev_id, addendum("PCIe Bandwidth Inst"),
+                                           "MB/s");
                 }
             }
         };
@@ -822,32 +1024,97 @@ data::post_process(uint32_t _dev_id)
                               counter_track::at(_dev_id, track_index++), _ts, _usage);
             }
 
-            if(_settings.vcn_activity && !itr.m_xcp_metrics.empty())
+            if(_settings.vcn_activity && !itr.m_gpu_metrics.empty())
             {
-                // Iterate over all XCPs and their VCN busy/activity values
-                for(const auto& metrics : itr.m_xcp_metrics)
+                if(gpu::vcn_is_device_level_only(_dev_id))
                 {
-                    for(const auto& vcn_val : metrics.vcn_busy)
+                    // Device-level VCN activity
+                    for(const auto& vcn_val : itr.m_gpu_metrics[0].vcn_activity)
                     {
                         TRACE_COUNTER("device_vcn_activity",
                                       counter_track::at(_dev_id, track_index++), _ts,
                                       vcn_val);
                     }
                 }
+                else
+                {
+                    // XCP-level VCN busy (per-XCP organization)
+                    for(const auto& xcp_data : itr.m_gpu_metrics[0].vcn_busy)
+                    {
+                        for(const auto& vcn_val : xcp_data)
+                        {
+                            TRACE_COUNTER("device_vcn_activity",
+                                          counter_track::at(_dev_id, track_index++), _ts,
+                                          vcn_val);
+                        }
+                    }
+                }
             }
 
-            if(_settings.jpeg_activity && !itr.m_xcp_metrics.empty())
+            if(_settings.jpeg_activity && !itr.m_gpu_metrics.empty())
             {
-                // Iterate over all XCPs and their JPEG busy/activity values
-                for(const auto& metrics : itr.m_xcp_metrics)
+                if(gpu::jpeg_is_device_level_only(_dev_id))
                 {
-                    for(const auto& jpeg_val : metrics.jpeg_busy)
+                    // Device-level JPEG activity
+                    for(const auto& jpeg_val : itr.m_gpu_metrics[0].jpeg_activity)
                     {
                         TRACE_COUNTER("device_jpeg_activity",
                                       counter_track::at(_dev_id, track_index++), _ts,
                                       jpeg_val);
                     }
                 }
+                else
+                {
+                    // XCP-level JPEG busy (per-XCP organization)
+                    for(const auto& xcp_data : itr.m_gpu_metrics[0].jpeg_busy)
+                    {
+                        for(const auto& jpeg_val : xcp_data)
+                        {
+                            TRACE_COUNTER("device_jpeg_activity",
+                                          counter_track::at(_dev_id, track_index++), _ts,
+                                          jpeg_val);
+                        }
+                    }
+                }
+            }
+
+            if(_settings.xgmi && !itr.m_gpu_metrics.empty())
+            {
+                TRACE_COUNTER("device_xgmi_link_width",
+                              counter_track::at(_dev_id, track_index++), _ts,
+                              itr.m_gpu_metrics[0].xgmi_link_width);
+                TRACE_COUNTER("device_xgmi_link_speed",
+                              counter_track::at(_dev_id, track_index++), _ts,
+                              itr.m_gpu_metrics[0].xgmi_link_speed);
+                for(const auto& read_val : itr.m_gpu_metrics[0].xgmi_read_data_acc)
+                {
+                    TRACE_COUNTER("device_xgmi_read_data",
+                                  counter_track::at(_dev_id, track_index++), _ts,
+                                  read_val);
+                }
+
+                for(const auto& write_val : itr.m_gpu_metrics[0].xgmi_write_data_acc)
+                {
+                    TRACE_COUNTER("device_xgmi_write_data",
+                                  counter_track::at(_dev_id, track_index++), _ts,
+                                  write_val);
+                }
+            }
+
+            if(_settings.pcie && !itr.m_gpu_metrics.empty())
+            {
+                TRACE_COUNTER("device_pcie_link_width",
+                              counter_track::at(_dev_id, track_index++), _ts,
+                              itr.m_gpu_metrics[0].pcie_link_width);
+                TRACE_COUNTER("device_pcie_link_speed",
+                              counter_track::at(_dev_id, track_index++), _ts,
+                              itr.m_gpu_metrics[0].pcie_link_speed);
+                TRACE_COUNTER("device_pcie_bandwidth_acc",
+                              counter_track::at(_dev_id, track_index++), _ts,
+                              itr.m_gpu_metrics[0].pcie_bandwidth_acc);
+                TRACE_COUNTER("device_pcie_bandwidth_inst",
+                              counter_track::at(_dev_id, track_index++), _ts,
+                              itr.m_gpu_metrics[0].pcie_bandwidth_inst);
             }
         };
 
@@ -951,6 +1218,8 @@ setup()
                     key_pair_t{ "mem_usage", get_settings(itr).mem_usage },
                     key_pair_t{ "vcn_activity", get_settings(itr).vcn_activity },
                     key_pair_t{ "jpeg_activity", get_settings(itr).jpeg_activity },
+                    key_pair_t{ "xgmi", get_settings(itr).xgmi },
+                    key_pair_t{ "pcie", get_settings(itr).pcie },
                 };
 
                 // Initialize all metrics to false
@@ -1023,6 +1292,35 @@ uint32_t
 device_count()
 {
     return gpu::device_count();
+}
+
+void
+postfork_child_cleanup()
+{
+    // In child process, disable AMD SMI to prevent shutdown errors
+    ROCPROFSYS_VERBOSE_F(2, "Disabling AMD SMI in child process after fork...\n");
+
+    // Set to Finalized to prevent any sampling attempts (though is_child_process() check
+    // in sample() already handles this)
+    get_state().store(State::Finalized);
+
+    // Mark as not initialized so shutdown won't try to cleanup AMD SMI library
+    is_initialized() = false;
+
+    // Clear device list to prevent any GPU operations
+    data::device_list.clear();
+}
+
+void
+postfork_parent_reinit()
+{
+    // In parent process, AMD SMI device handles may be corrupted after fork
+    // Reinitialize AMD SMI to get fresh handles
+    ROCPROFSYS_VERBOSE_F(2, "Reinitializing AMD SMI in parent process after fork...\n");
+
+    // Shutdown and reinitialize to get fresh device handles
+    shutdown();
+    setup();
 }
 }  // namespace amd_smi
 }  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.hpp
@@ -31,6 +31,7 @@
 #include "core/common.hpp"
 #include "core/components/fwd.hpp"
 #include "core/defines.hpp"
+#include "core/gpu_metrics.hpp"
 #include "core/state.hpp"
 #include "library/thread_data.hpp"
 
@@ -70,6 +71,14 @@ post_process();
 
 void set_state(State);
 
+// Fork handling - cleanup AMD SMI state in child process
+void
+postfork_child_cleanup();
+
+// Fork handling - reinitialize AMD SMI state in parent process
+void
+postfork_parent_reinit();
+
 struct settings
 {
     bool busy          = true;
@@ -78,6 +87,8 @@ struct settings
     bool mem_usage     = true;
     bool vcn_activity  = true;
     bool jpeg_activity = true;
+    bool xgmi          = true;
+    bool pcie          = true;
 };
 
 struct data
@@ -93,11 +104,8 @@ struct data
     using mem_usage_t = uint64_t;
     using temp_t      = int64_t;
 
-    struct xcp_metrics_t
-    {
-        std::vector<uint16_t> vcn_busy;
-        std::vector<uint16_t> jpeg_busy;
-    };
+    // Use the shared gpu_metrics_t from core/gpu_metrics.hpp
+    using gpu_metrics_t = rocprofsys::gpu::gpu_metrics_t;
 
     ROCPROFSYS_DEFAULT_OBJECT(data)
 
@@ -112,7 +120,7 @@ struct data
     timestamp_t                m_ts          = 0;
     temp_t                     m_temp        = 0;
     mem_usage_t                m_mem_usage   = 0;
-    std::vector<xcp_metrics_t> m_xcp_metrics = {};
+    std::vector<gpu_metrics_t> m_gpu_metrics = {};
 #if ROCPROFSYS_USE_ROCM > 0
     amdsmi_engine_usage_t m_busy_perc = {};
     amdsmi_power_info_t   m_power     = {};
@@ -133,6 +141,7 @@ private:
     friend void rocprofsys::amd_smi::sample();
     friend void rocprofsys::amd_smi::shutdown();
     friend void rocprofsys::amd_smi::post_process();
+    friend void rocprofsys::amd_smi::postfork_child_cleanup();
 
     static size_t                        device_count;
     static std::set<uint32_t>            device_list;
@@ -167,6 +176,14 @@ post_process()
 
 inline void
 set_state(State)
+{}
+
+inline void
+postfork_child_cleanup()
+{}
+
+inline void
+postfork_parent_reinit()
 {}
 #endif
 }  // namespace amd_smi

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/exit_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/exit_gotcha.cpp
@@ -60,7 +60,7 @@ invoke_exit_gotcha(const exit_gotcha::gotcha_data& _data, FuncT _func, Args... _
 {
     threading::clear_callbacks();
 
-    if(get_state() < State::Finalized)
+    if(get_state() < State::Finalized && !is_child_process())
     {
         if(config::settings_are_configured())
         {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
@@ -115,6 +115,7 @@ postfork_child()
         << "Error! child process " << process::get_id()
         << " believes it is the root process " << get_root_process_id() << "\n";
 
+    set_state(State::Finalized);
     settings::enabled() = false;
     settings::verbose() = -127;
     settings::debug()   = false;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
@@ -27,6 +27,7 @@
 #include "core/perfetto.hpp"
 #include "core/perfetto_fwd.hpp"
 #include "core/state.hpp"
+#include "library/amd_smi.hpp"
 #include "library/components/fork_gotcha.hpp"
 #include "library/runtime.hpp"
 #include "library/sampling.hpp"
@@ -97,6 +98,12 @@ postfork_parent()
 {
     if(postfork_parent_lock) return;
 
+    // Reinitialize AMD SMI in parent process ensures the background sampling thread
+    // doesn't access AMD SMI during the shutdown/setup transition. AMD SMI device handles
+    // may be corrupted after fork.
+    if(config::get_use_process_sampling() && config::get_use_amd_smi())
+        amd_smi::postfork_parent_reinit();
+
     rocprofsys::categories::enable_categories(config::get_enabled_categories());
 
     if(config::get_use_sampling()) sampling::unblock_samples();
@@ -116,6 +123,12 @@ postfork_child()
         << " believes it is the root process " << get_root_process_id() << "\n";
 
     set_state(State::Finalized);
+
+    // Clean up AMD SMI in child process before other shutdowns
+    // This prevents AMD SMI from attempting operations with inconsistent state
+    if(config::get_use_process_sampling() && config::get_use_amd_smi())
+        amd_smi::postfork_child_cleanup();
+
     settings::enabled() = false;
     settings::verbose() = -127;
     settings::debug()   = false;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_deleter.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_deleter.cpp
@@ -24,6 +24,7 @@
 #include "api.hpp"
 #include "core/utility.hpp"
 #include "library/components/pthread_create_gotcha.hpp"
+#include "library/runtime.hpp"
 #include "library/thread_info.hpp"
 
 #include <timemory/backends/threading.hpp>
@@ -44,9 +45,12 @@ thread_deleter<void>::operator()() const
     {
         auto _tid = _info->index_data->sequent_value;
 
-        component::pthread_create_gotcha::shutdown(_tid);
+        if(!is_child_process()) component::pthread_create_gotcha::shutdown(_tid);
+
         set_thread_state(ThreadState::Completed);
-        if(get_state() < State::Finalized && _tid == 0) rocprofsys_finalize_hidden();
+
+        if(get_state() < State::Finalized && !is_child_process() && _tid == 0)
+            rocprofsys_finalize_hidden();
     }
     else
     {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_deleter.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_deleter.cpp
@@ -46,7 +46,6 @@ thread_deleter<void>::operator()() const
         auto _tid = _info->index_data->sequent_value;
 
         if(!is_child_process()) component::pthread_create_gotcha::shutdown(_tid);
-
         set_thread_state(ThreadState::Completed);
 
         if(get_state() < State::Finalized && !is_child_process() && _tid == 0)

--- a/projects/rocprofiler-systems/tests/rocprof-sys-fork-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-fork-tests.cmake
@@ -40,3 +40,18 @@ rocprofiler_systems_add_test(
     RUNTIME_FAIL_REGEX "(${ROCPROFSYS_ABORT_FAIL_REGEX})"
     REWRITE_RUN_FAIL_REGEX "(${ROCPROFSYS_ABORT_FAIL_REGEX})"
 )
+
+rocprofiler_systems_add_test(
+    NAME fork-hipMallocConcurrency
+    TARGET hipMallocConcurrencyMproc
+    REWRITE_ARGS -e -v 2 --print-instrumented modules -i 16
+    RUNTIME_ARGS -e -v 1 --label file -i 16
+    ENVIRONMENT
+        "${_base_environment};ROCPROFSYS_SAMPLING_FREQ=250;ROCPROFSYS_SAMPLING_REALTIME=ON"
+    SAMPLING_PASS_REGEX "Validation PASSED|fork.. called on PID"
+    RUNTIME_PASS_REGEX "Validation PASSED|fork.. called on PID"
+    REWRITE_RUN_PASS_REGEX "Validation PASSED|fork.. called on PID"
+    SAMPLING_FAIL_REGEX "(${ROCPROFSYS_ABORT_FAIL_REGEX})"
+    RUNTIME_FAIL_REGEX "(${ROCPROFSYS_ABORT_FAIL_REGEX})"
+    REWRITE_RUN_FAIL_REGEX "(${ROCPROFSYS_ABORT_FAIL_REGEX})"
+)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Solves Issue SWDEV-559256
Fix segmentation fault when applications using fork() have child processes call exit() instead of _exit(). The crash occurs during thread-local destructor cleanup attempting to access already-freed profiling data structures.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Set `State::Finalized` in `postfork_child()` before shutting down profiling subsystems. This prevents thread-local destructors (e.g., in tracing.cpp:142) from running cleanup code when checking `get_state() != State::Finalized`.

Changed file: source/lib/rocprof-sys/library/components/fork_gotcha.cpp
Function: postfork_child()
Change: Added set_state(State::Finalized) before cleanup operations

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Tested with HIP application (hipMallocConcurrencyMproc) that:
- Calls fork() to create child process
- Child performs GPU operations (hipMalloc, kernel execution)
- Child calls exit() with return code

Tested with rocprof-sys-sample -PTHD flags

Tested: All fork ctests (baseline, sampling, binary-rewrite, 
binary-rewrite-run, runtime-instrument) executed 50 iterations 
consecutively.
.
## Test Result

<!-- Briefly summarize test outcomes. -->
1. No segmentation fault with exit() in child process
2. Both parent and child complete successfully with profiling data collected
3. Works with various flag combinations (-P, -T, -H, -D)
4. Parent process profiling unaffected
<img width="1557" height="786" alt="image" src="https://github.com/user-attachments/assets/1d360db6-fcde-4038-a415-aff670df45b5" />

All fork* ctests passed without failures or timeouts.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
