### PR TITLE
Fix agent device ID in the cached kernel_dispatch perfetto trace

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
@@ -463,7 +463,7 @@ perfetto_processor_t::handle([[maybe_unused]] const kernel_dispatch_sample& _kds
 
     auto kernel_symbol = m_metadata.get_kernel_symbol(_kds.kernel_id);
     auto _agent_device_id =
-        m_agent_manager.get_agent_by_handle(_kds.agent_id_handle).device_id;
+        m_agent_manager.get_agent_by_handle(_kds.agent_id_handle).device_type_index;
     auto _queue_id_handle = _kds.queue_id_handle;
     auto _stream_handle   = _kds.stream_handle;
     auto _corr_id         = _kds.correlation_id_internal;


### PR DESCRIPTION
## Motivation

The wrong agent ID was used for track name in cached data for Perfetto output.

## Technical Details

Use the correct ID as in legacy implementation.

## JIRA ID

- AIPROFSYST-54

## Test Plan

Existing test cover the change.

## Test Result

Tests pass successfully

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
