### PR TITLE
Fix setmemaccess failure for multiple handle mapping to same va range

### DIFF
--- a/projects/clr/hipamd/src/hip_vm.cpp
+++ b/projects/clr/hipamd/src/hip_vm.cpp
@@ -369,17 +369,23 @@ hipError_t hipMemSetAccess(void* ptr, size_t size, const hipMemAccessDesc* desc,
   if (mem_object) {
     memLocationType = static_cast<hipMemLocationType>(mem_object->getUserData().locationType);
     if (mem_object->parent()) {
+      bool buffer_match = false;
       size_t accumulated_buffer_size = 0;
+      size_t subbuffer_size = 0;
       for (auto sub_buffer : mem_object->parent()->subBuffers()) {
-        accumulated_buffer_size += sub_buffer->getSize();
-        if (accumulated_buffer_size > size) {
-          HIP_RETURN(hipErrorInvalidValue);
-        } else if (accumulated_buffer_size == size) {
-          break;
+        size_t current_size = sub_buffer->getSize();
+        accumulated_buffer_size += current_size;
+        if (sub_buffer->getSvmPtr() == ptr) {
+          subbuffer_size = current_size;
+          buffer_match = true;
         }
       }
-
-      if (accumulated_buffer_size != size) {
+      if (!buffer_match) {
+        LogPrintfError("Requested addr 0x%x not mapped!", ptr);
+        HIP_RETURN(hipErrorInvalidValue);
+      }
+      if (subbuffer_size != size && accumulated_buffer_size != size) {
+        LogPrintfError("Given size %zu doesn't match mapped size!", size);
         HIP_RETURN(hipErrorInvalidValue);
       }
     }

--- a/projects/clr/hipamd/src/hip_vm.cpp
+++ b/projects/clr/hipamd/src/hip_vm.cpp
@@ -381,11 +381,13 @@ hipError_t hipMemSetAccess(void* ptr, size_t size, const hipMemAccessDesc* desc,
         }
       }
       if (!buffer_match) {
-        LogPrintfError("Requested addr 0x%x not mapped!", ptr);
+        LogPrintfError("Requested addr %p not mapped!", ptr);
         HIP_RETURN(hipErrorInvalidValue);
       }
       if (subbuffer_size != size && accumulated_buffer_size != size) {
-        LogPrintfError("Given size %zu doesn't match mapped size!", size);
+        LogPrintfError(
+          "Given size %zu doesn't match sub-buffer size %zu or accumulated size %zu!",
+          size, subbuffer_size, accumulated_buffer_size);
         HIP_RETURN(hipErrorInvalidValue);
       }
     }

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -2330,6 +2330,11 @@ bool Device::SetMemAccess(void* va_addr, size_t va_size, VmmAccess access_flags,
   desc.agent_handle =
       access_location == VmmLocationType::kDevice ? getBackendDevice() : getCpuAgent();
 
+  amd::Memory* va_mem_obj = amd::MemObjMap::FindMemObj(va_addr);
+  if (va_mem_obj == nullptr) {
+    return false;
+  }
+
   if ((hsa_status = Hsa::vmem_set_access(va_addr, va_size, &desc, 1)) != HSA_STATUS_SUCCESS) {
     LogPrintfError("Failed hsa_amd_vmem_set_access. Failed with status:%d \n", hsa_status);
     return false;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
@@ -1507,6 +1507,118 @@ TEST_CASE("Unit_hipMemSetAccessHost_devicealloc") {
   HIP_CHECK(hipMemRelease(handle));
 }
 /**
+ * Test Description
+ * ------------------------
+ *    - Test setting access for physical memory handles of different size
+ * mapped to same va range at offsets of buffer size. SetMemAccess should
+ * work for each va address offset
+ * ------------------------
+ *    - unit/virtualMemoryManagement/hipMemSetGetAccess.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 6.1
+ */
+TEST_CASE("Unit_hipMemSetAccess_MultipleOffsets") {
+  int deviceId = 0;
+  hipDevice_t device;
+  CTX_CREATE();
+  HIP_CHECK(hipDeviceGet(&device, deviceId));
+  checkVMMSupported(device);
+  // Data sizes
+	constexpr size_t SIZES[] = {DATA_SIZE * 261, DATA_SIZE * 351, DATA_SIZE * 813};
+  constexpr int NSIZES = 3;
+  // Find recommended granularity for device
+	size_t granularity;
+	hipMemAllocationProp alloc_prop = {};
+	alloc_prop.type = hipMemAllocationTypePinned;
+	alloc_prop.location.type = hipMemLocationTypeDevice;
+	alloc_prop.location.id = 0;
+	HIP_CHECK(hipMemGetAllocationGranularity(&granularity, &alloc_prop, hipMemAllocationGranularityRecommended));
+  INFO("Device recommended granularity : " << granularity);
+
+  // Reserve a 1 GB va range
+	constexpr size_t maxSize = 1ull << 30;
+	hipDeviceptr_t pool_addr;
+	HIP_CHECK(hipMemAddressReserve(reinterpret_cast<void**>(&pool_addr), maxSize, 0, 0, 0));
+	INFO("Reserved virtual memory pool at " << reinterpret_cast<void*>(pool_addr));
+
+  std::vector<size_t> regions(NSIZES, 0);
+
+	for (size_t i = 0; i < NSIZES; ++i)
+	{
+    size_t rounded = SIZES[i];
+		if(rounded %  granularity != 0)
+		{
+			rounded = granularity * ((rounded / granularity) + 1);
+		}
+		regions[i] = rounded;
+    INFO("Final Size at index " << i << " : " << regions[i]);
+	}
+
+  // Initialize host buffer
+  size_t max_size = *std::max_element(regions.begin(), regions.end());
+  int* ptrA_h = static_cast<int*>(malloc(max_size));
+  REQUIRE(ptrA_h != nullptr);
+  int* ptrB_h = static_cast<int*>(malloc(max_size));
+  REQUIRE(ptrB_h != nullptr);
+  for (int idx = 0; idx < max_size / sizeof(int) ; idx++) {
+    ptrA_h[idx] = idx;
+  }
+
+  hipMemAllocationProp prop = {};
+	prop.type = hipMemAllocationTypePinned;
+	prop.location.type = hipMemLocationTypeDevice;
+	prop.location.id = 0;
+
+	size_t pool_size = 0;
+	for (size_t i = 0; i < NSIZES; ++i)
+	{
+    // Creat phys memory handle and map to offsets of va range
+		hipMemGenericAllocationHandle_t handle;
+		HIP_CHECK(hipMemCreate(&handle, regions[i], &prop, 0));
+    unsigned long long uiptr = reinterpret_cast<unsigned long long>(pool_addr);
+    uiptr += pool_size;
+		HIP_CHECK(hipMemMap(reinterpret_cast<void*>(uiptr), regions[i], 0, handle, 0));
+		HIP_CHECK(hipMemRelease(handle));
+
+		hipMemAccessDesc access = {};
+		access.location.type = hipMemLocationTypeDevice;
+		access.location.id = 0;
+		access.flags = hipMemAccessFlagsProtReadWrite;
+    // Set Access for each offset of original va
+		HIP_CHECK(hipMemSetAccess(reinterpret_cast<void*>(uiptr), regions[i], &access, 1));
+		pool_size += regions[i];
+
+    // Copy host buffer to device
+    HIP_CHECK(hipMemcpyHtoD(reinterpret_cast<void*>(uiptr), ptrA_h, regions[i]));
+
+    // Verify device data
+    HIP_CHECK(hipMemcpyDtoH(ptrB_h, reinterpret_cast<void*>(uiptr), regions[i]));
+    for (int idx = 0; idx < regions[i] / sizeof(int); idx++) {
+      REQUIRE(ptrB_h[idx] == idx);
+    }
+	}
+
+  // Unmap VMM
+	pool_size = 0;
+	for (size_t i = 0; i < NSIZES; ++i)
+	{
+    unsigned long long uiptr = reinterpret_cast<unsigned long long>(pool_addr);
+    uiptr += pool_size;
+		HIP_CHECK(hipMemUnmap(reinterpret_cast<void*>(uiptr), regions[i]));
+		pool_size += regions[i];
+	}
+
+	HIP_CHECK(hipMemAddressFree(reinterpret_cast<void*>(pool_addr), maxSize));
+  free(ptrA_h);
+  free(ptrB_h);
+	CTX_DESTROY();
+}
+
+
+
+
+/**
  * End doxygen group VirtualMemoryManagementTest.
  * @}
  */

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
@@ -1524,36 +1524,36 @@ TEST_CASE("Unit_hipMemSetAccess_MultipleOffsets") {
   CTX_CREATE();
   HIP_CHECK(hipDeviceGet(&device, deviceId));
   checkVMMSupported(device);
+
   // Data sizes
-	constexpr size_t SIZES[] = {DATA_SIZE * 261, DATA_SIZE * 351, DATA_SIZE * 813};
+  constexpr size_t SIZES[] = {DATA_SIZE * 261, DATA_SIZE * 351, DATA_SIZE * 813};
   constexpr int NSIZES = 3;
+
   // Find recommended granularity for device
-	size_t granularity;
-	hipMemAllocationProp alloc_prop = {};
-	alloc_prop.type = hipMemAllocationTypePinned;
-	alloc_prop.location.type = hipMemLocationTypeDevice;
-	alloc_prop.location.id = 0;
-	HIP_CHECK(hipMemGetAllocationGranularity(&granularity, &alloc_prop, hipMemAllocationGranularityRecommended));
+  size_t granularity;
+  hipMemAllocationProp alloc_prop{};
+  alloc_prop.type = hipMemAllocationTypePinned;
+  alloc_prop.location.type = hipMemLocationTypeDevice;
+  alloc_prop.location.id = 0;
+  HIP_CHECK(hipMemGetAllocationGranularity(&granularity, &alloc_prop,
+                                          hipMemAllocationGranularityRecommended));
   INFO("Device recommended granularity : " << granularity);
 
-  // Reserve a 1 GB va range
-	constexpr size_t maxSize = 1ull << 30;
-	hipDeviceptr_t pool_addr;
-	HIP_CHECK(hipMemAddressReserve(reinterpret_cast<void**>(&pool_addr), maxSize, 0, 0, 0));
-	INFO("Reserved virtual memory pool at " << reinterpret_cast<void*>(pool_addr));
+  // Reserve a 1 GB VA range
+  constexpr size_t reservedSize = 1ull << 30;
+  hipDeviceptr_t pool_addr;
+  HIP_CHECK(hipMemAddressReserve(reinterpret_cast<void**>(&pool_addr), reservedSize, 0, 0, 0));
+  INFO("Reserved virtual memory pool at " << reinterpret_cast<void*>(pool_addr));
 
   std::vector<size_t> regions(NSIZES, 0);
-
-	for (size_t i = 0; i < NSIZES; ++i)
-	{
+  for (size_t i = 0; i < NSIZES; ++i) {
     size_t rounded = SIZES[i];
-		if(rounded %  granularity != 0)
-		{
-			rounded = granularity * ((rounded / granularity) + 1);
-		}
-		regions[i] = rounded;
+    if (rounded % granularity != 0) {
+      rounded = granularity * ((rounded / granularity) + 1);
+    }
+    regions[i] = rounded;
     INFO("Final Size at index " << i << " : " << regions[i]);
-	}
+  }
 
   // Initialize host buffer
   size_t max_size = *std::max_element(regions.begin(), regions.end());
@@ -1561,62 +1561,59 @@ TEST_CASE("Unit_hipMemSetAccess_MultipleOffsets") {
   REQUIRE(ptrA_h != nullptr);
   int* ptrB_h = static_cast<int*>(malloc(max_size));
   REQUIRE(ptrB_h != nullptr);
-  for (int idx = 0; idx < max_size / sizeof(int) ; idx++) {
+  for (int idx = 0; idx < static_cast<int>(max_size / sizeof(int)); ++idx) {
     ptrA_h[idx] = idx;
   }
 
-  hipMemAllocationProp prop = {};
-	prop.type = hipMemAllocationTypePinned;
-	prop.location.type = hipMemLocationTypeDevice;
-	prop.location.id = 0;
+  hipMemAllocationProp prop{};
+  prop.type = hipMemAllocationTypePinned;
+  prop.location.type = hipMemLocationTypeDevice;
+  prop.location.id = 0;
 
-	size_t pool_size = 0;
-	for (size_t i = 0; i < NSIZES; ++i)
-	{
-    // Creat phys memory handle and map to offsets of va range
-		hipMemGenericAllocationHandle_t handle;
-		HIP_CHECK(hipMemCreate(&handle, regions[i], &prop, 0));
+  size_t pool_size = 0;
+  for (size_t i = 0; i < NSIZES; ++i) {
+    // Create phys memory handle and map to offsets of VA range
+    hipMemGenericAllocationHandle_t handle;
+    HIP_CHECK(hipMemCreate(&handle, regions[i], &prop, 0));
+
     unsigned long long uiptr = reinterpret_cast<unsigned long long>(pool_addr);
     uiptr += pool_size;
-		HIP_CHECK(hipMemMap(reinterpret_cast<void*>(uiptr), regions[i], 0, handle, 0));
-		HIP_CHECK(hipMemRelease(handle));
+    HIP_CHECK(hipMemMap(reinterpret_cast<void*>(uiptr), regions[i], 0, handle, 0));
+    HIP_CHECK(hipMemRelease(handle));
 
-		hipMemAccessDesc access = {};
-		access.location.type = hipMemLocationTypeDevice;
-		access.location.id = 0;
-		access.flags = hipMemAccessFlagsProtReadWrite;
-    // Set Access for each offset of original va
-		HIP_CHECK(hipMemSetAccess(reinterpret_cast<void*>(uiptr), regions[i], &access, 1));
-		pool_size += regions[i];
+    hipMemAccessDesc access{};
+    access.location.type = hipMemLocationTypeDevice;
+    access.location.id = 0;
+    access.flags = hipMemAccessFlagsProtReadWrite;
+
+    // Set access for each offset of original VA
+    HIP_CHECK(hipMemSetAccess(reinterpret_cast<void*>(uiptr), regions[i], &access, 1));
+    pool_size += regions[i];
 
     // Copy host buffer to device
     HIP_CHECK(hipMemcpyHtoD(reinterpret_cast<void*>(uiptr), ptrA_h, regions[i]));
 
     // Verify device data
     HIP_CHECK(hipMemcpyDtoH(ptrB_h, reinterpret_cast<void*>(uiptr), regions[i]));
-    for (int idx = 0; idx < regions[i] / sizeof(int); idx++) {
+    for (int idx = 0; idx < static_cast<int>(regions[i] / sizeof(int)); ++idx) {
       REQUIRE(ptrB_h[idx] == idx);
     }
-	}
+  }
 
   // Unmap VMM
-	pool_size = 0;
-	for (size_t i = 0; i < NSIZES; ++i)
-	{
+  pool_size = 0;
+  for (size_t i = 0; i < NSIZES; ++i) {
     unsigned long long uiptr = reinterpret_cast<unsigned long long>(pool_addr);
     uiptr += pool_size;
-		HIP_CHECK(hipMemUnmap(reinterpret_cast<void*>(uiptr), regions[i]));
-		pool_size += regions[i];
-	}
+    HIP_CHECK(hipMemUnmap(reinterpret_cast<void*>(uiptr), regions[i]));
+    pool_size += regions[i];
+  }
 
-	HIP_CHECK(hipMemAddressFree(reinterpret_cast<void*>(pool_addr), maxSize));
+  HIP_CHECK(hipMemAddressFree(reinterpret_cast<void*>(pool_addr), reservedSize));
   free(ptrA_h);
   free(ptrB_h);
-	CTX_DESTROY();
+  CTX_DESTROY();
 }
-
-
-
 
 /**
  * End doxygen group VirtualMemoryManagementTest.


### PR DESCRIPTION
## Motivation

- SetMemAccess fails when access is set for multiple offsets of same va range

## Technical Details
- While setting access, either the size should match sub buffer size or it should match the accumulated size of all sub buffers
- Also check if the given address exists in sub buffer objects.
- for rocr path (linux and rocr-on-windows) check if the va is in memobject map before setting access

[## JIRA ID
](https://github.com/ROCm/rocm-systems/issues/2516)

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
- test added to map multiple phys memory handles of different sizes to same va range.
- setmemaccess is called for each va range offset seperately.
## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
