### PR TITLE
SWDEV-541351 - Disable Defer of Managed variable for now to support non-HMM devices

### DIFF
--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -156,7 +156,7 @@ void __hipRegisterManagedVar(
     return 0;
 #else
     char* var = getenv("HIP_ENABLE_DEFERRED_LOADING");
-    return var ? atoi(var) : 1;
+    return var ? atoi(var) : 0;
 #endif
   }()};
   hipError_t hip_error = hipSuccess;


### PR DESCRIPTION
## Motivation

- To support static managed variables on non-HMM Devices, disable the deferring managed var allocation.
- Issue found in ticket SWDEV-541351
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
