### PR TITLE
SWDEV-572673 - Remove unnecessary memory test types

### DIFF
--- a/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
@@ -858,7 +858,7 @@ TEST_CASE("Unit_hipHostRegister_MemAdvise_SetGet") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipHostRegister_Memcpy", "[hipHostRegister]") {
+TEST_CASE("Unit_hipHostRegister_Memcpy") {
   // 1 refers to hipHostRegister
   // 0 refers to malloc
   auto mem_type = GENERATE(0, 1);
@@ -907,7 +907,7 @@ template <typename T> __global__ void fill_kernel(T* dataPtr, T value) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipHostRegister_Flags", "[hipHostRegister]") {
+TEST_CASE("Unit_hipHostRegister_Flags") {
   size_t sizeBytes = 1 * sizeof(int);
   int* hostPtr = reinterpret_cast<int*>(malloc(sizeBytes));
 
@@ -957,7 +957,7 @@ TEST_CASE("Unit_hipHostRegister_Flags", "[hipHostRegister]") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEST_CASE("Unit_hipHostRegister_Negative", "[hipHostRegister]") {
+TEST_CASE("Unit_hipHostRegister_Negative") {
   int* hostPtr = nullptr;
 
   size_t sizeBytes = 1 * sizeof(int);

--- a/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
@@ -60,13 +60,12 @@ template <typename T> __global__ void Inc(T* Ad) {
   Ad[tx] = Ad[tx] + static_cast<T>(1);
 }
 
-template <typename T>
-void doMemCopy(size_t numElements, int offset, T* A, T* Bh, T* Bd, bool internalRegister) {
+void doMemCopy(size_t numElements, int offset, int* A, int* Bh, int* Bd, bool internalRegister) {
   constexpr auto memsetval = 13.0f;
   A = A + offset;
   numElements -= offset;
 
-  size_t sizeBytes = numElements * sizeof(T);
+  size_t sizeBytes = numElements * sizeof(int);
 
   if (internalRegister) {
     HIP_CHECK(hipHostRegister(A, sizeBytes, 0));
@@ -107,14 +106,13 @@ void doMemCopy(size_t numElements, int offset, T* A, T* Bh, T* Bd, bool internal
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_hipHostRegister_ReferenceFromKernelandhipMemset",
-                   "[multigpu]", int, float, double) {
-  size_t sizeBytes{LEN * sizeof(TestType)};
-  TestType *A, **Ad;
+TEST_CASE("Unit_hipHostRegister_ReferenceFromKernelandhipMemset", "[multigpu]") {
+  size_t sizeBytes{LEN * sizeof(int)};
+  int *A, **Ad;
   int num_devices = 0;
   HIP_CHECK(hipGetDeviceCount(&num_devices));
-  Ad = new TestType*[num_devices];
-  A = reinterpret_cast<TestType*>(malloc(sizeBytes));
+  Ad = new int*[num_devices];
+  A = reinterpret_cast<int*>(malloc(sizeBytes));
   SECTION("hipHostRegisterDefault") {
     HIP_CHECK(hipHostRegister(A, sizeBytes, hipHostRegisterDefault));
   }
@@ -133,7 +131,7 @@ TEMPLATE_TEST_CASE("Unit_hipHostRegister_ReferenceFromKernelandhipMemset",
   }
 #endif
   for (int i = 0; i < LEN; i++) {
-    A[i] = static_cast<TestType>(1);
+    A[i] = static_cast<int>(1);
   }
 
   for (int i = 0; i < num_devices; i++) {
@@ -148,7 +146,7 @@ TEMPLATE_TEST_CASE("Unit_hipHostRegister_ReferenceFromKernelandhipMemset",
     HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipDeviceSynchronize());
   }
-  REQUIRE(A[10] == 1 + static_cast<TestType>(num_devices));
+  REQUIRE(A[10] == 1 + static_cast<int>(num_devices));
   // Reference the registered device pointer Ad in hipMemset:
   for (int i = 0; i < num_devices; i++) {
     HIP_CHECK(hipSetDevice(i));
@@ -174,19 +172,19 @@ TEMPLATE_TEST_CASE("Unit_hipHostRegister_ReferenceFromKernelandhipMemset",
  * ------------------------
  *    - HIP_VERSION >= 5.6
  */
-TEMPLATE_TEST_CASE("Unit_hipHostRegister_DirectReferenceFromKernel", "", int, float, double) {
+TEST_CASE("Unit_hipHostRegister_DirectReferenceFromKernel") {
   auto flags = GENERATE(hipHostRegisterDefault, hipHostRegisterPortable, hipHostRegisterMapped);
   // Execute the test only if xnack is supported
   hipDeviceProp_t prop;
   HIP_CHECK(hipGetDeviceProperties(&prop, 0));
   std::string arch = prop.gcnArchName;
   TEST_SKIP(arch, "Xnack+ is not supported. Skipping the test ...")
-  size_t sizeBytes{LEN * sizeof(TestType)};
-  TestType* A;
-  A = reinterpret_cast<TestType*>(malloc(sizeBytes));
+  size_t sizeBytes{LEN * sizeof(int)};
+  int* A;
+  A = reinterpret_cast<int*>(malloc(sizeBytes));
   REQUIRE(A != nullptr);
   // Initialize buffer with data
-  TestType val = static_cast<TestType>(1);
+  int val = static_cast<int>(1);
   for (int i = 0; i < LEN; i++) {
     A[i] = val;
   }
@@ -197,7 +195,7 @@ TEMPLATE_TEST_CASE("Unit_hipHostRegister_DirectReferenceFromKernel", "", int, fl
   HIP_CHECK(hipGetLastError());
   HIP_CHECK(hipDeviceSynchronize());
   for (int i = 0; i < LEN; i++) {
-    REQUIRE(A[i] == (val + static_cast<TestType>(1)));
+    REQUIRE(A[i] == (val + static_cast<int>(1)));
   }
   HIP_CHECK(hipHostUnregister(A));
   free(A);
@@ -215,16 +213,15 @@ TEMPLATE_TEST_CASE("Unit_hipHostRegister_DirectReferenceFromKernel", "", int, fl
  * ------------------------
  *    - HIP_VERSION >= 5.6
  */
-TEMPLATE_TEST_CASE("Unit_hipHostRegister_DirectReferenceMultGpu", "[multigpu]",
-                   int, float, double) {
+TEST_CASE("Unit_hipHostRegister_DirectReferenceMultGpu", "[multigpu]") {
   // 1 refers to doing hipHostRegister once for all devices
   // 0 refers to doing hipHostRegister for each device
   auto register_once = GENERATE(0, 1);
   hipDeviceProp_t prop;
   int numDevices = HipTest::getDeviceCount();
-  size_t sizeBytes{LEN * sizeof(TestType)};
-  TestType* A;
-  A = reinterpret_cast<TestType*>(malloc(sizeBytes));
+  size_t sizeBytes{LEN * sizeof(int)};
+  int* A;
+  A = reinterpret_cast<int*>(malloc(sizeBytes));
   REQUIRE(A != nullptr);
   // Register host memory only once for all device
   if (register_once == 1) {
@@ -233,7 +230,7 @@ TEMPLATE_TEST_CASE("Unit_hipHostRegister_DirectReferenceMultGpu", "[multigpu]",
   // Reference the registered device pointer A from inside all devices:
   for (int dev = 0; dev < numDevices; dev++) {
     // Initialize buffer with data
-    TestType val = static_cast<TestType>(1);
+    int val = static_cast<int>(1);
     for (int i = 0; i < LEN; i++) {
       A[i] = val;
     }
@@ -251,7 +248,7 @@ TEMPLATE_TEST_CASE("Unit_hipHostRegister_DirectReferenceMultGpu", "[multigpu]",
     HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipDeviceSynchronize());
     for (int i = 0; i < LEN; i++) {
-      REQUIRE(A[i] == (val + static_cast<TestType>(1)));
+      REQUIRE(A[i] == (val + static_cast<int>(1)));
     }
     if (register_once == 0) {
       HIP_CHECK(hipHostUnregister(A));
@@ -861,30 +858,30 @@ TEST_CASE("Unit_hipHostRegister_MemAdvise_SetGet") {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_hipHostRegister_Memcpy", "", int, float, double) {
+TEST_CASE("Unit_hipHostRegister_Memcpy", "[hipHostRegister]") {
   // 1 refers to hipHostRegister
   // 0 refers to malloc
   auto mem_type = GENERATE(0, 1);
   HIP_CHECK(hipSetDevice(0));
 
-  size_t sizeBytes = LEN * sizeof(TestType);
-  TestType* A = reinterpret_cast<TestType*>(malloc(sizeBytes));
+  size_t sizeBytes = LEN * sizeof(int);
+  int* A = reinterpret_cast<int*>(malloc(sizeBytes));
 
   // Copy to B, this should be optimal pinned malloc copy:
   // Note we are using the host pointer here:
-  TestType *Bh, *Bd;
-  Bh = reinterpret_cast<TestType*>(malloc(sizeBytes));
+  int *Bh, *Bd;
+  Bh = reinterpret_cast<int*>(malloc(sizeBytes));
   HIP_CHECK(hipMalloc(&Bd, sizeBytes));
 
   REQUIRE(LEN > OFFSET);
   if (mem_type) {
     for (size_t i = 0; i < OFFSET; i++) {
-      doMemCopy<TestType>(LEN, i, A, Bh, Bd, true /*internalRegister*/);
+      doMemCopy(LEN, i, A, Bh, Bd, true /*internalRegister*/);
     }
   } else {
     HIP_CHECK(hipHostRegister(A, sizeBytes, 0));
     for (size_t i = 0; i < OFFSET; i++) {
-      doMemCopy<TestType>(LEN, i, A, Bh, Bd, false /*internalRegister*/);
+      doMemCopy(LEN, i, A, Bh, Bd, false /*internalRegister*/);
     }
     HIP_CHECK(hipHostUnregister(A));
   }
@@ -910,9 +907,9 @@ template <typename T> __global__ void fill_kernel(T* dataPtr, T value) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_hipHostRegister_Flags", "", int, float, double) {
-  size_t sizeBytes = 1 * sizeof(TestType);
-  TestType* hostPtr = reinterpret_cast<TestType*>(malloc(sizeBytes));
+TEST_CASE("Unit_hipHostRegister_Flags", "[hipHostRegister]") {
+  size_t sizeBytes = 1 * sizeof(int);
+  int* hostPtr = reinterpret_cast<int*>(malloc(sizeBytes));
 
   /* Flags aren't used for AMD devices currently */
   struct FlagType {
@@ -960,15 +957,15 @@ TEMPLATE_TEST_CASE("Unit_hipHostRegister_Flags", "", int, float, double) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_hipHostRegister_Negative", "", int, float, double) {
-  TestType* hostPtr = nullptr;
+TEST_CASE("Unit_hipHostRegister_Negative", "[hipHostRegister]") {
+  int* hostPtr = nullptr;
 
-  size_t sizeBytes = 1 * sizeof(TestType);
+  size_t sizeBytes = 1 * sizeof(int);
   SECTION("hipHostRegister Negative Test - nullptr") {
     HIP_CHECK_ERROR(hipHostRegister(hostPtr, 1, 0), hipErrorInvalidValue);
   }
 
-  hostPtr = reinterpret_cast<TestType*>(malloc(sizeBytes));
+  hostPtr = reinterpret_cast<int*>(malloc(sizeBytes));
   SECTION("hipHostRegister Negative Test - zero size") {
     HIP_CHECK_ERROR(hipHostRegister(hostPtr, 0, 0), hipErrorInvalidValue);
   }

--- a/projects/hip-tests/catch/unit/memory/hipMallocPitch.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocPitch.cc
@@ -389,12 +389,12 @@ static void threadFunc(int gpu) { MemoryAllocDiffSizes<float>(gpu); }
  * hipMallocPitch API for different datatypes
  *
  */
-TEMPLATE_TEST_CASE("Unit_hipMallocPitch_Basic", "[hipMallocPitch]", int, unsigned int, float) {
+TEST_CASE("Unit_hipMallocPitch_Basic", "[hipMallocPitch]") {
   CHECK_IMAGE_SUPPORT
 
-  TestType* A_d;
+  int* A_d;
   size_t pitch_A = 0;
-  size_t width{NUM_W * sizeof(TestType)};
+  size_t width{NUM_W * sizeof(int)};
   REQUIRE(hipMallocPitch(reinterpret_cast<void**>(&A_d), &pitch_A, width, NUM_H) == hipSuccess);
   REQUIRE(width <= pitch_A);
   HIP_CHECK(hipFree(A_d));
@@ -404,53 +404,52 @@ TEMPLATE_TEST_CASE("Unit_hipMallocPitch_Basic", "[hipMallocPitch]", int, unsigne
  * This testcase verifies hipMallocPitch API for small
  * and big chunks of data.
  */
-TEMPLATE_TEST_CASE("Unit_hipMallocPitch_SmallandBigChunks", "[hipMallocPitch]", int, unsigned int,
-                   float) {
+TEST_CASE("Unit_hipMallocPitch_SmallandBigChunks", "[hipMallocPitch]") {
   CHECK_IMAGE_SUPPORT
 
-  MemoryAllocDiffSizes<TestType>(0);
+  MemoryAllocDiffSizes<int>(0);
 }
 
 /*
  * This testcase verifies the memory allocated by hipMallocPitch API
  * by performing Memcpy2D on the allocated memory.
  */
-TEMPLATE_TEST_CASE("Unit_hipMallocPitch_Memcpy2D", "", int, float, double) {
+TEST_CASE("Unit_hipMallocPitch_Memcpy2D") {
   CHECK_IMAGE_SUPPORT
 
   HIP_CHECK(hipSetDevice(0));
-  TestType *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr}, *A_d{nullptr}, *B_d{nullptr};
+  int *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr}, *A_d{nullptr}, *B_d{nullptr};
   size_t pitch_A = 0, pitch_B = 0;
-  size_t width{NUM_W * sizeof(TestType)};
+  size_t width{NUM_W * sizeof(int)};
 
   // Allocating memory
-  HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &A_h, &B_h, &C_h, NUM_W * NUM_H, false);
+  HipTest::initArrays<int>(nullptr, nullptr, nullptr, &A_h, &B_h, &C_h, NUM_W * NUM_H, false);
   HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&A_d), &pitch_A, width, NUM_H));
   HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&B_d), &pitch_B, width, NUM_H));
 
   // Initialize the data
-  HipTest::setDefaultData<TestType>(NUM_W * NUM_H, A_h, B_h, C_h);
+  HipTest::setDefaultData<int>(NUM_W * NUM_H, A_h, B_h, C_h);
 
   // Host to Device
-  HIP_CHECK(hipMemcpy2D(A_d, pitch_A, A_h, COLUMNS * sizeof(TestType), COLUMNS * sizeof(TestType),
-                        ROWS, hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy2D(A_d, pitch_A, A_h, COLUMNS * sizeof(int), COLUMNS * sizeof(int), ROWS,
+                        hipMemcpyHostToDevice));
 
   // Performs D2D on same GPU device
-  HIP_CHECK(hipMemcpy2D(B_d, pitch_B, A_d, pitch_A, COLUMNS * sizeof(TestType), ROWS,
+  HIP_CHECK(hipMemcpy2D(B_d, pitch_B, A_d, pitch_A, COLUMNS * sizeof(int), ROWS,
                         hipMemcpyDeviceToDevice));
 
   // hipMemcpy2D Device to Host
-  HIP_CHECK(hipMemcpy2D(B_h, COLUMNS * sizeof(TestType), B_d, pitch_B, COLUMNS * sizeof(TestType),
-                        ROWS, hipMemcpyDeviceToHost));
+  HIP_CHECK(hipMemcpy2D(B_h, COLUMNS * sizeof(int), B_d, pitch_B, COLUMNS * sizeof(int), ROWS,
+                        hipMemcpyDeviceToHost));
 
   // Validating the result
-  REQUIRE(HipTest::checkArray<TestType>(A_h, B_h, COLUMNS, ROWS) == true);
+  REQUIRE(HipTest::checkArray<int>(A_h, B_h, COLUMNS, ROWS) == true);
 
 
   // DeAllocating the memory
   HIP_CHECK(hipFree(A_d));
   HIP_CHECK(hipFree(B_d));
-  HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, A_h, B_h, C_h, false);
+  HipTest::freeArrays<int>(nullptr, nullptr, nullptr, A_h, B_h, C_h, false);
 }
 
 
@@ -483,32 +482,32 @@ TEST_CASE("Unit_hipMallocPitch_MultiThread", "[multigpu]") {
  *     variable to another kernel variable.
  *  3. Validating the result
  */
-TEMPLATE_TEST_CASE("Unit_hipMallocPitch_KernelLaunch", "", int, float, double) {
+TEST_CASE("Unit_hipMallocPitch_KernelLaunch") {
   CHECK_IMAGE_SUPPORT
 
   HIP_CHECK(hipSetDevice(0));
-  TestType *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr}, *A_d{nullptr}, *B_d{nullptr};
+  int *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr}, *A_d{nullptr}, *B_d{nullptr};
   size_t pitch_A = 0, pitch_B = 0;
-  size_t width{NUM_W * sizeof(TestType)};
+  size_t width{NUM_W * sizeof(int)};
 
   // Allocating memory
-  HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &A_h, &B_h, &C_h, NUM_W * NUM_H, false);
+  HipTest::initArrays<int>(nullptr, nullptr, nullptr, &A_h, &B_h, &C_h, NUM_W * NUM_H, false);
   HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&A_d), &pitch_A, width, NUM_H));
   HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&B_d), &pitch_B, width, NUM_H));
 
   // Host to Device
-  HIP_CHECK(hipMemcpy2D(A_d, pitch_A, A_h, COLUMNS * sizeof(TestType), COLUMNS * sizeof(TestType),
-                        ROWS, hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy2D(A_d, pitch_A, A_h, COLUMNS * sizeof(int), COLUMNS * sizeof(int), ROWS,
+                        hipMemcpyHostToDevice));
 
 
-  hipLaunchKernelGGL(copy_var<TestType>, dim3(1), dim3(1), 0, 0, static_cast<TestType*>(A_d),
-                     static_cast<TestType*>(B_d), ROWS, pitch_A);
+  hipLaunchKernelGGL(copy_var, dim3(1), dim3(1), 0, 0, static_cast<int*>(A_d),
+                     static_cast<int*>(B_d), ROWS, pitch_A);
   HIP_CHECK(hipGetLastError());
 
 
   // hipMemcpy2D Device to Host
-  HIP_CHECK(hipMemcpy2D(B_h, COLUMNS * sizeof(TestType), B_d, pitch_B, COLUMNS * sizeof(TestType),
-                        ROWS, hipMemcpyDeviceToHost));
+  HIP_CHECK(hipMemcpy2D(B_h, COLUMNS * sizeof(int), B_d, pitch_B, COLUMNS * sizeof(int), ROWS,
+                        hipMemcpyDeviceToHost));
 
   // Validating the result
   validateResult(A_h, B_h, pitch_A);
@@ -516,5 +515,5 @@ TEMPLATE_TEST_CASE("Unit_hipMallocPitch_KernelLaunch", "", int, float, double) {
   // DeAllocating the memory
   HIP_CHECK(hipFree(A_d));
   HIP_CHECK(hipFree(B_d));
-  HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, A_h, B_h, C_h, false);
+  HipTest::freeArrays<int>(nullptr, nullptr, nullptr, A_h, B_h, C_h, false);
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy2DAsync_old.cc
@@ -75,24 +75,23 @@ static constexpr auto ROWS{6};
  *  - HIP_VERSION >= 6.1
  */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpy2DAsync_Host&PinnedMem", "", int, float, double) {
+TEST_CASE("Unit_hipMemcpy2DAsync_Host&PinnedMem") {
   CHECK_IMAGE_SUPPORT
   // 1 refers to pinned host memory
   auto mem_type = GENERATE(0, 1);
   auto memcpy_d2d_type = GENERATE(0, 1);
   HIP_CHECK(hipSetDevice(0));
-  TestType *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr}, *A_d{nullptr}, *B_d{nullptr};
+  int *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr}, *A_d{nullptr}, *B_d{nullptr};
   size_t pitch_A, pitch_B;
-  size_t width{NUM_W * sizeof(TestType)};
+  size_t width{NUM_W * sizeof(int)};
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
 
   // Allocating memory
   if (mem_type) {
-    HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &A_h, &B_h, &C_h, NUM_W * NUM_H, true);
+    HipTest::initArrays<int>(nullptr, nullptr, nullptr, &A_h, &B_h, &C_h, NUM_W * NUM_H, true);
   } else {
-    HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &A_h, &B_h, &C_h, NUM_W * NUM_H,
-                                  false);
+    HipTest::initArrays<int>(nullptr, nullptr, nullptr, &A_h, &B_h, &C_h, NUM_W * NUM_H, false);
   }
   hipMemcpyKind d2d_type;
   if (memcpy_d2d_type) {
@@ -104,49 +103,47 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy2DAsync_Host&PinnedMem", "", int, float, doubl
   HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&B_d), &pitch_B, width, NUM_H));
 
   // Initialize the data
-  HipTest::setDefaultData<TestType>(NUM_W * NUM_H, A_h, B_h, C_h);
+  HipTest::setDefaultData<int>(NUM_W * NUM_H, A_h, B_h, C_h);
   SECTION("Calling Async apis with stream object created by user") {
     // Host to Device
-    HIP_CHECK(hipMemcpy2DAsync(A_d, pitch_A, A_h, COLUMNS * sizeof(TestType),
-                               COLUMNS * sizeof(TestType), ROWS, hipMemcpyHostToDevice, stream));
+    HIP_CHECK(hipMemcpy2DAsync(A_d, pitch_A, A_h, COLUMNS * sizeof(int), COLUMNS * sizeof(int),
+                               ROWS, hipMemcpyHostToDevice, stream));
 
     // Performs D2D on same GPU device
-    HIP_CHECK(hipMemcpy2DAsync(B_d, pitch_B, A_d, pitch_A, COLUMNS * sizeof(TestType), ROWS,
-                               d2d_type, stream));
+    HIP_CHECK(hipMemcpy2DAsync(B_d, pitch_B, A_d, pitch_A, COLUMNS * sizeof(int), ROWS, d2d_type,
+                               stream));
 
     // hipMemcpy2DAsync Device to Host
-    HIP_CHECK(hipMemcpy2DAsync(B_h, COLUMNS * sizeof(TestType), B_d, pitch_B,
-                               COLUMNS * sizeof(TestType), ROWS, hipMemcpyDeviceToHost, stream));
+    HIP_CHECK(hipMemcpy2DAsync(B_h, COLUMNS * sizeof(int), B_d, pitch_B, COLUMNS * sizeof(int),
+                               ROWS, hipMemcpyDeviceToHost, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
   }
   SECTION("Calling Async apis with hipStreamPerThread") {
     // Host to Device
-    HIP_CHECK(hipMemcpy2DAsync(A_d, pitch_A, A_h, COLUMNS * sizeof(TestType),
-                               COLUMNS * sizeof(TestType), ROWS, hipMemcpyHostToDevice,
-                               hipStreamPerThread));
+    HIP_CHECK(hipMemcpy2DAsync(A_d, pitch_A, A_h, COLUMNS * sizeof(int), COLUMNS * sizeof(int),
+                               ROWS, hipMemcpyHostToDevice, hipStreamPerThread));
 
     // Performs D2D on same GPU device
-    HIP_CHECK(hipMemcpy2DAsync(B_d, pitch_B, A_d, pitch_A, COLUMNS * sizeof(TestType), ROWS,
-                               d2d_type, hipStreamPerThread));
+    HIP_CHECK(hipMemcpy2DAsync(B_d, pitch_B, A_d, pitch_A, COLUMNS * sizeof(int), ROWS, d2d_type,
+                               hipStreamPerThread));
 
     // hipMemcpy2DAsync Device to Host
-    HIP_CHECK(hipMemcpy2DAsync(B_h, COLUMNS * sizeof(TestType), B_d, pitch_B,
-                               COLUMNS * sizeof(TestType), ROWS, hipMemcpyDeviceToHost,
-                               hipStreamPerThread));
+    HIP_CHECK(hipMemcpy2DAsync(B_h, COLUMNS * sizeof(int), B_d, pitch_B, COLUMNS * sizeof(int),
+                               ROWS, hipMemcpyDeviceToHost, hipStreamPerThread));
     HIP_CHECK(hipStreamSynchronize(hipStreamPerThread));
   }
 
   // Validating the result
-  REQUIRE(HipTest::checkArray<TestType>(A_h, B_h, COLUMNS, ROWS) == true);
+  REQUIRE(HipTest::checkArray<int>(A_h, B_h, COLUMNS, ROWS) == true);
 
 
   // DeAllocating the memory
   HIP_CHECK(hipFree(A_d));
   HIP_CHECK(hipFree(B_d));
   if (mem_type) {
-    HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, A_h, B_h, C_h, true);
+    HipTest::freeArrays<int>(nullptr, nullptr, nullptr, A_h, B_h, C_h, true);
   } else {
-    HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, A_h, B_h, C_h, false);
+    HipTest::freeArrays<int>(nullptr, nullptr, nullptr, A_h, B_h, C_h, false);
   }
   HIP_CHECK(hipStreamDestroy(stream));
 }
@@ -172,15 +169,14 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy2DAsync_Host&PinnedMem", "", int, float, doubl
  *  - HIP_VERSION >= 5.2
  */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpy2DAsync_multiDevice-Host&PinnedMem",
-                   "[multigpu]", int, float, double) {
+TEST_CASE("Unit_hipMemcpy2DAsync_multiDevice-Host&PinnedMem", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
   auto mem_type = GENERATE(0, 1);
   int numDevices = 0;
   int canAccessPeer = 0;
-  TestType *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr}, *A_d{nullptr};
+  int *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr}, *A_d{nullptr};
   size_t pitch_A;
-  size_t width{NUM_W * sizeof(TestType)};
+  size_t width{NUM_W * sizeof(int)};
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   hipStream_t stream;
 
@@ -192,20 +188,18 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy2DAsync_multiDevice-Host&PinnedMem",
 
       // Allocating memory
       if (mem_type) {
-        HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &A_h, &B_h, &C_h, NUM_W * NUM_H,
-                                      true);
+        HipTest::initArrays<int>(nullptr, nullptr, nullptr, &A_h, &B_h, &C_h, NUM_W * NUM_H, true);
       } else {
-        HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &A_h, &B_h, &C_h, NUM_W * NUM_H,
-                                      false);
+        HipTest::initArrays<int>(nullptr, nullptr, nullptr, &A_h, &B_h, &C_h, NUM_W * NUM_H, false);
       }
       HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&A_d), &pitch_A, width, NUM_H));
 
       // Initialize the data
-      HipTest::setDefaultData<TestType>(NUM_W * NUM_H, A_h, B_h, C_h);
+      HipTest::setDefaultData<int>(NUM_W * NUM_H, A_h, B_h, C_h);
 
       // Host to Device
-      HIP_CHECK(hipMemcpy2DAsync(A_d, pitch_A, A_h, COLUMNS * sizeof(TestType),
-                                 COLUMNS * sizeof(TestType), ROWS, hipMemcpyHostToDevice, stream));
+      HIP_CHECK(hipMemcpy2DAsync(A_d, pitch_A, A_h, COLUMNS * sizeof(int), COLUMNS * sizeof(int),
+                                 ROWS, hipMemcpyHostToDevice, stream));
 
       // Change device
       HIP_CHECK(hipSetDevice(1));
@@ -215,23 +209,23 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy2DAsync_multiDevice-Host&PinnedMem",
       HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&X_d), &pitch_X, width, NUM_H));
 
       // Device to Device
-      HIP_CHECK(hipMemcpy2DAsync(X_d, pitch_X, A_d, pitch_A, COLUMNS * sizeof(TestType), ROWS,
+      HIP_CHECK(hipMemcpy2DAsync(X_d, pitch_X, A_d, pitch_A, COLUMNS * sizeof(int), ROWS,
                                  hipMemcpyDeviceToDevice, stream));
 
       // Device to Host
-      HIP_CHECK(hipMemcpy2DAsync(B_h, COLUMNS * sizeof(TestType), X_d, pitch_X,
-                                 COLUMNS * sizeof(TestType), ROWS, hipMemcpyDeviceToHost, stream));
+      HIP_CHECK(hipMemcpy2DAsync(B_h, COLUMNS * sizeof(int), X_d, pitch_X, COLUMNS * sizeof(int),
+                                 ROWS, hipMemcpyDeviceToHost, stream));
       HIP_CHECK(hipStreamSynchronize(stream));
 
       // Validating the result
-      REQUIRE(HipTest::checkArray<TestType>(A_h, B_h, COLUMNS, ROWS) == true);
+      REQUIRE(HipTest::checkArray<int>(A_h, B_h, COLUMNS, ROWS) == true);
 
       // DeAllocating the memory
       HIP_CHECK(hipFree(A_d));
       if (mem_type) {
-        HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, A_h, B_h, C_h, true);
+        HipTest::freeArrays<int>(nullptr, nullptr, nullptr, A_h, B_h, C_h, true);
       } else {
-        HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, A_h, B_h, C_h, false);
+        HipTest::freeArrays<int>(nullptr, nullptr, nullptr, A_h, B_h, C_h, false);
       }
       HIP_CHECK(hipFree(X_d));
       HIP_CHECK(hipStreamDestroy(stream));
@@ -265,15 +259,14 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy2DAsync_multiDevice-Host&PinnedMem",
  *  - HIP_VERSION >= 5.2
  */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpy2DAsync_multiDevice-StreamOnDiffDevice",
-                   "[multigpu]", int, float, double) {
+TEST_CASE("Unit_hipMemcpy2DAsync_multiDevice-StreamOnDiffDevice", "[multigpu]") {
   CHECK_IMAGE_SUPPORT
   auto mem_type = GENERATE(0, 1);
   int numDevices = 0;
   int canAccessPeer = 0;
-  TestType *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr}, *A_d{nullptr};
+  int *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr}, *A_d{nullptr};
   size_t pitch_A;
-  size_t width{NUM_W * sizeof(TestType)};
+  size_t width{NUM_W * sizeof(int)};
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   hipStream_t stream;
 
@@ -284,11 +277,9 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy2DAsync_multiDevice-StreamOnDiffDevice",
 
       // Allocating memory
       if (mem_type) {
-        HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &A_h, &B_h, &C_h, NUM_W * NUM_H,
-                                      true);
+        HipTest::initArrays<int>(nullptr, nullptr, nullptr, &A_h, &B_h, &C_h, NUM_W * NUM_H, true);
       } else {
-        HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &A_h, &B_h, &C_h, NUM_W * NUM_H,
-                                      false);
+        HipTest::initArrays<int>(nullptr, nullptr, nullptr, &A_h, &B_h, &C_h, NUM_W * NUM_H, false);
       }
       HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&A_d), &pitch_A, width, NUM_H));
       char* X_d{nullptr};
