### PR TITLE
[rocprofv3] Change file output in tool_detach to occur on a separate thread so tool_detach will return immediately

### DIFF
--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-process-attachment.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-process-attachment.rst
@@ -114,6 +114,7 @@ Reattaching to the same process
 The dynamic process attachment functionality supports reattachment, which can be used to attach multiple times to the same PID over a process's lifetime. Give the same PID to ``rocprofv3`` to reattach.
 
 There are some restrictions on what options can change when reattaching.  Typically, tracing, PC sampling, ATT, counter collection, and other options that change what data will be collected cannot be changed. ``rocprofv3`` will throw a ``RuntimeError`` if it detects a configuration change that is not supported.
+Furthermore, output file generation from the previous attachment must be finished. Otherwise, errors or data corruption might occur after the profiler is reattached.
 
 .. class:: details
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -127,8 +127,7 @@ rocprofv3_error_signal_handler(int signo, siginfo_t*, void*);
 namespace
 {
 // Thread for safe cleanup output generation
-std::unique_ptr<std::thread> cleanup_thread = nullptr;
-std::mutex                   cleanup_thread_mutex;
+auto output_generation_thread = common::Synchronized<std::unique_ptr<std::thread>>{};
 
 using sigaction_t      = struct sigaction;
 using signal_func_t    = sighandler_t (*)(int signum, sighandler_t handler);
@@ -1868,12 +1867,28 @@ get_tracing_callbacks()
     return tracing_callbacks_t{use_real_callbacks};
 }
 
+void reset_output_thread(auto& thread_ptr)
+{
+    ROCP_INFO << "finalize output thread started...";
+    if(thread_ptr)
+    {
+        if(thread_ptr->joinable()) thread_ptr->join();
+        thread_ptr.reset();
+    }
+    ROCP_INFO << "finalize output thread exiting...";
+}
+
 int
 tool_attach(rocprofiler_client_detach_t /*detach_func*/,
             rocprofiler_context_id_t* context_ids,
             uint64_t                  context_ids_length,
             void* /*tool_data*/)
 {
+    // reset any existing output thread from prior tool usage
+    ::output_generation_thread.wlock([](auto& thread_ptr) {
+        reset_output_thread(thread_ptr);
+    });
+
     // save the existing config for comparison
     auto original_config = tool::get_config();
 
@@ -2847,16 +2862,10 @@ tool_detach(void* /*tool_data*/)
 
     // Launch generate output in a separate thread for safe cleanup
     // This allows tool_detach to return immediately without waiting
-    {
-        std::lock_guard<std::mutex> lock(::cleanup_thread_mutex);
-        if(::cleanup_thread)
-        {
-            if(::cleanup_thread->joinable()) ::cleanup_thread->join();
-            ::cleanup_thread.reset();
-        }
-        ::cleanup_thread =
-            std::make_unique<std::thread>([]() { generate_output(cleanup_mode::reset); });
-    }
+    ::output_generation_thread.wlock([](auto& thread_ptr) {
+        reset_output_thread(thread_ptr);
+        thread_ptr = std::make_unique<std::thread>([]() { generate_output(cleanup_mode::reset); });
+    });
 }
 
 void
@@ -2870,14 +2879,9 @@ tool_fini(void* /*tool_data*/)
     client_finalizer  = nullptr;
 
     // Join the cleanup thread if it exists and is active
-    {
-        std::lock_guard<std::mutex> lock(::cleanup_thread_mutex);
-        if(::cleanup_thread)
-        {
-            if(::cleanup_thread->joinable()) ::cleanup_thread->join();
-            ::cleanup_thread.reset();
-        }
-    }
+    ::output_generation_thread.wlock([](auto& thread_ptr) {
+        reset_output_thread(thread_ptr);
+    });
 
     auto _fini_timer = common::simple_timer{"[rocprofv3] tool finalization"};
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2841,7 +2841,7 @@ tool_detach(void* /*tool_data*/)
     if(tool_metadata->process_end_ns == 0)
         rocprofiler_get_timestamp(&(tool_metadata->process_end_ns));
 
-    // Launch generate output in a seperate thread and detach it
+    // Launch generate output in a separate thread and detach it
     // This allows tool_detach to return immediately without waiting
     std::thread([]() { generate_output(cleanup_mode::reset); }).detach();
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -1867,7 +1867,8 @@ get_tracing_callbacks()
     return tracing_callbacks_t{use_real_callbacks};
 }
 
