### PR TITLE
[rocprofiler-systems] Fix dockerfile version check for 7.0 and update supported containers

### DIFF
--- a/projects/rocprofiler-systems/docker/Dockerfile.opensuse
+++ b/projects/rocprofiler-systems/docker/Dockerfile.opensuse
@@ -38,13 +38,16 @@ RUN ROCM_MAJOR=$(echo "${ROCM_VERSION}" | sed 's/\./ /g' | awk '{print $1}') && 
         OS_VERSION_MAJOR=$(echo "$OS_VERSION" | cut -d'.' -f1) && \
         OS_VERSION_MINOR=$(echo "$OS_VERSION" | cut -d'.' -f2) && \
         ROCM_PATCH=$(echo "${ROCM_VERSION}" | sed 's/\./ /g' | awk '{print $3}') && \
-        if [ -z "${ROCM_PATCH}" ] || [ "${ROCM_PATCH}" = "0" ]; then \
+        ROCM_URL_VERSION="${ROCM_VERSION}" && \
+        if [ -z "${ROCM_PATCH}" ]; then \
+            ROCM_PATCH=0; \
+        elif [ "${ROCM_PATCH}" = "0" ]; then \
             ROCM_PATCH=0 && \
-            ROCM_VERSION=$(echo "${ROCM_VERSION}" | sed 's/\.0$//') \
-        ; fi && \
+            ROCM_URL_VERSION="${ROCM_MAJOR}.${ROCM_MINOR}"; \
+        fi && \
         ROCM_VERSN=$(( ("${ROCM_MAJOR}"*10000)+("${ROCM_MINOR}"*100) + ("${ROCM_PATCH}"))) && \
         zypper --non-interactive addrepo https://download.opensuse.org/repositories/devel:languages:perl/15.6/devel:languages:perl.repo && \
-        zypper --non-interactive --no-gpg-checks install -y https://repo.radeon.com/amdgpu-install/${ROCM_VERSION}/sle/${OS_VERSION}/amdgpu-install-${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1.noarch.rpm && \
+        zypper --non-interactive --no-gpg-checks install -y https://repo.radeon.com/amdgpu-install/${ROCM_URL_VERSION}/sle/${OS_VERSION}/amdgpu-install-${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1.noarch.rpm && \
         zypper --non-interactive --gpg-auto-import-keys refresh && \
         zypper --non-interactive install -y rocm-dev rccl-devel libpciaccess0 && \
         zypper --non-interactive clean --all; \

--- a/projects/rocprofiler-systems/docker/Dockerfile.rhel
+++ b/projects/rocprofiler-systems/docker/Dockerfile.rhel
@@ -31,14 +31,17 @@ RUN ROCM_MAJOR=$(echo "${ROCM_VERSION}" | sed 's/\./ /g' | awk '{print $1}') && 
         OS_VERSION_MAJOR=$(echo "$OS_VERSION" | cut -d'.' -f1) && \
         RPM_TAG=".el${OS_VERSION_MAJOR}" && \
         ROCM_PATCH=$(echo "${ROCM_VERSION}" | sed 's/\./ /g' | awk '{print $3}') && \
-        if [ -z "${ROCM_PATCH}" ] || [ "${ROCM_PATCH}" = "0" ]; then \
+        ROCM_URL_VERSION="${ROCM_VERSION}" && \
+        if [ -z "${ROCM_PATCH}" ]; then \
+            ROCM_PATCH=0; \
+        elif [ "${ROCM_PATCH}" = "0" ]; then \
             ROCM_PATCH=0 && \
-            ROCM_VERSION=$(echo "${ROCM_VERSION}" | sed 's/\.0$//') \
-        ; fi && \
+            ROCM_URL_VERSION="${ROCM_MAJOR}.${ROCM_MINOR}"; \
+        fi && \
         ROCM_VERSN=$(( ("${ROCM_MAJOR}"*10000)+("${ROCM_MINOR}"*100) + ("${ROCM_PATCH}"))) && \
         if [ "${OS_VERSION_MAJOR}" -eq 8 ]; then PERL_REPO=powertools; else PERL_REPO=crb; fi && \
         dnf -y --enablerepo=${PERL_REPO} install perl-File-BaseDir && \
-        yum install -y https://repo.radeon.com/amdgpu-install/${ROCM_VERSION}/rhel/${OS_VERSION}/amdgpu-install-${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1${RPM_TAG}.noarch.rpm && \
+        yum install -y https://repo.radeon.com/amdgpu-install/${ROCM_URL_VERSION}/rhel/${OS_VERSION}/amdgpu-install-${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1${RPM_TAG}.noarch.rpm && \
         yum install -y rocm-dev && \
         yum clean all; \
     fi

--- a/projects/rocprofiler-systems/docker/Dockerfile.ubuntu
+++ b/projects/rocprofiler-systems/docker/Dockerfile.ubuntu
@@ -39,13 +39,16 @@ RUN ROCM_MAJOR=$(echo "${ROCM_VERSION}" | sed 's/\./ /g' | awk '{print $1}') && 
         OS_VERSION=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"') && \
         OS_CODENAME=$(grep '^VERSION_CODENAME=' /etc/os-release | cut -d'=' -f2) && \
         ROCM_PATCH=$(echo "${ROCM_VERSION}" | sed 's/\./ /g' | awk '{print $3}') && \
-        if [ -z "${ROCM_PATCH}" ] || [ "${ROCM_PATCH}" = "0" ]; then \
+        ROCM_URL_VERSION="${ROCM_VERSION}" && \
+        if [ -z "${ROCM_PATCH}" ]; then \
+            ROCM_PATCH=0; \
+        elif [ "${ROCM_PATCH}" = "0" ]; then \
             ROCM_PATCH=0 && \
-            ROCM_VERSION=$(echo "${ROCM_VERSION}" | sed 's/\.0$//') \
-        ; fi && \
+            ROCM_URL_VERSION="${ROCM_MAJOR}.${ROCM_MINOR}"; \
+        fi && \
         ROCM_VERSN=$(( ("${ROCM_MAJOR}"*10000)+("${ROCM_MINOR}"*100) + ("${ROCM_PATCH}"))) && \
         AMDGPU_DEB="amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb" && \
-        wget https://repo.radeon.com/amdgpu-install/${ROCM_VERSION}/ubuntu/${OS_CODENAME}/${AMDGPU_DEB} && \
+        wget https://repo.radeon.com/amdgpu-install/${ROCM_URL_VERSION}/ubuntu/${OS_CODENAME}/${AMDGPU_DEB} && \
         apt-get install -y ./${AMDGPU_DEB} && \
         apt-get update && \
         apt-get install -y rocm-dev rccl-dev libpciaccess0 ${EXTRA_PACKAGES} && \


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Existing code strips trailing 0 in ROCM_VERSION. If the user passes in 7.0, it transforms it into 7 and the URL code uses this, causing failure. New change prevents this.


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Added `ROCM_URL_VERSION` for readability
If minor version is 0 and patch version is not given, prevent the 0 from being stripped. 
If no patch version is given, force it to be 0. This is technically not needed, but makes it clear that 0 is being used.


## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Ran .`/build-docker.sh --distro rhel --versions 8.10  --rocm-versions 7.0 --python-versions 10 --retry 1`


## Test Result

<!-- Briefly summarize test outcomes. -->
Command now does not crash when trying to find URL.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
