### PR TITLE
[SWDEV-568546] Fix mVF XGMI link status reporting links as down

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -39,6 +39,98 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - Fix uses direct `.decode()` on c_char arrays, matching the proven pattern in `amdsmi_get_soc_pstate()`.
   - Affected command: `amd-smi static --xgmi-plpd`
 
+### Changed
+
+- N/A
+
+### Removed
+
+- N/A
+
+### Optimized
+
+- N/A
+
+### Resolved Issues
+
+- - **Fixed an issue on MI3x ASICs in mVF configurations where `amd-smi xgmi --source-status` and `amd-smi xgmi --link-status` incorrectly reported links as down**.  
+  - Updated driver logic to detect when `amdsmi_get_gpu_xgmi_link_status()` should return `AMDSMI_STATUS_NOT_SUPPORTED`. In mVF configurations, links are connected over XGMI and active, but security restrictions prevent the driver from exposing link status. In these cases we now return `AMDSMI_STATUS_NOT_SUPPORTED` instead of reporting the links as down.
+  - Example outputs:
+
+    ```console
+    $ amd-smi xgmi --source-status
+
+    GPU LINK PORT STATUS:
+           bdf           port_num
+    GPU0   0000:05:00.0  N/A  N/A  N/A  N/A  N/A  N/A  N/A  N/A
+    GPU1   0000:15:00.0  N/A  N/A  N/A  N/A  N/A  N/A  N/A  N/A
+    GPU2   0000:65:00.0  N/A  N/A  N/A  N/A  N/A  N/A  N/A  N/A
+    GPU3   0000:75:00.0  N/A  N/A  N/A  N/A  N/A  N/A  N/A  N/A
+    GPU4   0000:85:00.0  N/A  N/A  N/A  N/A  N/A  N/A  N/A  N/A
+    GPU5   0000:95:00.0  N/A  N/A  N/A  N/A  N/A  N/A  N/A  N/A
+    GPU6   0000:e5:00.0  N/A  N/A  N/A  N/A  N/A  N/A  N/A  N/A
+    GPU7   0000:f5:00.0  N/A  N/A  N/A  N/A  N/A  N/A  N/A  N/A
+    ...  
+    ```
+
+    ```console
+    $ amd-smi xgmi --link-status
+
+    XGMI LINK STATUS:
+           bdf           GPU0          GPU1          GPU2          GPU3          GPU4          GPU5          GPU6          GPU7
+    GPU0   0000:05:00.0  SELF          N/A           N/A           N/A           N/A           N/A           N/A           N/A
+    GPU1   0000:15:00.0  N/A           SELF          N/A           N/A           N/A           N/A           N/A           N/A
+    GPU2   0000:65:00.0  N/A           N/A           SELF          N/A           N/A           N/A           N/A           N/A
+    GPU3   0000:75:00.0  N/A           N/A           N/A           SELF          N/A           N/A           N/A           N/A
+    GPU4   0000:85:00.0  N/A           N/A           N/A           N/A           SELF          N/A           N/A           N/A
+    GPU5   0000:95:00.0  N/A           N/A           N/A           N/A           N/A           SELF          N/A           N/A
+    GPU6   0000:e5:00.0  N/A           N/A           N/A           N/A           N/A           N/A           SELF          N/A
+    GPU7   0000:f5:00.0  N/A           N/A           N/A           N/A           N/A           N/A           N/A           SELF
+    ...
+    ```
+
+- **Fixed `amd-smi xgmi --metric` on devices without XGMI links reporting `bit_rate` and `max_bandwidth` with their maximum values instead of `N/A`**.  
+  - Updated the logic to report `N/A` for `bit_rate` and `max_bandwidth` when no XGMI links are present.
+  - Below shows a before and after of the fix (using 2 Navi ASICs without XGMI links as an example).
+
+    - Before fix:
+    ```console
+    $ amd-smi xgmi --metric
+
+    LINK METRIC TABLE:
+           bdf           bit_rate  max_bandwidth  link_type  GPU0         GPU1
+    GPU0   0000:08:00.0  65535 Gb/s4294967295 Gb/sN/A
+     Read                                                    N/A          N/A
+     Write                                                   N/A          N/A
+    GPU1   0000:44:00.0  65535 Gb/s4294967295 Gb/sN/A
+     Read                                                    N/A          N/A
+     Write                                                   N/A          N/A
+    ...
+    ```
+    - After fix:
+
+    ```console
+    $ amd-smi xgmi --metric
+
+    LINK METRIC TABLE:
+           bdf           bit_rate  max_bandwidth  link_type  GPU0         GPU1
+    GPU0   0000:08:00.0  N/A       N/A             N/A
+     Read                                                    N/A          N/A
+     Write                                                   N/A          N/A
+    GPU1   0000:44:00.0  N/A       N/A             N/A
+     Read                                                    N/A          N/A
+     Write                                                   N/A          N/A
+    ...
+    ```
+
+### Upcoming Changes
+
+- N/A
+
+### Known Issues
+
+- N/A
+
 ## amd_smi_lib for ROCm 7.11.0
 
 ### Added

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -7982,8 +7982,8 @@ class AMDSMICommands():
             self.helpers.check_required_groups(check_render=True, check_video=False)
             self.group_check_printed = True
 
