### PR TITLE
Adding counters support for GFX1152 and GFX1153

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/core.cpp
@@ -789,6 +789,7 @@ rocprofiler-sdk:
           - gfx1101
           - gfx1150
           - gfx1151
+          - gfx1153
           - gfx908
           - gfx90a
           - gfx9
@@ -841,6 +842,7 @@ rocprofiler-sdk:
           - gfx1101
           - gfx1150
           - gfx1151
+          - gfx1153
           - gfx940
           - gfx908
           - gfx900
@@ -870,6 +872,7 @@ rocprofiler-sdk:
           - gfx1101
           - gfx1150
           - gfx1151
+          - gfx1153
           - gfx908
           - gfx90a
           - gfx9

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/core.cpp
@@ -789,6 +789,7 @@ rocprofiler-sdk:
           - gfx1101
           - gfx1150
           - gfx1151
+          - gfx1152
           - gfx1153
           - gfx908
           - gfx90a
@@ -842,6 +843,7 @@ rocprofiler-sdk:
           - gfx1101
           - gfx1150
           - gfx1151
+          - gfx1152
           - gfx1153
           - gfx940
           - gfx908
@@ -872,6 +874,7 @@ rocprofiler-sdk:
           - gfx1101
           - gfx1150
           - gfx1151
+          - gfx1152
           - gfx1153
           - gfx908
           - gfx90a

--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/counter_defs.yaml
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/counter_defs.yaml
@@ -433,6 +433,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -462,6 +463,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx9
       - gfx900
       - gfx906
@@ -604,6 +606,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       expression: (GL2C_EA_RDREQ_32B_sum*32+GL2C_EA_RDREQ_64B_sum*64+GL2C_EA_RDREQ_96B_sum*96+GL2C_EA_RDREQ_128B_sum*128)/1024
     - architectures:
       - gfx12
@@ -735,6 +738,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: GL2C
       event: 102
     - architectures:
@@ -759,6 +763,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -779,6 +784,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: GL2C
       event: 99
     - architectures:
@@ -803,6 +809,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -823,6 +830,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: GL2C
       event: 100
     - architectures:
@@ -847,6 +855,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -867,6 +876,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: GL2C
       event: 101
   - name: GL2C_EA_RDREQ_96B_sum
@@ -885,6 +895,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       expression: reduce(GL2C_EA_RDREQ_96B,sum)
   - name: GL2C_EA_WRREQ
     description: Number of transactions (all sizes) going over the GL2C_EA_WRREQ interface for all clients. This does not
@@ -942,6 +953,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: GL2C
       event: 85
     - architectures:
@@ -967,6 +979,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -987,6 +1000,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: GL2C
       event: 42
     - architectures:
@@ -1011,6 +1025,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -1031,6 +1046,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: GL2C
       event: 96
   - name: GL2C_MC_RDREQ_sum
@@ -1049,6 +1065,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       expression: reduce(GL2C_MC_RDREQ,sum)
   - name: GL2C_MC_WRREQ
     description: Number of transactions (either 32-byte or 64-byte) going over the GL2C_EA_wrreq interface. Atomics may travel
@@ -1067,6 +1084,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: GL2C
       event: 83
   - name: GL2C_MC_WRREQ_STALL
@@ -1085,6 +1103,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: GL2C
       event: 88
     - architectures:
@@ -1110,6 +1129,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       expression: reduce(GL2C_MC_WRREQ,sum)
   - name: GL2C_MISS
     description: Number of cache misses.  UC reads count as misses.
@@ -1127,6 +1147,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: GL2C
       event: 43
     - architectures:
@@ -1151,6 +1172,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -1171,6 +1193,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -1191,6 +1214,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx9
       - gfx900
       - gfx906
@@ -1216,6 +1240,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -1245,6 +1270,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -1361,6 +1387,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -1486,6 +1513,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -1513,6 +1541,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -1606,6 +1635,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx9
       - gfx900
       - gfx906
@@ -1627,6 +1657,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -1649,6 +1680,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -1681,6 +1713,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -1710,6 +1743,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx9
       - gfx906
       - gfx908
@@ -1853,6 +1887,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx9
       - gfx906
       - gfx908
@@ -1877,6 +1912,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx9
       - gfx900
       - gfx906
@@ -1907,6 +1943,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx9
       - gfx906
       - gfx908
@@ -2944,6 +2981,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: SQ
       event: 256
     - architectures:
