### PR TITLE
[rocpd] Performance optimization of Perfetto converter

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/importer.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/importer.py
@@ -47,8 +47,30 @@ def internal_init(_input, _output, skip_auto_merge, automerge_limit):
     assert _check_for_valid_dbs(
         _input
     ), "RocpdImportData error, invalid SQLite3 database provided"
+
     _connection = libpyrocpd.connect(_output)
     _connection.execute("PRAGMA foreign_keys = ON")
+    _connection.execute(
+        "PRAGMA journal_mode = WAL;"
+    )  # Write-Ahead Logging for better concurrency
+    _connection.execute(f"PRAGMA cache_size = -{64 * 1024 * 1024};")  # Use 64MB for cache
+    _connection.execute("PRAGMA temp_store = MEMORY;")
+    _connection.execute("PRAGMA foreign_keys = OFF;")  # defer FK checks until end
+
+    # Enable mmap to increase the performance of reading large DB files
+    # The maximum size of mmap is 2GB (2*1024*1024*1024)
+    # Get total size of all the database files
+    total_size = sum(
+        os.path.getsize(db_file) for db_file in _input if os.path.exists(db_file)
+    )
+
+    # Get the buffer size for mmap
+    mmap_size = total_size + (256 * 1024 * 1024)  # Add 256MB buffer
+
+    if mmap_size < 2 * 1024 * 1024 * 1024:
+        # do not use mmap for large files
+        _connection.execute(f"PRAGMA mmap_size = {mmap_size};")
+
     _table_info = _create_temp_views(_connection, _input)
     _create_meta_views(_connection)
     return (_connection, _input, _table_info)

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/libpyrocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/libpyrocpd.cpp
@@ -130,6 +130,53 @@ get_type_name(const py::object& obj)
     return obj.get_type().attr("__name__").cast<std::string>();
 }
 
+struct db_index
+{
+    using guid_t = std::string;
+    guid_t guid  = {};
+    pid_t  nid   = {};
+    pid_t  pid   = {};
+
+    bool operator==(const db_index& other) const
+    {
+        return guid == other.guid && nid == other.nid && pid == other.pid;
+    }
+
+    bool operator<(const db_index& other) const
+    {
+        return std::tie(guid, nid, pid) < std::tie(other.guid, other.nid, other.pid);
+    }
+};
+
+template <typename T>
+class sql_data_handler
+{
+public:
+    sql_data_handler(sqlite3*         conn,
+                     std::string_view table,
+                     std::string_view order_by   = {},
+                     int64_t          chunk_size = rocpd::sql_generator<T>::compute_chunk_size())
+    {
+        auto sqlgen_perf = rocprofiler::common::simple_timer{
+            fmt::format("Fetching data from table: \"{}\"", table)};
+        auto                    query = fmt::format("SELECT * FROM {}", table);
+        rocpd::sql_generator<T> generator(conn, query, order_by, chunk_size);
+        for(auto ditr : generator)
+        {
+            for(auto& itr : generator.get(ditr))
+            {
+                data_[{itr.guid, itr.nid, itr.pid}].push_back(std::move(itr));
+            }
+        }
+    }
+    ~sql_data_handler() = default;
+
+    const std::vector<T>& operator[](const db_index& index) { return data_[index]; }
+
+private:
+    std::map<db_index, std::vector<T>> data_;
+};
+
 struct RocpdImportData
 {
     RocpdImportData()  = default;
@@ -422,6 +469,30 @@ PYBIND11_MODULE(libpyrocpd, pyrocpd)
                 auto* conn  = rocpd::interop::get_connection(std::move(obj));
                 auto  nodes = rocpd::read<rocpd::types::node>(conn);
 
+                auto _sqlgen_perft = common::simple_timer{"Perfetto generation from SQL (total)"};
+                rocpd::sql_data_handler<rocpd::types::kernel_dispatch> kernels(
+                    conn, "kernels", kernels_order_by);
+                rocpd::sql_data_handler<rocpd::types::memory_allocation> memory_allocations(
+                    conn, "memory_allocations");
+                rocpd::sql_data_handler<rocpd::types::memory_copies>  memory_copies(conn,
+                                                                                   "memory_copies");
+                rocpd::sql_data_handler<rocpd::types::scratch_memory> scratch_memory(
+                    conn, "scratch_memory");
+                rocpd::sql_data_handler<rocpd::types::counter> counters(conn,
+                                                                        "counters_collection");
+                rocpd::sql_data_handler<rocpd::types::region>  regions(
+                    conn, "regions", region_order_by);
+                rocpd::sql_data_handler<rocpd::types::sample> samples(
+                    conn, "samples", sample_order_by);
+                rocpd::sql_data_handler<rocpd::types::thread> threads(conn, "threads");
+
+                std::vector<rocpd::db_index> db_indexes;
+                std::map<
+                    rocpd::db_index,
+                    std::unordered_map<uint64_t, std::pair<rocpd::types::agent, tool::agent_index>>>
+                                                                 db_agent_map;
+                std::map<rocpd::db_index, rocpd::types::process> db_process_map;
+
                 for(const auto& nitr : nodes)
                 {
                     auto agents = rocpd::read<rocpd::types::agent>(
@@ -438,42 +509,6 @@ PYBIND11_MODULE(libpyrocpd, pyrocpd)
                                            pitr.guid,
                                            nitr.id,
                                            nitr.guid);
-                        auto select_guid_nid_pid = [&nitr, &pitr](std::string_view tbl) {
-                            return fmt::format("SELECT * FROM {} WHERE guid = '{}' AND nid "
-                                               "= {} AND pid = {}",
-                                               tbl,
-                                               pitr.guid,
-                                               nitr.id,
-                                               pitr.pid);
-                        };
-
-                        auto _sqlgen_perft = common::simple_timer{fmt::format(
-                            "Perfetto generation from SQL for process {} (total)", pitr.pid)};
-
-                        auto kernels = rocpd::sql_generator<rocpd::types::kernel_dispatch>{
-                            conn, select_guid_nid_pid("kernels"), kernels_order_by};
-
-                        auto memory_allocations =
-                            rocpd::sql_generator<rocpd::types::memory_allocation>{
-                                conn, select_guid_nid_pid("memory_allocations")};
-
-                        auto memory_copies = rocpd::sql_generator<rocpd::types::memory_copies>{
-                            conn, select_guid_nid_pid("memory_copies")};
-
-                        auto scratch_memory = rocpd::sql_generator<rocpd::types::scratch_memory>{
-                            conn, select_guid_nid_pid("scratch_memory")};
-
-                        auto counters = rocpd::sql_generator<rocpd::types::counter>{
-                            conn, select_guid_nid_pid("counters_collection")};
-
-                        auto regions = rocpd::sql_generator<rocpd::types::region>{
-                            conn, select_guid_nid_pid("regions"), region_order_by};
-
-                        auto samples = rocpd::sql_generator<rocpd::types::sample>{
-                            conn, select_guid_nid_pid("samples"), sample_order_by};
-
-                        auto threads = rocpd::sql_generator<rocpd::types::thread>{
-                            conn, select_guid_nid_pid("threads")};
 
                         // absolute_index |-> (agent, agent_index)
                         auto agents_map =
@@ -488,20 +523,31 @@ PYBIND11_MODULE(libpyrocpd, pyrocpd)
 
                         ROCP_TRACE << "Starting Perfetto generation from SQL for process "
                                    << pitr.pid;
-                        auto _sqlgen_perfw = common::simple_timer{fmt::format(
-                            "Perfetto generation from SQL for process {} (write)", pitr.pid)};
-                        rocpd::output::write_perfetto(perfetto_session,
-                                                      pitr,
-                                                      agents_map,
-                                                      threads,
-                                                      regions,
-                                                      samples,
-                                                      kernels,
-                                                      memory_copies,
-                                                      scratch_memory,
-                                                      memory_allocations,
-                                                      counters);
+
+                        rocpd::db_index index{pitr.guid, static_cast<pid_t>(nitr.id), pitr.pid};
+
+                        db_agent_map[index]   = std::move(agents_map);
+                        db_process_map[index] = std::move(pitr);
+                        db_indexes.push_back(std::move(index));
                     }
+                }
+
+                for(const rocpd::db_index& index : db_indexes)
+                {
+                    auto _sqlgen_perfw = common::simple_timer{fmt::format(
+                        "Perfetto generation from SQL for process {} (write)", index.pid)};
+
+                    rocpd::output::write_perfetto(perfetto_session,
+                                                  db_process_map[index],
+                                                  db_agent_map[index],
+                                                  threads[index],
+                                                  regions[index],
+                                                  samples[index],
+                                                  kernels[index],
+                                                  memory_copies[index],
+                                                  scratch_memory[index],
+                                                  memory_allocations[index],
+                                                  counters[index]);
                 }
             }
             return true;

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/libpyrocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/libpyrocpd.cpp
@@ -130,21 +130,43 @@ get_type_name(const py::object& obj)
     return obj.get_type().attr("__name__").cast<std::string>();
 }
 
-struct db_index
+struct node_unique_index
 {
     using guid_t = std::string;
     guid_t guid  = {};
     pid_t  nid   = {};
-    pid_t  pid   = {};
 
-    bool operator==(const db_index& other) const
+    bool operator==(const node_unique_index& other) const
     {
-        return guid == other.guid && nid == other.nid && pid == other.pid;
+        return guid == other.guid && nid == other.nid;
     }
 
-    bool operator<(const db_index& other) const
+    bool operator<(const node_unique_index& other) const
     {
-        return std::tie(guid, nid, pid) < std::tie(other.guid, other.nid, other.pid);
+        return std::tie(guid, nid) < std::tie(other.guid, other.nid);
+    }
+};
+
+struct process_unique_index : public node_unique_index
+{
+    pid_t pid = {};
+
+    bool operator==(const process_unique_index& other) const
+    {
+        return static_cast<const node_unique_index&>(*this) ==
+                   static_cast<const node_unique_index&>(other) &&
+               pid == other.pid;
+    }
+
+    bool operator<(const process_unique_index& other) const
+    {
+        const node_unique_index& base_this  = *this;
+        const node_unique_index& base_other = other;
+
+        if(base_this < base_other) return true;
+        if(base_other < base_this) return false;
+
+        return pid < other.pid;
     }
 };
 
