### PR TITLE
SWDEV-574976 - Improve CAS and exchange test perf

### DIFF
--- a/projects/hip-tests/catch/unit/atomics/__hip_atomic_compare_exchange_strong.cc
+++ b/projects/hip-tests/catch/unit/atomics/__hip_atomic_compare_exchange_strong.cc
@@ -30,6 +30,54 @@ THE SOFTWARE.
  * @ingroup AtomicsTest
  */
 
+// Helper function to run __hip_atomic_compare_exchange_strong tests with WAVEFRONT scope
+template <typename TestType> static void runHipAtomicCompareExchangeStrongWavefrontTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinCAS,
+                                   __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinCAS,
+                                   __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinCAS,
+                                   __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size, cache_line_size);
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_compare_exchange_strong tests with WORKGROUP scope
+template <typename TestType> static void runHipAtomicCompareExchangeStrongWorkgroupTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinCAS,
+                                   __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinCAS,
+                                   __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinCAS,
+                                   __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size, cache_line_size);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -55,28 +103,15 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_compare_exchange_strong_Positive_Wavefront", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinCAS,
-                                   __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinCAS,
-                                   __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinCAS,
-                                   __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size, cache_line_size);
-    }
+TEST_CASE("Unit___hip_atomic_compare_exchange_strong_Positive_Wavefront") {
+  SECTION("int") { runHipAtomicCompareExchangeStrongWavefrontTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicCompareExchangeStrongWavefrontTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicCompareExchangeStrongWavefrontTest<unsigned long>(); }
+  SECTION("unsigned long long") {
+    runHipAtomicCompareExchangeStrongWavefrontTest<unsigned long long>();
   }
+  SECTION("float") { runHipAtomicCompareExchangeStrongWavefrontTest<float>(); }
+  SECTION("double") { runHipAtomicCompareExchangeStrongWavefrontTest<double>(); }
 }
 
 /**
@@ -104,28 +139,15 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_compare_exchange_strong_Positive_Wavefront
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_compare_exchange_strong_Positive_Workgroup", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinCAS,
-                                   __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinCAS,
-                                   __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinCAS,
-                                   __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size, cache_line_size);
-    }
+TEST_CASE("Unit___hip_atomic_compare_exchange_strong_Positive_Workgroup") {
+  SECTION("int") { runHipAtomicCompareExchangeStrongWorkgroupTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicCompareExchangeStrongWorkgroupTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicCompareExchangeStrongWorkgroupTest<unsigned long>(); }
+  SECTION("unsigned long long") {
+    runHipAtomicCompareExchangeStrongWorkgroupTest<unsigned long long>();
   }
+  SECTION("float") { runHipAtomicCompareExchangeStrongWorkgroupTest<float>(); }
+  SECTION("double") { runHipAtomicCompareExchangeStrongWorkgroupTest<double>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/__hip_atomic_exchange.cc
+++ b/projects/hip-tests/catch/unit/atomics/__hip_atomic_exchange.cc
@@ -31,6 +31,58 @@ THE SOFTWARE.
  *    - @ref Unit_AtomicBuiltins_Negative_Parameters_RTC
  */
 
