### PR TITLE
[rocprofiler-systems] Add test for MPI perfetto file merge verification

### DIFF
--- a/projects/rocprofiler-systems/tests/rocprof-sys-mpi-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-mpi-tests.cmake
@@ -56,6 +56,29 @@ rocprofiler_systems_add_test(
 
 rocprofiler_systems_add_test(
     SKIP_RUNTIME
+    NAME "mpi-perfetto-merge"
+    TARGET mpi-example
+    MPI ON
+    NUM_PROCS 2
+    LABELS "perfetto-merge"
+    REWRITE_ARGS
+        -e
+        -v
+        2
+        --label
+        file
+        line
+        --min-instructions
+        0
+    ENVIRONMENT "${_base_environment};ROCPROFSYS_VERBOSE=1"
+    REWRITE_RUN_PASS_REGEX
+        "Successfully executed: .+rocprof-sys-merge-output.sh.*"
+    REWRITE_RUN_FAIL_REGEX
+        "Script not found|Failed to execute|ROCPROFSYS_ABORT_FAIL_REGEX"
+)
+
+rocprofiler_systems_add_test(
+    SKIP_RUNTIME
     NAME "mpi-flat-mpip"
     TARGET mpi-example
     MPI ON


### PR DESCRIPTION
## Motivation

When running rocprofiler-systems with MPI, each process generates its own perfetto trace file. The system includes a merge script (`rocprof-sys-merge-output.sh`) that consolidates these files into a single `merged.proto` file on rank 0. However, there was no automated test to verify that this merge process executes successfully, which could lead to undetected failures in multiprocess profiling scenarios.
Solves: SWDEV-516736

## Technical Details

Added a new test `mpi-perfetto-merge` in `rocprof-sys-mpi-tests.cmake`.

## Test Plan

Run tests.

## Test Result

Tests are passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
