### PR TITLE
SWDEV-563777 - further reduce compilation warnings

### DIFF
--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -633,6 +633,8 @@ hipError_t ihipMemcpyCommand(amd::Command*& command, void* dst, const void* src,
                                            *srcMemory->asBuffer(), *dstMemory->asBuffer(), sOffset,
                                            dOffset, sizeBytes, copyMetadata);
       break;
+    case hipHostToHost:
+      break;
   }
   if (command == nullptr) {
     return hipErrorOutOfMemory;

--- a/projects/clr/hipamd/src/hip_mempool.cpp
+++ b/projects/clr/hipamd/src/hip_mempool.cpp
@@ -32,7 +32,8 @@ namespace {
 inline bool IsMemPoolValid(MemoryPool* mem_pool) {
   bool result = false;
   for (auto it : g_devices) {
-    if (result = it->IsMemoryPoolValid(mem_pool) == true) {
+    result = it->IsMemoryPoolValid(mem_pool);
+    if (result) {
       break;
     }
   }

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -753,7 +753,7 @@ Device::Device()
       vaCacheAccess_(nullptr),
       vaCacheMap_(nullptr),
       index_(0) {
-  memset(&info_, '\0', sizeof(info_));
+  memset(static_cast<void*>(&info_), '\0', sizeof(info_));
   // By default consider just 1 xcc per device
   info_.numberOfXccs_ = 1;
 }

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1616,7 +1616,7 @@ void VirtualGPU::dispatchBarrierValuePacket(uint16_t packetHeader, bool resolveD
   barrier_value_packet_.cond = cond;
 
   // Dependent signal and external signal cant be true at the same time
-  assert(resolveDepSignal & (signal.handle != 0) == 0);
+  assert((resolveDepSignal && (signal.handle != 0)) == false);
   if (resolveDepSignal) {
     auto wait_signals = Barriers().WaitingSignal();
     if (wait_signals.size() > 0) {

--- a/projects/hip/docs/doxygen-input/doxy.cfg
+++ b/projects/hip/docs/doxygen-input/doxy.cfg
@@ -777,7 +777,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES
@@ -793,7 +793,7 @@ WARNINGS               = YES
 # will automatically be disabled.
 # The default value is: YES.
 
-WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_UNDOCUMENTED   = NO
 
 # If the WARN_IF_DOC_ERROR tag is set to YES, doxygen will generate warnings for
 # potential errors in the documentation, such as not documenting some parameters


### PR DESCRIPTION
This change resolves some of the warnings generated during clr builds. Quiet regular output of doxygen.
Disable non-documented warnings of doxygen.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Reduce warnings during clr builds that pollute the output 
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Basic fixes that are not changing the behavior 
## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
SWDEV-563777
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Local testing
## Test Result

<!-- Briefly summarize test outcomes. -->
tests are passing
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
