### PR TITLE
rocr: Format script skips non-existing files in sparse checkouts

### DIFF
--- a/projects/rocr-runtime/clang-format-diff.py
+++ b/projects/rocr-runtime/clang-format-diff.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import, division, print_function
 
 import argparse
 import difflib
+import os
 import re
 import subprocess
 import sys
@@ -95,6 +96,10 @@ def main():
   for filename, lines in lines_by_file.items():
     if args.i and args.verbose:
       print('Formatting {}'.format(filename))
+    if not os.path.exists(filename):
+      if args.verbose:
+        print('File {} does not exist, skipping.'.format(filename))
+      continue
     command = [args.binary, filename]
     if args.i:
       command.append('-i')


### PR DESCRIPTION
## Motivation

When formatting in sparse clones, the format script occasionally can't find a file, e.g., before merging from origin.

## Technical Details

The format script skips paths that don't exist but are reported by `git diff -U0 HEAD^`

## JIRA ID

NA

## Test Plan

Formatted code in multiple WIP local branches that origin/develop was not merged in.

## Test Result

Successfully formatted files in local branch.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
