### PR TITLE
[7.2] Fix rocpd validation ctests

### DIFF
--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/jpeg-decode/amd-smi-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/jpeg-decode/amd-smi-rules.json
@@ -23,7 +23,8 @@
             ]
         },
         {
-            "min_rows": 500,
+            "_comment": "The actual number of samples will vary depending on the GPU. This validates presence of samples, not the actual number of samples.",
+            "min_rows": 100,
             "name_prefix": "rocpd_pmc_event_",
             "required_columns": [
                 "event_id",
@@ -35,21 +36,21 @@
                     "comparison": "greater_than",
                     "description": "Check for amd-smi monitoring busy times",
                     "error_message": "Less than expected number of captured amd-smi mm-busy samples!",
-                    "expected_result": 50,
+                    "expected_result": 10,
                     "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_busy_mm'"
                 },
                 {
                     "comparison": "greater_than",
                     "description": "Check for amd-smi monitoring GPU memory usage",
                     "error_message": "Less than expected number of captured amd-smi memory-usage samples!",
-                    "expected_result": 50,
+                    "expected_result": 10,
                     "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_memory_usage'"
                 },
                 {
                     "comparison": "greater_than",
                     "description": "Check for amd-smi monitoring JPEG activity",
                     "error_message": "Less than expected activity in amd-smi jpeg-activity samples!",
-                    "expected_result": 50,
+                    "expected_result": 10,
                     "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name LIKE 'device_jpeg_activity_%' and event.value > 0"
                 }
             ]

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/python/python-builtin-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/python/python-builtin-rules.json
@@ -36,7 +36,7 @@
                     "description": "Verify that percentages sum to 100.",
                     "error_message": "Percentages do not sum to 100.",
                     "expected_result": 100,
-                    "query": "SELECT SUM(percentage) FROM top;"
+                    "query": "SELECT ROUND(SUM(percentage), 1) FROM top;"
                 }
             ]
         },

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/python/python-source-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/python/python-source-rules.json
@@ -50,7 +50,7 @@
                     "description": "Verify that percentages sum to 100.",
                     "error_message": "Percentages do not sum to 100.",
                     "expected_result": 100,
-                    "query": "SELECT SUM(percentage) FROM top;"
+                    "query": "SELECT ROUND(SUM(percentage), 1) FROM top;"
                 }
             ]
         },

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/roctx/amd-smi-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/roctx/amd-smi-rules.json
@@ -23,6 +23,7 @@
             ]
         },
         {
+            "_comment": "The actual number of samples will vary depending on the GPU. This validates presence of samples, not the actual number of samples.",
             "min_rows": 100,
             "name_prefix": "rocpd_pmc_event_",
             "required_columns": [

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/video-decode/amd-smi-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/video-decode/amd-smi-rules.json
@@ -23,7 +23,8 @@
             ]
         },
         {
-            "min_rows": 500,
+            "_comment": "The actual number of samples will vary depending on the GPU. This validates presence of samples, not the actual number of samples.",
+            "min_rows": 100,
             "name_prefix": "rocpd_pmc_event_",
             "required_columns": [
                 "event_id",
@@ -35,21 +36,21 @@
                     "comparison": "greater_than",
                     "description": "Check for amd-smi monitoring busy times",
                     "error_message": "Less than expected number of captured amd-smi mm-busy samples!",
-                    "expected_result": 150,
+                    "expected_result": 10,
                     "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_busy_mm'"
                 },
                 {
                     "comparison": "greater_than",
                     "description": "Check for amd-smi monitoring GPU memory usage",
                     "error_message": "Less than expected number of captured amd-smi memory-usage samples!",
-                    "expected_result": 150,
+                    "expected_result": 10,
                     "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name = 'device_memory_usage'"
                 },
                 {
                     "comparison": "greater_than",
                     "description": "Check for amd-smi monitoring VCN activity",
                     "error_message": "Less than expected activity in amd-smi vcn-activity samples!",
-                    "expected_result": 100,
+                    "expected_result": 10,
                     "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name LIKE 'device_vcn_activity_%' and event.value > 0"
                 }
             ]

--- a/projects/rocprofiler-systems/tests/rocprof-sys-roctx-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-roctx-tests.cmake
@@ -106,7 +106,7 @@ rocprofiler_systems_add_validation_test(
     ARGS -l ${ROCTX_LABEL} -c ${ROCTX_COUNT} -d ${ROCTX_DEPTH} -p
 )
 
-if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU} AND TEST transpose-sampling)
+if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU} AND TEST roctx-api-sampling)
     set_property(TEST roctx-api-sampling APPEND PROPERTY LABELS rocpd)
 
     rocprofiler_systems_add_validation_test(

--- a/projects/rocprofiler-systems/tests/rocprof-sys-testing.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-testing.cmake
@@ -1227,6 +1227,14 @@ function(ROCPROFILER_SYSTEMS_ADD_VALIDATION_TEST)
         list(APPEND TEST_DEPENDS "${TEST_NAME}-run")
     endif()
 
+    # Add labels from the parent test to the validation test
+    get_test_property(${TEST_NAME} LABELS PARENT_TEST_LABELS)
+    if(PARENT_TEST_LABELS)
+        list(APPEND TEST_LABELS "${PARENT_TEST_LABELS}")
+        list(REMOVE_DUPLICATES TEST_LABELS)
+        list(SORT TEST_LABELS)
+    endif()
+
     if(NOT TEST_PASS_REGEX)
         set(TEST_PASS_REGEX
             "rocprof-sys-tests-output/${TEST_NAME}/(${TEST_TIMEMORY_FILE}|${TEST_PERFETTO_FILE}|${TEST_ROCPD_FILE}) validated"


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Resolve SWDEV-568849.

 Cherry-pick changes to fix ctests failures on some systems.
- validate-transpose-sampling-rocpd (Failed)
- validate-video-decode-sampling-rocpd (Failed)
- validate-jpeg-decode-sampling-rocpd (Failed)
- validate-roctx-api-sampling-rocpd (Failed)


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Cherry-picks commits: 
- f8694173f6 - Round the sum of percentages before validating to account for floating point errors (#1824) (13 days ago) [David Galiffi]
- 3ad7c20961 - Change test condition from transpose-sampling to roctx-api-sampling (#1784) (2 weeks ago) [David Galiffi]
- 540eda3865 - [rocprof-sys] Forward ctest labels from the execution test to the validation test. (#1697) (12 days ago) [David Galiffi]

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
