### PR TITLE
Run pre-commit's whitespace related hooks on projects/rocr-runtime

### DIFF
--- a/projects/rocr-runtime/CMakeLists.txt
+++ b/projects/rocr-runtime/CMakeLists.txt
@@ -352,5 +352,5 @@ cpack_add_component(asan
   DISPLAY_NAME "ASAN"
   DESCRIPTION "ASAN libraries for rocr-runtime")
 
-# Debian specific packaging configuration install lintian files 
+# Debian specific packaging configuration install lintian files
 configure_pkg( ${CORE_TARGET} ${COMP_TYPE} ${CPACK_PACKAGE_VERSION} ${PKG_MAINTAINER_NM} ${PKG_MAINTAINER_EMAIL} )

--- a/projects/rocr-runtime/README.md
+++ b/projects/rocr-runtime/README.md
@@ -62,7 +62,7 @@ Ensure you have the following installed:
     ```sh
     cmake -DCMAKE_INSTALL_PREFIX=<rocm install dir> ..
     ```
-    e.g: 
+    e.g:
     ```
     cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm ..
     ```

--- a/projects/rocr-runtime/cmake_modules/utils.cmake
+++ b/projects/rocr-runtime/cmake_modules/utils.cmake
@@ -54,10 +54,10 @@ function( get_path LIB CACHED_PATH HELP )
         find_file( FULLPATH NAMES ${ARGS_NAMES} HINTS ${${CACHED_PATH}} ${ARGS_HINTS} )
     endif()
     set( RESULT (NOT ${FULLPATH} MATCHES NOTFOUND) )
-    
+
     # Extract path
     get_filename_component ( DIRPATH ${FULLPATH} DIRECTORY )
-    
+
     # Check path against cache
     if( NOT "${${CACHED_PATH}}" STREQUAL "" )
         if ( NOT "${${CACHED_PATH}}" STREQUAL "${DIRPATH}" )

--- a/projects/rocr-runtime/runtime/cmake_modules/COPYING-CMAKE-SCRIPTS
+++ b/projects/rocr-runtime/runtime/cmake_modules/COPYING-CMAKE-SCRIPTS
@@ -7,7 +7,7 @@ are met:
 2. Redistributions in binary form must reproduce the copyright
    notice, this list of conditions and the following disclaimer in the
    documentation and/or other materials provided with the distribution.
-3. The name of the author may not be used to endorse or promote products 
+3. The name of the author may not be used to endorse or promote products
    derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR

--- a/projects/rocr-runtime/runtime/docs/index.rst
+++ b/projects/rocr-runtime/runtime/docs/index.rst
@@ -20,7 +20,7 @@ The documentation is structured as follows:
   .. grid-item-card:: Install
 
     * :ref:`installation`
-    
+
   .. grid-item-card:: API reference
 
     * :ref:`c-interface-adaptors`

--- a/projects/rocr-runtime/runtime/docs/install/installation.rst
+++ b/projects/rocr-runtime/runtime/docs/install/installation.rst
@@ -25,7 +25,7 @@ Prerequisites
 - Install ``libdrm`` package.
 
 .. code-block:: shell
-    
+
     sudo apt install libdrm-dev
 
 The ROCR prebuilt binaries include:
@@ -67,7 +67,7 @@ Prerequisites
 .. code-block:: shell
 
     sudo apt install xxd
-    
+
 Building the runtime
 ----------------------
 

--- a/projects/rocr-runtime/runtime/docs/sphinx/_toc.yml.in
+++ b/projects/rocr-runtime/runtime/docs/sphinx/_toc.yml.in
@@ -11,7 +11,7 @@ subtrees:
     - file: api-reference/c-interface-adaptors
     - file: api-reference/environment_variables
     - file: api-reference/api
-    
+
   - caption: Contribution
     entries:
     - file: contribution/contributing-to-rocr

--- a/projects/rocr-runtime/runtime/hsa-runtime-tools/CMakeLists.txt
+++ b/projects/rocr-runtime/runtime/hsa-runtime-tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 ################################################################################
 ##
-## Copyright (c) Advanced Micro Devices, Inc., or its affiliates. 
-## 
+## Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+##
 ## SPDX-License-Identifier: MIT
 ##
 ################################################################################

