### PR TITLE
[rocprofiler-systems] Fix roctx wall clock tree, change timemory push/pop to use proper category, and add roctx as valid domain choice

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/rocprofiler-sdk.cpp
@@ -328,6 +328,7 @@ config_settings(const std::shared_ptr<settings>& _config)
     _add_domain("hip_api");
     _add_domain("hsa_api");
     _add_domain("marker_api");
+    _add_domain("roctx");
 
     for(const auto& itr : buffered_tracing_info)
         _add_domain(itr.name);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -651,7 +651,14 @@ tool_tracing_callback_start(CategoryT, rocprofiler_callback_tracing_record_t rec
                 }
                 default:
                 {
-                    break;
+                    // A basic roctx marker region starts with roctxRangePushA ENTER and
+                    // ends with roctxRangePop EXIT.
+                    // Breaking instead of returning allows the roctxRangePop ENTER to be
+                    // processed, which timemory will link to the roctxRangePop EXIT. As
+                    // we do not push roctxRangePushA EXIT into timemory, it will think
+                    // that the roctxRangePushA ENTER is still active when it is in fact
+                    // not. This will cause the wall clock tree to be incorrect.
+                    return;
                 }
             }
         }
@@ -659,7 +666,7 @@ tool_tracing_callback_start(CategoryT, rocprofiler_callback_tracing_record_t rec
 
     if(get_use_timemory())
     {
-        tracing::push_timemory(category::rocm_marker_api{}, _name);
+        tracing::push_timemory(CategoryT{}, _name);
     }
 }
 
@@ -729,7 +736,7 @@ tool_tracing_callback_stop(
 
     if(get_use_timemory())
     {
-        tracing::pop_timemory(category::rocm_marker_api{}, _name);
+        tracing::pop_timemory(CategoryT{}, _name);
     }
 
     if(get_use_perfetto())
@@ -1069,7 +1076,7 @@ ompt_tracing_callback_start(rocprofiler_callback_tracing_record_t record,
 
     if(get_use_timemory())
     {
-        tracing::push_timemory(category::rocm_marker_api{}, _name);
+        tracing::push_timemory(category::rocm_ompt_api{}, _name);
     }
 
     if(get_use_perfetto())
@@ -1115,7 +1122,7 @@ ompt_tracing_callback_stop(
 
     if(get_use_timemory())
     {
-        tracing::pop_timemory(category::rocm_marker_api{}, _name);
+        tracing::pop_timemory(category::rocm_ompt_api{}, _name);
     }
 
     if(get_use_perfetto())


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Closes 569092

When doing this ticket, I also noticed the program would SEGFAULT when `ROCPROFSYS_ROCM_DOMAINS=roctx` even though the docs tell us we can do this. Went ahead and fixed that.

Also noticed that timemory push/pop in `rocprofiler-sdk.cpp` was always using `category::rocm_marker_api` instead of `CategoryT`. Fixed that as well.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
 - Change a `break` to `return` in `tool_tracing_callback_start`. (See comment I left)
 - Timemory push/pop now uses `CategoryT` as opposed to `category::rocm_marker_api`
 - Added `roctx` as a valid domain choice. This avoids the SEGFAULT.

**Note**: This change means that we will NOT see `roctxRangePop` in the wall clock anymore. However, this shouldn't have been true in the first place considering perfetto output does not show this. 

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Checked against openmp-vv-host, roctx and custom marker program.

## Test Result
With changes, wall_clock tree is now as it should be. HIP, HSA and OpenMP calls are also present in the wall clock. 
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
