### PR TITLE
[7.2] Fix test build failure on RHEL 10 (#1955)

### DIFF
--- a/projects/rocprofiler-systems/examples/videodecode/video_demuxer.h
+++ b/projects/rocprofiler-systems/examples/videodecode/video_demuxer.h
@@ -570,9 +570,17 @@ private:
              !strcmp(av_fmt_input_ctx_->iformat->long_name, "FLV (Flash Video)") ||
              !strcmp(av_fmt_input_ctx_->iformat->long_name, "Matroska / WebM"));
 
+        // For latest version of FFMPeg, read_seek and read_seek2 are not exposed in
+        // AVInputFormat
+#if USE_AVCODEC_GREATER_THAN_58_134
+        // Check if the input stream is seekable for FFmpeg >= 58.134
+        is_seekable_ = (av_fmt_input_ctx_->iformat->flags & AVFMT_NO_BYTE_SEEK) == 0 &&
+                       av_fmt_input_ctx_->pb && av_fmt_input_ctx_->pb->seekable;
+#else
         // Check if the input file allow seek functionality.
         is_seekable_ = av_fmt_input_ctx_->iformat->read_seek ||
                        av_fmt_input_ctx_->iformat->read_seek2;
+#endif
 
         if(is_h264_)
         {


### PR DESCRIPTION
## Motivation

To solve: SWDEV-566076 
FFmpeg versions >= 58.134 no longer expose read_seek and read_seek2 function pointers in AVInputFormat, requiring alternative seek detection methods. This pull request updates the `VideoDemuxer` class to improve compatibility with newer versions of FFmpeg. The main change is how the code determines whether the input file is seekable, addressing differences in FFmpeg API versions.


## Technical Details

In `video_demuxer.h`, added a conditional check for `USE_AVCODEC_GREATER_THAN_58_134` to set `is_seekable_` to `true` for newer FFmpeg versions, since `read_seek` and `read_seek2` are no longer exposed in `AVFormatContext`. For older versions, the previous method of checking these fields remains in place. The conditional compilation now assumes seek capability is available for newer FFmpeg versions.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
