### PR TITLE
Fix vaddr overlapping ranges on windows

### DIFF
--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -36,19 +36,21 @@ std::unordered_set<hipArray*> hipArraySet;
 
 // ================================================================================================
 amd::Memory* getMemoryObject(const void* ptr, size_t& offset, size_t size) {
-  auto memObj = amd::MemObjMap::FindMemObj(ptr, &offset);
-  if (memObj == nullptr) {
+  hip::Device* device = hip::getCurrentDevice();
+  amd::Device* currentDev = (device != nullptr) ? device->devices()[0] : nullptr;
+  auto memObj = amd::MemObjMap::FindMemObj(ptr, &offset, currentDev);
+
+  if (memObj == nullptr && device != nullptr) {
     // If memObj not found, use arena_mem_obj. arena_mem_obj is null, if HMM is disabled.
-    memObj =
-        (hip::getCurrentDevice()->asContext()->svmDevices()[0])->GetArenaMemObj(ptr, offset, size);
+    memObj = (device->asContext()->svmDevices()[0])->GetArenaMemObj(ptr, offset, size);
   }
 
   // On Windows, when using hipHostRegister, the map may contain a single memory object for
   // multiple devices. This is because device addresses can overlap.
   // The offset needs to be calculated relative to the memory of the current device.
-  if (IS_WINDOWS && (memObj != nullptr) && (memObj->getMemFlags() & CL_MEM_USE_HOST_PTR)) {
-    device::Memory* currentDevMem =
-        memObj->getDeviceMemory(*hip::getCurrentDevice()->devices()[0], false);
+  if (IS_WINDOWS && (memObj != nullptr) && (memObj->getMemFlags() & CL_MEM_USE_HOST_PTR) &&
+      currentDev != nullptr) {
+    device::Memory* currentDevMem = memObj->getDeviceMemory(*currentDev, false);
     if (currentDevMem != nullptr) {
       size_t currentDevOffset = reinterpret_cast<uint64_t>(ptr) - currentDevMem->virtualAddress();
       if (currentDevOffset < memObj->getSize()) {
@@ -1337,12 +1339,14 @@ hipError_t ihipHostRegister(void* hostPtr, size_t sizeBytes, unsigned int flags)
 
     amd::MemObjMap::AddMemObj(hostPtr, mem);
     for (const auto& device : g_devices) {
-      // Since the amd::Memory object is shared between all devices
-      // it's fine to have multiple addresses mapped to it
-      const device::Memory* devMem = mem->getDeviceMemory(*device->devices()[0]);
-      void* vAddr = reinterpret_cast<void*>(devMem->virtualAddress());
-      if ((hostPtr != vAddr) && (amd::MemObjMap::FindMemObj(vAddr) == nullptr)) {
-        amd::MemObjMap::AddMemObj(vAddr, mem);
+      // Each device maintains its own VA->memory mapping to avoid conflicts
+      amd::Device* amdDevice = device->devices()[0];
+      const device::Memory* devMem = mem->getDeviceMemory(*amdDevice);
+      if (devMem != nullptr) {
+        void* vAddr = reinterpret_cast<void*>(devMem->virtualAddress());
+        if (hostPtr != vAddr) {
+          amdDevice->AddDevMemObj(vAddr, mem);
+        }
       }
     }
 
@@ -1375,11 +1379,13 @@ hipError_t ihipHostUnregister(void* hostPtr) {
 
     amd::MemObjMap::RemoveMemObj(hostPtr);
     for (const auto& device : g_devices) {
-      const device::Memory* devMem = mem->getDeviceMemory(*device->devices()[0]);
+      // Remove device VA from per-device map
+      amd::Device* amdDevice = device->devices()[0];
+      const device::Memory* devMem = mem->getDeviceMemory(*amdDevice);
       if (devMem != nullptr) {
         void* vAddr = reinterpret_cast<void*>(devMem->virtualAddress());
-        if ((vAddr != hostPtr) && amd::MemObjMap::FindMemObj(vAddr)) {
-          amd::MemObjMap::RemoveMemObj(vAddr);
+        if (vAddr != hostPtr) {
+          amdDevice->RemoveDevMemObj(vAddr);
         }
       }
     }

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -373,27 +373,32 @@ void MemObjMap::RemoveMemObj(const void* k) {
   guarantee(rval == 1, "Memobj map does not have ptr: 0x%x", reinterpret_cast<uintptr_t>(k));
 }
 
-amd::Memory* MemObjMap::FindMemObj(const void* k, size_t* offset) {
+amd::Memory* MemObjMap::FindMemObj(const void* k, size_t* offset, Device* dev) {
   std::shared_lock lock(AllocatedLock_);
   uintptr_t key = reinterpret_cast<uintptr_t>(k);
+
+  // First search the global map
   auto it = MemObjMap_.upper_bound(key);
-  if (it == MemObjMap_.begin()) {
-    return nullptr;
+  if (it != MemObjMap_.begin()) {
+    --it;
+    amd::Memory* mem = it->second;
+    size_t mem_size = (mem->getMemFlags() & ROCCLR_MEM_PHYMEM)
+                          ? sizeof(mem->getUserData().hsa_handle)
+                          : mem->getSize();
+    if (key >= it->first && key < (it->first + mem_size)) {
+      if (offset != nullptr) {
+        *offset = key - it->first;
+      }
+      return mem;
+    }
   }
 
-  --it;
-  amd::Memory* mem = it->second;
-  size_t mem_size = (mem->getMemFlags() & ROCCLR_MEM_PHYMEM) ? sizeof(mem->getUserData().hsa_handle)
-                                                             : mem->getSize();
-  if (key >= it->first && key < (it->first + mem_size)) {
-    if (offset != nullptr) {
-      *offset = key - it->first;
-    }
-    // the k is in the range
-    return mem;
-  } else {
-    return nullptr;
+  // Search per-device va maps on Windows (due to overlapping ranges)
+  if (IS_WINDOWS && dev != nullptr) {
+    return dev->FindDevMemObj(k, offset);
   }
+
+  return nullptr;
 }
 
 void MemObjMap::UpdateAccess(amd::Device* peerDev) {
@@ -1178,6 +1183,45 @@ void Device::RemoveHostcallMemory(amd::Memory* memory) {
   if (it != hostcall_allocated_memories_.end()) {
     hostcall_allocated_memories_.erase(it);
   }
+}
+
+// ================================================================================================
+void Device::AddDevMemObj(const void* k, amd::Memory* memObj) {
+  std::unique_lock lock(MemObjMap::AllocatedLock_);
+  auto rval = devMemObjMap_.insert({reinterpret_cast<uintptr_t>(k), memObj});
+  if (!rval.second) {
+    ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_MEM,
+            "Device memobj map already has an entry for VA: 0x%llx",
+            reinterpret_cast<uintptr_t>(k));
+  }
+}
+
+// ================================================================================================
+void Device::RemoveDevMemObj(const void* k) {
+  std::unique_lock lock(MemObjMap::AllocatedLock_);
+  devMemObjMap_.erase(reinterpret_cast<uintptr_t>(k));
+}
+
+// ================================================================================================
+amd::Memory* Device::FindDevMemObj(const void* k, size_t* offset) const {
+  uintptr_t key = reinterpret_cast<uintptr_t>(k);
+  auto it = devMemObjMap_.upper_bound(key);
+  if (it == devMemObjMap_.begin()) {
+    return nullptr;
+  }
+
+  --it;
+  amd::Memory* mem = it->second;
+  size_t mem_size = (mem->getMemFlags() & ROCCLR_MEM_PHYMEM)
+                        ? sizeof(mem->getUserData().hsa_handle)
+                        : mem->getSize();
+  if (key >= it->first && key < (it->first + mem_size)) {
+    if (offset != nullptr) {
+      *offset = key - it->first;
+    }
+    return mem;
+  }
+  return nullptr;
 }
 
 }  // namespace amd

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1389,7 +1389,7 @@ class MemObjMap : public AllStatic {
   static void RemoveMemObj(const void* k);
 
   //!< Find the mem object based on the input pointer, outputs the offset
-  static amd::Memory* FindMemObj(const void* k, size_t* offset = nullptr);
+  static amd::Memory* FindMemObj(const void* k, size_t* offset = nullptr, Device* dev = nullptr);
   static void UpdateAccess(amd::Device* peerDev);
   //!< Purge all user allocated memories on the given device
   static void Purge(amd::Device* dev);
@@ -1408,13 +1408,14 @@ class MemObjMap : public AllStatic {
   //!< Same as FindMemObj but for ipc handle to MemObj mapping
   static amd::Memory* FindIpcHandleMemObj(const IpcMemHandle& k);
 
+  //!< Shared read/write lock for all MemObjMap operations (including per-device maps)
+  static std::shared_mutex AllocatedLock_;
+
  private:
   //!< the mem object<->hostptr information container
   static std::map<uintptr_t, amd::Memory*> MemObjMap_;
   //!< the virtual mem object<->hostptr information container
   static std::map<uintptr_t, amd::Memory*> VirtualMemObjMap_;
-  //!< Shared read/write lock
-  static std::shared_mutex AllocatedLock_;
   //!< the ipc handle<->mem object information container
   static std::map<IpcMemHandle, amd::Memory*> IpcHandleMemObjMap_;
 };
@@ -2180,6 +2181,15 @@ class Device : public RuntimeObject {
   //! Enable the specified extension
   char* getExtensionString();
 
+  //! Adds object<->vaddr mapping for this device
+  void AddDevMemObj(const void* k, amd::Memory* memObj);
+
+  //! Removes object<->vaddr mapping for this device
+  void RemoveDevMemObj(const void* k);
+
+  //! Finds a memory object by device virtual address for this device
+  amd::Memory* FindDevMemObj(const void* k, size_t* offset = nullptr) const;
+
   device::Info info_;           //!< Device info structure
   device::Settings* settings_;  //!< Device settings
   union {
@@ -2224,6 +2234,9 @@ class Device : public RuntimeObject {
   Monitor* vaCacheAccess_;                            //!< Lock to serialize VA caching access
   std::map<uintptr_t, device::Memory*>* vaCacheMap_;  //!< VA cache map
   uint32_t index_;                                    //!< Unique device index
+
+  std::map<uintptr_t, amd::Memory*>
+      devMemObjMap_;  //!< Per-device VA map for interleaved device VAs (Windows)
   static constexpr int kDefaultNumaNode = -1;         //! Default NUMA node value for SVM operations
   // Tracks all amd::Memory objects allocated via hostcall for this device.
   std::vector<amd::Memory*> hostcall_allocated_memories_;


### PR DESCRIPTION
## Motivation

Some tests are failing on windows because  PAL returns non-unique memory ranges for hipHostRegister device allocations.

## Technical Details

Add per-device vamaps and fallback search when global lookup fails.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
Resolved SWDEV-568794

## Test Plan

Tested with hipStreamValue_Wait* tests.

## Test Result

Tests are passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
