### PR TITLE
[rocprofiler-sdk] CI Fix

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/common/logging.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/logging.cpp
@@ -25,6 +25,7 @@
 #include "lib/common/filesystem.hpp"
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <glog/logging.h>
 #include <glog/vlog_is_on.h>
 


### PR DESCRIPTION
## Motivation
Add fmt ranges header to fix `error: ‘join’ is not a member of ‘fmt’`
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Adds `#include <fmt/ranges.h>` to the logging file 

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
