### PR TITLE
[rocprof-sys] Add test cleanup fixtures for binary-rewrite and runtime-instrument tests

### DIFF
--- a/projects/rocprofiler-systems/tests/rocprof-sys-python-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-python-tests.cmake
@@ -90,6 +90,9 @@ foreach(_VERSION ${ROCPROFSYS_PYTHON_VERSIONS})
         DEPENDS code-coverage-basic-blocks-binary-rewrite
                 code-coverage-basic-blocks-binary-rewrite-run
                 code-coverage-basic-blocks-hybrid-runtime-instrument
+        FIXTURES_REQUIRED
+            code-coverage-basic-blocks-binary-rewrite-fixture
+            code-coverage-basic-blocks-hybrid-runtime-instrument-fixture
         LABELS "code-coverage"
         ENVIRONMENT "${_python_environment}"
     )

--- a/projects/rocprofiler-systems/tests/rocprof-sys-testing.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-testing.cmake
@@ -1365,6 +1365,64 @@ function(ROCPROFILER_SYSTEMS_ADD_VALIDATION_TEST)
                 ${TEST_PROPERTIES}
         )
     endforeach()
+
+    if(TEST_ROCPD_FILE)
+        set(_DB_FIXTURE "rocprofsys-${TEST_NAME}-db")
+
+        add_test(
+            NAME ${TEST_NAME}-cleanup-db
+            COMMAND
+                sh -c
+                "rm -f ${PROJECT_BINARY_DIR}/rocprof-sys-tests-output/${TEST_NAME}/*.db"
+            WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+        )
+
+        set_tests_properties(
+            ${TEST_NAME}-cleanup-db
+            PROPERTIES
+                FIXTURES_CLEANUP ${_DB_FIXTURE}
+                LABELS "cleanup;db;rocpd"
+                TIMEOUT 30
+        )
+
+        if(TEST ${TEST_NAME})
+            get_test_property(${TEST_NAME} FIXTURES_REQUIRED _EXISTING_FIXTURES)
+            if(_EXISTING_FIXTURES)
+                set_tests_properties(
+                    ${TEST_NAME}
+                    PROPERTIES FIXTURES_REQUIRED "${_EXISTING_FIXTURES};${_DB_FIXTURE}"
+                )
+            else()
+                set_tests_properties(
+                    ${TEST_NAME}
+                    PROPERTIES FIXTURES_REQUIRED "${_DB_FIXTURE}"
+                )
+            endif()
+        endif()
+
+        foreach(
+            _VAL_TEST
+            validate-${TEST_NAME}-timemory
+            validate-${TEST_NAME}-perfetto
+            validate-${TEST_NAME}-rocpd
+        )
+            if(TEST ${_VAL_TEST})
+                get_test_property(${_VAL_TEST} FIXTURES_REQUIRED _EXISTING_FIXTURES)
+                if(_EXISTING_FIXTURES)
+                    set_tests_properties(
+                        ${_VAL_TEST}
+                        PROPERTIES
+                            FIXTURES_REQUIRED "${_EXISTING_FIXTURES};${_DB_FIXTURE}"
+                    )
+                else()
+                    set_tests_properties(
+                        ${_VAL_TEST}
+                        PROPERTIES FIXTURES_REQUIRED "${_DB_FIXTURE}"
+                    )
+                endif()
+            endif()
+        endforeach()
+    endif()
 endfunction()
 
 # -------------------------------------------------------------------------------------- #

--- a/projects/rocprofiler-systems/tests/rocprof-sys-testing.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-testing.cmake
@@ -705,6 +705,15 @@ function(ROCPROFILER_SYSTEMS_ADD_TEST)
                     $<TARGET_FILE_DIR:${TEST_TARGET}>/${TEST_NAME}.inst ${TEST_RUN_ARGS}
                 WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
             )
