### PR TITLE
fix: prevent static initialization deadlock in thread_data

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_data.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_data.hpp
@@ -71,14 +71,7 @@ struct base_thread_data
         };
         grow_functors().emplace_back(_func);
 
-        // Immediately sync this container to current peak_num_threads.
-        // This ensures containers instantiated after threads exceed
-        // max_supported_threads are properly sized.
-        auto _current_peak = get_current_peak_num_threads();
-        if(_current_peak > static_cast<int64_t>(max_supported_threads))
-        {
-            _func(_current_peak);
-        }
+        // Don't call _func here - causes recursive static initialization deadlock.
     }
 };
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_data.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_data.hpp
@@ -71,7 +71,8 @@ struct base_thread_data
         };
         grow_functors().emplace_back(_func);
 
-        // Don't call _func here - causes recursive static initialization deadlock.
+        // NOTE: Do not call _func() here - causes recursive static initialization
+        // deadlock. Container resizing is handled via grow_functors() in thread_info.cpp.
     }
 };
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Profiler hangs on shutdown when tracing apps with many threads (e.g., TensorFlow GPU workloads). Deadlock occurs in static initialization guard.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Root cause: base_thread_data constructor calls _func() which recursively calls private_instance() - the same static being initialized. This causes self-deadlock on __cxa_guard_acquire.
Fix: Remove the _func() call from constructor. The resize logic already exists in grow_functors() (thread_info.cpp) and gets called when thread count grows. Finalization in library.cpp already handles undersized containers with bounds check.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
Solves AIPROFSYST-44

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

- Built and ran rocprof-sys-run in default mode, with sampling and trace modes separately on TensorFlow workload.
- Verified profiler completes finalization without hanging
- Confirmed trace output is generated successfully

## Test Result

<!-- Briefly summarize test outcomes. -->
Profiler finalization completes successfully. No deadlock observed on NAVI22, NAVI31, MI300, MI308, MI325, MI350, MI355.
<img width="1495" height="587" alt="image" src="https://github.com/user-attachments/assets/d6235637-82cb-4ead-ad38-18f7bdb9985b" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
