### PR TITLE
SWDEV-572679 - Fix hipGraphicsGLRegisterImage

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocglinterop_windows.cpp
+++ b/projects/clr/rocclr/device/rocm/rocglinterop_windows.cpp
@@ -166,8 +166,26 @@ bool Export(amd::Memory* mem, GLenum targetType, int miplevel, hsa_handle_t* han
   const auto GLContext = mem->getContext().info().hCtx_;
   const auto name = static_cast<uint>(obj->getGLName());
 
-  assert(targetType == GL_ARRAY_BUFFER && "Only GL_ARRAY_BUFFER is supported");
-  constexpr GLenum type = GL_RESOURCE_ATTACH_VERTEXBUFFER_AMD;
+  GLenum type;
+  switch (obj->getCLGLObjectType()) {
+    case CL_GL_OBJECT_BUFFER:
+      type = GL_RESOURCE_ATTACH_VERTEXBUFFER_AMD;
+      break;
+    case CL_GL_OBJECT_RENDERBUFFER:
+      type = GL_RESOURCE_ATTACH_RENDERBUFFER_AMD;
+      break;
+    case CL_GL_OBJECT_TEXTURE_BUFFER:
+    case CL_GL_OBJECT_TEXTURE1D:
+    case CL_GL_OBJECT_TEXTURE1D_ARRAY:
+    case CL_GL_OBJECT_TEXTURE2D:
+    case CL_GL_OBJECT_TEXTURE2D_ARRAY:
+    case CL_GL_OBJECT_TEXTURE3D:
+      type = GL_RESOURCE_ATTACH_TEXTURE_AMD;
+      break;
+    default:
+      LogError("Unknown OpenGL interop type: 0x%x", obj->getCLGLObjectType());
+      return false;
+  }
 
   const auto glRenderContext = reinterpret_cast<HGLRC>(GLContext);
   GLResource glResource = {.type = type, .name = name};

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -237,7 +237,7 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
 
   static constexpr int MaxMetadataSizeDwords = 64;
   amdImageDesc_ =
-      reinterpret_cast<hsa_amd_image_descriptor_t*>(new char[(MaxMetadataSizeDwords + 2) * sizeof(int)]());
+      reinterpret_cast<hsa_amd_image_descriptor_t*>(new int[MaxMetadataSizeDwords + 2]());
   if (amdImageDesc_ == nullptr) {
     return false;
   }

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -236,13 +236,14 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
   Hsa::agent_get_info(agent, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_CHIP_ID), &id);
 
   static constexpr int MaxMetadataSizeDwords = 64;
+  static constexpr uint32_t DeviceIdVendorShift = 16u;
   amdImageDesc_ =
-      reinterpret_cast<hsa_amd_image_descriptor_t*>(new char[(MaxMetadataSizeDwords + 2) * sizeof(int)]());
+      reinterpret_cast<hsa_amd_image_descriptor_t*>(new int[MaxMetadataSizeDwords + 2]());
   if (amdImageDesc_ == nullptr) {
     return false;
   }
   amdImageDesc_->version = 1;
-  amdImageDesc_->deviceID = (AmdVendor << 16) | id;
+  amdImageDesc_->deviceID = (AmdVendor << DeviceIdVendorShift) | id;
 
   hsa_handle_t handle;
   int offset;

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -236,14 +236,13 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
   Hsa::agent_get_info(agent, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_CHIP_ID), &id);
 
   static constexpr int MaxMetadataSizeDwords = 64;
-  static constexpr uint32_t DeviceIdVendorShift = 16u;
   amdImageDesc_ =
-      reinterpret_cast<hsa_amd_image_descriptor_t*>(new int[MaxMetadataSizeDwords + 2]());
+      reinterpret_cast<hsa_amd_image_descriptor_t*>(new char[(MaxMetadataSizeDwords + 2) * sizeof(int)]());
   if (amdImageDesc_ == nullptr) {
     return false;
   }
   amdImageDesc_->version = 1;
-  amdImageDesc_->deviceID = (AmdVendor << DeviceIdVendorShift) | id;
+  amdImageDesc_->deviceID = (AmdVendor << 16) | id;
 
   hsa_handle_t handle;
   int offset;

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -237,7 +237,7 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
 
   static constexpr int MaxMetadataSizeDwords = 64;
   amdImageDesc_ =
