### PR TITLE
Fix a graph test and change some graph API behavior

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -1497,7 +1497,17 @@ hipError_t hipGraphAddChildGraphNode(hipGraphNode_t* pGraphNode, hipGraph_t grap
       (numDependencies > 0 && pDependencies == nullptr) || childGraph == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
+
+  // If the child graph has alloc/free nodes, we return an error
+  auto g = reinterpret_cast<hip::Graph*>(childGraph);
+  for (auto n : g->GetNodes()) {
+    if (n->GetType() == hipGraphNodeTypeMemAlloc || n->GetType() == hipGraphNodeTypeMemFree) {
+      HIP_RETURN(hipErrorNotSupported);
+    }
+  }
+
   hip::GraphNode* node = new hip::ChildGraphNode(reinterpret_cast<hip::Graph*>(childGraph));
+
   hipError_t status = ihipGraphAddNode(node, reinterpret_cast<hip::Graph*>(graph),
                                        reinterpret_cast<hip::GraphNode* const*>(pDependencies),
                                        numDependencies, false);
@@ -2179,6 +2189,14 @@ hipError_t hipGraphRemoveDependencies(hipGraph_t graph, const hipGraphNode_t* fr
   hip::GraphNode* const* fromNode = reinterpret_cast<hip::GraphNode* const*>(from);
   hip::GraphNode* const* toNode = reinterpret_cast<hip::GraphNode* const*>(to);
   hip::Graph* g = reinterpret_cast<hip::Graph*>(graph);
+
+  // If the graph has alloc/free nodes, we return an error
+  for (auto n : g->GetNodes()) {
+    if (n->GetType() == hipGraphNodeTypeMemAlloc || n->GetType() == hipGraphNodeTypeMemFree) {
+      HIP_RETURN(hipErrorNotSupported);
+    }
+  }
+
   for (size_t i = 0; i < numDependencies; i++) {
     if (toNode[i]->GetParentGraph() != g || fromNode[i]->GetParentGraph() != g ||
         fromNode[i]->RemoveEdgeDep(toNode[i]) == false) {

--- a/projects/hip-tests/catch/hipTestMain/config/config_amd_windows
+++ b/projects/hip-tests/catch/hipTestMain/config/config_amd_windows
@@ -643,8 +643,6 @@
         "Unit_Device___fma_rn_Accuracy_Positive",
         "SWDEV-450909: Test failed in stress testing",
         "Unit_RTC_LinkDestroy_Default",
-        "=== SWDEV-457316 Below tests are disabled temporarily to avoid combined PSDB ===",
-        "Unit_hipGraphAddMemFreeNode_Negative_NotSupported",
         "=== SWDEV-454245, SWDEV-454247 : Below tests fail on 29/03/24 ===",
         "Unit_hipStreamBeginCaptureToGraph_IndepGraphsThreads",
         "Unit_hipStreamBeginCaptureToGraph_CaptureDepGraph",

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemFreeNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemFreeNode.cc
@@ -143,8 +143,7 @@ TEST_CASE("Unit_hipGraphAddMemFreeNode_Negative_NotSupported") {
   HIP_CHECK(hipGraphCreate(&graph1, 0));
   HIP_CHECK(hipGraphCreate(&graph2, 0));
 
-  hipMemAllocNodeParams alloc_param;
-  memset(&alloc_param, 0, sizeof(alloc_param));
+  hipMemAllocNodeParams alloc_param{};
   alloc_param.bytesize = N;
   alloc_param.poolProps.allocType = hipMemAllocationTypePinned;
   alloc_param.poolProps.location.id = 0;
@@ -158,18 +157,19 @@ TEST_CASE("Unit_hipGraphAddMemFreeNode_Negative_NotSupported") {
 
   SECTION("More than one instantation of the graph exists") {
     hipGraphExec_t graph_exec1, graph_exec2;
-    HIP_CHECK(hipGraphInstantiate(&graph_exec1, graph2, nullptr, nullptr, 0));
-    HIP_CHECK_ERROR(hipGraphInstantiate(&graph_exec2, graph2, nullptr, nullptr, 0),
+    HIP_CHECK(hipGraphInstantiate(&graph_exec1, graph1, nullptr, nullptr, 0));
+    HIP_CHECK_ERROR(hipGraphInstantiate(&graph_exec2, graph1, nullptr, nullptr, 0),
                     hipErrorNotSupported);
     HIP_CHECK(hipGraphExecDestroy(graph_exec1));
   }
 
-#if HT_NVIDIA  // EXSWHTEC-352
   SECTION("Clone graph with mem free node") {
     hipGraph_t cloned_graph;
     HIP_CHECK_ERROR(hipGraphClone(&cloned_graph, graph2), hipErrorNotSupported);
   }
 
+  // hipGraphAddChildGraphNode/hipGraphRemoveDependencies should not allow to add child graph if it
+  // contains a alloc, free or conditional node
   SECTION("Use graph in a child node") {
     hipGraph_t parent_graph;
     HIP_CHECK(hipGraphCreate(&parent_graph, 0));
@@ -185,7 +185,6 @@ TEST_CASE("Unit_hipGraphAddMemFreeNode_Negative_NotSupported") {
     HIP_CHECK_ERROR(hipGraphRemoveDependencies(graph2, &free_node, &empty_node, 1),
                     hipErrorNotSupported);
   }
-#endif
 
   HIP_CHECK(hipGraphDestroy(graph1));
   HIP_CHECK(hipGraphDestroy(graph2));

--- a/projects/hip-tests/catch/unit/graph/hipGraphAddMemFreeNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAddMemFreeNode.cc
@@ -168,8 +168,6 @@ TEST_CASE("Unit_hipGraphAddMemFreeNode_Negative_NotSupported") {
     HIP_CHECK_ERROR(hipGraphClone(&cloned_graph, graph2), hipErrorNotSupported);
   }
 
-  // hipGraphAddChildGraphNode/hipGraphRemoveDependencies should not allow to add child graph if it
-  // contains a alloc, free or conditional node
   SECTION("Use graph in a child node") {
     hipGraph_t parent_graph;
     HIP_CHECK(hipGraphCreate(&parent_graph, 0));


### PR DESCRIPTION
## Motivation

Fix some graph tests

## Technical Details

While using `hipGraphAddChildGraphNode`, sub graphs should not have alloc/free nodes.
While using `hipGraphRemoveDependencies`, graphs with alloc/free nodes should fail when removing dependencies.

## JIRA ID

closes SWDEV-465143

## Test Plan

Existing tests is now enabled for all platforms

## Test Result

The test should pass in CI and finish stress test.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
