### PR TITLE
CP 7.2 rocr: Fix IPC dmabuf hang with large allocations

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -892,7 +892,7 @@ class Runtime {
 
   // IPC DMA buf unix domain socket server dmabuf FD passing
   int ipc_sock_server_fd_;
-  std::map<uint64_t, int> ipc_sock_server_conns_;
+  std::map<uint64_t, size_t> ipc_sock_server_conns_;
   KernelMutex ipc_sock_server_lock_;
 
  private:


### PR DESCRIPTION
## Motivation
Changed ipc_sock_server_conns_ map's value to size_t. Previous type of int caused allocations of sizes greater than 2GB to overflow, causing the message len to be stored as a negative value, preventing the IPC server from exporting the dmabuf file descriptors properly, which lead to hangs on the importer process receiving malformed data.
