### PR TITLE
Run pre-commit's whitespace related hooks on projects/rocminfo

### DIFF
--- a/projects/rocminfo/.github/ISSUE_TEMPLATE/issue_report.yml
+++ b/projects/rocminfo/.github/ISSUE_TEMPLATE/issue_report.yml
@@ -14,7 +14,7 @@ body:
         echo "OS:" && cat /etc/os-release | grep -E "^(NAME=|VERSION=)";
         echo "CPU: " && cat /proc/cpuinfo | grep "model name" | sort --unique;
         echo "GPU:" && /opt/rocm/bin/rocminfo | grep -E "^\s*(Name|Marketing Name)";
-        
+
       Windows:
          (Get-WmiObject Win32_OperatingSystem).Version
          (Get-WmiObject win32_Processor).Name
@@ -163,7 +163,7 @@ body:
     description: (Optional) Detailed steps to reproduce the issue.
   validations:
     required: false
-    
+
 - type: textarea
   attributes:
     label: (Optional for Linux users) Output of /opt/rocm/bin/rocminfo --support

--- a/projects/rocminfo/.github/workflows/rocm_ci_caller.yml
+++ b/projects/rocminfo/.github/workflows/rocm_ci_caller.yml
@@ -1,25 +1,25 @@
 name: ROCm CI Caller
-on: 
+on:
   # Commenting below to avoid re-runs of amd smi for trivial rebases
-  pull_request:  
-    branches: [amd-staging, amd-mainline, release/rocm-rel-*]  
-    types: [opened, reopened, synchronize]  
-  push:  
-    branches: [amd-mainline]  
+  pull_request:
+    branches: [amd-staging, amd-mainline, release/rocm-rel-*]
+    types: [opened, reopened, synchronize]
+  push:
+    branches: [amd-mainline]
   workflow_dispatch:
-  issue_comment:  
+  issue_comment:
     types: [created]
-  
-jobs:  
-  call-workflow:  
+
+jobs:
+  call-workflow:
     if: ${{ github.event_name != 'issue_comment' || github.event.comment.body == '!verify' }}
-    uses: AMD-ROCm-Internal/rocm_ci_infra/.github/workflows/rocm_ci.yml@mainline 
-    secrets: inherit  
-    with:  
-      input_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}  
-      input_pr_num: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || 0 }}  
-      input_pr_url: ${{ github.event_name == 'pull_request' && github.event.pull_request.html_url || '' }}  
-      input_pr_title: ${{ github.event_name == 'pull_request' && github.event.pull_request.title || '' }}  
-      repository_name: ${{ github.repository }}  
-      base_ref: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref }} 
+    uses: AMD-ROCm-Internal/rocm_ci_infra/.github/workflows/rocm_ci.yml@mainline
+    secrets: inherit
+    with:
+      input_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      input_pr_num: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || 0 }}
+      input_pr_url: ${{ github.event_name == 'pull_request' && github.event.pull_request.html_url || '' }}
+      input_pr_title: ${{ github.event_name == 'pull_request' && github.event.pull_request.title || '' }}
+      repository_name: ${{ github.repository }}
+      base_ref: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref }}
       trigger_event_type: ${{ github.event_name }}

--- a/projects/rocminfo/CONTRIBUTING.md
+++ b/projects/rocminfo/CONTRIBUTING.md
@@ -31,7 +31,7 @@ The goal of `rocminfo` is to provide the user with all the system information th
 C++ code changes should conform to the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
 
 ## Pull Request Guidelines
