### PR TITLE
Add CI pipeline to ensure new tests contain categories [DO NOT MERGE]

### DIFF
--- a/.github/scripts/check_tests_categories.py
+++ b/.github/scripts/check_tests_categories.py
@@ -1,0 +1,107 @@
+import os
+import re
+import subprocess
+
+base_ref = os.environ["BASE_REF"]
+
+test_regex = r'TEST_CASE\("([^"]+)"(, "([^"]*)")*\)'
+template_test_regex = r'TEMPLATE_TEST_CASE\("([^"]+)", "([^"]*)",\s*((?:[^;]*?))\)'
+summary_path = "summary.txt"
+
+test_pattern = re.compile(test_regex)
+template_test_pattern = re.compile(template_test_regex, re.DOTALL)
+
+diff = subprocess.check_output(
+    ["git", "diff", f"origin/{base_ref}...HEAD", "--unified=0"],
+    text=True,
+    errors="replace",
+)
+
+problems = []
+
+current_file = None
+new_line = None
+
+chunk_lines = []
+chunk_start_line = None
+
+
+def process_chunk():
+    global problems, current_file, chunk_lines, chunk_start_line
+
+    if not chunk_lines or chunk_start_line is None:
+        return
+
+    for i, content in enumerate(chunk_lines):
+        line_no = chunk_start_line + i
+
+        m = test_pattern.search(content)
+        if m:
+            try:
+                g3 = m.group(3)
+                if not g3 or not g3.strip():
+                    raise IndexError
+            except IndexError:
+                problems.append((current_file, line_no, content.strip()))
+
+    chunk_text = "\n".join(chunk_lines)
+
+    for m in template_test_pattern.finditer(chunk_text):
+        try:
+            g2 = m.group(2)
+            if not g2 or not g2.strip():
+                raise IndexError
+        except IndexError:
+            prefix = chunk_text[: m.start()]
+            line_offset = prefix.count("\n")
+            line_no = chunk_start_line + line_offset
+
+            match_lines = chunk_text[m.start() : m.end()].splitlines()
+            snippet = match_lines[0].strip() if match_lines else ""
+
+            problems.append((current_file, line_no, snippet))
+
+    chunk_lines = []
+    chunk_start_line = None
+
+
+for line in diff.splitlines():
+    if line.startswith("+++ b/"):
+        process_chunk()
+        current_file = line[6:]
+    elif line.startswith("@@"):
+        process_chunk()
+        m = re.search(r"\+(\d+)(?:,(\d+))?", line)
+        if not m:
+            continue
+        start = int(m.group(1))
+        count = int(m.group(2) or "1")
+        new_line = start - 1
+    elif line.startswith("+") and not line.startswith("+++"):
+        if new_line is None:
+            continue
+        new_line += 1
+        content = line[1:]
+
+        if not chunk_lines:
+            chunk_start_line = new_line
+
+        chunk_lines.append(content)
+    else:
+        process_chunk()
+
+process_chunk()
+
+with open(summary_path, "w", encoding="utf-8") as f:
+    f.write("### Test categories validation\n\n")
+    if not problems:
+        f.write("No issues found.\n")
+    else:
+        f.write("### Tests missing at least one category\n\n")
+        f.write("| File | Line | Snippet |\n")
+        f.write("| --- | --- | --- |\n")
+        for file, line_no, snippet in problems:
+            snippet = snippet.replace("|", "\\|")
+            f.write(f"| `{file}` | {line_no} | `{snippet}` |\n")
+
+raise SystemExit(bool(problems))

--- a/.github/workflows/check_tests.yaml
+++ b/.github/workflows/check_tests.yaml
@@ -3,6 +3,8 @@ name: Check test categories
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - "projects/hip-tests/**"
 
 jobs:
   check-tests:

--- a/.github/workflows/check_tests.yaml
+++ b/.github/workflows/check_tests.yaml
@@ -1,0 +1,30 @@
+name: Check test categories
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set base branch for diff
+        run: |
+          echo "BASE_REF=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
+
+      - name: Run test category validation
+        run: |
+          python .github/scripts/check_tests_categories.py
+
+      - name: Publish summary to workflow
+        if: always()
+        run: |
+          cat summary.txt >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Motivation
With the introduction of category labels for HIP tests, we want to ensure that these labels will be present on all new tests. This PR introduces CI pipeline to verify this.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
**NOTE: do not merge this PR until HIP tests categories are merged.**
## Technical Details
On opening or pushing to the PR the pipeline will grab the diff between current state and target branch and check each addition chunk for the presence of TEST_CASE or TEMPLATE_TEST_CASE header. If the header is presented, it is checked in order to find a category. If category isn't present or empty, the pipeline fails, and offending file and line are dumped into github summary
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
N/A
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
Will provide additional dummy commit with an erroneous addition to demonstrate summary.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Example of the failed check: https://github.com/ROCm/rocm-systems/actions/runs/19899958402?pr=2158
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
