### PR TITLE
[SWDEV-571334] Fix NPM node_handle issue with older driver

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -85,6 +85,7 @@ class AMDSMICommands():
                         continue
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     if e.err_code in (amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED,
+                                      amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_FILE_ERROR,
                                       amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_INVAL):
                         logging.debug("Unable to get node handle: %s", e.get_error_info())
                     else:


### PR DESCRIPTION

## Motivation

amd-smi thows FILE_ERROR with old drivers.

## Technical Details

Older driver throwing FILE_ERROR when trying to get NPM handle.

## JIRA ID

SWDEV-571334

## Test Plan

Verified with CLI

## Test Result

Passed, attached logs

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
