### PR TITLE
SWDEV-559166 - Fix race condition in getDemangledName

### DIFF
--- a/projects/clr/rocclr/device/rocm/rockernel.hpp
+++ b/projects/clr/rocclr/device/rocm/rockernel.hpp
@@ -48,20 +48,14 @@ class Kernel : public device::Kernel {
 
   //! Pull demangled name, used only for logging
   const std::string& getDemangledName() {
-    if (demangled_name_.empty()) {
-      initDemangledName();
-    }
+    std::call_once(demangle_once_, [this] {
+      amd::Os::CxaDemangle(name(), &demangled_name_);
+    });
     return demangled_name_;
   }
 
- private:
-  void initDemangledName() {
-    if (demangled_name_.empty()) {
-      amd::Os::CxaDemangle(name(), &demangled_name_);
-    }
-  }
-
   std::string demangled_name_;  //!< Cache demangled name
+  std::once_flag demangle_once_;
 };
 
 }  // namespace amd::roc

--- a/projects/clr/rocclr/platform/command.cpp
+++ b/projects/clr/rocclr/platform/command.cpp
@@ -66,9 +66,8 @@ Event::~Event() {
     delete callback;
     callback = next;
   }
-  // Release the notify event
-  if (notify_event_ != nullptr) {
-    notify_event_->release();
+  if (auto* notifyEvent = notify_event_.load(std::memory_order_acquire)) {
+    notifyEvent->release();
   }
   // Destroy global HW event if available
   if ((hw_event_ != nullptr) && (device_ != nullptr)) {
@@ -269,11 +268,10 @@ bool Event::notifyCmdQueue(bool cpu_wait) {
         // If HW event was assigned, then notification can be ignored, since a barrier was issued
         // @note: Force the marker always in OCL for now, since OCL events require precise
         // sequence of the status update
-        ((HwEvent() == nullptr) || !amd::IS_HIP) && !notified_.test_and_set()) {
+        ((HwEvent() == nullptr) || !amd::IS_HIP) && (notify_event_ == nullptr)) {
       // Make sure the queue is draining the enqueued commands.
       amd::Command* command = new amd::Marker(*queue, false, nullWaitList, this, cpu_wait);
       if (command == NULL) {
-        notified_.clear();
         return false;
       }
       command->enqueue();

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -90,7 +90,7 @@ class Event : public RuntimeObject {
   std::atomic_flag notified_;              //!< Command queue was notified
 
   void* hw_event_;        //!< HW event ID associated with SW event
-  Event* notify_event_;   //!< Notify event, which should contain HW signal
+  std::atomic<Event*> notify_event_;   //!< Notify event, which should contain HW signal
   const Device* device_;  //!< Device, this event associated with
 
   std::atomic<int32_t> event_entry_scope_;  //!< Command entry scope
@@ -219,7 +219,7 @@ class Event : public RuntimeObject {
   void* HwEvent() const { return hw_event_; }
 
   //! Returns notify even associated with the current command
-  Event* NotifyEvent() const {ScopedLock l(notify_lock_); return notify_event_; }
+  Event* NotifyEvent() const { return notify_event_; }
 
   //! Get entry scope of the event
   int32_t getCommandEntryScope() const {


### PR DESCRIPTION
## Motivation
This PR fixes a race condition when logging is enabled in getDemangledName(). It also removes the notify_lock_ mutex from the NotifyEvent synchronization mechanism and replaces it with atomic operations on notify_event_ 
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
When threads launch the same kernel there can be a race condition in getDemangledName as reported by tsan
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Tsan should no longer report a race condition in getDemangledName()
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Tsan  no longer reporst a race condition in getDemangledName()
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
