### PR TITLE
rocr: Use shared_ptr to manage static allocd objs.

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -369,13 +369,16 @@ hsa_status_t KfdDriver::FreeMemory(void *mem, size_t size) {
   return FreeKfdMemory(mem, size) ? HSA_STATUS_SUCCESS : HSA_STATUS_ERROR;
 }
 
-hsa_status_t KfdDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
-                                    HSA_QUEUE_PRIORITY priority, uint32_t sdma_engine_id,
-                                    void* queue_addr, uint64_t queue_size_bytes, HsaEvent* event,
+hsa_status_t
+KfdDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type,
+            uint32_t queue_pct, HSA_QUEUE_PRIORITY priority,
+            uint32_t sdma_engine_id, void* queue_addr,
+            uint64_t queue_size_bytes, std::shared_ptr<HsaEvent> event,
                                     HsaQueueResource& queue_resource) const {
-  if (HSAKMT_CALL(hsaKmtCreateQueueExt(node_id, type, queue_pct, priority, sdma_engine_id,
-                                       queue_addr, queue_size_bytes, event, &queue_resource)) !=
-      HSAKMT_STATUS_SUCCESS) {
+  if (HSAKMT_CALL(hsaKmtCreateQueueExt(node_id, type, queue_pct, priority,
+                    sdma_engine_id, queue_addr, queue_size_bytes,
+                                        event.get(), &queue_resource)) !=
+                                                      HSAKMT_STATUS_SUCCESS) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
   return HSA_STATUS_SUCCESS;
@@ -388,11 +391,13 @@ hsa_status_t KfdDriver::DestroyQueue(HSA_QUEUEID queue_id) const {
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t KfdDriver::UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_pct,
-                                    HSA_QUEUE_PRIORITY priority, void* queue_addr,
-                                    uint64_t queue_size, HsaEvent* event) const {
+hsa_status_t
+KfdDriver::UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_pct,
+                       HSA_QUEUE_PRIORITY priority, void* queue_addr,
+                       uint64_t queue_size,
+                                      std::shared_ptr<HsaEvent> event) const {
   if (HSAKMT_CALL(hsaKmtUpdateQueue(queue_id, queue_pct, priority, queue_addr, queue_size,
-                                    event)) != HSAKMT_STATUS_SUCCESS) {
+                                    event.get())) != HSAKMT_STATUS_SUCCESS) {
     return HSA_STATUS_ERROR;
   }
   return HSA_STATUS_SUCCESS;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
@@ -414,12 +414,14 @@ hsa_status_t KfdVirtioDriver::MakeMemoryUnresident(const void* mem) const {
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t KfdVirtioDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
-                                          HSA_QUEUE_PRIORITY priority, uint32_t sdma_engine_id,
-                                          void* queue_addr, uint64_t queue_size_bytes,
-                                          HsaEvent* event, HsaQueueResource& queue_resource) const {
+hsa_status_t
+KfdVirtioDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type,
+                  uint32_t queue_pct, HSA_QUEUE_PRIORITY priority,
+                  uint32_t sdma_engine_id, void* queue_addr,
+                  uint64_t queue_size_bytes, std::shared_ptr<HsaEvent> event,
+                                      HsaQueueResource& queue_resource) const {
   if (vhsaKmtCreateQueueExt(node_id, type, queue_pct, priority, sdma_engine_id, queue_addr,
-                            queue_size_bytes, event, &queue_resource) != HSAKMT_STATUS_SUCCESS)
+                            queue_size_bytes, event.get, &queue_resource) != HSAKMT_STATUS_SUCCESS)
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
 
   return HSA_STATUS_SUCCESS;