--- a/projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt
+++ b/projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt
@@ -111,14 +111,14 @@ set_property(TARGET  ${CORE_RUNTIME_TARGET} PROPERTY OUTPUT_NAME ${CORE_RUNTIME_
 if (UNIX)
   target_compile_definitions(${CORE_RUNTIME_TARGET} PRIVATE "${HSA_COMMON_DEFS}" __linux__ HSA_EXPORT=1 HSA_EXPORT_FINALIZER=1 HSA_EXPORT_IMAGES=1 HSA_DEPRECATED=
   ROCR_BUILD_ID="${PACKAGE_VERSION_STRING}-${VERSION_JOB}-${VERSION_HASH}" )
-  
+
   ## Check for memfd_create syscall
   include(CheckSymbolExists)
   CHECK_SYMBOL_EXISTS ( "__NR_memfd_create" "sys/syscall.h" HAVE_MEMFD_CREATE )
   if ( HAVE_MEMFD_CREATE )
     target_compile_definitions(${CORE_RUNTIME_TARGET} PRIVATE HAVE_MEMFD_CREATE )
   endif()
-  
+
   ## Check for _GNU_SOURCE pthread extensions
   set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
   CHECK_SYMBOL_EXISTS ( "pthread_attr_setaffinity_np" "pthread.h" HAVE_PTHREAD_ATTR_SETAFFINITY_NP )
@@ -236,7 +236,7 @@ else()
   set(SRC_OS core/util/win/os_win.cpp
 	     libamdhsacode/win32/amd_core_dump.cpp)
 endif()
-         
+
 if ( BUILD_THUNK_VIRTIO )
   list(APPEND SRCS core/driver/virtio/amd_kfd_virtio_driver.cpp)
   target_compile_definitions(hsa-runtime64 PRIVATE HSAKMT_VIRTIO_ENABLED=1)

--- a/projects/rocr-runtime/runtime/hsa-runtime/cmake_modules/COPYING-CMAKE-SCRIPTS
+++ b/projects/rocr-runtime/runtime/hsa-runtime/cmake_modules/COPYING-CMAKE-SCRIPTS
@@ -7,7 +7,7 @@ are met:
 2. Redistributions in binary form must reproduce the copyright
    notice, this list of conditions and the following disclaimer in the
    documentation and/or other materials provided with the distribution.
-3. The name of the author may not be used to endorse or promote products 
+3. The name of the author may not be used to endorse or promote products
    derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR

--- a/projects/rocr-runtime/runtime/hsa-runtime/cmake_modules/FindLibElf.cmake
+++ b/projects/rocr-runtime/runtime/hsa-runtime/cmake_modules/FindLibElf.cmake
@@ -29,7 +29,7 @@ if (UNIX)
       /opt/local/include
       /opt/local/include/libelf
       ENV CPATH)
-  
+
   find_library (LIBELF_LIBRARIES
     NAMES
       elf
@@ -42,15 +42,15 @@ if (UNIX)
       /opt/local/lib64
       ENV LIBRARY_PATH
       ENV LD_LIBRARY_PATH)
-  
+
   include (FindPackageHandleStandardArgs)
-  
-  
+
+
   # handle the QUIETLY and REQUIRED arguments and set LIBELF_FOUND to TRUE if all listed variables are TRUE
   FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibElf DEFAULT_MSG
     LIBELF_LIBRARIES
     LIBELF_INCLUDE_DIRS)
-  
+
   SET(CMAKE_REQUIRED_LIBRARIES elf)
   if (CMAKE_CXX_COMPILER_LOADED)
     INCLUDE(CheckCXXSourceCompiles)
@@ -64,9 +64,9 @@ if (UNIX)
   else()
   set ( ELF_GETSHDRSTRNDX "TRUE" )
   endif(CMAKE_CXX_COMPILER_LOADED)
-  
+
   mark_as_advanced(LIBELF_INCLUDE_DIRS LIBELF_LIBRARIES ELF_GETSHDRSTRNDX)
