### PR TITLE
[rocprof-sys] Fix test build failure on RHEL 10

### DIFF
--- a/projects/rocprofiler-systems/examples/videodecode/video_demuxer.h
+++ b/projects/rocprofiler-systems/examples/videodecode/video_demuxer.h
@@ -570,8 +570,8 @@ private:
              !strcmp(av_fmt_input_ctx_->iformat->long_name, "FLV (Flash Video)") ||
              !strcmp(av_fmt_input_ctx_->iformat->long_name, "Matroska / WebM"));
 
-        // For latest version of FFMPeg, read_seek and read_seek2 is not exposed in
-        // AVFormatContext
+        // For latest version of FFMPeg, read_seek and read_seek2 are not exposed in
+        // AVInputFormat
 #if USE_AVCODEC_GREATER_THAN_58_134
         is_seekable_ = true;
 #else

--- a/projects/rocprofiler-systems/examples/videodecode/video_demuxer.h
+++ b/projects/rocprofiler-systems/examples/videodecode/video_demuxer.h
@@ -573,7 +573,16 @@ private:
         // For latest version of FFMPeg, read_seek and read_seek2 are not exposed in
         // AVInputFormat
 #if USE_AVCODEC_GREATER_THAN_58_134
-        is_seekable_ = true;
+        // Check if the input stream is seekable for FFmpeg >= 58.134
+        if((av_fmt_input_ctx_->iformat->flags & AVFMT_NO_BYTE_SEEK) == 0 &&
+           av_fmt_input_ctx_->pb && av_fmt_input_ctx_->pb->seekable)
+        {
+            is_seekable_ = true;
+        }
+        else
+        {
+            is_seekable_ = false;
+        }
 #else
         // Check if the input file allow seek functionality.
         is_seekable_ = av_fmt_input_ctx_->iformat->read_seek ||

--- a/projects/rocprofiler-systems/examples/videodecode/video_demuxer.h
+++ b/projects/rocprofiler-systems/examples/videodecode/video_demuxer.h
@@ -570,9 +570,15 @@ private:
              !strcmp(av_fmt_input_ctx_->iformat->long_name, "FLV (Flash Video)") ||
              !strcmp(av_fmt_input_ctx_->iformat->long_name, "Matroska / WebM"));
 
+        // For latest version of FFMPeg, read_seek and read_seek2 is not exposed in
+        // AVFormatContext
+#if USE_AVCODEC_GREATER_THAN_58_134
+        is_seekable_ = true;
+#else
         // Check if the input file allow seek functionality.
         is_seekable_ = av_fmt_input_ctx_->iformat->read_seek ||
                        av_fmt_input_ctx_->iformat->read_seek2;
+#endif
 
         if(is_h264_)
         {

--- a/projects/rocprofiler-systems/examples/videodecode/video_demuxer.h
+++ b/projects/rocprofiler-systems/examples/videodecode/video_demuxer.h
@@ -574,15 +574,8 @@ private:
         // AVInputFormat
 #if USE_AVCODEC_GREATER_THAN_58_134
         // Check if the input stream is seekable for FFmpeg >= 58.134
-        if((av_fmt_input_ctx_->iformat->flags & AVFMT_NO_BYTE_SEEK) == 0 &&
-           av_fmt_input_ctx_->pb && av_fmt_input_ctx_->pb->seekable)
-        {
-            is_seekable_ = true;
-        }
-        else
-        {
-            is_seekable_ = false;
-        }
+        is_seekable_ = (av_fmt_input_ctx_->iformat->flags & AVFMT_NO_BYTE_SEEK) == 0 &&
+                       av_fmt_input_ctx_->pb && av_fmt_input_ctx_->pb->seekable;
 #else
         // Check if the input file allow seek functionality.
         is_seekable_ = av_fmt_input_ctx_->iformat->read_seek ||


### PR DESCRIPTION
## Motivation

To solve: SWDEV-566076 
FFmpeg versions >= 58.134 no longer expose read_seek and read_seek2 function pointers in AVInputFormat,
requiring alternative seek detection methods. This pull request updates the `VideoDemuxer` class to improve compatibility with newer versions of FFmpeg. The main change is how the code determines whether the input file is seekable, addressing differences in FFmpeg API versions.


## Technical Details

In `video_demuxer.h`, added a conditional check for `USE_AVCODEC_GREATER_THAN_58_134` to set `is_seekable_` to `true` for newer FFmpeg versions, since `read_seek` and `read_seek2` are no longer exposed in `AVFormatContext`. For older versions, the previous method of checking these fields remains in place. The conditional compilation
now assumes seek capability is available for newer FFmpeg versions.

## Test Plan
 There are no new tests. 

## Test Result

Tests passed on RHEL 10 and Ubuntu with MI350
RHEL 10 + MI350 test can be seen below :
<img width="522" height="336" alt="image" src="https://github.com/user-attachments/assets/79ab85ed-72bc-463e-b294-491345efdab0" />

Ubuntu 10 + MI350 test can be seen below :
<img width="587" height="480" alt="image" src="https://github.com/user-attachments/assets/36837265-489d-48db-8704-6682c2a39bb1" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
