### PR TITLE
SWDEV-574976 - Improve Add and Sub test performance

### DIFF
--- a/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_add.cc
+++ b/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_add.cc
@@ -17,6 +17,56 @@
  *    - @ref Unit_AtomicBuiltins_Negative_Parameters_RTC
  */
 
+// Helper function to run __hip_atomic_fetch_add tests with WAVEFRONT scope
+template <typename TestType>
+static void runHipAtomicFetchAddWavefrontTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinAdd,
+                                   __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinAdd,
+                                   __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinAdd,
+                                   __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size, cache_line_size);
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_add tests with WORKGROUP scope
+template <typename TestType>
+static void runHipAtomicFetchAddWorkgroupTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinAdd,
+                                   __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinAdd,
+                                   __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinAdd,
+                                   __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size, cache_line_size);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -42,28 +92,13 @@
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-HIP_TEMPLATE_TEST_CASE(Unit___hip_atomic_fetch_add_Positive_Wavefront, int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinAdd,
-                                   __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinAdd,
-                                   __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinAdd,
-                                   __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size, cache_line_size);
-    }
-  }
+HIP_TEST_CASE(Unit___hip_atomic_fetch_add_Positive_Wavefront) {
+  SECTION("int") { runHipAtomicFetchAddWavefrontTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchAddWavefrontTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchAddWavefrontTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchAddWavefrontTest<unsigned long long>(); }
+  SECTION("float") { runHipAtomicFetchAddWavefrontTest<float>(); }
+  SECTION("double") { runHipAtomicFetchAddWavefrontTest<double>(); }
 }
 
 /**
@@ -91,28 +126,13 @@ HIP_TEMPLATE_TEST_CASE(Unit___hip_atomic_fetch_add_Positive_Wavefront, int, unsi
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-HIP_TEMPLATE_TEST_CASE(Unit___hip_atomic_fetch_add_Positive_Workgroup, int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinAdd,
-                                   __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinAdd,
-                                   __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kBuiltinAdd,
-                                   __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size, cache_line_size);
-    }
-  }
+HIP_TEST_CASE(Unit___hip_atomic_fetch_add_Positive_Workgroup) {
+  SECTION("int") { runHipAtomicFetchAddWorkgroupTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchAddWorkgroupTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchAddWorkgroupTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchAddWorkgroupTest<unsigned long long>(); }
+  SECTION("float") { runHipAtomicFetchAddWorkgroupTest<float>(); }
+  SECTION("double") { runHipAtomicFetchAddWorkgroupTest<double>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/atomicAdd.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicAdd.cc
@@ -15,6 +15,52 @@
  * @ingroup AtomicsTest
  */
 