-      reinterpret_cast<hsa_amd_image_descriptor_t*>(new int[MaxMetadataSizeDwords + 2]());
+      reinterpret_cast<hsa_amd_image_descriptor_t*>(new char[(MaxMetadataSizeDwords + 2) * sizeof(int)]());
   if (amdImageDesc_ == nullptr) {
     return false;
   }

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -231,6 +231,19 @@ hsa_status_t Memory::interopMapBuffer(hsa_handle_t fdn, hsa_interop_map_flag_t f
 // ================================================================================================
 bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
 #if IS_WINDOWS
+  hsa_agent_t agent = dev().getBackendDevice();
+  uint32_t id;
+  Hsa::agent_get_info(agent, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_CHIP_ID), &id);
+
+  static constexpr int MaxMetadataSizeDwords = 64;
+  amdImageDesc_ =
+      reinterpret_cast<hsa_amd_image_descriptor_t*>(new int[MaxMetadataSizeDwords + 2]());
+  if (amdImageDesc_ == nullptr) {
+    return false;
+  }
+  amdImageDesc_->version = 1;
+  amdImageDesc_->deviceID = (AmdVendor << 16) | id;
+
   hsa_handle_t handle;
   int offset;
 

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2008 - 2025 Advanced Micro Devices, Inc.
+/* Copyright (c) 2008 - 2026 Advanced Micro Devices, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -230,20 +230,31 @@ hsa_status_t Memory::interopMapBuffer(hsa_handle_t fdn, hsa_interop_map_flag_t f
 // Setup an interop buffer (dmabuf handle) as an OpenCL buffer
 // ================================================================================================
 bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
-#if IS_WINDOWS
+  assert(owner()->isInterop() && "Object is not an interop object.");
+
+  static constexpr size_t MaxMetadataSizeDwords = 64;
+  static constexpr size_t HeaderSizeDwords =
+      sizeof(hsa_amd_image_descriptor_t) / sizeof(uint32_t) - 1;
+
+  static_assert(alignof(hsa_amd_image_descriptor_t) == alignof(uint32_t),
+                "Unexpected alignment for hsa_amd_image_descriptor_t");
+  amdImageDesc_ = reinterpret_cast<hsa_amd_image_descriptor_t*>(
+      new uint32_t[MaxMetadataSizeDwords + HeaderSizeDwords]());
+
+  if (amdImageDesc_ == nullptr) {
+    return false;
+  }
+
   hsa_agent_t agent = dev().getBackendDevice();
   uint32_t id;
   Hsa::agent_get_info(agent, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_CHIP_ID), &id);
 
-  static constexpr int MaxMetadataSizeDwords = 64;
-  amdImageDesc_ =
-      reinterpret_cast<hsa_amd_image_descriptor_t*>(new int[MaxMetadataSizeDwords + 2]());
-  if (amdImageDesc_ == nullptr) {
-    return false;
-  }
-  amdImageDesc_->version = 1;
-  amdImageDesc_->deviceID = (AmdVendor << 16) | id;
+  static constexpr uint32_t DeviceIdVendorShift = 16u;
 
+  amdImageDesc_->version = 1;
+  amdImageDesc_->deviceID = (AmdVendor << DeviceIdVendorShift) | id;
+
+#if IS_WINDOWS
   hsa_handle_t handle;
   int offset;
 
@@ -253,8 +264,6 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
   deviceMemory_ = static_cast<char*>(interop_deviceMemory_) + offset;
   return true;
 #else
-  assert(owner()->isInterop() && "Object is not an interop object.");
-
   mesa_glinterop_export_in in = {0};
   mesa_glinterop_export_out out = {0};
 
@@ -268,18 +277,7 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
   else
     in.access = MESA_GLINTEROP_ACCESS_READ_WRITE;
 
-  hsa_agent_t agent = dev().getBackendDevice();
-  uint32_t id;
-  Hsa::agent_get_info(agent, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_CHIP_ID), &id);
-
-  static constexpr int MaxMetadataSizeDwords = 64;
   static constexpr int MaxMetadataSizeBytes = MaxMetadataSizeDwords * sizeof(int);
-  amdImageDesc_ = reinterpret_cast<hsa_amd_image_descriptor_t*>(new int[MaxMetadataSizeDwords + 2]);
-  if (amdImageDesc_ == nullptr) {
-    return false;
-  }
-  amdImageDesc_->version = 1;
-  amdImageDesc_->deviceID = AmdVendor << 16 | id;
 
   in.target = targetType;
   in.obj = owner()->getInteropObj()->asGLObject()->getGLName();
@@ -1559,7 +1557,7 @@ void Image::destroy() {
     return;
   }
 
-  delete[] amdImageDesc_;
+  delete[] reinterpret_cast<uint32_t*>(amdImageDesc_);
   amdImageDesc_ = nullptr;
 
   if (kind_ == MEMORY_KIND_INTEROP) {


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Unit_hipGraphicsGLRegisterImage_Positive_Basic fails due to a WGL image resource attachment failure and a missing HIP image descriptor configuration.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

This patch fixes the WGL image resource attachment by using the correct image types and adds the missing image descriptor configuration.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

SWDEV-572679

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

This patch covers the following hip-tests test cases:

Unit_hipGraphicsGLRegisterImage_Positive_Basic 
Unit_hipGraphicsGLRegisterImage_Positive_Register_Twice 
Unit_hipGraphicsGLRegisterImage_Negative_Parameters 

## Test Result

<!-- Briefly summarize test outcomes. -->

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
