### PR TITLE
Take into account thread-local mode in checks for valid capture

### DIFF
--- a/projects/clr/hipamd/src/hip_stream.cpp
+++ b/projects/clr/hipamd/src/hip_stream.cpp
@@ -153,12 +153,14 @@ bool Stream::StreamCaptureOngoing(hipStream_t hStream) {
       return false;
     }
     // If any stream in current/concurrent thread is capturing in global mode
-    amd::ScopedLock lock(g_captureStreamsLock);
-    if (!g_captureStreams.empty()) {
-      for (auto stream : hip::g_captureStreams) {
-        stream->SetCaptureStatus(hipStreamCaptureStatusInvalidated);
+    if (hip::tls.stream_capture_mode_ == hipStreamCaptureModeGlobal) {
+      amd::ScopedLock lock(g_captureStreamsLock);
+      if (!g_captureStreams.empty()) {
+        for (auto stream : hip::g_captureStreams) {
+          stream->SetCaptureStatus(hipStreamCaptureStatusInvalidated);
+        }
+        return true;
       }
-      return true;
     }
     // If any stream in current thread is capturing in ThreadLocal mode
     if (!hip::tls.capture_streams_.empty()) {


### PR DESCRIPTION
## Motivation
This PR addresses https://github.com/ROCm/hip/issues/3876
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
In the case where one thread captures a stream in global capture mode, an action like hipEventQuery on a different thread for a different stream  under thread-local capture mode currently returns hipErrorStreamCaptureUnsupported. 
However In thread-local capture mode sequences in other threads should be ignored.
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
