### PR TITLE
Add timeout to Queue Sync function when detaching to avoid hang

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
@@ -268,7 +268,6 @@ write_perfetto(
 
     for(const auto& aitr : agent_queue_ids)
     {
-        uint32_t nqueue = 0;
         for(auto qitr : aitr.second)
         {
             const auto* _agent = _get_agent(aitr.first);
@@ -277,7 +276,7 @@ write_perfetto(
             auto agent_index_info =
                 tool_metadata.get_agent_index(_agent->id, ocfg.agent_index_value);
             _namess << "COMPUTE " << agent_index_info.label << " [" << agent_index_info.index
-                    << "] QUEUE [" << nqueue++ << "] ";
+                    << "] QUEUE [" << qitr.handle - 1 << "] ";
             _namess << agent_index_info.type;
 
             auto _track = ::perfetto::Track{get_hash_id(_namess.str())};

--- a/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
@@ -268,6 +268,7 @@ write_perfetto(
 
     for(const auto& aitr : agent_queue_ids)
     {
+        uint32_t nqueue = 0;
         for(auto qitr : aitr.second)
         {
             const auto* _agent = _get_agent(aitr.first);
@@ -276,7 +277,7 @@ write_perfetto(
             auto agent_index_info =
                 tool_metadata.get_agent_index(_agent->id, ocfg.agent_index_value);
             _namess << "COMPUTE " << agent_index_info.label << " [" << agent_index_info.index
-                    << "] QUEUE [" << qitr.handle - 1 << "] ";
+                    << "] QUEUE [" << nqueue++ << "] ";
             _namess << agent_index_info.type;
 
             auto _track = ::perfetto::Track{get_hash_id(_namess.str())};

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -680,7 +680,7 @@ Queue::create_signal(uint32_t attribute, hsa_signal_t* signal) const
 }
 
 void
-Queue::sync(bool is_detaching) const
+Queue::sync(bool set_timeout) const
 {
 #if defined(ROCPROFILER_CI_STRICT_TIMESTAMPS) && ROCPROFILER_CI_STRICT_TIMESTAMPS > 0
     constexpr auto timeout_sec = std::chrono::seconds{5};
@@ -696,7 +696,7 @@ Queue::sync(bool is_detaching) const
         _core_api.hsa_signal_wait_relaxed_fn(_active_kernels,
                                              HSA_SIGNAL_CONDITION_EQ,
                                              0,
-                                             is_detaching ? timeout : UINT64_MAX,
+                                             set_timeout ? timeout : UINT64_MAX,
                                              HSA_WAIT_STATE_ACTIVE);
     }
     // get_balanced_signal_slots() increments upon kernel dispatch completion and decrements in

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -680,12 +680,24 @@ Queue::create_signal(uint32_t attribute, hsa_signal_t* signal) const
 }
 
 void
-Queue::sync() const
+Queue::sync(bool is_detaching) const
 {
+#if defined(ROCPROFILER_CI_STRICT_TIMESTAMPS) && ROCPROFILER_CI_STRICT_TIMESTAMPS > 0
+    constexpr auto timeout_sec = std::chrono::seconds{5};
+#else
+    // wait a maximum of thirty seconds
+    constexpr auto timeout_sec = std::chrono::seconds{30};
+#endif
+
+    constexpr auto timeout =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(timeout_sec).count();
     if(_active_kernels.handle != 0u)
     {
-        _core_api.hsa_signal_wait_relaxed_fn(
-            _active_kernels, HSA_SIGNAL_CONDITION_EQ, 0, UINT64_MAX, HSA_WAIT_STATE_ACTIVE);
+        _core_api.hsa_signal_wait_relaxed_fn(_active_kernels,
+                                             HSA_SIGNAL_CONDITION_EQ,
+                                             0,
+                                             is_detaching ? timeout : UINT64_MAX,
+                                             HSA_WAIT_STATE_ACTIVE);
     }
     // get_balanced_signal_slots() increments upon kernel dispatch completion and decrements in
     // WriteInterceptor with a starting value of NUM_SIGNALS, so the get_balanced_signal_slots()

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.hpp
@@ -149,7 +149,7 @@ public:
     {
         return _core_api.hsa_signal_load_scacquire_fn(_active_kernels);
     }
-    void sync() const;
+    void sync(bool is_detaching = false) const;
 
     void register_callback(ClientID id, queue_cb_t enqueue_cb, completed_cb_t complete_cb);
     void remove_callback(ClientID id);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.hpp
@@ -149,7 +149,7 @@ public:
     {
         return _core_api.hsa_signal_load_scacquire_fn(_active_kernels);
     }
-    void sync(bool is_detaching = false) const;
+    void sync(bool set_timeout = false) const;
 
     void register_callback(ClientID id, queue_cb_t enqueue_cb, completed_cb_t complete_cb);
     void remove_callback(ClientID id);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -533,10 +533,11 @@ queue_controller_init(HsaApiTable* table)
 }
 
 void
-queue_controller_sync()
+queue_controller_sync(bool is_detaching)
 {
     if(get_queue_controller())
-        get_queue_controller()->iterate_queues([](const Queue* _queue) { _queue->sync(); });
+        get_queue_controller()->iterate_queues(
+            [is_detaching](const Queue* _queue) { _queue->sync(is_detaching); });
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -533,11 +533,11 @@ queue_controller_init(HsaApiTable* table)
 }
 
 void
-queue_controller_sync(bool is_detaching)
+queue_controller_sync(bool set_timeout)
 {
     if(get_queue_controller())
         get_queue_controller()->iterate_queues(
-            [is_detaching](const Queue* _queue) { _queue->sync(is_detaching); });
+            [set_timeout](const Queue* _queue) { _queue->sync(set_timeout); });
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
@@ -135,7 +135,7 @@ void
 queue_controller_fini();
 
 void
-queue_controller_sync(bool is_detaching = false);
+queue_controller_sync(bool set_timeout = false);
 
 void
 queue_controller_init(RocAttachDispatchTable* table);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
@@ -135,7 +135,7 @@ void
 queue_controller_fini();
 
 void
-queue_controller_sync();
+queue_controller_sync(bool is_detaching = false);
 
 void
 queue_controller_init(RocAttachDispatchTable* table);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -693,7 +693,7 @@ invoke_client_detaches()
             context::stop_client_contexts(itr->internal_client_id);
 
             hsa::async_copy_sync();
-            hsa::queue_controller_sync();
+            hsa::queue_controller_sync(true);
             pc_sampling::service_sync();
 
             auto _fini_status = get_fini_status();


### PR DESCRIPTION
## Motivation

Detach function sometimes hangs on queue sync function. Adding timeout to HSA signal wait function similar to what is seen in async copy sync function only when performing detachment.

## Technical Details

Added timeout to HSA signal wait function for queue sync.

## Test Plan

Confirmed that hang no long occurs for vllm benchmark workloads

## Test Result

Confirmed that hang no long occurs for vllm benchmark workloads

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
