### PR TITLE
[libhsakmt/virtio]: Enable vmheap support for virtio driver

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt_virtio.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt_virtio.h
@@ -125,6 +125,8 @@ int vamdgpu_bo_export(amdgpu_bo_handle buf_handle, enum amdgpu_bo_handle_type ty
                      uint32_t* shared_handle);
 int vamdgpu_bo_import(amdgpu_device_handle dev, enum amdgpu_bo_handle_type type,
                      uint32_t shared_handle, struct amdgpu_bo_import_result* output);
+int vamdgpu_bo_va_op(amdgpu_bo_handle bo, uint64_t offset, uint64_t size, uint64_t addr,
+                    uint64_t flags, uint32_t ops);
 
 #ifdef __cplusplus
 }

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt_virtio.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt_virtio.h
@@ -111,6 +111,8 @@ HSAKMT_STATUS HSAKMTAPI vhsaKmtDestroyQueue(HSA_QUEUEID QueueId);
 HSAKMT_STATUS HSAKMTAPI vhsaKmtRegisterGraphicsHandleToNodes(
     HSAuint64 GraphicsResourceHandle, HsaGraphicsResourceInfo* GraphicsResourceInfo,
     HSAuint64 NumberOfNodes, HSAuint32* NodeArray);
+HSAKMT_STATUS HSAKMTAPI vhsaKmtExportDMABufHandle(void* MemoryAddress, HSAuint64 MemorySizeInBytes,
+                                                  int* DMABufFd, HSAuint64* Offset);
 HSAKMT_STATUS HSAKMTAPI vhsaKmtGetRuntimeCapabilities(HSAuint32* caps_mask);
 
 int vamdgpu_query_gpu_info(amdgpu_device_handle dev, void* out);

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt_virtio.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt_virtio.h
@@ -117,6 +117,8 @@ int vamdgpu_query_gpu_info(amdgpu_device_handle dev, void* out);
 int vamdgpu_device_initialize(int fd, uint32_t* major_version, uint32_t* minor_version,
                              amdgpu_device_handle* device_handle);
 int vamdgpu_device_deinitialize(amdgpu_device_handle device_handle);
+int vamdgpu_device_get_fd(amdgpu_device_handle device_handle);
+int vdrmCommandWriteRead(int fd, unsigned long drmCommandIndex, void* data, unsigned long size);
 
 #ifdef __cplusplus
 }

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt_virtio.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt_virtio.h
@@ -44,6 +44,9 @@ HSAKMT_STATUS HSAKMTAPI vhsaKmtOpenKFD(void);
 HSAKMT_STATUS HSAKMTAPI vhsaKmtCloseKFD(void);
 HSAKMT_STATUS HSAKMTAPI vhsaKmtAllocMemory(HSAuint32 PreferredNode, HSAuint64 SizeInBytes,
                                            HsaMemFlags MemFlags, void** MemoryAddress);
+HSAKMT_STATUS HSAKMTAPI vhsaKmtAllocMemoryAlign(HSAuint32 PreferredNode, HSAuint64 SizeInBytes,
+                                                HSAuint64 Alignment, HsaMemFlags MemFlags,
+                                                void** MemoryAddress);
 HSAKMT_STATUS HSAKMTAPI vhsaKmtFreeMemory(void* MemoryAddress, HSAuint64 SizeInBytes);
 HSAKMT_STATUS HSAKMTAPI vhsaKmtMapMemoryToGPUNodes(void* MemoryAddress, HSAuint64 MemorySizeInBytes,
                                                    HSAuint64* AlternateVAGPU,

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt_virtio.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt_virtio.h
@@ -119,6 +119,8 @@ int vamdgpu_device_initialize(int fd, uint32_t* major_version, uint32_t* minor_v
 int vamdgpu_device_deinitialize(amdgpu_device_handle device_handle);
 int vamdgpu_device_get_fd(amdgpu_device_handle device_handle);
 int vdrmCommandWriteRead(int fd, unsigned long drmCommandIndex, void* data, unsigned long size);
+int vamdgpu_bo_cpu_map(amdgpu_bo_handle buf_handle, void** cpu);
+int vamdgpu_bo_free(amdgpu_bo_handle buf_handle);
 
 #ifdef __cplusplus
 }

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt_virtio.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt_virtio.h
@@ -121,6 +121,10 @@ int vamdgpu_device_get_fd(amdgpu_device_handle device_handle);
 int vdrmCommandWriteRead(int fd, unsigned long drmCommandIndex, void* data, unsigned long size);
 int vamdgpu_bo_cpu_map(amdgpu_bo_handle buf_handle, void** cpu);
 int vamdgpu_bo_free(amdgpu_bo_handle buf_handle);
+int vamdgpu_bo_export(amdgpu_bo_handle buf_handle, enum amdgpu_bo_handle_type type,
+                     uint32_t* shared_handle);
+int vamdgpu_bo_import(amdgpu_device_handle dev, enum amdgpu_bo_handle_type type,
+                     uint32_t shared_handle, struct amdgpu_bo_import_result* output);
 
 #ifdef __cplusplus
 }

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt_virtio.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt_virtio.h
@@ -114,6 +114,9 @@ HSAKMT_STATUS HSAKMTAPI vhsaKmtRegisterGraphicsHandleToNodes(
 HSAKMT_STATUS HSAKMTAPI vhsaKmtGetRuntimeCapabilities(HSAuint32* caps_mask);
 
 int vamdgpu_query_gpu_info(amdgpu_device_handle dev, void* out);
+int vamdgpu_device_initialize(int fd, uint32_t* major_version, uint32_t* minor_version,
+                             amdgpu_device_handle* device_handle);
+int vamdgpu_device_deinitialize(amdgpu_device_handle device_handle);
 
 #ifdef __cplusplus
 }

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_amdgpu.c
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_amdgpu.c
@@ -282,3 +282,33 @@ int vamdgpu_bo_import(amdgpu_device_handle dev, enum amdgpu_bo_handle_type type,
 
   return rsp->ret;
 }
+
+int vamdgpu_bo_va_op(amdgpu_bo_handle bo, uint64_t offset, uint64_t size, uint64_t addr,
+                     uint64_t flags, uint32_t ops) {
+  CHECK_VIRTIO_KFD_OPEN();
+
+  vhsakmt_device_handle vdev = vhsakmt_dev();
+  vhsakmt_bo_handle vbo = (vhsakmt_bo_handle)bo;
+
+  struct vhsakmt_ccmd_memory_rsp* rsp;
+  struct vhsakmt_ccmd_memory_req req = {
+      .hdr = VHSAKMT_CCMD(MEMORY, sizeof(struct vhsakmt_ccmd_memory_req)),
+      .type = VHSAKMT_CCMD_MEMORY_AMDGPU_VA_OP,
+      .res_id = vbo->real.res_id,
+      .amdgpu_va_op_args =
+          {
+              .bo = (uint64_t)bo,
+              .offset = offset,
+              .size = size,
+              .addr = addr,
+              .flags = flags,
+              .ops = ops,
+          },
+  };
+
+  rsp = vhsakmt_alloc_rsp(vdev, &req.hdr, sizeof(struct vhsakmt_ccmd_memory_rsp));
+  if (!rsp) return -ENOMEM;
+
+  vhsakmt_execbuf_cpu(vdev, &req.hdr, __FUNCTION__);
+  return rsp->ret;
+}

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_amdgpu.c
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_amdgpu.c
@@ -169,3 +169,116 @@ int vamdgpu_bo_free(amdgpu_bo_handle buf_handle) {
 
   return rsp->ret;
 }
