### PR TITLE
Merge tests for binary atomic operations with different memory locality

### DIFF
--- a/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_and.cc
+++ b/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_and.cc
@@ -33,8 +33,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs a builtin atomic AND with memory scope WAVEFRONT from multiple threads on the same
- * address.
+ *  - Performs a builtin atomic AND with memory scope WAVEFRONT in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -43,63 +46,22 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Wavefront_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
-                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic AND with memory scope WAVEFRONT from multiple threads on adjacent
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_and.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Wavefront_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
-                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
-                                                                          sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic AND with memory scope WAVEFRONT from multiple threads on scattered
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_and.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Wavefront_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Wavefront", "", int, unsigned int,
+                   unsigned long, unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
+                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
+                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
+                                                                          sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
                                             __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
@@ -108,11 +70,15 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Wavefront_Scattered_Add
   }
 }
 
+
 /**
  * Test Description
  * ------------------------
- *  - Performs a builtin atomic AND with memory scope WORKGROUP from multiple threads on the same
- * address.
+ *  - Performs a builtin atomic AND with memory scope WORKGROUP in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -121,63 +87,22 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Wavefront_Scattered_Add
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Workgroup_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
-                                            __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic AND with memory scope WORKGROUP from multiple threads on adjacent
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_and.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Workgroup_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
-                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
-                                                                          sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic AND with memory scope WORKGROUP from multiple threads on scattered
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_and.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Workgroup_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Workgroup", "", int, unsigned int,
+                   unsigned long, unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
+                                            __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
+                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
+                                                                          sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
                                             __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,

--- a/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_max.cc
+++ b/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_max.cc
@@ -33,8 +33,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs a builtin atomic MAX with memory scope WAVEFRONT from multiple threads on the same
- * address.
+ *  - Performs a builtin atomic MAX with memory scope WAVEFRONT in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -43,63 +46,22 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Wavefront_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
-                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic MAX with memory scope WAVEFRONT from multiple threads on adjacent
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_max.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Wavefront_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
-                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
-                                                                         sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic MAX with memory scope WAVEFRONT from multiple threads on scattered
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_max.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Wavefront_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Wavefront", "", int, unsigned int,
+                   unsigned long, unsigned long long, float, double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
+                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
+                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
+                                                                         sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
@@ -111,8 +73,11 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Wavefront_Scattered_Add
 /**
  * Test Description
  * ------------------------
- *  - Performs a builtin atomic MAX with memory scope WORKGROUP from multiple threads on the same
- * address.
+ *  - Performs a builtin atomic MAX with memory scope WORKGROUP in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -121,63 +86,22 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Wavefront_Scattered_Add
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Workgroup_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
-                                           __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic MAX with memory scope WORKGROUP from multiple threads on adjacent
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_max.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Workgroup_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
-                                           __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
-                                                                         sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic MAX with memory scope WORKGROUP from multiple threads on scattered
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_max.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Workgroup_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Workgroup", "", int, unsigned int,
+                   unsigned long, unsigned long long, float, double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
+                                           __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
+                                           __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
+                                                                         sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,

--- a/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_min.cc
+++ b/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_min.cc
@@ -33,8 +33,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs a builtin atomic MIN with memory scope WAVEFRONT from multiple threads on the same
- * address.
+ *  - Performs a builtin atomic MIN with memory scope WAVEFRONT in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -43,63 +46,22 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Wavefront_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
-                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic MIN with memory scope WAVEFRONT from multiple threads on adjacent
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_min.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Wavefront_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
-                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
-                                                                         sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic MIN with memory scope WAVEFRONT from multiple threads on scattered
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_min.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Wavefront_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Wavefront", "", int, unsigned int,
+                   unsigned long, unsigned long long, float, double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
+                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
+                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
+                                                                         sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
@@ -111,8 +73,11 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Wavefront_Scattered_Add
 /**
  * Test Description
  * ------------------------
- *  - Performs a builtin atomic MIN with memory scope WORKGROUP from multiple threads on the same
- * address.
+ *  - Performs a builtin atomic MIN with memory scope WORKGROUP in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -121,63 +86,22 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Wavefront_Scattered_Add
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Workgroup_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
-                                           __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic MIN with memory scope WORKGROUP from multiple threads on adjacent
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_min.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Workgroup_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
-                                           __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
-                                                                         sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic MIN with memory scope WORKGROUP from multiple threads on scattered
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_min.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Workgroup_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Workgroup", "", int, unsigned int,
+                   unsigned long, unsigned long long, float, double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
+                                           __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
+                                           __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
+                                                                         sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,

--- a/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_or.cc
+++ b/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_or.cc
@@ -33,8 +33,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs a builtin atomic OR with memory scope WAVEFRONT from multiple threads on the same
- * address.
+ *  - Performs a builtin atomic OR with memory scope WAVEFRONT in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -43,63 +46,22 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Wavefront_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
-                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic OR with memory scope WAVEFRONT from multiple threads on adjacent
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_or.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Wavefront_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
-                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
-                                                                          sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic OR with memory scope WAVEFRONT from multiple threads on scattered
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_or.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Wavefront_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Wavefront", "", int, unsigned int,
+                   unsigned long, unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
+                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
+                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
+                                                                          sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
                                             __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
@@ -108,11 +70,15 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Wavefront_Scattered_Addr
   }
 }
 
+
 /**
  * Test Description
  * ------------------------
- *  - Performs a builtin atomic OR with memory scope WORKGROUP from multiple threads on the same
- * address.
+ *  - Performs a builtin atomic OR with memory scope WORKGROUP in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -121,63 +87,22 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Wavefront_Scattered_Addr
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Workgroup_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
-                                            __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic OR with memory scope WORKGROUP from multiple threads on adjacent
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_or.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Workgroup_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
-                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
-                                                                          sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic OR with memory scope WORKGROUP from multiple threads on scattered
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_or.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Workgroup_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Workgroup", "", int, unsigned int,
+                   unsigned long, unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
+                                            __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
+                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
+                                                                          sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
                                             __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,

--- a/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_xor.cc
+++ b/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_xor.cc
@@ -33,8 +33,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs a builtin atomic XOR with memory scope WAVEFRONT from multiple threads on the same
- * address.
+ *  - Performs a builtin atomic XOR with memory scope WAVEFRONT in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -43,63 +46,22 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Wavefront_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
-                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic XOR with memory scope WAVEFRONT from multiple threads on adjacent
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_xor.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Wavefront_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
-                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
-                                                                          sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic XOR with memory scope WAVEFRONT from multiple threads on scattered
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_xor.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Wavefront_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Wavefront", "", int, unsigned int,
+                   unsigned long, unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
+                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
+                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
+                                                                          sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
                                             __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
@@ -111,8 +73,11 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Wavefront_Scattered_Add
 /**
  * Test Description
  * ------------------------
- *  - Performs a builtin atomic XOR with memory scope WORKGROUP from multiple threads on the same
- * address.
+ *  - Performs a builtin atomic XOR with memory scope WORKGROUP in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -121,63 +86,22 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Wavefront_Scattered_Add
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Workgroup_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
-                                            __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic XOR with memory scope WORKGROUP from multiple threads on adjacent
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_xor.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Workgroup_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
-                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
-                                                                          sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs a builtin atomic XOR with memory scope WORKGROUP from multiple threads on scattered
- * addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/__hip_atomic_fetch_xor.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Workgroup_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Workgroup", "", int, unsigned int,
+                   unsigned long, unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
+                                            __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
+                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
+                                                                          sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
                                             __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,

--- a/projects/hip-tests/catch/unit/atomics/atomicAnd.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicAnd.cc
@@ -36,7 +36,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs atomicAnd from multiple threads on the same address.
+ *  - Performs atomicAnd in multiple memory patterns:
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -45,60 +49,21 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_SameAddress", "", int, unsigned int, unsigned long,
+TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Single_Kernel", "", int, unsigned int, unsigned long,
                    unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kAnd>(
-          1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicAnd from multiple threads on adjacent addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicAnd.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kAnd>(
-          warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicAnd from multiple threads on the scattered addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicAnd.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Scattered_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kAnd>(
+          1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kAnd>(
+          warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kAnd>(
           warp_size, cache_line_size);
@@ -109,7 +74,11 @@ TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Scattered_Addresses", "", int, unsig
 /**
  * Test Description
  * ------------------------
- *  - Performs atomicAnd from multiple threads on the same address.
+ *  - Performs atomicAnd in multiple memory patterns:
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches multiple kernels.
  * Test source
  * ------------------------
@@ -118,66 +87,30 @@ TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Scattered_Addresses", "", int, unsig
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Multi_Kernel_Same_Address", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAnd>(
-          2, 1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicAnd from multiple threads on adjacent addresses.
- *  - Uses only one device and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicAnd.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Multi_Kernel_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAnd>(
-          2, warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicAnd from multiple threads on the scattered addresses.
- *  - Uses only one device and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicAnd.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Multi_Kernel_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Multi_Kernel", "", int, unsigned int, unsigned long,
+                   unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAnd>(
+          2, 1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAnd>(
+          2, warp_size, sizeof(TestType));
+    }
+
     DYNAMIC_SECTION("Scattered address " << current) {
       Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAnd>(
           2, warp_size, cache_line_size);
     }
   }
 }
+
 
 /**
  * Test Description

--- a/projects/hip-tests/catch/unit/atomics/atomicAnd.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicAnd.cc
@@ -36,7 +36,7 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs atomicAnd in multiple memory patterns:
+ *  - Performs atomicAnd in multiple memory patterns.
  *    -# From multiple threads on the same address;
  *    -# From multiple threads on adjacent addresses;
  *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
@@ -49,7 +49,7 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Single_Kernel", "", int, unsigned int, unsigned long,
+TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive", "", int, unsigned int, unsigned long,
                    unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
@@ -74,7 +74,7 @@ TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Single_Kernel", "", int, unsigned in
 /**
  * Test Description
  * ------------------------
- *  - Performs atomicAnd in multiple memory patterns:
+ *  - Performs atomicAnd in multiple memory patterns.
  *    -# From multiple threads on the same address;
  *    -# From multiple threads on adjacent addresses;
  *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line

--- a/projects/hip-tests/catch/unit/atomics/atomicAnd.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicAnd.cc
@@ -111,7 +111,6 @@ TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Multi_Kernel", "", int, unsigned int
   }
 }
 
-
 /**
  * Test Description
  * ------------------------

--- a/projects/hip-tests/catch/unit/atomics/atomicAnd_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicAnd_system.cc
@@ -35,7 +35,7 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs atomicAnd_system in multiple memory patterns:
+ *  - Performs atomicAnd_system in multiple memory patterns.
  *    -# From multiple threads on the same address;
  *    -# From multiple threads on adjacent addresses;
  *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line

--- a/projects/hip-tests/catch/unit/atomics/atomicAnd_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicAnd_system.cc
@@ -35,7 +35,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs atomicAnd_system from multiple threads on the same address.
+ *  - Performs atomicAnd_system in multiple memory patterns:
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses multiple devices and launches multiple kernels.
  * Test source
  * ------------------------
@@ -45,65 +49,21 @@ THE SOFTWARE.
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicAnd_system_Positive_Peer_GPUs_Same_Address",
-                   "[multigpu]", int, unsigned int, unsigned long,
-                   unsigned long long) {
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAndSystem>(
-          2, 2, 1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicAnd_system from multiple threads on adjacent addresses.
- *  - Uses multiple devices and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicAnd_system.cc
- * Test requirements
- * ------------------------
- *  - Multi-device
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE(
-    "Unit_atomicAnd_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]",
-    int, unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAndSystem>(
-          2, 2, warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicAnd_system from multiple threads on scattered addresses.
- *  - Uses multiple devices and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicAnd_system.cc
- * Test requirements
- * ------------------------
- *  - Multi-device
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE(
-    "Unit_atomicAnd_system_Positive_Peer_GPUs_Scattered_Addresses",
-    "[multigpu]", int, unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit_atomicAnd_system_Positive_Peer_GPUs", "[multigpu]", int, unsigned int,
+                   unsigned long, unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAndSystem>(
+          2, 2, 1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAndSystem>(
+          2, 2, warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAndSystem>(
           2, 2, warp_size, cache_line_size);

--- a/projects/hip-tests/catch/unit/atomics/atomicMax.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicMax.cc
@@ -71,7 +71,6 @@ TEMPLATE_TEST_CASE("Unit_atomicMax_Positive", "", int, unsigned int, unsigned lo
   }
 }
 
-
 /**
  * Test Description
  * ------------------------

--- a/projects/hip-tests/catch/unit/atomics/atomicMax.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicMax.cc
@@ -36,7 +36,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs atomicMax from multiple threads on the same address.
+ *  - Performs atomicMax in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -45,60 +49,21 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_SameAddress", "", int, unsigned int, unsigned long,
+TEMPLATE_TEST_CASE("Unit_atomicMax_Positive", "", int, unsigned int, unsigned long,
                    unsigned long long, float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kMax>(
-          1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicMax from multiple threads on adjacent addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kMax>(
-          warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicMax from multiple threads on the scaterred addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Scattered_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kMax>(
+          1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kMax>(
+          warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kMax>(
           warp_size, cache_line_size);
@@ -106,10 +71,15 @@ TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Scattered_Addresses", "", int, unsig
   }
 }
 
+
 /**
  * Test Description
  * ------------------------
- *  - Performs atomicMax from multiple threads on the same address.
+ *  - Performs atomicMax in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches multiple kernels.
  * Test source
  * ------------------------
@@ -118,60 +88,20 @@ TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Scattered_Addresses", "", int, unsig
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Multi_Kernel_Same_Address", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Multi_Kernel", "", int, unsigned int, unsigned long,
+                   unsigned long long, float, double) {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
   for (auto current = 0; current < cmd_options.iterations; ++current) {
     DYNAMIC_SECTION("Same address " << current) {
       MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMax>(
           2, 1, sizeof(TestType));
     }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicMax from multiple threads on adjacent addresses.
- *  - Uses only one device and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Multi_Kernel_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
     DYNAMIC_SECTION("Adjacent address " << current) {
       MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMax>(
           2, warp_size, sizeof(TestType));
     }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicMax from multiple threads on the scaterred addresses.
- *  - Uses only one device and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Multi_Kernel_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
     DYNAMIC_SECTION("Scattered address " << current) {
       MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMax>(
           2, warp_size, cache_line_size);

--- a/projects/hip-tests/catch/unit/atomics/atomicMax_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicMax_system.cc
@@ -35,7 +35,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs atomicMax_system from multiple threads on the same address.
+ *  - Performs atomicMax_system in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses multiple devices and launches multiple kernels.
  * Test source
  * ------------------------
@@ -46,83 +50,25 @@ THE SOFTWARE.
  *  - HIP_VERSION >= 5.2
  */
 #if HT_AMD
