### PR TITLE
Add category tags to HIP unit tests - Part 2: Compute & Sync

### DIFF
--- a/projects/hip-tests/catch/unit/atomics/acquire_release.cc
+++ b/projects/hip-tests/catch/unit/atomics/acquire_release.cc
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 #include "memory_order_common.hh"
 
-TEST_CASE("Unit___hip_atomic_load_store_Positive_Acquire_Release") {
+TEST_CASE("Unit___hip_atomic_load_store_Positive_Acquire_Release", "[atomic]") {
   SECTION("ACQUIRE/RELEASE") {
     SECTION("WAVEFRONT") {
       AcquireRelease::Test<BuiltinAtomicOperation::kLoadStore, __ATOMIC_ACQUIRE,
@@ -61,7 +61,7 @@ TEST_CASE("Unit___hip_atomic_load_store_Positive_Acquire_Release") {
   }
 }
 
-TEST_CASE("Unit___hip_atomic_exchange_Positive_Acquire_Release") {
+TEST_CASE("Unit___hip_atomic_exchange_Positive_Acquire_Release", "[atomic]") {
   SECTION("ACQUIRE/RELEASE") {
     SECTION("WAVEFRONT") {
       AcquireRelease::Test<BuiltinAtomicOperation::kExchange, __ATOMIC_ACQUIRE,
@@ -115,7 +115,7 @@ TEST_CASE("Unit___hip_atomic_exchange_Positive_Acquire_Release") {
   }
 }
 
-TEST_CASE("Unit___hip_atomic_compare_exchange_strong_Positive_Acquire_Release") {
+TEST_CASE("Unit___hip_atomic_compare_exchange_strong_Positive_Acquire_Release", "[atomic]") {
   SECTION("ACQUIRE/RELEASE") {
     SECTION("WAVEFRONT") {
       AcquireRelease::Test<BuiltinAtomicOperation::kCompareExchangeStrong, __ATOMIC_ACQUIRE,
@@ -172,7 +172,7 @@ TEST_CASE("Unit___hip_atomic_compare_exchange_strong_Positive_Acquire_Release") 
   }
 }
 
-TEST_CASE("Unit___hip_atomic_compare_exchange_weak_Positive_Acquire_Release") {
+TEST_CASE("Unit___hip_atomic_compare_exchange_weak_Positive_Acquire_Release", "[atomic]") {
   SECTION("ACQUIRE/RELEASE") {
     SECTION("WAVEFRONT") {
       AcquireRelease::Test<BuiltinAtomicOperation::kCompareExchangeWeak, __ATOMIC_ACQUIRE,
@@ -226,7 +226,7 @@ TEST_CASE("Unit___hip_atomic_compare_exchange_weak_Positive_Acquire_Release") {
   }
 }
 
-TEST_CASE("Unit___hip_atomic_fetch_add_Positive_Acquire_Release") {
+TEST_CASE("Unit___hip_atomic_fetch_add_Positive_Acquire_Release", "[atomic]") {
   SECTION("ACQUIRE/RELEASE") {
     SECTION("WAVEFRONT") {
       AcquireRelease::Test<BuiltinAtomicOperation::kAdd, __ATOMIC_ACQUIRE,
@@ -280,7 +280,7 @@ TEST_CASE("Unit___hip_atomic_fetch_add_Positive_Acquire_Release") {
   }
 }
 
-TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Acquire_Release") {
+TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Acquire_Release", "[atomic]") {
   SECTION("ACQUIRE/RELEASE") {
     SECTION("WAVEFRONT") {
       AcquireRelease::Test<BuiltinAtomicOperation::kAnd, __ATOMIC_ACQUIRE,
@@ -334,7 +334,7 @@ TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Acquire_Release") {
   }
 }
 
-TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Acquire_Release") {
+TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Acquire_Release", "[atomic]") {
   SECTION("ACQUIRE/RELEASE") {
     SECTION("WAVEFRONT") {
       AcquireRelease::Test<BuiltinAtomicOperation::kOr, __ATOMIC_ACQUIRE,
@@ -388,7 +388,7 @@ TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Acquire_Release") {
   }
 }
 
-TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Acquire_Release") {
+TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Acquire_Release", "[atomic]") {
   SECTION("ACQUIRE/RELEASE") {
     SECTION("WAVEFRONT") {
       AcquireRelease::Test<BuiltinAtomicOperation::kXor, __ATOMIC_ACQUIRE,
@@ -442,7 +442,7 @@ TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Acquire_Release") {
   }
 }
 
-TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Acquire_Release") {
+TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Acquire_Release", "[atomic]") {
   SECTION("ACQUIRE/RELEASE") {
     SECTION("WAVEFRONT") {
       AcquireRelease::Test<BuiltinAtomicOperation::kMin, __ATOMIC_ACQUIRE,
@@ -496,7 +496,7 @@ TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Acquire_Release") {
   }
 }
 
-TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Acquire_Release") {
+TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Acquire_Release", "[atomic]") {
   SECTION("ACQUIRE/RELEASE") {
     SECTION("WAVEFRONT") {
       AcquireRelease::Test<BuiltinAtomicOperation::kMax, __ATOMIC_ACQUIRE,

--- a/projects/hip-tests/catch/unit/atomics/atomicAdd.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicAdd.cc
@@ -136,7 +136,7 @@ TEMPLATE_TEST_CASE("Unit_atomicAdd_Positive_Multi_Kernel", "", int, unsigned int
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_atomicAdd_Negative_Parameters_RTC") {
+TEST_CASE("Unit_atomicAdd_Negative_Parameters_RTC", "[atomic]") {
   hiprtcProgram program{};
 
   const auto program_source = GENERATE(kAtomicAdd_int, kAtomicAdd_uint, kAtomicAdd_ulong,

--- a/projects/hip-tests/catch/unit/atomics/atomicAnd.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicAnd.cc
@@ -191,7 +191,7 @@ TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Multi_Kernel_Scattered_Addresses", "
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_atomicAnd_Negative_Parameters_RTC") {
+TEST_CASE("Unit_atomicAnd_Negative_Parameters_RTC", "[atomic]") {
   hiprtcProgram program{};
 
   const auto program_source =

--- a/projects/hip-tests/catch/unit/atomics/atomicCAS.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicCAS.cc
@@ -142,7 +142,7 @@ TEMPLATE_TEST_CASE("Unit_atomicCAS_Positive_Multi_Kernel", "", int, unsigned int
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_atomicCAS_Negative_Parameters_RTC") {
+TEST_CASE("Unit_atomicCAS_Negative_Parameters_RTC", "[atomic]") {
   hiprtcProgram program{};
 
   const auto program_source = GENERATE(kAtomicCAS_int, kAtomicCAS_uint, kAtomicCAS_ulong,

--- a/projects/hip-tests/catch/unit/atomics/atomicDec.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicDec.cc
@@ -134,7 +134,7 @@ TEMPLATE_TEST_CASE("Unit_atomicDec_Positive_Multi_Kernel", "", unsigned int) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_atomicDec_Negative_Parameters_RTC") {
+TEST_CASE("Unit_atomicDec_Negative_Parameters_RTC", "[atomic]") {
   hiprtcProgram program{};
 
   const auto program_source = GENERATE(kAtomicDec_uint);

--- a/projects/hip-tests/catch/unit/atomics/atomicExch.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicExch.cc
@@ -183,7 +183,7 @@ TEMPLATE_TEST_CASE("Unit_atomicExch_Positive_Multi_Kernel", "", int, unsigned in
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_atomicExch_Negative_Parameters_RTC") {
+TEST_CASE("Unit_atomicExch_Negative_Parameters_RTC", "[atomic]") {
   hiprtcProgram program{};
 
   const auto program_source = GENERATE(kAtomicExchInt, kAtomicExchUnsignedInt, kAtomicExchULL,

--- a/projects/hip-tests/catch/unit/atomics/atomicExch_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicExch_system.cc
@@ -206,7 +206,7 @@ TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Host_And_Peer_GPUs",
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_atomicExch_system_Negative_Parameters_RTC") {
+TEST_CASE("Unit_atomicExch_system_Negative_Parameters_RTC", "[atomic]") {
   hiprtcProgram program{};
 
   const auto program_source =

--- a/projects/hip-tests/catch/unit/atomics/atomicInc.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicInc.cc
@@ -134,7 +134,7 @@ TEMPLATE_TEST_CASE("Unit_atomicInc_Positive_Multi_Kernel", "", unsigned int) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_atomicInc_Negative_Parameters_RTC") {
+TEST_CASE("Unit_atomicInc_Negative_Parameters_RTC", "[atomic]") {
   hiprtcProgram program{};
 
   const auto program_source = GENERATE(kAtomicInc_uint);

--- a/projects/hip-tests/catch/unit/atomics/atomicMax.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicMax.cc
@@ -191,7 +191,7 @@ TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Multi_Kernel_Scattered_Addresses", "
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_atomicMax_Negative_Parameters_RTC") {
+TEST_CASE("Unit_atomicMax_Negative_Parameters_RTC", "[atomic]") {
   hiprtcProgram program{};
 
   const auto program_source = GENERATE(kAtomicMax_int, kAtomicMax_uint, kAtomicMax_ulong,

--- a/projects/hip-tests/catch/unit/atomics/atomicMin.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicMin.cc
@@ -191,7 +191,7 @@ TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Multi_Kernel_Scattered_Addresses", "
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_atomicMin_Negative_Parameters_RTC") {
+TEST_CASE("Unit_atomicMin_Negative_Parameters_RTC", "[atomic]") {
   hiprtcProgram program{};
 
   const auto program_source = GENERATE(kAtomicMin_int, kAtomicMin_uint, kAtomicMin_ulong,

--- a/projects/hip-tests/catch/unit/atomics/atomicOr.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicOr.cc
@@ -191,7 +191,7 @@ TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Multi_Kernel_Scattered_Addresses", ""
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_atomicOr_Negative_Parameters_RTC") {
+TEST_CASE("Unit_atomicOr_Negative_Parameters_RTC", "[atomic]") {
   hiprtcProgram program{};
 
   const auto program_source =

--- a/projects/hip-tests/catch/unit/atomics/atomicSub.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicSub.cc
@@ -136,7 +136,7 @@ TEMPLATE_TEST_CASE("Unit_atomicSub_Positive_Multi_Kernel", "", int, unsigned int
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_atomicSub_Negative_Parameters_RTC") {
+TEST_CASE("Unit_atomicSub_Negative_Parameters_RTC", "[atomic]") {
   hiprtcProgram program{};
 
   const auto program_source = GENERATE(kAtomicSub_int, kAtomicSub_uint, kAtomicSub_ulong,

--- a/projects/hip-tests/catch/unit/atomics/atomicXor.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicXor.cc
@@ -190,7 +190,7 @@ TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Multi_Kernel_Scattered_Addresses", "
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_atomicXor_Negative_Parameters_RTC") {
+TEST_CASE("Unit_atomicXor_Negative_Parameters_RTC", "[atomic]") {
   hiprtcProgram program{};
 
   const auto program_source =

--- a/projects/hip-tests/catch/unit/atomics/atomic_builtins.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomic_builtins.cc
@@ -80,7 +80,7 @@ void AtomicBuiltinsRTCWrapper(const char* program_source, int expected_errors_nu
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_AtomicBuiltins_Negative_Parameters_RTC") {
+TEST_CASE("Unit_AtomicBuiltins_Negative_Parameters_RTC", "[atomic]") {
   AtomicBuiltinsRTCWrapper(kBuiltinStore, 5, 5);
   AtomicBuiltinsRTCWrapper(kBuiltinLoad, 4, 4);
   AtomicBuiltinsRTCWrapper(kBuiltinCompExWeak, 5, 7);

--- a/projects/hip-tests/catch/unit/atomics/sequential_consistency.cc
+++ b/projects/hip-tests/catch/unit/atomics/sequential_consistency.cc
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 #include "memory_order_common.hh"
 
-TEST_CASE("Unit___hip_atomic_load_store_Positive_Sequential_Consistency") {
+TEST_CASE("Unit___hip_atomic_load_store_Positive_Sequential_Consistency", "[atomic]") {
   SECTION("WAVEFRONT") {
     SequentialConsistency::Test<BuiltinAtomicOperation::kLoadStore, __HIP_MEMORY_SCOPE_WAVEFRONT>();
   }
@@ -37,7 +37,7 @@ TEST_CASE("Unit___hip_atomic_load_store_Positive_Sequential_Consistency") {
   SECTION("SYSTEM") { SequentialConsistency::SystemTest<BuiltinAtomicOperation::kLoadStore>(); }
 }
 
-TEST_CASE("Unit___hip_atomic_exchange_Positive_Sequential_Consistency") {
+TEST_CASE("Unit___hip_atomic_exchange_Positive_Sequential_Consistency", "[atomic]") {
   SECTION("WAVEFRONT") {
     SequentialConsistency::Test<BuiltinAtomicOperation::kExchange, __HIP_MEMORY_SCOPE_WAVEFRONT>();
   }
@@ -50,7 +50,7 @@ TEST_CASE("Unit___hip_atomic_exchange_Positive_Sequential_Consistency") {
   SECTION("SYSTEM") { SequentialConsistency::SystemTest<BuiltinAtomicOperation::kExchange>(); }
 }
 
-TEST_CASE("Unit___hip_atomic_compare_exchange_strong_Positive_Sequential_Consistency") {
+TEST_CASE("Unit___hip_atomic_compare_exchange_strong_Positive_Sequential_Consistency", "[atomic]") {
   SECTION("WAVEFRONT") {
     SequentialConsistency::Test<BuiltinAtomicOperation::kCompareExchangeStrong,
                                 __HIP_MEMORY_SCOPE_WAVEFRONT>();
@@ -68,7 +68,7 @@ TEST_CASE("Unit___hip_atomic_compare_exchange_strong_Positive_Sequential_Consist
   }
 }
 
-TEST_CASE("Unit___hip_atomic_compare_exchange_weak_Positive_Sequential_Consistency") {
+TEST_CASE("Unit___hip_atomic_compare_exchange_weak_Positive_Sequential_Consistency", "[atomic]") {
   SECTION("WAVEFRONT") {
     SequentialConsistency::Test<BuiltinAtomicOperation::kCompareExchangeWeak,
                                 __HIP_MEMORY_SCOPE_WAVEFRONT>();
@@ -86,7 +86,7 @@ TEST_CASE("Unit___hip_atomic_compare_exchange_weak_Positive_Sequential_Consisten
   }
 }
 
-TEST_CASE("Unit___hip_atomic_fetch_add_Positive_Sequential_Consistency") {
+TEST_CASE("Unit___hip_atomic_fetch_add_Positive_Sequential_Consistency", "[atomic]") {
   SECTION("WAVEFRONT") {
     SequentialConsistency::Test<BuiltinAtomicOperation::kAdd, __HIP_MEMORY_SCOPE_WAVEFRONT>();
   }
@@ -99,7 +99,7 @@ TEST_CASE("Unit___hip_atomic_fetch_add_Positive_Sequential_Consistency") {
   SECTION("SYSTEM") { SequentialConsistency::SystemTest<BuiltinAtomicOperation::kAdd>(); }
 }
 
-TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Sequential_Consistency") {
+TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Sequential_Consistency", "[atomic]") {
   SECTION("WAVEFRONT") {
     SequentialConsistency::Test<BuiltinAtomicOperation::kAnd, __HIP_MEMORY_SCOPE_WAVEFRONT>();
   }
@@ -112,7 +112,7 @@ TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Sequential_Consistency") {
   SECTION("SYSTEM") { SequentialConsistency::SystemTest<BuiltinAtomicOperation::kAnd>(); }
 }
 
-TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Sequential_Consistency") {
+TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Sequential_Consistency", "[atomic]") {
   SECTION("WAVEFRONT") {
     SequentialConsistency::Test<BuiltinAtomicOperation::kOr, __HIP_MEMORY_SCOPE_WAVEFRONT>();
   }
@@ -125,7 +125,7 @@ TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Sequential_Consistency") {
   SECTION("SYSTEM") { SequentialConsistency::SystemTest<BuiltinAtomicOperation::kOr>(); }
 }
 
-TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Sequential_Consistency") {
+TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Sequential_Consistency", "[atomic]") {
   SECTION("WAVEFRONT") {
     SequentialConsistency::Test<BuiltinAtomicOperation::kXor, __HIP_MEMORY_SCOPE_WAVEFRONT>();
   }
@@ -138,7 +138,7 @@ TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Sequential_Consistency") {
   SECTION("SYSTEM") { SequentialConsistency::SystemTest<BuiltinAtomicOperation::kXor>(); }
 }
 
-TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Sequential_Consistency") {
+TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Sequential_Consistency", "[atomic]") {
   SECTION("WAVEFRONT") {
     SequentialConsistency::Test<BuiltinAtomicOperation::kMin, __HIP_MEMORY_SCOPE_WAVEFRONT>();
   }
@@ -151,7 +151,7 @@ TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Sequential_Consistency") {
   SECTION("SYSTEM") { SequentialConsistency::SystemTest<BuiltinAtomicOperation::kMin>(); }
 }
 
-TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Sequential_Consistency") {
+TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Sequential_Consistency", "[atomic]") {
   SECTION("WAVEFRONT") {
     SequentialConsistency::Test<BuiltinAtomicOperation::kMax, __HIP_MEMORY_SCOPE_WAVEFRONT>();
   }

--- a/projects/hip-tests/catch/unit/cooperativeGrps/binary_partition.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/binary_partition.cc
@@ -44,7 +44,7 @@ static __global__ void binary_part_tiled_odd_even_val(int* data, int* odd_res, i
   }
 }
 
-TEST_CASE("Unit_cg_binary_part") {
+TEST_CASE("Unit_cg_binary_part", "[cooperativeLaunch]") {
   const size_t warp_size = getWarpSize();
 
   int *data, *odd_res, *even_res;

--- a/projects/hip-tests/catch/unit/cooperativeGrps/cg_any_all.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/cg_any_all.cc
@@ -42,7 +42,7 @@ __global__ void coop_any_coal_odd_even(unsigned int* data, unsigned int even_val
   }
 }
 
-TEST_CASE("Unit_coopgroups_any") {
+TEST_CASE("Unit_coopgroups_any", "[cooperativeLaunch]") {
   const size_t warp_size = getWarpSize();
 
   unsigned int *data, *res;
@@ -283,7 +283,7 @@ __global__ void coop_all_coal_odd_even(unsigned int* data, unsigned int even_val
   }
 }
 
-TEST_CASE("Unit_coopgroups_coal_all") {
+TEST_CASE("Unit_coopgroups_coal_all", "[cooperativeLaunch]") {
   const size_t warp_size = getWarpSize();
 
   unsigned int *data, *res;
@@ -488,7 +488,7 @@ __global__ void coop_match_any_coal_odd_even(unsigned int* data, unsigned long l
   }
 }
 
-TEST_CASE("Unit_coopgroups_match_any_coal") {
+TEST_CASE("Unit_coopgroups_match_any_coal", "[cooperativeLaunch]") {
   const size_t warp_size = getWarpSize();
 
   unsigned int* data;
@@ -558,7 +558,7 @@ __global__ void coop_match_all_coal_odd_even(unsigned int* data, unsigned long l
   }
 }
 
-TEST_CASE("Unit_coopgroups_match_all_coal") {
+TEST_CASE("Unit_coopgroups_match_all_coal", "[cooperativeLaunch]") {
   const size_t warp_size = getWarpSize();
 
   unsigned int* data;

--- a/projects/hip-tests/catch/unit/cooperativeGrps/cg_ballot.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/cg_ballot.cc
@@ -42,7 +42,7 @@ __global__ void coop_ballot_coal_alternate(int* data, unsigned long long* d_even
   }
 }
 
-TEST_CASE("Unit_coopgroups_ballot") {
+TEST_CASE("Unit_coopgroups_ballot", "[cooperativeLaunch]") {
   const size_t warp_size = getWarpSize();
   std::vector<int> input;
   input.reserve(warp_size);
@@ -97,7 +97,7 @@ static __global__ void coop_ballot_binary_part_3_5_7(int* data, unsigned long lo
   res[tid] = part.ballot((val % 7) == 0);
 }
 
-TEST_CASE("Unit_binary_part_ballot") {
+TEST_CASE("Unit_binary_part_ballot", "[cooperativeLaunch]") {
   const size_t warp_size = getWarpSize();
   std::vector<int> input;
   input.reserve(warp_size);

--- a/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_group.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_group.cc
@@ -136,7 +136,7 @@ static uint64_t get_active_mask(unsigned int test_case, size_t warp_size) {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Coalesced_Group_Getters_Positive_Basic") {
+TEST_CASE("Unit_Coalesced_Group_Getters_Positive_Basic", "[cooperativeLaunch]") {
   int device;
   hipDeviceProp_t device_properties;
   HIP_CHECK(hipGetDevice(&device));
@@ -224,7 +224,7 @@ TEST_CASE("Unit_Coalesced_Group_Getters_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Coalesced_Group_Getters_Via_Base_Type_Positive_Basic") {
+TEST_CASE("Unit_Coalesced_Group_Getters_Via_Base_Type_Positive_Basic", "[cooperativeLaunch]") {
   int device;
   hipDeviceProp_t device_properties;
   HIP_CHECK(hipGetDevice(&device));
@@ -314,7 +314,7 @@ TEST_CASE("Unit_Coalesced_Group_Getters_Via_Base_Type_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Coalesced_Group_Getters_Via_Non_Member_Functions_Positive_Basic") {
+TEST_CASE("Unit_Coalesced_Group_Getters_Via_Non_Member_Functions_Positive_Basic", "[cooperativeLaunch]") {
   int device;
   hipDeviceProp_t device_properties;
   HIP_CHECK(hipGetDevice(&device));

--- a/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_group_tiled_partition.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_group_tiled_partition.cc
@@ -125,7 +125,7 @@ __global__ void coalesced_group_tiled_partition_thread_rank_getter(uint64_t* act
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Coalesced_Group_Tiled_Partition_Getters_Positive_Basic") {
+TEST_CASE("Unit_Coalesced_Group_Tiled_Partition_Getters_Positive_Basic", "[cooperativeLaunch]") {
   const auto tile_size = GenerateTileSizes();
   INFO("Tile size: " << tile_size);
   auto blocks = GenerateBlockDimensions();

--- a/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_groups_shfl_down_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_groups_shfl_down_old.cc
@@ -237,7 +237,7 @@ static void test_shfl_down() {
 }
 
 
-TEST_CASE("Unit_coalesced_groups_shfl_down") {
+TEST_CASE("Unit_coalesced_groups_shfl_down", "[cooperativeLaunch]") {
   // Use default device for validating the test
   int deviceId;
   ASSERT_EQUAL(hipGetDevice(&deviceId), hipSuccess);

--- a/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_groups_shfl_up_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_groups_shfl_up_old.cc
@@ -222,7 +222,7 @@ static void test_shfl_up() {
   }
 }
 
-TEST_CASE("Unit_coalesced_groups_shfl_up") {
+TEST_CASE("Unit_coalesced_groups_shfl_up", "[cooperativeLaunch]") {
   // Use default device for validating the test
   int deviceId;
   ASSERT_EQUAL(hipGetDevice(&deviceId), hipSuccess);

--- a/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_tiled_groups_metagrp.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/coalesced_tiled_groups_metagrp.cc
@@ -69,7 +69,7 @@ static __global__ void kernel_tiledgrp_threadblk(int* mgrpSize, int* mgrpRank) {
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_tiled_groups_metagrp_basic") {
+TEST_CASE("Unit_tiled_groups_metagrp_basic", "[cooperativeLaunch]") {
   int *mgrpSize_d = nullptr, *mgrpRank_d = nullptr;
   int *mgrpSize_h = nullptr, *mgrpRank_h = nullptr;
   mgrpSize_h = new int[total_elem];
@@ -107,7 +107,7 @@ TEST_CASE("Unit_tiled_groups_metagrp_basic") {
  * ------------------------
  *    - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_coalesced_groups_metagrp_basic") {
+TEST_CASE("Unit_coalesced_groups_metagrp_basic", "[cooperativeLaunch]") {
   int *mgrpSize_d = nullptr, *mgrpRank_d = nullptr;
   int *mgrpSize_h = nullptr, *mgrpRank_h = nullptr;
   mgrpSize_h = new int[total_elem];

--- a/projects/hip-tests/catch/unit/cooperativeGrps/grid_group.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/grid_group.cc
@@ -108,7 +108,7 @@ static __global__ void sync_kernel(unsigned int* atomic_val, unsigned int* per_l
  *  - HIP_VERSION >= 5.2
  *  - Device supports cooperative launch
  */
-TEST_CASE("Unit_Grid_Group_Getters_Positive_Basic") {
+TEST_CASE("Unit_Grid_Group_Getters_Positive_Basic", "[cooperativeLaunch]") {
   int device;
   hipDeviceProp_t device_properties;
   HIP_CHECK(hipGetDevice(&device));
@@ -179,7 +179,7 @@ TEST_CASE("Unit_Grid_Group_Getters_Positive_Basic") {
  *  - HIP_VERSION >= 5.2
  *  - Device supports cooperative launch
  */
-TEST_CASE("Unit_Grid_Group_Getters_Via_Non_Member_Functions_Positive_Basic") {
+TEST_CASE("Unit_Grid_Group_Getters_Via_Non_Member_Functions_Positive_Basic", "[cooperativeLaunch]") {
   int device;
   hipDeviceProp_t device_properties;
   HIP_CHECK(hipGetDevice(&device));
@@ -248,7 +248,7 @@ TEST_CASE("Unit_Grid_Group_Getters_Via_Non_Member_Functions_Positive_Basic") {
  *  - HIP_VERSION >= 5.2
  *  - Device supports cooperative launch
  */
-TEST_CASE("Unit_Grid_Group_Sync_Positive_Basic") {
+TEST_CASE("Unit_Grid_Group_Sync_Positive_Basic", "[cooperativeLaunch]") {
   int device;
   hipDeviceProp_t device_properties;
   HIP_CHECK(hipGetDevice(&device));

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGCoalescedGroups_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGCoalescedGroups_old.cc
@@ -464,7 +464,7 @@ static void test_shfl_broadcast() {
   }
 }
 
-TEST_CASE("Unit_coalesced_groups") {
+TEST_CASE("Unit_coalesced_groups", "[cooperativeLaunch]") {
   // Use default device for validating the test
   int deviceId;
   HIP_CHECK(hipGetDevice(&deviceId));

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGGridGroupType_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGGridGroupType_old.cc
@@ -323,7 +323,7 @@ template <typename F> static void test_cg_grid_group_type(F kernel_func, int blo
   HIP_CHECK(hipHostFree(group_dim_host));
 }
 
-TEST_CASE("Unit_hipCGGridGroupType_Basic") {
+TEST_CASE("Unit_hipCGGridGroupType_Basic", "[cooperativeLaunch]") {
   // Use default device for validating the test
   int device;
   hipDeviceProp_t device_properties;
@@ -368,7 +368,7 @@ TEST_CASE("Unit_hipCGGridGroupType_Basic") {
   }
 }
 
-TEST_CASE("Unit_hipCGGridGroupType_DataSharing") {
+TEST_CASE("Unit_hipCGGridGroupType_DataSharing", "[cooperativeLaunch]") {
   const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
   HIP_CHECK(hipSetDevice(device));
 
@@ -448,7 +448,7 @@ TEST_CASE("Unit_hipCGGridGroupType_DataSharing") {
   free(host_mem_2);
 }
 
-TEST_CASE("Unit_hipCGGridGroupType_Barrier") {
+TEST_CASE("Unit_hipCGGridGroupType_Barrier", "[cooperativeLaunch]") {
   const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
   HIP_CHECK(hipSetDevice(device));
 

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGMultiGridGroupType_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGMultiGridGroupType_old.cc
@@ -378,7 +378,7 @@ template <typename F> static void test_cg_multi_grid_group_type(F kernel_func, i
   }
 }
 
-TEST_CASE("Unit_hipCGMultiGridGroupType_Basic", "[multigpu]") {
+TEST_CASE("Unit_hipCGMultiGridGroupType_Basic", "[multigpu][cooperativeLaunch]") {
   int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   num_devices = min(num_devices, MaxGPUs);
@@ -425,7 +425,7 @@ TEST_CASE("Unit_hipCGMultiGridGroupType_Basic", "[multigpu]") {
   }
 }
 
-TEST_CASE("Unit_hipCGMultiGridGroupType_Barrier", "[multigpu]") {
+TEST_CASE("Unit_hipCGMultiGridGroupType_Barrier", "[multigpu][cooperativeLaunch]") {
   int num_devices = 0;
   uint32_t loops = GENERATE(1, 2, 3, 4);
   uint32_t warps = GENERATE(4, 8, 16, 32);

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGThreadBlockTileTypeShfl_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGThreadBlockTileTypeShfl_old.cc
@@ -176,7 +176,7 @@ template <unsigned int tile_size> static void test_group_partition(TiledGroupShf
   delete[] expected_result;
 }
 
-TEST_CASE("Unit_hipCGThreadBlockTileType_Shfl") {
+TEST_CASE("Unit_hipCGThreadBlockTileType_Shfl", "[cooperativeLaunch]") {
   // Use default device for validating the test
   int device;
   hipDeviceProp_t device_properties;

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGThreadBlockType_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGThreadBlockType_old.cc
@@ -190,7 +190,7 @@ static void test_cg_thread_block_type(ThreadBlockTypeTests test_type, int block_
 }
 
 
-TEST_CASE("Unit_hipCGThreadBlockType") {
+TEST_CASE("Unit_hipCGThreadBlockType", "[cooperativeLaunch]") {
   // Use default device for validating the test
   int device;
   hipDeviceProp_t device_properties;

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipCGTiledPartitionType_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipCGTiledPartitionType_old.cc
@@ -338,7 +338,7 @@ static void test_group_partition_nested(unsigned int outer_tile_size,
   }
 }
 
-TEST_CASE("Unit_hipCGThreadBlockTileType") {
+TEST_CASE("Unit_hipCGThreadBlockTileType", "[cooperativeLaunch]") {
   // Use default device for validating the test
   int device;
   hipDeviceProp_t device_properties;

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipLaunchCooperativeKernelMultiDevice_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipLaunchCooperativeKernelMultiDevice_old.cc
@@ -130,7 +130,7 @@ __global__ void test_gws(uint* buf, uint buf_size, long* tmp_buf, long* result) 
   }
 }
 
-TEST_CASE("Unit_hipLaunchCooperativeKernelMultiDevice_Basic", "[multigpu]") {
+TEST_CASE("Unit_hipLaunchCooperativeKernelMultiDevice_Basic", "[multigpu][cooperativeLaunch]") {
   constexpr uint num_kernel_args = 4;
 
   int device_num = 0;

--- a/projects/hip-tests/catch/unit/cooperativeGrps/hipLaunchCooperativeKernel_old.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/hipLaunchCooperativeKernel_old.cc
@@ -59,7 +59,7 @@ __global__ void test_gws(int* buf, size_t buf_size, long* tmp_buf, long* result)
   }
 }
 
-TEST_CASE("Unit_hipLaunchCooperativeKernel_Basic") {
+TEST_CASE("Unit_hipLaunchCooperativeKernel_Basic", "[cooperativeLaunch]") {
   // Use default device for validating the test
   int device;
   int *A_h, *A_d;

--- a/projects/hip-tests/catch/unit/cooperativeGrps/multi_grid_group.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/multi_grid_group.cc
@@ -154,7 +154,7 @@ static void get_multi_grid_dims(dim3& grid_dim, dim3& block_dim, unsigned int de
  *  - HIP_VERSION >= 5.2
  *  - Devices support cooperative multi device launch
  */
-TEST_CASE("Unit_Multi_Grid_Group_Getters_Positive_Basic", "[multigpu]") {
+TEST_CASE("Unit_Multi_Grid_Group_Getters_Positive_Basic", "[multigpu][cooperativeLaunch]") {
   int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   num_devices = min(num_devices, kMaxGPUs);
@@ -302,7 +302,7 @@ TEST_CASE("Unit_Multi_Grid_Group_Getters_Positive_Basic", "[multigpu]") {
  *  - HIP_VERSION >= 5.2
  *  - Devices support cooperative multi device launch
  */
-TEST_CASE("Unit_Multi_Grid_Group_Getters_Positive_Base_Type", "[multigpu]") {
+TEST_CASE("Unit_Multi_Grid_Group_Getters_Positive_Base_Type", "[multigpu][cooperativeLaunch]") {
   int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   num_devices = min(num_devices, kMaxGPUs);
@@ -423,8 +423,7 @@ TEST_CASE("Unit_Multi_Grid_Group_Getters_Positive_Base_Type", "[multigpu]") {
  *  - HIP_VERSION >= 5.2
  *  - Devices support cooperative multi device launch
  */
-TEST_CASE("Unit_Multi_Grid_Group_Getters_Positive_Non_Member_Functions",
-          "[multigpu]") {
+TEST_CASE("Unit_Multi_Grid_Group_Getters_Positive_Non_Member_Functions", "[multigpu][cooperativeLaunch]") {
   int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
   num_devices = min(num_devices, kMaxGPUs);
@@ -536,7 +535,7 @@ TEST_CASE("Unit_Multi_Grid_Group_Getters_Positive_Non_Member_Functions",
  *  - HIP_VERSION >= 5.2
  *  - Devices support cooperative multi device launch
  */
-TEST_CASE("Unit_Multi_Grid_Group_Positive_Sync", "[multigpu]") {
+TEST_CASE("Unit_Multi_Grid_Group_Positive_Sync", "[multigpu][cooperativeLaunch]") {
   CHECK_IMAGE_SUPPORT
   int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block.cc
@@ -79,7 +79,7 @@ static __global__ void thread_block_non_member_thread_rank_getter(unsigned int* 
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Thread_Block_Getters_Positive_Basic") {
+TEST_CASE("Unit_Thread_Block_Getters_Positive_Basic", "[cooperativeLaunch]") {
   const auto blocks = GenerateBlockDimensions();
   const auto threads = GenerateThreadDimensions();
   if (blocks.x <= 0 || blocks.y <= 0 || blocks.z <= 0 || threads.x <= 0 || threads.y <= 0 ||
@@ -157,7 +157,7 @@ TEST_CASE("Unit_Thread_Block_Getters_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Thread_Block_Getters_Via_Base_Type_Positive_Basic") {
+TEST_CASE("Unit_Thread_Block_Getters_Via_Base_Type_Positive_Basic", "[cooperativeLaunch]") {
   const auto blocks = GenerateBlockDimensions();
   const auto threads = GenerateThreadDimensions();
   if (blocks.x <= 0 || blocks.y <= 0 || blocks.z <= 0 || threads.x <= 0 || threads.y <= 0 ||
@@ -208,7 +208,7 @@ TEST_CASE("Unit_Thread_Block_Getters_Via_Base_Type_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Thread_Block_Getters_Via_Non_Member_Functions_Positive_Basic") {
+TEST_CASE("Unit_Thread_Block_Getters_Via_Non_Member_Functions_Positive_Basic", "[cooperativeLaunch]") {
   const auto blocks = GenerateBlockDimensions();
   const auto threads = GenerateThreadDimensions();
   if (blocks.x <= 0 || blocks.y <= 0 || blocks.z <= 0 || threads.x <= 0 || threads.y <= 0 ||

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -120,7 +120,7 @@ template <bool dynamic, size_t... tile_sizes> void BlockPartitionGettersBasicTes
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Thread_Block_Tile_Getters_Positive_Basic") {
+TEST_CASE("Unit_Thread_Block_Tile_Getters_Positive_Basic", "[cooperativeLaunch]") {
   BlockPartitionGettersBasicTest<false, 2, 4, 8, 16, 32>();
 }
 
@@ -137,7 +137,7 @@ TEST_CASE("Unit_Thread_Block_Tile_Getters_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Thread_Block_Tile_Dynamic_Getters_Positive_Basic") {
+TEST_CASE("Unit_Thread_Block_Tile_Dynamic_Getters_Positive_Basic", "[cooperativeLaunch]") {
   BlockPartitionGettersBasicTest<true, 2, 4, 8, 16, 32>();
 }
 

--- a/projects/hip-tests/catch/unit/executionControl/hipExtLaunchKernel.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipExtLaunchKernel.cc
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipExtLaunchKernel_Positive_Basic") {
+TEST_CASE("Unit_hipExtLaunchKernel_Positive_Basic", "[kernel]") {
   SECTION("Kernel with no arguments") {
     HIP_CHECK(hipExtLaunchKernel(reinterpret_cast<void*>(kernel), dim3{1, 1, 1}, dim3{1, 1, 1},
                                  nullptr, 0, nullptr, nullptr, nullptr, 0u));
@@ -47,7 +47,7 @@ TEST_CASE("Unit_hipExtLaunchKernel_Positive_Basic") {
   }
 }
 
-TEST_CASE("Unit_hipExtLaunchKernel_Positive_Parameters") {
+TEST_CASE("Unit_hipExtLaunchKernel_Positive_Parameters", "[kernel]") {
   SECTION("blockDim.x == maxBlockDimX") {
     const unsigned int x = GetDeviceAttribute(hipDeviceAttributeMaxBlockDimX, 0);
     HIP_CHECK(hipExtLaunchKernel(reinterpret_cast<void*>(kernel), dim3{1, 1, 1}, dim3{x, 1, 1},
@@ -67,7 +67,7 @@ TEST_CASE("Unit_hipExtLaunchKernel_Positive_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipExtLaunchKernel_Negative_Parameters") {
+TEST_CASE("Unit_hipExtLaunchKernel_Negative_Parameters", "[kernel]") {
   SECTION("f == nullptr") {
     HIP_CHECK_ERROR(hipExtLaunchKernel(nullptr, dim3{1, 1, 1}, dim3{1, 1, 1}, nullptr, 0, nullptr,
                                        nullptr, nullptr, 0u),
@@ -187,7 +187,7 @@ TEST_CASE("Unit_hipExtLaunchKernel_Negative_Parameters") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_hipExtLaunchKernel_capturehipExtLaunchKernel") {
+TEST_CASE("Unit_hipExtLaunchKernel_capturehipExtLaunchKernel", "[kernel]") {
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
   int* A_d;

--- a/projects/hip-tests/catch/unit/executionControl/hipExtLaunchMultiKernelMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipExtLaunchMultiKernelMultiDevice.cc
@@ -27,8 +27,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Positive_Basic",
-          "[multigpu]") {
+TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Positive_Basic", "[multigpu][kernel]") {
   const auto device_count = HipTest::getDeviceCount();
 
   std::vector<hipLaunchParams> params_list(device_count);
@@ -55,8 +54,7 @@ TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Positive_Basic",
   }
 }
 
-TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Negative_Parameters",
-          "[multigpu]") {
+TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Negative_Parameters", "[multigpu][kernel]") {
   const auto device_count = HipTest::getDeviceCount();
 
   std::vector<hipLaunchParams> params_list(device_count);
@@ -123,7 +121,7 @@ TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Negative_Parameters",
   }
 }
 
-TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Negative_MultiKernelSameDevice") {
+TEST_CASE("Unit_hipExtLaunchMultiKernelMultiDevice_Negative_MultiKernelSameDevice", "[kernel]") {
   HIP_CHECK(hipSetDevice(0));
 
   std::vector<hipLaunchParams> params_list(2);

--- a/projects/hip-tests/catch/unit/executionControl/hipFuncGetAttributes.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipFuncGetAttributes.cc
@@ -29,7 +29,7 @@ __constant__ char const_data[kConstSizeBytes];
 
 __global__ void attribute_test_kernel() {}
 
-TEST_CASE("Unit_hipFuncGetAttributes_Positive_Basic") {
+TEST_CASE("Unit_hipFuncGetAttributes_Positive_Basic", "[kernel]") {
   hipFuncAttributes attr;
   HIP_CHECK(hipFuncGetAttributes(&attr, reinterpret_cast<void*>(attribute_test_kernel)));
 
@@ -57,7 +57,7 @@ TEST_CASE("Unit_hipFuncGetAttributes_Positive_Basic") {
   }
 }
 
-TEST_CASE("Unit_hipFuncGetAttributes_Negative_Parameters") {
+TEST_CASE("Unit_hipFuncGetAttributes_Negative_Parameters", "[kernel]") {
   SECTION("attr == nullptr") {
     HIP_CHECK_ERROR(hipFuncGetAttributes(nullptr, reinterpret_cast<void*>(attribute_test_kernel)),
                     hipErrorInvalidValue);

--- a/projects/hip-tests/catch/unit/executionControl/hipFuncSetAttribute.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipFuncSetAttribute.cc
@@ -45,7 +45,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize") {
+TEST_CASE("Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize", "[kernel]") {
   HIP_CHECK(hipFuncSetAttribute(reinterpret_cast<void*>(kernel),
                                 hipFuncAttributeMaxDynamicSharedMemorySize, 1024));
 
@@ -67,7 +67,7 @@ TEST_CASE("Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipFuncSetAttribute_Positive_PreferredSharedMemoryCarveout") {
+TEST_CASE("Unit_hipFuncSetAttribute_Positive_PreferredSharedMemoryCarveout", "[kernel]") {
   HIP_CHECK(hipFuncSetAttribute(reinterpret_cast<void*>(kernel),
                                 hipFuncAttributePreferredSharedMemoryCarveout, 50));
 
@@ -99,7 +99,7 @@ TEST_CASE("Unit_hipFuncSetAttribute_Positive_PreferredSharedMemoryCarveout") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipFuncSetAttribute_Positive_Parameters") {
+TEST_CASE("Unit_hipFuncSetAttribute_Positive_Parameters", "[kernel]") {
   SECTION("hipFuncAttributeMaxDynamicSharedMemorySize == 0") {
     HIP_CHECK(hipFuncSetAttribute(reinterpret_cast<void*>(kernel),
                                   hipFuncAttributeMaxDynamicSharedMemorySize, 0));
@@ -160,7 +160,7 @@ TEST_CASE("Unit_hipFuncSetAttribute_Positive_Parameters") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipFuncSetAttribute_Negative_Parameters") {
+TEST_CASE("Unit_hipFuncSetAttribute_Negative_Parameters", "[kernel]") {
   SECTION("func == nullptr") {
     HIP_CHECK_ERROR(hipFuncSetAttribute(nullptr, hipFuncAttributePreferredSharedMemoryCarveout, 50),
                     hipErrorInvalidDeviceFunction);
@@ -220,7 +220,7 @@ TEST_CASE("Unit_hipFuncSetAttribute_Negative_Parameters") {
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize_Not_Supported") {
+TEST_CASE("Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize_Not_Supported", "[kernel]") {
 #if HT_NVIDIA
   HipTest::HIP_SKIP_TEST("This is an AMD specific test");
   return;
@@ -252,7 +252,7 @@ TEST_CASE("Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize_Not_Supp
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipFuncSetAttribute_Positive_PreferredSharedMemoryCarveout_Not_Supported") {
+TEST_CASE("Unit_hipFuncSetAttribute_Positive_PreferredSharedMemoryCarveout_Not_Supported", "[kernel]") {
 #if HT_NVIDIA
   HipTest::HIP_SKIP_TEST("This is an AMD specific test");
   return;

--- a/projects/hip-tests/catch/unit/executionControl/hipFuncSetCacheConfig.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipFuncSetCacheConfig.cc
@@ -50,7 +50,7 @@ constexpr std::array<hipFuncCache_t, 4> kCacheConfigs{
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipFuncSetCacheConfig_Positive_Basic") {
+TEST_CASE("Unit_hipFuncSetCacheConfig_Positive_Basic", "[kernel]") {
   const auto cache_config = GENERATE(from_range(begin(kCacheConfigs), end(kCacheConfigs)));
 
   HIP_CHECK(hipFuncSetCacheConfig(reinterpret_cast<void*>(kernel), cache_config));
@@ -74,7 +74,7 @@ TEST_CASE("Unit_hipFuncSetCacheConfig_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipFuncSetCacheConfig_Negative_Parameters") {
+TEST_CASE("Unit_hipFuncSetCacheConfig_Negative_Parameters", "[kernel]") {
   SECTION("func == nullptr") {
     HIP_CHECK_ERROR(hipFuncSetCacheConfig(nullptr, hipFuncCachePreferNone),
                     hipErrorInvalidDeviceFunction);
@@ -99,7 +99,7 @@ TEST_CASE("Unit_hipFuncSetCacheConfig_Negative_Parameters") {
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipFuncSetCacheConfig_Negative_Not_Supported") {
+TEST_CASE("Unit_hipFuncSetCacheConfig_Negative_Not_Supported", "[kernel]") {
 #if HT_NVIDIA
   HipTest::HIP_SKIP_TEST("This is an AMD specific test");
   return;

--- a/projects/hip-tests/catch/unit/executionControl/hipFuncSetSharedMemConfig.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipFuncSetSharedMemConfig.cc
@@ -49,7 +49,7 @@ constexpr std::array<hipSharedMemConfig, 3> kSharedMemConfigs{
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipFuncSetSharedMemConfig_Positive_Basic") {
+TEST_CASE("Unit_hipFuncSetSharedMemConfig_Positive_Basic", "[kernel]") {
   const auto shared_mem_config =
       GENERATE(from_range(begin(kSharedMemConfigs), end(kSharedMemConfigs)));
 
@@ -74,7 +74,7 @@ TEST_CASE("Unit_hipFuncSetSharedMemConfig_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipFuncSetSharedMemConfig_Negative_Parameters") {
+TEST_CASE("Unit_hipFuncSetSharedMemConfig_Negative_Parameters", "[kernel]") {
   SECTION("func == nullptr") {
     HIP_CHECK_ERROR(hipFuncSetSharedMemConfig(nullptr, hipSharedMemBankSizeDefault),
                     hipErrorInvalidDeviceFunction);
@@ -99,7 +99,7 @@ TEST_CASE("Unit_hipFuncSetSharedMemConfig_Negative_Parameters") {
  *  - Platform specific (AMD)
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipFuncSetSharedMemConfig_Negative_Not_Supported") {
+TEST_CASE("Unit_hipFuncSetSharedMemConfig_Negative_Not_Supported", "[kernel]") {
 #if HT_NVIDIA
   HipTest::HIP_SKIP_TEST("This is an AMD specific test");
   return;

--- a/projects/hip-tests/catch/unit/executionControl/hipGetProcAddressLaunchCbExecCtrlApis.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipGetProcAddressLaunchCbExecCtrlApis.cc
@@ -36,7 +36,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_KernelLaunchApis") {
+TEST_CASE("Unit_hipGetProcAddress_KernelLaunchApis", "[kernel]") {
   void* hipConfigureCall_ptr = nullptr;
   void* hipSetupArgument_ptr = nullptr;
   void* hipLaunchByPtr_ptr = nullptr;
@@ -358,7 +358,7 @@ TEST_CASE("Unit_hipGetProcAddress_KernelLaunchApis") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_CallbackActivityAPIs") {
+TEST_CASE("Unit_hipGetProcAddress_CallbackActivityAPIs", "[kernel]") {
   void* hipGetStreamDeviceId_ptr = nullptr;
   void* hipApiName_ptr = nullptr;
   void* hipKernelNameRef_ptr = nullptr;
@@ -424,7 +424,7 @@ TEST_CASE("Unit_hipGetProcAddress_CallbackActivityAPIs") {
  * ------------------------
  *  - HIP_VERSION >= 6.2
  */
-TEST_CASE("Unit_hipGetProcAddress_ExecutionControlAPIs") {
+TEST_CASE("Unit_hipGetProcAddress_ExecutionControlAPIs", "[kernel]") {
   void* hipFuncSetAttribute_ptr = nullptr;
   void* hipFuncSetCacheConfig_ptr = nullptr;
   void* hipFuncSetSharedMemConfig_ptr = nullptr;

--- a/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernel.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernel.cc
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipLaunchCooperativeKernel_Positive_Basic") {
+TEST_CASE("Unit_hipLaunchCooperativeKernel_Positive_Basic", "[kernel]") {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -54,7 +54,7 @@ TEST_CASE("Unit_hipLaunchCooperativeKernel_Positive_Basic") {
   }
 }
 
-TEST_CASE("Unit_hipLaunchCooperativeKernel_Positive_Parameters") {
+TEST_CASE("Unit_hipLaunchCooperativeKernel_Positive_Parameters", "[kernel]") {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -79,7 +79,7 @@ TEST_CASE("Unit_hipLaunchCooperativeKernel_Positive_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipLaunchCooperativeKernel_Negative_Parameters") {
+TEST_CASE("Unit_hipLaunchCooperativeKernel_Negative_Parameters", "[kernel]") {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;

--- a/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernelMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipLaunchCooperativeKernelMultiDevice.cc
@@ -27,8 +27,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipLaunchCooperativeKernelMultiDevice_Positive_Basic",
-          "[multigpu]") {
+TEST_CASE("Unit_hipLaunchCooperativeKernelMultiDevice_Positive_Basic", "[multigpu][kernel]") {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -60,8 +59,7 @@ TEST_CASE("Unit_hipLaunchCooperativeKernelMultiDevice_Positive_Basic",
   }
 }
 
-TEST_CASE("Unit_hipLaunchCooperativeKernelMultiDevice_Negative_Parameters",
-          "[multigpu]") {
+TEST_CASE("Unit_hipLaunchCooperativeKernelMultiDevice_Negative_Parameters", "[multigpu][kernel]") {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -138,7 +136,7 @@ TEST_CASE("Unit_hipLaunchCooperativeKernelMultiDevice_Negative_Parameters",
   }
 }
 
-TEST_CASE("Unit_hipLaunchCooperativeKernelMultiDevice_Negative_MultiKernelSameDevice") {
+TEST_CASE("Unit_hipLaunchCooperativeKernelMultiDevice_Negative_MultiKernelSameDevice", "[kernel]") {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;

--- a/projects/hip-tests/catch/unit/executionControl/hipLaunchKernel.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipLaunchKernel.cc
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include <resource_guards.hh>
 #include <utils.hh>
 
-TEST_CASE("Unit_hipLaunchKernel_Positive_Basic") {
+TEST_CASE("Unit_hipLaunchKernel_Positive_Basic", "[kernel]") {
   SECTION("Kernel with no arguments") {
     HIP_CHECK(hipLaunchKernel(reinterpret_cast<void*>(kernel), dim3{1, 1, 1}, dim3{1, 1, 1},
                               nullptr, 0, nullptr));
@@ -47,7 +47,7 @@ TEST_CASE("Unit_hipLaunchKernel_Positive_Basic") {
   }
 }
 
-TEST_CASE("Unit_hipLaunchKernel_Positive_Parameters") {
+TEST_CASE("Unit_hipLaunchKernel_Positive_Parameters", "[kernel]") {
   SECTION("blockDim.x == maxBlockDimX") {
     const unsigned int x = GetDeviceAttribute(hipDeviceAttributeMaxBlockDimX, 0);
     HIP_CHECK(hipLaunchKernel(reinterpret_cast<void*>(kernel), dim3{1, 1, 1}, dim3{x, 1, 1},
@@ -67,7 +67,7 @@ TEST_CASE("Unit_hipLaunchKernel_Positive_Parameters") {
   }
 }
 
-TEST_CASE("Unit_hipLaunchKernel_Negative_Parameters") {
+TEST_CASE("Unit_hipLaunchKernel_Negative_Parameters", "[kernel]") {
   SECTION("f == nullptr") {
     HIP_CHECK_ERROR(hipLaunchKernel(nullptr, dim3{1, 1, 1}, dim3{1, 1, 1}, nullptr, 0, nullptr),
                     hipErrorInvalidDeviceFunction);

--- a/projects/hip-tests/catch/unit/executionControl/launch_api.cc
+++ b/projects/hip-tests/catch/unit/executionControl/launch_api.cc
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <resource_guards.hh>
 
-TEST_CASE("Unit_hipLaunchByPtr_Positive_Basic") {
+TEST_CASE("Unit_hipLaunchByPtr_Positive_Basic", "[kernel]") {
   LinearAllocGuard<int> alloc(LinearAllocs::hipMallocManaged, 4);
 
   SECTION("hipConfigureCall") { HIP_CHECK(hipConfigureCall(dim3{1}, dim3{1}, 0, nullptr)); }
@@ -43,12 +43,12 @@ TEST_CASE("Unit_hipLaunchByPtr_Positive_Basic") {
   REQUIRE(alloc.ptr()[0] == 42);
 }
 
-TEST_CASE("Unit_hipLaunchByPtr_Negative_Parameters") {
+TEST_CASE("Unit_hipLaunchByPtr_Negative_Parameters", "[kernel]") {
   HIP_CHECK(hipConfigureCall(dim3{1}, dim3{1}, 0, nullptr));
   HIP_CHECK_ERROR(hipLaunchByPtr(nullptr), hipErrorInvalidDeviceFunction);
 }
 
-TEST_CASE("Unit___hipPushCallConfiguration_Positive_Basic") {
+TEST_CASE("Unit___hipPushCallConfiguration_Positive_Basic", "[kernel]") {
   StreamGuard stream_guard(Streams::created);
   HIP_CHECK(__hipPushCallConfiguration(dim3{1, 2, 3}, dim3{3, 2, 1}, 1024, stream_guard.stream()));
 

--- a/projects/hip-tests/catch/unit/kernel/hipAutoThreadIdx.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipAutoThreadIdx.cc
@@ -50,7 +50,7 @@ static __global__ void vecSqrSingBlk(int* A_d, size_t NELEM) {
  * ------------------------
  * - HIP_VERSION >= 6.1
  */
-TEST_CASE("Unit_kernel_Assign_threadIdx_to_auto") {
+TEST_CASE("Unit_kernel_Assign_threadIdx_to_auto", "[kernel]") {
   int* A_d;
   const unsigned blocks = 256;
   const unsigned threadsPerBlock = 128;

--- a/projects/hip-tests/catch/unit/kernel/hipConfigureCall.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipConfigureCall.cc
@@ -30,7 +30,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_ConfigureCall") {
+TEST_CASE("Unit_ConfigureCall", "[kernel]") {
   struct dim3 grid_dim{};
   struct dim3 block_dim{};
   size_t shared_memory_size = 1024;
@@ -49,7 +49,7 @@ TEST_CASE("Unit_ConfigureCall") {
  * ------------------------
  *  - HIP_VERSION >= 6.0
  */
-TEST_CASE("Unit_ConfigureCall_CheckParams") {
+TEST_CASE("Unit_ConfigureCall_CheckParams", "[kernel]") {
   struct dim3 grid_dim{16, 8, 1};
   struct dim3 test_grid_dim{};
   struct dim3 block_dim{16, 8, 1};

--- a/projects/hip-tests/catch/unit/kernel/hipDynamicShared.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipDynamicShared.cc
@@ -124,7 +124,7 @@ template <typename T> void testExternShared(size_t N, unsigned groupElements) {
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_hipDynamicShared") {
+TEST_CASE("Unit_hipDynamicShared", "[kernel]") {
   SECTION("test case with float for least size") {
     testExternShared<float>(1024, 4);
     testExternShared<float>(1024, 8);

--- a/projects/hip-tests/catch/unit/kernel/hipDynamicShared2.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipDynamicShared2.cc
@@ -57,7 +57,7 @@ __global__ void vectorAdd(float* Ad, float* Bd) {
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_hipDynamicShared2") {
+TEST_CASE("Unit_hipDynamicShared2", "[kernel]") {
   float *A, *B, *Ad, *Bd;
   A = new float[LEN];
   B = new float[LEN];

--- a/projects/hip-tests/catch/unit/kernel/hipEmptyKernel.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipEmptyKernel.cc
@@ -48,7 +48,7 @@ __global__ void Empty(int param) {}
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_hipEmptyKernel") {
+TEST_CASE("Unit_hipEmptyKernel", "[kernel]") {
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Empty), dim3(1), dim3(1), 0, 0, 0);
   HIP_CHECK(hipDeviceSynchronize());
 }

--- a/projects/hip-tests/catch/unit/kernel/hipExtLaunchKernelGGL.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipExtLaunchKernelGGL.cc
@@ -118,7 +118,7 @@ arguments
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_hipExtLaunchKernelGGL") {
+TEST_CASE("Unit_hipExtLaunchKernelGGL", "[kernel]") {
   SECTION("test run") {
     size_t N = 4 * 1024 * 1024;
     test(N);

--- a/projects/hip-tests/catch/unit/kernel/hipGridLaunch.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipGridLaunch.cc
@@ -103,7 +103,7 @@ int test_triple_chevron(size_t N) {
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_hipGridLaunch") {
+TEST_CASE("Unit_hipGridLaunch", "[kernel]") {
   size_t N = 4 * 1024 * 1024;
   SECTION("Test test_gl2") { test_gl2(N); }
 

--- a/projects/hip-tests/catch/unit/kernel/hipLanguageExtensions.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipLanguageExtensions.cc
@@ -98,7 +98,7 @@ template <typename T> __global__ void vectorADD(T __restrict__* A_d, T* B_d, T* 
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_hipLanguageExtensions") { REQUIRE(true); }
+TEST_CASE("Unit_hipLanguageExtensions", "[kernel]") { REQUIRE(true); }
 
 /**
  * End doxygen group KernelTest.

--- a/projects/hip-tests/catch/unit/kernel/hipLaunchBounds.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipLaunchBounds.cc
@@ -58,7 +58,7 @@ static bool verify(int N, int* x, int val) {
   return true;
 }
 
-TEST_CASE("Unit_hipLaunchBounds_With_maxThreadsPerBlock_Check") {
+TEST_CASE("Unit_hipLaunchBounds_With_maxThreadsPerBlock_Check", "[kernel]") {
   constexpr size_t N = 10000;
   hipError_t ret;
   int* x;
@@ -98,7 +98,7 @@ TEST_CASE("Unit_hipLaunchBounds_With_maxThreadsPerBlock_Check") {
   HIP_CHECK(hipFree(x));
 }
 
-TEST_CASE("Unit_hipLaunchBounds_With_maxThreadsPerBlock_blocksPerCU_Check") {
+TEST_CASE("Unit_hipLaunchBounds_With_maxThreadsPerBlock_blocksPerCU_Check", "[kernel]") {
   constexpr size_t N = 10000;
   hipError_t ret;
   int* x;

--- a/projects/hip-tests/catch/unit/kernel/hipLaunchKernelEx.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipLaunchKernelEx.cc
@@ -137,7 +137,7 @@ __global__ void normalKernel(int* output, int totalThreads) {
  * ------------------------
  *    - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipLaunchKernelExC_NegetiveTsts") {
+TEST_CASE("Unit_hipLaunchKernelExC_NegetiveTsts", "[kernel]") {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -207,7 +207,7 @@ TEST_CASE("Unit_hipLaunchKernelExC_NegetiveTsts") {
  *    - HIP_VERSION >= 6.5
  */
 
-TEST_CASE("Unit_hipLaunchKernelEx_NegetiveTsts") {
+TEST_CASE("Unit_hipLaunchKernelEx_NegetiveTsts", "[kernel]") {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -330,7 +330,7 @@ bool runTest(const char* testName, const void* kernelFunc, int totalThreads, int
  * ------------------------
  *    - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipLaunchKernelEx_Functional") {
+TEST_CASE("Unit_hipLaunchKernelEx_Functional", "[kernel]") {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -362,7 +362,7 @@ TEST_CASE("Unit_hipLaunchKernelEx_Functional") {
  * ------------------------
  *  - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipLaunchKernelEx_With_Different_Kernels") {
+TEST_CASE("Unit_hipLaunchKernelEx_With_Different_Kernels", "[kernel]") {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -434,7 +434,7 @@ TEST_CASE("Unit_hipLaunchKernelEx_With_Different_Kernels") {
  * ------------------------
  *  - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipLaunchKernelEx_With_CooperativeKernelWithArgs") {
+TEST_CASE("Unit_hipLaunchKernelEx_With_CooperativeKernelWithArgs", "[kernel]") {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;
@@ -497,7 +497,7 @@ TEST_CASE("Unit_hipLaunchKernelEx_With_CooperativeKernelWithArgs") {
  * ------------------------
  *  - HIP_VERSION >= 6.5
  */
-TEST_CASE("Unit_hipLaunchKernelEx_With_MaxBlockDims") {
+TEST_CASE("Unit_hipLaunchKernelEx_With_MaxBlockDims", "[kernel]") {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCooperativeLaunch)) {
     HipTest::HIP_SKIP_TEST("CooperativeLaunch not supported");
     return;

--- a/projects/hip-tests/catch/unit/kernel/hipLaunchParm.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipLaunchParm.cc
@@ -542,7 +542,7 @@ template <class T1, class T2> __global__ void myKernel(T1 a, T2 b) {}
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_hipLaunchParm") {
+TEST_CASE("Unit_hipLaunchParm", "[kernel]") {
   hipMallocError = hipMalloc(reinterpret_cast<void**>(&result_d), BLOCK_DIM_SIZE * sizeof(bool));
   hipHostMallocError =
       hipHostMalloc(reinterpret_cast<void**>(&result_h), BLOCK_DIM_SIZE * sizeof(bool));

--- a/projects/hip-tests/catch/unit/kernel/hipLaunchParmFunctor.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipLaunchParmFunctor.cc
@@ -402,7 +402,7 @@ void HipFunctorTests::TestForFunctorContainInStructObj(void) {
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_hipLaunchParmFunctor") {
+TEST_CASE("Unit_hipLaunchParmFunctor", "[kernel]") {
   HipFunctorTests FunctorTests;
 
   SECTION("test for simple class functor") { FunctorTests.TestForSimpleClassFunctor(); }

--- a/projects/hip-tests/catch/unit/kernel/hipMemFaultStackAllocation.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipMemFaultStackAllocation.cc
@@ -63,7 +63,7 @@ static bool verify(const int* C_d, const int* A_d) {
   return true;
 }
 
-TEST_CASE("Unit_hipMemFaultStackAllocation_Check") {
+TEST_CASE("Unit_hipMemFaultStackAllocation_Check", "[kernel]") {
   hipError_t ret;
   int *A_d, *C_d;
   const size_t Nbytes = N * sizeof(int);

--- a/projects/hip-tests/catch/unit/kernel/hipPrintfKernel.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipPrintfKernel.cc
@@ -45,7 +45,7 @@ __global__ void run_printf() { printf("Hello World\n"); }
  * ------------------------
  * - HIP_VERSION >= 5.6
  */
-TEST_CASE("Unit_kernel_ChkPrintf", "[multigpu]") {
+TEST_CASE("Unit_kernel_ChkPrintf", "[multigpu][kernel]") {
   int device_count = 0;
   CaptureStream capture(stdout);
   HIP_CHECK(hipGetDeviceCount(&device_count));

--- a/projects/hip-tests/catch/unit/kernel/hipSetupArgument.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipSetupArgument.cc
@@ -27,7 +27,7 @@ __global__ void add_vectors(int* a, int* b, int* result, int size) {
   }
 }
 
-TEST_CASE("Unit_hipSetupArgument_Simple") {
+TEST_CASE("Unit_hipSetupArgument_Simple", "[kernel]") {
   dim3 grid_dim(1, 1, 1);
   dim3 block_dim(1, 1, 1);
 
@@ -48,7 +48,7 @@ TEST_CASE("Unit_hipSetupArgument_Simple") {
  * ------------------------
  *  - unit/kernel/hipSetupArgument.cc
  */
-TEST_CASE("Unit_hipSetupArgument_Execute_Kernel_And_Check_Result") {
+TEST_CASE("Unit_hipSetupArgument_Execute_Kernel_And_Check_Result", "[kernel]") {
   constexpr auto block_size = 32;
   auto vec_size = 256;
   size_t block_num = static_cast<size_t>(std::ceil(static_cast<float>(vec_size) / block_size));

--- a/projects/hip-tests/catch/unit/kernel/hipTestConstant.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipTestConstant.cc
@@ -50,7 +50,7 @@ static __global__ void Get(int* Ad) {
  * - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_kernel_chkConstantViaKernel") {
+TEST_CASE("Unit_kernel_chkConstantViaKernel", "[kernel]") {
   int *A, *B, *Ad;
   A = new int[LEN];
   B = new int[LEN];

--- a/projects/hip-tests/catch/unit/kernel/hipTestGlobalVariable.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipTestGlobalVariable.cc
@@ -95,7 +95,7 @@ void runTestGlobalArray() {
   HIP_CHECK(hipFree(Ad));
 }
 
-TEST_CASE("Unit_kernel_chkGlobalArrAndGlobalVaribleViaKernelFn") {
+TEST_CASE("Unit_kernel_chkGlobalArrAndGlobalVaribleViaKernelFn", "[kernel]") {
   runTestConstantGlobalVar();
   runTestGlobalArray();
 }

--- a/projects/hip-tests/catch/unit/kernel/hipTestMemKernel.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipTestMemKernel.cc
@@ -96,7 +96,7 @@ __global__ void MemSet12(uint8_t* In) {
  * - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_kernel_MemoryOperationsViaKernels") {
+TEST_CASE("Unit_kernel_MemoryOperationsViaKernels", "[kernel]") {
   uint8_t *A, *Ad, *B, *Bd, *C, *Cd;
   A = new uint8_t[LEN8];
   B = new uint8_t[LEN8];

--- a/projects/hip-tests/catch/unit/kernel/launch_bounds.cc
+++ b/projects/hip-tests/catch/unit/kernel/launch_bounds.cc
@@ -51,7 +51,7 @@ __global__ void __launch_bounds__(256, 2) myKern(int* C, const int* A, int N) {
  * - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_kernel_LaunchBounds_Functional") {
+TEST_CASE("Unit_kernel_LaunchBounds_Functional", "[kernel]") {
   size_t Nbytes = N * sizeof(int);
   int *A_d, *C_d, *A_h, *C_h;
   HIPCHECK(hipMalloc(&A_d, Nbytes));

--- a/projects/hip-tests/catch/unit/launchBounds/launch_bounds.cc
+++ b/projects/hip-tests/catch/unit/launchBounds/launch_bounds.cc
@@ -96,7 +96,7 @@ template <bool out_of_bounds> void LaunchBoundsWrapper(const int threads_per_blo
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Kernel_Launch_bounds_Positive_Basic") {
+TEST_CASE("Unit_Kernel_Launch_bounds_Positive_Basic", "[kernel]") {
   auto threads_per_block = GENERATE(1, kMaxThreadsPerBlock / 2, kMaxThreadsPerBlock);
   LaunchBoundsWrapper<false>(threads_per_block);
 }
@@ -116,7 +116,7 @@ TEST_CASE("Unit_Kernel_Launch_bounds_Positive_Basic") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Kernel_Launch_bounds_Negative_OutOfBounds") {
+TEST_CASE("Unit_Kernel_Launch_bounds_Negative_OutOfBounds", "[kernel]") {
   auto threads_per_block =
       GENERATE(-1 * kMaxThreadsPerBlock, -1, kMaxThreadsPerBlock + 1, 2 * kMaxThreadsPerBlock);
   LaunchBoundsWrapper<true>(threads_per_block);
@@ -141,7 +141,7 @@ TEST_CASE("Unit_Kernel_Launch_bounds_Negative_OutOfBounds") {
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_Kernel_Launch_bounds_Negative_Parameters_RTC") {
+TEST_CASE("Unit_Kernel_Launch_bounds_Negative_Parameters_RTC", "[kernel]") {
   hiprtcProgram program{};
 
 #if HT_AMD

--- a/projects/hip-tests/catch/unit/synchronization/cache_coherency_cpu_gpu.cc
+++ b/projects/hip-tests/catch/unit/synchronization/cache_coherency_cpu_gpu.cc
@@ -254,7 +254,7 @@ static bool cpu_to_gpu_coherency() {
  *    - Test to be run only on AMD.
  */
 
-TEST_CASE("Unit_cache_coherency_cpu_gpu") {
+TEST_CASE("Unit_cache_coherency_cpu_gpu", "[sync]") {
   bool passed = true;
   // Coherency between CPU and GPU sharing host and device memory.
   REQUIRE(passed == cpu_to_gpu_coherency());

--- a/projects/hip-tests/catch/unit/synchronization/cache_coherency_gpu_gpu.cc
+++ b/projects/hip-tests/catch/unit/synchronization/cache_coherency_gpu_gpu.cc
@@ -284,7 +284,7 @@ static bool gpu_to_gpu_coherency() {
  *    - Test to be run only on AMD.
  */
 
-TEST_CASE("Unit_cache_coherency_gpu_gpu", "[multigpu]") {
+TEST_CASE("Unit_cache_coherency_gpu_gpu", "[multigpu][sync]") {
   bool passed = true;
   // Coherency between GPUs accessing local or remote FB.
   REQUIRE(passed == gpu_to_gpu_coherency());

--- a/projects/hip-tests/catch/unit/synchronization/copy_coherency.cc
+++ b/projects/hip-tests/catch/unit/synchronization/copy_coherency.cc
@@ -321,7 +321,7 @@ void testWrapper(size_t numElements) {
  *    - HIP_VERSION >= 5.5
  */
 
-TEST_CASE("Unit_Copy_Coherency") {
+TEST_CASE("Unit_Copy_Coherency", "[sync]") {
   for (int index = 0; index < sizeof(g_elementSizes) / sizeof(int); index++) {
     size_t numElements = g_elementSizes[index];
     testWrapper(numElements);

--- a/projects/hip-tests/catch/unit/syncthreads/__syncthreads.cc
+++ b/projects/hip-tests/catch/unit/syncthreads/__syncthreads.cc
@@ -43,7 +43,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_Positive_Basic") {
+TEST_CASE("Unit___syncthreads_Positive_Basic", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 

--- a/projects/hip-tests/catch/unit/syncthreads/__syncthreads_and.cc
+++ b/projects/hip-tests/catch/unit/syncthreads/__syncthreads_and.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_and_Positive_Basic") {
+TEST_CASE("Unit___syncthreads_and_Positive_Basic", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -71,7 +71,7 @@ TEST_CASE("Unit___syncthreads_and_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_and_Positive_Predicate_Zero") {
+TEST_CASE("Unit___syncthreads_and_Positive_Predicate_Zero", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -99,7 +99,7 @@ TEST_CASE("Unit___syncthreads_and_Positive_Predicate_Zero") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_and_Positive_Predicate_One") {
+TEST_CASE("Unit___syncthreads_and_Positive_Predicate_One", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -128,7 +128,7 @@ TEST_CASE("Unit___syncthreads_and_Positive_Predicate_One") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_and_Positive_Predicate_OddEven") {
+TEST_CASE("Unit___syncthreads_and_Positive_Predicate_OddEven", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -156,7 +156,7 @@ TEST_CASE("Unit___syncthreads_and_Positive_Predicate_OddEven") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_and_Positive_Predicate_Negative") {
+TEST_CASE("Unit___syncthreads_and_Positive_Predicate_Negative", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -184,7 +184,7 @@ TEST_CASE("Unit___syncthreads_and_Positive_Predicate_Negative") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_and_Positive_Predicate_Id") {
+TEST_CASE("Unit___syncthreads_and_Positive_Predicate_Id", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -212,7 +212,7 @@ TEST_CASE("Unit___syncthreads_and_Positive_Predicate_Id") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_and_Negative_Parameters_RTC") {
+TEST_CASE("Unit___syncthreads_and_Negative_Parameters_RTC", "[sync]") {
   hiprtcProgram program{};
 
   HIPRTC_CHECK(hiprtcCreateProgram(&program, kSyncthreadsAndSource, "__syncthreads_and_negative.cc",

--- a/projects/hip-tests/catch/unit/syncthreads/__syncthreads_count.cc
+++ b/projects/hip-tests/catch/unit/syncthreads/__syncthreads_count.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_count_Positive_Basic") {
+TEST_CASE("Unit___syncthreads_count_Positive_Basic", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -71,7 +71,7 @@ TEST_CASE("Unit___syncthreads_count_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_count_Positive_Predicate_Zero") {
+TEST_CASE("Unit___syncthreads_count_Positive_Predicate_Zero", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -99,7 +99,7 @@ TEST_CASE("Unit___syncthreads_count_Positive_Predicate_Zero") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_count_Positive_Predicate_One") {
+TEST_CASE("Unit___syncthreads_count_Positive_Predicate_One", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -128,7 +128,7 @@ TEST_CASE("Unit___syncthreads_count_Positive_Predicate_One") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_count_Positive_Predicate_OddEven") {
+TEST_CASE("Unit___syncthreads_count_Positive_Predicate_OddEven", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -156,7 +156,7 @@ TEST_CASE("Unit___syncthreads_count_Positive_Predicate_OddEven") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_count_Positive_Predicate_Negative") {
+TEST_CASE("Unit___syncthreads_count_Positive_Predicate_Negative", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -184,7 +184,7 @@ TEST_CASE("Unit___syncthreads_count_Positive_Predicate_Negative") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_count_Positive_Predicate_Id") {
+TEST_CASE("Unit___syncthreads_count_Positive_Predicate_Id", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -212,7 +212,7 @@ TEST_CASE("Unit___syncthreads_count_Positive_Predicate_Id") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_count_Negative_Parameters_RTC") {
+TEST_CASE("Unit___syncthreads_count_Negative_Parameters_RTC", "[sync]") {
   hiprtcProgram program{};
 
   HIPRTC_CHECK(hiprtcCreateProgram(&program, kSyncthreadsCountSource,

--- a/projects/hip-tests/catch/unit/syncthreads/__syncthreads_or.cc
+++ b/projects/hip-tests/catch/unit/syncthreads/__syncthreads_or.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_or_Positive_Basic") {
+TEST_CASE("Unit___syncthreads_or_Positive_Basic", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -71,7 +71,7 @@ TEST_CASE("Unit___syncthreads_or_Positive_Basic") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_or_Positive_Predicate_Zero") {
+TEST_CASE("Unit___syncthreads_or_Positive_Predicate_Zero", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -99,7 +99,7 @@ TEST_CASE("Unit___syncthreads_or_Positive_Predicate_Zero") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_or_Positive_Predicate_One") {
+TEST_CASE("Unit___syncthreads_or_Positive_Predicate_One", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -128,7 +128,7 @@ TEST_CASE("Unit___syncthreads_or_Positive_Predicate_One") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_or_Positive_Predicate_OddEven") {
+TEST_CASE("Unit___syncthreads_or_Positive_Predicate_OddEven", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -156,7 +156,7 @@ TEST_CASE("Unit___syncthreads_or_Positive_Predicate_OddEven") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_or_Positive_Predicate_Negative") {
+TEST_CASE("Unit___syncthreads_or_Positive_Predicate_Negative", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -184,7 +184,7 @@ TEST_CASE("Unit___syncthreads_or_Positive_Predicate_Negative") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_or_Positive_Predicate_Id") {
+TEST_CASE("Unit___syncthreads_or_Positive_Predicate_Id", "[sync]") {
   const auto kGridSize = 2;
   const auto kBlockSize = GENERATE(13, 32, 64, 513);
 
@@ -212,7 +212,7 @@ TEST_CASE("Unit___syncthreads_or_Positive_Predicate_Id") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___syncthreads_or_Negative_Parameters_RTC") {
+TEST_CASE("Unit___syncthreads_or_Negative_Parameters_RTC", "[sync]") {
   hiprtcProgram program{};
 
   HIPRTC_CHECK(hiprtcCreateProgram(&program, kSyncthreadsOrSource, "__syncthreads_or_negative.cc",

--- a/projects/hip-tests/catch/unit/threadfence/__threadfence.cc
+++ b/projects/hip-tests/catch/unit/threadfence/__threadfence.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_Positive_Basic_Shared") {
+TEST_CASE("Unit___threadfence_Positive_Basic_Shared", "[sync]") {
   LinearAllocGuard<int> in_dev(LinearAllocs::hipMalloc, 2 * sizeof(int));
   LinearAllocGuard<int> out_dev(LinearAllocs::hipMalloc, 2 * sizeof(int));
 
@@ -76,7 +76,7 @@ TEST_CASE("Unit___threadfence_Positive_Basic_Shared") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_Positive_Basic_Global") {
+TEST_CASE("Unit___threadfence_Positive_Basic_Global", "[sync]") {
   LinearAllocGuard<int> in_dev(LinearAllocs::hipMalloc, 2 * sizeof(int));
   LinearAllocGuard<int> out_dev(LinearAllocs::hipMalloc, 2 * sizeof(int));
 
@@ -108,7 +108,7 @@ TEST_CASE("Unit___threadfence_Positive_Basic_Global") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_Positive_Basic_Pinned") {
+TEST_CASE("Unit___threadfence_Positive_Basic_Pinned", "[sync]") {
   LinearAllocGuard<int> in_host(LinearAllocs::hipHostMalloc, 2 * sizeof(int));
   LinearAllocGuard<int> out_host(LinearAllocs::hipHostMalloc, 2 * sizeof(int));
 
@@ -136,7 +136,7 @@ TEST_CASE("Unit___threadfence_Positive_Basic_Pinned") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_Positive_Basic_Managed") {
+TEST_CASE("Unit___threadfence_Positive_Basic_Managed", "[sync]") {
   LinearAllocGuard<int> in_host(LinearAllocs::hipMallocManaged, 2 * sizeof(int));
   LinearAllocGuard<int> out_host(LinearAllocs::hipMallocManaged, 2 * sizeof(int));
 
@@ -164,7 +164,7 @@ TEST_CASE("Unit___threadfence_Positive_Basic_Managed") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_Positive_Basic_Peer", "[multigpu]") {
+TEST_CASE("Unit___threadfence_Positive_Basic_Peer", "[multigpu][sync]") {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("At least 2 devices are required");

--- a/projects/hip-tests/catch/unit/threadfence/__threadfence_block.cc
+++ b/projects/hip-tests/catch/unit/threadfence/__threadfence_block.cc
@@ -44,7 +44,7 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_block_Positive_Basic_Shared") {
+TEST_CASE("Unit___threadfence_block_Positive_Basic_Shared", "[sync]") {
   LinearAllocGuard<int> in_dev(LinearAllocs::hipMalloc, 2 * sizeof(int));
   LinearAllocGuard<int> out_dev(LinearAllocs::hipMalloc, 2 * sizeof(int));
 
@@ -76,7 +76,7 @@ TEST_CASE("Unit___threadfence_block_Positive_Basic_Shared") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_block_Positive_Basic_Global") {
+TEST_CASE("Unit___threadfence_block_Positive_Basic_Global", "[sync]") {
   LinearAllocGuard<int> in_dev(LinearAllocs::hipMalloc, 2 * sizeof(int));
   LinearAllocGuard<int> out_dev(LinearAllocs::hipMalloc, 2 * sizeof(int));
 
@@ -108,7 +108,7 @@ TEST_CASE("Unit___threadfence_block_Positive_Basic_Global") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_block_Positive_Basic_Pinned") {
+TEST_CASE("Unit___threadfence_block_Positive_Basic_Pinned", "[sync]") {
   LinearAllocGuard<int> in_host(LinearAllocs::hipHostMalloc, 2 * sizeof(int));
   LinearAllocGuard<int> out_host(LinearAllocs::hipHostMalloc, 2 * sizeof(int));
 
@@ -136,7 +136,7 @@ TEST_CASE("Unit___threadfence_block_Positive_Basic_Pinned") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_block_Positive_Basic_Managed") {
+TEST_CASE("Unit___threadfence_block_Positive_Basic_Managed", "[sync]") {
   LinearAllocGuard<int> in_host(LinearAllocs::hipMallocManaged, 2 * sizeof(int));
   LinearAllocGuard<int> out_host(LinearAllocs::hipMallocManaged, 2 * sizeof(int));
 
@@ -164,7 +164,7 @@ TEST_CASE("Unit___threadfence_block_Positive_Basic_Managed") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_block_Positive_Basic_Peer", "[multigpu]") {
+TEST_CASE("Unit___threadfence_block_Positive_Basic_Peer", "[multigpu][sync]") {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("At least 2 devices are required");

--- a/projects/hip-tests/catch/unit/threadfence/__threadfence_system.cc
+++ b/projects/hip-tests/catch/unit/threadfence/__threadfence_system.cc
@@ -60,7 +60,7 @@ __global__ void ReadKernel(int* out, int* in) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_system_Positive_Basic_Peer", "[multigpu]") {
+TEST_CASE("Unit___threadfence_system_Positive_Basic_Peer", "[multigpu][sync]") {
   const auto device_count = HipTest::getDeviceCount();
   if (device_count < 2) {
     HipTest::HIP_SKIP_TEST("At least 2 devices are required");
@@ -114,7 +114,7 @@ TEST_CASE("Unit___threadfence_system_Positive_Basic_Peer", "[multigpu]") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit___threadfence_system_Positive_Basic_Host") {
+TEST_CASE("Unit___threadfence_system_Positive_Basic_Host", "[sync]") {
   LinearAllocGuard<int> in_host(LinearAllocs::hipHostMalloc, 2 * sizeof(int));
   LinearAllocGuard<int> out_host(LinearAllocs::hipHostMalloc, 2 * sizeof(int));
 

--- a/projects/hip-tests/catch/unit/warp/hipMatchSyncAllTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipMatchSyncAllTests.cc
@@ -330,7 +330,7 @@ static void runTestMatchAll_4() {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipMatchSync_All") {
+TEST_CASE("Unit_hipMatchSync_All", "[warp]") {
   CHECK_WARP_MATCH_FUNCTIONS_SUPPORT
 
   SECTION("run test for int") {

--- a/projects/hip-tests/catch/unit/warp/hipMatchSyncAnyTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipMatchSyncAnyTests.cc
@@ -205,7 +205,7 @@ static void runTestMatchAny_3() {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipMatchSync_Any") {
+TEST_CASE("Unit_hipMatchSync_Any", "[warp]") {
   CHECK_WARP_MATCH_FUNCTIONS_SUPPORT
 
   SECTION("run test for int") {

--- a/projects/hip-tests/catch/unit/warp/hipShflSyncDownTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipShflSyncDownTests.cc
@@ -229,7 +229,7 @@ static void runTestShflDown_4() {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipShflSync_Down") {
+TEST_CASE("Unit_hipShflSync_Down", "[warp]") {
   CHECK_WARP_MATCH_FUNCTIONS_SUPPORT
 
   SECTION("run test for short") {

--- a/projects/hip-tests/catch/unit/warp/hipShflSyncTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipShflSyncTests.cc
@@ -171,7 +171,7 @@ static void runTestShfl_3() {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipShflSync") {
+TEST_CASE("Unit_hipShflSync", "[warp]") {
   CHECK_WARP_MATCH_FUNCTIONS_SUPPORT
 
   SECTION("run test for short") {

--- a/projects/hip-tests/catch/unit/warp/hipShflSyncUpTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipShflSyncUpTests.cc
@@ -211,7 +211,7 @@ static void runTestShflUp_4() {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipShflSync_Up") {
+TEST_CASE("Unit_hipShflSync_Up", "[warp]") {
   CHECK_WARP_MATCH_FUNCTIONS_SUPPORT
 
   SECTION("run test for short") {

--- a/projects/hip-tests/catch/unit/warp/hipShflSyncXorTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipShflSyncXorTests.cc
@@ -288,7 +288,7 @@ static void runTestShflXor_4() {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipShflSync_Xor") {
+TEST_CASE("Unit_hipShflSync_Xor", "[warp]") {
   CHECK_WARP_MATCH_FUNCTIONS_SUPPORT
 
   SECTION("run test for short") {

--- a/projects/hip-tests/catch/unit/warp/hipShflTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipShflTests.cc
@@ -165,7 +165,7 @@ template <typename T> static void runTest() {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipShflTests") {
+TEST_CASE("Unit_hipShflTests", "[warp]") {
   SECTION("run test for int") { runTest<int>(); }
   SECTION("run test for float") { runTest<float>(); }
   SECTION("run test for double") { runTest<double>(); }
@@ -211,7 +211,7 @@ __global__ void testShflWithUndefArgs(unsigned long total_out_strings, unsigned 
     out[lane]++;
   }
 }
-TEST_CASE("Unit_hipShflUndefArgs") {
+TEST_CASE("Unit_hipShflUndefArgs", "[warp]") {
   hipDeviceProp_t prop;
   int device;
   HIP_CHECK(hipGetDevice(&device));

--- a/projects/hip-tests/catch/unit/warp/hipShflUpDownTest.cc
+++ b/projects/hip-tests/catch/unit/warp/hipShflUpDownTest.cc
@@ -152,7 +152,7 @@ template <typename T> static void runTestShflXor() {
  * ticket SWDEV-379177
  */
 
-TEST_CASE("Unit_runTestShfl_up") {
+TEST_CASE("Unit_runTestShfl_up", "[warp]") {
   SECTION("runTestShflUp for int") { runTestShflUp<int>(); }
   SECTION("runTestShflUp for float") { runTestShflUp<float>(); }
   SECTION("runTestShflUp for double") { runTestShflUp<double>(); }
@@ -189,7 +189,7 @@ TEST_CASE("Unit_runTestShfl_up") {
  * ticket SWDEV-379177
  */
 
-TEST_CASE("Unit_runTestShfl_Down") {
+TEST_CASE("Unit_runTestShfl_Down", "[warp]") {
   SECTION("runTestShflDown for int") { runTestShflDown<int>(); }
   SECTION("runTestShflDown for float") { runTestShflDown<float>(); }
   SECTION("runTestShflDown for double") { runTestShflDown<double>(); }
@@ -226,7 +226,7 @@ TEST_CASE("Unit_runTestShfl_Down") {
  * ticket SWDEV-379177
  */
 
-TEST_CASE("Unit_runTestShfl_Xor") {
+TEST_CASE("Unit_runTestShfl_Xor", "[warp]") {
   SECTION("runTestShflXor for int") { runTestShflXor<int>(); }
   SECTION("runTestShflXor for float") { runTestShflXor<float>(); }
   SECTION("runTestShflXor for double") { runTestShflXor<double>(); }

--- a/projects/hip-tests/catch/unit/warp/hipVoteSyncTests.cc
+++ b/projects/hip-tests/catch/unit/warp/hipVoteSyncTests.cc
@@ -567,7 +567,7 @@ static void runTestBallot_3() {
  *    - HIP_VERSION >= 5.6
  */
 
-TEST_CASE("Unit_hipVoteSync_Any") {
+TEST_CASE("Unit_hipVoteSync_Any", "[warp]") {
   CHECK_WARP_MATCH_FUNCTIONS_SUPPORT
 
   runTestAny_1();
@@ -577,7 +577,7 @@ TEST_CASE("Unit_hipVoteSync_Any") {
   runTestAny_4();
 }
 
-TEST_CASE("Unit_hipVoteSync_All") {
+TEST_CASE("Unit_hipVoteSync_All", "[warp]") {
   CHECK_WARP_MATCH_FUNCTIONS_SUPPORT
 
   runTestAll_1_w64();
@@ -587,7 +587,7 @@ TEST_CASE("Unit_hipVoteSync_All") {
   runTestAll_4();
 }
 
-TEST_CASE("Unit_hipVoteSync_Ballot") {
+TEST_CASE("Unit_hipVoteSync_Ballot", "[warp]") {
   CHECK_WARP_MATCH_FUNCTIONS_SUPPORT
 
   runTestBallot_1();

--- a/projects/hip-tests/catch/unit/warp/warp_all.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_all.cc
@@ -109,7 +109,7 @@ class WarpAll : public WarpVoteTest<WarpAll, uint64_t> {
  *  - HIP_VERSION >= 5.2
  *  - Device supports warp vote
  */
-TEST_CASE("Unit_Warp_Vote_All_Positive_Basic") {
+TEST_CASE("Unit_Warp_Vote_All_Positive_Basic", "[warp]") {
   int device;
   hipDeviceProp_t device_properties;
   HIP_CHECK(hipGetDevice(&device));

--- a/projects/hip-tests/catch/unit/warp/warp_any.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_any.cc
@@ -100,7 +100,7 @@ class WarpAny : public WarpVoteTest<WarpAny, uint64_t> {
  *  - HIP_VERSION >= 5.2
  *  - Device supports warp vote
  */
-TEST_CASE("Unit_Warp_Vote_Any_Positive_Basic") {
+TEST_CASE("Unit_Warp_Vote_Any_Positive_Basic", "[warp]") {
   int device;
   hipDeviceProp_t device_properties;
   HIP_CHECK(hipGetDevice(&device));

--- a/projects/hip-tests/catch/unit/warp/warp_ballot.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_ballot.cc
@@ -99,7 +99,7 @@ class WarpBallot : public WarpVoteTest<WarpBallot, uint64_t> {
  *  - HIP_VERSION >= 5.2
  *  - Device supports warp ballot
  */
-TEST_CASE("Unit_Warp_Ballot_Positive_Basic") {
+TEST_CASE("Unit_Warp_Ballot_Positive_Basic", "[warp]") {
   int device;
   hipDeviceProp_t device_properties;
   HIP_CHECK(hipGetDevice(&device));

--- a/projects/hip-tests/catch/unit/warp/warp_reduce.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_reduce.cc
@@ -196,7 +196,7 @@ void runTestReduceForTypes(const std::tuple<T, Types...>) {
   runTestReduceForTypes<Op>(remainingTypes);
 }
 
-TEST_CASE("Unit_hipReduceRandom") {
+TEST_CASE("Unit_hipReduceRandom", "[warp]") {
   const std::tuple<int, unsigned int, long long, unsigned long long, float, half, double> allTypes;
   const std::tuple<int, unsigned int, long long, unsigned long long> integralTypes;
 


### PR DESCRIPTION
Tag compute and synchronization APIs with category tags:
- kernel (19 files) -> [kernel]
- atomics (50 files) -> [atomic]
- synchronization (5 files) -> [sync]
- syncthreads (1 file) -> [sync]
- cooperativeGrps (3 files) -> [cooperativeLaunch]
- warp (11 files) -> [warp]

Total: 89 files, ~260 test cases tagged

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
