### PR TITLE
Revert "Adding full build capability to theROCK for HIP changes"

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -3,10 +3,10 @@ This dictionary is used to map specific file directory changes to the correspond
 """
 subtree_to_project_map = {
     'projects/aqlprofile': 'profiler',
-    'projects/clr': 'all',
-    'projects/hip': 'all',
-    'projects/hip-tests': 'all',
-    'projects/hipother': 'all',
+    'projects/clr': 'core',
+    'projects/hip': 'core',
+    'projects/hip-tests': 'core',
+    'projects/hipother': 'core',
     'projects/rdc': 'rdc',
     'projects/rocm-core': 'core',
     'projects/rocm-smi-lib': 'core',
@@ -16,7 +16,7 @@ subtree_to_project_map = {
     'projects/rocprofiler-sdk': 'profiler',
     'projects/rocprofiler-systems': 'profiler',
     'projects/rocprofiler': 'profiler',
-    'projects/rocr-runtime': 'all',
+    'projects/rocr-runtime': 'core',
     'projects/roctracer': 'profiler'
 }
 
@@ -30,7 +30,7 @@ project_map = {
         "project_to_test": "rocprofiler-tests",
     },
     "all": {
-        "cmake_options": "-DTHEROCK_ENABLE_ALL=ON",
+        "cmake_options": "-DTHEROCK_ENABLE_CORE=ON -DTHEROCK_ENABLE_PROFILER=ON -DTHEROCK_ENABLE_ALL=OFF",
         "project_to_test": "hip-tests, rocprofiler-tests",
     }
 }

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           # Remove patches here if they cannot be applied cleanly, and they have not been deleted from TheRock repo
           # rm ./TheRock/patches/amd-mainline/rocm-systems/*.patch
-          ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-systems
+          ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-systems --no-include-rocm-libraries --no-include-ml-frameworks
           rm ./TheRock/patches/amd-mainline/rocm-systems/0002-Revert-hsakmt-bump-vgpr-count-for-gfx1151-1807.patch
 
 

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -86,8 +86,9 @@ jobs:
         timeout-minutes: 30
         run: |
           git config --global core.longpaths true
-          python ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-systems
+          python ./TheRock/build_tools/fetch_sources.py --jobs 12 --no-include-rocm-systems --no-include-rocm-libraries --no-include-ml-frameworks
           dvc pull
+
       - name: Configure Projects
         env:
           amdgpu_families: ${{ env.AMDGPU_FAMILIES }}


### PR DESCRIPTION
Reverts ROCm/rocm-systems#2003

MIOpen build failures on windows causing blockers on unrelated file changes.