### PR TITLE
rocr: Fix exception on AsyncEventControl init (#1852)

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -2326,7 +2326,7 @@ Runtime::AsyncEventsControl::AsyncEventsControl(AsyncEventsInfo *asyncInfo)
   if (err != HSA_STATUS_SUCCESS)
     throw AMD::hsa_exception(HSA_STATUS_ERROR, "Failed to allocate async handler signal");
 
-  thread_ = os::CreateThread(AsyncEventsLoop, asyncInfo, 0, priority);
+  asyncInfo->control.thread_ = os::CreateThread(AsyncEventsLoop, asyncInfo, 0, priority);
   if (!asyncInfo->control.thread_)
     throw AMD::hsa_exception(HSA_STATUS_ERROR, "Failed to initialize async handler thread");
 
@@ -2389,7 +2389,7 @@ hsa_status_t Runtime::Load() {
   }
 
   asyncSignals_.reset(new AsyncEventsInfo(false));
-  asyncExceptions_.reset(new AsyncEventsInfo(true));
+  asyncExceptions_.reset(new AsyncEventsInfo(g_use_interrupt_wait));
 
   // Setup system clock frequency for the first time.
   if (sys_clock_freq_ == 0) {


### PR DESCRIPTION
* rocr: Fix exception on AsyncEventControl init

Fix exception on init when compiling with in release mode.

* rocr: Fix crash when interrupts are disabled

Fix segfault due to assert for signal->EopEvent() being false when HSA_ENABLE_INTERRUPT=0. Use Signal::WaitMultiple(..) when interrupt is disabled.