### PR TITLE
[rocprofiler-systems] Improve rocpd writing speed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -78,7 +78,7 @@
 	url = https://github.com/jrmadsen/pybind11.git
 [submodule "projects/rocprofiler-systems/external/sqlite"]
 	path = projects/rocprofiler-systems/external/sqlite
-	url = https://github.com/sqlite/sqlite
+	url = https://github.com/sqlite/sqlite.git
 [submodule "projects/rocprofiler-systems/examples/openmp/external/ompvv"]
 	path = projects/rocprofiler-systems/examples/openmp/external/ompvv
 	url = https://github.com/OpenMP-Validation-and-Verification/OpenMP_VV.git

--- a/projects/rocprofiler-systems/CMakeLists.txt
+++ b/projects/rocprofiler-systems/CMakeLists.txt
@@ -236,9 +236,10 @@ rocprofiler_systems_add_option(ROCPROFSYS_BUILD_CODECOV "Build for code coverage
 rocprofiler_systems_add_option(ROCPROFSYS_INSTALL_PERFETTO_TOOLS
                                "Install perfetto tools (i.e. traced, perfetto, etc.)" OFF
 )
-rocprofiler_systems_add_option(ROCPROFILER_BUILD_SQLITE3
-                               "Enable building sqlite3 library internally" OFF
+rocprofiler_systems_add_option(ROCPROFSYS_BUILD_SQLITE3
+                               "Enable building sqlite3 library internally" ON
 )
+
 rocprofiler_systems_add_option(ROCPROFSYS_BUILD_GTEST
                                "Enable building googletest library internally" ON
 )

--- a/projects/rocprofiler-systems/cmake/SQLite3.cmake
+++ b/projects/rocprofiler-systems/cmake/SQLite3.cmake
@@ -1,6 +1,6 @@
 include_guard(GLOBAL)
 
-if(ROCPROFILER_BUILD_SQLITE3)
+if(ROCPROFSYS_BUILD_SQLITE3)
     message(STATUS "Building SQLite3 from source!")
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/external/sqlite
@@ -16,29 +16,34 @@ if(ROCPROFILER_BUILD_SQLITE3)
 
     find_program(MAKE_COMMAND NAMES make gmake PATH_SUFFIXES bin REQUIRED)
 
-    include(ExternalProject)
-    ExternalProject_Add(
-        rocprofiler-systems-sqlite-build
-        PREFIX ${PROJECT_BINARY_DIR}/external/sqlite/build
-        SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/sqlite
-        BUILD_IN_SOURCE 0
-        CONFIGURE_COMMAND
-            <SOURCE_DIR>/configure --prefix=${PROJECT_BINARY_DIR}/external/sqlite/install
-            --libdir=${PROJECT_BINARY_DIR}/external/sqlite/install/lib --disable-shared
-            --with-tempstore=yes --enable-all --disable-tcl CFLAGS=-O3\ -g1
-        BUILD_COMMAND ${MAKE_COMMAND} install -s
-        INSTALL_COMMAND ""
+    set(SQLITE_BUILD_DIR ${PROJECT_BINARY_DIR}/external/sqlite/build)
+    set(SQLITE_INSTALL_DIR ${PROJECT_BINARY_DIR}/external/sqlite/install)
+    set(SQLITE_LIB ${SQLITE_INSTALL_DIR}/lib/libsqlite3.a)
+
+    add_custom_command(
+        OUTPUT ${SQLITE_LIB}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${SQLITE_BUILD_DIR}
+        COMMAND
+            ${CMAKE_COMMAND} -E chdir ${SQLITE_BUILD_DIR}
+            ${PROJECT_SOURCE_DIR}/external/sqlite/configure --prefix=${SQLITE_INSTALL_DIR}
+            --libdir=${SQLITE_INSTALL_DIR}/lib --disable-shared --with-tempstore=yes
+            --enable-all --disable-tcl
+            CFLAGS=-O3\ -g1\ -fPIC\ -DSQLITE_DEFAULT_MEMSTATUS=0
+        COMMAND ${CMAKE_COMMAND} -E chdir ${SQLITE_BUILD_DIR} ${MAKE_COMMAND} install -s
+        COMMENT "Building SQLite3 from source"
+        VERBATIM
     )
+
+    add_custom_target(rocprofiler-systems-sqlite-build DEPENDS ${SQLITE_LIB})
 
     target_link_libraries(
         rocprofiler-systems-sqlite3
-        INTERFACE
-            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/external/sqlite/install/lib/libsqlite3.a>
+        INTERFACE $<BUILD_INTERFACE:${SQLITE_LIB}>
     )
     target_include_directories(
         rocprofiler-systems-sqlite3
         SYSTEM
-        INTERFACE $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/external/sqlite/install/include>
+        INTERFACE $<BUILD_INTERFACE:${SQLITE_INSTALL_DIR}/include>
     )
     add_dependencies(rocprofiler-systems-sqlite3 rocprofiler-systems-sqlite-build)
 else()

--- a/projects/rocprofiler-systems/source/lib/core/rocpd/data_storage/database.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/rocpd/data_storage/database.hpp
@@ -34,7 +34,6 @@ namespace rocpd
 {
 namespace data_storage
 {
-static std::mutex _mutex;
 class database
 {
 public:
@@ -182,8 +181,7 @@ public:
         std::shared_ptr<sqlite3_stmt> stmt{ p_stmt, sqlite3_finalize };
 
         return [stmt, query, this](Values... value) {
-            std::lock_guard lock{ _mutex };
-            int             position = 1;
+            int position = 1;
 
             ((bind_value(stmt.get(), position++, value, query)), ...);
 


### PR DESCRIPTION
## Motivation

Improve SQLite3 database performance by enabling optimized compile flags and removing unnecessary synchronization overhead. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Renamed option `ROCPROFILER_BUILD_SQLITE3` to `ROCPROFSYS_BUILD_SQLITE3` for naming consistency and enabled it by default
- Replaced `ExternalProject_Add` with `add_custom_command` + `add_custom_target` for more efficient CMake build integration
- Added SQLite3 compile flags: `-fPIC` and `-DSQLITE_DEFAULT_MEMSTATUS=0` to disable memory status tracking for better performance
- Removed static mutex and lock_guard in `database.hpp` prepared statement execution, eliminating unnecessary synchronization overhead
- Added sqlite submodule and fixed `.gitmodules` URL format

## JIRA ID
AIPROFSYST-86

## Test Plan

- Build the project with `ROCPROFSYS_BUILD_SQLITE3=ON` (default) and verify SQLite3 builds from source
- Build with `ROCPROFSYS_BUILD_SQLITE3=OFF` and verify system SQLite3 is used
- Run existing database-related tests to ensure data integrity
- Profile database operations to verify performance improvement

## Test Result

- SQLite3 should build successfully with the new compile flags
- Measurable performance improvement in database write operations due to removed mutex overhead and disabled memory status tracking
- 
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
