### PR TITLE
rocr/aie: Use util/os to get system memory

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -155,12 +155,6 @@ hsa_status_t XdnaDriver::DiscoverDriver(std::unique_ptr<core::Driver>& driver) {
   return HSA_STATUS_ERROR;
 }
 
-uint64_t XdnaDriver::GetSystemMemoryByteSize() {
-  const long pagesize = sysconf(_SC_PAGESIZE);
-  const long page_count = sysconf(_SC_PHYS_PAGES);
-  return pagesize * page_count;
-}
-
 uint64_t XdnaDriver::GetDevHeapByteSize() {
   return dev_heap_size;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -181,9 +181,6 @@ public:
 
   static hsa_status_t DiscoverDriver(std::unique_ptr<core::Driver>& driver);
 
-  /// @brief Returns the size of the system memory heap in bytes.
-  static uint64_t GetSystemMemoryByteSize();
-
   /// @brief Returns the size of the dev heap in bytes.
   static uint64_t GetDevHeapByteSize();
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_agent.cpp
@@ -53,6 +53,7 @@
 #include "core/inc/amd_xdna_driver.h"
 #include "core/inc/driver.h"
 #include "core/inc/runtime.h"
+#include "core/util/os.h"
 
 namespace rocr {
 namespace AMD {
@@ -293,11 +294,8 @@ hsa_status_t AieAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type, u
 }
 
 void AieAgent::InitRegionList() {
-  /// TODO: Find a way to set the other memory properties in a reasonable way.
-  ///       This should be easier once the ROCt source is incorporated into the
-  ///       ROCr source. Since the AIE itself currently has no memory regions of
-  ///       its own all memory is just the system DRAM.
-  const uint64_t total_system_memory = XdnaDriver::GetSystemMemoryByteSize();
+  /// AIE itself currently has no memory regions of its own, all memory is just the system DRAM.
+  const uint64_t total_system_memory = os::HostTotalPhysicalMemory();
 
   /// For allocating kernel arguments or other objects that only need
   /// system memory.


### PR DESCRIPTION
## Motivation

Remove code duplication.

## Technical Details

`os::HostTotalPhysicalMemory()` can replace the total system memory calculation in `XDNADriver`.

## JIRA ID

NA

## Test Plan

Verify with `rocminfo`.

## Test Result

Memory shown is the same before and after the change.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
