### PR TITLE
[rocprofiler-sdk] Improve counter descriptions in rocprofiler-sdk counter_defs.yaml

### DIFF
--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/counter_defs.yaml
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/counter_defs.yaml
@@ -2,9 +2,7 @@ rocprofiler-sdk:
   counters-schema-version: 1
   counters:
   - name: ALUStalledByLDS
-    description: 'The percentage of GPUTime ALU units are stalled by the LDS input queue being full or the output queue being
-      not ready. If there are LDS bank conflicts, reduce them. Otherwise, try reducing the number of LDS accesses if possible.
-      Value range: 0% (optimal) to 100% (bad).'
+    description: 'The percentage of GPUTime ALU units are stalled by the LDS input queue being full or the output queue being not ready. If there are LDS bank conflicts, reduce them. Otherwise, try reducing the number of LDS accesses if possible. Value range: 0% (optimal) to 100% (bad).'
     properties: []
     definitions:
     - architectures:
@@ -23,21 +21,21 @@ rocprofiler-sdk:
       - gfx90a
       expression: 400*reduce(SQ_WAIT_INST_LDS,sum)/reduce(SQ_WAVES,sum)/reduce(GRBM_GUI_ACTIVE,max)
   - name: AggSysCycles
-    description: 'Unit: cycles'
+    description: 'Aggregate system cycles across all compute units. Calculated as the maximum GPU active cycles (GRBM_GUI_ACTIVE) multiplied by the number of compute units (CU_NUM). This represents the total GPU compute capacity in cycles. Unit: cycles. Higher values indicate more total computational work capacity utilized.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: reduce(GRBM_GUI_ACTIVE,max)*CU_NUM
   - name: AvgNumActiveThreads
-    description: 'Unit: percent'
+    description: 'Average number of active threads per VALU instruction. Calculated as thread-cycles (SQ_THREAD_CYCLES_VALU) divided by active VALU instruction cycles (SQ_ACTIVE_INST_VALU). This metric helps identify thread divergence within wavefronts. Unit: threads. Value range: 0-64 threads. Higher values (closer to 64) indicate better thread utilization with less divergence. Lower values suggest threads are taking different execution paths or workgroups are not multiples of 64.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: reduce(SQ_THREAD_CYCLES_VALU,sum)/reduce(SQ_ACTIVE_INST_VALU,sum)
   - name: CPC_CPC_STAT_BUSY
-    description: CPC Busy.
+    description: 'Command Processor Compute (CPC) is busy processing commands. The CPC is a micro-controller that decodes fetched commands and passes kernel launch information to workgroup processors for scheduling. Unit: cycles. Higher values indicate the CPC is actively processing work.'
     properties: []
     definitions:
     - architectures:
@@ -50,7 +48,7 @@ rocprofiler-sdk:
       block: CPC
       event: 25
   - name: CPC_CPC_STAT_IDLE
-    description: CPC Idle.
+    description: 'Command Processor Compute (CPC) is idle with no commands to process. The CPC handles command packet processing and kernel scheduling. Unit: cycles. Higher values may indicate insufficient work being submitted to the GPU or scheduling inefficiencies.'
     properties: []
     definitions:
     - architectures:
@@ -63,7 +61,7 @@ rocprofiler-sdk:
       block: CPC
       event: 26
   - name: CPC_CPC_STAT_STALL
-    description: CPC Stalled.
+    description: 'Command Processor Compute (CPC) is stalled waiting for resources or dependencies. The CPC may stall due to back-pressure from downstream units or resource unavailability. Unit: cycles. Lower values are better. High stall cycles indicate scheduling bottlenecks.'
     properties: []
     definitions:
     - architectures:
@@ -76,7 +74,7 @@ rocprofiler-sdk:
       block: CPC
       event: 27
   - name: CPC_CPC_TCIU_BUSY
-    description: CPC TCIU interface Busy.
+    description: 'Command Processor Compute (CPC) Texture Cache Interface Unit (TCIU) is busy handling memory requests. The TCIU is the interface between the command processor and the memory system. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -89,7 +87,7 @@ rocprofiler-sdk:
       block: CPC
       event: 28
   - name: CPC_CPC_TCIU_IDLE
-    description: CPC TCIU interface Idle.
+    description: 'Command Processor Compute (CPC) Texture Cache Interface Unit (TCIU) is idle with no memory requests to process. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -102,7 +100,7 @@ rocprofiler-sdk:
       block: CPC
       event: 29
   - name: CPC_CPC_UTCL2IU_BUSY
-    description: CPC UTCL2 interface Busy.
+    description: 'Command Processor Compute (CPC) Unified Translation Cache Level 2 Interface Unit is busy handling address translation requests. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -115,7 +113,7 @@ rocprofiler-sdk:
       block: CPC
       event: 30
   - name: CPC_CPC_UTCL2IU_IDLE
-    description: CPC UTCL2 interface Idle.
+    description: 'Command Processor Compute (CPC) Unified Translation Cache Level 2 Interface Unit is idle with no address translation requests. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -141,7 +139,7 @@ rocprofiler-sdk:
       block: CPC
       event: 32
   - name: CPC_ME1_BUSY_FOR_PACKET_DECODE
-    description: Me1 busy for packet decode.
+    description: 'Command Processor Micro Engine 1 (ME1) is busy decoding command packets. ME1 runs packet-processing firmware on the CPC. Unit: cycles. Higher values indicate active command processing.'
     properties: []
     definitions:
     - architectures:
@@ -154,7 +152,7 @@ rocprofiler-sdk:
       block: CPC
       event: 13
   - name: CPC_ME1_DC0_SPI_BUSY
-    description: CPC Me1 Processor Busy.
+    description: 'Command Processor Micro Engine 1 (ME1) processor is busy sending work to the Shader Processor Input (SPI). The SPI receives work and forwards it to compute units. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -180,7 +178,7 @@ rocprofiler-sdk:
       block: CPC
       event: 24
   - name: CPC_ALWAYS_COUNT
-    description: Always Count.
+    description: 'Always counting register used for calculating elapsed time or cycle counts. This counter continuously increments and can be used as a baseline for timing measurements. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -196,7 +194,7 @@ rocprofiler-sdk:
       block: CPC
       event: 3
   - name: CPC_ADC_DISPATCH_ALLOC_DONE
-    description: ADC dispatch allocation done.
+    description: 'Automated Dispatch Controller (ADC) has completed dispatch allocation. Tracks when dispatch resources have been successfully allocated for kernel launches. Unit: count.'
     properties: []
     definitions:
     - architectures:
@@ -204,7 +202,7 @@ rocprofiler-sdk:
       block: CPC
       event: 4
   - name: CPC_ADC_VALID_CHUNK_END
-    description: ADC cralwer valid chunk end at multi-xcc mode.
+    description: 'Automated Dispatch Controller (ADC) crawler has reached the end of a valid chunk in multi-XCC (accelerator compute complex) mode. Unit: count.'
     properties: []
     definitions:
     - architectures:
@@ -212,7 +210,7 @@ rocprofiler-sdk:
       block: CPC
       event: 9
   - name: CPC_SYNC_FIFO_FULL_LEVEL
-    description: SYNC FIFO full last cycles.
+    description: 'Synchronization FIFO reached full capacity and remained full. Indicates back-pressure in the command processor synchronization pipeline. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -220,7 +218,7 @@ rocprofiler-sdk:
       block: CPC
       event: 43
   - name: CPC_SYNC_FIFO_FULL
-    description: SYNC FIFO full times.
+    description: 'Number of times the synchronization FIFO became completely full. High values indicate synchronization bottlenecks. Unit: count. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -228,7 +226,7 @@ rocprofiler-sdk:
       block: CPC
       event: 44
   - name: CPC_GD_BUSY
-    description: ADC busy.
+    description: 'Graphics Data (GD) unit of the command processor is busy. The GD unit handles graphics-related command processing. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -236,7 +234,7 @@ rocprofiler-sdk:
       block: CPC
       event: 61
   - name: CPC_TG_SEND
-    description: ADC thread group send.
+    description: 'Thread Group (TG) send operations from the command processor. Counts dispatches sent to compute units. Unit: count.'
     properties: []
     definitions:
     - architectures:
@@ -244,7 +242,7 @@ rocprofiler-sdk:
       block: CPC
       event: 62
   - name: CPC_WALK_NEXT_CHUNK
-    description: ADC walking next valid chunk at multi-xcc mode.
+    description: 'Command processor walker advanced to the next chunk of commands. Tracks progression through command buffer processing. Unit: count.'
     properties: []
     definitions:
     - architectures:
@@ -252,7 +250,7 @@ rocprofiler-sdk:
       block: CPC
       event: 63
   - name: CPC_STALLED_BY_SE0_SPI
-    description: ADC csdata stalled by SE0SPI.
+    description: 'Command Processor is stalled by Shader Engine 0 Shader Processor Input (SPI). Indicates back-pressure from SE0 preventing command dispatch. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -260,7 +258,7 @@ rocprofiler-sdk:
       block: CPC
       event: 64
   - name: CPC_STALLED_BY_SE1_SPI
-    description: ADC csdata stalled by SE1SPI.
+    description: 'Command Processor is stalled by Shader Engine 1 Shader Processor Input (SPI). Indicates back-pressure from SE1 preventing command dispatch. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -268,7 +266,7 @@ rocprofiler-sdk:
       block: CPC
       event: 65
   - name: CPC_STALLED_BY_SE2_SPI
-    description: ADC csdata stalled by SE2SPI.
+    description: 'Command Processor is stalled by Shader Engine 2 Shader Processor Input (SPI). Indicates back-pressure from SE2 preventing command dispatch. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -276,7 +274,7 @@ rocprofiler-sdk:
       block: CPC
       event: 66
   - name: CPC_STALLED_BY_SE3_SPI
-    description: ADC csdata stalled by SE3SPI.
+    description: 'Command Processor is stalled by Shader Engine 3 Shader Processor Input (SPI). Indicates back-pressure from SE3 preventing command dispatch. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -292,7 +290,7 @@ rocprofiler-sdk:
       block: CPC
       event: 68
   - name: CPC_SYNC_WRREQ_FIFO_BUSY
-    description: CPC Sync Counter Request Fifo is not empty.
+    description: 'Synchronization write request FIFO is busy processing write synchronization requests. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -308,7 +306,7 @@ rocprofiler-sdk:
       block: CPC
       event: 70
   - name: CPC_CANE_STALL
-    description: CPC Sync counter sending is stalled by CANE.
+    description: 'Command processor CANE (Command Arbiter and Network Engine) is stalled. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -329,7 +327,7 @@ rocprofiler-sdk:
       block: CPF
       event: 20
   - name: CPF_CPF_STAT_BUSY
-    description: CPF Busy.
+    description: 'Command Processor Fetcher (CPF) is busy fetching commands from memory. The CPF reads commands from HSA queues and hands them to the CPC for processing. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -342,7 +340,7 @@ rocprofiler-sdk:
       block: CPF
       event: 23
   - name: CPF_CPF_STAT_IDLE
-    description: CPF Idle.
+    description: 'Command Processor Fetcher (CPF) is idle with no commands to fetch from memory. Unit: cycles. High idle time may indicate insufficient work submission.'
     properties: []
     definitions:
     - architectures:
@@ -355,7 +353,7 @@ rocprofiler-sdk:
       block: CPF
       event: 24
   - name: CPF_CPF_STAT_STALL
-    description: CPF Stalled.
+    description: 'Command Processor Fetcher (CPF) is stalled waiting for resources or memory access. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -368,7 +366,7 @@ rocprofiler-sdk:
       block: CPF
       event: 25
   - name: CPF_CPF_TCIU_BUSY
-    description: CPF TCIU interface Busy.
+    description: 'Command Processor Fetcher (CPF) Texture Cache Interface Unit is busy handling memory requests for command fetching. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -381,7 +379,7 @@ rocprofiler-sdk:
       block: CPF
       event: 26
   - name: CPF_CPF_TCIU_IDLE
-    description: CPF TCIU interface Idle.
+    description: 'Command Processor Fetcher (CPF) Texture Cache Interface Unit is idle with no memory requests. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -394,7 +392,7 @@ rocprofiler-sdk:
       block: CPF
       event: 27
   - name: CPF_CPF_TCIU_STALL
-    description: CPF TCIU interface Stalled waiting on Free, Tags.
+    description: 'Command Processor Fetcher (CPF) Texture Cache Interface Unit is stalled waiting for memory responses. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -407,7 +405,7 @@ rocprofiler-sdk:
       block: CPF
       event: 28
   - name: CP_UTIL
-    description: Percentage of the GRBM_GUI_ACTIVE time that any of the Command Processor (CPG/CPC/CPF) blocks are busy
+    description: 'Command Processor (CP) utilization percentage. Combines CPC and CPF activity. Indicates how busy the command processor is with work dispatch. Unit: percent. Value range: 0% (idle) to 100% (fully utilized).'
     properties: []
     definitions:
     - architectures:
@@ -418,7 +416,7 @@ rocprofiler-sdk:
       - gfx1032
       expression: 100*reduce(GRBM_CP_BUSY,max)/reduce(GRBM_GUI_ACTIVE,max)
   - name: CU_NUM
-    description: CU_NUM
+    description: 'Number of Compute Units (CUs) available on the GPU. Each CU contains vector ALUs, scalar ALU, local data share (LDS), and registers. This is a hardware configuration constant that varies by GPU model (e.g., MI250X has 110 CUs per GCD). Unit: count.'
     properties: []
     definitions:
     - architectures:
@@ -447,7 +445,7 @@ rocprofiler-sdk:
       - gfx950
       expression: simd_count/simd_per_cu
   - name: SIMD_NUM
-    description: SIMD Number
+    description: 'Number of SIMD (Single Instruction Multiple Data) units per Compute Unit. Each CU typically contains 4 SIMD units (also called Execution Units) for parallel vector processing. Each SIMD can manage up to 10 wavefronts on CDNA architectures. This is a hardware configuration constant. Unit: count.'
     properties: []
     definitions:
     - architectures:
@@ -476,14 +474,14 @@ rocprofiler-sdk:
       - gfx1201
       expression: simd_count
   - name: CpUtil
-    description: 'Unit: percent'
+    description: 'Command Processor utilization percentage. Indicates how busy the command processor is with dispatching and managing GPU work. Unit: percent. Value range: 0% (idle) to 100% (fully utilized).'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*reduce(GRBM_CP_BUSY,max)/reduce(GRBM_GUI_ACTIVE,max)
   - name: EA_UTIL
-    description: Percentage of the GRBM_GUI_ACTIVE time that the Efficiency Arbiter (EA) block is busy.
+    description: 'Efficiency Arbiter (EA) utilization percentage. The EA manages traffic between the GPU and Infinity Fabric/memory. Unit: percent. Value range: 0% (idle) to 100% (saturated). High values may indicate memory bandwidth bottlenecks.'
     properties: []
     definitions:
     - architectures:
@@ -494,85 +492,84 @@ rocprofiler-sdk:
       - gfx1032
       expression: 100*reduce(GRBM_EA_BUSY,max)/reduce(GRBM_GUI_ACTIVE,max)
   - name: EaAtomicLatency
-    description: 'Unit: cycles'
+    description: 'Efficiency Arbiter (EA) atomic operation latency. The EA is the memory controller interface managing traffic to Infinity Fabric and DRAM. Measures average cycles for atomic memory operations. Unit: cycles. Lower values indicate better performance.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: TCC_EA_ATOMIC_LEVEL_sum/TCC_EA_ATOMIC_sum
   - name: EaRdDramStallRate
-    description: 'Unit: percent'
+    description: 'Efficiency Arbiter (EA) read request stall rate when accessing DRAM. Percentage of time read requests to DRAM are stalled due to memory controller back-pressure or bandwidth saturation. Unit: percent. Lower values are better (0% is optimal).'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*TCC_EA_RDREQ_DRAM_CREDIT_STALL_sum/TCC_BUSY_sum
   - name: EaRdGmiStallRate
-    description: 'Unit: percent'
+    description: 'Efficiency Arbiter (EA) read request stall rate when accessing Global Memory Interface (GMI). GMI provides socket-to-socket communication via Infinity Fabric xGMI links. Unit: percent. Lower values are better (0% is optimal).'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*TCC_EA_RDREQ_GMI_CREDIT_STALL_sum/TCC_BUSY_sum
   - name: EaRdIoStallRate
-    description: 'Unit: percent'
+    description: 'Efficiency Arbiter (EA) read request stall rate when accessing IO devices. Measures stalls on reads to IO-connected devices. Unit: percent. Lower values are better (0% is optimal).'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*TCC_EA_RDREQ_IO_CREDIT_STALL_sum/TCC_BUSY_sum
   - name: EaRdLatency
-    description: 'Unit: cycles'
+    description: 'Efficiency Arbiter (EA) read latency to memory. Average cycles for read operations through the EA to Infinity Fabric and memory subsystem. Unit: cycles. Lower values indicate better memory access performance.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: TCC_EA_RDREQ_LEVEL_sum/TCC_EA_RDREQ_sum
   - name: EaUtil
-    description: 'Unit: percent'
+    description: 'Efficiency Arbiter (EA) utilization percentage. Indicates how busy the memory controller interface is. Unit: percent. Value range: 0% (idle) to 100% (saturated).'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*reduce(GRBM_EA_BUSY,max)/reduce(GRBM_GUI_ACTIVE,max)
   - name: EaWrDramStallRate
-    description: 'Unit: percent'
+    description: 'Efficiency Arbiter (EA) write request stall rate when accessing DRAM. Percentage of time write requests to DRAM are stalled. Unit: percent. Lower values are better (0% is optimal).'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*TCC_EA_WRREQ_DRAM_CREDIT_STALL_sum/TCC_BUSY_sum
   - name: EaWrGmiStallRate
-    description: 'Unit: percent'
+    description: 'Efficiency Arbiter (EA) write request stall rate when accessing Global Memory Interface (GMI). Unit: percent. Lower values are better (0% is optimal).'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*TCC_EA_WRREQ_GMI_CREDIT_STALL_sum/TCC_BUSY_sum
   - name: EaWrIoStallRate
-    description: 'Unit: percent'
+    description: 'Efficiency Arbiter (EA) write request stall rate when accessing IO devices. Unit: percent. Lower values are better (0% is optimal).'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*TCC_EA_WRREQ_IO_CREDIT_STALL_sum/TCC_BUSY_sum
   - name: EaWrLatency
-    description: 'Unit: cycles'
+    description: 'Efficiency Arbiter (EA) write latency to memory. Average cycles for write operations through the EA to Infinity Fabric and memory. Unit: cycles. Lower values indicate better performance.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: TCC_EA_WRREQ_LEVEL_sum/TCC_EA_WRREQ_sum
   - name: EaWrStarveRate
-    description: 'Unit: percent'
+    description: 'Efficiency Arbiter (EA) write request starvation rate. Percentage of time write requests are starved due to read request prioritization or resource contention. Unit: percent. Lower values are better (0% is optimal).'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*TCC_TOO_MANY_EA_WRREQS_STALL_sum/TCC_BUSY_sum
   - name: FETCH_SIZE
-    description: The total kilobytes fetched from the video memory. This is measured with all extra fetches and any cache
-      or memory effects taken into account.
+    description: The total kilobytes fetched from the video memory. This is measured with all extra fetches and any cache or memory effects taken into account.
     properties: []
     definitions:
     - architectures:
@@ -622,8 +619,7 @@ rocprofiler-sdk:
       - gfx950
       expression: (WRITE_SIZE*1024+TCC_BUBBLE_sum*128+(TCC_BUBBLE_sum-TCC_EA0_RDREQ_sum)*64)/reduce(GRBM_GUI_ACTIVE,max)
   - name: FetchSize
-    description: The total kilobytes fetched from the video memory. This is measured with all extra fetches and any cache
-      or memory effects taken into account.
+    description: The total kilobytes fetched from the video memory. This is measured with all extra fetches and any cache or memory effects taken into account.
     properties: []
     definitions:
     - architectures:
@@ -641,8 +637,7 @@ rocprofiler-sdk:
       - gfx1201
       expression: FETCH_SIZE
   - name: FlatLDSInsts
-    description: The average number of FLAT instructions that read or write to LDS executed per work item (affected by flow
-      control).
+    description: The average number of FLAT instructions that read or write to LDS executed per work item (affected by flow control).
     properties: []
     definitions:
     - architectures:
@@ -653,8 +648,7 @@ rocprofiler-sdk:
       - gfx90a
       expression: reduce(SQ_INSTS_FLAT_LDS_ONLY,sum)/reduce(SQ_WAVES,sum)
   - name: FlatVMemInsts
-    description: The average number of FLAT instructions that read from or write to the video memory executed per work item
-      (affected by flow control). Includes FLAT instructions that read from or write to scratch.
+    description: The average number of FLAT instructions that read from or write to the video memory executed per work item (affected by flow control). Includes FLAT instructions that read from or write to scratch.
     properties: []
     definitions:
     - architectures:
@@ -881,8 +875,7 @@ rocprofiler-sdk:
       - gfx1151
       expression: reduce(GL2C_EA_RDREQ_96B,sum)
   - name: GL2C_EA_WRREQ
-    description: Number of transactions (all sizes) going over the GL2C_EA_WRREQ interface for all clients. This does not
-      include probe commands.
+    description: Number of transactions (all sizes) going over the GL2C_EA_WRREQ interface for all clients. This does not include probe commands.
     properties: []
     definitions:
     - architectures:
@@ -892,8 +885,7 @@ rocprofiler-sdk:
       block: GL2C
       event: 108
   - name: GL2C_EA_WRREQ_sum
-    description: Number of transactions (either 32-byte or 64-byte) going over the GL2C_EA_WRREQ interface. Sum over GL2C
-      instances.
+    description: Number of transactions (either 32-byte or 64-byte) going over the GL2C_EA_WRREQ interface. Sum over GL2C instances.
     properties: []
     definitions:
     - architectures:
@@ -902,7 +894,7 @@ rocprofiler-sdk:
       - gfx1201
       expression: reduce(GL2C_EA_WRREQ,sum)
   - name: GL2C_EA_WRREQ_STALL
-    description: Number of cycles a write request was stalled.
+    description: 'GL2 Cache Controller (GL2C) write requests to Efficiency Arbiter are stalled. Indicates back-pressure from the memory subsystem preventing L2 cache writebacks. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -945,8 +937,7 @@ rocprofiler-sdk:
       block: GL2C
       event: 114
   - name: GL2C_EA_WRREQ_64B_sum