-  
+
   if(LIBELF_FOUND)
     add_library(elf::elf UNKNOWN IMPORTED)
     set_property(TARGET elf::elf PROPERTY IMPORTED_LOCATION ${LIBELF_LIBRARIES})
@@ -89,6 +89,6 @@ else()
   endif()
   set(USE_AMD_LIBELF "yes" CACHE FORCE "")
   set(AMD_ELFTOOLCHAIN_DIR ${ROCR_LIBELF_INCLUDE_DIR}/../..;${ROCR_LIBELF_INCLUDE_DIR}/../common/win32;${ROCR_LIBELF_INCLUDE_DIR}/../common)
-  set(ROCR_LIBELF_INCLUDE_DIR ${ROCR_LIBELF_INCLUDE_DIR};${AMD_ELFTOOLCHAIN_DIR}) 
-  set(LIBELF_INCLUDE_DIR ${ROCR_LIBELF_INCLUDE_DIR}) 
+  set(ROCR_LIBELF_INCLUDE_DIR ${ROCR_LIBELF_INCLUDE_DIR};${AMD_ELFTOOLCHAIN_DIR})
+  set(LIBELF_INCLUDE_DIR ${ROCR_LIBELF_INCLUDE_DIR})
 endif()

--- a/projects/rocr-runtime/runtime/hsa-runtime/cmake_modules/utils.cmake
+++ b/projects/rocr-runtime/runtime/hsa-runtime/cmake_modules/utils.cmake
@@ -54,10 +54,10 @@ function( get_path LIB CACHED_PATH HELP )
         find_file( FULLPATH NAMES ${ARGS_NAMES} HINTS ${${CACHED_PATH}} ${ARGS_HINTS} )
     endif()
     set( RESULT (NOT ${FULLPATH} MATCHES NOTFOUND) )
-    
+
     # Extract path
     get_filename_component ( DIRPATH ${FULLPATH} DIRECTORY )
