### PR TITLE
[rocprofiler-systems] Add SIGKILL delay option 

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -838,6 +838,11 @@ configure_settings(bool _init)
         "starting with '_' or containing '::_M'.",
         true, "causal", "analysis", "advanced");
 
+    ROCPROFSYS_CONFIG_SETTING(int, "ROCPROFSYS_KILL_DELAY",
+                              "Delay (in seconds) before terminating the process "
+                              "after a kill signal is received.",
+                              0, "process", "advanced");
+
     // set the defaults
     _config->get_flamegraph_output()     = false;
     _config->get_ctest_notes()           = false;
@@ -2554,6 +2559,18 @@ get_caching_perfetto()
 {
     static auto _v = get_config()->at("ROCPROFSYS_TRACE_CACHED");
     return static_cast<tim::tsettings<bool>&>(*_v).get();
+}
+
+int
+get_kill_delay()
+{
+    static auto _v     = get_config()->find("ROCPROFSYS_KILL_DELAY");
+    auto        result = static_cast<tim::tsettings<int>&>(*_v->second).get();
+    if(result < 0)
+    {
+        static_cast<tim::tsettings<int>&>(*_v->second).set(0);
+    }
+    return result;
 }
 
 tmp_file::tmp_file(std::string _v)

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -843,6 +843,13 @@ configure_settings(bool _init)
                               "after a kill signal is received.",
                               0, "process", "advanced");
 
+    auto kill_delay_config = _config->find("ROCPROFSYS_KILL_DELAY")->second;
+    auto kill_delay_value  = kill_delay_config->get<int>().second;
+    if(kill_delay_value < 0)
+    {
+        kill_delay_config->set(0);
+    }
+
     // set the defaults
     _config->get_flamegraph_output()     = false;
     _config->get_ctest_notes()           = false;
@@ -2564,13 +2571,8 @@ get_caching_perfetto()
 int
 get_kill_delay()
 {
-    static auto _v     = get_config()->find("ROCPROFSYS_KILL_DELAY");
-    auto        result = static_cast<tim::tsettings<int>&>(*_v->second).get();
-    if(result < 0)
-    {
-        static_cast<tim::tsettings<int>&>(*_v->second).set(0);
-    }
-    return result;
+    static auto _v = get_config()->find("ROCPROFSYS_KILL_DELAY");
+    return static_cast<tim::tsettings<int>&>(*_v->second).get();
 }
 
 tmp_file::tmp_file(std::string _v)

--- a/projects/rocprofiler-systems/source/lib/core/config.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.hpp
@@ -358,6 +358,9 @@ get_trace_thread_join();
 bool
 get_use_tmp_files();
 
