### PR TITLE
[rocprofiler-systems] Add cached demangler and replace old demangle

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.hpp
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "core/demangler.hpp"
 #include "defines.hpp"
 
 #include <timemory/settings/macros.hpp>
@@ -273,7 +274,7 @@ TIMEMORY_CEREAL_SAVE_FUNCTION_NAME(SettingsTextArchive& ar, const NameValuePair<
     }
     else
     {
-        ar.setNextType(tim::demangle<T>().c_str());
+        ar.setNextType(rocprofsys::utility::demangle<T>().c_str());
     }
     ar(t.value);
 }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.hpp
@@ -45,7 +45,6 @@
 namespace regex_const = ::std::regex_constants;  // NOLINT
 namespace comp        = ::tim::component;        // NOLINT
 using settings        = ::tim::settings;         // NOLINT
-using tim::demangle;                             // NOLINT
 using tim::type_list;                            // NOLINT
 
 //--------------------------------------------------------------------------------------//

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/component_categories.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/component_categories.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "common.hpp"
+#include "core/demangler.hpp"
 #include "defines.hpp"
 
 #include <timemory/components/types.hpp>
@@ -51,7 +52,7 @@ struct component_categories
         (void) _cleanup;  // unused but set if sizeof...(Tp) == 0
 
         TIMEMORY_FOLD_EXPRESSION(_v.emplace(TIMEMORY_JOIN(
-            "::", "component", _cleanup(tim::try_demangle<Tp>(), "tim::"))));
+            "::", "component", _cleanup(rocprofsys::utility::demangle<Tp>(), "tim::"))));
     }
 
     void operator()(std::set<std::string>& _v) const

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/get_categories.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/get_categories.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "common.hpp"
+#include "core/demangler.hpp"
 
 #include <timemory/utility/demangle.hpp>
 #include <timemory/utility/type_list.hpp>
@@ -43,7 +44,7 @@ get_categories(type_list<Tp...>)
     };
     (void) _cleanup;  // unused but set if sizeof...(Tp) == 0
 
-    auto _vec = str_vec_t{ _cleanup(demangle<Tp>(), "tim::")... };
+    auto _vec = str_vec_t{ _cleanup(rocprofsys::utility::demangle<Tp>(), "tim::")... };
     std::sort(_vec.begin(), _vec.end(), [](const auto& lhs, const auto& rhs) {
         // prioritize project category
         auto lpos = lhs.find("project::");

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
@@ -29,6 +29,8 @@
 #include <timemory/components/timing/wall_clock.hpp>
 #include <timemory/utility/join.hpp>
 
+#include "core/demangler.hpp"
+
 #include <algorithm>
 #include <link.h>
 #include <linux/limits.h>
@@ -893,7 +895,8 @@ process_modules(const std::vector<module_t*>& _app_modules)
 
         for(auto* fitr : symtab_data.functions.at(itr))
         {
-            symtab_data.typed_func_names[tim::demangle(fitr->getName())] = fitr;
+            symtab_data.typed_func_names[rocprofsys::utility::demangle(fitr->getName())] =
+                fitr;
 
             symtab_data.symbols.emplace(fitr, std::vector<symtab_symbol_t*>{});
             if(!fitr->getSymbols(symtab_data.symbols.at(fitr))) continue;
@@ -906,7 +909,6 @@ process_modules(const std::vector<module_t*>& _app_modules)
             }
         }
     }
