### PR TITLE
[hip] Add novectorize to `ToolsDispatchTable`

### DIFF
--- a/projects/clr/hipamd/src/hip_api_trace.cpp
+++ b/projects/clr/hipamd/src/hip_api_trace.cpp
@@ -1504,7 +1504,7 @@ NO_VECTORIZE const HipCompilerDispatchTable* GetHipCompilerDispatchTable() {
   static auto* _v = &GetDispatchTableImpl<HipCompilerDispatchTable>();
   return _v;
 }
-const HipToolsDispatchTable* GetHipToolsDispatchTable() {
+NO_VECTORIZE const HipToolsDispatchTable* GetHipToolsDispatchTable() {
   static auto* _v = &GetDispatchTableImpl<HipToolsDispatchTable>();
   return _v;
 }


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

`NO_VECTORIZE` was not added to `GetHipToolsDispatchTable()`

## Technical Details

Add `NO_VECTORIZE` to `GetHipToolsDispatchTable` for uniform behavior across all HIP table registration with rocprofiler-register. 

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
