### PR TITLE
Add Cline storage to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.cline_storage


### PR DESCRIPTION
## Motivation

The Cline plugin for Visual Studio Code will create the `.cline_storage` directory in the top-level directory. This PR ensures that it isn't checked into git.

## Technical Details

Adds `.cline_storage` to `.gitignore`.

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
