### PR TITLE
[SWDEV-569899] Optimized KFD node enumeration and KFD process listing

### DIFF
--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -705,6 +705,11 @@ amdsmi_get_gpu_device_uuid(amdsmi_processor_handle processor_handle,
     return status;
 }
 
+// Add a static cache for KFD nodes with initialization flag
+static std::once_flag kfd_nodes_initialized;
+static std::map<uint64_t, std::shared_ptr<amd::smi::KFDNode>> cached_nodes;
+static uint32_t cached_smallest_node_id = std::numeric_limits<uint32_t>::max();
+
 amdsmi_status_t
 amdsmi_get_gpu_enumeration_info(amdsmi_processor_handle processor_handle,
                                 amdsmi_enumeration_info_t *info){
@@ -733,25 +738,26 @@ amdsmi_get_gpu_enumeration_info(amdsmi_processor_handle processor_handle,
     info->drm_render = gpu_device->get_drm_render_minor();
 
     // Retrieve HIP ID (difference from the smallest node ID) and HSA ID
-    std::map<uint64_t, std::shared_ptr<amd::smi::KFDNode>> nodes;
-    if (amd::smi::DiscoverKFDNodes(&nodes) == 0) {
-        uint32_t smallest_node_id = std::numeric_limits<uint32_t>::max();
-        for (const auto& node_pair : nodes) {
-            uint32_t node_id = 0;
-            if (node_pair.second->get_node_id(&node_id) == 0) {
-                smallest_node_id = std::min(smallest_node_id, node_id);
+    // Initialize KFD nodes once
+    std::call_once(kfd_nodes_initialized, []() {
+        if (amd::smi::DiscoverKFDNodes(&cached_nodes) == 0) {
+            for (const auto& node_pair : cached_nodes) {
+                uint32_t node_id = 0;
+                if (node_pair.second->get_node_id(&node_id) == 0) {
+                    cached_smallest_node_id = std::min(cached_smallest_node_id, node_id);
+                }
             }
         }
+    });
 
-        // Default to 0xffffffff as not supported
-        info->hsa_id = std::numeric_limits<uint32_t>::max();
-        info->hip_id = std::numeric_limits<uint32_t>::max();
-        amdsmi_kfd_info_t kfd_info;
-        status = amdsmi_get_gpu_kfd_info(processor_handle, &kfd_info);
-        if (status == AMDSMI_STATUS_SUCCESS) {
-            info->hsa_id = kfd_info.node_id;
-            info->hip_id = kfd_info.node_id - smallest_node_id;
-        }
+    // Default to 0xffffffff as not supported
+    info->hsa_id = std::numeric_limits<uint32_t>::max();
+    info->hip_id = std::numeric_limits<uint32_t>::max();
+    amdsmi_kfd_info_t kfd_info;
+    status = amdsmi_get_gpu_kfd_info(processor_handle, &kfd_info);
+    if (status == AMDSMI_STATUS_SUCCESS) {
+        info->hsa_id = kfd_info.node_id;
+        info->hip_id = kfd_info.node_id - cached_smallest_node_id;
     }
 
     // Retrieve HIP UUID

--- a/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
@@ -113,6 +113,16 @@ pthread_mutex_t* AMDSmiGPUDevice::get_mutex() {
     return amd::smi::GetMutex(gpu_id_);
 }
 
+// cache the compute process list for the device
+static std::chrono::steady_clock::time_point last_compute_process_list_update_time;
+static const std::chrono::milliseconds compute_process_list_cache_duration = std::chrono::milliseconds(500); // 500 ms
+static std::mutex compute_process_list_mutex;
+static uint32_t num_running_processes = 0;
+using RsmiDeviceList_t = uint32_t[];
+using RsmiProcessList_t = rsmi_process_info_t[];
+static std::unique_ptr<RsmiProcessList_t> list_all_processes_ptr = std::make_unique<RsmiProcessList_t>(0);
+static std::unordered_map<uint32_t, amdsmi_proc_info_t> process_info_cache_map;
+
 int32_t AMDSmiGPUDevice::get_compute_process_list_impl(GPUComputeProcessList_t& compute_process_list,
                                                        ComputeProcessListType_t list_type)
 {
@@ -127,30 +137,35 @@ int32_t AMDSmiGPUDevice::get_compute_process_list_impl(GPUComputeProcessList_t& 
      *  rsmi_process_info_t currently running on the system.
      */
     auto status_code(rsmi_status_t::RSMI_STATUS_SUCCESS);
-    auto num_running_processes = uint32_t(0);
+    // only get new data if cache duration has expired
+    std::lock_guard<std::mutex> lock(compute_process_list_mutex);
+    if (std::chrono::steady_clock::now() - last_compute_process_list_update_time > compute_process_list_cache_duration) {
+        // Clear the process info cache when refreshing
+        process_info_cache_map.clear();
 
-    status_code = rsmi_compute_process_info_get(nullptr, &num_running_processes);
-    if ((status_code != rsmi_status_t::RSMI_STATUS_SUCCESS) || (num_running_processes <= 0)) {
-        return status_code;
-    }
+        status_code = rsmi_compute_process_info_get(nullptr, &num_running_processes);
+        if ((status_code != rsmi_status_t::RSMI_STATUS_SUCCESS) || (num_running_processes <= 0)) {
+            return status_code;
+        }
 
-    /**
-     *  Make a type safe pointer, then
-     *
-     * second call to rsmi_compute_process_info_get() g
-     *  the allocated rsmi_process_info_t array.
-     */
-    using RsmiDeviceList_t = uint32_t[];
-    using RsmiProcessList_t = rsmi_process_info_t[];
-    std::unique_ptr<RsmiProcessList_t> list_all_processes_ptr = std::make_unique<RsmiProcessList_t>(num_running_processes);
+        /**
+         *  Make a type safe pointer, then
+         *
+         * second call to rsmi_compute_process_info_get() g
+         *  the allocated rsmi_process_info_t array.
+         */
+        list_all_processes_ptr = std::make_unique<RsmiProcessList_t>(num_running_processes);
 
-    status_code = rsmi_compute_process_info_get(list_all_processes_ptr.get(), &num_running_processes);
-    if (status_code != rsmi_status_t::RSMI_STATUS_SUCCESS) {
-        return status_code;
-    }
+        status_code = rsmi_compute_process_info_get(list_all_processes_ptr.get(), &num_running_processes);
+        if (status_code != rsmi_status_t::RSMI_STATUS_SUCCESS) {
+            return status_code;
+        }
 
-    if (num_running_processes <= 0) {
-        return rsmi_status_t::RSMI_STATUS_SUCCESS; // No processes running
+        if (num_running_processes <= 0) {
+            return rsmi_status_t::RSMI_STATUS_SUCCESS; // No processes running
+        }
+
+        last_compute_process_list_update_time = std::chrono::steady_clock::now();
     }
 
     /**
@@ -228,11 +243,21 @@ int32_t AMDSmiGPUDevice::get_compute_process_list_impl(GPUComputeProcessList_t& 
         for (auto device_idx = uint32_t(0); device_idx < list_device_allocation_size; ++device_idx) {
             // Is this device running this process?
             if (list_device_ptr[device_idx] == get_gpu_id()) {
-                std::unordered_set<uint64_t> gpu_set;
-                gpu_set.insert(get_kfd_gpu_id());
-                GetProcessInfoForPID(rsmi_proc_info.process_id, &rsmi_proc_info, &gpu_set);
                 amdsmi_proc_info_t tmp_amdsmi_proc_info{};
-                get_process_info(rsmi_proc_info, tmp_amdsmi_proc_info);
+
+                auto cached_amdsmi_proc = process_info_cache_map.find(rsmi_proc_info.process_id);
+                if (cached_amdsmi_proc != process_info_cache_map.end()) {
+                    // Use cached info
+                    tmp_amdsmi_proc_info = cached_amdsmi_proc->second;
+                }
+                else {
+                    // Need to get new info from system
+                    std::unordered_set<uint64_t> gpu_set;
+                    gpu_set.insert(get_kfd_gpu_id());
+                    GetProcessInfoForPID(rsmi_proc_info.process_id, &rsmi_proc_info, &gpu_set);
+                    get_process_info(rsmi_proc_info, tmp_amdsmi_proc_info);
+                    process_info_cache_map[rsmi_proc_info.process_id] = tmp_amdsmi_proc_info;
+                }
                 compute_process_list.emplace(rsmi_proc_info.process_id, tmp_amdsmi_proc_info);
            }
         }


### PR DESCRIPTION
## Motivation

Amd Smi performance was suffering greatly when partitioned devices exceeded 10.

## Technical Details

Optimizes KFD node enumeration and KFD process listing by adding in caching to reduce excessive calls.

## JIRA ID

SWDEV-569899

## Test Plan

Timed execution performance on test setup which included 63 devices.

## Test Result

Previous testing showed 21 seconds of execution time. New performance after implementation of caching changes has reduced execution time down to consistently around 5 seconds.

## Submission Checklist
