### PR TITLE
Merge tests for device properties from old HIP versions

### DIFF
--- a/projects/hip-tests/catch/unit/device/hipExtGetLinkTypeAndHopCount.cc
+++ b/projects/hip-tests/catch/unit/device/hipExtGetLinkTypeAndHopCount.cc
@@ -31,8 +31,7 @@ THE SOFTWARE.
  * - Returns the link type and hop count between two devices.
  */
 
-#if __linux__
-#if HT_AMD
+#if __linux__ && HT_AMD
 /**
  * Test Description
  * ------------------------
@@ -160,7 +159,6 @@ TEST_CASE("Unit_hipExtGetLinkTypeAndHopCount_Negative_Parameters") {
     HIP_CHECK_ERROR(hipExtGetLinkTypeAndHopCount(0, 1, nullptr, nullptr), hipErrorInvalidValue);
   }
 }
-#endif
 #endif
 
 /**

--- a/projects/hip-tests/catch/unit/device/hipGetDeviceProperties.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetDeviceProperties.cc
@@ -292,7 +292,9 @@ TEST_CASE("Print_Out_Properties") {
   std::cout << std::setw(w) << "pageableMemoryAccessUsesHostPageTables: "
             << properties.pageableMemoryAccessUsesHostPageTables << "\n";
 
+  std::cout << std::setw(w) << "New Attributes added in Rocm 6.0" << "\n";
 #if HT_AMD
+  std::cout << std::setw(w) << "uuid: " << properties.uuid.bytes << "\n";
   std::cout << std::setw(w) << "gcnArchName: " << std::string(properties.gcnArchName, 256) << "\n";
   std::cout << std::setw(w) << "asicRevision: " << properties.asicRevision << "\n";
   std::cout << std::setw(w)
@@ -339,32 +341,6 @@ TEST_CASE("Print_Out_Properties") {
             << properties.cooperativeMultiDeviceUnmatchedBlockDim << "\n";
   std::cout << std::setw(w) << "cooperativeMultiDeviceUnmatchedSharedMem: "
             << properties.cooperativeMultiDeviceUnmatchedSharedMem << "\n";
-#endif
-  std::flush(std::cout);
-}
-
-/**
- * Test Description
- * ------------------------
- *  - Print out all properties in agreed upon format.
- * Test source
- * ------------------------
- *  - unit/device/hipGetDeviceProperties.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 6.0
- */
-TEST_CASE("Print_Out_Properties_6.0") {
-  constexpr int w = 42;
-  const auto device = GENERATE(range(0, HipTest::getDeviceCount()));
-
-  hipDeviceProp_t properties;
-  HIP_CHECK(hipGetDeviceProperties(&properties, device));
-
-  std::cout << std::left;
-  std::cout << std::setw(w) << "New Attributes added in Rocm 6.0" << "\n";
-#if HT_AMD
-  std::cout << std::setw(w) << "uuid: " << properties.uuid.bytes << "\n";
 #endif
   std::cout << std::setw(w) << "maxTexture1DLayered.width: " << properties.maxTexture1DLayered[0]
             << "\n";


### PR DESCRIPTION
## Motivation
We want to reduce the number of tests to speed up compilation and run time. This PR merges redundant tests.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Merges two tests for printing device properties, which were separated due to version mismatch.
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
Part of the HIP tests improvement board
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
Merged tests should pass as before.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Waiting for PSDB.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