+// Helper function to run __hip_atomic_exchange tests with WAVEFRONT scope
+template <typename TestType> static void runHipAtomicExchangeWavefrontTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      AtomicExchSingleDeviceSingleKernelTest<TestType, AtomicScopes::builtin,
+                                             __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      AtomicExchSingleDeviceSingleKernelTest<TestType, AtomicScopes::builtin,
+                                             __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
+                                                                           sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      AtomicExchSingleDeviceSingleKernelTest<TestType, AtomicScopes::builtin,
+                                             __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
+                                                                           cache_line_size);
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_exchange tests with WORKGROUP scope
+template <typename TestType> static void runHipAtomicExchangeWorkgroupTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      AtomicExchSingleDeviceSingleKernelTest<TestType, AtomicScopes::builtin,
+                                             __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      AtomicExchSingleDeviceSingleKernelTest<TestType, AtomicScopes::builtin,
+                                             __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
+                                                                           sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      AtomicExchSingleDeviceSingleKernelTest<TestType, AtomicScopes::builtin,
+                                             __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
+                                                                           cache_line_size);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -57,30 +109,13 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_exchange_Positive_Wavefront", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      AtomicExchSingleDeviceSingleKernelTest<TestType, AtomicScopes::builtin,
-                                             __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      AtomicExchSingleDeviceSingleKernelTest<TestType, AtomicScopes::builtin,
-                                             __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
-                                                                           sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      AtomicExchSingleDeviceSingleKernelTest<TestType, AtomicScopes::builtin,
-                                             __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
-                                                                           cache_line_size);
-    }
-  }
+TEST_CASE("Unit___hip_atomic_exchange_Positive_Wavefront") {
+  SECTION("int") { runHipAtomicExchangeWavefrontTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicExchangeWavefrontTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicExchangeWavefrontTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicExchangeWavefrontTest<unsigned long long>(); }
+  SECTION("float") { runHipAtomicExchangeWavefrontTest<float>(); }
+  SECTION("double") { runHipAtomicExchangeWavefrontTest<double>(); }
 }
 
 /**
@@ -109,30 +144,13 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_exchange_Positive_Wavefront", "", int, uns
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_exchange_Positive_Workgroup", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      AtomicExchSingleDeviceSingleKernelTest<TestType, AtomicScopes::builtin,
-                                             __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      AtomicExchSingleDeviceSingleKernelTest<TestType, AtomicScopes::builtin,
-                                             __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
-                                                                           sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      AtomicExchSingleDeviceSingleKernelTest<TestType, AtomicScopes::builtin,
-                                             __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
-                                                                           cache_line_size);
-    }
-  }
+TEST_CASE("Unit___hip_atomic_exchange_Positive_Workgroup") {
+  SECTION("int") { runHipAtomicExchangeWorkgroupTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicExchangeWorkgroupTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicExchangeWorkgroupTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicExchangeWorkgroupTest<unsigned long long>(); }
+  SECTION("float") { runHipAtomicExchangeWorkgroupTest<float>(); }
+  SECTION("double") { runHipAtomicExchangeWorkgroupTest<double>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/arithmetic_common.hh
+++ b/projects/hip-tests/catch/unit/atomics/arithmetic_common.hh
@@ -473,11 +473,9 @@ void TestCore(const TestParams& p) {
   Verify<TestType, operation>(p, res_vals, old_vals);
 }
 
-inline dim3 GenerateThreadDimensions() { return dim3(1024); }
+inline dim3 GenerateThreadDimensions() { return dim3(512); }
 
-inline dim3 GenerateBlockDimensions() {
-  return dim3(8);
-}
+inline dim3 GenerateBlockDimensions() { return dim3(4); }
 
 // Configures and creates the TestCore for a single device, and a single kernel launch
 template <typename TestType, AtomicOperation operation, int memory_scope = __HIP_MEMORY_SCOPE_AGENT>

--- a/projects/hip-tests/catch/unit/atomics/atomicCAS.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicCAS.cc
@@ -31,11 +31,49 @@ THE SOFTWARE.
  * @ingroup AtomicsTest
  */
 
