### PR TITLE
Disable Unit_hipStreamPerThread_MultiThread

### DIFF
--- a/projects/hip-tests/catch/hipTestMain/config/config_amd_linux
+++ b/projects/hip-tests/catch/hipTestMain/config/config_amd_linux
@@ -139,6 +139,8 @@
         "Unit_Device_tgammaf_Accuracy_Limited_Positive",
         "=== TODO === fail on 100% test data",
         "Unit_Device___hfma2_Accuracy_Positive",
+        "=== Test does not reflect a valid use case - SWDEV-569454",
+        "Unit_hipStreamPerThread_MultiThread",
     #endif
     #if defined gfx90a || defined gfx942 || defined gfx950
         "=== SWDEV-443630 : Below test failed in stress test on 19/01/24 ===",

--- a/projects/hip-tests/catch/hipTestMain/config/config_amd_windows
+++ b/projects/hip-tests/catch/hipTestMain/config/config_amd_windows
@@ -749,6 +749,8 @@
         "========mlsejenkins_Window_Failures_on_gfx1201===========================================",
         "Unit_hipMemPoolSetAttribute_EventDependencies",
         "Unit_hipStreamSynchronize_NullStreamSynchronization",
+        "=== Test does not reflect a valid use case - SWDEV-569454",
+        "Unit_hipStreamPerThread_MultiThread",
     #endif
         "=== Following tests disabled as it should be a local perf test",
         "Performance_hipExtLaunchKernelGGL_QueryGPUFrequency",

--- a/projects/hip-tests/catch/hipTestMain/config/config_amd_wsl.json
+++ b/projects/hip-tests/catch/hipTestMain/config/config_amd_wsl.json
@@ -629,6 +629,8 @@
         "Unit_hipStreamCreate_WithPriorityPerformance_Nonblocking_high",
         "Unit_hipStreamCreate_WithPriorityPerformance_Default_low",
         "=== Following tests disabled as it should be a local perf test",
-        "Performance_hipExtLaunchKernelGGL_QueryGPUFrequency"
+        "Performance_hipExtLaunchKernelGGL_QueryGPUFrequency",
+        "=== Test does not reflect a valid use case - SWDEV-569454",
+        "Unit_hipStreamPerThread_MultiThread"
     ]
 }

--- a/projects/hip-tests/catch/hipTestMain/config/config_nvidia_linux.json
+++ b/projects/hip-tests/catch/hipTestMain/config/config_nvidia_linux.json
@@ -65,6 +65,8 @@
         "Unit_Device___ll2half_rd_Accuracy_Positive",
         "Unit_Device___ll2half_ru_Accuracy_Positive",
         "Unit_Device___ull2half_rz_Accuracy_Positive",
-        "Unit_Device___ull2half_rd_Accuracy_Positive"
+        "Unit_Device___ull2half_rd_Accuracy_Positive",
+        "=== Test does not reflect a valid use case - SWDEV-569454",
+        "Unit_hipStreamPerThread_MultiThread"
     ]
 }

--- a/projects/hip-tests/catch/hipTestMain/config/config_nvidia_windows.json
+++ b/projects/hip-tests/catch/hipTestMain/config/config_nvidia_windows.json
@@ -65,6 +65,8 @@
         "Unit_hipDeviceSynchronize_Functional",
         "Unit_hipDeviceReset_Positive_Basic",
         "Unit_hipDeviceReset_Positive_Threaded",
-        "Unit_hipModuleGetTexRef_Positive_Basic"
+        "Unit_hipModuleGetTexRef_Positive_Basic",
+        "=== Test does not reflect a valid use case - SWDEV-569454",
+        "Unit_hipStreamPerThread_MultiThread"
     ]
 }


### PR DESCRIPTION
## Motivation

Unit_hipStreamPerThread_MultiThread is broken and causes random segfaults in multiple platforms.

## Technical Details

This test is launching threads that call HIP APIs and then immediately detaching those threads and returning from main().

This causes multiple issues because when returning from main(), global variables are destroyed while threads might still be running which leads to random segfaults.

## JIRA ID

Resolves SWDEV-569454

## Test Plan

CI Passes. Segfaults are no longer reproducible locally

## Test Result

Segfaults are not reproducible when running the full test suite this test.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
