### PR TITLE
[rocprofiler-sdk] Backward compatibility of HIP dispatch to Release 7.1.0

### DIFF
--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/hip/api_args.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/hip/api_args.h
@@ -3292,6 +3292,19 @@ typedef union rocprofiler_hip_api_args_t
     } hipStreamGetId;
 #endif
 #if HIP_RUNTIME_API_TABLE_STEP_VERSION >= 15
+    // HIP changed the option pointer types for hipLibraryLoad* APIs:
+    //
+    //   • ROCm 7.1.0 (HIP runtime API table step 15):
+    //        jitOptions        : hipJitOption**     (double pointer)
+    //        libraryOptions    : hipLibraryOption** (double pointer)
+    //
+    //   • Newer HIP versions:
+    //        jitOptions        : hipJitOption*      (single pointer)
+    //        libraryOptions    : hipLibraryOption*  (single pointer)
+    //
+    // Switch types at compile time to have backward compatibility across ROCm
+    // versions. HIP_RUNTIME_API_TABLE_STEP_VERSION is included to correctly
+    // detect a newer HIP runtime even when installed on a 7.1.0 ROCm stack.
     struct
     {
         hipLibrary_t* library;
@@ -3311,6 +3324,7 @@ typedef union rocprofiler_hip_api_args_t
         void**       libraryOptionValues;
         unsigned int numLibraryOptions;
     } hipLibraryLoadData;
+    // Same compatibility logic for hipLibraryLoadFromFile().
     struct
     {
         hipLibrary_t* library;

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/hip/api_args.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/hip/api_args.h
@@ -34,6 +34,12 @@
 #include <hip/amd_detail/amd_hip_gl_interop.h>
 #include <hip/amd_detail/hip_api_trace.hpp>
 
+#if defined(__has_include)
+#    if __has_include(<rocm-core/rocm_version.h>)
+#        include <rocm-core/rocm_version.h>
+#    endif
+#endif
+
 #include <stdint.h>
 
 ROCPROFILER_EXTERN_C_INIT
@@ -3288,25 +3294,41 @@ typedef union rocprofiler_hip_api_args_t
 #if HIP_RUNTIME_API_TABLE_STEP_VERSION >= 15
     struct
     {
-        hipLibrary_t*     library;
-        const void*       code;
+        hipLibrary_t* library;
+        const void*   code;
+#    if(ROCM_VERSION_MAJOR == 7) && (ROCM_VERSION_MINOR == 1) && (ROCM_VERSION_PATCH == 0) &&      \
+        HIP_RUNTIME_API_TABLE_STEP_VERSION == 15
+        hipJitOption**     jitOptions;
+        void**             jitOptionsValues;
+        unsigned int       numJitOptions;
+        hipLibraryOption** libraryOptions;
+#    else
         hipJitOption*     jitOptions;
         void**            jitOptionsValues;
         unsigned int      numJitOptions;
         hipLibraryOption* libraryOptions;
-        void**            libraryOptionValues;
-        unsigned int      numLibraryOptions;
+#    endif
+        void**       libraryOptionValues;
+        unsigned int numLibraryOptions;
     } hipLibraryLoadData;
     struct
     {
-        hipLibrary_t*     library;
-        const char*       fileName;
+        hipLibrary_t* library;
+        const char*   fileName;
+#    if(ROCM_VERSION_MAJOR == 7) && (ROCM_VERSION_MINOR == 1) && (ROCM_VERSION_PATCH == 0) &&      \
+        HIP_RUNTIME_API_TABLE_STEP_VERSION == 15
+        hipJitOption**     jitOptions;
+        void**             jitOptionsValues;
+        unsigned int       numJitOptions;
+        hipLibraryOption** libraryOptions;
+#    else
         hipJitOption*     jitOptions;
         void**            jitOptionsValues;
         unsigned int      numJitOptions;
         hipLibraryOption* libraryOptions;
-        void**            libraryOptionValues;
-        unsigned int      numLibraryOptions;
+#    endif
+        void**       libraryOptionValues;
+        unsigned int numLibraryOptions;
     } hipLibraryLoadFromFile;
     struct
     {


### PR DESCRIPTION
## Motivation

fix build issue of latest rocprofiler-sdk on rocm 7.1.0

## Technical Details

HIP 7.1.0 used a different ABI for the hipLibraryLoad* APIs:
hipJitOption** / hipLibraryOption** (double-pointer) instead of the newer single-pointer form.
This PR updates rocprofiler-sdk’s API wrappers to switch between the two layouts at compile time.

We detect the 7.1.0 ABI using:

ROCM_VERSION_MAJOR/MINOR/PATCH

HIP_RUNTIME_API_TABLE_STEP_VERSION == 15 (for considering case where newer hip runtime is built from source)

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

rocprofiler-sdk builds with rocm 7.1.0 and rocm 7.1.0 with newer HIP runtime

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
