### PR TITLE
[SWDEV-564696] Structure size mismatch in SOC pstate/XGMI PLPD 

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -1153,6 +1153,34 @@ class AMDSMICommands():
         # Convert and store output by pid for csv format
         multiple_devices_csv_override = False
         if self.logger.is_csv_format():
+            # Format soc_pstate for CSV output
+            if 'soc_pstate' in static_dict and isinstance(static_dict['soc_pstate'], dict):
+                pstate_data = static_dict['soc_pstate']
+                if 'policies' in pstate_data and isinstance(pstate_data['policies'], list):
+                    # Format as "0:soc_pstate_default, 1:soc_pstate_0, ..."
+                    policy_strings = [f"{p['policy_id']}:{p['policy_description']}" 
+                                     for p in pstate_data['policies'] 
+                                     if 'policy_id' in p and 'policy_description' in p]
+                    static_dict['soc_pstate'] = {
+                        'num_supported': pstate_data.get('num_supported', 'N/A'),
+                        'current_id': pstate_data.get('current_id', 'N/A'),
+                        'policies': ', '.join(policy_strings) if policy_strings else 'N/A'
+                    }
+            
+            # Format xgmi_plpd for CSV output
+            if 'xgmi_plpd' in static_dict and isinstance(static_dict['xgmi_plpd'], dict):
+                plpd_data = static_dict['xgmi_plpd']
+                if 'policies' in plpd_data and isinstance(plpd_data['policies'], list):
+                    # Format as "0:plpd_disallow, 1:plpd_default, ..."
+                    policy_strings = [f"{p['policy_id']}:{p['policy_description']}" 
+                                     for p in plpd_data['policies'] 
+                                     if 'policy_id' in p and 'policy_description' in p]
+                    static_dict['xgmi_plpd'] = {
+                        'num_supported': plpd_data.get('num_supported', 'N/A'),
+                        'current_id': plpd_data.get('current_id', 'N/A'),
+                        'policies': ', '.join(policy_strings) if policy_strings else 'N/A'
+                    }
+            
             # For NUMA data - flatten CPU affinity lists
             if 'numa' in static_dict and isinstance(static_dict['numa'], dict):
                 numa_data = static_dict.pop('numa')
@@ -4793,7 +4821,16 @@ class AMDSMICommands():
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
                         raise PermissionError('Command requires elevation') from e
-                    self.logger.store_output(args.gpu, 'socpstate', f"[{e.get_error_info(detailed=False)}] Unable to set soc pstate dpm policy to {args.soc_pstate}")
+                    
+                    # If AMDSMI_STATUS_INVAL, show valid policy list
+                    error_msg = f"[{e.get_error_info(detailed=False)}] Unable to set soc pstate dpm policy to {args.soc_pstate}"
+                    if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_INVAL:
+                        valid_policies = self.helpers.get_soc_pstates()
+                        if valid_policies and valid_policies[0] != "N/A":
+                            valid_policies_str = f"[{', '.join(valid_policies)}]"
+                            self.logger.print_output(f"Valid SOC P-State Policies: {valid_policies_str}\n", None, None)
+                    
+                    self.logger.store_output(args.gpu, 'socpstate', error_msg)
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
                     return
@@ -4807,7 +4844,16 @@ class AMDSMICommands():
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
                         raise PermissionError('Command requires elevation') from e
-                    self.logger.store_output(args.gpu, 'xgmiplpd', f"[{e.get_error_info(detailed=False)}] Unable to set XGMI per-link power down policy to {args.xgmi_plpd}")
+                    
+                    # If AMDSMI_STATUS_INVAL, show valid policy list
+                    error_msg = f"[{e.get_error_info(detailed=False)}] Unable to set XGMI per-link power down policy to {args.xgmi_plpd}"
+                    if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_INVAL:
+                        valid_policies = self.helpers.get_xgmi_plpd_policies()
+                        if valid_policies and valid_policies[0] != "N/A":
+                            valid_policies_str = f"[{', '.join(valid_policies)}]"
+                            self.logger.print_output(f"Valid XGMI PLPD Policies: {valid_policies_str}\n", None, None)
+                    
+                    self.logger.store_output(args.gpu, 'xgmiplpd', error_msg)
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
                     return

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -914,19 +914,18 @@ class AMDSMICommands():
                     policy_info = "N/A"
                     logging.debug("Failed to get soc pstate policy info for gpu %s | %s", gpu_id, e.get_error_info())
 
