### PR TITLE
[rocr-runtime] Move blit kernel params from static to Runtime-managed lifecycle

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/common/static_object.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/static_object.cpp
@@ -77,3 +77,5 @@ register_static_dtor(static_dtor_func_t&& _func)
 }
 }  // namespace common
 }  // namespace rocprofiler
+
+// Trigger CI

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_kernel.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_kernel.h
@@ -53,6 +53,11 @@
 
 namespace rocr {
 namespace AMD {
+
+/// @brief Destroys blit kernel parameters allocated during runtime.
+/// Called during Runtime::Unload() to ensure deterministic cleanup ordering.
+void DestroyBlitKernelParams();
+
 class BlitKernel : public core::Blit {
  public:
   explicit BlitKernel(core::Queue* queue);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
@@ -43,6 +43,7 @@
 #include "core/inc/amd_blit_kernel.h"
 
 #include <algorithm>
+#include <mutex>
 #include <sstream>
 #include <string>
 
@@ -53,8 +54,22 @@
 namespace rocr {
 namespace AMD {
 
-static std::string& kBlitKernelSource() {
-  static std::string kBlitKernelSource_(R"(
+// Structure to hold blit kernel source and cached parameters.
+// Allocated on first use, destroyed explicitly during Runtime::Unload().
+struct BlitKernelParamsData {
+  std::string source;
+  int copy_aligned_vec_width;
+  int copy_aligned_unroll;
+  int copy_misaligned_unroll;
+  int fill_vec_width;
+  int fill_unroll;
+  bool initialized;
+};
+
+static BlitKernelParamsData* g_blit_params = nullptr;
+static std::once_flag g_blit_params_init_flag;
+
+static const char* kBlitKernelSourceText = R"(
   // Compatibility function for GFXIP 7.
 
   function s_load_dword_offset(byte_offset)
@@ -491,45 +506,68 @@ static std::string& kBlitKernelSource() {
   L_FILL_PHASE_2_DONE:
     s_endpgm
   end
-)");
-  return kBlitKernelSource_;
-}
+)";
 
 // Search kernel source for variable definition and return value.
-int GetKernelSourceParam(const char* paramName) {
+static int GetKernelSourceParam(const std::string& source, const char* paramName) {
   std::stringstream paramDef;
   paramDef << "var " << paramName << " = ";
 
-  std::string::size_type paramDefLoc =
-                              kBlitKernelSource().find(paramDef.str());
+  std::string::size_type paramDefLoc = source.find(paramDef.str());
   assert(paramDefLoc != std::string::npos);
   std::string::size_type paramValLoc = paramDefLoc + paramDef.str().size();
-  std::string::size_type paramEndLoc =
-      kBlitKernelSource().find('\n', paramDefLoc);
+  std::string::size_type paramEndLoc = source.find('\n', paramDefLoc);
   assert(paramEndLoc != std::string::npos);
 
-  std::string paramVal(&kBlitKernelSource()[paramValLoc],
-                       &kBlitKernelSource()[paramEndLoc]);
+  std::string paramVal(&source[paramValLoc], &source[paramEndLoc]);
   return std::stoi(paramVal);
 }
 
-
-#define DEFINE_KERNEL_PARAM_FUNC(name) \
-static int& name() { \
-    static std::once_flag initFlag; \
-    static int val; \
-    std::call_once(initFlag, [&]() { \
-        val = GetKernelSourceParam(#name); \
-    }); \
-    return val; \
+// Initialize the blit kernel params on first access.
+static void InitBlitKernelParams() {
+  std::call_once(g_blit_params_init_flag, []() {
+    g_blit_params = new BlitKernelParamsData();
+    g_blit_params->source = kBlitKernelSourceText;
+    g_blit_params->copy_aligned_vec_width = GetKernelSourceParam(g_blit_params->source, "kCopyAlignedVecWidth");
+    g_blit_params->copy_aligned_unroll = GetKernelSourceParam(g_blit_params->source, "kCopyAlignedUnroll");
+    g_blit_params->copy_misaligned_unroll = GetKernelSourceParam(g_blit_params->source, "kCopyMisalignedUnroll");
+    g_blit_params->fill_vec_width = GetKernelSourceParam(g_blit_params->source, "kFillVecWidth");
+    g_blit_params->fill_unroll = GetKernelSourceParam(g_blit_params->source, "kFillUnroll");
+    g_blit_params->initialized = true;
+  });
 }
 
-// Use the macro to define the functions
-DEFINE_KERNEL_PARAM_FUNC(kCopyAlignedVecWidth)
-DEFINE_KERNEL_PARAM_FUNC(kCopyAlignedUnroll)
-DEFINE_KERNEL_PARAM_FUNC(kCopyMisalignedUnroll)
-DEFINE_KERNEL_PARAM_FUNC(kFillVecWidth)
-DEFINE_KERNEL_PARAM_FUNC(kFillUnroll)
+// Destroy blit kernel params during Runtime::Unload().
+void DestroyBlitKernelParams() {
+  delete g_blit_params;
+  g_blit_params = nullptr;
+}
+
+// Accessor functions for cached kernel parameters.
+static int kCopyAlignedVecWidth() {
+  InitBlitKernelParams();
+  return g_blit_params->copy_aligned_vec_width;
+}
+
+static int kCopyAlignedUnroll() {
+  InitBlitKernelParams();
+  return g_blit_params->copy_aligned_unroll;
+}
+
+static int kCopyMisalignedUnroll() {
+  InitBlitKernelParams();
+  return g_blit_params->copy_misaligned_unroll;
+}
+
+static int kFillVecWidth() {
+  InitBlitKernelParams();
+  return g_blit_params->fill_vec_width;
+}
+
+static int kFillUnroll() {
+  InitBlitKernelParams();
+  return g_blit_params->fill_unroll;
+}
 
 static unsigned extractAqlBits(unsigned v, unsigned pos, unsigned width) {
   return (v >> pos) & ((1 << width) - 1);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -70,6 +70,7 @@
 #endif
 
 #include "core/common/shared.h"
+#include "core/inc/amd_blit_kernel.h"
 #include "core/inc/amd_core_dump.hpp"
 #include "core/inc/amd_cpu_agent.h"
 #include "core/inc/amd_gpu_agent.h"
@@ -2457,6 +2458,11 @@ void Runtime::Unload() {
 
   asyncSignals_.reset();
   asyncExceptions_.reset();
+
+  // Destroy blit kernel parameters after async handlers are destroyed.
+  // This ensures deterministic cleanup ordering instead of relying on
+  // static destruction order.
+  AMD::DestroyBlitKernelParams();
 
   if (vm_fault_signal_ != nullptr) {
     vm_fault_signal_->DestroySignal();


### PR DESCRIPTION
## Summary

- Move `kBlitKernelSource_` from a function-local static `std::string` to a pointer-based allocation that is explicitly destroyed during `Runtime::Unload()`
- This ensures deterministic cleanup ordering instead of relying on C++ static destruction order
- The cleanup happens after async handlers are destroyed in the shutdown sequence

## Changes

- Add `BlitKernelParamsData` struct to hold kernel source and cached parameters
- Use `std::call_once` for thread-safe lazy initialization
- Add `DestroyBlitKernelParams()` function called after async handlers in `Unload()`
- Replace macro-based parameter functions with simple accessors

## Test plan

- [ ] Build rocr-runtime
- [ ] Run existing tests
- [ ] Verify no memory leaks during shutdown with valgrind/ASan

🤖 Generated with [Claude Code](https://claude.com/claude-code)