### PR TITLE
rocr: Remove dependency on KFD for vmem API to support xdnadriver

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -42,6 +42,7 @@
 
 #include "core/inc/amd_kfd_driver.h"
 
+#include <cassert>
 #include <memory>
 #include <string>
 
@@ -452,15 +453,17 @@ hsa_status_t KfdDriver::ExportDMABuf(void *mem, size_t size, int *dmabuf_fd,
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
+  assert(offset_res == 0);
+
   *dmabuf_fd = dmabuf_fd_res;
   *offset = offset_res;
 
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t KfdDriver::ImportDMABuf(int dmabuf_fd, core::Agent &agent,
-                                     core::ShareableHandle &handle, void* mem) {
-  auto &gpu_agent = static_cast<GpuAgent &>(agent);
+hsa_status_t KfdDriver::ImportDMABuf(int dmabuf_fd, const core::Agent& agent,
+                                     core::ShareableHandle* handle, void* mem) {
+  const auto& gpu_agent = static_cast<const GpuAgent&>(agent);
   HsaExternalHandleDesc desc;
   desc.device_handle = gpu_agent.libThunkDev();
   desc.fd = static_cast<HSAint32>(dmabuf_fd);
@@ -473,12 +476,16 @@ hsa_status_t KfdDriver::ImportDMABuf(int dmabuf_fd, core::Agent &agent,
   if (status != HSAKMT_STATUS_SUCCESS) {
     return HSA_STATUS_ERROR;
   }
-  handle.handle = reinterpret_cast<uint64_t>(res.buf_handle);
+  *handle = core::ShareableHandle{reinterpret_cast<uint64_t>(res.buf_handle)};
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t KfdDriver::Map(core::ShareableHandle handle, void *mem,
-                            size_t offset, size_t size,
+hsa_status_t KfdDriver::DestroyImportedShareableHandle(core::ShareableHandle* handle) {
+  // Calls DestroyShareableHandle, as an amdgpu_bo_handle object is created during ImportDMABuf.
+  return DestroyShareableHandle(handle);
+}
+
+hsa_status_t KfdDriver::Map(core::ShareableHandle handle, void* mem, size_t offset, size_t size,
                             hsa_access_permission_t perms) {
   HsaMemoryObjectHandle memhandle = reinterpret_cast<HsaMemoryObjectHandle>(handle.handle);
   HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtMemoryVaMap(memhandle, static_cast<HSAuint64>(offset),
@@ -501,13 +508,42 @@ hsa_status_t KfdDriver::Unmap(core::ShareableHandle handle, void *mem,
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t KfdDriver::ReleaseShareableHandle(core::ShareableHandle &handle) {
-  auto memhandle = reinterpret_cast<HsaMemoryObjectHandle>(handle.handle);
+hsa_status_t KfdDriver::CreateShareableHandle(void* va, void* mem, size_t size,
+                                              const core::Agent& agent,
+                                              core::ShareableHandle* handle, uint64_t* offset,
+                                              int* drm_fd, uint64_t* drm_fd_offset) {
+  // Create handle by exporting and importing the memory from the owning agent.
+
+  // Export memory.
+  int dmabuf_fd = 0;
+  hsa_status_t err = ExportDMABuf(mem, size, &dmabuf_fd, offset);
+  if (err != HSA_STATUS_SUCCESS) return err;
+
+  // Import memory.
+  err = ImportDMABuf(dmabuf_fd, agent, handle, mem);
+  core::Runtime::runtime_singleton_->DmaBufClose(dmabuf_fd);
+  if (err != HSA_STATUS_SUCCESS) return err;
+
+  // Get address that memory is mapped to.
+  auto devhandle = static_cast<const GpuAgent&>(agent).libThunkDev();
+  auto memhandle = reinterpret_cast<HsaMemoryObjectHandle>(handle->handle);
+  HSAKMT_STATUS hsakmt_err =
+      HSAKMT_CALL(hsaKmtMemoryGetCpuAddr(devhandle, memhandle, reinterpret_cast<HSAint32*>(drm_fd),
+                                         reinterpret_cast<HSAuint64*>(drm_fd_offset)));
+  if (hsakmt_err != HSAKMT_STATUS_SUCCESS) {
+    return HSA_STATUS_ERROR;
+  }
+
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::DestroyShareableHandle(core::ShareableHandle* handle) {
+  auto memhandle = reinterpret_cast<HsaMemoryObjectHandle>(handle->handle);
   HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtMemHandleFree(memhandle));
   if (status != HSAKMT_STATUS_SUCCESS) {
     return HSA_STATUS_ERROR;
   }
-  handle = {};
+  *handle = {};
   return HSA_STATUS_SUCCESS;
 }
 
@@ -738,7 +774,7 @@ hsa_status_t KfdDriver::GetQueueSaveAreaInfo(HSA_QUEUEID queue_id, void** addres
   *address = queue_info.SaveAreaHeader;
   *size = queue_info.SaveAreaSizeInBytes;
 
-  return HSA_STATUS_SUCCESS; 
+  return HSA_STATUS_SUCCESS;
 }
 
 } // namespace AMD

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
@@ -480,17 +480,22 @@ hsa_status_t KfdVirtioDriver::ExportDMABuf(void* mem, size_t size, int* dmabuf_f
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t KfdVirtioDriver::ImportDMABuf(int dmabuf_fd, core::Agent& agent,
-                                           core::ShareableHandle& handle, void* mem) {
-  auto &gpu_agent = static_cast<GpuAgent &>(agent);
+hsa_status_t KfdVirtioDriver::ImportDMABuf(int dmabuf_fd, const core::Agent& agent,
+                                           core::ShareableHandle* handle, void* mem) {
+  const auto& gpu_agent = static_cast<const GpuAgent&>(agent);
   amdgpu_bo_import_result res;
   auto ret = vamdgpu_bo_import(
       gpu_agent.libDrmDev(), amdgpu_bo_handle_type_dma_buf_fd, dmabuf_fd, &res);
   if (ret)
     return HSA_STATUS_ERROR;
 
-  handle.handle = reinterpret_cast<uint64_t>(res.buf_handle);
+  *handle = core::ShareableHandle{reinterpret_cast<uint64_t>(res.buf_handle)};
   return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdVirtioDriver::DestroyImportedShareableHandle(core::ShareableHandle* handle) {
+  // Calls DestroyShareableHandle, as an amdgpu_bo_handle object is created during ImportDMABuf.
+  return DestroyShareableHandle(handle);
 }
 
 hsa_status_t KfdVirtioDriver::Map(core::ShareableHandle handle, void* mem, size_t offset,
@@ -519,7 +524,14 @@ hsa_status_t KfdVirtioDriver::Unmap(core::ShareableHandle handle, void* mem, siz
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t KfdVirtioDriver::ReleaseShareableHandle(core::ShareableHandle& handle) {
+hsa_status_t KfdVirtioDriver::CreateShareableHandle(void* va, void* mem, size_t size,
+                                                    const core::Agent& agent,
+                                                    core::ShareableHandle* handle, uint64_t* offset,
+                                                    int* drm_fd, uint64_t* drm_fd_offset) {
+  return HSA_STATUS_ERROR;
+}
+
+hsa_status_t KfdVirtioDriver::DestroyShareableHandle(core::ShareableHandle* handle) {
   const auto ldrm_bo = reinterpret_cast<amdgpu_bo_handle>(handle.handle);
   if (!ldrm_bo)
     return HSA_STATUS_ERROR;
@@ -547,7 +559,6 @@ hsa_status_t KfdVirtioDriver::SPMSetDestBuffer(uint32_t node_id, uint32_t size, 
                                                bool* is_data_loss) const {
   return HSA_STATUS_ERROR;
 }
-
 
 hsa_status_t KfdVirtioDriver::OpenSMI(uint32_t node_id, int* fd) const { return HSA_STATUS_ERROR; }
 
@@ -586,7 +597,7 @@ hsa_status_t KfdVirtioDriver::GetQueueSaveAreaInfo(HSA_QUEUEID queue_id, void** 
   *address = queue_info.SaveAreaHeader;
   *size = queue_info.SaveAreaSizeInBytes;
 
-  return HSA_STATUS_SUCCESS; 
+  return HSA_STATUS_SUCCESS;
 }
 
 }  // namespace AMD

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -48,6 +48,7 @@
 #include <unistd.h>
 
 #include <array>
+#include <cassert>
 #include <filesystem>
 #include <fstream>
 #include <map>
@@ -337,29 +338,38 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
     return HSA_STATUS_ERROR;
   }
 
-  /// TODO: For now we always map the memory and keep a mapping from handles
-  /// to VA memory addresses. Once we can support the separate VMEM call to
-  /// map handles we can fix this.
   if (use_bo_shmem) {
-    bo_handle.vaddr =
-        mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, get_bo_info_args.map_offset);
-    if (bo_handle.vaddr == MAP_FAILED) {
-      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+    if (alloc_flags & core::MemoryRegion::AllocateMemoryOnly) {
+      /// TODO: We create an anonymous mapping to get a unique virtual address since the memory
+      /// handle mapping, i.e., Runtime::memory_handle_map_, is indexed using ThunkHandle which is
+      /// driver-agnostic and just a pointer to the virtual address space. We waste a page, but it
+      /// ensures uniqueness across drivers.
+      bo_handle.vaddr =
+          mmap(nullptr, MemoryRegion::GetPageSize(), PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+      if (bo_handle.vaddr == MAP_FAILED) {
+        return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+      }
+    } else {
+      bo_handle.vaddr =
+          mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, get_bo_info_args.map_offset);
+      if (bo_handle.vaddr == MAP_FAILED) {
+        return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+      }
     }
+    bo_handle.unmap_vaddr = true;
   } else {
+    /// This is dev heap and is already mapped. See InitDeviceHeap().
     bo_handle.vaddr = reinterpret_cast<void*>(get_bo_info_args.vaddr);
+    bo_handle.unmap_vaddr = false;
   }
 
-  if (alloc_flags & core::MemoryRegion::AllocateMemoryOnly) {
-    *mem = reinterpret_cast<void *>(create_bo_args.handle);
-  } else {
-    *mem = bo_handle.vaddr;
-  }
-
-  vmem_handle_mappings.emplace(bo_handle.handle, bo_handle.vaddr);
+  // We keep a mapping from VA memory addresses to BO handles because some operations, e.g.,
+  // FreeMemory, pass only the memory address and not a BO handle.
   vmem_addr_mappings.emplace(bo_handle.vaddr, bo_handle);
 
   bo_guard.Dismiss();
+
+  *mem = bo_handle.vaddr;
 
   return HSA_STATUS_SUCCESS;
 }
@@ -368,15 +378,24 @@ hsa_status_t XdnaDriver::FreeMemory(void *mem, size_t size) {
   auto it = vmem_addr_mappings.find(mem);
   if (it == vmem_addr_mappings.end()) return HSA_STATUS_ERROR_INVALID_ALLOCATION;
 
-  auto handle = it->second.handle;
+  auto& bo_handle = it->second;
+  if (bo_handle.unmap_vaddr) {
+    if (munmap(bo_handle.vaddr, bo_handle.size) != 0) {
+      return HSA_STATUS_ERROR;
+    }
+    bo_handle.unmap_vaddr = false;
+  }
+  bo_handle.vaddr = nullptr;
+  bo_handle.size = 0;
 
+  // Close the BO.
   drm_gem_close close_args = {};
-  close_args.handle = handle;
+  close_args.handle = bo_handle.handle;
   if (ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_args) < 0) {
     return HSA_STATUS_ERROR;
   }
+  bo_handle.handle = AMDXDNA_INVALID_BO_HANDLE;
 
-  vmem_handle_mappings.erase(handle);
   vmem_addr_mappings.erase(it);
 
   return HSA_STATUS_SUCCESS;
@@ -445,15 +464,20 @@ hsa_status_t XdnaDriver::ExportDMABuf(void* mem, size_t size, int* dmabuf_fd, si
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::ImportDMABuf(int dmabuf_fd, core::Agent &agent,
-                                      core::ShareableHandle &handle, void* mem) {
+hsa_status_t XdnaDriver::ImportDMABuf(int dmabuf_fd, const core::Agent& agent,
+                                      core::ShareableHandle* handle, void* mem) {
   drm_prime_handle import_params = {};
   import_params.handle = AMDXDNA_INVALID_BO_HANDLE;
   import_params.fd = dmabuf_fd;
   if (ioctl(fd_, DRM_IOCTL_PRIME_FD_TO_HANDLE, &import_params) < 0)
     return HSA_STATUS_ERROR;
 
-  handle.handle = import_params.handle;
+  *handle = core::ShareableHandle{import_params.handle};
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t XdnaDriver::DestroyImportedShareableHandle(core::ShareableHandle* handle) {
+  // Nothing to do for XDNA since we have a single, non-ref counted handle.
   return HSA_STATUS_SUCCESS;
 }
 
@@ -484,9 +508,50 @@ hsa_status_t XdnaDriver::Unmap(core::ShareableHandle handle, void *mem,
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::ReleaseShareableHandle(core::ShareableHandle &handle) {
+hsa_status_t XdnaDriver::CreateShareableHandle(void* va, void* mem, size_t size,
+                                               const core::Agent& agent,
+                                               core::ShareableHandle* handle, uint64_t* offset,
+                                               int* drm_fd, uint64_t* drm_fd_offset) {
+  // Find BO handle; mem is the BO handle; see AllocateMemory.
+  auto bo_handle = FindBOHandle(mem);
+  if (!bo_handle.IsValid()) {
+    return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+  }
+
+  // Get offset.
+  amdxdna_drm_get_bo_info get_bo_info_args = {};
+  get_bo_info_args.handle = bo_handle.handle;
+  if (ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args) < 0) {
+    return HSA_STATUS_ERROR;
+  }
+
+  // Get fd associated with the handle.
+  drm_prime_handle params = {};
+  params.handle = bo_handle.handle;
+  params.flags = DRM_RDWR;
+  params.fd = -1;
+  if (ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &params) < 0) {
+    return HSA_STATUS_ERROR;
+  }
+
+  // Map memory to the virtual address.
+  void* mapped_ptr = mmap(va, size, PROT_READ | PROT_WRITE, MAP_FIXED | MAP_SHARED, fd_,
+                          get_bo_info_args.map_offset);
+  if (mapped_ptr == MAP_FAILED) {
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
+
+  *handle = core::ShareableHandle{bo_handle.handle};
+  *offset = 0;
+  *drm_fd = params.fd;
+  *drm_fd_offset = 0;
+
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t XdnaDriver::DestroyShareableHandle(core::ShareableHandle* handle) {
   drm_gem_close close_params = {};
-  close_params.handle = handle.handle;
+  close_params.handle = handle->handle;
   if (ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_params) < 0)
     return HSA_STATUS_ERROR;
 
@@ -530,7 +595,8 @@ hsa_status_t XdnaDriver::InitDeviceHeap() {
   }
 
   const size_t size = dev_heap_align * 2 - 1;
-  dev_heap_handle.vaddr = mmap(0, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  dev_heap_handle.vaddr =
+      mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   if (dev_heap_handle.vaddr == MAP_FAILED) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
@@ -553,26 +619,16 @@ hsa_status_t XdnaDriver::InitDeviceHeap() {
 }
 
 hsa_status_t XdnaDriver::FreeDeviceHeap() {
-  hsa_status_t status = HSA_STATUS_SUCCESS;
-
   if (dev_heap_aligned) {
     if (munmap(dev_heap_aligned, dev_heap_size) != 0) {
-      status = HSA_STATUS_ERROR;
+      return HSA_STATUS_ERROR;
     }
     dev_heap_aligned = nullptr;
   }
 
-  if (dev_heap_handle.IsValid()) {
-    if (munmap(dev_heap_handle.vaddr, dev_heap_handle.size) != 0) {
-      status = HSA_STATUS_ERROR;
-    }
-    drm_gem_close close_bo_args = {};
-    close_bo_args.handle = dev_heap_handle.handle;
-    ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
-    dev_heap_handle = BOHandle{};
-  }
+  DestroyBOHandle(dev_heap_handle);
 
-  return status;
+  return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t XdnaDriver::ExecCmdAndWait(const BOHandle& cmd_chain_bo_handle,
@@ -664,28 +720,30 @@ hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) {
     return HSA_STATUS_ERROR;
   }
 
-  // Close the BO in case of error.
-  MAKE_NAMED_SCOPE_GUARD(cmd_bo_handle_guard, [&] {
-    drm_gem_close close_bo_args = {};
-    close_bo_args.handle = create_cmd_bo.handle;
-    ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
-  });
+  BOHandle tmp_cmd_bo_handle;
+  tmp_cmd_bo_handle.handle = create_cmd_bo.handle;
+  tmp_cmd_bo_handle.size = size;
+
+  // Unmap and close the command BO in case of error.
+  MAKE_NAMED_SCOPE_GUARD(tmp_cmd_bo_handle_guard, [&] { DestroyBOHandle(tmp_cmd_bo_handle); });
 
   amdxdna_drm_get_bo_info cmd_bo_get_bo_info = {};
-  cmd_bo_get_bo_info.handle = create_cmd_bo.handle;
+  cmd_bo_get_bo_info.handle = tmp_cmd_bo_handle.handle;
   if (ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &cmd_bo_get_bo_info) < 0) {
     return HSA_STATUS_ERROR;
   }
 
-  void* mem = static_cast<amdxdna_cmd*>(mmap(nullptr, create_cmd_bo.size, PROT_READ | PROT_WRITE,
-                                             MAP_SHARED, fd_, cmd_bo_get_bo_info.map_offset));
+  void* mem = mmap(nullptr, tmp_cmd_bo_handle.size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_,
+                   cmd_bo_get_bo_info.map_offset);
   if (mem == MAP_FAILED) {
     return HSA_STATUS_ERROR;
   }
+  tmp_cmd_bo_handle.vaddr = mem;
+  tmp_cmd_bo_handle.unmap_vaddr = true;
 
-  cmd_bo_handle = BOHandle{mem, create_cmd_bo.handle, size};
+  tmp_cmd_bo_handle_guard.Dismiss();
 
-  cmd_bo_handle_guard.Dismiss();
+  cmd_bo_handle = tmp_cmd_bo_handle;
 
   return HSA_STATUS_SUCCESS;
 }
@@ -832,27 +890,9 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uin
     FlushOperands(pkt->count, cmd_pkt_payload);
   }
 
-  // Unmapping and closing the cmd BOs
-  cmd_bo_handles_guard.Dismiss();
-  for (auto& command_bo_handle : cmd_bo_handles) {
-    if (munmap(command_bo_handle.vaddr, command_bo_handle.size) != 0) {
-      status = HSA_STATUS_ERROR;
-    }
-    drm_gem_close close_bo_args = {};
-    close_bo_args.handle = command_bo_handle.handle;
-    ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
-  }
+  // Guards will unmap and close cmd BOs and cmd_chain BO.
 
-  // Unmapping and closing the cmd_chain BO
-  cmd_chain_bo_handle_guard.Dismiss();
-  if (munmap(cmd_chain, cmd_chain_size) != 0) {
-    status = HSA_STATUS_ERROR;
-  }
-  drm_gem_close close_bo_args = {};
-  close_bo_args.handle = cmd_chain_bo_handle.handle;
-  ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
-
-  return status;
+  return HSA_STATUS_SUCCESS;
 }
 
 hsa_status_t XdnaDriver::SPMAcquire(uint32_t preferred_node_id) const {
@@ -879,11 +919,24 @@ hsa_status_t XdnaDriver::IsModelEnabled(bool* enable) const {
 }
 
 void XdnaDriver::DestroyBOHandle(BOHandle& handle) {
-  munmap(handle.vaddr, handle.size);
-  drm_gem_close close_bo_args = {};
-  close_bo_args.handle = handle.handle;
-  ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args);
-  handle = {};
+  if (handle.unmap_vaddr) {
+    // Unmap the memory.
+    if (munmap(handle.vaddr, handle.size) != 0) {
+      assert(false && "Failed to unmap BO memory.");
+    }
+    handle.unmap_vaddr = false;
+  }
+  handle.vaddr = nullptr;
+  handle.size = 0;
+
+  if (handle.IsValid()) {
+    drm_gem_close close_bo_args = {};
+    close_bo_args.handle = handle.handle;
+    if (ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_bo_args) < 0) {
+      assert(false && "Failed to close BO handle.");
+    }
+    handle.handle = AMDXDNA_INVALID_BO_HANDLE;
+  }
 }
 
 XdnaDriver::BOHandle XdnaDriver::FindBOHandle(void* mem) const {
@@ -1022,7 +1075,7 @@ hsa_status_t XdnaDriver::MakeMemoryResident(const void* mem, size_t size, uint64
 }
 
 hsa_status_t XdnaDriver::GetQueueSaveAreaInfo(HSA_QUEUEID queue_id, void** address, size_t* size) const {
-  return HSA_STATUS_ERROR; 
+  return HSA_STATUS_ERROR;
 }
 
 hsa_status_t XdnaDriver::MakeMemoryUnresident(const void* mem) const { return HSA_STATUS_ERROR; }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -109,13 +109,17 @@ public:
                              uint32_t* first_gws) const override;
   hsa_status_t ExportDMABuf(void *mem, size_t size, int *dmabuf_fd,
                             size_t *offset) override;
-  hsa_status_t ImportDMABuf(int dmabuf_fd, core::Agent &agent,
-                            core::ShareableHandle &handle, void* mem) override;
+  hsa_status_t ImportDMABuf(int dmabuf_fd, const core::Agent& agent, core::ShareableHandle* handle,
+                            void* mem) override;
+  hsa_status_t DestroyImportedShareableHandle(core::ShareableHandle* handle) override;
   hsa_status_t Map(core::ShareableHandle handle, void *mem, size_t offset,
                    size_t size, hsa_access_permission_t perms) override;
   hsa_status_t Unmap(core::ShareableHandle handle, void *mem, size_t offset,
                      size_t size) override;
-  hsa_status_t ReleaseShareableHandle(core::ShareableHandle &handle) override;
+  hsa_status_t CreateShareableHandle(void* va, void* mem, size_t size, const core::Agent& agent,
+                                     core::ShareableHandle* handle, uint64_t* offset, int* drm_fd,
+                                     uint64_t* drm_fd_offset) override;
+  hsa_status_t DestroyShareableHandle(core::ShareableHandle* handle) override;
   hsa_status_t SPMAcquire(uint32_t preferred_node_id) const override;
   hsa_status_t SPMRelease(uint32_t preferred_node_id) const override;
   hsa_status_t SPMSetDestBuffer(uint32_t preferred_node_id, uint32_t size_bytes, uint32_t* timeout,
@@ -141,7 +145,7 @@ public:
   hsa_status_t IsModelEnabled(bool* enable) const override;
 
   hsa_status_t GetQueueSaveAreaInfo(HSA_QUEUEID queue_id, void** address, size_t* size) const override;
-  
+
  private:
   /// @brief Allocate agent accessible memory (system / local memory).
   static void *AllocateKfdMemory(const HsaMemFlags &flags, uint32_t node_id,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_virtio_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_virtio_driver.h
@@ -101,12 +101,16 @@ class KfdVirtioDriver final : public core::Driver {
                               uint32_t* cu_mask) const override;
   hsa_status_t AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_GWS, uint32_t* GWS) const override;
   hsa_status_t ExportDMABuf(void* mem, size_t size, int* dmabuf_fd, size_t* offset) override;
-  hsa_status_t ImportDMABuf(int dmabuf_fd, core::Agent& agent,
-                            core::ShareableHandle& handle, void* mem) override;
+  hsa_status_t ImportDMABuf(int dmabuf_fd, const core::Agent& agent, core::ShareableHandle* handle,
+                            void* mem) override;
+  hsa_status_t DestroyImportedShareableHandle(core::ShareableHandle* handle) override;
   hsa_status_t Map(core::ShareableHandle handle, void* mem, size_t offset, size_t size,
                    hsa_access_permission_t perms) override;
   hsa_status_t Unmap(core::ShareableHandle handle, void* mem, size_t offset, size_t size) override;
-  hsa_status_t ReleaseShareableHandle(core::ShareableHandle& handle) override;
+  hsa_status_t CreateShareableHandle(void* va, void* mem, size_t size, const core::Agent& agent,
+                                     core::ShareableHandle* handle, uint64_t* offset, int* drm_fd,
+                                     uint64_t* drm_fd_offset) override;
+  hsa_status_t DestroyShareableHandle(core::ShareableHandle* handle) override;
   hsa_status_t GetTileConfig(uint32_t node_id, HsaGpuTileConfig* config) const;
   hsa_status_t SPMAcquire(uint32_t node_id) const override;
   hsa_status_t SPMRelease(uint32_t node_id) const override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -127,6 +127,8 @@ class XdnaDriver final : public core::Driver {
     uint32_t handle = AMDXDNA_INVALID_BO_HANDLE;
     /// Size in bytes.
     size_t size = 0;
+    /// True if @ref vaddr needs to be unmapped.
+    bool unmap_vaddr = false;
 
     constexpr BOHandle() = default;
     constexpr BOHandle(void* vaddr, uint32_t handle, size_t size)
@@ -216,13 +218,17 @@ public:
                              uint32_t* first_gws) const override;
   hsa_status_t ExportDMABuf(void *mem, size_t size, int *dmabuf_fd,
                             size_t *offset) override;
-  hsa_status_t ImportDMABuf(int dmabuf_fd, core::Agent &agent,
-                            core::ShareableHandle &handle, void* mem) override;
+  hsa_status_t ImportDMABuf(int dmabuf_fd, const core::Agent& agent, core::ShareableHandle* handle,
+                            void* mem) override;
+  hsa_status_t DestroyImportedShareableHandle(core::ShareableHandle* handle) override;
   hsa_status_t Map(core::ShareableHandle handle, void *mem, size_t offset,
                    size_t size, hsa_access_permission_t perms) override;
   hsa_status_t Unmap(core::ShareableHandle handle, void *mem, size_t offset,
                      size_t size) override;
-  hsa_status_t ReleaseShareableHandle(core::ShareableHandle &handle) override;
+  hsa_status_t CreateShareableHandle(void* va, void* mem, size_t size, const core::Agent& agent,
+                                     core::ShareableHandle* handle, uint64_t* offset, int* drm_fd,
+                                     uint64_t* drm_fd_offset) override;
+  hsa_status_t DestroyShareableHandle(core::ShareableHandle* handle) override;
 
   /// @brief Submits @p num_pkts packets in a command chain.
   hsa_status_t SubmitCmdChain(hsa_amd_aie_ert_packet_t* first_pkt, uint32_t num_pkts,
@@ -251,14 +257,14 @@ public:
   hsa_status_t IsModelEnabled(bool* enable) const override;
 
   hsa_status_t GetQueueSaveAreaInfo(HSA_QUEUEID queue_id, void** address, size_t* size) const override;
-  
+
  private:
   /// @brief Destroys @p bo_handle.
   ///
   /// This function will unmap the virtual address and close the BO, but will not return any status.
   void DestroyBOHandle(BOHandle& bo_handle);
 
-  /// @brief Finds the BO associated with the address.
+  /// @brief Returns the BO associated with the address.
   BOHandle FindBOHandle(void* mem) const;
 
   /// @brief Creates a new hardware context with the given PDI BO handles.
@@ -296,11 +302,6 @@ public:
   hsa_status_t ExecCmdAndWait(const BOHandle& cmd_chain_bo_handle,
                               const std::vector<uint32_t>& bo_handles, HSA_QUEUEID queue_id);
 
-  /// TODO: Remove this in the future and rely on the core Runtime
-  /// object to track handle allocations. Using the VMEM API for mapping XDNA
-  /// driver handles requires a bit more refactoring. So rely on the XDNA driver
-  /// to manage some of this for now.
-  std::unordered_map<uint32_t, void *> vmem_handle_mappings;
   std::map<void*, BOHandle> vmem_addr_mappings;
 
   /// @brief Hardware context to PDI cache mapping.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -196,7 +196,7 @@ public:
   virtual hsa_status_t AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_gws,
                                      uint32_t* first_gws) const = 0;
 
-  /// @brief Imports memory using dma-buf.
+  /// @brief Exports a memory object via dma-buf.
   ///
   /// @param[in] mem virtual address
   /// @param[in] size memory size in bytes
@@ -205,14 +205,21 @@ public:
   virtual hsa_status_t ExportDMABuf(void *mem, size_t size, int *dmabuf_fd,
                                     size_t *offset) = 0;
 
-  /// @brief Imports a memory chunk via dma-buf.
+  /// @brief Imports a memory object via dma-buf.
+  ///
+  /// @note The handle must be destroyed with @ref DestroyImportedShareableHandle.
   ///
   /// @param[in] dmabuf_fd dma-buf file descriptor
   /// @param[in] agent agent to import the memory for
   /// @param[out] handle handle to the imported memory
   /// @param[in] mem address of existing buffer, used to bypass import
-  virtual hsa_status_t ImportDMABuf(int dmabuf_fd, core::Agent &agent,
-                                    core::ShareableHandle &handle, void* mem = nullptr) = 0;
+  virtual hsa_status_t ImportDMABuf(int dmabuf_fd, const core::Agent& agent,
+                                    core::ShareableHandle* handle, void* mem = nullptr) = 0;
+
+  /// @brief Destroys the handle created during @ref ImportDMABuf.
+  ///
+  /// @param[in] handle handle of the object to release
+  virtual hsa_status_t DestroyImportedShareableHandle(core::ShareableHandle* handle) = 0;
 
   /// @brief Maps the memory associated with the handle.
   ///
@@ -234,11 +241,28 @@ public:
   virtual hsa_status_t Unmap(core::ShareableHandle handle, void *mem,
                              size_t offset, size_t size) = 0;
 
-  /// @brief Releases the object associated with the handle.
+  /// @brief Maps the virtual address to the physical address and creates a handle to share this
+  /// mapping.
   ///
-  /// @param[in] handle handle of the object to release
-  virtual hsa_status_t
-  ReleaseShareableHandle(core::ShareableHandle &handle) = 0;
+  /// @note The handle must be destroyed with @ref DestroyShareableHandle.
+  ///
+  /// @param[in] va virtual address
+  /// @param[in] mem physical memory handle
+  /// @param[in] size memory size in bytes
+  /// @param[in] agent agent associated with @p mem
+  /// @param[out] handle handle of the memory object
+  /// @param[out] offset memory offset in bytes
+  /// @param[out] drm_fd file descriptor
+  /// @param[out] drm_fd_offset offset in @p drm_fd
+  virtual hsa_status_t CreateShareableHandle(void* va, void* mem, size_t size,
+                                             const core::Agent& agent,
+                                             core::ShareableHandle* handle, uint64_t* offset,
+                                             int* drm_fd, uint64_t* drm_fd_offset) = 0;
+
+  /// @brief Destroys the handle created during @ref CreateShareableHandle.
+  ///
+  /// @param[in] handle handle of the object to destroy
+  virtual hsa_status_t DestroyShareableHandle(core::ShareableHandle* handle) = 0;
 
   /// @brief Acquire a streaming performance monitor on an agent.
   /// @param[in] preferred_node_id Node ID of the preferred agent.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -912,8 +912,6 @@ class Runtime {
   lazy_ptr<AsyncEventsInfo> asyncExceptions_;
  private:
   void CheckVirtualMemApiSupport();
-  int GetAmdgpuDeviceArgs(Agent *agent, ShareableHandle handle, int *drm_fd,
-                          uint64_t *cpu_addr);
 
   bool virtual_mem_api_supported_;
   bool xnack_enabled_;
@@ -984,8 +982,6 @@ class Runtime {
     MappedHandle(MemoryHandle* mem_handle, AddressHandle* address_handle, void* va,
                  uint64_t offset, size_t size, int drm_fd, void *drm_cpu_addr,
                  hsa_access_permission_t perm, ShareableHandle shareable_handle);
-
-    MappedHandle() {}
 
     __forceinline core::Agent* agentOwner() const { return mem_handle->region->owner(); }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -2307,9 +2307,9 @@ void Runtime::PrintMemoryMapNear(void* ptr) {
     it++;
   }
   fprintf(stderr, "\n");
-  it = start;  
+  it = start;
   lock.unlock();
-  
+
   hsa_amd_pointer_info_t info = {};
   PtrInfoBlockData block = {};
   uint32_t count = 0;
@@ -2491,13 +2491,13 @@ void Runtime::Unload() {
   if (vm_fault_signal_ != nullptr) {
     vm_fault_signal_.reset();
   }
-  
+
   vm_fault_event_.reset();
 
   if (hw_exception_signal_ != nullptr) {
     hw_exception_signal_.reset();
   }
-  
+
   hw_exception_event_.reset();
 
 
@@ -2613,18 +2613,6 @@ static int (*fn_amdgpu_device_get_fd)(HsaAMDGPUDeviceHandle device_handle) = NUL
 int fn_amdgpu_device_get_fd_nosupport(HsaAMDGPUDeviceHandle device_handle) {
   fprintf(stderr, "amdgpu_device_get_fd not available. Please update version of libdrm");
   return -1;
-}
-
-int Runtime::GetAmdgpuDeviceArgs(Agent *agent, ShareableHandle handle,
-                                 int *drm_fd, uint64_t *cpu_addr) {
-  auto devhandle = static_cast<AMD::GpuAgent*>(agent)->libThunkDev();
-  auto memhandle = reinterpret_cast<HsaMemoryObjectHandle>(handle.handle);
-  HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtMemoryGetCpuAddr(devhandle, memhandle,
-                         reinterpret_cast<HSAint32*>(drm_fd), reinterpret_cast<HSAuint64*>(cpu_addr)));
-  if (status != HSAKMT_STATUS_SUCCESS) {
-    return HSA_STATUS_ERROR;
-  }
-  return HSA_STATUS_SUCCESS;
 }
 
 void Runtime::CheckVirtualMemApiSupport() {
@@ -3638,10 +3626,6 @@ hsa_status_t Runtime::VMemoryHandleRelease(hsa_amd_vmem_alloc_handle_t memoryOnl
 hsa_status_t Runtime::VMemoryHandleMap(void* va, size_t size, size_t in_offset,
                                        hsa_amd_vmem_alloc_handle_t memoryOnlyHandle,
                                        uint64_t flags) {
-  int drm_fd, dmabuf_fd = 0;
-  uint64_t offset = 0, ret;
-  uint64_t drm_cpu_addr = 0;
-
   std::lock_guard<std::shared_mutex> lock(memory_lock_);
   auto addressHandle = VMemoryFindReservedAddressHandle(va);
   if (addressHandle == nullptr ||
@@ -3670,34 +3654,23 @@ hsa_status_t Runtime::VMemoryHandleMap(void* va, size_t size, size_t in_offset,
 
   auto *agent = memoryHandleIt->second.agentOwner();
 
-  // For now, this is only supported for KFD due to the call to
-  // GetAmdgpuDeviceArgs
-  if (agent->device_type() != core::Agent::DeviceType::kAmdGpuDevice)
+  if (agent->device_type() == core::Agent::DeviceType::kAmdCpuDevice)
     return HSA_STATUS_ERROR_INVALID_AGENT;
 
-  // Create handle by exporting and importing the memory from the owning agent
-  auto &agent_driver = agent->driver();
+  // Create mapping
   ShareableHandle shareable_handle;
-  hsa_status_t status = agent_driver.ExportDMABuf(memoryHandleIt->first, size,
-                                                  &dmabuf_fd, &offset);
-  if (status != HSA_STATUS_SUCCESS)
-    return status;
-  assert(offset == 0);
+  uint64_t offset = 0;
+  int drm_fd = 0;
+  uint64_t drm_fd_offset = 0;
+  hsa_status_t err = agent->driver().CreateShareableHandle(
+      va, memoryHandleIt->first, size, *agent, &shareable_handle, &offset, &drm_fd, &drm_fd_offset);
+  if (err != HSA_STATUS_SUCCESS) return err;
 
-  status = agent_driver.ImportDMABuf(dmabuf_fd, *agent, shareable_handle, memoryHandleIt->first);
-  if (status != HSA_STATUS_SUCCESS)
-    return status;
-
-  core::Runtime::runtime_singleton_->DmaBufClose(dmabuf_fd);
-
-  // Get address that memory is mapped to
-  ret = GetAmdgpuDeviceArgs(agent, shareable_handle, &drm_fd, &drm_cpu_addr);
-  if (ret) return HSA_STATUS_ERROR;
-
+  // Register the mapping
   mapped_handle_map_.emplace(
       std::piecewise_construct, std::forward_as_tuple(va),
       std::forward_as_tuple(&memoryHandleIt->second, addressHandle, va, offset, size, drm_fd,
-                            reinterpret_cast<void*>(drm_cpu_addr), HSA_ACCESS_PERMISSION_NONE,
+                            reinterpret_cast<void*>(drm_fd_offset), HSA_ACCESS_PERMISSION_NONE,
                             shareable_handle));
 
   addressHandle->use_count++;
@@ -3742,9 +3715,8 @@ hsa_status_t Runtime::VMemoryHandleUnmap(void* va, size_t size) {
     }
 
     if (mappedHandleIt.second->shareable_handle.IsValid()) {
-      hsa_status_t status =
-        mappedHandleIt.second->agentOwner()->driver().ReleaseShareableHandle(
-                                      mappedHandleIt.second->shareable_handle);
+      hsa_status_t status = mappedHandleIt.second->agentOwner()->driver().DestroyShareableHandle(
+          &(mappedHandleIt.second->shareable_handle));
       if (status != HSA_STATUS_SUCCESS) {
         return status;
       }
@@ -3790,7 +3762,6 @@ Runtime::MappedHandleAllowedAgent::MappedHandleAllowedAgent(
   assert(status == HSA_STATUS_SUCCESS);
   if (status != HSA_STATUS_SUCCESS)
     return;
-  assert(offset == 0);
 
   void* reuse_handle = nullptr;
   // If MappedHandle's public handle is same as target agent public handle
@@ -3799,8 +3770,8 @@ Runtime::MappedHandleAllowedAgent::MappedHandleAllowedAgent(
     reuse_handle = memHandle->thunk_handle;
   }
   // Import to target agent.
-  status = targetAgent->driver().ImportDMABuf(dmabuf_fd, *targetAgent,
-                                              shareable_handle, reuse_handle);
+  status =
+      targetAgent->driver().ImportDMABuf(dmabuf_fd, *targetAgent, &shareable_handle, reuse_handle);
   assert(status == HSA_STATUS_SUCCESS);
   core::Runtime::runtime_singleton_->DmaBufClose(dmabuf_fd);
   if (status != HSA_STATUS_SUCCESS)
@@ -3810,8 +3781,7 @@ Runtime::MappedHandleAllowedAgent::MappedHandleAllowedAgent(
 Runtime::MappedHandleAllowedAgent::~MappedHandleAllowedAgent() {
   if (targetAgent->device_type() == core::Agent::DeviceType::kAmdCpuDevice) return;
 
-  hsa_status_t status =
-      targetAgent->driver().ReleaseShareableHandle(shareable_handle);
+  hsa_status_t status = targetAgent->driver().DestroyImportedShareableHandle(&shareable_handle);
   assert(status == HSA_STATUS_SUCCESS);
 }
 


### PR DESCRIPTION
## Motivation

The use of the HSA vmem API with XDNA devices was not possible due to its dependence on the amdgpu driver API use in runtime.cpp. This PR moves the relevant calls in the `KFDDriver` and simplifies the `Driver` API that `Runtime::VMemoryHandleMap` uses.

## Technical Details

1. A new function `Driver::CreateShareableHandle` was added that creates handles for vmem-related allocations.
2. Destruction of handles is split because for amdgpu it appears they are ref-counted wheareas for xdna-driver they are not and that causes the same BO to be destroyed more than once (see `DestroyImportedShareableHandle` vs `DestroyShareableHandle`).
3. Inaccessible pages are created to get a virtual address, since `ThunkHandle` is a only a pointer. This wastes an extra page for each `XDNADriver`-based allocation if not needed to be mapped at allocation, but it guarantees the address uniqueness among drivers.

Follow-ups:

1. It seems that we ended up with two different handle concepts merged in one (`core::ShareableHandle`). They may need to be separated to two, one handle that does not own an allocation (`core::ShareableHandle`) and one that does (`core::MemoryHandle`); the latter is probably similar to `Runtime::MemoryHandle`. Further discussion is welcome.
2. The `ThunkHandle` definition creates the need to waste a page in `XDNADriver` although we already have a BO handle. It's unclear how to address that without an extra mapping, e.g., `ThunkHandle` -> {driver, `handle`}.
3. The `fn_amdgpu_device_get_fd` is still set by `Runtime`. It's unclear if this needs to move in `KFDDriver` or not.

## JIRA ID

NA

## Test Plan

- rocrtst runs
- Local testing via AIE-specific tests.

## Test Result

Successful run.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
