### PR TITLE
SWDEV-538607 - SIMDe fall back mechanism and improve messages

### DIFF
--- a/projects/clr/rocclr/cmake/FindSIMDe.cmake
+++ b/projects/clr/rocclr/cmake/FindSIMDe.cmake
@@ -20,7 +20,7 @@
 
 include(FindPackageHandleStandardArgs)
 
-find_package(PkgConfig REQUIRED)
+find_package(PkgConfig)
 if(PkgConfig_FOUND)
     pkg_check_modules(simde IMPORTED_TARGET simde)
 endif()
@@ -29,9 +29,8 @@ if(PkgConfig_FOUND AND simde_FOUND)
     message(STATUS "Found SIMDe via pkg-config")
     set(SIMDE_TARGET PkgConfig::simde)
 else()
-    message(STATUS "SIMDe not found via pkg-config. Falling back to find_path...")
-
     if(WIN32)
+        message(STATUS "SIMDe not found via pkg-config. Falling back to find_path in ENV{DK_ROOT}")
         find_path(SIMDE_INCLUDE_DIR
             NAMES simde/simde-common.h
             PATHS
@@ -39,6 +38,7 @@ else()
             NO_DEFAULT_PATH
     )
     elseif(UNIX)
+        message(STATUS "SIMDe not found via pkg-config. Falling back to find_path in default installed path")
         find_path(SIMDE_INCLUDE_DIR
             NAMES simde/simde-common.h
             PATHS
@@ -58,6 +58,6 @@ else()
         endif()
         set(SIMDE_TARGET SIMDE)
     else()
-        message(WARNING "could not find simde")
+        message(WARNING "Could not find simde, install simde package - Linux: libsimde-dev or Windows: update DK/simde")
     endif()
 endif()

--- a/projects/clr/rocclr/cmake/FindSIMDe.cmake
+++ b/projects/clr/rocclr/cmake/FindSIMDe.cmake
@@ -35,6 +35,7 @@ else()
             NAMES simde/simde-common.h
             PATHS
                 "$ENV{DK_ROOT}/simde"
+                "${THEROCK_BINARY_DIR}/third-party/simde/source"
             NO_DEFAULT_PATH
     )
     elseif(UNIX)

--- a/projects/clr/rocclr/cmake/FindSIMDe.cmake
+++ b/projects/clr/rocclr/cmake/FindSIMDe.cmake
@@ -45,6 +45,7 @@ else()
             PATHS
                 /usr/include
                 /usr/local/include
+                "${THEROCK_BINARY_DIR}/third-party/simde/source"
             NO_DEFAULT_PATH
     )
     endif()


### PR DESCRIPTION
fix some simde messages in error scenarios
convert PkgConfig to not required.
Add rock/third-party/simde to search paths for linux and windows

## Motivation
Better messages and fallback mechanism

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
SWDEV-538607

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
All builds and tests pass
Rock Build - linux and windows
Legacy build - linux and windows

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
NA

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