+
+            add_test(
+                NAME ${TEST_NAME}-binary-rewrite-cleanup
+                COMMAND
+                    ${CMAKE_COMMAND} -E rm -rf
+                    $<TARGET_FILE_DIR:${TEST_TARGET}>/${TEST_NAME}.inst
+                    ${PROJECT_BINARY_DIR}/rocprof-sys-tests-output/${TEST_NAME}-binary-rewrite
+                WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+            )
         endif()
 
         if(NOT TEST_SKIP_RUNTIME AND NOT ROCPROFSYS_USE_SANITIZER)
@@ -713,6 +722,14 @@ function(ROCPROFILER_SYSTEMS_ADD_TEST)
                 COMMAND
                     $<TARGET_FILE:rocprofiler-systems-instrument> ${TEST_RUNTIME_ARGS} --
                     $<TARGET_FILE:${TEST_TARGET}> ${TEST_RUN_ARGS}
+                WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+            )
+
+            add_test(
+                NAME ${TEST_NAME}-runtime-instrument-cleanup
+                COMMAND
+                    ${CMAKE_COMMAND} -E rm -rf
+                    ${PROJECT_BINARY_DIR}/rocprof-sys-tests-output/${TEST_NAME}-runtime-instrument
                 WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
             )
         endif()
@@ -740,7 +757,9 @@ function(ROCPROFILER_SYSTEMS_ADD_TEST)
             sampling
             binary-rewrite
             binary-rewrite-run
+            binary-rewrite-cleanup
             runtime-instrument
+            runtime-instrument-cleanup
             sys-run
         )
             string(
@@ -783,7 +802,9 @@ function(ROCPROFILER_SYSTEMS_ADD_TEST)
                 endif()
             endif()
 
-            if("${_TEST}" MATCHES "binary-rewrite-run")
+            if("${_TEST}" MATCHES "-cleanup$")
+                set(_REGEX_VAR)
+            elseif("${_TEST}" MATCHES "binary-rewrite-run")
                 set(_REGEX_VAR REWRITE_RUN)
             elseif("${_TEST}" MATCHES "runtime-instrument")
                 set(_REGEX_VAR RUNTIME)
@@ -838,6 +859,36 @@ function(ROCPROFILER_SYSTEMS_ADD_TEST)
                         FIXTURES_REQUIRED rocprofsys-global-tmp-files
                         ${_props}
                 )
+
+                if("${_TEST}" STREQUAL "binary-rewrite")
+                    set_tests_properties(
+                        ${TEST_NAME}-${_TEST}
+                        PROPERTIES FIXTURES_SETUP ${TEST_NAME}-binary-rewrite-fixture
+                    )
+                elseif("${_TEST}" STREQUAL "binary-rewrite-run")
+                    set_tests_properties(
+                        ${TEST_NAME}-${_TEST}
+                        PROPERTIES
+                            FIXTURES_REQUIRED
+                                "rocprofsys-global-tmp-files;${TEST_NAME}-binary-rewrite-fixture"
+                    )
+                elseif("${_TEST}" STREQUAL "binary-rewrite-cleanup")
+                    set_tests_properties(
+                        ${TEST_NAME}-${_TEST}
+                        PROPERTIES FIXTURES_CLEANUP ${TEST_NAME}-binary-rewrite-fixture
+                    )
+                elseif("${_TEST}" STREQUAL "runtime-instrument")
+                    set_tests_properties(
+                        ${TEST_NAME}-${_TEST}
+                        PROPERTIES FIXTURES_SETUP ${TEST_NAME}-runtime-instrument-fixture
+                    )
+                elseif("${_TEST}" STREQUAL "runtime-instrument-cleanup")
+                    set_tests_properties(
+                        ${TEST_NAME}-${_TEST}
+                        PROPERTIES
+                            FIXTURES_CLEANUP ${TEST_NAME}-runtime-instrument-fixture
+                    )
+                endif()
             endif()
         endforeach()
     endif()