@@ -296,34 +287,34 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy2DAsync_multiDevice-StreamOnDiffDevice",
       HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&X_d), &pitch_X, width, NUM_H));
 
       // Initialize the data
-      HipTest::setDefaultData<TestType>(NUM_W * NUM_H, A_h, B_h, C_h);
+      HipTest::setDefaultData<int>(NUM_W * NUM_H, A_h, B_h, C_h);
 
       // Change device
       HIP_CHECK(hipSetDevice(1));
       HIP_CHECK(hipStreamCreate(&stream));
 
       // Host to Device
-      HIP_CHECK(hipMemcpy2DAsync(A_d, pitch_A, A_h, COLUMNS * sizeof(TestType),
-                                 COLUMNS * sizeof(TestType), ROWS, hipMemcpyHostToDevice, stream));
+      HIP_CHECK(hipMemcpy2DAsync(A_d, pitch_A, A_h, COLUMNS * sizeof(int), COLUMNS * sizeof(int),
+                                 ROWS, hipMemcpyHostToDevice, stream));
 
       // Device to Device
-      HIP_CHECK(hipMemcpy2DAsync(X_d, pitch_X, A_d, pitch_A, COLUMNS * sizeof(TestType), ROWS,
+      HIP_CHECK(hipMemcpy2DAsync(X_d, pitch_X, A_d, pitch_A, COLUMNS * sizeof(int), ROWS,
                                  hipMemcpyDeviceToDevice, stream));
 
       // Device to Host
-      HIP_CHECK(hipMemcpy2DAsync(B_h, COLUMNS * sizeof(TestType), X_d, pitch_X,
-                                 COLUMNS * sizeof(TestType), ROWS, hipMemcpyDeviceToHost, stream));
+      HIP_CHECK(hipMemcpy2DAsync(B_h, COLUMNS * sizeof(int), X_d, pitch_X, COLUMNS * sizeof(int),
+                                 ROWS, hipMemcpyDeviceToHost, stream));
       HIP_CHECK(hipStreamSynchronize(stream));
 
       // Validating the result
-      REQUIRE(HipTest::checkArray<TestType>(A_h, B_h, COLUMNS, ROWS) == true);
+      REQUIRE(HipTest::checkArray<int>(A_h, B_h, COLUMNS, ROWS) == true);
 
       // DeAllocating the memory
       HIP_CHECK(hipFree(A_d));
       if (mem_type) {
-        HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, A_h, B_h, C_h, true);
+        HipTest::freeArrays<int>(nullptr, nullptr, nullptr, A_h, B_h, C_h, true);
       } else {
-        HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, A_h, B_h, C_h, false);
+        HipTest::freeArrays<int>(nullptr, nullptr, nullptr, A_h, B_h, C_h, false);
       }
       HIP_CHECK(hipFree(X_d));
       HIP_CHECK(hipStreamDestroy(stream));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3DAsync_old.cc
