### PR TITLE
SWDEV-570501 - hipGraphicsGLRegisterBuffer

### DIFF
--- a/projects/clr/hipamd/src/hip_stream.cpp
+++ b/projects/clr/hipamd/src/hip_stream.cpp
@@ -74,10 +74,9 @@ bool Stream::Create() { return create(); }
 // ================================================================================================
 void Stream::Destroy(hip::Stream* stream, bool forceDestroy) {
   stream->device().removeFromActiveQueues(stream);
-  stream->device_->RemoveStream(stream);
+  stream->GetDevice()->RemoveStream(stream);
   stream->SetForceDestroy(forceDestroy);
   stream->release();
-  stream = nullptr;
 }
 
 // ================================================================================================

--- a/projects/clr/rocclr/device/rocm/rocglinterop.hpp
+++ b/projects/clr/rocclr/device/rocm/rocglinterop.hpp
@@ -136,5 +136,7 @@ bool Export(mesa_glinterop_export_in& in, mesa_glinterop_export_out& out, MESA_I
 
 bool glAssociate(Device* device, uint flags, void* GLplatformContext, void* GLdeviceContext);
 bool glDissociate(Device* device, void* GLplatformContext, void* GLdeviceContext);
+bool glExport(amd::Memory* mem, GLenum targetType, int miplevel, hsa_handle_t* handle, int* offset);
+
 } // namespace GlInterop
 }  // namespace amd::roc

--- a/projects/clr/rocclr/device/rocm/rocglinterop.hpp
+++ b/projects/clr/rocclr/device/rocm/rocglinterop.hpp
@@ -136,7 +136,7 @@ bool Export(mesa_glinterop_export_in& in, mesa_glinterop_export_out& out, MESA_I
 
 bool glAssociate(Device* device, uint flags, void* GLplatformContext, void* GLdeviceContext);
 bool glDissociate(Device* device, void* GLplatformContext, void* GLdeviceContext);
-bool glExport(amd::Memory* mem, GLenum targetType, int miplevel, hsa_handle_t* handle, int* offset);
+bool Export(amd::Memory* mem, GLenum targetType, int miplevel, hsa_handle_t* handle, int* offset);
 
 } // namespace GlInterop
 }  // namespace amd::roc

--- a/projects/clr/rocclr/device/rocm/rocglinterop_windows.cpp
+++ b/projects/clr/rocclr/device/rocm/rocglinterop_windows.cpp
@@ -23,6 +23,7 @@
 #include "utils/flags.hpp"
 #include "device/rocm/rocglinterop.hpp"
 #include "GL/gl_interop.h"
