### PR TITLE
SWDEV-572673 - Reduce stream value tests into one test

### DIFF
--- a/projects/hip-tests/catch/unit/stream/hipStreamValue.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamValue.cc
@@ -354,119 +354,216 @@ void testWait(TEST_WAIT<typename TestType::UIntType> tc) {
   HIP_CHECK(hipStreamDestroy(stream));
 }
 
-// TEMPLATE_TEST_CASE wasn't working within a macro, so sections were used instead
-#define DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT32(suffix, test_t)                                    \
-  TEST_CASE("Unit_hipStreamValue_Wait32_Blocking_" + std::string(suffix)) {                        \
-    SECTION("HostPtr") { testWait<TestParams<uint32_t, PtrType::HostPtr>, true>(test_t); }         \
-    SECTION("DevicePtr") { testWait<TestParams<uint32_t, PtrType::DevicePtr>, true>(test_t); }     \
-    SECTION("DevicePtrToHost") {                                                                   \
-      testWait<TestParams<uint32_t, PtrType::DevicePtrToHost>, true>(test_t);                      \
-    }                                                                                              \
-  }                                                                                                \
-  TEST_CASE("Unit_hipStreamValue_Wait32_NonBlocking_" + std::string(suffix)) {                     \
-    SECTION("HostPtr") { testWait<TestParams<uint32_t, PtrType::HostPtr>, false>(test_t); }        \
-    SECTION("DevicePtr") { testWait<TestParams<uint32_t, PtrType::DevicePtr>, false>(test_t); }    \
-    SECTION("DevicePtrToHost") {                                                                   \
-      testWait<TestParams<uint32_t, PtrType::DevicePtrToHost>, false>(test_t);                     \
-    }                                                                                              \
+// Combined blocking test case for both uint32_t and uint64_t
+TEMPLATE_TEST_CASE("Unit_hipStreamValue_Wait_Blocking", "", uint32_t, uint64_t) {
+  if (!streamWaitValueSupported()) {
+    HipTest::HIP_SKIP_TEST("hipStreamWaitValue not supported on this device.");
+    return;
   }
 
+  using UIntT = TestType;
+  using TestWaitType = TEST_WAIT<UIntT>;
 
-// Using Mask
-DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT32("Mask_Gte",
-                                        TEST_WAIT32(hipStreamWaitValueGte, 0xF, 0x4, 0x3, 0x6))
-DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT32("Mask_Eq_1",
-                                        TEST_WAIT32(  // mask will ignore few MSB bits
-                                            hipStreamWaitValueEq, 0x0000FFFF, 0x00000001,
-                                            0x0FFF0000, 0x0FFF0001))
-DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT32("Mask_Eq_2",
-                                        TEST_WAIT32(hipStreamWaitValueEq, 0xFF, 0x11, 0x25, 0x11))
-DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT32("Mask_And",
-                                        TEST_WAIT32(  // mask will discard bits 8 to 11
-                                            hipStreamWaitValueAnd, 0xFF, 0xF4A, 0xF35, 0X02))
-
-// Not Using Mask
-DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT32("NoMask_Eq", TEST_WAIT32(hipStreamWaitValueEq, 0x7FFFFFFF,
-                                                                 0x7FFF0000, 0x7FFFFFFF))
-DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT32("NoMask_Gte", TEST_WAIT32(hipStreamWaitValueGte, 0x7FFF0001,
-                                                                  0x7FFF0000, 0x7FFF0010))
-DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT32("NoMask_And", TEST_WAIT32(hipStreamWaitValueAnd, 0x70F0F0F0,
-                                                                  0x0F0F0F0F, 0X1F0F0F0F))
-DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT32("NoMask_Nor", TEST_WAIT32(hipStreamWaitValueNor, 0x7AAAAAAA,
-                                                                  0x85555555, 0x9AAAAAAA))
-
-#undef DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT32
-
+  SECTION("Mask_Gte") {
+    TestWaitType testCase(hipStreamWaitValueGte, 0xF, 0x4, 0x3, 0x6);
+    
+    SECTION("HostPtr") { 
+      testWait<TestParams<UIntT, PtrType::HostPtr>, true>(testCase); 
+    }
+    SECTION("DevicePtr") { 
+      testWait<TestParams<UIntT, PtrType::DevicePtr>, true>(testCase); 
+    }
+    SECTION("DevicePtrToHost") { 
+      testWait<TestParams<UIntT, PtrType::DevicePtrToHost>, true>(testCase); 
+    }
 #if HT_AMD
-// TEMPLATE_TEST_CASE wasn't working within a macro, so sections were used instead
-#define DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT64(suffix, test_t)                                    \
-  TEST_CASE("Unit_hipStreamValue_Wait64_Blocking_" + std::string(suffix)) {                        \
-    SECTION("HostPtr") { testWait<TestParams<uint64_t, PtrType::HostPtr>, true>(test_t); }         \
-    SECTION("DevicePtr") { testWait<TestParams<uint64_t, PtrType::DevicePtr>, true>(test_t); }     \
-    SECTION("DevicePtrToHost") {                                                                   \
-      testWait<TestParams<uint64_t, PtrType::DevicePtrToHost>, true>(test_t);                      \
-    }                                                                                              \
-    SECTION("Signal") { testWait<TestParams<uint64_t, PtrType::Signal>, true>(test_t); }           \
-  }                                                                                                \
-  TEST_CASE("Unit_hipStreamValue_Wait64_NonBlocking_" + std::string(suffix)) {                     \
-    SECTION("HostPtr") { testWait<TestParams<uint64_t, PtrType::HostPtr>, false>(test_t); }        \
-    SECTION("DevicePtr") { testWait<TestParams<uint64_t, PtrType::DevicePtr>, false>(test_t); }    \
-    SECTION("DevicePtrToHost") {                                                                   \
-      testWait<TestParams<uint64_t, PtrType::DevicePtrToHost>, false>(test_t);                     \
-    }                                                                                              \
-    SECTION("Signal") { testWait<TestParams<uint64_t, PtrType::Signal>, false>(test_t); }          \
-  }
-#else
-#define DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT64(suffix, test_t)                                    \
-  TEST_CASE("Unit_hipStreamValue_Wait64_Blocking_" + std::string(suffix)) {                        \
-    SECTION("HostPtr") { testWait<TestParams<uint64_t, PtrType::HostPtr>, true>(test_t); }         \
-    SECTION("DevicePtr") { testWait<TestParams<uint64_t, PtrType::DevicePtr>, true>(test_t); }     \
-    SECTION("DevicePtrToHost") {                                                                   \
-      testWait<TestParams<uint64_t, PtrType::DevicePtrToHost>, true>(test_t);                      \
-    }                                                                                              \
-  }                                                                                                \
-  TEST_CASE("Unit_hipStreamValue_Wait64_NonBlocking_" + std::string(suffix)) {                     \
-    SECTION("HostPtr") { testWait<TestParams<uint64_t, PtrType::HostPtr>, false>(test_t); }        \
-    SECTION("DevicePtr") { testWait<TestParams<uint64_t, PtrType::DevicePtr>, false>(test_t); }    \
-    SECTION("DevicePtrToHost") {                                                                   \
-      testWait<TestParams<uint64_t, PtrType::DevicePtrToHost>, false>(test_t);                     \
-    }                                                                                              \
-  }
+    if constexpr (std::is_same_v<UIntT, uint64_t>) {
+      SECTION("Signal") { 
+        testWait<TestParams<UIntT, PtrType::Signal>, true>(testCase); 
+      }
+    }
 #endif
+  }
 
+  if constexpr (std::is_same_v<UIntT, uint64_t>) {
+    SECTION("Mask_Gte_1") {
+      TestWaitType testCase(hipStreamWaitValueGte, 0x0000FFFFFFFFFFFF, 0x000000007FFF0001, 
+                            0x7FFF00007FFF0000, 0x000000007FFF0001);
+      SECTION("HostPtr") { 
+        testWait<TestParams<UIntT, PtrType::HostPtr>, true>(testCase); 
+      }
+      SECTION("DevicePtr") { 
+        testWait<TestParams<UIntT, PtrType::DevicePtr>, true>(testCase); 
+      }
+      SECTION("DevicePtrToHost") { 
+        testWait<TestParams<UIntT, PtrType::DevicePtrToHost>, true>(testCase); 
+      }
+#if HT_AMD
+      SECTION("Signal") { 
+        testWait<TestParams<UIntT, PtrType::Signal>, true>(testCase); 
+      }
+#endif
+    }
+  }
 
-// Using Mask
-DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT64("Mask_Gte_1",
-                                        TEST_WAIT64(  // mask will ignore few MSB bits
-                                            hipStreamWaitValueGte, 0x0000FFFFFFFFFFFF,
-                                            0x000000007FFF0001, 0x7FFF00007FFF0000,
-                                            0x000000007FFF0001))
-DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT64("Mask_Gte_2",
-                                        TEST_WAIT64(hipStreamWaitValueGte, 0xF, 0x4, 0x3, 0x6))
-DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT64("Mask_Eq_1",
-                                        TEST_WAIT64(  // mask will ignore few MSB bits
-                                            hipStreamWaitValueEq, 0x0000FFFFFFFFFFFF,
-                                            0x000000000FFF0001, 0x7FFF00000FFF0000,
-                                            0x7F0000000FFF0001))
-DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT64("Mask_Eq_2",
-                                        TEST_WAIT64(hipStreamWaitValueEq, 0xFF, 0x11, 0x25, 0x11))
-DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT64("Mask_And",
-                                        TEST_WAIT64(  // mask will discard bits 8 to 11
-                                            hipStreamWaitValueAnd, 0xFF, 0xF4A, 0xF35, 0X02))
+  SECTION("Mask_Eq_1") {
+    TestWaitType testCase = std::is_same_v<UIntT, uint32_t>
+      ? TestWaitType(hipStreamWaitValueEq, 0x0000FFFF, 0x00000001, 0x0FFF0000, 0x0FFF0001)
+      : TestWaitType(hipStreamWaitValueEq, 0x0000FFFFFFFFFFFF, 0x000000000FFF0001, 
+                     0x7FFF00000FFF0000, 0x7F0000000FFF0001);
+    
+    SECTION("HostPtr") { 
+      testWait<TestParams<UIntT, PtrType::HostPtr>, true>(testCase); 
+    }
+    SECTION("DevicePtr") { 
+      testWait<TestParams<UIntT, PtrType::DevicePtr>, true>(testCase); 
+    }
+    SECTION("DevicePtrToHost") { 
+      testWait<TestParams<UIntT, PtrType::DevicePtrToHost>, true>(testCase); 
+    }
+#if HT_AMD
+    if constexpr (std::is_same_v<UIntT, uint64_t>) {
+      SECTION("Signal") { 
+        testWait<TestParams<UIntT, PtrType::Signal>, true>(testCase); 
+      }
+    }
+#endif
+  }
 
-DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT64("NoMask_Gte",
-                                        TEST_WAIT64(hipStreamWaitValueGte, 0x7FFFFFFFFFFF0001,
-                                                    0x7FFFFFFFFFFF0000, 0x7FFFFFFFFFFF0001))
-DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT64("NoMask_Eq",
-                                        TEST_WAIT64(hipStreamWaitValueEq, 0x7FFFFFFFFFFFFFFF,
-                                                    0x7FFFFFFF0FFF0000, 0x7FFFFFFFFFFFFFFF))
-DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT64("NoMask_And",
-                                        TEST_WAIT64(hipStreamWaitValueAnd, 0x70F0F0F0F0F0F0F0,
-                                                    0x0F0F0F0F0F0F0F0F, 0X1F0F0F0F0F0F0F0F))
-DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT64("NoMask_Nor",
-                                        TEST_WAIT64(hipStreamWaitValueNor, 0x4724724747247247,
-                                                    0xbddbddbdbddbddbd, 0xbddbddbdbddbddb3))
-#undef DEFINE_STREAM_WAIT_VAL_TEST_CASES_INT64
+  SECTION("Mask_Eq_2") {
+    TestWaitType testCase(hipStreamWaitValueEq, 0xFF, 0x11, 0x25, 0x11);
+    
+    SECTION("HostPtr") { 
+      testWait<TestParams<UIntT, PtrType::HostPtr>, true>(testCase); 
+    }
+    SECTION("DevicePtr") { 
+      testWait<TestParams<UIntT, PtrType::DevicePtr>, true>(testCase); 
+    }
+    SECTION("DevicePtrToHost") { 
+      testWait<TestParams<UIntT, PtrType::DevicePtrToHost>, true>(testCase); 
+    }
+#if HT_AMD
+    if constexpr (std::is_same_v<UIntT, uint64_t>) {
+      SECTION("Signal") { 
+        testWait<TestParams<UIntT, PtrType::Signal>, true>(testCase); 
+      }
+    }
+#endif
+  }
+
+  SECTION("Mask_And") {
+    TestWaitType testCase(hipStreamWaitValueAnd, 0xFF, 0xF4A, 0xF35, 0X02);
+    
+    SECTION("HostPtr") { 
+      testWait<TestParams<UIntT, PtrType::HostPtr>, true>(testCase); 
+    }
+    SECTION("DevicePtr") { 
+      testWait<TestParams<UIntT, PtrType::DevicePtr>, true>(testCase); 
+    }
+    SECTION("DevicePtrToHost") { 
+      testWait<TestParams<UIntT, PtrType::DevicePtrToHost>, true>(testCase); 
+    }
+#if HT_AMD
+    if constexpr (std::is_same_v<UIntT, uint64_t>) {
+      SECTION("Signal") { 
+        testWait<TestParams<UIntT, PtrType::Signal>, true>(testCase); 
+      }
+    }
+#endif
+  }
+
+  SECTION("NoMask_Eq") {
+    TestWaitType testCase = std::is_same_v<UIntT, uint32_t>
+      ? TestWaitType(hipStreamWaitValueEq, 0x7FFFFFFF, 0x7FFF0000, 0x7FFFFFFF)
+      : TestWaitType(hipStreamWaitValueEq, 0x7FFFFFFFFFFFFFFF, 0x7FFFFFFF0FFF0000, 0x7FFFFFFFFFFFFFFF);
+    
+    SECTION("HostPtr") { 
+      testWait<TestParams<UIntT, PtrType::HostPtr>, true>(testCase); 
+    }
+    SECTION("DevicePtr") { 
+      testWait<TestParams<UIntT, PtrType::DevicePtr>, true>(testCase); 
+    }
+    SECTION("DevicePtrToHost") { 
+      testWait<TestParams<UIntT, PtrType::DevicePtrToHost>, true>(testCase); 
+    }
+#if HT_AMD
+    if constexpr (std::is_same_v<UIntT, uint64_t>) {
+      SECTION("Signal") { 
+        testWait<TestParams<UIntT, PtrType::Signal>, true>(testCase); 
+      }
+    }
+#endif
+  }
+
+  SECTION("NoMask_Gte") {
+    TestWaitType testCase = std::is_same_v<UIntT, uint32_t>
+      ? TestWaitType(hipStreamWaitValueGte, 0x7FFF0001, 0x7FFF0000, 0x7FFF0010)
+      : TestWaitType(hipStreamWaitValueGte, 0x7FFFFFFFFFFF0001, 0x7FFFFFFFFFFF0000, 0x7FFFFFFFFFFF0001);
+    
+    SECTION("HostPtr") { 
+      testWait<TestParams<UIntT, PtrType::HostPtr>, true>(testCase); 
+    }
+    SECTION("DevicePtr") { 
+      testWait<TestParams<UIntT, PtrType::DevicePtr>, true>(testCase); 
+    }
+    SECTION("DevicePtrToHost") { 
+      testWait<TestParams<UIntT, PtrType::DevicePtrToHost>, true>(testCase); 
+    }
+#if HT_AMD
+    if constexpr (std::is_same_v<UIntT, uint64_t>) {
+      SECTION("Signal") { 
+        testWait<TestParams<UIntT, PtrType::Signal>, true>(testCase); 
+      }
+    }
+#endif
+  }
+
+  SECTION("NoMask_And") {
+    TestWaitType testCase = std::is_same_v<UIntT, uint32_t>
+      ? TestWaitType(hipStreamWaitValueAnd, 0x70F0F0F0, 0x0F0F0F0F, 0X1F0F0F0F)
+      : TestWaitType(hipStreamWaitValueAnd, 0x70F0F0F0F0F0F0F0, 0x0F0F0F0F0F0F0F0F, 0X1F0F0F0F0F0F0F0F);
+    
+    SECTION("HostPtr") { 
+      testWait<TestParams<UIntT, PtrType::HostPtr>, true>(testCase); 
+    }
+    SECTION("DevicePtr") { 
+      testWait<TestParams<UIntT, PtrType::DevicePtr>, true>(testCase); 
+    }
+    SECTION("DevicePtrToHost") { 
+      testWait<TestParams<UIntT, PtrType::DevicePtrToHost>, true>(testCase); 
+    }
+#if HT_AMD
+    if constexpr (std::is_same_v<UIntT, uint64_t>) {
+      SECTION("Signal") { 
+        testWait<TestParams<UIntT, PtrType::Signal>, true>(testCase); 
+      }
+    }
+#endif
+  }
+
+  SECTION("NoMask_Nor") {
+    TestWaitType testCase = std::is_same_v<UIntT, uint32_t>
+      ? TestWaitType(hipStreamWaitValueNor, 0x7AAAAAAA, 0x85555555, 0x9AAAAAAA)
+      : TestWaitType(hipStreamWaitValueNor, 0x4724724747247247, 0xbddbddbdbddbddbd, 0xbddbddbdbddbddb3);
+    
+    SECTION("HostPtr") { 
+      testWait<TestParams<UIntT, PtrType::HostPtr>, true>(testCase); 
+    }
+    SECTION("DevicePtr") { 
+      testWait<TestParams<UIntT, PtrType::DevicePtr>, true>(testCase); 
+    }
+    SECTION("DevicePtrToHost") { 
+      testWait<TestParams<UIntT, PtrType::DevicePtrToHost>, true>(testCase); 
+    }
+#if HT_AMD
+    if constexpr (std::is_same_v<UIntT, uint64_t>) {
+      SECTION("Signal") { 
+        testWait<TestParams<UIntT, PtrType::Signal>, true>(testCase); 
+      }
+    }
+#endif
+  }
+}
 
 // Negative Tests
 TEST_CASE("Unit_hipStreamValue_Negative_InvalidMemory") {
@@ -500,63 +597,60 @@ TEST_CASE("Unit_hipStreamValue_Negative_InvalidMemory") {
   HIP_CHECK(hipStreamDestroy(stream));
 }
 
-TEMPLATE_TEST_CASE("Unit_hipStreamValue_Negative_UninitializedStream", "", uint32_t, uint64_t) {
+// Merge the two similar negative tests
+TEMPLATE_TEST_CASE("Unit_hipStreamValue_Negative_StreamAndFlag", "", uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
     HipTest::HIP_SKIP_TEST("hipStreamWaitValue not supported on this device.");
     return;
   }
 
-  hipStream_t stream{reinterpret_cast<hipStream_t>(0xFFFF)};
+  SECTION("Invalid Stream handle") {
+    hipStream_t stream{reinterpret_cast<hipStream_t>(0xFFFF)};
 
-  // Allocate Host Memory
-  auto hostPtr = std::make_unique<TestType>();
+    // Allocate Host Memory
+    auto hostPtr = std::make_unique<TestType>();
 
-  // Register Host Memory
-  HIP_CHECK(hipHostRegister(hostPtr.get(), sizeof(TestType), 0));
+    // Register Host Memory
+    HIP_CHECK(hipHostRegister(hostPtr.get(), sizeof(TestType), 0));
 
-  // Set dummy data
-  *hostPtr = 0x0;
+    // Set dummy data
+    *hostPtr = 0x0;
 
-  const auto compareOp = hipStreamWaitValueGte;
-  const auto expectedError = hipErrorContextIsDestroyed;
+    const auto compareOp = hipStreamWaitValueGte;
+    const auto expectedError = hipErrorContextIsDestroyed;
 
-  // Stream handle negative tests
-  SECTION("Invalid Stream handle for hipStreamWriteValue") {
-    HIP_CHECK_ERROR(writeFunc<TestType>(stream, hostPtr.get(), 0, writeFlag), expectedError);
+    SECTION("Invalid Stream handle for hipStreamWriteValue") {
+      HIP_CHECK_ERROR(writeFunc<TestType>(stream, hostPtr.get(), 0, writeFlag), expectedError);
+    }
+
+    SECTION("Invalid Stream handle for hipStreamWaitValue") {
+      HIP_CHECK_ERROR(waitFunc<TestType>(stream, hostPtr.get(), 0, compareOp), expectedError);
+    }
+
+    // Cleanup
+    HIP_CHECK(hipHostUnregister(hostPtr.get()));
   }
 
-  SECTION("Invalid Stream handle for hipStreamWaitValue") {
-    HIP_CHECK_ERROR(waitFunc<TestType>(stream, hostPtr.get(), 0, compareOp), expectedError);
+  SECTION("Invalid Flag") {
+    hipStream_t stream{nullptr};
+    HIP_CHECK(hipStreamCreate(&stream));
+    REQUIRE(stream != nullptr);
+
+    // Allocate Host Memory
+    auto hostPtr = std::make_unique<TestType>();
+
+    // Register Host Memory
+    HIP_CHECK(hipHostRegister(hostPtr.get(), sizeof(TestType), 0));
+
+    // Set dummy data
+    *hostPtr = 0x0;
+
+    HIP_CHECK_ERROR(waitFunc<TestType>(stream, hostPtr.get(), 0, -1), hipErrorInvalidValue);
+
+    // Cleanup
+    HIP_CHECK(hipHostUnregister(hostPtr.get()));
+    HIP_CHECK(hipStreamDestroy(stream));
   }
-
-  // Cleanup
-  HIP_CHECK(hipHostUnregister(hostPtr.get()));
-}
-
-TEMPLATE_TEST_CASE("Unit_hipStreamValue_Negative_InvalidFlag", "", uint32_t, uint64_t) {
-  if (!streamWaitValueSupported()) {
-    HipTest::HIP_SKIP_TEST("hipStreamWaitValue not supported on this device.");
-    return;
-  }
-
-  hipStream_t stream{nullptr};
-  HIP_CHECK(hipStreamCreate(&stream));
-  REQUIRE(stream != nullptr);
-
-  // Allocate Host Memory
-  auto hostPtr = std::make_unique<TestType>();
-
-  // Register Host Memory
-  HIP_CHECK(hipHostRegister(hostPtr.get(), sizeof(TestType), 0));
-
-  // Set dummy data
-  *hostPtr = 0x0;
-
-  HIP_CHECK_ERROR(waitFunc<TestType>(stream, hostPtr.get(), 0, -1), hipErrorInvalidValue);
-
-  // Cleanup
-  HIP_CHECK(hipHostUnregister(hostPtr.get()));
-  HIP_CHECK(hipStreamDestroy(stream));
 }
 
 TEMPLATE_TEST_CASE("Unit_hipStreamWriteValue_Default", "", uint32_t, uint64_t) {


### PR DESCRIPTION
## Motivation

This PR improves the runtime of the hipStreamValue test cases, by reducing the HIP initialization overhead.

## Technical Details

By reducing hipStreamValue test cases into 4 larger test cases, we reduce the total runtime of the very small checks by triggering HIP initialization once.

## JIRA ID

Contributes to SWDEV-572673

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
