### PR TITLE
[SWDEV-546332] Add support for reading all VCLK/DCLK frequency levels…

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -1183,9 +1183,9 @@ class AMDSMICommands():
                             continue
                         freq_dict = {}
                         current_level = frequencies['current']
+                        # Add current_level first for proper output ordering
                         freq_dict.update({'current_level':current_level})
-                        current_frequency = str(self.helpers.convert_SI_unit(frequencies['frequency'][current_level], AMDSMIHelpers.SI_Unit.MICRO)) + "MHz"
-                        freq_dict.update({'current_frequency':current_frequency})
+                        # Add frequency_levels second
                         freq_dict.update({'frequency_levels':{}})
                         if frequencies["num_supported"] != 0:
                             for level in range(len(frequencies['frequency'])):

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -30,6 +30,7 @@
 
 
 #include <cstdlib>
+#include <cctype>
 #include <string>
 #include <algorithm>
 #include <sstream>
@@ -3664,67 +3665,118 @@ amdsmi_status_t  amdsmi_get_clk_freq(amdsmi_processor_handle processor_handle,
     AMDSMI_CHECK_INIT();
     // nullptr api supported
 
-    // Get from gpu_metrics
+    // Read VCLK/DCLK from sysfs pp_dpm files instead of gpu_metrics
     if (clk_type == AMDSMI_CLK_TYPE_VCLK0 ||
         clk_type == AMDSMI_CLK_TYPE_VCLK1 ||
         clk_type == AMDSMI_CLK_TYPE_DCLK0 ||
         clk_type == AMDSMI_CLK_TYPE_DCLK1 ) {
-        // Default unit is MHz
-        char unit = 'M';
 
-        // when f == nullptr -> check if metrics are supported
-        amdsmi_gpu_metrics_t metric_info;
-        amdsmi_gpu_metrics_t * metric_info_p = nullptr;
-
-        if (f != nullptr) {
-            metric_info_p = &metric_info;
+        // Get the GPU device to access renderD number
+        amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
+        amdsmi_status_t status = get_gpu_device_from_handle(processor_handle, &gpu_device);
+        if (status != AMDSMI_STATUS_SUCCESS) {
+            return status;
         }
 
-        // when metric_info_p == nullptr - this will not return AMDSMI_STATUS_SUCCESS
-        auto r_status =  amdsmi_get_gpu_metrics_info(
-                processor_handle, metric_info_p);
-        if (r_status != AMDSMI_STATUS_SUCCESS)
-            return r_status;
+        // Get renderD number for this GPU
+        uint32_t drm_render = gpu_device->get_drm_render_minor();
+
+        // Determine the sysfs file name based on clock type
+        const char* pp_dpm_file = nullptr;
+        if (clk_type == AMDSMI_CLK_TYPE_VCLK0) {
+            pp_dpm_file = "pp_dpm_vclk";
+        } else if (clk_type == AMDSMI_CLK_TYPE_VCLK1) {
+            pp_dpm_file = "pp_dpm_vclk1";
+        } else if (clk_type == AMDSMI_CLK_TYPE_DCLK0) {
+            pp_dpm_file = "pp_dpm_dclk";
+        } else if (clk_type == AMDSMI_CLK_TYPE_DCLK1) {
+            pp_dpm_file = "pp_dpm_dclk1";
+        }
+
+        // Construct the sysfs path: /sys/class/drm/renderD<num>/device/pp_dpm_*
+        std::string sysfs_path = "/sys/class/drm/renderD" + std::to_string(drm_render) + "/device/" + pp_dpm_file;
+
+        // Check if the file exists
+        std::ifstream file(sysfs_path);
+        if (!file.good()) {
+            // File doesn't exist, fallback to gpu_metrics for backward compatibility
+            // or return not supported
+            return AMDSMI_STATUS_NOT_SUPPORTED;
+        }
+
+        // Parse the pp_dpm file
+        // Format example:
+        // 0: 200Mhz
+        // 1: 400Mhz *
+        // 2: 800Mhz
+        if (f == nullptr) {
+            return AMDSMI_STATUS_INVAL;
+        }
 
         f->num_supported = 0;
-        if (clk_type == AMDSMI_CLK_TYPE_VCLK0) {
-            f->current = 0;
-            f->frequency[0] = std::numeric_limits<uint64_t>::max();
-            if (metric_info_p->current_vclk0 != std::numeric_limits<uint16_t>::max()) {
-                f->frequency[0] = static_cast<uint64_t>(metric_info_p->current_vclk0)
-                    * amd::smi::get_multiplier_from_char(unit);  // match MHz ROCm SMI provides
-                f->num_supported = 1;
+        f->current = 0;
+        f->has_deep_sleep = 0;
+
+        std::string line;
+        uint32_t level_index = 0;
+
+        while (std::getline(file, line) && level_index < AMDSMI_MAX_NUM_FREQUENCIES) {
+            // Parse line format: "0: 200Mhz" or "1: 400Mhz *"
+            size_t colon_pos = line.find(':');
+            if (colon_pos == std::string::npos) {
+                continue;
             }
-        }
-        if (clk_type == AMDSMI_CLK_TYPE_VCLK1) {
-            f->current = 0;
-            f->frequency[0] = std::numeric_limits<uint64_t>::max();
-            if (metric_info_p->current_vclk1 != std::numeric_limits<uint16_t>::max()) {
-                f->frequency[0] = static_cast<uint64_t>(metric_info_p->current_vclk1)
-                    * amd::smi::get_multiplier_from_char(unit);  // match MHz ROCm SMI provides
-                f->num_supported = 1;
+
+            // Extract level number
+            std::string level_str = line.substr(0, colon_pos);
+            level_str.erase(0, level_str.find_first_not_of(" \t"));
+            level_str.erase(level_str.find_last_not_of(" \t") + 1);
+
+            // Extract frequency value
+            std::string freq_str = line.substr(colon_pos + 1);
+
+            // Check if this is the current level (marked with *)
+            bool is_current = (freq_str.find('*') != std::string::npos);
+            if (is_current) {
+                f->current = level_index;
             }
-        }
-        if (clk_type == AMDSMI_CLK_TYPE_DCLK0) {
-            f->current = 0;
-            f->frequency[0] = std::numeric_limits<uint64_t>::max();
-            if (metric_info_p->current_dclk0 != std::numeric_limits<uint16_t>::max()) {
-                f->frequency[0] = static_cast<uint64_t>(metric_info_p->current_dclk0)
-                    * amd::smi::get_multiplier_from_char(unit);  // match MHz ROCm SMI provides
-                f->num_supported = 1;
+
+            // Remove asterisk and spaces
+            freq_str.erase(std::remove(freq_str.begin(), freq_str.end(), '*'), freq_str.end());
+            freq_str.erase(0, freq_str.find_first_not_of(" \t"));
+            freq_str.erase(freq_str.find_last_not_of(" \t") + 1);
+
+            // Parse frequency value (e.g., "200Mhz" or "200 Mhz")
+            uint64_t freq_value = 0;
+            char unit = 'M';  // Default to MHz
+
+            size_t unit_pos = freq_str.find_first_not_of("0123456789 ");
+            if (unit_pos != std::string::npos) {
+                std::string value_str = freq_str.substr(0, unit_pos);
+                value_str.erase(std::remove(value_str.begin(), value_str.end(), ' '), value_str.end());
+
+                try {
+                    freq_value = std::stoull(value_str);
+                } catch (...) {
+                    continue;  // Skip invalid lines
+                }
+
+                // Extract unit (M for MHz, G for GHz, etc.)
+                std::string unit_str = freq_str.substr(unit_pos);
+                if (!unit_str.empty()) {
+                    unit = static_cast<char>(std::toupper(static_cast<unsigned char>(unit_str[0])));
+                }
             }
-        }
-        if (clk_type == AMDSMI_CLK_TYPE_DCLK1) {
-            f->current = 0;
-            f->frequency[0] = std::numeric_limits<uint64_t>::max();
-            if (metric_info_p->current_dclk1 != std::numeric_limits<uint16_t>::max()) {
-                f->frequency[0] = static_cast<uint64_t>(metric_info_p->current_dclk1)
-                    * amd::smi::get_multiplier_from_char(unit);  // match MHz ROCm SMI provides
-                f->num_supported = 1;
-            }
+
+            // Convert to Hz based on unit
+            f->frequency[level_index] = freq_value * amd::smi::get_multiplier_from_char(unit);
+            level_index++;
         }
 
-        return r_status;
+        f->num_supported = level_index;
+        file.close();
+
+        return (f->num_supported > 0) ? AMDSMI_STATUS_SUCCESS : AMDSMI_STATUS_NOT_SUPPORTED;
     }
 
     return rsmi_wrapper(rsmi_dev_gpu_clk_freq_get, processor_handle, 0,


### PR DESCRIPTION
… from sysfs

Change VCLK0/VCLK1/DCLK0/DCLK1 to read all frequency levels from sysfs pp_dpm_* files instead of just current frequency from gpu_metrics. Parse all levels and detect current level from asterisk marker.

Updated Python CLI output ordering to show current_level first.

## Motivation
Amd-smi static displays the incorrect number of clock levels for vclk and dclk:

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
SWDEV-546332
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
run amd-smi static --clock 
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
# GPU: 0

## CLOCK

### SYS
- **CURRENT_LEVEL:** 1
- **FREQUENCY_LEVELS:**
  - LEVEL 0: 500 MHz
  - LEVEL 1: 0 MHz
  - LEVEL 2: 2210 MHz

### MEM
- **CURRENT_LEVEL:** 0
- **FREQUENCY_LEVELS:**
  - LEVEL 0: 96 MHz
  - LEVEL 1: 456 MHz
  - LEVEL 2: 772 MHz
  - LEVEL 3: 1124 MHz

### DF
- **CURRENT_LEVEL:** 7
- **FREQUENCY_LEVELS:**
  - LEVEL 0: 601 MHz
  - LEVEL 1: 1000 MHz
  - LEVEL 2: 1200 MHz
  - LEVEL 3: 1600 MHz
  - LEVEL 4: 1801 MHz
  - LEVEL 5: 2000 MHz
  - LEVEL 6: 2201 MHz
  - LEVEL 7: 2301 MHz

### SOC
- **CURRENT_LEVEL:** 1
- **FREQUENCY_LEVELS:**
  - LEVEL 0: 300 MHz
  - LEVEL 1: 1500 MHz

### DCEF
- **CURRENT_LEVEL:** 1
- **FREQUENCY_LEVELS:**
  - LEVEL 0: 145 MHz
  - LEVEL 1: 200 MHz
  - LEVEL 2: 1563 MHz

### VCLK0
- **CURRENT_LEVEL:** 1
- **FREQUENCY_LEVELS:**
  - LEVEL 0: 513 MHz
  - LEVEL 1: 25 MHz
  - LEVEL 2: 2934 MHz

### VCLK1
- **CURRENT_LEVEL:** 1
- **FREQUENCY_LEVELS:**
  - LEVEL 0: 513 MHz
  - LEVEL 1: 25 MHz
  - LEVEL 2: 2934 MHz

### DCLK0
- **CURRENT_LEVEL:** 1
- **FREQUENCY_LEVELS:**
  - LEVEL 0: 513 MHz
  - LEVEL 1: 25 MHz
  - LEVEL 2: 2200 MHz

### DCLK1
- **CURRENT_LEVEL:** 1
- **FREQUENCY_LEVELS:**
  - LEVEL 0: 513 MHz
  - LEVEL 1: 25 MHz
  - LEVEL 2: 2200 MHz

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
