### PR TITLE
fix: resolve crash when profiling TensorFlow GPU application

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
@@ -44,10 +44,10 @@
 #include <timemory/utility/types.hpp>
 
 #include <csignal>
-#include <cstring>
 #include <dlfcn.h>
 #include <ostream>
 #include <pthread.h>
+#include <string_view>
 #include <utility>
 
 namespace rocprofsys
@@ -544,19 +544,28 @@ pthread_create_gotcha::get_native_handles()
 
 namespace
 {
+constexpr const char* rocm_internal_libraries[] = { "libhsa-runtime64",
+                                                    "librocprofiler-sdk", "libamdhip64" };
+
 bool
 is_rocm_internal_thread(void* func_ptr)
 {
     if(!func_ptr) return false;
 
     Dl_info info;
-    if(dladdr(func_ptr, &info) == 0 || info.dli_fname == nullptr) return false;
+    if(dladdr(func_ptr, &info) == 0 || info.dli_fname == nullptr)
+    {
+        ROCPROFSYS_VERBOSE(4, "dladdr failed or returned no filename for func_ptr=%p\n",
+                           func_ptr);
+        return false;
+    }
 
-    const char* lib_name = info.dli_fname;
+    std::string_view lib_name{ info.dli_fname };
 
-    if(std::strstr(lib_name, "libhsa-runtime64") != nullptr) return true;
-    if(std::strstr(lib_name, "librocprofiler-sdk") != nullptr) return true;
-    if(std::strstr(lib_name, "libamdhip64") != nullptr) return true;
+    for(const auto* lib : rocm_internal_libraries)
+    {
+        if(lib_name.find(lib) != std::string_view::npos) return true;
+    }
 
     return false;
 }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
@@ -44,6 +44,8 @@
 #include <timemory/utility/types.hpp>
 
 #include <csignal>
+#include <cstring>
+#include <dlfcn.h>
 #include <ostream>
 #include <pthread.h>
 #include <utility>
@@ -540,11 +542,38 @@ pthread_create_gotcha::get_native_handles()
     return _v;
 }
 
+namespace
+{
+bool
+is_rocm_internal_thread(void* func_ptr)
+{
+    if(!func_ptr) return false;
+
+    Dl_info info;
+    if(dladdr(func_ptr, &info) == 0 || info.dli_fname == nullptr) return false;
+
+    const char* lib_name = info.dli_fname;
+
+    if(std::strstr(lib_name, "libhsa-runtime64") != nullptr) return true;
+    if(std::strstr(lib_name, "librocprofiler-sdk") != nullptr) return true;
+    if(std::strstr(lib_name, "libamdhip64") != nullptr) return true;
+
+    return false;
+}
+}  // namespace
+
 // pthread_create
 int
 pthread_create_gotcha::operator()(pthread_t* thread, const pthread_attr_t* attr,
                                   void* (*func)(void*), void*              arg) const
 {
+    // Bypass wrapper for internal ROCm threads to avoid interfering with their event
+    // loops
+    if(is_rocm_internal_thread(reinterpret_cast<void*>(func)))
+    {
+        return (*m_wrappee)(thread, attr, func, arg);
+    }
+
     auto        _tid          = utility::get_thread_index();
     auto        _thr_state    = get_thread_state();
     auto        _glob_state   = get_state();

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/jpeg-decode/validation-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/jpeg-decode/validation-rules.json
@@ -63,7 +63,7 @@
             ]
         },
         {
-            "min_rows": 3,
+            "min_rows": 2,
             "name": "threads",
             "required_columns": [
                 "tid",

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/roctx/validation-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/roctx/validation-rules.json
@@ -84,7 +84,7 @@
             ]
         },
         {
-            "min_rows": 3,
+            "min_rows": 2,
             "name": "threads",
             "required_columns": [
                 "tid",

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/transpose/validation-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/transpose/validation-rules.json
@@ -84,7 +84,7 @@
             ]
         },
         {
-            "min_rows": 3,
+            "min_rows": 2,
             "name": "threads",
             "required_columns": [
                 "tid",


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Profiling TensorFlow GPU application with rocprof-sys-run causes a crash. The backtrace shows the crash originates in AsyncEventsLoop (HSA runtime's internal event monitoring thread) while the pthread_create_gotcha wrapper is active.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Root Cause: The pthread_create_gotcha wrapper instruments all threads including internal ROCm library threads. These internal threads run infinite blocking loops to monitor GPU signals and should not be wrapped.
Crash Backtrace:
#0  0x00007fffe5aec59f in rocr::core::Runtime::AsyncEventsLoop(void*) () from /opt/rocm-7.1.1/lib/libhsa-runtime64.so.1  <- **CRASH**
#1  0x00007fffe5b53831 in rocr::os::ThreadTrampoline(void*) () from /opt/rocm-7.1.1/lib/libhsa-runtime64.so.1
#2  0x00007ffff4ac82e2 in rocprofsys::component::pthread_create_gotcha::wrapper::operator() (this=0x5555649e7770) at /workspace/rocm-systems/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp:356  <- **Wrapper active**

Evidence from HSA Runtime (rocr-runtime/runtime.cpp):
void Runtime::AsyncEventsLoop(void* _eventsInfo) {
    while(!async_events_control_exit){
        //Blocks waiting for GPU completion signals
        index = Signal::WaitMultiple(..., HSA_WAIT_STATE_BLOCKED, ...);
        //Process internal HSA events
        processEvent(index, value[0], wait_any);
    }
}

This thread monitors GPU completion signals in a blocking loop - it doesn't execute user kernels and provides no profiling value.
Fix: Added is_rocm_internal_thread() using dladdr() to detect if the thread originates from libhsa-runtime64, librocprofiler-sdk, or libamdhip64. Bypass the wrapper for these internal threads.
This also follows from rocprofiler-sdk/internal_threading.h:
"the HIP, HSA internal threads are typically background threads which just monitor kernel completion"

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
- SWDEV-525956
- AIPROFSYST-44

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Tested profiling TensorFlow GPU application (example.py) with multiple modes:
- ROCPROFSYS_MODE=trace
- ROCPROFSYS_MODE=sampling
- Default mode

## Test Result

<!-- Briefly summarize test outcomes. -->

- All profiling modes complete successfully without crash on NAVI, MI300, 308, 325, 350 and 355.
- Perfetto/rocgdb output generated properly
- Finalization completes normally
<img width="1422" height="677" alt="image" src="https://github.com/user-attachments/assets/41ea7a5d-f6b6-4f7d-abca-747900c1ec79" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
