### PR TITLE
Do not declare ocml attributes when using gcc

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bf16.h
@@ -111,9 +111,8 @@
 #if !defined(__HIPCC_RTC__)
 #include <hip/amd_detail/amd_hip_common.h>
 #include "amd_hip_vector_types.h"  // float2 etc
-#include "device_library_decls.h"  // ocml conversion functions
-#include "math_fwd.h"              // ocml device functions
 #if defined(__clang__) && defined(__HIP__)
+#include "math_fwd.h"              // ocml device functions
 #include <hip/amd_detail/amd_warp_functions.h>       // define warpSize
 #include <hip/amd_detail/amd_warp_sync_functions.h>  // Sync functions
 #endif


### PR DESCRIPTION
## Motivation

Including `hip_fp8.h` when compiling with gcc fails due to non-existing `_Float16` type.

## Technical Details

Currently `amd_detail/amd_hip_bf16.h` is `amd_detail/device_library_decls.h` which contains `clang` specific declarations. The solution is to make sure that `clang` specific declarations are only included when compiling with `clang`

## JIRA ID

Resolves: SWDEV-571222

## Test Plan

Github CI Passes

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
