### PR TITLE
SWDEV-570074 - Refactor Memset memory object handling.

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -208,18 +208,28 @@ hipError_t ihipGraphAddMemsetNode(hip::GraphNode** pGraphNode, hip::Graph* graph
     return hipErrorInvalidValue;
   }
   if (pMemsetParams->height == 1) {
+    size_t offset = 0;
+    amd::Memory* memObj = getMemoryObject(pMemsetParams->dst, offset);
+    if (memObj == nullptr) {
+      return hipErrorInvalidValue;
+    }
     status =
-        ihipMemset_validate(pMemsetParams->dst, pMemsetParams->value, pMemsetParams->elementSize,
-                            pMemsetParams->width * pMemsetParams->elementSize);
+        ihipMemset_validate(memObj, pMemsetParams->value, pMemsetParams->elementSize,
+                            pMemsetParams->width * pMemsetParams->elementSize, offset);
   } else {
     if (pMemsetParams->pitch < (pMemsetParams->width * pMemsetParams->elementSize)) {
       return hipErrorInvalidValue;
     }
     auto sizeBytes =
         pMemsetParams->width * pMemsetParams->height * depth * pMemsetParams->elementSize;
+    size_t offset = 0;
+    amd::Memory* memObj = getMemoryObject(pMemsetParams->dst, offset, sizeBytes);
+    if (memObj == nullptr) {
+      return hipErrorInvalidValue;
+    }
     status = ihipMemset3D_validate(
         {pMemsetParams->dst, pMemsetParams->pitch, pMemsetParams->width, pMemsetParams->height},
-        pMemsetParams->value, {pMemsetParams->width, pMemsetParams->height, depth}, sizeBytes);
+        memObj, offset, pMemsetParams->value, {pMemsetParams->width, pMemsetParams->height, depth}, sizeBytes);
   }
   if (status != hipSuccess) {
     return status;

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -213,9 +213,8 @@ hipError_t ihipGraphAddMemsetNode(hip::GraphNode** pGraphNode, hip::Graph* graph
     if (memObj == nullptr) {
       return hipErrorInvalidValue;
     }
-    status =
-        ihipMemset_validate(memObj, pMemsetParams->value, pMemsetParams->elementSize,
-                            pMemsetParams->width * pMemsetParams->elementSize, offset);
+    status = ihipMemset_validate(memObj, pMemsetParams->value, pMemsetParams->elementSize,
+                                 pMemsetParams->width * pMemsetParams->elementSize, offset);
   } else {
     if (pMemsetParams->pitch < (pMemsetParams->width * pMemsetParams->elementSize)) {
       return hipErrorInvalidValue;
@@ -229,7 +228,8 @@ hipError_t ihipGraphAddMemsetNode(hip::GraphNode** pGraphNode, hip::Graph* graph
     }
     status = ihipMemset3D_validate(
         {pMemsetParams->dst, pMemsetParams->pitch, pMemsetParams->width, pMemsetParams->height},
-        memObj, offset, pMemsetParams->value, {pMemsetParams->width, pMemsetParams->height, depth}, sizeBytes);
+        memObj, offset, pMemsetParams->value, {pMemsetParams->width, pMemsetParams->height, depth},
+        sizeBytes);
   }
   if (status != hipSuccess) {
     return status;

--- a/projects/clr/hipamd/src/hip_graph_helper.hpp
+++ b/projects/clr/hipamd/src/hip_graph_helper.hpp
@@ -45,7 +45,8 @@ hipError_t ihipLaunchKernel_validate(hipFunction_t f, const amd::LaunchParams& l
                                      void** kernelParams, void** extra, int deviceId,
                                      uint32_t params);
 
-hipError_t ihipMemset_validate(amd::Memory* dstMemory, int64_t value, size_t valueSize, size_t sizeBytes, size_t offset);
+hipError_t ihipMemset_validate(amd::Memory* dstMemory, int64_t value, size_t valueSize,
+                               size_t sizeBytes, size_t offset);
 
 hipError_t ihipMemset3D_validate(hipPitchedPtr pitchedDevPtr, amd::Memory* memory, size_t offset,
                                  int value, hipExtent extent, size_t sizeBytes);
@@ -63,8 +64,8 @@ hipError_t ihipMemcpy3DCommand(amd::Command*& command, const hipMemcpy3DParms* p
 hipError_t ihipGetMemcpyParam3DCommand(amd::Command*& command, const HIP_MEMCPY3D* pCopy,
                                        hip::Stream* stream);
 
-hipError_t ihipMemsetCommand(amd::Command*& command, amd::Memory* dstMemory,
-                             int64_t value, size_t valueSize, size_t sizeBytes, hip::Stream* stream,
+hipError_t ihipMemsetCommand(amd::Command*& command, amd::Memory* dstMemory, int64_t value,
+                             size_t valueSize, size_t sizeBytes, hip::Stream* stream,
                              size_t offset);
 
 hipError_t ihipMemset3DCommand(amd::Command*& command, hipPitchedPtr pitchedDevPtr,
@@ -73,22 +74,24 @@ hipError_t ihipMemset3DCommand(amd::Command*& command, hipPitchedPtr pitchedDevP
 
 // Helper functions for hip_graph to maintain vector behavior
 inline hipError_t ihipMemsetCommand(std::vector<amd::Command*>& commands, amd::Memory* dstMemory,
-                                            int64_t value, size_t valueSize, size_t sizeBytes, 
-                                            hip::Stream* stream, size_t offset) {
+                                    int64_t value, size_t valueSize, size_t sizeBytes,
+                                    hip::Stream* stream, size_t offset) {
   amd::Command* command = nullptr;
-  hipError_t status = ihipMemsetCommand(command, dstMemory, value, valueSize, sizeBytes, stream, offset);
+  hipError_t status =
+      ihipMemsetCommand(command, dstMemory, value, valueSize, sizeBytes, stream, offset);
   if (status == hipSuccess && command != nullptr) {
     commands.push_back(command);
   }
   return status;
 }
 
-inline hipError_t ihipMemset3DCommand(std::vector<amd::Command*>& commands, hipPitchedPtr pitchedDevPtr,
-                                               amd::Memory* memory, size_t offset, int value, 
-                                               hipExtent extent, hip::Stream* stream, 
-                                               size_t elementSize = 1) {
+inline hipError_t ihipMemset3DCommand(std::vector<amd::Command*>& commands,
+                                      hipPitchedPtr pitchedDevPtr, amd::Memory* memory,
+                                      size_t offset, int value, hipExtent extent,
+                                      hip::Stream* stream, size_t elementSize = 1) {
   amd::Command* command = nullptr;
-  hipError_t status = ihipMemset3DCommand(command, pitchedDevPtr, memory, offset, value, extent, stream, elementSize);
+  hipError_t status = ihipMemset3DCommand(command, pitchedDevPtr, memory, offset, value, extent,
+                                          stream, elementSize);
   if (status == hipSuccess && command != nullptr) {
     commands.push_back(command);
   }

--- a/projects/clr/hipamd/src/hip_graph_helper.hpp
+++ b/projects/clr/hipamd/src/hip_graph_helper.hpp
@@ -45,10 +45,10 @@ hipError_t ihipLaunchKernel_validate(hipFunction_t f, const amd::LaunchParams& l
                                      void** kernelParams, void** extra, int deviceId,
                                      uint32_t params);
 
-hipError_t ihipMemset_validate(void* dst, int64_t value, size_t valueSize, size_t sizeBytes);
+hipError_t ihipMemset_validate(amd::Memory* dstMemory, int64_t value, size_t valueSize, size_t sizeBytes, size_t offset);
 
-hipError_t ihipMemset3D_validate(hipPitchedPtr pitchedDevPtr, int value, hipExtent extent,
-                                 size_t sizeBytes);
+hipError_t ihipMemset3D_validate(hipPitchedPtr pitchedDevPtr, amd::Memory* memory, size_t offset,
+                                 int value, hipExtent extent, size_t sizeBytes);
 
 hipError_t ihipLaunchKernelCommand(amd::Command*& command, hipFunction_t f,
                                    amd::LaunchParams& launch_params, hip::Stream* stream,
@@ -63,12 +63,37 @@ hipError_t ihipMemcpy3DCommand(amd::Command*& command, const hipMemcpy3DParms* p
 hipError_t ihipGetMemcpyParam3DCommand(amd::Command*& command, const HIP_MEMCPY3D* pCopy,
                                        hip::Stream* stream);
 
-hipError_t ihipMemsetCommand(std::vector<amd::Command*>& commands, void* dst, int64_t value,
-                             size_t valueSize, size_t sizeBytes, hip::Stream* stream);
+hipError_t ihipMemsetCommand(amd::Command*& command, amd::Memory* dstMemory,
+                             int64_t value, size_t valueSize, size_t sizeBytes, hip::Stream* stream,
+                             size_t offset);
 
-hipError_t ihipMemset3DCommand(std::vector<amd::Command*>& commands, hipPitchedPtr pitchedDevPtr,
-                               int value, hipExtent extent, hip::Stream* stream,
-                               size_t elementSize = 1);
+hipError_t ihipMemset3DCommand(amd::Command*& command, hipPitchedPtr pitchedDevPtr,
+                               amd::Memory* memory, size_t offset, int value, hipExtent extent,
+                               hip::Stream* stream, size_t elementSize = 1);
+
+// Helper functions for hip_graph to maintain vector behavior
+inline hipError_t ihipMemsetCommand(std::vector<amd::Command*>& commands, amd::Memory* dstMemory,
+                                            int64_t value, size_t valueSize, size_t sizeBytes, 
+                                            hip::Stream* stream, size_t offset) {
+  amd::Command* command = nullptr;
+  hipError_t status = ihipMemsetCommand(command, dstMemory, value, valueSize, sizeBytes, stream, offset);
+  if (status == hipSuccess && command != nullptr) {
+    commands.push_back(command);
+  }
+  return status;
+}
+
+inline hipError_t ihipMemset3DCommand(std::vector<amd::Command*>& commands, hipPitchedPtr pitchedDevPtr,
+                                               amd::Memory* memory, size_t offset, int value, 
+                                               hipExtent extent, hip::Stream* stream, 
+                                               size_t elementSize = 1) {
+  amd::Command* command = nullptr;
+  hipError_t status = ihipMemset3DCommand(command, pitchedDevPtr, memory, offset, value, extent, stream, elementSize);
+  if (status == hipSuccess && command != nullptr) {
+    commands.push_back(command);
+  }
+  return status;
+}
 
 hipError_t ihipMemcpySymbol_validate(const void* symbol, size_t sizeBytes, size_t offset,
                                      size_t& sym_size, hipDeviceptr_t& device_ptr);

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -2358,10 +2358,11 @@ class GraphMemsetNode : public GraphNode {
       if (memObj == nullptr) {
         return hipErrorInvalidValue;
       }
-      status = ihipMemsetCommand(commands_, memObj, memsetParams_.value,
-                                            memsetParams_.elementSize, sizeBytes, stream, offset);
+      status = ihipMemsetCommand(commands_, memObj, memsetParams_.value, memsetParams_.elementSize,
+                                 sizeBytes, stream, offset);
     } else {
-      auto sizeBytes = memsetParams_.width * memsetParams_.elementSize * memsetParams_.height * depth_;
+      auto sizeBytes =
+          memsetParams_.width * memsetParams_.elementSize * memsetParams_.height * depth_;
       size_t offset = 0;
       amd::Memory* memObj = getMemoryObject(memsetParams_.dst, offset);
       if (memObj == nullptr) {
@@ -2417,7 +2418,8 @@ class GraphMemsetNode : public GraphNode {
         return hipErrorInvalidValue;
       }
       sizeBytes = params->width * params->elementSize;
-      hip_error = ihipMemset_validate(memObj, params->value, params->elementSize, sizeBytes, offset);
+      hip_error =
+          ihipMemset_validate(memObj, params->value, params->elementSize, sizeBytes, offset);
     } else {
       if (isExec) {
         // 2D - hipGraphExecMemsetNodeSetParams returns invalid value if new width or new height is
@@ -2447,8 +2449,9 @@ class GraphMemsetNode : public GraphNode {
         return hipErrorInvalidValue;
       }
       hip_error = ihipMemset3D_validate(
-          {params->dst, params->pitch, params->width * params->elementSize, params->height},
-          memObj, offset, params->value, {params->width * params->elementSize, params->height, depth}, sizeBytes);
+          {params->dst, params->pitch, params->width * params->elementSize, params->height}, memObj,
+          offset, params->value, {params->width * params->elementSize, params->height, depth},
+          sizeBytes);
     }
     if (hip_error != hipSuccess) {
       return hip_error;

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -2353,14 +2353,25 @@ class GraphMemsetNode : public GraphNode {
     }
     if (memsetParams_.height == 1 && depth_ == 1) {
       size_t sizeBytes = memsetParams_.width * memsetParams_.elementSize;
-      hipError_t status = ihipMemsetCommand(commands_, memsetParams_.dst, memsetParams_.value,
-                                            memsetParams_.elementSize, sizeBytes, stream);
+      size_t offset = 0;
+      amd::Memory* memObj = getMemoryObject(memsetParams_.dst, offset);
+      if (memObj == nullptr) {
+        return hipErrorInvalidValue;
+      }
+      status = ihipMemsetCommand(commands_, memObj, memsetParams_.value,
+                                            memsetParams_.elementSize, sizeBytes, stream, offset);
     } else {
-      hipError_t status = ihipMemset3DCommand(
+      auto sizeBytes = memsetParams_.width * memsetParams_.elementSize * memsetParams_.height * depth_;
+      size_t offset = 0;
+      amd::Memory* memObj = getMemoryObject(memsetParams_.dst, offset);
+      if (memObj == nullptr) {
+        return hipErrorInvalidValue;
+      }
+      status = ihipMemset3DCommand(
           commands_,
           {memsetParams_.dst, memsetParams_.pitch, arrWidth_ * memsetParams_.elementSize,
            arrHeight_},
-          memsetParams_.value,
+          memObj, offset, memsetParams_.value,
           {memsetParams_.width * memsetParams_.elementSize, memsetParams_.height, depth_}, stream,
           memsetParams_.elementSize);
     }
@@ -2396,15 +2407,17 @@ class GraphMemsetNode : public GraphNode {
     if (params->height == 1) {
       // 1D - for hipGraphMemsetNodeSetParams & hipGraphExecMemsetNodeSetParams, They return
       // invalid value if new width is more than actual allocation.
-      size_t discardOffset = 0;
-      amd::Memory* memObj = getMemoryObject(params->dst, discardOffset);
-      if (memObj != nullptr) {
-        if (params->width * params->elementSize > memObj->getSize()) {
-          return hipErrorInvalidValue;
-        }
+      size_t offset = 0;
+      amd::Memory* memObj = getMemoryObject(params->dst, offset);
+      if (memObj == nullptr) {
+        return hipErrorInvalidValue;
+      }
+
+      if (params->width * params->elementSize > memObj->getSize()) {
+        return hipErrorInvalidValue;
       }
       sizeBytes = params->width * params->elementSize;
-      hip_error = ihipMemset_validate(params->dst, params->value, params->elementSize, sizeBytes);
+      hip_error = ihipMemset_validate(memObj, params->value, params->elementSize, sizeBytes, offset);
     } else {
       if (isExec) {
         // 2D - hipGraphExecMemsetNodeSetParams returns invalid value if new width or new height is
@@ -2428,9 +2441,14 @@ class GraphMemsetNode : public GraphNode {
         }
       }
       sizeBytes = params->width * params->elementSize * params->height * depth;
+      size_t offset = 0;
+      amd::Memory* memObj = getMemoryObject(params->dst, offset, sizeBytes);
+      if (memObj == nullptr) {
+        return hipErrorInvalidValue;
+      }
       hip_error = ihipMemset3D_validate(
           {params->dst, params->pitch, params->width * params->elementSize, params->height},
-          params->value, {params->width * params->elementSize, params->height, depth}, sizeBytes);
+          memObj, offset, params->value, {params->width * params->elementSize, params->height, depth}, sizeBytes);
     }
     if (hip_error != hipSuccess) {
       return hip_error;

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -2994,62 +2994,20 @@ hipError_t hipMemcpy3DBatchAsync(size_t numOps, struct hipMemcpy3DBatchOp* opLis
   HIP_RETURN(status);
 }
 
-hipError_t packFillMemoryCommand(amd::Command*& command, amd::Memory* memory, size_t offset,
-                                 int64_t value, size_t valueSize, size_t sizeBytes,
-                                 hip::Stream* stream) {
-  if ((memory == nullptr) || (stream == nullptr)) {
-    return hipErrorInvalidValue;
-  }
-
-  amd::Command::EventWaitList waitList;
-  amd::Coord3D fillOffset(offset, 0, 0);
-  amd::Coord3D fillSize(sizeBytes, 1, 1);
-  // surface=[pitch, width, height]
-  amd::Coord3D surface(sizeBytes, sizeBytes, 1);
-  amd::FillMemoryCommand* fillMemCommand =
-      new amd::FillMemoryCommand(*stream, CL_COMMAND_FILL_BUFFER, waitList, *memory->asBuffer(),
-                                 &value, valueSize, fillOffset, fillSize, surface);
-  if (fillMemCommand == nullptr) {
-    return hipErrorOutOfMemory;
-  }
-
-  if (!fillMemCommand->validatePeerMemory()) {
-    delete fillMemCommand;
-    return hipErrorInvalidValue;
-  }
-  command = fillMemCommand;
-  return hipSuccess;
-}
-
-hipError_t ihipMemset_validate(void* dst, int64_t value, size_t valueSize, size_t sizeBytes) {
-  if (sizeBytes == 0) {
-    // Skip if nothing needs filling.
-    return hipSuccess;
-  }
-
-  if (dst == nullptr) {
-    return hipErrorInvalidValue;
-  }
-
-  size_t offset = 0;
-  amd::Memory* memory = getMemoryObject(dst, offset);
-  if (memory == nullptr) {
-    // dst ptr is host ptr hence error
-    return hipErrorInvalidValue;
-  }
-
+hipError_t ihipMemset_validate(amd::Memory* dstMemory, int64_t value, size_t valueSize,
+                               size_t sizeBytes, size_t offset) {
   // Validate Mem Access in case of VMM Memory
-  if (!memory->ValidateMemAccess(*hip::getCurrentDevice()->devices()[0], true)) {
+  if (!dstMemory->ValidateMemAccess(*hip::getCurrentDevice()->devices()[0], true)) {
     return hipErrorUnknown;
   }
 
   // In case of vmm sub object, validate using parents vaddr mem object.
-  if (memory->parent() && (memory->getMemFlags() & CL_MEM_VA_RANGE_AMD)) {
-    memory = memory->parent();
+  if (dstMemory->parent() && (dstMemory->getMemFlags() & CL_MEM_VA_RANGE_AMD)) {
+    dstMemory = dstMemory->parent();
   }
 
   // Return error if sizeBytes passed to memcpy is more than the actual size allocated
-  if (sizeBytes > (memory->getSize() - offset)) {
+  if (offset > dstMemory->getSize() || sizeBytes > (dstMemory->getSize() - offset)) {
     return hipErrorInvalidValue;
   }
   return hipSuccess;
@@ -3089,67 +3047,82 @@ hipError_t ihipGraphMemsetParams_validate(const hipMemsetParams* pNodeParams) {
   return hipSuccess;
 }
 
-hipError_t ihipMemsetCommand(std::vector<amd::Command*>& commands, void* dst, int64_t value,
-                             size_t valueSize, size_t sizeBytes, hip::Stream* stream) {
-  hipError_t hip_error = hipSuccess;
-  auto aligned_dst = amd::alignUp(reinterpret_cast<address>(dst), sizeof(uint64_t));
-  size_t offset = 0;
-  amd::Memory* memory = getMemoryObject(dst, offset);
-  size_t n_head_bytes = 0;
-  size_t n_tail_bytes = 0;
-  amd::Command* command;
+hipError_t ihipMemsetCommand(amd::Command*& command, amd::Memory* dstMemory,
+                             int64_t value, size_t valueSize, size_t sizeBytes, hip::Stream* stream,
+                             size_t offset) {
+  if ((dstMemory == nullptr) || (stream == nullptr)) {
+    return hipErrorInvalidValue;
+  }
 
-  hip_error = packFillMemoryCommand(command, memory, offset, value, valueSize, sizeBytes, stream);
-  commands.push_back(command);
+  amd::Command::EventWaitList waitList;
+  amd::Coord3D fillOffset(offset, 0, 0);
+  amd::Coord3D fillSize(sizeBytes, 1, 1);
+  // surface=[pitch, width, height]
+  amd::Coord3D surface(sizeBytes, sizeBytes, 1);
+  amd::FillMemoryCommand* fillMemCommand =
+      new amd::FillMemoryCommand(*stream, CL_COMMAND_FILL_BUFFER, waitList, *dstMemory->asBuffer(),
+                                 &value, valueSize, fillOffset, fillSize, surface);
+  if (fillMemCommand == nullptr) {
+    return hipErrorOutOfMemory;
+  }
 
-  return hip_error;
+  if (!fillMemCommand->validatePeerMemory()) {
+    delete fillMemCommand;
+    return hipErrorInvalidValue;
+  }
+  command = fillMemCommand;
+  return hipSuccess;
 }
 
 hipError_t ihipMemset(void* dst, int64_t value, size_t valueSize, size_t sizeBytes,
                       hipStream_t stream, bool isAsync = false) {
   hipError_t hip_error = hipSuccess;
-  do {
-    // Nothing to do, fill size is 0. Returns hipSuccess.
-    if (sizeBytes == 0) {
-      break;
-    }
+  // Nothing to do, fill size is 0. Returns hipSuccess.
+  if (sizeBytes == 0) {
+    return hipSuccess;
+  }
 
-    // In case of validation failure stop processing. Returns hip_error.
-    hip_error = ihipMemset_validate(dst, value, valueSize, sizeBytes);
-    if (hip_error != hipSuccess) {
-      break;
-    }
-    // This is required to comply with the spec
-    // spec says hipMemset will be asynchronous when destination memory is device memory
-    // and pointer is non-offseted
-    if (isAsync == false) {
-      size_t offset = 0;
-      amd::Memory* memObj = getMemoryObject(dst, offset);
-      auto flags = memObj->getMemFlags();
-      if ((memObj->getUserData().sync_mem_ops_) ||
-          (offset == 0 &&
-           !(flags & (CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_SVM_ATOMICS | CL_MEM_USE_HOST_PTR)))) {
-        isAsync = true;
-      }
-    }
-    std::vector<amd::Command*> commands;
-    hip::Stream* hip_stream = hip::getStream(stream);
-    if (hip_stream == nullptr) {
-      return hipErrorOutOfMemory;
-    }
-    hip_error = ihipMemsetCommand(commands, dst, value, valueSize, sizeBytes, hip_stream);
-    if (hip_error != hipSuccess) {
-      break;
-    }
+  if (dst == nullptr) {
+    return hipErrorInvalidValue;
+  }
 
-    for (auto command : commands) {
-      command->enqueue();
-      if (!isAsync) {
-        hip_stream->finish();
-      }
-      command->release();
+  size_t offset = 0;
+  amd::Memory* memObj = getMemoryObject(dst, offset);
+  if (memObj == nullptr) {
+    return hipErrorInvalidValue;
+  }
+
+  // In case of validation failure stop processing. Returns hip_error.
+  hip_error = ihipMemset_validate(memObj, value, valueSize, sizeBytes, offset);
+  if (hip_error != hipSuccess) {
+    return hip_error;
+  }
+  // This is required to comply with the spec
+  // spec says hipMemset will be asynchronous when destination memory is device memory
+  // and pointer is non-offseted
+  if (isAsync == false) {
+    auto flags = memObj->getMemFlags();
+    if ((memObj->getUserData().sync_mem_ops_) ||
+        (offset == 0 &&
+         !(flags & (CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_SVM_ATOMICS | CL_MEM_USE_HOST_PTR)))) {
+      isAsync = true;
     }
-  } while (0);
+  }
+  hip::Stream* hip_stream = hip::getStream(stream);
+  if (hip_stream == nullptr) {
+    return hipErrorOutOfMemory;
+  }
+  amd::Command* command = nullptr;
+  hip_error = ihipMemsetCommand(command, memObj, value, valueSize, sizeBytes, hip_stream, offset);
+  if (hip_error != hipSuccess) {
+    return hip_error;
+  }
+
+  command->enqueue();
+  if (!isAsync) {
+    hip_stream->finish();
+  }
+  command->release();
   return hip_error;
 }
 
@@ -3232,11 +3205,8 @@ hipError_t hipMemsetD32Async(hipDeviceptr_t dst, int value, size_t count, hipStr
   HIP_RETURN(ihipMemset(dst, value, valueSize, sizeBytes, stream, true));
 }
 
-hipError_t ihipMemset3D_validate(hipPitchedPtr pitchedDevPtr, int value, hipExtent extent,
-                                 size_t sizeBytes) {
-  size_t offset = 0;
-  amd::Memory* memory = getMemoryObject(pitchedDevPtr.ptr, offset, sizeBytes);
-
+hipError_t ihipMemset3D_validate(hipPitchedPtr pitchedDevPtr, amd::Memory* memory, size_t offset,
+                                 int value, hipExtent extent, size_t sizeBytes) {
   if (memory == nullptr) {
     return hipErrorInvalidValue;
   }
@@ -3253,15 +3223,13 @@ hipError_t ihipMemset3D_validate(hipPitchedPtr pitchedDevPtr, int value, hipExte
 }
 
 // ================================================================================================
-hipError_t ihipMemset3DCommand(std::vector<amd::Command*>& commands, hipPitchedPtr pitchedDevPtr,
-                               int value, hipExtent extent, hip::Stream* stream,
-                               size_t elementSize = 1) {
-  size_t offset = 0;
+hipError_t ihipMemset3DCommand(amd::Command*& command, hipPitchedPtr pitchedDevPtr,
+                               amd::Memory* memory, size_t offset, int value, hipExtent extent,
+                               hip::Stream* stream, size_t elementSize = 1) {
   auto sizeBytes = extent.width * extent.height * extent.depth;
-  amd::Memory* memory = getMemoryObject(pitchedDevPtr.ptr, offset);
   if (pitchedDevPtr.pitch == extent.width) {
-    return ihipMemsetCommand(commands, pitchedDevPtr.ptr, value, elementSize,
-                             static_cast<size_t>(sizeBytes), stream);
+    return ihipMemsetCommand(command, memory, value, elementSize,
+                             static_cast<size_t>(sizeBytes), stream, offset);
   }
   // Workaround for cases when pitch > row until fill kernel will be updated to support pitch.
   // Fall back to filling one row at a time.
@@ -3276,11 +3244,12 @@ hipError_t ihipMemset3DCommand(std::vector<amd::Command*>& commands, hipPitchedP
                    pitchedDevPtr.pitch, 0)) {
     return hipErrorInvalidValue;
   }
-  amd::FillMemoryCommand* command;
   command =
       new amd::FillMemoryCommand(*stream, CL_COMMAND_FILL_BUFFER, amd::Command::EventWaitList{},
                                  *memory->asBuffer(), &value, elementSize, origin, region, surface);
-  commands.push_back(command);
+  if (command == nullptr) {
+    return hipErrorOutOfMemory;
+  }
   return hipSuccess;
 }
 
@@ -3293,7 +3262,12 @@ hipError_t ihipMemset3D(hipPitchedPtr pitchedDevPtr, int value, hipExtent extent
     // sizeBytes is zero hence returning early as nothing to be set
     return hipSuccess;
   }
-  hipError_t status = ihipMemset3D_validate(pitchedDevPtr, value, extent, sizeBytes);
+  size_t offset = 0;
+  amd::Memory* memory = getMemoryObject(pitchedDevPtr.ptr, offset, sizeBytes);
+  if (memory == nullptr) {
+    return hipErrorInvalidValue;
+  }
+  hipError_t status = ihipMemset3D_validate(pitchedDevPtr, memory, offset, value, extent, sizeBytes);
   if (status != hipSuccess) {
     return status;
   }
@@ -3301,27 +3275,23 @@ hipError_t ihipMemset3D(hipPitchedPtr pitchedDevPtr, int value, hipExtent extent
   // spec says hipMemset will be asynchronous when destination memory is device memory
   // and pointer is non-offseted
   if (isAsync == false) {
-    size_t offset = 0;
-    amd::Memory* memObj = getMemoryObject(pitchedDevPtr.ptr, offset);
-    auto flags = memObj->getMemFlags();
+    auto flags = memory->getMemFlags();
     if (offset == 0 &&
         !(flags & (CL_MEM_USE_HOST_PTR | CL_MEM_SVM_ATOMICS | CL_MEM_SVM_FINE_GRAIN_BUFFER))) {
       isAsync = true;
     }
   }
   hip::Stream* hip_stream = hip::getStream(stream);
-  std::vector<amd::Command*> commands;
-  status = ihipMemset3DCommand(commands, pitchedDevPtr, value, extent, hip_stream, elementSize);
+  amd::Command* command = nullptr;
+  status = ihipMemset3DCommand(command, pitchedDevPtr, memory, offset, value, extent, hip_stream, elementSize);
   if (status != hipSuccess) {
     return status;
   }
-  for (auto& command : commands) {
-    command->enqueue();
-    if (!isAsync) {
-      hip_stream->finish();
-    }
-    command->release();
+  command->enqueue();
+  if (!isAsync) {
+    hip_stream->finish();
   }
+  command->release();
   return hipSuccess;
 }
 

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -3047,8 +3047,8 @@ hipError_t ihipGraphMemsetParams_validate(const hipMemsetParams* pNodeParams) {
   return hipSuccess;
 }
 
-hipError_t ihipMemsetCommand(amd::Command*& command, amd::Memory* dstMemory,
-                             int64_t value, size_t valueSize, size_t sizeBytes, hip::Stream* stream,
+hipError_t ihipMemsetCommand(amd::Command*& command, amd::Memory* dstMemory, int64_t value,
+                             size_t valueSize, size_t sizeBytes, hip::Stream* stream,
                              size_t offset) {
   if ((dstMemory == nullptr) || (stream == nullptr)) {
     return hipErrorInvalidValue;
@@ -3228,8 +3228,8 @@ hipError_t ihipMemset3DCommand(amd::Command*& command, hipPitchedPtr pitchedDevP
                                hip::Stream* stream, size_t elementSize = 1) {
   auto sizeBytes = extent.width * extent.height * extent.depth;
   if (pitchedDevPtr.pitch == extent.width) {
-    return ihipMemsetCommand(command, memory, value, elementSize,
-                             static_cast<size_t>(sizeBytes), stream, offset);
+    return ihipMemsetCommand(command, memory, value, elementSize, static_cast<size_t>(sizeBytes),
+                             stream, offset);
   }
   // Workaround for cases when pitch > row until fill kernel will be updated to support pitch.
   // Fall back to filling one row at a time.
@@ -3267,7 +3267,8 @@ hipError_t ihipMemset3D(hipPitchedPtr pitchedDevPtr, int value, hipExtent extent
   if (memory == nullptr) {
     return hipErrorInvalidValue;
   }
-  hipError_t status = ihipMemset3D_validate(pitchedDevPtr, memory, offset, value, extent, sizeBytes);
+  hipError_t status =
+      ihipMemset3D_validate(pitchedDevPtr, memory, offset, value, extent, sizeBytes);
   if (status != hipSuccess) {
     return status;
   }
@@ -3283,7 +3284,8 @@ hipError_t ihipMemset3D(hipPitchedPtr pitchedDevPtr, int value, hipExtent extent
   }
   hip::Stream* hip_stream = hip::getStream(stream);
   amd::Command* command = nullptr;
-  status = ihipMemset3DCommand(command, pitchedDevPtr, memory, offset, value, extent, hip_stream, elementSize);
+  status = ihipMemset3DCommand(command, pitchedDevPtr, memory, offset, value, extent, hip_stream,
+                               elementSize);
   if (status != hipSuccess) {
     return status;
   }


### PR DESCRIPTION
## Motivation

This RP refactors the hipMemset code to reduce the number of times we call get_memory_object, which traverses a std::map holding all the virtual memory objects. This PR adjusts the behaviour of both 1D and 3D versions of memset. The overall performance differences is small, as once you traverse the map, the nodes are in cache, so subsequent calls are less expensive. However, this can be around ~18% of the time from hipMemset being called to the command being constructed. So while it doesn't show up in overall benchmarking, it is still worthwhile avoiding multiple calls.

## Technical Details

As opposed to passing a pointer to each function we get the memory object once and then pass that.

## JIRA ID

Resolves SWDEV-570074

## Test Plan

Normal memset tests are suitable for this change

## Test Result

Passing locally

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
