### PR TITLE
SWDEV-541351 - fix use of uninitialized memory in AtomicsTest

### DIFF
--- a/projects/hip-tests/catch/unit/atomics/memory_order_common.hh
+++ b/projects/hip-tests/catch/unit/atomics/memory_order_common.hh
@@ -217,6 +217,8 @@ template <BuiltinAtomicOperation operation, int memory_order, int memory_scope> 
   SECTION("Global memory") {
     const auto alloc_type = LinearAllocs::hipMalloc;
     LinearAllocGuard<int> data(alloc_type, sizeof(int));
+
+    HIP_CHECK(hipMemset(data.ptr(), 0, sizeof(int)));
     TestKernel<operation, memory_order, memory_scope>
         <<<blocks, threads>>>(flag.ptr(), data.ptr(), ret.ptr());
   }
@@ -245,9 +247,13 @@ template <BuiltinAtomicOperation operation, int memory_order> void SystemTest() 
   LinearAllocGuard<int> flag(LinearAllocs::hipMallocManaged, sizeof(int));
   LinearAllocGuard<int> ret(LinearAllocs::hipMallocManaged, sizeof(int));
 
+  HIP_CHECK(hipMemset(flag.ptr(), 0, sizeof(int)));
+
   SECTION("Global memory") {
     const auto alloc_type = GENERATE(LinearAllocs::hipHostMalloc , LinearAllocs::hipMallocManaged);
     LinearAllocGuard<int> data(alloc_type, sizeof(int));
+
+    HIP_CHECK(hipMemset(data.ptr(), 0, sizeof(int)));
 
     if constexpr(operation == BuiltinAtomicOperation::kAnd) {
       flag.ptr()[0] = 1;
@@ -405,6 +411,9 @@ template <BuiltinAtomicOperation operation, int memory_scope> void Test() {
   LinearAllocGuard<int> counter1(LinearAllocs::hipMallocManaged, sizeof(int));
   LinearAllocGuard<int> counter2(LinearAllocs::hipMallocManaged, sizeof(int));
 
+  HIP_CHECK(hipMemset(counter1.ptr(), 0, sizeof(int)));
+  HIP_CHECK(hipMemset(counter2.ptr(), 0, sizeof(int)));
+
   SECTION("Global memory") {
     const auto alloc_type = LinearAllocs::hipMalloc;
     LinearAllocGuard<int> flag1(alloc_type, sizeof(int));
@@ -443,8 +452,10 @@ template <BuiltinAtomicOperation operation> void SystemTest() {
 
   LinearAllocGuard<int> counter1(LinearAllocs::hipMallocManaged, sizeof(int));
   LinearAllocGuard<int> counter2(LinearAllocs::hipMallocManaged, sizeof(int));
-
   std::vector<StreamGuard> streams;
+
+  HIP_CHECK(hipMemset(counter1.ptr(), 0, sizeof(int)));
+  HIP_CHECK(hipMemset(counter2.ptr(), 0, sizeof(int)));
 
   for (auto j = 0; j < 2; ++j) {
       streams.emplace_back(Streams::created);


### PR DESCRIPTION
## Motivation
There are multiple reports of the AtomicsTest binary failing randomly:

https://ontrack-internal.amd.com/browse/SWDEV-541351
https://ontrack-internal.amd.com/browse/SWDEV-567986
https://ontrack-internal.amd.com/browse/SWDEV-435667

## Technical Details
This PR addresses use of uninitialized memory which is one the reasons of the instability of these tests.

## Test Plan
On a MI250X, I added these lines to the LinearAllocGuard constructor:

```cpp
   case LinearAllocs::hipMalloc:
	HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&ptr_), size));
	for (int i = 0; i < size / sizeof(T); i++) {
	     ptr()[i] = rand(); // add some rubbish
	}
	break;
   case LinearAllocs::hipMallocManaged:
	HIP_CHECK(hipMallocManaged(reinterpret_cast<void**>(&ptr_), size, flags ? flags : 1u));
	host_ptr_ = ptr_;
	for (int i = 0; i < size / sizeof(T); i++) {
	     ptr()[i] = rand(); // add some rubbish
	}
	break;
```

to make apparent any problems related with the LinearAllocGuard initialization (this is not part of the PR, it is just to demonstrate that the tests do not initialize memory as they should)
The tests then hang here:

```
0.001 s: ACQUIRE/RELEASE
0.001 s: Unit___hip_atomic_compare_exchange_weak_Positive_Acquire_Release  
```

## Test Result
After adding the initialization of the associated LinearAllocGuard the tests are now pass even if we inject random data in the LinearAllocGuards.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
