### PR TITLE
SWDEV-574457 - hiptest vm fault

### DIFF
--- a/projects/hip-tests/catch/unit/memory/hipMemset2DAsyncMultiThreadAndKernel.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemset2DAsyncMultiThreadAndKernel.cc
@@ -41,6 +41,7 @@ void queueJobsForhipMemset2DAsync(char* A_d, char* A_h, size_t pitch, size_t wid
   constexpr int memsetval = 0x22;
   HIPCHECK(hipMemset2DAsync(A_d, pitch, memsetval, NUM_W, NUM_H, stream));
   HIPCHECK(hipMemcpy2DAsync(A_h, width, A_d, pitch, NUM_W, NUM_H, hipMemcpyDeviceToHost, stream));
+  HIPCHECK(hipStreamSynchronize(stream));
 }
 
 


### PR DESCRIPTION
## Motivation
Fix a VM fault issue caused by the test

## Technical Details

If thread exit, WDDM release memory for this thread, as a result vm fault happens if GPU is still working on the memory.

## JIRA ID
SWDEV-574457

## Test Plan
Test the failed test 1000 times. Originally always see vm fault randomly.

## Test Result
No vm fault. Test passed 1000 times.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