+
+int vamdgpu_bo_export(amdgpu_bo_handle buf_handle, enum amdgpu_bo_handle_type type,
+                      uint32_t* shared_handle) {
+  CHECK_VIRTIO_KFD_OPEN();
+
+  vhsakmt_device_handle vdev = vhsakmt_dev();
+  vhsakmt_bo_handle bo = (vhsakmt_bo_handle)buf_handle;
+
+  if (type != amdgpu_bo_handle_type_kms) {
+    vhsa_err("%s: unsupported export type: %u\n", __FUNCTION__, type);
+    return -EINVAL;
+  }
+
+  struct vhsakmt_ccmd_memory_rsp* rsp;
+  struct vhsakmt_ccmd_memory_req req = {
+      .hdr = VHSAKMT_CCMD(MEMORY, sizeof(struct vhsakmt_ccmd_memory_req)),
+      .type = VHSAKMT_CCMD_MEMORY_AMDGPU_EXPORT,
+      .res_id = bo->real.res_id,
+      .amdgpu_export_args =
+          {
+              .buf_handle = (uint64_t)buf_handle,
+              .type = (uint32_t)type,
+          },
+  };
+
+  rsp = vhsakmt_alloc_rsp(vdev, &req.hdr, sizeof(struct vhsakmt_ccmd_memory_rsp));
+  if (!rsp) return -ENOMEM;
+
+  vhsakmt_execbuf_cpu(vdev, &req.hdr, __FUNCTION__);
+  if (rsp->ret) return rsp->ret;
+
+  *shared_handle = rsp->shared_handle;
+
+  return rsp->ret;
+}
+
+static vhsakmt_bo_handle vhsakmt_bo_from_resid(vhsakmt_device_handle dev, uint32_t res_id) {
+  vhsakmt_bo_handle bo;
+  struct vhsakmt_ccmd_memory_req req = {
+      .hdr = VHSAKMT_CCMD(MEMORY, sizeof(struct vhsakmt_ccmd_memory_req)),
+      .type = VHSAKMT_CCMD_MEMORY_MAP_USERPTR,
+      .res_id = res_id,
+  };
+  struct vhsakmt_ccmd_memory_rsp* rsp =
+      vhsakmt_alloc_rsp(dev, &req.hdr, sizeof(struct vhsakmt_ccmd_memory_rsp));
+  if (!rsp) return NULL;
+
+  rsp->map_userptr_rsp.userptr_handle = 0;
+  vhsakmt_execbuf_cpu(dev, &req.hdr, __FUNCTION__);
+
+  bo = vhsakmt_find_bo_by_addr(dev, (void*)rsp->map_userptr_rsp.userptr_handle);
+
+  return bo;
+}
+
+int vamdgpu_bo_import(amdgpu_device_handle dev, enum amdgpu_bo_handle_type type,
+                      uint32_t shared_handle, struct amdgpu_bo_import_result* output) {
+  CHECK_VIRTIO_KFD_OPEN();
+
+  vhsakmt_device_handle vdev = vhsakmt_dev();
+  vhsakmt_bo_handle obj;
+  uint32_t bo_handle, res_id;
+  int r;
+
+  if ( type != amdgpu_bo_handle_type_dma_buf_fd) {
+    vhsa_err("%s: unsupported import type: %u\n", __FUNCTION__, type);
+    return -EINVAL;
+  }
+
+  r = vhsakmt_handle_to_resid(vdev, shared_handle, &res_id, &bo_handle);
+  if (r) return r;
+
+  obj = vhsakmt_bo_from_resid(vdev, res_id);
+  if (!obj) return HSAKMT_STATUS_INVALID_HANDLE;
+
+  struct vhsakmt_ccmd_memory_rsp* rsp;
+  struct vhsakmt_ccmd_memory_req req = {
+      .hdr = VHSAKMT_CCMD(MEMORY, sizeof(struct vhsakmt_ccmd_memory_req)),
+      .type = VHSAKMT_CCMD_MEMORY_AMDGPU_IMPORT,
+      .res_id = res_id,
+      .amdgpu_import_args =
+          {
+              .dev = (int64_t)dev,
+              .type = (uint32_t)type,
+              .shared_handle = shared_handle,
+          },
+  };
+
+  rsp = vhsakmt_alloc_rsp(vdev, &req.hdr, sizeof(struct vhsakmt_ccmd_memory_rsp));
+  if (!rsp) return -ENOMEM;
+
+  vhsakmt_execbuf_cpu(vdev, &req.hdr, __FUNCTION__);
+  if (rsp->ret) return rsp->ret;
+
+  if (obj->amdgpu_bo.imported) {
+    vhsa_debug("%s: bo already imported for shared_handle: %u\n", __FUNCTION__, shared_handle);
+    vhsakmt_atomic_inc(&obj->amdgpu_bo.refcount);
+    output->alloc_size = obj->amdgpu_bo.import_size;
+    output->buf_handle = (amdgpu_bo_handle)obj;
+    return HSAKMT_STATUS_SUCCESS;
+  }
+
+  memcpy(output, &rsp->amdgpu_import_rsp.output, sizeof(struct amdgpu_bo_import_result));
+
+  obj->bo_type |= VHSA_BO_AMDGPU;
+  obj->amdgpu_bo.imported = true;
+  obj->amdgpu_bo.import_size = output->alloc_size;
+  atomic_store(&obj->amdgpu_bo.refcount, 1);
+
+  output->buf_handle = (amdgpu_bo_handle)obj;
+
+  return rsp->ret;
+}

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_amdgpu.c
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_amdgpu.c
@@ -23,6 +23,17 @@
 #include "hsakmt/hsakmt_virtio.h"
 #include "hsakmt_virtio_device.h"
 