@@ -2972,6 +3010,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: SQ
       event: 261
     - architectures:
@@ -3076,6 +3115,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -3350,6 +3390,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -3523,6 +3564,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: SQ
       event: 56
     - architectures:
@@ -3638,6 +3680,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: SQ
       event: 57
     - architectures:
@@ -3710,6 +3753,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: SQ
       event: 58
     - architectures:
@@ -3782,6 +3826,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: SQ
       event: 59
     - architectures:
@@ -3831,6 +3876,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: SQ
       event: 66
     - architectures:
@@ -3851,6 +3897,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: SQ
       event: 67
     - architectures:
@@ -3891,6 +3938,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: SQ
       event: 62
     - architectures:
@@ -4457,6 +4505,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: SQ
       event: 70
     - architectures:
@@ -4485,6 +4534,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: SQ
       event: 72
     - architectures:
@@ -4513,6 +4563,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: SQ
       event: 73
     - architectures:
@@ -5134,6 +5185,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: SQ
       event: 82
     - architectures:
@@ -5161,6 +5213,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       block: SQ
       event: 83
     - architectures:
@@ -5189,6 +5242,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -5363,6 +5417,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -5412,6 +5467,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -5990,6 +6046,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -6019,6 +6076,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -6048,6 +6106,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -6275,6 +6334,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201
@@ -10417,6 +10477,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx9
       - gfx906
       - gfx908
@@ -10614,6 +10675,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       expression: ((GL2C_MC_WRREQ_sum-GL2C_EA_WRREQ_64B_sum)*32+GL2C_EA_WRREQ_64B_sum*64)/1024
     - architectures:
       - gfx940
@@ -10665,6 +10727,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx9
       - gfx906
       - gfx908
@@ -10712,6 +10775,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1153
       - gfx12
       - gfx1200
       - gfx1201

--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/counter_defs.yaml
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/counter_defs.yaml
@@ -433,6 +433,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -463,6 +464,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx9
       - gfx900
@@ -606,6 +608,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       expression: (GL2C_EA_RDREQ_32B_sum*32+GL2C_EA_RDREQ_64B_sum*64+GL2C_EA_RDREQ_96B_sum*96+GL2C_EA_RDREQ_128B_sum*128)/1024
     - architectures:
@@ -738,6 +741,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: GL2C
       event: 102
@@ -763,6 +767,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -784,6 +789,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: GL2C
       event: 99
@@ -809,6 +815,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -830,6 +837,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: GL2C
       event: 100
@@ -855,6 +863,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -876,6 +885,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: GL2C
       event: 101
@@ -895,6 +905,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       expression: reduce(GL2C_EA_RDREQ_96B,sum)
   - name: GL2C_EA_WRREQ
@@ -953,6 +964,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: GL2C
       event: 85
@@ -979,6 +991,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -1000,6 +1013,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: GL2C
       event: 42
@@ -1025,6 +1039,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -1046,6 +1061,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: GL2C
       event: 96
@@ -1065,6 +1081,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       expression: reduce(GL2C_MC_RDREQ,sum)
   - name: GL2C_MC_WRREQ
@@ -1084,6 +1101,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: GL2C
       event: 83
@@ -1103,6 +1121,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: GL2C
       event: 88
@@ -1129,6 +1148,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       expression: reduce(GL2C_MC_WRREQ,sum)
   - name: GL2C_MISS
@@ -1147,6 +1167,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: GL2C
       event: 43
@@ -1172,6 +1193,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -1193,6 +1215,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -1214,6 +1237,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx9
       - gfx900
@@ -1240,6 +1264,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -1270,6 +1295,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -1387,6 +1413,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -1513,6 +1540,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -1541,6 +1569,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -1635,6 +1664,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx9
       - gfx900
@@ -1657,6 +1687,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -1680,6 +1711,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -1713,6 +1745,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -1743,6 +1776,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx9
       - gfx906
@@ -1887,6 +1921,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx9
       - gfx906
@@ -1912,6 +1947,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx9
       - gfx900
@@ -1943,6 +1979,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx9
       - gfx906
@@ -2981,6 +3018,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: SQ
       event: 256
@@ -3010,6 +3048,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: SQ
       event: 261
@@ -3115,6 +3154,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -3390,6 +3430,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -3564,6 +3605,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: SQ
       event: 56
@@ -3680,6 +3722,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: SQ
       event: 57
@@ -3753,6 +3796,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: SQ
       event: 58
