### PR TITLE
comment update for wrong units associated with RDC 

### DIFF
--- a/projects/rdc/include/rdc/rdc.h
+++ b/projects/rdc/include/rdc/rdc.h
@@ -209,7 +209,7 @@ typedef enum {
   RDC_FI_GPU_MEMORY_ACTIVITY,       //!< Memory busy percentage
   RDC_FI_GPU_MEMORY_MAX_BANDWIDTH,  //<! The Memory max bandwidth at current memory clock in
                                     // Mb/Second
-  RDC_FI_GPU_MEMORY_CUR_BANDWIDTH,  //<! The Memory current bandwidth in Mb/Second
+  RDC_FI_GPU_MEMORY_CUR_BANDWIDTH,  //<! The Memory current bandwidth in GB/Second
   RDC_FI_GPU_BUSY_PERCENT,          //<! The GPU busy percentage
 
   /**

--- a/projects/rdc/include/rdc/rdc.h
+++ b/projects/rdc/include/rdc/rdc.h
@@ -208,8 +208,8 @@ typedef enum {
   RDC_FI_GPU_MM_DEC_UTIL,           //!< Multimedia decoder busy percentage
   RDC_FI_GPU_MEMORY_ACTIVITY,       //!< Memory busy percentage
   RDC_FI_GPU_MEMORY_MAX_BANDWIDTH,  //<! The Memory max bandwidth at current memory clock in
-                                    // Mb/Second
-  RDC_FI_GPU_MEMORY_CUR_BANDWIDTH,  //<! The Memory current bandwidth in GB/Second
+                                    // Gb/Second
+  RDC_FI_GPU_MEMORY_CUR_BANDWIDTH,  //<! The Memory current bandwidth in Gb/Second
   RDC_FI_GPU_BUSY_PERCENT,          //<! The GPU busy percentage
 
   /**


### PR DESCRIPTION
update units in the comment for RDC field "RDC_FI_GPU_MEMORY_CUR_BANDWIDTH" from Mb/s to Gb/s