### PR TITLE
HIPRTC: Fix CDNA CU description

### DIFF
--- a/projects/hip/docs/how-to/hip_rtc.rst
+++ b/projects/hip/docs/how-to/hip_rtc.rst
@@ -320,13 +320,13 @@ using the bitcode APIs provided by HIPRTC.
   hiprtcGetBitcode(prog, kernel_bitcode.data());
 
 CU mode vs WGP mode
--------------------------------------------------------------------------------
+-------------------
 
 All :doc:`supported AMD GPUs <rocm-install-on-linux:reference/system-requirements>` are built around a data-parallel
 processor (DPP) array.
 
-On CDNA GPUs, the DPP is organized as a set of compute unit (CU) pipelines, with each CU containing a single SIMD64
-unit. Each CU has its own low-latency memory space called local data share (LDS), which threads from a warp running on
+On CDNA GPUs, the DPP is organized as a set of compute unit (CU) pipelines, with each CU containing four SIMD64
+units. Each CU has its own low-latency memory space called local data share (LDS), which threads from a warp running on
 the CU can access.
 
 On RDNA GPUs, the DPP is organized as a set of workgroup processor (WGP) pipelines. Each WGP contains two CUs, and each


### PR DESCRIPTION
## Motivation

The current text states that each CDNA CU contains a single SIMD64. This is wrong as they contain four SIMD64 units (see CDNA ISA documents).

## Technical Details

Changes the description: CDNA CUs contain four SIMD64 units.

## JIRA ID

ROCDOC-2376

## Test Plan

Will check the published documentation. Also built it locally.

## Test Result

Local documentation looks good.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
