### PR TITLE
Run pre-commit's whitespace related hooks on projects/roctracer

### DIFF
--- a/projects/roctracer/test/golden_traces/MatrixTranspose_kfd_trace.txt
+++ b/projects/roctracer/test/golden_traces/MatrixTranspose_kfd_trace.txt
@@ -1,5 +1,5 @@
 + LD_PRELOAD=libkfdwrapper64.so ./test/MatrixTranspose
-ROCTracer (pid=1963): 
+ROCTracer (pid=1963):
     KFD-trace()
 3802694735152956
 Device name Device 687f

--- a/projects/roctracer/test/golden_traces/copy_hsa_trace.txt
+++ b/projects/roctracer/test/golden_traces/copy_hsa_trace.txt
@@ -1,4 +1,4 @@
-ROCTracer (pid=566828): 
+ROCTracer (pid=566828):
 0x55e1b9d507c0 agent cpu
 0x55e1b9d4eeb0 agent gpu
 0x55e1b9d8b540 agent gpu

--- a/projects/roctracer/test/golden_traces/load_unload_reload_trace.txt
+++ b/projects/roctracer/test/golden_traces/load_unload_reload_trace.txt
@@ -1,4 +1,4 @@
-ROCTracer (pid=566858): 
+ROCTracer (pid=566858):
 0x55ae2fa607c0 agent cpu
 0x55ae2fa5eeb0 agent gpu
 0x55ae2fa9b540 agent gpu
@@ -9,7 +9,7 @@ ROCTracer (pid=566858):
 975785719403482:975785719403643 566858:566858 hsa_agent_get_info(, 17, 0x7ffe30b97814) = 0 :7
 975785719404274:975785719404364 566858:566858 hsa_agent_get_info(, 17, 0x7ffe30b97814) = 0 :8
 975785719404274:975785719404885 566858:566858 hsa_iterate_agents(1, 0) = 0 :5
-ROCTracer (pid=566858): 
+ROCTracer (pid=566858):
 0x55ae2fa607c0 agent cpu
 0x55ae2fb02cc0 agent gpu
 0x55ae2fa62970 agent gpu

--- a/projects/roctracer/utils.cmake
+++ b/projects/roctracer/utils.cmake
@@ -29,7 +29,7 @@ function( configure_pkg PACKAGE_NAME_T COMPONENT_NAME_T PACKAGE_VERSION_T MAINTA
         @ONLY
       )
 
-      # Install Change Log 
+      # Install Change Log
       find_program ( DEB_GZIP_EXEC gzip )
       if(EXISTS "${CMAKE_BINARY_DIR}/DEBIAN/changelog.Debian" )
         execute_process(
@@ -56,7 +56,7 @@ function( configure_pkg PACKAGE_NAME_T COMPONENT_NAME_T PACKAGE_VERSION_T MAINTA
 endfunction()
 
 # Set variables for changelog and copyright
-# For Debian specific Packages 
+# For Debian specific Packages
 function( set_debian_pkg_cmake_flags DEB_PACKAGE_NAME_T DEB_PACKAGE_VERSION_T DEB_MAINTAINER_NM_T DEB_MAINTAINER_EMAIL_T )
     # Setting configure flags
     set( DEB_PACKAGE_NAME             "${DEB_PACKAGE_NAME_T}" CACHE STRING "Debian Package Name" )
@@ -65,7 +65,7 @@ function( set_debian_pkg_cmake_flags DEB_PACKAGE_NAME_T DEB_PACKAGE_VERSION_T DE
     set( DEB_MAINTAINER_EMAIL         "${DEB_MAINTAINER_EMAIL_T}" CACHE STRING "Debian Package Maintainer Email" )
     set( DEB_COPYRIGHT_YEAR           "2025" CACHE STRING "Debian Package Copyright Year" )
     set( DEB_LICENSE                  "MIT" CACHE STRING "Debian Package License Type" )
-    set( DEB_CHANGELOG_INSTALL_FILENM "changelog.Debian.gz" CACHE STRING "Debian Package ChangeLog File Name" ) 
+    set( DEB_CHANGELOG_INSTALL_FILENM "changelog.Debian.gz" CACHE STRING "Debian Package ChangeLog File Name" )
 
     # Get TimeStamp
     find_program( DEB_DATE_TIMESTAMP_EXEC date )


### PR DESCRIPTION
In order for pre-commit to be useful, everything needs to meet a common baseline.

