### PR TITLE
SWDEV-574976 - Improve Or/Xor/And test perf

### DIFF
--- a/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_and.cc
+++ b/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_and.cc
@@ -30,6 +30,90 @@ THE SOFTWARE.
  * @ingroup AtomicsTest
  */
 
+// Helper function to run __hip_atomic_fetch_and tests for WAVEFRONT scope, same address
+template <typename TestType>
+static void runHipAtomicFetchAndWavefrontSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
+                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_and tests for WAVEFRONT scope, adjacent addresses
+template <typename TestType>
+static void runHipAtomicFetchAndWavefrontAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
+                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
+                                                                          sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_and tests for WAVEFRONT scope, scattered addresses
+template <typename TestType>
+static void runHipAtomicFetchAndWavefrontScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
+                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
+                                                                          cache_line_size);
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_and tests for WORKGROUP scope, same address
+template <typename TestType>
+static void runHipAtomicFetchAndWorkgroupSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
+                                            __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_and tests for WORKGROUP scope, adjacent addresses
+template <typename TestType>
+static void runHipAtomicFetchAndWorkgroupAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
+                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
+                                                                          sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_and tests for WORKGROUP scope, scattered addresses
+template <typename TestType>
+static void runHipAtomicFetchAndWorkgroupScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
+                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
+                                                                          cache_line_size);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -43,14 +127,11 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Wavefront_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
-                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Wavefront_SameAddress") {
+  SECTION("int") { runHipAtomicFetchAndWavefrontSameAddressTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchAndWavefrontSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchAndWavefrontSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchAndWavefrontSameAddressTest<unsigned long long>(); }
 }
 
 /**
@@ -66,18 +147,11 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Wavefront_SameAddress",
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Wavefront_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
-                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
-                                                                          sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Wavefront_Adjacent_Addresses") {
+  SECTION("int") { runHipAtomicFetchAndWavefrontAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchAndWavefrontAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchAndWavefrontAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchAndWavefrontAdjacentAddressesTest<unsigned long long>(); }
 }
 
 /**
@@ -93,19 +167,11 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Wavefront_Adjacent_Addr
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Wavefront_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
-                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
-                                                                          cache_line_size);
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Wavefront_Scattered_Addresses") {
+  SECTION("int") { runHipAtomicFetchAndWavefrontScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchAndWavefrontScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchAndWavefrontScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchAndWavefrontScatteredAddressesTest<unsigned long long>(); }
 }
 
 /**
@@ -121,14 +187,11 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Wavefront_Scattered_Add
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Workgroup_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
-                                            __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Workgroup_SameAddress") {
+  SECTION("int") { runHipAtomicFetchAndWorkgroupSameAddressTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchAndWorkgroupSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchAndWorkgroupSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchAndWorkgroupSameAddressTest<unsigned long long>(); }
 }
 
 /**
@@ -144,18 +207,11 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Workgroup_SameAddress",
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Workgroup_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
-                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
-                                                                          sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Workgroup_Adjacent_Addresses") {
+  SECTION("int") { runHipAtomicFetchAndWorkgroupAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchAndWorkgroupAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchAndWorkgroupAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchAndWorkgroupAdjacentAddressesTest<unsigned long long>(); }
 }
 
 /**
@@ -171,19 +227,11 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Workgroup_Adjacent_Addr
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Workgroup_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinAnd,
-                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
-                                                                          cache_line_size);
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_and_Positive_Workgroup_Scattered_Addresses") {
+  SECTION("int") { runHipAtomicFetchAndWorkgroupScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchAndWorkgroupScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchAndWorkgroupScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchAndWorkgroupScatteredAddressesTest<unsigned long long>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_or.cc
+++ b/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_or.cc
@@ -30,6 +30,90 @@ THE SOFTWARE.
  * @ingroup AtomicsTest
  */
 
