### PR TITLE
Fix disabled fortify source security flag

### DIFF
--- a/projects/amdsmi/cmake_modules/help_package.cmake
+++ b/projects/amdsmi/cmake_modules/help_package.cmake
@@ -54,7 +54,7 @@ function(generic_package)
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ASAN_LINKER_FLAGS}" PARENT_SCOPE)
     else()
         ## Security breach mitigation flags
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFORTIFY_SOURCE=2 -fstack-protector-all -Wcast-align" PARENT_SCOPE)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FORTIFY_SOURCE=2 -fstack-protector-all -Wcast-align" PARENT_SCOPE)
         ## More security breach mitigation flags
         set(HARDENING_LDFLAGS "${HARDENING_LDFLAGS} -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${HARDENING_LDFLAGS}" PARENT_SCOPE)

--- a/projects/rocm-smi-lib/CMakeLists.txt
+++ b/projects/rocm-smi-lib/CMakeLists.txt
@@ -1,4 +1,4 @@
- f#
+#
 # Minimum version of cmake and C++ required
 #
 message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")

--- a/projects/rocm-smi-lib/CMakeLists.txt
+++ b/projects/rocm-smi-lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-#
+ f#
 # Minimum version of cmake and C++ required
 #
 message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
@@ -145,7 +145,7 @@ if (${ADDRESS_SANITIZER})
 else ()
     ## Security breach mitigation flags
     set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} -DFORTIFY_SOURCE=2 -fstack-protector-all -Wcast-align")
+      "${CMAKE_CXX_FLAGS} -D_FORTIFY_SOURCE=2 -fstack-protector-all -Wcast-align")
     ## More security breach mitigation flags
     set(HARDENING_LDFLAGS
       "${HARDENING_LDFLAGS} -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now")

--- a/projects/rocm-smi-lib/cmake_modules/help_package.cmake
+++ b/projects/rocm-smi-lib/cmake_modules/help_package.cmake
@@ -54,7 +54,7 @@ function(generic_package)
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ASAN_LINKER_FLAGS}" PARENT_SCOPE)
     else()
         ## Security breach mitigation flags
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFORTIFY_SOURCE=2 -fstack-protector-all -Wcast-align" PARENT_SCOPE)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FORTIFY_SOURCE=2 -fstack-protector-all -Wcast-align" PARENT_SCOPE)
         ## More security breach mitigation flags
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-z,noexecstack -Wl,-znoexecheap -Wl,-z,relro" PARENT_SCOPE)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wtrampolines -Wl,-z,now -fPIE" PARENT_SCOPE)


### PR DESCRIPTION
## Motivation

Fix disabled fortify source disabled security flag
## Technical Details

Due to a mistake, this is not currently enabled as a base security flag

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