@@ -1032,7 +1083,7 @@ function(ROCPROFILER_SYSTEMS_ADD_PYTHON_TEST)
         TEST
         "STANDALONE" # options
         "NAME;FILE;TIMEOUT;PYTHON_EXECUTABLE;PYTHON_VERSION" # single value args
-        "PROFILE_ARGS;RUN_ARGS;ENVIRONMENT;LABELS;PROPERTIES;PASS_REGEX;FAIL_REGEX;SKIP_REGEX;DEPENDS;COMMAND" # multiple
+        "PROFILE_ARGS;RUN_ARGS;ENVIRONMENT;LABELS;PROPERTIES;PASS_REGEX;FAIL_REGEX;SKIP_REGEX;DEPENDS;COMMAND;FIXTURES_REQUIRED" # multiple
         # value args
         ${ARGN}
     )
@@ -1131,6 +1182,12 @@ function(ROCPROFILER_SYSTEMS_ADD_PYTHON_TEST)
         rocprofiler_systems_check_pass_fail_regex("${_TEST}" "${_PASS_REGEX}"
             "${_FAIL_REGEX}"
         )
+
+        set(_PYTHON_FIXTURES "rocprofsys-global-tmp-files")
+        if(TEST_FIXTURES_REQUIRED)
+            list(APPEND _PYTHON_FIXTURES "${TEST_FIXTURES_REQUIRED}")
+        endif()
+
         set_tests_properties(
             ${_TEST}
             PROPERTIES
@@ -1142,7 +1199,7 @@ function(ROCPROFILER_SYSTEMS_ADD_PYTHON_TEST)
                 FAIL_REGULAR_EXPRESSION "${${_FAIL_REGEX}}"
                 SKIP_REGULAR_EXPRESSION "${TEST_SKIP_REGEX}"
                 REQUIRED_FILES "${TEST_FILE}"
-                FIXTURES_REQUIRED rocprofsys-global-tmp-files
+                FIXTURES_REQUIRED "${_PYTHON_FIXTURES}"
                 ${_TEST_PROPERTIES}
         )
     endforeach()
@@ -1321,6 +1378,16 @@ function(ROCPROFILER_SYSTEMS_ADD_VALIDATION_TEST)
 
     list(APPEND TEST_ENVIRONMENT "ROCPROFSYS_CI_TIMEOUT=${TEST_TIMEOUT}")
 
+    # Determine the cleanup fixture this validation test should require
+    set(_VALIDATION_FIXTURES "rocprofsys-global-tmp-files")
+    if("${TEST_NAME}" MATCHES "-binary-rewrite(-run)?$")
+        string(REGEX REPLACE "-binary-rewrite(-run)?$" "" _BASE_TEST_NAME "${TEST_NAME}")
+        list(APPEND _VALIDATION_FIXTURES "${_BASE_TEST_NAME}-binary-rewrite-fixture")
+    elseif("${TEST_NAME}" MATCHES "-runtime-instrument$")
+        string(REGEX REPLACE "-runtime-instrument$" "" _BASE_TEST_NAME "${TEST_NAME}")
+        list(APPEND _VALIDATION_FIXTURES "${_BASE_TEST_NAME}-runtime-instrument-fixture")
+    endif()
+
     foreach(
         _TEST
         validate-${TEST_NAME}-timemory
@@ -1361,68 +1428,10 @@ function(ROCPROFILER_SYSTEMS_ADD_VALIDATION_TEST)
                 FAIL_REGULAR_EXPRESSION "${TEST_FAIL_REGEX}"
                 SKIP_REGULAR_EXPRESSION "${TEST_SKIP_REGEX}"
                 REQUIRED_FILES "${TEST_FILE}"
-                FIXTURES_REQUIRED rocprofsys-global-tmp-files
+                FIXTURES_REQUIRED "${_VALIDATION_FIXTURES}"
                 ${TEST_PROPERTIES}
         )
     endforeach()
