### PR TITLE
[rocprofiler-compute] Update RHEL8/9 workflow with latest ROCm 7.1.1 installs

### DIFF
--- a/.github/workflows/rocprofiler-compute-rhel-8.yml
+++ b/.github/workflows/rocprofiler-compute-rhel-8.yml
@@ -69,9 +69,9 @@ jobs:
           max_attempts: 3
           command: |
             if [ ${{ matrix.os-release }} == "8.10" ]; then
-              yum install -y https://repo.radeon.com/amdgpu-install/latest/rhel/8.10/amdgpu-install-7.1.70100-1.el8.noarch.rpm
+              yum install -y https://repo.radeon.com/amdgpu-install/latest/rhel/8.10/amdgpu-install-7.1.1.70101-1.el8.noarch.rpm
             else
-              yum install -y https://repo.radeon.com/amdgpu-install/latest/rhel/9.4/amdgpu-install-7.1.70100-1.el9.noarch.rpm
+              yum install -y https://repo.radeon.com/amdgpu-install/latest/rhel/9.4/amdgpu-install-7.1.1.70101-1.el9.noarch.rpm
             fi
             yum install -y rocm-dev
       - name: Checkout


### PR DESCRIPTION
## Motivation

Previously using 7.1.0 which is no longer latest and not hosted on site anymore. Upgrading to 7.1.1 since it is now public release, good for testing.

## Technical Details

## Test Plan

If passes RHEL8/9 workflow run with new links.

## Test Result

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
