### PR TITLE
[rocprofiler-sdk] Fix `fmt::join` build errors

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/common/logging.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/logging.cpp
@@ -25,6 +25,7 @@
 #include "lib/common/filesystem.hpp"
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <glog/logging.h>
 #include <glog/vlog_is_on.h>
 

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -56,6 +56,7 @@
 #include <rocprofiler-sdk-rocpd/types.h>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <sqlite3.h>
 #include <unistd.h>
 

--- a/projects/rocprofiler-sdk/source/lib/output/generateStats.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateStats.cpp
@@ -33,6 +33,7 @@
 #include <rocprofiler-sdk/marker/api_id.h>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include <unistd.h>
 #include <cstdint>

--- a/projects/rocprofiler-sdk/source/lib/output/sql/common.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/sql/common.cpp
@@ -31,6 +31,7 @@
 #include <rocprofiler-sdk/cxx/operators.hpp>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <sqlite3.h>
 
 #include <iomanip>

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/libpyrocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/libpyrocpd.cpp
@@ -54,6 +54,7 @@
 #include <rocprofiler-sdk-rocpd/sql.h>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <gotcha/gotcha.h>
 #include <pybind11/detail/common.h>
 #include <pybind11/pybind11.h>

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/serialization/sql.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/serialization/sql.cpp
@@ -23,6 +23,9 @@
 #include "lib/python/rocpd/source/serialization/sql.hpp"
 #include "lib/output/sql/common.hpp"
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 namespace cereal
 {
 SQLite3InputArchive::SQLite3InputArchive(sqlite3*         conn,

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/sql_generator.hpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/sql_generator.hpp
@@ -31,6 +31,8 @@
 #include "lib/output/generator.hpp"
 #include "lib/output/sql/common.hpp"
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <sqlite3.h>
 
 #include <chrono>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -79,6 +79,7 @@
 #include <rocprofiler-sdk/cxx/operators.hpp>
 
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 
 #include <time.h>
 #include <unistd.h>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/device_counting.cpp
@@ -39,6 +39,7 @@
 #include <rocprofiler-sdk/rocprofiler.h>
 
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 #include <gtest/gtest.h>
 #include <hsa/hsa.h>
 #include <hsa/hsa_api_trace.h>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/dimension.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/dimension.cpp
@@ -39,6 +39,7 @@
 #include <rocprofiler-sdk/rocprofiler.h>
 
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 #include <gtest/gtest.h>
 #include <hsa/hsa.h>
 #include <hsa/hsa_api_trace.h>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/details/format.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/details/format.hpp
@@ -31,8 +31,8 @@
 #include <hip/hip_deprecated.h>
 #include <hip/hip_version.h>
 
-#include "fmt/core.h"
-#include "fmt/ranges.h"
+#include <fmt/core.h>
+#include <fmt/ranges.h>
 
 #define ROCP_SDK_HIP_FORMATTER(TYPE, ...)                                                          \
     template <>                                                                                    \

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/details/fmt.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/details/fmt.hpp
@@ -22,6 +22,9 @@
 
 #include "lib/rocprofiler-sdk/hsa/queue.hpp"
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 namespace fmt
 {
 template <>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -39,6 +39,8 @@
 #include <rocprofiler-sdk/external_correlation.h>
 #include <rocprofiler-sdk/fwd.h>
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <hsa/hsa.h>
 #include <hsa/hsa_ext_amd.h>
 

--- a/projects/rocprofiler-sdk/source/lib/tests/common/parse.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/common/parse.cpp
@@ -23,6 +23,7 @@
 #include <rocprofiler-sdk/cxx/details/tokenize.hpp>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <gtest/gtest.h>
 
 #include <cstddef>


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
- remedy use of `fmt::join` without `#include <fmt/ranges.h>`

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- adding include in every file using `fmt::join`

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
N/A

## Test Result

<!-- Briefly summarize test outcomes. -->
N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
