### PR TITLE
SWDEV-548892 - Stop using ocml log wrappers

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -1694,7 +1694,7 @@ __BF16_DEVICE_STATIC__ __hip_bfloat16 hfloor(const __hip_bfloat16 h) {
  * \brief Calculate natural log of bfloat16
  */
 __BF16_DEVICE_STATIC__ __hip_bfloat16 hlog(const __hip_bfloat16 h) {
-  return __float2bfloat16(__ocml_log_f32(__bfloat162float(h)));
+  return __float2bfloat16(__builtin_elementwise_log(__bfloat162float(h)));
 }
 
 /**
@@ -1702,7 +1702,7 @@ __BF16_DEVICE_STATIC__ __hip_bfloat16 hlog(const __hip_bfloat16 h) {
  * \brief Calculate log 10 of bfloat16
  */
 __BF16_DEVICE_STATIC__ __hip_bfloat16 hlog10(const __hip_bfloat16 h) {
-  return __float2bfloat16(__ocml_log10_f32(__bfloat162float(h)));
+  return __float2bfloat16(__builtin_elementwise_log10(__bfloat162float(h)));
 }
 
 /**
@@ -1710,7 +1710,7 @@ __BF16_DEVICE_STATIC__ __hip_bfloat16 hlog10(const __hip_bfloat16 h) {
  * \brief Calculate log 2 of bfloat16
  */
 __BF16_DEVICE_STATIC__ __hip_bfloat16 hlog2(const __hip_bfloat16 h) {
-  return __float2bfloat16(__ocml_log2_f32(__bfloat162float(h)));
+  return __float2bfloat16(__builtin_elementwise_log2(__bfloat162float(h)));
 }
 
 /**

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp16.h
@@ -968,13 +968,13 @@ inline __device__ __half hexp10(__half x) {
   return __half_raw{__ocml_exp10_f16(static_cast<__half_raw>(x).data)};
 }
 inline __device__ __half hlog2(__half x) {
-  return __half_raw{__ocml_log2_f16(static_cast<__half_raw>(x).data)};
+  return __half_raw{__builtin_elementwise_log2(static_cast<__half_raw>(x).data)};
 }
 inline __device__ __half hlog(__half x) {
-  return __half_raw{__ocml_log_f16(static_cast<__half_raw>(x).data)};
+  return __half_raw{__builtin_elementwise_log(static_cast<__half_raw>(x).data)};
 }
 inline __device__ __half hlog10(__half x) {
-  return __half_raw{__ocml_log10_f16(static_cast<__half_raw>(x).data)};
+  return __half_raw{__builtin_elementwise_log10(static_cast<__half_raw>(x).data)};
 }
 inline __device__ __half hrcp(__half x) {
   return __half_raw{static_cast<_Float16>(1.0f) / static_cast<__half_raw>(x).data};
@@ -1015,9 +1015,18 @@ inline __device__ __half2 h2exp2(__half2 x) {
   return __half2{__builtin_elementwise_exp2(static_cast<__half2_raw>(x).data)};
 }
 inline __device__ __half2 h2exp10(__half2 x) { return __half2{__ocml_exp10_2f16(x)}; }
-inline __device__ __half2 h2log2(__half2 x) { return __half2{__ocml_log2_2f16(x)}; }
-inline __device__ __half2 h2log(__half2 x) { return __ocml_log_2f16(x); }
-inline __device__ __half2 h2log10(__half2 x) { return __ocml_log10_2f16(x); }
+inline __device__ __half2 h2log2(__half2 x) {
+  return __half2{__builtin_elementwise_log2(static_cast<__half2_raw>(x).data)};
+}
+
+inline __device__ __half2 h2log(__half2 x) {
+  return __half2{__builtin_elementwise_log(static_cast<__half2_raw>(x).data)};
+}
+
+inline __device__ __half2 h2log10(__half2 x) {
+  return __half2{__builtin_elementwise_log10(static_cast<__half2_raw>(x).data)};
+}
+
 inline __device__ __half2 h2rcp(__half2 x) {
   return _Float16_2{_Float16_2{static_cast<_Float16>(1.0f), static_cast<_Float16>(1.0f)} / x.data};
 }


### PR DESCRIPTION
Directly use elementwise builtins.