### PR TITLE
SWDEV-564927 - Allow sizeBytes to be 0 when hipMemsetAsync is captured

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -891,6 +891,12 @@ hipError_t capturehipMemsetAsync(hipStream_t& stream, void*& dst, int& value, si
   if (!hip::isValid(stream)) {
     return hipErrorContextIsDestroyed;
   }
+
+  // No work should be done
+  if (sizeBytes == 0) {
+    return hipSuccess;
+  }
+
   hipMemsetParams memsetParams = {0};
   memsetParams.dst = dst;
   memsetParams.value = value;


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
When hipMemSetAsync is called with 0 for sizeBytes when capture is active, it returns an error.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
In this case, don't add node, just return success.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Created tests that validate that hipMemSetAsync behaves the same with/without capture when sizeBytess is 0.

## Test Result

Test passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
