### PR TITLE
SMI event message with PID does match gitpid() in a container, now skipped.

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
@@ -1541,7 +1541,7 @@ queue_fail:
  *
  */
 
-inline bool IsRunningInContainer () {
+inline bool IsRunningInContainer() {
     bool inCon = false;
     struct stat buffer;
     std::vector<std::string> filenames = {

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
@@ -1537,6 +1537,29 @@ queue_fail:
 }
 
 /*
+ * Check if Test is being ran inside of a container.
+ *
+ */
+
+inline bool IsRunningInContainer () {
+    bool inCon = false;
+    struct stat buffer;
+    std::vector<std::string> filenames = {
+	    "/.dockerenv",  // docker
+	    "/run/.containerenv", // podman, and some docker
+	    "/run/systemd/container" // lxc, and some docker
+    };
+
+    for (const std::string& filename : filenames) {
+	    if (stat(filename.c_str(), &buffer) == 0) {
+		    inCon = true;
+		    break;
+	    }
+    }
+    return inCon;
+}
+
+/*
  * Test SMI HMM SVM profiling event
  * Use separate thread to read event the same way as ROCr and ROCProfiler
  */
@@ -1582,20 +1605,23 @@ unsigned int ReadSMIEventThread(void* p) {
                      &addr, &size, &unused, &unused, &unused, &unused, &trigger), 9, pArgs->nodeid);
         EXPECT_EQ_GPU((HSAuint64 *)(addr << PAGE_SHIFT), pArgs->pBuf, pArgs->nodeid);
         EXPECT_EQ_GPU(size << PAGE_SHIFT, pArgs->BufSize, pArgs->nodeid);
-        EXPECT_EQ_GPU(pid, getpid(), pArgs->nodeid);
+        if (!IsRunningInContainer())
+		EXPECT_EQ_GPU(pid, getpid(), pArgs->nodeid);
         EXPECT_EQ_GPU(trigger, HSA_MIGRATE_TRIGGER_PREFETCH, pArgs->nodeid);
 
      }else if (event_id == HSA_SMI_EVENT_QUEUE_EVICTION) {
         /* the message is HSA_SMI_EVENT_QUEUE_EVICTION */
         EXPECT_EQ_GPU(sscanf(msg + sizeof(event_id), "%ld -%d %x %d\n",  &timestamp, &pid, &id, &trigger),
                       4, pArgs->nodeid);
-        EXPECT_EQ_GPU(pid, getpid(), pArgs->nodeid);
+        if (!IsRunningInContainer())
+		EXPECT_EQ_GPU(pid, getpid(), pArgs->nodeid);
         EXPECT_EQ_GPU(trigger, HSA_QUEUE_EVICTION_TRIGGER_SVM, pArgs->nodeid);
 
     } else if (event_id == HSA_SMI_EVENT_QUEUE_RESTORE) {
       /* the message is HSA_SMI_EVENT_QUEUE_RESTORE */
         EXPECT_EQ_GPU(sscanf(msg + sizeof(event_id), "%ld -%d %x\n", &timestamp, &pid, &id), 3, pArgs->nodeid);
-        EXPECT_EQ_GPU(pid, getpid(), pArgs->nodeid);
+        if (!IsRunningInContainer())
+		EXPECT_EQ_GPU(pid, getpid(), pArgs->nodeid);
 
     } else if (event_id == HSA_SMI_EVENT_UNMAP_FROM_GPU) {
         /* the message is HSA_SMI_EVENT_UNMAP_FROM_GPU */
@@ -1603,7 +1629,8 @@ unsigned int ReadSMIEventThread(void* p) {
                       &addr, &size, &id, &trigger), 6, pArgs->nodeid);
         /* unmap address can be from different gpus */
         EXPECT_EQ_GPU(size << PAGE_SHIFT, pArgs->BufSize, pArgs->nodeid);
-        EXPECT_EQ_GPU(pid, getpid(), pArgs->nodeid);
+        if (!IsRunningInContainer())
+		EXPECT_EQ_GPU(pid, getpid(), pArgs->nodeid);
         EXPECT_EQ_GPU(trigger, HSA_SVM_UNMAP_TRIGGER_UNMAP_FROM_CPU, pArgs->nodeid);
     } else {
         WARN() << "HMMProfilingEvent failed on gpuNode: " <<  pArgs->nodeid << std::endl;

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
@@ -1537,7 +1537,7 @@ queue_fail:
 }
 
 /*
- * Check if Test is being ran inside of a container.
+ * Check if Test is being run inside of a container.
  *
  */
 


### PR DESCRIPTION
Greetings

I do not necessarily expecting this code to get approve in its current state, but it set the stage to begin a conversation around how to deal with the PID of our test when running in container and comparing that to the SMI event messages.

## Motivation

This change is motivated by http://log.zuul.linux.amd.com/b28/osg/b287ddef2b054a9ead5cb0bc5002a4ee/kfdtest.log which means all test are failing on test case HMMProfilingEvent* .  

## Technical Details
According to Harish K who also looked at this:
...
"This is a new test case and I don't think we have this pid matching case before.
 
The bug is actually in the driver. The driver shouldn't send the actual pid to userspace. Instead, it should check if the process has a virtualized pid. If so, then it should find the correct namespace and send the virtualized pid.
 ..."

There are some code like this that checks if we are in container in **amd_core_dump.cpp**  .  So I think we need an API like this somewhere, but not necessarily the way I implemented it (a wider scope perhaps) .    

```
// Optional: Detect if running in a container
namespace {
[[nodiscard]] bool is_running_in_container() {
  std::ifstream cgroup("/proc/1/cgroup");
  if (!cgroup.is_open()) return false;

  std::string line;
  while (std::getline(cgroup, line)) {
    if (line.find("docker") != std::string::npos ||
        line.find("lxc") != std::string::npos ||
        line.find("kubepods") != std::string::npos) {
      return true;
    }
  }
  return false;
}
} // anonymous namespace
```
## JIRA ID
SWDEV-530005
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
