### PR TITLE
SWDEV-569101 - Resolve deadlock caused by graph packet batching when profiling is enabled

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -440,7 +440,8 @@ hsa_signal_t VirtualGPU::HwQueueTracker::ActiveSignal(hsa_signal_value_t init_va
   auto temp_id = (current_id_ + 2) % signal_list_.size();
 
   // If GPU is still busy with processing, then add more signals to avoid more frequent stalls
-  if (Hsa::signal_load_relaxed(signal_list_[temp_id]->signal_) > 0) {
+  if ((Hsa::signal_load_relaxed(signal_list_[temp_id]->signal_) > 0) ||
+      (signal_list_[temp_id]->ts_ == ts)) {
     std::unique_ptr<ProfilingSignal> signal(new ProfilingSignal());
     if ((signal != nullptr) && CreateSignal(signal.get())) {
       // Find valid new index


### PR DESCRIPTION
## Motivation
This PR fixes a deadlock in ActiveSignal when profiling and graph packet batching is enabled, that is introduced after https://github.com/ROCm/rocm-systems/pull/1354. 
## Technical Details
Added a timestamp check to the signal insertion logic. Previously, a new profiling signal was only created when the existing signal was still active (signal > 0). Added a second condition signal_list_[temp_id]->ts_ == ts to handle the case where the slot is already associated with the current timestamp.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Tested with the job from https://ontrack-internal.amd.com/browse/SWDEV-569101 and verified that it resolves the hang against with various combinations of ROC_SIGNAL_POOL_SIZE and DEBUG_HIP_GRAPH_BATCH_SIZE.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
The hang reported in  https://ontrack-internal.amd.com/browse/SWDEV-569101 is now resolved.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
