### PR TITLE
SWDEV-562761 - Cleanup static fatbin on runtime teardown

### DIFF
--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -362,57 +362,59 @@ hipError_t StatCO::removeFatBinary(FatBinaryInfo** module) {
 }
 
 // =================================================================================================
-hipError_t StatCO::removeAllFatBinaries() {
+void StatCO::RemoveAllFatBinaries() {
   amd::ScopedLock lock(sclock_);
 
+  // Clear mapping tables that associate modules with host-side constructs
   module_to_hostModule_.clear();
   module_to_hostFunctions_.clear();
   module_to_hostVars_.clear();
 
+  // Delete all registered variables and clear the container
   for (auto const& [_, var] : vars_) {
     delete var;
   }
   vars_.clear();
 
-  // Cleanup managed vars.
+  // Clean up managed variables - these require special handling for memory on each device
   for (auto& [_, managed_vars] : managedVars_) {
     for (auto& managed_var : managed_vars) {
-      hipError_t err = hipSuccess;
+      // Free device-specific allocations across all devices
       for (auto dev : g_devices) {
         DeviceVar* dvar = nullptr;
-        err = managed_var->getDeviceVarPtr(&dvar, dev->deviceId());
-        if (err == hipSuccess && dvar != nullptr) {
-          // Free also deletes the device ptr.
-          err = ihipFree(dvar->device_ptr());
+        if (managed_var->getDeviceVarPtr(&dvar, dev->deviceId()) == hipSuccess && dvar) {
+          // Free device memory (also deletes the device ptr)
+          [[maybe_unused]] hipError_t err = ihipFree(dvar->device_ptr());
           assert(err == hipSuccess);
         }
       }
-      // Check if it is a managed or host alloc.
+
+      // Free the managed memory allocation itself
+      void** managed_ptr = static_cast<void**>(managed_var->getManagedVarPtr());
       if (managed_var->getAllocFlag()) {
-        err = ihipFree(*(static_cast<void**>(managed_var->getManagedVarPtr())));
+        // Memory was allocated with ihipMallocManaged - use ihipFree
+        [[maybe_unused]] hipError_t err = ihipFree(*managed_ptr);
         assert(err == hipSuccess);
       } else {
-        void** pointer = static_cast<void**>(managed_var->getManagedVarPtr());
-        amd::Os::releaseMemory(*pointer, managed_var->getSize());
+        // Memory was allocated with OS-level allocator - use OS release
+        amd::Os::releaseMemory(*managed_ptr, managed_var->getSize());
       }
       delete managed_var;
     }
-    managed_vars.clear();
   }
   managedVars_.clear();
 
+  // Delete all registered functions and clear the container
   for (auto const& [_, func] : functions_) {
     delete func;
   }
   functions_.clear();
 
-  for (auto& [_, fb_info] : modules_) {
+  // Delete all fat binary info objects and clear the modules container
+  for (auto const& [_, fb_info] : modules_) {
     delete fb_info;
-    fb_info = nullptr;
   }
   modules_.clear();
-
-  return hipSuccess;
 }
 
 hipError_t StatCO::registerStatFunction(const void* hostFunction, Function* func) {

--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -361,6 +361,58 @@ hipError_t StatCO::removeFatBinary(FatBinaryInfo** module) {
   return hipSuccess;
 }
 
+hipError_t StatCO::removeAllFatBinaries() {
+  amd::ScopedLock lock(sclock_);
+  
+  module_to_hostModule_.clear();
+  module_to_hostFunctions_.clear();
+  module_to_hostVars_.clear();
+
+  for (auto const& [_, var] : vars_) {
+    delete var;
+  }
+  vars_.clear();
+
+  // Cleanup managed vars
+  for (auto& [_, managedVars] : managedVars_) {
+    for (auto& managedVar : managedVars) {
+      hipError_t err = hipSuccess;
+      for (auto dev : g_devices) {
+        DeviceVar* dvar = nullptr;
+        err = managedVar->getDeviceVarPtr(&dvar, dev->deviceId());
+        if (err == hipSuccess && dvar != nullptr) {
+          // free also deletes the device ptr
+          err = ihipFree(dvar->device_ptr());
+          assert(err == hipSuccess);
+        }
+      }
+      if (managedVar->getAllocFlag()) {  // check if it is a managed or host alloc
+        err = ihipFree(*(static_cast<void**>(managedVar->getManagedVarPtr())));
+        assert(err == hipSuccess);
+      } else {
+        void** pointer = static_cast<void**>(managedVar->getManagedVarPtr());
+        amd::Os::releaseMemory(*pointer, managedVar->getSize());
+      }
+      delete managedVar;
+    }
+    managedVars.clear();
+  }
+  managedVars_.clear();
+
+  for (auto const& [_, func] : functions_) {
+    delete func;
+  }
+  functions_.clear();
+
+  for (auto& [_, fb_info] : modules_) {
+    delete fb_info;
+    fb_info = nullptr;
+  }
+  modules_.clear();
+
+  return hipSuccess;
+}
+
 hipError_t StatCO::registerStatFunction(const void* hostFunction, Function* func) {
   amd::ScopedLock lock(sclock_);
 

--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -361,6 +361,7 @@ hipError_t StatCO::removeFatBinary(FatBinaryInfo** module) {
   return hipSuccess;
 }
 
+//==================================================================================================
 hipError_t StatCO::removeAllFatBinaries() {
   amd::ScopedLock lock(sclock_);
   

--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -361,10 +361,10 @@ hipError_t StatCO::removeFatBinary(FatBinaryInfo** module) {
   return hipSuccess;
 }
 
-//==================================================================================================
+// =================================================================================================
 hipError_t StatCO::removeAllFatBinaries() {
   amd::ScopedLock lock(sclock_);
-  
+
   module_to_hostModule_.clear();
   module_to_hostFunctions_.clear();
   module_to_hostVars_.clear();
@@ -374,29 +374,30 @@ hipError_t StatCO::removeAllFatBinaries() {
   }
   vars_.clear();
 
-  // Cleanup managed vars
-  for (auto& [_, managedVars] : managedVars_) {
-    for (auto& managedVar : managedVars) {
+  // Cleanup managed vars.
+  for (auto& [_, managed_vars] : managedVars_) {
+    for (auto& managed_var : managed_vars) {
       hipError_t err = hipSuccess;
       for (auto dev : g_devices) {
         DeviceVar* dvar = nullptr;
-        err = managedVar->getDeviceVarPtr(&dvar, dev->deviceId());
+        err = managed_var->getDeviceVarPtr(&dvar, dev->deviceId());
         if (err == hipSuccess && dvar != nullptr) {
-          // free also deletes the device ptr
+          // Free also deletes the device ptr.
           err = ihipFree(dvar->device_ptr());
           assert(err == hipSuccess);
         }
       }
-      if (managedVar->getAllocFlag()) {  // check if it is a managed or host alloc
-        err = ihipFree(*(static_cast<void**>(managedVar->getManagedVarPtr())));
+      // Check if it is a managed or host alloc.
+      if (managed_var->getAllocFlag()) {
+        err = ihipFree(*(static_cast<void**>(managed_var->getManagedVarPtr())));
         assert(err == hipSuccess);
       } else {
-        void** pointer = static_cast<void**>(managedVar->getManagedVarPtr());
-        amd::Os::releaseMemory(*pointer, managedVar->getSize());
+        void** pointer = static_cast<void**>(managed_var->getManagedVarPtr());
+        amd::Os::releaseMemory(*pointer, managed_var->getSize());
       }
-      delete managedVar;
+      delete managed_var;
     }
-    managedVars.clear();
+    managed_vars.clear();
   }
   managedVars_.clear();
 

--- a/projects/clr/hipamd/src/hip_code_object.hpp
+++ b/projects/clr/hipamd/src/hip_code_object.hpp
@@ -155,8 +155,8 @@ class StatCO : public CodeObject {
   // Add/Remove/Digest Fat Binaries passed to us from "__hipRegisterFatBinary"
   FatBinaryInfo** addFatBinary(const void* data, bool initialized, bool& success);
   hipError_t removeFatBinary(FatBinaryInfo** module);
-  hipError_t removeAllFatBinaries();
   hipError_t digestFatBinary(const void* data, FatBinaryInfo*& programs);
+  void RemoveAllFatBinaries();
 
   // Register vars/funcs given to use from __hipRegister[Var/Func/ManagedVar]
   hipError_t registerStatFunction(const void* hostFunction, Function* func);

--- a/projects/clr/hipamd/src/hip_code_object.hpp
+++ b/projects/clr/hipamd/src/hip_code_object.hpp
@@ -155,6 +155,7 @@ class StatCO : public CodeObject {
   // Add/Remove/Digest Fat Binaries passed to us from "__hipRegisterFatBinary"
   FatBinaryInfo** addFatBinary(const void* data, bool initialized, bool& success);
   hipError_t removeFatBinary(FatBinaryInfo** module);
+  hipError_t removeAllFatBinaries();
   hipError_t digestFatBinary(const void* data, FatBinaryInfo*& programs);
 
   // Register vars/funcs given to use from __hipRegister[Var/Func/ManagedVar]

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -813,6 +813,11 @@ void PlatformState::init() {
   for (auto& it : statCO_.functions_) {
     it.second->resize_dFunc(g_devices.size());
   }
+  amd::RuntimeTearDown::RegisterTearDownCallback("PlatformState static fatbin cleanup", [this]() {
+    runtime_destroyed_.store(true, std::memory_order_release);
+    hipError_t err = statCO_.removeAllFatBinaries();
+    assert(err == hipSuccess);
+  });
 }
 
 hipError_t PlatformState::loadModule(hipModule_t* module, const char* fname, const void* image) {
@@ -989,6 +994,9 @@ hip::FatBinaryInfo** PlatformState::addFatBinary(const void* data, bool& success
 }
 
 hipError_t PlatformState::removeFatBinary(hip::FatBinaryInfo** module) {
+  if (runtime_destroyed_.load(std::memory_order_acquire)) {
+    return hipSuccess;
+  }
   return statCO_.removeFatBinary(module);
 }
 

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -814,9 +814,7 @@ void PlatformState::init() {
     it.second->resize_dFunc(g_devices.size());
   }
   amd::RuntimeTearDown::RegisterTearDownCallback("PlatformState static fatbin cleanup", [this]() {
-    runtime_destroyed_.store(true, std::memory_order_release);
-    hipError_t err = statCO_.removeAllFatBinaries();
-    assert(err == hipSuccess);
+    statCO_.RemoveAllFatBinaries();
   });
 }
 
@@ -994,9 +992,6 @@ hip::FatBinaryInfo** PlatformState::addFatBinary(const void* data, bool& success
 }
 
 hipError_t PlatformState::removeFatBinary(hip::FatBinaryInfo** module) {
-  if (runtime_destroyed_.load(std::memory_order_acquire)) {
-    return hipSuccess;
-  }
   return statCO_.removeFatBinary(module);
 }
 

--- a/projects/clr/hipamd/src/hip_platform.hpp
+++ b/projects/clr/hipamd/src/hip_platform.hpp
@@ -144,7 +144,6 @@ class PlatformState {
   std::unordered_map<hipModule_t, hip::DynCO*> dynCO_map_;
   hip::StatCO statCO_;  //!< Static Code object var
   bool initialized_{false};
-  std::atomic<bool> runtime_destroyed_{false};
   std::unordered_map<textureReference*, std::pair<hipModule_t, std::string>> texRef_map_;
 
   std::unordered_map<std::string, std::shared_ptr<UniqueFD>> ufd_map_;  //!< Unique File Desc Map

--- a/projects/clr/hipamd/src/hip_platform.hpp
+++ b/projects/clr/hipamd/src/hip_platform.hpp
@@ -144,6 +144,7 @@ class PlatformState {
   std::unordered_map<hipModule_t, hip::DynCO*> dynCO_map_;
   hip::StatCO statCO_;  //!< Static Code object var
   bool initialized_{false};
+  std::atomic<bool> runtime_destroyed_{false};
   std::unordered_map<textureReference*, std::pair<hipModule_t, std::string>> texRef_map_;
 
   std::unordered_map<std::string, std::shared_ptr<UniqueFD>> ufd_map_;  //!< Unique File Desc Map

--- a/projects/clr/rocclr/platform/runtime.cpp
+++ b/projects/clr/rocclr/platform/runtime.cpp
@@ -107,15 +107,25 @@ void Runtime::tearDown() {
 // ~RuntimeTearDown() will reference listenerLock.
 // listenerLock will be constructed ealier and destructed later than
 // runtime_tear_down.
-amd::Monitor listenerLock("Hostcall listener lock");
-std::vector<ReferenceCountedObject*> RuntimeTearDown::external_;
+amd::Monitor listenerLock ROCCLR_INIT_PRIORITY(101) ("Hostcall listener lock");
+std::vector<ReferenceCountedObject*> RuntimeTearDown::external_ ROCCLR_INIT_PRIORITY(101) {};
+std::vector<std::pair<std::string, RuntimeTearDown::TearDownCallback>> 
+  RuntimeTearDown::tear_down_funcs_ ROCCLR_INIT_PRIORITY(101) {};
+class RuntimeTearDown runtime_tear_down ROCCLR_INIT_PRIORITY(101) {};
 
 RuntimeTearDown::~RuntimeTearDown() {
+  ClPrint(amd::LOG_INFO, amd::LOG_INIT, "Begin runtime teardown");
 #if !defined(_WIN32) && !defined(BUILD_STATIC_LIBS)
   // Only perform destruction if process matches the initialization,
   // to avoid a call with the child process after fork()
   if (amd::IS_HIP && amd::Os::getProcessId() == Runtime::pid()) {
+    // Execute teardown funcs in reverse order of registration
+    for (auto it = tear_down_funcs_.rbegin(); it != tear_down_funcs_.rend(); ++it) {
+      ClPrint(amd::LOG_DEBUG, amd::LOG_INIT, "~RuntimeTearDown invoke callback: %s", it->first.c_str());
+      it->second();
+    }
     for (auto it : external_) {
+      ClPrint(amd::LOG_DEBUG, amd::LOG_INIT, "~RuntimeTearDown release external object: %p", it);
       it->release();
     }
     Runtime::tearDown();
@@ -123,9 +133,18 @@ RuntimeTearDown::~RuntimeTearDown() {
 #endif
 }
 
-void RuntimeTearDown::RegisterObject(ReferenceCountedObject* obj) { external_.push_back(obj); }
-
-class RuntimeTearDown runtime_tear_down;
+void RuntimeTearDown::RegisterObject(ReferenceCountedObject* obj) {
+  if (obj) {
+    external_.push_back(obj);
+    ClPrint(amd::LOG_DEBUG, amd::LOG_INIT, "RuntimeTearDown registered external object: %p", obj);
+  }
+}
+void RuntimeTearDown::RegisterTearDownCallback(const std::string& msg, TearDownCallback func) {
+  if (func) {
+    tear_down_funcs_.emplace_back(msg, std::move(func));
+    ClPrint(amd::LOG_DEBUG, amd::LOG_INIT, "RuntimeTearDown registered callback fun: %s", msg.c_str());
+  }
+}
 
 uint ReferenceCountedObject::retain() {
   uint prev = referenceCount_.fetch_add(1, std::memory_order_relaxed);

--- a/projects/clr/rocclr/platform/runtime.cpp
+++ b/projects/clr/rocclr/platform/runtime.cpp
@@ -105,25 +105,25 @@ void Runtime::tearDown() {
 }
 
 // ~RuntimeTearDown() will reference listenerLock.
-// listenerLock will be constructed ealier and destructed later than
+// listenerLock will be constructed earlier and destructed later than
 // runtime_tear_down.
-amd::Monitor listenerLock ROCCLR_INIT_PRIORITY(101) ("Hostcall listener lock");
-std::vector<ReferenceCountedObject*> RuntimeTearDown::external_ ROCCLR_INIT_PRIORITY(101) {};
+amd::Monitor listenerLock ROCCLR_INIT_PRIORITY(101)("Hostcall listener lock");
+std::vector<ReferenceCountedObject*> RuntimeTearDown::external_ ROCCLR_INIT_PRIORITY(101){};
 std::vector<std::pair<std::string, RuntimeTearDown::TearDownCallback>> 
-  RuntimeTearDown::tear_down_funcs_ ROCCLR_INIT_PRIORITY(101) {};
-class RuntimeTearDown runtime_tear_down ROCCLR_INIT_PRIORITY(101) {};
+  RuntimeTearDown::tear_down_funcs_ ROCCLR_INIT_PRIORITY(101){};
+class RuntimeTearDown runtime_tear_down ROCCLR_INIT_PRIORITY(101){};
 
-//==================================================================================================
+// =================================================================================================
 RuntimeTearDown::~RuntimeTearDown() {
   ClPrint(amd::LOG_INFO, amd::LOG_INIT, "Begin runtime teardown");
 #if !defined(_WIN32) && !defined(BUILD_STATIC_LIBS)
   // Only perform destruction if process matches the initialization,
-  // to avoid a call with the child process after fork()
+  // to avoid a call with the child process after fork().
   if (amd::IS_HIP && amd::Os::getProcessId() == Runtime::pid()) {
-    // Execute teardown funcs in reverse order of registration
+    // Execute teardown funcs in reverse order of registration.
     for (auto it = tear_down_funcs_.rbegin(); it != tear_down_funcs_.rend(); ++it) {
-      ClPrint(amd::LOG_DEBUG, amd::LOG_INIT,
-              "~RuntimeTearDown invoke callback: %s", it->first.c_str());
+      ClPrint(amd::LOG_DEBUG, amd::LOG_INIT, "~RuntimeTearDown invoke callback: %s",
+              it->first.c_str());
       it->second();
     }
     for (auto it : external_) {
@@ -135,7 +135,7 @@ RuntimeTearDown::~RuntimeTearDown() {
 #endif
 }
 
-//==================================================================================================
+// =================================================================================================
 void RuntimeTearDown::RegisterObject(ReferenceCountedObject* obj) {
   if (obj) {
     external_.push_back(obj);
@@ -143,16 +143,16 @@ void RuntimeTearDown::RegisterObject(ReferenceCountedObject* obj) {
   }
 }
 
-//==================================================================================================
+// =================================================================================================
 void RuntimeTearDown::RegisterTearDownCallback(const std::string& msg, TearDownCallback func) {
   if (func) {
     tear_down_funcs_.emplace_back(msg, std::move(func));
-    ClPrint(amd::LOG_DEBUG, amd::LOG_INIT,
-            "RuntimeTearDown registered callback fun: %s", msg.c_str());
+    ClPrint(amd::LOG_DEBUG, amd::LOG_INIT, "RuntimeTearDown registered callback: %s",
+            msg.c_str());
   }
 }
 
-//==================================================================================================
+// =================================================================================================
 uint ReferenceCountedObject::retain() {
   uint prev = referenceCount_.fetch_add(1, std::memory_order_relaxed);
   assert(prev != 0 && "An object with count==0 is invalid");

--- a/projects/clr/rocclr/platform/runtime.cpp
+++ b/projects/clr/rocclr/platform/runtime.cpp
@@ -107,11 +107,11 @@ void Runtime::tearDown() {
 // ~RuntimeTearDown() will reference listenerLock.
 // listenerLock will be constructed earlier and destructed later than
 // runtime_tear_down.
-amd::Monitor listenerLock ROCCLR_INIT_PRIORITY(101)("Hostcall listener lock");
-std::vector<ReferenceCountedObject*> RuntimeTearDown::external_ ROCCLR_INIT_PRIORITY(101){};
+amd::Monitor listenerLock{};
+std::vector<ReferenceCountedObject*> RuntimeTearDown::external_{};
 std::vector<std::pair<std::string, RuntimeTearDown::TearDownCallback>> 
-  RuntimeTearDown::tear_down_funcs_ ROCCLR_INIT_PRIORITY(101){};
-class RuntimeTearDown runtime_tear_down ROCCLR_INIT_PRIORITY(101){};
+  RuntimeTearDown::tear_down_funcs_{};
+class RuntimeTearDown runtime_tear_down{};
 
 // =================================================================================================
 RuntimeTearDown::~RuntimeTearDown() {

--- a/projects/clr/rocclr/platform/runtime.cpp
+++ b/projects/clr/rocclr/platform/runtime.cpp
@@ -113,6 +113,7 @@ std::vector<std::pair<std::string, RuntimeTearDown::TearDownCallback>>
   RuntimeTearDown::tear_down_funcs_ ROCCLR_INIT_PRIORITY(101) {};
 class RuntimeTearDown runtime_tear_down ROCCLR_INIT_PRIORITY(101) {};
 
+//==================================================================================================
 RuntimeTearDown::~RuntimeTearDown() {
   ClPrint(amd::LOG_INFO, amd::LOG_INIT, "Begin runtime teardown");
 #if !defined(_WIN32) && !defined(BUILD_STATIC_LIBS)
@@ -121,7 +122,8 @@ RuntimeTearDown::~RuntimeTearDown() {
   if (amd::IS_HIP && amd::Os::getProcessId() == Runtime::pid()) {
     // Execute teardown funcs in reverse order of registration
     for (auto it = tear_down_funcs_.rbegin(); it != tear_down_funcs_.rend(); ++it) {
-      ClPrint(amd::LOG_DEBUG, amd::LOG_INIT, "~RuntimeTearDown invoke callback: %s", it->first.c_str());
+      ClPrint(amd::LOG_DEBUG, amd::LOG_INIT,
+              "~RuntimeTearDown invoke callback: %s", it->first.c_str());
       it->second();
     }
     for (auto it : external_) {
@@ -133,19 +135,24 @@ RuntimeTearDown::~RuntimeTearDown() {
 #endif
 }
 
+//==================================================================================================
 void RuntimeTearDown::RegisterObject(ReferenceCountedObject* obj) {
   if (obj) {
     external_.push_back(obj);
     ClPrint(amd::LOG_DEBUG, amd::LOG_INIT, "RuntimeTearDown registered external object: %p", obj);
   }
 }
+
+//==================================================================================================
 void RuntimeTearDown::RegisterTearDownCallback(const std::string& msg, TearDownCallback func) {
   if (func) {
     tear_down_funcs_.emplace_back(msg, std::move(func));
-    ClPrint(amd::LOG_DEBUG, amd::LOG_INIT, "RuntimeTearDown registered callback fun: %s", msg.c_str());
+    ClPrint(amd::LOG_DEBUG, amd::LOG_INIT,
+            "RuntimeTearDown registered callback fun: %s", msg.c_str());
   }
 }
 
+//==================================================================================================
 uint ReferenceCountedObject::retain() {
   uint prev = referenceCount_.fetch_add(1, std::memory_order_relaxed);
   assert(prev != 0 && "An object with count==0 is invalid");

--- a/projects/clr/rocclr/platform/runtime.cpp
+++ b/projects/clr/rocclr/platform/runtime.cpp
@@ -137,19 +137,14 @@ RuntimeTearDown::~RuntimeTearDown() {
 
 // =================================================================================================
 void RuntimeTearDown::RegisterObject(ReferenceCountedObject* obj) {
-  if (obj) {
-    external_.push_back(obj);
-    ClPrint(amd::LOG_DEBUG, amd::LOG_INIT, "RuntimeTearDown registered external object: %p", obj);
-  }
+  external_.push_back(obj);
+  ClPrint(amd::LOG_DEBUG, amd::LOG_INIT, "RuntimeTearDown registered external object: %p", obj);
 }
 
 // =================================================================================================
 void RuntimeTearDown::RegisterTearDownCallback(const std::string& msg, TearDownCallback func) {
-  if (func) {
-    tear_down_funcs_.emplace_back(msg, std::move(func));
-    ClPrint(amd::LOG_DEBUG, amd::LOG_INIT, "RuntimeTearDown registered callback: %s",
-            msg.c_str());
-  }
+  tear_down_funcs_.emplace_back(msg, std::move(func));
+  ClPrint(amd::LOG_DEBUG, amd::LOG_INIT, "RuntimeTearDown registered callback: %s", msg.c_str());
 }
 
 // =================================================================================================

--- a/projects/clr/rocclr/platform/runtime.hpp
+++ b/projects/clr/rocclr/platform/runtime.hpp
@@ -62,16 +62,18 @@ class Runtime : AllStatic {
 /*@}*/
 
 class RuntimeTearDown : public HeapObject {
-  typedef std::function<void()> TearDownCallback;
-  static std::vector<ReferenceCountedObject*> external_;
-  static std::vector<std::pair<std::string, TearDownCallback>> tear_down_funcs_;
-
  public:
+  using TearDownCallback = std::function<void()>;
+
   RuntimeTearDown() {}
   ~RuntimeTearDown();
 
   static void RegisterObject(ReferenceCountedObject* obj);
   static void RegisterTearDownCallback(const std::string& msg, TearDownCallback func);
+
+ private:
+  static std::vector<ReferenceCountedObject*> external_;
+  static std::vector<std::pair<std::string, TearDownCallback>> tear_down_funcs_;
 };
 
 }  // namespace amd

--- a/projects/clr/rocclr/platform/runtime.hpp
+++ b/projects/clr/rocclr/platform/runtime.hpp
@@ -21,6 +21,7 @@
 #ifndef RUNTIME_HPP_
 #define RUNTIME_HPP_
 
+#include <functional>
 #include "top.hpp"
 #include "thread/thread.hpp"
 
@@ -61,13 +62,16 @@ class Runtime : AllStatic {
 /*@}*/
 
 class RuntimeTearDown : public HeapObject {
+  typedef std::function<void()> TearDownCallback;
   static std::vector<ReferenceCountedObject*> external_;
+  static std::vector<std::pair<std::string, TearDownCallback>> tear_down_funcs_;
 
  public:
   RuntimeTearDown() {}
   ~RuntimeTearDown();
 
   static void RegisterObject(ReferenceCountedObject* obj);
+  static void RegisterTearDownCallback(const std::string& msg, TearDownCallback func);
 };
 
 }  // namespace amd


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Ensures runtime teardown cleanup static fatbin, so any future calls to __hipUnregisterFatBinary will not attempt to access global vars already destroyed.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
~RuntimeTearDown now cleans up remaining fat binaries.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
hip-tests and verifying with reporter

## Test Result

<!-- Briefly summarize test outcomes. -->
no failures on hip-tests and reporter no longer sees segfault with the patch

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
