### PR TITLE
Graph API tutorial: Fix wrong executable call

### DIFF
--- a/projects/hip/docs/tutorial/graph_api.rst
+++ b/projects/hip/docs/tutorial/graph_api.rst
@@ -332,7 +332,7 @@ Inside the ``build`` directory you will now generate a trace:
 
 .. code-block:: bash
 
-  rocprofv3 -o streams -d outDir -f pftrace --hip-trace --kernel-trace --memory-copy-trace --memory-allocation-trace -- ./HIP-Doc/Tutorials/graph_api/src/hip_graph_api_tutorial_graph_creation
+  rocprofv3 -o streams -d outDir -f pftrace --hip-trace --kernel-trace --memory-copy-trace --memory-allocation-trace -- ./HIP-Doc/Tutorials/graph_api/src/hip_graph_api_tutorial_streams
 
 .. note::
   For more information on the ``rocprofv3`` tool, please refer to its


### PR DESCRIPTION
## Motivation

One of the executable calls in the HIP Graph API tutorial is wrong.

## Technical Details

Changes the call to the correct executable.

## JIRA ID

n/a

## Test Plan

n/a

## Test Result

n/a

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
