### PR TITLE
SWDEV-569450 - Fix Unit_hipStreamBeginCaptureToGraph_CapturePartialInThreads

### DIFF
--- a/projects/clr/hipamd/src/hip_event.cpp
+++ b/projects/clr/hipamd/src/hip_event.cpp
@@ -396,6 +396,13 @@ hipError_t hipEventRecord_common(hipEvent_t event, hipStream_t stream, unsigned 
   hip::Event* e = reinterpret_cast<hip::Event*>(event);
   hip::Stream* s = reinterpret_cast<hip::Stream*>(stream);
   hip::Stream* hip_stream = hip::getStream(stream);
+  if (hipStream_t lastCaptureStream = e->GetCaptureStream()) {
+    if (hip::isValid(lastCaptureStream)) {
+      if ((lastCaptureStream != nullptr) && (lastCaptureStream != hipStreamLegacy)) {
+        reinterpret_cast<hip::Stream*>(e->GetCaptureStream())->EraseCaptureEvent(event);
+      }
+    }
+  }
   e->SetCaptureStream(stream);
   if ((stream != nullptr && stream != hipStreamLegacy) &&
       (s->GetCaptureStatus() == hipStreamCaptureStatusActive)) {


### PR DESCRIPTION
## Motivation
This PR fixes the Unit_hipStreamBeginCaptureToGraph_CapturePartialInThreads test by ensuring that when an event is recorded on a new stream during graph capture, it is properly removed from the previous stream's capture event list.
Otherwise when the event is destroyed, it can lead to a dangled event reference in the original stream and cause a segfault.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Added logic to erase the event from the previous capture stream before setting a new capture stream
Prevents duplicate event tracking across multiple streams during graph capture operations.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Unit_hipStreamBeginCaptureToGraph_CapturePartialInThreads should pass
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Unit_hipStreamBeginCaptureToGraph_CapturePartialInThreads passes and does not show any warning in valgrind
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
