### PR TITLE
rocclr: Fix error handling in VmHeap::CommitMemory when SetMemAccess …

### DIFF
--- a/projects/clr/rocclr/platform/vmheap.cpp
+++ b/projects/clr/rocclr/platform/vmheap.cpp
@@ -75,7 +75,9 @@ bool VmHeap::CommitMemory(void* addr, size_t size) {
 
   // Enable memory access
   if (!device_->SetMemAccess(addr, padded_size, Device::VmmAccess::kReadWrite)) {
-    LogError("SetAccess failed for the commited memory in VmHeap!");
+    LogError("SetAccess failed for the committed memory in VmHeap!");
+    SvmBuffer::free(device_->context(), phys_mem_obj->getSvmPtr());
+    return false;
   }
   return true;
 }


### PR DESCRIPTION
When device_->SetMemAccess() fails, the function still returns true, indicating success. This causes the caller to assume the memory is accessible when it actually isn't, leading to potential access violations or undefined behavior when the memory is used later.

This patch adds proper error handling to clean up the allocated resources and return false to indicate the failure to the caller.

Changes:
- Return false instead of true when SetMemAccess fails
- Free the allocated physical memory on failure to avoid resource leak
- Fix spelling: 'commited' -> 'committed'

## Motivation

Fix vmheap allocate fail handle path issue.

## Technical Details

When device_->SetMemAccess() fails, the function still returns true, indicating success. This causes the caller to assume the memory is accessible when it actually isn't, leading to potential access violations or undefined behavior when the memory is used later.

## JIRA ID

none

## Test Plan

hip catch

## Test Result

hip catch xpassed

## Submission Checklist
Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
