### PR TITLE
[rocprofiler-sdk] Move device locking to context start/stop

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
@@ -98,17 +98,8 @@ CounterController::configure_agent_collection(rocprofiler_context_id_t          
         return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
     }
 
-    if(counters::counter_collection_has_device_lock())
-    {
-        /**
-         * Note: This should retrun if the lock fails to aquire in the future. However, this
-         * is a change in the required permissions for rocprofiler and needs to be communicated
-         * with partners before strict enforcement. If the required permissions are not obtained,
-         * those profilers will function as they currently do (without any of the benefits of the
-         * IOCTL).
-         */
-        counters::counter_collection_device_lock(rocprofiler::agent::get_agent(agent_id), true);
-    }
+    // Device lock is now context-based. Locked in @ref start_agent_ctx and unlocked in @ref
+    // stop_agent_ctx
 
     ctx.device_counter_collection->agent_data.emplace_back();
     ctx.device_counter_collection->agent_data.back().callback_data =

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
@@ -34,6 +34,7 @@
 #include "lib/rocprofiler-sdk/hsa/hsa.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
 #include "lib/rocprofiler-sdk/hsa/rocprofiler_packet.hpp"
+#include "rocprofiler-sdk/rocprofiler.h"
 
 #include <rocprofiler-sdk/fwd.h>
 
@@ -523,6 +524,12 @@ start_agent_ctx(const context::context* ctx)
             {
                 callback_data.device_locked = true;
             }
+            else
+            {
+                ROCP_WARNING << fmt::format("Failed to lock device for agent {} with status {}.",
+                                            callback_data.agent_id.handle,
+                                            rocprofiler_get_status_string(lock_status));
+            }
         }
 
         callback_data.packet->packets.start_packet.completion_signal = callback_data.start_signal;
@@ -595,16 +602,13 @@ stop_agent_ctx(const context::context* ctx)
         if(callback_data.device_locked && counter_collection_has_device_lock())
         {
             auto unlock_status = counter_collection_device_unlock(callback_data.profile->agent);
-            if(unlock_status == ROCPROFILER_STATUS_SUCCESS)
-            {
-                callback_data.device_locked = false;
-            }
-            else
-            {
-                ROCP_WARNING << fmt::format(
-                    "Failed to unlock device for agent {} after stopping counter collection.",
-                    callback_data.agent_id.handle);
-            }
+            callback_data.device_locked = false;
+
+            ROCP_WARNING_IF(unlock_status != ROCPROFILER_STATUS_SUCCESS)
+                << fmt::format("Failed to unlock device for agent {} with status {}. "
+                               "Counter values may be inaccurate.",
+                               callback_data.agent_id.handle,
+                               rocprofiler_get_status_string(unlock_status));
         }
     }
 
@@ -637,28 +641,7 @@ device_counting_service_finalize()
                         rocprofiler::context::device_counting_service::state::EXIT};
         };
 
-        if(counters::counter_collection_has_device_lock())
-        {
-            for(auto& callback_data : ctx->device_counter_collection->agent_data)
-            {
-                // Only attempt unlock if the device is actually locked
-                if(callback_data.device_locked && callback_data.profile)
-                {
-                    auto unlock_status =
-                        counter_collection_device_unlock(callback_data.profile->agent);
-                    if(unlock_status == ROCPROFILER_STATUS_SUCCESS)
-                    {
-                        callback_data.device_locked = false;
-                    }
-                    else
-                    {
-                        ROCP_WARNING << fmt::format(
-                            "Failed to unlock device for agent {} during finalization.",
-                            callback_data.agent_id.handle);
-                    }
-                }
-            }
-        }
+        // No need unlock, as KFD unlocks the agent when the process exits
     }
     return ROCPROFILER_STATUS_SUCCESS;
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
@@ -28,6 +28,7 @@
 #include "lib/rocprofiler-sdk/counters/controller.hpp"
 #include "lib/rocprofiler-sdk/counters/core.hpp"
 #include "lib/rocprofiler-sdk/counters/id_decode.hpp"
+#include "lib/rocprofiler-sdk/counters/ioctl.hpp"
 #include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
 #include "lib/rocprofiler-sdk/hsa/details/fmt.hpp"
 #include "lib/rocprofiler-sdk/hsa/hsa.hpp"
