### PR TITLE
Scale amd-smi memory usage data

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -697,7 +697,8 @@ data::sample(uint32_t _device_id)
                 serialize_settings(m_dev_id), _device_id, _timestamp,
                 m_busy_perc.gfx_activity, m_busy_perc.umc_activity,
                 m_busy_perc.mm_activity, m_power.current_socket_power, m_temp,
-                m_mem_usage, serialize_gpu_metrics(m_dev_id, metrics, capabilities) });
+                (m_mem_usage / units::megabyte),
+                serialize_gpu_metrics(m_dev_id, metrics, capabilities) });
 
             if(has_data) m_gpu_metrics.push_back(metrics);
         }


### PR DESCRIPTION
## Motivation

- The cached data for AMD SMI device memory usage was not scaled when stored into the cache.

## Technical Details

 - Scaled down to the units of Megabytes when data is cached

## JIRA ID

[SWDEV-570440]

## Test Plan

 - Run the existing tests to verify the changes

## Test Result

- Existing tests passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
