### PR TITLE
CSS: Don't reference images that aren't generated by Doxygen

### DIFF
--- a/projects/hip/docs/doxygen/Doxyfile
+++ b/projects/hip/docs/doxygen/Doxyfile
@@ -1243,7 +1243,8 @@ HTML_STYLESHEET        =
 # list). For an example see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_STYLESHEET  = ../_doxygen/extra_stylesheet.css
+HTML_EXTRA_STYLESHEET  = ../_doxygen/extra_stylesheet.css \
+                         ../_doxygen/doxygen-img-ref-fix.css
 
 # The HTML_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the HTML output directory. Note


### PR DESCRIPTION
## Motivation

Doxygen generates CSS files that reference images which aren't copied to the target directory. This is harmless (because the features are not used anyway) but makes the dead link checker unhappy.

## Technical Details

The Doxyfile now loads the new CSS override from https://github.com/ROCm/rocm-docs-core/pull/1467.

## JIRA ID

Fixes ROCDOC-2270.

## Test Plan

n/a

## Test Result

n/a

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
