### PR TITLE
Add ROCPROF_ATTACH_DURATION_CMD_LINE environment variable to reset attach duration between runs

### DIFF
--- a/projects/rocprofiler-sdk/source/bin/rocprofv3-attach.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3-attach.py
@@ -38,6 +38,7 @@ def main(
     attach_library=os.environ.get(
         "ROCPROF_ATTACH_TOOL_LIBRARY", ROCPROF_ATTACH_TOOL_LIBRARY
     ),
+    duration_cmd_line=os.environ.pop("ROCPROF_ATTACH_DURATION_CMD_LINE", None),
     duration=os.environ.get("ROCPROF_ATTACH_DURATION", None),
 ):
     if pid is None:
@@ -83,6 +84,9 @@ def main(
 
     signal.signal(signal.SIGINT, signal_handler)
 
+    # Override ROCPROF_ATTACH_DURATION env variable if cmd line arg was set
+    if duration_cmd_line is not None:
+        duration = duration_cmd_line
     if duration is None:
         sys.stdout.write("Press Enter to detach...")
         sys.stdout.flush()  # Force the prompt to appear immediately

--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -1516,7 +1516,7 @@ def run(app_args, args, **kwargs):
     elif args.pid:
         update_env("ROCPROF_ATTACH_PID", args.pid)
         if args.attach_duration_msec is not None:
-            update_env("ROCPROF_ATTACH_DURATION", f"{args.attach_duration_msec}")
+            update_env("ROCPROF_ATTACH_DURATION_CMD_LINE", f"{args.attach_duration_msec}")
         path = os.path.join(f"{ROCM_DIR}", "bin/rocprofv3-attach")
         if app_args:
             exit_code = subprocess.check_call([sys.executable, path], env=app_env)


### PR DESCRIPTION
## Motivation

Currently, the attach duration does not reset between runs. For instance, if we attach the profiler to a program for 200 milliseconds, and then attempt to re-attach to the program with no duration set in the command line, the rocprofiler will only attach for 200 milliseconds. This PR attempts to fix that by introducing a new environment variable `ROCPROF_ATTACH_DURATION_CMD_LINE ` to be set via the command line argument and be reset between each attach run.

## Technical Details

This situation occurs since we are setting the environment variable `ROCPROF_ATTACH_DURATION` via the command line, and then not resetting it between any runs. I added a new environment variable `ROCPROF_ATTACH_DURATION_CMD_LINE` that is set via the command line, and is reset when `rocprofv3-attach.py` is run. It overrides the `ROCPROF_ATTACH_DURATION` environment variable if it is set. I added this new variable to allow the users to use `ROCPROF_ATTACH_DURATION` without the command line argument setting it if desired.

## Test Plan

Confirmed reset between runs.

## Test Result

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