@@ -505,6 +506,25 @@ start_agent_ctx(const context::context* ctx)
             continue;
         }
 
+        if(!callback_data.device_locked && counters::counter_collection_has_device_lock())
+        {
+            /**
+             * Note: This should retrun if the lock fails to aquire in the future. However, this
+             * is a change in the required permissions for rocprofiler and needs to be communicated
+             * with partners before strict enforcement. If the required permissions are not
+             * obtained, those profilers will function as they currently do (without any of the
+             * benefits of the IOCTL). On some GPU hardware, this IOCTL also disables PTL, if
+             * supported.
+             */
+            auto lock_status =
+                counter_collection_device_lock(agent::get_agent(callback_data.agent_id), true);
+
+            if(lock_status == ROCPROFILER_STATUS_SUCCESS)
+            {
+                callback_data.device_locked = true;
+            }
+        }
+
         callback_data.packet->packets.start_packet.completion_signal = callback_data.start_signal;
         hsa::get_core_table()->hsa_signal_store_relaxed_fn(callback_data.start_signal, 1);
         submitPacket(agent->profile_queue(), &callback_data.packet->packets.start_packet);
@@ -571,6 +591,21 @@ stop_agent_ctx(const context::context* ctx)
                                                           1,
                                                           UINT64_MAX,
                                                           HSA_WAIT_STATE_ACTIVE);
+
+        if(callback_data.device_locked && counter_collection_has_device_lock())
+        {
+            auto unlock_status = counter_collection_device_unlock(callback_data.profile->agent);
+            if(unlock_status == ROCPROFILER_STATUS_SUCCESS)
+            {
+                callback_data.device_locked = false;
+            }
+            else
+            {
+                ROCP_WARNING << fmt::format(
+                    "Failed to unlock device for agent {} after stopping counter collection.",
+                    callback_data.agent_id.handle);
+            }
+        }
     }
 
     agent_ctx.status.exchange(rocprofiler::context::device_counting_service::state::DISABLED);
@@ -601,6 +636,29 @@ device_counting_service_finalize()
                         rocprofiler::context::device_counting_service::state::ENABLED,
                         rocprofiler::context::device_counting_service::state::EXIT};
         };
+
+        if(counters::counter_collection_has_device_lock())
+        {
+            for(auto& callback_data : ctx->device_counter_collection->agent_data)
+            {
+                // Only attempt unlock if the device is actually locked
+                if(callback_data.device_locked && callback_data.profile)
+                {
+                    auto unlock_status =
+                        counter_collection_device_unlock(callback_data.profile->agent);
+                    if(unlock_status == ROCPROFILER_STATUS_SUCCESS)
+                    {
+                        callback_data.device_locked = false;
+                    }
+                    else
+                    {
+                        ROCP_WARNING << fmt::format(
+                            "Failed to unlock device for agent {} during finalization.",
+                            callback_data.agent_id.handle);
+                    }
+                }
+            }
+        }
     }
     return ROCPROFILER_STATUS_SUCCESS;
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.hpp
@@ -64,6 +64,9 @@ struct agent_callback_data
     bool                                                   set_profile     = false;
     std::vector<rocprofiler_counter_record_t>*             cached_counters = nullptr;
 
+    // KFD IOCTL device lock state for this agent
+    bool device_locked = false;
+
     agent_callback_data() = default;
     agent_callback_data(agent_callback_data&& rhs) noexcept
     : queue(rhs.queue)
@@ -76,9 +79,14 @@ struct agent_callback_data
     , agent_id(rhs.agent_id)
     , cb(rhs.cb)
     , buffer(rhs.buffer)
+    , set_profile(rhs.set_profile)
+    , cached_counters(rhs.cached_counters)
+    , device_locked(rhs.device_locked)
     {
         rhs.completion.handle   = 0;
         rhs.start_signal.handle = 0;
+        rhs.cached_counters     = nullptr;
+        rhs.device_locked       = false;
     }
 
     agent_callback_data& operator=(const agent_callback_data&) = delete;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp
