### PR TITLE
Do cleanup on context start failure

### DIFF
--- a/projects/rocprofiler-sdk/samples/counter_collection/device_counting_sync_client.cpp
+++ b/projects/rocprofiler-sdk/samples/counter_collection/device_counting_sync_client.cpp
@@ -239,10 +239,12 @@ counter_sampler::sample_counter_values(const std::vector<std::string>&          
         return ROCPROFILER_STATUS_ERROR;
     }
     profile_ = profile_cached->second;
-    rocprofiler_start_context(ctx_);
+    auto status = rocprofiler_start_context(ctx_);
+    if(status != ROCPROFILER_STATUS_SUCCESS) return status;
+
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
     size_t out_size = out.size();
-    auto   status   = rocprofiler_sample_device_counting_service(
+    status          = rocprofiler_sample_device_counting_service(
         ctx_, {}, ROCPROFILER_COUNTER_FLAG_NONE, out.data(), &out_size);
     rocprofiler_stop_context(ctx_);
     out.resize(out_size);

--- a/projects/rocprofiler-sdk/samples/counter_collection/device_counting_sync_client.cpp
+++ b/projects/rocprofiler-sdk/samples/counter_collection/device_counting_sync_client.cpp
@@ -238,7 +238,7 @@ counter_sampler::sample_counter_values(const std::vector<std::string>&          
         std::cerr << "Caught exception: " << e.what() << "\n";
         return ROCPROFILER_STATUS_ERROR;
     }
-    profile_ = profile_cached->second;
+    profile_    = profile_cached->second;
     auto status = rocprofiler_start_context(ctx_);
     if(status != ROCPROFILER_STATUS_SUCCESS) return status;
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -347,7 +347,7 @@ start_context(rocprofiler_context_id_t context_id)
 #endif
 
     // If some service failed, do cleanup
-    if (status != ROCPROFILER_STATUS_SUCCESS) stop_context(context_id);
+    if(status != ROCPROFILER_STATUS_SUCCESS) stop_context(context_id);
     return status;
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -342,9 +342,12 @@ start_context(rocprofiler_context_id_t context_id)
     if(cfg->dispatch_thread_trace) cfg->dispatch_thread_trace->start_context();
     if(cfg->device_counter_collection) status = rocprofiler::counters::start_agent_ctx(cfg);
 #if ROCPROFILER_SDK_HSA_PC_SAMPLING > 0
-    if(cfg->pc_sampler) status = rocprofiler::pc_sampling::start_service(cfg);
+    if(cfg->pc_sampler && status == ROCPROFILER_STATUS_SUCCESS)
+        status = rocprofiler::pc_sampling::start_service(cfg);
 #endif
 
+    // If some service failed, do cleanup
+    if (status != ROCPROFILER_STATUS_SUCCESS) stop_context(context_id);
     return status;
 }
 


### PR DESCRIPTION
## Motivation

* The counter collection context error if ignored.
* If the pc sampling service fails to start with the context, the SDK enters a state where some services are enabled and some are disabled in a context.

## Technical Details

If context fails

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
