### PR TITLE
rocr/aie: Throw exception for malformed packets and packet submission errors

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -54,6 +54,7 @@
 #endif
 
 #include <atomic>
+#include <cassert>
 #include <cstring>
 
 #include "core/inc/amd_xdna_driver.h"
@@ -73,18 +74,16 @@ AieAqlQueue::AieAqlQueue(core::SharedQueue* shared_queue, AieAgent* agent, size_
       agent_(*agent),
       active_(false) {
   if (agent_.device_type() != core::Agent::DeviceType::kAmdAieDevice) {
-    throw AMD::hsa_exception(
-        HSA_STATUS_ERROR_INVALID_AGENT,
-        "Attempting to create an AIE queue on a non-AIE agent.");
+    throw hsa_exception(HSA_STATUS_ERROR_INVALID_AGENT,
+                        "Attempting to create an AIE queue on a non-AIE agent.");
   }
   queue_size_bytes_ = req_size_pkts * sizeof(core::AqlPacket);
   ring_buf_ = agent_.system_allocator()(queue_size_bytes_, 4096,
                                         core::MemoryRegion::AllocateNoFlags);
 
   if (!ring_buf_) {
-    throw AMD::hsa_exception(
-        HSA_STATUS_ERROR_INVALID_QUEUE_CREATION,
-        "Could not allocate a ring buffer for an AIE queue.");
+    throw hsa_exception(HSA_STATUS_ERROR_INVALID_QUEUE_CREATION,
+                        "Could not allocate a ring buffer for an AIE queue.");
   }
 
   // Populate hsa_queue_t fields.
@@ -107,7 +106,7 @@ AieAqlQueue::AieAqlQueue(core::SharedQueue* shared_queue, AieAgent* agent, size_
       agent_.driver().CreateQueue(node_id, HSA_QUEUE_COMPUTE_AQL, 0, rocr::HSA::HSA_AMD_QUEUE_PRIORITY_NORMAL, 0,
                                   nullptr, queue_size_bytes_, nullptr, queue_resource);
   if (status != HSA_STATUS_SUCCESS) {
-    throw AMD::hsa_exception(status, "Failed to create a hardware context for an AIE queue.");
+    throw hsa_exception(status, "Failed to create a hardware context for an AIE queue.");
   }
 
   queue_id_ = queue_resource.QueueId;
@@ -226,7 +225,7 @@ void AieAqlQueue::SubmitPackets() {
     // Get the packet header information
     if (pkt->header.header != HSA_PACKET_TYPE_VENDOR_SPECIFIC ||
         pkt->header.AmdFormat != HSA_AMD_PACKET_TYPE_AIE_ERT) {
-      assert(false && "Invalid packet header");
+      throw hsa_exception(HSA_STATUS_ERROR_INVALID_PACKET_FORMAT, "Invalid packet header");
     }
 
     // Get the payload information
@@ -248,7 +247,7 @@ void AieAqlQueue::SubmitPackets() {
         hsa_status_t status = driver.SubmitCmdChain(pkt, num_cont_start_cu_pkts, queue_id_,
                                                     agent_.properties().NumNeuralCores);
         if (status != HSA_STATUS_SUCCESS) {
-          assert(false && "Could not submit packets");
+          throw hsa_exception(status, "Could not submit packets");
         }
 
         cur_id += num_cont_start_cu_pkts;


### PR DESCRIPTION
## Motivation

When either malformed packets were queued or a submission error happened, the error would be swallowed in Release builds.

## Technical Details

Replacing asserts() with exceptions which will propagate to the public API and will cause an `abort()` for easier debugging.

## JIRA ID

NA

## Test Plan

Local testing on Phoenix NPU.

## Test Result

If the kernel is given an argument to non-NPU memory, the following is reported:
```
HSA exception: Invalid packet header
Aborted (core dumped)
```
and execution aborts.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
