### PR TITLE
SWDEV-548892 - Partially avoid using ockl workitem ID functions

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_runtime.h
@@ -244,20 +244,17 @@ typedef struct dim3 {
 #pragma push_macro("__DEVICE__")
 #define __DEVICE__ static __device__ __forceinline__
 
-extern "C" __device__ __attribute__((const)) size_t __ockl_get_local_id(unsigned int);
-__DEVICE__ unsigned int __hip_get_thread_idx_x() { return __ockl_get_local_id(0); }
-__DEVICE__ unsigned int __hip_get_thread_idx_y() { return __ockl_get_local_id(1); }
-__DEVICE__ unsigned int __hip_get_thread_idx_z() { return __ockl_get_local_id(2); }
+__DEVICE__ unsigned int __hip_get_thread_idx_x() { return __builtin_amdgcn_workitem_id_x(); }
+__DEVICE__ unsigned int __hip_get_thread_idx_y() { return __builtin_amdgcn_workitem_id_y(); }
+__DEVICE__ unsigned int __hip_get_thread_idx_z() { return __builtin_amdgcn_workitem_id_z(); }
 
-extern "C" __device__ __attribute__((const)) size_t __ockl_get_group_id(unsigned int);
-__DEVICE__ unsigned int __hip_get_block_idx_x() { return __ockl_get_group_id(0); }
-__DEVICE__ unsigned int __hip_get_block_idx_y() { return __ockl_get_group_id(1); }
-__DEVICE__ unsigned int __hip_get_block_idx_z() { return __ockl_get_group_id(2); }
+__DEVICE__ unsigned int __hip_get_block_idx_x() { return __builtin_amdgcn_workgroup_id_x(); }
+__DEVICE__ unsigned int __hip_get_block_idx_y() { return __builtin_amdgcn_workgroup_id_y(); }
+__DEVICE__ unsigned int __hip_get_block_idx_z() { return __builtin_amdgcn_workgroup_id_z(); }
 
-extern "C" __device__ __attribute__((const)) size_t __ockl_get_local_size(unsigned int);
-__DEVICE__ unsigned int __hip_get_block_dim_x() { return __ockl_get_local_size(0); }
-__DEVICE__ unsigned int __hip_get_block_dim_y() { return __ockl_get_local_size(1); }
-__DEVICE__ unsigned int __hip_get_block_dim_z() { return __ockl_get_local_size(2); }
+__DEVICE__ unsigned int __hip_get_block_dim_x() { return __builtin_amdgcn_workgroup_size_x(); }
+__DEVICE__ unsigned int __hip_get_block_dim_y() { return __builtin_amdgcn_workgroup_size_y(); }
+__DEVICE__ unsigned int __hip_get_block_dim_z() { return __builtin_amdgcn_workgroup_size_z(); }
 
 extern "C" __device__ __attribute__((const)) size_t __ockl_get_num_groups(unsigned int);
 __DEVICE__ unsigned int __hip_get_grid_dim_x() { return __ockl_get_num_groups(0); }
@@ -351,9 +348,30 @@ __DEFINE_HCC_FUNC(group_size, blockDim)
 __DEFINE_HCC_FUNC(num_groups, gridDim)
 #pragma pop_macro("__DEFINE_HCC_FUNC")
 
-extern "C" __device__ __attribute__((const)) size_t __ockl_get_global_id(unsigned int);
 inline __device__ __attribute__((always_inline)) unsigned int hc_get_workitem_absolute_id(int dim) {
-  return (unsigned int)__ockl_get_global_id(dim);
+  unsigned int local_id, group_id, group_size;
+
+  switch (dim) {
+    case 0:
+      local_id = __builtin_amdgcn_workitem_id_x();
+      group_id = __builtin_amdgcn_workgroup_id_x();
+      group_size = __builtin_amdgcn_workgroup_size_x();
+      break;
+    case 1:
+      local_id = __builtin_amdgcn_workitem_id_y();
+      group_id = __builtin_amdgcn_workgroup_id_y();
+      group_size = __builtin_amdgcn_workgroup_size_y();
+      break;
+    case 2:
+      local_id = __builtin_amdgcn_workitem_id_z();
+      group_id = __builtin_amdgcn_workgroup_id_z();
+      group_size = __builtin_amdgcn_workgroup_size_z();
+      break;
+    default:
+      return 0;
+  }
+
+  return group_id * group_size + local_id;
 }
 
 #endif

--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/codeobj_library_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/codeobj_library_test.cpp
@@ -309,10 +309,10 @@ TEST(codeobj_library, codeobj_table_test)
 
 /**
  * Verifies that DWARF inline annotation produces " -> " separators.
- * The test kernel calls a __device__ function that calls __syncthreads(),
- * which inlines through HIP headers.  This guarantees at least 3 call stack
- * levels (kernel -> device func -> HIP header), i.e. at least two " -> "
- * separators in the comment of the s_barrier instruction.
+ * The test kernel inlines a chain of __device__ helpers
+ * (kernel -> barrier_wrapper -> accumulate -> combine), guaranteeing at least
+ * 3 call stack levels, i.e. at least two " -> " separators in the deepest
+ * instruction comment.
  */
 TEST(codeobj_library, inline_annotation)
 {
@@ -328,7 +328,7 @@ TEST(codeobj_library, inline_annotation)
     ASSERT_FALSE(comp.m_symbol_map.empty());
     EXPECT_TRUE(comp.m_line_number_map.empty());
 
-    constexpr size_t min_depth = 3;  // kernel -> barrier_wrapper -> HIP header(s)
+    constexpr size_t min_depth = 3;  // kernel -> barrier_wrapper -> accumulate -> combine
     size_t           max_depth = 0;
     for(auto& [kaddr, sym] : comp.m_symbol_map)
     {

--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/syncthreads_kernel.hip
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/syncthreads_kernel.hip
@@ -1,15 +1,30 @@
 #include <hip/hip_runtime.h>
 
-__device__ void
-barrier_wrapper(int* data)
+// Builds a deterministic, deeply-nested inlined call stack for the DWARF
+// inline-annotation test: kernel -> barrier_wrapper -> accumulate -> combine.
+__device__ __attribute__((always_inline)) int
+combine(const int* data, int i)
+{
+    return data[i] + data[i ^ 1];
+}
+
+__device__ __attribute__((always_inline)) int
+accumulate(const int* data, int i)
+{
+    return combine(data, i) + combine(data, i ^ 1);
+}
+
+__device__ __attribute__((always_inline)) void
+barrier_wrapper(int* data, int i)
 {
     __syncthreads();
-    data[threadIdx.x] += data[threadIdx.x ^ 1];
+    data[i] += accumulate(data, i);
 }
 
 __global__ void
 syncthreads_kernel(int* data)
 {
-    data[threadIdx.x] = threadIdx.x;
-    barrier_wrapper(data);
+    int i   = threadIdx.x;
+    data[i] = i;
+    barrier_wrapper(data, i);
 }


### PR DESCRIPTION
The same functions are already directly implemented in clang. The development history is messy. The builtins should implement both the COv4 or COv5+ ABI depending on the compiler flag, but we somehow ended up with versioned ABI paths in both the OCKL functions which are also partially implemented with these builtins. It's simplest to just use the builtin.

This also drops the handling of the global offset from the __hip_get_block_dim_{x|y|z} functions, and hc_get_workitem_absolute_id. This is an OpenCL feature and I do not think is accessible from HIP, so this is theoretically faster.

I'm also not sure if there's any reason for hc_get_workitem_absolute_id to still exist. There are no references to it in the repo, besides this definition.

Leaves __ockl_get_num_groups alone for now. The replacement should be `__builtin_amdgcn_grid_size_x() / __builtin_amdgcn_workgroup_size_x()`. However, that needs to be accompanied by an optimization to turn that into a load from the new ABI location which apparently hasn't been implemented yet.