### PR TITLE
Fix GL2C and TCC counter packet generation for GFX12

### DIFF
--- a/projects/perf-dkms/src/amdgpu_pmu.h
+++ b/projects/perf-dkms/src/amdgpu_pmu.h
@@ -99,6 +99,7 @@ void amdgpu_pmu_cleanup_sysfs(struct amdgpu_pmu *pmu);
 /* AQL Hardware Integration Functions */
 int aql_pmu_init(void);
 void aql_pmu_cleanup(void);
+void aql_pmu_flush_all_measurements(void);
 bool aql_pmu_is_available(void);
 int aql_pmu_get_gpu_count(void);
 uint32_t aql_pmu_get_gpu_id_for_event(struct perf_event *event);

--- a/projects/perf-dkms/src/aql_c/counter_registry.c
+++ b/projects/perf-dkms/src/aql_c/counter_registry.c
@@ -6,21 +6,18 @@
 #include "counter_registry.h"
 #include "gfx12_events.h"
 
-#ifdef USERSPACE_BUILD
-#include <string.h>
-#include <stddef.h>
-#else
+#ifdef __KERNEL__
 #include <linux/string.h>
 #include <linux/kernel.h>
+#include <linux/errno.h>
+#else
+#include <string.h>
+#include <stddef.h>
+#include <errno.h>
 #endif
 
 /* Include dimension support for validation */
-#ifndef USERSPACE_BUILD
 #include "../pmu_dimension.h"