@@ -89,32 +89,45 @@ counter_collection_device_lock(const rocprofiler_agent_t* agent, bool all_queues
     return ROCPROFILER_STATUS_SUCCESS;
 }
 
-// Not required now but may be useful in the future.
-// rocprofiler_status_t
-// counter_collection_device_unlock(const rocprofiler_agent_t* agent) {
-//     CHECK(agent);
-//     kfd_ioctl_profiler_args args = {};
-//     args.op = KFD_IOC_PROFILER_PMC;
-//     args.pmc.gpu_id = agent->gpu_id;
-//     args.pmc.lock = 0;
-//     args.pmc.perfcount_enable = 0;
+rocprofiler_status_t
+counter_collection_device_unlock(const rocprofiler_agent_t* agent)
+{
+    CHECK(agent);
+    kfd_ioctl_profiler_args args = {};
+    args.op                      = KFD_IOC_PROFILER_PMC;
+    args.pmc.gpu_id              = agent->gpu_id;
+    args.pmc.lock                = 0;
+    args.pmc.perfcount_enable    = 0;
 
-//     int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PROFILER, &args);
-//     if (ret != 0) {
-//         switch (ret) {
-//             case -EBUSY:
-//             case -EPERM:
-//                 ROCP_WARNING << fmt::format("Could not unlock the device {}", agent->id.handle);
-//                 return ROCPROFILER_STATUS_ERROR;
-//             case -EINVAL:
-//                 return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI;
-//             default:
-//                 ROCP_WARNING << fmt::format("Could not unlock the device {}", agent->id.handle);
-//                 return ROCPROFILER_STATUS_ERROR;
-//         }
-//     }
+    int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PROFILER, &args);
+    if(ret != 0)
+    {
+        switch(ret)
+        {
+            case -EBUSY:
+                // retry?
+                ROCP_WARNING << fmt::format("Device {} is busy and could not be unlocked.",
+                                            agent->id.handle);
+                return ROCPROFILER_STATUS_ERROR_OUT_OF_RESOURCES;
+            case -EPERM:
+                ROCP_WARNING << fmt::format(
+                    "Device {} could not be unlocked due to lack of permissions (capability "
+                    "SYS_PERFMON). This is probably a bug.",
+                    agent->id.handle);
+                return ROCPROFILER_STATUS_ERROR_PERMISSION_DENIED;
+            case -EINVAL:
+                ROCP_WARNING << fmt::format(
+                    "Driver/Kernel version does not support unlocking device {}. PTL may remain "
+                    "disabled. This is probably a bug.",
+                    agent->id.handle);
+                return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI;
+            default:
+                ROCP_WARNING << fmt::format("Failed to unlock device {}.", agent->id.handle);
+                return ROCPROFILER_STATUS_ERROR;
+        }
+    }
 
-//     return ROCPROFILER_STATUS_SUCCESS;
-// }
+    return ROCPROFILER_STATUS_SUCCESS;
+}
 }  // namespace counters
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.hpp
@@ -34,5 +34,8 @@ counter_collection_has_device_lock();
 rocprofiler_status_t
 counter_collection_device_lock(const rocprofiler_agent_t* agent, bool all_queues);
 
+rocprofiler_status_t
+counter_collection_device_unlock(const rocprofiler_agent_t* agent);
+
 }  // namespace counters
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/device_counting.cpp
@@ -29,6 +29,7 @@
 #include "lib/rocprofiler-sdk/counters/metrics.hpp"
 #include "lib/rocprofiler-sdk/counters/tests/code_object_loader.hpp"
 #include "lib/rocprofiler-sdk/counters/tests/hsa_tables.hpp"
+#include "lib/rocprofiler-sdk/details/kfd_ioctl.h"
 #include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
 #include "lib/rocprofiler-sdk/registration.hpp"
@@ -44,7 +45,9 @@
 #include <hsa/hsa.h>
 #include <hsa/hsa_api_trace.h>
 #include <hsa/hsa_ext_amd.h>
+#include <sys/ioctl.h>
 
+#include <cerrno>
 #include <cstddef>
 #include <cstdint>
 #include <sstream>