+int
+get_kill_delay();
+
 std::string
 get_tmpdir();
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/CMakeLists.txt
@@ -8,6 +8,7 @@ set(component_sources
     ${CMAKE_CURRENT_LIST_DIR}/cpu_freq.cpp
     ${CMAKE_CURRENT_LIST_DIR}/exit_gotcha.cpp
     ${CMAKE_CURRENT_LIST_DIR}/fork_gotcha.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/kill_gotcha.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mpi_gotcha.cpp
     ${CMAKE_CURRENT_LIST_DIR}/numa_gotcha.cpp
     ${CMAKE_CURRENT_LIST_DIR}/vaapi_gotcha.cpp
@@ -27,6 +28,7 @@ set(component_headers
     ${CMAKE_CURRENT_LIST_DIR}/ensure_storage.hpp
     ${CMAKE_CURRENT_LIST_DIR}/exit_gotcha.hpp
     ${CMAKE_CURRENT_LIST_DIR}/fork_gotcha.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/kill_gotcha.hpp
     ${CMAKE_CURRENT_LIST_DIR}/mpip.hpp
     ${CMAKE_CURRENT_LIST_DIR}/mpi_gotcha.hpp
     ${CMAKE_CURRENT_LIST_DIR}/numa_gotcha.hpp

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/kill_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/kill_gotcha.cpp
@@ -43,6 +43,13 @@ int
 kill_gotcha::operator()(const gotcha_data& _data, kill_func_t _func, pid_t _pid,
                         int _sig) const
 {
+    // When profiling multi-process applications where a parent process sends SIGKILL to
+    // child processes, the termination can occur before the profiler has a chance to
+    // flush collected data. This introduces a configurable delay before SIGKILL
+    // signals are forwarded, allowing profiling data to be captured before process
+    // termination.
+    // NOTE: This is a workaround.
+
     auto kill_delay = get_kill_delay();
     if(kill_delay > 0)
     {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/kill_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/kill_gotcha.cpp
@@ -1,0 +1,64 @@
+// MIT License
+//
+// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "kill_gotcha.hpp"
+#include "core/config.hpp"
+#include "core/debug.hpp"
+
+#include <cstdlib>
+#include <unistd.h>
+
+namespace rocprofsys
+{
+namespace component
+{
+void
+kill_gotcha::configure()
+{
+    kill_gotcha_t::get_initializer() = []() {
+        kill_gotcha_t::configure<0, int, pid_t, int>("kill");
+    };
+}
+
+int
+kill_gotcha::operator()(const gotcha_data& _data, kill_func_t _func, pid_t _pid,
+                        int _sig) const
+{
+    auto kill_delay = get_kill_delay();
+    if(kill_delay > 0)
+    {
+        auto _self_pid = getpid();
+
+        if(_sig == SIGKILL && _pid != _self_pid && _pid > 0)
+        {
+            ROCPROFSYS_DEBUG("[kill_gotcha] Intercepted '%s(%d, SIGKILL)' triggered from "
+                             "process with id: %d. Sleeping for %d seconds...\n",
+                             _data.tool_id.c_str(), _pid, _self_pid, kill_delay);
+
+            ::sleep(kill_delay);
+        }
+    }
+
+    return (*_func)(_pid, _sig);
+}
+}  // namespace component
+}  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/kill_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/kill_gotcha.hpp
@@ -1,0 +1,59 @@
+// MIT License
+//
+// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "core/defines.hpp"
+
+#include <timemory/components/base.hpp>
+#include <timemory/components/gotcha/backends.hpp>
+
+#include <csignal>
+#include <sys/types.h>
+
+namespace rocprofsys
+{
+namespace component
+{
+struct kill_gotcha : tim::component::base<kill_gotcha, void>
+{
+    static constexpr size_t gotcha_capacity = 1;
+
+    using gotcha_data = tim::component::gotcha_data;
+    using kill_func_t = int (*)(pid_t, int);
+
+    ROCPROFSYS_DEFAULT_OBJECT(kill_gotcha)
+
+    static std::string label() { return "kill_gotcha"; }
+
+    static void configure();
+
+    static inline void start() {}
+    static inline void stop() {}
+
+    int operator()(const gotcha_data&, kill_func_t, pid_t, int) const;
+};
+}  // namespace component
+
+using kill_gotcha_t = tim::component::gotcha<component::kill_gotcha::gotcha_capacity,
+                                             std::tuple<>, component::kill_gotcha>;
+}  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/runtime.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/runtime.cpp
@@ -198,6 +198,7 @@ setup_gotchas()
     component::mpi_gotcha::configure();
     component::exit_gotcha::configure();
     component::fork_gotcha::configure();
+    component::kill_gotcha::configure();
 }
 }  // namespace
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/runtime.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/runtime.hpp
@@ -30,6 +30,7 @@
 #include "library/causal/components/causal_gotcha.hpp"
 #include "library/components/exit_gotcha.hpp"
 #include "library/components/fork_gotcha.hpp"
+#include "library/components/kill_gotcha.hpp"
 #include "library/components/mpi_gotcha.hpp"
 #include "library/components/numa_gotcha.hpp"
 #include "library/components/pthread_gotcha.hpp"
@@ -49,7 +50,7 @@ namespace rocprofsys
 {
 // started during preinit phase
 using preinit_bundle_t =
-    tim::lightweight_tuple<exit_gotcha_t, fork_gotcha_t, mpi_gotcha_t>;
+    tim::lightweight_tuple<exit_gotcha_t, fork_gotcha_t, mpi_gotcha_t, kill_gotcha_t>;
 
 // started during init phase
 using init_bundle_t = tim::lightweight_tuple<causal::component::causal_gotcha,


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
When profiling multi-process applications where a parent process sends SIGKILL to child processes, the termination can occur before the profiler has a chance to flush collected data. This PR introduces a configurable delay before SIGKILL signals are forwarded, allowing profiling data to be captured before process termination. This is workaround.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Added new configuration setting `ROCPROFSYS_KILL_DELAY` (default: 0 seconds) to specify a delay before SIGKILL signals are forwarded to other processes
- Implemented `kill_gotcha` component that intercepts the `kill()` system call
- The gotcha only delays SIGKILL signals sent to external processes (pid > 0 and not self)
- Integrated `kill_gotcha_t` into the `preinit_bundle_t` for early initialization

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFSYST-74

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
1. Run a multi-process application where parent sends SIGKILL to children with `ROCPROFSYS_KILL_DELAY=0` (default behavior should be unchanged)
2. Run the same application with `ROCPROFSYS_KILL_DELAY=5` and verify the delay before child process termination
3. Verify that SIGKILL to self (getpid()) is not delayed
4. Verify that other signals (SIGTERM, etc.) are not affected by this setting

## Test Result

<!-- Briefly summarize test outcomes. -->
- With `ROCPROFSYS_KILL_DELAY=0`: No delay, identical behavior to unpatched version
- With `ROCPROFSYS_KILL_DELAY=N`: N-second delay before SIGKILL is sent to external processes, allowing profiler to flush data
- Debug message should be printed when delay is active (in debug mode)
- 
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
