### PR TITLE
Fix rocprofv3 pmc crash on gfx1151 (#2169)

### DIFF
--- a/projects/aqlprofile/src/core/pm4_factory.h
+++ b/projects/aqlprofile/src/core/pm4_factory.h
@@ -412,11 +412,13 @@ inline bool Pm4Factory::CheckConcurrent(const profile_t* profile) {
 
 // Return GPU id for a given agent
 inline gpu_id_t Pm4Factory::GetGpuId(std::string_view gfx_ip) {
+  // More specific GPU IDs must come before less specific IDs.
   std::vector<std::pair<std::string, gpu_id_t>> gfxip_map = {
       {"gfx908", MI100_GPU_ID}, {"gfx90a", MI200_GPU_ID}, {"gfx900", GFX9_GPU_ID},
       {"gfx902", GFX9_GPU_ID},  {"gfx906", GFX9_GPU_ID},  {"gfx94", MI300_GPU_ID},
-      {"gfx95", MI350_GPU_ID},  {"gfx10", GFX10_GPU_ID},  {"gfx11", GFX11_GPU_ID},
-      {"gfx115", GFX115X_GPU_ID}, {"gfx12", GFX12_GPU_ID},
+      {"gfx95", MI350_GPU_ID},  {"gfx10", GFX10_GPU_ID},
+      {"gfx115", GFX115X_GPU_ID}, {"gfx11", GFX11_GPU_ID},
+      {"gfx12", GFX12_GPU_ID},
   };
 
   for (const auto& [name, id] : gfxip_map) {

--- a/projects/aqlprofile/src/util/hsa_rsrc_factory.cpp
+++ b/projects/aqlprofile/src/util/hsa_rsrc_factory.cpp
@@ -46,11 +46,11 @@
 
 // Callback function to get available in the system agents
 hsa_status_t HsaRsrcFactory::GetHsaAgentsCallback(hsa_agent_t agent, void* data) {
-  hsa_status_t status = HSA_STATUS_ERROR;
   HsaRsrcFactory* hsa_rsrc = reinterpret_cast<HsaRsrcFactory*>(data);
-  const AgentInfo* agent_info = hsa_rsrc->AddAgentInfo(agent);
-  if (agent_info != NULL) status = HSA_STATUS_SUCCESS;
-  return status;
+  // AddAgentInfo may return NULL for unsupported agent types (e.g., NPU)
+  // We should continue iterating regardless
+  hsa_rsrc->AddAgentInfo(agent);
+  return HSA_STATUS_SUCCESS;
 }
 
 // This function checks to see if the provided

--- a/projects/aqlprofile/src/util/hsa_rsrc_factory.cpp
+++ b/projects/aqlprofile/src/util/hsa_rsrc_factory.cpp
@@ -47,8 +47,8 @@
 // Callback function to get available in the system agents
 hsa_status_t HsaRsrcFactory::GetHsaAgentsCallback(hsa_agent_t agent, void* data) {
   HsaRsrcFactory* hsa_rsrc = reinterpret_cast<HsaRsrcFactory*>(data);
-  // AddAgentInfo may return NULL for unsupported agent types (e.g., NPU)
-  // We should continue iterating regardless
+  // AddAgentInfo may return NULL for unsupported agent types (e.g., NPU).
+  // We should continue iterating regardless.
   hsa_rsrc->AddAgentInfo(agent);
   return HSA_STATUS_SUCCESS;
 }

--- a/projects/rocprofiler/src/util/hsa_rsrc_factory.cpp
+++ b/projects/rocprofiler/src/util/hsa_rsrc_factory.cpp
@@ -73,11 +73,11 @@ static const char* cpp_demangle(const char* symname) {
 
 // Callback function to get available in the system agents
 hsa_status_t HsaRsrcFactory::GetHsaAgentsCallback(hsa_agent_t agent, void* data) {
-  hsa_status_t status = HSA_STATUS_ERROR;
   HsaRsrcFactory* hsa_rsrc = reinterpret_cast<HsaRsrcFactory*>(data);
-  const AgentInfo* agent_info = hsa_rsrc->AddAgentInfo(agent);
-  if (agent_info != nullptr) status = HSA_STATUS_SUCCESS;
-  return status;
+  // AddAgentInfo may return NULL for unsupported agent types (e.g., NPU).
+  // We should continue iterating regardless.
+  hsa_rsrc->AddAgentInfo(agent);
+  return HSA_STATUS_SUCCESS;
 }
 
 // This function checks to see if the provided

--- a/projects/rocprofiler/test/util/hsa_rsrc_factory.cpp
+++ b/projects/rocprofiler/test/util/hsa_rsrc_factory.cpp
@@ -56,11 +56,11 @@ static const char* cpp_demangle(const char* symname) {
 
 // Callback function to get available in the system agents
 hsa_status_t HsaRsrcFactory::GetHsaAgentsCallback(hsa_agent_t agent, void* data) {
-  hsa_status_t status = HSA_STATUS_ERROR;
   HsaRsrcFactory* hsa_rsrc = reinterpret_cast<HsaRsrcFactory*>(data);
-  const AgentInfo* agent_info = hsa_rsrc->AddAgentInfo(agent);
-  if (agent_info != NULL) status = HSA_STATUS_SUCCESS;
-  return status;
+  // AddAgentInfo may return NULL for unsupported agent types (e.g., NPU).
+  // We should continue iterating regardless.
+  hsa_rsrc->AddAgentInfo(agent);
+  return HSA_STATUS_SUCCESS;
 }
 
 // This function checks to see if the provided


### PR DESCRIPTION
## Motivation

Fixes the crash described in #2169 when capturing pmc on gfx1151.

## Technical Details

This PR addresses two issues for gfx1151:
- In `Pm4Factory::GetGpuId`, the first matching entry from the gfxip_map vector is taken, but "gfx115" came after "gfx11" in that list.
- `HsaRsrcFactory::GetHsaAgentsCallback` would fail when it saw an NPU agent. Now it ignores it and continues.

Please advice on how to properly unit test this. Thanks!

## JIRA ID

Github #2169

## Test Plan

Run the reproducer from #2169

## Test Result

Passed with
```
Function    MBytes/sec  Min (sec)   Max         Average     
Copy        244216.061  0.00220     0.00230     0.00221     
Mul         236772.570  0.00227     0.00238     0.00228     
Add         232917.010  0.00346     0.00357     0.00347     
Triad       234737.208  0.00343     0.00351     0.00344     
Dot         239368.038  0.00224     0.00231     0.00225     
W20251204 04:23:43.175435 125262329387712 simple_timer.cpp:55] [rocprofv3] '/tmp/rocprofv3-crash/BabelStream/build/hip-stream' ::     1.869773 sec
W20251204 04:23:43.183237 125262329387712 generateRocpd.cpp:582] writing SQL database for process 14714 on node 1112378664
E20251204 04:23:43.183581 125262329387712 generateRocpd.cpp:605] Opened result file: /scratch/xsjstrhalo14/14714_results.db (UUID=00000079-947b-747b-a428-1793eff7b799)
W20251204 04:23:43.377191 125262329387712 simple_timer.cpp:55] SQLite3 generation :: rocpd_string             ::     0.006347 sec
W20251204 04:23:43.380683 125262329387712 simple_timer.cpp:55] SQLite3 generation :: rocpd_info_node          ::     0.003477 sec
W20251204 04:23:43.383677 125262329387712 simple_timer.cpp:55] SQLite3 generation :: rocpd_info_process       ::     0.002988 sec
W20251204 04:23:43.393087 125262329387712 simple_timer.cpp:55] SQLite3 generation :: rocpd_info_agent         ::     0.003803 sec
W20251204 04:23:43.396785 125262329387712 simple_timer.cpp:55] SQLite3 generation :: rocpd_info_pmc           ::     0.003689 sec
W20251204 04:23:43.400782 125262329387712 simple_timer.cpp:55] SQLite3 generation :: rocpd kernel info        ::     0.003990 sec
W20251204 04:23:43.400790 125262329387712 simple_timer.cpp:55] SQLite3 generation :: rocpd_region             ::     0.000002 sec
W20251204 04:23:43.412974 125262329387712 simple_timer.cpp:55] SQLite3 generation :: rocpd_kernel_dispatch    ::     0.012180 sec
W20251204 04:23:43.421500 125262329387712 simple_timer.cpp:55] SQLite3 generation :: rocpd_pmc_event          ::     0.008515 sec
W20251204 04:23:43.421530 125262329387712 simple_timer.cpp:55] SQLite3 generation :: rocpd_memory_copy        ::     0.000000 sec
W20251204 04:23:43.421545 125262329387712 simple_timer.cpp:55] SQLite3 generation :: rocpd_memory_allocate    ::     0.000001 sec
W20251204 04:23:43.421774 125262329387712 simple_timer.cpp:55] SQLite3 generation :: SQL indexing             ::     0.000203 sec
W20251204 04:23:43.422253 125262329387712 simple_timer.cpp:55] SQLite3 generation :: total                    ::     0.239016 sec
W20251204 04:23:43.423705 125262329387712 simple_timer.cpp:55] [rocprofv3] output generation ::     0.247771 sec
W20251204 04:23:43.423742 125262329387712 simple_timer.cpp:55] [rocprofv3] tool finalization ::     0.247812 sec
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
