### PR TITLE
SWDEV-547108 - Fix PAL build with HSA backend

### DIFF
--- a/projects/clr/rocclr/device/pal/palvirtual.hpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.hpp
@@ -60,7 +60,11 @@ struct AqlPacketMgmt : public amd::EmbeddedObject {
   static constexpr uint32_t kAqlPacketsListSize = 4 * Ki;
   AqlPacketMgmt(const Device& dev);
 
+#if defined(WITH_HSA_DEVICE)
+  amd_queue_v2_t amd_queue_{};
+#else
   amd_queue_t amd_queue_{};
+#endif
   alignas(sizeof(hsa_kernel_dispatch_packet_t))
       hsa_kernel_dispatch_packet_t aql_packets_[kAqlPacketsListSize];  //!< The list of AQL packets
   GpuEvent aql_events_[kAqlPacketsListSize];    //!< The list of gpu for each AQL packet


### PR DESCRIPTION
## Motivation
Incorrect usage of the latest HSA headers

## Technical Details
When hip is built with HSA backend then the headers from ROCR will be used, but scratch_backing_memory_byte_size is a part of amd_queue_v2_t structure

## Test Plan
N/A

## Test Result
N/A

## Submission Checklist
N/A