### PR TITLE
[rocprofiler-sdk] Add HSA and HIP API tracing via perf user_events

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/output/generatePerfUserEvents.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generatePerfUserEvents.cpp
@@ -38,7 +38,16 @@ namespace tool
 {
 namespace
 {
-// Event structure matching the schema
+// Generic user event info structure
+struct user_event_info
+{
+    int               fd                                         = -1;
+    uint32_t          write_index                                = 0;
+    uint32_t          enable_storage __attribute__((aligned(4))) = 0;
+    std::atomic<bool> initialized{false};
+};
+
+// Event structure matching the kernel dispatch schema
 struct kernel_dispatch_event
 {
     uint64_t dispatch_id;
@@ -56,80 +65,138 @@ struct kernel_dispatch_event
     uint16_t wg_z;
 } __attribute__((packed));
 
-// Enable bit storage - kernel writes to this when tracepoint is enabled
-// Must be aligned to enable_size (4 bytes)
-static uint32_t enable_storage __attribute__((aligned(4))) = 0;
+// Event structure matching the HSA API schema
+struct hsa_api_event
+{
+    uint32_t kind;
+    uint32_t operation;
+    uint64_t correlation_id;
+    uint64_t start_ts;
+    uint64_t end_ts;
+    uint32_t thread_id;
+} __attribute__((packed));
 
-// Global state for the registered event
-static int               g_user_events_fd = -1;
-static uint32_t          g_write_index    = 0;
-static std::atomic<bool> g_initialized{false};
+// Event structure matching the HIP API schema
+struct hip_api_event
+{
+    uint32_t kind;
+    uint32_t operation;
+    uint64_t correlation_id;
+    uint64_t start_ts;
+    uint64_t end_ts;
+    uint32_t thread_id;
+} __attribute__((packed));
+
+// Global state for the registered events
+static user_event_info g_kernel_dispatch_event;
+static user_event_info g_hsa_api_event;
+static user_event_info g_hip_api_event;
+
+// Helper function to register a user event
+static bool
+register_user_event(user_event_info& info, const char* event_def, const char* event_name)
+{
+    if(info.initialized.load())
+    {
+        return true;  // Already initialized
+    }
+
+    // Open the user_events_data file
+    info.fd = open("/sys/kernel/tracing/user_events_data", O_RDWR);
+    if(info.fd < 0)
+    {
+        ROCP_WARNING
+            << "Failed to open /sys/kernel/tracing/user_events_data for event '" << event_name
+            << "': " << strerror(errno)
+            << ". This feature requires Linux kernel 5.18+ with CONFIG_USER_EVENTS enabled.";
+        return false;
+    }
+
+    // Register the event
+    struct user_reg reg = {};
+    reg.size            = sizeof(reg);
+    reg.name_args       = reinterpret_cast<uint64_t>(event_def);
+    reg.enable_bit      = 0;
+    reg.enable_size     = sizeof(info.enable_storage);
+    reg.enable_addr     = reinterpret_cast<uint64_t>(&info.enable_storage);
+
+    if(ioctl(info.fd, DIAG_IOCSREG, &reg) < 0)
+    {
+        ROCP_WARNING << "Failed to register perf user_event '" << event_name
+                     << "': " << strerror(errno);
+        close(info.fd);
+        info.fd = -1;
+        return false;
+    }
+
+    info.write_index = reg.write_index;
+    info.initialized.store(true);
+
+    ROCP_INFO << "Successfully registered perf user_event '" << event_name << "' "
+              << "(write_index=" << info.write_index << "). "
+              << "To capture events, run: perf record -e user_events:" << event_name << " -a "
+              << "<command>";
+
+    return true;
+}
 
 }  // namespace
 
 bool
 init_perf_user_events()
 {
-    if(g_initialized.load())
-    {
-        return true;  // Already initialized
-    }
+    // Define event schemas
+    const char* kernel_dispatch_def =
+        "rocprof_kernel_dispatch u64 dispatch_id; u64 correlation_id; "
+        "u64 kernel_id; u64 start_ts; u64 end_ts; u32 agent_id; "
+        "u32 queue_id; u32 grid_x; u32 grid_y; u32 grid_z; "
+        "u16 wg_x; u16 wg_y; u16 wg_z";
 
-    // Open the user_events_data file
-    g_user_events_fd = open("/sys/kernel/tracing/user_events_data", O_RDWR);
-    if(g_user_events_fd < 0)
-    {
-        ROCP_WARNING << "Failed to open /sys/kernel/tracing/user_events_data: " << strerror(errno)
-                     << ". Perf user_events output will be disabled. "
-                     << "This feature requires Linux kernel 5.18+ with CONFIG_USER_EVENTS enabled.";
-        return false;
-    }
+    const char* hsa_api_def = "rocprof_hsa_api u32 kind; u32 operation; "
+                              "u64 correlation; u64 start_ts; u64 end_ts; u32 thread_id";
 
-    // Define the event schema
-    const char* event_def = "rocprof_kernel_dispatch u64 dispatch_id; u64 correlation_id; "
-                            "u64 kernel_id; u64 start_ts; u64 end_ts; u32 agent_id; "
-                            "u32 queue_id; u32 grid_x; u32 grid_y; u32 grid_z; "
-                            "u16 wg_x; u16 wg_y; u16 wg_z";
+    const char* hip_api_def = "rocprof_hip_api u32 kind; u32 operation; "
+                              "u64 correlation; u64 start_ts; u64 end_ts; u32 thread_id";
 
-    // Register the event
-    // Note: enable_size must be 4 or 8, and enable_addr must be aligned
-    struct user_reg reg = {};
-    reg.size            = sizeof(reg);
-    reg.name_args       = reinterpret_cast<uint64_t>(event_def);
-    reg.enable_bit      = 0;
-    reg.enable_size     = sizeof(enable_storage);
-    reg.enable_addr     = reinterpret_cast<uint64_t>(&enable_storage);
+    // Register all events
+    bool kernel_ok = register_user_event(
+        g_kernel_dispatch_event, kernel_dispatch_def, "rocprof_kernel_dispatch");
+    bool hsa_ok = register_user_event(g_hsa_api_event, hsa_api_def, "rocprof_hsa_api");
+    bool hip_ok = register_user_event(g_hip_api_event, hip_api_def, "rocprof_hip_api");
 
-    if(ioctl(g_user_events_fd, DIAG_IOCSREG, &reg) < 0)
-    {
-        ROCP_WARNING << "Failed to register perf user_event 'rocprof_kernel_dispatch': "
-                     << strerror(errno) << ". Perf user_events output will be disabled.";
-        close(g_user_events_fd);
-        g_user_events_fd = -1;
-        return false;
-    }
-
-    g_write_index = reg.write_index;
-    g_initialized.store(true);
-
-    ROCP_INFO << "Successfully registered perf user_event 'rocprof_kernel_dispatch' "
-              << "(write_index=" << g_write_index << "). "
-              << "To capture events, run: perf record -e user_events:rocprof_kernel_dispatch -a "
-                 "<command>";
-
-    return true;
+    // Return true if at least one event registered successfully
+    return kernel_ok || hsa_ok || hip_ok;
 }
 
 void
 cleanup_perf_user_events()
 {
-    if(g_user_events_fd >= 0)
+    // Cleanup kernel dispatch event
+    if(g_kernel_dispatch_event.fd >= 0)
     {
-        close(g_user_events_fd);
-        g_user_events_fd = -1;
+        close(g_kernel_dispatch_event.fd);
+        g_kernel_dispatch_event.fd = -1;
     }
-    g_initialized.store(false);
-    enable_storage = 0;
+    g_kernel_dispatch_event.initialized.store(false);
+    g_kernel_dispatch_event.enable_storage = 0;
+
+    // Cleanup HSA API event
+    if(g_hsa_api_event.fd >= 0)
+    {
+        close(g_hsa_api_event.fd);
+        g_hsa_api_event.fd = -1;
+    }
+    g_hsa_api_event.initialized.store(false);
+    g_hsa_api_event.enable_storage = 0;
+
+    // Cleanup HIP API event
+    if(g_hip_api_event.fd >= 0)
+    {
+        close(g_hip_api_event.fd);
+        g_hip_api_event.fd = -1;
+    }
+    g_hip_api_event.initialized.store(false);
+    g_hip_api_event.enable_storage = 0;
 }
 
 void
@@ -141,15 +208,15 @@ write_perf_user_events(
     (void) cfg;
     (void) tool_metadata;
 
-    if(!g_initialized.load() || g_user_events_fd < 0)
+    if(!g_kernel_dispatch_event.initialized.load() || g_kernel_dispatch_event.fd < 0)
     {
-        ROCP_WARNING << "Perf user_events not initialized. Call init_perf_user_events() first.";
+        ROCP_WARNING << "Perf user_event 'rocprof_kernel_dispatch' not initialized.";
         return;
     }
 
     // Check if tracepoint is enabled (someone is listening)
     // The kernel sets enable_storage to non-zero when tracepoint is enabled
-    if(enable_storage == 0)
+    if(g_kernel_dispatch_event.enable_storage == 0)
     {
         ROCP_WARNING << "Perf user_event 'rocprof_kernel_dispatch' is registered but not enabled. "
                      << "No events will be written. "
@@ -187,9 +254,11 @@ write_perf_user_events(
             evt.wg_z           = static_cast<uint16_t>(record.dispatch_info.workgroup_size.z);
 
             // Write event using writev
-            struct iovec iov[2] = {{&g_write_index, sizeof(g_write_index)}, {&evt, sizeof(evt)}};
+            struct iovec iov[2] = {
+                {&g_kernel_dispatch_event.write_index, sizeof(g_kernel_dispatch_event.write_index)},
+                {&evt, sizeof(evt)}};
 
-            ssize_t ret = writev(g_user_events_fd, iov, 2);
+            ssize_t ret = writev(g_kernel_dispatch_event.fd, iov, 2);
             if(ret < 0)
             {
                 // Only log first failure to avoid spam
@@ -207,6 +276,146 @@ write_perf_user_events(
 
     ROCP_INFO << "Wrote " << event_count << " of " << total_records
               << " kernel dispatch events to perf user_events";
+}
+
+void
+write_hsa_api_events(const output_config&                                          cfg,
+                     const metadata&                                               tool_metadata,
+                     const generator<rocprofiler_buffer_tracing_hsa_api_record_t>& hsa_api_gen)
+{
+    (void) cfg;
+    (void) tool_metadata;
+
+    if(!g_hsa_api_event.initialized.load() || g_hsa_api_event.fd < 0)
+    {
+        ROCP_WARNING << "Perf user_event 'rocprof_hsa_api' not initialized.";
+        return;
+    }
+
+    // Check if tracepoint is enabled (someone is listening)
+    if(g_hsa_api_event.enable_storage == 0)
+    {
+        ROCP_WARNING << "Perf user_event 'rocprof_hsa_api' is registered but not enabled. "
+                     << "No events will be written. "
+                     << "To capture events, start perf before running rocprofv3: "
+                     << "perf record -e user_events:rocprof_hsa_api -a &";
+        return;
+    }
+
+    ROCP_INFO << "Tracepoint enabled, writing HSA API events...";
+
+    // Iterate through HSA API records and emit events
+    uint64_t event_count   = 0;
+    uint64_t total_records = 0;
+    for(auto ditr : hsa_api_gen)
+    {
+        for(const auto& record : hsa_api_gen.get(ditr))
+        {
+            total_records++;
+
+            // Populate the event structure
+            struct hsa_api_event evt = {};
+
+            evt.kind           = record.kind;
+            evt.operation      = record.operation;
+            evt.correlation_id = record.correlation_id.internal;
+            evt.start_ts       = record.start_timestamp;
+            evt.end_ts         = record.end_timestamp;
+            evt.thread_id      = record.thread_id;
+
+            // Write event using writev
+            struct iovec iov[2] = {
+                {&g_hsa_api_event.write_index, sizeof(g_hsa_api_event.write_index)},
+                {&evt, sizeof(evt)}};
+
+            ssize_t ret = writev(g_hsa_api_event.fd, iov, 2);
+            if(ret < 0)
+            {
+                // Only log first failure to avoid spam
+                if(event_count == 0 && errno != EBADF)
+                {
+                    ROCP_WARNING << "Failed to write perf user_event: " << strerror(errno);
+                }
+            }
+            else
+            {
+                event_count++;
+            }
+        }
+    }
+
+    ROCP_INFO << "Wrote " << event_count << " of " << total_records
+              << " HSA API events to perf user_events";
+}
+
+void
+write_hip_api_events(const output_config&                                       cfg,
+                     const metadata&                                            tool_metadata,
+                     const generator<tool_buffer_tracing_hip_api_ext_record_t>& hip_api_gen)
+{
+    (void) cfg;
+    (void) tool_metadata;
+
+    if(!g_hip_api_event.initialized.load() || g_hip_api_event.fd < 0)
+    {
+        ROCP_WARNING << "Perf user_event 'rocprof_hip_api' not initialized.";
+        return;
+    }
+
+    // Check if tracepoint is enabled (someone is listening)
+    if(g_hip_api_event.enable_storage == 0)
+    {
+        ROCP_WARNING << "Perf user_event 'rocprof_hip_api' is registered but not enabled. "
+                     << "No events will be written. "
+                     << "To capture events, start perf before running rocprofv3: "
+                     << "perf record -e user_events:rocprof_hip_api -a &";
+        return;
+    }
+
+    ROCP_INFO << "Tracepoint enabled, writing HIP API events...";
+
+    // Iterate through HIP API records and emit events
+    uint64_t event_count   = 0;
+    uint64_t total_records = 0;
+    for(auto ditr : hip_api_gen)
+    {
+        for(const auto& record : hip_api_gen.get(ditr))
+        {
+            total_records++;
+
+            // Populate the event structure
+            struct hip_api_event evt = {};
+
+            evt.kind           = record.kind;
+            evt.operation      = record.operation;
+            evt.correlation_id = record.correlation_id.internal;
+            evt.start_ts       = record.start_timestamp;
+            evt.end_ts         = record.end_timestamp;
+            evt.thread_id      = record.thread_id;
+
+            // Write event using writev
+            struct iovec iov[2] = {
+                {&g_hip_api_event.write_index, sizeof(g_hip_api_event.write_index)},
+                {&evt, sizeof(evt)}};
+
+            ssize_t ret = writev(g_hip_api_event.fd, iov, 2);
+            if(ret < 0)
+            {
+                // Only log first failure to avoid spam
+                if(event_count == 0 && errno != EBADF)
+                {
+                    ROCP_WARNING << "Failed to write perf user_event: " << strerror(errno);
+                }
+            }
+            else
+            {
+                event_count++;
+            }
+        }
+    }
+
+    ROCP_INFO << "Wrote " << event_count << " of " << total_records
+              << " HIP API events to perf user_events";
 }
 
 }  // namespace tool

--- a/projects/rocprofiler-sdk/source/lib/output/generatePerfUserEvents.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generatePerfUserEvents.hpp
@@ -27,6 +27,8 @@
 #include "output_config.hpp"
 #include "stream_info.hpp"
 
+#include <rocprofiler-sdk/buffer_tracing.h>
+
 namespace rocprofiler
 {
 namespace tool
@@ -46,6 +48,20 @@ write_perf_user_events(
     const output_config&                                               cfg,
     const metadata&                                                    tool_metadata,
     const generator<tool_buffer_tracing_kernel_dispatch_ext_record_t>& kernel_dispatch_gen);
+
+// Write HSA API events to perf user_events.
+// Must call init_perf_user_events() first.
+void
+write_hsa_api_events(const output_config&                                          cfg,
+                     const metadata&                                               tool_metadata,
+                     const generator<rocprofiler_buffer_tracing_hsa_api_record_t>& hsa_api_gen);
+
+// Write HIP API events to perf user_events.
+// Must call init_perf_user_events() first.
+void
+write_hip_api_events(const output_config&                                       cfg,
+                     const metadata&                                            tool_metadata,
+                     const generator<tool_buffer_tracing_hip_api_ext_record_t>& hip_api_gen);
 
 // Cleanup perf user_events resources.
 // Call this at tool shutdown.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2769,6 +2769,8 @@ generate_output(cleanup_mode _cleanup_mode)
     {
         tool::write_perf_user_events(
             tool::get_config(), *tool_metadata, kernel_dispatch_output.get_generator());
+        tool::write_hsa_api_events(tool::get_config(), *tool_metadata, hsa_output.get_generator());
+        tool::write_hip_api_events(tool::get_config(), *tool_metadata, hip_output.get_generator());
     }
 
     if(tool::get_config().otf2_output && outdata.num_output > 0 &&


### PR DESCRIPTION
## Summary
- Extends perf user_events integration to support HSA and HIP API tracing
- Refactors event registration into reusable helper function supporting multiple event types
- Adds `write_hsa_api_events()` and `write_hip_api_events()` for buffer record processing

## Event Schemas
- `rocprof_hsa_api`: kind, operation, correlation, start_ts, end_ts, thread_id
- `rocprof_hip_api`: kind, operation, correlation, start_ts, end_ts, thread_id

## Usage
```bash
# Enable user_events output
export ROCPROF_PERF_USER_EVENTS_OUTPUT=1

# Run rocprofv3 with HSA/HIP tracing
rocprofv3 --hsa-trace --hip-trace -- ./your_app
```

## Test plan
- [x] Build verification (compilation succeeds)
- [x] Events register successfully (verified via "registered but not enabled" messages)
- [x] user_events mechanism verified working via test utility
- [ ] End-to-end testing with perf record (blocked by user_events lifecycle - events are ephemeral)

## Notes
Linux user_events are ephemeral - they only exist while the registering process holds the file descriptor open. This means perf must be configured after rocprofv3 starts, or a wrapper script is needed.