### PR TITLE
[SWDEV-545128] Implement some changes in AMD-SMI to aggregate metric from primary and secondary KFD processes

### DIFF
--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -29,11 +29,13 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 #include "rocm_smi/rocm_smi_io_link.h"
 #include "rocm_smi/rocm_smi_kfd.h"
@@ -47,6 +49,7 @@ namespace amd::smi {
 
 static const char *kKFDProcPathRoot = "/sys/class/kfd/kfd/proc";
 static const char *kKFDNodesPathRoot = "/sys/class/kfd/kfd/topology/nodes";
+static const char *kKFDContextPrefix = "context_";  // Prefix for secondary KFD contexts
 
 
 
@@ -96,6 +99,37 @@ static const char *kKFDNodePropHIVE_IDStr =            "hive_id";
 
 static bool is_number(const std::string &s) {
   return !s.empty() && std::all_of(s.begin(), s.end(), ::isdigit);
+}
+
+// Helper function to get secondary context directories under a KFD process
+// Returns a vector of full paths to context_xxxx directories
+// For example: /sys/class/kfd/kfd/proc/1685/context_0
+static std::vector<std::string> GetSecondaryContextPaths(const std::string& proc_path) {
+  std::vector<std::string> context_paths;
+
+  DIR* dir = opendir(proc_path.c_str());
+  if (!dir) {
+    return context_paths;
+  }
+
+  struct dirent* entry;
+  while ((entry = readdir(dir)) != nullptr) {
+    // Skip . and ..
+    if (entry->d_name[0] == '.') continue;
+
+    // Check if the entry starts with "context_"
+    if (strncmp(entry->d_name, kKFDContextPrefix, strlen(kKFDContextPrefix)) == 0) {
+      std::string context_path = proc_path + "/" + entry->d_name;
+      // Verify it's a directory
+      struct stat st;
+      if (stat(context_path.c_str(), &st) == 0 && S_ISDIR(st.st_mode)) {
+        context_paths.push_back(context_path);
+      }
+    }
+  }
+
+  closedir(dir);
+  return context_paths;
 }
 
 static std::string KFDDevicePath(uint32_t dev_id) {
@@ -283,6 +317,9 @@ int GetProcessInfo(rsmi_process_info_t *procs, uint32_t num_allocated,
 
   std::string proc_id_str;
   std::string tmp;
+  // Keep track of PIDs we've already seen to avoid duplicates
+  // (e.g., if both "1234" and "pid:1234-id:1" exist)
+  std::unordered_set<uint32_t> seen_pids;
 
   while (dentry != nullptr) {
     if (dentry->d_name[0] == '.') {
@@ -291,16 +328,36 @@ int GetProcessInfo(rsmi_process_info_t *procs, uint32_t num_allocated,
     }
 
     proc_id_str = dentry->d_name;
-    assert(is_number(proc_id_str) && "Unexpected file name in kfd/proc dir");
-    if (!is_number(proc_id_str)) {
-      dentry = readdir(proc_dir);
-      continue;
+
+    // Check if the entry is a plain number (traditional format)
+    if (is_number(proc_id_str)) {
+      uint32_t pid = static_cast<uint32_t>(std::stoi(proc_id_str));
+      if (seen_pids.find(pid) == seen_pids.end()) {
+        seen_pids.insert(pid);
+        if (procs && *num_procs_found < num_allocated) {
+          procs[*num_procs_found].process_id = pid;
+        }
+        ++(*num_procs_found);
+      }
     }
-    if (procs && *num_procs_found < num_allocated) {
-      procs[*num_procs_found].process_id =
-                                static_cast<uint32_t>(std::stoi(proc_id_str));
+    // Check for "pid:XXXX-id:X" format (alternative format for multi-context processes)
+    else if (proc_id_str.find("pid:") == 0) {
+      // Extract PID from "pid:XXXX-id:X" format
+      size_t dash_pos = proc_id_str.find('-');
+      if (dash_pos != std::string::npos) {
+        std::string pid_part = proc_id_str.substr(4, dash_pos - 4);  // Extract XXXX from "pid:XXXX-id:X"
+        if (is_number(pid_part)) {
+          uint32_t pid = static_cast<uint32_t>(std::stoi(pid_part));
+          if (seen_pids.find(pid) == seen_pids.end()) {
+            seen_pids.insert(pid);
+            if (procs && *num_procs_found < num_allocated) {
+              procs[*num_procs_found].process_id = pid;
+            }
+            ++(*num_procs_found);
+          }
+        }
+      }
     }
-    ++(*num_procs_found);
 
     dentry = readdir(proc_dir);
   }
@@ -318,6 +375,30 @@ int GetKfdGpuIdsForPid(long pid, std::unordered_set<uint64_t>* out){
   out->clear();
 
   std::string pdir = std::string(kKFDProcPathRoot) + "/" + std::to_string(pid);
+
+  // Helper lambda to extract GPU IDs from files in a directory
+  auto extract_gpu_ids_from_dir = [&out](const std::string& dir_path) {
+    DIR* d = opendir(dir_path.c_str());
+    if (!d) return;
+
+    struct dirent* e;
+    while ((e = readdir(d))) {
+      if (e->d_name[0] == '.') continue; // skip "."/".." and hidden entries
+
+      // Grab KFD GPU id from one of these fields
+      if (!strncmp(e->d_name, "stats_", 6)) {
+        out->insert(strtoull(e->d_name + 6, nullptr, 10));
+      } else if (!strncmp(e->d_name, "vram_", 5)) {
+        out->insert(strtoull(e->d_name + 5, nullptr, 10));
+      } else if (!strncmp(e->d_name, "counters_", 9)) {
+        out->insert(strtoull(e->d_name + 9, nullptr, 10));
+      } else if (!strncmp(e->d_name, "sdma_", 5)) {
+        out->insert(strtoull(e->d_name + 5, nullptr, 10));
+      }
+    }
+    closedir(d);
+  };
+
   DIR* d = opendir(pdir.c_str());
 
   if (!d) {
@@ -344,6 +425,38 @@ int GetKfdGpuIdsForPid(long pid, std::unordered_set<uint64_t>* out){
   }
 
   closedir(d);
+
+  // Also check secondary contexts (context_xxxx directories)
+  // These are created by the KFD multiple contexts feature
+  std::vector<std::string> context_paths = GetSecondaryContextPaths(pdir);
+  for (const auto& context_path : context_paths) {
+    extract_gpu_ids_from_dir(context_path);
+  }
+
+  // Also check for "pid:PID-id:X" format directories at the parent level
+  // This is another format used for multi-context processes
+  std::string pid_prefix = "pid:" + std::to_string(pid) + "-id:";
+  DIR* proc_root = opendir(kKFDProcPathRoot);
+  if (proc_root) {
+    struct dirent* root_entry;
+    while ((root_entry = readdir(proc_root))) {
+      if (root_entry->d_name[0] == '.') continue;
+      std::string entry_name = root_entry->d_name;
+      if (entry_name.find(pid_prefix) == 0) {
+        // Found a pid:PID-id:X directory for this process
+        std::string alternate_path = std::string(kKFDProcPathRoot) + "/" + entry_name;
+        extract_gpu_ids_from_dir(alternate_path);
+
+        // Also check for context_xxxx in this alternate path
+        std::vector<std::string> alt_context_paths = GetSecondaryContextPaths(alternate_path);
+        for (const auto& alt_context_path : alt_context_paths) {
+          extract_gpu_ids_from_dir(alt_context_path);
+        }
+      }
+    }
+    closedir(proc_root);
+  }
+
   return 0;
 
 }
@@ -352,6 +465,7 @@ int GetKfdGpuIdsForPid(long pid, std::unordered_set<uint64_t>* out){
 // gpus_found.
 // Directory structure:
 //     /sys/class/kfd/kfd/proc/<pid>/queues/<queue id>/gpuid
+//     /sys/class/kfd/kfd/proc/<pid>/context_<id>/queues/<queue id>/gpuid (for secondary contexts)
 
 int GetProcessGPUs(uint32_t pid, std::unordered_set<uint64_t> *gpu_set) {
   int err;
@@ -366,58 +480,105 @@ int GetProcessGPUs(uint32_t pid, std::unordered_set<uint64_t> *gpu_set) {
     return 0;
   }
 
-  std::string queues_dir = kKFDProcPathRoot;
-  queues_dir += "/";
-  queues_dir += std::to_string(pid);
-  queues_dir += "/queues";
+  std::string proc_path = kKFDProcPathRoot;
+  proc_path += "/";
+  proc_path += std::to_string(pid);
 
-  auto queues_dir_hd = opendir(queues_dir.c_str());
+  // Helper lambda to read GPU IDs from queues in a given base path
+  auto read_gpus_from_queues = [&](const std::string& base_path) -> int {
+    std::string queues_dir = base_path + "/queues";
+    auto queues_dir_hd = opendir(queues_dir.c_str());
 
-  if (queues_dir_hd == nullptr) {
-    std::string err_str = "Unable to open queues directory for process ";
-    err_str += std::to_string(pid);
-    perror(err_str.c_str());
-    return ESRCH;
+    if (queues_dir_hd == nullptr) {
+      // Directory doesn't exist, which is okay for secondary contexts
+      return 0;
+    }
+
+    auto q_dentry = readdir(queues_dir_hd);
+    std::string tmp;
+
+    while (q_dentry != nullptr) {
+      if (q_dentry->d_name[0] == '.') {
+        q_dentry = readdir(queues_dir_hd);
+        continue;
+      }
+
+      if (!is_number(q_dentry->d_name)) {
+        q_dentry = readdir(queues_dir_hd);
+        continue;
+      }
+
+      std::string q_gpu_id_str = queues_dir + '/' + q_dentry->d_name + "/gpuid";
+
+      int read_err = ReadSysfsStr(q_gpu_id_str, &tmp);
+      if (read_err) {
+        q_dentry = readdir(queues_dir_hd);
+        continue;
+      }
+
+      uint64_t val;
+      try {
+        val = static_cast<uint64_t>(std::stoi(tmp));
+      } catch (...) {
+        std::cerr << "Error; read invalid data: " << tmp << " from " <<
+                                                      q_gpu_id_str << std::endl;
+        closedir(queues_dir_hd);
+        return ENXIO;  // Return "no such device" if we read an invalid gpu id
+      }
+      gpu_set->insert(val);
+
+      q_dentry = readdir(queues_dir_hd);
+    }
+
+    closedir(queues_dir_hd);
+    return 0;
+  };
+
+  // Read from primary process queues
+  err = read_gpus_from_queues(proc_path);
+  if (err != 0 && err != ESRCH) {
+    return err;
   }
 
-  auto q_dentry = readdir(queues_dir_hd);
-
-  std::string q_gpu_id_str;
-  std::string q_dir;
-
-  std::string tmp;
-
-  while (q_dentry != nullptr) {
-    if (q_dentry->d_name[0] == '.') {
-      q_dentry = readdir(queues_dir_hd);
-      continue;
+  // Read from secondary context queues
+  std::vector<std::string> context_paths = GetSecondaryContextPaths(proc_path);
+  for (const auto& context_path : context_paths) {
+    err = read_gpus_from_queues(context_path);
+    if (err != 0 && err != ESRCH) {
+      return err;
     }
+  }
 
-    if (!is_number(q_dentry->d_name)) {
-      q_dentry = readdir(queues_dir_hd);
-      continue;
+  // Also check for "pid:PID-id:X" format directories at the parent level
+  // This is another format used for multi-context processes
+  std::string pid_prefix = "pid:" + std::to_string(pid) + "-id:";
+  DIR* proc_root = opendir(kKFDProcPathRoot);
+  if (proc_root) {
+    struct dirent* root_entry;
+    while ((root_entry = readdir(proc_root))) {
+      if (root_entry->d_name[0] == '.') continue;
+      std::string entry_name = root_entry->d_name;
+      if (entry_name.find(pid_prefix) == 0) {
+        // Found a pid:PID-id:X directory for this process
+        std::string alternate_path = std::string(kKFDProcPathRoot) + "/" + entry_name;
+        err = read_gpus_from_queues(alternate_path);
+        if (err != 0 && err != ESRCH) {
+          closedir(proc_root);
+          return err;
+        }
+
+        // Also check for context_xxxx in this alternate path
+        std::vector<std::string> alt_context_paths = GetSecondaryContextPaths(alternate_path);
+        for (const auto& alt_context_path : alt_context_paths) {
+          err = read_gpus_from_queues(alt_context_path);
+          if (err != 0 && err != ESRCH) {
+            closedir(proc_root);
+            return err;
+          }
+        }
+      }
     }
-
-    q_gpu_id_str = queues_dir + '/' + q_dentry->d_name + "/gpuid";
-
-    err = ReadSysfsStr(q_gpu_id_str, &tmp);
-    if (err) {
-      q_dentry = readdir(queues_dir_hd);
-      continue;
-    }
-
-    uint64_t val;
-    try {
-      val = static_cast<uint64_t>(std::stoi(tmp));
-    } catch (...) {
-      std::cerr << "Error; read invalid data: " << tmp << " from " <<
-                                                    q_gpu_id_str << std::endl;
-      closedir(queues_dir_hd);
-      return ENXIO;  // Return "no such device" if we read an invalid gpu id
-    }
-    gpu_set->insert(val);
-
-    q_dentry = readdir(queues_dir_hd);
+    closedir(proc_root);
   }
 
   // if no queues were present, fallback to grab KFD GPU IDs from parent dir names
@@ -426,10 +587,6 @@ int GetProcessGPUs(uint32_t pid, std::unordered_set<uint64_t> *gpu_set) {
     return kfd_ret;
   }
 
-  errno = 0;
-  if (closedir(queues_dir_hd)) {
-    return errno;
-  }
   return 0;
 }
 
@@ -485,64 +642,128 @@ int GetProcessInfoForPID(uint32_t pid, rsmi_process_info_t *proc,
   proc->cu_occupancy = 0;
   proc->evicted_time = 0;
 
+  // Collect all paths to read metrics from: primary process + secondary contexts
+  std::vector<std::string> metric_paths;
+  metric_paths.push_back(proc_str_path);
+
+  // Add secondary context paths (context_xxxx directories)
+  // These are created by the KFD multiple contexts feature
+  std::vector<std::string> context_paths = GetSecondaryContextPaths(proc_str_path);
+  for (const auto& context_path : context_paths) {
+    metric_paths.push_back(context_path);
+  }
+
+  // Also check for "pid:PID-id:X" format directories at the parent level
+  // This is another format used for multi-context processes
+  std::string pid_prefix = "pid:" + std::to_string(pid) + "-id:";
+  DIR* proc_root = opendir(kKFDProcPathRoot);
+  if (proc_root) {
+    struct dirent* root_entry;
+    while ((root_entry = readdir(proc_root))) {
+      if (root_entry->d_name[0] == '.') continue;
+      std::string entry_name = root_entry->d_name;
+      if (entry_name.find(pid_prefix) == 0) {
+        // Found a pid:PID-id:X directory for this process
+        std::string alternate_path = std::string(kKFDProcPathRoot) + "/" + entry_name;
+        metric_paths.push_back(alternate_path);
+
+        // Also check for context_xxxx in this alternate path
+        std::vector<std::string> alt_context_paths = GetSecondaryContextPaths(alternate_path);
+        for (const auto& alt_context_path : alt_context_paths) {
+          metric_paths.push_back(alt_context_path);
+        }
+      }
+    }
+    closedir(proc_root);
+  }
+
   for (itr = gpu_set->begin(); itr != gpu_set->end(); itr++) {
     uint64_t gpu_id = (*itr);
 
-    std::string vram_str_path = proc_str_path;
-    vram_str_path += "/vram_";
-    vram_str_path += std::to_string(gpu_id);
+    // Aggregate metrics from primary process and all secondary contexts
+    for (const auto& metric_base_path : metric_paths) {
+      std::string vram_str_path = metric_base_path;
+      vram_str_path += "/vram_";
+      vram_str_path += std::to_string(gpu_id);
 
-    err = ReadSysfsStr(vram_str_path, &tmp);
-    auto sysfs_data_errcode = CheckValidProcessInfoData(tmp, err);
+      err = ReadSysfsStr(vram_str_path, &tmp);
+      auto sysfs_data_errcode = CheckValidProcessInfoData(tmp, err);
 
-    // Report all errors, except ENOENT (2), which should be ignored
-    // and the proc->vram_usage should be unmodified
-    if (!(sysfs_data_errcode == 0 || sysfs_data_errcode == ENOENT)){
-      return sysfs_data_errcode;
-    }
-    // Do not store any invalid values
-    else if (sysfs_data_errcode == 0) {
-      proc->vram_usage += std::stoull(tmp);
-    }
+      // Report all errors, except ENOENT (2), which should be ignored
+      // and the proc->vram_usage should be unmodified
+      if (!(sysfs_data_errcode == 0 || sysfs_data_errcode == ENOENT)){
+        return sysfs_data_errcode;
+      }
+      // Do not store any invalid values
+      else if (sysfs_data_errcode == 0) {
+        proc->vram_usage += std::stoull(tmp);
+      }
 
-    std::string sdma_str_path = proc_str_path;
-    sdma_str_path += "/sdma_";
-    sdma_str_path += std::to_string(gpu_id);
+      std::string sdma_str_path = metric_base_path;
+      sdma_str_path += "/sdma_";
+      sdma_str_path += std::to_string(gpu_id);
 
-    err = ReadSysfsStr(sdma_str_path, &tmp);
-    sysfs_data_errcode = CheckValidProcessInfoData(tmp, err);
+      err = ReadSysfsStr(sdma_str_path, &tmp);
+      sysfs_data_errcode = CheckValidProcessInfoData(tmp, err);
 
-    if (!(sysfs_data_errcode == 0 || sysfs_data_errcode == ENOENT)){
-      return sysfs_data_errcode;
-    }
-    else if (sysfs_data_errcode == 0) {
-      proc->sdma_usage += std::stoull(tmp);
-    }
+      if (!(sysfs_data_errcode == 0 || sysfs_data_errcode == ENOENT)){
+        return sysfs_data_errcode;
+      }
+      else if (sysfs_data_errcode == 0) {
+        proc->sdma_usage += std::stoull(tmp);
+      }
 
-    // Build the path and read from Sysfs file, info that
-    // encodes Compute Unit usage by a process of interest
-    std::string cu_occupancy_path = proc_str_path;
-    cu_occupancy_path += "/stats_";
-    cu_occupancy_path += std::to_string(gpu_id);
-    cu_occupancy_path += "/cu_occupancy";
+      // Build the path and read from Sysfs file, info that
+      // encodes Compute Unit usage by a process of interest
+      std::string cu_occupancy_path = metric_base_path;
+      cu_occupancy_path += "/stats_";
+      cu_occupancy_path += std::to_string(gpu_id);
+      cu_occupancy_path += "/cu_occupancy";
 
-    err = GetProcessKFDStats(cu_occupancy_path, kfd_stat);
-    if (err != 0){
-      return err;
-    }
-    proc->cu_occupancy = kfd_stat;
+      err = GetProcessKFDStats(cu_occupancy_path, kfd_stat);
+      if (err != 0){
+        // For secondary contexts, ENOENT is acceptable if stats don't exist
+        if (err != ENOENT || metric_base_path == proc_str_path) {
+          // Only return error for primary process, or non-ENOENT errors
+          if (metric_base_path == proc_str_path || err != ENOENT) {
+            // Check if file actually exists before returning error
+            if (FileExists(cu_occupancy_path.c_str()) || err != ENOENT) {
+              return err;
+            }
+          }
+        }
+      } else {
+        // Aggregate cu_occupancy (use max value as it represents peak usage)
+        if (kfd_stat != KFD_STATS_INVALID && kfd_stat > proc->cu_occupancy) {
+          proc->cu_occupancy = kfd_stat;
+        }
+      }
 
-    std::string evicted_time_path = proc_str_path;
-    evicted_time_path += "/stats_";
-    evicted_time_path += std::to_string(gpu_id);
-    evicted_time_path += "/evicted_ms";
+      std::string evicted_time_path = metric_base_path;
+      evicted_time_path += "/stats_";
+      evicted_time_path += std::to_string(gpu_id);
+      evicted_time_path += "/evicted_ms";
 
-    err = GetProcessKFDStats(evicted_time_path, kfd_stat);
-    if (err != 0){
-      return err;
-    }
-    proc->evicted_time = kfd_stat;
-
+      err = GetProcessKFDStats(evicted_time_path, kfd_stat);
+      if (err != 0){
+        // For secondary contexts, ENOENT is acceptable if stats don't exist
+        if (metric_base_path == proc_str_path || err != ENOENT) {
+          if (FileExists(evicted_time_path.c_str()) || err != ENOENT) {
+            return err;
+          }
+        }
+      } else {
+        // Aggregate evicted_time (sum all evicted times)
+        if (kfd_stat != KFD_STATS_INVALID) {
+          // Handle potential overflow by checking before addition
+          if (proc->evicted_time <= UINT32_MAX - kfd_stat) {
+            proc->evicted_time += kfd_stat;
+          } else {
+            proc->evicted_time = UINT32_MAX;  // Cap at max value
+          }
+        }
+      }
+    }  // End of metric_paths loop
   }
 
   return 0;

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -358,6 +358,12 @@ int GetProcessInfo(rsmi_process_info_t *procs, uint32_t num_allocated,
         }
       }
     }
+    else {
+      // Skip unexpected entries that don't match known formats
+      // (e.g., non-numeric, non-pid: format files/directories)
+      dentry = readdir(proc_dir);
+      continue;
+    }
 
     dentry = readdir(proc_dir);
   }
@@ -405,26 +411,10 @@ int GetKfdGpuIdsForPid(long pid, std::unordered_set<uint64_t>* out){
     perror(("Unable to open KFD process directory for process " + std::to_string(pid)).c_str());
     return errno ? errno : ESRCH;
   }
-
-  struct dirent* e;
-
-  while ((e = readdir(d))) {
-
-    if (e->d_name[0] == '.') continue; // skip "."/".." and hidden entries
-
-    // Grab KFD GPU id from one of these fields
-    if (!strncmp(e->d_name, "stats_", 6)) {
-      out->insert(strtoull(e->d_name + 6, nullptr, 10));
-    } else if (!strncmp(e->d_name, "vram_", 5)) {
-      out->insert(strtoull(e->d_name + 5, nullptr, 10));
-    } else if (!strncmp(e->d_name, "counters_", 9)) {
-      out->insert(strtoull(e->d_name + 9, nullptr, 10));
-    } else if (!strncmp(e->d_name, "sdma_", 5)) {
-      out->insert(strtoull(e->d_name + 5, nullptr, 10));
-    }
-  }
-
   closedir(d);
+
+  // Use the lambda for the primary process directory (instead of duplicating code)
+  extract_gpu_ids_from_dir(pdir);
 
   // Also check secondary contexts (context_xxxx directories)
   // These are created by the KFD multiple contexts feature

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -97,6 +97,12 @@ static const char *kKFDNodePropHIVE_IDStr =            "hive_id";
 // static const char *kKFDNodePropMAX_ENGINE_CLK_CCOMPUTEStr =
 //                                                "max_engine_clk_ccompute";
 
+// KFD process file prefixes for extracting GPU IDs
+static const char* kKFDStatsPrefix = "stats_";
+static const char* kKFDVramPrefix = "vram_";
+static const char* kKFDCountersPrefix = "counters_";
+static const char* kKFDSdmaPrefix = "sdma_";
+
 static bool is_number(const std::string &s) {
   return !s.empty() && std::all_of(s.begin(), s.end(), ::isdigit);
 }
@@ -130,49 +136,6 @@ static std::vector<std::string> GetSecondaryContextPaths(const std::string& proc
 
   closedir(dir);
   return context_paths;
-}
-
-// Helper function to get all metric paths for a PID, including:
-// 1. The primary process path (e.g., /sys/class/kfd/kfd/proc/1234)
-// 2. Any "pid:PID-id:X" format alternate directories
-// 3. All context_xxxx subdirectories under each of those
-// This eliminates duplicated traversal code across multiple functions.
-static std::vector<std::string> GetAllMetricPathsForPid(uint32_t pid) noexcept {
-  std::vector<std::string> paths;
-
-  // Add primary process path
-  std::string primary_path = std::string(kKFDProcPathRoot) + "/" + std::to_string(pid);
-  paths.push_back(primary_path);
-
-  // Add secondary contexts for primary path
-  std::vector<std::string> primary_contexts = GetSecondaryContextPaths(primary_path);
-  for (const auto& ctx : primary_contexts) {
-    paths.push_back(ctx);
-  }
-
-  // Check for "pid:PID-id:X" format directories at the parent level
-  std::string pid_prefix = "pid:" + std::to_string(pid) + "-id:";
-  DIR* proc_root = opendir(kKFDProcPathRoot);
-  if (proc_root) {
-    struct dirent* root_entry;
-    while ((root_entry = readdir(proc_root))) {
-      if (root_entry->d_name[0] == '.') continue;
-      std::string entry_name = root_entry->d_name;
-      if (entry_name.find(pid_prefix) == 0) {
-        std::string alternate_path = std::string(kKFDProcPathRoot) + "/" + entry_name;
-        paths.push_back(alternate_path);
-
-        // Also add context_xxxx subdirectories
-        std::vector<std::string> alt_contexts = GetSecondaryContextPaths(alternate_path);
-        for (const auto& alt_ctx : alt_contexts) {
-          paths.push_back(alt_ctx);
-        }
-      }
-    }
-    closedir(proc_root);
-  }
-
-  return paths;
 }
 
 
@@ -427,7 +390,7 @@ int GetKfdGpuIdsForPid(long pid, std::unordered_set<uint64_t>* out){
   std::string pdir = std::string(kKFDProcPathRoot) + "/" + std::to_string(pid);
 
   // Helper lambda to extract GPU IDs from files in a directory
-  auto extract_gpu_ids_from_dir = [out](const std::string& dir_path) {
+  auto extract_gpu_ids_from_dir = [&out](const std::string& dir_path) {
     DIR* d = opendir(dir_path.c_str());
     if (!d) return;
 
@@ -436,14 +399,14 @@ int GetKfdGpuIdsForPid(long pid, std::unordered_set<uint64_t>* out){
       if (e->d_name[0] == '.') continue; // skip "."/".." and hidden entries
 
       // Grab KFD GPU id from one of these fields
-      if (!strncmp(e->d_name, "stats_", 6)) {
-        out->insert(strtoull(e->d_name + 6, nullptr, 10));
-      } else if (!strncmp(e->d_name, "vram_", 5)) {
-        out->insert(strtoull(e->d_name + 5, nullptr, 10));
-      } else if (!strncmp(e->d_name, "counters_", 9)) {
-        out->insert(strtoull(e->d_name + 9, nullptr, 10));
-      } else if (!strncmp(e->d_name, "sdma_", 5)) {
-        out->insert(strtoull(e->d_name + 5, nullptr, 10));
+      if (!strncmp(e->d_name, kKFDStatsPrefix, strlen(kKFDStatsPrefix))) {
+        out->insert(strtoull(e->d_name + strlen(kKFDStatsPrefix), nullptr, 10));
+      } else if (!strncmp(e->d_name, kKFDVramPrefix, strlen(kKFDVramPrefix))) {
+        out->insert(strtoull(e->d_name + strlen(kKFDVramPrefix), nullptr, 10));
+      } else if (!strncmp(e->d_name, kKFDCountersPrefix, strlen(kKFDCountersPrefix))) {
+        out->insert(strtoull(e->d_name + strlen(kKFDCountersPrefix), nullptr, 10));
+      } else if (!strncmp(e->d_name, kKFDSdmaPrefix, strlen(kKFDSdmaPrefix))) {
+        out->insert(strtoull(e->d_name + strlen(kKFDSdmaPrefix), nullptr, 10));
       }
     }
     closedir(d);
@@ -707,14 +670,11 @@ int GetProcessInfoForPID(uint32_t pid, rsmi_process_info_t *proc,
     closedir(proc_root);
   }
 
-  for (itr = gpu_set->begin(); itr != gpu_set->end(); itr++) {
-    uint64_t gpu_id = (*itr);
+  for (const auto& gpu_id : *gpu_set) {
 
     // Aggregate metrics from primary process and all secondary contexts
     for (const auto& metric_base_path : metric_paths) {
-      std::string vram_str_path = metric_base_path;
-      vram_str_path += "/vram_";
-      vram_str_path += std::to_string(gpu_id);
+      std::string vram_str_path = metric_base_path + "/vram_" + std::to_string(gpu_id);
 
       err = ReadSysfsStr(vram_str_path, &tmp);
       auto sysfs_data_errcode = CheckValidProcessInfoData(tmp, err);
@@ -729,9 +689,7 @@ int GetProcessInfoForPID(uint32_t pid, rsmi_process_info_t *proc,
         proc->vram_usage += std::stoull(tmp);
       }
 
-      std::string sdma_str_path = metric_base_path;
-      sdma_str_path += "/sdma_";
-      sdma_str_path += std::to_string(gpu_id);
+      std::string sdma_str_path = metric_base_path + "/sdma_" + std::to_string(gpu_id);
 
       err = ReadSysfsStr(sdma_str_path, &tmp);
       sysfs_data_errcode = CheckValidProcessInfoData(tmp, err);
@@ -745,10 +703,7 @@ int GetProcessInfoForPID(uint32_t pid, rsmi_process_info_t *proc,
 
       // Build the path and read from Sysfs file, info that
       // encodes Compute Unit usage by a process of interest
-      std::string cu_occupancy_path = metric_base_path;
-      cu_occupancy_path += "/stats_";
-      cu_occupancy_path += std::to_string(gpu_id);
-      cu_occupancy_path += "/cu_occupancy";
+      std::string cu_occupancy_path = metric_base_path + "/stats_" + std::to_string(gpu_id) + "/cu_occupancy";
 
       err = GetProcessKFDStats(cu_occupancy_path, kfd_stat);
       if (err != 0) {
@@ -766,10 +721,7 @@ int GetProcessInfoForPID(uint32_t pid, rsmi_process_info_t *proc,
         }
       }
 
-      std::string evicted_time_path = metric_base_path;
-      evicted_time_path += "/stats_";
-      evicted_time_path += std::to_string(gpu_id);
-      evicted_time_path += "/evicted_ms";
+      std::string evicted_time_path = metric_base_path + "/stats_" + std::to_string(gpu_id) + "/evicted_ms";
 
       err = GetProcessKFDStats(evicted_time_path, kfd_stat);
       if (err != 0) {

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -104,7 +104,7 @@ static bool is_number(const std::string &s) {
 // Helper function to get secondary context directories under a KFD process
 // Returns a vector of full paths to context_xxxx directories
 // For example: /sys/class/kfd/kfd/proc/1685/context_0
-static std::vector<std::string> GetSecondaryContextPaths(const std::string& proc_path) {
+static std::vector<std::string> GetSecondaryContextPaths(const std::string& proc_path) noexcept {
   std::vector<std::string> context_paths;
 
   DIR* dir = opendir(proc_path.c_str());
@@ -131,6 +131,50 @@ static std::vector<std::string> GetSecondaryContextPaths(const std::string& proc
   closedir(dir);
   return context_paths;
 }
+
+// Helper function to get all metric paths for a PID, including:
+// 1. The primary process path (e.g., /sys/class/kfd/kfd/proc/1234)
+// 2. Any "pid:PID-id:X" format alternate directories
+// 3. All context_xxxx subdirectories under each of those
+// This eliminates duplicated traversal code across multiple functions.
+static std::vector<std::string> GetAllMetricPathsForPid(uint32_t pid) noexcept {
+  std::vector<std::string> paths;
+
+  // Add primary process path
+  std::string primary_path = std::string(kKFDProcPathRoot) + "/" + std::to_string(pid);
+  paths.push_back(primary_path);
+
+  // Add secondary contexts for primary path
+  std::vector<std::string> primary_contexts = GetSecondaryContextPaths(primary_path);
+  for (const auto& ctx : primary_contexts) {
+    paths.push_back(ctx);
+  }
+
+  // Check for "pid:PID-id:X" format directories at the parent level
+  std::string pid_prefix = "pid:" + std::to_string(pid) + "-id:";
+  DIR* proc_root = opendir(kKFDProcPathRoot);
+  if (proc_root) {
+    struct dirent* root_entry;
+    while ((root_entry = readdir(proc_root))) {
+      if (root_entry->d_name[0] == '.') continue;
+      std::string entry_name = root_entry->d_name;
+      if (entry_name.find(pid_prefix) == 0) {
+        std::string alternate_path = std::string(kKFDProcPathRoot) + "/" + entry_name;
+        paths.push_back(alternate_path);
+
+        // Also add context_xxxx subdirectories
+        std::vector<std::string> alt_contexts = GetSecondaryContextPaths(alternate_path);
+        for (const auto& alt_ctx : alt_contexts) {
+          paths.push_back(alt_ctx);
+        }
+      }
+    }
+    closedir(proc_root);
+  }
+
+  return paths;
+}
+
 
 static std::string KFDDevicePath(uint32_t dev_id) {
   std::string node_path = kKFDNodesPathRoot;
@@ -331,7 +375,7 @@ int GetProcessInfo(rsmi_process_info_t *procs, uint32_t num_allocated,
 
     // Check if the entry is a plain number (traditional format)
     if (is_number(proc_id_str)) {
-      uint32_t pid = static_cast<uint32_t>(std::stoi(proc_id_str));
+      uint32_t pid = static_cast<uint32_t>(std::stoul(proc_id_str));
       if (seen_pids.find(pid) == seen_pids.end()) {
         seen_pids.insert(pid);
         if (procs && *num_procs_found < num_allocated) {
@@ -347,7 +391,7 @@ int GetProcessInfo(rsmi_process_info_t *procs, uint32_t num_allocated,
       if (dash_pos != std::string::npos) {
         std::string pid_part = proc_id_str.substr(4, dash_pos - 4);  // Extract XXXX from "pid:XXXX-id:X"
         if (is_number(pid_part)) {
-          uint32_t pid = static_cast<uint32_t>(std::stoi(pid_part));
+          uint32_t pid = static_cast<uint32_t>(std::stoul(pid_part));
           if (seen_pids.find(pid) == seen_pids.end()) {
             seen_pids.insert(pid);
             if (procs && *num_procs_found < num_allocated) {
@@ -383,7 +427,7 @@ int GetKfdGpuIdsForPid(long pid, std::unordered_set<uint64_t>* out){
   std::string pdir = std::string(kKFDProcPathRoot) + "/" + std::to_string(pid);
 
   // Helper lambda to extract GPU IDs from files in a directory
-  auto extract_gpu_ids_from_dir = [&out](const std::string& dir_path) {
+  auto extract_gpu_ids_from_dir = [out](const std::string& dir_path) {
     DIR* d = opendir(dir_path.c_str());
     if (!d) return;
 
@@ -470,9 +514,7 @@ int GetProcessGPUs(uint32_t pid, std::unordered_set<uint64_t> *gpu_set) {
     return 0;
   }
 
-  std::string proc_path = kKFDProcPathRoot;
-  proc_path += "/";
-  proc_path += std::to_string(pid);
+  std::string proc_path = std::string(kKFDProcPathRoot) + "/" + std::to_string(pid);
 
   // Helper lambda to read GPU IDs from queues in a given base path
   auto read_gpus_from_queues = [&](const std::string& base_path) -> int {
@@ -618,9 +660,7 @@ int GetProcessInfoForPID(uint32_t pid, rsmi_process_info_t *proc,
   std::unordered_set<uint64_t>::iterator itr;
   uint32_t kfd_stat;
 
-  std::string proc_str_path = kKFDProcPathRoot;
-  proc_str_path += "/";
-  proc_str_path +=  std::to_string(pid);
+  std::string proc_str_path = std::string(kKFDProcPathRoot) + "/" + std::to_string(pid);
 
   if (!FileExists(proc_str_path.c_str())) {
     return ESRCH;
@@ -711,16 +751,13 @@ int GetProcessInfoForPID(uint32_t pid, rsmi_process_info_t *proc,
       cu_occupancy_path += "/cu_occupancy";
 
       err = GetProcessKFDStats(cu_occupancy_path, kfd_stat);
-      if (err != 0){
-        // For secondary contexts, ENOENT is acceptable if stats don't exist
-        if (err != ENOENT || metric_base_path == proc_str_path) {
-          // Only return error for primary process, or non-ENOENT errors
-          if (metric_base_path == proc_str_path || err != ENOENT) {
-            // Check if file actually exists before returning error
-            if (FileExists(cu_occupancy_path.c_str()) || err != ENOENT) {
-              return err;
-            }
-          }
+      if (err != 0) {
+        // ENOENT is acceptable for secondary contexts where stats may not exist
+        // Only return error for: non-ENOENT errors, OR primary process with existing file
+        bool is_primary = (metric_base_path == proc_str_path);
+        bool file_exists = FileExists(cu_occupancy_path.c_str());
+        if (err != ENOENT || (is_primary && file_exists)) {
+          return err;
         }
       } else {
         // Aggregate cu_occupancy (use max value as it represents peak usage)
@@ -735,12 +772,13 @@ int GetProcessInfoForPID(uint32_t pid, rsmi_process_info_t *proc,
       evicted_time_path += "/evicted_ms";
 
       err = GetProcessKFDStats(evicted_time_path, kfd_stat);
-      if (err != 0){
-        // For secondary contexts, ENOENT is acceptable if stats don't exist
-        if (metric_base_path == proc_str_path || err != ENOENT) {
-          if (FileExists(evicted_time_path.c_str()) || err != ENOENT) {
-            return err;
-          }
+      if (err != 0) {
+        // ENOENT is acceptable for secondary contexts where stats may not exist
+        // Only return error for: non-ENOENT errors, OR primary process with existing file
+        bool is_primary_ctx = (metric_base_path == proc_str_path);
+        bool file_found = FileExists(evicted_time_path.c_str());
+        if (err != ENOENT || (is_primary_ctx && file_found)) {
+          return err;
         }
       } else {
         // Aggregate evicted_time (sum all evicted times)

--- a/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
@@ -184,28 +184,75 @@ int32_t AMDSmiGPUDevice::get_compute_process_list_impl(GPUComputeProcessList_t& 
 
         // Safely handle KFD processes to get total memory_usage of the process
         uint64_t kfd_gpu_id = get_kfd_gpu_id();
-        std::string kfd_path = "/sys/class/kfd/kfd/proc/" +
-                            std::to_string(rsmi_proc_info.process_id) +
-                            "/vram_" + std::to_string(kfd_gpu_id);
+        std::string kfd_proc_path = "/sys/class/kfd/kfd/proc/" +
+                            std::to_string(rsmi_proc_info.process_id);
+        std::string kfd_vram_file = "/vram_" + std::to_string(kfd_gpu_id);
 
-        // Check if the file exists before attempting to open it
-        if (access(kfd_path.c_str(), R_OK) == 0) {
-            std::ifstream kfd_file(kfd_path.c_str());
-            if (kfd_file.is_open()) {
-                std::string line;
-                if (std::getline(kfd_file, line)) {
-                    try {
-                        uint64_t vram_bytes = std::stoull(line);
-                        amdsmi_proc_info.mem = vram_bytes; // Already in bytes
-                    } catch (const std::exception& e) {
-                        // Handle conversion error gracefully
-                        std::ostringstream ss;
-                        ss << __PRETTY_FUNCTION__ << " | Failed to parse VRAM value from KFD: " << e.what();
-                        LOG_DEBUG(ss);
+        // Helper lambda to read VRAM from a path and add to total
+        auto read_vram_from_path = [&](const std::string& base_path) -> uint64_t {
+            uint64_t vram_bytes = 0;
+            std::string vram_path = base_path + kfd_vram_file;
+            if (access(vram_path.c_str(), R_OK) == 0) {
+                std::ifstream kfd_file(vram_path.c_str());
+                if (kfd_file.is_open()) {
+                    std::string line;
+                    if (std::getline(kfd_file, line)) {
+                        try {
+                            vram_bytes = std::stoull(line);
+                        } catch (const std::exception& e) {
+                            std::ostringstream ss;
+                            ss << __PRETTY_FUNCTION__ << " | Failed to parse VRAM value from KFD: " << e.what();
+                            LOG_DEBUG(ss);
+                        }
+                    }
+                    kfd_file.close();
+                }
+            }
+            return vram_bytes;
+        };
+
+        // Helper lambda to read VRAM from all contexts in a directory
+        auto read_vram_from_all_contexts = [&](const std::string& base_path) -> uint64_t {
+            uint64_t total = read_vram_from_path(base_path);
+
+            // Check for secondary contexts (context_xxxx directories)
+            DIR* dir = opendir(base_path.c_str());
+            if (dir != nullptr) {
+                struct dirent* entry;
+                while ((entry = readdir(dir)) != nullptr) {
+                    if (strncmp(entry->d_name, "context_", 8) == 0) {
+                        std::string context_path = base_path + "/" + entry->d_name;
+                        total += read_vram_from_path(context_path);
                     }
                 }
-                kfd_file.close();
+                closedir(dir);
             }
+            return total;
+        };
+
+        // Read VRAM from primary process
+        uint64_t total_vram = read_vram_from_all_contexts(kfd_proc_path);
+
+        // Also check for "pid:PID-id:X" format directories at the parent level
+        // This is another format used for multi-context processes
+        std::string kfd_root = "/sys/class/kfd/kfd/proc/";
+        std::string pid_prefix = "pid:" + std::to_string(rsmi_proc_info.process_id) + "-id:";
+        DIR* proc_root = opendir(kfd_root.c_str());
+        if (proc_root != nullptr) {
+            struct dirent* root_entry;
+            while ((root_entry = readdir(proc_root)) != nullptr) {
+                if (root_entry->d_name[0] == '.') continue;
+                std::string entry_name = root_entry->d_name;
+                if (entry_name.find(pid_prefix) == 0) {
+                    std::string alternate_path = kfd_root + entry_name;
+                    total_vram += read_vram_from_all_contexts(alternate_path);
+                }
+            }
+            closedir(proc_root);
+        }
+
+        if (total_vram > 0) {
+            amdsmi_proc_info.mem = total_vram;
         }
 
         return status_code;

--- a/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
@@ -20,6 +20,7 @@
  * THE SOFTWARE.
  */
 
+#include <cstring>
 #include <memory>
 #include <unordered_set>
 #include <dirent.h>
@@ -32,6 +33,9 @@
 #include "rocm_smi/rocm_smi_logger.h"
 
 namespace amd::smi {
+
+// Constant for KFD context directory prefix
+static constexpr const char* kContextPrefix = "context_";
 
 uint32_t AMDSmiGPUDevice::get_gpu_id() const {
     return gpu_id_;
@@ -188,31 +192,46 @@ int32_t AMDSmiGPUDevice::get_compute_process_list_impl(GPUComputeProcessList_t& 
                             std::to_string(rsmi_proc_info.process_id);
         std::string kfd_vram_file = "/vram_" + std::to_string(kfd_gpu_id);
 
-        // Helper lambda to read VRAM from a path and add to total
-        auto read_vram_from_path = [&](const std::string& base_path) -> uint64_t {
+        // Helper for safe addition without overflow
+        auto safe_add = [](uint64_t a, uint64_t b) -> uint64_t {
+            return (a > UINT64_MAX - b) ? UINT64_MAX : a + b;
+        };
+        // Helper lambda to read VRAM from a path.
+        // Returns 0 if file doesn't exist or can't be read (intentional for optional paths).
+        // Logs parse errors via LOG_INFO but doesn't propagate them - this is a best-effort
+        // aggregation where partial data is better than failing the entire operation.
+        auto read_vram_from_path = [&kfd_vram_file](const std::string& base_path) -> uint64_t {
             uint64_t vram_bytes = 0;
             std::string vram_path = base_path + kfd_vram_file;
-            if (access(vram_path.c_str(), R_OK) == 0) {
-                std::ifstream kfd_file(vram_path.c_str());
-                if (kfd_file.is_open()) {
-                    std::string line;
-                    if (std::getline(kfd_file, line)) {
-                        try {
-                            vram_bytes = std::stoull(line);
-                        } catch (const std::exception& e) {
-                            std::ostringstream ss;
-                            ss << __PRETTY_FUNCTION__ << " | Failed to parse VRAM value from KFD: " << e.what();
-                            LOG_DEBUG(ss);
-                        }
-                    }
-                    kfd_file.close();
+
+            // File may not exist for secondary contexts - this is expected, not an error
+            if (access(vram_path.c_str(), R_OK) != 0) {
+                return 0;  // File doesn't exist or not readable - expected for optional paths
+            }
+
+            std::ifstream kfd_file(vram_path.c_str());
+            if (!kfd_file.is_open()) {
+                return 0;  // Couldn't open file - treat as no data available
+            }
+
+            std::string line;
+            if (std::getline(kfd_file, line)) {
+                try {
+                    vram_bytes = std::stoull(line);
+                } catch (const std::exception& e) {
+                    // Parse error is unexpected - log it for debugging
+                    std::ostringstream ss;
+                    ss << __PRETTY_FUNCTION__ << " | Failed to parse VRAM value from KFD: " << e.what();
+                    LOG_INFO(ss);
+                    // Return 0 rather than failing - best effort aggregation
                 }
             }
+            kfd_file.close();
             return vram_bytes;
         };
 
         // Helper lambda to read VRAM from all contexts in a directory
-        auto read_vram_from_all_contexts = [&](const std::string& base_path) -> uint64_t {
+        auto read_vram_from_all_contexts = [&read_vram_from_path, &safe_add](const std::string& base_path) -> uint64_t {
             uint64_t total = read_vram_from_path(base_path);
 
             // Check for secondary contexts (context_xxxx directories)
@@ -220,9 +239,9 @@ int32_t AMDSmiGPUDevice::get_compute_process_list_impl(GPUComputeProcessList_t& 
             if (dir != nullptr) {
                 struct dirent* entry;
                 while ((entry = readdir(dir)) != nullptr) {
-                    if (strncmp(entry->d_name, "context_", 8) == 0) {
+                    if (strncmp(entry->d_name, kContextPrefix, strlen(kContextPrefix)) == 0) {
                         std::string context_path = base_path + "/" + entry->d_name;
-                        total += read_vram_from_path(context_path);
+                        total = safe_add(total, read_vram_from_path(context_path));
                     }
                 }
                 closedir(dir);
@@ -245,7 +264,7 @@ int32_t AMDSmiGPUDevice::get_compute_process_list_impl(GPUComputeProcessList_t& 
                 std::string entry_name = root_entry->d_name;
                 if (entry_name.find(pid_prefix) == 0) {
                     std::string alternate_path = kfd_root + entry_name;
-                    total_vram += read_vram_from_all_contexts(alternate_path);
+                    total_vram = safe_add(total_vram, read_vram_from_all_contexts(alternate_path));
                 }
             }
             closedir(proc_root);

--- a/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
@@ -21,6 +21,7 @@
  */
 
 #include <cstring>
+#include <fstream>
 #include <memory>
 #include <unordered_set>
 #include <dirent.h>
@@ -209,7 +210,7 @@ int32_t AMDSmiGPUDevice::get_compute_process_list_impl(GPUComputeProcessList_t& 
                 return 0;  // File doesn't exist or not readable - expected for optional paths
             }
 
-            std::ifstream kfd_file(vram_path.c_str());
+            std::ifstream kfd_file(vram_path);
             if (!kfd_file.is_open()) {
                 return 0;  // Couldn't open file - treat as no data available
             }


### PR DESCRIPTION

## Motivation

This PR adds support for parsing per-GPU KFD process files that use the _NNNN suffix naming convention (e.g., vram_46775, stats_46775/).
The ROCm kernel driver exposes per-GPU process statistics in /sys/class/kfd/kfd/proc/PID/ with GPU-specific file suffixes.
Without this change, AMD-SMI cannot read process memory usage and statistics on systems using this KFD file structure.

## Technical Details

Modified src/rocm_smi_kfd.cc and [rocm_smi_kfd.cc](vscode-file://vscode-app/c:/Users/kbillaka/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to parse files with _NNNN GPU ID suffixes.
Added logic to read cu_occupancy and evicted_ms from stats_NNNN/ subdirectories under each process.
The implementation maintains backward compatibility with older KFD structures while supporting the new per-GPU naming convention.

## JIRA ID

Resolves [SWDEV-545128]

## Test Plan

Built AMD-SMI from source and ran amd-smi process command with active GPU workloads.
Verified KFD directory structure parsing by inspecting /sys/class/kfd/kfd/proc/PID/ contents.
Tested both text and JSON output formats to confirm correct data retrieval.

## Test Result

Process detection working correctly - PID, process name, and memory usage displayed.
Per-GPU stats (cu_occupancy=0, evicted_ms=0) read successfully from stats_46775/ directory.
All tests passed on MI300A GPU with KFD_ID 46775.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
