### PR TITLE
SWDEV-540027,SWDEV-533546 - Add e8m0 struct

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
@@ -1135,7 +1135,6 @@ struct __hip_fp8_e8m0 {
 
   __hip_fp8_e8m0() = default;
   __FP8_HOST_DEVICE__ inline explicit __hip_fp8_e8m0(const __half f) {
-    float intermediate_float = static_cast<float>(f);
     __x = __hip_cvt_float_to_e8m0(f, __default_saturation, __default_interpret);
   }
   __FP8_HOST_DEVICE__ inline explicit __hip_fp8_e8m0(const __hip_bfloat16 f) {

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
@@ -70,6 +70,7 @@
 #if !defined(__HIPCC_RTC__)
 #include <hip/amd_detail/amd_hip_common.h>
 #include <climits>
+#include <limits>
 
 #include "host_defines.h"          // __hip_internal::
 #include "amd_hip_vector_types.h"  // float2 etc
@@ -955,6 +956,8 @@ namespace hip_detail {
 
 constexpr __hip_fp8_storage_t e8m0_NaN = 0xFFU;
 constexpr __hip_internal::uint16_t bf16_NaN = 0x7FFFU;
+constexpr __hip_internal::uint32_t float_NaN = 0x7FFFFFFFU;
+constexpr __hip_internal::uint64_t double_NaN = 0x7FFFFFFFFFFFFFFFU;
 
 constexpr __hip_internal::uint16_t bf16_sig_mask = 0x007FU;
 constexpr __hip_internal::uint32_t float_sig_mask = 0x007FFFFFU;
@@ -971,6 +974,64 @@ constexpr __hip_internal::uint64_t double_sign_mask = 0x8000000000000000U;
 constexpr __hip_internal::uint16_t bf16_half_sig_bit = 0x0040U;
 constexpr __hip_internal::uint32_t float_half_sig_bit = 0x00400000U;
 constexpr __hip_internal::uint64_t double_half_sig_bit = 0x0008000000000000U;
+
+__FP8_HOST_DEVICE_STATIC__ float __internal_cvt_e8m0_to_float(const __hip_fp8_storage_t x) {
+  union {
+    float as_float;
+    __hip_internal::uint32_t as_int;
+  } ret;
+
+  switch (x) {
+    case 0x00U: {
+      ret.as_int = float_half_sig_bit;
+      break;
+    }
+    case hip_detail::e8m0_NaN:
+      ret.as_int = float_NaN;
+      break;
+    default:
+      ret.as_int = static_cast<__hip_internal::uint32_t>(x) << 23;
+  };
+  return ret.as_float;
+}
+
+__FP8_HOST_DEVICE_STATIC__ double __internal_cvt_e8m0_to_double(const __hip_fp8_storage_t x) {
+  union {
+    double as_double;
+    __hip_internal::uint64_t as_int;
+  } ret;
+
+  switch (x) {
+    case 0x00U:
+      ret.as_int = double_half_sig_bit;
+      break;
+    case hip_detail::e8m0_NaN:
+      ret.as_int = double_NaN;
+      break;
+    default:
+      // shift due to bias difference between double and single precision exponents
+      ret.as_int = (static_cast<__hip_internal::uint64_t>(x + 0x0380U) << 52);
+  }
+  return ret.as_double;
+}
+
+// Converts e8m0 to arbitrary integer type T
+// Uses conversion to float for bounds check
+// Double round not a concern as e8m0 is just the f32 mantissa
+template <typename T_int>
+__FP8_HOST_DEVICE_STATIC__ T_int internal_cvt_e8m0_to_int_type(__hip_fp8_storage_t x) {
+  float f = __internal_cvt_e8m0_to_float(x);
+  if (x == hip_detail::e8m0_NaN) {
+    return 0;
+  }
+  if (f > std::numeric_limits<T_int>::max()) {
+    return std::numeric_limits<T_int>::max();
+  }
+  if (f < std::numeric_limits<T_int>::lowest()) {
+    return std::numeric_limits<T_int>::lowest();
+  }
+  return static_cast<T_int>(f);
+}
 
 }  // namespace hip_detail
 
@@ -1059,13 +1120,122 @@ __FP8_HOST_DEVICE_STATIC__ __hip_bfloat16_raw
 __hip_cvt_e8m0_to_bf16raw(const __hip_fp8_storage_t x) {
   switch (x) {
     case 0x00U:
-      return __hip_bfloat16_raw{0x0040U};
+      return __hip_bfloat16_raw{hip_detail::bf16_half_sig_bit};
     case hip_detail::e8m0_NaN:
       return __hip_bfloat16_raw{hip_detail::bf16_NaN};
     default:
       return __hip_bfloat16_raw{static_cast<unsigned short>(x << 7)};
   }
 }
+
+struct __hip_fp8_e8m0 {
+  __hip_fp8_storage_t __x;  //! raw storage of fp8 number
+  constexpr static __hip_saturation_t __default_saturation = __HIP_SATFINITE;
+  constexpr static hipRoundMode __default_interpret = hipRoundPosInf;
+
+  __hip_fp8_e8m0() = default;
+  __FP8_HOST_DEVICE__ inline explicit __hip_fp8_e8m0(const __half f) {
+    float intermediate_float = static_cast<float>(f);
+    __x = __hip_cvt_float_to_e8m0(f, __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__ inline explicit __hip_fp8_e8m0(const __hip_bfloat16 f) {
+    __x = __hip_cvt_bfloat16raw_to_e8m0(f, __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__ inline explicit __hip_fp8_e8m0(const double f) {
+    __x = __hip_cvt_double_to_e8m0(f, __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__ inline explicit __hip_fp8_e8m0(const float f) {
+    __x = __hip_cvt_float_to_e8m0(f, __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__ inline explicit __hip_fp8_e8m0(const int val) {
+    __x =
+        __hip_cvt_float_to_e8m0(static_cast<float>(val), __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__ inline explicit __hip_fp8_e8m0(const long int val) {
+    __x =
+        __hip_cvt_float_to_e8m0(static_cast<float>(val), __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__
+  inline explicit __hip_fp8_e8m0(const long long int val) {
+    __x =
+        __hip_cvt_float_to_e8m0(static_cast<float>(val), __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__
+  inline explicit __hip_fp8_e8m0(const short int val) {
+    __x =
+        __hip_cvt_float_to_e8m0(static_cast<float>(val), __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__
+  inline explicit __hip_fp8_e8m0(const unsigned int val) {
+    __x =
+        __hip_cvt_float_to_e8m0(static_cast<float>(val), __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__
+  inline explicit __hip_fp8_e8m0(const unsigned long int val) {
+    __x =
+        __hip_cvt_float_to_e8m0(static_cast<float>(val), __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__
+  inline explicit __hip_fp8_e8m0(const unsigned long long int val) {
+    __x =
+        __hip_cvt_float_to_e8m0(static_cast<float>(val), __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__
+  inline explicit __hip_fp8_e8m0(const unsigned short int val) {
+    __x =
+        __hip_cvt_float_to_e8m0(static_cast<float>(val), __default_saturation, __default_interpret);
+  }
+
+  __FP8_HOST_DEVICE__ inline explicit operator __half() const {
+    return __float2half_rn(static_cast<float>(*this));
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator __hip_bfloat16() const {
+    return static_cast<__hip_bfloat16>(__hip_cvt_e8m0_to_bf16raw(__x));
+  }
+
+  /* fp8_e8m0 can't represent a zero value, so always return true.*/
+  __FP8_HOST_DEVICE__ inline explicit operator bool() const { return true; }
+  __FP8_HOST_DEVICE__ inline explicit operator char() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<char>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator double() const {
+    return hip_detail::__internal_cvt_e8m0_to_double(__x);
+  }
+
+  __FP8_HOST_DEVICE__ inline explicit operator float() const {
+    return hip_detail::__internal_cvt_e8m0_to_float(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator int() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<int>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator long int() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<long int>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator long long int() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<long long int>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator short int() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<short int>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator signed char() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<signed char>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator unsigned char() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<unsigned char>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator unsigned int() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<unsigned int>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator unsigned long int() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<unsigned long int>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator unsigned long long int() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<unsigned long long int>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator unsigned short int() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<unsigned short int>(__x);
+  }
+};
 
 /**
  * \brief struct representing single fp8 number with e4m3 interpretation

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
@@ -956,8 +956,8 @@ namespace hip_detail {
 
 constexpr __hip_fp8_storage_t e8m0_NaN = 0xFFU;
 constexpr __hip_internal::uint16_t bf16_NaN = 0x7FFFU;
-constexpr __hip_internal::uint32_t float_NaN = 0x7FFFFFFFU;
-constexpr __hip_internal::uint64_t double_NaN = 0x7FFFFFFFFFFFFFFFU;
+constexpr __hip_internal::uint32_t default_float_NaN = 0x7FFF0000U;
+constexpr __hip_internal::uint64_t default_double_NaN = 0x7FFF000000000000U;
 
 constexpr __hip_internal::uint16_t bf16_sig_mask = 0x007FU;
 constexpr __hip_internal::uint32_t float_sig_mask = 0x007FFFFFU;
@@ -987,7 +987,7 @@ __FP8_HOST_DEVICE_STATIC__ float __internal_cvt_e8m0_to_float(const __hip_fp8_st
       break;
     }
     case hip_detail::e8m0_NaN:
-      ret.as_int = float_NaN;
+      ret.as_int = default_float_NaN;
       break;
     default:
       ret.as_int = static_cast<__hip_internal::uint32_t>(x) << 23;
@@ -1006,7 +1006,7 @@ __FP8_HOST_DEVICE_STATIC__ double __internal_cvt_e8m0_to_double(const __hip_fp8_
       ret.as_int = double_half_sig_bit;
       break;
     case hip_detail::e8m0_NaN:
-      ret.as_int = double_NaN;
+      ret.as_int = default_double_NaN;
       break;
     default:
       // shift due to bias difference between double and single precision exponents

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #include <hip_test_common.hh>
 #include <hip/hip_fp8.h>
 #include <cmath>
+#include <type_traits>
 
 void host_cvt_bfloat16raw_to_e8m0(const std::vector<__hip_bfloat16>& in,
                                   std::vector<unsigned char>& out, __hip_saturation_t sat,
@@ -342,3 +343,280 @@ TEST_CASE("Unit__hip_cvt_e8m0_to_bf16raw") {
   }
 }
 
+template <typename T_in, typename T_out>
+void host_e8m0_constructors(const std::vector<T_in>& in, std::vector<T_out>& out) {
+  for (size_t i = 0; i < in.size(); ++i) {
+    __hip_fp8_e8m0 fp8(in[i]);
+    out[i] = static_cast<T_out>(fp8);
+  }
+}
+
+template <typename T_in, typename T_out>
+__global__ void e8m0_constructors_kernel(const T_in* in, T_out* out, size_t size) {
+  size_t tid = threadIdx.x + blockDim.x * blockIdx.x;
+
+  if (tid < size) {
+    __hip_fp8_e8m0 fp8(in[tid]);
+    out[tid] = static_cast<T_out>(fp8);
+  }
+}
+
+template <typename T_in, typename T_out>
+void device_e8m0_constructors(const std::vector<T_in>& in, std::vector<T_out>& out) {
+  T_in* in_d = nullptr;
+  T_out* out_d = nullptr;
+  REQUIRE(in.size() < 1024);
+
+  HIP_CHECK(hipMalloc(&in_d, sizeof(T_in) * in.size()));
+  HIP_CHECK(hipMalloc(&out_d, sizeof(T_out) * out.size()));
+
+  HIP_CHECK(hipMemcpy(in_d, in.data(), sizeof(T_in) * in.size(), hipMemcpyHostToDevice));
+
+  e8m0_constructors_kernel<T_in, T_out><<<1, 1024>>>(in_d, out_d, in.size());
+
+  HIP_CHECK(hipMemcpy(out.data(), out_d, sizeof(T_out) * out.size(), hipMemcpyDeviceToHost));
+
+  HIP_CHECK(hipFree(in_d));
+  HIP_CHECK(hipFree(out_d));
+}
+
+template <typename T>
+void compare_e8m0_results(const std::vector<T>& out, const std::vector<T>& exp) {
+  for (size_t i = 0; i < out.size(); ++i) {
+    INFO("out:" << out[i] << " exp:" << exp[i] << " for index:" << i);
+    if constexpr (std::is_floating_point_v<T>) {
+      if (std::isnan(exp[i])) {
+        REQUIRE(std::isnan(out[i]));
+      } else {
+        REQUIRE_THAT(out[i],
+                     Catch::WithinAbs(exp[i], (T)1e-6) || Catch::WithinRel(exp[i], (T)1e-3));
+      }
+    } else {
+      REQUIRE(out[i] == exp[i]);
+    }
+  }
+}
+
+TEMPLATE_TEST_CASE("Unit_e8m0_float_constructors", , half, __hip_bfloat16, float, double) {
+  bool run_on_host = GENERATE(true, false);
+
+  std::vector<TestType> in = {0, 10, 16, -10, -16, std::nanf("0")};
+  std::array<float, 6> exp_values = {0, 16, 16, 16, 16, std::nanf("0")};
+
+  if constexpr (std::is_same_v<TestType, half> || std::is_same_v<TestType, __hip_bfloat16>) {
+    std::vector<float> exp(exp_values.begin(), exp_values.end());
+    std::vector<float> out(exp.size());
+
+    if (run_on_host) {
+      host_e8m0_constructors<TestType, float>(in, out);
+    } else {
+      device_e8m0_constructors<TestType, float>(in, out);
+    }
+    compare_e8m0_results(out, exp);
+  } else {
+    std::vector<TestType> exp(exp_values.begin(), exp_values.end());
+    std::vector<TestType> out(exp.size());
+
+    if (run_on_host) {
+      host_e8m0_constructors<TestType, TestType>(in, out);
+    } else {
+      device_e8m0_constructors<TestType, TestType>(in, out);
+    }
+    compare_e8m0_results(out, exp);
+  }
+}
+
+TEMPLATE_TEST_CASE("Unit_e8m0_int_constructors", , int, long int, long long int, short int,
+                   unsigned int, unsigned long int, unsigned long long int, unsigned short int) {
+  bool run_on_host = GENERATE(true, false);
+
+  std::vector<TestType> in = {
+      static_cast<TestType>(0),  static_cast<TestType>(1),  static_cast<TestType>(2),
+      static_cast<TestType>(4),  static_cast<TestType>(8),  static_cast<TestType>(15),
+      static_cast<TestType>(16), static_cast<TestType>(32), static_cast<TestType>(64)};
+  std::vector<TestType> exp = {
+      static_cast<TestType>(0),  static_cast<TestType>(1),  static_cast<TestType>(2),
+      static_cast<TestType>(4),  static_cast<TestType>(8),  static_cast<TestType>(16),
+      static_cast<TestType>(16), static_cast<TestType>(32), static_cast<TestType>(64)};
+
+  if constexpr (std::is_signed_v<TestType>) {
+    in.insert(in.end(),
+              {static_cast<TestType>(-1), static_cast<TestType>(-2), static_cast<TestType>(-4),
+               static_cast<TestType>(-8), static_cast<TestType>(-15), static_cast<TestType>(-16),
+               static_cast<TestType>(-32), static_cast<TestType>(-64)});
+    exp.insert(exp.end(),
+               {static_cast<TestType>(1), static_cast<TestType>(2), static_cast<TestType>(4),
+                static_cast<TestType>(8), static_cast<TestType>(16), static_cast<TestType>(16),
+                static_cast<TestType>(32), static_cast<TestType>(64)});
+  }
+
+  std::vector<TestType> out(exp.size());
+
+  if (run_on_host) {
+    host_e8m0_constructors<TestType, TestType>(in, out);
+  } else {
+    device_e8m0_constructors<TestType, TestType>(in, out);
+  }
+  compare_e8m0_results(out, exp);
+}
+
+template <typename T_out>
+void host_e8m0_float_conversions(const std::vector<float>& in, std::vector<T_out>& out) {
+  for (size_t i = 0; i < in.size(); ++i) {
+    __hip_fp8_e8m0 fp8(in[i]);
+    out[i] = static_cast<T_out>(fp8);
+  }
+}
+
+template <typename T_out>
+__global__ void e8m0_float_conversions_kernel(const float* in, T_out* out, size_t size) {
+  size_t tid = threadIdx.x + blockDim.x * blockIdx.x;
+
+  if (tid < size) {
+    __hip_fp8_e8m0 fp8(in[tid]);
+    out[tid] = static_cast<T_out>(fp8);
+  }
+}
+
+template <typename T_out>
+void device_e8m0_float_conversions(const std::vector<float>& in, std::vector<T_out>& out) {
+  float* in_d = nullptr;
+  T_out* out_d = nullptr;
+  REQUIRE(in.size() < 1024);
+
+  HIP_CHECK(hipMalloc(&in_d, sizeof(float) * in.size()));
+  HIP_CHECK(hipMalloc(&out_d, sizeof(T_out) * out.size()));
+
+  HIP_CHECK(hipMemcpy(in_d, in.data(), sizeof(float) * in.size(), hipMemcpyHostToDevice));
+
+  e8m0_float_conversions_kernel<T_out><<<1, 1024>>>(in_d, out_d, in.size());
+
+  HIP_CHECK(hipMemcpy(out.data(), out_d, sizeof(T_out) * out.size(), hipMemcpyDeviceToHost));
+
+  HIP_CHECK(hipFree(in_d));
+  HIP_CHECK(hipFree(out_d));
+}
+
+TEMPLATE_TEST_CASE("Unit_e8m0_float_conversions", , half, __hip_bfloat16, float, double) {
+  bool run_on_host = GENERATE(true, false);
+
+  std::vector<float> in = {0.0f, 10.0f, 16.0f, -10.0f, -16.0f, std::nanf("0")};
+  std::array<float, 6> exp_values = {0.0f, 16.0f, 16.0f, 16.0f, 16.0f, std::nanf("0")};
+
+  if constexpr (std::is_same_v<TestType, half> || std::is_same_v<TestType, __hip_bfloat16>) {
+    std::vector<float> exp(exp_values.begin(), exp_values.end());
+    std::vector<float> out(exp.size());
+
+    if (run_on_host) {
+      host_e8m0_float_conversions<float>(in, out);
+    } else {
+      device_e8m0_float_conversions<float>(in, out);
+    }
+    compare_e8m0_results(out, exp);
+  } else {
+    std::vector<TestType> exp(exp_values.begin(), exp_values.end());
+    std::vector<TestType> out(exp.size());
+
+    if (run_on_host) {
+      host_e8m0_float_conversions<TestType>(in, out);
+    } else {
+      device_e8m0_float_conversions<TestType>(in, out);
+    }
+    compare_e8m0_results(out, exp);
+  }
+}
+
+TEMPLATE_TEST_CASE("Unit_e8m0_int_conversions", , char, double, float, int, long int, long long int,
+                   short int, signed char, unsigned char, unsigned int, unsigned long int,
+                   unsigned long long int, unsigned short int) {
+  bool run_on_host = GENERATE(true, false);
+
+  std::vector<float> in = {0.0f, 1.0f, 2.0f, 4.0f, 8.0f, 15.0f, 16.0f, 32.0f, 64.0f};
+  std::vector<TestType> exp = {
+      static_cast<TestType>(0),  static_cast<TestType>(1),  static_cast<TestType>(2),
+      static_cast<TestType>(4),  static_cast<TestType>(8),  static_cast<TestType>(16),
+      static_cast<TestType>(16), static_cast<TestType>(32), static_cast<TestType>(64)};
+  if constexpr (std::is_signed_v<TestType>) {
+    // Test negative values if signed
+    in.insert(in.end(), {-1.0f, -2.0f, -4.0f, -8.0f, -15.0f, -16.0f, -32.0f, -64.0f});
+    exp.insert(exp.end(),
+               {static_cast<TestType>(1), static_cast<TestType>(2), static_cast<TestType>(4),
+                static_cast<TestType>(8), static_cast<TestType>(16), static_cast<TestType>(16),
+                static_cast<TestType>(32), static_cast<TestType>(64)});
+  }
+
+  std::vector<TestType> out(exp.size());
+
+  if (run_on_host) {
+    host_e8m0_float_conversions<TestType>(in, out);
+  } else {
+    device_e8m0_float_conversions<TestType>(in, out);
+  }
+  compare_e8m0_results(out, exp);
+}
+
+template <typename T_out>
+void host_e8m0_saturation_conversions(const std::vector<unsigned char>& in,
+                                      std::vector<T_out>& out) {
+  for (size_t i = 0; i < in.size(); ++i) {
+    __hip_fp8_e8m0 fp8;
+    fp8.__x = in[i];
+    out[i] = static_cast<T_out>(fp8);
+  }
+}
+
+template <typename T_out>
+__global__ void e8m0_saturation_conversions_kernel(const unsigned char* in, T_out* out,
+                                                   size_t size) {
+  size_t tid = threadIdx.x + blockDim.x * blockIdx.x;
+
+  if (tid < size) {
+    __hip_fp8_e8m0 fp8;
+    fp8.__x = in[tid];
+    out[tid] = static_cast<T_out>(fp8);
+  }
+}
+
+template <typename T_out>
+void device_e8m0_saturation_conversions(const std::vector<unsigned char>& in,
+                                        std::vector<T_out>& out) {
+  unsigned char* in_d = nullptr;
+  T_out* out_d = nullptr;
+  REQUIRE(in.size() < 1024);
+
+  HIP_CHECK(hipMalloc(&in_d, sizeof(unsigned char) * in.size()));
+  HIP_CHECK(hipMalloc(&out_d, sizeof(T_out) * out.size()));
+
+  HIP_CHECK(hipMemcpy(in_d, in.data(), sizeof(unsigned char) * in.size(), hipMemcpyHostToDevice));
+
+  e8m0_saturation_conversions_kernel<T_out><<<1, 1024>>>(in_d, out_d, in.size());
+
+  HIP_CHECK(hipMemcpy(out.data(), out_d, sizeof(T_out) * out.size(), hipMemcpyDeviceToHost));
+
+  HIP_CHECK(hipFree(in_d));
+  HIP_CHECK(hipFree(out_d));
+}
+
+TEMPLATE_TEST_CASE("Unit_e8m0_int_conversions_saturation", , char, int, long int, long long int,
+                   short int, signed char, unsigned char, unsigned int, unsigned long int,
+                   unsigned long long int, unsigned short int) {
+  bool run_on_host = GENERATE(true, false);
+
+  // Test with maximum non-NAN e8m0 value
+  std::vector<unsigned char> in = {0xFE};
+  std::vector<TestType> out(in.size());
+
+  if (run_on_host) {
+    host_e8m0_saturation_conversions<TestType>(in, out);
+  } else {
+    device_e8m0_saturation_conversions<TestType>(in, out);
+  }
+
+  // Verify that the output is clamped to the maximum value of TestType
+  TestType expected_max = std::numeric_limits<TestType>::max();
+
+  for (size_t i = 0; i < out.size(); ++i) {
+    INFO("out:" << out[i] << " expected_max:" << expected_max << " for index:" << i);
+    REQUIRE(out[i] == expected_max);
+  }
+}

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
@@ -526,8 +526,8 @@ TEMPLATE_TEST_CASE("Unit_e8m0_float_conversions", , half, __hip_bfloat16, float,
   }
 }
 
-TEMPLATE_TEST_CASE("Unit_e8m0_int_conversions", , char, double, float, int, long int, long long int,
-                   short int, signed char, unsigned char, unsigned int, unsigned long int,
+TEMPLATE_TEST_CASE("Unit_e8m0_int_conversions", , char, int, long int, long long int, short int,
+                   signed char, unsigned char, unsigned int, unsigned long int,
                    unsigned long long int, unsigned short int) {
   bool run_on_host = GENERATE(true, false);
 


### PR DESCRIPTION
## Motivation

This PR adds the __hip_e8m0 fp8 struct. It is used to store the scaling value of a floating point/bf16 value. Primarily used for fast low precision arithmetic.

## Technical Details

This PR adds the __hip_e8m0 fp8 struct and its associated conversions/constructors

## Test Plan

Testing has been added for these conversions and constructors. We test saturation, NaN's, negative values, and positive values on both host and devices.

## Test Result

Tests pass locally

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
