### PR TITLE
[SWDEV-566465] Fix json output for amdsmi reset

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -5492,9 +5492,11 @@ class AMDSMICommands():
                         raise PermissionError('Command requires elevation') from e
                     final_output[f"ppt{current_sensor_num}"] = f"[{e.get_error_info(detailed=False)}] Unable to reset cap to default power cap"
                 self.logger.store_output(args.gpu, 'powercap', final_output)
+                if multiple_devices:
+                    self.logger.store_multiple_device_output()
+                    return
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
-                return
 
         #######################
         # BM commands - END   #


### PR DESCRIPTION

## Motivation

Incorrect json output format for 'amd-smi reset' command.

## Technical Details

For multiple devices, the output needs to be stored.

## Test Plan

Attached the logs

## Test Result

Passed

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
