### PR TITLE
SWDEV-572673 - Reduce cooperative groups tests combinatorial explosion

### DIFF
--- a/projects/hip-tests/catch/include/cpu_grid.h
+++ b/projects/hip-tests/catch/include/cpu_grid.h
@@ -108,8 +108,7 @@ struct CPUMultiGrid {
 inline dim3 GenerateThreadDimensions() {
   hipDeviceProp_t props;
   HIP_CHECK(hipGetDeviceProperties(&props, 0));
-  const auto multipliers = {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3,
-                            1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5};
+  const auto multipliers = {0.5, 1.0, 1.5, 2.0};
   return GENERATE_COPY(
       dim3(1, 1, 1), dim3(props.maxThreadsDim[0], 1, 1), dim3(1, props.maxThreadsDim[1], 1),
       dim3(1, 1, props.maxThreadsDim[2]),
@@ -130,7 +129,7 @@ inline dim3 GenerateThreadDimensions() {
 inline dim3 GenerateBlockDimensions() {
   hipDeviceProp_t props;
   HIP_CHECK(hipGetDeviceProperties(&props, 0));
-  const auto multipliers = {0.5, 0.9, 1.0, 1.1, 1.5, 1.9, 2.0, 3.0, 4.0};
+  const auto multipliers = {0.5, 1.0, 1.5, 2.0};
   return GENERATE_COPY(dim3(1, 1, 1),
                        map([sm = props.multiProcessorCount](
                                double i) { return dim3(static_cast<int>(i * sm), 1, 1); },
@@ -148,7 +147,7 @@ inline dim3 GenerateBlockDimensions() {
 inline dim3 GenerateThreadDimensionsForShuffle() {
   hipDeviceProp_t props;
   HIP_CHECK(hipGetDeviceProperties(&props, 0));
-  const auto multipliers = {0.5, 0.9, 1.0, 1.5, 2.0};
+  const auto multipliers = {0.5, 1.0, 2.0};
   return GENERATE_COPY(
       dim3(1, 1, 1), dim3(props.maxThreadsDim[0], 1, 1), dim3(1, props.maxThreadsDim[1], 1),
       dim3(1, 1, props.maxThreadsDim[2]),

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -77,7 +77,6 @@ template <bool dynamic, size_t tile_size> void BlockPartitionGettersBasicTestImp
     thread_block_partition_size_getter<dynamic, tile_size><<<blocks, threads>>>(uint_arr_dev.ptr());
     HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipMemcpy(uint_arr.ptr(), uint_arr_dev.ptr(), alloc_size, hipMemcpyDeviceToHost));
-    HIP_CHECK(hipDeviceSynchronize());
     thread_block_partition_thread_rank_getter<dynamic, tile_size>
         <<<blocks, threads>>>(uint_arr_dev.ptr());
     HIP_CHECK(hipGetLastError());
@@ -95,7 +94,6 @@ template <bool dynamic, size_t tile_size> void BlockPartitionGettersBasicTestImp
     });
 
     HIP_CHECK(hipMemcpy(uint_arr.ptr(), uint_arr_dev.ptr(), alloc_size, hipMemcpyDeviceToHost));
-    HIP_CHECK(hipDeviceSynchronize());
 
     ArrayAllOf(uint_arr.ptr(), grid.thread_count_, [&grid](unsigned int i) {
       return grid.thread_rank_in_block(i).value() % tile_size;
@@ -121,7 +119,7 @@ template <bool dynamic, size_t... tile_sizes> void BlockPartitionGettersBasicTes
  *    - HIP_VERSION >= 5.2
  */
 TEST_CASE("Unit_Thread_Block_Tile_Getters_Positive_Basic") {
-  BlockPartitionGettersBasicTest<false, 2, 4, 8, 16, 32>();
+  BlockPartitionGettersBasicTest<false, 2, 8, 32>();
 }
 
 /**


### PR DESCRIPTION
## Motivation
The cooperative group tests take a long time to execute, this is due to the combinatorial explosion of warp size, thread size, and thread combinations. This test reduces the number of warp sizes tested and the thread sizes tested. This is to speed up ROCm tests while maintain converge.


## Technical Details

Catch2 generates test cases use the cartesian product. So when you have 3 different GENERATE's you can an excessive number of cases to test. The change doesn't effect what is tested, all thread/block dimensions are tested however the multiplication sizes and the number of warp sizes are altered. 

We also remove unnecessary stream synchronizations as the memcpy syncs already due to using the default stream

## JIRA ID

Contributes to SWDEV-572673

## Test Plan

Testing can remain the same

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