+// Helper function to run __hip_atomic_fetch_or tests for WAVEFRONT scope, same address
+template <typename TestType>
+static void runHipAtomicFetchOrWavefrontSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
+                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_or tests for WAVEFRONT scope, adjacent addresses
+template <typename TestType>
+static void runHipAtomicFetchOrWavefrontAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
+                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
+                                                                          sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_or tests for WAVEFRONT scope, scattered addresses
+template <typename TestType>
+static void runHipAtomicFetchOrWavefrontScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
+                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
+                                                                          cache_line_size);
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_or tests for WORKGROUP scope, same address
+template <typename TestType>
+static void runHipAtomicFetchOrWorkgroupSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
+                                            __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_or tests for WORKGROUP scope, adjacent addresses
+template <typename TestType>
+static void runHipAtomicFetchOrWorkgroupAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
+                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
+                                                                          sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_or tests for WORKGROUP scope, scattered addresses
+template <typename TestType>
+static void runHipAtomicFetchOrWorkgroupScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
+                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
+                                                                          cache_line_size);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -43,14 +127,11 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Wavefront_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
-                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Wavefront_SameAddress") {
+  SECTION("int") { runHipAtomicFetchOrWavefrontSameAddressTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchOrWavefrontSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchOrWavefrontSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchOrWavefrontSameAddressTest<unsigned long long>(); }
 }
 
 /**
@@ -66,18 +147,11 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Wavefront_SameAddress", 
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Wavefront_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
-                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
-                                                                          sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Wavefront_Adjacent_Addresses") {
+  SECTION("int") { runHipAtomicFetchOrWavefrontAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchOrWavefrontAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchOrWavefrontAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchOrWavefrontAdjacentAddressesTest<unsigned long long>(); }
 }
 
 /**
@@ -93,19 +167,11 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Wavefront_Adjacent_Addre
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Wavefront_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
-                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
-                                                                          cache_line_size);
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Wavefront_Scattered_Addresses") {
+  SECTION("int") { runHipAtomicFetchOrWavefrontScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchOrWavefrontScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchOrWavefrontScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchOrWavefrontScatteredAddressesTest<unsigned long long>(); }
 }
 
 /**
@@ -121,14 +187,11 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Wavefront_Scattered_Addr
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Workgroup_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
-                                            __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Workgroup_SameAddress") {
+  SECTION("int") { runHipAtomicFetchOrWorkgroupSameAddressTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchOrWorkgroupSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchOrWorkgroupSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchOrWorkgroupSameAddressTest<unsigned long long>(); }
 }
 
 /**
@@ -144,18 +207,11 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Workgroup_SameAddress", 
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Workgroup_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
-                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
-                                                                          sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Workgroup_Adjacent_Addresses") {
+  SECTION("int") { runHipAtomicFetchOrWorkgroupAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchOrWorkgroupAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchOrWorkgroupAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchOrWorkgroupAdjacentAddressesTest<unsigned long long>(); }
 }
 
 /**
@@ -171,19 +227,11 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Workgroup_Adjacent_Addre
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Workgroup_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinOr,
-                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
-                                                                          cache_line_size);
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_or_Positive_Workgroup_Scattered_Addresses") {
+  SECTION("int") { runHipAtomicFetchOrWorkgroupScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchOrWorkgroupScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchOrWorkgroupScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchOrWorkgroupScatteredAddressesTest<unsigned long long>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_xor.cc
+++ b/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_xor.cc
@@ -30,6 +30,90 @@ THE SOFTWARE.
  * @ingroup AtomicsTest
  */
 
