### PR TITLE
[SWDEV-569899] Added caching of KFD Nodes for enumeration API

### DIFF
--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -705,6 +705,11 @@ amdsmi_get_gpu_device_uuid(amdsmi_processor_handle processor_handle,
     return status;
 }
 
+// Add a static cache for KFD nodes with initialization flag
+static std::once_flag kfd_nodes_initialized;
+static std::map<uint64_t, std::shared_ptr<amd::smi::KFDNode>> cached_nodes;
+static uint32_t cached_smallest_node_id = std::numeric_limits<uint32_t>::max();
+
 amdsmi_status_t
 amdsmi_get_gpu_enumeration_info(amdsmi_processor_handle processor_handle,
                                 amdsmi_enumeration_info_t *info){
@@ -733,25 +738,26 @@ amdsmi_get_gpu_enumeration_info(amdsmi_processor_handle processor_handle,
     info->drm_render = gpu_device->get_drm_render_minor();
 
     // Retrieve HIP ID (difference from the smallest node ID) and HSA ID
-    std::map<uint64_t, std::shared_ptr<amd::smi::KFDNode>> nodes;
-    if (amd::smi::DiscoverKFDNodes(&nodes) == 0) {
-        uint32_t smallest_node_id = std::numeric_limits<uint32_t>::max();
-        for (const auto& node_pair : nodes) {
-            uint32_t node_id = 0;
-            if (node_pair.second->get_node_id(&node_id) == 0) {
-                smallest_node_id = std::min(smallest_node_id, node_id);
+    // Initialize KFD nodes once
+    std::call_once(kfd_nodes_initialized, []() {
+        if (amd::smi::DiscoverKFDNodes(&cached_nodes) == 0) {
+            for (const auto& node_pair : cached_nodes) {
+                uint32_t node_id = 0;
+                if (node_pair.second->get_node_id(&node_id) == 0) {
+                    cached_smallest_node_id = std::min(cached_smallest_node_id, node_id);
+                }
             }
         }
+    });
 
-        // Default to 0xffffffff as not supported
-        info->hsa_id = std::numeric_limits<uint32_t>::max();
-        info->hip_id = std::numeric_limits<uint32_t>::max();
-        amdsmi_kfd_info_t kfd_info;
-        status = amdsmi_get_gpu_kfd_info(processor_handle, &kfd_info);
-        if (status == AMDSMI_STATUS_SUCCESS) {
-            info->hsa_id = kfd_info.node_id;
-            info->hip_id = kfd_info.node_id - smallest_node_id;
-        }
+    // Default to 0xffffffff as not supported
+    info->hsa_id = std::numeric_limits<uint32_t>::max();
+    info->hip_id = std::numeric_limits<uint32_t>::max();
+    amdsmi_kfd_info_t kfd_info;
+    status = amdsmi_get_gpu_kfd_info(processor_handle, &kfd_info);
+    if (status == AMDSMI_STATUS_SUCCESS) {
+        info->hsa_id = kfd_info.node_id;
+        info->hip_id = kfd_info.node_id - cached_smallest_node_id;
     }
 
     // Retrieve HIP UUID

--- a/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
@@ -115,7 +115,7 @@ pthread_mutex_t* AMDSmiGPUDevice::get_mutex() {
 }
 
 // cache the compute process list for the device
-static std::atomic<std::chrono::steady_clock::time_point> last_compute_process_list_update_time = {};
+static std::atomic<std::chrono::steady_clock::time_point> last_compute_process_list_update_time{std::chrono::steady_clock::time_point{}};
 static const std::chrono::milliseconds compute_process_list_cache_duration = std::chrono::milliseconds(500); // 500 ms
 static std::mutex compute_process_list_mutex;
 static uint32_t num_running_processes = 0;

--- a/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
@@ -24,6 +24,7 @@
 #include <unordered_set>
 #include <dirent.h>
 #include <sys/types.h>
+#include <atomic>
 
 #include "amd_smi/impl/amd_smi_gpu_device.h"
 #include "amd_smi/impl/fdinfo.h"
@@ -114,13 +115,11 @@ pthread_mutex_t* AMDSmiGPUDevice::get_mutex() {
 }
 
 // cache the compute process list for the device
-static std::chrono::steady_clock::time_point last_compute_process_list_update_time;
+static std::atomic<std::chrono::steady_clock::time_point> last_compute_process_list_update_time = {};
 static const std::chrono::milliseconds compute_process_list_cache_duration = std::chrono::milliseconds(500); // 500 ms
 static std::mutex compute_process_list_mutex;
 static uint32_t num_running_processes = 0;
-using RsmiDeviceList_t = uint32_t[];
-using RsmiProcessList_t = rsmi_process_info_t[];
-static std::unique_ptr<RsmiProcessList_t> list_all_processes_ptr = std::make_unique<RsmiProcessList_t>(0);
+static std::unique_ptr<rsmi_process_info_t[]> list_all_processes_ptr = nullptr;
 static std::unordered_map<uint32_t, amdsmi_proc_info_t> process_info_cache_map;
 
 int32_t AMDSmiGPUDevice::get_compute_process_list_impl(GPUComputeProcessList_t& compute_process_list,
@@ -138,8 +137,15 @@ int32_t AMDSmiGPUDevice::get_compute_process_list_impl(GPUComputeProcessList_t& 
      */
     auto status_code(rsmi_status_t::RSMI_STATUS_SUCCESS);
     // only get new data if cache duration has expired
-    std::lock_guard<std::mutex> lock(compute_process_list_mutex);
-    if (std::chrono::steady_clock::now() - last_compute_process_list_update_time > compute_process_list_cache_duration) {
+    if (std::chrono::steady_clock::now() - last_compute_process_list_update_time.load() > compute_process_list_cache_duration) {
+        // double-check locking pattern here
+        std::lock_guard<std::mutex> lock(compute_process_list_mutex);
+        if (std::chrono::steady_clock::now() - last_compute_process_list_update_time.load() <= compute_process_list_cache_duration) {
+            // another thread already updated the data while we were waiting for the lock
+            // so just return the existing data
+            return rsmi_status_t::RSMI_STATUS_SUCCESS;
+        }
+
         // Clear the process info cache when refreshing
         process_info_cache_map.clear();
 
@@ -151,10 +157,10 @@ int32_t AMDSmiGPUDevice::get_compute_process_list_impl(GPUComputeProcessList_t& 
         /**
          *  Make a type safe pointer, then
          *
-         * second call to rsmi_compute_process_info_get() g
+         * second call to rsmi_compute_process_info_get() to get the actual data into
          *  the allocated rsmi_process_info_t array.
          */
-        list_all_processes_ptr = std::make_unique<RsmiProcessList_t>(num_running_processes);
+        list_all_processes_ptr = std::make_unique<rsmi_process_info_t[]>(num_running_processes);
 
         status_code = rsmi_compute_process_info_get(list_all_processes_ptr.get(), &num_running_processes);
         if (status_code != rsmi_status_t::RSMI_STATUS_SUCCESS) {
@@ -232,7 +238,7 @@ int32_t AMDSmiGPUDevice::get_compute_process_list_impl(GPUComputeProcessList_t& 
     auto update_list_by_running_device = [&](rsmi_process_info_t rsmi_proc_info) {
         // Get all devices running this process into list_device_ptr
         auto status_result(true);
-        std::unique_ptr<RsmiDeviceList_t> list_device_ptr = std::make_unique<RsmiDeviceList_t>(num_running_devices);
+        std::unique_ptr<uint32_t[]> list_device_ptr = std::make_unique<uint32_t[]>(num_running_devices);
         list_device_allocation_size = num_running_devices;
         auto status_code = rsmi_compute_process_gpus_get(rsmi_proc_info.process_id, list_device_ptr.get(), &list_device_allocation_size);
         if (status_code != rsmi_status_t::RSMI_STATUS_SUCCESS) {
@@ -273,8 +279,8 @@ int32_t AMDSmiGPUDevice::get_compute_process_list_impl(GPUComputeProcessList_t& 
     for (auto process_idx = uint32_t(0); process_idx < num_running_processes; ++process_idx) {
         if (list_type == ComputeProcessListType_t::kAllProcesses ||
             list_type == ComputeProcessListType_t::kAllProcessesOnDevice) {
-            if (update_list_by_running_device(list_all_processes_ptr[process_idx])) {
-            }
+                std::lock_guard<std::mutex> lock(compute_process_list_mutex);
+                update_list_by_running_device(list_all_processes_ptr[process_idx]);
         }
     }
 

--- a/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
@@ -113,6 +113,16 @@ pthread_mutex_t* AMDSmiGPUDevice::get_mutex() {
     return amd::smi::GetMutex(gpu_id_);
 }
 
+// cache the compute process list for the device
+static std::chrono::steady_clock::time_point last_compute_process_list_update_time;
+static const std::chrono::milliseconds compute_process_list_cache_duration = std::chrono::milliseconds(500); // 500 ms
+static std::mutex compute_process_list_mutex;
+static uint32_t num_running_processes = 0;
+using RsmiDeviceList_t = uint32_t[];
+using RsmiProcessList_t = rsmi_process_info_t[];
+static std::unique_ptr<RsmiProcessList_t> list_all_processes_ptr = std::make_unique<RsmiProcessList_t>(0);
+static std::unordered_map<uint32_t, amdsmi_proc_info_t> process_info_cache_map;
+
 int32_t AMDSmiGPUDevice::get_compute_process_list_impl(GPUComputeProcessList_t& compute_process_list,
                                                        ComputeProcessListType_t list_type)
 {
@@ -127,30 +137,35 @@ int32_t AMDSmiGPUDevice::get_compute_process_list_impl(GPUComputeProcessList_t& 
      *  rsmi_process_info_t currently running on the system.
      */
     auto status_code(rsmi_status_t::RSMI_STATUS_SUCCESS);
-    auto num_running_processes = uint32_t(0);
+    // only get new data if cache duration has expired
+    std::lock_guard<std::mutex> lock(compute_process_list_mutex);
+    if (std::chrono::steady_clock::now() - last_compute_process_list_update_time > compute_process_list_cache_duration) {
+        // Clear the process info cache when refreshing
+        process_info_cache_map.clear();
 
-    status_code = rsmi_compute_process_info_get(nullptr, &num_running_processes);
-    if ((status_code != rsmi_status_t::RSMI_STATUS_SUCCESS) || (num_running_processes <= 0)) {
-        return status_code;
-    }
+        status_code = rsmi_compute_process_info_get(nullptr, &num_running_processes);
+        if ((status_code != rsmi_status_t::RSMI_STATUS_SUCCESS) || (num_running_processes <= 0)) {
+            return status_code;
+        }
 
-    /**
-     *  Make a type safe pointer, then
-     *
-     * second call to rsmi_compute_process_info_get() g
-     *  the allocated rsmi_process_info_t array.
-     */
-    using RsmiDeviceList_t = uint32_t[];
-    using RsmiProcessList_t = rsmi_process_info_t[];
-    std::unique_ptr<RsmiProcessList_t> list_all_processes_ptr = std::make_unique<RsmiProcessList_t>(num_running_processes);
+        /**
+         *  Make a type safe pointer, then
+         *
+         * second call to rsmi_compute_process_info_get() g
+         *  the allocated rsmi_process_info_t array.
+         */
+        list_all_processes_ptr = std::make_unique<RsmiProcessList_t>(num_running_processes);
 
-    status_code = rsmi_compute_process_info_get(list_all_processes_ptr.get(), &num_running_processes);
-    if (status_code != rsmi_status_t::RSMI_STATUS_SUCCESS) {
-        return status_code;
-    }
+        status_code = rsmi_compute_process_info_get(list_all_processes_ptr.get(), &num_running_processes);
+        if (status_code != rsmi_status_t::RSMI_STATUS_SUCCESS) {
+            return status_code;
+        }
 
-    if (num_running_processes <= 0) {
-        return rsmi_status_t::RSMI_STATUS_SUCCESS; // No processes running
+        if (num_running_processes <= 0) {
+            return rsmi_status_t::RSMI_STATUS_SUCCESS; // No processes running
+        }
+
+        last_compute_process_list_update_time = std::chrono::steady_clock::now();
     }
 
     /**
@@ -228,11 +243,21 @@ int32_t AMDSmiGPUDevice::get_compute_process_list_impl(GPUComputeProcessList_t& 
         for (auto device_idx = uint32_t(0); device_idx < list_device_allocation_size; ++device_idx) {
             // Is this device running this process?
             if (list_device_ptr[device_idx] == get_gpu_id()) {
-                std::unordered_set<uint64_t> gpu_set;
-                gpu_set.insert(get_kfd_gpu_id());
-                GetProcessInfoForPID(rsmi_proc_info.process_id, &rsmi_proc_info, &gpu_set);
                 amdsmi_proc_info_t tmp_amdsmi_proc_info{};
-                get_process_info(rsmi_proc_info, tmp_amdsmi_proc_info);
+
+                auto cached_amdsmi_proc = process_info_cache_map.find(rsmi_proc_info.process_id);
+                if (cached_amdsmi_proc != process_info_cache_map.end()) {
+                    // Use cached info
+                    tmp_amdsmi_proc_info = cached_amdsmi_proc->second;
+                }
+                else {
+                    // Need to get new info from system
+                    std::unordered_set<uint64_t> gpu_set;
+                    gpu_set.insert(get_kfd_gpu_id());
+                    GetProcessInfoForPID(rsmi_proc_info.process_id, &rsmi_proc_info, &gpu_set);
+                    get_process_info(rsmi_proc_info, tmp_amdsmi_proc_info);
+                    process_info_cache_map[rsmi_proc_info.process_id] = tmp_amdsmi_proc_info;
+                }
                 compute_process_list.emplace(rsmi_proc_info.process_id, tmp_amdsmi_proc_info);
            }
         }


### PR DESCRIPTION
## Motivation

When devices are partitioned such that there become greater than 10 devices, KFD Node enumeration and process listing for each device become prohibitively expensive.

## Technical Details

Implemented caching of KFD node enumeration to improve performance.

## JIRA ID

SWDEV-569899

## Test Plan


## Test Result


## Submission Checklist


