### PR TITLE
[rdc][rocprofiler-sdk][7.2 backport] Add PTL unified control and fix counter ID lookup

### DIFF
--- a/projects/rdc/include/rdc_modules/rdc_rocp/RdcRocpCounterSampler.h
+++ b/projects/rdc/include/rdc_modules/rdc_rocp/RdcRocpCounterSampler.h
@@ -94,6 +94,7 @@ class CounterSampler {
   std::map<uint64_t, uint64_t> counter_sizes_;
   std::map<std::vector<std::string>, ProfileSet> cached_profile_sets_;
   mutable std::map<uint64_t, std::string> id_to_name_;  // Per-instance counter ID to name map
+  mutable std::mutex id_to_name_mutex_;  // Protects id_to_name_
 
   mutable std::once_flag roc_counters_init_flag {};
   mutable std::map<uint64_t, std::string> roc_counters {};

--- a/projects/rdc/include/rdc_modules/rdc_rocp/RdcRocpCounterSampler.h
+++ b/projects/rdc/include/rdc_modules/rdc_rocp/RdcRocpCounterSampler.h
@@ -93,6 +93,7 @@ class CounterSampler {
   std::map<std::vector<std::string>, rocprofiler_counter_config_id_t> cached_counter_;
   std::map<uint64_t, uint64_t> counter_sizes_;
   std::map<std::vector<std::string>, ProfileSet> cached_profile_sets_;
+  mutable std::map<uint64_t, std::string> id_to_name_;  // Per-instance counter ID to name map
 
   mutable std::once_flag roc_counters_init_flag {};
   mutable std::map<uint64_t, std::string> roc_counters {};

--- a/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcRocpCounterSampler.cc
+++ b/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcRocpCounterSampler.cc
@@ -55,11 +55,7 @@ void RocprofilerCall(Callable&& callable, const std::string& msg, const char* fi
   }
 }
 
-// File-level static map for counter ID to name lookup (shared between functions)
-namespace {
-  std::map<uint64_t, std::string> g_counter_names;
-  std::mutex g_counter_names_mutex;
-}
+// Per-instance counter maps are now used instead of global maps (see id_to_name_ member)
 
 namespace amd {
 namespace rdc {
@@ -93,21 +89,33 @@ CounterSampler::~CounterSampler() { ctx_ = {}; }
 
 const std::string& CounterSampler::decode_record_name(
     const rocprofiler_record_counter_t& rec) const {
+  // Extract counter ID from record using SDK API
   rocprofiler_counter_id_t counter_id = {.handle = 0};
   rocprofiler_query_record_counter_id(rec.id, &counter_id);
 
-  // Extract base metric ID (lower 16 bits)
-  uint64_t base_id = counter_id.handle & 0xFFFF;
-
-  std::lock_guard<std::mutex> lock(g_counter_names_mutex);
-  auto it = g_counter_names.find(base_id);
-  if (it == g_counter_names.end()) {
-    RDC_LOG(RDC_ERROR, "Error: Counter base_id " << base_id
-                                                << " not found in global counter map." << std::endl);
-    throw std::runtime_error("Counter base_id not found in global counter map");
+  // Check cache first
+  auto it = id_to_name_.find(counter_id.handle);
+  if (it != id_to_name_.end()) {
+    return it->second;
   }
 
-  return it->second;
+  // Query SDK directly for the counter name (more robust than pre-enumeration)
+  rocprofiler_counter_info_v0_t info;
+  auto status = rocprofiler_query_counter_info(counter_id, ROCPROFILER_COUNTER_INFO_VERSION_0,
+                                                static_cast<void*>(&info));
+  if (status == ROCPROFILER_STATUS_SUCCESS) {
+    // Cache the result for future lookups
+    id_to_name_[counter_id.handle] = info.name;
+    return id_to_name_[counter_id.handle];
+  }
+
+  // Counter not found - log error
+  RDC_LOG(RDC_ERROR, "Error: Failed to query counter info for handle=0x" << std::hex
+          << counter_id.handle << std::dec << " (status=" << status << ")" << std::endl);
+
+  // Return a static error string rather than throwing
+  static const std::string unknown_counter = "UNKNOWN_COUNTER";
+  return unknown_counter;
 }
 
 std::unordered_map<std::string, size_t> CounterSampler::get_record_dimensions(
@@ -232,21 +240,17 @@ std::unordered_map<std::string, rocprofiler_counter_id_t> CounterSampler::get_su
       },
       "Could not fetch supported counters", __FILE__, __LINE__);
 
-  std::lock_guard<std::mutex> lock(g_counter_names_mutex);
   for (auto& counter : gpu_counters) {
-    rocprofiler_counter_info_v0_t version;
+    rocprofiler_counter_info_v0_t info;
     RocprofilerCall(
         [&]() {
           return rocprofiler_query_counter_info(counter, ROCPROFILER_COUNTER_INFO_VERSION_0,
-                                                static_cast<void*>(&version));
+                                                static_cast<void*>(&info));
         },
         "Could not query info for counter", __FILE__, __LINE__);
 
-    // Extract base metric ID (lower 16 bits) and populate global map
-    uint64_t base_id = counter.handle & 0xFFFF;
-    g_counter_names[base_id] = version.name;
-
-    out.emplace(version.name, counter);
+    // Store the full counter ID for creating profiles
+    out.emplace(info.name, counter);
   }
   return out;
 }
@@ -446,6 +450,7 @@ void CounterSampler::sample_counters_with_packing(const std::vector<std::string>
     records.resize(profile.expected_size);
 
     counter_ = profile.config;
+
     rocprofiler_start_context(ctx_);
     size_t out_size = records.size();
 

--- a/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcRocpCounterSampler.cc
+++ b/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcRocpCounterSampler.cc
@@ -93,6 +93,7 @@ const std::string& CounterSampler::decode_record_name(
   rocprofiler_counter_id_t counter_id = {.handle = 0};
   rocprofiler_query_record_counter_id(rec.id, &counter_id);
 
+  std::lock_guard<std::mutex> lock(id_to_name_mutex_);
   // Check cache first
   auto it = id_to_name_.find(counter_id.handle);
   if (it != id_to_name_.end()) {

--- a/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcRocpCounterSampler.cc
+++ b/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcRocpCounterSampler.cc
@@ -55,6 +55,12 @@ void RocprofilerCall(Callable&& callable, const std::string& msg, const char* fi
   }
 }
 
+// File-level static map for counter ID to name lookup (shared between functions)
+namespace {
+  std::map<uint64_t, std::string> g_counter_names;
+  std::mutex g_counter_names_mutex;
+}
+
 namespace amd {
 namespace rdc {
 
@@ -87,22 +93,18 @@ CounterSampler::~CounterSampler() { ctx_ = {}; }
 
 const std::string& CounterSampler::decode_record_name(
     const rocprofiler_record_counter_t& rec) const {
-
-  std::call_once(roc_counters_init_flag, [this](){
-    auto name_to_id = CounterSampler::get_supported_counters(agent_);
-    for (const auto& [name, id] : name_to_id) {
-      roc_counters.emplace(id.handle, name);
-    }
-  });
-
   rocprofiler_counter_id_t counter_id = {.handle = 0};
   rocprofiler_query_record_counter_id(rec.id, &counter_id);
 
-  auto it = roc_counters.find(counter_id.handle);
-  if (it == roc_counters.end()) {
-    RDC_LOG(RDC_ERROR, "Error: Counter handle " << counter_id.handle
-                                                << " not found in roc_counters." << std::endl);
-    throw std::runtime_error("Counter handle not found in roc_counters");
+  // Extract base metric ID (lower 16 bits)
+  uint64_t base_id = counter_id.handle & 0xFFFF;
+
+  std::lock_guard<std::mutex> lock(g_counter_names_mutex);
+  auto it = g_counter_names.find(base_id);
+  if (it == g_counter_names.end()) {
+    RDC_LOG(RDC_ERROR, "Error: Counter base_id " << base_id
+                                                << " not found in global counter map." << std::endl);
+    throw std::runtime_error("Counter base_id not found in global counter map");
   }
 
   return it->second;
@@ -229,6 +231,8 @@ std::unordered_map<std::string, rocprofiler_counter_id_t> CounterSampler::get_su
             static_cast<void*>(&gpu_counters));
       },
       "Could not fetch supported counters", __FILE__, __LINE__);
+
+  std::lock_guard<std::mutex> lock(g_counter_names_mutex);
   for (auto& counter : gpu_counters) {
     rocprofiler_counter_info_v0_t version;
     RocprofilerCall(
@@ -237,6 +241,11 @@ std::unordered_map<std::string, rocprofiler_counter_id_t> CounterSampler::get_su
                                                 static_cast<void*>(&version));
         },
         "Could not query info for counter", __FILE__, __LINE__);
+
+    // Extract base metric ID (lower 16 bits) and populate global map
+    uint64_t base_id = counter.handle & 0xFFFF;
+    g_counter_names[base_id] = version.name;
+
     out.emplace(version.name, counter);
   }
   return out;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
@@ -101,18 +101,6 @@ CounterController::configure_agent_collection(rocprofiler_context_id_t          
         return ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT;
     }
 
-    if(counters::counter_collection_has_device_lock())
-    {
-        /**
-         * Note: This should retrun if the lock fails to aquire in the future. However, this
-         * is a change in the required permissions for rocprofiler and needs to be communicated
-         * with partners before strict enforcement. If the required permissions are not obtained,
-         * those profilers will function as they currently do (without any of the benefits of the
-         * IOCTL).
-         */
-        counters::counter_collection_device_lock(rocprofiler::agent::get_agent(agent_id), true);
-    }
-
     ctx.device_counter_collection->agent_data.emplace_back();
     ctx.device_counter_collection->agent_data.back().callback_data =
         rocprofiler_user_data_t{.ptr = user_data};
@@ -151,26 +139,18 @@ CounterController::configure_dispatch(rocprofiler_context_id_t                  
 
     if(!ctx.counter_collection)
     {
-        std::call_once(flag, []() {
-            if(counters::counter_collection_has_device_lock())
+        // Disable PTL for all GPUs for dispatch counter collection
+        for(const auto& agent : agent::get_agents())
+        {
+            if(agent->type == ROCPROFILER_AGENT_TYPE_GPU)
             {
-                /**
-                 * Note: This should retrun if the lock fails to aquire in the future. However, this
-                 * is a change in the required permissions for rocprofiler and needs to be
-                 * communicated with partners before strict enforcement. If the required permissions
-                 * are not obtained, those profilers will function as they currently do (without any
-                 * of the benefits of the IOCTL).
-                 */
-                for(const auto& agent : agent::get_agents())
+                if(counters::ptl_control_supported())
                 {
-                    if(agent->type == ROCPROFILER_AGENT_TYPE_GPU)
-                    {
-                        counters::counter_collection_device_lock(
-                            rocprofiler::agent::get_agent(agent->id), false);
-                    }
+                    counters::counter_collection_ptl_disable(
+                        rocprofiler::agent::get_agent(agent->id));
                 }
             }
-        });
+        }
 
         ctx.counter_collection =
             std::make_unique<rocprofiler::context::dispatch_counter_collection_service>();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
@@ -28,6 +28,7 @@
 #include "lib/rocprofiler-sdk/counters/controller.hpp"
 #include "lib/rocprofiler-sdk/counters/core.hpp"
 #include "lib/rocprofiler-sdk/counters/id_decode.hpp"
+#include "lib/rocprofiler-sdk/counters/ioctl.hpp"
 #include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
 #include "lib/rocprofiler-sdk/hsa/details/fmt.hpp"
 #include "lib/rocprofiler-sdk/hsa/hsa.hpp"
@@ -438,6 +439,15 @@ start_agent_ctx(const context::context* ctx)
             break;
         }
 
+        // Lock the device for profiling (non-fatal if it fails)
+        if(counters::counter_collection_has_device_lock())
+        {
+            counters::counter_collection_device_lock(agent->get_rocp_agent(), true);
+        }
+
+        // Disable PTL (non-fatal if it fails)
+        counters::counter_collection_ptl_disable(agent->get_rocp_agent());
+
         callback_data.set_profile = false;
 
         // Ask the tool what profile we should use for this agent
@@ -571,6 +581,15 @@ stop_agent_ctx(const context::context* ctx)
                                                           1,
                                                           UINT64_MAX,
                                                           HSA_WAIT_STATE_ACTIVE);
+
+        // Re-enable PTL (non-fatal if it fails)
+        counters::counter_collection_ptl_enable(agent->get_rocp_agent());
+
+        // Unlock the device (non-fatal if it fails)
+        if(counters::counter_collection_has_device_lock())
+        {
+            counters::counter_collection_device_unlock(agent->get_rocp_agent());
+        }
     }
 
     agent_ctx.status.exchange(rocprofiler::context::device_counting_service::state::DISABLED);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp
@@ -102,8 +102,11 @@ counter_collection_device_unlock(const rocprofiler_agent_t* agent)
     int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PROFILER, &args);
     if(ret != 0)
     {
+        auto err = errno;
         ROCP_WARNING << fmt::format(
-            "Failed to unlock device {} (error: {}). Continuing anyway.", agent->id.handle, ret);
+            "Failed to unlock device {} (error: {}). Continuing anyway.",
+            agent->id.handle,
+            strerror(err));
         return ROCPROFILER_STATUS_ERROR;
     }
 