-#ifdef HT_NVIDIA
-#define TYPES
-#else
-#define TYPES , float, double
-#endif
+// Helper function to run atomicCAS tests (single kernel)
+template <typename TestType> static void runAtomicCASTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kCASAdd>(1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kCASAdd>(warp_size, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kCASAdd>(warp_size, cache_line_size);
+    }
+  }
+}
+
+// Helper function to run atomicCAS tests (multiple kernels)
+template <typename TestType> static void runAtomicCASMultiKernelTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kCASAdd>(2, 1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kCASAdd>(2, warp_size,
+                                                                         sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kCASAdd>(2, warp_size,
+                                                                         cache_line_size);
+    }
+  }
+}
 
 /**
  * Test Description
@@ -62,25 +100,15 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicCAS_Positive", "", int, unsigned int, unsigned long long,
-                   unsigned short int TYPES) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kCASAdd>(1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kCASAdd>(warp_size, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kCASAdd>(warp_size, cache_line_size);
-    }
-  }
+TEST_CASE("Unit_atomicCAS_Positive") {
+  SECTION("int") { runAtomicCASTest<int>(); }
+  SECTION("unsigned int") { runAtomicCASTest<unsigned int>(); }
+  SECTION("unsigned long long") { runAtomicCASTest<unsigned long long>(); }
+  SECTION("unsigned short int") { runAtomicCASTest<unsigned short int>(); }
+#ifndef HT_NVIDIA
+  SECTION("float") { runAtomicCASTest<float>(); }
+  SECTION("double") { runAtomicCASTest<double>(); }
+#endif
 }
 
 /**
@@ -107,27 +135,15 @@ TEMPLATE_TEST_CASE("Unit_atomicCAS_Positive", "", int, unsigned int, unsigned lo
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicCAS_Positive_Multi_Kernel", "", int, unsigned int,
-                   unsigned long long, unsigned short int TYPES) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kCASAdd>(2, 1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kCASAdd>(2, warp_size,
-                                                                         sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kCASAdd>(2, warp_size,
-                                                                         cache_line_size);
-    }
-  }
+TEST_CASE("Unit_atomicCAS_Positive_Multi_Kernel") {
+  SECTION("int") { runAtomicCASMultiKernelTest<int>(); }
+  SECTION("unsigned int") { runAtomicCASMultiKernelTest<unsigned int>(); }
+  SECTION("unsigned long long") { runAtomicCASMultiKernelTest<unsigned long long>(); }
+  SECTION("unsigned short int") { runAtomicCASMultiKernelTest<unsigned short int>(); }
+#ifndef HT_NVIDIA
+  SECTION("float") { runAtomicCASMultiKernelTest<float>(); }
+  SECTION("double") { runAtomicCASMultiKernelTest<double>(); }
+#endif
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/atomicCAS_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicCAS_system.cc
@@ -67,16 +67,14 @@ TEMPLATE_TEST_CASE("Unit_atomicCAS_system_Positive_Peer_GPUs", "[multigpu]",
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kCASAddSystem>(
-          2, 2, 1, sizeof(TestType));
-    }
+  SECTION("Same address") {
+    MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kCASAddSystem>(
+        2, 2, 1, sizeof(TestType));
+  }
 
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kCASAddSystem>(
-          2, 2, warp_size, cache_line_size);
-    }
+  SECTION("Scattered addresses") {
+    MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kCASAddSystem>(
+        2, 2, warp_size, cache_line_size);
   }
 }
 
@@ -113,21 +111,19 @@ TEMPLATE_TEST_CASE("Unit_atomicCAS_system_Positive_Host_And_GPU", "[multigpu]",
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kCASAddSystem>(
-          1, 1, 1, sizeof(TestType), 4);
-    }
+  SECTION("Same address") {
+    MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kCASAddSystem>(
+        1, 1, 1, sizeof(TestType), 4);
+  }
 
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kCASAddSystem>(
-          1, 1, warp_size, sizeof(TestType), 4);
-    }
+  SECTION("Adjacent addresses") {
+    MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kCASAddSystem>(
+        1, 1, warp_size, sizeof(TestType), 4);
+  }
 
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kCASAddSystem>(
-          1, 1, warp_size, cache_line_size, 4);
-    }
+  SECTION("Scattered addresses") {
+    MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kCASAddSystem>(
+        1, 1, warp_size, cache_line_size, 4);
   }
 }
 
@@ -164,16 +160,14 @@ TEMPLATE_TEST_CASE("Unit_atomicCAS_system_Positive_Host_And_Peer_GPUs",
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kCASAddSystem>(
-          2, 2, 1, sizeof(TestType), 4);
-    }
+  SECTION("Same address") {
+    MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kCASAddSystem>(
+        2, 2, 1, sizeof(TestType), 4);
+  }
 
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kCASAddSystem>(
-          2, 2, warp_size, cache_line_size, 4);
-    }
+  SECTION("Scattered addresses") {
+    MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kCASAddSystem>(
+        2, 2, warp_size, cache_line_size, 4);
   }
 }
 

--- a/projects/hip-tests/catch/unit/atomics/atomicExch.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicExch.cc
@@ -29,6 +29,62 @@ THE SOFTWARE.
  * @ingroup AtomicsTest
  */
 