-#else
-/* Userspace builds don't need dimension validation */
-struct pmu_dimension_coords;
-#endif
 
 /* Base counter definitions - architecture agnostic */
 static const counter_def_t base_counters[] = {

--- a/projects/perf-dkms/src/aql_c/gfx12_creator.c
+++ b/projects/perf-dkms/src/aql_c/gfx12_creator.c
@@ -65,19 +65,23 @@
 #define mmGRBM_PERFCOUNTER1_LO              12355
 #define mmGRBM_PERFCOUNTER1_HI              12356
 
-/* GL2C registers */
-#define mmGL2C_PERFCOUNTER0_SELECT          15232
-#define mmGL2C_PERFCOUNTER0_LO              13184
-#define mmGL2C_PERFCOUNTER0_HI              13185
-#define mmGL2C_PERFCOUNTER1_SELECT          15234
-#define mmGL2C_PERFCOUNTER1_LO              13186
-#define mmGL2C_PERFCOUNTER1_HI              13187
-#define mmGL2C_PERFCOUNTER2_SELECT          15236
-#define mmGL2C_PERFCOUNTER2_LO              13188
-#define mmGL2C_PERFCOUNTER2_HI              13189
-#define mmGL2C_PERFCOUNTER3_SELECT          15238
-#define mmGL2C_PERFCOUNTER3_LO              13190
-#define mmGL2C_PERFCOUNTER3_HI              13191
+/* GL2C registers - BASE_IDX=1, absolute UCONFIG addresses
+ * Hardware register (gc_12_0_0_offset.h): regGL2C_PERFCOUNTER0_SELECT = 0x3b80, BASE_IDX=1
+ * Absolute UCONFIG address = 0xC000 + (0x3b80 - 0x2000) = 0xdb80 = 56192
+ * Same pattern applies to LO/HI: 0xc000 + (reg - 0x2000)
+ */
+#define mmGL2C_PERFCOUNTER0_SELECT          56192  /* 0xdb80 = 0xc000 + (0x3b80 - 0x2000) */
+#define mmGL2C_PERFCOUNTER0_LO              54144  /* 0xd380 = 0xc000 + (0x3380 - 0x2000) */
+#define mmGL2C_PERFCOUNTER0_HI              54145  /* 0xd381 = 0xc000 + (0x3381 - 0x2000) */
+#define mmGL2C_PERFCOUNTER1_SELECT          56194  /* 0xdb82 = 0xc000 + (0x3b82 - 0x2000) */
+#define mmGL2C_PERFCOUNTER1_LO              54146  /* 0xd382 = 0xc000 + (0x3382 - 0x2000) */
+#define mmGL2C_PERFCOUNTER1_HI              54147  /* 0xd383 = 0xc000 + (0x3383 - 0x2000) */
+#define mmGL2C_PERFCOUNTER2_SELECT          56196  /* 0xdb84 = 0xc000 + (0x3b84 - 0x2000) */
+#define mmGL2C_PERFCOUNTER2_LO              54148  /* 0xd384 = 0xc000 + (0x3384 - 0x2000) */
+#define mmGL2C_PERFCOUNTER2_HI              54149  /* 0xd385 = 0xc000 + (0x3385 - 0x2000) */
+#define mmGL2C_PERFCOUNTER3_SELECT          56198  /* 0xdb86 = 0xc000 + (0x3b86 - 0x2000) */
+#define mmGL2C_PERFCOUNTER3_LO              54150  /* 0xd386 = 0xc000 + (0x3386 - 0x2000) */
+#define mmGL2C_PERFCOUNTER3_HI              54151  /* 0xd387 = 0xc000 + (0x3387 - 0x2000) */
 
 /* SPI registers */
 #define mmSPI_PERFCOUNTER0_SELECT           14720
@@ -260,11 +264,19 @@
 #define GFX12_COUNTER_BLOCK_DFLT_ATTR             1
 #define GFX12_COUNTER_BLOCK_SPM_GLOBAL_ATTR       0x1000
 
-/* GFX12 Architecture parameters - from Rust demo.rs */
+/* GFX12 Architecture parameters - from actual gfx1200 GPU topology
+ * These values should match the physical GPU configuration.
+ * For reference gfx1200 (AMD Radeon RX 9060 XT):
+ *   - 32 Compute Units (CUs)
+ *   - 2 Shader Engines (SEs)
+ *   - 2 Shader Arrays per SE (SAs)
+ *   - 16 Workgroup Processors (WGPs = CUs / 2)
+ *   - 4 WGPs per SA (16 WGPs / 4 SAs)
+ */
 #define GFX12_NUM_XCC           1
-#define GFX12_NUM_SE            4
+#define GFX12_NUM_SE            2
 #define GFX12_NUM_SA            2
-#define GFX12_NUM_CU            64
+#define GFX12_NUM_CU            32
 #define GFX12_NUM_WGP_PER_SA    4
 
 /**
@@ -1403,7 +1415,11 @@ arch_t* create_gfx12_arch(void) {
     arch->block_map.blocks[HW_IP_BLOCK_PA_SC] = pa_sc_block;
     arch->block_map.blocks[HW_IP_BLOCK_PA_SU] = pa_su_block;
     arch->block_map.blocks[HW_IP_BLOCK_GDS] = gds_block;
-    arch->block_map.block_count = 14;
+    /* Block count must be >= highest block ID + 1
+     * Highest registered block is HW_IP_BLOCK_TCC=19, so we need at least 20
+     * Using HW_IP_BLOCK_LAST allows for all possible blocks
+     */
+    arch->block_map.block_count = HW_IP_BLOCK_LAST;
 
     /* Initialize control registers for GFX12 */
     arch->control_regs = (arch_control_regs_t) {

--- a/projects/perf-dkms/src/aql_c/packet_generation.c
+++ b/projects/perf-dkms/src/aql_c/packet_generation.c
@@ -11,6 +11,7 @@
 #else
 #include <errno.h>
 #include <stdbool.h>
+#include <stdio.h>
 #endif
 
 #define VALIDATE_BLOCK_ID(arch, counter) \
@@ -244,14 +245,45 @@ int generate_start_packet(pm4_buffer_t *buffer, const arch_t *arch,
       return ret;
   }
 
-  /* 5. Configure each counter in broadcast mode */
+  /* 5. Configure each counter */
   for (size_t i = 0; i < collection->counter_count; i++) {
     counter_info_t *counter = &collection->counters[i];
 
-    /* Configure the counter (broadcast mode already set) */
-    ret = generate_counter_config(buffer, arch, counter);
-    if (ret < 0)
-      return ret;
+    /* GL2C and TCC counters need per-instance configuration instead of broadcast.
+     * Other blocks (SQ, GRBM, TA) work correctly with broadcast mode. */
+    bool needs_per_instance_config = (counter->block_id == HW_IP_BLOCK_GL2C ||
+                                      counter->block_id == HW_IP_BLOCK_TCC);
+
+    if (needs_per_instance_config) {
+      /* Get block info to determine number of instances */
+      block_info_t *block = arch->block_map.blocks[counter->block_id];
+      uint32_t num_instances = block->instance_count;
+
+      /* Configure each instance separately */
+      for (uint32_t instance = 0; instance < num_instances; instance++) {
+        /* Set GRBM_GFX_INDEX to select this specific instance */
+        uint32_t grbm_value = 0xa0000000u | instance;
+        ret = pm4_append_set_uconfig_reg(buffer, arch->control_regs.grbm_gfx_index, grbm_value);
+        if (ret < 0)
+          return ret;
+
+        /* Configure the counter for this instance */
+        ret = generate_counter_config(buffer, arch, counter);
+        if (ret < 0)
+          return ret;
+      }
+
+      /* Reset to broadcast mode after per-instance config */
+      ret = generate_grbm_broadcast(buffer, arch);
+      if (ret < 0)
+        return ret;
+
+    } else {
+      /* Other blocks: Configure once in broadcast mode (already set) */
+      ret = generate_counter_config(buffer, arch, counter);
+      if (ret < 0)
+        return ret;
+    }
   }
 
   /* 6. GRBM broadcast again */
@@ -327,10 +359,16 @@ int generate_read_packet(pm4_buffer_t *buffer, const arch_t *arch,
       return -ENOENT;
     }
 
-    /* Reset to broadcast mode for each counter */
-    ret = generate_grbm_broadcast(buffer, arch);
-    if (ret < 0)
-      return ret;
+    /* Reset to broadcast mode for each counter
+     * Skip for multi-instance global blocks (GL2C, TCC) - they handle broadcast per-instance */
+    bool is_multi_instance_global = (counter->block_id == HW_IP_BLOCK_GL2C ||
+                                      counter->block_id == HW_IP_BLOCK_TCC);
+
+    if (!is_multi_instance_global) {
+      ret = generate_grbm_broadcast(buffer, arch);
+      if (ret < 0)
+        return ret;
+    }
 
     /* Get register info */
     counter_reg_info_t *reg_info =
@@ -418,21 +456,177 @@ int generate_read_packet(pm4_buffer_t *buffer, const arch_t *arch,
         }
       }
     } else {
-      /* No SE dimension found - global block, read once */
-      pm4_copy_data_flags_t flags = {
-          .bits = {.src_sel = 0,      /* Non-priv registers */
-                   .dst_sel = 2,      /* TC_L2 memory */
-                   .src_temporal = 3, /* LU cache policy */
-                   .dst_temporal = 3, /* LU cache policy */
-                   .count_sel = 0,    /* 32-bit data */
-                   .wr_confirm = 0}};
+      /* No SE dimension found - global block
+       * Check if block has multiple instances (e.g., GL2C has 16 instances, TCC has 16)
+       */
+      uint32_t num_instances = block->instance_count;
 
-      ret = pm4_append_copy_data(buffer, flags, reg_info->register_addr_lo,
-                                 reg_info->register_addr_hi, current_addr);
-      if (ret < 0)
-        return ret;
+      if (num_instances > 1) {
+        /* Multi-instance global block - iterate through each instance
+         *
+         * This handles blocks like GL2C and TCC which have multiple hardware instances
+         * that must be read separately. Each instance is selected by setting the
+         * INSTANCE_INDEX field in GRBM_GFX_INDEX while broadcasting to all SE/SA.
+         *
+         * Reference: aqlprofile pmc_builder.h lines 593-594:
+         *   else if (block_info->instance_count > 1) {
+         *     grbm_value = Primitives::grbm_inst_index_value(block_des.index);
+         *   }
+         */
 
-      current_addr += 8; /* 64-bit counter value */
+        /* GL2C and TCC blocks require separate LO+HI reads like GRBM.
+         * Our register addresses already include BASE_IDX adjustments, so we can
+         * use them directly in COPY_DATA packets.
+         */
+        bool is_split_read_block = (counter->block_id == HW_IP_BLOCK_GL2C ||
+                                     counter->block_id == HW_IP_BLOCK_TCC);
+
+        for (uint32_t instance = 0; instance < num_instances; instance++) {
+          /* GL2C requires a broadcast->instance toggle sequence per rocprofv3.
+           * Reset to broadcast mode first, then set the specific instance.
+           * This ensures the GPU properly routes subsequent operations to the correct instance. */
+          ret = generate_grbm_broadcast(buffer, arch);
+          if (ret < 0)
+            return ret;
+
+          /* Set GRBM index to select specific instance
+           * GRBM_GFX_INDEX format for instance selection:
+           * - INSTANCE_INDEX = instance number (bits 0-7)
+           * - SE_BROADCAST_WRITES = 1 (broadcast to all SEs, bit 30)
+           * - SA_BROADCAST_WRITES = 1 (broadcast to all SAs, bit 29)
+           * Value = 0xa0000000 | instance
+           */
+          uint32_t grbm_value = 0xa0000000u | instance;
+          ret = pm4_append_set_uconfig_reg(buffer, arch->control_regs.grbm_gfx_index, grbm_value);
+          if (ret < 0)
+            return ret;
+
+          if (is_split_read_block) {
+            /* GL2C/TCC: Read LO and HI separately as 32-bit values
+             *
+             * GL2C and TCC counters must be read as separate 32-bit LO/HI operations
+             * instead of combined 64-bit reads. This matches aqlprofile's implementation
+             * for these blocks on GFX12.
+             *
+             * The register addresses in gfx12_creator.c are already absolute UCONFIG
+             * addresses with BASE_IDX=1 adjustment applied (e.g., GL2C_PERFCOUNTER0_LO
+             * is defined as 0xd380 = 0xc000 + (0x3380 - 0x2000)).
+             *
+             * For COPY_DATA, pm4_append_copy_data expects the UCONFIG-relative offset,
+             * so we subtract UCONFIG_SPACE_START (0xc000) to get the packet register field.
+             */
+
+            pm4_copy_data_flags_t flags = {
+                .bits = {.src_sel = 0,      /* Non-priv registers */
+                         .dst_sel = 2,      /* TC_L2 memory */
+                         .src_temporal = 3, /* LU cache policy */
+                         .dst_temporal = 3, /* LU cache policy */
+                         .count_sel = 0,    /* 32-bit data */
+                         .wr_confirm = 0}};
+
+            /* COPY_DATA expects absolute UCONFIG addresses, not offsets.
+             * GL2C register definitions are already absolute (e.g., 0xd380), so use them directly. */
+            uint32_t reg_lo = reg_info->register_addr_lo;
+            uint32_t reg_hi = reg_info->register_addr_hi;
+
+            /* Read LO register (32-bit) */
+            ret = pm4_append_copy_data(buffer, flags, reg_lo,
+                                       0, current_addr);
+            if (ret < 0)
+              return ret;
+            current_addr += 4; /* 32-bit value */
+
+            /* Read HI register (32-bit) */
+            ret = pm4_append_copy_data(buffer, flags, reg_hi,
+                                       0, current_addr);
+            if (ret < 0)
+              return ret;
+            current_addr += 4; /* 32-bit value */
+          } else {
+            /* Other multi-instance blocks: Combined 64-bit read */
+            pm4_copy_data_flags_t flags = {
+                .bits = {.src_sel = 0,      /* Non-priv registers */
+                         .dst_sel = 2,      /* TC_L2 memory */
+                         .src_temporal = 3, /* LU cache policy */
+                         .dst_temporal = 3, /* LU cache policy */
+                         .count_sel = 0,    /* 32-bit data */
+                         .wr_confirm = 0}};
+
+            ret = pm4_append_copy_data(buffer, flags, reg_info->register_addr_lo,
+                                       reg_info->register_addr_hi, current_addr);
+            if (ret < 0)
+              return ret;
+
+            current_addr += 8; /* 64-bit counter value */
+          }
+        }
+      } else {
+        /* Single-instance global block - read once
+         *
+         * Special case for GRBM: Read LO and HI as separate 32-bit COPY_DATA packets
+         * instead of one combined 64-bit read. This matches aqlprofile's implementation
+         * for GRBM counters on GFX12.
+         *
+         * Reference: aqlprofile pmc_builder.h ReadXccPackets() - GRBM counters are read
+         * with two separate BuildCopyCounterDataPacket() calls for LO and HI registers.
+         */
+        if (counter->block_id == HW_IP_BLOCK_GRBM) {
+          /* GRBM: Read LO and HI separately as 32-bit values
+           *
+           * GRBM registers have BASE_IDX=1 in gc_12_0_0_offset.h, which means
+           * they need an offset adjustment of -0x2000 to convert from the defined
+           * register offset to the UCONFIG register space offset.
+           *
+           * Example: regGRBM_PERFCOUNTER0_LO = 0x3040 (BASE_IDX=1)
+           *          UCONFIG offset = 0x3040 - 0x2000 = 0x1040
+           *          Absolute UCONFIG address = 0xc000 + 0x1040 = 0xd040
+           *
+           * This matches how aqlprofile handles GRBM registers on GFX12.
+           */
+          pm4_copy_data_flags_t flags = {
+              .bits = {.src_sel = 0,      /* Non-priv registers */
+                       .dst_sel = 2,      /* TC_L2 memory */
+                       .src_temporal = 3, /* LU cache policy */
+                       .dst_temporal = 3, /* LU cache policy */
+                       .count_sel = 0,    /* 32-bit data */
+                       .wr_confirm = 0}};
+
+          /* GRBM register offset adjustment for BASE_IDX=1 */
+          const uint32_t grbm_base_offset = 0x2000;
+          uint32_t grbm_reg_lo = reg_info->register_addr_lo - grbm_base_offset;
+          uint32_t grbm_reg_hi = reg_info->register_addr_hi - grbm_base_offset;
+
+          /* Read LO register (32-bit) */
+          ret = pm4_append_copy_data(buffer, flags, grbm_reg_lo,
+                                     0, current_addr);
+          if (ret < 0)
+            return ret;
+          current_addr += 4; /* 32-bit value */
+
+          /* Read HI register (32-bit) */
+          ret = pm4_append_copy_data(buffer, flags, grbm_reg_hi,
+                                     0, current_addr);
+          if (ret < 0)
+            return ret;
+          current_addr += 4; /* 32-bit value */
+        } else {
+          /* Normal global block: Read LO+HI as one 64-bit value */
+          pm4_copy_data_flags_t flags = {
+              .bits = {.src_sel = 0,      /* Non-priv registers */
+                       .dst_sel = 2,      /* TC_L2 memory */
+                       .src_temporal = 3, /* LU cache policy */
+                       .dst_temporal = 3, /* LU cache policy */
+                       .count_sel = 0,    /* 32-bit data */
+                       .wr_confirm = 0}};
+
+          ret = pm4_append_copy_data(buffer, flags, reg_info->register_addr_lo,
+                                     reg_info->register_addr_hi, current_addr);
+          if (ret < 0)
+            return ret;
+
+          current_addr += 8; /* 64-bit counter value */
+        }
+      }
     }
   }
 
