### PR TITLE
[rocprofiler-sdk] Fix python linting

### DIFF
--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -984,8 +984,8 @@ def get_args(
 
     import re
 
-    filter_regex = re.compile(filter) if filter != None else None
-    ignored_regex = re.compile(ignore_prev_inp) if ignore_prev_inp != None else None
+    filter_regex = re.compile(filter) if filter is not None else None
+    ignored_regex = re.compile(ignore_prev_inp) if ignore_prev_inp is not None else None
 
     def ensure_type(name, var, type_id):
         if not isinstance(var, type_id):


### PR DESCRIPTION
## Motivation

Python linting jobs have been failing since 304c2b8. flake8 rules are not currently included in make format. This will be fixed. This change is only to get the workflow passing again.

## Test Plan

Use existing CI workflow for python linting.

## Test Result

Pending

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