@@ -99,14 +102,17 @@ findDeviceMetrics(const hsa::AgentCache& agent, const std::unordered_set<std::st
 void
 test_init()
 {
-    HsaApiTable table;
-    table.amd_ext_ = &get_ext_table();
-    table.core_    = &get_api_table();
-    rocprofiler::hsa::copy_table(table.core_, 0);
-    rocprofiler::hsa::copy_table(table.amd_ext_, 0);
-    agent::construct_agent_cache(&table);
-    ASSERT_TRUE(hsa::get_queue_controller() != nullptr);
-    hsa::get_queue_controller()->init(get_api_table(), get_ext_table());
+    static std::once_flag once{};
+    std::call_once(once, [&]() {
+        HsaApiTable table;
+        table.amd_ext_ = &get_ext_table();
+        table.core_    = &get_api_table();
+        rocprofiler::hsa::copy_table(table.core_, 0);
+        rocprofiler::hsa::copy_table(table.amd_ext_, 0);
+        agent::construct_agent_cache(&table);
+        ASSERT_TRUE(hsa::get_queue_controller() != nullptr);
+        hsa::get_queue_controller()->init(get_api_table(), get_ext_table());
+    });
 }
 
 common::Synchronized<std::vector<rocprofiler_record_counter_t>>&
@@ -263,6 +269,49 @@ get_agent_data_from_ctx(rocprofiler_context_id_t ctx, const rocprofiler_agent_t*
     return &(*it);
 }
 
+bool
+expect_device_lock(rocprofiler_context_id_t ctx, const rocprofiler_agent_t* agent)
+{
+    std::once_flag once{};
+
+    int kfd_ioctl_status = -EPERM;
+
+    // Check if we can lock the device using the KFD IOCTL
+    std::call_once(once, [&]() {
+        if(!counters::counter_collection_has_device_lock()) return;
+
+        int kfd_fd = open("/dev/kfd", O_RDWR | O_CLOEXEC);
+        if(kfd_fd == -1)
+        {
+            return;
+        }
+
+        kfd_ioctl_profiler_args args = {};
+        args.op                      = KFD_IOC_PROFILER_PMC;
+        args.pmc.gpu_id              = agent->gpu_id;
+        args.pmc.lock                = 1;
+        args.pmc.perfcount_enable    = 0;
+
+        kfd_ioctl_status = ::ioctl(kfd_fd, AMDKFD_IOC_PROFILER, &args);
+        if(kfd_ioctl_status != 0)
+        {
+            close(kfd_fd);
+            return;
+        }
+
+        args.pmc.gpu_id           = agent->gpu_id;
+        args.pmc.lock             = 0;
+        args.pmc.perfcount_enable = 0;
+
+        auto ret = ::ioctl(kfd_fd, AMDKFD_IOC_PROFILER, &args);
+        ASSERT_EQ(ret, 0) << "Unable to unlock device when lock was successful";
+        close(kfd_fd);
+    });
+
+    const auto* agent_data = get_agent_data_from_ctx(ctx, agent);
+    return (kfd_ioctl_status == 0) && !agent_data->profile->reqired_hw_counters.empty();
+}
+
 }  // namespace
 
 class device_counting_service_test : public ::testing::Test
@@ -282,6 +331,9 @@ protected:
         test_init();
         // rocprofiler_debugger_block();
         counters::device_counting_service_hsa_registration();
+
+        const bool has_device_lock = counters::counter_collection_has_device_lock();
+        ROCP_WARNING_IF(!has_device_lock) << fmt::format("Kernel does not support device lock");
 
         std::string kernel_name = "null_kernel";
 
@@ -400,6 +452,9 @@ protected:
                         static_cast<void*>(&cfg_id)),
                     "Could not create agent collection");
 
+                const auto* agent_data = get_agent_data_from_ctx(ctx, agent.get_rocp_agent());
+                EXPECT_FALSE(agent_data->device_locked) << "Device should be unlocked";
+
                 // This queue will only be present if a context exists when AgentCache is
                 // construction This is a workaround for the test environment since we create
                 // contexts after AgentCache constructed.
@@ -423,8 +478,10 @@ protected:
 
                 ROCPROFILER_CALL(status, "Could not start context");
 