@@ -498,11 +692,23 @@ size_t calculate_counter_memory_size(const arch_t *arch,
 
     size_t counter_size = 8; /* Base 64-bit counter size */
 
-    /* Multiply by topology dimensions - use block-specific dimension sizes */
+    /* Check if block has SE/SA/WGP dimensions */
+    bool has_se_dimension = false;
     for (size_t dim_idx = 0; dim_idx < block->dimension_count; dim_idx++) {
       dimension_t *dim = &block->dimensions[dim_idx];
-      /* Always use the dimension size from the block, not the arch defaults */
+      if (dim->dim == HARDWARE_DIM_SE) {
+        has_se_dimension = true;
+      }
+      /* Multiply by topology dimensions - use block-specific dimension sizes */
       counter_size *= dim->size;
+    }
+
+    /* For global blocks (no SE dimension) with multiple instances,
+     * multiply by instance count to allocate space for all instances.
+     * This handles blocks like GL2C (16 instances) and TCC (16 instances).
+     */
+    if (!has_se_dimension && block->instance_count > 1) {
+      counter_size *= block->instance_count;
     }
 
     total_size += counter_size;

--- a/projects/perf-dkms/src/aql_c/tests/Makefile
+++ b/projects/perf-dkms/src/aql_c/tests/Makefile
@@ -57,10 +57,10 @@ RM = /usr/bin/cmake -E rm -f
 EQUALS = =
 
 # The top-level source directory on which CMake was run.
-CMAKE_SOURCE_DIR = /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms
+CMAKE_SOURCE_DIR = /home/ben/rocm-systems/projects/perf-dkms
 
 # The top-level build directory on which CMake was run.
-CMAKE_BINARY_DIR = /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build
+CMAKE_BINARY_DIR = /home/ben/rocm-systems/projects/perf-dkms/build
 
 #=============================================================================
 # Targets provided globally by CMake.
@@ -142,14 +142,14 @@ install/strip/fast: preinstall/fast
 
 # The main all target
 all: cmake_check_build_system
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(CMAKE_COMMAND) -E cmake_progress_start /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build/CMakeFiles /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build/src/aql_c/tests//CMakeFiles/progress.marks
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/all
-	$(CMAKE_COMMAND) -E cmake_progress_start /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build/CMakeFiles 0
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(CMAKE_COMMAND) -E cmake_progress_start /home/ben/rocm-systems/projects/perf-dkms/build/CMakeFiles /home/ben/rocm-systems/projects/perf-dkms/build/src/aql_c/tests//CMakeFiles/progress.marks
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/all
+	$(CMAKE_COMMAND) -E cmake_progress_start /home/ben/rocm-systems/projects/perf-dkms/build/CMakeFiles 0
 .PHONY : all
 
 # The main clean target
 clean:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/clean
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/clean
 .PHONY : clean
 
 # The main clean target
@@ -158,22 +158,22 @@ clean/fast: clean
 
 # Prepare targets for installation.
 preinstall: all
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/preinstall
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/preinstall
 .PHONY : preinstall
 
 # Prepare targets for installation.
 preinstall/fast:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/preinstall
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/preinstall
 .PHONY : preinstall/fast
 
 # clear depends
 depend:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(CMAKE_COMMAND) -S$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR) --check-build-system CMakeFiles/Makefile.cmake 1
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(CMAKE_COMMAND) -S$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR) --check-build-system CMakeFiles/Makefile.cmake 1
 .PHONY : depend
 
 # Convenience name for target.
 src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/rule:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/rule
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/rule
 .PHONY : src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/rule
 
 # Convenience name for target.
@@ -182,12 +182,12 @@ test_pm4_lib: src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/rule
 
 # fast build rule for target.
 test_pm4_lib/fast:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/build
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/build
 .PHONY : test_pm4_lib/fast
 
 # Convenience name for target.
 src/aql_c/tests/CMakeFiles/test_pm4.dir/rule:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/test_pm4.dir/rule
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/test_pm4.dir/rule
 .PHONY : src/aql_c/tests/CMakeFiles/test_pm4.dir/rule
 
 # Convenience name for target.
@@ -196,12 +196,12 @@ test_pm4: src/aql_c/tests/CMakeFiles/test_pm4.dir/rule
 
 # fast build rule for target.
 test_pm4/fast:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_pm4.dir/build.make src/aql_c/tests/CMakeFiles/test_pm4.dir/build
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_pm4.dir/build.make src/aql_c/tests/CMakeFiles/test_pm4.dir/build
 .PHONY : test_pm4/fast
 
 # Convenience name for target.
 src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/rule:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/rule
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/rule
 .PHONY : src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/rule
 
 # Convenience name for target.
