### PR TITLE
[rocprofiler-sdk][rdc] Add gfx950 support to ValuPipeIssueUtil counter

### DIFF
--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/counter_defs.yaml
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/counter_defs.yaml
@@ -10495,6 +10495,7 @@ rocprofiler-sdk:
       - gfx940
       - gfx941
       - gfx942
+      - gfx950
       expression: 100*reduce(SQ_ACTIVE_INST_VALU,sum)/(reduce(GRBM_GUI_ACTIVE,max)*CU_NUM)
     - architectures:
       - gfx12


### PR DESCRIPTION
## Summary

- Add gfx950 architecture to the `ValuPipeIssueUtil` counter definition in `counter_defs.yaml`

This enables MI350 (gfx950) support for the `RDC_FI_PROF_VALU_PIPE_ISSUE_UTIL` telemetry field in RDC.

## Background

The `ValuPipeIssueUtil` counter was missing gfx950 in its architecture list, making it the only RDC profiling counter not available on MI350. All other RDC counters already support gfx950.

## Test plan

- [ ] Verify counter is available on gfx950 hardware via rocprofiler-sdk
- [ ] Verify RDC can query `RDC_FI_PROF_VALU_PIPE_ISSUE_UTIL` on MI350