### PR TITLE
Add section for JIRA ID for integration with JIRA cloud

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Motivation
+
+<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
+
+## Technical Details
+
+<!-- Explain the changes along with any relevant GitHub links. -->
+
+## JIRA ID
+
+<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
+<!-- Do not post any JIRA links here. -->
+
+## Test Plan
+
+<!-- Explain any relevant testing done to verify this PR. -->
+
+## Test Result
+
+<!-- Briefly summarize test outcomes. -->
+
+## Submission Checklist
+
+- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


### PR DESCRIPTION
## Motivation

Add section for JIRA ID for integration with JIRA cloud

This is coming from https://github.com/ROCm/.github/pull/26 where this change was approved.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

This PR overrides the default PR template across ROCm organization by adding a section for JIRA ID.

This change requires `Autolink references` to be disabled for JIRA IDs to prevent expanding JIRA ID (e.g. SWDEV-12345 to a url such as <jira_url>/SWDEV-12345)

Confirmed offline with repository admins that `Autolink references` is disabled.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