@@ -210,12 +210,12 @@ test_counter_registry_lib: src/aql_c/tests/CMakeFiles/test_counter_registry_lib.
 
 # fast build rule for target.
 test_counter_registry_lib/fast:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build
 .PHONY : test_counter_registry_lib/fast
 
 # Convenience name for target.
 src/aql_c/tests/CMakeFiles/test_counter_registry.dir/rule:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/test_counter_registry.dir/rule
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/test_counter_registry.dir/rule
 .PHONY : src/aql_c/tests/CMakeFiles/test_counter_registry.dir/rule
 
 # Convenience name for target.
@@ -224,12 +224,12 @@ test_counter_registry: src/aql_c/tests/CMakeFiles/test_counter_registry.dir/rule
 
 # fast build rule for target.
 test_counter_registry/fast:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry.dir/build
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry.dir/build
 .PHONY : test_counter_registry/fast
 
 # Convenience name for target.
 src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/rule:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/rule
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/rule
 .PHONY : src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/rule
 
 # Convenience name for target.
@@ -238,12 +238,12 @@ test_packet_generation_lib: src/aql_c/tests/CMakeFiles/test_packet_generation_li
 
 # fast build rule for target.
 test_packet_generation_lib/fast:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build
 .PHONY : test_packet_generation_lib/fast
 
 # Convenience name for target.
 src/aql_c/tests/CMakeFiles/test_packet_generation.dir/rule:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/test_packet_generation.dir/rule
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/test_packet_generation.dir/rule
 .PHONY : src/aql_c/tests/CMakeFiles/test_packet_generation.dir/rule
 
 # Convenience name for target.
@@ -252,12 +252,12 @@ test_packet_generation: src/aql_c/tests/CMakeFiles/test_packet_generation.dir/ru
 
 # fast build rule for target.
 test_packet_generation/fast:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation.dir/build
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation.dir/build
 .PHONY : test_packet_generation/fast
 
 # Convenience name for target.
 src/aql_c/tests/CMakeFiles/run-tests.dir/rule:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/run-tests.dir/rule
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/run-tests.dir/rule
 .PHONY : src/aql_c/tests/CMakeFiles/run-tests.dir/rule
 
 # Convenience name for target.
@@ -266,12 +266,12 @@ run-tests: src/aql_c/tests/CMakeFiles/run-tests.dir/rule
 
 # fast build rule for target.
 run-tests/fast:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/run-tests.dir/build.make src/aql_c/tests/CMakeFiles/run-tests.dir/build
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/run-tests.dir/build.make src/aql_c/tests/CMakeFiles/run-tests.dir/build
 .PHONY : run-tests/fast
 
 # Convenience name for target.
 src/aql_c/tests/CMakeFiles/run-pm4-test.dir/rule:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/run-pm4-test.dir/rule
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/run-pm4-test.dir/rule
 .PHONY : src/aql_c/tests/CMakeFiles/run-pm4-test.dir/rule
 
 # Convenience name for target.
@@ -280,12 +280,12 @@ run-pm4-test: src/aql_c/tests/CMakeFiles/run-pm4-test.dir/rule
 
 # fast build rule for target.
 run-pm4-test/fast:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/run-pm4-test.dir/build.make src/aql_c/tests/CMakeFiles/run-pm4-test.dir/build
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/run-pm4-test.dir/build.make src/aql_c/tests/CMakeFiles/run-pm4-test.dir/build
 .PHONY : run-pm4-test/fast
 
 # Convenience name for target.
 src/aql_c/tests/CMakeFiles/run-counter-test.dir/rule:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/run-counter-test.dir/rule
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/run-counter-test.dir/rule
 .PHONY : src/aql_c/tests/CMakeFiles/run-counter-test.dir/rule
 
 # Convenience name for target.
@@ -294,12 +294,12 @@ run-counter-test: src/aql_c/tests/CMakeFiles/run-counter-test.dir/rule
 
 # fast build rule for target.
 run-counter-test/fast:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/run-counter-test.dir/build.make src/aql_c/tests/CMakeFiles/run-counter-test.dir/build
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/run-counter-test.dir/build.make src/aql_c/tests/CMakeFiles/run-counter-test.dir/build
 .PHONY : run-counter-test/fast
 
 # Convenience name for target.
 src/aql_c/tests/CMakeFiles/run-packet-test.dir/rule:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/run-packet-test.dir/rule
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tests/CMakeFiles/run-packet-test.dir/rule
 .PHONY : src/aql_c/tests/CMakeFiles/run-packet-test.dir/rule
 
 # Convenience name for target.
@@ -308,7 +308,7 @@ run-packet-test: src/aql_c/tests/CMakeFiles/run-packet-test.dir/rule
 
 # fast build rule for target.
 run-packet-test/fast:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/run-packet-test.dir/build.make src/aql_c/tests/CMakeFiles/run-packet-test.dir/build
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/run-packet-test.dir/build.make src/aql_c/tests/CMakeFiles/run-packet-test.dir/build
 .PHONY : run-packet-test/fast
 
 __/arch_creator.o: __/arch_creator.c.o
@@ -316,8 +316,8 @@ __/arch_creator.o: __/arch_creator.c.o
 
 # target to build an object file
 __/arch_creator.c.o:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/arch_creator.c.o
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/arch_creator.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/arch_creator.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/arch_creator.c.o
 .PHONY : __/arch_creator.c.o
 
 __/arch_creator.i: __/arch_creator.c.i
@@ -325,8 +325,8 @@ __/arch_creator.i: __/arch_creator.c.i
 
 # target to preprocess a source file
 __/arch_creator.c.i:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/arch_creator.c.i
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/arch_creator.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/arch_creator.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/arch_creator.c.i
 .PHONY : __/arch_creator.c.i
 
 __/arch_creator.s: __/arch_creator.c.s
@@ -334,8 +334,8 @@ __/arch_creator.s: __/arch_creator.c.s
 
 # target to generate assembly for a file
 __/arch_creator.c.s:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/arch_creator.c.s
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/arch_creator.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/arch_creator.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/arch_creator.c.s
 .PHONY : __/arch_creator.c.s
 
 __/counter_registry.o: __/counter_registry.c.o
@@ -343,8 +343,8 @@ __/counter_registry.o: __/counter_registry.c.o
 
 # target to build an object file
 __/counter_registry.c.o:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/counter_registry.c.o
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/counter_registry.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/counter_registry.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/counter_registry.c.o
 .PHONY : __/counter_registry.c.o
 
 __/counter_registry.i: __/counter_registry.c.i
@@ -352,8 +352,8 @@ __/counter_registry.i: __/counter_registry.c.i
 
 # target to preprocess a source file
 __/counter_registry.c.i:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/counter_registry.c.i
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/counter_registry.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/counter_registry.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/counter_registry.c.i
 .PHONY : __/counter_registry.c.i
 
 __/counter_registry.s: __/counter_registry.c.s
@@ -361,8 +361,8 @@ __/counter_registry.s: __/counter_registry.c.s
 
 # target to generate assembly for a file
 __/counter_registry.c.s:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/counter_registry.c.s
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/counter_registry.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/counter_registry.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/counter_registry.c.s
 .PHONY : __/counter_registry.c.s
 
 __/gfx12_creator.o: __/gfx12_creator.c.o
@@ -370,8 +370,8 @@ __/gfx12_creator.o: __/gfx12_creator.c.o
 
 # target to build an object file
 __/gfx12_creator.c.o:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/gfx12_creator.c.o
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/gfx12_creator.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/gfx12_creator.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/gfx12_creator.c.o
 .PHONY : __/gfx12_creator.c.o
 
 __/gfx12_creator.i: __/gfx12_creator.c.i