-
-    if(TEST_ROCPD_FILE)
-        set(_DB_FIXTURE "rocprofsys-${TEST_NAME}-db")
-
-        add_test(
-            NAME ${TEST_NAME}-cleanup-db
-            COMMAND
-                sh -c
-                "rm -f ${PROJECT_BINARY_DIR}/rocprof-sys-tests-output/${TEST_NAME}/*.db"
-            WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-        )
-
-        set_tests_properties(
-            ${TEST_NAME}-cleanup-db
-            PROPERTIES
-                FIXTURES_CLEANUP ${_DB_FIXTURE}
-                LABELS "cleanup;db;rocpd"
-                TIMEOUT 30
-        )
-
-        if(TEST ${TEST_NAME})
-            get_test_property(${TEST_NAME} FIXTURES_REQUIRED _EXISTING_FIXTURES)
-            if(_EXISTING_FIXTURES)
-                set_tests_properties(
-                    ${TEST_NAME}
-                    PROPERTIES FIXTURES_REQUIRED "${_EXISTING_FIXTURES};${_DB_FIXTURE}"
-                )
-            else()
-                set_tests_properties(
-                    ${TEST_NAME}
-                    PROPERTIES FIXTURES_REQUIRED "${_DB_FIXTURE}"
-                )
-            endif()
-        endif()
-
-        foreach(
-            _VAL_TEST
-            validate-${TEST_NAME}-timemory
-            validate-${TEST_NAME}-perfetto
-            validate-${TEST_NAME}-rocpd
-        )
-            if(TEST ${_VAL_TEST})
-                get_test_property(${_VAL_TEST} FIXTURES_REQUIRED _EXISTING_FIXTURES)
-                if(_EXISTING_FIXTURES)
-                    set_tests_properties(
-                        ${_VAL_TEST}
-                        PROPERTIES
-                            FIXTURES_REQUIRED "${_EXISTING_FIXTURES};${_DB_FIXTURE}"
-                    )
-                else()
-                    set_tests_properties(
-                        ${_VAL_TEST}
-                        PROPERTIES FIXTURES_REQUIRED "${_DB_FIXTURE}"
-                    )
-                endif()
-            endif()
-        endforeach()
-    endif()
 endfunction()
 
 # -------------------------------------------------------------------------------------- #


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Test artifacts (instrumented binaries and output directories) were accumulating during test runs. This PR introduces proper cleanup fixtures to ensure test resources are properly managed and removed after dependent tests complete, improving test isolation and preventing disk space buildup.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Added `binary-rewrite-cleanup` and `runtime-instrument-cleanup` tests that remove instrumented binaries and output directories using `cmake -E rm -rf`
- Implemented CMake test fixtures (`FIXTURES_SETUP` and `FIXTURES_CLEANUP`) to establish proper test ordering:
  - `binary-rewrite` sets up the `binary-rewrite-fixture`
  - `binary-rewrite-run` and validation tests require this fixture
  - `binary-rewrite-cleanup` performs cleanup for this fixture
  - Same pattern applied for `runtime-instrument`
- Extended `ROCPROFILER_SYSTEMS_ADD_PYTHON_TEST` to accept `FIXTURES_REQUIRED` parameter
- Updated validation tests to require appropriate cleanup fixtures based on test name pattern matching
- Added fixture requirements to Python code-coverage tests

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Run the full test suite with `ctest` to verify test ordering is correct
- Verify that cleanup tests run after all dependent tests (binary-rewrite-run, validation tests, Python tests)
- Check that instrumented binaries and output directories are removed after test completion

## Test Result

<!-- Briefly summarize test outcomes. -->
- Tests should execute in correct dependency order (instrument → run → validate → cleanup)
- After test suite completion, no stale `.inst` binaries or test output directories should remain in `rocprof-sys-tests-output/`
- No test failures due to missing required files (cleanup should only run after dependent tests)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