-                # Format for CSV output
+                # Format for CSV output - flatten completely to avoid extra columns
                 if self.logger.is_csv_format() and isinstance(policy_info, dict):
-                    if 'policies' in policy_info and isinstance(policy_info['policies'], list):
-                        # Format as "0:soc_pstate_default, 1:soc_pstate_0, ..."
-                        policy_strings = [f"{p['policy_id']}:{p['policy_description']}" 
-                                         for p in policy_info['policies'] 
-                                         if 'policy_id' in p and 'policy_description' in p]
-                        policy_info = {
-                            'num_supported': policy_info.get('num_supported', 'N/A'),
-                            'current_id': policy_info.get('current_id', 'N/A'),
-                            'policies': ', '.join(policy_strings) if policy_strings else 'N/A'
-                        }
-                static_dict['soc_pstate'] = policy_info
+                    policies_str = ', '.join(
+                        f"{p['policy_id']}:{p['policy_description']}"
+                        for p in policy_info.get('policies', [])
+                    ) or 'N/A'
+                    
+                    static_dict['num_supported'] = policy_info.get('num_supported', 'N/A')
+                    static_dict['current_id'] = policy_info.get('current_id', 'N/A')
+                    static_dict['policies'] = policies_str
+                else:
+                    static_dict['soc_pstate'] = policy_info
         if 'xgmi_plpd' in current_platform_args:
             if args.xgmi_plpd:
                 try:
@@ -935,19 +934,18 @@ class AMDSMICommands():
                     policy_info = "N/A"
                     logging.debug("Failed to get xgmi_plpd info for gpu %s | %s", gpu_id, e.get_error_info())
 
-                # Format for CSV output
+                # Format for CSV output - flatten completely to avoid extra columns
                 if self.logger.is_csv_format() and isinstance(policy_info, dict):
-                    if 'policies' in policy_info and isinstance(policy_info['policies'], list):
-                        # Format as "0:plpd_disallow, 1:plpd_default, ..."
-                        policy_strings = [f"{p['policy_id']}:{p['policy_description']}" 
-                                         for p in policy_info['policies'] 
-                                         if 'policy_id' in p and 'policy_description' in p]
-                        policy_info = {
-                            'num_supported': policy_info.get('num_supported', 'N/A'),
-                            'current_id': policy_info.get('current_id', 'N/A'),
-                            'policies': ', '.join(policy_strings) if policy_strings else 'N/A'
-                        }
-                static_dict['xgmi_plpd'] = policy_info
+                    policies_str = ', '.join(
+                        f"{p['policy_id']}:{p['policy_description']}"
+                        for p in policy_info.get('policies', [])
+                    ) or 'N/A'
+                    
+                    static_dict['num_supported'] = policy_info.get('num_supported', 'N/A')
+                    static_dict['current_id'] = policy_info.get('current_id', 'N/A')
+                    static_dict['policies'] = policies_str
+                else:
+                    static_dict['xgmi_plpd'] = policy_info
         if 'process_isolation' in current_platform_args:
             if args.process_isolation:
                 try:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -914,6 +914,18 @@ class AMDSMICommands():
                     policy_info = "N/A"
                     logging.debug("Failed to get soc pstate policy info for gpu %s | %s", gpu_id, e.get_error_info())
 
+                # Format for CSV output
+                if self.logger.is_csv_format() and isinstance(policy_info, dict):
+                    if 'policies' in policy_info and isinstance(policy_info['policies'], list):
+                        # Format as "0:soc_pstate_default, 1:soc_pstate_0, ..."
+                        policy_strings = [f"{p['policy_id']}:{p['policy_description']}" 
+                                         for p in policy_info['policies'] 
+                                         if 'policy_id' in p and 'policy_description' in p]
+                        policy_info = {
+                            'num_supported': policy_info.get('num_supported', 'N/A'),
+                            'current_id': policy_info.get('current_id', 'N/A'),
+                            'policies': ', '.join(policy_strings) if policy_strings else 'N/A'
+                        }
                 static_dict['soc_pstate'] = policy_info
         if 'xgmi_plpd' in current_platform_args:
             if args.xgmi_plpd:
@@ -923,6 +935,18 @@ class AMDSMICommands():
                     policy_info = "N/A"
                     logging.debug("Failed to get xgmi_plpd info for gpu %s | %s", gpu_id, e.get_error_info())
 