-
     _pr.stop();
     _wc.stop();
     verbprintf(0, "Processing %zu modules... Done (%.3f %s, %.3f %s)\n",

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/function_signature.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/function_signature.cpp
@@ -22,6 +22,8 @@
 
 #include "function_signature.hpp"
 
+#include "core/demangler.hpp"
+
 function_signature::function_signature(std::string_view _ret, std::string_view _name,
                                        std::string_view _file, location_t _row,
                                        location_t _col, bool _loop, bool _info_beg,
@@ -32,7 +34,7 @@ function_signature::function_signature(std::string_view _ret, std::string_view _
 , m_row(std::move(_row))
 , m_col(std::move(_col))
 , m_return(_ret)
-, m_name(tim::demangle(_name.data()))
+, m_name(rocprofsys::utility::demangle(_name.data()))
 , m_file(_file)
 {
     if(m_file.find('/') != std::string_view::npos)

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
@@ -27,6 +27,7 @@
 #include "binary/scope_filter.hpp"
 #include "binary/symbol.hpp"
 #include "common/defines.h"
+#include "core/demangler.hpp"
 #include "core/utility.hpp"
 #include "fwd.hpp"
 #include "log.hpp"
@@ -491,7 +492,7 @@ get_internal_libs_data_impl()
             for(const auto& fitr : _funcs)
             {
                 auto _fname = fitr->getName();
-                auto _dname = tim::demangle(_fname);
+                auto _dname = rocprofsys::utility::demangle(_fname);
 
                 _data[itr.first][_mpath].emplace(_fname);
                 _data[itr.first][_mpath].emplace(_dname);

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -24,6 +24,7 @@
 #include "common/defines.h"
 #include "common/join.hpp"
 #include "common/path.hpp"
+#include "core/demangler.hpp"
 #include "dl/dl.hpp"
 #include "fwd.hpp"
 #include "internal_libs.hpp"
@@ -1451,8 +1452,8 @@ main(int argc, char** argv)
        dynamic_cast<process_t*>(addr_space) != nullptr)
     {
         errprintf(-1, "address space statisfied dynamic_cast<%s> and dynamic_cast<%s>.\n",
-                  tim::demangle<binary_edit_t*>().c_str(),
-                  tim::demangle<process_t*>().c_str());
+                  rocprofsys::utility::demangle<binary_edit_t*>().c_str(),
+                  rocprofsys::utility::demangle<process_t*>().c_str());
     }
 
     auto _rewrite = (dynamic_cast<binary_edit_t*>(addr_space) != nullptr &&

--- a/projects/rocprofiler-systems/source/lib/binary/symbol.cpp
+++ b/projects/rocprofiler-systems/source/lib/binary/symbol.cpp
@@ -41,6 +41,7 @@
 #include <libcoff.h>
 
 #include "core/binary/fwd.hpp"
+#include "core/demangler.hpp"
 #include "core/timemory.hpp"
 #include "core/utility.hpp"
 #include "dwarf_entry.hpp"
@@ -116,7 +117,8 @@ symbol::operator()(const std::vector<scope_filter>& _filters) const
     using sf = scope_filter;
 
     // apply filters to the main symbol
-    return (sf::satisfies_filter(_filters, sf::FUNCTION_FILTER, demangle(func)) &&
+    return (sf::satisfies_filter(_filters, sf::FUNCTION_FILTER,
+                                 rocprofsys::utility::demangle(func)) &&
             (sf::satisfies_filter(_filters, sf::SOURCE_FILTER, file) ||
              sf::satisfies_filter(_filters, sf::SOURCE_FILTER, join(':', file, line))));
 }
@@ -283,7 +285,8 @@ symbol::get_inline_symbols(const std::vector<scope_filter>& _filters) const
 
     for(const auto& itr : inlines)
     {
-        if(sf::satisfies_filter(_filters, sf::FUNCTION_FILTER, demangle(itr.func)) &&
+        if(sf::satisfies_filter(_filters, sf::FUNCTION_FILTER,
+                                rocprofsys::utility::demangle(itr.func)) &&
            (sf::satisfies_filter(_filters, sf::SOURCE_FILTER, itr.file) ||
             sf::satisfies_filter(_filters, sf::SOURCE_FILTER,
                                  join(':', itr.file, itr.line))))
@@ -316,7 +319,8 @@ symbol::get_debug_line_info(const std::vector<scope_filter>& _filters) const
 
     auto _data = Tp{};
 
-    if(sf::satisfies_filter(_filters, sf::FUNCTION_FILTER, demangle(func)))
+    if(sf::satisfies_filter(_filters, sf::FUNCTION_FILTER,
+                            rocprofsys::utility::demangle(func)))
     {
         for(const auto& itr : dwarf_info)
         {
@@ -361,7 +365,7 @@ symbol::serialize(ArchiveT& ar, const unsigned int)
        make_nvp("line", line), make_nvp("func", func), make_nvp("file", file),
        make_nvp("inlines", inlines), make_nvp("dwarf_info", dwarf_info));
     if constexpr(concepts::is_output_archive<ArchiveT>::value)
-        ar(cereal::make_nvp("dfunc", demangle(func)));
+        ar(cereal::make_nvp("dfunc", rocprofsys::utility::demangle(func)));
 }
 
 template void

--- a/projects/rocprofiler-systems/source/lib/core/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/CMakeLists.txt
@@ -137,3 +137,7 @@ set_target_properties(
     rocprofiler-systems-core-library
     PROPERTIES OUTPUT_NAME ${BINARY_NAME_PREFIX}-core
 )
+
+if(ROCPROFSYS_BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/projects/rocprofiler-systems/source/lib/core/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/CMakeLists.txt
@@ -48,8 +48,6 @@ set(core_sources
     ${CMAKE_CURRENT_LIST_DIR}/state.cpp
     ${CMAKE_CURRENT_LIST_DIR}/timemory.cpp
     ${CMAKE_CURRENT_LIST_DIR}/utility.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/agent_manager.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/node_info.cpp
 )
 
 set(core_headers
@@ -66,6 +64,7 @@ set(core_headers
     ${CMAKE_CURRENT_LIST_DIR}/constraint.hpp
     ${CMAKE_CURRENT_LIST_DIR}/cpu.hpp
     ${CMAKE_CURRENT_LIST_DIR}/debug.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/demangler.hpp
     ${CMAKE_CURRENT_LIST_DIR}/dynamic_library.hpp
     ${CMAKE_CURRENT_LIST_DIR}/exception.hpp
     ${CMAKE_CURRENT_LIST_DIR}/gpu.hpp
@@ -81,9 +80,6 @@ set(core_headers
     ${CMAKE_CURRENT_LIST_DIR}/state.hpp
     ${CMAKE_CURRENT_LIST_DIR}/timemory.hpp
     ${CMAKE_CURRENT_LIST_DIR}/utility.hpp
-    ${CMAKE_CURRENT_LIST_DIR}/agent.hpp
-    ${CMAKE_CURRENT_LIST_DIR}/agent_manager.hpp
-    ${CMAKE_CURRENT_LIST_DIR}/node_info.hpp
 )
 
 add_library(rocprofiler-systems-core-library STATIC)

--- a/projects/rocprofiler-systems/source/lib/core/common.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/common.hpp
@@ -115,12 +115,10 @@ namespace policy    = ::tim::policy;     // NOLINT
 namespace trait     = ::tim::trait;      // NOLINT
 namespace cereal    = ::tim::cereal;     // NOLINT
 
-using ::tim::auto_lock_t;   // NOLINT
-using ::tim::demangle;      // NOLINT
-using ::tim::get_env;       // NOLINT
-using ::tim::set_env;       // NOLINT
-using ::tim::try_demangle;  // NOLINT
-using ::tim::type_mutex;    // NOLINT
+using ::tim::auto_lock_t;  // NOLINT
+using ::tim::get_env;      // NOLINT
+using ::tim::set_env;      // NOLINT
+using ::tim::type_mutex;   // NOLINT
 
 struct construct_on_thread
 {

--- a/projects/rocprofiler-systems/source/lib/core/demangler.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/demangler.hpp
@@ -1,0 +1,98 @@
+// MIT License
+//
+// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <cstdlib>
+#include <cxxabi.h>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+
+namespace rocprofsys
+{
+namespace utility
+{
+
+struct demangler
+{
+    template <typename Tp>
+    std::string demangle()
+    {
+        return demangle(typeid(Tp).name());
+    }
+
+    std::string demangle(std::string_view _mangled_name)
+    {
+        if(_mangled_name.empty()) return {};
+
+        std::lock_guard<std::mutex> _lk{ m_mutex };
+
+        auto _it = m_cache.find(_mangled_name);
+        if(_it != m_cache.end()) return _it->second;
+
+        auto _result = demangle_impl(_mangled_name.data());
+        m_cache.emplace(_mangled_name, _result);
+        return _result;
+    }
+
+private:
+    std::mutex                                      m_mutex;
+    std::map<std::string, std::string, std::less<>> m_cache;
+
+    static std::string demangle_impl(const char* _mangled_name)
+    {
+        int                                         _status = 0;
+        std::unique_ptr<char, decltype(&std::free)> _demangled(
+            abi::__cxa_demangle(_mangled_name, nullptr, nullptr, &_status), &std::free);
+
+        if(_status != 0 || !_demangled) return std::string{ _mangled_name };
+
+        return std::string{ _demangled.get() };
+    }
+};
+
+inline demangler&
+get_demangler()
+{
+    static demangler g_demangler;
+    return g_demangler;
+}
+
+template <typename Tp>
+inline std::string
+demangle()
+{
+    return get_demangler().demangle<Tp>();
+}
+
+inline std::string
+demangle(std::string_view name)
+{
+    return get_demangler().demangle(name);
+}
+
+}  // namespace utility
+}  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/demangler.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/demangler.hpp
@@ -28,6 +28,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <string_view>
 
@@ -58,19 +59,25 @@ struct demangler
     {
         if(_mangled_name.empty()) return {};
 
-        std::lock_guard<std::mutex> _lk{ m_mutex };
+        const auto result = try_get_from_cache(_mangled_name);
+        if(result._found)
+        {
+            return result._cache_it->second;
+        }
 
-        auto _it = m_cache.find(_mangled_name);
-        if(_it != m_cache.end()) return _it->second;
-
-        auto _result = demangle_impl(_mangled_name.data());
-        m_cache.emplace(_mangled_name, _result);
-        return _result;
+        return demangle_and_cache(_mangled_name);
     }
 
 private:
-    std::mutex                                      m_mutex;
+    std::shared_mutex                               m_mutex;
     std::map<std::string, std::string, std::less<>> m_cache;
+    using cache_iterator = typename decltype(m_cache)::iterator;
+
+    struct cache_result
+    {
+        bool           _found;
+        cache_iterator _cache_it;
+    };
 
     static std::string demangle_impl(const char* _mangled_name)
     {
@@ -81,6 +88,34 @@ private:
         if(_status != 0 || !_demangled) return std::string{ _mangled_name };
 
         return std::string{ _demangled.get() };
+    }
+
+    cache_result try_get_from_cache(std::string_view _mangled_name)
+    {
+        std::shared_lock<std::shared_mutex> _read_lock{ m_mutex };
+
+        auto _it = m_cache.find(_mangled_name);
+        if(_it != m_cache.end())
+        {
+            return { true, _it };
+        }
+
+        return { false, m_cache.end() };
+    }
+
+    std::string demangle_and_cache(std::string_view _mangled_name)
+    {
+        std::unique_lock<std::shared_mutex> _write_lock{ m_mutex };
+
+        auto _it = m_cache.find(_mangled_name);
+        if(_it != m_cache.end())
+        {
+            return _it->second;
+        }
+
+        auto _result = demangle_impl(_mangled_name.data());
+        m_cache.emplace(_mangled_name, _result);
+        return _result;
     }
 };
 

--- a/projects/rocprofiler-systems/source/lib/core/demangler.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/demangler.hpp
@@ -65,6 +65,7 @@ struct demangler
             return result._cache_it->second;
         }
 
+        // Possible improvement: Limit the cache size to avoid memory bloat
         return demangle_and_cache(_mangled_name);
     }
 

--- a/projects/rocprofiler-systems/source/lib/core/demangler.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/demangler.hpp
@@ -36,6 +36,16 @@ namespace rocprofsys
 namespace utility
 {
 
+struct cxa_demangle_wrapper_impl
+{
+    static char* demangle(const char* _mangled_name, char* _output_buffer,
+                          size_t* _length, int* _status)
+    {
+        return abi::__cxa_demangle(_mangled_name, _output_buffer, _length, _status);
+    }
+};
+
+template <typename DemanglerTp = cxa_demangle_wrapper_impl>
 struct demangler
 {
     template <typename Tp>
@@ -66,7 +76,7 @@ private:
     {
         int                                         _status = 0;
         std::unique_ptr<char, decltype(&std::free)> _demangled(
-            abi::__cxa_demangle(_mangled_name, nullptr, nullptr, &_status), &std::free);
+            DemanglerTp::demangle(_mangled_name, nullptr, nullptr, &_status), &std::free);
 
         if(_status != 0 || !_demangled) return std::string{ _mangled_name };
 
@@ -74,7 +84,7 @@ private:
     }
 };
 
-inline demangler&
+inline demangler<>&
 get_demangler()
 {
     static demangler g_demangler;

--- a/projects/rocprofiler-systems/source/lib/core/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -9,28 +9,22 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
-add_executable(
-    rocprof-sys-unit-tests
-    $<TARGET_OBJECTS:lib-common-tests>
-    $<TARGET_OBJECTS:trace-cache-tests>
-    $<TARGET_OBJECTS:demangler-tests>
-)
+add_library(demangler-tests OBJECT demangler_test.cpp)
 
 target_link_libraries(
-    rocprof-sys-unit-tests
-    PRIVATE
-        rocprofiler-systems-googletest-library
-        rocprofiler-systems-common-library
-        rocprofiler-systems-core-library
+    demangler-tests
+    PRIVATE rocprofiler-systems-googletest-library rocprofiler-systems-core-library
 )
+
+target_include_directories(demangler-tests PRIVATE ${PROJECT_SOURCE_DIR}/source/lib)

--- a/projects/rocprofiler-systems/source/lib/core/tests/demangler_test.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/tests/demangler_test.cpp
@@ -1,0 +1,155 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "gtest/gtest.h"
+
+#include "core/demangler.hpp"
+
+#include <cstring>
+#include <string>
+
+struct mock_demangler_impl
+{
+    static inline int call_count = 0;
+
+    static char* demangle(const char* _mangled_name, char*, size_t*, int* _status)
+    {
+        ++call_count;
+
+        if(std::string(_mangled_name).find("FAIL") != std::string::npos)
+        {
+            *_status = -1;
+            return nullptr;
+        }
+
+        std::string result = "demangled_" + std::string(_mangled_name);
+        char*       output = static_cast<char*>(std::malloc(result.size() + 1));
+        memcpy(output, result.c_str(), result.size() + 1);
+        *_status = 0;
+        return output;
+    }
+};
+
+class demangler_test : public ::testing::Test
+{
+protected:
+    void SetUp() override { mock_demangler_impl::call_count = 0; }
+};
+
+TEST_F(demangler_test, successful_demangle)
+{
+    rocprofsys::utility::demangler<mock_demangler_impl> demangler;
+    std::string result = demangler.demangle("mangled");
+
+    EXPECT_EQ(result, "demangled_mangled");
+    EXPECT_EQ(mock_demangler_impl::call_count, 1);
+}
+
+TEST_F(demangler_test, failed_demangle_returns_original)
+{
+    rocprofsys::utility::demangler<mock_demangler_impl> demangler;
+    std::string result = demangler.demangle("mangled_FAIL");
+
+    EXPECT_EQ(result, "mangled_FAIL");
+    EXPECT_EQ(mock_demangler_impl::call_count, 1);
+}
+
+TEST_F(demangler_test, empty_string_returns_empty)
+{
+    rocprofsys::utility::demangler<mock_demangler_impl> demangler;
+    std::string                                         result = demangler.demangle("");
+
+    EXPECT_TRUE(result.empty());
+    EXPECT_EQ(mock_demangler_impl::call_count, 0);
+}
+
+TEST_F(demangler_test, caching_prevents_redundant_calls)
+{
+    rocprofsys::utility::demangler<mock_demangler_impl> demangler;
+
+    std::string first  = demangler.demangle("mangled");
+    std::string second = demangler.demangle("mangled");
+    std::string third  = demangler.demangle("mangled");
+
+    EXPECT_EQ(first, "demangled_mangled");
+    EXPECT_EQ(first, second);
+    EXPECT_EQ(second, third);
+    EXPECT_EQ(mock_demangler_impl::call_count, 1);
+}
+
+TEST_F(demangler_test, different_inputs_cached_separately)
+{
+    rocprofsys::utility::demangler<mock_demangler_impl> demangler;
+
+    std::string result1       = demangler.demangle("mangled1");
+    std::string result2       = demangler.demangle("mangled2");
+    std::string result1_again = demangler.demangle("mangled1");
+
+    EXPECT_EQ(result1, "demangled_mangled1");
+    EXPECT_EQ(result2, "demangled_mangled2");
+    EXPECT_EQ(result1, result1_again);
+    EXPECT_EQ(mock_demangler_impl::call_count, 2);
+}
+
+TEST_F(demangler_test, string_view_interface)
+{
+    rocprofsys::utility::demangler<mock_demangler_impl> demangler;
+    std::string                                         str = "mangled";
+    std::string_view                                    sv{ str };
+
+    std::string result = demangler.demangle(sv);
+
+    EXPECT_EQ(result, "demangled_mangled");
+    EXPECT_EQ(mock_demangler_impl::call_count, 1);
+}
+
+TEST_F(demangler_test, template_demangle_interface)
+{
+    rocprofsys::utility::demangler<mock_demangler_impl> demangler;
+    std::string result = demangler.demangle<int>();
+
+    EXPECT_NE(result.find("demangled_"), std::string::npos);
+    EXPECT_FALSE(result.empty());
+}
+
+TEST_F(demangler_test, cache_handles_failed_demangle)
+{
+    rocprofsys::utility::demangler<mock_demangler_impl> demangler;
+
+    std::string first  = demangler.demangle("FAIL");
+    std::string second = demangler.demangle("FAIL");
+
+    EXPECT_EQ(first, "FAIL");
+    EXPECT_EQ(first, second);
+    EXPECT_EQ(mock_demangler_impl::call_count, 1);
+}
+
+TEST_F(demangler_test, multiple_instances_independent_caches)
+{
+    rocprofsys::utility::demangler<mock_demangler_impl> demangler1;
+    rocprofsys::utility::demangler<mock_demangler_impl> demangler2;
+
+    demangler1.demangle("mangled");
+    demangler2.demangle("mangled");
+
+    EXPECT_EQ(mock_demangler_impl::call_count, 2);
+}

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
@@ -25,6 +25,7 @@
 #include "core/agent_manager.hpp"
 #include "core/categories.hpp"
 #include "core/common_types.hpp"
+#include "core/demangler.hpp"
 #include "core/gpu_metrics.hpp"
 #include "core/utility.hpp"
 #include "library/tracing.hpp"
@@ -474,7 +475,7 @@ perfetto_processor_t::handle([[maybe_unused]] const kernel_dispatch_sample& _kds
         throw std::runtime_error("Kernel symbol is missing for kernel dispatch");
     }
 
-    auto kernel_name = tim::demangle(kernel_symbol->kernel_name);
+    auto kernel_name = rocprofsys::utility::demangle(kernel_symbol->kernel_name);
 
     const auto _track =
         tracing::get_perfetto_track(category::rocm_kernel_dispatch{}, _track_desc,

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.cpp
@@ -25,6 +25,7 @@
 #include "core/common_types.hpp"
 #include "core/config.hpp"
 #include "core/debug.hpp"
+#include "core/demangler.hpp"
 #include "core/gpu_metrics.hpp"
 #include "core/node_info.hpp"
 #include "core/rocpd/data_processor.hpp"
@@ -90,8 +91,10 @@ rocpd_processor_t::handle([[maybe_unused]] const kernel_dispatch_sample& _kds)
         throw std::runtime_error("Kernel symbol is missing for kernel dispatch");
     }
 
-    auto region_name_primary_key = m_data_processor->insert_string(
-        tim::demangle(kernel_symbol->kernel_name).c_str());
+    auto region_name_primary_key =
+        m_data_processor->insert_string(rocprofsys::utility::get_demangler()
+                                            .demangle(kernel_symbol->kernel_name)
+                                            .c_str());
 
     auto stack_id        = _kds.correlation_id_internal;
     auto parent_stack_id = _kds.correlation_id_ancestor;
@@ -698,7 +701,7 @@ rocpd_processor_t::post_process_metadata()
     auto _kernel_symbols_list = m_metadata->get_kernel_symbol_list();
     for(const auto& kernel_symbol : _kernel_symbols_list)
     {
-        auto kernel_name = tim::demangle(kernel_symbol.kernel_name);
+        auto kernel_name = rocprofsys::utility::demangle(kernel_symbol.kernel_name);
         m_data_processor->insert_kernel_symbol(
             kernel_symbol.kernel_id, n_info.id, process_info.pid,
             kernel_symbol.code_object_id, kernel_symbol.kernel_name, kernel_name.c_str(),

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.cpp
@@ -40,7 +40,6 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
-#include <timemory/utility/demangle.hpp>
 
 #if ROCPROFSYS_USE_ROCM > 0
 #    include "library/rocprofiler-sdk/fwd.hpp"
@@ -91,10 +90,8 @@ rocpd_processor_t::handle([[maybe_unused]] const kernel_dispatch_sample& _kds)
         throw std::runtime_error("Kernel symbol is missing for kernel dispatch");
     }
 
-    auto region_name_primary_key =
-        m_data_processor->insert_string(rocprofsys::utility::get_demangler()
-                                            .demangle(kernel_symbol->kernel_name)
-                                            .c_str());
+    auto region_name_primary_key = m_data_processor->insert_string(
+        rocprofsys::utility::demangle(kernel_symbol->kernel_name).c_str());
 
     auto stack_id        = _kds.correlation_id_internal;
     auto parent_stack_id = _kds.correlation_id_ancestor;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
@@ -30,6 +30,7 @@
 #include "core/config.hpp"
 #include "core/containers/c_array.hpp"
 #include "core/debug.hpp"
+#include "core/demangler.hpp"
 #include "core/state.hpp"
 #include "core/utility.hpp"
 #include "library/causal/delay.hpp"
@@ -399,7 +400,8 @@ save_line_info_impl(std::ostream&                           _ofs,
             _ofs << "    " << as_hex(_addr_off) << " [" << as_hex(_addr)
                  << "] :: " << itr.file;
             if(itr.line > 0) _ofs << ":" << itr.line;
-            if(!itr.func.empty()) _ofs << " [" << tim::demangle(itr.func) << "]";
+            if(!itr.func.empty())
+                _ofs << " [" << rocprofsys::utility::demangle(itr.func) << "]";
             _ofs << "\n";
 
             if(std::get<0>(_info))
@@ -408,7 +410,7 @@ save_line_info_impl(std::ostream&                           _ofs,
                 {
                     _ofs << "        " << ditr.file << ":" << ditr.line;
                     if(!ditr.func.empty())
-                        _ofs << " [" << tim::demangle(ditr.func) << "]";
+                        _ofs << " [" << rocprofsys::utility::demangle(ditr.func) << "]";
                     _ofs << "\n";
                 }
             }
@@ -608,14 +610,16 @@ perform_experiment_impl(std::shared_ptr<std::promise<void>> _started)  // NOLINT
                                     << " :: " << std::setw(5) << std::boolalpha
                                     << _is_eligible << " :: " << as_hex(itr.first) << " "
                                     << _linfo->location << ":" << _linfo->lineno << " ["
-                                    << demangle(_linfo->name) << "]\n";
+                                    << rocprofsys::utility::demangle(_linfo->name)
+                                    << "]\n";
                             for(const auto& iitr : _linfo->lineinfo.lines)
                             {
-                                _sample << "    " << std::setw(8) << itr.second
-                                        << " :: " << std::setw(5) << std::boolalpha
-                                        << _is_eligible << " :: " << as_hex(itr.first)
-                                        << " " << iitr.location << ":" << iitr.line
-                                        << " [" << demangle(iitr.name) << "]\n";
+                                _sample
+                                    << "    " << std::setw(8) << itr.second
+                                    << " :: " << std::setw(5) << std::boolalpha
+                                    << _is_eligible << " :: " << as_hex(itr.first) << " "
+                                    << iitr.location << ":" << iitr.line << " ["
+                                    << rocprofsys::utility::demangle(iitr.name) << "]\n";
                             }
                         }
                     }
@@ -839,8 +843,11 @@ sample_selection(size_t _nitr, size_t _wait_ns)
                             as_hex(_lookup_addr).c_str(), as_hex(_addr).c_str(),
                             as_hex(_sym_addr).c_str(),
                             (_location.empty()) ? "" : _location.data(),
-                            demangle(itr.func).c_str(), itr.file.c_str(), itr.line,
-                            itr.address.as_string().c_str(), itr.address.size());
+                            rocprofsys::utility::get_demangler()
+                                .demangle(itr.func)
+                                .c_str(),
+                            itr.file.c_str(), itr.line, itr.address.as_string().c_str(),
+                            itr.address.size());
                     }
                 }
             }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
@@ -843,9 +843,7 @@ sample_selection(size_t _nitr, size_t _wait_ns)
                             as_hex(_lookup_addr).c_str(), as_hex(_addr).c_str(),
                             as_hex(_sym_addr).c_str(),
                             (_location.empty()) ? "" : _location.data(),
-                            rocprofsys::utility::get_demangler()
-                                .demangle(itr.func)
-                                .c_str(),
+                            rocprofsys::utility::demangle(itr.func).c_str(),
                             itr.file.c_str(), itr.line, itr.address.as_string().c_str(),
                             itr.address.size());
                     }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/experiment.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/experiment.cpp
@@ -27,6 +27,7 @@
 #include "common/defines.h"
 #include "core/config.hpp"
 #include "core/debug.hpp"
+#include "core/demangler.hpp"
 #include "core/state.hpp"
 #include "library/causal/components/backtrace.hpp"
 #include "library/causal/components/progress_point.hpp"
@@ -127,7 +128,7 @@ experiment::sample::serialize(ArchiveT& ar, const unsigned)
 
     if constexpr(concepts::is_output_archive<ArchiveT>::value)
     {
-        ar(cereal::make_nvp("dfunc", demangle(name)),
+        ar(cereal::make_nvp("dfunc", rocprofsys::utility::demangle(name)),
            cereal::make_nvp("dwarf_info", std::vector<binary::dwarf_entry>{}));
     }
     ar(cereal::make_nvp("inlines", inlines));
@@ -140,7 +141,7 @@ std::string
 experiment::sample::get_identifier() const
 {
     return (lineno > 0 && !location.empty()) ? join(":", location, lineno)
-                                             : demangle(name);
+                                             : rocprofsys::utility::demangle(name);
 }
 
 template <typename ArchiveT>
@@ -391,7 +392,7 @@ experiment::as_string() const
         }
         return _v;
     };
