### PR TITLE
Revert correcting the VGPR size for GFX 11.5.1

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -67,6 +67,8 @@ jobs:
           # Remove patches here if they cannot be applied cleanly, and they have not been deleted from TheRock repo
           # rm ./TheRock/patches/amd-mainline/rocm-systems/*.patch
           ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-systems --no-include-rocm-libraries --no-include-ml-frameworks
+          rm ./TheRock/patches/amd-mainline/rocm-systems/0002-Revert-hsakmt-bump-vgpr-count-for-gfx1151-1807.patch
+
 
 
       - name: Patch rocm-systems

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           # Remove patches here if they cannot be applied cleanly, and they have not been deleted from TheRock repo
           # rm ./TheRock/patches/amd-mainline/rocm-systems/*.patch
+          rm ./TheRock/patches/amd-mainline/rocm-systems/0002-Revert-hsakmt-bump-vgpr-count-for-gfx1151-1807.patch
           git -c user.name="therockbot" -c "user.email=therockbot@amd.com" am --whitespace=nowarn ./TheRock/patches/amd-mainline/rocm-systems/*.patch
 
       - name: Install requirements

--- a/projects/rocr-runtime/libhsakmt/src/queues.c
+++ b/projects/rocr-runtime/libhsakmt/src/queues.c
@@ -116,7 +116,6 @@ uint32_t hsakmt_get_vgpr_size_per_cu(uint32_t gfxv)
 
 	else if (gfxv == GFX_VERSION_PLUM_BONITO ||
 		 gfxv == GFX_VERSION_WHEAT_NAS ||
-		 gfxv == GFX_VERSION_GFX1151 ||
 		 gfxv == GFX_VERSION_GFX1200 ||
 		 gfxv == GFX_VERSION_GFX1201)
 		vgpr_size = 0x60000;


### PR DESCRIPTION
Although the value is correct; there is no source of truth between kernel and userspace.  This leads to problems if the kernel has strict restrictions (such as kernel 6.17 or earlier). The restrictions were lifted in 6.17.9 and and 6.18, but there is no guarantee userspace is using this.

So short term this value will be wrong.  But on newer kernels the kernel will communicate the right size and rocr-runtime will be adjusted to use that.

Link: https://github.com/ROCm/TheRock/pull/2505