@@ -379,8 +379,8 @@ __/gfx12_creator.i: __/gfx12_creator.c.i
 
 # target to preprocess a source file
 __/gfx12_creator.c.i:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/gfx12_creator.c.i
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/gfx12_creator.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/gfx12_creator.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/gfx12_creator.c.i
 .PHONY : __/gfx12_creator.c.i
 
 __/gfx12_creator.s: __/gfx12_creator.c.s
@@ -388,8 +388,8 @@ __/gfx12_creator.s: __/gfx12_creator.c.s
 
 # target to generate assembly for a file
 __/gfx12_creator.c.s:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/gfx12_creator.c.s
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/gfx12_creator.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/gfx12_creator.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/gfx12_creator.c.s
 .PHONY : __/gfx12_creator.c.s
 
 __/gfx12_events.o: __/gfx12_events.c.o
@@ -397,8 +397,8 @@ __/gfx12_events.o: __/gfx12_events.c.o
 
 # target to build an object file
 __/gfx12_events.c.o:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/gfx12_events.c.o
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/gfx12_events.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/gfx12_events.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/gfx12_events.c.o
 .PHONY : __/gfx12_events.c.o
 
 __/gfx12_events.i: __/gfx12_events.c.i
@@ -406,8 +406,8 @@ __/gfx12_events.i: __/gfx12_events.c.i
 
 # target to preprocess a source file
 __/gfx12_events.c.i:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/gfx12_events.c.i
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/gfx12_events.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/gfx12_events.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/gfx12_events.c.i
 .PHONY : __/gfx12_events.c.i
 
 __/gfx12_events.s: __/gfx12_events.c.s
@@ -415,8 +415,8 @@ __/gfx12_events.s: __/gfx12_events.c.s
 
 # target to generate assembly for a file
 __/gfx12_events.c.s:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/gfx12_events.c.s
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/gfx12_events.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry_lib.dir/__/gfx12_events.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/gfx12_events.c.s
 .PHONY : __/gfx12_events.c.s
 
 __/packet_generation.o: __/packet_generation.c.o
@@ -424,7 +424,7 @@ __/packet_generation.o: __/packet_generation.c.o
 
 # target to build an object file
 __/packet_generation.c.o:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/packet_generation.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/packet_generation.c.o
 .PHONY : __/packet_generation.c.o
 
 __/packet_generation.i: __/packet_generation.c.i
@@ -432,7 +432,7 @@ __/packet_generation.i: __/packet_generation.c.i
 
 # target to preprocess a source file
 __/packet_generation.c.i:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/packet_generation.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/packet_generation.c.i
 .PHONY : __/packet_generation.c.i
 
 __/packet_generation.s: __/packet_generation.c.s
@@ -440,7 +440,7 @@ __/packet_generation.s: __/packet_generation.c.s
 
 # target to generate assembly for a file
 __/packet_generation.c.s:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/packet_generation.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/packet_generation.c.s
 .PHONY : __/packet_generation.c.s
 
 __/pm4_packets.o: __/pm4_packets.c.o
@@ -448,8 +448,8 @@ __/pm4_packets.o: __/pm4_packets.c.o
 
 # target to build an object file
 __/pm4_packets.c.o:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/__/pm4_packets.c.o
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/pm4_packets.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/__/pm4_packets.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/pm4_packets.c.o
 .PHONY : __/pm4_packets.c.o
 
 __/pm4_packets.i: __/pm4_packets.c.i
@@ -457,8 +457,8 @@ __/pm4_packets.i: __/pm4_packets.c.i
 
 # target to preprocess a source file
 __/pm4_packets.c.i:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/__/pm4_packets.c.i
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/pm4_packets.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/__/pm4_packets.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/pm4_packets.c.i
 .PHONY : __/pm4_packets.c.i
 
 __/pm4_packets.s: __/pm4_packets.c.s
@@ -466,8 +466,8 @@ __/pm4_packets.s: __/pm4_packets.c.s
 
 # target to generate assembly for a file
 __/pm4_packets.c.s:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/__/pm4_packets.c.s
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/pm4_packets.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_pm4_lib.dir/__/pm4_packets.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation_lib.dir/__/pm4_packets.c.s
 .PHONY : __/pm4_packets.c.s
 
 test_counter_registry.o: test_counter_registry.c.o
@@ -475,7 +475,7 @@ test_counter_registry.o: test_counter_registry.c.o
 
 # target to build an object file
 test_counter_registry.c.o:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry.dir/test_counter_registry.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry.dir/test_counter_registry.c.o
 .PHONY : test_counter_registry.c.o
 
 test_counter_registry.i: test_counter_registry.c.i
@@ -483,7 +483,7 @@ test_counter_registry.i: test_counter_registry.c.i
 
 # target to preprocess a source file
 test_counter_registry.c.i:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry.dir/test_counter_registry.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry.dir/test_counter_registry.c.i
 .PHONY : test_counter_registry.c.i
 
 test_counter_registry.s: test_counter_registry.c.s
@@ -491,7 +491,7 @@ test_counter_registry.s: test_counter_registry.c.s
 
 # target to generate assembly for a file
 test_counter_registry.c.s:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry.dir/test_counter_registry.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_counter_registry.dir/build.make src/aql_c/tests/CMakeFiles/test_counter_registry.dir/test_counter_registry.c.s
 .PHONY : test_counter_registry.c.s
 
 test_packet_generation.o: test_packet_generation.c.o
@@ -499,7 +499,7 @@ test_packet_generation.o: test_packet_generation.c.o
 
 # target to build an object file
 test_packet_generation.c.o:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation.dir/test_packet_generation.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation.dir/test_packet_generation.c.o
 .PHONY : test_packet_generation.c.o
 
 test_packet_generation.i: test_packet_generation.c.i
@@ -507,7 +507,7 @@ test_packet_generation.i: test_packet_generation.c.i
 
 # target to preprocess a source file
 test_packet_generation.c.i:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation.dir/test_packet_generation.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation.dir/test_packet_generation.c.i
 .PHONY : test_packet_generation.c.i
 
 test_packet_generation.s: test_packet_generation.c.s
@@ -515,7 +515,7 @@ test_packet_generation.s: test_packet_generation.c.s
 
 # target to generate assembly for a file
 test_packet_generation.c.s:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation.dir/test_packet_generation.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_packet_generation.dir/build.make src/aql_c/tests/CMakeFiles/test_packet_generation.dir/test_packet_generation.c.s
 .PHONY : test_packet_generation.c.s
 
 test_pm4_packets.o: test_pm4_packets.c.o
@@ -523,7 +523,7 @@ test_pm4_packets.o: test_pm4_packets.c.o
 
 # target to build an object file
 test_pm4_packets.c.o:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_pm4.dir/build.make src/aql_c/tests/CMakeFiles/test_pm4.dir/test_pm4_packets.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_pm4.dir/build.make src/aql_c/tests/CMakeFiles/test_pm4.dir/test_pm4_packets.c.o
 .PHONY : test_pm4_packets.c.o
 
 test_pm4_packets.i: test_pm4_packets.c.i
@@ -531,7 +531,7 @@ test_pm4_packets.i: test_pm4_packets.c.i
 
 # target to preprocess a source file
 test_pm4_packets.c.i:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_pm4.dir/build.make src/aql_c/tests/CMakeFiles/test_pm4.dir/test_pm4_packets.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_pm4.dir/build.make src/aql_c/tests/CMakeFiles/test_pm4.dir/test_pm4_packets.c.i
 .PHONY : test_pm4_packets.c.i
 
 test_pm4_packets.s: test_pm4_packets.c.s
@@ -539,7 +539,7 @@ test_pm4_packets.s: test_pm4_packets.c.s
 
 # target to generate assembly for a file
 test_pm4_packets.c.s:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_pm4.dir/build.make src/aql_c/tests/CMakeFiles/test_pm4.dir/test_pm4_packets.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tests/CMakeFiles/test_pm4.dir/build.make src/aql_c/tests/CMakeFiles/test_pm4.dir/test_pm4_packets.c.s
 .PHONY : test_pm4_packets.c.s
 
 # Help Target
