### PR TITLE
SWDEV-548892 - Make declaration of __ockl_fdot2 always available

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/hip_fp16_math_fwd.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/hip_fp16_math_fwd.h
@@ -55,10 +55,7 @@ __device__ __attribute__((const)) _Float16 __ocml_fmin_f16(_Float16, _Float16);
 typedef _Float16 __2f16 __attribute__((ext_vector_type(2)));
 typedef short __2i16 __attribute__((ext_vector_type(2)));
 
-#if defined(__clang__) && defined(__HIP__)
 __device__ __attribute__((const)) float __ockl_fdot2(__2f16 a, __2f16 b, float c, bool s);
-#endif
-
 __device__ __attribute__((const)) __2f16 __ocml_ceil_2f16(__2f16);
 __device__ __attribute__((const)) __2f16 __ocml_fabs_2f16(__2f16);
 __device__ __2f16 __ocml_cos_2f16(__2f16);


### PR DESCRIPTION
It makes no sense to check the compiler or language. Currently this is relying on a declaration leaked out of the clang builtin headers, which should not be exporting ockl functions.