### PR TITLE
Adding support to build ROCm with Multiple Python Environments

### DIFF
--- a/projects/rocprofiler-systems/docs/install/install.rst
+++ b/projects/rocprofiler-systems/docs/install/install.rst
@@ -126,21 +126,18 @@ Optional third-party packages
   * AMD SMI Lib for GPU monitoring
   * ROCprofiler SDK for GPU hardware counters and ROCm tracing
 
-* `Building ROCm with Multiple Python Environments`_
+* Building ROCm with multiple python environments
 
-   * ``ROCPROFSYS_PYTHON_PREFIX`` specifies the root directory where Python environments are located
-   * ``ROCPROFSYS_PYTHON_ENVS`` specifies the list of Python environments to build bindings for
+  By default, ROCm Systems Profiler uses the system Python environment. To build
+  with multiple or specific Python environments, specify the prefix during CMake configuration:
 
-   .. note::
-       By default, ROCm Systems Profiler builds with the system Python environment. To build
-       ROCm Systems Profiler with multiple Python environments, specify the prefix and
-       environment list during CMake configuration:
+  * ``ROCPROFSYS_PYTHON_PREFIX`` specifies the root directory where Python environments are located.
+  * ``ROCPROFSYS_PYTHON_ENVS`` specifies the list of Python environments to build bindings for.
 
-       .. code-block:: shell
+  .. code-block:: shell
 
-            cmake -D ROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs \
-                     -D ROCPROFSYS_PYTHON_ENVS="py3.7;py3.8;py3.9;py3.10;py3.11" \
-                     ...
+     cmake -D ROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs \
+              -D ROCPROFSYS_PYTHON_ENVS="py3.7;py3.8;py3.9;py3.10;py3.11" 
 
 * `PAPI <https://icl.utk.edu/papi/>`_
 * MPI

--- a/projects/rocprofiler-systems/docs/install/install.rst
+++ b/projects/rocprofiler-systems/docs/install/install.rst
@@ -126,7 +126,7 @@ Optional third-party packages
   * AMD SMI Lib for GPU monitoring
   * ROCprofiler SDK for GPU hardware counters and ROCm tracing
 
-* Building ROCm with multiple python environments
+* Building ROCm with multiple Python environments
 
   By default, ROCm Systems Profiler uses the system Python environment. To build
   with multiple or specific Python environments, specify the prefix during CMake configuration:

--- a/projects/rocprofiler-systems/docs/install/install.rst
+++ b/projects/rocprofiler-systems/docs/install/install.rst
@@ -137,7 +137,7 @@ Optional third-party packages
   .. code-block:: shell
 
      cmake -D ROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs \
-              -D ROCPROFSYS_PYTHON_ENVS="py3.7;py3.8;py3.9;py3.10;py3.11" 
+              -D ROCPROFSYS_PYTHON_ENVS="py3.7;py3.8;py3.9;py3.10;py3.11"
 
 * `PAPI <https://icl.utk.edu/papi/>`_
 * MPI

--- a/projects/rocprofiler-systems/docs/install/install.rst
+++ b/projects/rocprofiler-systems/docs/install/install.rst
@@ -126,6 +126,22 @@ Optional third-party packages
   * AMD SMI Lib for GPU monitoring
   * ROCprofiler SDK for GPU hardware counters and ROCm tracing
 
+* `Building ROCm with Multiple Python Environments`_
+
+   * ``ROCPROFSYS_PYTHON_PREFIX`` specifies the root directory where Python environments are located
+   * ``ROCPROFSYS_PYTHON_ENVS`` specifies the list of Python environments to build bindings for
+
+   .. note::
+       By default, ROCm Systems Profiler builds with the system Python environment. To build
+       ROCm Systems Profiler with multiple Python environments, specify the prefix and
+       environment list during CMake configuration:
+
+       .. code-block:: shell
+
+            cmake -D ROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs \
+                     -D ROCPROFSYS_PYTHON_ENVS="py3.7;py3.8;py3.9;py3.10;py3.11" \
+                     ...
+
 * `PAPI <https://icl.utk.edu/papi/>`_
 * MPI
 