-        (total_socket_count, total_processor_count, num_gpu_sockets, num_cpus_sockets) = self.helpers._get_socket_and_processor_info()
-        logging.debug(f"total sockets: {total_socket_count}, total processors: {total_processor_count}, gpu sockets: {num_gpu_sockets}, cpu sockets: {num_cpus_sockets}")
+        (total_socket_count, num_gpu_sockets, num_cpu_sockets) = self.helpers._get_socket_counts()
+        logging.debug(f"total sockets: {total_socket_count}, gpu sockets: {num_gpu_sockets}, cpu sockets: {num_cpu_sockets}")
 
         # Populate the possible gpus and their bdfs
         xgmi_values = []
@@ -8232,7 +8232,7 @@ class AMDSMICommands():
                 # First column: GPU# + tab + bdf, then status for each dest bdf
                 if self.logger.is_human_readable_format():
                     gpu_id_str = f"GPU{src_gpu_id}"
-                    row_dict = {"": f"{self.helpers.fmt(gpu_id_str, 7, 'left')}{self.helpers.fmt(src_gpu_bdf, 14, 'left')}"}
+                    row_dict = {"": f"{gpu_id_str.ljust(7)}{src_gpu_bdf.ljust(14)}"}
                 else:
                     row_dict = {"gpu": f"GPU{src_gpu_id}", "bdf": src_gpu_bdf}
                 json_status = []

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -8255,8 +8255,9 @@ class AMDSMICommands():
                         statuses = []
                         for link_idx in link_indexes:
                             if link_idx < len(src_link_status_map[src_gpu_bdf]):
-                                if str(src_link_status_map[src_gpu_bdf][link_idx]) != "N/A":
-                                    statuses.append(str(src_link_status_map[src_gpu_bdf][link_idx]))
+                                status_str = str(src_link_status_map[src_gpu_bdf][link_idx])
+                                if status_str != "N/A":
+                                    statuses.append(status_str)
 
                         # Join multiple statuses with "/"
                         if statuses:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -7937,7 +7937,6 @@ class AMDSMICommands():
             # Print the output for single gpu, which currently does not have multiple xcp information
             self.logger.print_output(multiple_device_enabled=False, watching_output=watching_output, tabular=True, dual_csv_output=dual_csv_output)
 
