### PR TITLE
Add rccl to auto-labeler yaml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -26,6 +26,10 @@
 - changed-files:
   - any-glob-to-any-file: 'projects/rccl/**/*'
 
+"project: rccl-tests":
+- changed-files:
+  - any-glob-to-any-file: 'projects/rccl-tests/**/*'
+
 "project: rdc":
 - changed-files:
   - any-glob-to-any-file: 'projects/rdc/**/*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,6 +22,10 @@
 - changed-files:
   - any-glob-to-any-file: 'projects/hip-tests/**/*'
 
+"project: rccl":
+- changed-files:
+  - any-glob-to-any-file: 'projects/rccl/**/*'
+
 "project: rdc":
 - changed-files:
   - any-glob-to-any-file: 'projects/rdc/**/*'


### PR DESCRIPTION
## Motivation

Adds config for automatically adding `project: rccl` label to PRs modifying rccl files

## Technical Details

Follows same convention as rest of components in labeler yaml

## Test Plan

Can only test after merge
