### PR TITLE
Fix: Add visibility hidden to devInfoTypesStrings to prevent symbol i…

### DIFF
--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_device.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_device.h
@@ -276,6 +276,7 @@ class Device {
     auto dev_copy_internal_to_external_metrics(DevInfoTypes type = DevInfoTypes::kDevGpuMetrics)
         -> AMGpuMetricsPublicLatestTupl_t;
 
+    __attribute__((visibility("hidden")))
     static const std::map<DevInfoTypes, const char*> devInfoTypesStrings;
     void set_smi_device_id(uint32_t device_id) { m_device_id = device_id; }
     void set_smi_partition_id(uint32_t partition_id) { m_partition_id = partition_id; }


### PR DESCRIPTION
…nterposition

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Prevent double-free crash when both `libamd_smi.so` and `librocm_smi64.so` are loaded in the same process.

When using `rocprofiler-systems` (which uses `libamd_smi.so`) to profile applications that use RCCL (which uses `librocm_smi64.so`), the `Device::devInfoTypesStrings` static map symbol gets interposed between the two libraries. During process shutdown, both library destructors attempt to free the same memory, causing a double-free crash.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Added `__attribute__((visibility("hidden")))` to the `Device::devInfoTypesStrings` static member declaration.

**Root Cause:**
- `devInfoTypesStrings` is exported as a `GLOBAL DEFAULT` symbol in the dynamic symbol table
- When both `libamd_smi.so` and `librocm_smi64.so` are loaded, the dynamic linker interposes these symbols
- Both libraries' destructors then try to free the same memory during `__cxa_finalize`

**Fix:**
- `visibility("hidden")` prevents the symbol from being exported
- Each library maintains its own private instance of the static map
- No symbol interposition occurs, preventing the double-free

**Change:**
__attribute__((visibility("hidden")))
static const std::map<DevInfoTypes, const char*> devInfoTypesStrings;This is an internal implementation detail not part of the public API.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
1. Built amdsmi with the fix applied.
2. Verified symbol visibility using `readelf -Ws`:
    -  Before: `devInfoTypesStrings` visible as `GLOBAL DEFAULT`
    -  After: Symbol not in dynamic symbol table (hidden)
3. Ran rocprofiler-systems rccl-tests with profiling enabled

## Test Result

<!-- Briefly summarize test outcomes. -->
- 22/37 amdsmi tests passed
- 13 tests skipped (require elevated permissions for write operations)
- 2 tests failed (TempRead, TestFrequenciesRead) - pre-existing issues, unrelated to visibility change
- Symbol correctly hidden in `libamd_smi.so` (verified via `readelf`)
- rccl-test-all-reduce-perf-sampling passes without double-free crash

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