+                # Format for CSV output
+                if self.logger.is_csv_format() and isinstance(policy_info, dict):
+                    if 'policies' in policy_info and isinstance(policy_info['policies'], list):
+                        # Format as "0:plpd_disallow, 1:plpd_default, ..."
+                        policy_strings = [f"{p['policy_id']}:{p['policy_description']}" 
+                                         for p in policy_info['policies'] 
+                                         if 'policy_id' in p and 'policy_description' in p]
+                        policy_info = {
+                            'num_supported': policy_info.get('num_supported', 'N/A'),
+                            'current_id': policy_info.get('current_id', 'N/A'),
+                            'policies': ', '.join(policy_strings) if policy_strings else 'N/A'
+                        }
                 static_dict['xgmi_plpd'] = policy_info
         if 'process_isolation' in current_platform_args:
             if args.process_isolation:
@@ -1153,34 +1177,6 @@ class AMDSMICommands():
         # Convert and store output by pid for csv format
         multiple_devices_csv_override = False
         if self.logger.is_csv_format():
-            # Format soc_pstate for CSV output
-            if 'soc_pstate' in static_dict and isinstance(static_dict['soc_pstate'], dict):
-                pstate_data = static_dict['soc_pstate']
-                if 'policies' in pstate_data and isinstance(pstate_data['policies'], list):
-                    # Format as "0:soc_pstate_default, 1:soc_pstate_0, ..."
-                    policy_strings = [f"{p['policy_id']}:{p['policy_description']}" 
-                                     for p in pstate_data['policies'] 
-                                     if 'policy_id' in p and 'policy_description' in p]
-                    static_dict['soc_pstate'] = {
-                        'num_supported': pstate_data.get('num_supported', 'N/A'),
-                        'current_id': pstate_data.get('current_id', 'N/A'),
-                        'policies': ', '.join(policy_strings) if policy_strings else 'N/A'
-                    }
-            
-            # Format xgmi_plpd for CSV output
-            if 'xgmi_plpd' in static_dict and isinstance(static_dict['xgmi_plpd'], dict):
-                plpd_data = static_dict['xgmi_plpd']
-                if 'policies' in plpd_data and isinstance(plpd_data['policies'], list):
-                    # Format as "0:plpd_disallow, 1:plpd_default, ..."
-                    policy_strings = [f"{p['policy_id']}:{p['policy_description']}" 
-                                     for p in plpd_data['policies'] 
-                                     if 'policy_id' in p and 'policy_description' in p]
-                    static_dict['xgmi_plpd'] = {
-                        'num_supported': plpd_data.get('num_supported', 'N/A'),
-                        'current_id': plpd_data.get('current_id', 'N/A'),
-                        'policies': ', '.join(policy_strings) if policy_strings else 'N/A'
-                    }
-            
             # For NUMA data - flatten CPU affinity lists
             if 'numa' in static_dict and isinstance(static_dict['numa'], dict):
                 numa_data = static_dict.pop('numa')
@@ -4821,16 +4817,17 @@ class AMDSMICommands():
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
                         raise PermissionError('Command requires elevation') from e
-                    
-                    # If AMDSMI_STATUS_INVAL, show valid policy list
-                    error_msg = f"[{e.get_error_info(detailed=False)}] Unable to set soc pstate dpm policy to {args.soc_pstate}"
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_INVAL:
-                        valid_policies = self.helpers.get_soc_pstates()
-                        if valid_policies and valid_policies[0] != "N/A":
-                            valid_policies_str = f"[{', '.join(valid_policies)}]"
-                            self.logger.print_output(f"Valid SOC P-State Policies: {valid_policies_str}\n", None, None)
-                    
-                    self.logger.store_output(args.gpu, 'socpstate', error_msg)
+                        soc_pstate_info = amdsmi_interface.amdsmi_get_soc_pstate(args.gpu)
+                        policy_string = "N/A"
+                        # Check if 'policies' key exists before accessing it
+                        if 'policies' in soc_pstate_info and soc_pstate_info['policies']:
+                            policy_string = ""
+                            for policy in soc_pstate_info['policies']:
+                                policy_string += f"{policy['policy_id']}: {policy['policy_description']}, "
+                            policy_string = policy_string.rstrip(", ")  # Remove trailing comma and space
+                        print(f"Valid SOC P-State Policies: [{policy_string}]\n")
+                    self.logger.store_output(args.gpu, 'socpstate', f"[{e.get_error_info(detailed=False)}] Unable to set soc pstate dpm policy to {args.soc_pstate}")
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
                     return
@@ -4844,16 +4841,17 @@ class AMDSMICommands():
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
                         raise PermissionError('Command requires elevation') from e
