### PR TITLE
Revert "[ci] Adding org var and dynamic selection of targets"

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -7,10 +7,6 @@ on:
         type: string
       project_to_test:
         type: string
-      amdgpu_families:
-        type: string
-      test_runs_on:
-        type: string
 
 
 permissions:
@@ -30,7 +26,7 @@ jobs:
     env:
       CACHE_DIR: ${{ github.workspace }}/.container-cache
       CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf
-      AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+      AMDGPU_FAMILIES: "gfx94X-dcgpu"
       TEATIME_FORCE_INTERACTIVE: 0
       AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
     steps:
@@ -42,7 +38,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
+          ref: 5cee24b272e0c58d2ce7c5ab01aee3400e562812 # 2025-12-12 commit
 
       - name: Install python deps
         run: |
@@ -72,6 +68,8 @@ jobs:
           # rm ./TheRock/patches/amd-mainline/rocm-systems/*.patch
           ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-systems --no-include-rocm-libraries --no-include-ml-frameworks
           rm ./TheRock/patches/amd-mainline/rocm-systems/0002-Revert-hsakmt-bump-vgpr-count-for-gfx1151-1807.patch
+
+
 
       - name: Patch rocm-systems
         run: |
@@ -130,6 +128,6 @@ jobs:
     uses: ./.github/workflows/therock-test-packages.yml
     with:
       project_to_test: ${{ inputs.project_to_test }}
-      amdgpu_families: ${{ inputs.amdgpu_families }}
-      test_runs_on: ${{ inputs.test_runs_on }}
+      amdgpu_families: "gfx94X-dcgpu"
+      test_runs_on: "linux-mi325-1gpu-ossci-rocm"
       platform: "linux"

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -7,10 +7,6 @@ on:
         type: string
       project_to_test:
         type: string
-      amdgpu_families:
-        type: string
-      test_runs_on:
-        type: string
 
 permissions:
   contents: read
@@ -19,6 +15,8 @@ jobs:
   therock-build-windows:
     name: Build Windows Packages
     runs-on: azure-windows-scale-rocm
+    outputs:
+      AMDGPU_FAMILIES: ${{ env.AMDGPU_FAMILIES }}
     permissions:
       contents: read
       id-token: write
@@ -29,7 +27,9 @@ jobs:
       BUILD_DIR: B:\build
       CCACHE_DIR: "${{ github.workspace }}/.container-cache/ccache"
       CCACHE_MAXSIZE: "700M"
-      AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+      # TODO(geomin12): Add matrix of families
+      # To get a fast signal of windows building for TheRock, adding gfx110X
+      AMDGPU_FAMILIES: "gfx110X-dgpu"
     steps:
       - name: "Checking out repository for rocm-systems"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
+          ref: 5cee24b272e0c58d2ce7c5ab01aee3400e562812 # 2025-12-12 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
@@ -153,6 +153,6 @@ jobs:
     uses: ./.github/workflows/therock-test-packages.yml
     with:
       project_to_test: ${{ inputs.project_to_test }}
-      amdgpu_families: ${{ inputs.amdgpu_families }}
-      test_runs_on: ${{ inputs.test_runs_on }}
+      amdgpu_families: ${{ needs.therock-build-windows.outputs.AMDGPU_FAMILIES }}
+      test_runs_on: "windows-strix-halo-gpu-rocm"
       platform: "windows"

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -37,8 +37,6 @@ jobs:
       BASE_REF: HEAD^
     outputs:
       projects: ${{ steps.projects.outputs.projects }}