-
     def xgmi(self, args, multiple_devices=False, gpu=None, metric=None, xgmi_source_status=None, xgmi_link_status=None):
         """ Get topology information for target gpus
             params:
@@ -7982,6 +7981,9 @@ class AMDSMICommands():
         if not self.group_check_printed:
             self.helpers.check_required_groups(check_render=True, check_video=False)
             self.group_check_printed = True
+
+        (total_socket_count, total_processor_count, num_gpu_sockets, num_cpus_sockets) = self.helpers._get_socket_and_processor_info()
+        logging.debug(f"total sockets: {total_socket_count}, total processors: {total_processor_count}, gpu sockets: {num_gpu_sockets}, cpu sockets: {num_cpus_sockets}")
 
         # Populate the possible gpus and their bdfs
         xgmi_values = []
@@ -8042,17 +8044,8 @@ class AMDSMICommands():
 
                 # Populate bitrate and max_bandwidth with units logic
                 bw_unit = 'Gb/s'
-                if self.logger.is_human_readable_format():
-                    xgmi_dict['link_metrics']['bit_rate'] = f"{bitrate} {bw_unit}"
-                    xgmi_dict['link_metrics']['max_bandwidth'] = f"{max_bandwidth} {bw_unit}"
-                elif self.logger.is_json_format():
-                    xgmi_dict['link_metrics']['bit_rate'] = {"value" : bitrate,
-                                                             "unit" : bw_unit}
-                    xgmi_dict['link_metrics']['max_bandwidth'] = {"value" : max_bandwidth,
-                                                                  "unit" : bw_unit}
-                elif self.logger.is_csv_format():
-                    xgmi_dict['link_metrics']['bit_rate'] = bitrate
-                    xgmi_dict['link_metrics']['max_bandwidth'] = max_bandwidth
+                xgmi_dict['link_metrics']['bit_rate'] = self.helpers.unit_format(self.logger, bitrate, bw_unit)
+                xgmi_dict['link_metrics']['max_bandwidth'] = self.helpers.unit_format(self.logger, max_bandwidth, bw_unit)
 
                 # Populate link metrics
                 for dest_gpu in args.gpu:
@@ -8084,11 +8077,9 @@ class AMDSMICommands():
                         if self.logger.is_human_readable_format():
                             dest_link_dict['read'] = self.helpers.convert_bytes_to_readable(dest_link_dict['read'] * 1024, True)
                             dest_link_dict['write'] = self.helpers.convert_bytes_to_readable(dest_link_dict['write'] * 1024, True)
-                        elif self.logger.is_json_format():
-                            dest_link_dict['read'] = {"value" : dest_link_dict['read'],
-                                                    "unit" : data_unit}
-                            dest_link_dict['write'] = {"value" : dest_link_dict['write'],
-                                                    "unit" : data_unit}
+                        else:
+                            dest_link_dict['read'] = self.helpers.unit_format(self.logger, dest_link_dict['read'], data_unit)
+                            dest_link_dict['write'] = self.helpers.unit_format(self.logger, dest_link_dict['write'], data_unit)
 
                         try:
                             link_type = amdsmi_interface.amdsmi_topo_get_link_type(src_gpu, dest_gpu)['type']
@@ -8184,17 +8175,20 @@ class AMDSMICommands():
                                        "link_status": "N/A"}
                 try:
                     link_status = amdsmi_interface.amdsmi_get_gpu_xgmi_link_status(src_gpu)
+                    logging.debug(f"GPU(src): {src_gpu_id}, BDF(src): {src_gpu_bdf}, link_status: {link_status}")
                     tabular_output_dict['link_status'] = link_status['status']
-                    if self.logger.is_human_readable_format():
-                        del tabular_output_dict['gpu']
-                    else:
-                        del tabular_output_dict['gpu#']
-                    tabular_output.append(tabular_output_dict)
-                    if self.logger.is_json_format():
-                        self.logger.store_xgmi_source_status_json_output.append(tabular_output_dict)
                 except amdsmi_exception.AmdSmiLibraryException as e:
-                    xgmi_dict['link_metrics']['link_status']={"status": "failed"}
                     logging.debug("Failed to get XGMI link status for GPU %s | %s", src_gpu_id, e.get_error_info())
+                    # "N/A" * number of gpu sockets, since we only display in for number of total sockets
+                    # These can be CPU or GPU links, so we use total_socket_count
+                    tabular_output_dict['link_status'] = ["N/A"] * total_socket_count
+                if self.logger.is_human_readable_format():
+                    del tabular_output_dict['gpu']
+                else:
+                    del tabular_output_dict['gpu#']
+                tabular_output.append(tabular_output_dict)
+                if self.logger.is_json_format():
+                    self.logger.store_xgmi_source_status_json_output.append(tabular_output_dict)
 
                 #populate link status data for output
                 if self.logger.is_human_readable_format():
@@ -8210,7 +8204,7 @@ class AMDSMICommands():
 
         if args.link_status:
             # XGMI LINK STATUS for src_gpu to dest_gpu
-            header = ["       ".ljust(8), "bdf".ljust(15)] + [f"GPU{d['gpu']}".ljust(14) for d in xgmi_values]
+            header = ["       ".ljust(7), "bdf".ljust(14)] + [f"GPU{d['gpu']}".ljust(14) for d in xgmi_values]
             self.logger.table_header = "".join(header)
             self.logger.table_title = "\nXGMI LINK STATUS"
 
@@ -8223,7 +8217,8 @@ class AMDSMICommands():
                     link_status = amdsmi_interface.amdsmi_get_gpu_xgmi_link_status(src_gpu)
                     src_link_status_map[src_gpu_bdf] = link_status['status']
                 except amdsmi_exception.AmdSmiLibraryException:
-                    src_link_status_map[src_gpu_bdf] = ["N/A"] * amdsmi_interface.AMDSMI_MAX_NUM_XGMI_LINKS
+                    # "N/A" * number of gpu sockets, since we only display in for number of gpu sockets
+                    src_link_status_map[src_gpu_bdf] = ["N/A"] * num_gpu_sockets
 
             tabular_output = []
             for src_xgmi_dict in xgmi_values:
@@ -8236,7 +8231,8 @@ class AMDSMICommands():
                     xgmi_metrics_info = {"links": []}
                 # First column: GPU# + tab + bdf, then status for each dest bdf
                 if self.logger.is_human_readable_format():
-                    row_dict = {"": f"GPU{src_gpu_id}\t{src_gpu_bdf}".ljust(20)}
+                    gpu_id_str = f"GPU{src_gpu_id}"
+                    row_dict = {"": f"{self.helpers.fmt(gpu_id_str, 7, 'left')}{self.helpers.fmt(src_gpu_bdf, 14, 'left')}"}
                 else:
                     row_dict = {"gpu": f"GPU{src_gpu_id}", "bdf": src_gpu_bdf}
                 json_status = []
@@ -8259,7 +8255,8 @@ class AMDSMICommands():
                         statuses = []
                         for link_idx in link_indexes:
                             if link_idx < len(src_link_status_map[src_gpu_bdf]):
-                                statuses.append(str(src_link_status_map[src_gpu_bdf][link_idx]))
+                                if str(src_link_status_map[src_gpu_bdf][link_idx]) != "N/A":
+                                    statuses.append(str(src_link_status_map[src_gpu_bdf][link_idx]))
 
                         # Join multiple statuses with "/"
                         if statuses:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -1647,23 +1647,6 @@ class AMDSMIHelpers():
                     return f"{value}".rstrip()
             return f"{value}"
 
-    def unit_unformat(self, logger, formatted_value):
-        """
-        This function will unformat output with unit based on the logger output format
-        params:
-            logger (AMDSMILogger) - Logger to print out output
-            formatted_value - the value to be unformatted
-        return:
-            str or dict : unformatted output
-        """
-        if logger.is_json_format():
-            if isinstance(formatted_value, dict):
-                return formatted_value['value']
-            return formatted_value
-        if logger.is_human_readable_format():
-            return formatted_value.split()[0]
-        return formatted_value
-
 
     class SI_Unit(float, Enum):
         GIGA = 1000000000  # 10^9
@@ -2525,6 +2508,85 @@ class AMDSMIHelpers():
                         continue
             ret = {f"xcp_{i}": violation_status[key][i] for i in range(num_partition)}
         return ret
+
+    @lru_cache(maxsize=1)
+    def _get_socket_and_processor_info(self):
+        """
+        Discover and cache basic topology information for sockets and GPU processors.
+
+        This helper queries AMDSMI for all socket and processor handles and derives:
+            - total_socket_count: total number of sockets (CPU + GPU) reported
+            - total_processor_count: total number of GPU processors reported
+            - num_gpu_sockets: number of GPU sockets (identified by BDF‐style strings, e.g. '0000:08:00')
+            - num_cpus_sockets: number of CPU sockets (non‑BDF style, e.g. '0', '1', ...)
+
+        The result is cached per AMDSMIHelpers instance (LRU maxsize=1). If system
+        topology changes (e.g. GPUs added/removed), callers must explicitly clear
+        the cache via `self._get_socket_and_processor_info.cache_clear()`.
+
+        Returns:
+            tuple[int, int, int, int]:
+                (total_socket_count,
+                 total_processor_count,
+                 num_gpu_sockets,
+                 num_cpus_sockets)
+        """
+        total_processor_count = 0
+        total_socket_count = 0
+        num_gpu_sockets = 0
+        num_cpus_sockets = 0
+
+        try:
+            sockets = amdsmi_interface.amdsmi_get_socket_handles()
+            for socket in sockets:
+                total_socket_count += 1
+                try:
+                    socket_info = amdsmi_interface.amdsmi_get_socket_info(socket)
+                    # Check if it contains this format: 0000:08:00 -> GPU socket
+                    # CPU socket: 0, 1, etc. (does not contain ':')
+                    if str(socket_info).count(":") == 2:
+                        num_gpu_sockets += 1
+                    else:
+                        num_cpus_sockets += 1
+                    logging.debug(f"Socket info: {socket_info}")
+                except amdsmi_exception.AmdSmiLibraryException as e:
+                    logging.debug(f"Failed to get socket info: {e}")
+        except amdsmi_exception.AmdSmiLibraryException as e:
+            logging.debug(f"Failed to get number of GPU sockets: {e}")
+
+        try:
+            processors = amdsmi_interface.amdsmi_get_processor_handles()
+            for _ in processors:
+                total_processor_count += 1
+
+        except amdsmi_exception.AmdSmiLibraryException as e:
+            logging.debug(f"Failed to get number of GPU processors: {e}")
+        out = (total_socket_count, total_processor_count, num_gpu_sockets, num_cpus_sockets)
+        return out
+
+    @staticmethod
+    def fmt(val, width, align="left"):
+        """
+        Format a value as a fixed‑width string with configurable alignment.
+
+        Args:
+            val: Any value to be converted to string and formatted.
+            width (int): Field width to pad or truncate to.
+            align (str, optional): Text alignment within the field:
+                - "left"   -> left‑justify (default, uses str.ljust)
+                - "right"  -> right‑justify (uses str.rjust)
+                - "center" -> center within the field (uses str.center)
+
+        Returns:
+            str: The formatted string representation of `val` with the requested
+                 width and alignment applied.
+        """
+        s = str(val)
+        if align == "left":
+            return s.ljust(width)
+        if align == "center":
+            return s.center(width)
+        return s.rjust(width)
 
     @staticmethod
     def average_flattened_ints(data, context="data"):

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -2510,83 +2510,44 @@ class AMDSMIHelpers():
         return ret
 
     @lru_cache(maxsize=1)
-    def _get_socket_and_processor_info(self):
-        """
-        Discover and cache basic topology information for sockets and GPU processors.
+    def _get_socket_counts(self):
+        """Discover and cache basic topology counts for sockets.
 
-        This helper queries AMDSMI for all socket and processor handles and derives:
-            - total_socket_count: total number of sockets (CPU + GPU) reported
-            - total_processor_count: total number of GPU processors reported
-            - num_gpu_sockets: number of GPU sockets (identified by BDF‐style strings, e.g. '0000:08:00')
-            - num_cpus_sockets: number of CPU sockets (non‑BDF style, e.g. '0', '1', ...)
+        This helper queries AMDSMI for all socket handles and categorizes them:
+            - total_sockets: total number of sockets (CPU + GPU) reported
+            - gpu_sockets: number of GPU sockets (identified by BDF-style strings, e.g. '0000:08:00')
+            - cpu_sockets: number of CPU sockets (non-BDF style, e.g. '0', '1', ...)
 
-        The result is cached per AMDSMIHelpers instance (LRU maxsize=1). If system
-        topology changes (e.g. GPUs added/removed), callers must explicitly clear
-        the cache via `self._get_socket_and_processor_info.cache_clear()`.
+        The result is cached (LRU maxsize=1). If system topology changes
+        (e.g. GPUs added/removed), callers must explicitly clear the cache
+        via `self._get_socket_counts.cache_clear()`.
 
         Returns:
-            tuple[int, int, int, int]:
-                (total_socket_count,
-                 total_processor_count,
-                 num_gpu_sockets,
-                 num_cpus_sockets)
+            tuple[int, int, int]:
+                (total_sockets, gpu_sockets, cpu_sockets)
         """