@@ -171,10 +193,10 @@ public:
     }
     ~sql_data_handler() = default;
 
-    const std::vector<T>& operator[](const db_index& index) { return data_[index]; }
+    const std::vector<T>& operator[](const process_unique_index& index) { return data_[index]; }
 
 private:
-    std::map<db_index, std::vector<T>> data_;
+    std::map<process_unique_index, std::vector<T>> data_;
 };
 
 struct RocpdImportData
@@ -444,16 +466,6 @@ PYBIND11_MODULE(libpyrocpd, pyrocpd)
     pyrocpd.def(
         "write_perfetto",
         [](rocpd::RocpdImportData& data, const tool::output_config& output_cfg) -> bool {
-            auto _create_agent_index =
-                [&output_cfg](const rocpd::types::agent& _agent) -> tool::agent_index {
-                auto ret_index = tool::create_agent_index(
-                    output_cfg.agent_index_value,
-                    _agent.node_id,                                      // absolute index
-                    static_cast<uint32_t>(_agent.logical_node_id),       // relative index
-                    static_cast<uint32_t>(_agent.logical_node_type_id),  // type-relative index
-                    std::string_view(_agent.type));
-                return ret_index;
-            };
             // ORDER BY expression for kernel dispatches
             constexpr auto kernels_order_by =
                 "agent_abs_index ASC, stream_id ASC, queue_id ASC, start ASC, end DESC";
@@ -464,12 +476,13 @@ PYBIND11_MODULE(libpyrocpd, pyrocpd)
             auto perfetto_session = rocpd::output::PerfettoSession{output_cfg};
             auto sqlgen_perf      = common::simple_timer{
                 fmt::format("Perfetto generation from {} SQL database(s)", data.size())};
+
             for(auto obj : {data.connection})
             {
-                auto* conn  = rocpd::interop::get_connection(std::move(obj));
-                auto  nodes = rocpd::read<rocpd::types::node>(conn);
+                auto* conn = rocpd::interop::get_connection(std::move(obj));
 
                 auto _sqlgen_perft = common::simple_timer{"Perfetto generation from SQL (total)"};
+
                 rocpd::sql_data_handler<rocpd::types::kernel_dispatch> kernels(
                     conn, "kernels", kernels_order_by);
                 rocpd::sql_data_handler<rocpd::types::memory_allocation> memory_allocations(
@@ -486,68 +499,63 @@ PYBIND11_MODULE(libpyrocpd, pyrocpd)
                     conn, "samples", sample_order_by);
                 rocpd::sql_data_handler<rocpd::types::thread> threads(conn, "threads");
 
-                std::vector<rocpd::db_index> db_indexes;
-                std::map<
-                    rocpd::db_index,
-                    std::unordered_map<uint64_t, std::pair<rocpd::types::agent, tool::agent_index>>>
-                                                                 db_agent_map;
-                std::map<rocpd::db_index, rocpd::types::process> db_process_map;
-
-                for(const auto& nitr : nodes)
+                std::vector<rocpd::types::node> nodes;
                 {
-                    auto agents = rocpd::read<rocpd::types::agent>(
-                        conn, fmt::format("WHERE guid = '{}' AND nid = {}", nitr.guid, nitr.id));
-                    auto processes = rocpd::read<rocpd::types::process>(
-                        conn, fmt::format("WHERE guid = '{}' AND nid = {}", nitr.guid, nitr.id));
+                    auto sqlgen_perf = rocprofiler::common::simple_timer{
+                        fmt::format("Fetching data from table: \"nodes\"")};
+                    nodes = rocpd::read<rocpd::types::node>(conn);
+                }
 
-                    for(const auto& pitr : processes)
+                std::map<rocpd::node_unique_index, std::vector<rocpd::types::agent>> agents;
+                {
+                    auto sqlgen_perf = rocprofiler::common::simple_timer{
+                        fmt::format("Fetching data from table: \"agents\"")};
+                    for(const auto& nitr : nodes)
                     {
-                        ROCP_FATAL_IF(pitr.nid != nitr.id || pitr.guid != nitr.guid)
-                            << fmt::format("Found process with a mismatched nid/guid. process: "
-                                           "{}/{} vs. node: {}/{}",
-                                           pitr.nid,
-                                           pitr.guid,
-                                           nitr.id,
-                                           nitr.guid);
+                        auto node_agents = rocpd::read<rocpd::types::agent>(
+                            conn,
+                            fmt::format("WHERE guid = '{}' AND nid = {}", nitr.guid, nitr.id));
 
-                        // absolute_index |-> (agent, agent_index)
-                        auto agents_map =
-                            std::unordered_map<uint64_t,
-                                               std::pair<rocpd::types::agent, tool::agent_index>>{};
-
-                        for(const auto& itr : agents)
-                        {
-                            auto new_index = _create_agent_index(itr);
-                            agents_map.emplace(itr.absolute_index, std::make_pair(itr, new_index));
-                        }
-
-                        ROCP_TRACE << "Starting Perfetto generation from SQL for process "
-                                   << pitr.pid;
-
-                        rocpd::db_index index{pitr.guid, static_cast<pid_t>(nitr.id), pitr.pid};
-
-                        db_agent_map[index]   = std::move(agents_map);
-                        db_process_map[index] = std::move(pitr);
-                        db_indexes.push_back(std::move(index));
+                        rocpd::node_unique_index node_index{nitr.guid, static_cast<pid_t>(nitr.id)};
+                        agents[node_index] = std::move(node_agents);
                     }
                 }
 
-                for(const rocpd::db_index& index : db_indexes)
+                std::map<rocpd::process_unique_index, rocpd::types::process> processes;
+                {
+                    auto sqlgen_perf = rocprofiler::common::simple_timer{
+                        fmt::format("Fetching data from table: \"processes\"")};
+                    for(const auto& nitr : nodes)
+                    {
+                        auto node_processes = rocpd::read<rocpd::types::process>(
+                            conn,
+                            fmt::format("WHERE guid = '{}' AND nid = {}", nitr.guid, nitr.id));
+
+                        for(const auto& pitr : node_processes)
+                        {
+                            rocpd::process_unique_index process_index{
+                                {nitr.guid, static_cast<pid_t>(nitr.id)}, pitr.pid};
+                            processes[process_index] = std::move(pitr);
+                        }
+                    }
+                }
+
+                for(const auto& [process_index, processes] : processes)
                 {
                     auto _sqlgen_perfw = common::simple_timer{fmt::format(
-                        "Perfetto generation from SQL for process {} (write)", index.pid)};
+                        "Perfetto generation from SQL for process {} (write)", process_index.pid)};
 
                     rocpd::output::write_perfetto(perfetto_session,
-                                                  db_process_map[index],
-                                                  db_agent_map[index],
-                                                  threads[index],
-                                                  regions[index],
-                                                  samples[index],
-                                                  kernels[index],
-                                                  memory_copies[index],
-                                                  scratch_memory[index],
-                                                  memory_allocations[index],
-                                                  counters[index]);
+                                                  processes,
+                                                  agents[process_index],
+                                                  threads[process_index],
+                                                  regions[process_index],
+                                                  samples[process_index],
+                                                  kernels[process_index],
+                                                  memory_copies[process_index],
+                                                  scratch_memory[process_index],
+                                                  memory_allocations[process_index],
+                                                  counters[process_index]);
                 }
             }
             return true;

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
@@ -169,15 +169,15 @@ write_perfetto(
     const PerfettoSession& perfetto_session,
     const types::process&  process,
     const std::unordered_map<uint64_t, std::pair<rocpd::types::agent, tool::agent_index>>&
-                                                     agent_data,
-    const tool::generator<types::thread>&            thread_gen,
-    const tool::generator<types::region>&            region_gen,
-    const tool::generator<types::sample>&            sample_gen,
-    const tool::generator<types::kernel_dispatch>&   kernel_dispatch_gen,
-    const tool::generator<types::memory_copies>&     memory_copy_gen,
-    const tool::generator<types::scratch_memory>&    scratch_memory_gen,
-    const tool::generator<types::memory_allocation>& memory_allocation_gen,
-    const tool::generator<types::counter>&           counter_collection_gen)
+                                                 agent_data,
+    const std::vector<types::thread>&            thread_gen,
+    const std::vector<types::region>&            region_gen,
+    const std::vector<types::sample>&            sample_gen,
+    const std::vector<types::kernel_dispatch>&   kernel_dispatch_gen,
+    const std::vector<types::memory_copies>&     memory_copy_gen,
+    const std::vector<types::scratch_memory>&    scratch_memory_gen,
+    const std::vector<types::memory_allocation>& memory_allocation_gen,
+    const std::vector<types::counter>&           counter_collection_gen)
 {
     namespace sdk    = ::rocprofiler::sdk;
     namespace common = ::rocprofiler::common;
@@ -226,62 +226,58 @@ write_perfetto(
     auto stream_tracks = std::unordered_map<rocprofiler_stream_id_t, ::perfetto::Track>{};
 
     {
-        for(auto ditr : memory_copy_gen)
-            for(const auto& itr : memory_copy_gen.get(ditr))
+        for(const auto& itr : memory_copy_gen)
+        {
+            auto stream_id = rocprofiler_stream_id_t{.handle = itr.stream_id};
+            agent_stream_ids.emplace(stream_id);
+            if(ocfg.group_by_queue)
             {
-                auto stream_id = rocprofiler_stream_id_t{.handle = itr.stream_id};
-                agent_stream_ids.emplace(stream_id);
-                if(ocfg.group_by_queue)
-                {
-                    agent_thread_ids[itr.dst_agent_abs_index].emplace(itr.tid);
-                }
+                agent_thread_ids[itr.dst_agent_abs_index].emplace(itr.tid);
             }
+        }
     }
 
-    for(auto ditr : memory_allocation_gen)
-        for(const auto& itr : memory_allocation_gen.get(ditr))
-        {
-            agent_thread_ids_alloc[itr.agent_abs_index].emplace(itr.tid);
-        }
+    for(const auto& itr : memory_allocation_gen)
+    {
+        agent_thread_ids_alloc[itr.agent_abs_index].emplace(itr.tid);
+    }
 
     {
-        for(auto ditr : kernel_dispatch_gen)
-            for(const auto& itr : kernel_dispatch_gen.get(ditr))
+        for(const auto& itr : kernel_dispatch_gen)
+        {
+            auto stream_id = rocprofiler_stream_id_t{.handle = itr.stream_id};
+            auto queue_id  = rocprofiler_queue_id_t{.handle = itr.queue_id};
+            agent_stream_ids.emplace(stream_id);
+            if(ocfg.group_by_queue)
             {
-                auto stream_id = rocprofiler_stream_id_t{.handle = itr.stream_id};
-                auto queue_id  = rocprofiler_queue_id_t{.handle = itr.queue_id};
-                agent_stream_ids.emplace(stream_id);
-                if(ocfg.group_by_queue)
-                {
-                    agent_queue_ids[itr.agent_abs_index].emplace(queue_id);
-                }
+                agent_queue_ids[itr.agent_abs_index].emplace(queue_id);
             }
+        }
     }
 
     uint64_t nthrn = 0;
-    for(auto ditr : thread_gen)
-        for(const auto& itr : thread_gen.get(ditr))
-        {
-            auto is_main_thread = (static_cast<uint64_t>(itr.tid) == this_pid);
-            auto _idx           = (is_main_thread) ? 0 : ++nthrn;
-            thread_indexes.emplace(itr.tid, _idx);
-            auto _track = ::perfetto::Track{static_cast<uint64_t>(itr.tid), this_pid_track};
-            auto _desc  = _track.Serialize();
-            if(is_main_thread)
-                _desc.set_name(fmt::format("{}", ::basename(command_line.front().c_str())));
-            else
-                _desc.set_name(fmt::format("THREAD {}", _idx));
-            _desc.mutable_thread()->set_pid(this_pid);
-            _desc.mutable_thread()->set_tid(itr.tid);
-            if(is_main_thread)
-                _desc.mutable_thread()->set_thread_name(
-                    fmt::format("{}", ::basename(command_line.front().c_str())));
-            else
-                _desc.mutable_thread()->set_thread_name(fmt::format("THREAD {}", _idx));
-            ::perfetto::TrackEvent::SetTrackDescriptor(_track, _desc);
+    for(const auto& itr : thread_gen)
+    {
+        auto is_main_thread = (static_cast<uint64_t>(itr.tid) == this_pid);
+        auto _idx           = (is_main_thread) ? 0 : ++nthrn;
+        thread_indexes.emplace(itr.tid, _idx);
+        auto _track = ::perfetto::Track{static_cast<uint64_t>(itr.tid), this_pid_track};
+        auto _desc  = _track.Serialize();
+        if(is_main_thread)
+            _desc.set_name(fmt::format("{}", ::basename(command_line.front().c_str())));
+        else
+            _desc.set_name(fmt::format("THREAD {}", _idx));
+        _desc.mutable_thread()->set_pid(this_pid);
+        _desc.mutable_thread()->set_tid(itr.tid);
+        if(is_main_thread)
+            _desc.mutable_thread()->set_thread_name(
+                fmt::format("{}", ::basename(command_line.front().c_str())));
+        else
+            _desc.mutable_thread()->set_thread_name(fmt::format("THREAD {}", _idx));
+        ::perfetto::TrackEvent::SetTrackDescriptor(_track, _desc);
 
-            thread_tracks.emplace(itr.tid, _track);
-        }
+        thread_tracks.emplace(itr.tid, _track);
+    }
 
     for(const auto& [abs_index, thread_ids] : agent_thread_ids)
     {
@@ -352,13 +348,12 @@ write_perfetto(
     // Fetch counter values
     auto counter_id_value = std::map<uint32_t, double>{};
     auto counter_id_name  = std::map<uint32_t, std::string>{};
-    for(auto ditr : counter_collection_gen)
-        for(const auto& record : counter_collection_gen.get(ditr))
-        {
-            // Accumulate counters based on ID
-            counter_id_value[record.counter_id] += record.value;
-            counter_id_name[record.counter_id] = std::string{record.counter_name};
-        }
+    for(const auto& record : counter_collection_gen)
+    {
+        // Accumulate counters based on ID
+        counter_id_value[record.counter_id] += record.value;
+        counter_id_name[record.counter_id] = std::string{record.counter_name};
+    }
 
     // trace events
     {
@@ -372,333 +367,314 @@ write_perfetto(
             return sdk::get_perfetto_category(_category_idx);
         };
 
-        for(auto ditr : region_gen)
+        for(const auto& itr : region_gen)
         {
-            for(auto itr : region_gen.get(ditr))
+            auto& track      = thread_tracks.at(itr.tid);
+            auto  _name      = itr.name;
+            auto  _operation = itr.name;
+
+            if(itr.has_extdata())
             {
-                auto& track      = thread_tracks.at(itr.tid);
-                auto  _name      = itr.name;
-                auto  _operation = itr.name;
-
-                if(itr.has_extdata())
-                {
-                    auto _extdata = itr.get_extdata();
-                    if(_extdata.message && !_extdata.message->empty())
-                        _name = _extdata.message.value();
-                    if(_extdata.operation && !_extdata.operation->empty())
-                        _operation = _extdata.operation.value();
-                }
-
-                auto _category = ::perfetto::DynamicCategory{get_category_string(itr.category)};
-                TRACE_EVENT_BEGIN(_category,
-                                  ::perfetto::DynamicString{_name},
-                                  track,
-                                  itr.start,
-                                  ::perfetto::Flow::Global(itr.stack_id ^ uuid_pid),
-                                  "begin_ns",
-                                  itr.start,
-                                  "end_ns",
-                                  itr.end,
-                                  "delta_ns",
-                                  (itr.end - itr.start),
-                                  "tid",
-                                  itr.tid,
-                                  "kind",
-                                  itr.category,
-                                  "operation",
-                                  _operation,
-                                  "corr_id",
-                                  itr.stack_id,
-                                  "ancestor_id",
-                                  itr.parent_stack_id,
-                                  [&](::perfetto::EventContext ctx) { (void) ctx; });
-
-                TRACE_EVENT_END(_category, track, itr.end);
-
-                tracing_session->FlushBlocking();
+                auto _extdata = itr.get_extdata();
+                if(_extdata.message && !_extdata.message->empty()) _name = _extdata.message.value();
+                if(_extdata.operation && !_extdata.operation->empty())
+                    _operation = _extdata.operation.value();
             }
-        }
 
-        for(auto ditr : sample_gen)
-        {
-            for(auto itr : sample_gen.get(ditr))
-            {
-                auto& track      = thread_tracks.at(itr.tid);
-                auto  _name      = itr.name;
-                auto  _operation = itr.name;
+            auto _category = ::perfetto::DynamicCategory{get_category_string(itr.category)};
+            TRACE_EVENT_BEGIN(_category,
+                              ::perfetto::DynamicString{_name},
+                              track,
+                              itr.start,
+                              ::perfetto::Flow::Global(itr.stack_id ^ uuid_pid),
+                              "begin_ns",
+                              itr.start,
+                              "end_ns",
+                              itr.end,
+                              "delta_ns",
+                              (itr.end - itr.start),
+                              "tid",
+                              itr.tid,
+                              "kind",
+                              itr.category,
+                              "operation",
+                              _operation,
+                              "corr_id",
+                              itr.stack_id,
+                              "ancestor_id",
+                              itr.parent_stack_id,
+                              [&](::perfetto::EventContext ctx) { (void) ctx; });
 
-                if(itr.has_extdata())
-                {
-                    auto _extdata = itr.get_extdata();
-                    if(_extdata.message && !_extdata.message->empty())
-                        _name = _extdata.message.value();
-                    if(_extdata.operation && !_extdata.operation->empty())
-                        _operation = _extdata.operation.value();
-                }
+            TRACE_EVENT_END(_category, track, itr.end);
 
-                auto _category = ::perfetto::DynamicCategory{get_category_string(itr.category)};
-                TRACE_EVENT_INSTANT(_category,
-                                    ::perfetto::DynamicString{_name},
-                                    track,
-                                    itr.timestamp,
-                                    ::perfetto::Flow::Global(itr.stack_id ^ uuid_pid),
-                                    "begin_ns",
-                                    itr.timestamp,
-                                    "end_ns",
-                                    itr.timestamp,
-                                    "delta_ns",
-                                    0,
-                                    "tid",
-                                    itr.tid,
-                                    "kind",
-                                    itr.category,
-                                    "operation",
-                                    _operation,
-                                    "corr_id",
-                                    itr.stack_id,
-                                    "ancestor_id",
-                                    itr.parent_stack_id,
-                                    [&](::perfetto::EventContext ctx) { (void) ctx; });
-
-                tracing_session->FlushBlocking();
-            }
-        }
-
-        for(auto ditr : memory_copy_gen)
-        {
-            for(auto itr : memory_copy_gen.get(ditr))
-            {
-                ::perfetto::Track* _track = nullptr;
-                if(ocfg.group_by_queue)
-                {
-                    _track = &agent_thread_tracks.at(itr.dst_agent_abs_index).at(itr.tid);
-                }
-                else
-                {
-                    auto stream_id = rocprofiler_stream_id_t{.handle = itr.stream_id};
-                    _track         = &stream_tracks.at(stream_id);
-                }
-
-                auto src_agent_index = agent_data.at(itr.src_agent_abs_index).second;
-                auto dst_agent_index = agent_data.at(itr.dst_agent_abs_index).second;
-                TRACE_EVENT_BEGIN(sdk::perfetto_category<sdk::category::memory_copy>::name,
-                                  ::perfetto::DynamicString{itr.name},
-                                  *_track,
-                                  itr.start,
-                                  ::perfetto::Flow::Global(itr.stack_id ^ uuid_pid),
-                                  "begin_ns",
-                                  itr.start,
-                                  "end_ns",
-                                  itr.end,
-                                  "delta_ns",
-                                  (itr.end - itr.start),
-                                  "kind",
-                                  itr.category,
-                                  "operation",
-                                  itr.name,
-                                  "src_agent",
-                                  src_agent_index.as_string("-"),
-                                  "dst_agent",
-                                  dst_agent_index.as_string("-"),
-                                  "copy_bytes",
-                                  itr.size,
-                                  "corr_id",
-                                  itr.stack_id,
-                                  "tid",
-                                  itr.tid,
-                                  "stream_id",
-                                  itr.stream_id);
-                TRACE_EVENT_END(
-                    sdk::perfetto_category<sdk::category::memory_copy>::name, *_track, itr.end);
-            }
             tracing_session->FlushBlocking();
         }
 
-        for(auto ditr : kernel_dispatch_gen)
+        for(const auto& itr : sample_gen)
         {
-            auto gen = kernel_dispatch_gen.get(ditr);
+            auto& track      = thread_tracks.at(itr.tid);
+            auto  _name      = itr.name;
+            auto  _operation = itr.name;
 
-            // Temporary fix until timestamp issues are resolved:
-            // Kernel dispatches executing on the same agent/queue/stream may have overlapping
-            // timestamps due to firmware reporting inaccuracies. Perfetto requires non-overlapping
-            // time slices on the same track for proper visualization.
-            // In the initial fix, the timestamps were set halfway between the ending timestamp and
-            // starting timestamp of overlapping kernel dispatches. In cases when one slice was
-            // completely overlapped by another one, this halfway point could fall before the
-            // beginning of the first slice or after the ending of the second one, making the
-            // duration of the slice negative. In the new fix, the halfway point is placed between
-            // the midpoints of the two overlapping slices.
+            if(itr.has_extdata())
             {
-                struct kernel_dispatch_group_index
+                auto _extdata = itr.get_extdata();
+                if(_extdata.message && !_extdata.message->empty()) _name = _extdata.message.value();
+                if(_extdata.operation && !_extdata.operation->empty())
+                    _operation = _extdata.operation.value();
+            }
+
+            auto _category = ::perfetto::DynamicCategory{get_category_string(itr.category)};
+            TRACE_EVENT_INSTANT(_category,
+                                ::perfetto::DynamicString{_name},
+                                track,
+                                itr.timestamp,
+                                ::perfetto::Flow::Global(itr.stack_id ^ uuid_pid),
+                                "begin_ns",
+                                itr.timestamp,
+                                "end_ns",
+                                itr.timestamp,
+                                "delta_ns",
+                                0,
+                                "tid",
+                                itr.tid,
+                                "kind",
+                                itr.category,
+                                "operation",
+                                _operation,
+                                "corr_id",
+                                itr.stack_id,
+                                "ancestor_id",
+                                itr.parent_stack_id,
+                                [&](::perfetto::EventContext ctx) { (void) ctx; });
+        }
+
+        tracing_session->FlushBlocking();
+
+        for(const auto& itr : memory_copy_gen)
+        {
+            ::perfetto::Track* _track = nullptr;
+            if(ocfg.group_by_queue)
+            {
+                _track = &agent_thread_tracks.at(itr.dst_agent_abs_index).at(itr.tid);
+            }
+            else
+            {
+                auto stream_id = rocprofiler_stream_id_t{.handle = itr.stream_id};
+                _track         = &stream_tracks.at(stream_id);
+            }
+
+            auto src_agent_index = agent_data.at(itr.src_agent_abs_index).second;
+            auto dst_agent_index = agent_data.at(itr.dst_agent_abs_index).second;
+            TRACE_EVENT_BEGIN(sdk::perfetto_category<sdk::category::memory_copy>::name,
+                              ::perfetto::DynamicString{itr.name},
+                              *_track,
+                              itr.start,
+                              ::perfetto::Flow::Global(itr.stack_id ^ uuid_pid),
+                              "begin_ns",
+                              itr.start,
+                              "end_ns",
+                              itr.end,
+                              "delta_ns",
+                              (itr.end - itr.start),
+                              "kind",
+                              itr.category,
+                              "operation",
+                              itr.name,
+                              "src_agent",
+                              src_agent_index.as_string("-"),
+                              "dst_agent",
+                              dst_agent_index.as_string("-"),
+                              "copy_bytes",
+                              itr.size,
+                              "corr_id",
+                              itr.stack_id,
+                              "tid",
+                              itr.tid,
+                              "stream_id",
+                              itr.stream_id);
+            TRACE_EVENT_END(
+                sdk::perfetto_category<sdk::category::memory_copy>::name, *_track, itr.end);
+        }
+        tracing_session->FlushBlocking();
+
+        // Temporary fix until timestamp issues are resolved:
+        // Kernel dispatches executing on the same agent/queue/stream may have overlapping
+        // timestamps due to firmware reporting inaccuracies. Perfetto requires non-overlapping
+        // time slices on the same track for proper visualization.
+        // In the initial fix, the timestamps were set halfway between the ending timestamp and
+        // starting timestamp of overlapping kernel dispatches. In cases when one slice was
+        // completely overlapped by another one, this halfway point could fall before the
+        // beginning of the first slice or after the ending of the second one, making the
+        // duration of the slice negative. In the new fix, the halfway point is placed between
+        // the midpoints of the two overlapping slices.
+        std::vector<types::kernel_dispatch> kernel_dispatch(kernel_dispatch_gen);
+        {
+            struct kernel_dispatch_group_index
+            {
+                uint64_t agent_absolute_index = 0;
+                uint64_t stream_id            = 0;
+                uint64_t queue_id             = 0;
+
+                bool operator<(const kernel_dispatch_group_index& other) const
                 {
-                    uint64_t agent_absolute_index = 0;
-                    uint64_t stream_id            = 0;
-                    uint64_t queue_id             = 0;
+                    if(agent_absolute_index != other.agent_absolute_index)
+                        return agent_absolute_index < other.agent_absolute_index;
 
-                    bool operator<(const kernel_dispatch_group_index& other) const
-                    {
-                        if(agent_absolute_index != other.agent_absolute_index)
-                            return agent_absolute_index < other.agent_absolute_index;
+                    if(queue_id != other.queue_id) return queue_id < other.queue_id;
 
-                        if(queue_id != other.queue_id) return queue_id < other.queue_id;
-
-                        return stream_id < other.stream_id;
-                    }
-                };
-
-                struct kernel_dispatch_data
-                {
-                    std::vector<types::kernel_dispatch>::iterator sample;
-                    rocprofiler_timestamp_t                       timestamp;
-                };
-
-                std::map<kernel_dispatch_group_index, std::vector<kernel_dispatch_data>>
-                    kernel_groups;
-
-                // The visualization problem only happens for overlapping dispatches on the same
-                // agent/queue/stream. Separate all dispatches into groups based on their execution
-                // context.
-                for(auto it = begin(gen); it != end(gen); ++it)
-                {
-                    kernel_dispatch_group_index group_index;
-                    group_index.agent_absolute_index = it->agent_abs_index;
-                    if(ocfg.group_by_queue)
-                        group_index.queue_id = it->queue_id;
-                    else
-                        group_index.stream_id = it->stream_id;
-
-                    // Define each dispatch by the middle timestamp to keep their relative order
-                    // correct.
-                    kernel_groups[group_index].push_back({it, (it->start + it->end) / 2});
+                    return stream_id < other.stream_id;
                 }
+            };
 
-                for(auto& kernel_group : kernel_groups)
+            struct kernel_dispatch_data
+            {
+                types::kernel_dispatch* sample;
+                rocprofiler_timestamp_t timestamp;
+            };
+
+            std::map<kernel_dispatch_group_index, std::vector<kernel_dispatch_data>> kernel_groups;
+
+            // The visualization problem only happens for overlapping dispatches on the same
+            // agent/queue/stream. Separate all dispatches into groups based on their execution
+            // context.
+            for(types::kernel_dispatch& it : kernel_dispatch)
+            {
+                kernel_dispatch_group_index group_index;
+                group_index.agent_absolute_index = it.agent_abs_index;
+                if(ocfg.group_by_queue)
+                    group_index.queue_id = it.queue_id;
+                else
+                    group_index.stream_id = it.stream_id;
+
+                // Define each dispatch by the middle timestamp to keep their relative order
+                // correct.
+                kernel_groups[group_index].push_back({&it, it.start + (it.end - it.start) / 2});
+            }
+
+            for(auto& [_, group_data] : kernel_groups)
+            {
+                // Sort dispatches within the group by timestamp to ensure proper temporal
+                // ordering.
+                std::sort(group_data.begin(),
+                          group_data.end(),
+                          [&](const kernel_dispatch_data& a, const kernel_dispatch_data& b) {
+                              return a.timestamp < b.timestamp;
+                          });
+
+                // Adjust end and start timestamps of consecutive dispatches to remove overlaps.
+                for(auto sample_it = group_data.begin(); sample_it != group_data.end() - 1;
+                    ++sample_it)
                 {
-                    // Sort dispatches within the group by timestamp to ensure proper temporal
-                    // ordering.
-                    auto& group_data = kernel_group.second;
-                    std::sort(begin(group_data),
-                              end(group_data),
-                              [&](const kernel_dispatch_data& a, const kernel_dispatch_data& b) {
-                                  return a.timestamp < b.timestamp;
+                    auto next_sample_it = std::next(sample_it);
+
+                    auto current_it = sample_it->sample;
+                    auto next_it    = next_sample_it->sample;
+
+                    // Skip overlap handling if there is no overlap
+                    if(next_it->start >= current_it->end) continue;
+
+                    auto current_midpoint = sample_it->timestamp;
+                    auto next_midpoint    = next_sample_it->timestamp;
+
+                    auto current_mid_to_end_duration = current_it->end - current_midpoint;
+                    auto next_start_to_mid_duration  = next_midpoint - next_it->start;
+                    auto total_span                  = current_mid_to_end_duration +
+                                      next_start_to_mid_duration;  // Total duration to redistribute
+                    auto max_span =
+                        next_midpoint - current_midpoint;  // Available space between midpoints
+
+                    // Preserve the proportions of each dispatch within the overlapped region to
+                    // minimize the timing error.
+                    double scale_factor =
+                        (total_span > 0) ? static_cast<double>(max_span) / total_span : 0.0;
+
+                    auto new_current_end =
+                        current_midpoint + static_cast<rocprofiler_timestamp_t>(
+                                               current_mid_to_end_duration * scale_factor);
+
+                    auto new_next_start =
+                        next_midpoint - static_cast<rocprofiler_timestamp_t>(
+                                            next_start_to_mid_duration * scale_factor);
+
+                    // Report changed timestamps to ROCP INFO
+                    ROCP_INFO << fmt::format(
+                        "Kernel ending timestamp changed from {} ns to {} ns "
+                        "following kernel starting timestamp changed from {} ns to {} ns "
+                        "due to firmware timestamp error.",
+                        current_it->end,
+                        new_current_end,
+                        next_it->start,
+                        new_next_start);
+
+                    current_it->end = new_current_end;
+                    next_it->start  = new_next_start;
+                }
+            }
+        }
+
+        for(const auto& current : kernel_dispatch)
+        {
+            ::perfetto::Track* _track    = nullptr;
+            auto               agent_id  = current.agent_abs_index;
+            auto               queue_id  = rocprofiler_queue_id_t{.handle = current.queue_id};
+            auto               stream_id = rocprofiler_stream_id_t{.handle = current.stream_id};
+            if(ocfg.group_by_queue)
+            {
+                _track = &agent_queue_tracks.at(agent_id).at(queue_id);
+            }
+            else
+            {
+                _track = &stream_tracks.at(stream_id);
+            }
+
+            auto agent_index = agent_data.at(current.agent_abs_index).second;
+            auto _name =
+                (ocfg.kernel_rename && !current.region.empty()) ? current.region : current.name;
+            TRACE_EVENT_BEGIN(sdk::perfetto_category<sdk::category::kernel_dispatch>::name,
+                              ::perfetto::DynamicString{_name},
+                              *_track,
+                              current.start,
+                              ::perfetto::Flow::Global(current.stack_id ^ uuid_pid),
+                              "begin_ns",
+                              current.start,
+                              "end_ns",
+                              current.end,
+                              "delta_ns",
+                              (current.end - current.start),
+                              "kind",
+                              current.category,
+                              "agent",
+                              agent_index.as_string("-"),
+                              "corr_id",
+                              current.stack_id,
+                              "queue",
+                              current.queue_id,
+                              "tid",
+                              current.tid,
+                              "kernel_id",
+                              current.kernel_id,
+                              "Scratch_Size",
+                              current.scratch_size,
+                              "LDS_Block_Size",
+                              current.lds_size,
+                              "workgroup_size",
+                              to_string(current.workgroup_size),
+                              "grid_size",
+                              to_string(current.grid_size),
+                              "stream_id",
+                              current.stream_id,
+                              [&](::perfetto::EventContext ctx) {
+                                  for(auto& [counter_id, counter_value] : counter_id_value)
+                                  {
+                                      rocprofiler::sdk::add_perfetto_annotation(
+                                          ctx, counter_id_name.at(counter_id), counter_value);
+                                  }
                               });
-
-                    // Adjust end and start timestamps of consecutive dispatches to remove overlaps.
-                    for(auto sample_it = group_data.begin(); sample_it != group_data.end() - 1;
-                        ++sample_it)
-                    {
-                        auto next_sample_it = std::next(sample_it);
-
-                        auto current_it = sample_it->sample;
-                        auto next_it    = next_sample_it->sample;
-
-                        // Skip overlap handling if there is no overlap
-                        if(next_it->start >= current_it->end) continue;
-
-                        auto current_midpoint = sample_it->timestamp;
-                        auto next_midpoint    = next_sample_it->timestamp;
-
-                        auto current_mid_to_end_duration = current_it->end - current_midpoint;
-                        auto next_start_to_mid_duration  = next_midpoint - next_it->start;
-                        auto total_span =
-                            current_mid_to_end_duration +
-                            next_start_to_mid_duration;  // Total duration to redistribute
-                        auto max_span =
-                            next_midpoint - current_midpoint;  // Available space between midpoints
-
-                        // Preserve the proportions of each dispatch within the overlapped region to
-                        // minimize the timing error.
-                        double scale_factor =
-                            (total_span > 0) ? static_cast<double>(max_span) / total_span : 0.0;
-
-                        auto new_current_end =
-                            current_midpoint + static_cast<rocprofiler_timestamp_t>(
-                                                   current_mid_to_end_duration * scale_factor);
-
-                        auto new_next_start =
-                            next_midpoint - static_cast<rocprofiler_timestamp_t>(
-                                                next_start_to_mid_duration * scale_factor);
-
-                        // Report changed timestamps to ROCP INFO
-                        ROCP_INFO << fmt::format(
-                            "Kernel ending timestamp changed from {} ns to {} ns "
-                            "following kernel starting timestamp changed from {} ns to {} ns "
-                            "due to firmware timestamp error.",
-                            current_it->end,
-                            new_current_end,
-                            next_it->start,
-                            new_next_start);
-
-                        current_it->end = new_current_end;
-                        next_it->start  = new_next_start;
-                    }
-                }
-            }
-
-            for(auto& current : gen)
-            {
-                ::perfetto::Track* _track    = nullptr;
-                auto               agent_id  = current.agent_abs_index;
-                auto               queue_id  = rocprofiler_queue_id_t{.handle = current.queue_id};
-                auto               stream_id = rocprofiler_stream_id_t{.handle = current.stream_id};
-                if(ocfg.group_by_queue)
-                {
-                    _track = &agent_queue_tracks.at(agent_id).at(queue_id);
-                }
-                else
-                {
-                    _track = &stream_tracks.at(stream_id);
-                }
-
-                auto agent_index = agent_data.at(current.agent_abs_index).second;
-                auto _name =
-                    (ocfg.kernel_rename && !current.region.empty()) ? current.region : current.name;
-                TRACE_EVENT_BEGIN(sdk::perfetto_category<sdk::category::kernel_dispatch>::name,
-                                  ::perfetto::DynamicString{_name},
-                                  *_track,
-                                  current.start,
-                                  ::perfetto::Flow::Global(current.stack_id ^ uuid_pid),
-                                  "begin_ns",
-                                  current.start,
-                                  "end_ns",
-                                  current.end,
-                                  "delta_ns",
-                                  (current.end - current.start),
-                                  "kind",
-                                  current.category,
-                                  "agent",
-                                  agent_index.as_string("-"),
-                                  "corr_id",
-                                  current.stack_id,
-                                  "queue",
-                                  current.queue_id,
-                                  "tid",
-                                  current.tid,
-                                  "kernel_id",
-                                  current.kernel_id,
-                                  "Scratch_Size",
-                                  current.scratch_size,
-                                  "LDS_Block_Size",
-                                  current.lds_size,
-                                  "workgroup_size",
-                                  to_string(current.workgroup_size),
-                                  "grid_size",
-                                  to_string(current.grid_size),
-                                  "stream_id",
-                                  current.stream_id,
-                                  [&](::perfetto::EventContext ctx) {
-                                      for(auto& [counter_id, counter_value] : counter_id_value)
-                                      {
-                                          rocprofiler::sdk::add_perfetto_annotation(
-                                              ctx, counter_id_name.at(counter_id), counter_value);
-                                      }
-                                  });
-                TRACE_EVENT_END(sdk::perfetto_category<sdk::category::kernel_dispatch>::name,
-                                *_track,
-                                current.end);
-            }
-            tracing_session->FlushBlocking();
+            TRACE_EVENT_END(
+                sdk::perfetto_category<sdk::category::kernel_dispatch>::name, *_track, current.end);
         }
+        tracing_session->FlushBlocking();
     }
 
     // counter tracks
@@ -708,36 +684,30 @@ write_perfetto(
         auto mem_cpy_extremes  = std::pair<uint64_t, uint64_t>{std::numeric_limits<uint64_t>::max(),
                                                               std::numeric_limits<uint64_t>::min()};
         auto constexpr timestamp_buffer = 1000;
-        for(auto ditr : memory_copy_gen)
+        for(const auto& itr : memory_copy_gen)
         {
-            for(const auto& itr : memory_copy_gen.get(ditr))
-            {
-                uint64_t _mean_timestamp = itr.start + (0.5 * (itr.end - itr.start));
+            uint64_t _mean_timestamp = itr.start + (0.5 * (itr.end - itr.start));
 
-                mem_cpy_endpoints[itr.dst_agent_abs_index].emplace(itr.start - timestamp_buffer, 0);
-                mem_cpy_endpoints[itr.dst_agent_abs_index].emplace(itr.start, 0);
-                mem_cpy_endpoints[itr.dst_agent_abs_index].emplace(_mean_timestamp, 0);
-                mem_cpy_endpoints[itr.dst_agent_abs_index].emplace(itr.end, 0);
-                mem_cpy_endpoints[itr.dst_agent_abs_index].emplace(itr.end + timestamp_buffer, 0);
+            mem_cpy_endpoints[itr.dst_agent_abs_index].emplace(itr.start - timestamp_buffer, 0);
+            mem_cpy_endpoints[itr.dst_agent_abs_index].emplace(itr.start, 0);
+            mem_cpy_endpoints[itr.dst_agent_abs_index].emplace(_mean_timestamp, 0);
+            mem_cpy_endpoints[itr.dst_agent_abs_index].emplace(itr.end, 0);
+            mem_cpy_endpoints[itr.dst_agent_abs_index].emplace(itr.end + timestamp_buffer, 0);
 
-                mem_cpy_extremes = std::make_pair(std::min(mem_cpy_extremes.first, itr.start),
-                                                  std::max(mem_cpy_extremes.second, itr.end));
-            }
+            mem_cpy_extremes = std::make_pair(std::min(mem_cpy_extremes.first, itr.start),
+                                              std::max(mem_cpy_extremes.second, itr.end));
         }
 
-        for(auto ditr : memory_copy_gen)
+        for(const auto& itr : memory_copy_gen)
         {
-            for(const auto& itr : memory_copy_gen.get(ditr))
-            {
-                auto mbeg = mem_cpy_endpoints.at(itr.dst_agent_abs_index).lower_bound(itr.start);
-                auto mend = mem_cpy_endpoints.at(itr.dst_agent_abs_index).upper_bound(itr.end);
+            auto mbeg = mem_cpy_endpoints.at(itr.dst_agent_abs_index).lower_bound(itr.start);
+            auto mend = mem_cpy_endpoints.at(itr.dst_agent_abs_index).upper_bound(itr.end);
 
-                LOG_IF(FATAL, mbeg == mend)
-                    << "Missing range for timestamp [" << itr.start << ", " << itr.end << "]";
+            LOG_IF(FATAL, mbeg == mend)
+                << "Missing range for timestamp [" << itr.start << ", " << itr.end << "]";
 
-                for(auto mitr = mbeg; mitr != mend; ++mitr)
-                    mitr->second += itr.size;
-            }
+            for(auto mitr = mbeg; mitr != mend; ++mitr)
+                mitr->second += itr.size;
         }
 
         constexpr auto bytes_multiplier         = 1024;
@@ -809,60 +779,57 @@ write_perfetto(
         auto free_mem_info = std::vector<free_memory_information>{};
 
         // Load memory allocation endpoints
-        for(auto ditr : memory_allocation_gen)
+        for(const auto& itr : memory_allocation_gen)
         {
-            for(const auto& itr : memory_allocation_gen.get(ditr))
+            if(itr.type == "ALLOC")
             {
-                if(itr.type == "ALLOC")
-                {
-                    LOG_IF(FATAL, itr.agent_name.empty())
-                        << "Missing agent id for memory allocation trace";
+                LOG_IF(FATAL, itr.agent_name.empty())
+                    << "Missing agent id for memory allocation trace";
 
-                    if(itr.level == "REAL")
-                    {
-                        mem_alloc_endpoints[itr.agent_abs_index].emplace(
-                            itr.start,
-                            memory_information{itr.size,
-                                               rocprofiler_address_t{.handle = itr.address},
-                                               rocprofiler_queue_id_t{.handle = itr.queue_id},
-                                               true});
-                        mem_alloc_endpoints[itr.agent_abs_index].emplace(
-                            itr.end,
-                            memory_information{itr.size,
-                                               rocprofiler_address_t{.handle = itr.address},
-                                               rocprofiler_queue_id_t{.handle = itr.queue_id},
-                                               true});
+                if(itr.level == "REAL")
+                {
+                    mem_alloc_endpoints[itr.agent_abs_index].emplace(
+                        itr.start,
+                        memory_information{itr.size,
+                                           rocprofiler_address_t{.handle = itr.address},
+                                           rocprofiler_queue_id_t{.handle = itr.queue_id},
+                                           true});
+                    mem_alloc_endpoints[itr.agent_abs_index].emplace(
+                        itr.end,
+                        memory_information{itr.size,
+                                           rocprofiler_address_t{.handle = itr.address},
+                                           rocprofiler_queue_id_t{.handle = itr.queue_id},
+                                           true});
 
-                        address_to_agent_and_size.emplace(
-                            rocprofiler_address_t{.handle = itr.address},
-                            rocprofiler::agent::index_and_size{itr.agent_abs_index, itr.size});
-                    }
-                    // Scratch memory operations are indexed by queue id as agent
-                    // id is not available
-                    else if(itr.level == "SCRATCH")
-                    {
-                        queue_to_agent_and_size.emplace(
-                            rocprofiler_queue_id_t{.handle = itr.queue_id},
-                            rocprofiler::agent::index_and_size{itr.agent_abs_index, itr.size});
-                    }
+                    address_to_agent_and_size.emplace(
+                        rocprofiler_address_t{.handle = itr.address},
+                        rocprofiler::agent::index_and_size{itr.agent_abs_index, itr.size});
                 }
-                else if(itr.type == "FREE")
+                // Scratch memory operations are indexed by queue id as agent
+                // id is not available
+                else if(itr.level == "SCRATCH")
                 {
-                    // Store free memory operations in seperate vector to pair with agent
-                    // and allocation size in following loop
-                    if(itr.level == "REAL")
-                    {
-                        free_mem_info.push_back(free_memory_information{
-                            itr.start,
-                            itr.end,
-                            rocprofiler_address_t{.handle = itr.address},
-                            rocprofiler_queue_id_t{.handle = itr.queue_id}});
-                    }
+                    queue_to_agent_and_size.emplace(
+                        rocprofiler_queue_id_t{.handle = itr.queue_id},
+                        rocprofiler::agent::index_and_size{itr.agent_abs_index, itr.size});
                 }
-                else
+            }
+            else if(itr.type == "FREE")
+            {
+                // Store free memory operations in seperate vector to pair with agent
+                // and allocation size in following loop
+                if(itr.level == "REAL")
                 {
-                    ROCP_CI_LOG(WARNING) << "unhandled memory allocation type " << itr.type;
+                    free_mem_info.push_back(
+                        free_memory_information{itr.start,
+                                                itr.end,
+                                                rocprofiler_address_t{.handle = itr.address},
+                                                rocprofiler_queue_id_t{.handle = itr.queue_id}});
                 }
+            }
+            else
+            {
+                ROCP_CI_LOG(WARNING) << "unhandled memory allocation type " << itr.type;
             }
         }
 
@@ -983,41 +950,39 @@ write_perfetto(
             std::unordered_map<uint64_t, std::map<rocprofiler_timestamp_t, uint64_t>>{};
 
         // Load scratch memory usage endpoints
-        for(const auto& ditr : scratch_memory_gen)
-            for(const auto& itr : scratch_memory_gen.get(ditr))
+        for(const auto& itr : scratch_memory_gen)
+        {
+            auto agent_abs_index = itr.agent_abs_index;
+            if(itr.operation == "FREE")
             {
-                auto agent_abs_index = itr.agent_abs_index;
-                if(itr.operation == "FREE")
-                {
-                    auto [agent_index, size] =
-                        queue_to_agent_and_size[rocprofiler_queue_id_t{.handle = itr.queue_id}];
-                    agent_abs_index = agent_index;
-                }
-
-                // Track start and end timestamps for this scratch memory record
-                scratch_mem_endpoints[agent_abs_index].emplace(itr.start, 0);
-                scratch_mem_endpoints[agent_abs_index].emplace(itr.end, 0);
+                auto [agent_index, size] =
+                    queue_to_agent_and_size[rocprofiler_queue_id_t{.handle = itr.queue_id}];
+                agent_abs_index = agent_index;
             }
+
+            // Track start and end timestamps for this scratch memory record
+            scratch_mem_endpoints[agent_abs_index].emplace(itr.start, 0);
+            scratch_mem_endpoints[agent_abs_index].emplace(itr.end, 0);
+        }
 
         // Load values at each endpoint
-        for(const auto& ditr : scratch_memory_gen)
-            for(const auto& itr : scratch_memory_gen.get(ditr))
+        for(const auto& itr : scratch_memory_gen)
+        {
+            if(itr.operation == "ALLOC")
             {
-                if(itr.operation == "ALLOC")
+                auto agent_abs_index = itr.agent_abs_index;
+
+                // For each timestamp in the range of this record including intervening
+                // deallocations write in allocation size
+                auto begin = scratch_mem_endpoints.at(agent_abs_index).lower_bound(itr.start);
+                auto end   = scratch_mem_endpoints.at(agent_abs_index).upper_bound(itr.end);
+
+                for(auto mitr = begin; mitr != end; ++mitr)
                 {
-                    auto agent_abs_index = itr.agent_abs_index;
-
-                    // For each timestamp in the range of this record including intervening
-                    // deallocations write in allocation size
-                    auto begin = scratch_mem_endpoints.at(agent_abs_index).lower_bound(itr.start);
-                    auto end   = scratch_mem_endpoints.at(agent_abs_index).upper_bound(itr.end);
-
-                    for(auto mitr = begin; mitr != end; ++mitr)
-                    {
-                        mitr->second = itr.size;
-                    }
+                    mitr->second = itr.size;
                 }
             }
+        }
 
         // Create counter tracks for visualization
         auto scratch_mem_tracks = std::unordered_map<uint64_t, ::perfetto::CounterTrack>{};
@@ -1074,78 +1039,70 @@ write_perfetto(
 
         auto constexpr timestamp_buffer = 1000;
 
-        for(auto ditr : counter_collection_gen)
-            for(const auto& record : counter_collection_gen.get(ditr))
+        for(const auto& record : counter_collection_gen)
+        {
+            // const auto& info = record.;
+
+            const auto& start_timestamp = record.start;
+            const auto& end_timestamp   = record.end;
+
+            uint64_t _mean_timestamp = start_timestamp + (0.5 * (end_timestamp - start_timestamp));
+
+            for(auto& [counter_id, counter_value] : counter_id_value)
             {
-                // const auto& info = record.;
-
-                const auto& start_timestamp = record.start;
-                const auto& end_timestamp   = record.end;
-
-                uint64_t _mean_timestamp =
-                    start_timestamp + (0.5 * (end_timestamp - start_timestamp));
-
-                for(auto& [counter_id, counter_value] : counter_id_value)
-                {
-                    counters_endpoints[record.agent_abs_index][counter_id].emplace(
-                        start_timestamp - timestamp_buffer, 0);
-                    counters_endpoints[record.agent_abs_index][counter_id].emplace(start_timestamp,
-                                                                                   counter_value);
-                    counters_endpoints[record.agent_abs_index][counter_id].emplace(_mean_timestamp,
-                                                                                   counter_value);
-                    counters_endpoints[record.agent_abs_index][counter_id].emplace(end_timestamp,
-                                                                                   0);
-                    counters_endpoints[record.agent_abs_index][counter_id].emplace(
-                        end_timestamp + timestamp_buffer, 0);
-                }
-
-                counters_extremes = std::make_pair(std::min(counters_extremes.first, record.start),
-                                                   std::max(counters_extremes.second, record.end));
+                counters_endpoints[record.agent_abs_index][counter_id].emplace(
+                    start_timestamp - timestamp_buffer, 0);
+                counters_endpoints[record.agent_abs_index][counter_id].emplace(start_timestamp,
+                                                                               counter_value);
+                counters_endpoints[record.agent_abs_index][counter_id].emplace(_mean_timestamp,
+                                                                               counter_value);
+                counters_endpoints[record.agent_abs_index][counter_id].emplace(end_timestamp, 0);
+                counters_endpoints[record.agent_abs_index][counter_id].emplace(
+                    end_timestamp + timestamp_buffer, 0);
             }
+
+            counters_extremes = std::make_pair(std::min(counters_extremes.first, record.start),
+                                               std::max(counters_extremes.second, record.end));
+        }
 
         auto counter_tracks =
             std::unordered_map<uint64_t, std::map<std::string, ::perfetto::CounterTrack>>{};
 
         constexpr auto extremes_endpoint_buffer = 5000;
 
-        for(auto ditr : counter_collection_gen)
+        for(const auto& record : counter_collection_gen)
         {
-            for(const auto& record : counter_collection_gen.get(ditr))
+            // const auto& info = record.dispatch_data.dispatch_info;
+            // const auto& sym  = tool_metadata.get_kernel_symbol(info.kernel_id);
+
+            // CHECK(sym != nullptr);
+
+            auto name = record.kernel_name;
+
+            for(auto& [counter_id, counter_value] : counter_id_value)
             {
-                // const auto& info = record.dispatch_data.dispatch_info;
-                // const auto& sym  = tool_metadata.get_kernel_symbol(info.kernel_id);
+                counters_endpoints[record.agent_id][counter_id].emplace(
+                    counters_extremes.first - extremes_endpoint_buffer, 0);
+                counters_endpoints[record.agent_id][counter_id].emplace(
+                    counters_extremes.second + extremes_endpoint_buffer, 0);
 
-                // CHECK(sym != nullptr);
+                const auto _agent           = agent_data.at(record.agent_abs_index).first;
+                auto       agent_index_info = agent_data.at(record.agent_abs_index).second;
+                auto       track_name_ss    = std::stringstream{};
+                track_name_ss << agent_index_info.label << " [" << agent_index_info.index << "] "
+                              << "PMC " << record.counter_name;
 
-                auto name = record.kernel_name;
+                auto track_name = track_name_ss.str();
 
-                for(auto& [counter_id, counter_value] : counter_id_value)
+                counter_tracks[record.agent_abs_index].emplace(
+                    track_name, ::perfetto::CounterTrack{track_name.c_str(), this_pid_track});
+                auto& endpoints = counters_endpoints[record.agent_id][counter_id];
+                for(auto& counter_itr : endpoints)
                 {
-                    counters_endpoints[record.agent_id][counter_id].emplace(
-                        counters_extremes.first - extremes_endpoint_buffer, 0);
-                    counters_endpoints[record.agent_id][counter_id].emplace(
-                        counters_extremes.second + extremes_endpoint_buffer, 0);
-
-                    const auto _agent           = agent_data.at(record.agent_abs_index).first;
-                    auto       agent_index_info = agent_data.at(record.agent_abs_index).second;
-                    auto       track_name_ss    = std::stringstream{};
-                    track_name_ss << agent_index_info.label << " [" << agent_index_info.index
-                                  << "] "
-                                  << "PMC " << record.counter_name;
-
-                    auto track_name = track_name_ss.str();
-
-                    counter_tracks[record.agent_abs_index].emplace(
-                        track_name, ::perfetto::CounterTrack{track_name.c_str(), this_pid_track});
-                    auto& endpoints = counters_endpoints[record.agent_id][counter_id];
-                    for(auto& counter_itr : endpoints)
-                    {
-                        TRACE_COUNTER(
-                            sdk::perfetto_category<sdk::category::counter_collection>::name,
-                            counter_tracks[record.agent_abs_index].at(track_name),
-                            counter_itr.first,
-                            counter_itr.second);
-                    }
+                    TRACE_COUNTER(sdk::perfetto_category<sdk::category::counter_collection>::name,
+                                  counter_tracks[record.agent_abs_index].at(track_name),
+                                  counter_itr.first,
+                                  counter_itr.second);
                 }
             }
             tracing_session->FlushBlocking();

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
@@ -165,19 +165,17 @@ PerfettoSession::~PerfettoSession()
 }
 
 void
-write_perfetto(
-    const PerfettoSession& perfetto_session,
-    const types::process&  process,
-    const std::unordered_map<uint64_t, std::pair<rocpd::types::agent, tool::agent_index>>&
-                                                 agent_data,
-    const std::vector<types::thread>&            thread_gen,
-    const std::vector<types::region>&            region_gen,
-    const std::vector<types::sample>&            sample_gen,
-    const std::vector<types::kernel_dispatch>&   kernel_dispatch_gen,
-    const std::vector<types::memory_copies>&     memory_copy_gen,
-    const std::vector<types::scratch_memory>&    scratch_memory_gen,
-    const std::vector<types::memory_allocation>& memory_allocation_gen,
-    const std::vector<types::counter>&           counter_collection_gen)
+write_perfetto(const PerfettoSession&                       perfetto_session,
+               const types::process&                        process,
+               const std::vector<types::agent>&             agent_data,
+               const std::vector<types::thread>&            thread_gen,
+               const std::vector<types::region>&            region_gen,
+               const std::vector<types::sample>&            sample_gen,
+               const std::vector<types::kernel_dispatch>&   kernel_dispatch_gen,
+               const std::vector<types::memory_copies>&     memory_copy_gen,
+               const std::vector<types::scratch_memory>&    scratch_memory_gen,
+               const std::vector<types::memory_allocation>& memory_allocation_gen,
+               const std::vector<types::counter>&           counter_collection_gen)
 {
     namespace sdk    = ::rocprofiler::sdk;
     namespace common = ::rocprofiler::common;
@@ -225,15 +223,35 @@ write_perfetto(
                            std::unordered_map<rocprofiler_queue_id_t, ::perfetto::Track>>{};
     auto stream_tracks = std::unordered_map<rocprofiler_stream_id_t, ::perfetto::Track>{};
 
+    const tool::output_config& output_cfg = perfetto_session.config;
+    auto                       _create_agent_index =
+        [&output_cfg](const rocpd::types::agent& _agent) -> tool::agent_index {
+        auto ret_index = tool::create_agent_index(
+            output_cfg.agent_index_value,
+            _agent.node_id,                                      // absolute index
+            static_cast<uint32_t>(_agent.logical_node_id),       // relative index
+            static_cast<uint32_t>(_agent.logical_node_type_id),  // type-relative index
+            std::string_view(_agent.type));
+        return ret_index;
+    };
+
+    // absolute_index |-> (agent, agent_index)
+    auto agents_map =
+        std::unordered_map<uint64_t, std::pair<rocpd::types::agent, tool::agent_index>>{};
+
+    for(const auto& itr : agent_data)
     {
-        for(const auto& itr : memory_copy_gen)
+        auto new_index = _create_agent_index(itr);
+        agents_map.emplace(itr.absolute_index, std::make_pair(itr, new_index));
+    }
+
+    for(const auto& itr : memory_copy_gen)
+    {
+        auto stream_id = rocprofiler_stream_id_t{.handle = itr.stream_id};
+        agent_stream_ids.emplace(stream_id);
+        if(ocfg.group_by_queue)
         {
-            auto stream_id = rocprofiler_stream_id_t{.handle = itr.stream_id};
-            agent_stream_ids.emplace(stream_id);
-            if(ocfg.group_by_queue)
-            {
-                agent_thread_ids[itr.dst_agent_abs_index].emplace(itr.tid);
-            }
+            agent_thread_ids[itr.dst_agent_abs_index].emplace(itr.tid);
         }
     }
 
@@ -281,7 +299,7 @@ write_perfetto(
 
     for(const auto& [abs_index, thread_ids] : agent_thread_ids)
     {
-        const auto _agent = agent_data.at(abs_index).first;
+        const auto _agent = agents_map.at(abs_index).first;
 
         for(auto titr : thread_ids)
         {
@@ -308,9 +326,8 @@ write_perfetto(
 
     for(const auto& [abs_index, queue_ids] : agent_queue_ids)
     {
-        uint32_t   nqueue           = 0;
-        const auto _agent           = agent_data.at(abs_index).first;
-        auto       agent_index_info = agent_data.at(abs_index).second;
+        uint32_t nqueue           = 0;
+        auto     agent_index_info = agents_map.at(abs_index).second;
 
         for(auto qitr : queue_ids)
         {
@@ -406,9 +423,9 @@ write_perfetto(
                               [&](::perfetto::EventContext ctx) { (void) ctx; });
 
             TRACE_EVENT_END(_category, track, itr.end);
-
-            tracing_session->FlushBlocking();
         }
+
+        tracing_session->FlushBlocking();
 
         for(const auto& itr : sample_gen)
         {
@@ -464,8 +481,8 @@ write_perfetto(
                 _track         = &stream_tracks.at(stream_id);
             }
 
-            auto src_agent_index = agent_data.at(itr.src_agent_abs_index).second;
-            auto dst_agent_index = agent_data.at(itr.dst_agent_abs_index).second;
+            auto src_agent_index = agents_map.at(itr.src_agent_abs_index).second;
+            auto dst_agent_index = agents_map.at(itr.dst_agent_abs_index).second;
             TRACE_EVENT_BEGIN(sdk::perfetto_category<sdk::category::memory_copy>::name,
                               ::perfetto::DynamicString{itr.name},
                               *_track,
@@ -496,6 +513,7 @@ write_perfetto(
             TRACE_EVENT_END(
                 sdk::perfetto_category<sdk::category::memory_copy>::name, *_track, itr.end);
         }
+
         tracing_session->FlushBlocking();
 
         // Temporary fix until timestamp issues are resolved:
@@ -628,7 +646,7 @@ write_perfetto(
                 _track = &stream_tracks.at(stream_id);
             }
 
-            auto agent_index = agent_data.at(current.agent_abs_index).second;
+            auto agent_index = agents_map.at(current.agent_abs_index).second;
             auto _name =
                 (ocfg.kernel_rename && !current.region.empty()) ? current.region : current.name;
             TRACE_EVENT_BEGIN(sdk::perfetto_category<sdk::category::kernel_dispatch>::name,
@@ -674,6 +692,7 @@ write_perfetto(
             TRACE_EVENT_END(
                 sdk::perfetto_category<sdk::category::kernel_dispatch>::name, *_track, current.end);
         }
+
         tracing_session->FlushBlocking();
     }
 
@@ -724,9 +743,8 @@ write_perfetto(
             mem_cpy_endpoints[abs_index].emplace(mem_cpy_extremes.second + extremes_endpoint_buffer,
                                                  0);
 
-            auto       _track_name      = std::stringstream{};
-            const auto _agent           = agent_data.at(abs_index).first;
-            auto       agent_index_info = agent_data.at(abs_index).second;
+            auto _track_name      = std::stringstream{};
+            auto agent_index_info = agents_map.at(abs_index).second;
             _track_name << "COPY BYTES to " << agent_index_info.label << " ["
                         << agent_index_info.index << "] (" << agent_index_info.type << ")";
 
@@ -912,10 +930,10 @@ write_perfetto(
 
             auto _track_name = std::stringstream{};
 
-            if(agent_data.find(abs_index) != agent_data.end())
+            auto agent_it = agents_map.find(abs_index);
+            if(agent_it != agents_map.end())
             {
-                const auto _agent           = agent_data.at(abs_index).first;
-                auto       agent_index_info = agent_data.at(abs_index).second;
+                auto& [_, agent_index_info] = agent_it->second;
                 _track_name << "ALLOCATE BYTES on " << agent_index_info.label << " ["
                             << agent_index_info.index << "] (" << agent_index_info.type << ")";
             }
@@ -994,9 +1012,8 @@ write_perfetto(
             // Add buffer timestamps for better visualization
             if(!ts_map.empty())
             {
-                auto       _track_name      = std::stringstream{};
-                const auto _agent           = agent_data.at(abs_index).first;
-                auto       agent_index_info = agent_data.at(abs_index).second;
+                auto _track_name      = std::stringstream{};
+                auto agent_index_info = agents_map.at(abs_index).second;
 
                 _track_name << "SCRATCH MEMORY on " << agent_index_info.label << " ["
                             << agent_index_info.index << "] (" << agent_index_info.type << ")";
@@ -1086,9 +1103,8 @@ write_perfetto(
                 counters_endpoints[record.agent_id][counter_id].emplace(
                     counters_extremes.second + extremes_endpoint_buffer, 0);
 
-                const auto _agent           = agent_data.at(record.agent_abs_index).first;
-                auto       agent_index_info = agent_data.at(record.agent_abs_index).second;
-                auto       track_name_ss    = std::stringstream{};
+                auto agent_index_info = agents_map.at(record.agent_abs_index).second;
+                auto track_name_ss    = std::stringstream{};
                 track_name_ss << agent_index_info.label << " [" << agent_index_info.index << "] "
                               << "PMC " << record.counter_name;
 

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.hpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.hpp
@@ -53,18 +53,16 @@ struct PerfettoSession
 };
 
 void
-write_perfetto(
-    const PerfettoSession& perfetto_session,
-    const types::process&  process,
-    const std::unordered_map<uint64_t, std::pair<rocpd::types::agent, tool::agent_index>>&
-                                                 agent_data,
-    const std::vector<types::thread>&            thread_gen,
-    const std::vector<types::region>&            region_gen,
-    const std::vector<types::sample>&            sample_gen,
-    const std::vector<types::kernel_dispatch>&   kernel_dispatch_gen,
-    const std::vector<types::memory_copies>&     memory_copy_gen,
-    const std::vector<types::scratch_memory>&    scratch_memory_gen,
-    const std::vector<types::memory_allocation>& memory_allocation_gen,
-    const std::vector<types::counter>&           counter_collection_gen);
+write_perfetto(const PerfettoSession&                       perfetto_session,
+               const types::process&                        process,
+               const std::vector<types::agent>&             agent_data,
+               const std::vector<types::thread>&            thread_data,
+               const std::vector<types::region>&            region_data,
+               const std::vector<types::sample>&            sample_data,
+               const std::vector<types::kernel_dispatch>&   kernel_dispatch_data,
+               const std::vector<types::memory_copies>&     memory_copy_data,
+               const std::vector<types::scratch_memory>&    scratch_memory_data,
+               const std::vector<types::memory_allocation>& memory_allocation_datan,
+               const std::vector<types::counter>&           counter_collection_data);
 }  // namespace output
 }  // namespace rocpd

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.hpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.hpp
@@ -57,14 +57,14 @@ write_perfetto(
     const PerfettoSession& perfetto_session,
     const types::process&  process,
     const std::unordered_map<uint64_t, std::pair<rocpd::types::agent, tool::agent_index>>&
-                                                     agent_data,
-    const tool::generator<types::thread>&            thread_gen,
-    const tool::generator<types::region>&            region_gen,
-    const tool::generator<types::sample>&            sample_gen,
-    const tool::generator<types::kernel_dispatch>&   kernel_dispatch_gen,
-    const tool::generator<types::memory_copies>&     memory_copy_gen,
-    const tool::generator<types::scratch_memory>&    scratch_memory_gen,
-    const tool::generator<types::memory_allocation>& memory_allocation_gen,
-    const tool::generator<types::counter>&           counter_collection_gen);
+                                                 agent_data,
+    const std::vector<types::thread>&            thread_gen,
+    const std::vector<types::region>&            region_gen,
+    const std::vector<types::sample>&            sample_gen,
+    const std::vector<types::kernel_dispatch>&   kernel_dispatch_gen,
+    const std::vector<types::memory_copies>&     memory_copy_gen,
+    const std::vector<types::scratch_memory>&    scratch_memory_gen,
+    const std::vector<types::memory_allocation>& memory_allocation_gen,
+    const std::vector<types::counter>&           counter_collection_gen);
 }  // namespace output
 }  // namespace rocpd

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/types.hpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/types.hpp
@@ -127,6 +127,7 @@ struct thread : public base_class<common_node_info>
 {
     pid_t       ppid  = 0;
     pid_t       pid   = 0;
+    pid_t       nid   = 0;
     pid_t       tid   = 0;
     uint64_t    start = 0;
     uint64_t    end   = 0;
@@ -297,6 +298,7 @@ struct memory_allocation
 {
     uint64_t                id               = 0;
     guid_t                  guid             = {};
+    pid_t                   nid              = 0;
     pid_t                   pid              = 0;
     pid_t                   tid              = 0;
     rocprofiler_timestamp_t start            = 0;
@@ -324,6 +326,7 @@ struct memory_copies
 {
     uint64_t                id                   = 0;
     guid_t                  guid                 = {};
+    pid_t                   nid                  = 0;
     pid_t                   pid                  = 0;
     pid_t                   tid                  = 0;
     rocprofiler_timestamp_t start                = 0;
@@ -363,6 +366,7 @@ struct scratch_memory
     uint64_t                agent_type_index = 0;
     std::string             agent_type       = {};
     uint64_t                queue_id         = 0;
+    pid_t                   nid              = 0;
     pid_t                   pid              = 0;
     pid_t                   tid              = 0;
     std::string             alloc_flags      = {};
@@ -426,6 +430,7 @@ struct counter
     uint32_t                stack_id         = 0;
     uint64_t                correlation_id   = 0;
     uint64_t                event_id         = 0;
+    pid_t                   nid              = 0;
     pid_t                   pid              = 0;
     pid_t                   tid              = 0;
     uint32_t                agent_id         = 0;
@@ -539,6 +544,7 @@ load(ArchiveT& ar, rocpd::types::thread& data)
 
     LOAD_DATA_FIELD(ppid);
     LOAD_DATA_FIELD(pid);
+    LOAD_DATA_FIELD(nid);
     LOAD_DATA_FIELD(tid);
     LOAD_DATA_FIELD(start);
     LOAD_DATA_FIELD(end);
@@ -732,6 +738,7 @@ load(ArchiveT& ar, rocpd::types::memory_allocation& data)
 {
     LOAD_DATA_FIELD(id);
     LOAD_DATA_FIELD(guid);
+    LOAD_DATA_FIELD(nid);
     LOAD_DATA_FIELD(pid);
     LOAD_DATA_FIELD(tid);
     LOAD_DATA_FIELD(start);
@@ -761,6 +768,7 @@ load(ArchiveT& ar, rocpd::types::memory_copies& data)
 {
     LOAD_DATA_FIELD(id);
     LOAD_DATA_FIELD(guid);
+    LOAD_DATA_FIELD(nid);
     LOAD_DATA_FIELD(pid);
     LOAD_DATA_FIELD(tid);
     LOAD_DATA_FIELD(start);
@@ -801,6 +809,7 @@ load(ArchiveT& ar, rocpd::types::scratch_memory& data)
     LOAD_DATA_FIELD(agent_type_index);
     LOAD_DATA_FIELD(agent_type);
     LOAD_DATA_FIELD(queue_id);
+    LOAD_DATA_FIELD(nid);
     LOAD_DATA_FIELD(pid);
     LOAD_DATA_FIELD(tid);
     LOAD_DATA_FIELD(alloc_flags);
@@ -873,6 +882,7 @@ load(ArchiveT& ar, rocpd::types::counter& data)
     LOAD_DATA_FIELD(stack_id);
     LOAD_DATA_FIELD(correlation_id);
     LOAD_DATA_FIELD(event_id);
+    LOAD_DATA_FIELD(nid);
     LOAD_DATA_FIELD(pid);
     LOAD_DATA_FIELD(tid);
     LOAD_DATA_FIELD(agent_id);


### PR DESCRIPTION
# PR Details
This change improves query performance when multiple databases are attached.

## Associated Jira Ticket Number/Link
SWDEV-552367

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## Technical details


When N databases are attached, any SELECT statement that targets a table in one of those databases is internally expanded into a unified SELECT that includes all attached databases.
Even if the query is intended to fetch data from only one database, SQLite still performs a scan on every attached database.

In the previous implementation:

- We attached ~10 databases.
- For each database, we ran a SELECT filtered by a database index.
- Internally, SQLite executed a unified SELECT that scanned all 10 databases separately.
- Because this happened for each database, this resulted in N × N selects (e.g., 100 scans) even though only N of them returned actual data.

This unnecessary work caused performance to degrade significantly as more databases were attached.

Solution

This PR changes the logic to query each table only once, regardless of how many databases are attached.
All data separation by database index is now handled on the C++ side rather than relying on SQLite to re-run unified queries repeatedly.

After the data is grouped per database, the resulting vectors are passed directly to the Perfetto writer.  On the Perfetto writing side looping thought the vectors multiple times doesn't affect the performance.

Result

- Eliminates redundant unified SELECT executions
- Reduces total query overhead
- Keeps performance stable even with many attached databases

For 9 attached databases the processing time reduced from 296 seconds to 92.
Fetching data from the databases takes 89% of the total time. 

## Added/updated tests?

<!-- We encourage you to keep the code coverage percentage at 80% and above. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [ ] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [ ] No, Does not apply to this PR.

