### PR TITLE
[rocprofiler-compute] Do not use absolute python path when adding tests

### DIFF
--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -152,6 +152,15 @@ if(CHECK_PYTHON_DEPS)
 endif()
 
 # ----------------------
+# Portable Python command for tests
+# ----------------------
+# For build-time checks, use ${Python3_EXECUTABLE} (absolute path from find_package)
+# For runtime tests (add_test), use portable command that resolves from PATH
+# This allows tests to work when build/install folders are moved to different machines
+set(PYTHON_TEST_COMMAND "python3" CACHE STRING "Python command for running tests (portable)")
+message(STATUS "Python test command: ${PYTHON_TEST_COMMAND}")
+
+# ----------------------
 # modulefile creation
 # ----------------------
 
@@ -255,7 +264,7 @@ endif()
 add_test(
     NAME test_profile_kernel_execution
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -m kernel_execution
+        ${PYTHON_TEST_COMMAND} -m pytest -m kernel_execution
         --junitxml=tests/test_profile_kernel_execution.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
@@ -263,7 +272,7 @@ add_test(
 add_test(
     NAME test_profile_dispatch
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -m dispatch
+        ${PYTHON_TEST_COMMAND} -m pytest -m dispatch
         --junitxml=tests/test_profile_dispatch.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
@@ -271,42 +280,42 @@ add_test(
 add_test(
     NAME test_profile_mem
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -m mem --junitxml=tests/test_profile_mem.xml
+        ${PYTHON_TEST_COMMAND} -m pytest -m mem --junitxml=tests/test_profile_mem.xml
         ${COV_OPTION} tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
     NAME test_profile_join
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -m join --junitxml=tests/test_profile_join.xml
+        ${PYTHON_TEST_COMMAND} -m pytest -m join --junitxml=tests/test_profile_join.xml
         ${COV_OPTION} tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
     NAME test_profile_sort
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -m sort --junitxml=tests/test_profile_sort.xml
+        ${PYTHON_TEST_COMMAND} -m pytest -m sort --junitxml=tests/test_profile_sort.xml
         ${COV_OPTION} tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
     NAME test_profile_misc
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -m misc --junitxml=tests/test_profile_misc.xml
+        ${PYTHON_TEST_COMMAND} -m pytest -m misc --junitxml=tests/test_profile_misc.xml
         ${COV_OPTION} tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
     NAME test_profile_path
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -m path --junitxml=tests/test_profile_path.xml
+        ${PYTHON_TEST_COMMAND} -m pytest -m path --junitxml=tests/test_profile_path.xml
         ${COV_OPTION} tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
     NAME test_profile_roofline_1
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -m roofline_1
+        ${PYTHON_TEST_COMMAND} -m pytest -m roofline_1
         --junitxml=tests/test_profile_roofline_1.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
@@ -314,7 +323,7 @@ add_test(
 add_test(
     NAME test_profile_roofline_2
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -m roofline_2
+        ${PYTHON_TEST_COMMAND} -m pytest -m roofline_2
         --junitxml=tests/test_profile_roofline_2.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
@@ -322,7 +331,7 @@ add_test(
 add_test(
     NAME test_profile_section
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -m section
+        ${PYTHON_TEST_COMMAND} -m pytest -m section
         --junitxml=tests/test_profile_section.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
@@ -330,7 +339,7 @@ add_test(
 add_test(
     NAME test_profile_pc_sampling
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -s -m pc_sampling
+        ${PYTHON_TEST_COMMAND} -m pytest -s -m pc_sampling
         --junitxml=tests/test_profile_pc_sampling.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
@@ -338,7 +347,7 @@ add_test(
 add_test(
     NAME test_profile_sets_func
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -m sets_func
+        ${PYTHON_TEST_COMMAND} -m pytest -m sets_func
         --junitxml=tests/test_profile_sets_func.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
@@ -346,7 +355,7 @@ add_test(
 add_test(
     NAME test_profile_live_attach_detach
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -s -m live_attach_detach
+        ${PYTHON_TEST_COMMAND} -m pytest -s -m live_attach_detach
         --junitxml=tests/test_profile_live_attach_detach.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
@@ -354,7 +363,7 @@ add_test(
 add_test(
     NAME test_profile_iteration_multiplexing
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -s -m iteration_multiplexing
+        ${PYTHON_TEST_COMMAND} -m pytest -s -m iteration_multiplexing
         --junitxml=tests/test_profile_iteration_multiplexing.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
@@ -384,7 +393,7 @@ set_tests_properties(
 add_test(
     NAME test_analyze_commands
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -n ${PYTEST_NUMPROCS_ANALYSIS} --verbose
+        ${PYTHON_TEST_COMMAND} -m pytest -n ${PYTEST_NUMPROCS_ANALYSIS} --verbose
         --junitxml=tests/test_analyze_commands.xml ${COV_OPTION}
         tests/test_analyze_commands.py ${WORKING_DIR_OPTION}
 )
@@ -396,7 +405,7 @@ add_test(
 add_test(
     NAME test_analyze_workloads
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -n ${PYTEST_NUMPROCS}
+        ${PYTHON_TEST_COMMAND} -m pytest -n ${PYTEST_NUMPROCS}
         --junitxml=tests/test_analyze_workloads.xml ${COV_OPTION}
         tests/test_analyze_workloads.py ${WORKING_DIR_OPTION}
 )
@@ -408,7 +417,7 @@ add_test(
 add_test(
     NAME test_L1_cache_counters
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -m L1_cache
+        ${PYTHON_TEST_COMMAND} -m pytest -m L1_cache
         --junitxml=tests/test_L1_cache_counters.xml ${COV_OPTION}
         tests/test_TCP_counters.py ${WORKING_DIR_OPTION}
 )
@@ -420,7 +429,7 @@ add_test(
 add_test(
     NAME test_num_xcds_spec_class
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -m num_xcds_spec_class
+        ${PYTHON_TEST_COMMAND} -m pytest -m num_xcds_spec_class
         --junitxml=tests/test_num_xcds_spec_class.xml ${COV_OPTION}
         tests/test_gpu_specs.py ${WORKING_DIR_OPTION}
 )
@@ -428,7 +437,7 @@ add_test(
 add_test(
     NAME test_num_xcds_cli_output
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest -m num_xcds_cli_output
+        ${PYTHON_TEST_COMMAND} -m pytest -m num_xcds_cli_output
         --junitxml=tests/test_num_xcds_cli_output.xml ${COV_OPTION}
         tests/test_gpu_specs.py ${WORKING_DIR_OPTION}
 )
@@ -440,7 +449,7 @@ add_test(
 add_test(
     NAME test_utils
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest --junitxml=tests/test_utils.xml ${COV_OPTION}
+        ${PYTHON_TEST_COMMAND} -m pytest --junitxml=tests/test_utils.xml ${COV_OPTION}
         tests/test_utils.py ${WORKING_DIR_OPTION}
 )
 
@@ -451,7 +460,7 @@ add_test(
 add_test(
     NAME test_autogen_config
     COMMAND
-        ${Python3_EXECUTABLE} -m pytest --junitxml=tests/test_autogen_config.xml
+        ${PYTHON_TEST_COMMAND} -m pytest --junitxml=tests/test_autogen_config.xml
         ${COV_OPTION} tests/test_autogen_config.py ${WORKING_DIR_OPTION}
 )
 
@@ -486,7 +495,7 @@ if(${ENABLE_COVERAGE})
     add_test(
         NAME generate_coverage_report
         COMMAND
-            ${Python3_EXECUTABLE} -m coverage xml -o ${CMAKE_BINARY_DIR}/coverage.xml
+            ${PYTHON_TEST_COMMAND} -m coverage xml -o ${CMAKE_BINARY_DIR}/coverage.xml
             ${WORKING_DIR_OPTION}
     )
 


### PR DESCRIPTION
## Motivation

When running ctest on the installation folder after transferring it to a different machine, the python executable path could be different. So, do not use absolute python path in add_test calls in cmake, instead just use `python3`

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

 Do not use absolute python path in add_test calls in cmake, instead just use `python3`

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Ensure build and install works and ctest works properly

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
