### PR TITLE
[BUG] Fix the issue where ipc_shmem_->read_index goes out of bounds when waiting for an IPC event.

### DIFF
--- a/projects/clr/hipamd/src/hip_event_ipc.cpp
+++ b/projects/clr/hipamd/src/hip_event_ipc.cpp
@@ -101,7 +101,7 @@ hipError_t IPCEvent::synchronize() {
 
 // ================================================================================================
 hipError_t IPCEvent::streamWait(hip::Stream* stream, uint flags) {
-  int offset = ipc_evt_.ipc_shmem_->read_index;
+  int offset = ipc_evt_.ipc_shmem_->read_index % IPC_SIGNALS_PER_EVENT;
   hipError_t status =
       ihipStreamOperation(reinterpret_cast<hipStream_t>(stream), ROCCLR_COMMAND_STREAM_WAIT_VALUE,
                           &(ipc_evt_.ipc_shmem_->signal[offset]), 0, 1, 1, sizeof(uint32_t));


### PR DESCRIPTION
In the hipEvent_t stream-wait operation using shared-memory (IPC) events, the calculation of

[offset = ipc_shmem_->read_index](https://github.com/ROCm/rocm-systems/blob/f7338717aeb56fbe394c0683539a0cf2f7f3ded7/projects/clr/hipamd/src/hip_event_ipc.cpp#L104)

does not apply a modulo with IPC_SIGNALS_PER_EVENT (which is fixed at 32), causing subsequent access to

ipc_shmem_->signal[offset]

to go out of bounds.
https://github.com/ROCm/rocm-systems/blob/f7338717aeb56fbe394c0683539a0cf2f7f3ded7/projects/clr/hipamd/src/hip_event_ipc.cpp#L107

Looking at the initialization code, ipc_shmem_->signal[] is only initialized with IPC_SIGNALS_PER_EVENT = 32 elements:
https://github.com/ROCm/rocm-systems/blob/f7338717aeb56fbe394c0683539a0cf2f7f3ded7/projects/clr/hipamd/src/hip_event_ipc.cpp#L67

Therefore, when an IPC event’s stream-wait is invoked more than 32 times, it triggers an out-of-bounds access and results in an abnormal termination — which indeed matches what we encountered in practice.