### PR TITLE
[rocprofiler-systems] Set skip_validation TRUE if transferBench not built

### DIFF
--- a/projects/rocprofiler-systems/tests/rocprof-sys-gpu-connect-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-gpu-connect-tests.cmake
@@ -60,6 +60,8 @@ if(EXISTS "${PROJECT_BINARY_DIR}/transferBench")
     if(_transfer_output MATCHES "Error: No valid transfers created")
         set(skip_validation TRUE)
     endif()
+else()
+    set(skip_validation TRUE)
 endif()
 
 rocprofiler_systems_add_test(


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This PR fixes a CMake configuration issue where the `transferBench` validation test would be configured even if the `transferBench` example was disabled. The change ensures that validation is skipped when the binary doesn't exist.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Add `skip_validation TRUE` if bin not found.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Building with `-D ROCPROFSYS_DISABLE_EXAMPLES="transferBench"`

## Test Result

<!-- Briefly summarize test outcomes. -->
Can now build

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
