### PR TITLE
clr: Remove unneccesary call to SetMemAccess in hipGraphAddMemAllocNode

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -820,12 +820,6 @@ class Graph {
       LogError("Failed to reserve Virtual Address");
     }
 
-    // Set Access to read write for all devices.
-    for (size_t dev_idx = 0; dev_idx < g_devices.size(); ++dev_idx) {
-      amd::Device* device = g_devices[dev_idx]->devices()[0];
-      device->SetMemAccess(ptr, size, amd::Device::VmmAccess::kReadWrite);
-    }
-
     return ptr;
   }
 


### PR DESCRIPTION
## Motivation

- Remove call to SetMemAccess since its always failing.

## Technical Details

- SetMemAccess failures are not reported and only show up in log.
- SetMemAccess is called after reserving virtual address which seems incorrect.
- 
## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