+/* amdgpu device initialize/deinitialize wil be called in vhsakmtopen 
+ * so just return ENOSYS here to avoid duplicate implementation
+ */
+int vamdgpu_device_initialize(int fd, uint32_t* major_version, uint32_t* minor_version,
+                              amdgpu_device_handle* device_handle) {
+  return -ENOSYS;
+}
+int vamdgpu_device_deinitialize(amdgpu_device_handle device_handle) {
+  return -ENOSYS;
+}
+
 int vamdgpu_query_gpu_info(amdgpu_device_handle handle, void* out) {
   CHECK_VIRTIO_KFD_OPEN();
 

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_amdgpu.c
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_amdgpu.c
@@ -134,3 +134,38 @@ HSAKMT_STATUS vhsaKmtGetAMDGPUDeviceHandle(HSAuint32 NodeId, HsaAMDGPUDeviceHand
 
   return rsp->ret;
 }
+
+int vamdgpu_bo_cpu_map(amdgpu_bo_handle buf_handle, void** cpu) {
+  return 0;
+}
+
+int vamdgpu_bo_free(amdgpu_bo_handle buf_handle) {
+  CHECK_VIRTIO_KFD_OPEN();
+
+  vhsakmt_device_handle vdev = vhsakmt_dev();
+  vhsakmt_bo_handle vbo = (vhsakmt_bo_handle)buf_handle;
+
+  struct vhsakmt_ccmd_memory_rsp* rsp;
+  struct vhsakmt_ccmd_memory_req req = {
+      .hdr = VHSAKMT_CCMD(MEMORY, sizeof(struct vhsakmt_ccmd_memory_req)),
+      .type = VHSAKMT_CCMD_MEMORY_AMDGPU_BO_FREE,
+      .buf_handle = (uint64_t)buf_handle,
+      .res_id = vbo->real.res_id,
+  };
+
+  rsp = vhsakmt_alloc_rsp(vdev, &req.hdr, sizeof(struct vhsakmt_ccmd_memory_rsp));
+  if (!rsp) return -ENOMEM;
+
+  vhsakmt_execbuf_cpu(vdev, &req.hdr, __FUNCTION__);
+
+  if (vbo->amdgpu_bo.imported) {
+    if (vhsakmt_atomic_dec_return(&vbo->amdgpu_bo.refcount) > 0) {
+      return HSAKMT_STATUS_SUCCESS;
+    }
+    vbo->amdgpu_bo.import_size = 0;
+    vbo->amdgpu_bo.imported = false;
+    vbo->bo_type &= (uint32_t)~VHSA_BO_AMDGPU;
+  }
+
+  return rsp->ret;
+}

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_amdgpu.c
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_amdgpu.c
@@ -54,8 +54,83 @@ int vamdgpu_query_gpu_info(amdgpu_device_handle handle, void* out) {
   return ret;
 }
 
+int vamdgpu_device_get_fd(amdgpu_device_handle device_handle) {
+  CHECK_VIRTIO_KFD_OPEN();
+
+  vhsakmt_device_handle dev = vhsakmt_dev();
+  struct vhsakmt_node* node = NULL;
+  for (uint32_t i = 0; i < dev->sys_props->NumNodes; i++) {
+    if (dev->vhsakmt_nodes[i].amdgpu_device_handle == device_handle) {
+      node = &dev->vhsakmt_nodes[i];
+      break;
+    }
+  }
+  if (node)
+    return node->amdgpu_fd;
+
+  return -1;
+}
+
+int vdrmCommandWriteRead(int fd, unsigned long drmCommandIndex, void* data, unsigned long size) {
+  CHECK_VIRTIO_KFD_OPEN();
+
+  if (size > VHSAKMT_CCMD_QUERY_DRM_CMD_WRITE_READ_MAX_SIZE)
+    return -EINVAL;
+
+  vhsakmt_device_handle dev = vhsakmt_dev();
+  struct vhsakmt_ccmd_query_info_rsp* rsp;
+  struct vhsakmt_ccmd_query_info_req req = {
+      .hdr = VHSAKMT_CCMD(QUERY_INFO, sizeof(struct vhsakmt_ccmd_query_info_req) + size),
+      .type = VHSAKMT_CCMD_QUERY_DRM_CMD_WRITE_READ,
+      .drm_cmd_write_read_args =
+          {
+              .fd = fd,
+              .drmCommandIndex = drmCommandIndex,
+              .size = size,
+          },
+  };
+
+  memcpy(req.payload, data, size);
+
+  rsp = vhsakmt_alloc_rsp(dev, &req.hdr,
+                          sizeof(struct vhsakmt_ccmd_query_info_rsp) + size);
+  if (!rsp) return -ENOMEM;
+
+  vhsakmt_execbuf_cpu(dev, &req.hdr, __FUNCTION__);
+  if (rsp->ret) return rsp->ret;
+
+  memcpy(data, rsp->payload, size);
+
+  return rsp->ret;
+}
+
 HSAKMT_STATUS vhsaKmtGetAMDGPUDeviceHandle(HSAuint32 NodeId, HsaAMDGPUDeviceHandle* DeviceHandle) {
   CHECK_VIRTIO_KFD_OPEN();
 
-  return HSAKMT_STATUS_SUCCESS;
+  struct vhsakmt_node* node = vhsakmt_get_node_by_id(vhsakmt_dev(), NodeId);
+  if (!node) return HSAKMT_STATUS_INVALID_HANDLE;
+
+  if (node->amdgpu_device_handle) {
+    *DeviceHandle = node->amdgpu_device_handle;
+    return HSAKMT_STATUS_SUCCESS;
+  }
+
+  vhsakmt_device_handle dev = vhsakmt_dev();
+  struct vhsakmt_ccmd_query_info_rsp* rsp;
+  struct vhsakmt_ccmd_query_info_req req = {
+      .hdr = VHSAKMT_CCMD(QUERY_INFO, sizeof(struct vhsakmt_ccmd_query_info_req)),
+      .type = VHSAKMT_CCMD_QUERY_AMDGPU_DEVICE_HANDLE,
+      .NodeID = NodeId,
+  };
+
+  rsp = vhsakmt_alloc_rsp(dev, &req.hdr, sizeof(struct vhsakmt_ccmd_query_info_rsp));
+  if (!rsp) return -ENOMEM;
+
+  vhsakmt_execbuf_cpu(dev, &req.hdr, __FUNCTION__);
+  *DeviceHandle = (void*)rsp->device_handle_rsp.amdgpu_device_handle;
+
+  node->amdgpu_device_handle = (void*)rsp->device_handle_rsp.amdgpu_device_handle;
+  node->amdgpu_fd = (int)rsp->device_handle_rsp.fd;
+
+  return rsp->ret;
 }

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_device.h
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_device.h
@@ -73,7 +73,7 @@ extern vhsakmt_device_handle dev_list;
 #define VHSA_BO_QUEUE_RW_PTR 1 << 4   /* queue read write ptr, from host map to guest*/
 /* allocated from KFD, but used for AQL queue read write ptr */
 #define VHSA_BO_QUEUE_AQL_RW_PTR 1 << 5
-#define VHSA_BO_CLGL 1 << 6 /* CLGL memory, imported from mesa GL */
+#define VHSA_BO_AMDGPU 1 << 6 /* amdgpu bo */
 /* allocated from KFD, but is scratch memory, do not need map and unmap in ioctrl */
 #define VHSA_BO_SCRATCH 1 << 7
 #define VHSA_BO_QUEUE 1 << 8
@@ -143,7 +143,13 @@ struct vhsakmt_bo {
   vHsaEvent* event;
   uint64_t queue_id;
   vhsakmt_bo_handle rw_bo;
-  void* gl_meta_data;
+  struct
+  {
+    void* gl_meta_data;
+    uint64_t import_size;
+    bool imported : 1;
+    int refcount;
+  } amdgpu_bo;
 };
 
 /*hsakmt_virtio_memory.c*/
@@ -183,6 +189,7 @@ bool vhsakmt_is_userptr(vhsakmt_device_handle dev, void* addr);
 /*hsakmt_virtio_device.c*/
 int vhsakmt_execbuf_cpu(vhsakmt_device_handle dev, struct vhsakmt_ccmd_req* req, const char* from);
 void* vhsakmt_alloc_rsp(vhsakmt_device_handle dev, struct vhsakmt_ccmd_req* req, uint32_t sz);
+int vhsakmt_handle_to_resid(vhsakmt_device_handle dev, uint32_t handle, uint32_t* res_id, uint32_t* bo_handle);
 
 /*hsakmt_virtio_event.c*/
 void* vhsakmt_event_host_handle(HsaEvent* h);

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_device.h
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_device.h
@@ -37,6 +37,8 @@ extern "C" {
 
 #define vhsakmt_atomic_inc_return(ptr) (atomic_fetch_add((ptr), 1) + 1)
 #define vhsakmt_atomic_dec_return(ptr) (atomic_fetch_sub((ptr), 1) - 1)
+#define vhsakmt_atomic_inc(ptr) ((void)atomic_fetch_add((ptr), 1))
+#define vhsakmt_atomic_dec(ptr) ((void)atomic_fetch_sub((ptr), 1))
 
 #define VHSA_VPTR_TO_UINT64(vptr) ((uint64_t)(unsigned long)(vptr))
 #define VHSA_UINT64_TO_VPTR(v) ((void*)(unsigned long)(v))
@@ -185,6 +187,7 @@ int vhsakmt_set_node_doorbell(vhsakmt_device_handle dev, uint32_t node, void* do
 void* vhsakmt_node_doorbell(vhsakmt_device_handle dev, uint32_t node);
 bool vhsakmt_is_scratch_mem(vhsakmt_device_handle dev, void* addr);
 bool vhsakmt_is_userptr(vhsakmt_device_handle dev, void* addr);
+struct vhsakmt_node* vhsakmt_get_node_by_id(vhsakmt_device_handle dev, uint32_t node_id);
 
 /*hsakmt_virtio_device.c*/
 int vhsakmt_execbuf_cpu(vhsakmt_device_handle dev, struct vhsakmt_ccmd_req* req, const char* from);

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_device.h
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_device.h
@@ -94,6 +94,8 @@ struct vhsakmt_node {
   void* doorbell_base;
   uint64_t scratch_start;
   uint64_t scratch_size;
+  HsaAMDGPUDeviceHandle amdgpu_device_handle;
+  int amdgpu_fd;
 };
 
 struct vhsakmt_device {

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_memory.c
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_memory.c
@@ -379,7 +379,7 @@ int vhsakmt_bo_free(vhsakmt_device_handle dev, vhsakmt_bo_handle bo) {
 
   if (bo->event) free(bo->event);
 
-  if (bo->gl_meta_data) free(bo->gl_meta_data);
+  if (bo->amdgpu_bo.gl_meta_data) free(bo->amdgpu_bo.gl_meta_data);
 
   pthread_mutex_destroy(&bo->map_mutex);
 
@@ -802,7 +802,7 @@ HSAKMT_STATUS HSAKMTAPI vhsaKmtDeregisterMemory(void* MemoryAddress) {
   vhsakmt_device_handle dev = vhsakmt_dev();
   vhsakmt_bo_handle bo = vhsakmt_find_bo_by_addr(dev, MemoryAddress);
 
-  if (bo && (bo->bo_type & VHSA_BO_CLGL)) return vhsakmt_remove_clgl_bo(dev, bo);
+  if (bo && (bo->bo_type & VHSA_BO_AMDGPU)) return vhsakmt_remove_clgl_bo(dev, bo);
 
   if (!dev->use_svm) {
     return vhsakmt_deregister_userptr_non_svm(dev, MemoryAddress);
@@ -884,8 +884,8 @@ HSAKMT_STATUS HSAKMTAPI vhsaKmtGetTileConfig(HSAuint32 NodeId, HsaGpuTileConfig*
   return rsp->ret;
 }
 
-static int vhsakmt_create_clgl_bo(vhsakmt_device_handle dev, void* addr, size_t size,
-                                  uint32_t res_id, uint32_t bo_handle, void* meta_data) {
+static int vhsakmt_create_amdgpu_bo(vhsakmt_device_handle dev, void* addr, size_t size,
+                                    uint32_t res_id, uint32_t bo_handle, void* meta_data) {
   vhsakmt_bo_handle out = calloc(1, sizeof(struct vhsakmt_bo));
   if (!out) return -ENOMEM;
 
@@ -902,8 +902,8 @@ static int vhsakmt_create_clgl_bo(vhsakmt_device_handle dev, void* addr, size_t 
 
   /* GL bo handle from GL context*/
   out->real.handle = bo_handle;
-  out->bo_type |= VHSA_BO_CLGL;
-  if (meta_data) out->gl_meta_data = meta_data;
+  out->bo_type |= VHSA_BO_AMDGPU;
+  if (meta_data) out->amdgpu_bo.gl_meta_data = meta_data;
 
   out->host_addr = addr;
 
@@ -912,18 +912,18 @@ static int vhsakmt_create_clgl_bo(vhsakmt_device_handle dev, void* addr, size_t 
   return 0;
 }
 
-static int vhsakmt_gfxhandle_to_resid(vhsakmt_device_handle dev, uint32_t gfx_handle,
-                                      uint32_t* res_id, uint32_t* bo_handle) {
-  int r = drmPrimeFDToHandle(dev->vgdev->fd, gfx_handle, bo_handle);
+int vhsakmt_handle_to_resid(vhsakmt_device_handle dev, uint32_t handle,
+                            uint32_t* res_id, uint32_t* bo_handle) {
+  int r = drmPrimeFDToHandle(dev->vgdev->fd, handle, bo_handle);
   if (r) {
-    vhsa_err("%s: drmPrimeFDToHandle failed for handle: %u\n", __FUNCTION__, gfx_handle);
+    vhsa_err("%s: drmPrimeFDToHandle failed for handle: %u\n", __FUNCTION__, handle);
     return r;
   }
 
   virtio_gpu_res_id(dev->vgdev, *bo_handle, res_id);
 
-  vhsa_debug("%s: register praphics handle: handle: %d, bo_handle: %d, res_id: %d\n", __FUNCTION__,
-             gfx_handle, *bo_handle, *res_id);
+  vhsa_debug("%s: drm handle: %d, bo_handle: %d, res_id: %d\n", __FUNCTION__,
+             handle, *bo_handle, *res_id);
 
   return 0;
 }
@@ -952,7 +952,7 @@ HSAKMT_STATUS HSAKMTAPI vhsaKmtRegisterGraphicsHandleToNodes(
 #ifdef CLGL_EXPORT_RESID
   req->reg_ghd_to_nodes.GraphicsResourceHandle = GraphicsResourceHandle;
 #else
-  r = vhsakmt_gfxhandle_to_resid(dev, GraphicsResourceHandle, &res_id, &bo_handle);
+  r = vhsakmt_handle_to_resid(dev, GraphicsResourceHandle, &res_id, &bo_handle);
   if (r) return r;
 
   req->reg_ghd_to_nodes.GraphicsResourceHandle = bo_handle;
@@ -988,9 +988,9 @@ HSAKMT_STATUS HSAKMTAPI vhsaKmtRegisterGraphicsHandleToNodes(
              GraphicsResourceHandle, GraphicsResourceInfo->MemoryAddress,
              GraphicsResourceInfo->SizeInBytes);
 
-  r = vhsakmt_create_clgl_bo(dev, GraphicsResourceInfo->MemoryAddress,
-                             GraphicsResourceInfo->SizeInBytes, res_id, bo_handle,
-                             VHSA_UINT64_TO_VPTR(GraphicsResourceInfo->Metadata));
+  r = vhsakmt_create_amdgpu_bo(dev, GraphicsResourceInfo->MemoryAddress,
+                               GraphicsResourceInfo->SizeInBytes, res_id, bo_handle,
+                               VHSA_UINT64_TO_VPTR(GraphicsResourceInfo->Metadata));
   if (r) goto free_out;
 
   r = rsp->ret;

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_memory.c
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_memory.c
@@ -295,8 +295,9 @@ int vhsakmt_create_mappable_blob_bo(vhsakmt_device_handle dev, size_t size, uint
   return r;
 }
 
-HSAKMT_STATUS HSAKMTAPI vhsaKmtAllocMemory(HSAuint32 PreferredNode, HSAuint64 SizeInBytes,
-                                           HsaMemFlags MemFlags, void** MemoryAddress) {
+HSAKMT_STATUS HSAKMTAPI vhsaKmtAllocMemoryAlign(HSAuint32 PreferredNode, HSAuint64 SizeInBytes,
+                                                HSAuint64 Alignment, HsaMemFlags MemFlags,
+                                                void** MemoryAddress) {
   vhsakmt_device_handle dev = vhsakmt_dev();
   struct vhsakmt_ccmd_memory_rsp* rsp;
   vhsakmt_bo_handle bo;
@@ -310,6 +311,7 @@ HSAKMT_STATUS HSAKMTAPI vhsaKmtAllocMemory(HSAuint32 PreferredNode, HSAuint64 Si
               .PreferredNode = PreferredNode,
               .SizeInBytes = SizeInBytes,
               .MemFlags = MemFlags,
+              .Alignment = Alignment,
           },
   };
 
@@ -349,6 +351,11 @@ HSAKMT_STATUS HSAKMTAPI vhsaKmtAllocMemory(HSAuint32 PreferredNode, HSAuint64 Si
              *MemoryAddress, bo->host_addr, SizeInBytes, bo->real.res_id, bo->real.handle);
 
   return rsp->ret;
+}
+
+HSAKMT_STATUS HSAKMTAPI vhsaKmtAllocMemory(HSAuint32 PreferredNode, HSAuint64 SizeInBytes,
+                                           HsaMemFlags MemFlags, void** MemoryAddress) {
+  return vhsaKmtAllocMemoryAlign(PreferredNode, SizeInBytes, 0, MemFlags, MemoryAddress);
 }
 
 int vhsakmt_bo_free(vhsakmt_device_handle dev, vhsakmt_bo_handle bo) {

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_memory.c
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_memory.c
@@ -129,7 +129,6 @@ static vhsakmt_bo_handle vhsakmt_find_userptr(vhsakmt_device_handle dev, unsigne
 }
 
 static void vhsakmt_destroy_userptr(vhsakmt_device_handle dev, vhsakmt_bo_handle bo) {
-  hsakmt_interval_tree_remove(&dev->userptr_tree, &bo->itn);
   pthread_mutex_destroy(&bo->map_mutex);
 
   struct drm_gem_close drm_req = {
@@ -754,6 +753,9 @@ static int vhsakmt_deregister_userptr_non_svm(vhsakmt_device_handle dev, void* M
   size_t page_size = getpagesize();
   unsigned long aligned_addr = ((uint64_t)MemoryAddress / page_size) * page_size;
   interval_tree_node_t* n;
+  vhsakmt_bo_handle* bos_to_free = NULL;
+  int free_count = 0;
+  int free_capacity = 0;
 
   pthread_mutex_lock(&dev->bo_handles_mutex);
 
@@ -773,7 +775,7 @@ static int vhsakmt_deregister_userptr_non_svm(vhsakmt_device_handle dev, void* M
     n = hsakmt_interval_tree_iter_next(&dev->userptr_tree, n, aligned_addr, aligned_addr);
   }
 
-  /* Second pass: Free all userptrs if all refcounts are <= 0 */
+  /* Second pass: Collect BOs to free and remove from tree */
   if (can_free_all) {
     n = hsakmt_interval_tree_iter_first(&dev->userptr_tree, aligned_addr, aligned_addr);
     while (n) {
@@ -785,7 +787,21 @@ static int vhsakmt_deregister_userptr_non_svm(vhsakmt_device_handle dev, void* M
         vhsa_debug("%s: destroying userptr: %p, size: %x, res_id: %d\n", __FUNCTION__, bo->cpu_addr,
                    bo->size, bo->real.res_id);
 
-        vhsakmt_destroy_userptr(dev, bo);
+        hsakmt_interval_tree_remove(&dev->userptr_tree, &bo->itn);
+
+        if (free_count >= free_capacity) {
+          int new_capacity = free_capacity == 0 ? 32 : free_capacity * 2;
+          vhsakmt_bo_handle* new_array = realloc(bos_to_free, new_capacity * sizeof(vhsakmt_bo_handle));
+          if (!new_array) {
+            vhsa_err("%s: failed to allocate memory for BO array, freeing %d BOs\n", __FUNCTION__, free_count);
+            pthread_mutex_unlock(&dev->bo_handles_mutex);
+            goto cleanup;
+          }
+          bos_to_free = new_array;
+          free_capacity = new_capacity;
+        }
+
+        bos_to_free[free_count++] = bo;
       }
 
       n = next;
@@ -793,6 +809,17 @@ static int vhsakmt_deregister_userptr_non_svm(vhsakmt_device_handle dev, void* M
   }
 
   pthread_mutex_unlock(&dev->bo_handles_mutex);
+
+cleanup:
+  for (int i = 0; i < free_count; i++) {
+    vhsakmt_bo_handle bo = bos_to_free[i];
+    vhsakmt_destroy_userptr(dev, bo);
+  }
+
+  if (bos_to_free) {
+    free(bos_to_free);
+  }
+
   return 0;
 }
 

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_memory.c
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_memory.c
@@ -1001,3 +1001,49 @@ free_out:
   free(req);
   return r;
 }
+
+static int vhsakmt_export_dmabuf(vhsakmt_device_handle dev, uint32_t bo_handle, int* dmabuf_fd) {
+  return drmPrimeHandleToFD(dev->vgdev->fd, bo_handle, DRM_CLOEXEC | DRM_RDWR, dmabuf_fd);
+}
+
+HSAKMT_STATUS HSAKMTAPI vhsaKmtExportDMABufHandle(void* MemoryAddress, HSAuint64 MemorySizeInBytes,
+                                                  int* DMABufFd, HSAuint64* Offset) {
+  CHECK_VIRTIO_KFD_OPEN();
+
+  vhsakmt_device_handle dev = vhsakmt_dev();
+  vhsakmt_bo_handle bo =  vhsakmt_find_bo_by_addr(dev, MemoryAddress);
+  if (!bo) return HSAKMT_STATUS_INVALID_HANDLE;
+  int r;
+
+  r = vhsakmt_export_dmabuf(dev, bo->real.handle, DMABufFd);
+  if (r) {
+    vhsa_err("%s: export dmabuf failed for handle: %d\n",
+              __FUNCTION__, bo->real.handle);
+    return -HSAKMT_STATUS_ERROR;
+  }
+
+  struct vhsakmt_ccmd_memory_rsp* rsp;
+  struct vhsakmt_ccmd_memory_req req = {
+      .hdr = VHSAKMT_CCMD(MEMORY, sizeof(struct vhsakmt_ccmd_memory_req)),
+      .type = VHSAKMT_CCMD_MEMORY_EXPORT_DMABUF,
+      .export_dmabuf_args =
+          {
+              .MemoryAddress = (uint64_t)MemoryAddress,
+              .MemorySizeInBytes = MemorySizeInBytes,
+          },
+      .res_id = bo->real.res_id,
+  };
+
+  rsp = vhsakmt_alloc_rsp(dev, &req.hdr, sizeof(struct vhsakmt_ccmd_memory_rsp));
+  if (!rsp) return -ENOMEM;
+
+  vhsakmt_execbuf_cpu(dev, &req.hdr, __FUNCTION__);
+  if (rsp->ret) return rsp->ret;
+
+  *Offset = rsp->export_dmabuf_rsp.offset;
+
+  vhsa_debug("%s: gva: %p, size: %lx, dmabuf_fd: %d, offset: %lx, resid: %x \n", __FUNCTION__,
+             MemoryAddress, MemorySizeInBytes, *DMABufFd, *Offset, bo->real.res_id);
+
+  return r;
+}

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_openclose.c
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_openclose.c
@@ -134,6 +134,8 @@ static void vhsakmt_device_destroy(struct vhsakmt_device* dev) {
   if (dev->vhsakmt_nodes) free(dev->vhsakmt_nodes);
 
   virtio_gpu_close(dev->vgdev);
+  free(dev);
+  dev_list = NULL;
 }
 
 HSAKMT_STATUS HSAKMTAPI vhsaKmtCloseKFD(void) {

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_proto.h
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_proto.h
@@ -326,6 +326,7 @@ typedef struct _memory_req_alloc_args {
   HsaMemFlags MemFlags;
   uint64_t SizeInBytes;
   uint64_t MemoryAddress;
+  uint64_t Alignment;
 } memory_req_alloc_args;
 VHSAKMT_STATIC_ASSERT_SIZE(_memory_req_alloc_args)
 

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_proto.h
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_proto.h
@@ -109,6 +109,8 @@ enum vhsakmt_ccmd_query_type {
   VHSAKMT_CCMD_QUERY_TILE_CONFIG,
   VHSAKMT_CCMD_QUERY_NANO_TIME,
   VHSAKMT_CCMD_QUERY_GET_RUNTIME_CAPS,
+  VHSAKMT_CCMD_QUERY_AMDGPU_DEVICE_HANDLE,
+  VHSAKMT_CCMD_QUERY_DRM_CMD_WRITE_READ,
 };
 
 #define QUERY_PTR_INFO_MAX_MAPPED_NODES 3
@@ -164,6 +166,19 @@ typedef struct _query_nano_time_rsp {
 } query_nano_time_rsp;
 VHSAKMT_STATIC_ASSERT_SIZE(_query_nano_time_rsp)
 
+typedef struct _query_drm_cmd_write_read_args {
+   uint64_t fd;
+   uint64_t drmCommandIndex;
+   uint64_t size;
+} query_drm_cmd_write_read_args;
+VHSAKMT_STATIC_ASSERT_SIZE(_query_drm_cmd_write_read_args)
+
+typedef struct _query_device_handle_rsp {
+  uint64_t amdgpu_device_handle;
+  uint64_t fd;
+} query_device_handle_rsp;
+VHSAKMT_STATIC_ASSERT_SIZE(_query_device_handle_rsp)
+
 struct vhsakmt_ccmd_query_info_req {
   struct vhsakmt_ccmd_req hdr;
   struct drm_amdgpu_info info;
@@ -178,6 +193,7 @@ struct vhsakmt_ccmd_query_info_req {
     query_req_node_io_link_args node_io_link_args;
     query_tile_config tile_config_args;
     query_open_kfd_args open_kfd_args;
+    query_drm_cmd_write_read_args drm_cmd_write_read_args;
   };
 
   uint8_t payload[];
@@ -186,8 +202,9 @@ VHSAKMT_DEFINE_CAST(vhsakmt_ccmd_req, vhsakmt_ccmd_query_info_req)
 VHSAKMT_STATIC_ASSERT_SIZE(vhsakmt_ccmd_query_info_req)
 #define VHSAKMT_CCMD_QUERY_MAX_TILE_CONFIG 128
 #define VHSAKMT_CCMD_QUERY_MAX_GET_NOD_MEM_PROP 128
-#define VHSAKMT_CCMD_QUERY_MAX_GET_NOD_CACHE_PROP 128
-#define VHSAKMT_CCMD_QUERY_MAX_GET_NOD_IO_LINK_PROP 128
+#define VHSAKMT_CCMD_QUERY_MAX_GET_NOD_CACHE_PROP 512
+#define VHSAKMT_CCMD_QUERY_MAX_GET_NOD_IO_LINK_PROP 512
+#define VHSAKMT_CCMD_QUERY_DRM_CMD_WRITE_READ_MAX_SIZE 128
 
 struct vhsakmt_ccmd_query_info_rsp {
   struct vhsakmt_ccmd_rsp hdr;
@@ -203,6 +220,7 @@ struct vhsakmt_ccmd_query_info_rsp {
     HsaNodeProperties node_props;
     int32_t xnack_mode;
     HsaClockCounters clock_counters;
+    query_device_handle_rsp device_handle_rsp;
     uint32_t caps;
     uint64_t pad[9];
   };

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_proto.h
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_proto.h
@@ -337,6 +337,7 @@ enum vhsakmt_ccmd_memory_type {
   VHSAKMT_CCMD_MEMORY_REG_MEM_WITH_FLAG,
   VHSAKMT_CCMD_MEMORY_DEREG_MEM,
   VHSAKMT_CCMD_MEMORY_MAP_USERPTR,
+  VHSAKMT_CCMD_MEMORY_AMDGPU_BO_FREE,
 };
 
 typedef struct _memory_req_alloc_args {
@@ -385,6 +386,7 @@ struct vhsakmt_ccmd_memory_req {
   struct vhsakmt_ccmd_req hdr;
   union {
     uint64_t MemoryAddress;
+    uint64_t buf_handle;
     uint32_t Node;
     memory_req_alloc_args alloc_args;
     memory_req_map_to_GPU_nodes_args map_to_GPU_nodes_args;

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_proto.h
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_proto.h
@@ -340,6 +340,7 @@ enum vhsakmt_ccmd_memory_type {
   VHSAKMT_CCMD_MEMORY_EXPORT_DMABUF,
   VHSAKMT_CCMD_MEMORY_AMDGPU_IMPORT,
   VHSAKMT_CCMD_MEMORY_AMDGPU_EXPORT,
+  VHSAKMT_CCMD_MEMORY_AMDGPU_VA_OP,
   VHSAKMT_CCMD_MEMORY_AMDGPU_BO_FREE,
 };
 
@@ -399,6 +400,17 @@ typedef struct _memory_amdgpu_export_args {
 } memory_amdgpu_export_args;
 VHSAKMT_STATIC_ASSERT_SIZE(_memory_amdgpu_export_args)
 
+typedef struct _memory_amdgpu_va_op_args {
+   uint64_t bo;
+   uint64_t offset;
+   uint64_t size;
+   uint64_t addr;
+   uint64_t flags;
+   uint32_t ops;
+   uint32_t pad;
+} memory_amdgpu_va_op_args;
+VHSAKMT_STATIC_ASSERT_SIZE(_memory_amdgpu_va_op_args)
+
 typedef struct _memory_export_dmabuf_args {
   uint64_t MemoryAddress;
   uint64_t MemorySizeInBytes;
@@ -419,6 +431,7 @@ struct vhsakmt_ccmd_memory_req {
     memory_export_dmabuf_args export_dmabuf_args;
     memory_amdgpu_import_args amdgpu_import_args;
     memory_amdgpu_export_args amdgpu_export_args;
+    memory_amdgpu_va_op_args amdgpu_va_op_args;
   };
   uint64_t blob_id;
   uint32_t type;

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_proto.h
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_proto.h
@@ -337,6 +337,9 @@ enum vhsakmt_ccmd_memory_type {
   VHSAKMT_CCMD_MEMORY_REG_MEM_WITH_FLAG,
   VHSAKMT_CCMD_MEMORY_DEREG_MEM,
   VHSAKMT_CCMD_MEMORY_MAP_USERPTR,
+  VHSAKMT_CCMD_MEMORY_EXPORT_DMABUF,
+  VHSAKMT_CCMD_MEMORY_AMDGPU_IMPORT,
+  VHSAKMT_CCMD_MEMORY_AMDGPU_EXPORT,
   VHSAKMT_CCMD_MEMORY_AMDGPU_BO_FREE,
 };
 
@@ -382,6 +385,26 @@ typedef struct _memory_reg_mem_with_flag {
 } memory_reg_mem_with_flag;
 VHSAKMT_STATIC_ASSERT_SIZE(_memory_reg_mem_with_flag)
 
+typedef struct _memory_amdgpu_import_args {
+  int64_t dev;
+  uint32_t type;
+  uint32_t shared_handle;
+} memory_amdgpu_import_args;
+VHSAKMT_STATIC_ASSERT_SIZE(_memory_amdgpu_import_args)
+
+typedef struct _memory_amdgpu_export_args {
+  uint64_t buf_handle;
+   uint32_t type;
+   uint32_t pad;
+} memory_amdgpu_export_args;
+VHSAKMT_STATIC_ASSERT_SIZE(_memory_amdgpu_export_args)
+
+typedef struct _memory_export_dmabuf_args {
+  uint64_t MemoryAddress;
+  uint64_t MemorySizeInBytes;
+} memory_export_dmabuf_args;
+VHSAKMT_STATIC_ASSERT_SIZE(_memory_export_dmabuf_args)
+
 struct vhsakmt_ccmd_memory_req {
   struct vhsakmt_ccmd_req hdr;
   union {
@@ -393,6 +416,9 @@ struct vhsakmt_ccmd_memory_req {
     memory_req_free_args free_args;
     memory_map_mem_to_gpu_args map_to_GPU_args;
     memory_reg_mem_with_flag reg_mem_with_flag;
+    memory_export_dmabuf_args export_dmabuf_args;
+    memory_amdgpu_import_args amdgpu_import_args;
+    memory_amdgpu_export_args amdgpu_export_args;
   };
   uint64_t blob_id;
   uint32_t type;
@@ -409,14 +435,29 @@ typedef struct _vhsakmt_ccmd_memory_map_userptr_rsp {
 } vhsakmt_ccmd_memory_map_userptr_rsp;
 VHSAKMT_STATIC_ASSERT_SIZE(_vhsakmt_ccmd_memory_map_userptr_rsp)
 
+typedef struct _vhsakmt_ccmd_memory_export_dmabuf_rsp {
+  int64_t dmabuf_fd;
+  uint64_t offset;
+} vhsakmt_ccmd_memory_export_dmabuf_rsp;
+VHSAKMT_STATIC_ASSERT_SIZE(_vhsakmt_ccmd_memory_export_dmabuf_rsp)
+
+typedef struct _vhsakmt_ccmd_memory_amdgpu_import_rsp
+{
+  struct amdgpu_bo_import_result output;
+}vhsakmt_ccmd_memory_amdgpu_import_rsp;
+VHSAKMT_STATIC_ASSERT_SIZE(_vhsakmt_ccmd_memory_amdgpu_import_rsp)
+
 struct vhsakmt_ccmd_memory_rsp {
   struct vhsakmt_ccmd_rsp hdr;
   int32_t ret;
   union {
     vhsakmt_ccmd_memory_map_userptr_rsp map_userptr_rsp;
+    vhsakmt_ccmd_memory_export_dmabuf_rsp export_dmabuf_rsp;
     uint64_t memory_handle;
     uint64_t alternate_vagpu;
     uint64_t available_bytes;
+    vhsakmt_ccmd_memory_amdgpu_import_rsp amdgpu_import_rsp;
+    uint32_t shared_handle;
   };
   uint8_t payload[];
 };

--- a/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_vm.c
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/hsakmt_virtio_vm.c
@@ -111,3 +111,10 @@ void* vhsakmt_node_doorbell(vhsakmt_device_handle dev, uint32_t node) {
 
   return dev->vhsakmt_nodes[node].doorbell_base;
 }
+
+struct vhsakmt_node* vhsakmt_get_node_by_id(vhsakmt_device_handle dev, uint32_t node_id) {
+  if (!dev->vhsakmt_nodes || !dev->sys_props) return NULL;
+  if (node_id >= dev->sys_props->NumNodes) return NULL;
+
+  return &dev->vhsakmt_nodes[node_id];
+}

--- a/projects/rocr-runtime/libhsakmt/src/virtio/libhsakmt_virtio.ver
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/libhsakmt_virtio.ver
@@ -41,6 +41,8 @@ vhsaKmtDestroyQueue;
 vhsaKmtRegisterGraphicsHandleToNodes;
 vhsaKmtGetRuntimeCapabilities;
 vamdgpu_query_gpu_info;
+vamdgpu_device_initialize;
+vamdgpu_device_deinitialize;
 local: *;
 };
 

--- a/projects/rocr-runtime/libhsakmt/src/virtio/libhsakmt_virtio.ver
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/libhsakmt_virtio.ver
@@ -39,6 +39,7 @@ vhsaKmtCreateQueueExt;
 vhsaKmtCreateQueue;
 vhsaKmtDestroyQueue;
 vhsaKmtRegisterGraphicsHandleToNodes;
+vhsaKmtExportDMABufHandle;
 vhsaKmtGetRuntimeCapabilities;
 vamdgpu_query_gpu_info;
 vamdgpu_device_initialize;

--- a/projects/rocr-runtime/libhsakmt/src/virtio/libhsakmt_virtio.ver
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/libhsakmt_virtio.ver
@@ -47,6 +47,8 @@ vamdgpu_device_get_fd;
 vdrmCommandWriteRead;
 vamdgpu_bo_cpu_map;
 vamdgpu_bo_free;
+vamdgpu_bo_export;
+vamdgpu_bo_import;
 local: *;
 };
 

--- a/projects/rocr-runtime/libhsakmt/src/virtio/libhsakmt_virtio.ver
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/libhsakmt_virtio.ver
@@ -49,6 +49,7 @@ vamdgpu_bo_cpu_map;
 vamdgpu_bo_free;
 vamdgpu_bo_export;
 vamdgpu_bo_import;
+vamdgpu_bo_va_op;
 local: *;
 };
 

--- a/projects/rocr-runtime/libhsakmt/src/virtio/libhsakmt_virtio.ver
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/libhsakmt_virtio.ver
@@ -3,6 +3,7 @@ global:
 vhsaKmtOpenKFD;
 vhsaKmtCloseKFD;
 vhsaKmtAllocMemory;
+vhsaKmtAllocMemoryAlign;
 vhsaKmtFreeMemory;
 vhsaKmtMapMemoryToGPUNodes;
 vhsaKmtUnmapMemoryToGPU;

--- a/projects/rocr-runtime/libhsakmt/src/virtio/libhsakmt_virtio.ver
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/libhsakmt_virtio.ver
@@ -43,6 +43,8 @@ vhsaKmtGetRuntimeCapabilities;
 vamdgpu_query_gpu_info;
 vamdgpu_device_initialize;
 vamdgpu_device_deinitialize;
+vamdgpu_device_get_fd;
+vdrmCommandWriteRead;
 local: *;
 };
 

--- a/projects/rocr-runtime/libhsakmt/src/virtio/libhsakmt_virtio.ver
+++ b/projects/rocr-runtime/libhsakmt/src/virtio/libhsakmt_virtio.ver
@@ -45,6 +45,8 @@ vamdgpu_device_initialize;
 vamdgpu_device_deinitialize;
 vamdgpu_device_get_fd;
 vdrmCommandWriteRead;
+vamdgpu_bo_cpu_map;
+vamdgpu_bo_free;
 local: *;
 };
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
@@ -45,6 +45,7 @@
 
 #include <link.h>
 #include <vector>
+#include <amdgpu_drm.h>
 
 #include "core/inc/amd_gpu_agent.h"
 #include "core/inc/amd_memory_region.h"
@@ -54,6 +55,20 @@ extern r_debug _amdgpu_r_debug;
 
 namespace rocr {
 namespace AMD {
+
+__forceinline uint64_t drm_perm(hsa_access_permission_t perm) {
+  switch (perm) {
+  case HSA_ACCESS_PERMISSION_RO:
+    return AMDGPU_VM_PAGE_READABLE;
+  case HSA_ACCESS_PERMISSION_WO:
+    return AMDGPU_VM_PAGE_WRITEABLE;
+  case HSA_ACCESS_PERMISSION_RW:
+    return AMDGPU_VM_PAGE_READABLE | AMDGPU_VM_PAGE_WRITEABLE;
+  case HSA_ACCESS_PERMISSION_NONE:
+  default:
+    return 0;
+  }
+}
 
 KfdVirtioDriver::KfdVirtioDriver(std::string devnode_name)
     : core::Driver(core::DriverType::KFD_VIRTIO, std::move(devnode_name)) {}
@@ -448,26 +463,73 @@ hsa_status_t KfdVirtioDriver::AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_G
 }
 
 hsa_status_t KfdVirtioDriver::ExportDMABuf(void* mem, size_t size, int* dmabuf_fd, size_t* offset) {
-  return HSA_STATUS_ERROR;
+  int dmabuf_fd_res = -1;
+  size_t offset_res = 0;
+  HSAKMT_STATUS status =
+      vhsaKmtExportDMABufHandle(mem, size, &dmabuf_fd_res, &offset_res);
+  if (status != HSAKMT_STATUS_SUCCESS) {
+    if (status == HSAKMT_STATUS_INVALID_PARAMETER) {
+      return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
+
+  *dmabuf_fd = dmabuf_fd_res;
+  *offset = offset_res;
+
+  return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t KfdVirtioDriver::ImportDMABuf(int dmabuf_fd, core::Agent& agent,
                                            core::ShareableHandle& handle) {
-  return HSA_STATUS_ERROR;
+  auto &gpu_agent = static_cast<GpuAgent &>(agent);
+  amdgpu_bo_import_result res;
+  auto ret = vamdgpu_bo_import(
+      gpu_agent.libDrmDev(), amdgpu_bo_handle_type_dma_buf_fd, dmabuf_fd, &res);
+  if (ret)
+    return HSA_STATUS_ERROR;
+
+  handle.handle = reinterpret_cast<uint64_t>(res.buf_handle);
+  return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t KfdVirtioDriver::Map(core::ShareableHandle handle, void* mem, size_t offset,
                                   size_t size, hsa_access_permission_t perms) {
-  return HSA_STATUS_ERROR;
+  const auto ldrm_bo = reinterpret_cast<amdgpu_bo_handle>(handle.handle);
+  if (!ldrm_bo)
+    return HSA_STATUS_ERROR;
+
+  if (vamdgpu_bo_va_op(ldrm_bo, offset, size, reinterpret_cast<uint64_t>(mem),
+                       drm_perm(perms), AMDGPU_VA_OP_MAP) != 0)
+    return HSA_STATUS_ERROR;
+
+  return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t KfdVirtioDriver::Unmap(core::ShareableHandle handle, void* mem, size_t offset,
                                     size_t size) {
-  return HSA_STATUS_ERROR;
+  const auto ldrm_bo = reinterpret_cast<amdgpu_bo_handle>(handle.handle);
+  if (!ldrm_bo)
+    return HSA_STATUS_ERROR;
+
+  if (vamdgpu_bo_va_op(ldrm_bo, offset, size, reinterpret_cast<uint64_t>(mem), 0,
+                      AMDGPU_VA_OP_UNMAP) != 0)
+    return HSA_STATUS_ERROR;
+
+  return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t KfdVirtioDriver::ReleaseShareableHandle(core::ShareableHandle& handle) {
-  return HSA_STATUS_ERROR;
+  const auto ldrm_bo = reinterpret_cast<amdgpu_bo_handle>(handle.handle);
+  if (!ldrm_bo)
+    return HSA_STATUS_ERROR;
+
+  const auto ret = vamdgpu_bo_free(ldrm_bo);
+  if (ret)
+    return HSA_STATUS_ERROR;
+
+  handle = {};
+  return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t KfdVirtioDriver::GetTileConfig(uint32_t node_id, HsaGpuTileConfig* config) const {


### PR DESCRIPTION
## Motivation

This PR only changes the libhsakmt/virtio code, so zero effects on normal functions.

This series of patches implements the necessary support in libhsakmt's virtio backend to enable the CLR vmheap functionality.

## Technical Details

The vmheap implementation in CLR relies on specific AMDGPU buffer object (BO) management capabilities and device interactions. This series bridges the gap by adding the required infrastructure and APIs to the virtio driver.
## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->



## Test Plan

rocr
hip catch

## Test Result

rocr passed
hip catch passed

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
