### PR TITLE
clr: Bump _amdgpu_r_debug.r_version to 11

### DIFF
--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -842,7 +842,7 @@ Device::~Device() {
 extern const char* SchedulerSourceCode;
 extern const char* SchedulerSourceCode20;
 
-constexpr int TrapHandlerABIVersion = 10;
+constexpr int TrapHandlerABIVersion = 11;
 extern const char* TrapHandlerCode;
 
 // ================================================================================================


### PR DESCRIPTION
## Motivation

This patch bumps the CRL's _amdgpu_r_debug.r_version to 11 to follow ROCr.  This is also used by the debugger as a baseline to ensure simulated AQL queues are supported.

## Technical Details

Bump the ABI version number exposed to the debugger to match ROCr and give a baseline for debugging support on Winodws.

## Test Plan

ROCgdb on windows debugger tests.

## Test Result

No regression identified.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
