### PR TITLE
Fix CPX mode crash by removing agent encoding from counter IDs

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/output/generateCSV.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateCSV.cpp
@@ -603,8 +603,7 @@ generate_csv(const output_config&                    cfg,
     auto counter_id_to_name = std::unordered_map<rocprofiler_counter_id_t, std::string_view>{};
     for(const auto& itr : tool_metadata.get_counter_info())
     {
-        // Counter records now contain agent-encoded IDs (reconstructed in tool.cpp),
-        // so we use the full agent-encoded ID from metadata as the map key
+        // Use counter ID from metadata as the map key
         counter_id_to_name.emplace(itr.id, itr.name);
     }
 

--- a/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
@@ -312,8 +312,7 @@ write_perfetto(
     auto counter_id_to_name = std::unordered_map<rocprofiler_counter_id_t, std::string_view>{};
     for(const auto& itr : tool_metadata.get_counter_info())
     {
-        // Counter records now contain agent-encoded IDs (reconstructed in tool.cpp),
-        // so we use the full agent-encoded ID from metadata as the map key
+        // Use counter ID from metadata as the map key
         counter_id_to_name.emplace(itr.id, itr.name);
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -1553,7 +1553,7 @@ counter_record_callback(rocprofiler_dispatch_counting_service_data_t dispatch_da
 
     for(size_t count = 0; count < record_count; ++count)
     {
-        // Get agent-encoded counter ID from record
+        // Get counter ID from record
         auto _counter_id = rocprofiler_counter_id_t{};
         ROCPROFILER_CALL(rocprofiler_query_record_counter_id(record_data[count].id, &_counter_id),
                          "query record counter id");

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counter_config.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counter_config.cpp
@@ -62,7 +62,7 @@ rocprofiler_create_counter_config(rocprofiler_agent_id_t           agent_id,
     {
         auto& counter_id = counters_list[i];
 
-        // Extract base metric ID from counter_id (handles agent-encoded counter IDs)
+        // Extract base metric ID from counter_id
         auto base_metric_id    = rocprofiler::counters::get_base_metric_from_counter_id(counter_id);
         const auto* metric_ptr = rocprofiler::common::get_val(id_map, base_metric_id);
         if(!metric_ptr) return ROCPROFILER_STATUS_ERROR_COUNTER_NOT_FOUND;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters.cpp
@@ -237,7 +237,7 @@ rocprofiler_query_counter_info(rocprofiler_counter_id_t              counter_id,
                 {
                     auto& rec = instances.emplace_back();
                     counters::set_dim_in_rec(rec.instance_id, metric_dim.type(), i);
-                    // Store full agent-encoded counter ID in instance record
+                    // Store counter ID in instance record
                     counters::set_counter_in_rec(rec.instance_id, counter_id);
                 }
             }
@@ -251,7 +251,7 @@ rocprofiler_query_counter_info(rocprofiler_counter_id_t              counter_id,
                     {
                         auto& rec = tmp.emplace_back(instance);
                         counters::set_dim_in_rec(rec.instance_id, metric_dim.type(), i);
-                        // Store full agent-encoded counter ID in instance record
+                        // Store counter ID in instance record
                         counters::set_counter_in_rec(rec.instance_id, counter_id);
                     }
                 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters.cpp
@@ -88,24 +88,35 @@ get_static_ptr_array(const std::vector<Tp>& vec)
 
 }  // namespace
 
-// Helper function to extract agent_id from agent-encoded counter_id
-// Returns agent_id with handle=0 if not found
+// Find the first agent that supports the given counter metric ID.
+// Since counter IDs no longer encode agent information, this looks up the
+// metric by ID, finds its architecture, then returns the first matching agent.
 rocprofiler_agent_id_t
-get_agent_id_from_counter_id(rocprofiler_counter_id_t counter_id)
+get_first_agent_for_metric(rocprofiler_counter_id_t counter_id)
 {
-    // Extract logical_node_id from counter ID encoding
-    auto agent_index = get_agent_from_counter_id(counter_id) - AGENT_ENCODING_OFFSET;
+    auto base_metric_id = get_base_metric_from_counter_id(counter_id);
+    auto metrics        = loadMetrics();
 
-    // Find the agent with matching logical_node_id
-    for(const auto* agent : rocprofiler::agent::get_agents())
+    const auto* metric_ptr =
+        common::get_val(metrics->id_to_metric, static_cast<uint64_t>(base_metric_id));
+    if(!metric_ptr) return sdk::null_agent_id;
+
+    // Find which architecture this metric belongs to
+    for(const auto& [arch_name, id_set] : metrics->arch_to_id)
     {
-        if(agent && agent->logical_node_id == agent_index)
+        if(id_set.count(base_metric_id) == 0) continue;
+
+        // Find the first GPU agent with this architecture
+        for(const auto* agent : rocprofiler::agent::get_agents())
         {
-            return agent->id;
+            if(agent && agent->type == ROCPROFILER_AGENT_TYPE_GPU &&
+               std::string(agent->name) == arch_name)
+            {
+                return agent->id;
+            }
         }
     }
 
-    // Return invalid agent_id if not found
     return sdk::null_agent_id;
 }
 
@@ -136,7 +147,7 @@ rocprofiler_query_counter_info(rocprofiler_counter_id_t              counter_id,
     auto        metrics_map = counters::loadMetrics();
     const auto& id_map      = metrics_map->id_to_metric;
 
-    // Extract base metric ID from counter_id (handles agent-encoded counter IDs)
+    // Extract base metric ID from counter_id
     auto base_metric_id = counters::get_base_metric_from_counter_id(counter_id);
 
     auto base_info = [&](auto& out_struct) {
@@ -188,10 +199,9 @@ rocprofiler_query_counter_info(rocprofiler_counter_id_t              counter_id,
 
     // Construct all possible permutations of instance ids. This is every instance
     // that can be returned by the counter across all dimensions.
-    // Note: Dimensions are agent-specific. This function uses the agent from counter ID encoding.
     auto dim_permutations = [&](auto& out_struct) {
-        // Get agent from counter ID encoding
-        auto agent_id = counters::get_agent_id_from_counter_id(counter_id);
+        // Find an agent that supports this metric for dimension lookup
+        auto agent_id = counters::get_first_agent_for_metric(counter_id);
         if(agent_id == rocprofiler::sdk::null_agent_id) return false;
 
         auto dim_ptr = counters::get_dimension_cache(agent_id);
@@ -297,8 +307,8 @@ rocprofiler_query_counter_info(rocprofiler_counter_id_t              counter_id,
 
             if(!base_info(_out_struct)) return ROCPROFILER_STATUS_ERROR_COUNTER_NOT_FOUND;
 
-            // Get agent from counter ID encoding
-            auto agent_id = counters::get_agent_id_from_counter_id(counter_id);
+            // Find an agent that supports this metric for dimension lookup
+            auto agent_id = counters::get_first_agent_for_metric(counter_id);
             if(agent_id.handle == 0) return ROCPROFILER_STATUS_ERROR_AGENT_NOT_FOUND;
 
             if(!dim_info(_out_struct, agent_id)) return ROCPROFILER_STATUS_ERROR_DIM_NOT_FOUND;
@@ -333,7 +343,7 @@ rocprofiler_query_counter_instance_count(rocprofiler_agent_id_t   agent_id,
     auto dim_ptr    = counters::get_dimension_cache(agent_id);
     if(!dim_ptr) return ROCPROFILER_STATUS_ERROR_AGENT_NOT_FOUND;
 
-    // Extract base metric ID from counter_id (handles agent-encoded counter IDs)
+    // Extract base metric ID from counter_id
     auto        base_metric_id = counters::get_base_metric_from_counter_id(counter_id);
     const auto* dims = common::get_val(dim_ptr->id_to_dim, static_cast<uint64_t>(base_metric_id));
     if(!dims) return ROCPROFILER_STATUS_ERROR_COUNTER_NOT_FOUND;
@@ -371,10 +381,8 @@ rocprofiler_iterate_agent_supported_counters(rocprofiler_agent_id_t             
     ids.reserve(metrics.size());
     for(const auto& metric : metrics)
     {
-        // Create agent-encoded counter ID using the agent's logical_node_id
         rocprofiler_counter_id_t counter_id{.handle = 0};
         counters::set_base_metric_in_counter_id(counter_id, metric.id());
-        counters::set_agent_in_counter_id(counter_id, agent->logical_node_id);
         ids.push_back(counter_id);
     }
 
@@ -395,17 +403,8 @@ rocprofiler_query_record_counter_id(rocprofiler_counter_instance_id_t id,
     // Get base metric ID from instance record (bits 63-48)
     uint16_t base_metric = static_cast<uint16_t>(id >> counters::DIM_BIT_LENGTH);
 
-    // Try to get agent encoding from ROCPROFILER_DIMENSION_AGENT dimension field
-    uint8_t agent_encoded =
-        static_cast<uint8_t>(counters::rec_to_dim_pos(id, counters::ROCPROFILER_DIMENSION_AGENT));
-
-    // Reconstruct full agent-encoded counter ID
-    // Note: agent_encoded includes the offset, but set_agent_in_counter_id() adds the offset,
-    // so we need to subtract it first to get the raw logical_node_id
     counter_id->handle = 0;
     counters::set_base_metric_in_counter_id(*counter_id, base_metric);
-    counters::set_agent_in_counter_id(
-        *counter_id, agent_encoded > 0 ? agent_encoded - counters::AGENT_ENCODING_OFFSET : 0);
 
     return ROCPROFILER_STATUS_SUCCESS;
 }
@@ -425,11 +424,11 @@ rocprofiler_iterate_counter_dimensions(rocprofiler_counter_id_t              id,
                                        rocprofiler_available_dimensions_cb_t info_cb,
                                        void*                                 user_data)
 {
-    // Extract base metric ID from counter_id (handles agent-encoded counter IDs)
+    // Extract base metric ID from counter_id
     auto base_metric_id = counters::get_base_metric_from_counter_id(id);
 
-    // Get agent from counter ID encoding
-    auto agent_id = counters::get_agent_id_from_counter_id(id);
+    // Find an agent that supports this metric for dimension lookup
+    auto agent_id = counters::get_first_agent_for_metric(id);
     if(agent_id.handle == 0) return ROCPROFILER_STATUS_ERROR_AGENT_NOT_FOUND;
 
     auto dim_ptr = counters::get_dimension_cache(agent_id);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/evaluate_ast.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/evaluate_ast.cpp
@@ -135,10 +135,7 @@ perform_reduction(
         perform_reduction_to_single_instance(reduce_op, input_array, &result);
         input_array->clear();
         input_array->push_back(result);
-        // Preserve DIMENSION_AGENT when reducing to single instance
-        auto agent_dim = rec_to_dim_pos(result.id, ROCPROFILER_DIMENSION_AGENT);
         set_dim_in_rec(input_array->begin()->id, ROCPROFILER_DIMENSION_NONE, 0);
-        set_dim_in_rec(input_array->begin()->id, ROCPROFILER_DIMENSION_AGENT, agent_dim);
         return input_array;
     }
 
@@ -171,10 +168,7 @@ perform_reduction(
     }
     if(input_array->size() == 1)
     {
-        // Preserve DIMENSION_AGENT when reducing to single instance
-        auto agent_dim = rec_to_dim_pos(input_array->begin()->id, ROCPROFILER_DIMENSION_AGENT);
         set_dim_in_rec(input_array->begin()->id, ROCPROFILER_DIMENSION_NONE, 0);
-        set_dim_in_rec(input_array->begin()->id, ROCPROFILER_DIMENSION_AGENT, agent_dim);
     }
     return input_array;
 }
@@ -735,10 +729,6 @@ EvaluateAST::read_special_counters(
         if(!out_map[metric.id()].empty()) out_map[metric.id()].clear();
         auto& record = out_map[metric.id()].emplace_back();
         set_counter_in_rec(record.id, {.handle = metric.id()});
-        // Don't use DIMENSION_NONE as it overwrites the DIMENSION_AGENT field
-        // Instead, explicitly set DIMENSION_AGENT with the agent's logical_node_id
-        set_dim_in_rec(
-            record.id, ROCPROFILER_DIMENSION_AGENT, agent.logical_node_id + AGENT_ENCODING_OFFSET);
 
         record.counter_value = get_agent_property(metric.name(), agent);
     }
@@ -778,13 +768,6 @@ EvaluateAST::read_pkt(const aql::CounterPacketConstruct* pkt_gen, hsa::AQLPacket
             CHECK_EQ(aql_status, ROCPROFILER_STATUS_SUCCESS)
                 << rocprofiler_get_status_string(aql_status);
 
-            // Set DIMENSION_AGENT with the agent's logical_node_id
-            auto        agent_id = it.pkt_gen->agent();
-            const auto* agent    = CHECK_NOTNULL(rocprofiler::agent::get_agent(agent_id));
-            set_dim_in_rec(next_rec.id,
-                           ROCPROFILER_DIMENSION_AGENT,
-                           agent->logical_node_id + AGENT_ENCODING_OFFSET);
-
             // set_dim_in_rec(next_rec.id, ROCPROFILER_DIMENSION_NONE, vec.size() - 1);
             // Note: in the near future we need to use hw_counter here instead
             next_rec.counter_value = counter_value;
@@ -804,14 +787,7 @@ EvaluateAST::set_out_id(std::vector<rocprofiler_counter_record_t>& results) cons
 {
     for(auto& record : results)
     {
-        // Preserve the agent encoding from the instance record
-        auto agent_encoded = rec_to_dim_pos(record.id, ROCPROFILER_DIMENSION_AGENT);
-
-        // Update the counter ID (this will overwrite DIMENSION_AGENT)
         set_counter_in_rec(record.id, _out_id);
-
-        // Restore the agent encoding that was in the original record
-        set_dim_in_rec(record.id, ROCPROFILER_DIMENSION_AGENT, agent_encoded);
     }
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/id_decode.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/id_decode.cpp
@@ -91,30 +91,6 @@ aqlprofile_id_to_rocprof_instance()
 
 // Counter ID encoding/decoding implementations
 void
-set_agent_in_counter_id(rocprofiler_counter_id_t& id, uint8_t agent_logical_node_id)
-{
-    // Check that logical_node_id + offset fits in 6 bits
-    // With AGENT_ENCODING_OFFSET=1, this allows logical_node_id 0-62 (63 agents)
-    CHECK(agent_logical_node_id < ((1 << AGENT_BIT_LENGTH) - AGENT_ENCODING_OFFSET))
-        << "Agent logical_node_id " << static_cast<int>(agent_logical_node_id)
-        << " exceeds limit (max " << ((1 << AGENT_BIT_LENGTH) - AGENT_ENCODING_OFFSET - 1)
-        << " to allow for encoding offset)";
-
-    // Add encoding offset to ensure agent 0 is detectable (non-zero)
-    uint8_t agent_encoded = agent_logical_node_id + AGENT_ENCODING_OFFSET;
-
-    // Clear agent bits and set new value
-    id.handle = (id.handle & ~(AGENT_MASK << AGENT_BIT_OFFSET)) |
-                (static_cast<uint64_t>(agent_encoded) << AGENT_BIT_OFFSET);
-}
-
-uint8_t
-get_agent_from_counter_id(rocprofiler_counter_id_t id)
-{
-    return static_cast<uint8_t>((id.handle >> AGENT_BIT_OFFSET) & AGENT_MASK);
-}
-
-void
 set_base_metric_in_counter_id(rocprofiler_counter_id_t& id, uint16_t metric_id)
 {
     CHECK(metric_id <= BASE_METRIC_MASK) << "Base metric ID exceeds 16-bit limit";
@@ -126,13 +102,6 @@ uint16_t
 get_base_metric_from_counter_id(rocprofiler_counter_id_t id)
 {
     return static_cast<uint16_t>(id.handle & BASE_METRIC_MASK);
-}
-
-bool
-is_agent_encoded_counter_id(rocprofiler_counter_id_t id)
-{
-    // Check if agent bits are non-zero
-    return ((id.handle >> AGENT_BIT_OFFSET) & AGENT_MASK) != 0;
 }
 
 }  // namespace counters

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/id_decode.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/id_decode.hpp
@@ -70,25 +70,15 @@ inline size_t
 rec_to_dim_pos(rocprofiler_counter_instance_id_t          id,
                rocprofiler_profile_counter_instance_types dim);
 
-// Counter ID encoding/decoding functions for agent-specific counter IDs
-void
-set_agent_in_counter_id(rocprofiler_counter_id_t& id, uint8_t agent_logical_node_id);
-uint8_t
-get_agent_from_counter_id(rocprofiler_counter_id_t id);
+// Counter ID encoding/decoding functions
 void
 set_base_metric_in_counter_id(rocprofiler_counter_id_t& id, uint16_t metric_id);
 uint16_t
 get_base_metric_from_counter_id(rocprofiler_counter_id_t id);
-bool
-is_agent_encoded_counter_id(rocprofiler_counter_id_t id);
 
 // Counter ID encoding constants
-constexpr uint64_t AGENT_BIT_OFFSET       = 32;
-constexpr uint64_t AGENT_BIT_LENGTH       = 6;
 constexpr uint64_t BASE_METRIC_BIT_LENGTH = 16;
-constexpr uint64_t AGENT_MASK             = ((1ULL << AGENT_BIT_LENGTH) - 1);
 constexpr uint64_t BASE_METRIC_MASK       = ((1ULL << BASE_METRIC_BIT_LENGTH) - 1);
-constexpr uint8_t  AGENT_ENCODING_OFFSET  = 1;  // Offset to reserve 0 for detection
 
 const std::unordered_map<int, rocprofiler_profile_counter_instance_types>&
 aqlprofile_id_to_rocprof_instance();
@@ -102,16 +92,8 @@ rocprofiler::counters::rec_to_counter_id(rocprofiler_counter_instance_id_t id)
     // Extract base metric ID from instance record (bits 63-48)
     uint16_t base_metric = static_cast<uint16_t>(id >> DIM_BIT_LENGTH);
 
-    // Extract agent encoding from ROCPROFILER_DIMENSION_AGENT dimension field
-    uint8_t agent_encoded = static_cast<uint8_t>(rec_to_dim_pos(id, ROCPROFILER_DIMENSION_AGENT));
-
-    // Reconstruct full agent-encoded counter ID
-    // Note: agent_encoded includes the offset, but set_agent_in_counter_id() adds the offset,
-    // so we need to subtract it first to get the raw logical_node_id
     rocprofiler_counter_id_t counter_id{.handle = 0};
     set_base_metric_in_counter_id(counter_id, base_metric);
-    set_agent_in_counter_id(counter_id,
-                            agent_encoded > 0 ? agent_encoded - AGENT_ENCODING_OFFSET : 0);
 
     return counter_id;
 }
@@ -148,7 +130,7 @@ void
 rocprofiler::counters::set_counter_in_rec(rocprofiler_counter_instance_id_t& id,
                                           rocprofiler_counter_id_t           value)
 {
-    // Extract base metric from agent-encoded counter ID
+    // Extract base metric from counter ID
     uint16_t base_metric = get_base_metric_from_counter_id(value);
 
     // Maximum counter value given the current setup (16-bit field)
@@ -158,15 +140,6 @@ rocprofiler::counters::set_counter_in_rec(rocprofiler_counter_instance_id_t& id,
     id = id & ~((MAX_64 >> (BITS_IN_UINT64 - DIM_BIT_LENGTH)) << (DIM_BIT_LENGTH));
     // Set the base metric ID in bits 63-48
     id = id | (static_cast<uint64_t>(base_metric) << DIM_BIT_LENGTH);
-
-    // Store agent encoding in ROCPROFILER_DIMENSION_AGENT dimension field
-    // NOTE: ROCPROFILER_DIMENSION_AGENT is a special dimension used to store agent information
-    // This field is for internal use only and should not be set by external code
-    uint8_t agent_encoded = get_agent_from_counter_id(value);
-
-    // Unconditionally set DIMENSION_AGENT, even if agent_encoded is 0
-    // (This preserves the agent encoding for all counter IDs)
-    set_dim_in_rec(id, ROCPROFILER_DIMENSION_AGENT, agent_encoded);
 }
 
 size_t
@@ -186,24 +159,14 @@ rocprofiler::counters::rec_to_dim_pos(rocprofiler_counter_instance_id_t         
 
 // Counter ID encoding/decoding implementations
 //
-// NEW COUNTER ID REPRESENTATION (Agent-Specific Counter IDs):
+// COUNTER ID REPRESENTATION:
 // ============================================================
-// Counter IDs (rocprofiler_counter_id_t::handle, 64-bit) are now agent-specific.
-// The counter ID encodes both the base metric ID and the agent's logical_node_id.
+// Counter IDs (rocprofiler_counter_id_t::handle, 64-bit) contain only the base metric ID.
+// Agent information is NOT encoded in counter IDs.
 //
 // Bit Layout:
-//   Bits 63-38: Reserved/unused (26 bits)
-//   Bits 37-32: Agent logical_node_id (6 bits) - supports up to 64 agents
-//   Bits 31-16: Reserved/unused (16 bits)
+//   Bits 63-16: Reserved/unused (48 bits)
 //   Bits 15-0:  Base metric ID (16 bits) - architecture-based metric identifier
 //
-// Rationale:
-// - Allows unique counter IDs for agents with same architecture but different configurations
-//   (e.g., same gfx90a but different CU counts: 110 vs 104)
-// - Maintains consistency: counter IDs are now agent-specific, matching agent-specific dimensions
-// - Agent encoding is mandatory: All counter IDs must have agent encoding (agent bits != 0)
-//
-// Usage:
-// - use set_agent_in_counter_id() / set_base_metric_in_counter_id() to encode
-// - use get_agent_from_counter_id() / get_base_metric_from_counter_id() to decode
-// - use is_agent_encoded_counter_id() to check if counter ID has agent encoding
+// Note: Dimensions are agent-specific and looked up via the agent_id provided
+// to rocprofiler_iterate_agent_supported_counters().

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -365,28 +365,7 @@ getMetricsForAgent(const rocprofiler_agent_t* agent)
     if(const auto* metric_ptr =
            rocprofiler::common::get_val(mets->arch_to_metric, std::string(agent->name)))
     {
-        // Clone metrics and encode agent-specific counter IDs
-        std::vector<Metric> agent_specific_metrics;
-        agent_specific_metrics.reserve(metric_ptr->size());
-
-        for(const auto& base_metric : *metric_ptr)
-        {
-            Metric agent_metric = base_metric;
-
-            // Encode agent into counter ID using agent's logical_node_id + AGENT_ENCODING_OFFSET.
-            // We add offset so that agent 0 has non-zero encoding and is detectable as
-            // agent-encoded. Only logical_node_id values 0-62 (i.e., 63 agents) are supported,
-            // since adding AGENT_ENCODING_OFFSET (1) results in encoded values 1-63, which fit in a
-            // 6-bit field.
-            rocprofiler_counter_id_t new_id{.handle = 0};
-            set_base_metric_in_counter_id(new_id, base_metric.id());
-            set_agent_in_counter_id(new_id, static_cast<uint8_t>(agent->logical_node_id));
-
-            agent_metric.set_id(new_id.handle);
-            agent_specific_metrics.push_back(agent_metric);
-        }
-
-        return agent_specific_metrics;
+        return *metric_ptr;
     }
 
     return std::vector<Metric>{};
@@ -398,13 +377,7 @@ checkValidMetric(const std::string& agent, const Metric& metric)
     auto        metrics   = loadMetrics();
     const auto* agent_map = common::get_val(metrics->arch_to_id, agent);
 
-    // Extract base metric ID if counter ID is agent-encoded
-    rocprofiler_counter_id_t counter_id{.handle = metric.id()};
-    uint64_t                 base_metric_id = is_agent_encoded_counter_id(counter_id)
-                                                  ? get_base_metric_from_counter_id(counter_id)
-                                                  : metric.id();
-
-    return agent_map != nullptr && agent_map->count(base_metric_id) > 0;
+    return agent_map != nullptr && agent_map->count(metric.id()) > 0;
 }
 
 bool

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.hpp
@@ -107,8 +107,6 @@ loadMetrics(bool reload = false, std::optional<ArchMetric> add_metric = std::nul
 
 /**
  * Get the metrics that apply to a specific agent.
- * The returned metrics will have counter IDs that are unique per agent
- * (encoding both base metric ID and agent's logical_node_id).
  */
 std::vector<Metric>
 getMetricsForAgent(const rocprofiler_agent_t* agent);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/sample_processing.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/sample_processing.cpp
@@ -96,15 +96,6 @@ proccess_completed_cb(completed_cb_params_t&& params)
         CHECK(ret);
         ast.set_out_id(*ret);
 
-        // Ensure all output records have proper agent encoding in DIMENSION_AGENT
-        for(auto& val : *ret)
-        {
-            counters::set_dim_in_rec(
-                val.id,
-                counters::ROCPROFILER_DIMENSION_AGENT,
-                prof_config->agent->logical_node_id + counters::AGENT_ENCODING_OFFSET);
-        }
-
         out.reserve(out.size() + ret->size());
         for(auto& val : *ret)
         {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/core.cpp
@@ -746,8 +746,7 @@ TEST(core, public_api_iterate_agents)
         auto expected = findDeviceMetrics(agent, {});
         for(const auto& x : expected)
         {
-            // Counter IDs from API now include agent encoding. Extract base metric ID for
-            // comparison.
+            // Extract base metric ID for comparison.
             bool found = false;
             for(auto it = from_api.begin(); it != from_api.end(); ++it)
             {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/dimension.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/dimension.cpp
@@ -71,15 +71,10 @@ check_counter_id(rocprofiler_counter_instance_id_t id, uint64_t expected_base_me
 
     auto reconstructed_id = rec_to_counter_id(id);
 
-    // After our agent encoding changes, rec_to_counter_id() returns a full agent-encoded
-    // counter ID. We need to extract the base metric ID to compare with the expected value.
-    auto reconstructed_base = get_base_metric_from_counter_id(reconstructed_id);
-    auto api_base           = get_base_metric_from_counter_id(api_id);
+    EXPECT_EQ(reconstructed_id.handle, expected_base_metric);
+    EXPECT_EQ(api_id.handle, expected_base_metric);
 
-    EXPECT_EQ(reconstructed_base, expected_base_metric);
-    EXPECT_EQ(api_base, expected_base_metric);
-
-    // Both methods should return the same counter ID (including agent encoding)
+    // Both methods should return the same counter ID
     EXPECT_EQ(reconstructed_id.handle, api_id.handle);
 }
 }  // namespace
@@ -304,9 +299,6 @@ TEST(dimension, block_dim_test)
 
             /**
              * Check the public API returns this value.
-             * Counter IDs now have agent encoding, so rocprofiler_iterate_counter_dimensions()
-             * can extract the agent from the counter ID itself and return agent-specific
-             * dimensions.
              */
             rocprofiler_iterate_counter_dimensions(
                 {.handle = metric.id()},

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/evaluate_ast_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/evaluate_ast_test.cpp
@@ -327,15 +327,11 @@ TEST(evaluate_ast, counter_constants)
             ASSERT_EQ(ptr->size(), 1);
             EXPECT_EQ(ptr->at(0).counter_value, raw_agent_values[c.name()]);
 
-            // After agent encoding changes, rec_to_counter_id() returns a full agent-encoded ID
-            // Extract and compare just the base metric ID
+            // Extract and compare the base metric ID
             auto reconstructed_id = rocprofiler::counters::rec_to_counter_id(ptr->at(0).id);
             auto base_metric =
                 rocprofiler::counters::get_base_metric_from_counter_id(reconstructed_id);
             EXPECT_EQ(base_metric, c.id());
-
-            // Note: With agent encoding, ROCPROFILER_DIMENSION_AGENT is always set,
-            // so we cannot check that ROCPROFILER_DIMENSION_NONE == 0
         }
         asts.at("gfx9").at(name).expand_derived(asts.at("gfx9"));
         std::vector<std::unique_ptr<std::vector<rocprofiler_record_counter_t>>> cache;
@@ -344,13 +340,10 @@ TEST(evaluate_ast, counter_constants)
         EXPECT_FLOAT_EQ(ret->at(0).counter_value, final_computed_values[name]);
 
         asts.at("gfx9").at(name).set_out_id(*ret);
-        // After agent encoding changes, rec_to_counter_id() returns agent-encoded ID
-        // Extract and compare just the base metric ID
+        // Extract and compare the base metric ID
         auto reconstructed_id = rocprofiler::counters::rec_to_counter_id(ret->at(0).id);
         auto base_metric = rocprofiler::counters::get_base_metric_from_counter_id(reconstructed_id);
         EXPECT_EQ(base_metric, metrics[name].id());
-        // Note: With agent encoding, ROCPROFILER_DIMENSION_AGENT is always set,
-        // so we cannot check that ROCPROFILER_DIMENSION_NONE == 0
     }
 }
 
@@ -532,7 +525,7 @@ TEST(evaluate_ast, evaluate_simple_counters)
         for(const auto& v : *ret)
         {
             set_counter_in_rec(expected[pos].id, {.handle = metrics[name].id()});
-            // After agent encoding changes, compare base metrics extracted from counter IDs
+            // Compare base metrics extracted from counter IDs
             auto v_counter_id        = rocprofiler::counters::rec_to_counter_id(v.id);
             auto expected_counter_id = rocprofiler::counters::rec_to_counter_id(expected[pos].id);
             auto v_base = rocprofiler::counters::get_base_metric_from_counter_id(v_counter_id);
@@ -660,7 +653,7 @@ run_reduce_test(
         for(const auto& v : *ret)
         {
             set_counter_in_rec(expected[pos].id, {.handle = metrics[name].id()});
-            // After agent encoding changes, compare base metrics extracted from counter IDs
+            // Compare base metrics extracted from counter IDs
             auto v_counter_id        = rocprofiler::counters::rec_to_counter_id(v.id);
             auto expected_counter_id = rocprofiler::counters::rec_to_counter_id(expected[pos].id);
             auto v_base = rocprofiler::counters::get_base_metric_from_counter_id(v_counter_id);
@@ -1171,7 +1164,7 @@ TEST(evaluate_ast, evaluate_mixed_counters)
         for(const auto& v : *ret)
         {
             set_counter_in_rec(expected.at(pos).id, {.handle = metrics[name].id()});
-            // After agent encoding changes, compare base metrics extracted from counter IDs
+            // Compare base metrics extracted from counter IDs
             auto v_counter_id = rocprofiler::counters::rec_to_counter_id(v.id);
             auto expected_counter_id =
                 rocprofiler::counters::rec_to_counter_id(expected.at(pos).id);
@@ -1276,7 +1269,7 @@ TEST(evaluate_ast, derived_counter_reduction)
         for(const auto& v : *ret)
         {
             set_counter_in_rec(expected[pos].id, {.handle = metrics[name].id()});
-            // After agent encoding changes, compare base metrics extracted from counter IDs
+            // Compare base metrics extracted from counter IDs
             auto v_counter_id        = rocprofiler::counters::rec_to_counter_id(v.id);
             auto expected_counter_id = rocprofiler::counters::rec_to_counter_id(expected[pos].id);
             auto v_base = rocprofiler::counters::get_base_metric_from_counter_id(v_counter_id);
@@ -1411,7 +1404,7 @@ TEST(evatuate_ast, evaluate_select)
         for(const auto& v : *ret)
         {
             set_counter_in_rec(expected[pos].id, {.handle = metrics[name].id()});
-            // After agent encoding changes, compare base metrics extracted from counter IDs
+            // Compare base metrics extracted from counter IDs
             auto v_counter_id        = rocprofiler::counters::rec_to_counter_id(v.id);
             auto expected_counter_id = rocprofiler::counters::rec_to_counter_id(expected[pos].id);
             auto v_base = rocprofiler::counters::get_base_metric_from_counter_id(v_counter_id);
@@ -1555,7 +1548,7 @@ TEST(evaluate_ast, counter_reduction_dimension)
         for(const auto& v : *ret)
         {
             set_counter_in_rec(expected[pos].id, {.handle = metrics[name].id()});
-            // After agent encoding changes, compare base metrics extracted from counter IDs
+            // Compare base metrics extracted from counter IDs
             auto v_counter_id        = rocprofiler::counters::rec_to_counter_id(v.id);
             auto expected_counter_id = rocprofiler::counters::rec_to_counter_id(expected[pos].id);
             auto v_base = rocprofiler::counters::get_base_metric_from_counter_id(v_counter_id);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/metrics_test_helpers.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/metrics_test_helpers.hpp
@@ -33,9 +33,7 @@ namespace rocprofiler
 namespace counters
 {
 /**
- * Test helper: Get metrics by architecture name without agent encoding.
- * This function is for internal testing purposes only and should not be used in production code.
- * Returns metrics with base IDs only (no agent-specific encoding).
+ * Test helper: Get metrics by architecture name.
  */
 inline std::vector<Metric>
 getMetricsForAgent(const std::string& agent_arch)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

This commit removes the 6-bit agent encoding from counter IDs that caused fatal failures in CPX mode when agent logical_node_id exceeded 62. CPX mode (Compute Partitioning) can create 8+ partitions per GPU, easily exceeding 
the 63-agent limit in multi-GPU systems.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
