### PR TITLE
rocr: Support ARM64 and RISCV by adding _mm_sfence equivalent inline asm

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -474,7 +474,15 @@ void AqlQueue::StoreRelaxed(hsa_signal_value_t value) {
     HSAKMT_CALL(hsaKmtQueueRingDoorbell(queue_id_, value));
   } else {
     // Hardware doorbell supports AQL semantics.
+#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc64__)
     _mm_sfence();
+#elif defined(__aarch64__)
+    __asm__ __volatile__ ("\tdmb oshst" : : : "memory");
+#elif defined(__riscv64)
+    __asm__ __volatile__ ("\tfence ow, ow" : : : "memory");
+#else
+    #error "Please add support for your architecture"
+#endif
     *(signal_.hardware_doorbell_ptr) = uint64_t(value);
     /* signal_ is allocated as uncached so we do not need read-back to flush WC */
   }
@@ -1559,7 +1567,15 @@ void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope
   memcpy(&queue_slot[1], &slot_data[1], slot_size_b - sizeof(uint32_t));
   if (IsDeviceMemRingBuf() && needsPcieOrdering()) {
     // Ensure the packet body is written as header may get reordered when writing over PCIE
+#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc64__)
     _mm_sfence();
+#elif defined(__aarch64__)
+    __asm__ __volatile__ ("\tdmb oshst" : : : "memory");
+#elif defined(__riscv64)
+    __asm__ __volatile__ ("\tfence ow, ow" : : : "memory");
+#else
+  #error "Please add support for your architecture"
+#endif
   }
   atomic::Store(&queue_slot[0], slot_data[0], std::memory_order_release);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
@@ -901,7 +901,15 @@ void BlitKernel::PopulateQueue(uint64_t index, uint64_t code_handle, void* args,
   std::atomic_thread_fence(std::memory_order_release);
   if (queue_->IsDeviceMemRingBuf() && queue_->needsPcieOrdering()) {
     // Ensure the packet body is written as header may get reordered when writing over PCIE
+#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc64__)
     _mm_sfence();
+#elif defined(__aarch64__)
+    __asm__ __volatile__ ("\tdmb oshst" : : : "memory");
+#elif defined(__riscv64)
+    __asm__ __volatile__ ("\tfence ow, ow" : : : "memory");
+#else
+  #error "Please add support for your architecture"
+#endif
   }
 #if defined(__linux__)
   __atomic_store_n(&(queue_buffer[index & queue_bitmask_].full_header),

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
@@ -271,7 +271,15 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
       ring[barrier & mask].barrier_and.completion_signal = Signal::Convert(async_doorbell_);
       if (wrapped->IsDeviceMemRingBuf() && needsPcieOrdering()) {
         // Ensure the packet body is written as header may get reordered when writing over PCIE
+#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc64__)
         _mm_sfence();
+#elif defined(__aarch64__)
+        __asm__ __volatile__ ("\tdmb oshst" : : : "memory");
+#elif defined(__riscv64)
+        __asm__ __volatile__ ("\tfence ow, ow" : : : "memory");
+#else
+  #error "Please add support for your architecture"
+#endif
       }
       atomic::Store(&ring[barrier & mask].barrier_and.header, kBarrierHeader,
                     std::memory_order_release);
@@ -318,7 +326,15 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
       if (write_index != 0) {
         if (wrapped->IsDeviceMemRingBuf() && needsPcieOrdering()) {
           // Ensure the packet body is written as header may get reordered when writing over PCIE
+#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc64__)
           _mm_sfence();
+#elif defined(__aarch64__)
+          __asm__ __volatile__ ("\tdmb oshst" : : : "memory");
+#elif defined(__riscv64)
+          __asm__ __volatile__ ("\tfence ow, ow" : : : "memory");
+#else
+  #error "Please add support for your architecture"
+#endif
         }
         atomic::Store(&ring[write & mask].packet.header, packets[first_written_packet_index].packet.header,
                       std::memory_order_release);
@@ -419,7 +435,15 @@ void InterceptQueue::StoreRelaxed(hsa_signal_value_t value) {
 
     if (IsDeviceMemRingBuf() && needsPcieOrdering()) {
       // Ensure the packet body is written as header may get reordered when writing over PCIE
+#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc64__)
       _mm_sfence();
+#elif defined(__aarch64__)
+      __asm__ __volatile__ ("\tdmb oshst" : : : "memory");
+#elif defined(__riscv64)
+      __asm__ __volatile__ ("\tfence ow, ow" : : : "memory");
+#else
+  #error "Please add support for your architecture"
+#endif
     }
   }
   i = next_packet_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/atomic_helpers.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/atomic_helpers.h
@@ -224,7 +224,15 @@ static __forceinline void PreFence(std::memory_order order) {
     case std::memory_order_release:
     case std::memory_order_seq_cst:
     case std::memory_order_acq_rel:
+#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc64__)
       _mm_sfence();
+#elif defined(__aarch64__)
+      __asm__ __volatile__ ("\tdmb oshst" : : : "memory");
+#elif defined(__riscv64)
+      __asm__ __volatile__ ("\tfence ow, ow" : : : "memory");
+#else
+  #error "Please add support for your architecture"
+#endif
     default:;
   }
 #endif

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/locks.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/locks.h
@@ -72,7 +72,11 @@ class HybridMutex {
     while (!lock_.compare_exchange_strong(old, 1)) {
       cnt--;
       if (cnt > maxSpinIterPause) {
+#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc64__)
         _mm_pause();
+#else
+  #warn "Please add support for your architecture"
+#endif
       } else if (cnt-- > maxSpinIterYield) {
         os::YieldThread();
       } else {


### PR DESCRIPTION
## Motivation

Currently ROCm does not build for non-x86 platforms except powerpc64.

## Technical Details

Other CPU architectures like arm64 and riscv64 require _mm_sfence equivalent code.

## Test Plan

Try to compile for arm64 or riscv64.

## Test Result

Successful build.