### PR TITLE
Add async attach and detach in rocprofiler-sdk and rocprofiler-register.

### DIFF
--- a/projects/rocprofiler-register/source/lib/rocprofiler-register/rocprofiler_register.cpp
+++ b/projects/rocprofiler-register/source/lib/rocprofiler-register/rocprofiler_register.cpp
@@ -34,14 +34,20 @@
 #include <array>
 #include <atomic>
 #include <bitset>
+#include <cerrno>
+#include <cstring>
 #include <fstream>
+#include <memory>
 #include <mutex>
 #include <regex>
 #include <stdexcept>
 #include <string_view>
+#include <thread>
 #include <utility>
 
 #include <dlfcn.h>
+#include <sys/socket.h>
+#include <sys/un.h>
 #include <unistd.h>
 
 namespace
@@ -77,6 +83,14 @@ typedef int (*rocprofiler_tool_initialize_t)(rocprofiler_client_finalize_t final
                                              void*                         tool_data);
 
 typedef void (*rocprofiler_tool_finalize_t)(void* tool_data);
+
+
+rocprofiler_register_error_code_t
+rocprofiler_register_attach(const char* environment_buffer,
+                            const char* tool_lib_path) ROCPROFILER_REGISTER_PUBLIC_API;
+
+rocprofiler_register_error_code_t
+rocprofiler_register_detach() ROCPROFILER_REGISTER_PUBLIC_API;
 
 typedef struct rocprofiler_tool_configure_result_t
 {
@@ -159,6 +173,407 @@ constexpr auto rocprofiler_lib_detach_entrypoint = "rocprofiler_detach";
 
 constexpr auto rocprofiler_register_lib_name =
     "librocprofiler-register.so." ROCPROFILER_REGISTER_SOVERSION;
+
+// ======================================================================================
+// Socket communication types and utilities for attach/detach operations
+// ======================================================================================
+
+/// Socket path constants for Unix domain socket communication
+constexpr auto socket_path_prefix = std::string_view{ "/tmp/rocprofiler." };
+constexpr auto socket_path_suffix = std::string_view{ ".sock" };
+
+/// Operation codes for attach/detach socket protocol
+enum class attach_op : uint32_t
+{
+    attach   = 0,  ///< Request to attach profiler
+    detach   = 1,  ///< Request to detach profiler
+    response = 2,  ///< Response message from server
+};
+
+/// Status codes for attach/detach response
+enum class attach_status : uint32_t
+{
+    success = 0,  ///< Operation completed successfully
+    error   = 1,  ///< Operation failed with error
+};
+
+/// Message header for socket communication protocol
+struct attach_message_header
+{
+    uint32_t op                = 0;  ///< Operation type (see attach_op)
+    uint32_t tool_lib_path_len = 0;  ///< Length of tool library path string
+    uint32_t env_buffer_len    = 0;  ///< Length of environment buffer
+};
+
+/// Response message sent back to client
+struct attach_response_message
+{
+    uint32_t op     = 0;  ///< Should be attach_op::response
+    uint32_t status = 0;  ///< Status code (see attach_status)
+};
+
+/// RAII wrapper for socket file descriptor management
+class socket_fd_guard
+{
+public:
+    explicit socket_fd_guard(int fd) noexcept
+    : m_fd{ fd }
+    {}
+
+    ~socket_fd_guard() noexcept
+    {
+        if(m_fd >= 0) ::close(m_fd);
+    }
+
+    socket_fd_guard(const socket_fd_guard&)            = delete;
+    socket_fd_guard& operator=(const socket_fd_guard&) = delete;
+    socket_fd_guard(socket_fd_guard&& other) noexcept
+    : m_fd{ std::exchange(other.m_fd, -1) }
+    {}
+    socket_fd_guard& operator=(socket_fd_guard&& other) noexcept
+    {
+        if(this != &other)
+        {
+            if(m_fd >= 0) ::close(m_fd);
+            m_fd = std::exchange(other.m_fd, -1);
+        }
+        return *this;
+    }
+
+    [[nodiscard]] int    get() const noexcept { return m_fd; }
+    [[nodiscard]] int    release() noexcept { return std::exchange(m_fd, -1); }
+    [[nodiscard]] bool   valid() const noexcept { return m_fd >= 0; }
+    [[nodiscard]]        operator bool() const noexcept { return valid(); }
+
+private:
+    int m_fd = -1;
+};
+
+/// Global state for socket monitoring thread
+struct socket_monitor_state
+{
+    std::unique_ptr<std::thread> thread        = nullptr;
+    std::atomic<bool>            running       = { false };
+    std::string                  socket_path   = {};
+};
+
+auto g_socket_state = socket_monitor_state{};
+
+/// Generates the socket path for current process using PID
+[[nodiscard]] std::string
+get_socket_path_for_current_process()
+{
+    return fmt::format("{}{}{}", socket_path_prefix, ::getpid(), socket_path_suffix);
+}
+
+/// Sends a response message to client
+[[nodiscard]] bool
+send_response(int _client_fd, attach_status _status)
+{
+    auto _response = attach_response_message{
+        .op     = static_cast<uint32_t>(attach_op::response),
+        .status = static_cast<uint32_t>(_status)
+    };
+
+    auto _bytes_sent = ::send(_client_fd, &_response, sizeof(_response), 0);
+    return _bytes_sent == static_cast<ssize_t>(sizeof(_response));
+}
+
+/// Sends a response message with raw status code (for error codes)
+[[nodiscard]] bool
+send_response(int _client_fd, uint32_t _status_code)
+{
+    auto _response = attach_response_message{
+        .op     = static_cast<uint32_t>(attach_op::response),
+        .status = _status_code
+    };
+
+    auto _bytes_sent = ::send(_client_fd, &_response, sizeof(_response), 0);
+    return _bytes_sent == static_cast<ssize_t>(sizeof(_response));
+}
+
+/// Receives exactly the specified number of bytes from socket
+[[nodiscard]] bool
+recv_all(int _fd, void* _buffer, size_t _size)
+{
+    auto* _buf        = static_cast<uint8_t*>(_buffer);
+    auto  _total_read = size_t{ 0 };
+
+    while(_total_read < _size)
+    {
+        auto _bytes_read = ::recv(_fd, _buf + _total_read, _size - _total_read, 0);
+
+        if(_bytes_read <= 0)
+        {
+            if(_bytes_read == 0)
+            {
+                LOG(ERROR) << "Connection closed by client";
+            }
+            else if(errno != EINTR)
+            {
+                LOG(ERROR) << "Failed to read from client: " << std::strerror(errno);
+            }
+            return false;
+        }
+        _total_read += static_cast<size_t>(_bytes_read);
+    }
+    return true;
+}
+
+/// Handles the ATTACH operation from client
+void
+handle_attach_op(int                         _client_fd,
+                 std::string_view            _tool_lib_path,
+                 const std::vector<uint8_t>& _env_buffer)
+{
+    LOG(INFO) << "Received ATTACH operation";
+    LOG(INFO) << "Tool library path: " << _tool_lib_path;
+
+    // Parse and log environment buffer contents
+    if(!_env_buffer.empty() && _env_buffer.size() >= sizeof(uint32_t))
+    {
+        auto        _var_count = *reinterpret_cast<const uint32_t*>(_env_buffer.data());
+        const auto* _position =
+            reinterpret_cast<const char*>(_env_buffer.data() + sizeof(uint32_t));
+        const auto* _end =
+            reinterpret_cast<const char*>(_env_buffer.data() + _env_buffer.size());
+
+        LOG(INFO) << "Environment variables (" << _var_count << " pairs):";
+
+        for(uint32_t _i = 0; _i < _var_count && _position < _end; ++_i)
+        {
+            const auto* _name = _position;
+            _position += std::strlen(_name) + 1;
+            if(_position >= _end) break;
+
+            const auto* _value = _position;
+            _position += std::strlen(_value) + 1;
+
+            LOG(INFO) << "  " << _name << "=" << _value;
+        }
+    }
+
+    // Store tool_lib_path and environment buffer for attach operation
+    auto _stored_tool_lib_path = std::string{ _tool_lib_path };
+    LOG(INFO) << "Stored tool_lib_path: " << _stored_tool_lib_path;
+
+    auto _stored_env_buffer =
+        std::string{ reinterpret_cast<const char*>(_env_buffer.data()), _env_buffer.size() };
+    LOG(INFO) << "Stored environment buffer (" << _stored_env_buffer.size() << " bytes)";
+
+    auto _attach_result =
+        rocprofiler_register_attach(_stored_env_buffer.c_str(), _stored_tool_lib_path.c_str());
+
+    // Send response with the actual error code
+    if(_attach_result != ROCP_REG_SUCCESS)
+    {
+        LOG(ERROR) << "rocprofiler_register_attach failed with error: " << _attach_result
+                   << " (" << rocprofiler_register_error_string(_attach_result) << ")";
+
+        if(send_response(_client_fd, static_cast<uint32_t>(_attach_result)))
+        {
+            LOG(INFO) << "Sent ATTACH error response with code: " << _attach_result;
+        }
+        else
+        {
+            LOG(ERROR) << "Failed to send error response";
+        }
+    }
+    else
+    {
+        if(send_response(_client_fd, attach_status::success))
+        {
+            LOG(INFO) << "Sent ATTACH success response";
+        }
+        else
+        {
+            LOG(ERROR) << "Failed to send response";
+        }
+    }
+}
+
+/// Handles the DETACH operation from client
+void
+handle_detach_op(int _client_fd)
+{
+    LOG(INFO) << "Received DETACH operation";
+
+    auto _detach_result = rocprofiler_register_detach();
+
+    // Send response with the actual error code
+    if(_detach_result != ROCP_REG_SUCCESS)
+    {
+        LOG(ERROR) << "rocprofiler_register_detach failed with error: " << _detach_result
+                   << " (" << rocprofiler_register_error_string(_detach_result) << ")";
+
+        if(send_response(_client_fd, static_cast<uint32_t>(_detach_result)))
+        {
+            LOG(INFO) << "Sent DETACH error response with code: " << _detach_result;
+        }
+        else
+        {
+            LOG(ERROR) << "Failed to send error response";
+        }
+    }
+    else
+    {
+        if(send_response(_client_fd, attach_status::success))
+        {
+            LOG(INFO) << "Sent DETACH success response";
+        }
+        else
+        {
+            LOG(ERROR) << "Failed to send response";
+        }
+    }
+}
+
+/// Main function for socket monitoring thread
+void
+socket_monitor_thread()
+{
+    // Generate socket path with current process PID
+    g_socket_state.socket_path = get_socket_path_for_current_process();
+    const auto* _socket_path   = g_socket_state.socket_path.c_str();
+
+    // Create Unix domain socket
+    auto _server_fd = socket_fd_guard{ ::socket(AF_UNIX, SOCK_STREAM, 0) };
+    if(!_server_fd)
+    {
+        LOG(ERROR) << "Failed to create socket: " << std::strerror(errno);
+        return;
+    }
+
+    // Remove existing socket file if it exists
+    ::unlink(_socket_path);
+
+    // Set up server address
+    auto _server_addr         = sockaddr_un{};
+    _server_addr.sun_family   = AF_UNIX;
+    std::strncpy(_server_addr.sun_path, _socket_path, sizeof(_server_addr.sun_path) - 1);
+
+    // Bind socket to the path
+    if(::bind(_server_fd.get(),
+              reinterpret_cast<sockaddr*>(&_server_addr),
+              sizeof(_server_addr)) == -1)
+    {
+        LOG(ERROR) << "Failed to bind socket: " << std::strerror(errno);
+        return;
+    }
+
+    // Listen for connections
+    constexpr auto max_pending_connections = 5;
+    if(::listen(_server_fd.get(), max_pending_connections) == -1)
+    {
+        LOG(ERROR) << "Failed to listen on socket: " << std::strerror(errno);
+        ::unlink(_socket_path);
+        return;
+    }
+
+    LOG(INFO) << "Socket thread started, listening on " << _socket_path;
+
+    g_socket_state.running = true;
+
+    while(g_socket_state.running)
+    {
+        auto      _client_addr = sockaddr_un{};
+        socklen_t _client_len  = sizeof(_client_addr);
+
+        // Accept client connection
+        auto _client_fd = socket_fd_guard{
+            ::accept(_server_fd.get(), reinterpret_cast<sockaddr*>(&_client_addr), &_client_len)
+        };
+
+        if(!_client_fd)
+        {
+            if(errno != EINTR && g_socket_state.running)
+            {
+                LOG(ERROR) << "Failed to accept connection: " << std::strerror(errno);
+            }
+            continue;
+        }
+
+        LOG(INFO) << "Client connected";
+
+        // Read message header
+        auto _header = attach_message_header{};
+        if(!recv_all(_client_fd.get(), &_header, sizeof(_header)))
+        {
+            LOG(ERROR) << "Failed to read message header";
+            continue;
+        }
+
+        LOG(INFO) << "Received header: op=" << _header.op
+                  << ", tool_lib_path_len=" << _header.tool_lib_path_len
+                  << ", env_buffer_len=" << _header.env_buffer_len;
+
+        // Read tool library path
+        auto _tool_lib_path = std::string{};
+        if(_header.tool_lib_path_len > 0)
+        {
+            auto _path_buffer = std::vector<char>(_header.tool_lib_path_len);
+            if(!recv_all(_client_fd.get(), _path_buffer.data(), _header.tool_lib_path_len))
+            {
+                LOG(ERROR) << "Failed to read tool library path";
+                continue;
+            }
+            _tool_lib_path = std::string{ _path_buffer.data() };
+        }
+
+        // Read environment buffer
+        auto _env_buffer = std::vector<uint8_t>{};
+        if(_header.env_buffer_len > 0)
+        {
+            _env_buffer.resize(_header.env_buffer_len);
+            if(!recv_all(_client_fd.get(), _env_buffer.data(), _header.env_buffer_len))
+            {
+                LOG(ERROR) << "Failed to read environment buffer";
+                continue;
+            }
+        }
+
+        // Handle the operation based on op code
+        auto _should_exit = false;
+        switch(static_cast<attach_op>(_header.op))
+        {
+            case attach_op::attach:
+            {
+                handle_attach_op(_client_fd.get(), _tool_lib_path, _env_buffer);
+                break;
+            }
+            case attach_op::detach:
+            {
+                LOG(INFO) << "Detaching profiler and exiting socket thread...";
+                handle_detach_op(_client_fd.get());
+                _should_exit = true;
+                break;
+            }
+            default:
+            {
+                LOG(ERROR) << "Unknown operation: " << _header.op;
+                send_response(_client_fd.get(), attach_status::error);
+                break;
+            }
+        }
+
+        LOG(INFO) << "Client disconnected";
+
+        // Exit the loop if DETACH was received
+        if(_should_exit)
+        {
+            LOG(INFO) << "DETACH received, stopping socket monitor thread";
+            g_socket_state.running = false;
+            break;
+        }
+    }
+
+    ::unlink(_socket_path);
+    LOG(INFO) << "Socket thread terminated";
+}
+
+// ======================================================================================
+// End of socket communication utilities
+// ======================================================================================
 
 enum rocp_reg_supported_library  // NOLINT(performance-enum-size)
 {
@@ -945,11 +1360,35 @@ rocprofiler_register_invoke_all_registrations()
 }
 
 rocprofiler_register_error_code_t
-rocprofiler_register_attach(const char* environment_buffer,
-                            const char* tool_lib_path) ROCPROFILER_REGISTER_PUBLIC_API;
+rocprofiler_register_thread_init() ROCPROFILER_REGISTER_PUBLIC_API;
 
 rocprofiler_register_error_code_t
-rocprofiler_register_detach() ROCPROFILER_REGISTER_PUBLIC_API;
+rocprofiler_register_thread_init()
+{
+    // check if thread is already running
+    if(g_socket_state.thread && g_socket_state.running.load())
+    {
+        LOG(INFO) << "Socket monitoring thread is already running";
+        return ROCP_REG_SUCCESS;
+    }
+
+    try
+    {
+        // create and start the socket monitoring thread
+        g_socket_state.thread = std::make_unique<std::thread>(socket_monitor_thread);
+
+        // detach the thread so it can run independently
+        g_socket_state.thread->detach();
+
+        LOG(INFO) << "Socket monitoring thread started successfully";
+        return ROCP_REG_SUCCESS;
+    }
+    catch(const std::exception& _e)
+    {
+        LOG(ERROR) << "Failed to start socket monitoring thread: " << _e.what();
+        return ROCP_REG_ROCPROFILER_ERROR;
+    }
+}
 
 //
 //  This function can be invoked by ptrace

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.hpp
@@ -24,9 +24,13 @@
 
 #include <rocprofiler-sdk/rocprofiler.h>
 
+#include <sys/types.h>
+#include <unistd.h>
+
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -35,6 +39,107 @@
 
 namespace rocprofiler
 {
+namespace common
+{
+// Socket path prefix for attach communication
+constexpr const char* socket_path_prefix = "/tmp/rocprofiler.";
+constexpr const char* socket_path_suffix = ".sock";
+
+// Helper function to generate socket path for a specific PID
+inline std::string
+get_socket_path_for_pid(pid_t pid)
+{
+    return std::string(socket_path_prefix) + std::to_string(pid) + socket_path_suffix;
+}
+
+typedef enum rocprofiler_register_error_code_t  // NOLINT(performance-enum-size)
+{
+    ROCP_REG_SUCCESS = 0,
+    ROCP_REG_NO_TOOLS,
+    ROCP_REG_DEADLOCK,
+    ROCP_REG_BAD_API_TABLE_LENGTH,
+    ROCP_REG_UNSUPPORTED_API,
+    ROCP_REG_INVALID_API_ADDRESS,
+    ROCP_REG_ROCPROFILER_ERROR,
+    ROCP_REG_EXCESS_API_INSTANCES,
+    ROCP_REG_INVALID_ARGUMENT,
+    ROCP_REG_ATTACHMENT_NOT_AVAILABLE,
+    ROCP_REG_ERROR_CODE_END,
+} rocprofiler_register_error_code_t;
+
+// Operation codes
+enum attach_op : uint32_t
+{
+    ATTACH_OP_ATTACH   = 0,
+    ATTACH_OP_DETACH   = 1,
+    ATTACH_OP_RESPONSE = 2,  // Response from server
+};
+
+// Response status codes
+enum attach_status : uint32_t
+{
+    ATTACH_STATUS_SUCCESS = 0,
+    ATTACH_STATUS_ERROR   = 1,
+};
+
+// Message header for socket communication
+// Format: [op (4 bytes)][tool_lib_path_len (4 bytes)][env_len (4 bytes)][tool_lib_path][env_data]
+struct attach_message_header
+{
+    uint32_t op                = 0;  // Operation type
+    uint32_t tool_lib_path_len = 0;  // Length of tool library path string (including null terminator)
+    uint32_t env_buffer_len    = 0;  // Length of environment buffer
+};
+
+// Response message from server
+struct attach_response_message
+{
+    uint32_t op     = 0;  // Should be ATTACH_OP_RESPONSE
+    uint32_t status = 0;  // Status code (attach_status)
+};
+
+// Helper function to serialize attach message
+inline std::vector<uint8_t>
+serialize_attach_message(uint32_t                    op,
+                         const std::string&          tool_lib_path,
+                         const std::vector<uint8_t>& env_buffer)
+{
+    attach_message_header header;
+    header.op                = op;
+    header.tool_lib_path_len = static_cast<uint32_t>(tool_lib_path.size() + 1);  // +1 for null
+    header.env_buffer_len    = static_cast<uint32_t>(env_buffer.size());
+
+    std::vector<uint8_t> message;
+    message.reserve(sizeof(header) + header.tool_lib_path_len + header.env_buffer_len);
+
+    // Add header
+    const auto* header_bytes = reinterpret_cast<const uint8_t*>(&header);
+    message.insert(message.end(), header_bytes, header_bytes + sizeof(header));
+
+    // Add tool library path (including null terminator)
+    message.insert(message.end(), tool_lib_path.begin(), tool_lib_path.end());
+    message.push_back(0);  // null terminator
+
+    // Add environment buffer
+    message.insert(message.end(), env_buffer.begin(), env_buffer.end());
+
+    return message;
+}
+
+// Helper function to serialize response message
+inline std::vector<uint8_t>
+serialize_response_message(uint32_t status)
+{
+    attach_response_message response;
+    response.op     = ATTACH_OP_RESPONSE;
+    response.status = status;
+
+    std::vector<uint8_t> message(sizeof(response));
+    std::memcpy(message.data(), &response, sizeof(response));
+    return message;
+}
+}  // namespace common
+
 namespace attach
 {
 class PTraceSession

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -28,8 +28,15 @@
 
 #include <rocprofiler-sdk/defines.h>
 
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
 #include <atomic>
+#include <chrono>
+#include <cstring>
 #include <thread>
+#include <vector>
 
 extern char** environ;
 
@@ -140,9 +147,304 @@ build_environment_buffer()
 
     return environment_buffer;
 }
+// Helper function to connect to Unix socket with retries
+int
+connect_to_socket(const char* socket_path, int max_retries, int retry_delay_ms)
+{
+    int                socket_fd;
+    struct sockaddr_un server_addr;
+
+    for(int retry = 0; retry < max_retries; ++retry)
+    {
+        // Create socket
+        socket_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+        if(socket_fd == -1)
+        {
+            ROCP_ERROR << "Failed to create socket: " << strerror(errno);
+            return -1;
+        }
+
+        // Set up server address
+        memset(&server_addr, 0, sizeof(server_addr));
+        server_addr.sun_family = AF_UNIX;
+        strncpy(server_addr.sun_path, socket_path, sizeof(server_addr.sun_path) - 1);
+
+        // Try to connect
+        if(connect(socket_fd, (struct sockaddr*) &server_addr, sizeof(server_addr)) == 0)
+        {
+            ROCP_TRACE << "Connected to socket " << socket_path << " on attempt " << (retry + 1);
+            return socket_fd;
+        }
+
+        // Connection failed, close socket and retry
+        close(socket_fd);
+
+        if(retry < max_retries - 1)
+        {
+            ROCP_TRACE << "Connection attempt " << (retry + 1) << " failed, retrying in "
+                       << retry_delay_ms << "ms...";
+            std::this_thread::sleep_for(std::chrono::milliseconds(retry_delay_ms));
+        }
+    }
+
+    ROCP_ERROR << "Failed to connect to socket " << socket_path << " after " << max_retries
+               << " attempts";
+    return -1;
+}
+
+// Helper function to send all bytes
+bool
+send_all(int fd, const void* buffer, size_t size)
+{
+    const uint8_t* buf        = static_cast<const uint8_t*>(buffer);
+    size_t         total_sent = 0;
+    while(total_sent < size)
+    {
+        ssize_t bytes_sent = send(fd, buf + total_sent, size - total_sent, 0);
+        if(bytes_sent <= 0)
+        {
+            if(bytes_sent == 0)
+            {
+                ROCP_ERROR << "Connection closed by server";
+            }
+            else if(errno != EINTR)
+            {
+                ROCP_ERROR << "Failed to send data: " << strerror(errno);
+            }
+            return false;
+        }
+        total_sent += bytes_sent;
+    }
+    return true;
+}
+
+// Helper function to receive all bytes
+bool
+recv_all(int fd, void* buffer, size_t size)
+{
+    uint8_t* buf        = static_cast<uint8_t*>(buffer);
+    size_t   total_read = 0;
+    while(total_read < size)
+    {
+        ssize_t bytes_read = recv(fd, buf + total_read, size - total_read, 0);
+        if(bytes_read <= 0)
+        {
+            if(bytes_read == 0)
+            {
+                ROCP_ERROR << "Connection closed by server";
+            }
+            else if(errno != EINTR)
+            {
+                ROCP_ERROR << "Failed to receive data: " << strerror(errno);
+            }
+            return false;
+        }
+        total_read += bytes_read;
+    }
+    return true;
+}
 }  // anonymous namespace
 
 ROCPROFILER_EXTERN_C_INIT
+
+void
+handle_attach_operations(uint32_t pid)
+{
+    // Setup attachment for rocprofiler via socket communication
+    ROCP_TRACE << "Socket-based attachment library called for pid " << pid;
+    ptrace_session = std::make_unique<rocprofiler::attach::PTraceSession>(pid);
+    ROCP_TRACE << "Attempting attachment to pid " << pid;
+    if(!ptrace_session->attach())
+    {
+        ROCP_ERROR << "Attachment failed to pid " << pid;
+        ptrace_session->m_setup_status.store(ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT);
+        finished_setup.store(true);
+        return;
+    }
+    ROCP_TRACE << "Attachment success to pid " << pid;
+
+    // Build environment buffer
+    auto environment_buffer = build_environment_buffer();
+    ROCP_TRACE << "Built environment buffer with " << environment_buffer.size() << " bytes";
+
+    // Get tool library path
+    auto tool_lib_path =
+        rocprofiler::common::get_env("ROCPROF_ATTACH_TOOL_LIBRARY", "librocprofiler-sdk-tool.so");
+    ROCP_TRACE << "Tool library path: " << tool_lib_path;
+
+    // Execute rocprofiler_register_thread_init in target process to create socket_monitor_thread
+    if(!ptrace_session->call_function("librocprofiler-register.so",
+                                      "rocprofiler_register_thread_init"))
+    {
+        ROCP_ERROR << "Failed to call rocprofiler_register_thread_init in target process " << pid;
+        ptrace_session->m_setup_status.store(ROCPROFILER_STATUS_ERROR);
+        finished_setup.store(true);
+        return;
+    }
+    ROCP_TRACE << "Successfully created socket_monitor_thread in target process";
+
+    // Give the socket thread time to start up
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Connect to the Unix socket with retries
+    constexpr int max_retries    = 10;
+    constexpr int retry_delay_ms = 200;
+    // Generate socket path with target process PID
+    std::string socket_path      = common::get_socket_path_for_pid(pid);
+
+    int socket_fd = connect_to_socket(socket_path.c_str(), max_retries, retry_delay_ms);
+    if(socket_fd == -1)
+    {
+        ROCP_ERROR << "Failed to connect to socket " << socket_path;
+        ptrace_session->m_setup_status.store(ROCPROFILER_STATUS_ERROR);
+        finished_setup.store(true);
+        return;
+    }
+    ROCP_TRACE << "Connected to socket " << socket_path;
+
+    // Serialize and send ATTACH message
+    auto message = common::serialize_attach_message(common::ATTACH_OP_ATTACH,
+                                                    tool_lib_path,
+                                                    environment_buffer);
+
+    if(!send_all(socket_fd, message.data(), message.size()))
+    {
+        ROCP_ERROR << "Failed to send ATTACH message to target process";
+        close(socket_fd);
+        ptrace_session->m_setup_status.store(ROCPROFILER_STATUS_ERROR);
+        finished_setup.store(true);
+        return;
+    }
+    ROCP_TRACE << "Sent ATTACH message (" << message.size() << " bytes)";
+
+    // Receive response
+    common::attach_response_message response;
+    if(!recv_all(socket_fd, &response, sizeof(response)))
+    {
+        ROCP_ERROR << "Failed to receive response from target process";
+        close(socket_fd);
+        ptrace_session->m_setup_status.store(ROCPROFILER_STATUS_ERROR);
+        finished_setup.store(true);
+        return;
+    }
+
+    // Check response
+    if(response.op != common::ATTACH_OP_RESPONSE)
+    {
+        ROCP_ERROR << "Unexpected response op code: " << response.op;
+        close(socket_fd);
+        ptrace_session->m_setup_status.store(ROCPROFILER_STATUS_ERROR);
+        finished_setup.store(true);
+        return;
+    }
+
+    if(response.status != common::ATTACH_STATUS_SUCCESS)
+    {
+        ROCP_ERROR << "ATTACH operation failed with rocprofiler_register error code: " << response.status;
+        // Map rocprofiler_register error codes to more specific rocprofiler status
+        rocprofiler_status_t mapped_status = ROCPROFILER_STATUS_ERROR;
+        switch(response.status)
+        {
+            case ROCP_REG_NO_TOOLS:
+                ROCP_ERROR << "  -> No profiling tools found";
+                break;
+            case ROCP_REG_DEADLOCK:
+                ROCP_ERROR << "  -> Deadlock detected in rocprofiler-register";
+                break;
+            case ROCP_REG_INVALID_ARGUMENT:
+                ROCP_ERROR << "  -> Invalid argument provided";
+                mapped_status = ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
+                break;
+            case ROCP_REG_ATTACHMENT_NOT_AVAILABLE:
+                ROCP_ERROR << "  -> Attachment not available (rocprofiler-attach library was never loaded)";
+                ROCP_ERROR << "  -> Start the app with ROCP_TOOL_ATTACH=1 or build rocprofiler-register with ROCP_REG_DEFAULT_ATTACHMENT=ON";
+                break;
+            default:
+                ROCP_ERROR << "  -> Unknown error";
+                break;
+        }
+        close(socket_fd);
+        ptrace_session->m_setup_status.store(mapped_status);
+        finished_setup.store(true);
+        return;
+    }
+
+    ROCP_TRACE << "ATTACH operation completed successfully";
+    close(socket_fd);
+
+    // Allow main thread to continue
+    finished_setup.store(true);
+    if(!ptrace_session->handle_signals())
+    {
+        ROCP_ERROR << "Signal handling loop terminated unexpectedly for pid " << pid;
+        // don't return, try to detach anyways
+    }
+
+    // Detach rocprofiler via socket
+    ROCP_TRACE << "Detaching rocprofiler from pid " << pid << " via socket";
+
+    // Connect to socket for detach operation
+    int detach_socket_fd = connect_to_socket(socket_path.c_str(), max_retries, retry_delay_ms);
+    if(detach_socket_fd == -1)
+    {
+        ROCP_ERROR << "Failed to connect to socket for detach operation";
+        // Continue with ptrace detach anyway
+    }
+    else
+    {
+        // Send DETACH message (empty environment buffer and tool_lib_path)
+        std::vector<uint8_t> empty_env_buffer;
+        auto                 detach_message = common::serialize_attach_message(common::ATTACH_OP_DETACH,
+                                                                               "",
+                                                                               empty_env_buffer);
+
+        if(!send_all(detach_socket_fd, detach_message.data(), detach_message.size()))
+        {
+            ROCP_ERROR << "Failed to send DETACH message";
+        }
+        else
+        {
+            ROCP_TRACE << "Sent DETACH message";
+
+            // Receive response
+            common::attach_response_message detach_response;
+            if(recv_all(detach_socket_fd, &detach_response, sizeof(detach_response)))
+            {
+                if(detach_response.op == common::ATTACH_OP_RESPONSE &&
+                   detach_response.status == common::ATTACH_STATUS_SUCCESS)
+                {
+                    ROCP_TRACE << "DETACH operation completed successfully";
+                }
+                else
+                {
+                    ROCP_ERROR << "DETACH operation failed with rocprofiler_register error code: " << detach_response.status;
+                    // Log more specific error information based on error code
+                    switch(detach_response.status)
+                    {
+                        case ROCP_REG_NO_TOOLS:  // ROCP_REG_NO_TOOLS
+                            ROCP_ERROR << "  -> No profiling tools found (detach entry point is NULL)";
+                            break;
+                        case ROCP_REG_ATTACHMENT_NOT_AVAILABLE:  // ROCP_REG_ATTACHMENT_NOT_AVAILABLE
+                            ROCP_ERROR << "  -> Attachment not available (rocprofiler-attach library was never loaded)";
+                            break;
+                        default:
+                            ROCP_ERROR << "  -> Unknown error during detach";
+                            break;
+                    }
+                }
+            }
+            else
+            {
+                ROCP_ERROR << "Failed to receive DETACH response";
+            }
+        }
+        close(detach_socket_fd);
+    }
+
+    ptrace_session->stop();
+    ptrace_session->detach();
+    ptrace_session.reset();
+}
 
 void
 handle_ptrace_operations(uint32_t pid)
@@ -230,7 +532,7 @@ int
 attach(uint32_t pid)
 {
     initialize_logging();
-    ptrace_thread = std::thread(handle_ptrace_operations, pid);
+    ptrace_thread = std::thread(handle_attach_operations, pid);
     // Wait for ptrace thread to finish setting up
     while(!finished_setup.load())
         std::this_thread::yield();


### PR DESCRIPTION
## Motivation

<!-- When rocprofv3 attach to a running LLM process, it pauses the target process's main thread temporarily while executing the rocprofiler_register_attach function. -->

## Technical Details

<!-- This patch implements asynchronous attach and detach functionality for ROCProfiler v3. It introduces a Unix domain socket-based communication mechanism with a dedicated monitoring thread to handle profiler attach/detach requests. The implementation includes a complete socket protocol with message headers, response handling, and environment variable transmission. Additionally, it provides RAII-style socket resource management and comprehensive error handling, enabling dynamic profiling without blocking the target application's execution. -->

## JIRA ID

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
