### PR TITLE
[SWDEV-571541] Fix Python 3.8/3.7 typing errors

### DIFF
--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -5578,7 +5578,7 @@ def amdsmi_set_gpu_ptl_state(
 
 def amdsmi_get_gpu_ptl_formats(
     processor_handle: processor_handle_t
-    ) -> tuple[int, int]:
+    ) -> Tuple[int, int]:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
     data_format1 = amdsmi_wrapper.amdsmi_ptl_data_format_t()


### PR DESCRIPTION
Changes:
  - Fixed `amd-smi` showing:
```console
  $ amd-smi
Traceback (most recent call last):
  File "/opt/rocm/bin/amd-smi", line 53, in <module>
    from amdsmi_init import *
  File "/opt/rocm/libexec/amdsmi_cli/amdsmi_init.py", line 38, in <module>
    from amdsmi import amdsmi_interface, amdsmi_exception
  File "/usr/local/lib/python3.8/dist-packages/amdsmi/__init__.py", line 24, in <module>
    from .amdsmi_interface import amdsmi_init
  File "/usr/local/lib/python3.8/dist-packages/amdsmi/amdsmi_interface.py", line 5581, in <module>
    ) -> tuple[int, int]:
TypeError: 'type' object is not subscriptable
```
  This was a python3.8 issue, which is now resolved by using
  `Tuple[int, int]` typing for Python 3.8 compatibility.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
