### PR TITLE
SWDEV-548892 - Stop using ocml exp10 functions

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -1681,7 +1681,7 @@ __BF16_DEVICE_STATIC__ __hip_bfloat16 hexp(const __hip_bfloat16 h) {
  * \brief Calculate exponential 10 of bfloat16
  */
 __BF16_DEVICE_STATIC__ __hip_bfloat16 hexp10(const __hip_bfloat16 h) {
-  return __float2bfloat16(__ocml_exp10_f32(__bfloat162float(h)));
+  return __float2bfloat16(__builtin_elementwise_exp10(__bfloat162float(h)));
 }
 
 /**

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp16.h
@@ -949,7 +949,7 @@ inline __device__ __half hexp2(__half x) {
   return __half_raw{__builtin_elementwise_exp2(static_cast<__half_raw>(x).data)};
 }
 inline __device__ __half hexp10(__half x) {
-  return __half_raw{__ocml_exp10_f16(static_cast<__half_raw>(x).data)};
+  return __half_raw{__builtin_elementwise_exp10(static_cast<__half_raw>(x).data)};
 }
 inline __device__ __half hlog2(__half x) {
   return __half_raw{__builtin_elementwise_log2(static_cast<__half_raw>(x).data)};
@@ -998,7 +998,10 @@ inline __device__ __half2 h2exp(__half2 x) {
 inline __device__ __half2 h2exp2(__half2 x) {
   return __half2{__builtin_elementwise_exp2(static_cast<__half2_raw>(x).data)};
 }
-inline __device__ __half2 h2exp10(__half2 x) { return __half2{__ocml_exp10_2f16(x)}; }
+inline __device__ __half2 h2exp10(__half2 x) {
+  return __half2{__builtin_elementwise_exp10(static_cast<__half2_raw>(x).data)};
+}
+
 inline __device__ __half2 h2log2(__half2 x) {
   return __half2{__builtin_elementwise_log2(static_cast<__half2_raw>(x).data)};
 }


### PR DESCRIPTION
Follow exp and exp2. I only separated exp10 just in case it breaks a build somewhere, since the elementwise exp10 builtin is much more recent than the others.