-    description: Number of 64-byte transactions going (64-byte write or CMPSWAP) over the GL2C_EA_wrreq interface. Sum over
-      GL2C instances.
+    description: Number of 64-byte transactions going (64-byte write or CMPSWAP) over the GL2C_EA_wrreq interface. Sum over GL2C instances.
     properties: []
     definitions:
     - architectures:
@@ -990,7 +981,7 @@ rocprofiler-sdk:
       block: GL2C
       event: 41
   - name: GL2C_HIT_sum
-    description: Number of cache hits. Sum over GL2C instances.
+    description: 'Sum of GL2 (L2) cache hits across all cache channels. GL2 is the coherence point shared by all CUs. Uses hit-on-miss counting. Unit: count. Higher hit counts indicate better cache utilization.'
     properties: []
     definitions:
     - architectures:
@@ -1045,8 +1036,7 @@ rocprofiler-sdk:
       - gfx1151
       expression: reduce(GL2C_MC_RDREQ,sum)
   - name: GL2C_MC_WRREQ
-    description: Number of transactions (either 32-byte or 64-byte) going over the GL2C_EA_wrreq interface. Atomics may travel
-      over the same interface and are generally classified as write requests. This does not include probe commands
+    description: Number of transactions (either 32-byte or 64-byte) going over the GL2C_EA_wrreq interface. Atomics may travel over the same interface and are generally classified as write requests. This does not include probe commands
     properties: []
     definitions:
     - architectures:
@@ -1064,7 +1054,7 @@ rocprofiler-sdk:
       block: GL2C
       event: 83
   - name: GL2C_MC_WRREQ_STALL
-    description: Number of cycles a write request was stalled.
+    description: 'GL2 Cache Controller write requests to Memory Controller are stalled. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -1088,8 +1078,7 @@ rocprofiler-sdk:
       block: GL2C
       event: 122
   - name: GL2C_MC_WRREQ_sum
-    description: Number of transactions (either 32-byte or 64-byte) going over the GL2C_MC_wrreq interface. Sum over GL2C
-      instances.
+    description: Number of transactions (either 32-byte or 64-byte) going over the GL2C_MC_wrreq interface. Sum over GL2C instances.
     properties: []
     definitions:
     - architectures:
@@ -1130,7 +1119,7 @@ rocprofiler-sdk:
       block: GL2C
       event: 42
   - name: GL2C_MISS_sum
-    description: Number of cache misses. Sum over GL2C instances.
+    description: 'Sum of GL2 (L2) cache misses across all cache channels. Misses require fetching from Infinity Fabric and memory. Unit: count. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -1170,7 +1159,7 @@ rocprofiler-sdk:
       - gfx1201
       expression: reduce(GL2C_MC_WRREQ_STALL,max)
   - name: GPUBusy
-    description: The percentage of time GPU was busy.
+    description: 'Percentage of time the GPU was busy executing work. Calculated as 100 * GRBM_GUI_ACTIVE / GRBM_COUNT, representing active GPU cycles divided by total GPU clock cycles. Unit: percent. Value range: 0% (idle) to 100% (fully utilized). Higher values indicate better GPU utilization.'
     properties: []
     definitions:
     - architectures:
@@ -1254,7 +1243,7 @@ rocprofiler-sdk:
       block: GRBM
       event: 0
   - name: GRBM_CPC_BUSY
-    description: The Command Processor Compute (CPC) is busy.
+    description: 'Graphics Register Bus Manager (GRBM) indicates Command Processor Compute (CPC) block is busy. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -1267,7 +1256,7 @@ rocprofiler-sdk:
       block: GRBM
       event: 30
   - name: GRBM_CPF_BUSY
-    description: The Command Processor Fetchers (CPF) is busy.
+    description: 'Graphics Register Bus Manager (GRBM) indicates Command Processor Fetcher (CPF) block is busy. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -1298,7 +1287,7 @@ rocprofiler-sdk:
       block: GRBM
       event: 3
   - name: GRBM_EA_BUSY
-    description: The Efficiency Arbiter (EA) block is busy.
+    description: 'Graphics Register Bus Manager (GRBM) indicates the Efficiency Arbiter (EA) memory controller interface is busy. The EA manages traffic to Infinity Fabric and memory. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -1316,7 +1305,7 @@ rocprofiler-sdk:
       block: GRBM
       event: 35
   - name: GRBM_GDS_BUSY
-    description: The Global Data Share (GDS) is busy.
+    description: 'Graphics Register Bus Manager (GRBM) indicates the Global Data Share (GDS) is busy. GDS is a small memory shared across all CUs for global atomics and synchronization. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -1328,7 +1317,7 @@ rocprofiler-sdk:
       block: GRBM
       event: 25
   - name: GRBM_GL2CC_BUSY
-    description: The GL2CC block is busy.
+    description: 'Graphics Register Bus Manager (GRBM) indicates the GL2 Cache Controller is busy. GL2CC manages the L2 cache (TCC) operations. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -1340,7 +1329,7 @@ rocprofiler-sdk:
       block: GRBM
       event: 40
   - name: GRBM_GUI_ACTIVE
-    description: The GUI is Active
+    description: 'Graphics Register Bus Manager (GRBM) Graphics User Interface is active. Indicates when the GPU has active work being processed. This is a fundamental counter used in many derived metrics. Unit: cycles. Higher values indicate more GPU activity.'
     properties: []
     definitions:
     - architectures:
@@ -1432,14 +1421,14 @@ rocprofiler-sdk:
       block: GRBM
       event: 34
   - name: GpuUtil
-    description: 'Unit: percent'
+    description: 'GPU utilization percentage, indicating how effectively the GPU is being used for computation. Similar to GPUBusy but may use different calculation methodology. Unit: percent. Value range: 0% (idle) to 100% (fully utilized). Higher values are generally better, but very high utilization may indicate saturation.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*reduce(GRBM_GUI_ACTIVE,max)/reduce(GRBM_COUNT,max)
   - name: InstrFetchLatency
-    description: 'Unit: cycles'
+    description: 'Instruction fetch latency from instruction cache. Measures average cycles to fetch instructions into the pipeline. GPU automatically fetches instructions from memory into on-chip instruction caches (32KB on CDNA2, 64KB on CDNA3). Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -1450,15 +1439,14 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(accumulate(SQ_IFETCH_LEVEL, HIGH_RES),sum)/reduce(SQ_IFETCH,sum)
   - name: L1iCacheHitRate
-    description: 'Unit: percent'
+    description: 'L1 instruction cache hit rate. Percentage of instruction fetch requests that hit in the L1 instruction cache versus requiring fetch from L2 or memory. Unit: percent. Value range: 0% to 100%. Higher values (closer to 100%) indicate better instruction cache utilization.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*reduce(SQC_ICACHE_HITS,sum)/reduce(SQC_ICACHE_REQ,sum)
   - name: L2CacheHit
-    description: 'The percentage of fetch, write, atomic, and other instructions that hit the data in L2 cache. Value range:
-      0% (no hit) to 100% (optimal).'
+    description: 'The percentage of fetch, write, atomic, and other instructions that hit the data in L2 cache. Value range: 0% (no hit) to 100% (optimal).'
     properties: []
     definitions:
     - architectures:
@@ -1485,7 +1473,7 @@ rocprofiler-sdk:
       - gfx1201
       expression: 100*reduce(GL2C_HIT,sum)/(reduce(GL2C_HIT,sum)+reduce(GL2C_MISS,sum))
   - name: L2CacheTagRamStallRate
-    description: 'Unit: percent'
+    description: 'L2 cache tag RAM stall rate. Percentage of time L2 cache operations are stalled waiting for tag RAM access. Tag RAM stores cache line tags for hit/miss determination. Unit: percent. Lower values are better (0% is optimal).'
     properties: []
     definitions:
     - architectures:
@@ -1521,8 +1509,7 @@ rocprofiler-sdk:
       - gfx950
       expression: 100*reduce(SQ_LDS_BANK_CONFLICT,sum)/reduce(GRBM_GUI_ACTIVE,max)/CU_NUM
   - name: LDSInsts
-    description: The average number of LDS read or LDS write instructions executed per work item (affected by flow control).  Excludes
-      FLAT instructions that read from or write to LDS.
+    description: The average number of LDS read or LDS write instructions executed per work item (affected by flow control).  Excludes FLAT instructions that read from or write to LDS.
     properties: []
     definitions:
     - architectures:
@@ -1533,7 +1520,7 @@ rocprofiler-sdk:
       - gfx90a
       expression: (reduce(SQ_INSTS_LDS,sum)-reduce(SQ_INSTS_FLAT_LDS_ONLY,sum))/reduce(SQ_WAVES,sum)
   - name: LdsBankConflict
-    description: 'Unit: conflicts/access'
+    description: 'Rate of bank conflicts in Local Data Share (LDS) memory accesses. Bank conflicts occur when multiple threads in a wavefront access different addresses that map to the same LDS bank (32 banks, 4B wide each), causing serialization. Unit: conflicts per access. Value range: 0 (optimal - no conflicts) to higher values (poor). Maximum conflict rate is ~97%. Reduce conflicts by avoiding stride patterns that are multiples of 32 or by adding padding to data structures.'
     properties: []
     definitions:
     - architectures:
@@ -1542,7 +1529,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(SQ_LDS_BANK_CONFLICT,sum)/(reduce(SQ_LDS_IDX_ACTIVE,sum)-reduce(SQ_LDS_BANK_CONFLICT,sum))
   - name: LdsLatency
-    description: 'Unit: cycles'
+    description: 'Local Data Share (LDS) access latency. Average cycles to access LDS memory. LDS is low-latency on-chip RAM in each compute unit, typically an order of magnitude faster than global memory. Unit: cycles. Lower values indicate better performance. Bank conflicts increase latency.'
     properties: []
     definitions:
     - architectures:
@@ -1562,14 +1549,14 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(accumulate(SQ_INST_LEVEL_LDS, HIGH_RES),sum)/reduce(SQ_INSTS_LDS,sum)
   - name: LdsPipeIssueUtil
-    description: 'Unit: percent'
+    description: 'LDS pipeline issue utilization. Percentage of cycles the LDS instruction issue pipeline is actively issuing LDS operations. Unit: percent. Value range: 0% (idle) to 100% (fully utilized). Higher values indicate heavy LDS usage.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 400*reduce(SQ_ACTIVE_INST_LDS,sum)/(reduce(GRBM_GUI_ACTIVE,max)*CU_NUM*2)
   - name: LdsUtil
-    description: 'Unit: percent'
+    description: "Local Data Share (LDS) utilization percentage. Indicates how effectively LDS bandwidth is being used. LDS provides 128B/clock throughput (32 banks \xD7 4B). Unit: percent. Value range: 0% to 100%."
     properties: []
     definitions:
     - architectures:
@@ -1611,7 +1598,7 @@ rocprofiler-sdk:
       - gfx950
       expression: wave_front_size
   - name: MeanOccupancyPerActiveCU
-    description: Mean occupancy per active compute unit.
+    description: "Mean wavefront occupancy per active compute unit. Average number of wavefronts resident on CUs that have at least one active wavefront. Unit: wavefronts. CDNA2 CUs support up to 32 wavefronts (4 SIMDs \xD7 8 wavefronts each). Higher occupancy helps hide memory latency."
     properties: []
     definitions:
     - architectures:
@@ -1633,7 +1620,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(accumulate(SQ_LEVEL_WAVES, LOW_RES),sum)/reduce(SQ_BUSY_CU_CYCLES,sum)
   - name: MeanOccupancyPerCU
-    description: Mean occupancy per compute unit.
+    description: 'Mean wavefront occupancy per compute unit across all CUs. Average number of wavefronts resident on each CU including idle CUs. Unit: wavefronts. Higher values indicate better GPU utilization and latency hiding capability.'
     properties: []
     definitions:
     - architectures:
@@ -1660,7 +1647,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(accumulate(SQ_LEVEL_WAVES, HIGH_RES),sum)/reduce(GRBM_GUI_ACTIVE,max)/CU_NUM
   - name: OccupancyPercent
-    description: GPU Occupancy as % of maximum.
+    description: 'Wavefront occupancy as a percentage of theoretical maximum. Indicates how many wavefront slots are filled relative to hardware limits. Unit: percent. Value range: 0% to 100%. Higher values enable better latency hiding but 100% is not always necessary for peak performance.'
     properties: []
     definitions:
     - architectures:
@@ -1687,9 +1674,7 @@ rocprofiler-sdk:
       - gfx950
       expression: 400*reduce(SQ_WAVE_CYCLES,sum)/reduce(GRBM_GUI_ACTIVE,max)/CU_NUM/32
   - name: MemUnitBusy
-    description: 'The percentage of GPUTime the memory unit is active. The result includes the stall time (MemUnitStalled).
-      This is measured with all extra fetches and writes and any cache or memory effects taken into account. Value range:
-      0% to 100% (fetch-bound).'
+    description: 'The percentage of GPUTime the memory unit is active. The result includes the stall time (MemUnitStalled). This is measured with all extra fetches and writes and any cache or memory effects taken into account. Value range: 0% to 100% (fetch-bound).'
     properties: []
     definitions:
     - architectures:
@@ -1713,8 +1698,7 @@ rocprofiler-sdk:
       - gfx1201
       expression: 100*reduce(TA_TA_BUSY,max)/reduce(GRBM_GUI_ACTIVE,max)
   - name: MemUnitStalled
-    description: 'The percentage of GPUTime the memory unit is stalled. Try reducing the number or size of fetches and writes
-      if possible. Value range: 0% (optimal) to 100% (bad).'
+    description: 'The percentage of GPUTime the memory unit is stalled. Try reducing the number or size of fetches and writes if possible. Value range: 0% (optimal) to 100% (bad).'
     properties: []
     definitions:
     - architectures:
@@ -1744,7 +1728,7 @@ rocprofiler-sdk:
       - gfx950
       expression: WRITE_REQ_32B
   - name: MfmaFlops
-    description: 'Unit: FLOP'
+    description: 'Matrix Fused Multiply-Add (MFMA) floating point operations per second across all data types. MFMA instructions use dedicated Matrix Cores in CDNA accelerators to perform D=A*B+C operations on matrices distributed across wavefront lanes. Unit: FLOPS. Higher values indicate better utilization of matrix cores.'
     properties: []
     definitions:
     - architectures:
@@ -1755,7 +1739,7 @@ rocprofiler-sdk:
       - gfx950
       expression: (SQ_INSTS_VALU_MFMA_MOPS_F16+SQ_INSTS_VALU_MFMA_MOPS_BF16+SQ_INSTS_VALU_MFMA_MOPS_F32+SQ_INSTS_VALU_MFMA_MOPS_F64)*512
   - name: MfmaFlopsBF16
-    description: 'Unit: FLOP'
+    description: 'MFMA floating point operations per second using BF16 (16-bit brain float) precision for input matrices. BF16 provides higher throughput than FP32 with minimal accuracy loss. MI250X peak: 383 TFLOPS. Unit: FLOPS. Higher values are better.'
     properties: []
     definitions:
     - architectures:
@@ -1766,7 +1750,7 @@ rocprofiler-sdk:
       - gfx950
       expression: SQ_INSTS_VALU_MFMA_MOPS_BF16*512
   - name: MfmaFlopsF16
-    description: 'Unit: FLOP'
+    description: 'MFMA floating point operations per second using FP16 (16-bit floating point) precision for input matrices. FP16 provides ~8x speedup versus FP32 on MI325X. MI250X peak: 383 TFLOPS. Unit: FLOPS. Higher values are better.'
     properties: []
     definitions:
     - architectures:
@@ -1777,7 +1761,7 @@ rocprofiler-sdk:
       - gfx950
       expression: SQ_INSTS_VALU_MFMA_MOPS_F16*512
   - name: MfmaFlopsF32
-    description: 'Unit: FLOP'
+    description: 'MFMA floating point operations per second using FP32 (32-bit floating point) precision. FP32 MFMA provides balanced performance and accuracy. MI250X peak: 95.7 TFLOPS. Unit: FLOPS. Higher values are better.'
     properties: []
     definitions:
     - architectures:
@@ -1788,7 +1772,7 @@ rocprofiler-sdk:
       - gfx950
       expression: SQ_INSTS_VALU_MFMA_MOPS_F32*512
   - name: MfmaFlopsF64
-    description: 'Unit: IOP'
+    description: 'MFMA floating point operations per second using FP64 (64-bit floating point) precision. FP64 MFMA delivers 2x throughput versus FP64 vector instructions on CDNA2+. MI250X peak: 95.7 TFLOPS. Unit: FLOPS. Higher values are better.'
     properties: []
     definitions:
     - architectures:
@@ -1799,7 +1783,7 @@ rocprofiler-sdk:
       - gfx950
       expression: SQ_INSTS_VALU_MFMA_MOPS_F64*512
   - name: MfmaUtil
-    description: 'Unit: percent'
+    description: 'Matrix Fused Multiply-Add (MFMA) utilization percentage. Indicates how effectively the specialized matrix cores are being used. Unit: percent. Value range: 0% (unused) to 100% (fully utilized). Higher values indicate better AI/HPC workload performance.'
     properties: []
     definitions:
     - architectures:
@@ -1856,7 +1840,7 @@ rocprofiler-sdk:
       - gfx1201
       expression: reduce(SQ_INSTS_SALU,sum)/reduce(SQ_WAVES,sum)
   - name: SE_NUM
-    description: SE_NUM
+    description: 'Number of Shader Engines (SEs) on the GPU. Each shader engine contains multiple compute units and associated memory hierarchy. This is a hardware configuration constant that varies by GPU model. Unit: count.'
     properties: []
     definitions:
     - architectures:
@@ -1885,8 +1869,7 @@ rocprofiler-sdk:
       - gfx1201
       expression: array_count/simd_arrays_per_engine
   - name: SFetchInsts
-    description: The average number of scalar fetch instructions from the video memory executed per work-item (affected by
-      flow control).
+    description: The average number of scalar fetch instructions from the video memory executed per work-item (affected by flow control).
     properties: []
     definitions:
     - architectures:
@@ -1910,9 +1893,7 @@ rocprofiler-sdk:
       - gfx1201
       expression: reduce(SQ_INSTS_SMEM,sum)/reduce(SQ_WAVES,sum)
   - name: SPI_CSN_BUSY
-    description: Number of clocks with outstanding waves (SPI or SH). Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source,
-      DEBUG_PIPE_SEL = 1, source is CS1; DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is CS3; default, source
-      is CS0;
+    description: Number of clocks with outstanding waves (SPI or SH). Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source, DEBUG_PIPE_SEL = 1, source is CS1; DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is CS3; default, source is CS0;
     properties: []
     definitions:
     - architectures:
@@ -1925,8 +1906,7 @@ rocprofiler-sdk:
       block: SPI
       event: 48
   - name: SPI_CSN_NUM_THREADGROUPS
-    description: Number of threadgroups launched. Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source, DEBUG_PIPE_SEL
-      = 1, source is CS1; DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is CS3; default, source is CS0;
+    description: Number of threadgroups launched. Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source, DEBUG_PIPE_SEL = 1, source is CS1; DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is CS3; default, source is CS0;
     properties: []
     definitions:
     - architectures:
@@ -1939,8 +1919,7 @@ rocprofiler-sdk:
       block: SPI
       event: 49
   - name: SPI_CSN_WAVE
-    description: Number of waves. Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source, DEBUG_PIPE_SEL = 1, source is CS1;
-      DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is CS3; default, source is CS0;
+    description: Number of waves. Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source, DEBUG_PIPE_SEL = 1, source is CS1; DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is CS3; default, source is CS0;
     properties: []
     definitions:
     - architectures:
@@ -1953,9 +1932,7 @@ rocprofiler-sdk:
       block: SPI
       event: 52
   - name: SPI_CSN_WINDOW_VALID
-    description: Clock count enabled by perfcounter_start event. Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source,
-      DEBUG_PIPE_SEL = 1, source is CS1; DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is CS3; default, source
-      is CS0;
+    description: Clock count enabled by perfcounter_start event. Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source, DEBUG_PIPE_SEL = 1, source is CS1; DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is CS3; default, source is CS0;
     properties: []
     definitions:
     - architectures:
@@ -2124,9 +2101,7 @@ rocprofiler-sdk:
       block: SPI
       event: 133
   - name: SPI_SWC_CSC_WR
-    description: Number of clocks to write CSC waves to SGPRs (need to multiply this value by 4) Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL
-      to select source, DEBUG_PIPE_SEL = 1, source is CS1; DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is
-      CS3; default, source is CS0;
+    description: Number of clocks to write CSC waves to SGPRs (need to multiply this value by 4) Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source, DEBUG_PIPE_SEL = 1, source is CS1; DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is CS3; default, source is CS0;
     properties: []
     definitions:
     - architectures:
@@ -2139,8 +2114,7 @@ rocprofiler-sdk:
       block: SPI
       event: 189
   - name: SPI_UTIL
-    description: Percentage of the GRBM_GUI_ACTIVE time that any of the Shader Pipe Interpolators (SPI) are busy in the shader
-      engine(s)
+    description: Percentage of the GRBM_GUI_ACTIVE time that any of the Shader Pipe Interpolators (SPI) are busy in the shader engine(s)
     properties: []
     definitions:
     - architectures:
@@ -2151,9 +2125,7 @@ rocprofiler-sdk:
       - gfx1032
       expression: 100*reduce(GRBM_SPI_BUSY,max)/reduce(GRBM_GUI_ACTIVE,max)
   - name: SPI_VWC_CSC_WR
-    description: Number of clocks to write CSC waves to VGPRs (need to multiply this value by 4) Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL
-      to select source, DEBUG_PIPE_SEL = 1, source is CS1; DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is
-      CS3; default, source is CS0;
+    description: Number of clocks to write CSC waves to VGPRs (need to multiply this value by 4) Requires SPI_DEBUG_CNTL.DEBUG_PIPE_SEL to select source, DEBUG_PIPE_SEL = 1, source is CS1; DEBUG_PIPE_SEL = 2, source is CS2; DEBUG_PIPE_SEL = 3, source is CS3; default, source is CS0;
     properties: []
     definitions:
     - architectures:
@@ -2350,7 +2322,7 @@ rocprofiler-sdk:
       block: SPI
       event: 22
   - name: SPI_CS3_WAVE
