### PR TITLE
Adjust amdgpu version output for `amd-smi`

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -4,11 +4,12 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ***All information listed below is for reference and subject to change.***
 
-## amd_smi_lib for ROCm 7.3.0
+## amd_smi_lib for ROCm 7.11.0
 
 ### Added
 
-- N/A
+- **Added `os_kernel_version` to `amd-smi static --driver` output and default output**.  
+  - Displays the Linux kernel version from `os.uname().release`.
 
 ### Changed
 

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -799,7 +799,8 @@ class AMDSMICommands():
                 static_dict['limit'] = limit_info
         if args.driver:
             driver_info_dict = {"name" : "N/A",
-                                "version" : "N/A"}
+                                "version" : "N/A",
+                                "os_kernel_version" : "N/A"}
 
             try:
                 driver_info = amdsmi_interface.amdsmi_get_gpu_driver_info(args.gpu)
@@ -807,6 +808,11 @@ class AMDSMICommands():
                 driver_info_dict["version"] = driver_info["driver_version"]
             except amdsmi_exception.AmdSmiLibraryException as e:
                 logging.debug("Failed to get driver info for gpu %s | %s", gpu_id, e.get_error_info())
+
+            try:
+                driver_info_dict["os_kernel_version"] = os.uname().release
+            except (AttributeError, OSError) as e:
+                logging.debug("Failed to get os kernel version for gpu %s | %s", gpu_id, e)
 
             static_dict['driver'] = driver_info_dict
         if args.board:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -7517,10 +7517,12 @@ class AMDSMICommands():
         processors = amdsmi_interface.amdsmi_get_processor_handles()
         version_info = {"amd-smi": "N/A",
                         "amdgpu version": "N/A",
+                        "kernel version": "N/A",
                         "fw pldm version": "N/A",
                         "vbios version": "N/A",
                         "rocm version": (False, "N/A")}
         version_info['rocm version'] = amdsmi_interface.amdsmi_get_rocm_version()
+        version_info['kernel version'] = os.uname().release
         try:
             version_info["amdgpu version"] = amdsmi_interface.amdsmi_get_gpu_driver_info(processors[0])
         except amdsmi_exception.AmdSmiLibraryException as e:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -1042,8 +1042,13 @@ class AMDSMILogger():
         print(default_line_1)
         # Split the version line into 3 lines, each wrapping to the same width
         print("| AMD-SMI          {0:40s} {1:19s}|".format(amd_smi_version.ljust(40), ""))
+
+        # Print amdgpu or kernel version based on availability, if neither then don't print
         if amdgpu_version.strip() != "N/A":
             print("| amdgpu Version:  {0:40s} {1:19s}|".format(amdgpu_version, ""))
+        elif kernel_version.strip() != "N/A":
+            print("| OS kernel Version:  {0:40s} {1:19s}|".format(kernel_version, ""))
+
         if rocm_version != "N/A":
             print("| ROCm Version:    {0:40s} {1:19s}|".format(rocm_version, ""))
 
@@ -1052,7 +1057,6 @@ class AMDSMILogger():
             print("| VBIOS Version:   {0:22s}  {1:35s} |".format(vbios_version, ""))
         if fw_pldm_version != "N/A":
             print("| FW PLDM:         {0:15s}  {1:42s} |".format(fw_pldm_version, ""))
-        print("| kernel Version:  {0:40s} {1:19s}|".format(kernel_version, ""))
 
         print("| Platform:        {0:25.25s} {1:34s}|".format(str(self.helpers.os_info()), ""))
         print(default_line_2)

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -1036,6 +1036,7 @@ class AMDSMILogger():
                 amdgpu_version = str(driver_version['driver_version'])[:80]
         fw_pldm_version = str(output['version_info']['fw pldm version'])
         vbios_version = str(output['version_info']['vbios version'])
+        kernel_version = str(output['version_info']['kernel version'])
 
         # print GPU info
         print(default_line_1)