-When you create a pull request, you should target the `TODO ADD THIS` branch.  
+When you create a pull request, you should target the `TODO ADD THIS` branch.
 
 By creating a pull request, you agree to the statements made in the [code license](#code-license) section. Your pull request should target the default branch. Our current default branch is the `TODO ADD THIS` branch, which serves as our integration branch.
 

--- a/projects/rocminfo/docs/how-to/use-rocm-agent-enumerator.rst
+++ b/projects/rocminfo/docs/how-to/use-rocm-agent-enumerator.rst
@@ -16,7 +16,7 @@ See the following example output of the rocm_agent_enumerator command on a syste
     gfx941
 
 
-.. Note:: 
+.. Note::
 
 The gfx000 represents the CPU agent.
 

--- a/projects/rocminfo/docs/how-to/use-rocminfo.rst
+++ b/projects/rocminfo/docs/how-to/use-rocminfo.rst
@@ -19,7 +19,7 @@ See the following example output of the ROCmInfo command on a system with MI300X
 
 .. code-block::
 
-        HSA System Attributes 
+        HSA System Attributes
         =====================
         Runtime Version:         1.1
         Runtime Ext Version:     1.6
@@ -175,7 +175,7 @@ See the following example output of the ROCmInfo command on a system with MI300X
               Default Rounding Mode:   NEAR
               Fast f16:                TRUE
               Workgroup Max Size:      1024(0x400
-        
+
               Workgroup Max Size per Dimension:
                 x                        1024(0x400)
                 y                        1024(0x400)
@@ -185,6 +185,6 @@ See the following example output of the ROCmInfo command on a system with MI300X
                 x                        4294967295(0xffffffff)
                 y                        4294967295(0xffffffff)
                 z                        4294967295(0xffffffff)
-        
+
         *** Done ***
 

--- a/projects/rocminfo/docs/index.rst
+++ b/projects/rocminfo/docs/index.rst
@@ -16,13 +16,13 @@ You can access ROCmInfo code at `GitHub. <https://github.com/ROCm/rocminfo>`_
   .. grid-item-card:: Build
 
        * :doc:`ROCmInfo installation <./install/build>`
- 
+
 
   .. grid-item-card:: How to
 
     * :doc:`Use ROCmInfo <how-to/use-rocminfo>`
     * :doc:`Use ROCm agent enumerator <how-to/use-rocm-agent-enumerator>`
-    
+
 
 
 To contribute to the documentation, refer to

--- a/projects/rocminfo/docs/install/build.rst
+++ b/projects/rocminfo/docs/install/build.rst
@@ -16,17 +16,17 @@ For example,
 .. code-block::
 
     $ git fetch --tags origin
-    
+
     Building from the CMakeLists.txt directory might look like this:
-    
+
     mkdir -p build
-    
+
     cd build
-    
+
     cmake -DCMAKE_PREFIX_PATH=/opt/rocm ..
-    
+
     make
-    
+
     cd ..
 
 Upon a successful build, the binary, ROCmInfo, and the Python script, rocm_agent_enumerator, will be in the `build` folder.

--- a/projects/rocminfo/docs/sphinx/_toc.yml.in
+++ b/projects/rocminfo/docs/sphinx/_toc.yml.in
@@ -5,14 +5,14 @@ subtrees:
 - caption: Install
   entries:
   - file: install/build.rst
-    title: ROCmInfo installation 
+    title: ROCmInfo installation
 
 - caption: How to
   entries:
   - file: how-to/use-rocminfo.rst
     title: Use ROCmInfo
   - file: how-to/use-rocm-agent-enumerator.rst
-    title: Use ROCm agent enumerator 
+    title: Use ROCm agent enumerator
 
 - caption: About
   entries:

--- a/projects/rocminfo/rocm_agent_enumerator
+++ b/projects/rocminfo/rocm_agent_enumerator
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 ################################################################################
-# Copyright © 2025 Advanced Micro Devices, Inc., or its affiliates. 
-#  
+# Copyright © 2025 Advanced Micro Devices, Inc., or its affiliates.
+#
 # SPDX-License-Identifier: MIT
 ################################################################################
 
@@ -258,7 +258,7 @@ def main():
   if len(sys.argv) == 2 and sys.argv[1] == '-name' :
     """ Prints the list of available AMD GCN target names extracted from rocminfo, a tool
         shipped with this script to enumerate GPU agents available on a working ROCm stack."""
-    target_list = readFromROCMINFO(True) 
+    target_list = readFromROCMINFO(True)
   else:
     """Prints the list of available AMD GCN ISA
 


### PR DESCRIPTION
In order for pre-commit to be useful, everything needs to meet a common baseline.