+// Helper function to run __hip_atomic_fetch_xor tests for WAVEFRONT scope, same address
+template <typename TestType>
+static void runHipAtomicFetchXorWavefrontSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
+                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_xor tests for WAVEFRONT scope, adjacent addresses
+template <typename TestType>
+static void runHipAtomicFetchXorWavefrontAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
+                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
+                                                                          sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_xor tests for WAVEFRONT scope, scattered addresses
+template <typename TestType>
+static void runHipAtomicFetchXorWavefrontScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
+                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
+                                                                          cache_line_size);
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_xor tests for WORKGROUP scope, same address
+template <typename TestType>
+static void runHipAtomicFetchXorWorkgroupSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
+                                            __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_xor tests for WORKGROUP scope, adjacent addresses
+template <typename TestType>
+static void runHipAtomicFetchXorWorkgroupAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
+                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
+                                                                          sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_xor tests for WORKGROUP scope, scattered addresses
+template <typename TestType>
+static void runHipAtomicFetchXorWorkgroupScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
+                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
+                                                                          cache_line_size);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -43,14 +127,11 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Wavefront_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
-                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Wavefront_SameAddress") {
+  SECTION("int") { runHipAtomicFetchXorWavefrontSameAddressTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchXorWavefrontSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchXorWavefrontSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchXorWavefrontSameAddressTest<unsigned long long>(); }
 }
 
 /**
@@ -66,18 +147,11 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Wavefront_SameAddress",
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Wavefront_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
-                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
-                                                                          sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Wavefront_Adjacent_Addresses") {
+  SECTION("int") { runHipAtomicFetchXorWavefrontAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchXorWavefrontAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchXorWavefrontAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchXorWavefrontAdjacentAddressesTest<unsigned long long>(); }
 }
 
 /**
@@ -93,19 +167,11 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Wavefront_Adjacent_Addr
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Wavefront_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
-                                            __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
-                                                                          cache_line_size);
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Wavefront_Scattered_Addresses") {
+  SECTION("int") { runHipAtomicFetchXorWavefrontScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchXorWavefrontScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchXorWavefrontScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchXorWavefrontScatteredAddressesTest<unsigned long long>(); }
 }
 
 /**
@@ -121,14 +187,11 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Wavefront_Scattered_Add
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Workgroup_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
-                                            __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Workgroup_SameAddress") {
+  SECTION("int") { runHipAtomicFetchXorWorkgroupSameAddressTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchXorWorkgroupSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchXorWorkgroupSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchXorWorkgroupSameAddressTest<unsigned long long>(); }
 }
 
 /**
@@ -144,18 +207,11 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Workgroup_SameAddress",
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Workgroup_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
-                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
-                                                                          sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Workgroup_Adjacent_Addresses") {
+  SECTION("int") { runHipAtomicFetchXorWorkgroupAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchXorWorkgroupAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchXorWorkgroupAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchXorWorkgroupAdjacentAddressesTest<unsigned long long>(); }
 }
 
 /**
@@ -171,19 +227,11 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Workgroup_Adjacent_Addr
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Workgroup_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kBuiltinXor,
-                                            __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
-                                                                          cache_line_size);
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_xor_Positive_Workgroup_Scattered_Addresses") {
+  SECTION("int") { runHipAtomicFetchXorWorkgroupScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchXorWorkgroupScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchXorWorkgroupScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchXorWorkgroupScatteredAddressesTest<unsigned long long>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/atomicAnd.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicAnd.cc
@@ -33,20 +33,9 @@ THE SOFTWARE.
  * performs atomic bitwise AND between address and val, returns old value.
  */
 
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicAnd from multiple threads on the same address.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicAnd.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_SameAddress", "", int, unsigned int, unsigned long,
-                   unsigned long long) {
+// Helper function to run atomicAnd tests for same address (single kernel)
+template <typename TestType>
+static void runAtomicAndSameAddressTest() {
   for (auto current = 0; current < cmd_options.iterations; ++current) {
     DYNAMIC_SECTION("Same address " << current) {
       Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kAnd>(
@@ -55,20 +44,9 @@ TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_SameAddress", "", int, unsigned int,
   }
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicAnd from multiple threads on adjacent addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicAnd.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
+// Helper function to run atomicAnd tests for adjacent addresses (single kernel)
+template <typename TestType>
+static void runAtomicAndAdjacentAddressesTest() {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
 
@@ -80,20 +58,9 @@ TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Adjacent_Addresses", "", int, unsign
   }
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicAnd from multiple threads on the scattered addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicAnd.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Scattered_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
+// Helper function to run atomicAnd tests for scattered addresses (single kernel)
+template <typename TestType>
+static void runAtomicAndScatteredAddressesTest() {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
@@ -106,6 +73,103 @@ TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Scattered_Addresses", "", int, unsig
   }
 }
 
+// Helper function to run atomicAnd tests for same address (multiple kernels)
+template <typename TestType>
+static void runAtomicAndMultiKernelSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAnd>(
+          2, 1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicAnd tests for adjacent addresses (multiple kernels)
+template <typename TestType>
+static void runAtomicAndMultiKernelAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAnd>(
+          2, warp_size, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicAnd tests for scattered addresses (multiple kernels)
+template <typename TestType>
+static void runAtomicAndMultiKernelScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAnd>(
+          2, warp_size, cache_line_size);
+    }
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs atomicAnd from multiple threads on the same address.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/atomicAnd.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_atomicAnd_Positive_SameAddress") {
+  SECTION("int") { runAtomicAndSameAddressTest<int>(); }
+  SECTION("unsigned int") { runAtomicAndSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicAndSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicAndSameAddressTest<unsigned long long>(); }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs atomicAnd from multiple threads on adjacent addresses.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/atomicAnd.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_atomicAnd_Positive_Adjacent_Addresses") {
+  SECTION("int") { runAtomicAndAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicAndAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicAndAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicAndAdjacentAddressesTest<unsigned long long>(); }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs atomicAnd from multiple threads on the scattered addresses.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/atomicAnd.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_atomicAnd_Positive_Scattered_Addresses") {
+  SECTION("int") { runAtomicAndScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicAndScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicAndScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicAndScatteredAddressesTest<unsigned long long>(); }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -118,14 +182,11 @@ TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Scattered_Addresses", "", int, unsig
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Multi_Kernel_Same_Address", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAnd>(
-          2, 1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_atomicAnd_Positive_Multi_Kernel_Same_Address") {
+  SECTION("int") { runAtomicAndMultiKernelSameAddressTest<int>(); }
+  SECTION("unsigned int") { runAtomicAndMultiKernelSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicAndMultiKernelSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicAndMultiKernelSameAddressTest<unsigned long long>(); }
 }
 
 /**
@@ -140,16 +201,12 @@ TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Multi_Kernel_Same_Address", "", int,
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Multi_Kernel_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAnd>(
-          2, warp_size, sizeof(TestType));
-    }
+TEST_CASE("Unit_atomicAnd_Positive_Multi_Kernel_Adjacent_Addresses") {
+  SECTION("int") { runAtomicAndMultiKernelAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicAndMultiKernelAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicAndMultiKernelAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") {
+    runAtomicAndMultiKernelAdjacentAddressesTest<unsigned long long>();
   }
 }
 
@@ -165,17 +222,12 @@ TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Multi_Kernel_Adjacent_Addresses", ""
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicAnd_Positive_Multi_Kernel_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAnd>(
-          2, warp_size, cache_line_size);
-    }
+TEST_CASE("Unit_atomicAnd_Positive_Multi_Kernel_Scattered_Addresses") {
+  SECTION("int") { runAtomicAndMultiKernelScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicAndMultiKernelScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicAndMultiKernelScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") {
+    runAtomicAndMultiKernelScatteredAddressesTest<unsigned long long>();
   }
 }
 

--- a/projects/hip-tests/catch/unit/atomics/atomicAnd_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicAnd_system.cc
@@ -32,6 +32,46 @@ THE SOFTWARE.
  * performs system-wide atomic bitwise AND between address and val, returns old value.
  */
 
+// Helper function to run atomicAnd_system tests for same address
+template <typename TestType>
+static void runAtomicAndSystemSameAddressTest() {
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAndSystem>(
+          2, 2, 1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicAnd_system tests for adjacent addresses
+template <typename TestType>
+static void runAtomicAndSystemAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAndSystem>(
+          2, 2, warp_size, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicAnd_system tests for scattered addresses
+template <typename TestType>
+static void runAtomicAndSystemScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAndSystem>(
+          2, 2, warp_size, cache_line_size);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -45,15 +85,11 @@ THE SOFTWARE.
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicAnd_system_Positive_Peer_GPUs_Same_Address",
-                   "[multigpu]", int, unsigned int, unsigned long,
-                   unsigned long long) {
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAndSystem>(
-          2, 2, 1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_atomicAnd_system_Positive_Peer_GPUs_Same_Address", "[multigpu]") {
+  SECTION("int") { runAtomicAndSystemSameAddressTest<int>(); }
+  SECTION("unsigned int") { runAtomicAndSystemSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicAndSystemSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicAndSystemSameAddressTest<unsigned long long>(); }
 }
 
 /**
@@ -69,18 +105,11 @@ TEMPLATE_TEST_CASE("Unit_atomicAnd_system_Positive_Peer_GPUs_Same_Address",
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE(
-    "Unit_atomicAnd_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]",
-    int, unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAndSystem>(
-          2, 2, warp_size, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_atomicAnd_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]") {
+  SECTION("int") { runAtomicAndSystemAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicAndSystemAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicAndSystemAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicAndSystemAdjacentAddressesTest<unsigned long long>(); }
 }
 
 /**
@@ -96,19 +125,11 @@ TEMPLATE_TEST_CASE(
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE(
-    "Unit_atomicAnd_system_Positive_Peer_GPUs_Scattered_Addresses",
-    "[multigpu]", int, unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kAndSystem>(
-          2, 2, warp_size, cache_line_size);
-    }
-  }
+TEST_CASE("Unit_atomicAnd_system_Positive_Peer_GPUs_Scattered_Addresses", "[multigpu]") {
+  SECTION("int") { runAtomicAndSystemScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicAndSystemScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicAndSystemScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicAndSystemScatteredAddressesTest<unsigned long long>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/atomicOr.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicOr.cc
@@ -33,20 +33,9 @@ THE SOFTWARE.
  * performs atomic bitwise OR between address and val, returns old value.
  */
 
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicOr from multiple threads on the same address.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicOr.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_SameAddress", "", int, unsigned int, unsigned long,
-                   unsigned long long) {
+// Helper function to run atomicOr tests for same address (single kernel)
+template <typename TestType>
+static void runAtomicOrSameAddressTest() {
   for (auto current = 0; current < cmd_options.iterations; ++current) {
     DYNAMIC_SECTION("Same address " << current) {
       Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kOr>(
@@ -55,20 +44,9 @@ TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_SameAddress", "", int, unsigned int, 
   }
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicOr from multiple threads on adjacent addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicOr.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
+// Helper function to run atomicOr tests for adjacent addresses (single kernel)
+template <typename TestType>
+static void runAtomicOrAdjacentAddressesTest() {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
 
@@ -80,20 +58,9 @@ TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Adjacent_Addresses", "", int, unsigne
   }
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicOr from multiple threads on the scattered addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicOr.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Scattered_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
+// Helper function to run atomicOr tests for scattered addresses (single kernel)
+template <typename TestType>
+static void runAtomicOrScatteredAddressesTest() {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
@@ -106,6 +73,103 @@ TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Scattered_Addresses", "", int, unsign
   }
 }
 
+// Helper function to run atomicOr tests for same address (multiple kernels)
+template <typename TestType>
+static void runAtomicOrMultiKernelSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOr>(
+          2, 1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicOr tests for adjacent addresses (multiple kernels)
+template <typename TestType>
+static void runAtomicOrMultiKernelAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOr>(
+          2, warp_size, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicOr tests for scattered addresses (multiple kernels)
+template <typename TestType>
+static void runAtomicOrMultiKernelScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOr>(
+          2, warp_size, cache_line_size);
+    }
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs atomicOr from multiple threads on the same address.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/atomicOr.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_atomicOr_Positive_SameAddress") {
+  SECTION("int") { runAtomicOrSameAddressTest<int>(); }
+  SECTION("unsigned int") { runAtomicOrSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicOrSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicOrSameAddressTest<unsigned long long>(); }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs atomicOr from multiple threads on adjacent addresses.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/atomicOr.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_atomicOr_Positive_Adjacent_Addresses") {
+  SECTION("int") { runAtomicOrAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicOrAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicOrAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicOrAdjacentAddressesTest<unsigned long long>(); }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs atomicOr from multiple threads on the scattered addresses.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/atomicOr.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_atomicOr_Positive_Scattered_Addresses") {
+  SECTION("int") { runAtomicOrScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicOrScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicOrScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicOrScatteredAddressesTest<unsigned long long>(); }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -118,14 +182,11 @@ TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Scattered_Addresses", "", int, unsign
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Multi_Kernel_Same_Address", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOr>(
-          2, 1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_atomicOr_Positive_Multi_Kernel_Same_Address") {
+  SECTION("int") { runAtomicOrMultiKernelSameAddressTest<int>(); }
+  SECTION("unsigned int") { runAtomicOrMultiKernelSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicOrMultiKernelSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicOrMultiKernelSameAddressTest<unsigned long long>(); }
 }
 
 /**
@@ -140,16 +201,12 @@ TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Multi_Kernel_Same_Address", "", int, 
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Multi_Kernel_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOr>(
-          2, warp_size, sizeof(TestType));
-    }
+TEST_CASE("Unit_atomicOr_Positive_Multi_Kernel_Adjacent_Addresses") {
+  SECTION("int") { runAtomicOrMultiKernelAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicOrMultiKernelAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicOrMultiKernelAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") {
+    runAtomicOrMultiKernelAdjacentAddressesTest<unsigned long long>();
   }
 }
 
@@ -165,17 +222,12 @@ TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Multi_Kernel_Adjacent_Addresses", "",
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicOr_Positive_Multi_Kernel_Scattered_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOr>(
-          2, warp_size, cache_line_size);
-    }
+TEST_CASE("Unit_atomicOr_Positive_Multi_Kernel_Scattered_Addresses") {
+  SECTION("int") { runAtomicOrMultiKernelScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicOrMultiKernelScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicOrMultiKernelScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") {
+    runAtomicOrMultiKernelScatteredAddressesTest<unsigned long long>();
   }
 }
 

--- a/projects/hip-tests/catch/unit/atomics/atomicOr_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicOr_system.cc
@@ -32,6 +32,46 @@ THE SOFTWARE.
  * performs system-wide atomic bitwise OR between address and val, returns old value.
  */
 
+// Helper function to run atomicOr_system tests for same address
+template <typename TestType>
+static void runAtomicOrSystemSameAddressTest() {
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOrSystem>(
+          2, 2, 1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicOr_system tests for adjacent addresses
+template <typename TestType>
+static void runAtomicOrSystemAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOrSystem>(
+          2, 2, warp_size, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicOr_system tests for scattered addresses
+template <typename TestType>
+static void runAtomicOrSystemScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOrSystem>(
+          2, 2, warp_size, cache_line_size);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -45,15 +85,11 @@ THE SOFTWARE.
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicOr_system_Positive_Peer_GPUs_Same_Address",
-                   "[multigpu]", int, unsigned int, unsigned long,
-                   unsigned long long) {
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOrSystem>(
-          2, 2, 1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_atomicOr_system_Positive_Peer_GPUs_Same_Address", "[multigpu]") {
+  SECTION("int") { runAtomicOrSystemSameAddressTest<int>(); }
+  SECTION("unsigned int") { runAtomicOrSystemSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicOrSystemSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicOrSystemSameAddressTest<unsigned long long>(); }
 }
 
 /**
@@ -69,18 +105,11 @@ TEMPLATE_TEST_CASE("Unit_atomicOr_system_Positive_Peer_GPUs_Same_Address",
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicOr_system_Positive_Peer_GPUs_Adjacent_Addresses",
-                   "[multigpu]", int, unsigned int, unsigned long,
-                   unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOrSystem>(
-          2, 2, warp_size, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_atomicOr_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]") {
+  SECTION("int") { runAtomicOrSystemAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicOrSystemAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicOrSystemAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicOrSystemAdjacentAddressesTest<unsigned long long>(); }
 }
 
 /**
@@ -96,19 +125,11 @@ TEMPLATE_TEST_CASE("Unit_atomicOr_system_Positive_Peer_GPUs_Adjacent_Addresses",
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE(
-    "Unit_atomicOr_system_Positive_Peer_GPUs_Scattered_Addresses", "[multigpu]",
-    int, unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kOrSystem>(
-          2, 2, warp_size, cache_line_size);
-    }
-  }
+TEST_CASE("Unit_atomicOr_system_Positive_Peer_GPUs_Scattered_Addresses", "[multigpu]") {
+  SECTION("int") { runAtomicOrSystemScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicOrSystemScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicOrSystemScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicOrSystemScatteredAddressesTest<unsigned long long>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/atomicXor.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicXor.cc
@@ -33,20 +33,9 @@ THE SOFTWARE.
  * performs atomic bitwise XOR between address and val, returns old value.
  */
 
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicXor from multiple threads on the same address.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicXor.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_SameAddress", "", int, unsigned int, unsigned long,
-                   unsigned long long) {
+// Helper function to run atomicXor tests for same address (single kernel)
+template <typename TestType>
+static void runAtomicXorSameAddressTest() {
   for (auto current = 0; current < cmd_options.iterations; ++current) {
     DYNAMIC_SECTION("Same address " << current) {
       Bitwise::SingleDeviceSingleKernelTest<TestType, Bitwise::AtomicOperation::kXor>(
@@ -55,20 +44,9 @@ TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_SameAddress", "", int, unsigned int,
   }
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicXor from multiple threads on adjacent addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicXor.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
+// Helper function to run atomicXor tests for adjacent addresses (single kernel)
+template <typename TestType>
+static void runAtomicXorAdjacentAddressesTest() {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
 
@@ -80,20 +58,9 @@ TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Adjacent_Addresses", "", int, unsign
   }
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicXor from multiple threads on the scattered addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicXor.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Scattered_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
+// Helper function to run atomicXor tests for scattered addresses (single kernel)
+template <typename TestType>
+static void runAtomicXorScatteredAddressesTest() {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
@@ -106,6 +73,103 @@ TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Scattered_Addresses", "", int, unsig
   }
 }
 
+// Helper function to run atomicXor tests for same address (multiple kernels)
+template <typename TestType>
+static void runAtomicXorMultiKernelSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXor>(
+          2, 1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicXor tests for adjacent addresses (multiple kernels)
+template <typename TestType>
+static void runAtomicXorMultiKernelAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXor>(
+          2, warp_size, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicXor tests for scattered addresses (multiple kernels)
+template <typename TestType>
+static void runAtomicXorMultiKernelScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXor>(
+          2, warp_size, cache_line_size);
+    }
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs atomicXor from multiple threads on the same address.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/atomicXor.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_atomicXor_Positive_SameAddress") {
+  SECTION("int") { runAtomicXorSameAddressTest<int>(); }
+  SECTION("unsigned int") { runAtomicXorSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicXorSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicXorSameAddressTest<unsigned long long>(); }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs atomicXor from multiple threads on adjacent addresses.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/atomicXor.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_atomicXor_Positive_Adjacent_Addresses") {
+  SECTION("int") { runAtomicXorAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicXorAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicXorAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicXorAdjacentAddressesTest<unsigned long long>(); }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs atomicXor from multiple threads on the scattered addresses.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/atomicXor.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_atomicXor_Positive_Scattered_Addresses") {
+  SECTION("int") { runAtomicXorScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicXorScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicXorScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicXorScatteredAddressesTest<unsigned long long>(); }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -118,14 +182,11 @@ TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Scattered_Addresses", "", int, unsig
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Multi_Kernel_Same_Address", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXor>(
-          2, 1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_atomicXor_Positive_Multi_Kernel_Same_Address") {
+  SECTION("int") { runAtomicXorMultiKernelSameAddressTest<int>(); }
+  SECTION("unsigned int") { runAtomicXorMultiKernelSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicXorMultiKernelSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicXorMultiKernelSameAddressTest<unsigned long long>(); }
 }
 
 /**
@@ -140,15 +201,12 @@ TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Multi_Kernel_Same_Address", "", int,
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Multi_Kernel_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXor>(
-          2, warp_size, sizeof(TestType));
-    }
+TEST_CASE("Unit_atomicXor_Positive_Multi_Kernel_Adjacent_Addresses") {
+  SECTION("int") { runAtomicXorMultiKernelAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicXorMultiKernelAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicXorMultiKernelAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") {
+    runAtomicXorMultiKernelAdjacentAddressesTest<unsigned long long>();
   }
 }
 
@@ -164,17 +222,12 @@ TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Multi_Kernel_Adjacent_Addresses", ""
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicXor_Positive_Multi_Kernel_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      Bitwise::SingleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXor>(
-          2, warp_size, cache_line_size);
-    }
+TEST_CASE("Unit_atomicXor_Positive_Multi_Kernel_Scattered_Addresses") {
+  SECTION("int") { runAtomicXorMultiKernelScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicXorMultiKernelScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicXorMultiKernelScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") {
+    runAtomicXorMultiKernelScatteredAddressesTest<unsigned long long>();
   }
 }
 

--- a/projects/hip-tests/catch/unit/atomics/atomicXor_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicXor_system.cc
@@ -32,6 +32,46 @@ THE SOFTWARE.
  * performs system-wide atomic bitwise XOR between address and val, returns old value.
  */
 
+// Helper function to run atomicXor_system tests for same address
+template <typename TestType>
+static void runAtomicXorSystemSameAddressTest() {
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXorSystem>(
+          2, 2, 1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicXor_system tests for adjacent addresses
+template <typename TestType>
+static void runAtomicXorSystemAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXorSystem>(
+          2, 2, warp_size, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicXor_system tests for scattered addresses
+template <typename TestType>
+static void runAtomicXorSystemScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXorSystem>(
+          2, 2, warp_size, cache_line_size);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -45,15 +85,11 @@ THE SOFTWARE.
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicXor_system_Positive_Peer_GPUs_Same_Address",
-                   "[multigpu]", int, unsigned int, unsigned long,
-                   unsigned long long) {
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXorSystem>(
-          2, 2, 1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_atomicXor_system_Positive_Peer_GPUs_Same_Address", "[multigpu]") {
+  SECTION("int") { runAtomicXorSystemSameAddressTest<int>(); }
+  SECTION("unsigned int") { runAtomicXorSystemSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicXorSystemSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicXorSystemSameAddressTest<unsigned long long>(); }
 }
 
 /**
@@ -69,18 +105,11 @@ TEMPLATE_TEST_CASE("Unit_atomicXor_system_Positive_Peer_GPUs_Same_Address",
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE(
-    "Unit_atomicXor_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]",
-    int, unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXorSystem>(
-          2, 2, warp_size, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_atomicXor_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]") {
+  SECTION("int") { runAtomicXorSystemAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicXorSystemAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicXorSystemAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicXorSystemAdjacentAddressesTest<unsigned long long>(); }
 }
 
 /**
@@ -96,19 +125,11 @@ TEMPLATE_TEST_CASE(
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE(
-    "Unit_atomicXor_system_Positive_Peer_GPUs_Scattered_Addresses",
-    "[multigpu]", int, unsigned int, unsigned long, unsigned long long) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      Bitwise::MultipleDeviceMultipleKernelTest<TestType, Bitwise::AtomicOperation::kXorSystem>(
-          2, 2, warp_size, cache_line_size);
-    }
-  }
+TEST_CASE("Unit_atomicXor_system_Positive_Peer_GPUs_Scattered_Addresses", "[multigpu]") {
+  SECTION("int") { runAtomicXorSystemScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicXorSystemScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicXorSystemScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicXorSystemScatteredAddressesTest<unsigned long long>(); }
 }
 
 /**


### PR DESCRIPTION
## Motivation

Currently the CI spend 75% of its time on tests that take less than 0.65 seconds. This means most of the runtime is initializing and de-initializing HIP.  This PR flattens the atomic OR, XOR, AND test cases to reduce time spent initializing the runtime.

## Technical Details

We flatten TEMPLATE_TEST_CASE's into TEST_CASES and run each dtype inside a section.

## JIRA ID

Part of SWDEV-574976

## Test Plan

Refactor in testing, does not need its own tests

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
