### PR TITLE
SWDEV-566268 - skip 2 failing tests on rock Windows

### DIFF
--- a/projects/hip-tests/catch/hipTestMain/config/config_amd_windows
+++ b/projects/hip-tests/catch/hipTestMain/config/config_amd_windows
@@ -748,6 +748,8 @@
         "Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_MultiKernelSameDevice",
         "Unit_hipExtModuleLaunchKernel_Positive_Parameters",
         "Unit_hip_linker_spirv_input",
+        "Unit_hipMultiThreadStreams1_AsyncAsync",
+        "Unit_hipMultiThreadStreams1_AsyncSame",
         "========mlsejenkins_Window_Failures_on_gfx1201===========================================",
         "Unit_hipMemPoolSetAttribute_EventDependencies",
         "Unit_hipStreamSynchronize_NullStreamSynchronization",


### PR DESCRIPTION
## Motivation
skip 2 failing tests on rock, so RockPR to enable hip-tests can be merged

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
skip 2 failing tests on rock, so RockPR to enable hip-tests can be merged

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
SWDEV-566268

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
All tests passed on rock hip-tests execution

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
NA

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
