### PR TITLE
Run pre-commit's whitespace related hooks on projects/rocm-smi-lib

### DIFF
--- a/projects/rocm-smi-lib/.github/CONTRIBUTING.md
+++ b/projects/rocm-smi-lib/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to ROCm SMI #
 
-We welcome contributions to ROCm SMI.  
+We welcome contributions to ROCm SMI.
 Please follow these details to help ensure your contributions will be successfully accepted.
 
 ## Issue Discussion ##

--- a/projects/rocm-smi-lib/.github/workflows/rocm_ci_caller.yml
+++ b/projects/rocm-smi-lib/.github/workflows/rocm_ci_caller.yml
@@ -1,25 +1,25 @@
-name: ROCm CI Caller  
-on:  
-  pull_request:  
-    branches: [amd-staging, release/rocm-rel-*, amd-mainline]  
-    types: [opened, reopened, synchronize]  
-  push:  
-    branches: [amd-mainline]  
-  workflow_dispatch:  
-  issue_comment:  
-    types: [created]  
-  
-jobs:  
-  call-workflow:  
-    if: github.event_name != 'issue_comment' ||(github.event_name == 'issue_comment' && github.event.issue.pull_request && (startsWith(github.event.comment.body, '!verify') || startsWith(github.event.comment.body, '!verify release') || startsWith(github.event.comment.body, '!verify retest')))  
+name: ROCm CI Caller
+on:
+  pull_request:
+    branches: [amd-staging, release/rocm-rel-*, amd-mainline]
+    types: [opened, reopened, synchronize]
+  push:
+    branches: [amd-mainline]
+  workflow_dispatch:
+  issue_comment:
+    types: [created]
+
+jobs:
+  call-workflow:
+    if: github.event_name != 'issue_comment' ||(github.event_name == 'issue_comment' && github.event.issue.pull_request && (startsWith(github.event.comment.body, '!verify') || startsWith(github.event.comment.body, '!verify release') || startsWith(github.event.comment.body, '!verify retest')))
     uses: AMD-ROCm-Internal/rocm_ci_infra/.github/workflows/rocm_ci.yml@mainline
-    secrets: inherit  
-    with:  
-      input_sha: ${{github.event_name == 'pull_request' && github.event.pull_request.head.sha || (github.event_name == 'push' && github.sha) || (github.event_name == 'issue_comment' && github.event.issue.pull_request.head.sha) || github.sha}}  
-      input_pr_num: ${{github.event_name == 'pull_request' && github.event.pull_request.number || (github.event_name == 'issue_comment' && github.event.issue.number) || 0}}  
-      input_pr_url: ${{github.event_name == 'pull_request' && github.event.pull_request.html_url || (github.event_name == 'issue_comment' && github.event.issue.pull_request.html_url) || ''}}  
-      input_pr_title: ${{github.event_name == 'pull_request' && github.event.pull_request.title || (github.event_name == 'issue_comment' && github.event.issue.pull_request.title) || ''}}  
-      repository_name: ${{ github.repository }}  
-      base_ref: ${{github.event_name == 'pull_request' && github.event.pull_request.base.ref || (github.event_name == 'issue_comment' && github.event.issue.pull_request.base.ref) || github.ref}}  
-      trigger_event_type: ${{ github.event_name }}  
-      comment_text: ${{ github.event_name == 'issue_comment' && github.event.comment.body || '' }} 
+    secrets: inherit
+    with:
+      input_sha: ${{github.event_name == 'pull_request' && github.event.pull_request.head.sha || (github.event_name == 'push' && github.sha) || (github.event_name == 'issue_comment' && github.event.issue.pull_request.head.sha) || github.sha}}
+      input_pr_num: ${{github.event_name == 'pull_request' && github.event.pull_request.number || (github.event_name == 'issue_comment' && github.event.issue.number) || 0}}
+      input_pr_url: ${{github.event_name == 'pull_request' && github.event.pull_request.html_url || (github.event_name == 'issue_comment' && github.event.issue.pull_request.html_url) || ''}}
+      input_pr_title: ${{github.event_name == 'pull_request' && github.event.pull_request.title || (github.event_name == 'issue_comment' && github.event.issue.pull_request.title) || ''}}
+      repository_name: ${{ github.repository }}
+      base_ref: ${{github.event_name == 'pull_request' && github.event.pull_request.base.ref || (github.event_name == 'issue_comment' && github.event.issue.pull_request.base.ref) || github.ref}}
+      trigger_event_type: ${{ github.event_name }}
+      comment_text: ${{ github.event_name == 'issue_comment' && github.event.comment.body || '' }}