+#include "platform/interop_gl.hpp"
 
 namespace amd::roc {
 namespace GlInterop {
@@ -157,8 +158,7 @@ bool glDissociate(Device* device, void* GLplatformContext, void* GLdeviceContext
 }
 
 // ================================================================================================
-bool glExport(amd::Memory* mem, GLenum targetType, int miplevel, hsa_handle_t* handle,
-              int* offset) {
+bool Export(amd::Memory* mem, GLenum targetType, int miplevel, hsa_handle_t* handle, int* offset) {
   const auto* obj = mem->getInteropObj()->asGLObject();
   const auto GLContext = mem->getContext().info().hCtx_;
   const auto name = static_cast<uint>(obj->getGLName());
@@ -170,7 +170,7 @@ bool glExport(amd::Memory* mem, GLenum targetType, int miplevel, hsa_handle_t* h
   const GLResource hRes = {.type = type, .name = name};
   GLResourceData hData = {.version = GL_RESOURCE_DATA_VERSION};
 
-  if (!wglResourceAttachAMD(hRC, &hRes, &hData)) return false;
+  if (!wglResourceAttachAMD(hRC, const_cast<GLvoid*>(static_cast<const GLvoid*>(&hRes)), &hData)) return false;
 
   *handle = reinterpret_cast<hsa_handle_t>(hData.handle);
   *offset = static_cast<size_t>(hData.offset);

--- a/projects/clr/rocclr/device/rocm/rocglinterop_windows.cpp
+++ b/projects/clr/rocclr/device/rocm/rocglinterop_windows.cpp
@@ -159,6 +159,9 @@ bool glDissociate(Device* device, void* GLplatformContext, void* GLdeviceContext
 
 // ================================================================================================
 bool Export(amd::Memory* mem, GLenum targetType, int miplevel, hsa_handle_t* handle, int* offset) {
+  assert(mem->getInteropObj() != nullptr);
+  assert(mem->getInteropObj()->asGLObject() != nullptr);
+
   const auto* obj = mem->getInteropObj()->asGLObject();
   const auto GLContext = mem->getContext().info().hCtx_;
   const auto name = static_cast<uint>(obj->getGLName());
@@ -166,14 +169,14 @@ bool Export(amd::Memory* mem, GLenum targetType, int miplevel, hsa_handle_t* han
   assert(targetType == GL_ARRAY_BUFFER && "Only GL_ARRAY_BUFFER is supported");
   constexpr GLenum type = GL_RESOURCE_ATTACH_VERTEXBUFFER_AMD;
 
-  const auto hRC = reinterpret_cast<HGLRC>(GLContext);
-  GLResource hRes = {.type = type, .name = name};
-  GLResourceData hData = {.version = GL_RESOURCE_DATA_VERSION};
+  const auto glRenderContext = reinterpret_cast<HGLRC>(GLContext);
+  GLResource glResource = {.type = type, .name = name};
+  GLResourceData glResourceData = {.version = GL_RESOURCE_DATA_VERSION};
 
-  if (!wglResourceAttachAMD(hRC, static_cast<GLvoid*>(&hRes), &hData)) return false;
-
-  *handle = reinterpret_cast<hsa_handle_t>(hData.handle);
-  *offset = static_cast<int>(hData.offset);
+  if (!wglResourceAttachAMD(glRenderContext, static_cast<GLvoid*>(&glResource), &glResourceData))
+    return false;
+  *handle = reinterpret_cast<hsa_handle_t>(glResourceData.handle);
+  *offset = static_cast<int>(glResourceData.offset);
 
   return true;
 }

--- a/projects/clr/rocclr/device/rocm/rocglinterop_windows.cpp
+++ b/projects/clr/rocclr/device/rocm/rocglinterop_windows.cpp
@@ -167,10 +167,10 @@ bool Export(amd::Memory* mem, GLenum targetType, int miplevel, hsa_handle_t* han
   constexpr GLenum type = GL_RESOURCE_ATTACH_VERTEXBUFFER_AMD;
 
   const auto hRC = reinterpret_cast<HGLRC>(GLContext);
-  const GLResource hRes = {.type = type, .name = name};
+  GLResource hRes = {.type = type, .name = name};
   GLResourceData hData = {.version = GL_RESOURCE_DATA_VERSION};
 
-  if (!wglResourceAttachAMD(hRC, const_cast<GLvoid*>(static_cast<const GLvoid*>(&hRes)), &hData)) return false;
+  if (!wglResourceAttachAMD(hRC, static_cast<GLvoid*>(&hRes), &hData)) return false;
 
   *handle = reinterpret_cast<hsa_handle_t>(hData.handle);
   *offset = static_cast<int>(hData.offset);

--- a/projects/clr/rocclr/device/rocm/rocglinterop_windows.cpp
+++ b/projects/clr/rocclr/device/rocm/rocglinterop_windows.cpp
@@ -163,7 +163,7 @@ bool Export(amd::Memory* mem, GLenum targetType, int miplevel, hsa_handle_t* han
   const auto GLContext = mem->getContext().info().hCtx_;
   const auto name = static_cast<uint>(obj->getGLName());
 
-  static_assert(GL_ARRAY_BUFFER == GL_ARRAY_BUFFER, "Only GL_ARRAY_BUFFER is supported");
+  assert(targetType == GL_ARRAY_BUFFER && "Only GL_ARRAY_BUFFER is supported");
   constexpr GLenum type = GL_RESOURCE_ATTACH_VERTEXBUFFER_AMD;
 
   const auto hRC = reinterpret_cast<HGLRC>(GLContext);
@@ -173,7 +173,7 @@ bool Export(amd::Memory* mem, GLenum targetType, int miplevel, hsa_handle_t* han
   if (!wglResourceAttachAMD(hRC, const_cast<GLvoid*>(static_cast<const GLvoid*>(&hRes)), &hData)) return false;
 
   *handle = reinterpret_cast<hsa_handle_t>(hData.handle);
-  *offset = static_cast<size_t>(hData.offset);
+  *offset = static_cast<int>(hData.offset);
 
   return true;
 }

--- a/projects/clr/rocclr/device/rocm/rocglinterop_windows.cpp
+++ b/projects/clr/rocclr/device/rocm/rocglinterop_windows.cpp
@@ -156,5 +156,27 @@ bool glDissociate(Device* device, void* GLplatformContext, void* GLdeviceContext
   return wglEndCLInteropAMD(static_cast<HGLRC>(GLplatformContext), 0) != FALSE;
 }
 
+// ================================================================================================
+bool glExport(amd::Memory* mem, GLenum targetType, int miplevel, hsa_handle_t* handle,
+              int* offset) {
+  const auto* obj = mem->getInteropObj()->asGLObject();
+  const auto GLContext = mem->getContext().info().hCtx_;
+  const auto name = static_cast<uint>(obj->getGLName());
+
+  static_assert(GL_ARRAY_BUFFER == GL_ARRAY_BUFFER, "Only GL_ARRAY_BUFFER is supported");
+  constexpr GLenum type = GL_RESOURCE_ATTACH_VERTEXBUFFER_AMD;
+
+  const auto hRC = reinterpret_cast<HGLRC>(GLContext);
+  const GLResource hRes = {.type = type, .name = name};
+  GLResourceData hData = {.version = GL_RESOURCE_DATA_VERSION};
+
+  if (!wglResourceAttachAMD(hRC, &hRes, &hData)) return false;
+
+  *handle = reinterpret_cast<hsa_handle_t>(hData.handle);
+  *offset = static_cast<size_t>(hData.offset);
+
+  return true;
+}
+
 } // namespace GlInterop
 } // namespace amd::roc

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -231,9 +231,19 @@ hsa_status_t Memory::interopMapBuffer(amd::Os::FileDesc fdn) {
 // ================================================================================================
 bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
 #if IS_WINDOWS
-  return false;
+  hsa_handle_t handle;
+  int offset;
+
+  if (!GlInterop::glExport(owner(), targetType, miplevel, &handle, &offset)) return false;
+  if (interopMapBuffer(handle) != HSA_STATUS_SUCCESS) return false;
+
+  deviceMemory_ = static_cast<char*>(interop_deviceMemory_) + offset;
+  return true;
 #else
   assert(owner()->isInterop() && "Object is not an interop object.");
+
+  auto memFlags = owner()->getMemFlags();
+  hsa_agent_t agent = dev().getBackendDevice();
 
   mesa_glinterop_export_in in = {0};
   mesa_glinterop_export_out out = {0};
@@ -241,14 +251,13 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
   in.version = MESA_GLINTEROP_EXPORT_IN_VERSION;
   out.version = MESA_GLINTEROP_EXPORT_OUT_VERSION;
 
-  if (owner()->getMemFlags() & CL_MEM_READ_ONLY)
+  if (memFlags & CL_MEM_READ_ONLY)
     in.access = MESA_GLINTEROP_ACCESS_READ_ONLY;
-  else if (owner()->getMemFlags() & CL_MEM_WRITE_ONLY)
+  else if (memFlags & CL_MEM_WRITE_ONLY)
     in.access = MESA_GLINTEROP_ACCESS_WRITE_ONLY;
   else
     in.access = MESA_GLINTEROP_ACCESS_READ_WRITE;
 
-  hsa_agent_t agent = dev().getBackendDevice();
   uint32_t id;
   Hsa::agent_get_info(agent, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_CHIP_ID), &id);
 

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -208,10 +208,12 @@ hsa_status_t Memory::interopMapBuffer(hsa_handle_t fdn, hsa_handle_type_t handle
   size_t metadata_size = 0;
   void* metadata;
   auto fd = fdn;
-  hsa_resource_handle_t resourceHandle = {.type = handleType, .handle = fd};
-  hsa_status_t status =
-      Hsa::interop_map_buffer(1, &agent, resourceHandle, &size, &interop_deviceMemory_,
-                              &metadata_size, (const void**)&metadata);
+  uint32_t flags = 0;
+  if (handleType == HSA_HANDLE_TYPE_KMT) {
+    flags |= HSA_INTEROP_MAP_FLAG_KMT_HANDLE;
+  }
+  hsa_status_t status = Hsa::interop_map_buffer(1, &agent, fd, flags, &size, &interop_deviceMemory_,
+                                                &metadata_size, (const void**)&metadata);
   ClPrint(amd::LOG_DEBUG, amd::LOG_MEM, "Map Interop memory %p, size 0x%zx", interop_deviceMemory_,
           size);
   deviceMemory_ = static_cast<char*>(interop_deviceMemory_);  // + out.buf_offset;

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -244,22 +244,20 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
 #else
   assert(owner()->isInterop() && "Object is not an interop object.");
 
-  auto memFlags = owner()->getMemFlags();
-  hsa_agent_t agent = dev().getBackendDevice();
-
   mesa_glinterop_export_in in = {0};
   mesa_glinterop_export_out out = {0};
 
   in.version = MESA_GLINTEROP_EXPORT_IN_VERSION;
   out.version = MESA_GLINTEROP_EXPORT_OUT_VERSION;
 
-  if (memFlags & CL_MEM_READ_ONLY)
+  if (owner()->getMemFlags() & CL_MEM_READ_ONLY)
     in.access = MESA_GLINTEROP_ACCESS_READ_ONLY;
-  else if (memFlags & CL_MEM_WRITE_ONLY)
+  else if (owner()->getMemFlags() & CL_MEM_WRITE_ONLY)
     in.access = MESA_GLINTEROP_ACCESS_WRITE_ONLY;
   else
     in.access = MESA_GLINTEROP_ACCESS_READ_WRITE;
 
+  hsa_agent_t agent = dev().getBackendDevice();
   uint32_t id;
   Hsa::agent_get_info(agent, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_CHIP_ID), &id);
 
@@ -289,9 +287,9 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
       return false;
   }
 
-  hsa_status_t status = interopMapBuffer(out.dmabuf_fd, HSA_HANDLE_TYPE_FD);
+  if (interopMapBuffer(out.dmabuf_fd) != HSA_STATUS_SUCCESS) return false;
+
   close(out.dmabuf_fd);
-  if (status != HSA_STATUS_SUCCESS) return false;
   deviceMemory_ = static_cast<char*>(interop_deviceMemory_) + out.buf_offset;
 
   return true;

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -202,16 +202,12 @@ void Memory::cpuUnmap(device::VirtualDevice& vDev) {
 }
 
 // ================================================================================================
-hsa_status_t Memory::interopMapBuffer(hsa_handle_t fdn, hsa_handle_type_t handleType) {
+hsa_status_t Memory::interopMapBuffer(hsa_handle_t fdn, hsa_interop_map_flag_t flags) {
   hsa_agent_t agent = dev().getBackendDevice();
   size_t size;
   size_t metadata_size = 0;
   void* metadata;
   auto fd = fdn;
-  uint32_t flags = 0;
-  if (handleType == HSA_HANDLE_TYPE_KMT) {
-    flags |= HSA_INTEROP_MAP_FLAG_KMT_HANDLE;
-  }
   hsa_status_t status = Hsa::interop_map_buffer(1, &agent, fd, flags, &size, &interop_deviceMemory_,
                                                 &metadata_size, (const void**)&metadata);
   ClPrint(amd::LOG_DEBUG, amd::LOG_MEM, "Map Interop memory %p, size 0x%zx", interop_deviceMemory_,
@@ -239,7 +235,7 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
   int offset;
 
   if (!GlInterop::Export(owner(), targetType, miplevel, &handle, &offset)) return false;
-  if (interopMapBuffer(handle, HSA_HANDLE_TYPE_KMT) != HSA_STATUS_SUCCESS) return false;
+  if (interopMapBuffer(handle, HSA_INTEROP_MAP_FLAG_KMT_HANDLE) != HSA_STATUS_SUCCESS) return false;
 
   deviceMemory_ = static_cast<char*>(interop_deviceMemory_) + offset;
   return true;
@@ -289,7 +285,7 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
       return false;
   }
 
-  if (interopMapBuffer(out.dmabuf_fd, HSA_HANDLE_TYPE_FD) != HSA_STATUS_SUCCESS) return false;
+  if (interopMapBuffer(out.dmabuf_fd) != HSA_STATUS_SUCCESS) return false;
 
   close(out.dmabuf_fd);
   deviceMemory_ = static_cast<char*>(interop_deviceMemory_) + out.buf_offset;
@@ -906,7 +902,7 @@ bool Buffer::create(bool alloc_local) {
     auto ext_memory = interop->asExternalMemory();
     amd::GLObject* glObject = interop->asGLObject();
     if (ext_memory != nullptr) {
-      return interopMapBuffer(ext_memory->Handle(), HSA_HANDLE_TYPE_NT) == HSA_STATUS_SUCCESS;
+      return interopMapBuffer(ext_memory->Handle()) == HSA_STATUS_SUCCESS;
     } else if (glObject != nullptr) {
       return createInteropBuffer(GL_ARRAY_BUFFER, 0);
     }

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -287,7 +287,7 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
       return false;
   }
 
-  if (interopMapBuffer(out.dmabuf_fd) != HSA_STATUS_SUCCESS) return false;
+  if (interopMapBuffer(out.dmabuf_fd, HSA_HANDLE_TYPE_FD) != HSA_STATUS_SUCCESS) return false;
 
   close(out.dmabuf_fd);
   deviceMemory_ = static_cast<char*>(interop_deviceMemory_) + out.buf_offset;

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -202,14 +202,16 @@ void Memory::cpuUnmap(device::VirtualDevice& vDev) {
 }
 
 // ================================================================================================
-hsa_status_t Memory::interopMapBuffer(amd::Os::FileDesc fdn) {
+hsa_status_t Memory::interopMapBuffer(hsa_handle_t fdn, hsa_handle_type_t handleType) {
   hsa_agent_t agent = dev().getBackendDevice();
   size_t size;
   size_t metadata_size = 0;
   void* metadata;
   auto fd = fdn;
-  hsa_status_t status = Hsa::interop_map_buffer(1, &agent, fd, 0, &size, &interop_deviceMemory_,
-                                                &metadata_size, (const void**)&metadata);
+  hsa_resource_handle_t resourceHandle = {.type = handleType, .handle = fd};
+  hsa_status_t status =
+      Hsa::interop_map_buffer(1, &agent, resourceHandle, &size, &interop_deviceMemory_,
+                              &metadata_size, (const void**)&metadata);
   ClPrint(amd::LOG_DEBUG, amd::LOG_MEM, "Map Interop memory %p, size 0x%zx", interop_deviceMemory_,
           size);
   deviceMemory_ = static_cast<char*>(interop_deviceMemory_);  // + out.buf_offset;
@@ -234,8 +236,8 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
   hsa_handle_t handle;
   int offset;
 
-  if (!GlInterop::glExport(owner(), targetType, miplevel, &handle, &offset)) return false;
-  if (interopMapBuffer(handle) != HSA_STATUS_SUCCESS) return false;
+  if (!GlInterop::Export(owner(), targetType, miplevel, &handle, &offset)) return false;
+  if (interopMapBuffer(handle, HSA_HANDLE_TYPE_KMT) != HSA_STATUS_SUCCESS) return false;
 
   deviceMemory_ = static_cast<char*>(interop_deviceMemory_) + offset;
   return true;
@@ -287,9 +289,9 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
       return false;
   }
 
-  if (interopMapBuffer(out.dmabuf_fd) != HSA_STATUS_SUCCESS) return false;
-
+  hsa_status_t status = interopMapBuffer(out.dmabuf_fd, HSA_HANDLE_TYPE_FD);
   close(out.dmabuf_fd);
+  if (status != HSA_STATUS_SUCCESS) return false;
   deviceMemory_ = static_cast<char*>(interop_deviceMemory_) + out.buf_offset;
 
   return true;
@@ -904,9 +906,7 @@ bool Buffer::create(bool alloc_local) {
     auto ext_memory = interop->asExternalMemory();
     amd::GLObject* glObject = interop->asGLObject();
     if (ext_memory != nullptr) {
-      hsa_status_t status = interopMapBuffer(ext_memory->Handle());
-      if (status != HSA_STATUS_SUCCESS) return false;
-      return true;
+      return interopMapBuffer(ext_memory->Handle(), HSA_HANDLE_TYPE_NT) == HSA_STATUS_SUCCESS;
     } else if (glObject != nullptr) {
       return createInteropBuffer(GL_ARRAY_BUFFER, 0);
     }

--- a/projects/clr/rocclr/device/rocm/rocmemory.hpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.hpp
@@ -126,7 +126,9 @@ class Memory : public device::Memory {
 
   // Free / deregister device memory.
   virtual void destroy() = 0;
-  hsa_status_t interopMapBuffer(amd::Os::FileDesc fdn);
+
+  // Map interop buffer
+  hsa_status_t interopMapBuffer(hsa_handle_t fdn, hsa_handle_type_t handleType);
 
   // Place interop object into HSA's flat address space
   bool createInteropBuffer(GLenum targetType, int miplevel);

--- a/projects/clr/rocclr/device/rocm/rocmemory.hpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.hpp
@@ -128,7 +128,8 @@ class Memory : public device::Memory {
   virtual void destroy() = 0;
 
   // Map interop buffer
-  hsa_status_t interopMapBuffer(hsa_handle_t fdn, hsa_handle_type_t handleType);
+  hsa_status_t interopMapBuffer(hsa_handle_t fdn,
+                                hsa_interop_map_flag_t flags = HSA_INTEROP_MAP_FLAG_NONE);
 
   // Place interop object into HSA's flat address space
   bool createInteropBuffer(GLenum targetType, int miplevel);

--- a/projects/clr/rocclr/device/rocm/rocrctx.hpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.hpp
@@ -386,9 +386,10 @@ class Hsa : public amd::AllStatic {
     return ROCR_DYN(hsa_amd_memory_unlock)(host_ptr);
   }
   static hsa_status_t interop_map_buffer(uint32_t num_agents, hsa_agent_t* agents,
-                                         hsa_resource_handle_t interop_handle, size_t* size,
-                                         void** ptr, size_t* metadata_size, const void** metadata) {
-    return ROCR_DYN(hsa_amd_interop_map_buffer)(num_agents, agents, interop_handle, size, ptr,
+                                         hsa_handle_t interop_handle, uint32_t flags,
+                                         size_t* size, void** ptr, size_t* metadata_size,
+                                         const void** metadata) {
+    return ROCR_DYN(hsa_amd_interop_map_buffer)(num_agents, agents, interop_handle, flags, size, ptr,
                                                 metadata_size, metadata);
   }
   static hsa_status_t interop_unmap_buffer(void* ptr) {

--- a/projects/clr/rocclr/device/rocm/rocrctx.hpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.hpp
@@ -386,11 +386,10 @@ class Hsa : public amd::AllStatic {
     return ROCR_DYN(hsa_amd_memory_unlock)(host_ptr);
   }
   static hsa_status_t interop_map_buffer(uint32_t num_agents, hsa_agent_t* agents,
-    amd::Os::FileDesc interop_handle,
-    uint32_t flags, size_t* size,
-    void** ptr, size_t* metadata_size, const void** metadata) {
-    return ROCR_DYN(hsa_amd_interop_map_buffer)(num_agents, agents, interop_handle, flags, size,
-                                                ptr, metadata_size, metadata);
+                                         hsa_resource_handle_t interop_handle, size_t* size,
+                                         void** ptr, size_t* metadata_size, const void** metadata) {
+    return ROCR_DYN(hsa_amd_interop_map_buffer)(num_agents, agents, interop_handle, size, ptr,
+                                                metadata_size, metadata);
   }
   static hsa_status_t interop_unmap_buffer(void* ptr) {
     return ROCR_DYN(hsa_amd_interop_unmap_buffer)(ptr);

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
@@ -1513,6 +1513,7 @@ typedef union
     struct
     {
         unsigned int requiresVAddr : 1;  // Requires virtual address
+        unsigned int kmtHandle     : 1;  // Handle is a KMT handle
     } ui32;
 } HSA_REGISTER_MEM_FLAGS;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
@@ -1092,17 +1092,12 @@ hsa_status_t HSA_API
 }
 
 // Mirrors Amd Extension Apis
-hsa_status_t HSA_API hsa_amd_interop_map_buffer(uint32_t num_agents,
-                                        hsa_agent_t* agents,
-                                        hsa_handle_t interop_handle,
-                                        uint32_t flags,
-                                        size_t* size,
-                                        void** ptr,
-                                        size_t* metadata_size,
-                                        const void** metadata) {
-  return amdExtTable->hsa_amd_interop_map_buffer_fn(
-                                     num_agents, agents, interop_handle,
-                                     flags, size, ptr, metadata_size, metadata);
+hsa_status_t HSA_API hsa_amd_interop_map_buffer(uint32_t num_agents, hsa_agent_t* agents,
+                                                hsa_resource_handle_t interop_handle, size_t* size,
+                                                void** ptr, size_t* metadata_size,
+                                                const void** metadata) {
+  return amdExtTable->hsa_amd_interop_map_buffer_fn(num_agents, agents, interop_handle, size, ptr,
+                                                    metadata_size, metadata);
 }
 
 // Mirrors Amd Extension Apis

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
@@ -1093,11 +1093,11 @@ hsa_status_t HSA_API
 
 // Mirrors Amd Extension Apis
 hsa_status_t HSA_API hsa_amd_interop_map_buffer(uint32_t num_agents, hsa_agent_t* agents,
-                                                hsa_resource_handle_t interop_handle, size_t* size,
-                                                void** ptr, size_t* metadata_size,
+                                                hsa_handle_t interop_handle, uint32_t flags,
+                                                size_t* size, void** ptr, size_t* metadata_size,
                                                 const void** metadata) {
-  return amdExtTable->hsa_amd_interop_map_buffer_fn(num_agents, agents, interop_handle, size, ptr,
-                                                    metadata_size, metadata);
+  return amdExtTable->hsa_amd_interop_map_buffer_fn(num_agents, agents, interop_handle, flags, size,
+                                                    ptr, metadata_size, metadata);
 }
 
 // Mirrors Amd Extension Apis

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
@@ -219,8 +219,7 @@ hsa_status_t
 // Mirrors Amd Extension Apis
 hsa_status_t hsa_amd_interop_map_buffer(uint32_t num_agents,
                                         hsa_agent_t* agents,
-                                        hsa_handle_t interop_handle,
-                                        uint32_t flags,
+                                        hsa_resource_handle_t interop_handle,
                                         size_t* size,
                                         void** ptr,
                                         size_t* metadata_size,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
@@ -219,7 +219,8 @@ hsa_status_t
 // Mirrors Amd Extension Apis
 hsa_status_t hsa_amd_interop_map_buffer(uint32_t num_agents,
                                         hsa_agent_t* agents,
-                                        hsa_resource_handle_t interop_handle,
+                                        hsa_handle_t interop_handle,
+                                        uint32_t flags,
                                         size_t* size,
                                         void** ptr,
                                         size_t* metadata_size,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -346,11 +346,8 @@ class Runtime {
                                      hsa_signal_value_t value,
                                      hsa_amd_signal_handler handler, void* arg);
 
-  hsa_status_t InteropMap(uint32_t num_agents, Agent** agents,
-                          hsa_handle_t interop_handle,
-                          uint32_t flags, size_t* size,
-                          void** ptr, size_t* metadata_size,
-                          const void** metadata);
+  hsa_status_t InteropMap(uint32_t num_agents, Agent** agents, hsa_resource_handle_t interop_handle,
+                          size_t* size, void** ptr, size_t* metadata_size, const void** metadata);
 
   hsa_status_t InteropUnmap(void* ptr);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -346,8 +346,9 @@ class Runtime {
                                      hsa_signal_value_t value,
                                      hsa_amd_signal_handler handler, void* arg);
 
-  hsa_status_t InteropMap(uint32_t num_agents, Agent** agents, hsa_resource_handle_t interop_handle,
-                          size_t* size, void** ptr, size_t* metadata_size, const void** metadata);
+  hsa_status_t InteropMap(uint32_t num_agents, Agent** agents, hsa_handle_t handle,
+                          hsa_handle_type_t handle_type, size_t* size, void** ptr,
+                          size_t* metadata_size, const void** metadata);
 
   hsa_status_t InteropUnmap(void* ptr);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -347,7 +347,7 @@ class Runtime {
                                      hsa_amd_signal_handler handler, void* arg);
 
   hsa_status_t InteropMap(uint32_t num_agents, Agent** agents, hsa_handle_t handle,
-                          hsa_handle_type_t handle_type, size_t* size, void** ptr,
+                          hsa_interop_map_flag_t flags, size_t* size, void** ptr,
                           size_t* metadata_size, const void** metadata);
 
   hsa_status_t InteropUnmap(void* ptr);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -995,15 +995,6 @@ hsa_status_t hsa_amd_agent_memory_pool_get_info(
 hsa_status_t hsa_amd_interop_map_buffer(uint32_t num_agents, hsa_agent_t* agents,
                                         hsa_handle_t interop_handle, uint32_t flags, size_t* size,
                                         void** ptr, size_t* metadata_size, const void** metadata) {
-#if defined(__linux__)
-  hsa_handle_type_t handle_type = HSA_HANDLE_TYPE_FD;
-#else
-  hsa_handle_type_t handle_type = HSA_HANDLE_TYPE_NT;
-#endif
-
-  if (flags & HSA_INTEROP_MAP_FLAG_KMT_HANDLE)
-    handle_type = HSA_HANDLE_TYPE_KMT;
-
   static const int tinyArraySize = 8;
   TRY;
   IS_OPEN();
@@ -1029,8 +1020,9 @@ hsa_status_t hsa_amd_interop_map_buffer(uint32_t num_agents, hsa_agent_t* agents
     core_agents[i] = device;
   }
 
-  auto ret = core::Runtime::runtime_singleton_->InteropMap(num_agents, core_agents, interop_handle,
-                                                           handle_type, size, ptr, metadata_size, metadata);
+  auto ret = core::Runtime::runtime_singleton_->InteropMap(
+      num_agents, core_agents, interop_handle, static_cast<hsa_interop_map_flag_t>(flags), size,
+      ptr, metadata_size, metadata);
 
   return ret;
   CATCH;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -992,19 +992,15 @@ hsa_status_t hsa_amd_agent_memory_pool_get_info(
   CATCH;
 }
 
-hsa_status_t hsa_amd_interop_map_buffer(uint32_t num_agents,
-                                        hsa_agent_t* agents,
-                                        hsa_handle_t interop_handle,
-                                        uint32_t flags, size_t* size,
-                                        void** ptr, size_t* metadata_size,
-                                        const void** metadata) {
-  static const int tinyArraySize=8;
+hsa_status_t hsa_amd_interop_map_buffer(uint32_t num_agents, hsa_agent_t* agents,
+                                        hsa_resource_handle_t interop_handle, size_t* size,
+                                        void** ptr, size_t* metadata_size, const void** metadata) {
+  static const int tinyArraySize = 8;
   TRY;
   IS_OPEN();
   IS_BAD_PTR(agents);
   IS_BAD_PTR(size);
   IS_BAD_PTR(ptr);
-  if (flags != 0) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   if (num_agents == 0) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
   core::Agent* short_agents[tinyArraySize];
@@ -1024,9 +1020,8 @@ hsa_status_t hsa_amd_interop_map_buffer(uint32_t num_agents,
     core_agents[i] = device;
   }
 
-  auto ret = core::Runtime::runtime_singleton_->InteropMap(
-      num_agents, core_agents, interop_handle, flags, size, ptr, metadata_size,
-      metadata);
+  auto ret = core::Runtime::runtime_singleton_->InteropMap(num_agents, core_agents, interop_handle,
+                                                           size, ptr, metadata_size, metadata);
 
   return ret;
   CATCH;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -993,8 +993,17 @@ hsa_status_t hsa_amd_agent_memory_pool_get_info(
 }
 
 hsa_status_t hsa_amd_interop_map_buffer(uint32_t num_agents, hsa_agent_t* agents,
-                                        hsa_resource_handle_t interop_handle, size_t* size,
+                                        hsa_handle_t interop_handle, uint32_t flags, size_t* size,
                                         void** ptr, size_t* metadata_size, const void** metadata) {
+#if defined(__linux__)
+  hsa_handle_type_t handle_type = HSA_HANDLE_TYPE_FD;
+#else
+  hsa_handle_type_t handle_type = HSA_HANDLE_TYPE_NT;
+#endif
+
+  if (flags & HSA_INTEROP_MAP_FLAG_KMT_HANDLE)
+    handle_type = HSA_HANDLE_TYPE_KMT;
+
   static const int tinyArraySize = 8;
   TRY;
   IS_OPEN();
@@ -1021,7 +1030,7 @@ hsa_status_t hsa_amd_interop_map_buffer(uint32_t num_agents, hsa_agent_t* agents
   }
 
   auto ret = core::Runtime::runtime_singleton_->InteropMap(num_agents, core_agents, interop_handle,
-                                                           size, ptr, metadata_size, metadata);
+                                                           handle_type, size, ptr, metadata_size, metadata);
 
   return ret;
   CATCH;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -901,7 +901,7 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents,
   }
 
   const HSA_REGISTER_MEM_FLAGS regFlags = {
-      .ui32 = {.kmtHandle = (interop_handle.type == HSA_HANDLE_TYPE_KMT) ? 1u : 0u}};
+      .ui32 = {.kmtHandle = (interop_handle.type == HSA_HANDLE_TYPE_KMT)}};
 
   auto status =
       hsaKmtRegisterGraphicsHandleToNodesExt(resource_handle, &info, num_agents, nodes, regFlags);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -899,11 +899,11 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents, hsa_handle
     agents[i]->GetInfo(static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_DRIVER_NODE_ID), &nodes[i]);
   }
 
-  const HSA_REGISTER_MEM_FLAGS regFlags = {
+  const HSA_REGISTER_MEM_FLAGS reg_flags = {
       .ui32 = {.kmtHandle = (handle_type == HSA_HANDLE_TYPE_KMT)}};
 
   auto status =
-      hsaKmtRegisterGraphicsHandleToNodesExt(resource_handle, &info, num_agents, nodes, regFlags);
+      hsaKmtRegisterGraphicsHandleToNodesExt(resource_handle, &info, num_agents, nodes, reg_flags);
   if (status != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
 
   assert(num_agents > 0);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -867,8 +867,8 @@ hsa_status_t Runtime::SetAsyncSignalHandler(hsa_signal_t signal,
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents,
-                                 hsa_resource_handle_t interop_handle, size_t* size, void** ptr,
+hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents, hsa_handle_t handle,
+                                 hsa_handle_type_t handle_type, size_t* size, void** ptr,
                                  size_t* metadata_size, const void** metadata) {
   constexpr int tinyArraySize = 8;
   HsaGraphicsResourceInfo info;
@@ -876,13 +876,12 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents,
   HSAuint32 short_nodes[tinyArraySize];
   HSAuint32* nodes = short_nodes;
 
-  static_assert(sizeof(HSAint64) >= sizeof(interop_handle.handle),
-                "HSAint64 too small for interop_handle");
+  static_assert(sizeof(HSAint64) >= sizeof(handle), "HSAint64 too small for interop_handle");
   HSAint64 resource_handle =
 #ifdef _WIN32
-      static_cast<HSAint64>(reinterpret_cast<uintptr_t>(interop_handle.handle));
+      static_cast<HSAint64>(reinterpret_cast<uintptr_t>(handle));
 #else
-      static_cast<HSAint64>(interop_handle.handle);
+      static_cast<HSAint64>(handle);
 #endif
 
   if (num_agents > tinyArraySize) {
@@ -901,7 +900,7 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents,
   }
 
   const HSA_REGISTER_MEM_FLAGS regFlags = {
-      .ui32 = {.kmtHandle = (interop_handle.type == HSA_HANDLE_TYPE_KMT)}};
+      .ui32 = {.kmtHandle = (handle_type == HSA_HANDLE_TYPE_KMT)}};
 
   auto status =
       hsaKmtRegisterGraphicsHandleToNodesExt(resource_handle, &info, num_agents, nodes, regFlags);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -868,23 +868,21 @@ hsa_status_t Runtime::SetAsyncSignalHandler(hsa_signal_t signal,
 }
 
 hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents,
-                                 hsa_handle_t interop_handle,
-                                 uint32_t flags,
-                                 size_t* size, void** ptr,
+                                 hsa_resource_handle_t interop_handle, size_t* size, void** ptr,
                                  size_t* metadata_size, const void** metadata) {
-  static const int tinyArraySize=8;
+  constexpr int tinyArraySize = 8;
   HsaGraphicsResourceInfo info;
 
   HSAuint32 short_nodes[tinyArraySize];
   HSAuint32* nodes = short_nodes;
 
-  static_assert(sizeof(HSAint64) >= sizeof(interop_handle),
+  static_assert(sizeof(HSAint64) >= sizeof(interop_handle.handle),
                 "HSAint64 too small for interop_handle");
   HSAint64 resource_handle =
 #ifdef _WIN32
-      static_cast<HSAint64>(reinterpret_cast<uintptr_t>(interop_handle));
+      static_cast<HSAint64>(reinterpret_cast<uintptr_t>(interop_handle.handle));
 #else
-      static_cast<HSAint64>(interop_handle);
+      static_cast<HSAint64>(interop_handle.handle);
 #endif
 
   if (num_agents > tinyArraySize) {
@@ -902,9 +900,12 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents,
     agents[i]->GetInfo(static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_DRIVER_NODE_ID), &nodes[i]);
   }
 
-  if (HSAKMT_CALL(hsaKmtRegisterGraphicsHandleToNodes(resource_handle, &info, num_agents,
-                                          nodes)) != HSAKMT_STATUS_SUCCESS)
-    return HSA_STATUS_ERROR;
+  const HSA_REGISTER_MEM_FLAGS regFlags = {
+      .ui32 = {.kmtHandle = (interop_handle.type == HSA_HANDLE_TYPE_KMT) ? 1u : 0u}};
+
+  auto status =
+      hsaKmtRegisterGraphicsHandleToNodesExt(resource_handle, &info, num_agents, nodes, regFlags);
+  if (status != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
 
   assert(num_agents > 0);
   auto& driver = agents[0]->driver();

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -868,7 +868,7 @@ hsa_status_t Runtime::SetAsyncSignalHandler(hsa_signal_t signal,
 }
 
 hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents, hsa_handle_t handle,
-                                 hsa_handle_type_t handle_type, size_t* size, void** ptr,
+                                 hsa_interop_map_flag_t flags, size_t* size, void** ptr,
                                  size_t* metadata_size, const void** metadata) {
   constexpr int tinyArraySize = 8;
   HsaGraphicsResourceInfo info;
@@ -900,7 +900,7 @@ hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents, hsa_handle
   }
 
   const HSA_REGISTER_MEM_FLAGS reg_flags = {
-      .ui32 = {.kmtHandle = (handle_type == HSA_HANDLE_TYPE_KMT)}};
+      .ui32 = {.kmtHandle = ((flags & HSA_INTEROP_MAP_FLAG_KMT_HANDLE) != 0)}};
 
   auto status =
       hsaKmtRegisterGraphicsHandleToNodesExt(resource_handle, &info, num_agents, nodes, reg_flags);

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa.h
@@ -5692,6 +5692,25 @@ typedef int hsa_handle_t;
 #endif
 
 /**
+ * @brief Enumeration of handle types.
+ */
+typedef enum {
+  HSA_HANDLE_TYPE_NONE = 0,
+  HSA_HANDLE_TYPE_FD,
+  HSA_HANDLE_TYPE_NT,
+  HSA_HANDLE_TYPE_KMT,
+  HSA_HANDLE_TYPE_MAX
+} hsa_handle_type_t;
+
+/**
+ * @brief Container for a system dependent resource handle.
+ */
+typedef struct hsa_resource_handle_s {
+  hsa_handle_type_t type;  //!< Type of the handle
+  hsa_handle_t handle;     //!< Platform dependent handle
+} hsa_resource_handle_t;
+
+/**
  * @brief Platform-independent container for a Windows LUID.
  */
 typedef struct hsa_luid_s {

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa.h
@@ -5705,8 +5705,8 @@ typedef enum {
 /**
  * @brief Enumeration of interop map flags.
  */
-typedef enum hsa_interop_map_flag_e : uint32_t {
-    HSA_INTEROP_MAP_FLAG_KMT_HANDLE = (1u << 0),
+typedef enum : uint32_t {
+  HSA_INTEROP_MAP_FLAG_KMT_HANDLE = (1u << 0),
 } hsa_interop_map_flag_t;
 
 /**

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa.h
@@ -5692,12 +5692,12 @@ typedef int hsa_handle_t;
 #endif
 
 /**
- * @brief Enumeration of interop map flags.
+ * @brief Interop map flags.
  */
-typedef enum : uint32_t {
-  HSA_INTEROP_MAP_FLAG_NONE = 0,
-  HSA_INTEROP_MAP_FLAG_KMT_HANDLE = (1u << 0),
-} hsa_interop_map_flag_t;
+typedef uint32_t hsa_interop_map_flag_t;
+
+#define HSA_INTEROP_MAP_FLAG_NONE        0u
+#define HSA_INTEROP_MAP_FLAG_KMT_HANDLE  (1u << 0)
 
 /**
  * @brief Platform-independent container for a Windows LUID.

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa.h
@@ -5696,9 +5696,9 @@ typedef int hsa_handle_t;
  */
 typedef enum {
   HSA_HANDLE_TYPE_NONE = 0,
-  HSA_HANDLE_TYPE_FD,
-  HSA_HANDLE_TYPE_NT,
-  HSA_HANDLE_TYPE_KMT,
+  HSA_HANDLE_TYPE_FD,           //!< File descriptor handle
+  HSA_HANDLE_TYPE_NT,           //!< Windows NT handle
+  HSA_HANDLE_TYPE_KMT,          //!< Windows KMT handle
   HSA_HANDLE_TYPE_MAX
 } hsa_handle_type_t;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa.h
@@ -5703,12 +5703,11 @@ typedef enum {
 } hsa_handle_type_t;
 
 /**
- * @brief Container for a system dependent resource handle.
+ * @brief Enumeration of interop map flags.
  */
-typedef struct hsa_resource_handle_s {
-  hsa_handle_type_t type;  //!< Type of the handle
-  hsa_handle_t handle;     //!< Platform dependent handle
-} hsa_resource_handle_t;
+typedef enum hsa_interop_map_flag_e : uint32_t {
+    HSA_INTEROP_MAP_FLAG_KMT_HANDLE = (1u << 0),
+} hsa_interop_map_flag_t;
 
 /**
  * @brief Platform-independent container for a Windows LUID.

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa.h
@@ -5692,20 +5692,10 @@ typedef int hsa_handle_t;
 #endif
 
 /**
- * @brief Enumeration of handle types.
- */
-typedef enum {
-  HSA_HANDLE_TYPE_NONE = 0,
-  HSA_HANDLE_TYPE_FD,           //!< File descriptor handle
-  HSA_HANDLE_TYPE_NT,           //!< Windows NT handle
-  HSA_HANDLE_TYPE_KMT,          //!< Windows KMT handle
-  HSA_HANDLE_TYPE_MAX
-} hsa_handle_type_t;
-
-/**
  * @brief Enumeration of interop map flags.
  */
 typedef enum : uint32_t {
+  HSA_INTEROP_MAP_FLAG_NONE = 0,
   HSA_INTEROP_MAP_FLAG_KMT_HANDLE = (1u << 0),
 } hsa_interop_map_flag_t;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -2307,7 +2307,8 @@ hsa_status_t HSA_API
  *
  * @param[in] agents List of accessing agents.
  *
- * @param[in] interop_buffer handle (FD on Linux and HANDLE on Windows)
+ * @param[in] interop_handle interop buffer handle (FD on Linux and HANDLE on
+ * Windows)
  *
  * @param [in] flags Reserved, must be 0
  *

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -2307,7 +2307,7 @@ hsa_status_t HSA_API
  *
  * @param[in] agents List of accessing agents.
  *
- * @param[in] interop_handle Handle of interop buffer (dmabuf handle in Linux)
+ * @param[in] interop_buffer handle (FD on Linux and HANDLE on Windows)
  *
  * @param [in] flags Reserved, must be 0
  *
@@ -2329,8 +2329,8 @@ hsa_status_t HSA_API
  * @retval HSA_STATUS_ERROR_INVALID_ARGUMENT all other errors
  */
 hsa_status_t HSA_API hsa_amd_interop_map_buffer(uint32_t num_agents, hsa_agent_t* agents,
-                                                hsa_resource_handle_t interop_handle, size_t* size,
-                                                void** ptr, size_t* metadata_size,
+                                                hsa_handle_t interop_handle, uint32_t flags,
+                                                size_t* size, void** ptr, size_t* metadata_size,
                                                 const void** metadata);
 
 /**

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -2328,14 +2328,10 @@ hsa_status_t HSA_API
  *
  * @retval HSA_STATUS_ERROR_INVALID_ARGUMENT all other errors
  */
-hsa_status_t HSA_API hsa_amd_interop_map_buffer(uint32_t num_agents,
-                                        hsa_agent_t* agents,
-                                        hsa_handle_t interop_handle,
-                                        uint32_t flags,
-                                        size_t* size,
-                                        void** ptr,
-                                        size_t* metadata_size,
-                                        const void** metadata);
+hsa_status_t HSA_API hsa_amd_interop_map_buffer(uint32_t num_agents, hsa_agent_t* agents,
+                                                hsa_resource_handle_t interop_handle, size_t* size,
+                                                void** ptr, size_t* metadata_size,
+                                                const void** metadata);
 
 /**
  * @brief Removes a previously mapped interop object from HSA's flat address space.


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This patch adds GL buffer interop support on Windows by enabling hipGraphicsGLRegisterBuffer.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

WGL and KMT handle support have been implemented.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

SWDEV-570501

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

This patch covers the following hip-tests test cases:

- Unit_hipGraphicsGLRegisterBuffer_Positive_Basic
- Unit_hipGraphicsGLRegisterBuffer_Positive_Register_Twice
- Unit_hipGraphicsGLRegisterBuffer_Negative_Parameters

## Test Result

<!-- Briefly summarize test outcomes. -->

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
