### PR TITLE
[rocprofiler-sdk] Set ROCPROFILER_REGISTER_LIBRARY env variable in initialization

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/common/CMakeLists.txt
@@ -5,6 +5,7 @@ rocprofiler_activate_clang_tidy()
 
 set(common_sources
     demangle.cpp
+    dl.cpp
     elf_utils.cpp
     environment.cpp
     logging.cpp
@@ -21,6 +22,7 @@ set(common_headers
     abi.hpp
     defines.hpp
     demangle.hpp
+    dl.hpp
     elf_utils.hpp
     environment.hpp
     filesystem.hpp

--- a/projects/rocprofiler-sdk/source/lib/common/dl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/dl.cpp
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#define GNU_SOURCE 1
+#define _GNU_SOURCE 1
 
 #include "lib/common/dl.hpp"
 #include "lib/common/environment.hpp"

--- a/projects/rocprofiler-sdk/source/lib/common/dl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/dl.cpp
@@ -82,10 +82,11 @@ get_linked_path(std::string_view _name, open_modes_vec_t&& _open_modes)
     dl_iterate_phdr(dl_iterate_callback, &loaded_libs);
     for(const auto& itr : loaded_libs)
     {
+        ROCP_TRACE << fmt::format("Checking loaded library '{}' for match to '{}'", itr, _name);
         if(fs::path{itr}.filename().string().find(_name) == 0)
         {
             ROCP_INFO << fmt::format(
-                "Matched '{}' to '{}' from libraries from dl_iterate_phdr", itr, _name);
+                "+ Matched '{}' to '{}' from libraries from dl_iterate_phdr", itr, _name);
             return fs::absolute(fs::path{itr}).string();
         }
     }

--- a/projects/rocprofiler-sdk/source/lib/common/dl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/dl.cpp
@@ -25,6 +25,7 @@
 #include "lib/common/dl.hpp"
 #include "lib/common/environment.hpp"
 #include "lib/common/filesystem.hpp"
+#include "lib/common/logging.hpp"
 #include "lib/common/utility.hpp"
 
 #include <rocprofiler-sdk/cxx/details/tokenize.hpp>
@@ -94,6 +95,10 @@ get_linked_path(std::string_view _name, open_modes_vec_t&& _open_modes)
     // constructor. This is kept here for debugging purposes only.
     if(common::get_env("ROCPROFILER_LINKED_PATH_USE_DLOPEN", false))
     {
+        ROCP_INFO << fmt::format("Attempting to resolve linked path for '{}' via dlopen ... "
+                                 "(ROCPROFILER_LINKED_PATH_USE_DLOPEN=1)",
+                                 _name);
+
         if(_name.empty()) return fs::current_path().string();
 
         if(_open_modes.empty()) _open_modes = default_link_open_modes;
@@ -154,6 +159,10 @@ get_symbol_path(const std::vector<std::string>& _lib_names,
     // constructor. This is kept here for debugging purposes only.
     if(common::get_env("ROCPROFILER_SYMBOL_PATH_USE_DLOPEN", false))
     {
+        ROCP_INFO << fmt::format("Attempting to resolve symbol path for '{}' via dlopen ... "
+                                 "(ROCPROFILER_SYMBOL_PATH_USE_DLOPEN=1)",
+                                 _sym_name);
+
         auto  _lib_name = std::string{};
         void* _handle   = nullptr;
 
@@ -161,7 +170,8 @@ get_symbol_path(const std::vector<std::string>& _lib_names,
         {
             if(!itr.empty())
             {
-                ROCP_INFO << "Attempting dlopen('" << itr << "', RTLD_NOLOAD | RTLD_LAZY) ...";
+                ROCP_INFO << fmt::format("Attempting dlopen('{}', RTLD_NOLOAD | RTLD_LAZY) ...",
+                                         itr);
                 void* _handle_v = dlopen(itr.c_str(), RTLD_NOLOAD | RTLD_LAZY);
                 if(_handle_v)
                 {
@@ -175,10 +185,9 @@ get_symbol_path(const std::vector<std::string>& _lib_names,
         if(!_handle) _handle = RTLD_DEFAULT;
 
         const void* _fn = dlsym(_handle, _sym_name.data());
-        ROCP_CI_LOG_IF(INFO, !_fn)
-            << fmt::format("rocprofiler-sdk could not locate '{}' symbol in {}",
-                           _sym_name,
-                           (_handle) ? _lib_name : "RTLD_DEFAULT");
+        ROCP_INFO_IF(!_fn) << fmt::format("rocprofiler-sdk could not locate '{}' symbol in {}",
+                                          _sym_name,
+                                          (_handle) ? _lib_name : "RTLD_DEFAULT");
     }
 
     return std::nullopt;

--- a/projects/rocprofiler-sdk/source/lib/common/dl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/dl.cpp
@@ -1,0 +1,188 @@
+// MIT License
+//
+// Copyright (c) 2022 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#define GNU_SOURCE 1
+
+#include "lib/common/dl.hpp"
+#include "lib/common/environment.hpp"
+#include "lib/common/filesystem.hpp"
+#include "lib/common/utility.hpp"
+
+#include <rocprofiler-sdk/cxx/details/tokenize.hpp>
+
+#include <fmt/core.h>
+
+#include <dlfcn.h>
+#include <elf.h>
+#include <link.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <fstream>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+
+namespace rocprofiler
+{
+namespace common
+{
+namespace dl
+{
+namespace
+{
+namespace fs = ::rocprofiler::common::filesystem;
+
+const auto default_link_open_modes = open_modes_vec_t{(RTLD_LAZY | RTLD_NOLOAD)};
+}  // namespace
+
+std::optional<std::string>
+get_linked_path(std::string_view _name, open_modes_vec_t&& _open_modes)
+{
+    auto dl_iterate_callback = [](struct dl_phdr_info* info, size_t, void* data) -> int {
+        auto* _data     = static_cast<std::vector<std::string>*>(data);
+        auto  _existing = std::unordered_set<std::string>{};
+        for(int i = 0; i < info->dlpi_phnum; ++i)
+        {
+            if(info->dlpi_phdr[i].p_type == PT_LOAD && info->dlpi_name != nullptr &&
+               !std::string_view{info->dlpi_name}.empty())
+            {
+                if(_existing.emplace(info->dlpi_name).second)
+                {
+                    ROCP_TRACE << "dl_iterate_phdr found loaded library: " << info->dlpi_name;
+                    _data->emplace_back(info->dlpi_name);
+                }
+            }
+        }
+        return 0;
+    };
+
+    auto loaded_libs = std::vector<std::string>{};
+    dl_iterate_phdr(dl_iterate_callback, &loaded_libs);
+    for(const auto& itr : loaded_libs)
+    {
+        if(fs::path{itr}.filename().string().find(_name) == 0)
+        {
+            ROCP_INFO << fmt::format(
+                "Matched '{}' to '{}' from libraries from dl_iterate_phdr", itr, _name);
+            return fs::absolute(fs::path{itr}).string();
+        }
+    }
+
+    // using dlopen, even via RTLD_NOLOAD, can deadlock the application if called from within
+    // another dlopen or if the dlopen triggers this library constructor from within this library
+    // constructor. This is kept here for debugging purposes only.
+    if(common::get_env("ROCPROFILER_LINKED_PATH_USE_DLOPEN", false))
+    {
+        if(_name.empty()) return fs::current_path().string();
+
+        if(_open_modes.empty()) _open_modes = default_link_open_modes;
+
+        void* _handle = nullptr;
+        bool  _noload = false;
+        for(auto _mode : _open_modes)
+        {
+            _handle = dlopen(_name.data(), _mode);
+            _noload = (_mode & RTLD_NOLOAD) == RTLD_NOLOAD;
+            if(_handle) break;
+        }
+
+        if(_handle)
+        {
+            struct link_map* _link_map = nullptr;
+            dlinfo(_handle, RTLD_DI_LINKMAP, &_link_map);
+            if(_link_map != nullptr && !std::string_view{_link_map->l_name}.empty())
+            {
+                return fs::absolute(fs::path{_link_map->l_name}).string();
+            }
+            if(_noload == false) dlclose(_handle);
+        }
+    }
+
+    return std::nullopt;
+}
+
+std::optional<std::string>
+get_symbol_path(const std::vector<std::string>& _lib_names,
+                std::string_view                _sym_name,
+                const void*                     _addr,
+                bool                            _canonicalize)
+{
+    if(auto dl_info = Dl_info{}; _addr && dladdr(_addr, &dl_info) != 0 && dl_info.dli_fname)
+    {
+        ROCP_CI_LOG_IF(WARNING,
+                       dl_info.dli_sname && std::string_view{dl_info.dli_sname} != _sym_name)
+            << fmt::format("rocprofiler-sdk located '{}' symbol via dladdr in '{}' but the symbol "
+                           "name resolves to '{}' instead",
+                           _sym_name,
+                           dl_info.dli_fname,
+                           dl_info.dli_sname);
+
+        auto _ec   = std::error_code{};
+        auto _path = (_canonicalize) ? fs::canonical(fs::path{dl_info.dli_fname}, _ec)
+                                     : fs::absolute(fs::path{dl_info.dli_fname}, _ec);
+        ROCP_CI_LOG_IF(WARNING, _ec) << fmt::format("Error resolving {} path for '{}': {} :: {}",
+                                                    (_canonicalize) ? "canonical" : "absolute",
+                                                    dl_info.dli_fname,
+                                                    _ec.value(),
+                                                    _ec.message());
+        if(!_ec) return _path.string();
+    }
+
+    // using dlopen, even via RTLD_NOLOAD, can deadlock the application if called from within
+    // another dlopen or if the dlopen triggers this library constructor from within this library
+    // constructor. This is kept here for debugging purposes only.
+    if(common::get_env("ROCPROFILER_SYMBOL_PATH_USE_DLOPEN", false))
+    {
+        auto  _lib_name = std::string{};
+        void* _handle   = nullptr;
+
+        for(const auto& itr : _lib_names)
+        {
+            if(!itr.empty())
+            {
+                ROCP_INFO << "Attempting dlopen('" << itr << "', RTLD_NOLOAD | RTLD_LAZY) ...";
+                void* _handle_v = dlopen(itr.c_str(), RTLD_NOLOAD | RTLD_LAZY);
+                if(_handle_v)
+                {
+                    _lib_name = itr;
+                    _handle   = _handle_v;
+                    break;
+                }
+            }
+        }
+
+        if(!_handle) _handle = RTLD_DEFAULT;
+
+        const void* _fn = dlsym(_handle, _sym_name.data());
+        ROCP_CI_LOG_IF(INFO, !_fn)
+            << fmt::format("rocprofiler-sdk could not locate '{}' symbol in {}",
+                           _sym_name,
+                           (_handle) ? _lib_name : "RTLD_DEFAULT");
+    }
+
+    return std::nullopt;
+}
+}  // namespace dl
+}  // namespace common
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/common/dl.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/dl.hpp
@@ -1,0 +1,55 @@
+// MIT License
+//
+// Copyright (c) 2022 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <dlfcn.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace rocprofiler
+{
+namespace common
+{
+namespace dl
+{
+using open_modes_vec_t = std::vector<int>;
+
+// helper function for translating generic lib name to resolved path
+std::optional<std::string>
+get_linked_path(std::string_view, open_modes_vec_t&& = {});
+
+// helper function for translating symbol name to resolved library path
+std::optional<std::string>
+get_symbol_path(const std::vector<std::string>& _lib_names,
+                std::string_view                _sym_name,
+                const void*                     _addr         = nullptr,
+                bool                            _canonicalize = false);
+}  // namespace dl
+}  // namespace common
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/common/logging.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/logging.hpp
@@ -26,8 +26,12 @@
 
 #include <glog/logging.h>
 
+#include <fmt/format.h>  // usually used in conjunction with logging
+#include <fmt/ranges.h>
+
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <string_view>
 
 #define ROCP_LOG_LEVEL_TRACE   4

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -29,6 +29,7 @@
 #include <rocprofiler-sdk/version.h>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include <dlfcn.h>
 #include <link.h>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -52,12 +52,34 @@ std::unordered_map<std::string, void*> m_target_symbol_addrs  = {};
 auto
 get_this_library_path()
 {
-    const auto libname = fmt::format("{}.{}", ROCATTACH_LIBRARY_NAME, ROCPROFILER_SOVERSION);
-    auto       _this_lib_path =
-        rocprofiler::common::dl::get_linked_path(libname, {RTLD_NOLOAD | RTLD_LAZY});
-    LOG_IF(FATAL, !_this_lib_path)
-        << fmt::format("{} could not locate itself in the list of loaded libraries", libname);
-    return fs::path{*_this_lib_path}.parent_path().string();
+    const auto libnames = std::array<std::string, 3>{
+        fmt::format("{}.{}.{}.{}",
+                    ROCATTACH_LIBRARY_NAME,
+                    ROCPROFILER_VERSION_MAJOR,
+                    ROCPROFILER_VERSION_MINOR,
+                    ROCPROFILER_VERSION_PATCH),
+        fmt::format("{}.{}", ROCATTACH_LIBRARY_NAME, ROCPROFILER_SOVERSION),
+        fmt::format("{}", ROCATTACH_LIBRARY_NAME),
+    };
+
+    for(const auto& itr : libnames)
+    {
+        ROCP_INFO << fmt::format("Searching for {} library path", itr);
+        if(auto _this_lib_path =
+               rocprofiler::common::dl::get_linked_path(itr, {RTLD_NOLOAD | RTLD_LAZY});
+           _this_lib_path)
+        {
+            auto _val = fs::path{*_this_lib_path}.parent_path().string();
+            ROCP_INFO << fmt::format("Found {} library path: {}", itr, _val);
+            return _val;
+        }
+    }
+
+    ROCP_FATAL << fmt::format(
+        "{} could not locate itself in the list of loaded libraries. Tried: {}",
+        ROCATTACH_LIBRARY_NAME,
+        fmt::join(libnames, ", "));
+    return std::string{};
 }
 
 void*

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -22,8 +22,13 @@
 
 #include "symbol_lookup.hpp"
 
+#include "lib/common/dl.hpp"
 #include "lib/common/filesystem.hpp"
 #include "lib/common/logging.hpp"
+
+#include <rocprofiler-sdk/version.h>
+
+#include <fmt/format.h>
 
 #include <dlfcn.h>
 #include <link.h>
@@ -40,49 +45,18 @@ namespace rocattach
 {
 namespace
 {
-constexpr char ROCATTACH_LIBRARY_NAME[]                       = "librocprofiler-sdk-rocattach.so.1";
+constexpr auto                         ROCATTACH_LIBRARY_NAME = "librocprofiler-sdk-rocattach.so";
 std::unordered_map<std::string, void*> m_target_library_addrs = {};
 std::unordered_map<std::string, void*> m_target_symbol_addrs  = {};
-
-using open_modes_vec_t = std::vector<int>;
-
-std::optional<std::string>
-get_linked_path(std::string_view _name, open_modes_vec_t&& _open_modes)
-{
-    const open_modes_vec_t default_link_open_modes = {(RTLD_LAZY | RTLD_NOLOAD)};
-    if(_name.empty()) return fs::current_path().string();
-
-    if(_open_modes.empty()) _open_modes = default_link_open_modes;
-
-    void* _handle = nullptr;
-    bool  _noload = false;
-    for(auto _mode : _open_modes)
-    {
-        _handle = dlopen(_name.data(), _mode);
-        _noload = (_mode & RTLD_NOLOAD) == RTLD_NOLOAD;
-        if(_handle) break;
-    }
-
-    if(_handle)
-    {
-        struct link_map* _link_map = nullptr;
-        dlinfo(_handle, RTLD_DI_LINKMAP, &_link_map);
-        if(_link_map != nullptr && !std::string_view{_link_map->l_name}.empty())
-        {
-            return fs::absolute(fs::path{_link_map->l_name}).string();
-        }
-        if(_noload == false) dlclose(_handle);
-    }
-
-    return std::nullopt;
-}
 
 auto
 get_this_library_path()
 {
-    auto _this_lib_path = get_linked_path(ROCATTACH_LIBRARY_NAME, {RTLD_NOLOAD | RTLD_LAZY});
-    LOG_IF(FATAL, !_this_lib_path) << "[rocprofiler-sdk-rocattach] " << ROCATTACH_LIBRARY_NAME
-                                   << " could not locate itself in the list of loaded libraries";
+    const auto libname = fmt::format("{}.{}", ROCATTACH_LIBRARY_NAME, ROCPROFILER_SOVERSION);
+    auto       _this_lib_path =
+        rocprofiler::common::dl::get_linked_path(libname, {RTLD_NOLOAD | RTLD_LAZY});
+    LOG_IF(FATAL, !_this_lib_path)
+        << fmt::format("{} could not locate itself in the list of loaded libraries", libname);
     return fs::path{*_this_lib_path}.parent_path().string();
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -210,7 +210,7 @@ set_rocprofiler_register_library()
         // ensures that rocprofiler-register uses this library path
         if(!_this_library_path.empty() && enabled)
         {
-            // used to check for conflicts is already set
+            // used to check for conflicts if already set
             auto _existing = common::get_env("ROCPROFILER_REGISTER_LIBRARY", std::string{});
             if(_existing.empty() ||
                common::get_env("ROCPROFILER_FORCE_ROCPROFILER_REGISTER_LIBRARY", false))

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -23,6 +23,7 @@
 #define _GNU_SOURCE 1
 
 #include "lib/rocprofiler-sdk/registration.hpp"
+#include "lib/common/dl.hpp"
 #include "lib/common/elf_utils.hpp"
 #include "lib/common/environment.hpp"
 #include "lib/common/filesystem.hpp"
@@ -148,6 +149,90 @@ resolved_exists(std::string_view fname)
     }
 
     return fs::exists(fname);
+}
+
+auto
+get_this_library_path()
+{
+    const auto libnames = std::vector<std::string>{
+        fmt::format("librocprofiler-sdk.so.{}.{}.{}",
+                    ROCPROFILER_VERSION_MAJOR,
+                    ROCPROFILER_VERSION_MINOR,
+                    ROCPROFILER_VERSION_PATCH),
+        fmt::format("librocprofiler-sdk.so.{}", ROCPROFILER_SOVERSION),
+        "librocprofiler-sdk.so",
+    };
+
+    if(auto _this_lib_path =
+           common::dl::get_symbol_path(libnames,
+                                       "rocprofiler_set_api_table",
+                                       reinterpret_cast<const void*>(rocprofiler_set_api_table),
+                                       true);
+       _this_lib_path)
+        return *_this_lib_path;
+
+    for(const auto& libname : libnames)
+    {
+        if(auto _this_lib_path = common::dl::get_linked_path(libname, {RTLD_NOLOAD | RTLD_LAZY});
+           _this_lib_path)
+        {
+            if(!resolved_exists(*_this_lib_path))
+            {
+                ROCP_CI_LOG(FATAL) << fmt::format("{} resolved path '{}' does not exist",
+                                                  libname,
+                                                  fs::absolute(fs::path{*_this_lib_path}).string());
+            }
+            return fs::canonical(fs::path{*_this_lib_path}).string();
+        }
+    }
+
+    ROCP_CI_LOG(WARNING) << fmt::format(
+        "{} could not locate itself in the list of loaded libraries",
+        fmt::join(libnames.begin(), libnames.end(), "/"));
+
+    return std::string{};
+}
+
+void
+set_rocprofiler_register_library()
+{
+    // this function sets the ROCPROFILER_REGISTER_LIBRARY env var to the path of this library
+    // to ensure that rocprofiler-register will always use this instance of the rocprofiler-sdk
+    // library.
+
+    static auto _once = std::once_flag{};
+    std::call_once(_once, []() {
+        init_logging();
+        auto _this_library_path = get_this_library_path();
+        ROCP_INFO << fmt::format("rocprofiler-sdk library path: '{}'", _this_library_path);
+        // opt out of setting the ROCPROFILER_REGISTER_LIBRARY env var
+        auto enabled = common::get_env("ROCPROFILER_SET_ROCPROFILER_REGISTER_LIBRARY", true);
+        // ensures that rocprofiler-register uses this library path
+        if(!_this_library_path.empty() && enabled)
+        {
+            // used to check for conflicts is already set
+            auto _existing = common::get_env("ROCPROFILER_REGISTER_LIBRARY", std::string{});
+            if(_existing.empty() ||
+               common::get_env("ROCPROFILER_FORCE_ROCPROFILER_REGISTER_LIBRARY", false))
+            {
+                common::set_env("ROCPROFILER_REGISTER_LIBRARY", _this_library_path, 1);
+            }
+            else
+            {
+                // only report conflict if existing value differs from this library path
+                auto _existing_path = fs::path{_existing};
+                ROCP_CI_LOG_IF(WARNING,
+                               _existing_path.is_absolute() &&
+                                   fs::canonical(_existing_path).string() != _this_library_path)
+                    << fmt::format(
+                           "ROCPROFILER_REGISTER_LIBRARY is already set to '{}' (resolves to "
+                           "'{}'), not overriding with '{}'",
+                           _existing,
+                           fs::canonical(_existing_path).string(),
+                           _this_library_path);
+            }
+        }
+    });
 }
 
 // invoke all rocprofiler_configure symbols
@@ -821,6 +906,8 @@ initialize()
     static auto _once = std::once_flag{};
     std::call_once(_once, []() {
         ROCP_INFO << "rocprofiler initialize started...";
+        // set the "ROCPROFILER_REGISTER_LIBRARY" env var
+        set_rocprofiler_register_library();
         // initialization is in process
         set_init_status(-1);
         std::atexit([]() {
@@ -965,7 +1052,8 @@ rocprofiler_force_configure(rocprofiler_configure_func_t configure_func)
     // let's just make sure that the forced configure function is a nullptr
     if(forced_config) return ROCPROFILER_STATUS_ERROR_CONFIGURATION_LOCKED;
 
-    setenv("ROCPROFILER_REGISTER_FORCE_LOAD", "1", 1);
+    rocprofiler::common::set_env("ROCPROFILER_REGISTER_FORCE_LOAD", "1", 1);
+    rocprofiler::registration::set_rocprofiler_register_library();
     forced_config = configure_func;
     rocprofiler::registration::initialize();
 

--- a/projects/rocprofiler-sdk/source/lib/tests/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/tests/common/CMakeLists.txt
@@ -6,6 +6,7 @@ project(rocprofiler-sdk-tests-common LANGUAGES C CXX)
 set(common_sources
     c_array.cpp
     demangling.cpp
+    dl.cpp
     environment.cpp
     md5sum.cpp
     mpl.cpp

--- a/projects/rocprofiler-sdk/source/lib/tests/common/dl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/common/dl.cpp
@@ -1,0 +1,135 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/common/dl.hpp"
+#include "lib/common/environment.hpp"
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include <cxxabi.h>
+#include <cstddef>
+#include <cstdint>
+#include <sstream>
+#include <string>
+
+TEST(common, dl_get_linked_path)
+{
+    rocprofiler::common::set_env("ROCPROFILER_LINKED_PATH_USE_DLOPEN", "0", 1);
+
+    auto real_lib  = std::string_view{"libstdc++.so"};
+    auto real_path = rocprofiler::common::dl::get_linked_path(real_lib);
+    ASSERT_TRUE(real_path.has_value());
+    EXPECT_FALSE(real_path->empty());
+    fmt::print("{} linked path: {}\n", real_lib, real_path.value());
+
+    auto fake_lib  = std::string_view{"libthis_library_does_not_exist.so"};
+    auto fake_path = rocprofiler::common::dl::get_linked_path(fake_lib);
+    EXPECT_FALSE(fake_path.has_value())
+        << fmt::format("fake_path: {}", fake_path.value_or(std::string{}));
+    if(fake_path)
+    {
+        EXPECT_TRUE(fake_path->empty())
+            << fmt::format("fake_path: {}", fake_path.value_or(std::string{}));
+        fmt::print("{} linked path: {}\n", fake_lib, fake_path.value());
+    }
+}
+
+TEST(common, dl_get_symbol_path)
+{
+    rocprofiler::common::set_env("ROCPROFILER_SYMBOL_PATH_USE_DLOPEN", "0", 1);
+
+    auto real_lib  = std::string_view{"libstdc++.so"};
+    auto real_path = rocprofiler::common::dl::get_symbol_path(
+        {std::string{real_lib}, fmt::format("{}.6", real_lib)},
+        "__cxa_demangle",
+        reinterpret_cast<const void*>(abi::__cxa_demangle));
+    ASSERT_TRUE(real_path.has_value());
+    EXPECT_FALSE(real_path->empty());
+    fmt::print("{} symbol path: {}\n", "__cxa_demangle", real_path.value());
+
+    auto fake_lib = std::string_view{"libthis_library_does_not_exist.so"};
+    auto fake_sym = std::string_view{"this_symbol_does_not_exist"};
+    auto fake_path =
+        rocprofiler::common::dl::get_symbol_path({std::string{fake_lib}}, fake_sym, nullptr);
+    EXPECT_FALSE(fake_path.has_value())
+        << fmt::format("fake_path: {}", fake_path.value_or(std::string{}));
+    if(fake_path)
+    {
+        EXPECT_TRUE(fake_path->empty())
+            << fmt::format("fake_path: {}", fake_path.value_or(std::string{}));
+        fmt::print("{} symbol path: {}\n", fake_sym, fake_path.value());
+    }
+}
+
+TEST(common, dl_get_linked_path_use_dlopen)
+{
+    rocprofiler::common::set_env("ROCPROFILER_LINKED_PATH_USE_DLOPEN", "1", 1);
+
+    auto real_lib  = std::string_view{"libstdc++.so"};
+    auto real_path = rocprofiler::common::dl::get_linked_path(real_lib);
+    ASSERT_TRUE(real_path.has_value());
+    EXPECT_FALSE(real_path->empty());
+    fmt::print("{} linked path: {}\n", real_lib, real_path.value());
+
+    auto fake_lib  = std::string_view{"libthis_library_does_not_exist.so"};
+    auto fake_path = rocprofiler::common::dl::get_linked_path(fake_lib);
+    EXPECT_FALSE(fake_path.has_value())
+        << fmt::format("fake_path: {}", fake_path.value_or(std::string{}));
+    if(fake_path)
+    {
+        EXPECT_TRUE(fake_path->empty())
+            << fmt::format("fake_path: {}", fake_path.value_or(std::string{}));
+        fmt::print("{} linked path: {}\n", fake_lib, fake_path.value());
+    }
+
+    rocprofiler::common::set_env("ROCPROFILER_LINKED_PATH_USE_DLOPEN", "0", 1);
+}
+
+TEST(common, dl_get_symbol_path_use_dlopen)
+{
+    rocprofiler::common::set_env("ROCPROFILER_SYMBOL_PATH_USE_DLOPEN", "1", 1);
+
+    auto real_lib  = std::string_view{"libstdc++.so"};
+    auto real_path = rocprofiler::common::dl::get_symbol_path(
+        {std::string{real_lib}, fmt::format("{}.6", real_lib)},
+        "__cxa_demangle",
+        reinterpret_cast<const void*>(abi::__cxa_demangle));
+    ASSERT_TRUE(real_path.has_value());
+    EXPECT_FALSE(real_path->empty());
+    fmt::print("{} symbol path: {}\n", "__cxa_demangle", real_path.value());
+
+    auto fake_lib = std::string_view{"libthis_library_does_not_exist.so"};
+    auto fake_sym = std::string_view{"this_symbol_does_not_exist"};
+    auto fake_path =
+        rocprofiler::common::dl::get_symbol_path({std::string{fake_lib}}, fake_sym, nullptr);
+    EXPECT_FALSE(fake_path.has_value())
+        << fmt::format("fake_path: {}", fake_path.value_or(std::string{}));
+    if(fake_path)
+    {
+        EXPECT_TRUE(fake_path->empty())
+            << fmt::format("fake_path: {}", fake_path.value_or(std::string{}));
+        fmt::print("{} symbol path: {}\n", fake_sym, fake_path.value());
+    }
+
+    rocprofiler::common::set_env("ROCPROFILER_SYMBOL_PATH_USE_DLOPEN", "0", 1);
+}


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
- Setting this environment variable tells rocprofiler-register which specific rocprofiler-sdk library to load (if it hasn't loaded it already)
- This ensures that all rocprofiler-register instances communicate with the same rocprofiler-sdk library and/or the rocprofiler-sdk library that a tool library called rocprofiler_force_configure in.
- It was noted by HPCToolkit that is was possible to dlopen one version of the rocprofiler-sdk library, call `rocprofiler_force_configure`, and then have rocprofiler-register load a different rocprofiler-sdk library. This fixes that issue

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- rocprofiler-register uses the `ROCPROFILER_REGISTER_LIBRARY` environment variable to decide which rocprofiler-sdk library to dlopen, it defaults to `"librocprofiler-sdk.so"`.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- A test plan is needed but it is tricky to create one.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
