### PR TITLE
Fix missing RCCL submodule configurations in root `.gitmodules`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -85,3 +85,9 @@
 [submodule "projects/rocprofiler-systems/external/googletest"]
 	path = projects/rocprofiler-systems/external/googletest
 	url = https://github.com/google/googletest.git
+[submodule "projects/rccl/ext-src/mscclpp"]
+	path = projects/rccl/ext-src/mscclpp
+	url = https://github.com/microsoft/mscclpp.git
+[submodule "projects/rccl/ext-src/json"]
+	path = projects/rccl/ext-src/json
+	url = https://github.com/nlohmann/json.git


### PR DESCRIPTION
Add mscclpp and json submodule entries to root .gitmodules to fix Azure CI build failures when initializing submodules from repository root.

Fixes error:
'fatal: No url found for submodule path projects/rccl/ext-src/json in .gitmodules'

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
