### PR TITLE
fix(rdc): Fix CXXFLAGS clobbering and incompatibility with non-x64 architecture

### DIFF
--- a/projects/rdc/CMakeLists.txt
+++ b/projects/rdc/CMakeLists.txt
@@ -136,30 +136,7 @@ project(${RDC} VERSION "${VERSION_STRING}" HOMEPAGE_URL "https://github.com/Rade
 # this must go after project()
 include(GNUInstallDirs)
 
-# NB: CMAKE_<LANG>_FLAGS are initialized from environment (CXXFLAGS et al.)
-# during project(). Setting them before project() discards env and toolchain
-# defaults. Cf. CMAKE_<LANG>_FLAGS_INIT for toolchain overrides.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -m64 -msse -msse2")
-set(CMAKE_CXX_FLAGS_DEBUG
-    "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb -DDEBUG"
-    CACHE STRING
-    "Flags for Debug builds"
-)
-set(CMAKE_CXX_FLAGS_RELEASE
-    "${CMAKE_CXX_FLAGS_RELEASE} -O2 -s -DNDEBUG"
-    CACHE STRING
-    "Flags for Release builds"
-)
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO
-    "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O2 -g -DNDEBUG"
-    CACHE STRING
-    "Flags for RelWithDebInfo builds"
-)
-set(CMAKE_CXX_FLAGS_MINSIZEREL
-    "${CMAKE_CXX_FLAGS_MINSIZEREL} -Os -DNDEBUG"
-    CACHE STRING
-    "Flags for MinSizeRel builds"
-)
+add_compile_options(-Wall -Wextra)
 
 set(COMMON_DIR "${CMAKE_CURRENT_SOURCE_DIR}/common")
 

--- a/projects/rdc/CMakeLists.txt
+++ b/projects/rdc/CMakeLists.txt
@@ -59,29 +59,6 @@ set_property(
     PROPERTY STRINGS "Debug" "Release" "RelWithDebInfo" "MinSizeRel"
 )
 
-# Set compile flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -m64 -msse -msse2")
-set(CMAKE_CXX_FLAGS_DEBUG
-    "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb -DDEBUG"
-    CACHE STRING
-    "Flags for Debug builds"
-)
-set(CMAKE_CXX_FLAGS_RELEASE
-    "${CMAKE_CXX_FLAGS_RELEASE} -O2 -s -DNDEBUG"
-    CACHE STRING
-    "Flags for Release builds"
-)
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO
-    "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O2 -g -DNDEBUG"
-    CACHE STRING
-    "Flags for RelWithDebInfo builds"
-)
-set(CMAKE_CXX_FLAGS_MINSIZEREL
-    "${CMAKE_CXX_FLAGS_MINSIZEREL} -Os -DNDEBUG"
-    CACHE STRING
-    "Flags for MinSizeRel builds"
-)
-
 set(CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/"
     CACHE INTERNAL
@@ -158,6 +135,31 @@ project(${RDC} VERSION "${VERSION_STRING}" HOMEPAGE_URL "https://github.com/Rade
 # Include CMAKE_INSTALL_* variables
 # this must go after project()
 include(GNUInstallDirs)
+
+# NB: CMAKE_<LANG>_FLAGS are initialized from environment (CXXFLAGS et al.)
+# during project(). Setting them before project() discards env and toolchain
+# defaults. Cf. CMAKE_<LANG>_FLAGS_INIT for toolchain overrides.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -m64 -msse -msse2")
+set(CMAKE_CXX_FLAGS_DEBUG
+    "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb -DDEBUG"
+    CACHE STRING
+    "Flags for Debug builds"
+)
+set(CMAKE_CXX_FLAGS_RELEASE
+    "${CMAKE_CXX_FLAGS_RELEASE} -O2 -s -DNDEBUG"
+    CACHE STRING
+    "Flags for Release builds"
+)
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO
+    "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O2 -g -DNDEBUG"
+    CACHE STRING
+    "Flags for RelWithDebInfo builds"
+)
+set(CMAKE_CXX_FLAGS_MINSIZEREL
+    "${CMAKE_CXX_FLAGS_MINSIZEREL} -Os -DNDEBUG"
+    CACHE STRING
+    "Flags for MinSizeRel builds"
+)
 
 set(COMMON_DIR "${CMAKE_CURRENT_SOURCE_DIR}/common")
 

--- a/projects/rdc/example/CMakeLists.txt
+++ b/projects/rdc/example/CMakeLists.txt
@@ -31,30 +31,6 @@ cmake_minimum_required(VERSION 3.15)
 option(CMAKE_VERBOSE_MAKEFILE "Enable verbose output" ON)
 option(CMAKE_EXPORT_COMPILE_COMMANDS "Export compile commands for linters and autocompleters" ON)
 
-# Set compile flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -m64 -msse -msse2")
-set(CMAKE_CXX_FLAGS_DEBUG
-    "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb -DDEBUG"
-    CACHE STRING
-    "Flags for Debug builds"
-)
-# note: no '-s' here unlike other CMakeLists.txt
-set(CMAKE_CXX_FLAGS_RELEASE
-    "${CMAKE_CXX_FLAGS_RELEASE} -O2 -DNDEBUG"
-    CACHE STRING
-    "Flags for Release builds"
-)
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO
-    "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O2 -g -DNDEBUG"
-    CACHE STRING
-    "Flags for RelWithDebInfo builds"
-)
-set(CMAKE_CXX_FLAGS_MINSIZEREL
-    "${CMAKE_CXX_FLAGS_MINSIZEREL} -Os -DNDEBUG"
-    CACHE STRING
-    "Flags for MinSizeRel builds"
-)
-
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "The C++ standard to use")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -65,6 +41,8 @@ if(CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.4.0)
 endif()
 
 project(RDC_example)
+
+add_compile_options(-Wall -Wextra)
 
 # provides cmake_print_variables(VAR)
 include(CMakePrintHelpers)

--- a/projects/rdc/tests/example/CMakeLists.txt
+++ b/projects/rdc/tests/example/CMakeLists.txt
@@ -22,29 +22,7 @@ message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 message("                       Cmake Example Lib                           ")
 message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
 
-# Set compile flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -m64 -msse -msse2")
-set(CMAKE_CXX_FLAGS_DEBUG
-    "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb -DDEBUG"
-    CACHE STRING
-    "Flags for Debug builds"
-)
-# note: no '-s' here unlike other CMakeLists.txt
-set(CMAKE_CXX_FLAGS_RELEASE
-    "${CMAKE_CXX_FLAGS_RELEASE} -O2 -DNDEBUG"
-    CACHE STRING
-    "Flags for Release builds"
-)
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO
-    "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O2 -g -DNDEBUG"
-    CACHE STRING
-    "Flags for RelWithDebInfo builds"
-)
-set(CMAKE_CXX_FLAGS_MINSIZEREL
-    "${CMAKE_CXX_FLAGS_MINSIZEREL} -Os -DNDEBUG"
-    CACHE STRING
-    "Flags for MinSizeRel builds"
-)
+add_compile_options(-Wall -Wextra)
 
 # Required Defines first:
 


### PR DESCRIPTION
## Motivation

rdc should respect CXXFLAGS env var.  
rdc should build successfully for non-x64 hosts.

Ran into this while bumping nixpkgs ROCm to 7.0.2, and discovered that the CXXFLAGS env var no longer functioned.

## Technical Details

Removing unnecessary manual reimplementation of CMake flag logic, removing unneeded explicit m64/msse flags.

## JIRA ID

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
