### PR TITLE
[ci] Adding label for rocm-libraries to build

### DIFF
--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -3,6 +3,8 @@ This script determines which build flag and tests to run based on SUBTREES
 
 Required environment variables:
   - SUBTREES
+
+For documentation, please see docs/ci-behavior-manipulation.md
 """
 
 import fnmatch

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -9,9 +9,9 @@ import fnmatch
 import json
 import logging
 import subprocess
-from therock_matrix import subtree_to_project_map, project_map
+from therock_matrix import subtree_to_project_map, collect_projects_to_run
 import time
-from typing import Mapping, Optional, Iterable
+from typing import Mapping, Optional, Iterable, List
 import os
 
 logging.basicConfig(level=logging.INFO)
@@ -31,6 +31,16 @@ def set_github_output(d: Mapping[str, str]):
     with open(step_output_file, "a") as f:
         f.writelines(f"{k}={v}" + "\n" for k, v in d.items())
 
+
+def get_pr_labels(args) -> List[str]:
+    """Gets a list of labels applied to a pull request."""
+    data = json.loads(args.get("pr_labels"))
+    labels = []
+    for label in data.get("labels", []):
+        labels.append(label["name"])
+    return labels
+
+
 def retry(max_attempts, delay_seconds, exceptions):
     def decorator(func):
         def newfn(*args, **kwargs):
@@ -39,14 +49,19 @@ def retry(max_attempts, delay_seconds, exceptions):
                 try:
                     return func(*args, **kwargs)
                 except exceptions as e:
-                    print(f'Exception {str(e)} thrown when attempting to run , attempt {attempt} of {max_attempts}')
+                    print(
+                        f"Exception {str(e)} thrown when attempting to run , attempt {attempt} of {max_attempts}"
+                    )
                     attempt += 1
                     if attempt < max_attempts:
                         backoff = delay_seconds * (2 ** (attempt - 1))
                         time.sleep(backoff)
             return func(*args, **kwargs)
+
         return newfn
+
     return decorator
+
 
 @retry(max_attempts=3, delay_seconds=2, exceptions=(TimeoutError))
 def get_modified_paths(base_ref: str) -> Optional[Iterable[str]]:
@@ -148,27 +163,26 @@ def retrieve_projects(args):
     if related_to_therock_ci:
         subtrees = list(subtree_to_project_map.keys())
 
-    projects = set()
-    # collect the associated subtree to project
-    for subtree in subtrees:
-        if subtree in subtree_to_project_map:
-            projects.add(subtree_to_project_map.get(subtree))
+    enable_rocm_libraries = False
+    pr_labels = get_pr_labels(args)
+    for label in pr_labels:
+        if label == "enable-rocm-libraries":
+            enable_rocm_libraries = True
+            break
 
-    # retrieve the subtrees to checkout, cmake options to build, and projects to test
-    project_to_run = []
-    # Currently as we have no tests, we just build all packages available if an applicable change is made.
-    # As we start to get an idea of test times, we can divide test jobs.
-    if projects:
-        for project in ["all"]:
-            if project in project_map:
-                project_to_run.append(project_map.get(project))
+    project_to_run = collect_projects_to_run(subtrees, enable_rocm_libraries)
 
-    return project_to_run
+    return project_to_run, json.dumps(enable_rocm_libraries)
 
 
 def run(args):
-    project_to_run = retrieve_projects(args)
-    set_github_output({"projects": json.dumps(project_to_run)})
+    project_to_run, enable_rocm_libraries = retrieve_projects(args)
+    set_github_output(
+        {
+            "projects": json.dumps(project_to_run),
+            "enable_rocm_libraries": enable_rocm_libraries,
+        }
+    )
 
 
 if __name__ == "__main__":
@@ -185,6 +199,8 @@ if __name__ == "__main__":
     args["input_projects"] = input_projects
 
     args["base_ref"] = os.environ.get("BASE_REF", "HEAD^")
+
+    args["pr_labels"] = os.environ.get("PR_LABELS", '{"labels": []}')
 
     logging.info(f"Retrieved arguments {args}")
 

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -168,7 +168,6 @@ def retrieve_projects(args):
     for label in pr_labels:
         if label == "enable-rocm-libraries":
             enable_rocm_libraries = True
-            break
 
     project_to_run = collect_projects_to_run(subtrees, enable_rocm_libraries)
 

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -1,36 +1,73 @@
 """
 This dictionary is used to map specific file directory changes to the corresponding build flag and tests
 """
+from therock_configure_ci import get_pr_labels
+
 subtree_to_project_map = {
-    'projects/aqlprofile': 'profiler',
-    'projects/clr': 'core',
-    'projects/hip': 'core',
-    'projects/hip-tests': 'core',
-    'projects/hipother': 'core',
-    'projects/rdc': 'rdc',
-    'projects/rocm-core': 'core',
-    'projects/rocm-smi-lib': 'core',
-    'projects/rocminfo': 'core',
-    'projects/rocprofiler-compute': 'profiler',
-    'projects/rocprofiler-register': 'profiler',
-    'projects/rocprofiler-sdk': 'profiler',
-    'projects/rocprofiler-systems': 'profiler',
-    'projects/rocprofiler': 'profiler',
-    'projects/rocr-runtime': 'core',
-    'projects/roctracer': 'profiler'
+    "projects/aqlprofile": "profiler",
+    "projects/clr": "core",
+    "projects/hip": "core",
+    "projects/hip-tests": "core",
+    "projects/hipother": "core",
+    "projects/rdc": "rdc",
+    "projects/rocm-core": "core",
+    "projects/rocm-smi-lib": "core",
+    "projects/rocminfo": "core",
+    "projects/rocprofiler-compute": "profiler",
+    "projects/rocprofiler-register": "profiler",
+    "projects/rocprofiler-sdk": "profiler",
+    "projects/rocprofiler-systems": "profiler",
+    "projects/rocprofiler": "profiler",
+    "projects/rocr-runtime": "core",
+    "projects/roctracer": "profiler",
 }
 
 project_map = {
     "core": {
-        "cmake_options": "-DTHEROCK_ENABLE_CORE=ON -DTHEROCK_ENABLE_HIP_RUNTIME=ON -DTHEROCK_ENABLE_ALL=OFF",
+        "cmake_options": [
+            "-DTHEROCK_ENABLE_CORE=ON",
+            "-DTHEROCK_ENABLE_HIP_RUNTIME=ON",
+            "-DTHEROCK_ENABLE_ALL=OFF",
+        ],
         "project_to_test": "hip-tests",
     },
     "profiler": {
-        "cmake_options": "-DTHEROCK_ENABLE_PROFILER=ON -DTHEROCK_ENABLE_ALL=OFF",
+        "cmake_options": ["-DTHEROCK_ENABLE_PROFILER=ON", "-DTHEROCK_ENABLE_ALL=OFF"],
         "project_to_test": "rocprofiler-tests",
     },
     "all": {
-        "cmake_options": "-DTHEROCK_ENABLE_CORE=ON -DTHEROCK_ENABLE_PROFILER=ON -DTHEROCK_ENABLE_ALL=OFF",
+        "cmake_options": [
+            "-DTHEROCK_ENABLE_CORE=ON",
+            "-DTHEROCK_ENABLE_PROFILER=ON",
+            "-DTHEROCK_ENABLE_ALL=OFF",
+        ],
         "project_to_test": "hip-tests, rocprofiler-tests",
-    }
+    },
 }
+
+
+def collect_projects_to_run(subtrees, enable_rocm_libraries):
+    projects = set()
+    # collect the associated subtree to project
+    for subtree in subtrees:
+        if subtree in subtree_to_project_map:
+            projects.add(subtree_to_project_map.get(subtree))
+
+    # retrieve the subtrees to checkout, cmake options to build, and projects to test
+    project_to_run = []
+    # Currently as we have no tests, we just build all packages available if an applicable change is made.
+    # As we start to get an idea of test times, we can divide test jobs.
+    if projects:
+        for project in ["all"]:
+            if project in project_map:
+                # If the "enable_rocm_libraries" label is set, we allow the ROCm Libraries to be used and we build everything
+                if enable_rocm_libraries:
+                    project_map[project]["cmake_options"] = [
+                        "-DTHEROCK_ROCM_LIBRARIES_SOURCE_DIR=../rocm-libraries"
+                    ]
+
+                cmake_flag_options = " ".join(project_map[project]["cmake_options"])
+                project_map[project]["cmake_options"] = cmake_flag_options
+                project_to_run.append(project_map.get(project))
+
+    return project_to_run

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -1,8 +1,6 @@
 """
 This dictionary is used to map specific file directory changes to the corresponding build flag and tests
 """
-from therock_configure_ci import get_pr_labels
-
 subtree_to_project_map = {
     "projects/aqlprofile": "profiler",
     "projects/clr": "core",

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -61,7 +61,7 @@ def collect_projects_to_run(subtrees, enable_rocm_libraries):
                 # If the "enable_rocm_libraries" label is set, we allow the ROCm Libraries to be used and we build everything
                 if enable_rocm_libraries:
                     project_map[project]["cmake_options"] = [
-                        "-DTHEROCK_ROCM_LIBRARIES_SOURCE_DIR=../rocm-libraries"
+                        "-DTHEROCK_ROCM_LIBRARIES_SOURCE_DIR=../rocm-libraries", "-DTHEROCK_USE_EXTERNAL_COMPOSABLE_KERNEL=ON", "-DTHEROCK_COMPOSABLE_KERNEL_SOURCE_DIR=../composable_kernel"
                     ]
 
                 cmake_flag_options = " ".join(project_map[project]["cmake_options"])

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -53,6 +53,13 @@ jobs:
           repository: "ROCm/rocm-libraries"
           path: "rocm-libraries"
 
+      - name: Checkout composable_kernel repository
+        if: ${{ inputs.enable_rocm_libraries == 'true' }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: "ROCm/composable_kernel"
+          path: "composable_kernel"
+
       - name: Install python deps
         run: |
           pip install -r TheRock/requirements.txt

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -12,7 +12,7 @@ on:
       test_runs_on:
         type: string
       enable_rocm_libraries:
-        type: boolean
+        type: string
 
 
 permissions:
@@ -47,7 +47,7 @@ jobs:
           ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
 
       - name: Checkout TheRock repository
-        if: ${{ inputs.enable_rocm_libraries }}
+        if: ${{ inputs.enable_rocm_libraries == 'true' }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/rocm-libraries"

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -11,6 +11,8 @@ on:
         type: string
       test_runs_on:
         type: string
+      enable_rocm_libraries:
+        type: boolean
 
 
 permissions:
@@ -43,6 +45,13 @@ jobs:
           repository: "ROCm/TheRock"
           path: "TheRock"
           ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
+
+      - name: Checkout TheRock repository
+        if: ${{ inputs.enable_rocm_libraries }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: "ROCm/rocm-libraries"
+          path: "rocm-libraries"
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -11,6 +11,8 @@ on:
         type: string
       test_runs_on:
         type: string
+      enable_rocm_libraries:
+        type: boolean
 
 permissions:
   contents: read
@@ -40,6 +42,13 @@ jobs:
           repository: "ROCm/TheRock"
           path: "TheRock"
           ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
+
+      - name: Checkout TheRock repository
+        if: ${{ inputs.enable_rocm_libraries }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: "ROCm/rocm-libraries"
+          path: "rocm-libraries"
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -33,6 +33,10 @@ jobs:
       CCACHE_MAXSIZE: "700M"
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
     steps:
+      - name: Configure GitHub longpath
+        run: |
+          git config --global core.longpaths true
+
       - name: "Checking out repository for rocm-systems"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -12,7 +12,7 @@ on:
       test_runs_on:
         type: string
       enable_rocm_libraries:
-        type: boolean
+        type: string
 
 permissions:
   contents: read
@@ -44,7 +44,7 @@ jobs:
           ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
 
       - name: Checkout TheRock repository
-        if: ${{ inputs.enable_rocm_libraries }}
+        if: ${{ inputs.enable_rocm_libraries == 'true' }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/rocm-libraries"

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -43,12 +43,19 @@ jobs:
           path: "TheRock"
           ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
 
-      - name: Checkout TheRock repository
+      - name: Checkout rocm-libraries repository (if enabled)
         if: ${{ inputs.enable_rocm_libraries == 'true' }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/rocm-libraries"
           path: "rocm-libraries"
+
+      - name: Checkout composable_kernel repository (if enabled)
+        if: ${{ inputs.enable_rocm_libraries == 'true' }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: "ROCm/composable_kernel"
+          path: "composable_kernel"
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -10,6 +10,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - labeled
   workflow_dispatch:
     inputs:
       projects:
@@ -39,6 +40,7 @@ jobs:
       projects: ${{ steps.projects.outputs.projects }}
       linux_package_targets: ${{ steps.configure_linux.outputs.package_targets }}
       windows_package_targets: ${{ steps.configure_windows.outputs.package_targets }}
+      enable_rocm_libraries: ${{ steps.projects.outputs.enable_rocm_libraries }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -63,6 +65,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pydantic requests
+
+      - name: Set PR_LABELS variable with labels assigned to pull request
+        if: ${{ github.event.pull_request }} # only set PR labels var if this is a pull request
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo "PR_LABELS=$(gh pr view ${PR_NUMBER} --json labels)" >> $GITHUB_ENV
 
       - name: Detect changed subtrees
         id: detect
@@ -124,6 +134,7 @@ jobs:
       project_to_test: ${{ matrix.projects.project_to_test }}
       amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
       test_runs_on: ${{ matrix.target_bundle.test_machine }}
+      enable_rocm_libraries: ${{ needs.setup.outputs.enable_rocm_libraries }}
 
   therock-ci-windows:
     name: Windows (${{ matrix.projects.project_to_test }} | ${{ matrix.target_bundle.amdgpu_family }})
@@ -144,6 +155,7 @@ jobs:
       project_to_test: ${{ matrix.projects.project_to_test }}
       amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
       test_runs_on: ${{ matrix.target_bundle.test_machine }}
+      enable_rocm_libraries: ${{ needs.setup.outputs.enable_rocm_libraries }}
 
   therock_ci_summary:
     name: TheRock CI Summary

--- a/docs/ci-behavior-manipulation.md
+++ b/docs/ci-behavior-manipulation.md
@@ -1,0 +1,19 @@
+# CI Behavior Manipulation
+
+TheRock CI is controlled by [`therock_configure_ci.py`](../.github/scripts/therock_configure_ci.py), where it controls push, pull request and workflow dispatch CI behavior.
+
+## Push behavior
+
+For `push`, TheRock CI only runs builds and tests when pushed to the `develop` branch. TheRock CI will run builds and tests for Linux `gfx94X`, `gfx950` and Windows `gfx1511`, `gfx110X`
+
+## Pull request behavior
+
+For `pull_request`, TheRock CI will run builds and tests for Linux `gfx94X`, `gfx950` and Windows `gfx1511`, `gfx110X`
+
+However, if additional options are wanted, you can add a label to manipulate the behavior. The labels we provide are:
+
+- `enable-rocm-libraries`: TheRock CI will include rocm-libraries repository at `HEAD` and will build rocm-libraries
+
+## Workflow dispatch behavior
+
+For `workflow_dispatch`, you are able to trigger CI in [GitHub's therock-ci.yml workflow page](https://github.com/ROCm/rocm-systems/actions/workflows/therock-ci.yml). From [`therock_matrix.py`](../.github/scripts/therock_matrix.py), please select the projects you want to run (ex: `projects/clr`)


### PR DESCRIPTION
## Motivation

As requested, if a PR wants to include rocm-libraries build, it needs to add a label `enable-rocm-libraries`

## Technical Details

If label is added, rocm-libraries is built with TheRock CI

## JIRA ID

N/A

## Test Plan

Will test with CI labels

## Test Result

Normal run works here: https://github.com/ROCm/rocm-systems/actions/runs/20349471809/job/58470055755?pr=2393

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
