### PR TITLE
CP 7.2.1 rocr: SVMPrefetch to a particular numa node

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -55,6 +55,7 @@
 #include <sys/mman.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <numaif.h> //for move_pages
 #else
 #define debug_warning(__VA_ARGS__)
 #endif
@@ -3351,12 +3352,30 @@ hsa_status_t Runtime::SvmPrefetch(void* ptr, size_t size, hsa_agent_t agent,
       return false;
     }
 
-    HSA_SVM_ATTRIBUTE attrib;
-    attrib.type = HSA_SVM_ATTR_PREFETCH_LOC;
-    attrib.value = op->node_id;
-    HSAKMT_STATUS error = HSAKMT_CALL(hsaKmtSVMSetAttr(op->base, op->size, 1, &attrib));
-    assert(error == HSAKMT_STATUS_SUCCESS && "KFD Prefetch failed.");
+    Agent* dest = Runtime::runtime_singleton_->GetSVMPrefetchAgent(op->base, op->size);
 
+    if (dest == nullptr || dest->device_type() == Agent::kAmdGpuDevice) {
+      // Prefetch location is not valid for move_pages usecase.
+      HSA_SVM_ATTRIBUTE attrib;
+      attrib.type = HSA_SVM_ATTR_PREFETCH_LOC;
+      attrib.value = op->node_id;
+      HSAKMT_STATUS error = HSAKMT_CALL(hsaKmtSVMSetAttr(op->base, op->size, 1, &attrib));
+      assert(error == HSAKMT_STATUS_SUCCESS && "KFD Prefetch failed.");
+    } else {
+      // Migrate pages to the requested CPU NUMA node
+      void* base_ptr = op->base;
+      size_t num_pages = op->size / 4096;
+      std::vector<void*> pages(num_pages);
+      for (size_t i = 0; i < num_pages; ++i)
+          pages[i] = static_cast<uint8_t*>(base_ptr) + i * 4096;
+      std::vector<int> nodes(num_pages, op->node_id);
+      std::vector<int> status(num_pages, -1);
+
+      int ret = move_pages(0, num_pages, pages.data(), nodes.data(), status.data(), 0);
+      assert(ret == 0 && "move_pages failed");
+    }
+
+    
     removePrefetchRanges(op);
 
     if (op->completion.handle != 0) Signal::Convert(op->completion)->SubRelaxed(1);


### PR DESCRIPTION
## Motivation
ROCr:
In order for hipMemPrefetchAysnc_v2() api to work, we need rocr to migrates the ranges of pages requested to the particular NUMA node in question, via move_pages().

HIP/clr:
>Fix: We should be passing the NUMA node id which is later indexed into the cpu_agent array in getCpuAgent() correctly.
>This allows the migration of pages to the correct NUMA nodes in ROCr.