-TEMPLATE_TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs_Same_Address",
-                   "[multigpu]", int, unsigned int, unsigned long,
-                   unsigned long long, float, double) {
+TEMPLATE_TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs", "[multigpu]", int, unsigned int,
+                   unsigned long, unsigned long long, float, double) {
 #else
-TEMPLATE_TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs_Same_Address",
-                   "[multigpu]", int, unsigned int, unsigned long,
-                   unsigned long long) {
-#endif
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMaxSystem>(
-          2, 2, 1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicMax_system from multiple threads on adjacent addresses.
- *  - Uses multiple devices and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicMax_system.cc
- * Test requirements
- * ------------------------
- *  - Multi-device
- *  - HIP_VERSION >= 5.2
- */
-#if HT_AMD
-TEMPLATE_TEST_CASE(
-    "Unit_atomicMax_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]",
-    int, unsigned int, unsigned long, unsigned long long, float, double) {
-#else
-TEMPLATE_TEST_CASE(
-    "Unit_atomicMax_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]",
-    int, unsigned int, unsigned long, unsigned long long) {
-#endif
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMaxSystem>(
-          2, 2, warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicMax_system from multiple threads on scaterred addresses.
- *  - Uses multiple devices and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicMax_system.cc
- * Test requirements
- * ------------------------
- *  - Multi-device
- *  - HIP_VERSION >= 5.2
- */
-#if HT_AMD
-TEMPLATE_TEST_CASE(
-    "Unit_atomicMax_system_Positive_Peer_GPUs_Scattered_Addresses",
-    "[multigpu]", int, unsigned int, unsigned long, unsigned long long, float,
-    double) {
-#else
-TEMPLATE_TEST_CASE(
-    "Unit_atomicMax_system_Positive_Peer_GPUs_Scattered_Addresses",
-    "[multigpu]", int, unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs", "[multigpu]", int, unsigned int,
+                   unsigned long, unsigned long long) {
 #endif
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMaxSystem>(
+          2, 2, 1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMaxSystem>(
+          2, 2, warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMaxSystem>(
           2, 2, warp_size, cache_line_size);

--- a/projects/hip-tests/catch/unit/atomics/atomicMin.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicMin.cc
@@ -36,7 +36,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs atomicMin from multiple threads on the same address.
+ *  - Performs atomicMin in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -45,60 +49,21 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_SameAddress", "", int, unsigned int, unsigned long,
+TEMPLATE_TEST_CASE("Unit_atomicMin_Positive", "", int, unsigned int, unsigned long,
                    unsigned long long, float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kMin>(
-          1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicMin from multiple threads on adjacent addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kMin>(
-          warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicMin from multiple threads on the scaterred addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Scattered_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kMin>(
+          1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kMin>(
+          warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kMin>(
           warp_size, cache_line_size);
@@ -109,7 +74,11 @@ TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Scattered_Addresses", "", int, unsig
 /**
  * Test Description
  * ------------------------
- *  - Performs atomicMin from multiple threads on the same address.
+ *  - Performs atomicMin in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches multiple kernels.
  * Test source
  * ------------------------
@@ -118,60 +87,21 @@ TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Scattered_Addresses", "", int, unsig
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Multi_Kernel_Same_Address", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMin>(
-          2, 1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicMin from multiple threads on adjacent addresses.
- *  - Uses only one device and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Multi_Kernel_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMin>(
-          2, warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicMin from multiple threads on the scaterred addresses.
- *  - Uses only one device and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Multi_Kernel_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
+TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Multi_Kernel", "", int, unsigned int, unsigned long,
+                   unsigned long long, float, double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMin>(
+          2, 1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMin>(
+          2, warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMin>(
           2, warp_size, cache_line_size);

--- a/projects/hip-tests/catch/unit/atomics/atomicMin_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicMin_system.cc
@@ -35,7 +35,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs atomicMin_system from multiple threads on the same address.
+ *  - Performs atomicMin_system in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses multiple devices and launches multiple kernels.
  * Test source
  * ------------------------
@@ -46,83 +50,25 @@ THE SOFTWARE.
  *  - HIP_VERSION >= 5.2
  */
 #if HT_AMD
-TEMPLATE_TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs_Same_Address",
-                   "[multigpu]", int, unsigned int, unsigned long,
-                   unsigned long long, float, double) {
+TEMPLATE_TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs", "[multigpu]", int, unsigned int,
+                   unsigned long, unsigned long long, float, double) {
 #else
-TEMPLATE_TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs_Same_Address",
-                   "[multigpu]", int, unsigned int, unsigned long,
-                   unsigned long long) {
-#endif
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMinSystem>(
-          2, 2, 1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicMin_system from multiple threads on adjacent addresses.
- *  - Uses multiple devices and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicMin_system.cc
- * Test requirements
- * ------------------------
- *  - Multi-device
- *  - HIP_VERSION >= 5.2
- */
-#if HT_AMD
-TEMPLATE_TEST_CASE(
-    "Unit_atomicMin_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]",
-    int, unsigned int, unsigned long, unsigned long long, float, double) {
-#else
-TEMPLATE_TEST_CASE(
-    "Unit_atomicMin_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]",
-    int, unsigned int, unsigned long, unsigned long long) {
-#endif
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMinSystem>(
-          2, 2, warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicMin_system from multiple threads on scaterred addresses.
- *  - Uses multiple devices and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicMin_system.cc
- * Test requirements
- * ------------------------
- *  - Multi-device
- *  - HIP_VERSION >= 5.2
- */
-#if HT_AMD
-TEMPLATE_TEST_CASE(
-    "Unit_atomicMin_system_Positive_Peer_GPUs_Scattered_Addresses",
-    "[multigpu]", int, unsigned int, unsigned long, unsigned long long, float,
-    double) {
-#else
-TEMPLATE_TEST_CASE(
-    "Unit_atomicMin_system_Positive_Peer_GPUs_Scattered_Addresses",
-    "[multigpu]", int, unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs", "[multigpu]", int, unsigned int,
+                   unsigned long, unsigned long long) {
 #endif
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMinSystem>(
+          2, 2, 1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMinSystem>(
+          2, 2, warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMinSystem>(
           2, 2, warp_size, cache_line_size);

--- a/projects/hip-tests/catch/unit/atomics/atomicOr.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicOr.cc
@@ -36,7 +36,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs atomicOr from multiple threads on the same address.
+ *  - Performs atomicOr in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -45,60 +49,21 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_SameAddress", "", int, unsigned int, unsigned long,
+TEMPLATE_TEST_CASE("Unit_atomicOr_Positive", "", int, unsigned int, unsigned long,
                    unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kOr>(
-          1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicOr from multiple threads on adjacent addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicOr.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kOr>(
-          warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicOr from multiple threads on the scattered addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicOr.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Scattered_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kOr>(
+          1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kOr>(
+          warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kOr>(
           warp_size, cache_line_size);
@@ -106,10 +71,15 @@ TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Scattered_Addresses", "", int, unsign
   }
 }
 
+
 /**
  * Test Description
  * ------------------------
- *  - Performs atomicOr from multiple threads on the same address.
+ *  - Performs atomicOr in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches multiple kernels.
  * Test source
  * ------------------------
@@ -118,60 +88,21 @@ TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Scattered_Addresses", "", int, unsign
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Multi_Kernel_Same_Address", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOr>(
-          2, 1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicOr from multiple threads on adjacent addresses.
- *  - Uses only one device and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicOr.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Multi_Kernel_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOr>(
-          2, warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicOr from multiple threads on the scattered addresses.
- *  - Uses only one device and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicOr.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Multi_Kernel_Scattered_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Multi_Kernel", "", int, unsigned int, unsigned long,
+                   unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOr>(
+          2, 1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOr>(
+          2, warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOr>(
           2, warp_size, cache_line_size);

--- a/projects/hip-tests/catch/unit/atomics/atomicOr_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicOr_system.cc
@@ -35,7 +35,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs atomicOr_system from multiple threads on the same address.
+ *  - Performs atomicOr_system in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses multiple devices and launches multiple kernels.
  * Test source
  * ------------------------
@@ -45,65 +49,21 @@ THE SOFTWARE.
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicOr_system_Positive_Peer_GPUs_Same_Address",
-                   "[multigpu]", int, unsigned int, unsigned long,
-                   unsigned long long) {
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOrSystem>(
-          2, 2, 1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicOr_system from multiple threads on adjacent addresses.
- *  - Uses multiple devices and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicOr_system.cc
- * Test requirements
- * ------------------------
- *  - Multi-device
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicOr_system_Positive_Peer_GPUs_Adjacent_Addresses",
-                   "[multigpu]", int, unsigned int, unsigned long,
-                   unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOrSystem>(
-          2, 2, warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicOr_system from multiple threads on scattered addresses.
- *  - Uses multiple devices and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicOr_system.cc
- * Test requirements
- * ------------------------
- *  - Multi-device
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE(
-    "Unit_atomicOr_system_Positive_Peer_GPUs_Scattered_Addresses", "[multigpu]",
-    int, unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit_atomicOr_system_Positive_Peer_GPUs", "[multigpu]", int, unsigned int,
+                   unsigned long, unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOrSystem>(
+          2, 2, 1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOrSystem>(
+          2, 2, warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOrSystem>(
           2, 2, warp_size, cache_line_size);

--- a/projects/hip-tests/catch/unit/atomics/atomicXor.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicXor.cc
@@ -36,7 +36,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs atomicXor from multiple threads on the same address.
+ *  - Performs atomicXor in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -45,60 +49,21 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_SameAddress", "", int, unsigned int, unsigned long,
+TEMPLATE_TEST_CASE("Unit_atomicXor_Positive", "", int, unsigned int, unsigned long,
                    unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kXor>(
-          1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicXor from multiple threads on adjacent addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicXor.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kXor>(
-          warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicXor from multiple threads on the scattered addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicXor.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Scattered_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kXor>(
+          1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kXor>(
+          warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kXor>(
           warp_size, cache_line_size);
@@ -109,7 +74,11 @@ TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Scattered_Addresses", "", int, unsig
 /**
  * Test Description
  * ------------------------
- *  - Performs atomicXor from multiple threads on the same address.
+ *  - Performs atomicXor in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches multiple kernels.
  * Test source
  * ------------------------
@@ -118,65 +87,28 @@ TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Scattered_Addresses", "", int, unsig
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Multi_Kernel_Same_Address", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXor>(
-          2, 1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicXor from multiple threads on adjacent addresses.
- *  - Uses only one device and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicXor.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Multi_Kernel_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXor>(
-          2, warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicXor from multiple threads on the scattered addresses.
- *  - Uses only one device and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicXor.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Multi_Kernel_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Multi_Kernel", "", int, unsigned int, unsigned long,
+                   unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXor>(
+          2, 1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXor>(
+          2, warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXor>(
           2, warp_size, cache_line_size);
     }
   }
 }
+
 
 /**
  * Test Description

--- a/projects/hip-tests/catch/unit/atomics/atomicXor_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicXor_system.cc
@@ -35,7 +35,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs atomicXor_system from multiple threads on the same address.
+ *  - Performs atomicXor_system in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses multiple devices and launches multiple kernels.
  * Test source
  * ------------------------
@@ -45,72 +49,27 @@ THE SOFTWARE.
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicXor_system_Positive_Peer_GPUs_Same_Address",
-                   "[multigpu]", int, unsigned int, unsigned long,
-                   unsigned long long) {
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXorSystem>(
-          2, 2, 1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicXor_system from multiple threads on adjacent addresses.
- *  - Uses multiple devices and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicXor_system.cc
- * Test requirements
- * ------------------------
- *  - Multi-device
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE(
-    "Unit_atomicXor_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]",
-    int, unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXorSystem>(
-          2, 2, warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicXor_system from multiple threads on scattered addresses.
- *  - Uses multiple devices and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicXor_system.cc
- * Test requirements
- * ------------------------
- *  - Multi-device
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE(
-    "Unit_atomicXor_system_Positive_Peer_GPUs_Scattered_Addresses",
-    "[multigpu]", int, unsigned int, unsigned long, unsigned long long) {
+TEMPLATE_TEST_CASE("Unit_atomicXor_system_Positive_Peer_GPUs", "[multigpu]", int, unsigned int,
+                   unsigned long, unsigned long long) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXorSystem>(
+          2, 2, 1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXorSystem>(
+          2, 2, warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXorSystem>(
           2, 2, warp_size, cache_line_size);
     }
   }
 }
-
 /**
  * End doxygen group AtomicsTest.
  * @}

--- a/projects/hip-tests/catch/unit/atomics/safeAtomicMax.cc
+++ b/projects/hip-tests/catch/unit/atomics/safeAtomicMax.cc
@@ -35,7 +35,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs safeAtomicMax from multiple threads on the same address.
+ *  - Performs safeAtomicMax in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -44,57 +48,20 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_SameAddress", "", float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kSafeMax>(
-          1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs safeAtomicMax from multiple threads on adjacent addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/safeAtomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_Adjacent_Addresses", "", float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kSafeMax>(
-          warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs safeAtomicMax from multiple threads on the scattered addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/safeAtomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_Scattered_Addresses", "", float, double) {
+TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive", "", float, double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kSafeMax>(
+          1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kSafeMax>(
+          warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kSafeMax>(
           warp_size, cache_line_size);
@@ -105,7 +72,11 @@ TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_Scattered_Addresses", "", float,
 /**
  * Test Description
  * ------------------------
- *  - Performs safeAtomicMax from multiple threads on the same address.
+ *  - Performs safeAtomicMax in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches multiple kernels.
  * Test source
  * ------------------------
@@ -114,59 +85,20 @@ TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_Scattered_Addresses", "", float,
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_Multi_Kernel_Same_Address", "", float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMax>(
-          2, 1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs safeAtomicMax from multiple threads on adjacent addresses.
- *  - Uses only one device and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/safeAtomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_Multi_Kernel_Adjacent_Addresses", "", float,
-                   double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMax>(
-          2, warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs safeAtomicMax from multiple threads on the scattered addresses.
- *  - Uses only one device and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/safeAtomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_Multi_Kernel_Scattered_Addresses", "", float,
-                   double) {
+TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_Multi_Kernel", "", float, double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMax>(
+          2, 1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMax>(
+          2, warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMax>(
           2, warp_size, cache_line_size);

--- a/projects/hip-tests/catch/unit/atomics/safeAtomicMin.cc
+++ b/projects/hip-tests/catch/unit/atomics/safeAtomicMin.cc
@@ -35,7 +35,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs safeAtomicMin from multiple threads on the same address.
+ *  - Performs safeAtomicMin in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -44,57 +48,20 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_SameAddress", "", float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kSafeMin>(
-          1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs safeAtomicMin from multiple threads on adjacent addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/safeAtomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_Adjacent_Addresses", "", float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kSafeMin>(
-          warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs safeAtomicMin from multiple threads on the scattered addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/safeAtomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_Scattered_Addresses", "", float, double) {
+TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive", "", float, double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kSafeMin>(
+          1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kSafeMin>(
+          warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kSafeMin>(
           warp_size, cache_line_size);
@@ -105,7 +72,11 @@ TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_Scattered_Addresses", "", float,
 /**
  * Test Description
  * ------------------------
- *  - Performs safeAtomicMin from multiple threads on the same address.
+ *  - Performs safeAtomicMin in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches multiple kernels.
  * Test source
  * ------------------------
@@ -114,59 +85,20 @@ TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_Scattered_Addresses", "", float,
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_Multi_Kernel_Same_Address", "", float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMin>(
-          2, 1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs safeAtomicMin from multiple threads on adjacent addresses.
- *  - Uses only one device and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/safeAtomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_Multi_Kernel_Adjacent_Addresses", "", float,
-                   double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMin>(
-          2, warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs safeAtomicMin from multiple threads on the scattered addresses.
- *  - Uses only one device and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/safeAtomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_Multi_Kernel_Scattered_Addresses", "", float,
-                   double) {
+TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_Multi_Kernel", "", float, double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMin>(
+          2, 1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMin>(
+          2, warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMin>(
           2, warp_size, cache_line_size);

--- a/projects/hip-tests/catch/unit/atomics/unsafeAtomicMax.cc
+++ b/projects/hip-tests/catch/unit/atomics/unsafeAtomicMax.cc
@@ -35,7 +35,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs unsafeAtomicMax from multiple threads on the same address.
+ *  - Performs unsafeAtomicMax in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -44,57 +48,20 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_SameAddress", "", float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMax>(
-          1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs unsafeAtomicMax from multiple threads on adjacent addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/unsafeAtomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_Adjacent_Addresses", "", float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMax>(
-          warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs unsafeAtomicMax from multiple threads on the scattered addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/unsafeAtomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_Scattered_Addresses", "", float, double) {
+TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive", "", float, double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMax>(
+          1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMax>(
+          warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMax>(
           warp_size, cache_line_size);
@@ -105,7 +72,11 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_Scattered_Addresses", "", floa
 /**
  * Test Description
  * ------------------------
- *  - Performs unsafeAtomicMax from multiple threads on the same address.
+ *  - Performs unsafeAtomicMax in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches multiple kernels.
  * Test source
  * ------------------------
@@ -114,59 +85,20 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_Scattered_Addresses", "", floa
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_Multi_Kernel_Same_Address", "", float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMax>(
-          2, 1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs unsafeAtomicMax from multiple threads on adjacent addresses.
- *  - Uses only one device and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/unsafeAtomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_Multi_Kernel_Adjacent_Addresses", "", float,
-                   double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMax>(
-          2, warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs unsafeAtomicMax from multiple threads on the scattered addresses.
- *  - Uses only one device and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/unsafeAtomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_Multi_Kernel_Scattered_Addresses", "", float,
-                   double) {
+TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_Multi_Kernel", "", float, double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMax>(
+          2, 1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMax>(
+          2, warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMax>(
           2, warp_size, cache_line_size);

--- a/projects/hip-tests/catch/unit/atomics/unsafeAtomicMin.cc
+++ b/projects/hip-tests/catch/unit/atomics/unsafeAtomicMin.cc
@@ -35,7 +35,11 @@ THE SOFTWARE.
 /**
  * Test Description
  * ------------------------
- *  - Performs unsafeAtomicMin from multiple threads on the same address.
+ *  - Performs unsafeAtomicMin in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches one kernel.
  * Test source
  * ------------------------
@@ -44,57 +48,20 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_SameAddress", "", float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMin>(
-          1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs unsafeAtomicMin from multiple threads on adjacent addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/unsafeAtomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_Adjacent_Addresses", "", float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMin>(
-          warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs unsafeAtomicMin from multiple threads on the scattered addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/unsafeAtomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_Scattered_Addresses", "", float, double) {
+TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive", "", float, double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMin>(
+          1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMin>(
+          warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMin>(
           warp_size, cache_line_size);
@@ -102,10 +69,15 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_Scattered_Addresses", "", floa
   }
 }
 
+
 /**
  * Test Description
  * ------------------------
- *  - Performs unsafeAtomicMin from multiple threads on the same address.
+ *  - Performs unsafeAtomicMin in multiple memory patterns.
+ *    -# From multiple threads on the same address;
+ *    -# From multiple threads on adjacent addresses;
+ *    -# From multiple threads on the scattered addresses. Addresses are spread by L1 cache line
+ *        size;
  *  - Uses only one device and launches multiple kernels.
  * Test source
  * ------------------------
@@ -114,59 +86,20 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_Scattered_Addresses", "", floa
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_Multi_Kernel_Same_Address", "", float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMin>(
-          2, 1, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs unsafeAtomicMin from multiple threads on adjacent addresses.
- *  - Uses only one device and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/unsafeAtomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_Multi_Kernel_Adjacent_Addresses", "", float,
-                   double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMin>(
-          2, warp_size, sizeof(TestType));
-    }
-  }
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Performs unsafeAtomicMin from multiple threads on the scattered addresses.
- *  - Uses only one device and launches multiple kernels.
- * Test source
- * ------------------------
- *  - unit/atomics/unsafeAtomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_Multi_Kernel_Scattered_Addresses", "", float,
-                   double) {
+TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_Multi_Kernel", "", float, double) {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
   for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMin>(
+          2, 1, sizeof(TestType));
+    }
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMin>(
+          2, warp_size, sizeof(TestType));
+    }
     DYNAMIC_SECTION("Scattered address " << current) {
       MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMin>(
           2, warp_size, cache_line_size);


### PR DESCRIPTION
## Motivation
We want to reduce the number of tests to speed up compilation and run time. This PR starts merging similar tests to avoid setup/teardown costs while preserving the required checks.  
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
PR merges atomic And/Or/Xor/Max/Min tests from three separate tests (Same address, adjacent addresses and scattered addresses) into a single one with three dynamic sections.
Approach is similar to [AtomicAdd tests](https://github.com/ROCm/rocm-systems/blob/develop/projects/hip-tests/catch/unit/atomics/atomicAdd.cc#L59-L78).
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
Part of the HIP tests improvement board
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
Merged tests should pass as before.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Waiting for PSDB.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
