### PR TITLE
[AMD-SMI] [SWDEV-572092] amd-smi does not redirect output to file when --json option is used.

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -626,7 +626,7 @@ class AMDSMILogger():
             json_std_output = json.dumps(combined_json, indent=4)
             print(json_std_output)
         else:
-            with open(self.destination, 'w', encoding="utf-8") as output_file:
+            with self.destination.open('w', encoding="utf-8") as output_file:
                 json.dump(combined_json, output_file, indent=4)
 
 

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -622,7 +622,6 @@ class AMDSMILogger():
             combined_json["partition_profiles"] = self.store_partition_profiles_json_output
         if self.store_partition_resources_json_output:
             combined_json["partition_resources"] = self.store_partition_resources_json_output
-
         if self.destination == 'stdout':
             json_std_output = json.dumps(combined_json, indent=4)
             print(json_std_output)


### PR DESCRIPTION
<img width="509" height="495" alt="image" src="https://github.com/user-attachments/assets/07a32f55-aab4-4617-be04-8fd885bba7da" />
