### PR TITLE
Enable Lintian configuration/Files for AMDSMI

### DIFF
--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -41,6 +41,10 @@ generic_add_rocm()
 # provide git to utilities
 find_program(GIT NAMES git)
 
+# Set Lintian Support Flags
+set( BUILD_ENABLE_LINTIAN_OVERRIDES OFF CACHE BOOL "Enable/Disable Lintian Overrides" )
+set( BUILD_DEBIAN_PKGING_FLAG OFF CACHE BOOL "Internal Status Flag to indicate Debian Packaging Build" )
+
 ## Setup the package version based on git tags.
 set(PKG_VERSION_GIT_TAG_PREFIX "amdsmi_pkg_ver")
 get_version_from_file("include/amd_smi/amdsmi.h" "MAJOR")
@@ -121,7 +125,9 @@ cmake_dependent_option(ENABLE_LDCONFIG "Set library links and caches using ldcon
 set(SHARE_INSTALL_PREFIX "${CMAKE_INSTALL_DATAROOTDIR}/${AMD_SMI}" CACHE STRING "Tests and Example install directory")
 
 # Packaging directives
-set(CPACK_PACKAGE_CONTACT "AMD-SMILib Support <amd-smi.support@amd.com>" CACHE STRING "")
+set(PKG_MAINTAINER_NM     "AMD-SMILib Support")
+set(PKG_MAINTAINER_EMAIL  "amd-smi.support@amd.com")
+set(CPACK_PACKAGE_CONTACT "${PKG_MAINTAINER_NM} <${PKG_MAINTAINER_EMAIL}>" CACHE STRING "")
 
 generic_package()
 
@@ -345,13 +351,17 @@ install(
 
 set(CPACK_RPM_PACKAGE_LICENSE "MIT")
 if(ENABLE_ASAN_PACKAGING)
+    set( COMP_TYPE "asan" )
     # install license file in share/doc/amd_smi-asan folder
     install(
         FILES ${CPACK_RESOURCE_FILE_LICENSE}
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/doc/${CPACK_PACKAGE_NAME}-asan
         RENAME LICENSE.txt
         COMPONENT asan)
+else()
+    set( COMP_TYPE "dev" )
 endif()
+
 # docs are installed into different share directory from tests and examples
 install(
     FILES ${CPACK_RESOURCE_FILE_LICENSE}
@@ -505,6 +515,29 @@ set(CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE "${CMAKE_CURRENT_BINARY_DIR}/RPM/postun
 #Set the names now using CPACK utility
 set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
 set(CPACK_RPM_FILE_NAME "RPM-DEFAULT")
+
+# Configure Lintian Specific Package Data
+configure_pkg( ${CPACK_PACKAGE_NAME} ${COMP_TYPE} ${CPACK_PACKAGE_VERSION} ${PKG_MAINTAINER_NM} ${PKG_MAINTAINER_EMAIL} )
+
+# Custom installation for Debian Lintian File
+if(BUILD_ENABLE_LINTIAN_OVERRIDES AND BUILD_DEBIAN_PKGING_FLAG)
+    set( OVERRIDE_FILE "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_OVERRIDES_INSTALL_FILENM}" )
+    set( OVERRIDE_TEMP_INSTALL_LOC "/_CPack_Packages/Linux/DEB/${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-Linux/runtime" )
+    if(BUILD_SHARED_LIBS)
+      set(CPACK_INSTALL_COMMANDS
+          "${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}${OVERRIDE_TEMP_INSTALL_LOC}${DEB_OVERRIDES_INSTALL_PATH}"
+          "${CMAKE_COMMAND} -E copy ${OVERRIDE_FILE} ${CMAKE_BINARY_DIR}${OVERRIDE_TEMP_INSTALL_LOC}${DEB_OVERRIDES_INSTALL_PATH}"
+      )
+    else()
+      set( OVERRIDE_FILE_STATIC "${DEB_OVERRIDES_INSTALL_FILENM}-static-dev" )
+      set( OVERRIDE_FILE_STATIC_DEST
+           "${CMAKE_BINARY_DIR}${OVERRIDE_TEMP_INSTALL_LOC}${DEB_OVERRIDES_INSTALL_PATH}${OVERRIDE_FILE_STATIC}" )
+      set(CPACK_INSTALL_COMMANDS
+          "${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}${OVERRIDE_TEMP_INSTALL_LOC}${DEB_OVERRIDES_INSTALL_PATH}"
+          "${CMAKE_COMMAND} -E copy ${OVERRIDE_FILE} ${OVERRIDE_FILE_STATIC_DEST}"
+      )
+    endif()
+endif()
 
 include(CPack)
 

--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -42,8 +42,16 @@ generic_add_rocm()
 find_program(GIT NAMES git)
 
 # Set Lintian Support Flags
-set( BUILD_ENABLE_LINTIAN_OVERRIDES OFF CACHE BOOL "Enable/Disable Lintian Overrides" )
-set( BUILD_DEBIAN_PKGING_FLAG OFF CACHE BOOL "Internal Status Flag to indicate Debian Packaging Build" )
+set(BUILD_ENABLE_LINTIAN_OVERRIDES
+    OFF
+    CACHE BOOL
+    "Enable/Disable Lintian Overrides"
+)
+set(BUILD_DEBIAN_PKGING_FLAG
+    OFF
+    CACHE BOOL
+    "Internal Status Flag to indicate Debian Packaging Build"
+)
 
 ## Setup the package version based on git tags.
 set(PKG_VERSION_GIT_TAG_PREFIX "amdsmi_pkg_ver")
@@ -125,9 +133,13 @@ cmake_dependent_option(ENABLE_LDCONFIG "Set library links and caches using ldcon
 set(SHARE_INSTALL_PREFIX "${CMAKE_INSTALL_DATAROOTDIR}/${AMD_SMI}" CACHE STRING "Tests and Example install directory")
 
 # Packaging directives
-set(PKG_MAINTAINER_NM     "AMD-SMILib Support")
-set(PKG_MAINTAINER_EMAIL  "amd-smi.support@amd.com")
-set(CPACK_PACKAGE_CONTACT "${PKG_MAINTAINER_NM} <${PKG_MAINTAINER_EMAIL}>" CACHE STRING "")
+set(PKG_MAINTAINER_NM "AMD-SMILib Support")
+set(PKG_MAINTAINER_EMAIL "amd-smi.support@amd.com")
+set(CPACK_PACKAGE_CONTACT
+    "${PKG_MAINTAINER_NM} <${PKG_MAINTAINER_EMAIL}>"
+    CACHE STRING
+    ""
+)
 
 generic_package()
 
@@ -351,7 +363,7 @@ install(
 
 set(CPACK_RPM_PACKAGE_LICENSE "MIT")
 if(ENABLE_ASAN_PACKAGING)
-    set( COMP_TYPE "asan" )
+    set(COMP_TYPE "asan")
     # install license file in share/doc/amd_smi-asan folder
     install(
         FILES ${CPACK_RESOURCE_FILE_LICENSE}
@@ -359,7 +371,7 @@ if(ENABLE_ASAN_PACKAGING)
         RENAME LICENSE.txt
         COMPONENT asan)
 else()
-    set( COMP_TYPE "dev" )
+    set(COMP_TYPE "dev")
 endif()
 
 # docs are installed into different share directory from tests and examples
@@ -517,25 +529,30 @@ set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
 set(CPACK_RPM_FILE_NAME "RPM-DEFAULT")
 
 # Configure Lintian Specific Package Data
-configure_pkg( ${CPACK_PACKAGE_NAME} ${COMP_TYPE} ${CPACK_PACKAGE_VERSION} ${PKG_MAINTAINER_NM} ${PKG_MAINTAINER_EMAIL} )
+configure_pkg( ${CPACK_PACKAGE_NAME} ${COMP_TYPE} ${CPACK_PACKAGE_VERSION} ${PKG_MAINTAINER_NM} ${PKG_MAINTAINER_EMAIL})
 
 # Custom installation for Debian Lintian File
 if(BUILD_ENABLE_LINTIAN_OVERRIDES AND BUILD_DEBIAN_PKGING_FLAG)
-    set( OVERRIDE_FILE "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_OVERRIDES_INSTALL_FILENM}" )
-    set( OVERRIDE_TEMP_INSTALL_LOC "/_CPack_Packages/Linux/DEB/${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-Linux/runtime" )
+    set(OVERRIDE_FILE
+        "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_OVERRIDES_INSTALL_FILENM}"
+    )
+    set(OVERRIDE_TEMP_INSTALL_LOC
+        "/_CPack_Packages/Linux/DEB/${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-Linux/runtime"
+    )
     if(BUILD_SHARED_LIBS)
-      set(CPACK_INSTALL_COMMANDS
-          "${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}${OVERRIDE_TEMP_INSTALL_LOC}${DEB_OVERRIDES_INSTALL_PATH}"
-          "${CMAKE_COMMAND} -E copy ${OVERRIDE_FILE} ${CMAKE_BINARY_DIR}${OVERRIDE_TEMP_INSTALL_LOC}${DEB_OVERRIDES_INSTALL_PATH}"
-      )
+        set(CPACK_INSTALL_COMMANDS
+            "${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}${OVERRIDE_TEMP_INSTALL_LOC}${DEB_OVERRIDES_INSTALL_PATH}"
+            "${CMAKE_COMMAND} -E copy ${OVERRIDE_FILE} ${CMAKE_BINARY_DIR}${OVERRIDE_TEMP_INSTALL_LOC}${DEB_OVERRIDES_INSTALL_PATH}"
+        )
     else()
-      set( OVERRIDE_FILE_STATIC "${DEB_OVERRIDES_INSTALL_FILENM}-static-dev" )
-      set( OVERRIDE_FILE_STATIC_DEST
-           "${CMAKE_BINARY_DIR}${OVERRIDE_TEMP_INSTALL_LOC}${DEB_OVERRIDES_INSTALL_PATH}${OVERRIDE_FILE_STATIC}" )
-      set(CPACK_INSTALL_COMMANDS
-          "${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}${OVERRIDE_TEMP_INSTALL_LOC}${DEB_OVERRIDES_INSTALL_PATH}"
-          "${CMAKE_COMMAND} -E copy ${OVERRIDE_FILE} ${OVERRIDE_FILE_STATIC_DEST}"
-      )
+        set(OVERRIDE_FILE_STATIC "${DEB_OVERRIDES_INSTALL_FILENM}-static-dev")
+        set(OVERRIDE_FILE_STATIC_DEST
+            "${CMAKE_BINARY_DIR}${OVERRIDE_TEMP_INSTALL_LOC}${DEB_OVERRIDES_INSTALL_PATH}${OVERRIDE_FILE_STATIC}"
+        )
+        set(CPACK_INSTALL_COMMANDS
+            "${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}${OVERRIDE_TEMP_INSTALL_LOC}${DEB_OVERRIDES_INSTALL_PATH}"
+            "${CMAKE_COMMAND} -E copy ${OVERRIDE_FILE} ${OVERRIDE_FILE_STATIC_DEST}"
+        )
     endif()
 endif()
 

--- a/projects/amdsmi/DEBIAN/changelog.in
+++ b/projects/amdsmi/DEBIAN/changelog.in
@@ -1,0 +1,4 @@
+@DEB_PACKAGE_NAME@ (@DEB_PACKAGE_VERSION@) stable; urgency=low
+
+  * ROCm Runtime software stack Base Package.
+ -- @DEB_MAINTAINER_NAME@ <@DEB_MAINTAINER_EMAIL@>  @DEB_TIMESTAMP@

--- a/projects/amdsmi/DEBIAN/copyright.in
+++ b/projects/amdsmi/DEBIAN/copyright.in
@@ -3,7 +3,7 @@ Upstream-Name: amdsmi
 Source: https://github.com/ROCm/amdsmi.git
 
 Files: *
-Copyright: @CURRENT_YEAR@ Advanced Micro Devices, Inc.
+Copyright: @CURRENT_YEAR@ Advanced Micro Devices, Inc. All rights reserved.
 License: MIT
 
 License: MIT

--- a/projects/amdsmi/DEBIAN/overrides.in
+++ b/projects/amdsmi/DEBIAN/overrides.in
@@ -1,0 +1,3 @@
+@DEB_OVERRIDES_INSTALL_FILENM@: no-copyright-file
+@DEB_OVERRIDES_INSTALL_FILENM@: debian-changelog-file-missing
+@DEB_OVERRIDES_INSTALL_FILENM@: dir-or-file-in-opt

--- a/projects/amdsmi/cmake_modules/utils.cmake
+++ b/projects/amdsmi/cmake_modules/utils.cmake
@@ -248,7 +248,7 @@ function( configure_pkg PACKAGE_NAME_T COMPONENT_NAME_T PACKAGE_VERSION_T MAINTA
           message(FATAL_ERROR "Failed to compress: ${error}")
         endif()
         install ( FILES "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_CHANGELOG_INSTALL_FILENM}"
-		  DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/${PACKAGE_NAME_T}
+                  DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/${PACKAGE_NAME_T}
                   COMPONENT ${COMPONENT_NAME_T})
       endif()
 
@@ -279,8 +279,6 @@ function( set_debian_pkg_cmake_flags DEB_PACKAGE_NAME_T DEB_PACKAGE_VERSION_T DE
     set( DEB_PACKAGE_VERSION          "${DEB_PACKAGE_VERSION_T}" CACHE STRING "Debian Package Version String" )
     set( DEB_MAINTAINER_NAME          "${DEB_MAINTAINER_NM_T}" CACHE STRING "Debian Package Maintainer Name" )
     set( DEB_MAINTAINER_EMAIL         "${DEB_MAINTAINER_EMAIL_T}" CACHE STRING "Debian Package Maintainer Email" )
-    set( DEB_COPYRIGHT_YEAR           "2025" CACHE STRING "Debian Package Copyright Year" )
-    set( DEB_LICENSE                  "MIT" CACHE STRING "Debian Package License Type" )
     set( DEB_CHANGELOG_INSTALL_FILENM "changelog.Debian.gz" CACHE STRING "Debian Package ChangeLog File Name" )
 
     if( BUILD_ENABLE_LINTIAN_OVERRIDES )
@@ -297,7 +295,7 @@ function( set_debian_pkg_cmake_flags DEB_PACKAGE_NAME_T DEB_PACKAGE_VERSION_T DE
     execute_process (
         COMMAND ${DEB_DATE_TIMESTAMP_EXEC} ${DEB_TIMESTAMP_FORMAT_OPTION}
         OUTPUT_VARIABLE TIMESTAMP_T
-	OUTPUT_STRIP_TRAILING_WHITESPACE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     set( DEB_TIMESTAMP "${TIMESTAMP_T}" CACHE STRING "Current Time Stamp for Copyright/Changelog" )
 
@@ -305,8 +303,6 @@ function( set_debian_pkg_cmake_flags DEB_PACKAGE_NAME_T DEB_PACKAGE_VERSION_T DE
     message(STATUS "DEB_PACKAGE_VERSION          : ${DEB_PACKAGE_VERSION}" )
     message(STATUS "DEB_MAINTAINER_NAME          : ${DEB_MAINTAINER_NAME}" )
     message(STATUS "DEB_MAINTAINER_EMAIL         : ${DEB_MAINTAINER_EMAIL}" )
-    message(STATUS "DEB_COPYRIGHT_YEAR           : ${DEB_COPYRIGHT_YEAR}" )
-    message(STATUS "DEB_LICENSE                  : ${DEB_LICENSE}" )
     message(STATUS "DEB_TIMESTAMP                : ${DEB_TIMESTAMP}" )
     message(STATUS "DEB_CHANGELOG_INSTALL_FILENM : ${DEB_CHANGELOG_INSTALL_FILENM}" )
 endfunction()

--- a/projects/amdsmi/cmake_modules/utils.cmake
+++ b/projects/amdsmi/cmake_modules/utils.cmake
@@ -198,3 +198,115 @@ function(get_package_version_number DEFAULT_VERSION_STRING VERSION_PREFIX GIT)
     set(CPACK_PACKAGE_VERSION_MINOR ${VERSION_MINOR} PARENT_SCOPE)
     set(CPACK_PACKAGE_VERSION_PATCH ${VERSION_PATCH} PARENT_SCOPE)
 endfunction()
+
+# function to append content of IN_FILE to OUT_FILE
+function(append_file IN_FILE OUT_FILE)
+    file(READ "${IN_FILE}" CONTENTS)
+    file(APPEND "${OUT_FILE}" "${CONTENTS}")
+endfunction()
+
+## Configure Lintian Specific install Files for Debian Package
+function( configure_pkg PACKAGE_NAME_T COMPONENT_NAME_T PACKAGE_VERSION_T MAINTAINER_NM_T MAINTAINER_EMAIL_T)
+    # Check If Debian Platform
+    find_file (DEBIAN debian_version debconf.conf PATHS /etc)
+    if(DEBIAN)
+      set( BUILD_ENABLE_LINTIAN_OVERRIDES ON CACHE BOOL "Enable/Disable Lintian Overrides" FORCE )
+      set( BUILD_DEBIAN_PKGING_FLAG ON CACHE BOOL "Internal Status Flag to indicate Debian Packaging Build" FORCE )
+      set_debian_pkg_cmake_flags( ${PACKAGE_NAME_T} ${PACKAGE_VERSION_T}
+                                  ${MAINTAINER_NM_T} ${MAINTAINER_EMAIL_T} )
+
+      # Create debian directory in build tree
+      file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/DEBIAN")
+
+      # Configure the changelog file
+      set( CHANGELOG_DATA_FILES "${CMAKE_SOURCE_DIR}/DEBIAN/changelog.in" "${CMAKE_SOURCE_DIR}/CHANGELOG.md" )
+      set( CHANGELOG_DATA_APPENDED "${CMAKE_BINARY_DIR}/DEBIAN/changelog.in" )
+      file( WRITE "${CHANGELOG_DATA_APPENDED}" "" )
+      foreach( changelog_data ${CHANGELOG_DATA_FILES} )
+        append_file("${changelog_data}" "${CHANGELOG_DATA_APPENDED}")
+      endforeach()
+      configure_file(
+        "${CHANGELOG_DATA_APPENDED}"
+        "${CMAKE_BINARY_DIR}/DEBIAN/changelog.Debian"
+        @ONLY
+      )
+
+      # Install Change Log
+      find_program ( DEB_GZIP_EXEC gzip )
+      if( NOT DEB_GZIP_EXEC )
+        message(FATAL_ERROR "gzip command not found: Failed to compress the changelog")
+      endif()
+      if(EXISTS "${CMAKE_BINARY_DIR}/DEBIAN/changelog.Debian" )
+        execute_process(
+          COMMAND ${DEB_GZIP_EXEC} -f -n -9 "${CMAKE_BINARY_DIR}/DEBIAN/changelog.Debian"
+          WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/DEBIAN"
+          RESULT_VARIABLE result
+          OUTPUT_VARIABLE output
+          ERROR_VARIABLE error
+        )
+        if(NOT ${result} EQUAL 0)
+          message(FATAL_ERROR "Failed to compress: ${error}")
+        endif()
+        install ( FILES "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_CHANGELOG_INSTALL_FILENM}"
+		  DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/${PACKAGE_NAME_T}
+                  COMPONENT ${COMPONENT_NAME_T})
+      endif()
+
+      if( BUILD_ENABLE_LINTIAN_OVERRIDES )
+        if(ENABLE_ASAN_PACKAGING)
+          string( FIND ${DEB_OVERRIDES_INSTALL_FILENM} "asan" OUT_VAR2)
+          if(OUT_VAR2 EQUAL -1)
+            set( DEB_OVERRIDES_INSTALL_FILENM
+                 "${DEB_OVERRIDES_INSTALL_FILENM}-asan" CACHE STRING "Debian Package Lintian Override File Name" FORCE)
+          endif()
+        endif()
+        # Configure the Lintian Overrides file
+        configure_file(
+          "${CMAKE_SOURCE_DIR}/DEBIAN/overrides.in"
+          "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_OVERRIDES_INSTALL_FILENM}"
+          FILE_PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+          @ONLY
+        )
+      endif()
+    endif()
+endfunction()
+
+# Set variables for changelog and copyright
+# For Debian specific Packages
+function( set_debian_pkg_cmake_flags DEB_PACKAGE_NAME_T DEB_PACKAGE_VERSION_T DEB_MAINTAINER_NM_T DEB_MAINTAINER_EMAIL_T )
+    # Setting configure flags
+    set( DEB_PACKAGE_NAME             "${DEB_PACKAGE_NAME_T}" CACHE STRING "Debian Package Name" )
+    set( DEB_PACKAGE_VERSION          "${DEB_PACKAGE_VERSION_T}" CACHE STRING "Debian Package Version String" )
+    set( DEB_MAINTAINER_NAME          "${DEB_MAINTAINER_NM_T}" CACHE STRING "Debian Package Maintainer Name" )
+    set( DEB_MAINTAINER_EMAIL         "${DEB_MAINTAINER_EMAIL_T}" CACHE STRING "Debian Package Maintainer Email" )
+    set( DEB_COPYRIGHT_YEAR           "2025" CACHE STRING "Debian Package Copyright Year" )
+    set( DEB_LICENSE                  "MIT" CACHE STRING "Debian Package License Type" )
+    set( DEB_CHANGELOG_INSTALL_FILENM "changelog.Debian.gz" CACHE STRING "Debian Package ChangeLog File Name" )
+
+    if( BUILD_ENABLE_LINTIAN_OVERRIDES )
+      set( DEB_OVERRIDES_INSTALL_FILENM "${DEB_PACKAGE_NAME}" CACHE STRING "Debian Package Lintian Override File Name" )
+      set( DEB_OVERRIDES_INSTALL_PATH   "/usr/share/lintian/overrides/" CACHE STRING "Deb Pkg Lintian Override Install Location" )
+    endif()
+
+    # Get TimeStamp
+    find_program( DEB_DATE_TIMESTAMP_EXEC date )
+    if( NOT DEB_DATE_TIMESTAMP_EXEC )
+      message(FATAL_ERROR "date command not found: Failed to Configure the timestamp for Copyright/Changelog.")
+    endif()
+    set ( DEB_TIMESTAMP_FORMAT_OPTION "-R" )
+    execute_process (
+        COMMAND ${DEB_DATE_TIMESTAMP_EXEC} ${DEB_TIMESTAMP_FORMAT_OPTION}
+        OUTPUT_VARIABLE TIMESTAMP_T
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    set( DEB_TIMESTAMP "${TIMESTAMP_T}" CACHE STRING "Current Time Stamp for Copyright/Changelog" )
+
+    message(STATUS "DEB_PACKAGE_NAME             : ${DEB_PACKAGE_NAME}" )
+    message(STATUS "DEB_PACKAGE_VERSION          : ${DEB_PACKAGE_VERSION}" )
+    message(STATUS "DEB_MAINTAINER_NAME          : ${DEB_MAINTAINER_NAME}" )
+    message(STATUS "DEB_MAINTAINER_EMAIL         : ${DEB_MAINTAINER_EMAIL}" )
+    message(STATUS "DEB_COPYRIGHT_YEAR           : ${DEB_COPYRIGHT_YEAR}" )
+    message(STATUS "DEB_LICENSE                  : ${DEB_LICENSE}" )
+    message(STATUS "DEB_TIMESTAMP                : ${DEB_TIMESTAMP}" )
+    message(STATUS "DEB_CHANGELOG_INSTALL_FILENM : ${DEB_CHANGELOG_INSTALL_FILENM}" )
+endfunction()

--- a/projects/amdsmi/cmake_modules/utils.cmake
+++ b/projects/amdsmi/cmake_modules/utils.cmake
@@ -206,103 +206,180 @@ function(append_file IN_FILE OUT_FILE)
 endfunction()
 
 ## Configure Lintian Specific install Files for Debian Package
-function( configure_pkg PACKAGE_NAME_T COMPONENT_NAME_T PACKAGE_VERSION_T MAINTAINER_NM_T MAINTAINER_EMAIL_T)
+function(
+    configure_pkg
+    PACKAGE_NAME_T
+    COMPONENT_NAME_T
+    PACKAGE_VERSION_T
+    MAINTAINER_NM_T
+    MAINTAINER_EMAIL_T
+)
     # Check If Debian Platform
-    find_file (DEBIAN debian_version debconf.conf PATHS /etc)
+    find_file(DEBIAN debian_version debconf.conf PATHS /etc)
     if(DEBIAN)
-      set( BUILD_ENABLE_LINTIAN_OVERRIDES ON CACHE BOOL "Enable/Disable Lintian Overrides" FORCE )
-      set( BUILD_DEBIAN_PKGING_FLAG ON CACHE BOOL "Internal Status Flag to indicate Debian Packaging Build" FORCE )
-      set_debian_pkg_cmake_flags( ${PACKAGE_NAME_T} ${PACKAGE_VERSION_T}
-                                  ${MAINTAINER_NM_T} ${MAINTAINER_EMAIL_T} )
-
-      # Create debian directory in build tree
-      file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/DEBIAN")
-
-      # Configure the changelog file
-      set( CHANGELOG_DATA_FILES "${CMAKE_SOURCE_DIR}/DEBIAN/changelog.in" "${CMAKE_SOURCE_DIR}/CHANGELOG.md" )
-      set( CHANGELOG_DATA_APPENDED "${CMAKE_BINARY_DIR}/DEBIAN/changelog.in" )
-      file( WRITE "${CHANGELOG_DATA_APPENDED}" "" )
-      foreach( changelog_data ${CHANGELOG_DATA_FILES} )
-        append_file("${changelog_data}" "${CHANGELOG_DATA_APPENDED}")
-      endforeach()
-      configure_file(
-        "${CHANGELOG_DATA_APPENDED}"
-        "${CMAKE_BINARY_DIR}/DEBIAN/changelog.Debian"
-        @ONLY
-      )
-
-      # Install Change Log
-      find_program ( DEB_GZIP_EXEC gzip )
-      if( NOT DEB_GZIP_EXEC )
-        message(FATAL_ERROR "gzip command not found: Failed to compress the changelog")
-      endif()
-      if(EXISTS "${CMAKE_BINARY_DIR}/DEBIAN/changelog.Debian" )
-        execute_process(
-          COMMAND ${DEB_GZIP_EXEC} -f -n -9 "${CMAKE_BINARY_DIR}/DEBIAN/changelog.Debian"
-          WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/DEBIAN"
-          RESULT_VARIABLE result
-          OUTPUT_VARIABLE output
-          ERROR_VARIABLE error
+        set(BUILD_ENABLE_LINTIAN_OVERRIDES
+            ON
+            CACHE BOOL
+            "Enable/Disable Lintian Overrides"
+            FORCE
         )
-        if(NOT ${result} EQUAL 0)
-          message(FATAL_ERROR "Failed to compress: ${error}")
-        endif()
-        install ( FILES "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_CHANGELOG_INSTALL_FILENM}"
-                  DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/${PACKAGE_NAME_T}
-                  COMPONENT ${COMPONENT_NAME_T})
-      endif()
+        set(BUILD_DEBIAN_PKGING_FLAG
+            ON
+            CACHE BOOL
+            "Internal Status Flag to indicate Debian Packaging Build"
+            FORCE
+        )
+        set_debian_pkg_cmake_flags(${PACKAGE_NAME_T} ${PACKAGE_VERSION_T}
+                                  ${MAINTAINER_NM_T} ${MAINTAINER_EMAIL_T}
+        )
 
-      if( BUILD_ENABLE_LINTIAN_OVERRIDES )
-        if(ENABLE_ASAN_PACKAGING)
-          string( FIND ${DEB_OVERRIDES_INSTALL_FILENM} "asan" OUT_VAR2)
-          if(OUT_VAR2 EQUAL -1)
-            set( DEB_OVERRIDES_INSTALL_FILENM
-                 "${DEB_OVERRIDES_INSTALL_FILENM}-asan" CACHE STRING "Debian Package Lintian Override File Name" FORCE)
-          endif()
-        endif()
-        # Configure the Lintian Overrides file
+        # Create debian directory in build tree
+        file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/DEBIAN")
+
+        # Configure the changelog file
+        set(CHANGELOG_DATA_FILES
+            "${CMAKE_SOURCE_DIR}/DEBIAN/changelog.in"
+            "${CMAKE_SOURCE_DIR}/CHANGELOG.md"
+        )
+        set(CHANGELOG_DATA_APPENDED "${CMAKE_BINARY_DIR}/DEBIAN/changelog.in")
+        file(WRITE "${CHANGELOG_DATA_APPENDED}" "")
+        foreach(changelog_data ${CHANGELOG_DATA_FILES})
+            append_file("${changelog_data}" "${CHANGELOG_DATA_APPENDED}")
+        endforeach()
         configure_file(
-          "${CMAKE_SOURCE_DIR}/DEBIAN/overrides.in"
-          "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_OVERRIDES_INSTALL_FILENM}"
-          FILE_PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
-          @ONLY
+            "${CHANGELOG_DATA_APPENDED}"
+            "${CMAKE_BINARY_DIR}/DEBIAN/changelog.Debian"
+            @ONLY
         )
-      endif()
+
+        # Install Change Log
+        find_program(DEB_GZIP_EXEC gzip)
+        if(NOT DEB_GZIP_EXEC)
+            message(
+                FATAL_ERROR
+                "gzip command not found: Failed to compress the changelog"
+            )
+        endif()
+        if(EXISTS "${CMAKE_BINARY_DIR}/DEBIAN/changelog.Debian")
+            execute_process(
+                COMMAND
+                    ${DEB_GZIP_EXEC} -f -n -9
+                    "${CMAKE_BINARY_DIR}/DEBIAN/changelog.Debian"
+                WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/DEBIAN"
+                RESULT_VARIABLE result
+                OUTPUT_VARIABLE output
+                ERROR_VARIABLE error
+            )
+            if(NOT ${result} EQUAL 0)
+                message(FATAL_ERROR "Failed to compress: ${error}")
+            endif()
+            install(
+                FILES
+                    "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_CHANGELOG_INSTALL_FILENM}"
+                DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/${PACKAGE_NAME_T}
+                COMPONENT ${COMPONENT_NAME_T}
+            )
+        endif()
+
+        if(BUILD_ENABLE_LINTIAN_OVERRIDES)
+            if(ENABLE_ASAN_PACKAGING)
+                string(FIND ${DEB_OVERRIDES_INSTALL_FILENM} "asan" OUT_VAR2)
+                if(OUT_VAR2 EQUAL -1)
+                    set(DEB_OVERRIDES_INSTALL_FILENM
+                        "${DEB_OVERRIDES_INSTALL_FILENM}-asan"
+                        CACHE STRING
+                        "Debian Package Lintian Override File Name"
+                        FORCE
+                    )
+                endif()
+            endif()
+            # Configure the Lintian Overrides file
+            configure_file(
+                "${CMAKE_SOURCE_DIR}/DEBIAN/overrides.in"
+                "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_OVERRIDES_INSTALL_FILENM}"
+                FILE_PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+                @ONLY
+            )
+        endif()
     endif()
 endfunction()
 
 # Set variables for changelog and copyright
 # For Debian specific Packages
-function( set_debian_pkg_cmake_flags DEB_PACKAGE_NAME_T DEB_PACKAGE_VERSION_T DEB_MAINTAINER_NM_T DEB_MAINTAINER_EMAIL_T )
+function(
+    set_debian_pkg_cmake_flags
+    DEB_PACKAGE_NAME_T
+    DEB_PACKAGE_VERSION_T
+    DEB_MAINTAINER_NM_T
+    DEB_MAINTAINER_EMAIL_T
+)
     # Setting configure flags
-    set( DEB_PACKAGE_NAME             "${DEB_PACKAGE_NAME_T}" CACHE STRING "Debian Package Name" )
-    set( DEB_PACKAGE_VERSION          "${DEB_PACKAGE_VERSION_T}" CACHE STRING "Debian Package Version String" )
-    set( DEB_MAINTAINER_NAME          "${DEB_MAINTAINER_NM_T}" CACHE STRING "Debian Package Maintainer Name" )
-    set( DEB_MAINTAINER_EMAIL         "${DEB_MAINTAINER_EMAIL_T}" CACHE STRING "Debian Package Maintainer Email" )
-    set( DEB_CHANGELOG_INSTALL_FILENM "changelog.Debian.gz" CACHE STRING "Debian Package ChangeLog File Name" )
+    set(DEB_PACKAGE_NAME
+        "${DEB_PACKAGE_NAME_T}"
+        CACHE STRING
+        "Debian Package Name"
+    )
+    set(DEB_PACKAGE_VERSION
+        "${DEB_PACKAGE_VERSION_T}"
+        CACHE STRING
+        "Debian Package Version String"
+    )
+    set(DEB_MAINTAINER_NAME
+        "${DEB_MAINTAINER_NM_T}"
+        CACHE STRING
+        "Debian Package Maintainer Name"
+    )
+    set(DEB_MAINTAINER_EMAIL
+        "${DEB_MAINTAINER_EMAIL_T}"
+        CACHE STRING
+        "Debian Package Maintainer Email"
+    )
+    set(DEB_CHANGELOG_INSTALL_FILENM
+        "changelog.Debian.gz"
+        CACHE STRING
+        "Debian Package ChangeLog File Name"
+    )
 
-    if( BUILD_ENABLE_LINTIAN_OVERRIDES )
-      set( DEB_OVERRIDES_INSTALL_FILENM "${DEB_PACKAGE_NAME}" CACHE STRING "Debian Package Lintian Override File Name" )
-      set( DEB_OVERRIDES_INSTALL_PATH   "/usr/share/lintian/overrides/" CACHE STRING "Deb Pkg Lintian Override Install Location" )
+    if(BUILD_ENABLE_LINTIAN_OVERRIDES)
+        set(DEB_OVERRIDES_INSTALL_FILENM
+            "${DEB_PACKAGE_NAME}"
+            CACHE STRING
+            "Debian Package Lintian Override File Name"
+        )
+        set(DEB_OVERRIDES_INSTALL_PATH
+            "/usr/share/lintian/overrides/"
+            CACHE STRING
+            "Deb Pkg Lintian Override Install Location"
+        )
     endif()
 
     # Get TimeStamp
-    find_program( DEB_DATE_TIMESTAMP_EXEC date )
-    if( NOT DEB_DATE_TIMESTAMP_EXEC )
-      message(FATAL_ERROR "date command not found: Failed to Configure the timestamp for Copyright/Changelog.")
+    find_program(DEB_DATE_TIMESTAMP_EXEC date)
+    if(NOT DEB_DATE_TIMESTAMP_EXEC)
+        message(
+            FATAL_ERROR
+            "date command not found: Failed to Configure the timestamp for Copyright/Changelog."
+        )
     endif()
-    set ( DEB_TIMESTAMP_FORMAT_OPTION "-R" )
-    execute_process (
+    set(DEB_TIMESTAMP_FORMAT_OPTION "-R")
+    execute_process(
         COMMAND ${DEB_DATE_TIMESTAMP_EXEC} ${DEB_TIMESTAMP_FORMAT_OPTION}
         OUTPUT_VARIABLE TIMESTAMP_T
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-    set( DEB_TIMESTAMP "${TIMESTAMP_T}" CACHE STRING "Current Time Stamp for Copyright/Changelog" )
+    set(DEB_TIMESTAMP
+        "${TIMESTAMP_T}"
+        CACHE STRING
+        "Current Time Stamp for Copyright/Changelog"
+    )
 
-    message(STATUS "DEB_PACKAGE_NAME             : ${DEB_PACKAGE_NAME}" )
-    message(STATUS "DEB_PACKAGE_VERSION          : ${DEB_PACKAGE_VERSION}" )
-    message(STATUS "DEB_MAINTAINER_NAME          : ${DEB_MAINTAINER_NAME}" )
-    message(STATUS "DEB_MAINTAINER_EMAIL         : ${DEB_MAINTAINER_EMAIL}" )
-    message(STATUS "DEB_TIMESTAMP                : ${DEB_TIMESTAMP}" )
-    message(STATUS "DEB_CHANGELOG_INSTALL_FILENM : ${DEB_CHANGELOG_INSTALL_FILENM}" )
+    message(STATUS "DEB_PACKAGE_NAME             : ${DEB_PACKAGE_NAME}")
+    message(STATUS "DEB_PACKAGE_VERSION          : ${DEB_PACKAGE_VERSION}")
+    message(STATUS "DEB_MAINTAINER_NAME          : ${DEB_MAINTAINER_NAME}")
+    message(STATUS "DEB_MAINTAINER_EMAIL         : ${DEB_MAINTAINER_EMAIL}")
+    message(STATUS "DEB_TIMESTAMP                : ${DEB_TIMESTAMP}")
+    message(
+        STATUS
+        "DEB_CHANGELOG_INSTALL_FILENM : ${DEB_CHANGELOG_INSTALL_FILENM}"
+    )
 endfunction()


### PR DESCRIPTION
## Motivation
This pull request introduces comprehensive improvements to the Debian packaging process for the `amdsmi` project, focusing on better support for Lintian overrides, changelog management, and package metadata. The changes add new CMake configuration options, automate the generation and installation of Debian-specific files, and enhance the handling of package maintainer information. These updates streamline compliance with Debian packaging standards and improve maintainability.

## Technical Details
**Debian Packaging Enhancements**

* Added new CMake options `BUILD_ENABLE_LINTIAN_OVERRIDES` and `BUILD_DEBIAN_PKGING_FLAG` to control Lintian override and Debian packaging support.
* Implemented the `configure_pkg()` function in `utils.cmake` to automate the creation and installation of Debian changelog and Lintian override files, including compression and file permissions.
* Added template files for Debian changelog (`changelog.in`) and Lintian overrides (`overrides.in`) to the `DEBIAN` directory, supporting dynamic substitution of package metadata. [[1]](diffhunk://#diff-17cd7919f77f5c57ab3ff254236048279a6549863ca23f8b3cc44634528f07a5R1-R4) [[2]](diffhunk://#diff-9677d485e6fc4e216f69ce970c782165cbbcdf895bf692edb8fd465bad400e98R1-R3)

**Metadata and Maintainer Information**

* Refactored maintainer info in CMake: split into separate name and email variables, and updated how `CPACK_PACKAGE_CONTACT` is set for consistency across packaging scripts.
* Updated copyright template to include "All rights reserved." for improved legal clarity.

**Conditional Installation Logic**

* Enhanced installation logic to handle different component types (`asan` vs. `dev`) and to conditionally install Lintian override files based on build flags and shared/static library status. [[1]](diffhunk://#diff-ebd20e1dc4edf0498f7c9c72d49942177031b20cac056d90e3210960e9b10348R354-R364) [[2]](diffhunk://#diff-ebd20e1dc4edf0498f7c9c72d49942177031b20cac056d90e3210960e9b10348R519-R541)

These changes collectively improve the Debian packaging workflow, automate compliance steps, and make package metadata management more robust.

## JIRA ID

## Test Plan

## Test Result

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Imported from https://github.com/ROCm/amdsmi/pull/152, https://github.com/ROCm/rocm-systems/pull/1902