@@ -603,6 +603,6 @@ help:
 # No rule that depends on this can have commands that come from listfiles
 # because they might be regenerated.
 cmake_check_build_system:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(CMAKE_COMMAND) -S$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR) --check-build-system CMakeFiles/Makefile.cmake 0
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(CMAKE_COMMAND) -S$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR) --check-build-system CMakeFiles/Makefile.cmake 0
 .PHONY : cmake_check_build_system
 

--- a/projects/perf-dkms/src/aql_c/tools/Makefile
+++ b/projects/perf-dkms/src/aql_c/tools/Makefile
@@ -57,10 +57,10 @@ RM = /usr/bin/cmake -E rm -f
 EQUALS = =
 
 # The top-level source directory on which CMake was run.
-CMAKE_SOURCE_DIR = /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms
+CMAKE_SOURCE_DIR = /home/ben/rocm-systems/projects/perf-dkms
 
 # The top-level build directory on which CMake was run.
-CMAKE_BINARY_DIR = /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build
+CMAKE_BINARY_DIR = /home/ben/rocm-systems/projects/perf-dkms/build
 
 #=============================================================================
 # Targets provided globally by CMake.
@@ -142,14 +142,14 @@ install/strip/fast: preinstall/fast
 
 # The main all target
 all: cmake_check_build_system
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(CMAKE_COMMAND) -E cmake_progress_start /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build/CMakeFiles /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build/src/aql_c/tools//CMakeFiles/progress.marks
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tools/all
-	$(CMAKE_COMMAND) -E cmake_progress_start /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build/CMakeFiles 0
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(CMAKE_COMMAND) -E cmake_progress_start /home/ben/rocm-systems/projects/perf-dkms/build/CMakeFiles /home/ben/rocm-systems/projects/perf-dkms/build/src/aql_c/tools//CMakeFiles/progress.marks
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tools/all
+	$(CMAKE_COMMAND) -E cmake_progress_start /home/ben/rocm-systems/projects/perf-dkms/build/CMakeFiles 0
 .PHONY : all
 
 # The main clean target
 clean:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tools/clean
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tools/clean
 .PHONY : clean
 
 # The main clean target
@@ -158,22 +158,22 @@ clean/fast: clean
 
 # Prepare targets for installation.
 preinstall: all
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tools/preinstall
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tools/preinstall
 .PHONY : preinstall
 
 # Prepare targets for installation.
 preinstall/fast:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tools/preinstall
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tools/preinstall
 .PHONY : preinstall/fast
 
 # clear depends
 depend:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(CMAKE_COMMAND) -S$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR) --check-build-system CMakeFiles/Makefile.cmake 1
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(CMAKE_COMMAND) -S$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR) --check-build-system CMakeFiles/Makefile.cmake 1
 .PHONY : depend
 
 # Convenience name for target.
 src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/rule:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/rule
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/rule
 .PHONY : src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/rule
 
 # Convenience name for target.
@@ -182,12 +182,12 @@ packet_gen_tool: src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/rule
 
 # fast build rule for target.
 packet_gen_tool/fast:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build
 .PHONY : packet_gen_tool/fast
 
 # Convenience name for target.
 src/aql_c/tools/CMakeFiles/pm4_decoder.dir/rule:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tools/CMakeFiles/pm4_decoder.dir/rule
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tools/CMakeFiles/pm4_decoder.dir/rule
 .PHONY : src/aql_c/tools/CMakeFiles/pm4_decoder.dir/rule
 
 # Convenience name for target.
@@ -196,12 +196,12 @@ pm4_decoder: src/aql_c/tools/CMakeFiles/pm4_decoder.dir/rule
 
 # fast build rule for target.
 pm4_decoder/fast:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/pm4_decoder.dir/build.make src/aql_c/tools/CMakeFiles/pm4_decoder.dir/build
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/pm4_decoder.dir/build.make src/aql_c/tools/CMakeFiles/pm4_decoder.dir/build
 .PHONY : pm4_decoder/fast
 
 # Convenience name for target.
 src/aql_c/tools/CMakeFiles/tools-help.dir/rule:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tools/CMakeFiles/tools-help.dir/rule
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f CMakeFiles/Makefile2 src/aql_c/tools/CMakeFiles/tools-help.dir/rule
 .PHONY : src/aql_c/tools/CMakeFiles/tools-help.dir/rule
 
 # Convenience name for target.
@@ -210,7 +210,7 @@ tools-help: src/aql_c/tools/CMakeFiles/tools-help.dir/rule
 
 # fast build rule for target.
 tools-help/fast:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/tools-help.dir/build.make src/aql_c/tools/CMakeFiles/tools-help.dir/build
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/tools-help.dir/build.make src/aql_c/tools/CMakeFiles/tools-help.dir/build
 .PHONY : tools-help/fast
 
 __/arch_creator.o: __/arch_creator.c.o
@@ -218,7 +218,7 @@ __/arch_creator.o: __/arch_creator.c.o
 
 # target to build an object file
 __/arch_creator.c.o:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/arch_creator.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/arch_creator.c.o
 .PHONY : __/arch_creator.c.o
 
 __/arch_creator.i: __/arch_creator.c.i
@@ -226,7 +226,7 @@ __/arch_creator.i: __/arch_creator.c.i
 
 # target to preprocess a source file
 __/arch_creator.c.i:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/arch_creator.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/arch_creator.c.i
 .PHONY : __/arch_creator.c.i
 
 __/arch_creator.s: __/arch_creator.c.s
@@ -234,7 +234,7 @@ __/arch_creator.s: __/arch_creator.c.s
 
 # target to generate assembly for a file
 __/arch_creator.c.s:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/arch_creator.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/arch_creator.c.s
 .PHONY : __/arch_creator.c.s
 
 __/counter_registry.o: __/counter_registry.c.o
@@ -242,7 +242,7 @@ __/counter_registry.o: __/counter_registry.c.o
 
 # target to build an object file
 __/counter_registry.c.o:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/counter_registry.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/counter_registry.c.o
 .PHONY : __/counter_registry.c.o
 
 __/counter_registry.i: __/counter_registry.c.i
@@ -250,7 +250,7 @@ __/counter_registry.i: __/counter_registry.c.i
 
 # target to preprocess a source file
 __/counter_registry.c.i:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/counter_registry.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/counter_registry.c.i
 .PHONY : __/counter_registry.c.i
 
 __/counter_registry.s: __/counter_registry.c.s
@@ -258,7 +258,7 @@ __/counter_registry.s: __/counter_registry.c.s
 
 # target to generate assembly for a file
 __/counter_registry.c.s:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/counter_registry.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/counter_registry.c.s
 .PHONY : __/counter_registry.c.s
 
 __/gfx12_creator.o: __/gfx12_creator.c.o
@@ -266,7 +266,7 @@ __/gfx12_creator.o: __/gfx12_creator.c.o
 
 # target to build an object file
 __/gfx12_creator.c.o:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/gfx12_creator.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/gfx12_creator.c.o
 .PHONY : __/gfx12_creator.c.o
 
 __/gfx12_creator.i: __/gfx12_creator.c.i
@@ -274,7 +274,7 @@ __/gfx12_creator.i: __/gfx12_creator.c.i
 
 # target to preprocess a source file
 __/gfx12_creator.c.i:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/gfx12_creator.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/gfx12_creator.c.i
 .PHONY : __/gfx12_creator.c.i
 
 __/gfx12_creator.s: __/gfx12_creator.c.s
@@ -282,7 +282,7 @@ __/gfx12_creator.s: __/gfx12_creator.c.s
 
 # target to generate assembly for a file
 __/gfx12_creator.c.s:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/gfx12_creator.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/gfx12_creator.c.s
 .PHONY : __/gfx12_creator.c.s
 
 __/gfx12_events.o: __/gfx12_events.c.o