@@ -1051,6 +1052,7 @@ class AMDSMILogger():
             print("| VBIOS Version:   {0:22s}  {1:35s} |".format(vbios_version, ""))
         if fw_pldm_version != "N/A":
             print("| FW PLDM:         {0:15s}  {1:42s} |".format(fw_pldm_version, ""))
+        print("| kernel Version:  {0:40s} {1:19s}|".format(kernel_version, ""))
 
         print("| Platform:        {0:25.25s} {1:34s}|".format(str(self.helpers.os_info()), ""))
         print(default_line_2)

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -1041,7 +1041,7 @@ class AMDSMILogger():
         print(default_line_1)
         # Split the version line into 3 lines, each wrapping to the same width
         print("| AMD-SMI          {0:40s} {1:19s}|".format(amd_smi_version.ljust(40), ""))
-        if amdgpu_version != "N/A":
+        if amdgpu_version.strip() != "N/A":
             print("| amdgpu Version:  {0:40s} {1:19s}|".format(amdgpu_version, ""))
         if rocm_version != "N/A":
             print("| ROCm Version:    {0:40s} {1:19s}|".format(rocm_version, ""))

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -3086,6 +3086,7 @@ def amdsmi_get_gpu_driver_info(
         )
     )
 
+    # Not including os_kernel_version here due to it just being os.uname().release
     driver_info = {
         "driver_name": info.driver_name.decode("utf-8"),
         "driver_version": info.driver_version.decode("utf-8"),


### PR DESCRIPTION
I noticed that even though amd-smi is supposed to hide the amdgpu version when no dkms package found it was showing `N/A`.  I also believe it's useful to have the kernel version in this case.  So I've got changes for both of those.

Before:
```
$ /opt/rocm/bin/amd-smi 
+------------------------------------------------------------------------------+
| AMD-SMI          26.2.1+ebe22b5907-dirty                                     |
| amdgpu Version:  N/A                                                         |
| VBIOS Version:   00133300                                                    |
| Platform:        Linux Baremetal                                             |
|-------------------------------------+----------------------------------------|
| BDF                        GPU-Name | Mem-Uti   Temp   UEC       Power-Usage |
| GPU  HIP-ID  OAM-ID  Partition-Mode | GFX-Uti    Fan               Mem-Usage |
|=====================================+========================================|
| 0000:c5:00.0 ...adeon 860M Graphics | N/A        N/A   0                 N/A |
|   0       0     N/A             N/A | N/A        N/A            170/27017 MB |
+-------------------------------------+----------------------------------------+
+------------------------------------------------------------------------------+
| Processes:                                                                   |
|  GPU        PID  Process Name          GTT_MEM  VRAM_MEM  MEM_USAGE     CU % |
|==============================================================================|
|  No running processes found                                                  |
+------------------------------------------------------------------------------+
```

After:
```
$ /opt/rocm/bin/amd-smi 
+------------------------------------------------------------------------------+
| AMD-SMI          26.2.1+ebe22b5907-dirty                                     |
| VBIOS Version:   00133300                                                    |
| kernel Version:  6.19.0-rc4-00067-ga01b0fd8bedf                              |
| Platform:        Linux Baremetal                                             |
|-------------------------------------+----------------------------------------|
| BDF                        GPU-Name | Mem-Uti   Temp   UEC       Power-Usage |
| GPU  HIP-ID  OAM-ID  Partition-Mode | GFX-Uti    Fan               Mem-Usage |
|=====================================+========================================|
| 0000:c5:00.0 ...adeon 860M Graphics | N/A        N/A   0                 N/A |
|   0       0     N/A             N/A | N/A        N/A            170/27017 MB |
+-------------------------------------+----------------------------------------+
+------------------------------------------------------------------------------+
| Processes:                                                                   |
|  GPU        PID  Process Name          GTT_MEM  VRAM_MEM  MEM_USAGE     CU % |
|==============================================================================|
|  No running processes found                                                  |
+------------------------------------------------------------------------------+
```