-    description: Number of waves of PIPE3.
+    description: 'Shader Processor Input (SPI) Context Save/Restore wave counter. The SPI receives work from the command processor and forwards it to compute units. Unit: count.'
     properties: []
     definitions:
     - architectures:
@@ -2947,8 +2919,7 @@ rocprofiler-sdk:
       block: SQ
       event: 288
   - name: SQC_LDS_IDX_ACTIVE
-    description: Number of cycles LDS is used for indexed (non-direct,non-interpolation) operations. {per-simd, emulated,
-      C1}
+    description: Number of cycles LDS is used for indexed (non-direct,non-interpolation) operations. {per-simd, emulated, C1}
     properties: []
     definitions:
     - architectures:
@@ -3053,9 +3024,7 @@ rocprofiler-sdk:
       block: SQ
       event: 267
   - name: SQ_ACCUM_PREV
-    description: This is a hardware register that can be used for accumulating values for other counters. This is useful in
-      expressions where you want to integrate over time. Only accumulates once every 4 cycles. This counter is primarily for
-      use with derived counters supplied by rocprof.
+    description: This is a hardware register that can be used for accumulating values for other counters. This is useful in expressions where you want to integrate over time. Only accumulates once every 4 cycles. This counter is primarily for use with derived counters supplied by rocprof.
     properties: []
     definitions:
     - architectures:
@@ -3082,9 +3051,7 @@ rocprofiler-sdk:
       block: SQ
       event: 1
   - name: SQ_ACCUM_PREV_HIRES
-    description: This is a hardware register that can be used for accumulating values for other counters. This is useful in
-      expressions where you want to integrate over time. This counter is primarily for use with derived counters supplied
-      by rocprof.
+    description: This is a hardware register that can be used for accumulating values for other counters. This is useful in expressions where you want to integrate over time. This counter is primarily for use with derived counters supplied by rocprof.
     properties: []
     definitions:
     - architectures:
@@ -3106,9 +3073,7 @@ rocprofiler-sdk:
       block: SQ
       event: 200
   - name: SQ_ACTIVE_INST_ANY
-    description: Number of cycles each wave spends working on any type of instruction. Useful in determining percentage of
-      time spend executing wave workloads (see WaveExec). This value is returned on a per-SE (aggregate of values in SIMDs
-      in the SE) basis with units in quad-cycles(4 cycles).
+    description: Number of cycles each wave spends working on any type of instruction. Useful in determining percentage of time spend executing wave workloads (see WaveExec). This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles).
     properties: []
     definitions:
     - architectures:
@@ -3130,11 +3095,7 @@ rocprofiler-sdk:
       block: SQ
       event: 117
   - name: SQ_ACTIVE_INST_EXP_GDS
-    description: Number of cycles each wave spends working on EXPORT or GDS instructions. This value represents the number
-      of cycles each wave spends executing instructions synchronizing workgroups across the device (global data sync). High
-      values indicates large amounts of time spent waiting on communication between CUs. This value is returned on a per-SE
-      (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles). See AMD ISAs for more information
-      on GDS instructions.
+    description: Number of cycles each wave spends working on EXPORT or GDS instructions. This value represents the number of cycles each wave spends executing instructions synchronizing workgroups across the device (global data sync). High values indicates large amounts of time spent waiting on communication between CUs. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles). See AMD ISAs for more information on GDS instructions.
     properties: []
     definitions:
     - architectures:
@@ -3156,10 +3117,7 @@ rocprofiler-sdk:
       block: SQ
       event: 122
   - name: SQ_ACTIVE_INST_FLAT
-    description: Number of cycles each wave spends working on FLAT instructions. This value represents the number of cycles
-      each wave spends executing instructions accessing flat scratch memory locations. High values indicates a large amount
-      of reading/writing to scratch memory on the device. This value is returned on a per-SE (aggregate of values in SIMDs
-      in the SE) basis with units in quad-cycles(4 cycles). See AMD ISAs for more information on FLAT instructions.
+    description: Number of cycles each wave spends working on FLAT instructions. This value represents the number of cycles each wave spends executing instructions accessing flat scratch memory locations. High values indicates a large amount of reading/writing to scratch memory on the device. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles). See AMD ISAs for more information on FLAT instructions.
     properties: []
     definitions:
     - architectures:
@@ -3181,10 +3139,7 @@ rocprofiler-sdk:
       block: SQ
       event: 124
   - name: SQ_ACTIVE_INST_LDS
-    description: Number of cycles each wave spends working on LDS instructions. This value represents the number of cycles
-      each wave spends executing instructions accessing the local data store (data shared between SIMDs on the same CU). High
-      values indicates a large amount of reading/writing to this shared memory space. This value is returned on a per-SE (aggregate
-      of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles). See AMD ISAs for more information on LDS instructions.
+    description: Number of cycles each wave spends working on LDS instructions. This value represents the number of cycles each wave spends executing instructions accessing the local data store (data shared between SIMDs on the same CU). High values indicates a large amount of reading/writing to this shared memory space. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles). See AMD ISAs for more information on LDS instructions.
     properties: []
     definitions:
     - architectures:
@@ -3206,10 +3161,7 @@ rocprofiler-sdk:
       block: SQ
       event: 119
   - name: SQ_ACTIVE_INST_MISC
-    description: Number of cycles each wave spends working on a BRANCH or SENDMSG instructions. This value represents the
-      number of cycles each wave spends executing instructions performing control flow branching and message sending. This
-      value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles). See
-      AMD ISAs for more information on BRANCH and SENDMSG instructions.
+    description: Number of cycles each wave spends working on a BRANCH or SENDMSG instructions. This value represents the number of cycles each wave spends executing instructions performing control flow branching and message sending. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles). See AMD ISAs for more information on BRANCH and SENDMSG instructions.
     properties: []
     definitions:
     - architectures:
@@ -3231,11 +3183,7 @@ rocprofiler-sdk:
       block: SQ
       event: 123
   - name: SQ_ACTIVE_INST_SCA
-    description: Number of cycles each wave spends working on a SALU or SMEM instructions. This value represents the number
-      of cycles each wave spends executing scalar ALU or scalar memory instructions. On MI200/300 platforms, there is a single
-      ALU per CU. High values indicates a large amount of time spent executing scalar instructions. This value is returned
-      on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles). See AMD ISAs for more
-      information on SALU and SMEM instructions.
+    description: Number of cycles each wave spends working on a SALU or SMEM instructions. This value represents the number of cycles each wave spends executing scalar ALU or scalar memory instructions. On MI200/300 platforms, there is a single ALU per CU. High values indicates a large amount of time spent executing scalar instructions. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles). See AMD ISAs for more information on SALU and SMEM instructions.
     properties: []
     definitions:
     - architectures:
@@ -3257,10 +3205,7 @@ rocprofiler-sdk:
       block: SQ
       event: 121
   - name: SQ_ACTIVE_INST_VALU
-    description: Number of cycles each wave spends working on a VALU instructions. This value represents the number of cycles
-      each wave spends executing vector ALU instructions. On MI200 platforms, there are 4 VALUs per CU. High values indicates
-      a large amount of time spent executing vector instructions. This value is returned on a per-SE (aggregate of values
-      in SIMDs in the SE) basis with units in quad-cycles(4 cycles).
+    description: Number of cycles each wave spends working on a VALU instructions. This value represents the number of cycles each wave spends executing vector ALU instructions. On MI200 platforms, there are 4 VALUs per CU. High values indicates a large amount of time spent executing vector instructions. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles).
     properties: []
     definitions:
     - architectures:
@@ -3288,10 +3233,7 @@ rocprofiler-sdk:
       block: SQ
       event: 120
   - name: SQ_ACTIVE_INST_VMEM
-    description: Number of cycles each wave spends working on a VMEM instructions. This value represents the number of cycles
-      each wave spends executing vector memory instructions. High values indicates a large amount of time spent executing
-      vector memory operations. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units
-      in quad-cycles(4 cycles).
+    description: Number of cycles each wave spends working on a VMEM instructions. This value represents the number of cycles each wave spends executing vector memory instructions. High values indicates a large amount of time spent executing vector memory operations. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles).
     properties: []
     definitions:
     - architectures:
@@ -3313,8 +3255,7 @@ rocprofiler-sdk:
       block: SQ
       event: 118
   - name: SQ_BUSY_CU_CYCLES
-    description: Number of quad-cycles each CU is busy. Can be used to calculate the percentage of time each CU is busy. This
-      value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles).
+    description: Number of quad-cycles each CU is busy. Can be used to calculate the percentage of time each CU is busy. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles).
     properties: []
     definitions:
     - architectures:
@@ -3327,9 +3268,7 @@ rocprofiler-sdk:
       block: SQ
       event: 13
   - name: SQ_BUSY_CYCLES
-    description: Number of clock cycles there are active waves in a shader engine (as reported by the distributed sequencer).
-      This value does not denote the number of active waves, only the clock cycle in which any wave is present in a SE. This
-      value is returned on a per-shader engine basis in clock cycles.
+    description: Number of clock cycles there are active waves in a shader engine (as reported by the distributed sequencer). This value does not denote the number of active waves, only the clock cycle in which any wave is present in a SE. This value is returned on a per-shader engine basis in clock cycles.
     properties: []
     definitions:
     - architectures:
@@ -3356,7 +3295,7 @@ rocprofiler-sdk:
       block: SQ
       event: 3
   - name: SQ_CYCLES
-    description: Clock cycles. Value is returned per-SIMD.
+    description: 'Sequencer (SQ) total cycles. The SQ is the instruction scheduler that manages wavefront execution on compute units. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -3391,8 +3330,7 @@ rocprofiler-sdk:
       block: SQ
       event: 136
   - name: SQ_IFETCH_LEVEL
-    description: Number of inflight instruction fetch requests from the cache. This is a value returned per-sharder engine.
-      Best used with accumlate() functions as part of a derived counter.
+    description: Number of inflight instruction fetch requests from the cache. This is a value returned per-sharder engine. Best used with accumlate() functions as part of a derived counter.
     properties: []
     definitions:
     - architectures:
@@ -3414,9 +3352,7 @@ rocprofiler-sdk:
       block: SQ
       event: 137
   - name: SQ_INSTS
-    description: Total number of instructions issued. When used in combination with SQ_ACTIVE_INST_ANY (cycle count for executing
-      instructions) the average latency of instruction execution can be calculated (SQ_ACTIVE_INST_ANY / SQ_INSTS). This value
-      is returned per-SE (aggregate of values in SIMDs in the SE).
+    description: Total number of instructions issued. When used in combination with SQ_ACTIVE_INST_ANY (cycle count for executing instructions) the average latency of instruction execution can be calculated (SQ_ACTIVE_INST_ANY / SQ_INSTS). This value is returned per-SE (aggregate of values in SIMDs in the SE).
     properties: []
     definitions:
     - architectures:
@@ -3429,9 +3365,7 @@ rocprofiler-sdk:
       block: SQ
       event: 25
   - name: SQ_INSTS_BRANCH
-    description: Total number of BRANCH instructions issued. This value is returned per-SE (aggregate of values in SIMDs in
-      the SE). This value SHOULD NOT be used in combination with SQ_ACTIVE_INST_MISC to calculate latency. SQ_ACTIVE_INST_MISC
-      includes both BRANCH and SENDMSG instructions while this is only BRANCH.
+    description: Total number of BRANCH instructions issued. This value is returned per-SE (aggregate of values in SIMDs in the SE). This value SHOULD NOT be used in combination with SQ_ACTIVE_INST_MISC to calculate latency. SQ_ACTIVE_INST_MISC includes both BRANCH and SENDMSG instructions while this is only BRANCH.
     properties: []
     definitions:
     - architectures:
@@ -3453,9 +3387,7 @@ rocprofiler-sdk:
       block: SQ
       event: 71
   - name: SQ_INSTS_EXP_GDS
-    description: Total number of EXPORT or GDS (global wave state) instructions issued. When used in combination with SQ_ACTIVE_INST_EXP_GDS
-      (cycle count for executing instructions) the average latency of EXPORT/GDS instruction execution can be calculated (SQ_ACTIVE_INST_EXP_GDS
-      / SQ_INSTS_EXP_GDS). This value is returned per-SE (aggregate of values in SIMDs in the SE).
+    description: Total number of EXPORT or GDS (global wave state) instructions issued. When used in combination with SQ_ACTIVE_INST_EXP_GDS (cycle count for executing instructions) the average latency of EXPORT/GDS instruction execution can be calculated (SQ_ACTIVE_INST_EXP_GDS / SQ_INSTS_EXP_GDS). This value is returned per-SE (aggregate of values in SIMDs in the SE).
     properties: []
     definitions:
     - architectures:
@@ -3477,9 +3409,7 @@ rocprofiler-sdk:
       block: SQ
       event: 70
   - name: SQ_INSTS_FLAT
-    description: Total number of FLAT instructions issued. When used in combination with SQ_ACTIVE_INST_FLAT (cycle count
-      for executing instructions) the average latency of FLAT instruction execution can be calculated (SQ_ACTIVE_INST_FLAT
-      / SQ_INSTS). This value is returned per-SE (aggregate of values in SIMDs in the SE).
+    description: Total number of FLAT instructions issued. When used in combination with SQ_ACTIVE_INST_FLAT (cycle count for executing instructions) the average latency of FLAT instruction execution can be calculated (SQ_ACTIVE_INST_FLAT / SQ_INSTS). This value is returned per-SE (aggregate of values in SIMDs in the SE).
     properties: []
     definitions:
     - architectures:
@@ -3530,8 +3460,7 @@ rocprofiler-sdk:
       block: SQ
       event: 64
   - name: SQ_INSTS_FLAT_LDS_ONLY
-    description: Total number of FLAT instructions issued that read/wrote only from/to LDS (scratch memory). Values are only
-      populated if EARLY_TA_DONE is enabled. This value is returned per-SE (aggregate of values in SIMDs in the SE).
+    description: Total number of FLAT instructions issued that read/wrote only from/to LDS (scratch memory). Values are only populated if EARLY_TA_DONE is enabled. This value is returned per-SE (aggregate of values in SIMDs in the SE).
     properties: []
     definitions:
     - architectures:
@@ -3549,8 +3478,7 @@ rocprofiler-sdk:
       block: SQ
       event: 59
   - name: SQ_INSTS_GDS
-    description: Total number of GDS (global data sync) instructions issued. This value is returned per-SE (aggregate of values
-      in SIMDs in the SE). See AMD ISAs for more information on GDS (global data sync) instructions.
+    description: Total number of GDS (global data sync) instructions issued. This value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on GDS (global data sync) instructions.
     properties: []
     definitions:
     - architectures:
@@ -3593,8 +3521,7 @@ rocprofiler-sdk:
       block: SQ
       event: 68
   - name: SQ_INSTS_LDS
-    description: Total number of LDS instructions issued (including FLAT). This value is returned per-SE (aggregate of values
-      in SIMDs in the SE). See AMD ISAs for more information on LDS instructions.
+    description: Total number of LDS instructions issued (including FLAT). This value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on LDS instructions.
     properties: []
     definitions:
     - architectures:
@@ -3645,8 +3572,7 @@ rocprofiler-sdk:
       block: SQ
       event: 67
   - name: SQ_INSTS_MFMA
-    description: Total number of MFMA (Matrix-Fused-Multiply-Add) instructions issued. This value is returned per-SE (aggregate
-      of values in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
+    description: Total number of MFMA (Matrix-Fused-Multiply-Add) instructions issued. This value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
     properties: []
     definitions:
     - architectures:
@@ -3668,8 +3594,7 @@ rocprofiler-sdk:
       block: SQ
       event: 58
   - name: SQ_INSTS_SALU
-    description: Total Number of SALU (Scalar ALU) instructions issued. This value is returned per-SE (aggregate of values
-      in SIMDs in the SE). See AMD ISAs for more information on SALU instructions.
+    description: Total Number of SALU (Scalar ALU) instructions issued. This value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on SALU instructions.
     properties: []
     definitions:
     - architectures:
@@ -3717,8 +3642,7 @@ rocprofiler-sdk:
       block: SQ
       event: 62
   - name: SQ_INSTS_SENDMSG
-    description: Total number of Sendmsg (typically an interrupt to the CPU host) instructions issued. This value is returned
-      per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on Sendmsg instructions.
+    description: Total number of Sendmsg (typically an interrupt to the CPU host) instructions issued. This value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on Sendmsg instructions.
     properties: []
     definitions:
     - architectures:
@@ -3740,8 +3664,7 @@ rocprofiler-sdk:
       block: SQ
       event: 72
   - name: SQ_INSTS_SMEM
-    description: Total number of SMEM (Scalar Memory Read) instructions issued. This value is returned per-SE (aggregate of
-      values in SIMDs in the SE). See AMD ISAs for more information on SMEM instructions.
+    description: Total number of SMEM (Scalar Memory Read) instructions issued. This value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on SMEM instructions.
     properties: []
     definitions:
     - architectures:
@@ -3789,10 +3712,7 @@ rocprofiler-sdk:
       block: SQ
       event: 63
   - name: SQ_INSTS_SMEM_NORM
-    description: Number of SMEM instructions issued normalized to match the level of memory accessed (i.e. scratch, global,
-      etc). This normalized value is designed to give a hint of high cost memory actions being used. The formula used to calculate
-      this value is the following (INST_COUNT *2 for load/store; INST_COUNT*2 atomic; INST_COUNT*2 memtime; INST_COUNT*4 wb/inv).
-      This value is returned per-SE (aggregate of values in SIMDs in the SE).
+    description: Number of SMEM instructions issued normalized to match the level of memory accessed (i.e. scratch, global, etc). This normalized value is designed to give a hint of high cost memory actions being used. The formula used to calculate this value is the following (INST_COUNT *2 for load/store; INST_COUNT*2 atomic; INST_COUNT*2 memtime; INST_COUNT*4 wb/inv). This value is returned per-SE (aggregate of values in SIMDs in the SE).
     properties: []
     definitions:
     - architectures:
@@ -3814,8 +3734,7 @@ rocprofiler-sdk:
       block: SQ
       event: 203
   - name: SQ_INSTS_TEX_LOAD
-    description: The number of buffer load, image load, sample, or atomic (with return) texture instructions issued. The value
-      is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on TEX_LOAD instructions.
+    description: The number of buffer load, image load, sample, or atomic (with return) texture instructions issued. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on TEX_LOAD instructions.
     properties: []
     definitions:
     - architectures:
@@ -3834,8 +3753,7 @@ rocprofiler-sdk:
       block: SQ
       event: 54
   - name: SQ_INSTS_TEX_STORE
-    description: The number of buffer store, image store, or atomic (without return) texture instructions issued. The value
-      is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on TEX_STORE instructions.
+    description: The number of buffer store, image store, or atomic (without return) texture instructions issued. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on TEX_STORE instructions.
     properties: []
     definitions:
     - architectures:
@@ -3854,8 +3772,7 @@ rocprofiler-sdk:
       block: SQ
       event: 55
   - name: SQ_INSTS_VALU
-    description: The number of VALU (Vector ALU) instructions issued. The value is returned per-SE (aggregate of values in
-      SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
+    description: The number of VALU (Vector ALU) instructions issued. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
     properties: []
     definitions:
     - architectures:
@@ -3894,9 +3811,7 @@ rocprofiler-sdk:
       block: SQ
       event: 50
   - name: SQ_INSTS_VALU_ADD_F16
-    description: The number of VALU (Vector ALU) ADD/SUB instructions on float16. For maximum performance lower precision
-      floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs
-      in the SE). See AMD ISAs for more information on VALU instructions.
+    description: The number of VALU (Vector ALU) ADD/SUB instructions on float16. For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
     properties: []
     definitions:
     - architectures:
@@ -3908,9 +3823,7 @@ rocprofiler-sdk:
       block: SQ
       event: 27
   - name: SQ_INSTS_VALU_ADD_F32
-    description: The number of VALU (Vector ALU) ADD/SUB instructions on float32. For maximum performance lower precision
-      floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs
-      in the SE). See AMD ISAs for more information on VALU instructions.
+    description: The number of VALU (Vector ALU) ADD/SUB instructions on float32. For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
     properties: []
     definitions:
     - architectures:
@@ -3922,9 +3835,7 @@ rocprofiler-sdk:
       block: SQ
       event: 31
   - name: SQ_INSTS_VALU_ADD_F64
-    description: The number of VALU ADD/SUB instructions on float64. For maximum performance lower precision floating point
-      ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See
-      AMD ISAs for more information on VALU instructions.
+    description: The number of VALU ADD/SUB instructions on float64. For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
     properties: []
     definitions:
     - architectures:
@@ -3936,8 +3847,7 @@ rocprofiler-sdk:
       block: SQ
       event: 35
   - name: SQ_INSTS_VALU_CVT