@@ -131,10 +134,11 @@ counter_collection_ptl_disable(const rocprofiler_agent_t* agent)
     int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PROFILER, &args);
     if(ret != 0)
     {
+        auto err = errno;
         ROCP_WARNING << fmt::format(
             "Failed to disable PTL on device {} (error: {}). Continuing anyway.",
             agent->id.handle,
-            ret);
+            strerror(err));
         return ROCPROFILER_STATUS_ERROR;
     }
 
@@ -153,10 +157,11 @@ counter_collection_ptl_enable(const rocprofiler_agent_t* agent)
     int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PROFILER, &args);
     if(ret != 0)
     {
+        auto err = errno;
         ROCP_WARNING << fmt::format(
             "Failed to enable PTL on device {} (error: {}). Continuing anyway.",
             agent->id.handle,
-            ret);
+            strerror(err));
         return ROCPROFILER_STATUS_ERROR;
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp
@@ -89,32 +89,78 @@ counter_collection_device_lock(const rocprofiler_agent_t* agent, bool all_queues
     return ROCPROFILER_STATUS_SUCCESS;
 }
 
-// Not required now but may be useful in the future.
-// rocprofiler_status_t
-// counter_collection_device_unlock(const rocprofiler_agent_t* agent) {
-//     CHECK(agent);
-//     kfd_ioctl_profiler_args args = {};
-//     args.op = KFD_IOC_PROFILER_PMC;
-//     args.pmc.gpu_id = agent->gpu_id;
-//     args.pmc.lock = 0;
-//     args.pmc.perfcount_enable = 0;
+rocprofiler_status_t
+counter_collection_device_unlock(const rocprofiler_agent_t* agent)
+{
+    CHECK(agent);
+    kfd_ioctl_profiler_args args = {};
+    args.op                      = KFD_IOC_PROFILER_PMC;
+    args.pmc.gpu_id              = agent->gpu_id;
+    args.pmc.lock                = 0;
+    args.pmc.perfcount_enable    = 0;
 
-//     int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PROFILER, &args);
-//     if (ret != 0) {
-//         switch (ret) {
-//             case -EBUSY:
-//             case -EPERM:
-//                 ROCP_WARNING << fmt::format("Could not unlock the device {}", agent->id.handle);
-//                 return ROCPROFILER_STATUS_ERROR;
-//             case -EINVAL:
-//                 return ROCPROFILER_STATUS_ERROR_INCOMPATIBLE_ABI;
-//             default:
-//                 ROCP_WARNING << fmt::format("Could not unlock the device {}", agent->id.handle);
-//                 return ROCPROFILER_STATUS_ERROR;
-//         }
-//     }
+    int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PROFILER, &args);
+    if(ret != 0)
+    {
+        ROCP_WARNING << fmt::format(
+            "Failed to unlock device {} (error: {}). Continuing anyway.", agent->id.handle, ret);
+        return ROCPROFILER_STATUS_ERROR;
+    }
 
