### PR TITLE
SWDEV-408621 - create a single exe for Memory/Graphs

### DIFF
--- a/projects/hip-tests/catch/unit/graph/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/graph/CMakeLists.txt
@@ -18,11 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-# FIXME: cjatin
-# This is a temp hack to pass it on windows since it has a char limit for
-# command line. Eventually we need to use rsp files with ninja on windows.
-# But this exposes several problems with hipcc and build system on windows.
-# While those are fixed, this hack should allow us to pass windows CI.
 set(TEST_SRC
   hipGraphAddEmptyNode.cc
   hipGraphAddDependencies.cc
@@ -86,26 +81,7 @@ set(TEST_SRC
   hipGraphAddBatchMemOpNode.cc
   hipGraphBatchMemOpNodeSetParams.cc
   hipDrvGraphExecMemcpyNodeSetParams.cc
-  hipDrvGraphAddMemFreeNode.cc)
-
-if(HIP_PLATFORM MATCHES "amd")
-  set(AMD_SRC
-    hipStreamCaptureExtModuleLaunchKernel.cc
-    hipStreamBeginCaptureToGraph.cc
-    hipGetProcAddressGraphApis.cc
-    # Below files are disbled in NVIDIA as PSDB builds are failing due to lower CUDA version.
-    hipGraphExecNodeSetParams.cc
-    hipGraphNodeSetParams.cc
-    hipGraphExecGetFlags.cc
-  )
-  set(TEST_SRC ${TEST_SRC} ${AMD_SRC})
-endif()
-
-hip_add_exe_to_target(NAME GraphsTest1
-                      TEST_SRC ${TEST_SRC}
-                      TEST_TARGET_NAME build_tests)
-
-set(TEST_SRC
+  hipDrvGraphAddMemFreeNode.cc
   hipStreamGetCaptureInfo.cc
   hipStreamGetCaptureInfo_old.cc
   hipStreamEndCapture.cc
@@ -166,11 +142,17 @@ set(TEST_SRC
   hipDeviceSetGraphMemAttribute.cc
   hipDeviceGetGraphMemAttribute.cc
   hipDeviceGraphMemTrim.cc
-  hipDrvGraphExecMemsetNodeSetParams.cc
-)
+  hipDrvGraphExecMemsetNodeSetParams.cc)
 
 if(HIP_PLATFORM MATCHES "amd")
   set(AMD_SRC
+    hipStreamCaptureExtModuleLaunchKernel.cc
+    hipStreamBeginCaptureToGraph.cc
+    hipGetProcAddressGraphApis.cc
+    # Below files are disbled in NVIDIA as PSDB builds are failing due to lower CUDA version.
+    hipGraphExecNodeSetParams.cc
+    hipGraphNodeSetParams.cc
+    hipGraphExecGetFlags.cc
     # hipGraphAddNode, hipGraphNodeParams, hipMemcpyNodeParams are not mapped to Nvidia
     hipGraphAddNode.cc
     # hipDrvGraphAddMemsetNode, HIP_MEMSET_NODE_PARAMS are not mapped to Nvidia
@@ -189,7 +171,7 @@ add_custom_target(add_Kernel.code COMMAND ${CMAKE_HIP_COMPILER}
 set_property(GLOBAL APPEND PROPERTY
              G_INSTALL_CUSTOM_TARGETS ${CMAKE_CURRENT_BINARY_DIR}/add_Kernel.code)
 
-hip_add_exe_to_target(NAME GraphsTest2
+hip_add_exe_to_target(NAME GraphsTest
                       TEST_SRC ${TEST_SRC}
                       TEST_TARGET_NAME build_tests)
 
@@ -201,9 +183,9 @@ if(HIP_PLATFORM MATCHES "amd")
     -I${CMAKE_CURRENT_SOURCE_DIR}/../../../../include/
     -I${HIP_INCLUDE_DIR} ${HIP_PATH_OPT}
     -I${CMAKE_CURRENT_SOURCE_DIR}/../../include)
-  add_dependencies(build_tests hipMatMul)
+  add_dependencies(GraphsTest hipMatMul)
   set_property(GLOBAL APPEND PROPERTY
                G_INSTALL_CUSTOM_TARGETS ${CMAKE_CURRENT_BINARY_DIR}/hipMatMul.code)
 endif()
 
-add_dependencies(build_tests add_Kernel.code)
+add_dependencies(GraphsTest add_Kernel.code)

--- a/projects/hip-tests/catch/unit/memory/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/memory/CMakeLists.txt
@@ -21,11 +21,6 @@
 # Common Tests - Test independent of all platforms
 set(COMMON_SHARED_SRC DriverContext.cc)
 
-# FIXME: cjatin
-# This is a temp hack to pass it on windows since it has a char limit for
-# command line. Eventually we need to use rsp files with ninja on windows.
-# But this exposes several problems with hipcc and build system on windows.
-# While those are fixed, this hack should allow us to pass windows CI.
 set(TEST_SRC
     malloc.cc
     hipMemsetBasic.cc
@@ -97,71 +92,6 @@ set(TEST_SRC
     hipMemsetD2D32Async.cc
     hipMemcpy3DPeer.cc
     hipMemcpy3DPeerAsync.cc
-    )
-
-if(UNIX)
-  set(TEST_SRC ${TEST_SRC} hipMemPoolExportPointer.cc
-  hipMemPoolExportToShareableHandle.cc
-  hipMemPoolImportFromShareableHandle.cc
-  hipMemPoolImportPointer.cc)
-endif()
-
-if(HIP_PLATFORM MATCHES "amd")
-  set(TEST_SRC
-      ${TEST_SRC}
-      hipMemPtrGetInfo.cc
-      hipPointerGetAttributes.cc
-      hipExtMallocWithFlags.cc
-      hipMallocMngdMultiThread.cc
-      hipMemVmm.cc
-      hipArray.cc
-      hipMemcpyDeviceToDeviceNoCU.cc
-      hipGetProcAddressMemoryApis.cc
-      # Will be enabled for NVIDIA after fix for SWDEV-551244
-      hipMemPrefetchAsync_v2.cc
-      hipMemAdvise_v2.cc)
-  if(UNIX)
-    # Should be compiled for NVIDIA as well after EXSWHTEC-346 is addressed
-    # For windows build error occurs undefined symbol: hipPointerSetAttribute
-    set(TEST_SRC ${TEST_SRC} hipPointerSetAttribute.cc)
-  endif()
-else()
-  set(TEST_SRC ${TEST_SRC} hipGetSymbolSizeAddress.cc)
-endif()
-
-hip_add_exe_to_target(NAME MemoryTest1
-  TEST_SRC ${TEST_SRC}
-  TEST_TARGET_NAME build_tests COMMON_SHARED_SRC ${COMMON_SHARED_SRC})
-
-if(UNIX)
-  # link libnuma for numa_available(), numa_max_node(), move_pages(), etc.
-  find_package(NUMA QUIET)
-  if(NUMA_FOUND)
-    set(NUMA "${NUMA_LIBRARIES}")
-  else()
-    find_library(NUMA NAMES numa REQUIRED)
-  endif()
-  target_link_libraries(MemoryTest1 ${NUMA})
-endif()
-
-if(HIP_PLATFORM MATCHES "amd")
-  set_source_files_properties(hipHostRegister_exe.cc PROPERTIES LANGUAGE HIP)
-  add_executable(hipHostRegisterPerf EXCLUDE_FROM_ALL hipHostRegister_exe.cc)
-  set_target_properties(hipHostRegisterPerf PROPERTIES LINKER_LANGUAGE HIP)
-  add_dependencies(build_tests hipHostRegisterPerf)
-  set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS hipHostRegisterPerf)
-  target_link_libraries(hipHostRegisterPerf hip::host hip::device)
-if(UNIX)
-  set_source_files_properties(hipMemAdvise_AlignedAllocMem_Exe.cc PROPERTIES LANGUAGE HIP)
-  add_executable(hipMemAdviseTstAlignedAllocMem EXCLUDE_FROM_ALL hipMemAdvise_AlignedAllocMem_Exe.cc)
-  set_target_properties(hipMemAdviseTstAlignedAllocMem PROPERTIES LINKER_LANGUAGE HIP)
-  add_dependencies(MemoryTest1 hipMemAdviseTstAlignedAllocMem)
-  set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS hipMemAdviseTstAlignedAllocMem)
-  target_link_libraries(hipMemAdviseTstAlignedAllocMem hip::host hip::device)
-endif()
-endif()
-
-set(TEST_SRC
     hipMemcpyFromSymbol.cc
     hipPtrGetAttribute.cc
     hipMemPoolApi.cc
@@ -223,17 +153,44 @@ set(TEST_SRC
     hipMemGetAddressRange.cc
     hipMallocMipmappedArray.cc
     hipFreeMipmappedArray.cc
-    hipHostAlloc.cc)
+    hipHostAlloc.cc
+)
+
+if(UNIX)
+  set(TEST_SRC ${TEST_SRC}
+  hipMemPoolExportPointer.cc
+  hipMemPoolExportToShareableHandle.cc
+  hipMemPoolImportFromShareableHandle.cc
+  hipMemPoolImportPointer.cc)
+endif()
 
 if(HIP_PLATFORM MATCHES "amd")
   set(TEST_SRC
       ${TEST_SRC}
+      hipMemPtrGetInfo.cc
+      hipPointerGetAttributes.cc
+      hipExtMallocWithFlags.cc
+      hipMallocMngdMultiThread.cc
+      hipMemVmm.cc
+      hipArray.cc
+      hipMemcpyDeviceToDeviceNoCU.cc
+      hipGetProcAddressMemoryApis.cc
+      # Will be enabled for NVIDIA after fix for SWDEV-551244
+      hipMemPrefetchAsync_v2.cc
+      hipMemAdvise_v2.cc
       # Test below currently doesn't work on NVIDIA, will update based on ticket response
       hipDrvMemcpy2DUnaligned.cc
       # Below 3 tests should be compiled for NVIDIA as well after EXSWHTEC-349 is addressed
       hipArrayGetInfo.cc
       hipArrayGetDescriptor.cc
       hipArray3DGetDescriptor.cc)
+  if(UNIX)
+    # Should be compiled for NVIDIA as well after EXSWHTEC-346 is addressed
+    # For windows build error occurs undefined symbol: hipPointerSetAttribute
+    set(TEST_SRC ${TEST_SRC} hipPointerSetAttribute.cc)
+  endif()
+else()
+  set(TEST_SRC ${TEST_SRC} hipGetSymbolSizeAddress.cc)
 endif()
 
 set(NOT_FOR_gfx90a_AND_ABOVE_TEST hipMallocArray.cc hipArrayCreate.cc) # tests not for gfx90a+
@@ -273,22 +230,43 @@ else()
   set(TEST_SRC ${TEST_SRC} ${NOT_FOR_gfx90a_AND_ABOVE_TEST})
 endif()
 
-hip_add_exe_to_target(NAME MemoryTest2
+hip_add_exe_to_target(NAME MemoryTest
   TEST_SRC ${TEST_SRC}
   TEST_TARGET_NAME build_tests COMMON_SHARED_SRC ${COMMON_SHARED_SRC})
 
 if(HIP_PLATFORM MATCHES "amd")
-set(TEST_SRC
-  inlineVar.cc
-  memoryCommon.cc
-)
+  set_source_files_properties(hipHostRegister_exe.cc PROPERTIES LANGUAGE HIP)
+  add_executable(hipHostRegisterPerf EXCLUDE_FROM_ALL hipHostRegister_exe.cc)
+  set_target_properties(hipHostRegisterPerf PROPERTIES LINKER_LANGUAGE HIP)
+  add_dependencies(build_tests hipHostRegisterPerf)
+  set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS hipHostRegisterPerf)
+  target_link_libraries(hipHostRegisterPerf hip::host hip::device)
+  if(UNIX)
+    set_source_files_properties(hipMemAdvise_AlignedAllocMem_Exe.cc PROPERTIES LANGUAGE HIP)
+    add_executable(hipMemAdviseTstAlignedAllocMem EXCLUDE_FROM_ALL hipMemAdvise_AlignedAllocMem_Exe.cc)
+    set_target_properties(hipMemAdviseTstAlignedAllocMem PROPERTIES LINKER_LANGUAGE HIP)
+    add_dependencies(MemoryTest hipMemAdviseTstAlignedAllocMem)
+    set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS hipMemAdviseTstAlignedAllocMem)
+    target_link_libraries(hipMemAdviseTstAlignedAllocMem hip::host hip::device)
+  endif()
+endif()
 
-#hip_add_exe_to_target(NAME InlineVarTest
-#  TEST_SRC ${TEST_SRC}
-#  TEST_TARGET_NAME build_tests COMMON_SHARED_SRC ${COMMON_SHARED_SRC})
-#
-#  set_target_properties(InlineVarTest PROPERTIES COMPILE_FLAGS -fgpu-rdc)
-#  set_target_properties(InlineVarTest PROPERTIES LINK_FLAGS -fgpu-rdc)
+if(UNIX)
+  # link libnuma for numa_available(), numa_max_node(), move_pages(), etc.
+  find_package(NUMA QUIET)
+  if(NUMA_FOUND)
+    set(NUMA "${NUMA_LIBRARIES}")
+  else()
+    find_library(NUMA NAMES numa REQUIRED)
+  endif()
+  target_link_libraries(MemoryTest ${NUMA})
+endif()
+
+if(HIP_PLATFORM MATCHES "amd")
+  set(TEST_SRC
+    inlineVar.cc
+    memoryCommon.cc
+  )
 endif()
 
 set(TEST_SRC
@@ -304,6 +282,5 @@ hip_add_exe_to_target(NAME SVMAtomicTest
 
 if(HIP_PLATFORM MATCHES "nvidia")
   set_target_properties(SVMAtomicTest PROPERTIES COMPILE_FLAGS -arch=sm_70)
-  set_target_properties(MemoryTest1 PROPERTIES COMPILE_FLAGS -arch=sm_70)
-  set_target_properties(MemoryTest2 PROPERTIES COMPILE_FLAGS -arch=sm_70)
+  set_target_properties(MemoryTest PROPERTIES COMPILE_FLAGS -arch=sm_70)
 endif()


### PR DESCRIPTION
## Motivation

Create a single executable instead of two for Graphs and Memory tests

## Technical Details

Previously we had a limitation in hipcc where if we had too many files for an executable, the link step would fail on windows. Since we are now on amdclang, this can be fixed.

## JIRA ID

Resolves SWDEV-408621

## Test Plan

NA

## Test Result

Existing test should pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
