### PR TITLE
SWDEV-574976 - Improve atomic min/max test perf

### DIFF
--- a/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_max.cc
+++ b/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_max.cc
@@ -30,6 +30,90 @@ THE SOFTWARE.
  * @ingroup AtomicsTest
  */
 
+// Helper function to run __hip_atomic_fetch_max tests for WAVEFRONT scope, same address
+template <typename TestType>
+static void runHipAtomicFetchMaxWavefrontSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
+                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_max tests for WAVEFRONT scope, adjacent addresses
+template <typename TestType>
+static void runHipAtomicFetchMaxWavefrontAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
+                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
+                                                                         sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_max tests for WAVEFRONT scope, scattered addresses
+template <typename TestType>
+static void runHipAtomicFetchMaxWavefrontScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
+                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
+                                                                         cache_line_size);
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_max tests for WORKGROUP scope, same address
+template <typename TestType>
+static void runHipAtomicFetchMaxWorkgroupSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
+                                           __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_max tests for WORKGROUP scope, adjacent addresses
+template <typename TestType>
+static void runHipAtomicFetchMaxWorkgroupAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
+                                           __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
+                                                                         sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_max tests for WORKGROUP scope, scattered addresses
+template <typename TestType>
+static void runHipAtomicFetchMaxWorkgroupScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
+                                           __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
+                                                                         cache_line_size);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -43,14 +127,13 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Wavefront_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
-                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Wavefront_SameAddress") {
+  SECTION("int") { runHipAtomicFetchMaxWavefrontSameAddressTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchMaxWavefrontSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchMaxWavefrontSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchMaxWavefrontSameAddressTest<unsigned long long>(); }
+  SECTION("float") { runHipAtomicFetchMaxWavefrontSameAddressTest<float>(); }
+  SECTION("double") { runHipAtomicFetchMaxWavefrontSameAddressTest<double>(); }
 }
 
 /**
@@ -66,18 +149,13 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Wavefront_SameAddress",
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Wavefront_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
-                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
-                                                                         sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Wavefront_Adjacent_Addresses") {
+  SECTION("int") { runHipAtomicFetchMaxWavefrontAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchMaxWavefrontAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchMaxWavefrontAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchMaxWavefrontAdjacentAddressesTest<unsigned long long>(); }
+  SECTION("float") { runHipAtomicFetchMaxWavefrontAdjacentAddressesTest<float>(); }
+  SECTION("double") { runHipAtomicFetchMaxWavefrontAdjacentAddressesTest<double>(); }
 }
 
 /**
@@ -93,19 +171,13 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Wavefront_Adjacent_Addr
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Wavefront_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
-                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
-                                                                         cache_line_size);
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Wavefront_Scattered_Addresses") {
+  SECTION("int") { runHipAtomicFetchMaxWavefrontScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchMaxWavefrontScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchMaxWavefrontScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchMaxWavefrontScatteredAddressesTest<unsigned long long>(); }
+  SECTION("float") { runHipAtomicFetchMaxWavefrontScatteredAddressesTest<float>(); }
+  SECTION("double") { runHipAtomicFetchMaxWavefrontScatteredAddressesTest<double>(); }
 }
 
 /**
@@ -121,14 +193,13 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Wavefront_Scattered_Add
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Workgroup_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
-                                           __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Workgroup_SameAddress") {
+  SECTION("int") { runHipAtomicFetchMaxWorkgroupSameAddressTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchMaxWorkgroupSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchMaxWorkgroupSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchMaxWorkgroupSameAddressTest<unsigned long long>(); }
+  SECTION("float") { runHipAtomicFetchMaxWorkgroupSameAddressTest<float>(); }
+  SECTION("double") { runHipAtomicFetchMaxWorkgroupSameAddressTest<double>(); }
 }
 
 /**
@@ -144,18 +215,13 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Workgroup_SameAddress",
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Workgroup_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
-                                           __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
-                                                                         sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Workgroup_Adjacent_Addresses") {
+  SECTION("int") { runHipAtomicFetchMaxWorkgroupAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchMaxWorkgroupAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchMaxWorkgroupAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchMaxWorkgroupAdjacentAddressesTest<unsigned long long>(); }
+  SECTION("float") { runHipAtomicFetchMaxWorkgroupAdjacentAddressesTest<float>(); }
+  SECTION("double") { runHipAtomicFetchMaxWorkgroupAdjacentAddressesTest<double>(); }
 }
 
 /**
@@ -171,19 +237,13 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Workgroup_Adjacent_Addr
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Workgroup_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMax,
-                                           __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
-                                                                         cache_line_size);
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_max_Positive_Workgroup_Scattered_Addresses") {
+  SECTION("int") { runHipAtomicFetchMaxWorkgroupScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchMaxWorkgroupScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchMaxWorkgroupScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchMaxWorkgroupScatteredAddressesTest<unsigned long long>(); }
+  SECTION("float") { runHipAtomicFetchMaxWorkgroupScatteredAddressesTest<float>(); }
+  SECTION("double") { runHipAtomicFetchMaxWorkgroupScatteredAddressesTest<double>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_min.cc
+++ b/projects/hip-tests/catch/unit/atomics/__hip_atomic_fetch_min.cc
@@ -30,6 +30,90 @@ THE SOFTWARE.
  * @ingroup AtomicsTest
  */
 
