### PR TITLE
SWDEV-568100 - Reduce latency before the first graph packet gets dispatched

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1466,7 +1466,7 @@ bool VirtualGPU::dispatchAqlPacketBatch(const std::vector<uint8_t*>& packets,
   dispatchBlockingWait();
 
   // Add all kernel names in bulk
-  vcmd->addKernelNames(kernelNames);
+  vcmd->setKernelNamesRef(&kernelNames);
 
   // Dispatch all packets with a single doorbell ring
   // Cast packets vector to AQL packets vector on the fly

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -1383,6 +1383,7 @@ class AccumulateCommand : public Command {
  private:
   //! Kernel names and timestamps list for activity profiling
   std::vector<std::string> kernelNames_;
+  const std::vector<std::string>* kernelNamesRef_ = nullptr;
   std::vector<std::pair<uint64_t, uint64_t>> tsList_;
 
  public:
@@ -1399,13 +1400,20 @@ class AccumulateCommand : public Command {
     kernelNames_.insert(kernelNames_.end(), kernelNames.begin(), kernelNames.end());
   }
 
+  //! Set kernel names by reference
+  void setKernelNamesRef(const std::vector<std::string>* kernelNames) {
+    kernelNamesRef_ = kernelNames;
+  }
+
   //! Add kernel timestamp to the list if available
   void addTimestamps(uint64_t startTs, uint64_t endTs) {
     tsList_.push_back(std::make_pair(startTs, endTs));
   }
 
   //! Return the kernel names
-  const std::vector<std::string>& getKernelNames() const { return kernelNames_; }
+  const std::vector<std::string>& getKernelNames() const {
+    return kernelNamesRef_ != nullptr ? *kernelNamesRef_ : kernelNames_;
+  }
 
   //! Return the kernel timestamps
   const std::vector<std::pair<uint64_t, uint64_t>>& getTimestamps() const { return tsList_; }

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -1395,11 +1395,6 @@ class AccumulateCommand : public Command {
   //! Add kernel name to the list if available
   void addKernelName(const std::string& kernelName) { kernelNames_.push_back(kernelName); }
 
-  //! Add multiple kernel names in bulk
-  void addKernelNames(const std::vector<std::string>& kernelNames) {
-    kernelNames_.insert(kernelNames_.end(), kernelNames.begin(), kernelNames.end());
-  }
-
   //! Set kernel names by reference
   void setKernelNamesRef(const std::vector<std::string>* kernelNames) {
     kernelNamesRef_ = kernelNames;


### PR DESCRIPTION
## Motivation
The purpose of this PR is to fix a performance regression in vllm caused by a latency before the first kernel in the graph is launched, that is introduced by rocm 7.1 change: [clr: Optimize doorbell ring](https://github.com/ROCm/rocm-systems/pull/1030)

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

change: [clr: Optimize doorbell ring](https://github.com/ROCm/rocm-systems/pull/1030) adds batching, which makes graph packet dispatch faster overall. However, before dispatch can begin, there is additional bookkeeping and batch preparation work. This upfront overhead appears as added latency before the first kernel (i.e., the first batch) is dispatched. 

A fix has been included as part of change [clr: Use graph segment scheduling to process HIP Graphs](https://github.com/ROCm/rocm-systems/pull/1372) that is much larger in scope. This PR extracts the changes from [clr: Use graph segment scheduling to process HIP Graphs](https://github.com/ROCm/rocm-systems/pull/1372)  that specifically resolve the perf drop seen in vllm ticket SWDEV-568100

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
SWDEV-568100
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
Tested with the vllm job from SWDEV-568100 and confirmed that it resolves the additional latency before the first packet is dispatched that is introduced in rocm 7.0. 
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
The latency before the first graph packet is dispatched is now ~20us. That matches rocm 7.0.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
