### PR TITLE
[AMD-SMI] [SWDEV-572092] amd-smi does not redirect output to file when --json option is used.

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -623,9 +623,12 @@ class AMDSMILogger():
         if self.store_partition_resources_json_output:
             combined_json["partition_resources"] = self.store_partition_resources_json_output
 
-        self.destination == 'stdout'
-        json_std_output = json.dumps(combined_json, indent=4)
-        print(json_std_output)
+        if self.destination == 'stdout':
+            json_std_output = json.dumps(combined_json, indent=4)
+            print(json_std_output)
+        else:
+            with self.destination.open('w', encoding="utf-8") as output_file:
+                json.dump(combined_json, output_file, indent=4)
 
 
     def _print_csv_output(self, multiple_device_enabled=False, watching_output=False):


### PR DESCRIPTION
<img width="1018" height="990" alt="image" src="https://github.com/user-attachments/assets/4fa57d06-c21b-48d1-b2f7-74022e5ced26" />
