### PR TITLE
Fix flaky test Unit_hipStreamAddCallback_StrmSyncTiming

### DIFF
--- a/projects/hip-tests/catch/unit/stream/hipStreamACb_StrmSyncTiming.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamACb_StrmSyncTiming.cc
@@ -113,15 +113,7 @@ TEST_CASE("Unit_hipStreamAddCallback_StrmSyncTiming") {
   while (!cbDone) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
-
-  // Since the callback is supposed to be called only after an implicit stream
-  // synchronization, and the runtime cannot continue until the callback is done
-  // hipStreamSynchronize call should not take much time.
-  auto start = std::chrono::high_resolution_clock::now();
-  HIPCHECK(hipStreamSynchronize(mystream));
-  auto stop = std::chrono::high_resolution_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop - start);
-
+  HIPCHECK(hipStreamQuery(mystream));
   HIPCHECK(hipStreamDestroy(mystream));
   HIPCHECK(hipFree(A_d));
   HIPCHECK(hipFree(C_d));
@@ -129,10 +121,4 @@ TEST_CASE("Unit_hipStreamAddCallback_StrmSyncTiming") {
   free(C_h);
 
   REQUIRE(Data_mismatch.load() == 0);
-  // HIP runtime cannot proceed further in the queue until callback completes
-  // Stream synchronize should not have much task to do after callback
-  // It should just be an extra empty marker wait
-  // Therefore the hipStreamSynchronize() in the
-  // main thread should hardly take any time to complete.
-  REQUIRE(duration.count() < 100);
 }


### PR DESCRIPTION
## Motivation
This test makes some strong assumptions that the hipStreamSynchronize on empty stream should take <100us and can occasionally fail in PSDBs
## Technical Details
Use hipStreamQuery instead
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Running the test repeatedly in a loop should not show any  failures
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
The test does not show any failures under stress test
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
