### PR TITLE
Track process_sampler state for CPU sampling

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/cpu_freq.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/cpu_freq.cpp
@@ -254,6 +254,8 @@ config()
 void
 sample()
 {
+    if(get_state() >= State::Finalized) return;
+
     auto _timestamp = tim::get_clock_real_now<size_t, std::nano>();
 
     auto _rcache = tim::rusage_cache{ RUSAGE_SELF };


### PR DESCRIPTION
## Motivation

When sampling multiprocess applications the CPU sampler is not stopping when process_sampler is stopped, causing it to try to write to closed buffer.

## Technical Details

Added state check inside of CPU sampler.

## Test Plan

Tested with vllm workloads

## Test Result

All tests pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