-void reset_output_thread(auto& thread_ptr)
+void
+reset_output_thread(std::unique_ptr<std::thread>& thread_ptr)
 {
     ROCP_INFO << "finalize output thread started...";
     if(thread_ptr)
@@ -1885,9 +1886,7 @@ tool_attach(rocprofiler_client_detach_t /*detach_func*/,
             void* /*tool_data*/)
 {
     // reset any existing output thread from prior tool usage
-    ::output_generation_thread.wlock([](auto& thread_ptr) {
-        reset_output_thread(thread_ptr);
-    });
+    ::output_generation_thread.wlock([](auto& thread_ptr) { reset_output_thread(thread_ptr); });
 
     // save the existing config for comparison
     auto original_config = tool::get_config();
@@ -2879,9 +2878,7 @@ tool_fini(void* /*tool_data*/)
     client_finalizer  = nullptr;
 
     // Join the cleanup thread if it exists and is active
-    ::output_generation_thread.wlock([](auto& thread_ptr) {
-        reset_output_thread(thread_ptr);
-    });
+    ::output_generation_thread.wlock([](auto& thread_ptr) { reset_output_thread(thread_ptr); });
 
     auto _fini_timer = common::simple_timer{"[rocprofv3] tool finalization"};
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2841,7 +2841,9 @@ tool_detach(void* /*tool_data*/)
     if(tool_metadata->process_end_ns == 0)
         rocprofiler_get_timestamp(&(tool_metadata->process_end_ns));
 
-    generate_output(cleanup_mode::reset);
+    // Launch generate output in a seperate thread and detach it
+    // This allows tool_detach to return immediately without waiting
+    std::thread([]() { generate_output(cleanup_mode::reset); }).detach();
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -126,6 +126,10 @@ rocprofv3_error_signal_handler(int signo, siginfo_t*, void*);
 
 namespace
 {
+// Thread for safe cleanup output generation
+std::unique_ptr<std::thread> cleanup_thread = nullptr;
+std::mutex                   cleanup_thread_mutex;
+
 using sigaction_t      = struct sigaction;
 using signal_func_t    = sighandler_t (*)(int signum, sighandler_t handler);
 using sigaction_func_t = int (*)(int signum,
@@ -2841,9 +2845,18 @@ tool_detach(void* /*tool_data*/)
     if(tool_metadata->process_end_ns == 0)
         rocprofiler_get_timestamp(&(tool_metadata->process_end_ns));
 
-    // Launch generate output in a separate thread and detach it
+    // Launch generate output in a separate thread for safe cleanup
     // This allows tool_detach to return immediately without waiting
-    std::thread([]() { generate_output(cleanup_mode::reset); }).detach();
+    {
+        std::lock_guard<std::mutex> lock(::cleanup_thread_mutex);
+        if(::cleanup_thread)
+        {
+            if(::cleanup_thread->joinable()) ::cleanup_thread->join();
+            ::cleanup_thread.reset();
+        }
+        ::cleanup_thread =
+            std::make_unique<std::thread>([]() { generate_output(cleanup_mode::reset); });
+    }
 }
 
 void
@@ -2855,6 +2868,16 @@ tool_fini(void* /*tool_data*/)
 
     client_identifier = nullptr;
     client_finalizer  = nullptr;
+
+    // Join the cleanup thread if it exists and is active
+    {
+        std::lock_guard<std::mutex> lock(::cleanup_thread_mutex);
+        if(::cleanup_thread)
+        {
+            if(::cleanup_thread->joinable()) ::cleanup_thread->join();
+            ::cleanup_thread.reset();
+        }
+    }
 
     auto _fini_timer = common::simple_timer{"[rocprofv3] tool finalization"};
 


### PR DESCRIPTION
## Motivation

Customer made a code change suggestion where file output generation in `tool_detach` is changed to occur on a separate, detached thread. This allows `tool_detach` to immediately return, fixing a hang/termination issue when profiling large vLLMs like DeepSeek where detaching would cause the workload to terminate due to how long it was taking to generate the requested output files. 

## Technical Details

The function `generate_output` is now run on a detached thread after `tool_detach` is called.

## Test Plan

Existing attach/detach tests should pass.

## Test Result


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