@@ -635,7 +635,7 @@ template <typename T> void Memcpy3DAsync<T>::simple_Memcpy3DAsync() {
  *  - HIP_VERSION >= 6.0
  */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpy3DAsync_Basic", "[hipMemcpy3DAsync]", int, unsigned int, float) {
+TEST_CASE("Unit_hipMemcpy3DAsync_Basic", "[hipMemcpy3DAsync]") {
   CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -646,16 +646,8 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy3DAsync_Basic", "[hipMemcpy3DAsync]", int, uns
   auto i = GENERATE_COPY(10, 100, 1024, prop.maxTexture3D[0]);
   auto j = GENERATE(10, 100);
   if (numDevices > 1) {
-    if (std::is_same<TestType, int>::value) {
-      Memcpy3DAsync<TestType> memcpy3d_obj(i, j, j, hipChannelFormatKindSigned);
-      memcpy3d_obj.simple_Memcpy3DAsync();
-    } else if (std::is_same<TestType, unsigned int>::value) {
-      Memcpy3DAsync<TestType> memcpy3d_obj(i, j, j, hipChannelFormatKindUnsigned);
-      memcpy3d_obj.simple_Memcpy3DAsync();
-    } else if (std::is_same<TestType, float>::value) {
-      Memcpy3DAsync<TestType> memcpy3d_obj(i, j, j, hipChannelFormatKindFloat);
-      memcpy3d_obj.simple_Memcpy3DAsync();
-    }
+    Memcpy3DAsync<int> memcpy3d_obj(i, j, j, hipChannelFormatKindSigned);
+    memcpy3d_obj.simple_Memcpy3DAsync();
   } else {
     SUCCEED("skipping the testcases as numDevices < 2");
   }

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3DBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3DBatchAsync.cc
@@ -68,20 +68,10 @@ void checkArrayContent(hipArray_t array, size_t width, size_t height,
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEMPLATE_TEST_CASE("Unit_hipMemcpy3DBatchAsync_Ptr2PtrBatchOps", "", char, int,
-                   float) {
-  constexpr auto kfloatval1 = -1.5f;
-  constexpr auto kfloatval2 = 2.25f;
-  constexpr auto kfloatval3 = -0.75f;
-  const TestType val1 = std::is_floating_point_v<TestType> ? kfloatval1
-                        : std::is_integral_v<TestType>     ? 10
-                                                           : 'a';
-  const TestType val2 = std::is_floating_point_v<TestType> ? kfloatval2
-                        : std::is_integral_v<TestType>     ? 7
-                                                           : 'b';
-  const TestType val3 = std::is_floating_point_v<TestType> ? kfloatval3
-                        : std::is_integral_v<TestType>     ? 3
-                                                           : 'c';
+TEST_CASE("Unit_hipMemcpy3DBatchAsync_Ptr2PtrBatchOps") {
+  const int val1 = 10;
+  const int val2 = 7;
+  const int val3 = 3;
 
   constexpr int numOps = 4;
   constexpr int numW = 16;
@@ -89,18 +79,18 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy3DBatchAsync_Ptr2PtrBatchOps", "", char, int,
   constexpr int depth = 10;
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
-  hipExtent extent = make_hipExtent(numW * sizeof(TestType), numH, depth);
+  hipExtent extent = make_hipExtent(numW * sizeof(int), numH, depth);
   size_t elements_3d = numW * numH * depth;
 
   // Source Pointers
-  std::vector<TestType> srcPtr1(elements_3d, val1);
-  std::vector<TestType> srcPtr2(elements_3d, val2);
-  std::vector<TestType> srcPtr3(elements_3d, val3);
+  std::vector<int> srcPtr1(elements_3d, val1);
+  std::vector<int> srcPtr2(elements_3d, val2);
+  std::vector<int> srcPtr3(elements_3d, val3);
 
   // Device Pointers
   void *dstPtr1, *dstPtr2;
-  HIP_CHECK(hipMalloc(&dstPtr1, elements_3d * sizeof(TestType)));
-  HIP_CHECK(hipMalloc(&dstPtr2, elements_3d * sizeof(TestType)));
+  HIP_CHECK(hipMalloc(&dstPtr1, elements_3d * sizeof(int)));
+  HIP_CHECK(hipMalloc(&dstPtr2, elements_3d * sizeof(int)));
 
   // Prepare batch ops array
   hipMemcpy3DBatchOp ops[numOps];
@@ -211,17 +201,10 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy3DBatchAsync_Ptr2PtrBatchOps", "", char, int,
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEMPLATE_TEST_CASE("Unit_hipMemcpy3DBatchAsync_ArrayMemCpyBatchOps", "", char,
-                   int, float) {
+TEST_CASE("Unit_hipMemcpy3DBatchAsync_ArrayMemCpyBatchOps") {
   CHECK_IMAGE_SUPPORT
-  constexpr auto kfloatval1 = -1.5f;
-  constexpr auto kfloatval2 = 2.25f;
-  const TestType val1 = std::is_floating_point_v<TestType> ? kfloatval1
-                        : std::is_integral_v<TestType>     ? 10
-                                                           : 'a';
-  const TestType val2 = std::is_floating_point_v<TestType> ? kfloatval2
-                        : std::is_integral_v<TestType>     ? 7
-                                                           : 'b';
+  const int val1 = 10;
+  const int val2 = 7;
   constexpr int numOps = 5;
   constexpr int numW = 16;
   constexpr int numH = 16;
@@ -232,26 +215,25 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy3DBatchAsync_ArrayMemCpyBatchOps", "", char,
   size_t elements_3d = extent.width * extent.height * extent.depth;
 
   // Host Pointers
-  std::vector<TestType> srcPtr1(elements_3d, val1);
-  std::vector<TestType> srcPtr2(elements_3d, val2);
+  std::vector<int> srcPtr1(elements_3d, val1);
+  std::vector<int> srcPtr2(elements_3d, val2);
 
   // Device Pointer
   void *dstPtr;
-  HIP_CHECK(hipMalloc(&dstPtr, elements_3d * sizeof(TestType)));
+  HIP_CHECK(hipMalloc(&dstPtr, elements_3d * sizeof(int)));
 
   // Dev Arrays
-  hipChannelFormatDesc channelDesc = hipCreateChannelDesc<TestType>();
+  hipChannelFormatDesc channelDesc = hipCreateChannelDesc<int>();
   hipArray_t array1, array2, array3;
   HIP_CHECK(hipMalloc3DArray(&array1, &channelDesc, extent, 0));
   HIP_CHECK(hipMalloc3DArray(&array2, &channelDesc, extent, 0));
   HIP_CHECK(hipMalloc3DArray(&array3, &channelDesc, extent, 0));
 
   // Fill dev Array with val2
-  std::vector<TestType> tmpHost(elements_3d, val2);
+  std::vector<int> tmpHost(elements_3d, val2);
   hipMemcpy3DParms fillParms{};
   fillParms.srcPtr =
-      make_hipPitchedPtr(tmpHost.data(), extent.width * sizeof(TestType),
-                         extent.width, extent.height);
+      make_hipPitchedPtr(tmpHost.data(), extent.width * sizeof(int), extent.width, extent.height);
   fillParms.dstArray = array1;
   fillParms.extent = extent;
   fillParms.kind = hipMemcpyHostToDevice;
@@ -334,8 +316,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy3DBatchAsync_ArrayMemCpyBatchOps", "", char,
   HIP_CHECK(hipStreamSynchronize(stream));
 
   // Check Random Array data
-  checkArrayContent<TestType>(array2, extent.width, extent.height, extent.depth,
-                              val1);
+  checkArrayContent<int>(array2, extent.width, extent.height, extent.depth, val1);
   // Check Final data.
   for (size_t i = 0; i < elements_3d; ++i) {
     INFO("Pointer Copy Failure at Index: " << i << "\nval : " << srcPtr2[i]);

--- a/projects/hip-tests/catch/unit/memory/hipMemcpy3D_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpy3D_old.cc
@@ -527,7 +527,7 @@ template <typename T> void Memcpy3D<T>::simple_Memcpy3D() {
  *  - HIP_VERSION >= 5.2
  */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpy3D_Basic", "[hipMemcpy3D]", int, unsigned int, float) {
+TEST_CASE("Unit_hipMemcpy3D_Basic", "[hipMemcpy3D]") {
   CHECK_IMAGE_SUPPORT
   int device = -1;
   HIP_CHECK(hipGetDevice(&device));
@@ -538,16 +538,8 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpy3D_Basic", "[hipMemcpy3D]", int, unsigned int,
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices > 1) {
-    if (std::is_same<TestType, float>::value) {
-      Memcpy3D<TestType> memcpy3d_obj(i, j, j, hipChannelFormatKindFloat);
-      memcpy3d_obj.simple_Memcpy3D();
-    } else if (std::is_same<TestType, unsigned int>::value) {
-      Memcpy3D<TestType> memcpy3d_obj(i, j, j, hipChannelFormatKindUnsigned);
-      memcpy3d_obj.simple_Memcpy3D();
-    } else if (std::is_same<TestType, int>::value) {
-      Memcpy3D<TestType> memcpy3d_obj(i, j, j, hipChannelFormatKindSigned);
-      memcpy3d_obj.simple_Memcpy3D();
-    }
+    Memcpy3D<int> memcpy3d_obj(i, j, j, hipChannelFormatKindSigned);
+    memcpy3d_obj.simple_Memcpy3D();
   } else {
     SUCCEED("skipping the testcases as numDevices < 2");
   }

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAsync_old.cc
@@ -41,8 +41,8 @@ std::atomic<size_t> Thread_count{0};
 static unsigned blocksPerCU{6};  // to hide latency
 static unsigned threadsPerBlock{256};
 
-template <typename T>
-void Thread_func(T* A_d, T* B_d, T* C_d, T* C_h, size_t Nbytes, hipStream_t mystream) {
+// Change template helper functions to use int
+void Thread_func(int* A_d, int* B_d, int* C_d, int* C_h, size_t Nbytes, hipStream_t mystream) {
   unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, N_ELMTS);
   hipLaunchKernelGGL(HipTest::vector_square, dim3(blocks), dim3(threadsPerBlock), 0, mystream, A_d,
                      C_d, N_ELMTS);
@@ -55,11 +55,11 @@ void Thread_func(T* A_d, T* B_d, T* C_d, T* C_h, size_t Nbytes, hipStream_t myst
   Thread_count++;
 }
 
-template <typename T> void Thread_func_MultiStream() {
+void Thread_func_MultiStream() {
   int Data_mismatch = 0;
-  T *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr};
-  T *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr};
-  size_t Nbytes = N_ELMTS * sizeof(T);
+  int *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr};
+  int *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr};
+  size_t Nbytes = N_ELMTS * sizeof(int);
   unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, N_ELMTS);
 
   HipTest::initArrays(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, N_ELMTS, false);
@@ -84,21 +84,16 @@ template <typename T> void Thread_func_MultiStream() {
     }
   }
   // Releasing resources
-  HipTest::freeArrays<T>(A_d, B_d, C_d, A_h, B_h, C_h, false);
+  HipTest::freeArrays<int>(A_d, B_d, C_d, A_h, B_h, C_h, false);
   REQUIRE(Data_mismatch == 0);
 }
 
-/*
-This testcase verifies hipMemcpyAsync API
-Initializes device variables
-Launches kernel and performs the sum of device variables
-copies the result to host variable and validates the result.
-*/
-TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_KernelLaunch", "", int, float, double) {
-  size_t Nbytes = NUM_ELM * sizeof(TestType);
+// Change from TEMPLATE_TEST_CASE to TEST_CASE
+TEST_CASE("Unit_hipMemcpyAsync_KernelLaunch") {
+  size_t Nbytes = NUM_ELM * sizeof(int);
 
-  TestType *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr};
-  TestType *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr};
+  int *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr};
+  int *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr};
   HIP_CHECK(hipSetDevice(0));
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
@@ -109,8 +104,8 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_KernelLaunch", "", int, float, double) {
   HIP_CHECK(hipMemcpyAsync(B_d, B_h, Nbytes, hipMemcpyHostToDevice, stream));
   HIP_CHECK(hipStreamSynchronize(stream));
 
-  hipLaunchKernelGGL(HipTest::vectorADD, dim3(1), dim3(1), 0, 0, static_cast<const TestType*>(A_d),
-                     static_cast<const TestType*>(B_d), C_d, NUM_ELM);
+  hipLaunchKernelGGL(HipTest::vectorADD, dim3(1), dim3(1), 0, 0, static_cast<const int*>(A_d),
+                     static_cast<const int*>(B_d), C_d, NUM_ELM);
   HIP_CHECK(hipGetLastError());
   HIP_CHECK(hipMemcpyAsync(C_h, C_d, Nbytes, hipMemcpyDeviceToHost, stream));
   HIP_CHECK(hipStreamSynchronize(stream));
@@ -118,51 +113,41 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_KernelLaunch", "", int, float, double) {
 
   HipTest::checkVectorADD(A_h, B_h, C_h, NUM_ELM);
 
-  HipTest::freeArrays<TestType>(A_d, B_d, C_d, A_h, B_h, C_h, false);
+  HipTest::freeArrays<int>(A_d, B_d, C_d, A_h, B_h, C_h, false);
 }
-/*
-This testcase verifies the following scenarios
-1. H2H,H2PinMem and PinnedMem2Host
-2. H2D-D2D-D2H in same GPU
-3. Pinned Host Memory to device variables in same GPU
-4. Device context change
-5. H2D-D2D-D2H peer GPU
-*/
-TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_H2H-H2D-D2H-H2PinMem", "[multigpu]",
-                   char, int, float, double) {
-  TestType *A_d{nullptr}, *B_d{nullptr};
-  TestType *A_h{nullptr}, *B_h{nullptr};
-  TestType *A_Ph{nullptr}, *B_Ph{nullptr};
+
+// Change from TEMPLATE_TEST_CASE to TEST_CASE
+TEST_CASE("Unit_hipMemcpyAsync_H2H-H2D-D2H-H2PinMem", "[multigpu]") {
+  int *A_d{nullptr}, *B_d{nullptr};
+  int *A_h{nullptr}, *B_h{nullptr};
+  int *A_Ph{nullptr}, *B_Ph{nullptr};
   HIP_CHECK(hipSetDevice(0));
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
-  HipTest::initArrays<TestType>(&A_d, &B_d, nullptr, &A_h, &B_h, nullptr,
-                                NUM_ELM * sizeof(TestType));
-  HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &A_Ph, &B_Ph, nullptr,
-                                NUM_ELM * sizeof(TestType), true);
+  HipTest::initArrays<int>(&A_d, &B_d, nullptr, &A_h, &B_h, nullptr, NUM_ELM * sizeof(int));
+  HipTest::initArrays<int>(nullptr, nullptr, nullptr, &A_Ph, &B_Ph, nullptr, NUM_ELM * sizeof(int),
+                           true);
 
   SECTION("H2H, H2PinMem and PinMem2H") {
-    HIP_CHECK(hipMemcpyAsync(B_h, A_h, NUM_ELM * sizeof(TestType), hipMemcpyHostToHost, stream));
-    HIP_CHECK(hipMemcpyAsync(A_Ph, B_h, NUM_ELM * sizeof(TestType), hipMemcpyHostToHost, stream));
-    HIP_CHECK(hipMemcpyAsync(B_Ph, A_Ph, NUM_ELM * sizeof(TestType), hipMemcpyHostToHost, stream));
+    HIP_CHECK(hipMemcpyAsync(B_h, A_h, NUM_ELM * sizeof(int), hipMemcpyHostToHost, stream));
+    HIP_CHECK(hipMemcpyAsync(A_Ph, B_h, NUM_ELM * sizeof(int), hipMemcpyHostToHost, stream));
+    HIP_CHECK(hipMemcpyAsync(B_Ph, A_Ph, NUM_ELM * sizeof(int), hipMemcpyHostToHost, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
     HipTest::checkTest(A_h, B_Ph, NUM_ELM);
   }
 
   SECTION("H2D-D2D-D2H-SameGPU") {
-    HIP_CHECK(hipMemcpyAsync(A_d, A_h, NUM_ELM * sizeof(TestType), hipMemcpyHostToDevice, stream));
-    HIP_CHECK(
-        hipMemcpyAsync(B_d, A_d, NUM_ELM * sizeof(TestType), hipMemcpyDeviceToDevice, stream));
-    HIP_CHECK(hipMemcpyAsync(B_h, B_d, NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost, stream));
+    HIP_CHECK(hipMemcpyAsync(A_d, A_h, NUM_ELM * sizeof(int), hipMemcpyHostToDevice, stream));
+    HIP_CHECK(hipMemcpyAsync(B_d, A_d, NUM_ELM * sizeof(int), hipMemcpyDeviceToDevice, stream));
+    HIP_CHECK(hipMemcpyAsync(B_h, B_d, NUM_ELM * sizeof(int), hipMemcpyDeviceToHost, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
     HipTest::checkTest(A_h, B_h, NUM_ELM);
   }
 
   SECTION("pH2D-D2D-D2pH-SameGPU") {
-    HIP_CHECK(hipMemcpyAsync(A_d, A_Ph, NUM_ELM * sizeof(TestType), hipMemcpyHostToDevice, stream));
-    HIP_CHECK(
-        hipMemcpyAsync(B_d, A_d, NUM_ELM * sizeof(TestType), hipMemcpyDeviceToDevice, stream));
-    HIP_CHECK(hipMemcpyAsync(B_Ph, B_d, NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost, stream));
+    HIP_CHECK(hipMemcpyAsync(A_d, A_Ph, NUM_ELM * sizeof(int), hipMemcpyHostToDevice, stream));
+    HIP_CHECK(hipMemcpyAsync(B_d, A_d, NUM_ELM * sizeof(int), hipMemcpyDeviceToDevice, stream));
+    HIP_CHECK(hipMemcpyAsync(B_Ph, B_d, NUM_ELM * sizeof(int), hipMemcpyDeviceToHost, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
     HipTest::checkTest(A_Ph, B_Ph, NUM_ELM);
   }
@@ -176,12 +161,9 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_H2H-H2D-D2H-H2PinMem", "[multigpu]",
       HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, 0, 1));
       if (canAccessPeer) {
         HIP_CHECK(hipSetDevice(1));
-        HIP_CHECK(
-            hipMemcpyAsync(A_d, A_h, NUM_ELM * sizeof(TestType), hipMemcpyHostToDevice, stream));
-        HIP_CHECK(
-            hipMemcpyAsync(B_d, A_d, NUM_ELM * sizeof(TestType), hipMemcpyDeviceToDevice, stream));
-        HIP_CHECK(
-            hipMemcpyAsync(B_h, B_d, NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost, stream));
+        HIP_CHECK(hipMemcpyAsync(A_d, A_h, NUM_ELM * sizeof(int), hipMemcpyHostToDevice, stream));
+        HIP_CHECK(hipMemcpyAsync(B_d, A_d, NUM_ELM * sizeof(int), hipMemcpyDeviceToDevice, stream));
+        HIP_CHECK(hipMemcpyAsync(B_h, B_d, NUM_ELM * sizeof(int), hipMemcpyDeviceToHost, stream));
         HIP_CHECK(hipStreamSynchronize(stream));
         HipTest::checkTest(A_h, B_h, NUM_ELM);
 
@@ -201,15 +183,12 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_H2H-H2D-D2H-H2PinMem", "[multigpu]",
       HIP_CHECK(hipDeviceCanAccessPeer(&canAccessPeer, 0, 1));
       if (canAccessPeer) {
         HIP_CHECK(hipSetDevice(1));
-        TestType* C_d{nullptr};
-        HipTest::initArrays<TestType>(nullptr, nullptr, &C_d, nullptr, nullptr, nullptr,
-                                      NUM_ELM * sizeof(TestType));
-        HIP_CHECK(
-            hipMemcpyAsync(A_d, A_h, NUM_ELM * sizeof(TestType), hipMemcpyHostToDevice, stream));
-        HIP_CHECK(
-            hipMemcpyAsync(C_d, A_d, NUM_ELM * sizeof(TestType), hipMemcpyDeviceToDevice, stream));
-        HIP_CHECK(
-            hipMemcpyAsync(B_h, C_d, NUM_ELM * sizeof(TestType), hipMemcpyDeviceToHost, stream));
+        int* C_d{nullptr};
+        HipTest::initArrays<int>(nullptr, nullptr, &C_d, nullptr, nullptr, nullptr,
+                                 NUM_ELM * sizeof(int));
+        HIP_CHECK(hipMemcpyAsync(A_d, A_h, NUM_ELM * sizeof(int), hipMemcpyHostToDevice, stream));
+        HIP_CHECK(hipMemcpyAsync(C_d, A_d, NUM_ELM * sizeof(int), hipMemcpyDeviceToDevice, stream));
+        HIP_CHECK(hipMemcpyAsync(B_h, C_d, NUM_ELM * sizeof(int), hipMemcpyDeviceToHost, stream));
         HIP_CHECK(hipStreamSynchronize(stream));
         HipTest::checkTest(A_h, B_h, NUM_ELM);
         HIP_CHECK(hipFree(C_d));
@@ -222,21 +201,21 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_H2H-H2D-D2H-H2PinMem", "[multigpu]",
 
   HIP_CHECK(hipStreamDestroy(stream));
 
-  HipTest::freeArrays<TestType>(A_d, B_d, nullptr, A_h, B_h, nullptr, false);
-  HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, A_Ph, B_Ph, nullptr, true);
+  HipTest::freeArrays<int>(A_d, B_d, nullptr, A_h, B_h, nullptr, false);
+  HipTest::freeArrays<int>(nullptr, nullptr, nullptr, A_Ph, B_Ph, nullptr, true);
 }
 
 // This test launches multiple threads which uses same stream to deploy kernel
 // and also launch hipMemcpyAsync() api. This test case is simulate the scenario
 // reported in SWDEV-181598
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_hipMultiMemcpyMultiThread", "", int, float, double) {
-  size_t Nbytes = N_ELMTS * sizeof(TestType);
+TEST_CASE("Unit_hipMemcpyAsync_hipMultiMemcpyMultiThread") {
+  size_t Nbytes = N_ELMTS * sizeof(int);
 
   int Data_mismatch = 0;
   hipStream_t mystream;
-  TestType *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr};
-  TestType *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr};
+  int *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr};
+  int *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr};
 
   HipTest::initArrays(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, N_ELMTS, false);
 
@@ -245,7 +224,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_hipMultiMemcpyMultiThread", "", int, flo
 
   std::thread T[NUM_THREADS];
   for (int i = 0; i < NUM_THREADS; i++) {
-    T[i] = std::thread(Thread_func<TestType>, A_d, B_d, C_d, C_h, Nbytes, mystream);
+    T[i] = std::thread(Thread_func, A_d, B_d, C_d, C_h, Nbytes, mystream);
   }
 
   // Wait until all the threads finish their execution
@@ -264,15 +243,14 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_hipMultiMemcpyMultiThread", "", int, flo
   }
   REQUIRE(Thread_count.load() == NUM_THREADS);
   REQUIRE(Data_mismatch == 0);
-  HipTest::freeArrays<TestType>(A_d, B_d, C_d, A_h, B_h, C_h, false);
+  HipTest::freeArrays<int>(A_d, B_d, C_d, A_h, B_h, C_h, false);
   Thread_count.exchange(0);
 }
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_hipMultiMemcpyMultiThreadMultiStream", "", int, float,
-                   double) {
+TEST_CASE("Unit_hipMemcpyAsync_hipMultiMemcpyMultiThreadMultiStream") {
   std::thread T[NUM_THREADS];
   for (int i = 0; i < NUM_THREADS; i++) {
-    T[i] = std::thread(Thread_func_MultiStream<TestType>);
+    T[i] = std::thread(Thread_func_MultiStream);
   }
 
   // Wait until all the threads finish their execution
@@ -289,8 +267,7 @@ This testcase verifies hipMemcpy API with pinnedMemory and hostRegister
 along with kernel launches
 */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_PinnedRegMemWithKernelLaunch",
-                   "[multigpu]", int, float, double) {
+TEST_CASE("Unit_hipMemcpyAsync_PinnedRegMemWithKernelLaunch", "[multigpu]") {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {
@@ -299,30 +276,29 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_PinnedRegMemWithKernelLaunch",
     // 1 refers to pinned Memory
     // 2 refers to register Memory
     int MallocPinType = GENERATE(0, 1);
-    size_t Nbytes = NUM_ELM * sizeof(TestType);
+    size_t Nbytes = NUM_ELM * sizeof(int);
     unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, NUM_ELM);
 
-    TestType *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr};
-    TestType *X_d{nullptr}, *Y_d{nullptr}, *Z_d{nullptr};
-    TestType *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr};
+    int *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr};
+    int *X_d{nullptr}, *Y_d{nullptr}, *Z_d{nullptr};
+    int *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr};
     if (MallocPinType) {
       HipTest::initArrays(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, NUM_ELM, true);
     } else {
-      A_h = reinterpret_cast<TestType*>(malloc(Nbytes));
+      A_h = reinterpret_cast<int*>(malloc(Nbytes));
       HIP_CHECK(hipHostRegister(A_h, Nbytes, hipHostRegisterDefault));
-      B_h = reinterpret_cast<TestType*>(malloc(Nbytes));
+      B_h = reinterpret_cast<int*>(malloc(Nbytes));
       HIP_CHECK(hipHostRegister(B_h, Nbytes, hipHostRegisterDefault));
-      C_h = reinterpret_cast<TestType*>(malloc(Nbytes));
+      C_h = reinterpret_cast<int*>(malloc(Nbytes));
       HIP_CHECK(hipHostRegister(C_h, Nbytes, hipHostRegisterDefault));
-      HipTest::initArrays<TestType>(&A_d, &B_d, &C_d, nullptr, nullptr, nullptr, NUM_ELM, false);
-      HipTest::setDefaultData<TestType>(NUM_ELM, A_h, B_h, C_h);
+      HipTest::initArrays<int>(&A_d, &B_d, &C_d, nullptr, nullptr, nullptr, NUM_ELM, false);
+      HipTest::setDefaultData<int>(NUM_ELM, A_h, B_h, C_h);
     }
     HIP_CHECK(hipMemcpy(A_d, A_h, Nbytes, hipMemcpyHostToDevice));
     HIP_CHECK(hipMemcpy(B_d, B_h, Nbytes, hipMemcpyHostToDevice));
 
     hipLaunchKernelGGL(HipTest::vectorADD, dim3(blocks), dim3(threadsPerBlock), 0, 0,
-                       static_cast<const TestType*>(A_d), static_cast<const TestType*>(B_d), C_d,
-                       NUM_ELM);
+                       static_cast<const int*>(A_d), static_cast<const int*>(B_d), C_d, NUM_ELM);
     HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipMemcpy(C_h, C_d, Nbytes, hipMemcpyDeviceToHost));
     HipTest::checkVectorADD(A_h, B_h, C_h, NUM_ELM);