@@ -431,9 +433,11 @@ hsa_status_t KfdVirtioDriver::DestroyQueue(HSA_QUEUEID queue_id) const {
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t KfdVirtioDriver::UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_percentage,
-                                          HSA_QUEUE_PRIORITY priority, void* queue_mem,
-                                          uint64_t queue_size, HsaEvent* event) const {
+hsa_status_t
+KfdVirtioDriver::UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_percentage,
+                             HSA_QUEUE_PRIORITY priority, void* queue_mem,
+                             uint64_t queue_size,
+                                      std::shared_ptr<HsaEvent> event) const {
   return HSA_STATUS_ERROR;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -388,9 +388,11 @@ hsa_status_t XdnaDriver::FreeMemory(void *mem, size_t size) {
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
-                                     HSA_QUEUE_PRIORITY priority, uint32_t sdma_engine_id,
-                                     void* queue_addr, uint64_t queue_size_bytes, HsaEvent* event,
+hsa_status_t
+XdnaDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type,
+              uint32_t queue_pct, HSA_QUEUE_PRIORITY priority,
+              uint32_t sdma_engine_id, void* queue_addr,
+              uint64_t queue_size_bytes, std::shared_ptr<HsaEvent> event,
                                      HsaQueueResource& queue_resource) const {
   queue_resource.QueueId = AMDXDNA_INVALID_CTX_HANDLE;
   return HSA_STATUS_SUCCESS;
@@ -412,9 +414,11 @@ hsa_status_t XdnaDriver::DestroyQueue(HSA_QUEUEID queue_id) const {
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_pct,
-                                     HSA_QUEUE_PRIORITY priority, void* queue_addr,
-                                     uint64_t queue_size, HsaEvent* event) const {
+hsa_status_t
+XdnaDriver::UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_pct,
+                        HSA_QUEUE_PRIORITY priority, void* queue_addr,
+                        uint64_t queue_size,
+                                  std::shared_ptr<HsaEvent> event) const {
   // AIE doesn't support queue updates.
   return HSA_STATUS_ERROR_INVALID_QUEUE;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -332,25 +332,25 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   std::vector<uint32_t> cu_mask_;
 
   // Shared event used for queue errors
-  static __forceinline HsaEvent*& queue_event() {
-    static HsaEvent* queue_event_ = nullptr;
+  static __forceinline std::shared_ptr<HsaEvent> queue_event() {
+    static std::shared_ptr<HsaEvent> queue_event_;
     return queue_event_;
   }
   // Queue count - used to ref count queue_event_
   static __forceinline std::atomic<uint32_t>& queue_count() {
-    // This allocation is meant to last until the last thread has exited.
-    // It is intentionally not freed.
-    static std::atomic<uint32_t>* queue_count_ = new std::atomic<uint32_t>(0);
+    // Use shared_ptr to avoid static deallocation fiasco
+    static std::shared_ptr<std::atomic<uint32_t>> queue_count_ =
+                                std::make_shared<std::atomic<uint32_t>>(0);
     return *queue_count_;
   }
 
   // Mutex for queue_event_ manipulation
-KernelMutex& queue_lock() {
-  // This allocation is meant to last until the last thread has exited.
-  // It is intentionally not freed.
-  static KernelMutex* queue_lock_ = new KernelMutex();
-  return *queue_lock_;
-}
+  KernelMutex& queue_lock() {
+    // Use shared_ptr to avoid static deallocation fiasco
+    static std::shared_ptr<KernelMutex> queue_lock_ =
+                                            std::make_shared<KernelMutex>();
+    return *queue_lock_;
+  }
 
   static __forceinline int& rtti_id() {
     static int rtti_id_ = 0;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -96,12 +96,16 @@ public:
                               void **mem, size_t size,
                               uint32_t node_id) override;
   hsa_status_t FreeMemory(void *mem, size_t size) override;
-  hsa_status_t CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
-                           HSA_QUEUE_PRIORITY priority, uint32_t sdma_engine_id, void* queue_addr,
-                           uint64_t queue_size_bytes, HsaEvent* event,
-                           HsaQueueResource& queue_resource) const override;
-  hsa_status_t UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_pct, HSA_QUEUE_PRIORITY priority,
-                           void* queue_addr, uint64_t queue_size, HsaEvent* event) const override;
+  hsa_status_t CreateQueue(
+                    uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
+                    HSA_QUEUE_PRIORITY priority, uint32_t sdma_engine_id,
+                    void* queue_addr, uint64_t queue_size_bytes,
+                    std::shared_ptr<HsaEvent> event,
+                              HsaQueueResource& queue_resource) const override;
+  hsa_status_t UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_pct,
+                  HSA_QUEUE_PRIORITY priority, void* queue_addr,
+                  uint64_t queue_size, std::shared_ptr<HsaEvent> event)
+                                                                const override;
   hsa_status_t DestroyQueue(HSA_QUEUEID queue_id) const override;
   hsa_status_t SetQueueCUMask(HSA_QUEUEID queue_id, uint32_t cu_mask_count,
                               uint32_t* queue_cu_mask) const override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_virtio_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_virtio_driver.h
@@ -89,14 +89,16 @@ class KfdVirtioDriver final : public core::Driver {
                                   const HsaMemMapFlags* mem_flags, uint32_t num_nodes,
                                   const uint32_t* nodes) const override;
   hsa_status_t MakeMemoryUnresident(const void* mem) const override;
-  hsa_status_t CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
-                           HSA_QUEUE_PRIORITY priority, uint32_t sdma_engine_id, void* queue_addr,
-                           uint64_t queue_size_bytes, HsaEvent* event,
-                           HsaQueueResource& queue_resource) const override;
+  hsa_status_t CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type,
+                  uint32_t queue_pct, HSA_QUEUE_PRIORITY priority,
+                  uint32_t sdma_engine_id, void* queue_addr,
+                  uint64_t queue_size_bytes, std::shared_ptr<HsaEvent> event,
+                             HsaQueueResource& queue_resource) const override;
   hsa_status_t DestroyQueue(HSA_QUEUEID queue_id) const override;
   hsa_status_t UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_percentage,
-                           HSA_QUEUE_PRIORITY priority, void* queue_mem, uint64_t queue_size,
-                           HsaEvent* event) const override;
+                  HSA_QUEUE_PRIORITY priority, void* queue_mem,
+                  uint64_t queue_size, std::shared_ptr<HsaEvent> event)
+                                                                const override;
   hsa_status_t SetQueueCUMask(HSA_QUEUEID queue_id, uint32_t num_cu_mask,
                               uint32_t* cu_mask) const override;
   hsa_status_t AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_GWS, uint32_t* GWS) const override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -206,12 +206,15 @@ public:
                               void **mem, size_t size,
                               uint32_t node_id) override;
   hsa_status_t FreeMemory(void *mem, size_t size) override;
-  hsa_status_t CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
-                           HSA_QUEUE_PRIORITY priority, uint32_t sdma_engine_id, void* queue_addr,
-                           uint64_t queue_size_bytes, HsaEvent* event,
-                           HsaQueueResource& queue_resource) const override;
-  hsa_status_t UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_pct, HSA_QUEUE_PRIORITY priority,
-                           void* queue_addr, uint64_t queue_size, HsaEvent* event) const override;
+  hsa_status_t CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type,
+                uint32_t queue_pct, HSA_QUEUE_PRIORITY priority,
+                uint32_t sdma_engine_id, void* queue_addr,
+                uint64_t queue_size_bytes, std::shared_ptr<HsaEvent> event,
+                              HsaQueueResource& queue_resource) const override;
+  hsa_status_t UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_pct,
+                  HSA_QUEUE_PRIORITY priority, void* queue_addr,
+                  uint64_t queue_size, std::shared_ptr<HsaEvent> event)
+                                                                const override;
   hsa_status_t DestroyQueue(HSA_QUEUEID queue_id) const override;
   hsa_status_t SetQueueCUMask(HSA_QUEUEID queue_id, uint32_t cu_mask_count,
                               uint32_t* queue_cu_mask) const override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/default_signal.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/default_signal.h
@@ -151,7 +151,7 @@ class BusyWaitSignal : public Signal {
   }
 
   /// @brief see the base class Signal
-  __forceinline HsaEvent* EopEvent() { return NULL; }
+  __forceinline std::shared_ptr<HsaEvent> EopEvent() { return NULL; }
 
  protected:
   bool _IsA(rtti_t id) const { return id == &rtti_id(); }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -46,6 +46,7 @@
 #include <cstdint>
 #include <limits>
 #include <string>
+#include <memory>
 
 #include "core/inc/memory_region.h"
 #include "hsakmt/hsakmttypes.h"