-    
+
     # Check path against cache
     if( NOT "${${CACHED_PATH}}" STREQUAL "" )
         if ( NOT "${${CACHED_PATH}}" STREQUAL "${DIRPATH}" )

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/common/shared.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/common/shared.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_kernel.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_kernel.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_shaders.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_shaders.h
@@ -40,7 +40,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef OPENSRC_HSA_RUNTIME_CORE_INC_AMD_BLIT_SHADERS_H_ 
+#ifndef OPENSRC_HSA_RUNTIME_CORE_INC_AMD_BLIT_SHADERS_H_
 #define OPENSRC_HSA_RUNTIME_CORE_INC_AMD_BLIT_SHADERS_H_
 
 namespace rocr {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_elf_image.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_elf_image.hpp
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_loader_context.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_loader_context.hpp
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_topology.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_topology.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_trap_handler_v1.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_trap_handler_v1.h
@@ -40,8 +40,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef OPENSRC_HSA_RUNTIME_CORE_INC_AMD_TRAP_HANDLER_V1_H_ 
-#define OPENSRC_HSA_RUNTIME_CORE_INC_AMD_TRAP_HANDLER_V1_H_ 
+#ifndef OPENSRC_HSA_RUNTIME_CORE_INC_AMD_TRAP_HANDLER_V1_H_
+#define OPENSRC_HSA_RUNTIME_CORE_INC_AMD_TRAP_HANDLER_V1_H_
 
 namespace rocr {
 namespace AMD {
@@ -459,4 +459,4 @@ static const unsigned int kCodeTrapHandler10[] = {
 }  // namespace AMD
 }  // namespace rocr
 
-#endif  //OPENSRC_HSA_RUNTIME_CORE_INC_AMD_TRAP_HANDLER_V1_H_ 
+#endif  //OPENSRC_HSA_RUNTIME_CORE_INC_AMD_TRAP_HANDLER_V1_H_

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/blit.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/blit.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/checked.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/checked.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_api_trace_int.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_api_trace_int.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_interface.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_interface.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_internal.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_internal.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_table_interface.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_table_interface.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ven_amd_loader_impl.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ven_amd_loader_impl.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2020-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/registers.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/registers.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_loader_context.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_loader_context.cpp
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/blit_shaders/create_blit_shader_header.py
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/blit_shaders/create_blit_shader_header.py
@@ -1,7 +1,7 @@
 ################################################################################
 ##
-## Copyright (c) Advanced Micro Devices, Inc., or its affiliates. 
-## 
+## Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+##
 ## SPDX-License-Identifier: MIT
 ##
 ################################################################################
@@ -68,4 +68,3 @@ if len(sys.argv) > 1:
 
 else:
   print("Empty arguments!")
-  

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_interface.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_interface.cpp
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -63,7 +63,7 @@ ExtensionEntryPoints::ExtensionEntryPoints() {
 
 // Initialize Finalizer function table to be NULLs
 void ExtensionEntryPoints::InitFinalizerExtTable() {
-  
+
   // Initialize Version of Api Table
   finalizer_api.version.major_id = 0x00;
   finalizer_api.version.minor_id = 0x00;
@@ -79,7 +79,7 @@ void ExtensionEntryPoints::InitFinalizerExtTable() {
 
 // Initialize Image function table to be NULLs
 void ExtensionEntryPoints::InitImageExtTable() {
- 
+
   // Initialize Version of Api Table
   image_api.version.major_id = 0x00;
   image_api.version.minor_id = 0x00;
@@ -128,10 +128,10 @@ void ExtensionEntryPoints::InitAmdExtTable() {
 // begins hosting Api's from other extension libraries
 void ExtensionEntryPoints::UpdateAmdExtTable(decltype(::hsa_amd_image_create)* func_ptr) {
   assert(hsa_api_table().amd_ext_api.hsa_amd_image_create_fn ==
-             (decltype(hsa_amd_image_create)*)hsa_ext_null && 
+             (decltype(hsa_amd_image_create)*)hsa_ext_null &&
              "Duplicate load of extension import.");
   assert(hsa_internal_api_table().amd_ext_api.hsa_amd_image_create_fn ==
-             (decltype(hsa_amd_image_create)*)hsa_ext_null && 
+             (decltype(hsa_amd_image_create)*)hsa_ext_null &&
              "Duplicate load of extension import.");
   hsa_api_table().amd_ext_api.hsa_amd_image_create_fn = func_ptr;
   hsa_internal_api_table().amd_ext_api.hsa_amd_image_create_fn = func_ptr;
@@ -226,7 +226,7 @@ bool ExtensionEntryPoints::LoadFinalizer(std::string library_name) {
     return false;
   }
   libs_.push_back(lib);
-  
+
   void* ptr;
 
   ptr = os::GetExportAddress(lib, "hsa_ext_program_create_impl");
@@ -281,12 +281,12 @@ bool ExtensionEntryPoints::LoadFinalizer(std::string library_name) {
     finalizer_api.hsa_ext_program_finalize_fn =
         (decltype(::hsa_ext_program_finalize)*)ptr;
   }
-  
+
   // Initialize Version of Api Table
   finalizer_api.version.major_id = HSA_FINALIZER_API_TABLE_MAJOR_VERSION;
   finalizer_api.version.minor_id = sizeof(::FinalizerExtTable);
   finalizer_api.version.step_id = HSA_FINALIZER_API_TABLE_STEP_VERSION;
- 
+
   // Update handle of table of HSA extensions
   hsa_internal_api_table().CloneExts(&finalizer_api,
                                     core::HsaApiTable::HSA_EXT_FINALIZER_API_TABLE_ID);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/isa.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/isa.cpp
@@ -288,7 +288,7 @@ const IsaRegistry::IsaMap& IsaRegistry::GetSupportedIsas() {
   if (supported_isas->size() > 0) {
     return *supported_isas;
   }
-  
+
   auto parse_out_minor_ver = [&](const std::string& generic_name) -> int32_t {
       size_t dot_pos = generic_name.find('.');
       int32_t min;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/create_trap_handler_header.py
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/create_trap_handler_header.py
@@ -1,7 +1,7 @@
 ################################################################################
 ##
-## Copyright (c) Advanced Micro Devices, Inc., or its affiliates. 
-## 
+## Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+##
 ## SPDX-License-Identifier: MIT
 ##
 ################################################################################
@@ -68,4 +68,3 @@ if len(sys.argv) > 1:
 
 else:
   print("Empty arguments!")
-  

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler.s
@@ -267,7 +267,7 @@ trap_entry:
   //   [0x08] out_buf_t* stochastic_trap_buffers;
   //
   // --- Start profile trap handlers GFX9 --- //
-  // If the wave entered the trap handler: 
+  // If the wave entered the trap handler:
   // If on gfx9:
   // - Check SQ_WAVE_PC_HI_HT_SHIFT bit on TTMP1 register to
   //   identify if it was a host trap.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/atomic_helpers.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/atomic_helpers.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2025, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
@@ -539,7 +539,7 @@ typedef struct EventDescriptor_ {
 EventHandle CreateOsEvent(bool auto_reset, bool init_state) {
   EventDescriptor* eventDescrp;
   eventDescrp = (EventDescriptor*)malloc(sizeof(EventDescriptor));
-  
+
   if(!eventDescrp) { return nullptr; }
 
   pthread_mutex_init(&eventDescrp->mutex, NULL);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/locks.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/locks.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -52,12 +52,12 @@ namespace rocr {
 
 class HybridMutex {
  public:
-  HybridMutex():lock_(0) { 
-    sem_ = os::CreateSemaphore(); 
+  HybridMutex():lock_(0) {
+    sem_ = os::CreateSemaphore();
   }
 
-  ~HybridMutex() { 
-    os::DestroySemaphore(sem_); 
+  ~HybridMutex() {
+    os::DestroySemaphore(sem_);
   }
 
   bool Try() {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/mpsc_queue.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/mpsc_queue.hpp
@@ -153,7 +153,7 @@ public:
         Node* head = head_.ptr.load(std::memory_order_relaxed);
         Node* next = head->next.load(std::memory_order_acquire);
         if (!next) return false;
-        out = next->value; 
+        out = next->value;
         return true;
     }
 
@@ -229,4 +229,4 @@ private:
 };
 
 }
-#endif // HSA_RUNTIME_CORE_UTIL_MPSC_QUEUE_HPP_ 
+#endif // HSA_RUNTIME_CORE_UTIL_MPSC_QUEUE_HPP_

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/small_heap.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/small_heap.cpp
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/small_heap.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/small_heap.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/timer.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/timer.cpp
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/timer.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/timer.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -168,6 +168,6 @@ class fast_clock {
   static init fast_clock_init;
 };
 }   //  namespace timer
-}   //  namespace rocr  
+}   //  namespace rocr
 
 #endif

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2025, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/blit_src/create_hsaco_ascii_file.py
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/blit_src/create_hsaco_ascii_file.py
@@ -1,7 +1,7 @@
 ################################################################################
 ##
-## Copyright (c) Advanced Micro Devices, Inc., or its affiliates. 
-## 
+## Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+##
 ## SPDX-License-Identifier: MIT
 ##
 ################################################################################
@@ -68,4 +68,3 @@ if len(sys.argv) > 1:
 
 else:
   print("Empty arguments!")
-  

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_lut_gfx11.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_lut_gfx11.cpp
@@ -46,7 +46,7 @@
 namespace rocr {
 namespace image {
 
-  /* 
+  /*
    * The type table has changed for gfx11, so we need a separate instance for
    * the Property LUT
    */

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_ai.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_ai.cpp
@@ -196,7 +196,7 @@ hsa_status_t ImageManagerAi::PopulateImageSrd(Image& image, const metadata_amd_t
       ((SQ_IMG_RSRC_WORD3*)(&image.srd[3]))->bits.TYPE =
           ImageLut().MapGeometry(image.desc.geometry);
     }
-    
+
     // Imported metadata holds the offset to metadata, add the image base address.
     uintptr_t meta = uintptr_t(((SQ_IMG_RSRC_WORD5*)(&image.srd[5]))->bits.META_DATA_ADDRESS_HI) << 40;
     meta |= uintptr_t(((SQ_IMG_RSRC_WORD7*)(&image.srd[7]))->bits.META_DATA_ADDRESS) << 8;
@@ -583,7 +583,7 @@ uint32_t ImageManagerAi::GetAddrlibSurfaceInfoAi(
   prefSettingsInput.resourceType    = in.resourceType;
 
   // Disallow all swizzles but linear.
-  if (tileMode == Image::TileMode::LINEAR) 
+  if (tileMode == Image::TileMode::LINEAR)
   {
       prefSettingsInput.forbiddenBlock.macroThin4KB = 1;
       prefSettingsInput.forbiddenBlock.macroThick4KB = 1;

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_gfx11.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_gfx11.cpp
@@ -332,7 +332,7 @@ hsa_status_t ImageManagerGfx11::PopulateImageSrd(Image& image,
       reinterpret_cast<SQ_IMG_RSRC_WORD3*>(&image.srd[3])->bits.TYPE =
           ImageLut().MapGeometry(image.desc.geometry);
     }
-    
+
     // Imported metadata holds the offset to metadata, add the image base address.
     uintptr_t meta = uintptr_t(((SQ_IMG_RSRC_WORD7*)(&image.srd[7]))->bits.META_DATA_ADDRESS_HI) << 16;
     meta |= uintptr_t(((SQ_IMG_RSRC_WORD6*)(&image.srd[6]))->bits.META_DATA_ADDRESS) << 8;

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_nv.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_nv.cpp
@@ -190,7 +190,7 @@ static FORMAT GetCombinedFormat(uint8_t fmt, uint8_t type) {
   return CFMT_INVALID;
 };
 //-----------------------------------------------------------------------------
-// End workaround 
+// End workaround
 //-----------------------------------------------------------------------------
 
 ImageManagerNv::ImageManagerNv() : ImageManagerKv() {}
@@ -319,7 +319,7 @@ hsa_status_t ImageManagerNv::PopulateImageSrd(Image& image,
       reinterpret_cast<SQ_IMG_RSRC_WORD3*>(&image.srd[3])->bits.TYPE =
           ImageLut().MapGeometry(image.desc.geometry);
     }
-    
+
     // Imported metadata holds the offset to metadata, add the image base address.
     uintptr_t meta = uintptr_t(((SQ_IMG_RSRC_WORD7*)(&image.srd[7]))->bits.META_DATA_ADDRESS_HI) << 16;
     meta |= uintptr_t(((SQ_IMG_RSRC_WORD6*)(&image.srd[6]))->bits.META_DATA_ADDRESS) << 8;

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_nv.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_nv.h
@@ -40,8 +40,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef EXT_IMAGE_IMAGE_MANAGER_NV_H_ 
-#define EXT_IMAGE_IMAGE_MANAGER_NV_H_ 
+#ifndef EXT_IMAGE_IMAGE_MANAGER_NV_H_
+#define EXT_IMAGE_IMAGE_MANAGER_NV_H_
 
 #include "addrlib/inc/addrinterface.h"
 #include "image_manager_kv.h"
@@ -95,4 +95,4 @@ class ImageManagerNv : public ImageManagerKv {
 
 }  // namespace image
 }  // namespace rocr
-#endif  // EXT_IMAGE_IMAGE_MANAGER_NV_H_ 
+#endif  // EXT_IMAGE_IMAGE_MANAGER_NV_H_

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_runtime.cpp
@@ -421,7 +421,7 @@ hsa_status_t ImageRuntime::CreateImageHandleWithLayout(
 
   if(image_layout->version!=1)
     return (hsa_status_t)HSA_EXT_STATUS_ERROR_IMAGE_FORMAT_UNSUPPORTED;
-  
+
   uint32_t id;
   HSA::hsa_agent_get_info(component, (hsa_agent_info_t)HSA_AMD_AGENT_INFO_CHIP_ID, &id);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/resource_gfx11.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/resource_gfx11.h
@@ -573,7 +573,7 @@ struct sq_img_samp_word2_t {
   unsigned int BLEND_PRT          : SQ_IMG_SAMP_WORD2_BLEND_PTR_SZ;
   unsigned int DERIV_ADJUST_EN    : SQ_IMG_SAMP_WORD2_DERIV_ADJUST_EN_SZ;
 #elif defined(BIGENDIAN_CPU)
-  unsigned int DERIV_ADJUST_EN    : SQ_IMG_SAMP_WORD2_DERIV_ADJUST_EN_SZ 
+  unsigned int DERIV_ADJUST_EN    : SQ_IMG_SAMP_WORD2_DERIV_ADJUST_EN_SZ
   unsigned int BLEND_PRT          : SQ_IMG_SAMP_WORD2_BLEND_PRT_SZ;
   unsigned int ANISO_OVERRIDE     : SQ_IMG_SAMP_WORD2_ANISO_OVERRIDE_SZ;
   unsigned int                    : 1;

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/resource_gfx11.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/resource_gfx11.h
@@ -573,7 +573,7 @@ struct sq_img_samp_word2_t {
   unsigned int BLEND_PRT          : SQ_IMG_SAMP_WORD2_BLEND_PTR_SZ;
   unsigned int DERIV_ADJUST_EN    : SQ_IMG_SAMP_WORD2_DERIV_ADJUST_EN_SZ;
 #elif defined(BIGENDIAN_CPU)
-  unsigned int DERIV_ADJUST_EN    : SQ_IMG_SAMP_WORD2_DERIV_ADJUST_EN_SZ
+  unsigned int DERIV_ADJUST_EN    : SQ_IMG_SAMP_WORD2_DERIV_ADJUST_EN_SZ;
   unsigned int BLEND_PRT          : SQ_IMG_SAMP_WORD2_BLEND_PRT_SZ;
   unsigned int ANISO_OVERRIDE     : SQ_IMG_SAMP_WORD2_ANISO_OVERRIDE_SZ;
   unsigned int                    : 1;

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/resource_gfx12.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/resource_gfx12.h
@@ -438,7 +438,7 @@ union SQ_IMG_RSRC_WORD7 {
 
 
 
-	
+
 #define SQ_IMG_SAMP_WORD0_REG_SZ 32
 #define SQ_IMG_SAMP_WORD0_CLAMP_X_SZ            3
 #define SQ_IMG_SAMP_WORD0_CLAMP_Y_SZ            3

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/amd_hsa_common.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/amd_hsa_common.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/amd_hsa_kernel_code.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/amd_hsa_kernel_code.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/amd_hsa_signal.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/amd_hsa_signal.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_amd_tool.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_amd_tool.h
@@ -1,9 +1,9 @@
 /*
- * Copyright © Advanced Micro Devices, Inc., or its affiliates. 
- * 
+ * Copyright © Advanced Micro Devices, Inc., or its affiliates.
+ *
  * SPDX-License-Identifier: MIT
  */
- 
+
 #ifndef HSA_RUNTIME_AMD_TOOL_EVENTS_H_
 #define HSA_RUNTIME_AMD_TOOL_EVENTS_H_
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_finalize.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_finalize.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_image.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_image.h
@@ -2,24 +2,24 @@
 //
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
-// 
+//
 // Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
-// 
+//
 // Developed by:
-// 
+//
 //                 AMD Research and AMD HSA Software Development
-// 
+//
 //                 Advanced Micro Devices, Inc.
-// 
+//
 //                 www.amd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to
 // deal with the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense,
 // and/or sell copies of the Software, and to permit persons to whom the
 // Software is furnished to do so, subject to the following conditions:
-// 
+//
 //  - Redistributions of source code must retain the above copyright notice,
 //    this list of conditions and the following disclaimers.
 //  - Redistributions in binary form must reproduce the above copyright
@@ -29,7 +29,7 @@
 //    nor the names of its contributors may be used to endorse or promote
 //    products derived from this Software without specific prior written
 //    permission.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
@@ -54,7 +54,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif /*__cplusplus*/ 
+#endif /*__cplusplus*/
 
 /** \defgroup ext-images Images and Samplers
  *  @{
@@ -267,7 +267,7 @@ typedef enum {
  * @brief A fixed-size type used to represent ::hsa_ext_image_channel_type_t constants.
  */
 typedef uint32_t hsa_ext_image_channel_type32_t;
-    
+
 /**
  *
  * @brief Channel order associated with the elements of an image. See
@@ -303,7 +303,7 @@ typedef enum {
  * @brief A fixed-size type used to represent ::hsa_ext_image_channel_order_t constants.
  */
 typedef uint32_t hsa_ext_image_channel_order32_t;
-    
+
 
 /**
  * @brief Image format.
@@ -1170,7 +1170,7 @@ typedef enum {
  * @brief A fixed-size type used to represent ::hsa_ext_sampler_coordinate_mode_t constants.
  */
 typedef uint32_t hsa_ext_sampler_coordinate_mode32_t;
-    
+
 
 /**
  * @brief Sampler filter modes. See the <em>Filter Mode</em> section
@@ -1507,9 +1507,9 @@ typedef struct hsa_ext_images_1_pfn_s {
 
 } hsa_ext_images_1_pfn_t;
 /** @} */
-    
+
 #ifdef __cplusplus
 }  // end extern "C" block
-#endif /*__cplusplus*/ 
+#endif /*__cplusplus*/
 
 #endif

--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_elf_image.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_elf_image.cpp
@@ -213,18 +213,18 @@ namespace elf {
 #else // _WIN32
       int in = _open(filename.c_str(), O_RDONLY);
       if (in < 0) { return perror("open failed"); }
-      if (_lseek(in, 0L, SEEK_END) < 0) { 
+      if (_lseek(in, 0L, SEEK_END) < 0) {
         _close(in);
-        return perror("lseek failed"); 
+        return perror("lseek failed");
       }
       off_t size;
-      if ((size = _lseek(in, 0L, SEEK_CUR)) < 0) { 
+      if ((size = _lseek(in, 0L, SEEK_CUR)) < 0) {
         _close(in);
-        return perror("lseek(2) failed"); 
+        return perror("lseek(2) failed");
       }
-      if (_lseek(in, 0L, SEEK_SET) < 0) { 
+      if (_lseek(in, 0L, SEEK_SET) < 0) {
         _close(in);
-        return perror("lseek(3) failed"); 
+        return perror("lseek(3) failed");
       }
       if (_lseek(d, 0L, SEEK_SET) < 0) { return perror("lseek(3) failed"); }
       ssize_t written;
@@ -283,7 +283,7 @@ namespace elf {
         free(buffer1);
         return perror("Incomplete read");
       }
-      
+
       *buffer = buffer1;
       if (size) { *size = size1; }
       return true;

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -93,7 +93,7 @@ namespace rocr {
   // Having a side effect prevents call site optimization that allows removal of a noinline function call
   // with no side effect.
 #if defined(__linux__)
-  __attribute__((noinline)) 
+  __attribute__((noinline))
 #else
   __declspec(noinline)
 #endif
@@ -1615,7 +1615,7 @@ uint64_t ExecutableImpl::SymbolAddress(hsa_agent_t agent, elf::Symbol* sym)
 {
   elf::Section* sec = sym->section();
   if(!sec) { return NULL; }
-  
+
   Segment* seg = SectionSegment(agent, sec);
   uint64_t vaddr = sec->addr() + sym->value();
   return nullptr == seg ? 0 : (uint64_t) (uintptr_t) seg->Address(vaddr);

--- a/projects/rocr-runtime/runtime/packages/hsa-ext-rocr-dev/Old CMakeLists.txt
+++ b/projects/rocr-runtime/runtime/packages/hsa-ext-rocr-dev/Old CMakeLists.txt
@@ -59,7 +59,7 @@ set( PACKAGE_VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.
 set ( CPACK_GENERATOR "DEB;RPM" CACHE STRING "Package types to build")
 
 set ( PACKAGE_DIRECTORIES "hsa/lib")
-add_custom_command ( OUTPUT ${PACKAGE_DIRECTORIES} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${CMAKE_COMMAND} -E make_directory "hsa/lib" ) 
+add_custom_command ( OUTPUT ${PACKAGE_DIRECTORIES} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${CMAKE_COMMAND} -E make_directory "hsa/lib" )
 add_custom_target (create_dirs DEPENDS ${PACKAGE_DIRECTORIES} )
 
 set ( TOOLS_NAME     "libhsa-runtime-tools64" )


### PR DESCRIPTION
In order for pre-commit to be useful, everything needs to meet a common baseline.