@@ -333,7 +309,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_PinnedRegMemWithKernelLaunch",
     int device;
     HIP_CHECK(hipGetDevice(&device));
     INFO("hipMemcpy is set to happen between device 0 and device " << device);
-    HipTest::initArrays<TestType>(&X_d, &Y_d, &Z_d, nullptr, nullptr, nullptr, NUM_ELM, false);
+    HipTest::initArrays<int>(&X_d, &Y_d, &Z_d, nullptr, nullptr, nullptr, NUM_ELM, false);
 
     hipStream_t gpu1Stream;
     HIP_CHECK(hipStreamCreate(&gpu1Stream));
@@ -350,8 +326,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_PinnedRegMemWithKernelLaunch",
     HIP_CHECK(hipMemcpyAsync(Y_d, B_h, Nbytes, hipMemcpyHostToDevice, gpu1Stream));
 
     hipLaunchKernelGGL(HipTest::vectorADD, dim3(blocks), dim3(threadsPerBlock), 0, 0,
-                       static_cast<const TestType*>(X_d), static_cast<const TestType*>(Y_d), Z_d,
-                       NUM_ELM);
+                       static_cast<const int*>(X_d), static_cast<const int*>(Y_d), Z_d, NUM_ELM);
     HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipMemcpyAsync(C_h, Z_d, Nbytes, hipMemcpyDeviceToHost, gpu1Stream));
     HIP_CHECK(hipStreamSynchronize(gpu1Stream));
