### PR TITLE
Handle cpu name having colons

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
@@ -137,7 +137,7 @@ parse_cpu_info()
         for(const auto& itr : bitr)
         {
             auto match = sdk::parse::tokenize(itr, std::vector<std::string_view>{": "});
-            if(match.size() == 2)
+            if(match.size() >= 2)
             {
                 auto get_stol = [_label = std::string_view{itr}](const auto& _value) -> long {
                     try
@@ -153,24 +153,33 @@ parse_cpu_info()
                     return 0;
                 };
 
-                const auto& value = match.back();
+                // For cases with multiple colons, join all tokens after the first one
+                // e.g. "model name : AMD EPYC : 100-000000248" split into
+                // ["model name", "AMD EPYC", "100-000000248"] with the last two tokens joined
+                // back together with ": "
+                std::string value;
+                if(match.size() == 2)
+                {
+                    value = match.back();
+                }
+                else
+                {
+                    // Join all tokens after the first one with ": " separator
+                    for(size_t i = 1; i < match.size(); ++i)
+                    {
+                        if(i > 1) value += ": ";
+                        value += match[i];
+                    }
+                }
 
                 if(itr.find("vendor_id") == 0)
                     info_v.vendor_id = value;
                 else if(itr.find("model name") == 0)
                 {
-                    info_v.model_name      = value;
-                    size_t first_colon_pos = value.find(':');
-                    // This handles the case where the model name has multiple colons
-                    // Example "model name : AMD EPYC : 100-000000248"
-                    if(first_colon_pos != std::string::npos)
-                    {
-                        // Extract the model name after the first colon
-                        info_v.model_name = value.substr(first_colon_pos + 1);
-                        // Remove leading and trailing whitespaces
-                        info_v.model_name =
-                            sdk::parse::strip(std::string{info_v.model_name}, " \t\n\v\f\r");
-                    }
+                    info_v.model_name = value;
+                    // Remove leading and trailing whitespaces
+                    info_v.model_name =
+                        sdk::parse::strip(std::string{info_v.model_name}, " \t\n\v\f\r");
                 }
                 else if(itr.find("processor") == 0)
                     info_v.processor = get_stol(value);

--- a/projects/rocprofiler-sdk/source/lib/tests/common/parse.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/common/parse.cpp
@@ -68,3 +68,53 @@ TEST(parse, strip)
                        test_message,
                        stripped_message);
 }
+
+TEST(parse, cpu_info_model_name)
+{
+    // Simulate the logic in agent.cpp
+    auto parse_line = [](std::string_view line) -> std::string {
+        auto match = sdk::parse::tokenize(line, std::vector<std::string_view>{": "});
+        std::string model_name;
+
+        if(match.size() >= 2)
+        {
+            std::string value;
+            if(match.size() == 2)
+            {
+                value = match.back();
+            }
+            else
+            {
+                // Join all tokens after the first one with ": " separator
+                for(size_t i = 1; i < match.size(); ++i)
+                {
+                    if(i > 1) value += ": ";
+                    value += match[i];
+                }
+            }
+
+            if(line.find("model name") == 0)
+            {
+                model_name = value;
+                // Remove leading and trailing whitespaces
+                model_name =
+                    sdk::parse::strip(std::string{model_name}, " \t\n\v\f\r");
+            }
+        }
+        return model_name;
+    };
+
+    // Case 1: Normal model name
+    {
+        auto line = "model name : AMD EPYC 7742 64-Core Processor";
+        auto name = parse_line(line);
+        EXPECT_EQ(name, "AMD EPYC 7742 64-Core Processor");
+    }
+
+    // Case 2: Model name with colons (The bug fix case)
+    {
+        auto line = "model name : AMD EPYC : 100-000000248";
+        auto name = parse_line(line);
+        EXPECT_EQ(name, "AMD EPYC : 100-000000248");
+    }
+}

--- a/projects/rocprofiler-sdk/source/lib/tests/common/parse.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/common/parse.cpp
@@ -73,7 +73,7 @@ TEST(parse, cpu_info_model_name)
 {
     // Simulate the logic in agent.cpp
     auto parse_line = [](std::string_view line) -> std::string {
-        auto match = sdk::parse::tokenize(line, std::vector<std::string_view>{": "});
+        auto        match = sdk::parse::tokenize(line, std::vector<std::string_view>{": "});
         std::string model_name;
 
         if(match.size() >= 2)
@@ -97,8 +97,7 @@ TEST(parse, cpu_info_model_name)
             {
                 model_name = value;
                 // Remove leading and trailing whitespaces
-                model_name =
-                    sdk::parse::strip(std::string{model_name}, " \t\n\v\f\r");
+                model_name = sdk::parse::strip(std::string{model_name}, " \t\n\v\f\r");
             }
         }
         return model_name;
@@ -106,15 +105,15 @@ TEST(parse, cpu_info_model_name)
 
     // Case 1: Normal model name
     {
-        auto line = "model name : AMD EPYC 7742 64-Core Processor";
-        auto name = parse_line(line);
+        const auto* line = "model name : AMD EPYC 7742 64-Core Processor";
+        auto        name = parse_line(line);
         EXPECT_EQ(name, "AMD EPYC 7742 64-Core Processor");
     }
 
     // Case 2: Model name with colons (The bug fix case)
     {
-        auto line = "model name : AMD EPYC : 100-000000248";
-        auto name = parse_line(line);
+        const auto* line = "model name : AMD EPYC : 100-000000248";
+        auto        name = parse_line(line);
         EXPECT_EQ(name, "AMD EPYC : 100-000000248");
     }
 }


### PR DESCRIPTION
## Motivation

I was looking into SWDEV-559466 and found the root of the problem to be the lack of agent data (checked by Perfetto generation tests) on certain machines.

## Technical Details

The data from `/proc/cpuinfo` sometimes includes model names that contain a colon and this was mishandled by the function.

## JIRA ID

Resolves SWDEV-559466

## Test Plan

Run `ctest -R rocprofv3-test-rocpd-scratch*`.

## Test Result

On the target environment there is a different issue causing related tests to fail. It is documented under SWDEV-534891.
