### PR TITLE
Run pre-commit's whitespace related hooks on projects/rocr-runtime/libhsakmt

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
@@ -425,15 +425,15 @@ hsaKmtQueueRingDoorbell(
 );
 
 /**
-  Allows an HSA process to set/change the default and alternate memory coherency, before starting to dispatch. 
+  Allows an HSA process to set/change the default and alternate memory coherency, before starting to dispatch.
 */
 
 HSAKMT_STATUS
 HSAKMTAPI
 hsaKmtSetMemoryPolicy(
     HSAuint32       Node,                       //IN
-    HSAuint32       DefaultPolicy,     	   	    //IN  
-    HSAuint32       AlternatePolicy,       	    //IN  
+    HSAuint32       DefaultPolicy,     	   	    //IN
+    HSAuint32       AlternatePolicy,       	    //IN
     void*           MemoryAddressAlternate,     //IN (page-aligned)
     HSAuint64       MemorySizeInBytes   	    //IN (page-aligned)
     );
@@ -676,7 +676,7 @@ HSAKMTAPI
 hsaKmtMapMemoryToGPU(
     void*           MemoryAddress,     //IN (page-aligned)
     HSAuint64       MemorySizeInBytes, //IN (page-aligned)
-    HSAuint64*      AlternateVAGPU     //OUT (page-aligned)     
+    HSAuint64*      AlternateVAGPU     //OUT (page-aligned)
     );
 
 /**
@@ -769,8 +769,8 @@ hsaKmtDbgRegister(
   Detaches the debugger process from the HW debug established by hsaKmtDbgRegister() API
 */
 
-HSAKMT_STATUS 
-HSAKMTAPI 
+HSAKMT_STATUS
+HSAKMTAPI
 hsaKmtDbgUnregister(
     HSAuint32       NodeId      //IN
     );
@@ -862,7 +862,7 @@ hsaKmtDbgGetQueueData(
     bool suspend_queues //In
     );
 
-/**   
+/**
   Check whether gpu firmware and kernel support debugging
 */
 HSAKMT_STATUS
@@ -960,7 +960,7 @@ HSAKMT_STATUS
 HSAKMTAPI
 hsaKmtPmcStartTrace(
     HSATraceId  TraceId,                //IN
-    void*       TraceBuffer,            //IN (page aligned) 
+    void*       TraceBuffer,            //IN (page aligned)
     HSAuint64   TraceBufferSizeBytes    //IN (page aligned)
     );
 
