### PR TITLE
Replace usages of __ockl_gws_init and __ockl_clz with builtins

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_device_functions.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_device_functions.h
@@ -52,10 +52,12 @@ __device__ static inline unsigned int __popcll(unsigned long long int input) {
   return __builtin_popcountll(input);
 }
 
-__device__ static inline int __clz(int input) { return __ockl_clz_u32((uint)input); }
+__device__ static inline int __clz(int input) {
+  return input == 0u ? 32 : __builtin_clz((uint)input);
+}
 
 __device__ static inline int __clzll(long long int input) {
-  return __ockl_clz_u64((__hip_uint64_t)input);
+  return input == 0u ? 64 : __builtin_clzl((__hip_uint64_t)input);
 }
 
 __device__ static inline int __ffs(unsigned int input) {

--- a/projects/clr/hipamd/include/hip/amd_detail/device_library_decls.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/device_library_decls.h
@@ -56,11 +56,6 @@ extern "C" __device__ __attribute__((const)) uint __ockl_mul_hi_u32(uint, uint);
 extern "C" __device__ __attribute__((const)) int __ockl_mul_hi_i32(int, int);
 extern "C" __device__ __attribute__((const)) uint __ockl_sadd_u32(uint, uint, uint);
 
-extern "C" __device__ __attribute__((const)) uchar __ockl_clz_u8(uchar);
-extern "C" __device__ __attribute__((const)) ushort __ockl_clz_u16(ushort);
-extern "C" __device__ __attribute__((const)) uint __ockl_clz_u32(uint);
-extern "C" __device__ __attribute__((const)) __hip_uint64_t __ockl_clz_u64(__hip_uint64_t);
-
 extern "C" __device__ __attribute__((const)) float __ocml_fmin_f32(float, float);
 extern "C" __device__ __attribute__((const)) float __ocml_fmax_f32(float, float);
 
@@ -91,7 +86,6 @@ extern "C" __device__ __attribute__((const)) double __ocml_cvtrtn_f64_u64(__hip_
 extern "C" __device__ __attribute__((const)) double __ocml_cvtrtp_f64_u64(__hip_uint64_t);
 extern "C" __device__ __attribute__((const)) double __ocml_cvtrtz_f64_u64(__hip_uint64_t);
 
-extern "C" __device__ __attribute__((convergent)) void __ockl_gws_init(uint nwm1, uint rid);
 extern "C" __device__ __attribute__((convergent)) void __ockl_gws_barrier(uint nwm1, uint rid);
 
 extern "C" __device__ __attribute__((const)) __hip_uint32_t __ockl_lane_u32();

--- a/projects/clr/rocclr/device/blitcl.cpp
+++ b/projects/clr/rocclr/device/blitcl.cpp
@@ -47,8 +47,6 @@ const char* BlitLinearSourceCode = BLIT_KERNELS(
 
     extern void __ockl_dm_init_v1(ulong, ulong, uint, uint);
 
-    extern void __ockl_gws_init(uint nwm1, uint rid);
-
     __kernel void __amd_rocclr_fillBufferAligned(__global void* buf, __constant uchar* pattern,
                                                  uint pattern_size, uint alignment, ulong end_ptr,
                                                  uint next_chunk, uint workgroup_size) {
@@ -182,7 +180,7 @@ const char* HipExtraSourceCode = BLIT_KERNELS(
       __ockl_dm_init_v1(heap_to_initialize, initial_blocks, heap_size, number_of_initial_blocks);
     }
 
-    __kernel void __amd_rocclr_gwsInit(uint value) { __ockl_gws_init(value, 0); });
+    __kernel void __amd_rocclr_gwsInit(uint value) { __builtin_amdgcn_ds_gws_init(value, 0); });
 
 const char* HipExtraSourceCodeNoGWS = BLIT_KERNELS(
     __kernel void __amd_rocclr_streamOpsWrite(__global uint* ptrInt, __global ulong* ptrUlong,


### PR DESCRIPTION
## Motivation

Remove OCKL usages in HIP headers where the mapping is straightforward.

## Technical Details

* This PR removes __ockl usages for `__ockl_gws_init`, `__ockl_clz_u32` and `__ockl_clz_u64` and replaces them with equivalent builtins.


## JIRA ID

SWDEV-548892

## Test Plan

Github CI passes.
Compare assembly generated by `__ockl` and their equivalent __builtin to make sure they are equivalent.

## Test Result

The mappings are straightforward since the __ockl functions are already forwarding to the respective builtins. See:

* https://github.com/ROCm/llvm-project/blob/amd-staging/amd/device-libs/ockl/src/clz.cl
* https://github.com/ROCm/llvm-project/blob/amd-staging/amd/device-libs/ockl/src/cg.cl#L97

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
