### PR TITLE
Reuse spirv code objects for devices for same devices

### DIFF
--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -526,6 +526,7 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
           continue;
         }
 
+        LogPrintfInfo("Compiling device : %s code object from spirv", device_name.c_str());
         comgr_helper::ComgrDataSetUniqueHandle spirv_data_set;
         comgr_helper::ComgrDataSetUniqueHandle reloc_data;
         comgr_helper::ComgrDataUniqueHandle spirv_data;

--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -479,6 +479,13 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
     }
   }
 
+  // SPIRV Code object lookup
+  // We should compile it once, for each device and reuse the code object.
+  // There is a cache in comgr to help with recompile, but ideally, we should not need to compile
+  // the SPIRV again for the device if we already have the device isa for it already.
+  std::unordered_map<std::string /* isa */, std::pair<const char* /* co size */, size_t /* size */>>
+      spirv_cache_;
+
   LogPrintfInfo("Forcing SPIRV: %s", (HIP_FORCE_SPIRV_CODEOBJECT != 0 ? "true" : "false"));
   hipError_t hip_status = hipErrorInvalidImage;
   do {
@@ -507,6 +514,17 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
       } else if (spirv_isa_found) {
         std::string target_id = device->devices()[0]->isa().targetId();
         std::string isa = "amdgcn-amd-amdhsa--" + target_id;
+
+        // See if we already compiled it
+        if (auto cache = spirv_cache_.find(isa); cache != spirv_cache_.end()) {
+          LogPrintfInfo("Reusing compiled code object for isa: %s code object: %p", isa.c_str(),
+                        cache->second.first);
+          hip_status = AddDevProgram(device, cache->second.first, cache->second.second, 0);
+          if (hip_status != hipSuccess) {
+            break;
+          }
+          continue;
+        }
 
         comgr_helper::ComgrDataSetUniqueHandle spirv_data_set;
         comgr_helper::ComgrDataSetUniqueHandle reloc_data;
@@ -627,6 +645,7 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
 
         char* co = new char[co_size];
         code_obj_allocations_.insert(co);  // track to release later
+        spirv_cache_.insert(std::make_pair(isa, std::make_pair(co, co_size)));  // Add to cache
         if (auto comgr_status = amd::Comgr::get_data(exe_data.get(), &co_size, co);
             comgr_status != AMD_COMGR_STATUS_SUCCESS) {
           LogError("Failed to get exe data");

--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -525,6 +525,7 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
           continue;
         }
 
+        LogPrintfInfo("Compiling device : %s code object from spirv", device_name.c_str());
         comgr_helper::ComgrDataSetUniqueHandle spirv_data_set;
         comgr_helper::ComgrDataSetUniqueHandle reloc_data;
         comgr_helper::ComgrDataUniqueHandle spirv_data;

--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -480,6 +480,13 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
     }
   }
 
+  // SPIRV Code object lookup
+  // We should compile it once, for each device and reuse the code object.
+  // There is a cache in comgr to help with recompile, but ideally, we should not need to compile
+  // the SPIRV again for the device if we already have the device isa for it already.
+  std::unordered_map<std::string /* isa */, std::pair<const char* /* co size */, size_t /* size */>>
+      spirv_cache_;
+
   LogPrintfInfo("Forcing SPIRV: %s", (HIP_FORCE_SPIRV_CODEOBJECT != 0 ? "true" : "false"));
   hipError_t hip_status = hipErrorInvalidImage;
   do {
@@ -506,6 +513,17 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
       } else if (spirv_isa_found) {
         std::string target_id = device->devices()[0]->isa().targetId();
         std::string isa = "amdgcn-amd-amdhsa--" + target_id;
+
+        // See if we already compiled it
+        if (auto cache = spirv_cache_.find(isa); cache != spirv_cache_.end()) {
+          LogPrintfInfo("Reusing compiled code object for isa: %s code object: %p", isa.c_str(),
+                        cache->second.first);
+          hip_status = AddDevProgram(device, cache->second.first, cache->second.second, 0);
+          if (hip_status != hipSuccess) {
+            break;
+          }
+          continue;
+        }
 
         comgr_helper::ComgrDataSetUniqueHandle spirv_data_set;
         comgr_helper::ComgrDataSetUniqueHandle reloc_data;
@@ -626,6 +644,7 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
 
         char* co = new char[co_size];
         code_obj_allocations_.insert(co);  // track to release later
+        spirv_cache_.insert(std::make_pair(isa, std::make_pair(co, co_size)));  // Add to cache
         if (auto comgr_status = amd::Comgr::get_data(exe_data.get(), &co_size, co);
             comgr_status != AMD_COMGR_STATUS_SUCCESS) {
           LogError("Failed to get exe data");


### PR DESCRIPTION
## Motivation

If a system has multiple devices, we should not re-compile spirv for same devices and we should use code objects that we already have.

## Technical Details

We basically track the isa and code object pointers and reuse them when we encounter same device again.

## JIRA ID


## Test Plan

Existing test cases should pass and a manual validation on multigpu devices where we see in logs that we do not recompile for  device.

## Test Result

It should pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