@@ -988,8 +988,8 @@ hsaKmtPmcStopTrace(
   Sets trap handler and trap buffer to be used for all queues associated with the specified NodeId within this process context
 */
 
-HSAKMT_STATUS 
-HSAKMTAPI 
+HSAKMT_STATUS
+HSAKMTAPI
 hsaKmtSetTrapHandler(
     HSAuint32           NodeId,                   //IN
     void*               TrapHandlerBaseAddress,   //IN

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
@@ -558,24 +558,24 @@ typedef struct _HsaMemFlags
                                           // when setting this entry to 1. Scratch allocation may fail due to limited
                                           // resources. Application code is required to work without any allocation.
                                           // Allocation fails on any node without GPU function.
-            unsigned int AtomicAccessFull: 1; // default = 0: If set, the memory will be allocated and mapped to allow 
-                                              // atomic ops processing. On AMD APU, this will use the ATC path on system 
-                                              // memory, irrespective of the NonPaged flag setting (= if NonPaged is set, 
-                                              // the memory is pagelocked but mapped through IOMMUv2 instead of GPUVM). 
+            unsigned int AtomicAccessFull: 1; // default = 0: If set, the memory will be allocated and mapped to allow
+                                              // atomic ops processing. On AMD APU, this will use the ATC path on system
+                                              // memory, irrespective of the NonPaged flag setting (= if NonPaged is set,
+                                              // the memory is pagelocked but mapped through IOMMUv2 instead of GPUVM).
                                               // All atomic ops must be supported on this memory.
-            unsigned int AtomicAccessPartial: 1; // default = 0: See above for AtomicAccessFull description, however 
-                                                 // focused on AMD discrete GPU that support PCIe atomics; the memory 
-                                                 // allocation is mapped to allow for PCIe atomics to operate on system 
-                                                 // memory, irrespective of NonPaged set or the presence of an ATC path 
-                                                 // in the system. The atomic operations supported are limited to SWAP, 
-                                                 // CompareAndSwap (CAS) and FetchAdd (this PCIe op allows both atomic 
-                                                 // increment and decrement via 2-complement arithmetic), which are the 
+            unsigned int AtomicAccessPartial: 1; // default = 0: See above for AtomicAccessFull description, however
+                                                 // focused on AMD discrete GPU that support PCIe atomics; the memory
+                                                 // allocation is mapped to allow for PCIe atomics to operate on system
+                                                 // memory, irrespective of NonPaged set or the presence of an ATC path
+                                                 // in the system. The atomic operations supported are limited to SWAP,
+                                                 // CompareAndSwap (CAS) and FetchAdd (this PCIe op allows both atomic
+                                                 // increment and decrement via 2-complement arithmetic), which are the
                                                  // only atomic ops directly supported in PCI Express.
-                                                 // On AMD APU, setting this flag will allocate the same type of memory 
-                                                 // as AtomicAccessFull, but it will be considered compatible with 
+                                                 // On AMD APU, setting this flag will allocate the same type of memory
+                                                 // as AtomicAccessFull, but it will be considered compatible with
                                                  // discrete GPU atomic operations access.
-            unsigned int ExecuteAccess: 1; // default = 0: Identifies if memory is primarily used for data or accessed 
-                                           // for executable code (e.g. queue memory) by the host CPU or the device. 
+            unsigned int ExecuteAccess: 1; // default = 0: Identifies if memory is primarily used for data or accessed
+                                           // for executable code (e.g. queue memory) by the host CPU or the device.
                                            // Influences the page attribute setting within the allocation
             unsigned int CoarseGrain : 1;  // default = 0: The memory can be accessed assuming cache
                                            // coherency maintained by link infrastructure and HSA agents.

--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -4675,7 +4675,7 @@ static void fmm_clear_aperture(manageable_aperture_t *app)
 void hsakmt_fmm_clear_all_mem(HsaKFDContext *ctx)
 {
 	uint32_t i;
-	
+
 	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
 	/* Close render node FDs. The child process needs to open new ones */
 	for (i = 0; i <= DRM_LAST_RENDER_NODE - DRM_FIRST_RENDER_NODE; i++) {
@@ -4696,7 +4696,7 @@ void hsakmt_fmm_clear_all_aperture(HsaKFDContext *ctx)
 {
 	uint32_t i;
 	void *map_addr;
-	
+
 	struct hsa_kfd_fmm_context *fmm_ctx = hsakmt_kfdcontext_get_fmm_context(ctx);
 
 	fmm_clear_aperture(&fmm_ctx->mem_handle_aperture);

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.c
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.c
@@ -1,9 +1,9 @@
 /*
- * Copyright © Advanced Micro Devices, Inc., or its affiliates. 
- * 
+ * Copyright © Advanced Micro Devices, Inc., or its affiliates.
+ *
  * SPDX-License-Identifier: MIT
  */
- 
+
 #include <stdio.h>
 #include <errno.h>
 #include <sys/ioctl.h>

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/gtest-1.6.0/gtest/gtest.h
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/gtest-1.6.0/gtest/gtest.h
@@ -2465,35 +2465,35 @@ class ThreadLocal {
 
 class Mutex {
  public:
-  Mutex():owner_(0), handle_() 
+  Mutex():owner_(0), handle_()
   {
     ::InitializeCriticalSection(&handle_);
   }
-  
+
   ~Mutex()
   {
     ::DeleteCriticalSection(&handle_);
   }
-  
-  void Lock() 
+
+  void Lock()
   {
     ::EnterCriticalSection(&handle_);
     owner_ = ::GetCurrentThreadId();
   }
-  
-  void Unlock() 
+
+  void Unlock()
   {
     ::LeaveCriticalSection(&handle_);
     owner_ = 0;
   }
-  
+
  // Does nothing if the current thread holds the mutex. Otherwise, crashes
 // with high probability.
   void AssertHeld() const {
     GTEST_CHECK_(owner_ == ::GetCurrentThreadId())
        << "The current thread is not holding the mutex @" << this;
   }
-  
+
   private:
   DWORD              owner_;
   CRITICAL_SECTION   handle_;

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/run_kfdtest.sh
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/run_kfdtest.sh
@@ -313,7 +313,7 @@ done
 
 if [ "$CONCURRENTNODES" == "all" ]; then
     validNodes=$(getHsaNodes)
-    CONCURRENTNODES=$(echo $validNodes | tr ' ' ',') 
+    CONCURRENTNODES=$(echo $validNodes | tr ' ' ',')
 else
     validNodes=$(getHsaNodes)
     validNodesArray=($validNodes)

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/Dispatch.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/Dispatch.hpp
@@ -45,7 +45,7 @@ class Dispatch {
     void SetScratch(int numWaves, int waveSize, HSAuint64 scratch_base);
 
     void SetSpiPriority(unsigned int priority);
-    
+
     void SetPriv(bool priv);
 
     HsaEvent *GetHsaEvent() { return m_pEop; }

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDGraphicsInterop.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDGraphicsInterop.cpp
@@ -146,7 +146,7 @@ TEST_F(KFDGraphicsInterop, RegisterGraphicsHandle) {
 
 #if 0
 /* This test isn't testing things the way we wanted it to. It is flaky and
- * will end up failing if the memory is evicted, which isn't possible for what 
+ * will end up failing if the memory is evicted, which isn't possible for what
  * it is intended to test. It needs a rework
  */
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
@@ -1057,7 +1057,7 @@ void KFDSVMRangeTest::MigratePolicyTest(int gpuNode) {
 
     for (HSAuint64 i = 0; i < BufferSize / 8; i += 512) {
         Dispatch dispatch(isaBuffer);
-        
+
         dispatch.SetArgs(pBuf + i, pData + i);
         dispatch.Submit(queue);
         dispatch.Sync(HSA_EVENTTIMEOUT_INFINITE);

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDTestMain.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDTestMain.cpp
@@ -103,7 +103,7 @@ GTEST_API_ int main(int argc, char **argv) {
             g_TestNodeId = args.NodeId;
             g_TestGPUsNum = 1;
         }
-        
+
         g_IsEmuMode = CheckEmuModeEnabled();
 
         LOG() << "Profile: " << (TESTPROFILE)g_TestRunProfile << std::endl;

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/LinuxOSWrapper.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/LinuxOSWrapper.cpp
@@ -221,7 +221,7 @@ bool GetCommandLineArguments(int argc, char **argv, CommandLineArguments& rArgs)
             {
                 rArgs.ConcurrentNodes = optarg;
             }
-            break;  
+            break;
         case 8:
             {
                 int testNodeNum = atoi(optarg);

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/OSWrapper.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/OSWrapper.hpp
@@ -71,7 +71,7 @@ struct CommandLineArguments {
     /* Time in units of seconds */
     unsigned int SleepTime;
     std::string ConcurrentNodes;
-    unsigned int TestNodeNum; 
+    unsigned int TestNodeNum;
 };
 
 // It is either MEM_NONE or the bitwise OR of one or more of the following flags

--- a/projects/rocr-runtime/libhsakmt/tests/reopen/kmtreopen.c
+++ b/projects/rocr-runtime/libhsakmt/tests/reopen/kmtreopen.c
@@ -1,6 +1,6 @@
 /*
- * Copyright © Advanced Micro Devices, Inc., or its affiliates. 
- * 
+ * Copyright © Advanced Micro Devices, Inc., or its affiliates.
+ *
  * SPDX-License-Identifier: MIT
  */
 


### PR DESCRIPTION
In order for pre-commit to be useful, everything needs to meet a common baseline.