-                    
-                    # If AMDSMI_STATUS_INVAL, show valid policy list
-                    error_msg = f"[{e.get_error_info(detailed=False)}] Unable to set XGMI per-link power down policy to {args.xgmi_plpd}"
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_INVAL:
-                        valid_policies = self.helpers.get_xgmi_plpd_policies()
-                        if valid_policies and valid_policies[0] != "N/A":
-                            valid_policies_str = f"[{', '.join(valid_policies)}]"
-                            self.logger.print_output(f"Valid XGMI PLPD Policies: {valid_policies_str}\n", None, None)
-                    
-                    self.logger.store_output(args.gpu, 'xgmiplpd', error_msg)
+                        xgmi_plpd_info = amdsmi_interface.amdsmi_get_xgmi_plpd(args.gpu)
+                        policy_string = "N/A"
+                        # Check if 'policies' key exists before accessing it
+                        if 'policies' in xgmi_plpd_info and xgmi_plpd_info['policies']:
+                            policy_string = ""
+                            for policy in xgmi_plpd_info['policies']:
+                                policy_string += f"{policy['policy_id']}: {policy['policy_description']}, "
+                            policy_string = policy_string.rstrip(", ")  # Remove trailing comma and space
+                        print(f"Valid XGMI PLPD Policies: [{policy_string}]\n")
+                    self.logger.store_output(args.gpu, 'xgmiplpd', f"[{e.get_error_info(detailed=False)}] Unable to set XGMI per-link power down policy to {args.xgmi_plpd}")
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
                     return

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
@@ -1067,8 +1067,6 @@ int Device::writeDevInfo(DevInfoTypes type, std::string val) {
   sysfs_path += kDevAttribNameMap.at(type);
   switch (type) {
     case kDevGPUMClk:
-    case kDevSocPstate:
-    case kDevXgmiPlpd:
     case kDevProcessIsolation:
     case kDevShaderClean:
     case kDevDCEFClk:
@@ -1082,6 +1080,9 @@ int Device::writeDevInfo(DevInfoTypes type, std::string val) {
     case kDevComputePartition:
     case kDevMemoryPartition:
     case kDevXcpConfig:
+      return writeDevInfoStr(type, val, true);
+    case kDevSocPstate:
+    case kDevXgmiPlpd:
       return writeDevInfoStr(type, val, true);
 
     default:

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
@@ -1080,7 +1080,6 @@ int Device::writeDevInfo(DevInfoTypes type, std::string val) {
     case kDevComputePartition:
     case kDevMemoryPartition:
     case kDevXcpConfig:
-      return writeDevInfoStr(type, val, true);
     case kDevSocPstate:
     case kDevXgmiPlpd:
       return writeDevInfoStr(type, val, true);

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -3818,7 +3818,7 @@ amdsmi_status_t amdsmi_get_xgmi_plpd(amdsmi_processor_handle processor_handle,
     memset(policy, 0, sizeof(*policy));
 
     // Use rsmi structure with correct size (32-byte description fields)
-    rsmi_dpm_policy_t rsmi_policy;
+    rsmi_dpm_policy_t rsmi_policy = {};
     amdsmi_status_t ret = rsmi_wrapper(rsmi_dev_xgmi_plpd_get, processor_handle, 0,
                     &rsmi_policy);
     

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -3766,8 +3766,36 @@ amdsmi_status_t amdsmi_get_soc_pstate(amdsmi_processor_handle processor_handle,
                          amdsmi_dpm_policy_t* policy) {
     AMDSMI_CHECK_INIT();
 
-    return rsmi_wrapper(rsmi_dev_soc_pstate_get, processor_handle, 0,
-                    reinterpret_cast<rsmi_dpm_policy_t*>(policy));
+    if (policy == nullptr) {
+        return AMDSMI_STATUS_INVAL;
+    }
+
+    // Initialize output structure to zero
+    memset(policy, 0, sizeof(*policy));
+
+    // Use rsmi structure with correct size (32-byte description fields)
+    rsmi_dpm_policy_t rsmi_policy;
+    amdsmi_status_t ret = rsmi_wrapper(rsmi_dev_soc_pstate_get, processor_handle, 0,
+                    &rsmi_policy);
+    
+    if (ret != AMDSMI_STATUS_SUCCESS) {
+        return ret;
+    }
+
+    // Copy data from rsmi structure to amdsmi structure field-by-field
+    // to handle the different structure sizes properly
+    policy->num_supported = rsmi_policy.num_supported;
+    policy->current = rsmi_policy.current;
+    
+    for (uint32_t i = 0; i < rsmi_policy.num_supported && i < AMDSMI_MAX_NUM_PM_POLICIES; i++) {
+        policy->policies[i].policy_id = rsmi_policy.policies[i].policy_id;
+        strncpy(policy->policies[i].policy_description, 
+                rsmi_policy.policies[i].policy_description,
+                AMDSMI_MAX_STRING_LENGTH - 1);
+        policy->policies[i].policy_description[AMDSMI_MAX_STRING_LENGTH - 1] = '\0';
+    }
+
+    return AMDSMI_STATUS_SUCCESS;
 }
 
 amdsmi_status_t amdsmi_set_xgmi_plpd(amdsmi_processor_handle processor_handle,
@@ -3782,8 +3810,36 @@ amdsmi_status_t amdsmi_get_xgmi_plpd(amdsmi_processor_handle processor_handle,
                          amdsmi_dpm_policy_t* policy) {
     AMDSMI_CHECK_INIT();
 
-    return rsmi_wrapper(rsmi_dev_xgmi_plpd_get, processor_handle, 0,
-                    reinterpret_cast<rsmi_dpm_policy_t*>(policy));
+    if (policy == nullptr) {
+        return AMDSMI_STATUS_INVAL;
+    }
+
+    // Initialize output structure to zero
+    memset(policy, 0, sizeof(*policy));
+
+    // Use rsmi structure with correct size (32-byte description fields)
+    rsmi_dpm_policy_t rsmi_policy;
+    amdsmi_status_t ret = rsmi_wrapper(rsmi_dev_xgmi_plpd_get, processor_handle, 0,
+                    &rsmi_policy);
+    
+    if (ret != AMDSMI_STATUS_SUCCESS) {
+        return ret;
+    }
+
+    // Copy data from rsmi structure to amdsmi structure field-by-field
+    // to handle the different structure sizes properly
+    policy->num_supported = rsmi_policy.num_supported;
+    policy->current = rsmi_policy.current;
+    
+    for (uint32_t i = 0; i < rsmi_policy.num_supported && i < AMDSMI_MAX_NUM_PM_POLICIES; i++) {
+        policy->policies[i].policy_id = rsmi_policy.policies[i].policy_id;
+        strncpy(policy->policies[i].policy_description, 
+                rsmi_policy.policies[i].policy_description,
+                AMDSMI_MAX_STRING_LENGTH - 1);
+        policy->policies[i].policy_description[AMDSMI_MAX_STRING_LENGTH - 1] = '\0';
+    }
+
+    return AMDSMI_STATUS_SUCCESS;
 }
 
 amdsmi_status_t amdsmi_get_gpu_process_isolation(amdsmi_processor_handle processor_handle,

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -3774,7 +3774,7 @@ amdsmi_status_t amdsmi_get_soc_pstate(amdsmi_processor_handle processor_handle,
     memset(policy, 0, sizeof(*policy));
 
     // Use rsmi structure with correct size (32-byte description fields)
-    rsmi_dpm_policy_t rsmi_policy;
+    rsmi_dpm_policy_t rsmi_policy = {};
     amdsmi_status_t ret = rsmi_wrapper(rsmi_dev_soc_pstate_get, processor_handle, 0,
                     &rsmi_policy);
     


### PR DESCRIPTION
## Motivation

Fix structure mismatch bug in amdsmi_get_soc_pstate() and amdsmi_get_xgmi_plpd() causing all policy IDs to display as 0. Replaced unsafe reinterpret_cast between incompatible structure types (260 vs 36 bytes) with field-by-field copying. Enhanced error handling and refined CSV output formatting.

## Technical Details

Core Fix (Phase 1):

Replaced reinterpret_cast with field-by-field copying in amd_smi.cc . Consolidated switch cases in [rocm_smi_device.cc]. Improved error messages and flattened CSV output in [amdsmi_commands.py].

## JIRA ID

Resolves SWDEV-564696

## Test Plan

Built with CMake/Make, tested amd-smi static --soc-pstate and --xgmi-plpd on MI300A hardware. Validated policy IDs display correctly (0,1,2,3), CSV produces clean 3-column format, and error messages show valid policy lists.

## Test Result

All builds successful (PSDB #2919 passed). Policy IDs now display correctly with unique values (0,1,2,3) instead of all 0s. CSV output clean without extra columns. Error handling shows valid policy lists. No regressions.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.