--- a/projects/rocm-smi-lib/CHANGELOG.md
+++ b/projects/rocm-smi-lib/CHANGELOG.md
@@ -8,7 +8,7 @@ Full documentation for rocm_smi_lib is available at [https://rocm.docs.amd.com/]
 
 ### Added
 
-- **Added runtime power management detection and device wake support**.
+- **Added runtime power management detection and device wake support**.  
   - Implemented DRM ioctl-based device wake mechanism to handle GPUs in BACO state.
   - Added `check_runtime_pm_status()` to detect runtime PM suspended devices.
   - Added `wake_device()` to wake devices using DRM ioctl.
@@ -18,14 +18,14 @@ Full documentation for rocm_smi_lib is available at [https://rocm.docs.amd.com/]
 
 ### Added
 
-- **Added support for GPU metrics 1.8**.
-  - Added new fields for `rsmi_gpu_metrics_t` including:
+- **Added support for GPU metrics 1.8**.  
+  - Added new fields for `rsmi_gpu_metrics_t` including:  
     - Adding the following metrics to allow new calculations for violation status:
     - Per XCP metrics `gfx_below_host_limit_ppt_acc[XCP][MAX_XCC]` - GFX Clock Host limit Package Power Tracking violation counts
     - Per XCP metrics `gfx_below_host_limit_thm_acc[XCP][MAX_XCC]` - GFX Clock Host limit Thermal (TVIOL) violation counts
     - Per XCP metrics `gfx_low_utilization_acc[XCP][MAX_XCC]` - violation counts for how did low utilization caused the GPU to be below application clocks.
     - Per XCP metrics `gfx_below_host_limit_total_acc[XCP][MAX_XCC]`- violation counts for how long GPU was held below application clocks any limiter (see above new violation metrics).
-  - Increasing available JPEG engines to 40.
+  - Increasing available JPEG engines to 40.  
   Current ASICs may not support all 40. These will be indicated as UINT16_MAX or N/A in CLI.
 
 ### Changed
@@ -34,7 +34,7 @@ Full documentation for rocm_smi_lib is available at [https://rocm.docs.amd.com/]
 
 ### Removed
 
-- **Removed backwards compatibility `rsmi_dev_gpu_metrics_info_get()`'s `jpeg_activity` or `vcn_activity` fields: use `xcp_stats.jpeg_busy` or `xcp_stats.vcn_busy`**
+- **Removed backwards compatibility `rsmi_dev_gpu_metrics_info_get()`'s `jpeg_activity` or `vcn_activity` fields: use `xcp_stats.jpeg_busy` or `xcp_stats.vcn_busy`**  
   - Backwards compability is removed for `jpeg_activity` and `vcn_activity` fields, if the `jpeg_busy` or `vcn_busy` field is available.
     - <i>Reasons for this change</i>:
       - Providing both `vcn_activity`/`jpeg_activity` and XCP (partition) stats `vcn_busy`/`jpeg_busy` caused confusion for users about which field to use. By removing backward compatibility, it is easier to identify the relevant field.
@@ -130,7 +130,7 @@ Full documentation for rocm_smi_lib is available at [https://rocm.docs.amd.com/]
 
     These changes impact what information is readable/writable for the partition nodes.
 
-    <b><i>Example: Previous Outputs in CPX</b></i>
+    <b><i>Example: Previous Outputs in CPX</b></i>  
     ```shell
     $ rocm-smi
 
@@ -151,7 +151,7 @@ Full documentation for rocm_smi_lib is available at [https://rocm.docs.amd.com/]
     ...
     ==========================================================================================================================
     ================================================== End of ROCm SMI Log ===================================================
-    ```
+    ```  
     <b><i>Example: Corrected outputs in CPX</i></b>
     ```shell
     $ rocm-smi
@@ -187,13 +187,13 @@ Full documentation for rocm_smi_lib is available at [https://rocm.docs.amd.com/]
 
 ### Added
 
-- **Added support for GPU metrics 1.7 to `rsmi_dev_gpu_metrics_info_get()`**
-Updated `rsmi_dev_gpu_metrics_info_get()` and structure `rsmi_gpu_metrics_t` to include new fields for XGMI Link Status, graphics clocks below host limit (per XCP), and VRAM max bandwidth:
+- **Added support for GPU metrics 1.7 to `rsmi_dev_gpu_metrics_info_get()`**  
+Updated `rsmi_dev_gpu_metrics_info_get()` and structure `rsmi_gpu_metrics_t` to include new fields for XGMI Link Status, graphics clocks below host limit (per XCP), and VRAM max bandwidth:  
   - `uint64_t vram_max_bandwidth` - VRAM max bandwidth at max memory clock (GB/s)
   - `uint16_t xgmi_link_status[MAX_NUM_XGMI_LINKS]` - XGMI link statis, 1=Up 0=Down
   - `uint64_t gfx_below_host_limit_acc[MAX_NUM_XCC]` - graphics clocks below host limit (per XCP) accumulators. Used for graphic clk below host limit violation status.
 
-- **Added new GPU metrics 1.7 to `rocm-smi --showmetrics`**
+- **Added new GPU metrics 1.7 to `rocm-smi --showmetrics`**  
 New metrics added to `rocm-smi --showmetrics`
 ```shell
 $ rocm-smi --showmetrics
@@ -227,25 +227,25 @@ $ rocm-smi --showmetrics
 
 ### Resolved issues
 
-- **Fixed `rsmi_dev_target_graphics_version_get`, `rocm-smi --showhw`, and `rocm-smi --showprod` not displaying graphics version properly for MI2x, MI1x or Navi 3x ASICs.**
+- **Fixed `rsmi_dev_target_graphics_version_get`, `rocm-smi --showhw`, and `rocm-smi --showprod` not displaying graphics version properly for MI2x, MI1x or Navi 3x ASICs.**  
 
 ### Upcoming changes
 
 ## rocm_smi_lib for ROCm 6.3
 
-- **Added `rsmi_dev_memory_partition_capabilities_get` which returns driver memory partition capablities.**
+- **Added `rsmi_dev_memory_partition_capabilities_get` which returns driver memory partition capablities.**  
 Driver now has the ability to report what the user can set memory partition modes to. User can now see available
 memory partition modes upon an invalid argument return from memory partition mode set (`rsmi_dev_memory_partition_set`).
 
 
-- **Added support for GPU metrics 1.6 to `rsmi_dev_gpu_metrics_info_get()`**
-Updated `rsmi_dev_gpu_metrics_info_get()` and structure `rsmi_gpu_metrics_t` to include new fields for PVIOL / TVIOL,  XCP (Graphics Compute Partitions) stats, and pcie_lc_perf_other_end_recovery:
+- **Added support for GPU metrics 1.6 to `rsmi_dev_gpu_metrics_info_get()`**  
+Updated `rsmi_dev_gpu_metrics_info_get()` and structure `rsmi_gpu_metrics_t` to include new fields for PVIOL / TVIOL,  XCP (Graphics Compute Partitions) stats, and pcie_lc_perf_other_end_recovery:  
   - `uint64_t accumulation_counter` - used for all throttled calculations
   - `uint64_t prochot_residency_acc` - Processor hot accumulator
   - `uint64_t ppt_residency_acc` - Package Power Tracking (PPT) accumulator (used in PVIOL calculations)
   - `uint64_t socket_thm_residency_acc` - Socket thermal accumulator - (used in TVIOL calculations)
   - `uint64_t vr_thm_residency_acc` - Voltage Rail (VR) thermal accumulator
-  - `uint64_t hbm_thm_residency_acc` - High Bandwidth Memory (HBM) thermal accumulator
+  - `uint64_t hbm_thm_residency_acc` - High Bandwidth Memory (HBM) thermal accumulator 
   - `uint16_t num_partition` - corresponds to the current total number of partitions
   - `struct amdgpu_xcp_metrics_t xcp_stats[MAX_NUM_XCP]` - for each partition associated with current GPU, provides gfx busy & accumulators, jpeg, and decoder (VCN) engine utilizations
     - `uint32_t gfx_busy_inst[MAX_NUM_XCC]` - graphic engine utilization (%)
@@ -254,18 +254,18 @@ Updated `rsmi_dev_gpu_metrics_info_get()` and structure `rsmi_gpu_metrics_t` to 
     - `uint64_t gfx_busy_acc[MAX_NUM_XCC]` - graphic engine utilization accumulated (%)
   - `uint32_t pcie_lc_perf_other_end_recovery` - corresponds to the pcie other end recovery counter
 
-- **Added ability to view raw GPU metrics`rocm-smi --showmetrics`**
-Users can now view GPU metrics from our new `rocm-smi --showmetrics`. Unlike AMD SMI (or other ROCM-SMI interfaces), these values are ***not*** converted into applicable units as users may see in `amd-smi metric`. Units listed display as indicated by the driver, they are not converted (eg. in other AMD SMI/ROCm SMI interfaces which use the data provided). It is important to note, that fields displaying `N/A` data mean this ASIC does not support or backward compatibility was not provided in a newer ASIC's GPU metric structure.
+- **Added ability to view raw GPU metrics`rocm-smi --showmetrics`**  
+Users can now view GPU metrics from our new `rocm-smi --showmetrics`. Unlike AMD SMI (or other ROCM-SMI interfaces), these values are ***not*** converted into applicable units as users may see in `amd-smi metric`. Units listed display as indicated by the driver, they are not converted (eg. in other AMD SMI/ROCm SMI interfaces which use the data provided). It is important to note, that fields displaying `N/A` data mean this ASIC does not support or backward compatibility was not provided in a newer ASIC's GPU metric structure.   
 
 ### Changed
 
-- **Added back in C++ tests for `memorypartition_read_write`**.
+- **Added back in C++ tests for `memorypartition_read_write`**.  
 Due to driver adding in all needed features for memory partition write. We have re-enabled memorypartition_read_write.
 
-- **Updated `rsmi_dev_memory_partition_set` to not return until a successful restart of AMD GPU Driver.**
+- **Updated `rsmi_dev_memory_partition_set` to not return until a successful restart of AMD GPU Driver.**  
 This change keeps checking for ~ up to 40 seconds for a successful restart of the AMD GPU driver. Additionally, the API call continues to check if memory partition (NPS) SYSFS files are successfully updated to reflect the user's requested memory partition (NPS) mode change. Otherwise, reports an error back to the user. Due to these changes, we have updated ROCm SMI's CLI to reflect the maximum wait of 40 seconds, while memory partition change is in progress.
 
-- **All APIs now have the ability to catch driver reporting invalid arguments.**
+- **All APIs now have the ability to catch driver reporting invalid arguments.**  
 Now ROCm SMI APIs can show RSMI_STATUS_INVALID_ARGS when driver returns EINVAL.
 
 ### Removed
@@ -276,11 +276,11 @@ Now ROCm SMI APIs can show RSMI_STATUS_INVALID_ARGS when driver returns EINVAL.
 
 ### Resolved issues
 
-- **Fixed `rsmi_dev_target_graphics_version_get`, `rocm-smi --showhw`, and `rocm-smi --showprod` not displaying properly for MI2x or Navi 3x ASICs.**
+- **Fixed `rsmi_dev_target_graphics_version_get`, `rocm-smi --showhw`, and `rocm-smi --showprod` not displaying properly for MI2x or Navi 3x ASICs.**  
 
 ### Upcoming changes
 
-- **Re-enable C++ tests for `memorypartition_read_write`**.
+- **Re-enable C++ tests for `memorypartition_read_write`**.  
   - This change is part of the partition feature redesign.
   - SMI's workflow needs to be adjusted in order to accomidate incoming driver changes to enable
   Dynamic memory partition feature. We plan on re-enabling testing for this feature during ROCm
@@ -290,20 +290,20 @@ Now ROCm SMI APIs can show RSMI_STATUS_INVALID_ARGS when driver returns EINVAL.
 
 ### Optimized
 
-- **Improved handling of UnicodeEncodeErrors with non UTF-8 locales**
+- **Improved handling of UnicodeEncodeErrors with non UTF-8 locales**  
 Non UTF-8 locales were causing crashing on UTF-8 special characters
 
 ### Resolved issues
 
-- **Fixed rsmitstReadWrite.TestComputePartitionReadWrite segfault**
+- **Fixed rsmitstReadWrite.TestComputePartitionReadWrite segfault**  
 Segfault was caused due to unhandled start conditions:
 
 1) When setting CPX as a partition mode, there is a DRM node limitation of 64.
-This is a known limitation of the driver, if other drivers are using other DRM nodes (ex. using PCIe space, such as ast).
-The number of DRM nodes can be checked via `ls /sys/class/drm`
-Recommended steps for removing unnecessary drivers:
-a. unloading amdgpu - `sudo rmmod amdgpu`
-b. removing unnecessary driver(s) - ex. `sudo rmmod ast`
+This is a known limitation of the driver, if other drivers are using other DRM nodes (ex. using PCIe space, such as ast).  
+The number of DRM nodes can be checked via `ls /sys/class/drm`  
+Recommended steps for removing unnecessary drivers:  
+a. unloading amdgpu - `sudo rmmod amdgpu`  
+b. removing unnecessary driver(s) - ex. `sudo rmmod ast`  
 c. reload amgpu - `sudo modprobe amdgpu`
 
 2) Since user could start amdgpu in different partition modes (ex. `sudo modprobe amdgpu user_partt_mode=1`).
@@ -314,19 +314,19 @@ The test segfault could be seen on all MI3x ASICs, if brought up in a non-SPX co
 
 ### Changed
 
-- **Added Partition ID API (`rsmi_dev_partition_id_get(..)`)**
+- **Added Partition ID API (`rsmi_dev_partition_id_get(..)`)**  
 Previously `rsmi_dev_partition_id_get` could only be retrived by querying through `rsmi_dev_pci_id_get()`
 and parsing optional bits in our python CLI/API. We are now making this available directly through API.
-As well as added testing, in our compute partitioning tests verifing partition IDs update accordingly.
+As well as added testing, in our compute partitioning tests verifing partition IDs update accordingly. 
 
 ### Resolved issues
 
-- **Partition ID CLI output**
+- **Partition ID CLI output**  
 Due to driver changes in KFD, some devices may report bits [31:28] or [2:0]. With the newly added `rsmi_dev_partition_id_get(..)`, we provided this fallback to properly retreive partition ID. We
 plan to eventually remove partition ID from the function portion of the BDF (Bus Device Function). See below for PCI ID description.
 
   - bits [63:32] = domain
-  - bits [31:28] or bits [2:0] = partition id
+  - bits [31:28] or bits [2:0] = partition id 
   - bits [27:16] = reserved
   - bits [15:8]  = Bus
   - bits [7:3] = Device
@@ -336,12 +336,12 @@ plan to eventually remove partition ID from the function portion of the BDF (Bus
 
 ### Added
 
-- **Added Ring Hang event**
+- **Added Ring Hang event**  
 Added `RSMI_EVT_NOTIF_RING_HANG` to the possible events in the `rsmi_evt_notification_type_t` enum.
 
 ### Resolved issues
 
-- **Fixed parsing of `pp_od_clk_voltage` within `get_od_clk_volt_info`**
+- **Fixed parsing of `pp_od_clk_voltage` within `get_od_clk_volt_info`**  
 The parsing of `pp_od_clk_voltage` was not dynamic enough to work with the dropping of voltage curve support on MI series cards.
 
 ## rocm_smi_lib for ROCm 6.1.1

--- a/projects/rocm-smi-lib/CHANGELOG.md
+++ b/projects/rocm-smi-lib/CHANGELOG.md
@@ -8,7 +8,7 @@ Full documentation for rocm_smi_lib is available at [https://rocm.docs.amd.com/]
 
 ### Added
 
-- **Added runtime power management detection and device wake support**.  
+- **Added runtime power management detection and device wake support**.
   - Implemented DRM ioctl-based device wake mechanism to handle GPUs in BACO state.
   - Added `check_runtime_pm_status()` to detect runtime PM suspended devices.
   - Added `wake_device()` to wake devices using DRM ioctl.
@@ -18,14 +18,14 @@ Full documentation for rocm_smi_lib is available at [https://rocm.docs.amd.com/]
 
 ### Added
 
-- **Added support for GPU metrics 1.8**.  
-  - Added new fields for `rsmi_gpu_metrics_t` including:  
+- **Added support for GPU metrics 1.8**.
+  - Added new fields for `rsmi_gpu_metrics_t` including:
     - Adding the following metrics to allow new calculations for violation status:
     - Per XCP metrics `gfx_below_host_limit_ppt_acc[XCP][MAX_XCC]` - GFX Clock Host limit Package Power Tracking violation counts
     - Per XCP metrics `gfx_below_host_limit_thm_acc[XCP][MAX_XCC]` - GFX Clock Host limit Thermal (TVIOL) violation counts
     - Per XCP metrics `gfx_low_utilization_acc[XCP][MAX_XCC]` - violation counts for how did low utilization caused the GPU to be below application clocks.
     - Per XCP metrics `gfx_below_host_limit_total_acc[XCP][MAX_XCC]`- violation counts for how long GPU was held below application clocks any limiter (see above new violation metrics).
-  - Increasing available JPEG engines to 40.  
+  - Increasing available JPEG engines to 40.
   Current ASICs may not support all 40. These will be indicated as UINT16_MAX or N/A in CLI.
 
 ### Changed
@@ -34,7 +34,7 @@ Full documentation for rocm_smi_lib is available at [https://rocm.docs.amd.com/]
 
 ### Removed
 
-- **Removed backwards compatibility `rsmi_dev_gpu_metrics_info_get()`'s `jpeg_activity` or `vcn_activity` fields: use `xcp_stats.jpeg_busy` or `xcp_stats.vcn_busy`**  
+- **Removed backwards compatibility `rsmi_dev_gpu_metrics_info_get()`'s `jpeg_activity` or `vcn_activity` fields: use `xcp_stats.jpeg_busy` or `xcp_stats.vcn_busy`**
   - Backwards compability is removed for `jpeg_activity` and `vcn_activity` fields, if the `jpeg_busy` or `vcn_busy` field is available.
     - <i>Reasons for this change</i>:
       - Providing both `vcn_activity`/`jpeg_activity` and XCP (partition) stats `vcn_busy`/`jpeg_busy` caused confusion for users about which field to use. By removing backward compatibility, it is easier to identify the relevant field.
@@ -130,7 +130,7 @@ Full documentation for rocm_smi_lib is available at [https://rocm.docs.amd.com/]
 
     These changes impact what information is readable/writable for the partition nodes.
 
-    <b><i>Example: Previous Outputs in CPX</b></i>  
+    <b><i>Example: Previous Outputs in CPX</b></i>
     ```shell
     $ rocm-smi
 
@@ -151,7 +151,7 @@ Full documentation for rocm_smi_lib is available at [https://rocm.docs.amd.com/]
     ...
     ==========================================================================================================================
     ================================================== End of ROCm SMI Log ===================================================
-    ```  
+    ```
     <b><i>Example: Corrected outputs in CPX</i></b>
     ```shell
     $ rocm-smi
@@ -187,13 +187,13 @@ Full documentation for rocm_smi_lib is available at [https://rocm.docs.amd.com/]
 
 ### Added
 
-- **Added support for GPU metrics 1.7 to `rsmi_dev_gpu_metrics_info_get()`**  
-Updated `rsmi_dev_gpu_metrics_info_get()` and structure `rsmi_gpu_metrics_t` to include new fields for XGMI Link Status, graphics clocks below host limit (per XCP), and VRAM max bandwidth:  
+- **Added support for GPU metrics 1.7 to `rsmi_dev_gpu_metrics_info_get()`**
+Updated `rsmi_dev_gpu_metrics_info_get()` and structure `rsmi_gpu_metrics_t` to include new fields for XGMI Link Status, graphics clocks below host limit (per XCP), and VRAM max bandwidth:
   - `uint64_t vram_max_bandwidth` - VRAM max bandwidth at max memory clock (GB/s)
   - `uint16_t xgmi_link_status[MAX_NUM_XGMI_LINKS]` - XGMI link statis, 1=Up 0=Down
   - `uint64_t gfx_below_host_limit_acc[MAX_NUM_XCC]` - graphics clocks below host limit (per XCP) accumulators. Used for graphic clk below host limit violation status.
 
-- **Added new GPU metrics 1.7 to `rocm-smi --showmetrics`**  
+- **Added new GPU metrics 1.7 to `rocm-smi --showmetrics`**
 New metrics added to `rocm-smi --showmetrics`
 ```shell
 $ rocm-smi --showmetrics
@@ -227,25 +227,25 @@ $ rocm-smi --showmetrics
 
 ### Resolved issues
 
-- **Fixed `rsmi_dev_target_graphics_version_get`, `rocm-smi --showhw`, and `rocm-smi --showprod` not displaying graphics version properly for MI2x, MI1x or Navi 3x ASICs.**  
+- **Fixed `rsmi_dev_target_graphics_version_get`, `rocm-smi --showhw`, and `rocm-smi --showprod` not displaying graphics version properly for MI2x, MI1x or Navi 3x ASICs.**
 
 ### Upcoming changes
 
 ## rocm_smi_lib for ROCm 6.3
 
-- **Added `rsmi_dev_memory_partition_capabilities_get` which returns driver memory partition capablities.**  
+- **Added `rsmi_dev_memory_partition_capabilities_get` which returns driver memory partition capablities.**
 Driver now has the ability to report what the user can set memory partition modes to. User can now see available
 memory partition modes upon an invalid argument return from memory partition mode set (`rsmi_dev_memory_partition_set`).
 
 
-- **Added support for GPU metrics 1.6 to `rsmi_dev_gpu_metrics_info_get()`**  
-Updated `rsmi_dev_gpu_metrics_info_get()` and structure `rsmi_gpu_metrics_t` to include new fields for PVIOL / TVIOL,  XCP (Graphics Compute Partitions) stats, and pcie_lc_perf_other_end_recovery:  
+- **Added support for GPU metrics 1.6 to `rsmi_dev_gpu_metrics_info_get()`**
+Updated `rsmi_dev_gpu_metrics_info_get()` and structure `rsmi_gpu_metrics_t` to include new fields for PVIOL / TVIOL,  XCP (Graphics Compute Partitions) stats, and pcie_lc_perf_other_end_recovery:
   - `uint64_t accumulation_counter` - used for all throttled calculations
   - `uint64_t prochot_residency_acc` - Processor hot accumulator
   - `uint64_t ppt_residency_acc` - Package Power Tracking (PPT) accumulator (used in PVIOL calculations)
   - `uint64_t socket_thm_residency_acc` - Socket thermal accumulator - (used in TVIOL calculations)
   - `uint64_t vr_thm_residency_acc` - Voltage Rail (VR) thermal accumulator
-  - `uint64_t hbm_thm_residency_acc` - High Bandwidth Memory (HBM) thermal accumulator 
+  - `uint64_t hbm_thm_residency_acc` - High Bandwidth Memory (HBM) thermal accumulator
   - `uint16_t num_partition` - corresponds to the current total number of partitions
   - `struct amdgpu_xcp_metrics_t xcp_stats[MAX_NUM_XCP]` - for each partition associated with current GPU, provides gfx busy & accumulators, jpeg, and decoder (VCN) engine utilizations
     - `uint32_t gfx_busy_inst[MAX_NUM_XCC]` - graphic engine utilization (%)
@@ -254,18 +254,18 @@ Updated `rsmi_dev_gpu_metrics_info_get()` and structure `rsmi_gpu_metrics_t` to 
     - `uint64_t gfx_busy_acc[MAX_NUM_XCC]` - graphic engine utilization accumulated (%)
   - `uint32_t pcie_lc_perf_other_end_recovery` - corresponds to the pcie other end recovery counter
 
-- **Added ability to view raw GPU metrics`rocm-smi --showmetrics`**  
-Users can now view GPU metrics from our new `rocm-smi --showmetrics`. Unlike AMD SMI (or other ROCM-SMI interfaces), these values are ***not*** converted into applicable units as users may see in `amd-smi metric`. Units listed display as indicated by the driver, they are not converted (eg. in other AMD SMI/ROCm SMI interfaces which use the data provided). It is important to note, that fields displaying `N/A` data mean this ASIC does not support or backward compatibility was not provided in a newer ASIC's GPU metric structure.   
+- **Added ability to view raw GPU metrics`rocm-smi --showmetrics`**
+Users can now view GPU metrics from our new `rocm-smi --showmetrics`. Unlike AMD SMI (or other ROCM-SMI interfaces), these values are ***not*** converted into applicable units as users may see in `amd-smi metric`. Units listed display as indicated by the driver, they are not converted (eg. in other AMD SMI/ROCm SMI interfaces which use the data provided). It is important to note, that fields displaying `N/A` data mean this ASIC does not support or backward compatibility was not provided in a newer ASIC's GPU metric structure.
 
 ### Changed
 
-- **Added back in C++ tests for `memorypartition_read_write`**.  
+- **Added back in C++ tests for `memorypartition_read_write`**.
 Due to driver adding in all needed features for memory partition write. We have re-enabled memorypartition_read_write.
 
-- **Updated `rsmi_dev_memory_partition_set` to not return until a successful restart of AMD GPU Driver.**  
+- **Updated `rsmi_dev_memory_partition_set` to not return until a successful restart of AMD GPU Driver.**
 This change keeps checking for ~ up to 40 seconds for a successful restart of the AMD GPU driver. Additionally, the API call continues to check if memory partition (NPS) SYSFS files are successfully updated to reflect the user's requested memory partition (NPS) mode change. Otherwise, reports an error back to the user. Due to these changes, we have updated ROCm SMI's CLI to reflect the maximum wait of 40 seconds, while memory partition change is in progress.
 
-- **All APIs now have the ability to catch driver reporting invalid arguments.**  
+- **All APIs now have the ability to catch driver reporting invalid arguments.**
 Now ROCm SMI APIs can show RSMI_STATUS_INVALID_ARGS when driver returns EINVAL.
 
 ### Removed
@@ -276,11 +276,11 @@ Now ROCm SMI APIs can show RSMI_STATUS_INVALID_ARGS when driver returns EINVAL.
 
 ### Resolved issues
 
-- **Fixed `rsmi_dev_target_graphics_version_get`, `rocm-smi --showhw`, and `rocm-smi --showprod` not displaying properly for MI2x or Navi 3x ASICs.**  
+- **Fixed `rsmi_dev_target_graphics_version_get`, `rocm-smi --showhw`, and `rocm-smi --showprod` not displaying properly for MI2x or Navi 3x ASICs.**
 
 ### Upcoming changes
 
-- **Re-enable C++ tests for `memorypartition_read_write`**.  
+- **Re-enable C++ tests for `memorypartition_read_write`**.
   - This change is part of the partition feature redesign.
   - SMI's workflow needs to be adjusted in order to accomidate incoming driver changes to enable
   Dynamic memory partition feature. We plan on re-enabling testing for this feature during ROCm
@@ -290,20 +290,20 @@ Now ROCm SMI APIs can show RSMI_STATUS_INVALID_ARGS when driver returns EINVAL.
 
 ### Optimized
 
-- **Improved handling of UnicodeEncodeErrors with non UTF-8 locales**  
+- **Improved handling of UnicodeEncodeErrors with non UTF-8 locales**
 Non UTF-8 locales were causing crashing on UTF-8 special characters
 
 ### Resolved issues
 
-- **Fixed rsmitstReadWrite.TestComputePartitionReadWrite segfault**  
+- **Fixed rsmitstReadWrite.TestComputePartitionReadWrite segfault**
 Segfault was caused due to unhandled start conditions:
 
 1) When setting CPX as a partition mode, there is a DRM node limitation of 64.
-This is a known limitation of the driver, if other drivers are using other DRM nodes (ex. using PCIe space, such as ast).  
-The number of DRM nodes can be checked via `ls /sys/class/drm`  
-Recommended steps for removing unnecessary drivers:  
-a. unloading amdgpu - `sudo rmmod amdgpu`  
-b. removing unnecessary driver(s) - ex. `sudo rmmod ast`  
+This is a known limitation of the driver, if other drivers are using other DRM nodes (ex. using PCIe space, such as ast).
+The number of DRM nodes can be checked via `ls /sys/class/drm`
+Recommended steps for removing unnecessary drivers:
+a. unloading amdgpu - `sudo rmmod amdgpu`
+b. removing unnecessary driver(s) - ex. `sudo rmmod ast`
 c. reload amgpu - `sudo modprobe amdgpu`
 
 2) Since user could start amdgpu in different partition modes (ex. `sudo modprobe amdgpu user_partt_mode=1`).
@@ -314,19 +314,19 @@ The test segfault could be seen on all MI3x ASICs, if brought up in a non-SPX co
 
 ### Changed
 
-- **Added Partition ID API (`rsmi_dev_partition_id_get(..)`)**  
+- **Added Partition ID API (`rsmi_dev_partition_id_get(..)`)**
 Previously `rsmi_dev_partition_id_get` could only be retrived by querying through `rsmi_dev_pci_id_get()`
 and parsing optional bits in our python CLI/API. We are now making this available directly through API.
-As well as added testing, in our compute partitioning tests verifing partition IDs update accordingly. 
+As well as added testing, in our compute partitioning tests verifing partition IDs update accordingly.
 
 ### Resolved issues
 
-- **Partition ID CLI output**  
+- **Partition ID CLI output**
 Due to driver changes in KFD, some devices may report bits [31:28] or [2:0]. With the newly added `rsmi_dev_partition_id_get(..)`, we provided this fallback to properly retreive partition ID. We
 plan to eventually remove partition ID from the function portion of the BDF (Bus Device Function). See below for PCI ID description.
 
   - bits [63:32] = domain
-  - bits [31:28] or bits [2:0] = partition id 
+  - bits [31:28] or bits [2:0] = partition id
   - bits [27:16] = reserved
   - bits [15:8]  = Bus
   - bits [7:3] = Device
@@ -336,12 +336,12 @@ plan to eventually remove partition ID from the function portion of the BDF (Bus
 
 ### Added
 
-- **Added Ring Hang event**  
+- **Added Ring Hang event**
 Added `RSMI_EVT_NOTIF_RING_HANG` to the possible events in the `rsmi_evt_notification_type_t` enum.
 
 ### Resolved issues
 
-- **Fixed parsing of `pp_od_clk_voltage` within `get_od_clk_volt_info`**  
+- **Fixed parsing of `pp_od_clk_voltage` within `get_od_clk_volt_info`**
 The parsing of `pp_od_clk_voltage` was not dynamic enough to work with the dropping of voltage curve support on MI series cards.
 
 ## rocm_smi_lib for ROCm 6.1.1

--- a/projects/rocm-smi-lib/docs/how-to/use-cpp.rst
+++ b/projects/rocm-smi-lib/docs/how-to/use-cpp.rst
@@ -25,28 +25,28 @@ Many of the functions in the library take a "device index". The device index is 
 Hello ROCm SMI
 ================
 
-The only required ROCm-SMI call for any program that wants to use ROCm-SMI is the ``rsmi_init()`` call. This call initializes some internal data structures that will be used by subsequent ROCm-SMI calls. 
+The only required ROCm-SMI call for any program that wants to use ROCm-SMI is the ``rsmi_init()`` call. This call initializes some internal data structures that will be used by subsequent ROCm-SMI calls.
 
 When ROCm-SMI is no longer being used, ``rsmi_shut_down()`` should be called. This provides a way to do any releasing of resources that ROCm-SMI may have held. In many cases, this may have no effect, but may be necessary in future versions of the library.
 
 A simple "Hello World" type program that displays the device ID of detected devices would look like this:
 
 .. code-block:: c
-  
+
     #include <stdint.h>
     #include "rocm_smi/rocm_smi.h"
     int main() {
       rsmi_status_t ret;
       uint32_t num_devices;
       uint16_t dev_id;
-    
+
       // We will skip return code checks for this example, but it
       // is recommended to always check this as some calls may not
       // apply for some devices or ROCm releases
-    
+
       ret = rsmi_init(0);
       ret = rsmi_num_monitor_devices(&num_devices);
-    
+
       for (int i=0; i < num_devices; ++i) {
         ret = rsmi_dev_id_get(i, &dev_id);
         // dev_id holds the device ID of device i, upon a

--- a/projects/rocm-smi-lib/docs/how-to/use-python.rst
+++ b/projects/rocm-smi-lib/docs/how-to/use-python.rst
@@ -30,7 +30,7 @@ The SMI will report two "versions": the ``ROCM-SMI`` version and the ``ROCM-SMI-
 - ``ROCM-SMI`` version is the CLI/tool version number with commit ID appended after + sign.
 
 - ``ROCM-SMI-LIB`` version is the library package version number.
-  
+
 .. code-block:: shell-session
 
    ROCM-SMI version: 2.0.0+8e78352
@@ -219,7 +219,7 @@ Detailed option descriptions
 ============================
 
 --setextremum <[min or max] [sclk or mclk] [value in MHz to set to]>
-    Provided ASIC support, users can now set a maximum or minimum sclk or mclk value through our Python CLI tool (`rocm-smi --setextremum max sclk 1500`). See example below.  
+    Provided ASIC support, users can now set a maximum or minimum sclk or mclk value through our Python CLI tool (`rocm-smi --setextremum max sclk 1500`). See example below.
 
     .. code-block:: shell-session
 
@@ -287,7 +287,7 @@ Detailed option descriptions
 
 --setoverdrive, --setmemoverdrive <#>
     .. warning::
-      
+
        DEPRECATED IN NEWER KERNEL VERSIONS. Use ``--setslevel`` or ``--setmlevel`` instead.
 
     This sets the percentage above maximum for the max Performance Level.

--- a/projects/rocm-smi-lib/docs/index.rst
+++ b/projects/rocm-smi-lib/docs/index.rst
@@ -39,12 +39,12 @@ For more information, refer to `<https://github.com/ROCm/rocm_smi_lib>`__.
 
      * :doc:`Use C++ in ROCm SMI <how-to/use-cpp>`
      * :doc:`Use Python in ROCm SMI <how-to/use-python>`
-   
 
-  .. grid-item-card:: Tutorials    
+
+  .. grid-item-card:: Tutorials
 
      * :doc:`C++ <tutorials/cpp_tutorials>`
-     * :doc:`Python <tutorials/python_tutorials>`  
+     * :doc:`Python <tutorials/python_tutorials>`
 
 
 To contribute to the documentation, refer to `Contributing to ROCm <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.

--- a/projects/rocm-smi-lib/docs/sphinx/_toc.yml.in
+++ b/projects/rocm-smi-lib/docs/sphinx/_toc.yml.in
@@ -10,12 +10,12 @@ subtrees:
   entries:
   - file: install/install
     title: ROCm SMI installation
- 
-- caption: How to 
+
+- caption: How to
   entries:
   - file: how-to/use-cpp
   - file: how-to/use-python
-    
+
 - caption: API Reference
   entries:
     - file: doxygen/html/files
@@ -28,15 +28,15 @@ subtrees:
       title: Modules
     - file: reference/python_api
       title: Python API
-  
-    
+
+
 - caption: Tutorials
   entries:
   - file: tutorials/cpp_tutorials
-    title: C++ 
+    title: C++
   - file: tutorials/python_tutorials
-    title: Python 
-    
+    title: Python
+
 - caption: About
   entries:
   - file: license

--- a/projects/rocm-smi-lib/python_smi_tools/rsmiBindingsInit.py.in
+++ b/projects/rocm-smi-lib/python_smi_tools/rsmiBindingsInit.py.in
@@ -11,7 +11,7 @@ from enum import Enum
 import os
 
 # Use ROCm installation path if running from standard installation
-# With File Reorg rsmiBindings.py and rsmiBindingsInit.py will be installed in 
+# With File Reorg rsmiBindings.py and rsmiBindingsInit.py will be installed in
 # /opt/rocm/libexec/rocm_smi. relative path changed accordingly.
 # if ROCM_SMI_LIB_PATH is set, we can load 'librocm_smi64.so' from that location
 #

--- a/projects/rocm-smi-lib/src/rocm_smi.cc
+++ b/projects/rocm-smi-lib/src/rocm_smi.cc
@@ -6309,7 +6309,7 @@ rsmi_event_notification_get(int timeout_ms,
 
             sscanf(message, "%" PRId64 " -%d @%" PRIu32 "(%" PRIu32 ") %x->%x %x:%x %d\n", &ns, &pid, &start, &size, &from, &to, &prefetch_loc, &preferred_loc, &migrate_trigger);
             std::stringstream final_message;
-            final_message << "nd: " << std::to_string(ns).c_str() 
+            final_message << "nd: " << std::to_string(ns).c_str()
                           << "  pid: " << std::to_string(pid).c_str()
                           << "  start: 0x" << std::hex << start
                           << "  size: 0x" << std::hex << size
@@ -6335,7 +6335,7 @@ rsmi_event_notification_get(int timeout_ms,
 
             sscanf(message, "%" PRId64 " -%d @%" PRIu32 "(%" PRIu32 ") %x->%x %d %d\n", &ns, &pid, &start, &size, &from, &to, &migrate_trigger, &error_code);
             std::stringstream final_message;
-            final_message << "nd: " << std::to_string(ns).c_str() 
+            final_message << "nd: " << std::to_string(ns).c_str()
                           << "  pid: " << std::to_string(pid).c_str()
                           << "  start: 0x" << std::hex << start
                           << "  size: 0x" << std::hex << size

--- a/projects/rocm-smi-lib/src/rocm_smi_gpu_metrics.cc
+++ b/projects/rocm-smi-lib/src/rocm_smi_gpu_metrics.cc
@@ -1854,7 +1854,7 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v18_t::copy_internal_to_external_m
   ss << __PRETTY_FUNCTION__ << " | ======= start =======";
   LOG_TRACE(ss);
 
-  auto copy_data_from_internal_metrics_tbl = [&]() 
+  auto copy_data_from_internal_metrics_tbl = [&]()
   {
     AMGpuMetricsPublicLatest_t metrics_public_init{};
 
@@ -2051,7 +2051,7 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v18_t::copy_internal_to_external_m
      << " |";
   LOG_TRACE(ss);
 
-  return std::make_tuple(status_code, copy_data_from_internal_metrics_tbl);  
+  return std::make_tuple(status_code, copy_data_from_internal_metrics_tbl);
 };
 
 AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v17_t::copy_internal_to_external_metrics()

--- a/projects/rocm-smi-lib/tests/rocm_smi_test/functional/measure_api_execution_time.cc
+++ b/projects/rocm-smi-lib/tests/rocm_smi_test/functional/measure_api_execution_time.cc
@@ -93,7 +93,7 @@ void TestMeasureApiExecutionTime::Run(void) {
   constexpr float kFAN_SPEED_ELAPSED_MICROSEC_BASE = (1000);
   /**
    * gpu_metrics can only refresh every 1000 microseconds (1 millisecs) due to FW
-   * 
+   *
    * We have additional processing time (each read() -> fread()  ~ costs 900 microseconds).
    * We need to read 2x:
    * 1) reading metric's header to check support (~900 microseconds)
@@ -103,17 +103,17 @@ void TestMeasureApiExecutionTime::Run(void) {
    * 5) Pass to public structure (~100 microseconds)
    * ---------------------------
    * ~2100 worst case
-   * 
+   *
    * Note: performance of fread/mmap/read
    * https://github.com/nurettn/c-read-vs-mmap-vs-fread
-   * 
+   *
    * Possible improvments ideas:
    * a) Initize "N/A" / Max UINT only for non-backwards comptable public struct
    * or arrays
    * b) Directly put data into public structure - this skips other copy/fill
    * procedures
    * c) Expirement with other file reading options
-   **/ 
+   **/
   constexpr float kMETRICS_ELAPSED_MICROSEC_BASE = (2100);
   bool skip = false;
 

--- a/projects/rocm-smi-lib/tests/rocm_smi_test/functional/perf_level_read_write.cc
+++ b/projects/rocm-smi-lib/tests/rocm_smi_test/functional/perf_level_read_write.cc
@@ -128,7 +128,7 @@ void TestPerfLevelReadWrite::Run(void) {
       ret = rsmi_dev_perf_level_set(dv_ind,
                                      static_cast<rsmi_dev_perf_level_t>(pfl_i));
       if (ret == RSMI_STATUS_NOT_SUPPORTED || ret == RSMI_STATUS_UNEXPECTED_DATA) {
-          std::cout << "\t**" << GetPerfLevelStr(static_cast<rsmi_dev_perf_level_t>(pfl_i)) 
+          std::cout << "\t**" << GetPerfLevelStr(static_cast<rsmi_dev_perf_level_t>(pfl_i))
                   << " returned RSMI_STATUS_NOT_SUPPORTED"  << std::endl;
       } else {
           CHK_ERR_ASRT(ret)


### PR DESCRIPTION
In order for pre-commit to be useful, everything needs to meet a common baseline.
