### PR TITLE
[rocpd] Write rocpd yaml files as a list, even when only 1 file

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/package.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/package.py
@@ -377,11 +377,7 @@ def create_metadata_file(db_files, output_path=".", metadata_filename="index.yam
                     rocpd_metadata_param_version: rocpd_package_version,
                     # "source": "rocprofv3",  # omitting source, not sure why we need this, and how we determine the source as rocprof-sys, for example.
                     "path": ".",
-                    "files": (
-                        rel_paths
-                        if len(rel_paths) > 1
-                        else (rel_paths[0] if rel_paths else "")
-                    ),
+                    "files": rel_paths,
                 }
             }
         }


### PR DESCRIPTION
## Motivation

Always list the `files` as a list, even when only 1 file.  This makes the yaml parsing more consistent.
As requested by @vstempen 

## Technical Details

Always list the `files` as a list, even when only 1 file.  This makes the yaml parsing more consistent.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Ran ctest.
Also manually converted with ROCPD using multiple DBs and let auto-merge merge DBs into 1 merge file.  Confirmed index.yaml listed `files` as 1 item in a list format (with `-`)

## Test Result

Yaml file should look like this now:
```
files:
    - merged_db_0_dffd8669-cf9a-4e8d-9ac8-18b9e65a6b7e.db
```

instead of the previous:
```
files: merged_db_0_dffd8669-cf9a-4e8d-9ac8-18b9e65a6b7e.db
 ```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
