### PR TITLE
rocr: Fix HSA_WAIT_ANY_DEBUG flag default to prevent CPU polling

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -261,7 +261,9 @@ class Flag {
     dev_mem_queue_buf_ = (var == "1") ? true : false;
 
     var = os::GetEnvVar("HSA_WAIT_ANY_DEBUG");
-    wait_any_ = (var == "1") ? true : false;
+    // FIX: Default to true (blocking/interrupt mode), allow disabling with "0"
+    // Previously defaulted to false, causing 100% CPU polling even with interrupt support
+    wait_any_ = (var == "0") ? false : true;
 
     /* hsa_signal_wait_relaxed abort timeout  */
     var = os::GetEnvVar("HSA_SIGNAL_WAIT_ABORT_TIMEOUT");


### PR DESCRIPTION
## Summary

Fix high CPU usage in HSA runtime's AsyncEventsLoop by correcting the default value of the `wait_any_` flag. When `HSA_WAIT_ANY_DEBUG` environment variable is not set, the runtime now defaults to blocking/interrupt mode instead of polling mode.

## Problem

The `wait_any_` flag in `flag.h` was defaulting to `false` when `HSA_WAIT_ANY_DEBUG` was not explicitly set. This caused the AsyncEventsLoop to always use polling mode (tight loop checking signals), consuming 80-100% CPU even when interrupt support was available and no work was being done.

## Root Cause

In `flag.h:266`, the flag initialization was:
```cpp
wait_any_ = (var == "1") ? true : false;  // Defaults to false
```

This meant that unless users explicitly set `HSA_WAIT_ANY_DEBUG=1`, the runtime would poll instead of block.

## Solution

Changed the default to true:
```cpp
wait_any_ = (var == "0") ? false : true;  // Defaults to true
```

Now the runtime uses blocking mode by default and only switches to polling if explicitly disabled with `HSA_WAIT_ANY_DEBUG=0`.

## Impact

**Before:**
- AsyncEventsLoop consumed 80-100% CPU in polling loop
- Thread spun continuously checking signal values
- Poor power efficiency and system responsiveness

**After:**
- AsyncEventsLoop blocks on `hsaKmtWaitOnMultipleEvents_Ext()`
- Thread sleeps in kernel waiting for GPU interrupts
- Near 0% CPU usage during idle periods
- Proper power efficiency

## Detailed Technical Explanation

### Signal Creation Path

When ROCprofiler (or any HSA application) creates signals, they go through `hsa_amd_signal_create()` in `hsa_ext_amd.cpp`:

```cpp
// hsa_ext_amd.cpp:543-573
bool enable_ipc = attributes & HSA_AMD_SIGNAL_IPC;
bool use_default =
    enable_ipc || (attributes & HSA_AMD_SIGNAL_AMD_GPU_ONLY) || (!core::g_use_interrupt_wait);

if ((!use_default) && (num_consumers != 0)) {
  IS_BAD_PTR(consumers);
  std::set<hsa_agent_t, AgentHandleCompare> consumer_set(consumers, consumers + num_consumers);
  if (consumer_set.size() != num_consumers) {
    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
  }
  use_default = true;
  for (const core::Agent* cpu_agent : core::Runtime::runtime_singleton_->cpu_agents()) {
    use_default &= (consumer_set.find(cpu_agent->public_handle()) == consumer_set.end());
  }
}

if (use_default) {
  ret = new core::DefaultSignal(initial_value, enable_ipc);  // NO INTERRUPTS
} else {
  ret = new core::InterruptSignal(initial_value);            // HAS INTERRUPTS
}
```

**Key Point:** When ROCprofiler creates signals with `num_consumers=0` (which is correct usage), they get **InterruptSignal** objects that HAVE KFD interrupt support, not DefaultSignal objects.

### AsyncEventsLoop Decision Point

The AsyncEventsLoop thread in `runtime.cpp` monitors all registered signals. The critical decision happens here:

```cpp
// runtime.cpp:1838-1856
if (core::Runtime::runtime_singleton_->flag().wait_any()) {
  // BLOCKING MODE - Uses KFD interrupts
  index = Signal::WaitMultiple(uint32_t(async_events_.Size()), 
                               &async_events_.signal_[0],
                               &async_events_.cond_[0], 
                               &async_events_.value_[0], 
                               uint64_t(-1),
                               HSA_WAIT_STATE_BLOCKED, 
                               value, 
                               false);
} else {
  // POLLING MODE - Tight loop burning CPU
  index = 1;
  wait_any = false;
  hsa_signals = reinterpret_cast<hsa_signal_handle*>(&async_events_.signal_[0]);
}
```

### The Bug: Polling Path Spins Forever

When `wait_any()` returns **false** (the bug), the code takes the polling path. Here's what happens:

```cpp
// runtime.cpp:1849-1856
// Set wait_any = false, skip the blocking call
index = 1;
wait_any = false;
hsa_signals = reinterpret_cast<hsa_signal_handle*>(&async_events_.signal_[0]);
```

Then it enters an inner loop that checks all signals:

```cpp
// runtime.cpp:1881-1930
while (!finish) {
  // If using WaitAny (blocking), finish after one iteration
  if (wait_any) {
    finish = true;  // Exit after one check
  }
  
  bool interrupt_wait = false;
  
  // Check all signals
  for (size_t i = index; i < async_events_.Size(); i++) {
    hsa_signal_handle sig(async_events_.signal_[i]);
    value[0] = atomic::Load(&sig->signal_.value, std::memory_order_relaxed);
    
    if (CheckSignalCondition(value[0], async_events_.cond_[i], async_events_.value_[i])) {
      // Signal is ready, process it
      if (!processEvent(i, value[0], wait_any)) {
        i--;
      }
      if (!wait_any) {
        finish = true;  // Exit after finding a ready signal
      }
    }
    
    // Try to prepare for KFD interrupt
    if (!finish && !polling) {
      interrupt_wait = PrepareInterrupt(i, init_age);
      if (!interrupt_wait) {
        // PrepareInterrupt failed, must poll
        polling = true;
        finish = false;  // Keep looping!
      }
    }
  }
  
  // If interrupt was prepared, block on KFD
  if (interrupt_wait) {
    WaitForInterrupt();  // Blocks in kernel
  }
  
  // BUG: If no signals were ready and PrepareInterrupt failed,
  // finish is still false, so the while loop repeats immediately!
  // This causes infinite CPU spinning.
}
```

**The Problem:** When using the polling path (`wait_any=false`):
1. No signals are ready (normal idle state)
2. `PrepareInterrupt()` can fail for various reasons
3. When it fails, `polling=true` and `finish=false`
4. The `while (!finish)` loop repeats immediately
5. This creates a tight spin loop checking all signals repeatedly
6. **Result: 100% CPU usage**

### Why InterruptSignals Don't Help

Even though the signals were created as **InterruptSignal** objects with KFD interrupt support, they're never used because:

1. The `wait_any_` flag defaults to **false**
2. AsyncEventsLoop chooses the **polling path**
3. The polling path calls `PrepareInterrupt()` but doesn't reliably use it
4. The thread spins in user space instead of blocking in kernel

### The Fix in Context

By changing the default to `wait_any_=true`, the code now takes the blocking path:

```cpp
// runtime.cpp:1844-1848 - Now the default behavior!
index = Signal::WaitMultiple(uint32_t(async_events_.Size()), 
                             &async_events_.signal_[0],
                             &async_events_.cond_[0], 
                             &async_events_.value_[0], 
                             uint64_t(-1),
                             HSA_WAIT_STATE_BLOCKED,  // Key: BLOCKED state
                             value, 
                             false);
```

This eventually calls down to:

```cpp
// interrupt_signal.cpp - WaitMultiple implementation
HSAKMT_CALL(hsaKmtWaitOnMultipleEvents_Ext(&hsa_events[0], unique_evts, false, wait_ms, &event_age[0]));
```

Which **blocks the thread in the kernel** waiting for GPU interrupts from any of the InterruptSignal events.

### Signal Type Check

The InterruptSignal class provides the KFD event handle:

```cpp
// interrupt_signal.cpp
HsaEvent* InterruptSignal::EopEvent() {
  return signal_.event;  // Returns KFD event handle
}

// vs. DefaultSignal:
HsaEvent* DefaultSignal::EopEvent() {
  return NULL;  // No interrupt support
}
```

`Signal::WaitMultiple()` uses this to build the event list for `hsaKmtWaitOnMultipleEvents_Ext()`.

## Testing

Verified with rocprofiler-sdk counter collection sample:
- Before fix: 82-100% CPU usage during idle
- After fix: Near 0% CPU usage during idle
- Confirmed proper blocking on `hsaKmtWaitOnMultipleEvents_Ext()`
- Both sync and async modes working correctly

## Files Changed

- `projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h` (1 line changed + 2 comment lines)