### PR TITLE
[SWDEV-566543] Fix param validation in FrequenciesRead test

### DIFF
--- a/projects/amdsmi/tests/amd_smi_test/functional/frequencies_read.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/frequencies_read.cc
@@ -148,7 +148,7 @@ void TestFrequenciesRead::Run(void) {
                                                               << std::endl;
         // Verify api support checking functionality is working
         err = amdsmi_get_gpu_pci_bandwidth(processor_handles_[i], nullptr);
-        ASSERT_EQ(err, AMDSMI_STATUS_NOT_SUPPORTED);
+        ASSERT_EQ(err, AMDSMI_STATUS_INVAL);
       } else if (err == AMDSMI_STATUS_NOT_YET_IMPLEMENTED) {
           std::cout << "\t**Get PCIE Bandwidth "
                     << ": Not implemented on this machine" << std::endl;


### PR DESCRIPTION
## Motivation

Failure in amdsmitst FrequenciesRead on Strix APU.

## Technical Details

Fixed incorrect error code expectation in FrequenciesRead test when calling amdsmi_get_gpu_pci_bandwidth() with nullptr pameter.


## JIRA ID

SWDEV-566543

## Test Plan

amdsmitst

## Test Result

Passed with the patch.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