@@ -359,7 +334,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_PinnedRegMemWithKernelLaunch",
     HipTest::checkVectorADD(A_h, B_h, C_h, NUM_ELM);
 
     if (MallocPinType) {
-      HipTest::freeArrays<TestType>(A_d, B_d, C_d, A_h, B_h, C_h, true);
+      HipTest::freeArrays<int>(A_d, B_d, C_d, A_h, B_h, C_h, true);
     } else {
       HIP_CHECK(hipHostUnregister(A_h));
       free(A_h);
@@ -367,9 +342,9 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyAsync_PinnedRegMemWithKernelLaunch",
       free(B_h);
       HIP_CHECK(hipHostUnregister(C_h));
       free(C_h);
-      HipTest::freeArrays<TestType>(A_d, B_d, C_d, nullptr, nullptr, nullptr, false);
+      HipTest::freeArrays<int>(A_d, B_d, C_d, nullptr, nullptr, nullptr, false);
     }
-    HipTest::freeArrays<TestType>(X_d, Y_d, Z_d, nullptr, nullptr, nullptr, false);
+    HipTest::freeArrays<int>(X_d, Y_d, Z_d, nullptr, nullptr, nullptr, false);
     HIP_CHECK(hipStreamDestroy(gpu1Stream));
   }
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyAtoH_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyAtoH_old.cc
@@ -43,29 +43,29 @@ Output:"B_h" host variable output of hipMemcpyAtoH API
 The same scenario is then verified with pinned host memory
 */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpyAtoH_Basic", "[hipMemcpyAtoH]", char, int, float) {
