### PR TITLE
[amdsmi][SWDEV-568613] Add gpu_metrics 1.0 support

### DIFF
--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_gpu_metrics.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_gpu_metrics.h
@@ -141,6 +141,59 @@ struct AMDGpuMetricsBase_t {
 };
 using AMDGpuMetricsBaseRef = AMDGpuMetricsBase_t&;
 
+struct AMDGpuMetrics_v10_t {
+    ~AMDGpuMetrics_v10_t() = default;
+
+    struct AMDGpuMetricsHeader_v1_t m_common_header;
+
+    // Driver attached timestamp (in ns)
+    uint64_t m_system_clock_counter;
+
+    // Temperature
+    uint16_t m_temperature_edge;
+    uint16_t m_temperature_hotspot;
+    uint16_t m_temperature_mem;
+    uint16_t m_temperature_vrgfx;
+    uint16_t m_temperature_vrsoc;
+    uint16_t m_temperature_vrmem;
+
+    // Utilization
+    uint16_t m_average_gfx_activity;
+    uint16_t m_average_umc_activity;    // memory controller
+    uint16_t m_average_mm_activity;     // UVD or VCN
+
+    // Power/Energy
+    uint16_t m_average_socket_power;
+    uint32_t m_energy_accumulator;
+
+    // Average clocks
+    uint16_t m_average_gfxclk_frequency;
+    uint16_t m_average_socclk_frequency;
+    uint16_t m_average_uclk_frequency;
+    uint16_t m_average_vclk0_frequency;
+    uint16_t m_average_dclk0_frequency;
+    uint16_t m_average_vclk1_frequency;
+    uint16_t m_average_dclk1_frequency;
+
+    // Current clocks
+    uint16_t m_current_gfxclk;
+    uint16_t m_current_socclk;
+    uint16_t m_current_uclk;
+    uint16_t m_current_vclk0;
+    uint16_t m_current_dclk0;
+    uint16_t m_current_vclk1;
+    uint16_t m_current_dclk1;
+
+    // Throttle status
+    uint32_t m_throttle_status;
+
+    // Fans
+    uint16_t m_current_fan_speed;
+
+    // Link width/speed
+    uint8_t m_pcie_link_width;
+    uint8_t m_pcie_link_speed;      // in 0.1 GT/s
+};
 
 struct AMDGpuMetrics_v11_t {
   ~AMDGpuMetrics_v11_t() = default;
@@ -1115,6 +1168,35 @@ class GpuMetricsBase_t {
 };
 using GpuMetricsBasePtr = std::shared_ptr<GpuMetricsBase_t>;
 using AMDGpuMetricFactories_t = const std::map<AMDGpuMetricVersionFlags_t, GpuMetricsBasePtr>;
+
+class GpuMetricsBase_v10_t final : public GpuMetricsBase_t {
+    public:
+       virtual ~GpuMetricsBase_v10_t() = default;
+
+       size_t sizeof_metric_table() override {
+         return sizeof(AMDGpuMetrics_v10_t);
+       }
+
+       GpuMetricTypePtr_t get_metrics_table() override {
+         if (!m_gpu_metric_ptr) {
+           m_gpu_metric_ptr.reset(&m_gpu_metrics_tbl, [](AMDGpuMetrics_v10_t*){});
+         }
+         assert(m_gpu_metric_ptr != nullptr);
+         return m_gpu_metric_ptr;
+       }
+
+       AMDGpuMetricVersionFlags_t get_gpu_metrics_version_used() override {
+         return AMDGpuMetricVersionFlags_t::kGpuMetricV10;
+       }
+
+       rsmi_status_t populate_metrics_dynamic_tbl() override;
+       AMGpuMetricsPublicLatestTupl_t copy_internal_to_external_metrics() override;
+
+
+    private:
+       AMDGpuMetrics_v10_t m_gpu_metrics_tbl;
+       std::shared_ptr<AMDGpuMetrics_v10_t> m_gpu_metric_ptr;
+};
 
 class GpuMetricsBase_v11_t final : public GpuMetricsBase_t {
  public:

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_gpu_metrics.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_gpu_metrics.cc
@@ -145,6 +145,7 @@ std::string stringfy_metric_header_version(const AMDGpuMetricsHeader_v1_t& metri
 //  version 1.8: 264
 //  version 1.9: 265
 const AMDGpuMetricVersionTranslationTbl_t amdgpu_metric_version_translation_table {
+  {join_metrics_version(1, 0), AMDGpuMetricVersionFlags_t::kGpuMetricV10},
   {join_metrics_version(1, 1), AMDGpuMetricVersionFlags_t::kGpuMetricV11},
   {join_metrics_version(1, 2), AMDGpuMetricVersionFlags_t::kGpuMetricV12},
   {join_metrics_version(1, 3), AMDGpuMetricVersionFlags_t::kGpuMetricV13},
@@ -389,6 +390,7 @@ GpuMetricsBasePtr amdgpu_metrics_factory(AMDGpuMetricVersionFlags_t v,
                                          const std::string& file_path) {
   if (!is_partition_metrics) {
     switch (v) {
+      case AMDGpuMetricVersionFlags_t::kGpuMetricV10: return std::make_shared<GpuMetricsBase_v10_t>();
       case AMDGpuMetricVersionFlags_t::kGpuMetricV11: return std::make_shared<GpuMetricsBase_v11_t>();
       case AMDGpuMetricVersionFlags_t::kGpuMetricV12: return std::make_shared<GpuMetricsBase_v12_t>();
       case AMDGpuMetricVersionFlags_t::kGpuMetricV13: return std::make_shared<GpuMetricsBase_v13_t>();
@@ -537,7 +539,7 @@ rsmi_status_t GpuMetricsBaseDynamic_t::populate_metrics_dynamic_tbl() {
   LOG_TRACE(ss);
 
   auto m_metrics_dynamic_tbl = AMDGpuDynamicMetricsTbl_t{};
-  
+
   auto emit = [&](AMDGpuMetricsClassId_t cls, AMDGpuMetricsUnitType_t unit,
                   const char* label,
                   const details::AMDGpuMetricAttributeData_t& row) {
@@ -4461,6 +4463,303 @@ AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v11_t::copy_internal_to_external_m
   return std::make_tuple(status_code, copy_data_from_internal_metrics_tbl);
 }
 
+rsmi_status_t GpuMetricsBase_v10_t::populate_metrics_dynamic_tbl() {
+    std::ostringstream ss;
+    auto status_code(rsmi_status_t::RSMI_STATUS_SUCCESS);
+    ss << __PRETTY_FUNCTION__ << " | ======= start =======";
+    LOG_TRACE(ss);
+
+    auto m_metrics_dynamic_tbl = AMDGpuDynamicMetricsTbl_t{};
+    //
+    //  Note: Any metric treatment/changes (if any) should happen before they
+    //        get written to internal/external tables.
+    //
+    auto run_metric_adjustments_v10 = [&]() {
+      ss << __PRETTY_FUNCTION__ << " | ======= start =======";
+      const auto gpu_metrics_version = translate_flag_to_metric_version(get_gpu_metrics_version_used());
+      ss << __PRETTY_FUNCTION__
+                  << " | ======= info ======= "
+                  << " | Applying adjustments "
+                  << " | Metric Version: " << stringfy_metric_header_version(
+                                                disjoin_metrics_version(gpu_metrics_version))
+                  << " |";
+      LOG_TRACE(ss);
+    };
+
+
+    //  Adjustments/Changes specific to this version
+    run_metric_adjustments_v10();
+
+    // Timestamp Info
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricTimestamp]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricTSClockCounter,
+                format_metric_row(m_gpu_metrics_tbl.m_system_clock_counter,
+                                  "system_clock_counter"))
+             );
+
+    // Temperature Info
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricTemperature]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricTempEdge,
+                format_metric_row(m_gpu_metrics_tbl.m_temperature_edge,
+                                  "temperature_edge"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricTemperature]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricTempHotspot,
+                format_metric_row(m_gpu_metrics_tbl.m_temperature_hotspot,
+                                  "temperature_hotspot"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricTemperature]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricTempMem,
+                format_metric_row(m_gpu_metrics_tbl.m_temperature_mem,
+                                  "temperature_mem"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricTemperature]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricTempVrGfx,
+                format_metric_row(m_gpu_metrics_tbl.m_temperature_vrgfx,
+                                  "temperature_vrgfx"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricTemperature]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricTempVrSoc,
+                format_metric_row(m_gpu_metrics_tbl.m_temperature_vrsoc,
+                                  "temperature_vrsoc"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricTemperature]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricTempVrMem,
+                format_metric_row(m_gpu_metrics_tbl.m_temperature_vrmem,
+                                  "temperature_vrmem"))
+             );
+
+    // Power/Energy Info
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricPowerEnergy]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricAvgSocketPower,
+                format_metric_row(m_gpu_metrics_tbl.m_average_socket_power,
+                                  "average_socket_power"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricPowerEnergy]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricEnergyAccumulator,
+                format_metric_row(m_gpu_metrics_tbl.m_energy_accumulator,
+                                  "energy_acc"))
+             );
+
+    // Utilization Info
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricUtilization]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricAvgGfxActivity,
+                format_metric_row(m_gpu_metrics_tbl.m_average_gfx_activity,
+                                  "average_gfx_activity"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricUtilization]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricAvgUmcActivity,
+                format_metric_row(m_gpu_metrics_tbl.m_average_umc_activity,
+                                  "average_umc_activity"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricUtilization]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricAvgMmActivity,
+                format_metric_row(m_gpu_metrics_tbl.m_average_mm_activity,
+                                  "average_mm_activity"))
+             );
+
+
+    // Fan Info
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricCurrentFanSpeed]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricCurrFanSpeed,
+                format_metric_row(m_gpu_metrics_tbl.m_current_fan_speed,
+                                  "current_fan_speed"))
+             );
+
+    // Throttle Info
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricThrottleStatus]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricThrottleStatus,
+                format_metric_row(m_gpu_metrics_tbl.m_throttle_status,
+                                  "throttle_status"))
+             );
+
+    // Average Info
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricAverageClock]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricAvgGfxClockFrequency,
+                format_metric_row(m_gpu_metrics_tbl.m_average_gfxclk_frequency,
+                                  "average_gfxclk_frequency"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricAverageClock]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricAvgSocClockFrequency,
+                format_metric_row(m_gpu_metrics_tbl.m_average_socclk_frequency,
+                                  "average_socclk_frequency"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricAverageClock]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricAvgUClockFrequency,
+                format_metric_row(m_gpu_metrics_tbl.m_average_uclk_frequency,
+                                  "average_uclk_frequency"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricAverageClock]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricAvgVClock0Frequency,
+                format_metric_row(m_gpu_metrics_tbl.m_average_vclk0_frequency,
+                                  "average_vclk0_frequency"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricAverageClock]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricAvgDClock0Frequency,
+                format_metric_row(m_gpu_metrics_tbl.m_average_dclk0_frequency,
+                                  "average_dclk0_frequency"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricAverageClock]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricAvgVClock1Frequency,
+                format_metric_row(m_gpu_metrics_tbl.m_average_vclk1_frequency,
+                                  "average_vclk1_frequency"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricAverageClock]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricAvgDClock1Frequency,
+                format_metric_row(m_gpu_metrics_tbl.m_average_dclk1_frequency,
+                                  "average_dclk1_frequency"))
+             );
+
+    // CurrentClock Info
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricCurrentClock]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricCurrGfxClock,
+                format_metric_row(m_gpu_metrics_tbl.m_current_gfxclk,
+                                  "current_gfxclk"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricCurrentClock]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricCurrSocClock,
+                format_metric_row(m_gpu_metrics_tbl.m_current_socclk,
+                                  "current_socclk"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricCurrentClock]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricCurrUClock,
+                format_metric_row(m_gpu_metrics_tbl.m_current_uclk,
+                                  "current_uclk"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricCurrentClock]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricCurrVClock0,
+                format_metric_row(m_gpu_metrics_tbl.m_current_vclk0,
+                                  "current_vclk0"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricCurrentClock]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricCurrDClock0,
+                format_metric_row(m_gpu_metrics_tbl.m_current_dclk0,
+                                  "current_dclk0"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricCurrentClock]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricCurrVClock1,
+                format_metric_row(m_gpu_metrics_tbl.m_current_vclk1,
+                                  "current_vclk1"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricCurrentClock]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricCurrDClock1,
+                format_metric_row(m_gpu_metrics_tbl.m_current_dclk1,
+                                  "current_dclk1"))
+             );
+
+    // Link/Width/Speed Info
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricLinkWidthSpeed]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricPcieLinkWidth,
+                format_metric_row(m_gpu_metrics_tbl.m_pcie_link_width,
+                                  "pcie_link_width"))
+             );
+    m_metrics_dynamic_tbl[AMDGpuMetricsClassId_t::kGpuMetricLinkWidthSpeed]
+      .insert(std::make_pair(AMDGpuMetricsUnitType_t::kMetricPcieLinkSpeed,
+                format_metric_row(m_gpu_metrics_tbl.m_pcie_link_speed,
+                                  "pcie_link_speed"))
+             );
+
+    ss << __PRETTY_FUNCTION__
+                << " | ======= end ======= "
+                << " | Success "
+                << " | Returning = " << getRSMIStatusString(status_code)
+                << " |";
+    LOG_TRACE(ss);
+
+    // Copy to base class
+    std::copy(m_metrics_dynamic_tbl.begin(),
+              m_metrics_dynamic_tbl.end(),
+              std::inserter(GpuMetricsBase_t::m_base_metrics_dynamic_tbl,
+                            GpuMetricsBase_t::m_base_metrics_dynamic_tbl.end()));
+
+    return status_code;
+}
+
+AMGpuMetricsPublicLatestTupl_t GpuMetricsBase_v10_t::copy_internal_to_external_metrics() {
+    std::ostringstream ss;
+    auto status_code(rsmi_status_t::RSMI_STATUS_SUCCESS);
+    ss << __PRETTY_FUNCTION__ << " | ======= start =======";
+    LOG_TRACE(ss);
+
+    auto copy_data_from_internal_metrics_tbl = [&]() {
+      AMGpuMetricsPublicLatest_t metrics_public_init{};
+
+      //
+      //  Note: Initializing data members with their max. If field is max,
+      //        no data was assigned to it.
+      init_max_public_gpu_matrics(metrics_public_init);
+
+      // Header
+      metrics_public_init.common_header.structure_size = m_gpu_metrics_tbl.m_common_header.m_structure_size;
+      metrics_public_init.common_header.format_revision = m_gpu_metrics_tbl.m_common_header.m_format_revision;
+      metrics_public_init.common_header.content_revision = m_gpu_metrics_tbl.m_common_header.m_content_revision;
+
+      // Temperature
+      metrics_public_init.temperature_edge = m_gpu_metrics_tbl.m_temperature_edge;
+      metrics_public_init.temperature_hotspot = m_gpu_metrics_tbl.m_temperature_hotspot;
+      metrics_public_init.temperature_mem = m_gpu_metrics_tbl.m_temperature_mem;
+      metrics_public_init.temperature_vrgfx = m_gpu_metrics_tbl.m_temperature_vrgfx;
+      metrics_public_init.temperature_vrsoc = m_gpu_metrics_tbl.m_temperature_vrsoc;
+      metrics_public_init.temperature_vrmem = m_gpu_metrics_tbl.m_temperature_vrmem;
+
+      // Utilization
+      metrics_public_init.average_gfx_activity = m_gpu_metrics_tbl.m_average_gfx_activity;
+      metrics_public_init.average_umc_activity = m_gpu_metrics_tbl.m_average_umc_activity;
+      metrics_public_init.average_mm_activity = m_gpu_metrics_tbl.m_average_mm_activity;
+
+      // Power/Energy
+      metrics_public_init.average_socket_power = m_gpu_metrics_tbl.m_average_socket_power;
+      metrics_public_init.energy_accumulator = m_gpu_metrics_tbl.m_energy_accumulator;
+
+      // Driver attached timestamp (in ns)
+      metrics_public_init.system_clock_counter = m_gpu_metrics_tbl.m_system_clock_counter;
+
+      // Average clocks
+      metrics_public_init.average_gfxclk_frequency = m_gpu_metrics_tbl.m_average_gfxclk_frequency;
+      metrics_public_init.average_socclk_frequency = m_gpu_metrics_tbl.m_average_socclk_frequency;
+      metrics_public_init.average_uclk_frequency = m_gpu_metrics_tbl.m_average_uclk_frequency;
+      metrics_public_init.average_vclk0_frequency = m_gpu_metrics_tbl.m_average_vclk0_frequency;
+      metrics_public_init.average_dclk0_frequency = m_gpu_metrics_tbl.m_average_dclk0_frequency;
+      metrics_public_init.average_vclk1_frequency = m_gpu_metrics_tbl.m_average_vclk1_frequency;
+      metrics_public_init.average_dclk1_frequency = m_gpu_metrics_tbl.m_average_dclk1_frequency;
+
+      // Current clocks
+      metrics_public_init.current_gfxclk = m_gpu_metrics_tbl.m_current_gfxclk;
+      metrics_public_init.current_socclk = m_gpu_metrics_tbl.m_current_socclk;
+      metrics_public_init.current_vclk0 = m_gpu_metrics_tbl.m_current_vclk0;
+      metrics_public_init.current_dclk0 = m_gpu_metrics_tbl.m_current_dclk0;
+      metrics_public_init.current_uclk = m_gpu_metrics_tbl.m_current_uclk;
+      metrics_public_init.current_vclk1 = m_gpu_metrics_tbl.m_current_vclk1;
+      metrics_public_init.current_dclk1 = m_gpu_metrics_tbl.m_current_dclk1;
+
+      // Throttle status
+      metrics_public_init.throttle_status = m_gpu_metrics_tbl.m_throttle_status;
+
+      // Fans
+      metrics_public_init.current_fan_speed = m_gpu_metrics_tbl.m_current_fan_speed;
+
+      // Link width/speed
+      metrics_public_init.pcie_link_width = m_gpu_metrics_tbl.m_pcie_link_width;
+      metrics_public_init.pcie_link_speed = m_gpu_metrics_tbl.m_pcie_link_speed;
+
+
+      //
+      // Note:  Backwards compatibility -> Handling extra/exception cases
+      //        related to earlier versions (1.0)
+
+
+      return metrics_public_init;
+    }();
+
+    ss << __PRETTY_FUNCTION__
+                << " | ======= end ======= "
+                << " | Success "
+                << " | Returning = " << getRSMIStatusString(status_code)
+                << " |";
+    LOG_TRACE(ss);
+
+    return std::make_tuple(status_code, copy_data_from_internal_metrics_tbl);
+}
 
 auto Device::dev_read_gpu_metrics_header_data(DevInfoTypes type) -> rsmi_status_t {
   std::ostringstream ss;
@@ -4911,6 +5210,12 @@ auto Device::dev_log_gpu_metrics(std::ostringstream& outstream_metrics,
         auto tmp_metric_info = ("[ " + amdgpu_metrics_unit_type_translation_table.at(metric_unit) + " ]");
         for (const auto& metric_value : metric_values) {
           switch (metric_value.m_original_type) {
+            case (AMDGpuMetricsDataType_t::kUInt8):
+              {
+                auto value = get_casted_value<AMDGpuMetricsDataType_t::kUInt8>(metric_value);
+                tmp_outstream_metrics << print_unsigned_hex_and_int((value), metric_value.m_info) << " -> " << tmp_metric_info;
+              }
+              break;
             case (AMDGpuMetricsDataType_t::kUInt16):
               {
                 auto value = get_casted_value<AMDGpuMetricsDataType_t::kUInt16>(metric_value);
@@ -4932,9 +5237,9 @@ auto Device::dev_log_gpu_metrics(std::ostringstream& outstream_metrics,
               }
               break;
 
-              default:
-                tmp_outstream_metrics << "Error: No data type conversion for original type: " << static_cast<AMDGpuMetricsDataTypeId_t>(metric_value.m_original_type) << "\n";
-                break;
+            default:
+            tmp_outstream_metrics << "Error: No data type conversion for original type: " << static_cast<AMDGpuMetricsDataTypeId_t>(metric_value.m_original_type) << "\n";
+            break;
           }
         }
       }

--- a/projects/amdsmi/tests/amd_smi_test/functional/dynamic_metrics_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/dynamic_metrics_test.cc
@@ -59,7 +59,7 @@ auto GetExpectedMetricVersionFlag(uint16_t major, uint16_t minor, bool is_partit
   } else {  // GPU metrics
     if (major == 1) {
       switch (minor) {
-        case 0: return Flag::kGpuMetricNone;
+        case 0: return Flag::kGpuMetricV10;
         case 1: return Flag::kGpuMetricV11;
         case 2: return Flag::kGpuMetricV12;
         case 3: return Flag::kGpuMetricV13;
@@ -113,7 +113,7 @@ TEST(AmdSmiDynamicMetricTest, GPUMetricDynamicVersionSupported) {
     if (ver >= 9) {
       test_detail += "Dynamic] ";
     } else {
-      test_detail += "] ";
+      test_detail += "Static] ";
     }
     std::cout << test_detail << "Checking version 1." << ver << std::endl;
     SCOPED_TRACE(testing::Message() << "Subtest for minor version: 1." << ver);
@@ -129,23 +129,16 @@ TEST(AmdSmiDynamicMetricTest, GPUMetricDynamicVersionSupported) {
     ASSERT_TRUE(std::filesystem::exists(fake_path));
 
     const auto* header = reinterpret_cast<const amd::smi::AMDGpuMetricsHeader_v1_t*>(blob.data());
-
     const auto flag = amd::smi::translate_header_to_flag_version(*header, is_partition_metrics,
                                                                  fake_path.string());
-
     EXPECT_EQ(flag, GetExpectedMetricVersionFlag(1, ver, is_partition_metrics))
         << "Version 1." << ver << " should be treated as supported";
 
     auto gpu_metrics_ptr =
         amd::smi::amdgpu_metrics_factory(flag, is_partition_metrics, fake_path.string());
+    EXPECT_NE(gpu_metrics_ptr, nullptr)
+        << "Factory must create metrics object for supported version";
 
-    if (ver != 0) {
-      EXPECT_NE(gpu_metrics_ptr, nullptr)
-          << "Factory must create metrics object for supported version";
-    } else {
-      EXPECT_EQ(gpu_metrics_ptr, nullptr)
-          << "Factory must not create metrics object for unsupported versions";
-    }
     if (gpu_metrics_ptr) {
       std::cout << test_detail << "Created valid object for version 1." << ver << std::endl;
     } else {
@@ -164,7 +157,7 @@ TEST(AmdSmiDynamicMetricTest, XCPMetricDynamicVersionSupported) {
     if (ver >= 1) {
       test_detail += "Dynamic] ";
     } else {
-      test_detail += "] ";
+      test_detail += "Static] ";
     }
     std::cout << test_detail << "Checking version 1." << ver << std::endl;
     SCOPED_TRACE(testing::Message() << "Subtest for minor version: 1." << ver);
@@ -180,18 +173,16 @@ TEST(AmdSmiDynamicMetricTest, XCPMetricDynamicVersionSupported) {
     ASSERT_TRUE(std::filesystem::exists(fake_path));
 
     const auto* header = reinterpret_cast<const amd::smi::AMDGpuMetricsHeader_v1_t*>(blob.data());
-
     const auto flag = amd::smi::translate_header_to_flag_version(*header, is_partition_metrics,
                                                                  fake_path.string());
-
     EXPECT_EQ(flag, GetExpectedMetricVersionFlag(1, ver, is_partition_metrics))
         << "Version 1." << ver << " should be treated as supported";
 
     auto xcp_metrics_ptr =
         amd::smi::amdgpu_metrics_factory(flag, is_partition_metrics, fake_path.string());
-
     EXPECT_NE(xcp_metrics_ptr, nullptr)
         << "Factory must create metrics object for supported version";
+
     if (xcp_metrics_ptr) {
       std::cout << test_detail << "Created valid object for version 1." << ver << std::endl;
     } else {


### PR DESCRIPTION
fix: Add gpu_metrics 1.0 support which is still used by some hardware

Code changes related to the following:
  * APIs
  * Unit tests

## Motivation

Some hardware, such as NV10, VG20, still require `gpu metrics 1.0` support

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Add **gpu metrics** support to older hardware where **version 1.0 is required**

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

SWDEV-568613

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Command line execution/validation with: 

- amd-smi: `amd-smi metric`
- Unit tests: `amdsmitst` -> ` amdsmitstReadWrite.TestPowerReadWrite`, `amdsmitstReadWrite.TestFrequenciesReadWrite`

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Previous execution showed `Unable to load gpu metrics table; version not supported ...`

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