-    auto _func = _patch(demangle(selection.symbol.func));
+    auto _func = _patch(rocprofsys::utility::demangle(selection.symbol.func));
     _ss << "['" << _func << "']";
 
     return _ss.str();
@@ -620,7 +621,7 @@ experiment::save_experiments(std::string _fname_base, const filename_config_t& _
                 as_hex(_line_info.address).c_str(), _line_info.file.c_str(),
                 _line_info.line, _line_info.func.c_str());
 
-            ofs << "experiment\tselected=" << demangle(_name)
+            ofs << "experiment\tselected=" << rocprofsys::utility::demangle(_name)
                 << "\tspeedup=" << std::setprecision(2)
                 << static_cast<double>(itr.virtual_speedup / 100.0)
                 << "\tduration=" << itr.duration << "\tselected-samples=" << itr.selected
@@ -637,7 +638,8 @@ experiment::save_experiments(std::string _fname_base, const filename_config_t& _
                 if(pitr.second.is_throughput_point() && pitr.second.get_delta() != 0)
                 {
                     ofs << "throughput-point\tname="
-                        << tim::demangle(tim::get_hash_identifier(pitr.first))
+                        << rocprofsys::utility::demangle(
+                               tim::get_hash_identifier(pitr.first))
                         << "\tdelta=" << pitr.second.get_delta() << "\n";
                     if(get_causal_end_to_end()) break;
                 }
@@ -646,7 +648,8 @@ experiment::save_experiments(std::string _fname_base, const filename_config_t& _
                     if(get_causal_end_to_end()) continue;
                     auto _delta = std::max<int64_t>(pitr.second.get_latency_delta(), 1);
                     ofs << "latency-point\tname="
-                        << tim::demangle(tim::get_hash_identifier(pitr.first))
+                        << rocprofsys::utility::demangle(
+                               tim::get_hash_identifier(pitr.first))
                         << "\tarrivals=" << pitr.second.get_arrival()
                         << "\tdepartures=" << pitr.second.get_departure()
                         << "\tdifference=" << _delta << "\n";

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace.cpp
@@ -24,6 +24,7 @@
 #include "core/components/fwd.hpp"
 #include "core/config.hpp"
 #include "core/debug.hpp"
+#include "core/demangler.hpp"
 #include "core/perfetto.hpp"
 #include "core/state.hpp"
 #include "library/components/ensure_storage.hpp"
@@ -150,7 +151,7 @@ backtrace::filter_and_patch(const std::vector<entry_type>& _data)
     _ret.reserve(_data.size());
     for(const auto& itr : _data)
     {
-        auto _name = tim::demangle(_patch_label(itr.name));
+        auto _name = rocprofsys::utility::demangle(_patch_label(itr.name));
         auto _use  = _use_label(_name);
         if(_use == -1) break;
         if(_use == 0) continue;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
@@ -24,6 +24,7 @@
 
 #include "core/config.hpp"
 #include "core/defines.hpp"
+#include "core/demangler.hpp"
 #include "core/state.hpp"
 #include "core/timemory.hpp"
 #include "core/trace_cache/cache_manager.hpp"
@@ -403,7 +404,10 @@ category_region<CategoryT>::audit(const gotcha_data_t& _data, audit::incoming,
         {
             int64_t _n = 0;
             ROCPROFSYS_FOLD_EXPRESSION(tracing::add_perfetto_annotation(
-                ctx, tim::try_demangle<std::remove_reference_t<Args>>(), _args, _n++));
+                ctx,
+                rocprofsys::utility::get_demangler()
+                    .demangle<std::remove_reference_t<Args>>(),
+                _args, _n++));
         }
     });
 }