@@ -158,10 +159,12 @@ public:
   /// @param[in] queue_size_bytes Size of the queue's ring buffer in bytes.
   /// @param[in] event HsaEvent for event-driven callbacks.
   /// @param[out] queue_resource Queue resource information populated by the driver.
-  virtual hsa_status_t CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
-                                   HSA_QUEUE_PRIORITY priority, uint32_t sdma_engine_id,
-                                   void* queue_addr, uint64_t queue_size_bytes, HsaEvent* event,
-                                   HsaQueueResource& queue_resource) const = 0;
+  virtual hsa_status_t CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type,
+                        uint32_t queue_pct, HSA_QUEUE_PRIORITY priority,
+                        uint32_t sdma_engine_id, void* queue_addr,
+                        uint64_t queue_size_bytes,
+                        std::shared_ptr<HsaEvent> event,
+                                  HsaQueueResource& queue_resource) const = 0;
 
   /// @brief Destroy a queue.
   /// @param queue_id Kernel-mode driver's assigned queue ID.
@@ -175,8 +178,9 @@ public:
   /// @param[in] queue_size_bytes Size of the queue's ring buffer in bytes.
   /// @param[in] event HsaEvent for event-driven callbacks.
   virtual hsa_status_t UpdateQueue(HSA_QUEUEID queue_id, uint32_t queue_pct,
-                                   HSA_QUEUE_PRIORITY priority, void* queue_addr,
-                                   uint64_t queue_size_bytes, HsaEvent* event) const = 0;
+                                   HSA_QUEUE_PRIORITY priority,
+                                   void* queue_addr, uint64_t queue_size_bytes,
+                                      std::shared_ptr<HsaEvent> event) const = 0;
 
   /// @brief Set the CU mask for a queue.
   /// @details This sets the CU bitmask for a queue. The CU mask determines which CUs

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/interrupt_signal.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/interrupt_signal.h
@@ -75,8 +75,8 @@ class InterruptSignal : private LocalSignal, public Signal {
 
     EventPool() : allEventsAllocated(false) {}
 
-    HsaEvent* alloc();
-    void free(HsaEvent* evt);
+    std::shared_ptr<HsaEvent> alloc();
+    void free(std::shared_ptr<HsaEvent> evt);
     void clear() {
       events_.clear();
       allEventsAllocated = false;
@@ -84,12 +84,12 @@ class InterruptSignal : private LocalSignal, public Signal {
 
    private:
     HybridMutex lock_;
-    std::vector<unique_event_ptr> events_;
+    std::vector<std::shared_ptr<HsaEvent>> events_;
     bool allEventsAllocated;
   };
 
-  static HsaEvent* CreateEvent(HSA_EVENTTYPE type, bool manual_reset);
-  static void DestroyEvent(HsaEvent* evt);
+  static std::shared_ptr<HsaEvent> CreateEvent(HSA_EVENTTYPE type, bool manual_reset);
+  static void DestroyEvent(HsaEvent *evt);
 
   /// @brief Determines if a Signal* can be safely converted to an
   /// InterruptSignal* via static_cast.
@@ -98,7 +98,7 @@ class InterruptSignal : private LocalSignal, public Signal {
   }
 
   explicit InterruptSignal(hsa_signal_value_t initial_value,
-                           HsaEvent* use_event = NULL);
+                           std::shared_ptr<HsaEvent> use_event = NULL);
 
   ~InterruptSignal();
 
@@ -188,14 +188,14 @@ class InterruptSignal : private LocalSignal, public Signal {
   }
 
   /// @brief See base class Signal.
-  __forceinline HsaEvent* EopEvent() { return event_; }
+  __forceinline std::shared_ptr<HsaEvent> EopEvent() {return event_;}
 
  protected:
   bool _IsA(rtti_t id) const { return id == &rtti_id(); }
 
  private:
   /// @variable KFD event on which the interrupt signal is based on.
-  HsaEvent* event_;
+  std::shared_ptr<HsaEvent> event_;
 
   /// @variable Indicates whether the signal should release the event when it
   /// closes or not.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/isa.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/isa.h
@@ -229,7 +229,7 @@ class IsaRegistry final {
   static const Isa *GetIsa(const Isa::Version &version,
                            IsaFeature sramecc = IsaFeature::Any,
                            IsaFeature xnack = IsaFeature::Any);
-  static const std::unordered_map<std::string, unsigned int> &
+  static std::shared_ptr<const std::unordered_map<std::string, unsigned int>>
                                                 GetSupportedGenericVersions();
  private:
   /// @brief IsaRegistry's map type.
@@ -242,7 +242,7 @@ class IsaRegistry final {
   ~IsaRegistry() = default;
 
   /// @returns Supported instruction set architectures.
-  static const IsaMap& GetSupportedIsas();
+  static std::shared_ptr<const IsaMap> GetSupportedIsas();
 }; // class IsaRegistry
 
 } // namespace core

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -713,13 +713,11 @@ class Runtime {
     prefetch_map_t::iterator next;
   };
 
-  // Will be created before any user could call hsa_init but also could be
-  // destroyed before incorrectly written programs call hsa_shutdown.
-  static __forceinline KernelMutex& bootstrap_lock() {
-    // This allocation is meant to last until the last thread has exited.
-    // It is intentionally not freed.
-    static KernelMutex* bootstrap_lock_ = new KernelMutex;
-    return *bootstrap_lock_;
+  static __forceinline std::shared_ptr<KernelMutex> bootstrap_lock() {
+    // This static could probably be replaced with a constinit in C++20
+    // when we get there.
+    static std::shared_ptr<KernelMutex> bootstrap_lock_ = std::make_shared<KernelMutex>(); 
+    return bootstrap_lock_;
   }
   Runtime();
 
@@ -850,13 +848,13 @@ class Runtime {
   size_t num_nodes_;
 
   // @brief AMD HSA event to monitor for virtual memory access fault.
-  HsaEvent* vm_fault_event_;
+  std::shared_ptr<HsaEvent> vm_fault_event_;
 
   // @brief HSA signal to contain the VM fault event.
   Signal* vm_fault_signal_;
 
   // @brief AMD HSA event to monitor for HW exceptions.
-  HsaEvent* hw_exception_event_;
+  std::shared_ptr<HsaEvent> hw_exception_event_;
 
   // @brief HSA signal to contain the HW exceptionevent.
   Signal* hw_exception_signal_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/signal.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/signal.h
@@ -401,7 +401,7 @@ class Signal {
 
   /// @brief Applies only to InterrupEvent type, returns the event used to.
   /// Returns NULL for DefaultEvent Type.
-  virtual HsaEvent* EopEvent() = 0;
+  virtual std::shared_ptr<HsaEvent> EopEvent() = 0;
 
   /// @brief Waits until multiple signals in the list satisfy their conditions
   /// or a timeout is reached.
@@ -667,7 +667,7 @@ class DoorbellSignal : public Signal {
   }
 
   /// @brief This operation is illegal
-  HsaEvent* EopEvent() final override {
+  std::shared_ptr<HsaEvent> EopEvent() final override {
     assert(false);
     return NULL;
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -220,8 +220,7 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
     ScopedAcquire<KernelMutex> _lock(&queue_lock());
     queue_count()--;
     if (queue_count() == 0) {
-      core::InterruptSignal::DestroyEvent(queue_event());
-      queue_event() = nullptr;
+      queue_event().reset();  // Call the queue_event deleter
     }
   });
 
@@ -390,8 +389,7 @@ AqlQueue::~AqlQueue() {
     ScopedAcquire<KernelMutex> lock(&queue_lock());
     queue_count()--;
     if (queue_count() == 0) {
-      core::InterruptSignal::DestroyEvent(queue_event());
-      queue_event() = nullptr;
+      queue_event().reset();  // call the queue_event deleter
     }
   }
   agent_->system_deallocator()(pm4_ib_buf_);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
@@ -47,28 +47,29 @@
 namespace rocr {
 namespace core {
 
-HsaEvent* InterruptSignal::EventPool::alloc() {
+std::shared_ptr<HsaEvent> InterruptSignal::EventPool::alloc() {
   ScopedAcquire<HybridMutex> lock(&lock_);
   if (events_.empty()) {
     if (!allEventsAllocated) {
-      HsaEvent* evt = InterruptSignal::CreateEvent(HSA_EVENTTYPE_SIGNAL, false);
+      std::shared_ptr<HsaEvent> evt =
+                    InterruptSignal::CreateEvent(HSA_EVENTTYPE_SIGNAL, false);
       if (evt == nullptr) allEventsAllocated = true;
       return evt;
     }
     return nullptr;
   }
-  HsaEvent* ret = events_.back().release();
+  std::shared_ptr<HsaEvent> ret = events_.back();
   events_.pop_back();
   return ret;
 }
 
-void InterruptSignal::EventPool::free(HsaEvent* evt) {
+void InterruptSignal::EventPool::free(std::shared_ptr<HsaEvent> evt) {
   if (evt == nullptr) return;
   ScopedAcquire<HybridMutex> lock(&lock_);
-  events_.push_back(unique_event_ptr(evt));
+  events_.push_back(evt);
 }
 
-HsaEvent* InterruptSignal::CreateEvent(HSA_EVENTTYPE type, bool manual_reset) {
+std::shared_ptr<HsaEvent> InterruptSignal::CreateEvent(HSA_EVENTTYPE type, bool manual_reset) {
   HsaEventDescriptor event_descriptor;
   event_descriptor.EventType = type;
   event_descriptor.SyncVar.SyncVar.UserData = NULL;
@@ -86,13 +87,20 @@ HsaEvent* InterruptSignal::CreateEvent(HSA_EVENTTYPE type, bool manual_reset) {
     }
   }
 
-  return ret;
+  return std::shared_ptr<HsaEvent>(ret, [](HsaEvent* evt) {
+      if (evt) {
+        HSAKMT_CALL(hsaKmtDestroyEvent)(evt);
+      }
+  });}
+
+void InterruptSignal::DestroyEvent(HsaEvent *evt) {
+  HSAKMT_CALL(hsaKmtDestroyEvent(evt));
+  evt = nullptr;
 }
 
-void InterruptSignal::DestroyEvent(HsaEvent* evt) { HSAKMT_CALL(hsaKmtDestroyEvent(evt)); }
-
-InterruptSignal::InterruptSignal(hsa_signal_value_t initial_value, HsaEvent* use_event)
-    : LocalSignal(initial_value, false), Signal(signal()) {
+InterruptSignal::InterruptSignal(hsa_signal_value_t initial_value,
+                                  std::shared_ptr<HsaEvent> use_event)
+                    : LocalSignal(initial_value, false), Signal(signal()) {
   if (use_event != nullptr) {
     event_ = use_event;
     free_event_ = false;
@@ -194,7 +202,7 @@ hsa_signal_value_t InterruptSignal::WaitRelaxed(hsa_signal_condition_t condition
       static_cast<uint32_t>(signal_abort_timeout ? signal_abort_timeout * 1000 : 0xFFFFFFFFUL)
     );
 
-    HSAKMT_CALL(hsaKmtWaitOnEvent_Ext(event_, wait_ms, &event_age));
+    HSAKMT_CALL(hsaKmtWaitOnEvent_Ext(event_.get(), wait_ms, &event_age));
   }
 }
 
@@ -372,7 +380,7 @@ hsa_signal_value_t InterruptSignal::CasAcqRel(hsa_signal_value_t expected,
 }
   /// @brief Notify driver of signal value change if necessary.
   void InterruptSignal::SetEvent() {
-    if (InWaiting()) HSAKMT_CALL(hsaKmtSetEvent(event_));
+    if (InWaiting()) HSAKMT_CALL(hsaKmtSetEvent(event_.get()));
   }
 
 }  // namespace core

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/isa.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/isa.cpp
@@ -48,6 +48,7 @@
 #include <iostream>
 #include <sstream>
 #include <utility>
+#include <memory>
 
 namespace rocr {
 namespace core {
@@ -79,10 +80,10 @@ bool Isa::IsCompatible(const Isa &code_object_isa,
                        const Isa &agent_isa, unsigned int codeGenericVersion) {
 
   bool code_obj_isa_is_generic = false;
-  auto generic_it = IsaRegistry::GetSupportedGenericVersions().find(
-                                                 code_object_isa.GetIsaName());
+  auto generic_versions = IsaRegistry::GetSupportedGenericVersions();
+  auto generic_it = generic_versions->find(code_object_isa.GetIsaName());
 
-  if (generic_it != IsaRegistry::GetSupportedGenericVersions().end()) {
+  if (generic_it != generic_versions->end()) {
     code_obj_isa_is_generic = true;
   }
 
@@ -230,14 +231,16 @@ hsa_round_method_t Isa::GetRoundMethod(
 }
 
 const Isa *IsaRegistry::GetIsa(const std::string &full_name) {
-  auto isareg_iter = GetSupportedIsas().find(full_name);
-  return isareg_iter == GetSupportedIsas().end() ?
+  auto map = GetSupportedIsas();
+  auto isareg_iter = map->find(full_name);
+  return isareg_iter == map->end() ?
                                               nullptr : &isareg_iter->second;
 }
 
 const Isa *IsaRegistry::GetIsa(const Isa::Version &version, IsaFeature sramecc, IsaFeature xnack) {
-  auto isareg_iter = std::find_if(GetSupportedIsas().begin(),
-                                  GetSupportedIsas().end(),
+  auto map = GetSupportedIsas();
+  auto isareg_iter = std::find_if(map->begin(),
+                                  map->end(),
                                   [&](const IsaMap::value_type& isareg) {
                                     return isareg.second.GetVersion() == version &&
                                         (isareg.second.GetSramecc() == IsaFeature::Unsupported ||
@@ -245,48 +248,45 @@ const Isa *IsaRegistry::GetIsa(const Isa::Version &version, IsaFeature sramecc, 
                                         (isareg.second.GetXnack() == IsaFeature::Unsupported ||
                                          isareg.second.GetXnack() == xnack);
                                   });
-  return isareg_iter == GetSupportedIsas().end() ?
+  return isareg_iter == map->end() ?
                                               nullptr : &isareg_iter->second;
 }
 
 
 // TODO: c++20 use constexpr or consteval
-const std::unordered_map<std::string, unsigned int> &
+std::shared_ptr<const std::unordered_map<std::string, unsigned int>>
 IsaRegistry::GetSupportedGenericVersions() {
-  static const
-    std::unordered_map<std::string, unsigned int> * min_gen_versions =
-                          new std::unordered_map<std::string, unsigned int> {
-    {prepend_isa_prefix("gfx9-generic"), 1},
-    {prepend_isa_prefix("gfx9-generic:xnack-"), 1},
-    {prepend_isa_prefix("gfx9-generic:xnack+"), 1},
-    {prepend_isa_prefix("gfx9-4-generic"), 1},
-    {prepend_isa_prefix("gfx9-4-generic:xnack-"), 1},
-    {prepend_isa_prefix("gfx9-4-generic:xnack+"), 1},
-    {prepend_isa_prefix("gfx9-4-generic:sramecc-"), 1},
-    {prepend_isa_prefix("gfx9-4-generic:sramecc+"), 1},
-    {prepend_isa_prefix("gfx9-4-generic:sramecc-:xnack-"), 1},
-    {prepend_isa_prefix("gfx9-4-generic:sramecc-:xnack+"), 1},
-    {prepend_isa_prefix("gfx9-4-generic:sramecc+:xnack-"), 1},
-    {prepend_isa_prefix("gfx9-4-generic:sramecc+:xnack+"), 1},
-    {prepend_isa_prefix("gfx10-1-generic"), 1},
-    {prepend_isa_prefix("gfx10-1-generic:xnack-"), 1},
-    {prepend_isa_prefix("gfx10-1-generic:xnack+"), 1},
-    {prepend_isa_prefix("gfx10-3-generic"), 1},
-    {prepend_isa_prefix("gfx11-generic"), 1},
-    {prepend_isa_prefix("gfx12-generic"), 1}
-  };
-  return *min_gen_versions;
+  static const std::shared_ptr<std::unordered_map<std::string, unsigned int>> min_gen_versions =
+      std::make_shared<std::unordered_map<std::string, unsigned int>>(
+          std::unordered_map<std::string, unsigned int>{
+              {prepend_isa_prefix("gfx9-generic"), 1},
+              {prepend_isa_prefix("gfx9-generic:xnack-"), 1},
+              {prepend_isa_prefix("gfx9-generic:xnack+"), 1},
+              {prepend_isa_prefix("gfx9-4-generic"), 1},
+              {prepend_isa_prefix("gfx9-4-generic:xnack-"), 1},
+              {prepend_isa_prefix("gfx9-4-generic:xnack+"), 1},
+              {prepend_isa_prefix("gfx9-4-generic:sramecc-"), 1},
+              {prepend_isa_prefix("gfx9-4-generic:sramecc+"), 1},
+              {prepend_isa_prefix("gfx9-4-generic:sramecc-:xnack-"), 1},
+              {prepend_isa_prefix("gfx9-4-generic:sramecc-:xnack+"), 1},
+              {prepend_isa_prefix("gfx9-4-generic:sramecc+:xnack-"), 1},
+              {prepend_isa_prefix("gfx9-4-generic:sramecc+:xnack+"), 1},
+              {prepend_isa_prefix("gfx10-1-generic"), 1},
+              {prepend_isa_prefix("gfx10-1-generic:xnack-"), 1},
+              {prepend_isa_prefix("gfx10-1-generic:xnack+"), 1},
+              {prepend_isa_prefix("gfx10-3-generic"), 1},
+              {prepend_isa_prefix("gfx11-generic"), 1},
+              {prepend_isa_prefix("gfx12-generic"), 1}});
+  return min_gen_versions;
 }
 
-const IsaRegistry::IsaMap& IsaRegistry::GetSupportedIsas() {
+std::shared_ptr<const IsaRegistry::IsaMap> IsaRegistry::GetSupportedIsas() {
   // agent, and vendor name length limit excluding terminating nul character.
   constexpr size_t hsa_name_size = 63;
-  // This allocation is meant to last until the last thread has exited.
-  // It is intentionally not freed.
-  static IsaMap* supported_isas = new IsaMap();
+  static std::shared_ptr<IsaMap> supported_isas = std::make_shared<IsaMap>();
 
   if (supported_isas->size() > 0) {
-    return *supported_isas;
+    return supported_isas;
   }
   
   auto parse_out_minor_ver = [&](const std::string& generic_name) -> int32_t {
@@ -438,7 +438,7 @@ const IsaRegistry::IsaMap& IsaRegistry::GetSupportedIsas() {
   ISAREG_ENTRY_GEN("gfx1201",                12, 0, 1, unsupported, unsupported, 32, "gfx12-generic")
 #undef ISAREG_ENTRY_GEN
 
-  return *supported_isas;
+  return supported_isas;
 }
 
 } // namespace core

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -119,7 +119,8 @@ bool g_use_mwaitx;
 Runtime* Runtime::runtime_singleton_ = NULL;
 
 hsa_status_t Runtime::Acquire() {
-  ScopedAcquire<KernelMutex> boot(&bootstrap_lock());
+  std::shared_ptr<KernelMutex> lck = bootstrap_lock();
+  ScopedAcquire<KernelMutex> boot(lck.get());
 
   if (runtime_singleton_ == NULL) {
     memset(log_flags, 0, sizeof(log_flags));
@@ -146,7 +147,8 @@ hsa_status_t Runtime::Acquire() {
 }
 
 hsa_status_t Runtime::Release() {
-  ScopedAcquire<KernelMutex> boot(&bootstrap_lock());
+  std::shared_ptr<KernelMutex> lck = bootstrap_lock();
+  ScopedAcquire<KernelMutex> boot(lck.get());
 
   if (runtime_singleton_ == nullptr) return HSA_STATUS_ERROR_NOT_INITIALIZED;
 
@@ -1771,7 +1773,7 @@ void Runtime::AsyncEventsLoop(void* _eventsInfo) {
 
   // Prepares a list of events for a wait inside KFD
   auto PrepareInterrupt = [&](size_t idx, bool init_age) {
-    HsaEvent* hsa_event = hsa_signals[idx]->EopEvent();
+    HsaEvent* hsa_event = hsa_signals[idx]->EopEvent().get();
     // If any signal doesn't have an interrupt, then switch to polling
     if (hsa_event == nullptr) {
       unique_evts = 0;
@@ -1781,7 +1783,7 @@ void Runtime::AsyncEventsLoop(void* _eventsInfo) {
           hsa_events.resize(unique_evts + 10);
           event_age.resize(unique_evts + 10);
       }
-      if (init_age || hsa_events[unique_evts] != hsa_event ) {
+      if (init_age || hsa_events[unique_evts] != hsa_event) {
         event_age[unique_evts] = runtime_singleton_->KfdVersion().supports_event_age ? 1 : 0;
       }
       hsa_events[unique_evts] = hsa_event;
@@ -2089,7 +2091,7 @@ bool Runtime::HwExceptionHandler(hsa_signal_value_t val, void* arg) {
 
   if (hw_exception_signal == NULL) return false;
 
-  HsaEvent* exception_event = hw_exception_signal->EopEvent();
+  std::shared_ptr<HsaEvent> exception_event = hw_exception_signal->EopEvent();
 
   HsaHwException& exception = exception_event->EventData.EventData.HwException;
 
@@ -2144,7 +2146,7 @@ bool Runtime::VMFaultHandler(hsa_signal_value_t val, void* arg) {
     return false;
   }
 
-  HsaEvent* vm_fault_event = vm_fault_signal->EopEvent();
+  std::shared_ptr<HsaEvent> vm_fault_event = vm_fault_signal->EopEvent();
 
   HsaMemoryAccessFault& fault =
       vm_fault_event->EventData.EventData.MemoryAccessFault;
@@ -2455,14 +2457,14 @@ void Runtime::Unload() {
     vm_fault_signal_->DestroySignal();
     vm_fault_signal_ = nullptr;
   }
-  core::InterruptSignal::DestroyEvent(vm_fault_event_);
+  core::InterruptSignal::DestroyEvent(vm_fault_event_.get());
   vm_fault_event_ = nullptr;
 
   if (hw_exception_signal_ != nullptr) {
     hw_exception_signal_->DestroySignal();
     hw_exception_signal_ = nullptr;
   }
-  core::InterruptSignal::DestroyEvent(hw_exception_event_);
+  core::InterruptSignal::DestroyEvent(hw_exception_event_.get());
   hw_exception_event_ = nullptr;
 
   SharedSignalPool.clear();

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/signal.cpp
@@ -220,32 +220,41 @@ uint32_t Signal::WaitMultiple(uint32_t signal_count, const hsa_signal_t* hsa_sig
   }
 
   const uint32_t small_size = 10;
-  HsaEvent* short_evts[small_size];
+//  HsaEvent* short_evts[small_size];
+  std::array<HsaEvent *, small_size> short_evts;
   HsaEvent** evts = NULL;
+  std::vector<HsaEvent *> evts_vec;
   uint32_t unique_evts = 0;
   if (wait_hint != HSA_WAIT_STATE_ACTIVE) {
-    if (signal_count > small_size)
-      evts = new HsaEvent* [signal_count];
-    else
-      evts = short_evts;
-    for (uint32_t i = 0; i < signal_count; i++)
-      evts[i] = signals[i]->EopEvent();
+    if (signal_count > small_size) {
+      //evts = new HsaEvent* [signal_count];
+      evts_vec.reserve(signal_count);
+      evts = evts_vec.data();
+    }
+    else {
+      evts = short_evts.data();
+    }
+    for (uint32_t i = 0; i < signal_count; i++){
+      evts[i] = signals[i]->EopEvent().get();
+    }
     std::sort(evts, evts + signal_count);
     HsaEvent** end = std::unique(evts, evts + signal_count);
     unique_evts = uint32_t(end - evts);
   }
-  MAKE_SCOPE_GUARD([&]() {
-    if (signal_count > small_size) delete[] evts;
-  });
-#if defined(__linux__)
-  uint64_t event_age[unique_evts];
-#else
-  auto event_age = reinterpret_cast<uint64_t*>(_alloca(unique_evts * sizeof(unique_evts)));
-#endif
-  memset(event_age, 0, unique_evts * sizeof(uint64_t));
+  // MAKE_SCOPE_GUARD([&]() {
+  //   if (signal_count > small_size) delete[] evts;
+  // });
+
+  std::vector<uint64_t> event_age_vec;
+// #if defined(__linux__)
+//   uint64_t event_age[unique_evts];
+// #else
+//   auto event_age = reinterpret_cast<uint64_t*>(_alloca(unique_evts * sizeof(unique_evts)));
+// #endif
+  // memset(event_age, 0, unique_evts * sizeof(uint64_t));
   if (core::Runtime::runtime_singleton_->KfdVersion().supports_event_age)
     for (uint32_t i = 0; i < unique_evts; i++)
-      event_age[i] = 1;
+      event_age_vec[i] = 1;
 
   int64_t value;
 
@@ -326,7 +335,8 @@ uint32_t Signal::WaitMultiple(uint32_t signal_count, const hsa_signal_t* hsa_sig
     uint64_t ct=timer::duration_cast<std::chrono::milliseconds>(
       time_remaining).count();
     wait_ms = (ct>0xFFFFFFFEu) ? 0xFFFFFFFEu : ct;
-    HSAKMT_CALL(hsaKmtWaitOnMultipleEvents_Ext(evts, unique_evts, wait_on_all, wait_ms, event_age));
+    HSAKMT_CALL(hsaKmtWaitOnMultipleEvents_Ext(evts, unique_evts,
+                                wait_on_all, wait_ms, event_age_vec.data()));
   }
 }
 
@@ -367,7 +377,7 @@ uint32_t Signal::WaitAnyExceptions(uint32_t signal_count, const hsa_signal_t* hs
 
   for (uint32_t i = 0; i < signal_count; i++) {
     assert(signals[i]->EopEvent() != NULL);
-    evts[i] = signals[i]->EopEvent();
+    evts[i] = signals[i]->EopEvent().get();
   }
 
   std::sort(evts, evts + signal_count);

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_runtime.cpp
@@ -149,49 +149,53 @@ hsa_status_t ImageRuntime::CreateImageManager(hsa_agent_t agent, void* data) {
   return HSA_STATUS_SUCCESS;
 }
 
-ImageRuntime* ImageRuntime::instance() {
-  ImageRuntime* instance = get_instance().load(std::memory_order_acquire);
-  if (instance == NULL) {
+std::shared_ptr<ImageRuntime> ImageRuntime::instance() {
+  ImageRuntime* raw_instance = get_instance().load(std::memory_order_acquire);
+  if (raw_instance == NULL) {
     // Protect the initialization from multi threaded access.
     std::lock_guard<std::mutex> lock(instance_mutex());
 
     // Make sure we are not initializing it twice.
-    instance = get_instance().load(std::memory_order_relaxed);
-    if (instance != NULL) {
-      return instance;
+    raw_instance = get_instance().load(std::memory_order_relaxed);
+    if (raw_instance != NULL) {
+      return get_shared_instance();
     }
 
-    instance = CreateSingleton();
-    if (instance == NULL) {
-      return NULL;
+    raw_instance = CreateSingleton();
+    if (raw_instance == NULL) {
+      return nullptr;
     }
 
     // UnloadCallback = &ext_image::ImageRuntime::DestroySingleton;
   }
 
-  return instance;
+  // Return the shared_ptr (increments refcount for thread safety)
+  return get_shared_instance();
 }
 
 ImageRuntime* ImageRuntime::CreateSingleton() {
-  ImageRuntime* instance = new ImageRuntime();
+  auto shared_instance = std::make_shared<ImageRuntime>();
 
-  if (HSA_STATUS_SUCCESS != instance->blit_kernel_.Initialize()) {
-    instance->Cleanup();
-    delete instance;
+  if (HSA_STATUS_SUCCESS != shared_instance->blit_kernel_.Initialize()) {
+    shared_instance->Cleanup();
     return NULL;
   }
 
-  if (HSA_STATUS_SUCCESS != HSA::hsa_iterate_agents(CreateImageManager, instance)) {
-    instance->Cleanup();
-    delete instance;
+  if (HSA_STATUS_SUCCESS != HSA::hsa_iterate_agents(CreateImageManager, shared_instance.get())) {
+    shared_instance->Cleanup();
     return NULL;
   }
 
-  assert(instance->kernarg_pool_.handle != 0);
-  assert(instance->image_managers_.size() != 0);
+  assert(shared_instance->kernarg_pool_.handle != 0);
+  assert(shared_instance->image_managers_.size() != 0);
 
-  get_instance().store(instance, std::memory_order_release);
-  return instance;
+  // Store raw pointer in atomic for backward compatibility
+  get_instance().store(shared_instance.get(), std::memory_order_release);
+
+  // Store shared_ptr for actual ownership
+  get_shared_instance() = shared_instance;
+
+  return shared_instance.get();
 }
 
 void ImageRuntime::DestroySingleton() {
@@ -203,7 +207,9 @@ void ImageRuntime::DestroySingleton() {
   instance->Cleanup();
 
   get_instance().store(NULL, std::memory_order_release);
-  delete instance;
+
+  // Release the shared_ptr - object will be deleted when last reference goes away
+  get_shared_instance().reset();
 }
 
 hsa_status_t ImageRuntime::GetImageInfoMaxDimension(hsa_agent_t component,

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_runtime.h
@@ -46,6 +46,7 @@
 #include <atomic>
 #include <map>
 #include <mutex>
+#include <memory>
 
 #include "inc/hsa.h"
 
@@ -61,10 +62,16 @@ namespace image {
 class ImageRuntime {
  public:
   /// @brief Getter for the ImageRuntime singleton object.
-  static ImageRuntime* instance();
+  static std::shared_ptr<ImageRuntime> instance();
 
   /// @brief Destroy singleton object.
   static void DestroySingleton();
+
+  /// @brief Constructor - public to allow std::make_shared to construct.
+  ImageRuntime();
+
+  /// @brief Destructor - public to allow shared_ptr to delete.
+  ~ImageRuntime();
 
   /// @brief Retrieve maximum size of width, height, depth, array size in pixels
   /// for a particular geometry on a component.
@@ -156,24 +163,24 @@ class ImageRuntime {
 
   static hsa_status_t CreateImageManager(hsa_agent_t agent, void* data);
 
-  ImageRuntime();
-
-  ~ImageRuntime();
-
   void Cleanup();
 
-  /// Pointer to singleton object.
+  /// Pointer to singleton object
   static __forceinline std::atomic<ImageRuntime*>& get_instance() {
-    // This allocation is meant to last until the last thread has exited.
-    // It is intentionally not freed.
-    static std::atomic<ImageRuntime*>* instance_ = new std::atomic<ImageRuntime*>();
+    // Using shared_ptr to avoid static deallocation fiasco
+    static std::shared_ptr<std::atomic<ImageRuntime*>> instance_ =
+        std::make_shared<std::atomic<ImageRuntime*>>();
     return *instance_;
   }
 
+  static __forceinline std::shared_ptr<ImageRuntime>& get_shared_instance() {
+    static std::shared_ptr<ImageRuntime> shared_instance_;
+    return shared_instance_;
+  }
+
   static __forceinline std::mutex& instance_mutex() {
-    // This allocation is meant to last until the last thread has exited.
-    // It is intentionally not freed.
-    static std::mutex* instance_mutex_ = new std::mutex();
+    // Using shared_ptr to avoid deallocation fiasco
+    static std::shared_ptr<std::mutex> instance_mutex_ = std::make_shared<std::mutex>();
     return *instance_mutex_;
   }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/pcs/pcs_runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/pcs/pcs_runtime.cpp
@@ -58,32 +58,38 @@ do {                                                           \
 } while (false)
 
 
-PcsRuntime* PcsRuntime::instance() {
-  PcsRuntime* instance = get_instance().load(std::memory_order_acquire);
-  if (instance == NULL) {
+std::shared_ptr<PcsRuntime> PcsRuntime::instance() {
+  PcsRuntime* raw_instance = get_instance().load(std::memory_order_acquire);
+  if (raw_instance == NULL) {
     // Protect the initialization from multi threaded access.
     std::lock_guard<std::mutex> lock(instance_mutex());
 
     // Make sure we are not initializing it twice.
-    instance = get_instance().load(std::memory_order_relaxed);
-    if (instance != NULL) {
-      return instance;
+    raw_instance = get_instance().load(std::memory_order_relaxed);
+    if (raw_instance != NULL) {
+      return get_shared_instance();
     }
 
-    instance = CreateSingleton();
-    if (instance == NULL) {
-      return NULL;
+    raw_instance = CreateSingleton();
+    if (raw_instance == NULL) {
+      return nullptr;
     }
   }
 
-  return instance;
+  // Return the shared_ptr (increments refcount for thread safety)
+  return get_shared_instance();
 }
 
 PcsRuntime* PcsRuntime::CreateSingleton() {
-  PcsRuntime* instance = new PcsRuntime();
+  auto shared_instance = std::make_shared<PcsRuntime>();
+  
+  // Store raw pointer in atomic for backward compatibility
+  get_instance().store(shared_instance.get(), std::memory_order_release);
 
-  get_instance().store(instance, std::memory_order_release);
-  return instance;
+  // Store shared_ptr for actual ownership
+  get_shared_instance() = shared_instance;
+
+  return shared_instance.get();
 }
 
 void PcsRuntime::DestroySingleton() {
@@ -93,7 +99,9 @@ void PcsRuntime::DestroySingleton() {
   }
 
   get_instance().store(NULL, std::memory_order_release);
-  delete instance;
+
+  // Release the shared_ptr - object will be deleted when last reference goes away
+  get_shared_instance().reset();
 }
 
 void ReleasePcSamplingRsrcs() { PcsRuntime::DestroySingleton(); }

--- a/projects/rocr-runtime/runtime/hsa-runtime/pcs/pcs_runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/pcs/pcs_runtime.h
@@ -46,6 +46,7 @@
 #include <atomic>
 #include <map>
 #include <mutex>
+#include <memory>
 
 #include "hsakmt/hsakmt.h"
 
@@ -63,7 +64,7 @@ class PcsRuntime {
   ~PcsRuntime() {}
 
   /// @brief Getter for the PcsRuntime singleton object.
-  static PcsRuntime* instance();
+  static std::shared_ptr<PcsRuntime> instance();
 
   bool SessionsActive() const;
 
@@ -151,19 +152,24 @@ class PcsRuntime {
   /// @brief Initialize singleton object, must be called once.
   static PcsRuntime* CreateSingleton();
 
-  /// Pointer to singleton object.
+  /// Pointer to singleton object
   static __forceinline std::atomic<PcsRuntime*>& get_instance() {
-    // This allocation is meant to last until the last thread has exited.
-    // It is intentionally not freed.
-    static std::atomic<PcsRuntime*>* instance_ = new std::atomic<PcsRuntime*>();
+    // Using shared_ptr to avoid static deallocation fiasco
+    static std::shared_ptr<std::atomic<PcsRuntime*>> instance_ =
+        std::make_shared<std::atomic<PcsRuntime*>>();
     return *instance_;
   }
+
+  static __forceinline std::shared_ptr<PcsRuntime>& get_shared_instance() {
+    static std::shared_ptr<PcsRuntime> shared_instance_;
+    return shared_instance_;
+  }
+
   static __forceinline std::mutex& instance_mutex() {
-    // This allocation is meant to last until the last thread has exited.
-    // It is intentionally not freed.
-   static std::mutex* instance_mutex_ = new std::mutex();
-   return *instance_mutex_;
-}
+    // Using shared_ptr to manage lifetime and avoid static deallocation fiasco.
+    static std::shared_ptr<std::mutex> instance_mutex_ = std::make_shared<std::mutex>();
+    return *instance_mutex_;
+  }
   // Map of pc sampling sessions indexed by hsa_ven_amd_pcs_t handle
   std::map<uint64_t, PcSamplingSession> pc_sampling_;
   KernelMutex pc_sampling_lock_;


### PR DESCRIPTION
This allows us to not have to let some statically initialized, dynamically allocated objects to "leak".

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