+// Helper function to run atomicExch tests for same address (compile time)
+template <typename TestType> static void runAtomicExchSameAddressCompileTimeTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Positive Same Address" << current) {
+      AtomicExchSameAddressTest<TestType, AtomicScopes::device>();
+    }
+  }
+}
+
+// Helper function to run atomicExch tests (single kernel)
+template <typename TestType> static void runAtomicExchTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      AtomicExchSingleDeviceSingleKernelTest<TestType, AtomicScopes::device>(1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      AtomicExchSingleDeviceSingleKernelTest<TestType, AtomicScopes::device>(warp_size,
+                                                                             sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      AtomicExchSingleDeviceSingleKernelTest<TestType, AtomicScopes::device>(warp_size,
+                                                                             cache_line_size);
+    }
+  }
+}
+
+// Helper function to run atomicExch tests (multi kernel)
+template <typename TestType> static void runAtomicExchMultiKernelTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      AtomicExchSingleDeviceMultipleKernelTest<TestType, AtomicScopes::device>(2, 1,
+                                                                               sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      AtomicExchSingleDeviceMultipleKernelTest<TestType, AtomicScopes::device>(2, warp_size,
+                                                                               sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      AtomicExchSingleDeviceMultipleKernelTest<TestType, AtomicScopes::device>(2, warp_size,
+                                                                               cache_line_size);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -50,18 +106,17 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-#if HT_NVIDIA
-TEMPLATE_TEST_CASE("Unit_atomicExch_Positive_Same_Address_Compile_Time", "", int, unsigned int,
-                   unsigned long long, float) {
-#else
-TEMPLATE_TEST_CASE("Unit_atomicExch_Positive_Same_Address_Compile_Time", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
-#endif  // HT_NVIDIA
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Positive Same Address" << current) {
-      AtomicExchSameAddressTest<TestType, AtomicScopes::device>();
-    }
-  }
+TEST_CASE("Unit_atomicExch_Positive_Same_Address_Compile_Time") {
+  SECTION("int") { runAtomicExchSameAddressCompileTimeTest<int>(); }
+  SECTION("unsigned int") { runAtomicExchSameAddressCompileTimeTest<unsigned int>(); }
+#ifndef HT_NVIDIA
+  SECTION("unsigned long") { runAtomicExchSameAddressCompileTimeTest<unsigned long>(); }
+#endif
+  SECTION("unsigned long long") { runAtomicExchSameAddressCompileTimeTest<unsigned long long>(); }
+  SECTION("float") { runAtomicExchSameAddressCompileTimeTest<float>(); }
+#ifndef HT_NVIDIA
+  SECTION("double") { runAtomicExchSameAddressCompileTimeTest<double>(); }
+#endif
 }
 
 /**
@@ -90,31 +145,17 @@ TEMPLATE_TEST_CASE("Unit_atomicExch_Positive_Same_Address_Compile_Time", "", int
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-#if HT_NVIDIA
-TEMPLATE_TEST_CASE("Unit_atomicExch_Positive", "", int, unsigned int, unsigned long long, float) {
-#else
-TEMPLATE_TEST_CASE("Unit_atomicExch_Positive", "", int, unsigned int, unsigned long,
-                   unsigned long long, float, double) {
-#endif  // HT_NVIDIA
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      AtomicExchSingleDeviceSingleKernelTest<TestType, AtomicScopes::device>(1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      AtomicExchSingleDeviceSingleKernelTest<TestType, AtomicScopes::device>(warp_size,
-                                                                             sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      AtomicExchSingleDeviceSingleKernelTest<TestType, AtomicScopes::device>(warp_size,
-                                                                             cache_line_size);
-    }
-  }
+TEST_CASE("Unit_atomicExch_Positive") {
+  SECTION("int") { runAtomicExchTest<int>(); }
+  SECTION("unsigned int") { runAtomicExchTest<unsigned int>(); }
+#ifndef HT_NVIDIA
+  SECTION("unsigned long") { runAtomicExchTest<unsigned long>(); }
+#endif
+  SECTION("unsigned long long") { runAtomicExchTest<unsigned long long>(); }
+  SECTION("float") { runAtomicExchTest<float>(); }
+#ifndef HT_NVIDIA
+  SECTION("double") { runAtomicExchTest<double>(); }
+#endif
 }
 
 /**
@@ -142,33 +183,17 @@ TEMPLATE_TEST_CASE("Unit_atomicExch_Positive", "", int, unsigned int, unsigned l
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-#if HT_NVIDIA
-TEMPLATE_TEST_CASE("Unit_atomicExch_Positive_Multi_Kernel", "", int, unsigned int,
-                   unsigned long long, float) {
-#else
-TEMPLATE_TEST_CASE("Unit_atomicExch_Positive_Multi_Kernel", "", int, unsigned int, unsigned long,
-                   unsigned long long, float, double) {
-#endif  // HT_NVIDIA
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      AtomicExchSingleDeviceMultipleKernelTest<TestType, AtomicScopes::device>(2, 1,
-                                                                               sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      AtomicExchSingleDeviceMultipleKernelTest<TestType, AtomicScopes::device>(2, warp_size,
-                                                                               sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      AtomicExchSingleDeviceMultipleKernelTest<TestType, AtomicScopes::device>(2, warp_size,
-                                                                               cache_line_size);
-    }
-  }
+TEST_CASE("Unit_atomicExch_Positive_Multi_Kernel") {
+  SECTION("int") { runAtomicExchMultiKernelTest<int>(); }
+  SECTION("unsigned int") { runAtomicExchMultiKernelTest<unsigned int>(); }
+#ifndef HT_NVIDIA
+  SECTION("unsigned long") { runAtomicExchMultiKernelTest<unsigned long>(); }
+#endif
+  SECTION("unsigned long long") { runAtomicExchMultiKernelTest<unsigned long long>(); }
+  SECTION("float") { runAtomicExchMultiKernelTest<float>(); }
+#ifndef HT_NVIDIA
+  SECTION("double") { runAtomicExchMultiKernelTest<double>(); }
+#endif
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/atomicExch_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicExch_system.cc
@@ -29,6 +29,74 @@ THE SOFTWARE.
  * @ingroup AtomicsTest
  */
 
+// Helper function to run atomicExch_system tests for peer GPUs
+template <typename TestType> static void runAtomicExchSystemPeerGPUsTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, 1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size,
+                                                                  sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size, cache_line_size);
+    }
+  }
+}
+
+// Helper function to run atomicExch_system tests for host and GPU
+template <typename TestType> static void runAtomicExchSystemHostAndGPUTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(1, 1, 1, sizeof(TestType), 4);
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(1, 1, warp_size, sizeof(TestType),
+                                                                  4);
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(1, 1, warp_size, cache_line_size,
+                                                                  4);
+    }
+  }
+}
+
+// Helper function to run atomicExch_system tests for host and peer GPUs
+template <typename TestType> static void runAtomicExchSystemHostAndPeerGPUsTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, 1, sizeof(TestType), 4);
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size, sizeof(TestType),
+                                                                  4);
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size, cache_line_size,
+                                                                  4);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -54,32 +122,17 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-#if HT_NVIDIA
-TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Peer_GPUs", "[multigpu]",
-                   int, unsigned int, unsigned long long, float) {
-#else
-TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Peer_GPUs", "[multigpu]",
-                   int, unsigned int, unsigned long, unsigned long long, float,
-                   double) {
-#endif  // HT_NVIDIA
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, 1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size,
-                                                                  sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size, cache_line_size);
-    }
-  }
+TEST_CASE("Unit_atomicExch_system_Positive_Peer_GPUs", "[multigpu]") {
+  SECTION("int") { runAtomicExchSystemPeerGPUsTest<int>(); }
+  SECTION("unsigned int") { runAtomicExchSystemPeerGPUsTest<unsigned int>(); }
+#ifndef HT_NVIDIA
+  SECTION("unsigned long") { runAtomicExchSystemPeerGPUsTest<unsigned long>(); }
+#endif
+  SECTION("unsigned long long") { runAtomicExchSystemPeerGPUsTest<unsigned long long>(); }
+  SECTION("float") { runAtomicExchSystemPeerGPUsTest<float>(); }
+#ifndef HT_NVIDIA
+  SECTION("double") { runAtomicExchSystemPeerGPUsTest<double>(); }
+#endif
 }
 
 /**
@@ -109,33 +162,17 @@ TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Peer_GPUs", "[multigpu]",
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-#if HT_NVIDIA
-TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Host_And_GPU", "[multigpu]",
-                   int, unsigned int, unsigned long long, float) {
-#else
-TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Host_And_GPU", "[multigpu]",
-                   int, unsigned int, unsigned long, unsigned long long, float,
-                   double) {
-#endif // HT_NVIDIA
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(1, 1, 1, sizeof(TestType), 4);
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(1, 1, warp_size, sizeof(TestType),
-                                                                  4);
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(1, 1, warp_size, cache_line_size,
-                                                                  4);
-    }
-  }
+TEST_CASE("Unit_atomicExch_system_Positive_Host_And_GPU", "[multigpu]") {
+  SECTION("int") { runAtomicExchSystemHostAndGPUTest<int>(); }
+  SECTION("unsigned int") { runAtomicExchSystemHostAndGPUTest<unsigned int>(); }
+#ifndef HT_NVIDIA
+  SECTION("unsigned long") { runAtomicExchSystemHostAndGPUTest<unsigned long>(); }
+#endif
+  SECTION("unsigned long long") { runAtomicExchSystemHostAndGPUTest<unsigned long long>(); }
+  SECTION("float") { runAtomicExchSystemHostAndGPUTest<float>(); }
+#ifndef HT_NVIDIA
+  SECTION("double") { runAtomicExchSystemHostAndGPUTest<double>(); }
+#endif
 }
 
 /**
@@ -165,33 +202,17 @@ TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Host_And_GPU", "[multigpu]",
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-#if HT_NVIDIA
-TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Host_And_Peer_GPUs",
-                   "[multigpu]", int, unsigned int, unsigned long long, float) {
-#else
-TEMPLATE_TEST_CASE("Unit_atomicExch_system_Positive_Host_And_Peer_GPUs",
-                   "[multigpu]", int, unsigned int, unsigned long,
-                   unsigned long long, float, double) {
-#endif  // HT_NVIDIA
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, 1, sizeof(TestType), 4);
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size, sizeof(TestType),
-                                                                  4);
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size, cache_line_size,
-                                                                  4);
-    }
-  }
+TEST_CASE("Unit_atomicExch_system_Positive_Host_And_Peer_GPUs", "[multigpu]") {
+  SECTION("int") { runAtomicExchSystemHostAndPeerGPUsTest<int>(); }
+  SECTION("unsigned int") { runAtomicExchSystemHostAndPeerGPUsTest<unsigned int>(); }
+#ifndef HT_NVIDIA
+  SECTION("unsigned long") { runAtomicExchSystemHostAndPeerGPUsTest<unsigned long>(); }
+#endif
+  SECTION("unsigned long long") { runAtomicExchSystemHostAndPeerGPUsTest<unsigned long long>(); }
+  SECTION("float") { runAtomicExchSystemHostAndPeerGPUsTest<float>(); }
+#ifndef HT_NVIDIA
+  SECTION("double") { runAtomicExchSystemHostAndPeerGPUsTest<double>(); }
+#endif
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/atomicExch_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicExch_system.cc
@@ -35,16 +35,16 @@ template <typename TestType> static void runAtomicExchSystemPeerGPUsTest() {
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
-  DYNAMIC_SECTION("Same address " << current) {
+  SECTION("Same address") {
     AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, 1, sizeof(TestType));
   }
 
-  DYNAMIC_SECTION("Adjacent addresses " << current) {
+  SECTION("Adjacent addresses") {
     AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size,
                                                                 sizeof(TestType));
   }
 
-  DYNAMIC_SECTION("Scattered addresses " << current) {
+  SECTION("Scattered addresses") {
     AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size, cache_line_size);
   }
 }
@@ -55,16 +55,16 @@ template <typename TestType> static void runAtomicExchSystemHostAndGPUTest() {
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
-  DYNAMIC_SECTION("Same address " << current) {
+  SECTION("Same address") {
     AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(1, 1, 1, sizeof(TestType), 4);
   }
 
-  DYNAMIC_SECTION("Adjacent addresses " << current) {
+  SECTION("Adjacent addresses") {
     AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(1, 1, warp_size, sizeof(TestType),
                                                                 4);
   }
 
-  DYNAMIC_SECTION("Scattered addresses " << current) {
+  SECTION("Scattered addresses") {
     AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(1, 1, warp_size, cache_line_size,
                                                                 4);
   }
@@ -76,16 +76,16 @@ template <typename TestType> static void runAtomicExchSystemHostAndPeerGPUsTest(
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
-  DYNAMIC_SECTION("Same address " << current) {
+  SECTION("Same address") {
     AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, 1, sizeof(TestType), 4);
   }
 
-  DYNAMIC_SECTION("Adjacent addresses " << current) {
+  SECTION("Adjacent addresses") {
     AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size, sizeof(TestType),
                                                                 4);
   }
 
-  DYNAMIC_SECTION("Scattered addresses " << current) {
+  SECTION("Scattered addresses") {
     AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size, cache_line_size,
                                                                 4);
   }

--- a/projects/hip-tests/catch/unit/atomics/atomicExch_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicExch_system.cc
@@ -35,19 +35,17 @@ template <typename TestType> static void runAtomicExchSystemPeerGPUsTest() {
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, 1, sizeof(TestType));
-    }
+  DYNAMIC_SECTION("Same address " << current) {
+    AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, 1, sizeof(TestType));
+  }
 
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size,
-                                                                  sizeof(TestType));
-    }
+  DYNAMIC_SECTION("Adjacent addresses " << current) {
+    AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size,
+                                                                sizeof(TestType));
+  }
 
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size, cache_line_size);
-    }
+  DYNAMIC_SECTION("Scattered addresses " << current) {
+    AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size, cache_line_size);
   }
 }
 
@@ -57,20 +55,18 @@ template <typename TestType> static void runAtomicExchSystemHostAndGPUTest() {
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(1, 1, 1, sizeof(TestType), 4);
-    }
+  DYNAMIC_SECTION("Same address " << current) {
+    AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(1, 1, 1, sizeof(TestType), 4);
+  }
 
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(1, 1, warp_size, sizeof(TestType),
-                                                                  4);
-    }
+  DYNAMIC_SECTION("Adjacent addresses " << current) {
+    AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(1, 1, warp_size, sizeof(TestType),
+                                                                4);
+  }
 
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(1, 1, warp_size, cache_line_size,
-                                                                  4);
-    }
+  DYNAMIC_SECTION("Scattered addresses " << current) {
+    AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(1, 1, warp_size, cache_line_size,
+                                                                4);
   }
 }
 
@@ -80,20 +76,18 @@ template <typename TestType> static void runAtomicExchSystemHostAndPeerGPUsTest(
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
 
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, 1, sizeof(TestType), 4);
-    }
+  DYNAMIC_SECTION("Same address " << current) {
+    AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, 1, sizeof(TestType), 4);
+  }
 
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size, sizeof(TestType),
-                                                                  4);
-    }
+  DYNAMIC_SECTION("Adjacent addresses " << current) {
+    AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size, sizeof(TestType),
+                                                                4);
+  }
 
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size, cache_line_size,
-                                                                  4);
-    }
+  DYNAMIC_SECTION("Scattered addresses " << current) {
+    AtomicExchMultipleDeviceMultipleKernelAndHostTest<TestType>(2, 2, warp_size, cache_line_size,
+                                                                4);
   }
 }
 


### PR DESCRIPTION
## Motivation

Currently the CI spend 75% of its time on tests that take less than 0.65 seconds. This means most of the runtime is initializing and de-initializing HIP.  This PR flattens the atomic CAS and exchange templated tests, so that we reduce the amount of time spent on HIP initialization and reduce the total runtime.

This PR also drops the CAS_system tests from taking 56 seconds to 4 seconds, by reducing the thread and block dimensions. Other than that change, there is no alteration in test coverage.

## Technical Details

We flatten TEMPLATE_TEST_CASE's into TEST_CASES and run each dtype inside a section.
CAS_system tests use thread dimensions of 512 and block dimensions of 4 now to dramatically reduce test runtime.

## JIRA ID

Part of SWDEV-574976

## Test Plan

Refactor in testing, does not need its own tests

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
