### PR TITLE
[rocprofiler-compute] Remove hip dependency during analysis

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -36,7 +36,6 @@ import yaml
 
 import config
 from roofline import Roofline
-from utils import benchmark
 from utils.amdsmi_interface import amdsmi_ctx, get_gpu_model, get_mem_max_clock
 from utils.logger import (
     console_debug,
@@ -650,6 +649,9 @@ class OmniSoC_Base:
     @abstractmethod
     def post_profiling(self) -> None:
         """Perform any SoC-specific post profiling activities."""
+        # Dynamic import to isolate hip dependency during profile time only
+        from utils import benchmark
+
         console_debug("profiling", f"perform SoC post processing for {self.__arch}")
 
         # Roofline can be skipped via --no-roof

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -649,11 +649,7 @@ class OmniSoC_Base:
     @abstractmethod
     def post_profiling(self) -> None:
         """Perform any SoC-specific post profiling activities."""
-        # Dynamic import to isolate hip dependency during profile time only
-        from utils import benchmark
-
         console_debug("profiling", f"perform SoC post processing for {self.__arch}")
-
         # Roofline can be skipped via --no-roof
         # Roofline not supported on MI 100
         # If --filter-blocks is provided, roofline block (block 4) should be mentioned
@@ -668,6 +664,9 @@ class OmniSoC_Base:
         ):
             console_log("roofline", "Skipping roofline")
         else:
+            # Dynamic import to isolate hip dependency during profile time only
+            from utils import benchmark
+
             pmc_path = Path(self.get_args().path) / "pmc_perf.csv"
             if not pmc_path.is_file():
                 console_warning(


### PR DESCRIPTION
## Motivation

Remove hip dependency during analysis.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Dynamically import roofline benchmark module during profiling phase only.

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Ensure analysis can be done without ROCm stack installed and ensured successful profile after this change.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Tests pass

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
