### PR TITLE
SWDEV-567475 - Fix failures in graph tests due to GraphExec destroy h…

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -1521,7 +1521,6 @@ hipError_t ihipGraphInstantiate(hip::GraphExec** pGraphExec, hip::Graph* graph,
     delete *pGraphExec;
     return hipErrorInvalidValue;
   }
-  graph->SetGraphInstantiated(true);
   if (DEBUG_HIP_GRAPH_DOT_PRINT) {
     static int i = 1;
     std::string filename =

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -1521,6 +1521,7 @@ hipError_t ihipGraphInstantiate(hip::GraphExec** pGraphExec, hip::Graph* graph,
     delete *pGraphExec;
     return hipErrorInvalidValue;
   }
+  graph->SetGraphInstantiated(true);
   if (DEBUG_HIP_GRAPH_DOT_PRINT) {
     static int i = 1;
     std::string filename =

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -552,7 +552,6 @@ class Graph {
     amd::ScopedLock lock(graphSetLock_);
     graphSet_.insert(this);
     mem_pool_ = device->GetGraphMemoryPool();
-    graphInstantiated_ = false;
     roots_.resize(DEBUG_HIP_FORCE_GRAPH_QUEUES);
     leafs_.resize(DEBUG_HIP_FORCE_GRAPH_QUEUES);
     wait_order_.resize(DEBUG_HIP_FORCE_GRAPH_QUEUES);
@@ -591,6 +590,9 @@ class Graph {
     }
     graphUserObj_.clear();
     memAllocNodePtrs_.clear();
+    if (instantiateDeviceId_ != -1) {
+      static_cast<amd::ReferenceCountedObject*>(g_devices[instantiateDeviceId_])->release();
+    }
   }
 
   void AddManualNodeDuringCapture(GraphNode* node) { capturedNodes_.insert(node); }
@@ -632,6 +634,7 @@ class Graph {
   const std::vector<Node>& GetNodes() const { return vertices_; }
   /// returns all the edges in the graph
   std::vector<std::pair<Node, Node>> GetEdges() const;
+  int instantiateDeviceId_ = -1;
   // returns the original graph ptr if cloned
   const Graph* getOriginalGraph() const { return pOriginalGraph_; }
   // Add user obj resource to graph
@@ -760,9 +763,7 @@ class Graph {
 
   void FreeAllMemory(hip::Stream* stream) { mem_pool_->FreeAllMemory(stream); }
 
-  bool IsGraphInstantiated() const { return graphInstantiated_; }
-
-  void SetGraphInstantiated(bool graphInstantiate) { graphInstantiated_ = graphInstantiate; }
+  bool IsGraphInstantiated() const { return instantiateDeviceId_ >= 0; }
 
   //! returns count of unreleased memalloc nodes
   uint32_t GetMemAllocNodeCount() const { return memalloc_nodes_; }
@@ -799,7 +800,6 @@ class Graph {
   hip::Device* device_;                //!< HIP device object
   hip::MemoryPool* mem_pool_;          //!< Memory pool, associated with this graph
   std::unordered_set<GraphNode*> capturedNodes_;
-  bool graphInstantiated_;
   std::unordered_map<Node, Node> clonedNodes_;
   //! Map of device ID to vector of streams allocated for that device during graph execution.
   //! Each device may require multiple streams to handle parallel execution of graph nodes.
@@ -835,9 +835,6 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
       if (kernArgManager_ != nullptr) {
         kernArgManager_->release();
       }
-    }
-    if (instantiateDeviceId_ != -1) {
-      static_cast<ReferenceCountedObject*>(g_devices[instantiateDeviceId_])->release();
     }
 
     packetBatches_.clear();
@@ -899,7 +896,6 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
   std::unordered_map<int, std::vector<hip::Stream*>> parallel_streams_;
   uint64_t flags_ = 0;
   GraphKernelArgManager* kernArgManager_ = nullptr;  //!< Kernel Arg manager for graph.
-  int instantiateDeviceId_ = -1;
   bool hasHiddenHeap_ = false;  //!< Hidden heap indicator for Kernel node
   bool repeatLaunch_ = false;
 

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -634,7 +634,6 @@ class Graph {
   const std::vector<Node>& GetNodes() const { return vertices_; }
   /// returns all the edges in the graph
   std::vector<std::pair<Node, Node>> GetEdges() const;
-  int instantiateDeviceId_ = -1;
   // returns the original graph ptr if cloned
   const Graph* getOriginalGraph() const { return pOriginalGraph_; }
   // Add user obj resource to graph
@@ -780,6 +779,7 @@ class Graph {
   //!< Used to track which devices are accessed by each parallel stream
   //!< during multi-device graph execution scheduling.
   std::unordered_map<int, std::set<int>> streams_dev_ids_;
+  int instantiateDeviceId_ = -1;
 
  private:
   friend class GraphExec;

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -552,6 +552,7 @@ class Graph {
     amd::ScopedLock lock(graphSetLock_);
     graphSet_.insert(this);
     mem_pool_ = device->GetGraphMemoryPool();
+    graphInstantiated_ = false;
     roots_.resize(DEBUG_HIP_FORCE_GRAPH_QUEUES);
     leafs_.resize(DEBUG_HIP_FORCE_GRAPH_QUEUES);
     wait_order_.resize(DEBUG_HIP_FORCE_GRAPH_QUEUES);
@@ -762,7 +763,8 @@ class Graph {
 
   void FreeAllMemory(hip::Stream* stream) { mem_pool_->FreeAllMemory(stream); }
 
-  bool IsGraphInstantiated() const { return instantiateDeviceId_ >= 0; }
+  bool IsGraphInstantiated() const { return graphInstantiated_; }
+  void SetGraphInstantiated(bool graphInstantiate) { graphInstantiated_ = graphInstantiate; }
 
   //! returns count of unreleased memalloc nodes
   uint32_t GetMemAllocNodeCount() const { return memalloc_nodes_; }
@@ -800,6 +802,7 @@ class Graph {
   hip::Device* device_;                //!< HIP device object
   hip::MemoryPool* mem_pool_;          //!< Memory pool, associated with this graph
   std::unordered_set<GraphNode*> capturedNodes_;
+  bool graphInstantiated_;
   std::unordered_map<Node, Node> clonedNodes_;
   //! Map of device ID to vector of streams allocated for that device during graph execution.
   //! Each device may require multiple streams to handle parallel execution of graph nodes.

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -764,6 +764,7 @@ class Graph {
   void FreeAllMemory(hip::Stream* stream) { mem_pool_->FreeAllMemory(stream); }
 
   bool IsGraphInstantiated() const { return graphInstantiated_; }
+
   void SetGraphInstantiated(bool graphInstantiate) { graphInstantiated_ = graphInstantiate; }
 
   //! returns count of unreleased memalloc nodes


### PR DESCRIPTION
…andler accessing hip::device after shutdown

## Motivation
This PR fixes a bug where graph test failures occurred due to the GraphExec destructor accessing hip::device from the global g_devices array after shutdown. The fix relocates device reference management from the GraphExec derived class to the Graph base class to ensure proper cleanup order.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Moved instantiateDeviceId_ member from GraphExec to Graph base class
Relocated device release logic from GraphExec destructor to Graph destructor
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
All graph related tests should pass
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Run the graph tests locally on a MI350 machine. All tests pass
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
