### PR TITLE
SWDEV-548892 - Stop using ockl steadyctr function

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_device_functions.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_device_functions.h
@@ -40,8 +40,6 @@ extern "C" __device__ int printf(const char* fmt, ...);
 template <typename... All> static inline __device__ void printf(const char* format, All... all) {}
 #endif
 
-extern "C" __device__ unsigned long long __ockl_steadyctr_u64();
-
 /*
 Integer Intrinsics
 */
@@ -628,7 +626,7 @@ __device__ inline __attribute((always_inline)) long long int __clock() { return 
 // Clock function to return wall clock count at a constant frequency that can be queried
 // through hipDeviceAttributeWallClockRate attribute.
 __device__ inline __attribute__((always_inline)) long long int wall_clock64() {
-  return (long long int)__ockl_steadyctr_u64();
+  return (long long int)__builtin_readsteadycounter();
 }
 
 __device__ inline __attribute__((always_inline)) long long int clock64() { return __clock64(); }


### PR DESCRIPTION
Directly use the builtin