-//     return ROCPROFILER_STATUS_SUCCESS;
-// }
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+
+bool
+ptl_control_supported()
+{
+    kfd_ioctl_profiler_args args = {};
+    args.op                      = KFD_IOC_PROFILER_VERSION;
+    int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PROFILER, &args);
+    return (ret == 0);
+}
+
+rocprofiler_status_t
+counter_collection_ptl_disable(const rocprofiler_agent_t* agent)
+{
+    CHECK(agent);
+    kfd_ioctl_profiler_args args = {};
+    args.op                      = KFD_IOC_PROFILER_PTL_CONTROL;
+    args.ptl.gpu_id              = agent->gpu_id;
+    args.ptl.enable              = 0;
+
+    int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PROFILER, &args);
+    if(ret != 0)
+    {
+        ROCP_WARNING << fmt::format(
+            "Failed to disable PTL on device {} (error: {}). Continuing anyway.",
+            agent->id.handle,
+            ret);
+        return ROCPROFILER_STATUS_ERROR;
+    }
+
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+
+rocprofiler_status_t
+counter_collection_ptl_enable(const rocprofiler_agent_t* agent)
+{
+    CHECK(agent);
+    kfd_ioctl_profiler_args args = {};
+    args.op                      = KFD_IOC_PROFILER_PTL_CONTROL;
+    args.ptl.gpu_id              = agent->gpu_id;
+    args.ptl.enable              = 1;
+
+    int ret = ioctl(pc_sampling::ioctl::get_kfd_fd(), AMDKFD_IOC_PROFILER, &args);
+    if(ret != 0)
+    {
+        ROCP_WARNING << fmt::format(
+            "Failed to enable PTL on device {} (error: {}). Continuing anyway.",
+            agent->id.handle,
+            ret);
+        return ROCPROFILER_STATUS_ERROR;
+    }
+
+    return ROCPROFILER_STATUS_SUCCESS;
+}
 }  // namespace counters
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp
@@ -103,10 +103,9 @@ counter_collection_device_unlock(const rocprofiler_agent_t* agent)
     if(ret != 0)
     {
         auto err = errno;
-        ROCP_WARNING << fmt::format(
-            "Failed to unlock device {} (error: {}). Continuing anyway.",
-            agent->id.handle,
-            strerror(err));
+        ROCP_WARNING << fmt::format("Failed to unlock device {} (error: {}). Continuing anyway.",
+                                    agent->id.handle,
+                                    strerror(err));
         return ROCPROFILER_STATUS_ERROR;
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.cpp
@@ -135,7 +135,7 @@ counter_collection_ptl_disable(const rocprofiler_agent_t* agent)
     if(ret != 0)
     {
         auto err = errno;
-        ROCP_WARNING << fmt::format(
+        ROCP_INFO << fmt::format(
             "Failed to disable PTL on device {} (error: {}). Continuing anyway.",
             agent->id.handle,
             strerror(err));
@@ -158,7 +158,7 @@ counter_collection_ptl_enable(const rocprofiler_agent_t* agent)
     if(ret != 0)
     {
         auto err = errno;
-        ROCP_WARNING << fmt::format(
+        ROCP_INFO << fmt::format(
             "Failed to enable PTL on device {} (error: {}). Continuing anyway.",
             agent->id.handle,
             strerror(err));

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/ioctl.hpp
@@ -34,5 +34,17 @@ counter_collection_has_device_lock();
 rocprofiler_status_t
 counter_collection_device_lock(const rocprofiler_agent_t* agent, bool all_queues);
 
+rocprofiler_status_t
+counter_collection_device_unlock(const rocprofiler_agent_t* agent);
+
+bool
+ptl_control_supported();
+
+rocprofiler_status_t
+counter_collection_ptl_disable(const rocprofiler_agent_t* agent);
+
+rocprofiler_status_t
+counter_collection_ptl_enable(const rocprofiler_agent_t* agent);
+
 }  // namespace counters
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/details/kfd_ioctl.h
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/details/kfd_ioctl.h
@@ -1823,9 +1823,10 @@ struct kfd_ioctl_pc_sample_args
 #define KFD_IOC_PROFILER_VERSION_NUM 1
 enum kfd_profiler_ops
 {
-    KFD_IOC_PROFILER_PMC       = 0,
-    KFD_IOC_PROFILER_PC_SAMPLE = 1,
-    KFD_IOC_PROFILER_VERSION   = 2,
+    KFD_IOC_PROFILER_PMC         = 0,
+    KFD_IOC_PROFILER_PC_SAMPLE   = 1,
+    KFD_IOC_PROFILER_VERSION     = 2,
+    KFD_IOC_PROFILER_PTL_CONTROL = 3,
 };
 
 /**
@@ -1838,6 +1839,12 @@ struct kfd_ioctl_pmc_settings
     __u32 perfcount_enable; /* Force Perfcount Enable for queues on GPU */
 };
 
+struct kfd_ioctl_ptl_control
+{
+    __u32 gpu_id; /* This is the user_gpu_id */
+    __u32 enable; /* 1 to enable PTL, 0 to disable PTL */
+};
+
 struct kfd_ioctl_profiler_args
 {
     __u32 op; /* kfd_profiler_op */
@@ -1846,6 +1853,7 @@ struct kfd_ioctl_profiler_args
         struct kfd_ioctl_pc_sample_args pc_sample;
         struct kfd_ioctl_pmc_settings   pmc;
         __u32                           version; /* KFD_IOC_PROFILER_VERSION_NUM */
+        struct kfd_ioctl_ptl_control    ptl;
     };
 };
 


### PR DESCRIPTION
## Summary
Backport of #2469 to release/rocm-rel-7.2

This change adds PTL (Peak Tops Limiter) control support for MI300 GPUs and fixes a counter ID lookup issue in RDC.

### rocprofiler-sdk changes:
- Add KFD_IOC_PROFILER_PTL_CONTROL ioctl operation and kfd_ioctl_ptl_control struct to kfd_ioctl.h for PTL enable/disable control
- Add ptl_control_supported(), counter_collection_ptl_disable(), and counter_collection_ptl_enable() functions to ioctl.cpp/hpp
- Integrate PTL disable in configure_dispatch() for dispatch counter collection
- Add PTL disable on start and PTL enable on stop for device counting service in device_counting.cpp
- Print strerror(errno) instead of -1 for better error messages

### RDC changes:
- Fix counter ID lookup by using per-instance cache with direct SDK query instead of global map
- Add mutex for thread-safe id_to_name cache access

## Test plan
- [ ] Verify PTL control works on MI300 GPUs
- [ ] Verify counter collection continues to work on older GPUs without PTL support
- [ ] Verify RDC counter ID lookup works correctly

Cherry-picked from: #2469

🤖 Generated with [Claude Code](https://claude.com/claude-code)