@@ -431,7 +435,10 @@ category_region<CategoryT>::audit(std::string_view _name, audit::incoming,
         {
             int64_t _n = 0;
             ROCPROFSYS_FOLD_EXPRESSION(tracing::add_perfetto_annotation(
-                ctx, tim::try_demangle<std::remove_reference_t<Args>>(), _args, _n++));
+                ctx,
+                rocprofsys::utility::get_demangler()
+                    .demangle<std::remove_reference_t<Args>>(),
+                _args, _n++));
         }
     });
 }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
@@ -404,9 +404,7 @@ category_region<CategoryT>::audit(const gotcha_data_t& _data, audit::incoming,
         {
             int64_t _n = 0;
             ROCPROFSYS_FOLD_EXPRESSION(tracing::add_perfetto_annotation(
-                ctx,
-                rocprofsys::utility::get_demangler()
-                    .demangle<std::remove_reference_t<Args>>(),
+                ctx, rocprofsys::utility::demangle<std::remove_reference_t<Args>>(),
                 _args, _n++));
         }
     });
@@ -435,9 +433,7 @@ category_region<CategoryT>::audit(std::string_view _name, audit::incoming,
         {
             int64_t _n = 0;
             ROCPROFSYS_FOLD_EXPRESSION(tracing::add_perfetto_annotation(
-                ctx,
-                rocprofsys::utility::get_demangler()
-                    .demangle<std::remove_reference_t<Args>>(),
+                ctx, rocprofsys::utility::demangle<std::remove_reference_t<Args>>(),
                 _args, _n++));
         }
     });

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpip.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpip.hpp
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "core/demangler.hpp"
 #include "core/timemory.hpp"
 
 #include <timemory/components/base.hpp>
