### PR TITLE
[SWDEV-570457] Fix Python 3.8/3.7 typing errors

### DIFF
--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -5578,7 +5578,7 @@ def amdsmi_set_gpu_ptl_state(
 
 def amdsmi_get_gpu_ptl_formats(
     processor_handle: processor_handle_t
-    ) -> tuple[int, int]:
+    ) -> Tuple[int, int]:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
     data_format1 = amdsmi_wrapper.amdsmi_ptl_data_format_t()


### PR DESCRIPTION
Changes:
  - Fixed `amd-smi` showing:
```console
  $ amd-smi
Traceback (most recent call last):
  File "/opt/rocm/bin/amd-smi", line 53, in <module>
    from amdsmi_init import *
  File "/opt/rocm/libexec/amdsmi_cli/amdsmi_init.py", line 38, in <module>
    from amdsmi import amdsmi_interface, amdsmi_exception
  File "/usr/local/lib/python3.8/dist-packages/amdsmi/__init__.py", line 24, in <module>
    from .amdsmi_interface import amdsmi_init
  File "/usr/local/lib/python3.8/dist-packages/amdsmi/amdsmi_interface.py", line 5581, in <module>
    ) -> tuple[int, int]:
TypeError: 'type' object is not subscriptable
```
  This was a python3.8 issue, which is now resolved by using
  `Tuple[int, int]` typing for Python 3.8 compatibility.

## Motivation
Running `amd-smi version --loglevel debug` fails immediately with a TypeError originating from amdsmi_interface.py using PEP 585-type annotations (tuple[int, int]) 

This impacts all amd-smi CLI calls in Python environments less than Python 3.9. 

<img width="787" height="357" alt="image" src="https://github.com/user-attachments/assets/b47b51d3-e8fc-42e6-a15b-69445b1129cb" />

## Technical Details

  [This commit](https://github.com/ROCm/rocm-systems/commit/422253f871a9025469bc10c947e9077423a0402f) used a newer typing interface, which is not supported in earlier Python versions. The issue, which is now resolved by using
  `Tuple[int, int]` typing for Python 3.8 compatibility.

## JIRA ID
Resolves SWDEV-570457

## Test Plan
- Run amd-smi CLI tests


## Test Result

<img width="805" height="501" alt="image" src="https://github.com/user-attachments/assets/62adeb2d-b7b1-45b0-a8f6-f4abe06b7073" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