-        total_processor_count = 0
-        total_socket_count = 0
-        num_gpu_sockets = 0
-        num_cpus_sockets = 0
+        gpu_sockets = 0
+        cpu_sockets = 0
 
         try:
             sockets = amdsmi_interface.amdsmi_get_socket_handles()
             for socket in sockets:
-                total_socket_count += 1
                 try:
-                    socket_info = amdsmi_interface.amdsmi_get_socket_info(socket)
-                    # Check if it contains this format: 0000:08:00 -> GPU socket
+                    info = str(amdsmi_interface.amdsmi_get_socket_info(socket))
+                    logging.debug(f"Socket info: {info}")
+                    # Check if it contains BDF format: 0000:08:00 -> GPU socket
                     # CPU socket: 0, 1, etc. (does not contain ':')
-                    if str(socket_info).count(":") == 2:
-                        num_gpu_sockets += 1
+                    if info.count(":") == 2:
+                        gpu_sockets += 1
                     else:
-                        num_cpus_sockets += 1
-                    logging.debug(f"Socket info: {socket_info}")
+                        cpu_sockets += 1
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     logging.debug(f"Failed to get socket info: {e}")
         except amdsmi_exception.AmdSmiLibraryException as e:
-            logging.debug(f"Failed to get number of GPU sockets: {e}")
+            logging.debug(f"Failed to get socket handles: {e}")
+            sockets = []
 