+TEST_CASE("Unit_hipMemcpyAtoH_Basic", "[hipMemcpyAtoH]") {
   CHECK_IMAGE_SUPPORT
 
   HIP_CHECK(hipSetDevice(0));
   // 1 refers to pinned host memory scenario
   auto memtype_check = GENERATE(0, 1);
   hipArray_t A_d;
-  TestType *hData{nullptr}, *B_h{nullptr};
-  size_t width{NUM_W * sizeof(TestType)};
+  int *hData{nullptr}, *B_h{nullptr};
+  size_t width{NUM_W * sizeof(int)};
 
   // Initialization of data
   if (memtype_check) {
-    HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &hData, &B_h, nullptr, NUM_W, true);
+    HipTest::initArrays<int>(nullptr, nullptr, nullptr, &hData, &B_h, nullptr, NUM_W, true);
   } else {
-    HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &hData, &B_h, nullptr, NUM_W);
+    HipTest::initArrays<int>(nullptr, nullptr, nullptr, &hData, &B_h, nullptr, NUM_W);
   }
-  HipTest::setDefaultData<TestType>(NUM_W, hData, B_h, nullptr);
-  hipChannelFormatDesc desc = hipCreateChannelDesc<TestType>();
+  HipTest::setDefaultData<int>(NUM_W, hData, B_h, nullptr);
+  hipChannelFormatDesc desc = hipCreateChannelDesc<int>();
   HIP_CHECK(hipMallocArray(&A_d, &desc, NUM_W, NUM_H, hipArrayDefault));
   HIP_CHECK(hipMemcpy2DToArray(A_d, 0, 0, hData, width, width, NUM_H, hipMemcpyHostToDevice));
 
   // Performing API call
-  REQUIRE(hipMemcpyAtoH(B_h, A_d, 0, copy_bytes * sizeof(TestType)) == hipSuccess);
+  REQUIRE(hipMemcpyAtoH(B_h, A_d, 0, copy_bytes * sizeof(int)) == hipSuccess);
 
   // Validating the result
   REQUIRE(HipTest::checkArray(B_h, hData, copy_bytes, NUM_H) == true);
@@ -73,10 +73,9 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyAtoH_Basic", "[hipMemcpyAtoH]", char, int, flo
   // DeAllocating the memory
   HIP_CHECK(hipFreeArray(A_d));
   if (memtype_check) {
-    REQUIRE(HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, hData, B_h, nullptr, true) ==
-            true);
+    REQUIRE(HipTest::freeArrays<int>(nullptr, nullptr, nullptr, hData, B_h, nullptr, true) == true);
   } else {
-    REQUIRE(HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, hData, B_h, nullptr, false) ==
+    REQUIRE(HipTest::freeArrays<int>(nullptr, nullptr, nullptr, hData, B_h, nullptr, false) ==
             true);
   }
 }
@@ -90,8 +89,7 @@ Output:"B_h" host variable output of hipMemcpyAtoH API
         is then validated with "hData"
 */
 #if HT_AMD