@@ -184,7 +185,8 @@ rocprofsys::component::activate_mpip()
 
         static std::string _label = []() {
             std::stringstream ss;
-            ss << "rocprofsys-mpip-" << demangle<Toolset>() << "-" << demangle<Tag>();
+            ss << "rocprofsys-mpip-" << rocprofsys::utility::demangle<Toolset>() << "-"
+               << rocprofsys::utility::demangle<Tag>();
             return ss.str();
         }();
         ROCPROFSYS_BASIC_DEBUG_F("Adding cleanup for %s", _label.c_str());
@@ -208,7 +210,8 @@ rocprofsys::component::deactivate_mpip(uint64_t id)
     {
         static std::string _label = []() {
             std::stringstream ss;
-            ss << "rocprofsys-mpip-" << demangle<Toolset>() << "-" << demangle<Tag>();
+            ss << "rocprofsys-mpip-" << rocprofsys::utility::demangle<Toolset>() << "-"
+               << rocprofsys::utility::demangle<Tag>();
             return ss.str();
         }();
         ROCPROFSYS_BASIC_DEBUG_F("Removing cleanup for %s", _label.c_str());

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -28,6 +28,7 @@
 #include "core/config.hpp"
 #include "core/containers/stable_vector.hpp"
 #include "core/debug.hpp"
+#include "core/demangler.hpp"
 #include "core/gpu.hpp"
 #include "core/perfetto.hpp"
 #include "core/state.hpp"
@@ -335,8 +336,9 @@ iterate_args_callback(rocprofiler_callback_tracing_kind_t /*kind*/, int32_t /*op
 {
     auto* _data = static_cast<function_args_t*>(data);
     if(arg_type && arg_name && arg_value_str)
-        _data->emplace_back(
-            argument_info{ arg_number, demangle(arg_type), arg_name, arg_value_str });
+        _data->emplace_back(argument_info{ arg_number,
+                                           rocprofsys::utility::demangle(arg_type),
+                                           arg_name, arg_value_str });
     return 0;
 }
 
@@ -388,8 +390,8 @@ get_backtrace(std::optional<std::vector<tim::unwind::processed_entry>>& _bt_data
                 (_linfo && _linfo.line > 0)
                            ? join("", _linfo.line)
                            : ((itr.lineno == 0) ? std::string{ "?" } : join("", itr.lineno));
-            auto _entry                              = join("", demangle(*_func), " @ ",
-                                                            join(':', ::basename(_loc->c_str()), _line));
+            auto _entry = join("", rocprofsys::utility::demangle(*_func), " @ ",
+                               join(':', ::basename(_loc->c_str()), _line));
             backtrace[join("", "frame#", _bt_cnt++)] = _entry;
         }
     }
@@ -771,7 +773,7 @@ tool_tracing_callback_stop(
                                              : ((itr.lineno == 0) ? std::string{ "?" }
                                                                   : join("", itr.lineno));
                             auto _entry =
-                                join("", demangle(*_func), " @ ",
+                                join("", rocprofsys::utility::demangle(*_func), " @ ",
                                      join(':', ::basename(_loc->c_str()), _line));
                             if(_bt_cnt < 10)
                             {
@@ -1139,12 +1141,13 @@ ompt_tracing_callback_stop(
                             (_linfo && !_linfo.location.empty())
                                 ? &_linfo.location
                                 : ((itr.location.empty()) ? &_unk : &itr.location);
-                        auto _line  = (_linfo && _linfo.line > 0)
-                                          ? join("", _linfo.line)
-                                          : ((itr.lineno == 0) ? std::string{ "?" }
-                                                               : join("", itr.lineno));
-                        auto _entry = join("", demangle(*_func), " @ ",
-                                           join(':', ::basename(_loc->c_str()), _line));
+                        auto _line = (_linfo && _linfo.line > 0)
+                                         ? join("", _linfo.line)
+                                         : ((itr.lineno == 0) ? std::string{ "?" }
+                                                              : join("", itr.lineno));
+                        auto _entry =
+                            join("", rocprofsys::utility::demangle(*_func), " @ ",
+                                 join(':', ::basename(_loc->c_str()), _line));
                         if(_bt_cnt < 10)
                         {
                             // Prepend zero for better ordering in UI. Only one zero
@@ -1570,13 +1573,13 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
                 const auto* _kern_sym_data =
                     get_kernel_symbol_info(record->dispatch_info.kernel_id);
 
-                auto        _name     = tim::demangle(_kern_sym_data->kernel_name);
-                auto        _stack_id = record->correlation_id.internal;
-                auto        _beg_ns   = record->start_timestamp;
-                auto        _end_ns   = record->end_timestamp;
-                auto        _agent_id = record->dispatch_info.agent_id;
-                auto        _queue_id = record->dispatch_info.queue_id;
-                const auto* _agent    = tool_data->get_gpu_tool_agent(_agent_id);
+                auto _name = rocprofsys::utility::demangle(_kern_sym_data->kernel_name);
+                auto _stack_id     = record->correlation_id.internal;
+                auto _beg_ns       = record->start_timestamp;
+                auto _end_ns       = record->end_timestamp;
+                auto _agent_id     = record->dispatch_info.agent_id;
+                auto _queue_id     = record->dispatch_info.queue_id;
+                const auto* _agent = tool_data->get_gpu_tool_agent(_agent_id);
 
                 uint64_t _stream_id = get_stream_id(record).handle;
                 if(_stream_id == 0)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/counters.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/counters.cpp
@@ -22,6 +22,7 @@
 
 #include "library/rocprofiler-sdk/counters.hpp"
 #include "core/agent_manager.hpp"
+#include "core/demangler.hpp"
 #include "core/trace_cache/cache_manager.hpp"
 #include "core/trace_cache/metadata_registry.hpp"
 #include "library/rocprofiler-sdk/fwd.hpp"
@@ -94,7 +95,9 @@ counter_event::operator()(const client_data* tool_data, ::perfetto::CounterTrack
     const auto* _kern_sym_data =
         tool_data->get_kernel_symbol_info(_dispatch_info.kernel_id);
 
-    auto _bundle = counter_bundle_t{ tim::demangle(_kern_sym_data->kernel_name), _scope };
+    auto _bundle =
+        counter_bundle_t{ rocprofsys::utility::demangle(_kern_sym_data->kernel_name),
+                          _scope };
 
     _bundle.push(_dispatch_info.queue_id.handle)
         .start()

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
@@ -1548,8 +1548,7 @@ post_process_perfetto(int64_t _tid, const std::vector<timer_sampling_data>& _tim
                                         tracing::add_perfetto_annotation(
                                             ctx, _label.c_str(),
                                             JOIN('@',
-                                                 rocprofsys::utility::get_demangler()
-                                                     .demangle(line.name),
+                                                 rocprofsys::utility::demangle(line.name),
                                                  JOIN(':', line.location, line.line)));
                                     }
                                 }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
@@ -25,6 +25,7 @@
 #include "core/components/fwd.hpp"
 #include "core/config.hpp"
 #include "core/debug.hpp"
+#include "core/demangler.hpp"
 #include "core/locking.hpp"
 #include "core/node_info.hpp"
 #include "core/perf.hpp"
@@ -172,7 +173,7 @@ generate_call_stack_json(const tim::unwind::processed_entry& stack_entry)
 {
     nlohmann::json call_stack;
 
-    call_stack["name"] = std::string(demangle(stack_entry.name));
+    call_stack["name"] = std::string(rocprofsys::utility::demangle(stack_entry.name));
     call_stack["pc"]   = as_hex(stack_entry.address);
     call_stack["file"] = std::string(stack_entry.location);
 
@@ -184,7 +185,7 @@ generate_line_info_json(const tim::unwind::processed_entry& line_info_entry)
 {
     nlohmann::json line_info;
     line_info["line_address"] = as_hex(line_info_entry.line_address);
-    line_info["name"]         = std::string(demangle(line_info_entry.name));
+    line_info["name"] = std::string(rocprofsys::utility::demangle(line_info_entry.name));
 
     if(line_info_entry.lineinfo && !line_info_entry.lineinfo.lines.empty())
     {
@@ -193,7 +194,7 @@ generate_line_info_json(const tim::unwind::processed_entry& line_info_entry)
         for(const auto& line : _lines)
         {
             nlohmann::json inlined;
-            inlined["name"]      = std::string(demangle(line.name));
+            inlined["name"]      = std::string(rocprofsys::utility::demangle(line.name));
             inlined["location"]  = std::string(line.location);
             inlined["line"]      = std::to_string(line.line);
             line_info["inlined"] = inlined;
@@ -311,7 +312,7 @@ cache_sampling_data(int64_t _tid, const std::vector<timer_sampling_data>& _timer
 
         for(const auto& iitr : itr.m_stack)
         {
-            auto _name       = std::string(demangle(iitr.name));
+            auto _name       = std::string(rocprofsys::utility::demangle(iitr.name));
             auto _track_name = get_track_name<category::timer_sampling>(*_thread_info);
             auto _call_stack = generate_call_stack_json(iitr);
             auto _line_info  = generate_line_info_json(iitr);
@@ -343,7 +344,7 @@ cache_sampling_data(int64_t _tid, const std::vector<timer_sampling_data>& _timer
 
         for(const auto& iitr : itr.m_stack)
         {
-            auto _name       = std::string(demangle(iitr.name));
+            auto _name       = std::string(rocprofsys::utility::demangle(iitr.name));
             auto _track_name = get_track_name<category::overflow_sampling>(*_thread_info);
             auto _call_stack = generate_call_stack_json(iitr);
             auto _line_info  = generate_line_info_json(iitr);
@@ -1384,7 +1385,8 @@ post_process_perfetto(int64_t _tid, const std::vector<timer_sampling_data>& _tim
             for(const auto& iitr : itr.m_stack)
             {
                 const auto* _name =
-                    static_strings.emplace(demangle(iitr.name)).first->c_str();
+                    static_strings.emplace(rocprofsys::utility::demangle(iitr.name))
+                        .first->c_str();
                 tracing::push_perfetto_track(
                     category::overflow_sampling{}, _name, _track, _beg,
                     [&](::perfetto::EventContext ctx) {
@@ -1405,7 +1407,8 @@ post_process_perfetto(int64_t _tid, const std::vector<timer_sampling_data>& _tim
                                     auto _label = JOIN('-', "lineinfo", _n++);
                                     tracing::add_perfetto_annotation(
                                         ctx, _label.c_str(),
-                                        JOIN('@', demangle(line.name),
+                                        JOIN('@',
+                                             rocprofsys::utility::demangle(line.name),
                                              JOIN(':', line.location, line.line)));
                                 }
                             }
@@ -1496,7 +1499,9 @@ post_process_perfetto(int64_t _tid, const std::vector<timer_sampling_data>& _tim
                     for(const auto& line : _lines)
                     {
                         const auto* _name =
-                            static_strings.emplace(demangle(line.name)).first->c_str();
+                            static_strings
+                                .emplace(rocprofsys::utility::demangle(line.name))
+                                .first->c_str();
                         auto _info = JOIN(':', line.location, line.line);
                         tracing::push_perfetto_track(
                             category::timer_sampling{}, _name, _track, _beg,
@@ -1542,7 +1547,9 @@ post_process_perfetto(int64_t _tid, const std::vector<timer_sampling_data>& _tim
                                         auto _label = JOIN('-', "lineinfo", _n++);
                                         tracing::add_perfetto_annotation(
                                             ctx, _label.c_str(),
-                                            JOIN('@', demangle(line.name),
+                                            JOIN('@',
+                                                 rocprofsys::utility::get_demangler()
+                                                     .demangle(line.name),
                                                  JOIN(':', line.location, line.line)));
                                     }
                                 }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/tracing.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/tracing.hpp
@@ -28,6 +28,7 @@
 #include "core/config.hpp"
 #include "core/debug.hpp"
 #include "core/defines.hpp"
+#include "core/demangler.hpp"
 #include "core/perfetto.hpp"
 #include "core/state.hpp"
 #include "core/timemory.hpp"
@@ -181,8 +182,9 @@ get_perfetto_track(CategoryT, FuncT&& _desc_generator, Args&&... _args)
         ::perfetto::TrackEvent::SetTrackDescriptor(_track, _desc);
 
         ROCPROFSYS_VERBOSE_F(4, "[%s] Created %s(%zu) with description: \"%s\"\n",
-                             trait::name<CategoryT>::value, demangle<TrackT>().c_str(),
-                             _uuid, _name.c_str());
+                             trait::name<CategoryT>::value,
+                             rocprofsys::utility::demangle<TrackT>().c_str(), _uuid,
+                             _name.c_str());
 
         _track_uuids.emplace(_uuid, _name);
     }

--- a/projects/rocprofiler-systems/source/tests/dummy.cpp
+++ b/projects/rocprofiler-systems/source/tests/dummy.cpp
@@ -1,3 +1,0 @@
-#include <gtest/gtest.h>
-
-TEST(first, test) { ASSERT_TRUE(true); }


### PR DESCRIPTION
## Motivation

Symbol demangling via `abi::__cxa_demangle` is called frequently throughout the codebase, particularly in sampling, tracing, and binary analysis code paths. Each call to demangle the same symbol incurs redundant computation. This change introduces a caching layer to improve performance by avoiding repeated demangling of identical mangled names.

## Technical Details

- Added new `demangler` class in `source/lib/core/demangler.hpp` that caches demangled results in a `std::map<std::string, std::string, std::less<>>` using transparent comparison for efficient `std::string_view` lookups
- Replaced all usages of `tim::demangle` and `tim::try_demangle` from timemory with the new `rocprofsys::utility::get_demangler().demangle()` API
- Removed `demangle` and `try_demangle` imports from `core/common.hpp`
- Removed duplicate entries from `CMakeLists.txt`.

## Test Plan

- Profile sampling-heavy workloads to measure performance improvement from caching
- Verify symbol names are correctly demangled in Perfetto traces and sampling output
- Test with C++ code containing heavily templated symbols (which benefit most from caching)

## Test Result

- All existing tests should pass with identical demangled output
- Performance improvement expected in workloads with repeated symbol lookups (sampling, backtraces)
- No functional changes to user-visible output

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