-    description: The number of VALU (Vector ALU) data conversion instructions (ex. float -> int). The value is returned per-SE
-      (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
+    description: The number of VALU (Vector ALU) data conversion instructions (ex. float -> int). The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
     properties: []
     definitions:
     - architectures:
@@ -3949,9 +3859,7 @@ rocprofiler-sdk:
       block: SQ
       event: 41
   - name: SQ_INSTS_VALU_FMA_F16
-    description: The number of VALU (Vector ALU) FMA (Fused-Multiply-Add)/MAD(Multiply-Add) instructions on float16. For maximum
-      performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE
-      (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
+    description: The number of VALU (Vector ALU) FMA (Fused-Multiply-Add)/MAD(Multiply-Add) instructions on float16. For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
     properties: []
     definitions:
     - architectures:
@@ -3963,9 +3871,7 @@ rocprofiler-sdk:
       block: SQ
       event: 29
   - name: SQ_INSTS_VALU_FMA_F32
-    description: The number of VALU (Vector ALU) FMA (Fused-Multiply-Add)/MAD(Multiply-Add) instructions on float32. For maximum
-      performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE
-      (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
+    description: The number of VALU (Vector ALU) FMA (Fused-Multiply-Add)/MAD(Multiply-Add) instructions on float32. For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
     properties: []
     definitions:
     - architectures:
@@ -3977,9 +3883,7 @@ rocprofiler-sdk:
       block: SQ
       event: 33
   - name: SQ_INSTS_VALU_FMA_F64
-    description: The number of VALU (Vector ALU) FMA (Fused-Multiply-Add)/MAD(Multiply-Add) instructions on float64. For maximum
-      performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE
-      (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
+    description: The number of VALU (Vector ALU) FMA (Fused-Multiply-Add)/MAD(Multiply-Add) instructions on float64. For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
     properties: []
     definitions:
     - architectures:
@@ -3991,8 +3895,7 @@ rocprofiler-sdk:
       block: SQ
       event: 37
   - name: SQ_INSTS_VALU_INT32
-    description: The number of VALU (Vector ALU) 32-bit integer (signed or unsigned) instructions. The value is returned per-SE
-      (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instruction.
+    description: The number of VALU (Vector ALU) 32-bit integer (signed or unsigned) instructions. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instruction.
     properties: []
     definitions:
     - architectures:
@@ -4004,8 +3907,7 @@ rocprofiler-sdk:
       block: SQ
       event: 39
   - name: SQ_INSTS_VALU_INT64
-    description: The number of VALU (Vector ALU) 64-bit integer (signed or unsigned) instructions. The value is returned per-SE
-      (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instruction.
+    description: The number of VALU (Vector ALU) 64-bit integer (signed or unsigned) instructions. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instruction.
     properties: []
     definitions:
     - architectures:
@@ -4017,9 +3919,7 @@ rocprofiler-sdk:
       block: SQ
       event: 40
   - name: SQ_INSTS_VALU_MFMA_BF16
-    description: The number of MFMA (Matrix-Fused-Multiply-Add) operating on BF16 format (V_MFMA or V_SMFMAC). For maximum
-      performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE
-      (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
+    description: The number of MFMA (Matrix-Fused-Multiply-Add) operating on BF16 format (V_MFMA or V_SMFMAC). For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
     properties: []
     definitions:
     - architectures:
@@ -4031,9 +3931,7 @@ rocprofiler-sdk:
       block: SQ
       event: 44
   - name: SQ_INSTS_VALU_MFMA_F16
-    description: The number of MFMA (Matrix-Fused-Multiply-Add) operating on F16 format (V_MFMA or V_SMFMAC). For maximum
-      performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE
-      (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
+    description: The number of MFMA (Matrix-Fused-Multiply-Add) operating on F16 format (V_MFMA or V_SMFMAC). For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
     properties: []
     definitions:
     - architectures:
@@ -4045,9 +3943,7 @@ rocprofiler-sdk:
       block: SQ
       event: 43
   - name: SQ_INSTS_VALU_MFMA_F32
-    description: The number of MFMA (Matrix-Fused-Multiply-Add) operating on F32 format (V_MFMA or V_SMFMAC). For maximum
-      performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE
-      (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
+    description: The number of MFMA (Matrix-Fused-Multiply-Add) operating on F32 format (V_MFMA or V_SMFMAC). For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
     properties: []
     definitions:
     - architectures:
@@ -4059,9 +3955,7 @@ rocprofiler-sdk:
       block: SQ
       event: 45
   - name: SQ_INSTS_VALU_MFMA_F64
-    description: The number of MFMA (Matrix-Fused-Multiply-Add) operating on F64 format (V_MFMA_F64_*). For maximum performance
-      lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of
-      values in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
+    description: The number of MFMA (Matrix-Fused-Multiply-Add) operating on F64 format (V_MFMA_F64_*). For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
     properties: []
     definitions:
     - architectures:
@@ -4073,8 +3967,7 @@ rocprofiler-sdk:
       block: SQ
       event: 46
   - name: SQ_INSTS_VALU_MFMA_I8
-    description: The number of MFMA (Matrix-Fused-Multiply-Add) operating on I8 format (V_MFMA or V_SMFMAC). See AMD ISAs
-      for more information on MFMA instructions.
+    description: The number of MFMA (Matrix-Fused-Multiply-Add) operating on I8 format (V_MFMA or V_SMFMAC). See AMD ISAs for more information on MFMA instructions.
     properties: []
     definitions:
     - architectures:
@@ -4086,8 +3979,7 @@ rocprofiler-sdk:
       block: SQ
       event: 42
   - name: SQ_INSTS_VALU_MFMA_F8
-    description: The number of MFMA (Matrix-Fused-Multiply-Add) operating on F8 format (V_MFMA or V_SMFMAC). See AMD CDNA3
-      ISA for more informations.
+    description: The number of MFMA (Matrix-Fused-Multiply-Add) operating on F8 format (V_MFMA or V_SMFMAC). See AMD CDNA3 ISA for more informations.
     properties: []
     definitions:
     - architectures:
@@ -4098,7 +3990,7 @@ rocprofiler-sdk:
       block: SQ
       event: 48
   - name: SQ_INSTS_VALU_MFMA_XF32
-    description: Number of VALU V_MFMA_*_XF32 instructions.
+    description: 'Sequencer count of VALU MFMA instructions using extended FP32 precision. These are matrix operations on the specialized matrix cores. Unit: count.'
     properties: []
     definitions:
     - architectures:
@@ -4106,10 +3998,7 @@ rocprofiler-sdk:
       block: SQ
       event: 47
   - name: SQ_INSTS_VALU_MFMA_MOPS_BF16
-    description: The number of math operation instructions on the VALU (Vector ALU) using MFMA (Matrix-Fused-Multiply-Add)
-      and operating on BF16 (bfloat16) data. Captures add or mul ops performed divided by 512. For maximum performance lower
-      precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values
-      in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
+    description: The number of math operation instructions on the VALU (Vector ALU) using MFMA (Matrix-Fused-Multiply-Add) and operating on BF16 (bfloat16) data. Captures add or mul ops performed divided by 512. For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
     properties: []
     definitions:
     - architectures:
@@ -4127,10 +4016,7 @@ rocprofiler-sdk:
       block: SQ
       event: 52
   - name: SQ_INSTS_VALU_MFMA_MOPS_F16
-    description: The number of math operation instructions on the VALU (Vector ALU) using MFMA (Matrix-Fused-Multiply-Add)
-      and operating on F16 (float16) data. Captures add or mul ops performed divided by 512. For maximum performance lower
-      precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values
-      in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
+    description: The number of math operation instructions on the VALU (Vector ALU) using MFMA (Matrix-Fused-Multiply-Add) and operating on F16 (float16) data. Captures add or mul ops performed divided by 512. For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
     properties: []
     definitions:
     - architectures:
@@ -4148,10 +4034,7 @@ rocprofiler-sdk:
       block: SQ
       event: 51
   - name: SQ_INSTS_VALU_MFMA_MOPS_F32
-    description: The number of math operation instructions on the VALU (Vector ALU) using MFMA (Matrix-Fused-Multiply-Add)
-      and operating on F32 (float32) data. Captures add or mul ops performed divided by 512. For maximum performance lower
-      precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values
-      in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
+    description: The number of math operation instructions on the VALU (Vector ALU) using MFMA (Matrix-Fused-Multiply-Add) and operating on F32 (float32) data. Captures add or mul ops performed divided by 512. For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
     properties: []
     definitions:
     - architectures:
@@ -4169,10 +4052,7 @@ rocprofiler-sdk:
       block: SQ
       event: 53
   - name: SQ_INSTS_VALU_MFMA_MOPS_F64
-    description: The number of math operation instructions on the VALU (Vector ALU) using MFMA (Matrix-Fused-Multiply-Add)
-      and operating on F64 (float64) data. Captures add or mul ops performed divided by 512. For maximum performance lower
-      precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values
-      in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
+    description: The number of math operation instructions on the VALU (Vector ALU) using MFMA (Matrix-Fused-Multiply-Add) and operating on F64 (float64) data. Captures add or mul ops performed divided by 512. For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
     properties: []
     definitions:
     - architectures:
@@ -4190,9 +4070,7 @@ rocprofiler-sdk:
       block: SQ
       event: 54
   - name: SQ_INSTS_VALU_MFMA_MOPS_I8
-    description: The number of math operation instructions on the VALU (Vector ALU) using MFMA (Matrix-Fused-Multiply-Add)
-      and operating on I8 (8 bit int) data. Captures add or mul ops performed divided by 512. The value is returned per-SE
-      (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
+    description: The number of math operation instructions on the VALU (Vector ALU) using MFMA (Matrix-Fused-Multiply-Add) and operating on I8 (8 bit int) data. Captures add or mul ops performed divided by 512. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on MFMA instructions.
     properties: []
     definitions:
     - architectures:
@@ -4210,8 +4088,7 @@ rocprofiler-sdk:
       block: SQ
       event: 50
   - name: SQ_INSTS_VALU_MFMA_MOPS_F8
-    description: The number of math operation on F8 datatype. Captures add or mul ops performed divided by 512. The value
-      is returned per-SE (aggregate of values in SIMDs in the SE). See AMD CDNA3 ISA for more information on MFMA F8 instructions.
+    description: The number of math operation on F8 datatype. Captures add or mul ops performed divided by 512. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD CDNA3 ISA for more information on MFMA F8 instructions.
     properties: []
     definitions:
     - architectures:
@@ -4225,8 +4102,7 @@ rocprofiler-sdk:
       block: SQ
       event: 56
   - name: SQ_INSTS_VALU_MFMA_MOPS_XF32
-    description: Number of VALU matrix math operations (add or mul) performed dividied by 512, assuming a full EXEC mask,
-      of data type XF32. (per-simd, emulated)
+    description: Number of VALU matrix math operations (add or mul) performed dividied by 512, assuming a full EXEC mask, of data type XF32. (per-simd, emulated)
     properties: []
     definitions:
     - architectures:
@@ -4234,8 +4110,7 @@ rocprofiler-sdk:
       block: SQ
       event: 55
   - name: SQ_VALU_MFMA_COEXEC_CYCLES
-    description: Number of cycles in which MFMA VALU was busy and a normal VALU instruction was issued (co-execution) (per-simd,
-      nondeterministic)
+    description: Number of cycles in which MFMA VALU was busy and a normal VALU instruction was issued (co-execution) (per-simd, nondeterministic)
     properties: []
     definitions:
     - architectures:
@@ -4243,9 +4118,7 @@ rocprofiler-sdk:
       block: SQ
       event: 94
   - name: SQ_INSTS_VALU_MUL_F16
-    description: The number of VALU MUL instructions on float16 data. For maximum performance lower precision floating point
-      ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See
-      AMD ISAs for more information on VALU instructions.
+    description: The number of VALU MUL instructions on float16 data. For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
     properties: []
     definitions:
     - architectures:
@@ -4257,9 +4130,7 @@ rocprofiler-sdk:
       block: SQ
       event: 28
   - name: SQ_INSTS_VALU_MUL_F32
-    description: The number of VALU MUL instructions on float32 data. For maximum performance lower precision floating point
-      ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See
-      AMD ISAs for more information on VALU instructions.
+    description: The number of VALU MUL instructions on float32 data. For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
     properties: []
     definitions:
     - architectures:
@@ -4271,9 +4142,7 @@ rocprofiler-sdk:
       block: SQ
       event: 32
   - name: SQ_INSTS_VALU_MUL_F64
-    description: The number of VALU MUL instructions on float64 data. For maximum performance lower precision floating point
-      ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See
-      AMD ISAs for more information on VALU instructions.
+    description: The number of VALU MUL instructions on float64 data. For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
     properties: []
     definitions:
     - architectures:
@@ -4285,9 +4154,7 @@ rocprofiler-sdk:
       block: SQ
       event: 36
   - name: SQ_INSTS_VALU_TRANS_F16
-    description: The number of VALU transcendental instructions on float16 data. Transcendental instructions include sin,
-      cos, exp, log, etc. For maximum performance lower precision floating point ops are preferred to higher precision ones.
-      The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
+    description: The number of VALU transcendental instructions on float16 data. Transcendental instructions include sin, cos, exp, log, etc. For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
     properties: []
     definitions:
     - architectures:
@@ -4299,9 +4166,7 @@ rocprofiler-sdk:
       block: SQ
       event: 30
   - name: SQ_INSTS_VALU_TRANS_F32
-    description: The number of VALU transcendental instructions on float32 data. Transcendental instructions include sin,
-      cos, exp, log, etc. For maximum performance lower precision floating point ops are preferred to higher precision ones.
-      The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
+    description: The number of VALU transcendental instructions on float32 data. Transcendental instructions include sin, cos, exp, log, etc. For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
     properties: []
     definitions:
     - architectures:
@@ -4313,9 +4178,7 @@ rocprofiler-sdk:
       block: SQ
       event: 34
   - name: SQ_INSTS_VALU_TRANS_F64
-    description: The number of VALU transcendental instructions on float64 data. Transcendental instructions include sin,
-      cos, exp, log, etc. For maximum performance lower precision floating point ops are preferred to higher precision ones.
-      The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
+    description: The number of VALU transcendental instructions on float64 data. Transcendental instructions include sin, cos, exp, log, etc. For maximum performance lower precision floating point ops are preferred to higher precision ones. The value is returned per-SE (aggregate of values in SIMDs in the SE). See AMD ISAs for more information on VALU instructions.
     properties: []
     definitions:
     - architectures:
@@ -4327,8 +4190,7 @@ rocprofiler-sdk:
       block: SQ
       event: 38
   - name: SQ_INSTS_VMEM
-    description: The number of VMEM (GPU Memory) instructions issued. The value is returned per-SE (aggregate of values in
-      SIMDs in the SE).
+    description: The number of VMEM (GPU Memory) instructions issued. The value is returned per-SE (aggregate of values in SIMDs in the SE).
     properties: []
     definitions:
     - architectures:
@@ -4350,8 +4212,7 @@ rocprofiler-sdk:
       block: SQ
       event: 61
   - name: SQ_INSTS_VMEM_RD
-    description: The number of VMEM (GPU Memory) read instructions issued (including FLAT/scratch memory). The value is returned
-      per-SE (aggregate of values in SIMDs in the SE).
+    description: The number of VMEM (GPU Memory) read instructions issued (including FLAT/scratch memory). The value is returned per-SE (aggregate of values in SIMDs in the SE).
     properties: []
     definitions:
     - architectures:
@@ -4379,8 +4240,7 @@ rocprofiler-sdk:
       block: SQ
       event: 60
   - name: SQ_INSTS_VMEM_WR
-    description: The number of VMEM (GPU Memory) write instructions issued (including FLAT/scratch memory). The value is returned
-      per-SE (aggregate of values in SIMDs in the SE).
+    description: The number of VMEM (GPU Memory) write instructions issued (including FLAT/scratch memory). The value is returned per-SE (aggregate of values in SIMDs in the SE).
     properties: []
     definitions:
     - architectures:
@@ -4408,10 +4268,7 @@ rocprofiler-sdk:
       block: SQ
       event: 59
   - name: SQ_INSTS_VSKIPPED
-    description: The number of vector instructions skipped. This can occur when the S_SETVSKIP bit is enabled on certain instructions.
-      Often this is used as an alturnative to branching (a compiler may replace a branch with setting this bit to skip the
-      operation, typically as a performance optimization). The value is returned per-SE (aggregate of values in SIMDs in the
-      SE).
+    description: The number of vector instructions skipped. This can occur when the S_SETVSKIP bit is enabled on certain instructions. Often this is used as an alturnative to branching (a compiler may replace a branch with setting this bit to skip the operation, typically as a performance optimization). The value is returned per-SE (aggregate of values in SIMDs in the SE).
     properties: []
     definitions:
     - architectures:
@@ -4460,8 +4317,7 @@ rocprofiler-sdk:
       block: SQ
       event: 58
   - name: SQ_INSTS_WAVE32_LDS
-    description: Number of wave32 LDS indexed instructions issued. Wave64 may count 1 or 2, depending on what gets issued.
-      {emulated, C1}
+    description: Number of wave32 LDS indexed instructions issued. Wave64 may count 1 or 2, depending on what gets issued. {emulated, C1}
     properties: []
     definitions:
     - architectures:
@@ -4488,8 +4344,7 @@ rocprofiler-sdk:
       block: SQ
       event: 60
   - name: SQ_INSTS_WAVE32_VALU
-    description: Number of wave32 valu instructions issued. Wave64 may count 1 or 2, depending on what gets issued. {emulated,
-      C1}
+    description: Number of wave32 valu instructions issued. Wave64 may count 1 or 2, depending on what gets issued. {emulated, C1}
     properties: []
     definitions:
     - architectures:
@@ -4516,8 +4371,7 @@ rocprofiler-sdk:
       block: SQ
       event: 61
   - name: SQ_INST_CYCLES_SALU
-    description: The number of cycles needed to execute non-memory read scalar operations (SALU). This value is returned on
-      a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles).
+    description: The number of cycles needed to execute non-memory read scalar operations (SALU). This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles).
     properties: []
     definitions:
     - architectures:
@@ -4545,8 +4399,7 @@ rocprofiler-sdk:
       block: SQ
       event: 133
   - name: SQ_INST_CYCLES_SMEM
-    description: The number of cycles needed to execute scalar memory reads (SMEM). This value is returned on a per-SE (aggregate
-      of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles).
+    description: The number of cycles needed to execute scalar memory reads (SMEM). This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles).
     properties: []
     definitions:
     - architectures:
@@ -4568,9 +4421,7 @@ rocprofiler-sdk:
       block: SQ
       event: 132
   - name: SQ_INST_CYCLES_VMEM
-    description: The number of cycles needed to send addr and data for VMEM (lds, buffer, image, flat, scratch, global) instructions,
-      windowed by perf_en. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units in
-      quad-cycles(4 cycles).
+    description: The number of cycles needed to send addr and data for VMEM (lds, buffer, image, flat, scratch, global) instructions, windowed by perf_en. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles).
     properties: []
     definitions:
     - architectures:
@@ -4595,8 +4446,7 @@ rocprofiler-sdk:
       block: SQ
       event: 102
   - name: SQ_INST_CYCLES_VMEM_RD
-    description: The number of cycles needed to send addr and cmd data for VMEM read instructions. This value is returned
-      on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles).
+    description: The number of cycles needed to send addr and cmd data for VMEM read instructions. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles).
     properties: []
     definitions:
     - architectures:
@@ -4618,8 +4468,7 @@ rocprofiler-sdk:
       block: SQ
       event: 126
   - name: SQ_INST_CYCLES_VMEM_WR
-    description: The number of cycles needed to send addr and cmd data for VMEM write instructions. This value is returned
-      on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles).
+    description: The number of cycles needed to send addr and cmd data for VMEM write instructions. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis with units in quad-cycles(4 cycles).
     properties: []
     definitions:
     - architectures:
@@ -4641,9 +4490,7 @@ rocprofiler-sdk:
       block: SQ
       event: 125
   - name: SQ_INST_LEVEL_GDS
-    description: Number of in-flight GDS (global) instructions. This value represents the number of instructions each wave
-      spends synchronizing workgroups across the device (global data sync). Set next counter to ACCUM_PREV and divide by INSTS_GDS
-      for average latency. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
+    description: Number of in-flight GDS (global) instructions. This value represents the number of instructions each wave spends synchronizing workgroups across the device (global data sync). Set next counter to ACCUM_PREV and divide by INSTS_GDS for average latency. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
     properties: []
     definitions:
     - architectures:
@@ -4662,10 +4509,7 @@ rocprofiler-sdk:
       block: SQ
       event: 87
   - name: SQ_INST_LEVEL_LDS
-    description: Number of in-flight LDS instructions. This value represents the number of instructions each wave spends executing
-      instructions accessing the local data store (data shared between SIMDs on the same CU). Set next counter to ACCUM_PREV
-      and divide by INSTS_LDS for average latency. Includes FLAT instructions. This value is returned on a per-SE (aggregate
-      of values in SIMDs in the SE) basis.
+    description: Number of in-flight LDS instructions. This value represents the number of instructions each wave spends executing instructions accessing the local data store (data shared between SIMDs on the same CU). Set next counter to ACCUM_PREV and divide by INSTS_LDS for average latency. Includes FLAT instructions. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
     properties: []
     definitions:
     - architectures:
@@ -4708,10 +4552,7 @@ rocprofiler-sdk:
       block: SQ
       event: 90
   - name: SQ_INST_LEVEL_SMEM
-    description: Number of in-flight SMEM instructions (*2 load/store; *2 atomic; *2 memtime; *4 wb/inv). Set next counter
-      to ACCUM_PREV and divide by INSTS_SMEM for average latency per smem request. Falls slightly short of total request latency
-      because some fetches are divided into two requests that may finish at different times and this counter collects the
-      average latency of the two. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
+    description: Number of in-flight SMEM instructions (*2 load/store; *2 atomic; *2 memtime; *4 wb/inv). Set next counter to ACCUM_PREV and divide by INSTS_SMEM for average latency per smem request. Falls slightly short of total request latency because some fetches are divided into two requests that may finish at different times and this counter collects the average latency of the two. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
     properties: []
     definitions:
     - architectures:
@@ -4733,8 +4574,7 @@ rocprofiler-sdk:
       block: SQ
       event: 89
   - name: SQ_INST_LEVEL_VMEM
-    description: Number of in-flight VMEM instructions. Set next counter to ACCUM_PREV and divide by INSTS_VMEM for average
-      latency. Includes FLAT instructions. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
+    description: Number of in-flight VMEM instructions. Set next counter to ACCUM_PREV and divide by INSTS_VMEM for average latency. Includes FLAT instructions. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
     properties: []
     definitions:
     - architectures:
@@ -4756,8 +4596,7 @@ rocprofiler-sdk:
       block: SQ
       event: 88
   - name: SQ_ITEMS
-    description: Number of valid items per wave. This value is returned on a per-SE (aggregate of values in SIMDs in the SE)
-      basis.
+    description: Number of valid items per wave. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
     properties: []
     definitions:
     - architectures:
@@ -4770,8 +4609,7 @@ rocprofiler-sdk:
       block: SQ
       event: 14
   - name: SQ_LDS_ADDR_CONFLICT
-    description: Number of cycles LDS (local data store) is stalled by address conflicts. This value is returned on a per-SE
-      (aggregate of values in SIMDs in the SE) basis.
+    description: Number of cycles LDS (local data store) is stalled by address conflicts. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
     properties: []
     definitions:
     - architectures:
@@ -4793,8 +4631,7 @@ rocprofiler-sdk:
       block: SQ
       event: 143
   - name: SQ_LDS_ATOMIC_RETURN
-    description: The number of atomic return cycles in LDS (local data store). This value is returned on a per-SE (aggregate
-      of values in SIMDs in the SE) basis.
+    description: The number of atomic return cycles in LDS (local data store). This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
     properties: []
     definitions:
     - architectures:
@@ -4816,8 +4653,7 @@ rocprofiler-sdk:
       block: SQ
       event: 146
   - name: SQ_LDS_BANK_CONFLICT
-    description: The number of cycles LDS (local data store) is stalled by bank conflicts. This value is returned on a per-SE
-      (aggregate of values in SIMDs in the SE) basis.
+    description: The number of cycles LDS (local data store) is stalled by bank conflicts. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
     properties: []
     definitions:
     - architectures:
@@ -4845,8 +4681,7 @@ rocprofiler-sdk:
       block: SQ
       event: 142
   - name: SQ_LDS_IDX_ACTIVE
-    description: Number of cycles LDS (local data store) is used for indexed (non-direct,non-interpolation) operations. This
-      value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
+    description: Number of cycles LDS (local data store) is used for indexed (non-direct,non-interpolation) operations. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
     properties: []
     definitions:
     - architectures:
@@ -4868,8 +4703,7 @@ rocprofiler-sdk:
       block: SQ
       event: 147
   - name: SQ_LDS_MEM_VIOLATIONS
-    description: Number of threads that have a memory violation in the LDS (local data store). This value is returned on a
-      per-SE (aggregate of values in SIMDs in the SE) basis.
+    description: Number of threads that have a memory violation in the LDS (local data store). This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
     properties: []
     definitions:
     - architectures:
@@ -4891,8 +4725,7 @@ rocprofiler-sdk:
       block: SQ
       event: 145
   - name: SQ_LDS_UNALIGNED_STALL
-    description: Number of cycles LDS (local data store) is stalled processing flat unaligned load/store ops. This value is
-      returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
+    description: Number of cycles LDS (local data store) is stalled processing flat unaligned load/store ops. This value is returned on a per-SE (aggregate of values in SIMDs in the SE) basis.
     properties: []
     definitions:
     - architectures:
@@ -4914,8 +4747,7 @@ rocprofiler-sdk:
       block: SQ
       event: 144
   - name: SQ_LEVEL_WAVES
-    description: Track the number of waves. Set ACCUM_PREV for the next counter to use this. This value is returned on a per-SIMD
-      basis.
+    description: Track the number of waves. Set ACCUM_PREV for the next counter to use this. This value is returned on a per-SIMD basis.
     properties: []
     definitions:
     - architectures:
@@ -4936,8 +4768,7 @@ rocprofiler-sdk:
       block: SQ
       event: 5
   - name: SQ_THREAD_CYCLES_VALU
-    description: 'Number of thread-cycles used to execute VALU operations (similar to INST_CYCLES_VALU but multiplied by #
-      of active threads). (per-simd)'
+    description: 'Number of thread-cycles used to execute VALU operations (similar to INST_CYCLES_VALU but multiplied by # of active threads). (per-simd)'
     properties: []
     definitions:
     - architectures:
@@ -4965,8 +4796,7 @@ rocprofiler-sdk:
       block: SQ
       event: 134
   - name: SQ_VALU_MFMA_BUSY_CYCLES
-    description: Number of cycles the MFMA (Matrixed-Fused-Multiply-Add) ALU is busy. This value is returned on a per-SIMD
-      basis.
+    description: Number of cycles the MFMA (Matrixed-Fused-Multiply-Add) ALU is busy. This value is returned on a per-SIMD basis.
     properties: []
     definitions:
     - architectures:
@@ -5164,11 +4994,7 @@ rocprofiler-sdk:
       block: SQ
       event: 71
   - name: SQ_WAVES
-    description: Count number of waves sent to distributed sequencers (SQs). This value represents the number of waves that
-      are sent to each SQ. This only counts new waves sent since the start of collection (for dispatch profiling this is the
-      timeframe of kernel execution, for agent profiling it is the timeframe between start_context and read counter data).
-      A sum of all SQ_WAVES values will give the total number of waves started by the application during the collection timeframe.
-      Returns one value per-SE (aggregates of SIMD values).
+    description: Count number of waves sent to distributed sequencers (SQs). This value represents the number of waves that are sent to each SQ. This only counts new waves sent since the start of collection (for dispatch profiling this is the timeframe of kernel execution, for agent profiling it is the timeframe between start_context and read counter data). A sum of all SQ_WAVES values will give the total number of waves started by the application during the collection timeframe. Returns one value per-SE (aggregates of SIMD values).
     properties: []
     definitions:
     - architectures:
@@ -5198,12 +5024,7 @@ rocprofiler-sdk:
       block: SQ
       event: 4
   - name: SQ_WAVES_EQ_64
-    description: Count number of waves with exactly 64 active threads sent to SQs. This value represents the number of waves
-      that an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling this is the timeframe
-      of kernel execution, for agent profiling it is the timeframe between start_context and read counter data) with exactly
-      64 threads. A sum of all SQ_WAVES_EQ_64 values will give the total number of waves with 64 threads enqueued during the
-      collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful for checking for
-      wavefront occupancy.
+    description: Count number of waves with exactly 64 active threads sent to SQs. This value represents the number of waves that an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling this is the timeframe of kernel execution, for agent profiling it is the timeframe between start_context and read counter data) with exactly 64 threads. A sum of all SQ_WAVES_EQ_64 values will give the total number of waves with 64 threads enqueued during the collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful for checking for wavefront occupancy.
     properties: []
     definitions:
     - architectures:
@@ -5216,12 +5037,7 @@ rocprofiler-sdk:
       block: SQ
       event: 6
   - name: SQ_WAVES_LT_16
-    description: Count number of waves sent <16 active threads sent to SQs. (per-simd, emulated, global). This value represents
-      the number of waves that an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling
-      this is the timeframe of kernel execution, for agent profiling it is the timeframe between start_context and read counter
-      data) with less than 16 threads. A sum of all SQ_WAVES_LT_16 values will give the total number of waves with 16 threads
-      enqueued during the collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful
-      for checking for wavefront occupancy.
+    description: Count number of waves sent <16 active threads sent to SQs. (per-simd, emulated, global). This value represents the number of waves that an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling this is the timeframe of kernel execution, for agent profiling it is the timeframe between start_context and read counter data) with less than 16 threads. A sum of all SQ_WAVES_LT_16 values will give the total number of waves with 16 threads enqueued during the collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful for checking for wavefront occupancy.
     properties: []
     definitions:
     - architectures:
@@ -5234,12 +5050,7 @@ rocprofiler-sdk:
       block: SQ
       event: 10
   - name: SQ_WAVES_LT_32
-    description: Count number of waves sent <32 active threads sent to SQs. This value represents the number of waves that
-      an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling this is the timeframe of
-      kernel execution, for agent profiling it is the timeframe between start_context and read counter data) with less than
-      32 threads. A sum of all SQ_WAVES_LT_32 values will give the total number of waves with 32 threads enqueued during the
-      collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful for checking for
-      wavefront occupancy.
+    description: Count number of waves sent <32 active threads sent to SQs. This value represents the number of waves that an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling this is the timeframe of kernel execution, for agent profiling it is the timeframe between start_context and read counter data) with less than 32 threads. A sum of all SQ_WAVES_LT_32 values will give the total number of waves with 32 threads enqueued during the collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful for checking for wavefront occupancy.
     properties: []
     definitions:
     - architectures:
@@ -5252,12 +5063,7 @@ rocprofiler-sdk:
       block: SQ
       event: 9
   - name: SQ_WAVES_LT_48
-    description: Count number of waves with <48 active threads sent to SQs. This value represents the number of waves that
-      an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling this is the timeframe of
-      kernel execution, for agent profiling it is the timeframe between start_context and read counter data) with less than
-      48 threads. A sum of all SQ_WAVES_LT_48 values will give the total number of waves with 48 threads enqueued during the
-      collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful for checking for
-      wavefront occupancy.
+    description: Count number of waves with <48 active threads sent to SQs. This value represents the number of waves that an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling this is the timeframe of kernel execution, for agent profiling it is the timeframe between start_context and read counter data) with less than 48 threads. A sum of all SQ_WAVES_LT_48 values will give the total number of waves with 48 threads enqueued during the collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful for checking for wavefront occupancy.
     properties: []
     definitions:
     - architectures:
@@ -5270,12 +5076,7 @@ rocprofiler-sdk:
       block: SQ
       event: 8
   - name: SQ_WAVES_LT_64
-    description: Count number of waves with <64 active threads sent to SQs. This value represents the number of waves that
-      an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling this is the timeframe of
-      kernel execution, for agent profiling it is the timeframe between start_context and read counter data) with less than
-      64 threads. A sum of all SQ_WAVES_LT_64 values will give the total number of waves with 64 threads enqueued during the
-      collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful for checking for
-      wavefront occupancy.
+    description: Count number of waves with <64 active threads sent to SQs. This value represents the number of waves that an each individual SIMD has enqueued during the collection timeframe (for dispatch profiling this is the timeframe of kernel execution, for agent profiling it is the timeframe between start_context and read counter data) with less than 64 threads. A sum of all SQ_WAVES_LT_64 values will give the total number of waves with 64 threads enqueued during the collection timeframe by the application. Returns one value per-SE (aggregates of SIMD values). Useful for checking for wavefront occupancy.
     properties: []
     definitions:
     - architectures:
@@ -5288,11 +5089,7 @@ rocprofiler-sdk:
       block: SQ
       event: 7
   - name: SQ_WAVES_RESTORED
-    description: Count number of context-restored waves sent to SQs. This value represents the number of waves whos current
-      register state has been restored from a register bank during the collection timeframe (for dispatch profiling this is
-      the timeframe of kernel execution, for agent profiling it is the timeframe between start_context and read counter data).
-      Context saving/restoring is a slow operation and should be limited. High values can also indicate that stalling may
-      be taking place (waiting for free register space). Returns one value per-SE (aggregates of SIMD values).
+    description: Count number of context-restored waves sent to SQs. This value represents the number of waves whos current register state has been restored from a register bank during the collection timeframe (for dispatch profiling this is the timeframe of kernel execution, for agent profiling it is the timeframe between start_context and read counter data). Context saving/restoring is a slow operation and should be limited. High values can also indicate that stalling may be taking place (waiting for free register space). Returns one value per-SE (aggregates of SIMD values).
     properties: []
     definitions:
     - architectures:
@@ -5314,11 +5111,7 @@ rocprofiler-sdk:
       block: SQ
       event: 201
   - name: SQ_WAVES_SAVED
-    description: Count number of context-saved waves sent to SQs. This value represents the number of waves whos current register
-      state has been saved to a register bank during the collection timeframe (for dispatch profiling this is the timeframe
-      of kernel execution, for agent profiling it is the timeframe between start_context and read counter data) . Context
-      saving/restoring is a slow operation and should be limited. High values can also indicate that stalling may be taking
-      place (waiting for free register space). Returns one value per-SE (aggregates of SIMD values).
+    description: Count number of context-saved waves sent to SQs. This value represents the number of waves whos current register state has been saved to a register bank during the collection timeframe (for dispatch profiling this is the timeframe of kernel execution, for agent profiling it is the timeframe between start_context and read counter data) . Context saving/restoring is a slow operation and should be limited. High values can also indicate that stalling may be taking place (waiting for free register space). Returns one value per-SE (aggregates of SIMD values).
     properties: []
     definitions:
     - architectures:
@@ -5340,9 +5133,7 @@ rocprofiler-sdk:
       block: SQ
       event: 202
   - name: SQ_WAVES_sum
-    description: Gives the total number of waves currently enqueued by the application during the collection timeframe (for
-      dispatch profiling this is the timeframe of kernel execution, for agent profiling it is the timeframe between start_context
-      and read counter data). See SQ_WAVES for more details.
+    description: Gives the total number of waves currently enqueued by the application during the collection timeframe (for dispatch profiling this is the timeframe of kernel execution, for agent profiling it is the timeframe between start_context and read counter data). See SQ_WAVES for more details.
     properties: []
     definitions:
     - architectures:
@@ -5371,10 +5162,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(SQ_WAVES,sum)
   - name: SQ_WAVE_CYCLES
-    description: The cycles spent executing waves in the CUs. This value is reported per-SE (aggregates of SIMD values) and
-      is nondeterministic. Units are in quad-cycles (4 cycles). Useful for determining how much time is spent executing wave
-      code vs overhead/waiting. Low cycle count relative to actual number of cycles processed by the CU can indicate that
-      the CU is stalling or is overloaded.
+    description: The cycles spent executing waves in the CUs. This value is reported per-SE (aggregates of SIMD values) and is nondeterministic. Units are in quad-cycles (4 cycles). Useful for determining how much time is spent executing wave code vs overhead/waiting. Low cycle count relative to actual number of cycles processed by the CU can indicate that the CU is stalling or is overloaded.
     properties: []
     definitions:
     - architectures:
@@ -5464,7 +5252,7 @@ rocprofiler-sdk:
       block: SQ
       event: 86
   - name: SQ_INSTS_VALU_MFMA_F6F4
-    description: Number of VALU V_MFMA_*_F6F4 instructions.
+    description: 'Sequencer count of VALU MFMA instructions using FP6/FP4 precision (CDNA4/MI355+). FP4 and FP6 deliver up to 4x higher peak throughput versus FP16. Unit: count.'
     properties: []
     definitions:
     - architectures:
@@ -5472,8 +5260,7 @@ rocprofiler-sdk:
       block: SQ
       event: 49
   - name: SQ_INSTS_VALU_MFMA_MOPS_F6F4
-    description: Number of VALU matrix math operations (add or mul) performed dividied by 512, assuming a full EXEC mask,
-      of data type F6 or F4.
+    description: Number of VALU matrix math operations (add or mul) performed dividied by 512, assuming a full EXEC mask, of data type F6 or F4.
     properties: []
     definitions:
     - architectures:
@@ -5617,8 +5404,7 @@ rocprofiler-sdk:
       block: SQ
       event: 16
   - name: SQ_INST_CYCLES_VALU
-    description: Number of cycles needed to execute VALU operations (SIMD cycles), where there is overlapping V_OP32_1 
-     and V_OP32_T instruction, count them separately. 
+    description: Number of cycles needed to execute VALU operations (SIMD cycles), where there is overlapping V_OP32_1 and V_OP32_T instruction, count them separately.
     properties: []
     definitions:
     - architectures:
@@ -5638,14 +5424,14 @@ rocprofiler-sdk:
       block: SQ
       event: 250
   - name: ScaPipeIssueUtil
-    description: 'Unit: percent'
+    description: 'Scalar pipeline issue utilization. Percentage of cycles the scalar ALU (SALU) instruction issue pipeline is actively issuing scalar operations. SALU executes instructions shared across all threads in a wavefront (control flow, pointer arithmetic, etc.). Unit: percent. Value range: 0% (idle) to 100% (fully utilized).'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*reduce(SQ_ACTIVE_INST_SCA,sum)/(reduce(GRBM_GUI_ACTIVE,max)*CU_NUM)
   - name: SmemLatency
-    description: 'Unit: cycles'
+    description: 'Scalar memory (SMEM) access latency. Average cycles for scalar memory operations to complete. SMEM transfers data between scalar registers (SGPRs) and memory through the scalar L1 data cache, typically used for read-only uniform accesses like kernel arguments. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -5656,7 +5442,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(accumulate(SQ_INST_LEVEL_SMEM, HIGH_RES),sum)/reduce(SQ_INSTS_SMEM_NORM,sum)
   - name: SpiUtil
-    description: 'Unit: percent'
+    description: 'Shader Processor Input (SPI) utilization percentage. Indicates how busy the SPI is distributing work to compute units. The SPI accumulates work items and sends them in waves (32 or 64 work items) to CUs. Unit: percent. Value range: 0% (idle) to 100% (fully utilized).'
     properties: []
     definitions:
     - architectures:
@@ -5830,7 +5616,7 @@ rocprofiler-sdk:
       - gfx1201
       expression: reduce(TA_BUFFER_LOAD_WAVEFRONTS,sum)
   - name: TA_BUFFER_READ_WAVEFRONTS
-    description: Number of buffer read wavefronts processed by TA.
+    description: 'Texture Addressing (TA) unit wavefronts performing buffer read operations. TA calculates effective addresses and coalesces memory requests. Unit: wavefronts.'
     properties: []
     definitions:
     - architectures:
@@ -5885,7 +5671,7 @@ rocprofiler-sdk:
       - gfx1201
       expression: reduce(TA_BUFFER_STORE_WAVEFRONTS,sum)
   - name: TA_BUFFER_TOTAL_CYCLES
-    description: Number of buffer cycles issued to TC.
+    description: 'Texture Addressing (TA) unit total cycles processing buffer operations. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -5913,7 +5699,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TA_BUFFER_TOTAL_CYCLES,sum)
   - name: TA_BUFFER_WAVEFRONTS
-    description: Number of buffer wavefronts processed by TA.
+    description: 'Texture Addressing (TA) unit wavefronts performing buffer operations (reads/writes). Unit: wavefronts.'
     properties: []
     definitions:
     - architectures:
@@ -5969,7 +5755,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TA_BUFFER_WRITE_WAVEFRONTS,sum)
   - name: TA_BUSY_avr
-    description: TA block is busy. Average over TA instances.
+    description: 'Texture Addressing (TA) unit average busy cycles across instances. TA is the address calculation and coalescing unit in the vL1D cache pipeline. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -5998,7 +5784,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TA_TA_BUSY,avr)
   - name: TA_BUSY_max
-    description: TA block is busy. Max over TA instances.
+    description: 'Texture Addressing (TA) unit maximum busy cycles across instances. Useful for identifying hotspot TA units. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -6027,7 +5813,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TA_TA_BUSY,max)
   - name: TA_BUSY_min
-    description: TA block is busy. Min over TA instances.
+    description: 'Texture Addressing (TA) unit minimum busy cycles across instances. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -6135,7 +5921,7 @@ rocprofiler-sdk:
       - gfx1032
       expression: reduce(TA_FLAT_LOAD_WAVEFRONTS,sum)
   - name: TA_FLAT_READ_WAVEFRONTS
-    description: Number of flat opcode reads processed by the TA.
+    description: 'Texture Addressing (TA) unit wavefronts performing flat address space read operations. Flat addressing can access global, private, or group memory. Unit: wavefronts.'
     properties: []
     definitions:
     - architectures:
@@ -6220,7 +6006,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TA_FLAT_WAVEFRONTS,sum)
   - name: TA_FLAT_WRITE_WAVEFRONTS
-    description: Number of flat opcode writes processed by the TA.
+    description: 'Texture Addressing (TA) unit wavefronts performing flat address space write operations. Unit: wavefronts.'
     properties: []
     definitions:
     - architectures:
@@ -6299,7 +6085,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TA_TA_BUSY,sum)
   - name: TA_TOTAL_WAVEFRONTS
-    description: Total number of wavefronts processed by TA.
+    description: 'Texture Addressing (TA) unit total wavefronts processed across all operation types. Unit: wavefronts.'
     properties: []
     definitions:
     - architectures:
@@ -6422,7 +6208,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCA_BUSY,sum)
   - name: TCA_CYCLE
-    description: Number of cycles. Not windowable.
+    description: 'Texture Cache Arbiter (TCA) total cycles. TCA is part of the vL1D cache subsystem that arbitrates cache requests. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -6502,7 +6288,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_ALL_TC_OP_WB_WRITEBACK,sum)
   - name: TCC_ATOMIC
-    description: Number of atomic requests of all types.
+    description: 'Texture Cache per Channel (TCC/L2) atomic operations. TCC is the L2 cache and coherence point shared by all CUs. Atomics are treated as write operations at this level. Unit: count.'
     properties: []
     definitions:
     - architectures:
@@ -6543,7 +6329,7 @@ rocprofiler-sdk:
       block: TCC
       event: 2
   - name: TCC_BUSY_avr
-    description: TCC_BUSY avr over all memory channels.
+    description: 'Texture Cache per Channel (TCC/L2) average busy cycles across all L2 cache channels. CDNA accelerators have 32 L2 channels with 256B address interleaving. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -6595,7 +6381,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_CC_REQ,sum)
   - name: TCC_CYCLE
-    description: Number of cycles. Not windowable.
+    description: 'Texture Cache per Channel (TCC/L2) total cycles. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -6635,8 +6421,7 @@ rocprofiler-sdk:
       block: TCC
       event: 40
   - name: TCC_EA0_ATOMIC_LEVEL
-    description: The sum of the number of EA atomics in flight. This is primarily meant for measure average EA atomic latency.
-      Average atomic latency = TCC_PERF_SEL_EA_WRREQ_ATOMIC_LEVEL/TCC_PERF_SEL_EA_WRREQ_ATOMIC.
+    description: The sum of the number of EA atomics in flight. This is primarily meant for measure average EA atomic latency. Average atomic latency = TCC_PERF_SEL_EA_WRREQ_ATOMIC_LEVEL/TCC_PERF_SEL_EA_WRREQ_ATOMIC.
     properties: []
     definitions:
     - architectures:
@@ -6651,8 +6436,7 @@ rocprofiler-sdk:
       block: TCC
       event: 41
   - name: TCC_EA0_ATOMIC_LEVEL_sum
-    description: The sum of the number of EA atomics in flight. This is primarily meant for measure average EA atomic latency.
-      Average atomic latency = TCC_PERF_SEL_EA_WRREQ_ATOMIC_LEVEL/TCC_PERF_SEL_EA_WRREQ_ATOMIC. Sum over TCC instances.
+    description: The sum of the number of EA atomics in flight. This is primarily meant for measure average EA atomic latency. Average atomic latency = TCC_PERF_SEL_EA_WRREQ_ATOMIC_LEVEL/TCC_PERF_SEL_EA_WRREQ_ATOMIC. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -6663,8 +6447,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_EA0_ATOMIC_LEVEL,sum)
   - name: TCC_EA0_ATOMIC_sum
-    description: Number of transactions going over the TC_EA_wrreq interface that are actually atomic requests. Sum over TCC
-      instances.
+    description: Number of transactions going over the TC_EA_wrreq interface that are actually atomic requests. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -6731,8 +6514,7 @@ rocprofiler-sdk:
       block: TCC
       event: 108
   - name: TCC_EA0_RDREQ_DRAM_CREDIT_STALL