-                const auto* agent_data = get_agent_data_from_ctx(ctx, agent.get_rocp_agent());
-                EXPECT_TRUE(agent_data->device_locked) << "Device should be locked";
+                if(expect_device_lock(ctx, agent.get_rocp_agent()))
+                {
+                    EXPECT_TRUE(agent_data->device_locked) << "Device should be locked";
+                }
 
                 // Execute kernel
                 submitPacket(queue, &kernel_pkt);
@@ -462,7 +519,10 @@ protected:
                 ROCPROFILER_CALL(rocprofiler_stop_context(ctx), "Could not stop context");
                 rocprofiler_flush_buffer(opt_buff_id);
 
-                EXPECT_FALSE(agent_data->device_locked) << "Device should be unlocked";
+                if(expect_device_lock(ctx, agent.get_rocp_agent()))
+                {
+                    EXPECT_FALSE(agent_data->device_locked) << "Device should be unlocked";
+                }
 
                 if(hsa_signal_wait_relaxed(found_data,
                                            HSA_SIGNAL_CONDITION_EQ,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/device_counting.cpp
@@ -25,6 +25,7 @@
 #include "lib/common/utility.hpp"
 #include "lib/rocprofiler-sdk/agent.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
+#include "lib/rocprofiler-sdk/counters/ioctl.hpp"
 #include "lib/rocprofiler-sdk/counters/metrics.hpp"
 #include "lib/rocprofiler-sdk/counters/tests/code_object_loader.hpp"
 #include "lib/rocprofiler-sdk/counters/tests/hsa_tables.hpp"
@@ -239,6 +240,29 @@ submitPacket(hsa_queue_t* queue, const void* packet)
     return write_idx;
 }
 
+const rocprofiler::counters::agent_callback_data*
+get_agent_data_from_ctx(rocprofiler_context_id_t ctx, const rocprofiler_agent_t* agent)
+{
+    using namespace rocprofiler::counters;
+    const auto* ctx_obj = context::get_registered_context(ctx);
+
+    [&]() {
+        ASSERT_NE(ctx_obj, nullptr);
+        ASSERT_NE(ctx_obj->device_counter_collection, nullptr);
+        ASSERT_GT(ctx_obj->device_counter_collection->agent_data.size(), 0);
+    }();
+
+    const auto& agents = ctx_obj->device_counter_collection->agent_data;
+    auto        it =
+        std::find_if(agents.begin(), agents.end(), [&](const agent_callback_data& agent_data) {
+            return agent_data.agent_id.handle == agent->id.handle;
+        });
+
+    EXPECT_NE(it, agents.end())
+        << "Agent with specified agent_id not found, this should not happen";
+    return &(*it);
+}
+
 }  // namespace
 
 class device_counting_service_test : public ::testing::Test
@@ -399,6 +423,9 @@ protected:
 
                 ROCPROFILER_CALL(status, "Could not start context");
 
+                const auto* agent_data = get_agent_data_from_ctx(ctx, agent.get_rocp_agent());
+                EXPECT_TRUE(agent_data->device_locked) << "Device should be locked";
+
                 // Execute kernel
                 submitPacket(queue, &kernel_pkt);
                 submitPacket(queue, &kernel_pkt);
@@ -434,6 +461,8 @@ protected:
                 }
                 ROCPROFILER_CALL(rocprofiler_stop_context(ctx), "Could not stop context");
                 rocprofiler_flush_buffer(opt_buff_id);
+
+                EXPECT_FALSE(agent_data->device_locked) << "Device should be unlocked";
 
                 if(hsa_signal_wait_relaxed(found_data,
                                            HSA_SIGNAL_CONDITION_EQ,


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Move device locking into `start_agent_ctx` and `stop_agent_ctx` for agent device collection mode, instead of locking and unlocking at profile creation/destruction. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- **State tracking**: Added `device_locked` boolean flag to `agent_callback_data` struct to track per-agent lock state.
- **Moved lock acquisition**: Device locking has been removed from `configure_agent_collection` and added to `start_agent_ctx` (lock) `stop_agent_ctx` (unlock) in `device_counting.cpp`, ensuring locks are only held when actively collecting counters. Cleanup also unlocks agent if context is not stopped. 


## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

[in development]

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
