### PR TITLE
[perf-dkms] Add tracepoint-based time series sampling support

### DIFF
--- a/projects/perf-dkms/src/CMakeLists.txt
+++ b/projects/perf-dkms/src/CMakeLists.txt
@@ -12,6 +12,8 @@ set(KBUILD_BIN_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set(KERNEL_MODULE_SOURCES
     pmu_main.c
     pmu_events.c
+    amdgpu_pmu_trace.c
+    amdgpu_pmu_trace.h
     amdgpu_pmu.h
     pmu_dimension.h
     kfd_test.c
@@ -46,7 +48,7 @@ file(WRITE ${KBUILD_BIN_DIR}/Kbuild
 obj-m := amdgpu_pmu.o
 
 # Include AMD GPU PMU, KFD test, and minimal AQL integration
-amdgpu_pmu-y := pmu_main.o pmu_events.o kfd_test.o \\
+amdgpu_pmu-y := pmu_main.o pmu_events.o amdgpu_pmu_trace.o kfd_test.o \\
               aql_perf.o aql_packet_ops.o aql_error_recovery.o aql_pmu_integration.o \\
               aql_c/arch_creator.o aql_c/gfx12_creator.o \\
               aql_c/pm4_packets.o aql_c/counter_registry.o aql_c/gfx12_events.o \\
@@ -69,6 +71,7 @@ add_custom_command(
     DEPENDS
         ${KBUILD_SRC_DIR}/pmu_main.c
         ${KBUILD_SRC_DIR}/pmu_events.c
+        ${KBUILD_SRC_DIR}/amdgpu_pmu_trace.c
         ${KBUILD_SRC_DIR}/kfd_test.c
         ${KBUILD_SRC_DIR}/aql_perf.c
         ${KBUILD_SRC_DIR}/aql_packet_ops.c

--- a/projects/perf-dkms/src/amdgpu_pmu_trace.c
+++ b/projects/perf-dkms/src/amdgpu_pmu_trace.c
@@ -1,0 +1,14 @@
+/*
+ * amdgpu_pmu_trace.c - Tracepoint definitions for AMDGPU PMU
+ *
+ * This file creates the actual tracepoint code by defining CREATE_TRACE_POINTS
+ * before including the tracepoint header. This must be done exactly once in
+ * the entire kernel module.
+ *
+ * The CREATE_TRACE_POINTS macro causes the TRACE_EVENT() macros to generate
+ * the actual tracepoint functions (e.g., trace_counter_sample()) instead of
+ * just declaring them.
+ */
+
+#define CREATE_TRACE_POINTS
+#include "amdgpu_pmu_trace.h"

--- a/projects/perf-dkms/src/amdgpu_pmu_trace.h
+++ b/projects/perf-dkms/src/amdgpu_pmu_trace.h
@@ -1,0 +1,61 @@
+/*
+ * amdgpu_pmu_trace.h - Tracepoint definitions for AMDGPU PMU
+ *
+ * This header defines tracepoints for GPU performance counter sampling,
+ * allowing perf record to capture counter samples as trace events.
+ *
+ * Usage:
+ *   perf record -e amdgpu_pmu:counter_sample -a ./app
+ *   perf script
+ */
+
+#undef TRACE_SYSTEM
+#define TRACE_SYSTEM amdgpu_pmu
+
+#if !defined(_AMDGPU_PMU_TRACE_H) || defined(TRACE_HEADER_MULTI_READ)
+#define _AMDGPU_PMU_TRACE_H
+
+#include <linux/tracepoint.h>
+
+/**
+ * counter_sample - Emitted when a GPU counter is sampled
+ * @counter_id: Numeric counter identifier (from counter_id_t enum)
+ * @counter_name: Human-readable counter name (e.g., "SQ_WAVES")
+ * @value: Current counter value
+ * @delta: Change since last sample (for rate calculation)
+ * @timestamp_ns: High-precision timestamp (ktime_get_ns())
+ *
+ * This tracepoint is emitted by the timer handler for each active sampling
+ * event. It provides full visibility into GPU counter behavior over time.
+ *
+ * Example output:
+ *   test_32_waves-1234 [000] 1000.123: amdgpu_pmu:counter_sample: \
+ *       id=30 name=SQ_WAVES value=64 delta=32 ts=1000123456789
+ */
+TRACE_EVENT(counter_sample,
+
+	    TP_PROTO(u32 counter_id, const char *counter_name, u64 value, u64 delta,
+		     u64 timestamp_ns),
+
+	    TP_ARGS(counter_id, counter_name, value, delta, timestamp_ns),
+
+	    TP_STRUCT__entry(__field(u32, counter_id) __string(counter_name, counter_name)
+				     __field(u64, value) __field(u64, delta)
+					     __field(u64, timestamp_ns)),
+
+	    TP_fast_assign(__entry->counter_id = counter_id; __assign_str(counter_name);
+			   __entry->value = value; __entry->delta = delta;
+			   __entry->timestamp_ns = timestamp_ns;),
+
+	    TP_printk("id=%u name=%s value=%llu delta=%llu ts=%llu", __entry->counter_id,
+		      __get_str(counter_name), __entry->value, __entry->delta,
+		      __entry->timestamp_ns));
+
+#endif /* _AMDGPU_PMU_TRACE_H */
+
+/* This part must be outside protection */
+#undef TRACE_INCLUDE_PATH
+#define TRACE_INCLUDE_PATH ../../ src
+#undef TRACE_INCLUDE_FILE
+#define TRACE_INCLUDE_FILE amdgpu_pmu_trace
+#include <trace/define_trace.h>

--- a/projects/perf-dkms/src/aql_packet_ops.c
+++ b/projects/perf-dkms/src/aql_packet_ops.c
@@ -659,6 +659,9 @@ struct aql_measurement *aql_perf_measurement_create(struct aql_perf_session *ses
 	measurement->cached_counter_value = 0;
 	measurement->cache_valid = false;
 
+	/* Initialize tracepoint sampling support */
+	atomic64_set(&measurement->prev_counter_value, 0);
+
 	/* Initialize reference count - starts at 1 for the creator */
 	kref_init(&measurement->refcount);
 

--- a/projects/perf-dkms/src/aql_perf.c
+++ b/projects/perf-dkms/src/aql_perf.c
@@ -245,13 +245,14 @@ static void aql_perf_session_release(struct aql_perf_session *session)
 	{
 		struct aql_measurement *measurement, *tmp;
 		struct list_head local_list;
+		unsigned long flags;
 
 		INIT_LIST_HEAD(&local_list);
 
 		/* Move all measurements to local list to avoid holding spinlock during cleanup */
-		spin_lock(&session->measurement_lock);
+		spin_lock_irqsave(&session->measurement_lock, flags);
 		list_splice_init(&session->active_measurements, &local_list);
-		spin_unlock(&session->measurement_lock);
+		spin_unlock_irqrestore(&session->measurement_lock, flags);
 
 		/* Stop and cleanup each measurement */
 		list_for_each_entry_safe(measurement, tmp, &local_list, list)
@@ -285,13 +286,15 @@ static void aql_perf_session_release(struct aql_perf_session *session)
 	/* Clean up any remaining shared counter refs */
 	{
 		struct shared_counter_ref *ref, *tmp;
-		spin_lock(&session->shared_lock);
+		unsigned long flags;
+
+		spin_lock_irqsave(&session->shared_lock, flags);
 		list_for_each_entry_safe(ref, tmp, &session->shared_counters, list)
 		{
 			list_del(&ref->list);
 			kfree(ref);
 		}
-		spin_unlock(&session->shared_lock);
+		spin_unlock_irqrestore(&session->shared_lock, flags);
 	}
 
 	/* Free counter buffers and architectures for all GPUs */
@@ -378,15 +381,19 @@ struct aql_perf_session *aql_perf_session_create(void)
  * aql_perf_session_get - Increment session reference count
  * @session: Session to reference
  *
- * Note: Currently only one global session exists, so this refcounting
- * infrastructure is not strictly necessary. However, it provides safety
- * for potential future designs with multiple sessions or session sharing
- * between different subsystems.
+ * Uses refcount_inc_not_zero() to safely increment the reference count
+ * only if it's not already zero (session being destroyed). This is critical
+ * for RCU-protected access where readers may encounter a session in the
+ * process of being destroyed.
+ *
+ * Returns: true if reference acquired, false if session is being destroyed
  */
-void aql_perf_session_get(struct aql_perf_session *session)
+bool aql_perf_session_get(struct aql_perf_session *session)
 {
-	if (session)
-		refcount_inc(&session->ref_count);
+	if (!session)
+		return false;
+
+	return refcount_inc_not_zero(&session->ref_count);
 }
 
 /**

--- a/projects/perf-dkms/src/aql_perf.h
+++ b/projects/perf-dkms/src/aql_perf.h
@@ -227,6 +227,9 @@ struct aql_measurement {
 	bool cache_valid; /* Whether cached value is valid */
 	bool pending_destroy; /* Measurement should be freed after async work */
 
+	/* Tracepoint sampling support - delta tracking */
+	atomic64_t prev_counter_value; /* Previous value for delta calculation */
+
 	/* Reference counting to prevent use-after-free with work items */
 	struct kref refcount; /* Reference count for safe async operations */
 };
@@ -283,7 +286,7 @@ struct workqueue_struct *aql_get_global_workqueue(void);
 struct aql_perf_session *aql_perf_session_create(void);
 int aql_perf_session_initialize(struct aql_perf_session *session);
 void aql_perf_session_destroy(struct aql_perf_session *session);
-void aql_perf_session_get(struct aql_perf_session *session);
+bool aql_perf_session_get(struct aql_perf_session *session);
 void aql_perf_session_put(struct aql_perf_session *session);
 
 /* GPU Discovery and Setup */

--- a/projects/perf-dkms/src/aql_pmu_integration.c
+++ b/projects/perf-dkms/src/aql_pmu_integration.c
@@ -12,14 +12,16 @@
 #include <linux/perf_event.h>
 #include <linux/atomic.h>
 #include <linux/limits.h>
+#include <linux/rcupdate.h>
+#include <linux/spinlock.h>
 
 #include "aql_perf.h"
 #include "amdgpu_pmu.h"
 #include "pmu_dimension.h"
 
-/* Global AQL session - initialized during module load */
-static struct aql_perf_session *global_aql_session = NULL;
-static struct mutex aql_pmu_mutex;
+/* Global AQL session - RCU-protected for safe access from atomic context */
+static struct aql_perf_session __rcu *global_aql_session = NULL;
+static struct mutex aql_pmu_mutex; /* For writes and non-atomic operations */
 static bool aql_feature_available = false;
 
 /* Global workqueue - shared by all measurements */
@@ -59,30 +61,32 @@ int aql_pmu_init(void)
 	aql_info("Created global workqueue for all measurements");
 
 	/* Create global AQL session */
-	global_aql_session = aql_perf_session_create();
-	if (IS_ERR(global_aql_session)) {
-		ret = PTR_ERR(global_aql_session);
+	struct aql_perf_session *session = aql_perf_session_create();
+	if (IS_ERR(session)) {
+		ret = PTR_ERR(session);
 		aql_err("Failed to create global AQL session: %d", ret);
-		global_aql_session = NULL;
 		destroy_workqueue(aql_global_workqueue);
 		aql_global_workqueue = NULL;
 		return ret;
 	}
 
 	/* Initialize the session */
-	ret = aql_perf_session_initialize(global_aql_session);
+	ret = aql_perf_session_initialize(session);
 	if (ret) {
 		aql_err("Failed to initialize global AQL session: %d", ret);
-		aql_perf_session_put(global_aql_session);
-		global_aql_session = NULL;
+		aql_perf_session_put(session);
 		destroy_workqueue(aql_global_workqueue);
 		aql_global_workqueue = NULL;
 		return ret;
 	}
 
+	/* Publish session via RCU */
+	mutex_lock(&aql_pmu_mutex);
+	rcu_assign_pointer(global_aql_session, session);
 	aql_feature_available = true;
-	aql_info("AQL PMU integration initialized successfully with %u GPUs",
-		 global_aql_session->num_gpus);
+	mutex_unlock(&aql_pmu_mutex);
+
+	aql_info("AQL PMU integration initialized successfully with %u GPUs", session->num_gpus);
 
 	return 0;
 }
@@ -118,18 +122,22 @@ void aql_pmu_flush_all_measurements(void)
  */
 void aql_pmu_cleanup(void)
 {
+	struct aql_perf_session *session;
+
 	aql_info("Cleaning up AQL PMU integration");
 
+	/* Clear session pointer under mutex */
 	mutex_lock(&aql_pmu_mutex);
-
-	if (global_aql_session) {
-		aql_perf_session_put(global_aql_session);
-		global_aql_session = NULL;
-	}
-
+	session = rcu_dereference_protected(global_aql_session, lockdep_is_held(&aql_pmu_mutex));
+	rcu_assign_pointer(global_aql_session, NULL);
 	aql_feature_available = false;
-
 	mutex_unlock(&aql_pmu_mutex);
+
+	/* Wait for all RCU readers to finish before releasing session */
+	if (session) {
+		synchronize_rcu();
+		aql_perf_session_put(session);
+	}
 
 	/* Destroy global workqueue - safe because session is already released
      * and timer is already cancelled (done in pmu_main.c before calling this) */
@@ -149,12 +157,13 @@ void aql_pmu_cleanup(void)
  */
 bool aql_pmu_is_available(void)
 {
+	struct aql_perf_session *session;
 	bool available;
 
-	mutex_lock(&aql_pmu_mutex);
-	available = aql_feature_available && global_aql_session &&
-		    (global_aql_session->state == SESSION_ACTIVE);
-	mutex_unlock(&aql_pmu_mutex);
+	rcu_read_lock();
+	session = rcu_dereference(global_aql_session);
+	available = aql_feature_available && session && (session->state == SESSION_ACTIVE);
+	rcu_read_unlock();
 
 	return available;
 }
@@ -189,6 +198,7 @@ static bool aql_pmu_should_use_hardware(struct perf_event *event)
  * @event: Perf event to map
  *
  * Internal version that assumes aql_pmu_mutex is already held by caller.
+ * Uses rcu_dereference_protected since mutex provides necessary protection.
  *
  * Returns: GPU device ID (e.g., 7410), or U32_MAX on error
  */
@@ -202,7 +212,7 @@ static uint32_t aql_pmu_get_gpu_id_for_event_locked(struct perf_event *event)
 		return U32_MAX;
 	}
 
-	session = global_aql_session;
+	session = rcu_dereference_protected(global_aql_session, lockdep_is_held(&aql_pmu_mutex));
 	cpu = event->cpu;
 
 	aql_debug("get_gpu_id_for_event: cpu=%d, num_gpus=%u", cpu,
@@ -296,22 +306,25 @@ int aql_pmu_event_init(struct perf_event *event, const struct pmu_dimension_coor
 
 	aql_debug("Before mutex_lock(&aql_pmu_mutex)");
 	mutex_lock(&aql_pmu_mutex);
-	aql_debug("After mutex_lock(&aql_pmu_mutex), global_aql_session=%p", global_aql_session);
 
-	if (!global_aql_session) {
+	struct aql_perf_session *session =
+		rcu_dereference_protected(global_aql_session, lockdep_is_held(&aql_pmu_mutex));
+	aql_debug("After mutex_lock(&aql_pmu_mutex), session=%p", session);
+
+	if (!session) {
 		aql_debug("Global AQL session is NULL, falling back to simulation");
 		mutex_unlock(&aql_pmu_mutex);
 		return -EOPNOTSUPP;
 	}
 
-	aql_debug("About to check session state, session=%p", global_aql_session);
-	if (global_aql_session->state != SESSION_ACTIVE) {
+	aql_debug("About to check session state, session=%p", session);
+	if (session->state != SESSION_ACTIVE) {
 		aql_debug("AQL session state is %d (not active), falling back to simulation",
-			  global_aql_session->state);
+			  session->state);
 		mutex_unlock(&aql_pmu_mutex);
 		return -EOPNOTSUPP;
 	}
-	aql_debug("Session is active, state=%d", global_aql_session->state);
+	aql_debug("Session is active, state=%d", session->state);
 
 	/* Select GPU for this event */
 	aql_debug("Before aql_pmu_select_gpu");
@@ -325,7 +338,7 @@ int aql_pmu_event_init(struct perf_event *event, const struct pmu_dimension_coor
 
 	/* Create AQL measurement */
 	aql_debug("Before aql_perf_measurement_create for GPU %u", gpu_id);
-	measurement = aql_perf_measurement_create(global_aql_session, gpu_id, event);
+	measurement = aql_perf_measurement_create(session, gpu_id, event);
 	aql_debug("After aql_perf_measurement_create, measurement=%p", measurement);
 	if (IS_ERR(measurement)) {
 		aql_err("Failed to create AQL measurement: %ld", PTR_ERR(measurement));
@@ -439,6 +452,29 @@ int aql_pmu_event_stop(struct perf_event *event)
 }
 
 /**
+ * __aql_pmu_event_read_internal - Internal read function without logging
+ * @event: Perf event to read
+ *
+ * This is the quiet version used by high-frequency sampling paths (e.g., timer).
+ * No logging to avoid flooding kernel log at 50Hz sampling rate.
+ *
+ * Returns: Counter value
+ */
+static uint64_t __aql_pmu_event_read_internal(struct perf_event *event)
+{
+	struct aql_measurement *measurement;
+
+	if (!event->hw.config_base) {
+		return 0;
+	}
+
+	measurement = (struct aql_measurement *)event->hw.config_base;
+
+	/* Use atomic version to return cached value and schedule refresh */
+	return aql_perf_measurement_read_atomic(measurement);
+}
+
+/**
  * aql_pmu_event_read - Read AQL event counter value
  * @event: Perf event to read
  *
@@ -455,9 +491,10 @@ uint64_t aql_pmu_event_read(struct perf_event *event)
 
 	measurement = (struct aql_measurement *)event->hw.config_base;
 
-	/* Use atomic version to return cached value and schedule refresh */
-	counter_value = aql_perf_measurement_read_atomic(measurement);
+	/* Call internal read function */
+	counter_value = __aql_pmu_event_read_internal(event);
 
+	/* Log results */
 	aql_debug("GPU %u: read=%llu", measurement->gpu_id, counter_value);
 	aql_info("[PMU] ========== aql_pmu_event_read RETURNING: %llu (0x%llx) ==========",
 		 counter_value, counter_value);
@@ -501,11 +538,13 @@ uint64_t aql_pmu_event_read_sync(struct perf_event *event)
  */
 int aql_pmu_get_gpu_count(void)
 {
+	struct aql_perf_session *session;
 	int count;
 
-	mutex_lock(&aql_pmu_mutex);
-	count = global_aql_session ? global_aql_session->num_gpus : 0;
-	mutex_unlock(&aql_pmu_mutex);
+	rcu_read_lock();
+	session = rcu_dereference(global_aql_session);
+	count = session ? session->num_gpus : 0;
+	rcu_read_unlock();
 
 	return count;
 }
@@ -516,9 +555,15 @@ int aql_pmu_get_gpu_count(void)
  * Retrieves the global AQL session and increments its reference count.
  * Caller must call aql_pmu_put_session() when done.
  *
- * Note: Currently returns the single global session. The reference counting
- * is designed for future flexibility if multiple sessions or session lifecycle
- * management becomes necessary.
+ * IMPORTANT: This function is safe to call from atomic context (e.g., timer
+ * callbacks, hard IRQ handlers) because it uses RCU read-side critical
+ * sections instead of mutexes.
+ *
+ * RCU Protocol:
+ * - Readers (this function) use rcu_read_lock/unlock for atomic-safe access
+ * - Writers (init/cleanup) use rcu_assign_pointer and synchronize_rcu
+ * - Reference count is acquired with refcount_inc_not_zero to avoid races
+ *   with session destruction
  *
  * Returns: Global AQL session with incremented refcount, or NULL
  */
@@ -526,11 +571,11 @@ struct aql_perf_session *aql_pmu_get_session(void)
 {
 	struct aql_perf_session *session;
 
-	mutex_lock(&aql_pmu_mutex);
-	session = global_aql_session;
-	if (session)
-		aql_perf_session_get(session);
-	mutex_unlock(&aql_pmu_mutex);
+	rcu_read_lock();
+	session = rcu_dereference(global_aql_session);
+	if (session && !aql_perf_session_get(session))
+		session = NULL; /* Session is being destroyed, don't use it */
+	rcu_read_unlock();
 
 	return session;
 }
@@ -557,24 +602,26 @@ void aql_pmu_put_session(struct aql_perf_session *session)
  */
 void aql_pmu_get_stats(struct aql_perf_stats *stats)
 {
+	struct aql_perf_session *session;
+
 	if (!stats)
 		return;
 
 	aql_perf_get_stats(stats);
 
 	/* Add session-specific stats if available */
-	mutex_lock(&aql_pmu_mutex);
-	if (global_aql_session) {
-		atomic64_add(atomic64_read(&global_aql_session->stats.packets_submitted),
+	rcu_read_lock();
+	session = rcu_dereference(global_aql_session);
+	if (session) {
+		atomic64_add(atomic64_read(&session->stats.packets_submitted),
 			     &stats->packets_submitted);
-		atomic64_add(atomic64_read(&global_aql_session->stats.packets_completed),
+		atomic64_add(atomic64_read(&session->stats.packets_completed),
 			     &stats->packets_completed);
-		atomic64_add(atomic64_read(&global_aql_session->stats.errors_total),
-			     &stats->errors_total);
-		atomic64_add(atomic64_read(&global_aql_session->stats.sessions_created),
+		atomic64_add(atomic64_read(&session->stats.errors_total), &stats->errors_total);
+		atomic64_add(atomic64_read(&session->stats.sessions_created),
 			     &stats->sessions_created);
 	}
-	mutex_unlock(&aql_pmu_mutex);
+	rcu_read_unlock();
 }
 
 EXPORT_SYMBOL_GPL(aql_get_global_workqueue);

--- a/projects/perf-dkms/src/pmu_main.c
+++ b/projects/perf-dkms/src/pmu_main.c
@@ -21,6 +21,7 @@
 #include "aql_perf.h"
 #include "aql_c/counter_registry.h"
 #include "pmu_dimension.h"
+#include "amdgpu_pmu_trace.h"
 
 /* Global PMU instance */
 static struct amdgpu_pmu *amdgpu_pmu_instance;
@@ -42,6 +43,7 @@ static void amdgpu_pmu_del(struct perf_event *event, int flags);
 static void amdgpu_pmu_start(struct perf_event *event, int flags);
 static void amdgpu_pmu_stop(struct perf_event *event, int flags);
 static void amdgpu_pmu_read(struct perf_event *event);
+static void __amdgpu_pmu_read_internal(struct perf_event *event);
 
 /*
  * PMU_FORMAT_ATTR - Define a perf format attribute
@@ -165,6 +167,74 @@ static const struct attribute_group *amdgpu_pmu_attr_groups[] = {
 };
 
 /**
+ * amdgpu_pmu_generate_samples - Update counter values for sampling events
+ * @session: AQL performance session (already looked up by timer handler)
+ *
+ * Called from timer handler - must be atomic-safe.
+ * For sampling events (perf record), the timer ensures counter values are
+ * kept up-to-date by reading from the cache. The perf subsystem will sample
+ * these values at the configured sample frequency via the read() callback.
+ *
+ * Phase 2: Also emits tracepoint events for explicit sample capture with
+ * perf record -e amdgpu_pmu:counter_sample
+ *
+ * Note: Direct perf_event_overflow() is not available to kernel modules as
+ * it's not exported. Instead, we rely on perf's built-in software-based
+ * sampling mechanism which reads counter values via our read() callback.
+ * The timer's job is to keep the cached values fresh.
+ */
+static void amdgpu_pmu_generate_samples(struct aql_perf_session *session)
+{
+	struct aql_measurement *meas;
+	unsigned long flags;
+
+	if (!session)
+		return;
+
+	spin_lock_irqsave(&session->measurement_lock, flags);
+
+	list_for_each_entry(meas, &session->active_measurements, list)
+	{
+		struct perf_event *event = meas->event;
+		const counter_def_t *counter;
+		u64 prev_value, curr_value, delta;
+		u32 counter_id;
+
+		/* Skip if not a valid event */
+		if (!event)
+			continue;
+
+		/* Skip if not a sampling event (sample_period = 0 means counting mode) */
+		if (!is_sampling_event(event))
+			continue;
+
+		/* Update counter value using quiet internal function (no logging).
+		 * This ensures the cached value is fresh when perf subsystem reads it
+		 * for sampling. The actual sampling is handled by perf core. */
+		__amdgpu_pmu_read_internal(event);
+
+		/* Phase 2: Emit tracepoint with counter information and delta */
+		counter_id = (u32)event->attr.config;
+		counter = lookup_counter_by_id((counter_id_t)counter_id);
+		if (!counter) {
+			/* Counter not found - skip tracepoint but continue processing */
+			continue;
+		}
+
+		/* Calculate delta since last sample */
+		curr_value = local64_read(&event->count);
+		prev_value = atomic64_read(&meas->prev_counter_value);
+		delta = curr_value - prev_value;
+		atomic64_set(&meas->prev_counter_value, curr_value);
+
+		/* Emit tracepoint: visible via perf record -e amdgpu_pmu:counter_sample */
+		trace_counter_sample(counter_id, counter->name, curr_value, delta, ktime_get_ns());
+	}
+
+	spin_unlock_irqrestore(&session->measurement_lock, flags);
+}
+
+/**
  * amdgpu_pmu_poll_measurements - Poll active measurements and schedule background reads
  * @session: AQL performance session
  * @wq: Workqueue to schedule work on
@@ -229,16 +299,19 @@ enum hrtimer_restart amdgpu_pmu_timer_handler(struct hrtimer *timer)
 		goto reschedule;
 	}
 
-	/* Get AQL session to poll measurements */
+	/* Get AQL session to poll measurements (lookup once, use for all operations) */
 	session = aql_pmu_get_session();
 	if (!session) {
 		pmu_debug("Timer: No AQL session available\n");
 		goto reschedule;
 	}
 
-	/* Poll all active measurements */
+	/* Poll all active measurements (for perf stat counting mode) */
 	count = amdgpu_pmu_poll_measurements(session, wq);
 	pmu_debug("Timer: Updated %d active measurements\n", count);
+
+	/* Generate samples for sampling events (for perf record sampling mode - Phase 1) */
+	amdgpu_pmu_generate_samples(session);
 
 	aql_pmu_put_session(session);
 
@@ -397,10 +470,32 @@ static int amdgpu_pmu_event_init(struct perf_event *event)
 		return -EINVAL;
 	}
 
-	/* We don't support sampling */
+	/* Allow both counting (sample_period=0) and sampling (sample_period>0) events.
+	 * Sampling is supported via hrtimer-based periodic sampling (Task 1.2). */
 	if (is_sampling_event(event)) {
-		pmu_err("Sampling events not supported\n");
-		return -EOPNOTSUPP;
+		u64 sample_period = event->attr.sample_period;
+
+		pmu_info("Sampling event requested with period %llu\n", sample_period);
+
+		/* Validate sampling period is reasonable */
+		if (sample_period == 0) {
+			pmu_err("Sampling event must have non-zero sample_period\n");
+			return -EINVAL;
+		}
+
+		/* Warn if sample_period is less than our timer period (20ms).
+		 * Users may expect hardware-based sampling with precise period,
+		 * but we use software timer at fixed interval. */
+		if (sample_period < timer_period_ms * 1000000ULL) {
+			pmu_warn(
+				"Sample period %llu ns < timer period %d ms - samples will be at timer rate\n",
+				sample_period, timer_period_ms);
+		}
+
+		/* Mark this event as a sampling event for the timer handler.
+		 * We use hwc->sample_period (set by perf core) to distinguish
+		 * sampling events from counting events at runtime. */
+		pmu_debug("Event marked for sampling mode (sample_period=%llu)\n", sample_period);
 	}
 
 	/* GPU PMU doesn't support inherit (GPU counters aren't per-process) */
@@ -652,6 +747,21 @@ static void amdgpu_pmu_stop(struct perf_event *event, int flags)
 	pmu_err("stop: Non-AQL event detected, config=0x%llx\n", event->attr.config);
 }
 
+/* Internal read function - no logging, safe for high-frequency calls */
+static void __amdgpu_pmu_read_internal(struct perf_event *event)
+{
+	struct hw_perf_event *hwc = &event->hw;
+
+	/* Check if this is an AQL hardware event */
+	if (hwc->config_base != 0) {
+		uint64_t counter_value = aql_pmu_event_read(event);
+		local64_set(&event->count, counter_value);
+		return;
+	}
+
+	/* Only AQL hardware events are supported - silently return for others */
+}
+
 /* PMU callback: Read event counter */
 static void amdgpu_pmu_read(struct perf_event *event)
 {
@@ -663,25 +773,20 @@ static void amdgpu_pmu_read(struct perf_event *event)
 	pmu_info("read: ENTRY - config=0x%llx, old_count=%llu, hwc->config_base=0x%lx\n",
 		 event->attr.config, (unsigned long long)old_count, hwc->config_base);
 
-	/* Check if this is an AQL hardware event */
+	/* Call internal read function */
+	__amdgpu_pmu_read_internal(event);
+
+	/* Log results */
+	new_count = local64_read(&event->count);
 	if (hwc->config_base != 0) {
-		pmu_info("read: Reading AQL hardware counter for config=0x%llx\n",
-			 event->attr.config);
-		uint64_t counter_value = aql_pmu_event_read(event);
-		pmu_info("read: ========== SETTING event->count = %llu (0x%llx) ==========\n",
-			 counter_value, counter_value);
-		local64_set(&event->count, counter_value);
-		new_count = local64_read(&event->count);
 		pmu_info("read: AQL counter read complete - old=%llu, new=%llu, delta=%lld\n",
 			 (unsigned long long)old_count, (unsigned long long)new_count,
 			 (long long)(new_count - old_count));
 		pmu_info("read: ========== FINAL event->count = %llu (0x%llx) ==========\n",
 			 new_count, new_count);
-		return;
+	} else {
+		pmu_err("read: Non-AQL event detected, config=0x%llx\n", event->attr.config);
 	}
-
-	/* Only AQL hardware events are supported */
-	pmu_err("read: Non-AQL event detected, config=0x%llx\n", event->attr.config);
 }
 
 /* Initialize event attributes from counter_registry */
@@ -835,7 +940,10 @@ static int __init amdgpu_pmu_init(void)
 		.stop = amdgpu_pmu_stop,
 		.read = amdgpu_pmu_read,
 		.attr_groups = amdgpu_pmu_attr_groups,
-		.capabilities = PERF_PMU_CAP_NO_INTERRUPT | PERF_PMU_CAP_NO_EXCLUDE,
+		/* Note: PERF_PMU_CAP_NO_INTERRUPT removed to enable sampling mode.
+		 * We use hrtimer-based sampling instead of hardware overflow interrupts.
+		 * See amdgpu_pmu_generate_samples() for sample generation. */
+		.capabilities = PERF_PMU_CAP_NO_EXCLUDE,
 	};
 
 	/* Register PMU with perf subsystem */

--- a/projects/rocprofiler-sdk/source/lib/output/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/output/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TOOL_OUTPUT_HEADERS
     generateJSON.hpp
     generateOTF2.hpp
     generatePerfetto.hpp
+    generatePerfUserEvents.hpp
     generateStats.hpp
     generateRocpd.hpp
     generator.hpp
@@ -41,6 +42,7 @@ set(TOOL_OUTPUT_SOURCES
     generateJSON.cpp
     generateOTF2.cpp
     generatePerfetto.cpp
+    generatePerfUserEvents.cpp
     generateStats.cpp
     generateRocpd.cpp
     metadata.cpp

--- a/projects/rocprofiler-sdk/source/lib/output/generatePerfUserEvents.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generatePerfUserEvents.cpp
@@ -1,0 +1,213 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "generatePerfUserEvents.hpp"
+#include "lib/common/logging.hpp"
+
+#include <fcntl.h>
+#include <linux/user_events.h>
+#include <sys/ioctl.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cstring>
+
+namespace rocprofiler
+{
+namespace tool
+{
+namespace
+{
+// Event structure matching the schema
+struct kernel_dispatch_event
+{
+    uint64_t dispatch_id;
+    uint64_t correlation_id;
+    uint64_t kernel_id;
+    uint64_t start_ts;
+    uint64_t end_ts;
+    uint32_t agent_id;
+    uint32_t queue_id;
+    uint32_t grid_x;
+    uint32_t grid_y;
+    uint32_t grid_z;
+    uint16_t wg_x;
+    uint16_t wg_y;
+    uint16_t wg_z;
+} __attribute__((packed));
+
+// Enable bit storage - kernel writes to this when tracepoint is enabled
+// Must be aligned to enable_size (4 bytes)
+static uint32_t enable_storage __attribute__((aligned(4))) = 0;
+
+// Global state for the registered event
+static int               g_user_events_fd = -1;
+static uint32_t          g_write_index    = 0;
+static std::atomic<bool> g_initialized{false};
+
+}  // namespace
+
+bool
+init_perf_user_events()
+{
+    if(g_initialized.load())
+    {
+        return true;  // Already initialized
+    }
+
+    // Open the user_events_data file
+    g_user_events_fd = open("/sys/kernel/tracing/user_events_data", O_RDWR);
+    if(g_user_events_fd < 0)
+    {
+        ROCP_WARNING << "Failed to open /sys/kernel/tracing/user_events_data: " << strerror(errno)
+                     << ". Perf user_events output will be disabled. "
+                     << "This feature requires Linux kernel 5.18+ with CONFIG_USER_EVENTS enabled.";
+        return false;
+    }
+
+    // Define the event schema
+    const char* event_def = "rocprof_kernel_dispatch u64 dispatch_id; u64 correlation_id; "
+                            "u64 kernel_id; u64 start_ts; u64 end_ts; u32 agent_id; "
+                            "u32 queue_id; u32 grid_x; u32 grid_y; u32 grid_z; "
+                            "u16 wg_x; u16 wg_y; u16 wg_z";
+
+    // Register the event
+    // Note: enable_size must be 4 or 8, and enable_addr must be aligned
+    struct user_reg reg = {};
+    reg.size            = sizeof(reg);
+    reg.name_args       = reinterpret_cast<uint64_t>(event_def);
+    reg.enable_bit      = 0;
+    reg.enable_size     = sizeof(enable_storage);
+    reg.enable_addr     = reinterpret_cast<uint64_t>(&enable_storage);
+
+    if(ioctl(g_user_events_fd, DIAG_IOCSREG, &reg) < 0)
+    {
+        ROCP_WARNING << "Failed to register perf user_event 'rocprof_kernel_dispatch': "
+                     << strerror(errno) << ". Perf user_events output will be disabled.";
+        close(g_user_events_fd);
+        g_user_events_fd = -1;
+        return false;
+    }
+
+    g_write_index = reg.write_index;
+    g_initialized.store(true);
+
+    ROCP_INFO << "Successfully registered perf user_event 'rocprof_kernel_dispatch' "
+              << "(write_index=" << g_write_index << "). "
+              << "To capture events, run: perf record -e user_events:rocprof_kernel_dispatch -a "
+                 "<command>";
+
+    return true;
+}
+
+void
+cleanup_perf_user_events()
+{
+    if(g_user_events_fd >= 0)
+    {
+        close(g_user_events_fd);
+        g_user_events_fd = -1;
+    }
+    g_initialized.store(false);
+    enable_storage = 0;
+}
+
+void
+write_perf_user_events(
+    const output_config&                                               cfg,
+    const metadata&                                                    tool_metadata,
+    const generator<tool_buffer_tracing_kernel_dispatch_ext_record_t>& kernel_dispatch_gen)
+{
+    (void) cfg;
+    (void) tool_metadata;
+
+    if(!g_initialized.load() || g_user_events_fd < 0)
+    {
+        ROCP_WARNING << "Perf user_events not initialized. Call init_perf_user_events() first.";
+        return;
+    }
+
+    // Check if tracepoint is enabled (someone is listening)
+    // The kernel sets enable_storage to non-zero when tracepoint is enabled
+    if(enable_storage == 0)
+    {
+        ROCP_WARNING << "Perf user_event 'rocprof_kernel_dispatch' is registered but not enabled. "
+                     << "No events will be written. "
+                     << "To capture events, start perf before running rocprofv3: "
+                     << "perf record -e user_events:rocprof_kernel_dispatch -a &";
+        return;
+    }
+
+    ROCP_INFO << "Tracepoint enabled, writing kernel dispatch events...";
+
+    // Iterate through kernel dispatch records and emit events
+    uint64_t event_count   = 0;
+    uint64_t total_records = 0;
+    for(auto ditr : kernel_dispatch_gen)
+    {
+        for(const auto& record : kernel_dispatch_gen.get(ditr))
+        {
+            total_records++;
+
+            // Populate the event structure
+            struct kernel_dispatch_event evt = {};
+
+            evt.dispatch_id    = record.dispatch_info.dispatch_id;
+            evt.correlation_id = record.correlation_id.internal;
+            evt.kernel_id      = record.dispatch_info.kernel_id;
+            evt.start_ts       = record.start_timestamp;
+            evt.end_ts         = record.end_timestamp;
+            evt.agent_id       = record.dispatch_info.agent_id.handle;
+            evt.queue_id       = record.dispatch_info.queue_id.handle;
+            evt.grid_x         = record.dispatch_info.grid_size.x;
+            evt.grid_y         = record.dispatch_info.grid_size.y;
+            evt.grid_z         = record.dispatch_info.grid_size.z;
+            evt.wg_x           = static_cast<uint16_t>(record.dispatch_info.workgroup_size.x);
+            evt.wg_y           = static_cast<uint16_t>(record.dispatch_info.workgroup_size.y);
+            evt.wg_z           = static_cast<uint16_t>(record.dispatch_info.workgroup_size.z);
+
+            // Write event using writev
+            struct iovec iov[2] = {{&g_write_index, sizeof(g_write_index)}, {&evt, sizeof(evt)}};
+
+            ssize_t ret = writev(g_user_events_fd, iov, 2);
+            if(ret < 0)
+            {
+                // Only log first failure to avoid spam
+                if(event_count == 0 && errno != EBADF)
+                {
+                    ROCP_WARNING << "Failed to write perf user_event: " << strerror(errno);
+                }
+            }
+            else
+            {
+                event_count++;
+            }
+        }
+    }
+
+    ROCP_INFO << "Wrote " << event_count << " of " << total_records
+              << " kernel dispatch events to perf user_events";
+}
+
+}  // namespace tool
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/output/generatePerfUserEvents.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generatePerfUserEvents.hpp
@@ -1,0 +1,56 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "generator.hpp"
+#include "metadata.hpp"
+#include "output_config.hpp"
+#include "stream_info.hpp"
+
+namespace rocprofiler
+{
+namespace tool
+{
+
+// Initialize perf user_events - registers the tracepoint early so external tools
+// (like perf record) can subscribe before events are written.
+// Call this at tool initialization, before profiling starts.
+// Returns true if initialization succeeded, false otherwise.
+bool
+init_perf_user_events();
+
+// Write kernel dispatch events to perf user_events.
+// Must call init_perf_user_events() first.
+void
+write_perf_user_events(
+    const output_config&                                               cfg,
+    const metadata&                                                    tool_metadata,
+    const generator<tool_buffer_tracing_kernel_dispatch_ext_record_t>& kernel_dispatch_gen);
+
+// Cleanup perf user_events resources.
+// Call this at tool shutdown.
+void
+cleanup_perf_user_events();
+
+}  // namespace tool
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/output/output_config.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/output_config.cpp
@@ -74,19 +74,24 @@ output_config::parse_env()
     for(const auto& itr : sdk::parse::tokenize(output_format, " \t,;:"))
         entries.emplace(to_upper(itr));
 
-    csv_output     = entries.count("CSV") > 0;
-    json_output    = entries.count("JSON") > 0;
-    pftrace_output = entries.count("PFTRACE") > 0;
-    otf2_output    = entries.count("OTF2") > 0;
-    rocpd_output   = entries.count("ROCPD") > 0 || entries.empty();
+    csv_output              = entries.count("CSV") > 0;
+    json_output             = entries.count("JSON") > 0;
+    pftrace_output          = entries.count("PFTRACE") > 0;
+    otf2_output             = entries.count("OTF2") > 0;
+    rocpd_output            = entries.count("ROCPD") > 0 || entries.empty();
+    perf_user_events_output = entries.count("PERF_USER_EVENTS") > 0;
 
     const auto supported_formats =
-        std::set<std::string_view>{"CSV", "JSON", "PFTRACE", "OTF2", "ROCPD"};
+        std::set<std::string_view>{"CSV", "JSON", "PFTRACE", "OTF2", "ROCPD", "PERF_USER_EVENTS"};
     for(const auto& itr : entries)
     {
         LOG_IF(FATAL, supported_formats.count(itr) == 0)
             << "Unsupported output format type: " << itr;
     }
+
+    // Allow direct environment variable override
+    perf_user_events_output =
+        common::get_env("ROCPROF_PERF_USER_EVENTS_OUTPUT", perf_user_events_output);
 
     std::string agent_index = common::get_env("ROCPROF_AGENT_INDEX", "relative");
     if(agent_index == "type-relative")

--- a/projects/rocprofiler-sdk/source/lib/output/output_config.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/output_config.hpp
@@ -53,11 +53,11 @@ constexpr auto perfetto_shmem_size_hint_kb = 64;
 
 struct output_config
 {
-    output_config()                         = default;
-    ~output_config()                        = default;
-    output_config(const output_config&)     = default;
-    output_config(output_config&&) noexcept = default;
-    output_config& operator=(const output_config&) = default;
+    output_config()                                    = default;
+    ~output_config()                                   = default;
+    output_config(const output_config&)                = default;
+    output_config(output_config&&) noexcept            = default;
+    output_config& operator=(const output_config&)     = default;
     output_config& operator=(output_config&&) noexcept = default;
 
     bool                     stats                       = false;
@@ -68,6 +68,7 @@ struct output_config
     bool                     pftrace_output              = false;
     bool                     otf2_output                 = false;
     bool                     rocpd_output                = false;
+    bool                     perf_user_events_output     = false;
     bool                     summary_output              = false;
     bool                     kernel_rename               = false;
     bool                     group_by_queue              = false;
@@ -131,6 +132,7 @@ output_config::save(ArchiveT& ar) const
     CFG_SERIALIZE_MEMBER(otf2_output);
     CFG_SERIALIZE_MEMBER(summary_output);
     CFG_SERIALIZE_MEMBER(rocpd_output);
+    CFG_SERIALIZE_MEMBER(perf_user_events_output);
     CFG_SERIALIZE_MEMBER(kernel_rename);
     CFG_SERIALIZE_MEMBER(group_by_queue);
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -49,6 +49,7 @@
 #include "lib/output/generateCSV.hpp"
 #include "lib/output/generateJSON.hpp"
 #include "lib/output/generateOTF2.hpp"
+#include "lib/output/generatePerfUserEvents.hpp"
 #include "lib/output/generatePerfetto.hpp"
 #include "lib/output/generateRocpd.hpp"
 #include "lib/output/generateStats.hpp"
@@ -108,7 +109,8 @@
 #include <sys/wait.h>
 
 #if defined(CODECOV) && CODECOV > 0
-extern "C" {
+extern "C"
+{
 extern void
 __gcov_dump(void);
 }
@@ -118,7 +120,8 @@ namespace common = ::rocprofiler::common;
 namespace tool   = ::rocprofiler::tool;
 namespace fs     = ::rocprofiler::common::filesystem;
 
-extern "C" {
+extern "C"
+{
 void
 rocprofv3_error_signal_handler(int signo, siginfo_t*, void*);
 }
@@ -1919,6 +1922,12 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
 
     tool_metadata->init(tool::metadata::inprocess_with_counters{get_config_perf_counters()});
 
+    // Initialize perf user_events early so external tools can subscribe before events are written
+    if(tool::get_config().perf_user_events_output)
+    {
+        tool::init_perf_user_events();
+    }
+
     ROCPROFILER_CALL(rocprofiler_create_context(&get_client_ctx()), "create context failed");
 
     auto code_obj_ctx = null_context_id;
@@ -2755,6 +2764,13 @@ generate_output(cleanup_mode _cleanup_mode)
                           counters_output.get_generator());
     }
 
+    if(tool::get_config().perf_user_events_output && outdata.num_output > 0 &&
+       outdata.num_bytes >= tool::get_config().minimum_output_bytes)
+    {
+        tool::write_perf_user_events(
+            tool::get_config(), *tool_metadata, kernel_dispatch_output.get_generator());
+    }
+
     if(tool::get_config().otf2_output && outdata.num_output > 0 &&
        outdata.num_bytes >= tool::get_config().minimum_output_bytes)
     {
@@ -2863,6 +2879,9 @@ tool_fini(void* /*tool_data*/)
     flush();
 
     generate_output(cleanup_mode::destroy);
+
+    // Cleanup perf user_events resources
+    tool::cleanup_perf_user_events();
 
     if(destructors)
     {
@@ -2975,7 +2994,8 @@ wait_pid(pid_t _pid, int _opts = 0)
     return _status;
 }
 
-extern "C" {
+extern "C"
+{
 void
 rocprofv3_set_main(main_func_t main_func) ROCPROFV3_INTERNAL_API;
 


### PR DESCRIPTION
## Summary

- Add kernel tracepoint infrastructure to perf-dkms for emitting counter samples
- Add Linux user_events support to rocprofiler-sdk for kernel dispatch tracing
- Enables unified GPU profiling with `perf record` capturing both counter time series and kernel dispatch events

## Changes

### perf-dkms
- New `amdgpu_pmu:counter_sample` tracepoint with counter_id, name, value, delta, timestamp
- Emit tracepoints from timer handler for active sampling events
- Track previous counter values for delta calculation
- Fix critical bugs: RCU for atomic-safe session access, consistent spin_lock_irqsave usage

### rocprofiler-sdk  
- New `user_events:rocprof_kernel_dispatch` event with dispatch info, timestamps, grid dimensions
- Add `PERF_USER_EVENTS` output format and `ROCPROF_PERF_USER_EVENTS_OUTPUT` env var

## Usage

```bash
perf record -e amdgpu_pmu/config=0x1e/ \
            -e amdgpu_pmu:counter_sample \
            -e user_events:rocprof_kernel_dispatch \
            -c 1000000 -a -- rocprofv3 --kernel-trace -- ./app

perf script
```

## Test plan

- [x] Build perf-dkms module successfully
- [x] Verify `amdgpu_pmu:counter_sample` tracepoint appears in `/sys/kernel/debug/tracing/available_events`
- [x] Verify counting mode (perf stat) still works
- [x] Verify tracepoint samples are emitted during sampling
- [x] Build rocprofiler-sdk with user_events support
- [x] Verify `user_events:rocprof_kernel_dispatch` events captured with local rocprofv3 build
- [x] Verify combined capture works with both event types in same perf record session