-TEMPLATE_TEST_CASE("Unit_hipMemcpyAtoH_multiDevice-PeerDeviceContext",
-                   "[hipMemcpyAtoH][multigpu]", char, int, float) {
+TEST_CASE("Unit_hipMemcpyAtoH_multiDevice-PeerDeviceContext", "[hipMemcpyAtoH][multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -104,13 +102,13 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyAtoH_multiDevice-PeerDeviceContext",
     } else {
       HIP_CHECK(hipSetDevice(0));
       hipArray_t A_d;
-      TestType *hData{nullptr}, *B_h{nullptr};
-      size_t width{NUM_W * sizeof(TestType)};
+      int *hData{nullptr}, *B_h{nullptr};
+      size_t width{NUM_W * sizeof(int)};
 
       // Initialization of data
-      HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &hData, &B_h, nullptr, NUM_W);
-      HipTest::setDefaultData<TestType>(NUM_W, hData, B_h, nullptr);
-      hipChannelFormatDesc desc = hipCreateChannelDesc<TestType>();
+      HipTest::initArrays<int>(nullptr, nullptr, nullptr, &hData, &B_h, nullptr, NUM_W);
+      HipTest::setDefaultData<int>(NUM_W, hData, B_h, nullptr);
+      hipChannelFormatDesc desc = hipCreateChannelDesc<int>();
       HIP_CHECK(hipMallocArray(&A_d, &desc, NUM_W, NUM_H, hipArrayDefault));
       HIP_CHECK(hipMemcpy2DToArray(A_d, 0, 0, hData, width, width, NUM_H, hipMemcpyHostToDevice));
 
@@ -119,14 +117,14 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyAtoH_multiDevice-PeerDeviceContext",
       HIP_CHECK(hipSetDevice(1));
 
       // Performing API call
-      REQUIRE(hipMemcpyAtoH(B_h, A_d, 0, copy_bytes * sizeof(TestType)) == hipSuccess);
+      REQUIRE(hipMemcpyAtoH(B_h, A_d, 0, copy_bytes * sizeof(int)) == hipSuccess);
       // Validating the result
       REQUIRE(HipTest::checkArray(B_h, hData, copy_bytes, NUM_H) == true);
 
       // DeAllocating the memory
       HIP_CHECK(hipFreeArray(A_d));
-      REQUIRE(HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, hData, B_h, nullptr,
-                                            false) == true);
+      REQUIRE(HipTest::freeArrays<int>(nullptr, nullptr, nullptr, hData, B_h, nullptr, false) ==
+              true);
     }
   } else {
     SUCCEED("skipping the testcases as numDevices < 2");

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -177,7 +177,7 @@ TEST_CASE("Unit_hipMemcpyBatchAsync_D2H_Functional") {
   const int val1 = 10;
   const int val2 = 4;
   // Allocate buffers for pointer-ptr copy
-  int* hostDstPtr[count];
+  int *hostDstPtr[count];
   void *deviceSrcPtr[count];
   std::vector<std::vector<int>> hostPtr(count, std::vector<int>(arrSize, val1));
   std::array<int, arrSize> arr;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -44,29 +44,20 @@
  *  - HIP_VERSION >= 7.1
  */
 #if HT_AMD
-TEMPLATE_TEST_CASE("Unit_hipMemcpyBatchAsync_D2D_Functional", "", char, int,
-                   float) {
+TEST_CASE("Unit_hipMemcpyBatchAsync_D2D_Functional") {
   const size_t count = 2;
   size_t numAttrs = 0;
   const size_t arrSize = 4096;
-  const size_t size = 4096 * sizeof(TestType);
+  const size_t size = 4096 * sizeof(int);
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
-  constexpr auto kfloatval1 = 2.25f;
-  constexpr auto kfloatval2 = 0.25f;
-  const TestType val1 = std::is_floating_point_v<TestType> ? kfloatval1
-                        : std::is_integral_v<TestType>     ? 10
-                                                           : 'a';
-  const TestType val2 = std::is_floating_point_v<TestType> ? kfloatval2
-                        : std::is_integral_v<TestType>     ? 4
-                                                           : 'b';
+  const int val1 = 10;
+  const int val2 = 4;
 
   // Allocate buffers for pointer-ptr copy
   void *srcPtr[count], *dstPtr[count];
-  std::vector<std::vector<TestType>> hostPtr1(
-      count, std::vector<TestType>(arrSize, val1));
-  std::vector<std::vector<TestType>> hostPtr2(
-      count, std::vector<TestType>(arrSize, val2));
+  std::vector<std::vector<int>> hostPtr1(count, std::vector<int>(arrSize, val1));
+  std::vector<std::vector<int>> hostPtr2(count, std::vector<int>(arrSize, val2));
   size_t sizes[2];
   size_t attrsIdxs[1];
   for (int i = 0; i < count; i++) {
@@ -115,28 +106,20 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyBatchAsync_D2D_Functional", "", char, int,
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEMPLATE_TEST_CASE("Unit_hipMemcpyBatchAsync_H2D_Functional", "", char, int,
-                   float) {
+TEST_CASE("Unit_hipMemcpyBatchAsync_H2D_Functional") {
   const size_t count = 2;
   size_t numAttrs = 0;
   const size_t arrSize = 4096;
-  const size_t size = 4096 * sizeof(TestType);
+  const size_t size = 4096 * sizeof(int);
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
 
   // Allocate buffers for pointer-ptr copy
   void *hostSrcPtr[count], *dstPtr[count];
-  constexpr auto kfloatval1 = 2.25f;
-  constexpr auto kfloatval2 = 0.25f;
-  const TestType val1 = std::is_floating_point_v<TestType> ? kfloatval1
-                        : std::is_integral_v<TestType>     ? 10
-                                                           : 'a';
-  const TestType val2 = std::is_floating_point_v<TestType> ? kfloatval2
-                        : std::is_integral_v<TestType>     ? 4
-                                                           : 'b';
-  std::vector<std::vector<TestType>> hostPtr(
-      count, std::vector<TestType>(arrSize, val2));
-  std::array<TestType, arrSize> arr;
+  const int val1 = 10;
+  const int val2 = 4;
+  std::vector<std::vector<int>> hostPtr(count, std::vector<int>(arrSize, val2));
+  std::array<int, arrSize> arr;
   arr.fill(val1);
   size_t sizes[2];
   size_t attrsIdxs[1];
@@ -183,29 +166,21 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyBatchAsync_H2D_Functional", "", char, int,
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEMPLATE_TEST_CASE("Unit_hipMemcpyBatchAsync_D2H_Functional", "", char, int,
-                   float) {
+TEST_CASE("Unit_hipMemcpyBatchAsync_D2H_Functional") {
   const size_t count = 2;
   size_t numAttrs = 0;
   const size_t arrSize = 4096;
-  const size_t size = 4096 * sizeof(TestType);
+  const size_t size = 4096 * sizeof(int);
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
 
-  constexpr auto kfloatval1 = 2.25f;
-  constexpr auto kfloatval2 = 0.25f;
-  const TestType val1 = std::is_floating_point_v<TestType> ? kfloatval1
-                        : std::is_integral_v<TestType>     ? 10
-                                                           : 'a';
-  const TestType val2 = std::is_floating_point_v<TestType> ? kfloatval2
-                        : std::is_integral_v<TestType>     ? 4
-                                                           : 'b';
+  const int val1 = 10;
+  const int val2 = 4;
   // Allocate buffers for pointer-ptr copy
-  TestType *hostDstPtr[count];
+  int* hostDstPtr[count];
   void *deviceSrcPtr[count];
-  std::vector<std::vector<TestType>> hostPtr(
-      count, std::vector<TestType>(arrSize, val1));
-  std::array<TestType, arrSize> arr;
+  std::vector<std::vector<int>> hostPtr(count, std::vector<int>(arrSize, val1));
+  std::array<int, arrSize> arr;
   arr.fill(val2);
   size_t sizes[2];
   size_t attrsIdxs[1];
@@ -253,26 +228,19 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyBatchAsync_D2H_Functional", "", char, int,
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-TEMPLATE_TEST_CASE("Unit_hipMemcpyBatchAsync_H2H_Functional", "", char, int,
-                   float) {
+TEST_CASE("Unit_hipMemcpyBatchAsync_H2H_Functional") {
   const size_t count = 2;
   size_t numAttrs = 0;
   const size_t arrSize = 4096;
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
 
-  constexpr auto kfloatval1 = 2.25;
-  const TestType val1 = std::is_floating_point_v<TestType> ? kfloatval1
-                        : std::is_integral_v<TestType>     ? 10
-                                                           : 'a';
-  constexpr auto kfloatval2 = 0.25f;
-  const TestType val2 = std::is_floating_point_v<TestType> ? kfloatval2
-                        : std::is_integral_v<TestType>     ? 4
-                                                           : 'b';
+  const int val1 = 10;
+  const int val2 = 4;
 
   // Allocate buffers for pointer-ptr copy
-  TestType *hostDstPtr[count], *hostSrcPtr[count];
-  std::array<TestType, arrSize> arr1, arr2;
+  int *hostDstPtr[count], *hostSrcPtr[count];
+  std::array<int, arrSize> arr1, arr2;
   arr1.fill(val1);
   arr2.fill(val2);
   size_t sizes[2];
@@ -280,7 +248,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyBatchAsync_H2H_Functional", "", char, int,
   for (int i = 0; i < count; i++) {
     hostDstPtr[i] = arr1.data();
     hostSrcPtr[i] = arr2.data();
-    sizes[i] = arrSize * sizeof(TestType);
+    sizes[i] = arrSize * sizeof(int);
   }
   attrsIdxs[0] = 0;
   size_t failIdx;

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyDtoA.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyDtoA.cc
@@ -23,19 +23,19 @@ THE SOFTWARE.
 
 #define N 32
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpyDtoA_Basic", "", char, int, float) {
+TEST_CASE("Unit_hipMemcpyDtoA_Basic") {
   CHECK_IMAGE_SUPPORT
 
   hipArray_t dst_array = nullptr;
   hipDeviceptr_t src_device;
-  std::vector<TestType> src_host(N);
-  std::vector<TestType> dst_host(N);
-  size_t copy_size = N * sizeof(TestType);
-  size_t offset = GENERATE(0, N * sizeof(TestType) / 2);
+  std::vector<int> src_host(N);
+  std::vector<int> dst_host(N);
+  size_t copy_size = N * sizeof(int);
+  size_t offset = GENERATE(0, N * sizeof(int) / 2);
 
   std::iota(src_host.begin(), src_host.end(), 0);
 
-  auto channel_descriptor = hipCreateChannelDesc<TestType>();
+  auto channel_descriptor = hipCreateChannelDesc<int>();
   HIP_CHECK(hipMallocArray(&dst_array, &channel_descriptor, copy_size));
   HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&src_device), copy_size));
 
@@ -43,7 +43,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyDtoA_Basic", "", char, int, float) {
   HIP_CHECK(hipMemcpyDtoA(dst_array, offset, src_device, copy_size - offset));
   HIP_CHECK(hipMemcpyAtoH(dst_host.data(), dst_array, offset, copy_size - offset));
 
-  for (int index = 0; index < offset / sizeof(TestType); index++) {
+  for (int index = 0; index < offset / sizeof(int); index++) {
     if (src_host[index] != dst_host[index]) {
       REQUIRE(false);
     }

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyDtoDAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyDtoDAsync.cc
@@ -40,12 +40,11 @@ This testcase verifies hipMemcpyDtoDAsync API
 7.DtoH copy and validating the result
 */
 
-TEMPLATE_TEST_CASE("Unit_hipMemcpyDtoDAsync_Basic", "[multigpu]", int, float,
-                   double) {
-  size_t Nbytes = NUM_ELM * sizeof(TestType);
+TEST_CASE("Unit_hipMemcpyDtoDAsync_Basic", "[multigpu]") {
+  size_t Nbytes = NUM_ELM * sizeof(int);
   int numDevices = 0;
-  TestType *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr}, *X_d{nullptr}, *Y_d{nullptr}, *Z_d{nullptr};
-  TestType *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr};
+  int *A_d{nullptr}, *B_d{nullptr}, *C_d{nullptr}, *X_d{nullptr}, *Y_d{nullptr}, *Z_d{nullptr};
+  int *A_h{nullptr}, *B_h{nullptr}, *C_h{nullptr};
   hipStream_t stream;
 
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -58,7 +57,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyDtoDAsync_Basic", "[multigpu]", int, float,
     } else {
       INFO("Machine does not have P2P Capabilities");
     }
-    HipTest::initArrays<TestType>(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, NUM_ELM, false);
+    HipTest::initArrays<int>(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, NUM_ELM, false);
     HIP_CHECK(hipSetDevice(1));
     HIP_CHECK(hipMalloc(&X_d, Nbytes));
     HIP_CHECK(hipMalloc(&Y_d, Nbytes));
@@ -67,13 +66,12 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyDtoDAsync_Basic", "[multigpu]", int, float,
     HIP_CHECK(hipSetDevice(0));
     HIP_CHECK(hipMemcpy(A_d, A_h, Nbytes, hipMemcpyHostToDevice));
     HIP_CHECK(hipMemcpy(B_d, B_h, Nbytes, hipMemcpyHostToDevice));
-    hipLaunchKernelGGL(HipTest::vectorADD, dim3(1), dim3(1), 0, 0,
-                       static_cast<const TestType*>(A_d), static_cast<const TestType*>(B_d), C_d,
-                       NUM_ELM);
+    hipLaunchKernelGGL(HipTest::vectorADD, dim3(1), dim3(1), 0, 0, static_cast<const int*>(A_d),
+                       static_cast<const int*>(B_d), C_d, NUM_ELM);
     HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipMemcpy(C_h, C_d, Nbytes, hipMemcpyDeviceToHost));
     HIP_CHECK(hipDeviceSynchronize());
-    HipTest::checkVectorADD<TestType>(A_h, B_h, C_h, NUM_ELM);
+    HipTest::checkVectorADD<int>(A_h, B_h, C_h, NUM_ELM);
 
     HIP_CHECK(hipSetDevice(1));
     HIP_CHECK(hipStreamCreate(&stream));
@@ -81,16 +79,15 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyDtoDAsync_Basic", "[multigpu]", int, float,
     HIP_CHECK(hipMemcpyDtoDAsync((hipDeviceptr_t)Y_d, (hipDeviceptr_t)B_d, Nbytes, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
 
-    hipLaunchKernelGGL(HipTest::vectorADD, dim3(1), dim3(1), 0, 0,
-                       static_cast<const TestType*>(X_d), static_cast<const TestType*>(Y_d), Z_d,
-                       NUM_ELM);
+    hipLaunchKernelGGL(HipTest::vectorADD, dim3(1), dim3(1), 0, 0, static_cast<const int*>(X_d),
+                       static_cast<const int*>(Y_d), Z_d, NUM_ELM);
     HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipMemcpyDtoHAsync(C_h, (hipDeviceptr_t)Z_d, Nbytes, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
     HIP_CHECK(hipDeviceSynchronize());
-    HipTest::checkVectorADD<TestType>(A_h, B_h, C_h, NUM_ELM);
+    HipTest::checkVectorADD<int>(A_h, B_h, C_h, NUM_ELM);
 
-    HipTest::freeArrays<TestType>(A_d, B_d, C_d, A_h, B_h, C_h, false);
+    HipTest::freeArrays<int>(A_d, B_d, C_d, A_h, B_h, C_h, false);
     HIP_CHECK(hipFree(X_d));
     HIP_CHECK(hipFree(Y_d));
     HIP_CHECK(hipFree(Z_d));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyHtoA_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyHtoA_old.cc
@@ -43,30 +43,30 @@ Output: "A_d" output of hipMemcpyHtoA is copied to "hData" host variable
 
 The same scenario is then verified with pinned host memory
 */
-TEMPLATE_TEST_CASE("Unit_hipMemcpyHtoA_Basic", "[hipMemcpyHtoA]", char, int, float) {
+TEST_CASE("Unit_hipMemcpyHtoA_Basic", "[hipMemcpyHtoA]") {
   CHECK_IMAGE_SUPPORT
 
   HIP_CHECK(hipSetDevice(0));
   auto memtype_check = GENERATE(0, 1);
   hipArray_t A_d;
-  TestType *hData{nullptr}, *B_h{nullptr};
-  size_t width{NUM_W * sizeof(TestType)};
+  int *hData{nullptr}, *B_h{nullptr};
+  size_t width{NUM_W * sizeof(int)};
 
   // Initialization of data
   if (memtype_check) {
-    HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &hData, &B_h, nullptr, NUM_W, true);
+    HipTest::initArrays<int>(nullptr, nullptr, nullptr, &hData, &B_h, nullptr, NUM_W, true);
   } else {
-    HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &hData, &B_h, nullptr, NUM_W);
+    HipTest::initArrays<int>(nullptr, nullptr, nullptr, &hData, &B_h, nullptr, NUM_W);
   }
-  HipTest::setDefaultData<TestType>(NUM_W, hData, B_h, nullptr);
-  hipChannelFormatDesc desc = hipCreateChannelDesc<TestType>();
+  HipTest::setDefaultData<int>(NUM_W, hData, B_h, nullptr);
+  hipChannelFormatDesc desc = hipCreateChannelDesc<int>();
   HIP_CHECK(hipMallocArray(&A_d, &desc, NUM_W, NUM_H, hipArrayDefault));
   HIP_CHECK(hipMemcpy2DToArray(A_d, 0, 0, hData, width, width, NUM_H, hipMemcpyHostToDevice));
 
   // Performing API call
-  HIP_CHECK(hipMemcpyHtoA(A_d, 0, B_h, copy_bytes * sizeof(TestType)));
-  HIP_CHECK(hipMemcpy2DFromArray(hData, sizeof(TestType) * NUM_W, A_d, 0, 0,
-                                 sizeof(TestType) * NUM_W, 1, hipMemcpyDeviceToHost));
+  HIP_CHECK(hipMemcpyHtoA(A_d, 0, B_h, copy_bytes * sizeof(int)));
+  HIP_CHECK(hipMemcpy2DFromArray(hData, sizeof(int) * NUM_W, A_d, 0, 0, sizeof(int) * NUM_W, 1,
+                                 hipMemcpyDeviceToHost));
 
 
   // Validating the result
@@ -75,10 +75,9 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyHtoA_Basic", "[hipMemcpyHtoA]", char, int, flo
   // DeAllocating the memory
   HIP_CHECK(hipFreeArray(A_d));
   if (memtype_check) {
-    REQUIRE(HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, hData, B_h, nullptr, true) ==
-            true);
+    REQUIRE(HipTest::freeArrays<int>(nullptr, nullptr, nullptr, hData, B_h, nullptr, true) == true);
   } else {
-    REQUIRE(HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, hData, B_h, nullptr, false) ==
+    REQUIRE(HipTest::freeArrays<int>(nullptr, nullptr, nullptr, hData, B_h, nullptr, false) ==
             true);
   }
 }
@@ -93,8 +92,7 @@ Output: "A_d" output of hipMemcpyHtoA is copied to "hData" host variable
         validated the result with "B_h"
 */
 #if HT_AMD
-TEMPLATE_TEST_CASE("Unit_hipMemcpyHtoA_multiDevice-PeerDeviceContext",
-                   "[hipMemcpyHtoA][multigpu]", char, int, float) {
+TEST_CASE("Unit_hipMemcpyHtoA_multiDevice-PeerDeviceContext", "[hipMemcpyHtoA][multigpu]") {
   CHECK_IMAGE_SUPPORT
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
@@ -106,13 +104,13 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyHtoA_multiDevice-PeerDeviceContext",
     } else {
       HIP_CHECK(hipSetDevice(0));
       hipArray_t A_d;
-      TestType *hData{nullptr}, *B_h{nullptr};
-      size_t width{NUM_W * sizeof(TestType)};
+      int *hData{nullptr}, *B_h{nullptr};
+      size_t width{NUM_W * sizeof(int)};
 
       // Initialization of data
-      HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &hData, &B_h, nullptr, NUM_W);
-      HipTest::setDefaultData<TestType>(NUM_W, hData, B_h, nullptr);
-      hipChannelFormatDesc desc = hipCreateChannelDesc<TestType>();
+      HipTest::initArrays<int>(nullptr, nullptr, nullptr, &hData, &B_h, nullptr, NUM_W);
+      HipTest::setDefaultData<int>(NUM_W, hData, B_h, nullptr);
+      hipChannelFormatDesc desc = hipCreateChannelDesc<int>();
       HIP_CHECK(hipMallocArray(&A_d, &desc, NUM_W, NUM_H, hipArrayDefault));
       HIP_CHECK(hipMemcpy2DToArray(A_d, 0, 0, hData, width, width, NUM_H, hipMemcpyHostToDevice));
 
@@ -120,17 +118,17 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyHtoA_multiDevice-PeerDeviceContext",
       HIP_CHECK(hipSetDevice(1));
 
       // Performing API call
-      HIP_CHECK(hipMemcpyHtoA(A_d, 0, B_h, copy_bytes * sizeof(TestType)));
-      HIP_CHECK(hipMemcpy2DFromArray(hData, sizeof(TestType) * NUM_W, A_d, 0, 0,
-                                     sizeof(TestType) * NUM_W, 1, hipMemcpyDeviceToHost));
+      HIP_CHECK(hipMemcpyHtoA(A_d, 0, B_h, copy_bytes * sizeof(int)));
+      HIP_CHECK(hipMemcpy2DFromArray(hData, sizeof(int) * NUM_W, A_d, 0, 0, sizeof(int) * NUM_W, 1,
+                                     hipMemcpyDeviceToHost));
 
       // Validating the result
       REQUIRE(HipTest::checkArray(B_h, hData, copy_bytes, NUM_H) == true);
 
       // DeAllocating the memory
       HIP_CHECK(hipFreeArray(A_d));
-      REQUIRE(HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, hData, B_h, nullptr,
-                                            false) == true);
+      REQUIRE(HipTest::freeArrays<int>(nullptr, nullptr, nullptr, hData, B_h, nullptr, false) ==
+              true);
     }
   } else {
     SUCCEED("skipping the testcases as numDevices < 2");

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyParam2D_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyParam2D_old.cc
@@ -39,9 +39,7 @@ static constexpr size_t NUM_H{10};
  * it with the initalized data "C_h".
  *
  */
-TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2D_multiDevice-D2D",
-                   "[hipMemcpyParam2D][multigpu]", char, float, int, double,
-                   long double) {
+TEST_CASE("Unit_hipMemcpyParam2D_multiDevice-D2D", "[hipMemcpyParam2D][multigpu]") {
   CHECK_IMAGE_SUPPORT
 
   int numDevices = 0;
@@ -49,13 +47,12 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2D_multiDevice-D2D",
   if (numDevices > 1) {
     // Initialize and Allocating Memory
     HIP_CHECK(hipSetDevice(0));
-    TestType *A_h{nullptr}, *C_h{nullptr}, *A_d{nullptr};
+    int *A_h{nullptr}, *C_h{nullptr}, *A_d{nullptr};
     size_t pitch_A;
-    size_t width{NUM_W * sizeof(TestType)};
+    size_t width{NUM_W * sizeof(int)};
     HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&A_d), &pitch_A, width, NUM_H));
-    HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &A_h, nullptr, &C_h, width * NUM_H,
-                                  false);
-    HipTest::setDefaultData<TestType>(NUM_W * NUM_H, A_h, nullptr, C_h);
+    HipTest::initArrays<int>(nullptr, nullptr, nullptr, &A_h, nullptr, &C_h, width * NUM_H, false);
+    HipTest::setDefaultData<int>(NUM_W * NUM_H, A_h, nullptr, C_h);
 
     int peerAccess = 0;
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 1, 0));
@@ -68,8 +65,8 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2D_multiDevice-D2D",
       HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&E_d), &pitch_E, width, NUM_H));
 
       // Initalizing A_d with C_h
-      HIP_CHECK(hipMemcpy2D(A_d, pitch_A, C_h, width, NUM_W * sizeof(TestType), NUM_H,
-                            hipMemcpyHostToDevice));
+      HIP_CHECK(
+          hipMemcpy2D(A_d, pitch_A, C_h, width, NUM_W * sizeof(int), NUM_H, hipMemcpyHostToDevice));
 
       // Device to Device
       hip_Memcpy2D desc = {};
@@ -81,20 +78,20 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2D_multiDevice-D2D",
       desc.dstHost = E_d;
       desc.dstDevice = hipDeviceptr_t(E_d);
       desc.dstPitch = pitch_E;
-      desc.WidthInBytes = NUM_W * sizeof(TestType);
+      desc.WidthInBytes = NUM_W * sizeof(int);
       desc.Height = NUM_H;
       REQUIRE(hipMemcpyParam2D(&desc) == hipSuccess);
 
       // Copying E_d to A_h
-      HIP_CHECK(hipMemcpy2D(A_h, width, E_d, pitch_E, NUM_W * sizeof(TestType), NUM_H,
-                            hipMemcpyDeviceToHost));
+      HIP_CHECK(
+          hipMemcpy2D(A_h, width, E_d, pitch_E, NUM_W * sizeof(int), NUM_H, hipMemcpyDeviceToHost));
 
       // Validating the result
-      REQUIRE(HipTest::checkArray<TestType>(A_h, C_h, NUM_W, NUM_H) == true);
+      REQUIRE(HipTest::checkArray<int>(A_h, C_h, NUM_W, NUM_H) == true);
 
       // DeAllocating the memory
       HIP_CHECK(hipFree(A_d));
-      HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, A_h, nullptr, C_h, false);
+      HipTest::freeArrays<int>(nullptr, nullptr, nullptr, A_h, nullptr, C_h, false);
     }
   } else {
     SUCCEED("skipping the testcases as numDevices < 2");
@@ -113,8 +110,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2D_multiDevice-D2D",
  *
  * Validating the result by comparing "A_h" to "C_h"
  */
-TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2D_multiDevice-H2D-D2H", "[hipMemcpyParam2D]", char, float,
-                   int, double, long double) {
+TEST_CASE("Unit_hipMemcpyParam2D_multiDevice-H2D-D2H", "[hipMemcpyParam2D]") {
   CHECK_IMAGE_SUPPORT
 
   // 1 refers to pinned host memory and 0 refers
@@ -126,21 +122,20 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2D_multiDevice-H2D-D2H", "[hipMemcpyParam
     HIP_CHECK(hipSetDevice(0));
 
     // Initialize and Allocating Memory
-    TestType *A_h{nullptr}, *C_h{nullptr}, *A_d{nullptr};
+    int *A_h{nullptr}, *C_h{nullptr}, *A_d{nullptr};
     size_t pitch_A;
-    size_t width{NUM_W * sizeof(TestType)};
+    size_t width{NUM_W * sizeof(int)};
 
     HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&A_d), &pitch_A, width, NUM_H));
 
     // Based on memory type (pinned/unpinned) allocating memory
     if (memory_type) {
-      HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &A_h, nullptr, &C_h, width * NUM_H,
-                                    true);
+      HipTest::initArrays<int>(nullptr, nullptr, nullptr, &A_h, nullptr, &C_h, width * NUM_H, true);
     } else {
-      HipTest::initArrays<TestType>(nullptr, nullptr, nullptr, &A_h, nullptr, &C_h, width * NUM_H,
-                                    false);
+      HipTest::initArrays<int>(nullptr, nullptr, nullptr, &A_h, nullptr, &C_h, width * NUM_H,
+                               false);
     }