--- a/projects/rocprofiler-systems/docs/install/install.rst
+++ b/projects/rocprofiler-systems/docs/install/install.rst
@@ -111,6 +111,7 @@ while Dyninst requires TBB), and the CMake option to build the package alongside
 
    "Dyninst", "13.0", "ROCm Systems Profiler", "``ROCPROFSYS_BUILD_DYNINST`` (default: OFF)"
    "Libunwind", "", "ROCm Systems Profiler", "``ROCPROFSYS_BUILD_LIBUNWIND`` (default: ON)"
+   "Nlohmann/JSON", "", "ROCm Systems Profiler", "``ROCPROFSYS_BUILD_NLOHMANN_JSON`` (default: ON)"
    "SQLite", "", "ROCm Systems Profiler", "``ROCPROFSYS_BUILD_SQLITE`` (default: OFF)"
    "TBB", "2018.6", "Dyninst", "``ROCPROFSYS_BUILD_TBB`` (default: OFF)"
    "ElfUtils", "0.178", "Dyninst", "``ROCPROFSYS_BUILD_ELFUTILS`` (default: OFF)"
@@ -126,18 +127,9 @@ Optional third-party packages
   * AMD SMI Lib for GPU monitoring
   * ROCprofiler SDK for GPU hardware counters and ROCm tracing
 
-* Building ROCm with multiple Python environments
+* Python
 
-  By default, ROCm Systems Profiler uses the system Python environment. To build
-  with multiple or specific Python environments, specify the prefix during CMake configuration:
-
-  * ``ROCPROFSYS_PYTHON_PREFIX`` specifies the root directory where Python environments are located.
-  * ``ROCPROFSYS_PYTHON_ENVS`` specifies the list of Python environments to build bindings for.
-
-  .. code-block:: shell
-
-     cmake -D ROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs \
-              -D ROCPROFSYS_PYTHON_ENVS="py3.7;py3.8;py3.9;py3.10;py3.11"
+  * ``ROCPROFSYS_USE_PYTHON`` enables Python support.
 
 * `PAPI <https://icl.utk.edu/papi/>`_
 * MPI
@@ -295,6 +287,23 @@ and the MPICH headers and then using
 ROCm Systems Profiler on an application built against OpenMPI causes a segmentation fault.
 This happens because the value of the ``MPI_COMM_WORLD`` is truncated
 during the function wrapping before being passed along to the underlying MPI function.
+
+Python support within ROCm Systems Profiler
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ROCm Systems Profiler supports profiling Python code via the ``ROCPROFSYS_USE_PYTHON`` CMake option.
+Python support is enabled via the ``ROCPROFSYS_USE_PYTHON`` and the
+``ROCPROFSYS_PYTHON_VERSIONS="<MAJOR>.<MINOR>`` CMake options.
+Alternatively, to build multiple Python versions, use
+``ROCPROFSYS_PYTHON_VERSIONS="<MAJOR>.<MINOR>;[<MAJOR>.<MINOR>]"``,
+and ``ROCPROFSYS_PYTHON_ROOT_DIRS="/path/to/version;[/path/to/version]"`` instead of just ``ROCPROFSYS_PYTHON_VERSIONS``.
+When building multiple Python versions, the length of the ``ROCPROFSYS_PYTHON_VERSIONS``
+and ``ROCPROFSYS_PYTHON_ROOT_DIRS`` lists must
+be the same size.
+
+.. code-block:: shell
+   cmake --preset release -D ROCPROFSYS_PYTHON_ROOT_DIRS="/usr/bin;/usr/bin" -D ROCPROFSYS_PYTHON_VERSIONS="3.10;3.12"
+
 
 ROCm Systems Profiler without ROCm
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Motivation
Documentation improvements: This pull request updates the installation documentation for ROCm Systems Profiler to include instructions for building with multiple Python environments. The most important changes are enhancements to the documentation that clarify how to configure builds for different Python versions.

## Technical Details

Added a new section describing how to build ROCm Systems Profiler with multiple Python environments using the `ROCPROFSYS_PYTHON_PREFIX` and `ROCPROFSYS_PYTHON_ENVS` CMake options.
* Provided a shell command example and explanatory note to guide users through the configuration process.

## Test Plan

Verified on systems

## Test Result

 NA

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
