### PR TITLE
Fix the SOVERSION for rocm_smi and liboam for Debian / Ubuntu Like build environments

### DIFF
--- a/projects/rocm-smi-lib/oam/CMakeLists.txt
+++ b/projects/rocm-smi-lib/oam/CMakeLists.txt
@@ -36,8 +36,8 @@ set(SO_VERSION_GIT_TAG_PREFIX "oam_so_ver")
 message("Package version: ${PKG_VERSION_STR}")
 
 # Debian package specific variables
-# Set a default value for the package version
-get_version_from_tag("1.0.0.0" ${SO_VERSION_GIT_TAG_PREFIX} GIT)
+# Set a default value for the package version - use the main package version as fallback
+get_version_from_tag("${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}" ${SO_VERSION_GIT_TAG_PREFIX} GIT)
 
 # VERSION_* variables should be set by get_version_from_tag
 if ( ${ROCM_PATCH_VERSION} )

--- a/projects/rocm-smi-lib/rocm_smi/CMakeLists.txt
+++ b/projects/rocm-smi-lib/rocm_smi/CMakeLists.txt
@@ -38,8 +38,8 @@ set(SO_VERSION_GIT_TAG_PREFIX "rsmi_so_ver")
 message("Package version: ${PKG_VERSION_STR}")
 
 # Debian package specific variables
-# Set a default value for the package version
-get_version_from_tag("1.0.0.0" ${SO_VERSION_GIT_TAG_PREFIX} GIT)
+# Set a default value for the package version - use the main package version as fallback
+get_version_from_tag("${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}" ${SO_VERSION_GIT_TAG_PREFIX} GIT)
 
 # VERSION_* variables should be set by get_version_from_tag
 if ( ${ROCM_PATCH_VERSION} )


### PR DESCRIPTION
    Package building environments like in Debian and Ubuntu do not really
    have .git shipped together with the original tarball which is causing
    rocm_smi soversion to fallback to 1 which is not true.

    This PR at least makes it fall back to CPACK version set before.