@@ -3826,6 +3870,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: SQ
       event: 59
@@ -3876,6 +3921,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: SQ
       event: 66
@@ -3897,6 +3943,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: SQ
       event: 67
@@ -3938,6 +3985,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: SQ
       event: 62
@@ -4505,6 +4553,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: SQ
       event: 70
@@ -4534,6 +4583,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: SQ
       event: 72
@@ -4563,6 +4613,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: SQ
       event: 73
@@ -5185,6 +5236,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: SQ
       event: 82
@@ -5213,6 +5265,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       block: SQ
       event: 83
@@ -5242,6 +5295,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -5417,6 +5471,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -5467,6 +5522,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -6046,6 +6102,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -6076,6 +6133,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -6106,6 +6164,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -6334,6 +6393,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200
@@ -10477,6 +10537,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx9
       - gfx906
@@ -10675,6 +10736,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       expression: ((GL2C_MC_WRREQ_sum-GL2C_EA_WRREQ_64B_sum)*32+GL2C_EA_WRREQ_64B_sum*64)/1024
     - architectures:
@@ -10727,6 +10789,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx9
       - gfx906
@@ -10775,6 +10838,7 @@ rocprofiler-sdk:
       - gfx1102
       - gfx1150
       - gfx1151
+      - gfx1152
       - gfx1153
       - gfx12
       - gfx1200

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/extra_counters.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/extra_counters.yaml
@@ -20,6 +20,7 @@ rocprofiler-sdk:
           - gfx1101
           - gfx1150
           - gfx1151
+          - gfx1153
           - gfx908
           - gfx90a
           - gfx9

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/extra_counters.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/extra_counters.yaml
@@ -20,6 +20,7 @@ rocprofiler-sdk:
           - gfx1101
           - gfx1150
           - gfx1151
+          - gfx1152
           - gfx1153
           - gfx908
           - gfx90a

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/input1/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/input1/validate.py
@@ -80,7 +80,7 @@ def test_validate_counter_collection_pmc1_json(json_data):
     counter_collection_data = data["callback_records"]["counter_collection"]
     dispatch_ids = []
     # at present, AQLProfile has bugs when reporting the counters for below architectures
-    skip_gfx = ("gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1153")
+    skip_gfx = ("gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1152", "gfx1153")
 
     def get_kernel_name(kernel_id):
         return data["kernel_symbols"][kernel_id]["formatted_kernel_name"]

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/input1/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/input1/validate.py
@@ -80,7 +80,7 @@ def test_validate_counter_collection_pmc1_json(json_data):
     counter_collection_data = data["callback_records"]["counter_collection"]
     dispatch_ids = []
     # at present, AQLProfile has bugs when reporting the counters for below architectures
-    skip_gfx = ("gfx1101", "gfx1102", "gfx1150", "gfx1151")
+    skip_gfx = ("gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1153")
 
     def get_kernel_name(kernel_id):
         return data["kernel_symbols"][kernel_id]["formatted_kernel_name"]

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/kernel_filtering/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/kernel_filtering/validate.py
@@ -70,7 +70,7 @@ def validate_json(json_data, counter_name, check_dispatch):
     counter_collection_data = data["callback_records"]["counter_collection"]
     dispatch_ids = []
     # at present, AQLProfile has bugs when reporting the counters for below architectures
-    skip_gfx = ("gfx1101", "gfx1102", "gfx1150", "gfx1151")
+    skip_gfx = ("gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1153")
 
     def get_kernel_name(kernel_id):
         return data["kernel_symbols"][kernel_id]["formatted_kernel_name"]

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/kernel_filtering/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/kernel_filtering/validate.py
@@ -70,7 +70,7 @@ def validate_json(json_data, counter_name, check_dispatch):
     counter_collection_data = data["callback_records"]["counter_collection"]
     dispatch_ids = []
     # at present, AQLProfile has bugs when reporting the counters for below architectures
-    skip_gfx = ("gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1153")
+    skip_gfx = ("gfx1101", "gfx1102", "gfx1150", "gfx1151", "gfx1152", "gfx1153")
 
     def get_kernel_name(kernel_id):
         return data["kernel_symbols"][kernel_id]["formatted_kernel_name"]


### PR DESCRIPTION
## Motivation

Enabling counters support for gfx1153

## Technical Details

Added gfx1153 architecture in supported counters list 

## Test Plan

## Test Result

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