-    description: Number of cycles there was a stall because the read request interface was out of DRAM credits. Stalls occur
-      regardless of whether a read needed to be performed or not.
+    description: Number of cycles there was a stall because the read request interface was out of DRAM credits. Stalls occur regardless of whether a read needed to be performed or not.
     properties: []
     definitions:
     - architectures:
@@ -6747,8 +6529,7 @@ rocprofiler-sdk:
       block: TCC
       event: 49
   - name: TCC_EA0_RDREQ_DRAM_CREDIT_STALL_sum
-    description: Number of cycles there was a stall because the read request interface was out of DRAM credits. Stalls occur
-      regardless of whether a read needed to be performed or not. Sum over TCC instances.
+    description: Number of cycles there was a stall because the read request interface was out of DRAM credits. Stalls occur regardless of whether a read needed to be performed or not. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -6770,8 +6551,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_EA0_RDREQ_DRAM,sum)
   - name: TCC_EA0_RDREQ_GMI_CREDIT_STALL
-    description: Number of cycles there was a stall because the read request interface was out of GMI credits. Stalls occur
-      regardless of whether a read needed to be performed or not.
+    description: Number of cycles there was a stall because the read request interface was out of GMI credits. Stalls occur regardless of whether a read needed to be performed or not.
     properties: []
     definitions:
     - architectures:
@@ -6786,8 +6566,7 @@ rocprofiler-sdk:
       block: TCC
       event: 48
   - name: TCC_EA0_RDREQ_GMI_CREDIT_STALL_sum
-    description: Number of cycles there was a stall because the read request interface was out of GMI credits. Stalls occur
-      regardless of whether a read needed to be performed or not. Sum over TCC instances.
+    description: Number of cycles there was a stall because the read request interface was out of GMI credits. Stalls occur regardless of whether a read needed to be performed or not. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -6798,8 +6577,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_EA0_RDREQ_GMI_CREDIT_STALL,sum)
   - name: TCC_EA0_RDREQ_IO_CREDIT_STALL
-    description: Number of cycles there was a stall because the read request interface was out of IO credits. Stalls occur
-      regardless of whether a read needed to be performed or not.
+    description: Number of cycles there was a stall because the read request interface was out of IO credits. Stalls occur regardless of whether a read needed to be performed or not.
     properties: []
     definitions:
     - architectures:
@@ -6814,8 +6592,7 @@ rocprofiler-sdk:
       block: TCC
       event: 47
   - name: TCC_EA0_RDREQ_IO_CREDIT_STALL_sum
-    description: Number of cycles there was a stall because the read request interface was out of IO credits. Stalls occur
-      regardless of whether a read needed to be performed or not. Sum over TCC instances.
+    description: Number of cycles there was a stall because the read request interface was out of IO credits. Stalls occur regardless of whether a read needed to be performed or not. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -6826,8 +6603,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_EA0_RDREQ_IO_CREDIT_STALL,sum)
   - name: TCC_EA0_RDREQ_LEVEL
-    description: The sum of the number of TCC/EA read requests in flight. This is primarily meant for measure average EA read
-      latency. Average read latency = TCC_PERF_SEL_EA_RDREQ_LEVEL/TCC_PERF_SEL_EA_RDREQ.
+    description: The sum of the number of TCC/EA read requests in flight. This is primarily meant for measure average EA read latency. Average read latency = TCC_PERF_SEL_EA_RDREQ_LEVEL/TCC_PERF_SEL_EA_RDREQ.
     properties: []
     definitions:
     - architectures:
@@ -6842,8 +6618,7 @@ rocprofiler-sdk:
       block: TCC
       event: 50
   - name: TCC_EA0_RDREQ_LEVEL_sum
-    description: The sum of the number of TCC/EA read requests in flight. This is primarily meant for measure average EA read
-      latency. Average read latency = TCC_PERF_SEL_EA_RDREQ_LEVEL/TCC_PERF_SEL_EA_RDREQ. Sum over TCC instances.
+    description: The sum of the number of TCC/EA read requests in flight. This is primarily meant for measure average EA read latency. Average read latency = TCC_PERF_SEL_EA_RDREQ_LEVEL/TCC_PERF_SEL_EA_RDREQ. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -6879,8 +6654,7 @@ rocprofiler-sdk:
       block: TCC
       event: 46
   - name: TCC_EA0_RD_UNCACHED_32B_sum
-    description: Number of 32-byte TCC/EA read due to uncached traffic. A 64-byte request will be counted as 2 Sum over TCC
-      instances.
+    description: Number of 32-byte TCC/EA read due to uncached traffic. A 64-byte request will be counted as 2 Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -6891,8 +6665,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_EA0_RD_UNCACHED_32B,sum)
   - name: TCC_EA0_WRREQ
-    description: Number of transactions (either 32-byte or 64-byte) going over the TC_EA_wrreq interface. Atomics may travel
-      over the same interface and are generally classified as write requests. This does not include probe commands.
+    description: Number of transactions (either 32-byte or 64-byte) going over the TC_EA_wrreq interface. Atomics may travel over the same interface and are generally classified as write requests. This does not include probe commands.
     properties: []
     definitions:
     - architectures:
@@ -6920,8 +6693,7 @@ rocprofiler-sdk:
       block: TCC
       event: 31
   - name: TCC_EA0_WRREQ_64B_sum
-    description: Number of 64-byte transactions going (64-byte write or CMPSWAP) over the TC_EA_wrreq interface. Sum over
-      TCC instances.
+    description: Number of 64-byte transactions going (64-byte write or CMPSWAP) over the TC_EA_wrreq interface. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -6961,8 +6733,7 @@ rocprofiler-sdk:
       block: TCC
       event: 37
   - name: TCC_EA0_WRREQ_DRAM_CREDIT_STALL_sum
-    description: Number of cycles a EA write request was stalled because the interface was out of DRAM credits. Sum over TCC
-      instances.
+    description: Number of cycles a EA write request was stalled because the interface was out of DRAM credits. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -6999,8 +6770,7 @@ rocprofiler-sdk:
       block: TCC
       event: 36
   - name: TCC_EA0_WRREQ_GMI_CREDIT_STALL_sum
-    description: Number of cycles a EA write request was stalled because the interface was out of GMI credits. Sum over TCC
-      instances.
+    description: Number of cycles a EA write request was stalled because the interface was out of GMI credits. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -7026,8 +6796,7 @@ rocprofiler-sdk:
       block: TCC
       event: 35
   - name: TCC_EA0_WRREQ_IO_CREDIT_STALL_sum
-    description: Number of cycles a EA write request was stalled because the interface was out of IO credits. Sum over TCC
-      instances.
+    description: Number of cycles a EA write request was stalled because the interface was out of IO credits. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -7038,8 +6807,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_EA0_WRREQ_IO_CREDIT_STALL,sum)
   - name: TCC_EA0_WRREQ_LEVEL
-    description: The sum of the number of EA write requests in flight. This is primarily meant for measure average EA write
-      latency. Average write latency = TCC_PERF_SEL_EA_WRREQ_LEVEL/TCC_PERF_SEL_EA_WRREQ.
+    description: The sum of the number of EA write requests in flight. This is primarily meant for measure average EA write latency. Average write latency = TCC_PERF_SEL_EA_WRREQ_LEVEL/TCC_PERF_SEL_EA_WRREQ.
     properties: []
     definitions:
     - architectures:
@@ -7054,8 +6822,7 @@ rocprofiler-sdk:
       block: TCC
       event: 39
   - name: TCC_EA0_WRREQ_LEVEL_sum
-    description: The sum of the number of EA write requests in flight. This is primarily meant for measure average EA write
-      latency. Average write latency = TCC_PERF_SEL_EA_WRREQ_LEVEL/TCC_PERF_SEL_EA_WRREQ. Sum over TCC instances.
+    description: The sum of the number of EA write requests in flight. This is primarily meant for measure average EA write latency. Average write latency = TCC_PERF_SEL_EA_WRREQ_LEVEL/TCC_PERF_SEL_EA_WRREQ. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -7080,7 +6847,7 @@ rocprofiler-sdk:
       block: TCC
       event: 32
   - name: TCC_EA0_WRREQ_STALL
-    description: Number of cycles a write request was stalled.
+    description: 'TCC (L2 cache) write requests to Efficiency Arbiter 0 are stalled. Indicates back-pressure from Infinity Fabric/memory preventing L2 writebacks. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -7106,9 +6873,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_EA0_WRREQ_STALL,sum)
   - name: TCC_EA0_WRREQ_sum
-    description: Number of transactions (either 32-byte or 64-byte) going over the TC_EA_wrreq interface. Atomics may travel
-      over the same interface and are generally classified as write requests. This does not include probe commands. Sum over
-      TCC instances.
+    description: Number of transactions (either 32-byte or 64-byte) going over the TC_EA_wrreq interface. Atomics may travel over the same interface and are generally classified as write requests. This does not include probe commands. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -7118,8 +6883,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_EA0_WRREQ,sum)
   - name: TCC_EA0_WR_UNCACHED_32B
-    description: Number of 32-byte write/atomic going over the TC_EA_wrreq interface due to uncached traffic. Note that CC
-      mtypes can produce uncached requests, and those are included in this. A 64-byte request will be counted as 2
+    description: Number of 32-byte write/atomic going over the TC_EA_wrreq interface due to uncached traffic. Note that CC mtypes can produce uncached requests, and those are included in this. A 64-byte request will be counted as 2
     properties: []
     definitions:
     - architectures:
@@ -7134,9 +6898,7 @@ rocprofiler-sdk:
       block: TCC
       event: 33
   - name: TCC_EA0_WR_UNCACHED_32B_sum
-    description: Number of 32-byte write/atomic going over the TC_EA_wrreq interface due to uncached traffic. Note that CC
-      mtypes can produce uncached requests, and those are included in this. A 64-byte request will be counted as 2. Sum over
-      TCC instances.
+    description: Number of 32-byte write/atomic going over the TC_EA_wrreq interface due to uncached traffic. Note that CC mtypes can produce uncached requests, and those are included in this. A 64-byte request will be counted as 2. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -7177,8 +6939,7 @@ rocprofiler-sdk:
       - gfx906
       expression: reduce(TCC_EA1_RDREQ,sum)
   - name: TCC_EA1_WRREQ
-    description: Number of transactions (either 32-byte or 64-byte) going over the TC_EA_wrreq interface. Atomics may travel
-      over the same interface and are generally classified as write requests. This does not include probe commands.
+    description: Number of transactions (either 32-byte or 64-byte) going over the TC_EA_wrreq interface. Atomics may travel over the same interface and are generally classified as write requests. This does not include probe commands.
     properties: []
     definitions:
     - architectures:
@@ -7194,15 +6955,14 @@ rocprofiler-sdk:
       block: TCC
       event: 257
   - name: TCC_EA1_WRREQ_64B_sum
-    description: Number of 64-byte transactions going (64-byte write or CMPSWAP) over the TC_EA_wrreq interface. Sum over
-      TCC EA1s.
+    description: Number of 64-byte transactions going (64-byte write or CMPSWAP) over the TC_EA_wrreq interface. Sum over TCC EA1s.
     properties: []
     definitions:
     - architectures:
       - gfx906
       expression: reduce(TCC_EA1_WRREQ_64B,sum)
   - name: TCC_EA1_WRREQ_STALL
-    description: Number of cycles a write request was stalled.
+    description: 'TCC (L2 cache) write requests to Efficiency Arbiter 1 are stalled. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -7225,8 +6985,7 @@ rocprofiler-sdk:
       block: TCC
       event: 36
   - name: TCC_EA_ATOMIC_LEVEL
-    description: The sum of the number of EA atomics in flight. This is primarily meant for measure average EA atomic latency.
-      Average atomic latency = TCC_PERF_SEL_EA_WRREQ_ATOMIC_LEVEL/TCC_PERF_SEL_EA_WRREQ_ATOMIC.
+    description: The sum of the number of EA atomics in flight. This is primarily meant for measure average EA atomic latency. Average atomic latency = TCC_PERF_SEL_EA_WRREQ_ATOMIC_LEVEL/TCC_PERF_SEL_EA_WRREQ_ATOMIC.
     properties: []
     definitions:
     - architectures:
@@ -7234,16 +6993,14 @@ rocprofiler-sdk:
       block: TCC
       event: 37
   - name: TCC_EA_ATOMIC_LEVEL_sum
-    description: The sum of the number of EA atomics in flight. This is primarily meant for measure average EA atomic latency.
-      Average atomic latency = TCC_PERF_SEL_EA_WRREQ_ATOMIC_LEVEL/TCC_PERF_SEL_EA_WRREQ_ATOMIC. Sum over TCC instances.
+    description: The sum of the number of EA atomics in flight. This is primarily meant for measure average EA atomic latency. Average atomic latency = TCC_PERF_SEL_EA_WRREQ_ATOMIC_LEVEL/TCC_PERF_SEL_EA_WRREQ_ATOMIC. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: reduce(TCC_EA_ATOMIC_LEVEL,sum)
   - name: TCC_EA_ATOMIC_sum
-    description: Number of transactions going over the TC_EA_wrreq interface that are actually atomic requests. Sum over TCC
-      instances.
+    description: Number of transactions going over the TC_EA_wrreq interface that are actually atomic requests. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -7299,8 +7056,7 @@ rocprofiler-sdk:
       block: TCC
       event: 102
   - name: TCC_EA_RDREQ_DRAM_CREDIT_STALL
-    description: Number of cycles there was a stall because the read request interface was out of DRAM credits. Stalls occur
-      regardless of whether a read needed to be performed or not.
+    description: Number of cycles there was a stall because the read request interface was out of DRAM credits. Stalls occur regardless of whether a read needed to be performed or not.
     properties: []
     definitions:
     - architectures:
@@ -7308,8 +7064,7 @@ rocprofiler-sdk:
       block: TCC
       event: 43
   - name: TCC_EA_RDREQ_DRAM_CREDIT_STALL_sum
-    description: Number of cycles there was a stall because the read request interface was out of DRAM credits. Stalls occur
-      regardless of whether a read needed to be performed or not. Sum over TCC instances.
+    description: Number of cycles there was a stall because the read request interface was out of DRAM credits. Stalls occur regardless of whether a read needed to be performed or not. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -7323,8 +7078,7 @@ rocprofiler-sdk:
       - gfx90a
       expression: reduce(TCC_EA_RDREQ_DRAM,sum)
   - name: TCC_EA_RDREQ_GMI_CREDIT_STALL
-    description: Number of cycles there was a stall because the read request interface was out of GMI credits. Stalls occur
-      regardless of whether a read needed to be performed or not.
+    description: Number of cycles there was a stall because the read request interface was out of GMI credits. Stalls occur regardless of whether a read needed to be performed or not.
     properties: []
     definitions:
     - architectures:
@@ -7332,16 +7086,14 @@ rocprofiler-sdk:
       block: TCC
       event: 42
   - name: TCC_EA_RDREQ_GMI_CREDIT_STALL_sum
-    description: Number of cycles there was a stall because the read request interface was out of GMI credits. Stalls occur
-      regardless of whether a read needed to be performed or not. Sum over TCC instances.
+    description: Number of cycles there was a stall because the read request interface was out of GMI credits. Stalls occur regardless of whether a read needed to be performed or not. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: reduce(TCC_EA_RDREQ_GMI_CREDIT_STALL,sum)
   - name: TCC_EA_RDREQ_IO_CREDIT_STALL
-    description: Number of cycles there was a stall because the read request interface was out of IO credits. Stalls occur
-      regardless of whether a read needed to be performed or not.
+    description: Number of cycles there was a stall because the read request interface was out of IO credits. Stalls occur regardless of whether a read needed to be performed or not.
     properties: []
     definitions:
     - architectures:
@@ -7349,16 +7101,14 @@ rocprofiler-sdk:
       block: TCC
       event: 41
   - name: TCC_EA_RDREQ_IO_CREDIT_STALL_sum
-    description: Number of cycles there was a stall because the read request interface was out of IO credits. Stalls occur
-      regardless of whether a read needed to be performed or not. Sum over TCC instances.
+    description: Number of cycles there was a stall because the read request interface was out of IO credits. Stalls occur regardless of whether a read needed to be performed or not. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: reduce(TCC_EA_RDREQ_IO_CREDIT_STALL,sum)
   - name: TCC_EA_RDREQ_LEVEL
-    description: The sum of the number of TCC/EA read requests in flight. This is primarily meant for measure average EA read
-      latency. Average read latency = TCC_PERF_SEL_EA_RDREQ_LEVEL/TCC_PERF_SEL_EA_RDREQ.
+    description: The sum of the number of TCC/EA read requests in flight. This is primarily meant for measure average EA read latency. Average read latency = TCC_PERF_SEL_EA_RDREQ_LEVEL/TCC_PERF_SEL_EA_RDREQ.
     properties: []
     definitions:
     - architectures:
@@ -7366,8 +7116,7 @@ rocprofiler-sdk:
       block: TCC
       event: 44
   - name: TCC_EA_RDREQ_LEVEL_sum
-    description: The sum of the number of TCC/EA read requests in flight. This is primarily meant for measure average EA read
-      latency. Average read latency = TCC_PERF_SEL_EA_RDREQ_LEVEL/TCC_PERF_SEL_EA_RDREQ. Sum over TCC instances.
+    description: The sum of the number of TCC/EA read requests in flight. This is primarily meant for measure average EA read latency. Average read latency = TCC_PERF_SEL_EA_RDREQ_LEVEL/TCC_PERF_SEL_EA_RDREQ. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -7393,16 +7142,14 @@ rocprofiler-sdk:
       block: TCC
       event: 40
   - name: TCC_EA_RD_UNCACHED_32B_sum
-    description: Number of 32-byte TCC/EA read due to uncached traffic. A 64-byte request will be counted as 2 Sum over TCC
-      instances.
+    description: Number of 32-byte TCC/EA read due to uncached traffic. A 64-byte request will be counted as 2 Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: reduce(TCC_EA_RD_UNCACHED_32B,sum)
   - name: TCC_EA_WRREQ
-    description: Number of transactions (either 32-byte or 64-byte) going over the TC_EA_wrreq interface. Atomics may travel
-      over the same interface and are generally classified as write requests. This does not include probe commands.
+    description: Number of transactions (either 32-byte or 64-byte) going over the TC_EA_wrreq interface. Atomics may travel over the same interface and are generally classified as write requests. This does not include probe commands.
     properties: []
     definitions:
     - architectures:
@@ -7432,8 +7179,7 @@ rocprofiler-sdk:
       block: TCC
       event: 27
   - name: TCC_EA_WRREQ_64B_sum
-    description: Number of 64-byte transactions going (64-byte write or CMPSWAP) over the TC_EA_wrreq interface. Sum over
-      TCC instances.
+    description: Number of 64-byte transactions going (64-byte write or CMPSWAP) over the TC_EA_wrreq interface. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -7460,8 +7206,7 @@ rocprofiler-sdk:
       block: TCC
       event: 33
   - name: TCC_EA_WRREQ_DRAM_CREDIT_STALL_sum
-    description: Number of cycles a EA write request was stalled because the interface was out of DRAM credits. Sum over TCC
-      instances.
+    description: Number of cycles a EA write request was stalled because the interface was out of DRAM credits. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -7483,8 +7228,7 @@ rocprofiler-sdk:
       block: TCC
       event: 32
   - name: TCC_EA_WRREQ_GMI_CREDIT_STALL_sum
-    description: Number of cycles a EA write request was stalled because the interface was out of GMI credits. Sum over TCC
-      instances.
+    description: Number of cycles a EA write request was stalled because the interface was out of GMI credits. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -7499,16 +7243,14 @@ rocprofiler-sdk:
       block: TCC
       event: 31
   - name: TCC_EA_WRREQ_IO_CREDIT_STALL_sum
-    description: Number of cycles a EA write request was stalled because the interface was out of IO credits. Sum over TCC
-      instances.
+    description: Number of cycles a EA write request was stalled because the interface was out of IO credits. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: reduce(TCC_EA_WRREQ_IO_CREDIT_STALL,sum)
   - name: TCC_EA_WRREQ_LEVEL
-    description: The sum of the number of EA write requests in flight. This is primarily meant for measure average EA write
-      latency. Average write latency = TCC_PERF_SEL_EA_WRREQ_LEVEL/TCC_PERF_SEL_EA_WRREQ.
+    description: The sum of the number of EA write requests in flight. This is primarily meant for measure average EA write latency. Average write latency = TCC_PERF_SEL_EA_WRREQ_LEVEL/TCC_PERF_SEL_EA_WRREQ.
     properties: []
     definitions:
     - architectures:
@@ -7516,15 +7258,14 @@ rocprofiler-sdk:
       block: TCC
       event: 35
   - name: TCC_EA_WRREQ_LEVEL_sum
-    description: The sum of the number of EA write requests in flight. This is primarily meant for measure average EA write
-      latency. Average write latency = TCC_PERF_SEL_EA_WRREQ_LEVEL/TCC_PERF_SEL_EA_WRREQ. Sum over TCC instances.
+    description: The sum of the number of EA write requests in flight. This is primarily meant for measure average EA write latency. Average write latency = TCC_PERF_SEL_EA_WRREQ_LEVEL/TCC_PERF_SEL_EA_WRREQ. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: reduce(TCC_EA_WRREQ_LEVEL,sum)
   - name: TCC_EA_WRREQ_STALL
-    description: Number of cycles a write request was stalled.
+    description: 'TCC (L2 cache) write requests to Efficiency Arbiter are stalled across all EA interfaces. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -7557,8 +7298,7 @@ rocprofiler-sdk:
       - gfx90a
       expression: reduce(TCC_EA_WRREQ,sum)
   - name: TCC_EA_WR_UNCACHED_32B
-    description: Number of 32-byte write/atomic going over the TC_EA_wrreq interface due to uncached traffic. Note that CC
-      mtypes can produce uncached requests, and those are included in this. A 64-byte request will be counted as 2
+    description: Number of 32-byte write/atomic going over the TC_EA_wrreq interface due to uncached traffic. Note that CC mtypes can produce uncached requests, and those are included in this. A 64-byte request will be counted as 2
     properties: []
     definitions:
     - architectures:
@@ -7566,16 +7306,14 @@ rocprofiler-sdk:
       block: TCC
       event: 29
   - name: TCC_EA_WR_UNCACHED_32B_sum