@@ -290,7 +290,7 @@ __/gfx12_events.o: __/gfx12_events.c.o
 
 # target to build an object file
 __/gfx12_events.c.o:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/gfx12_events.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/gfx12_events.c.o
 .PHONY : __/gfx12_events.c.o
 
 __/gfx12_events.i: __/gfx12_events.c.i
@@ -298,7 +298,7 @@ __/gfx12_events.i: __/gfx12_events.c.i
 
 # target to preprocess a source file
 __/gfx12_events.c.i:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/gfx12_events.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/gfx12_events.c.i
 .PHONY : __/gfx12_events.c.i
 
 __/gfx12_events.s: __/gfx12_events.c.s
@@ -306,7 +306,7 @@ __/gfx12_events.s: __/gfx12_events.c.s
 
 # target to generate assembly for a file
 __/gfx12_events.c.s:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/gfx12_events.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/gfx12_events.c.s
 .PHONY : __/gfx12_events.c.s
 
 __/packet_generation.o: __/packet_generation.c.o
@@ -314,7 +314,7 @@ __/packet_generation.o: __/packet_generation.c.o
 
 # target to build an object file
 __/packet_generation.c.o:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/packet_generation.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/packet_generation.c.o
 .PHONY : __/packet_generation.c.o
 
 __/packet_generation.i: __/packet_generation.c.i
@@ -322,7 +322,7 @@ __/packet_generation.i: __/packet_generation.c.i
 
 # target to preprocess a source file
 __/packet_generation.c.i:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/packet_generation.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/packet_generation.c.i
 .PHONY : __/packet_generation.c.i
 
 __/packet_generation.s: __/packet_generation.c.s
@@ -330,7 +330,7 @@ __/packet_generation.s: __/packet_generation.c.s
 
 # target to generate assembly for a file
 __/packet_generation.c.s:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/packet_generation.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/packet_generation.c.s
 .PHONY : __/packet_generation.c.s
 
 __/pm4_packets.o: __/pm4_packets.c.o
@@ -338,7 +338,7 @@ __/pm4_packets.o: __/pm4_packets.c.o
 
 # target to build an object file
 __/pm4_packets.c.o:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/pm4_packets.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/pm4_packets.c.o
 .PHONY : __/pm4_packets.c.o
 
 __/pm4_packets.i: __/pm4_packets.c.i
@@ -346,7 +346,7 @@ __/pm4_packets.i: __/pm4_packets.c.i
 
 # target to preprocess a source file
 __/pm4_packets.c.i:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/pm4_packets.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/pm4_packets.c.i
 .PHONY : __/pm4_packets.c.i
 
 __/pm4_packets.s: __/pm4_packets.c.s
@@ -354,7 +354,7 @@ __/pm4_packets.s: __/pm4_packets.c.s
 
 # target to generate assembly for a file
 __/pm4_packets.c.s:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/pm4_packets.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/__/pm4_packets.c.s
 .PHONY : __/pm4_packets.c.s
 
 packet_gen_tool.o: packet_gen_tool.c.o
@@ -362,7 +362,7 @@ packet_gen_tool.o: packet_gen_tool.c.o
 
 # target to build an object file
 packet_gen_tool.c.o:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/packet_gen_tool.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/packet_gen_tool.c.o
 .PHONY : packet_gen_tool.c.o
 
 packet_gen_tool.i: packet_gen_tool.c.i
@@ -370,7 +370,7 @@ packet_gen_tool.i: packet_gen_tool.c.i
 
 # target to preprocess a source file
 packet_gen_tool.c.i:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/packet_gen_tool.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/packet_gen_tool.c.i
 .PHONY : packet_gen_tool.c.i
 
 packet_gen_tool.s: packet_gen_tool.c.s
@@ -378,7 +378,7 @@ packet_gen_tool.s: packet_gen_tool.c.s
 
 # target to generate assembly for a file
 packet_gen_tool.c.s:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/packet_gen_tool.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/build.make src/aql_c/tools/CMakeFiles/packet_gen_tool.dir/packet_gen_tool.c.s
 .PHONY : packet_gen_tool.c.s
 
 pm4_decoder.o: pm4_decoder.c.o
@@ -386,7 +386,7 @@ pm4_decoder.o: pm4_decoder.c.o
 
 # target to build an object file
 pm4_decoder.c.o:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/pm4_decoder.dir/build.make src/aql_c/tools/CMakeFiles/pm4_decoder.dir/pm4_decoder.c.o
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/pm4_decoder.dir/build.make src/aql_c/tools/CMakeFiles/pm4_decoder.dir/pm4_decoder.c.o
 .PHONY : pm4_decoder.c.o
 
 pm4_decoder.i: pm4_decoder.c.i
@@ -394,7 +394,7 @@ pm4_decoder.i: pm4_decoder.c.i
 
 # target to preprocess a source file
 pm4_decoder.c.i:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/pm4_decoder.dir/build.make src/aql_c/tools/CMakeFiles/pm4_decoder.dir/pm4_decoder.c.i
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/pm4_decoder.dir/build.make src/aql_c/tools/CMakeFiles/pm4_decoder.dir/pm4_decoder.c.i
 .PHONY : pm4_decoder.c.i
 
 pm4_decoder.s: pm4_decoder.c.s
@@ -402,7 +402,7 @@ pm4_decoder.s: pm4_decoder.c.s
 
 # target to generate assembly for a file
 pm4_decoder.c.s:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/pm4_decoder.dir/build.make src/aql_c/tools/CMakeFiles/pm4_decoder.dir/pm4_decoder.c.s
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(MAKE) $(MAKESILENT) -f src/aql_c/tools/CMakeFiles/pm4_decoder.dir/build.make src/aql_c/tools/CMakeFiles/pm4_decoder.dir/pm4_decoder.c.s
 .PHONY : pm4_decoder.c.s
 
 # Help Target
@@ -456,6 +456,6 @@ help:
 # No rule that depends on this can have commands that come from listfiles
 # because they might be regenerated.
 cmake_check_build_system:
-	cd /home/ben/rocm-systems/worktrees/rename/projects/perf-dkms/build && $(CMAKE_COMMAND) -S$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR) --check-build-system CMakeFiles/Makefile.cmake 0
+	cd /home/ben/rocm-systems/projects/perf-dkms/build && $(CMAKE_COMMAND) -S$(CMAKE_SOURCE_DIR) -B$(CMAKE_BINARY_DIR) --check-build-system CMakeFiles/Makefile.cmake 0
 .PHONY : cmake_check_build_system
 

