### PR TITLE
SWDEV-568926 - Destroy queue_inactive_signal directly.

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -383,7 +383,7 @@ AqlQueue::~AqlQueue() {
 
   exception_signal_->WaitingDec();
   exception_signal_->DestroySignal();
-  HSA::hsa_signal_destroy(amd_queue_.queue_inactive_signal);
+  core::Signal::Convert(amd_queue_.queue_inactive_signal)->DestroySignal();
   FreeQueueMemory();
 
   if (core::g_use_interrupt_wait) {


### PR DESCRIPTION
## Motivation

hsa_signal_destroy cause exit from ISOPEN which causes queue_inactive_signal leaked.

## Technical Details

hsa_signal_destroy cause exit from ISOPEN which causes queue_inactive_signal leaked.

## Test Plan

No change

## Test Result

No change

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