-      linux_package_targets: ${{ steps.configure_linux.outputs.package_targets }}
-      windows_package_targets: ${{ steps.configure_windows.outputs.package_targets }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -46,13 +44,6 @@ jobs:
           sparse-checkout: .github
           sparse-checkout-cone-mode: true
           fetch-depth: 2
-
-      - name: Checkout TheRock repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          repository: "ROCm/TheRock"
-          path: TheRock
-          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -83,30 +74,8 @@ jobs:
         run: |
           python .github/scripts/therock_configure_ci.py
 
-      - name: Fetch Linux targets for build and test
-        env:
-          THEROCK_PACKAGE_PLATFORM: "linux"
-          # TODO(geomin12): Allow dynamic values of AMDGPU_FAMILIES, with opt-in options
-          AMDGPU_FAMILIES: "gfx94X, gfx950"
-          # Variable comes from ROCm organization variable 'ROCM_THEROCK_TEST_RUNNERS'
-          ROCM_THEROCK_TEST_RUNNERS: ${{ vars.ROCM_THEROCK_TEST_RUNNERS }}
-          LOAD_TEST_RUNNERS_FROM_VAR: true
-        id: configure_linux
-        run: python ./TheRock/build_tools/github_actions/fetch_package_targets.py
-
-      - name: Fetch Windows targets for build and test
-        env:
-          THEROCK_PACKAGE_PLATFORM: "windows"
-          # TODO(geomin12): Allow dynamic values of AMDGPU_FAMILIES, with opt-in options
-          AMDGPU_FAMILIES: "gfx1151, gfx110X"
-          # Variable comes from ROCm organization variable 'ROCM_THEROCK_TEST_RUNNERS'
-          ROCM_THEROCK_TEST_RUNNERS: ${{ vars.ROCM_THEROCK_TEST_RUNNERS }}
-          LOAD_TEST_RUNNERS_FROM_VAR: true
-        id: configure_windows
-        run: python ./TheRock/build_tools/github_actions/fetch_package_targets.py
-
   therock-ci-linux:
-    name: Linux (${{ matrix.projects.project_to_test }} | ${{ matrix.target_bundle.amdgpu_family }})
+    name: Linux (${{ matrix.projects.project_to_test }})
     permissions:
       contents: read
       id-token: write
@@ -116,17 +85,14 @@ jobs:
       fail-fast: false
       matrix:
         projects: ${{ fromJSON(needs.setup.outputs.projects) }}
-        target_bundle: ${{ fromJSON(needs.setup.outputs.linux_package_targets) }}
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       project_to_test: ${{ matrix.projects.project_to_test }}
-      amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
-      test_runs_on: ${{ matrix.target_bundle.test_machine }}
 
   therock-ci-windows:
-    name: Windows (${{ matrix.projects.project_to_test }} | ${{ matrix.target_bundle.amdgpu_family }})
+    name: Windows (${{ matrix.projects.project_to_test }})
     permissions:
       contents: read
       id-token: write
@@ -136,14 +102,11 @@ jobs:
       fail-fast: false
       matrix:
         projects: ${{ fromJSON(needs.setup.outputs.projects) }}
-        target_bundle: ${{ fromJSON(needs.setup.outputs.windows_package_targets) }}
     uses: ./.github/workflows/therock-ci-windows.yml
     secrets: inherit
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       project_to_test: ${{ matrix.projects.project_to_test }}
-      amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
-      test_runs_on: ${{ matrix.target_bundle.test_machine }}
 
   therock_ci_summary:
     name: TheRock CI Summary

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -29,7 +29,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
-          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
+          ref: 5cee24b272e0c58d2ce7c5ab01aee3400e562812 # 2025-12-12 commit
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
       # Post-job cleanup isn't necessary since no executables are launched in this job.
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
+          ref: 5cee24b272e0c58d2ce7c5ab01aee3400e562812 # 2025-12-12 commit
 
       - name: "Configuring CI options"
         env:
@@ -84,7 +84,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
-          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
+          ref: 5cee24b272e0c58d2ce7c5ab01aee3400e562812 # 2025-12-12 commit
 
       - name: Pre-job cleanup processes on Windows
         if: ${{ runner.os == 'Windows' }}
@@ -95,7 +95,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: bfcaf6e0bcd4bfe3c21990f49bbccb7d2a087d5d # 2025-12-15 commit
+          ref: 5cee24b272e0c58d2ce7c5ab01aee3400e562812 # 2025-12-12 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'


### PR DESCRIPTION
Reverts ROCm/rocm-systems#2317

Revert is required as organization variables do not work with forked PRs, thus causing failures. We will use a different approach instead of org vars