-    description: Number of 32-byte write/atomic going over the TC_EA_wrreq interface due to uncached traffic. Note that CC
-      mtypes can produce uncached requests, and those are included in this. A 64-byte request will be counted as 2. Sum over
-      TCC instances.
+    description: Number of 32-byte write/atomic going over the TC_EA_wrreq interface due to uncached traffic. Note that CC mtypes can produce uncached requests, and those are included in this. A 64-byte request will be counted as 2. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: reduce(TCC_EA_WR_UNCACHED_32B,sum)
   - name: TCC_HIT
-    description: Number of cache hits.
+    description: 'Texture Cache per Channel (TCC/L2) cache hit count. Uses hit-on-miss approach: if a request arrives for a pending cache line, it counts as a hit. Consider latency metrics when evaluating hit rate. Unit: count. Higher values indicate better cache utilization.'
     properties: []
     definitions:
     - architectures:
@@ -7597,7 +7335,7 @@ rocprofiler-sdk:
       block: TCC
       event: 21
   - name: TCC_HIT_sum
-    description: Number of cache hits. Sum over TCC instances.
+    description: 'Sum of TCC (L2 cache) hits across all L2 cache channels. Unit: count. Higher values indicate better cache utilization.'
     properties: []
     definitions:
     - architectures:
@@ -7626,7 +7364,7 @@ rocprofiler-sdk:
       block: TCC
       event: 15
   - name: TCC_MISS
-    description: Number of cache misses. UC reads count as misses.
+    description: 'Texture Cache per Channel (TCC/L2) cache miss count. Misses are passed to Infinity Fabric to route to appropriate memory location. Unit: count. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -7747,7 +7485,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_NORMAL_WRITEBACK,sum)
   - name: TCC_PROBE
-    description: Number of probe requests. Not windowable.
+    description: 'TCC (L2 cache) coherence probe operations. Probes maintain cache coherence across the memory hierarchy. Unit: count.'
     properties: []
     definitions:
     - architectures:
@@ -7833,8 +7571,7 @@ rocprofiler-sdk:
       block: TCC
       event: 16
   - name: TCC_READ_sum
-    description: Number of read requests. Compressed reads are included in this, but metadata reads are not included. Sum
-      over TCC instances.
+    description: Number of read requests. Compressed reads are included in this, but metadata reads are not included. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -7846,8 +7583,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_READ,sum)
   - name: TCC_REQ
-    description: Number of requests of all types. This is measured at the tag block. This may be more than the number of requests
-      arriving at the TCC, but it is a good indication of the total amount of work that needs to be performed.
+    description: Number of requests of all types. This is measured at the tag block. This may be more than the number of requests arriving at the TCC, but it is a good indication of the total amount of work that needs to be performed.
     properties: []
     definitions:
     - architectures:
@@ -7863,9 +7599,7 @@ rocprofiler-sdk:
       block: TCC
       event: 6
   - name: TCC_REQ_sum
-    description: Number of requests of all types. This is measured at the tag block. This may be more than the number of requests
-      arriving at the TCC, but it is a good indication of the total amount of work that needs to be performed. Sum over TCC
-      instances.
+    description: Number of requests of all types. This is measured at the tag block. This may be more than the number of requests arriving at the TCC, but it is a good indication of the total amount of work that needs to be performed. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -7933,9 +7667,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_STREAMING_REQ,sum)
   - name: TCC_TAG_STALL
-    description: Number of cycles the normal request pipeline in the tag was stalled for any reason. Normally, stalls of this
-      nature are measured exactly from one point the pipeline, but that is not the case for this counter. Probes can stall
-      the pipeline at a variety of places, and there is no single point that can reasonably measure the total stalls accurately.
+    description: Number of cycles the normal request pipeline in the tag was stalled for any reason. Normally, stalls of this nature are measured exactly from one point the pipeline, but that is not the case for this counter. Probes can stall the pipeline at a variety of places, and there is no single point that can reasonably measure the total stalls accurately.
     properties: []
     definitions:
     - architectures:
@@ -7963,8 +7695,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_TAG_STALL,sum)
   - name: TCC_TOO_MANY_EA_WRREQS_STALL
-    description: Number of cycles the TCC could not send a EA write request because it already reached its maximum number
-      of pending EA write requests.
+    description: Number of cycles the TCC could not send a EA write request because it already reached its maximum number of pending EA write requests.
     properties: []
     definitions:
     - architectures:
@@ -7980,8 +7711,7 @@ rocprofiler-sdk:
       block: TCC
       event: 38
   - name: TCC_TOO_MANY_EA_WRREQS_STALL_sum
-    description: Number of cycles the TCC could not send a EA write request because it already reached its maximum number
-      of pending EA write requests. Sum over TCC instances.
+    description: Number of cycles the TCC could not send a EA write request because it already reached its maximum number of pending EA write requests. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -8021,7 +7751,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_UC_REQ,sum)
   - name: TCC_WRITE
-    description: Number of write requests.
+    description: 'TCC (L2 cache) write operations (including atomics). Unit: count.'
     properties: []
     definitions:
     - architectures:
@@ -8037,8 +7767,7 @@ rocprofiler-sdk:
       block: TCC
       event: 17
   - name: TCC_WRITEBACK
-    description: Number of lines written back to main memory. This includes writebacks of dirty lines and uncached write/atomic
-      requests.
+    description: Number of lines written back to main memory. This includes writebacks of dirty lines and uncached write/atomic requests.
     properties: []
     definitions:
     - architectures:
@@ -8054,8 +7783,7 @@ rocprofiler-sdk:
       block: TCC
       event: 26
   - name: TCC_WRITEBACK_sum
-    description: Number of lines written back to main memory. This includes writebacks of dirty lines and uncached write/atomic
-      requests. Sum over TCC instances.
+    description: Number of lines written back to main memory. This includes writebacks of dirty lines and uncached write/atomic requests. Sum over TCC instances.
     properties: []
     definitions:
     - architectures:
@@ -8067,7 +7795,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_WRITEBACK,sum)
   - name: TCC_WRITE_sum
-    description: Number of write requests. Sum over TCC instances.
+    description: 'Sum of TCC (L2 cache) write operations across all L2 cache channels. Unit: count.'
     properties: []
     definitions:
     - architectures:
@@ -8103,7 +7831,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_EA0_WRREQ_STALL,max)
   - name: TCC_BUBBLE
-    description: Number of 128-byte read requests sent to EA.
+    description: 'TCC (L2 cache) bubble cycles when no operations can be processed. Bubbles indicate pipeline stalls or inefficiencies. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -8131,8 +7859,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_BUBBLE,sum)
   - name: TCC_EA0_RDREQ_DRAM_32B
-    description: Number of 32-byte TCC/EA read requests due to DRAM traffic, 1 64-byte request will be counted to 2, 128-byte
-      as 4.
+    description: Number of 32-byte TCC/EA read requests due to DRAM traffic, 1 64-byte request will be counted to 2, 128-byte as 4.
     properties: []
     definitions:
     - architectures:
@@ -8140,8 +7867,7 @@ rocprofiler-sdk:
       block: TCC
       event: 112
   - name: TCC_EA0_RDREQ_GMI_32B
-    description: Number of 32-byte TCC/EA read requests due to GMI traffic, 1 64-byte request will be counted to 2, 128-byte
-      as 4.
+    description: Number of 32-byte TCC/EA read requests due to GMI traffic, 1 64-byte request will be counted to 2, 128-byte as 4.
     properties: []
     definitions:
     - architectures:
@@ -8149,8 +7875,7 @@ rocprofiler-sdk:
       block: TCC
       event: 113
   - name: TCC_EA0_RDREQ_IO_32B
-    description: Number of 32-byte TCC/EA read requests due to IO traffic, 1 64-byte request will be counted to 2, 128-byte
-      as 4.
+    description: Number of 32-byte TCC/EA read requests due to IO traffic, 1 64-byte request will be counted to 2, 128-byte as 4.
     properties: []
     definitions:
     - architectures:
@@ -8238,7 +7963,7 @@ rocprofiler-sdk:
       block: TCC
       event: 8
   - name: TCC_LATENCY_FIFO_FULL
-    description: Number of cycles the latency fifo was full.
+    description: 'TCC (L2 cache) latency tracking FIFO is full. When full, the L2 cannot track additional in-flight requests. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -8270,8 +7995,7 @@ rocprofiler-sdk:
       block: TCC
       event: 45
   - name: TCC_IB_REQ
-    description: Number of requests through the IB. This measures the raw request count from graphics clients going to this
-      TCC.
+    description: Number of requests through the IB. This measures the raw request count from graphics clients going to this TCC.
     properties: []
     definitions:
     - architectures:
@@ -8279,7 +8003,7 @@ rocprofiler-sdk:
       block: TCC
       event: 67
   - name: TCC_IB_STALL
-    description: Number of cycles the IB output was stalled.
+    description: 'TCC (L2 cache) input buffer stall cycles. Indicates back-pressure preventing new requests from entering L2. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -8311,7 +8035,7 @@ rocprofiler-sdk:
       block: TCC
       event: 116
   - name: TCC_CLIENT184_REQ
-    description: 'Number of cycles client184 sent a request to this TCC.'
+    description: Number of cycles client184 sent a request to this TCC.
     properties: []
     definitions:
     - architectures:
@@ -8319,7 +8043,7 @@ rocprofiler-sdk:
       block: TCC
       event: 312
   - name: TCC_CLIENT185_REQ
-    description: 'Number of cycles client185 sent a request to this TCC.'
+    description: Number of cycles client185 sent a request to this TCC.
     properties: []
     definitions:
     - architectures:
@@ -8327,7 +8051,7 @@ rocprofiler-sdk:
       block: TCC
       event: 313
   - name: TCC_CLIENT186_REQ
-    description: 'Number of cycles client186 sent a request to this TCC.'
+    description: Number of cycles client186 sent a request to this TCC.
     properties: []
     definitions:
     - architectures:
@@ -8335,7 +8059,7 @@ rocprofiler-sdk:
       block: TCC
       event: 314
   - name: TCC_CLIENT187_REQ
-    description: 'Number of cycles client187 sent a request to this TCC.'
+    description: Number of cycles client187 sent a request to this TCC.
     properties: []
     definitions:
     - architectures:
@@ -8343,7 +8067,7 @@ rocprofiler-sdk:
       block: TCC
       event: 315
   - name: TCC_CLIENT188_REQ
-    description: 'Number of cycles client188 sent a request to this TCC.'
+    description: Number of cycles client188 sent a request to this TCC.
     properties: []
     definitions:
     - architectures:
@@ -8351,7 +8075,7 @@ rocprofiler-sdk:
       block: TCC
       event: 316
   - name: TCC_CLIENT189_REQ
-    description: 'Number of cycles client189 sent a request to this TCC.'
+    description: Number of cycles client189 sent a request to this TCC.
     properties: []
     definitions:
     - architectures:
@@ -8359,7 +8083,7 @@ rocprofiler-sdk:
       block: TCC
       event: 317
   - name: TCC_CLIENT190_REQ
-    description: 'Number of cycles client190 sent a request to this TCC.'
+    description: Number of cycles client190 sent a request to this TCC.
     properties: []
     definitions:
     - architectures:
@@ -8367,7 +8091,7 @@ rocprofiler-sdk:
       block: TCC
       event: 318
   - name: TCC_CLIENT191_REQ
-    description: 'Number of cycles client191 sent a request to this TCC.'
+    description: Number of cycles client191 sent a request to this TCC.
     properties: []
     definitions:
     - architectures:
@@ -8417,8 +8141,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_BYPASS_REQ,sum)
   - name: TCC_IB_REQ_sum
-    description: Number of requests through the IB. This measures the raw request count from graphics clients going to this
-      TCC. Sum over TCP instances.
+    description: Number of requests through the IB. This measures the raw request count from graphics clients going to this TCC. Sum over TCP instances.
     properties: []
     definitions:
     - architectures:
@@ -8446,8 +8169,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_IB_STALL,sum)
   - name: TCC_EA0_WRREQ_WRITE_DRAM_32B_sum
-    description: Number of 32-byte TCC/EA write requests due to DRAM traffic, 1 64-byte request will be counted to 2. Sum
-      over TCP instances.
+    description: Number of 32-byte TCC/EA write requests due to DRAM traffic, 1 64-byte request will be counted to 2. Sum over TCP instances.
     properties: []
     definitions:
     - architectures:
@@ -8461,32 +8183,28 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_EA0_WRREQ_WRITE_DRAM,sum)
   - name: TCC_EA0_WRREQ_WRITE_ATOMIC_32B_sum
-    description: Number of 32-byte TCC/EA atomic requests due to DRAM traffic, 1 64-byte request will be counted to 2. Sum
-      over TCP instances.
+    description: Number of 32-byte TCC/EA atomic requests due to DRAM traffic, 1 64-byte request will be counted to 2. Sum over TCP instances.
     properties: []
     definitions:
     - architectures:
       - gfx950
       expression: reduce(TCC_EA0_WRREQ_WRITE_ATOMIC_32B,sum)
   - name: TCC_EA0_WRREQ_WRITE_GMI_32B_sum
-    description: Number of 32-byte TCC/EA write requests due to GMI traffic, 1 64-byte request will be counted to 2. Sum over
-      TCP instances.
+    description: Number of 32-byte TCC/EA write requests due to GMI traffic, 1 64-byte request will be counted to 2. Sum over TCP instances.
     properties: []
     definitions:
     - architectures:
       - gfx950
       expression: reduce(TCC_EA0_WRREQ_WRITE_GMI_32B,sum)
   - name: TCC_EA0_WRREQ_ATOMIC_GMI_32B_sum
-    description: Number of 32-byte TCC/EA atomic requests due to GMI traffic, 1 64-byte request will be counted to 2. Sum
-      over TCP instances.
+    description: Number of 32-byte TCC/EA atomic requests due to GMI traffic, 1 64-byte request will be counted to 2. Sum over TCP instances.
     properties: []
     definitions:
     - architectures:
       - gfx950
       expression: reduce(TCC_EA0_WRREQ_ATOMIC_GMI_32B,sum)
   - name: TCC_EA0_WRREQ_WRITE_IO_32B_sum
-    description: Number of 32-byte TCC/EA write requests due to IO traffic, 1 64-byte request will be counted to 2. Sum over
-      TCP instances.
+    description: Number of 32-byte TCC/EA write requests due to IO traffic, 1 64-byte request will be counted to 2. Sum over TCP instances.
     properties: []
     definitions:
     - architectures:
@@ -8500,40 +8218,35 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCC_EA0_WRREQ_ATOMIC_DRAM,sum)
   - name: TCC_EA0_WRREQ_ATOMIC_IO_32B_sum
-    description: Number of 32-byte TCC/EA atomic requests due to IO traffic, 1 64-byte request will be counted to 2. Sum over
-      TCP instances.
+    description: Number of 32-byte TCC/EA atomic requests due to IO traffic, 1 64-byte request will be counted to 2. Sum over TCP instances.
     properties: []
     definitions:
     - architectures:
       - gfx950
       expression: reduce(TCC_EA0_WRREQ_ATOMIC_IO_32B,sum)
   - name: TCC_EA0_WRREQ_ATOMIC_DRAM_32B_sum
-    description: Number of 32-byte TCC/EA atomic requests due to DRAM traffic, 1 64-byte request will be counted to 2. Sum
-      over TCP instances.
+    description: Number of 32-byte TCC/EA atomic requests due to DRAM traffic, 1 64-byte request will be counted to 2. Sum over TCP instances.
     properties: []
     definitions:
     - architectures:
       - gfx950
       expression: reduce(TCC_EA0_WRREQ_ATOMIC_DRAM_32B,sum)
   - name: TCC_EA0_RDREQ_IO_32B_sum
-    description: Number of 32-byte TCC/EA read requests due to IO traffic, 1 64-byte request will be counted to 2, 128-byte
-      as 4. Sum over TCP instances.
+    description: Number of 32-byte TCC/EA read requests due to IO traffic, 1 64-byte request will be counted to 2, 128-byte as 4. Sum over TCP instances.
     properties: []
     definitions:
     - architectures:
       - gfx950
       expression: reduce(TCC_EA0_RDREQ_IO_32B,sum)
   - name: TCC_EA0_RDREQ_GMI_32B_sum
-    description: Number of 32-byte TCC/EA read requests due to GMI traffic, 1 64-byte request will be counted to 2, 128-byte
-      as 4. Sum over TCP instances.
+    description: Number of 32-byte TCC/EA read requests due to GMI traffic, 1 64-byte request will be counted to 2, 128-byte as 4. Sum over TCP instances.
     properties: []
     definitions:
     - architectures:
       - gfx950
       expression: reduce(TCC_EA0_RDREQ_GMI_32B,sum)
   - name: TCC_EA0_RDREQ_DRAM_32B_sum
-    description: Number of 32-byte TCC/EA read requests due to DRAM traffic, 1 64-byte request will be counted to 2, 128-byte
-      as 4. Sum over TCP instances.
+    description: Number of 32-byte TCC/EA read requests due to DRAM traffic, 1 64-byte request will be counted to 2, 128-byte as 4. Sum over TCP instances.
     properties: []
     definitions:
     - architectures:
@@ -8568,7 +8281,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCP_ATOMIC_TAGCONFLICT_STALL_CYCLES,sum)
   - name: TCP_GATE_EN1
-    description: TCP interface clocks are turned on. Not Windowed.
+    description: 'Texture Cache per Pipe (TCP/vL1D) power gate enable signal 1. TCP is the L1 data cache. Power gating reduces leakage when cache is inactive. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -8593,7 +8306,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCP_GATE_EN1,sum)
   - name: TCP_GATE_EN2
-    description: TCP core clocks are turned on. Not Windowed.
+    description: 'Texture Cache per Pipe (TCP/vL1D) power gate enable signal 2. Unit: cycles.'
     properties: []
     definitions:
     - architectures:
@@ -8690,7 +8403,7 @@ rocprofiler-sdk:
       block: TCP
       event: 25
   - name: TCP_TA_TCP_STATE_READ_sum
-    description: Number of state reads Sum over TCP instances.
+    description: 'Sum of TCP (vL1D/L1 data cache) state read operations from Texture Addressing unit. Unit: count.'
     properties: []
     definitions:
     - architectures:
@@ -9242,8 +8955,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCP_TCC_WRITE_REQ,sum)
   - name: TCP_TCP_LATENCY
-    description: Total TCP wave latency (from first clock of wave entering to first clock of wave leaving), divide by TA_TCP_STATE_READ
-      to avg wave latency
+    description: Total TCP wave latency (from first clock of wave entering to first clock of wave leaving), divide by TA_TCP_STATE_READ to avg wave latency
     properties: []
     definitions:
     - architectures:
@@ -9256,8 +8968,7 @@ rocprofiler-sdk:
       block: TCP
       event: 64
   - name: TCP_TCP_LATENCY_sum
-    description: Total TCP wave latency (from first clock of wave entering to first clock of wave leaving), divide by TA_TCP_STATE_READ
-      to avg wave latency Sum over TCP instances.
+    description: Total TCP wave latency (from first clock of wave entering to first clock of wave leaving), divide by TA_TCP_STATE_READ to avg wave latency Sum over TCP instances.
     properties: []
     definitions:
     - architectures:
@@ -9266,7 +8977,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCP_TCP_LATENCY,sum)
   - name: TCP_TCP_TA_DATA_STALL_CYCLES
-    description: TCP stalls TA data interface. Now Windowed.
+    description: 'TCP (vL1D/L1) stall cycles waiting to send data to Texture Addressing (TA) unit. Indicates back-pressure in the cache data return path. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -9282,7 +8993,7 @@ rocprofiler-sdk:
       block: TCP
       event: 6
   - name: TCP_TCP_TA_DATA_STALL_CYCLES_max
-    description: Maximum number of TCP stalls TA data interface.
+    description: 'Maximum TCP (vL1D/L1) data stall cycles across all TCP instances. Useful for identifying hotspots. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -9297,7 +9008,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCP_TCP_TA_DATA_STALL_CYCLES,max)
   - name: TCP_TCP_TA_DATA_STALL_CYCLES_sum
-    description: Total number of TCP stalls TA data interface.
+    description: 'Sum of TCP (vL1D/L1) data stall cycles across all TCP instances. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -9337,7 +9048,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCP_TCR_TCP_STALL_CYCLES,sum)
   - name: TCP_TD_TCP_STALL_CYCLES
-    description: TD stalls TCP
+    description: 'TCP (vL1D/L1) stall cycles in the Texture Data (TD) unit. TD is the data return path routing data from cache RAM back to wavefronts. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -9350,7 +9061,7 @@ rocprofiler-sdk:
       block: TCP
       event: 7
   - name: TCP_TD_TCP_STALL_CYCLES_sum
-    description: TD stalls TCP. Sum over TCP instances.
+    description: 'Sum of TCP Texture Data (TD) stall cycles across all TCP instances. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -9378,8 +9089,7 @@ rocprofiler-sdk:
       block: TCP
       event: 27
   - name: TCP_TOTAL_ACCESSES_sum
-    description: Total number of pixels/buffers from TA. Equals TCP_PERF_SEL_TOTAL_READ+TCP_PERF_SEL_TOTAL_NONREAD. Sum over
-      TCP instances.
+    description: Total number of pixels/buffers from TA. Equals TCP_PERF_SEL_TOTAL_READ+TCP_PERF_SEL_TOTAL_NONREAD. Sum over TCP instances.
     properties: []
     definitions:
     - architectures:
@@ -9475,8 +9185,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCP_TOTAL_CACHE_ACCESSES,sum)
   - name: TCP_TOTAL_READ
-    description: Total number of read pixels/buffers from TA. Equals TCP_PERF_SEL_TOTAL_HIT_LRU_READ + TCP_PERF_SEL_TOTAL_MISS_LRU_READ
-      + TCP_PERF_SEL_TOTAL_MISS_EVICT_READ
+    description: Total number of read pixels/buffers from TA. Equals TCP_PERF_SEL_TOTAL_HIT_LRU_READ + TCP_PERF_SEL_TOTAL_MISS_LRU_READ + TCP_PERF_SEL_TOTAL_MISS_EVICT_READ
     properties: []
     definitions:
     - architectures:
@@ -9492,8 +9201,7 @@ rocprofiler-sdk:
       block: TCP
       event: 28
   - name: TCP_TOTAL_READ_sum
