### PR TITLE
Move submodule definitions from projects/rccl/.gitmodules to root

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,13 @@
+[submodule "projects/rccl/ext-src/mscclpp"]
+	path = projects/rccl/ext-src/mscclpp
+	url = https://github.com/microsoft/mscclpp.git
+	ignore = dirty
+	shallow = true
+[submodule "projects/rccl/ext-src/json"]
+	path = projects/rccl/ext-src/json
+	url = https://github.com/nlohmann/json.git
+	ignore = dirty
+	shallow = true
 [submodule "projects/rocprofiler/perfetto"]
 	path = projects/rocprofiler/plugin/perfetto/perfetto
 	url = https://github.com/google/perfetto.git


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
- rccl project was recently updated and is breaking some CI workflows now due to missing submodule definitions in `.gitmodules`
- See an example workflow being broken here: https://github.com/ROCm/rocm-systems/actions/runs/20156966946/job/57916704799

`Error: fatal: No url found for submodule path 'projects/rccl/ext-src/json' in .gitmodules`
`Error: The process '/usr/bin/git' failed with exit code 128`

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Seems like there were definitions inside of `projects/rccl/.gitmodules` for these submodules, but these were not being picked up on the super-repo
- Moved the definitions from `projects/rccl/.gitmodules` to the root `.gitmodules` file
  - Should we be removing all `projects/*/.gitmodules` files if they are not being used anymore with the super-repo?

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Verify that we have no git clone issues in workflows

## Test Result

<!-- Briefly summarize test outcomes. -->
- Workflows pass successfully without any git clone issues
  - I started a separate branch that included this change along with a small change on a workflow to trigger that workflow, and it was able to progress past the checkout stage
  - https://github.com/ROCm/rocm-systems/actions/runs/20174860437/job/57920175494?pr=2297

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
