### PR TITLE
[clr] Fix compilation issues with libc++

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/device_library_decls.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/device_library_decls.h
@@ -120,6 +120,13 @@ extern "C" __device__ __hip_uint64_t __ockl_fprintf_append_string_n(__hip_uint64
                                                                     __hip_uint64_t length,
                                                                     __hip_uint32_t is_last);
 
+// libc++ <ranges> uses __local as function name; include one file, before defining __local macro
+#if defined(__cplusplus) && defined(_LIBCPP_VERSION) && defined(__has_include)
+#  if __has_include (<__ranges/join_view.h>)
+#    include <__ranges/join_view.h>
+#  endif
+#endif
+
 // Introduce local address space
 #define __local __attribute__((address_space(3)))
 

--- a/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
@@ -250,6 +250,13 @@ typedef __hip_internal::int64_t __hip_int64_t;
 
 #define __global__
 
+// __config in libc++ fails on `__has_attribute(__noinline__)` if __noinline__ is emptied
+#if defined(__cplusplus) && defined(__has_include)
+#  if __has_include(<__config>)
+#    include <__config>
+#  endif
+#endif
+
 #define __noinline__
 #define __forceinline__ inline
 


### PR DESCRIPTION
## Motivation

Definitions of `__noinline__` and `__local` macro cause compilation issues with `-stdlib=libc++` flag. These tokens are used in few standard include files; inclusion of these files solves the issue and does not affect stdlibc++ as these files don't exist/included there.

## Technical Details

Closes ROCm/rocm-systems#1874

## Test Plan

Tested in MIOpen, where it causes compilation issue via transitive nlohmann_json include (see https://bugs.gentoo.org/965954)

## Test Result

`#include <ranges>` -> works (compare to original version: https://godbolt.org/z/n9rMYeW7a)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
