### PR TITLE
[perf-dkms] Apply Linux kernel coding style with clang-format

### DIFF
--- a/projects/perf-dkms/.clang-format
+++ b/projects/perf-dkms/.clang-format
@@ -1,0 +1,90 @@
+# Linux kernel coding style for clang-format
+# Based on https://www.kernel.org/doc/html/latest/process/clang-format.html
+
+BasedOnStyle: LLVM
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+BreakStringLiterals: false
+ColumnLimit: 100
+CommentPragmas: '^ IWYU pragma:'
+ContinuationIndentWidth: 8
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex: '.*'
+    Priority: 1
+IndentCaseLabels: false
+IndentGotoLabels: false
+IndentPPDirectives: None
+IndentWidth: 8
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PenaltyBreakAssignment: 10
+PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakComment: 10
+PenaltyBreakFirstLessLess: 0
+PenaltyBreakString: 10
+PenaltyExcessCharacter: 100
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments: false
+SortIncludes: false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatementsExceptForEachMacros
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+TabWidth: 8
+UseTab: Always

--- a/projects/perf-dkms/src/amdgpu_pmu.h
+++ b/projects/perf-dkms/src/amdgpu_pmu.h
@@ -35,41 +35,41 @@ struct pmu_dimension_coords;
 
 /* Per-event private data */
 struct amdgpu_pmu_event {
-    struct perf_event *event;
-    u64 prev_count;
-    u64 period;
-    bool active;
-    bool uses_aql_hardware;                  /* Event uses AQL hardware counters */
+	struct perf_event *event;
+	u64 prev_count;
+	u64 period;
+	bool active;
+	bool uses_aql_hardware; /* Event uses AQL hardware counters */
 };
 
 /* Main PMU structure */
 struct amdgpu_pmu {
-    struct pmu pmu;                          /* Base PMU structure */
-    struct device *dev;                      /* Device for sysfs */
+	struct pmu pmu; /* Base PMU structure */
+	struct device *dev; /* Device for sysfs */
 
-    /* Event management */
-    spinlock_t lock;                         /* Protects event_list */
-    struct amdgpu_pmu_event events[AMDGPU_PMU_MAX_EVENTS];
-    DECLARE_BITMAP(used_mask, AMDGPU_PMU_MAX_EVENTS);
-    int num_events;
+	/* Event management */
+	spinlock_t lock; /* Protects event_list */
+	struct amdgpu_pmu_event events[AMDGPU_PMU_MAX_EVENTS];
+	DECLARE_BITMAP(used_mask, AMDGPU_PMU_MAX_EVENTS);
+	int num_events;
 
-    /* Timer for simulating counter updates */
-    struct hrtimer timer;
-    ktime_t timer_period;
+	/* Timer for simulating counter updates */
+	struct hrtimer timer;
+	ktime_t timer_period;
 
-    /* AQL Hardware Integration */
-    struct mutex aql_mutex;                  /* Protects AQL operations */
+	/* AQL Hardware Integration */
+	struct mutex aql_mutex; /* Protects AQL operations */
 
-    /* Statistics */
-    atomic64_t total_events;
-    atomic64_t total_samples;
-    atomic64_t hardware_events;              /* Number of hardware events */
-    atomic64_t simulation_events;            /* Number of simulation events */
+	/* Statistics */
+	atomic64_t total_events;
+	atomic64_t total_samples;
+	atomic64_t hardware_events; /* Number of hardware events */
+	atomic64_t simulation_events; /* Number of simulation events */
 
-    /* Simulated counter values */
-    atomic64_t counter_sq_waves;
-    atomic64_t counter_sq_instructions;
-    atomic64_t counter_ta_busy;
+	/* Simulated counter values */
+	atomic64_t counter_sq_waves;
+	atomic64_t counter_sq_instructions;
+	atomic64_t counter_ta_busy;
 };
 
 /* Function prototypes */
@@ -112,16 +112,12 @@ uint64_t aql_pmu_event_read_sync(struct perf_event *event);
 void aql_pmu_get_stats(struct aql_perf_stats *stats);
 
 /* Debug helpers */
-#define pmu_debug(fmt, ...) \
-    pr_info("[" MODULE_NAME "] " fmt, ##__VA_ARGS__)
+#define pmu_debug(fmt, ...) pr_info("[" MODULE_NAME "] " fmt, ##__VA_ARGS__)
 
-#define pmu_info(fmt, ...) \
-    pr_info("[" MODULE_NAME "] " fmt, ##__VA_ARGS__)
+#define pmu_info(fmt, ...) pr_info("[" MODULE_NAME "] " fmt, ##__VA_ARGS__)
 
-#define pmu_warn(fmt, ...) \
-    pr_warn("[" MODULE_NAME "] " fmt, ##__VA_ARGS__)
+#define pmu_warn(fmt, ...) pr_warn("[" MODULE_NAME "] " fmt, ##__VA_ARGS__)
 
-#define pmu_err(fmt, ...) \
-    pr_err("[" MODULE_NAME "] " fmt, ##__VA_ARGS__)
+#define pmu_err(fmt, ...) pr_err("[" MODULE_NAME "] " fmt, ##__VA_ARGS__)
 
 #endif /* _AMDGPU_PMU_H */

--- a/projects/perf-dkms/src/aql_c/aql_structures.h
+++ b/projects/perf-dkms/src/aql_c/aql_structures.h
@@ -31,109 +31,103 @@ typedef struct dimension dimension_t;
 
 /* Enumerations */
 typedef enum {
-    HARDWARE_DIM_XCC,
-    HARDWARE_DIM_SE,
-    HARDWARE_DIM_SA,
-    HARDWARE_DIM_CU,
-    HARDWARE_DIM_WGP
+	HARDWARE_DIM_XCC,
+	HARDWARE_DIM_SE,
+	HARDWARE_DIM_SA,
+	HARDWARE_DIM_CU,
+	HARDWARE_DIM_WGP
 } hardware_dimensions_t;
 
 typedef enum {
-    HW_IP_BLOCK_ATC,     /* Address Translation Cache */
-    HW_IP_BLOCK_CPC,     /* Command Processor Compute */
-    HW_IP_BLOCK_CPF,     /* Command Processor Fetcher */
-    HW_IP_BLOCK_CPG,     /* Command Processor Graphics */
-    HW_IP_BLOCK_DB,      /* Depth Buffer */
-    HW_IP_BLOCK_EA,      /* Efficiency Arbiter */
-    HW_IP_BLOCK_GDS,     /* Global Data Store */
-    HW_IP_BLOCK_GRBM,    /* Graphics Register Bus Manager */
-    HW_IP_BLOCK_GL2C,    /* Graphics L2 Cache C */
-    HW_IP_BLOCK_PA_SC,   /* Primitive Assembly - Scan Converter */
-    HW_IP_BLOCK_PA_SU,   /* Primitive Assembly - Setup Unit */
-    HW_IP_BLOCK_RMI,     /* Render Backend Memory Interface */
-    HW_IP_BLOCK_SPI,     /* Shader Processor Input */
-    HW_IP_BLOCK_SQ,      /* Shader Processor (Sequencer) */
-    HW_IP_BLOCK_SX,      /* Shader Export */
-    HW_IP_BLOCK_TA,      /* Texture Addresser */
-    HW_IP_BLOCK_TCP,     /* Texture Cache Processor */
-    HW_IP_BLOCK_TD,      /* Texture Data */
-    HW_IP_BLOCK_TCA,     /* Texture Cache Arbiter */
-    HW_IP_BLOCK_TCC,     /* Texture Cache Controller */
-    HW_IP_BLOCK_UMC,     /* Unified Memory Controller */
-    HW_IP_BLOCK_SDMA,
-    HW_IP_BLOCK_LAST
+	HW_IP_BLOCK_ATC, /* Address Translation Cache */
+	HW_IP_BLOCK_CPC, /* Command Processor Compute */
+	HW_IP_BLOCK_CPF, /* Command Processor Fetcher */
+	HW_IP_BLOCK_CPG, /* Command Processor Graphics */
+	HW_IP_BLOCK_DB, /* Depth Buffer */
+	HW_IP_BLOCK_EA, /* Efficiency Arbiter */
+	HW_IP_BLOCK_GDS, /* Global Data Store */
+	HW_IP_BLOCK_GRBM, /* Graphics Register Bus Manager */
+	HW_IP_BLOCK_GL2C, /* Graphics L2 Cache C */
+	HW_IP_BLOCK_PA_SC, /* Primitive Assembly - Scan Converter */
+	HW_IP_BLOCK_PA_SU, /* Primitive Assembly - Setup Unit */
+	HW_IP_BLOCK_RMI, /* Render Backend Memory Interface */
+	HW_IP_BLOCK_SPI, /* Shader Processor Input */
+	HW_IP_BLOCK_SQ, /* Shader Processor (Sequencer) */
+	HW_IP_BLOCK_SX, /* Shader Export */
+	HW_IP_BLOCK_TA, /* Texture Addresser */
+	HW_IP_BLOCK_TCP, /* Texture Cache Processor */
+	HW_IP_BLOCK_TD, /* Texture Data */
+	HW_IP_BLOCK_TCA, /* Texture Cache Arbiter */
+	HW_IP_BLOCK_TCC, /* Texture Cache Controller */
+	HW_IP_BLOCK_UMC, /* Unified Memory Controller */
+	HW_IP_BLOCK_SDMA,
+	HW_IP_BLOCK_LAST
 } hardware_ip_block_t;
 
 /* Architecture type enumeration */
-typedef enum {
-    ARCH_TYPE_GFX9,
-    ARCH_TYPE_GFX10,
-    ARCH_TYPE_GFX11,
-    ARCH_TYPE_GFX12
-} arch_type_t;
+typedef enum { ARCH_TYPE_GFX9, ARCH_TYPE_GFX10, ARCH_TYPE_GFX11, ARCH_TYPE_GFX12 } arch_type_t;
 
 /* Block info - represents a hardware performance counter block type */
 typedef struct {
-    const char* name;                      /* Unique string identifier */
-    hardware_ip_block_t id;                /* Block ID */
-    uint32_t instance_count;               /* Maximum number of block instances per shader array */
-    uint32_t event_id_max;                 /* Maximum counter event ID */
-    uint32_t counter_count;                /* Maximum number of counters that can be enabled at once */
-    counter_reg_info_t* counter_reg_info;  /* Array of counter register addresses */
-    uint32_t attr;                         /* Block attributes mask */
-    block_delay_info_t* delay_info;        /* Optional block delay info */
-    uint32_t spm_block_id;                 /* SPM block id */
+	const char *name; /* Unique string identifier */
+	hardware_ip_block_t id; /* Block ID */
+	uint32_t instance_count; /* Maximum number of block instances per shader array */
+	uint32_t event_id_max; /* Maximum counter event ID */
+	uint32_t counter_count; /* Maximum number of counters that can be enabled at once */
+	counter_reg_info_t *counter_reg_info; /* Array of counter register addresses */
+	uint32_t attr; /* Block attributes mask */
+	block_delay_info_t *delay_info; /* Optional block delay info */
+	uint32_t spm_block_id; /* SPM block id */
 
-    /* Hardware dimensions for this block */
-    dimension_t* dimensions;               /* Array of dimensions relevant to this block */
-    uint32_t dimension_count;              /* Number of dimensions for this block */
+	/* Hardware dimensions for this block */
+	dimension_t *dimensions; /* Array of dimensions relevant to this block */
+	uint32_t dimension_count; /* Number of dimensions for this block */
 } block_info_t;
 
 /* Block info map - provides fast lookup by hardware_ip_block_t */
 typedef struct {
-    /* Direct indexed array for O(1) lookup by block ID */
-    block_info_t* blocks[HW_IP_BLOCK_LAST];
+	/* Direct indexed array for O(1) lookup by block ID */
+	block_info_t *blocks[HW_IP_BLOCK_LAST];
 
-    /* Total number of blocks defined */
-    uint32_t block_count;
+	/* Total number of blocks defined */
+	uint32_t block_count;
 } block_info_map_t;
 
 /* Architecture-specific control registers for packet generation */
 typedef struct {
-    /* Global control registers */
-    uint32_t grbm_gfx_index;           /* GRBM graphics index register */
-    uint32_t cp_perfmon_cntl;          /* CP performance monitor control */
-    uint32_t compute_perfcount_enable; /* Compute performance counter enable */
-    uint32_t sq_perfcounter_ctrl2;     /* SQ performance counter control 2 */
+	/* Global control registers */
+	uint32_t grbm_gfx_index; /* GRBM graphics index register */
+	uint32_t cp_perfmon_cntl; /* CP performance monitor control */
+	uint32_t compute_perfcount_enable; /* Compute performance counter enable */
+	uint32_t sq_perfcounter_ctrl2; /* SQ performance counter control 2 */
 
+	/* Register space bases */
+	uint32_t uconfig_space_start; /* Base of UCONFIG register space */
+	uint32_t persistent_space_start; /* Base of persistent (SH) register space */
 
-    /* Register space bases */
-    uint32_t uconfig_space_start;      /* Base of UCONFIG register space */
-    uint32_t persistent_space_start;   /* Base of persistent (SH) register space */
+	/* Event configuration */
+	uint32_t cs_partial_flush_event; /* Event type for CS partial flush */
+	uint32_t event_index_flush; /* Event index for flush operations */
 
-    /* Event configuration */
-    uint32_t cs_partial_flush_event;   /* Event type for CS partial flush */
-    uint32_t event_index_flush;        /* Event index for flush operations */
+	/* Cache coherency parameters */
+	uint32_t gcr_cntl_default; /* Default GCR control value */
+	uint32_t poll_interval_default; /* Default poll interval for cache ops */
 
-    /* Cache coherency parameters */
-    uint32_t gcr_cntl_default;         /* Default GCR control value */
-    uint32_t poll_interval_default;    /* Default poll interval for cache ops */
+	/* Performance counter control bits */
+	struct {
+		uint8_t sq_ps_en_bit; /* Bit position for PS enable */
+		uint8_t sq_gs_en_bit; /* Bit position for GS enable */
+		uint8_t sq_hs_en_bit; /* Bit position for HS enable */
+		uint8_t sq_cs_en_bit; /* Bit position for CS enable */
+	} counter_control_bits;
 
-    /* Performance counter control bits */
-    struct {
-        uint8_t sq_ps_en_bit;          /* Bit position for PS enable */
-        uint8_t sq_gs_en_bit;          /* Bit position for GS enable */
-        uint8_t sq_hs_en_bit;          /* Bit position for HS enable */
-        uint8_t sq_cs_en_bit;          /* Bit position for CS enable */
-    } counter_control_bits;
-
-    /* Perfmon states */
-    struct {
-        uint8_t perfmon_state_disable; /* Disable state value */
-        uint8_t perfmon_state_enable;  /* Enable state value */
-        uint8_t perfmon_state_stop;    /* Stop state value */
-        uint8_t perfmon_sample_bit;    /* Sample enable bit position */
-    } perfmon_states;
+	/* Perfmon states */
+	struct {
+		uint8_t perfmon_state_disable; /* Disable state value */
+		uint8_t perfmon_state_enable; /* Enable state value */
+		uint8_t perfmon_state_stop; /* Stop state value */
+		uint8_t perfmon_sample_bit; /* Sample enable bit position */
+	} perfmon_states;
 } arch_control_regs_t;
 
 /* Forward declare arch_event_map_t from counter_registry.h */
@@ -141,33 +135,33 @@ typedef struct arch_event_map arch_event_map_t;
 
 /* Unified architecture structure - same fields for all architectures */
 typedef struct {
-    arch_type_t type;
-    uint32_t num_xcc;
-    uint32_t num_se;
-    uint32_t num_sa;
-    uint32_t num_cu;
-    uint32_t num_wgp_per_sa;
+	arch_type_t type;
+	uint32_t num_xcc;
+	uint32_t num_se;
+	uint32_t num_sa;
+	uint32_t num_cu;
+	uint32_t num_wgp_per_sa;
 
-    /* PM4 command buffer for building GPU command streams */
-    pm4_buffer_t* command;
+	/* PM4 command buffer for building GPU command streams */
+	pm4_buffer_t *command;
 
-    /* Block info organized by hardware IP block type */
-    block_info_map_t block_map;
+	/* Block info organized by hardware IP block type */
+	block_info_map_t block_map;
 
-    /* Architecture-specific control registers */
-    arch_control_regs_t control_regs;
+	/* Architecture-specific control registers */
+	arch_control_regs_t control_regs;
 
-    /* Architecture-specific event mapping */
-    const arch_event_map_t* event_map;
-    size_t event_count;
+	/* Architecture-specific event mapping */
+	const arch_event_map_t *event_map;
+	size_t event_count;
 } arch_t;
 
 /* Counter allocation state */
 typedef enum {
-    COUNTER_STATE_FREE = 0,
-    COUNTER_STATE_ALLOCATED,
-    COUNTER_STATE_RESERVED,    /* Reserved by system */
-    COUNTER_STATE_ERROR
+	COUNTER_STATE_FREE = 0,
+	COUNTER_STATE_ALLOCATED,
+	COUNTER_STATE_RESERVED, /* Reserved by system */
+	COUNTER_STATE_ERROR
 } counter_state_t;
 
 /* Forward declaration for KFD allocation type */
@@ -175,299 +169,297 @@ struct kfd_data_alloc;
 
 /* Counter allocation info - tracks what a counter is being used for */
 typedef struct {
-    atomic_t state;             /* Atomic state for lock-free allocation */
-    uint32_t event_id;          /* Event being monitored */
-    uint32_t instance_id;       /* Which instance of the block (0 to instance_count-1) */
-    uint32_t user_id;           /* User-defined ID for tracking */
-    const char* description;    /* Optional description of what's being measured */
-    uint64_t allocation_time;   /* Timestamp when allocated */
+	atomic_t state; /* Atomic state for lock-free allocation */
+	uint32_t event_id; /* Event being monitored */
+	uint32_t instance_id; /* Which instance of the block (0 to instance_count-1) */
+	uint32_t user_id; /* User-defined ID for tracking */
+	const char *description; /* Optional description of what's being measured */
+	uint64_t allocation_time; /* Timestamp when allocated */
 
-    /* GPU device memory buffers (allocated via kfd_alloc_device, 1 page each) */
-    struct kfd_data_alloc* command_buffer;  /* PM4 command buffer for counter operations */
-    struct kfd_data_alloc* data_buffer;     /* Data buffer for counter readback */
+	/* GPU device memory buffers (allocated via kfd_alloc_device, 1 page each) */
+	struct kfd_data_alloc *command_buffer; /* PM4 command buffer for counter operations */
+	struct kfd_data_alloc *data_buffer; /* Data buffer for counter readback */
 } counter_allocation_t;
 
 /* Counter register information with allocation tracking */
 struct counter_reg_info {
-    /* Hardware register addresses */
-    uint32_t select_addr;
-    uint32_t control_addr;
-    uint32_t register_addr_lo;
-    uint32_t register_addr_hi;
+	/* Hardware register addresses */
+	uint32_t select_addr;
+	uint32_t control_addr;
+	uint32_t register_addr_lo;
+	uint32_t register_addr_hi;
 
-    /* Allocation tracking */
-    counter_allocation_t allocation;
+	/* Allocation tracking */
+	counter_allocation_t allocation;
 };
 
 /* Block delay information */
 struct block_delay_info {
-    uint32_t reg;
-    uint32_t val;
+	uint32_t reg;
+	uint32_t val;
 };
 
 /* Hardware dimension information */
 struct dimension {
-    uint32_t size;
-    hardware_dimensions_t dim;
+	uint32_t size;
+	hardware_dimensions_t dim;
 };
 
 /* GPU block information */
 typedef struct {
-    const char* name;
-    hardware_ip_block_t id;
-    uint32_t instance_count;
-    uint32_t event_id_max;
-    uint32_t counter_count;
-    struct kvec_counter_reg_info* counter_reg_info;
-    uint32_t attr;
-    block_delay_info_t* delay_info;  /* Optional - NULL if not present */
-    uint32_t spm_block_id;
+	const char *name;
+	hardware_ip_block_t id;
+	uint32_t instance_count;
+	uint32_t event_id_max;
+	uint32_t counter_count;
+	struct kvec_counter_reg_info *counter_reg_info;
+	uint32_t attr;
+	block_delay_info_t *delay_info; /* Optional - NULL if not present */
+	uint32_t spm_block_id;
 } gpu_block_info_t;
 
 /* Counter descriptor */
 typedef struct {
-    const char* name;
-    hardware_ip_block_t id;
-    uint32_t event_id;
+	const char *name;
+	hardware_ip_block_t id;
+	uint32_t event_id;
 } counter_t;
 
 /* PM4 command wrapper */
 typedef struct {
-    uint32_t value;
+	uint32_t value;
 } pm4_command_t;
 
 /* Bitfield structures for GFX12 */
 
 /* CP Perfmon Control */
 typedef union {
-    uint32_t raw;
-    struct {
-        uint32_t perfmon_state : 4;          /* bits 0-3 */
-        uint32_t spm_perfmon_state : 4;      /* bits 4-7 */
-        uint32_t perfmon_enable_mode : 2;    /* bits 8-9 */
-        uint32_t perfmon_sample_enable : 1;  /* bit 10 */
-        uint32_t reserved : 21;              /* bits 11-31 */
-    } bits;
+	uint32_t raw;
+	struct {
+		uint32_t perfmon_state : 4; /* bits 0-3 */
+		uint32_t spm_perfmon_state : 4; /* bits 4-7 */
+		uint32_t perfmon_enable_mode : 2; /* bits 8-9 */
+		uint32_t perfmon_sample_enable : 1; /* bit 10 */
+		uint32_t reserved : 21; /* bits 11-31 */
+	} bits;
 } cp_perfmon_cntl_t;
 
 /* GRBM GFX Index */
 typedef union {
-    uint32_t raw;
-    struct {
-        uint32_t instance_index : 7;           /* bits 0-6 */
-        uint32_t reserved1 : 1;                /* bit 7 */
-        uint32_t sa_index : 2;                 /* bits 8-9 */
-        uint32_t reserved2 : 6;                /* bits 10-15 */
-        uint32_t se_index : 4;                 /* bits 16-19 */
-        uint32_t reserved3 : 9;                /* bits 20-28 */
-        uint32_t sa_broadcast_writes : 1;      /* bit 29 */
-        uint32_t instance_broadcast_writes : 1;/* bit 30 */
-        uint32_t se_broadcast_writes : 1;      /* bit 31 */
-    } bits;
+	uint32_t raw;
+	struct {
+		uint32_t instance_index : 7; /* bits 0-6 */
+		uint32_t reserved1 : 1; /* bit 7 */
+		uint32_t sa_index : 2; /* bits 8-9 */
+		uint32_t reserved2 : 6; /* bits 10-15 */
+		uint32_t se_index : 4; /* bits 16-19 */
+		uint32_t reserved3 : 9; /* bits 20-28 */
+		uint32_t sa_broadcast_writes : 1; /* bit 29 */
+		uint32_t instance_broadcast_writes : 1; /* bit 30 */
+		uint32_t se_broadcast_writes : 1; /* bit 31 */
+	} bits;
 } grbm_gfx_index_t;
 
 /* Barrier Event */
 typedef union {
-    uint32_t raw;
-    struct {
-        uint32_t event_type : 6;           /* bits 0-5 */
-        uint32_t reserved1 : 2;            /* bits 6-7 */
-        uint32_t event_index : 4;          /* bits 8-11 */
-        uint32_t reserved2 : 9;            /* bits 12-20 */
-        uint32_t samp_plst_cntr_mode : 2;  /* bits 21-22 */
-        uint32_t offload_enable : 1;       /* bit 23 */
-        uint32_t reserved3 : 8;            /* bits 24-31 */
-    } bits;
+	uint32_t raw;
+	struct {
+		uint32_t event_type : 6; /* bits 0-5 */
+		uint32_t reserved1 : 2; /* bits 6-7 */
+		uint32_t event_index : 4; /* bits 8-11 */
+		uint32_t reserved2 : 9; /* bits 12-20 */
+		uint32_t samp_plst_cntr_mode : 2; /* bits 21-22 */
+		uint32_t offload_enable : 1; /* bit 23 */
+		uint32_t reserved3 : 8; /* bits 24-31 */
+	} bits;
 } barrier_event_t;
 
 /* Copy Data */
 typedef union {
-    uint32_t raw;
-    struct {
-        uint32_t src_sel : 4;          /* bits 0-3 */
-        uint32_t reserved1 : 4;        /* bits 4-7 */
-        uint32_t dst_sel : 4;          /* bits 8-11 */
-        uint32_t reserved2 : 1;        /* bit 12 */
-        uint32_t src_temporal : 2;     /* bits 13-14 */
-        uint32_t reserved3 : 1;        /* bit 15 */
-        uint32_t count_sel : 1;        /* bit 16 */
-        uint32_t reserved4 : 3;        /* bits 17-19 */
-        uint32_t wr_confirm : 1;       /* bit 20 */
-        uint32_t mode : 1;             /* bit 21 */
-        uint32_t reserved5 : 1;        /* bit 22 */
-        uint32_t aid_id : 2;           /* bits 23-24 */
-        uint32_t dst_temporal : 2;     /* bits 25-26 */
-        uint32_t reserved6 : 2;        /* bits 27-28 */
-        uint32_t pq_exe_status : 1;    /* bit 29 */
-        uint32_t reserved7 : 2;        /* bits 30-31 */
-    } bits;
+	uint32_t raw;
+	struct {
+		uint32_t src_sel : 4; /* bits 0-3 */
+		uint32_t reserved1 : 4; /* bits 4-7 */
+		uint32_t dst_sel : 4; /* bits 8-11 */
+		uint32_t reserved2 : 1; /* bit 12 */
+		uint32_t src_temporal : 2; /* bits 13-14 */
+		uint32_t reserved3 : 1; /* bit 15 */
+		uint32_t count_sel : 1; /* bit 16 */
+		uint32_t reserved4 : 3; /* bits 17-19 */
+		uint32_t wr_confirm : 1; /* bit 20 */
+		uint32_t mode : 1; /* bit 21 */
+		uint32_t reserved5 : 1; /* bit 22 */
+		uint32_t aid_id : 2; /* bits 23-24 */
+		uint32_t dst_temporal : 2; /* bits 25-26 */
+		uint32_t reserved6 : 2; /* bits 27-28 */
+		uint32_t pq_exe_status : 1; /* bit 29 */
+		uint32_t reserved7 : 2; /* bits 30-31 */
+	} bits;
 } copy_data_t;
 
 /* Performance Counter Control 2 */
 typedef union {
-    uint32_t raw;
-    struct {
-        uint32_t force_en : 1;     /* bit 0 */
-        uint32_t vmid_en : 16;     /* bits 1-16 */
-        uint32_t reserved : 15;    /* bits 17-31 */
-    } bits;
+	uint32_t raw;
+	struct {
+		uint32_t force_en : 1; /* bit 0 */
+		uint32_t vmid_en : 16; /* bits 1-16 */
+		uint32_t reserved : 15; /* bits 17-31 */
+	} bits;
 } perf_counter_ctrl2_t;
 
 /* SQ Performance Control */
 typedef union {
-    uint32_t raw;
-    struct {
-        uint32_t ps_en : 1;             /* bit 0 */
-        uint32_t reserved1 : 1;         /* bit 1 */
-        uint32_t gs_en : 1;             /* bit 2 */
-        uint32_t reserved2 : 1;         /* bit 3 */
-        uint32_t hs_en : 1;             /* bit 4 */
-        uint32_t reserved3 : 1;         /* bit 5 */
-        uint32_t cs_en : 1;             /* bit 6 */
-        uint32_t reserved4 : 7;         /* bits 7-13 */
-        uint32_t disable_me0pipe0 : 1;  /* bit 14 */
-        uint32_t disable_me0pipe1 : 1;  /* bit 15 */
-        uint32_t disable_me1pipe0 : 1;  /* bit 16 */
-        uint32_t disable_me1pipe1 : 1;  /* bit 17 */
-        uint32_t disable_me1pipe3 : 1;  /* bit 18 */
-        uint32_t reserved5 : 13;        /* bits 19-31 */
-    } bits;
+	uint32_t raw;
+	struct {
+		uint32_t ps_en : 1; /* bit 0 */
+		uint32_t reserved1 : 1; /* bit 1 */
+		uint32_t gs_en : 1; /* bit 2 */
+		uint32_t reserved2 : 1; /* bit 3 */
+		uint32_t hs_en : 1; /* bit 4 */
+		uint32_t reserved3 : 1; /* bit 5 */
+		uint32_t cs_en : 1; /* bit 6 */
+		uint32_t reserved4 : 7; /* bits 7-13 */
+		uint32_t disable_me0pipe0 : 1; /* bit 14 */
+		uint32_t disable_me0pipe1 : 1; /* bit 15 */
+		uint32_t disable_me1pipe0 : 1; /* bit 16 */
+		uint32_t disable_me1pipe1 : 1; /* bit 17 */
+		uint32_t disable_me1pipe3 : 1; /* bit 18 */
+		uint32_t reserved5 : 13; /* bits 19-31 */
+	} bits;
 } sq_perf_control_t;
 
 /* Performance Counter Select */
 typedef union {
-    uint32_t raw;
-    struct {
-        uint32_t perf_sel : 9;      /* bits 0-8 */
-        uint32_t reserved1 : 11;    /* bits 9-19 */
-        uint32_t spm_mode : 4;      /* bits 20-23 */
-        uint32_t reserved2 : 4;     /* bits 24-27 */
-        uint32_t perf_mode : 4;     /* bits 28-31 */
-    } bits;
+	uint32_t raw;
+	struct {
+		uint32_t perf_sel : 9; /* bits 0-8 */
+		uint32_t reserved1 : 11; /* bits 9-19 */
+		uint32_t spm_mode : 4; /* bits 20-23 */
+		uint32_t reserved2 : 4; /* bits 24-27 */
+		uint32_t perf_mode : 4; /* bits 28-31 */
+	} bits;
 } perf_counter_select_t;
 
 /* Compute Performance Count Enable */
 typedef union {
-    uint32_t raw;
-    struct {
-        uint32_t enable : 1;        /* bit 0 */
-        uint32_t reserved : 31;     /* bits 1-31 */
-    } bits;
+	uint32_t raw;
+	struct {
+		uint32_t enable : 1; /* bit 0 */
+		uint32_t reserved : 31; /* bits 1-31 */
+	} bits;
 } compute_perfcount_enable_t;
 
 /* KFD Memory Flags */
 typedef union {
-    uint32_t raw;
-    struct {
-        uint32_t non_paged : 1;             /* bit 0 */
-        uint32_t cache_policy : 2;          /* bits 1-2 */
-        uint32_t read_only : 1;             /* bit 3 */
-        uint32_t page_size : 2;             /* bits 4-5 */
-        uint32_t host_access : 1;           /* bit 6 */
-        uint32_t no_substitute : 1;         /* bit 7 */
-        uint32_t gds_memory : 1;            /* bit 8 */
-        uint32_t scratch : 1;               /* bit 9 */
-        uint32_t atomic_access_full : 1;    /* bit 10 */
-        uint32_t atomic_access_partial : 1; /* bit 11 */
-        uint32_t execute_access : 1;        /* bit 12 */
-        uint32_t coarse_grain : 1;          /* bit 13 */
-        uint32_t aql_queue_memory : 1;      /* bit 14 */
-        uint32_t fixed_address : 1;         /* bit 15 */
-        uint32_t no_numa_bind : 1;          /* bit 16 */
-        uint32_t uncached : 1;               /* bit 17 */
-        uint32_t no_address : 1;             /* bit 18 */
-        uint32_t only_address : 1;          /* bit 19 */
-        uint32_t extended_coherent : 1;     /* bit 20 */
-        uint32_t gtt_access : 1;            /* bit 21 */
-        uint32_t contiguous : 1;            /* bit 22 */
-        uint32_t reserved : 9;              /* bits 23-31 */
-    } bits;
+	uint32_t raw;
+	struct {
+		uint32_t non_paged : 1; /* bit 0 */
+		uint32_t cache_policy : 2; /* bits 1-2 */
+		uint32_t read_only : 1; /* bit 3 */
+		uint32_t page_size : 2; /* bits 4-5 */
+		uint32_t host_access : 1; /* bit 6 */
+		uint32_t no_substitute : 1; /* bit 7 */
+		uint32_t gds_memory : 1; /* bit 8 */
+		uint32_t scratch : 1; /* bit 9 */
+		uint32_t atomic_access_full : 1; /* bit 10 */
+		uint32_t atomic_access_partial : 1; /* bit 11 */
+		uint32_t execute_access : 1; /* bit 12 */
+		uint32_t coarse_grain : 1; /* bit 13 */
+		uint32_t aql_queue_memory : 1; /* bit 14 */
+		uint32_t fixed_address : 1; /* bit 15 */
+		uint32_t no_numa_bind : 1; /* bit 16 */
+		uint32_t uncached : 1; /* bit 17 */
+		uint32_t no_address : 1; /* bit 18 */
+		uint32_t only_address : 1; /* bit 19 */
+		uint32_t extended_coherent : 1; /* bit 20 */
+		uint32_t gtt_access : 1; /* bit 21 */
+		uint32_t contiguous : 1; /* bit 22 */
+		uint32_t reserved : 9; /* bits 23-31 */
+	} bits;
 } kfd_memory_flags_t;
 
 /* PM4 Packet Structures */
 
 /* Set UConfig Register packet */
 typedef struct {
-    uint32_t header;        /* Contains op_code and size */
-    uint16_t reg_offset;
-    uint16_t reserved;
-    uint32_t reg_value;
+	uint32_t header; /* Contains op_code and size */
+	uint16_t reg_offset;
+	uint16_t reserved;
+	uint32_t reg_value;
 } set_uconfig_reg_packet_t;
 
 /* Event Write packet */
 typedef struct {
-    uint32_t header;        /* Contains op_code and size */
-    uint32_t event;
+	uint32_t header; /* Contains op_code and size */
+	uint32_t event;
 } event_write_packet_t;
 
 /* Copy Data packet */
 typedef struct {
-    uint32_t header;        /* Contains op_code and size */
-    uint32_t copy_data;
-    uint32_t src_reg_offset_lo;
-    uint32_t src_reg_offset_hi;
-    uint32_t dst_reg_offset_lo;
-    uint32_t dst_reg_offset_hi;
+	uint32_t header; /* Contains op_code and size */
+	uint32_t copy_data;
+	uint32_t src_reg_offset_lo;
+	uint32_t src_reg_offset_hi;
+	uint32_t dst_reg_offset_lo;
+	uint32_t dst_reg_offset_hi;
 } copy_data_packet_t;
 
 /* Flush Cache packet */
 typedef struct {
-    uint32_t header;        /* Contains op_code and size */
-    uint32_t reserved;
-    uint32_t coher_size;
-    uint32_t coher_size_hi;
-    uint32_t coher_base_lo;
-    uint32_t coher_base_hi;
-    uint32_t poll_interval;
-    uint32_t gcr_cntl;
+	uint32_t header; /* Contains op_code and size */
+	uint32_t reserved;
+	uint32_t coher_size;
+	uint32_t coher_size_hi;
+	uint32_t coher_base_lo;
+	uint32_t coher_base_hi;
+	uint32_t poll_interval;
+	uint32_t gcr_cntl;
 } flush_cache_packet_t;
 
 /* Write SH Register packet */
 typedef struct {
-    uint32_t header;        /* Contains op_code and size */
-    union {
-        uint32_t raw;
-        struct {
-            uint32_t reg_offset : 16;
-            uint32_t reserved : 7;
-            uint32_t vmid_shift : 5;
-            uint32_t index : 4;
-        } fields;
-    } word1;
-    uint32_t reg_value;
+	uint32_t header; /* Contains op_code and size */
+	union {
+		uint32_t raw;
+		struct {
+			uint32_t reg_offset : 16;
+			uint32_t reserved : 7;
+			uint32_t vmid_shift : 5;
+			uint32_t index : 4;
+		} fields;
+	} word1;
+	uint32_t reg_value;
 } write_sh_register_packet_t;
 
 /* Helper macros for PM4 packet creation */
-#define PM4_HEADER(op_code, size_dw) \
-    (((op_code) << 8) | (((size_dw) - 2) & 0x3FFF) << 16)
+#define PM4_HEADER(op_code, size_dw) (((op_code) << 8) | (((size_dw) - 2) & 0x3FFF) << 16)
 
-#define SET_UCONFIG_REG_OPCODE      0x79
-#define EVENT_WRITE_OPCODE           0x46  /* decimal 70 */
-#define COPY_DATA_OPCODE             0x40  /* decimal 64 */
-#define FLUSH_CACHE_OPCODE           0x58
-#define WRITE_SH_REG_OPCODE          0x76
+#define SET_UCONFIG_REG_OPCODE 0x79
+#define EVENT_WRITE_OPCODE 0x46 /* decimal 70 */
+#define COPY_DATA_OPCODE 0x40 /* decimal 64 */
+#define FLUSH_CACHE_OPCODE 0x58
+#define WRITE_SH_REG_OPCODE 0x76
 
 /* Allocation summary structure */
 typedef struct {
-    uint32_t total_counters;
-    uint32_t free_counters;
-    uint32_t allocated_counters;
-    uint32_t reserved_counters;
-    uint32_t error_counters;
+	uint32_t total_counters;
+	uint32_t free_counters;
+	uint32_t allocated_counters;
+	uint32_t reserved_counters;
+	uint32_t error_counters;
 } counter_allocation_summary_t;
 
 /* Function pointer type for block iteration */
-typedef void (*block_info_visitor_fn)(hardware_ip_block_t block_id, block_info_t* block, void* user_data);
+typedef void (*block_info_visitor_fn)(hardware_ip_block_t block_id, block_info_t *block,
+				      void *user_data);
 
 /* Helper macros for counter allocation */
 #define COUNTER_ALLOCATE_SIMPLE(block, event_id, instance_id) \
-    counter_allocate(block, event_id, instance_id, 0, NULL)
+	counter_allocate(block, event_id, instance_id, 0, NULL)
 
-#define COUNTER_IS_FREE(counter) \
-    (counter_get_state(counter) == COUNTER_STATE_FREE)
+#define COUNTER_IS_FREE(counter) (counter_get_state(counter) == COUNTER_STATE_FREE)
 
-#define COUNTER_IS_ALLOCATED(counter) \
-    (counter_get_state(counter) == COUNTER_STATE_ALLOCATED)
+#define COUNTER_IS_ALLOCATED(counter) (counter_get_state(counter) == COUNTER_STATE_ALLOCATED)
 
 /* All function declarations commented out for now */
 /*
@@ -545,7 +537,7 @@ uint32_t gpu_block_info_get_spm_block_id(const gpu_block_info_t* self);
 /* pm4_op_t and related types are now defined in pm4_packets.h */
 
 /* Architecture creation and destruction functions */
-arch_t* arch_create_by_name(const char* arch_name);
-void arch_destroy(arch_t* arch);
+arch_t *arch_create_by_name(const char *arch_name);
+void arch_destroy(arch_t *arch);
 
 #endif /* AQL_STRUCTURES_H */

--- a/projects/perf-dkms/src/aql_c/aql_types.h
+++ b/projects/perf-dkms/src/aql_c/aql_types.h
@@ -14,17 +14,17 @@
 
 /* Basic result codes */
 typedef enum {
-    AQL_SUCCESS = 0,
-    AQL_ERROR_INVALID_ARGUMENT = -1,
-    AQL_ERROR_NO_MEMORY = -2,
-    AQL_ERROR_UNSUPPORTED = -3,
+	AQL_SUCCESS = 0,
+	AQL_ERROR_INVALID_ARGUMENT = -1,
+	AQL_ERROR_NO_MEMORY = -2,
+	AQL_ERROR_UNSUPPORTED = -3,
 } aql_result_t;
 
 /* Basic packet structure */
 typedef struct {
-    uint32_t header;
-    uint32_t* ib_base;
-    uint32_t ib_size_dw;
+	uint32_t header;
+	uint32_t *ib_base;
+	uint32_t ib_size_dw;
 } aql_pm4_ib_packet_t;
 
 #endif /* AQL_TYPES_H */

--- a/projects/perf-dkms/src/aql_c/arch_creator.c
+++ b/projects/perf-dkms/src/aql_c/arch_creator.c
@@ -30,15 +30,17 @@
  * @note Caller is responsible for freeing with arch_destroy()
  * @see arch_destroy(), Pm4Factory::Create in projects/aqlprofile/src/core/pm4_factory.h:113
  */
-arch_t* arch_create_by_name(const char* arch_name) {
-    if (!arch_name) return NULL;
+arch_t *arch_create_by_name(const char *arch_name)
+{
+	if (!arch_name)
+		return NULL;
 
-    /* GFX12 architecture */
-    if (strcmp(arch_name, "gfx12") == 0 || strcmp(arch_name, "GFX12") == 0) {
-        return create_gfx12_arch();
-    }
+	/* GFX12 architecture */
+	if (strcmp(arch_name, "gfx12") == 0 || strcmp(arch_name, "GFX12") == 0) {
+		return create_gfx12_arch();
+	}
 
-    /* Future architectures can be added here with their respective creator functions:
+	/* Future architectures can be added here with their respective creator functions:
      *
      * if (strcmp(arch_name, "gfx11") == 0 || strcmp(arch_name, "GFX11") == 0) {
      *     return create_gfx11_arch();
@@ -53,8 +55,8 @@ arch_t* arch_create_by_name(const char* arch_name) {
      * }
      */
 
-    /* Unknown architecture */
-    return NULL;
+	/* Unknown architecture */
+	return NULL;
 }
 
 /**
@@ -80,31 +82,33 @@ arch_t* arch_create_by_name(const char* arch_name) {
  * @see arch_create_by_name(), Pm4Factory::~Pm4Factory in
  *      projects/aqlprofile/src/core/pm4_factory.h:233
  */
-void arch_destroy(arch_t* arch) {
-    if (!arch) return;
+void arch_destroy(arch_t *arch)
+{
+	if (!arch)
+		return;
 
-    /* Free block information */
-    for (uint32_t i = 0; i < HW_IP_BLOCK_LAST; i++) {
-        if (arch->block_map.blocks[i]) {
-            /* Free counter register info arrays */
-            if (arch->block_map.blocks[i]->counter_reg_info) {
-                FREE(arch->block_map.blocks[i]->counter_reg_info);
-            }
+	/* Free block information */
+	for (uint32_t i = 0; i < HW_IP_BLOCK_LAST; i++) {
+		if (arch->block_map.blocks[i]) {
+			/* Free counter register info arrays */
+			if (arch->block_map.blocks[i]->counter_reg_info) {
+				FREE(arch->block_map.blocks[i]->counter_reg_info);
+			}
 
-            /* Free dimensions arrays */
-            if (arch->block_map.blocks[i]->dimensions) {
-                FREE(arch->block_map.blocks[i]->dimensions);
-            }
+			/* Free dimensions arrays */
+			if (arch->block_map.blocks[i]->dimensions) {
+				FREE(arch->block_map.blocks[i]->dimensions);
+			}
 
-            FREE(arch->block_map.blocks[i]);
-        }
-    }
+			FREE(arch->block_map.blocks[i]);
+		}
+	}
 
-    /* Free command buffer */
-    if (arch->command) {
-        FREE(arch->command);
-    }
+	/* Free command buffer */
+	if (arch->command) {
+		FREE(arch->command);
+	}
 
-    /* Free the architecture structure itself */
-    FREE(arch);
+	/* Free the architecture structure itself */
+	FREE(arch);
 }

--- a/projects/perf-dkms/src/aql_c/arch_creator.h
+++ b/projects/perf-dkms/src/aql_c/arch_creator.h
@@ -21,7 +21,7 @@
  * @note Caller is responsible for freeing with arch_destroy()
  * @see arch_destroy(), create_gfx12_arch()
  */
-arch_t* arch_create_by_name(const char* arch_name);
+arch_t *arch_create_by_name(const char *arch_name);
 
 /**
  * @brief Create a GFX12 architecture structure
@@ -34,7 +34,7 @@ arch_t* arch_create_by_name(const char* arch_name);
  * @note Caller must call arch_destroy() to free the returned structure
  * @see arch_create_by_name(), arch_destroy()
  */
-arch_t* arch_create_gfx12(void);
+arch_t *arch_create_gfx12(void);
 
 /**
  * @brief Destroy an architecture structure and free all memory
@@ -47,7 +47,7 @@ arch_t* arch_create_gfx12(void);
  * @note Safe to call with NULL pointer
  * @see arch_create_by_name(), arch_create_gfx12()
  */
-void arch_destroy(arch_t* arch);
+void arch_destroy(arch_t *arch);
 
 /**
  * @brief Initialize an architecture structure (currently unused)
@@ -61,6 +61,6 @@ void arch_destroy(arch_t* arch);
  *
  * @note This function is not currently used; use arch_create_by_name() instead
  */
-int arch_init(arch_t* arch, arch_type_t type);
+int arch_init(arch_t *arch, arch_type_t type);
 
 #endif /* ARCH_CREATOR_H */

--- a/projects/perf-dkms/src/aql_c/arch_creator_common.h
+++ b/projects/perf-dkms/src/aql_c/arch_creator_common.h
@@ -25,7 +25,7 @@
 #endif
 
 /* Function declarations for architecture-specific creators */
-arch_t* create_gfx12_arch(void);
+arch_t *create_gfx12_arch(void);
 /* Future architecture creators can be declared here:
  * arch_t* create_gfx11_arch(void);
  * arch_t* create_gfx10_arch(void);
@@ -44,10 +44,10 @@ arch_t* create_gfx12_arch(void);
  * different parts of the GPU.
  */
 typedef struct {
-    uint32_t se;    /* Shader Engine index (0 to num_se-1) */
-    uint32_t sa;    /* Shader Array index within SE (0 to num_sa-1) */
-    uint32_t wgp;   /* Work Group Processor index within SA (0 to wgp_per_sa-1) */
-    uint32_t flat_index; /* Equivalent flat array index */
+	uint32_t se; /* Shader Engine index (0 to num_se-1) */
+	uint32_t sa; /* Shader Array index within SE (0 to num_sa-1) */
+	uint32_t wgp; /* Work Group Processor index within SA (0 to wgp_per_sa-1) */
+	uint32_t flat_index; /* Equivalent flat array index */
 } dimension_coords_t;
 
 /**
@@ -70,8 +70,9 @@ typedef struct {
  * @see decode_dimension_index()
  */
 static inline uint32_t encode_dimension_index(uint32_t se, uint32_t sa, uint32_t wgp,
-                                              uint32_t sa_count, uint32_t wgp_per_sa) {
-    return (se * sa_count * wgp_per_sa) + (sa * wgp_per_sa) + wgp;
+					      uint32_t sa_count, uint32_t wgp_per_sa)
+{
+	return (se * sa_count * wgp_per_sa) + (sa * wgp_per_sa) + wgp;
 }
 
 /**
@@ -91,19 +92,20 @@ static inline uint32_t encode_dimension_index(uint32_t se, uint32_t sa, uint32_t
  * @note Coordinates are calculated using integer division and modulo
  * @see encode_dimension_index(), validate_dimension_coords()
  */
-static inline dimension_coords_t decode_dimension_index(uint32_t flat_index,
-                                                        uint32_t sa_count, uint32_t wgp_per_sa) {
-    dimension_coords_t coords;
-    coords.flat_index = flat_index;
+static inline dimension_coords_t decode_dimension_index(uint32_t flat_index, uint32_t sa_count,
+							uint32_t wgp_per_sa)
+{
+	dimension_coords_t coords;
+	coords.flat_index = flat_index;
 
-    /* Calculate coordinates using integer division */
-    uint32_t sa_wgp_total = sa_count * wgp_per_sa;
-    coords.se = flat_index / sa_wgp_total;
-    uint32_t remainder = flat_index % sa_wgp_total;
-    coords.sa = remainder / wgp_per_sa;
-    coords.wgp = remainder % wgp_per_sa;
+	/* Calculate coordinates using integer division */
+	uint32_t sa_wgp_total = sa_count * wgp_per_sa;
+	coords.se = flat_index / sa_wgp_total;
+	uint32_t remainder = flat_index % sa_wgp_total;
+	coords.sa = remainder / wgp_per_sa;
+	coords.wgp = remainder % wgp_per_sa;
 
-    return coords;
+	return coords;
 }
 
 /**
@@ -122,12 +124,12 @@ static inline dimension_coords_t decode_dimension_index(uint32_t flat_index,
  * @note Returns 0 (invalid) if coords pointer is NULL
  * @see decode_dimension_index(), encode_dimension_index()
  */
-static inline int validate_dimension_coords(const dimension_coords_t* coords,
-                                            uint32_t se_count, uint32_t sa_count, uint32_t wgp_per_sa) {
-    if (!coords) return 0;
-    return (coords->se < se_count &&
-            coords->sa < sa_count &&
-            coords->wgp < wgp_per_sa);
+static inline int validate_dimension_coords(const dimension_coords_t *coords, uint32_t se_count,
+					    uint32_t sa_count, uint32_t wgp_per_sa)
+{
+	if (!coords)
+		return 0;
+	return (coords->se < se_count && coords->sa < sa_count && coords->wgp < wgp_per_sa);
 }
 
 /**
@@ -152,24 +154,27 @@ static inline int validate_dimension_coords(const dimension_coords_t* coords,
  * @note Initializes allocation state to COUNTER_STATE_FREE
  * @see counter_reg_info_t, projects/aqlprofile/gfxip/gfx12/gfx12_block_info.h
  */
-static inline void create_counter_reg_info(counter_reg_info_t* reg_info, uint32_t select_addr, uint32_t control_addr,
-                                           uint32_t register_addr_lo, uint32_t register_addr_hi) {
-    if (!reg_info) return;
+static inline void create_counter_reg_info(counter_reg_info_t *reg_info, uint32_t select_addr,
+					   uint32_t control_addr, uint32_t register_addr_lo,
+					   uint32_t register_addr_hi)
+{
+	if (!reg_info)
+		return;
 
-    reg_info->select_addr = select_addr;
-    reg_info->control_addr = control_addr;
-    reg_info->register_addr_lo = register_addr_lo;
-    reg_info->register_addr_hi = register_addr_hi;
+	reg_info->select_addr = select_addr;
+	reg_info->control_addr = control_addr;
+	reg_info->register_addr_lo = register_addr_lo;
+	reg_info->register_addr_hi = register_addr_hi;
 
-    /* Initialize allocation info to FREE state */
-    atomic_set(&reg_info->allocation.state, COUNTER_STATE_FREE);
-    reg_info->allocation.event_id = 0;
-    reg_info->allocation.instance_id = 0;
-    reg_info->allocation.user_id = 0;
-    reg_info->allocation.description = NULL;
-    reg_info->allocation.allocation_time = 0;
-    reg_info->allocation.command_buffer = NULL;
-    reg_info->allocation.data_buffer = NULL;
+	/* Initialize allocation info to FREE state */
+	atomic_set(&reg_info->allocation.state, COUNTER_STATE_FREE);
+	reg_info->allocation.event_id = 0;
+	reg_info->allocation.instance_id = 0;
+	reg_info->allocation.user_id = 0;
+	reg_info->allocation.description = NULL;
+	reg_info->allocation.allocation_time = 0;
+	reg_info->allocation.command_buffer = NULL;
+	reg_info->allocation.data_buffer = NULL;
 }
 
 #endif /* ARCH_CREATOR_COMMON_H */

--- a/projects/perf-dkms/src/aql_c/counter_registry.c
+++ b/projects/perf-dkms/src/aql_c/counter_registry.c
@@ -21,7 +21,7 @@
 
 /* Base counter definitions - architecture agnostic */
 static const counter_def_t base_counters[] = {
-    /*
+	/*
      * GL2C Block Counters - DIM_SE_SA (L2 Cache per Shader Array)
      *
      * Dimension rationale: The GL2C (Graphics L2 Cache) is a hardware block that
@@ -32,17 +32,17 @@ static const counter_def_t base_counters[] = {
      *
      * Hardware topology: SE -> SA -> [GL2C instance] -> WGPs (share this cache)
      */
-    {COUNTER_GL2C_EA_RDREQ, "gl2c_ea_rdreq", HW_IP_BLOCK_GL2C, DIM_SE_SA},
-    {COUNTER_GL2C_EA_RDREQ_128B, "gl2c_ea_rdreq_128b", HW_IP_BLOCK_GL2C, DIM_SE_SA},
-    {COUNTER_GL2C_EA_RDREQ_32B, "gl2c_ea_rdreq_32b", HW_IP_BLOCK_GL2C, DIM_SE_SA},
-    {COUNTER_GL2C_EA_RDREQ_64B, "gl2c_ea_rdreq_64b", HW_IP_BLOCK_GL2C, DIM_SE_SA},
-    {COUNTER_GL2C_EA_WRREQ, "gl2c_ea_wrreq", HW_IP_BLOCK_GL2C, DIM_SE_SA},
-    {COUNTER_GL2C_EA_WRREQ_64B, "gl2c_ea_wrreq_64b", HW_IP_BLOCK_GL2C, DIM_SE_SA},
-    {COUNTER_GL2C_EA_WRREQ_STALL, "gl2c_ea_wrreq_stall", HW_IP_BLOCK_GL2C, DIM_SE_SA},
-    {COUNTER_GL2C_HIT, "gl2c_hit", HW_IP_BLOCK_GL2C, DIM_SE_SA},
-    {COUNTER_GL2C_MISS, "gl2c_miss", HW_IP_BLOCK_GL2C, DIM_SE_SA},
+	{ COUNTER_GL2C_EA_RDREQ, "gl2c_ea_rdreq", HW_IP_BLOCK_GL2C, DIM_SE_SA },
+	{ COUNTER_GL2C_EA_RDREQ_128B, "gl2c_ea_rdreq_128b", HW_IP_BLOCK_GL2C, DIM_SE_SA },
+	{ COUNTER_GL2C_EA_RDREQ_32B, "gl2c_ea_rdreq_32b", HW_IP_BLOCK_GL2C, DIM_SE_SA },
+	{ COUNTER_GL2C_EA_RDREQ_64B, "gl2c_ea_rdreq_64b", HW_IP_BLOCK_GL2C, DIM_SE_SA },
+	{ COUNTER_GL2C_EA_WRREQ, "gl2c_ea_wrreq", HW_IP_BLOCK_GL2C, DIM_SE_SA },
+	{ COUNTER_GL2C_EA_WRREQ_64B, "gl2c_ea_wrreq_64b", HW_IP_BLOCK_GL2C, DIM_SE_SA },
+	{ COUNTER_GL2C_EA_WRREQ_STALL, "gl2c_ea_wrreq_stall", HW_IP_BLOCK_GL2C, DIM_SE_SA },
+	{ COUNTER_GL2C_HIT, "gl2c_hit", HW_IP_BLOCK_GL2C, DIM_SE_SA },
+	{ COUNTER_GL2C_MISS, "gl2c_miss", HW_IP_BLOCK_GL2C, DIM_SE_SA },
 
-    /*
+	/*
      * SQ Block Counters - DIM_SE_SA_WGP (Shader Quad per Work Group Processor)
      *
      * Dimension rationale: The SQ (Shader Quad / Shader Engine Sequencer) contains
@@ -54,30 +54,30 @@ static const counter_def_t base_counters[] = {
      *
      * Hardware topology: SE -> SA -> WGP -> [SQ instance with CUs/SIMDs]
      */
-    {COUNTER_SQC_LDS_BANK_CONFLICT, "sqc_lds_bank_conflict", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQC_LDS_IDX_ACTIVE, "sqc_lds_idx_active", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_ACCUM_PREV, "sq_accum_prev", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_BUSY_CYCLES, "sq_busy_cycles", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_INSTS_FLAT, "sq_insts_flat", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_INSTS_LDS, "sq_insts_lds", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_INSTS_SALU, "sq_insts_salu", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_INSTS_SMEM, "sq_insts_smem", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_INSTS_TEX_LOAD, "sq_insts_tex_load", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_INSTS_TEX_STORE, "sq_insts_tex_store", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_INSTS_VALU, "sq_insts_valu", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_INSTS_WAVE32, "sq_insts_wave32", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_INSTS_WAVE32_LDS, "sq_insts_wave32_lds", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_INSTS_WAVE32_VALU, "sq_insts_wave32_valu", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_INST_CYCLES_VMEM, "sq_inst_cycles_vmem", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_INST_LEVEL_LDS, "sq_inst_level_lds", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_WAIT_ANY, "sq_wait_any", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_WAIT_INST_ANY, "sq_wait_inst_any", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_WAVE32_INSTS, "sq_wave32_insts", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_WAVE64_INSTS, "sq_wave64_insts", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_WAVES, "sq_waves", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
-    {COUNTER_SQ_WAVE_CYCLES, "sq_wave_cycles", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP},
+	{ COUNTER_SQC_LDS_BANK_CONFLICT, "sqc_lds_bank_conflict", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQC_LDS_IDX_ACTIVE, "sqc_lds_idx_active", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_ACCUM_PREV, "sq_accum_prev", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_BUSY_CYCLES, "sq_busy_cycles", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_INSTS_FLAT, "sq_insts_flat", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_INSTS_LDS, "sq_insts_lds", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_INSTS_SALU, "sq_insts_salu", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_INSTS_SMEM, "sq_insts_smem", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_INSTS_TEX_LOAD, "sq_insts_tex_load", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_INSTS_TEX_STORE, "sq_insts_tex_store", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_INSTS_VALU, "sq_insts_valu", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_INSTS_WAVE32, "sq_insts_wave32", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_INSTS_WAVE32_LDS, "sq_insts_wave32_lds", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_INSTS_WAVE32_VALU, "sq_insts_wave32_valu", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_INST_CYCLES_VMEM, "sq_inst_cycles_vmem", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_INST_LEVEL_LDS, "sq_inst_level_lds", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_WAIT_ANY, "sq_wait_any", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_WAIT_INST_ANY, "sq_wait_inst_any", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_WAVE32_INSTS, "sq_wave32_insts", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_WAVE64_INSTS, "sq_wave64_insts", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_WAVES, "sq_waves", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
+	{ COUNTER_SQ_WAVE_CYCLES, "sq_wave_cycles", HW_IP_BLOCK_SQ, DIM_SE_SA_WGP },
 
-    /*
+	/*
      * TA Block Counters - DIM_SE_SA_WGP (Texture Addresser per WGP)
      *
      * Dimension rationale: The TA (Texture Addresser) handles texture and buffer
@@ -86,11 +86,13 @@ static const counter_def_t base_counters[] = {
      *
      * Hardware topology: SE -> SA -> WGP -> [TA instance]
      */
-    {COUNTER_TA_BUFFER_LOAD_WAVEFRONTS, "ta_buffer_load_wavefronts", HW_IP_BLOCK_TA, DIM_SE_SA_WGP},
-    {COUNTER_TA_BUFFER_STORE_WAVEFRONTS, "ta_buffer_store_wavefronts", HW_IP_BLOCK_TA, DIM_SE_SA_WGP},
-    {COUNTER_TA_TA_BUSY, "ta_ta_busy", HW_IP_BLOCK_TA, DIM_SE_SA_WGP},
+	{ COUNTER_TA_BUFFER_LOAD_WAVEFRONTS, "ta_buffer_load_wavefronts", HW_IP_BLOCK_TA,
+	  DIM_SE_SA_WGP },
+	{ COUNTER_TA_BUFFER_STORE_WAVEFRONTS, "ta_buffer_store_wavefronts", HW_IP_BLOCK_TA,
+	  DIM_SE_SA_WGP },
+	{ COUNTER_TA_TA_BUSY, "ta_ta_busy", HW_IP_BLOCK_TA, DIM_SE_SA_WGP },
 
-    /*
+	/*
      * GRBM Block Counters - DIM_NONE (Global, not per-dimension)
      *
      * Dimension rationale: The GRBM (Graphics Register Bus Manager) is a global
@@ -101,12 +103,11 @@ static const counter_def_t base_counters[] = {
      *
      * Hardware topology: GPU -> [Single GRBM instance] (global, not replicated)
      */
-    {COUNTER_GRBM_COUNT, "grbm_count", HW_IP_BLOCK_GRBM, DIM_NONE},
-    {COUNTER_GRBM_GUI_ACTIVE, "grbm_gui_active", HW_IP_BLOCK_GRBM, DIM_NONE},
+	{ COUNTER_GRBM_COUNT, "grbm_count", HW_IP_BLOCK_GRBM, DIM_NONE },
+	{ COUNTER_GRBM_GUI_ACTIVE, "grbm_gui_active", HW_IP_BLOCK_GRBM, DIM_NONE },
 };
 
 #define BASE_COUNTER_COUNT (sizeof(base_counters) / sizeof(counter_def_t))
-
 
 /* Lookup functions */
 
@@ -129,15 +130,17 @@ static const counter_def_t base_counters[] = {
  * @see lookup_counter_by_id(), lookup_event_id(), BlockInfoMap::Find in
  *      projects/aqlprofile/src/core/pm4_factory.h:89
  */
-const counter_def_t* lookup_counter_by_name(const char* counter_name) {
-    if (!counter_name) return NULL;
+const counter_def_t *lookup_counter_by_name(const char *counter_name)
+{
+	if (!counter_name)
+		return NULL;
 
-    for (size_t i = 0; i < BASE_COUNTER_COUNT; i++) {
-        if (strcmp(base_counters[i].name, counter_name) == 0) {
-            return &base_counters[i];
-        }
-    }
-    return NULL;
+	for (size_t i = 0; i < BASE_COUNTER_COUNT; i++) {
+		if (strcmp(base_counters[i].name, counter_name) == 0) {
+			return &base_counters[i];
+		}
+	}
+	return NULL;
 }
 
 /**
@@ -152,15 +155,17 @@ const counter_def_t* lookup_counter_by_name(const char* counter_name) {
  * @note The returned pointer is valid for the lifetime of the program
  * @see lookup_counter_by_name(), lookup_event_id()
  */
-const counter_def_t* lookup_counter_by_id(counter_id_t id) {
-    if (id <= 0 || id >= COUNTER_ID_LAST) return NULL;
+const counter_def_t *lookup_counter_by_id(counter_id_t id)
+{
+	if (id <= 0 || id >= COUNTER_ID_LAST)
+		return NULL;
 
-    for (size_t i = 0; i < BASE_COUNTER_COUNT; i++) {
-        if (base_counters[i].id == id) {
-            return &base_counters[i];
-        }
-    }
-    return NULL;
+	for (size_t i = 0; i < BASE_COUNTER_COUNT; i++) {
+		if (base_counters[i].id == id) {
+			return &base_counters[i];
+		}
+	}
+	return NULL;
 }
 
 /**
@@ -185,34 +190,38 @@ const counter_def_t* lookup_counter_by_id(counter_id_t id) {
  * @see lookup_counter_by_name(), GpuBlockInfo::select_value in
  *      projects/aqlprofile/def/gpu_block_info.h
  */
-int lookup_event_id(const counter_def_t* counter, const arch_t* arch, uint32_t* out_event_id) {
-    uint32_t event_id;
+int lookup_event_id(const counter_def_t *counter, const arch_t *arch, uint32_t *out_event_id)
+{
+	uint32_t event_id;
 
-    if (!counter || !arch || !out_event_id) return -EINVAL;
+	if (!counter || !arch || !out_event_id)
+		return -EINVAL;
 
-    /* Use the event map from the architecture structure */
-    if (!arch->event_map || arch->event_count == 0) return -ENOENT;
+	/* Use the event map from the architecture structure */
+	if (!arch->event_map || arch->event_count == 0)
+		return -ENOENT;
 
-    for (size_t i = 0; i < arch->event_count; i++) {
-        if (arch->event_map[i].counter_id == counter->id) {
-            event_id = arch->event_map[i].event_id;
+	for (size_t i = 0; i < arch->event_count; i++) {
+		if (arch->event_map[i].counter_id == counter->id) {
+			event_id = arch->event_map[i].event_id;
 
-            /* Validate 9-bit limit - event IDs are programmed into SELECT registers
+			/* Validate 9-bit limit - event IDs are programmed into SELECT registers
              * which only have 9 bits for event selection. Values exceeding this will
              * be silently truncated, causing wrong events to be counted. */
-            if (event_id > EVENT_ID_MAX) {
+			if (event_id > EVENT_ID_MAX) {
 #ifdef __KERNEL__
-                printk(KERN_ERR "AQL_PERF: Event ID 0x%x for counter '%s' exceeds 9-bit limit (max=0x%x)\n",
-                       event_id, counter->name, EVENT_ID_MAX);
+				printk(KERN_ERR
+				       "AQL_PERF: Event ID 0x%x for counter '%s' exceeds 9-bit limit (max=0x%x)\n",
+				       event_id, counter->name, EVENT_ID_MAX);
 #endif
-                return -ERANGE;  /* Invalid event ID */
-            }
+				return -ERANGE; /* Invalid event ID */
+			}
 
-            *out_event_id = event_id;
-            return 0;  /* Success */
-        }
-    }
-    return -ENOENT;  /* Counter not found in event map */
+			*out_event_id = event_id;
+			return 0; /* Success */
+		}
+	}
+	return -ENOENT; /* Counter not found in event map */
 }
 
 /**
@@ -227,8 +236,9 @@ int lookup_event_id(const counter_def_t* counter, const arch_t* arch, uint32_t* 
  * @note Array is valid for the lifetime of the program
  * @see get_counter_count()
  */
-const counter_def_t* get_all_counters(void) {
-    return base_counters;
+const counter_def_t *get_all_counters(void)
+{
+	return base_counters;
 }
 
 /**
@@ -238,8 +248,9 @@ const counter_def_t* get_all_counters(void) {
  *
  * @see get_all_counters()
  */
-size_t get_counter_count(void) {
-    return BASE_COUNTER_COUNT;
+size_t get_counter_count(void)
+{
+	return BASE_COUNTER_COUNT;
 }
 
 /**
@@ -262,44 +273,44 @@ size_t get_counter_count(void) {
  * @param dims Requested dimension coordinates
  * @return 0 on success, -EINVAL if counter doesn't support requested dimensions
  */
-int pmu_validate_counter_dimensions(const counter_def_t* counter,
-                                    const struct pmu_dimension_coords* dims)
+int pmu_validate_counter_dimensions(const counter_def_t *counter,
+				    const struct pmu_dimension_coords *dims)
 {
-    uint32_t requested_dims = 0;
+	uint32_t requested_dims = 0;
 
-    if (!counter || !dims)
-        return -EINVAL;
+	if (!counter || !dims)
+		return -EINVAL;
 
-    /* If dimensions not specified, always valid */
-    if (!dims->valid)
-        return 0;
+	/* If dimensions not specified, always valid */
+	if (!dims->valid)
+		return 0;
 
-    /* Aggregate mode is always allowed */
-    if (dims->aggregate)
-        return 0;
+	/* Aggregate mode is always allowed */
+	if (dims->aggregate)
+		return 0;
 
-    /* Build a bitmap of requested dimensions.
+	/* Build a bitmap of requested dimensions.
      * Note: We check != 0 because dimension value 0 is indistinguishable from
      * "not specified" in the current config1 encoding. This means se=0 cannot
      * be explicitly requested (it's the default). This is a known limitation. */
-    if (dims->xcc != 0)
-        requested_dims |= DIM_XCC;
-    if (dims->se != 0)
-        requested_dims |= DIM_SE;
-    if (dims->sa != 0)
-        requested_dims |= DIM_SA;
-    if (dims->wgp != 0)
-        requested_dims |= DIM_WGP;
-    if (dims->cu != 0)
-        requested_dims |= DIM_CU;
+	if (dims->xcc != 0)
+		requested_dims |= DIM_XCC;
+	if (dims->se != 0)
+		requested_dims |= DIM_SE;
+	if (dims->sa != 0)
+		requested_dims |= DIM_SA;
+	if (dims->wgp != 0)
+		requested_dims |= DIM_WGP;
+	if (dims->cu != 0)
+		requested_dims |= DIM_CU;
 
-    /* Special case: if counter supports DIM_NONE, reject any dimensions */
-    if (counter->supported_dimensions == DIM_NONE && requested_dims != 0)
-        return -EINVAL;
+	/* Special case: if counter supports DIM_NONE, reject any dimensions */
+	if (counter->supported_dimensions == DIM_NONE && requested_dims != 0)
+		return -EINVAL;
 
-    /* Check if all requested dimensions are supported */
-    if ((requested_dims & ~counter->supported_dimensions) != 0)
-        return -EINVAL;
+	/* Check if all requested dimensions are supported */
+	if ((requested_dims & ~counter->supported_dimensions) != 0)
+		return -EINVAL;
 
-    return 0;
+	return 0;
 }

--- a/projects/perf-dkms/src/aql_c/counter_registry.h
+++ b/projects/perf-dkms/src/aql_c/counter_registry.h
@@ -22,7 +22,7 @@ struct pmu_dimension_coords;
  * This limit is enforced at runtime in lookup_event_id() and should also be
  * validated at compile-time in architecture-specific event definition files.
  */
-#define EVENT_ID_MAX 0x1FF  /* 9-bit limit (0-511) */
+#define EVENT_ID_MAX 0x1FF /* 9-bit limit (0-511) */
 
 /*
  * Dimension Capability Flags
@@ -39,15 +39,15 @@ struct pmu_dimension_coords;
  * When a user specifies dimensions not supported by a counter, the event
  * creation will fail with an appropriate error message.
  */
-#define DIM_NONE        0x00  /* Global counter, no dimension support */
-#define DIM_XCC         0x01  /* Per-XCC (Infinity Fabric block) */
-#define DIM_SE          0x02  /* Per-Shader Engine */
-#define DIM_SA          0x04  /* Per-Shader Array */
-#define DIM_WGP         0x08  /* Per-Work Group Processor */
-#define DIM_CU          0x10  /* Per-Compute Unit */
-#define DIM_ALL         (DIM_XCC | DIM_SE | DIM_SA | DIM_WGP | DIM_CU)
-#define DIM_SE_SA_WGP   (DIM_SE | DIM_SA | DIM_WGP)
-#define DIM_SE_SA       (DIM_SE | DIM_SA)
+#define DIM_NONE 0x00 /* Global counter, no dimension support */
+#define DIM_XCC 0x01 /* Per-XCC (Infinity Fabric block) */
+#define DIM_SE 0x02 /* Per-Shader Engine */
+#define DIM_SA 0x04 /* Per-Shader Array */
+#define DIM_WGP 0x08 /* Per-Work Group Processor */
+#define DIM_CU 0x10 /* Per-Compute Unit */
+#define DIM_ALL (DIM_XCC | DIM_SE | DIM_SA | DIM_WGP | DIM_CU)
+#define DIM_SE_SA_WGP (DIM_SE | DIM_SA | DIM_WGP)
+#define DIM_SE_SA (DIM_SE | DIM_SA)
 
 /**
  * @brief Counter ID enumeration - stable identifiers across architectures
@@ -61,51 +61,51 @@ struct pmu_dimension_coords;
  * GFX10, GFX11, GFX12, etc.
  */
 typedef enum {
-    /* GL2C Block Counters */
-    COUNTER_GL2C_EA_RDREQ = 1,
-    COUNTER_GL2C_EA_RDREQ_128B,
-    COUNTER_GL2C_EA_RDREQ_32B,
-    COUNTER_GL2C_EA_RDREQ_64B,
-    COUNTER_GL2C_EA_WRREQ,
-    COUNTER_GL2C_EA_WRREQ_64B,
-    COUNTER_GL2C_EA_WRREQ_STALL,
-    COUNTER_GL2C_HIT,
-    COUNTER_GL2C_MISS,
+	/* GL2C Block Counters */
+	COUNTER_GL2C_EA_RDREQ = 1,
+	COUNTER_GL2C_EA_RDREQ_128B,
+	COUNTER_GL2C_EA_RDREQ_32B,
+	COUNTER_GL2C_EA_RDREQ_64B,
+	COUNTER_GL2C_EA_WRREQ,
+	COUNTER_GL2C_EA_WRREQ_64B,
+	COUNTER_GL2C_EA_WRREQ_STALL,
+	COUNTER_GL2C_HIT,
+	COUNTER_GL2C_MISS,
 
-    /* SQ Block Counters */
-    COUNTER_SQC_LDS_BANK_CONFLICT,
-    COUNTER_SQC_LDS_IDX_ACTIVE,
-    COUNTER_SQ_ACCUM_PREV,
-    COUNTER_SQ_BUSY_CYCLES,
-    COUNTER_SQ_INSTS_FLAT,
-    COUNTER_SQ_INSTS_LDS,
-    COUNTER_SQ_INSTS_SALU,
-    COUNTER_SQ_INSTS_SMEM,
-    COUNTER_SQ_INSTS_TEX_LOAD,
-    COUNTER_SQ_INSTS_TEX_STORE,
-    COUNTER_SQ_INSTS_VALU,
-    COUNTER_SQ_INSTS_WAVE32,
-    COUNTER_SQ_INSTS_WAVE32_LDS,
-    COUNTER_SQ_INSTS_WAVE32_VALU,
-    COUNTER_SQ_INST_CYCLES_VMEM,
-    COUNTER_SQ_INST_LEVEL_LDS,
-    COUNTER_SQ_WAIT_ANY,
-    COUNTER_SQ_WAIT_INST_ANY,
-    COUNTER_SQ_WAVE32_INSTS,
-    COUNTER_SQ_WAVE64_INSTS,
-    COUNTER_SQ_WAVES,
-    COUNTER_SQ_WAVE_CYCLES,
+	/* SQ Block Counters */
+	COUNTER_SQC_LDS_BANK_CONFLICT,
+	COUNTER_SQC_LDS_IDX_ACTIVE,
+	COUNTER_SQ_ACCUM_PREV,
+	COUNTER_SQ_BUSY_CYCLES,
+	COUNTER_SQ_INSTS_FLAT,
+	COUNTER_SQ_INSTS_LDS,
+	COUNTER_SQ_INSTS_SALU,
+	COUNTER_SQ_INSTS_SMEM,
+	COUNTER_SQ_INSTS_TEX_LOAD,
+	COUNTER_SQ_INSTS_TEX_STORE,
+	COUNTER_SQ_INSTS_VALU,
+	COUNTER_SQ_INSTS_WAVE32,
+	COUNTER_SQ_INSTS_WAVE32_LDS,
+	COUNTER_SQ_INSTS_WAVE32_VALU,
+	COUNTER_SQ_INST_CYCLES_VMEM,
+	COUNTER_SQ_INST_LEVEL_LDS,
+	COUNTER_SQ_WAIT_ANY,
+	COUNTER_SQ_WAIT_INST_ANY,
+	COUNTER_SQ_WAVE32_INSTS,
+	COUNTER_SQ_WAVE64_INSTS,
+	COUNTER_SQ_WAVES,
+	COUNTER_SQ_WAVE_CYCLES,
 
-    /* TA Block Counters */
-    COUNTER_TA_BUFFER_LOAD_WAVEFRONTS,
-    COUNTER_TA_BUFFER_STORE_WAVEFRONTS,
-    COUNTER_TA_TA_BUSY,
+	/* TA Block Counters */
+	COUNTER_TA_BUFFER_LOAD_WAVEFRONTS,
+	COUNTER_TA_BUFFER_STORE_WAVEFRONTS,
+	COUNTER_TA_TA_BUSY,
 
-    /* GRBM Block Counters */
-    COUNTER_GRBM_COUNT,
-    COUNTER_GRBM_GUI_ACTIVE,
+	/* GRBM Block Counters */
+	COUNTER_GRBM_COUNT,
+	COUNTER_GRBM_GUI_ACTIVE,
 
-    COUNTER_ID_LAST
+	COUNTER_ID_LAST
 } counter_id_t;
 
 /**
@@ -116,10 +116,10 @@ typedef enum {
  * which hardware block it belongs to.
  */
 typedef struct {
-    counter_id_t id;                 /* Unique numeric identifier */
-    const char* name;                /* Counter name (e.g., "SQ_WAVES") */
-    hardware_ip_block_t hw_block;    /* Hardware block this counter belongs to */
-    uint32_t supported_dimensions;   /* Bitmap of supported dimension flags (DIM_*) */
+	counter_id_t id; /* Unique numeric identifier */
+	const char *name; /* Counter name (e.g., "SQ_WAVES") */
+	hardware_ip_block_t hw_block; /* Hardware block this counter belongs to */
+	uint32_t supported_dimensions; /* Bitmap of supported dimension flags (DIM_*) */
 } counter_def_t;
 
 /**
@@ -133,8 +133,8 @@ typedef struct {
  * projects/aqlprofile/def/gfx12/ event definition files.
  */
 struct arch_event_map {
-    counter_id_t counter_id;         /* Architecture-agnostic counter ID */
-    uint32_t event_id;               /* Architecture-specific hardware event ID */
+	counter_id_t counter_id; /* Architecture-agnostic counter ID */
+	uint32_t event_id; /* Architecture-specific hardware event ID */
 };
 
 /* Function prototypes */
@@ -145,7 +145,7 @@ struct arch_event_map {
  * @param counter_name String name of the counter (e.g., "SQ_WAVES")
  * @return Pointer to counter definition, or NULL if not found
  */
-const counter_def_t* lookup_counter_by_name(const char* counter_name);
+const counter_def_t *lookup_counter_by_name(const char *counter_name);
 
 /**
  * @brief Look up a counter definition by its numeric ID
@@ -153,7 +153,7 @@ const counter_def_t* lookup_counter_by_name(const char* counter_name);
  * @param id Numeric counter identifier from counter_id_t enum
  * @return Pointer to counter definition, or NULL if not found
  */
-const counter_def_t* lookup_counter_by_id(counter_id_t id);
+const counter_def_t *lookup_counter_by_id(counter_id_t id);
 
 /**
  * @brief Look up the architecture-specific hardware event ID for a counter
@@ -163,14 +163,14 @@ const counter_def_t* lookup_counter_by_id(counter_id_t id);
  * @param out_event_id Output: hardware event ID (valid if return is 0)
  * @return 0 on success, negative error code on failure (-EINVAL, -ENOENT, -ERANGE)
  */
-int lookup_event_id(const counter_def_t* counter, const arch_t* arch, uint32_t* out_event_id);
+int lookup_event_id(const counter_def_t *counter, const arch_t *arch, uint32_t *out_event_id);
 
 /**
  * @brief Get pointer to the full array of counter definitions
  *
  * @return Pointer to array of counter definitions
  */
-const counter_def_t* get_all_counters(void);
+const counter_def_t *get_all_counters(void);
 
 /**
  * @brief Get the total number of registered counters
@@ -194,7 +194,7 @@ size_t get_counter_count(void);
  *   A GRBM counter (DIM_NONE) will fail if any dimension is specified.
  *   An SQ counter (DIM_SE_SA_WGP) will fail if XCC or CU is specified.
  */
-int pmu_validate_counter_dimensions(const counter_def_t* counter,
-                                    const struct pmu_dimension_coords* dims);
+int pmu_validate_counter_dimensions(const counter_def_t *counter,
+				    const struct pmu_dimension_coords *dims);
 
 #endif /* COUNTER_REGISTRY_H */

--- a/projects/perf-dkms/src/aql_c/gfx12_creator.c
+++ b/projects/perf-dkms/src/aql_c/gfx12_creator.c
@@ -73,9 +73,9 @@
  * =============================================================================
  * Source: pm4_packets.h and AMD hardware documentation
  */
-#define UCONFIG_SPACE_START                 0x0000C000
-#define PERSISTENT_SPACE_START              0x00002C00
-#define BASE_IDX1_OFFSET                    0x00002000
+#define UCONFIG_SPACE_START 0x0000C000
+#define PERSISTENT_SPACE_START 0x00002C00
+#define BASE_IDX1_OFFSET 0x00002000
 
 /* =============================================================================
  * GLOBAL CONTROL REGISTERS
@@ -83,14 +83,14 @@
  * Source: gc_12_0_0_offset.h (via Rust offset.rs)
  * All BASE_IDX=0 (standard UCONFIG addressing)
  */
-#define mmGRBM_GFX_INDEX                    0xC200  /* regGRBM_GFX_INDEX */
-#define mmCP_PERFMON_CNTL                   0xD808  /* regCP_PERFMON_CNTL */
-#define mmCOMPUTE_PERFCOUNT_ENABLE          0x2E0B  /* regCOMPUTE_PERFCOUNT_ENABLE */
-#define mmSQ_PERFCOUNTER_CTRL               0xD9E0  /* regSQ_PERFCOUNTER_CTRL */
-#define mmSQ_PERFCOUNTER_CTRL2              0xD9E2  /* regSQ_PERFCOUNTER_CTRL2 */
+#define mmGRBM_GFX_INDEX 0xC200 /* regGRBM_GFX_INDEX */
+#define mmCP_PERFMON_CNTL 0xD808 /* regCP_PERFMON_CNTL */
+#define mmCOMPUTE_PERFCOUNT_ENABLE 0x2E0B /* regCOMPUTE_PERFCOUNT_ENABLE */
+#define mmSQ_PERFCOUNTER_CTRL 0xD9E0 /* regSQ_PERFCOUNTER_CTRL */
+#define mmSQ_PERFCOUNTER_CTRL2 0xD9E2 /* regSQ_PERFCOUNTER_CTRL2 */
 
 /* Event types - from pm4_packets.h */
-#define VGT_EVENT_TYPE_CS_PARTIAL_FLUSH     0x07
+#define VGT_EVENT_TYPE_CS_PARTIAL_FLUSH 0x07
 
 /* =============================================================================
  * CPC (Command Processor Compute) REGISTERS
@@ -99,12 +99,12 @@
  * BASE_IDX: 0 (standard UCONFIG addressing)
  * Address calculation: 0xC000 + offset
  */
-#define mmCPC_PERFCOUNTER0_SELECT           0xD819  /* regCPC_PERFCOUNTER0_SELECT */
-#define mmCPC_PERFCOUNTER0_LO               0xD006  /* regCPC_PERFCOUNTER0_LO */
-#define mmCPC_PERFCOUNTER0_HI               0xD007  /* regCPC_PERFCOUNTER0_HI */
-#define mmCPC_PERFCOUNTER1_SELECT           0xD813  /* regCPC_PERFCOUNTER1_SELECT */
-#define mmCPC_PERFCOUNTER1_LO               0xD004  /* regCPC_PERFCOUNTER1_LO */
-#define mmCPC_PERFCOUNTER1_HI               0xD005  /* regCPC_PERFCOUNTER1_HI */
+#define mmCPC_PERFCOUNTER0_SELECT 0xD819 /* regCPC_PERFCOUNTER0_SELECT */
+#define mmCPC_PERFCOUNTER0_LO 0xD006 /* regCPC_PERFCOUNTER0_LO */
+#define mmCPC_PERFCOUNTER0_HI 0xD007 /* regCPC_PERFCOUNTER0_HI */
+#define mmCPC_PERFCOUNTER1_SELECT 0xD813 /* regCPC_PERFCOUNTER1_SELECT */
+#define mmCPC_PERFCOUNTER1_LO 0xD004 /* regCPC_PERFCOUNTER1_LO */
+#define mmCPC_PERFCOUNTER1_HI 0xD005 /* regCPC_PERFCOUNTER1_HI */
 
 /* =============================================================================
  * SQ (Shader Sequencer) REGISTERS
@@ -113,22 +113,22 @@
  * BASE_IDX: 0 (standard UCONFIG addressing)
  * Address calculation: 0xC000 + offset
  */
-#define mmSQ_PERFCOUNTER0_SELECT            0xD9C0  /* regSQ_PERFCOUNTER0_SELECT */
-#define mmSQ_PERFCOUNTER0_LO                0xD1C0  /* regSQ_PERFCOUNTER0_LO */
-#define mmSQ_PERFCOUNTER1_LO                0xD1C2  /* regSQ_PERFCOUNTER1_LO */
-#define mmSQ_PERFCOUNTER2_SELECT            0xD9C2  /* regSQ_PERFCOUNTER2_SELECT */
-#define mmSQ_PERFCOUNTER2_LO                0xD1C4  /* regSQ_PERFCOUNTER2_LO */
-#define mmSQ_PERFCOUNTER3_LO                0xD1C6  /* regSQ_PERFCOUNTER3_LO */
-#define mmSQ_PERFCOUNTER4_SELECT            0xD9C4  /* regSQ_PERFCOUNTER4_SELECT */
-#define mmSQ_PERFCOUNTER4_LO                0xD1C8  /* regSQ_PERFCOUNTER4_LO */
-#define mmSQ_PERFCOUNTER5_LO                0xD1CA  /* regSQ_PERFCOUNTER5_LO */
-#define mmSQ_PERFCOUNTER6_SELECT            0xD9C6  /* regSQ_PERFCOUNTER6_SELECT */
-#define mmSQ_PERFCOUNTER6_LO                0xD1CC  /* regSQ_PERFCOUNTER6_LO */
-#define mmSQ_PERFCOUNTER7_LO                0xD1CE  /* regSQ_PERFCOUNTER7_LO */
-#define mmSQ_PERFCOUNTER8_SELECT            0xD9C8  /* regSQ_PERFCOUNTER8_SELECT */
-#define mmSQ_PERFCOUNTER10_SELECT           0xD9CA  /* regSQ_PERFCOUNTER10_SELECT */
-#define mmSQ_PERFCOUNTER12_SELECT           0xD9CC  /* regSQ_PERFCOUNTER12_SELECT */
-#define mmSQ_PERFCOUNTER14_SELECT           0xD9CE  /* regSQ_PERFCOUNTER14_SELECT */
+#define mmSQ_PERFCOUNTER0_SELECT 0xD9C0 /* regSQ_PERFCOUNTER0_SELECT */
+#define mmSQ_PERFCOUNTER0_LO 0xD1C0 /* regSQ_PERFCOUNTER0_LO */
+#define mmSQ_PERFCOUNTER1_LO 0xD1C2 /* regSQ_PERFCOUNTER1_LO */
+#define mmSQ_PERFCOUNTER2_SELECT 0xD9C2 /* regSQ_PERFCOUNTER2_SELECT */
+#define mmSQ_PERFCOUNTER2_LO 0xD1C4 /* regSQ_PERFCOUNTER2_LO */
+#define mmSQ_PERFCOUNTER3_LO 0xD1C6 /* regSQ_PERFCOUNTER3_LO */
+#define mmSQ_PERFCOUNTER4_SELECT 0xD9C4 /* regSQ_PERFCOUNTER4_SELECT */
+#define mmSQ_PERFCOUNTER4_LO 0xD1C8 /* regSQ_PERFCOUNTER4_LO */
+#define mmSQ_PERFCOUNTER5_LO 0xD1CA /* regSQ_PERFCOUNTER5_LO */
+#define mmSQ_PERFCOUNTER6_SELECT 0xD9C6 /* regSQ_PERFCOUNTER6_SELECT */
+#define mmSQ_PERFCOUNTER6_LO 0xD1CC /* regSQ_PERFCOUNTER6_LO */
+#define mmSQ_PERFCOUNTER7_LO 0xD1CE /* regSQ_PERFCOUNTER7_LO */
+#define mmSQ_PERFCOUNTER8_SELECT 0xD9C8 /* regSQ_PERFCOUNTER8_SELECT */
+#define mmSQ_PERFCOUNTER10_SELECT 0xD9CA /* regSQ_PERFCOUNTER10_SELECT */
+#define mmSQ_PERFCOUNTER12_SELECT 0xD9CC /* regSQ_PERFCOUNTER12_SELECT */
+#define mmSQ_PERFCOUNTER14_SELECT 0xD9CE /* regSQ_PERFCOUNTER14_SELECT */
 
 /* =============================================================================
  * GRBM (Graphics Register Bus Manager) REGISTERS
@@ -143,12 +143,12 @@
  * NOTE: Values below are ABSOLUTE UCONFIG addresses ready for PM4 packets.
  *       Do NOT apply additional BASE_IDX adjustments at runtime.
  */
-#define mmGRBM_PERFCOUNTER0_SELECT          0xd840  /* 0xC000 + (0x3840 - 0x2000) */
-#define mmGRBM_PERFCOUNTER0_LO              0xd040  /* 0xC000 + (0x3040 - 0x2000) */
-#define mmGRBM_PERFCOUNTER0_HI              0xd041  /* 0xC000 + (0x3041 - 0x2000) */
-#define mmGRBM_PERFCOUNTER1_SELECT          0xd841  /* 0xC000 + (0x3841 - 0x2000) */
-#define mmGRBM_PERFCOUNTER1_LO              0xd043  /* 0xC000 + (0x3043 - 0x2000) */
-#define mmGRBM_PERFCOUNTER1_HI              0xd044  /* 0xC000 + (0x3044 - 0x2000) */
+#define mmGRBM_PERFCOUNTER0_SELECT 0xd840 /* 0xC000 + (0x3840 - 0x2000) */
+#define mmGRBM_PERFCOUNTER0_LO 0xd040 /* 0xC000 + (0x3040 - 0x2000) */
+#define mmGRBM_PERFCOUNTER0_HI 0xd041 /* 0xC000 + (0x3041 - 0x2000) */
+#define mmGRBM_PERFCOUNTER1_SELECT 0xd841 /* 0xC000 + (0x3841 - 0x2000) */
+#define mmGRBM_PERFCOUNTER1_LO 0xd043 /* 0xC000 + (0x3043 - 0x2000) */
+#define mmGRBM_PERFCOUNTER1_HI 0xd044 /* 0xC000 + (0x3044 - 0x2000) */
 
 /* =============================================================================
  * GL2C (Graphics L2 Cache Channel) REGISTERS
@@ -166,18 +166,18 @@
  *   3. Broadcast->instance toggle before each instance read
  *   4. Absolute UCONFIG addresses in COPY_DATA (use values below directly)
  */
-#define mmGL2C_PERFCOUNTER0_SELECT          0xDB80  /* regGL2C_PERFCOUNTER0_SELECT, BASE_IDX=1 */
-#define mmGL2C_PERFCOUNTER0_LO              0xD380  /* regGL2C_PERFCOUNTER0_LO, BASE_IDX=1 */
-#define mmGL2C_PERFCOUNTER0_HI              0xD381  /* regGL2C_PERFCOUNTER0_HI, BASE_IDX=1 */
-#define mmGL2C_PERFCOUNTER1_SELECT          0xDB82  /* regGL2C_PERFCOUNTER1_SELECT, BASE_IDX=1 */
-#define mmGL2C_PERFCOUNTER1_LO              0xD382  /* regGL2C_PERFCOUNTER1_LO, BASE_IDX=1 */
-#define mmGL2C_PERFCOUNTER1_HI              0xD383  /* regGL2C_PERFCOUNTER1_HI, BASE_IDX=1 */
-#define mmGL2C_PERFCOUNTER2_SELECT          0xDB84  /* regGL2C_PERFCOUNTER2_SELECT, BASE_IDX=1 */
-#define mmGL2C_PERFCOUNTER2_LO              0xD384  /* regGL2C_PERFCOUNTER2_LO, BASE_IDX=1 */
-#define mmGL2C_PERFCOUNTER2_HI              0xD385  /* regGL2C_PERFCOUNTER2_HI, BASE_IDX=1 */
-#define mmGL2C_PERFCOUNTER3_SELECT          0xDB86  /* regGL2C_PERFCOUNTER3_SELECT, BASE_IDX=1 */
-#define mmGL2C_PERFCOUNTER3_LO              0xD386  /* regGL2C_PERFCOUNTER3_LO, BASE_IDX=1 */
-#define mmGL2C_PERFCOUNTER3_HI              0xD387  /* regGL2C_PERFCOUNTER3_HI, BASE_IDX=1 */
+#define mmGL2C_PERFCOUNTER0_SELECT 0xDB80 /* regGL2C_PERFCOUNTER0_SELECT, BASE_IDX=1 */
+#define mmGL2C_PERFCOUNTER0_LO 0xD380 /* regGL2C_PERFCOUNTER0_LO, BASE_IDX=1 */
+#define mmGL2C_PERFCOUNTER0_HI 0xD381 /* regGL2C_PERFCOUNTER0_HI, BASE_IDX=1 */
+#define mmGL2C_PERFCOUNTER1_SELECT 0xDB82 /* regGL2C_PERFCOUNTER1_SELECT, BASE_IDX=1 */
+#define mmGL2C_PERFCOUNTER1_LO 0xD382 /* regGL2C_PERFCOUNTER1_LO, BASE_IDX=1 */
+#define mmGL2C_PERFCOUNTER1_HI 0xD383 /* regGL2C_PERFCOUNTER1_HI, BASE_IDX=1 */
+#define mmGL2C_PERFCOUNTER2_SELECT 0xDB84 /* regGL2C_PERFCOUNTER2_SELECT, BASE_IDX=1 */
+#define mmGL2C_PERFCOUNTER2_LO 0xD384 /* regGL2C_PERFCOUNTER2_LO, BASE_IDX=1 */
+#define mmGL2C_PERFCOUNTER2_HI 0xD385 /* regGL2C_PERFCOUNTER2_HI, BASE_IDX=1 */
+#define mmGL2C_PERFCOUNTER3_SELECT 0xDB86 /* regGL2C_PERFCOUNTER3_SELECT, BASE_IDX=1 */
+#define mmGL2C_PERFCOUNTER3_LO 0xD386 /* regGL2C_PERFCOUNTER3_LO, BASE_IDX=1 */
+#define mmGL2C_PERFCOUNTER3_HI 0xD387 /* regGL2C_PERFCOUNTER3_HI, BASE_IDX=1 */
 
 /* =============================================================================
  * SPI (Shader Processor Input) REGISTERS
@@ -186,24 +186,24 @@
  * BASE_IDX: 0 (standard UCONFIG addressing)
  * Address calculation: 0xC000 + offset
  */
-#define mmSPI_PERFCOUNTER0_SELECT           0x3980  /* regSPI_PERFCOUNTER0_SELECT */
-#define mmSPI_PERFCOUNTER0_LO               0x3181  /* regSPI_PERFCOUNTER0_LO */
-#define mmSPI_PERFCOUNTER0_HI               0x3180  /* regSPI_PERFCOUNTER0_HI */
-#define mmSPI_PERFCOUNTER1_SELECT           0x3981  /* regSPI_PERFCOUNTER1_SELECT */
-#define mmSPI_PERFCOUNTER1_LO               0x3183  /* regSPI_PERFCOUNTER1_LO */
-#define mmSPI_PERFCOUNTER1_HI               0x3182  /* regSPI_PERFCOUNTER1_HI */
-#define mmSPI_PERFCOUNTER2_SELECT           0x3982  /* regSPI_PERFCOUNTER2_SELECT */
-#define mmSPI_PERFCOUNTER2_LO               0x3185  /* regSPI_PERFCOUNTER2_LO */
-#define mmSPI_PERFCOUNTER2_HI               0x3184  /* regSPI_PERFCOUNTER2_HI */
-#define mmSPI_PERFCOUNTER3_SELECT           0x3983  /* regSPI_PERFCOUNTER3_SELECT */
-#define mmSPI_PERFCOUNTER3_LO               0x3187  /* regSPI_PERFCOUNTER3_LO */
-#define mmSPI_PERFCOUNTER3_HI               0x3186  /* regSPI_PERFCOUNTER3_HI */
-#define mmSPI_PERFCOUNTER4_SELECT           0x3984  /* regSPI_PERFCOUNTER4_SELECT */
-#define mmSPI_PERFCOUNTER4_LO               0x3189  /* regSPI_PERFCOUNTER4_LO */
-#define mmSPI_PERFCOUNTER4_HI               0x3188  /* regSPI_PERFCOUNTER4_HI */
-#define mmSPI_PERFCOUNTER5_SELECT           0x3985  /* regSPI_PERFCOUNTER5_SELECT */
-#define mmSPI_PERFCOUNTER5_LO               0x318B  /* regSPI_PERFCOUNTER5_LO */
-#define mmSPI_PERFCOUNTER5_HI               0x318A  /* regSPI_PERFCOUNTER5_HI */
+#define mmSPI_PERFCOUNTER0_SELECT 0x3980 /* regSPI_PERFCOUNTER0_SELECT */
+#define mmSPI_PERFCOUNTER0_LO 0x3181 /* regSPI_PERFCOUNTER0_LO */
+#define mmSPI_PERFCOUNTER0_HI 0x3180 /* regSPI_PERFCOUNTER0_HI */
+#define mmSPI_PERFCOUNTER1_SELECT 0x3981 /* regSPI_PERFCOUNTER1_SELECT */
+#define mmSPI_PERFCOUNTER1_LO 0x3183 /* regSPI_PERFCOUNTER1_LO */
+#define mmSPI_PERFCOUNTER1_HI 0x3182 /* regSPI_PERFCOUNTER1_HI */
+#define mmSPI_PERFCOUNTER2_SELECT 0x3982 /* regSPI_PERFCOUNTER2_SELECT */
+#define mmSPI_PERFCOUNTER2_LO 0x3185 /* regSPI_PERFCOUNTER2_LO */
+#define mmSPI_PERFCOUNTER2_HI 0x3184 /* regSPI_PERFCOUNTER2_HI */
+#define mmSPI_PERFCOUNTER3_SELECT 0x3983 /* regSPI_PERFCOUNTER3_SELECT */
+#define mmSPI_PERFCOUNTER3_LO 0x3187 /* regSPI_PERFCOUNTER3_LO */
+#define mmSPI_PERFCOUNTER3_HI 0x3186 /* regSPI_PERFCOUNTER3_HI */
+#define mmSPI_PERFCOUNTER4_SELECT 0x3984 /* regSPI_PERFCOUNTER4_SELECT */
+#define mmSPI_PERFCOUNTER4_LO 0x3189 /* regSPI_PERFCOUNTER4_LO */
+#define mmSPI_PERFCOUNTER4_HI 0x3188 /* regSPI_PERFCOUNTER4_HI */
+#define mmSPI_PERFCOUNTER5_SELECT 0x3985 /* regSPI_PERFCOUNTER5_SELECT */
+#define mmSPI_PERFCOUNTER5_LO 0x318B /* regSPI_PERFCOUNTER5_LO */
+#define mmSPI_PERFCOUNTER5_HI 0x318A /* regSPI_PERFCOUNTER5_HI */
 
 /* =============================================================================
  * TA (Texture Addresser) REGISTERS
@@ -212,12 +212,12 @@
  * BASE_IDX: 0 (standard UCONFIG addressing)
  * Address calculation: 0xC000 + offset
  */
-#define mmTA_PERFCOUNTER0_SELECT            0x3AC0  /* regTA_PERFCOUNTER0_SELECT */
-#define mmTA_PERFCOUNTER0_LO                0x32C0  /* regTA_PERFCOUNTER0_LO */
-#define mmTA_PERFCOUNTER0_HI                0x32C1  /* regTA_PERFCOUNTER0_HI */
-#define mmTA_PERFCOUNTER1_SELECT            0x3AC2  /* regTA_PERFCOUNTER1_SELECT */
-#define mmTA_PERFCOUNTER1_LO                0x32C2  /* regTA_PERFCOUNTER1_LO */
-#define mmTA_PERFCOUNTER1_HI                0x32C3  /* regTA_PERFCOUNTER1_HI */
+#define mmTA_PERFCOUNTER0_SELECT 0x3AC0 /* regTA_PERFCOUNTER0_SELECT */
+#define mmTA_PERFCOUNTER0_LO 0x32C0 /* regTA_PERFCOUNTER0_LO */
+#define mmTA_PERFCOUNTER0_HI 0x32C1 /* regTA_PERFCOUNTER0_HI */
+#define mmTA_PERFCOUNTER1_SELECT 0x3AC2 /* regTA_PERFCOUNTER1_SELECT */
+#define mmTA_PERFCOUNTER1_LO 0x32C2 /* regTA_PERFCOUNTER1_LO */
+#define mmTA_PERFCOUNTER1_HI 0x32C3 /* regTA_PERFCOUNTER1_HI */
 
 /* =============================================================================
  * TCP (Texture Cache Processor) REGISTERS
@@ -226,18 +226,18 @@
  * BASE_IDX: 0 (standard UCONFIG addressing)
  * Address calculation: 0xC000 + offset
  */
-#define mmTCP_PERFCOUNTER0_SELECT           0x3B40  /* regTCP_PERFCOUNTER0_SELECT */
-#define mmTCP_PERFCOUNTER0_LO               0x3340  /* regTCP_PERFCOUNTER0_LO */
-#define mmTCP_PERFCOUNTER0_HI               0x3341  /* regTCP_PERFCOUNTER0_HI */
-#define mmTCP_PERFCOUNTER1_SELECT           0x3B42  /* regTCP_PERFCOUNTER1_SELECT */
-#define mmTCP_PERFCOUNTER1_LO               0x3342  /* regTCP_PERFCOUNTER1_LO */
-#define mmTCP_PERFCOUNTER1_HI               0x3343  /* regTCP_PERFCOUNTER1_HI */
-#define mmTCP_PERFCOUNTER2_SELECT           0x3B44  /* regTCP_PERFCOUNTER2_SELECT */
-#define mmTCP_PERFCOUNTER2_LO               0x3344  /* regTCP_PERFCOUNTER2_LO */
-#define mmTCP_PERFCOUNTER2_HI               0x3345  /* regTCP_PERFCOUNTER2_HI */
-#define mmTCP_PERFCOUNTER3_SELECT           0x3B46  /* regTCP_PERFCOUNTER3_SELECT */
-#define mmTCP_PERFCOUNTER3_LO               0x3346  /* regTCP_PERFCOUNTER3_LO */
-#define mmTCP_PERFCOUNTER3_HI               0x3347  /* regTCP_PERFCOUNTER3_HI */
+#define mmTCP_PERFCOUNTER0_SELECT 0x3B40 /* regTCP_PERFCOUNTER0_SELECT */
+#define mmTCP_PERFCOUNTER0_LO 0x3340 /* regTCP_PERFCOUNTER0_LO */
+#define mmTCP_PERFCOUNTER0_HI 0x3341 /* regTCP_PERFCOUNTER0_HI */
+#define mmTCP_PERFCOUNTER1_SELECT 0x3B42 /* regTCP_PERFCOUNTER1_SELECT */
+#define mmTCP_PERFCOUNTER1_LO 0x3342 /* regTCP_PERFCOUNTER1_LO */
+#define mmTCP_PERFCOUNTER1_HI 0x3343 /* regTCP_PERFCOUNTER1_HI */
+#define mmTCP_PERFCOUNTER2_SELECT 0x3B44 /* regTCP_PERFCOUNTER2_SELECT */
+#define mmTCP_PERFCOUNTER2_LO 0x3344 /* regTCP_PERFCOUNTER2_LO */
+#define mmTCP_PERFCOUNTER2_HI 0x3345 /* regTCP_PERFCOUNTER2_HI */
+#define mmTCP_PERFCOUNTER3_SELECT 0x3B46 /* regTCP_PERFCOUNTER3_SELECT */
+#define mmTCP_PERFCOUNTER3_LO 0x3346 /* regTCP_PERFCOUNTER3_LO */
+#define mmTCP_PERFCOUNTER3_HI 0x3347 /* regTCP_PERFCOUNTER3_HI */
 
 /* =============================================================================
  * TD (Texture Data) REGISTERS
@@ -246,12 +246,12 @@
  * BASE_IDX: 0 (standard UCONFIG addressing)
  * Address calculation: 0xC000 + offset
  */
-#define mmTD_PERFCOUNTER0_SELECT            0x3BC0  /* regTD_PERFCOUNTER0_SELECT */
-#define mmTD_PERFCOUNTER0_LO                0x33C0  /* regTD_PERFCOUNTER0_LO */
-#define mmTD_PERFCOUNTER0_HI                0x33C1  /* regTD_PERFCOUNTER0_HI */
-#define mmTD_PERFCOUNTER1_SELECT            0x3BC2  /* regTD_PERFCOUNTER1_SELECT */
-#define mmTD_PERFCOUNTER1_LO                0x33C2  /* regTD_PERFCOUNTER1_LO */
-#define mmTD_PERFCOUNTER1_HI                0x33C3  /* regTD_PERFCOUNTER1_HI */
+#define mmTD_PERFCOUNTER0_SELECT 0x3BC0 /* regTD_PERFCOUNTER0_SELECT */
+#define mmTD_PERFCOUNTER0_LO 0x33C0 /* regTD_PERFCOUNTER0_LO */
+#define mmTD_PERFCOUNTER0_HI 0x33C1 /* regTD_PERFCOUNTER0_HI */
+#define mmTD_PERFCOUNTER1_SELECT 0x3BC2 /* regTD_PERFCOUNTER1_SELECT */
+#define mmTD_PERFCOUNTER1_LO 0x33C2 /* regTD_PERFCOUNTER1_LO */
+#define mmTD_PERFCOUNTER1_HI 0x33C3 /* regTD_PERFCOUNTER1_HI */
 
 /* =============================================================================
  * TCC (Texture Cache Controller) REGISTERS
@@ -265,18 +265,18 @@
  *   2. Split 32-bit LO+HI reads in READ packet
  *   3. Broadcast->instance toggle before each instance read
  */
-#define mmTCC_PERFCOUNTER0_SELECT           0x3C40  /* regTCC_PERFCOUNTER0_SELECT */
-#define mmTCC_PERFCOUNTER0_LO               0x3440  /* regTCC_PERFCOUNTER0_LO */
-#define mmTCC_PERFCOUNTER0_HI               0x3441  /* regTCC_PERFCOUNTER0_HI */
-#define mmTCC_PERFCOUNTER1_SELECT           0x3C42  /* regTCC_PERFCOUNTER1_SELECT */
-#define mmTCC_PERFCOUNTER1_LO               0x3442  /* regTCC_PERFCOUNTER1_LO */
-#define mmTCC_PERFCOUNTER1_HI               0x3443  /* regTCC_PERFCOUNTER1_HI */
-#define mmTCC_PERFCOUNTER2_SELECT           0x3C44  /* regTCC_PERFCOUNTER2_SELECT */
-#define mmTCC_PERFCOUNTER2_LO               0x3444  /* regTCC_PERFCOUNTER2_LO */
-#define mmTCC_PERFCOUNTER2_HI               0x3445  /* regTCC_PERFCOUNTER2_HI */
-#define mmTCC_PERFCOUNTER3_SELECT           0x3C46  /* regTCC_PERFCOUNTER3_SELECT */
-#define mmTCC_PERFCOUNTER3_LO               0x3446  /* regTCC_PERFCOUNTER3_LO */
-#define mmTCC_PERFCOUNTER3_HI               0x3447  /* regTCC_PERFCOUNTER3_HI */
+#define mmTCC_PERFCOUNTER0_SELECT 0x3C40 /* regTCC_PERFCOUNTER0_SELECT */
+#define mmTCC_PERFCOUNTER0_LO 0x3440 /* regTCC_PERFCOUNTER0_LO */
+#define mmTCC_PERFCOUNTER0_HI 0x3441 /* regTCC_PERFCOUNTER0_HI */
+#define mmTCC_PERFCOUNTER1_SELECT 0x3C42 /* regTCC_PERFCOUNTER1_SELECT */
+#define mmTCC_PERFCOUNTER1_LO 0x3442 /* regTCC_PERFCOUNTER1_LO */
+#define mmTCC_PERFCOUNTER1_HI 0x3443 /* regTCC_PERFCOUNTER1_HI */
+#define mmTCC_PERFCOUNTER2_SELECT 0x3C44 /* regTCC_PERFCOUNTER2_SELECT */
+#define mmTCC_PERFCOUNTER2_LO 0x3444 /* regTCC_PERFCOUNTER2_LO */
+#define mmTCC_PERFCOUNTER2_HI 0x3445 /* regTCC_PERFCOUNTER2_HI */
+#define mmTCC_PERFCOUNTER3_SELECT 0x3C46 /* regTCC_PERFCOUNTER3_SELECT */
+#define mmTCC_PERFCOUNTER3_LO 0x3446 /* regTCC_PERFCOUNTER3_LO */
+#define mmTCC_PERFCOUNTER3_HI 0x3447 /* regTCC_PERFCOUNTER3_HI */
 
 /* =============================================================================
  * SX (Shader Export) REGISTERS
@@ -285,18 +285,18 @@
  * BASE_IDX: 0 (standard UCONFIG addressing)
  * Address calculation: 0xC000 + offset
  */
-#define mmSX_PERFCOUNTER0_SELECT            0x3A80  /* regSX_PERFCOUNTER0_SELECT */
-#define mmSX_PERFCOUNTER0_LO                0x3280  /* regSX_PERFCOUNTER0_LO */
-#define mmSX_PERFCOUNTER0_HI                0x3281  /* regSX_PERFCOUNTER0_HI */
-#define mmSX_PERFCOUNTER1_SELECT            0x3A82  /* regSX_PERFCOUNTER1_SELECT */
-#define mmSX_PERFCOUNTER1_LO                0x3282  /* regSX_PERFCOUNTER1_LO */
-#define mmSX_PERFCOUNTER1_HI                0x3283  /* regSX_PERFCOUNTER1_HI */
-#define mmSX_PERFCOUNTER2_SELECT            0x3A84  /* regSX_PERFCOUNTER2_SELECT */
-#define mmSX_PERFCOUNTER2_LO                0x3284  /* regSX_PERFCOUNTER2_LO */
-#define mmSX_PERFCOUNTER2_HI                0x3285  /* regSX_PERFCOUNTER2_HI */
-#define mmSX_PERFCOUNTER3_SELECT            0x3A86  /* regSX_PERFCOUNTER3_SELECT */
-#define mmSX_PERFCOUNTER3_LO                0x3286  /* regSX_PERFCOUNTER3_LO */
-#define mmSX_PERFCOUNTER3_HI                0x3287  /* regSX_PERFCOUNTER3_HI */
+#define mmSX_PERFCOUNTER0_SELECT 0x3A80 /* regSX_PERFCOUNTER0_SELECT */
+#define mmSX_PERFCOUNTER0_LO 0x3280 /* regSX_PERFCOUNTER0_LO */
+#define mmSX_PERFCOUNTER0_HI 0x3281 /* regSX_PERFCOUNTER0_HI */
+#define mmSX_PERFCOUNTER1_SELECT 0x3A82 /* regSX_PERFCOUNTER1_SELECT */
+#define mmSX_PERFCOUNTER1_LO 0x3282 /* regSX_PERFCOUNTER1_LO */
+#define mmSX_PERFCOUNTER1_HI 0x3283 /* regSX_PERFCOUNTER1_HI */
+#define mmSX_PERFCOUNTER2_SELECT 0x3A84 /* regSX_PERFCOUNTER2_SELECT */
+#define mmSX_PERFCOUNTER2_LO 0x3284 /* regSX_PERFCOUNTER2_LO */
+#define mmSX_PERFCOUNTER2_HI 0x3285 /* regSX_PERFCOUNTER2_HI */
+#define mmSX_PERFCOUNTER3_SELECT 0x3A86 /* regSX_PERFCOUNTER3_SELECT */
+#define mmSX_PERFCOUNTER3_LO 0x3286 /* regSX_PERFCOUNTER3_LO */
+#define mmSX_PERFCOUNTER3_HI 0x3287 /* regSX_PERFCOUNTER3_HI */
 
 /* =============================================================================
  * DB (Depth Buffer) REGISTERS
@@ -305,18 +305,18 @@
  * BASE_IDX: 0 (standard UCONFIG addressing)
  * Address calculation: 0xC000 + offset
  */
-#define mmDB_PERFCOUNTER0_SELECT            0x3900  /* regDB_PERFCOUNTER0_SELECT */
-#define mmDB_PERFCOUNTER0_LO                0x3200  /* regDB_PERFCOUNTER0_LO */
-#define mmDB_PERFCOUNTER0_HI                0x3201  /* regDB_PERFCOUNTER0_HI */
-#define mmDB_PERFCOUNTER1_SELECT            0x3902  /* regDB_PERFCOUNTER1_SELECT */
-#define mmDB_PERFCOUNTER1_LO                0x3202  /* regDB_PERFCOUNTER1_LO */
-#define mmDB_PERFCOUNTER1_HI                0x3203  /* regDB_PERFCOUNTER1_HI */
-#define mmDB_PERFCOUNTER2_SELECT            0x3904  /* regDB_PERFCOUNTER2_SELECT */
-#define mmDB_PERFCOUNTER2_LO                0x3204  /* regDB_PERFCOUNTER2_LO */
-#define mmDB_PERFCOUNTER2_HI                0x3205  /* regDB_PERFCOUNTER2_HI */
-#define mmDB_PERFCOUNTER3_SELECT            0x3906  /* regDB_PERFCOUNTER3_SELECT */
-#define mmDB_PERFCOUNTER3_LO                0x3206  /* regDB_PERFCOUNTER3_LO */
-#define mmDB_PERFCOUNTER3_HI                0x3207  /* regDB_PERFCOUNTER3_HI */
+#define mmDB_PERFCOUNTER0_SELECT 0x3900 /* regDB_PERFCOUNTER0_SELECT */
+#define mmDB_PERFCOUNTER0_LO 0x3200 /* regDB_PERFCOUNTER0_LO */
+#define mmDB_PERFCOUNTER0_HI 0x3201 /* regDB_PERFCOUNTER0_HI */
+#define mmDB_PERFCOUNTER1_SELECT 0x3902 /* regDB_PERFCOUNTER1_SELECT */
+#define mmDB_PERFCOUNTER1_LO 0x3202 /* regDB_PERFCOUNTER1_LO */
+#define mmDB_PERFCOUNTER1_HI 0x3203 /* regDB_PERFCOUNTER1_HI */
+#define mmDB_PERFCOUNTER2_SELECT 0x3904 /* regDB_PERFCOUNTER2_SELECT */
+#define mmDB_PERFCOUNTER2_LO 0x3204 /* regDB_PERFCOUNTER2_LO */
+#define mmDB_PERFCOUNTER2_HI 0x3205 /* regDB_PERFCOUNTER2_HI */
+#define mmDB_PERFCOUNTER3_SELECT 0x3906 /* regDB_PERFCOUNTER3_SELECT */
+#define mmDB_PERFCOUNTER3_LO 0x3206 /* regDB_PERFCOUNTER3_LO */
+#define mmDB_PERFCOUNTER3_HI 0x3207 /* regDB_PERFCOUNTER3_HI */
 
 /* =============================================================================
  * PA_SC (Primitive Assembly - Scan Converter) REGISTERS
@@ -325,18 +325,18 @@
  * BASE_IDX: 0 (standard UCONFIG addressing)
  * Address calculation: 0xC000 + offset
  */
-#define mmPA_SC_PERFCOUNTER0_SELECT         0x3780  /* regPA_SC_PERFCOUNTER0_SELECT */
-#define mmPA_SC_PERFCOUNTER0_LO             0x3180  /* regPA_SC_PERFCOUNTER0_LO */
-#define mmPA_SC_PERFCOUNTER0_HI             0x3181  /* regPA_SC_PERFCOUNTER0_HI */
-#define mmPA_SC_PERFCOUNTER1_SELECT         0x3782  /* regPA_SC_PERFCOUNTER1_SELECT */
-#define mmPA_SC_PERFCOUNTER1_LO             0x3182  /* regPA_SC_PERFCOUNTER1_LO */
-#define mmPA_SC_PERFCOUNTER1_HI             0x3183  /* regPA_SC_PERFCOUNTER1_HI */
-#define mmPA_SC_PERFCOUNTER2_SELECT         0x3784  /* regPA_SC_PERFCOUNTER2_SELECT */
-#define mmPA_SC_PERFCOUNTER2_LO             0x3184  /* regPA_SC_PERFCOUNTER2_LO */
-#define mmPA_SC_PERFCOUNTER2_HI             0x3185  /* regPA_SC_PERFCOUNTER2_HI */
-#define mmPA_SC_PERFCOUNTER3_SELECT         0x3786  /* regPA_SC_PERFCOUNTER3_SELECT */
-#define mmPA_SC_PERFCOUNTER3_LO             0x3186  /* regPA_SC_PERFCOUNTER3_LO */
-#define mmPA_SC_PERFCOUNTER3_HI             0x3187  /* regPA_SC_PERFCOUNTER3_HI */
+#define mmPA_SC_PERFCOUNTER0_SELECT 0x3780 /* regPA_SC_PERFCOUNTER0_SELECT */
+#define mmPA_SC_PERFCOUNTER0_LO 0x3180 /* regPA_SC_PERFCOUNTER0_LO */
+#define mmPA_SC_PERFCOUNTER0_HI 0x3181 /* regPA_SC_PERFCOUNTER0_HI */
+#define mmPA_SC_PERFCOUNTER1_SELECT 0x3782 /* regPA_SC_PERFCOUNTER1_SELECT */
+#define mmPA_SC_PERFCOUNTER1_LO 0x3182 /* regPA_SC_PERFCOUNTER1_LO */
+#define mmPA_SC_PERFCOUNTER1_HI 0x3183 /* regPA_SC_PERFCOUNTER1_HI */
+#define mmPA_SC_PERFCOUNTER2_SELECT 0x3784 /* regPA_SC_PERFCOUNTER2_SELECT */
+#define mmPA_SC_PERFCOUNTER2_LO 0x3184 /* regPA_SC_PERFCOUNTER2_LO */
+#define mmPA_SC_PERFCOUNTER2_HI 0x3185 /* regPA_SC_PERFCOUNTER2_HI */
+#define mmPA_SC_PERFCOUNTER3_SELECT 0x3786 /* regPA_SC_PERFCOUNTER3_SELECT */
+#define mmPA_SC_PERFCOUNTER3_LO 0x3186 /* regPA_SC_PERFCOUNTER3_LO */
+#define mmPA_SC_PERFCOUNTER3_HI 0x3187 /* regPA_SC_PERFCOUNTER3_HI */
 
 /* =============================================================================
  * PA_SU (Primitive Assembly - Setup Unit) REGISTERS
@@ -345,18 +345,18 @@
  * BASE_IDX: 0 (standard UCONFIG addressing)
  * Address calculation: 0xC000 + offset
  */
-#define mmPA_SU_PERFCOUNTER0_SELECT         0x3788  /* regPA_SU_PERFCOUNTER0_SELECT */
-#define mmPA_SU_PERFCOUNTER0_LO             0x3188  /* regPA_SU_PERFCOUNTER0_LO */
-#define mmPA_SU_PERFCOUNTER0_HI             0x3189  /* regPA_SU_PERFCOUNTER0_HI */
-#define mmPA_SU_PERFCOUNTER1_SELECT         0x378A  /* regPA_SU_PERFCOUNTER1_SELECT */
-#define mmPA_SU_PERFCOUNTER1_LO             0x318A  /* regPA_SU_PERFCOUNTER1_LO */
-#define mmPA_SU_PERFCOUNTER1_HI             0x318B  /* regPA_SU_PERFCOUNTER1_HI */
-#define mmPA_SU_PERFCOUNTER2_SELECT         0x378C  /* regPA_SU_PERFCOUNTER2_SELECT */
-#define mmPA_SU_PERFCOUNTER2_LO             0x318C  /* regPA_SU_PERFCOUNTER2_LO */
-#define mmPA_SU_PERFCOUNTER2_HI             0x318D  /* regPA_SU_PERFCOUNTER2_HI */
-#define mmPA_SU_PERFCOUNTER3_SELECT         0x378E  /* regPA_SU_PERFCOUNTER3_SELECT */
-#define mmPA_SU_PERFCOUNTER3_LO             0x318E  /* regPA_SU_PERFCOUNTER3_LO */
-#define mmPA_SU_PERFCOUNTER3_HI             0x318F  /* regPA_SU_PERFCOUNTER3_HI */
+#define mmPA_SU_PERFCOUNTER0_SELECT 0x3788 /* regPA_SU_PERFCOUNTER0_SELECT */
+#define mmPA_SU_PERFCOUNTER0_LO 0x3188 /* regPA_SU_PERFCOUNTER0_LO */
+#define mmPA_SU_PERFCOUNTER0_HI 0x3189 /* regPA_SU_PERFCOUNTER0_HI */
+#define mmPA_SU_PERFCOUNTER1_SELECT 0x378A /* regPA_SU_PERFCOUNTER1_SELECT */
+#define mmPA_SU_PERFCOUNTER1_LO 0x318A /* regPA_SU_PERFCOUNTER1_LO */
+#define mmPA_SU_PERFCOUNTER1_HI 0x318B /* regPA_SU_PERFCOUNTER1_HI */
+#define mmPA_SU_PERFCOUNTER2_SELECT 0x378C /* regPA_SU_PERFCOUNTER2_SELECT */
+#define mmPA_SU_PERFCOUNTER2_LO 0x318C /* regPA_SU_PERFCOUNTER2_LO */
+#define mmPA_SU_PERFCOUNTER2_HI 0x318D /* regPA_SU_PERFCOUNTER2_HI */
+#define mmPA_SU_PERFCOUNTER3_SELECT 0x378E /* regPA_SU_PERFCOUNTER3_SELECT */
+#define mmPA_SU_PERFCOUNTER3_LO 0x318E /* regPA_SU_PERFCOUNTER3_LO */
+#define mmPA_SU_PERFCOUNTER3_HI 0x318F /* regPA_SU_PERFCOUNTER3_HI */
 
 /* =============================================================================
  * GDS (Global Data Store) REGISTERS
@@ -365,65 +365,65 @@
  * BASE_IDX: 0 (standard UCONFIG addressing)
  * Address calculation: 0xC000 + offset
  */
-#define mmGDS_PERFCOUNTER0_SELECT           0x3810  /* regGDS_PERFCOUNTER0_SELECT */
-#define mmGDS_PERFCOUNTER0_LO               0x3210  /* regGDS_PERFCOUNTER0_LO */
-#define mmGDS_PERFCOUNTER0_HI               0x3211  /* regGDS_PERFCOUNTER0_HI */
-#define mmGDS_PERFCOUNTER1_SELECT           0x3812  /* regGDS_PERFCOUNTER1_SELECT */
-#define mmGDS_PERFCOUNTER1_LO               0x3212  /* regGDS_PERFCOUNTER1_LO */
-#define mmGDS_PERFCOUNTER1_HI               0x3213  /* regGDS_PERFCOUNTER1_HI */
-#define mmGDS_PERFCOUNTER2_SELECT           0x3814  /* regGDS_PERFCOUNTER2_SELECT */
-#define mmGDS_PERFCOUNTER2_LO               0x3214  /* regGDS_PERFCOUNTER2_LO */
-#define mmGDS_PERFCOUNTER2_HI               0x3215  /* regGDS_PERFCOUNTER2_HI */
-#define mmGDS_PERFCOUNTER3_SELECT           0x3816  /* regGDS_PERFCOUNTER3_SELECT */
-#define mmGDS_PERFCOUNTER3_LO               0x3216  /* regGDS_PERFCOUNTER3_LO */
-#define mmGDS_PERFCOUNTER3_HI               0x3217  /* regGDS_PERFCOUNTER3_HI */
+#define mmGDS_PERFCOUNTER0_SELECT 0x3810 /* regGDS_PERFCOUNTER0_SELECT */
+#define mmGDS_PERFCOUNTER0_LO 0x3210 /* regGDS_PERFCOUNTER0_LO */
+#define mmGDS_PERFCOUNTER0_HI 0x3211 /* regGDS_PERFCOUNTER0_HI */
+#define mmGDS_PERFCOUNTER1_SELECT 0x3812 /* regGDS_PERFCOUNTER1_SELECT */
+#define mmGDS_PERFCOUNTER1_LO 0x3212 /* regGDS_PERFCOUNTER1_LO */
+#define mmGDS_PERFCOUNTER1_HI 0x3213 /* regGDS_PERFCOUNTER1_HI */
+#define mmGDS_PERFCOUNTER2_SELECT 0x3814 /* regGDS_PERFCOUNTER2_SELECT */
+#define mmGDS_PERFCOUNTER2_LO 0x3214 /* regGDS_PERFCOUNTER2_LO */
+#define mmGDS_PERFCOUNTER2_HI 0x3215 /* regGDS_PERFCOUNTER2_HI */
+#define mmGDS_PERFCOUNTER3_SELECT 0x3816 /* regGDS_PERFCOUNTER3_SELECT */
+#define mmGDS_PERFCOUNTER3_LO 0x3216 /* regGDS_PERFCOUNTER3_LO */
+#define mmGDS_PERFCOUNTER3_HI 0x3217 /* regGDS_PERFCOUNTER3_HI */
 
 /* Block info constants - from Rust block_info.rs */
-#define GFX12_CPC_COUNTER_BLOCK_NUM_COUNTERS      2
-#define GFX12_CPC_COUNTER_BLOCK_MAX_EVENT         0x1F  /* Placeholder - actual from enums */
-#define GFX12_SQ_COUNTER_BLOCK_NUM_COUNTERS       8
-#define GFX12_SQ_COUNTER_BLOCK_MAX_EVENT          0xFF  /* Placeholder - actual from enums */
-#define GFX12_GRBM_COUNTER_BLOCK_NUM_COUNTERS     2
-#define GFX12_GRBM_COUNTER_BLOCK_MAX_EVENT        51
-#define GFX12_GL2C_COUNTER_BLOCK_NUM_COUNTERS     4
-#define GFX12_GL2C_COUNTER_BLOCK_MAX_EVENT        249
-#define GFX12_GL2C_COUNTER_BLOCK_NUM_INSTANCES    16
-#define GFX12_SPI_COUNTER_BLOCK_NUM_COUNTERS      6
-#define GFX12_SPI_COUNTER_BLOCK_MAX_EVENT         318
-#define GFX12_SPI_COUNTER_BLOCK_NUM_INSTANCES     1
-#define GFX12_TA_COUNTER_BLOCK_NUM_COUNTERS       2
-#define GFX12_TA_COUNTER_BLOCK_MAX_EVENT          254
-#define GFX12_TA_COUNTER_BLOCK_NUM_INSTANCES      2
-#define GFX12_TCP_COUNTER_BLOCK_NUM_COUNTERS      4
-#define GFX12_TCP_COUNTER_BLOCK_MAX_EVENT         99
-#define GFX12_TCP_COUNTER_BLOCK_NUM_INSTANCES     2
-#define GFX12_TD_COUNTER_BLOCK_NUM_COUNTERS       2
-#define GFX12_TD_COUNTER_BLOCK_MAX_EVENT          127
-#define GFX12_TD_COUNTER_BLOCK_NUM_INSTANCES      2
-#define GFX12_TCC_COUNTER_BLOCK_NUM_COUNTERS      4
-#define GFX12_TCC_COUNTER_BLOCK_MAX_EVENT         255
-#define GFX12_TCC_COUNTER_BLOCK_NUM_INSTANCES     16
-#define GFX12_SX_COUNTER_BLOCK_NUM_COUNTERS       4
-#define GFX12_SX_COUNTER_BLOCK_MAX_EVENT          189
-#define GFX12_SX_COUNTER_BLOCK_NUM_INSTANCES      1
-#define GFX12_DB_COUNTER_BLOCK_NUM_COUNTERS       4
-#define GFX12_DB_COUNTER_BLOCK_MAX_EVENT          218
-#define GFX12_DB_COUNTER_BLOCK_NUM_INSTANCES      1
-#define GFX12_PA_SC_COUNTER_BLOCK_NUM_COUNTERS    4
-#define GFX12_PA_SC_COUNTER_BLOCK_MAX_EVENT       171
-#define GFX12_PA_SC_COUNTER_BLOCK_NUM_INSTANCES   1
+#define GFX12_CPC_COUNTER_BLOCK_NUM_COUNTERS 2
+#define GFX12_CPC_COUNTER_BLOCK_MAX_EVENT 0x1F /* Placeholder - actual from enums */
+#define GFX12_SQ_COUNTER_BLOCK_NUM_COUNTERS 8
+#define GFX12_SQ_COUNTER_BLOCK_MAX_EVENT 0xFF /* Placeholder - actual from enums */
+#define GFX12_GRBM_COUNTER_BLOCK_NUM_COUNTERS 2
+#define GFX12_GRBM_COUNTER_BLOCK_MAX_EVENT 51
+#define GFX12_GL2C_COUNTER_BLOCK_NUM_COUNTERS 4
+#define GFX12_GL2C_COUNTER_BLOCK_MAX_EVENT 249
+#define GFX12_GL2C_COUNTER_BLOCK_NUM_INSTANCES 16
+#define GFX12_SPI_COUNTER_BLOCK_NUM_COUNTERS 6
+#define GFX12_SPI_COUNTER_BLOCK_MAX_EVENT 318
+#define GFX12_SPI_COUNTER_BLOCK_NUM_INSTANCES 1
+#define GFX12_TA_COUNTER_BLOCK_NUM_COUNTERS 2
+#define GFX12_TA_COUNTER_BLOCK_MAX_EVENT 254
+#define GFX12_TA_COUNTER_BLOCK_NUM_INSTANCES 2
+#define GFX12_TCP_COUNTER_BLOCK_NUM_COUNTERS 4
+#define GFX12_TCP_COUNTER_BLOCK_MAX_EVENT 99
+#define GFX12_TCP_COUNTER_BLOCK_NUM_INSTANCES 2
+#define GFX12_TD_COUNTER_BLOCK_NUM_COUNTERS 2
+#define GFX12_TD_COUNTER_BLOCK_MAX_EVENT 127
+#define GFX12_TD_COUNTER_BLOCK_NUM_INSTANCES 2
+#define GFX12_TCC_COUNTER_BLOCK_NUM_COUNTERS 4
+#define GFX12_TCC_COUNTER_BLOCK_MAX_EVENT 255
+#define GFX12_TCC_COUNTER_BLOCK_NUM_INSTANCES 16
+#define GFX12_SX_COUNTER_BLOCK_NUM_COUNTERS 4
+#define GFX12_SX_COUNTER_BLOCK_MAX_EVENT 189
+#define GFX12_SX_COUNTER_BLOCK_NUM_INSTANCES 1
+#define GFX12_DB_COUNTER_BLOCK_NUM_COUNTERS 4
+#define GFX12_DB_COUNTER_BLOCK_MAX_EVENT 218
+#define GFX12_DB_COUNTER_BLOCK_NUM_INSTANCES 1
+#define GFX12_PA_SC_COUNTER_BLOCK_NUM_COUNTERS 4
+#define GFX12_PA_SC_COUNTER_BLOCK_MAX_EVENT 171
+#define GFX12_PA_SC_COUNTER_BLOCK_NUM_INSTANCES 1
 
-#define GFX12_PA_SU_COUNTER_BLOCK_NUM_COUNTERS    4
-#define GFX12_PA_SU_COUNTER_BLOCK_MAX_EVENT       171
-#define GFX12_PA_SU_COUNTER_BLOCK_NUM_INSTANCES   1
+#define GFX12_PA_SU_COUNTER_BLOCK_NUM_COUNTERS 4
+#define GFX12_PA_SU_COUNTER_BLOCK_MAX_EVENT 171
+#define GFX12_PA_SU_COUNTER_BLOCK_NUM_INSTANCES 1
 
-#define GFX12_GDS_COUNTER_BLOCK_NUM_COUNTERS      4
-#define GFX12_GDS_COUNTER_BLOCK_MAX_EVENT         121
-#define GFX12_GDS_COUNTER_BLOCK_NUM_INSTANCES     1
+#define GFX12_GDS_COUNTER_BLOCK_NUM_COUNTERS 4
+#define GFX12_GDS_COUNTER_BLOCK_MAX_EVENT 121
+#define GFX12_GDS_COUNTER_BLOCK_NUM_INSTANCES 1
 
 /* Counter block attributes - from Rust enums */
-#define GFX12_COUNTER_BLOCK_DFLT_ATTR             1
-#define GFX12_COUNTER_BLOCK_SPM_GLOBAL_ATTR       0x1000
+#define GFX12_COUNTER_BLOCK_DFLT_ATTR 1
+#define GFX12_COUNTER_BLOCK_SPM_GLOBAL_ATTR 0x1000
 
 /* GFX12 Architecture parameters - from actual gfx1200 GPU topology
  * These values should match the physical GPU configuration.
@@ -434,11 +434,11 @@
  *   - 16 Workgroup Processors (WGPs = CUs / 2)
  *   - 4 WGPs per SA (16 WGPs / 4 SAs)
  */
-#define GFX12_NUM_XCC           1
-#define GFX12_NUM_SE            2
-#define GFX12_NUM_SA            2
-#define GFX12_NUM_CU            32
-#define GFX12_NUM_WGP_PER_SA    4
+#define GFX12_NUM_XCC 1
+#define GFX12_NUM_SE 2
+#define GFX12_NUM_SA 2
+#define GFX12_NUM_CU 32
+#define GFX12_NUM_WGP_PER_SA 4
 
 /**
  * @brief Create CPC (Command Processor Compute) block information for GFX12
@@ -464,44 +464,47 @@
  * @see create_gfx12_sq_block(), GFX12 block info in
  *      projects/aqlprofile/gfxip/gfx12/gfx12_block_info.h
  */
-static block_info_t* create_gfx12_cpc_block(void) {
-    block_info_t* block = ALLOC(sizeof(block_info_t));
-    if (!block) return NULL;
+static block_info_t *create_gfx12_cpc_block(void)
+{
+	block_info_t *block = ALLOC(sizeof(block_info_t));
+	if (!block)
+		return NULL;
 
-    /* Allocate counter register info array */
-    counter_reg_info_t* counter_regs = ALLOC_ARRAY(counter_reg_info_t, GFX12_CPC_COUNTER_BLOCK_NUM_COUNTERS);
-    if (!counter_regs) {
-        FREE(block);
-        return NULL;
-    }
+	/* Allocate counter register info array */
+	counter_reg_info_t *counter_regs =
+		ALLOC_ARRAY(counter_reg_info_t, GFX12_CPC_COUNTER_BLOCK_NUM_COUNTERS);
+	if (!counter_regs) {
+		FREE(block);
+		return NULL;
+	}
 
-    /* Initialize CPC counter registers - based on Rust implementation */
-    create_counter_reg_info(&counter_regs[0], mmCPC_PERFCOUNTER0_SELECT, 0,
-                           mmCPC_PERFCOUNTER0_LO, mmCPC_PERFCOUNTER0_HI);
-    create_counter_reg_info(&counter_regs[1], mmCPC_PERFCOUNTER1_SELECT, 0,
-                           mmCPC_PERFCOUNTER1_LO, mmCPC_PERFCOUNTER1_HI);
+	/* Initialize CPC counter registers - based on Rust implementation */
+	create_counter_reg_info(&counter_regs[0], mmCPC_PERFCOUNTER0_SELECT, 0,
+				mmCPC_PERFCOUNTER0_LO, mmCPC_PERFCOUNTER0_HI);
+	create_counter_reg_info(&counter_regs[1], mmCPC_PERFCOUNTER1_SELECT, 0,
+				mmCPC_PERFCOUNTER1_LO, mmCPC_PERFCOUNTER1_HI);
 
-    /* Create dimensions for CPC block - global block with no SE/SA dependencies */
-    block->dimension_count = 1;
-    block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
-    if (!block->dimensions) {
-        FREE(counter_regs);
-        FREE(block);
-        return NULL;
-    }
-    block->dimensions[0] = (dimension_t){.size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC};
+	/* Create dimensions for CPC block - global block with no SE/SA dependencies */
+	block->dimension_count = 1;
+	block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
+	if (!block->dimensions) {
+		FREE(counter_regs);
+		FREE(block);
+		return NULL;
+	}
+	block->dimensions[0] = (dimension_t){ .size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC };
 
-    block->name = "CPC";
-    block->id = HW_IP_BLOCK_CPC;
-    block->instance_count = 1;
-    block->event_id_max = GFX12_CPC_COUNTER_BLOCK_MAX_EVENT;
-    block->counter_count = GFX12_CPC_COUNTER_BLOCK_NUM_COUNTERS;
-    block->counter_reg_info = counter_regs;
-    block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR | GFX12_COUNTER_BLOCK_SPM_GLOBAL_ATTR;
-    block->delay_info = NULL;
-    block->spm_block_id = 0;
+	block->name = "CPC";
+	block->id = HW_IP_BLOCK_CPC;
+	block->instance_count = 1;
+	block->event_id_max = GFX12_CPC_COUNTER_BLOCK_MAX_EVENT;
+	block->counter_count = GFX12_CPC_COUNTER_BLOCK_NUM_COUNTERS;
+	block->counter_reg_info = counter_regs;
+	block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR | GFX12_COUNTER_BLOCK_SPM_GLOBAL_ATTR;
+	block->delay_info = NULL;
+	block->spm_block_id = 0;
 
-    return block;
+	return block;
 }
 
 /**
@@ -530,62 +533,66 @@ static block_info_t* create_gfx12_cpc_block(void) {
  * @see create_gfx12_cpc_block(), GFX12 block info in
  *      projects/aqlprofile/gfxip/gfx12/gfx12_block_info.h
  */
-static block_info_t* create_gfx12_sq_block(void) {
-    block_info_t* block = ALLOC(sizeof(block_info_t));
-    if (!block) return NULL;
+static block_info_t *create_gfx12_sq_block(void)
+{
+	block_info_t *block = ALLOC(sizeof(block_info_t));
+	if (!block)
+		return NULL;
 
-    /* Allocate counter register info array */
-    counter_reg_info_t* counter_regs = ALLOC_ARRAY(counter_reg_info_t, GFX12_SQ_COUNTER_BLOCK_NUM_COUNTERS);
-    if (!counter_regs) {
-        FREE(block);
-        return NULL;
-    }
+	/* Allocate counter register info array */
+	counter_reg_info_t *counter_regs =
+		ALLOC_ARRAY(counter_reg_info_t, GFX12_SQ_COUNTER_BLOCK_NUM_COUNTERS);
+	if (!counter_regs) {
+		FREE(block);
+		return NULL;
+	}
 
-    /* Initialize SQ counter registers - based on Rust implementation */
-    create_counter_reg_info(&counter_regs[0], mmSQ_PERFCOUNTER0_SELECT, mmSQ_PERFCOUNTER_CTRL,
-                           mmSQ_PERFCOUNTER0_LO, 0);
-    create_counter_reg_info(&counter_regs[1], mmSQ_PERFCOUNTER2_SELECT, mmSQ_PERFCOUNTER_CTRL,
-                           mmSQ_PERFCOUNTER1_LO, 0);
-    create_counter_reg_info(&counter_regs[2], mmSQ_PERFCOUNTER4_SELECT, mmSQ_PERFCOUNTER_CTRL,
-                           mmSQ_PERFCOUNTER2_LO, 0);
-    create_counter_reg_info(&counter_regs[3], mmSQ_PERFCOUNTER6_SELECT, mmSQ_PERFCOUNTER_CTRL,
-                           mmSQ_PERFCOUNTER3_LO, 0);
-    create_counter_reg_info(&counter_regs[4], mmSQ_PERFCOUNTER8_SELECT, mmSQ_PERFCOUNTER_CTRL,
-                           mmSQ_PERFCOUNTER4_LO, 0);
-    create_counter_reg_info(&counter_regs[5], mmSQ_PERFCOUNTER10_SELECT, mmSQ_PERFCOUNTER_CTRL,
-                           mmSQ_PERFCOUNTER5_LO, 0);
-    create_counter_reg_info(&counter_regs[6], mmSQ_PERFCOUNTER12_SELECT, mmSQ_PERFCOUNTER_CTRL,
-                           mmSQ_PERFCOUNTER6_LO, 0);
-    create_counter_reg_info(&counter_regs[7], mmSQ_PERFCOUNTER14_SELECT, mmSQ_PERFCOUNTER_CTRL,
-                           mmSQ_PERFCOUNTER7_LO, 0);
+	/* Initialize SQ counter registers - based on Rust implementation */
+	create_counter_reg_info(&counter_regs[0], mmSQ_PERFCOUNTER0_SELECT, mmSQ_PERFCOUNTER_CTRL,
+				mmSQ_PERFCOUNTER0_LO, 0);
+	create_counter_reg_info(&counter_regs[1], mmSQ_PERFCOUNTER2_SELECT, mmSQ_PERFCOUNTER_CTRL,
+				mmSQ_PERFCOUNTER1_LO, 0);
+	create_counter_reg_info(&counter_regs[2], mmSQ_PERFCOUNTER4_SELECT, mmSQ_PERFCOUNTER_CTRL,
+				mmSQ_PERFCOUNTER2_LO, 0);
+	create_counter_reg_info(&counter_regs[3], mmSQ_PERFCOUNTER6_SELECT, mmSQ_PERFCOUNTER_CTRL,
+				mmSQ_PERFCOUNTER3_LO, 0);
+	create_counter_reg_info(&counter_regs[4], mmSQ_PERFCOUNTER8_SELECT, mmSQ_PERFCOUNTER_CTRL,
+				mmSQ_PERFCOUNTER4_LO, 0);
+	create_counter_reg_info(&counter_regs[5], mmSQ_PERFCOUNTER10_SELECT, mmSQ_PERFCOUNTER_CTRL,
+				mmSQ_PERFCOUNTER5_LO, 0);
+	create_counter_reg_info(&counter_regs[6], mmSQ_PERFCOUNTER12_SELECT, mmSQ_PERFCOUNTER_CTRL,
+				mmSQ_PERFCOUNTER6_LO, 0);
+	create_counter_reg_info(&counter_regs[7], mmSQ_PERFCOUNTER14_SELECT, mmSQ_PERFCOUNTER_CTRL,
+				mmSQ_PERFCOUNTER7_LO, 0);
 
-    /* Create dimensions for SQ block - SE/SA/WGP dependent block
+	/* Create dimensions for SQ block - SE/SA/WGP dependent block
      * SQ counters require 4 sub-instances per SA to match hardware layout.
      * With instance_index = (wgp << 2), iterating wgp=0,1,2,3 gives
      * instance_index = 0x00, 0x04, 0x08, 0x0c (matching aqlprofile).
      * Total instances: 4 SE × 2 SA × 4 sub-instances = 32 */
-    block->dimension_count = 3;
-    block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
-    if (!block->dimensions) {
-        FREE(counter_regs);
-        FREE(block);
-        return NULL;
-    }
-    block->dimensions[0] = (dimension_t){.size = GFX12_NUM_SE, .dim = HARDWARE_DIM_SE};
-    block->dimensions[1] = (dimension_t){.size = GFX12_NUM_SA, .dim = HARDWARE_DIM_SA};
-    block->dimensions[2] = (dimension_t){.size = 4, .dim = HARDWARE_DIM_WGP};  /* 4 sub-instances per SA */
+	block->dimension_count = 3;
+	block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
+	if (!block->dimensions) {
+		FREE(counter_regs);
+		FREE(block);
+		return NULL;
+	}
+	block->dimensions[0] = (dimension_t){ .size = GFX12_NUM_SE, .dim = HARDWARE_DIM_SE };
+	block->dimensions[1] = (dimension_t){ .size = GFX12_NUM_SA, .dim = HARDWARE_DIM_SA };
+	block->dimensions[2] =
+		(dimension_t){ .size = 4, .dim = HARDWARE_DIM_WGP }; /* 4 sub-instances per SA */
 
-    block->name = "SQ";
-    block->id = HW_IP_BLOCK_SQ;
-    block->instance_count = 1;
-    block->event_id_max = GFX12_SQ_COUNTER_BLOCK_MAX_EVENT;
-    block->counter_count = GFX12_SQ_COUNTER_BLOCK_NUM_COUNTERS;
-    block->counter_reg_info = counter_regs;
-    block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
-    block->delay_info = NULL;
-    block->spm_block_id = 9; /* SPM_SE_BLOCK_NAME_SQG from Rust */
+	block->name = "SQ";
+	block->id = HW_IP_BLOCK_SQ;
+	block->instance_count = 1;
+	block->event_id_max = GFX12_SQ_COUNTER_BLOCK_MAX_EVENT;
+	block->counter_count = GFX12_SQ_COUNTER_BLOCK_NUM_COUNTERS;
+	block->counter_reg_info = counter_regs;
+	block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
+	block->delay_info = NULL;
+	block->spm_block_id = 9; /* SPM_SE_BLOCK_NAME_SQG from Rust */
 
-    return block;
+	return block;
 }
 
 /**
@@ -611,44 +618,47 @@ static block_info_t* create_gfx12_sq_block(void) {
  * @see create_gfx12_cpc_block(), GFX12 block info in
  *      projects/aqlprofile/gfxip/gfx12/gfx12_block_info.h
  */
-static block_info_t* create_gfx12_grbm_block(void) {
-    block_info_t* block = ALLOC(sizeof(block_info_t));
-    if (!block) return NULL;
+static block_info_t *create_gfx12_grbm_block(void)
+{
+	block_info_t *block = ALLOC(sizeof(block_info_t));
+	if (!block)
+		return NULL;
 
-    /* Allocate counter register info array */
-    counter_reg_info_t* counter_regs = ALLOC_ARRAY(counter_reg_info_t, GFX12_GRBM_COUNTER_BLOCK_NUM_COUNTERS);
-    if (!counter_regs) {
-        FREE(block);
-        return NULL;
-    }
+	/* Allocate counter register info array */
+	counter_reg_info_t *counter_regs =
+		ALLOC_ARRAY(counter_reg_info_t, GFX12_GRBM_COUNTER_BLOCK_NUM_COUNTERS);
+	if (!counter_regs) {
+		FREE(block);
+		return NULL;
+	}
 
-    /* Initialize GRBM counter registers - based on aqlprofile reference */
-    create_counter_reg_info(&counter_regs[0], mmGRBM_PERFCOUNTER0_SELECT, 0,
-                           mmGRBM_PERFCOUNTER0_LO, mmGRBM_PERFCOUNTER0_HI);
-    create_counter_reg_info(&counter_regs[1], mmGRBM_PERFCOUNTER1_SELECT, 0,
-                           mmGRBM_PERFCOUNTER1_LO, mmGRBM_PERFCOUNTER1_HI);
+	/* Initialize GRBM counter registers - based on aqlprofile reference */
+	create_counter_reg_info(&counter_regs[0], mmGRBM_PERFCOUNTER0_SELECT, 0,
+				mmGRBM_PERFCOUNTER0_LO, mmGRBM_PERFCOUNTER0_HI);
+	create_counter_reg_info(&counter_regs[1], mmGRBM_PERFCOUNTER1_SELECT, 0,
+				mmGRBM_PERFCOUNTER1_LO, mmGRBM_PERFCOUNTER1_HI);
 
-    /* Create dimensions for GRBM block - global block with no SE/SA dependencies */
-    block->dimension_count = 1;
-    block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
-    if (!block->dimensions) {
-        FREE(counter_regs);
-        FREE(block);
-        return NULL;
-    }
-    block->dimensions[0] = (dimension_t){.size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC};
+	/* Create dimensions for GRBM block - global block with no SE/SA dependencies */
+	block->dimension_count = 1;
+	block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
+	if (!block->dimensions) {
+		FREE(counter_regs);
+		FREE(block);
+		return NULL;
+	}
+	block->dimensions[0] = (dimension_t){ .size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC };
 
-    block->name = "GRBM";
-    block->id = HW_IP_BLOCK_GRBM;
-    block->instance_count = 1;
-    block->event_id_max = GFX12_GRBM_COUNTER_BLOCK_MAX_EVENT;
-    block->counter_count = GFX12_GRBM_COUNTER_BLOCK_NUM_COUNTERS;
-    block->counter_reg_info = counter_regs;
-    block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
-    block->delay_info = NULL;
-    block->spm_block_id = 0;
+	block->name = "GRBM";
+	block->id = HW_IP_BLOCK_GRBM;
+	block->instance_count = 1;
+	block->event_id_max = GFX12_GRBM_COUNTER_BLOCK_MAX_EVENT;
+	block->counter_count = GFX12_GRBM_COUNTER_BLOCK_NUM_COUNTERS;
+	block->counter_reg_info = counter_regs;
+	block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
+	block->delay_info = NULL;
+	block->spm_block_id = 0;
 
-    return block;
+	return block;
 }
 
 /**
@@ -675,48 +685,51 @@ static block_info_t* create_gfx12_grbm_block(void) {
  * @see create_gfx12_tcc_block(), GFX12 block info in
  *      projects/aqlprofile/gfxip/gfx12/gfx12_block_info.h
  */
-static block_info_t* create_gfx12_gl2c_block(void) {
-    block_info_t* block = ALLOC(sizeof(block_info_t));
-    if (!block) return NULL;
+static block_info_t *create_gfx12_gl2c_block(void)
+{
+	block_info_t *block = ALLOC(sizeof(block_info_t));
+	if (!block)
+		return NULL;
 
-    /* Allocate counter register info array */
-    counter_reg_info_t* counter_regs = ALLOC_ARRAY(counter_reg_info_t, GFX12_GL2C_COUNTER_BLOCK_NUM_COUNTERS);
-    if (!counter_regs) {
-        FREE(block);
-        return NULL;
-    }
+	/* Allocate counter register info array */
+	counter_reg_info_t *counter_regs =
+		ALLOC_ARRAY(counter_reg_info_t, GFX12_GL2C_COUNTER_BLOCK_NUM_COUNTERS);
+	if (!counter_regs) {
+		FREE(block);
+		return NULL;
+	}
 
-    /* Initialize GL2C counter registers - based on aqlprofile reference */
-    create_counter_reg_info(&counter_regs[0], mmGL2C_PERFCOUNTER0_SELECT, 0,
-                           mmGL2C_PERFCOUNTER0_LO, mmGL2C_PERFCOUNTER0_HI);
-    create_counter_reg_info(&counter_regs[1], mmGL2C_PERFCOUNTER1_SELECT, 0,
-                           mmGL2C_PERFCOUNTER1_LO, mmGL2C_PERFCOUNTER1_HI);
-    create_counter_reg_info(&counter_regs[2], mmGL2C_PERFCOUNTER2_SELECT, 0,
-                           mmGL2C_PERFCOUNTER2_LO, mmGL2C_PERFCOUNTER2_HI);
-    create_counter_reg_info(&counter_regs[3], mmGL2C_PERFCOUNTER3_SELECT, 0,
-                           mmGL2C_PERFCOUNTER3_LO, mmGL2C_PERFCOUNTER3_HI);
+	/* Initialize GL2C counter registers - based on aqlprofile reference */
+	create_counter_reg_info(&counter_regs[0], mmGL2C_PERFCOUNTER0_SELECT, 0,
+				mmGL2C_PERFCOUNTER0_LO, mmGL2C_PERFCOUNTER0_HI);
+	create_counter_reg_info(&counter_regs[1], mmGL2C_PERFCOUNTER1_SELECT, 0,
+				mmGL2C_PERFCOUNTER1_LO, mmGL2C_PERFCOUNTER1_HI);
+	create_counter_reg_info(&counter_regs[2], mmGL2C_PERFCOUNTER2_SELECT, 0,
+				mmGL2C_PERFCOUNTER2_LO, mmGL2C_PERFCOUNTER2_HI);
+	create_counter_reg_info(&counter_regs[3], mmGL2C_PERFCOUNTER3_SELECT, 0,
+				mmGL2C_PERFCOUNTER3_LO, mmGL2C_PERFCOUNTER3_HI);
 
-    /* Create dimensions for GL2C block - global block with no SE/SA dependencies */
-    block->dimension_count = 1;
-    block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
-    if (!block->dimensions) {
-        FREE(counter_regs);
-        FREE(block);
-        return NULL;
-    }
-    block->dimensions[0] = (dimension_t){.size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC};
+	/* Create dimensions for GL2C block - global block with no SE/SA dependencies */
+	block->dimension_count = 1;
+	block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
+	if (!block->dimensions) {
+		FREE(counter_regs);
+		FREE(block);
+		return NULL;
+	}
+	block->dimensions[0] = (dimension_t){ .size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC };
 
-    block->name = "GL2C";
-    block->id = HW_IP_BLOCK_GL2C;
-    block->instance_count = GFX12_GL2C_COUNTER_BLOCK_NUM_INSTANCES;
-    block->event_id_max = GFX12_GL2C_COUNTER_BLOCK_MAX_EVENT;
-    block->counter_count = GFX12_GL2C_COUNTER_BLOCK_NUM_COUNTERS;
-    block->counter_reg_info = counter_regs;
-    block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
-    block->delay_info = NULL;
-    block->spm_block_id = 0;
+	block->name = "GL2C";
+	block->id = HW_IP_BLOCK_GL2C;
+	block->instance_count = GFX12_GL2C_COUNTER_BLOCK_NUM_INSTANCES;
+	block->event_id_max = GFX12_GL2C_COUNTER_BLOCK_MAX_EVENT;
+	block->counter_count = GFX12_GL2C_COUNTER_BLOCK_NUM_COUNTERS;
+	block->counter_reg_info = counter_regs;
+	block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
+	block->delay_info = NULL;
+	block->spm_block_id = 0;
 
-    return block;
+	return block;
 }
 
 /**
@@ -742,53 +755,56 @@ static block_info_t* create_gfx12_gl2c_block(void) {
  * @see create_gfx12_sq_block(), GFX12 block info in
  *      projects/aqlprofile/gfxip/gfx12/gfx12_block_info.h
  */
-static block_info_t* create_gfx12_spi_block(void) {
-    block_info_t* block = ALLOC(sizeof(block_info_t));
-    if (!block) return NULL;
+static block_info_t *create_gfx12_spi_block(void)
+{
+	block_info_t *block = ALLOC(sizeof(block_info_t));
+	if (!block)
+		return NULL;
 
-    /* Allocate counter register info array */
-    counter_reg_info_t* counter_regs = ALLOC_ARRAY(counter_reg_info_t, GFX12_SPI_COUNTER_BLOCK_NUM_COUNTERS);
-    if (!counter_regs) {
-        FREE(block);
-        return NULL;
-    }
+	/* Allocate counter register info array */
+	counter_reg_info_t *counter_regs =
+		ALLOC_ARRAY(counter_reg_info_t, GFX12_SPI_COUNTER_BLOCK_NUM_COUNTERS);
+	if (!counter_regs) {
+		FREE(block);
+		return NULL;
+	}
 
-    /* Initialize SPI counter registers - based on aqlprofile reference */
-    create_counter_reg_info(&counter_regs[0], mmSPI_PERFCOUNTER0_SELECT, 0,
-                           mmSPI_PERFCOUNTER0_LO, mmSPI_PERFCOUNTER0_HI);
-    create_counter_reg_info(&counter_regs[1], mmSPI_PERFCOUNTER1_SELECT, 0,
-                           mmSPI_PERFCOUNTER1_LO, mmSPI_PERFCOUNTER1_HI);
-    create_counter_reg_info(&counter_regs[2], mmSPI_PERFCOUNTER2_SELECT, 0,
-                           mmSPI_PERFCOUNTER2_LO, mmSPI_PERFCOUNTER2_HI);
-    create_counter_reg_info(&counter_regs[3], mmSPI_PERFCOUNTER3_SELECT, 0,
-                           mmSPI_PERFCOUNTER3_LO, mmSPI_PERFCOUNTER3_HI);
-    create_counter_reg_info(&counter_regs[4], mmSPI_PERFCOUNTER4_SELECT, 0,
-                           mmSPI_PERFCOUNTER4_LO, mmSPI_PERFCOUNTER4_HI);
-    create_counter_reg_info(&counter_regs[5], mmSPI_PERFCOUNTER5_SELECT, 0,
-                           mmSPI_PERFCOUNTER5_LO, mmSPI_PERFCOUNTER5_HI);
+	/* Initialize SPI counter registers - based on aqlprofile reference */
+	create_counter_reg_info(&counter_regs[0], mmSPI_PERFCOUNTER0_SELECT, 0,
+				mmSPI_PERFCOUNTER0_LO, mmSPI_PERFCOUNTER0_HI);
+	create_counter_reg_info(&counter_regs[1], mmSPI_PERFCOUNTER1_SELECT, 0,
+				mmSPI_PERFCOUNTER1_LO, mmSPI_PERFCOUNTER1_HI);
+	create_counter_reg_info(&counter_regs[2], mmSPI_PERFCOUNTER2_SELECT, 0,
+				mmSPI_PERFCOUNTER2_LO, mmSPI_PERFCOUNTER2_HI);
+	create_counter_reg_info(&counter_regs[3], mmSPI_PERFCOUNTER3_SELECT, 0,
+				mmSPI_PERFCOUNTER3_LO, mmSPI_PERFCOUNTER3_HI);
+	create_counter_reg_info(&counter_regs[4], mmSPI_PERFCOUNTER4_SELECT, 0,
+				mmSPI_PERFCOUNTER4_LO, mmSPI_PERFCOUNTER4_HI);
+	create_counter_reg_info(&counter_regs[5], mmSPI_PERFCOUNTER5_SELECT, 0,
+				mmSPI_PERFCOUNTER5_LO, mmSPI_PERFCOUNTER5_HI);
 
-    /* Create dimensions for SPI block - SE block with SE dimensions */
-    block->dimension_count = 2;
-    block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
-    if (!block->dimensions) {
-        FREE(counter_regs);
-        FREE(block);
-        return NULL;
-    }
-    block->dimensions[0] = (dimension_t){.size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC};
-    block->dimensions[1] = (dimension_t){.size = GFX12_NUM_SE, .dim = HARDWARE_DIM_SE};
+	/* Create dimensions for SPI block - SE block with SE dimensions */
+	block->dimension_count = 2;
+	block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
+	if (!block->dimensions) {
+		FREE(counter_regs);
+		FREE(block);
+		return NULL;
+	}
+	block->dimensions[0] = (dimension_t){ .size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC };
+	block->dimensions[1] = (dimension_t){ .size = GFX12_NUM_SE, .dim = HARDWARE_DIM_SE };
 
-    block->name = "SPI";
-    block->id = HW_IP_BLOCK_SPI;
-    block->instance_count = GFX12_SPI_COUNTER_BLOCK_NUM_INSTANCES;
-    block->event_id_max = GFX12_SPI_COUNTER_BLOCK_MAX_EVENT;
-    block->counter_count = GFX12_SPI_COUNTER_BLOCK_NUM_COUNTERS;
-    block->counter_reg_info = counter_regs;
-    block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
-    block->delay_info = NULL;
-    block->spm_block_id = 0;
+	block->name = "SPI";
+	block->id = HW_IP_BLOCK_SPI;
+	block->instance_count = GFX12_SPI_COUNTER_BLOCK_NUM_INSTANCES;
+	block->event_id_max = GFX12_SPI_COUNTER_BLOCK_MAX_EVENT;
+	block->counter_count = GFX12_SPI_COUNTER_BLOCK_NUM_COUNTERS;
+	block->counter_reg_info = counter_regs;
+	block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
+	block->delay_info = NULL;
+	block->spm_block_id = 0;
 
-    return block;
+	return block;
 }
 
 /**
@@ -815,55 +831,58 @@ static block_info_t* create_gfx12_spi_block(void) {
  * @see create_gfx12_tcp_block(), create_gfx12_td_block(), GFX12 block info in
  *      projects/aqlprofile/gfxip/gfx12/gfx12_block_info.h
  */
-static block_info_t* create_gfx12_ta_block(void) {
-    block_info_t* block = ALLOC(sizeof(block_info_t));
-    if (!block) return NULL;
+static block_info_t *create_gfx12_ta_block(void)
+{
+	block_info_t *block = ALLOC(sizeof(block_info_t));
+	if (!block)
+		return NULL;
 
-    /* Allocate counter register info array */
-    counter_reg_info_t* counter_regs = ALLOC_ARRAY(counter_reg_info_t, GFX12_TA_COUNTER_BLOCK_NUM_COUNTERS);
-    if (!counter_regs) {
-        FREE(block);
-        return NULL;
-    }
+	/* Allocate counter register info array */
+	counter_reg_info_t *counter_regs =
+		ALLOC_ARRAY(counter_reg_info_t, GFX12_TA_COUNTER_BLOCK_NUM_COUNTERS);
+	if (!counter_regs) {
+		FREE(block);
+		return NULL;
+	}
 
-    /* Initialize TA counter registers - based on aqlprofile reference */
-    create_counter_reg_info(&counter_regs[0], mmTA_PERFCOUNTER0_SELECT, 0,
-                           mmTA_PERFCOUNTER0_LO, mmTA_PERFCOUNTER0_HI);
-    create_counter_reg_info(&counter_regs[1], mmTA_PERFCOUNTER1_SELECT, 0,
-                           mmTA_PERFCOUNTER1_LO, mmTA_PERFCOUNTER1_HI);
+	/* Initialize TA counter registers - based on aqlprofile reference */
+	create_counter_reg_info(&counter_regs[0], mmTA_PERFCOUNTER0_SELECT, 0, mmTA_PERFCOUNTER0_LO,
+				mmTA_PERFCOUNTER0_HI);
+	create_counter_reg_info(&counter_regs[1], mmTA_PERFCOUNTER1_SELECT, 0, mmTA_PERFCOUNTER1_LO,
+				mmTA_PERFCOUNTER1_HI);
 
-    /* Allocate dimensions - TA is a WGP block with XCC+SE+SA+WGP structure (4 dimensions) */
-    dimension_t* dimensions = ALLOC_ARRAY(dimension_t, 4);
-    if (!dimensions) {
-        FREE(counter_regs);
-        FREE(block);
-        return NULL;
-    }
+	/* Allocate dimensions - TA is a WGP block with XCC+SE+SA+WGP structure (4 dimensions) */
+	dimension_t *dimensions = ALLOC_ARRAY(dimension_t, 4);
+	if (!dimensions) {
+		FREE(counter_regs);
+		FREE(block);
+		return NULL;
+	}
 
-    /* Initialize WGP dimensions - based on aqlprofile CounterBlockWgpAttr */
-    dimensions[0].dim = HARDWARE_DIM_XCC;
-    dimensions[0].size = GFX12_NUM_XCC;
-    dimensions[1].dim = HARDWARE_DIM_SE;
-    dimensions[1].size = GFX12_NUM_SE;
-    dimensions[2].dim = HARDWARE_DIM_SA;
-    dimensions[2].size = GFX12_NUM_SA;
-    dimensions[3].dim = HARDWARE_DIM_WGP;
-    dimensions[3].size = GFX12_NUM_WGP_PER_SA;
+	/* Initialize WGP dimensions - based on aqlprofile CounterBlockWgpAttr */
+	dimensions[0].dim = HARDWARE_DIM_XCC;
+	dimensions[0].size = GFX12_NUM_XCC;
+	dimensions[1].dim = HARDWARE_DIM_SE;
+	dimensions[1].size = GFX12_NUM_SE;
+	dimensions[2].dim = HARDWARE_DIM_SA;
+	dimensions[2].size = GFX12_NUM_SA;
+	dimensions[3].dim = HARDWARE_DIM_WGP;
+	dimensions[3].size = GFX12_NUM_WGP_PER_SA;
 
-    /* Initialize TA block */
-    block->name = "TA";
-    block->id = HW_IP_BLOCK_TA;
-    block->instance_count = GFX12_TA_COUNTER_BLOCK_NUM_INSTANCES; /* 2 instances */
-    block->event_id_max = GFX12_TA_COUNTER_BLOCK_MAX_EVENT; /* 254 */
-    block->counter_count = GFX12_TA_COUNTER_BLOCK_NUM_COUNTERS; /* 2 counters */
-    block->dimensions = dimensions;
-    block->dimension_count = 4; /* XCC, SE, SA, WGP */
-    block->counter_reg_info = counter_regs;
-    block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
-    block->delay_info = NULL;
-    block->spm_block_id = 0;
+	/* Initialize TA block */
+	block->name = "TA";
+	block->id = HW_IP_BLOCK_TA;
+	block->instance_count = GFX12_TA_COUNTER_BLOCK_NUM_INSTANCES; /* 2 instances */
+	block->event_id_max = GFX12_TA_COUNTER_BLOCK_MAX_EVENT; /* 254 */
+	block->counter_count = GFX12_TA_COUNTER_BLOCK_NUM_COUNTERS; /* 2 counters */
+	block->dimensions = dimensions;
+	block->dimension_count = 4; /* XCC, SE, SA, WGP */
+	block->counter_reg_info = counter_regs;
+	block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
+	block->delay_info = NULL;
+	block->spm_block_id = 0;
 
-    return block;
+	return block;
 }
 
 /**
@@ -890,59 +909,62 @@ static block_info_t* create_gfx12_ta_block(void) {
  * @see create_gfx12_ta_block(), create_gfx12_tcc_block(), GFX12 block info in
  *      projects/aqlprofile/gfxip/gfx12/gfx12_block_info.h
  */
-static block_info_t* create_gfx12_tcp_block(void) {
-    block_info_t* block = ALLOC(sizeof(block_info_t));
-    if (!block) return NULL;
+static block_info_t *create_gfx12_tcp_block(void)
+{
+	block_info_t *block = ALLOC(sizeof(block_info_t));
+	if (!block)
+		return NULL;
 
-    /* Allocate counter register info array */
-    counter_reg_info_t* counter_regs = ALLOC_ARRAY(counter_reg_info_t, GFX12_TCP_COUNTER_BLOCK_NUM_COUNTERS);
-    if (!counter_regs) {
-        FREE(block);
-        return NULL;
-    }
+	/* Allocate counter register info array */
+	counter_reg_info_t *counter_regs =
+		ALLOC_ARRAY(counter_reg_info_t, GFX12_TCP_COUNTER_BLOCK_NUM_COUNTERS);
+	if (!counter_regs) {
+		FREE(block);
+		return NULL;
+	}
 
-    /* Initialize TCP counter registers - based on aqlprofile reference */
-    create_counter_reg_info(&counter_regs[0], mmTCP_PERFCOUNTER0_SELECT, 0,
-                           mmTCP_PERFCOUNTER0_LO, mmTCP_PERFCOUNTER0_HI);
-    create_counter_reg_info(&counter_regs[1], mmTCP_PERFCOUNTER1_SELECT, 0,
-                           mmTCP_PERFCOUNTER1_LO, mmTCP_PERFCOUNTER1_HI);
-    create_counter_reg_info(&counter_regs[2], mmTCP_PERFCOUNTER2_SELECT, 0,
-                           mmTCP_PERFCOUNTER2_LO, mmTCP_PERFCOUNTER2_HI);
-    create_counter_reg_info(&counter_regs[3], mmTCP_PERFCOUNTER3_SELECT, 0,
-                           mmTCP_PERFCOUNTER3_LO, mmTCP_PERFCOUNTER3_HI);
+	/* Initialize TCP counter registers - based on aqlprofile reference */
+	create_counter_reg_info(&counter_regs[0], mmTCP_PERFCOUNTER0_SELECT, 0,
+				mmTCP_PERFCOUNTER0_LO, mmTCP_PERFCOUNTER0_HI);
+	create_counter_reg_info(&counter_regs[1], mmTCP_PERFCOUNTER1_SELECT, 0,
+				mmTCP_PERFCOUNTER1_LO, mmTCP_PERFCOUNTER1_HI);
+	create_counter_reg_info(&counter_regs[2], mmTCP_PERFCOUNTER2_SELECT, 0,
+				mmTCP_PERFCOUNTER2_LO, mmTCP_PERFCOUNTER2_HI);
+	create_counter_reg_info(&counter_regs[3], mmTCP_PERFCOUNTER3_SELECT, 0,
+				mmTCP_PERFCOUNTER3_LO, mmTCP_PERFCOUNTER3_HI);
 
-    /* Allocate dimensions - TCP is a WGP block with XCC+SE+SA+WGP structure (4 dimensions) */
-    dimension_t* dimensions = ALLOC_ARRAY(dimension_t, 4);
-    if (!dimensions) {
-        FREE(counter_regs);
-        FREE(block);
-        return NULL;
-    }
+	/* Allocate dimensions - TCP is a WGP block with XCC+SE+SA+WGP structure (4 dimensions) */
+	dimension_t *dimensions = ALLOC_ARRAY(dimension_t, 4);
+	if (!dimensions) {
+		FREE(counter_regs);
+		FREE(block);
+		return NULL;
+	}
 
-    /* Initialize WGP dimensions - based on aqlprofile CounterBlockWgpAttr */
-    dimensions[0].dim = HARDWARE_DIM_XCC;
-    dimensions[0].size = GFX12_NUM_XCC;
-    dimensions[1].dim = HARDWARE_DIM_SE;
-    dimensions[1].size = GFX12_NUM_SE;
-    dimensions[2].dim = HARDWARE_DIM_SA;
-    dimensions[2].size = GFX12_NUM_SA;
-    dimensions[3].dim = HARDWARE_DIM_WGP;
-    dimensions[3].size = GFX12_NUM_WGP_PER_SA;
+	/* Initialize WGP dimensions - based on aqlprofile CounterBlockWgpAttr */
+	dimensions[0].dim = HARDWARE_DIM_XCC;
+	dimensions[0].size = GFX12_NUM_XCC;
+	dimensions[1].dim = HARDWARE_DIM_SE;
+	dimensions[1].size = GFX12_NUM_SE;
+	dimensions[2].dim = HARDWARE_DIM_SA;
+	dimensions[2].size = GFX12_NUM_SA;
+	dimensions[3].dim = HARDWARE_DIM_WGP;
+	dimensions[3].size = GFX12_NUM_WGP_PER_SA;
 
-    /* Initialize TCP block */
-    block->name = "TCP";
-    block->id = HW_IP_BLOCK_TCP;
-    block->instance_count = GFX12_TCP_COUNTER_BLOCK_NUM_INSTANCES; /* 2 instances */
-    block->event_id_max = GFX12_TCP_COUNTER_BLOCK_MAX_EVENT; /* 99 */
-    block->counter_count = GFX12_TCP_COUNTER_BLOCK_NUM_COUNTERS; /* 4 counters */
-    block->dimensions = dimensions;
-    block->dimension_count = 4; /* XCC, SE, SA, WGP */
-    block->counter_reg_info = counter_regs;
-    block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
-    block->delay_info = NULL;
-    block->spm_block_id = 0;
+	/* Initialize TCP block */
+	block->name = "TCP";
+	block->id = HW_IP_BLOCK_TCP;
+	block->instance_count = GFX12_TCP_COUNTER_BLOCK_NUM_INSTANCES; /* 2 instances */
+	block->event_id_max = GFX12_TCP_COUNTER_BLOCK_MAX_EVENT; /* 99 */
+	block->counter_count = GFX12_TCP_COUNTER_BLOCK_NUM_COUNTERS; /* 4 counters */
+	block->dimensions = dimensions;
+	block->dimension_count = 4; /* XCC, SE, SA, WGP */
+	block->counter_reg_info = counter_regs;
+	block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
+	block->delay_info = NULL;
+	block->spm_block_id = 0;
 
-    return block;
+	return block;
 }
 
 /**
@@ -969,55 +991,58 @@ static block_info_t* create_gfx12_tcp_block(void) {
  * @see create_gfx12_ta_block(), create_gfx12_tcp_block(), GFX12 block info in
  *      projects/aqlprofile/gfxip/gfx12/gfx12_block_info.h
  */
-static block_info_t* create_gfx12_td_block(void) {
-    block_info_t* block = ALLOC(sizeof(block_info_t));
-    if (!block) return NULL;
+static block_info_t *create_gfx12_td_block(void)
+{
+	block_info_t *block = ALLOC(sizeof(block_info_t));
+	if (!block)
+		return NULL;
 
-    /* Allocate counter register info array */
-    counter_reg_info_t* counter_regs = ALLOC_ARRAY(counter_reg_info_t, GFX12_TD_COUNTER_BLOCK_NUM_COUNTERS);
-    if (!counter_regs) {
-        FREE(block);
-        return NULL;
-    }
+	/* Allocate counter register info array */
+	counter_reg_info_t *counter_regs =
+		ALLOC_ARRAY(counter_reg_info_t, GFX12_TD_COUNTER_BLOCK_NUM_COUNTERS);
+	if (!counter_regs) {
+		FREE(block);
+		return NULL;
+	}
 
-    /* Initialize TD counter registers - based on aqlprofile reference */
-    create_counter_reg_info(&counter_regs[0], mmTD_PERFCOUNTER0_SELECT, 0,
-                           mmTD_PERFCOUNTER0_LO, mmTD_PERFCOUNTER0_HI);
-    create_counter_reg_info(&counter_regs[1], mmTD_PERFCOUNTER1_SELECT, 0,
-                           mmTD_PERFCOUNTER1_LO, mmTD_PERFCOUNTER1_HI);
+	/* Initialize TD counter registers - based on aqlprofile reference */
+	create_counter_reg_info(&counter_regs[0], mmTD_PERFCOUNTER0_SELECT, 0, mmTD_PERFCOUNTER0_LO,
+				mmTD_PERFCOUNTER0_HI);
+	create_counter_reg_info(&counter_regs[1], mmTD_PERFCOUNTER1_SELECT, 0, mmTD_PERFCOUNTER1_LO,
+				mmTD_PERFCOUNTER1_HI);
 
-    /* Allocate dimensions - TD is a WGP block with XCC+SE+SA+WGP structure (4 dimensions) */
-    dimension_t* dimensions = ALLOC_ARRAY(dimension_t, 4);
-    if (!dimensions) {
-        FREE(counter_regs);
-        FREE(block);
-        return NULL;
-    }
+	/* Allocate dimensions - TD is a WGP block with XCC+SE+SA+WGP structure (4 dimensions) */
+	dimension_t *dimensions = ALLOC_ARRAY(dimension_t, 4);
+	if (!dimensions) {
+		FREE(counter_regs);
+		FREE(block);
+		return NULL;
+	}
 
-    /* Initialize WGP dimensions - based on aqlprofile CounterBlockWgpAttr */
-    dimensions[0].dim = HARDWARE_DIM_XCC;
-    dimensions[0].size = GFX12_NUM_XCC;
-    dimensions[1].dim = HARDWARE_DIM_SE;
-    dimensions[1].size = GFX12_NUM_SE;
-    dimensions[2].dim = HARDWARE_DIM_SA;
-    dimensions[2].size = GFX12_NUM_SA;
-    dimensions[3].dim = HARDWARE_DIM_WGP;
-    dimensions[3].size = GFX12_NUM_WGP_PER_SA;
+	/* Initialize WGP dimensions - based on aqlprofile CounterBlockWgpAttr */
+	dimensions[0].dim = HARDWARE_DIM_XCC;
+	dimensions[0].size = GFX12_NUM_XCC;
+	dimensions[1].dim = HARDWARE_DIM_SE;
+	dimensions[1].size = GFX12_NUM_SE;
+	dimensions[2].dim = HARDWARE_DIM_SA;
+	dimensions[2].size = GFX12_NUM_SA;
+	dimensions[3].dim = HARDWARE_DIM_WGP;
+	dimensions[3].size = GFX12_NUM_WGP_PER_SA;
 
-    /* Initialize TD block */
-    block->name = "TD";
-    block->id = HW_IP_BLOCK_TD;
-    block->instance_count = GFX12_TD_COUNTER_BLOCK_NUM_INSTANCES; /* 2 instances */
-    block->event_id_max = GFX12_TD_COUNTER_BLOCK_MAX_EVENT; /* 127 */
-    block->counter_count = GFX12_TD_COUNTER_BLOCK_NUM_COUNTERS; /* 2 counters */
-    block->dimensions = dimensions;
-    block->dimension_count = 4; /* XCC, SE, SA, WGP */
-    block->counter_reg_info = counter_regs;
-    block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
-    block->delay_info = NULL;
-    block->spm_block_id = 0;
+	/* Initialize TD block */
+	block->name = "TD";
+	block->id = HW_IP_BLOCK_TD;
+	block->instance_count = GFX12_TD_COUNTER_BLOCK_NUM_INSTANCES; /* 2 instances */
+	block->event_id_max = GFX12_TD_COUNTER_BLOCK_MAX_EVENT; /* 127 */
+	block->counter_count = GFX12_TD_COUNTER_BLOCK_NUM_COUNTERS; /* 2 counters */
+	block->dimensions = dimensions;
+	block->dimension_count = 4; /* XCC, SE, SA, WGP */
+	block->counter_reg_info = counter_regs;
+	block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
+	block->delay_info = NULL;
+	block->spm_block_id = 0;
 
-    return block;
+	return block;
 }
 
 /**
@@ -1044,48 +1069,51 @@ static block_info_t* create_gfx12_td_block(void) {
  * @see create_gfx12_tcp_block(), create_gfx12_gl2c_block(), GFX12 block info in
  *      projects/aqlprofile/gfxip/gfx12/gfx12_block_info.h
  */
-static block_info_t* create_gfx12_tcc_block(void) {
-    block_info_t* block = ALLOC(sizeof(block_info_t));
-    if (!block) return NULL;
+static block_info_t *create_gfx12_tcc_block(void)
+{
+	block_info_t *block = ALLOC(sizeof(block_info_t));
+	if (!block)
+		return NULL;
 
-    /* Allocate counter register info array */
-    counter_reg_info_t* counter_regs = ALLOC_ARRAY(counter_reg_info_t, GFX12_TCC_COUNTER_BLOCK_NUM_COUNTERS);
-    if (!counter_regs) {
-        FREE(block);
-        return NULL;
-    }
+	/* Allocate counter register info array */
+	counter_reg_info_t *counter_regs =
+		ALLOC_ARRAY(counter_reg_info_t, GFX12_TCC_COUNTER_BLOCK_NUM_COUNTERS);
+	if (!counter_regs) {
+		FREE(block);
+		return NULL;
+	}
 
-    /* Initialize TCC counter registers - based on aqlprofile reference */
-    create_counter_reg_info(&counter_regs[0], mmTCC_PERFCOUNTER0_SELECT, 0,
-                           mmTCC_PERFCOUNTER0_LO, mmTCC_PERFCOUNTER0_HI);
-    create_counter_reg_info(&counter_regs[1], mmTCC_PERFCOUNTER1_SELECT, 0,
-                           mmTCC_PERFCOUNTER1_LO, mmTCC_PERFCOUNTER1_HI);
-    create_counter_reg_info(&counter_regs[2], mmTCC_PERFCOUNTER2_SELECT, 0,
-                           mmTCC_PERFCOUNTER2_LO, mmTCC_PERFCOUNTER2_HI);
-    create_counter_reg_info(&counter_regs[3], mmTCC_PERFCOUNTER3_SELECT, 0,
-                           mmTCC_PERFCOUNTER3_LO, mmTCC_PERFCOUNTER3_HI);
+	/* Initialize TCC counter registers - based on aqlprofile reference */
+	create_counter_reg_info(&counter_regs[0], mmTCC_PERFCOUNTER0_SELECT, 0,
+				mmTCC_PERFCOUNTER0_LO, mmTCC_PERFCOUNTER0_HI);
+	create_counter_reg_info(&counter_regs[1], mmTCC_PERFCOUNTER1_SELECT, 0,
+				mmTCC_PERFCOUNTER1_LO, mmTCC_PERFCOUNTER1_HI);
+	create_counter_reg_info(&counter_regs[2], mmTCC_PERFCOUNTER2_SELECT, 0,
+				mmTCC_PERFCOUNTER2_LO, mmTCC_PERFCOUNTER2_HI);
+	create_counter_reg_info(&counter_regs[3], mmTCC_PERFCOUNTER3_SELECT, 0,
+				mmTCC_PERFCOUNTER3_LO, mmTCC_PERFCOUNTER3_HI);
 
-    /* Create dimensions for TCC block - global block with no SE/SA dependencies */
-    block->dimension_count = 1;
-    block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
-    if (!block->dimensions) {
-        FREE(counter_regs);
-        FREE(block);
-        return NULL;
-    }
-    block->dimensions[0] = (dimension_t){.size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC};
+	/* Create dimensions for TCC block - global block with no SE/SA dependencies */
+	block->dimension_count = 1;
+	block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
+	if (!block->dimensions) {
+		FREE(counter_regs);
+		FREE(block);
+		return NULL;
+	}
+	block->dimensions[0] = (dimension_t){ .size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC };
 
-    block->name = "TCC";
-    block->id = HW_IP_BLOCK_TCC;
-    block->instance_count = GFX12_TCC_COUNTER_BLOCK_NUM_INSTANCES;
-    block->event_id_max = GFX12_TCC_COUNTER_BLOCK_MAX_EVENT;
-    block->counter_count = GFX12_TCC_COUNTER_BLOCK_NUM_COUNTERS;
-    block->counter_reg_info = counter_regs;
-    block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
-    block->delay_info = NULL;
-    block->spm_block_id = 0;
+	block->name = "TCC";
+	block->id = HW_IP_BLOCK_TCC;
+	block->instance_count = GFX12_TCC_COUNTER_BLOCK_NUM_INSTANCES;
+	block->event_id_max = GFX12_TCC_COUNTER_BLOCK_MAX_EVENT;
+	block->counter_count = GFX12_TCC_COUNTER_BLOCK_NUM_COUNTERS;
+	block->counter_reg_info = counter_regs;
+	block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
+	block->delay_info = NULL;
+	block->spm_block_id = 0;
 
-    return block;
+	return block;
 }
 
 /**
@@ -1111,49 +1139,52 @@ static block_info_t* create_gfx12_tcc_block(void) {
  * @see create_gfx12_db_block(), GFX12 block info in
  *      projects/aqlprofile/gfxip/gfx12/gfx12_block_info.h
  */
-static block_info_t* create_gfx12_sx_block(void) {
-    block_info_t* block = ALLOC(sizeof(block_info_t));
-    if (!block) return NULL;
+static block_info_t *create_gfx12_sx_block(void)
+{
+	block_info_t *block = ALLOC(sizeof(block_info_t));
+	if (!block)
+		return NULL;
 
-    /* Allocate counter register info array */
-    counter_reg_info_t* counter_regs = ALLOC_ARRAY(counter_reg_info_t, GFX12_SX_COUNTER_BLOCK_NUM_COUNTERS);
-    if (!counter_regs) {
-        FREE(block);
-        return NULL;
-    }
+	/* Allocate counter register info array */
+	counter_reg_info_t *counter_regs =
+		ALLOC_ARRAY(counter_reg_info_t, GFX12_SX_COUNTER_BLOCK_NUM_COUNTERS);
+	if (!counter_regs) {
+		FREE(block);
+		return NULL;
+	}
 
-    /* Initialize SX counter registers - based on aqlprofile reference */
-    create_counter_reg_info(&counter_regs[0], mmSX_PERFCOUNTER0_SELECT, 0,
-                           mmSX_PERFCOUNTER0_LO, mmSX_PERFCOUNTER0_HI);
-    create_counter_reg_info(&counter_regs[1], mmSX_PERFCOUNTER1_SELECT, 0,
-                           mmSX_PERFCOUNTER1_LO, mmSX_PERFCOUNTER1_HI);
-    create_counter_reg_info(&counter_regs[2], mmSX_PERFCOUNTER2_SELECT, 0,
-                           mmSX_PERFCOUNTER2_LO, mmSX_PERFCOUNTER2_HI);
-    create_counter_reg_info(&counter_regs[3], mmSX_PERFCOUNTER3_SELECT, 0,
-                           mmSX_PERFCOUNTER3_LO, mmSX_PERFCOUNTER3_HI);
+	/* Initialize SX counter registers - based on aqlprofile reference */
+	create_counter_reg_info(&counter_regs[0], mmSX_PERFCOUNTER0_SELECT, 0, mmSX_PERFCOUNTER0_LO,
+				mmSX_PERFCOUNTER0_HI);
+	create_counter_reg_info(&counter_regs[1], mmSX_PERFCOUNTER1_SELECT, 0, mmSX_PERFCOUNTER1_LO,
+				mmSX_PERFCOUNTER1_HI);
+	create_counter_reg_info(&counter_regs[2], mmSX_PERFCOUNTER2_SELECT, 0, mmSX_PERFCOUNTER2_LO,
+				mmSX_PERFCOUNTER2_HI);
+	create_counter_reg_info(&counter_regs[3], mmSX_PERFCOUNTER3_SELECT, 0, mmSX_PERFCOUNTER3_LO,
+				mmSX_PERFCOUNTER3_HI);
 
-    /* Create dimensions for SX block - SE block with SE dimensions */
-    block->dimension_count = 2;
-    block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
-    if (!block->dimensions) {
-        FREE(counter_regs);
-        FREE(block);
-        return NULL;
-    }
-    block->dimensions[0] = (dimension_t){.size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC};
-    block->dimensions[1] = (dimension_t){.size = GFX12_NUM_SE, .dim = HARDWARE_DIM_SE};
+	/* Create dimensions for SX block - SE block with SE dimensions */
+	block->dimension_count = 2;
+	block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
+	if (!block->dimensions) {
+		FREE(counter_regs);
+		FREE(block);
+		return NULL;
+	}
+	block->dimensions[0] = (dimension_t){ .size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC };
+	block->dimensions[1] = (dimension_t){ .size = GFX12_NUM_SE, .dim = HARDWARE_DIM_SE };
 
-    block->name = "SX";
-    block->id = HW_IP_BLOCK_SX;
-    block->instance_count = GFX12_SX_COUNTER_BLOCK_NUM_INSTANCES;
-    block->event_id_max = GFX12_SX_COUNTER_BLOCK_MAX_EVENT;
-    block->counter_count = GFX12_SX_COUNTER_BLOCK_NUM_COUNTERS;
-    block->counter_reg_info = counter_regs;
-    block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
-    block->delay_info = NULL;
-    block->spm_block_id = 0;
+	block->name = "SX";
+	block->id = HW_IP_BLOCK_SX;
+	block->instance_count = GFX12_SX_COUNTER_BLOCK_NUM_INSTANCES;
+	block->event_id_max = GFX12_SX_COUNTER_BLOCK_MAX_EVENT;
+	block->counter_count = GFX12_SX_COUNTER_BLOCK_NUM_COUNTERS;
+	block->counter_reg_info = counter_regs;
+	block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
+	block->delay_info = NULL;
+	block->spm_block_id = 0;
 
-    return block;
+	return block;
 }
 
 /**
@@ -1179,49 +1210,52 @@ static block_info_t* create_gfx12_sx_block(void) {
  * @see create_gfx12_sx_block(), create_gfx12_pa_sc_block(), GFX12 block info in
  *      projects/aqlprofile/gfxip/gfx12/gfx12_block_info.h
  */
-static block_info_t* create_gfx12_db_block(void) {
-    block_info_t* block = ALLOC(sizeof(block_info_t));
-    if (!block) return NULL;
+static block_info_t *create_gfx12_db_block(void)
+{
+	block_info_t *block = ALLOC(sizeof(block_info_t));
+	if (!block)
+		return NULL;
 
-    /* Allocate counter register info array */
-    counter_reg_info_t* counter_regs = ALLOC_ARRAY(counter_reg_info_t, GFX12_DB_COUNTER_BLOCK_NUM_COUNTERS);
-    if (!counter_regs) {
-        FREE(block);
-        return NULL;
-    }
+	/* Allocate counter register info array */
+	counter_reg_info_t *counter_regs =
+		ALLOC_ARRAY(counter_reg_info_t, GFX12_DB_COUNTER_BLOCK_NUM_COUNTERS);
+	if (!counter_regs) {
+		FREE(block);
+		return NULL;
+	}
 
-    /* Initialize DB counter registers - based on aqlprofile reference */
-    create_counter_reg_info(&counter_regs[0], mmDB_PERFCOUNTER0_SELECT, 0,
-                           mmDB_PERFCOUNTER0_LO, mmDB_PERFCOUNTER0_HI);
-    create_counter_reg_info(&counter_regs[1], mmDB_PERFCOUNTER1_SELECT, 0,
-                           mmDB_PERFCOUNTER1_LO, mmDB_PERFCOUNTER1_HI);
-    create_counter_reg_info(&counter_regs[2], mmDB_PERFCOUNTER2_SELECT, 0,
-                           mmDB_PERFCOUNTER2_LO, mmDB_PERFCOUNTER2_HI);
-    create_counter_reg_info(&counter_regs[3], mmDB_PERFCOUNTER3_SELECT, 0,
-                           mmDB_PERFCOUNTER3_LO, mmDB_PERFCOUNTER3_HI);
+	/* Initialize DB counter registers - based on aqlprofile reference */
+	create_counter_reg_info(&counter_regs[0], mmDB_PERFCOUNTER0_SELECT, 0, mmDB_PERFCOUNTER0_LO,
+				mmDB_PERFCOUNTER0_HI);
+	create_counter_reg_info(&counter_regs[1], mmDB_PERFCOUNTER1_SELECT, 0, mmDB_PERFCOUNTER1_LO,
+				mmDB_PERFCOUNTER1_HI);
+	create_counter_reg_info(&counter_regs[2], mmDB_PERFCOUNTER2_SELECT, 0, mmDB_PERFCOUNTER2_LO,
+				mmDB_PERFCOUNTER2_HI);
+	create_counter_reg_info(&counter_regs[3], mmDB_PERFCOUNTER3_SELECT, 0, mmDB_PERFCOUNTER3_LO,
+				mmDB_PERFCOUNTER3_HI);
 
-    /* Create dimensions for DB block - SE block with SE dimensions */
-    block->dimension_count = 2;
-    block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
-    if (!block->dimensions) {
-        FREE(counter_regs);
-        FREE(block);
-        return NULL;
-    }
-    block->dimensions[0] = (dimension_t){.size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC};
-    block->dimensions[1] = (dimension_t){.size = GFX12_NUM_SE, .dim = HARDWARE_DIM_SE};
+	/* Create dimensions for DB block - SE block with SE dimensions */
+	block->dimension_count = 2;
+	block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
+	if (!block->dimensions) {
+		FREE(counter_regs);
+		FREE(block);
+		return NULL;
+	}
+	block->dimensions[0] = (dimension_t){ .size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC };
+	block->dimensions[1] = (dimension_t){ .size = GFX12_NUM_SE, .dim = HARDWARE_DIM_SE };
 
-    block->name = "DB";
-    block->id = HW_IP_BLOCK_DB;
-    block->instance_count = GFX12_DB_COUNTER_BLOCK_NUM_INSTANCES;
-    block->event_id_max = GFX12_DB_COUNTER_BLOCK_MAX_EVENT;
-    block->counter_count = GFX12_DB_COUNTER_BLOCK_NUM_COUNTERS;
-    block->counter_reg_info = counter_regs;
-    block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
-    block->delay_info = NULL;
-    block->spm_block_id = 0;
+	block->name = "DB";
+	block->id = HW_IP_BLOCK_DB;
+	block->instance_count = GFX12_DB_COUNTER_BLOCK_NUM_INSTANCES;
+	block->event_id_max = GFX12_DB_COUNTER_BLOCK_MAX_EVENT;
+	block->counter_count = GFX12_DB_COUNTER_BLOCK_NUM_COUNTERS;
+	block->counter_reg_info = counter_regs;
+	block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
+	block->delay_info = NULL;
+	block->spm_block_id = 0;
 
-    return block;
+	return block;
 }
 
 /**
@@ -1247,49 +1281,52 @@ static block_info_t* create_gfx12_db_block(void) {
  * @see create_gfx12_pa_su_block(), GFX12 block info in
  *      projects/aqlprofile/gfxip/gfx12/gfx12_block_info.h
  */
-static block_info_t* create_gfx12_pa_sc_block(void) {
-    block_info_t* block = ALLOC(sizeof(block_info_t));
-    if (!block) return NULL;
+static block_info_t *create_gfx12_pa_sc_block(void)
+{
+	block_info_t *block = ALLOC(sizeof(block_info_t));
+	if (!block)
+		return NULL;
 
-    /* Allocate counter register info array */
-    counter_reg_info_t* counter_regs = ALLOC_ARRAY(counter_reg_info_t, GFX12_PA_SC_COUNTER_BLOCK_NUM_COUNTERS);
-    if (!counter_regs) {
-        FREE(block);
-        return NULL;
-    }
+	/* Allocate counter register info array */
+	counter_reg_info_t *counter_regs =
+		ALLOC_ARRAY(counter_reg_info_t, GFX12_PA_SC_COUNTER_BLOCK_NUM_COUNTERS);
+	if (!counter_regs) {
+		FREE(block);
+		return NULL;
+	}
 
-    /* Initialize PA_SC counter registers - based on aqlprofile reference */
-    create_counter_reg_info(&counter_regs[0], mmPA_SC_PERFCOUNTER0_SELECT, 0,
-                           mmPA_SC_PERFCOUNTER0_LO, mmPA_SC_PERFCOUNTER0_HI);
-    create_counter_reg_info(&counter_regs[1], mmPA_SC_PERFCOUNTER1_SELECT, 0,
-                           mmPA_SC_PERFCOUNTER1_LO, mmPA_SC_PERFCOUNTER1_HI);
-    create_counter_reg_info(&counter_regs[2], mmPA_SC_PERFCOUNTER2_SELECT, 0,
-                           mmPA_SC_PERFCOUNTER2_LO, mmPA_SC_PERFCOUNTER2_HI);
-    create_counter_reg_info(&counter_regs[3], mmPA_SC_PERFCOUNTER3_SELECT, 0,
-                           mmPA_SC_PERFCOUNTER3_LO, mmPA_SC_PERFCOUNTER3_HI);
+	/* Initialize PA_SC counter registers - based on aqlprofile reference */
+	create_counter_reg_info(&counter_regs[0], mmPA_SC_PERFCOUNTER0_SELECT, 0,
+				mmPA_SC_PERFCOUNTER0_LO, mmPA_SC_PERFCOUNTER0_HI);
+	create_counter_reg_info(&counter_regs[1], mmPA_SC_PERFCOUNTER1_SELECT, 0,
+				mmPA_SC_PERFCOUNTER1_LO, mmPA_SC_PERFCOUNTER1_HI);
+	create_counter_reg_info(&counter_regs[2], mmPA_SC_PERFCOUNTER2_SELECT, 0,
+				mmPA_SC_PERFCOUNTER2_LO, mmPA_SC_PERFCOUNTER2_HI);
+	create_counter_reg_info(&counter_regs[3], mmPA_SC_PERFCOUNTER3_SELECT, 0,
+				mmPA_SC_PERFCOUNTER3_LO, mmPA_SC_PERFCOUNTER3_HI);
 
-    /* Create dimensions for PA_SC block - SE block with SE dimensions */
-    block->dimension_count = 2;
-    block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
-    if (!block->dimensions) {
-        FREE(counter_regs);
-        FREE(block);
-        return NULL;
-    }
-    block->dimensions[0] = (dimension_t){.size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC};
-    block->dimensions[1] = (dimension_t){.size = GFX12_NUM_SE, .dim = HARDWARE_DIM_SE};
+	/* Create dimensions for PA_SC block - SE block with SE dimensions */
+	block->dimension_count = 2;
+	block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
+	if (!block->dimensions) {
+		FREE(counter_regs);
+		FREE(block);
+		return NULL;
+	}
+	block->dimensions[0] = (dimension_t){ .size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC };
+	block->dimensions[1] = (dimension_t){ .size = GFX12_NUM_SE, .dim = HARDWARE_DIM_SE };
 
-    block->name = "PA_SC";
-    block->id = HW_IP_BLOCK_PA_SC;
-    block->instance_count = GFX12_PA_SC_COUNTER_BLOCK_NUM_INSTANCES;
-    block->event_id_max = GFX12_PA_SC_COUNTER_BLOCK_MAX_EVENT;
-    block->counter_count = GFX12_PA_SC_COUNTER_BLOCK_NUM_COUNTERS;
-    block->counter_reg_info = counter_regs;
-    block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
-    block->delay_info = NULL;
-    block->spm_block_id = 0;
+	block->name = "PA_SC";
+	block->id = HW_IP_BLOCK_PA_SC;
+	block->instance_count = GFX12_PA_SC_COUNTER_BLOCK_NUM_INSTANCES;
+	block->event_id_max = GFX12_PA_SC_COUNTER_BLOCK_MAX_EVENT;
+	block->counter_count = GFX12_PA_SC_COUNTER_BLOCK_NUM_COUNTERS;
+	block->counter_reg_info = counter_regs;
+	block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
+	block->delay_info = NULL;
+	block->spm_block_id = 0;
 
-    return block;
+	return block;
 }
 
 /**
@@ -1315,50 +1352,53 @@ static block_info_t* create_gfx12_pa_sc_block(void) {
  * @see create_gfx12_pa_sc_block(), GFX12 block info in
  *      projects/aqlprofile/gfxip/gfx12/gfx12_block_info.h
  */
-static block_info_t* create_gfx12_pa_su_block(void) {
-    block_info_t* block = ALLOC(sizeof(block_info_t));
-    if (!block) return NULL;
+static block_info_t *create_gfx12_pa_su_block(void)
+{
+	block_info_t *block = ALLOC(sizeof(block_info_t));
+	if (!block)
+		return NULL;
 
-    /* Allocate counter register info array */
-    counter_reg_info_t* counter_regs = ALLOC_ARRAY(counter_reg_info_t, GFX12_PA_SU_COUNTER_BLOCK_NUM_COUNTERS);
-    if (!counter_regs) {
-        FREE(block);
-        return NULL;
-    }
+	/* Allocate counter register info array */
+	counter_reg_info_t *counter_regs =
+		ALLOC_ARRAY(counter_reg_info_t, GFX12_PA_SU_COUNTER_BLOCK_NUM_COUNTERS);
+	if (!counter_regs) {
+		FREE(block);
+		return NULL;
+	}
 
-    /* Initialize PA_SU counter registers - based on aqlprofile reference */
-    create_counter_reg_info(&counter_regs[0], mmPA_SU_PERFCOUNTER0_SELECT, 0,
-                           mmPA_SU_PERFCOUNTER0_LO, mmPA_SU_PERFCOUNTER0_HI);
-    create_counter_reg_info(&counter_regs[1], mmPA_SU_PERFCOUNTER1_SELECT, 0,
-                           mmPA_SU_PERFCOUNTER1_LO, mmPA_SU_PERFCOUNTER1_HI);
-    create_counter_reg_info(&counter_regs[2], mmPA_SU_PERFCOUNTER2_SELECT, 0,
-                           mmPA_SU_PERFCOUNTER2_LO, mmPA_SU_PERFCOUNTER2_HI);
-    create_counter_reg_info(&counter_regs[3], mmPA_SU_PERFCOUNTER3_SELECT, 0,
-                           mmPA_SU_PERFCOUNTER3_LO, mmPA_SU_PERFCOUNTER3_HI);
+	/* Initialize PA_SU counter registers - based on aqlprofile reference */
+	create_counter_reg_info(&counter_regs[0], mmPA_SU_PERFCOUNTER0_SELECT, 0,
+				mmPA_SU_PERFCOUNTER0_LO, mmPA_SU_PERFCOUNTER0_HI);
+	create_counter_reg_info(&counter_regs[1], mmPA_SU_PERFCOUNTER1_SELECT, 0,
+				mmPA_SU_PERFCOUNTER1_LO, mmPA_SU_PERFCOUNTER1_HI);
+	create_counter_reg_info(&counter_regs[2], mmPA_SU_PERFCOUNTER2_SELECT, 0,
+				mmPA_SU_PERFCOUNTER2_LO, mmPA_SU_PERFCOUNTER2_HI);
+	create_counter_reg_info(&counter_regs[3], mmPA_SU_PERFCOUNTER3_SELECT, 0,
+				mmPA_SU_PERFCOUNTER3_LO, mmPA_SU_PERFCOUNTER3_HI);
 
-    /* Create dimensions for PA_SU block - SE block with SE dimensions */
-    block->dimension_count = 2;
-    block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
-    if (!block->dimensions) {
-        FREE(counter_regs);
-        FREE(block);
-        return NULL;
-    }
+	/* Create dimensions for PA_SU block - SE block with SE dimensions */
+	block->dimension_count = 2;
+	block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
+	if (!block->dimensions) {
+		FREE(counter_regs);
+		FREE(block);
+		return NULL;
+	}
 
-    block->dimensions[0] = (dimension_t){.size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC};
-    block->dimensions[1] = (dimension_t){.size = GFX12_NUM_SE, .dim = HARDWARE_DIM_SE};
+	block->dimensions[0] = (dimension_t){ .size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC };
+	block->dimensions[1] = (dimension_t){ .size = GFX12_NUM_SE, .dim = HARDWARE_DIM_SE };
 
-    block->name = "PA_SU";
-    block->id = HW_IP_BLOCK_PA_SU;
-    block->instance_count = GFX12_PA_SU_COUNTER_BLOCK_NUM_INSTANCES;
-    block->event_id_max = GFX12_PA_SU_COUNTER_BLOCK_MAX_EVENT;
-    block->counter_count = GFX12_PA_SU_COUNTER_BLOCK_NUM_COUNTERS;
-    block->counter_reg_info = counter_regs;
-    block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
-    block->delay_info = NULL;
-    block->spm_block_id = 0;
+	block->name = "PA_SU";
+	block->id = HW_IP_BLOCK_PA_SU;
+	block->instance_count = GFX12_PA_SU_COUNTER_BLOCK_NUM_INSTANCES;
+	block->event_id_max = GFX12_PA_SU_COUNTER_BLOCK_MAX_EVENT;
+	block->counter_count = GFX12_PA_SU_COUNTER_BLOCK_NUM_COUNTERS;
+	block->counter_reg_info = counter_regs;
+	block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
+	block->delay_info = NULL;
+	block->spm_block_id = 0;
 
-    return block;
+	return block;
 }
 
 /**
@@ -1384,49 +1424,52 @@ static block_info_t* create_gfx12_pa_su_block(void) {
  * @see create_gfx12_cpc_block(), GFX12 block info in
  *      projects/aqlprofile/gfxip/gfx12/gfx12_block_info.h
  */
-static block_info_t* create_gfx12_gds_block(void) {
-    block_info_t* block = ALLOC(sizeof(block_info_t));
-    if (!block) return NULL;
+static block_info_t *create_gfx12_gds_block(void)
+{
+	block_info_t *block = ALLOC(sizeof(block_info_t));
+	if (!block)
+		return NULL;
 
-    /* Allocate counter register info array */
-    counter_reg_info_t* counter_regs = ALLOC_ARRAY(counter_reg_info_t, GFX12_GDS_COUNTER_BLOCK_NUM_COUNTERS);
-    if (!counter_regs) {
-        FREE(block);
-        return NULL;
-    }
+	/* Allocate counter register info array */
+	counter_reg_info_t *counter_regs =
+		ALLOC_ARRAY(counter_reg_info_t, GFX12_GDS_COUNTER_BLOCK_NUM_COUNTERS);
+	if (!counter_regs) {
+		FREE(block);
+		return NULL;
+	}
 
-    /* Initialize GDS counter registers - based on aqlprofile reference */
-    create_counter_reg_info(&counter_regs[0], mmGDS_PERFCOUNTER0_SELECT, 0,
-                           mmGDS_PERFCOUNTER0_LO, mmGDS_PERFCOUNTER0_HI);
-    create_counter_reg_info(&counter_regs[1], mmGDS_PERFCOUNTER1_SELECT, 0,
-                           mmGDS_PERFCOUNTER1_LO, mmGDS_PERFCOUNTER1_HI);
-    create_counter_reg_info(&counter_regs[2], mmGDS_PERFCOUNTER2_SELECT, 0,
-                           mmGDS_PERFCOUNTER2_LO, mmGDS_PERFCOUNTER2_HI);
-    create_counter_reg_info(&counter_regs[3], mmGDS_PERFCOUNTER3_SELECT, 0,
-                           mmGDS_PERFCOUNTER3_LO, mmGDS_PERFCOUNTER3_HI);
+	/* Initialize GDS counter registers - based on aqlprofile reference */
+	create_counter_reg_info(&counter_regs[0], mmGDS_PERFCOUNTER0_SELECT, 0,
+				mmGDS_PERFCOUNTER0_LO, mmGDS_PERFCOUNTER0_HI);
+	create_counter_reg_info(&counter_regs[1], mmGDS_PERFCOUNTER1_SELECT, 0,
+				mmGDS_PERFCOUNTER1_LO, mmGDS_PERFCOUNTER1_HI);
+	create_counter_reg_info(&counter_regs[2], mmGDS_PERFCOUNTER2_SELECT, 0,
+				mmGDS_PERFCOUNTER2_LO, mmGDS_PERFCOUNTER2_HI);
+	create_counter_reg_info(&counter_regs[3], mmGDS_PERFCOUNTER3_SELECT, 0,
+				mmGDS_PERFCOUNTER3_LO, mmGDS_PERFCOUNTER3_HI);
 
-    /* Create dimensions for GDS block - XCC block with XCC dimensions only */
-    block->dimension_count = 1;
-    block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
-    if (!block->dimensions) {
-        FREE(counter_regs);
-        FREE(block);
-        return NULL;
-    }
+	/* Create dimensions for GDS block - XCC block with XCC dimensions only */
+	block->dimension_count = 1;
+	block->dimensions = ALLOC_ARRAY(dimension_t, block->dimension_count);
+	if (!block->dimensions) {
+		FREE(counter_regs);
+		FREE(block);
+		return NULL;
+	}
 
-    block->dimensions[0] = (dimension_t){.size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC};
+	block->dimensions[0] = (dimension_t){ .size = GFX12_NUM_XCC, .dim = HARDWARE_DIM_XCC };
 
-    block->name = "GDS";
-    block->id = HW_IP_BLOCK_GDS;
-    block->instance_count = GFX12_GDS_COUNTER_BLOCK_NUM_INSTANCES;
-    block->event_id_max = GFX12_GDS_COUNTER_BLOCK_MAX_EVENT;
-    block->counter_count = GFX12_GDS_COUNTER_BLOCK_NUM_COUNTERS;
-    block->counter_reg_info = counter_regs;
-    block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
-    block->delay_info = NULL;
-    block->spm_block_id = 0;
+	block->name = "GDS";
+	block->id = HW_IP_BLOCK_GDS;
+	block->instance_count = GFX12_GDS_COUNTER_BLOCK_NUM_INSTANCES;
+	block->event_id_max = GFX12_GDS_COUNTER_BLOCK_MAX_EVENT;
+	block->counter_count = GFX12_GDS_COUNTER_BLOCK_NUM_COUNTERS;
+	block->counter_reg_info = counter_regs;
+	block->attr = GFX12_COUNTER_BLOCK_DFLT_ATTR;
+	block->delay_info = NULL;
+	block->spm_block_id = 0;
 
-    return block;
+	return block;
 }
 
 /**
@@ -1454,136 +1497,140 @@ static block_info_t* create_gfx12_gds_block(void) {
  * @see arch_destroy(), Pm4Factory::Gfx12Create in
  *      projects/aqlprofile/src/core/gfx12_factory.cpp
  */
-arch_t* create_gfx12_arch(void) {
-    arch_t* arch = ALLOC(sizeof(arch_t));
-    if (!arch) return NULL;
+arch_t *create_gfx12_arch(void)
+{
+	arch_t *arch = ALLOC(sizeof(arch_t));
+	if (!arch)
+		return NULL;
 
-    /* Initialize architecture fields - from Rust demo.rs */
-    arch->type = ARCH_TYPE_GFX12;
-    arch->num_xcc = GFX12_NUM_XCC;
-    arch->num_se = GFX12_NUM_SE;
-    arch->num_sa = GFX12_NUM_SA;
-    arch->num_cu = GFX12_NUM_CU;
-    arch->num_wgp_per_sa = GFX12_NUM_WGP_PER_SA;
-    arch->command = NULL; /* Will be allocated as needed */
+	/* Initialize architecture fields - from Rust demo.rs */
+	arch->type = ARCH_TYPE_GFX12;
+	arch->num_xcc = GFX12_NUM_XCC;
+	arch->num_se = GFX12_NUM_SE;
+	arch->num_sa = GFX12_NUM_SA;
+	arch->num_cu = GFX12_NUM_CU;
+	arch->num_wgp_per_sa = GFX12_NUM_WGP_PER_SA;
+	arch->command = NULL; /* Will be allocated as needed */
 
-    /* Initialize block map */
-    memset(&arch->block_map, 0, sizeof(block_info_map_t));
+	/* Initialize block map */
+	memset(&arch->block_map, 0, sizeof(block_info_map_t));
 
-    /* Create and add block info entries */
-    block_info_t* cpc_block = create_gfx12_cpc_block();
-    block_info_t* sq_block = create_gfx12_sq_block();
-    block_info_t* grbm_block = create_gfx12_grbm_block();
-    block_info_t* gl2c_block = create_gfx12_gl2c_block();
-    block_info_t* spi_block = create_gfx12_spi_block();
-    block_info_t* ta_block = create_gfx12_ta_block();
-    block_info_t* tcp_block = create_gfx12_tcp_block();
-    block_info_t* td_block = create_gfx12_td_block();
-    block_info_t* tcc_block = create_gfx12_tcc_block();
-    block_info_t* sx_block = create_gfx12_sx_block();
-    block_info_t* db_block = create_gfx12_db_block();
-    block_info_t* pa_sc_block = create_gfx12_pa_sc_block();
-    block_info_t* pa_su_block = create_gfx12_pa_su_block();
-    block_info_t* gds_block = create_gfx12_gds_block();
+	/* Create and add block info entries */
+	block_info_t *cpc_block = create_gfx12_cpc_block();
+	block_info_t *sq_block = create_gfx12_sq_block();
+	block_info_t *grbm_block = create_gfx12_grbm_block();
+	block_info_t *gl2c_block = create_gfx12_gl2c_block();
+	block_info_t *spi_block = create_gfx12_spi_block();
+	block_info_t *ta_block = create_gfx12_ta_block();
+	block_info_t *tcp_block = create_gfx12_tcp_block();
+	block_info_t *td_block = create_gfx12_td_block();
+	block_info_t *tcc_block = create_gfx12_tcc_block();
+	block_info_t *sx_block = create_gfx12_sx_block();
+	block_info_t *db_block = create_gfx12_db_block();
+	block_info_t *pa_sc_block = create_gfx12_pa_sc_block();
+	block_info_t *pa_su_block = create_gfx12_pa_su_block();
+	block_info_t *gds_block = create_gfx12_gds_block();
 
-    if (!cpc_block || !sq_block || !grbm_block || !gl2c_block || !spi_block || !ta_block || !tcp_block || !td_block || !tcc_block || !sx_block || !db_block || !pa_sc_block || !pa_su_block || !gds_block) {
-        FREE(arch);
-        if (cpc_block) {
-            FREE(cpc_block->dimensions);
-            FREE(cpc_block->counter_reg_info);
-            FREE(cpc_block);
-        }
-        if (sq_block) {
-            FREE(sq_block->dimensions);
-            FREE(sq_block->counter_reg_info);
-            FREE(sq_block);
-        }
-        if (grbm_block) {
-            FREE(grbm_block->dimensions);
-            FREE(grbm_block->counter_reg_info);
-            FREE(grbm_block);
-        }
-        if (gl2c_block) {
-            FREE(gl2c_block->dimensions);
-            FREE(gl2c_block->counter_reg_info);
-            FREE(gl2c_block);
-        }
-        if (spi_block) {
-            FREE(spi_block->dimensions);
-            FREE(spi_block->counter_reg_info);
-            FREE(spi_block);
-        }
-        if (ta_block) {
-            FREE(ta_block->dimensions);
-            FREE(ta_block->counter_reg_info);
-            FREE(ta_block);
-        }
-        if (tcp_block) {
-            FREE(tcp_block->dimensions);
-            FREE(tcp_block->counter_reg_info);
-            FREE(tcp_block);
-        }
-        if (td_block) {
-            FREE(td_block->dimensions);
-            FREE(td_block->counter_reg_info);
-            FREE(td_block);
-        }
-        if (tcc_block) {
-            FREE(tcc_block->dimensions);
-            FREE(tcc_block->counter_reg_info);
-            FREE(tcc_block);
-        }
-        if (sx_block) {
-            FREE(sx_block->dimensions);
-            FREE(sx_block->counter_reg_info);
-            FREE(sx_block);
-        }
-        if (db_block) {
-            FREE(db_block->dimensions);
-            FREE(db_block->counter_reg_info);
-            FREE(db_block);
-        }
-        if (pa_sc_block) {
-            FREE(pa_sc_block->dimensions);
-            FREE(pa_sc_block->counter_reg_info);
-            FREE(pa_sc_block);
-        }
-        if (pa_su_block) {
-            FREE(pa_su_block->dimensions);
-            FREE(pa_su_block->counter_reg_info);
-            FREE(pa_su_block);
-        }
-        if (gds_block) {
-            FREE(gds_block->dimensions);
-            FREE(gds_block->counter_reg_info);
-            FREE(gds_block);
-        }
-        return NULL;
-    }
+	if (!cpc_block || !sq_block || !grbm_block || !gl2c_block || !spi_block || !ta_block ||
+	    !tcp_block || !td_block || !tcc_block || !sx_block || !db_block || !pa_sc_block ||
+	    !pa_su_block || !gds_block) {
+		FREE(arch);
+		if (cpc_block) {
+			FREE(cpc_block->dimensions);
+			FREE(cpc_block->counter_reg_info);
+			FREE(cpc_block);
+		}
+		if (sq_block) {
+			FREE(sq_block->dimensions);
+			FREE(sq_block->counter_reg_info);
+			FREE(sq_block);
+		}
+		if (grbm_block) {
+			FREE(grbm_block->dimensions);
+			FREE(grbm_block->counter_reg_info);
+			FREE(grbm_block);
+		}
+		if (gl2c_block) {
+			FREE(gl2c_block->dimensions);
+			FREE(gl2c_block->counter_reg_info);
+			FREE(gl2c_block);
+		}
+		if (spi_block) {
+			FREE(spi_block->dimensions);
+			FREE(spi_block->counter_reg_info);
+			FREE(spi_block);
+		}
+		if (ta_block) {
+			FREE(ta_block->dimensions);
+			FREE(ta_block->counter_reg_info);
+			FREE(ta_block);
+		}
+		if (tcp_block) {
+			FREE(tcp_block->dimensions);
+			FREE(tcp_block->counter_reg_info);
+			FREE(tcp_block);
+		}
+		if (td_block) {
+			FREE(td_block->dimensions);
+			FREE(td_block->counter_reg_info);
+			FREE(td_block);
+		}
+		if (tcc_block) {
+			FREE(tcc_block->dimensions);
+			FREE(tcc_block->counter_reg_info);
+			FREE(tcc_block);
+		}
+		if (sx_block) {
+			FREE(sx_block->dimensions);
+			FREE(sx_block->counter_reg_info);
+			FREE(sx_block);
+		}
+		if (db_block) {
+			FREE(db_block->dimensions);
+			FREE(db_block->counter_reg_info);
+			FREE(db_block);
+		}
+		if (pa_sc_block) {
+			FREE(pa_sc_block->dimensions);
+			FREE(pa_sc_block->counter_reg_info);
+			FREE(pa_sc_block);
+		}
+		if (pa_su_block) {
+			FREE(pa_su_block->dimensions);
+			FREE(pa_su_block->counter_reg_info);
+			FREE(pa_su_block);
+		}
+		if (gds_block) {
+			FREE(gds_block->dimensions);
+			FREE(gds_block->counter_reg_info);
+			FREE(gds_block);
+		}
+		return NULL;
+	}
 
-    /* Add blocks to the map */
-    arch->block_map.blocks[HW_IP_BLOCK_CPC] = cpc_block;
-    arch->block_map.blocks[HW_IP_BLOCK_SQ] = sq_block;
-    arch->block_map.blocks[HW_IP_BLOCK_GRBM] = grbm_block;
-    arch->block_map.blocks[HW_IP_BLOCK_GL2C] = gl2c_block;
-    arch->block_map.blocks[HW_IP_BLOCK_SPI] = spi_block;
-    arch->block_map.blocks[HW_IP_BLOCK_TA] = ta_block;
-    arch->block_map.blocks[HW_IP_BLOCK_TCP] = tcp_block;
-    arch->block_map.blocks[HW_IP_BLOCK_TD] = td_block;
-    arch->block_map.blocks[HW_IP_BLOCK_TCC] = tcc_block;
-    arch->block_map.blocks[HW_IP_BLOCK_SX] = sx_block;
-    arch->block_map.blocks[HW_IP_BLOCK_DB] = db_block;
-    arch->block_map.blocks[HW_IP_BLOCK_PA_SC] = pa_sc_block;
-    arch->block_map.blocks[HW_IP_BLOCK_PA_SU] = pa_su_block;
-    arch->block_map.blocks[HW_IP_BLOCK_GDS] = gds_block;
-    /* Block count must be >= highest block ID + 1
+	/* Add blocks to the map */
+	arch->block_map.blocks[HW_IP_BLOCK_CPC] = cpc_block;
+	arch->block_map.blocks[HW_IP_BLOCK_SQ] = sq_block;
+	arch->block_map.blocks[HW_IP_BLOCK_GRBM] = grbm_block;
+	arch->block_map.blocks[HW_IP_BLOCK_GL2C] = gl2c_block;
+	arch->block_map.blocks[HW_IP_BLOCK_SPI] = spi_block;
+	arch->block_map.blocks[HW_IP_BLOCK_TA] = ta_block;
+	arch->block_map.blocks[HW_IP_BLOCK_TCP] = tcp_block;
+	arch->block_map.blocks[HW_IP_BLOCK_TD] = td_block;
+	arch->block_map.blocks[HW_IP_BLOCK_TCC] = tcc_block;
+	arch->block_map.blocks[HW_IP_BLOCK_SX] = sx_block;
+	arch->block_map.blocks[HW_IP_BLOCK_DB] = db_block;
+	arch->block_map.blocks[HW_IP_BLOCK_PA_SC] = pa_sc_block;
+	arch->block_map.blocks[HW_IP_BLOCK_PA_SU] = pa_su_block;
+	arch->block_map.blocks[HW_IP_BLOCK_GDS] = gds_block;
+	/* Block count must be >= highest block ID + 1
      * Highest registered block is HW_IP_BLOCK_TCC=19, so we need at least 20
      * Using HW_IP_BLOCK_LAST allows for all possible blocks
      */
-    arch->block_map.block_count = HW_IP_BLOCK_LAST;
+	arch->block_map.block_count = HW_IP_BLOCK_LAST;
 
-    /* Initialize control registers for GFX12 */
-    arch->control_regs = (arch_control_regs_t) {
+	/* Initialize control registers for GFX12 */
+	arch->control_regs = (arch_control_regs_t) {
         .grbm_gfx_index = mmGRBM_GFX_INDEX,                    /* 49664 */
         .cp_perfmon_cntl = mmCP_PERFMON_CNTL,                  /* 55304 */
         .compute_perfcount_enable = mmCOMPUTE_PERFCOUNT_ENABLE, /* 11787 */
@@ -1608,9 +1655,9 @@ arch_t* create_gfx12_arch(void) {
         }
     };
 
-    /* Set up the event map for this architecture */
-    arch->event_map = get_gfx12_events();
-    arch->event_count = get_gfx12_event_count();
+	/* Set up the event map for this architecture */
+	arch->event_map = get_gfx12_events();
+	arch->event_count = get_gfx12_event_count();
 
-    return arch;
+	return arch;
 }

--- a/projects/perf-dkms/src/aql_c/gfx12_events.c
+++ b/projects/perf-dkms/src/aql_c/gfx12_events.c
@@ -13,49 +13,49 @@
 
 /* GFX12 architecture-specific event mappings */
 static const struct arch_event_map gfx12_events[] = {
-    /* GL2C Block Events */
-    {COUNTER_GL2C_EA_RDREQ, 140},
-    {COUNTER_GL2C_EA_RDREQ_128B, 148},
-    {COUNTER_GL2C_EA_RDREQ_32B, 146},
-    {COUNTER_GL2C_EA_RDREQ_64B, 147},
-    {COUNTER_GL2C_EA_WRREQ, 108},
-    {COUNTER_GL2C_EA_WRREQ_64B, 114},
-    {COUNTER_GL2C_EA_WRREQ_STALL, 122},
-    {COUNTER_GL2C_HIT, 41},
-    {COUNTER_GL2C_MISS, 42},
+	/* GL2C Block Events */
+	{ COUNTER_GL2C_EA_RDREQ, 140 },
+	{ COUNTER_GL2C_EA_RDREQ_128B, 148 },
+	{ COUNTER_GL2C_EA_RDREQ_32B, 146 },
+	{ COUNTER_GL2C_EA_RDREQ_64B, 147 },
+	{ COUNTER_GL2C_EA_WRREQ, 108 },
+	{ COUNTER_GL2C_EA_WRREQ_64B, 114 },
+	{ COUNTER_GL2C_EA_WRREQ_STALL, 122 },
+	{ COUNTER_GL2C_HIT, 41 },
+	{ COUNTER_GL2C_MISS, 42 },
 
-    /* SQ Block Events */
-    {COUNTER_SQC_LDS_BANK_CONFLICT, 288},
-    {COUNTER_SQC_LDS_IDX_ACTIVE, 293},
-    {COUNTER_SQ_ACCUM_PREV, 1},
-    {COUNTER_SQ_BUSY_CYCLES, 3},
-    {COUNTER_SQ_INSTS_FLAT, 44},
-    {COUNTER_SQ_INSTS_LDS, 45},
-    {COUNTER_SQ_INSTS_SALU, 46},
-    {COUNTER_SQ_INSTS_SMEM, 47},
-    {COUNTER_SQ_INSTS_TEX_LOAD, 54},
-    {COUNTER_SQ_INSTS_TEX_STORE, 55},
-    {COUNTER_SQ_INSTS_VALU, 50},
-    {COUNTER_SQ_INSTS_WAVE32, 58},
-    {COUNTER_SQ_INSTS_WAVE32_LDS, 60},
-    {COUNTER_SQ_INSTS_WAVE32_VALU, 61},
-    {COUNTER_SQ_INST_CYCLES_VMEM, 102},
-    {COUNTER_SQ_INST_LEVEL_LDS, 75},
-    {COUNTER_SQ_WAIT_ANY, 27},
-    {COUNTER_SQ_WAIT_INST_ANY, 26},
-    {COUNTER_SQ_WAVE32_INSTS, 70},
-    {COUNTER_SQ_WAVE64_INSTS, 71},
-    {COUNTER_SQ_WAVES, 4},
-    {COUNTER_SQ_WAVE_CYCLES, 24},
+	/* SQ Block Events */
+	{ COUNTER_SQC_LDS_BANK_CONFLICT, 288 },
+	{ COUNTER_SQC_LDS_IDX_ACTIVE, 293 },
+	{ COUNTER_SQ_ACCUM_PREV, 1 },
+	{ COUNTER_SQ_BUSY_CYCLES, 3 },
+	{ COUNTER_SQ_INSTS_FLAT, 44 },
+	{ COUNTER_SQ_INSTS_LDS, 45 },
+	{ COUNTER_SQ_INSTS_SALU, 46 },
+	{ COUNTER_SQ_INSTS_SMEM, 47 },
+	{ COUNTER_SQ_INSTS_TEX_LOAD, 54 },
+	{ COUNTER_SQ_INSTS_TEX_STORE, 55 },
+	{ COUNTER_SQ_INSTS_VALU, 50 },
+	{ COUNTER_SQ_INSTS_WAVE32, 58 },
+	{ COUNTER_SQ_INSTS_WAVE32_LDS, 60 },
+	{ COUNTER_SQ_INSTS_WAVE32_VALU, 61 },
+	{ COUNTER_SQ_INST_CYCLES_VMEM, 102 },
+	{ COUNTER_SQ_INST_LEVEL_LDS, 75 },
+	{ COUNTER_SQ_WAIT_ANY, 27 },
+	{ COUNTER_SQ_WAIT_INST_ANY, 26 },
+	{ COUNTER_SQ_WAVE32_INSTS, 70 },
+	{ COUNTER_SQ_WAVE64_INSTS, 71 },
+	{ COUNTER_SQ_WAVES, 4 },
+	{ COUNTER_SQ_WAVE_CYCLES, 24 },
 
-    /* TA Block Events */
-    {COUNTER_TA_BUFFER_LOAD_WAVEFRONTS, 45},
-    {COUNTER_TA_BUFFER_STORE_WAVEFRONTS, 46},
-    {COUNTER_TA_TA_BUSY, 15},
+	/* TA Block Events */
+	{ COUNTER_TA_BUFFER_LOAD_WAVEFRONTS, 45 },
+	{ COUNTER_TA_BUFFER_STORE_WAVEFRONTS, 46 },
+	{ COUNTER_TA_TA_BUSY, 15 },
 
-    /* GRBM Block Events */
-    {COUNTER_GRBM_COUNT, 0},
-    {COUNTER_GRBM_GUI_ACTIVE, 2},
+	/* GRBM Block Events */
+	{ COUNTER_GRBM_COUNT, 0 },
+	{ COUNTER_GRBM_GUI_ACTIVE, 2 },
 };
 
 #define GFX12_EVENT_COUNT (sizeof(gfx12_events) / sizeof(struct arch_event_map))
@@ -124,8 +124,9 @@ _Static_assert(2 <= EVENT_ID_MAX, "GRBM_GUI_ACTIVE event ID exceeds limit");
  * @note Array is valid for the lifetime of the program
  * @see get_gfx12_event_count(), lookup_event_id() in counter_registry.c
  */
-const struct arch_event_map* get_gfx12_events(void) {
-    return gfx12_events;
+const struct arch_event_map *get_gfx12_events(void)
+{
+	return gfx12_events;
 }
 
 /**
@@ -138,6 +139,7 @@ const struct arch_event_map* get_gfx12_events(void) {
  *
  * @see get_gfx12_events()
  */
-size_t get_gfx12_event_count(void) {
-    return GFX12_EVENT_COUNT;
+size_t get_gfx12_event_count(void)
+{
+	return GFX12_EVENT_COUNT;
 }

--- a/projects/perf-dkms/src/aql_c/gfx12_events.h
+++ b/projects/perf-dkms/src/aql_c/gfx12_events.h
@@ -16,7 +16,7 @@
  * @return Pointer to const array of arch_event_map structures
  * @see get_gfx12_event_count()
  */
-const struct arch_event_map* get_gfx12_events(void);
+const struct arch_event_map *get_gfx12_events(void);
 
 /**
  * @brief Get the number of GFX12 event mappings

--- a/projects/perf-dkms/src/aql_c/packet_generation.c
+++ b/projects/perf-dkms/src/aql_c/packet_generation.c
@@ -14,10 +14,10 @@
 #include <stdio.h>
 #endif
 
-#define VALIDATE_BLOCK_ID(arch, counter) \
-    (((counter)->block_id >= HW_IP_BLOCK_LAST) || \
-     ((counter)->block_id > (arch)->block_map.block_count) || \
-     (!(arch)->block_map.blocks[(counter)->block_id]))
+#define VALIDATE_BLOCK_ID(arch, counter)                          \
+	(((counter)->block_id >= HW_IP_BLOCK_LAST) ||             \
+	 ((counter)->block_id > (arch)->block_map.block_count) || \
+	 (!(arch)->block_map.blocks[(counter)->block_id]))
 
 /**
  * @brief Generate CS partial flush packet to synchronize compute shader execution
@@ -39,14 +39,14 @@
  * @see pm4_append_event_write(), GpuPmcBuilder::Start in
  *      projects/aqlprofile/src/pm4/pmc_builder.h:240
  */
-int generate_cs_partial_flush(pm4_buffer_t *buffer, const arch_t *arch) {
-  if (!buffer || !arch) {
-    return -EINVAL;
-  }
+int generate_cs_partial_flush(pm4_buffer_t *buffer, const arch_t *arch)
+{
+	if (!buffer || !arch) {
+		return -EINVAL;
+	}
 
-  return pm4_append_event_write(buffer,
-                                arch->control_regs.cs_partial_flush_event,
-                                arch->control_regs.event_index_flush);
+	return pm4_append_event_write(buffer, arch->control_regs.cs_partial_flush_event,
+				      arch->control_regs.event_index_flush);
 }
 
 /**
@@ -68,12 +68,13 @@ int generate_cs_partial_flush(pm4_buffer_t *buffer, const arch_t *arch) {
  * @see pm4_grbm_broadcast(), GpuPmcBuilder::SetGrbmBroadcast in
  *      projects/aqlprofile/src/pm4/pmc_builder.h:191
  */
-int generate_grbm_broadcast(pm4_buffer_t *buffer, const arch_t *arch) {
-  if (!buffer || !arch) {
-    return -EINVAL;
-  }
+int generate_grbm_broadcast(pm4_buffer_t *buffer, const arch_t *arch)
+{
+	if (!buffer || !arch) {
+		return -EINVAL;
+	}
 
-  return pm4_grbm_broadcast(buffer, arch->control_regs.grbm_gfx_index);
+	return pm4_grbm_broadcast(buffer, arch->control_regs.grbm_gfx_index);
 }
 
 /**
@@ -98,21 +99,20 @@ int generate_grbm_broadcast(pm4_buffer_t *buffer, const arch_t *arch) {
  * @see pm4_perfcount_enable(), GpuPmcBuilder::SetPerfmonCntl in
  *      projects/aqlprofile/src/pm4/pmc_builder.h:195
  */
-int generate_perfmon_enable(pm4_buffer_t *buffer, const arch_t *arch,
-                            uint8_t enable_state, bool sample_enable) {
-  if (!buffer || !arch) {
-    return -EINVAL;
-  }
+int generate_perfmon_enable(pm4_buffer_t *buffer, const arch_t *arch, uint8_t enable_state,
+			    bool sample_enable)
+{
+	if (!buffer || !arch) {
+		return -EINVAL;
+	}
 
-  /* Build perfmon control value */
-  uint32_t perfmon_value = enable_state & 0xF; /* perfmon_state in bits 0-3 */
-  if (sample_enable) {
-    perfmon_value |=
-        (1U << arch->control_regs.perfmon_states.perfmon_sample_bit);
-  }
+	/* Build perfmon control value */
+	uint32_t perfmon_value = enable_state & 0xF; /* perfmon_state in bits 0-3 */
+	if (sample_enable) {
+		perfmon_value |= (1U << arch->control_regs.perfmon_states.perfmon_sample_bit);
+	}
 
-  return pm4_perfcount_enable(buffer, arch->control_regs.cp_perfmon_cntl,
-                              perfmon_value);
+	return pm4_perfcount_enable(buffer, arch->control_regs.cp_perfmon_cntl, perfmon_value);
 }
 
 /**
@@ -135,270 +135,265 @@ int generate_perfmon_enable(pm4_buffer_t *buffer, const arch_t *arch,
  * @see generate_start_packet(), GpuPmcBuilder::Start in
  *      projects/aqlprofile/src/pm4/pmc_builder.h:284
  */
-int generate_counter_config(pm4_buffer_t *buffer, const arch_t *arch,
-                            const counter_info_t *counter) {
-  int ret;
+int generate_counter_config(pm4_buffer_t *buffer, const arch_t *arch, const counter_info_t *counter)
+{
+	int ret;
 
-  if (!buffer || !arch || !counter) {
-    return -EINVAL;
-  }
+	if (!buffer || !arch || !counter) {
+		return -EINVAL;
+	}
 
-  /* Get block info for this counter */
-  if (VALIDATE_BLOCK_ID(arch, counter)) {
-    return -ENOENT; /* Block not found */
-  }
+	/* Get block info for this counter */
+	if (VALIDATE_BLOCK_ID(arch, counter)) {
+		return -ENOENT; /* Block not found */
+	}
 
-  block_info_t *block = arch->block_map.blocks[counter->block_id];
-  /* Validate counter index */
-  if (counter->counter_index >= block->counter_count) {
-    return -EINVAL; /* Counter index out of range */
-  }
+	block_info_t *block = arch->block_map.blocks[counter->block_id];
+	/* Validate counter index */
+	if (counter->counter_index >= block->counter_count) {
+		return -EINVAL; /* Counter index out of range */
+	}
 
-  /* Get register info for this counter */
-  counter_reg_info_t *reg_info =
-      &block->counter_reg_info[counter->counter_index];
+	/* Get register info for this counter */
+	counter_reg_info_t *reg_info = &block->counter_reg_info[counter->counter_index];
 
-  /* Write counter select register */
-  uint32_t select_value = counter->event_id & 0x1FF; /* 9-bit event ID */
-  ret = pm4_append_set_uconfig_reg(
-      buffer, reg_info->select_addr,
-      select_value);
-  if (ret < 0) {
-    return ret;
-  }
+	/* Write counter select register */
+	uint32_t select_value = counter->event_id & 0x1FF; /* 9-bit event ID */
+	ret = pm4_append_set_uconfig_reg(buffer, reg_info->select_addr, select_value);
+	if (ret < 0) {
+		return ret;
+	}
 
-  /* Write counter control register if present */
-  if (reg_info->control_addr != 0) {
-    uint32_t control_value = 0;
+	/* Write counter control register if present */
+	if (reg_info->control_addr != 0) {
+		uint32_t control_value = 0;
 
-    /* For SQ counters, enable all shader stages */
-    if (counter->block_id == HW_IP_BLOCK_SQ) {
-      control_value |=
-          (1U << arch->control_regs.counter_control_bits.sq_ps_en_bit); /* PS */
-      control_value |=
-          (1U << arch->control_regs.counter_control_bits.sq_gs_en_bit); /* GS */
-      control_value |=
-          (1U << arch->control_regs.counter_control_bits.sq_hs_en_bit); /* HS */
-      control_value |=
-          (1U << arch->control_regs.counter_control_bits.sq_cs_en_bit); /* CS */
-    }
+		/* For SQ counters, enable all shader stages */
+		if (counter->block_id == HW_IP_BLOCK_SQ) {
+			control_value |=
+				(1U
+				 << arch->control_regs.counter_control_bits.sq_ps_en_bit); /* PS */
+			control_value |=
+				(1U
+				 << arch->control_regs.counter_control_bits.sq_gs_en_bit); /* GS */
+			control_value |=
+				(1U
+				 << arch->control_regs.counter_control_bits.sq_hs_en_bit); /* HS */
+			control_value |=
+				(1U
+				 << arch->control_regs.counter_control_bits.sq_cs_en_bit); /* CS */
+		}
 
-    ret = pm4_append_set_uconfig_reg(
-        buffer, reg_info->control_addr,
-        control_value);
-    if (ret < 0) {
-      return ret;
-    }
-  }
+		ret = pm4_append_set_uconfig_reg(buffer, reg_info->control_addr, control_value);
+		if (ret < 0) {
+			return ret;
+		}
+	}
 
-  return 0;
+	return 0;
 }
 
 /* Generate PM4 packet sequence to start performance counters */
 int generate_start_packet(pm4_buffer_t *buffer, const arch_t *arch,
-                          const counter_collection_t *collection) {
-  int ret;
+			  const counter_collection_t *collection)
+{
+	int ret;
 
-  if (!buffer || !arch || !collection || !collection->counters) {
-    return -EINVAL;
-  }
+	if (!buffer || !arch || !collection || !collection->counters) {
+		return -EINVAL;
+	}
 
-  /* 1. CS partial flush */
-  ret = generate_cs_partial_flush(buffer, arch);
-  if (ret < 0)
-    return ret;
+	/* 1. CS partial flush */
+	ret = generate_cs_partial_flush(buffer, arch);
+	if (ret < 0)
+		return ret;
 
-  /* 2. GRBM broadcast mode */
-  ret = generate_grbm_broadcast(buffer, arch);
-  if (ret < 0)
-    return ret;
+	/* 2. GRBM broadcast mode */
+	ret = generate_grbm_broadcast(buffer, arch);
+	if (ret < 0)
+		return ret;
 
-  /* 3. Disable perfmon initially */
-  ret = generate_perfmon_enable(
-      buffer, arch, arch->control_regs.perfmon_states.perfmon_state_disable,
-      false);
-  if (ret < 0)
-    return ret;
+	/* 3. Disable perfmon initially */
+	ret = generate_perfmon_enable(
+		buffer, arch, arch->control_regs.perfmon_states.perfmon_state_disable, false);
+	if (ret < 0)
+		return ret;
 
-  /* 4. Enable SQ control for SQ counters (force_en=1, vmid_en=0xFFFF) */
-  bool has_sq_counters = false;
-  for (size_t i = 0; i < collection->counter_count; i++) {
-    if (collection->counters[i].block_id == HW_IP_BLOCK_SQ) {
-      has_sq_counters = true;
-      break;
-    }
-  }
+	/* 4. Enable SQ control for SQ counters (force_en=1, vmid_en=0xFFFF) */
+	bool has_sq_counters = false;
+	for (size_t i = 0; i < collection->counter_count; i++) {
+		if (collection->counters[i].block_id == HW_IP_BLOCK_SQ) {
+			has_sq_counters = true;
+			break;
+		}
+	}
 
-  if (has_sq_counters) {
-    uint32_t sq_ctrl2_value =
-        (1U << 0) | (0xFFFFU << 1); /* force_en | vmid_en */
-    ret = pm4_append_set_uconfig_reg(
-        buffer,
-        arch->control_regs.sq_perfcounter_ctrl2, /* mmSQ_PERFCOUNTER_CTRL2 */
-        sq_ctrl2_value);
-    if (ret < 0)
-      return ret;
+	if (has_sq_counters) {
+		uint32_t sq_ctrl2_value = (1U << 0) | (0xFFFFU << 1); /* force_en | vmid_en */
+		ret = pm4_append_set_uconfig_reg(
+			buffer,
+			arch->control_regs.sq_perfcounter_ctrl2, /* mmSQ_PERFCOUNTER_CTRL2 */
+			sq_ctrl2_value);
+		if (ret < 0)
+			return ret;
 
-    /* Reset GRBM_GFX_INDEX to broadcast before configuring counters */
-    ret = generate_grbm_broadcast(buffer, arch);
-    if (ret < 0)
-      return ret;
-  }
+		/* Reset GRBM_GFX_INDEX to broadcast before configuring counters */
+		ret = generate_grbm_broadcast(buffer, arch);
+		if (ret < 0)
+			return ret;
+	}
 
-  /* 5. Configure each counter */
-  for (size_t i = 0; i < collection->counter_count; i++) {
-    counter_info_t *counter = &collection->counters[i];
+	/* 5. Configure each counter */
+	for (size_t i = 0; i < collection->counter_count; i++) {
+		counter_info_t *counter = &collection->counters[i];
 
-    /* GL2C and TCC counters need per-instance configuration instead of broadcast.
+		/* GL2C and TCC counters need per-instance configuration instead of broadcast.
      * Other blocks (SQ, GRBM, TA) work correctly with broadcast mode. */
-    bool needs_per_instance_config = (counter->block_id == HW_IP_BLOCK_GL2C ||
-                                      counter->block_id == HW_IP_BLOCK_TCC);
+		bool needs_per_instance_config = (counter->block_id == HW_IP_BLOCK_GL2C ||
+						  counter->block_id == HW_IP_BLOCK_TCC);
 
-    if (needs_per_instance_config) {
-      /* Get block info to determine number of instances */
-      block_info_t *block = arch->block_map.blocks[counter->block_id];
-      uint32_t num_instances = block->instance_count;
+		if (needs_per_instance_config) {
+			/* Get block info to determine number of instances */
+			block_info_t *block = arch->block_map.blocks[counter->block_id];
+			uint32_t num_instances = block->instance_count;
 
-      /* Configure each instance separately */
-      for (uint32_t instance = 0; instance < num_instances; instance++) {
-        /* Set GRBM_GFX_INDEX to select this specific instance */
-        uint32_t grbm_value = 0xa0000000u | instance;
-        ret = pm4_append_set_uconfig_reg(buffer, arch->control_regs.grbm_gfx_index, grbm_value);
-        if (ret < 0)
-          return ret;
+			/* Configure each instance separately */
+			for (uint32_t instance = 0; instance < num_instances; instance++) {
+				/* Set GRBM_GFX_INDEX to select this specific instance */
+				uint32_t grbm_value = 0xa0000000u | instance;
+				ret = pm4_append_set_uconfig_reg(
+					buffer, arch->control_regs.grbm_gfx_index, grbm_value);
+				if (ret < 0)
+					return ret;
 
-        /* Configure the counter for this instance */
-        ret = generate_counter_config(buffer, arch, counter);
-        if (ret < 0)
-          return ret;
-      }
+				/* Configure the counter for this instance */
+				ret = generate_counter_config(buffer, arch, counter);
+				if (ret < 0)
+					return ret;
+			}
 
-      /* Reset to broadcast mode after per-instance config */
-      ret = generate_grbm_broadcast(buffer, arch);
-      if (ret < 0)
-        return ret;
+			/* Reset to broadcast mode after per-instance config */
+			ret = generate_grbm_broadcast(buffer, arch);
+			if (ret < 0)
+				return ret;
 
-    } else {
-      /* Other blocks: Configure once in broadcast mode (already set) */
-      ret = generate_counter_config(buffer, arch, counter);
-      if (ret < 0)
-        return ret;
-    }
-  }
+		} else {
+			/* Other blocks: Configure once in broadcast mode (already set) */
+			ret = generate_counter_config(buffer, arch, counter);
+			if (ret < 0)
+				return ret;
+		}
+	}
 
-  /* 6. GRBM broadcast again */
-  ret = generate_grbm_broadcast(buffer, arch);
-  if (ret < 0)
-    return ret;
+	/* 6. GRBM broadcast again */
+	ret = generate_grbm_broadcast(buffer, arch);
+	if (ret < 0)
+		return ret;
 
-  /* 7. Enable compute perfcount */
-  ret = pm4_append_write_sh_reg(buffer,
-                                arch->control_regs.compute_perfcount_enable,
-                                0x1, /* enable */
-                                0, 0);
-  if (ret < 0)
-    return ret;
+	/* 7. Enable compute perfcount */
+	ret = pm4_append_write_sh_reg(buffer, arch->control_regs.compute_perfcount_enable,
+				      0x1, /* enable */
+				      0, 0);
+	if (ret < 0)
+		return ret;
 
-  /* 8. Enable perfmon (disable first, then enable) */
-  ret = generate_perfmon_enable(
-      buffer, arch, arch->control_regs.perfmon_states.perfmon_state_disable,
-      false);
-  if (ret < 0)
-    return ret;
+	/* 8. Enable perfmon (disable first, then enable) */
+	ret = generate_perfmon_enable(
+		buffer, arch, arch->control_regs.perfmon_states.perfmon_state_disable, false);
+	if (ret < 0)
+		return ret;
 
-  ret = generate_perfmon_enable(
-      buffer, arch, arch->control_regs.perfmon_states.perfmon_state_enable,
-      false);
-  if (ret < 0)
-    return ret;
+	ret = generate_perfmon_enable(
+		buffer, arch, arch->control_regs.perfmon_states.perfmon_state_enable, false);
+	if (ret < 0)
+		return ret;
 
-  /* 9. Final CS partial flush */
-  ret = generate_cs_partial_flush(buffer, arch);
-  if (ret < 0)
-    return ret;
+	/* 9. Final CS partial flush */
+	ret = generate_cs_partial_flush(buffer, arch);
+	if (ret < 0)
+		return ret;
 
-  return 0;
+	return 0;
 }
 
 /* Generate PM4 packet sequence to read performance counters */
 int generate_read_packet(pm4_buffer_t *buffer, const arch_t *arch,
-                         const counter_collection_t *collection) {
-  int ret;
-  uint64_t current_addr;
+			 const counter_collection_t *collection)
+{
+	int ret;
+	uint64_t current_addr;
 
-  if (!buffer || !arch || !collection || !collection->counters) {
-    return -EINVAL;
-  }
+	if (!buffer || !arch || !collection || !collection->counters) {
+		return -EINVAL;
+	}
 
-  /* 1. Enable perfmon with sampling */
-  ret = generate_perfmon_enable(
-      buffer, arch, arch->control_regs.perfmon_states.perfmon_state_enable,
-      true); /* enable sampling */
-  if (ret < 0)
-    return ret;
+	/* 1. Enable perfmon with sampling */
+	ret = generate_perfmon_enable(buffer, arch,
+				      arch->control_regs.perfmon_states.perfmon_state_enable,
+				      true); /* enable sampling */
+	if (ret < 0)
+		return ret;
 
-  /* 2. GRBM broadcast mode */
-  ret = generate_grbm_broadcast(buffer, arch);
-  if (ret < 0)
-    return ret;
+	/* 2. GRBM broadcast mode */
+	ret = generate_grbm_broadcast(buffer, arch);
+	if (ret < 0)
+		return ret;
 
-  /* 3. CS partial flush */
-  ret = generate_cs_partial_flush(buffer, arch);
-  if (ret < 0)
-    return ret;
+	/* 3. CS partial flush */
+	ret = generate_cs_partial_flush(buffer, arch);
+	if (ret < 0)
+		return ret;
 
-  /* 4. Read counters from all topology locations */
-  current_addr = collection->gpu_memory_addr;
+	/* 4. Read counters from all topology locations */
+	current_addr = collection->gpu_memory_addr;
 
-  for (size_t counter_idx = 0; counter_idx < collection->counter_count;
-       counter_idx++) {
-    counter_info_t *counter = &collection->counters[counter_idx];
-    block_info_t *block = arch->block_map.blocks[counter->block_id];
+	for (size_t counter_idx = 0; counter_idx < collection->counter_count; counter_idx++) {
+		counter_info_t *counter = &collection->counters[counter_idx];
+		block_info_t *block = arch->block_map.blocks[counter->block_id];
 
-    if (!block) {
-      return -ENOENT;
-    }
+		if (!block) {
+			return -ENOENT;
+		}
 
-    /* Reset to broadcast mode for each counter
+		/* Reset to broadcast mode for each counter
      * Skip for multi-instance global blocks (GL2C, TCC) - they handle broadcast per-instance */
-    bool is_multi_instance_global = (counter->block_id == HW_IP_BLOCK_GL2C ||
-                                      counter->block_id == HW_IP_BLOCK_TCC);
+		bool is_multi_instance_global = (counter->block_id == HW_IP_BLOCK_GL2C ||
+						 counter->block_id == HW_IP_BLOCK_TCC);
 
-    if (!is_multi_instance_global) {
-      ret = generate_grbm_broadcast(buffer, arch);
-      if (ret < 0)
-        return ret;
-    }
+		if (!is_multi_instance_global) {
+			ret = generate_grbm_broadcast(buffer, arch);
+			if (ret < 0)
+				return ret;
+		}
 
-    /* Get register info */
-    counter_reg_info_t *reg_info =
-        &block->counter_reg_info[counter->counter_index];
+		/* Get register info */
+		counter_reg_info_t *reg_info = &block->counter_reg_info[counter->counter_index];
 
-    /*
+		/*
      * Always iterate through GPU topology based on block dimensions.
      * This reads all instances; software filtering will select specific
      * dimensions if needed.
      */
-    bool has_se_dimension = false;
-    uint32_t num_se = arch->num_se;
-    uint32_t num_sa = arch->num_sa;
-    uint32_t num_wgp = arch->num_wgp_per_sa;
+		bool has_se_dimension = false;
+		uint32_t num_se = arch->num_se;
+		uint32_t num_sa = arch->num_sa;
+		uint32_t num_wgp = arch->num_wgp_per_sa;
 
-    /* Extract dimension sizes from block dimensions */
-    for (size_t dim_idx = 0; dim_idx < block->dimension_count; dim_idx++) {
-      dimension_t *dim = &block->dimensions[dim_idx];
-      if (dim->dim == HARDWARE_DIM_SE) {
-        num_se = dim->size;
-        has_se_dimension = true;
-      } else if (dim->dim == HARDWARE_DIM_SA) {
-        num_sa = dim->size;
-      } else if (dim->dim == HARDWARE_DIM_WGP) {
-        num_wgp = dim->size;
-      }
-    }
+		/* Extract dimension sizes from block dimensions */
+		for (size_t dim_idx = 0; dim_idx < block->dimension_count; dim_idx++) {
+			dimension_t *dim = &block->dimensions[dim_idx];
+			if (dim->dim == HARDWARE_DIM_SE) {
+				num_se = dim->size;
+				has_se_dimension = true;
+			} else if (dim->dim == HARDWARE_DIM_SA) {
+				num_sa = dim->size;
+			} else if (dim->dim == HARDWARE_DIM_WGP) {
+				num_wgp = dim->size;
+			}
+		}
 
-    if (has_se_dimension) {
-      /*
+		if (has_se_dimension) {
+			/*
        * SE-dependent block - iterate through SE x SA x WGP using block-specific dimensions.
        *
        * Read Strategy Rationale:
@@ -425,44 +420,48 @@ int generate_read_packet(pm4_buffer_t *buffer, const arch_t *arch,
        * Software filtering in aql_perf_measurement_read() handles dimension-specific
        * requests by indexing into the results array using encode_dimension_index().
        */
-      for (uint32_t se = 0; se < num_se; se++) {
-        for (uint32_t sa = 0; sa < num_sa; sa++) {
-          for (uint32_t wgp = 0; wgp < num_wgp; wgp++) {
-            /* Set GRBM index for specific location */
-            ret =
-                pm4_set_grbm_index(buffer, arch->control_regs.grbm_gfx_index,
-                                   wgp, /* instance_index - will be shifted in pm4_set_grbm_index */
-                                   sa, se);
-            if (ret < 0)
-              return ret;
+			for (uint32_t se = 0; se < num_se; se++) {
+				for (uint32_t sa = 0; sa < num_sa; sa++) {
+					for (uint32_t wgp = 0; wgp < num_wgp; wgp++) {
+						/* Set GRBM index for specific location */
+						ret = pm4_set_grbm_index(
+							buffer, arch->control_regs.grbm_gfx_index,
+							wgp, /* instance_index - will be shifted in pm4_set_grbm_index */
+							sa, se);
+						if (ret < 0)
+							return ret;
 
-            /* Copy counter data to memory */
-            pm4_copy_data_flags_t flags = {
-                .bits = {.src_sel = 0,      /* Non-priv registers */
-                         .dst_sel = 2,      /* TC_L2 memory */
-                         .src_temporal = 3, /* LU cache policy */
-                         .dst_temporal = 3, /* LU cache policy */
-                         .count_sel = 0,    /* 32-bit data */
-                         .wr_confirm = 0}};
+						/* Copy counter data to memory */
+						pm4_copy_data_flags_t flags = {
+							.bits = { .src_sel =
+									  0, /* Non-priv registers */
+								  .dst_sel = 2, /* TC_L2 memory */
+								  .src_temporal =
+									  3, /* LU cache policy */
+								  .dst_temporal =
+									  3, /* LU cache policy */
+								  .count_sel = 0, /* 32-bit data */
+								  .wr_confirm = 0 }
+						};
 
-            ret = pm4_append_copy_data(
-                buffer, flags, reg_info->register_addr_lo,
-                reg_info->register_addr_hi, current_addr);
-            if (ret < 0)
-              return ret;
+						ret = pm4_append_copy_data(
+							buffer, flags, reg_info->register_addr_lo,
+							reg_info->register_addr_hi, current_addr);
+						if (ret < 0)
+							return ret;
 
-            current_addr += 8; /* 64-bit counter value */
-          }
-        }
-      }
-    } else {
-      /* No SE dimension found - global block
+						current_addr += 8; /* 64-bit counter value */
+					}
+				}
+			}
+		} else {
+			/* No SE dimension found - global block
        * Check if block has multiple instances (e.g., GL2C has 16 instances, TCC has 16)
        */
-      uint32_t num_instances = block->instance_count;
+			uint32_t num_instances = block->instance_count;
 
-      if (num_instances > 1) {
-        /* Multi-instance global block - iterate through each instance
+			if (num_instances > 1) {
+				/* Multi-instance global block - iterate through each instance
          *
          * This handles blocks like GL2C and TCC which have multiple hardware instances
          * that must be read separately. Each instance is selected by setting the
@@ -474,35 +473,37 @@ int generate_read_packet(pm4_buffer_t *buffer, const arch_t *arch,
          *   }
          */
 
-        /* GL2C and TCC blocks require separate LO+HI reads like GRBM.
+				/* GL2C and TCC blocks require separate LO+HI reads like GRBM.
          * Our register addresses already include BASE_IDX adjustments, so we can
          * use them directly in COPY_DATA packets.
          */
-        bool is_split_read_block = (counter->block_id == HW_IP_BLOCK_GL2C ||
-                                     counter->block_id == HW_IP_BLOCK_TCC);
+				bool is_split_read_block = (counter->block_id == HW_IP_BLOCK_GL2C ||
+							    counter->block_id == HW_IP_BLOCK_TCC);
 
-        for (uint32_t instance = 0; instance < num_instances; instance++) {
-          /* GL2C requires a broadcast->instance toggle sequence per rocprofv3.
+				for (uint32_t instance = 0; instance < num_instances; instance++) {
+					/* GL2C requires a broadcast->instance toggle sequence per rocprofv3.
            * Reset to broadcast mode first, then set the specific instance.
            * This ensures the GPU properly routes subsequent operations to the correct instance. */
-          ret = generate_grbm_broadcast(buffer, arch);
-          if (ret < 0)
-            return ret;
+					ret = generate_grbm_broadcast(buffer, arch);
+					if (ret < 0)
+						return ret;
 
-          /* Set GRBM index to select specific instance
+					/* Set GRBM index to select specific instance
            * GRBM_GFX_INDEX format for instance selection:
            * - INSTANCE_INDEX = instance number (bits 0-7)
            * - SE_BROADCAST_WRITES = 1 (broadcast to all SEs, bit 30)
            * - SA_BROADCAST_WRITES = 1 (broadcast to all SAs, bit 29)
            * Value = 0xa0000000 | instance
            */
-          uint32_t grbm_value = 0xa0000000u | instance;
-          ret = pm4_append_set_uconfig_reg(buffer, arch->control_regs.grbm_gfx_index, grbm_value);
-          if (ret < 0)
-            return ret;
+					uint32_t grbm_value = 0xa0000000u | instance;
+					ret = pm4_append_set_uconfig_reg(
+						buffer, arch->control_regs.grbm_gfx_index,
+						grbm_value);
+					if (ret < 0)
+						return ret;
 
-          if (is_split_read_block) {
-            /* GL2C/TCC: Read LO and HI separately as 32-bit values
+					if (is_split_read_block) {
+						/* GL2C/TCC: Read LO and HI separately as 32-bit values
              *
              * GL2C and TCC counters must be read as separate 32-bit LO/HI operations
              * instead of combined 64-bit reads. This matches aqlprofile's implementation
@@ -516,52 +517,61 @@ int generate_read_packet(pm4_buffer_t *buffer, const arch_t *arch,
              * so we subtract UCONFIG_SPACE_START (0xc000) to get the packet register field.
              */
 
-            pm4_copy_data_flags_t flags = {
-                .bits = {.src_sel = 0,      /* Non-priv registers */
-                         .dst_sel = 2,      /* TC_L2 memory */
-                         .src_temporal = 3, /* LU cache policy */
-                         .dst_temporal = 3, /* LU cache policy */
-                         .count_sel = 0,    /* 32-bit data */
-                         .wr_confirm = 0}};
+						pm4_copy_data_flags_t flags = {
+							.bits = { .src_sel =
+									  0, /* Non-priv registers */
+								  .dst_sel = 2, /* TC_L2 memory */
+								  .src_temporal =
+									  3, /* LU cache policy */
+								  .dst_temporal =
+									  3, /* LU cache policy */
+								  .count_sel = 0, /* 32-bit data */
+								  .wr_confirm = 0 }
+						};
 
-            /* COPY_DATA expects absolute UCONFIG addresses, not offsets.
+						/* COPY_DATA expects absolute UCONFIG addresses, not offsets.
              * GL2C register definitions are already absolute (e.g., 0xd380), so use them directly. */
-            uint32_t reg_lo = reg_info->register_addr_lo;
-            uint32_t reg_hi = reg_info->register_addr_hi;
+						uint32_t reg_lo = reg_info->register_addr_lo;
+						uint32_t reg_hi = reg_info->register_addr_hi;
 
-            /* Read LO register (32-bit) */
-            ret = pm4_append_copy_data(buffer, flags, reg_lo,
-                                       0, current_addr);
-            if (ret < 0)
-              return ret;
-            current_addr += 4; /* 32-bit value */
+						/* Read LO register (32-bit) */
+						ret = pm4_append_copy_data(buffer, flags, reg_lo, 0,
+									   current_addr);
+						if (ret < 0)
+							return ret;
+						current_addr += 4; /* 32-bit value */
 
-            /* Read HI register (32-bit) */
-            ret = pm4_append_copy_data(buffer, flags, reg_hi,
-                                       0, current_addr);
-            if (ret < 0)
-              return ret;
-            current_addr += 4; /* 32-bit value */
-          } else {
-            /* Other multi-instance blocks: Combined 64-bit read */
-            pm4_copy_data_flags_t flags = {
-                .bits = {.src_sel = 0,      /* Non-priv registers */
-                         .dst_sel = 2,      /* TC_L2 memory */
-                         .src_temporal = 3, /* LU cache policy */
-                         .dst_temporal = 3, /* LU cache policy */
-                         .count_sel = 0,    /* 32-bit data */
-                         .wr_confirm = 0}};
+						/* Read HI register (32-bit) */
+						ret = pm4_append_copy_data(buffer, flags, reg_hi, 0,
+									   current_addr);
+						if (ret < 0)
+							return ret;
+						current_addr += 4; /* 32-bit value */
+					} else {
+						/* Other multi-instance blocks: Combined 64-bit read */
+						pm4_copy_data_flags_t flags = {
+							.bits = { .src_sel =
+									  0, /* Non-priv registers */
+								  .dst_sel = 2, /* TC_L2 memory */
+								  .src_temporal =
+									  3, /* LU cache policy */
+								  .dst_temporal =
+									  3, /* LU cache policy */
+								  .count_sel = 0, /* 32-bit data */
+								  .wr_confirm = 0 }
+						};
 
-            ret = pm4_append_copy_data(buffer, flags, reg_info->register_addr_lo,
-                                       reg_info->register_addr_hi, current_addr);
-            if (ret < 0)
-              return ret;
+						ret = pm4_append_copy_data(
+							buffer, flags, reg_info->register_addr_lo,
+							reg_info->register_addr_hi, current_addr);
+						if (ret < 0)
+							return ret;
 
-            current_addr += 8; /* 64-bit counter value */
-          }
-        }
-      } else {
-        /* Single-instance global block - read once
+						current_addr += 8; /* 64-bit counter value */
+					}
+				}
+			} else {
+				/* Single-instance global block - read once
          *
          * Special case for GRBM: Read LO and HI as separate 32-bit COPY_DATA packets
          * instead of one combined 64-bit read. This matches aqlprofile's implementation
@@ -570,8 +580,8 @@ int generate_read_packet(pm4_buffer_t *buffer, const arch_t *arch,
          * Reference: aqlprofile pmc_builder.h ReadXccPackets() - GRBM counters are read
          * with two separate BuildCopyCounterDataPacket() calls for LO and HI registers.
          */
-        if (counter->block_id == HW_IP_BLOCK_GRBM) {
-          /* GRBM: Read LO and HI separately as 32-bit values
+				if (counter->block_id == HW_IP_BLOCK_GRBM) {
+					/* GRBM: Read LO and HI separately as 32-bit values
            *
            * GRBM register addresses in gfx12_creator.c are already absolute UCONFIG
            * addresses (e.g., 0xd040 for GRBM_PERFCOUNTER0_LO). No runtime adjustment
@@ -579,171 +589,176 @@ int generate_read_packet(pm4_buffer_t *buffer, const arch_t *arch,
            *
            * This matches how aqlprofile handles GRBM registers on GFX12.
            */
-          pm4_copy_data_flags_t flags = {
-              .bits = {.src_sel = 0,      /* Non-priv registers */
-                       .dst_sel = 2,      /* TC_L2 memory */
-                       .src_temporal = 3, /* LU cache policy */
-                       .dst_temporal = 3, /* LU cache policy */
-                       .count_sel = 0,    /* 32-bit data */
-                       .wr_confirm = 0}};
+					pm4_copy_data_flags_t flags = {
+						.bits = { .src_sel = 0, /* Non-priv registers */
+							  .dst_sel = 2, /* TC_L2 memory */
+							  .src_temporal = 3, /* LU cache policy */
+							  .dst_temporal = 3, /* LU cache policy */
+							  .count_sel = 0, /* 32-bit data */
+							  .wr_confirm = 0 }
+					};
 
-          /* Read LO register (32-bit) - use absolute address directly */
-          ret = pm4_append_copy_data(buffer, flags, reg_info->register_addr_lo,
-                                     0, current_addr);
-          if (ret < 0)
-            return ret;
-          current_addr += 4; /* 32-bit value */
+					/* Read LO register (32-bit) - use absolute address directly */
+					ret = pm4_append_copy_data(buffer, flags,
+								   reg_info->register_addr_lo, 0,
+								   current_addr);
+					if (ret < 0)
+						return ret;
+					current_addr += 4; /* 32-bit value */
 
-          /* Read HI register (32-bit) - use absolute address directly */
-          ret = pm4_append_copy_data(buffer, flags, reg_info->register_addr_hi,
-                                     0, current_addr);
-          if (ret < 0)
-            return ret;
-          current_addr += 4; /* 32-bit value */
-        } else {
-          /* Normal global block: Read LO+HI as one 64-bit value */
-          pm4_copy_data_flags_t flags = {
-              .bits = {.src_sel = 0,      /* Non-priv registers */
-                       .dst_sel = 2,      /* TC_L2 memory */
-                       .src_temporal = 3, /* LU cache policy */
-                       .dst_temporal = 3, /* LU cache policy */
-                       .count_sel = 0,    /* 32-bit data */
-                       .wr_confirm = 0}};
+					/* Read HI register (32-bit) - use absolute address directly */
+					ret = pm4_append_copy_data(buffer, flags,
+								   reg_info->register_addr_hi, 0,
+								   current_addr);
+					if (ret < 0)
+						return ret;
+					current_addr += 4; /* 32-bit value */
+				} else {
+					/* Normal global block: Read LO+HI as one 64-bit value */
+					pm4_copy_data_flags_t flags = {
+						.bits = { .src_sel = 0, /* Non-priv registers */
+							  .dst_sel = 2, /* TC_L2 memory */
+							  .src_temporal = 3, /* LU cache policy */
+							  .dst_temporal = 3, /* LU cache policy */
+							  .count_sel = 0, /* 32-bit data */
+							  .wr_confirm = 0 }
+					};
 
-          ret = pm4_append_copy_data(buffer, flags, reg_info->register_addr_lo,
-                                     reg_info->register_addr_hi, current_addr);
-          if (ret < 0)
-            return ret;
+					ret = pm4_append_copy_data(buffer, flags,
+								   reg_info->register_addr_lo,
+								   reg_info->register_addr_hi,
+								   current_addr);
+					if (ret < 0)
+						return ret;
 
-          current_addr += 8; /* 64-bit counter value */
-        }
-      }
-    }
-  }
+					current_addr += 8; /* 64-bit counter value */
+				}
+			}
+		}
+	}
 
-  /* 5. Restore broadcast mode */
-  ret = generate_grbm_broadcast(buffer, arch);
-  if (ret < 0)
-    return ret;
+	/* 5. Restore broadcast mode */
+	ret = generate_grbm_broadcast(buffer, arch);
+	if (ret < 0)
+		return ret;
 
-  /* 6. Cache coherency flush */
-  ret = pm4_append_acquire_mem(buffer, collection->gpu_memory_addr,
-                               collection->memory_size,
-                               arch->control_regs.gcr_cntl_default);
-  if (ret < 0)
-    return ret;
+	/* 6. Cache coherency flush */
+	ret = pm4_append_acquire_mem(buffer, collection->gpu_memory_addr, collection->memory_size,
+				     arch->control_regs.gcr_cntl_default);
+	if (ret < 0)
+		return ret;
 
-  return 0;
+	return 0;
 }
 
 /* Generate PM4 packet sequence to stop performance counters */
-int generate_stop_packet(pm4_buffer_t *buffer, const arch_t *arch) {
-  int ret;
+int generate_stop_packet(pm4_buffer_t *buffer, const arch_t *arch)
+{
+	int ret;
 
-  if (!buffer || !arch) {
-    return -EINVAL;
-  }
+	if (!buffer || !arch) {
+		return -EINVAL;
+	}
 
-  /* 1. GRBM broadcast mode */
-  ret = generate_grbm_broadcast(buffer, arch);
-  if (ret < 0)
-    return ret;
+	/* 1. GRBM broadcast mode */
+	ret = generate_grbm_broadcast(buffer, arch);
+	if (ret < 0)
+		return ret;
 
-  /* 2. Set perfmon state to stop with sampling enabled */
-  ret = generate_perfmon_enable(
-      buffer, arch, arch->control_regs.perfmon_states.perfmon_state_stop,
-      false);
-  if (ret < 0)
-    return ret;
+	/* 2. Set perfmon state to stop with sampling enabled */
+	ret = generate_perfmon_enable(buffer, arch,
+				      arch->control_regs.perfmon_states.perfmon_state_stop, false);
+	if (ret < 0)
+		return ret;
 
-  /* 3. CS partial flush */
-  ret = generate_cs_partial_flush(buffer, arch);
-  if (ret < 0)
-    return ret;
+	/* 3. CS partial flush */
+	ret = generate_cs_partial_flush(buffer, arch);
+	if (ret < 0)
+		return ret;
 
-  return 0;
+	return 0;
 }
 
 /* Calculate total memory size needed for counter data collection */
-size_t calculate_counter_memory_size(const arch_t *arch,
-                                     const counter_collection_t *collection) {
-  if (!arch || !collection || !collection->counters) {
-    return 0;
-  }
+size_t calculate_counter_memory_size(const arch_t *arch, const counter_collection_t *collection)
+{
+	if (!arch || !collection || !collection->counters) {
+		return 0;
+	}
 
-  size_t total_size = 0;
+	size_t total_size = 0;
 
-  for (size_t i = 0; i < collection->counter_count; i++) {
-    counter_info_t *counter = &collection->counters[i];
-    block_info_t *block = arch->block_map.blocks[counter->block_id];
+	for (size_t i = 0; i < collection->counter_count; i++) {
+		counter_info_t *counter = &collection->counters[i];
+		block_info_t *block = arch->block_map.blocks[counter->block_id];
 
-    if (!block) {
-      continue; /* Skip invalid blocks */
-    }
+		if (!block) {
+			continue; /* Skip invalid blocks */
+		}
 
-    size_t counter_size = 8; /* Base 64-bit counter size */
+		size_t counter_size = 8; /* Base 64-bit counter size */
 
-    /* Check if block has SE/SA/WGP dimensions */
-    bool has_se_dimension = false;
-    for (size_t dim_idx = 0; dim_idx < block->dimension_count; dim_idx++) {
-      dimension_t *dim = &block->dimensions[dim_idx];
-      if (dim->dim == HARDWARE_DIM_SE) {
-        has_se_dimension = true;
-      }
-      /* Multiply by topology dimensions - use block-specific dimension sizes */
-      counter_size *= dim->size;
-    }
+		/* Check if block has SE/SA/WGP dimensions */
+		bool has_se_dimension = false;
+		for (size_t dim_idx = 0; dim_idx < block->dimension_count; dim_idx++) {
+			dimension_t *dim = &block->dimensions[dim_idx];
+			if (dim->dim == HARDWARE_DIM_SE) {
+				has_se_dimension = true;
+			}
+			/* Multiply by topology dimensions - use block-specific dimension sizes */
+			counter_size *= dim->size;
+		}
 
-    /* For global blocks (no SE dimension) with multiple instances,
+		/* For global blocks (no SE dimension) with multiple instances,
      * multiply by instance count to allocate space for all instances.
      * This handles blocks like GL2C (16 instances) and TCC (16 instances).
      */
-    if (!has_se_dimension && block->instance_count > 1) {
-      counter_size *= block->instance_count;
-    }
+		if (!has_se_dimension && block->instance_count > 1) {
+			counter_size *= block->instance_count;
+		}
 
-    total_size += counter_size;
-  }
+		total_size += counter_size;
+	}
 
-  return total_size;
+	return total_size;
 }
 
 /* Validate counter collection configuration */
-int validate_counter_collection(const arch_t *arch,
-                                const counter_collection_t *collection) {
-  if (!arch || !collection || !collection->counters) {
-    return -EINVAL;
-  }
+int validate_counter_collection(const arch_t *arch, const counter_collection_t *collection)
+{
+	if (!arch || !collection || !collection->counters) {
+		return -EINVAL;
+	}
 
-  if (collection->counter_count == 0) {
-    return -EINVAL;
-  }
+	if (collection->counter_count == 0) {
+		return -EINVAL;
+	}
 
-  /* Check each counter */
-  for (size_t i = 0; i < collection->counter_count; i++) {
-    counter_info_t *counter = &collection->counters[i];
+	/* Check each counter */
+	for (size_t i = 0; i < collection->counter_count; i++) {
+		counter_info_t *counter = &collection->counters[i];
 
-    /* Validate block ID */
-    if (VALIDATE_BLOCK_ID(arch, counter)) {
-      return -EINVAL;
-    }
+		/* Validate block ID */
+		if (VALIDATE_BLOCK_ID(arch, counter)) {
+			return -EINVAL;
+		}
 
-    /* Check if block exists in architecture */
-    block_info_t *block = arch->block_map.blocks[counter->block_id];
-    if (!block) {
-      return -ENOENT;
-    }
+		/* Check if block exists in architecture */
+		block_info_t *block = arch->block_map.blocks[counter->block_id];
+		if (!block) {
+			return -ENOENT;
+		}
 
-    /* Validate counter index */
-    if (counter->counter_index >= block->counter_count) {
-      return -EINVAL;
-    }
+		/* Validate counter index */
+		if (counter->counter_index >= block->counter_count) {
+			return -EINVAL;
+		}
 
-    /* Validate event ID */
-    if (counter->event_id > block->event_id_max) {
-      return -EINVAL;
-    }
-  }
+		/* Validate event ID */
+		if (counter->event_id > block->event_id_max) {
+			return -EINVAL;
+		}
+	}
 
-  return 0;
+	return 0;
 }

--- a/projects/perf-dkms/src/aql_c/packet_generation.h
+++ b/projects/perf-dkms/src/aql_c/packet_generation.h
@@ -31,10 +31,10 @@
  * projects/aqlprofile/src/pm4/pmc_builder.h:64-69
  */
 typedef struct {
-    hardware_ip_block_t block_id;      /* Which hardware block (SQ, CPC, etc.) */
-    uint32_t event_id;                 /* Event ID to monitor */
-    uint32_t counter_index;            /* Which counter in the block (0-7 for SQ) */
-    const char* name;                  /* Optional counter name for debugging */
+	hardware_ip_block_t block_id; /* Which hardware block (SQ, CPC, etc.) */
+	uint32_t event_id; /* Event ID to monitor */
+	uint32_t counter_index; /* Which counter in the block (0-7 for SQ) */
+	const char *name; /* Optional counter name for debugging */
 } counter_info_t;
 
 /**
@@ -48,10 +48,10 @@ typedef struct {
  * projects/aqlprofile/src/core/aql_profile.cpp
  */
 typedef struct {
-    counter_info_t* counters;          /* Array of counters to collect */
-    size_t counter_count;              /* Number of counters in array */
-    uint64_t gpu_memory_addr;          /* GPU address for counter data results */
-    size_t memory_size;                /* Size of allocated memory in bytes */
+	counter_info_t *counters; /* Array of counters to collect */
+	size_t counter_count; /* Number of counters in array */
+	uint64_t gpu_memory_addr; /* GPU address for counter data results */
+	size_t memory_size; /* Size of allocated memory in bytes */
 } counter_collection_t;
 
 /**
@@ -72,9 +72,8 @@ typedef struct {
  * @param collection Counter collection context
  * @return 0 on success, negative error code on failure
  */
-int generate_start_packet(pm4_buffer_t *buffer,
-                         const arch_t *arch,
-                         const counter_collection_t *collection);
+int generate_start_packet(pm4_buffer_t *buffer, const arch_t *arch,
+			  const counter_collection_t *collection);
 
 /**
  * Generate PM4 packet sequence to read performance counters
@@ -93,9 +92,8 @@ int generate_start_packet(pm4_buffer_t *buffer,
  * @param collection Counter collection context
  * @return 0 on success, negative error code on failure
  */
-int generate_read_packet(pm4_buffer_t *buffer,
-                        const arch_t *arch,
-                        const counter_collection_t *collection);
+int generate_read_packet(pm4_buffer_t *buffer, const arch_t *arch,
+			 const counter_collection_t *collection);
 
 /**
  * Generate PM4 packet sequence to stop performance counters
@@ -109,8 +107,7 @@ int generate_read_packet(pm4_buffer_t *buffer,
  * @param arch Architecture information with control registers
  * @return 0 on success, negative error code on failure
  */
-int generate_stop_packet(pm4_buffer_t *buffer,
-                        const arch_t *arch);
+int generate_stop_packet(pm4_buffer_t *buffer, const arch_t *arch);
 
 /**
  * Calculate total memory size needed for counter data collection
@@ -124,8 +121,7 @@ int generate_stop_packet(pm4_buffer_t *buffer,
  * @param collection Counter collection context
  * @return Total memory size in bytes, 0 on error
  */
-size_t calculate_counter_memory_size(const arch_t *arch,
-                                   const counter_collection_t *collection);
+size_t calculate_counter_memory_size(const arch_t *arch, const counter_collection_t *collection);
 
 /**
  * Helper function: Generate CS partial flush packet
@@ -151,10 +147,8 @@ int generate_grbm_broadcast(pm4_buffer_t *buffer, const arch_t *arch);
  * @param sample_enable Whether to enable sampling (boolean)
  * @return 0 on success, negative on error
  */
-int generate_perfmon_enable(pm4_buffer_t *buffer,
-                           const arch_t *arch,
-                           uint8_t enable_state,
-                           bool sample_enable);
+int generate_perfmon_enable(pm4_buffer_t *buffer, const arch_t *arch, uint8_t enable_state,
+			    bool sample_enable);
 
 /**
  * Helper function: Configure counter selection and control registers
@@ -163,9 +157,8 @@ int generate_perfmon_enable(pm4_buffer_t *buffer,
  * @param counter Counter to configure
  * @return 0 on success, negative on error
  */
-int generate_counter_config(pm4_buffer_t *buffer,
-                           const arch_t *arch,
-                           const counter_info_t *counter);
+int generate_counter_config(pm4_buffer_t *buffer, const arch_t *arch,
+			    const counter_info_t *counter);
 
 /**
  * Validate counter collection configuration
@@ -173,7 +166,6 @@ int generate_counter_config(pm4_buffer_t *buffer,
  * @param collection Counter collection to validate
  * @return 0 if valid, negative error code otherwise
  */
-int validate_counter_collection(const arch_t *arch,
-                               const counter_collection_t *collection);
+int validate_counter_collection(const arch_t *arch, const counter_collection_t *collection);
 
 #endif /* PACKET_GENERATION_H */

--- a/projects/perf-dkms/src/aql_c/pm4_packets.c
+++ b/projects/perf-dkms/src/aql_c/pm4_packets.c
@@ -39,45 +39,45 @@
  * @see pm4_buffer_destroy(), CmdBuffer in projects/aqlprofile/src/pm4/cmd_builder.h:90
  */
 #ifdef __KERNEL__
-pm4_buffer_t* pm4_buffer_create(size_t initial_capacity, gfp_t flags)
+pm4_buffer_t *pm4_buffer_create(size_t initial_capacity, gfp_t flags)
 #else
-pm4_buffer_t* pm4_buffer_create(size_t initial_capacity)
+pm4_buffer_t *pm4_buffer_create(size_t initial_capacity)
 #endif
 {
-    pm4_buffer_t *buffer;
+	pm4_buffer_t *buffer;
 
-    if (initial_capacity == 0) {
-        initial_capacity = 256;  /* Default 256 DWORDs = 1KB */
-    }
+	if (initial_capacity == 0) {
+		initial_capacity = 256; /* Default 256 DWORDs = 1KB */
+	}
 
 #ifdef __KERNEL__
-    buffer = kmalloc(sizeof(pm4_buffer_t), flags);
-    if (!buffer)
-        return NULL;
+	buffer = kmalloc(sizeof(pm4_buffer_t), flags);
+	if (!buffer)
+		return NULL;
 
-    buffer->data = kmalloc(initial_capacity * sizeof(uint32_t), flags);
-    buffer->gfp_flags = flags;
+	buffer->data = kmalloc(initial_capacity * sizeof(uint32_t), flags);
+	buffer->gfp_flags = flags;
 #else
-    buffer = malloc(sizeof(pm4_buffer_t));
-    if (!buffer)
-        return NULL;
+	buffer = malloc(sizeof(pm4_buffer_t));
+	if (!buffer)
+		return NULL;
 
-    buffer->data = malloc(initial_capacity * sizeof(uint32_t));
+	buffer->data = malloc(initial_capacity * sizeof(uint32_t));
 #endif
 
-    if (!buffer->data) {
+	if (!buffer->data) {
 #ifdef __KERNEL__
-        kfree(buffer);
+		kfree(buffer);
 #else
-        free(buffer);
+		free(buffer);
 #endif
-        return NULL;
-    }
+		return NULL;
+	}
 
-    buffer->capacity = initial_capacity;
-    buffer->size = 0;
+	buffer->capacity = initial_capacity;
+	buffer->size = 0;
 
-    return buffer;
+	return buffer;
 }
 
 /**
@@ -97,21 +97,21 @@ pm4_buffer_t* pm4_buffer_create(size_t initial_capacity)
  */
 void pm4_buffer_destroy(pm4_buffer_t *buffer)
 {
-    if (!buffer)
-        return;
+	if (!buffer)
+		return;
 
-    if (buffer->data) {
+	if (buffer->data) {
 #ifdef __KERNEL__
-        kfree(buffer->data);
+		kfree(buffer->data);
 #else
-        free(buffer->data);
+		free(buffer->data);
 #endif
-    }
+	}
 
 #ifdef __KERNEL__
-    kfree(buffer);
+	kfree(buffer);
 #else
-    free(buffer);
+	free(buffer);
 #endif
 }
 
@@ -131,11 +131,11 @@ void pm4_buffer_destroy(pm4_buffer_t *buffer)
  */
 int pm4_buffer_reset(pm4_buffer_t *buffer)
 {
-    if (!buffer)
-        return -1;
+	if (!buffer)
+		return -1;
 
-    buffer->size = 0;
-    return 0;
+	buffer->size = 0;
+	return 0;
 }
 
 /**
@@ -157,34 +157,34 @@ int pm4_buffer_reset(pm4_buffer_t *buffer)
  */
 int pm4_buffer_ensure_capacity(pm4_buffer_t *buffer, size_t required_dwords)
 {
-    size_t new_capacity;
-    uint32_t *new_data;
+	size_t new_capacity;
+	uint32_t *new_data;
 
-    if (!buffer)
-        return -1;
+	if (!buffer)
+		return -1;
 
-    if (buffer->size + required_dwords <= buffer->capacity)
-        return 0;  /* Already have enough space */
+	if (buffer->size + required_dwords <= buffer->capacity)
+		return 0; /* Already have enough space */
 
-    /* Double capacity or add required amount, whichever is larger */
-    new_capacity = buffer->capacity * 2;
-    if (new_capacity < buffer->size + required_dwords) {
-        new_capacity = buffer->size + required_dwords + 256;  /* Add some extra */
-    }
+	/* Double capacity or add required amount, whichever is larger */
+	new_capacity = buffer->capacity * 2;
+	if (new_capacity < buffer->size + required_dwords) {
+		new_capacity = buffer->size + required_dwords + 256; /* Add some extra */
+	}
 
 #ifdef __KERNEL__
-    new_data = krealloc(buffer->data, new_capacity * sizeof(uint32_t), buffer->gfp_flags);
+	new_data = krealloc(buffer->data, new_capacity * sizeof(uint32_t), buffer->gfp_flags);
 #else
-    new_data = realloc(buffer->data, new_capacity * sizeof(uint32_t));
+	new_data = realloc(buffer->data, new_capacity * sizeof(uint32_t));
 #endif
 
-    if (!new_data)
-        return -1;  /* Failed to allocate */
+	if (!new_data)
+		return -1; /* Failed to allocate */
 
-    buffer->data = new_data;
-    buffer->capacity = new_capacity;
+	buffer->data = new_data;
+	buffer->capacity = new_capacity;
 
-    return 0;
+	return 0;
 }
 
 /**
@@ -193,9 +193,9 @@ int pm4_buffer_ensure_capacity(pm4_buffer_t *buffer, size_t required_dwords)
  * @param buffer Pointer to PM4 buffer
  * @return Pointer to data array, or NULL if buffer is NULL
  */
-uint32_t* pm4_buffer_get_data(pm4_buffer_t *buffer)
+uint32_t *pm4_buffer_get_data(pm4_buffer_t *buffer)
 {
-    return buffer ? buffer->data : NULL;
+	return buffer ? buffer->data : NULL;
 }
 
 /**
@@ -206,7 +206,7 @@ uint32_t* pm4_buffer_get_data(pm4_buffer_t *buffer)
  */
 size_t pm4_buffer_get_size(pm4_buffer_t *buffer)
 {
-    return buffer ? buffer->size : 0;
+	return buffer ? buffer->size : 0;
 }
 
 /**
@@ -217,7 +217,7 @@ size_t pm4_buffer_get_size(pm4_buffer_t *buffer)
  */
 size_t pm4_buffer_get_size_bytes(pm4_buffer_t *buffer)
 {
-    return buffer ? buffer->size * sizeof(uint32_t) : 0;
+	return buffer ? buffer->size * sizeof(uint32_t) : 0;
 }
 
 /**
@@ -233,16 +233,16 @@ size_t pm4_buffer_get_size_bytes(pm4_buffer_t *buffer)
  */
 static int pm4_buffer_append(pm4_buffer_t *buffer, const uint32_t *data, size_t count)
 {
-    if (!buffer || !data)
-        return -1;
+	if (!buffer || !data)
+		return -1;
 
-    if (pm4_buffer_ensure_capacity(buffer, count) < 0)
-        return -1;
+	if (pm4_buffer_ensure_capacity(buffer, count) < 0)
+		return -1;
 
-    memcpy(&buffer->data[buffer->size], data, count * sizeof(uint32_t));
-    buffer->size += count;
+	memcpy(&buffer->data[buffer->size], data, count * sizeof(uint32_t));
+	buffer->size += count;
 
-    return 0;
+	return 0;
 }
 
 /* PM4 packet builder implementations */
@@ -267,25 +267,23 @@ static int pm4_buffer_append(pm4_buffer_t *buffer, const uint32_t *data, size_t 
  * @see pm4_append_write_sh_reg(), Gfx12CmdBuilder::BuildWriteUConfigRegPacket in
  *      projects/aqlprofile/src/pm4/gfx12_cmd_builder.h:185
  */
-int pm4_append_set_uconfig_reg(pm4_buffer_t *buffer,
-                                uint32_t reg_offset,
-                                uint32_t value)
+int pm4_append_set_uconfig_reg(pm4_buffer_t *buffer, uint32_t reg_offset, uint32_t value)
 {
-    uint32_t packet[3];
-    uint16_t offset;
+	uint32_t packet[3];
+	uint16_t offset;
 
-    if (!buffer)
-        return -1;
+	if (!buffer)
+		return -1;
 
-    /* Calculate register offset from UCONFIG base */
-    offset = (uint16_t)((reg_offset - UCONFIG_SPACE_START) & 0xFFFF);
+	/* Calculate register offset from UCONFIG base */
+	offset = (uint16_t)((reg_offset - UCONFIG_SPACE_START) & 0xFFFF);
 
-    /* Build packet matching aqlprofile SetUConfigReg structure */
-    packet[0] = PM4_TYPE_3_HEADER(PM4_SET_UCONFIG_REG_OPCODE, 12);  /* 3 DWORDs = 12 bytes */
-    packet[1] = offset & 0xFFFF;  /* reg_offset in lower 16 bits */
-    packet[2] = value;
+	/* Build packet matching aqlprofile SetUConfigReg structure */
+	packet[0] = PM4_TYPE_3_HEADER(PM4_SET_UCONFIG_REG_OPCODE, 12); /* 3 DWORDs = 12 bytes */
+	packet[1] = offset & 0xFFFF; /* reg_offset in lower 16 bits */
+	packet[2] = value;
 
-    return pm4_buffer_append(buffer, packet, 3);
+	return pm4_buffer_append(buffer, packet, 3);
 }
 
 /**
@@ -310,33 +308,30 @@ int pm4_append_set_uconfig_reg(pm4_buffer_t *buffer,
  * @see pm4_append_set_uconfig_reg(), Gfx12CmdBuilder::BuildWriteShRegPacket in
  *      projects/aqlprofile/src/pm4/gfx12_cmd_builder.h:173
  */
-int pm4_append_write_sh_reg(pm4_buffer_t *buffer,
-                             uint32_t reg_offset,
-                             uint32_t value,
-                             uint8_t vmid_shift,
-                             uint8_t index)
+int pm4_append_write_sh_reg(pm4_buffer_t *buffer, uint32_t reg_offset, uint32_t value,
+			    uint8_t vmid_shift, uint8_t index)
 {
-    uint32_t packet[3];
-    uint16_t offset;
-    uint32_t word1;
+	uint32_t packet[3];
+	uint16_t offset;
+	uint32_t word1;
 
-    if (!buffer)
-        return -1;
+	if (!buffer)
+		return -1;
 
-    /* Calculate register offset from PERSISTENT base */
-    offset = (uint16_t)((reg_offset - PERSISTENT_SPACE_START) & 0xFFFF);
+	/* Calculate register offset from PERSISTENT base */
+	offset = (uint16_t)((reg_offset - PERSISTENT_SPACE_START) & 0xFFFF);
 
-    /* Build word1 with bitfield layout matching Rust WriteSHRegister */
-    word1 = (offset & 0xFFFF) |           /* bits 0-15: reg_offset */
-            ((vmid_shift & 0x1F) << 23) |  /* bits 23-27: vmid_shift */
-            ((index & 0xF) << 28);          /* bits 28-31: index */
+	/* Build word1 with bitfield layout matching Rust WriteSHRegister */
+	word1 = (offset & 0xFFFF) | /* bits 0-15: reg_offset */
+		((vmid_shift & 0x1F) << 23) | /* bits 23-27: vmid_shift */
+		((index & 0xF) << 28); /* bits 28-31: index */
 
-    /* Build packet */
-    packet[0] = PM4_TYPE_3_HEADER(PM4_WRITE_SH_REG_OPCODE, 12);  /* 3 DWORDs = 12 bytes */
-    packet[1] = word1;
-    packet[2] = value;
+	/* Build packet */
+	packet[0] = PM4_TYPE_3_HEADER(PM4_WRITE_SH_REG_OPCODE, 12); /* 3 DWORDs = 12 bytes */
+	packet[1] = word1;
+	packet[2] = value;
 
-    return pm4_buffer_append(buffer, packet, 3);
+	return pm4_buffer_append(buffer, packet, 3);
 }
 
 /**
@@ -359,25 +354,23 @@ int pm4_append_write_sh_reg(pm4_buffer_t *buffer,
  * @see pm4_cs_partial_flush(), Gfx12CmdBuilder::BuildBarrierCommand in
  *      projects/aqlprofile/src/pm4/gfx12_cmd_builder.h:72
  */
-int pm4_append_event_write(pm4_buffer_t *buffer,
-                            uint32_t event_type,
-                            uint32_t event_index)
+int pm4_append_event_write(pm4_buffer_t *buffer, uint32_t event_type, uint32_t event_index)
 {
-    uint32_t packet[2];
-    pm4_barrier_event_t event = {0};
+	uint32_t packet[2];
+	pm4_barrier_event_t event = { 0 };
 
-    if (!buffer)
-        return -1;
+	if (!buffer)
+		return -1;
 
-    /* Build event structure matching Rust BarrierEvent */
-    event.bits.event_type = event_type & 0x3F;
-    event.bits.event_index = event_index & 0xF;
+	/* Build event structure matching Rust BarrierEvent */
+	event.bits.event_type = event_type & 0x3F;
+	event.bits.event_index = event_index & 0xF;
 
-    /* Build packet matching aqlprofile EventWrite */
-    packet[0] = PM4_TYPE_3_HEADER(PM4_EVENT_WRITE_OPCODE, 8);  /* 2 DWORDs = 8 bytes */
-    packet[1] = event.raw & 0xFFFF;  /* Only lower 16 bits used */
+	/* Build packet matching aqlprofile EventWrite */
+	packet[0] = PM4_TYPE_3_HEADER(PM4_EVENT_WRITE_OPCODE, 8); /* 2 DWORDs = 8 bytes */
+	packet[1] = event.raw & 0xFFFF; /* Only lower 16 bits used */
 
-    return pm4_buffer_append(buffer, packet, 2);
+	return pm4_buffer_append(buffer, packet, 2);
 }
 
 /**
@@ -401,26 +394,23 @@ int pm4_append_event_write(pm4_buffer_t *buffer,
  * @see pm4_set_grbm_index(), Gfx12CmdBuilder::BuildCopyRegDataPacket in
  *      projects/aqlprofile/src/pm4/gfx12_cmd_builder.h:227
  */
-int pm4_append_copy_data(pm4_buffer_t *buffer,
-                          pm4_copy_data_flags_t flags,
-                          uint32_t src_reg_lo,
-                          uint32_t src_reg_hi,
-                          uint64_t dst_addr)
+int pm4_append_copy_data(pm4_buffer_t *buffer, pm4_copy_data_flags_t flags, uint32_t src_reg_lo,
+			 uint32_t src_reg_hi, uint64_t dst_addr)
 {
-    uint32_t packet[6];
+	uint32_t packet[6];
 
-    if (!buffer)
-        return -1;
+	if (!buffer)
+		return -1;
 
-    /* Build packet matching aqlprofile CopyData */
-    packet[0] = PM4_TYPE_3_HEADER(PM4_COPY_DATA_OPCODE, 24);  /* 6 DWORDs = 24 bytes */
-    packet[1] = flags.raw;
-    packet[2] = src_reg_lo;
-    packet[3] = src_reg_hi;
-    packet[4] = (uint32_t)(dst_addr & 0xFFFFFFFF);
-    packet[5] = (uint32_t)(dst_addr >> 32);
+	/* Build packet matching aqlprofile CopyData */
+	packet[0] = PM4_TYPE_3_HEADER(PM4_COPY_DATA_OPCODE, 24); /* 6 DWORDs = 24 bytes */
+	packet[1] = flags.raw;
+	packet[2] = src_reg_lo;
+	packet[3] = src_reg_hi;
+	packet[4] = (uint32_t)(dst_addr & 0xFFFFFFFF);
+	packet[5] = (uint32_t)(dst_addr >> 32);
 
-    return pm4_buffer_append(buffer, packet, 6);
+	return pm4_buffer_append(buffer, packet, 6);
 }
 
 /**
@@ -445,34 +435,31 @@ int pm4_append_copy_data(pm4_buffer_t *buffer,
  * @see pm4_calculate_cache_coher_params(), Gfx12CmdBuilder::BuildCacheFlushPacket in
  *      projects/aqlprofile/src/pm4/gfx12_cmd_builder.h:92
  */
-int pm4_append_acquire_mem(pm4_buffer_t *buffer,
-                            uint64_t base_addr,
-                            uint64_t size,
-                            uint32_t gcr_cntl)
+int pm4_append_acquire_mem(pm4_buffer_t *buffer, uint64_t base_addr, uint64_t size,
+			   uint32_t gcr_cntl)
 {
-    uint32_t packet[8];
-    uint32_t coher_size_lo, coher_size_hi;
-    uint32_t coher_base_lo, coher_base_hi;
+	uint32_t packet[8];
+	uint32_t coher_size_lo, coher_size_hi;
+	uint32_t coher_base_lo, coher_base_hi;
 
-    if (!buffer)
-        return -1;
+	if (!buffer)
+		return -1;
 
-    /* Calculate coherency parameters matching Rust cache_cohere */
-    pm4_calculate_cache_coher_params(base_addr, size,
-                                      &coher_size_lo, &coher_size_hi,
-                                      &coher_base_lo, &coher_base_hi);
+	/* Calculate coherency parameters matching Rust cache_cohere */
+	pm4_calculate_cache_coher_params(base_addr, size, &coher_size_lo, &coher_size_hi,
+					 &coher_base_lo, &coher_base_hi);
 
-    /* Build packet matching aqlprofile AcquireMem */
-    packet[0] = PM4_TYPE_3_HEADER(PM4_ACQUIRE_MEM_OPCODE, 32);  /* 8 DWORDs = 32 bytes */
-    packet[1] = 0;  /* Reserved */
-    packet[2] = coher_size_lo;
-    packet[3] = coher_size_hi & 0xFF;  /* Only 8 bits for size_hi */
-    packet[4] = coher_base_lo;
-    packet[5] = coher_base_hi & 0xFFFFFF;  /* Only 24 bits for base_hi */
-    packet[6] = 0x10 & 0xFFFF;  /* poll_interval = 0x10 (poll every 4K) */
-    packet[7] = gcr_cntl & 0x7FFFF;  /* 19 bits for gcr_cntl */
+	/* Build packet matching aqlprofile AcquireMem */
+	packet[0] = PM4_TYPE_3_HEADER(PM4_ACQUIRE_MEM_OPCODE, 32); /* 8 DWORDs = 32 bytes */
+	packet[1] = 0; /* Reserved */
+	packet[2] = coher_size_lo;
+	packet[3] = coher_size_hi & 0xFF; /* Only 8 bits for size_hi */
+	packet[4] = coher_base_lo;
+	packet[5] = coher_base_hi & 0xFFFFFF; /* Only 24 bits for base_hi */
+	packet[6] = 0x10 & 0xFFFF; /* poll_interval = 0x10 (poll every 4K) */
+	packet[7] = gcr_cntl & 0x7FFFF; /* 19 bits for gcr_cntl */
 
-    return pm4_buffer_append(buffer, packet, 8);
+	return pm4_buffer_append(buffer, packet, 8);
 }
 
 /* Higher-level helper functions */
@@ -492,17 +479,17 @@ int pm4_append_acquire_mem(pm4_buffer_t *buffer,
  */
 int pm4_grbm_broadcast(pm4_buffer_t *buffer, uint32_t grbm_gfx_index_reg)
 {
-    pm4_grbm_gfx_index_t index = {0};
+	pm4_grbm_gfx_index_t index = { 0 };
 
-    /* Set broadcast mode for all units */
-    index.bits.instance_index = 0;
-    index.bits.sa_index = 0;
-    index.bits.se_index = 0;
-    index.bits.sa_broadcast_writes = 1;
-    index.bits.instance_broadcast_writes = 1;
-    index.bits.se_broadcast_writes = 1;
+	/* Set broadcast mode for all units */
+	index.bits.instance_index = 0;
+	index.bits.sa_index = 0;
+	index.bits.se_index = 0;
+	index.bits.sa_broadcast_writes = 1;
+	index.bits.instance_broadcast_writes = 1;
+	index.bits.se_broadcast_writes = 1;
 
-    return pm4_append_set_uconfig_reg(buffer, grbm_gfx_index_reg, index.raw);
+	return pm4_append_set_uconfig_reg(buffer, grbm_gfx_index_reg, index.raw);
 }
 
 /**
@@ -521,20 +508,17 @@ int pm4_grbm_broadcast(pm4_buffer_t *buffer, uint32_t grbm_gfx_index_reg)
  * @note wg_index is shifted left by 2 to match hardware expectations
  * @see pm4_grbm_broadcast()
  */
-int pm4_set_grbm_index(pm4_buffer_t *buffer,
-                        uint32_t grbm_gfx_index_reg,
-                        uint32_t wg_index,
-                        uint32_t sa_index,
-                        uint32_t se_index)
+int pm4_set_grbm_index(pm4_buffer_t *buffer, uint32_t grbm_gfx_index_reg, uint32_t wg_index,
+		       uint32_t sa_index, uint32_t se_index)
 {
-    pm4_grbm_gfx_index_t index = {0};
+	pm4_grbm_gfx_index_t index = { 0 };
 
-    /* Set specific index values matching Rust set_grbm_index */
-    index.bits.instance_index = (wg_index << 2) & 0x7F;  /* wg_index shifted by 2 */
-    index.bits.sa_index = sa_index & 0x3;
-    index.bits.se_index = se_index & 0xF;
+	/* Set specific index values matching Rust set_grbm_index */
+	index.bits.instance_index = (wg_index << 2) & 0x7F; /* wg_index shifted by 2 */
+	index.bits.sa_index = sa_index & 0x3;
+	index.bits.se_index = se_index & 0xF;
 
-    return pm4_append_set_uconfig_reg(buffer, grbm_gfx_index_reg, index.raw);
+	return pm4_append_set_uconfig_reg(buffer, grbm_gfx_index_reg, index.raw);
 }
 
 /**
@@ -550,11 +534,9 @@ int pm4_set_grbm_index(pm4_buffer_t *buffer,
  *
  * @see generate_perfmon_enable() in packet_generation.c
  */
-int pm4_perfcount_enable(pm4_buffer_t *buffer,
-                          uint32_t cp_perfmon_cntl_reg,
-                          uint32_t control_value)
+int pm4_perfcount_enable(pm4_buffer_t *buffer, uint32_t cp_perfmon_cntl_reg, uint32_t control_value)
 {
-    return pm4_append_set_uconfig_reg(buffer, cp_perfmon_cntl_reg, control_value);
+	return pm4_append_set_uconfig_reg(buffer, cp_perfmon_cntl_reg, control_value);
 }
 
 /**
@@ -570,8 +552,8 @@ int pm4_perfcount_enable(pm4_buffer_t *buffer,
  */
 int pm4_cs_partial_flush(pm4_buffer_t *buffer)
 {
-    /* Trigger CS partial flush event */
-    return pm4_append_event_write(buffer, VGT_EVENT_TYPE_CS_PARTIAL_FLUSH, 4);
+	/* Trigger CS partial flush event */
+	return pm4_append_event_write(buffer, VGT_EVENT_TYPE_CS_PARTIAL_FLUSH, 4);
 }
 
 /**
@@ -593,32 +575,29 @@ int pm4_cs_partial_flush(pm4_buffer_t *buffer)
  * @note Addresses are converted to 256-byte granularity by shifting right 8 bits
  * @see pm4_append_acquire_mem()
  */
-void pm4_calculate_cache_coher_params(uint64_t addr,
-                                       uint64_t size,
-                                       uint32_t *coher_size_lo,
-                                       uint32_t *coher_size_hi,
-                                       uint32_t *coher_base_lo,
-                                       uint32_t *coher_base_hi)
+void pm4_calculate_cache_coher_params(uint64_t addr, uint64_t size, uint32_t *coher_size_lo,
+				      uint32_t *coher_size_hi, uint32_t *coher_base_lo,
+				      uint32_t *coher_base_hi)
 {
-    uint64_t align;
-    uint64_t boundaries_crossed;
-    uint64_t ceiling;
-    uint64_t divided;
-    uint64_t coher_size;
+	uint64_t align;
+	uint64_t boundaries_crossed;
+	uint64_t ceiling;
+	uint64_t divided;
+	uint64_t coher_size;
 
-    /* Match Rust cache_cohere calculation exactly */
-    align = addr % 256;
-    boundaries_crossed = (align + size) >> 8;
-    ceiling = (size + 0xFF) >> 8;  /* Ceiling of size/256 */
-    divided = size >> 8;
+	/* Match Rust cache_cohere calculation exactly */
+	align = addr % 256;
+	boundaries_crossed = (align + size) >> 8;
+	ceiling = (size + 0xFF) >> 8; /* Ceiling of size/256 */
+	divided = size >> 8;
 
-    coher_size = boundaries_crossed + ceiling - divided;
+	coher_size = boundaries_crossed + ceiling - divided;
 
-    /* Set output parameters */
-    *coher_size_lo = (uint32_t)(coher_size & 0xFFFFFFFF);
-    *coher_size_hi = (uint32_t)(coher_size >> 32);
-    *coher_base_lo = (uint32_t)((addr >> 8) & 0xFFFFFFFF);
-    *coher_base_hi = (uint32_t)((addr >> 40) & 0xFFFFFF);
+	/* Set output parameters */
+	*coher_size_lo = (uint32_t)(coher_size & 0xFFFFFFFF);
+	*coher_size_hi = (uint32_t)(coher_size >> 32);
+	*coher_base_lo = (uint32_t)((addr >> 8) & 0xFFFFFFFF);
+	*coher_base_hi = (uint32_t)((addr >> 40) & 0xFFFFFF);
 }
 
 /* Debug/utility functions */
@@ -634,21 +613,21 @@ void pm4_calculate_cache_coher_params(uint64_t addr,
  */
 void pm4_dump_packet(const uint32_t *packet, size_t size_dwords)
 {
-    size_t i;
+	size_t i;
 
-    if (!packet || size_dwords == 0)
-        return;
+	if (!packet || size_dwords == 0)
+		return;
 
 #ifdef __KERNEL__
-    printk(KERN_INFO "PM4 Packet (%zu DWORDs):\n", size_dwords);
-    for (i = 0; i < size_dwords; i++) {
-        printk(KERN_INFO "  [%zu]: 0x%08X\n", i, packet[i]);
-    }
+	printk(KERN_INFO "PM4 Packet (%zu DWORDs):\n", size_dwords);
+	for (i = 0; i < size_dwords; i++) {
+		printk(KERN_INFO "  [%zu]: 0x%08X\n", i, packet[i]);
+	}
 #else
-    printf("PM4 Packet (%zu DWORDs):\n", size_dwords);
-    for (i = 0; i < size_dwords; i++) {
-        printf("  [%zu]: 0x%08X\n", i, packet[i]);
-    }
+	printf("PM4 Packet (%zu DWORDs):\n", size_dwords);
+	for (i = 0; i < size_dwords; i++) {
+		printf("  [%zu]: 0x%08X\n", i, packet[i]);
+	}
 #endif
 }
 
@@ -658,16 +637,22 @@ void pm4_dump_packet(const uint32_t *packet, size_t size_dwords)
  * @param opcode PM4 opcode value (from packet header bits 8-15)
  * @return String name of opcode, or "UNKNOWN" if not recognized
  */
-const char* pm4_opcode_to_string(uint8_t opcode)
+const char *pm4_opcode_to_string(uint8_t opcode)
 {
-    switch (opcode) {
-        case PM4_SET_UCONFIG_REG_OPCODE:  return "SET_UCONFIG_REG";
-        case PM4_EVENT_WRITE_OPCODE:       return "EVENT_WRITE";
-        case PM4_COPY_DATA_OPCODE:         return "COPY_DATA";
-        case PM4_ACQUIRE_MEM_OPCODE:       return "ACQUIRE_MEM";
-        case PM4_WRITE_SH_REG_OPCODE:      return "WRITE_SH_REG";
-        default:                           return "UNKNOWN";
-    }
+	switch (opcode) {
+	case PM4_SET_UCONFIG_REG_OPCODE:
+		return "SET_UCONFIG_REG";
+	case PM4_EVENT_WRITE_OPCODE:
+		return "EVENT_WRITE";
+	case PM4_COPY_DATA_OPCODE:
+		return "COPY_DATA";
+	case PM4_ACQUIRE_MEM_OPCODE:
+		return "ACQUIRE_MEM";
+	case PM4_WRITE_SH_REG_OPCODE:
+		return "WRITE_SH_REG";
+	default:
+		return "UNKNOWN";
+	}
 }
 
 /**
@@ -682,48 +667,48 @@ const char* pm4_opcode_to_string(uint8_t opcode)
  */
 int pm4_validate_packet(const uint32_t *packet, size_t size_dwords)
 {
-    uint32_t header;
-    uint8_t type;
-    uint8_t opcode;
-    uint16_t count;
-    size_t expected_size;
+	uint32_t header;
+	uint8_t type;
+	uint8_t opcode;
+	uint16_t count;
+	size_t expected_size;
 
-    if (!packet || size_dwords == 0)
-        return -1;
+	if (!packet || size_dwords == 0)
+		return -1;
 
-    header = packet[0];
-    type = (header >> 30) & 0x3;
+	header = packet[0];
+	type = (header >> 30) & 0x3;
 
-    if (type != 3) {
-        /* Not a Type 3 packet */
-        return -1;
-    }
+	if (type != 3) {
+		/* Not a Type 3 packet */
+		return -1;
+	}
 
-    opcode = (header >> 8) & 0xFF;
-    count = ((header >> 16) & 0x3FFF) + 1;  /* Count field is size-1 */
-    expected_size = count + 1;  /* +1 for header */
+	opcode = (header >> 8) & 0xFF;
+	count = ((header >> 16) & 0x3FFF) + 1; /* Count field is size-1 */
+	expected_size = count + 1; /* +1 for header */
 
-    if (expected_size != size_dwords) {
-        /* Size mismatch */
-        return -1;
-    }
+	if (expected_size != size_dwords) {
+		/* Size mismatch */
+		return -1;
+	}
 
-    /* Validate known opcodes */
-    switch (opcode) {
-        case PM4_SET_UCONFIG_REG_OPCODE:
-            return (expected_size == 3) ? 0 : -1;
-        case PM4_EVENT_WRITE_OPCODE:
-            return (expected_size == 2) ? 0 : -1;
-        case PM4_COPY_DATA_OPCODE:
-            return (expected_size == 6) ? 0 : -1;
-        case PM4_ACQUIRE_MEM_OPCODE:
-            return (expected_size == 8) ? 0 : -1;
-        case PM4_WRITE_SH_REG_OPCODE:
-            return (expected_size == 3) ? 0 : -1;
-        default:
-            /* Unknown opcode, but structure is valid */
-            return 0;
-    }
+	/* Validate known opcodes */
+	switch (opcode) {
+	case PM4_SET_UCONFIG_REG_OPCODE:
+		return (expected_size == 3) ? 0 : -1;
+	case PM4_EVENT_WRITE_OPCODE:
+		return (expected_size == 2) ? 0 : -1;
+	case PM4_COPY_DATA_OPCODE:
+		return (expected_size == 6) ? 0 : -1;
+	case PM4_ACQUIRE_MEM_OPCODE:
+		return (expected_size == 8) ? 0 : -1;
+	case PM4_WRITE_SH_REG_OPCODE:
+		return (expected_size == 3) ? 0 : -1;
+	default:
+		/* Unknown opcode, but structure is valid */
+		return 0;
+	}
 }
 
 /* pm4_op_t helper functions implementation */
@@ -740,85 +725,85 @@ int pm4_validate_packet(const uint32_t *packet, size_t size_dwords)
  *
  * @note Returns PM4_OP_INVALID if data is NULL, size is 0, or opcode is unknown
  */
-pm4_op_t pm4_op_from_buffer(const uint32_t* data, size_t size_dwords)
+pm4_op_t pm4_op_from_buffer(const uint32_t *data, size_t size_dwords)
 {
-    pm4_op_t op = {0};
-    uint32_t header;
-    uint8_t opcode;
+	pm4_op_t op = { 0 };
+	uint32_t header;
+	uint8_t opcode;
 
-    if (!data || size_dwords == 0) {
-        op.type = PM4_OP_INVALID;
-        return op;
-    }
+	if (!data || size_dwords == 0) {
+		op.type = PM4_OP_INVALID;
+		return op;
+	}
 
-    header = data[0];
-    opcode = (header >> 8) & 0xFF;
-    op.size_dwords = size_dwords;
+	header = data[0];
+	opcode = (header >> 8) & 0xFF;
+	op.size_dwords = size_dwords;
 
-    /* Determine packet type from opcode */
-    switch (opcode) {
-        case PM4_SET_UCONFIG_REG_OPCODE:
-            op.type = PM4_OP_SET_UCONFIG_REG;
-            if (size_dwords >= 3) {
-                op.packet.set_uconfig_reg.header = data[0];
-                op.packet.set_uconfig_reg.reg_offset = data[1] & 0xFFFF;
-                op.packet.set_uconfig_reg.reserved = (data[1] >> 16) & 0xFFFF;
-                op.packet.set_uconfig_reg.reg_value = data[2];
-            }
-            break;
+	/* Determine packet type from opcode */
+	switch (opcode) {
+	case PM4_SET_UCONFIG_REG_OPCODE:
+		op.type = PM4_OP_SET_UCONFIG_REG;
+		if (size_dwords >= 3) {
+			op.packet.set_uconfig_reg.header = data[0];
+			op.packet.set_uconfig_reg.reg_offset = data[1] & 0xFFFF;
+			op.packet.set_uconfig_reg.reserved = (data[1] >> 16) & 0xFFFF;
+			op.packet.set_uconfig_reg.reg_value = data[2];
+		}
+		break;
 
-        case PM4_EVENT_WRITE_OPCODE:
-            op.type = PM4_OP_EVENT_WRITE;
-            if (size_dwords >= 2) {
-                op.packet.event_write.header = data[0];
-                op.packet.event_write.event = data[1];
-            }
-            break;
+	case PM4_EVENT_WRITE_OPCODE:
+		op.type = PM4_OP_EVENT_WRITE;
+		if (size_dwords >= 2) {
+			op.packet.event_write.header = data[0];
+			op.packet.event_write.event = data[1];
+		}
+		break;
 
-        case PM4_COPY_DATA_OPCODE:
-            op.type = PM4_OP_COPY_DATA;
-            if (size_dwords >= 6) {
-                op.packet.copy_data.header = data[0];
-                op.packet.copy_data.copy_data = data[1];
-                op.packet.copy_data.src_reg_offset_lo = data[2];
-                op.packet.copy_data.src_reg_offset_hi = data[3];
-                op.packet.copy_data.dst_reg_offset_lo = data[4];
-                op.packet.copy_data.dst_reg_offset_hi = data[5];
-            }
-            break;
+	case PM4_COPY_DATA_OPCODE:
+		op.type = PM4_OP_COPY_DATA;
+		if (size_dwords >= 6) {
+			op.packet.copy_data.header = data[0];
+			op.packet.copy_data.copy_data = data[1];
+			op.packet.copy_data.src_reg_offset_lo = data[2];
+			op.packet.copy_data.src_reg_offset_hi = data[3];
+			op.packet.copy_data.dst_reg_offset_lo = data[4];
+			op.packet.copy_data.dst_reg_offset_hi = data[5];
+		}
+		break;
 
-        case PM4_ACQUIRE_MEM_OPCODE:
-            op.type = PM4_OP_FLUSH_CACHE;
-            if (size_dwords >= 8) {
-                op.packet.flush_cache.header = data[0];
-                op.packet.flush_cache.reserved = data[1];
-                op.packet.flush_cache.coher_size = data[2];
-                op.packet.flush_cache.coher_size_hi = data[3];
-                op.packet.flush_cache.coher_base_lo = data[4];
-                op.packet.flush_cache.coher_base_hi = data[5];
-                op.packet.flush_cache.poll_interval = data[6];
-                op.packet.flush_cache.gcr_cntl = data[7];
-            }
-            break;
+	case PM4_ACQUIRE_MEM_OPCODE:
+		op.type = PM4_OP_FLUSH_CACHE;
+		if (size_dwords >= 8) {
+			op.packet.flush_cache.header = data[0];
+			op.packet.flush_cache.reserved = data[1];
+			op.packet.flush_cache.coher_size = data[2];
+			op.packet.flush_cache.coher_size_hi = data[3];
+			op.packet.flush_cache.coher_base_lo = data[4];
+			op.packet.flush_cache.coher_base_hi = data[5];
+			op.packet.flush_cache.poll_interval = data[6];
+			op.packet.flush_cache.gcr_cntl = data[7];
+		}
+		break;
 
-        case PM4_WRITE_SH_REG_OPCODE:
-            op.type = PM4_OP_WRITE_SH_REG;
-            if (size_dwords >= 3) {
-                op.packet.write_sh_reg.header = data[0];
-                op.packet.write_sh_reg.word1 = data[1];
-                op.packet.write_sh_reg.reg_value = data[2];
-            }
-            break;
+	case PM4_WRITE_SH_REG_OPCODE:
+		op.type = PM4_OP_WRITE_SH_REG;
+		if (size_dwords >= 3) {
+			op.packet.write_sh_reg.header = data[0];
+			op.packet.write_sh_reg.word1 = data[1];
+			op.packet.write_sh_reg.reg_value = data[2];
+		}
+		break;
 
-        default:
-            op.type = PM4_OP_INVALID;
-            /* Copy raw data up to available space */
-            size_t copy_size = (size_dwords < 8) ? size_dwords : 8;
-            memcpy(op.packet.raw, data, copy_size * sizeof(uint32_t));
-            break;
-    }
+	default:
+		op.type = PM4_OP_INVALID;
+		/* Copy raw data up to available space */
+		size_t copy_size = (size_dwords < 8) ? size_dwords : 8;
+		memcpy(op.packet.raw, data, copy_size * sizeof(uint32_t));
+		break;
+	}
 
-    return op;
+	return op;
 }
 
 /**
@@ -832,65 +817,70 @@ pm4_op_t pm4_op_from_buffer(const uint32_t* data, size_t size_dwords)
  * @param buffer_size Size of output buffer in DWORDs
  * @return Number of DWORDs written, or -1 on error (NULL pointers or buffer too small)
  */
-int pm4_op_to_buffer(const pm4_op_t* op, uint32_t* buffer, size_t buffer_size)
+int pm4_op_to_buffer(const pm4_op_t *op, uint32_t *buffer, size_t buffer_size)
 {
-    if (!op || !buffer || buffer_size == 0)
-        return -1;
+	if (!op || !buffer || buffer_size == 0)
+		return -1;
 
-    if (op->size_dwords > buffer_size)
-        return -1;  /* Buffer too small */
+	if (op->size_dwords > buffer_size)
+		return -1; /* Buffer too small */
 
-    switch (op->type) {
-        case PM4_OP_SET_UCONFIG_REG:
-            if (buffer_size < 3) return -1;
-            buffer[0] = op->packet.set_uconfig_reg.header;
-            buffer[1] = op->packet.set_uconfig_reg.reg_offset |
-                       (op->packet.set_uconfig_reg.reserved << 16);
-            buffer[2] = op->packet.set_uconfig_reg.reg_value;
-            return 3;
+	switch (op->type) {
+	case PM4_OP_SET_UCONFIG_REG:
+		if (buffer_size < 3)
+			return -1;
+		buffer[0] = op->packet.set_uconfig_reg.header;
+		buffer[1] = op->packet.set_uconfig_reg.reg_offset |
+			    (op->packet.set_uconfig_reg.reserved << 16);
+		buffer[2] = op->packet.set_uconfig_reg.reg_value;
+		return 3;
 
-        case PM4_OP_EVENT_WRITE:
-            if (buffer_size < 2) return -1;
-            buffer[0] = op->packet.event_write.header;
-            buffer[1] = op->packet.event_write.event;
-            return 2;
+	case PM4_OP_EVENT_WRITE:
+		if (buffer_size < 2)
+			return -1;
+		buffer[0] = op->packet.event_write.header;
+		buffer[1] = op->packet.event_write.event;
+		return 2;
 
-        case PM4_OP_COPY_DATA:
-            if (buffer_size < 6) return -1;
-            buffer[0] = op->packet.copy_data.header;
-            buffer[1] = op->packet.copy_data.copy_data;
-            buffer[2] = op->packet.copy_data.src_reg_offset_lo;
-            buffer[3] = op->packet.copy_data.src_reg_offset_hi;
-            buffer[4] = op->packet.copy_data.dst_reg_offset_lo;
-            buffer[5] = op->packet.copy_data.dst_reg_offset_hi;
-            return 6;
+	case PM4_OP_COPY_DATA:
+		if (buffer_size < 6)
+			return -1;
+		buffer[0] = op->packet.copy_data.header;
+		buffer[1] = op->packet.copy_data.copy_data;
+		buffer[2] = op->packet.copy_data.src_reg_offset_lo;
+		buffer[3] = op->packet.copy_data.src_reg_offset_hi;
+		buffer[4] = op->packet.copy_data.dst_reg_offset_lo;
+		buffer[5] = op->packet.copy_data.dst_reg_offset_hi;
+		return 6;
 
-        case PM4_OP_FLUSH_CACHE:
-            if (buffer_size < 8) return -1;
-            buffer[0] = op->packet.flush_cache.header;
-            buffer[1] = op->packet.flush_cache.reserved;
-            buffer[2] = op->packet.flush_cache.coher_size;
-            buffer[3] = op->packet.flush_cache.coher_size_hi;
-            buffer[4] = op->packet.flush_cache.coher_base_lo;
-            buffer[5] = op->packet.flush_cache.coher_base_hi;
-            buffer[6] = op->packet.flush_cache.poll_interval;
-            buffer[7] = op->packet.flush_cache.gcr_cntl;
-            return 8;
+	case PM4_OP_FLUSH_CACHE:
+		if (buffer_size < 8)
+			return -1;
+		buffer[0] = op->packet.flush_cache.header;
+		buffer[1] = op->packet.flush_cache.reserved;
+		buffer[2] = op->packet.flush_cache.coher_size;
+		buffer[3] = op->packet.flush_cache.coher_size_hi;
+		buffer[4] = op->packet.flush_cache.coher_base_lo;
+		buffer[5] = op->packet.flush_cache.coher_base_hi;
+		buffer[6] = op->packet.flush_cache.poll_interval;
+		buffer[7] = op->packet.flush_cache.gcr_cntl;
+		return 8;
 
-        case PM4_OP_WRITE_SH_REG:
-            if (buffer_size < 3) return -1;
-            buffer[0] = op->packet.write_sh_reg.header;
-            buffer[1] = op->packet.write_sh_reg.word1;
-            buffer[2] = op->packet.write_sh_reg.reg_value;
-            return 3;
+	case PM4_OP_WRITE_SH_REG:
+		if (buffer_size < 3)
+			return -1;
+		buffer[0] = op->packet.write_sh_reg.header;
+		buffer[1] = op->packet.write_sh_reg.word1;
+		buffer[2] = op->packet.write_sh_reg.reg_value;
+		return 3;
 
-        case PM4_OP_INVALID:
-        default:
-            /* Copy raw data */
-            size_t copy_size = (op->size_dwords < buffer_size) ? op->size_dwords : buffer_size;
-            memcpy(buffer, op->packet.raw, copy_size * sizeof(uint32_t));
-            return (int)copy_size;
-    }
+	case PM4_OP_INVALID:
+	default:
+		/* Copy raw data */
+		size_t copy_size = (op->size_dwords < buffer_size) ? op->size_dwords : buffer_size;
+		memcpy(buffer, op->packet.raw, copy_size * sizeof(uint32_t));
+		return (int)copy_size;
+	}
 }
 
 /**
@@ -902,20 +892,26 @@ int pm4_op_to_buffer(const pm4_op_t* op, uint32_t* buffer, size_t buffer_size)
  * @param op Pointer to PM4 operation structure
  * @return Size in DWORDs (fixed size per type), or 0 if op is NULL
  */
-size_t pm4_op_get_size(const pm4_op_t* op)
+size_t pm4_op_get_size(const pm4_op_t *op)
 {
-    if (!op)
-        return 0;
+	if (!op)
+		return 0;
 
-    switch (op->type) {
-        case PM4_OP_SET_UCONFIG_REG:    return 3;
-        case PM4_OP_EVENT_WRITE:        return 2;
-        case PM4_OP_COPY_DATA:          return 6;
-        case PM4_OP_FLUSH_CACHE:        return 8;
-        case PM4_OP_WRITE_SH_REG:       return 3;
-        case PM4_OP_INVALID:
-        default:                        return op->size_dwords;
-    }
+	switch (op->type) {
+	case PM4_OP_SET_UCONFIG_REG:
+		return 3;
+	case PM4_OP_EVENT_WRITE:
+		return 2;
+	case PM4_OP_COPY_DATA:
+		return 6;
+	case PM4_OP_FLUSH_CACHE:
+		return 8;
+	case PM4_OP_WRITE_SH_REG:
+		return 3;
+	case PM4_OP_INVALID:
+	default:
+		return op->size_dwords;
+	}
 }
 
 /**
@@ -924,15 +920,21 @@ size_t pm4_op_get_size(const pm4_op_t* op)
  * @param type PM4 operation type from pm4_op_type_t enum
  * @return String name of operation type (e.g., "SET_UCONFIG_REG", "COPY_DATA")
  */
-const char* pm4_op_type_to_string(pm4_op_type_t type)
+const char *pm4_op_type_to_string(pm4_op_type_t type)
 {
-    switch (type) {
-        case PM4_OP_SET_UCONFIG_REG:    return "SET_UCONFIG_REG";
-        case PM4_OP_EVENT_WRITE:        return "EVENT_WRITE";
-        case PM4_OP_COPY_DATA:          return "COPY_DATA";
-        case PM4_OP_FLUSH_CACHE:        return "FLUSH_CACHE";
-        case PM4_OP_WRITE_SH_REG:       return "WRITE_SH_REG";
-        case PM4_OP_INVALID:
-        default:                        return "INVALID";
-    }
+	switch (type) {
+	case PM4_OP_SET_UCONFIG_REG:
+		return "SET_UCONFIG_REG";
+	case PM4_OP_EVENT_WRITE:
+		return "EVENT_WRITE";
+	case PM4_OP_COPY_DATA:
+		return "COPY_DATA";
+	case PM4_OP_FLUSH_CACHE:
+		return "FLUSH_CACHE";
+	case PM4_OP_WRITE_SH_REG:
+		return "WRITE_SH_REG";
+	case PM4_OP_INVALID:
+	default:
+		return "INVALID";
+	}
 }

--- a/projects/perf-dkms/src/aql_c/pm4_packets.h
+++ b/projects/perf-dkms/src/aql_c/pm4_packets.h
@@ -19,18 +19,18 @@
 #endif
 
 /* PM4 Opcodes - must match hardware specification */
-#define PM4_SET_UCONFIG_REG_OPCODE  0x79
-#define PM4_EVENT_WRITE_OPCODE       0x46  /* decimal 70 */
-#define PM4_COPY_DATA_OPCODE         0x40  /* decimal 64 */
-#define PM4_ACQUIRE_MEM_OPCODE       0x58  /* Flush/Invalidate cache */
-#define PM4_WRITE_SH_REG_OPCODE      0x76
+#define PM4_SET_UCONFIG_REG_OPCODE 0x79
+#define PM4_EVENT_WRITE_OPCODE 0x46 /* decimal 70 */
+#define PM4_COPY_DATA_OPCODE 0x40 /* decimal 64 */
+#define PM4_ACQUIRE_MEM_OPCODE 0x58 /* Flush/Invalidate cache */
+#define PM4_WRITE_SH_REG_OPCODE 0x76
 
 /* Register space bases */
-#define UCONFIG_SPACE_START          0x0000C000
-#define PERSISTENT_SPACE_START       0x00002C00
+#define UCONFIG_SPACE_START 0x0000C000
+#define PERSISTENT_SPACE_START 0x00002C00
 
 /* Event types */
-#define VGT_EVENT_TYPE_CS_PARTIAL_FLUSH  0x07
+#define VGT_EVENT_TYPE_CS_PARTIAL_FLUSH 0x07
 
 /* PM4 packet header construction
  *
@@ -46,18 +46,18 @@
  * - We match aqlprofile for compatibility: count = 1
  */
 #define PM4_TYPE_3_HEADER(opcode, packet_size_bytes) \
-    (3u << 30 | ((opcode) & 0xFF) << 8 | (((packet_size_bytes / 4) - 2) & 0x3FFF) << 16)
+	(3u << 30 | ((opcode) & 0xFF) << 8 | (((packet_size_bytes / 4) - 2) & 0x3FFF) << 16)
 
 /**
  * PM4 command buffer structure
  * Manages a growable buffer for accumulating PM4 packets
  */
 typedef struct {
-    uint32_t *data;       /* Buffer holding PM4 commands */
-    size_t capacity;      /* Buffer capacity in DWORDs */
-    size_t size;          /* Current size in DWORDs */
+	uint32_t *data; /* Buffer holding PM4 commands */
+	size_t capacity; /* Buffer capacity in DWORDs */
+	size_t size; /* Current size in DWORDs */
 #ifdef __KERNEL__
-    gfp_t gfp_flags;     /* Kernel memory allocation flags */
+	gfp_t gfp_flags; /* Kernel memory allocation flags */
 #endif
 } pm4_buffer_t;
 
@@ -66,25 +66,25 @@ typedef struct {
  * Matches Rust CopyData bitfield exactly
  */
 typedef union {
-    uint32_t raw;
-    struct {
-        uint32_t src_sel : 4;          /* bits 0-3 */
-        uint32_t reserved1 : 4;        /* bits 4-7 */
-        uint32_t dst_sel : 4;          /* bits 8-11 */
-        uint32_t reserved2 : 1;        /* bit 12 */
-        uint32_t src_temporal : 2;     /* bits 13-14 */
-        uint32_t reserved3 : 1;        /* bit 15 */
-        uint32_t count_sel : 1;        /* bit 16 */
-        uint32_t reserved4 : 3;        /* bits 17-19 */
-        uint32_t wr_confirm : 1;       /* bit 20 */
-        uint32_t mode : 1;             /* bit 21 */
-        uint32_t reserved5 : 1;        /* bit 22 */
-        uint32_t aid_id : 2;           /* bits 23-24 */
-        uint32_t dst_temporal : 2;     /* bits 25-26 */
-        uint32_t reserved6 : 2;        /* bits 27-28 */
-        uint32_t pq_exe_status : 1;    /* bit 29 */
-        uint32_t reserved7 : 2;        /* bits 30-31 */
-    } bits;
+	uint32_t raw;
+	struct {
+		uint32_t src_sel : 4; /* bits 0-3 */
+		uint32_t reserved1 : 4; /* bits 4-7 */
+		uint32_t dst_sel : 4; /* bits 8-11 */
+		uint32_t reserved2 : 1; /* bit 12 */
+		uint32_t src_temporal : 2; /* bits 13-14 */
+		uint32_t reserved3 : 1; /* bit 15 */
+		uint32_t count_sel : 1; /* bit 16 */
+		uint32_t reserved4 : 3; /* bits 17-19 */
+		uint32_t wr_confirm : 1; /* bit 20 */
+		uint32_t mode : 1; /* bit 21 */
+		uint32_t reserved5 : 1; /* bit 22 */
+		uint32_t aid_id : 2; /* bits 23-24 */
+		uint32_t dst_temporal : 2; /* bits 25-26 */
+		uint32_t reserved6 : 2; /* bits 27-28 */
+		uint32_t pq_exe_status : 1; /* bit 29 */
+		uint32_t reserved7 : 2; /* bits 30-31 */
+	} bits;
 } pm4_copy_data_flags_t;
 
 /**
@@ -92,18 +92,18 @@ typedef union {
  * Matches Rust GrbmGFXIndex bitfield exactly
  */
 typedef union {
-    uint32_t raw;
-    struct {
-        uint32_t instance_index : 7;           /* bits 0-6 */
-        uint32_t reserved1 : 1;                /* bit 7 */
-        uint32_t sa_index : 2;                 /* bits 8-9 */
-        uint32_t reserved2 : 6;                /* bits 10-15 */
-        uint32_t se_index : 4;                 /* bits 16-19 */
-        uint32_t reserved3 : 9;                /* bits 20-28 */
-        uint32_t sa_broadcast_writes : 1;      /* bit 29 */
-        uint32_t instance_broadcast_writes : 1;/* bit 30 */
-        uint32_t se_broadcast_writes : 1;      /* bit 31 */
-    } bits;
+	uint32_t raw;
+	struct {
+		uint32_t instance_index : 7; /* bits 0-6 */
+		uint32_t reserved1 : 1; /* bit 7 */
+		uint32_t sa_index : 2; /* bits 8-9 */
+		uint32_t reserved2 : 6; /* bits 10-15 */
+		uint32_t se_index : 4; /* bits 16-19 */
+		uint32_t reserved3 : 9; /* bits 20-28 */
+		uint32_t sa_broadcast_writes : 1; /* bit 29 */
+		uint32_t instance_broadcast_writes : 1; /* bit 30 */
+		uint32_t se_broadcast_writes : 1; /* bit 31 */
+	} bits;
 } pm4_grbm_gfx_index_t;
 
 /**
@@ -111,16 +111,16 @@ typedef union {
  * Matches Rust BarrierEvent bitfield exactly
  */
 typedef union {
-    uint32_t raw;
-    struct {
-        uint32_t event_type : 6;           /* bits 0-5 */
-        uint32_t reserved1 : 2;            /* bits 6-7 */
-        uint32_t event_index : 4;          /* bits 8-11 */
-        uint32_t reserved2 : 9;            /* bits 12-20 */
-        uint32_t samp_plst_cntr_mode : 2;  /* bits 21-22 */
-        uint32_t offload_enable : 1;       /* bit 23 */
-        uint32_t reserved3 : 8;            /* bits 24-31 */
-    } bits;
+	uint32_t raw;
+	struct {
+		uint32_t event_type : 6; /* bits 0-5 */
+		uint32_t reserved1 : 2; /* bits 6-7 */
+		uint32_t event_index : 4; /* bits 8-11 */
+		uint32_t reserved2 : 9; /* bits 12-20 */
+		uint32_t samp_plst_cntr_mode : 2; /* bits 21-22 */
+		uint32_t offload_enable : 1; /* bit 23 */
+		uint32_t reserved3 : 8; /* bits 24-31 */
+	} bits;
 } pm4_barrier_event_t;
 
 /* Buffer management functions */
@@ -138,9 +138,9 @@ typedef union {
  * @see pm4_buffer_destroy()
  */
 #ifdef __KERNEL__
-pm4_buffer_t* pm4_buffer_create(size_t initial_capacity, gfp_t flags);
+pm4_buffer_t *pm4_buffer_create(size_t initial_capacity, gfp_t flags);
 #else
-pm4_buffer_t* pm4_buffer_create(size_t initial_capacity);
+pm4_buffer_t *pm4_buffer_create(size_t initial_capacity);
 #endif
 
 /**
@@ -177,7 +177,7 @@ int pm4_buffer_ensure_capacity(pm4_buffer_t *buffer, size_t required_dwords);
  * @param buffer Pointer to buffer
  * @return Pointer to data array, or NULL if buffer is NULL
  */
-uint32_t* pm4_buffer_get_data(pm4_buffer_t *buffer);
+uint32_t *pm4_buffer_get_data(pm4_buffer_t *buffer);
 
 /**
  * @brief Get current buffer size in DWORDs
@@ -198,34 +198,22 @@ size_t pm4_buffer_get_size_bytes(pm4_buffer_t *buffer);
 /* PM4 packet builder functions - matches Rust PM4CommandWriter trait */
 
 /* SetUConfigReg packet - writes to UCONFIG register space */
-int pm4_append_set_uconfig_reg(pm4_buffer_t *buffer,
-                                uint32_t reg_offset,
-                                uint32_t value);
+int pm4_append_set_uconfig_reg(pm4_buffer_t *buffer, uint32_t reg_offset, uint32_t value);
 
 /* WriteSHRegister packet - writes to SH (persistent) register space */
-int pm4_append_write_sh_reg(pm4_buffer_t *buffer,
-                             uint32_t reg_offset,
-                             uint32_t value,
-                             uint8_t vmid_shift,
-                             uint8_t index);
+int pm4_append_write_sh_reg(pm4_buffer_t *buffer, uint32_t reg_offset, uint32_t value,
+			    uint8_t vmid_shift, uint8_t index);
 
 /* EventWrite packet - triggers GPU events */
-int pm4_append_event_write(pm4_buffer_t *buffer,
-                            uint32_t event_type,
-                            uint32_t event_index);
+int pm4_append_event_write(pm4_buffer_t *buffer, uint32_t event_type, uint32_t event_index);
 
 /* CopyData packet - copies data from registers to memory */
-int pm4_append_copy_data(pm4_buffer_t *buffer,
-                          pm4_copy_data_flags_t flags,
-                          uint32_t src_reg_lo,
-                          uint32_t src_reg_hi,
-                          uint64_t dst_addr);
+int pm4_append_copy_data(pm4_buffer_t *buffer, pm4_copy_data_flags_t flags, uint32_t src_reg_lo,
+			 uint32_t src_reg_hi, uint64_t dst_addr);
 
 /* AcquireMem (FlushCache) packet - ensures cache coherency */
-int pm4_append_acquire_mem(pm4_buffer_t *buffer,
-                            uint64_t base_addr,
-                            uint64_t size,
-                            uint32_t gcr_cntl);
+int pm4_append_acquire_mem(pm4_buffer_t *buffer, uint64_t base_addr, uint64_t size,
+			   uint32_t gcr_cntl);
 
 /* Higher-level helper functions that match Rust implementation */
 
@@ -250,11 +238,8 @@ int pm4_grbm_broadcast(pm4_buffer_t *buffer, uint32_t grbm_gfx_index_reg);
  * @param se_index Shader Engine index
  * @return 0 on success, negative on error
  */
-int pm4_set_grbm_index(pm4_buffer_t *buffer,
-                        uint32_t grbm_gfx_index_reg,
-                        uint32_t wg_index,
-                        uint32_t sa_index,
-                        uint32_t se_index);
+int pm4_set_grbm_index(pm4_buffer_t *buffer, uint32_t grbm_gfx_index_reg, uint32_t wg_index,
+		       uint32_t sa_index, uint32_t se_index);
 
 /**
  * @brief Enable or disable performance monitoring
@@ -266,9 +251,8 @@ int pm4_set_grbm_index(pm4_buffer_t *buffer,
  * @param control_value Control value to write (state + sample bit)
  * @return 0 on success, negative on error
  */
-int pm4_perfcount_enable(pm4_buffer_t *buffer,
-                          uint32_t cp_perfmon_cntl_reg,
-                          uint32_t control_value);
+int pm4_perfcount_enable(pm4_buffer_t *buffer, uint32_t cp_perfmon_cntl_reg,
+			 uint32_t control_value);
 
 /**
  * @brief Trigger CS partial flush event
@@ -293,12 +277,9 @@ int pm4_cs_partial_flush(pm4_buffer_t *buffer);
  * @param coher_base_lo Output: coherency base low 32 bits
  * @param coher_base_hi Output: coherency base high 24 bits
  */
-void pm4_calculate_cache_coher_params(uint64_t addr,
-                                       uint64_t size,
-                                       uint32_t *coher_size_lo,
-                                       uint32_t *coher_size_hi,
-                                       uint32_t *coher_base_lo,
-                                       uint32_t *coher_base_hi);
+void pm4_calculate_cache_coher_params(uint64_t addr, uint64_t size, uint32_t *coher_size_lo,
+				      uint32_t *coher_size_hi, uint32_t *coher_base_lo,
+				      uint32_t *coher_base_hi);
 
 /* Debug/utility functions */
 
@@ -316,7 +297,7 @@ void pm4_dump_packet(const uint32_t *packet, size_t size_dwords);
  * @param opcode PM4 opcode value
  * @return String name of opcode, or "UNKNOWN"
  */
-const char* pm4_opcode_to_string(uint8_t opcode);
+const char *pm4_opcode_to_string(uint8_t opcode);
 
 /**
  * @brief Validate a PM4 packet structure
@@ -335,64 +316,64 @@ int pm4_validate_packet(const uint32_t *packet, size_t size_dwords);
  * Used for handling variable-sized PM4 packets in a type-safe manner
  */
 typedef enum {
-    PM4_OP_SET_UCONFIG_REG,
-    PM4_OP_EVENT_WRITE,
-    PM4_OP_COPY_DATA,
-    PM4_OP_FLUSH_CACHE,
-    PM4_OP_WRITE_SH_REG,
-    PM4_OP_INVALID
+	PM4_OP_SET_UCONFIG_REG,
+	PM4_OP_EVENT_WRITE,
+	PM4_OP_COPY_DATA,
+	PM4_OP_FLUSH_CACHE,
+	PM4_OP_WRITE_SH_REG,
+	PM4_OP_INVALID
 } pm4_op_type_t;
 
 typedef struct {
-    pm4_op_type_t type;
-    size_t size_dwords;
-    union {
-        /* SetUConfigReg packet (3 DWORDs) */
-        struct {
-            uint32_t header;
-            uint16_t reg_offset;
-            uint16_t reserved;
-            uint32_t reg_value;
-        } set_uconfig_reg;
+	pm4_op_type_t type;
+	size_t size_dwords;
+	union {
+		/* SetUConfigReg packet (3 DWORDs) */
+		struct {
+			uint32_t header;
+			uint16_t reg_offset;
+			uint16_t reserved;
+			uint32_t reg_value;
+		} set_uconfig_reg;
 
-        /* EventWrite packet (2 DWORDs) */
-        struct {
-            uint32_t header;
-            uint32_t event;
-        } event_write;
+		/* EventWrite packet (2 DWORDs) */
+		struct {
+			uint32_t header;
+			uint32_t event;
+		} event_write;
 
-        /* CopyData packet (6 DWORDs) */
-        struct {
-            uint32_t header;
-            uint32_t copy_data;
-            uint32_t src_reg_offset_lo;
-            uint32_t src_reg_offset_hi;
-            uint32_t dst_reg_offset_lo;
-            uint32_t dst_reg_offset_hi;
-        } copy_data;
+		/* CopyData packet (6 DWORDs) */
+		struct {
+			uint32_t header;
+			uint32_t copy_data;
+			uint32_t src_reg_offset_lo;
+			uint32_t src_reg_offset_hi;
+			uint32_t dst_reg_offset_lo;
+			uint32_t dst_reg_offset_hi;
+		} copy_data;
 
-        /* FlushCache packet (8 DWORDs) */
-        struct {
-            uint32_t header;
-            uint32_t reserved;
-            uint32_t coher_size;
-            uint32_t coher_size_hi;
-            uint32_t coher_base_lo;
-            uint32_t coher_base_hi;
-            uint32_t poll_interval;
-            uint32_t gcr_cntl;
-        } flush_cache;
+		/* FlushCache packet (8 DWORDs) */
+		struct {
+			uint32_t header;
+			uint32_t reserved;
+			uint32_t coher_size;
+			uint32_t coher_size_hi;
+			uint32_t coher_base_lo;
+			uint32_t coher_base_hi;
+			uint32_t poll_interval;
+			uint32_t gcr_cntl;
+		} flush_cache;
 
-        /* WriteSHRegister packet (3 DWORDs) */
-        struct {
-            uint32_t header;
-            uint32_t word1;  /* Contains reg_offset, vmid_shift, index fields */
-            uint32_t reg_value;
-        } write_sh_reg;
+		/* WriteSHRegister packet (3 DWORDs) */
+		struct {
+			uint32_t header;
+			uint32_t word1; /* Contains reg_offset, vmid_shift, index fields */
+			uint32_t reg_value;
+		} write_sh_reg;
 
-        /* Raw access for unknown packet types */
-        uint32_t raw[8];  /* Max packet size is 8 DWORDs */
-    } packet;
+		/* Raw access for unknown packet types */
+		uint32_t raw[8]; /* Max packet size is 8 DWORDs */
+	} packet;
 } pm4_op_t;
 
 /* Helper functions for pm4_op_t */
@@ -404,7 +385,7 @@ typedef struct {
  * @param size_dwords Size of packet in DWORDs
  * @return Parsed pm4_op_t structure (type set to PM4_OP_INVALID on error)
  */
-pm4_op_t pm4_op_from_buffer(const uint32_t* data, size_t size_dwords);
+pm4_op_t pm4_op_from_buffer(const uint32_t *data, size_t size_dwords);
 
 /**
  * @brief Serialize a pm4_op_t structure to buffer
@@ -414,7 +395,7 @@ pm4_op_t pm4_op_from_buffer(const uint32_t* data, size_t size_dwords);
  * @param buffer_size Size of output buffer in DWORDs
  * @return Number of DWORDs written, or -1 on error
  */
-int pm4_op_to_buffer(const pm4_op_t* op, uint32_t* buffer, size_t buffer_size);
+int pm4_op_to_buffer(const pm4_op_t *op, uint32_t *buffer, size_t buffer_size);
 
 /**
  * @brief Get size of a PM4 operation in DWORDs
@@ -422,7 +403,7 @@ int pm4_op_to_buffer(const pm4_op_t* op, uint32_t* buffer, size_t buffer_size);
  * @param op Pointer to PM4 operation structure
  * @return Size in DWORDs, or 0 if op is NULL
  */
-size_t pm4_op_get_size(const pm4_op_t* op);
+size_t pm4_op_get_size(const pm4_op_t *op);
 
 /**
  * @brief Convert PM4 operation type to string name
@@ -430,6 +411,6 @@ size_t pm4_op_get_size(const pm4_op_t* op);
  * @param type PM4 operation type
  * @return String name of operation type
  */
-const char* pm4_op_type_to_string(pm4_op_type_t type);
+const char *pm4_op_type_to_string(pm4_op_type_t type);
 
 #endif /* PM4_PACKETS_H */

--- a/projects/perf-dkms/src/aql_c/tests/simple_packet_test.c
+++ b/projects/perf-dkms/src/aql_c/tests/simple_packet_test.c
@@ -11,52 +11,53 @@
 #include "aql_structures.h"
 #include "pm4_packets.h"
 
-int main(void) {
-    printf("🧪 Simple Packet Generation Test\n");
+int main(void)
+{
+	printf("🧪 Simple Packet Generation Test\n");
 
-    /* Test basic buffer creation */
-    pm4_buffer_t* buffer = pm4_buffer_create(1024);
-    if (!buffer) {
-        printf("❌ Failed to create buffer\n");
-        return -1;
-    }
-    printf("✓ Created buffer with capacity %zu\n", buffer->capacity);
+	/* Test basic buffer creation */
+	pm4_buffer_t *buffer = pm4_buffer_create(1024);
+	if (!buffer) {
+		printf("❌ Failed to create buffer\n");
+		return -1;
+	}
+	printf("✓ Created buffer with capacity %zu\n", buffer->capacity);
 
-    /* Create basic arch using the real creator */
-    arch_t* arch = arch_create_by_name("gfx12");
-    if (!arch) {
-        printf("❌ Failed to create arch\n");
-        pm4_buffer_destroy(buffer);
-        return -1;
-    }
-    printf("✓ Created GFX12 architecture\n");
+	/* Create basic arch using the real creator */
+	arch_t *arch = arch_create_by_name("gfx12");
+	if (!arch) {
+		printf("❌ Failed to create arch\n");
+		pm4_buffer_destroy(buffer);
+		return -1;
+	}
+	printf("✓ Created GFX12 architecture\n");
 
-    /* Test simple functions */
-    int ret = generate_cs_partial_flush(buffer, arch);
-    if (ret != 0) {
-        printf("❌ CS partial flush failed: %d\n", ret);
-    } else {
-        printf("✓ CS partial flush succeeded, buffer size: %zu\n", buffer->size);
-    }
+	/* Test simple functions */
+	int ret = generate_cs_partial_flush(buffer, arch);
+	if (ret != 0) {
+		printf("❌ CS partial flush failed: %d\n", ret);
+	} else {
+		printf("✓ CS partial flush succeeded, buffer size: %zu\n", buffer->size);
+	}
 
-    ret = generate_grbm_broadcast(buffer, arch);
-    if (ret != 0) {
-        printf("❌ GRBM broadcast failed: %d\n", ret);
-    } else {
-        printf("✓ GRBM broadcast succeeded, buffer size: %zu\n", buffer->size);
-    }
+	ret = generate_grbm_broadcast(buffer, arch);
+	if (ret != 0) {
+		printf("❌ GRBM broadcast failed: %d\n", ret);
+	} else {
+		printf("✓ GRBM broadcast succeeded, buffer size: %zu\n", buffer->size);
+	}
 
-    ret = generate_perfmon_enable(buffer, arch, 0, false);
-    if (ret != 0) {
-        printf("❌ Perfmon enable failed: %d\n", ret);
-    } else {
-        printf("✓ Perfmon enable succeeded, buffer size: %zu\n", buffer->size);
-    }
+	ret = generate_perfmon_enable(buffer, arch, 0, false);
+	if (ret != 0) {
+		printf("❌ Perfmon enable failed: %d\n", ret);
+	} else {
+		printf("✓ Perfmon enable succeeded, buffer size: %zu\n", buffer->size);
+	}
 
-    /* Clean up */
-    arch_destroy(arch);
-    pm4_buffer_destroy(buffer);
+	/* Clean up */
+	arch_destroy(arch);
+	pm4_buffer_destroy(buffer);
 
-    printf("✅ Simple test completed successfully!\n");
-    return 0;
+	printf("✅ Simple test completed successfully!\n");
+	return 0;
 }

--- a/projects/perf-dkms/src/aql_c/tests/test_counter_registry.c
+++ b/projects/perf-dkms/src/aql_c/tests/test_counter_registry.c
@@ -16,228 +16,243 @@
 static int tests_run = 0;
 static int tests_passed = 0;
 
-#define TEST_ASSERT(condition, message) do { \
-    tests_run++; \
-    if (condition) { \
-        tests_passed++; \
-        printf("PASS: %s\n", message); \
-    } else { \
-        printf("FAIL: %s\n", message); \
-    } \
-} while(0)
+#define TEST_ASSERT(condition, message)                \
+	do {                                           \
+		tests_run++;                           \
+		if (condition) {                       \
+			tests_passed++;                \
+			printf("PASS: %s\n", message); \
+		} else {                               \
+			printf("FAIL: %s\n", message); \
+		}                                      \
+	} while (0)
 
 /* Test lookup counter by name */
-void test_lookup_counter_by_name(void) {
-    printf("\n=== Testing lookup_counter_by_name ===\n");
+void test_lookup_counter_by_name(void)
+{
+	printf("\n=== Testing lookup_counter_by_name ===\n");
 
-    /* Test valid counter names */
-    const counter_def_t* counter = lookup_counter_by_name("SQ_WAVES");
-    TEST_ASSERT(counter != NULL, "lookup_counter_by_name: SQ_WAVES found");
-    TEST_ASSERT(counter->id == COUNTER_SQ_WAVES, "SQ_WAVES has correct ID");
-    TEST_ASSERT(counter->hw_block == HW_IP_BLOCK_SQ, "SQ_WAVES has correct hw_block");
+	/* Test valid counter names */
+	const counter_def_t *counter = lookup_counter_by_name("SQ_WAVES");
+	TEST_ASSERT(counter != NULL, "lookup_counter_by_name: SQ_WAVES found");
+	TEST_ASSERT(counter->id == COUNTER_SQ_WAVES, "SQ_WAVES has correct ID");
+	TEST_ASSERT(counter->hw_block == HW_IP_BLOCK_SQ, "SQ_WAVES has correct hw_block");
 
-    counter = lookup_counter_by_name("GL2C_HIT");
-    TEST_ASSERT(counter != NULL, "lookup_counter_by_name: GL2C_HIT found");
-    TEST_ASSERT(counter->id == COUNTER_GL2C_HIT, "GL2C_HIT has correct ID");
-    TEST_ASSERT(counter->hw_block == HW_IP_BLOCK_GL2C, "GL2C_HIT has correct hw_block");
+	counter = lookup_counter_by_name("GL2C_HIT");
+	TEST_ASSERT(counter != NULL, "lookup_counter_by_name: GL2C_HIT found");
+	TEST_ASSERT(counter->id == COUNTER_GL2C_HIT, "GL2C_HIT has correct ID");
+	TEST_ASSERT(counter->hw_block == HW_IP_BLOCK_GL2C, "GL2C_HIT has correct hw_block");
 
-    counter = lookup_counter_by_name("TA_TA_BUSY");
-    TEST_ASSERT(counter != NULL, "lookup_counter_by_name: TA_TA_BUSY found");
-    TEST_ASSERT(counter->id == COUNTER_TA_TA_BUSY, "TA_TA_BUSY has correct ID");
-    TEST_ASSERT(counter->hw_block == HW_IP_BLOCK_TA, "TA_TA_BUSY has correct hw_block");
+	counter = lookup_counter_by_name("TA_TA_BUSY");
+	TEST_ASSERT(counter != NULL, "lookup_counter_by_name: TA_TA_BUSY found");
+	TEST_ASSERT(counter->id == COUNTER_TA_TA_BUSY, "TA_TA_BUSY has correct ID");
+	TEST_ASSERT(counter->hw_block == HW_IP_BLOCK_TA, "TA_TA_BUSY has correct hw_block");
 
-    /* Test invalid counter names */
-    counter = lookup_counter_by_name("INVALID_COUNTER");
-    TEST_ASSERT(counter == NULL, "lookup_counter_by_name: Invalid counter returns NULL");
+	/* Test invalid counter names */
+	counter = lookup_counter_by_name("INVALID_COUNTER");
+	TEST_ASSERT(counter == NULL, "lookup_counter_by_name: Invalid counter returns NULL");
 
-    counter = lookup_counter_by_name(NULL);
-    TEST_ASSERT(counter == NULL, "lookup_counter_by_name: NULL input returns NULL");
+	counter = lookup_counter_by_name(NULL);
+	TEST_ASSERT(counter == NULL, "lookup_counter_by_name: NULL input returns NULL");
 
-    counter = lookup_counter_by_name("");
-    TEST_ASSERT(counter == NULL, "lookup_counter_by_name: Empty string returns NULL");
+	counter = lookup_counter_by_name("");
+	TEST_ASSERT(counter == NULL, "lookup_counter_by_name: Empty string returns NULL");
 }
 
 /* Test lookup counter by ID */
-void test_lookup_counter_by_id(void) {
-    printf("\n=== Testing lookup_counter_by_id ===\n");
+void test_lookup_counter_by_id(void)
+{
+	printf("\n=== Testing lookup_counter_by_id ===\n");
 
-    /* Test valid counter IDs */
-    const counter_def_t* counter = lookup_counter_by_id(COUNTER_SQ_WAVES);
-    TEST_ASSERT(counter != NULL, "lookup_counter_by_id: SQ_WAVES found");
-    TEST_ASSERT(strcmp(counter->name, "SQ_WAVES") == 0, "SQ_WAVES has correct name");
+	/* Test valid counter IDs */
+	const counter_def_t *counter = lookup_counter_by_id(COUNTER_SQ_WAVES);
+	TEST_ASSERT(counter != NULL, "lookup_counter_by_id: SQ_WAVES found");
+	TEST_ASSERT(strcmp(counter->name, "SQ_WAVES") == 0, "SQ_WAVES has correct name");
 
-    counter = lookup_counter_by_id(COUNTER_GL2C_HIT);
-    TEST_ASSERT(counter != NULL, "lookup_counter_by_id: GL2C_HIT found");
-    TEST_ASSERT(strcmp(counter->name, "GL2C_HIT") == 0, "GL2C_HIT has correct name");
+	counter = lookup_counter_by_id(COUNTER_GL2C_HIT);
+	TEST_ASSERT(counter != NULL, "lookup_counter_by_id: GL2C_HIT found");
+	TEST_ASSERT(strcmp(counter->name, "GL2C_HIT") == 0, "GL2C_HIT has correct name");
 
-    /* Test invalid counter IDs */
-    counter = lookup_counter_by_id(0);
-    TEST_ASSERT(counter == NULL, "lookup_counter_by_id: ID 0 returns NULL");
+	/* Test invalid counter IDs */
+	counter = lookup_counter_by_id(0);
+	TEST_ASSERT(counter == NULL, "lookup_counter_by_id: ID 0 returns NULL");
 
-    counter = lookup_counter_by_id(COUNTER_ID_LAST);
-    TEST_ASSERT(counter == NULL, "lookup_counter_by_id: ID >= COUNTER_ID_LAST returns NULL");
+	counter = lookup_counter_by_id(COUNTER_ID_LAST);
+	TEST_ASSERT(counter == NULL, "lookup_counter_by_id: ID >= COUNTER_ID_LAST returns NULL");
 
-    counter = lookup_counter_by_id(-1);
-    TEST_ASSERT(counter == NULL, "lookup_counter_by_id: Negative ID returns NULL");
+	counter = lookup_counter_by_id(-1);
+	TEST_ASSERT(counter == NULL, "lookup_counter_by_id: Negative ID returns NULL");
 }
 
 /* Test lookup event ID */
-void test_lookup_event_id(void) {
-    printf("\n=== Testing lookup_event_id ===\n");
+void test_lookup_event_id(void)
+{
+	printf("\n=== Testing lookup_event_id ===\n");
 
-    /* Create GFX12 architecture for testing */
-    arch_t* arch = arch_create_by_name("gfx12");
-    TEST_ASSERT(arch != NULL, "GFX12 architecture created successfully");
+	/* Create GFX12 architecture for testing */
+	arch_t *arch = arch_create_by_name("gfx12");
+	TEST_ASSERT(arch != NULL, "GFX12 architecture created successfully");
 
-    if (arch == NULL) {
-        printf("ERROR: Could not create GFX12 architecture, skipping lookup_event_id tests\n");
-        return;
-    }
+	if (arch == NULL) {
+		printf("ERROR: Could not create GFX12 architecture, skipping lookup_event_id tests\n");
+		return;
+	}
 
-    /* Test valid GFX12 event lookups */
-    uint32_t event_id;
-    int ret;
-    const counter_def_t* counter = lookup_counter_by_id(COUNTER_SQ_WAVES);
-    TEST_ASSERT(counter != NULL, "SQ_WAVES counter found");
-    if (counter) {
-        ret = lookup_event_id(counter, arch, &event_id);
-        TEST_ASSERT(ret == 0 && event_id == 4, "lookup_event_id: SQ_WAVES GFX12 event ID is 4");
-    }
+	/* Test valid GFX12 event lookups */
+	uint32_t event_id;
+	int ret;
+	const counter_def_t *counter = lookup_counter_by_id(COUNTER_SQ_WAVES);
+	TEST_ASSERT(counter != NULL, "SQ_WAVES counter found");
+	if (counter) {
+		ret = lookup_event_id(counter, arch, &event_id);
+		TEST_ASSERT(ret == 0 && event_id == 4,
+			    "lookup_event_id: SQ_WAVES GFX12 event ID is 4");
+	}
 
-    counter = lookup_counter_by_id(COUNTER_GL2C_HIT);
-    TEST_ASSERT(counter != NULL, "GL2C_HIT counter found");
-    if (counter) {
-        ret = lookup_event_id(counter, arch, &event_id);
-        TEST_ASSERT(ret == 0 && event_id == 41, "lookup_event_id: GL2C_HIT GFX12 event ID is 41");
-    }
+	counter = lookup_counter_by_id(COUNTER_GL2C_HIT);
+	TEST_ASSERT(counter != NULL, "GL2C_HIT counter found");
+	if (counter) {
+		ret = lookup_event_id(counter, arch, &event_id);
+		TEST_ASSERT(ret == 0 && event_id == 41,
+			    "lookup_event_id: GL2C_HIT GFX12 event ID is 41");
+	}
 
-    counter = lookup_counter_by_id(COUNTER_SQ_BUSY_CYCLES);
-    TEST_ASSERT(counter != NULL, "SQ_BUSY_CYCLES counter found");
-    if (counter) {
-        ret = lookup_event_id(counter, arch, &event_id);
-        TEST_ASSERT(ret == 0 && event_id == 3, "lookup_event_id: SQ_BUSY_CYCLES GFX12 event ID is 3");
-    }
+	counter = lookup_counter_by_id(COUNTER_SQ_BUSY_CYCLES);
+	TEST_ASSERT(counter != NULL, "SQ_BUSY_CYCLES counter found");
+	if (counter) {
+		ret = lookup_event_id(counter, arch, &event_id);
+		TEST_ASSERT(ret == 0 && event_id == 3,
+			    "lookup_event_id: SQ_BUSY_CYCLES GFX12 event ID is 3");
+	}
 
-    counter = lookup_counter_by_id(COUNTER_GRBM_COUNT);
-    TEST_ASSERT(counter != NULL, "GRBM_COUNT counter found");
-    if (counter) {
-        ret = lookup_event_id(counter, arch, &event_id);
-        TEST_ASSERT(ret == 0 && event_id == 0, "lookup_event_id: GRBM_COUNT GFX12 event ID is 0");
-    }
+	counter = lookup_counter_by_id(COUNTER_GRBM_COUNT);
+	TEST_ASSERT(counter != NULL, "GRBM_COUNT counter found");
+	if (counter) {
+		ret = lookup_event_id(counter, arch, &event_id);
+		TEST_ASSERT(ret == 0 && event_id == 0,
+			    "lookup_event_id: GRBM_COUNT GFX12 event ID is 0");
+	}
 
-    /* Test with NULL parameters */
-    ret = lookup_event_id(NULL, arch, &event_id);
-    TEST_ASSERT(ret < 0, "lookup_event_id: NULL counter returns error");
+	/* Test with NULL parameters */
+	ret = lookup_event_id(NULL, arch, &event_id);
+	TEST_ASSERT(ret < 0, "lookup_event_id: NULL counter returns error");
 
-    counter = lookup_counter_by_id(COUNTER_SQ_WAVES);
-    if (counter) {
-        ret = lookup_event_id(counter, NULL, &event_id);
-        TEST_ASSERT(ret < 0, "lookup_event_id: NULL architecture returns error");
-    }
+	counter = lookup_counter_by_id(COUNTER_SQ_WAVES);
+	if (counter) {
+		ret = lookup_event_id(counter, NULL, &event_id);
+		TEST_ASSERT(ret < 0, "lookup_event_id: NULL architecture returns error");
+	}
 
-    /* Clean up */
-    arch_destroy(arch);
+	/* Clean up */
+	arch_destroy(arch);
 }
 
 /* Test get all counters */
-void test_get_all_counters(void) {
-    printf("\n=== Testing get_all_counters ===\n");
+void test_get_all_counters(void)
+{
+	printf("\n=== Testing get_all_counters ===\n");
 
-    const counter_def_t* counters = get_all_counters();
-    TEST_ASSERT(counters != NULL, "get_all_counters: Returns non-NULL pointer");
+	const counter_def_t *counters = get_all_counters();
+	TEST_ASSERT(counters != NULL, "get_all_counters: Returns non-NULL pointer");
 
-    size_t count = get_counter_count();
-    TEST_ASSERT(count > 0, "get_counter_count: Returns positive count");
-    TEST_ASSERT(count == 36, "get_counter_count: Returns expected count of 36");
+	size_t count = get_counter_count();
+	TEST_ASSERT(count > 0, "get_counter_count: Returns positive count");
+	TEST_ASSERT(count == 36, "get_counter_count: Returns expected count of 36");
 
-    /* Verify first and last counters */
-    TEST_ASSERT(counters[0].id == COUNTER_GL2C_EA_RDREQ, "First counter has correct ID");
-    TEST_ASSERT(strcmp(counters[0].name, "GL2C_EA_RDREQ") == 0, "First counter has correct name");
+	/* Verify first and last counters */
+	TEST_ASSERT(counters[0].id == COUNTER_GL2C_EA_RDREQ, "First counter has correct ID");
+	TEST_ASSERT(strcmp(counters[0].name, "GL2C_EA_RDREQ") == 0,
+		    "First counter has correct name");
 
-    /* Verify some counters in the middle */
-    int found_sq_waves = 0;
-    int found_gl2c_hit = 0;
-    int found_ta_busy = 0;
+	/* Verify some counters in the middle */
+	int found_sq_waves = 0;
+	int found_gl2c_hit = 0;
+	int found_ta_busy = 0;
 
-    for (size_t i = 0; i < count; i++) {
-        if (counters[i].id == COUNTER_SQ_WAVES) {
-            found_sq_waves = 1;
-            TEST_ASSERT(strcmp(counters[i].name, "SQ_WAVES") == 0, "SQ_WAVES counter has correct name in array");
-        }
-        if (counters[i].id == COUNTER_GL2C_HIT) {
-            found_gl2c_hit = 1;
-            TEST_ASSERT(strcmp(counters[i].name, "GL2C_HIT") == 0, "GL2C_HIT counter has correct name in array");
-        }
-        if (counters[i].id == COUNTER_TA_TA_BUSY) {
-            found_ta_busy = 1;
-            TEST_ASSERT(strcmp(counters[i].name, "TA_TA_BUSY") == 0, "TA_TA_BUSY counter has correct name in array");
-        }
-    }
+	for (size_t i = 0; i < count; i++) {
+		if (counters[i].id == COUNTER_SQ_WAVES) {
+			found_sq_waves = 1;
+			TEST_ASSERT(strcmp(counters[i].name, "SQ_WAVES") == 0,
+				    "SQ_WAVES counter has correct name in array");
+		}
+		if (counters[i].id == COUNTER_GL2C_HIT) {
+			found_gl2c_hit = 1;
+			TEST_ASSERT(strcmp(counters[i].name, "GL2C_HIT") == 0,
+				    "GL2C_HIT counter has correct name in array");
+		}
+		if (counters[i].id == COUNTER_TA_TA_BUSY) {
+			found_ta_busy = 1;
+			TEST_ASSERT(strcmp(counters[i].name, "TA_TA_BUSY") == 0,
+				    "TA_TA_BUSY counter has correct name in array");
+		}
+	}
 
-    TEST_ASSERT(found_sq_waves, "SQ_WAVES counter found in get_all_counters array");
-    TEST_ASSERT(found_gl2c_hit, "GL2C_HIT counter found in get_all_counters array");
-    TEST_ASSERT(found_ta_busy, "TA_TA_BUSY counter found in get_all_counters array");
+	TEST_ASSERT(found_sq_waves, "SQ_WAVES counter found in get_all_counters array");
+	TEST_ASSERT(found_gl2c_hit, "GL2C_HIT counter found in get_all_counters array");
+	TEST_ASSERT(found_ta_busy, "TA_TA_BUSY counter found in get_all_counters array");
 }
 
 /* Test block type coverage */
-void test_block_type_coverage(void) {
-    printf("\n=== Testing block type coverage ===\n");
+void test_block_type_coverage(void)
+{
+	printf("\n=== Testing block type coverage ===\n");
 
-    const counter_def_t* counters = get_all_counters();
-    size_t count = get_counter_count();
+	const counter_def_t *counters = get_all_counters();
+	size_t count = get_counter_count();
 
-    int gl2c_count = 0;
-    int sq_count = 0;
-    int ta_count = 0;
-    int grbm_count = 0;
+	int gl2c_count = 0;
+	int sq_count = 0;
+	int ta_count = 0;
+	int grbm_count = 0;
 
-    for (size_t i = 0; i < count; i++) {
-        switch (counters[i].hw_block) {
-            case HW_IP_BLOCK_GL2C:
-                gl2c_count++;
-                break;
-            case HW_IP_BLOCK_SQ:
-                sq_count++;
-                break;
-            case HW_IP_BLOCK_TA:
-                ta_count++;
-                break;
-            case HW_IP_BLOCK_GRBM:
-                grbm_count++;
-                break;
-            default:
-                break;
-        }
-    }
+	for (size_t i = 0; i < count; i++) {
+		switch (counters[i].hw_block) {
+		case HW_IP_BLOCK_GL2C:
+			gl2c_count++;
+			break;
+		case HW_IP_BLOCK_SQ:
+			sq_count++;
+			break;
+		case HW_IP_BLOCK_TA:
+			ta_count++;
+			break;
+		case HW_IP_BLOCK_GRBM:
+			grbm_count++;
+			break;
+		default:
+			break;
+		}
+	}
 
-    TEST_ASSERT(gl2c_count == 9, "GL2C block has 9 counters");
-    TEST_ASSERT(sq_count == 22, "SQ block has 22 counters");
-    TEST_ASSERT(ta_count == 3, "TA block has 3 counters");
-    TEST_ASSERT(grbm_count == 2, "GRBM block has 2 counters");
+	TEST_ASSERT(gl2c_count == 9, "GL2C block has 9 counters");
+	TEST_ASSERT(sq_count == 22, "SQ block has 22 counters");
+	TEST_ASSERT(ta_count == 3, "TA block has 3 counters");
+	TEST_ASSERT(grbm_count == 2, "GRBM block has 2 counters");
 
-    TEST_ASSERT(gl2c_count + sq_count + ta_count + grbm_count == (int)count,
-                "All counters are accounted for across block types");
+	TEST_ASSERT(gl2c_count + sq_count + ta_count + grbm_count == (int)count,
+		    "All counters are accounted for across block types");
 }
 
-int main(void) {
-    printf("Starting counter registry tests...\n");
+int main(void)
+{
+	printf("Starting counter registry tests...\n");
 
-    test_lookup_counter_by_name();
-    test_lookup_counter_by_id();
-    test_lookup_event_id();
-    test_get_all_counters();
-    test_block_type_coverage();
+	test_lookup_counter_by_name();
+	test_lookup_counter_by_id();
+	test_lookup_event_id();
+	test_get_all_counters();
+	test_block_type_coverage();
 
-    printf("\n=== Test Summary ===\n");
-    printf("Tests run: %d\n", tests_run);
-    printf("Tests passed: %d\n", tests_passed);
-    printf("Tests failed: %d\n", tests_run - tests_passed);
+	printf("\n=== Test Summary ===\n");
+	printf("Tests run: %d\n", tests_run);
+	printf("Tests passed: %d\n", tests_passed);
+	printf("Tests failed: %d\n", tests_run - tests_passed);
 
-    if (tests_passed == tests_run) {
-        printf("All tests PASSED!\n");
-        return 0;
-    } else {
-        printf("Some tests FAILED!\n");
-        return 1;
-    }
+	if (tests_passed == tests_run) {
+		printf("All tests PASSED!\n");
+		return 0;
+	} else {
+		printf("Some tests FAILED!\n");
+		return 1;
+	}
 }

--- a/projects/perf-dkms/src/aql_c/tests/test_dimension_decode.c
+++ b/projects/perf-dkms/src/aql_c/tests/test_dimension_decode.c
@@ -14,192 +14,214 @@
 static int tests_run = 0;
 static int tests_passed = 0;
 
-#define TEST_ASSERT(condition, message) do { \
-    tests_run++; \
-    if (condition) { \
-        tests_passed++; \
-        printf("PASS: %s\n", message); \
-    } else { \
-        printf("FAIL: %s\n", message); \
-    } \
-} while(0)
+#define TEST_ASSERT(condition, message)                \
+	do {                                           \
+		tests_run++;                           \
+		if (condition) {                       \
+			tests_passed++;                \
+			printf("PASS: %s\n", message); \
+		} else {                               \
+			printf("FAIL: %s\n", message); \
+		}                                      \
+	} while (0)
 
 /* GFX12 parameters for testing */
-#define TEST_SE_COUNT       4
-#define TEST_SA_COUNT       2
-#define TEST_WGP_PER_SA     4
+#define TEST_SE_COUNT 4
+#define TEST_SA_COUNT 2
+#define TEST_WGP_PER_SA 4
 
 /* Test encoding function */
-static void test_encode_dimension_index(void) {
-    printf("\n=== Testing Dimension Encoding ===\n");
+static void test_encode_dimension_index(void)
+{
+	printf("\n=== Testing Dimension Encoding ===\n");
 
-    /* Test known cases */
-    TEST_ASSERT(encode_dimension_index(0, 0, 0, TEST_SA_COUNT, TEST_WGP_PER_SA) == 0,
-                "SE=0, SA=0, WGP=0 encodes to index 0");
-    TEST_ASSERT(encode_dimension_index(0, 0, 3, TEST_SA_COUNT, TEST_WGP_PER_SA) == 3,
-                "SE=0, SA=0, WGP=3 encodes to index 3");
-    TEST_ASSERT(encode_dimension_index(0, 1, 0, TEST_SA_COUNT, TEST_WGP_PER_SA) == 4,
-                "SE=0, SA=1, WGP=0 encodes to index 4");
-    TEST_ASSERT(encode_dimension_index(0, 1, 3, TEST_SA_COUNT, TEST_WGP_PER_SA) == 7,
-                "SE=0, SA=1, WGP=3 encodes to index 7");
-    TEST_ASSERT(encode_dimension_index(1, 0, 0, TEST_SA_COUNT, TEST_WGP_PER_SA) == 8,
-                "SE=1, SA=0, WGP=0 encodes to index 8");
-    TEST_ASSERT(encode_dimension_index(3, 1, 3, TEST_SA_COUNT, TEST_WGP_PER_SA) == 31,
-                "SE=3, SA=1, WGP=3 encodes to index 31");
+	/* Test known cases */
+	TEST_ASSERT(encode_dimension_index(0, 0, 0, TEST_SA_COUNT, TEST_WGP_PER_SA) == 0,
+		    "SE=0, SA=0, WGP=0 encodes to index 0");
+	TEST_ASSERT(encode_dimension_index(0, 0, 3, TEST_SA_COUNT, TEST_WGP_PER_SA) == 3,
+		    "SE=0, SA=0, WGP=3 encodes to index 3");
+	TEST_ASSERT(encode_dimension_index(0, 1, 0, TEST_SA_COUNT, TEST_WGP_PER_SA) == 4,
+		    "SE=0, SA=1, WGP=0 encodes to index 4");
+	TEST_ASSERT(encode_dimension_index(0, 1, 3, TEST_SA_COUNT, TEST_WGP_PER_SA) == 7,
+		    "SE=0, SA=1, WGP=3 encodes to index 7");
+	TEST_ASSERT(encode_dimension_index(1, 0, 0, TEST_SA_COUNT, TEST_WGP_PER_SA) == 8,
+		    "SE=1, SA=0, WGP=0 encodes to index 8");
+	TEST_ASSERT(encode_dimension_index(3, 1, 3, TEST_SA_COUNT, TEST_WGP_PER_SA) == 31,
+		    "SE=3, SA=1, WGP=3 encodes to index 31");
 }
 
 /* Test decoding function */
-static void test_decode_dimension_index(void) {
-    printf("\n=== Testing Dimension Decoding ===\n");
+static void test_decode_dimension_index(void)
+{
+	printf("\n=== Testing Dimension Decoding ===\n");
 
-    /* Test known cases */
-    dimension_coords_t coords;
+	/* Test known cases */
+	dimension_coords_t coords;
 
-    coords = decode_dimension_index(0, TEST_SA_COUNT, TEST_WGP_PER_SA);
-    TEST_ASSERT(coords.se == 0 && coords.sa == 0 && coords.wgp == 0 && coords.flat_index == 0,
-                "Index 0 decodes to SE=0, SA=0, WGP=0");
+	coords = decode_dimension_index(0, TEST_SA_COUNT, TEST_WGP_PER_SA);
+	TEST_ASSERT(coords.se == 0 && coords.sa == 0 && coords.wgp == 0 && coords.flat_index == 0,
+		    "Index 0 decodes to SE=0, SA=0, WGP=0");
 
-    coords = decode_dimension_index(3, TEST_SA_COUNT, TEST_WGP_PER_SA);
-    TEST_ASSERT(coords.se == 0 && coords.sa == 0 && coords.wgp == 3 && coords.flat_index == 3,
-                "Index 3 decodes to SE=0, SA=0, WGP=3");
+	coords = decode_dimension_index(3, TEST_SA_COUNT, TEST_WGP_PER_SA);
+	TEST_ASSERT(coords.se == 0 && coords.sa == 0 && coords.wgp == 3 && coords.flat_index == 3,
+		    "Index 3 decodes to SE=0, SA=0, WGP=3");
 
-    coords = decode_dimension_index(4, TEST_SA_COUNT, TEST_WGP_PER_SA);
-    TEST_ASSERT(coords.se == 0 && coords.sa == 1 && coords.wgp == 0 && coords.flat_index == 4,
-                "Index 4 decodes to SE=0, SA=1, WGP=0");
+	coords = decode_dimension_index(4, TEST_SA_COUNT, TEST_WGP_PER_SA);
+	TEST_ASSERT(coords.se == 0 && coords.sa == 1 && coords.wgp == 0 && coords.flat_index == 4,
+		    "Index 4 decodes to SE=0, SA=1, WGP=0");
 
-    coords = decode_dimension_index(7, TEST_SA_COUNT, TEST_WGP_PER_SA);
-    TEST_ASSERT(coords.se == 0 && coords.sa == 1 && coords.wgp == 3 && coords.flat_index == 7,
-                "Index 7 decodes to SE=0, SA=1, WGP=3");
+	coords = decode_dimension_index(7, TEST_SA_COUNT, TEST_WGP_PER_SA);
+	TEST_ASSERT(coords.se == 0 && coords.sa == 1 && coords.wgp == 3 && coords.flat_index == 7,
+		    "Index 7 decodes to SE=0, SA=1, WGP=3");
 
-    coords = decode_dimension_index(8, TEST_SA_COUNT, TEST_WGP_PER_SA);
-    TEST_ASSERT(coords.se == 1 && coords.sa == 0 && coords.wgp == 0 && coords.flat_index == 8,
-                "Index 8 decodes to SE=1, SA=0, WGP=0");
+	coords = decode_dimension_index(8, TEST_SA_COUNT, TEST_WGP_PER_SA);
+	TEST_ASSERT(coords.se == 1 && coords.sa == 0 && coords.wgp == 0 && coords.flat_index == 8,
+		    "Index 8 decodes to SE=1, SA=0, WGP=0");
 
-    coords = decode_dimension_index(31, TEST_SA_COUNT, TEST_WGP_PER_SA);
-    TEST_ASSERT(coords.se == 3 && coords.sa == 1 && coords.wgp == 3 && coords.flat_index == 31,
-                "Index 31 decodes to SE=3, SA=1, WGP=3");
+	coords = decode_dimension_index(31, TEST_SA_COUNT, TEST_WGP_PER_SA);
+	TEST_ASSERT(coords.se == 3 && coords.sa == 1 && coords.wgp == 3 && coords.flat_index == 31,
+		    "Index 31 decodes to SE=3, SA=1, WGP=3");
 }
 
 /* Test round-trip encode/decode */
-static void test_round_trip(void) {
-    printf("\n=== Testing Round-trip Encode/Decode ===\n");
+static void test_round_trip(void)
+{
+	printf("\n=== Testing Round-trip Encode/Decode ===\n");
 
-    /* Test all valid combinations */
-    int all_passed = 1;
-    for (uint32_t se = 0; se < TEST_SE_COUNT; se++) {
-        for (uint32_t sa = 0; sa < TEST_SA_COUNT; sa++) {
-            for (uint32_t wgp = 0; wgp < TEST_WGP_PER_SA; wgp++) {
-                uint32_t encoded = encode_dimension_index(se, sa, wgp, TEST_SA_COUNT, TEST_WGP_PER_SA);
-                dimension_coords_t decoded = decode_dimension_index(encoded, TEST_SA_COUNT, TEST_WGP_PER_SA);
+	/* Test all valid combinations */
+	int all_passed = 1;
+	for (uint32_t se = 0; se < TEST_SE_COUNT; se++) {
+		for (uint32_t sa = 0; sa < TEST_SA_COUNT; sa++) {
+			for (uint32_t wgp = 0; wgp < TEST_WGP_PER_SA; wgp++) {
+				uint32_t encoded = encode_dimension_index(
+					se, sa, wgp, TEST_SA_COUNT, TEST_WGP_PER_SA);
+				dimension_coords_t decoded = decode_dimension_index(
+					encoded, TEST_SA_COUNT, TEST_WGP_PER_SA);
 
-                if (decoded.se != se || decoded.sa != sa || decoded.wgp != wgp || decoded.flat_index != encoded) {
-                    all_passed = 0;
-                    printf("FAIL: Round-trip failed for SE=%u, SA=%u, WGP=%u (encoded=%u, decoded=SE:%u SA:%u WGP:%u)\n",
-                           se, sa, wgp, encoded, decoded.se, decoded.sa, decoded.wgp);
-                }
-            }
-        }
-    }
+				if (decoded.se != se || decoded.sa != sa || decoded.wgp != wgp ||
+				    decoded.flat_index != encoded) {
+					all_passed = 0;
+					printf("FAIL: Round-trip failed for SE=%u, SA=%u, WGP=%u (encoded=%u, decoded=SE:%u SA:%u WGP:%u)\n",
+					       se, sa, wgp, encoded, decoded.se, decoded.sa,
+					       decoded.wgp);
+				}
+			}
+		}
+	}
 
-    TEST_ASSERT(all_passed, "All 32 round-trip encode/decode operations");
+	TEST_ASSERT(all_passed, "All 32 round-trip encode/decode operations");
 }
 
 /* Test validation function */
-static void test_validation(void) {
-    printf("\n=== Testing Coordinate Validation ===\n");
+static void test_validation(void)
+{
+	printf("\n=== Testing Coordinate Validation ===\n");
 
-    dimension_coords_t valid_coords = {0, 0, 0, 0};
-    TEST_ASSERT(validate_dimension_coords(&valid_coords, TEST_SE_COUNT, TEST_SA_COUNT, TEST_WGP_PER_SA) == 1,
-                "Valid coordinates (0,0,0) pass validation");
+	dimension_coords_t valid_coords = { 0, 0, 0, 0 };
+	TEST_ASSERT(validate_dimension_coords(&valid_coords, TEST_SE_COUNT, TEST_SA_COUNT,
+					      TEST_WGP_PER_SA) == 1,
+		    "Valid coordinates (0,0,0) pass validation");
 
-    dimension_coords_t valid_max = {TEST_SE_COUNT-1, TEST_SA_COUNT-1, TEST_WGP_PER_SA-1, 31};
-    TEST_ASSERT(validate_dimension_coords(&valid_max, TEST_SE_COUNT, TEST_SA_COUNT, TEST_WGP_PER_SA) == 1,
-                "Valid max coordinates pass validation");
+	dimension_coords_t valid_max = { TEST_SE_COUNT - 1, TEST_SA_COUNT - 1, TEST_WGP_PER_SA - 1,
+					 31 };
+	TEST_ASSERT(validate_dimension_coords(&valid_max, TEST_SE_COUNT, TEST_SA_COUNT,
+					      TEST_WGP_PER_SA) == 1,
+		    "Valid max coordinates pass validation");
 
-    dimension_coords_t invalid_se = {TEST_SE_COUNT, 0, 0, 0};
-    TEST_ASSERT(validate_dimension_coords(&invalid_se, TEST_SE_COUNT, TEST_SA_COUNT, TEST_WGP_PER_SA) == 0,
-                "Invalid SE coordinate fails validation");
+	dimension_coords_t invalid_se = { TEST_SE_COUNT, 0, 0, 0 };
+	TEST_ASSERT(validate_dimension_coords(&invalid_se, TEST_SE_COUNT, TEST_SA_COUNT,
+					      TEST_WGP_PER_SA) == 0,
+		    "Invalid SE coordinate fails validation");
 
-    dimension_coords_t invalid_sa = {0, TEST_SA_COUNT, 0, 0};
-    TEST_ASSERT(validate_dimension_coords(&invalid_sa, TEST_SE_COUNT, TEST_SA_COUNT, TEST_WGP_PER_SA) == 0,
-                "Invalid SA coordinate fails validation");
+	dimension_coords_t invalid_sa = { 0, TEST_SA_COUNT, 0, 0 };
+	TEST_ASSERT(validate_dimension_coords(&invalid_sa, TEST_SE_COUNT, TEST_SA_COUNT,
+					      TEST_WGP_PER_SA) == 0,
+		    "Invalid SA coordinate fails validation");
 
-    dimension_coords_t invalid_wgp = {0, 0, TEST_WGP_PER_SA, 0};
-    TEST_ASSERT(validate_dimension_coords(&invalid_wgp, TEST_SE_COUNT, TEST_SA_COUNT, TEST_WGP_PER_SA) == 0,
-                "Invalid WGP coordinate fails validation");
+	dimension_coords_t invalid_wgp = { 0, 0, TEST_WGP_PER_SA, 0 };
+	TEST_ASSERT(validate_dimension_coords(&invalid_wgp, TEST_SE_COUNT, TEST_SA_COUNT,
+					      TEST_WGP_PER_SA) == 0,
+		    "Invalid WGP coordinate fails validation");
 
-    TEST_ASSERT(validate_dimension_coords(NULL, TEST_SE_COUNT, TEST_SA_COUNT, TEST_WGP_PER_SA) == 0,
-                "NULL coordinates fail validation");
+	TEST_ASSERT(validate_dimension_coords(NULL, TEST_SE_COUNT, TEST_SA_COUNT,
+					      TEST_WGP_PER_SA) == 0,
+		    "NULL coordinates fail validation");
 }
 
 /* Test edge cases */
-static void test_edge_cases(void) {
-    printf("\n=== Testing Edge Cases ===\n");
+static void test_edge_cases(void)
+{
+	printf("\n=== Testing Edge Cases ===\n");
 
-    /* Test boundary values */
-    uint32_t max_index = (TEST_SE_COUNT * TEST_SA_COUNT * TEST_WGP_PER_SA) - 1;
-    dimension_coords_t coords = decode_dimension_index(max_index, TEST_SA_COUNT, TEST_WGP_PER_SA);
-    TEST_ASSERT(coords.se == TEST_SE_COUNT-1 && coords.sa == TEST_SA_COUNT-1 && coords.wgp == TEST_WGP_PER_SA-1,
-                "Maximum index decodes to maximum coordinates");
+	/* Test boundary values */
+	uint32_t max_index = (TEST_SE_COUNT * TEST_SA_COUNT * TEST_WGP_PER_SA) - 1;
+	dimension_coords_t coords =
+		decode_dimension_index(max_index, TEST_SA_COUNT, TEST_WGP_PER_SA);
+	TEST_ASSERT(coords.se == TEST_SE_COUNT - 1 && coords.sa == TEST_SA_COUNT - 1 &&
+			    coords.wgp == TEST_WGP_PER_SA - 1,
+		    "Maximum index decodes to maximum coordinates");
 
-    /* Test that we can handle the full range */
-    int sequential_test_passed = 1;
-    for (uint32_t i = 0; i < 32; i++) {
-        dimension_coords_t decoded = decode_dimension_index(i, TEST_SA_COUNT, TEST_WGP_PER_SA);
-        uint32_t re_encoded = encode_dimension_index(decoded.se, decoded.sa, decoded.wgp, TEST_SA_COUNT, TEST_WGP_PER_SA);
-        if (re_encoded != i) {
-            sequential_test_passed = 0;
-            break;
-        }
-    }
-    TEST_ASSERT(sequential_test_passed, "Sequential decode/encode for all 32 indices");
+	/* Test that we can handle the full range */
+	int sequential_test_passed = 1;
+	for (uint32_t i = 0; i < 32; i++) {
+		dimension_coords_t decoded =
+			decode_dimension_index(i, TEST_SA_COUNT, TEST_WGP_PER_SA);
+		uint32_t re_encoded = encode_dimension_index(decoded.se, decoded.sa, decoded.wgp,
+							     TEST_SA_COUNT, TEST_WGP_PER_SA);
+		if (re_encoded != i) {
+			sequential_test_passed = 0;
+			break;
+		}
+	}
+	TEST_ASSERT(sequential_test_passed, "Sequential decode/encode for all 32 indices");
 }
 
 /* Print a reference table */
-static void print_reference_table(void) {
-    printf("\n=== Reference Table (First 16 entries) ===\n");
-    printf("Index | SE | SA | WGP | Formula\n");
-    printf("------|----|----|-----|--------\n");
+static void print_reference_table(void)
+{
+	printf("\n=== Reference Table (First 16 entries) ===\n");
+	printf("Index | SE | SA | WGP | Formula\n");
+	printf("------|----|----|-----|--------\n");
 
-    for (uint32_t i = 0; i < 16 && i < 32; i++) {
-        dimension_coords_t coords = decode_dimension_index(i, TEST_SA_COUNT, TEST_WGP_PER_SA);
-        printf("%5u | %2u | %2u | %3u | (%u×2×4) + (%u×4) + %u = %u\n",
-               i, coords.se, coords.sa, coords.wgp,
-               coords.se, coords.sa, coords.wgp, i);
-    }
-    printf("  ... | ...| ...| ... | ...\n");
+	for (uint32_t i = 0; i < 16 && i < 32; i++) {
+		dimension_coords_t coords =
+			decode_dimension_index(i, TEST_SA_COUNT, TEST_WGP_PER_SA);
+		printf("%5u | %2u | %2u | %3u | (%u×2×4) + (%u×4) + %u = %u\n", i, coords.se,
+		       coords.sa, coords.wgp, coords.se, coords.sa, coords.wgp, i);
+	}
+	printf("  ... | ...| ...| ... | ...\n");
 
-    /* Show last entry */
-    dimension_coords_t coords = decode_dimension_index(31, TEST_SA_COUNT, TEST_WGP_PER_SA);
-    printf("%5u | %2u | %2u | %3u | (%u×2×4) + (%u×4) + %u = 31\n",
-           31, coords.se, coords.sa, coords.wgp,
-           coords.se, coords.sa, coords.wgp);
+	/* Show last entry */
+	dimension_coords_t coords = decode_dimension_index(31, TEST_SA_COUNT, TEST_WGP_PER_SA);
+	printf("%5u | %2u | %2u | %3u | (%u×2×4) + (%u×4) + %u = 31\n", 31, coords.se, coords.sa,
+	       coords.wgp, coords.se, coords.sa, coords.wgp);
 }
 
 /* Main test runner */
-int main(void) {
-    printf("=== Dimension Encode/Decode Test Suite ===\n");
-    printf("Testing with SE_COUNT=%d, SA_COUNT=%d, WGP_PER_SA=%d (Total: %d instances)\n",
-           TEST_SE_COUNT, TEST_SA_COUNT, TEST_WGP_PER_SA,
-           TEST_SE_COUNT * TEST_SA_COUNT * TEST_WGP_PER_SA);
+int main(void)
+{
+	printf("=== Dimension Encode/Decode Test Suite ===\n");
+	printf("Testing with SE_COUNT=%d, SA_COUNT=%d, WGP_PER_SA=%d (Total: %d instances)\n",
+	       TEST_SE_COUNT, TEST_SA_COUNT, TEST_WGP_PER_SA,
+	       TEST_SE_COUNT * TEST_SA_COUNT * TEST_WGP_PER_SA);
 
-    test_encode_dimension_index();
-    test_decode_dimension_index();
-    test_round_trip();
-    test_validation();
-    test_edge_cases();
-    print_reference_table();
+	test_encode_dimension_index();
+	test_decode_dimension_index();
+	test_round_trip();
+	test_validation();
+	test_edge_cases();
+	print_reference_table();
 
-    printf("\n=== Test Results ===\n");
-    printf("Tests run: %d\n", tests_run);
-    printf("Tests passed: %d\n", tests_passed);
-    printf("Tests failed: %d\n", tests_run - tests_passed);
+	printf("\n=== Test Results ===\n");
+	printf("Tests run: %d\n", tests_run);
+	printf("Tests passed: %d\n", tests_passed);
+	printf("Tests failed: %d\n", tests_run - tests_passed);
 
-    if (tests_passed == tests_run) {
-        printf("All tests PASSED!\n");
-        return 0;
-    } else {
-        printf("Some tests FAILED!\n");
-        return 1;
-    }
+	if (tests_passed == tests_run) {
+		printf("All tests PASSED!\n");
+		return 0;
+	} else {
+		printf("Some tests FAILED!\n");
+		return 1;
+	}
 }

--- a/projects/perf-dkms/src/aql_c/tests/test_dimension_helpers.c
+++ b/projects/perf-dkms/src/aql_c/tests/test_dimension_helpers.c
@@ -20,46 +20,46 @@
 static int tests_passed = 0;
 static int tests_failed = 0;
 
-#define TEST(name) \
-    printf("Running test: %s\n", #name); \
-    test_##name()
+#define TEST(name)                           \
+	printf("Running test: %s\n", #name); \
+	test_##name()
 
-#define ASSERT(condition, message) \
-    do { \
-        if (!(condition)) { \
-            printf("  FAIL: %s (line %d)\n", message, __LINE__); \
-            tests_failed++; \
-            return; \
-        } \
-    } while(0)
+#define ASSERT(condition, message)                                           \
+	do {                                                                 \
+		if (!(condition)) {                                          \
+			printf("  FAIL: %s (line %d)\n", message, __LINE__); \
+			tests_failed++;                                      \
+			return;                                              \
+		}                                                            \
+	} while (0)
 
-#define PASS() \
-    do { \
-        printf("  PASS\n"); \
-        tests_passed++; \
-    } while(0)
+#define PASS()                      \
+	do {                        \
+		printf("  PASS\n"); \
+		tests_passed++;     \
+	} while (0)
 
 /**
  * Test basic dimension extraction from config1
  */
 static void test_extract_basic_dimensions(void)
 {
-    struct pmu_dimension_coords dims = {0};
-    uint64_t config1;
+	struct pmu_dimension_coords dims = { 0 };
+	uint64_t config1;
 
-    /* Test case 1: SE=2, SA=1, WGP=3 */
-    config1 = (2ULL << 8) | (1ULL << 16) | (3ULL << 24);
-    pmu_extract_dimensions(config1, &dims);
+	/* Test case 1: SE=2, SA=1, WGP=3 */
+	config1 = (2ULL << 8) | (1ULL << 16) | (3ULL << 24);
+	pmu_extract_dimensions(config1, &dims);
 
-    ASSERT(dims.valid == true, "Dimensions should be valid when config1 != 0");
-    ASSERT(dims.xcc == 0, "XCC should be 0");
-    ASSERT(dims.se == 2, "SE should be 2");
-    ASSERT(dims.sa == 1, "SA should be 1");
-    ASSERT(dims.wgp == 3, "WGP should be 3");
-    ASSERT(dims.cu == 0, "CU should be 0");
-    ASSERT(dims.aggregate == false, "Aggregate should be false");
+	ASSERT(dims.valid == true, "Dimensions should be valid when config1 != 0");
+	ASSERT(dims.xcc == 0, "XCC should be 0");
+	ASSERT(dims.se == 2, "SE should be 2");
+	ASSERT(dims.sa == 1, "SA should be 1");
+	ASSERT(dims.wgp == 3, "WGP should be 3");
+	ASSERT(dims.cu == 0, "CU should be 0");
+	ASSERT(dims.aggregate == false, "Aggregate should be false");
 
-    PASS();
+	PASS();
 }
 
 /**
@@ -67,21 +67,21 @@ static void test_extract_basic_dimensions(void)
  */
 static void test_extract_all_dimensions(void)
 {
-    struct pmu_dimension_coords dims = {0};
-    uint64_t config1;
+	struct pmu_dimension_coords dims = { 0 };
+	uint64_t config1;
 
-    /* Test case: XCC=1, SE=3, SA=1, WGP=2, CU=5 */
-    config1 = (1ULL << 0) | (3ULL << 8) | (1ULL << 16) | (2ULL << 24) | (5ULL << 32);
-    pmu_extract_dimensions(config1, &dims);
+	/* Test case: XCC=1, SE=3, SA=1, WGP=2, CU=5 */
+	config1 = (1ULL << 0) | (3ULL << 8) | (1ULL << 16) | (2ULL << 24) | (5ULL << 32);
+	pmu_extract_dimensions(config1, &dims);
 
-    ASSERT(dims.valid == true, "Dimensions should be valid");
-    ASSERT(dims.xcc == 1, "XCC should be 1");
-    ASSERT(dims.se == 3, "SE should be 3");
-    ASSERT(dims.sa == 1, "SA should be 1");
-    ASSERT(dims.wgp == 2, "WGP should be 2");
-    ASSERT(dims.cu == 5, "CU should be 5");
+	ASSERT(dims.valid == true, "Dimensions should be valid");
+	ASSERT(dims.xcc == 1, "XCC should be 1");
+	ASSERT(dims.se == 3, "SE should be 3");
+	ASSERT(dims.sa == 1, "SA should be 1");
+	ASSERT(dims.wgp == 2, "WGP should be 2");
+	ASSERT(dims.cu == 5, "CU should be 5");
 
-    PASS();
+	PASS();
 }
 
 /**
@@ -89,25 +89,25 @@ static void test_extract_all_dimensions(void)
  */
 static void test_extract_flags(void)
 {
-    struct pmu_dimension_coords dims = {0};
-    uint64_t config1;
+	struct pmu_dimension_coords dims = { 0 };
+	uint64_t config1;
 
-    /* Test case: SE=1 with aggregate flag */
-    config1 = (1ULL << 8) | (1ULL << 40);  /* SE=1, aggregate=1 */
-    pmu_extract_dimensions(config1, &dims);
+	/* Test case: SE=1 with aggregate flag */
+	config1 = (1ULL << 8) | (1ULL << 40); /* SE=1, aggregate=1 */
+	pmu_extract_dimensions(config1, &dims);
 
-    ASSERT(dims.valid == true, "Dimensions should be valid");
-    ASSERT(dims.se == 1, "SE should be 1");
-    ASSERT(dims.aggregate == true, "Aggregate should be true");
+	ASSERT(dims.valid == true, "Dimensions should be valid");
+	ASSERT(dims.se == 1, "SE should be 1");
+	ASSERT(dims.aggregate == true, "Aggregate should be true");
 
-    /* Test case: aggregate flag alone */
-    config1 = (1ULL << 40);  /* aggregate=1 */
-    pmu_extract_dimensions(config1, &dims);
+	/* Test case: aggregate flag alone */
+	config1 = (1ULL << 40); /* aggregate=1 */
+	pmu_extract_dimensions(config1, &dims);
 
-    ASSERT(dims.valid == true, "Dimensions should be valid");
-    ASSERT(dims.aggregate == true, "Aggregate should be true");
+	ASSERT(dims.valid == true, "Dimensions should be valid");
+	ASSERT(dims.aggregate == true, "Aggregate should be true");
 
-    PASS();
+	PASS();
 }
 
 /**
@@ -115,19 +115,19 @@ static void test_extract_flags(void)
  */
 static void test_extract_zero_config(void)
 {
-    struct pmu_dimension_coords dims = {0};
-    uint64_t config1 = 0;
+	struct pmu_dimension_coords dims = { 0 };
+	uint64_t config1 = 0;
 
-    pmu_extract_dimensions(config1, &dims);
+	pmu_extract_dimensions(config1, &dims);
 
-    ASSERT(dims.valid == false, "Dimensions should not be valid when config1=0");
-    ASSERT(dims.xcc == 0, "All fields should be zero");
-    ASSERT(dims.se == 0, "All fields should be zero");
-    ASSERT(dims.sa == 0, "All fields should be zero");
-    ASSERT(dims.wgp == 0, "All fields should be zero");
-    ASSERT(dims.cu == 0, "All fields should be zero");
+	ASSERT(dims.valid == false, "Dimensions should not be valid when config1=0");
+	ASSERT(dims.xcc == 0, "All fields should be zero");
+	ASSERT(dims.se == 0, "All fields should be zero");
+	ASSERT(dims.sa == 0, "All fields should be zero");
+	ASSERT(dims.wgp == 0, "All fields should be zero");
+	ASSERT(dims.cu == 0, "All fields should be zero");
 
-    PASS();
+	PASS();
 }
 
 /**
@@ -135,47 +135,45 @@ static void test_extract_zero_config(void)
  */
 static void test_validate_valid_dimensions(void)
 {
-    struct pmu_dimension_coords dims = {0};
-    struct pmu_dimension_limits limits = {
-        .max_xcc = 0,  /* 1 XCC */
-        .max_se = 3,   /* 4 SEs */
-        .max_sa = 1,   /* 2 SAs */
-        .max_wgp = 3,  /* 4 WGPs */
-        .max_cu = 63   /* 64 CUs */
-    };
+	struct pmu_dimension_coords dims = { 0 };
+	struct pmu_dimension_limits limits = {
+		.max_xcc = 0, /* 1 XCC */
+		.max_se = 3, /* 4 SEs */
+		.max_sa = 1, /* 2 SAs */
+		.max_wgp = 3, /* 4 WGPs */
+		.max_cu = 63 /* 64 CUs */
+	};
 
-    /* Test valid coordinates at minimum */
-    dims.xcc = 0;
-    dims.se = 0;
-    dims.sa = 0;
-    dims.wgp = 0;
-    dims.cu = 0;
-    dims.valid = true;
+	/* Test valid coordinates at minimum */
+	dims.xcc = 0;
+	dims.se = 0;
+	dims.sa = 0;
+	dims.wgp = 0;
+	dims.cu = 0;
+	dims.valid = true;
 
-    ASSERT(pmu_validate_dimensions(&dims, &limits) == true,
-           "Min coordinates should be valid");
+	ASSERT(pmu_validate_dimensions(&dims, &limits) == true, "Min coordinates should be valid");
 
-    /* Test valid coordinates at maximum */
-    dims.xcc = 0;
-    dims.se = 3;
-    dims.sa = 1;
-    dims.wgp = 3;
-    dims.cu = 63;
+	/* Test valid coordinates at maximum */
+	dims.xcc = 0;
+	dims.se = 3;
+	dims.sa = 1;
+	dims.wgp = 3;
+	dims.cu = 63;
 
-    ASSERT(pmu_validate_dimensions(&dims, &limits) == true,
-           "Max coordinates should be valid");
+	ASSERT(pmu_validate_dimensions(&dims, &limits) == true, "Max coordinates should be valid");
 
-    /* Test mid-range coordinates */
-    dims.xcc = 0;
-    dims.se = 2;
-    dims.sa = 1;
-    dims.wgp = 2;
-    dims.cu = 30;
+	/* Test mid-range coordinates */
+	dims.xcc = 0;
+	dims.se = 2;
+	dims.sa = 1;
+	dims.wgp = 2;
+	dims.cu = 30;
 
-    ASSERT(pmu_validate_dimensions(&dims, &limits) == true,
-           "Mid-range coordinates should be valid");
+	ASSERT(pmu_validate_dimensions(&dims, &limits) == true,
+	       "Mid-range coordinates should be valid");
 
-    PASS();
+	PASS();
 }
 
 /**
@@ -183,48 +181,48 @@ static void test_validate_valid_dimensions(void)
  */
 static void test_validate_invalid_dimensions(void)
 {
-    struct pmu_dimension_coords dims = {0};
-    struct pmu_dimension_limits limits = {
-        .max_xcc = 0,  /* 1 XCC */
-        .max_se = 3,   /* 4 SEs */
-        .max_sa = 1,   /* 2 SAs */
-        .max_wgp = 3,  /* 4 WGPs */
-        .max_cu = 63   /* 64 CUs */
-    };
+	struct pmu_dimension_coords dims = { 0 };
+	struct pmu_dimension_limits limits = {
+		.max_xcc = 0, /* 1 XCC */
+		.max_se = 3, /* 4 SEs */
+		.max_sa = 1, /* 2 SAs */
+		.max_wgp = 3, /* 4 WGPs */
+		.max_cu = 63 /* 64 CUs */
+	};
 
-    /* Test SE out of range */
-    dims.xcc = 0;
-    dims.se = 4;  /* Too large */
-    dims.sa = 0;
-    dims.wgp = 0;
-    dims.cu = 0;
-    dims.valid = true;
+	/* Test SE out of range */
+	dims.xcc = 0;
+	dims.se = 4; /* Too large */
+	dims.sa = 0;
+	dims.wgp = 0;
+	dims.cu = 0;
+	dims.valid = true;
 
-    ASSERT(pmu_validate_dimensions(&dims, &limits) == false,
-           "SE out of range should be invalid");
+	ASSERT(pmu_validate_dimensions(&dims, &limits) == false,
+	       "SE out of range should be invalid");
 
-    /* Test SA out of range */
-    dims.se = 0;
-    dims.sa = 2;  /* Too large */
+	/* Test SA out of range */
+	dims.se = 0;
+	dims.sa = 2; /* Too large */
 
-    ASSERT(pmu_validate_dimensions(&dims, &limits) == false,
-           "SA out of range should be invalid");
+	ASSERT(pmu_validate_dimensions(&dims, &limits) == false,
+	       "SA out of range should be invalid");
 
-    /* Test WGP out of range */
-    dims.sa = 0;
-    dims.wgp = 4;  /* Too large */
+	/* Test WGP out of range */
+	dims.sa = 0;
+	dims.wgp = 4; /* Too large */
 
-    ASSERT(pmu_validate_dimensions(&dims, &limits) == false,
-           "WGP out of range should be invalid");
+	ASSERT(pmu_validate_dimensions(&dims, &limits) == false,
+	       "WGP out of range should be invalid");
 
-    /* Test CU out of range */
-    dims.wgp = 0;
-    dims.cu = 64;  /* Too large */
+	/* Test CU out of range */
+	dims.wgp = 0;
+	dims.cu = 64; /* Too large */
 
-    ASSERT(pmu_validate_dimensions(&dims, &limits) == false,
-           "CU out of range should be invalid");
+	ASSERT(pmu_validate_dimensions(&dims, &limits) == false,
+	       "CU out of range should be invalid");
 
-    PASS();
+	PASS();
 }
 
 /**
@@ -232,27 +230,23 @@ static void test_validate_invalid_dimensions(void)
  */
 static void test_validate_invalid_flag(void)
 {
-    struct pmu_dimension_coords dims = {0};
-    struct pmu_dimension_limits limits = {
-        .max_xcc = 0,
-        .max_se = 3,
-        .max_sa = 1,
-        .max_wgp = 3,
-        .max_cu = 63
-    };
+	struct pmu_dimension_coords dims = { 0 };
+	struct pmu_dimension_limits limits = {
+		.max_xcc = 0, .max_se = 3, .max_sa = 1, .max_wgp = 3, .max_cu = 63
+	};
 
-    /* Valid coordinates but invalid flag */
-    dims.xcc = 0;
-    dims.se = 2;
-    dims.sa = 1;
-    dims.wgp = 2;
-    dims.cu = 0;
-    dims.valid = false;  /* Not valid */
+	/* Valid coordinates but invalid flag */
+	dims.xcc = 0;
+	dims.se = 2;
+	dims.sa = 1;
+	dims.wgp = 2;
+	dims.cu = 0;
+	dims.valid = false; /* Not valid */
 
-    ASSERT(pmu_validate_dimensions(&dims, &limits) == true,
-           "Validation should still check ranges even if valid=false");
+	ASSERT(pmu_validate_dimensions(&dims, &limits) == true,
+	       "Validation should still check ranges even if valid=false");
 
-    PASS();
+	PASS();
 }
 
 /**
@@ -260,33 +254,33 @@ static void test_validate_invalid_flag(void)
  */
 static void test_encode_dimension_index(void)
 {
-    uint32_t flat_index;
+	uint32_t flat_index;
 
-    /* GFX12 has: 4 SEs, 2 SAs, 4 WGPs per SA */
-    uint32_t sa_count = 2;
-    uint32_t wgp_per_sa = 4;
+	/* GFX12 has: 4 SEs, 2 SAs, 4 WGPs per SA */
+	uint32_t sa_count = 2;
+	uint32_t wgp_per_sa = 4;
 
-    /* Test case 1: SE=0, SA=0, WGP=0 */
-    flat_index = encode_dimension_index(0, 0, 0, sa_count, wgp_per_sa);
-    ASSERT(flat_index == 0, "First index should be 0");
+	/* Test case 1: SE=0, SA=0, WGP=0 */
+	flat_index = encode_dimension_index(0, 0, 0, sa_count, wgp_per_sa);
+	ASSERT(flat_index == 0, "First index should be 0");
 
-    /* Test case 2: SE=0, SA=0, WGP=1 */
-    flat_index = encode_dimension_index(0, 0, 1, sa_count, wgp_per_sa);
-    ASSERT(flat_index == 1, "SE=0,SA=0,WGP=1 should be index 1");
+	/* Test case 2: SE=0, SA=0, WGP=1 */
+	flat_index = encode_dimension_index(0, 0, 1, sa_count, wgp_per_sa);
+	ASSERT(flat_index == 1, "SE=0,SA=0,WGP=1 should be index 1");
 
-    /* Test case 3: SE=0, SA=1, WGP=0 */
-    flat_index = encode_dimension_index(0, 1, 0, sa_count, wgp_per_sa);
-    ASSERT(flat_index == 4, "SE=0,SA=1,WGP=0 should be index 4");
+	/* Test case 3: SE=0, SA=1, WGP=0 */
+	flat_index = encode_dimension_index(0, 1, 0, sa_count, wgp_per_sa);
+	ASSERT(flat_index == 4, "SE=0,SA=1,WGP=0 should be index 4");
 
-    /* Test case 4: SE=1, SA=0, WGP=0 */
-    flat_index = encode_dimension_index(1, 0, 0, sa_count, wgp_per_sa);
-    ASSERT(flat_index == 8, "SE=1,SA=0,WGP=0 should be index 8");
+	/* Test case 4: SE=1, SA=0, WGP=0 */
+	flat_index = encode_dimension_index(1, 0, 0, sa_count, wgp_per_sa);
+	ASSERT(flat_index == 8, "SE=1,SA=0,WGP=0 should be index 8");
 
-    /* Test case 5: SE=2, SA=1, WGP=3 */
-    flat_index = encode_dimension_index(2, 1, 3, sa_count, wgp_per_sa);
-    ASSERT(flat_index == 23, "SE=2,SA=1,WGP=3 should be index 23");
+	/* Test case 5: SE=2, SA=1, WGP=3 */
+	flat_index = encode_dimension_index(2, 1, 3, sa_count, wgp_per_sa);
+	ASSERT(flat_index == 23, "SE=2,SA=1,WGP=3 should be index 23");
 
-    PASS();
+	PASS();
 }
 
 /**
@@ -294,35 +288,35 @@ static void test_encode_dimension_index(void)
  */
 static void test_decode_dimension_index(void)
 {
-    dimension_coords_t coords;
-    uint32_t sa_count = 2;
-    uint32_t wgp_per_sa = 4;
+	dimension_coords_t coords;
+	uint32_t sa_count = 2;
+	uint32_t wgp_per_sa = 4;
 
-    /* Test case 1: Index 0 */
-    coords = decode_dimension_index(0, sa_count, wgp_per_sa);
-    ASSERT(coords.se == 0, "Index 0: SE should be 0");
-    ASSERT(coords.sa == 0, "Index 0: SA should be 0");
-    ASSERT(coords.wgp == 0, "Index 0: WGP should be 0");
+	/* Test case 1: Index 0 */
+	coords = decode_dimension_index(0, sa_count, wgp_per_sa);
+	ASSERT(coords.se == 0, "Index 0: SE should be 0");
+	ASSERT(coords.sa == 0, "Index 0: SA should be 0");
+	ASSERT(coords.wgp == 0, "Index 0: WGP should be 0");
 
-    /* Test case 2: Index 5 */
-    coords = decode_dimension_index(5, sa_count, wgp_per_sa);
-    ASSERT(coords.se == 0, "Index 5: SE should be 0");
-    ASSERT(coords.sa == 1, "Index 5: SA should be 1");
-    ASSERT(coords.wgp == 1, "Index 5: WGP should be 1");
+	/* Test case 2: Index 5 */
+	coords = decode_dimension_index(5, sa_count, wgp_per_sa);
+	ASSERT(coords.se == 0, "Index 5: SE should be 0");
+	ASSERT(coords.sa == 1, "Index 5: SA should be 1");
+	ASSERT(coords.wgp == 1, "Index 5: WGP should be 1");
 
-    /* Test case 3: Index 8 */
-    coords = decode_dimension_index(8, sa_count, wgp_per_sa);
-    ASSERT(coords.se == 1, "Index 8: SE should be 1");
-    ASSERT(coords.sa == 0, "Index 8: SA should be 0");
-    ASSERT(coords.wgp == 0, "Index 8: WGP should be 0");
+	/* Test case 3: Index 8 */
+	coords = decode_dimension_index(8, sa_count, wgp_per_sa);
+	ASSERT(coords.se == 1, "Index 8: SE should be 1");
+	ASSERT(coords.sa == 0, "Index 8: SA should be 0");
+	ASSERT(coords.wgp == 0, "Index 8: WGP should be 0");
 
-    /* Test case 4: Index 23 */
-    coords = decode_dimension_index(23, sa_count, wgp_per_sa);
-    ASSERT(coords.se == 2, "Index 23: SE should be 2");
-    ASSERT(coords.sa == 1, "Index 23: SA should be 1");
-    ASSERT(coords.wgp == 3, "Index 23: WGP should be 3");
+	/* Test case 4: Index 23 */
+	coords = decode_dimension_index(23, sa_count, wgp_per_sa);
+	ASSERT(coords.se == 2, "Index 23: SE should be 2");
+	ASSERT(coords.sa == 1, "Index 23: SA should be 1");
+	ASSERT(coords.wgp == 3, "Index 23: WGP should be 3");
 
-    PASS();
+	PASS();
 }
 
 /**
@@ -330,25 +324,28 @@ static void test_decode_dimension_index(void)
  */
 static void test_encode_decode_roundtrip(void)
 {
-    uint32_t sa_count = 2;
-    uint32_t wgp_per_sa = 4;
+	uint32_t sa_count = 2;
+	uint32_t wgp_per_sa = 4;
 
-    /* Test all valid SE/SA/WGP combinations for GFX12 */
-    for (uint32_t se = 0; se < 4; se++) {
-        for (uint32_t sa = 0; sa < 2; sa++) {
-            for (uint32_t wgp = 0; wgp < 4; wgp++) {
-                uint32_t flat = encode_dimension_index(se, sa, wgp, sa_count, wgp_per_sa);
-                dimension_coords_t coords = decode_dimension_index(flat, sa_count, wgp_per_sa);
+	/* Test all valid SE/SA/WGP combinations for GFX12 */
+	for (uint32_t se = 0; se < 4; se++) {
+		for (uint32_t sa = 0; sa < 2; sa++) {
+			for (uint32_t wgp = 0; wgp < 4; wgp++) {
+				uint32_t flat =
+					encode_dimension_index(se, sa, wgp, sa_count, wgp_per_sa);
+				dimension_coords_t coords =
+					decode_dimension_index(flat, sa_count, wgp_per_sa);
 
-                ASSERT(coords.se == se, "Round-trip: SE mismatch");
-                ASSERT(coords.sa == sa, "Round-trip: SA mismatch");
-                ASSERT(coords.wgp == wgp, "Round-trip: WGP mismatch");
-                ASSERT(coords.flat_index == flat, "Round-trip: flat index mismatch");
-            }
-        }
-    }
+				ASSERT(coords.se == se, "Round-trip: SE mismatch");
+				ASSERT(coords.sa == sa, "Round-trip: SA mismatch");
+				ASSERT(coords.wgp == wgp, "Round-trip: WGP mismatch");
+				ASSERT(coords.flat_index == flat,
+				       "Round-trip: flat index mismatch");
+			}
+		}
+	}
 
-    PASS();
+	PASS();
 }
 
 /**
@@ -356,48 +353,48 @@ static void test_encode_decode_roundtrip(void)
  */
 static void test_validate_dimension_coords(void)
 {
-    dimension_coords_t coords;
-    uint32_t se_count = 4;
-    uint32_t sa_count = 2;
-    uint32_t wgp_per_sa = 4;
+	dimension_coords_t coords;
+	uint32_t se_count = 4;
+	uint32_t sa_count = 2;
+	uint32_t wgp_per_sa = 4;
 
-    /* Valid coordinates */
-    coords.se = 2;
-    coords.sa = 1;
-    coords.wgp = 3;
+	/* Valid coordinates */
+	coords.se = 2;
+	coords.sa = 1;
+	coords.wgp = 3;
 
-    ASSERT(validate_dimension_coords(&coords, se_count, sa_count, wgp_per_sa) == 1,
-           "Valid coordinates should pass");
+	ASSERT(validate_dimension_coords(&coords, se_count, sa_count, wgp_per_sa) == 1,
+	       "Valid coordinates should pass");
 
-    /* SE out of range */
-    coords.se = 4;
-    coords.sa = 1;
-    coords.wgp = 0;
+	/* SE out of range */
+	coords.se = 4;
+	coords.sa = 1;
+	coords.wgp = 0;
 
-    ASSERT(validate_dimension_coords(&coords, se_count, sa_count, wgp_per_sa) == 0,
-           "SE out of range should fail");
+	ASSERT(validate_dimension_coords(&coords, se_count, sa_count, wgp_per_sa) == 0,
+	       "SE out of range should fail");
 
-    /* SA out of range */
-    coords.se = 0;
-    coords.sa = 2;
-    coords.wgp = 0;
+	/* SA out of range */
+	coords.se = 0;
+	coords.sa = 2;
+	coords.wgp = 0;
 
-    ASSERT(validate_dimension_coords(&coords, se_count, sa_count, wgp_per_sa) == 0,
-           "SA out of range should fail");
+	ASSERT(validate_dimension_coords(&coords, se_count, sa_count, wgp_per_sa) == 0,
+	       "SA out of range should fail");
 
-    /* WGP out of range */
-    coords.se = 0;
-    coords.sa = 0;
-    coords.wgp = 4;
+	/* WGP out of range */
+	coords.se = 0;
+	coords.sa = 0;
+	coords.wgp = 4;
 
-    ASSERT(validate_dimension_coords(&coords, se_count, sa_count, wgp_per_sa) == 0,
-           "WGP out of range should fail");
+	ASSERT(validate_dimension_coords(&coords, se_count, sa_count, wgp_per_sa) == 0,
+	       "WGP out of range should fail");
 
-    /* NULL pointer */
-    ASSERT(validate_dimension_coords(NULL, se_count, sa_count, wgp_per_sa) == 0,
-           "NULL pointer should fail");
+	/* NULL pointer */
+	ASSERT(validate_dimension_coords(NULL, se_count, sa_count, wgp_per_sa) == 0,
+	       "NULL pointer should fail");
 
-    PASS();
+	PASS();
 }
 
 /**
@@ -405,26 +402,26 @@ static void test_validate_dimension_coords(void)
  */
 static void test_extract_max_values(void)
 {
-    struct pmu_dimension_coords dims = {0};
-    uint64_t config1;
+	struct pmu_dimension_coords dims = { 0 };
+	uint64_t config1;
 
-    /* All fields at maximum (8 bits = 255) */
-    config1 = (255ULL << 0) |   /* XCC */
-              (255ULL << 8) |   /* SE */
-              (255ULL << 16) |  /* SA */
-              (255ULL << 24) |  /* WGP */
-              (255ULL << 32);   /* CU */
+	/* All fields at maximum (8 bits = 255) */
+	config1 = (255ULL << 0) | /* XCC */
+		  (255ULL << 8) | /* SE */
+		  (255ULL << 16) | /* SA */
+		  (255ULL << 24) | /* WGP */
+		  (255ULL << 32); /* CU */
 
-    pmu_extract_dimensions(config1, &dims);
+	pmu_extract_dimensions(config1, &dims);
 
-    ASSERT(dims.valid == true, "Dimensions should be valid");
-    ASSERT(dims.xcc == 255, "XCC should be 255");
-    ASSERT(dims.se == 255, "SE should be 255");
-    ASSERT(dims.sa == 255, "SA should be 255");
-    ASSERT(dims.wgp == 255, "WGP should be 255");
-    ASSERT(dims.cu == 255, "CU should be 255");
+	ASSERT(dims.valid == true, "Dimensions should be valid");
+	ASSERT(dims.xcc == 255, "XCC should be 255");
+	ASSERT(dims.se == 255, "SE should be 255");
+	ASSERT(dims.sa == 255, "SA should be 255");
+	ASSERT(dims.wgp == 255, "WGP should be 255");
+	ASSERT(dims.cu == 255, "CU should be 255");
 
-    PASS();
+	PASS();
 }
 
 /**
@@ -432,31 +429,31 @@ static void test_extract_max_values(void)
  */
 int main(void)
 {
-    printf("=== Dimension Helper Unit Tests ===\n\n");
+	printf("=== Dimension Helper Unit Tests ===\n\n");
 
-    /* Extraction tests */
-    TEST(extract_basic_dimensions);
-    TEST(extract_all_dimensions);
-    TEST(extract_flags);
-    TEST(extract_zero_config);
-    TEST(extract_max_values);
+	/* Extraction tests */
+	TEST(extract_basic_dimensions);
+	TEST(extract_all_dimensions);
+	TEST(extract_flags);
+	TEST(extract_zero_config);
+	TEST(extract_max_values);
 
-    /* Validation tests */
-    TEST(validate_valid_dimensions);
-    TEST(validate_invalid_dimensions);
-    TEST(validate_invalid_flag);
+	/* Validation tests */
+	TEST(validate_valid_dimensions);
+	TEST(validate_invalid_dimensions);
+	TEST(validate_invalid_flag);
 
-    /* Encode/decode tests */
-    TEST(encode_dimension_index);
-    TEST(decode_dimension_index);
-    TEST(encode_decode_roundtrip);
-    TEST(validate_dimension_coords);
+	/* Encode/decode tests */
+	TEST(encode_dimension_index);
+	TEST(decode_dimension_index);
+	TEST(encode_decode_roundtrip);
+	TEST(validate_dimension_coords);
 
-    /* Summary */
-    printf("\n=== Test Summary ===\n");
-    printf("PASSED: %d\n", tests_passed);
-    printf("FAILED: %d\n", tests_failed);
-    printf("TOTAL:  %d\n", tests_passed + tests_failed);
+	/* Summary */
+	printf("\n=== Test Summary ===\n");
+	printf("PASSED: %d\n", tests_passed);
+	printf("FAILED: %d\n", tests_failed);
+	printf("TOTAL:  %d\n", tests_passed + tests_failed);
 
-    return (tests_failed == 0) ? 0 : 1;
+	return (tests_failed == 0) ? 0 : 1;
 }

--- a/projects/perf-dkms/src/aql_c/tests/test_gfx12.c
+++ b/projects/perf-dkms/src/aql_c/tests/test_gfx12.c
@@ -16,1042 +16,1355 @@
 static int tests_run = 0;
 static int tests_passed = 0;
 
-#define TEST_ASSERT(condition, message) do { \
-    tests_run++; \
-    if (condition) { \
-        tests_passed++; \
-        printf("PASS: %s\n", message); \
-    } else { \
-        printf("FAIL: %s\n", message); \
-    } \
-} while(0)
+#define TEST_ASSERT(condition, message)                \
+	do {                                           \
+		tests_run++;                           \
+		if (condition) {                       \
+			tests_passed++;                \
+			printf("PASS: %s\n", message); \
+		} else {                               \
+			printf("FAIL: %s\n", message); \
+		}                                      \
+	} while (0)
 
 /* Forward declaration of external function */
-extern arch_t* arch_create_by_name(const char* arch_name);
+extern arch_t *arch_create_by_name(const char *arch_name);
 
 /* Helper function to free architecture structure */
-static void free_arch(arch_t* arch) {
-    if (!arch) return;
+static void free_arch(arch_t *arch)
+{
+	if (!arch)
+		return;
 
-    for (int i = 0; i < HW_IP_BLOCK_LAST; i++) {
-        block_info_t* block = arch->block_map.blocks[i];
-        if (block) {
-            if (block->counter_reg_info) {
-                free(block->counter_reg_info);
-            }
-            if (block->dimensions) {
-                free(block->dimensions);
-            }
-            free(block);
-        }
-    }
-    free(arch);
+	for (int i = 0; i < HW_IP_BLOCK_LAST; i++) {
+		block_info_t *block = arch->block_map.blocks[i];
+		if (block) {
+			if (block->counter_reg_info) {
+				free(block->counter_reg_info);
+			}
+			if (block->dimensions) {
+				free(block->dimensions);
+			}
+			free(block);
+		}
+	}
+	free(arch);
 }
 
 /* Test basic GFX12 architecture creation */
-static void test_gfx12_arch_creation(void) {
-    printf("\n=== Testing GFX12 Architecture Creation ===\n");
+static void test_gfx12_arch_creation(void)
+{
+	printf("\n=== Testing GFX12 Architecture Creation ===\n");
 
-    arch_t* arch = arch_create_by_name("gfx12");
-    TEST_ASSERT(arch != NULL, "GFX12 architecture creation");
+	arch_t *arch = arch_create_by_name("gfx12");
+	TEST_ASSERT(arch != NULL, "GFX12 architecture creation");
 
-    if (arch) {
-        TEST_ASSERT(arch->type == ARCH_TYPE_GFX12, "Architecture type is GFX12");
-        TEST_ASSERT(arch->num_xcc == 1, "GFX12 XCC count is 1");
-        TEST_ASSERT(arch->num_se == 4, "GFX12 SE count is 4");
-        TEST_ASSERT(arch->num_sa == 2, "GFX12 SA count is 2");
-        TEST_ASSERT(arch->num_cu == 64, "GFX12 CU count is 64");
-        TEST_ASSERT(arch->num_wgp_per_sa == 4, "GFX12 WGP per SA count is 4");
-        TEST_ASSERT(arch->block_map.block_count == 14, "Block map has 14 blocks");
+	if (arch) {
+		TEST_ASSERT(arch->type == ARCH_TYPE_GFX12, "Architecture type is GFX12");
+		TEST_ASSERT(arch->num_xcc == 1, "GFX12 XCC count is 1");
+		TEST_ASSERT(arch->num_se == 4, "GFX12 SE count is 4");
+		TEST_ASSERT(arch->num_sa == 2, "GFX12 SA count is 2");
+		TEST_ASSERT(arch->num_cu == 64, "GFX12 CU count is 64");
+		TEST_ASSERT(arch->num_wgp_per_sa == 4, "GFX12 WGP per SA count is 4");
+		TEST_ASSERT(arch->block_map.block_count == 14, "Block map has 14 blocks");
 
-        free_arch(arch);
-    }
+		free_arch(arch);
+	}
 }
 
 /* Test CPC block configuration */
-static void test_gfx12_cpc_block(void) {
-    printf("\n=== Testing GFX12 CPC Block ===\n");
+static void test_gfx12_cpc_block(void)
+{
+	printf("\n=== Testing GFX12 CPC Block ===\n");
 
-    arch_t* arch = arch_create_by_name("gfx12");
-    TEST_ASSERT(arch != NULL, "Architecture created for CPC block test");
+	arch_t *arch = arch_create_by_name("gfx12");
+	TEST_ASSERT(arch != NULL, "Architecture created for CPC block test");
 
-    if (arch) {
-        block_info_t* cpc_block = arch->block_map.blocks[HW_IP_BLOCK_CPC];
-        TEST_ASSERT(cpc_block != NULL, "CPC block exists");
+	if (arch) {
+		block_info_t *cpc_block = arch->block_map.blocks[HW_IP_BLOCK_CPC];
+		TEST_ASSERT(cpc_block != NULL, "CPC block exists");
 
-        if (cpc_block) {
-            TEST_ASSERT(strcmp(cpc_block->name, "CPC") == 0, "CPC block name is correct");
-            TEST_ASSERT(cpc_block->id == HW_IP_BLOCK_CPC, "CPC block ID is correct");
-            TEST_ASSERT(cpc_block->counter_count == 2, "CPC block has 2 counters");
-            TEST_ASSERT(cpc_block->counter_reg_info != NULL, "CPC counter register info exists");
-            TEST_ASSERT(cpc_block->dimension_count == 1, "CPC block has 1 dimension");
-            TEST_ASSERT(cpc_block->dimensions != NULL, "CPC dimensions array exists");
+		if (cpc_block) {
+			TEST_ASSERT(strcmp(cpc_block->name, "CPC") == 0,
+				    "CPC block name is correct");
+			TEST_ASSERT(cpc_block->id == HW_IP_BLOCK_CPC, "CPC block ID is correct");
+			TEST_ASSERT(cpc_block->counter_count == 2, "CPC block has 2 counters");
+			TEST_ASSERT(cpc_block->counter_reg_info != NULL,
+				    "CPC counter register info exists");
+			TEST_ASSERT(cpc_block->dimension_count == 1, "CPC block has 1 dimension");
+			TEST_ASSERT(cpc_block->dimensions != NULL, "CPC dimensions array exists");
 
-            if (cpc_block->dimensions) {
-                TEST_ASSERT(cpc_block->dimensions[0].dim == HARDWARE_DIM_XCC, "CPC dimension is XCC");
-                TEST_ASSERT(cpc_block->dimensions[0].size == 1, "CPC XCC dimension size is 1");
-            }
+			if (cpc_block->dimensions) {
+				TEST_ASSERT(cpc_block->dimensions[0].dim == HARDWARE_DIM_XCC,
+					    "CPC dimension is XCC");
+				TEST_ASSERT(cpc_block->dimensions[0].size == 1,
+					    "CPC XCC dimension size is 1");
+			}
 
-            /* Test counter register info */
-            if (cpc_block->counter_reg_info) {
-                counter_reg_info_t* reg0 = &cpc_block->counter_reg_info[0];
-                TEST_ASSERT(reg0->select_addr == 55305, "CPC counter 0 select address");
-                TEST_ASSERT(reg0->register_addr_lo == 53254, "CPC counter 0 LO address");
-                TEST_ASSERT(reg0->register_addr_hi == 53255, "CPC counter 0 HI address");
-                TEST_ASSERT(reg0->allocation.state == COUNTER_STATE_FREE, "CPC counter 0 initial state is FREE");
+			/* Test counter register info */
+			if (cpc_block->counter_reg_info) {
+				counter_reg_info_t *reg0 = &cpc_block->counter_reg_info[0];
+				TEST_ASSERT(reg0->select_addr == 55305,
+					    "CPC counter 0 select address");
+				TEST_ASSERT(reg0->register_addr_lo == 53254,
+					    "CPC counter 0 LO address");
+				TEST_ASSERT(reg0->register_addr_hi == 53255,
+					    "CPC counter 0 HI address");
+				TEST_ASSERT(reg0->allocation.state == COUNTER_STATE_FREE,
+					    "CPC counter 0 initial state is FREE");
 
-                counter_reg_info_t* reg1 = &cpc_block->counter_reg_info[1];
-                TEST_ASSERT(reg1->select_addr == 55299, "CPC counter 1 select address");
-                TEST_ASSERT(reg1->register_addr_lo == 53252, "CPC counter 1 LO address");
-                TEST_ASSERT(reg1->register_addr_hi == 53253, "CPC counter 1 HI address");
-                TEST_ASSERT(reg1->allocation.state == COUNTER_STATE_FREE, "CPC counter 1 initial state is FREE");
-            }
-        }
+				counter_reg_info_t *reg1 = &cpc_block->counter_reg_info[1];
+				TEST_ASSERT(reg1->select_addr == 55299,
+					    "CPC counter 1 select address");
+				TEST_ASSERT(reg1->register_addr_lo == 53252,
+					    "CPC counter 1 LO address");
+				TEST_ASSERT(reg1->register_addr_hi == 53253,
+					    "CPC counter 1 HI address");
+				TEST_ASSERT(reg1->allocation.state == COUNTER_STATE_FREE,
+					    "CPC counter 1 initial state is FREE");
+			}
+		}
 
-        free_arch(arch);
-    }
+		free_arch(arch);
+	}
 }
 
 /* Test SQ block configuration */
-static void test_gfx12_sq_block(void) {
-    printf("\n=== Testing GFX12 SQ Block ===\n");
+static void test_gfx12_sq_block(void)
+{
+	printf("\n=== Testing GFX12 SQ Block ===\n");
 
-    arch_t* arch = arch_create_by_name("gfx12");
-    TEST_ASSERT(arch != NULL, "Architecture created for SQ block test");
+	arch_t *arch = arch_create_by_name("gfx12");
+	TEST_ASSERT(arch != NULL, "Architecture created for SQ block test");
 
-    if (arch) {
-        block_info_t* sq_block = arch->block_map.blocks[HW_IP_BLOCK_SQ];
-        TEST_ASSERT(sq_block != NULL, "SQ block exists");
+	if (arch) {
+		block_info_t *sq_block = arch->block_map.blocks[HW_IP_BLOCK_SQ];
+		TEST_ASSERT(sq_block != NULL, "SQ block exists");
 
-        if (sq_block) {
-            TEST_ASSERT(strcmp(sq_block->name, "SQ") == 0, "SQ block name is correct");
-            TEST_ASSERT(sq_block->id == HW_IP_BLOCK_SQ, "SQ block ID is correct");
-            TEST_ASSERT(sq_block->counter_count == 8, "SQ block has 8 counters");
-            TEST_ASSERT(sq_block->counter_reg_info != NULL, "SQ counter register info exists");
-            TEST_ASSERT(sq_block->dimension_count == 3, "SQ block has 3 dimensions");
-            TEST_ASSERT(sq_block->dimensions != NULL, "SQ dimensions array exists");
-            TEST_ASSERT(sq_block->spm_block_id == 9, "SQ SPM block ID is correct");
+		if (sq_block) {
+			TEST_ASSERT(strcmp(sq_block->name, "SQ") == 0, "SQ block name is correct");
+			TEST_ASSERT(sq_block->id == HW_IP_BLOCK_SQ, "SQ block ID is correct");
+			TEST_ASSERT(sq_block->counter_count == 8, "SQ block has 8 counters");
+			TEST_ASSERT(sq_block->counter_reg_info != NULL,
+				    "SQ counter register info exists");
+			TEST_ASSERT(sq_block->dimension_count == 3, "SQ block has 3 dimensions");
+			TEST_ASSERT(sq_block->dimensions != NULL, "SQ dimensions array exists");
+			TEST_ASSERT(sq_block->spm_block_id == 9, "SQ SPM block ID is correct");
 
-            /* Test dimensions */
-            if (sq_block->dimensions) {
-                TEST_ASSERT(sq_block->dimensions[0].dim == HARDWARE_DIM_SE, "SQ dimension 0 is SE");
-                TEST_ASSERT(sq_block->dimensions[0].size == 4, "SQ SE dimension size is 4");
+			/* Test dimensions */
+			if (sq_block->dimensions) {
+				TEST_ASSERT(sq_block->dimensions[0].dim == HARDWARE_DIM_SE,
+					    "SQ dimension 0 is SE");
+				TEST_ASSERT(sq_block->dimensions[0].size == 4,
+					    "SQ SE dimension size is 4");
 
-                TEST_ASSERT(sq_block->dimensions[1].dim == HARDWARE_DIM_SA, "SQ dimension 1 is SA");
-                TEST_ASSERT(sq_block->dimensions[1].size == 2, "SQ SA dimension size is 2");
+				TEST_ASSERT(sq_block->dimensions[1].dim == HARDWARE_DIM_SA,
+					    "SQ dimension 1 is SA");
+				TEST_ASSERT(sq_block->dimensions[1].size == 2,
+					    "SQ SA dimension size is 2");
 
-                TEST_ASSERT(sq_block->dimensions[2].dim == HARDWARE_DIM_WGP, "SQ dimension 2 is WGP");
-                TEST_ASSERT(sq_block->dimensions[2].size == 4, "SQ WGP dimension size is 4");
-            }
+				TEST_ASSERT(sq_block->dimensions[2].dim == HARDWARE_DIM_WGP,
+					    "SQ dimension 2 is WGP");
+				TEST_ASSERT(sq_block->dimensions[2].size == 4,
+					    "SQ WGP dimension size is 4");
+			}
 
-            /* Test first few counter register configurations */
-            if (sq_block->counter_reg_info) {
-                counter_reg_info_t* reg0 = &sq_block->counter_reg_info[0];
-                TEST_ASSERT(reg0->select_addr == 55744, "SQ counter 0 select address");
-                TEST_ASSERT(reg0->control_addr == 55776, "SQ counter 0 control address");
-                TEST_ASSERT(reg0->register_addr_lo == 53696, "SQ counter 0 LO address");
-                TEST_ASSERT(reg0->allocation.state == COUNTER_STATE_FREE, "SQ counter 0 initial state is FREE");
+			/* Test first few counter register configurations */
+			if (sq_block->counter_reg_info) {
+				counter_reg_info_t *reg0 = &sq_block->counter_reg_info[0];
+				TEST_ASSERT(reg0->select_addr == 55744,
+					    "SQ counter 0 select address");
+				TEST_ASSERT(reg0->control_addr == 55776,
+					    "SQ counter 0 control address");
+				TEST_ASSERT(reg0->register_addr_lo == 53696,
+					    "SQ counter 0 LO address");
+				TEST_ASSERT(reg0->allocation.state == COUNTER_STATE_FREE,
+					    "SQ counter 0 initial state is FREE");
 
-                counter_reg_info_t* reg1 = &sq_block->counter_reg_info[1];
-                TEST_ASSERT(reg1->select_addr == 55746, "SQ counter 1 select address");
-                TEST_ASSERT(reg1->control_addr == 55776, "SQ counter 1 control address");
-                TEST_ASSERT(reg1->register_addr_lo == 53698, "SQ counter 1 LO address");
-                TEST_ASSERT(reg1->allocation.state == COUNTER_STATE_FREE, "SQ counter 1 initial state is FREE");
-            }
-        }
+				counter_reg_info_t *reg1 = &sq_block->counter_reg_info[1];
+				TEST_ASSERT(reg1->select_addr == 55746,
+					    "SQ counter 1 select address");
+				TEST_ASSERT(reg1->control_addr == 55776,
+					    "SQ counter 1 control address");
+				TEST_ASSERT(reg1->register_addr_lo == 53698,
+					    "SQ counter 1 LO address");
+				TEST_ASSERT(reg1->allocation.state == COUNTER_STATE_FREE,
+					    "SQ counter 1 initial state is FREE");
+			}
+		}
 
-        free_arch(arch);
-    }
+		free_arch(arch);
+	}
 }
 
 /* Test GRBM block configuration */
-static void test_gfx12_grbm_block(void) {
-    printf("\n=== Testing GFX12 GRBM Block ===\n");
+static void test_gfx12_grbm_block(void)
+{
+	printf("\n=== Testing GFX12 GRBM Block ===\n");
 
-    arch_t* arch = arch_create_by_name("gfx12");
-    TEST_ASSERT(arch != NULL, "Architecture created for GRBM block test");
+	arch_t *arch = arch_create_by_name("gfx12");
+	TEST_ASSERT(arch != NULL, "Architecture created for GRBM block test");
 
-    if (arch) {
-        block_info_t* grbm_block = arch->block_map.blocks[HW_IP_BLOCK_GRBM];
-        TEST_ASSERT(grbm_block != NULL, "GRBM block exists");
+	if (arch) {
+		block_info_t *grbm_block = arch->block_map.blocks[HW_IP_BLOCK_GRBM];
+		TEST_ASSERT(grbm_block != NULL, "GRBM block exists");
 
-        if (grbm_block) {
-            TEST_ASSERT(strcmp(grbm_block->name, "GRBM") == 0, "GRBM block name is correct");
-            TEST_ASSERT(grbm_block->id == HW_IP_BLOCK_GRBM, "GRBM block ID is correct");
-            TEST_ASSERT(grbm_block->counter_count == 2, "GRBM block has 2 counters");
-            TEST_ASSERT(grbm_block->event_id_max == 51, "GRBM block max event is 51");
-            TEST_ASSERT(grbm_block->counter_reg_info != NULL, "GRBM counter register info exists");
-            TEST_ASSERT(grbm_block->dimension_count == 1, "GRBM block has 1 dimension");
-            TEST_ASSERT(grbm_block->dimensions != NULL, "GRBM dimensions array exists");
+		if (grbm_block) {
+			TEST_ASSERT(strcmp(grbm_block->name, "GRBM") == 0,
+				    "GRBM block name is correct");
+			TEST_ASSERT(grbm_block->id == HW_IP_BLOCK_GRBM, "GRBM block ID is correct");
+			TEST_ASSERT(grbm_block->counter_count == 2, "GRBM block has 2 counters");
+			TEST_ASSERT(grbm_block->event_id_max == 51, "GRBM block max event is 51");
+			TEST_ASSERT(grbm_block->counter_reg_info != NULL,
+				    "GRBM counter register info exists");
+			TEST_ASSERT(grbm_block->dimension_count == 1, "GRBM block has 1 dimension");
+			TEST_ASSERT(grbm_block->dimensions != NULL, "GRBM dimensions array exists");
 
-            if (grbm_block->dimensions) {
-                TEST_ASSERT(grbm_block->dimensions[0].dim == HARDWARE_DIM_XCC, "GRBM dimension is XCC");
-                TEST_ASSERT(grbm_block->dimensions[0].size == 1, "GRBM XCC dimension size is 1");
-            }
+			if (grbm_block->dimensions) {
+				TEST_ASSERT(grbm_block->dimensions[0].dim == HARDWARE_DIM_XCC,
+					    "GRBM dimension is XCC");
+				TEST_ASSERT(grbm_block->dimensions[0].size == 1,
+					    "GRBM XCC dimension size is 1");
+			}
 
-            /* Test counter register info */
-            if (grbm_block->counter_reg_info) {
-                counter_reg_info_t* reg0 = &grbm_block->counter_reg_info[0];
-                TEST_ASSERT(reg0->select_addr == 14400, "GRBM counter 0 select address");
-                TEST_ASSERT(reg0->register_addr_lo == 12352, "GRBM counter 0 LO address");
-                TEST_ASSERT(reg0->register_addr_hi == 12353, "GRBM counter 0 HI address");
-                TEST_ASSERT(reg0->allocation.state == COUNTER_STATE_FREE, "GRBM counter 0 initial state is FREE");
+			/* Test counter register info */
+			if (grbm_block->counter_reg_info) {
+				counter_reg_info_t *reg0 = &grbm_block->counter_reg_info[0];
+				TEST_ASSERT(reg0->select_addr == 14400,
+					    "GRBM counter 0 select address");
+				TEST_ASSERT(reg0->register_addr_lo == 12352,
+					    "GRBM counter 0 LO address");
+				TEST_ASSERT(reg0->register_addr_hi == 12353,
+					    "GRBM counter 0 HI address");
+				TEST_ASSERT(reg0->allocation.state == COUNTER_STATE_FREE,
+					    "GRBM counter 0 initial state is FREE");
 
-                counter_reg_info_t* reg1 = &grbm_block->counter_reg_info[1];
-                TEST_ASSERT(reg1->select_addr == 14401, "GRBM counter 1 select address");
-                TEST_ASSERT(reg1->register_addr_lo == 12355, "GRBM counter 1 LO address");
-                TEST_ASSERT(reg1->register_addr_hi == 12356, "GRBM counter 1 HI address");
-                TEST_ASSERT(reg1->allocation.state == COUNTER_STATE_FREE, "GRBM counter 1 initial state is FREE");
-            }
-        }
+				counter_reg_info_t *reg1 = &grbm_block->counter_reg_info[1];
+				TEST_ASSERT(reg1->select_addr == 14401,
+					    "GRBM counter 1 select address");
+				TEST_ASSERT(reg1->register_addr_lo == 12355,
+					    "GRBM counter 1 LO address");
+				TEST_ASSERT(reg1->register_addr_hi == 12356,
+					    "GRBM counter 1 HI address");
+				TEST_ASSERT(reg1->allocation.state == COUNTER_STATE_FREE,
+					    "GRBM counter 1 initial state is FREE");
+			}
+		}
 
-        free_arch(arch);
-    }
+		free_arch(arch);
+	}
 }
 
 /* Test GL2C block configuration */
-static void test_gfx12_gl2c_block(void) {
-    printf("\n=== Testing GFX12 GL2C Block ===\n");
+static void test_gfx12_gl2c_block(void)
+{
+	printf("\n=== Testing GFX12 GL2C Block ===\n");
 
-    arch_t* arch = arch_create_by_name("gfx12");
-    TEST_ASSERT(arch != NULL, "Architecture created for GL2C block test");
+	arch_t *arch = arch_create_by_name("gfx12");
+	TEST_ASSERT(arch != NULL, "Architecture created for GL2C block test");
 
-    if (arch) {
-        block_info_t* gl2c_block = arch->block_map.blocks[HW_IP_BLOCK_GL2C];
-        TEST_ASSERT(gl2c_block != NULL, "GL2C block exists");
+	if (arch) {
+		block_info_t *gl2c_block = arch->block_map.blocks[HW_IP_BLOCK_GL2C];
+		TEST_ASSERT(gl2c_block != NULL, "GL2C block exists");
 
-        if (gl2c_block) {
-            TEST_ASSERT(strcmp(gl2c_block->name, "GL2C") == 0, "GL2C block name is correct");
-            TEST_ASSERT(gl2c_block->id == HW_IP_BLOCK_GL2C, "GL2C block ID is correct");
-            TEST_ASSERT(gl2c_block->counter_count == 4, "GL2C block has 4 counters");
-            TEST_ASSERT(gl2c_block->event_id_max == 249, "GL2C block max event is 249");
-            TEST_ASSERT(gl2c_block->instance_count == 16, "GL2C block has 16 instances");
-            TEST_ASSERT(gl2c_block->counter_reg_info != NULL, "GL2C counter register info exists");
-            TEST_ASSERT(gl2c_block->dimension_count == 1, "GL2C block has 1 dimension");
-            TEST_ASSERT(gl2c_block->dimensions != NULL, "GL2C dimensions array exists");
+		if (gl2c_block) {
+			TEST_ASSERT(strcmp(gl2c_block->name, "GL2C") == 0,
+				    "GL2C block name is correct");
+			TEST_ASSERT(gl2c_block->id == HW_IP_BLOCK_GL2C, "GL2C block ID is correct");
+			TEST_ASSERT(gl2c_block->counter_count == 4, "GL2C block has 4 counters");
+			TEST_ASSERT(gl2c_block->event_id_max == 249, "GL2C block max event is 249");
+			TEST_ASSERT(gl2c_block->instance_count == 16,
+				    "GL2C block has 16 instances");
+			TEST_ASSERT(gl2c_block->counter_reg_info != NULL,
+				    "GL2C counter register info exists");
+			TEST_ASSERT(gl2c_block->dimension_count == 1, "GL2C block has 1 dimension");
+			TEST_ASSERT(gl2c_block->dimensions != NULL, "GL2C dimensions array exists");
 
-            if (gl2c_block->dimensions) {
-                TEST_ASSERT(gl2c_block->dimensions[0].dim == HARDWARE_DIM_XCC, "GL2C dimension is XCC");
-                TEST_ASSERT(gl2c_block->dimensions[0].size == 1, "GL2C XCC dimension size is 1");
-            }
+			if (gl2c_block->dimensions) {
+				TEST_ASSERT(gl2c_block->dimensions[0].dim == HARDWARE_DIM_XCC,
+					    "GL2C dimension is XCC");
+				TEST_ASSERT(gl2c_block->dimensions[0].size == 1,
+					    "GL2C XCC dimension size is 1");
+			}
 
-            /* Test counter register info */
-            if (gl2c_block->counter_reg_info) {
-                counter_reg_info_t* reg0 = &gl2c_block->counter_reg_info[0];
-                TEST_ASSERT(reg0->select_addr == 15232, "GL2C counter 0 select address");
-                TEST_ASSERT(reg0->register_addr_lo == 13184, "GL2C counter 0 LO address");
-                TEST_ASSERT(reg0->register_addr_hi == 13185, "GL2C counter 0 HI address");
-                TEST_ASSERT(reg0->control_addr == 0, "GL2C counter 0 has no control address");
-                TEST_ASSERT(reg0->allocation.state == COUNTER_STATE_FREE, "GL2C counter 0 initial state is FREE");
+			/* Test counter register info */
+			if (gl2c_block->counter_reg_info) {
+				counter_reg_info_t *reg0 = &gl2c_block->counter_reg_info[0];
+				TEST_ASSERT(reg0->select_addr == 15232,
+					    "GL2C counter 0 select address");
+				TEST_ASSERT(reg0->register_addr_lo == 13184,
+					    "GL2C counter 0 LO address");
+				TEST_ASSERT(reg0->register_addr_hi == 13185,
+					    "GL2C counter 0 HI address");
+				TEST_ASSERT(reg0->control_addr == 0,
+					    "GL2C counter 0 has no control address");
+				TEST_ASSERT(reg0->allocation.state == COUNTER_STATE_FREE,
+					    "GL2C counter 0 initial state is FREE");
 
-                counter_reg_info_t* reg1 = &gl2c_block->counter_reg_info[1];
-                TEST_ASSERT(reg1->select_addr == 15234, "GL2C counter 1 select address");
-                TEST_ASSERT(reg1->register_addr_lo == 13186, "GL2C counter 1 LO address");
-                TEST_ASSERT(reg1->register_addr_hi == 13187, "GL2C counter 1 HI address");
-                TEST_ASSERT(reg1->control_addr == 0, "GL2C counter 1 has no control address");
+				counter_reg_info_t *reg1 = &gl2c_block->counter_reg_info[1];
+				TEST_ASSERT(reg1->select_addr == 15234,
+					    "GL2C counter 1 select address");
+				TEST_ASSERT(reg1->register_addr_lo == 13186,
+					    "GL2C counter 1 LO address");
+				TEST_ASSERT(reg1->register_addr_hi == 13187,
+					    "GL2C counter 1 HI address");
+				TEST_ASSERT(reg1->control_addr == 0,
+					    "GL2C counter 1 has no control address");
 
-                counter_reg_info_t* reg2 = &gl2c_block->counter_reg_info[2];
-                TEST_ASSERT(reg2->select_addr == 15236, "GL2C counter 2 select address");
-                TEST_ASSERT(reg2->register_addr_lo == 13188, "GL2C counter 2 LO address");
-                TEST_ASSERT(reg2->register_addr_hi == 13189, "GL2C counter 2 HI address");
-                TEST_ASSERT(reg2->control_addr == 0, "GL2C counter 2 has no control address");
+				counter_reg_info_t *reg2 = &gl2c_block->counter_reg_info[2];
+				TEST_ASSERT(reg2->select_addr == 15236,
+					    "GL2C counter 2 select address");
+				TEST_ASSERT(reg2->register_addr_lo == 13188,
+					    "GL2C counter 2 LO address");
+				TEST_ASSERT(reg2->register_addr_hi == 13189,
+					    "GL2C counter 2 HI address");
+				TEST_ASSERT(reg2->control_addr == 0,
+					    "GL2C counter 2 has no control address");
 
-                counter_reg_info_t* reg3 = &gl2c_block->counter_reg_info[3];
-                TEST_ASSERT(reg3->select_addr == 15238, "GL2C counter 3 select address");
-                TEST_ASSERT(reg3->register_addr_lo == 13190, "GL2C counter 3 LO address");
-                TEST_ASSERT(reg3->register_addr_hi == 13191, "GL2C counter 3 HI address");
-                TEST_ASSERT(reg3->control_addr == 0, "GL2C counter 3 has no control address");
-            }
-        }
+				counter_reg_info_t *reg3 = &gl2c_block->counter_reg_info[3];
+				TEST_ASSERT(reg3->select_addr == 15238,
+					    "GL2C counter 3 select address");
+				TEST_ASSERT(reg3->register_addr_lo == 13190,
+					    "GL2C counter 3 LO address");
+				TEST_ASSERT(reg3->register_addr_hi == 13191,
+					    "GL2C counter 3 HI address");
+				TEST_ASSERT(reg3->control_addr == 0,
+					    "GL2C counter 3 has no control address");
+			}
+		}
 
-        free_arch(arch);
-    }
+		free_arch(arch);
+	}
 }
 
 /* Test SPI block configuration */
-static void test_gfx12_spi_block(void) {
-    printf("\n=== Testing GFX12 SPI Block ===\n");
+static void test_gfx12_spi_block(void)
+{
+	printf("\n=== Testing GFX12 SPI Block ===\n");
 
-    arch_t* arch = arch_create_by_name("gfx12");
-    TEST_ASSERT(arch != NULL, "Architecture created for SPI block test");
+	arch_t *arch = arch_create_by_name("gfx12");
+	TEST_ASSERT(arch != NULL, "Architecture created for SPI block test");
 
-    if (arch) {
-        block_info_t* spi_block = arch->block_map.blocks[HW_IP_BLOCK_SPI];
-        TEST_ASSERT(spi_block != NULL, "SPI block exists");
+	if (arch) {
+		block_info_t *spi_block = arch->block_map.blocks[HW_IP_BLOCK_SPI];
+		TEST_ASSERT(spi_block != NULL, "SPI block exists");
 
-        if (spi_block) {
-            TEST_ASSERT(strcmp(spi_block->name, "SPI") == 0, "SPI block name is correct");
-            TEST_ASSERT(spi_block->id == HW_IP_BLOCK_SPI, "SPI block ID is correct");
-            TEST_ASSERT(spi_block->counter_count == 6, "SPI block has 6 counters");
-            TEST_ASSERT(spi_block->event_id_max == 318, "SPI block max event is 318");
-            TEST_ASSERT(spi_block->instance_count == 1, "SPI block has 1 instance");
-            TEST_ASSERT(spi_block->counter_reg_info != NULL, "SPI counter register info exists");
-            TEST_ASSERT(spi_block->dimension_count == 2, "SPI block has 2 dimensions");
-            TEST_ASSERT(spi_block->dimensions != NULL, "SPI dimensions array exists");
+		if (spi_block) {
+			TEST_ASSERT(strcmp(spi_block->name, "SPI") == 0,
+				    "SPI block name is correct");
+			TEST_ASSERT(spi_block->id == HW_IP_BLOCK_SPI, "SPI block ID is correct");
+			TEST_ASSERT(spi_block->counter_count == 6, "SPI block has 6 counters");
+			TEST_ASSERT(spi_block->event_id_max == 318, "SPI block max event is 318");
+			TEST_ASSERT(spi_block->instance_count == 1, "SPI block has 1 instance");
+			TEST_ASSERT(spi_block->counter_reg_info != NULL,
+				    "SPI counter register info exists");
+			TEST_ASSERT(spi_block->dimension_count == 2, "SPI block has 2 dimensions");
+			TEST_ASSERT(spi_block->dimensions != NULL, "SPI dimensions array exists");
 
-            if (spi_block->dimensions) {
-                TEST_ASSERT(spi_block->dimensions[0].dim == HARDWARE_DIM_XCC, "SPI dimension 0 is XCC");
-                TEST_ASSERT(spi_block->dimensions[0].size == 1, "SPI XCC dimension size is 1");
-                TEST_ASSERT(spi_block->dimensions[1].dim == HARDWARE_DIM_SE, "SPI dimension 1 is SE");
-                TEST_ASSERT(spi_block->dimensions[1].size == 4, "SPI SE dimension size is 4");
-            }
+			if (spi_block->dimensions) {
+				TEST_ASSERT(spi_block->dimensions[0].dim == HARDWARE_DIM_XCC,
+					    "SPI dimension 0 is XCC");
+				TEST_ASSERT(spi_block->dimensions[0].size == 1,
+					    "SPI XCC dimension size is 1");
+				TEST_ASSERT(spi_block->dimensions[1].dim == HARDWARE_DIM_SE,
+					    "SPI dimension 1 is SE");
+				TEST_ASSERT(spi_block->dimensions[1].size == 4,
+					    "SPI SE dimension size is 4");
+			}
 
-            /* Test counter register info */
-            if (spi_block->counter_reg_info) {
-                counter_reg_info_t* reg0 = &spi_block->counter_reg_info[0];
-                TEST_ASSERT(reg0->select_addr == 14720, "SPI counter 0 select address");
-                TEST_ASSERT(reg0->register_addr_lo == 12673, "SPI counter 0 LO address");
-                TEST_ASSERT(reg0->register_addr_hi == 12672, "SPI counter 0 HI address");
-                TEST_ASSERT(reg0->control_addr == 0, "SPI counter 0 has no control address");
-                TEST_ASSERT(reg0->allocation.state == COUNTER_STATE_FREE, "SPI counter 0 initial state is FREE");
+			/* Test counter register info */
+			if (spi_block->counter_reg_info) {
+				counter_reg_info_t *reg0 = &spi_block->counter_reg_info[0];
+				TEST_ASSERT(reg0->select_addr == 14720,
+					    "SPI counter 0 select address");
+				TEST_ASSERT(reg0->register_addr_lo == 12673,
+					    "SPI counter 0 LO address");
+				TEST_ASSERT(reg0->register_addr_hi == 12672,
+					    "SPI counter 0 HI address");
+				TEST_ASSERT(reg0->control_addr == 0,
+					    "SPI counter 0 has no control address");
+				TEST_ASSERT(reg0->allocation.state == COUNTER_STATE_FREE,
+					    "SPI counter 0 initial state is FREE");
 
-                counter_reg_info_t* reg1 = &spi_block->counter_reg_info[1];
-                TEST_ASSERT(reg1->select_addr == 14721, "SPI counter 1 select address");
-                TEST_ASSERT(reg1->register_addr_lo == 12675, "SPI counter 1 LO address");
-                TEST_ASSERT(reg1->register_addr_hi == 12674, "SPI counter 1 HI address");
-                TEST_ASSERT(reg1->control_addr == 0, "SPI counter 1 has no control address");
+				counter_reg_info_t *reg1 = &spi_block->counter_reg_info[1];
+				TEST_ASSERT(reg1->select_addr == 14721,
+					    "SPI counter 1 select address");
+				TEST_ASSERT(reg1->register_addr_lo == 12675,
+					    "SPI counter 1 LO address");
+				TEST_ASSERT(reg1->register_addr_hi == 12674,
+					    "SPI counter 1 HI address");
+				TEST_ASSERT(reg1->control_addr == 0,
+					    "SPI counter 1 has no control address");
 
-                counter_reg_info_t* reg5 = &spi_block->counter_reg_info[5];
-                TEST_ASSERT(reg5->select_addr == 14725, "SPI counter 5 select address");
-                TEST_ASSERT(reg5->register_addr_lo == 12683, "SPI counter 5 LO address");
-                TEST_ASSERT(reg5->register_addr_hi == 12682, "SPI counter 5 HI address");
-                TEST_ASSERT(reg5->control_addr == 0, "SPI counter 5 has no control address");
-            }
-        }
+				counter_reg_info_t *reg5 = &spi_block->counter_reg_info[5];
+				TEST_ASSERT(reg5->select_addr == 14725,
+					    "SPI counter 5 select address");
+				TEST_ASSERT(reg5->register_addr_lo == 12683,
+					    "SPI counter 5 LO address");
+				TEST_ASSERT(reg5->register_addr_hi == 12682,
+					    "SPI counter 5 HI address");
+				TEST_ASSERT(reg5->control_addr == 0,
+					    "SPI counter 5 has no control address");
+			}
+		}
 
-        free_arch(arch);
-    }
+		free_arch(arch);
+	}
 }
 
 /* Test GFX12 TD block configuration */
-static void test_gfx12_td_block(void) {
-    printf("\n=== Testing GFX12 TD Block ===\n");
-    arch_t* arch = arch_create_by_name("gfx12");
-    TEST_ASSERT(arch != NULL, "Architecture created for TD block test");
+static void test_gfx12_td_block(void)
+{
+	printf("\n=== Testing GFX12 TD Block ===\n");
+	arch_t *arch = arch_create_by_name("gfx12");
+	TEST_ASSERT(arch != NULL, "Architecture created for TD block test");
 
-    if (arch) {
-        block_info_t* td_block = arch->block_map.blocks[HW_IP_BLOCK_TD];
-        TEST_ASSERT(td_block != NULL, "TD block exists");
+	if (arch) {
+		block_info_t *td_block = arch->block_map.blocks[HW_IP_BLOCK_TD];
+		TEST_ASSERT(td_block != NULL, "TD block exists");
 
-        if (td_block) {
-            /* Validate basic block properties */
-            TEST_ASSERT(strcmp(td_block->name, "TD") == 0, "TD block name is correct");
-            TEST_ASSERT(td_block->id == HW_IP_BLOCK_TD, "TD block type correct");
-            TEST_ASSERT(td_block->counter_count == 2, "TD block has 2 counters");
-            TEST_ASSERT(td_block->event_id_max == 127, "TD block max event ID is 127");
-            TEST_ASSERT(td_block->instance_count == 2, "TD block has 2 instances");
+		if (td_block) {
+			/* Validate basic block properties */
+			TEST_ASSERT(strcmp(td_block->name, "TD") == 0, "TD block name is correct");
+			TEST_ASSERT(td_block->id == HW_IP_BLOCK_TD, "TD block type correct");
+			TEST_ASSERT(td_block->counter_count == 2, "TD block has 2 counters");
+			TEST_ASSERT(td_block->event_id_max == 127, "TD block max event ID is 127");
+			TEST_ASSERT(td_block->instance_count == 2, "TD block has 2 instances");
 
-            /* Validate WGP dimensions - TD is a WGP-level block with 4 dimensions */
-            TEST_ASSERT(td_block->dimensions != NULL, "TD block dimensions exist");
-            TEST_ASSERT(td_block->dimension_count == 4, "TD block has 4 dimensions");
+			/* Validate WGP dimensions - TD is a WGP-level block with 4 dimensions */
+			TEST_ASSERT(td_block->dimensions != NULL, "TD block dimensions exist");
+			TEST_ASSERT(td_block->dimension_count == 4, "TD block has 4 dimensions");
 
-            if (td_block->dimensions && td_block->dimension_count >= 4) {
-                TEST_ASSERT(td_block->dimensions[0].dim == HARDWARE_DIM_XCC, "TD dimension 0 is XCC");
-                TEST_ASSERT(td_block->dimensions[0].size == 1, "TD XCC dimension size is 1");
-                TEST_ASSERT(td_block->dimensions[1].dim == HARDWARE_DIM_SE, "TD dimension 1 is SE");
-                TEST_ASSERT(td_block->dimensions[1].size == 4, "TD SE dimension size is 4");
-                TEST_ASSERT(td_block->dimensions[2].dim == HARDWARE_DIM_SA, "TD dimension 2 is SA");
-                TEST_ASSERT(td_block->dimensions[2].size == 2, "TD SA dimension size is 2");
-                TEST_ASSERT(td_block->dimensions[3].dim == HARDWARE_DIM_WGP, "TD dimension 3 is WGP");
-                TEST_ASSERT(td_block->dimensions[3].size == 4, "TD WGP dimension size is 4");
-            }
+			if (td_block->dimensions && td_block->dimension_count >= 4) {
+				TEST_ASSERT(td_block->dimensions[0].dim == HARDWARE_DIM_XCC,
+					    "TD dimension 0 is XCC");
+				TEST_ASSERT(td_block->dimensions[0].size == 1,
+					    "TD XCC dimension size is 1");
+				TEST_ASSERT(td_block->dimensions[1].dim == HARDWARE_DIM_SE,
+					    "TD dimension 1 is SE");
+				TEST_ASSERT(td_block->dimensions[1].size == 4,
+					    "TD SE dimension size is 4");
+				TEST_ASSERT(td_block->dimensions[2].dim == HARDWARE_DIM_SA,
+					    "TD dimension 2 is SA");
+				TEST_ASSERT(td_block->dimensions[2].size == 2,
+					    "TD SA dimension size is 2");
+				TEST_ASSERT(td_block->dimensions[3].dim == HARDWARE_DIM_WGP,
+					    "TD dimension 3 is WGP");
+				TEST_ASSERT(td_block->dimensions[3].size == 4,
+					    "TD WGP dimension size is 4");
+			}
 
-            /* Validate counter register info */
-            TEST_ASSERT(td_block->counter_reg_info != NULL, "TD block counter registers exist");
-            if (td_block->counter_reg_info) {
-                counter_reg_info_t* reg0 = &td_block->counter_reg_info[0];
-                counter_reg_info_t* reg1 = &td_block->counter_reg_info[1];
+			/* Validate counter register info */
+			TEST_ASSERT(td_block->counter_reg_info != NULL,
+				    "TD block counter registers exist");
+			if (td_block->counter_reg_info) {
+				counter_reg_info_t *reg0 = &td_block->counter_reg_info[0];
+				counter_reg_info_t *reg1 = &td_block->counter_reg_info[1];
 
-                /* Counter 0 registers - based on estimated addresses */
-                TEST_ASSERT(reg0->select_addr == 15296, "TD counter 0 select register (0x3bc0)");
-                TEST_ASSERT(reg0->control_addr == 0, "TD counter 0 no control register");
-                TEST_ASSERT(reg0->register_addr_lo == 13248, "TD counter 0 lo register (0x33c0)");
-                TEST_ASSERT(reg0->register_addr_hi == 13249, "TD counter 0 hi register (0x33c1)");
+				/* Counter 0 registers - based on estimated addresses */
+				TEST_ASSERT(reg0->select_addr == 15296,
+					    "TD counter 0 select register (0x3bc0)");
+				TEST_ASSERT(reg0->control_addr == 0,
+					    "TD counter 0 no control register");
+				TEST_ASSERT(reg0->register_addr_lo == 13248,
+					    "TD counter 0 lo register (0x33c0)");
+				TEST_ASSERT(reg0->register_addr_hi == 13249,
+					    "TD counter 0 hi register (0x33c1)");
 
-                /* Counter 1 registers */
-                TEST_ASSERT(reg1->select_addr == 15298, "TD counter 1 select register (0x3bc2)");
-                TEST_ASSERT(reg1->control_addr == 0, "TD counter 1 no control register");
-                TEST_ASSERT(reg1->register_addr_lo == 13250, "TD counter 1 lo register (0x33c2)");
-                TEST_ASSERT(reg1->register_addr_hi == 13251, "TD counter 1 hi register (0x33c3)");
-            }
-        }
+				/* Counter 1 registers */
+				TEST_ASSERT(reg1->select_addr == 15298,
+					    "TD counter 1 select register (0x3bc2)");
+				TEST_ASSERT(reg1->control_addr == 0,
+					    "TD counter 1 no control register");
+				TEST_ASSERT(reg1->register_addr_lo == 13250,
+					    "TD counter 1 lo register (0x33c2)");
+				TEST_ASSERT(reg1->register_addr_hi == 13251,
+					    "TD counter 1 hi register (0x33c3)");
+			}
+		}
 
-        free_arch(arch);
-    }
+		free_arch(arch);
+	}
 }
 
 /* Test GFX12 TCC block configuration */
-static void test_gfx12_tcc_block(void) {
-    printf("\n=== Testing GFX12 TCC Block ===\n");
-    arch_t* arch = arch_create_by_name("gfx12");
-    TEST_ASSERT(arch != NULL, "Architecture created for TCC block test");
+static void test_gfx12_tcc_block(void)
+{
+	printf("\n=== Testing GFX12 TCC Block ===\n");
+	arch_t *arch = arch_create_by_name("gfx12");
+	TEST_ASSERT(arch != NULL, "Architecture created for TCC block test");
 
-    if (arch) {
-        block_info_t* tcc_block = arch->block_map.blocks[HW_IP_BLOCK_TCC];
-        TEST_ASSERT(tcc_block != NULL, "TCC block exists");
+	if (arch) {
+		block_info_t *tcc_block = arch->block_map.blocks[HW_IP_BLOCK_TCC];
+		TEST_ASSERT(tcc_block != NULL, "TCC block exists");
 
-        if (tcc_block) {
-            /* Validate basic block properties */
-            TEST_ASSERT(strcmp(tcc_block->name, "TCC") == 0, "TCC block name is correct");
-            TEST_ASSERT(tcc_block->id == HW_IP_BLOCK_TCC, "TCC block type correct");
-            TEST_ASSERT(tcc_block->counter_count == 4, "TCC block has 4 counters");
-            TEST_ASSERT(tcc_block->event_id_max == 255, "TCC block max event ID is 255");
-            TEST_ASSERT(tcc_block->instance_count == 16, "TCC block has 16 instances");
+		if (tcc_block) {
+			/* Validate basic block properties */
+			TEST_ASSERT(strcmp(tcc_block->name, "TCC") == 0,
+				    "TCC block name is correct");
+			TEST_ASSERT(tcc_block->id == HW_IP_BLOCK_TCC, "TCC block type correct");
+			TEST_ASSERT(tcc_block->counter_count == 4, "TCC block has 4 counters");
+			TEST_ASSERT(tcc_block->event_id_max == 255,
+				    "TCC block max event ID is 255");
+			TEST_ASSERT(tcc_block->instance_count == 16, "TCC block has 16 instances");
 
-            /* Validate global dimensions - TCC is a global block with 1 dimension */
-            TEST_ASSERT(tcc_block->dimensions != NULL, "TCC block dimensions exist");
-            TEST_ASSERT(tcc_block->dimension_count == 1, "TCC block has 1 dimension");
+			/* Validate global dimensions - TCC is a global block with 1 dimension */
+			TEST_ASSERT(tcc_block->dimensions != NULL, "TCC block dimensions exist");
+			TEST_ASSERT(tcc_block->dimension_count == 1, "TCC block has 1 dimension");
 
-            if (tcc_block->dimensions && tcc_block->dimension_count >= 1) {
-                TEST_ASSERT(tcc_block->dimensions[0].dim == HARDWARE_DIM_XCC, "TCC dimension 0 is XCC");
-                TEST_ASSERT(tcc_block->dimensions[0].size == 1, "TCC XCC dimension size is 1");
-            }
+			if (tcc_block->dimensions && tcc_block->dimension_count >= 1) {
+				TEST_ASSERT(tcc_block->dimensions[0].dim == HARDWARE_DIM_XCC,
+					    "TCC dimension 0 is XCC");
+				TEST_ASSERT(tcc_block->dimensions[0].size == 1,
+					    "TCC XCC dimension size is 1");
+			}
 
-            /* Validate counter register info */
-            TEST_ASSERT(tcc_block->counter_reg_info != NULL, "TCC block counter registers exist");
-            if (tcc_block->counter_reg_info) {
-                counter_reg_info_t* reg0 = &tcc_block->counter_reg_info[0];
-                counter_reg_info_t* reg1 = &tcc_block->counter_reg_info[1];
-                counter_reg_info_t* reg2 = &tcc_block->counter_reg_info[2];
-                counter_reg_info_t* reg3 = &tcc_block->counter_reg_info[3];
+			/* Validate counter register info */
+			TEST_ASSERT(tcc_block->counter_reg_info != NULL,
+				    "TCC block counter registers exist");
+			if (tcc_block->counter_reg_info) {
+				counter_reg_info_t *reg0 = &tcc_block->counter_reg_info[0];
+				counter_reg_info_t *reg1 = &tcc_block->counter_reg_info[1];
+				counter_reg_info_t *reg2 = &tcc_block->counter_reg_info[2];
+				counter_reg_info_t *reg3 = &tcc_block->counter_reg_info[3];
 
-                /* Counter 0 registers - based on estimated addresses */
-                TEST_ASSERT(reg0->select_addr == 15424, "TCC counter 0 select register (0x3c40)");
-                TEST_ASSERT(reg0->control_addr == 0, "TCC counter 0 no control register");
-                TEST_ASSERT(reg0->register_addr_lo == 13376, "TCC counter 0 lo register (0x3440)");
-                TEST_ASSERT(reg0->register_addr_hi == 13377, "TCC counter 0 hi register (0x3441)");
+				/* Counter 0 registers - based on estimated addresses */
+				TEST_ASSERT(reg0->select_addr == 15424,
+					    "TCC counter 0 select register (0x3c40)");
+				TEST_ASSERT(reg0->control_addr == 0,
+					    "TCC counter 0 no control register");
+				TEST_ASSERT(reg0->register_addr_lo == 13376,
+					    "TCC counter 0 lo register (0x3440)");
+				TEST_ASSERT(reg0->register_addr_hi == 13377,
+					    "TCC counter 0 hi register (0x3441)");
 
-                /* Counter 1 registers */
-                TEST_ASSERT(reg1->select_addr == 15426, "TCC counter 1 select register (0x3c42)");
-                TEST_ASSERT(reg1->control_addr == 0, "TCC counter 1 no control register");
-                TEST_ASSERT(reg1->register_addr_lo == 13378, "TCC counter 1 lo register (0x3442)");
-                TEST_ASSERT(reg1->register_addr_hi == 13379, "TCC counter 1 hi register (0x3443)");
+				/* Counter 1 registers */
+				TEST_ASSERT(reg1->select_addr == 15426,
+					    "TCC counter 1 select register (0x3c42)");
+				TEST_ASSERT(reg1->control_addr == 0,
+					    "TCC counter 1 no control register");
+				TEST_ASSERT(reg1->register_addr_lo == 13378,
+					    "TCC counter 1 lo register (0x3442)");
+				TEST_ASSERT(reg1->register_addr_hi == 13379,
+					    "TCC counter 1 hi register (0x3443)");
 
-                /* Counter 2 registers */
-                TEST_ASSERT(reg2->select_addr == 15428, "TCC counter 2 select register (0x3c44)");
-                TEST_ASSERT(reg2->control_addr == 0, "TCC counter 2 no control register");
-                TEST_ASSERT(reg2->register_addr_lo == 13380, "TCC counter 2 lo register (0x3444)");
-                TEST_ASSERT(reg2->register_addr_hi == 13381, "TCC counter 2 hi register (0x3445)");
+				/* Counter 2 registers */
+				TEST_ASSERT(reg2->select_addr == 15428,
+					    "TCC counter 2 select register (0x3c44)");
+				TEST_ASSERT(reg2->control_addr == 0,
+					    "TCC counter 2 no control register");
+				TEST_ASSERT(reg2->register_addr_lo == 13380,
+					    "TCC counter 2 lo register (0x3444)");
+				TEST_ASSERT(reg2->register_addr_hi == 13381,
+					    "TCC counter 2 hi register (0x3445)");
 
-                /* Counter 3 registers */
-                TEST_ASSERT(reg3->select_addr == 15430, "TCC counter 3 select register (0x3c46)");
-                TEST_ASSERT(reg3->control_addr == 0, "TCC counter 3 no control register");
-                TEST_ASSERT(reg3->register_addr_lo == 13382, "TCC counter 3 lo register (0x3446)");
-                TEST_ASSERT(reg3->register_addr_hi == 13383, "TCC counter 3 hi register (0x3447)");
-            }
-        }
+				/* Counter 3 registers */
+				TEST_ASSERT(reg3->select_addr == 15430,
+					    "TCC counter 3 select register (0x3c46)");
+				TEST_ASSERT(reg3->control_addr == 0,
+					    "TCC counter 3 no control register");
+				TEST_ASSERT(reg3->register_addr_lo == 13382,
+					    "TCC counter 3 lo register (0x3446)");
+				TEST_ASSERT(reg3->register_addr_hi == 13383,
+					    "TCC counter 3 hi register (0x3447)");
+			}
+		}
 
-        free_arch(arch);
-    }
+		free_arch(arch);
+	}
 }
 
 /* Test GFX12 SX block configuration */
-static void test_gfx12_sx_block(void) {
-    printf("\n=== Testing GFX12 SX Block ===\n");
-    arch_t* arch = arch_create_by_name("gfx12");
-    TEST_ASSERT(arch != NULL, "Architecture created for SX block test");
+static void test_gfx12_sx_block(void)
+{
+	printf("\n=== Testing GFX12 SX Block ===\n");
+	arch_t *arch = arch_create_by_name("gfx12");
+	TEST_ASSERT(arch != NULL, "Architecture created for SX block test");
 
-    if (arch) {
-        block_info_t* sx_block = arch->block_map.blocks[HW_IP_BLOCK_SX];
-        TEST_ASSERT(sx_block != NULL, "SX block exists");
+	if (arch) {
+		block_info_t *sx_block = arch->block_map.blocks[HW_IP_BLOCK_SX];
+		TEST_ASSERT(sx_block != NULL, "SX block exists");
 
-        if (sx_block) {
-            /* Validate basic block properties */
-            TEST_ASSERT(strcmp(sx_block->name, "SX") == 0, "SX block name is correct");
-            TEST_ASSERT(sx_block->id == HW_IP_BLOCK_SX, "SX block type correct");
-            TEST_ASSERT(sx_block->counter_count == 4, "SX block has 4 counters");
-            TEST_ASSERT(sx_block->event_id_max == 189, "SX block max event ID is 189");
-            TEST_ASSERT(sx_block->instance_count == 1, "SX block has 1 instance");
+		if (sx_block) {
+			/* Validate basic block properties */
+			TEST_ASSERT(strcmp(sx_block->name, "SX") == 0, "SX block name is correct");
+			TEST_ASSERT(sx_block->id == HW_IP_BLOCK_SX, "SX block type correct");
+			TEST_ASSERT(sx_block->counter_count == 4, "SX block has 4 counters");
+			TEST_ASSERT(sx_block->event_id_max == 189, "SX block max event ID is 189");
+			TEST_ASSERT(sx_block->instance_count == 1, "SX block has 1 instance");
 
-            /* Validate SE dimensions - SX is a SE block with 2 dimensions */
-            TEST_ASSERT(sx_block->dimensions != NULL, "SX block dimensions exist");
-            TEST_ASSERT(sx_block->dimension_count == 2, "SX block has 2 dimensions");
+			/* Validate SE dimensions - SX is a SE block with 2 dimensions */
+			TEST_ASSERT(sx_block->dimensions != NULL, "SX block dimensions exist");
+			TEST_ASSERT(sx_block->dimension_count == 2, "SX block has 2 dimensions");
 
-            if (sx_block->dimensions && sx_block->dimension_count >= 2) {
-                TEST_ASSERT(sx_block->dimensions[0].dim == HARDWARE_DIM_XCC, "SX dimension 0 is XCC");
-                TEST_ASSERT(sx_block->dimensions[0].size == 1, "SX XCC dimension size is 1");
-                TEST_ASSERT(sx_block->dimensions[1].dim == HARDWARE_DIM_SE, "SX dimension 1 is SE");
-                TEST_ASSERT(sx_block->dimensions[1].size == 4, "SX SE dimension size is 4");
-            }
+			if (sx_block->dimensions && sx_block->dimension_count >= 2) {
+				TEST_ASSERT(sx_block->dimensions[0].dim == HARDWARE_DIM_XCC,
+					    "SX dimension 0 is XCC");
+				TEST_ASSERT(sx_block->dimensions[0].size == 1,
+					    "SX XCC dimension size is 1");
+				TEST_ASSERT(sx_block->dimensions[1].dim == HARDWARE_DIM_SE,
+					    "SX dimension 1 is SE");
+				TEST_ASSERT(sx_block->dimensions[1].size == 4,
+					    "SX SE dimension size is 4");
+			}
 
-            /* Validate counter register info */
-            TEST_ASSERT(sx_block->counter_reg_info != NULL, "SX block counter registers exist");
-            if (sx_block->counter_reg_info) {
-                counter_reg_info_t* reg0 = &sx_block->counter_reg_info[0];
-                counter_reg_info_t* reg1 = &sx_block->counter_reg_info[1];
-                counter_reg_info_t* reg2 = &sx_block->counter_reg_info[2];
-                counter_reg_info_t* reg3 = &sx_block->counter_reg_info[3];
+			/* Validate counter register info */
+			TEST_ASSERT(sx_block->counter_reg_info != NULL,
+				    "SX block counter registers exist");
+			if (sx_block->counter_reg_info) {
+				counter_reg_info_t *reg0 = &sx_block->counter_reg_info[0];
+				counter_reg_info_t *reg1 = &sx_block->counter_reg_info[1];
+				counter_reg_info_t *reg2 = &sx_block->counter_reg_info[2];
+				counter_reg_info_t *reg3 = &sx_block->counter_reg_info[3];
 
-                /* Counter 0 registers - based on estimated addresses */
-                TEST_ASSERT(reg0->select_addr == 14976, "SX counter 0 select register (0x3a80)");
-                TEST_ASSERT(reg0->control_addr == 0, "SX counter 0 no control register");
-                TEST_ASSERT(reg0->register_addr_lo == 12928, "SX counter 0 lo register (0x3280)");
-                TEST_ASSERT(reg0->register_addr_hi == 12929, "SX counter 0 hi register (0x3281)");
+				/* Counter 0 registers - based on estimated addresses */
+				TEST_ASSERT(reg0->select_addr == 14976,
+					    "SX counter 0 select register (0x3a80)");
+				TEST_ASSERT(reg0->control_addr == 0,
+					    "SX counter 0 no control register");
+				TEST_ASSERT(reg0->register_addr_lo == 12928,
+					    "SX counter 0 lo register (0x3280)");
+				TEST_ASSERT(reg0->register_addr_hi == 12929,
+					    "SX counter 0 hi register (0x3281)");
 
-                /* Counter 1 registers */
-                TEST_ASSERT(reg1->select_addr == 14978, "SX counter 1 select register (0x3a82)");
-                TEST_ASSERT(reg1->control_addr == 0, "SX counter 1 no control register");
-                TEST_ASSERT(reg1->register_addr_lo == 12930, "SX counter 1 lo register (0x3282)");
-                TEST_ASSERT(reg1->register_addr_hi == 12931, "SX counter 1 hi register (0x3283)");
+				/* Counter 1 registers */
+				TEST_ASSERT(reg1->select_addr == 14978,
+					    "SX counter 1 select register (0x3a82)");
+				TEST_ASSERT(reg1->control_addr == 0,
+					    "SX counter 1 no control register");
+				TEST_ASSERT(reg1->register_addr_lo == 12930,
+					    "SX counter 1 lo register (0x3282)");
+				TEST_ASSERT(reg1->register_addr_hi == 12931,
+					    "SX counter 1 hi register (0x3283)");
 
-                /* Counter 2 registers */
-                TEST_ASSERT(reg2->select_addr == 14980, "SX counter 2 select register (0x3a84)");
-                TEST_ASSERT(reg2->control_addr == 0, "SX counter 2 no control register");
-                TEST_ASSERT(reg2->register_addr_lo == 12932, "SX counter 2 lo register (0x3284)");
-                TEST_ASSERT(reg2->register_addr_hi == 12933, "SX counter 2 hi register (0x3285)");
+				/* Counter 2 registers */
+				TEST_ASSERT(reg2->select_addr == 14980,
+					    "SX counter 2 select register (0x3a84)");
+				TEST_ASSERT(reg2->control_addr == 0,
+					    "SX counter 2 no control register");
+				TEST_ASSERT(reg2->register_addr_lo == 12932,
+					    "SX counter 2 lo register (0x3284)");
+				TEST_ASSERT(reg2->register_addr_hi == 12933,
+					    "SX counter 2 hi register (0x3285)");
 
-                /* Counter 3 registers */
-                TEST_ASSERT(reg3->select_addr == 14982, "SX counter 3 select register (0x3a86)");
-                TEST_ASSERT(reg3->control_addr == 0, "SX counter 3 no control register");
-                TEST_ASSERT(reg3->register_addr_lo == 12934, "SX counter 3 lo register (0x3286)");
-                TEST_ASSERT(reg3->register_addr_hi == 12935, "SX counter 3 hi register (0x3287)");
-            }
-        }
+				/* Counter 3 registers */
+				TEST_ASSERT(reg3->select_addr == 14982,
+					    "SX counter 3 select register (0x3a86)");
+				TEST_ASSERT(reg3->control_addr == 0,
+					    "SX counter 3 no control register");
+				TEST_ASSERT(reg3->register_addr_lo == 12934,
+					    "SX counter 3 lo register (0x3286)");
+				TEST_ASSERT(reg3->register_addr_hi == 12935,
+					    "SX counter 3 hi register (0x3287)");
+			}
+		}
 
-        free_arch(arch);
-    }
+		free_arch(arch);
+	}
 }
 
 /* Test GFX12 DB block configuration */
-static void test_gfx12_db_block(void) {
-    printf("\n=== Testing GFX12 DB Block ===\n");
-    arch_t* arch = arch_create_by_name("gfx12");
-    TEST_ASSERT(arch != NULL, "Architecture created for DB block test");
+static void test_gfx12_db_block(void)
+{
+	printf("\n=== Testing GFX12 DB Block ===\n");
+	arch_t *arch = arch_create_by_name("gfx12");
+	TEST_ASSERT(arch != NULL, "Architecture created for DB block test");
 
-    if (arch) {
-        block_info_t* db_block = arch->block_map.blocks[HW_IP_BLOCK_DB];
-        TEST_ASSERT(db_block != NULL, "DB block exists");
+	if (arch) {
+		block_info_t *db_block = arch->block_map.blocks[HW_IP_BLOCK_DB];
+		TEST_ASSERT(db_block != NULL, "DB block exists");
 
-        if (db_block) {
-            /* Validate basic block properties */
-            TEST_ASSERT(strcmp(db_block->name, "DB") == 0, "DB block name is correct");
-            TEST_ASSERT(db_block->id == HW_IP_BLOCK_DB, "DB block type correct");
-            TEST_ASSERT(db_block->counter_count == 4, "DB block has 4 counters");
-            TEST_ASSERT(db_block->event_id_max == 218, "DB block max event ID is 218");
-            TEST_ASSERT(db_block->instance_count == 1, "DB block has 1 instance");
+		if (db_block) {
+			/* Validate basic block properties */
+			TEST_ASSERT(strcmp(db_block->name, "DB") == 0, "DB block name is correct");
+			TEST_ASSERT(db_block->id == HW_IP_BLOCK_DB, "DB block type correct");
+			TEST_ASSERT(db_block->counter_count == 4, "DB block has 4 counters");
+			TEST_ASSERT(db_block->event_id_max == 218, "DB block max event ID is 218");
+			TEST_ASSERT(db_block->instance_count == 1, "DB block has 1 instance");
 
-            /* Validate SE dimensions - DB is a SE block with 2 dimensions */
-            TEST_ASSERT(db_block->dimensions != NULL, "DB block dimensions exist");
-            TEST_ASSERT(db_block->dimension_count == 2, "DB block has 2 dimensions");
+			/* Validate SE dimensions - DB is a SE block with 2 dimensions */
+			TEST_ASSERT(db_block->dimensions != NULL, "DB block dimensions exist");
+			TEST_ASSERT(db_block->dimension_count == 2, "DB block has 2 dimensions");
 
-            if (db_block->dimensions && db_block->dimension_count >= 2) {
-                TEST_ASSERT(db_block->dimensions[0].dim == HARDWARE_DIM_XCC, "DB dimension 0 is XCC");
-                TEST_ASSERT(db_block->dimensions[0].size == 1, "DB XCC dimension size is 1");
-                TEST_ASSERT(db_block->dimensions[1].dim == HARDWARE_DIM_SE, "DB dimension 1 is SE");
-                TEST_ASSERT(db_block->dimensions[1].size == 4, "DB SE dimension size is 4");
-            }
+			if (db_block->dimensions && db_block->dimension_count >= 2) {
+				TEST_ASSERT(db_block->dimensions[0].dim == HARDWARE_DIM_XCC,
+					    "DB dimension 0 is XCC");
+				TEST_ASSERT(db_block->dimensions[0].size == 1,
+					    "DB XCC dimension size is 1");
+				TEST_ASSERT(db_block->dimensions[1].dim == HARDWARE_DIM_SE,
+					    "DB dimension 1 is SE");
+				TEST_ASSERT(db_block->dimensions[1].size == 4,
+					    "DB SE dimension size is 4");
+			}
 
-            /* Validate counter register info */
-            TEST_ASSERT(db_block->counter_reg_info != NULL, "DB block counter registers exist");
-            if (db_block->counter_reg_info) {
-                counter_reg_info_t* reg0 = &db_block->counter_reg_info[0];
-                counter_reg_info_t* reg1 = &db_block->counter_reg_info[1];
-                counter_reg_info_t* reg2 = &db_block->counter_reg_info[2];
-                counter_reg_info_t* reg3 = &db_block->counter_reg_info[3];
+			/* Validate counter register info */
+			TEST_ASSERT(db_block->counter_reg_info != NULL,
+				    "DB block counter registers exist");
+			if (db_block->counter_reg_info) {
+				counter_reg_info_t *reg0 = &db_block->counter_reg_info[0];
+				counter_reg_info_t *reg1 = &db_block->counter_reg_info[1];
+				counter_reg_info_t *reg2 = &db_block->counter_reg_info[2];
+				counter_reg_info_t *reg3 = &db_block->counter_reg_info[3];
 
-                /* Counter 0 registers - based on estimated addresses */
-                TEST_ASSERT(reg0->select_addr == 14592, "DB counter 0 select register (0x3900)");
-                TEST_ASSERT(reg0->control_addr == 0, "DB counter 0 no control register");
-                TEST_ASSERT(reg0->register_addr_lo == 12800, "DB counter 0 lo register (0x3200)");
-                TEST_ASSERT(reg0->register_addr_hi == 12801, "DB counter 0 hi register (0x3201)");
+				/* Counter 0 registers - based on estimated addresses */
+				TEST_ASSERT(reg0->select_addr == 14592,
+					    "DB counter 0 select register (0x3900)");
+				TEST_ASSERT(reg0->control_addr == 0,
+					    "DB counter 0 no control register");
+				TEST_ASSERT(reg0->register_addr_lo == 12800,
+					    "DB counter 0 lo register (0x3200)");
+				TEST_ASSERT(reg0->register_addr_hi == 12801,
+					    "DB counter 0 hi register (0x3201)");
 
-                /* Counter 1 registers */
-                TEST_ASSERT(reg1->select_addr == 14594, "DB counter 1 select register (0x3902)");
-                TEST_ASSERT(reg1->control_addr == 0, "DB counter 1 no control register");
-                TEST_ASSERT(reg1->register_addr_lo == 12802, "DB counter 1 lo register (0x3202)");
-                TEST_ASSERT(reg1->register_addr_hi == 12803, "DB counter 1 hi register (0x3203)");
+				/* Counter 1 registers */
+				TEST_ASSERT(reg1->select_addr == 14594,
+					    "DB counter 1 select register (0x3902)");
+				TEST_ASSERT(reg1->control_addr == 0,
+					    "DB counter 1 no control register");
+				TEST_ASSERT(reg1->register_addr_lo == 12802,
+					    "DB counter 1 lo register (0x3202)");
+				TEST_ASSERT(reg1->register_addr_hi == 12803,
+					    "DB counter 1 hi register (0x3203)");
 
-                /* Counter 2 registers */
-                TEST_ASSERT(reg2->select_addr == 14596, "DB counter 2 select register (0x3904)");
-                TEST_ASSERT(reg2->control_addr == 0, "DB counter 2 no control register");
-                TEST_ASSERT(reg2->register_addr_lo == 12804, "DB counter 2 lo register (0x3204)");
-                TEST_ASSERT(reg2->register_addr_hi == 12805, "DB counter 2 hi register (0x3205)");
+				/* Counter 2 registers */
+				TEST_ASSERT(reg2->select_addr == 14596,
+					    "DB counter 2 select register (0x3904)");
+				TEST_ASSERT(reg2->control_addr == 0,
+					    "DB counter 2 no control register");
+				TEST_ASSERT(reg2->register_addr_lo == 12804,
+					    "DB counter 2 lo register (0x3204)");
+				TEST_ASSERT(reg2->register_addr_hi == 12805,
+					    "DB counter 2 hi register (0x3205)");
 
-                /* Counter 3 registers */
-                TEST_ASSERT(reg3->select_addr == 14598, "DB counter 3 select register (0x3906)");
-                TEST_ASSERT(reg3->control_addr == 0, "DB counter 3 no control register");
-                TEST_ASSERT(reg3->register_addr_lo == 12806, "DB counter 3 lo register (0x3206)");
-                TEST_ASSERT(reg3->register_addr_hi == 12807, "DB counter 3 hi register (0x3207)");
-            }
-        }
+				/* Counter 3 registers */
+				TEST_ASSERT(reg3->select_addr == 14598,
+					    "DB counter 3 select register (0x3906)");
+				TEST_ASSERT(reg3->control_addr == 0,
+					    "DB counter 3 no control register");
+				TEST_ASSERT(reg3->register_addr_lo == 12806,
+					    "DB counter 3 lo register (0x3206)");
+				TEST_ASSERT(reg3->register_addr_hi == 12807,
+					    "DB counter 3 hi register (0x3207)");
+			}
+		}
 
-        free_arch(arch);
-    }
+		free_arch(arch);
+	}
 }
 
 /* Test GFX12 PA_SC block configuration */
-static void test_gfx12_pa_sc_block(void) {
-    printf("\n=== Testing GFX12 PA_SC Block ===\n");
-    arch_t* arch = arch_create_by_name("gfx12");
-    TEST_ASSERT(arch != NULL, "Architecture created for PA_SC block test");
+static void test_gfx12_pa_sc_block(void)
+{
+	printf("\n=== Testing GFX12 PA_SC Block ===\n");
+	arch_t *arch = arch_create_by_name("gfx12");
+	TEST_ASSERT(arch != NULL, "Architecture created for PA_SC block test");
 
-    if (arch) {
-        block_info_t* pa_sc_block = arch->block_map.blocks[HW_IP_BLOCK_PA_SC];
-        TEST_ASSERT(pa_sc_block != NULL, "PA_SC block exists");
+	if (arch) {
+		block_info_t *pa_sc_block = arch->block_map.blocks[HW_IP_BLOCK_PA_SC];
+		TEST_ASSERT(pa_sc_block != NULL, "PA_SC block exists");
 
-        if (pa_sc_block) {
-            /* Validate basic block properties */
-            TEST_ASSERT(strcmp(pa_sc_block->name, "PA_SC") == 0, "PA_SC block name is correct");
-            TEST_ASSERT(pa_sc_block->id == HW_IP_BLOCK_PA_SC, "PA_SC block type correct");
-            TEST_ASSERT(pa_sc_block->counter_count == 4, "PA_SC block has 4 counters");
-            TEST_ASSERT(pa_sc_block->event_id_max == 171, "PA_SC block max event ID is 171");
-            TEST_ASSERT(pa_sc_block->instance_count == 1, "PA_SC block has 1 instance");
+		if (pa_sc_block) {
+			/* Validate basic block properties */
+			TEST_ASSERT(strcmp(pa_sc_block->name, "PA_SC") == 0,
+				    "PA_SC block name is correct");
+			TEST_ASSERT(pa_sc_block->id == HW_IP_BLOCK_PA_SC,
+				    "PA_SC block type correct");
+			TEST_ASSERT(pa_sc_block->counter_count == 4, "PA_SC block has 4 counters");
+			TEST_ASSERT(pa_sc_block->event_id_max == 171,
+				    "PA_SC block max event ID is 171");
+			TEST_ASSERT(pa_sc_block->instance_count == 1, "PA_SC block has 1 instance");
 
-            /* Validate SE dimensions - PA_SC is a SE block with 2 dimensions */
-            TEST_ASSERT(pa_sc_block->dimensions != NULL, "PA_SC block dimensions exist");
-            TEST_ASSERT(pa_sc_block->dimension_count == 2, "PA_SC block has 2 dimensions");
+			/* Validate SE dimensions - PA_SC is a SE block with 2 dimensions */
+			TEST_ASSERT(pa_sc_block->dimensions != NULL,
+				    "PA_SC block dimensions exist");
+			TEST_ASSERT(pa_sc_block->dimension_count == 2,
+				    "PA_SC block has 2 dimensions");
 
-            if (pa_sc_block->dimensions && pa_sc_block->dimension_count >= 2) {
-                TEST_ASSERT(pa_sc_block->dimensions[0].dim == HARDWARE_DIM_XCC, "PA_SC dimension 0 is XCC");
-                TEST_ASSERT(pa_sc_block->dimensions[0].size == 1, "PA_SC XCC dimension size is 1");
-                TEST_ASSERT(pa_sc_block->dimensions[1].dim == HARDWARE_DIM_SE, "PA_SC dimension 1 is SE");
-                TEST_ASSERT(pa_sc_block->dimensions[1].size == 4, "PA_SC SE dimension size is 4");
-            }
+			if (pa_sc_block->dimensions && pa_sc_block->dimension_count >= 2) {
+				TEST_ASSERT(pa_sc_block->dimensions[0].dim == HARDWARE_DIM_XCC,
+					    "PA_SC dimension 0 is XCC");
+				TEST_ASSERT(pa_sc_block->dimensions[0].size == 1,
+					    "PA_SC XCC dimension size is 1");
+				TEST_ASSERT(pa_sc_block->dimensions[1].dim == HARDWARE_DIM_SE,
+					    "PA_SC dimension 1 is SE");
+				TEST_ASSERT(pa_sc_block->dimensions[1].size == 4,
+					    "PA_SC SE dimension size is 4");
+			}
 
-            /* Validate counter register info */
-            TEST_ASSERT(pa_sc_block->counter_reg_info != NULL, "PA_SC block counter registers exist");
-            if (pa_sc_block->counter_reg_info) {
-                counter_reg_info_t* reg0 = &pa_sc_block->counter_reg_info[0];
-                counter_reg_info_t* reg1 = &pa_sc_block->counter_reg_info[1];
-                counter_reg_info_t* reg2 = &pa_sc_block->counter_reg_info[2];
-                counter_reg_info_t* reg3 = &pa_sc_block->counter_reg_info[3];
+			/* Validate counter register info */
+			TEST_ASSERT(pa_sc_block->counter_reg_info != NULL,
+				    "PA_SC block counter registers exist");
+			if (pa_sc_block->counter_reg_info) {
+				counter_reg_info_t *reg0 = &pa_sc_block->counter_reg_info[0];
+				counter_reg_info_t *reg1 = &pa_sc_block->counter_reg_info[1];
+				counter_reg_info_t *reg2 = &pa_sc_block->counter_reg_info[2];
+				counter_reg_info_t *reg3 = &pa_sc_block->counter_reg_info[3];
 
-                /* Counter 0 registers - based on estimated addresses */
-                TEST_ASSERT(reg0->select_addr == 14208, "PA_SC counter 0 select register (0x3780)");
-                TEST_ASSERT(reg0->control_addr == 0, "PA_SC counter 0 no control register");
-                TEST_ASSERT(reg0->register_addr_lo == 12672, "PA_SC counter 0 lo register (0x3180)");
-                TEST_ASSERT(reg0->register_addr_hi == 12673, "PA_SC counter 0 hi register (0x3181)");
+				/* Counter 0 registers - based on estimated addresses */
+				TEST_ASSERT(reg0->select_addr == 14208,
+					    "PA_SC counter 0 select register (0x3780)");
+				TEST_ASSERT(reg0->control_addr == 0,
+					    "PA_SC counter 0 no control register");
+				TEST_ASSERT(reg0->register_addr_lo == 12672,
+					    "PA_SC counter 0 lo register (0x3180)");
+				TEST_ASSERT(reg0->register_addr_hi == 12673,
+					    "PA_SC counter 0 hi register (0x3181)");
 
-                /* Counter 1 registers */
-                TEST_ASSERT(reg1->select_addr == 14210, "PA_SC counter 1 select register (0x3782)");
-                TEST_ASSERT(reg1->control_addr == 0, "PA_SC counter 1 no control register");
-                TEST_ASSERT(reg1->register_addr_lo == 12674, "PA_SC counter 1 lo register (0x3182)");
-                TEST_ASSERT(reg1->register_addr_hi == 12675, "PA_SC counter 1 hi register (0x3183)");
+				/* Counter 1 registers */
+				TEST_ASSERT(reg1->select_addr == 14210,
+					    "PA_SC counter 1 select register (0x3782)");
+				TEST_ASSERT(reg1->control_addr == 0,
+					    "PA_SC counter 1 no control register");
+				TEST_ASSERT(reg1->register_addr_lo == 12674,
+					    "PA_SC counter 1 lo register (0x3182)");
+				TEST_ASSERT(reg1->register_addr_hi == 12675,
+					    "PA_SC counter 1 hi register (0x3183)");
 
-                /* Counter 2 registers */
-                TEST_ASSERT(reg2->select_addr == 14212, "PA_SC counter 2 select register (0x3784)");
-                TEST_ASSERT(reg2->control_addr == 0, "PA_SC counter 2 no control register");
-                TEST_ASSERT(reg2->register_addr_lo == 12676, "PA_SC counter 2 lo register (0x3184)");
-                TEST_ASSERT(reg2->register_addr_hi == 12677, "PA_SC counter 2 hi register (0x3185)");
+				/* Counter 2 registers */
+				TEST_ASSERT(reg2->select_addr == 14212,
+					    "PA_SC counter 2 select register (0x3784)");
+				TEST_ASSERT(reg2->control_addr == 0,
+					    "PA_SC counter 2 no control register");
+				TEST_ASSERT(reg2->register_addr_lo == 12676,
+					    "PA_SC counter 2 lo register (0x3184)");
+				TEST_ASSERT(reg2->register_addr_hi == 12677,
+					    "PA_SC counter 2 hi register (0x3185)");
 
-                /* Counter 3 registers */
-                TEST_ASSERT(reg3->select_addr == 14214, "PA_SC counter 3 select register (0x3786)");
-                TEST_ASSERT(reg3->control_addr == 0, "PA_SC counter 3 no control register");
-                TEST_ASSERT(reg3->register_addr_lo == 12678, "PA_SC counter 3 lo register (0x3186)");
-                TEST_ASSERT(reg3->register_addr_hi == 12679, "PA_SC counter 3 hi register (0x3187)");
-            }
-        }
+				/* Counter 3 registers */
+				TEST_ASSERT(reg3->select_addr == 14214,
+					    "PA_SC counter 3 select register (0x3786)");
+				TEST_ASSERT(reg3->control_addr == 0,
+					    "PA_SC counter 3 no control register");
+				TEST_ASSERT(reg3->register_addr_lo == 12678,
+					    "PA_SC counter 3 lo register (0x3186)");
+				TEST_ASSERT(reg3->register_addr_hi == 12679,
+					    "PA_SC counter 3 hi register (0x3187)");
+			}
+		}
 
-        free_arch(arch);
-    }
+		free_arch(arch);
+	}
 }
 
-static void test_gfx12_pa_su_block(void) {
-    printf("\n=== Testing GFX12 PA_SU Block ===\n");
-    arch_t* arch = arch_create_by_name("gfx12");
-    TEST_ASSERT(arch != NULL, "Architecture created for PA_SU block test");
+static void test_gfx12_pa_su_block(void)
+{
+	printf("\n=== Testing GFX12 PA_SU Block ===\n");
+	arch_t *arch = arch_create_by_name("gfx12");
+	TEST_ASSERT(arch != NULL, "Architecture created for PA_SU block test");
 
-    if (arch) {
-        block_info_t* pa_su_block = arch->block_map.blocks[HW_IP_BLOCK_PA_SU];
-        TEST_ASSERT(pa_su_block != NULL, "PA_SU block exists");
+	if (arch) {
+		block_info_t *pa_su_block = arch->block_map.blocks[HW_IP_BLOCK_PA_SU];
+		TEST_ASSERT(pa_su_block != NULL, "PA_SU block exists");
 
-        if (pa_su_block) {
-            /* Validate basic block properties */
-            TEST_ASSERT(strcmp(pa_su_block->name, "PA_SU") == 0, "PA_SU block name is correct");
-            TEST_ASSERT(pa_su_block->id == HW_IP_BLOCK_PA_SU, "PA_SU block type correct");
-            TEST_ASSERT(pa_su_block->counter_count == 4, "PA_SU block has 4 counters");
-            TEST_ASSERT(pa_su_block->event_id_max == 171, "PA_SU block max event ID is 171");
-            TEST_ASSERT(pa_su_block->instance_count == 1, "PA_SU block has 1 instance");
+		if (pa_su_block) {
+			/* Validate basic block properties */
+			TEST_ASSERT(strcmp(pa_su_block->name, "PA_SU") == 0,
+				    "PA_SU block name is correct");
+			TEST_ASSERT(pa_su_block->id == HW_IP_BLOCK_PA_SU,
+				    "PA_SU block type correct");
+			TEST_ASSERT(pa_su_block->counter_count == 4, "PA_SU block has 4 counters");
+			TEST_ASSERT(pa_su_block->event_id_max == 171,
+				    "PA_SU block max event ID is 171");
+			TEST_ASSERT(pa_su_block->instance_count == 1, "PA_SU block has 1 instance");
 
-            /* Validate SE dimensions - PA_SU is a SE block with 2 dimensions */
-            TEST_ASSERT(pa_su_block->dimensions != NULL, "PA_SU block dimensions exist");
-            TEST_ASSERT(pa_su_block->dimension_count == 2, "PA_SU block has 2 dimensions");
+			/* Validate SE dimensions - PA_SU is a SE block with 2 dimensions */
+			TEST_ASSERT(pa_su_block->dimensions != NULL,
+				    "PA_SU block dimensions exist");
+			TEST_ASSERT(pa_su_block->dimension_count == 2,
+				    "PA_SU block has 2 dimensions");
 
-            if (pa_su_block->dimensions && pa_su_block->dimension_count >= 2) {
-                TEST_ASSERT(pa_su_block->dimensions[0].dim == HARDWARE_DIM_XCC, "PA_SU dimension 0 is XCC");
-                TEST_ASSERT(pa_su_block->dimensions[0].size == 1, "PA_SU XCC dimension size is 1");
-                TEST_ASSERT(pa_su_block->dimensions[1].dim == HARDWARE_DIM_SE, "PA_SU dimension 1 is SE");
-                TEST_ASSERT(pa_su_block->dimensions[1].size == 4, "PA_SU SE dimension size is 4");
-            }
+			if (pa_su_block->dimensions && pa_su_block->dimension_count >= 2) {
+				TEST_ASSERT(pa_su_block->dimensions[0].dim == HARDWARE_DIM_XCC,
+					    "PA_SU dimension 0 is XCC");
+				TEST_ASSERT(pa_su_block->dimensions[0].size == 1,
+					    "PA_SU XCC dimension size is 1");
+				TEST_ASSERT(pa_su_block->dimensions[1].dim == HARDWARE_DIM_SE,
+					    "PA_SU dimension 1 is SE");
+				TEST_ASSERT(pa_su_block->dimensions[1].size == 4,
+					    "PA_SU SE dimension size is 4");
+			}
 
-            /* Validate counter register info */
-            TEST_ASSERT(pa_su_block->counter_reg_info != NULL, "PA_SU block counter registers exist");
-            if (pa_su_block->counter_reg_info) {
-                counter_reg_info_t* reg0 = &pa_su_block->counter_reg_info[0];
-                counter_reg_info_t* reg1 = &pa_su_block->counter_reg_info[1];
-                counter_reg_info_t* reg2 = &pa_su_block->counter_reg_info[2];
-                counter_reg_info_t* reg3 = &pa_su_block->counter_reg_info[3];
+			/* Validate counter register info */
+			TEST_ASSERT(pa_su_block->counter_reg_info != NULL,
+				    "PA_SU block counter registers exist");
+			if (pa_su_block->counter_reg_info) {
+				counter_reg_info_t *reg0 = &pa_su_block->counter_reg_info[0];
+				counter_reg_info_t *reg1 = &pa_su_block->counter_reg_info[1];
+				counter_reg_info_t *reg2 = &pa_su_block->counter_reg_info[2];
+				counter_reg_info_t *reg3 = &pa_su_block->counter_reg_info[3];
 
-                /* Counter 0 registers */
-                TEST_ASSERT(reg0->select_addr == 14216, "PA_SU counter 0 select register (0x3788)");
-                TEST_ASSERT(reg0->control_addr == 0, "PA_SU counter 0 no control register");
-                TEST_ASSERT(reg0->register_addr_lo == 12680, "PA_SU counter 0 lo register (0x3188)");
-                TEST_ASSERT(reg0->register_addr_hi == 12681, "PA_SU counter 0 hi register (0x3189)");
+				/* Counter 0 registers */
+				TEST_ASSERT(reg0->select_addr == 14216,
+					    "PA_SU counter 0 select register (0x3788)");
+				TEST_ASSERT(reg0->control_addr == 0,
+					    "PA_SU counter 0 no control register");
+				TEST_ASSERT(reg0->register_addr_lo == 12680,
+					    "PA_SU counter 0 lo register (0x3188)");
+				TEST_ASSERT(reg0->register_addr_hi == 12681,
+					    "PA_SU counter 0 hi register (0x3189)");
 
-                /* Counter 1 registers */
-                TEST_ASSERT(reg1->select_addr == 14218, "PA_SU counter 1 select register (0x378a)");
-                TEST_ASSERT(reg1->control_addr == 0, "PA_SU counter 1 no control register");
-                TEST_ASSERT(reg1->register_addr_lo == 12682, "PA_SU counter 1 lo register (0x318a)");
-                TEST_ASSERT(reg1->register_addr_hi == 12683, "PA_SU counter 1 hi register (0x318b)");
+				/* Counter 1 registers */
+				TEST_ASSERT(reg1->select_addr == 14218,
+					    "PA_SU counter 1 select register (0x378a)");
+				TEST_ASSERT(reg1->control_addr == 0,
+					    "PA_SU counter 1 no control register");
+				TEST_ASSERT(reg1->register_addr_lo == 12682,
+					    "PA_SU counter 1 lo register (0x318a)");
+				TEST_ASSERT(reg1->register_addr_hi == 12683,
+					    "PA_SU counter 1 hi register (0x318b)");
 
-                /* Counter 2 registers */
-                TEST_ASSERT(reg2->select_addr == 14220, "PA_SU counter 2 select register (0x378c)");
-                TEST_ASSERT(reg2->control_addr == 0, "PA_SU counter 2 no control register");
-                TEST_ASSERT(reg2->register_addr_lo == 12684, "PA_SU counter 2 lo register (0x318c)");
-                TEST_ASSERT(reg2->register_addr_hi == 12685, "PA_SU counter 2 hi register (0x318d)");
+				/* Counter 2 registers */
+				TEST_ASSERT(reg2->select_addr == 14220,
+					    "PA_SU counter 2 select register (0x378c)");
+				TEST_ASSERT(reg2->control_addr == 0,
+					    "PA_SU counter 2 no control register");
+				TEST_ASSERT(reg2->register_addr_lo == 12684,
+					    "PA_SU counter 2 lo register (0x318c)");
+				TEST_ASSERT(reg2->register_addr_hi == 12685,
+					    "PA_SU counter 2 hi register (0x318d)");
 
-                /* Counter 3 registers */
-                TEST_ASSERT(reg3->select_addr == 14222, "PA_SU counter 3 select register (0x378e)");
-                TEST_ASSERT(reg3->control_addr == 0, "PA_SU counter 3 no control register");
-                TEST_ASSERT(reg3->register_addr_lo == 12686, "PA_SU counter 3 lo register (0x318e)");
-                TEST_ASSERT(reg3->register_addr_hi == 12687, "PA_SU counter 3 hi register (0x318f)");
-            }
-        }
+				/* Counter 3 registers */
+				TEST_ASSERT(reg3->select_addr == 14222,
+					    "PA_SU counter 3 select register (0x378e)");
+				TEST_ASSERT(reg3->control_addr == 0,
+					    "PA_SU counter 3 no control register");
+				TEST_ASSERT(reg3->register_addr_lo == 12686,
+					    "PA_SU counter 3 lo register (0x318e)");
+				TEST_ASSERT(reg3->register_addr_hi == 12687,
+					    "PA_SU counter 3 hi register (0x318f)");
+			}
+		}
 
-        free_arch(arch);
-    }
+		free_arch(arch);
+	}
 }
 
-static void test_gfx12_gds_block(void) {
-    printf("\n=== Testing GFX12 GDS Block ===\n");
-    arch_t* arch = arch_create_by_name("gfx12");
-    TEST_ASSERT(arch != NULL, "Architecture created for GDS block test");
+static void test_gfx12_gds_block(void)
+{
+	printf("\n=== Testing GFX12 GDS Block ===\n");
+	arch_t *arch = arch_create_by_name("gfx12");
+	TEST_ASSERT(arch != NULL, "Architecture created for GDS block test");
 
-    if (arch) {
-        block_info_t* gds_block = arch->block_map.blocks[HW_IP_BLOCK_GDS];
-        TEST_ASSERT(gds_block != NULL, "GDS block exists");
+	if (arch) {
+		block_info_t *gds_block = arch->block_map.blocks[HW_IP_BLOCK_GDS];
+		TEST_ASSERT(gds_block != NULL, "GDS block exists");
 
-        if (gds_block) {
-            /* Validate basic block properties */
-            TEST_ASSERT(strcmp(gds_block->name, "GDS") == 0, "GDS block name is correct");
-            TEST_ASSERT(gds_block->id == HW_IP_BLOCK_GDS, "GDS block type correct");
-            TEST_ASSERT(gds_block->counter_count == 4, "GDS block has 4 counters");
-            TEST_ASSERT(gds_block->event_id_max == 121, "GDS block max event ID is 121");
-            TEST_ASSERT(gds_block->instance_count == 1, "GDS block has 1 instance");
+		if (gds_block) {
+			/* Validate basic block properties */
+			TEST_ASSERT(strcmp(gds_block->name, "GDS") == 0,
+				    "GDS block name is correct");
+			TEST_ASSERT(gds_block->id == HW_IP_BLOCK_GDS, "GDS block type correct");
+			TEST_ASSERT(gds_block->counter_count == 4, "GDS block has 4 counters");
+			TEST_ASSERT(gds_block->event_id_max == 121,
+				    "GDS block max event ID is 121");
+			TEST_ASSERT(gds_block->instance_count == 1, "GDS block has 1 instance");
 
-            /* Validate XCC dimensions - GDS is a XCC block with 1 dimension */
-            TEST_ASSERT(gds_block->dimensions != NULL, "GDS block dimensions exist");
-            TEST_ASSERT(gds_block->dimension_count == 1, "GDS block has 1 dimension");
+			/* Validate XCC dimensions - GDS is a XCC block with 1 dimension */
+			TEST_ASSERT(gds_block->dimensions != NULL, "GDS block dimensions exist");
+			TEST_ASSERT(gds_block->dimension_count == 1, "GDS block has 1 dimension");
 
-            if (gds_block->dimensions && gds_block->dimension_count >= 1) {
-                TEST_ASSERT(gds_block->dimensions[0].dim == HARDWARE_DIM_XCC, "GDS dimension 0 is XCC");
-                TEST_ASSERT(gds_block->dimensions[0].size == 1, "GDS XCC dimension size is 1");
-            }
+			if (gds_block->dimensions && gds_block->dimension_count >= 1) {
+				TEST_ASSERT(gds_block->dimensions[0].dim == HARDWARE_DIM_XCC,
+					    "GDS dimension 0 is XCC");
+				TEST_ASSERT(gds_block->dimensions[0].size == 1,
+					    "GDS XCC dimension size is 1");
+			}
 
-            /* Validate counter register info */
-            TEST_ASSERT(gds_block->counter_reg_info != NULL, "GDS block counter registers exist");
-            if (gds_block->counter_reg_info) {
-                counter_reg_info_t* reg0 = &gds_block->counter_reg_info[0];
-                counter_reg_info_t* reg1 = &gds_block->counter_reg_info[1];
-                counter_reg_info_t* reg2 = &gds_block->counter_reg_info[2];
-                counter_reg_info_t* reg3 = &gds_block->counter_reg_info[3];
+			/* Validate counter register info */
+			TEST_ASSERT(gds_block->counter_reg_info != NULL,
+				    "GDS block counter registers exist");
+			if (gds_block->counter_reg_info) {
+				counter_reg_info_t *reg0 = &gds_block->counter_reg_info[0];
+				counter_reg_info_t *reg1 = &gds_block->counter_reg_info[1];
+				counter_reg_info_t *reg2 = &gds_block->counter_reg_info[2];
+				counter_reg_info_t *reg3 = &gds_block->counter_reg_info[3];
 
-                /* Counter 0 registers */
-                TEST_ASSERT(reg0->select_addr == 14352, "GDS counter 0 select register (0x3810)");
-                TEST_ASSERT(reg0->control_addr == 0, "GDS counter 0 no control register");
-                TEST_ASSERT(reg0->register_addr_lo == 12816, "GDS counter 0 lo register (0x3210)");
-                TEST_ASSERT(reg0->register_addr_hi == 12817, "GDS counter 0 hi register (0x3211)");
+				/* Counter 0 registers */
+				TEST_ASSERT(reg0->select_addr == 14352,
+					    "GDS counter 0 select register (0x3810)");
+				TEST_ASSERT(reg0->control_addr == 0,
+					    "GDS counter 0 no control register");
+				TEST_ASSERT(reg0->register_addr_lo == 12816,
+					    "GDS counter 0 lo register (0x3210)");
+				TEST_ASSERT(reg0->register_addr_hi == 12817,
+					    "GDS counter 0 hi register (0x3211)");
 
-                /* Counter 1 registers */
-                TEST_ASSERT(reg1->select_addr == 14354, "GDS counter 1 select register (0x3812)");
-                TEST_ASSERT(reg1->control_addr == 0, "GDS counter 1 no control register");
-                TEST_ASSERT(reg1->register_addr_lo == 12818, "GDS counter 1 lo register (0x3212)");
-                TEST_ASSERT(reg1->register_addr_hi == 12819, "GDS counter 1 hi register (0x3213)");
+				/* Counter 1 registers */
+				TEST_ASSERT(reg1->select_addr == 14354,
+					    "GDS counter 1 select register (0x3812)");
+				TEST_ASSERT(reg1->control_addr == 0,
+					    "GDS counter 1 no control register");
+				TEST_ASSERT(reg1->register_addr_lo == 12818,
+					    "GDS counter 1 lo register (0x3212)");
+				TEST_ASSERT(reg1->register_addr_hi == 12819,
+					    "GDS counter 1 hi register (0x3213)");
 
-                /* Counter 2 registers */
-                TEST_ASSERT(reg2->select_addr == 14356, "GDS counter 2 select register (0x3814)");
-                TEST_ASSERT(reg2->control_addr == 0, "GDS counter 2 no control register");
-                TEST_ASSERT(reg2->register_addr_lo == 12820, "GDS counter 2 lo register (0x3214)");
-                TEST_ASSERT(reg2->register_addr_hi == 12821, "GDS counter 2 hi register (0x3215)");
+				/* Counter 2 registers */
+				TEST_ASSERT(reg2->select_addr == 14356,
+					    "GDS counter 2 select register (0x3814)");
+				TEST_ASSERT(reg2->control_addr == 0,
+					    "GDS counter 2 no control register");
+				TEST_ASSERT(reg2->register_addr_lo == 12820,
+					    "GDS counter 2 lo register (0x3214)");
+				TEST_ASSERT(reg2->register_addr_hi == 12821,
+					    "GDS counter 2 hi register (0x3215)");
 
-                /* Counter 3 registers */
-                TEST_ASSERT(reg3->select_addr == 14358, "GDS counter 3 select register (0x3816)");
-                TEST_ASSERT(reg3->control_addr == 0, "GDS counter 3 no control register");
-                TEST_ASSERT(reg3->register_addr_lo == 12822, "GDS counter 3 lo register (0x3216)");
-                TEST_ASSERT(reg3->register_addr_hi == 12823, "GDS counter 3 hi register (0x3217)");
-            }
-        }
+				/* Counter 3 registers */
+				TEST_ASSERT(reg3->select_addr == 14358,
+					    "GDS counter 3 select register (0x3816)");
+				TEST_ASSERT(reg3->control_addr == 0,
+					    "GDS counter 3 no control register");
+				TEST_ASSERT(reg3->register_addr_lo == 12822,
+					    "GDS counter 3 lo register (0x3216)");
+				TEST_ASSERT(reg3->register_addr_hi == 12823,
+					    "GDS counter 3 hi register (0x3217)");
+			}
+		}
 
-        free_arch(arch);
-    }
+		free_arch(arch);
+	}
 }
 
 /* Test counter allocation simulation */
-static void test_counter_allocation(void) {
-    printf("\n=== Testing Counter Allocation ===\n");
+static void test_counter_allocation(void)
+{
+	printf("\n=== Testing Counter Allocation ===\n");
 
-    arch_t* arch = arch_create_by_name("gfx12");
-    TEST_ASSERT(arch != NULL, "Architecture created for allocation test");
+	arch_t *arch = arch_create_by_name("gfx12");
+	TEST_ASSERT(arch != NULL, "Architecture created for allocation test");
 
-    if (arch) {
-        block_info_t* cpc_block = arch->block_map.blocks[HW_IP_BLOCK_CPC];
-        if (cpc_block && cpc_block->counter_reg_info) {
-            counter_reg_info_t* reg = &cpc_block->counter_reg_info[0];
+	if (arch) {
+		block_info_t *cpc_block = arch->block_map.blocks[HW_IP_BLOCK_CPC];
+		if (cpc_block && cpc_block->counter_reg_info) {
+			counter_reg_info_t *reg = &cpc_block->counter_reg_info[0];
 
-            /* Simulate counter allocation */
-            reg->allocation.state = COUNTER_STATE_ALLOCATED;
-            reg->allocation.event_id = 0x10;
-            reg->allocation.instance_id = 1;
-            reg->allocation.user_id = 1234;
-            reg->allocation.allocation_time = 1000;
+			/* Simulate counter allocation */
+			reg->allocation.state = COUNTER_STATE_ALLOCATED;
+			reg->allocation.event_id = 0x10;
+			reg->allocation.instance_id = 1;
+			reg->allocation.user_id = 1234;
+			reg->allocation.allocation_time = 1000;
 
-            TEST_ASSERT(reg->allocation.state == COUNTER_STATE_ALLOCATED, "Counter allocated state");
-            TEST_ASSERT(reg->allocation.event_id == 0x10, "Counter event ID set");
-            TEST_ASSERT(reg->allocation.instance_id == 1, "Counter instance ID set");
-            TEST_ASSERT(reg->allocation.user_id == 1234, "Counter user ID set");
-            TEST_ASSERT(reg->allocation.allocation_time == 1000, "Counter allocation time set");
+			TEST_ASSERT(reg->allocation.state == COUNTER_STATE_ALLOCATED,
+				    "Counter allocated state");
+			TEST_ASSERT(reg->allocation.event_id == 0x10, "Counter event ID set");
+			TEST_ASSERT(reg->allocation.instance_id == 1, "Counter instance ID set");
+			TEST_ASSERT(reg->allocation.user_id == 1234, "Counter user ID set");
+			TEST_ASSERT(reg->allocation.allocation_time == 1000,
+				    "Counter allocation time set");
 
-            /* Simulate counter release */
-            reg->allocation.state = COUNTER_STATE_FREE;
-            reg->allocation.event_id = 0;
-            reg->allocation.instance_id = 0;
-            reg->allocation.user_id = 0;
-            reg->allocation.allocation_time = 0;
+			/* Simulate counter release */
+			reg->allocation.state = COUNTER_STATE_FREE;
+			reg->allocation.event_id = 0;
+			reg->allocation.instance_id = 0;
+			reg->allocation.user_id = 0;
+			reg->allocation.allocation_time = 0;
 
-            TEST_ASSERT(reg->allocation.state == COUNTER_STATE_FREE, "Counter freed state");
-        }
+			TEST_ASSERT(reg->allocation.state == COUNTER_STATE_FREE,
+				    "Counter freed state");
+		}
 
-        free_arch(arch);
-    }
+		free_arch(arch);
+	}
 }
 
 /* Test TA block configuration */
-static void test_gfx12_ta_block(void) {
-    printf("\n=== Testing GFX12 TA Block ===\n");
+static void test_gfx12_ta_block(void)
+{
+	printf("\n=== Testing GFX12 TA Block ===\n");
 
-    arch_t* arch = arch_create_by_name("gfx12");
-    TEST_ASSERT(arch != NULL, "Architecture created for TA block test");
+	arch_t *arch = arch_create_by_name("gfx12");
+	TEST_ASSERT(arch != NULL, "Architecture created for TA block test");
 
-    if (arch) {
-        block_info_t* ta_block = arch->block_map.blocks[HW_IP_BLOCK_TA];
-        TEST_ASSERT(ta_block != NULL, "TA block exists");
+	if (arch) {
+		block_info_t *ta_block = arch->block_map.blocks[HW_IP_BLOCK_TA];
+		TEST_ASSERT(ta_block != NULL, "TA block exists");
 
-        if (ta_block) {
-            /* Validate basic block properties */
-            TEST_ASSERT(strcmp(ta_block->name, "TA") == 0, "TA block name is correct");
-            TEST_ASSERT(ta_block->id == HW_IP_BLOCK_TA, "TA block type correct");
-            TEST_ASSERT(ta_block->counter_count == 2, "TA block has 2 counters");
-            TEST_ASSERT(ta_block->event_id_max == 254, "TA block max event ID is 254");
-            TEST_ASSERT(ta_block->instance_count == 2, "TA block has 2 instances");
+		if (ta_block) {
+			/* Validate basic block properties */
+			TEST_ASSERT(strcmp(ta_block->name, "TA") == 0, "TA block name is correct");
+			TEST_ASSERT(ta_block->id == HW_IP_BLOCK_TA, "TA block type correct");
+			TEST_ASSERT(ta_block->counter_count == 2, "TA block has 2 counters");
+			TEST_ASSERT(ta_block->event_id_max == 254, "TA block max event ID is 254");
+			TEST_ASSERT(ta_block->instance_count == 2, "TA block has 2 instances");
 
-            /* Validate WGP dimensions - TA is a WGP-level block with 4 dimensions */
-            TEST_ASSERT(ta_block->dimensions != NULL, "TA block dimensions exist");
-            TEST_ASSERT(ta_block->dimension_count == 4, "TA block has 4 dimensions");
-            if (ta_block->dimensions && ta_block->dimension_count >= 4) {
-                TEST_ASSERT(ta_block->dimensions[0].dim == HARDWARE_DIM_XCC, "TA dimension 0 is XCC");
-                TEST_ASSERT(ta_block->dimensions[0].size == 1, "TA XCC dimension size is 1");
-                TEST_ASSERT(ta_block->dimensions[1].dim == HARDWARE_DIM_SE, "TA dimension 1 is SE");
-                TEST_ASSERT(ta_block->dimensions[1].size == 4, "TA SE dimension size is 4");
-                TEST_ASSERT(ta_block->dimensions[2].dim == HARDWARE_DIM_SA, "TA dimension 2 is SA");
-                TEST_ASSERT(ta_block->dimensions[2].size == 2, "TA SA dimension size is 2");
-                TEST_ASSERT(ta_block->dimensions[3].dim == HARDWARE_DIM_WGP, "TA dimension 3 is WGP");
-                TEST_ASSERT(ta_block->dimensions[3].size == 4, "TA WGP dimension size is 4");
-            }
+			/* Validate WGP dimensions - TA is a WGP-level block with 4 dimensions */
+			TEST_ASSERT(ta_block->dimensions != NULL, "TA block dimensions exist");
+			TEST_ASSERT(ta_block->dimension_count == 4, "TA block has 4 dimensions");
+			if (ta_block->dimensions && ta_block->dimension_count >= 4) {
+				TEST_ASSERT(ta_block->dimensions[0].dim == HARDWARE_DIM_XCC,
+					    "TA dimension 0 is XCC");
+				TEST_ASSERT(ta_block->dimensions[0].size == 1,
+					    "TA XCC dimension size is 1");
+				TEST_ASSERT(ta_block->dimensions[1].dim == HARDWARE_DIM_SE,
+					    "TA dimension 1 is SE");
+				TEST_ASSERT(ta_block->dimensions[1].size == 4,
+					    "TA SE dimension size is 4");
+				TEST_ASSERT(ta_block->dimensions[2].dim == HARDWARE_DIM_SA,
+					    "TA dimension 2 is SA");
+				TEST_ASSERT(ta_block->dimensions[2].size == 2,
+					    "TA SA dimension size is 2");
+				TEST_ASSERT(ta_block->dimensions[3].dim == HARDWARE_DIM_WGP,
+					    "TA dimension 3 is WGP");
+				TEST_ASSERT(ta_block->dimensions[3].size == 4,
+					    "TA WGP dimension size is 4");
+			}
 
-            /* Validate counter register info */
-            TEST_ASSERT(ta_block->counter_reg_info != NULL, "TA block counter registers exist");
-            if (ta_block->counter_reg_info) {
-                counter_reg_info_t* reg0 = &ta_block->counter_reg_info[0];
-                counter_reg_info_t* reg1 = &ta_block->counter_reg_info[1];
+			/* Validate counter register info */
+			TEST_ASSERT(ta_block->counter_reg_info != NULL,
+				    "TA block counter registers exist");
+			if (ta_block->counter_reg_info) {
+				counter_reg_info_t *reg0 = &ta_block->counter_reg_info[0];
+				counter_reg_info_t *reg1 = &ta_block->counter_reg_info[1];
 
-                /* Counter 0 registers - from aqlprofile reference */
-                TEST_ASSERT(reg0->select_addr == 15040, "TA counter 0 select register (0x3ac0)");
-                TEST_ASSERT(reg0->control_addr == 0, "TA counter 0 no control register");
-                TEST_ASSERT(reg0->register_addr_lo == 12992, "TA counter 0 lo register (0x32c0)");
-                TEST_ASSERT(reg0->register_addr_hi == 12993, "TA counter 0 hi register (0x32c1)");
+				/* Counter 0 registers - from aqlprofile reference */
+				TEST_ASSERT(reg0->select_addr == 15040,
+					    "TA counter 0 select register (0x3ac0)");
+				TEST_ASSERT(reg0->control_addr == 0,
+					    "TA counter 0 no control register");
+				TEST_ASSERT(reg0->register_addr_lo == 12992,
+					    "TA counter 0 lo register (0x32c0)");
+				TEST_ASSERT(reg0->register_addr_hi == 12993,
+					    "TA counter 0 hi register (0x32c1)");
 
-                /* Counter 1 registers */
-                TEST_ASSERT(reg1->select_addr == 15042, "TA counter 1 select register (0x3ac2)");
-                TEST_ASSERT(reg1->control_addr == 0, "TA counter 1 no control register");
-                TEST_ASSERT(reg1->register_addr_lo == 12994, "TA counter 1 lo register (0x32c2)");
-                TEST_ASSERT(reg1->register_addr_hi == 12995, "TA counter 1 hi register (0x32c3)");
+				/* Counter 1 registers */
+				TEST_ASSERT(reg1->select_addr == 15042,
+					    "TA counter 1 select register (0x3ac2)");
+				TEST_ASSERT(reg1->control_addr == 0,
+					    "TA counter 1 no control register");
+				TEST_ASSERT(reg1->register_addr_lo == 12994,
+					    "TA counter 1 lo register (0x32c2)");
+				TEST_ASSERT(reg1->register_addr_hi == 12995,
+					    "TA counter 1 hi register (0x32c3)");
 
-                /* Test counter allocation simulation */
-                reg0->allocation.state = COUNTER_STATE_ALLOCATED;
-                reg0->allocation.event_id = 0x42; /* Valid TA event */
-                reg0->allocation.instance_id = 0; /* First instance */
-                reg0->allocation.user_id = 5678;
-                reg0->allocation.allocation_time = 2000;
+				/* Test counter allocation simulation */
+				reg0->allocation.state = COUNTER_STATE_ALLOCATED;
+				reg0->allocation.event_id = 0x42; /* Valid TA event */
+				reg0->allocation.instance_id = 0; /* First instance */
+				reg0->allocation.user_id = 5678;
+				reg0->allocation.allocation_time = 2000;
 
-                TEST_ASSERT(reg0->allocation.state == COUNTER_STATE_ALLOCATED, "TA counter allocated state");
-                TEST_ASSERT(reg0->allocation.event_id == 0x42, "TA counter event ID set");
-                TEST_ASSERT(reg0->allocation.instance_id == 0, "TA counter instance ID set");
-                TEST_ASSERT(reg0->allocation.user_id == 5678, "TA counter user ID set");
-                TEST_ASSERT(reg0->allocation.allocation_time == 2000, "TA counter allocation time set");
+				TEST_ASSERT(reg0->allocation.state == COUNTER_STATE_ALLOCATED,
+					    "TA counter allocated state");
+				TEST_ASSERT(reg0->allocation.event_id == 0x42,
+					    "TA counter event ID set");
+				TEST_ASSERT(reg0->allocation.instance_id == 0,
+					    "TA counter instance ID set");
+				TEST_ASSERT(reg0->allocation.user_id == 5678,
+					    "TA counter user ID set");
+				TEST_ASSERT(reg0->allocation.allocation_time == 2000,
+					    "TA counter allocation time set");
 
-                /* Simulate counter release */
-                reg0->allocation.state = COUNTER_STATE_FREE;
-                reg0->allocation.event_id = 0;
-                reg0->allocation.instance_id = 0;
-                reg0->allocation.user_id = 0;
-                reg0->allocation.allocation_time = 0;
+				/* Simulate counter release */
+				reg0->allocation.state = COUNTER_STATE_FREE;
+				reg0->allocation.event_id = 0;
+				reg0->allocation.instance_id = 0;
+				reg0->allocation.user_id = 0;
+				reg0->allocation.allocation_time = 0;
 
-                TEST_ASSERT(reg0->allocation.state == COUNTER_STATE_FREE, "TA counter freed state");
-            }
-        }
+				TEST_ASSERT(reg0->allocation.state == COUNTER_STATE_FREE,
+					    "TA counter freed state");
+			}
+		}
 
-        free_arch(arch);
-    }
+		free_arch(arch);
+	}
 }
 
 /* Test TCP block configuration */
-static void test_gfx12_tcp_block(void) {
-    printf("\n=== Testing GFX12 TCP Block ===\n");
+static void test_gfx12_tcp_block(void)
+{
+	printf("\n=== Testing GFX12 TCP Block ===\n");
 
-    arch_t* arch = arch_create_by_name("gfx12");
-    TEST_ASSERT(arch != NULL, "Architecture created for TCP block test");
+	arch_t *arch = arch_create_by_name("gfx12");
+	TEST_ASSERT(arch != NULL, "Architecture created for TCP block test");
 
-    if (arch) {
-        block_info_t* tcp_block = arch->block_map.blocks[HW_IP_BLOCK_TCP];
-        TEST_ASSERT(tcp_block != NULL, "TCP block exists");
+	if (arch) {
+		block_info_t *tcp_block = arch->block_map.blocks[HW_IP_BLOCK_TCP];
+		TEST_ASSERT(tcp_block != NULL, "TCP block exists");
 
-        if (tcp_block) {
-            /* Validate basic block properties */
-            TEST_ASSERT(strcmp(tcp_block->name, "TCP") == 0, "TCP block name is correct");
-            TEST_ASSERT(tcp_block->id == HW_IP_BLOCK_TCP, "TCP block type correct");
-            TEST_ASSERT(tcp_block->counter_count == 4, "TCP block has 4 counters");
-            TEST_ASSERT(tcp_block->event_id_max == 99, "TCP block max event ID is 99");
-            TEST_ASSERT(tcp_block->instance_count == 2, "TCP block has 2 instances");
+		if (tcp_block) {
+			/* Validate basic block properties */
+			TEST_ASSERT(strcmp(tcp_block->name, "TCP") == 0,
+				    "TCP block name is correct");
+			TEST_ASSERT(tcp_block->id == HW_IP_BLOCK_TCP, "TCP block type correct");
+			TEST_ASSERT(tcp_block->counter_count == 4, "TCP block has 4 counters");
+			TEST_ASSERT(tcp_block->event_id_max == 99, "TCP block max event ID is 99");
+			TEST_ASSERT(tcp_block->instance_count == 2, "TCP block has 2 instances");
 
-            /* Validate WGP dimensions - TCP is a WGP-level block with 4 dimensions */
-            TEST_ASSERT(tcp_block->dimensions != NULL, "TCP block dimensions exist");
-            TEST_ASSERT(tcp_block->dimension_count == 4, "TCP block has 4 dimensions");
-            if (tcp_block->dimensions && tcp_block->dimension_count >= 4) {
-                TEST_ASSERT(tcp_block->dimensions[0].dim == HARDWARE_DIM_XCC, "TCP dimension 0 is XCC");
-                TEST_ASSERT(tcp_block->dimensions[0].size == 1, "TCP XCC dimension size is 1");
-                TEST_ASSERT(tcp_block->dimensions[1].dim == HARDWARE_DIM_SE, "TCP dimension 1 is SE");
-                TEST_ASSERT(tcp_block->dimensions[1].size == 4, "TCP SE dimension size is 4");
-                TEST_ASSERT(tcp_block->dimensions[2].dim == HARDWARE_DIM_SA, "TCP dimension 2 is SA");
-                TEST_ASSERT(tcp_block->dimensions[2].size == 2, "TCP SA dimension size is 2");
-                TEST_ASSERT(tcp_block->dimensions[3].dim == HARDWARE_DIM_WGP, "TCP dimension 3 is WGP");
-                TEST_ASSERT(tcp_block->dimensions[3].size == 4, "TCP WGP dimension size is 4");
-            }
+			/* Validate WGP dimensions - TCP is a WGP-level block with 4 dimensions */
+			TEST_ASSERT(tcp_block->dimensions != NULL, "TCP block dimensions exist");
+			TEST_ASSERT(tcp_block->dimension_count == 4, "TCP block has 4 dimensions");
+			if (tcp_block->dimensions && tcp_block->dimension_count >= 4) {
+				TEST_ASSERT(tcp_block->dimensions[0].dim == HARDWARE_DIM_XCC,
+					    "TCP dimension 0 is XCC");
+				TEST_ASSERT(tcp_block->dimensions[0].size == 1,
+					    "TCP XCC dimension size is 1");
+				TEST_ASSERT(tcp_block->dimensions[1].dim == HARDWARE_DIM_SE,
+					    "TCP dimension 1 is SE");
+				TEST_ASSERT(tcp_block->dimensions[1].size == 4,
+					    "TCP SE dimension size is 4");
+				TEST_ASSERT(tcp_block->dimensions[2].dim == HARDWARE_DIM_SA,
+					    "TCP dimension 2 is SA");
+				TEST_ASSERT(tcp_block->dimensions[2].size == 2,
+					    "TCP SA dimension size is 2");
+				TEST_ASSERT(tcp_block->dimensions[3].dim == HARDWARE_DIM_WGP,
+					    "TCP dimension 3 is WGP");
+				TEST_ASSERT(tcp_block->dimensions[3].size == 4,
+					    "TCP WGP dimension size is 4");
+			}
 
-            /* Validate counter register info */
-            TEST_ASSERT(tcp_block->counter_reg_info != NULL, "TCP block counter registers exist");
-            if (tcp_block->counter_reg_info) {
-                counter_reg_info_t* reg0 = &tcp_block->counter_reg_info[0];
-                counter_reg_info_t* reg1 = &tcp_block->counter_reg_info[1];
-                counter_reg_info_t* reg2 = &tcp_block->counter_reg_info[2];
-                counter_reg_info_t* reg3 = &tcp_block->counter_reg_info[3];
+			/* Validate counter register info */
+			TEST_ASSERT(tcp_block->counter_reg_info != NULL,
+				    "TCP block counter registers exist");
+			if (tcp_block->counter_reg_info) {
+				counter_reg_info_t *reg0 = &tcp_block->counter_reg_info[0];
+				counter_reg_info_t *reg1 = &tcp_block->counter_reg_info[1];
+				counter_reg_info_t *reg2 = &tcp_block->counter_reg_info[2];
+				counter_reg_info_t *reg3 = &tcp_block->counter_reg_info[3];
 
-                /* Counter 0 registers - from aqlprofile reference */
-                TEST_ASSERT(reg0->select_addr == 15168, "TCP counter 0 select register (0x3b40)");
-                TEST_ASSERT(reg0->control_addr == 0, "TCP counter 0 no control register");
-                TEST_ASSERT(reg0->register_addr_lo == 13120, "TCP counter 0 lo register (0x3340)");
-                TEST_ASSERT(reg0->register_addr_hi == 13121, "TCP counter 0 hi register (0x3341)");
+				/* Counter 0 registers - from aqlprofile reference */
+				TEST_ASSERT(reg0->select_addr == 15168,
+					    "TCP counter 0 select register (0x3b40)");
+				TEST_ASSERT(reg0->control_addr == 0,
+					    "TCP counter 0 no control register");
+				TEST_ASSERT(reg0->register_addr_lo == 13120,
+					    "TCP counter 0 lo register (0x3340)");
+				TEST_ASSERT(reg0->register_addr_hi == 13121,
+					    "TCP counter 0 hi register (0x3341)");
 
-                /* Counter 1 registers */
-                TEST_ASSERT(reg1->select_addr == 15170, "TCP counter 1 select register (0x3b42)");
-                TEST_ASSERT(reg1->control_addr == 0, "TCP counter 1 no control register");
-                TEST_ASSERT(reg1->register_addr_lo == 13122, "TCP counter 1 lo register (0x3342)");
-                TEST_ASSERT(reg1->register_addr_hi == 13123, "TCP counter 1 hi register (0x3343)");
+				/* Counter 1 registers */
+				TEST_ASSERT(reg1->select_addr == 15170,
+					    "TCP counter 1 select register (0x3b42)");
+				TEST_ASSERT(reg1->control_addr == 0,
+					    "TCP counter 1 no control register");
+				TEST_ASSERT(reg1->register_addr_lo == 13122,
+					    "TCP counter 1 lo register (0x3342)");
+				TEST_ASSERT(reg1->register_addr_hi == 13123,
+					    "TCP counter 1 hi register (0x3343)");
 
-                /* Counter 2 registers */
-                TEST_ASSERT(reg2->select_addr == 15172, "TCP counter 2 select register (0x3b44)");
-                TEST_ASSERT(reg2->control_addr == 0, "TCP counter 2 no control register");
-                TEST_ASSERT(reg2->register_addr_lo == 13124, "TCP counter 2 lo register (0x3344)");
-                TEST_ASSERT(reg2->register_addr_hi == 13125, "TCP counter 2 hi register (0x3345)");
+				/* Counter 2 registers */
+				TEST_ASSERT(reg2->select_addr == 15172,
+					    "TCP counter 2 select register (0x3b44)");
+				TEST_ASSERT(reg2->control_addr == 0,
+					    "TCP counter 2 no control register");
+				TEST_ASSERT(reg2->register_addr_lo == 13124,
+					    "TCP counter 2 lo register (0x3344)");
+				TEST_ASSERT(reg2->register_addr_hi == 13125,
+					    "TCP counter 2 hi register (0x3345)");
 
-                /* Counter 3 registers */
-                TEST_ASSERT(reg3->select_addr == 15174, "TCP counter 3 select register (0x3b46)");
-                TEST_ASSERT(reg3->control_addr == 0, "TCP counter 3 no control register");
-                TEST_ASSERT(reg3->register_addr_lo == 13126, "TCP counter 3 lo register (0x3346)");
-                TEST_ASSERT(reg3->register_addr_hi == 13127, "TCP counter 3 hi register (0x3347)");
+				/* Counter 3 registers */
+				TEST_ASSERT(reg3->select_addr == 15174,
+					    "TCP counter 3 select register (0x3b46)");
+				TEST_ASSERT(reg3->control_addr == 0,
+					    "TCP counter 3 no control register");
+				TEST_ASSERT(reg3->register_addr_lo == 13126,
+					    "TCP counter 3 lo register (0x3346)");
+				TEST_ASSERT(reg3->register_addr_hi == 13127,
+					    "TCP counter 3 hi register (0x3347)");
 
-                /* Test counter allocation simulation */
-                reg0->allocation.state = COUNTER_STATE_ALLOCATED;
-                reg0->allocation.event_id = 0x30; /* Valid TCP event */
-                reg0->allocation.instance_id = 1; /* Second instance */
-                reg0->allocation.user_id = 7890;
-                reg0->allocation.allocation_time = 3000;
+				/* Test counter allocation simulation */
+				reg0->allocation.state = COUNTER_STATE_ALLOCATED;
+				reg0->allocation.event_id = 0x30; /* Valid TCP event */
+				reg0->allocation.instance_id = 1; /* Second instance */
+				reg0->allocation.user_id = 7890;
+				reg0->allocation.allocation_time = 3000;
 
-                TEST_ASSERT(reg0->allocation.state == COUNTER_STATE_ALLOCATED, "TCP counter allocated state");
-                TEST_ASSERT(reg0->allocation.event_id == 0x30, "TCP counter event ID set");
-                TEST_ASSERT(reg0->allocation.instance_id == 1, "TCP counter instance ID set");
-                TEST_ASSERT(reg0->allocation.user_id == 7890, "TCP counter user ID set");
-                TEST_ASSERT(reg0->allocation.allocation_time == 3000, "TCP counter allocation time set");
+				TEST_ASSERT(reg0->allocation.state == COUNTER_STATE_ALLOCATED,
+					    "TCP counter allocated state");
+				TEST_ASSERT(reg0->allocation.event_id == 0x30,
+					    "TCP counter event ID set");
+				TEST_ASSERT(reg0->allocation.instance_id == 1,
+					    "TCP counter instance ID set");
+				TEST_ASSERT(reg0->allocation.user_id == 7890,
+					    "TCP counter user ID set");
+				TEST_ASSERT(reg0->allocation.allocation_time == 3000,
+					    "TCP counter allocation time set");
 
-                /* Simulate counter release */
-                reg0->allocation.state = COUNTER_STATE_FREE;
-                reg0->allocation.event_id = 0;
-                reg0->allocation.instance_id = 0;
-                reg0->allocation.user_id = 0;
-                reg0->allocation.allocation_time = 0;
+				/* Simulate counter release */
+				reg0->allocation.state = COUNTER_STATE_FREE;
+				reg0->allocation.event_id = 0;
+				reg0->allocation.instance_id = 0;
+				reg0->allocation.user_id = 0;
+				reg0->allocation.allocation_time = 0;
 
-                TEST_ASSERT(reg0->allocation.state == COUNTER_STATE_FREE, "TCP counter freed state");
-            }
-        }
+				TEST_ASSERT(reg0->allocation.state == COUNTER_STATE_FREE,
+					    "TCP counter freed state");
+			}
+		}
 
-        free_arch(arch);
-    }
+		free_arch(arch);
+	}
 }
 
 /* Test invalid architecture name */
-static void test_invalid_arch(void) {
-    printf("\n=== Testing Invalid Architecture ===\n");
+static void test_invalid_arch(void)
+{
+	printf("\n=== Testing Invalid Architecture ===\n");
 
-    arch_t* arch = arch_create_by_name("invalid_arch");
-    TEST_ASSERT(arch == NULL, "Invalid architecture name returns NULL");
+	arch_t *arch = arch_create_by_name("invalid_arch");
+	TEST_ASSERT(arch == NULL, "Invalid architecture name returns NULL");
 
-    arch = arch_create_by_name(NULL);
-    TEST_ASSERT(arch == NULL, "NULL architecture name returns NULL");
+	arch = arch_create_by_name(NULL);
+	TEST_ASSERT(arch == NULL, "NULL architecture name returns NULL");
 }
 
 /* Test case sensitivity */
-static void test_case_sensitivity(void) {
-    printf("\n=== Testing Case Sensitivity ===\n");
+static void test_case_sensitivity(void)
+{
+	printf("\n=== Testing Case Sensitivity ===\n");
 
-    arch_t* arch1 = arch_create_by_name("gfx12");
-    arch_t* arch2 = arch_create_by_name("GFX12");
+	arch_t *arch1 = arch_create_by_name("gfx12");
+	arch_t *arch2 = arch_create_by_name("GFX12");
 
-    TEST_ASSERT(arch1 != NULL, "Lowercase gfx12 works");
-    TEST_ASSERT(arch2 != NULL, "Uppercase GFX12 works");
+	TEST_ASSERT(arch1 != NULL, "Lowercase gfx12 works");
+	TEST_ASSERT(arch2 != NULL, "Uppercase GFX12 works");
 
-    if (arch1) {
-        TEST_ASSERT(arch1->type == ARCH_TYPE_GFX12, "Lowercase creates GFX12 type");
-        free_arch(arch1);
-    }
+	if (arch1) {
+		TEST_ASSERT(arch1->type == ARCH_TYPE_GFX12, "Lowercase creates GFX12 type");
+		free_arch(arch1);
+	}
 
-    if (arch2) {
-        TEST_ASSERT(arch2->type == ARCH_TYPE_GFX12, "Uppercase creates GFX12 type");
-        free_arch(arch2);
-    }
+	if (arch2) {
+		TEST_ASSERT(arch2->type == ARCH_TYPE_GFX12, "Uppercase creates GFX12 type");
+		free_arch(arch2);
+	}
 }
 
 /* Main test runner */
-int main(void) {
-    printf("=== GFX12 Architecture Test Suite ===\n");
+int main(void)
+{
+	printf("=== GFX12 Architecture Test Suite ===\n");
 
-    test_gfx12_arch_creation();
-    test_gfx12_cpc_block();
-    test_gfx12_sq_block();
-    test_gfx12_grbm_block();
-    test_gfx12_gl2c_block();
-    test_gfx12_spi_block();
-    test_gfx12_ta_block();
-    test_gfx12_tcp_block();
-    test_gfx12_td_block();
-    test_gfx12_tcc_block();
-    test_gfx12_sx_block();
-    test_gfx12_db_block();
-    test_gfx12_pa_sc_block();
-    test_gfx12_pa_su_block();
-    test_gfx12_gds_block();
-    test_counter_allocation();
-    test_invalid_arch();
-    test_case_sensitivity();
+	test_gfx12_arch_creation();
+	test_gfx12_cpc_block();
+	test_gfx12_sq_block();
+	test_gfx12_grbm_block();
+	test_gfx12_gl2c_block();
+	test_gfx12_spi_block();
+	test_gfx12_ta_block();
+	test_gfx12_tcp_block();
+	test_gfx12_td_block();
+	test_gfx12_tcc_block();
+	test_gfx12_sx_block();
+	test_gfx12_db_block();
+	test_gfx12_pa_sc_block();
+	test_gfx12_pa_su_block();
+	test_gfx12_gds_block();
+	test_counter_allocation();
+	test_invalid_arch();
+	test_case_sensitivity();
 
-    printf("\n=== Test Results ===\n");
-    printf("Tests run: %d\n", tests_run);
-    printf("Tests passed: %d\n", tests_passed);
-    printf("Tests failed: %d\n", tests_run - tests_passed);
+	printf("\n=== Test Results ===\n");
+	printf("Tests run: %d\n", tests_run);
+	printf("Tests passed: %d\n", tests_passed);
+	printf("Tests failed: %d\n", tests_run - tests_passed);
 
-    if (tests_passed == tests_run) {
-        printf("All tests PASSED!\n");
-        return 0;
-    } else {
-        printf("Some tests FAILED!\n");
-        return 1;
-    }
+	if (tests_passed == tests_run) {
+		printf("All tests PASSED!\n");
+		return 0;
+	} else {
+		printf("Some tests FAILED!\n");
+		return 1;
+	}
 }

--- a/projects/perf-dkms/src/aql_c/tests/test_packet_generation.c
+++ b/projects/perf-dkms/src/aql_c/tests/test_packet_generation.c
@@ -13,393 +13,401 @@
 #include "pm4_packets.h"
 
 /* Test framework macros */
-#define TEST_ASSERT(condition, message) \
-    do { \
-        if (!(condition)) { \
-            fprintf(stderr, "ASSERTION FAILED: %s at %s:%d\n", message, __FILE__, __LINE__); \
-            return -1; \
-        } \
-        printf("✓ %s\n", message); \
-    } while (0)
+#define TEST_ASSERT(condition, message)                                                       \
+	do {                                                                                  \
+		if (!(condition)) {                                                           \
+			fprintf(stderr, "ASSERTION FAILED: %s at %s:%d\n", message, __FILE__, \
+				__LINE__);                                                    \
+			return -1;                                                            \
+		}                                                                             \
+		printf("✓ %s\n", message);                                                    \
+	} while (0)
 
-#define TEST_RUN(test_func) \
-    do { \
-        printf("\n=== Running %s ===\n", #test_func); \
-        if (test_func() != 0) { \
-            printf("❌ %s FAILED\n", #test_func); \
-            return -1; \
-        } \
-        printf("✅ %s PASSED\n", #test_func); \
-    } while (0)
+#define TEST_RUN(test_func)                                   \
+	do {                                                  \
+		printf("\n=== Running %s ===\n", #test_func); \
+		if (test_func() != 0) {                       \
+			printf("❌ %s FAILED\n", #test_func); \
+			return -1;                            \
+		}                                             \
+		printf("✅ %s PASSED\n", #test_func);         \
+	} while (0)
 
 /* Use real GFX12 architecture */
 #include "arch_creator.h"
 
-static arch_t* create_test_arch(void) {
-    arch_t* arch = arch_create_by_name("gfx12");
-    if (!arch) {
-        printf("ERROR: Failed to create GFX12 architecture\n");
-        return NULL;
-    }
-    return arch;
+static arch_t *create_test_arch(void)
+{
+	arch_t *arch = arch_create_by_name("gfx12");
+	if (!arch) {
+		printf("ERROR: Failed to create GFX12 architecture\n");
+		return NULL;
+	}
+	return arch;
 }
 
-static void destroy_test_arch(arch_t* arch) {
-    if (arch) {
-        arch_destroy(arch);
-    }
+static void destroy_test_arch(arch_t *arch)
+{
+	if (arch) {
+		arch_destroy(arch);
+	}
 }
 
-static pm4_buffer_t* create_test_buffer(void) {
-    pm4_buffer_t* buffer = malloc(sizeof(pm4_buffer_t));
-    if (!buffer) return NULL;
+static pm4_buffer_t *create_test_buffer(void)
+{
+	pm4_buffer_t *buffer = malloc(sizeof(pm4_buffer_t));
+	if (!buffer)
+		return NULL;
 
-    buffer->data = malloc(1024); /* 1024 DWORDs buffer */
-    if (!buffer->data) {
-        free(buffer);
-        return NULL;
-    }
+	buffer->data = malloc(1024); /* 1024 DWORDs buffer */
+	if (!buffer->data) {
+		free(buffer);
+		return NULL;
+	}
 
-    buffer->capacity = 1024;  /* capacity in DWORDs */
-    buffer->size = 0;         /* current size in DWORDs */
-    memset(buffer->data, 0, buffer->capacity * sizeof(uint32_t));
+	buffer->capacity = 1024; /* capacity in DWORDs */
+	buffer->size = 0; /* current size in DWORDs */
+	memset(buffer->data, 0, buffer->capacity * sizeof(uint32_t));
 
-    return buffer;
+	return buffer;
 }
 
-static void destroy_test_buffer(pm4_buffer_t* buffer) {
-    if (!buffer) return;
-    free(buffer->data);
-    free(buffer);
+static void destroy_test_buffer(pm4_buffer_t *buffer)
+{
+	if (!buffer)
+		return;
+	free(buffer->data);
+	free(buffer);
 }
 
 /* Test generate_cs_partial_flush */
-static int test_generate_cs_partial_flush(void) {
-    arch_t* arch = create_test_arch();
-    pm4_buffer_t* buffer = create_test_buffer();
+static int test_generate_cs_partial_flush(void)
+{
+	arch_t *arch = create_test_arch();
+	pm4_buffer_t *buffer = create_test_buffer();
 
-    TEST_ASSERT(arch != NULL, "Test arch creation");
-    TEST_ASSERT(buffer != NULL, "Test buffer creation");
+	TEST_ASSERT(arch != NULL, "Test arch creation");
+	TEST_ASSERT(buffer != NULL, "Test buffer creation");
 
-    /* Test normal operation */
-    int ret = generate_cs_partial_flush(buffer, arch);
-    TEST_ASSERT(ret == 0, "CS partial flush generation succeeds");
-    TEST_ASSERT(buffer->size > 0, "Buffer has data after CS partial flush");
+	/* Test normal operation */
+	int ret = generate_cs_partial_flush(buffer, arch);
+	TEST_ASSERT(ret == 0, "CS partial flush generation succeeds");
+	TEST_ASSERT(buffer->size > 0, "Buffer has data after CS partial flush");
 
-    /* Test null parameters */
-    ret = generate_cs_partial_flush(NULL, arch);
-    TEST_ASSERT(ret == -EINVAL, "CS partial flush fails with null buffer");
+	/* Test null parameters */
+	ret = generate_cs_partial_flush(NULL, arch);
+	TEST_ASSERT(ret == -EINVAL, "CS partial flush fails with null buffer");
 
-    ret = generate_cs_partial_flush(buffer, NULL);
-    TEST_ASSERT(ret == -EINVAL, "CS partial flush fails with null arch");
+	ret = generate_cs_partial_flush(buffer, NULL);
+	TEST_ASSERT(ret == -EINVAL, "CS partial flush fails with null arch");
 
-    destroy_test_buffer(buffer);
-    destroy_test_arch(arch);
-    return 0;
+	destroy_test_buffer(buffer);
+	destroy_test_arch(arch);
+	return 0;
 }
 
 /* Test generate_grbm_broadcast */
-static int test_generate_grbm_broadcast(void) {
-    arch_t* arch = create_test_arch();
-    pm4_buffer_t* buffer = create_test_buffer();
+static int test_generate_grbm_broadcast(void)
+{
+	arch_t *arch = create_test_arch();
+	pm4_buffer_t *buffer = create_test_buffer();
 
-    TEST_ASSERT(arch != NULL, "Test arch creation");
-    TEST_ASSERT(buffer != NULL, "Test buffer creation");
+	TEST_ASSERT(arch != NULL, "Test arch creation");
+	TEST_ASSERT(buffer != NULL, "Test buffer creation");
 
-    /* Test normal operation */
-    int ret = generate_grbm_broadcast(buffer, arch);
-    TEST_ASSERT(ret == 0, "GRBM broadcast generation succeeds");
-    TEST_ASSERT(buffer->size > 0, "Buffer has data after GRBM broadcast");
+	/* Test normal operation */
+	int ret = generate_grbm_broadcast(buffer, arch);
+	TEST_ASSERT(ret == 0, "GRBM broadcast generation succeeds");
+	TEST_ASSERT(buffer->size > 0, "Buffer has data after GRBM broadcast");
 
-    /* Test null parameters */
-    ret = generate_grbm_broadcast(NULL, arch);
-    TEST_ASSERT(ret == -EINVAL, "GRBM broadcast fails with null buffer");
+	/* Test null parameters */
+	ret = generate_grbm_broadcast(NULL, arch);
+	TEST_ASSERT(ret == -EINVAL, "GRBM broadcast fails with null buffer");
 
-    ret = generate_grbm_broadcast(buffer, NULL);
-    TEST_ASSERT(ret == -EINVAL, "GRBM broadcast fails with null arch");
+	ret = generate_grbm_broadcast(buffer, NULL);
+	TEST_ASSERT(ret == -EINVAL, "GRBM broadcast fails with null arch");
 
-    destroy_test_buffer(buffer);
-    destroy_test_arch(arch);
-    return 0;
+	destroy_test_buffer(buffer);
+	destroy_test_arch(arch);
+	return 0;
 }
 
 /* Test generate_perfmon_enable */
-static int test_generate_perfmon_enable(void) {
-    arch_t* arch = create_test_arch();
-    pm4_buffer_t* buffer = create_test_buffer();
+static int test_generate_perfmon_enable(void)
+{
+	arch_t *arch = create_test_arch();
+	pm4_buffer_t *buffer = create_test_buffer();
 
-    TEST_ASSERT(arch != NULL, "Test arch creation");
-    TEST_ASSERT(buffer != NULL, "Test buffer creation");
+	TEST_ASSERT(arch != NULL, "Test arch creation");
+	TEST_ASSERT(buffer != NULL, "Test buffer creation");
 
-    /* Test normal operation - disable */
-    int ret = generate_perfmon_enable(buffer, arch, 0, false);
-    TEST_ASSERT(ret == 0, "Perfmon enable (disable) generation succeeds");
-    TEST_ASSERT(buffer->size > 0, "Buffer has data after perfmon disable");
+	/* Test normal operation - disable */
+	int ret = generate_perfmon_enable(buffer, arch, 0, false);
+	TEST_ASSERT(ret == 0, "Perfmon enable (disable) generation succeeds");
+	TEST_ASSERT(buffer->size > 0, "Buffer has data after perfmon disable");
 
-    /* Reset buffer */
-    buffer->size = 0;
+	/* Reset buffer */
+	buffer->size = 0;
 
-    /* Test normal operation - enable with sampling */
-    ret = generate_perfmon_enable(buffer, arch, 1, true);
-    TEST_ASSERT(ret == 0, "Perfmon enable (with sampling) generation succeeds");
-    TEST_ASSERT(buffer->size > 0, "Buffer has data after perfmon enable");
+	/* Test normal operation - enable with sampling */
+	ret = generate_perfmon_enable(buffer, arch, 1, true);
+	TEST_ASSERT(ret == 0, "Perfmon enable (with sampling) generation succeeds");
+	TEST_ASSERT(buffer->size > 0, "Buffer has data after perfmon enable");
 
-    /* Test null parameters */
-    ret = generate_perfmon_enable(NULL, arch, 0, false);
-    TEST_ASSERT(ret == -EINVAL, "Perfmon enable fails with null buffer");
+	/* Test null parameters */
+	ret = generate_perfmon_enable(NULL, arch, 0, false);
+	TEST_ASSERT(ret == -EINVAL, "Perfmon enable fails with null buffer");
 
-    ret = generate_perfmon_enable(buffer, NULL, 0, false);
-    TEST_ASSERT(ret == -EINVAL, "Perfmon enable fails with null arch");
+	ret = generate_perfmon_enable(buffer, NULL, 0, false);
+	TEST_ASSERT(ret == -EINVAL, "Perfmon enable fails with null arch");
 
-    destroy_test_buffer(buffer);
-    destroy_test_arch(arch);
-    return 0;
+	destroy_test_buffer(buffer);
+	destroy_test_arch(arch);
+	return 0;
 }
 
 /* Test generate_counter_config */
-static int test_generate_counter_config(void) {
-    arch_t* arch = create_test_arch();
-    pm4_buffer_t* buffer = create_test_buffer();
+static int test_generate_counter_config(void)
+{
+	arch_t *arch = create_test_arch();
+	pm4_buffer_t *buffer = create_test_buffer();
 
-    TEST_ASSERT(arch != NULL, "Test arch creation");
-    TEST_ASSERT(buffer != NULL, "Test buffer creation");
+	TEST_ASSERT(arch != NULL, "Test arch creation");
+	TEST_ASSERT(buffer != NULL, "Test buffer creation");
 
-    /* Create test counter info */
-    counter_info_t counter = {
-        .block_id = HW_IP_BLOCK_SQ,
-        .counter_index = 0,
-        .event_id = 0x42
-    };
+	/* Create test counter info */
+	counter_info_t counter = { .block_id = HW_IP_BLOCK_SQ,
+				   .counter_index = 0,
+				   .event_id = 0x42 };
 
-    /* Debug: Check if block is properly set up */
-    printf("DEBUG: counter.block_id = %d, arch->block_map.blocks[%d] = %p\n",
-           counter.block_id, counter.block_id, arch->block_map.blocks[counter.block_id]);
+	/* Debug: Check if block is properly set up */
+	printf("DEBUG: counter.block_id = %d, arch->block_map.blocks[%d] = %p\n", counter.block_id,
+	       counter.block_id, arch->block_map.blocks[counter.block_id]);
 
-    if (arch->block_map.blocks[counter.block_id]) {
-        printf("DEBUG: block found, counter_count = %d\n",
-               arch->block_map.blocks[counter.block_id]->counter_count);
-    }
+	if (arch->block_map.blocks[counter.block_id]) {
+		printf("DEBUG: block found, counter_count = %d\n",
+		       arch->block_map.blocks[counter.block_id]->counter_count);
+	}
 
-    /* Test normal operation */
-    int ret = generate_counter_config(buffer, arch, &counter);
-    TEST_ASSERT(ret == 0, "Counter config generation succeeds");
-    TEST_ASSERT(buffer->size > 0, "Buffer has data after counter config");
+	/* Test normal operation */
+	int ret = generate_counter_config(buffer, arch, &counter);
+	TEST_ASSERT(ret == 0, "Counter config generation succeeds");
+	TEST_ASSERT(buffer->size > 0, "Buffer has data after counter config");
 
-    /* Test invalid block ID */
-    counter.block_id = HW_IP_BLOCK_LAST;
-    ret = generate_counter_config(buffer, arch, &counter);
-    TEST_ASSERT(ret == -ENOENT, "Counter config fails with invalid block ID");
+	/* Test invalid block ID */
+	counter.block_id = HW_IP_BLOCK_LAST;
+	ret = generate_counter_config(buffer, arch, &counter);
+	TEST_ASSERT(ret == -ENOENT, "Counter config fails with invalid block ID");
 
-    /* Test invalid counter index */
-    counter.block_id = HW_IP_BLOCK_SQ;
-    counter.counter_index = 10; /* Out of range */
-    ret = generate_counter_config(buffer, arch, &counter);
-    TEST_ASSERT(ret == -EINVAL, "Counter config fails with invalid counter index");
+	/* Test invalid counter index */
+	counter.block_id = HW_IP_BLOCK_SQ;
+	counter.counter_index = 10; /* Out of range */
+	ret = generate_counter_config(buffer, arch, &counter);
+	TEST_ASSERT(ret == -EINVAL, "Counter config fails with invalid counter index");
 
-    /* Test null parameters */
-    counter.counter_index = 0;
-    ret = generate_counter_config(NULL, arch, &counter);
-    TEST_ASSERT(ret == -EINVAL, "Counter config fails with null buffer");
+	/* Test null parameters */
+	counter.counter_index = 0;
+	ret = generate_counter_config(NULL, arch, &counter);
+	TEST_ASSERT(ret == -EINVAL, "Counter config fails with null buffer");
 
-    ret = generate_counter_config(buffer, NULL, &counter);
-    TEST_ASSERT(ret == -EINVAL, "Counter config fails with null arch");
+	ret = generate_counter_config(buffer, NULL, &counter);
+	TEST_ASSERT(ret == -EINVAL, "Counter config fails with null arch");
 
-    ret = generate_counter_config(buffer, arch, NULL);
-    TEST_ASSERT(ret == -EINVAL, "Counter config fails with null counter");
+	ret = generate_counter_config(buffer, arch, NULL);
+	TEST_ASSERT(ret == -EINVAL, "Counter config fails with null counter");
 
-    destroy_test_buffer(buffer);
-    destroy_test_arch(arch);
-    return 0;
+	destroy_test_buffer(buffer);
+	destroy_test_arch(arch);
+	return 0;
 }
 
 /* Test generate_start_packet */
-static int test_generate_start_packet(void) {
-    arch_t* arch = create_test_arch();
-    pm4_buffer_t* buffer = create_test_buffer();
+static int test_generate_start_packet(void)
+{
+	arch_t *arch = create_test_arch();
+	pm4_buffer_t *buffer = create_test_buffer();
 
-    TEST_ASSERT(arch != NULL, "Test arch creation");
-    TEST_ASSERT(buffer != NULL, "Test buffer creation");
+	TEST_ASSERT(arch != NULL, "Test arch creation");
+	TEST_ASSERT(buffer != NULL, "Test buffer creation");
 
-    /* Create test counter collection */
-    counter_info_t counters[2] = {
-        {.block_id = HW_IP_BLOCK_SQ, .counter_index = 0, .event_id = 0x42},
-        {.block_id = HW_IP_BLOCK_SQ, .counter_index = 1, .event_id = 0x43}
-    };
+	/* Create test counter collection */
+	counter_info_t counters[2] = {
+		{ .block_id = HW_IP_BLOCK_SQ, .counter_index = 0, .event_id = 0x42 },
+		{ .block_id = HW_IP_BLOCK_SQ, .counter_index = 1, .event_id = 0x43 }
+	};
 
-    counter_collection_t collection = {
-        .counters = counters,
-        .counter_count = 2,
-        .gpu_memory_addr = 0x1000000,
-        .memory_size = 1024
-    };
+	counter_collection_t collection = { .counters = counters,
+					    .counter_count = 2,
+					    .gpu_memory_addr = 0x1000000,
+					    .memory_size = 1024 };
 
-    /* Test normal operation */
-    int ret = generate_start_packet(buffer, arch, &collection);
-    TEST_ASSERT(ret == 0, "Start packet generation succeeds");
-    TEST_ASSERT(buffer->size > 0, "Buffer has data after start packet generation");
+	/* Test normal operation */
+	int ret = generate_start_packet(buffer, arch, &collection);
+	TEST_ASSERT(ret == 0, "Start packet generation succeeds");
+	TEST_ASSERT(buffer->size > 0, "Buffer has data after start packet generation");
 
-    /* Verify SQ_PERFCOUNTER_CTRL2 register was written (should contain force_en | vmid_en) */
-    /* This is a complex verification, so we'll just check that the buffer has reasonable content */
-    TEST_ASSERT(buffer->size > 10, "Start packet generates substantial PM4 content");
+	/* Verify SQ_PERFCOUNTER_CTRL2 register was written (should contain force_en | vmid_en) */
+	/* This is a complex verification, so we'll just check that the buffer has reasonable content */
+	TEST_ASSERT(buffer->size > 10, "Start packet generates substantial PM4 content");
 
-    /* Test null parameters */
-    ret = generate_start_packet(NULL, arch, &collection);
-    TEST_ASSERT(ret == -EINVAL, "Start packet fails with null buffer");
+	/* Test null parameters */
+	ret = generate_start_packet(NULL, arch, &collection);
+	TEST_ASSERT(ret == -EINVAL, "Start packet fails with null buffer");
 
-    ret = generate_start_packet(buffer, NULL, &collection);
-    TEST_ASSERT(ret == -EINVAL, "Start packet fails with null arch");
+	ret = generate_start_packet(buffer, NULL, &collection);
+	TEST_ASSERT(ret == -EINVAL, "Start packet fails with null arch");
 
-    ret = generate_start_packet(buffer, arch, NULL);
-    TEST_ASSERT(ret == -EINVAL, "Start packet fails with null collection");
+	ret = generate_start_packet(buffer, arch, NULL);
+	TEST_ASSERT(ret == -EINVAL, "Start packet fails with null collection");
 
-    /* Test empty collection */
-    collection.counter_count = 0;
-    ret = generate_start_packet(buffer, arch, &collection);
-    TEST_ASSERT(ret == 0, "Start packet succeeds with empty collection");
+	/* Test empty collection */
+	collection.counter_count = 0;
+	ret = generate_start_packet(buffer, arch, &collection);
+	TEST_ASSERT(ret == 0, "Start packet succeeds with empty collection");
 
-    destroy_test_buffer(buffer);
-    destroy_test_arch(arch);
-    return 0;
+	destroy_test_buffer(buffer);
+	destroy_test_arch(arch);
+	return 0;
 }
 
 /* Test generate_stop_packet */
-static int test_generate_stop_packet(void) {
-    arch_t* arch = create_test_arch();
-    pm4_buffer_t* buffer = create_test_buffer();
+static int test_generate_stop_packet(void)
+{
+	arch_t *arch = create_test_arch();
+	pm4_buffer_t *buffer = create_test_buffer();
 
-    TEST_ASSERT(arch != NULL, "Test arch creation");
-    TEST_ASSERT(buffer != NULL, "Test buffer creation");
+	TEST_ASSERT(arch != NULL, "Test arch creation");
+	TEST_ASSERT(buffer != NULL, "Test buffer creation");
 
-    /* Test normal operation */
-    int ret = generate_stop_packet(buffer, arch);
-    TEST_ASSERT(ret == 0, "Stop packet generation succeeds");
-    TEST_ASSERT(buffer->size > 0, "Buffer has data after stop packet generation");
+	/* Test normal operation */
+	int ret = generate_stop_packet(buffer, arch);
+	TEST_ASSERT(ret == 0, "Stop packet generation succeeds");
+	TEST_ASSERT(buffer->size > 0, "Buffer has data after stop packet generation");
 
-    /* Test null parameters */
-    ret = generate_stop_packet(NULL, arch);
-    TEST_ASSERT(ret == -EINVAL, "Stop packet fails with null buffer");
+	/* Test null parameters */
+	ret = generate_stop_packet(NULL, arch);
+	TEST_ASSERT(ret == -EINVAL, "Stop packet fails with null buffer");
 
-    ret = generate_stop_packet(buffer, NULL);
-    TEST_ASSERT(ret == -EINVAL, "Stop packet fails with null arch");
+	ret = generate_stop_packet(buffer, NULL);
+	TEST_ASSERT(ret == -EINVAL, "Stop packet fails with null arch");
 
-    destroy_test_buffer(buffer);
-    destroy_test_arch(arch);
-    return 0;
+	destroy_test_buffer(buffer);
+	destroy_test_arch(arch);
+	return 0;
 }
 
 /* Test calculate_counter_memory_size */
-static int test_calculate_counter_memory_size(void) {
-    arch_t* arch = create_test_arch();
+static int test_calculate_counter_memory_size(void)
+{
+	arch_t *arch = create_test_arch();
 
-    TEST_ASSERT(arch != NULL, "Test arch creation");
+	TEST_ASSERT(arch != NULL, "Test arch creation");
 
-    /* Create test counter collection */
-    counter_info_t counters[2] = {
-        {.block_id = HW_IP_BLOCK_SQ, .counter_index = 0, .event_id = 0x42},
-        {.block_id = HW_IP_BLOCK_SQ, .counter_index = 1, .event_id = 0x43}
-    };
+	/* Create test counter collection */
+	counter_info_t counters[2] = {
+		{ .block_id = HW_IP_BLOCK_SQ, .counter_index = 0, .event_id = 0x42 },
+		{ .block_id = HW_IP_BLOCK_SQ, .counter_index = 1, .event_id = 0x43 }
+	};
 
-    counter_collection_t collection = {
-        .counters = counters,
-        .counter_count = 2,
-        .gpu_memory_addr = 0x1000000,
-        .memory_size = 1024
-    };
+	counter_collection_t collection = { .counters = counters,
+					    .counter_count = 2,
+					    .gpu_memory_addr = 0x1000000,
+					    .memory_size = 1024 };
 
-    /* Test normal operation */
-    size_t size = calculate_counter_memory_size(arch, &collection);
-    TEST_ASSERT(size > 0, "Counter memory size calculation returns positive value");
-    TEST_ASSERT(size >= 16, "Counter memory size is at least 2 counters × 8 bytes");
+	/* Test normal operation */
+	size_t size = calculate_counter_memory_size(arch, &collection);
+	TEST_ASSERT(size > 0, "Counter memory size calculation returns positive value");
+	TEST_ASSERT(size >= 16, "Counter memory size is at least 2 counters × 8 bytes");
 
-    /* Test null parameters */
-    size = calculate_counter_memory_size(NULL, &collection);
-    TEST_ASSERT(size == 0, "Counter memory size returns 0 with null arch");
+	/* Test null parameters */
+	size = calculate_counter_memory_size(NULL, &collection);
+	TEST_ASSERT(size == 0, "Counter memory size returns 0 with null arch");
 
-    size = calculate_counter_memory_size(arch, NULL);
-    TEST_ASSERT(size == 0, "Counter memory size returns 0 with null collection");
+	size = calculate_counter_memory_size(arch, NULL);
+	TEST_ASSERT(size == 0, "Counter memory size returns 0 with null collection");
 
-    /* Test empty collection */
-    collection.counter_count = 0;
-    size = calculate_counter_memory_size(arch, &collection);
-    TEST_ASSERT(size == 0, "Counter memory size returns 0 with empty collection");
+	/* Test empty collection */
+	collection.counter_count = 0;
+	size = calculate_counter_memory_size(arch, &collection);
+	TEST_ASSERT(size == 0, "Counter memory size returns 0 with empty collection");
 
-    destroy_test_arch(arch);
-    return 0;
+	destroy_test_arch(arch);
+	return 0;
 }
 
 /* Test validate_counter_collection */
-static int test_validate_counter_collection(void) {
-    arch_t* arch = create_test_arch();
+static int test_validate_counter_collection(void)
+{
+	arch_t *arch = create_test_arch();
 
-    TEST_ASSERT(arch != NULL, "Test arch creation");
+	TEST_ASSERT(arch != NULL, "Test arch creation");
 
-    /* Create test counter collection */
-    counter_info_t counters[2] = {
-        {.block_id = HW_IP_BLOCK_SQ, .counter_index = 0, .event_id = 0x42},
-        {.block_id = HW_IP_BLOCK_SQ, .counter_index = 1, .event_id = 0x43}
-    };
+	/* Create test counter collection */
+	counter_info_t counters[2] = {
+		{ .block_id = HW_IP_BLOCK_SQ, .counter_index = 0, .event_id = 0x42 },
+		{ .block_id = HW_IP_BLOCK_SQ, .counter_index = 1, .event_id = 0x43 }
+	};
 
-    counter_collection_t collection = {
-        .counters = counters,
-        .counter_count = 2,
-        .gpu_memory_addr = 0x1000000,
-        .memory_size = 1024
-    };
+	counter_collection_t collection = { .counters = counters,
+					    .counter_count = 2,
+					    .gpu_memory_addr = 0x1000000,
+					    .memory_size = 1024 };
 
-    /* Test normal operation */
-    int ret = validate_counter_collection(arch, &collection);
-    TEST_ASSERT(ret == 0, "Counter collection validation succeeds");
+	/* Test normal operation */
+	int ret = validate_counter_collection(arch, &collection);
+	TEST_ASSERT(ret == 0, "Counter collection validation succeeds");
 
-    /* Test null parameters */
-    ret = validate_counter_collection(NULL, &collection);
-    TEST_ASSERT(ret == -EINVAL, "Validation fails with null arch");
+	/* Test null parameters */
+	ret = validate_counter_collection(NULL, &collection);
+	TEST_ASSERT(ret == -EINVAL, "Validation fails with null arch");
 
-    ret = validate_counter_collection(arch, NULL);
-    TEST_ASSERT(ret == -EINVAL, "Validation fails with null collection");
+	ret = validate_counter_collection(arch, NULL);
+	TEST_ASSERT(ret == -EINVAL, "Validation fails with null collection");
 
-    /* Test empty collection */
-    collection.counter_count = 0;
-    ret = validate_counter_collection(arch, &collection);
-    TEST_ASSERT(ret == -EINVAL, "Validation fails with empty collection");
+	/* Test empty collection */
+	collection.counter_count = 0;
+	ret = validate_counter_collection(arch, &collection);
+	TEST_ASSERT(ret == -EINVAL, "Validation fails with empty collection");
 
-    /* Test invalid block ID */
-    collection.counter_count = 1;
-    counters[0].block_id = HW_IP_BLOCK_LAST;
-    ret = validate_counter_collection(arch, &collection);
-    TEST_ASSERT(ret == -EINVAL, "Validation fails with invalid block ID");
+	/* Test invalid block ID */
+	collection.counter_count = 1;
+	counters[0].block_id = HW_IP_BLOCK_LAST;
+	ret = validate_counter_collection(arch, &collection);
+	TEST_ASSERT(ret == -EINVAL, "Validation fails with invalid block ID");
 
-    /* Test invalid counter index */
-    counters[0].block_id = HW_IP_BLOCK_SQ;
-    counters[0].counter_index = 10; /* Out of range */
-    ret = validate_counter_collection(arch, &collection);
-    TEST_ASSERT(ret == -EINVAL, "Validation fails with invalid counter index");
+	/* Test invalid counter index */
+	counters[0].block_id = HW_IP_BLOCK_SQ;
+	counters[0].counter_index = 10; /* Out of range */
+	ret = validate_counter_collection(arch, &collection);
+	TEST_ASSERT(ret == -EINVAL, "Validation fails with invalid counter index");
 
-    /* Test invalid event ID */
-    counters[0].counter_index = 0;
-    counters[0].event_id = 0x1000; /* Too large */
-    ret = validate_counter_collection(arch, &collection);
-    TEST_ASSERT(ret == -EINVAL, "Validation fails with invalid event ID");
+	/* Test invalid event ID */
+	counters[0].counter_index = 0;
+	counters[0].event_id = 0x1000; /* Too large */
+	ret = validate_counter_collection(arch, &collection);
+	TEST_ASSERT(ret == -EINVAL, "Validation fails with invalid event ID");
 
-    destroy_test_arch(arch);
-    return 0;
+	destroy_test_arch(arch);
+	return 0;
 }
 
 /* Main test runner */
-int main(void) {
-    printf("🧪 Starting Packet Generation Tests\n");
-    printf("===================================\n");
+int main(void)
+{
+	printf("🧪 Starting Packet Generation Tests\n");
+	printf("===================================\n");
 
-    TEST_RUN(test_generate_cs_partial_flush);
-    TEST_RUN(test_generate_grbm_broadcast);
-    TEST_RUN(test_generate_perfmon_enable);
-    TEST_RUN(test_generate_counter_config);
-    TEST_RUN(test_generate_start_packet);
-    TEST_RUN(test_generate_stop_packet);
-    TEST_RUN(test_calculate_counter_memory_size);
-    TEST_RUN(test_validate_counter_collection);
+	TEST_RUN(test_generate_cs_partial_flush);
+	TEST_RUN(test_generate_grbm_broadcast);
+	TEST_RUN(test_generate_perfmon_enable);
+	TEST_RUN(test_generate_counter_config);
+	TEST_RUN(test_generate_start_packet);
+	TEST_RUN(test_generate_stop_packet);
+	TEST_RUN(test_calculate_counter_memory_size);
+	TEST_RUN(test_validate_counter_collection);
 
-    printf("\n✅ All Packet Generation Tests PASSED!\n");
-    printf("======================================\n");
+	printf("\n✅ All Packet Generation Tests PASSED!\n");
+	printf("======================================\n");
 
-    return 0;
+	return 0;
 }

--- a/projects/perf-dkms/src/aql_c/tests/test_pm4_packets.c
+++ b/projects/perf-dkms/src/aql_c/tests/test_pm4_packets.c
@@ -15,377 +15,374 @@
 #include "../aql_structures.h"
 
 /* Test register addresses - from GFX12 specification */
-#define TEST_GRBM_GFX_INDEX_REG     (UCONFIG_SPACE_START + 0x30800)
-#define TEST_CP_PERFMON_CNTL_REG    (UCONFIG_SPACE_START + 0x36020)
+#define TEST_GRBM_GFX_INDEX_REG (UCONFIG_SPACE_START + 0x30800)
+#define TEST_CP_PERFMON_CNTL_REG (UCONFIG_SPACE_START + 0x36020)
 #define TEST_SQ_PERFCOUNTER_CTRL_REG (UCONFIG_SPACE_START + 0x30800)
 #define TEST_COMPUTE_PERFCOUNT_ENABLE_REG (PERSISTENT_SPACE_START + 0x1C84)
 
 /* Test utilities */
-static void print_buffer_hex(const char* name, const uint32_t* buffer, size_t size_dwords)
+static void print_buffer_hex(const char *name, const uint32_t *buffer, size_t size_dwords)
 {
-    printf("%s (%zu DWORDs):\n", name, size_dwords);
-    for (size_t i = 0; i < size_dwords; i++) {
-        printf("  [%zu]: 0x%08X\n", i, buffer[i]);
-    }
-    printf("\n");
+	printf("%s (%zu DWORDs):\n", name, size_dwords);
+	for (size_t i = 0; i < size_dwords; i++) {
+		printf("  [%zu]: 0x%08X\n", i, buffer[i]);
+	}
+	printf("\n");
 }
 
-static int compare_buffers(const uint32_t* buf1, const uint32_t* buf2, size_t size_dwords)
+static int compare_buffers(const uint32_t *buf1, const uint32_t *buf2, size_t size_dwords)
 {
-    for (size_t i = 0; i < size_dwords; i++) {
-        if (buf1[i] != buf2[i]) {
-            printf("Buffer mismatch at [%zu]: 0x%08X != 0x%08X\n", i, buf1[i], buf2[i]);
-            return -1;
-        }
-    }
-    return 0;
+	for (size_t i = 0; i < size_dwords; i++) {
+		if (buf1[i] != buf2[i]) {
+			printf("Buffer mismatch at [%zu]: 0x%08X != 0x%08X\n", i, buf1[i], buf2[i]);
+			return -1;
+		}
+	}
+	return 0;
 }
 
 /* Test basic buffer operations */
 static int test_buffer_create_destroy(void)
 {
-    printf("Testing PM4 buffer create/destroy...\n");
+	printf("Testing PM4 buffer create/destroy...\n");
 
-    pm4_buffer_t* buffer = pm4_buffer_create(256);
-    assert(buffer != NULL);
-    assert(pm4_buffer_get_size(buffer) == 0);
-    assert(pm4_buffer_get_data(buffer) != NULL);
+	pm4_buffer_t *buffer = pm4_buffer_create(256);
+	assert(buffer != NULL);
+	assert(pm4_buffer_get_size(buffer) == 0);
+	assert(pm4_buffer_get_data(buffer) != NULL);
 
-    pm4_buffer_destroy(buffer);
-    printf("  ✓ Buffer create/destroy passed\n\n");
-    return 0;
+	pm4_buffer_destroy(buffer);
+	printf("  ✓ Buffer create/destroy passed\n\n");
+	return 0;
 }
 
 /* Test SetUConfigReg packet generation */
 static int test_set_uconfig_reg_packet(void)
 {
-    printf("Testing SetUConfigReg packet...\n");
+	printf("Testing SetUConfigReg packet...\n");
 
-    pm4_buffer_t* buffer = pm4_buffer_create(256);
+	pm4_buffer_t *buffer = pm4_buffer_create(256);
 
-    /* Build SetUConfigReg packet */
-    uint32_t reg_offset = TEST_GRBM_GFX_INDEX_REG;
-    uint32_t reg_value = 0x80000100;  /* Test GRBM broadcast value */
+	/* Build SetUConfigReg packet */
+	uint32_t reg_offset = TEST_GRBM_GFX_INDEX_REG;
+	uint32_t reg_value = 0x80000100; /* Test GRBM broadcast value */
 
-    int result = pm4_append_set_uconfig_reg(buffer, reg_offset, reg_value);
-    assert(result == 0);
+	int result = pm4_append_set_uconfig_reg(buffer, reg_offset, reg_value);
+	assert(result == 0);
 
-    /* Verify packet structure */
-    uint32_t* data = pm4_buffer_get_data(buffer);
-    size_t size = pm4_buffer_get_size(buffer);
-    assert(size == 3);
+	/* Verify packet structure */
+	uint32_t *data = pm4_buffer_get_data(buffer);
+	size_t size = pm4_buffer_get_size(buffer);
+	assert(size == 3);
 
-    /* Expected packet structure matching Rust SetUConfigReg */
-    uint32_t expected[3];
-    expected[0] = PM4_TYPE_3_HEADER(PM4_SET_UCONFIG_REG_OPCODE, 12);  /* Header with count=1 */
-    expected[1] = (reg_offset - UCONFIG_SPACE_START) & 0xFFFF;       /* Register offset */
-    expected[2] = reg_value;                                         /* Register value */
+	/* Expected packet structure matching Rust SetUConfigReg */
+	uint32_t expected[3];
+	expected[0] = PM4_TYPE_3_HEADER(PM4_SET_UCONFIG_REG_OPCODE, 12); /* Header with count=1 */
+	expected[1] = (reg_offset - UCONFIG_SPACE_START) & 0xFFFF; /* Register offset */
+	expected[2] = reg_value; /* Register value */
 
-    print_buffer_hex("SetUConfigReg actual", data, size);
-    print_buffer_hex("SetUConfigReg expected", expected, 3);
+	print_buffer_hex("SetUConfigReg actual", data, size);
+	print_buffer_hex("SetUConfigReg expected", expected, 3);
 
-    assert(compare_buffers(data, expected, 3) == 0);
+	assert(compare_buffers(data, expected, 3) == 0);
 
-    pm4_buffer_destroy(buffer);
-    printf("  ✓ SetUConfigReg packet passed\n\n");
-    return 0;
+	pm4_buffer_destroy(buffer);
+	printf("  ✓ SetUConfigReg packet passed\n\n");
+	return 0;
 }
 
 /* Test EventWrite packet generation */
 static int test_event_write_packet(void)
 {
-    printf("Testing EventWrite packet...\n");
+	printf("Testing EventWrite packet...\n");
 
-    pm4_buffer_t* buffer = pm4_buffer_create(256);
+	pm4_buffer_t *buffer = pm4_buffer_create(256);
 
-    /* Build EventWrite packet for CS partial flush */
-    int result = pm4_append_event_write(buffer, VGT_EVENT_TYPE_CS_PARTIAL_FLUSH, 4);
-    assert(result == 0);
+	/* Build EventWrite packet for CS partial flush */
+	int result = pm4_append_event_write(buffer, VGT_EVENT_TYPE_CS_PARTIAL_FLUSH, 4);
+	assert(result == 0);
 
-    /* Verify packet structure */
-    uint32_t* data = pm4_buffer_get_data(buffer);
-    size_t size = pm4_buffer_get_size(buffer);
-    assert(size == 2);
+	/* Verify packet structure */
+	uint32_t *data = pm4_buffer_get_data(buffer);
+	size_t size = pm4_buffer_get_size(buffer);
+	assert(size == 2);
 
-    /* Expected packet structure matching Rust EventWrite */
-    uint32_t expected[2];
-    expected[0] = PM4_TYPE_3_HEADER(PM4_EVENT_WRITE_OPCODE, 8);  /* Header with count=2 */
+	/* Expected packet structure matching Rust EventWrite */
+	uint32_t expected[2];
+	expected[0] = PM4_TYPE_3_HEADER(PM4_EVENT_WRITE_OPCODE, 8); /* Header with count=2 */
 
-    /* Build barrier event matching Rust BarrierEvent */
-    pm4_barrier_event_t event = {0};
-    event.bits.event_type = VGT_EVENT_TYPE_CS_PARTIAL_FLUSH;
-    event.bits.event_index = 4;
-    expected[1] = event.raw & 0xFFFF;  /* Only lower 16 bits used */
+	/* Build barrier event matching Rust BarrierEvent */
+	pm4_barrier_event_t event = { 0 };
+	event.bits.event_type = VGT_EVENT_TYPE_CS_PARTIAL_FLUSH;
+	event.bits.event_index = 4;
+	expected[1] = event.raw & 0xFFFF; /* Only lower 16 bits used */
 
-    print_buffer_hex("EventWrite actual", data, size);
-    print_buffer_hex("EventWrite expected", expected, 2);
+	print_buffer_hex("EventWrite actual", data, size);
+	print_buffer_hex("EventWrite expected", expected, 2);
 
-    assert(compare_buffers(data, expected, 2) == 0);
+	assert(compare_buffers(data, expected, 2) == 0);
 
-    pm4_buffer_destroy(buffer);
-    printf("  ✓ EventWrite packet passed\n\n");
-    return 0;
+	pm4_buffer_destroy(buffer);
+	printf("  ✓ EventWrite packet passed\n\n");
+	return 0;
 }
 
 /* Test CopyData packet generation */
 static int test_copy_data_packet(void)
 {
-    printf("Testing CopyData packet...\n");
+	printf("Testing CopyData packet...\n");
 
-    pm4_buffer_t* buffer = pm4_buffer_create(256);
+	pm4_buffer_t *buffer = pm4_buffer_create(256);
 
-    /* Build CopyData packet for counter read */
-    pm4_copy_data_flags_t flags = {0};
-    flags.bits.src_sel = 0;          /* Non-priv counters */
-    flags.bits.dst_sel = 2;          /* TC_L2 */
-    flags.bits.src_temporal = 3;     /* LU */
-    flags.bits.dst_temporal = 3;     /* LU */
-    flags.bits.count_sel = 0;        /* 32-bit data */
-    flags.bits.wr_confirm = 0;       /* No confirmation */
+	/* Build CopyData packet for counter read */
+	pm4_copy_data_flags_t flags = { 0 };
+	flags.bits.src_sel = 0; /* Non-priv counters */
+	flags.bits.dst_sel = 2; /* TC_L2 */
+	flags.bits.src_temporal = 3; /* LU */
+	flags.bits.dst_temporal = 3; /* LU */
+	flags.bits.count_sel = 0; /* 32-bit data */
+	flags.bits.wr_confirm = 0; /* No confirmation */
 
-    uint32_t src_reg_lo = 0x8000;
-    uint32_t src_reg_hi = 0x0000;
-    uint64_t dst_addr = 0x123456789ABCDEF0ULL;
+	uint32_t src_reg_lo = 0x8000;
+	uint32_t src_reg_hi = 0x0000;
+	uint64_t dst_addr = 0x123456789ABCDEF0ULL;
 
-    int result = pm4_append_copy_data(buffer, flags, src_reg_lo, src_reg_hi, dst_addr);
-    assert(result == 0);
+	int result = pm4_append_copy_data(buffer, flags, src_reg_lo, src_reg_hi, dst_addr);
+	assert(result == 0);
 
-    /* Verify packet structure */
-    uint32_t* data = pm4_buffer_get_data(buffer);
-    size_t size = pm4_buffer_get_size(buffer);
-    assert(size == 6);
+	/* Verify packet structure */
+	uint32_t *data = pm4_buffer_get_data(buffer);
+	size_t size = pm4_buffer_get_size(buffer);
+	assert(size == 6);
 
-    /* Expected packet structure matching Rust CopyDataPacket */
-    uint32_t expected[6];
-    expected[0] = PM4_TYPE_3_HEADER(PM4_COPY_DATA_OPCODE, 24);  /* Header with count=4 */
-    expected[1] = flags.raw;
-    expected[2] = src_reg_lo;
-    expected[3] = src_reg_hi;
-    expected[4] = (uint32_t)(dst_addr & 0xFFFFFFFF);
-    expected[5] = (uint32_t)(dst_addr >> 32);
+	/* Expected packet structure matching Rust CopyDataPacket */
+	uint32_t expected[6];
+	expected[0] = PM4_TYPE_3_HEADER(PM4_COPY_DATA_OPCODE, 24); /* Header with count=4 */
+	expected[1] = flags.raw;
+	expected[2] = src_reg_lo;
+	expected[3] = src_reg_hi;
+	expected[4] = (uint32_t)(dst_addr & 0xFFFFFFFF);
+	expected[5] = (uint32_t)(dst_addr >> 32);
 
-    print_buffer_hex("CopyData actual", data, size);
-    print_buffer_hex("CopyData expected", expected, 6);
+	print_buffer_hex("CopyData actual", data, size);
+	print_buffer_hex("CopyData expected", expected, 6);
 
-    assert(compare_buffers(data, expected, 6) == 0);
+	assert(compare_buffers(data, expected, 6) == 0);
 
-    pm4_buffer_destroy(buffer);
-    printf("  ✓ CopyData packet passed\n\n");
-    return 0;
+	pm4_buffer_destroy(buffer);
+	printf("  ✓ CopyData packet passed\n\n");
+	return 0;
 }
 
 /* Test WriteSHRegister packet generation */
 static int test_write_sh_reg_packet(void)
 {
-    printf("Testing WriteSHRegister packet...\n");
+	printf("Testing WriteSHRegister packet...\n");
 
-    pm4_buffer_t* buffer = pm4_buffer_create(256);
+	pm4_buffer_t *buffer = pm4_buffer_create(256);
 
-    /* Build WriteSHRegister packet */
-    uint32_t reg_offset = TEST_COMPUTE_PERFCOUNT_ENABLE_REG;
-    uint32_t reg_value = 0x00000001;  /* Enable compute performance counting */
-    uint8_t vmid_shift = 0;
-    uint8_t index = 0;
+	/* Build WriteSHRegister packet */
+	uint32_t reg_offset = TEST_COMPUTE_PERFCOUNT_ENABLE_REG;
+	uint32_t reg_value = 0x00000001; /* Enable compute performance counting */
+	uint8_t vmid_shift = 0;
+	uint8_t index = 0;
 
-    int result = pm4_append_write_sh_reg(buffer, reg_offset, reg_value, vmid_shift, index);
-    assert(result == 0);
+	int result = pm4_append_write_sh_reg(buffer, reg_offset, reg_value, vmid_shift, index);
+	assert(result == 0);
 
-    /* Verify packet structure */
-    uint32_t* data = pm4_buffer_get_data(buffer);
-    size_t size = pm4_buffer_get_size(buffer);
-    assert(size == 3);
+	/* Verify packet structure */
+	uint32_t *data = pm4_buffer_get_data(buffer);
+	size_t size = pm4_buffer_get_size(buffer);
+	assert(size == 3);
 
-    /* Expected packet structure matching Rust WriteSHRegister */
-    uint32_t expected[3];
-    expected[0] = PM4_TYPE_3_HEADER(PM4_WRITE_SH_REG_OPCODE, 12);  /* Header with count=1 */
+	/* Expected packet structure matching Rust WriteSHRegister */
+	uint32_t expected[3];
+	expected[0] = PM4_TYPE_3_HEADER(PM4_WRITE_SH_REG_OPCODE, 12); /* Header with count=1 */
 
-    /* Build word1 with bitfield layout */
-    uint16_t offset = (uint16_t)((reg_offset - PERSISTENT_SPACE_START) & 0xFFFF);
-    expected[1] = (offset & 0xFFFF) |           /* bits 0-15: reg_offset */
-                  ((vmid_shift & 0x1F) << 23) |  /* bits 23-27: vmid_shift */
-                  ((index & 0xF) << 28);          /* bits 28-31: index */
-    expected[2] = reg_value;
+	/* Build word1 with bitfield layout */
+	uint16_t offset = (uint16_t)((reg_offset - PERSISTENT_SPACE_START) & 0xFFFF);
+	expected[1] = (offset & 0xFFFF) | /* bits 0-15: reg_offset */
+		      ((vmid_shift & 0x1F) << 23) | /* bits 23-27: vmid_shift */
+		      ((index & 0xF) << 28); /* bits 28-31: index */
+	expected[2] = reg_value;
 
-    print_buffer_hex("WriteSHRegister actual", data, size);
-    print_buffer_hex("WriteSHRegister expected", expected, 3);
+	print_buffer_hex("WriteSHRegister actual", data, size);
+	print_buffer_hex("WriteSHRegister expected", expected, 3);
 
-    assert(compare_buffers(data, expected, 3) == 0);
+	assert(compare_buffers(data, expected, 3) == 0);
 
-    pm4_buffer_destroy(buffer);
-    printf("  ✓ WriteSHRegister packet passed\n\n");
-    return 0;
+	pm4_buffer_destroy(buffer);
+	printf("  ✓ WriteSHRegister packet passed\n\n");
+	return 0;
 }
 
 /* Test AcquireMem (FlushCache) packet generation */
 static int test_acquire_mem_packet(void)
 {
-    printf("Testing AcquireMem packet...\n");
+	printf("Testing AcquireMem packet...\n");
 
-    pm4_buffer_t* buffer = pm4_buffer_create(256);
+	pm4_buffer_t *buffer = pm4_buffer_create(256);
 
-    /* Build AcquireMem packet for cache coherency */
-    uint64_t base_addr = 0x123456000ULL;  /* 256-byte aligned */
-    uint64_t size = 1024;  /* 1KB */
-    uint32_t gcr_cntl = 0x18000;  /* GCR control value */
+	/* Build AcquireMem packet for cache coherency */
+	uint64_t base_addr = 0x123456000ULL; /* 256-byte aligned */
+	uint64_t size = 1024; /* 1KB */
+	uint32_t gcr_cntl = 0x18000; /* GCR control value */
 
-    int result = pm4_append_acquire_mem(buffer, base_addr, size, gcr_cntl);
-    assert(result == 0);
+	int result = pm4_append_acquire_mem(buffer, base_addr, size, gcr_cntl);
+	assert(result == 0);
 
-    /* Verify packet structure */
-    uint32_t* data = pm4_buffer_get_data(buffer);
-    size_t packet_size = pm4_buffer_get_size(buffer);
-    assert(packet_size == 8);
+	/* Verify packet structure */
+	uint32_t *data = pm4_buffer_get_data(buffer);
+	size_t packet_size = pm4_buffer_get_size(buffer);
+	assert(packet_size == 8);
 
-    /* Calculate expected coherency parameters */
-    uint32_t coher_size_lo, coher_size_hi, coher_base_lo, coher_base_hi;
-    pm4_calculate_cache_coher_params(base_addr, size,
-                                     &coher_size_lo, &coher_size_hi,
-                                     &coher_base_lo, &coher_base_hi);
+	/* Calculate expected coherency parameters */
+	uint32_t coher_size_lo, coher_size_hi, coher_base_lo, coher_base_hi;
+	pm4_calculate_cache_coher_params(base_addr, size, &coher_size_lo, &coher_size_hi,
+					 &coher_base_lo, &coher_base_hi);
 
-    /* Expected packet structure matching Rust FlushCachePacket */
-    uint32_t expected[8];
-    expected[0] = PM4_TYPE_3_HEADER(PM4_ACQUIRE_MEM_OPCODE, 32);  /* Header with count=6 */
-    expected[1] = 0;  /* Reserved */
-    expected[2] = coher_size_lo;
-    expected[3] = coher_size_hi & 0xFF;  /* Only 8 bits */
-    expected[4] = coher_base_lo;
-    expected[5] = coher_base_hi & 0xFFFFFF;  /* Only 24 bits */
-    expected[6] = 0x10 & 0xFFFF;  /* poll_interval */
-    expected[7] = gcr_cntl & 0x7FFFF;  /* 19 bits */
+	/* Expected packet structure matching Rust FlushCachePacket */
+	uint32_t expected[8];
+	expected[0] = PM4_TYPE_3_HEADER(PM4_ACQUIRE_MEM_OPCODE, 32); /* Header with count=6 */
+	expected[1] = 0; /* Reserved */
+	expected[2] = coher_size_lo;
+	expected[3] = coher_size_hi & 0xFF; /* Only 8 bits */
+	expected[4] = coher_base_lo;
+	expected[5] = coher_base_hi & 0xFFFFFF; /* Only 24 bits */
+	expected[6] = 0x10 & 0xFFFF; /* poll_interval */
+	expected[7] = gcr_cntl & 0x7FFFF; /* 19 bits */
 
-    print_buffer_hex("AcquireMem actual", data, packet_size);
-    print_buffer_hex("AcquireMem expected", expected, 8);
+	print_buffer_hex("AcquireMem actual", data, packet_size);
+	print_buffer_hex("AcquireMem expected", expected, 8);
 
-    assert(compare_buffers(data, expected, 8) == 0);
+	assert(compare_buffers(data, expected, 8) == 0);
 
-    pm4_buffer_destroy(buffer);
-    printf("  ✓ AcquireMem packet passed\n\n");
-    return 0;
+	pm4_buffer_destroy(buffer);
+	printf("  ✓ AcquireMem packet passed\n\n");
+	return 0;
 }
 
 /* Test GRBM broadcast helper */
 static int test_grbm_broadcast(void)
 {
-    printf("Testing GRBM broadcast helper...\n");
+	printf("Testing GRBM broadcast helper...\n");
 
-    pm4_buffer_t* buffer = pm4_buffer_create(256);
+	pm4_buffer_t *buffer = pm4_buffer_create(256);
 
-    int result = pm4_grbm_broadcast(buffer, TEST_GRBM_GFX_INDEX_REG);
-    assert(result == 0);
+	int result = pm4_grbm_broadcast(buffer, TEST_GRBM_GFX_INDEX_REG);
+	assert(result == 0);
 
-    /* Verify it created a SetUConfigReg packet with broadcast flags */
-    uint32_t* data = pm4_buffer_get_data(buffer);
-    size_t size = pm4_buffer_get_size(buffer);
-    assert(size == 3);
+	/* Verify it created a SetUConfigReg packet with broadcast flags */
+	uint32_t *data = pm4_buffer_get_data(buffer);
+	size_t size = pm4_buffer_get_size(buffer);
+	assert(size == 3);
 
-    /* Expected GRBM broadcast value */
-    pm4_grbm_gfx_index_t expected_index = {0};
-    expected_index.bits.instance_index = 0;
-    expected_index.bits.sa_index = 0;
-    expected_index.bits.se_index = 0;
-    expected_index.bits.sa_broadcast_writes = 1;
-    expected_index.bits.instance_broadcast_writes = 1;
-    expected_index.bits.se_broadcast_writes = 1;
+	/* Expected GRBM broadcast value */
+	pm4_grbm_gfx_index_t expected_index = { 0 };
+	expected_index.bits.instance_index = 0;
+	expected_index.bits.sa_index = 0;
+	expected_index.bits.se_index = 0;
+	expected_index.bits.sa_broadcast_writes = 1;
+	expected_index.bits.instance_broadcast_writes = 1;
+	expected_index.bits.se_broadcast_writes = 1;
 
-    assert(data[2] == expected_index.raw);
+	assert(data[2] == expected_index.raw);
 
-    pm4_buffer_destroy(buffer);
-    printf("  ✓ GRBM broadcast helper passed\n\n");
-    return 0;
+	pm4_buffer_destroy(buffer);
+	printf("  ✓ GRBM broadcast helper passed\n\n");
+	return 0;
 }
 
 /* Test pm4_op_t conversion functions */
 static int test_pm4_op_conversion(void)
 {
-    printf("Testing pm4_op_t conversions...\n");
+	printf("Testing pm4_op_t conversions...\n");
 
-    /* Test SetUConfigReg conversion */
-    uint32_t test_packet[3] = {
-        PM4_TYPE_3_HEADER(PM4_SET_UCONFIG_REG_OPCODE, 1),
-        0x1234,
-        0x56789ABC
-    };
+	/* Test SetUConfigReg conversion */
+	uint32_t test_packet[3] = { PM4_TYPE_3_HEADER(PM4_SET_UCONFIG_REG_OPCODE, 1), 0x1234,
+				    0x56789ABC };
 
-    pm4_op_t op = pm4_op_from_buffer(test_packet, 3);
-    assert(op.type == PM4_OP_SET_UCONFIG_REG);
-    assert(op.size_dwords == 3);
-    assert(op.packet.set_uconfig_reg.header == test_packet[0]);
-    assert(op.packet.set_uconfig_reg.reg_offset == 0x1234);
-    assert(op.packet.set_uconfig_reg.reg_value == 0x56789ABC);
+	pm4_op_t op = pm4_op_from_buffer(test_packet, 3);
+	assert(op.type == PM4_OP_SET_UCONFIG_REG);
+	assert(op.size_dwords == 3);
+	assert(op.packet.set_uconfig_reg.header == test_packet[0]);
+	assert(op.packet.set_uconfig_reg.reg_offset == 0x1234);
+	assert(op.packet.set_uconfig_reg.reg_value == 0x56789ABC);
 
-    /* Test round-trip conversion */
-    uint32_t output_buffer[3];
-    int written = pm4_op_to_buffer(&op, output_buffer, 3);
-    assert(written == 3);
-    assert(compare_buffers(test_packet, output_buffer, 3) == 0);
+	/* Test round-trip conversion */
+	uint32_t output_buffer[3];
+	int written = pm4_op_to_buffer(&op, output_buffer, 3);
+	assert(written == 3);
+	assert(compare_buffers(test_packet, output_buffer, 3) == 0);
 
-    printf("  ✓ pm4_op_t conversions passed\n\n");
-    return 0;
+	printf("  ✓ pm4_op_t conversions passed\n\n");
+	return 0;
 }
 
 /* Test complex command sequence matching Rust counter_start implementation */
 static int test_counter_start_sequence(void)
 {
-    printf("Testing counter start sequence (matching Rust counter_start)...\n");
+	printf("Testing counter start sequence (matching Rust counter_start)...\n");
 
-    pm4_buffer_t* buffer = pm4_buffer_create(256);
+	pm4_buffer_t *buffer = pm4_buffer_create(256);
 
-    /* 1. GRBM broadcast */
-    int result = pm4_grbm_broadcast(buffer, TEST_GRBM_GFX_INDEX_REG);
-    assert(result == 0);
+	/* 1. GRBM broadcast */
+	int result = pm4_grbm_broadcast(buffer, TEST_GRBM_GFX_INDEX_REG);
+	assert(result == 0);
 
-    /* 2. Select performance counter (SQ_WAVES event_id=4) */
-    uint32_t select_reg = 0x8000;  /* SQ_PERFCOUNTER0_SELECT */
-    uint32_t select_value = 4;     /* perf_sel = 4 for SQ_WAVES */
-    result = pm4_append_set_uconfig_reg(buffer, UCONFIG_SPACE_START + select_reg, select_value);
-    assert(result == 0);
+	/* 2. Select performance counter (SQ_WAVES event_id=4) */
+	uint32_t select_reg = 0x8000; /* SQ_PERFCOUNTER0_SELECT */
+	uint32_t select_value = 4; /* perf_sel = 4 for SQ_WAVES */
+	result = pm4_append_set_uconfig_reg(buffer, UCONFIG_SPACE_START + select_reg, select_value);
+	assert(result == 0);
 
-    /* 3. Enable SQ counter control */
-    uint32_t control_reg = 0x8010;  /* SQ_PERFCOUNTER_CTRL */
-    uint32_t control_value = 0x0000005F;  /* Enable PS, GS, HS, CS */
-    result = pm4_append_set_uconfig_reg(buffer, UCONFIG_SPACE_START + control_reg, control_value);
-    assert(result == 0);
+	/* 3. Enable SQ counter control */
+	uint32_t control_reg = 0x8010; /* SQ_PERFCOUNTER_CTRL */
+	uint32_t control_value = 0x0000005F; /* Enable PS, GS, HS, CS */
+	result = pm4_append_set_uconfig_reg(buffer, UCONFIG_SPACE_START + control_reg,
+					    control_value);
+	assert(result == 0);
 
-    /* 4. Enable compute performance counting */
-    result = pm4_append_write_sh_reg(buffer, TEST_COMPUTE_PERFCOUNT_ENABLE_REG, 1, 0, 0);
-    assert(result == 0);
+	/* 4. Enable compute performance counting */
+	result = pm4_append_write_sh_reg(buffer, TEST_COMPUTE_PERFCOUNT_ENABLE_REG, 1, 0, 0);
+	assert(result == 0);
 
-    /* 5. Enable CP perfmon control */
-    result = pm4_append_set_uconfig_reg(buffer, TEST_CP_PERFMON_CNTL_REG, 0x00000000);
-    assert(result == 0);
+	/* 5. Enable CP perfmon control */
+	result = pm4_append_set_uconfig_reg(buffer, TEST_CP_PERFMON_CNTL_REG, 0x00000000);
+	assert(result == 0);
 
-    /* 6. Start perfmon */
-    result = pm4_append_set_uconfig_reg(buffer, TEST_CP_PERFMON_CNTL_REG, 0x00000001);
-    assert(result == 0);
+	/* 6. Start perfmon */
+	result = pm4_append_set_uconfig_reg(buffer, TEST_CP_PERFMON_CNTL_REG, 0x00000001);
+	assert(result == 0);
 
-    /* Verify we have expected number of packets */
-    size_t total_size = pm4_buffer_get_size(buffer);
-    size_t expected_size = 3 + 3 + 3 + 3 + 3 + 3;  /* 6 packets, each 3 DWORDs */
-    assert(total_size == expected_size);
+	/* Verify we have expected number of packets */
+	size_t total_size = pm4_buffer_get_size(buffer);
+	size_t expected_size = 3 + 3 + 3 + 3 + 3 + 3; /* 6 packets, each 3 DWORDs */
+	assert(total_size == expected_size);
 
-    print_buffer_hex("Counter start sequence", pm4_buffer_get_data(buffer), total_size);
+	print_buffer_hex("Counter start sequence", pm4_buffer_get_data(buffer), total_size);
 
-    pm4_buffer_destroy(buffer);
-    printf("  ✓ Counter start sequence passed\n\n");
-    return 0;
+	pm4_buffer_destroy(buffer);
+	printf("  ✓ Counter start sequence passed\n\n");
+	return 0;
 }
 
 /* Main test runner */
 int main(void)
 {
-    printf("=== PM4 Packet Builder Tests ===\n\n");
+	printf("=== PM4 Packet Builder Tests ===\n\n");
 
-    /* Run all tests */
-    assert(test_buffer_create_destroy() == 0);
-    assert(test_set_uconfig_reg_packet() == 0);
-    assert(test_event_write_packet() == 0);
-    assert(test_copy_data_packet() == 0);
-    assert(test_write_sh_reg_packet() == 0);
-    assert(test_acquire_mem_packet() == 0);
-    assert(test_grbm_broadcast() == 0);
-    assert(test_pm4_op_conversion() == 0);
-    assert(test_counter_start_sequence() == 0);
+	/* Run all tests */
+	assert(test_buffer_create_destroy() == 0);
+	assert(test_set_uconfig_reg_packet() == 0);
+	assert(test_event_write_packet() == 0);
+	assert(test_copy_data_packet() == 0);
+	assert(test_write_sh_reg_packet() == 0);
+	assert(test_acquire_mem_packet() == 0);
+	assert(test_grbm_broadcast() == 0);
+	assert(test_pm4_op_conversion() == 0);
+	assert(test_counter_start_sequence() == 0);
 
-    printf("=== All tests passed! ===\n");
-    return 0;
+	printf("=== All tests passed! ===\n");
+	return 0;
 }

--- a/projects/perf-dkms/src/aql_c/tools/packet_gen_tool.c
+++ b/projects/perf-dkms/src/aql_c/tools/packet_gen_tool.c
@@ -20,411 +20,463 @@
 #define MAX_COUNTERS 16
 #define MAX_BUFFER_SIZE 4096
 
-typedef enum {
-    PACKET_ALL,
-    PACKET_START,
-    PACKET_READ,
-    PACKET_STOP
-} packet_type_t;
+typedef enum { PACKET_ALL, PACKET_START, PACKET_READ, PACKET_STOP } packet_type_t;
 
 typedef struct {
-    char *gfx_name;
-    uint64_t output_address;
-    counter_info_t counters[MAX_COUNTERS];
-    size_t counter_count;
-    packet_type_t packet_filter;
-    bool continuous_hex;
-    bool quiet_mode;
+	char *gfx_name;
+	uint64_t output_address;
+	counter_info_t counters[MAX_COUNTERS];
+	size_t counter_count;
+	packet_type_t packet_filter;
+	bool continuous_hex;
+	bool quiet_mode;
 } tool_config_t;
 
-static void print_usage(const char *program_name) {
-    printf("Usage: %s [options] <gfx_name> <output_address_hex> <counter1> [counter2] ...\n", program_name);
-    printf("\n");
-    printf("Options:\n");
-    printf("  --packet=TYPE    : Select which packet to output (start, read, stop, all)\n");
-    printf("                     Default: all\n");
-    printf("  --continuous     : Print packet as continuous hex (no spaces, no 0x prefix)\n");
-    printf("  --quiet          : Suppress all output except packet data\n");
-    printf("\n");
-    printf("Arguments:\n");
-    printf("  gfx_name         : GPU architecture name (e.g., gfx12)\n");
-    printf("  output_address   : Output memory address in hex (e.g., 0x1000000)\n");
-    printf("  counterN         : Counter name (e.g., SQ_WAVES, GL2C_HIT) or\n");
-    printf("                     BLOCK:INDEX:EVENT_ID format (e.g., SQ:0:0x42)\n");
-    printf("\n");
-    printf("Available counter names: SQ_WAVES, SQ_BUSY_CYCLES, GL2C_HIT, GL2C_MISS,\n");
-    printf("                         TA_TA_BUSY, GRBM_COUNT, GRBM_GUI_ACTIVE, etc.\n");
-    printf("\n");
-    printf("Examples:\n");
-    printf("  %s gfx12 0x1000000 SQ_WAVES GL2C_HIT\n", program_name);
-    printf("  %s --packet=start --quiet gfx12 0x1000000 SQ_WAVES\n", program_name);
-    printf("  %s --continuous --packet=read gfx12 0x1000000 GL2C_HIT\n", program_name);
+static void print_usage(const char *program_name)
+{
+	printf("Usage: %s [options] <gfx_name> <output_address_hex> <counter1> [counter2] ...\n",
+	       program_name);
+	printf("\n");
+	printf("Options:\n");
+	printf("  --packet=TYPE    : Select which packet to output (start, read, stop, all)\n");
+	printf("                     Default: all\n");
+	printf("  --continuous     : Print packet as continuous hex (no spaces, no 0x prefix)\n");
+	printf("  --quiet          : Suppress all output except packet data\n");
+	printf("\n");
+	printf("Arguments:\n");
+	printf("  gfx_name         : GPU architecture name (e.g., gfx12)\n");
+	printf("  output_address   : Output memory address in hex (e.g., 0x1000000)\n");
+	printf("  counterN         : Counter name (e.g., SQ_WAVES, GL2C_HIT) or\n");
+	printf("                     BLOCK:INDEX:EVENT_ID format (e.g., SQ:0:0x42)\n");
+	printf("\n");
+	printf("Available counter names: SQ_WAVES, SQ_BUSY_CYCLES, GL2C_HIT, GL2C_MISS,\n");
+	printf("                         TA_TA_BUSY, GRBM_COUNT, GRBM_GUI_ACTIVE, etc.\n");
+	printf("\n");
+	printf("Examples:\n");
+	printf("  %s gfx12 0x1000000 SQ_WAVES GL2C_HIT\n", program_name);
+	printf("  %s --packet=start --quiet gfx12 0x1000000 SQ_WAVES\n", program_name);
+	printf("  %s --continuous --packet=read gfx12 0x1000000 GL2C_HIT\n", program_name);
 }
 
-static int parse_block_name(const char *block_name) {
-    if (strcmp(block_name, "ATC") == 0) return HW_IP_BLOCK_ATC;
-    if (strcmp(block_name, "CPC") == 0) return HW_IP_BLOCK_CPC;
-    if (strcmp(block_name, "CPF") == 0) return HW_IP_BLOCK_CPF;
-    if (strcmp(block_name, "CPG") == 0) return HW_IP_BLOCK_CPG;
-    if (strcmp(block_name, "DB") == 0) return HW_IP_BLOCK_DB;
-    if (strcmp(block_name, "EA") == 0) return HW_IP_BLOCK_EA;
-    if (strcmp(block_name, "GDS") == 0) return HW_IP_BLOCK_GDS;
-    if (strcmp(block_name, "GRBM") == 0) return HW_IP_BLOCK_GRBM;
-    if (strcmp(block_name, "GL2C") == 0) return HW_IP_BLOCK_GL2C;
-    if (strcmp(block_name, "PA_SC") == 0) return HW_IP_BLOCK_PA_SC;
-    if (strcmp(block_name, "PA_SU") == 0) return HW_IP_BLOCK_PA_SU;
-    if (strcmp(block_name, "RMI") == 0) return HW_IP_BLOCK_RMI;
-    if (strcmp(block_name, "SPI") == 0) return HW_IP_BLOCK_SPI;
-    if (strcmp(block_name, "SQ") == 0) return HW_IP_BLOCK_SQ;
-    if (strcmp(block_name, "SX") == 0) return HW_IP_BLOCK_SX;
-    if (strcmp(block_name, "TA") == 0) return HW_IP_BLOCK_TA;
-    if (strcmp(block_name, "TCP") == 0) return HW_IP_BLOCK_TCP;
-    if (strcmp(block_name, "TD") == 0) return HW_IP_BLOCK_TD;
-    if (strcmp(block_name, "TCA") == 0) return HW_IP_BLOCK_TCA;
-    if (strcmp(block_name, "TCC") == 0) return HW_IP_BLOCK_TCC;
-    if (strcmp(block_name, "UMC") == 0) return HW_IP_BLOCK_UMC;
-    if (strcmp(block_name, "SDMA") == 0) return HW_IP_BLOCK_SDMA;
-    return -1;
+static int parse_block_name(const char *block_name)
+{
+	if (strcmp(block_name, "ATC") == 0)
+		return HW_IP_BLOCK_ATC;
+	if (strcmp(block_name, "CPC") == 0)
+		return HW_IP_BLOCK_CPC;
+	if (strcmp(block_name, "CPF") == 0)
+		return HW_IP_BLOCK_CPF;
+	if (strcmp(block_name, "CPG") == 0)
+		return HW_IP_BLOCK_CPG;
+	if (strcmp(block_name, "DB") == 0)
+		return HW_IP_BLOCK_DB;
+	if (strcmp(block_name, "EA") == 0)
+		return HW_IP_BLOCK_EA;
+	if (strcmp(block_name, "GDS") == 0)
+		return HW_IP_BLOCK_GDS;
+	if (strcmp(block_name, "GRBM") == 0)
+		return HW_IP_BLOCK_GRBM;
+	if (strcmp(block_name, "GL2C") == 0)
+		return HW_IP_BLOCK_GL2C;
+	if (strcmp(block_name, "PA_SC") == 0)
+		return HW_IP_BLOCK_PA_SC;
+	if (strcmp(block_name, "PA_SU") == 0)
+		return HW_IP_BLOCK_PA_SU;
+	if (strcmp(block_name, "RMI") == 0)
+		return HW_IP_BLOCK_RMI;
+	if (strcmp(block_name, "SPI") == 0)
+		return HW_IP_BLOCK_SPI;
+	if (strcmp(block_name, "SQ") == 0)
+		return HW_IP_BLOCK_SQ;
+	if (strcmp(block_name, "SX") == 0)
+		return HW_IP_BLOCK_SX;
+	if (strcmp(block_name, "TA") == 0)
+		return HW_IP_BLOCK_TA;
+	if (strcmp(block_name, "TCP") == 0)
+		return HW_IP_BLOCK_TCP;
+	if (strcmp(block_name, "TD") == 0)
+		return HW_IP_BLOCK_TD;
+	if (strcmp(block_name, "TCA") == 0)
+		return HW_IP_BLOCK_TCA;
+	if (strcmp(block_name, "TCC") == 0)
+		return HW_IP_BLOCK_TCC;
+	if (strcmp(block_name, "UMC") == 0)
+		return HW_IP_BLOCK_UMC;
+	if (strcmp(block_name, "SDMA") == 0)
+		return HW_IP_BLOCK_SDMA;
+	return -1;
 }
 
-static int parse_counter_spec(const char *spec, counter_info_t *counter) {
-    char *spec_copy = strdup(spec);
-    if (!spec_copy) return -ENOMEM;
+static int parse_counter_spec(const char *spec, counter_info_t *counter)
+{
+	char *spec_copy = strdup(spec);
+	if (!spec_copy)
+		return -ENOMEM;
 
-    char *block_str = strtok(spec_copy, ":");
-    char *index_str = strtok(NULL, ":");
-    char *event_str = strtok(NULL, ":");
+	char *block_str = strtok(spec_copy, ":");
+	char *index_str = strtok(NULL, ":");
+	char *event_str = strtok(NULL, ":");
 
-    if (!block_str || !index_str || !event_str) {
-        free(spec_copy);
-        return -EINVAL;
-    }
+	if (!block_str || !index_str || !event_str) {
+		free(spec_copy);
+		return -EINVAL;
+	}
 
-    int block_id = parse_block_name(block_str);
-    if (block_id < 0) {
-        free(spec_copy);
-        return -EINVAL;
-    }
+	int block_id = parse_block_name(block_str);
+	if (block_id < 0) {
+		free(spec_copy);
+		return -EINVAL;
+	}
 
-    counter->block_id = block_id;
-    counter->counter_index = strtoul(index_str, NULL, 10);
-    counter->event_id = strtoul(event_str, NULL, 16);
+	counter->block_id = block_id;
+	counter->counter_index = strtoul(index_str, NULL, 10);
+	counter->event_id = strtoul(event_str, NULL, 16);
 
-    free(spec_copy);
-    return 0;
+	free(spec_copy);
+	return 0;
 }
 
-static int parse_counter_name(const char *counter_name, const arch_t *arch, counter_info_t *counter) {
-    if (!counter_name || !arch || !counter) return -EINVAL;
+static int parse_counter_name(const char *counter_name, const arch_t *arch, counter_info_t *counter)
+{
+	if (!counter_name || !arch || !counter)
+		return -EINVAL;
 
-    /* Try to look up counter by name first */
-    const counter_def_t *counter_def = lookup_counter_by_name(counter_name);
-    if (counter_def) {
-        /* Found by name - get the event ID from architecture */
-        uint32_t event_id;
-        int ret = lookup_event_id(counter_def, arch, &event_id);
-        if (ret < 0) {
-            printf("Warning: No event mapping found for counter '%s' in architecture (err=%d)\n", counter_name, ret);
-            return -ENOENT;
-        }
+	/* Try to look up counter by name first */
+	const counter_def_t *counter_def = lookup_counter_by_name(counter_name);
+	if (counter_def) {
+		/* Found by name - get the event ID from architecture */
+		uint32_t event_id;
+		int ret = lookup_event_id(counter_def, arch, &event_id);
+		if (ret < 0) {
+			printf("Warning: No event mapping found for counter '%s' in architecture (err=%d)\n",
+			       counter_name, ret);
+			return -ENOENT;
+		}
 
-        counter->block_id = counter_def->hw_block;
-        counter->counter_index = 0;  /* Default to first available counter in the block */
-        counter->event_id = event_id;
-        return 0;
-    }
+		counter->block_id = counter_def->hw_block;
+		counter->counter_index = 0; /* Default to first available counter in the block */
+		counter->event_id = event_id;
+		return 0;
+	}
 
-    /* If not found by name, fall back to the old BLOCK:INDEX:EVENT format */
-    return parse_counter_spec(counter_name, counter);
+	/* If not found by name, fall back to the old BLOCK:INDEX:EVENT format */
+	return parse_counter_spec(counter_name, counter);
 }
 
-static int parse_packet_type(const char *type_str) {
-    if (!type_str) return PACKET_ALL;
-    if (strcmp(type_str, "start") == 0) return PACKET_START;
-    if (strcmp(type_str, "read") == 0) return PACKET_READ;
-    if (strcmp(type_str, "stop") == 0) return PACKET_STOP;
-    if (strcmp(type_str, "all") == 0) return PACKET_ALL;
-    return -1;
+static int parse_packet_type(const char *type_str)
+{
+	if (!type_str)
+		return PACKET_ALL;
+	if (strcmp(type_str, "start") == 0)
+		return PACKET_START;
+	if (strcmp(type_str, "read") == 0)
+		return PACKET_READ;
+	if (strcmp(type_str, "stop") == 0)
+		return PACKET_STOP;
+	if (strcmp(type_str, "all") == 0)
+		return PACKET_ALL;
+	return -1;
 }
 
-static int parse_arguments(int argc, char *argv[], tool_config_t *config) {
-    /* Initialize default values */
-    config->packet_filter = PACKET_ALL;
-    config->continuous_hex = false;
-    config->quiet_mode = false;
-    config->counter_count = 0;
+static int parse_arguments(int argc, char *argv[], tool_config_t *config)
+{
+	/* Initialize default values */
+	config->packet_filter = PACKET_ALL;
+	config->continuous_hex = false;
+	config->quiet_mode = false;
+	config->counter_count = 0;
 
-    int arg_index = 1;
+	int arg_index = 1;
 
-    /* Parse options */
-    while (arg_index < argc && argv[arg_index][0] == '-') {
-        if (strncmp(argv[arg_index], "--packet=", 9) == 0) {
-            int packet_type = parse_packet_type(argv[arg_index] + 9);
-            if (packet_type < 0) {
-                fprintf(stderr, "Error: Invalid packet type '%s'\n", argv[arg_index] + 9);
-                return -EINVAL;
-            }
-            config->packet_filter = packet_type;
-        } else if (strcmp(argv[arg_index], "--continuous") == 0) {
-            config->continuous_hex = true;
-        } else if (strcmp(argv[arg_index], "--quiet") == 0) {
-            config->quiet_mode = true;
-        } else {
-            fprintf(stderr, "Error: Unknown option '%s'\n", argv[arg_index]);
-            return -EINVAL;
-        }
-        arg_index++;
-    }
+	/* Parse options */
+	while (arg_index < argc && argv[arg_index][0] == '-') {
+		if (strncmp(argv[arg_index], "--packet=", 9) == 0) {
+			int packet_type = parse_packet_type(argv[arg_index] + 9);
+			if (packet_type < 0) {
+				fprintf(stderr, "Error: Invalid packet type '%s'\n",
+					argv[arg_index] + 9);
+				return -EINVAL;
+			}
+			config->packet_filter = packet_type;
+		} else if (strcmp(argv[arg_index], "--continuous") == 0) {
+			config->continuous_hex = true;
+		} else if (strcmp(argv[arg_index], "--quiet") == 0) {
+			config->quiet_mode = true;
+		} else {
+			fprintf(stderr, "Error: Unknown option '%s'\n", argv[arg_index]);
+			return -EINVAL;
+		}
+		arg_index++;
+	}
 
-    /* Check remaining required arguments */
-    if (argc - arg_index < 3) {
-        return -EINVAL;
-    }
+	/* Check remaining required arguments */
+	if (argc - arg_index < 3) {
+		return -EINVAL;
+	}
 
-    config->gfx_name = argv[arg_index];
-    config->output_address = strtoull(argv[arg_index + 1], NULL, 16);
+	config->gfx_name = argv[arg_index];
+	config->output_address = strtoull(argv[arg_index + 1], NULL, 16);
 
-    /* Store the counter arguments for later parsing with architecture */
-    for (int i = arg_index + 2; i < argc && config->counter_count < MAX_COUNTERS; i++) {
-        config->counter_count++;
-    }
+	/* Store the counter arguments for later parsing with architecture */
+	for (int i = arg_index + 2; i < argc && config->counter_count < MAX_COUNTERS; i++) {
+		config->counter_count++;
+	}
 
-    return 0;
+	return 0;
 }
 
-static int parse_counters_with_arch(int argc, char *argv[], tool_config_t *config, const arch_t *arch) {
-    config->counter_count = 0;
+static int parse_counters_with_arch(int argc, char *argv[], tool_config_t *config,
+				    const arch_t *arch)
+{
+	config->counter_count = 0;
 
-    /* Find the start of counter arguments (after options, gfx_name, and output_address) */
-    int counter_start = 1;
-    while (counter_start < argc && argv[counter_start][0] == '-') {
-        counter_start++;
-    }
-    counter_start += 2;  /* Skip gfx_name and output_address */
+	/* Find the start of counter arguments (after options, gfx_name, and output_address) */
+	int counter_start = 1;
+	while (counter_start < argc && argv[counter_start][0] == '-') {
+		counter_start++;
+	}
+	counter_start += 2; /* Skip gfx_name and output_address */
 
-    for (int i = counter_start; i < argc && config->counter_count < MAX_COUNTERS; i++) {
-        if (parse_counter_name(argv[i], arch, &config->counters[config->counter_count]) == 0) {
-            config->counter_count++;
-        } else {
-            fprintf(stderr, "Error: Invalid counter specification: %s\n", argv[i]);
-            fprintf(stderr, "       Use counter name (e.g., SQ_WAVES) or BLOCK:INDEX:EVENT format (e.g., SQ:0:0x42)\n");
-            return -EINVAL;
-        }
-    }
+	for (int i = counter_start; i < argc && config->counter_count < MAX_COUNTERS; i++) {
+		if (parse_counter_name(argv[i], arch, &config->counters[config->counter_count]) ==
+		    0) {
+			config->counter_count++;
+		} else {
+			fprintf(stderr, "Error: Invalid counter specification: %s\n", argv[i]);
+			fprintf(stderr,
+				"       Use counter name (e.g., SQ_WAVES) or BLOCK:INDEX:EVENT format (e.g., SQ:0:0x42)\n");
+			return -EINVAL;
+		}
+	}
 
-    if (config->counter_count == 0) {
-        fprintf(stderr, "Error: No valid counters specified\n");
-        return -EINVAL;
-    }
+	if (config->counter_count == 0) {
+		fprintf(stderr, "Error: No valid counters specified\n");
+		return -EINVAL;
+	}
 
-    return 0;
+	return 0;
 }
 
-static void print_pm4_buffer_normal(const char *packet_type, pm4_buffer_t *buffer) {
-    printf("=== %s PACKET ===\n", packet_type);
-    printf("Size: %zu DWORDs (%zu bytes)\n", buffer->size, buffer->size * 4);
+static void print_pm4_buffer_normal(const char *packet_type, pm4_buffer_t *buffer)
+{
+	printf("=== %s PACKET ===\n", packet_type);
+	printf("Size: %zu DWORDs (%zu bytes)\n", buffer->size, buffer->size * 4);
 
-    for (size_t i = 0; i < buffer->size; i++) {
-        printf("0x%08x", buffer->data[i]);
-        if (i < buffer->size - 1) {
-            printf(" ");
-        }
-        if ((i + 1) % 8 == 0) {
-            printf("\n");
-        }
-    }
-    if (buffer->size % 8 != 0) {
-        printf("\n");
-    }
-    printf("\n");
+	for (size_t i = 0; i < buffer->size; i++) {
+		printf("0x%08x", buffer->data[i]);
+		if (i < buffer->size - 1) {
+			printf(" ");
+		}
+		if ((i + 1) % 8 == 0) {
+			printf("\n");
+		}
+	}
+	if (buffer->size % 8 != 0) {
+		printf("\n");
+	}
+	printf("\n");
 }
 
-static void print_pm4_buffer_continuous(pm4_buffer_t *buffer) {
-    for (size_t i = 0; i < buffer->size; i++) {
-        printf("%08x", buffer->data[i]);
-    }
+static void print_pm4_buffer_continuous(pm4_buffer_t *buffer)
+{
+	for (size_t i = 0; i < buffer->size; i++) {
+		printf("%08x", buffer->data[i]);
+	}
 }
 
-static void print_pm4_buffer_quiet(pm4_buffer_t *buffer) {
-    for (size_t i = 0; i < buffer->size; i++) {
-        printf("0x%08x", buffer->data[i]);
-        if (i < buffer->size - 1) {
-            printf(" ");
-        }
-    }
+static void print_pm4_buffer_quiet(pm4_buffer_t *buffer)
+{
+	for (size_t i = 0; i < buffer->size; i++) {
+		printf("0x%08x", buffer->data[i]);
+		if (i < buffer->size - 1) {
+			printf(" ");
+		}
+	}
 }
 
-static void print_pm4_buffer(const char *packet_type, pm4_buffer_t *buffer, const tool_config_t *config) {
-    if (config->continuous_hex) {
-        print_pm4_buffer_continuous(buffer);
-    } else if (config->quiet_mode) {
-        print_pm4_buffer_quiet(buffer);
-    } else {
-        print_pm4_buffer_normal(packet_type, buffer);
-    }
+static void print_pm4_buffer(const char *packet_type, pm4_buffer_t *buffer,
+			     const tool_config_t *config)
+{
+	if (config->continuous_hex) {
+		print_pm4_buffer_continuous(buffer);
+	} else if (config->quiet_mode) {
+		print_pm4_buffer_quiet(buffer);
+	} else {
+		print_pm4_buffer_normal(packet_type, buffer);
+	}
 }
 
-static pm4_buffer_t* create_buffer(void) {
-    pm4_buffer_t* buffer = malloc(sizeof(pm4_buffer_t));
-    if (!buffer) return NULL;
+static pm4_buffer_t *create_buffer(void)
+{
+	pm4_buffer_t *buffer = malloc(sizeof(pm4_buffer_t));
+	if (!buffer)
+		return NULL;
 
-    buffer->data = malloc(MAX_BUFFER_SIZE * sizeof(uint32_t));
-    if (!buffer->data) {
-        free(buffer);
-        return NULL;
-    }
+	buffer->data = malloc(MAX_BUFFER_SIZE * sizeof(uint32_t));
+	if (!buffer->data) {
+		free(buffer);
+		return NULL;
+	}
 
-    buffer->capacity = MAX_BUFFER_SIZE;
-    buffer->size = 0;
-    memset(buffer->data, 0, buffer->capacity * sizeof(uint32_t));
+	buffer->capacity = MAX_BUFFER_SIZE;
+	buffer->size = 0;
+	memset(buffer->data, 0, buffer->capacity * sizeof(uint32_t));
 
-    return buffer;
+	return buffer;
 }
 
-static void destroy_buffer(pm4_buffer_t* buffer) {
-    if (!buffer) return;
-    free(buffer->data);
-    free(buffer);
+static void destroy_buffer(pm4_buffer_t *buffer)
+{
+	if (!buffer)
+		return;
+	free(buffer->data);
+	free(buffer);
 }
 
-int main(int argc, char *argv[]) {
-    tool_config_t config;
-    arch_t *arch = NULL;
-    pm4_buffer_t *start_buffer = NULL, *read_buffer = NULL, *stop_buffer = NULL;
-    int ret = 0;
+int main(int argc, char *argv[])
+{
+	tool_config_t config;
+	arch_t *arch = NULL;
+	pm4_buffer_t *start_buffer = NULL, *read_buffer = NULL, *stop_buffer = NULL;
+	int ret = 0;
 
-    if (parse_arguments(argc, argv, &config) != 0) {
-        print_usage(argv[0]);
-        return 1;
-    }
+	if (parse_arguments(argc, argv, &config) != 0) {
+		print_usage(argv[0]);
+		return 1;
+	}
 
-    if (!config.quiet_mode) {
-        printf("Packet Generation Tool\n");
-        printf("======================\n");
-        printf("Architecture: %s\n", config.gfx_name);
-        printf("Output Address: 0x%lx\n", config.output_address);
-    }
+	if (!config.quiet_mode) {
+		printf("Packet Generation Tool\n");
+		printf("======================\n");
+		printf("Architecture: %s\n", config.gfx_name);
+		printf("Output Address: 0x%lx\n", config.output_address);
+	}
 
-    /* Create architecture */
-    arch = arch_create_by_name(config.gfx_name);
-    if (!arch) {
-        fprintf(stderr, "Error: Failed to create architecture '%s'\n", config.gfx_name);
-        ret = 1;
-        goto cleanup;
-    }
+	/* Create architecture */
+	arch = arch_create_by_name(config.gfx_name);
+	if (!arch) {
+		fprintf(stderr, "Error: Failed to create architecture '%s'\n", config.gfx_name);
+		ret = 1;
+		goto cleanup;
+	}
 
-    /* Parse counters with architecture available */
-    if (parse_counters_with_arch(argc, argv, &config, arch) != 0) {
-        ret = 1;
-        goto cleanup;
-    }
+	/* Parse counters with architecture available */
+	if (parse_counters_with_arch(argc, argv, &config, arch) != 0) {
+		ret = 1;
+		goto cleanup;
+	}
 
-    if (!config.quiet_mode) {
-        printf("Counter Count: %zu\n", config.counter_count);
-        for (size_t i = 0; i < config.counter_count; i++) {
-            printf("  Counter %zu: Block %d, Index %d, Event 0x%x\n", i,
-                   config.counters[i].block_id,
-                   config.counters[i].counter_index,
-                   config.counters[i].event_id);
-        }
-        printf("\n");
-    }
+	if (!config.quiet_mode) {
+		printf("Counter Count: %zu\n", config.counter_count);
+		for (size_t i = 0; i < config.counter_count; i++) {
+			printf("  Counter %zu: Block %d, Index %d, Event 0x%x\n", i,
+			       config.counters[i].block_id, config.counters[i].counter_index,
+			       config.counters[i].event_id);
+		}
+		printf("\n");
+	}
 
-    /* Create counter collection */
-    counter_collection_t collection = {
-        .counters = config.counters,
-        .counter_count = config.counter_count,
-        .gpu_memory_addr = config.output_address,
-        .memory_size = calculate_counter_memory_size(arch, &(counter_collection_t){
-            .counters = config.counters,
-            .counter_count = config.counter_count
-        })
-    };
+	/* Create counter collection */
+	counter_collection_t collection = {
+		.counters = config.counters,
+		.counter_count = config.counter_count,
+		.gpu_memory_addr = config.output_address,
+		.memory_size = calculate_counter_memory_size(
+			arch, &(counter_collection_t){ .counters = config.counters,
+						       .counter_count = config.counter_count })
+	};
 
-    if (!config.quiet_mode) {
-        printf("Required memory size: %zu bytes\n\n", collection.memory_size);
-    }
+	if (!config.quiet_mode) {
+		printf("Required memory size: %zu bytes\n\n", collection.memory_size);
+	}
 
-    /* Validate counter collection */
-    ret = validate_counter_collection(arch, &collection);
-    if (ret != 0) {
-        fprintf(stderr, "Error: Counter collection validation failed: %s\n", strerror(-ret));
-        ret = 1;
-        goto cleanup;
-    }
+	/* Validate counter collection */
+	ret = validate_counter_collection(arch, &collection);
+	if (ret != 0) {
+		fprintf(stderr, "Error: Counter collection validation failed: %s\n",
+			strerror(-ret));
+		ret = 1;
+		goto cleanup;
+	}
 
-    /* Create buffers */
-    start_buffer = create_buffer();
-    read_buffer = create_buffer();
-    stop_buffer = create_buffer();
+	/* Create buffers */
+	start_buffer = create_buffer();
+	read_buffer = create_buffer();
+	stop_buffer = create_buffer();
 
-    if (!start_buffer || !read_buffer || !stop_buffer) {
-        fprintf(stderr, "Error: Failed to create PM4 buffers\n");
-        ret = 1;
-        goto cleanup;
-    }
+	if (!start_buffer || !read_buffer || !stop_buffer) {
+		fprintf(stderr, "Error: Failed to create PM4 buffers\n");
+		ret = 1;
+		goto cleanup;
+	}
 
-    /* Generate START packet */
-    ret = generate_start_packet(start_buffer, arch, &collection);
-    if (ret != 0) {
-        fprintf(stderr, "Error: Failed to generate start packet: %s\n", strerror(-ret));
-        ret = 1;
-        goto cleanup;
-    }
+	/* Generate START packet */
+	ret = generate_start_packet(start_buffer, arch, &collection);
+	if (ret != 0) {
+		fprintf(stderr, "Error: Failed to generate start packet: %s\n", strerror(-ret));
+		ret = 1;
+		goto cleanup;
+	}
 
-    /* Generate READ packet */
-    ret = generate_read_packet(read_buffer, arch, &collection);
-    if (ret != 0) {
-        fprintf(stderr, "Error: Failed to generate read packet: %s\n", strerror(-ret));
-        ret = 1;
-        goto cleanup;
-    }
+	/* Generate READ packet */
+	ret = generate_read_packet(read_buffer, arch, &collection);
+	if (ret != 0) {
+		fprintf(stderr, "Error: Failed to generate read packet: %s\n", strerror(-ret));
+		ret = 1;
+		goto cleanup;
+	}
 
-    /* Generate STOP packet */
-    ret = generate_stop_packet(stop_buffer, arch);
-    if (ret != 0) {
-        fprintf(stderr, "Error: Failed to generate stop packet: %s\n", strerror(-ret));
-        ret = 1;
-        goto cleanup;
-    }
+	/* Generate STOP packet */
+	ret = generate_stop_packet(stop_buffer, arch);
+	if (ret != 0) {
+		fprintf(stderr, "Error: Failed to generate stop packet: %s\n", strerror(-ret));
+		ret = 1;
+		goto cleanup;
+	}
 
-    /* Print results based on packet filter */
-    bool printed_any = false;
-    if (config.packet_filter == PACKET_ALL || config.packet_filter == PACKET_START) {
-        print_pm4_buffer("START", start_buffer, &config);
-        printed_any = true;
-        if (config.continuous_hex && (config.packet_filter == PACKET_ALL)) {
-            /* Add space between packets in continuous mode when printing all */
-            if (config.packet_filter == PACKET_ALL) printf(" ");
-        } else if (config.quiet_mode && config.packet_filter == PACKET_ALL) {
-            printf("\n");
-        }
-    }
-    if (config.packet_filter == PACKET_ALL || config.packet_filter == PACKET_READ) {
-        print_pm4_buffer("READ", read_buffer, &config);
-        printed_any = true;
-        if (config.continuous_hex && (config.packet_filter == PACKET_ALL)) {
-            /* Add space between packets in continuous mode when printing all */
-            if (config.packet_filter == PACKET_ALL) printf(" ");
-        } else if (config.quiet_mode && config.packet_filter == PACKET_ALL) {
-            printf("\n");
-        }
-    }
-    if (config.packet_filter == PACKET_ALL || config.packet_filter == PACKET_STOP) {
-        print_pm4_buffer("STOP", stop_buffer, &config);
-        printed_any = true;
-    }
+	/* Print results based on packet filter */
+	bool printed_any = false;
+	if (config.packet_filter == PACKET_ALL || config.packet_filter == PACKET_START) {
+		print_pm4_buffer("START", start_buffer, &config);
+		printed_any = true;
+		if (config.continuous_hex && (config.packet_filter == PACKET_ALL)) {
+			/* Add space between packets in continuous mode when printing all */
+			if (config.packet_filter == PACKET_ALL)
+				printf(" ");
+		} else if (config.quiet_mode && config.packet_filter == PACKET_ALL) {
+			printf("\n");
+		}
+	}
+	if (config.packet_filter == PACKET_ALL || config.packet_filter == PACKET_READ) {
+		print_pm4_buffer("READ", read_buffer, &config);
+		printed_any = true;
+		if (config.continuous_hex && (config.packet_filter == PACKET_ALL)) {
+			/* Add space between packets in continuous mode when printing all */
+			if (config.packet_filter == PACKET_ALL)
+				printf(" ");
+		} else if (config.quiet_mode && config.packet_filter == PACKET_ALL) {
+			printf("\n");
+		}
+	}
+	if (config.packet_filter == PACKET_ALL || config.packet_filter == PACKET_STOP) {
+		print_pm4_buffer("STOP", stop_buffer, &config);
+		printed_any = true;
+	}
 
-    /* Add final newline for continuous and quiet modes */
-    if (printed_any && (config.continuous_hex || config.quiet_mode)) {
-        printf("\n");
-    }
+	/* Add final newline for continuous and quiet modes */
+	if (printed_any && (config.continuous_hex || config.quiet_mode)) {
+		printf("\n");
+	}
 
 cleanup:
-    if (start_buffer) destroy_buffer(start_buffer);
-    if (read_buffer) destroy_buffer(read_buffer);
-    if (stop_buffer) destroy_buffer(stop_buffer);
-    if (arch) arch_destroy(arch);
+	if (start_buffer)
+		destroy_buffer(start_buffer);
+	if (read_buffer)
+		destroy_buffer(read_buffer);
+	if (stop_buffer)
+		destroy_buffer(stop_buffer);
+	if (arch)
+		arch_destroy(arch);
 
-    return ret;
+	return ret;
 }

--- a/projects/perf-dkms/src/aql_c/tools/pm4_decoder.c
+++ b/projects/perf-dkms/src/aql_c/tools/pm4_decoder.c
@@ -16,855 +16,951 @@
 #include <getopt.h>
 
 /* PM4 packet type definitions */
-#define PM4_TYPE3_MASK          0xC0000000
-#define PM4_TYPE3_VALUE         0xC0000000
-#define PM4_OPCODE_MASK         0x0000FF00
-#define PM4_OPCODE_SHIFT        8
-#define PM4_COUNT_MASK          0x3FFF0000
-#define PM4_COUNT_SHIFT         16
+#define PM4_TYPE3_MASK 0xC0000000
+#define PM4_TYPE3_VALUE 0xC0000000
+#define PM4_OPCODE_MASK 0x0000FF00
+#define PM4_OPCODE_SHIFT 8
+#define PM4_COUNT_MASK 0x3FFF0000
+#define PM4_COUNT_SHIFT 16
 
 /* PM4 Opcodes supported by aql_c and aqlprofile */
-#define PM4_NOP                 0x10
-#define PM4_ATOMIC_MEM          0x1E
-#define PM4_REG_RMW             0x21
-#define PM4_PRED_EXEC           0x23
-#define PM4_WRITE_DATA          0x37
-#define PM4_WAIT_REG_MEM        0x3C
-#define PM4_INDIRECT_BUFFER     0x3F
-#define PM4_COPY_DATA           0x40
-#define PM4_EVENT_WRITE         0x46
-#define PM4_ACQUIRE_MEM         0x58
-#define PM4_PRIME_UTCL2         0x5D
-#define PM4_SET_CONFIG_REG      0x68
-#define PM4_SET_CONTEXT_REG     0x69
-#define PM4_SET_SH_REG          0x76
-#define PM4_SET_QUEUE_REG       0x78
-#define PM4_SET_UCONFIG_REG     0x79
+#define PM4_NOP 0x10
+#define PM4_ATOMIC_MEM 0x1E
+#define PM4_REG_RMW 0x21
+#define PM4_PRED_EXEC 0x23
+#define PM4_WRITE_DATA 0x37
+#define PM4_WAIT_REG_MEM 0x3C
+#define PM4_INDIRECT_BUFFER 0x3F
+#define PM4_COPY_DATA 0x40
+#define PM4_EVENT_WRITE 0x46
+#define PM4_ACQUIRE_MEM 0x58
+#define PM4_PRIME_UTCL2 0x5D
+#define PM4_SET_CONFIG_REG 0x68
+#define PM4_SET_CONTEXT_REG 0x69
+#define PM4_SET_SH_REG 0x76
+#define PM4_SET_QUEUE_REG 0x78
+#define PM4_SET_UCONFIG_REG 0x79
 
 /* Maximum packet size in DWORDs (4MB = 1048576 DWORDs) */
-#define MAX_PACKET_SIZE         1048576
+#define MAX_PACKET_SIZE 1048576
 
 typedef struct {
-    uint32_t type;
-    uint32_t opcode;
-    uint32_t count;
-    uint32_t size_dwords;
+	uint32_t type;
+	uint32_t opcode;
+	uint32_t count;
+	uint32_t size_dwords;
 } pm4_header_t;
 
 /* Global rebase state */
 typedef struct {
-    bool enabled;              /* Is rebasing enabled? */
-    uint64_t new_base;         /* New base address to use */
-    uint64_t original_base;    /* Original base address (from first COPY_DATA) */
-    bool base_found;           /* Have we found the original base yet? */
+	bool enabled; /* Is rebasing enabled? */
+	uint64_t new_base; /* New base address to use */
+	uint64_t original_base; /* Original base address (from first COPY_DATA) */
+	bool base_found; /* Have we found the original base yet? */
 } rebase_state_t;
 
-static rebase_state_t g_rebase_state = {0};
+static rebase_state_t g_rebase_state = { 0 };
 
 /**
  * Convert hex string to uint32_t array
  */
-static int hex_string_to_dwords(const char* hex_str, uint32_t* dwords, size_t max_dwords) {
-    size_t len = strlen(hex_str);
-    if (len % 8 != 0) {
-        fprintf(stderr, "Error: Hex string length must be multiple of 8 (4 bytes per DWORD)\n");
-        return -1;
-    }
+static int hex_string_to_dwords(const char *hex_str, uint32_t *dwords, size_t max_dwords)
+{
+	size_t len = strlen(hex_str);
+	if (len % 8 != 0) {
+		fprintf(stderr,
+			"Error: Hex string length must be multiple of 8 (4 bytes per DWORD)\n");
+		return -1;
+	}
 
-    size_t num_dwords = len / 8;
-    if (num_dwords > max_dwords) {
-        fprintf(stderr, "Error: Too many DWORDs (%zu > %zu)\n", num_dwords, max_dwords);
-        return -1;
-    }
+	size_t num_dwords = len / 8;
+	if (num_dwords > max_dwords) {
+		fprintf(stderr, "Error: Too many DWORDs (%zu > %zu)\n", num_dwords, max_dwords);
+		return -1;
+	}
 
-    for (size_t i = 0; i < num_dwords; i++) {
-        char dword_str[9];
-        strncpy(dword_str, hex_str + i * 8, 8);
-        dword_str[8] = '\0';
+	for (size_t i = 0; i < num_dwords; i++) {
+		char dword_str[9];
+		strncpy(dword_str, hex_str + i * 8, 8);
+		dword_str[8] = '\0';
 
-        char* endptr;
-        dwords[i] = (uint32_t)strtoul(dword_str, &endptr, 16);
-        if (*endptr != '\0') {
-            fprintf(stderr, "Error: Invalid hex characters in DWORD %zu: %s\n", i, dword_str);
-            return -1;
-        }
-    }
+		char *endptr;
+		dwords[i] = (uint32_t)strtoul(dword_str, &endptr, 16);
+		if (*endptr != '\0') {
+			fprintf(stderr, "Error: Invalid hex characters in DWORD %zu: %s\n", i,
+				dword_str);
+			return -1;
+		}
+	}
 
-    return (int)num_dwords;
+	return (int)num_dwords;
 }
 
 /**
  * Parse PM4 packet header
  */
-static bool parse_pm4_header(uint32_t header_dword, pm4_header_t* header) {
-    header->type = (header_dword & PM4_TYPE3_MASK) >> 30;
-    header->opcode = (header_dword & PM4_OPCODE_MASK) >> PM4_OPCODE_SHIFT;
-    header->count = (header_dword & PM4_COUNT_MASK) >> PM4_COUNT_SHIFT;
-    header->size_dwords = header->count + 2; /* count = size - 2 */
+static bool parse_pm4_header(uint32_t header_dword, pm4_header_t *header)
+{
+	header->type = (header_dword & PM4_TYPE3_MASK) >> 30;
+	header->opcode = (header_dword & PM4_OPCODE_MASK) >> PM4_OPCODE_SHIFT;
+	header->count = (header_dword & PM4_COUNT_MASK) >> PM4_COUNT_SHIFT;
+	header->size_dwords = header->count + 2; /* count = size - 2 */
 
-    return (header->type == 3); /* Only support Type 3 packets */
+	return (header->type == 3); /* Only support Type 3 packets */
 }
 
 /**
  * Get opcode name string
  */
-static const char* get_opcode_name(uint32_t opcode) {
-    switch (opcode) {
-        case PM4_NOP:               return "NOP";
-        case PM4_ATOMIC_MEM:        return "ATOMIC_MEM";
-        case PM4_REG_RMW:           return "REG_RMW";
-        case PM4_PRED_EXEC:         return "PRED_EXEC";
-        case PM4_WRITE_DATA:        return "WRITE_DATA";
-        case PM4_WAIT_REG_MEM:      return "WAIT_REG_MEM";
-        case PM4_INDIRECT_BUFFER:   return "INDIRECT_BUFFER";
-        case PM4_COPY_DATA:         return "COPY_DATA";
-        case PM4_EVENT_WRITE:       return "EVENT_WRITE";
-        case PM4_ACQUIRE_MEM:       return "ACQUIRE_MEM";
-        case PM4_PRIME_UTCL2:       return "PRIME_UTCL2";
-        case PM4_SET_CONFIG_REG:    return "SET_CONFIG_REG";
-        case PM4_SET_CONTEXT_REG:   return "SET_CONTEXT_REG";
-        case PM4_SET_SH_REG:        return "SET_SH_REG";
-        case PM4_SET_QUEUE_REG:     return "SET_QUEUE_REG";
-        case PM4_SET_UCONFIG_REG:   return "SET_UCONFIG_REG";
-        default:                    return "UNKNOWN";
-    }
+static const char *get_opcode_name(uint32_t opcode)
+{
+	switch (opcode) {
+	case PM4_NOP:
+		return "NOP";
+	case PM4_ATOMIC_MEM:
+		return "ATOMIC_MEM";
+	case PM4_REG_RMW:
+		return "REG_RMW";
+	case PM4_PRED_EXEC:
+		return "PRED_EXEC";
+	case PM4_WRITE_DATA:
+		return "WRITE_DATA";
+	case PM4_WAIT_REG_MEM:
+		return "WAIT_REG_MEM";
+	case PM4_INDIRECT_BUFFER:
+		return "INDIRECT_BUFFER";
+	case PM4_COPY_DATA:
+		return "COPY_DATA";
+	case PM4_EVENT_WRITE:
+		return "EVENT_WRITE";
+	case PM4_ACQUIRE_MEM:
+		return "ACQUIRE_MEM";
+	case PM4_PRIME_UTCL2:
+		return "PRIME_UTCL2";
+	case PM4_SET_CONFIG_REG:
+		return "SET_CONFIG_REG";
+	case PM4_SET_CONTEXT_REG:
+		return "SET_CONTEXT_REG";
+	case PM4_SET_SH_REG:
+		return "SET_SH_REG";
+	case PM4_SET_QUEUE_REG:
+		return "SET_QUEUE_REG";
+	case PM4_SET_UCONFIG_REG:
+		return "SET_UCONFIG_REG";
+	default:
+		return "UNKNOWN";
+	}
 }
 
 /**
  * Decode NOP packet
  */
-static void decode_nop_packet(const uint32_t* dwords, const pm4_header_t* header) {
-    printf("NOP (count=%u)\n", header->count);
-    if (header->count > 0) {
-        printf("  Payload: ");
-        for (uint32_t i = 1; i <= header->count; i++) {
-            printf("0x%08x ", dwords[i]);
-        }
-        printf("\n");
-    }
+static void decode_nop_packet(const uint32_t *dwords, const pm4_header_t *header)
+{
+	printf("NOP (count=%u)\n", header->count);
+	if (header->count > 0) {
+		printf("  Payload: ");
+		for (uint32_t i = 1; i <= header->count; i++) {
+			printf("0x%08x ", dwords[i]);
+		}
+		printf("\n");
+	}
 }
 
 /**
  * Decode EVENT_WRITE packet
  */
-static void decode_event_write_packet(const uint32_t* dwords, const pm4_header_t* header) {
-    if (header->size_dwords < 2) {
-        printf("EVENT_WRITE (invalid size: %u)\n", header->size_dwords);
-        return;
-    }
+static void decode_event_write_packet(const uint32_t *dwords, const pm4_header_t *header)
+{
+	if (header->size_dwords < 2) {
+		printf("EVENT_WRITE (invalid size: %u)\n", header->size_dwords);
+		return;
+	}
 
-    uint32_t event_data = dwords[1];
-    uint32_t event_type = event_data & 0x3F;
-    uint32_t event_index = (event_data >> 8) & 0xF;
+	uint32_t event_data = dwords[1];
+	uint32_t event_type = event_data & 0x3F;
+	uint32_t event_index = (event_data >> 8) & 0xF;
 
-    printf("EVENT_WRITE\n");
-    printf("  Event Type: 0x%x", event_type);
-    switch (event_type) {
-        case 0x07: printf(" (CS_PARTIAL_FLUSH)"); break;
-        case 0x16: printf(" (CACHE_FLUSH_AND_INV_TS_EVENT)"); break;
-        default: break;
-    }
-    printf("\n");
-    printf("  Event Index: %u\n", event_index);
+	printf("EVENT_WRITE\n");
+	printf("  Event Type: 0x%x", event_type);
+	switch (event_type) {
+	case 0x07:
+		printf(" (CS_PARTIAL_FLUSH)");
+		break;
+	case 0x16:
+		printf(" (CACHE_FLUSH_AND_INV_TS_EVENT)");
+		break;
+	default:
+		break;
+	}
+	printf("\n");
+	printf("  Event Index: %u\n", event_index);
 }
 
 /**
  * Rebase a COPY_DATA packet destination address
  */
-static void rebase_copy_data_packet(uint32_t* dwords, const pm4_header_t* header) {
-    if (header->size_dwords < 6) {
-        return;
-    }
+static void rebase_copy_data_packet(uint32_t *dwords, const pm4_header_t *header)
+{
+	if (header->size_dwords < 6) {
+		return;
+	}
 
-    uint32_t flags = dwords[1];
-    uint32_t dst_sel = (flags >> 8) & 0xF;
+	uint32_t flags = dwords[1];
+	uint32_t dst_sel = (flags >> 8) & 0xF;
 
-    /* Only rebase memory destinations */
-    if (dst_sel == 0) {
-        return; /* Register destination, skip */
-    }
+	/* Only rebase memory destinations */
+	if (dst_sel == 0) {
+		return; /* Register destination, skip */
+	}
 
-    uint32_t dst_lo = dwords[4];
-    uint32_t dst_hi = dwords[5];
-    uint64_t dst_addr = ((uint64_t)dst_hi << 32) | dst_lo;
+	uint32_t dst_lo = dwords[4];
+	uint32_t dst_hi = dwords[5];
+	uint64_t dst_addr = ((uint64_t)dst_hi << 32) | dst_lo;
 
-    /* If this is the first COPY_DATA, capture the original base */
-    if (!g_rebase_state.base_found) {
-        g_rebase_state.original_base = dst_addr;
-        g_rebase_state.base_found = true;
-        fprintf(stderr, "Original base address: 0x%016lx\n", g_rebase_state.original_base);
-    }
+	/* If this is the first COPY_DATA, capture the original base */
+	if (!g_rebase_state.base_found) {
+		g_rebase_state.original_base = dst_addr;
+		g_rebase_state.base_found = true;
+		fprintf(stderr, "Original base address: 0x%016lx\n", g_rebase_state.original_base);
+	}
 
-    /* Calculate offset from original base */
-    uint64_t offset = dst_addr - g_rebase_state.original_base;
+	/* Calculate offset from original base */
+	uint64_t offset = dst_addr - g_rebase_state.original_base;
 
-    /* Apply new base address */
-    uint64_t new_addr = g_rebase_state.new_base + offset;
+	/* Apply new base address */
+	uint64_t new_addr = g_rebase_state.new_base + offset;
 
-    fprintf(stderr, "COPY_DATA: 0x%016lx -> 0x%016lx (offset: 0x%lx)\n",
-            dst_addr, new_addr, offset);
+	fprintf(stderr, "COPY_DATA: 0x%016lx -> 0x%016lx (offset: 0x%lx)\n", dst_addr, new_addr,
+		offset);
 
-    /* Update the packet */
-    dwords[4] = (uint32_t)(new_addr & 0xFFFFFFFF);
-    dwords[5] = (uint32_t)(new_addr >> 32);
+	/* Update the packet */
+	dwords[4] = (uint32_t)(new_addr & 0xFFFFFFFF);
+	dwords[5] = (uint32_t)(new_addr >> 32);
 }
 
 /**
  * Decode COPY_DATA packet
  */
-static void decode_copy_data_packet(const uint32_t* dwords, const pm4_header_t* header) {
-    if (header->size_dwords < 6) {
-        printf("COPY_DATA (invalid size: %u)\n", header->size_dwords);
-        return;
-    }
+static void decode_copy_data_packet(const uint32_t *dwords, const pm4_header_t *header)
+{
+	if (header->size_dwords < 6) {
+		printf("COPY_DATA (invalid size: %u)\n", header->size_dwords);
+		return;
+	}
 
-    uint32_t flags = dwords[1];
-    uint32_t src_sel = flags & 0xF;
-    uint32_t dst_sel = (flags >> 8) & 0xF;
-    uint32_t count_sel = (flags >> 16) & 0x1;
-    uint32_t wr_confirm = (flags >> 20) & 0x1;
+	uint32_t flags = dwords[1];
+	uint32_t src_sel = flags & 0xF;
+	uint32_t dst_sel = (flags >> 8) & 0xF;
+	uint32_t count_sel = (flags >> 16) & 0x1;
+	uint32_t wr_confirm = (flags >> 20) & 0x1;
 
-    uint32_t src_lo = dwords[2];
-    uint32_t src_hi = dwords[3];
-    uint32_t dst_lo = dwords[4];
-    uint32_t dst_hi = dwords[5];
+	uint32_t src_lo = dwords[2];
+	uint32_t src_hi = dwords[3];
+	uint32_t dst_lo = dwords[4];
+	uint32_t dst_hi = dwords[5];
 
-    printf("COPY_DATA\n");
-    printf("  Source: %s (0x%08x%08x)\n",
-           (src_sel == 0) ? "REGISTER" : "MEMORY", src_hi, src_lo);
-    printf("  Destination: %s (0x%08x%08x)\n",
-           (dst_sel == 0) ? "REGISTER" : "MEMORY", dst_hi, dst_lo);
-    printf("  Count Select: %u, Write Confirm: %u\n", count_sel, wr_confirm);
+	printf("COPY_DATA\n");
+	printf("  Source: %s (0x%08x%08x)\n", (src_sel == 0) ? "REGISTER" : "MEMORY", src_hi,
+	       src_lo);
+	printf("  Destination: %s (0x%08x%08x)\n", (dst_sel == 0) ? "REGISTER" : "MEMORY", dst_hi,
+	       dst_lo);
+	printf("  Count Select: %u, Write Confirm: %u\n", count_sel, wr_confirm);
 }
 
 /**
  * Rebase an ACQUIRE_MEM packet base address
  * Note: ACQUIRE_MEM base address is stored in bits [47:8], shifted right by 8
  */
-static void rebase_acquire_mem_packet(uint32_t* dwords, const pm4_header_t* header) {
-    if (header->size_dwords < 8) {
-        return;
-    }
+static void rebase_acquire_mem_packet(uint32_t *dwords, const pm4_header_t *header)
+{
+	if (header->size_dwords < 8) {
+		return;
+	}
 
-    /* ACQUIRE_MEM addresses are stored shifted right by 8 bits (256-byte aligned) */
-    uint32_t coher_base_lo = dwords[4];
-    uint32_t coher_base_hi = dwords[5];
-    uint64_t base_shifted = ((uint64_t)coher_base_hi << 32) | coher_base_lo;
-    uint64_t base_addr = base_shifted << 8; /* Actual address */
+	/* ACQUIRE_MEM addresses are stored shifted right by 8 bits (256-byte aligned) */
+	uint32_t coher_base_lo = dwords[4];
+	uint32_t coher_base_hi = dwords[5];
+	uint64_t base_shifted = ((uint64_t)coher_base_hi << 32) | coher_base_lo;
+	uint64_t base_addr = base_shifted << 8; /* Actual address */
 
-    if (!g_rebase_state.base_found) {
-        /* We need to establish the base from COPY_DATA first */
-        return;
-    }
+	if (!g_rebase_state.base_found) {
+		/* We need to establish the base from COPY_DATA first */
+		return;
+	}
 
-    /* Calculate offset from original base */
-    uint64_t offset = base_addr - g_rebase_state.original_base;
+	/* Calculate offset from original base */
+	uint64_t offset = base_addr - g_rebase_state.original_base;
 
-    /* Apply new base address */
-    uint64_t new_addr = g_rebase_state.new_base + offset;
+	/* Apply new base address */
+	uint64_t new_addr = g_rebase_state.new_base + offset;
 
-    fprintf(stderr, "ACQUIRE_MEM: 0x%016lx -> 0x%016lx (offset: 0x%lx)\n",
-            base_addr, new_addr, offset);
+	fprintf(stderr, "ACQUIRE_MEM: 0x%016lx -> 0x%016lx (offset: 0x%lx)\n", base_addr, new_addr,
+		offset);
 
-    /* Shift back and update the packet */
-    uint64_t new_addr_shifted = new_addr >> 8;
-    dwords[4] = (uint32_t)(new_addr_shifted & 0xFFFFFFFF);
-    dwords[5] = (uint32_t)(new_addr_shifted >> 32);
+	/* Shift back and update the packet */
+	uint64_t new_addr_shifted = new_addr >> 8;
+	dwords[4] = (uint32_t)(new_addr_shifted & 0xFFFFFFFF);
+	dwords[5] = (uint32_t)(new_addr_shifted >> 32);
 }
 
 /**
  * Decode ACQUIRE_MEM (cache flush) packet
  */
-static void decode_acquire_mem_packet(const uint32_t* dwords, const pm4_header_t* header) {
-    if (header->size_dwords < 8) {
-        printf("ACQUIRE_MEM (invalid size: %u)\n", header->size_dwords);
-        return;
-    }
+static void decode_acquire_mem_packet(const uint32_t *dwords, const pm4_header_t *header)
+{
+	if (header->size_dwords < 8) {
+		printf("ACQUIRE_MEM (invalid size: %u)\n", header->size_dwords);
+		return;
+	}
 
-    uint32_t coher_size_lo = dwords[2];
-    uint32_t coher_size_hi = dwords[3];
-    uint32_t coher_base_lo = dwords[4];
-    uint32_t coher_base_hi = dwords[5];
-    uint32_t poll_interval = dwords[6];
-    uint32_t gcr_cntl = dwords[7];
+	uint32_t coher_size_lo = dwords[2];
+	uint32_t coher_size_hi = dwords[3];
+	uint32_t coher_base_lo = dwords[4];
+	uint32_t coher_base_hi = dwords[5];
+	uint32_t poll_interval = dwords[6];
+	uint32_t gcr_cntl = dwords[7];
 
-    printf("ACQUIRE_MEM (Cache Flush)\n");
-    printf("  Base Address: 0x%08x%08x\n", coher_base_hi, coher_base_lo);
-    printf("  Size: 0x%08x%08x\n", coher_size_hi, coher_size_lo);
-    printf("  Poll Interval: 0x%x\n", poll_interval);
-    printf("  GCR Control: 0x%x", gcr_cntl);
-    if (gcr_cntl & 0x1) printf(" (GL2_WB)");
-    if (gcr_cntl & 0x2) printf(" (GL2_INV)");
-    printf("\n");
+	printf("ACQUIRE_MEM (Cache Flush)\n");
+	printf("  Base Address: 0x%08x%08x\n", coher_base_hi, coher_base_lo);
+	printf("  Size: 0x%08x%08x\n", coher_size_hi, coher_size_lo);
+	printf("  Poll Interval: 0x%x\n", poll_interval);
+	printf("  GCR Control: 0x%x", gcr_cntl);
+	if (gcr_cntl & 0x1)
+		printf(" (GL2_WB)");
+	if (gcr_cntl & 0x2)
+		printf(" (GL2_INV)");
+	printf("\n");
 }
 
 /**
  * Decode register write packets (SET_UCONFIG_REG, SET_SH_REG, SET_CONFIG_REG)
  */
-static void decode_reg_write_packet(const uint32_t* dwords, const pm4_header_t* header) {
-    if (header->size_dwords < 3) {
-        printf("%s (invalid size: %u)\n", get_opcode_name(header->opcode), header->size_dwords);
-        return;
-    }
+static void decode_reg_write_packet(const uint32_t *dwords, const pm4_header_t *header)
+{
+	if (header->size_dwords < 3) {
+		printf("%s (invalid size: %u)\n", get_opcode_name(header->opcode),
+		       header->size_dwords);
+		return;
+	}
 
-    uint32_t reg_offset = dwords[1] & 0xFFFF;
-    uint32_t num_regs = header->count - 1; /* header->count includes register offset */
+	uint32_t reg_offset = dwords[1] & 0xFFFF;
+	uint32_t num_regs = header->count - 1; /* header->count includes register offset */
 
-    const char* space_name = "UNKNOWN";
-    uint32_t base_addr = 0;
+	const char *space_name = "UNKNOWN";
+	uint32_t base_addr = 0;
 
-    switch (header->opcode) {
-        case PM4_SET_UCONFIG_REG:
-            space_name = "UCONFIG";
-            base_addr = 0xC000;
-            break;
-        case PM4_SET_SH_REG:
-            space_name = "SH";
-            base_addr = 0x2C00;
-            break;
-        case PM4_SET_CONFIG_REG:
-            space_name = "CONFIG";
-            base_addr = 0x2000;
-            break;
-        case PM4_SET_CONTEXT_REG:
-            space_name = "CONTEXT";
-            base_addr = 0xA000;
-            break;
-        case PM4_SET_QUEUE_REG:
-            space_name = "QUEUE";
-            base_addr = 0;
-            break;
-    }
+	switch (header->opcode) {
+	case PM4_SET_UCONFIG_REG:
+		space_name = "UCONFIG";
+		base_addr = 0xC000;
+		break;
+	case PM4_SET_SH_REG:
+		space_name = "SH";
+		base_addr = 0x2C00;
+		break;
+	case PM4_SET_CONFIG_REG:
+		space_name = "CONFIG";
+		base_addr = 0x2000;
+		break;
+	case PM4_SET_CONTEXT_REG:
+		space_name = "CONTEXT";
+		base_addr = 0xA000;
+		break;
+	case PM4_SET_QUEUE_REG:
+		space_name = "QUEUE";
+		base_addr = 0;
+		break;
+	}
 
-    printf("SET_%s_REG\n", space_name);
-    printf("  Base Register: 0x%x (absolute: 0x%x)\n", reg_offset, base_addr + reg_offset);
-    printf("  Register Count: %u\n", num_regs);
+	printf("SET_%s_REG\n", space_name);
+	printf("  Base Register: 0x%x (absolute: 0x%x)\n", reg_offset, base_addr + reg_offset);
+	printf("  Register Count: %u\n", num_regs);
 
-    for (uint32_t i = 0; i < num_regs; i++) {
-        if (2 + i < header->size_dwords) {
-            printf("  [%u] 0x%x = 0x%08x\n", i, base_addr + reg_offset + i, dwords[2 + i]);
-        }
-    }
+	for (uint32_t i = 0; i < num_regs; i++) {
+		if (2 + i < header->size_dwords) {
+			printf("  [%u] 0x%x = 0x%08x\n", i, base_addr + reg_offset + i,
+			       dwords[2 + i]);
+		}
+	}
 }
 
 /**
  * Decode WAIT_REG_MEM packet
  */
-static void decode_wait_reg_mem_packet(const uint32_t* dwords, const pm4_header_t* header) {
-    if (header->size_dwords < 6) {
-        printf("WAIT_REG_MEM (invalid size: %u)\n", header->size_dwords);
-        return;
-    }
+static void decode_wait_reg_mem_packet(const uint32_t *dwords, const pm4_header_t *header)
+{
+	if (header->size_dwords < 6) {
+		printf("WAIT_REG_MEM (invalid size: %u)\n", header->size_dwords);
+		return;
+	}
 
-    uint32_t flags = dwords[1];
-    uint32_t function = flags & 0x7;
-    uint32_t mem_space = (flags >> 4) & 0x3;
-    uint32_t operation = (flags >> 6) & 0x3;
+	uint32_t flags = dwords[1];
+	uint32_t function = flags & 0x7;
+	uint32_t mem_space = (flags >> 4) & 0x3;
+	uint32_t operation = (flags >> 6) & 0x3;
 
-    uint32_t poll_addr_lo = dwords[2];
-    uint32_t poll_addr_hi = dwords[3];
-    uint32_t reference = dwords[4];
-    uint32_t mask = dwords[5];
+	uint32_t poll_addr_lo = dwords[2];
+	uint32_t poll_addr_hi = dwords[3];
+	uint32_t reference = dwords[4];
+	uint32_t mask = dwords[5];
 
-    printf("WAIT_REG_MEM\n");
-    printf("  Address: 0x%08x%08x (%s space)\n", poll_addr_hi, poll_addr_lo,
-           (mem_space == 0) ? "REGISTER" : "MEMORY");
-    printf("  Function: %u, Operation: %u\n", function, operation);
-    printf("  Reference: 0x%08x, Mask: 0x%08x\n", reference, mask);
+	printf("WAIT_REG_MEM\n");
+	printf("  Address: 0x%08x%08x (%s space)\n", poll_addr_hi, poll_addr_lo,
+	       (mem_space == 0) ? "REGISTER" : "MEMORY");
+	printf("  Function: %u, Operation: %u\n", function, operation);
+	printf("  Reference: 0x%08x, Mask: 0x%08x\n", reference, mask);
 }
 
 /**
  * Decode WRITE_DATA packet
  */
-static void decode_write_data_packet(const uint32_t* dwords, const pm4_header_t* header) {
-    if (header->size_dwords < 4) {
-        printf("WRITE_DATA (invalid size: %u)\n", header->size_dwords);
-        return;
-    }
+static void decode_write_data_packet(const uint32_t *dwords, const pm4_header_t *header)
+{
+	if (header->size_dwords < 4) {
+		printf("WRITE_DATA (invalid size: %u)\n", header->size_dwords);
+		return;
+	}
 
-    uint32_t flags = dwords[1];
-    uint32_t dst_sel = (flags >> 8) & 0xF;
-    uint32_t addr_incr = (flags >> 16) & 0x1;
-    uint32_t wr_confirm = (flags >> 20) & 0x1;
+	uint32_t flags = dwords[1];
+	uint32_t dst_sel = (flags >> 8) & 0xF;
+	uint32_t addr_incr = (flags >> 16) & 0x1;
+	uint32_t wr_confirm = (flags >> 20) & 0x1;
 
-    uint32_t dst_addr_lo = dwords[2];
-    uint32_t dst_addr_hi = dwords[3];
+	uint32_t dst_addr_lo = dwords[2];
+	uint32_t dst_addr_hi = dwords[3];
 
-    printf("WRITE_DATA\n");
-    printf("  Destination: %s (0x%08x%08x)\n",
-           (dst_sel == 5) ? "MEMORY" : "REGISTER", dst_addr_hi, dst_addr_lo);
-    printf("  Address Increment: %u, Write Confirm: %u\n", addr_incr, wr_confirm);
+	printf("WRITE_DATA\n");
+	printf("  Destination: %s (0x%08x%08x)\n", (dst_sel == 5) ? "MEMORY" : "REGISTER",
+	       dst_addr_hi, dst_addr_lo);
+	printf("  Address Increment: %u, Write Confirm: %u\n", addr_incr, wr_confirm);
 
-    uint32_t data_count = header->count - 3; /* header, flags, addr_lo, addr_hi */
-    if (data_count > 0) {
-        printf("  Data (%u DWORDs): ", data_count);
-        for (uint32_t i = 0; i < data_count && (4 + i) < header->size_dwords; i++) {
-            printf("0x%08x ", dwords[4 + i]);
-        }
-        printf("\n");
-    }
+	uint32_t data_count = header->count - 3; /* header, flags, addr_lo, addr_hi */
+	if (data_count > 0) {
+		printf("  Data (%u DWORDs): ", data_count);
+		for (uint32_t i = 0; i < data_count && (4 + i) < header->size_dwords; i++) {
+			printf("0x%08x ", dwords[4 + i]);
+		}
+		printf("\n");
+	}
 }
 
 /**
  * Decode PRED_EXEC packet
  */
-static void decode_pred_exec_packet(const uint32_t* dwords, const pm4_header_t* header) {
-    if (header->size_dwords < 2) {
-        printf("PRED_EXEC (invalid size: %u)\n", header->size_dwords);
-        return;
-    }
+static void decode_pred_exec_packet(const uint32_t *dwords, const pm4_header_t *header)
+{
+	if (header->size_dwords < 2) {
+		printf("PRED_EXEC (invalid size: %u)\n", header->size_dwords);
+		return;
+	}
 
-    uint32_t start_addr = dwords[1];
-    printf("PRED_EXEC\n");
-    printf("  Start Address: 0x%08x\n", start_addr);
+	uint32_t start_addr = dwords[1];
+	printf("PRED_EXEC\n");
+	printf("  Start Address: 0x%08x\n", start_addr);
 
-    /* Size is count (excluding header), but avoid underflow */
-    if (header->count > 0) {
-        printf("  Payload Size: %u DWORDs\n", header->count);
-    } else {
-        printf("  Payload Size: 0 DWORDs\n");
-    }
+	/* Size is count (excluding header), but avoid underflow */
+	if (header->count > 0) {
+		printf("  Payload Size: %u DWORDs\n", header->count);
+	} else {
+		printf("  Payload Size: 0 DWORDs\n");
+	}
 }
 
 /**
  * Decode ATOMIC_MEM packet
  */
-static void decode_atomic_mem_packet(const uint32_t* dwords, const pm4_header_t* header) {
-    if (header->size_dwords < 9) {
-        printf("ATOMIC_MEM (invalid size: %u)\n", header->size_dwords);
-        return;
-    }
+static void decode_atomic_mem_packet(const uint32_t *dwords, const pm4_header_t *header)
+{
+	if (header->size_dwords < 9) {
+		printf("ATOMIC_MEM (invalid size: %u)\n", header->size_dwords);
+		return;
+	}
 
-    uint32_t flags = dwords[1];
-    uint32_t atomic_op = flags & 0x7F;
-    uint32_t command = (flags >> 8) & 0xF;
-    uint32_t cache_policy = (flags >> 25) & 0x3;
+	uint32_t flags = dwords[1];
+	uint32_t atomic_op = flags & 0x7F;
+	uint32_t command = (flags >> 8) & 0xF;
+	uint32_t cache_policy = (flags >> 25) & 0x3;
 
-    uint32_t addr_lo = dwords[2];
-    uint32_t addr_hi = dwords[3];
-    uint32_t src_data_lo = dwords[4];
-    uint32_t src_data_hi = dwords[5];
-    uint32_t cmp_data_lo = dwords[6];
-    uint32_t cmp_data_hi = dwords[7];
-    uint32_t loop_interval = dwords[8] & 0x1FFF;
+	uint32_t addr_lo = dwords[2];
+	uint32_t addr_hi = dwords[3];
+	uint32_t src_data_lo = dwords[4];
+	uint32_t src_data_hi = dwords[5];
+	uint32_t cmp_data_lo = dwords[6];
+	uint32_t cmp_data_hi = dwords[7];
+	uint32_t loop_interval = dwords[8] & 0x1FFF;
 
-    printf("ATOMIC_MEM\n");
-    printf("  Address: 0x%08x%08x\n", addr_hi, addr_lo);
-    printf("  Atomic Operation: %u", atomic_op);
-    switch (atomic_op) {
-        case 7: printf(" (SWAP)"); break;
-        case 8: printf(" (CMPSWAP)"); break;
-        default: break;
-    }
-    printf("\n");
-    printf("  Command: %u", command);
-    switch (command) {
-        case 0: printf(" (SINGLE_PASS)"); break;
-        case 1: printf(" (LOOP_UNTIL_COMPARE_SATISFIED)"); break;
-        case 2: printf(" (WAIT_FOR_WRITE_CONFIRMATION)"); break;
-        case 3: printf(" (SEND_AND_CONTINUE)"); break;
-        default: break;
-    }
-    printf("\n");
-    printf("  Cache Policy: %u", cache_policy);
-    switch (cache_policy) {
-        case 0: printf(" (LRU)"); break;
-        case 1: printf(" (STREAM)"); break;
-        case 2: printf(" (NOA)"); break;
-        case 3: printf(" (BYPASS)"); break;
-        default: break;
-    }
-    printf("\n");
-    printf("  Source Data: 0x%08x%08x\n", src_data_hi, src_data_lo);
-    printf("  Compare Data: 0x%08x%08x\n", cmp_data_hi, cmp_data_lo);
-    if (command == 1) {
-        printf("  Loop Interval: %u\n", loop_interval);
-    }
+	printf("ATOMIC_MEM\n");
+	printf("  Address: 0x%08x%08x\n", addr_hi, addr_lo);
+	printf("  Atomic Operation: %u", atomic_op);
+	switch (atomic_op) {
+	case 7:
+		printf(" (SWAP)");
+		break;
+	case 8:
+		printf(" (CMPSWAP)");
+		break;
+	default:
+		break;
+	}
+	printf("\n");
+	printf("  Command: %u", command);
+	switch (command) {
+	case 0:
+		printf(" (SINGLE_PASS)");
+		break;
+	case 1:
+		printf(" (LOOP_UNTIL_COMPARE_SATISFIED)");
+		break;
+	case 2:
+		printf(" (WAIT_FOR_WRITE_CONFIRMATION)");
+		break;
+	case 3:
+		printf(" (SEND_AND_CONTINUE)");
+		break;
+	default:
+		break;
+	}
+	printf("\n");
+	printf("  Cache Policy: %u", cache_policy);
+	switch (cache_policy) {
+	case 0:
+		printf(" (LRU)");
+		break;
+	case 1:
+		printf(" (STREAM)");
+		break;
+	case 2:
+		printf(" (NOA)");
+		break;
+	case 3:
+		printf(" (BYPASS)");
+		break;
+	default:
+		break;
+	}
+	printf("\n");
+	printf("  Source Data: 0x%08x%08x\n", src_data_hi, src_data_lo);
+	printf("  Compare Data: 0x%08x%08x\n", cmp_data_hi, cmp_data_lo);
+	if (command == 1) {
+		printf("  Loop Interval: %u\n", loop_interval);
+	}
 }
 
 /**
  * Decode INDIRECT_BUFFER packet
  */
-static void decode_indirect_buffer_packet(const uint32_t* dwords, const pm4_header_t* header) {
-    if (header->size_dwords < 4) {
-        printf("INDIRECT_BUFFER (invalid size: %u)\n", header->size_dwords);
-        return;
-    }
+static void decode_indirect_buffer_packet(const uint32_t *dwords, const pm4_header_t *header)
+{
+	if (header->size_dwords < 4) {
+		printf("INDIRECT_BUFFER (invalid size: %u)\n", header->size_dwords);
+		return;
+	}
 
-    uint32_t ib_base_lo = (dwords[1] & 0x3FFFFFFF) << 2;
-    uint32_t ib_base_hi = dwords[2];
-    uint32_t control = dwords[3];
+	uint32_t ib_base_lo = (dwords[1] & 0x3FFFFFFF) << 2;
+	uint32_t ib_base_hi = dwords[2];
+	uint32_t control = dwords[3];
 
-    uint32_t ib_size = control & 0xFFFFF;
-    uint32_t chain = (control >> 20) & 0x1;
-    uint32_t offload_polling = (control >> 21) & 0x1;
-    uint32_t valid = (control >> 23) & 0x1;
-    uint32_t vmid = (control >> 24) & 0xF;
-    uint32_t cache_policy = (control >> 28) & 0x3;
-    uint32_t priv = (control >> 31) & 0x1;
+	uint32_t ib_size = control & 0xFFFFF;
+	uint32_t chain = (control >> 20) & 0x1;
+	uint32_t offload_polling = (control >> 21) & 0x1;
+	uint32_t valid = (control >> 23) & 0x1;
+	uint32_t vmid = (control >> 24) & 0xF;
+	uint32_t cache_policy = (control >> 28) & 0x3;
+	uint32_t priv = (control >> 31) & 0x1;
 
-    printf("INDIRECT_BUFFER\n");
-    printf("  Buffer Address: 0x%08x%08x\n", ib_base_hi, ib_base_lo);
-    printf("  Buffer Size: %u DWORDs (%u bytes)\n", ib_size, ib_size * 4);
-    printf("  Valid: %u, Chain: %u, Offload Polling: %u\n", valid, chain, offload_polling);
-    printf("  VMID: %u, Privileged: %u\n", vmid, priv);
-    printf("  Cache Policy: %u", cache_policy);
-    switch (cache_policy) {
-        case 0: printf(" (LRU)"); break;
-        case 1: printf(" (STREAM)"); break;
-        case 2: printf(" (NOA)"); break;
-        case 3: printf(" (BYPASS)"); break;
-        default: break;
-    }
-    printf("\n");
+	printf("INDIRECT_BUFFER\n");
+	printf("  Buffer Address: 0x%08x%08x\n", ib_base_hi, ib_base_lo);
+	printf("  Buffer Size: %u DWORDs (%u bytes)\n", ib_size, ib_size * 4);
+	printf("  Valid: %u, Chain: %u, Offload Polling: %u\n", valid, chain, offload_polling);
+	printf("  VMID: %u, Privileged: %u\n", vmid, priv);
+	printf("  Cache Policy: %u", cache_policy);
+	switch (cache_policy) {
+	case 0:
+		printf(" (LRU)");
+		break;
+	case 1:
+		printf(" (STREAM)");
+		break;
+	case 2:
+		printf(" (NOA)");
+		break;
+	case 3:
+		printf(" (BYPASS)");
+		break;
+	default:
+		break;
+	}
+	printf("\n");
 }
 
 /**
  * Decode PRIME_UTCL2 packet
  */
-static void decode_prime_utcl2_packet(const uint32_t* dwords, const pm4_header_t* header) {
-    if (header->size_dwords < 6) {
-        printf("PRIME_UTCL2 (invalid size: %u)\n", header->size_dwords);
-        return;
-    }
+static void decode_prime_utcl2_packet(const uint32_t *dwords, const pm4_header_t *header)
+{
+	if (header->size_dwords < 6) {
+		printf("PRIME_UTCL2 (invalid size: %u)\n", header->size_dwords);
+		return;
+	}
 
-    uint32_t flags = dwords[1];
-    uint32_t cache_perm = (flags >> 0) & 0x3;
-    uint32_t prime_mode = (flags >> 2) & 0x1;
-    uint32_t addr_lo = dwords[2];
-    uint32_t addr_hi = dwords[3];
-    uint32_t requested_pages = dwords[4] & 0x3FFF;
+	uint32_t flags = dwords[1];
+	uint32_t cache_perm = (flags >> 0) & 0x3;
+	uint32_t prime_mode = (flags >> 2) & 0x1;
+	uint32_t addr_lo = dwords[2];
+	uint32_t addr_hi = dwords[3];
+	uint32_t requested_pages = dwords[4] & 0x3FFF;
 
-    printf("PRIME_UTCL2 (Prime UTCL2 Cache)\n");
-    printf("  Address: 0x%08x%08x\n", addr_hi, addr_lo);
-    printf("  Cache Permission: %u", cache_perm);
-    switch (cache_perm) {
-        case 0: printf(" (EXECUTE)"); break;
-        case 1: printf(" (WRITE)"); break;
-        case 2: printf(" (READ)"); break;
-        default: break;
-    }
-    printf("\n");
-    printf("  Prime Mode: %u", prime_mode);
-    switch (prime_mode) {
-        case 0: printf(" (DO_NOT_WAIT_FOR_XNACK)"); break;
-        case 1: printf(" (WAIT_FOR_XNACK)"); break;
-        default: break;
-    }
-    printf("\n");
-    printf("  Requested Pages: %u\n", requested_pages);
+	printf("PRIME_UTCL2 (Prime UTCL2 Cache)\n");
+	printf("  Address: 0x%08x%08x\n", addr_hi, addr_lo);
+	printf("  Cache Permission: %u", cache_perm);
+	switch (cache_perm) {
+	case 0:
+		printf(" (EXECUTE)");
+		break;
+	case 1:
+		printf(" (WRITE)");
+		break;
+	case 2:
+		printf(" (READ)");
+		break;
+	default:
+		break;
+	}
+	printf("\n");
+	printf("  Prime Mode: %u", prime_mode);
+	switch (prime_mode) {
+	case 0:
+		printf(" (DO_NOT_WAIT_FOR_XNACK)");
+		break;
+	case 1:
+		printf(" (WAIT_FOR_XNACK)");
+		break;
+	default:
+		break;
+	}
+	printf("\n");
+	printf("  Requested Pages: %u\n", requested_pages);
 }
 
 /**
  * Decode unknown packet
  */
-static void decode_unknown_packet(const uint32_t* dwords, const pm4_header_t* header) {
-    printf("UNKNOWN_PACKET (opcode=0x%02x, size=%u)\n", header->opcode, header->size_dwords);
-    printf("  Raw data: ");
-    for (uint32_t i = 0; i < header->size_dwords; i++) {
-        printf("0x%08x ", dwords[i]);
-    }
-    printf("\n");
+static void decode_unknown_packet(const uint32_t *dwords, const pm4_header_t *header)
+{
+	printf("UNKNOWN_PACKET (opcode=0x%02x, size=%u)\n", header->opcode, header->size_dwords);
+	printf("  Raw data: ");
+	for (uint32_t i = 0; i < header->size_dwords; i++) {
+		printf("0x%08x ", dwords[i]);
+	}
+	printf("\n");
 }
 
 /**
  * Rebase a single PM4 packet (modifies dwords in place)
  */
-static void rebase_pm4_packet(uint32_t* dwords, size_t num_dwords) {
-    if (num_dwords == 0) {
-        return;
-    }
+static void rebase_pm4_packet(uint32_t *dwords, size_t num_dwords)
+{
+	if (num_dwords == 0) {
+		return;
+	}
 
-    pm4_header_t header;
-    if (!parse_pm4_header(dwords[0], &header)) {
-        return;
-    }
+	pm4_header_t header;
+	if (!parse_pm4_header(dwords[0], &header)) {
+		return;
+	}
 
-    if (header.size_dwords > num_dwords) {
-        return;
-    }
+	if (header.size_dwords > num_dwords) {
+		return;
+	}
 
-    /* Apply rebasing based on opcode */
-    switch (header.opcode) {
-        case PM4_COPY_DATA:
-            rebase_copy_data_packet(dwords, &header);
-            break;
-        case PM4_ACQUIRE_MEM:
-            rebase_acquire_mem_packet(dwords, &header);
-            break;
-        default:
-            /* Other packet types don't need rebasing */
-            break;
-    }
+	/* Apply rebasing based on opcode */
+	switch (header.opcode) {
+	case PM4_COPY_DATA:
+		rebase_copy_data_packet(dwords, &header);
+		break;
+	case PM4_ACQUIRE_MEM:
+		rebase_acquire_mem_packet(dwords, &header);
+		break;
+	default:
+		/* Other packet types don't need rebasing */
+		break;
+	}
 }
 
 /**
  * Decode a single PM4 packet
  */
-static void decode_pm4_packet(const uint32_t* dwords, size_t num_dwords) {
-    if (num_dwords == 0) {
-        fprintf(stderr, "Error: Empty packet\n");
-        return;
-    }
+static void decode_pm4_packet(const uint32_t *dwords, size_t num_dwords)
+{
+	if (num_dwords == 0) {
+		fprintf(stderr, "Error: Empty packet\n");
+		return;
+	}
 
-    pm4_header_t header;
-    if (!parse_pm4_header(dwords[0], &header)) {
-        fprintf(stderr, "Error: Not a Type 3 PM4 packet (header=0x%08x)\n", dwords[0]);
-        return;
-    }
+	pm4_header_t header;
+	if (!parse_pm4_header(dwords[0], &header)) {
+		fprintf(stderr, "Error: Not a Type 3 PM4 packet (header=0x%08x)\n", dwords[0]);
+		return;
+	}
 
-    if (header.size_dwords > num_dwords) {
-        fprintf(stderr, "Error: Packet size mismatch (expected %u, got %zu)\n",
-                header.size_dwords, num_dwords);
-        return;
-    }
+	if (header.size_dwords > num_dwords) {
+		fprintf(stderr, "Error: Packet size mismatch (expected %u, got %zu)\n",
+			header.size_dwords, num_dwords);
+		return;
+	}
 
-    /* Dispatch to specific decoder based on opcode */
-    switch (header.opcode) {
-        case PM4_NOP:
-            decode_nop_packet(dwords, &header);
-            break;
-        case PM4_ATOMIC_MEM:
-            decode_atomic_mem_packet(dwords, &header);
-            break;
-        case PM4_EVENT_WRITE:
-            decode_event_write_packet(dwords, &header);
-            break;
-        case PM4_COPY_DATA:
-            decode_copy_data_packet(dwords, &header);
-            break;
-        case PM4_ACQUIRE_MEM:
-            decode_acquire_mem_packet(dwords, &header);
-            break;
-        case PM4_INDIRECT_BUFFER:
-            decode_indirect_buffer_packet(dwords, &header);
-            break;
-        case PM4_PRIME_UTCL2:
-            decode_prime_utcl2_packet(dwords, &header);
-            break;
-        case PM4_SET_UCONFIG_REG:
-        case PM4_SET_SH_REG:
-        case PM4_SET_CONFIG_REG:
-        case PM4_SET_CONTEXT_REG:
-        case PM4_SET_QUEUE_REG:
-            decode_reg_write_packet(dwords, &header);
-            break;
-        case PM4_WAIT_REG_MEM:
-            decode_wait_reg_mem_packet(dwords, &header);
-            break;
-        case PM4_WRITE_DATA:
-            decode_write_data_packet(dwords, &header);
-            break;
-        case PM4_PRED_EXEC:
-            decode_pred_exec_packet(dwords, &header);
-            break;
-        default:
-            decode_unknown_packet(dwords, &header);
-            break;
-    }
+	/* Dispatch to specific decoder based on opcode */
+	switch (header.opcode) {
+	case PM4_NOP:
+		decode_nop_packet(dwords, &header);
+		break;
+	case PM4_ATOMIC_MEM:
+		decode_atomic_mem_packet(dwords, &header);
+		break;
+	case PM4_EVENT_WRITE:
+		decode_event_write_packet(dwords, &header);
+		break;
+	case PM4_COPY_DATA:
+		decode_copy_data_packet(dwords, &header);
+		break;
+	case PM4_ACQUIRE_MEM:
+		decode_acquire_mem_packet(dwords, &header);
+		break;
+	case PM4_INDIRECT_BUFFER:
+		decode_indirect_buffer_packet(dwords, &header);
+		break;
+	case PM4_PRIME_UTCL2:
+		decode_prime_utcl2_packet(dwords, &header);
+		break;
+	case PM4_SET_UCONFIG_REG:
+	case PM4_SET_SH_REG:
+	case PM4_SET_CONFIG_REG:
+	case PM4_SET_CONTEXT_REG:
+	case PM4_SET_QUEUE_REG:
+		decode_reg_write_packet(dwords, &header);
+		break;
+	case PM4_WAIT_REG_MEM:
+		decode_wait_reg_mem_packet(dwords, &header);
+		break;
+	case PM4_WRITE_DATA:
+		decode_write_data_packet(dwords, &header);
+		break;
+	case PM4_PRED_EXEC:
+		decode_pred_exec_packet(dwords, &header);
+		break;
+	default:
+		decode_unknown_packet(dwords, &header);
+		break;
+	}
 }
 
 /**
  * Process multiple packets from a hex string (rebase mode)
  * Now also decodes and displays the rebased packets instead of just outputting hex
  */
-static void process_packet_string_rebase(const char* hex_str) {
-    /* Dynamically allocate buffer to avoid stack overflow with large MAX_PACKET_SIZE */
-    uint32_t* dwords = malloc(MAX_PACKET_SIZE * 4 * sizeof(uint32_t));
-    if (!dwords) {
-        fprintf(stderr, "Error: Failed to allocate memory for packet buffer\n");
-        return;
-    }
+static void process_packet_string_rebase(const char *hex_str)
+{
+	/* Dynamically allocate buffer to avoid stack overflow with large MAX_PACKET_SIZE */
+	uint32_t *dwords = malloc(MAX_PACKET_SIZE * 4 * sizeof(uint32_t));
+	if (!dwords) {
+		fprintf(stderr, "Error: Failed to allocate memory for packet buffer\n");
+		return;
+	}
 
-    int num_dwords = hex_string_to_dwords(hex_str, dwords, MAX_PACKET_SIZE * 4);
-    if (num_dwords <= 0) {
-        free(dwords);
-        return;
-    }
+	int num_dwords = hex_string_to_dwords(hex_str, dwords, MAX_PACKET_SIZE * 4);
+	if (num_dwords <= 0) {
+		free(dwords);
+		return;
+	}
 
-    size_t offset = 0;
-    size_t remaining = (size_t)num_dwords;
-    int packet_count = 0;
+	size_t offset = 0;
+	size_t remaining = (size_t)num_dwords;
+	int packet_count = 0;
 
-    /* Process all packets and apply rebasing */
-    while (remaining > 0) {
-        if (remaining < 1) {
-            fprintf(stderr, "Error: Incomplete packet data\n");
-            break;
-        }
+	/* Process all packets and apply rebasing */
+	while (remaining > 0) {
+		if (remaining < 1) {
+			fprintf(stderr, "Error: Incomplete packet data\n");
+			break;
+		}
 
-        pm4_header_t header;
-        if (!parse_pm4_header(dwords[offset], &header)) {
-            fprintf(stderr, "Error: Invalid PM4 header at offset %zu\n", offset);
-            break;
-        }
+		pm4_header_t header;
+		if (!parse_pm4_header(dwords[offset], &header)) {
+			fprintf(stderr, "Error: Invalid PM4 header at offset %zu\n", offset);
+			break;
+		}
 
-        if (header.size_dwords > remaining) {
-            fprintf(stderr, "Error: Packet extends beyond available data\n");
-            break;
-        }
+		if (header.size_dwords > remaining) {
+			fprintf(stderr, "Error: Packet extends beyond available data\n");
+			break;
+		}
 
-        /* Apply rebasing to this packet */
-        rebase_pm4_packet(&dwords[offset], header.size_dwords);
+		/* Apply rebasing to this packet */
+		rebase_pm4_packet(&dwords[offset], header.size_dwords);
 
-        /* Decode and display the rebased packet */
-        decode_pm4_packet(&dwords[offset], header.size_dwords);
+		/* Decode and display the rebased packet */
+		decode_pm4_packet(&dwords[offset], header.size_dwords);
 
-        offset += header.size_dwords;
-        remaining -= header.size_dwords;
-        packet_count++;
+		offset += header.size_dwords;
+		remaining -= header.size_dwords;
+		packet_count++;
 
-        if (remaining > 0) {
-            printf("---\n"); /* Separator between packets */
-        }
-    }
+		if (remaining > 0) {
+			printf("---\n"); /* Separator between packets */
+		}
+	}
 
-    free(dwords);
+	free(dwords);
 }
 
 /**
  * Process multiple packets from a hex string (decode mode)
  */
-static void process_packet_string(const char* hex_str) {
-    /* Dynamically allocate buffer to avoid stack overflow with large MAX_PACKET_SIZE */
-    uint32_t* dwords = malloc(MAX_PACKET_SIZE * 4 * sizeof(uint32_t));
-    if (!dwords) {
-        fprintf(stderr, "Error: Failed to allocate memory for packet buffer\n");
-        return;
-    }
+static void process_packet_string(const char *hex_str)
+{
+	/* Dynamically allocate buffer to avoid stack overflow with large MAX_PACKET_SIZE */
+	uint32_t *dwords = malloc(MAX_PACKET_SIZE * 4 * sizeof(uint32_t));
+	if (!dwords) {
+		fprintf(stderr, "Error: Failed to allocate memory for packet buffer\n");
+		return;
+	}
 
-    int num_dwords = hex_string_to_dwords(hex_str, dwords, MAX_PACKET_SIZE * 4);
-    if (num_dwords <= 0) {
-        free(dwords);
-        return;
-    }
+	int num_dwords = hex_string_to_dwords(hex_str, dwords, MAX_PACKET_SIZE * 4);
+	if (num_dwords <= 0) {
+		free(dwords);
+		return;
+	}
 
-    size_t offset = 0;
-    size_t remaining = (size_t)num_dwords;
+	size_t offset = 0;
+	size_t remaining = (size_t)num_dwords;
 
-    while (remaining > 0) {
-        if (remaining < 1) {
-            fprintf(stderr, "Error: Incomplete packet data\n");
-            break;
-        }
+	while (remaining > 0) {
+		if (remaining < 1) {
+			fprintf(stderr, "Error: Incomplete packet data\n");
+			break;
+		}
 
-        pm4_header_t header;
-        if (!parse_pm4_header(dwords[offset], &header)) {
-            fprintf(stderr, "Error: Invalid PM4 header at offset %zu\n", offset);
-            break;
-        }
+		pm4_header_t header;
+		if (!parse_pm4_header(dwords[offset], &header)) {
+			fprintf(stderr, "Error: Invalid PM4 header at offset %zu\n", offset);
+			break;
+		}
 
-        if (header.size_dwords > remaining) {
-            fprintf(stderr, "Error: Packet extends beyond available data\n");
-            break;
-        }
+		if (header.size_dwords > remaining) {
+			fprintf(stderr, "Error: Packet extends beyond available data\n");
+			break;
+		}
 
-        decode_pm4_packet(&dwords[offset], header.size_dwords);
+		decode_pm4_packet(&dwords[offset], header.size_dwords);
 
-        offset += header.size_dwords;
-        remaining -= header.size_dwords;
+		offset += header.size_dwords;
+		remaining -= header.size_dwords;
 
-        if (remaining > 0) {
-            printf("---\n"); /* Separator between packets */
-        }
-    }
+		if (remaining > 0) {
+			printf("---\n"); /* Separator between packets */
+		}
+	}
 
-    free(dwords);
+	free(dwords);
 }
 
 /**
  * Print usage information
  */
-static void print_usage(const char* prog_name) {
-    fprintf(stderr, "Usage: %s [OPTIONS]\n", prog_name);
-    fprintf(stderr, "\n");
-    fprintf(stderr, "PM4 packet decoder and address rebaser\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Options:\n");
-    fprintf(stderr, "  -r, --rebase <addr>  Rebase memory addresses to new base and decode\n");
-    fprintf(stderr, "  -h, --help           Show this help message\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Examples:\n");
-    fprintf(stderr, "  # Decode packets:\n");
-    fprintf(stderr, "  echo \"c001790000000200e0000000\" | %s\n", prog_name);
-    fprintf(stderr, "\n");
-    fprintf(stderr, "  # Rebase addresses to 0x0 and decode:\n");
-    fprintf(stderr, "  echo \"c0044000060062000000d38000000000124ec00000007266\" | %s --rebase 0x0\n", prog_name);
-    fprintf(stderr, "  # (Will show COPY_DATA with destination 0x0000000000000000)\n");
+static void print_usage(const char *prog_name)
+{
+	fprintf(stderr, "Usage: %s [OPTIONS]\n", prog_name);
+	fprintf(stderr, "\n");
+	fprintf(stderr, "PM4 packet decoder and address rebaser\n");
+	fprintf(stderr, "\n");
+	fprintf(stderr, "Options:\n");
+	fprintf(stderr, "  -r, --rebase <addr>  Rebase memory addresses to new base and decode\n");
+	fprintf(stderr, "  -h, --help           Show this help message\n");
+	fprintf(stderr, "\n");
+	fprintf(stderr, "Examples:\n");
+	fprintf(stderr, "  # Decode packets:\n");
+	fprintf(stderr, "  echo \"c001790000000200e0000000\" | %s\n", prog_name);
+	fprintf(stderr, "\n");
+	fprintf(stderr, "  # Rebase addresses to 0x0 and decode:\n");
+	fprintf(stderr,
+		"  echo \"c0044000060062000000d38000000000124ec00000007266\" | %s --rebase 0x0\n",
+		prog_name);
+	fprintf(stderr, "  # (Will show COPY_DATA with destination 0x0000000000000000)\n");
 }
 
 /**
  * Main function - read hex strings from stdin and decode them
  */
-int main(int argc, char** argv) {
-    /* Parse command-line arguments */
-    static struct option long_options[] = {
-        {"rebase", required_argument, 0, 'r'},
-        {"help",   no_argument,       0, 'h'},
-        {0, 0, 0, 0}
-    };
+int main(int argc, char **argv)
+{
+	/* Parse command-line arguments */
+	static struct option long_options[] = { { "rebase", required_argument, 0, 'r' },
+						{ "help", no_argument, 0, 'h' },
+						{ 0, 0, 0, 0 } };
 
-    int opt;
-    while ((opt = getopt_long(argc, argv, "r:h", long_options, NULL)) != -1) {
-        switch (opt) {
-            case 'r': {
-                /* Parse rebase address */
-                char* endptr;
-                g_rebase_state.new_base = strtoull(optarg, &endptr, 16);
-                if (*endptr != '\0') {
-                    fprintf(stderr, "Error: Invalid rebase address: %s\n", optarg);
-                    return 1;
-                }
-                g_rebase_state.enabled = true;
-                fprintf(stderr, "Rebasing to new base address: 0x%016lx\n", g_rebase_state.new_base);
-                break;
-            }
-            case 'h':
-                print_usage(argv[0]);
-                return 0;
-            default:
-                print_usage(argv[0]);
-                return 1;
-        }
-    }
+	int opt;
+	while ((opt = getopt_long(argc, argv, "r:h", long_options, NULL)) != -1) {
+		switch (opt) {
+		case 'r': {
+			/* Parse rebase address */
+			char *endptr;
+			g_rebase_state.new_base = strtoull(optarg, &endptr, 16);
+			if (*endptr != '\0') {
+				fprintf(stderr, "Error: Invalid rebase address: %s\n", optarg);
+				return 1;
+			}
+			g_rebase_state.enabled = true;
+			fprintf(stderr, "Rebasing to new base address: 0x%016lx\n",
+				g_rebase_state.new_base);
+			break;
+		}
+		case 'h':
+			print_usage(argv[0]);
+			return 0;
+		default:
+			print_usage(argv[0]);
+			return 1;
+		}
+	}
 
-    char line[65536]; /* Increased from 4096 to 64KB to handle large hex strings */
+	char line[65536]; /* Increased from 4096 to 64KB to handle large hex strings */
 
-    while (fgets(line, sizeof(line), stdin) != NULL) {
-        /* Remove trailing newline */
-        size_t len = strlen(line);
-        while (len > 0 && (line[len-1] == '\n' || line[len-1] == '\r')) {
-            line[--len] = '\0';
-        }
+	while (fgets(line, sizeof(line), stdin) != NULL) {
+		/* Remove trailing newline */
+		size_t len = strlen(line);
+		while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r')) {
+			line[--len] = '\0';
+		}
 
-        /* Skip empty lines */
-        if (len == 0) {
-            continue;
-        }
+		/* Skip empty lines */
+		if (len == 0) {
+			continue;
+		}
 
-        /* Skip lines that don't look like hex */
-        bool valid_hex = true;
-        for (size_t i = 0; i < len; i++) {
-            if (!isxdigit(line[i])) {
-                valid_hex = false;
-                break;
-            }
-        }
+		/* Skip lines that don't look like hex */
+		bool valid_hex = true;
+		for (size_t i = 0; i < len; i++) {
+			if (!isxdigit(line[i])) {
+				valid_hex = false;
+				break;
+			}
+		}
 
-        if (!valid_hex) {
-            fprintf(stderr, "Error: Invalid hex string: %s\n", line);
-            continue;
-        }
+		if (!valid_hex) {
+			fprintf(stderr, "Error: Invalid hex string: %s\n", line);
+			continue;
+		}
 
-        /* Process based on mode */
-        if (g_rebase_state.enabled) {
-            process_packet_string_rebase(line);
-            printf("\n");
-        } else {
-            process_packet_string(line);
-            printf("\n");
-        }
-    }
+		/* Process based on mode */
+		if (g_rebase_state.enabled) {
+			process_packet_string_rebase(line);
+			printf("\n");
+		} else {
+			process_packet_string(line);
+			printf("\n");
+		}
+	}
 
-    return 0;
+	return 0;
 }

--- a/projects/perf-dkms/src/aql_error_recovery.c
+++ b/projects/perf-dkms/src/aql_error_recovery.c
@@ -24,29 +24,30 @@
  */
 static void aql_perf_disable_gpu(struct aql_perf_session *session, uint32_t gpu_id)
 {
-    struct aql_measurement *measurement, *tmp;
-    unsigned long flags;
+	struct aql_measurement *measurement, *tmp;
+	unsigned long flags;
 
-    aql_info("Session %llu: Disabling faulty GPU %u", session->session_id, gpu_id);
+	aql_info("Session %llu: Disabling faulty GPU %u", session->session_id, gpu_id);
 
-    /* Stop all measurements on this GPU */
-    spin_lock_irqsave(&session->measurement_lock, flags);
+	/* Stop all measurements on this GPU */
+	spin_lock_irqsave(&session->measurement_lock, flags);
 
-    list_for_each_entry_safe(measurement, tmp, &session->active_measurements, list) {
-        if (measurement->gpu_id == gpu_id) {
-            measurement->state = MEASUREMENT_ERROR;
-            list_del_init(&measurement->list);
-            atomic_dec(&session->active_gpu_count);
+	list_for_each_entry_safe(measurement, tmp, &session->active_measurements, list)
+	{
+		if (measurement->gpu_id == gpu_id) {
+			measurement->state = MEASUREMENT_ERROR;
+			list_del_init(&measurement->list);
+			atomic_dec(&session->active_gpu_count);
 
-            aql_debug("Session %llu: Stopped measurement on disabled GPU %u",
-                      session->session_id, gpu_id);
-        }
-    }
+			aql_debug("Session %llu: Stopped measurement on disabled GPU %u",
+				  session->session_id, gpu_id);
+		}
+	}
 
-    spin_unlock_irqrestore(&session->measurement_lock, flags);
+	spin_unlock_irqrestore(&session->measurement_lock, flags);
 
-    /* Mark GPU as disabled in error mask */
-    set_bit(gpu_id, &session->recovery.error_mask);
+	/* Mark GPU as disabled in error mask */
+	set_bit(gpu_id, &session->recovery.error_mask);
 }
 
 /**
@@ -55,22 +56,23 @@ static void aql_perf_disable_gpu(struct aql_perf_session *session, uint32_t gpu_
  */
 static void aql_perf_stop_all_measurements(struct aql_perf_session *session)
 {
-    struct aql_measurement *measurement, *tmp;
-    unsigned long flags;
+	struct aql_measurement *measurement, *tmp;
+	unsigned long flags;
 
-    aql_debug("Session %llu: Stopping all active measurements", session->session_id);
+	aql_debug("Session %llu: Stopping all active measurements", session->session_id);
 
-    spin_lock_irqsave(&session->measurement_lock, flags);
+	spin_lock_irqsave(&session->measurement_lock, flags);
 
-    list_for_each_entry_safe(measurement, tmp, &session->active_measurements, list) {
-        measurement->state = MEASUREMENT_ERROR;
-        list_del_init(&measurement->list);
-        atomic_dec(&session->active_gpu_count);
-    }
+	list_for_each_entry_safe(measurement, tmp, &session->active_measurements, list)
+	{
+		measurement->state = MEASUREMENT_ERROR;
+		list_del_init(&measurement->list);
+		atomic_dec(&session->active_gpu_count);
+	}
 
-    spin_unlock_irqrestore(&session->measurement_lock, flags);
+	spin_unlock_irqrestore(&session->measurement_lock, flags);
 
-    aql_debug("Session %llu: All measurements stopped", session->session_id);
+	aql_debug("Session %llu: All measurements stopped", session->session_id);
 }
 
 /**
@@ -81,82 +83,84 @@ static void aql_perf_stop_all_measurements(struct aql_perf_session *session)
  */
 static int aql_perf_reinitialize_session(struct aql_perf_session *session)
 {
-    int ret;
+	int ret;
 
-    aql_info("Session %llu: Attempting session reinitialization", session->session_id);
+	aql_info("Session %llu: Attempting session reinitialization", session->session_id);
 
-    /* Stop all active measurements first */
-    aql_perf_stop_all_measurements(session);
+	/* Stop all active measurements first */
+	aql_perf_stop_all_measurements(session);
 
-    /* Free existing counter buffers for all GPUs */
-    if (session->archs && session->num_gpus > 0) {
-        for (uint32_t i = 0; i < session->num_gpus; i++) {
-            if (session->archs[i]) {
-                aql_perf_free_counter_buffers(session->archs[i], session->kfd_file,
-                                              session->process, session->gpu_ids[i]);
-            }
-        }
-    }
+	/* Free existing counter buffers for all GPUs */
+	if (session->archs && session->num_gpus > 0) {
+		for (uint32_t i = 0; i < session->num_gpus; i++) {
+			if (session->archs[i]) {
+				aql_perf_free_counter_buffers(session->archs[i], session->kfd_file,
+							      session->process,
+							      session->gpu_ids[i]);
+			}
+		}
+	}
 
-    /* Close existing KFD file */
-    if (session->kfd_file) {
-        filp_close(session->kfd_file, NULL);
-        session->kfd_file = NULL;
-        session->process = NULL;
-    }
+	/* Close existing KFD file */
+	if (session->kfd_file) {
+		filp_close(session->kfd_file, NULL);
+		session->kfd_file = NULL;
+		session->process = NULL;
+	}
 
-    /* Clear error mask */
-    session->recovery.error_mask = 0;
+	/* Clear error mask */
+	session->recovery.error_mask = 0;
 
-    /* Re-open KFD device */
-    session->kfd_file = filp_open("/dev/kfd", O_RDWR, 0);
-    if (IS_ERR(session->kfd_file)) {
-        ret = PTR_ERR(session->kfd_file);
-        aql_err("Session %llu: Failed to reopen /dev/kfd during recovery: %d",
-                session->session_id, ret);
-        session->kfd_file = NULL;
-        return ret;
-    }
+	/* Re-open KFD device */
+	session->kfd_file = filp_open("/dev/kfd", O_RDWR, 0);
+	if (IS_ERR(session->kfd_file)) {
+		ret = PTR_ERR(session->kfd_file);
+		aql_err("Session %llu: Failed to reopen /dev/kfd during recovery: %d",
+			session->session_id, ret);
+		session->kfd_file = NULL;
+		return ret;
+	}
 
-    /* Extract kfd_process */
-    session->process = session->kfd_file->private_data;
-    if (!session->process) {
-        aql_err("Session %llu: No kfd_process found during recovery",
-                session->session_id);
-        filp_close(session->kfd_file, NULL);
-        session->kfd_file = NULL;
-        return -EINVAL;
-    }
+	/* Extract kfd_process */
+	session->process = session->kfd_file->private_data;
+	if (!session->process) {
+		aql_err("Session %llu: No kfd_process found during recovery", session->session_id);
+		filp_close(session->kfd_file, NULL);
+		session->kfd_file = NULL;
+		return -EINVAL;
+	}
 
-    /* Rediscover GPUs */
-    kfree(session->gpu_ids);
-    session->gpu_ids = NULL;
-    session->num_gpus = 0;
+	/* Rediscover GPUs */
+	kfree(session->gpu_ids);
+	session->gpu_ids = NULL;
+	session->num_gpus = 0;
 
-    ret = aql_perf_discover_gpus(session);
-    if (ret) {
-        aql_err("Session %llu: GPU rediscovery failed during recovery: %d",
-                session->session_id, ret);
-        return ret;
-    }
+	ret = aql_perf_discover_gpus(session);
+	if (ret) {
+		aql_err("Session %llu: GPU rediscovery failed during recovery: %d",
+			session->session_id, ret);
+		return ret;
+	}
 
-    /* Reallocate counter buffers for all GPU architectures */
-    if (session->archs && session->num_gpus > 0) {
-        for (uint32_t i = 0; i < session->num_gpus; i++) {
-            if (session->archs[i]) {
-                ret = aql_perf_allocate_counter_buffers(session->archs[i], session->kfd_file,
-                                                        session->process, session->gpu_ids[i]);
-                if (ret) {
-                    aql_err("Session %llu: Counter buffer reallocation failed for GPU %u during recovery: %d",
-                            session->session_id, session->gpu_ids[i], ret);
-                    return ret;
-                }
-            }
-        }
-    }
+	/* Reallocate counter buffers for all GPU architectures */
+	if (session->archs && session->num_gpus > 0) {
+		for (uint32_t i = 0; i < session->num_gpus; i++) {
+			if (session->archs[i]) {
+				ret = aql_perf_allocate_counter_buffers(session->archs[i],
+									session->kfd_file,
+									session->process,
+									session->gpu_ids[i]);
+				if (ret) {
+					aql_err("Session %llu: Counter buffer reallocation failed for GPU %u during recovery: %d",
+						session->session_id, session->gpu_ids[i], ret);
+					return ret;
+				}
+			}
+		}
+	}
 
-    aql_info("Session %llu: Session reinitialization successful", session->session_id);
-    return 0;
+	aql_info("Session %llu: Session reinitialization successful", session->session_id);
+	return 0;
 }
 
 /**
@@ -164,100 +168,100 @@ static int aql_perf_reinitialize_session(struct aql_perf_session *session)
  * @session: AQL performance session
  * @error: Error context
  */
-void aql_perf_handle_error(struct aql_perf_session *session,
-                          struct aql_error_context *error)
+void aql_perf_handle_error(struct aql_perf_session *session, struct aql_error_context *error)
 {
-    if (!session || !error) {
-        aql_err("Invalid parameters for error handling");
-        return;
-    }
+	if (!session || !error) {
+		aql_err("Invalid parameters for error handling");
+		return;
+	}
 
-    aql_err("Session %llu: Handling error - severity=%d, gpu_id=%u, code=%d, msg='%s'",
-            session->session_id, error->severity, error->gpu_id,
-            error->error_code, error->error_msg);
+	aql_err("Session %llu: Handling error - severity=%d, gpu_id=%u, code=%d, msg='%s'",
+		session->session_id, error->severity, error->gpu_id, error->error_code,
+		error->error_msg);
 
-    /* Update error statistics */
-    atomic64_inc(&session->stats.errors_total);
+	/* Update error statistics */
+	atomic64_inc(&session->stats.errors_total);
 
-    switch (error->severity) {
-    case AQL_ERROR_RECOVERABLE:
-        /* Simple retry with exponential backoff */
-        if (session->recovery.recovery_attempts < AQL_PERF_MAX_RECOVERY_ATTEMPTS) {
-            unsigned long delay = msecs_to_jiffies(100 << session->recovery.recovery_attempts);
+	switch (error->severity) {
+	case AQL_ERROR_RECOVERABLE:
+		/* Simple retry with exponential backoff */
+		if (session->recovery.recovery_attempts < AQL_PERF_MAX_RECOVERY_ATTEMPTS) {
+			unsigned long delay =
+				msecs_to_jiffies(100 << session->recovery.recovery_attempts);
 
-            aql_info("Session %llu: Scheduling recoverable error retry (attempt %d)",
-                     session->session_id, session->recovery.recovery_attempts + 1);
+			aql_info("Session %llu: Scheduling recoverable error retry (attempt %d)",
+				 session->session_id, session->recovery.recovery_attempts + 1);
 
-            schedule_delayed_work(&session->recovery.recovery_work, delay);
-            session->recovery.recovery_attempts++;
-        } else {
-            aql_err("Session %llu: Max recovery attempts exceeded for recoverable error",
-                    session->session_id);
+			schedule_delayed_work(&session->recovery.recovery_work, delay);
+			session->recovery.recovery_attempts++;
+		} else {
+			aql_err("Session %llu: Max recovery attempts exceeded for recoverable error",
+				session->session_id);
 
-            /* Escalate to system fault */
-            error->severity = AQL_ERROR_SYSTEM_FAULT;
-            aql_perf_handle_error(session, error);
-        }
-        break;
+			/* Escalate to system fault */
+			error->severity = AQL_ERROR_SYSTEM_FAULT;
+			aql_perf_handle_error(session, error);
+		}
+		break;
 
-    case AQL_ERROR_GPU_FAULT:
-        /* Isolate the faulty GPU */
-        aql_perf_disable_gpu(session, error->gpu_id);
-        aql_info("Session %llu: GPU %u disabled due to fault: %s",
-                 session->session_id, error->gpu_id, error->error_msg);
+	case AQL_ERROR_GPU_FAULT:
+		/* Isolate the faulty GPU */
+		aql_perf_disable_gpu(session, error->gpu_id);
+		aql_info("Session %llu: GPU %u disabled due to fault: %s", session->session_id,
+			 error->gpu_id, error->error_msg);
 
-        /* If all GPUs are disabled, escalate to system fault */
-        if (hweight_long(session->recovery.error_mask) >= session->num_gpus) {
-            aql_err("Session %llu: All GPUs disabled, escalating to system fault",
-                    session->session_id);
-            error->severity = AQL_ERROR_SYSTEM_FAULT;
-            aql_perf_handle_error(session, error);
-        }
-        break;
+		/* If all GPUs are disabled, escalate to system fault */
+		if (hweight_long(session->recovery.error_mask) >= session->num_gpus) {
+			aql_err("Session %llu: All GPUs disabled, escalating to system fault",
+				session->session_id);
+			error->severity = AQL_ERROR_SYSTEM_FAULT;
+			aql_perf_handle_error(session, error);
+		}
+		break;
 
-    case AQL_ERROR_SYSTEM_FAULT:
-        /* Reset the entire session */
-        mutex_lock(&session->session_mutex);
+	case AQL_ERROR_SYSTEM_FAULT:
+		/* Reset the entire session */
+		mutex_lock(&session->session_mutex);
 
-        if (session->state != SESSION_ERROR) {
-            aql_info("Session %llu: System fault detected, stopping all measurements",
-                     session->session_id);
-            session->state = SESSION_ERROR;
-            aql_perf_stop_all_measurements(session);
-        }
+		if (session->state != SESSION_ERROR) {
+			aql_info("Session %llu: System fault detected, stopping all measurements",
+				 session->session_id);
+			session->state = SESSION_ERROR;
+			aql_perf_stop_all_measurements(session);
+		}
 
-        /* Schedule recovery work */
-        if (session->recovery.recovery_attempts < AQL_PERF_MAX_RECOVERY_ATTEMPTS) {
-            schedule_delayed_work(&session->recovery.recovery_work,
-                                 msecs_to_jiffies(1000));
-            aql_info("Session %llu: Scheduled system recovery (attempt %d)",
-                     session->session_id, session->recovery.recovery_attempts + 1);
-        } else {
-            aql_err("Session %llu: Max system recovery attempts exceeded",
-                    session->session_id);
-            error->severity = AQL_ERROR_PERMANENT;
-            aql_perf_handle_error(session, error);
-        }
+		/* Schedule recovery work */
+		if (session->recovery.recovery_attempts < AQL_PERF_MAX_RECOVERY_ATTEMPTS) {
+			schedule_delayed_work(&session->recovery.recovery_work,
+					      msecs_to_jiffies(1000));
+			aql_info("Session %llu: Scheduled system recovery (attempt %d)",
+				 session->session_id, session->recovery.recovery_attempts + 1);
+		} else {
+			aql_err("Session %llu: Max system recovery attempts exceeded",
+				session->session_id);
+			error->severity = AQL_ERROR_PERMANENT;
+			aql_perf_handle_error(session, error);
+		}
 
-        mutex_unlock(&session->session_mutex);
-        break;
+		mutex_unlock(&session->session_mutex);
+		break;
 
-    case AQL_ERROR_PERMANENT:
-        /* Disable AQL feature entirely */
-        mutex_lock(&session->session_mutex);
-        session->state = SESSION_ERROR;
-        aql_perf_stop_all_measurements(session);
-        mutex_unlock(&session->session_mutex);
+	case AQL_ERROR_PERMANENT:
+		/* Disable AQL feature entirely */
+		mutex_lock(&session->session_mutex);
+		session->state = SESSION_ERROR;
+		aql_perf_stop_all_measurements(session);
+		mutex_unlock(&session->session_mutex);
 
-        aql_err("Session %llu: Permanent error detected, AQL performance monitoring disabled",
-                session->session_id);
-        break;
+		aql_err("Session %llu: Permanent error detected, AQL performance monitoring disabled",
+			session->session_id);
+		break;
 
-    default:
-        aql_err("Session %llu: Unknown error severity %d",
-                session->session_id, error->severity);
-        break;
-    }
+	default:
+		aql_err("Session %llu: Unknown error severity %d", session->session_id,
+			error->severity);
+		break;
+	}
 }
 
 /**
@@ -266,59 +270,60 @@ void aql_perf_handle_error(struct aql_perf_session *session,
  */
 void aql_perf_recovery_work(struct work_struct *work)
 {
-    struct aql_perf_session *session = container_of(work, struct aql_perf_session,
-                                                    recovery.recovery_work.work);
-    int ret;
+	struct aql_perf_session *session =
+		container_of(work, struct aql_perf_session, recovery.recovery_work.work);
+	int ret;
 
-    aql_info("Session %llu: Starting recovery work (attempt %d)",
-             session->session_id, session->recovery.recovery_attempts);
+	aql_info("Session %llu: Starting recovery work (attempt %d)", session->session_id,
+		 session->recovery.recovery_attempts);
 
-    mutex_lock(&session->session_mutex);
+	mutex_lock(&session->session_mutex);
 
-    if (session->state == SESSION_ERROR) {
-        /* Attempt to reinitialize the session */
-        ret = aql_perf_reinitialize_session(session);
-        if (ret == 0) {
-            session->state = SESSION_ACTIVE;
-            session->recovery.recovery_attempts = 0;
-            aql_info("Session %llu: Recovery successful", session->session_id);
-        } else {
-            session->recovery.recovery_attempts++;
+	if (session->state == SESSION_ERROR) {
+		/* Attempt to reinitialize the session */
+		ret = aql_perf_reinitialize_session(session);
+		if (ret == 0) {
+			session->state = SESSION_ACTIVE;
+			session->recovery.recovery_attempts = 0;
+			aql_info("Session %llu: Recovery successful", session->session_id);
+		} else {
+			session->recovery.recovery_attempts++;
 
-            if (session->recovery.recovery_attempts < AQL_PERF_MAX_RECOVERY_ATTEMPTS) {
-                /* Retry recovery with longer delay */
-                unsigned long delay = msecs_to_jiffies(5000 * session->recovery.recovery_attempts);
-                schedule_delayed_work(&session->recovery.recovery_work, delay);
+			if (session->recovery.recovery_attempts < AQL_PERF_MAX_RECOVERY_ATTEMPTS) {
+				/* Retry recovery with longer delay */
+				unsigned long delay = msecs_to_jiffies(
+					5000 * session->recovery.recovery_attempts);
+				schedule_delayed_work(&session->recovery.recovery_work, delay);
 
-                aql_info("Session %llu: Recovery failed (attempt %d), retrying in %ums",
-                         session->session_id, session->recovery.recovery_attempts,
-                         jiffies_to_msecs(delay));
-            } else {
-                /* Give up after max attempts */
-                struct aql_error_context error = {
-                    .severity = AQL_ERROR_PERMANENT,
-                    .gpu_id = 0,
-                    .error_code = ret,
-                    .timestamp = ktime_get()
-                };
-                snprintf(error.error_msg, sizeof(error.error_msg),
-                        "Recovery failed after %d attempts", AQL_PERF_MAX_RECOVERY_ATTEMPTS);
+				aql_info(
+					"Session %llu: Recovery failed (attempt %d), retrying in %ums",
+					session->session_id, session->recovery.recovery_attempts,
+					jiffies_to_msecs(delay));
+			} else {
+				/* Give up after max attempts */
+				struct aql_error_context error = { .severity = AQL_ERROR_PERMANENT,
+								   .gpu_id = 0,
+								   .error_code = ret,
+								   .timestamp = ktime_get() };
+				snprintf(error.error_msg, sizeof(error.error_msg),
+					 "Recovery failed after %d attempts",
+					 AQL_PERF_MAX_RECOVERY_ATTEMPTS);
 
-                aql_err("Session %llu: Recovery failed after %d attempts",
-                        session->session_id, AQL_PERF_MAX_RECOVERY_ATTEMPTS);
+				aql_err("Session %llu: Recovery failed after %d attempts",
+					session->session_id, AQL_PERF_MAX_RECOVERY_ATTEMPTS);
 
-                /* Handle as permanent error */
-                mutex_unlock(&session->session_mutex);
-                aql_perf_handle_error(session, &error);
-                return;
-            }
-        }
-    } else {
-        aql_debug("Session %llu: Recovery work called but session state is %d",
-                  session->session_id, session->state);
-    }
+				/* Handle as permanent error */
+				mutex_unlock(&session->session_mutex);
+				aql_perf_handle_error(session, &error);
+				return;
+			}
+		}
+	} else {
+		aql_debug("Session %llu: Recovery work called but session state is %d",
+			  session->session_id, session->state);
+	}
 
-    mutex_unlock(&session->session_mutex);
+	mutex_unlock(&session->session_mutex);
 }
 
 /**
@@ -332,29 +337,28 @@ void aql_perf_recovery_work(struct work_struct *work)
  * Returns: Allocated error context or NULL on failure
  */
 struct aql_error_context *aql_perf_create_error_context(enum aql_error_severity severity,
-                                                        uint32_t gpu_id,
-                                                        int error_code,
-                                                        const char *error_msg, ...)
+							uint32_t gpu_id, int error_code,
+							const char *error_msg, ...)
 {
-    struct aql_error_context *error;
-    va_list args;
+	struct aql_error_context *error;
+	va_list args;
 
-    error = kzalloc(sizeof(*error), GFP_KERNEL);
-    if (!error)
-        return NULL;
+	error = kzalloc(sizeof(*error), GFP_KERNEL);
+	if (!error)
+		return NULL;
 
-    error->severity = severity;
-    error->gpu_id = gpu_id;
-    error->error_code = error_code;
-    error->timestamp = ktime_get();
+	error->severity = severity;
+	error->gpu_id = gpu_id;
+	error->error_code = error_code;
+	error->timestamp = ktime_get();
 
-    if (error_msg) {
-        va_start(args, error_msg);
-        vsnprintf(error->error_msg, sizeof(error->error_msg), error_msg, args);
-        va_end(args);
-    }
+	if (error_msg) {
+		va_start(args, error_msg);
+		vsnprintf(error->error_msg, sizeof(error->error_msg), error_msg, args);
+		va_end(args);
+	}
 
-    return error;
+	return error;
 }
 
 /**
@@ -363,7 +367,7 @@ struct aql_error_context *aql_perf_create_error_context(enum aql_error_severity 
  */
 void aql_perf_destroy_error_context(struct aql_error_context *error)
 {
-    kfree(error);
+	kfree(error);
 }
 
 /**
@@ -375,21 +379,21 @@ void aql_perf_destroy_error_context(struct aql_error_context *error)
  */
 bool aql_perf_is_gpu_disabled(struct aql_perf_session *session, uint32_t gpu_id)
 {
-    uint32_t i;
+	uint32_t i;
 
-    if (!session)
-        return true;
+	if (!session)
+		return true;
 
-    /* Find GPU index from GPU ID */
-    for (i = 0; i < session->num_gpus; i++) {
-        if (session->gpu_ids[i] == gpu_id) {
-            /* Use index (0, 1, 2...) not hardware ID (7410, 7411...) */
-            return test_bit(i, &session->recovery.error_mask);
-        }
-    }
+	/* Find GPU index from GPU ID */
+	for (i = 0; i < session->num_gpus; i++) {
+		if (session->gpu_ids[i] == gpu_id) {
+			/* Use index (0, 1, 2...) not hardware ID (7410, 7411...) */
+			return test_bit(i, &session->recovery.error_mask);
+		}
+	}
 
-    /* GPU ID not found in session - treat as disabled */
-    return true;
+	/* GPU ID not found in session - treat as disabled */
+	return true;
 }
 
 /**
@@ -400,19 +404,19 @@ bool aql_perf_is_gpu_disabled(struct aql_perf_session *session, uint32_t gpu_id)
  */
 uint32_t aql_perf_get_healthy_gpu_count(struct aql_perf_session *session)
 {
-    uint32_t healthy_count = 0;
-    uint32_t i;
+	uint32_t healthy_count = 0;
+	uint32_t i;
 
-    if (!session)
-        return 0;
+	if (!session)
+		return 0;
 
-    for (i = 0; i < session->num_gpus; i++) {
-        if (!aql_perf_is_gpu_disabled(session, session->gpu_ids[i])) {
-            healthy_count++;
-        }
-    }
+	for (i = 0; i < session->num_gpus; i++) {
+		if (!aql_perf_is_gpu_disabled(session, session->gpu_ids[i])) {
+			healthy_count++;
+		}
+	}
 
-    return healthy_count;
+	return healthy_count;
 }
 
 EXPORT_SYMBOL_GPL(aql_perf_handle_error);

--- a/projects/perf-dkms/src/aql_packet_ops.c
+++ b/projects/perf-dkms/src/aql_packet_ops.c
@@ -23,9 +23,8 @@
 #include "aql_c/arch_creator_common.h"
 
 /* External KFD functions */
-extern int kfd_ioctl_submit_ib_packet(struct file *filep, struct kfd_process *p,
-                                     uint32_t gpu_id, const uint32_t* packet,
-                                     size_t ib_len);
+extern int kfd_ioctl_submit_ib_packet(struct file *filep, struct kfd_process *p, uint32_t gpu_id,
+				      const uint32_t *packet, size_t ib_len);
 
 /**
  * aql_perf_find_gpu_index - Find GPU index in session from GPU ID
@@ -36,17 +35,17 @@ extern int kfd_ioctl_submit_ib_packet(struct file *filep, struct kfd_process *p,
  */
 static int aql_perf_find_gpu_index(struct aql_perf_session *session, uint32_t gpu_id)
 {
-    uint32_t i;
+	uint32_t i;
 
-    if (!session || !session->gpu_ids)
-        return -1;
+	if (!session || !session->gpu_ids)
+		return -1;
 
-    for (i = 0; i < session->num_gpus; i++) {
-        if (session->gpu_ids[i] == gpu_id)
-            return i;
-    }
+	for (i = 0; i < session->num_gpus; i++) {
+		if (session->gpu_ids[i] == gpu_id)
+			return i;
+	}
 
-    return -1;
+	return -1;
 }
 
 /* Counter Sharing Helper Functions */
@@ -66,30 +65,30 @@ static int aql_perf_find_gpu_index(struct aql_perf_session *session, uint32_t gp
  *
  * Note: Caller must release the reference when done using release_shared_counter()
  */
-static struct shared_counter_ref *find_and_install_shared_counter(
-    struct aql_perf_session *session,
-    uint32_t counter_id,
-    struct aql_measurement *measurement)
+static struct shared_counter_ref *
+find_and_install_shared_counter(struct aql_perf_session *session, uint32_t counter_id,
+				struct aql_measurement *measurement)
 {
-    struct shared_counter_ref *ref;
-    unsigned long flags;
+	struct shared_counter_ref *ref;
+	unsigned long flags;
 
-    spin_lock_irqsave(&session->shared_lock, flags);
-    list_for_each_entry(ref, &session->shared_counters, list) {
-        if (ref->counter_id == counter_id) {
-            atomic_inc(&ref->ref_count);
-            /* Install while holding lock - prevents race */
-            measurement->shared_ref = ref;
-            measurement->owns_counter = false;
-            measurement->allocated_counter = ref->measurement->allocated_counter;
-            spin_unlock_irqrestore(&session->shared_lock, flags);
-            aql_info("[PMU] Found shared counter for counter_id=%u, new refcount=%d",
-                     counter_id, atomic_read(&ref->ref_count));
-            return ref;
-        }
-    }
-    spin_unlock_irqrestore(&session->shared_lock, flags);
-    return NULL;
+	spin_lock_irqsave(&session->shared_lock, flags);
+	list_for_each_entry(ref, &session->shared_counters, list)
+	{
+		if (ref->counter_id == counter_id) {
+			atomic_inc(&ref->ref_count);
+			/* Install while holding lock - prevents race */
+			measurement->shared_ref = ref;
+			measurement->owns_counter = false;
+			measurement->allocated_counter = ref->measurement->allocated_counter;
+			spin_unlock_irqrestore(&session->shared_lock, flags);
+			aql_info("[PMU] Found shared counter for counter_id=%u, new refcount=%d",
+				 counter_id, atomic_read(&ref->ref_count));
+			return ref;
+		}
+	}
+	spin_unlock_irqrestore(&session->shared_lock, flags);
+	return NULL;
 }
 
 /**
@@ -100,32 +99,30 @@ static struct shared_counter_ref *find_and_install_shared_counter(
  *
  * Returns: New shared counter reference, or NULL on allocation failure
  */
-static struct shared_counter_ref *create_shared_counter(
-    struct aql_perf_session *session,
-    uint32_t counter_id,
-    struct aql_measurement *measurement)
+static struct shared_counter_ref *create_shared_counter(struct aql_perf_session *session,
+							uint32_t counter_id,
+							struct aql_measurement *measurement)
 {
-    struct shared_counter_ref *ref;
-    unsigned long flags;
+	struct shared_counter_ref *ref;
+	unsigned long flags;
 
-    ref = kzalloc(sizeof(*ref), GFP_KERNEL);
-    if (!ref) {
-        aql_err("[PMU] Failed to allocate shared counter reference");
-        return NULL;
-    }
+	ref = kzalloc(sizeof(*ref), GFP_KERNEL);
+	if (!ref) {
+		aql_err("[PMU] Failed to allocate shared counter reference");
+		return NULL;
+	}
 
-    ref->counter_id = counter_id;
-    ref->measurement = measurement;
-    atomic_set(&ref->ref_count, 1);
+	ref->counter_id = counter_id;
+	ref->measurement = measurement;
+	atomic_set(&ref->ref_count, 1);
 
-    spin_lock_irqsave(&session->shared_lock, flags);
-    list_add(&ref->list, &session->shared_counters);
-    spin_unlock_irqrestore(&session->shared_lock, flags);
+	spin_lock_irqsave(&session->shared_lock, flags);
+	list_add(&ref->list, &session->shared_counters);
+	spin_unlock_irqrestore(&session->shared_lock, flags);
 
-    aql_info("[PMU] Created shared counter for counter_id=%u, ref_count=1",
-             counter_id);
+	aql_info("[PMU] Created shared counter for counter_id=%u, ref_count=1", counter_id);
 
-    return ref;
+	return ref;
 }
 
 /**
@@ -135,30 +132,28 @@ static struct shared_counter_ref *create_shared_counter(
  *
  * Decrements reference count. When count reaches zero, removes from list and frees.
  */
-void release_shared_counter(
-    struct aql_perf_session *session,
-    struct shared_counter_ref *ref)
+void release_shared_counter(struct aql_perf_session *session, struct shared_counter_ref *ref)
 {
-    unsigned long flags;
-    int old_count;
+	unsigned long flags;
+	int old_count;
 
-    if (!ref)
-        return;
+	if (!ref)
+		return;
 
-    old_count = atomic_read(&ref->ref_count);
+	old_count = atomic_read(&ref->ref_count);
 
-    if (atomic_dec_and_test(&ref->ref_count)) {
-        spin_lock_irqsave(&session->shared_lock, flags);
-        list_del(&ref->list);
-        spin_unlock_irqrestore(&session->shared_lock, flags);
+	if (atomic_dec_and_test(&ref->ref_count)) {
+		spin_lock_irqsave(&session->shared_lock, flags);
+		list_del(&ref->list);
+		spin_unlock_irqrestore(&session->shared_lock, flags);
 
-        aql_info("[PMU] Released shared counter for counter_id=%u (ref_count %d -> 0)",
-                 ref->counter_id, old_count);
-        kfree(ref);
-    } else {
-        aql_info("[PMU] Decremented shared counter for counter_id=%u (ref_count %d -> %d)",
-                 ref->counter_id, old_count, atomic_read(&ref->ref_count));
-    }
+		aql_info("[PMU] Released shared counter for counter_id=%u (ref_count %d -> 0)",
+			 ref->counter_id, old_count);
+		kfree(ref);
+	} else {
+		aql_info("[PMU] Decremented shared counter for counter_id=%u (ref_count %d -> %d)",
+			 ref->counter_id, old_count, atomic_read(&ref->ref_count));
+	}
 }
 
 /* Packet Creation Functions */
@@ -176,164 +171,166 @@ void release_shared_counter(
  * 3. Calls generate_start_packet() to create PM4 command buffer
  * 4. Stores allocated counter pointer in measurement->allocated_counter
  */
-int aql_perf_create_start_packet(struct aql_measurement *measurement,
-                                 pm4_buffer_t **out_pm4_buffer)
+int aql_perf_create_start_packet(struct aql_measurement *measurement, pm4_buffer_t **out_pm4_buffer)
 {
-    struct aql_perf_session *session;
-    arch_t *arch;
-    int gpu_idx;
-    const counter_def_t *counter_def;
-    block_info_t *block;
-    uint32_t event_id;
-    counter_reg_info_t *allocated_counter;
-    counter_info_t counter_info;
-    counter_collection_t collection;
-    pm4_buffer_t *pm4_buffer;
-    int ret;
+	struct aql_perf_session *session;
+	arch_t *arch;
+	int gpu_idx;
+	const counter_def_t *counter_def;
+	block_info_t *block;
+	uint32_t event_id;
+	counter_reg_info_t *allocated_counter;
+	counter_info_t counter_info;
+	counter_collection_t collection;
+	pm4_buffer_t *pm4_buffer;
+	int ret;
 
-    if (!measurement || !measurement->session || !out_pm4_buffer) {
-        aql_err("[PMU] aql_perf_create_start_packet: Invalid parameters");
-        return -EINVAL;
-    }
+	if (!measurement || !measurement->session || !out_pm4_buffer) {
+		aql_err("[PMU] aql_perf_create_start_packet: Invalid parameters");
+		return -EINVAL;
+	}
 
-    session = measurement->session;
+	session = measurement->session;
 
-    /* Find GPU architecture */
-    gpu_idx = aql_perf_find_gpu_index(session, measurement->gpu_id);
-    if (gpu_idx < 0 || !session->archs || !session->archs[gpu_idx]) {
-        aql_err("[PMU] Session %llu: GPU %u not found or no architecture available",
-                session->session_id, measurement->gpu_id);
-        return -ENODEV;
-    }
-    arch = session->archs[gpu_idx];
+	/* Find GPU architecture */
+	gpu_idx = aql_perf_find_gpu_index(session, measurement->gpu_id);
+	if (gpu_idx < 0 || !session->archs || !session->archs[gpu_idx]) {
+		aql_err("[PMU] Session %llu: GPU %u not found or no architecture available",
+			session->session_id, measurement->gpu_id);
+		return -ENODEV;
+	}
+	arch = session->archs[gpu_idx];
 
-    aql_debug("[PMU] aql_perf_create_start_packet: GPU %u, counter_id=%u",
-              measurement->gpu_id, measurement->counter_id);
+	aql_debug("[PMU] aql_perf_create_start_packet: GPU %u, counter_id=%u", measurement->gpu_id,
+		  measurement->counter_id);
 
-    /* Look up counter definition */
-    counter_def = lookup_counter_by_id((counter_id_t)measurement->counter_id);
-    if (!counter_def) {
-        aql_err("[PMU] Counter ID %u not found in registry", measurement->counter_id);
-        return -EINVAL;
-    }
+	/* Look up counter definition */
+	counter_def = lookup_counter_by_id((counter_id_t)measurement->counter_id);
+	if (!counter_def) {
+		aql_err("[PMU] Counter ID %u not found in registry", measurement->counter_id);
+		return -EINVAL;
+	}
 
-    /* Get architecture-specific event ID */
-    ret = lookup_event_id(counter_def, arch, &event_id);
-    if (ret < 0) {
-        aql_err("[PMU] No event mapping for counter %s (err=%d)", counter_def->name, ret);
-        return -ENOTSUPP;
-    }
+	/* Get architecture-specific event ID */
+	ret = lookup_event_id(counter_def, arch, &event_id);
+	if (ret < 0) {
+		aql_err("[PMU] No event mapping for counter %s (err=%d)", counter_def->name, ret);
+		return -ENOTSUPP;
+	}
 
-    /* Get block from architecture */
-    block = arch->block_map.blocks[counter_def->hw_block];
-    if (!block) {
-        aql_err("[PMU] Block %u not found in architecture", counter_def->hw_block);
-        return -EINVAL;
-    }
+	/* Get block from architecture */
+	block = arch->block_map.blocks[counter_def->hw_block];
+	if (!block) {
+		aql_err("[PMU] Block %u not found in architecture", counter_def->hw_block);
+		return -EINVAL;
+	}
 
-    /* Check if another event already allocated this counter */
-    struct shared_counter_ref *shared_ref = find_and_install_shared_counter(session, measurement->counter_id, measurement);
-    if (shared_ref) {
-        /* Reuse existing allocation - counter and references installed atomically */
-        const counter_def_t *counter_def_for_log = lookup_counter_by_id((counter_id_t)measurement->counter_id);
-        aql_info("[PMU] Sharing counter for %s (counter_id=%u, ref_count=%d)",
-                 counter_def_for_log ? counter_def_for_log->name : "unknown",
-                 measurement->counter_id,
-                 atomic_read(&shared_ref->ref_count));
+	/* Check if another event already allocated this counter */
+	struct shared_counter_ref *shared_ref =
+		find_and_install_shared_counter(session, measurement->counter_id, measurement);
+	if (shared_ref) {
+		/* Reuse existing allocation - counter and references installed atomically */
+		const counter_def_t *counter_def_for_log =
+			lookup_counter_by_id((counter_id_t)measurement->counter_id);
+		aql_info("[PMU] Sharing counter for %s (counter_id=%u, ref_count=%d)",
+			 counter_def_for_log ? counter_def_for_log->name : "unknown",
+			 measurement->counter_id, atomic_read(&shared_ref->ref_count));
 
-        /* No START packet needed - counter already started */
-        *out_pm4_buffer = NULL;
-        return 0;
-    }
+		/* No START packet needed - counter already started */
+		*out_pm4_buffer = NULL;
+		return 0;
+	}
 
-    aql_info("[PMU] generate_start_packet: Allocating counter from block=%s, event_id=0x%x",
-             block->name, event_id);
+	aql_info("[PMU] generate_start_packet: Allocating counter from block=%s, event_id=0x%x",
+		 block->name, event_id);
 
-    /* First event for this counter - allocate hardware counter */
-    allocated_counter = aql_counter_try_allocate(block, event_id, measurement->event);
-    if (!allocated_counter) {
-        aql_err("[PMU] Failed to allocate counter from block %s (all busy)", block->name);
-        return -EBUSY;
-    }
+	/* First event for this counter - allocate hardware counter */
+	allocated_counter = aql_counter_try_allocate(block, event_id, measurement->event);
+	if (!allocated_counter) {
+		aql_err("[PMU] Failed to allocate counter from block %s (all busy)", block->name);
+		return -EBUSY;
+	}
 
-    /* Create shared reference for this new allocation */
-    shared_ref = create_shared_counter(session, measurement->counter_id, measurement);
-    if (!shared_ref) {
-        aql_err("[PMU] Failed to create shared counter reference");
-        aql_counter_release(allocated_counter);
-        measurement->allocated_counter = NULL;
-        return -ENOMEM;
-    }
-    measurement->shared_ref = shared_ref;
-    measurement->owns_counter = true;
+	/* Create shared reference for this new allocation */
+	shared_ref = create_shared_counter(session, measurement->counter_id, measurement);
+	if (!shared_ref) {
+		aql_err("[PMU] Failed to create shared counter reference");
+		aql_counter_release(allocated_counter);
+		measurement->allocated_counter = NULL;
+		return -ENOMEM;
+	}
+	measurement->shared_ref = shared_ref;
+	measurement->owns_counter = true;
 
-    /* Build counter_info_t structure */
-    ret = aql_build_counter_info(measurement->counter_id, arch, allocated_counter,
-                                  &counter_info, &block);
-    if (ret) {
-        aql_err("[PMU] Failed to build counter info: %d", ret);
-        aql_counter_release(allocated_counter);
-        measurement->allocated_counter = NULL;
-        measurement->owns_counter = false;
-        release_shared_counter(session, measurement->shared_ref);
-        measurement->shared_ref = NULL;
-        return ret;
-    }
+	/* Build counter_info_t structure */
+	ret = aql_build_counter_info(measurement->counter_id, arch, allocated_counter,
+				     &counter_info, &block);
+	if (ret) {
+		aql_err("[PMU] Failed to build counter info: %d", ret);
+		aql_counter_release(allocated_counter);
+		measurement->allocated_counter = NULL;
+		measurement->owns_counter = false;
+		release_shared_counter(session, measurement->shared_ref);
+		measurement->shared_ref = NULL;
+		return ret;
+	}
 
-    /* Build counter_collection_t structure */
-    memset(&collection, 0, sizeof(collection));
-    collection.counters = &counter_info;
-    collection.counter_count = 1;
-    collection.gpu_memory_addr = (uint64_t)(uintptr_t)allocated_counter->allocation.data_buffer->gpu_addr;
-    collection.memory_size = PAGE_SIZE;
+	/* Build counter_collection_t structure */
+	memset(&collection, 0, sizeof(collection));
+	collection.counters = &counter_info;
+	collection.counter_count = 1;
+	collection.gpu_memory_addr =
+		(uint64_t)(uintptr_t)allocated_counter->allocation.data_buffer->gpu_addr;
+	collection.memory_size = PAGE_SIZE;
 
-    aql_info("[PMU] generate_start_packet: counter_index=%u, event_id=0x%x, gpu_addr=0x%llx",
-             counter_info.counter_index, counter_info.event_id, collection.gpu_memory_addr);
+	aql_info("[PMU] generate_start_packet: counter_index=%u, event_id=0x%x, gpu_addr=0x%llx",
+		 counter_info.counter_index, counter_info.event_id, collection.gpu_memory_addr);
 
-    /* Validate counter collection */
-    ret = validate_counter_collection(arch, &collection);
-    if (ret) {
-        aql_err("[PMU] Counter collection validation failed: %d", ret);
-        aql_counter_release(allocated_counter);
-        measurement->allocated_counter = NULL;
-        measurement->owns_counter = false;
-        release_shared_counter(session, measurement->shared_ref);
-        measurement->shared_ref = NULL;
-        return ret;
-    }
+	/* Validate counter collection */
+	ret = validate_counter_collection(arch, &collection);
+	if (ret) {
+		aql_err("[PMU] Counter collection validation failed: %d", ret);
+		aql_counter_release(allocated_counter);
+		measurement->allocated_counter = NULL;
+		measurement->owns_counter = false;
+		release_shared_counter(session, measurement->shared_ref);
+		measurement->shared_ref = NULL;
+		return ret;
+	}
 
-    /* Create PM4 buffer */
-    pm4_buffer = pm4_buffer_create(256, GFP_KERNEL);
-    if (!pm4_buffer) {
-        aql_err("[PMU] Failed to create PM4 buffer");
-        aql_counter_release(allocated_counter);
-        measurement->allocated_counter = NULL;
-        measurement->owns_counter = false;
-        release_shared_counter(session, measurement->shared_ref);
-        measurement->shared_ref = NULL;
-        return -ENOMEM;
-    }
+	/* Create PM4 buffer */
+	pm4_buffer = pm4_buffer_create(256, GFP_KERNEL);
+	if (!pm4_buffer) {
+		aql_err("[PMU] Failed to create PM4 buffer");
+		aql_counter_release(allocated_counter);
+		measurement->allocated_counter = NULL;
+		measurement->owns_counter = false;
+		release_shared_counter(session, measurement->shared_ref);
+		measurement->shared_ref = NULL;
+		return -ENOMEM;
+	}
 
-    /* Generate start packet */
-    ret = generate_start_packet(pm4_buffer, arch, &collection);
-    if (ret) {
-        aql_err("[PMU] generate_start_packet failed: %d", ret);
-        pm4_buffer_destroy(pm4_buffer);
-        aql_counter_release(allocated_counter);
-        measurement->allocated_counter = NULL;
-        measurement->owns_counter = false;
-        release_shared_counter(session, measurement->shared_ref);
-        measurement->shared_ref = NULL;
-        return ret;
-    }
+	/* Generate start packet */
+	ret = generate_start_packet(pm4_buffer, arch, &collection);
+	if (ret) {
+		aql_err("[PMU] generate_start_packet failed: %d", ret);
+		pm4_buffer_destroy(pm4_buffer);
+		aql_counter_release(allocated_counter);
+		measurement->allocated_counter = NULL;
+		measurement->owns_counter = false;
+		release_shared_counter(session, measurement->shared_ref);
+		measurement->shared_ref = NULL;
+		return ret;
+	}
 
-    aql_info("[PMU] generate_start_packet: PM4 buffer created, size=%zu DWORDs", pm4_buffer->size);
+	aql_info("[PMU] generate_start_packet: PM4 buffer created, size=%zu DWORDs",
+		 pm4_buffer->size);
 
-    /* Store allocated counter in measurement */
-    measurement->allocated_counter = allocated_counter;
+	/* Store allocated counter in measurement */
+	measurement->allocated_counter = allocated_counter;
 
-    *out_pm4_buffer = pm4_buffer;
-    return 0;
+	*out_pm4_buffer = pm4_buffer;
+	return 0;
 }
 
 /**
@@ -343,93 +340,91 @@ int aql_perf_create_start_packet(struct aql_measurement *measurement,
  *
  * Returns: 0 on success, negative error code on failure
  */
-int aql_perf_create_read_packet(struct aql_measurement *measurement,
-                                pm4_buffer_t **out_pm4_buffer)
+int aql_perf_create_read_packet(struct aql_measurement *measurement, pm4_buffer_t **out_pm4_buffer)
 {
-    struct aql_perf_session *session;
-    arch_t *arch;
-    int gpu_idx;
-    counter_info_t counter_info;
-    counter_collection_t collection;
-    block_info_t *block;
-    pm4_buffer_t *pm4_buffer;
-    counter_reg_info_t *counter;
-    int ret;
+	struct aql_perf_session *session;
+	arch_t *arch;
+	int gpu_idx;
+	counter_info_t counter_info;
+	counter_collection_t collection;
+	block_info_t *block;
+	pm4_buffer_t *pm4_buffer;
+	counter_reg_info_t *counter;
+	int ret;
 
-    aql_info("[PMU] aql_perf_create_read_packet: Entry for GPU %u, counter_id=%u",
-             measurement ? measurement->gpu_id : 0,
-             measurement ? measurement->counter_id : 0);
+	aql_info("[PMU] aql_perf_create_read_packet: Entry for GPU %u, counter_id=%u",
+		 measurement ? measurement->gpu_id : 0, measurement ? measurement->counter_id : 0);
 
-    if (!measurement || !measurement->session || !out_pm4_buffer) {
-        aql_err("[PMU] aql_perf_create_read_packet: Invalid parameters");
-        return -EINVAL;
-    }
+	if (!measurement || !measurement->session || !out_pm4_buffer) {
+		aql_err("[PMU] aql_perf_create_read_packet: Invalid parameters");
+		return -EINVAL;
+	}
 
-    /* Get local copy of allocated_counter to prevent TOCTOU race */
-    counter = measurement->allocated_counter;
-    if (!counter) {
-        aql_err("[PMU] aql_perf_create_read_packet: No counter allocated for measurement");
-        return -EINVAL;
-    }
+	/* Get local copy of allocated_counter to prevent TOCTOU race */
+	counter = measurement->allocated_counter;
+	if (!counter) {
+		aql_err("[PMU] aql_perf_create_read_packet: No counter allocated for measurement");
+		return -EINVAL;
+	}
 
-    /* Check if data_buffer is still valid (may be NULL during cleanup) */
-    if (!counter->allocation.data_buffer) {
-        aql_debug("[PMU] aql_perf_create_read_packet: data_buffer freed (measurement being cleaned up)");
-        return -ESHUTDOWN;
-    }
+	/* Check if data_buffer is still valid (may be NULL during cleanup) */
+	if (!counter->allocation.data_buffer) {
+		aql_debug(
+			"[PMU] aql_perf_create_read_packet: data_buffer freed (measurement being cleaned up)");
+		return -ESHUTDOWN;
+	}
 
-    aql_info("[PMU] aql_perf_create_read_packet: GPU %u, allocated_counter=%p",
-             measurement->gpu_id, counter);
+	aql_info("[PMU] aql_perf_create_read_packet: GPU %u, allocated_counter=%p",
+		 measurement->gpu_id, counter);
 
-    session = measurement->session;
+	session = measurement->session;
 
-    /* Find GPU architecture */
-    gpu_idx = aql_perf_find_gpu_index(session, measurement->gpu_id);
-    if (gpu_idx < 0 || !session->archs || !session->archs[gpu_idx]) {
-        aql_err("[PMU] Session %llu: GPU %u not found or no architecture available",
-                session->session_id, measurement->gpu_id);
-        return -ENODEV;
-    }
-    arch = session->archs[gpu_idx];
+	/* Find GPU architecture */
+	gpu_idx = aql_perf_find_gpu_index(session, measurement->gpu_id);
+	if (gpu_idx < 0 || !session->archs || !session->archs[gpu_idx]) {
+		aql_err("[PMU] Session %llu: GPU %u not found or no architecture available",
+			session->session_id, measurement->gpu_id);
+		return -ENODEV;
+	}
+	arch = session->archs[gpu_idx];
 
-    /* Build counter_info_t from allocated counter (use local copy) */
-    ret = aql_build_counter_info(measurement->counter_id, arch,
-                                  counter,
-                                  &counter_info, &block);
-    if (ret) {
-        aql_err("[PMU] Failed to build counter info: %d", ret);
-        return ret;
-    }
+	/* Build counter_info_t from allocated counter (use local copy) */
+	ret = aql_build_counter_info(measurement->counter_id, arch, counter, &counter_info, &block);
+	if (ret) {
+		aql_err("[PMU] Failed to build counter info: %d", ret);
+		return ret;
+	}
 
-    /* Build counter_collection_t (use local copy) */
-    memset(&collection, 0, sizeof(collection));
-    collection.counters = &counter_info;
-    collection.counter_count = 1;
-    collection.gpu_memory_addr = (uint64_t)(uintptr_t)counter->allocation.data_buffer->gpu_addr;
-    collection.memory_size = PAGE_SIZE;
+	/* Build counter_collection_t (use local copy) */
+	memset(&collection, 0, sizeof(collection));
+	collection.counters = &counter_info;
+	collection.counter_count = 1;
+	collection.gpu_memory_addr = (uint64_t)(uintptr_t)counter->allocation.data_buffer->gpu_addr;
+	collection.memory_size = PAGE_SIZE;
 
-    aql_info("[PMU] generate_read_packet: counter_index=%u, gpu_addr=0x%llx",
-             counter_info.counter_index, collection.gpu_memory_addr);
+	aql_info("[PMU] generate_read_packet: counter_index=%u, gpu_addr=0x%llx",
+		 counter_info.counter_index, collection.gpu_memory_addr);
 
-    /* Create PM4 buffer */
-    pm4_buffer = pm4_buffer_create(256, GFP_KERNEL);
-    if (!pm4_buffer) {
-        aql_err("[PMU] Failed to create PM4 buffer");
-        return -ENOMEM;
-    }
+	/* Create PM4 buffer */
+	pm4_buffer = pm4_buffer_create(256, GFP_KERNEL);
+	if (!pm4_buffer) {
+		aql_err("[PMU] Failed to create PM4 buffer");
+		return -ENOMEM;
+	}
 
-    /* Generate read packet */
-    ret = generate_read_packet(pm4_buffer, arch, &collection);
-    if (ret) {
-        aql_err("[PMU] generate_read_packet failed: %d", ret);
-        pm4_buffer_destroy(pm4_buffer);
-        return ret;
-    }
+	/* Generate read packet */
+	ret = generate_read_packet(pm4_buffer, arch, &collection);
+	if (ret) {
+		aql_err("[PMU] generate_read_packet failed: %d", ret);
+		pm4_buffer_destroy(pm4_buffer);
+		return ret;
+	}
 
-    aql_info("[PMU] generate_read_packet: PM4 buffer created, size=%zu DWORDs", pm4_buffer->size);
+	aql_info("[PMU] generate_read_packet: PM4 buffer created, size=%zu DWORDs",
+		 pm4_buffer->size);
 
-    *out_pm4_buffer = pm4_buffer;
-    return 0;
+	*out_pm4_buffer = pm4_buffer;
+	return 0;
 }
 
 /**
@@ -439,52 +434,52 @@ int aql_perf_create_read_packet(struct aql_measurement *measurement,
  *
  * Returns: 0 on success, negative error code on failure
  */
-int aql_perf_create_end_packet(struct aql_measurement *measurement,
-                               pm4_buffer_t **out_pm4_buffer)
+int aql_perf_create_end_packet(struct aql_measurement *measurement, pm4_buffer_t **out_pm4_buffer)
 {
-    struct aql_perf_session *session;
-    arch_t *arch;
-    int gpu_idx;
-    pm4_buffer_t *pm4_buffer;
-    int ret;
+	struct aql_perf_session *session;
+	arch_t *arch;
+	int gpu_idx;
+	pm4_buffer_t *pm4_buffer;
+	int ret;
 
-    if (!measurement || !measurement->session || !out_pm4_buffer) {
-        aql_err("[PMU] aql_perf_create_end_packet: Invalid parameters");
-        return -EINVAL;
-    }
+	if (!measurement || !measurement->session || !out_pm4_buffer) {
+		aql_err("[PMU] aql_perf_create_end_packet: Invalid parameters");
+		return -EINVAL;
+	}
 
-    session = measurement->session;
+	session = measurement->session;
 
-    /* Find GPU architecture */
-    gpu_idx = aql_perf_find_gpu_index(session, measurement->gpu_id);
-    if (gpu_idx < 0 || !session->archs || !session->archs[gpu_idx]) {
-        aql_err("[PMU] Session %llu: GPU %u not found or no architecture available",
-                session->session_id, measurement->gpu_id);
-        return -ENODEV;
-    }
-    arch = session->archs[gpu_idx];
+	/* Find GPU architecture */
+	gpu_idx = aql_perf_find_gpu_index(session, measurement->gpu_id);
+	if (gpu_idx < 0 || !session->archs || !session->archs[gpu_idx]) {
+		aql_err("[PMU] Session %llu: GPU %u not found or no architecture available",
+			session->session_id, measurement->gpu_id);
+		return -ENODEV;
+	}
+	arch = session->archs[gpu_idx];
 
-    aql_info("[PMU] generate_stop_packet: GPU %u", measurement->gpu_id);
+	aql_info("[PMU] generate_stop_packet: GPU %u", measurement->gpu_id);
 
-    /* Create PM4 buffer */
-    pm4_buffer = pm4_buffer_create(256, GFP_KERNEL);
-    if (!pm4_buffer) {
-        aql_err("[PMU] Failed to create PM4 buffer");
-        return -ENOMEM;
-    }
+	/* Create PM4 buffer */
+	pm4_buffer = pm4_buffer_create(256, GFP_KERNEL);
+	if (!pm4_buffer) {
+		aql_err("[PMU] Failed to create PM4 buffer");
+		return -ENOMEM;
+	}
 
-    /* Generate stop packet */
-    ret = generate_stop_packet(pm4_buffer, arch);
-    if (ret) {
-        aql_err("[PMU] generate_stop_packet failed: %d", ret);
-        pm4_buffer_destroy(pm4_buffer);
-        return ret;
-    }
+	/* Generate stop packet */
+	ret = generate_stop_packet(pm4_buffer, arch);
+	if (ret) {
+		aql_err("[PMU] generate_stop_packet failed: %d", ret);
+		pm4_buffer_destroy(pm4_buffer);
+		return ret;
+	}
 
-    aql_info("[PMU] generate_stop_packet: PM4 buffer created, size=%zu DWORDs", pm4_buffer->size);
+	aql_info("[PMU] generate_stop_packet: PM4 buffer created, size=%zu DWORDs",
+		 pm4_buffer->size);
 
-    *out_pm4_buffer = pm4_buffer;
-    return 0;
+	*out_pm4_buffer = pm4_buffer;
+	return 0;
 }
 
 /**
@@ -495,51 +490,49 @@ int aql_perf_create_end_packet(struct aql_measurement *measurement,
  *
  * Returns: 0 on success, negative error code on failure
  */
-int aql_perf_submit_pm4_packet(struct aql_perf_session *session,
-                               uint32_t gpu_id,
-                               pm4_buffer_t *pm4_buffer)
+int aql_perf_submit_pm4_packet(struct aql_perf_session *session, uint32_t gpu_id,
+			       pm4_buffer_t *pm4_buffer)
 {
-    int ret;
-    size_t ib_len;
+	int ret;
+	size_t ib_len;
 
-    if (!session || !pm4_buffer || !pm4_buffer->data) {
-        aql_err("[PMU] aql_perf_submit_pm4_packet: Invalid parameters");
-        return -EINVAL;
-    }
+	if (!session || !pm4_buffer || !pm4_buffer->data) {
+		aql_err("[PMU] aql_perf_submit_pm4_packet: Invalid parameters");
+		return -EINVAL;
+	}
 
-    /* IB length is already in DWORDs from pm4_buffer->size */
-    ib_len = pm4_buffer->size;
+	/* IB length is already in DWORDs from pm4_buffer->size */
+	ib_len = pm4_buffer->size;
 
-    aql_info("[PMU] kfd_ioctl_submit_ib_packet: gpu_id=%u, buffer=%p, size=%zu DWORDs (%zu bytes)",
-             gpu_id, pm4_buffer->data, pm4_buffer->size, pm4_buffer->size * 4);
+	aql_info(
+		"[PMU] kfd_ioctl_submit_ib_packet: gpu_id=%u, buffer=%p, size=%zu DWORDs (%zu bytes)",
+		gpu_id, pm4_buffer->data, pm4_buffer->size, pm4_buffer->size * 4);
 
-    /* Submit PM4 buffer via KFD (ib_len is in DWORDs) */
-    ret = kfd_ioctl_submit_ib_packet(session->kfd_file, session->process,
-                                    gpu_id, pm4_buffer->data, ib_len);
+	/* Submit PM4 buffer via KFD (ib_len is in DWORDs) */
+	ret = kfd_ioctl_submit_ib_packet(session->kfd_file, session->process, gpu_id,
+					 pm4_buffer->data, ib_len);
 
-    if (ret) {
-        struct aql_error_context error = {
-            .severity = AQL_ERROR_GPU_FAULT,
-            .gpu_id = gpu_id,
-            .error_code = ret,
-            .timestamp = ktime_get()
-        };
+	if (ret) {
+		struct aql_error_context error = { .severity = AQL_ERROR_GPU_FAULT,
+						   .gpu_id = gpu_id,
+						   .error_code = ret,
+						   .timestamp = ktime_get() };
 
-        snprintf(error.error_msg, sizeof(error.error_msg),
-                "Failed to submit PM4 packet: %d", ret);
+		snprintf(error.error_msg, sizeof(error.error_msg),
+			 "Failed to submit PM4 packet: %d", ret);
 
-        aql_err("[PMU] Session %llu: %s", session->session_id, error.error_msg);
-        aql_perf_handle_error(session, &error);
-        aql_perf_inc_stat(AQL_STAT_ERRORS_TOTAL);
-        return ret;
-    }
+		aql_err("[PMU] Session %llu: %s", session->session_id, error.error_msg);
+		aql_perf_handle_error(session, &error);
+		aql_perf_inc_stat(AQL_STAT_ERRORS_TOTAL);
+		return ret;
+	}
 
-    aql_info("[PMU] kfd_ioctl_submit_ib_packet: SUCCESS");
+	aql_info("[PMU] kfd_ioctl_submit_ib_packet: SUCCESS");
 
-    aql_perf_inc_stat(AQL_STAT_PACKETS_SUBMITTED);
-    aql_perf_inc_stat(AQL_STAT_PACKETS_COMPLETED);
+	aql_perf_inc_stat(AQL_STAT_PACKETS_SUBMITTED);
+	aql_perf_inc_stat(AQL_STAT_PACKETS_COMPLETED);
 
-    return 0;
+	return 0;
 }
 
 /* Measurement Management */
@@ -553,41 +546,40 @@ int aql_perf_submit_pm4_packet(struct aql_perf_session *session,
  */
 static void aql_measurement_release(struct kref *kref)
 {
-    struct aql_measurement *m = container_of(kref, struct aql_measurement, refcount);
-    counter_reg_info_t *counter;
-    unsigned long flags;
+	struct aql_measurement *m = container_of(kref, struct aql_measurement, refcount);
+	counter_reg_info_t *counter;
+	unsigned long flags;
 
-    aql_debug("[PMU] Releasing measurement for GPU %u (refcount reached 0)",
-              m->gpu_id);
+	aql_debug("[PMU] Releasing measurement for GPU %u (refcount reached 0)", m->gpu_id);
 
-    /* Release counter if still allocated (use local copy to prevent TOCTOU) */
-    if (m->owns_counter) {
-        counter = m->allocated_counter;
-        if (counter) {
-            aql_debug("[PMU] Releasing owned counter during final release");
-            aql_counter_release(counter);
-            m->allocated_counter = NULL;
-            m->owns_counter = false;
-        }
-    }
+	/* Release counter if still allocated (use local copy to prevent TOCTOU) */
+	if (m->owns_counter) {
+		counter = m->allocated_counter;
+		if (counter) {
+			aql_debug("[PMU] Releasing owned counter during final release");
+			aql_counter_release(counter);
+			m->allocated_counter = NULL;
+			m->owns_counter = false;
+		}
+	}
 
-    /* Release shared counter reference if still held */
-    if (m->shared_ref) {
-        aql_debug("[PMU] Releasing shared counter reference during final release");
-        release_shared_counter(m->session, m->shared_ref);
-        m->shared_ref = NULL;
-    }
+	/* Release shared counter reference if still held */
+	if (m->shared_ref) {
+		aql_debug("[PMU] Releasing shared counter reference during final release");
+		release_shared_counter(m->session, m->shared_ref);
+		m->shared_ref = NULL;
+	}
 
-    /* Remove from session's active list if still on it */
-    if (m->session && !list_empty(&m->list)) {
-        spin_lock_irqsave(&m->session->measurement_lock, flags);
-        list_del_init(&m->list);
-        atomic_dec(&m->session->active_gpu_count);
-        spin_unlock_irqrestore(&m->session->measurement_lock, flags);
-    }
+	/* Remove from session's active list if still on it */
+	if (m->session && !list_empty(&m->list)) {
+		spin_lock_irqsave(&m->session->measurement_lock, flags);
+		list_del_init(&m->list);
+		atomic_dec(&m->session->active_gpu_count);
+		spin_unlock_irqrestore(&m->session->measurement_lock, flags);
+	}
 
-    kfree(m);
-    aql_debug("[PMU] Measurement freed in release callback");
+	kfree(m);
+	aql_debug("[PMU] Measurement freed in release callback");
 }
 
 /**
@@ -596,10 +588,10 @@ static void aql_measurement_release(struct kref *kref)
  */
 void aql_measurement_get(struct aql_measurement *m)
 {
-    if (m) {
-        kref_get(&m->refcount);
-        aql_debug("[PMU] Measurement ref++ for GPU %u", m->gpu_id);
-    }
+	if (m) {
+		kref_get(&m->refcount);
+		aql_debug("[PMU] Measurement ref++ for GPU %u", m->gpu_id);
+	}
 }
 
 /**
@@ -611,10 +603,10 @@ void aql_measurement_get(struct aql_measurement *m)
  */
 void aql_measurement_put(struct aql_measurement *m)
 {
-    if (m) {
-        aql_debug("[PMU] Measurement ref-- for GPU %u", m->gpu_id);
-        kref_put(&m->refcount, aql_measurement_release);
-    }
+	if (m) {
+		aql_debug("[PMU] Measurement ref-- for GPU %u", m->gpu_id);
+		kref_put(&m->refcount, aql_measurement_release);
+	}
 }
 
 /**
@@ -626,56 +618,54 @@ void aql_measurement_put(struct aql_measurement *m)
  * Returns: New measurement or ERR_PTR on error
  */
 struct aql_measurement *aql_perf_measurement_create(struct aql_perf_session *session,
-                                                    uint32_t gpu_id,
-                                                    struct perf_event *event)
+						    uint32_t gpu_id, struct perf_event *event)
 {
-    struct aql_measurement *measurement;
-    int gpu_idx;
+	struct aql_measurement *measurement;
+	int gpu_idx;
 
-    if (!session || !event) {
-        aql_err("Invalid parameters for measurement creation");
-        return ERR_PTR(-EINVAL);
-    }
+	if (!session || !event) {
+		aql_err("Invalid parameters for measurement creation");
+		return ERR_PTR(-EINVAL);
+	}
 
-    gpu_idx = aql_perf_find_gpu_index(session, gpu_id);
-    if (gpu_idx < 0) {
-        aql_err("Session %llu: GPU %u not found in session",
-                session->session_id, gpu_id);
-        return ERR_PTR(-ENODEV);
-    }
+	gpu_idx = aql_perf_find_gpu_index(session, gpu_id);
+	if (gpu_idx < 0) {
+		aql_err("Session %llu: GPU %u not found in session", session->session_id, gpu_id);
+		return ERR_PTR(-ENODEV);
+	}
 
-    measurement = kzalloc(sizeof(*measurement), GFP_KERNEL);
-    if (!measurement) {
-        aql_err("Session %llu: Failed to allocate measurement structure",
-                session->session_id);
-        return ERR_PTR(-ENOMEM);
-    }
+	measurement = kzalloc(sizeof(*measurement), GFP_KERNEL);
+	if (!measurement) {
+		aql_err("Session %llu: Failed to allocate measurement structure",
+			session->session_id);
+		return ERR_PTR(-ENOMEM);
+	}
 
-    INIT_LIST_HEAD(&measurement->list);
-    measurement->session = session;
-    measurement->gpu_id = gpu_id;
-    measurement->event = event;
-    measurement->state = MEASUREMENT_IDLE;
-    measurement->counter_mask = 0x1; /* Default to first counter */
-    measurement->counter_id = (uint32_t)event->attr.config; /* Use event config as counter ID */
-    measurement->start_counter_value = 0;  /* Will be set when measurement starts */
-    measurement->last_counter_value = 0;
-    measurement->allocated_counter = NULL; /* No counter allocated yet */
-    measurement->shared_ref = NULL; /* No shared reference yet */
-    measurement->owns_counter = false; /* Not owning any counter yet */
+	INIT_LIST_HEAD(&measurement->list);
+	measurement->session = session;
+	measurement->gpu_id = gpu_id;
+	measurement->event = event;
+	measurement->state = MEASUREMENT_IDLE;
+	measurement->counter_mask = 0x1; /* Default to first counter */
+	measurement->counter_id = (uint32_t)event->attr.config; /* Use event config as counter ID */
+	measurement->start_counter_value = 0; /* Will be set when measurement starts */
+	measurement->last_counter_value = 0;
+	measurement->allocated_counter = NULL; /* No counter allocated yet */
+	measurement->shared_ref = NULL; /* No shared reference yet */
+	measurement->owns_counter = false; /* Not owning any counter yet */
 
-    /* Initialize cache lock for atomic context handling */
-    spin_lock_init(&measurement->cache_lock);
-    measurement->cached_counter_value = 0;
-    measurement->cache_valid = false;
+	/* Initialize cache lock for atomic context handling */
+	spin_lock_init(&measurement->cache_lock);
+	measurement->cached_counter_value = 0;
+	measurement->cache_valid = false;
 
-    /* Initialize reference count - starts at 1 for the creator */
-    kref_init(&measurement->refcount);
+	/* Initialize reference count - starts at 1 for the creator */
+	kref_init(&measurement->refcount);
 
-    aql_debug("Session %llu: Created measurement for GPU %u (initial refcount=1)",
-              session->session_id, gpu_id);
+	aql_debug("Session %llu: Created measurement for GPU %u (initial refcount=1)",
+		  session->session_id, gpu_id);
 
-    return measurement;
+	return measurement;
 }
 
 /**
@@ -691,122 +681,123 @@ struct aql_measurement *aql_perf_measurement_create(struct aql_perf_session *ses
  */
 int aql_perf_measurement_start(struct aql_measurement *measurement)
 {
-    struct aql_perf_session *session;
-    pm4_buffer_t *pm4_buffer = NULL;
-    unsigned long flags;
-    int ret;
+	struct aql_perf_session *session;
+	pm4_buffer_t *pm4_buffer = NULL;
+	unsigned long flags;
+	int ret;
 
-    if (!measurement || !measurement->session) {
-        aql_err("[PMU] Invalid measurement for start");
-        return -EINVAL;
-    }
+	if (!measurement || !measurement->session) {
+		aql_err("[PMU] Invalid measurement for start");
+		return -EINVAL;
+	}
 
-    session = measurement->session;
+	session = measurement->session;
 
-    mutex_lock(&session->session_mutex);
+	mutex_lock(&session->session_mutex);
 
-    if (session->state != SESSION_ACTIVE) {
-        aql_err("[PMU] Session %llu: Cannot start measurement, session not active",
-                session->session_id);
-        ret = -EINVAL;
-        goto unlock_session;
-    }
+	if (session->state != SESSION_ACTIVE) {
+		aql_err("[PMU] Session %llu: Cannot start measurement, session not active",
+			session->session_id);
+		ret = -EINVAL;
+		goto unlock_session;
+	}
 
-    /* Add to active measurements list */
-    spin_lock_irqsave(&session->measurement_lock, flags);
+	/* Add to active measurements list */
+	spin_lock_irqsave(&session->measurement_lock, flags);
 
-    if (measurement->state != MEASUREMENT_IDLE) {
-        aql_err("[PMU] Session %llu: Measurement already active for GPU %u",
-                session->session_id, measurement->gpu_id);
-        ret = -EBUSY;
-        spin_unlock_irqrestore(&session->measurement_lock, flags);
-        goto unlock_session;
-    }
+	if (measurement->state != MEASUREMENT_IDLE) {
+		aql_err("[PMU] Session %llu: Measurement already active for GPU %u",
+			session->session_id, measurement->gpu_id);
+		ret = -EBUSY;
+		spin_unlock_irqrestore(&session->measurement_lock, flags);
+		goto unlock_session;
+	}
 
-    measurement->state = MEASUREMENT_STARTING;
-    list_add_tail(&measurement->list, &session->active_measurements);
-    atomic_inc(&session->active_gpu_count);
-    measurement->start_time = ktime_get();
+	measurement->state = MEASUREMENT_STARTING;
+	list_add_tail(&measurement->list, &session->active_measurements);
+	atomic_inc(&session->active_gpu_count);
+	measurement->start_time = ktime_get();
 
-    spin_unlock_irqrestore(&session->measurement_lock, flags);
+	spin_unlock_irqrestore(&session->measurement_lock, flags);
 
-    /* Create START packet (allocates counter atomically or shares existing) */
-    ret = aql_perf_create_start_packet(measurement, &pm4_buffer);
-    if (ret) {
-        aql_err("[PMU] Session %llu: Failed to create START packet for GPU %u: %d",
-                session->session_id, measurement->gpu_id, ret);
-        goto cleanup_measurement;
-    }
+	/* Create START packet (allocates counter atomically or shares existing) */
+	ret = aql_perf_create_start_packet(measurement, &pm4_buffer);
+	if (ret) {
+		aql_err("[PMU] Session %llu: Failed to create START packet for GPU %u: %d",
+			session->session_id, measurement->gpu_id, ret);
+		goto cleanup_measurement;
+	}
 
-    /* If pm4_buffer is NULL, counter is shared and already started */
-    if (pm4_buffer) {
-        /* Submit PM4 buffer directly */
-        ret = aql_perf_submit_pm4_packet(session, measurement->gpu_id, pm4_buffer);
-        if (ret) {
-            counter_reg_info_t *counter;
-            aql_err("[PMU] Session %llu: Failed to submit START packet for GPU %u: %d",
-                    session->session_id, measurement->gpu_id, ret);
-            /* Counter was allocated, need to release it (use local copy to prevent TOCTOU) */
-            if (measurement->owns_counter) {
-                counter = measurement->allocated_counter;
-                if (counter) {
-                    aql_counter_release(counter);
-                    measurement->allocated_counter = NULL;
-                    measurement->owns_counter = false;
-                }
-            }
-            /* Release shared reference */
-            if (measurement->shared_ref) {
-                release_shared_counter(session, measurement->shared_ref);
-                measurement->shared_ref = NULL;
-            }
-            pm4_buffer_destroy(pm4_buffer);
-            goto cleanup_measurement;
-        }
+	/* If pm4_buffer is NULL, counter is shared and already started */
+	if (pm4_buffer) {
+		/* Submit PM4 buffer directly */
+		ret = aql_perf_submit_pm4_packet(session, measurement->gpu_id, pm4_buffer);
+		if (ret) {
+			counter_reg_info_t *counter;
+			aql_err("[PMU] Session %llu: Failed to submit START packet for GPU %u: %d",
+				session->session_id, measurement->gpu_id, ret);
+			/* Counter was allocated, need to release it (use local copy to prevent TOCTOU) */
+			if (measurement->owns_counter) {
+				counter = measurement->allocated_counter;
+				if (counter) {
+					aql_counter_release(counter);
+					measurement->allocated_counter = NULL;
+					measurement->owns_counter = false;
+				}
+			}
+			/* Release shared reference */
+			if (measurement->shared_ref) {
+				release_shared_counter(session, measurement->shared_ref);
+				measurement->shared_ref = NULL;
+			}
+			pm4_buffer_destroy(pm4_buffer);
+			goto cleanup_measurement;
+		}
 
-        /* Cleanup PM4 buffer */
-        pm4_buffer_destroy(pm4_buffer);
+		/* Cleanup PM4 buffer */
+		pm4_buffer_destroy(pm4_buffer);
 
-        /* KFD ioctl is synchronous - START packet has completed by this point.
+		/* KFD ioctl is synchronous - START packet has completed by this point.
          * The GPU has configured GRBM, enabled perfmon, set SQ control,
          * and configured counter registers. Safe to read baseline now. */
-        aql_info("[PMU] Session %llu: START packet completed", session->session_id);
+		aql_info("[PMU] Session %llu: START packet completed", session->session_id);
 
-        aql_info("[PMU] Session %llu: Started measurement for GPU %u (owns_counter=true)",
-                 session->session_id, measurement->gpu_id);
-    } else {
-        aql_info("[PMU] Session %llu: Started measurement for GPU %u (sharing counter, owns_counter=false)",
-                 session->session_id, measurement->gpu_id);
-    }
+		aql_info("[PMU] Session %llu: Started measurement for GPU %u (owns_counter=true)",
+			 session->session_id, measurement->gpu_id);
+	} else {
+		aql_info(
+			"[PMU] Session %llu: Started measurement for GPU %u (sharing counter, owns_counter=false)",
+			session->session_id, measurement->gpu_id);
+	}
 
-    /* Update state to active */
-    spin_lock_irqsave(&session->measurement_lock, flags);
-    measurement->state = MEASUREMENT_ACTIVE;
-    spin_unlock_irqrestore(&session->measurement_lock, flags);
+	/* Update state to active */
+	spin_lock_irqsave(&session->measurement_lock, flags);
+	measurement->state = MEASUREMENT_ACTIVE;
+	spin_unlock_irqrestore(&session->measurement_lock, flags);
 
-    /* Start background polling timer now that measurement is active.
+	/* Start background polling timer now that measurement is active.
      * This ensures timer only polls after measurements are ready. */
-    amdgpu_pmu_start_timer();
+	amdgpu_pmu_start_timer();
 
-    /* Read initial counter value for delta tracking.
+	/* Read initial counter value for delta tracking.
      * GPU counters don't reset on START, so we need to track the baseline. */
-    measurement->start_counter_value = aql_perf_measurement_read(measurement);
-    aql_info("[PMU] Session %llu: GPU %u baseline counter value=%llu",
-             session->session_id, measurement->gpu_id, measurement->start_counter_value);
+	measurement->start_counter_value = aql_perf_measurement_read(measurement);
+	aql_info("[PMU] Session %llu: GPU %u baseline counter value=%llu", session->session_id,
+		 measurement->gpu_id, measurement->start_counter_value);
 
-    mutex_unlock(&session->session_mutex);
-    return 0;
+	mutex_unlock(&session->session_mutex);
+	return 0;
 
 cleanup_measurement:
-    spin_lock_irqsave(&session->measurement_lock, flags);
-    list_del_init(&measurement->list);
-    measurement->state = MEASUREMENT_ERROR;
-    atomic_dec(&session->active_gpu_count);
-    spin_unlock_irqrestore(&session->measurement_lock, flags);
+	spin_lock_irqsave(&session->measurement_lock, flags);
+	list_del_init(&measurement->list);
+	measurement->state = MEASUREMENT_ERROR;
+	atomic_dec(&session->active_gpu_count);
+	spin_unlock_irqrestore(&session->measurement_lock, flags);
 
 unlock_session:
-    mutex_unlock(&session->session_mutex);
-    return ret;
+	mutex_unlock(&session->session_mutex);
+	return ret;
 }
 
 /**
@@ -822,104 +813,106 @@ unlock_session:
  */
 int aql_perf_measurement_stop(struct aql_measurement *measurement)
 {
-    struct aql_perf_session *session;
-    pm4_buffer_t *pm4_buffer = NULL;
-    unsigned long flags;
-    int ret;
+	struct aql_perf_session *session;
+	pm4_buffer_t *pm4_buffer = NULL;
+	unsigned long flags;
+	int ret;
 
-    if (!measurement || !measurement->session) {
-        aql_err("[PMU] Invalid measurement for stop");
-        return -EINVAL;
-    }
+	if (!measurement || !measurement->session) {
+		aql_err("[PMU] Invalid measurement for stop");
+		return -EINVAL;
+	}
 
-    /* If called from atomic context, use the atomic version instead */
-    if (in_atomic() || irqs_disabled()) {
-        aql_debug("[PMU] Stop called from atomic context, using async version");
-        return aql_perf_measurement_stop_atomic(measurement);
-    }
+	/* If called from atomic context, use the atomic version instead */
+	if (in_atomic() || irqs_disabled()) {
+		aql_debug("[PMU] Stop called from atomic context, using async version");
+		return aql_perf_measurement_stop_atomic(measurement);
+	}
 
-    session = measurement->session;
+	session = measurement->session;
 
-    mutex_lock(&session->session_mutex);
+	mutex_lock(&session->session_mutex);
 
-    spin_lock_irqsave(&session->measurement_lock, flags);
+	spin_lock_irqsave(&session->measurement_lock, flags);
 
-    if (measurement->state != MEASUREMENT_ACTIVE) {
-        aql_debug("[PMU] Session %llu: Measurement for GPU %u not active",
-                  session->session_id, measurement->gpu_id);
-        spin_unlock_irqrestore(&session->measurement_lock, flags);
-        mutex_unlock(&session->session_mutex);
-        return 0; /* Already stopped */
-    }
+	if (measurement->state != MEASUREMENT_ACTIVE) {
+		aql_debug("[PMU] Session %llu: Measurement for GPU %u not active",
+			  session->session_id, measurement->gpu_id);
+		spin_unlock_irqrestore(&session->measurement_lock, flags);
+		mutex_unlock(&session->session_mutex);
+		return 0; /* Already stopped */
+	}
 
-    measurement->state = MEASUREMENT_STOPPING;
-    spin_unlock_irqrestore(&session->measurement_lock, flags);
+	measurement->state = MEASUREMENT_STOPPING;
+	spin_unlock_irqrestore(&session->measurement_lock, flags);
 
-    /* Only generate STOP packet if we own the counter */
-    if (measurement->owns_counter) {
-        /* Create END packet */
-        ret = aql_perf_create_end_packet(measurement, &pm4_buffer);
-        if (ret) {
-            aql_err("[PMU] Session %llu: Failed to create END packet for GPU %u: %d",
-                    session->session_id, measurement->gpu_id, ret);
-            goto cleanup;
-        }
+	/* Only generate STOP packet if we own the counter */
+	if (measurement->owns_counter) {
+		/* Create END packet */
+		ret = aql_perf_create_end_packet(measurement, &pm4_buffer);
+		if (ret) {
+			aql_err("[PMU] Session %llu: Failed to create END packet for GPU %u: %d",
+				session->session_id, measurement->gpu_id, ret);
+			goto cleanup;
+		}
 
-        /* Submit PM4 buffer */
-        ret = aql_perf_submit_pm4_packet(session, measurement->gpu_id, pm4_buffer);
-        if (ret) {
-            aql_err("[PMU] Session %llu: Failed to submit END packet for GPU %u: %d",
-                    session->session_id, measurement->gpu_id, ret);
-            pm4_buffer_destroy(pm4_buffer);
-            goto cleanup;
-        }
+		/* Submit PM4 buffer */
+		ret = aql_perf_submit_pm4_packet(session, measurement->gpu_id, pm4_buffer);
+		if (ret) {
+			aql_err("[PMU] Session %llu: Failed to submit END packet for GPU %u: %d",
+				session->session_id, measurement->gpu_id, ret);
+			pm4_buffer_destroy(pm4_buffer);
+			goto cleanup;
+		}
 
-        /* Cleanup PM4 buffer */
-        pm4_buffer_destroy(pm4_buffer);
+		/* Cleanup PM4 buffer */
+		pm4_buffer_destroy(pm4_buffer);
 
-        /* Release allocated counter (we own it - use local copy to prevent TOCTOU) */
-        counter_reg_info_t *counter = measurement->allocated_counter;
-        if (counter) {
-            aql_counter_release(counter);
-            measurement->allocated_counter = NULL;
-            measurement->owns_counter = false;
-        }
+		/* Release allocated counter (we own it - use local copy to prevent TOCTOU) */
+		counter_reg_info_t *counter = measurement->allocated_counter;
+		if (counter) {
+			aql_counter_release(counter);
+			measurement->allocated_counter = NULL;
+			measurement->owns_counter = false;
+		}
 
-        aql_info("[PMU] Session %llu: Stopped measurement for GPU %u (owned counter, released)",
-                 session->session_id, measurement->gpu_id);
-    } else {
-        aql_info("[PMU] Session %llu: Stopped measurement for GPU %u (shared counter, not releasing)",
-                 session->session_id, measurement->gpu_id);
-    }
+		aql_info(
+			"[PMU] Session %llu: Stopped measurement for GPU %u (owned counter, released)",
+			session->session_id, measurement->gpu_id);
+	} else {
+		aql_info(
+			"[PMU] Session %llu: Stopped measurement for GPU %u (shared counter, not releasing)",
+			session->session_id, measurement->gpu_id);
+	}
 
-    /* Release shared reference (decrements ref count) */
-    if (measurement->shared_ref) {
-        release_shared_counter(session, measurement->shared_ref);
-        measurement->shared_ref = NULL;
-    }
+	/* Release shared reference (decrements ref count) */
+	if (measurement->shared_ref) {
+		release_shared_counter(session, measurement->shared_ref);
+		measurement->shared_ref = NULL;
+	}
 
-    /* Remove from active measurements */
-    spin_lock_irqsave(&session->measurement_lock, flags);
-    list_del_init(&measurement->list);
-    measurement->state = MEASUREMENT_IDLE;
-    atomic_dec(&session->active_gpu_count);
-    spin_unlock_irqrestore(&session->measurement_lock, flags);
+	/* Remove from active measurements */
+	spin_lock_irqsave(&session->measurement_lock, flags);
+	list_del_init(&measurement->list);
+	measurement->state = MEASUREMENT_IDLE;
+	atomic_dec(&session->active_gpu_count);
+	spin_unlock_irqrestore(&session->measurement_lock, flags);
 
-    /* Stop timer if no more active measurements */
-    amdgpu_pmu_stop_timer_if_idle();
+	/* Stop timer if no more active measurements */
+	amdgpu_pmu_stop_timer_if_idle();
 
-    mutex_unlock(&session->session_mutex);
-    return 0;
+	mutex_unlock(&session->session_mutex);
+	return 0;
 
 cleanup:
-    spin_lock_irqsave(&session->measurement_lock, flags);
-    list_del_init(&measurement->list);
-    measurement->state = MEASUREMENT_ERROR;
-    atomic_dec(&session->active_gpu_count);
-    spin_unlock_irqrestore(&session->measurement_lock, flags);
+	spin_lock_irqsave(&session->measurement_lock, flags);
+	list_del_init(&measurement->list);
+	measurement->state = MEASUREMENT_ERROR;
+	atomic_dec(&session->active_gpu_count);
+	spin_unlock_irqrestore(&session->measurement_lock, flags);
 
-    mutex_unlock(&session->session_mutex);
-    return ret;
+	mutex_unlock(&session->session_mutex);
+	return ret;
 }
 
 /**
@@ -935,43 +928,42 @@ cleanup:
  *
  * Returns: Sum of all instance values
  */
-static uint64_t aql_aggregate_counter_instances(
-    struct aql_perf_session *session,
-    struct aql_measurement *measurement,
-    uint64_t *result_buffer,
-    int gpu_idx)
+static uint64_t aql_aggregate_counter_instances(struct aql_perf_session *session,
+						struct aql_measurement *measurement,
+						uint64_t *result_buffer, int gpu_idx)
 {
-    arch_t *arch = session->archs[gpu_idx];
-    const counter_def_t *counter_def = lookup_counter_by_id((counter_id_t)measurement->counter_id);
-    block_info_t *block = arch->block_map.blocks[counter_def->hw_block];
-    uint64_t sum = 0;
-    uint32_t num_instances = 1;
+	arch_t *arch = session->archs[gpu_idx];
+	const counter_def_t *counter_def =
+		lookup_counter_by_id((counter_id_t)measurement->counter_id);
+	block_info_t *block = arch->block_map.blocks[counter_def->hw_block];
+	uint64_t sum = 0;
+	uint32_t num_instances = 1;
 
-    /* Determine total number of instances based on block dimensions */
-    for (size_t dim_idx = 0; dim_idx < block->dimension_count; dim_idx++) {
-        num_instances *= block->dimensions[dim_idx].size;
-    }
+	/* Determine total number of instances based on block dimensions */
+	for (size_t dim_idx = 0; dim_idx < block->dimension_count; dim_idx++) {
+		num_instances *= block->dimensions[dim_idx].size;
+	}
 
-    aql_info("[PMU] Aggregating %u instances (block dimensions: count=%zu)",
-             num_instances, block->dimension_count);
+	aql_info("[PMU] Aggregating %u instances (block dimensions: count=%zu)", num_instances,
+		 block->dimension_count);
 
-    /* Sum all instances and log individual values for debugging */
-    for (uint32_t i = 0; i < num_instances; i++) {
-        uint64_t value = result_buffer[i];
-        sum += value;
+	/* Sum all instances and log individual values for debugging */
+	for (uint32_t i = 0; i < num_instances; i++) {
+		uint64_t value = result_buffer[i];
+		sum += value;
 
-        /* Log first 20 and last 5 values to see patterns */
-        if (i < 20 || i >= (num_instances - 5)) {
-            aql_info("[PMU]   instance[%u] = %llu", i, value);
-        } else if (i == 20) {
-            aql_info("[PMU]   ... (skipping middle instances) ...");
-        }
-    }
+		/* Log first 20 and last 5 values to see patterns */
+		if (i < 20 || i >= (num_instances - 5)) {
+			aql_info("[PMU]   instance[%u] = %llu", i, value);
+		} else if (i == 20) {
+			aql_info("[PMU]   ... (skipping middle instances) ...");
+		}
+	}
 
-    aql_info("[PMU] Aggregated %u instances, total=%llu", num_instances, sum);
-    aql_info("[PMU] ========== AGGREGATION RESULT: %llu (0x%llx) ==========", sum, sum);
+	aql_info("[PMU] Aggregated %u instances, total=%llu", num_instances, sum);
+	aql_info("[PMU] ========== AGGREGATION RESULT: %llu (0x%llx) ==========", sum, sum);
 
-    return sum;
+	return sum;
 }
 
 /**
@@ -981,22 +973,24 @@ static uint64_t aql_aggregate_counter_instances(
  */
 static void read_diagnostic_log_buffer(struct aql_measurement *measurement, const char *when)
 {
-    counter_reg_info_t *counter = measurement->allocated_counter;
-    uint64_t *buffer;
+	counter_reg_info_t *counter = measurement->allocated_counter;
+	uint64_t *buffer;
 
-    if (!counter || !counter->allocation.data_buffer)
-        return;
+	if (!counter || !counter->allocation.data_buffer)
+		return;
 
-    buffer = (uint64_t*)counter->allocation.data_buffer->cpu_addr;
+	buffer = (uint64_t *)counter->allocation.data_buffer->cpu_addr;
 
-    if (strcmp(when, "BEFORE READ") == 0) {
-        aql_info("[PMU] READ_SYNC: GPU %u, buffer %s: [0]=0x%llx [1]=0x%llx [2]=0x%llx [3]=0x%llx",
-                 measurement->gpu_id, when, buffer[0], buffer[1], buffer[2], buffer[3]);
-    } else {
-        aql_info("[PMU] READ_SYNC: GPU %u, buffer %s: [0]=0x%llx [1]=0x%llx [2]=0x%llx [3]=0x%llx [4]=0x%llx [5]=0x%llx [6]=0x%llx [7]=0x%llx",
-                 measurement->gpu_id, when, buffer[0], buffer[1], buffer[2], buffer[3],
-                 buffer[4], buffer[5], buffer[6], buffer[7]);
-    }
+	if (strcmp(when, "BEFORE READ") == 0) {
+		aql_info(
+			"[PMU] READ_SYNC: GPU %u, buffer %s: [0]=0x%llx [1]=0x%llx [2]=0x%llx [3]=0x%llx",
+			measurement->gpu_id, when, buffer[0], buffer[1], buffer[2], buffer[3]);
+	} else {
+		aql_info(
+			"[PMU] READ_SYNC: GPU %u, buffer %s: [0]=0x%llx [1]=0x%llx [2]=0x%llx [3]=0x%llx [4]=0x%llx [5]=0x%llx [6]=0x%llx [7]=0x%llx",
+			measurement->gpu_id, when, buffer[0], buffer[1], buffer[2], buffer[3],
+			buffer[4], buffer[5], buffer[6], buffer[7]);
+	}
 }
 
 /**
@@ -1008,29 +1002,30 @@ static void read_diagnostic_log_buffer(struct aql_measurement *measurement, cons
  */
 static int read_submit_packet(struct aql_perf_session *session, struct aql_measurement *measurement)
 {
-    pm4_buffer_t *pm4_buffer = NULL;
-    int ret;
+	pm4_buffer_t *pm4_buffer = NULL;
+	int ret;
 
-    aql_info("[PMU] READ_SYNC: GPU %u, creating READ packet", measurement->gpu_id);
-    ret = aql_perf_create_read_packet(measurement, &pm4_buffer);
-    if (ret) {
-        aql_err("[PMU] READ_SYNC: GPU %u, failed to create READ packet: %d",
-                measurement->gpu_id, ret);
-        return ret;
-    }
+	aql_info("[PMU] READ_SYNC: GPU %u, creating READ packet", measurement->gpu_id);
+	ret = aql_perf_create_read_packet(measurement, &pm4_buffer);
+	if (ret) {
+		aql_err("[PMU] READ_SYNC: GPU %u, failed to create READ packet: %d",
+			measurement->gpu_id, ret);
+		return ret;
+	}
 
-    aql_info("[PMU] READ_SYNC: GPU %u, submitting PM4 READ packet (size=%zu DWORDs)",
-             measurement->gpu_id, pm4_buffer ? pm4_buffer->size : (size_t)0);
-    ret = aql_perf_submit_pm4_packet(session, measurement->gpu_id, pm4_buffer);
-    pm4_buffer_destroy(pm4_buffer);
-    if (ret) {
-        aql_err("[PMU] READ_SYNC: GPU %u, failed to submit READ packet: %d",
-                measurement->gpu_id, ret);
-        return ret;
-    }
+	aql_info("[PMU] READ_SYNC: GPU %u, submitting PM4 READ packet (size=%zu DWORDs)",
+		 measurement->gpu_id, pm4_buffer ? pm4_buffer->size : (size_t)0);
+	ret = aql_perf_submit_pm4_packet(session, measurement->gpu_id, pm4_buffer);
+	pm4_buffer_destroy(pm4_buffer);
+	if (ret) {
+		aql_err("[PMU] READ_SYNC: GPU %u, failed to submit READ packet: %d",
+			measurement->gpu_id, ret);
+		return ret;
+	}
 
-    aql_info("[PMU] READ_SYNC: GPU %u, READ packet submitted successfully", measurement->gpu_id);
-    return 0;
+	aql_info("[PMU] READ_SYNC: GPU %u, READ packet submitted successfully",
+		 measurement->gpu_id);
+	return 0;
 }
 
 /**
@@ -1041,20 +1036,20 @@ static int read_submit_packet(struct aql_perf_session *session, struct aql_measu
  */
 static uint64_t *read_get_result_buffer(struct aql_measurement *measurement)
 {
-    counter_reg_info_t *counter = measurement->allocated_counter;
-    uint64_t *result_buffer = NULL;
+	counter_reg_info_t *counter = measurement->allocated_counter;
+	uint64_t *result_buffer = NULL;
 
-    if (counter && counter->allocation.data_buffer) {
-        result_buffer = (uint64_t*)counter->allocation.data_buffer->cpu_addr;
-        aql_info("[PMU] READ_SYNC: GPU %u, data_buffer CPU addr=%p, GPU addr=0x%llx",
-                 measurement->gpu_id, result_buffer,
-                 (unsigned long long)counter->allocation.data_buffer->gpu_addr);
-    } else {
-        aql_warn("[PMU] READ_SYNC: GPU %u, no data buffer available (allocated_counter=%p)",
-                 measurement->gpu_id, counter);
-    }
+	if (counter && counter->allocation.data_buffer) {
+		result_buffer = (uint64_t *)counter->allocation.data_buffer->cpu_addr;
+		aql_info("[PMU] READ_SYNC: GPU %u, data_buffer CPU addr=%p, GPU addr=0x%llx",
+			 measurement->gpu_id, result_buffer,
+			 (unsigned long long)counter->allocation.data_buffer->gpu_addr);
+	} else {
+		aql_warn("[PMU] READ_SYNC: GPU %u, no data buffer available (allocated_counter=%p)",
+			 measurement->gpu_id, counter);
+	}
 
-    return result_buffer;
+	return result_buffer;
 }
 
 /**
@@ -1067,45 +1062,41 @@ static uint64_t *read_get_result_buffer(struct aql_measurement *measurement)
  * Returns: Counter value
  */
 static uint64_t read_extract_counter_value(struct aql_perf_session *session,
-                                          struct aql_measurement *measurement,
-                                          uint64_t *result_buffer,
-                                          int gpu_idx)
+					   struct aql_measurement *measurement,
+					   uint64_t *result_buffer, int gpu_idx)
 {
-    uint64_t counter_value;
+	uint64_t counter_value;
 
-    if (!result_buffer) {
-        return -1;
-    }
+	if (!result_buffer) {
+		return -1;
+	}
 
-    if (measurement->dimension_specific) {
-        /*
+	if (measurement->dimension_specific) {
+		/*
          * Dimension-specific counter: filter to return only the specific instance.
          * The GPU read packet collects all instances in a flat array.
          * Calculate the flat index for the target dimension and return only that value.
          */
-        arch_t *arch = session->archs[gpu_idx];
-        uint32_t flat_idx = encode_dimension_index(
-            measurement->target_dims.se,
-            measurement->target_dims.sa,
-            measurement->target_dims.wgp,
-            arch->num_sa,
-            arch->num_wgp_per_sa
-        );
+		arch_t *arch = session->archs[gpu_idx];
+		uint32_t flat_idx = encode_dimension_index(measurement->target_dims.se,
+							   measurement->target_dims.sa,
+							   measurement->target_dims.wgp,
+							   arch->num_sa, arch->num_wgp_per_sa);
 
-        counter_value = result_buffer[flat_idx];
+		counter_value = result_buffer[flat_idx];
 
-        aql_info("[PMU] READ_SYNC: GPU %u, dimension-specific read: SE=%u SA=%u WGP=%u -> flat_idx=%u, value=%llu",
-                 measurement->gpu_id,
-                 measurement->target_dims.se,
-                 measurement->target_dims.sa,
-                 measurement->target_dims.wgp,
-                 flat_idx, counter_value);
-    } else {
-        /* Aggregate across all instances */
-        counter_value = aql_aggregate_counter_instances(session, measurement, result_buffer, gpu_idx);
-    }
+		aql_info(
+			"[PMU] READ_SYNC: GPU %u, dimension-specific read: SE=%u SA=%u WGP=%u -> flat_idx=%u, value=%llu",
+			measurement->gpu_id, measurement->target_dims.se,
+			measurement->target_dims.sa, measurement->target_dims.wgp, flat_idx,
+			counter_value);
+	} else {
+		/* Aggregate across all instances */
+		counter_value = aql_aggregate_counter_instances(session, measurement, result_buffer,
+								gpu_idx);
+	}
 
-    return counter_value;
+	return counter_value;
 }
 
 /**
@@ -1117,25 +1108,25 @@ static uint64_t read_extract_counter_value(struct aql_perf_session *session,
  */
 static uint64_t read_compute_delta(struct aql_measurement *measurement, uint64_t counter_value)
 {
-    uint64_t delta = 0;
+	uint64_t delta = 0;
 
-    /* Compute delta from start value.
+	/* Compute delta from start value.
      * GPU counters are cumulative and don't reset on START, so we track
      * the baseline value and return the delta for this measurement period. */
-    if (counter_value >= measurement->start_counter_value) {
-        delta = counter_value - measurement->start_counter_value;
-    } else {
-        /* Counter wrapped around (very unlikely for 64-bit counters) */
-        aql_warn("[PMU] READ_SYNC: GPU %u counter wrapped: start=%llu, current=%llu",
-                 measurement->gpu_id, measurement->start_counter_value, counter_value);
-        delta = counter_value; /* Best effort */
-    }
+	if (counter_value >= measurement->start_counter_value) {
+		delta = counter_value - measurement->start_counter_value;
+	} else {
+		/* Counter wrapped around (very unlikely for 64-bit counters) */
+		aql_warn("[PMU] READ_SYNC: GPU %u counter wrapped: start=%llu, current=%llu",
+			 measurement->gpu_id, measurement->start_counter_value, counter_value);
+		delta = counter_value; /* Best effort */
+	}
 
-    aql_info("[PMU] READ_SYNC: GPU %u, delta=%llu (current=%llu - start=%llu)",
-             measurement->gpu_id, delta, counter_value, measurement->start_counter_value);
-    aql_info("[PMU] ========== COMPUTED DELTA: %llu (0x%llx) ==========", delta, delta);
+	aql_info("[PMU] READ_SYNC: GPU %u, delta=%llu (current=%llu - start=%llu)",
+		 measurement->gpu_id, delta, counter_value, measurement->start_counter_value);
+	aql_info("[PMU] ========== COMPUTED DELTA: %llu (0x%llx) ==========", delta, delta);
 
-    return delta;
+	return delta;
 }
 
 /**
@@ -1146,63 +1137,63 @@ static uint64_t read_compute_delta(struct aql_measurement *measurement, uint64_t
  */
 uint64_t aql_perf_measurement_read(struct aql_measurement *measurement)
 {
-    struct aql_perf_session *session;
-    uint64_t *result_buffer;
-    uint64_t counter_value;
-    int gpu_idx;
-    int ret;
+	struct aql_perf_session *session;
+	uint64_t *result_buffer;
+	uint64_t counter_value;
+	int gpu_idx;
+	int ret;
 
-    aql_info("[PMU] READ_SYNC: Entry for GPU %u",
-             measurement ? measurement->gpu_id : 0);
+	aql_info("[PMU] READ_SYNC: Entry for GPU %u", measurement ? measurement->gpu_id : 0);
 
-    if (!measurement || !measurement->session) {
-        aql_err("[PMU] READ_SYNC: Invalid measurement for read");
-        return 0;
-    }
+	if (!measurement || !measurement->session) {
+		aql_err("[PMU] READ_SYNC: Invalid measurement for read");
+		return 0;
+	}
 
-    session = measurement->session;
+	session = measurement->session;
 
-    aql_info("[PMU] READ_SYNC: GPU %u, state=%d, allocated_counter=%p",
-             measurement->gpu_id, measurement->state, measurement->allocated_counter);
+	aql_info("[PMU] READ_SYNC: GPU %u, state=%d, allocated_counter=%p", measurement->gpu_id,
+		 measurement->state, measurement->allocated_counter);
 
-    if (measurement->state != MEASUREMENT_ACTIVE) {
-        aql_info("[PMU] READ_SYNC: GPU %u not active (state=%d), returning cached value %llu",
-                 measurement->gpu_id, measurement->state, measurement->last_counter_value);
-        return measurement->last_counter_value;
-    }
+	if (measurement->state != MEASUREMENT_ACTIVE) {
+		aql_info(
+			"[PMU] READ_SYNC: GPU %u not active (state=%d), returning cached value %llu",
+			measurement->gpu_id, measurement->state, measurement->last_counter_value);
+		return measurement->last_counter_value;
+	}
 
-    gpu_idx = aql_perf_find_gpu_index(session, measurement->gpu_id);
-    if (gpu_idx < 0) {
-        aql_err("[PMU] READ_SYNC: GPU %u not found for read", measurement->gpu_id);
-        return measurement->last_counter_value;
-    }
+	gpu_idx = aql_perf_find_gpu_index(session, measurement->gpu_id);
+	if (gpu_idx < 0) {
+		aql_err("[PMU] READ_SYNC: GPU %u not found for read", measurement->gpu_id);
+		return measurement->last_counter_value;
+	}
 
-    /* DIAGNOSTIC: Log buffer contents before READ */
-    read_diagnostic_log_buffer(measurement, "BEFORE READ");
+	/* DIAGNOSTIC: Log buffer contents before READ */
+	read_diagnostic_log_buffer(measurement, "BEFORE READ");
 
-    /* Create and submit READ packet */
-    ret = read_submit_packet(session, measurement);
-    if (ret) {
-        return measurement->last_counter_value;
-    }
+	/* Create and submit READ packet */
+	ret = read_submit_packet(session, measurement);
+	if (ret) {
+		return measurement->last_counter_value;
+	}
 
-    /* DIAGNOSTIC: Log buffer contents after READ */
-    read_diagnostic_log_buffer(measurement, "AFTER READ");
+	/* DIAGNOSTIC: Log buffer contents after READ */
+	read_diagnostic_log_buffer(measurement, "AFTER READ");
 
-    /* Get result buffer and extract counter value */
-    result_buffer = read_get_result_buffer(measurement);
-    counter_value = read_extract_counter_value(session, measurement, result_buffer, gpu_idx);
+	/* Get result buffer and extract counter value */
+	result_buffer = read_get_result_buffer(measurement);
+	counter_value = read_extract_counter_value(session, measurement, result_buffer, gpu_idx);
 
-    aql_info("[PMU] READ_SYNC: GPU %u, absolute counter_value=%llu (dimension_specific=%d)",
-             measurement->gpu_id, counter_value, measurement->dimension_specific);
-    aql_info("[PMU] ========== RAW COUNTER VALUE: %llu (0x%llx) ==========",
-             counter_value, counter_value);
+	aql_info("[PMU] READ_SYNC: GPU %u, absolute counter_value=%llu (dimension_specific=%d)",
+		 measurement->gpu_id, counter_value, measurement->dimension_specific);
+	aql_info("[PMU] ========== RAW COUNTER VALUE: %llu (0x%llx) ==========", counter_value,
+		 counter_value);
 
-    /* Update cached value with absolute counter value */
-    measurement->last_counter_value = counter_value;
+	/* Update cached value with absolute counter value */
+	measurement->last_counter_value = counter_value;
 
-    /* Compute and return delta */
-    return read_compute_delta(measurement, counter_value);
+	/* Compute and return delta */
+	return read_compute_delta(measurement, counter_value);
 }
 
 /**
@@ -1215,79 +1206,78 @@ uint64_t aql_perf_measurement_read(struct aql_measurement *measurement)
  */
 void aql_perf_measurement_destroy(struct aql_measurement *measurement)
 {
-    bool is_atomic_ctx;
-    unsigned long flags;
+	bool is_atomic_ctx;
+	unsigned long flags;
 
-    if (!measurement)
-        return;
+	if (!measurement)
+		return;
 
-    aql_debug("[PMU] Destroying measurement for GPU %u", measurement->gpu_id);
+	aql_debug("[PMU] Destroying measurement for GPU %u", measurement->gpu_id);
 
-    /* Check if we're in atomic context (e.g., called from pmu_stub_del) */
-    is_atomic_ctx = in_atomic() || irqs_disabled();
+	/* Check if we're in atomic context (e.g., called from pmu_stub_del) */
+	is_atomic_ctx = in_atomic() || irqs_disabled();
 
-    if (is_atomic_ctx) {
-        aql_debug("[PMU] Destroy called from atomic context");
+	if (is_atomic_ctx) {
+		aql_debug("[PMU] Destroy called from atomic context");
 
-        /* Queue async STOP work if measurement is still active */
-        if (measurement->state == MEASUREMENT_ACTIVE) {
-            aql_debug("[PMU] Queueing async STOP from atomic destroy");
-            aql_perf_measurement_stop_atomic(measurement);
-        }
+		/* Queue async STOP work if measurement is still active */
+		if (measurement->state == MEASUREMENT_ACTIVE) {
+			aql_debug("[PMU] Queueing async STOP from atomic destroy");
+			aql_perf_measurement_stop_atomic(measurement);
+		}
 
-        /* Just drop the creator's reference - if there are pending work items,
+		/* Just drop the creator's reference - if there are pending work items,
          * they hold references and will keep the measurement alive until they complete */
-        aql_measurement_put(measurement);
-        return;
-    }
+		aql_measurement_put(measurement);
+		return;
+	}
 
-    /* Non-atomic context: safe to do synchronous cleanup before releasing reference */
+	/* Non-atomic context: safe to do synchronous cleanup before releasing reference */
 
-    /* Ensure measurement is stopped */
-    if (measurement->state == MEASUREMENT_ACTIVE) {
-        aql_debug("[PMU] Stopping active measurement before destroy");
-        aql_perf_measurement_stop(measurement);
-    }
+	/* Ensure measurement is stopped */
+	if (measurement->state == MEASUREMENT_ACTIVE) {
+		aql_debug("[PMU] Stopping active measurement before destroy");
+		aql_perf_measurement_stop(measurement);
+	}
 
-    /* Remove from session's active measurements list while we still have the session pointer.
+	/* Remove from session's active measurements list while we still have the session pointer.
      * The release callback will handle this too, but doing it here ensures it's done
      * before we drop our reference. */
-    if (measurement->session && !list_empty(&measurement->list)) {
-        spin_lock_irqsave(&measurement->session->measurement_lock, flags);
-        if (!list_empty(&measurement->list)) {
-            list_del_init(&measurement->list);
-            atomic_dec(&measurement->session->active_gpu_count);
-            aql_debug("[PMU] Removed measurement from active list");
-        }
-        spin_unlock_irqrestore(&measurement->session->measurement_lock, flags);
-    }
+	if (measurement->session && !list_empty(&measurement->list)) {
+		spin_lock_irqsave(&measurement->session->measurement_lock, flags);
+		if (!list_empty(&measurement->list)) {
+			list_del_init(&measurement->list);
+			atomic_dec(&measurement->session->active_gpu_count);
+			aql_debug("[PMU] Removed measurement from active list");
+		}
+		spin_unlock_irqrestore(&measurement->session->measurement_lock, flags);
+	}
 
-    /* Ensure counter is released if still allocated and owned (use local copy to prevent TOCTOU) */
-    if (measurement->owns_counter) {
-        counter_reg_info_t *counter = measurement->allocated_counter;
-        if (counter) {
-            aql_debug("[PMU] Releasing owned counter during destroy");
-            aql_counter_release(counter);
-            measurement->allocated_counter = NULL;
-            measurement->owns_counter = false;
-        }
-    }
+	/* Ensure counter is released if still allocated and owned (use local copy to prevent TOCTOU) */
+	if (measurement->owns_counter) {
+		counter_reg_info_t *counter = measurement->allocated_counter;
+		if (counter) {
+			aql_debug("[PMU] Releasing owned counter during destroy");
+			aql_counter_release(counter);
+			measurement->allocated_counter = NULL;
+			measurement->owns_counter = false;
+		}
+	}
 
-    /* Release shared counter reference if still held */
-    if (measurement->shared_ref) {
-        aql_debug("[PMU] Releasing shared counter reference during destroy");
-        release_shared_counter(measurement->session, measurement->shared_ref);
-        measurement->shared_ref = NULL;
-    }
+	/* Release shared counter reference if still held */
+	if (measurement->shared_ref) {
+		aql_debug("[PMU] Releasing shared counter reference during destroy");
+		release_shared_counter(measurement->session, measurement->shared_ref);
+		measurement->shared_ref = NULL;
+	}
 
-    aql_debug("[PMU] Session %llu: Cleanup complete for GPU %u, releasing creator's reference",
-              measurement->session ? measurement->session->session_id : 0,
-              measurement->gpu_id);
+	aql_debug("[PMU] Session %llu: Cleanup complete for GPU %u, releasing creator's reference",
+		  measurement->session ? measurement->session->session_id : 0, measurement->gpu_id);
 
-    /* Release the creator's reference - this may trigger aql_measurement_release()
+	/* Release the creator's reference - this may trigger aql_measurement_release()
      * if there are no pending work items. If work items exist, they hold references
      * and will trigger the final release when they complete. */
-    aql_measurement_put(measurement);
+	aql_measurement_put(measurement);
 }
 
 /* Work Queue Implementation for Atomic Context Support */
@@ -1298,69 +1288,69 @@ void aql_perf_measurement_destroy(struct aql_measurement *measurement)
  */
 void aql_work_handler(struct work_struct *work)
 {
-    struct aql_work_item *work_item = container_of(work, struct aql_work_item, work);
-    struct aql_measurement *measurement = work_item->measurement;
-    int result = 0;
-    unsigned long flags;
+	struct aql_work_item *work_item = container_of(work, struct aql_work_item, work);
+	struct aql_measurement *measurement = work_item->measurement;
+	int result = 0;
+	unsigned long flags;
 
-    aql_debug("Starting work handler for GPU %u, op_type=%d",
-              measurement->gpu_id, work_item->op_type);
+	aql_debug("Starting work handler for GPU %u, op_type=%d", measurement->gpu_id,
+		  work_item->op_type);
 
-    switch (work_item->op_type) {
-    case AQL_WORK_START:
-        result = aql_perf_measurement_start(measurement);
-        break;
+	switch (work_item->op_type) {
+	case AQL_WORK_START:
+		result = aql_perf_measurement_start(measurement);
+		break;
 
-    case AQL_WORK_STOP:
-        result = aql_perf_measurement_stop(measurement);
-        break;
+	case AQL_WORK_STOP:
+		result = aql_perf_measurement_stop(measurement);
+		break;
 
-    case AQL_WORK_READ:
-        {
-            aql_info("[PMU] WORK_READ: Starting for GPU %u", measurement->gpu_id);
-            uint64_t counter_value = aql_perf_measurement_read(measurement);
-            aql_info("[PMU] WORK_READ: GPU %u, read returned counter_value=%llu",
-                     measurement->gpu_id, counter_value);
+	case AQL_WORK_READ: {
+		aql_info("[PMU] WORK_READ: Starting for GPU %u", measurement->gpu_id);
+		uint64_t counter_value = aql_perf_measurement_read(measurement);
+		aql_info("[PMU] WORK_READ: GPU %u, read returned counter_value=%llu",
+			 measurement->gpu_id, counter_value);
 
-            /* Update cached value with fresh read */
-            spin_lock_irqsave(&measurement->cache_lock, flags);
-            uint64_t old_cached = measurement->cached_counter_value;
-            bool was_valid = measurement->cache_valid;
-            measurement->cached_counter_value = counter_value;
-            measurement->cache_valid = true;
-            spin_unlock_irqrestore(&measurement->cache_lock, flags);
+		/* Update cached value with fresh read */
+		spin_lock_irqsave(&measurement->cache_lock, flags);
+		uint64_t old_cached = measurement->cached_counter_value;
+		bool was_valid = measurement->cache_valid;
+		measurement->cached_counter_value = counter_value;
+		measurement->cache_valid = true;
+		spin_unlock_irqrestore(&measurement->cache_lock, flags);
 
-            aql_info("[PMU] WORK_READ: GPU %u, updated cache: old=%llu (valid=%d) -> new=%llu (valid=1)",
-                     measurement->gpu_id, old_cached, was_valid, counter_value);
-            aql_info("[PMU] ========== CACHED VALUE UPDATED: %llu (0x%llx) ==========",
-                     counter_value, counter_value);
-            result = 0; /* Read operations always succeed if we get here */
-        }
-        break;
+		aql_info(
+			"[PMU] WORK_READ: GPU %u, updated cache: old=%llu (valid=%d) -> new=%llu (valid=1)",
+			measurement->gpu_id, old_cached, was_valid, counter_value);
+		aql_info("[PMU] ========== CACHED VALUE UPDATED: %llu (0x%llx) ==========",
+			 counter_value, counter_value);
+		result = 0; /* Read operations always succeed if we get here */
+	} break;
 
-    default:
-        aql_err("Unknown work operation type: %d", work_item->op_type);
-        result = -EINVAL;
-        break;
-    }
+	default:
+		aql_err("Unknown work operation type: %d", work_item->op_type);
+		result = -EINVAL;
+		break;
+	}
 
-    work_item->result = result;
+	work_item->result = result;
 
-    /* Signal completion if waiting */
-    if (work_item->completion) {
-        complete(work_item->completion);
-    }
+	/* Signal completion if waiting */
+	if (work_item->completion) {
+		complete(work_item->completion);
+	}
 
-    aql_debug("Completed work handler for GPU %u, op_type=%d, result=%d",
-              measurement->gpu_id, work_item->op_type, result);
+	aql_debug("Completed work handler for GPU %u, op_type=%d, result=%d", measurement->gpu_id,
+		  work_item->op_type, result);
 
-    /* Release the measurement reference we took when creating the work item.
+	/* Release the measurement reference we took when creating the work item.
      * This may trigger aql_measurement_release() if it was the last reference. */
-    aql_measurement_put(measurement);
+	aql_measurement_put(measurement);
 
-    /* Free the work item structure */
-    kfree(work_item);
-    aql_debug("Work handler cleanup complete: released measurement reference and freed work_item");
+	/* Free the work item structure */
+	kfree(work_item);
+	aql_debug(
+		"Work handler cleanup complete: released measurement reference and freed work_item");
 }
 
 /**
@@ -1371,33 +1361,33 @@ void aql_work_handler(struct work_struct *work)
  * Returns: Work item or ERR_PTR on error
  */
 struct aql_work_item *aql_create_work_item(struct aql_measurement *measurement,
-                                          enum aql_work_op_type op_type)
+					   enum aql_work_op_type op_type)
 {
-    struct aql_work_item *work_item;
+	struct aql_work_item *work_item;
 
-    if (!measurement) {
-        aql_err("Invalid measurement");
-        return ERR_PTR(-EINVAL);
-    }
+	if (!measurement) {
+		aql_err("Invalid measurement");
+		return ERR_PTR(-EINVAL);
+	}
 
-    work_item = kzalloc(sizeof(*work_item), GFP_ATOMIC);
-    if (!work_item) {
-        aql_err("Failed to allocate work item");
-        return ERR_PTR(-ENOMEM);
-    }
+	work_item = kzalloc(sizeof(*work_item), GFP_ATOMIC);
+	if (!work_item) {
+		aql_err("Failed to allocate work item");
+		return ERR_PTR(-ENOMEM);
+	}
 
-    INIT_WORK(&work_item->work, aql_work_handler);
-    work_item->measurement = measurement;
-    work_item->op_type = op_type;
-    work_item->completion = NULL;
-    work_item->result = 0;
+	INIT_WORK(&work_item->work, aql_work_handler);
+	work_item->measurement = measurement;
+	work_item->op_type = op_type;
+	work_item->completion = NULL;
+	work_item->result = 0;
 
-    /* Take a reference to the measurement to prevent use-after-free */
-    aql_measurement_get(measurement);
-    aql_debug("Work item created for GPU %u, op_type=%d, took measurement reference",
-              measurement->gpu_id, op_type);
+	/* Take a reference to the measurement to prevent use-after-free */
+	aql_measurement_get(measurement);
+	aql_debug("Work item created for GPU %u, op_type=%d, took measurement reference",
+		  measurement->gpu_id, op_type);
 
-    return work_item;
+	return work_item;
 }
 
 /**
@@ -1408,35 +1398,34 @@ struct aql_work_item *aql_create_work_item(struct aql_measurement *measurement,
  */
 int aql_perf_measurement_start_atomic(struct aql_measurement *measurement)
 {
-    struct aql_work_item *work_item;
-    struct workqueue_struct *wq;
+	struct aql_work_item *work_item;
+	struct workqueue_struct *wq;
 
-    if (!measurement) {
-        return -EINVAL;
-    }
+	if (!measurement) {
+		return -EINVAL;
+	}
 
-    wq = aql_get_global_workqueue();
-    if (!wq) {
-        aql_err("Global workqueue not available");
-        return -EINVAL;
-    }
+	wq = aql_get_global_workqueue();
+	if (!wq) {
+		aql_err("Global workqueue not available");
+		return -EINVAL;
+	}
 
-    work_item = aql_create_work_item(measurement, AQL_WORK_START);
-    if (IS_ERR(work_item)) {
-        return PTR_ERR(work_item);
-    }
+	work_item = aql_create_work_item(measurement, AQL_WORK_START);
+	if (IS_ERR(work_item)) {
+		return PTR_ERR(work_item);
+	}
 
-    /* Schedule work without waiting on global workqueue */
-    if (!queue_work(wq, &work_item->work)) {
-        /* Work already queued - release our reference and free work_item */
-        aql_measurement_put(measurement);
-        kfree(work_item);
-        return -EBUSY; /* Work already queued */
-    }
+	/* Schedule work without waiting on global workqueue */
+	if (!queue_work(wq, &work_item->work)) {
+		/* Work already queued - release our reference and free work_item */
+		aql_measurement_put(measurement);
+		kfree(work_item);
+		return -EBUSY; /* Work already queued */
+	}
 
-    aql_debug("Scheduled START work for GPU %u from atomic context",
-              measurement->gpu_id);
-    return 0;
+	aql_debug("Scheduled START work for GPU %u from atomic context", measurement->gpu_id);
+	return 0;
 }
 
 /**
@@ -1447,35 +1436,34 @@ int aql_perf_measurement_start_atomic(struct aql_measurement *measurement)
  */
 int aql_perf_measurement_stop_atomic(struct aql_measurement *measurement)
 {
-    struct aql_work_item *work_item;
-    struct workqueue_struct *wq;
+	struct aql_work_item *work_item;
+	struct workqueue_struct *wq;
 
-    if (!measurement) {
-        return -EINVAL;
-    }
+	if (!measurement) {
+		return -EINVAL;
+	}
 
-    wq = aql_get_global_workqueue();
-    if (!wq) {
-        aql_err("Global workqueue not available");
-        return -EINVAL;
-    }
+	wq = aql_get_global_workqueue();
+	if (!wq) {
+		aql_err("Global workqueue not available");
+		return -EINVAL;
+	}
 
-    work_item = aql_create_work_item(measurement, AQL_WORK_STOP);
-    if (IS_ERR(work_item)) {
-        return PTR_ERR(work_item);
-    }
+	work_item = aql_create_work_item(measurement, AQL_WORK_STOP);
+	if (IS_ERR(work_item)) {
+		return PTR_ERR(work_item);
+	}
 
-    /* Schedule work without waiting on global workqueue */
-    if (!queue_work(wq, &work_item->work)) {
-        /* Work already queued - release our reference and free work_item */
-        aql_measurement_put(measurement);
-        kfree(work_item);
-        return -EBUSY; /* Work already queued */
-    }
+	/* Schedule work without waiting on global workqueue */
+	if (!queue_work(wq, &work_item->work)) {
+		/* Work already queued - release our reference and free work_item */
+		aql_measurement_put(measurement);
+		kfree(work_item);
+		return -EBUSY; /* Work already queued */
+	}
 
-    aql_debug("Scheduled STOP work for GPU %u from atomic context",
-              measurement->gpu_id);
-    return 0;
+	aql_debug("Scheduled STOP work for GPU %u from atomic context", measurement->gpu_id);
+	return 0;
 }
 
 /**
@@ -1486,60 +1474,60 @@ int aql_perf_measurement_stop_atomic(struct aql_measurement *measurement)
  */
 uint64_t aql_perf_measurement_read_atomic(struct aql_measurement *measurement)
 {
-    struct aql_work_item *work_item;
-    struct workqueue_struct *wq;
-    unsigned long flags;
-    uint64_t cached_value = 0;
-    bool cache_was_valid = false;
+	struct aql_work_item *work_item;
+	struct workqueue_struct *wq;
+	unsigned long flags;
+	uint64_t cached_value = 0;
+	bool cache_was_valid = false;
 
-    aql_info("[PMU] READ_ATOMIC: Entry for GPU %u",
-             measurement ? measurement->gpu_id : 0);
+	aql_info("[PMU] READ_ATOMIC: Entry for GPU %u", measurement ? measurement->gpu_id : 0);
 
-    if (!measurement) {
-        aql_warn("[PMU] READ_ATOMIC: NULL measurement");
-        return 0;
-    }
+	if (!measurement) {
+		aql_warn("[PMU] READ_ATOMIC: NULL measurement");
+		return 0;
+	}
 
-    aql_info("[PMU] READ_ATOMIC: GPU %u, state=%d, allocated_counter=%p",
-             measurement->gpu_id, measurement->state, measurement->allocated_counter);
+	aql_info("[PMU] READ_ATOMIC: GPU %u, state=%d, allocated_counter=%p", measurement->gpu_id,
+		 measurement->state, measurement->allocated_counter);
 
-    /* Return cached value immediately */
-    spin_lock_irqsave(&measurement->cache_lock, flags);
-    cache_was_valid = measurement->cache_valid;
-    if (measurement->cache_valid) {
-        cached_value = measurement->cached_counter_value;
-    }
-    spin_unlock_irqrestore(&measurement->cache_lock, flags);
+	/* Return cached value immediately */
+	spin_lock_irqsave(&measurement->cache_lock, flags);
+	cache_was_valid = measurement->cache_valid;
+	if (measurement->cache_valid) {
+		cached_value = measurement->cached_counter_value;
+	}
+	spin_unlock_irqrestore(&measurement->cache_lock, flags);
 
-    aql_info("[PMU] READ_ATOMIC: GPU %u, cache_valid=%d, cached_value=%llu",
-             measurement->gpu_id, cache_was_valid, cached_value);
+	aql_info("[PMU] READ_ATOMIC: GPU %u, cache_valid=%d, cached_value=%llu",
+		 measurement->gpu_id, cache_was_valid, cached_value);
 
-    /* Schedule background refresh of cached value on global workqueue */
-    wq = aql_get_global_workqueue();
-    if (wq) {
-        work_item = aql_create_work_item(measurement, AQL_WORK_READ);
-        if (!IS_ERR(work_item)) {
-            if (!queue_work(wq, &work_item->work)) {
-                /* Work already queued - release our reference and free work_item */
-                aql_info("[PMU] READ_ATOMIC: GPU %u, READ work already queued",
-                         measurement->gpu_id);
-                aql_measurement_put(measurement);
-                kfree(work_item);
-            } else {
-                aql_info("[PMU] READ_ATOMIC: GPU %u, scheduled READ work for background refresh",
-                         measurement->gpu_id);
-            }
-        } else {
-            aql_warn("[PMU] READ_ATOMIC: GPU %u, failed to create work item: %ld",
-                     measurement->gpu_id, PTR_ERR(work_item));
-        }
-    } else {
-        aql_warn("[PMU] READ_ATOMIC: Global workqueue not available");
-    }
+	/* Schedule background refresh of cached value on global workqueue */
+	wq = aql_get_global_workqueue();
+	if (wq) {
+		work_item = aql_create_work_item(measurement, AQL_WORK_READ);
+		if (!IS_ERR(work_item)) {
+			if (!queue_work(wq, &work_item->work)) {
+				/* Work already queued - release our reference and free work_item */
+				aql_info("[PMU] READ_ATOMIC: GPU %u, READ work already queued",
+					 measurement->gpu_id);
+				aql_measurement_put(measurement);
+				kfree(work_item);
+			} else {
+				aql_info(
+					"[PMU] READ_ATOMIC: GPU %u, scheduled READ work for background refresh",
+					measurement->gpu_id);
+			}
+		} else {
+			aql_warn("[PMU] READ_ATOMIC: GPU %u, failed to create work item: %ld",
+				 measurement->gpu_id, PTR_ERR(work_item));
+		}
+	} else {
+		aql_warn("[PMU] READ_ATOMIC: Global workqueue not available");
+	}
 
-    aql_info("[PMU] READ_ATOMIC: GPU %u, returning cached_value=%llu",
-             measurement->gpu_id, cached_value);
-    return cached_value;
+	aql_info("[PMU] READ_ATOMIC: GPU %u, returning cached_value=%llu", measurement->gpu_id,
+		 cached_value);
+	return cached_value;
 }
 
 EXPORT_SYMBOL_GPL(aql_perf_create_start_packet);

--- a/projects/perf-dkms/src/aql_perf.c
+++ b/projects/perf-dkms/src/aql_perf.c
@@ -25,17 +25,13 @@
 #include "aql_c/packet_generation.h"
 
 /* External KFD functions */
-extern int kfd_alloc_device(struct file *filep, struct kfd_process *p,
-                           uint32_t gpu_id, size_t data_size,
-                           struct kfd_data_alloc *data_alloc);
-extern int kfd_destroy_device_mem(struct file *filep, struct kfd_process *p,
-                                 uint32_t gpu_id,
-                                 struct kfd_data_alloc *data_alloc);
-extern int kfd_ioctl_submit_ib_packet(struct file *filep, struct kfd_process *p,
-                                     uint32_t gpu_id, const uint32_t* packet,
-                                     size_t ib_len);
-extern int kfd_process_get_all_gpuids(struct kfd_process *p, uint32_t *gpu_ids,
-                                     uint32_t *num_gpus);
+extern int kfd_alloc_device(struct file *filep, struct kfd_process *p, uint32_t gpu_id,
+			    size_t data_size, struct kfd_data_alloc *data_alloc);
+extern int kfd_destroy_device_mem(struct file *filep, struct kfd_process *p, uint32_t gpu_id,
+				  struct kfd_data_alloc *data_alloc);
+extern int kfd_ioctl_submit_ib_packet(struct file *filep, struct kfd_process *p, uint32_t gpu_id,
+				      const uint32_t *packet, size_t ib_len);
+extern int kfd_process_get_all_gpuids(struct kfd_process *p, uint32_t *gpu_ids, uint32_t *num_gpus);
 
 /* Global session ID counter */
 static atomic64_t session_id_counter = ATOMIC64_INIT(0);
@@ -51,22 +47,22 @@ DEFINE_PER_CPU(struct aql_perf_stats, aql_stats);
  */
 void aql_perf_inc_stat(enum aql_stat_type type)
 {
-    struct aql_perf_stats *stats = this_cpu_ptr(&aql_stats);
+	struct aql_perf_stats *stats = this_cpu_ptr(&aql_stats);
 
-    switch (type) {
-    case AQL_STAT_PACKETS_SUBMITTED:
-        atomic64_inc(&stats->packets_submitted);
-        break;
-    case AQL_STAT_PACKETS_COMPLETED:
-        atomic64_inc(&stats->packets_completed);
-        break;
-    case AQL_STAT_ERRORS_TOTAL:
-        atomic64_inc(&stats->errors_total);
-        break;
-    case AQL_STAT_SESSIONS_CREATED:
-        atomic64_inc(&stats->sessions_created);
-        break;
-    }
+	switch (type) {
+	case AQL_STAT_PACKETS_SUBMITTED:
+		atomic64_inc(&stats->packets_submitted);
+		break;
+	case AQL_STAT_PACKETS_COMPLETED:
+		atomic64_inc(&stats->packets_completed);
+		break;
+	case AQL_STAT_ERRORS_TOTAL:
+		atomic64_inc(&stats->errors_total);
+		break;
+	case AQL_STAT_SESSIONS_CREATED:
+		atomic64_inc(&stats->sessions_created);
+		break;
+	}
 }
 
 /**
@@ -75,19 +71,21 @@ void aql_perf_inc_stat(enum aql_stat_type type)
  */
 void aql_perf_get_stats(struct aql_perf_stats *stats)
 {
-    int cpu;
+	int cpu;
 
-    memset(stats, 0, sizeof(*stats));
+	memset(stats, 0, sizeof(*stats));
 
-    for_each_possible_cpu(cpu) {
-        struct aql_perf_stats *cpu_stats = per_cpu_ptr(&aql_stats, cpu);
-        atomic64_add(atomic64_read(&cpu_stats->packets_submitted), &stats->packets_submitted);
-        atomic64_add(atomic64_read(&cpu_stats->packets_completed), &stats->packets_completed);
-        atomic64_add(atomic64_read(&cpu_stats->errors_total), &stats->errors_total);
-        atomic64_add(atomic64_read(&cpu_stats->sessions_created), &stats->sessions_created);
-    }
+	for_each_possible_cpu(cpu)
+	{
+		struct aql_perf_stats *cpu_stats = per_cpu_ptr(&aql_stats, cpu);
+		atomic64_add(atomic64_read(&cpu_stats->packets_submitted),
+			     &stats->packets_submitted);
+		atomic64_add(atomic64_read(&cpu_stats->packets_completed),
+			     &stats->packets_completed);
+		atomic64_add(atomic64_read(&cpu_stats->errors_total), &stats->errors_total);
+		atomic64_add(atomic64_read(&cpu_stats->sessions_created), &stats->sessions_created);
+	}
 }
-
 
 /* GPU Architecture Detection */
 
@@ -97,22 +95,22 @@ void aql_perf_get_stats(struct aql_perf_stats *stats)
  *
  * Returns: Architecture name string or NULL if unknown
  */
-static const char* gfx_version_to_arch_name(uint32_t gfx_target_version)
+static const char *gfx_version_to_arch_name(uint32_t gfx_target_version)
 {
-    if (gfx_target_version >= 120000 && gfx_target_version < 130000)
-        return "gfx12";
-    else if (gfx_target_version >= 110000 && gfx_target_version < 120000)
-        return "gfx11";
-    else if (gfx_target_version >= 100000 && gfx_target_version < 110000)
-        return "gfx10";
-    else if (gfx_target_version >= 90000 && gfx_target_version < 100000)
-        return "gfx9";
-    else if (gfx_target_version >= 80000 && gfx_target_version < 90000)
-        return "gfx8";
-    else if (gfx_target_version >= 70000 && gfx_target_version < 80000)
-        return "gfx7";
+	if (gfx_target_version >= 120000 && gfx_target_version < 130000)
+		return "gfx12";
+	else if (gfx_target_version >= 110000 && gfx_target_version < 120000)
+		return "gfx11";
+	else if (gfx_target_version >= 100000 && gfx_target_version < 110000)
+		return "gfx10";
+	else if (gfx_target_version >= 90000 && gfx_target_version < 100000)
+		return "gfx9";
+	else if (gfx_target_version >= 80000 && gfx_target_version < 90000)
+		return "gfx8";
+	else if (gfx_target_version >= 70000 && gfx_target_version < 80000)
+		return "gfx7";
 
-    return NULL;
+	return NULL;
 }
 
 /**
@@ -121,112 +119,116 @@ static const char* gfx_version_to_arch_name(uint32_t gfx_target_version)
  *
  * Returns: Architecture name string or NULL on failure
  */
-static const char* get_arch_name_from_gpu_sysfs(uint32_t gpu_id)
+static const char *get_arch_name_from_gpu_sysfs(uint32_t gpu_id)
 {
-    char sysfs_path[128];
-    struct file *fp;
-    loff_t pos = 0;
-    char *buffer;
-    ssize_t bytes_read;
-    char *line, *next_line;
-    uint32_t gfx_target_version = 0;
-    const char *arch_name = NULL;
-    int node_id;
+	char sysfs_path[128];
+	struct file *fp;
+	loff_t pos = 0;
+	char *buffer;
+	ssize_t bytes_read;
+	char *line, *next_line;
+	uint32_t gfx_target_version = 0;
+	const char *arch_name = NULL;
+	int node_id;
 
-    aql_debug("Looking for GPU ID %u in KFD topology nodes", gpu_id);
+	aql_debug("Looking for GPU ID %u in KFD topology nodes", gpu_id);
 
-    /* Iterate through topology nodes to find the one with matching gpu_id */
-    for (node_id = 0; node_id < 32; node_id++) {
-        /* First, check if this node has the target GPU ID */
-        snprintf(sysfs_path, sizeof(sysfs_path),
-                 "/sys/class/kfd/kfd/topology/nodes/%d/gpu_id", node_id);
+	/* Iterate through topology nodes to find the one with matching gpu_id */
+	for (node_id = 0; node_id < 32; node_id++) {
+		/* First, check if this node has the target GPU ID */
+		snprintf(sysfs_path, sizeof(sysfs_path),
+			 "/sys/class/kfd/kfd/topology/nodes/%d/gpu_id", node_id);
 
-        fp = filp_open(sysfs_path, O_RDONLY, 0);
-        if (IS_ERR(fp))
-            continue;
+		fp = filp_open(sysfs_path, O_RDONLY, 0);
+		if (IS_ERR(fp))
+			continue;
 
-        buffer = kzalloc(16, GFP_KERNEL);
-        if (!buffer) {
-            filp_close(fp, NULL);
-            continue;
-        }
+		buffer = kzalloc(16, GFP_KERNEL);
+		if (!buffer) {
+			filp_close(fp, NULL);
+			continue;
+		}
 
-        pos = 0;
-        bytes_read = kernel_read(fp, buffer, 15, &pos);
-        filp_close(fp, NULL);
+		pos = 0;
+		bytes_read = kernel_read(fp, buffer, 15, &pos);
+		filp_close(fp, NULL);
 
-        if (bytes_read > 0) {
-            buffer[bytes_read] = '\0';
-            uint32_t node_gpu_id = simple_strtoul(buffer, NULL, 10);
-            kfree(buffer);
+		if (bytes_read > 0) {
+			buffer[bytes_read] = '\0';
+			uint32_t node_gpu_id = simple_strtoul(buffer, NULL, 10);
+			kfree(buffer);
 
-            if (node_gpu_id == gpu_id) {
-                aql_debug("Found GPU ID %u at topology node %d", gpu_id, node_id);
+			if (node_gpu_id == gpu_id) {
+				aql_debug("Found GPU ID %u at topology node %d", gpu_id, node_id);
 
-                /* Found the right node, now read properties */
-                snprintf(sysfs_path, sizeof(sysfs_path),
-                         "/sys/class/kfd/kfd/topology/nodes/%d/properties", node_id);
+				/* Found the right node, now read properties */
+				snprintf(sysfs_path, sizeof(sysfs_path),
+					 "/sys/class/kfd/kfd/topology/nodes/%d/properties",
+					 node_id);
 
-                fp = filp_open(sysfs_path, O_RDONLY, 0);
-                if (IS_ERR(fp)) {
-                    aql_err("Failed to open properties file for node %d", node_id);
-                    break;
-                }
+				fp = filp_open(sysfs_path, O_RDONLY, 0);
+				if (IS_ERR(fp)) {
+					aql_err("Failed to open properties file for node %d",
+						node_id);
+					break;
+				}
 
-                buffer = kzalloc(4096, GFP_KERNEL);
-                if (!buffer) {
-                    filp_close(fp, NULL);
-                    break;
-                }
+				buffer = kzalloc(4096, GFP_KERNEL);
+				if (!buffer) {
+					filp_close(fp, NULL);
+					break;
+				}
 
-                pos = 0;
-                bytes_read = kernel_read(fp, buffer, 4095, &pos);
-                filp_close(fp, NULL);
+				pos = 0;
+				bytes_read = kernel_read(fp, buffer, 4095, &pos);
+				filp_close(fp, NULL);
 
-                if (bytes_read > 0) {
-                    buffer[bytes_read] = '\0';
+				if (bytes_read > 0) {
+					buffer[bytes_read] = '\0';
 
-                    /* Parse for gfx_target_version */
-                    line = buffer;
-                    while (line && *line) {
-                        next_line = strchr(line, '\n');
-                        if (next_line)
-                            *next_line = '\0';
+					/* Parse for gfx_target_version */
+					line = buffer;
+					while (line && *line) {
+						next_line = strchr(line, '\n');
+						if (next_line)
+							*next_line = '\0';
 
-                        if (strncmp(line, "gfx_target_version ", 19) == 0) {
-                            gfx_target_version = simple_strtoul(line + 19, NULL, 10);
-                            aql_debug("GPU %u has gfx_target_version=%u",
-                                      gpu_id, gfx_target_version);
-                            break;
-                        }
+						if (strncmp(line, "gfx_target_version ", 19) == 0) {
+							gfx_target_version =
+								simple_strtoul(line + 19, NULL, 10);
+							aql_debug(
+								"GPU %u has gfx_target_version=%u",
+								gpu_id, gfx_target_version);
+							break;
+						}
 
-                        line = next_line ? next_line + 1 : NULL;
-                    }
-                }
+						line = next_line ? next_line + 1 : NULL;
+					}
+				}
 
-                kfree(buffer);
-                break;
-            }
-        } else {
-            kfree(buffer);
-        }
-    }
+				kfree(buffer);
+				break;
+			}
+		} else {
+			kfree(buffer);
+		}
+	}
 
-    /* Convert gfx_target_version to architecture name */
-    if (gfx_target_version > 0) {
-        arch_name = gfx_version_to_arch_name(gfx_target_version);
-        if (arch_name) {
-            aql_debug("GPU %u mapped to architecture %s (gfx_target_version=%u)",
-                      gpu_id, arch_name, gfx_target_version);
-        } else {
-            aql_info("GPU %u has unknown gfx_target_version=%u",
-                     gpu_id, gfx_target_version);
-        }
-    } else {
-        aql_err("Failed to find gfx_target_version for GPU %u", gpu_id);
-    }
+	/* Convert gfx_target_version to architecture name */
+	if (gfx_target_version > 0) {
+		arch_name = gfx_version_to_arch_name(gfx_target_version);
+		if (arch_name) {
+			aql_debug("GPU %u mapped to architecture %s (gfx_target_version=%u)",
+				  gpu_id, arch_name, gfx_target_version);
+		} else {
+			aql_info("GPU %u has unknown gfx_target_version=%u", gpu_id,
+				 gfx_target_version);
+		}
+	} else {
+		aql_err("Failed to find gfx_target_version for GPU %u", gpu_id);
+	}
 
-    return arch_name;
+	return arch_name;
 }
 
 /* Session Management */
@@ -237,92 +239,94 @@ static const char* get_arch_name_from_gpu_sysfs(uint32_t gpu_id)
  */
 static void aql_perf_session_release(struct aql_perf_session *session)
 {
+	aql_debug("Releasing session %llu", session->session_id);
 
-    aql_debug("Releasing session %llu", session->session_id);
+	/* Ensure all measurements are stopped and cleaned up */
+	{
+		struct aql_measurement *measurement, *tmp;
+		struct list_head local_list;
 
-    /* Ensure all measurements are stopped and cleaned up */
-    {
-        struct aql_measurement *measurement, *tmp;
-        struct list_head local_list;
+		INIT_LIST_HEAD(&local_list);
 
-        INIT_LIST_HEAD(&local_list);
+		/* Move all measurements to local list to avoid holding spinlock during cleanup */
+		spin_lock(&session->measurement_lock);
+		list_splice_init(&session->active_measurements, &local_list);
+		spin_unlock(&session->measurement_lock);
 
-        /* Move all measurements to local list to avoid holding spinlock during cleanup */
-        spin_lock(&session->measurement_lock);
-        list_splice_init(&session->active_measurements, &local_list);
-        spin_unlock(&session->measurement_lock);
+		/* Stop and cleanup each measurement */
+		list_for_each_entry_safe(measurement, tmp, &local_list, list)
+		{
+			aql_debug("Cleaning up measurement for GPU %u", measurement->gpu_id);
 
-        /* Stop and cleanup each measurement */
-        list_for_each_entry_safe(measurement, tmp, &local_list, list) {
-            aql_debug("Cleaning up measurement for GPU %u", measurement->gpu_id);
+			/* Stop measurement if active */
+			if (measurement->state == MEASUREMENT_ACTIVE) {
+				aql_perf_measurement_stop(measurement);
+			}
 
-            /* Stop measurement if active */
-            if (measurement->state == MEASUREMENT_ACTIVE) {
-                aql_perf_measurement_stop(measurement);
-            }
+			/* Note: No per-measurement workqueue to clean up - using global workqueue */
 
-            /* Note: No per-measurement workqueue to clean up - using global workqueue */
+			/* Release counter if owned */
+			if (measurement->owns_counter && measurement->allocated_counter) {
+				aql_counter_release(measurement->allocated_counter);
+				measurement->allocated_counter = NULL;
+			}
 
-            /* Release counter if owned */
-            if (measurement->owns_counter && measurement->allocated_counter) {
-                aql_counter_release(measurement->allocated_counter);
-                measurement->allocated_counter = NULL;
-            }
+			/* Release shared reference */
+			if (measurement->shared_ref) {
+				release_shared_counter(session, measurement->shared_ref);
+				measurement->shared_ref = NULL;
+			}
 
-            /* Release shared reference */
-            if (measurement->shared_ref) {
-                release_shared_counter(session, measurement->shared_ref);
-                measurement->shared_ref = NULL;
-            }
+			/* Free measurement (already removed from active_measurements by list_splice_init) */
+			kfree(measurement);
+		}
+	}
 
-            /* Free measurement (already removed from active_measurements by list_splice_init) */
-            kfree(measurement);
-        }
-    }
+	/* Clean up any remaining shared counter refs */
+	{
+		struct shared_counter_ref *ref, *tmp;
+		spin_lock(&session->shared_lock);
+		list_for_each_entry_safe(ref, tmp, &session->shared_counters, list)
+		{
+			list_del(&ref->list);
+			kfree(ref);
+		}
+		spin_unlock(&session->shared_lock);
+	}
 
-    /* Clean up any remaining shared counter refs */
-    {
-        struct shared_counter_ref *ref, *tmp;
-        spin_lock(&session->shared_lock);
-        list_for_each_entry_safe(ref, tmp, &session->shared_counters, list) {
-            list_del(&ref->list);
-            kfree(ref);
-        }
-        spin_unlock(&session->shared_lock);
-    }
+	/* Free counter buffers and architectures for all GPUs */
+	if (session->archs && session->num_gpus > 0) {
+		for (uint32_t i = 0; i < session->num_gpus; i++) {
+			if (session->archs[i]) {
+				/* Free counter buffers for this GPU */
+				aql_perf_free_counter_buffers(session->archs[i], session->kfd_file,
+							      session->process,
+							      session->gpu_ids[i]);
+				/* Destroy architecture */
+				arch_destroy(session->archs[i]);
+				session->archs[i] = NULL;
+			}
+		}
+		kfree(session->archs);
+		session->archs = NULL;
+	}
 
-    /* Free counter buffers and architectures for all GPUs */
-    if (session->archs && session->num_gpus > 0) {
-        for (uint32_t i = 0; i < session->num_gpus; i++) {
-            if (session->archs[i]) {
-                /* Free counter buffers for this GPU */
-                aql_perf_free_counter_buffers(session->archs[i], session->kfd_file,
-                                              session->process, session->gpu_ids[i]);
-                /* Destroy architecture */
-                arch_destroy(session->archs[i]);
-                session->archs[i] = NULL;
-            }
-        }
-        kfree(session->archs);
-        session->archs = NULL;
-    }
+	/* Close KFD file handle */
+	if (session->kfd_file) {
+		filp_close(session->kfd_file, NULL);
+		session->kfd_file = NULL;
+	}
 
-    /* Close KFD file handle */
-    if (session->kfd_file) {
-        filp_close(session->kfd_file, NULL);
-        session->kfd_file = NULL;
-    }
+	/* Cancel recovery work */
+	cancel_delayed_work_sync(&session->recovery.recovery_work);
 
-    /* Cancel recovery work */
-    cancel_delayed_work_sync(&session->recovery.recovery_work);
+	/* Free dynamic allocations */
+	kfree(session->gpu_ids);
+	kfree(session->counters.descriptors);
+	kfree(session->counters.counter_masks);
 
-    /* Free dynamic allocations */
-    kfree(session->gpu_ids);
-    kfree(session->counters.descriptors);
-    kfree(session->counters.counter_masks);
-
-    aql_debug("Session %llu fully released", session->session_id);
-    kfree(session);
+	aql_debug("Session %llu fully released", session->session_id);
+	kfree(session);
 }
 
 /**
@@ -332,42 +336,42 @@ static void aql_perf_session_release(struct aql_perf_session *session)
  */
 struct aql_perf_session *aql_perf_session_create(void)
 {
-    struct aql_perf_session *session;
+	struct aql_perf_session *session;
 
-    session = kzalloc(sizeof(*session), GFP_KERNEL);
-    if (!session) {
-        aql_err("Failed to allocate session structure");
-        return ERR_PTR(-ENOMEM);
-    }
+	session = kzalloc(sizeof(*session), GFP_KERNEL);
+	if (!session) {
+		aql_err("Failed to allocate session structure");
+		return ERR_PTR(-ENOMEM);
+	}
 
-    /* Generate unique session ID */
-    session->session_id = atomic64_inc_return(&session_id_counter);
+	/* Generate unique session ID */
+	session->session_id = atomic64_inc_return(&session_id_counter);
 
-    /* Initialize synchronization primitives */
-    mutex_init(&session->session_mutex);
-    spin_lock_init(&session->measurement_lock);
-    INIT_LIST_HEAD(&session->active_measurements);
-    refcount_set(&session->ref_count, 1);
-    atomic_set(&session->active_gpu_count, 0);
+	/* Initialize synchronization primitives */
+	mutex_init(&session->session_mutex);
+	spin_lock_init(&session->measurement_lock);
+	INIT_LIST_HEAD(&session->active_measurements);
+	refcount_set(&session->ref_count, 1);
+	atomic_set(&session->active_gpu_count, 0);
 
-    /* Initialize shared counter tracking */
-    INIT_LIST_HEAD(&session->shared_counters);
-    spin_lock_init(&session->shared_lock);
+	/* Initialize shared counter tracking */
+	INIT_LIST_HEAD(&session->shared_counters);
+	spin_lock_init(&session->shared_lock);
 
-    /* Initialize state */
-    session->state = SESSION_UNINITIALIZED;
-    session->max_gpus = AQL_PERF_MAX_GPUS;
+	/* Initialize state */
+	session->state = SESSION_UNINITIALIZED;
+	session->max_gpus = AQL_PERF_MAX_GPUS;
 
-    /* Setup error recovery */
-    INIT_DELAYED_WORK(&session->recovery.recovery_work, aql_perf_recovery_work);
+	/* Setup error recovery */
+	INIT_DELAYED_WORK(&session->recovery.recovery_work, aql_perf_recovery_work);
 
-    /* Initialize statistics */
-    memset(&session->stats, 0, sizeof(session->stats));
+	/* Initialize statistics */
+	memset(&session->stats, 0, sizeof(session->stats));
 
-    aql_info("Created AQL performance session %llu", session->session_id);
-    aql_perf_inc_stat(AQL_STAT_SESSIONS_CREATED);
+	aql_info("Created AQL performance session %llu", session->session_id);
+	aql_perf_inc_stat(AQL_STAT_SESSIONS_CREATED);
 
-    return session;
+	return session;
 }
 
 /**
@@ -381,8 +385,8 @@ struct aql_perf_session *aql_perf_session_create(void)
  */
 void aql_perf_session_get(struct aql_perf_session *session)
 {
-    if (session)
-        refcount_inc(&session->ref_count);
+	if (session)
+		refcount_inc(&session->ref_count);
 }
 
 /**
@@ -397,8 +401,8 @@ void aql_perf_session_get(struct aql_perf_session *session)
  */
 void aql_perf_session_put(struct aql_perf_session *session)
 {
-    if (session && refcount_dec_and_test(&session->ref_count))
-        aql_perf_session_release(session);
+	if (session && refcount_dec_and_test(&session->ref_count))
+		aql_perf_session_release(session);
 }
 
 /**
@@ -409,134 +413,130 @@ void aql_perf_session_put(struct aql_perf_session *session)
  */
 int aql_perf_session_initialize(struct aql_perf_session *session)
 {
-    int ret;
+	int ret;
 
-    if (!session) {
-        aql_err("Invalid session pointer");
-        return -EINVAL;
-    }
+	if (!session) {
+		aql_err("Invalid session pointer");
+		return -EINVAL;
+	}
 
-    mutex_lock(&session->session_mutex);
+	mutex_lock(&session->session_mutex);
 
-    if (session->state != SESSION_UNINITIALIZED) {
-        aql_err("Session %llu already initialized", session->session_id);
-        ret = -EINVAL;
-        goto unlock;
-    }
+	if (session->state != SESSION_UNINITIALIZED) {
+		aql_err("Session %llu already initialized", session->session_id);
+		ret = -EINVAL;
+		goto unlock;
+	}
 
-    session->state = SESSION_INITIALIZING;
-    aql_debug("Initializing session %llu", session->session_id);
+	session->state = SESSION_INITIALIZING;
+	aql_debug("Initializing session %llu", session->session_id);
 
-    /* Open KFD device */
-    session->kfd_file = filp_open("/dev/kfd", O_RDWR, 0);
-    if (IS_ERR(session->kfd_file)) {
-        ret = PTR_ERR(session->kfd_file);
-        aql_err("Session %llu: Failed to open /dev/kfd: %d",
-                session->session_id, ret);
-        session->kfd_file = NULL;
-        goto error;
-    }
+	/* Open KFD device */
+	session->kfd_file = filp_open("/dev/kfd", O_RDWR, 0);
+	if (IS_ERR(session->kfd_file)) {
+		ret = PTR_ERR(session->kfd_file);
+		aql_err("Session %llu: Failed to open /dev/kfd: %d", session->session_id, ret);
+		session->kfd_file = NULL;
+		goto error;
+	}
 
-    /* Extract kfd_process from private_data */
-    session->process = session->kfd_file->private_data;
-    if (!session->process) {
-        aql_err("Session %llu: No kfd_process in file private_data",
-                session->session_id);
-        ret = -EINVAL;
-        goto error;
-    }
+	/* Extract kfd_process from private_data */
+	session->process = session->kfd_file->private_data;
+	if (!session->process) {
+		aql_err("Session %llu: No kfd_process in file private_data", session->session_id);
+		ret = -EINVAL;
+		goto error;
+	}
 
-    aql_debug("Session %llu: KFD device opened successfully", session->session_id);
+	aql_debug("Session %llu: KFD device opened successfully", session->session_id);
 
-    /* Discover available GPUs */
-    ret = aql_perf_discover_gpus(session);
-    if (ret) {
-        aql_err("Session %llu: GPU discovery failed: %d",
-                session->session_id, ret);
-        goto error;
-    }
+	/* Discover available GPUs */
+	ret = aql_perf_discover_gpus(session);
+	if (ret) {
+		aql_err("Session %llu: GPU discovery failed: %d", session->session_id, ret);
+		goto error;
+	}
 
-    /* Detect and create GPU architectures for all GPUs */
-    if (session->num_gpus == 0) {
-        aql_err("Session %llu: No GPUs available for architecture detection",
-                session->session_id);
-        ret = -ENODEV;
-        goto error;
-    }
+	/* Detect and create GPU architectures for all GPUs */
+	if (session->num_gpus == 0) {
+		aql_err("Session %llu: No GPUs available for architecture detection",
+			session->session_id);
+		ret = -ENODEV;
+		goto error;
+	}
 
-    /* Allocate architecture array */
-    session->archs = kzalloc(session->num_gpus * sizeof(arch_t *), GFP_KERNEL);
-    if (!session->archs) {
-        aql_err("Session %llu: Failed to allocate architecture array", session->session_id);
-        ret = -ENOMEM;
-        goto error;
-    }
+	/* Allocate architecture array */
+	session->archs = kzalloc(session->num_gpus * sizeof(arch_t *), GFP_KERNEL);
+	if (!session->archs) {
+		aql_err("Session %llu: Failed to allocate architecture array", session->session_id);
+		ret = -ENOMEM;
+		goto error;
+	}
 
-    /* Create architecture for each GPU */
-    for (uint32_t i = 0; i < session->num_gpus; i++) {
-        const char *arch_name = get_arch_name_from_gpu_sysfs(session->gpu_ids[i]);
-        if (!arch_name) {
-            aql_err("Session %llu: Failed to determine architecture for GPU %u",
-                    session->session_id, session->gpu_ids[i]);
-            ret = -ENOTSUPP;
-            goto error;
-        }
+	/* Create architecture for each GPU */
+	for (uint32_t i = 0; i < session->num_gpus; i++) {
+		const char *arch_name = get_arch_name_from_gpu_sysfs(session->gpu_ids[i]);
+		if (!arch_name) {
+			aql_err("Session %llu: Failed to determine architecture for GPU %u",
+				session->session_id, session->gpu_ids[i]);
+			ret = -ENOTSUPP;
+			goto error;
+		}
 
-        session->archs[i] = arch_create_by_name(arch_name);
-        if (!session->archs[i]) {
-            aql_err("Session %llu: Failed to create architecture %s for GPU %u",
-                    session->session_id, arch_name, session->gpu_ids[i]);
-            ret = -ENOTSUPP;
-            goto error;
-        }
-        aql_info("Session %llu: Created architecture %s for GPU %u (index %u)",
-                 session->session_id, arch_name, session->gpu_ids[i], i);
+		session->archs[i] = arch_create_by_name(arch_name);
+		if (!session->archs[i]) {
+			aql_err("Session %llu: Failed to create architecture %s for GPU %u",
+				session->session_id, arch_name, session->gpu_ids[i]);
+			ret = -ENOTSUPP;
+			goto error;
+		}
+		aql_info("Session %llu: Created architecture %s for GPU %u (index %u)",
+			 session->session_id, arch_name, session->gpu_ids[i], i);
 
-        /* Allocate counter buffers for this GPU's architecture */
-        ret = aql_perf_allocate_counter_buffers(session->archs[i], session->kfd_file,
-                                                session->process, session->gpu_ids[i]);
-        if (ret) {
-            aql_err("Session %llu: Failed to allocate counter buffers for GPU %u: %d",
-                    session->session_id, session->gpu_ids[i], ret);
-            goto error;
-        }
-        aql_info("Session %llu: Allocated counter buffers for GPU %u (index %u)",
-                 session->session_id, session->gpu_ids[i], i);
-    }
+		/* Allocate counter buffers for this GPU's architecture */
+		ret = aql_perf_allocate_counter_buffers(session->archs[i], session->kfd_file,
+							session->process, session->gpu_ids[i]);
+		if (ret) {
+			aql_err("Session %llu: Failed to allocate counter buffers for GPU %u: %d",
+				session->session_id, session->gpu_ids[i], ret);
+			goto error;
+		}
+		aql_info("Session %llu: Allocated counter buffers for GPU %u (index %u)",
+			 session->session_id, session->gpu_ids[i], i);
+	}
 
-    /* Initialize counter configuration with default GFX12 counter */
-    session->counters.num_counters = 1;
-    session->counters.max_counters = 4;
+	/* Initialize counter configuration with default GFX12 counter */
+	session->counters.num_counters = 1;
+	session->counters.max_counters = 4;
 
-    session->counters.descriptors = kzalloc(session->counters.max_counters *
-                                           sizeof(struct gfx12_counter_desc),
-                                           GFP_KERNEL);
-    if (!session->counters.descriptors) {
-        ret = -ENOMEM;
-        goto error;
-    }
+	session->counters.descriptors = kzalloc(
+		session->counters.max_counters * sizeof(struct gfx12_counter_desc), GFP_KERNEL);
+	if (!session->counters.descriptors) {
+		ret = -ENOMEM;
+		goto error;
+	}
 
-    /* Configure default counter (SQ_WAVES) */
-    session->counters.descriptors[0].counter_select = GFX12_PERF_SEL_SQ_WAVES;
-    session->counters.descriptors[0].counter_mode = 0x1;
-    session->counters.descriptors[0].result_size = sizeof(uint64_t);
+	/* Configure default counter (SQ_WAVES) */
+	session->counters.descriptors[0].counter_select = GFX12_PERF_SEL_SQ_WAVES;
+	session->counters.descriptors[0].counter_mode = 0x1;
+	session->counters.descriptors[0].result_size = sizeof(uint64_t);
 
-    session->state = SESSION_ACTIVE;
-    aql_info("Session %llu initialized successfully with %u GPUs",
-             session->session_id, session->num_gpus);
+	session->state = SESSION_ACTIVE;
+	aql_info("Session %llu initialized successfully with %u GPUs", session->session_id,
+		 session->num_gpus);
 
-    mutex_unlock(&session->session_mutex);
-    return 0;
+	mutex_unlock(&session->session_mutex);
+	return 0;
 
 error:
-    session->state = SESSION_ERROR;
-    if (session->kfd_file) {
-        filp_close(session->kfd_file, NULL);
-        session->kfd_file = NULL;
-    }
+	session->state = SESSION_ERROR;
+	if (session->kfd_file) {
+		filp_close(session->kfd_file, NULL);
+		session->kfd_file = NULL;
+	}
 unlock:
-    mutex_unlock(&session->session_mutex);
-    return ret;
+	mutex_unlock(&session->session_mutex);
+	return ret;
 }
 
 /**
@@ -545,17 +545,17 @@ unlock:
  */
 void aql_perf_session_destroy(struct aql_perf_session *session)
 {
-    if (!session)
-        return;
+	if (!session)
+		return;
 
-    aql_debug("Destroying session %llu", session->session_id);
+	aql_debug("Destroying session %llu", session->session_id);
 
-    mutex_lock(&session->session_mutex);
-    session->state = SESSION_DESTROYING;
-    mutex_unlock(&session->session_mutex);
+	mutex_lock(&session->session_mutex);
+	session->state = SESSION_DESTROYING;
+	mutex_unlock(&session->session_mutex);
 
-    /* This will trigger cleanup through reference counting */
-    aql_perf_session_put(session);
+	/* This will trigger cleanup through reference counting */
+	aql_perf_session_put(session);
 }
 
 /* GPU Discovery and Memory Management */
@@ -568,35 +568,33 @@ void aql_perf_session_destroy(struct aql_perf_session *session)
  */
 int aql_perf_discover_gpus(struct aql_perf_session *session)
 {
-    uint32_t max_gpus = AQL_PERF_MAX_GPUS;
-    int ret;
+	uint32_t max_gpus = AQL_PERF_MAX_GPUS;
+	int ret;
 
-    session->gpu_ids = kzalloc(max_gpus * sizeof(uint32_t), GFP_KERNEL);
-    if (!session->gpu_ids) {
-        aql_err("Session %llu: Failed to allocate GPU ID array",
-                session->session_id);
-        return -ENOMEM;
-    }
+	session->gpu_ids = kzalloc(max_gpus * sizeof(uint32_t), GFP_KERNEL);
+	if (!session->gpu_ids) {
+		aql_err("Session %llu: Failed to allocate GPU ID array", session->session_id);
+		return -ENOMEM;
+	}
 
-    ret = kfd_process_get_all_gpuids(session->process, session->gpu_ids, &max_gpus);
-    if (ret) {
-        aql_err("Session %llu: Failed to get GPU IDs: %d",
-                session->session_id, ret);
-        kfree(session->gpu_ids);
-        session->gpu_ids = NULL;
-        return ret;
-    }
+	ret = kfd_process_get_all_gpuids(session->process, session->gpu_ids, &max_gpus);
+	if (ret) {
+		aql_err("Session %llu: Failed to get GPU IDs: %d", session->session_id, ret);
+		kfree(session->gpu_ids);
+		session->gpu_ids = NULL;
+		return ret;
+	}
 
-    session->num_gpus = max_gpus;
-    aql_debug("Session %llu: Discovered %u GPUs", session->session_id, session->num_gpus);
+	session->num_gpus = max_gpus;
+	aql_debug("Session %llu: Discovered %u GPUs", session->session_id, session->num_gpus);
 
-    /* Log discovered GPU IDs */
-    for (uint32_t i = 0; i < session->num_gpus; i++) {
-        aql_debug("Session %llu: GPU[%u] ID = %u",
-                  session->session_id, i, session->gpu_ids[i]);
-    }
+	/* Log discovered GPU IDs */
+	for (uint32_t i = 0; i < session->num_gpus; i++) {
+		aql_debug("Session %llu: GPU[%u] ID = %u", session->session_id, i,
+			  session->gpu_ids[i]);
+	}
 
-    return 0;
+	return 0;
 }
 
 /**
@@ -612,59 +610,61 @@ int aql_perf_discover_gpus(struct aql_perf_session *session)
  * Returns: 0 on success, negative error code on failure
  */
 int aql_perf_allocate_counter_buffers(arch_t *arch, struct file *kfd_file,
-                                      struct kfd_process *process, uint32_t gpu_id)
+				      struct kfd_process *process, uint32_t gpu_id)
 {
-    uint32_t block_idx, counter_idx;
-    int ret;
+	uint32_t block_idx, counter_idx;
+	int ret;
 
-    if (!arch || !kfd_file || !process)
-        return -EINVAL;
+	if (!arch || !kfd_file || !process)
+		return -EINVAL;
 
-    /* Iterate through all blocks */
-    for (block_idx = 0; block_idx < HW_IP_BLOCK_LAST; block_idx++) {
-        block_info_t *block = arch->block_map.blocks[block_idx];
-        if (!block || !block->counter_reg_info)
-            continue;
+	/* Iterate through all blocks */
+	for (block_idx = 0; block_idx < HW_IP_BLOCK_LAST; block_idx++) {
+		block_info_t *block = arch->block_map.blocks[block_idx];
+		if (!block || !block->counter_reg_info)
+			continue;
 
-        /* Allocate buffers for each counter in this block */
-        for (counter_idx = 0; counter_idx < block->counter_count; counter_idx++) {
-            counter_reg_info_t *reg = &block->counter_reg_info[counter_idx];
+		/* Allocate buffers for each counter in this block */
+		for (counter_idx = 0; counter_idx < block->counter_count; counter_idx++) {
+			counter_reg_info_t *reg = &block->counter_reg_info[counter_idx];
 
-            /* Allocate command buffer struct and device memory (1 page) */
-            reg->allocation.command_buffer = kzalloc(sizeof(struct kfd_data_alloc), GFP_KERNEL);
-            if (!reg->allocation.command_buffer) {
-                aql_perf_free_counter_buffers(arch, kfd_file, process, gpu_id);
-                return -ENOMEM;
-            }
+			/* Allocate command buffer struct and device memory (1 page) */
+			reg->allocation.command_buffer =
+				kzalloc(sizeof(struct kfd_data_alloc), GFP_KERNEL);
+			if (!reg->allocation.command_buffer) {
+				aql_perf_free_counter_buffers(arch, kfd_file, process, gpu_id);
+				return -ENOMEM;
+			}
 
-            ret = kfd_alloc_device(kfd_file, process, gpu_id, PAGE_SIZE,
-                                  reg->allocation.command_buffer);
-            if (ret != 0) {
-                kfree(reg->allocation.command_buffer);
-                reg->allocation.command_buffer = NULL;
-                aql_perf_free_counter_buffers(arch, kfd_file, process, gpu_id);
-                return ret;
-            }
+			ret = kfd_alloc_device(kfd_file, process, gpu_id, PAGE_SIZE,
+					       reg->allocation.command_buffer);
+			if (ret != 0) {
+				kfree(reg->allocation.command_buffer);
+				reg->allocation.command_buffer = NULL;
+				aql_perf_free_counter_buffers(arch, kfd_file, process, gpu_id);
+				return ret;
+			}
 
-            /* Allocate data buffer struct and device memory (1 page) */
-            reg->allocation.data_buffer = kzalloc(sizeof(struct kfd_data_alloc), GFP_KERNEL);
-            if (!reg->allocation.data_buffer) {
-                aql_perf_free_counter_buffers(arch, kfd_file, process, gpu_id);
-                return -ENOMEM;
-            }
+			/* Allocate data buffer struct and device memory (1 page) */
+			reg->allocation.data_buffer =
+				kzalloc(sizeof(struct kfd_data_alloc), GFP_KERNEL);
+			if (!reg->allocation.data_buffer) {
+				aql_perf_free_counter_buffers(arch, kfd_file, process, gpu_id);
+				return -ENOMEM;
+			}
 
-            ret = kfd_alloc_device(kfd_file, process, gpu_id, PAGE_SIZE,
-                                  reg->allocation.data_buffer);
-            if (ret != 0) {
-                kfree(reg->allocation.data_buffer);
-                reg->allocation.data_buffer = NULL;
-                aql_perf_free_counter_buffers(arch, kfd_file, process, gpu_id);
-                return ret;
-            }
-        }
-    }
+			ret = kfd_alloc_device(kfd_file, process, gpu_id, PAGE_SIZE,
+					       reg->allocation.data_buffer);
+			if (ret != 0) {
+				kfree(reg->allocation.data_buffer);
+				reg->allocation.data_buffer = NULL;
+				aql_perf_free_counter_buffers(arch, kfd_file, process, gpu_id);
+				return ret;
+			}
+		}
+	}
 
-    return 0;
+	return 0;
 }
 
 /**
@@ -676,43 +676,43 @@ int aql_perf_allocate_counter_buffers(arch_t *arch, struct file *kfd_file,
  *
  * Frees all command_buffer and data_buffer allocations.
  */
-void aql_perf_free_counter_buffers(arch_t *arch, struct file *kfd_file,
-                                   struct kfd_process *process, uint32_t gpu_id)
+void aql_perf_free_counter_buffers(arch_t *arch, struct file *kfd_file, struct kfd_process *process,
+				   uint32_t gpu_id)
 {
-    uint32_t block_idx, counter_idx;
+	uint32_t block_idx, counter_idx;
 
-    if (!arch)
-        return;
+	if (!arch)
+		return;
 
-    /* Iterate through all blocks */
-    for (block_idx = 0; block_idx < HW_IP_BLOCK_LAST; block_idx++) {
-        block_info_t *block = arch->block_map.blocks[block_idx];
-        if (!block || !block->counter_reg_info)
-            continue;
+	/* Iterate through all blocks */
+	for (block_idx = 0; block_idx < HW_IP_BLOCK_LAST; block_idx++) {
+		block_info_t *block = arch->block_map.blocks[block_idx];
+		if (!block || !block->counter_reg_info)
+			continue;
 
-        /* Free buffers for each counter in this block */
-        for (counter_idx = 0; counter_idx < block->counter_count; counter_idx++) {
-            counter_reg_info_t *reg = &block->counter_reg_info[counter_idx];
+		/* Free buffers for each counter in this block */
+		for (counter_idx = 0; counter_idx < block->counter_count; counter_idx++) {
+			counter_reg_info_t *reg = &block->counter_reg_info[counter_idx];
 
-            /* Free command buffer */
-            if (reg->allocation.command_buffer) {
-                if (kfd_file && process)
-                    kfd_destroy_device_mem(kfd_file, process, gpu_id,
-                                          reg->allocation.command_buffer);
-                kfree(reg->allocation.command_buffer);
-                reg->allocation.command_buffer = NULL;
-            }
+			/* Free command buffer */
+			if (reg->allocation.command_buffer) {
+				if (kfd_file && process)
+					kfd_destroy_device_mem(kfd_file, process, gpu_id,
+							       reg->allocation.command_buffer);
+				kfree(reg->allocation.command_buffer);
+				reg->allocation.command_buffer = NULL;
+			}
 
-            /* Free data buffer */
-            if (reg->allocation.data_buffer) {
-                if (kfd_file && process)
-                    kfd_destroy_device_mem(kfd_file, process, gpu_id,
-                                          reg->allocation.data_buffer);
-                kfree(reg->allocation.data_buffer);
-                reg->allocation.data_buffer = NULL;
-            }
-        }
-    }
+			/* Free data buffer */
+			if (reg->allocation.data_buffer) {
+				if (kfd_file && process)
+					kfd_destroy_device_mem(kfd_file, process, gpu_id,
+							       reg->allocation.data_buffer);
+				kfree(reg->allocation.data_buffer);
+				reg->allocation.data_buffer = NULL;
+			}
+		}
+	}
 }
 
 /* Counter Allocation Functions */
@@ -726,55 +726,55 @@ void aql_perf_free_counter_buffers(arch_t *arch, struct file *kfd_file,
  * Uses atomic compare-and-swap to claim a free counter without locks.
  * Returns: Pointer to allocated counter_reg_info_t, or NULL if all counters busy
  */
-counter_reg_info_t* aql_counter_try_allocate(block_info_t *block,
-                                             uint32_t event_id,
-                                             struct perf_event *perf_event)
+counter_reg_info_t *aql_counter_try_allocate(block_info_t *block, uint32_t event_id,
+					     struct perf_event *perf_event)
 {
-    uint32_t i;
-    int old_state;
+	uint32_t i;
+	int old_state;
 
-    if (!block || !block->counter_reg_info) {
-        aql_err("[PMU] aql_counter_try_allocate: Invalid block pointer");
-        return NULL;
-    }
+	if (!block || !block->counter_reg_info) {
+		aql_err("[PMU] aql_counter_try_allocate: Invalid block pointer");
+		return NULL;
+	}
 
-    aql_debug("[PMU] aql_counter_try_allocate: block=%s, event_id=0x%x, counter_count=%u",
-              block->name, event_id, block->counter_count);
+	aql_debug("[PMU] aql_counter_try_allocate: block=%s, event_id=0x%x, counter_count=%u",
+		  block->name, event_id, block->counter_count);
 
-    /* Try to allocate a free counter using atomic operations */
-    for (i = 0; i < block->counter_count; i++) {
-        counter_reg_info_t *reg = &block->counter_reg_info[i];
+	/* Try to allocate a free counter using atomic operations */
+	for (i = 0; i < block->counter_count; i++) {
+		counter_reg_info_t *reg = &block->counter_reg_info[i];
 
-        /* Log attempt */
-        aql_debug("[PMU] aql_counter_try_allocate: trying counter_index=%u, state=%d",
-                  i, atomic_read(&reg->allocation.state));
+		/* Log attempt */
+		aql_debug("[PMU] aql_counter_try_allocate: trying counter_index=%u, state=%d", i,
+			  atomic_read(&reg->allocation.state));
 
-        /* Try to atomically claim this counter (FREE -> ALLOCATED) */
-        old_state = atomic_cmpxchg(&reg->allocation.state,
-                                   COUNTER_STATE_FREE,
-                                   COUNTER_STATE_ALLOCATED);
+		/* Try to atomically claim this counter (FREE -> ALLOCATED) */
+		old_state = atomic_cmpxchg(&reg->allocation.state, COUNTER_STATE_FREE,
+					   COUNTER_STATE_ALLOCATED);
 
-        if (old_state == COUNTER_STATE_FREE) {
-            /* Successfully claimed! Populate fields */
-            reg->allocation.event_id = event_id;
-            reg->allocation.user_id = (uint32_t)(uintptr_t)perf_event;
-            reg->allocation.allocation_time = ktime_get();
+		if (old_state == COUNTER_STATE_FREE) {
+			/* Successfully claimed! Populate fields */
+			reg->allocation.event_id = event_id;
+			reg->allocation.user_id = (uint32_t)(uintptr_t)perf_event;
+			reg->allocation.allocation_time = ktime_get();
 
-            aql_info("[PMU] aql_counter_try_allocate: SUCCESS - allocated counter %u in block %s, event_id=0x%x, user_id=0x%x",
-                     i, block->name, event_id, reg->allocation.user_id);
+			aql_info(
+				"[PMU] aql_counter_try_allocate: SUCCESS - allocated counter %u in block %s, event_id=0x%x, user_id=0x%x",
+				i, block->name, event_id, reg->allocation.user_id);
 
-            return reg;
-        }
+			return reg;
+		}
 
-        /* Counter was taken by another thread, try next */
-        aql_debug("[PMU] aql_counter_try_allocate: counter_index=%u already allocated (state=%d)",
-                  i, old_state);
-    }
+		/* Counter was taken by another thread, try next */
+		aql_debug(
+			"[PMU] aql_counter_try_allocate: counter_index=%u already allocated (state=%d)",
+			i, old_state);
+	}
 
-    /* All counters are busy */
-    aql_warn("[PMU] aql_counter_try_allocate: FAILED - all %u counters in block %s are busy",
-             block->counter_count, block->name);
-    return NULL;
+	/* All counters are busy */
+	aql_warn("[PMU] aql_counter_try_allocate: FAILED - all %u counters in block %s are busy",
+		 block->counter_count, block->name);
+	return NULL;
 }
 
 /**
@@ -786,31 +786,31 @@ counter_reg_info_t* aql_counter_try_allocate(block_info_t *block,
  */
 void aql_counter_release(counter_reg_info_t *reg)
 {
-    int old_state;
+	int old_state;
 
-    if (!reg) {
-        aql_err("[PMU] aql_counter_release: NULL counter pointer");
-        return;
-    }
+	if (!reg) {
+		aql_err("[PMU] aql_counter_release: NULL counter pointer");
+		return;
+	}
 
-    old_state = atomic_read(&reg->allocation.state);
+	old_state = atomic_read(&reg->allocation.state);
 
-    aql_debug("[PMU] aql_counter_release: counter state %d -> %d, event_id=0x%x, user_id=0x%x",
-              old_state, COUNTER_STATE_FREE,
-              reg->allocation.event_id, reg->allocation.user_id);
+	aql_debug("[PMU] aql_counter_release: counter state %d -> %d, event_id=0x%x, user_id=0x%x",
+		  old_state, COUNTER_STATE_FREE, reg->allocation.event_id, reg->allocation.user_id);
 
-    /* Atomically set state back to FREE */
-    atomic_set(&reg->allocation.state, COUNTER_STATE_FREE);
+	/* Atomically set state back to FREE */
+	atomic_set(&reg->allocation.state, COUNTER_STATE_FREE);
 
-    /* Clear allocation tracking fields */
-    reg->allocation.event_id = 0;
-    reg->allocation.user_id = 0;
-    reg->allocation.description = NULL;
-    reg->allocation.allocation_time = 0;
+	/* Clear allocation tracking fields */
+	reg->allocation.event_id = 0;
+	reg->allocation.user_id = 0;
+	reg->allocation.description = NULL;
+	reg->allocation.allocation_time = 0;
 
-    /* Keep command_buffer and data_buffer - they are pre-allocated and reused */
+	/* Keep command_buffer and data_buffer - they are pre-allocated and reused */
 
-    aql_info("[PMU] aql_counter_release: counter released successfully (was state %d)", old_state);
+	aql_info("[PMU] aql_counter_release: counter released successfully (was state %d)",
+		 old_state);
 }
 
 /**
@@ -822,17 +822,17 @@ void aql_counter_release(counter_reg_info_t *reg)
  */
 static uint32_t aql_get_counter_index_in_block(block_info_t *block, counter_reg_info_t *reg)
 {
-    uint32_t i;
+	uint32_t i;
 
-    if (!block || !reg || !block->counter_reg_info)
-        return 0;
+	if (!block || !reg || !block->counter_reg_info)
+		return 0;
 
-    for (i = 0; i < block->counter_count; i++) {
-        if (&block->counter_reg_info[i] == reg)
-            return i;
-    }
+	for (i = 0; i < block->counter_count; i++) {
+		if (&block->counter_reg_info[i] == reg)
+			return i;
+	}
 
-    return 0;
+	return 0;
 }
 
 /**
@@ -845,60 +845,61 @@ static uint32_t aql_get_counter_index_in_block(block_info_t *block, counter_reg_
  *
  * Returns: 0 on success, negative error code on failure
  */
-int aql_build_counter_info(uint32_t counter_id,
-                           arch_t *arch,
-                           counter_reg_info_t *allocated_counter,
-                           counter_info_t *out_info,
-                           block_info_t **out_block)
+int aql_build_counter_info(uint32_t counter_id, arch_t *arch, counter_reg_info_t *allocated_counter,
+			   counter_info_t *out_info, block_info_t **out_block)
 {
-    const counter_def_t *counter_def;
-    uint32_t event_id;
-    block_info_t *block;
-    uint32_t counter_index;
-    int ret;
+	const counter_def_t *counter_def;
+	uint32_t event_id;
+	block_info_t *block;
+	uint32_t counter_index;
+	int ret;
 
-    if (!arch || !allocated_counter || !out_info || !out_block) {
-        aql_err("[PMU] aql_build_counter_info: Invalid parameters");
-        return -EINVAL;
-    }
+	if (!arch || !allocated_counter || !out_info || !out_block) {
+		aql_err("[PMU] aql_build_counter_info: Invalid parameters");
+		return -EINVAL;
+	}
 
-    /* Look up counter definition by ID */
-    counter_def = lookup_counter_by_id((counter_id_t)counter_id);
-    if (!counter_def) {
-        aql_err("[PMU] aql_build_counter_info: Counter ID %u not found in registry", counter_id);
-        return -EINVAL;
-    }
+	/* Look up counter definition by ID */
+	counter_def = lookup_counter_by_id((counter_id_t)counter_id);
+	if (!counter_def) {
+		aql_err("[PMU] aql_build_counter_info: Counter ID %u not found in registry",
+			counter_id);
+		return -EINVAL;
+	}
 
-    /* Get architecture-specific event ID */
-    ret = lookup_event_id(counter_def, arch, &event_id);
-    if (ret < 0) {
-        aql_err("[PMU] aql_build_counter_info: No event mapping for counter %s (err=%d)", counter_def->name, ret);
-        return -ENOTSUPP;
-    }
+	/* Get architecture-specific event ID */
+	ret = lookup_event_id(counter_def, arch, &event_id);
+	if (ret < 0) {
+		aql_err("[PMU] aql_build_counter_info: No event mapping for counter %s (err=%d)",
+			counter_def->name, ret);
+		return -ENOTSUPP;
+	}
 
-    /* Get block from architecture */
-    block = arch->block_map.blocks[counter_def->hw_block];
-    if (!block) {
-        aql_err("[PMU] aql_build_counter_info: Block %u not found in architecture", counter_def->hw_block);
-        return -EINVAL;
-    }
+	/* Get block from architecture */
+	block = arch->block_map.blocks[counter_def->hw_block];
+	if (!block) {
+		aql_err("[PMU] aql_build_counter_info: Block %u not found in architecture",
+			counter_def->hw_block);
+		return -EINVAL;
+	}
 
-    /* Find counter index within block */
-    counter_index = aql_get_counter_index_in_block(block, allocated_counter);
+	/* Find counter index within block */
+	counter_index = aql_get_counter_index_in_block(block, allocated_counter);
 
-    /* Populate counter_info_t */
-    memset(out_info, 0, sizeof(*out_info));
-    out_info->block_id = counter_def->hw_block;
-    out_info->event_id = event_id;
-    out_info->counter_index = counter_index;
-    out_info->name = counter_def->name;
+	/* Populate counter_info_t */
+	memset(out_info, 0, sizeof(*out_info));
+	out_info->block_id = counter_def->hw_block;
+	out_info->event_id = event_id;
+	out_info->counter_index = counter_index;
+	out_info->name = counter_def->name;
 
-    *out_block = block;
+	*out_block = block;
 
-    aql_debug("[PMU] aql_build_counter_info: block=%s, event_id=0x%x, counter_index=%u, name=%s",
-              block->name, event_id, counter_index, counter_def->name);
+	aql_debug(
+		"[PMU] aql_build_counter_info: block=%s, event_id=0x%x, counter_index=%u, name=%s",
+		block->name, event_id, counter_index, counter_def->name);
 
-    return 0;
+	return 0;
 }
 
 EXPORT_SYMBOL_GPL(aql_perf_session_create);

--- a/projects/perf-dkms/src/aql_perf.h
+++ b/projects/perf-dkms/src/aql_perf.h
@@ -28,164 +28,160 @@ struct amdgpu_ib;
 
 /* KFD Data Allocation Structure - from KFD module */
 struct kfd_data_alloc {
-    void *cpu_addr;
-    void *gpu_addr;
-    struct amdgpu_ib *ib;
-    size_t size;
+	void *cpu_addr;
+	void *gpu_addr;
+	struct amdgpu_ib *ib;
+	size_t size;
 };
 
 /* AQL Performance Counter Constants */
-#define AQL_PERF_MAX_GPUS           16
+#define AQL_PERF_MAX_GPUS 16
 #define AQL_PERF_RESULT_BUFFER_SIZE (PAGE_SIZE)
 #define AQL_PERF_PACKET_BUFFER_SIZE (PAGE_SIZE)
 #define AQL_PERF_MAX_RECOVERY_ATTEMPTS 3
 
 /* GFX12 Counter Constants */
-#define GFX12_PERF_SEL_SQ_WAVES     0x00000001
-#define GFX12_PERF_SEL_SQ_INSTS     0x00000002
-#define GFX12_PERF_SEL_TA_BUSY      0x00000003
-#define GFX12_GPU_TYPE              12
+#define GFX12_PERF_SEL_SQ_WAVES 0x00000001
+#define GFX12_PERF_SEL_SQ_INSTS 0x00000002
+#define GFX12_PERF_SEL_TA_BUSY 0x00000003
+#define GFX12_GPU_TYPE 12
 
 /* Error Codes */
-#define AQL_PERF_SUCCESS            0
-#define AQL_PERF_ERR_NO_DEVICE      -ENODEV
-#define AQL_PERF_ERR_NO_MEMORY      -ENOMEM
-#define AQL_PERF_ERR_INVALID        -EINVAL
-#define AQL_PERF_ERR_TIMEOUT        -ETIMEDOUT
-#define AQL_PERF_ERR_GPU_FAULT      -EIO
+#define AQL_PERF_SUCCESS 0
+#define AQL_PERF_ERR_NO_DEVICE -ENODEV
+#define AQL_PERF_ERR_NO_MEMORY -ENOMEM
+#define AQL_PERF_ERR_INVALID -EINVAL
+#define AQL_PERF_ERR_TIMEOUT -ETIMEDOUT
+#define AQL_PERF_ERR_GPU_FAULT -EIO
 
 /* Forward declaration for module parameter */
 extern bool debug_enable;
 
-#define aql_debug(fmt, ...) \
-    do { if (debug_enable) printk(KERN_DEBUG "AQL_PERF: " fmt, ##__VA_ARGS__); } while(0)
+#define aql_debug(fmt, ...)                                                 \
+	do {                                                                \
+		if (debug_enable)                                           \
+			printk(KERN_DEBUG "AQL_PERF: " fmt, ##__VA_ARGS__); \
+	} while (0)
 
-#define aql_info(fmt, ...) \
-    printk(KERN_INFO "AQL_PERF: " fmt, ##__VA_ARGS__)
+#define aql_info(fmt, ...) printk(KERN_INFO "AQL_PERF: " fmt, ##__VA_ARGS__)
 
-#define aql_warn(fmt, ...) \
-    printk(KERN_WARNING "AQL_PERF: WARNING: " fmt, ##__VA_ARGS__)
+#define aql_warn(fmt, ...) printk(KERN_WARNING "AQL_PERF: WARNING: " fmt, ##__VA_ARGS__)
 
-#define aql_err(fmt, ...) \
-    printk(KERN_ERR "AQL_PERF: ERROR: " fmt, ##__VA_ARGS__)
+#define aql_err(fmt, ...) printk(KERN_ERR "AQL_PERF: ERROR: " fmt, ##__VA_ARGS__)
 
 /* Session States */
 enum session_state {
-    SESSION_UNINITIALIZED = 0,
-    SESSION_INITIALIZING,
-    SESSION_ACTIVE,
-    SESSION_MEASURING,
-    SESSION_ERROR,
-    SESSION_DESTROYING
+	SESSION_UNINITIALIZED = 0,
+	SESSION_INITIALIZING,
+	SESSION_ACTIVE,
+	SESSION_MEASURING,
+	SESSION_ERROR,
+	SESSION_DESTROYING
 };
 
 /* Measurement States */
 enum measurement_state {
-    MEASUREMENT_IDLE = 0,
-    MEASUREMENT_STARTING,
-    MEASUREMENT_ACTIVE,
-    MEASUREMENT_READING,
-    MEASUREMENT_STOPPING,
-    MEASUREMENT_ERROR
+	MEASUREMENT_IDLE = 0,
+	MEASUREMENT_STARTING,
+	MEASUREMENT_ACTIVE,
+	MEASUREMENT_READING,
+	MEASUREMENT_STOPPING,
+	MEASUREMENT_ERROR
 };
 
 /* Work Operation Types */
-enum aql_work_op_type {
-    AQL_WORK_START = 0,
-    AQL_WORK_STOP,
-    AQL_WORK_READ
-};
+enum aql_work_op_type { AQL_WORK_START = 0, AQL_WORK_STOP, AQL_WORK_READ };
 
 /* AQL Work Structure for Deferred Operations */
 struct aql_work_item {
-    struct work_struct work;
-    struct aql_measurement *measurement;
-    enum aql_work_op_type op_type;
-    struct completion *completion;  /* For synchronous operations */
-    int result;                     /* Operation result */
+	struct work_struct work;
+	struct aql_measurement *measurement;
+	enum aql_work_op_type op_type;
+	struct completion *completion; /* For synchronous operations */
+	int result; /* Operation result */
 };
 
 /* AQL Packet Types */
 enum aql_perf_packet_type {
-    AQL_PERF_PACKET_START = 0x01,
-    AQL_PERF_PACKET_READ  = 0x02,
-    AQL_PERF_PACKET_END   = 0x03
+	AQL_PERF_PACKET_START = 0x01,
+	AQL_PERF_PACKET_READ = 0x02,
+	AQL_PERF_PACKET_END = 0x03
 };
 
 /* Error Severity Levels */
 enum aql_error_severity {
-    AQL_ERROR_RECOVERABLE = 0,
-    AQL_ERROR_GPU_FAULT,
-    AQL_ERROR_SYSTEM_FAULT,
-    AQL_ERROR_PERMANENT
+	AQL_ERROR_RECOVERABLE = 0,
+	AQL_ERROR_GPU_FAULT,
+	AQL_ERROR_SYSTEM_FAULT,
+	AQL_ERROR_PERMANENT
 };
 
 /* Statistics Types */
 enum aql_stat_type {
-    AQL_STAT_PACKETS_SUBMITTED = 0,
-    AQL_STAT_PACKETS_COMPLETED,
-    AQL_STAT_ERRORS_TOTAL,
-    AQL_STAT_SESSIONS_CREATED
+	AQL_STAT_PACKETS_SUBMITTED = 0,
+	AQL_STAT_PACKETS_COMPLETED,
+	AQL_STAT_ERRORS_TOTAL,
+	AQL_STAT_SESSIONS_CREATED
 };
 
 /* Performance Statistics */
 struct aql_perf_stats {
-    atomic64_t packets_submitted;
-    atomic64_t packets_completed;
-    atomic64_t errors_total;
-    atomic64_t sessions_created;
+	atomic64_t packets_submitted;
+	atomic64_t packets_completed;
+	atomic64_t errors_total;
+	atomic64_t sessions_created;
 };
 
 /* Error Context */
 struct aql_error_context {
-    enum aql_error_severity severity;
-    uint32_t gpu_id;
-    int error_code;
-    char error_msg[128];
-    ktime_t timestamp;
+	enum aql_error_severity severity;
+	uint32_t gpu_id;
+	int error_code;
+	char error_msg[128];
+	ktime_t timestamp;
 };
 
 /* Error Recovery Structure */
 struct aql_error_recovery {
-    unsigned long error_mask;        /* Bitmap of GPU errors */
-    struct delayed_work recovery_work; /* Delayed work for recovery */
-    int recovery_attempts;           /* Track recovery attempts */
+	unsigned long error_mask; /* Bitmap of GPU errors */
+	struct delayed_work recovery_work; /* Delayed work for recovery */
+	int recovery_attempts; /* Track recovery attempts */
 };
 
 /* Counter Descriptor */
 struct counter_descriptor {
-    uint32_t counter_id;
-    uint32_t counter_select;
-    uint32_t counter_mode;
-    const char *name;
-    const char *description;
-    uint32_t supported_gpus;
+	uint32_t counter_id;
+	uint32_t counter_select;
+	uint32_t counter_mode;
+	const char *name;
+	const char *description;
+	uint32_t supported_gpus;
 };
 
 /* GFX12 Counter Configuration */
 struct gfx12_counter_desc {
-    uint32_t counter_select;
-    uint32_t counter_mode;
-    uint64_t *result_buffer;
-    size_t result_size;
+	uint32_t counter_select;
+	uint32_t counter_mode;
+	uint64_t *result_buffer;
+	size_t result_size;
 };
 
 /* Counter Configuration */
 struct counter_config {
-    uint32_t num_counters;
-    uint32_t max_counters;
-    struct gfx12_counter_desc *descriptors;
-    uint64_t *counter_masks;
+	uint32_t num_counters;
+	uint32_t max_counters;
+	struct gfx12_counter_desc *descriptors;
+	uint64_t *counter_masks;
 };
 
 /* AQL Packet Structure */
 struct aql_perf_packet {
-    uint32_t packet_type;
-    uint32_t gpu_id;
-    uint64_t counter_select;
-    uint64_t result_address;
-    uint32_t packet_data[16];
-    size_t packet_size;
+	uint32_t packet_type;
+	uint32_t gpu_id;
+	uint64_t counter_select;
+	uint64_t result_address;
+	uint32_t packet_data[16];
+	size_t packet_size;
 };
 
 /* Forward declarations */
@@ -195,87 +191,87 @@ struct shared_counter_ref;
 
 /* Shared counter tracking for dimension-specific events */
 struct shared_counter_ref {
-    uint32_t counter_id;                   /* Which counter type (counter_id_t) */
-    struct aql_measurement *measurement;   /* The measurement that owns the counter */
-    atomic_t ref_count;                    /* How many events share this counter */
-    struct list_head list;                 /* List linkage */
+	uint32_t counter_id; /* Which counter type (counter_id_t) */
+	struct aql_measurement *measurement; /* The measurement that owns the counter */
+	atomic_t ref_count; /* How many events share this counter */
+	struct list_head list; /* List linkage */
 };
 
 /* Per-measurement tracking structure */
 struct aql_measurement {
-    struct list_head list;
-    struct aql_perf_session *session;
-    uint32_t gpu_id;
-    uint32_t counter_mask;
-    uint32_t counter_id;  /* Counter ID from counter_registry (counter_id_t) */
-    struct perf_event *event;
-    ktime_t start_time;
-    enum measurement_state state;
-    uint64_t start_counter_value;  /* Counter value when measurement started */
-    uint64_t last_counter_value;   /* Most recent counter value read */
+	struct list_head list;
+	struct aql_perf_session *session;
+	uint32_t gpu_id;
+	uint32_t counter_mask;
+	uint32_t counter_id; /* Counter ID from counter_registry (counter_id_t) */
+	struct perf_event *event;
+	ktime_t start_time;
+	enum measurement_state state;
+	uint64_t start_counter_value; /* Counter value when measurement started */
+	uint64_t last_counter_value; /* Most recent counter value read */
 
-    /* Allocated counter from block (NULL if not allocated) */
-    counter_reg_info_t* allocated_counter;
+	/* Allocated counter from block (NULL if not allocated) */
+	counter_reg_info_t *allocated_counter;
 
-    /* Counter sharing support */
-    struct shared_counter_ref *shared_ref;  /* Shared counter reference */
-    bool owns_counter;                      /* True if this measurement allocated the counter */
+	/* Counter sharing support */
+	struct shared_counter_ref *shared_ref; /* Shared counter reference */
+	bool owns_counter; /* True if this measurement allocated the counter */
 
-    /* Dimension-specific monitoring support */
-    struct pmu_dimension_coords target_dims;  /* Target hardware dimensions */
-    bool dimension_specific;                  /* True if targeting specific dimensions */
+	/* Dimension-specific monitoring support */
+	struct pmu_dimension_coords target_dims; /* Target hardware dimensions */
+	bool dimension_specific; /* True if targeting specific dimensions */
 
-    /* Work queue support for atomic context handling */
-    spinlock_t cache_lock;           /* Protects cached_counter_value */
-    uint64_t cached_counter_value;   /* Cached value for atomic reads */
-    bool cache_valid;                /* Whether cached value is valid */
-    bool pending_destroy;            /* Measurement should be freed after async work */
+	/* Work queue support for atomic context handling */
+	spinlock_t cache_lock; /* Protects cached_counter_value */
+	uint64_t cached_counter_value; /* Cached value for atomic reads */
+	bool cache_valid; /* Whether cached value is valid */
+	bool pending_destroy; /* Measurement should be freed after async work */
 
-    /* Reference counting to prevent use-after-free with work items */
-    struct kref refcount;            /* Reference count for safe async operations */
+	/* Reference counting to prevent use-after-free with work items */
+	struct kref refcount; /* Reference count for safe async operations */
 };
 
 /* Main AQL Performance Session Structure */
 struct aql_perf_session {
-    /* Core KFD integration */
-    struct file *kfd_file;
-    struct kfd_process *process;
+	/* Core KFD integration */
+	struct file *kfd_file;
+	struct kfd_process *process;
 
-    /* GPU management */
-    uint32_t *gpu_ids;
-    uint32_t num_gpus;
-    uint32_t max_gpus;
+	/* GPU management */
+	uint32_t *gpu_ids;
+	uint32_t num_gpus;
+	uint32_t max_gpus;
 
-    /* Thread safety and state management */
-    struct mutex session_mutex;
-    refcount_t ref_count;                /* Reference counting for future multi-session support.
+	/* Thread safety and state management */
+	struct mutex session_mutex;
+	refcount_t ref_count; /* Reference counting for future multi-session support.
                                           * Currently only one global session exists, but this
                                           * infrastructure allows safe sharing if needed. */
-    enum session_state state;
+	enum session_state state;
 
-    /* Resource tracking */
-    struct list_head active_measurements;
-    spinlock_t measurement_lock;
-    atomic_t active_gpu_count;
+	/* Resource tracking */
+	struct list_head active_measurements;
+	spinlock_t measurement_lock;
+	atomic_t active_gpu_count;
 
-    /* Counter sharing for dimension-specific events */
-    struct list_head shared_counters;  /* List of shared counter allocations */
-    spinlock_t shared_lock;            /* Protects shared_counters list */
+	/* Counter sharing for dimension-specific events */
+	struct list_head shared_counters; /* List of shared counter allocations */
+	spinlock_t shared_lock; /* Protects shared_counters list */
 
-    /* Error recovery */
-    struct aql_error_recovery recovery;
+	/* Error recovery */
+	struct aql_error_recovery recovery;
 
-    /* Performance monitoring */
-    struct aql_perf_stats stats;
+	/* Performance monitoring */
+	struct aql_perf_stats stats;
 
-    /* Counter configuration */
-    struct counter_config counters;
+	/* Counter configuration */
+	struct counter_config counters;
 
-    /* GPU Architecture - one per GPU */
-    arch_t **archs;  /* Array of architecture pointers, indexed by GPU index */
+	/* GPU Architecture - one per GPU */
+	arch_t **archs; /* Array of architecture pointers, indexed by GPU index */
 
-    /* Session ID for debugging */
-    uint64_t session_id;
+	/* Session ID for debugging */
+	uint64_t session_id;
 };
 
 /* Function prototypes */
@@ -295,38 +291,29 @@ int aql_perf_discover_gpus(struct aql_perf_session *session);
 
 /* Counter Buffer Management */
 int aql_perf_allocate_counter_buffers(arch_t *arch, struct file *kfd_file,
-                                      struct kfd_process *process, uint32_t gpu_id);
-void aql_perf_free_counter_buffers(arch_t *arch, struct file *kfd_file,
-                                   struct kfd_process *process, uint32_t gpu_id);
+				      struct kfd_process *process, uint32_t gpu_id);
+void aql_perf_free_counter_buffers(arch_t *arch, struct file *kfd_file, struct kfd_process *process,
+				   uint32_t gpu_id);
 
 /* Counter Allocation Functions */
-counter_reg_info_t* aql_counter_try_allocate(block_info_t *block,
-                                             uint32_t event_id,
-                                             struct perf_event *perf_event);
+counter_reg_info_t *aql_counter_try_allocate(block_info_t *block, uint32_t event_id,
+					     struct perf_event *perf_event);
 void aql_counter_release(counter_reg_info_t *reg);
-void release_shared_counter(struct aql_perf_session *session,
-                            struct shared_counter_ref *ref);
-int aql_build_counter_info(uint32_t counter_id,
-                           arch_t *arch,
-                           counter_reg_info_t *allocated_counter,
-                           counter_info_t *out_info,
-                           block_info_t **out_block);
+void release_shared_counter(struct aql_perf_session *session, struct shared_counter_ref *ref);
+int aql_build_counter_info(uint32_t counter_id, arch_t *arch, counter_reg_info_t *allocated_counter,
+			   counter_info_t *out_info, block_info_t **out_block);
 
 /* Packet Operations - New PM4-based implementation */
 int aql_perf_create_start_packet(struct aql_measurement *measurement,
-                                 pm4_buffer_t **out_pm4_buffer);
-int aql_perf_create_read_packet(struct aql_measurement *measurement,
-                                pm4_buffer_t **out_pm4_buffer);
-int aql_perf_create_end_packet(struct aql_measurement *measurement,
-                               pm4_buffer_t **out_pm4_buffer);
-int aql_perf_submit_pm4_packet(struct aql_perf_session *session,
-                               uint32_t gpu_id,
-                               pm4_buffer_t *pm4_buffer);
+				 pm4_buffer_t **out_pm4_buffer);
+int aql_perf_create_read_packet(struct aql_measurement *measurement, pm4_buffer_t **out_pm4_buffer);
+int aql_perf_create_end_packet(struct aql_measurement *measurement, pm4_buffer_t **out_pm4_buffer);
+int aql_perf_submit_pm4_packet(struct aql_perf_session *session, uint32_t gpu_id,
+			       pm4_buffer_t *pm4_buffer);
 
 /* Measurement Management */
 struct aql_measurement *aql_perf_measurement_create(struct aql_perf_session *session,
-                                                    uint32_t gpu_id,
-                                                    struct perf_event *event);
+						    uint32_t gpu_id, struct perf_event *event);
 int aql_perf_measurement_start(struct aql_measurement *measurement);
 int aql_perf_measurement_stop(struct aql_measurement *measurement);
 uint64_t aql_perf_measurement_read(struct aql_measurement *measurement);
@@ -344,11 +331,10 @@ uint64_t aql_perf_measurement_read_atomic(struct aql_measurement *measurement);
 /* Work Handler Functions */
 void aql_work_handler(struct work_struct *work);
 struct aql_work_item *aql_create_work_item(struct aql_measurement *measurement,
-                                          enum aql_work_op_type op_type);
+					   enum aql_work_op_type op_type);
 
 /* Error Handling */
-void aql_perf_handle_error(struct aql_perf_session *session,
-                          struct aql_error_context *error);
+void aql_perf_handle_error(struct aql_perf_session *session, struct aql_error_context *error);
 void aql_perf_recovery_work(struct work_struct *work);
 
 /* Statistics */
@@ -357,8 +343,8 @@ void aql_perf_get_stats(struct aql_perf_stats *stats);
 
 /* Error Recovery Functions */
 struct aql_error_context *aql_perf_create_error_context(enum aql_error_severity severity,
-                                                       uint32_t gpu_id, int error_code,
-                                                       const char *error_msg, ...);
+							uint32_t gpu_id, int error_code,
+							const char *error_msg, ...);
 void aql_perf_destroy_error_context(struct aql_error_context *error);
 bool aql_perf_is_gpu_disabled(struct aql_perf_session *session, uint32_t gpu_id);
 uint32_t aql_perf_get_healthy_gpu_count(struct aql_perf_session *session);

--- a/projects/perf-dkms/src/aql_pmu_integration.c
+++ b/projects/perf-dkms/src/aql_pmu_integration.c
@@ -32,7 +32,7 @@ static struct workqueue_struct *aql_global_workqueue = NULL;
  */
 struct workqueue_struct *aql_get_global_workqueue(void)
 {
-    return aql_global_workqueue;
+	return aql_global_workqueue;
 }
 
 /**
@@ -42,50 +42,49 @@ struct workqueue_struct *aql_get_global_workqueue(void)
  */
 int aql_pmu_init(void)
 {
-    int ret;
+	int ret;
 
-    mutex_init(&aql_pmu_mutex);
+	mutex_init(&aql_pmu_mutex);
 
-    aql_info("Initializing AQL PMU integration");
+	aql_info("Initializing AQL PMU integration");
 
-    /* Create global workqueue - shared by all measurements */
-    aql_global_workqueue = alloc_workqueue("aql_pmu",
-                                           WQ_MEM_RECLAIM | WQ_HIGHPRI | WQ_UNBOUND,
-                                           0);
-    if (!aql_global_workqueue) {
-        aql_err("Failed to create global workqueue");
-        return -ENOMEM;
-    }
+	/* Create global workqueue - shared by all measurements */
+	aql_global_workqueue =
+		alloc_workqueue("aql_pmu", WQ_MEM_RECLAIM | WQ_HIGHPRI | WQ_UNBOUND, 0);
+	if (!aql_global_workqueue) {
+		aql_err("Failed to create global workqueue");
+		return -ENOMEM;
+	}
 
-    aql_info("Created global workqueue for all measurements");
+	aql_info("Created global workqueue for all measurements");
 
-    /* Create global AQL session */
-    global_aql_session = aql_perf_session_create();
-    if (IS_ERR(global_aql_session)) {
-        ret = PTR_ERR(global_aql_session);
-        aql_err("Failed to create global AQL session: %d", ret);
-        global_aql_session = NULL;
-        destroy_workqueue(aql_global_workqueue);
-        aql_global_workqueue = NULL;
-        return ret;
-    }
+	/* Create global AQL session */
+	global_aql_session = aql_perf_session_create();
+	if (IS_ERR(global_aql_session)) {
+		ret = PTR_ERR(global_aql_session);
+		aql_err("Failed to create global AQL session: %d", ret);
+		global_aql_session = NULL;
+		destroy_workqueue(aql_global_workqueue);
+		aql_global_workqueue = NULL;
+		return ret;
+	}
 
-    /* Initialize the session */
-    ret = aql_perf_session_initialize(global_aql_session);
-    if (ret) {
-        aql_err("Failed to initialize global AQL session: %d", ret);
-        aql_perf_session_put(global_aql_session);
-        global_aql_session = NULL;
-        destroy_workqueue(aql_global_workqueue);
-        aql_global_workqueue = NULL;
-        return ret;
-    }
+	/* Initialize the session */
+	ret = aql_perf_session_initialize(global_aql_session);
+	if (ret) {
+		aql_err("Failed to initialize global AQL session: %d", ret);
+		aql_perf_session_put(global_aql_session);
+		global_aql_session = NULL;
+		destroy_workqueue(aql_global_workqueue);
+		aql_global_workqueue = NULL;
+		return ret;
+	}
 
-    aql_feature_available = true;
-    aql_info("AQL PMU integration initialized successfully with %u GPUs",
-             global_aql_session->num_gpus);
+	aql_feature_available = true;
+	aql_info("AQL PMU integration initialized successfully with %u GPUs",
+		 global_aql_session->num_gpus);
 
-    return 0;
+	return 0;
 }
 
 /**
@@ -99,19 +98,19 @@ int aql_pmu_init(void)
  */
 void aql_pmu_flush_all_measurements(void)
 {
-    mutex_lock(&aql_pmu_mutex);
+	mutex_lock(&aql_pmu_mutex);
 
-    if (!aql_global_workqueue) {
-        mutex_unlock(&aql_pmu_mutex);
-        return;
-    }
+	if (!aql_global_workqueue) {
+		mutex_unlock(&aql_pmu_mutex);
+		return;
+	}
 
-    pmu_info("Flushing global workqueue");
-    flush_workqueue(aql_global_workqueue);
+	pmu_info("Flushing global workqueue");
+	flush_workqueue(aql_global_workqueue);
 
-    mutex_unlock(&aql_pmu_mutex);
+	mutex_unlock(&aql_pmu_mutex);
 
-    pmu_info("Global workqueue flushed");
+	pmu_info("Global workqueue flushed");
 }
 
 /**
@@ -119,28 +118,28 @@ void aql_pmu_flush_all_measurements(void)
  */
 void aql_pmu_cleanup(void)
 {
-    aql_info("Cleaning up AQL PMU integration");
+	aql_info("Cleaning up AQL PMU integration");
 
-    mutex_lock(&aql_pmu_mutex);
+	mutex_lock(&aql_pmu_mutex);
 
-    if (global_aql_session) {
-        aql_perf_session_put(global_aql_session);
-        global_aql_session = NULL;
-    }
+	if (global_aql_session) {
+		aql_perf_session_put(global_aql_session);
+		global_aql_session = NULL;
+	}
 
-    aql_feature_available = false;
+	aql_feature_available = false;
 
-    mutex_unlock(&aql_pmu_mutex);
+	mutex_unlock(&aql_pmu_mutex);
 
-    /* Destroy global workqueue - safe because session is already released
+	/* Destroy global workqueue - safe because session is already released
      * and timer is already cancelled (done in pmu_main.c before calling this) */
-    if (aql_global_workqueue) {
-        aql_info("Destroying global workqueue");
-        destroy_workqueue(aql_global_workqueue);
-        aql_global_workqueue = NULL;
-    }
+	if (aql_global_workqueue) {
+		aql_info("Destroying global workqueue");
+		destroy_workqueue(aql_global_workqueue);
+		aql_global_workqueue = NULL;
+	}
 
-    aql_info("AQL PMU integration cleanup complete");
+	aql_info("AQL PMU integration cleanup complete");
 }
 
 /**
@@ -150,14 +149,14 @@ void aql_pmu_cleanup(void)
  */
 bool aql_pmu_is_available(void)
 {
-    bool available;
+	bool available;
 
-    mutex_lock(&aql_pmu_mutex);
-    available = aql_feature_available && global_aql_session &&
-                (global_aql_session->state == SESSION_ACTIVE);
-    mutex_unlock(&aql_pmu_mutex);
+	mutex_lock(&aql_pmu_mutex);
+	available = aql_feature_available && global_aql_session &&
+		    (global_aql_session->state == SESSION_ACTIVE);
+	mutex_unlock(&aql_pmu_mutex);
 
-    return available;
+	return available;
 }
 
 /**
@@ -168,15 +167,15 @@ bool aql_pmu_is_available(void)
  */
 static bool aql_pmu_should_use_hardware(struct perf_event *event)
 {
-    if (!event || !event->pmu)
-        return false;
+	if (!event || !event->pmu)
+		return false;
 
-    /* Check if AQL is available */
-    if (!aql_pmu_is_available())
-        return false;
+	/* Check if AQL is available */
+	if (!aql_pmu_is_available())
+		return false;
 
-    /* All events are now supported by hardware (validated by counter_registry) */
-    return true;
+	/* All events are now supported by hardware (validated by counter_registry) */
+	return true;
 }
 
 /**
@@ -195,59 +194,59 @@ static bool aql_pmu_should_use_hardware(struct perf_event *event)
  */
 static uint32_t aql_pmu_get_gpu_id_for_event_locked(struct perf_event *event)
 {
-    struct aql_perf_session *session;
-    uint32_t cpu;
-    uint32_t gpu_id;
+	struct aql_perf_session *session;
+	uint32_t cpu;
+	uint32_t gpu_id;
 
-    if (!event) {
-        return U32_MAX;
-    }
+	if (!event) {
+		return U32_MAX;
+	}
 
-    session = global_aql_session;
-    cpu = event->cpu;
+	session = global_aql_session;
+	cpu = event->cpu;
 
-    aql_debug("get_gpu_id_for_event: cpu=%d, num_gpus=%u",
-              cpu, session ? session->num_gpus : 0);
+	aql_debug("get_gpu_id_for_event: cpu=%d, num_gpus=%u", cpu,
+		  session ? session->num_gpus : 0);
 
-    if (!session || session->num_gpus == 0) {
-        aql_err("get_gpu_id_for_event: no session or no GPUs");
-        return U32_MAX;
-    }
+	if (!session || session->num_gpus == 0) {
+		aql_err("get_gpu_id_for_event: no session or no GPUs");
+		return U32_MAX;
+	}
 
-    /* For now, use simple CPU-to-GPU mapping */
-    if (cpu == -1) {
-        /* Use first healthy GPU for CPU-wide events */
-        for (uint32_t i = 0; i < session->num_gpus; i++) {
-            gpu_id = session->gpu_ids[i];
-            if (!aql_perf_is_gpu_disabled(session, gpu_id)) {
-                aql_debug("Selected GPU %u for CPU-wide event", gpu_id);
-                return gpu_id;
-            }
-        }
-    } else {
-        /* Map CPU to GPU using modulo */
-        uint32_t healthy_count = aql_perf_get_healthy_gpu_count(session);
+	/* For now, use simple CPU-to-GPU mapping */
+	if (cpu == -1) {
+		/* Use first healthy GPU for CPU-wide events */
+		for (uint32_t i = 0; i < session->num_gpus; i++) {
+			gpu_id = session->gpu_ids[i];
+			if (!aql_perf_is_gpu_disabled(session, gpu_id)) {
+				aql_debug("Selected GPU %u for CPU-wide event", gpu_id);
+				return gpu_id;
+			}
+		}
+	} else {
+		/* Map CPU to GPU using modulo */
+		uint32_t healthy_count = aql_perf_get_healthy_gpu_count(session);
 
-        if (healthy_count == 0) {
-            return U32_MAX;
-        }
+		if (healthy_count == 0) {
+			return U32_MAX;
+		}
 
-        uint32_t gpu_index = cpu % healthy_count;
-        uint32_t healthy_idx = 0;
+		uint32_t gpu_index = cpu % healthy_count;
+		uint32_t healthy_idx = 0;
 
-        for (uint32_t i = 0; i < session->num_gpus; i++) {
-            gpu_id = session->gpu_ids[i];
-            if (!aql_perf_is_gpu_disabled(session, gpu_id)) {
-                if (healthy_idx == gpu_index) {
-                    aql_debug("Selected GPU %u for CPU %u", gpu_id, cpu);
-                    return gpu_id;
-                }
-                healthy_idx++;
-            }
-        }
-    }
+		for (uint32_t i = 0; i < session->num_gpus; i++) {
+			gpu_id = session->gpu_ids[i];
+			if (!aql_perf_is_gpu_disabled(session, gpu_id)) {
+				if (healthy_idx == gpu_index) {
+					aql_debug("Selected GPU %u for CPU %u", gpu_id, cpu);
+					return gpu_id;
+				}
+				healthy_idx++;
+			}
+		}
+	}
 
-    return U32_MAX;
+	return U32_MAX;
 }
 
 /**
@@ -262,19 +261,19 @@ static uint32_t aql_pmu_get_gpu_id_for_event_locked(struct perf_event *event)
  */
 uint32_t aql_pmu_get_gpu_id_for_event(struct perf_event *event)
 {
-    uint32_t gpu_id;
+	uint32_t gpu_id;
 
-    mutex_lock(&aql_pmu_mutex);
-    gpu_id = aql_pmu_get_gpu_id_for_event_locked(event);
-    mutex_unlock(&aql_pmu_mutex);
+	mutex_lock(&aql_pmu_mutex);
+	gpu_id = aql_pmu_get_gpu_id_for_event_locked(event);
+	mutex_unlock(&aql_pmu_mutex);
 
-    return gpu_id;
+	return gpu_id;
 }
 
 /* Internal helper - calls locked version since we already hold mutex in event_init */
 static uint32_t aql_pmu_select_gpu(struct perf_event *event)
 {
-    return aql_pmu_get_gpu_id_for_event_locked(event);
+	return aql_pmu_get_gpu_id_for_event_locked(event);
 }
 
 /**
@@ -285,77 +284,78 @@ static uint32_t aql_pmu_select_gpu(struct perf_event *event)
  */
 int aql_pmu_event_init(struct perf_event *event, const struct pmu_dimension_coords *dims)
 {
-    struct aql_measurement *measurement;
-    uint32_t gpu_id;
+	struct aql_measurement *measurement;
+	uint32_t gpu_id;
 
-    aql_debug("ENTRY: aql_pmu_event_init");
+	aql_debug("ENTRY: aql_pmu_event_init");
 
-    if (!aql_pmu_should_use_hardware(event)) {
-        aql_debug("Not using hardware, returning -EOPNOTSUPP");
-        return -EOPNOTSUPP; /* Use simulation instead */
-    }
+	if (!aql_pmu_should_use_hardware(event)) {
+		aql_debug("Not using hardware, returning -EOPNOTSUPP");
+		return -EOPNOTSUPP; /* Use simulation instead */
+	}
 
-    aql_debug("Before mutex_lock(&aql_pmu_mutex)");
-    mutex_lock(&aql_pmu_mutex);
-    aql_debug("After mutex_lock(&aql_pmu_mutex), global_aql_session=%p", global_aql_session);
+	aql_debug("Before mutex_lock(&aql_pmu_mutex)");
+	mutex_lock(&aql_pmu_mutex);
+	aql_debug("After mutex_lock(&aql_pmu_mutex), global_aql_session=%p", global_aql_session);
 
-    if (!global_aql_session) {
-        aql_debug("Global AQL session is NULL, falling back to simulation");
-        mutex_unlock(&aql_pmu_mutex);
-        return -EOPNOTSUPP;
-    }
+	if (!global_aql_session) {
+		aql_debug("Global AQL session is NULL, falling back to simulation");
+		mutex_unlock(&aql_pmu_mutex);
+		return -EOPNOTSUPP;
+	}
 
-    aql_debug("About to check session state, session=%p", global_aql_session);
-    if (global_aql_session->state != SESSION_ACTIVE) {
-        aql_debug("AQL session state is %d (not active), falling back to simulation", global_aql_session->state);
-        mutex_unlock(&aql_pmu_mutex);
-        return -EOPNOTSUPP;
-    }
-    aql_debug("Session is active, state=%d", global_aql_session->state);
+	aql_debug("About to check session state, session=%p", global_aql_session);
+	if (global_aql_session->state != SESSION_ACTIVE) {
+		aql_debug("AQL session state is %d (not active), falling back to simulation",
+			  global_aql_session->state);
+		mutex_unlock(&aql_pmu_mutex);
+		return -EOPNOTSUPP;
+	}
+	aql_debug("Session is active, state=%d", global_aql_session->state);
 
-    /* Select GPU for this event */
-    aql_debug("Before aql_pmu_select_gpu");
-    gpu_id = aql_pmu_select_gpu(event);
-    aql_debug("After aql_pmu_select_gpu, gpu_id=%u", gpu_id);
-    if (gpu_id == U32_MAX) {
-        aql_debug("No suitable GPU found for event, falling back to simulation");
-        mutex_unlock(&aql_pmu_mutex);
-        return -EOPNOTSUPP;
-    }
+	/* Select GPU for this event */
+	aql_debug("Before aql_pmu_select_gpu");
+	gpu_id = aql_pmu_select_gpu(event);
+	aql_debug("After aql_pmu_select_gpu, gpu_id=%u", gpu_id);
+	if (gpu_id == U32_MAX) {
+		aql_debug("No suitable GPU found for event, falling back to simulation");
+		mutex_unlock(&aql_pmu_mutex);
+		return -EOPNOTSUPP;
+	}
 
-    /* Create AQL measurement */
-    aql_debug("Before aql_perf_measurement_create for GPU %u", gpu_id);
-    measurement = aql_perf_measurement_create(global_aql_session, gpu_id, event);
-    aql_debug("After aql_perf_measurement_create, measurement=%p", measurement);
-    if (IS_ERR(measurement)) {
-        aql_err("Failed to create AQL measurement: %ld", PTR_ERR(measurement));
-        mutex_unlock(&aql_pmu_mutex);
-        return PTR_ERR(measurement);
-    }
+	/* Create AQL measurement */
+	aql_debug("Before aql_perf_measurement_create for GPU %u", gpu_id);
+	measurement = aql_perf_measurement_create(global_aql_session, gpu_id, event);
+	aql_debug("After aql_perf_measurement_create, measurement=%p", measurement);
+	if (IS_ERR(measurement)) {
+		aql_err("Failed to create AQL measurement: %ld", PTR_ERR(measurement));
+		mutex_unlock(&aql_pmu_mutex);
+		return PTR_ERR(measurement);
+	}
 
-    /* Store dimension information in measurement if specified */
-    if (dims && dims->valid) {
-        measurement->target_dims = *dims;
-        /* If aggregate flag is set, aggregate across all dimensions.
+	/* Store dimension information in measurement if specified */
+	if (dims && dims->valid) {
+		measurement->target_dims = *dims;
+		/* If aggregate flag is set, aggregate across all dimensions.
          * Otherwise, monitor only the specific dimension. */
-        if (dims->aggregate) {
-            measurement->dimension_specific = false;  /* Aggregate mode */
-            aql_debug("GPU %u: aggregate mode (all dimensions)", gpu_id);
-        } else {
-            measurement->dimension_specific = true;   /* Dimension-specific mode */
-            aql_debug("GPU %u: dimension-specific se=%u sa=%u wgp=%u",
-                      gpu_id, dims->se, dims->sa, dims->wgp);
-        }
-    } else {
-        measurement->dimension_specific = false;
-        aql_debug("GPU %u: initialized (aggregated)", gpu_id);
-    }
+		if (dims->aggregate) {
+			measurement->dimension_specific = false; /* Aggregate mode */
+			aql_debug("GPU %u: aggregate mode (all dimensions)", gpu_id);
+		} else {
+			measurement->dimension_specific = true; /* Dimension-specific mode */
+			aql_debug("GPU %u: dimension-specific se=%u sa=%u wgp=%u", gpu_id, dims->se,
+				  dims->sa, dims->wgp);
+		}
+	} else {
+		measurement->dimension_specific = false;
+		aql_debug("GPU %u: initialized (aggregated)", gpu_id);
+	}
 
-    /* Store measurement in event's hardware config */
-    event->hw.config_base = (unsigned long)measurement;
+	/* Store measurement in event's hardware config */
+	event->hw.config_base = (unsigned long)measurement;
 
-    mutex_unlock(&aql_pmu_mutex);
-    return 0;
+	mutex_unlock(&aql_pmu_mutex);
+	return 0;
 }
 
 /**
@@ -364,22 +364,22 @@ int aql_pmu_event_init(struct perf_event *event, const struct pmu_dimension_coor
  */
 void aql_pmu_event_destroy(struct perf_event *event)
 {
-    struct aql_measurement *measurement;
+	struct aql_measurement *measurement;
 
-    if (!event->hw.config_base)
-        return;
+	if (!event->hw.config_base)
+		return;
 
-    measurement = (struct aql_measurement *)event->hw.config_base;
+	measurement = (struct aql_measurement *)event->hw.config_base;
 
-    mutex_lock(&aql_pmu_mutex);
+	mutex_lock(&aql_pmu_mutex);
 
-    aql_debug("Destroying hardware event for GPU %u", measurement->gpu_id);
-    aql_perf_measurement_destroy(measurement);
+	aql_debug("Destroying hardware event for GPU %u", measurement->gpu_id);
+	aql_perf_measurement_destroy(measurement);
 
-    /* Clear config_base so add/del/start/stop know the event is destroyed */
-    event->hw.config_base = 0;
+	/* Clear config_base so add/del/start/stop know the event is destroyed */
+	event->hw.config_base = 0;
 
-    mutex_unlock(&aql_pmu_mutex);
+	mutex_unlock(&aql_pmu_mutex);
 }
 
 /**
@@ -390,24 +390,24 @@ void aql_pmu_event_destroy(struct perf_event *event)
  */
 int aql_pmu_event_start(struct perf_event *event)
 {
-    struct aql_measurement *measurement;
-    int ret;
+	struct aql_measurement *measurement;
+	int ret;
 
-    if (!event->hw.config_base)
-        return -EINVAL;
+	if (!event->hw.config_base)
+		return -EINVAL;
 
-    measurement = (struct aql_measurement *)event->hw.config_base;
+	measurement = (struct aql_measurement *)event->hw.config_base;
 
-    /* Use atomic version to avoid sleeping in PMU callback */
-    ret = aql_perf_measurement_start_atomic(measurement);
-    if (ret) {
-        aql_err("Failed to schedule start for AQL measurement on GPU %u: %d",
-                measurement->gpu_id, ret);
-    } else {
-        aql_debug("Scheduled start for AQL measurement on GPU %u", measurement->gpu_id);
-    }
+	/* Use atomic version to avoid sleeping in PMU callback */
+	ret = aql_perf_measurement_start_atomic(measurement);
+	if (ret) {
+		aql_err("Failed to schedule start for AQL measurement on GPU %u: %d",
+			measurement->gpu_id, ret);
+	} else {
+		aql_debug("Scheduled start for AQL measurement on GPU %u", measurement->gpu_id);
+	}
 
-    return ret;
+	return ret;
 }
 
 /**
@@ -418,24 +418,24 @@ int aql_pmu_event_start(struct perf_event *event)
  */
 int aql_pmu_event_stop(struct perf_event *event)
 {
-    struct aql_measurement *measurement;
-    int ret;
+	struct aql_measurement *measurement;
+	int ret;
 
-    if (!event->hw.config_base)
-        return -EINVAL;
+	if (!event->hw.config_base)
+		return -EINVAL;
 
-    measurement = (struct aql_measurement *)event->hw.config_base;
+	measurement = (struct aql_measurement *)event->hw.config_base;
 
-    /* Use atomic version to avoid sleeping in PMU callback */
-    ret = aql_perf_measurement_stop_atomic(measurement);
-    if (ret) {
-        aql_err("Failed to schedule stop for AQL measurement on GPU %u: %d",
-                measurement->gpu_id, ret);
-    } else {
-        aql_debug("Scheduled stop for AQL measurement on GPU %u", measurement->gpu_id);
-    }
+	/* Use atomic version to avoid sleeping in PMU callback */
+	ret = aql_perf_measurement_stop_atomic(measurement);
+	if (ret) {
+		aql_err("Failed to schedule stop for AQL measurement on GPU %u: %d",
+			measurement->gpu_id, ret);
+	} else {
+		aql_debug("Scheduled stop for AQL measurement on GPU %u", measurement->gpu_id);
+	}
 
-    return ret;
+	return ret;
 }
 
 /**
@@ -446,23 +446,23 @@ int aql_pmu_event_stop(struct perf_event *event)
  */
 uint64_t aql_pmu_event_read(struct perf_event *event)
 {
-    struct aql_measurement *measurement;
-    uint64_t counter_value;
+	struct aql_measurement *measurement;
+	uint64_t counter_value;
 
-    if (!event->hw.config_base) {
-        return 0;
-    }
+	if (!event->hw.config_base) {
+		return 0;
+	}
 
-    measurement = (struct aql_measurement *)event->hw.config_base;
+	measurement = (struct aql_measurement *)event->hw.config_base;
 
-    /* Use atomic version to return cached value and schedule refresh */
-    counter_value = aql_perf_measurement_read_atomic(measurement);
+	/* Use atomic version to return cached value and schedule refresh */
+	counter_value = aql_perf_measurement_read_atomic(measurement);
 
-    aql_debug("GPU %u: read=%llu", measurement->gpu_id, counter_value);
-    aql_info("[PMU] ========== aql_pmu_event_read RETURNING: %llu (0x%llx) ==========",
-             counter_value, counter_value);
+	aql_debug("GPU %u: read=%llu", measurement->gpu_id, counter_value);
+	aql_info("[PMU] ========== aql_pmu_event_read RETURNING: %llu (0x%llx) ==========",
+		 counter_value, counter_value);
 
-    return counter_value;
+	return counter_value;
 }
 
 /**
@@ -477,21 +477,21 @@ uint64_t aql_pmu_event_read(struct perf_event *event)
  */
 uint64_t aql_pmu_event_read_sync(struct perf_event *event)
 {
-    struct aql_measurement *measurement;
-    uint64_t counter_value;
+	struct aql_measurement *measurement;
+	uint64_t counter_value;
 
-    if (!event->hw.config_base) {
-        return 0;
-    }
+	if (!event->hw.config_base) {
+		return 0;
+	}
 
-    measurement = (struct aql_measurement *)event->hw.config_base;
+	measurement = (struct aql_measurement *)event->hw.config_base;
 
-    /* Use synchronous version to wait for actual hardware read */
-    counter_value = aql_perf_measurement_read(measurement);
+	/* Use synchronous version to wait for actual hardware read */
+	counter_value = aql_perf_measurement_read(measurement);
 
-    aql_debug("GPU %u: read_sync=%llu", measurement->gpu_id, counter_value);
+	aql_debug("GPU %u: read_sync=%llu", measurement->gpu_id, counter_value);
 
-    return counter_value;
+	return counter_value;
 }
 
 /**
@@ -501,13 +501,13 @@ uint64_t aql_pmu_event_read_sync(struct perf_event *event)
  */
 int aql_pmu_get_gpu_count(void)
 {
-    int count;
+	int count;
 
-    mutex_lock(&aql_pmu_mutex);
-    count = global_aql_session ? global_aql_session->num_gpus : 0;
-    mutex_unlock(&aql_pmu_mutex);
+	mutex_lock(&aql_pmu_mutex);
+	count = global_aql_session ? global_aql_session->num_gpus : 0;
+	mutex_unlock(&aql_pmu_mutex);
 
-    return count;
+	return count;
 }
 
 /**
@@ -524,15 +524,15 @@ int aql_pmu_get_gpu_count(void)
  */
 struct aql_perf_session *aql_pmu_get_session(void)
 {
-    struct aql_perf_session *session;
+	struct aql_perf_session *session;
 
-    mutex_lock(&aql_pmu_mutex);
-    session = global_aql_session;
-    if (session)
-        aql_perf_session_get(session);
-    mutex_unlock(&aql_pmu_mutex);
+	mutex_lock(&aql_pmu_mutex);
+	session = global_aql_session;
+	if (session)
+		aql_perf_session_get(session);
+	mutex_unlock(&aql_pmu_mutex);
 
-    return session;
+	return session;
 }
 
 /**
@@ -547,8 +547,8 @@ struct aql_perf_session *aql_pmu_get_session(void)
  */
 void aql_pmu_put_session(struct aql_perf_session *session)
 {
-    if (session)
-        aql_perf_session_put(session);
+	if (session)
+		aql_perf_session_put(session);
 }
 
 /**
@@ -557,24 +557,24 @@ void aql_pmu_put_session(struct aql_perf_session *session)
  */
 void aql_pmu_get_stats(struct aql_perf_stats *stats)
 {
-    if (!stats)
-        return;
+	if (!stats)
+		return;
 
-    aql_perf_get_stats(stats);
+	aql_perf_get_stats(stats);
 
-    /* Add session-specific stats if available */
-    mutex_lock(&aql_pmu_mutex);
-    if (global_aql_session) {
-        atomic64_add(atomic64_read(&global_aql_session->stats.packets_submitted),
-                     &stats->packets_submitted);
-        atomic64_add(atomic64_read(&global_aql_session->stats.packets_completed),
-                     &stats->packets_completed);
-        atomic64_add(atomic64_read(&global_aql_session->stats.errors_total),
-                     &stats->errors_total);
-        atomic64_add(atomic64_read(&global_aql_session->stats.sessions_created),
-                     &stats->sessions_created);
-    }
-    mutex_unlock(&aql_pmu_mutex);
+	/* Add session-specific stats if available */
+	mutex_lock(&aql_pmu_mutex);
+	if (global_aql_session) {
+		atomic64_add(atomic64_read(&global_aql_session->stats.packets_submitted),
+			     &stats->packets_submitted);
+		atomic64_add(atomic64_read(&global_aql_session->stats.packets_completed),
+			     &stats->packets_completed);
+		atomic64_add(atomic64_read(&global_aql_session->stats.errors_total),
+			     &stats->errors_total);
+		atomic64_add(atomic64_read(&global_aql_session->stats.sessions_created),
+			     &stats->sessions_created);
+	}
+	mutex_unlock(&aql_pmu_mutex);
 }
 
 EXPORT_SYMBOL_GPL(aql_get_global_workqueue);

--- a/projects/perf-dkms/src/example_kfd_usage.c
+++ b/projects/perf-dkms/src/example_kfd_usage.c
@@ -17,35 +17,35 @@
  */
 static void example_basic_kfd_test(void)
 {
-    int ret;
-    struct kfd_test_result result;
+	int ret;
+	struct kfd_test_result result;
 
-    printk(KERN_INFO "Example: Testing KFD ioctl functionality\n");
+	printk(KERN_INFO "Example: Testing KFD ioctl functionality\n");
 
-    /* Run the KFD test */
-    ret = kfd_test_get_version();
+	/* Run the KFD test */
+	ret = kfd_test_get_version();
 
-    if (ret == 0) {
-        printk(KERN_INFO "Example: KFD test passed\n");
+	if (ret == 0) {
+		printk(KERN_INFO "Example: KFD test passed\n");
 
-        /* Get detailed results */
-        ret = kfd_test_get_result(&result);
-        if (ret == 0 && result.success) {
-            printk(KERN_INFO "Example: KFD Version: %u.%u\n",
-                   result.major_version, result.minor_version);
-        }
-    } else {
-        printk(KERN_ERR "Example: KFD test failed with error %d\n", ret);
+		/* Get detailed results */
+		ret = kfd_test_get_result(&result);
+		if (ret == 0 && result.success) {
+			printk(KERN_INFO "Example: KFD Version: %u.%u\n", result.major_version,
+			       result.minor_version);
+		}
+	} else {
+		printk(KERN_ERR "Example: KFD test failed with error %d\n", ret);
 
-        /* Get error details */
-        ret = kfd_test_get_result(&result);
-        if (ret == 0) {
-            printk(KERN_ERR "Example: Error: %s\n", result.error_msg);
-        }
-    }
+		/* Get error details */
+		ret = kfd_test_get_result(&result);
+		if (ret == 0) {
+			printk(KERN_ERR "Example: Error: %s\n", result.error_msg);
+		}
+	}
 
-    /* Print results to kernel log */
-    kfd_test_print_result();
+	/* Print results to kernel log */
+	kfd_test_print_result();
 }
 
 /*
@@ -53,37 +53,37 @@ static void example_basic_kfd_test(void)
  */
 static int example_conditional_kfd_functionality(void)
 {
-    struct kfd_test_result result;
-    int ret;
+	struct kfd_test_result result;
+	int ret;
 
-    /* Test if KFD is available */
-    ret = kfd_test_get_version();
-    if (ret != 0) {
-        printk(KERN_INFO "Example: KFD not available, using fallback functionality\n");
-        return -ENODEV;
-    }
+	/* Test if KFD is available */
+	ret = kfd_test_get_version();
+	if (ret != 0) {
+		printk(KERN_INFO "Example: KFD not available, using fallback functionality\n");
+		return -ENODEV;
+	}
 
-    /* Get the version information */
-    ret = kfd_test_get_result(&result);
-    if (ret != 0 || !result.success) {
-        printk(KERN_ERR "Example: Failed to get KFD test result\n");
-        return -EFAULT;
-    }
+	/* Get the version information */
+	ret = kfd_test_get_result(&result);
+	if (ret != 0 || !result.success) {
+		printk(KERN_ERR "Example: Failed to get KFD test result\n");
+		return -EFAULT;
+	}
 
-    /* Use KFD version to determine capabilities */
-    if (result.major_version >= 1) {
-        printk(KERN_INFO "Example: KFD v%u.%u supports modern features\n",
-               result.major_version, result.minor_version);
+	/* Use KFD version to determine capabilities */
+	if (result.major_version >= 1) {
+		printk(KERN_INFO "Example: KFD v%u.%u supports modern features\n",
+		       result.major_version, result.minor_version);
 
-        /* Enable advanced KFD-based functionality here */
-        return 1; /* Advanced mode */
-    } else {
-        printk(KERN_INFO "Example: KFD v%u.%u requires compatibility mode\n",
-               result.major_version, result.minor_version);
+		/* Enable advanced KFD-based functionality here */
+		return 1; /* Advanced mode */
+	} else {
+		printk(KERN_INFO "Example: KFD v%u.%u requires compatibility mode\n",
+		       result.major_version, result.minor_version);
 
-        /* Use compatibility mode */
-        return 0; /* Compatibility mode */
-    }
+		/* Use compatibility mode */
+		return 0; /* Compatibility mode */
+	}
 }
 
 /*
@@ -91,21 +91,21 @@ static int example_conditional_kfd_functionality(void)
  */
 static void example_pmu_kfd_integration(void)
 {
-    struct kfd_test_result kfd_result;
-    int ret;
+	struct kfd_test_result kfd_result;
+	int ret;
 
-    printk(KERN_INFO "Example: Integrating PMU with KFD capabilities\n");
+	printk(KERN_INFO "Example: Integrating PMU with KFD capabilities\n");
 
-    /* Test KFD availability for PMU integration */
-    ret = kfd_test_get_version();
-    kfd_test_get_result(&kfd_result);
+	/* Test KFD availability for PMU integration */
+	ret = kfd_test_get_version();
+	kfd_test_get_result(&kfd_result);
 
-    if (ret == 0 && kfd_result.success) {
-        printk(KERN_INFO "Example: KFD available for PMU integration\n");
-        printk(KERN_INFO "Example: Can use KFD v%u.%u for GPU performance monitoring\n",
-               kfd_result.major_version, kfd_result.minor_version);
+	if (ret == 0 && kfd_result.success) {
+		printk(KERN_INFO "Example: KFD available for PMU integration\n");
+		printk(KERN_INFO "Example: Can use KFD v%u.%u for GPU performance monitoring\n",
+		       kfd_result.major_version, kfd_result.minor_version);
 
-        /*
+		/*
          * Here you could implement:
          * - GPU counter programming via KFD
          * - AMD GPU performance event setup
@@ -113,16 +113,16 @@ static void example_pmu_kfd_integration(void)
          * - Integration with AQL packet generation
          */
 
-    } else {
-        printk(KERN_INFO "Example: KFD not available, using simulated counters only\n");
-        printk(KERN_INFO "Example: Error: %s\n",
-               kfd_result.error_msg[0] ? kfd_result.error_msg : "Unknown error");
+	} else {
+		printk(KERN_INFO "Example: KFD not available, using simulated counters only\n");
+		printk(KERN_INFO "Example: Error: %s\n",
+		       kfd_result.error_msg[0] ? kfd_result.error_msg : "Unknown error");
 
-        /*
+		/*
          * Fallback to timer-based simulation
          * This is what the current PMU stub already does
          */
-    }
+	}
 }
 
 /*
@@ -131,20 +131,20 @@ static void example_pmu_kfd_integration(void)
  */
 void run_kfd_integration_examples(void)
 {
-    printk(KERN_INFO "=== KFD Integration Examples ===\n");
+	printk(KERN_INFO "=== KFD Integration Examples ===\n");
 
-    example_basic_kfd_test();
+	example_basic_kfd_test();
 
-    printk(KERN_INFO "\n");
+	printk(KERN_INFO "\n");
 
-    int mode = example_conditional_kfd_functionality();
-    printk(KERN_INFO "Example: KFD functionality mode: %d\n", mode);
+	int mode = example_conditional_kfd_functionality();
+	printk(KERN_INFO "Example: KFD functionality mode: %d\n", mode);
 
-    printk(KERN_INFO "\n");
+	printk(KERN_INFO "\n");
 
-    example_pmu_kfd_integration();
+	example_pmu_kfd_integration();
 
-    printk(KERN_INFO "=== End KFD Integration Examples ===\n");
+	printk(KERN_INFO "=== End KFD Integration Examples ===\n");
 }
 
 /*
@@ -152,6 +152,6 @@ void run_kfd_integration_examples(void)
  */
 void cleanup_kfd_integration_examples(void)
 {
-    printk(KERN_INFO "Example: Cleaning up KFD integration examples\n");
-    /* Any cleanup code would go here */
+	printk(KERN_INFO "Example: Cleaning up KFD integration examples\n");
+	/* Any cleanup code would go here */
 }

--- a/projects/perf-dkms/src/kfd_test.c
+++ b/projects/perf-dkms/src/kfd_test.c
@@ -19,11 +19,10 @@
 struct kfd_process;
 
 /* External declarations for the exported KFD functions */
-extern long kfd_ioctl_get_version(struct file *filep, struct kfd_process *p,
-                                  void *data);
+extern long kfd_ioctl_get_version(struct file *filep, struct kfd_process *p, void *data);
 
 /* Global test result */
-static struct kfd_test_result kfd_result = {0};
+static struct kfd_test_result kfd_result = { 0 };
 
 /**
  * kfd_test_get_version - Test KFD ioctl get version call
@@ -35,70 +34,70 @@ static struct kfd_test_result kfd_result = {0};
  */
 int kfd_test_get_version(void)
 {
-    struct file *kfd_file = NULL;
-    struct kfd_ioctl_get_version_args version_args;
-    struct kfd_process *process;
-    long ret = 0;
+	struct file *kfd_file = NULL;
+	struct kfd_ioctl_get_version_args version_args;
+	struct kfd_process *process;
+	long ret = 0;
 
-    /* Clear previous results */
-    memset(&kfd_result, 0, sizeof(kfd_result));
-    memset(&version_args, 0, sizeof(version_args));
+	/* Clear previous results */
+	memset(&kfd_result, 0, sizeof(kfd_result));
+	memset(&version_args, 0, sizeof(version_args));
 
-    pmu_info("KFD Test: Opening /dev/kfd to get valid file and process\n");
+	pmu_info("KFD Test: Opening /dev/kfd to get valid file and process\n");
 
-    /* Open /dev/kfd which calls kfd_open() and sets up filep->private_data */
-    kfd_file = filp_open("/dev/kfd", O_RDWR, 0);
-    if (IS_ERR(kfd_file)) {
-        ret = PTR_ERR(kfd_file);
-        snprintf(kfd_result.error_msg, sizeof(kfd_result.error_msg),
-                "Failed to open /dev/kfd: error %ld", ret);
-        kfd_result.error_code = (int)ret;
-        pmu_err("KFD Test: %s\n", kfd_result.error_msg);
-        return ret;
-    }
+	/* Open /dev/kfd which calls kfd_open() and sets up filep->private_data */
+	kfd_file = filp_open("/dev/kfd", O_RDWR, 0);
+	if (IS_ERR(kfd_file)) {
+		ret = PTR_ERR(kfd_file);
+		snprintf(kfd_result.error_msg, sizeof(kfd_result.error_msg),
+			 "Failed to open /dev/kfd: error %ld", ret);
+		kfd_result.error_code = (int)ret;
+		pmu_err("KFD Test: %s\n", kfd_result.error_msg);
+		return ret;
+	}
 
-    pmu_info("KFD Test: Successfully opened /dev/kfd\n");
+	pmu_info("KFD Test: Successfully opened /dev/kfd\n");
 
-    /* Extract the kfd_process from private_data (set by kfd_open) */
-    process = kfd_file->private_data;
-    if (!process) {
-        ret = -EINVAL;
-        snprintf(kfd_result.error_msg, sizeof(kfd_result.error_msg),
-                "No kfd_process found in file private_data");
-        kfd_result.error_code = (int)ret;
-        pmu_err("KFD Test: %s\n", kfd_result.error_msg);
-        filp_close(kfd_file, NULL);
-        return ret;
-    }
+	/* Extract the kfd_process from private_data (set by kfd_open) */
+	process = kfd_file->private_data;
+	if (!process) {
+		ret = -EINVAL;
+		snprintf(kfd_result.error_msg, sizeof(kfd_result.error_msg),
+			 "No kfd_process found in file private_data");
+		kfd_result.error_code = (int)ret;
+		pmu_err("KFD Test: %s\n", kfd_result.error_msg);
+		filp_close(kfd_file, NULL);
+		return ret;
+	}
 
-    pmu_info("KFD Test: Found valid kfd_process, calling kfd_ioctl_get_version\n");
+	pmu_info("KFD Test: Found valid kfd_process, calling kfd_ioctl_get_version\n");
 
-    /* Now call kfd_ioctl_get_version with proper parameters */
-    ret = kfd_ioctl_get_version(kfd_file, process, &version_args);
+	/* Now call kfd_ioctl_get_version with proper parameters */
+	ret = kfd_ioctl_get_version(kfd_file, process, &version_args);
 
-    if (ret != 0) {
-        snprintf(kfd_result.error_msg, sizeof(kfd_result.error_msg),
-                "kfd_ioctl_get_version failed: error %ld", ret);
-        kfd_result.error_code = (int)ret;
-        pmu_err("KFD Test: %s\n", kfd_result.error_msg);
-        filp_close(kfd_file, NULL);
-        return ret;
-    }
+	if (ret != 0) {
+		snprintf(kfd_result.error_msg, sizeof(kfd_result.error_msg),
+			 "kfd_ioctl_get_version failed: error %ld", ret);
+		kfd_result.error_code = (int)ret;
+		pmu_err("KFD Test: %s\n", kfd_result.error_msg);
+		filp_close(kfd_file, NULL);
+		return ret;
+	}
 
-    /* Success - store the version information */
-    kfd_result.success = true;
-    kfd_result.major_version = version_args.major_version;
-    kfd_result.minor_version = version_args.minor_version;
-    kfd_result.error_code = 0;
+	/* Success - store the version information */
+	kfd_result.success = true;
+	kfd_result.major_version = version_args.major_version;
+	kfd_result.minor_version = version_args.minor_version;
+	kfd_result.error_code = 0;
 
-    pmu_info("KFD Test: SUCCESS! KFD Version: %u.%u\n",
-             kfd_result.major_version, kfd_result.minor_version);
+	pmu_info("KFD Test: SUCCESS! KFD Version: %u.%u\n", kfd_result.major_version,
+		 kfd_result.minor_version);
 
-    /* Clean up - this calls kfd_release which unrefs the process */
-    filp_close(kfd_file, NULL);
+	/* Clean up - this calls kfd_release which unrefs the process */
+	filp_close(kfd_file, NULL);
 
-    pmu_info("KFD Test: Test completed successfully\n");
-    return 0;
+	pmu_info("KFD Test: Test completed successfully\n");
+	return 0;
 }
 
 /**
@@ -109,11 +108,11 @@ int kfd_test_get_version(void)
  */
 int kfd_test_get_result(struct kfd_test_result *result)
 {
-    if (!result)
-        return -EINVAL;
+	if (!result)
+		return -EINVAL;
 
-    memcpy(result, &kfd_result, sizeof(struct kfd_test_result));
-    return 0;
+	memcpy(result, &kfd_result, sizeof(struct kfd_test_result));
+	return 0;
 }
 
 /**
@@ -121,11 +120,11 @@ int kfd_test_get_result(struct kfd_test_result *result)
  */
 void kfd_test_print_result(void)
 {
-    if (kfd_result.success) {
-        pmu_info("KFD Test Result: SUCCESS - Version %u.%u\n",
-                 kfd_result.major_version, kfd_result.minor_version);
-    } else {
-        pmu_info("KFD Test Result: FAILED - Error %d: %s\n",
-                 kfd_result.error_code, kfd_result.error_msg);
-    }
+	if (kfd_result.success) {
+		pmu_info("KFD Test Result: SUCCESS - Version %u.%u\n", kfd_result.major_version,
+			 kfd_result.minor_version);
+	} else {
+		pmu_info("KFD Test Result: FAILED - Error %d: %s\n", kfd_result.error_code,
+			 kfd_result.error_msg);
+	}
 }

--- a/projects/perf-dkms/src/kfd_test.h
+++ b/projects/perf-dkms/src/kfd_test.h
@@ -11,11 +11,11 @@
 
 /* KFD test result structure */
 struct kfd_test_result {
-    bool success;            /* True if test passed */
-    u32 major_version;       /* KFD major version (if successful) */
-    u32 minor_version;       /* KFD minor version (if successful) */
-    int error_code;          /* Error code (if failed) */
-    char error_msg[256];     /* Error message (if failed) */
+	bool success; /* True if test passed */
+	u32 major_version; /* KFD major version (if successful) */
+	u32 minor_version; /* KFD minor version (if successful) */
+	int error_code; /* Error code (if failed) */
+	char error_msg[256]; /* Error message (if failed) */
 };
 
 /* Function prototypes */

--- a/projects/perf-dkms/src/pmu_dimension.h
+++ b/projects/perf-dkms/src/pmu_dimension.h
@@ -47,16 +47,16 @@ typedef uint64_t u64;
  */
 
 /* Bit field layout constants */
-#define PMU_DIM_XCC_SHIFT       0
-#define PMU_DIM_XCC_MASK        0xFF
-#define PMU_DIM_SE_SHIFT        8
-#define PMU_DIM_SE_MASK         0xFF
-#define PMU_DIM_SA_SHIFT        16
-#define PMU_DIM_SA_MASK         0xFF
-#define PMU_DIM_WGP_SHIFT       24
-#define PMU_DIM_WGP_MASK        0xFF
-#define PMU_DIM_CU_SHIFT        32
-#define PMU_DIM_CU_MASK         0xFF
+#define PMU_DIM_XCC_SHIFT 0
+#define PMU_DIM_XCC_MASK 0xFF
+#define PMU_DIM_SE_SHIFT 8
+#define PMU_DIM_SE_MASK 0xFF
+#define PMU_DIM_SA_SHIFT 16
+#define PMU_DIM_SA_MASK 0xFF
+#define PMU_DIM_WGP_SHIFT 24
+#define PMU_DIM_WGP_MASK 0xFF
+#define PMU_DIM_CU_SHIFT 32
+#define PMU_DIM_CU_MASK 0xFF
 #define PMU_DIM_AGGREGATE_SHIFT 40
 
 /**
@@ -120,8 +120,7 @@ struct pmu_dimension_limits {
  * wgp=0,cu=0). If config1 is 0 (no dimensions specified), the driver uses
  * broadcast mode and aggregates across all instances.
  */
-static inline void pmu_extract_dimensions(u64 config1,
-					  struct pmu_dimension_coords *dims)
+static inline void pmu_extract_dimensions(u64 config1, struct pmu_dimension_coords *dims)
 {
 	dims->xcc = (config1 >> PMU_DIM_XCC_SHIFT) & PMU_DIM_XCC_MASK;
 	dims->se = (config1 >> PMU_DIM_SE_SHIFT) & PMU_DIM_SE_MASK;

--- a/projects/perf-dkms/src/pmu_events.c
+++ b/projects/perf-dkms/src/pmu_events.c
@@ -17,69 +17,69 @@
 /* Get event name from configuration */
 const char *amdgpu_pmu_get_event_name(u64 config)
 {
-    const counter_def_t *counter;
+	const counter_def_t *counter;
 
-    /* Config value is the counter_id */
-    counter = lookup_counter_by_id((counter_id_t)config);
-    if (counter) {
-        return counter->name;
-    }
+	/* Config value is the counter_id */
+	counter = lookup_counter_by_id((counter_id_t)config);
+	if (counter) {
+		return counter->name;
+	}
 
-    return "unknown";
+	return "unknown";
 }
 
 /* Get event description from configuration */
 const char *amdgpu_pmu_get_event_description(u64 config)
 {
-    const counter_def_t *counter;
+	const counter_def_t *counter;
 
-    /* Config value is the counter_id */
-    counter = lookup_counter_by_id((counter_id_t)config);
-    if (counter) {
-        /* Generate description from counter name and hardware block */
-        static char description[128];
-        const char *block_name;
+	/* Config value is the counter_id */
+	counter = lookup_counter_by_id((counter_id_t)config);
+	if (counter) {
+		/* Generate description from counter name and hardware block */
+		static char description[128];
+		const char *block_name;
 
-        switch (counter->hw_block) {
-        case HW_IP_BLOCK_GL2C:
-            block_name = "GL2C (L2 Cache)";
-            break;
-        case HW_IP_BLOCK_SQ:
-            block_name = "SQ (Shader Queue)";
-            break;
-        case HW_IP_BLOCK_TA:
-            block_name = "TA (Texture Addressing)";
-            break;
-        case HW_IP_BLOCK_GRBM:
-            block_name = "GRBM (Graphics Register Bus Manager)";
-            break;
-        default:
-            block_name = "Unknown";
-            break;
-        }
+		switch (counter->hw_block) {
+		case HW_IP_BLOCK_GL2C:
+			block_name = "GL2C (L2 Cache)";
+			break;
+		case HW_IP_BLOCK_SQ:
+			block_name = "SQ (Shader Queue)";
+			break;
+		case HW_IP_BLOCK_TA:
+			block_name = "TA (Texture Addressing)";
+			break;
+		case HW_IP_BLOCK_GRBM:
+			block_name = "GRBM (Graphics Register Bus Manager)";
+			break;
+		default:
+			block_name = "Unknown";
+			break;
+		}
 
-        snprintf(description, sizeof(description), "%s - %s counter",
-                 counter->name, block_name);
-        return description;
-    }
+		snprintf(description, sizeof(description), "%s - %s counter", counter->name,
+			 block_name);
+		return description;
+	}
 
-    return "Unknown event";
+	return "Unknown event";
 }
 
 /* Validate event configuration */
 bool amdgpu_pmu_is_valid_event(u64 config)
 {
-    /* Check if the counter ID exists in the registry */
-    return lookup_counter_by_id((counter_id_t)config) != NULL;
+	/* Check if the counter ID exists in the registry */
+	return lookup_counter_by_id((counter_id_t)config) != NULL;
 }
 
 /* Get total number of available events */
 size_t amdgpu_pmu_get_event_count(void)
 {
-    return get_counter_count();
+	return get_counter_count();
 }
 
-// TODO: Remove legacy stubs. 
+// TODO: Remove legacy stubs.
 /*
  * NOTE: Counter values are now managed by the AQL hardware layer.
  * The following functions are legacy stubs kept for compatibility.
@@ -89,32 +89,32 @@ size_t amdgpu_pmu_get_event_count(void)
 /* Get counter value based on event type */
 u64 amdgpu_pmu_get_counter_value(struct amdgpu_pmu *pmu, u64 config)
 {
-    /* Counter values are now read from hardware via AQL */
-    pmu_debug("Legacy counter read for config 0x%llx - values managed by AQL\n", config);
-    return 0;
+	/* Counter values are now read from hardware via AQL */
+	pmu_debug("Legacy counter read for config 0x%llx - values managed by AQL\n", config);
+	return 0;
 }
 
 /* Update counter value based on event type */
 void amdgpu_pmu_update_counter(struct amdgpu_pmu *pmu, u64 config, s64 delta)
 {
-    /* Counter updates are now handled by hardware via AQL */
-    pmu_debug("Legacy counter update for config 0x%llx - managed by AQL\n", config);
+	/* Counter updates are now handled by hardware via AQL */
+	pmu_debug("Legacy counter update for config 0x%llx - managed by AQL\n", config);
 }
 
 /* Reset all counters */
 void amdgpu_pmu_reset_counters(struct amdgpu_pmu *pmu)
 {
-    /* Counter resets are now handled by hardware via AQL */
-    pmu_debug("Legacy counter reset - managed by AQL\n");
+	/* Counter resets are now handled by hardware via AQL */
+	pmu_debug("Legacy counter reset - managed by AQL\n");
 }
 
 /* Print event statistics (for debugging) */
 void amdgpu_pmu_print_event_stats(struct amdgpu_pmu *pmu)
 {
-    pmu_info("Event Statistics:\n");
-    pmu_info("  Total Events: %lld\n", atomic64_read(&pmu->total_events));
-    pmu_info("  Hardware Events: %lld\n", atomic64_read(&pmu->hardware_events));
-    pmu_info("  Simulation Events: %lld\n", atomic64_read(&pmu->simulation_events));
+	pmu_info("Event Statistics:\n");
+	pmu_info("  Total Events: %lld\n", atomic64_read(&pmu->total_events));
+	pmu_info("  Hardware Events: %lld\n", atomic64_read(&pmu->hardware_events));
+	pmu_info("  Simulation Events: %lld\n", atomic64_read(&pmu->simulation_events));
 }
 
 /* Export symbols if needed by other modules */

--- a/projects/perf-dkms/src/pmu_main.c
+++ b/projects/perf-dkms/src/pmu_main.c
@@ -61,15 +61,14 @@ static void amdgpu_pmu_read(struct perf_event *event);
  *
  * This allows perf to parse: perf stat -e amdgpu_pmu/event,se=2/
  */
-#define PMU_FORMAT_ATTR(_name, _format) \
-static ssize_t __pmu_format_##_name##_show(struct device *dev, \
-					    struct device_attribute *attr, \
-					    char *page) \
-{ \
-	return sprintf(page, _format "\n"); \
-} \
-static struct device_attribute format_attr_##_name = \
-	__ATTR(_name, 0444, __pmu_format_##_name##_show, NULL)
+#define PMU_FORMAT_ATTR(_name, _format)                                                       \
+	static ssize_t __pmu_format_##_name##_show(struct device *dev,                        \
+						   struct device_attribute *attr, char *page) \
+	{                                                                                     \
+		return sprintf(page, _format "\n");                                           \
+	}                                                                                     \
+	static struct device_attribute format_attr_##_name =                                  \
+		__ATTR(_name, 0444, __pmu_format_##_name##_show, NULL)
 
 /*
  * Format Attributes - Define how perf encodes event parameters
@@ -85,44 +84,36 @@ static struct device_attribute format_attr_##_name = \
  *   Bits 32-39 : CU index
  *   Bit  40    : Aggregate flag
  */
-PMU_FORMAT_ATTR(config, "config:0-63");      /* Counter ID */
-PMU_FORMAT_ATTR(config1, "config1:0-63");    /* Raw dimension encoding */
-PMU_FORMAT_ATTR(xcc, "config1:0-7");         /* XCC index */
-PMU_FORMAT_ATTR(se, "config1:8-15");         /* SE index */
-PMU_FORMAT_ATTR(sa, "config1:16-23");        /* SA index */
-PMU_FORMAT_ATTR(wgp, "config1:24-31");       /* WGP index */
-PMU_FORMAT_ATTR(cu, "config1:32-39");        /* CU index */
-PMU_FORMAT_ATTR(aggregate, "config1:40");    /* Aggregate across dimensions */
+PMU_FORMAT_ATTR(config, "config:0-63"); /* Counter ID */
+PMU_FORMAT_ATTR(config1, "config1:0-63"); /* Raw dimension encoding */
+PMU_FORMAT_ATTR(xcc, "config1:0-7"); /* XCC index */
+PMU_FORMAT_ATTR(se, "config1:8-15"); /* SE index */
+PMU_FORMAT_ATTR(sa, "config1:16-23"); /* SA index */
+PMU_FORMAT_ATTR(wgp, "config1:24-31"); /* WGP index */
+PMU_FORMAT_ATTR(cu, "config1:32-39"); /* CU index */
+PMU_FORMAT_ATTR(aggregate, "config1:40"); /* Aggregate across dimensions */
 
 static struct attribute *amdgpu_pmu_format_attrs[] = {
-    &format_attr_config.attr,
-    &format_attr_config1.attr,
-    &format_attr_xcc.attr,
-    &format_attr_se.attr,
-    &format_attr_sa.attr,
-    &format_attr_wgp.attr,
-    &format_attr_cu.attr,
-    &format_attr_aggregate.attr,
-    NULL,
+	&format_attr_config.attr, &format_attr_config1.attr,   &format_attr_xcc.attr,
+	&format_attr_se.attr,	  &format_attr_sa.attr,	       &format_attr_wgp.attr,
+	&format_attr_cu.attr,	  &format_attr_aggregate.attr, NULL,
 };
 
 static struct attribute_group amdgpu_pmu_format_group = {
-    .name = "format",
-    .attrs = amdgpu_pmu_format_attrs,
+	.name = "format",
+	.attrs = amdgpu_pmu_format_attrs,
 };
 
 /* Event attributes - dynamically generated from counter_registry */
 struct pmu_event_attr {
-    struct device_attribute attr;
-    u64 id;
+	struct device_attribute attr;
+	u64 id;
 };
 
-static ssize_t amdgpu_pmu_event_show(struct device *dev,
-                                   struct device_attribute *attr,
-                                   char *buf)
+static ssize_t amdgpu_pmu_event_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
-    struct pmu_event_attr *pmu_attr = container_of(attr, struct pmu_event_attr, attr);
-    return sprintf(buf, "config=0x%llx\n", pmu_attr->id);
+	struct pmu_event_attr *pmu_attr = container_of(attr, struct pmu_event_attr, attr);
+	return sprintf(buf, "config=0x%llx\n", pmu_attr->id);
 }
 
 /* Dynamic event attributes - allocated during init */
@@ -131,48 +122,46 @@ static struct attribute **amdgpu_pmu_event_attrs = NULL;
 static size_t amdgpu_pmu_event_count = 0;
 
 static struct attribute_group amdgpu_pmu_events_group = {
-    .name = "events",
-    .attrs = NULL,  /* Set during init */
+	.name = "events",
+	.attrs = NULL, /* Set during init */
 };
 
 /* CPU mask attribute - shows which CPUs (GPUs) are available */
-static ssize_t cpumask_show(struct device *dev,
-                             struct device_attribute *attr,
-                             char *buf)
+static ssize_t cpumask_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
-    int num_gpus = aql_pmu_get_gpu_count();
-    cpumask_var_t mask;
-    ssize_t ret;
-    int i;
+	int num_gpus = aql_pmu_get_gpu_count();
+	cpumask_var_t mask;
+	ssize_t ret;
+	int i;
 
-    if (!zalloc_cpumask_var(&mask, GFP_KERNEL))
-        return -ENOMEM;
+	if (!zalloc_cpumask_var(&mask, GFP_KERNEL))
+		return -ENOMEM;
 
-    /* Set bits 0 to num_gpus-1 */
-    for (i = 0; i < num_gpus && i < nr_cpu_ids; i++)
-        cpumask_set_cpu(i, mask);
+	/* Set bits 0 to num_gpus-1 */
+	for (i = 0; i < num_gpus && i < nr_cpu_ids; i++)
+		cpumask_set_cpu(i, mask);
 
-    ret = cpumap_print_to_pagebuf(true, buf, mask);
-    free_cpumask_var(mask);
-    return ret;
+	ret = cpumap_print_to_pagebuf(true, buf, mask);
+	free_cpumask_var(mask);
+	return ret;
 }
 
 static DEVICE_ATTR_RO(cpumask);
 
 static struct attribute *amdgpu_pmu_cpumask_attrs[] = {
-    &dev_attr_cpumask.attr,
-    NULL,
+	&dev_attr_cpumask.attr,
+	NULL,
 };
 
 static struct attribute_group amdgpu_pmu_cpumask_group = {
-    .attrs = amdgpu_pmu_cpumask_attrs,
+	.attrs = amdgpu_pmu_cpumask_attrs,
 };
 
 static const struct attribute_group *amdgpu_pmu_attr_groups[] = {
-    &amdgpu_pmu_format_group,
-    &amdgpu_pmu_events_group,
-    &amdgpu_pmu_cpumask_group,
-    NULL,
+	&amdgpu_pmu_format_group,
+	&amdgpu_pmu_events_group,
+	&amdgpu_pmu_cpumask_group,
+	NULL,
 };
 
 /**
@@ -183,143 +172,147 @@ static const struct attribute_group *amdgpu_pmu_attr_groups[] = {
  * Returns: Number of measurements successfully scheduled for polling
  */
 static int amdgpu_pmu_poll_measurements(struct aql_perf_session *session,
-                                        struct workqueue_struct *wq)
+					struct workqueue_struct *wq)
 {
-    struct aql_measurement *measurement, *tmp;
-    unsigned long flags;
-    int polled_count = 0;
+	struct aql_measurement *measurement, *tmp;
+	unsigned long flags;
+	int polled_count = 0;
 
-    if (!session || !wq)
-        return 0;
+	if (!session || !wq)
+		return 0;
 
-    /* Iterate through active measurements and trigger background reads */
-    spin_lock_irqsave(&session->measurement_lock, flags);
+	/* Iterate through active measurements and trigger background reads */
+	spin_lock_irqsave(&session->measurement_lock, flags);
 
-    list_for_each_entry_safe(measurement, tmp, &session->active_measurements, list) {
-        if (measurement->state == MEASUREMENT_ACTIVE) {
-            /* Trigger background read to refresh cache on global workqueue */
-            struct aql_work_item *work_item = aql_create_work_item(measurement, AQL_WORK_READ);
-            if (!IS_ERR(work_item)) {
-                if (queue_work(wq, &work_item->work)) {
-                    polled_count++;
-                    pmu_debug("Timer: Scheduled read for GPU %u\n", measurement->gpu_id);
-                    pmu_info("Timer: ===== SCHEDULED READ for GPU %u =====\n", measurement->gpu_id);
-                } else {
-                    /* Work already queued - release our reference and free work_item */
-                    aql_measurement_put(measurement);
-                    kfree(work_item);
-                }
-            }
-        }
-    }
+	list_for_each_entry_safe(measurement, tmp, &session->active_measurements, list)
+	{
+		if (measurement->state == MEASUREMENT_ACTIVE) {
+			/* Trigger background read to refresh cache on global workqueue */
+			struct aql_work_item *work_item =
+				aql_create_work_item(measurement, AQL_WORK_READ);
+			if (!IS_ERR(work_item)) {
+				if (queue_work(wq, &work_item->work)) {
+					polled_count++;
+					pmu_debug("Timer: Scheduled read for GPU %u\n",
+						  measurement->gpu_id);
+					pmu_info("Timer: ===== SCHEDULED READ for GPU %u =====\n",
+						 measurement->gpu_id);
+				} else {
+					/* Work already queued - release our reference and free work_item */
+					aql_measurement_put(measurement);
+					kfree(work_item);
+				}
+			}
+		}
+	}
 
-    spin_unlock_irqrestore(&session->measurement_lock, flags);
+	spin_unlock_irqrestore(&session->measurement_lock, flags);
 
-    pmu_debug("Timer: Polled %d active measurements\n", polled_count);
-    return polled_count;
+	pmu_debug("Timer: Polled %d active measurements\n", polled_count);
+	return polled_count;
 }
 
 /* Timer handler - Periodic polling for background counter refresh */
 enum hrtimer_restart amdgpu_pmu_timer_handler(struct hrtimer *timer)
 {
-    struct amdgpu_pmu *pmu = container_of(timer, struct amdgpu_pmu, timer);
-    struct aql_perf_session *session;
-    struct workqueue_struct *wq;
-    int count;
+	struct amdgpu_pmu *pmu = container_of(timer, struct amdgpu_pmu, timer);
+	struct aql_perf_session *session;
+	struct workqueue_struct *wq;
+	int count;
 
-    pmu_debug("Timer handler fired - polling active measurements\n");
+	pmu_debug("Timer handler fired - polling active measurements\n");
 
-    /* Get global workqueue */
-    wq = aql_get_global_workqueue();
-    if (!wq) {
-        pmu_debug("Timer: Global workqueue not available\n");
-        goto reschedule;
-    }
+	/* Get global workqueue */
+	wq = aql_get_global_workqueue();
+	if (!wq) {
+		pmu_debug("Timer: Global workqueue not available\n");
+		goto reschedule;
+	}
 
-    /* Get AQL session to poll measurements */
-    session = aql_pmu_get_session();
-    if (!session) {
-        pmu_debug("Timer: No AQL session available\n");
-        goto reschedule;
-    }
+	/* Get AQL session to poll measurements */
+	session = aql_pmu_get_session();
+	if (!session) {
+		pmu_debug("Timer: No AQL session available\n");
+		goto reschedule;
+	}
 
-    /* Poll all active measurements */
-    count = amdgpu_pmu_poll_measurements(session, wq);
-    pmu_debug("Timer: Updated %d active measurements\n", count);
+	/* Poll all active measurements */
+	count = amdgpu_pmu_poll_measurements(session, wq);
+	pmu_debug("Timer: Updated %d active measurements\n", count);
 
-    aql_pmu_put_session(session);
+	aql_pmu_put_session(session);
 
 reschedule:
-    /* Reschedule timer for next period */
-    hrtimer_forward_now(timer, pmu->timer_period);
-    return HRTIMER_RESTART;
+	/* Reschedule timer for next period */
+	hrtimer_forward_now(timer, pmu->timer_period);
+	return HRTIMER_RESTART;
 }
 
 /* Start background polling timer - called when first measurement becomes active */
 void amdgpu_pmu_start_timer(void)
 {
-    struct amdgpu_pmu *pmu = amdgpu_pmu_instance;
+	struct amdgpu_pmu *pmu = amdgpu_pmu_instance;
 
-    pmu_info("amdgpu_pmu_start_timer() called\n");
+	pmu_info("amdgpu_pmu_start_timer() called\n");
 
-    if (!pmu) {
-        pmu_err("Cannot start timer: PMU not initialized\n");
-        return;
-    }
+	if (!pmu) {
+		pmu_err("Cannot start timer: PMU not initialized\n");
+		return;
+	}
 
-    /* Start timer if not already running */
-    if (!hrtimer_active(&pmu->timer)) {
-        hrtimer_start(&pmu->timer, pmu->timer_period, HRTIMER_MODE_REL);
-        pmu_info("Started background polling timer (period=%d ms)\n", timer_period_ms);
-    } else {
-        pmu_info("Timer already active, not starting again\n");
-    }
+	/* Start timer if not already running */
+	if (!hrtimer_active(&pmu->timer)) {
+		hrtimer_start(&pmu->timer, pmu->timer_period, HRTIMER_MODE_REL);
+		pmu_info("Started background polling timer (period=%d ms)\n", timer_period_ms);
+	} else {
+		pmu_info("Timer already active, not starting again\n");
+	}
 }
 EXPORT_SYMBOL(amdgpu_pmu_start_timer);
 
 /* Stop background polling timer - called when measurement stops */
 void amdgpu_pmu_stop_timer_if_idle(void)
 {
-    struct amdgpu_pmu *pmu = amdgpu_pmu_instance;
+	struct amdgpu_pmu *pmu = amdgpu_pmu_instance;
 
-    pmu_info("amdgpu_pmu_stop_timer_if_idle() called\n");
+	pmu_info("amdgpu_pmu_stop_timer_if_idle() called\n");
 
-    if (!pmu) {
-        pmu_err("Cannot stop timer: PMU not initialized\n");
-        return;
-    }
+	if (!pmu) {
+		pmu_err("Cannot stop timer: PMU not initialized\n");
+		return;
+	}
 
-    /* Just cancel the timer unconditionally.
+	/* Just cancel the timer unconditionally.
      * This is safe to call from atomic context (hrtimer_cancel handles it).
      * Timer will be restarted when next measurement becomes active. */
-    if (hrtimer_active(&pmu->timer)) {
-        hrtimer_cancel(&pmu->timer);
-        pmu_info("Stopped background polling timer\n");
-    }
+	if (hrtimer_active(&pmu->timer)) {
+		hrtimer_cancel(&pmu->timer);
+		pmu_info("Stopped background polling timer\n");
+	}
 }
 EXPORT_SYMBOL(amdgpu_pmu_stop_timer_if_idle);
 
 /* Find free event slot */
 int amdgpu_pmu_get_event_idx(struct amdgpu_pmu *pmu)
 {
-    int idx;
+	int idx;
 
-    idx = find_first_zero_bit(pmu->used_mask, AMDGPU_PMU_MAX_EVENTS);
-    if (idx == AMDGPU_PMU_MAX_EVENTS)
-        return -EAGAIN;
+	idx = find_first_zero_bit(pmu->used_mask, AMDGPU_PMU_MAX_EVENTS);
+	if (idx == AMDGPU_PMU_MAX_EVENTS)
+		return -EAGAIN;
 
-    set_bit(idx, pmu->used_mask);
-    return idx;
+	set_bit(idx, pmu->used_mask);
+	return idx;
 }
 
 /* Free event slot */
 void amdgpu_pmu_free_event_idx(struct amdgpu_pmu *pmu, int idx)
 {
-    if (idx >= 0 && idx < AMDGPU_PMU_MAX_EVENTS) {
-        clear_bit(idx, pmu->used_mask);
-        pmu->events[idx].event = NULL;
-        pmu->events[idx].active = false;
-    }
+	if (idx >= 0 && idx < AMDGPU_PMU_MAX_EVENTS) {
+		clear_bit(idx, pmu->used_mask);
+		pmu->events[idx].event = NULL;
+		pmu->events[idx].active = false;
+	}
 }
 
 /**
@@ -331,598 +324,601 @@ void amdgpu_pmu_free_event_idx(struct amdgpu_pmu *pmu, int idx)
  */
 static int get_gpu_dimension_limits(uint32_t gpu_id, struct pmu_dimension_limits *limits)
 {
-    struct aql_perf_session *session;
-    arch_t *arch;
-    uint32_t gpu_index;
-    int ret = 0;
+	struct aql_perf_session *session;
+	arch_t *arch;
+	uint32_t gpu_index;
+	int ret = 0;
 
-    if (!limits)
-        return -EINVAL;
+	if (!limits)
+		return -EINVAL;
 
-    session = aql_pmu_get_session();
-    if (!session) {
-        pmu_err("Cannot get dimension limits: no AQL session\n");
-        return -ENODEV;
-    }
+	session = aql_pmu_get_session();
+	if (!session) {
+		pmu_err("Cannot get dimension limits: no AQL session\n");
+		return -ENODEV;
+	}
 
-    /* Find GPU index from GPU ID */
-    for (gpu_index = 0; gpu_index < session->num_gpus; gpu_index++) {
-        if (session->gpu_ids[gpu_index] == gpu_id)
-            break;
-    }
+	/* Find GPU index from GPU ID */
+	for (gpu_index = 0; gpu_index < session->num_gpus; gpu_index++) {
+		if (session->gpu_ids[gpu_index] == gpu_id)
+			break;
+	}
 
-    if (gpu_index >= session->num_gpus) {
-        pmu_err("GPU %u not found in session\n", gpu_id);
-        ret = -ENODEV;
-        goto out;
-    }
+	if (gpu_index >= session->num_gpus) {
+		pmu_err("GPU %u not found in session\n", gpu_id);
+		ret = -ENODEV;
+		goto out;
+	}
 
-    /* Get architecture for this specific GPU */
-    if (!session->archs || !session->archs[gpu_index]) {
-        pmu_err("No architecture information for GPU %u\n", gpu_id);
-        ret = -ENODEV;
-        goto out;
-    }
+	/* Get architecture for this specific GPU */
+	if (!session->archs || !session->archs[gpu_index]) {
+		pmu_err("No architecture information for GPU %u\n", gpu_id);
+		ret = -ENODEV;
+		goto out;
+	}
 
-    arch = session->archs[gpu_index];
+	arch = session->archs[gpu_index];
 
-    /* Populate dimension limits from this GPU's architecture */
-    limits->max_xcc = (arch->num_xcc > 0) ? arch->num_xcc - 1 : 0;
-    limits->max_se = (arch->num_se > 0) ? arch->num_se - 1 : 0;
-    limits->max_sa = (arch->num_sa > 0) ? arch->num_sa - 1 : 0;
-    limits->max_wgp = (arch->num_wgp_per_sa > 0) ? arch->num_wgp_per_sa - 1 : 0;
-    limits->max_cu = (arch->num_cu > 0) ? arch->num_cu - 1 : 0;
+	/* Populate dimension limits from this GPU's architecture */
+	limits->max_xcc = (arch->num_xcc > 0) ? arch->num_xcc - 1 : 0;
+	limits->max_se = (arch->num_se > 0) ? arch->num_se - 1 : 0;
+	limits->max_sa = (arch->num_sa > 0) ? arch->num_sa - 1 : 0;
+	limits->max_wgp = (arch->num_wgp_per_sa > 0) ? arch->num_wgp_per_sa - 1 : 0;
+	limits->max_cu = (arch->num_cu > 0) ? arch->num_cu - 1 : 0;
 
-    pmu_debug("GPU %u dimension limits: XCC=0-%u, SE=0-%u, SA=0-%u, WGP=0-%u, CU=0-%u\n",
-              gpu_id, limits->max_xcc, limits->max_se, limits->max_sa,
-              limits->max_wgp, limits->max_cu);
+	pmu_debug("GPU %u dimension limits: XCC=0-%u, SE=0-%u, SA=0-%u, WGP=0-%u, CU=0-%u\n",
+		  gpu_id, limits->max_xcc, limits->max_se, limits->max_sa, limits->max_wgp,
+		  limits->max_cu);
 
 out:
-    aql_pmu_put_session(session);
-    return ret;
+	aql_pmu_put_session(session);
+	return ret;
 }
 
 /* PMU callback: Initialize event */
 static int amdgpu_pmu_event_init(struct perf_event *event)
 {
-    struct amdgpu_pmu *pmu = amdgpu_pmu_instance;
-    struct pmu_dimension_coords dims = {0};
-    const counter_def_t *counter;
-    u64 config = event->attr.config;
-    u64 config1 = event->attr.config1;
-    int ret;
+	struct amdgpu_pmu *pmu = amdgpu_pmu_instance;
+	struct pmu_dimension_coords dims = { 0 };
+	const counter_def_t *counter;
+	u64 config = event->attr.config;
+	u64 config1 = event->attr.config1;
+	int ret;
 
-    pmu_debug("event_init: config=0x%llx config1=0x%llx\n", config, config1);
+	pmu_debug("event_init: config=0x%llx config1=0x%llx\n", config, config1);
 
-    /* Check if event is for our PMU */
-    if (event->attr.type != event->pmu->type)
-        return -ENOENT;
+	/* Check if event is for our PMU */
+	if (event->attr.type != event->pmu->type)
+		return -ENOENT;
 
-    /* Check if event configuration is supported */
-    if (!amdgpu_pmu_is_valid_event(config)) {
-        pmu_err("Unsupported event config: 0x%llx\n", config);
-        return -EINVAL;
-    }
+	/* Check if event configuration is supported */
+	if (!amdgpu_pmu_is_valid_event(config)) {
+		pmu_err("Unsupported event config: 0x%llx\n", config);
+		return -EINVAL;
+	}
 
-    /* We don't support sampling */
-    if (is_sampling_event(event)) {
-        pmu_err("Sampling events not supported\n");
-        return -EOPNOTSUPP;
-    }
+	/* We don't support sampling */
+	if (is_sampling_event(event)) {
+		pmu_err("Sampling events not supported\n");
+		return -EOPNOTSUPP;
+	}
 
-    /* GPU PMU doesn't support inherit (GPU counters aren't per-process) */
-    if (event->attr.inherit) {
-        pmu_debug("Disabling inherit flag - GPU counters can't inherit to children\n");
-        event->attr.inherit = 0;
-    }
+	/* GPU PMU doesn't support inherit (GPU counters aren't per-process) */
+	if (event->attr.inherit) {
+		pmu_debug("Disabling inherit flag - GPU counters can't inherit to children\n");
+		event->attr.inherit = 0;
+	}
 
-    /* Require explicit CPU specification to map to GPU.
+	/* Require explicit CPU specification to map to GPU.
      * Users must use perf -C <cpu> where CPU number maps to GPU ID.
      * Example: perf stat -C 0 -e amdgpu_pmu/sq_waves/ (monitors GPU 0)
      *          perf stat -C 1 -e amdgpu_pmu/sq_waves/ (monitors GPU 1) */
-    if (event->cpu < 0) {
-        pmu_err("GPU PMU requires explicit CPU with -C flag (CPU maps to GPU ID)\n");
-        pmu_err("Example: perf stat -C 0 -e amdgpu_pmu/event/ (for GPU 0)\n");
-        return -EINVAL;
-    }
+	if (event->cpu < 0) {
+		pmu_err("GPU PMU requires explicit CPU with -C flag (CPU maps to GPU ID)\n");
+		pmu_err("Example: perf stat -C 0 -e amdgpu_pmu/event/ (for GPU 0)\n");
+		return -EINVAL;
+	}
 
-    /* Get actual GPU device ID for this event's CPU affinity */
-    uint32_t gpu_id = aql_pmu_get_gpu_id_for_event(event);
-    if (gpu_id == U32_MAX) {
-        pmu_err("Failed to map CPU %d to GPU\n", event->cpu);
-        return -ENODEV;
-    }
-    pmu_debug("Mapped CPU %d to GPU %u\n", event->cpu, gpu_id);
+	/* Get actual GPU device ID for this event's CPU affinity */
+	uint32_t gpu_id = aql_pmu_get_gpu_id_for_event(event);
+	if (gpu_id == U32_MAX) {
+		pmu_err("Failed to map CPU %d to GPU\n", event->cpu);
+		return -ENODEV;
+	}
+	pmu_debug("Mapped CPU %d to GPU %u\n", event->cpu, gpu_id);
 
-    /* Store GPU ID for later use (note: this is actual GPU device ID, not index) */
-    event->hw.idx = gpu_id;
+	/* Store GPU ID for later use (note: this is actual GPU device ID, not index) */
+	event->hw.idx = gpu_id;
 
-    /* Extract and validate dimensions from config1 if specified */
-    if (config1 != 0) {
-        struct pmu_dimension_limits gpu_limits;
+	/* Extract and validate dimensions from config1 if specified */
+	if (config1 != 0) {
+		struct pmu_dimension_limits gpu_limits;
 
-        pmu_extract_dimensions(config1, &dims);
-        pmu_debug("Extracted dimensions: xcc=%u se=%u sa=%u wgp=%u cu=%u agg=%d valid=%d\n",
-                  dims.xcc, dims.se, dims.sa, dims.wgp, dims.cu,
-                  dims.aggregate, dims.valid);
+		pmu_extract_dimensions(config1, &dims);
+		pmu_debug("Extracted dimensions: xcc=%u se=%u sa=%u wgp=%u cu=%u agg=%d valid=%d\n",
+			  dims.xcc, dims.se, dims.sa, dims.wgp, dims.cu, dims.aggregate,
+			  dims.valid);
 
-        /* Get dimension limits for the specific GPU this event targets */
-        ret = get_gpu_dimension_limits(gpu_id, &gpu_limits);
-        if (ret != 0) {
-            pmu_err("Failed to get dimension limits for GPU %u: %d\n", gpu_id, ret);
-            return ret;
-        }
+		/* Get dimension limits for the specific GPU this event targets */
+		ret = get_gpu_dimension_limits(gpu_id, &gpu_limits);
+		if (ret != 0) {
+			pmu_err("Failed to get dimension limits for GPU %u: %d\n", gpu_id, ret);
+			return ret;
+		}
 
-        /* Validate dimensions against this GPU's hardware limits */
-        if (!pmu_validate_dimensions(&dims, &gpu_limits)) {
-            pmu_err("Dimension out of range for GPU %u: xcc=%u se=%u sa=%u wgp=%u cu=%u (max: %u/%u/%u/%u/%u)\n",
-                    gpu_id, dims.xcc, dims.se, dims.sa, dims.wgp, dims.cu,
-                    gpu_limits.max_xcc, gpu_limits.max_se,
-                    gpu_limits.max_sa, gpu_limits.max_wgp,
-                    gpu_limits.max_cu);
-            return -EINVAL;
-        }
-        pmu_debug("Dimension validation passed\n");
+		/* Validate dimensions against this GPU's hardware limits */
+		if (!pmu_validate_dimensions(&dims, &gpu_limits)) {
+			pmu_err("Dimension out of range for GPU %u: xcc=%u se=%u sa=%u wgp=%u cu=%u (max: %u/%u/%u/%u/%u)\n",
+				gpu_id, dims.xcc, dims.se, dims.sa, dims.wgp, dims.cu,
+				gpu_limits.max_xcc, gpu_limits.max_se, gpu_limits.max_sa,
+				gpu_limits.max_wgp, gpu_limits.max_cu);
+			return -EINVAL;
+		}
+		pmu_debug("Dimension validation passed\n");
 
-        /* Get counter definition and validate it supports requested dimensions */
-        pmu_debug("Looking up counter definition for config=0x%llx\n", config);
-        counter = lookup_counter_by_id((counter_id_t)config);
-        pmu_debug("lookup_counter_by_id returned %p\n", counter);
-        if (counter) {
-            ret = pmu_validate_counter_dimensions(counter, &dims);
-            if (ret != 0) {
-                pmu_err("Counter '%s' does not support requested dimensions "
-                        "(supported: 0x%x, requested: xcc=%u se=%u sa=%u wgp=%u cu=%u)\n",
-                        counter->name, counter->supported_dimensions,
-                        dims.xcc, dims.se, dims.sa, dims.wgp, dims.cu);
-                return ret;
-            }
-            pmu_debug("Counter dimension validation passed\n");
-        }
-    }
+		/* Get counter definition and validate it supports requested dimensions */
+		pmu_debug("Looking up counter definition for config=0x%llx\n", config);
+		counter = lookup_counter_by_id((counter_id_t)config);
+		pmu_debug("lookup_counter_by_id returned %p\n", counter);
+		if (counter) {
+			ret = pmu_validate_counter_dimensions(counter, &dims);
+			if (ret != 0) {
+				pmu_err("Counter '%s' does not support requested dimensions "
+					"(supported: 0x%x, requested: xcc=%u se=%u sa=%u wgp=%u cu=%u)\n",
+					counter->name, counter->supported_dimensions, dims.xcc,
+					dims.se, dims.sa, dims.wgp, dims.cu);
+				return ret;
+			}
+			pmu_debug("Counter dimension validation passed\n");
+		}
+	}
 
-    /* Initialize AQL hardware counter */
-    pmu_debug("About to call aql_pmu_event_init\n");
-    ret = aql_pmu_event_init(event, dims.valid ? &dims : NULL);
-    pmu_debug("aql_pmu_event_init returned %d\n", ret);
-    if (ret != 0) {
-        pmu_err("AQL hardware counter initialization failed for config=0x%llx: %d\n",
-                config, ret);
-        return ret;
-    }
+	/* Initialize AQL hardware counter */
+	pmu_debug("About to call aql_pmu_event_init\n");
+	ret = aql_pmu_event_init(event, dims.valid ? &dims : NULL);
+	pmu_debug("aql_pmu_event_init returned %d\n", ret);
+	if (ret != 0) {
+		pmu_err("AQL hardware counter initialization failed for config=0x%llx: %d\n",
+			config, ret);
+		return ret;
+	}
 
-    /* Successfully initialized hardware counter */
-    if (dims.valid) {
-        pmu_debug("Using AQL hardware counter for event config=0x%llx with dimensions\n", config);
-    } else {
-        pmu_debug("Using AQL hardware counter for event config=0x%llx (no dimensions)\n", config);
-    }
-    atomic64_inc(&pmu->hardware_events);
-    atomic64_inc(&pmu->total_events);
+	/* Successfully initialized hardware counter */
+	if (dims.valid) {
+		pmu_debug("Using AQL hardware counter for event config=0x%llx with dimensions\n",
+			  config);
+	} else {
+		pmu_debug("Using AQL hardware counter for event config=0x%llx (no dimensions)\n",
+			  config);
+	}
+	atomic64_inc(&pmu->hardware_events);
+	atomic64_inc(&pmu->total_events);
 
-    /* Set destroy callback to properly cleanup when event is freed */
-    event->destroy = aql_pmu_event_destroy;
+	/* Set destroy callback to properly cleanup when event is freed */
+	event->destroy = aql_pmu_event_destroy;
 
-    return 0;
+	return 0;
 }
 
 /* PMU callback: Add event to PMU */
 static int amdgpu_pmu_add(struct perf_event *event, int flags)
 {
-    struct hw_perf_event *hwc = &event->hw;
+	struct hw_perf_event *hwc = &event->hw;
 
-    pmu_debug("add: config=0x%llx, flags=0x%x\n", event->attr.config, flags);
+	pmu_debug("add: config=0x%llx, flags=0x%x\n", event->attr.config, flags);
 
-    /* Check if this is an AQL hardware event */
-    if (hwc->config_base != 0) {
-        /* AQL hardware event - start measurement if requested */
-        if (flags & PERF_EF_START) {
-            int ret = aql_pmu_event_start(event);
-            if (ret) {
-                pmu_err("add: Failed to start AQL hardware event: %d\n", ret);
-                return ret;
-            }
-            hwc->state = 0;
-            /* Timer will be started by aql_perf_measurement_start() after measurement becomes active */
-        } else {
-            hwc->state = PERF_HES_STOPPED;
-        }
+	/* Check if this is an AQL hardware event */
+	if (hwc->config_base != 0) {
+		/* AQL hardware event - start measurement if requested */
+		if (flags & PERF_EF_START) {
+			int ret = aql_pmu_event_start(event);
+			if (ret) {
+				pmu_err("add: Failed to start AQL hardware event: %d\n", ret);
+				return ret;
+			}
+			hwc->state = 0;
+			/* Timer will be started by aql_perf_measurement_start() after measurement becomes active */
+		} else {
+			hwc->state = PERF_HES_STOPPED;
+		}
 
-        /* Set initial counter value */
-        local64_set(&event->count, 0);
+		/* Set initial counter value */
+		local64_set(&event->count, 0);
 
-        pmu_debug("add: Added AQL hardware event successfully\n");
-        return 0;
-    }
+		pmu_debug("add: Added AQL hardware event successfully\n");
+		return 0;
+	}
 
-    /* Event not initialized (config_base=0) - perf may be cloning/reusing event structure.
+	/* Event not initialized (config_base=0) - perf may be cloning/reusing event structure.
      * Return success but mark as stopped to prevent retry loop. */
-    pmu_debug("add: Event not initialized, marking as stopped\n");
-    hwc->state = PERF_HES_STOPPED | PERF_HES_UPTODATE;
-    local64_set(&event->count, 0);
-    return 0;
+	pmu_debug("add: Event not initialized, marking as stopped\n");
+	hwc->state = PERF_HES_STOPPED | PERF_HES_UPTODATE;
+	local64_set(&event->count, 0);
+	return 0;
 }
 
 /* PMU callback: Remove event from PMU */
 static void amdgpu_pmu_del(struct perf_event *event, int flags)
 {
-    struct hw_perf_event *hwc = &event->hw;
+	struct hw_perf_event *hwc = &event->hw;
 
-    pmu_info("del: ENTRY - config=0x%llx, flags=0x%x\n", event->attr.config, flags);
+	pmu_info("del: ENTRY - config=0x%llx, flags=0x%x\n", event->attr.config, flags);
 
-    /* Check if this is an AQL hardware event */
-    if (hwc->config_base != 0) {
-        /* CRITICAL: del() can be called from atomic context (e.g., perf stat exit).
+	/* Check if this is an AQL hardware event */
+	if (hwc->config_base != 0) {
+		/* CRITICAL: del() can be called from atomic context (e.g., perf stat exit).
          * We cannot do synchronous operations that sleep from atomic context.
          * Check if we're in atomic context and handle accordingly. */
-        if (in_atomic() || irqs_disabled()) {
-            pmu_warn("del: Called from atomic context, reading cached value\n");
+		if (in_atomic() || irqs_disabled()) {
+			pmu_warn("del: Called from atomic context, reading cached value\n");
 
-            /* Read cached counter value - this is safe in atomic context because
+			/* Read cached counter value - this is safe in atomic context because
              * aql_pmu_event_read() just returns the cached value without sleeping */
-            uint64_t counter_value = aql_pmu_event_read(event);
-            local64_set(&event->count, counter_value);
-            pmu_info("del: Final cached counter value=%llu\n", counter_value);
+			uint64_t counter_value = aql_pmu_event_read(event);
+			local64_set(&event->count, counter_value);
+			pmu_info("del: Final cached counter value=%llu\n", counter_value);
 
-            /* Just mark as stopped - cleanup will happen in event_destroy */
-            hwc->state = PERF_HES_STOPPED | PERF_HES_UPTODATE;
-            pmu_debug("del: Removed AQL hardware event (atomic mode)\n");
-            return;
-        }
+			/* Just mark as stopped - cleanup will happen in event_destroy */
+			hwc->state = PERF_HES_STOPPED | PERF_HES_UPTODATE;
+			pmu_debug("del: Removed AQL hardware event (atomic mode)\n");
+			return;
+		}
 
-        /* Safe to do synchronous operations - read final count before stopping.
+		/* Safe to do synchronous operations - read final count before stopping.
          * For NO_INTERRUPT PMUs like ours, we must update the count here
          * because perf stat won't explicitly call read(). */
-        pmu_debug("del: Reading final counter value before stop (synchronous)\n");
-        uint64_t counter_value = aql_pmu_event_read_sync(event);
-        local64_set(&event->count, counter_value);
-        pmu_info("del: Final counter value=%llu\n", counter_value);
+		pmu_debug("del: Reading final counter value before stop (synchronous)\n");
+		uint64_t counter_value = aql_pmu_event_read_sync(event);
+		local64_set(&event->count, counter_value);
+		pmu_info("del: Final counter value=%llu\n", counter_value);
 
-        /* Stop the event but DON'T destroy it - the event may be re-added later.
+		/* Stop the event but DON'T destroy it - the event may be re-added later.
          * Only event_destroy should free the measurement structure. */
-        aql_pmu_event_stop(event);
+		aql_pmu_event_stop(event);
 
-        /* Mark event as stopped */
-        hwc->state = PERF_HES_STOPPED | PERF_HES_UPTODATE;
+		/* Mark event as stopped */
+		hwc->state = PERF_HES_STOPPED | PERF_HES_UPTODATE;
 
-        pmu_debug("del: Removed AQL hardware event successfully\n");
-        return;
-    }
+		pmu_debug("del: Removed AQL hardware event successfully\n");
+		return;
+	}
 
-    pmu_debug("del: Event not initialized (config_base=0)\n");
+	pmu_debug("del: Event not initialized (config_base=0)\n");
 }
 
 /* PMU callback: Start event */
 static void amdgpu_pmu_start(struct perf_event *event, int flags)
 {
-    struct hw_perf_event *hwc = &event->hw;
+	struct hw_perf_event *hwc = &event->hw;
 
-    pmu_info("start: ENTRY - config=0x%llx, flags=0x%x, hwc->config_base=0x%lx\n",
-             event->attr.config, flags, hwc->config_base);
+	pmu_info("start: ENTRY - config=0x%llx, flags=0x%x, hwc->config_base=0x%lx\n",
+		 event->attr.config, flags, hwc->config_base);
 
-    /* Check if this is an AQL hardware event */
-    if (hwc->config_base != 0) {
-        pmu_debug("start: Starting AQL hardware event\n");
-        /* Reset counter if requested */
-        if (flags & PERF_EF_RELOAD) {
-            pmu_debug("start: Resetting counter (PERF_EF_RELOAD flag set)\n");
-            local64_set(&event->count, 0);
-        }
+	/* Check if this is an AQL hardware event */
+	if (hwc->config_base != 0) {
+		pmu_debug("start: Starting AQL hardware event\n");
+		/* Reset counter if requested */
+		if (flags & PERF_EF_RELOAD) {
+			pmu_debug("start: Resetting counter (PERF_EF_RELOAD flag set)\n");
+			local64_set(&event->count, 0);
+		}
 
-        if (aql_pmu_event_start(event) == 0) {
-            hwc->state = 0;
-            pmu_debug("start: Started AQL hardware event config=0x%llx successfully\n", event->attr.config);
-            /* Timer will be started by aql_perf_measurement_start() after measurement becomes active */
-        } else {
-            pmu_err("start: Failed to start AQL hardware event config=0x%llx\n", event->attr.config);
-            hwc->state = PERF_HES_STOPPED;
-        }
-        return;
-    }
+		if (aql_pmu_event_start(event) == 0) {
+			hwc->state = 0;
+			pmu_debug("start: Started AQL hardware event config=0x%llx successfully\n",
+				  event->attr.config);
+			/* Timer will be started by aql_perf_measurement_start() after measurement becomes active */
+		} else {
+			pmu_err("start: Failed to start AQL hardware event config=0x%llx\n",
+				event->attr.config);
+			hwc->state = PERF_HES_STOPPED;
+		}
+		return;
+	}
 
-    /* Only AQL hardware events are supported */
-    pmu_err("start: Non-AQL event detected, config=0x%llx\n", event->attr.config);
+	/* Only AQL hardware events are supported */
+	pmu_err("start: Non-AQL event detected, config=0x%llx\n", event->attr.config);
 }
 
 /* PMU callback: Stop event */
 static void amdgpu_pmu_stop(struct perf_event *event, int flags)
 {
-    struct hw_perf_event *hwc = &event->hw;
+	struct hw_perf_event *hwc = &event->hw;
 
-    pmu_info("stop: ENTRY - config=0x%llx, flags=0x%x, hwc->config_base=0x%lx\n",
-             event->attr.config, flags, hwc->config_base);
+	pmu_info("stop: ENTRY - config=0x%llx, flags=0x%x, hwc->config_base=0x%lx\n",
+		 event->attr.config, flags, hwc->config_base);
 
-    /* Check if this is an AQL hardware event */
-    if (hwc->config_base != 0) {
-        pmu_debug("stop: Stopping AQL hardware event\n");
-        /* Update count if requested */
-        if (flags & PERF_EF_UPDATE) {
-            pmu_debug("stop: Reading final count (PERF_EF_UPDATE flag set)\n");
-            amdgpu_pmu_read(event);
-        }
+	/* Check if this is an AQL hardware event */
+	if (hwc->config_base != 0) {
+		pmu_debug("stop: Stopping AQL hardware event\n");
+		/* Update count if requested */
+		if (flags & PERF_EF_UPDATE) {
+			pmu_debug("stop: Reading final count (PERF_EF_UPDATE flag set)\n");
+			amdgpu_pmu_read(event);
+		}
 
-        if (aql_pmu_event_stop(event) == 0) {
-            hwc->state = PERF_HES_STOPPED;
-            pmu_debug("stop: Stopped AQL hardware event config=0x%llx successfully\n", event->attr.config);
-        } else {
-            pmu_err("stop: Failed to stop AQL hardware event config=0x%llx\n", event->attr.config);
-        }
-        return;
-    }
+		if (aql_pmu_event_stop(event) == 0) {
+			hwc->state = PERF_HES_STOPPED;
+			pmu_debug("stop: Stopped AQL hardware event config=0x%llx successfully\n",
+				  event->attr.config);
+		} else {
+			pmu_err("stop: Failed to stop AQL hardware event config=0x%llx\n",
+				event->attr.config);
+		}
+		return;
+	}
 
-    /* Only AQL hardware events are supported */
-    pmu_err("stop: Non-AQL event detected, config=0x%llx\n", event->attr.config);
+	/* Only AQL hardware events are supported */
+	pmu_err("stop: Non-AQL event detected, config=0x%llx\n", event->attr.config);
 }
 
 /* PMU callback: Read event counter */
 static void amdgpu_pmu_read(struct perf_event *event)
 {
-    struct hw_perf_event *hwc = &event->hw;
-    uint64_t old_count, new_count;
+	struct hw_perf_event *hwc = &event->hw;
+	uint64_t old_count, new_count;
 
-    old_count = local64_read(&event->count);
+	old_count = local64_read(&event->count);
 
-    pmu_info("read: ENTRY - config=0x%llx, old_count=%llu, hwc->config_base=0x%lx\n",
-             event->attr.config, (unsigned long long)old_count, hwc->config_base);
+	pmu_info("read: ENTRY - config=0x%llx, old_count=%llu, hwc->config_base=0x%lx\n",
+		 event->attr.config, (unsigned long long)old_count, hwc->config_base);
 
-    /* Check if this is an AQL hardware event */
-    if (hwc->config_base != 0) {
-        pmu_info("read: Reading AQL hardware counter for config=0x%llx\n", event->attr.config);
-        uint64_t counter_value = aql_pmu_event_read(event);
-        pmu_info("read: ========== SETTING event->count = %llu (0x%llx) ==========\n",
-                 counter_value, counter_value);
-        local64_set(&event->count, counter_value);
-        new_count = local64_read(&event->count);
-        pmu_info("read: AQL counter read complete - old=%llu, new=%llu, delta=%lld\n",
-                 (unsigned long long)old_count, (unsigned long long)new_count,
-                 (long long)(new_count - old_count));
-        pmu_info("read: ========== FINAL event->count = %llu (0x%llx) ==========\n",
-                 new_count, new_count);
-        return;
-    }
+	/* Check if this is an AQL hardware event */
+	if (hwc->config_base != 0) {
+		pmu_info("read: Reading AQL hardware counter for config=0x%llx\n",
+			 event->attr.config);
+		uint64_t counter_value = aql_pmu_event_read(event);
+		pmu_info("read: ========== SETTING event->count = %llu (0x%llx) ==========\n",
+			 counter_value, counter_value);
+		local64_set(&event->count, counter_value);
+		new_count = local64_read(&event->count);
+		pmu_info("read: AQL counter read complete - old=%llu, new=%llu, delta=%lld\n",
+			 (unsigned long long)old_count, (unsigned long long)new_count,
+			 (long long)(new_count - old_count));
+		pmu_info("read: ========== FINAL event->count = %llu (0x%llx) ==========\n",
+			 new_count, new_count);
+		return;
+	}
 
-    /* Only AQL hardware events are supported */
-    pmu_err("read: Non-AQL event detected, config=0x%llx\n", event->attr.config);
+	/* Only AQL hardware events are supported */
+	pmu_err("read: Non-AQL event detected, config=0x%llx\n", event->attr.config);
 }
 
 /* Initialize event attributes from counter_registry */
 static int amdgpu_pmu_init_event_attrs(void)
 {
-    const counter_def_t *counters;
-    size_t i;
+	const counter_def_t *counters;
+	size_t i;
 
-    amdgpu_pmu_event_count = get_counter_count();
-    counters = get_all_counters();
+	amdgpu_pmu_event_count = get_counter_count();
+	counters = get_all_counters();
 
-    pmu_info("Initializing %zu event attributes from counter registry\n", amdgpu_pmu_event_count);
+	pmu_info("Initializing %zu event attributes from counter registry\n",
+		 amdgpu_pmu_event_count);
 
-    /* Allocate array of pmu_event_attr structures */
-    amdgpu_pmu_event_attrs_dynamic = kzalloc(amdgpu_pmu_event_count * sizeof(struct pmu_event_attr),
-                                           GFP_KERNEL);
-    if (!amdgpu_pmu_event_attrs_dynamic) {
-        pmu_err("Failed to allocate event attributes\n");
-        return -ENOMEM;
-    }
+	/* Allocate array of pmu_event_attr structures */
+	amdgpu_pmu_event_attrs_dynamic =
+		kzalloc(amdgpu_pmu_event_count * sizeof(struct pmu_event_attr), GFP_KERNEL);
+	if (!amdgpu_pmu_event_attrs_dynamic) {
+		pmu_err("Failed to allocate event attributes\n");
+		return -ENOMEM;
+	}
 
-    /* Allocate array of attribute pointers (+ 1 for NULL terminator) */
-    amdgpu_pmu_event_attrs = kzalloc((amdgpu_pmu_event_count + 1) * sizeof(struct attribute *),
-                                   GFP_KERNEL);
-    if (!amdgpu_pmu_event_attrs) {
-        kfree(amdgpu_pmu_event_attrs_dynamic);
-        amdgpu_pmu_event_attrs_dynamic = NULL;
-        pmu_err("Failed to allocate event attribute array\n");
-        return -ENOMEM;
-    }
+	/* Allocate array of attribute pointers (+ 1 for NULL terminator) */
+	amdgpu_pmu_event_attrs =
+		kzalloc((amdgpu_pmu_event_count + 1) * sizeof(struct attribute *), GFP_KERNEL);
+	if (!amdgpu_pmu_event_attrs) {
+		kfree(amdgpu_pmu_event_attrs_dynamic);
+		amdgpu_pmu_event_attrs_dynamic = NULL;
+		pmu_err("Failed to allocate event attribute array\n");
+		return -ENOMEM;
+	}
 
-    /* Initialize each event attribute */
-    for (i = 0; i < amdgpu_pmu_event_count; i++) {
-        struct pmu_event_attr *pmu_attr = &amdgpu_pmu_event_attrs_dynamic[i];
-        const counter_def_t *counter = &counters[i];
-        char *name_lower;
+	/* Initialize each event attribute */
+	for (i = 0; i < amdgpu_pmu_event_count; i++) {
+		struct pmu_event_attr *pmu_attr = &amdgpu_pmu_event_attrs_dynamic[i];
+		const counter_def_t *counter = &counters[i];
+		char *name_lower;
 
-        /* Store the counter ID */
-        pmu_attr->id = counter->id;
+		/* Store the counter ID */
+		pmu_attr->id = counter->id;
 
-        /* Use counter name directly (already lowercase in registry) */
-        name_lower = kstrdup(counter->name, GFP_KERNEL);
-        if (!name_lower) {
-            /* Cleanup on error */
-            while (i > 0) {
-                i--;
-                kfree(amdgpu_pmu_event_attrs_dynamic[i].attr.attr.name);
-            }
-            kfree(amdgpu_pmu_event_attrs);
-            kfree(amdgpu_pmu_event_attrs_dynamic);
-            amdgpu_pmu_event_attrs = NULL;
-            amdgpu_pmu_event_attrs_dynamic = NULL;
-            return -ENOMEM;
-        }
+		/* Use counter name directly (already lowercase in registry) */
+		name_lower = kstrdup(counter->name, GFP_KERNEL);
+		if (!name_lower) {
+			/* Cleanup on error */
+			while (i > 0) {
+				i--;
+				kfree(amdgpu_pmu_event_attrs_dynamic[i].attr.attr.name);
+			}
+			kfree(amdgpu_pmu_event_attrs);
+			kfree(amdgpu_pmu_event_attrs_dynamic);
+			amdgpu_pmu_event_attrs = NULL;
+			amdgpu_pmu_event_attrs_dynamic = NULL;
+			return -ENOMEM;
+		}
 
-        /* Initialize device_attribute */
-        sysfs_attr_init(&pmu_attr->attr.attr);
-        pmu_attr->attr.attr.name = name_lower;
-        pmu_attr->attr.attr.mode = 0444;
-        pmu_attr->attr.show = amdgpu_pmu_event_show;
-        pmu_attr->attr.store = NULL;
+		/* Initialize device_attribute */
+		sysfs_attr_init(&pmu_attr->attr.attr);
+		pmu_attr->attr.attr.name = name_lower;
+		pmu_attr->attr.attr.mode = 0444;
+		pmu_attr->attr.show = amdgpu_pmu_event_show;
+		pmu_attr->attr.store = NULL;
 
-        /* Add to attribute array */
-        amdgpu_pmu_event_attrs[i] = &pmu_attr->attr.attr;
+		/* Add to attribute array */
+		amdgpu_pmu_event_attrs[i] = &pmu_attr->attr.attr;
 
-        pmu_debug("  Event %zu: %s = config=0x%llx\n", i, name_lower, (u64)counter->id);
-    }
+		pmu_debug("  Event %zu: %s = config=0x%llx\n", i, name_lower, (u64)counter->id);
+	}
 
-    /* NULL terminate the array */
-    amdgpu_pmu_event_attrs[amdgpu_pmu_event_count] = NULL;
+	/* NULL terminate the array */
+	amdgpu_pmu_event_attrs[amdgpu_pmu_event_count] = NULL;
 
-    /* Set the events group attrs pointer */
-    amdgpu_pmu_events_group.attrs = amdgpu_pmu_event_attrs;
+	/* Set the events group attrs pointer */
+	amdgpu_pmu_events_group.attrs = amdgpu_pmu_event_attrs;
 
-    pmu_info("Successfully initialized %zu events\n", amdgpu_pmu_event_count);
-    return 0;
+	pmu_info("Successfully initialized %zu events\n", amdgpu_pmu_event_count);
+	return 0;
 }
 
 /* Cleanup event attributes */
 static void amdgpu_pmu_cleanup_event_attrs(void)
 {
-    size_t i;
+	size_t i;
 
-    if (amdgpu_pmu_event_attrs_dynamic) {
-        for (i = 0; i < amdgpu_pmu_event_count; i++) {
-            kfree(amdgpu_pmu_event_attrs_dynamic[i].attr.attr.name);
-        }
-        kfree(amdgpu_pmu_event_attrs_dynamic);
-        amdgpu_pmu_event_attrs_dynamic = NULL;
-    }
+	if (amdgpu_pmu_event_attrs_dynamic) {
+		for (i = 0; i < amdgpu_pmu_event_count; i++) {
+			kfree(amdgpu_pmu_event_attrs_dynamic[i].attr.attr.name);
+		}
+		kfree(amdgpu_pmu_event_attrs_dynamic);
+		amdgpu_pmu_event_attrs_dynamic = NULL;
+	}
 
-    if (amdgpu_pmu_event_attrs) {
-        kfree(amdgpu_pmu_event_attrs);
-        amdgpu_pmu_event_attrs = NULL;
-    }
+	if (amdgpu_pmu_event_attrs) {
+		kfree(amdgpu_pmu_event_attrs);
+		amdgpu_pmu_event_attrs = NULL;
+	}
 
-    amdgpu_pmu_event_count = 0;
-    amdgpu_pmu_events_group.attrs = NULL;
+	amdgpu_pmu_event_count = 0;
+	amdgpu_pmu_events_group.attrs = NULL;
 }
 
 /* Module initialization */
 static int __init amdgpu_pmu_init(void)
 {
-    struct amdgpu_pmu *pmu;
-    int ret;
+	struct amdgpu_pmu *pmu;
+	int ret;
 
-    pmu_info("Initializing PMU Stub module v%s\n", AMDGPU_PMU_VERSION);
+	pmu_info("Initializing PMU Stub module v%s\n", AMDGPU_PMU_VERSION);
 
-    /* Initialize event attributes from counter_registry */
-    ret = amdgpu_pmu_init_event_attrs();
-    if (ret)
-        return ret;
+	/* Initialize event attributes from counter_registry */
+	ret = amdgpu_pmu_init_event_attrs();
+	if (ret)
+		return ret;
 
-    /* Allocate PMU structure */
-    pmu = kzalloc(sizeof(*pmu), GFP_KERNEL);
-    if (!pmu) {
-        amdgpu_pmu_cleanup_event_attrs();
-        return -ENOMEM;
-    }
+	/* Allocate PMU structure */
+	pmu = kzalloc(sizeof(*pmu), GFP_KERNEL);
+	if (!pmu) {
+		amdgpu_pmu_cleanup_event_attrs();
+		return -ENOMEM;
+	}
 
-    /* Initialize PMU structure */
-    spin_lock_init(&pmu->lock);
-    bitmap_zero(pmu->used_mask, AMDGPU_PMU_MAX_EVENTS);
-    pmu->num_events = 0;
+	/* Initialize PMU structure */
+	spin_lock_init(&pmu->lock);
+	bitmap_zero(pmu->used_mask, AMDGPU_PMU_MAX_EVENTS);
+	pmu->num_events = 0;
 
-    /* Initialize counters */
-    atomic64_set(&pmu->counter_sq_waves, 0);
-    atomic64_set(&pmu->counter_sq_instructions, 0);
-    atomic64_set(&pmu->counter_ta_busy, 0);
-    atomic64_set(&pmu->total_events, 0);
-    atomic64_set(&pmu->total_samples, 0);
-    atomic64_set(&pmu->hardware_events, 0);
-    atomic64_set(&pmu->simulation_events, 0);
+	/* Initialize counters */
+	atomic64_set(&pmu->counter_sq_waves, 0);
+	atomic64_set(&pmu->counter_sq_instructions, 0);
+	atomic64_set(&pmu->counter_ta_busy, 0);
+	atomic64_set(&pmu->total_events, 0);
+	atomic64_set(&pmu->total_samples, 0);
+	atomic64_set(&pmu->hardware_events, 0);
+	atomic64_set(&pmu->simulation_events, 0);
 
-    /* Initialize AQL hardware integration */
-    mutex_init(&pmu->aql_mutex);
+	/* Initialize AQL hardware integration */
+	mutex_init(&pmu->aql_mutex);
 
-    /* Initialize timer */
-    hrtimer_setup(&pmu->timer, amdgpu_pmu_timer_handler, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
-    pmu->timer_period = ms_to_ktime(timer_period_ms);
+	/* Initialize timer */
+	hrtimer_setup(&pmu->timer, amdgpu_pmu_timer_handler, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+	pmu->timer_period = ms_to_ktime(timer_period_ms);
 
-    /* Set up PMU structure */
-    pmu->pmu = (struct pmu) {
-        .name           = PMU_NAME,
-        .task_ctx_nr    = -1,
-        .event_init     = amdgpu_pmu_event_init,
-        .add            = amdgpu_pmu_add,
-        .del            = amdgpu_pmu_del,
-        .start          = amdgpu_pmu_start,
-        .stop           = amdgpu_pmu_stop,
-        .read           = amdgpu_pmu_read,
-        .attr_groups    = amdgpu_pmu_attr_groups,
-        .capabilities   = PERF_PMU_CAP_NO_INTERRUPT | PERF_PMU_CAP_NO_EXCLUDE,
-    };
+	/* Set up PMU structure */
+	pmu->pmu = (struct pmu){
+		.name = PMU_NAME,
+		.task_ctx_nr = -1,
+		.event_init = amdgpu_pmu_event_init,
+		.add = amdgpu_pmu_add,
+		.del = amdgpu_pmu_del,
+		.start = amdgpu_pmu_start,
+		.stop = amdgpu_pmu_stop,
+		.read = amdgpu_pmu_read,
+		.attr_groups = amdgpu_pmu_attr_groups,
+		.capabilities = PERF_PMU_CAP_NO_INTERRUPT | PERF_PMU_CAP_NO_EXCLUDE,
+	};
 
-    /* Register PMU with perf subsystem */
-    ret = perf_pmu_register(&pmu->pmu, PMU_NAME, -1);
-    if (ret) {
-        pmu_err("Failed to register PMU: %d\n", ret);
-        amdgpu_pmu_cleanup_event_attrs();
-        kfree(pmu);
-        return ret;
-    }
+	/* Register PMU with perf subsystem */
+	ret = perf_pmu_register(&pmu->pmu, PMU_NAME, -1);
+	if (ret) {
+		pmu_err("Failed to register PMU: %d\n", ret);
+		amdgpu_pmu_cleanup_event_attrs();
+		kfree(pmu);
+		return ret;
+	}
 
-    amdgpu_pmu_instance = pmu;
+	amdgpu_pmu_instance = pmu;
 
-    /* Initialize AQL PMU integration */
-    ret = aql_pmu_init();
-    if (ret == 0) {
-        pmu_info("AQL hardware acceleration enabled\n");
-    } else {
-        pmu_err("AQL hardware acceleration required but not available: %d\n", ret);
-        perf_pmu_unregister(&pmu->pmu);
-        amdgpu_pmu_cleanup_event_attrs();
-        kfree(pmu);
-        return ret;
-    }
+	/* Initialize AQL PMU integration */
+	ret = aql_pmu_init();
+	if (ret == 0) {
+		pmu_info("AQL hardware acceleration enabled\n");
+	} else {
+		pmu_err("AQL hardware acceleration required but not available: %d\n", ret);
+		perf_pmu_unregister(&pmu->pmu);
+		amdgpu_pmu_cleanup_event_attrs();
+		kfree(pmu);
+		return ret;
+	}
 
-    /* Verify GPU architecture is available for dimension validation */
-    {
-        struct aql_perf_session *session = aql_pmu_get_session();
-        if (!session || session->num_gpus == 0 || !session->archs || !session->archs[0]) {
-            pmu_err("GPU architecture unavailable - cannot validate dimensions\n");
-            perf_pmu_unregister(&pmu->pmu);
-            amdgpu_pmu_cleanup_event_attrs();
-            if (session)
-                aql_pmu_put_session(session);
-            kfree(pmu);
-            return -ENODEV;
-        }
-        pmu_info("GPU architecture loaded - %u GPU(s) available\n", session->num_gpus);
-        aql_pmu_put_session(session);
-    }
+	/* Verify GPU architecture is available for dimension validation */
+	{
+		struct aql_perf_session *session = aql_pmu_get_session();
+		if (!session || session->num_gpus == 0 || !session->archs || !session->archs[0]) {
+			pmu_err("GPU architecture unavailable - cannot validate dimensions\n");
+			perf_pmu_unregister(&pmu->pmu);
+			amdgpu_pmu_cleanup_event_attrs();
+			if (session)
+				aql_pmu_put_session(session);
+			kfree(pmu);
+			return -ENODEV;
+		}
+		pmu_info("GPU architecture loaded - %u GPU(s) available\n", session->num_gpus);
+		aql_pmu_put_session(session);
+	}
 
-    pmu_info("PMU Stub module loaded successfully\n");
-    pmu_info("Events available under: /sys/bus/event_source/devices/%s/\n", PMU_NAME);
+	pmu_info("PMU Stub module loaded successfully\n");
+	pmu_info("Events available under: /sys/bus/event_source/devices/%s/\n", PMU_NAME);
 
-    return 0;
+	return 0;
 }
 
 /* Module cleanup */
 static void __exit amdgpu_pmu_exit(void)
 {
-    struct amdgpu_pmu *pmu = amdgpu_pmu_instance;
+	struct amdgpu_pmu *pmu = amdgpu_pmu_instance;
 
-    pmu_info("Unloading PMU Stub module\n");
+	pmu_info("Unloading PMU Stub module\n");
 
-    if (pmu) {
-        /* Step 1: Stop timer to prevent new work from being queued */
-        hrtimer_cancel(&pmu->timer);
+	if (pmu) {
+		/* Step 1: Stop timer to prevent new work from being queued */
+		hrtimer_cancel(&pmu->timer);
 
-        /* Step 2: Flush all measurement workqueues BEFORE session cleanup */
-        aql_pmu_flush_all_measurements();
+		/* Step 2: Flush all measurement workqueues BEFORE session cleanup */
+		aql_pmu_flush_all_measurements();
 
-        /* Step 3: Now safe to release session */
-        aql_pmu_cleanup();
-        pmu_info("AQL hardware acceleration disabled\n");
+		/* Step 3: Now safe to release session */
+		aql_pmu_cleanup();
+		pmu_info("AQL hardware acceleration disabled\n");
 
-        /* Unregister PMU */
-        perf_pmu_unregister(&pmu->pmu);
+		/* Unregister PMU */
+		perf_pmu_unregister(&pmu->pmu);
 
-        /* Print statistics */
-        pmu_info("Total events created: %lld\n",
-                 atomic64_read(&pmu->total_events));
-        pmu_info("Hardware events: %lld\n",
-                 atomic64_read(&pmu->hardware_events));
-        pmu_info("Simulation events: %lld\n",
-                 atomic64_read(&pmu->simulation_events));
-        pmu_info("Total samples: %lld\n",
-                 atomic64_read(&pmu->total_samples));
+		/* Print statistics */
+		pmu_info("Total events created: %lld\n", atomic64_read(&pmu->total_events));
+		pmu_info("Hardware events: %lld\n", atomic64_read(&pmu->hardware_events));
+		pmu_info("Simulation events: %lld\n", atomic64_read(&pmu->simulation_events));
+		pmu_info("Total samples: %lld\n", atomic64_read(&pmu->total_samples));
 
-        /* Free memory */
-        kfree(pmu);
-        amdgpu_pmu_instance = NULL;
-    }
+		/* Free memory */
+		kfree(pmu);
+		amdgpu_pmu_instance = NULL;
+	}
 
-    /* Cleanup event attributes */
-    amdgpu_pmu_cleanup_event_attrs();
+	/* Cleanup event attributes */
+	amdgpu_pmu_cleanup_event_attrs();
 
-    pmu_info("PMU Stub module unloaded\n");
+	pmu_info("PMU Stub module unloaded\n");
 }
 
 module_init(amdgpu_pmu_init);


### PR DESCRIPTION
## Summary

Add `.clang-format` configuration based on Linux kernel coding style and apply consistent formatting across all source files.

## Changes

- Add `.clang-format` with Linux kernel style settings
- Format all 35 source files (*.c and *.h) in `src/`

## Style Settings

| Setting | Value |
|---------|-------|
| Indentation | 8-space tabs |
| Line limit | 100 characters |
| Brace style | K&R (opening brace on same line, except functions) |
| Pointer alignment | Right (`char *ptr`) |

## Test plan

- [x] All files formatted with `clang-format -i`
- [x] Module builds successfully
- [x] No functional changes - formatting only