### PR TITLE
[clr] Remove AMD_COMGR_ACTION_ADD_PRECOMPILED_HEADERS action

### DIFF
--- a/projects/clr/rocclr/device/devprogram.cpp
+++ b/projects/clr/rocclr/device/devprogram.cpp
@@ -314,7 +314,6 @@ bool Program::compileToLLVMBitcode(const amd_comgr_data_set_t compileInputs,
 
   bool hasAction = false;
   bool hasOutput = false;
-  bool hasDataSetPCH = false;
 
   amd_comgr_status_t status = createAction(langver, options, &action, &hasAction);
 
@@ -322,19 +321,9 @@ bool Program::compileToLLVMBitcode(const amd_comgr_data_set_t compileInputs,
     status = amd::Comgr::create_data_set(&output);
   }
 
-  //  Adding Precompiled Headers
+  // Preprocess the source
   if (status == AMD_COMGR_STATUS_SUCCESS) {
     hasOutput = true;
-    status = amd::Comgr::create_data_set(&dataSetPCH);
-  }
-
-  // Preprocess the source
-  // FIXME: This must happen before the precompiled headers are added, as they
-  // do not embed the source text of the header, and so reference paths in the
-  // filesystem which do not exist at runtime.
-  if (status == AMD_COMGR_STATUS_SUCCESS) {
-    hasDataSetPCH = true;
-
     if (amdOptions->isDumpFlagSet(amd::option::DUMP_I)) {
       amd_comgr_data_set_t dataSetPreprocessor;
       bool hasDataSetPreprocessor = false;
@@ -360,17 +349,6 @@ bool Program::compileToLLVMBitcode(const amd_comgr_data_set_t compileInputs,
     }
   }
 
-  if (!isHIP()) {
-    if (status == AMD_COMGR_STATUS_SUCCESS) {
-      status = amd::Comgr::do_action(AMD_COMGR_ACTION_ADD_PRECOMPILED_HEADERS, action, input,
-                                     dataSetPCH);
-      extractBuildLog(dataSetPCH);
-    }
-
-    // Set input for the next stage
-    input = dataSetPCH;
-  }
-
   //  Compiling the source codes with precompiled headers or directly compileInputs
   if (status == AMD_COMGR_STATUS_SUCCESS) {
     if (link_dev_libs) {
@@ -393,10 +371,6 @@ bool Program::compileToLLVMBitcode(const amd_comgr_data_set_t compileInputs,
 
   if (hasAction) {
     amd::Comgr::destroy_action_info(action);
-  }
-
-  if (hasDataSetPCH) {
-    amd::Comgr::destroy_data_set(dataSetPCH);
   }
 
   if (hasOutput) {

--- a/projects/clr/rocclr/device/devprogram.cpp
+++ b/projects/clr/rocclr/device/devprogram.cpp
@@ -309,7 +309,6 @@ bool Program::compileToLLVMBitcode(const amd_comgr_data_set_t compileInputs,
   //  Create the output data set
   amd_comgr_action_info_t action{};
   amd_comgr_data_set_t output{};
-  amd_comgr_data_set_t dataSetPCH{};
   amd_comgr_data_set_t input = compileInputs;
 
   bool hasAction = false;


### PR DESCRIPTION
## Motivation

`AMD_COMGR_ACTION_ADD_PRECOMPILED_HEADERS` is deprecated and currently implemented as a no-op. We do not need to use it anymore.

## Technical Details

Since https://github.com/ROCm/llvm-project/commit/b754bb10cdfe71e3cda2e092b2f7d309419b8f86, the `opencl-c.pch` header is not used anymore and instead the compiler uses `-include opencl-c-base.h -fdeclare-opencl-builtins` when compiling OpenCL.