--- a/projects/perf-dkms/src/aql_packet_ops.c
+++ b/projects/perf-dkms/src/aql_packet_ops.c
@@ -124,7 +124,7 @@ static struct shared_counter_ref *create_shared_counter(
  *
  * Decrements reference count. When count reaches zero, removes from list and frees.
  */
-static void release_shared_counter(
+void release_shared_counter(
     struct aql_perf_session *session,
     struct shared_counter_ref *ref)
 {

--- a/projects/perf-dkms/src/aql_perf.c
+++ b/projects/perf-dkms/src/aql_perf.c
@@ -240,8 +240,50 @@ static void aql_perf_session_release(struct aql_perf_session *session)
 
     aql_debug("Releasing session %llu", session->session_id);
 
-    /* Ensure all measurements are stopped */
-    // This will be implemented in measurement management
+    /* Ensure all measurements are stopped and cleaned up */
+    {
+        struct aql_measurement *measurement, *tmp;
+        struct list_head local_list;
+
+        INIT_LIST_HEAD(&local_list);
+
+        /* Move all measurements to local list to avoid holding spinlock during cleanup */
+        spin_lock(&session->measurement_lock);
+        list_splice_init(&session->active_measurements, &local_list);
+        spin_unlock(&session->measurement_lock);
+
+        /* Stop and cleanup each measurement */
+        list_for_each_entry_safe(measurement, tmp, &local_list, list) {
+            aql_debug("Cleaning up measurement for GPU %u", measurement->gpu_id);
+
+            /* Stop measurement if active */
+            if (measurement->state == MEASUREMENT_ACTIVE) {
+                aql_perf_measurement_stop(measurement);
+            }
+
+            /* Flush and destroy workqueue */
+            if (measurement->work_queue) {
+                flush_workqueue(measurement->work_queue);
+                destroy_workqueue(measurement->work_queue);
+                measurement->work_queue = NULL;
+            }
+
+            /* Release counter if owned */
+            if (measurement->owns_counter && measurement->allocated_counter) {
+                aql_counter_release(measurement->allocated_counter);
+                measurement->allocated_counter = NULL;
+            }
+
+            /* Release shared reference */
+            if (measurement->shared_ref) {
+                release_shared_counter(session, measurement->shared_ref);
+                measurement->shared_ref = NULL;
+            }
+
+            /* Free measurement (already removed from active_measurements by list_splice_init) */
+            kfree(measurement);
+        }
+    }
 
     /* Clean up any remaining shared counter refs */
     {

--- a/projects/perf-dkms/src/aql_perf.h
+++ b/projects/perf-dkms/src/aql_perf.h
@@ -299,6 +299,8 @@ counter_reg_info_t* aql_counter_try_allocate(block_info_t *block,
                                              uint32_t event_id,
                                              struct perf_event *perf_event);
 void aql_counter_release(counter_reg_info_t *reg);
+void release_shared_counter(struct aql_perf_session *session,
+                            struct shared_counter_ref *ref);
 int aql_build_counter_info(uint32_t counter_id,
                            arch_t *arch,
                            counter_reg_info_t *allocated_counter,

--- a/projects/perf-dkms/src/aql_pmu_integration.c
+++ b/projects/perf-dkms/src/aql_pmu_integration.c
@@ -61,6 +61,72 @@ int aql_pmu_init(void)
 }
 
 /**
+ * aql_pmu_flush_all_measurements - Flush all measurement workqueues before cleanup
+ *
+ * This function ensures all pending work items complete before session cleanup.
+ * Must be called AFTER timer is cancelled but BEFORE session is released.
+ *
+ * IMPORTANT: This prevents use-after-free by ensuring no work handlers are running
+ * or queued when we free session resources.
+ *
+ * FIX: Use array-based approach to avoid list iterator invalidation.
+ * The previous version released the spinlock during iteration, which could cause
+ * use-after-free if another thread modified the list (poison value dead000000000100).
+ */
+void aql_pmu_flush_all_measurements(void)
+{
+    struct aql_perf_session *session;
+    struct aql_measurement *measurement;
+    struct workqueue_struct **queues;
+    int count = 0;
+    int capacity = 16;
+    unsigned long flags;
+    int i;
+
+    mutex_lock(&aql_pmu_mutex);
+
+    session = global_aql_session;
+    if (!session) {
+        mutex_unlock(&aql_pmu_mutex);
+        return;
+    }
+
+    /* Take reference to prevent session from being freed */
+    aql_perf_session_get(session);
+
+    /* Allocate array to hold workqueue pointers */
+    queues = kmalloc(capacity * sizeof(struct workqueue_struct *), GFP_KERNEL);
+    if (!queues) {
+        aql_perf_session_put(session);
+        mutex_unlock(&aql_pmu_mutex);
+        pmu_err("Failed to allocate memory for workqueue flush");
+        return;
+    }
+
+    /* Build array of workqueue pointers while holding lock */
+    spin_lock_irqsave(&session->measurement_lock, flags);
+    list_for_each_entry(measurement, &session->active_measurements, list) {
+        if (measurement->work_queue && count < capacity) {
+            queues[count++] = measurement->work_queue;
+        }
+    }
+    spin_unlock_irqrestore(&session->measurement_lock, flags);
+
+    /* Flush all workqueues outside the lock (safe - no list iteration) */
+    for (i = 0; i < count; i++) {
+        pmu_info("Flushing workqueue %d/%d", i + 1, count);
+        flush_workqueue(queues[i]);
+    }
+
+    kfree(queues);
+
+    aql_perf_session_put(session);
+    mutex_unlock(&aql_pmu_mutex);
+
+    pmu_info("All measurement workqueues flushed (%d total)", count);
+}
+
+/**
  * aql_pmu_cleanup - Cleanup AQL PMU integration
  */
 void aql_pmu_cleanup(void)
@@ -513,6 +579,7 @@ void aql_pmu_get_stats(struct aql_perf_stats *stats)
 
 EXPORT_SYMBOL_GPL(aql_pmu_init);
 EXPORT_SYMBOL_GPL(aql_pmu_cleanup);
+EXPORT_SYMBOL_GPL(aql_pmu_flush_all_measurements);
 EXPORT_SYMBOL_GPL(aql_pmu_is_available);
 EXPORT_SYMBOL_GPL(aql_pmu_event_init);
 EXPORT_SYMBOL_GPL(aql_pmu_event_destroy);

--- a/projects/perf-dkms/src/pmu_dimension.h
+++ b/projects/perf-dkms/src/pmu_dimension.h
@@ -13,7 +13,14 @@
 #ifndef _PMU_DIMENSION_H
 #define _PMU_DIMENSION_H
 
+#ifdef __KERNEL__
 #include <linux/types.h>
+#else
+#include <stdint.h>
+#include <stdbool.h>
+typedef uint8_t u8;
+typedef uint64_t u64;
+#endif
 
 /*
  * config1 Bit Field Layout for Dimension Encoding

--- a/projects/perf-dkms/src/pmu_main.c
+++ b/projects/perf-dkms/src/pmu_main.c
@@ -861,9 +861,13 @@ static void __exit amdgpu_pmu_exit(void)
     pmu_info("Unloading PMU Stub module\n");
 
     if (pmu) {
-        /* Cancel timer */
+        /* Step 1: Stop timer to prevent new work from being queued */
         hrtimer_cancel(&pmu->timer);
 
+        /* Step 2: Flush all measurement workqueues BEFORE session cleanup */
+        aql_pmu_flush_all_measurements();
+
+        /* Step 3: Now safe to release session */
         aql_pmu_cleanup();
         pmu_info("AQL hardware acceleration disabled\n");
 


### PR DESCRIPTION
## Summary
This PR resolves DMA fence timeout deadlocks when reading GL2C and TCC performance counters by fixing PM4 packet generation to match hardware requirements for multi-instance global blocks.

## Problem
GL2C and TCC counters were causing kernel hangs with DMA fence timeouts when accessed via perf. The root cause was incorrect PM4 packet generation that didn't match the hardware requirements for these multi-instance blocks.

## Solution
Fixed five critical issues in packet generation:

1. **Per-instance START configuration**: GL2C/TCC require individual instance configuration instead of broadcast mode
2. **Split 32-bit reads**: These blocks need separate LO+HI 32-bit reads instead of combined 64-bit reads  
3. **Broadcast-instance toggle**: Added required toggle sequence before each instance read
4. **Absolute register addresses**: COPY_DATA packets now use absolute UCONFIG addresses (0xd380) instead of relative offsets (0x1380)
5. **Removed duplicate broadcasts**: Eliminated redundant broadcast writes for multi-instance blocks

## Additional Improvements
- Enhanced measurement cleanup in session release to prevent memory leaks
- Improved workqueue management in measurement teardown
- Updated PMU integration for better dimension handling
- Fixed counter registry and GFX12-specific initialization

## Testing
- GL2C_HIT counter no longer causes DMA fence timeouts
- Test completes successfully without kernel hangs
- Packet validation confirms generated packets match rocprofiler-sdk reference implementation

## Files Changed
- `src/aql_c/packet_generation.c` - Core GL2C/TCC packet generation fixes
- `src/aql_perf.c` - Measurement cleanup improvements
- `src/aql_pmu_integration.c` - PMU integration enhancements
- Additional header and registry updates