+// Helper function to run atomicAdd tests (single kernel)
+template <typename TestType>
+static void runAtomicAddTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kAdd>(1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kAdd>(warp_size, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kAdd>(warp_size, cache_line_size);
+    }
+  }
+}
+
+// Helper function to run atomicAdd tests (multiple kernels)
+template <typename TestType>
+static void runAtomicAddMultiKernelTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kAdd>(2, 1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kAdd>(2, warp_size,
+                                                                      sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kAdd>(2, warp_size,
+                                                                      cache_line_size);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -40,25 +86,13 @@
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-HIP_TEMPLATE_TEST_CASE(Unit_atomicAdd_Positive, int, unsigned int, unsigned long,
-                   unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kAdd>(1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kAdd>(warp_size, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kAdd>(warp_size, cache_line_size);
-    }
-  }
+HIP_TEST_CASE(Unit_atomicAdd_Positive) {
+  SECTION("int") { runAtomicAddTest<int>(); }
+  SECTION("unsigned int") { runAtomicAddTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicAddTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicAddTest<unsigned long long>(); }
+  SECTION("float") { runAtomicAddTest<float>(); }
+  SECTION("double") { runAtomicAddTest<double>(); }
 }
 
 /**
@@ -85,27 +119,13 @@ HIP_TEMPLATE_TEST_CASE(Unit_atomicAdd_Positive, int, unsigned int, unsigned long
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-HIP_TEMPLATE_TEST_CASE(Unit_atomicAdd_Positive_Multi_Kernel, int, unsigned int, unsigned long,
-                   unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kAdd>(2, 1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kAdd>(2, warp_size,
-                                                                      sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kAdd>(2, warp_size,
-                                                                      cache_line_size);
-    }
-  }
+HIP_TEST_CASE(Unit_atomicAdd_Positive_Multi_Kernel) {
+  SECTION("int") { runAtomicAddMultiKernelTest<int>(); }
+  SECTION("unsigned int") { runAtomicAddMultiKernelTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicAddMultiKernelTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicAddMultiKernelTest<unsigned long long>(); }
+  SECTION("float") { runAtomicAddMultiKernelTest<float>(); }
+  SECTION("double") { runAtomicAddMultiKernelTest<double>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/atomicAdd_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicAdd_system.cc
@@ -14,6 +14,81 @@
  * @ingroup AtomicsTest
  */
 
+// Helper function to run atomicAdd_system tests for peer GPUs
+template <typename TestType>
+static void runAtomicAddSystemPeerGPUsTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kAddSystem>(
+          2, 2, 1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kAddSystem>(
+          2, 2, warp_size, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kAddSystem>(
+          2, 2, warp_size, cache_line_size);
+    }
+  }
+}
+
+// Helper function to run atomicAdd_system tests for host and GPU
+template <typename TestType>
+static void runAtomicAddSystemHostAndGPUTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kAddSystem>(
+          1, 1, 1, sizeof(TestType), 4);
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kAddSystem>(
+          1, 1, warp_size, sizeof(TestType), 4);
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kAddSystem>(
+          1, 1, warp_size, cache_line_size, 4);
+    }
+  }
+}
+
+// Helper function to run atomicAdd_system tests for host and peer GPUs
+template <typename TestType>
+static void runAtomicAddSystemHostAndPeerGPUsTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kAddSystem>(
+          2, 2, 1, sizeof(TestType), 4);
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kAddSystem>(
+          2, 2, warp_size, sizeof(TestType), 4);
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kAddSystem>(
+          2, 2, warp_size, cache_line_size, 4);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -38,29 +113,13 @@
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-HIP_TEMPLATE_TEST_CASE(Unit_atomicAdd_system_Positive_Peer_GPUs,
-                   int, unsigned int, unsigned long, unsigned long long, float,
-                   double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kAddSystem>(
-          2, 2, 1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kAddSystem>(
-          2, 2, warp_size, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kAddSystem>(
-          2, 2, warp_size, cache_line_size);
-    }
-  }
+HIP_TEST_CASE(Unit_atomicAdd_system_Positive_Peer_GPUs) {
+  SECTION("int") { runAtomicAddSystemPeerGPUsTest<int>(); }
+  SECTION("unsigned int") { runAtomicAddSystemPeerGPUsTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicAddSystemPeerGPUsTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicAddSystemPeerGPUsTest<unsigned long long>(); }
+  SECTION("float") { runAtomicAddSystemPeerGPUsTest<float>(); }
+  SECTION("double") { runAtomicAddSystemPeerGPUsTest<double>(); }
 }
 
 /**
@@ -88,29 +147,13 @@ HIP_TEMPLATE_TEST_CASE(Unit_atomicAdd_system_Positive_Peer_GPUs,
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-HIP_TEMPLATE_TEST_CASE(Unit_atomicAdd_system_Positive_Host_And_GPU,
-                   int, unsigned int, unsigned long, unsigned long long, float,
-                   double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kAddSystem>(
-          1, 1, 1, sizeof(TestType), 4);
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kAddSystem>(
-          1, 1, warp_size, sizeof(TestType), 4);
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kAddSystem>(
-          1, 1, warp_size, cache_line_size, 4);
-    }
-  }
+HIP_TEST_CASE(Unit_atomicAdd_system_Positive_Host_And_GPU) {
+  SECTION("int") { runAtomicAddSystemHostAndGPUTest<int>(); }
+  SECTION("unsigned int") { runAtomicAddSystemHostAndGPUTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicAddSystemHostAndGPUTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicAddSystemHostAndGPUTest<unsigned long long>(); }
+  SECTION("float") { runAtomicAddSystemHostAndGPUTest<float>(); }
+  SECTION("double") { runAtomicAddSystemHostAndGPUTest<double>(); }
 }
 
 /**
@@ -138,29 +181,13 @@ HIP_TEMPLATE_TEST_CASE(Unit_atomicAdd_system_Positive_Host_And_GPU,
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-HIP_TEMPLATE_TEST_CASE(Unit_atomicAdd_system_Positive_Host_And_Peer_GPUs,
-                   int, unsigned int, unsigned long,
-                   unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kAddSystem>(
-          2, 2, 1, sizeof(TestType), 4);
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kAddSystem>(
-          2, 2, warp_size, sizeof(TestType), 4);
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kAddSystem>(
-          2, 2, warp_size, cache_line_size, 4);
-    }
-  }
+HIP_TEST_CASE(Unit_atomicAdd_system_Positive_Host_And_Peer_GPUs) {
+  SECTION("int") { runAtomicAddSystemHostAndPeerGPUsTest<int>(); }
+  SECTION("unsigned int") { runAtomicAddSystemHostAndPeerGPUsTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicAddSystemHostAndPeerGPUsTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicAddSystemHostAndPeerGPUsTest<unsigned long long>(); }
+  SECTION("float") { runAtomicAddSystemHostAndPeerGPUsTest<float>(); }
+  SECTION("double") { runAtomicAddSystemHostAndPeerGPUsTest<double>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/atomicSub.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicSub.cc
@@ -15,6 +15,52 @@
  * @ingroup AtomicsTest
  */
 
+// Helper function to run atomicSub tests (single kernel)
+template <typename TestType>
+static void runAtomicSubTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kSub>(1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kSub>(warp_size, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kSub>(warp_size, cache_line_size);
+    }
+  }
+}
+
+// Helper function to run atomicSub tests (multiple kernels)
+template <typename TestType>
+static void runAtomicSubMultiKernelTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kSub>(2, 1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kSub>(2, warp_size,
+                                                                      sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kSub>(2, warp_size,
+                                                                      cache_line_size);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -40,25 +86,13 @@
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-HIP_TEMPLATE_TEST_CASE(Unit_atomicSub_Positive, int, unsigned int, unsigned long,
-                   unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kSub>(1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kSub>(warp_size, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kSub>(warp_size, cache_line_size);
-    }
-  }
+HIP_TEST_CASE(Unit_atomicSub_Positive) {
+  SECTION("int") { runAtomicSubTest<int>(); }
+  SECTION("unsigned int") { runAtomicSubTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicSubTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicSubTest<unsigned long long>(); }
+  SECTION("float") { runAtomicSubTest<float>(); }
+  SECTION("double") { runAtomicSubTest<double>(); }
 }
 
 /**
@@ -85,27 +119,13 @@ HIP_TEMPLATE_TEST_CASE(Unit_atomicSub_Positive, int, unsigned int, unsigned long
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-HIP_TEMPLATE_TEST_CASE(Unit_atomicSub_Positive_Multi_Kernel, int, unsigned int, unsigned long,
-                   unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kSub>(2, 1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kSub>(2, warp_size,
-                                                                      sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kSub>(2, warp_size,
-                                                                      cache_line_size);
-    }
-  }
+HIP_TEST_CASE(Unit_atomicSub_Positive_Multi_Kernel) {
+  SECTION("int") { runAtomicSubMultiKernelTest<int>(); }
+  SECTION("unsigned int") { runAtomicSubMultiKernelTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicSubMultiKernelTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicSubMultiKernelTest<unsigned long long>(); }
+  SECTION("float") { runAtomicSubMultiKernelTest<float>(); }
+  SECTION("double") { runAtomicSubMultiKernelTest<double>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/atomicSub_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicSub_system.cc
@@ -14,6 +14,81 @@
  * @ingroup AtomicsTest
  */
 
+// Helper function to run atomicSub_system tests for peer GPUs
+template <typename TestType>
+static void runAtomicSubSystemPeerGPUsTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kSubSystem>(
+          2, 2, 1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kSubSystem>(
+          2, 2, warp_size, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kSubSystem>(
+          2, 2, warp_size, cache_line_size);
+    }
+  }
+}
+
+// Helper function to run atomicSub_system tests for host and GPU
+template <typename TestType>
+static void runAtomicSubSystemHostAndGPUTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kSubSystem>(
+          1, 1, 1, sizeof(TestType), 4);
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kSubSystem>(
+          1, 1, warp_size, sizeof(TestType), 4);
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kSubSystem>(
+          1, 1, warp_size, cache_line_size, 4);
+    }
+  }
+}
+
+// Helper function to run atomicSub_system tests for host and peer GPUs
+template <typename TestType>
+static void runAtomicSubSystemHostAndPeerGPUsTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kSubSystem>(
+          2, 2, 1, sizeof(TestType), 4);
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kSubSystem>(
+          2, 2, warp_size, sizeof(TestType), 4);
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kSubSystem>(
+          2, 2, warp_size, cache_line_size, 4);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -38,29 +113,13 @@
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-HIP_TEMPLATE_TEST_CASE(Unit_atomicSub_system_Positive_Peer_GPUs,
-                   int, unsigned int, unsigned long, unsigned long long, float,
-                   double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kSubSystem>(
-          2, 2, 1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kSubSystem>(
-          2, 2, warp_size, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kSubSystem>(
-          2, 2, warp_size, cache_line_size);
-    }
-  }
+HIP_TEST_CASE(Unit_atomicSub_system_Positive_Peer_GPUs) {
+  SECTION("int") { runAtomicSubSystemPeerGPUsTest<int>(); }
+  SECTION("unsigned int") { runAtomicSubSystemPeerGPUsTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicSubSystemPeerGPUsTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicSubSystemPeerGPUsTest<unsigned long long>(); }
+  SECTION("float") { runAtomicSubSystemPeerGPUsTest<float>(); }
+  SECTION("double") { runAtomicSubSystemPeerGPUsTest<double>(); }
 }
 
 /**
@@ -88,29 +147,13 @@ HIP_TEMPLATE_TEST_CASE(Unit_atomicSub_system_Positive_Peer_GPUs,
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-HIP_TEMPLATE_TEST_CASE(Unit_atomicSub_system_Positive_Host_And_GPU,
-                   int, unsigned int, unsigned long, unsigned long long, float,
-                   double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kSubSystem>(
-          1, 1, 1, sizeof(TestType), 4);
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kSubSystem>(
-          1, 1, warp_size, sizeof(TestType), 4);
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kSubSystem>(
-          1, 1, warp_size, cache_line_size, 4);
-    }
-  }
+HIP_TEST_CASE(Unit_atomicSub_system_Positive_Host_And_GPU) {
+  SECTION("int") { runAtomicSubSystemHostAndGPUTest<int>(); }
+  SECTION("unsigned int") { runAtomicSubSystemHostAndGPUTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicSubSystemHostAndGPUTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicSubSystemHostAndGPUTest<unsigned long long>(); }
+  SECTION("float") { runAtomicSubSystemHostAndGPUTest<float>(); }
+  SECTION("double") { runAtomicSubSystemHostAndGPUTest<double>(); }
 }
 
 /**
@@ -138,29 +181,13 @@ HIP_TEMPLATE_TEST_CASE(Unit_atomicSub_system_Positive_Host_And_GPU,
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-HIP_TEMPLATE_TEST_CASE(Unit_atomicSub_system_Positive_Host_And_Peer_GPUs,
-                   int, unsigned int, unsigned long,
-                   unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kSubSystem>(
-          2, 2, 1, sizeof(TestType), 4);
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kSubSystem>(
-          2, 2, warp_size, sizeof(TestType), 4);
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      MultipleDeviceMultipleKernelAndHostTest<TestType, AtomicOperation::kSubSystem>(
-          2, 2, warp_size, cache_line_size, 4);
-    }
-  }
+HIP_TEST_CASE(Unit_atomicSub_system_Positive_Host_And_Peer_GPUs) {
+  SECTION("int") { runAtomicSubSystemHostAndPeerGPUsTest<int>(); }
+  SECTION("unsigned int") { runAtomicSubSystemHostAndPeerGPUsTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicSubSystemHostAndPeerGPUsTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicSubSystemHostAndPeerGPUsTest<unsigned long long>(); }
+  SECTION("float") { runAtomicSubSystemHostAndPeerGPUsTest<float>(); }
+  SECTION("double") { runAtomicSubSystemHostAndPeerGPUsTest<double>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/safeAtomicAdd.cc
+++ b/projects/hip-tests/catch/unit/atomics/safeAtomicAdd.cc
@@ -14,6 +14,53 @@
  * @ingroup AtomicsTest
  */
 
+// Helper function to run safeAtomicAdd tests (single kernel)
+template <typename TestType>
+static void runSafeAtomicAddTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kSafeAdd>(1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kSafeAdd>(warp_size,
+                                                                        sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kSafeAdd>(warp_size, cache_line_size);
+    }
+  }
+}
+
+// Helper function to run safeAtomicAdd tests (multiple kernels)
+template <typename TestType>
+static void runSafeAtomicAddMultiKernelTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kSafeAdd>(2, 1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kSafeAdd>(2, warp_size,
+                                                                          sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kSafeAdd>(2, warp_size,
+                                                                          cache_line_size);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -39,25 +86,9 @@
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-HIP_TEMPLATE_TEST_CASE(Unit_safeAtomicAdd_Positive, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kSafeAdd>(1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kSafeAdd>(warp_size,
-                                                                        sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kSafeAdd>(warp_size, cache_line_size);
-    }
-  }
+HIP_TEST_CASE(Unit_safeAtomicAdd_Positive) {
+  SECTION("float") { runSafeAtomicAddTest<float>(); }
+  SECTION("double") { runSafeAtomicAddTest<double>(); }
 }
 
 /**
@@ -84,26 +115,9 @@ HIP_TEMPLATE_TEST_CASE(Unit_safeAtomicAdd_Positive, float, double) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-HIP_TEMPLATE_TEST_CASE(Unit_safeAtomicAdd_Positive_Multi_Kernel, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kSafeAdd>(2, 1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kSafeAdd>(2, warp_size,
-                                                                          sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kSafeAdd>(2, warp_size,
-                                                                          cache_line_size);
-    }
-  }
+HIP_TEST_CASE(Unit_safeAtomicAdd_Positive_Multi_Kernel) {
+  SECTION("float") { runSafeAtomicAddMultiKernelTest<float>(); }
+  SECTION("double") { runSafeAtomicAddMultiKernelTest<double>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/unsafeAtomicAdd.cc
+++ b/projects/hip-tests/catch/unit/atomics/unsafeAtomicAdd.cc
@@ -17,6 +17,54 @@
  * @ingroup AtomicsTest
  */
 
+// Helper function to run unsafeAtomicAdd tests (single kernel)
+template <typename TestType>
+static void runUnsafeAtomicAddTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kUnsafeAdd>(1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kUnsafeAdd>(warp_size,
+                                                                          sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kUnsafeAdd>(warp_size,
+                                                                          cache_line_size);
+    }
+  }
+}
+
+// Helper function to run unsafeAtomicAdd tests (multi kernel)
+template <typename TestType>
+static void runUnsafeAtomicAddMultiKernelTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kUnsafeAdd>(2, 1, sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Adjacent addresses " << current) {
+      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kUnsafeAdd>(2, warp_size,
+                                                                            sizeof(TestType));
+    }
+
+    DYNAMIC_SECTION("Scattered addresses " << current) {
+      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kUnsafeAdd>(2, warp_size,
+                                                                            cache_line_size);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -42,26 +90,9 @@
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_Positive, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kUnsafeAdd>(1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kUnsafeAdd>(warp_size,
-                                                                          sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      SingleDeviceSingleKernelTest<TestType, AtomicOperation::kUnsafeAdd>(warp_size,
-                                                                          cache_line_size);
-    }
-  }
+HIP_TEST_CASE(Unit_unsafeAtomicAdd_Positive) {
+  SECTION("float") { runUnsafeAtomicAddTest<float>(); }
+  SECTION("double") { runUnsafeAtomicAddTest<double>(); }
 }
 
 /**
@@ -88,26 +119,9 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_Positive, float, double) {
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-HIP_TEMPLATE_TEST_CASE(Unit_unsafeAtomicAdd_Positive_Multi_Kernel, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kUnsafeAdd>(2, 1, sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Adjacent addresses " << current) {
-      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kUnsafeAdd>(2, warp_size,
-                                                                            sizeof(TestType));
-    }
-
-    DYNAMIC_SECTION("Scattered addresses " << current) {
-      SingleDeviceMultipleKernelTest<TestType, AtomicOperation::kUnsafeAdd>(2, warp_size,
-                                                                            cache_line_size);
-    }
-  }
+HIP_TEST_CASE(Unit_unsafeAtomicAdd_Positive_Multi_Kernel) {
+  SECTION("float") { runUnsafeAtomicAddMultiKernelTest<float>(); }
+  SECTION("double") { runUnsafeAtomicAddMultiKernelTest<double>(); }
 }
 
 template <typename Type,
@@ -119,8 +133,9 @@ __global__ void unsafe_add_kernel(Type* ptr, Type val) {
   (void)unsafeAtomicAdd(ptr, val);
 }
 
-HIP_TEMPLATE_TEST_CASE(Unit_unsafe_atomic_add_half_and_bfloat, __half2, __hip_bfloat162, __half,
-                   __hip_bfloat16) {
+// Helper function to run unsafe_atomic_add_half_and_bfloat tests
+template <typename TestType>
+static void runUnsafeAtomicAddHalfAndBfloatTest() {
   auto kernel = unsafe_add_kernel<TestType>;
   TestType val;
   if constexpr (std::is_same<TestType, __half2>::value) {
@@ -160,6 +175,13 @@ HIP_TEMPLATE_TEST_CASE(Unit_unsafe_atomic_add_half_and_bfloat, __half2, __hip_bf
   REQUIRE(hout.x == 32.0f);
   REQUIRE(hout.y == 64.0f);
   HIP_CHECK(hipFree(out));
+}
+
+TEST_CASE(Unit_unsafe_atomic_add_half_and_bfloat) {
+  SECTION("__half2") { runUnsafeAtomicAddHalfAndBfloatTest<__half2>(); }
+  SECTION("__hip_bfloat162") { runUnsafeAtomicAddHalfAndBfloatTest<__hip_bfloat162>(); }
+  SECTION("__half") { runUnsafeAtomicAddHalfAndBfloatTest<__half>(); }
+  SECTION("__hip_bfloat16") { runUnsafeAtomicAddHalfAndBfloatTest<__hip_bfloat16>(); }
 }
 
 /**


### PR DESCRIPTION
## Motivation

Currently the CI spend 75% of its time on tests that take less than 0.65 seconds. This means most of the runtime is initializing and de-initializing HIP.  This PR flattens the atomic Add and Sub test cases to reduce time spent initializing the runtime.

## Technical Details

We flatten TEMPLATE_TEST_CASE's into TEST_CASES and run each dtype inside a section.

## JIRA ID

Part of SWDEV-574976

## Test Plan

Refactor in testing, does not need its own tests

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