-    HipTest::setDefaultData<TestType>(NUM_W * NUM_H, A_h, nullptr, C_h);
+    HipTest::setDefaultData<int>(NUM_W * NUM_H, A_h, nullptr, C_h);
     int peerAccess = 0;
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 1, 0));
     if (!peerAccess) {
@@ -156,7 +151,7 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2D_multiDevice-H2D-D2H", "[hipMemcpyParam
       desc.dstHost = A_d;
       desc.dstDevice = hipDeviceptr_t(A_d);
       desc.dstPitch = pitch_A;
-      desc.WidthInBytes = NUM_W * sizeof(TestType);
+      desc.WidthInBytes = NUM_W * sizeof(int);
       desc.Height = NUM_H;
       REQUIRE(hipMemcpyParam2D(&desc) == hipSuccess);
 
@@ -170,19 +165,19 @@ TEMPLATE_TEST_CASE("Unit_hipMemcpyParam2D_multiDevice-H2D-D2H", "[hipMemcpyParam
       desc.dstHost = A_h;
       desc.dstDevice = hipDeviceptr_t(A_h);
       desc.dstPitch = width;
-      desc.WidthInBytes = NUM_W * sizeof(TestType);
+      desc.WidthInBytes = NUM_W * sizeof(int);
       desc.Height = NUM_H;
       REQUIRE(hipMemcpyParam2D(&desc) == hipSuccess);
 
       // Validating the result
-      REQUIRE(HipTest::checkArray<TestType>(A_h, C_h, NUM_W, NUM_H) == true);
+      REQUIRE(HipTest::checkArray<int>(A_h, C_h, NUM_W, NUM_H) == true);
 
       // DeAllocating the Memory
       HIP_CHECK(hipFree(A_d));
       if (memory_type) {
-        HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, A_h, nullptr, C_h, true);
+        HipTest::freeArrays<int>(nullptr, nullptr, nullptr, A_h, nullptr, C_h, true);
       } else {
-        HipTest::freeArrays<TestType>(nullptr, nullptr, nullptr, A_h, nullptr, C_h, false);
+        HipTest::freeArrays<int>(nullptr, nullptr, nullptr, A_h, nullptr, C_h, false);
       }
     }
   } else {


### PR DESCRIPTION
## Motivation

Most memcpy tests are type invariant, inside HIP we don't consider the underlying type but instead handle patterns and addresses. Some tests are re-ran with multiple test types, this is not necessary. This PR removes TEMPLATE_TEST_CASE's and replaces them with faster single type tests.

## Technical Details

Memory operations don't care about types, we are interested in sizes and alignements. The existing tests can be sped up while maintaining functionality by not checking multiple types.

## JIRA ID

Contributes to SWDEV-572673

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
