### PR TITLE
fix: prevent double-free crash during process exit in amd-smi

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/gpu.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/gpu.cpp
@@ -31,8 +31,6 @@
     }                                                                                    \
     }  // namespace ::tim::cereal
 
-#include "common/defines.h"
-
 #if !defined(ROCPROFSYS_USE_ROCM)
 #    define ROCPROFSYS_USE_ROCM 0
 #endif
@@ -43,6 +41,7 @@
 
 #include <timemory/manager.hpp>
 
+#include <dlfcn.h>
 #include <string>
 
 #include "core/agent_manager.hpp"
@@ -90,6 +89,17 @@ _amdsmi_is_initialized()
     return initialized;
 }
 
+void
+prevent_amdsmi_library_unload()
+{
+    static bool _initialized = false;
+    if(_initialized) return;
+    _initialized = true;
+
+    dlopen("libamd_smi.so", RTLD_NOW | RTLD_NOLOAD | RTLD_NODELETE);
+    dlopen("librocm_smi64.so", RTLD_NOW | RTLD_NOLOAD | RTLD_NODELETE);
+}
+
 bool
 amdsmi_init()
 {
@@ -100,6 +110,8 @@ amdsmi_init()
             ROCPROFSYS_AMD_SMI_CALL(::amdsmi_init(AMDSMI_INIT_AMD_GPUS));
             get_processor_handles();
             _amdsmi_is_initialized() = true;  // Mark as initialized
+
+            prevent_amdsmi_library_unload();
         } catch(std::exception& _e)
         {
             ROCPROFSYS_BASIC_VERBOSE(1, "Exception thrown initializing amd-smi: %s\n",

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -1265,10 +1265,7 @@ shutdown()
 
     try
     {
-        if(data::shutdown())
-        {
-            ROCPROFSYS_AMD_SMI_CALL(amdsmi_shut_down());
-        }
+        data::shutdown();
     } catch(std::runtime_error& _e)
     {
         ROCPROFSYS_VERBOSE(0, "Exception thrown when shutting down amd-smi: %s\n",

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/exit_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/exit_gotcha.cpp
@@ -25,7 +25,6 @@
 #include "core/config.hpp"
 #include "core/debug.hpp"
 #include "core/state.hpp"
-#include "core/timemory.hpp"
 #include "library/runtime.hpp"
 
 #include <timemory/backends/threading.hpp>
@@ -33,7 +32,9 @@
 #include <timemory/utility/types.hpp>
 
 #include <cstddef>
+#include <cstdio>
 #include <cstdlib>
+#include <unistd.h>
 
 namespace rocprofsys
 {
@@ -105,6 +106,39 @@ void
 exit_gotcha::operator()(const gotcha_data& _data, exit_func_t _func, int _ec) const
 {
     _exit_info = { true, _data.tool_id.find("quick") != std::string::npos, _ec };
+
+    if(config::get_use_amd_smi())
+    {
+        threading::clear_callbacks();
+
+        if(get_state() < ::rocprofsys::State::Finalized && !is_child_process())
+        {
+            if(config::settings_are_configured())
+            {
+                ROCPROFSYS_VERBOSE(0, "finalizing %s before calling %s(%i)...\n",
+                                   get_exe_name().c_str(), _data.tool_id.c_str(), _ec);
+            }
+            else
+            {
+                ROCPROFSYS_BASIC_VERBOSE(0, "finalizing %s before calling %s(%i)...\n",
+                                         get_exe_name().c_str(), _data.tool_id.c_str(),
+                                         _ec);
+            }
+
+            rocprofsys_finalize();
+        }
+
+        if(config::settings_are_configured())
+        {
+            ROCPROFSYS_VERBOSE(
+                0, "calling _exit(%i) in %s to avoid AMD SMI cleanup issues...\n", _ec,
+                get_exe_name().c_str());
+        }
+
+        std::fflush(nullptr);
+        _exit(_ec);
+    }
+
     invoke_exit_gotcha(_data, _func, _ec);
 }
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fix double-free crash during rocprofsys_finalize() when AMD SMI is enabled. The crash occurs in the AMD SMI library's static destructors during __cxa_finalize at process exit.
Depends on: #2212  (rccl-tests build infrastructure)

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

The AMD SMI library crashes when its static destructors run during process exit. This workaround:

- Prevents the library from being unloaded at exit
- Skips explicit shutdown call
- Uses _exit() to avoid running static destructors

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
SWDEV-542269

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

- ctest --test-dir <build_dir> -L "rccl-tests" --output-on-failure
- Verify no double-free crash occurs during test finalization

Prerequisites for RCCL Tests
To build and see rccl-tests, ensure the following dependencies are installed and configured before running CMake:
1. Install MPI
sudo apt updatesudo apt install -y openmpi-bin openmpi-common libopenmpi-dev

2. Set MPI Environment
export PATH=/usr/lib64/openmpi/bin:$PATH
export LD_LIBRARY_PATH=/usr/lib64/openmpi/lib:$LD_LIBRARY_PATH

3. Set ROCm Environment (for hipify-perl)
export PATH=/opt/rocm/bin:$PATH
export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH

4. Docker-specific (if running in container)
export OMPI_ALLOW_RUN_AS_ROOT=1export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1

**Note:** All environment variables must be set before running cmake --preset debug-optimized. If these are not configured, the rccl-tests will not be found during the CMake configure step.

## Test Result

<!-- Briefly summarize test outcomes. -->

- All 71 rccl-tests pass without crash on Navi, MI300X, 300A, 308, 325, 350 and 355X
- No double-free errors in profiling output
<img width="517" height="523" alt="image" src="https://github.com/user-attachments/assets/7dbaf1bc-514c-4ab0-a90a-f1947f4dc069" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
