### PR TITLE
fix(rdc): use pkg-config to find libcap

### DIFF
--- a/projects/rdc/CMakeLists.txt
+++ b/projects/rdc/CMakeLists.txt
@@ -196,9 +196,9 @@ mark_as_advanced(
     CPACK_GENERATOR
 )
 
-# check if libcap exists
-# needed for sys/capabilities.h
-find_library(LIB_CAP NAMES cap REQUIRED)
+# needed for sys/capability.h
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBCAP REQUIRED IMPORTED_TARGET libcap)
 
 if(BUILD_STANDALONE AND GRPC_ROOT STREQUAL GRPC_ROOT_DEFAULT)
     message(

--- a/projects/rdc/rdc_libs/rdc/CMakeLists.txt
+++ b/projects/rdc/rdc_libs/rdc/CMakeLists.txt
@@ -71,7 +71,7 @@ set(RDC_LIB_INC_LIST
 message("RDC_LIB_INC_LIST=${RDC_LIB_INC_LIST}")
 
 add_library(${RDC_LIB} SHARED ${RDC_LIB_SRC_LIST} ${RDC_LIB_INC_LIST})
-target_link_libraries(${RDC_LIB} ${BOOTSTRAP_LIB} pthread amd_smi cap)
+target_link_libraries(${RDC_LIB} ${BOOTSTRAP_LIB} pthread amd_smi PkgConfig::LIBCAP)
 target_include_directories(
     ${RDC_LIB}
     PRIVATE "${PROJECT_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}/include" "${AMD_SMI_INCLUDE_DIR}"

--- a/projects/rdc/server/CMakeLists.txt
+++ b/projects/rdc/server/CMakeLists.txt
@@ -97,7 +97,7 @@ target_link_libraries(
     pthread
     rt
     gRPC::grpc++
-    cap
+    PkgConfig::LIBCAP
     dl
     amd_smi
     rdc_bootstrap


### PR DESCRIPTION
## Motivation

In nix hermetic builds libcap headers aren't found in FHS paths. This caused a failure unless -I${lib.getInclude libcap} was manually added to CXXFLAGS, which is inconvenient.  
This may apply for any other situation where libcap is installed but not in a global default header path.

## Technical Details

Fixed this by using pkg-config to find libcap which provides both the library to link and include dirs.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