-    description: Total number of read pixels/buffers from TA. Equals TCP_PERF_SEL_TOTAL_HIT_LRU_READ + TCP_PERF_SEL_TOTAL_MISS_LRU_READ
-      + TCP_PERF_SEL_TOTAL_MISS_EVICT_READ. Sum over TCP instances.
+    description: Total number of read pixels/buffers from TA. Equals TCP_PERF_SEL_TOTAL_HIT_LRU_READ + TCP_PERF_SEL_TOTAL_MISS_LRU_READ + TCP_PERF_SEL_TOTAL_MISS_EVICT_READ. Sum over TCP instances.
     properties: []
     definitions:
     - architectures:
@@ -9521,8 +9229,7 @@ rocprofiler-sdk:
       block: TCP
       event: 30
   - name: TCP_TOTAL_WRITEBACK_INVALIDATES
-    description: Total number of cache invalidates. Equals TCP_PERF_SEL_TOTAL_WBINVL1+ TCP_PERF_SEL_TOTAL_WBINVL1_VOL+ TCP_PERF_SEL_CP_TCP_INVALIDATE+
-      TCP_PERF_SEL_SQ_TCP_INVALIDATE_VOL. Not Windowed.
+    description: Total number of cache invalidates. Equals TCP_PERF_SEL_TOTAL_WBINVL1+ TCP_PERF_SEL_TOTAL_WBINVL1_VOL+ TCP_PERF_SEL_CP_TCP_INVALIDATE+ TCP_PERF_SEL_SQ_TCP_INVALIDATE_VOL. Not Windowed.
     properties: []
     definitions:
     - architectures:
@@ -9541,8 +9248,7 @@ rocprofiler-sdk:
       block: TCP
       event: 41
   - name: TCP_TOTAL_WRITEBACK_INVALIDATES_sum
-    description: Total number of cache invalidates. Equals TCP_PERF_SEL_TOTAL_WBINVL1+ TCP_PERF_SEL_TOTAL_WBINVL1_VOL+ TCP_PERF_SEL_CP_TCP_INVALIDATE+
-      TCP_PERF_SEL_SQ_TCP_INVALIDATE_VOL. Not Windowed. Sum over TCP instances.
+    description: Total number of cache invalidates. Equals TCP_PERF_SEL_TOTAL_WBINVL1+ TCP_PERF_SEL_TOTAL_WBINVL1_VOL+ TCP_PERF_SEL_CP_TCP_INVALIDATE+ TCP_PERF_SEL_SQ_TCP_INVALIDATE_VOL. Not Windowed. Sum over TCP instances.
     properties: []
     definitions:
     - architectures:
@@ -9554,8 +9260,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCP_TOTAL_WRITEBACK_INVALIDATES,sum)
   - name: TCP_TOTAL_WRITE_sum
-    description: Total number of local write pixels/buffers from TA. Equals TCP_PERF_SEL_TOTAL_MISS_LRU_WRITE+ TCP_PERF_SEL_TOTAL_MISS_EVICT_WRITE.
-      Sum over TCP instances.
+    description: Total number of local write pixels/buffers from TA. Equals TCP_PERF_SEL_TOTAL_MISS_LRU_WRITE+ TCP_PERF_SEL_TOTAL_MISS_EVICT_WRITE. Sum over TCP instances.
     properties: []
     definitions:
     - architectures:
@@ -9755,7 +9460,7 @@ rocprofiler-sdk:
       block: TCP
       event: 63
   - name: TCP_TCP_TA_ADDR_STALL_CYCLES
-    description: TCP stalls TA addr interface.
+    description: 'TCP (vL1D/L1) address stall cycles waiting for Texture Addressing unit. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -9763,7 +9468,7 @@ rocprofiler-sdk:
       block: TCP
       event: 5
   - name: TCP_LFIFO_STALL_CYCLES
-    description: Memory Latency fifos full stall.
+    description: 'TCP (vL1D/L1) load FIFO stall cycles. LFIFO manages load request queueing. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -9795,9 +9500,7 @@ rocprofiler-sdk:
       block: TCP
       event: 23
   - name: TCP_UTCL1_THRASHING_STALL
-    description: Stall caused by thrashing feature in any probes. Not accurate when the stall signal has overlap between probe0
-      and probe1. Even worse with MECO of thrashing deadlock. Some event of probe0 could miss to count in with
-      MECO on. Anyway this perf count can be a rough estimation of thrashing.
+    description: Stall caused by thrashing feature in any probes. Not accurate when the stall signal has overlap between probe0 and probe1. Even worse with MECO of thrashing deadlock. Some event of probe0 could miss to count in with MECO on. Anyway this perf count can be a rough estimation of thrashing.
     properties: []
     definitions:
     - architectures:
@@ -10032,9 +9735,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TCP_UTCL1_SERIALIZATION_STALL,sum)
   - name: TCP_UTCL1_THRASHING_STALL_sum
-    description: Stall caused by thrashing feature in any probes. Not accurate when the stall signal has overlap between probe0
-      and probe1. Even worse with MECO of thrashing deadlock. Some event of probe0 could miss to count in with
-      MECO on. Anyway this perf count can be a rough estimation of thrashing. Sum over TCP instances.
+    description: Stall caused by thrashing feature in any probes. Not accurate when the stall signal has overlap between probe0 and probe1. Even worse with MECO of thrashing deadlock. Some event of probe0 could miss to count in with MECO on. Anyway this perf count can be a rough estimation of thrashing. Sum over TCP instances.
     properties: []
     definitions:
     - architectures:
@@ -10082,7 +9783,7 @@ rocprofiler-sdk:
       block: TCP
       event: 17
   - name: TD_ATOMIC_WAVEFRONT
-    description: Count the wavefronts with opcode = atomic.
+    description: 'Texture Data (TD) unit wavefronts performing atomic operations. TD is the data return path in the vL1D cache subsystem. Unit: wavefronts.'
     properties: []
     definitions:
     - architectures:
@@ -10110,7 +9811,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TD_ATOMIC_WAVEFRONT,sum)
   - name: TD_COALESCABLE_WAVEFRONT
-    description: Count wavefronts that TA finds coalescable.
+    description: 'Texture Data (TD) unit wavefronts with coalescable memory accesses. Coalescing combines requests to adjacent addresses. Unit: wavefronts. Higher values indicate better memory access patterns.'
     properties: []
     definitions:
     - architectures:
@@ -10192,7 +9893,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TD_SPI_STALL,sum)
   - name: TD_STORE_WAVEFRONT
-    description: Count the wavefronts with opcode = store.
+    description: 'Texture Data (TD) unit wavefronts performing store operations. Unit: wavefronts.'
     properties: []
     definitions:
     - architectures:
@@ -10220,7 +9921,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(TD_STORE_WAVEFRONT,sum)
   - name: TD_TC_STALL
-    description: TD is stalled waiting for TC data.
+    description: 'Texture Data (TD) unit stalled waiting for Texture Cache (TC/cache RAM). Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
@@ -10362,14 +10063,14 @@ rocprofiler-sdk:
       - gfx950
       expression: TOTAL_64_OPS/SIMD_NUM/reduce(GRBM_COUNT,max)
   - name: TaUtil
-    description: 'Unit: percent'
+    description: 'Texture Addressing (TA) unit utilization percentage. Indicates how busy the address calculation and coalescing units are. Unit: percent. Value range: 0% (idle) to 100% (fully utilized).'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*reduce(GRBM_TA_BUSY,max)/reduce(GRBM_GUI_ACTIVE,max)
   - name: TcUtil
-    description: 'Unit: percent'
+    description: 'Texture Cache (TC) utilization percentage. TC is the cache RAM in the vL1D/TCP subsystem. Unit: percent. Value range: 0% (idle) to 100% (fully utilized).'
     properties: []
     definitions:
     - architectures:
@@ -10420,8 +10121,7 @@ rocprofiler-sdk:
       - gfx1201
       expression: reduce(SQ_INSTS_VALU,sum)/reduce(SQ_WAVES,sum)
   - name: VALUUtilization
-    description: 'The percentage of active vector ALU threads in a wave. A lower number can mean either more thread divergence
-      in a wave or that the work-group size is not a multiple of 64. Value range: 0% (bad), 100% (ideal - no thread divergence).'
+    description: 'The percentage of active vector ALU threads in a wave. A lower number can mean either more thread divergence in a wave or that the work-group size is not a multiple of 64. Value range: 0% (bad), 100% (ideal - no thread divergence).'
     properties: []
     definitions:
     - architectures:
@@ -10447,8 +10147,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(SQ_BUSY_CU_CYCLES,sum)/reduce(GRBM_COUNT,max)/CU_NUM
   - name: VFetchInsts
-    description: The average number of vector fetch instructions from the video memory executed per work-item (affected by
-      flow control). Excludes FLAT instructions that fetch from video memory.
+    description: The average number of vector fetch instructions from the video memory executed per work-item (affected by flow control). Excludes FLAT instructions that fetch from video memory.
     properties: []
     definitions:
     - architectures:
@@ -10463,8 +10162,7 @@ rocprofiler-sdk:
       - gfx950
       expression: (reduce(SQ_INSTS_VMEM_RD,sum)-TA_FLAT_READ_WAVEFRONTS_sum)/reduce(SQ_WAVES,sum)
   - name: VWriteInsts
-    description: The average number of vector write instructions to the video memory executed per work-item (affected by flow
-      control). Excludes FLAT instructions that write to video memory.
+    description: The average number of vector write instructions to the video memory executed per work-item (affected by flow control). Excludes FLAT instructions that write to video memory.
     properties: []
     definitions:
     - architectures:
@@ -10479,14 +10177,14 @@ rocprofiler-sdk:
       - gfx950
       expression: (reduce(SQ_INSTS_VMEM_WR,sum)-TA_FLAT_WRITE_WAVEFRONTS_sum)/reduce(SQ_WAVES,sum)
   - name: ValuIops
-    description: 'Unit: IOP'
+    description: 'Vector ALU (VALU) integer operations per second. VALU performs per-thread vector operations on all threads in a wavefront. Unit: IOPS. Higher values indicate better vector integer throughput.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: (SQ_INSTS_VALU_INT32+SQ_INSTS_VALU_INT64)*64
   - name: ValuPipeIssueUtil
-    description: 'Unit: percent'
+    description: 'Vector ALU (VALU) pipeline issue utilization. Percentage of cycles the VALU instruction issue pipeline is actively issuing vector operations. Each CU has 4 VALU units (SIMDs). Unit: percent. Value range: 0% (idle) to 100% (fully utilized). Higher values indicate good compute utilization.'
     properties: []
     definitions:
     - architectures:
@@ -10502,7 +10200,7 @@ rocprofiler-sdk:
       - gfx1201
       expression: 100*reduce(SQ_INST_CYCLES_VALU,sum)/(reduce(GRBM_GUI_ACTIVE,max)*(SIMD_NUM/4))
   - name: VmemLatency
-    description: 'Unit: cycles'
+    description: 'Vector memory (VMEM) operation latency. Average cycles for VMEM loads, stores, and atomics to complete. VMEM unit transfers data between vector registers (VGPRs) and memory, with each thread supplying its own address. Unit: cycles. Lower values indicate better memory performance. Latency is hidden by high wavefront occupancy.'
     properties: []
     definitions:
     - architectures:
@@ -10513,7 +10211,7 @@ rocprofiler-sdk:
       - gfx950
       expression: reduce(accumulate(SQ_INST_LEVEL_VMEM, HIGH_RES),sum)/reduce(SQ_INSTS_VMEM,sum)
   - name: VmemPipeIssueUtil
-    description: 'Unit: percent'
+    description: 'Vector memory (VMEM) pipeline issue utilization. Percentage of cycles the VMEM instruction issue pipeline is actively issuing memory operations. Unit: percent. Value range: 0% (idle) to 100% (fully utilized). High values may indicate memory-bound workloads.'
     properties: []
     definitions:
     - architectures:
@@ -10582,8 +10280,7 @@ rocprofiler-sdk:
       - gfx950
       expression: TCC_EA0_WRREQ_64B_sum*2+(TCC_EA0_WRREQ_sum-TCC_EA0_WRREQ_64B_sum)
   - name: WRITE_SIZE
-    description: The total kilobytes written to the video memory. This is measured with all extra fetches and any cache or
-      memory effects taken into account.
+    description: The total kilobytes written to the video memory. This is measured with all extra fetches and any cache or memory effects taken into account.
     properties: []
     definitions:
     - architectures:
@@ -10615,35 +10312,35 @@ rocprofiler-sdk:
       - gfx950
       expression: ((TCC_EA0_WRREQ_sum-TCC_EA0_WRREQ_64B_sum)*32+TCC_EA0_WRREQ_64B_sum*64)/1024
   - name: WaveDepWait
-    description: 'Unit: percent'
+    description: 'Wavefront cycles waiting on data dependencies. Measures stall time when wavefronts cannot issue instructions due to dependencies on pending operations. Unit: cycles. Lower values are better. High values indicate instruction-level parallelism limitations.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*reduce(SQ_WAIT_ANY,sum)/reduce(SQ_WAVE_CYCLES,sum)
   - name: WaveDuration
-    description: 'Unit: cycles'
+    description: 'Average wavefront duration from start to completion. Measures the execution time of wavefronts on the GPU. Unit: cycles. Lower values indicate faster kernel execution.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 4*reduce(SQ_WAVE_CYCLES,sum)/reduce(SQ_WAVES,sum)
   - name: WaveExec
-    description: 'Unit: percent'
+    description: 'Wavefront execution cycles. Total cycles wavefronts spend actively executing instructions (not stalled). Unit: cycles. Higher values relative to total cycles indicate good execution efficiency.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*reduce(SQ_ACTIVE_INST_ANY,sum)/reduce(SQ_WAVE_CYCLES,sum)
   - name: WaveIssueWait
-    description: 'Unit: percent'
+    description: 'Wavefront cycles waiting to issue instructions. Measures stall time when instructions cannot be issued due to resource unavailability or structural hazards. Unit: cycles. Lower values are better.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*reduce(SQ_WAIT_INST_ANY,sum)/reduce(SQ_WAVE_CYCLES,sum)
   - name: Wavefronts
-    description: Total wavefronts.
+    description: "Total number of wavefronts launched. A wavefront contains 64 threads (work items) on CDNA architectures. Each CU can manage up to 32 concurrent wavefronts (4 SIMDs \xD7 8 wavefronts). Unit: count. Higher values indicate more parallel work."
     properties: []
     definitions:
     - architectures:
@@ -10667,8 +10364,7 @@ rocprofiler-sdk:
       - gfx1201
       expression: reduce(SQ_WAVES,sum)
   - name: WriteSize
-    description: The total kilobytes written to the video memory. This is measured with all extra fetches and any cache or
-      memory effects taken into account.
+    description: The total kilobytes written to the video memory. This is measured with all extra fetches and any cache or memory effects taken into account.
     properties: []
     definitions:
     - architectures:
@@ -10710,100 +10406,98 @@ rocprofiler-sdk:
       - gfx1201
       expression: 100*GL2C_WRREQ_STALL_max/reduce(GRBM_GUI_ACTIVE,max)
   - name: sL1dCacheHitRate
-    description: 'Unit: percent'
+    description: 'Scalar L1 data cache hit rate. Percentage of scalar memory (SMEM) requests that hit in the scalar L1 cache. Scalar cache is used for read-only uniform data like kernel arguments. Unit: percent. Value range: 0% to 100%. Higher values (closer to 100%) are better.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*reduce(SQC_DCACHE_HITS,sum)/reduce(SQC_DCACHE_REQ,sum)
   - name: vL1dAtomicTagConfStallRate
-    description: 'Unit: percent'
+    description: 'Vector L1 data cache (vL1D/TCP) atomic operation tag conflict stall rate. Percentage of time atomic operations stall due to tag RAM conflicts. Unit: percent. Lower values are better (0% is optimal).'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*TCP_ATOMIC_TAGCONFLICT_STALL_CYCLES_sum/TCP_GATE_EN2_sum
   - name: vL1dBufCoalesceRate
-    description: 'Unit: percent'
+    description: 'Vector L1 data cache (vL1D/TCP) buffer coalescing rate. Percentage of buffer operations that successfully coalesce adjacent memory accesses. The TA unit combines requests to adjacent addresses. Unit: percent. Value range: 0% to 100%. Higher values indicate better memory access patterns.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 6400*TA_TOTAL_WAVEFRONTS_sum/(TCP_TOTAL_ACCESSES_sum*4)
   - name: vL1dCacheTcbHitRate
-    description: 'Unit: percent'
+    description: 'Vector L1 data cache (vL1D/TCP) hit rate including hit-on-miss. Uses hit-on-miss approach: requests for pending cache lines count as hits. Consider latency metrics when evaluating hit rate. Unit: percent. Value range: 0% to 100%. Higher values are better.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*TCP_UTCL1_TRANSLATION_HIT_sum/TCP_UTCL1_REQUEST_sum
   - name: vL1dCacheUtil
-    description: 'Unit: percent'
+    description: 'Vector L1 data cache (vL1D/TCP) utilization percentage. Indicates how effectively the L1 data cache bandwidth is being used. CDNA3 L1 provides 128 bytes/cycle. Unit: percent. Value range: 0% to 100%.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*TCP_GATE_EN2_sum/TCP_GATE_EN1_sum
   - name: vL1dCacheWaveLatency
-    description: 'Unit: cycles'
+    description: 'Vector L1 data cache (vL1D/TCP) average latency per wavefront. Measures cycles from request to data return for cache operations. Unit: cycles. Lower values indicate better cache performance.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: TCP_TCP_LATENCY_sum/TCP_TA_TCP_STATE_READ_sum
   - name: vL1dDataPendRate
-    description: 'Unit: percent'
+    description: 'Vector L1 data cache (vL1D/TCP) data pending stall rate. Percentage of time cache is stalled with pending data requests awaiting responses from L2. Unit: percent. Lower values are better (0% is optimal).'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*TCP_PENDING_STALL_CYCLES_sum/TCP_GATE_EN2_sum
   - name: vL1dDataRetStallRate
-    description: 'Unit: percent'
+    description: 'Vector L1 data cache (vL1D/TCP) data return path stall rate. Percentage of time the data return path (TD unit) is stalled. Unit: percent. Lower values are better (0% is optimal).'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*TD_TC_STALL_sum/TD_TD_BUSY_sum
   - name: vL1dMissReqStallRate
-    description: 'Unit: percent'
+    description: 'Vector L1 data cache (vL1D/TCP) miss request stall rate. Percentage of time cache miss requests are stalled, often due to L2 interface back-pressure. Unit: percent. Lower values are better (0% is optimal).'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*TCP_TCR_TCP_STALL_CYCLES_sum/TCP_GATE_EN2_sum
   - name: vL1dRdTagConfStallRate
-    description: 'Unit: percent'
+    description: 'Vector L1 data cache (vL1D/TCP) read operation tag conflict stall rate. Percentage of time read operations stall due to tag RAM access conflicts. Unit: percent. Lower values are better (0% is optimal).'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*TCP_READ_TAGCONFLICT_STALL_CYCLES_sum/TCP_GATE_EN2_sum
   - name: vL1dReadFromL2Latency
-    description: 'Unit: cycles'
+    description: 'Vector L1 data cache (vL1D) average latency for reads that miss L1 and fetch from L2 cache. Unit: cycles. Lower values indicate better L2 performance. CDNA3 has improved L2 latency versus CDNA2.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: TCP_TCC_READ_REQ_LATENCY_sum/(TCP_TCC_READ_REQ_sum+TCP_TCC_ATOMIC_WITH_RET_REQ_sum)
   - name: vL1dWrTagConfStallRate
-    description: 'Unit: percent'
+    description: 'Vector L1 data cache (vL1D/TCP) write operation tag conflict stall rate. Percentage of time write operations stall due to tag RAM access conflicts. Unit: percent. Lower values are better (0% is optimal).'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: 100*TCP_WRITE_TAGCONFLICT_STALL_CYCLES_sum/TCP_GATE_EN2_sum
   - name: vL1dWriteToL2Latency
-    description: 'Unit: cycles'
+    description: 'Vector L1 data cache (vL1D) average latency for writes going to L2 cache. Unit: cycles. Lower values indicate better write-through/writeback performance.'
     properties: []
     definitions:
     - architectures:
       - gfx90a
       expression: TCP_TCC_WRITE_REQ_LATENCY_sum/(TCP_TCC_WRITE_REQ_sum+TCP_TCC_ATOMIC_WITHOUT_RET_REQ_sum)
   - name: SerializedAtomicRatio
-    description: Ratio of cycles spent waiting on serialized atomic accesses caused by contention (access to the same atomic)
-      over total number of cycles spent on atomic operations. Values greater than 0.10 indicate contention is high and might
-      be worth addressing.
+    description: Ratio of cycles spent waiting on serialized atomic accesses caused by contention (access to the same atomic) over total number of cycles spent on atomic operations. Values greater than 0.10 indicate contention is high and might be worth addressing.
     properties: []
     definitions:
     - architectures:
@@ -10814,8 +10508,7 @@ rocprofiler-sdk:
       - gfx950
       expression: TCP_ATOMIC_TAGCONFLICT_STALL_CYCLES_sum/TCP_GATE_EN1_sum
   - name: L0CacheHit
-    description: The percentage of read requests that hit the data in the L0 cache. The L0 cache contains vector data, which
-      is data that may vary in each thread across the wavefront. Value range 0% (no hit) to 100% (optimal).
+    description: The percentage of read requests that hit the data in the L0 cache. The L0 cache contains vector data, which is data that may vary in each thread across the wavefront. Value range 0% (no hit) to 100% (optimal).
     properties: []
     definitions:
     - architectures:


### PR DESCRIPTION
Enhanced descriptions for 146 performance counters to include:
- Clear explanations of what each counter measures
- Units of measurement
- Performance interpretation guidance (good vs bad values)
- Hardware component context and architecture details
- Optimization hints where applicable

Covered counter categories:
- Command Processor (CPC/CPF): 31 counters
- Memory Controller (EA): 12 counters
- L2 Cache (GL2C/TCC): 19 counters
- L1 Data Cache (TCP/vL1D): 23 counters
- Texture Units (TA/TD/TCA): 15 counters
- MFMA Matrix Operations: 6 counters
- Local Data Share (LDS): 4 counters
- Occupancy & Wavefronts: 9 counters
- Pipeline Utilization: 5 counters
- Latency Metrics: 10 counters
- GPU Configuration: 3 counters
- GPU Utilization: 8 counters
- SPI: 1 counter

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