-        try:
-            processors = amdsmi_interface.amdsmi_get_processor_handles()
-            for _ in processors:
-                total_processor_count += 1
-
-        except amdsmi_exception.AmdSmiLibraryException as e:
-            logging.debug(f"Failed to get number of GPU processors: {e}")
-        out = (total_socket_count, total_processor_count, num_gpu_sockets, num_cpus_sockets)
-        return out
-
-    @staticmethod
-    def fmt(val, width, align="left"):
-        """
-        Format a value as a fixed‑width string with configurable alignment.
-
-        Args:
-            val: Any value to be converted to string and formatted.
-            width (int): Field width to pad or truncate to.
-            align (str, optional): Text alignment within the field:
-                - "left"   -> left‑justify (default, uses str.ljust)
-                - "right"  -> right‑justify (uses str.rjust)
-                - "center" -> center within the field (uses str.center)
-
-        Returns:
-            str: The formatted string representation of `val` with the requested
-                 width and alignment applied.
-        """
-        s = str(val)
-        if align == "left":
-            return s.ljust(width)
-        if align == "center":
-            return s.center(width)
-        return s.rjust(width)
+        return (len(sockets), gpu_sockets, cpu_sockets)
 
     @staticmethod
     def average_flattened_ints(data, context="data"):

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -232,7 +232,7 @@ class AMDSMILogger():
                 table_values += string_value.ljust(11)
             elif key == "link_status":
                 for i in value:
-                    table_values += str(i).ljust(3)
+                    table_values += str(i).ljust(5)
             elif key == "RW":
                 table_values += string_value.ljust(57)
             elif key in ('pviol', 'tviol'):

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -4043,8 +4043,8 @@ def amdsmi_get_link_metrics(processor_handle: processor_handle_t):
         link = link_metrics.links[i]
         links.append({
             "bdf": _format_bdf(link.bdf),
-            "bit_rate": link.bit_rate,
-            "max_bandwidth": link.max_bandwidth,
+            "bit_rate": _validate_if_max_uint(link.bit_rate, MaxUIntegerTypes.UINT32_T),
+            "max_bandwidth": _validate_if_max_uint(link.max_bandwidth, MaxUIntegerTypes.UINT32_T),
             "link_type": link.link_type,
             "read": link.read,
             "write": link.write,

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -3268,8 +3268,7 @@ def amdsmi_get_gpu_total_ecc_count(
     }
 
 def amdsmi_get_gpu_cper_entries(
-    device_handle: amdsmi_wrapper.amdsmi_processor_handle | Path,
-    # processor_handle: Union[amdsmi_wrapper.amdsmi_processor_handle, str],
+    device_handle: Union[amdsmi_wrapper.amdsmi_processor_handle, Path],
     severity_mask: int,
     buffer_size: int = 4 * 1048576,
     cursor: int = 0

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -2664,7 +2664,10 @@ amdsmi_get_gpu_xgmi_link_status(amdsmi_processor_handle processor_handle,
     }
 
     uint32_t socket_count = 0;
-    amdsmi_get_socket_handles(&socket_count, nullptr);
+    status = amdsmi_get_socket_handles(&socket_count, nullptr);
+    if (status != AMDSMI_STATUS_SUCCESS) {
+        return status;
+    }
     // Total number of XGMI links cannot exceed AMDSMI_MAX_NUM_XGMI_LINKS
     link_status->total_links = socket_count <= AMDSMI_MAX_NUM_XGMI_LINKS ?
                                 socket_count : AMDSMI_MAX_NUM_XGMI_LINKS;

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -2663,13 +2663,18 @@ amdsmi_get_gpu_xgmi_link_status(amdsmi_processor_handle processor_handle,
         return status;
     }
 
-    uint32_t dev_num = 0;
-    rsmi_num_monitor_devices(&dev_num);
-    link_status->total_links = AMDSMI_MAX_NUM_XGMI_LINKS;
+    uint32_t socket_count = 0;
+    amdsmi_get_socket_handles(&socket_count, nullptr);
+    // Total number of XGMI links cannot exceed AMDSMI_MAX_NUM_XGMI_LINKS
+    link_status->total_links = socket_count <= AMDSMI_MAX_NUM_XGMI_LINKS ?
+                                socket_count : AMDSMI_MAX_NUM_XGMI_LINKS;
     // get the status values from the metric info
+    // if all links are disabled, return AMDSMI_STATUS_NOT_SUPPORTED
+    uint32_t disabled_link_count = 0;
     for (unsigned int i = 0; i < link_status->total_links; i++) {
         if (metric_info.xgmi_link_status[i] == std::numeric_limits<uint16_t>::max()) {
             link_status->status[i] = AMDSMI_XGMI_LINK_DISABLE;
+            disabled_link_count++;
         } else if (metric_info.xgmi_link_status[i] == 0) {
             link_status->status[i] = AMDSMI_XGMI_LINK_DOWN;
         } else if (metric_info.xgmi_link_status[i] == 1) {
@@ -2677,6 +2682,9 @@ amdsmi_get_gpu_xgmi_link_status(amdsmi_processor_handle processor_handle,
         } else {
             return AMDSMI_STATUS_UNEXPECTED_DATA;
         }
+    }
+    if (disabled_link_count == link_status->total_links) {
+        return AMDSMI_STATUS_NOT_SUPPORTED;
     }
     return AMDSMI_STATUS_SUCCESS;
 }
@@ -3031,6 +3039,8 @@ amdsmi_status_t amdsmi_get_link_metrics(amdsmi_processor_handle processor_handle
     amdsmi_gpu_metrics_t metric_info = {};
     for (unsigned int i = 0; i < AMDSMI_MAX_NUM_XGMI_LINKS; ++i) {
         link_metrics->links[i].max_bandwidth = std::numeric_limits<uint32_t>::max();
+        link_metrics->links[i].bit_rate = std::numeric_limits<uint32_t>::max();
+        link_metrics->links[i].bdf = amdsmi_bdf_t{};
     }
 
     amdsmi_status_t status =  amdsmi_get_gpu_metrics_info(
@@ -3086,7 +3096,9 @@ amdsmi_status_t amdsmi_get_link_metrics(amdsmi_processor_handle processor_handle
         link_metrics->links[i].read = metric_info.xgmi_read_data_acc[i];
         link_metrics->links[i].write = metric_info.xgmi_write_data_acc[i];
         link_metrics->links[i].link_type = AMDSMI_LINK_TYPE_XGMI;
-        link_metrics->links[i].bit_rate = metric_info.xgmi_link_speed;
+        if (metric_info.xgmi_link_speed != std::numeric_limits<uint16_t>::max()) {
+            link_metrics->links[i].bit_rate = metric_info.xgmi_link_speed;
+        }
         if ((metric_info.xgmi_link_speed != std::numeric_limits<uint16_t>::max()) &&
             (metric_info.xgmi_link_width != std::numeric_limits<uint16_t>::max()))
             link_metrics->links[i].max_bandwidth = metric_info.xgmi_link_speed * metric_info.xgmi_link_width;


### PR DESCRIPTION
Changes:
  - `amdsmi_get_gpu_xgmi_link_status()` now reports
AMDSMI_STATUS_NOT_SUPPORTED when all links show down.
  - Improved `amdsmi_get_link_metrics()` to provide `MaxUint32`
  for unsupported XGMI bit_rate & max_bandwidth fields.
  - Updated `amd-smi xgmi --source-status` / `--link-status`
  handling to treat fully disabled links as
  `AMDSMI_STATUS_NOT_SUPPORTED` and display N/A consistently.
  - Provided documentation for all updates

Signed-off-by: Charis Poag <Charis.Poag@amd.com>

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