+// Helper function to run __hip_atomic_fetch_min tests for WAVEFRONT scope, same address
+template <typename TestType>
+static void runHipAtomicFetchMinWavefrontSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
+                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_min tests for WAVEFRONT scope, adjacent addresses
+template <typename TestType>
+static void runHipAtomicFetchMinWavefrontAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
+                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
+                                                                         sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_min tests for WAVEFRONT scope, scattered addresses
+template <typename TestType>
+static void runHipAtomicFetchMinWavefrontScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
+                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
+                                                                         cache_line_size);
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_min tests for WORKGROUP scope, same address
+template <typename TestType>
+static void runHipAtomicFetchMinWorkgroupSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
+                                           __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_min tests for WORKGROUP scope, adjacent addresses
+template <typename TestType>
+static void runHipAtomicFetchMinWorkgroupAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
+                                           __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
+                                                                         sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run __hip_atomic_fetch_min tests for WORKGROUP scope, scattered addresses
+template <typename TestType>
+static void runHipAtomicFetchMinWorkgroupScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
+                                           __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
+                                                                         cache_line_size);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -43,14 +127,13 @@ THE SOFTWARE.
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Wavefront_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
-                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Wavefront_SameAddress") {
+  SECTION("int") { runHipAtomicFetchMinWavefrontSameAddressTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchMinWavefrontSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchMinWavefrontSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchMinWavefrontSameAddressTest<unsigned long long>(); }
+  SECTION("float") { runHipAtomicFetchMinWavefrontSameAddressTest<float>(); }
+  SECTION("double") { runHipAtomicFetchMinWavefrontSameAddressTest<double>(); }
 }
 
 /**
@@ -66,18 +149,13 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Wavefront_SameAddress",
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Wavefront_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
-                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
-                                                                         sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Wavefront_Adjacent_Addresses") {
+  SECTION("int") { runHipAtomicFetchMinWavefrontAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchMinWavefrontAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchMinWavefrontAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchMinWavefrontAdjacentAddressesTest<unsigned long long>(); }
+  SECTION("float") { runHipAtomicFetchMinWavefrontAdjacentAddressesTest<float>(); }
+  SECTION("double") { runHipAtomicFetchMinWavefrontAdjacentAddressesTest<double>(); }
 }
 
 /**
@@ -93,19 +171,13 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Wavefront_Adjacent_Addr
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Wavefront_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
-                                           __HIP_MEMORY_SCOPE_WAVEFRONT>(warp_size,
-                                                                         cache_line_size);
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Wavefront_Scattered_Addresses") {
+  SECTION("int") { runHipAtomicFetchMinWavefrontScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchMinWavefrontScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchMinWavefrontScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchMinWavefrontScatteredAddressesTest<unsigned long long>(); }
+  SECTION("float") { runHipAtomicFetchMinWavefrontScatteredAddressesTest<float>(); }
+  SECTION("double") { runHipAtomicFetchMinWavefrontScatteredAddressesTest<double>(); }
 }
 
 /**
@@ -121,14 +193,13 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Wavefront_Scattered_Add
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Workgroup_SameAddress", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
-                                           __HIP_MEMORY_SCOPE_WORKGROUP>(1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Workgroup_SameAddress") {
+  SECTION("int") { runHipAtomicFetchMinWorkgroupSameAddressTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchMinWorkgroupSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchMinWorkgroupSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchMinWorkgroupSameAddressTest<unsigned long long>(); }
+  SECTION("float") { runHipAtomicFetchMinWorkgroupSameAddressTest<float>(); }
+  SECTION("double") { runHipAtomicFetchMinWorkgroupSameAddressTest<double>(); }
 }
 
 /**
@@ -144,18 +215,13 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Workgroup_SameAddress",
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Workgroup_Adjacent_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
-                                           __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
-                                                                         sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Workgroup_Adjacent_Addresses") {
+  SECTION("int") { runHipAtomicFetchMinWorkgroupAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchMinWorkgroupAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchMinWorkgroupAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchMinWorkgroupAdjacentAddressesTest<unsigned long long>(); }
+  SECTION("float") { runHipAtomicFetchMinWorkgroupAdjacentAddressesTest<float>(); }
+  SECTION("double") { runHipAtomicFetchMinWorkgroupAdjacentAddressesTest<double>(); }
 }
 
 /**
@@ -171,19 +237,13 @@ TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Workgroup_Adjacent_Addr
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Workgroup_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kBuiltinMin,
-                                           __HIP_MEMORY_SCOPE_WORKGROUP>(warp_size,
-                                                                         cache_line_size);
-    }
-  }
+TEST_CASE("Unit___hip_atomic_fetch_min_Positive_Workgroup_Scattered_Addresses") {
+  SECTION("int") { runHipAtomicFetchMinWorkgroupScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runHipAtomicFetchMinWorkgroupScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runHipAtomicFetchMinWorkgroupScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runHipAtomicFetchMinWorkgroupScatteredAddressesTest<unsigned long long>(); }
+  SECTION("float") { runHipAtomicFetchMinWorkgroupScatteredAddressesTest<float>(); }
+  SECTION("double") { runHipAtomicFetchMinWorkgroupScatteredAddressesTest<double>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/atomicMax.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicMax.cc
@@ -33,20 +33,9 @@ THE SOFTWARE.
  * calculates maximum between address and val, returns old value.
  */
 
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicMax from multiple threads on the same address.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_SameAddress", "", int, unsigned int, unsigned long,
-                   unsigned long long, float, double) {
+// Helper function to run atomicMax tests for same address (single kernel)
+template <typename TestType>
+static void runAtomicMaxSameAddressTest() {
   for (auto current = 0; current < cmd_options.iterations; ++current) {
     DYNAMIC_SECTION("Same address " << current) {
       MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kMax>(
@@ -55,20 +44,9 @@ TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_SameAddress", "", int, unsigned int,
   }
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicMax from multiple threads on adjacent addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
+// Helper function to run atomicMax tests for adjacent addresses (single kernel)
+template <typename TestType>
+static void runAtomicMaxAdjacentAddressesTest() {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
 
@@ -80,20 +58,9 @@ TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Adjacent_Addresses", "", int, unsign
   }
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicMax from multiple threads on the scaterred addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Scattered_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
+// Helper function to run atomicMax tests for scattered addresses (single kernel)
+template <typename TestType>
+static void runAtomicMaxScatteredAddressesTest() {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
@@ -106,6 +73,109 @@ TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Scattered_Addresses", "", int, unsig
   }
 }
 
+// Helper function to run atomicMax tests for same address (multiple kernels)
+template <typename TestType>
+static void runAtomicMaxMultiKernelSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMax>(
+          2, 1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicMax tests for adjacent addresses (multiple kernels)
+template <typename TestType>
+static void runAtomicMaxMultiKernelAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMax>(
+          2, warp_size, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicMax tests for scattered addresses (multiple kernels)
+template <typename TestType>
+static void runAtomicMaxMultiKernelScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMax>(
+          2, warp_size, cache_line_size);
+    }
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs atomicMax from multiple threads on the same address.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/atomicMax.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_atomicMax_Positive_SameAddress") {
+  SECTION("int") { runAtomicMaxSameAddressTest<int>(); }
+  SECTION("unsigned int") { runAtomicMaxSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicMaxSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicMaxSameAddressTest<unsigned long long>(); }
+  SECTION("float") { runAtomicMaxSameAddressTest<float>(); }
+  SECTION("double") { runAtomicMaxSameAddressTest<double>(); }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs atomicMax from multiple threads on adjacent addresses.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/atomicMax.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_atomicMax_Positive_Adjacent_Addresses") {
+  SECTION("int") { runAtomicMaxAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicMaxAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicMaxAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicMaxAdjacentAddressesTest<unsigned long long>(); }
+  SECTION("float") { runAtomicMaxAdjacentAddressesTest<float>(); }
+  SECTION("double") { runAtomicMaxAdjacentAddressesTest<double>(); }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs atomicMax from multiple threads on the scaterred addresses.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/atomicMax.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_atomicMax_Positive_Scattered_Addresses") {
+  SECTION("int") { runAtomicMaxScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicMaxScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicMaxScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicMaxScatteredAddressesTest<unsigned long long>(); }
+  SECTION("float") { runAtomicMaxScatteredAddressesTest<float>(); }
+  SECTION("double") { runAtomicMaxScatteredAddressesTest<double>(); }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -118,14 +188,13 @@ TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Scattered_Addresses", "", int, unsig
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Multi_Kernel_Same_Address", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMax>(
-          2, 1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_atomicMax_Positive_Multi_Kernel_Same_Address") {
+  SECTION("int") { runAtomicMaxMultiKernelSameAddressTest<int>(); }
+  SECTION("unsigned int") { runAtomicMaxMultiKernelSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicMaxMultiKernelSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicMaxMultiKernelSameAddressTest<unsigned long long>(); }
+  SECTION("float") { runAtomicMaxMultiKernelSameAddressTest<float>(); }
+  SECTION("double") { runAtomicMaxMultiKernelSameAddressTest<double>(); }
 }
 
 /**
@@ -140,17 +209,15 @@ TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Multi_Kernel_Same_Address", "", int,
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Multi_Kernel_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMax>(
-          2, warp_size, sizeof(TestType));
-    }
+TEST_CASE("Unit_atomicMax_Positive_Multi_Kernel_Adjacent_Addresses") {
+  SECTION("int") { runAtomicMaxMultiKernelAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicMaxMultiKernelAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicMaxMultiKernelAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") {
+    runAtomicMaxMultiKernelAdjacentAddressesTest<unsigned long long>();
   }
+  SECTION("float") { runAtomicMaxMultiKernelAdjacentAddressesTest<float>(); }
+  SECTION("double") { runAtomicMaxMultiKernelAdjacentAddressesTest<double>(); }
 }
 
 /**
@@ -165,18 +232,15 @@ TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Multi_Kernel_Adjacent_Addresses", ""
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicMax_Positive_Multi_Kernel_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMax>(
-          2, warp_size, cache_line_size);
-    }
+TEST_CASE("Unit_atomicMax_Positive_Multi_Kernel_Scattered_Addresses") {
+  SECTION("int") { runAtomicMaxMultiKernelScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicMaxMultiKernelScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicMaxMultiKernelScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") {
+    runAtomicMaxMultiKernelScatteredAddressesTest<unsigned long long>();
   }
+  SECTION("float") { runAtomicMaxMultiKernelScatteredAddressesTest<float>(); }
+  SECTION("double") { runAtomicMaxMultiKernelScatteredAddressesTest<double>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/atomicMax_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicMax_system.cc
@@ -32,6 +32,46 @@ THE SOFTWARE.
  * performs system-wide atomic maximum between address and val, returns old value.
  */
 
+// Helper function to run atomicMax_system tests for same address
+template <typename TestType>
+static void runAtomicMaxSystemSameAddressTest() {
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMaxSystem>(
+          2, 2, 1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicMax_system tests for adjacent addresses
+template <typename TestType>
+static void runAtomicMaxSystemAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMaxSystem>(
+          2, 2, warp_size, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicMax_system tests for scattered addresses
+template <typename TestType>
+static void runAtomicMaxSystemScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMaxSystem>(
+          2, 2, warp_size, cache_line_size);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -45,21 +85,15 @@ THE SOFTWARE.
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-#if HT_AMD
-TEMPLATE_TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs_Same_Address",
-                   "[multigpu]", int, unsigned int, unsigned long,
-                   unsigned long long, float, double) {
-#else
-TEMPLATE_TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs_Same_Address",
-                   "[multigpu]", int, unsigned int, unsigned long,
-                   unsigned long long) {
+TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs_Same_Address", "[multigpu]") {
+  SECTION("int") { runAtomicMaxSystemSameAddressTest<int>(); }
+  SECTION("unsigned int") { runAtomicMaxSystemSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicMaxSystemSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicMaxSystemSameAddressTest<unsigned long long>(); }
+#ifdef HT_AMD
+  SECTION("float") { runAtomicMaxSystemSameAddressTest<float>(); }
+  SECTION("double") { runAtomicMaxSystemSameAddressTest<double>(); }
 #endif
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMaxSystem>(
-          2, 2, 1, sizeof(TestType));
-    }
-  }
 }
 
 /**
@@ -75,24 +109,15 @@ TEMPLATE_TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs_Same_Address",
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-#if HT_AMD
-TEMPLATE_TEST_CASE(
-    "Unit_atomicMax_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]",
-    int, unsigned int, unsigned long, unsigned long long, float, double) {
-#else
-TEMPLATE_TEST_CASE(
-    "Unit_atomicMax_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]",
-    int, unsigned int, unsigned long, unsigned long long) {
+TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]") {
+  SECTION("int") { runAtomicMaxSystemAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicMaxSystemAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicMaxSystemAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicMaxSystemAdjacentAddressesTest<unsigned long long>(); }
+#ifdef HT_AMD
+  SECTION("float") { runAtomicMaxSystemAdjacentAddressesTest<float>(); }
+  SECTION("double") { runAtomicMaxSystemAdjacentAddressesTest<double>(); }
 #endif
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMaxSystem>(
-          2, 2, warp_size, sizeof(TestType));
-    }
-  }
 }
 
 /**
@@ -108,26 +133,15 @@ TEMPLATE_TEST_CASE(
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-#if HT_AMD
-TEMPLATE_TEST_CASE(
-    "Unit_atomicMax_system_Positive_Peer_GPUs_Scattered_Addresses",
-    "[multigpu]", int, unsigned int, unsigned long, unsigned long long, float,
-    double) {
-#else
-TEMPLATE_TEST_CASE(
-    "Unit_atomicMax_system_Positive_Peer_GPUs_Scattered_Addresses",
-    "[multigpu]", int, unsigned int, unsigned long, unsigned long long) {
+TEST_CASE("Unit_atomicMax_system_Positive_Peer_GPUs_Scattered_Addresses", "[multigpu]") {
+  SECTION("int") { runAtomicMaxSystemScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicMaxSystemScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicMaxSystemScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicMaxSystemScatteredAddressesTest<unsigned long long>(); }
+#ifdef HT_AMD
+  SECTION("float") { runAtomicMaxSystemScatteredAddressesTest<float>(); }
+  SECTION("double") { runAtomicMaxSystemScatteredAddressesTest<double>(); }
 #endif
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMaxSystem>(
-          2, 2, warp_size, cache_line_size);
-    }
-  }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/atomicMin.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicMin.cc
@@ -33,20 +33,9 @@ THE SOFTWARE.
  * calculates minimum between address and val, returns old value.
  */
 
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicMin from multiple threads on the same address.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_SameAddress", "", int, unsigned int, unsigned long,
-                   unsigned long long, float, double) {
+// Helper function to run atomicMin tests for same address (single kernel)
+template <typename TestType>
+static void runAtomicMinSameAddressTest() {
   for (auto current = 0; current < cmd_options.iterations; ++current) {
     DYNAMIC_SECTION("Same address " << current) {
       MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kMin>(
@@ -55,20 +44,9 @@ TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_SameAddress", "", int, unsigned int,
   }
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicMin from multiple threads on adjacent addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
+// Helper function to run atomicMin tests for adjacent addresses (single kernel)
+template <typename TestType>
+static void runAtomicMinAdjacentAddressesTest() {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
 
@@ -80,20 +58,9 @@ TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Adjacent_Addresses", "", int, unsign
   }
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Performs atomicMin from multiple threads on the scaterred addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/atomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Scattered_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
+// Helper function to run atomicMin tests for scattered addresses (single kernel)
+template <typename TestType>
+static void runAtomicMinScatteredAddressesTest() {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
@@ -106,6 +73,109 @@ TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Scattered_Addresses", "", int, unsig
   }
 }
 
+// Helper function to run atomicMin tests for same address (multiple kernels)
+template <typename TestType>
+static void runAtomicMinMultiKernelSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMin>(
+          2, 1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicMin tests for adjacent addresses (multiple kernels)
+template <typename TestType>
+static void runAtomicMinMultiKernelAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMin>(
+          2, warp_size, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicMin tests for scattered addresses (multiple kernels)
+template <typename TestType>
+static void runAtomicMinMultiKernelScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMin>(
+          2, warp_size, cache_line_size);
+    }
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs atomicMin from multiple threads on the same address.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/atomicMin.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_atomicMin_Positive_SameAddress") {
+  SECTION("int") { runAtomicMinSameAddressTest<int>(); }
+  SECTION("unsigned int") { runAtomicMinSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicMinSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicMinSameAddressTest<unsigned long long>(); }
+  SECTION("float") { runAtomicMinSameAddressTest<float>(); }
+  SECTION("double") { runAtomicMinSameAddressTest<double>(); }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs atomicMin from multiple threads on adjacent addresses.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/atomicMin.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_atomicMin_Positive_Adjacent_Addresses") {
+  SECTION("int") { runAtomicMinAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicMinAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicMinAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicMinAdjacentAddressesTest<unsigned long long>(); }
+  SECTION("float") { runAtomicMinAdjacentAddressesTest<float>(); }
+  SECTION("double") { runAtomicMinAdjacentAddressesTest<double>(); }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs atomicMin from multiple threads on the scaterred addresses.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/atomicMin.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_atomicMin_Positive_Scattered_Addresses") {
+  SECTION("int") { runAtomicMinScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicMinScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicMinScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicMinScatteredAddressesTest<unsigned long long>(); }
+  SECTION("float") { runAtomicMinScatteredAddressesTest<float>(); }
+  SECTION("double") { runAtomicMinScatteredAddressesTest<double>(); }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -118,14 +188,13 @@ TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Scattered_Addresses", "", int, unsig
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Multi_Kernel_Same_Address", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMin>(
-          2, 1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_atomicMin_Positive_Multi_Kernel_Same_Address") {
+  SECTION("int") { runAtomicMinMultiKernelSameAddressTest<int>(); }
+  SECTION("unsigned int") { runAtomicMinMultiKernelSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicMinMultiKernelSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicMinMultiKernelSameAddressTest<unsigned long long>(); }
+  SECTION("float") { runAtomicMinMultiKernelSameAddressTest<float>(); }
+  SECTION("double") { runAtomicMinMultiKernelSameAddressTest<double>(); }
 }
 
 /**
@@ -140,17 +209,15 @@ TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Multi_Kernel_Same_Address", "", int,
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Multi_Kernel_Adjacent_Addresses", "", int, unsigned int,
-                   unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMin>(
-          2, warp_size, sizeof(TestType));
-    }
+TEST_CASE("Unit_atomicMin_Positive_Multi_Kernel_Adjacent_Addresses") {
+  SECTION("int") { runAtomicMinMultiKernelAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicMinMultiKernelAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicMinMultiKernelAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") {
+    runAtomicMinMultiKernelAdjacentAddressesTest<unsigned long long>();
   }
+  SECTION("float") { runAtomicMinMultiKernelAdjacentAddressesTest<float>(); }
+  SECTION("double") { runAtomicMinMultiKernelAdjacentAddressesTest<double>(); }
 }
 
 /**
@@ -165,18 +232,15 @@ TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Multi_Kernel_Adjacent_Addresses", ""
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_atomicMin_Positive_Multi_Kernel_Scattered_Addresses", "", int,
-                   unsigned int, unsigned long, unsigned long long, float, double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMin>(
-          2, warp_size, cache_line_size);
-    }
+TEST_CASE("Unit_atomicMin_Positive_Multi_Kernel_Scattered_Addresses") {
+  SECTION("int") { runAtomicMinMultiKernelScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicMinMultiKernelScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicMinMultiKernelScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") {
+    runAtomicMinMultiKernelScatteredAddressesTest<unsigned long long>();
   }
+  SECTION("float") { runAtomicMinMultiKernelScatteredAddressesTest<float>(); }
+  SECTION("double") { runAtomicMinMultiKernelScatteredAddressesTest<double>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/atomicMin_system.cc
+++ b/projects/hip-tests/catch/unit/atomics/atomicMin_system.cc
@@ -32,6 +32,46 @@ THE SOFTWARE.
  * performs system-wide atomic minimum between address and val, returns old value.
  */
 
+// Helper function to run atomicMin_system tests for same address
+template <typename TestType>
+static void runAtomicMinSystemSameAddressTest() {
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMinSystem>(
+          2, 2, 1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicMin_system tests for adjacent addresses
+template <typename TestType>
+static void runAtomicMinSystemAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMinSystem>(
+          2, 2, warp_size, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run atomicMin_system tests for scattered addresses
+template <typename TestType>
+static void runAtomicMinSystemScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < 1; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMinSystem>(
+          2, 2, warp_size, cache_line_size);
+    }
+  }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -45,21 +85,15 @@ THE SOFTWARE.
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-#if HT_AMD
-TEMPLATE_TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs_Same_Address",
-                   "[multigpu]", int, unsigned int, unsigned long,
-                   unsigned long long, float, double) {
-#else
-TEMPLATE_TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs_Same_Address",
-                   "[multigpu]", int, unsigned int, unsigned long,
-                   unsigned long long) {
+TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs_Same_Address", "[multigpu]") {
+  SECTION("int") { runAtomicMinSystemSameAddressTest<int>(); }
+  SECTION("unsigned int") { runAtomicMinSystemSameAddressTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicMinSystemSameAddressTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicMinSystemSameAddressTest<unsigned long long>(); }
+#ifdef HT_AMD
+  SECTION("float") { runAtomicMinSystemSameAddressTest<float>(); }
+  SECTION("double") { runAtomicMinSystemSameAddressTest<double>(); }
 #endif
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMinSystem>(
-          2, 2, 1, sizeof(TestType));
-    }
-  }
 }
 
 /**
@@ -75,24 +109,15 @@ TEMPLATE_TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs_Same_Address",
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-#if HT_AMD
-TEMPLATE_TEST_CASE(
-    "Unit_atomicMin_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]",
-    int, unsigned int, unsigned long, unsigned long long, float, double) {
-#else
-TEMPLATE_TEST_CASE(
-    "Unit_atomicMin_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]",
-    int, unsigned int, unsigned long, unsigned long long) {
+TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs_Adjacent_Addresses", "[multigpu]") {
+  SECTION("int") { runAtomicMinSystemAdjacentAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicMinSystemAdjacentAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicMinSystemAdjacentAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicMinSystemAdjacentAddressesTest<unsigned long long>(); }
+#ifdef HT_AMD
+  SECTION("float") { runAtomicMinSystemAdjacentAddressesTest<float>(); }
+  SECTION("double") { runAtomicMinSystemAdjacentAddressesTest<double>(); }
 #endif
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMinSystem>(
-          2, 2, warp_size, sizeof(TestType));
-    }
-  }
 }
 
 /**
@@ -108,26 +133,15 @@ TEMPLATE_TEST_CASE(
  *  - Multi-device
  *  - HIP_VERSION >= 5.2
  */
-#if HT_AMD
-TEMPLATE_TEST_CASE(
-    "Unit_atomicMin_system_Positive_Peer_GPUs_Scattered_Addresses",
-    "[multigpu]", int, unsigned int, unsigned long, unsigned long long, float,
-    double) {
-#else
-TEMPLATE_TEST_CASE(
-    "Unit_atomicMin_system_Positive_Peer_GPUs_Scattered_Addresses",
-    "[multigpu]", int, unsigned int, unsigned long, unsigned long long) {
+TEST_CASE("Unit_atomicMin_system_Positive_Peer_GPUs_Scattered_Addresses", "[multigpu]") {
+  SECTION("int") { runAtomicMinSystemScatteredAddressesTest<int>(); }
+  SECTION("unsigned int") { runAtomicMinSystemScatteredAddressesTest<unsigned int>(); }
+  SECTION("unsigned long") { runAtomicMinSystemScatteredAddressesTest<unsigned long>(); }
+  SECTION("unsigned long long") { runAtomicMinSystemScatteredAddressesTest<unsigned long long>(); }
+#ifdef HT_AMD
+  SECTION("float") { runAtomicMinSystemScatteredAddressesTest<float>(); }
+  SECTION("double") { runAtomicMinSystemScatteredAddressesTest<double>(); }
 #endif
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < 1; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      MinMax::MultipleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kMinSystem>(
-          2, 2, warp_size, cache_line_size);
-    }
-  }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/safeAtomicMax.cc
+++ b/projects/hip-tests/catch/unit/atomics/safeAtomicMax.cc
@@ -32,19 +32,9 @@ THE SOFTWARE.
  * calculates maximum between address and val, returns old value.
  */
 
-/**
- * Test Description
- * ------------------------
- *  - Performs safeAtomicMax from multiple threads on the same address.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/safeAtomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_SameAddress", "", float, double) {
+// Helper function to run safeAtomicMax tests for same address (single kernel)
+template <typename TestType>
+static void runSafeAtomicMaxSameAddressTest() {
   for (auto current = 0; current < cmd_options.iterations; ++current) {
     DYNAMIC_SECTION("Same address " << current) {
       MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kSafeMax>(
@@ -53,19 +43,9 @@ TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_SameAddress", "", float, double)
   }
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Performs safeAtomicMax from multiple threads on adjacent addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/safeAtomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_Adjacent_Addresses", "", float, double) {
+// Helper function to run safeAtomicMax tests for adjacent addresses (single kernel)
+template <typename TestType>
+static void runSafeAtomicMaxAdjacentAddressesTest() {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
 
@@ -77,19 +57,9 @@ TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_Adjacent_Addresses", "", float, 
   }
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Performs safeAtomicMax from multiple threads on the scattered addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/safeAtomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_Scattered_Addresses", "", float, double) {
+// Helper function to run safeAtomicMax tests for scattered addresses (single kernel)
+template <typename TestType>
+static void runSafeAtomicMaxScatteredAddressesTest() {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
@@ -102,6 +72,97 @@ TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_Scattered_Addresses", "", float,
   }
 }
 
+// Helper function to run safeAtomicMax tests for same address (multiple kernels)
+template <typename TestType>
+static void runSafeAtomicMaxMultiKernelSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMax>(
+          2, 1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run safeAtomicMax tests for adjacent addresses (multiple kernels)
+template <typename TestType>
+static void runSafeAtomicMaxMultiKernelAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMax>(
+          2, warp_size, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run safeAtomicMax tests for scattered addresses (multiple kernels)
+template <typename TestType>
+static void runSafeAtomicMaxMultiKernelScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMax>(
+          2, warp_size, cache_line_size);
+    }
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs safeAtomicMax from multiple threads on the same address.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/safeAtomicMax.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_safeAtomicMax_Positive_SameAddress") {
+  SECTION("float") { runSafeAtomicMaxSameAddressTest<float>(); }
+  SECTION("double") { runSafeAtomicMaxSameAddressTest<double>(); }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs safeAtomicMax from multiple threads on adjacent addresses.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/safeAtomicMax.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_safeAtomicMax_Positive_Adjacent_Addresses") {
+  SECTION("float") { runSafeAtomicMaxAdjacentAddressesTest<float>(); }
+  SECTION("double") { runSafeAtomicMaxAdjacentAddressesTest<double>(); }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs safeAtomicMax from multiple threads on the scattered addresses.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/safeAtomicMax.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_safeAtomicMax_Positive_Scattered_Addresses") {
+  SECTION("float") { runSafeAtomicMaxScatteredAddressesTest<float>(); }
+  SECTION("double") { runSafeAtomicMaxScatteredAddressesTest<double>(); }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -114,13 +175,9 @@ TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_Scattered_Addresses", "", float,
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_Multi_Kernel_Same_Address", "", float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMax>(
-          2, 1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_safeAtomicMax_Positive_Multi_Kernel_Same_Address") {
+  SECTION("float") { runSafeAtomicMaxMultiKernelSameAddressTest<float>(); }
+  SECTION("double") { runSafeAtomicMaxMultiKernelSameAddressTest<double>(); }
 }
 
 /**
@@ -135,17 +192,9 @@ TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_Multi_Kernel_Same_Address", "", 
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_Multi_Kernel_Adjacent_Addresses", "", float,
-                   double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMax>(
-          2, warp_size, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_safeAtomicMax_Positive_Multi_Kernel_Adjacent_Addresses") {
+  SECTION("float") { runSafeAtomicMaxMultiKernelAdjacentAddressesTest<float>(); }
+  SECTION("double") { runSafeAtomicMaxMultiKernelAdjacentAddressesTest<double>(); }
 }
 
 /**
@@ -160,18 +209,9 @@ TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_Multi_Kernel_Adjacent_Addresses"
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMax_Positive_Multi_Kernel_Scattered_Addresses", "", float,
-                   double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMax>(
-          2, warp_size, cache_line_size);
-    }
-  }
+TEST_CASE("Unit_safeAtomicMax_Positive_Multi_Kernel_Scattered_Addresses") {
+  SECTION("float") { runSafeAtomicMaxMultiKernelScatteredAddressesTest<float>(); }
+  SECTION("double") { runSafeAtomicMaxMultiKernelScatteredAddressesTest<double>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/safeAtomicMin.cc
+++ b/projects/hip-tests/catch/unit/atomics/safeAtomicMin.cc
@@ -32,19 +32,9 @@ THE SOFTWARE.
  * calculates minimum between address and val, returns old value.
  */
 
-/**
- * Test Description
- * ------------------------
- *  - Performs safeAtomicMin from multiple threads on the same address.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/safeAtomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_SameAddress", "", float, double) {
+// Helper function to run safeAtomicMin tests for same address (single kernel)
+template <typename TestType>
+static void runSafeAtomicMinSameAddressTest() {
   for (auto current = 0; current < cmd_options.iterations; ++current) {
     DYNAMIC_SECTION("Same address " << current) {
       MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kSafeMin>(
@@ -53,19 +43,9 @@ TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_SameAddress", "", float, double)
   }
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Performs safeAtomicMin from multiple threads on adjacent addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/safeAtomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_Adjacent_Addresses", "", float, double) {
+// Helper function to run safeAtomicMin tests for adjacent addresses (single kernel)
+template <typename TestType>
+static void runSafeAtomicMinAdjacentAddressesTest() {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
 
@@ -77,19 +57,9 @@ TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_Adjacent_Addresses", "", float, 
   }
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Performs safeAtomicMin from multiple threads on the scattered addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/safeAtomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_Scattered_Addresses", "", float, double) {
+// Helper function to run safeAtomicMin tests for scattered addresses (single kernel)
+template <typename TestType>
+static void runSafeAtomicMinScatteredAddressesTest() {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
@@ -102,6 +72,97 @@ TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_Scattered_Addresses", "", float,
   }
 }
 
+// Helper function to run safeAtomicMin tests for same address (multiple kernels)
+template <typename TestType>
+static void runSafeAtomicMinMultiKernelSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMin>(
+          2, 1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run safeAtomicMin tests for adjacent addresses (multiple kernels)
+template <typename TestType>
+static void runSafeAtomicMinMultiKernelAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMin>(
+          2, warp_size, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run safeAtomicMin tests for scattered addresses (multiple kernels)
+template <typename TestType>
+static void runSafeAtomicMinMultiKernelScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMin>(
+          2, warp_size, cache_line_size);
+    }
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs safeAtomicMin from multiple threads on the same address.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/safeAtomicMin.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_safeAtomicMin_Positive_SameAddress") {
+  SECTION("float") { runSafeAtomicMinSameAddressTest<float>(); }
+  SECTION("double") { runSafeAtomicMinSameAddressTest<double>(); }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs safeAtomicMin from multiple threads on adjacent addresses.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/safeAtomicMin.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_safeAtomicMin_Positive_Adjacent_Addresses") {
+  SECTION("float") { runSafeAtomicMinAdjacentAddressesTest<float>(); }
+  SECTION("double") { runSafeAtomicMinAdjacentAddressesTest<double>(); }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs safeAtomicMin from multiple threads on the scattered addresses.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/safeAtomicMin.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_safeAtomicMin_Positive_Scattered_Addresses") {
+  SECTION("float") { runSafeAtomicMinScatteredAddressesTest<float>(); }
+  SECTION("double") { runSafeAtomicMinScatteredAddressesTest<double>(); }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -114,13 +175,9 @@ TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_Scattered_Addresses", "", float,
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_Multi_Kernel_Same_Address", "", float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMin>(
-          2, 1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_safeAtomicMin_Positive_Multi_Kernel_Same_Address") {
+  SECTION("float") { runSafeAtomicMinMultiKernelSameAddressTest<float>(); }
+  SECTION("double") { runSafeAtomicMinMultiKernelSameAddressTest<double>(); }
 }
 
 /**
@@ -135,17 +192,9 @@ TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_Multi_Kernel_Same_Address", "", 
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_Multi_Kernel_Adjacent_Addresses", "", float,
-                   double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMin>(
-          2, warp_size, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_safeAtomicMin_Positive_Multi_Kernel_Adjacent_Addresses") {
+  SECTION("float") { runSafeAtomicMinMultiKernelAdjacentAddressesTest<float>(); }
+  SECTION("double") { runSafeAtomicMinMultiKernelAdjacentAddressesTest<double>(); }
 }
 
 /**
@@ -160,18 +209,9 @@ TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_Multi_Kernel_Adjacent_Addresses"
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_safeAtomicMin_Positive_Multi_Kernel_Scattered_Addresses", "", float,
-                   double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kSafeMin>(
-          2, warp_size, cache_line_size);
-    }
-  }
+TEST_CASE("Unit_safeAtomicMin_Positive_Multi_Kernel_Scattered_Addresses") {
+  SECTION("float") { runSafeAtomicMinMultiKernelScatteredAddressesTest<float>(); }
+  SECTION("double") { runSafeAtomicMinMultiKernelScatteredAddressesTest<double>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/unsafeAtomicMax.cc
+++ b/projects/hip-tests/catch/unit/atomics/unsafeAtomicMax.cc
@@ -32,19 +32,9 @@ THE SOFTWARE.
  * calculates maximum between address and val, returns old value.
  */
 
-/**
- * Test Description
- * ------------------------
- *  - Performs unsafeAtomicMax from multiple threads on the same address.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/unsafeAtomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_SameAddress", "", float, double) {
+// Helper function to run unsafeAtomicMax tests for same address (single kernel)
+template <typename TestType>
+static void runUnsafeAtomicMaxSameAddressTest() {
   for (auto current = 0; current < cmd_options.iterations; ++current) {
     DYNAMIC_SECTION("Same address " << current) {
       MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMax>(
@@ -53,19 +43,9 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_SameAddress", "", float, doubl
   }
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Performs unsafeAtomicMax from multiple threads on adjacent addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/unsafeAtomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_Adjacent_Addresses", "", float, double) {
+// Helper function to run unsafeAtomicMax tests for adjacent addresses (single kernel)
+template <typename TestType>
+static void runUnsafeAtomicMaxAdjacentAddressesTest() {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
 
@@ -77,19 +57,9 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_Adjacent_Addresses", "", float
   }
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Performs unsafeAtomicMax from multiple threads on the scattered addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/unsafeAtomicMax.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_Scattered_Addresses", "", float, double) {
+// Helper function to run unsafeAtomicMax tests for scattered addresses (single kernel)
+template <typename TestType>
+static void runUnsafeAtomicMaxScatteredAddressesTest() {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
@@ -102,6 +72,97 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_Scattered_Addresses", "", floa
   }
 }
 
+// Helper function to run unsafeAtomicMax tests for same address (multi kernel)
+template <typename TestType>
+static void runUnsafeAtomicMaxMultiKernelSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMax>(
+          2, 1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run unsafeAtomicMax tests for adjacent addresses (multi kernel)
+template <typename TestType>
+static void runUnsafeAtomicMaxMultiKernelAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMax>(
+          2, warp_size, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run unsafeAtomicMax tests for scattered addresses (multi kernel)
+template <typename TestType>
+static void runUnsafeAtomicMaxMultiKernelScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMax>(
+          2, warp_size, cache_line_size);
+    }
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs unsafeAtomicMax from multiple threads on the same address.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/unsafeAtomicMax.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_unsafeAtomicMax_Positive_SameAddress") {
+  SECTION("float") { runUnsafeAtomicMaxSameAddressTest<float>(); }
+  SECTION("double") { runUnsafeAtomicMaxSameAddressTest<double>(); }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs unsafeAtomicMax from multiple threads on adjacent addresses.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/unsafeAtomicMax.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_unsafeAtomicMax_Positive_Adjacent_Addresses") {
+  SECTION("float") { runUnsafeAtomicMaxAdjacentAddressesTest<float>(); }
+  SECTION("double") { runUnsafeAtomicMaxAdjacentAddressesTest<double>(); }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs unsafeAtomicMax from multiple threads on the scattered addresses.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/unsafeAtomicMax.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_unsafeAtomicMax_Positive_Scattered_Addresses") {
+  SECTION("float") { runUnsafeAtomicMaxScatteredAddressesTest<float>(); }
+  SECTION("double") { runUnsafeAtomicMaxScatteredAddressesTest<double>(); }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -114,13 +175,9 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_Scattered_Addresses", "", floa
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_Multi_Kernel_Same_Address", "", float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMax>(
-          2, 1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_unsafeAtomicMax_Positive_Multi_Kernel_Same_Address") {
+  SECTION("float") { runUnsafeAtomicMaxMultiKernelSameAddressTest<float>(); }
+  SECTION("double") { runUnsafeAtomicMaxMultiKernelSameAddressTest<double>(); }
 }
 
 /**
@@ -135,17 +192,9 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_Multi_Kernel_Same_Address", ""
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_Multi_Kernel_Adjacent_Addresses", "", float,
-                   double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMax>(
-          2, warp_size, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_unsafeAtomicMax_Positive_Multi_Kernel_Adjacent_Addresses") {
+  SECTION("float") { runUnsafeAtomicMaxMultiKernelAdjacentAddressesTest<float>(); }
+  SECTION("double") { runUnsafeAtomicMaxMultiKernelAdjacentAddressesTest<double>(); }
 }
 
 /**
@@ -160,18 +209,9 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_Multi_Kernel_Adjacent_Addresse
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMax_Positive_Multi_Kernel_Scattered_Addresses", "", float,
-                   double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMax>(
-          2, warp_size, cache_line_size);
-    }
-  }
+TEST_CASE("Unit_unsafeAtomicMax_Positive_Multi_Kernel_Scattered_Addresses") {
+  SECTION("float") { runUnsafeAtomicMaxMultiKernelScatteredAddressesTest<float>(); }
+  SECTION("double") { runUnsafeAtomicMaxMultiKernelScatteredAddressesTest<double>(); }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/atomics/unsafeAtomicMin.cc
+++ b/projects/hip-tests/catch/unit/atomics/unsafeAtomicMin.cc
@@ -32,19 +32,9 @@ THE SOFTWARE.
  * calculates minimum between address and val, returns old value.
  */
 
-/**
- * Test Description
- * ------------------------
- *  - Performs unsafeAtomicMin from multiple threads on the same address.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/unsafeAtomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_SameAddress", "", float, double) {
+// Helper function to run unsafeAtomicMin tests for same address (single kernel)
+template <typename TestType>
+static void runUnsafeAtomicMinSameAddressTest() {
   for (auto current = 0; current < cmd_options.iterations; ++current) {
     DYNAMIC_SECTION("Same address " << current) {
       MinMax::SingleDeviceSingleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMin>(
@@ -53,19 +43,9 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_SameAddress", "", float, doubl
   }
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Performs unsafeAtomicMin from multiple threads on adjacent addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/unsafeAtomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_Adjacent_Addresses", "", float, double) {
+// Helper function to run unsafeAtomicMin tests for adjacent addresses (single kernel)
+template <typename TestType>
+static void runUnsafeAtomicMinAdjacentAddressesTest() {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
 
@@ -77,19 +57,9 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_Adjacent_Addresses", "", float
   }
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Performs unsafeAtomicMin from multiple threads on the scattered addresses.
- *  - Uses only one device and launches one kernel.
- * Test source
- * ------------------------
- *  - unit/atomics/unsafeAtomicMin.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 5.2
- */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_Scattered_Addresses", "", float, double) {
+// Helper function to run unsafeAtomicMin tests for scattered addresses (single kernel)
+template <typename TestType>
+static void runUnsafeAtomicMinScatteredAddressesTest() {
   int warp_size = 0;
   HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
   const auto cache_line_size = 128u;
@@ -102,6 +72,97 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_Scattered_Addresses", "", floa
   }
 }
 
+// Helper function to run unsafeAtomicMin tests for same address (multi kernel)
+template <typename TestType>
+static void runUnsafeAtomicMinMultiKernelSameAddressTest() {
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Same address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMin>(
+          2, 1, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run unsafeAtomicMin tests for adjacent addresses (multi kernel)
+template <typename TestType>
+static void runUnsafeAtomicMinMultiKernelAdjacentAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Adjacent address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMin>(
+          2, warp_size, sizeof(TestType));
+    }
+  }
+}
+
+// Helper function to run unsafeAtomicMin tests for scattered addresses (multi kernel)
+template <typename TestType>
+static void runUnsafeAtomicMinMultiKernelScatteredAddressesTest() {
+  int warp_size = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
+  const auto cache_line_size = 128u;
+
+  for (auto current = 0; current < cmd_options.iterations; ++current) {
+    DYNAMIC_SECTION("Scattered address " << current) {
+      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMin>(
+          2, warp_size, cache_line_size);
+    }
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs unsafeAtomicMin from multiple threads on the same address.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/unsafeAtomicMin.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_unsafeAtomicMin_Positive_SameAddress") {
+  SECTION("float") { runUnsafeAtomicMinSameAddressTest<float>(); }
+  SECTION("double") { runUnsafeAtomicMinSameAddressTest<double>(); }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs unsafeAtomicMin from multiple threads on adjacent addresses.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/unsafeAtomicMin.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_unsafeAtomicMin_Positive_Adjacent_Addresses") {
+  SECTION("float") { runUnsafeAtomicMinAdjacentAddressesTest<float>(); }
+  SECTION("double") { runUnsafeAtomicMinAdjacentAddressesTest<double>(); }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Performs unsafeAtomicMin from multiple threads on the scattered addresses.
+ *  - Uses only one device and launches one kernel.
+ * Test source
+ * ------------------------
+ *  - unit/atomics/unsafeAtomicMin.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+TEST_CASE("Unit_unsafeAtomicMin_Positive_Scattered_Addresses") {
+  SECTION("float") { runUnsafeAtomicMinScatteredAddressesTest<float>(); }
+  SECTION("double") { runUnsafeAtomicMinScatteredAddressesTest<double>(); }
+}
+
 /**
  * Test Description
  * ------------------------
@@ -114,13 +175,9 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_Scattered_Addresses", "", floa
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_Multi_Kernel_Same_Address", "", float, double) {
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Same address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMin>(
-          2, 1, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_unsafeAtomicMin_Positive_Multi_Kernel_Same_Address") {
+  SECTION("float") { runUnsafeAtomicMinMultiKernelSameAddressTest<float>(); }
+  SECTION("double") { runUnsafeAtomicMinMultiKernelSameAddressTest<double>(); }
 }
 
 /**
@@ -135,17 +192,9 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_Multi_Kernel_Same_Address", ""
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_Multi_Kernel_Adjacent_Addresses", "", float,
-                   double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Adjacent address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMin>(
-          2, warp_size, sizeof(TestType));
-    }
-  }
+TEST_CASE("Unit_unsafeAtomicMin_Positive_Multi_Kernel_Adjacent_Addresses") {
+  SECTION("float") { runUnsafeAtomicMinMultiKernelAdjacentAddressesTest<float>(); }
+  SECTION("double") { runUnsafeAtomicMinMultiKernelAdjacentAddressesTest<double>(); }
 }
 
 /**
@@ -160,18 +209,9 @@ TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_Multi_Kernel_Adjacent_Addresse
  * ------------------------
  *  - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_unsafeAtomicMin_Positive_Multi_Kernel_Scattered_Addresses", "", float,
-                   double) {
-  int warp_size = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&warp_size, hipDeviceAttributeWarpSize, 0));
-  const auto cache_line_size = 128u;
-
-  for (auto current = 0; current < cmd_options.iterations; ++current) {
-    DYNAMIC_SECTION("Scattered address " << current) {
-      MinMax::SingleDeviceMultipleKernelTest<TestType, MinMax::AtomicOperation::kUnsafeMin>(
-          2, warp_size, cache_line_size);
-    }
-  }
+TEST_CASE("Unit_unsafeAtomicMin_Positive_Multi_Kernel_Scattered_Addresses") {
+  SECTION("float") { runUnsafeAtomicMinMultiKernelScatteredAddressesTest<float>(); }
+  SECTION("double") { runUnsafeAtomicMinMultiKernelScatteredAddressesTest<double>(); }
 }
 
 /**


### PR DESCRIPTION
## Motivation

Currently the CI spend 75% of its time on tests that take less than 0.65 seconds. This means most of the runtime is initializing and de-initializing HIP.  This PR flattens the atomic Min/Max test cases to reduce time spent initializing the runtime.

## Technical Details

We flatten TEMPLATE_TEST_CASE's into TEST_CASES and run each dtype inside a section.

## JIRA ID

Part of SWDEV-574976

## Test Plan

Refactor in testing, does not need its own tests

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
