### PR TITLE
[rocprofiler-compute] Enable running tests from installation only for TheRock setup

### DIFF
--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -684,6 +684,12 @@ if(INSTALL_TESTS)
         PATTERN "__pycache__" EXCLUDE
     )
     install(
+        DIRECTORY tests/workloads
+        DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}/tests
+        COMPONENT tests
+        PATTERN "__pycache__" EXCLUDE
+    )
+    install(
         PROGRAMS
             tests/vcopy
             tests/vmem

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -234,6 +234,21 @@ set(PYTEST_NUMPROCS_ANALYSIS
 message(STATUS "Pytest CPU threadcount: ${PYTEST_NUMPROCS_ANALYSIS}")
 
 # ---------------------------
+# add tests
+# ---------------------------
+
+option(
+    TEST_FROM_INSTALL
+    "Test from install directory rather than from source directory"
+    OFF
+)
+if(TEST_FROM_INSTALL)
+    set(WORKING_DIR_OPTION "")
+else()
+    set(WORKING_DIR_OPTION WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+endif()
+
+# ---------------------------
 # profile mode tests
 # ---------------------------
 
@@ -242,8 +257,7 @@ add_test(
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -m kernel_execution
         --junitxml=tests/test_profile_kernel_execution.xml ${COV_OPTION}
-        ${PROJECT_SOURCE_DIR}/tests/test_profile_general.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
@@ -251,48 +265,42 @@ add_test(
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -m dispatch
         --junitxml=tests/test_profile_dispatch.xml ${COV_OPTION}
-        ${PROJECT_SOURCE_DIR}/tests/test_profile_general.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
     NAME test_profile_mem
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -m mem --junitxml=tests/test_profile_mem.xml
-        ${COV_OPTION} ${PROJECT_SOURCE_DIR}/tests/test_profile_general.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        ${COV_OPTION} tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
     NAME test_profile_join
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -m join --junitxml=tests/test_profile_join.xml
-        ${COV_OPTION} ${PROJECT_SOURCE_DIR}/tests/test_profile_general.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        ${COV_OPTION} tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
     NAME test_profile_sort
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -m sort --junitxml=tests/test_profile_sort.xml
-        ${COV_OPTION} ${PROJECT_SOURCE_DIR}/tests/test_profile_general.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        ${COV_OPTION} tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
     NAME test_profile_misc
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -m misc --junitxml=tests/test_profile_misc.xml
-        ${COV_OPTION} ${PROJECT_SOURCE_DIR}/tests/test_profile_general.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        ${COV_OPTION} tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
     NAME test_profile_path
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -m path --junitxml=tests/test_profile_path.xml
-        ${COV_OPTION} ${PROJECT_SOURCE_DIR}/tests/test_profile_general.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        ${COV_OPTION} tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
@@ -300,8 +308,7 @@ add_test(
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -m roofline_1
         --junitxml=tests/test_profile_roofline_1.xml ${COV_OPTION}
-        ${PROJECT_SOURCE_DIR}/tests/test_profile_general.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
@@ -309,8 +316,7 @@ add_test(
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -m roofline_2
         --junitxml=tests/test_profile_roofline_2.xml ${COV_OPTION}
-        ${PROJECT_SOURCE_DIR}/tests/test_profile_general.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
@@ -318,8 +324,7 @@ add_test(
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -m section
         --junitxml=tests/test_profile_section.xml ${COV_OPTION}
-        ${PROJECT_SOURCE_DIR}/tests/test_profile_general.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
@@ -327,8 +332,7 @@ add_test(
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -s -m pc_sampling
         --junitxml=tests/test_profile_pc_sampling.xml ${COV_OPTION}
-        ${PROJECT_SOURCE_DIR}/tests/test_profile_general.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
@@ -336,8 +340,7 @@ add_test(
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -m sets_func
         --junitxml=tests/test_profile_sets_func.xml ${COV_OPTION}
-        ${PROJECT_SOURCE_DIR}/tests/test_profile_general.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
@@ -345,8 +348,7 @@ add_test(
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -s -m live_attach_detach
         --junitxml=tests/test_profile_live_attach_detach.xml ${COV_OPTION}
-        ${PROJECT_SOURCE_DIR}/tests/test_profile_general.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
@@ -354,8 +356,7 @@ add_test(
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -s -m iteration_multiplexing
         --junitxml=tests/test_profile_iteration_multiplexing.xml ${COV_OPTION}
-        ${PROJECT_SOURCE_DIR}/tests/test_profile_general.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 set_tests_properties(
@@ -385,8 +386,7 @@ add_test(
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -n ${PYTEST_NUMPROCS_ANALYSIS} --verbose
         --junitxml=tests/test_analyze_commands.xml ${COV_OPTION}
-        ${PROJECT_SOURCE_DIR}/tests/test_analyze_commands.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        tests/test_analyze_commands.py ${WORKING_DIR_OPTION}
 )
 
 # ---------------------------
@@ -398,8 +398,7 @@ add_test(
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -n ${PYTEST_NUMPROCS}
         --junitxml=tests/test_analyze_workloads.xml ${COV_OPTION}
-        ${PROJECT_SOURCE_DIR}/tests/test_analyze_workloads.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        tests/test_analyze_workloads.py ${WORKING_DIR_OPTION}
 )
 
 # ---------------------------
@@ -411,8 +410,7 @@ add_test(
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -m L1_cache
         --junitxml=tests/test_L1_cache_counters.xml ${COV_OPTION}
-        ${PROJECT_SOURCE_DIR}/tests/test_TCP_counters.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        tests/test_TCP_counters.py ${WORKING_DIR_OPTION}
 )
 
 # ---------------------------
@@ -424,8 +422,7 @@ add_test(
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -m num_xcds_spec_class
         --junitxml=tests/test_num_xcds_spec_class.xml ${COV_OPTION}
-        ${PROJECT_SOURCE_DIR}/tests/test_gpu_specs.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        tests/test_gpu_specs.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
@@ -433,8 +430,7 @@ add_test(
     COMMAND
         ${Python3_EXECUTABLE} -m pytest -m num_xcds_cli_output
         --junitxml=tests/test_num_xcds_cli_output.xml ${COV_OPTION}
-        ${PROJECT_SOURCE_DIR}/tests/test_gpu_specs.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        tests/test_gpu_specs.py ${WORKING_DIR_OPTION}
 )
 
 # ---------------------------
@@ -445,8 +441,7 @@ add_test(
     NAME test_utils
     COMMAND
         ${Python3_EXECUTABLE} -m pytest --junitxml=tests/test_utils.xml ${COV_OPTION}
-        ${PROJECT_SOURCE_DIR}/tests/test_utils.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        tests/test_utils.py ${WORKING_DIR_OPTION}
 )
 
 # -----------------------------------
@@ -457,8 +452,7 @@ add_test(
     NAME test_autogen_config
     COMMAND
         ${Python3_EXECUTABLE} -m pytest --junitxml=tests/test_autogen_config.xml
-        ${COV_OPTION} ${PROJECT_SOURCE_DIR}/tests/test_autogen_config.py
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        ${COV_OPTION} tests/test_autogen_config.py ${WORKING_DIR_OPTION}
 )
 
 # -----------------------------------
@@ -491,8 +485,9 @@ if(${ENABLE_COVERAGE})
 
     add_test(
         NAME generate_coverage_report
-        COMMAND ${Python3_EXECUTABLE} -m coverage xml -o ${CMAKE_BINARY_DIR}/coverage.xml
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        COMMAND
+            ${Python3_EXECUTABLE} -m coverage xml -o ${CMAKE_BINARY_DIR}/coverage.xml
+            ${WORKING_DIR_OPTION}
     )
 
     set_tests_properties(
@@ -687,6 +682,18 @@ if(INSTALL_TESTS)
         FILES_MATCHING
         PATTERN "*.py"
         PATTERN "__pycache__" EXCLUDE
+    )
+    install(
+        PROGRAMS
+            tests/vcopy
+            tests/vmem
+            tests/vrandom_access
+            tests/vsequential_access
+            tests/occupancy
+            tests/hip_dynamic_shared
+            tests/mat_mul_max
+        DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}/tests
+        COMPONENT tests
     )
     install(
         FILES requirements-test.txt

--- a/projects/rocprofiler-compute/tests/conftest.py
+++ b/projects/rocprofiler-compute/tests/conftest.py
@@ -37,9 +37,14 @@ SRC = os.path.join(ROOT, "src")
 if SRC not in sys.path:
     sys.path.insert(0, SRC)
 
-rocprof_compute = SourceFileLoader(
-    "rocprof-compute", "src/rocprof-compute"
-).load_module()
+try:
+    rocprof_compute = SourceFileLoader(
+        "rocprof-compute", "src/rocprof-compute"
+    ).load_module()
+except Exception:
+    rocprof_compute = SourceFileLoader(
+        "rocprof-compute", "rocprof-compute"
+    ).load_module()
 
 
 def pytest_addoption(parser):

--- a/projects/rocprofiler-compute/tests/conftest.py
+++ b/projects/rocprofiler-compute/tests/conftest.py
@@ -121,7 +121,7 @@ def binary_handler_profile_rocprof_compute(request):
             return process.returncode
         else:
             baseline_opts = [
-                "install/bin/rocprof-compute",
+                "rocprof-compute",
                 "profile",
                 "-n",
                 app_name,

--- a/projects/rocprofiler-compute/tests/test_TCP_counters.py
+++ b/projects/rocprofiler-compute/tests/test_TCP_counters.py
@@ -26,15 +26,10 @@
 import csv
 import re
 import subprocess
-from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
 import pytest
 import test_utils
-
-rocprof_compute = SourceFileLoader(
-    "rocprof-compute", "src/rocprof-compute"
-).load_module()
 
 config = {}
 config["vseq"] = ["./tests/vsequential_access"]

--- a/projects/rocprofiler-compute/tests/test_autogen_config.py
+++ b/projects/rocprofiler-compute/tests/test_autogen_config.py
@@ -26,9 +26,16 @@
 import hashlib
 from pathlib import Path
 
+import pytest
 import yaml
 
 
+@pytest.mark.skip(
+    reason=(
+        "TODO: Skip this test until we use "
+        "tools/config_management/.config.hashes.json for testing"
+    )
+)
 def test_modification_time():
     # Ensure hash map consistency
     hash_path = Path("tools/autogen_hash.yaml")

--- a/projects/rocprofiler-compute/tests/test_gpu_specs.py
+++ b/projects/rocprofiler-compute/tests/test_gpu_specs.py
@@ -30,7 +30,10 @@ from unittest.mock import patch
 
 import pytest
 
-from src.utils.specs import generate_machine_specs
+try:
+    from src.utils.specs import generate_machine_specs
+except Exception:
+    from utils.specs import generate_machine_specs
 
 # NOTE: Only testing gfx942 for now.
 GFX942_CHIP_IDS_TO_NUM_XCDS = {

--- a/projects/rocprofiler-compute/tests/test_gpu_specs.py
+++ b/projects/rocprofiler-compute/tests/test_gpu_specs.py
@@ -157,12 +157,20 @@ def test_num_xcds_cli_output():
     num_xcds = get_num_xcds()
 
     # 2. Run rocprof-compute -s and grab rocprof-compute num_xcd
-    proc = subprocess.run(
-        ["src/rocprof-compute", "-s"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    try:
+        proc = subprocess.run(
+            ["src/rocprof-compute", "-s"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except Exception:
+        proc = subprocess.run(
+            ["rocprof-compute", "-s"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
     assert proc.returncode == 0, (
         f"Non-zero exit ({proc.returncode}), stderr:\n{proc.stderr}"
     )

--- a/projects/rocprofiler-compute/tests/test_gpu_specs.py
+++ b/projects/rocprofiler-compute/tests/test_gpu_specs.py
@@ -26,16 +26,11 @@
 import re
 import subprocess
 import tempfile
-from importlib.machinery import SourceFileLoader
 from unittest.mock import patch
 
 import pytest
 
 from src.utils.specs import generate_machine_specs
-
-rocprof_compute = SourceFileLoader(
-    "rocprof-compute", "src/rocprof-compute"
-).load_module()
 
 # NOTE: Only testing gfx942 for now.
 GFX942_CHIP_IDS_TO_NUM_XCDS = {

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -72,7 +72,7 @@ config["METRIC_LOGGING"] = False
 num_kernels = 3
 num_devices = 1
 
-attach_detach_interval_msec_no_delay = 10000
+attach_detach_interval_msec_no_delay = 1000
 attach_detach_interval_msec_with_delay = 60000
 DEFAULT_ABS_DIFF = 15
 DEFAULT_REL_DIFF = 50


### PR DESCRIPTION
## Motivation

* TheRock setup requires ability to run tests from install folder only without any dependence on project source folder.

* New cmake option -DTEST_FROM_INSTALL=ON can be provided to support this use case.

* NOTE: If this option is provided it will not be possible to run tests from build folder since changing directory to project source will be disabled and the build folder does not contain the source files.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

* Use cmake option -DTEST_FROM_INSTALL=ON to enable running tests from installation folder only
    * It is not possible to run tests from build folder in this case
    * This option prevents changing working directory to source folder

* Fix SourceFileLoader to import rocprof-compute main module correctly

* Install sample executables in the test folder

* Skip autogen. config. test and add a TODO task for re-design of this test

* Add flexible import of source code in test_gpu_specs.py

* Update cmake to install tests/workloads folder when INSTALL_TESTS=ON

* Reduce workload duration for live attach detach from 10 seconds to 1 second

* PR to add rocprofiler-compute tests to TheRock setup https://github.com/ROCm/TheRock/pull/2300

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Run tests from installation folder and ensure pass

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Tests passing

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
