### PR TITLE
[SWDEV-571334] Dont crash on node handle error

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -82,13 +82,11 @@ class AMDSMICommands():
                     nh = amdsmi_interface.amdsmi_get_node_handle(dev)
                     if nh is not None:
                         self.node_handle = nh
-                        continue
+                        # Only need one handle, break after first success
+                        break
                 except amdsmi_exception.AmdSmiLibraryException as e:
-                    if e.err_code in (amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED,
-                                      amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_INVAL):
-                        logging.debug("Unable to get node handle: %s", e.get_error_info())
-                    else:
-                        raise e
+                    logging.debug("Unable to get node handle: %s", e.get_error_info())
+                    # Node handle functionality is optional, so don't raise an error
 
         if self.helpers.is_amd_hsmp_initialized():
             try:


### PR DESCRIPTION
## Motivation

amd-smi thows FILE_ERROR with old drivers.

## Technical Details

Older driver throwing FILE_ERROR when trying to get NPM handle.

## JIRA ID

SWDEV-571334

## Test Plan

Verified with CLI

## Test Result

Passed CLI run.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
