### PR TITLE
SWDEV-574976 - Combine surface vector types into single test instance

### DIFF
--- a/projects/hip-tests/catch/unit/surface/surf1D.cc
+++ b/projects/hip-tests/catch/unit/surface/surf1D.cc
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include <hip_array_common.hh>
 #include <hip_test_common.hh>
 #include <hip_texture_helper.hh>
+#include "surf_common.h"
 
 #pragma clang diagnostic ignored "-Wunused-variable"
 #pragma clang diagnostic ignored "-Wunused-parameter"
@@ -241,14 +242,16 @@ template <typename T> static void runTestRW(const int width) {
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf1Dread_Positive_Basic", "", char, uchar, short, ushort, int, uint,
-                   float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2, uchar2,
-                   short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4, int4,
-                   uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surf1Dread_Positive_Basic", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67, 131, 263);
-  runTestR<TestType>(width);
+
+  runTestR<vector_type_helper_t<TestType, 0>>(width);
+  runTestR<vector_type_helper_t<TestType, 1>>(width);
+  runTestR<vector_type_helper_t<TestType, 2>>(width);
+  runTestR<vector_type_helper_t<TestType, 4>>(width);
 }
 
 /**
@@ -262,14 +265,16 @@ TEMPLATE_TEST_CASE("Unit_surf1Dread_Positive_Basic", "", char, uchar, short, ush
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf1Dwrite_Positive_Basic", "", char, uchar, short, ushort, int, uint,
-                   float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2, uchar2,
-                   short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4, int4,
-                   uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surf1Dwrite_Positive_Basic", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67, 131, 263);
-  runTestW<TestType>(width);
+
+  runTestW<vector_type_helper_t<TestType, 0>>(width);
+  runTestW<vector_type_helper_t<TestType, 1>>(width);
+  runTestW<vector_type_helper_t<TestType, 2>>(width);
+  runTestW<vector_type_helper_t<TestType, 4>>(width);
 }
 
 /**
@@ -283,14 +288,16 @@ TEMPLATE_TEST_CASE("Unit_surf1Dwrite_Positive_Basic", "", char, uchar, short, us
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf1D_Positive_ReadWrite", "", char, uchar, short, ushort, int, uint,
-                   float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2, uchar2,
-                   short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4, int4,
-                   uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surf1D_Positive_ReadWrite", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67, 131, 263);
-  runTestRW<TestType>(width);
+
+  runTestRW<vector_type_helper_t<TestType, 0>>(width);
+  runTestRW<vector_type_helper_t<TestType, 1>>(width);
+  runTestRW<vector_type_helper_t<TestType, 2>>(width);
+  runTestRW<vector_type_helper_t<TestType, 4>>(width);
 }
 
 /**

--- a/projects/hip-tests/catch/unit/surface/surf1DLayered.cc
+++ b/projects/hip-tests/catch/unit/surface/surf1DLayered.cc
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include <hip_array_common.hh>
 #include <hip_test_common.hh>
 #include <hip_texture_helper.hh>
+#include "surf_common.h"
 
 #pragma clang diagnostic ignored "-Wunused-variable"
 #pragma clang diagnostic ignored "-Wunused-parameter"
@@ -241,14 +242,15 @@ template <typename T> static void runTestRW(const int width) {
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf1DLayeredread_Positive_Basic", "", char, uchar, short, ushort, int,
-                   uint, float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2, uchar2,
-                   short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4, int4,
-                   uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surf1DLayeredread_Positive_Basic", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67, 131, 263);
-  runTestR<TestType>(width);
+  runTestR<vector_type_helper_t<TestType, 0>>(width);
+  runTestR<vector_type_helper_t<TestType, 1>>(width);
+  runTestR<vector_type_helper_t<TestType, 2>>(width);
+  runTestR<vector_type_helper_t<TestType, 4>>(width);
 }
 
 /**
@@ -262,14 +264,15 @@ TEMPLATE_TEST_CASE("Unit_surf1DLayeredread_Positive_Basic", "", char, uchar, sho
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf1DLayeredwrite_Positive_Basic", "", char, uchar, short, ushort, int,
-                   uint, float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2, uchar2,
-                   short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4, int4,
-                   uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surf1DLayeredwrite_Positive_Basic", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67, 131, 263);
-  runTestW<TestType>(width);
+  runTestW<vector_type_helper_t<TestType, 0>>(width);
+  runTestW<vector_type_helper_t<TestType, 1>>(width);
+  runTestW<vector_type_helper_t<TestType, 2>>(width);
+  runTestW<vector_type_helper_t<TestType, 4>>(width);
 }
 
 /**
@@ -283,14 +286,15 @@ TEMPLATE_TEST_CASE("Unit_surf1DLayeredwrite_Positive_Basic", "", char, uchar, sh
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf1DLayered_Positive_ReadWrite", "", char, uchar, short, ushort, int,
-                   uint, float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2, uchar2,
-                   short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4, int4,
-                   uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surf1DLayered_Positive_ReadWrite", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67, 131, 263);
-  runTestRW<TestType>(width);
+  runTestRW<vector_type_helper_t<TestType, 0>>(width);
+  runTestRW<vector_type_helper_t<TestType, 1>>(width);
+  runTestRW<vector_type_helper_t<TestType, 2>>(width);
+  runTestRW<vector_type_helper_t<TestType, 4>>(width);
 }
 
 /**

--- a/projects/hip-tests/catch/unit/surface/surf2D.cc
+++ b/projects/hip-tests/catch/unit/surface/surf2D.cc
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include <hip_array_common.hh>
 #include <hip_test_common.hh>
 #include <hip_texture_helper.hh>
+#include "surf_common.h"
 
 #pragma clang diagnostic ignored "-Wunused-variable"
 #pragma clang diagnostic ignored "-Wunused-parameter"
@@ -280,15 +281,16 @@ template <typename T> static void runTestRW(const int width, const int height) {
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf2Dread_Positive_Basic", "", char, uchar, short, ushort, int, uint,
-                   float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2, uchar2,
-                   short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4, int4,
-                   uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surf2Dread_Positive_Basic", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
   const int height = GENERATE(131, 263);
-  runTestR<TestType>(width, height);
+  runTestR<vector_type_helper_t<TestType, 0>>(width, height);
+  runTestR<vector_type_helper_t<TestType, 1>>(width, height);
+  runTestR<vector_type_helper_t<TestType, 2>>(width, height);
+  runTestR<vector_type_helper_t<TestType, 4>>(width, height);
 }
 
 /**
@@ -302,15 +304,16 @@ TEMPLATE_TEST_CASE("Unit_surf2Dread_Positive_Basic", "", char, uchar, short, ush
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf2Dwrite_Positive_Basic", "", char, uchar, short, ushort, int, uint,
-                   float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2, uchar2,
-                   short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4, int4,
-                   uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surf2Dwrite_Positive_Basic", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
   const int height = GENERATE(131, 263);
-  runTestW<TestType>(width, height);
+  runTestW<vector_type_helper_t<TestType, 0>>(width, height);
+  runTestW<vector_type_helper_t<TestType, 1>>(width, height);
+  runTestW<vector_type_helper_t<TestType, 2>>(width, height);
+  runTestW<vector_type_helper_t<TestType, 4>>(width, height);
 }
 
 /**
@@ -324,15 +327,16 @@ TEMPLATE_TEST_CASE("Unit_surf2Dwrite_Positive_Basic", "", char, uchar, short, us
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf2D_Positive_ReadWrite", "", char, uchar, short, ushort, int, uint,
-                   float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2, uchar2,
-                   short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4, int4,
-                   uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surf2D_Positive_ReadWrite", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
   const int height = GENERATE(131, 263);
-  runTestRW<TestType>(width, height);
+  runTestRW<vector_type_helper_t<TestType, 0>>(width, height);
+  runTestRW<vector_type_helper_t<TestType, 1>>(width, height);
+  runTestRW<vector_type_helper_t<TestType, 2>>(width, height);
+  runTestRW<vector_type_helper_t<TestType, 4>>(width, height);
 }
 
 /**

--- a/projects/hip-tests/catch/unit/surface/surf2DLayered.cc
+++ b/projects/hip-tests/catch/unit/surface/surf2DLayered.cc
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include <hip_array_common.hh>
 #include <hip_test_common.hh>
 #include <hip_texture_helper.hh>
+#include "surf_common.h"
 
 #pragma clang diagnostic ignored "-Wunused-variable"
 #pragma clang diagnostic ignored "-Wunused-parameter"
@@ -280,15 +281,16 @@ template <typename T> static void runTestRW(const int width, const int height) {
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf2DLayeredread_Positive_Basic", "", char, uchar, short, ushort, int,
-                   uint, float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2, uchar2,
-                   short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4, int4,
-                   uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surf2DLayeredread_Positive_Basic", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
   const int height = GENERATE(131, 263);
-  runTestR<TestType>(width, height);
+  runTestR<vector_type_helper_t<TestType, 0>>(width, height);
+  runTestR<vector_type_helper_t<TestType, 1>>(width, height);
+  runTestR<vector_type_helper_t<TestType, 2>>(width, height);
+  runTestR<vector_type_helper_t<TestType, 4>>(width, height);
 }
 
 /**
@@ -302,15 +304,16 @@ TEMPLATE_TEST_CASE("Unit_surf2DLayeredread_Positive_Basic", "", char, uchar, sho
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf2DLayeredwrite_Positive_Basic", "", char, uchar, short, ushort, int,
-                   uint, float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2, uchar2,
-                   short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4, int4,
-                   uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surf2DLayeredwrite_Positive_Basic", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
   const int height = GENERATE(131, 263);
-  runTestW<TestType>(width, height);
+  runTestW<vector_type_helper_t<TestType, 0>>(width, height);
+  runTestW<vector_type_helper_t<TestType, 1>>(width, height);
+  runTestW<vector_type_helper_t<TestType, 2>>(width, height);
+  runTestW<vector_type_helper_t<TestType, 4>>(width, height);
 }
 
 /**
@@ -324,15 +327,16 @@ TEMPLATE_TEST_CASE("Unit_surf2DLayeredwrite_Positive_Basic", "", char, uchar, sh
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf2DLayered_Positive_ReadWrite", "", char, uchar, short, ushort, int,
-                   uint, float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2, uchar2,
-                   short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4, int4,
-                   uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surf2DLayered_Positive_ReadWrite", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
   const int height = GENERATE(131, 263);
-  runTestRW<TestType>(width, height);
+  runTestRW<vector_type_helper_t<TestType, 0>>(width, height);
+  runTestRW<vector_type_helper_t<TestType, 1>>(width, height);
+  runTestRW<vector_type_helper_t<TestType, 2>>(width, height);
+  runTestRW<vector_type_helper_t<TestType, 4>>(width, height);
 }
 
 /**

--- a/projects/hip-tests/catch/unit/surface/surf3D.cc
+++ b/projects/hip-tests/catch/unit/surface/surf3D.cc
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include <hip_array_common.hh>
 #include <hip_test_common.hh>
 #include <hip_texture_helper.hh>
+#include "surf_common.h"
 
 #pragma clang diagnostic ignored "-Wunused-variable"
 #pragma clang diagnostic ignored "-Wunused-parameter"
@@ -326,16 +327,17 @@ template <typename T> static void runTestRW(const int width, const int height, c
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf3Dread_Positive_Basic", "", char, uchar, short, ushort, int, uint,
-                   float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2, uchar2,
-                   short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4, int4,
-                   uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surf3Dread_Positive_Basic", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
   const int height = GENERATE(131, 263);
   const int depth = GENERATE(4, 11);
-  runTestR<TestType>(width, height, depth);
+  runTestR<vector_type_helper_t<TestType, 0>>(width, height, depth);
+  runTestR<vector_type_helper_t<TestType, 1>>(width, height, depth);
+  runTestR<vector_type_helper_t<TestType, 2>>(width, height, depth);
+  runTestR<vector_type_helper_t<TestType, 4>>(width, height, depth);
 }
 
 /**
@@ -349,16 +351,17 @@ TEMPLATE_TEST_CASE("Unit_surf3Dread_Positive_Basic", "", char, uchar, short, ush
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf3Dwrite_Positive_Basic", "", char, uchar, short, ushort, int, uint,
-                   float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2, uchar2,
-                   short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4, int4,
-                   uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surf3Dwrite_Positive_Basic", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
   const int height = GENERATE(131, 263);
   const int depth = GENERATE(4, 11);
-  runTestR<TestType>(width, height, depth);
+  runTestW<vector_type_helper_t<TestType, 0>>(width, height, depth);
+  runTestW<vector_type_helper_t<TestType, 1>>(width, height, depth);
+  runTestW<vector_type_helper_t<TestType, 2>>(width, height, depth);
+  runTestW<vector_type_helper_t<TestType, 4>>(width, height, depth);
 }
 
 /**
@@ -372,16 +375,17 @@ TEMPLATE_TEST_CASE("Unit_surf3Dwrite_Positive_Basic", "", char, uchar, short, us
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surf3D_Positive_ReadWrite", "", char, uchar, short, ushort, int, uint,
-                   float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2, uchar2,
-                   short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4, int4,
-                   uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surf3D_Positive_ReadWrite", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
   const int height = GENERATE(131, 263);
   const int depth = GENERATE(4, 11);
-  runTestR<TestType>(width, height, depth);
+  runTestRW<vector_type_helper_t<TestType, 0>>(width, height, depth);
+  runTestRW<vector_type_helper_t<TestType, 1>>(width, height, depth);
+  runTestRW<vector_type_helper_t<TestType, 2>>(width, height, depth);
+  runTestRW<vector_type_helper_t<TestType, 4>>(width, height, depth);
 }
 
 /**

--- a/projects/hip-tests/catch/unit/surface/surfCubemap.cc
+++ b/projects/hip-tests/catch/unit/surface/surfCubemap.cc
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include <hip_array_common.hh>
 #include <hip_test_common.hh>
 #include <hip_texture_helper.hh>
+#include "surf_common.h"
 
 #pragma clang diagnostic ignored "-Wunused-variable"
 #pragma clang diagnostic ignored "-Wunused-parameter"
@@ -280,15 +281,16 @@ template <typename T> static void runTestRW(const int width, const int height) {
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surfCubemapread_Positive_Basic", "", char, uchar, short, ushort, int, uint,
-                   float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2, uchar2,
-                   short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4, int4,
-                   uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surfCubemapread_Positive_Basic", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
   const int height = GENERATE(131, 263);
-  runTestR<TestType>(width, height);
+  runTestR<vector_type_helper_t<TestType, 0>>(width, height);
+  runTestR<vector_type_helper_t<TestType, 1>>(width, height);
+  runTestR<vector_type_helper_t<TestType, 2>>(width, height);
+  runTestR<vector_type_helper_t<TestType, 4>>(width, height);
 }
 
 /**
@@ -302,15 +304,16 @@ TEMPLATE_TEST_CASE("Unit_surfCubemapread_Positive_Basic", "", char, uchar, short
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surfCubemapwrite_Positive_Basic", "", char, uchar, short, ushort, int,
-                   uint, float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2, uchar2,
-                   short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4, int4,
-                   uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surfCubemapwrite_Positive_Basic", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
   const int height = GENERATE(131, 263);
-  runTestW<TestType>(width, height);
+  runTestW<vector_type_helper_t<TestType, 0>>(width, height);
+  runTestW<vector_type_helper_t<TestType, 1>>(width, height);
+  runTestW<vector_type_helper_t<TestType, 2>>(width, height);
+  runTestW<vector_type_helper_t<TestType, 4>>(width, height);
 }
 
 /**
@@ -324,15 +327,16 @@ TEMPLATE_TEST_CASE("Unit_surfCubemapwrite_Positive_Basic", "", char, uchar, shor
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surfCubemap_Positive_ReadWrite", "", char, uchar, short, ushort, int, uint,
-                   float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2, uchar2,
-                   short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4, int4,
-                   uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surfCubemap_Positive_ReadWrite", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
   const int height = GENERATE(131, 263);
-  runTestRW<TestType>(width, height);
+  runTestRW<vector_type_helper_t<TestType, 0>>(width, height);
+  runTestRW<vector_type_helper_t<TestType, 1>>(width, height);
+  runTestRW<vector_type_helper_t<TestType, 2>>(width, height);
+  runTestRW<vector_type_helper_t<TestType, 4>>(width, height);
 }
 
 /**

--- a/projects/hip-tests/catch/unit/surface/surfCubemapLayered.cc
+++ b/projects/hip-tests/catch/unit/surface/surfCubemapLayered.cc
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include <hip_array_common.hh>
 #include <hip_test_common.hh>
 #include <hip_texture_helper.hh>
+#include "surf_common.h"
 
 #pragma clang diagnostic ignored "-Wunused-variable"
 #pragma clang diagnostic ignored "-Wunused-parameter"
@@ -283,15 +284,16 @@ template <typename T> static void runTestRW(const int width, const int height) {
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surfCubemapLayeredread_Positive_Basic", "", char, uchar, short, ushort,
-                   int, uint, float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2,
-                   uchar2, short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4,
-                   int4, uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surfCubemapLayeredread_Positive_Basic", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
   const int height = GENERATE(131, 263);
-  runTestR<TestType>(width, height);
+  runTestR<vector_type_helper_t<TestType, 0>>(width, height);
+  runTestR<vector_type_helper_t<TestType, 1>>(width, height);
+  runTestR<vector_type_helper_t<TestType, 2>>(width, height);
+  runTestR<vector_type_helper_t<TestType, 4>>(width, height);
 }
 
 /**
@@ -305,15 +307,16 @@ TEMPLATE_TEST_CASE("Unit_surfCubemapLayeredread_Positive_Basic", "", char, uchar
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surfCubemapLayeredwrite_Positive_Basic", "", char, uchar, short, ushort,
-                   int, uint, float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2,
-                   uchar2, short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4,
-                   int4, uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surfCubemapLayeredwrite_Positive_Basic", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
   const int height = GENERATE(131, 263);
-  runTestW<TestType>(width, height);
+  runTestW<vector_type_helper_t<TestType, 0>>(width, height);
+  runTestW<vector_type_helper_t<TestType, 1>>(width, height);
+  runTestW<vector_type_helper_t<TestType, 2>>(width, height);
+  runTestW<vector_type_helper_t<TestType, 4>>(width, height);
 }
 
 /**
@@ -327,15 +330,16 @@ TEMPLATE_TEST_CASE("Unit_surfCubemapLayeredwrite_Positive_Basic", "", char, ucha
  * ------------------------
  *    - HIP_VERSION >= 5.7
  */
-TEMPLATE_TEST_CASE("Unit_surfCubemapLayered_Positive_ReadWrite", "", char, uchar, short, ushort,
-                   int, uint, float, char1, uchar1, short1, ushort1, int1, uint1, float1, char2,
-                   uchar2, short2, ushort2, int2, uint2, float2, char4, uchar4, short4, ushort4,
-                   int4, uint4, float4) {
+TEMPLATE_TEST_CASE("Unit_surfCubemapLayered_Positive_ReadWrite", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, float) {
   CHECK_IMAGE_SUPPORT;
 
   const int width = GENERATE(31, 67);
   const int height = GENERATE(131, 263);
-  runTestRW<TestType>(width, height);
+  runTestRW<vector_type_helper_t<TestType, 0>>(width, height);
+  runTestRW<vector_type_helper_t<TestType, 1>>(width, height);
+  runTestRW<vector_type_helper_t<TestType, 2>>(width, height);
+  runTestRW<vector_type_helper_t<TestType, 4>>(width, height);
 }
 
 /**

--- a/projects/hip-tests/catch/unit/surface/surf_common.h
+++ b/projects/hip-tests/catch/unit/surface/surf_common.h
@@ -1,0 +1,189 @@
+/*
+Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <hip/hip_runtime.h>
+#include <type_traits>
+
+/**
+ * @brief Template helper to map base types and dimensions to HIP vector types.
+ *
+ * This trait maps a base type T and dimension N to the corresponding HIP vector type.
+ * For example: vector_type_helper<char, 2>::type is char2
+ * Dimension 0 returns the base type itself.
+ *
+ * @tparam T Base type (char, uchar, short, ushort, int, uint, float)
+ * @tparam N Vector dimension (0 = base type, 1, 2, or 4)
+ */
+template <typename T, size_t N>
+struct vector_type_helper {
+  // Primary template is undefined - only valid specializations are defined below
+  // This ensures compile-time errors for invalid type/dimension combinations
+  static_assert(!std::is_same_v<T, T>,
+                "vector_type_helper: Invalid base type or dimension. "
+                "Valid base types: char, uchar, short, ushort, int, uint, float. "
+                "Valid dimensions: 0 (base type), 1, 2, 4");
+};
+
+// Specialization for dimension 0 (base type itself)
+template <typename T>
+struct vector_type_helper<T, 0> {
+  using type = T;
+};
+
+// Specialization for char base type
+template <>
+struct vector_type_helper<char, 1> {
+  using type = char1;
+  static_assert(sizeof(type) == sizeof(char), "char1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<char, 2> {
+  using type = char2;
+  static_assert(sizeof(type) == 2 * sizeof(char), "char2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<char, 4> {
+  using type = char4;
+  static_assert(sizeof(type) == 4 * sizeof(char), "char4 size mismatch");
+};
+
+// Specialization for unsigned char base type
+template <>
+struct vector_type_helper<unsigned char, 1> {
+  using type = uchar1;
+  static_assert(sizeof(type) == sizeof(unsigned char), "uchar1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned char, 2> {
+  using type = uchar2;
+  static_assert(sizeof(type) == 2 * sizeof(unsigned char), "uchar2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned char, 4> {
+  using type = uchar4;
+  static_assert(sizeof(type) == 4 * sizeof(unsigned char), "uchar4 size mismatch");
+};
+
+// Specialization for short base type
+template <>
+struct vector_type_helper<short, 1> {
+  using type = short1;
+  static_assert(sizeof(type) == sizeof(short), "short1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<short, 2> {
+  using type = short2;
+  static_assert(sizeof(type) == 2 * sizeof(short), "short2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<short, 4> {
+  using type = short4;
+  static_assert(sizeof(type) == 4 * sizeof(short), "short4 size mismatch");
+};
+
+// Specialization for unsigned short base type
+template <>
+struct vector_type_helper<unsigned short, 1> {
+  using type = ushort1;
+  static_assert(sizeof(type) == sizeof(unsigned short), "ushort1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned short, 2> {
+  using type = ushort2;
+  static_assert(sizeof(type) == 2 * sizeof(unsigned short), "ushort2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned short, 4> {
+  using type = ushort4;
+  static_assert(sizeof(type) == 4 * sizeof(unsigned short), "ushort4 size mismatch");
+};
+
+// Specialization for int base type
+template <>
+struct vector_type_helper<int, 1> {
+  using type = int1;
+  static_assert(sizeof(type) == sizeof(int), "int1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<int, 2> {
+  using type = int2;
+  static_assert(sizeof(type) == 2 * sizeof(int), "int2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<int, 4> {
+  using type = int4;
+  static_assert(sizeof(type) == 4 * sizeof(int), "int4 size mismatch");
+};
+
+// Specialization for unsigned int base type
+template <>
+struct vector_type_helper<unsigned int, 1> {
+  using type = uint1;
+  static_assert(sizeof(type) == sizeof(unsigned int), "uint1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned int, 2> {
+  using type = uint2;
+  static_assert(sizeof(type) == 2 * sizeof(unsigned int), "uint2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned int, 4> {
+  using type = uint4;
+  static_assert(sizeof(type) == 4 * sizeof(unsigned int), "uint4 size mismatch");
+};
+
+// Specialization for float base type
+template <>
+struct vector_type_helper<float, 1> {
+  using type = float1;
+  static_assert(sizeof(type) == sizeof(float), "float1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<float, 2> {
+  using type = float2;
+  static_assert(sizeof(type) == 2 * sizeof(float), "float2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<float, 4> {
+  using type = float4;
+  static_assert(sizeof(type) == 4 * sizeof(float), "float4 size mismatch");
+};
+
+// Convenience alias template for easier usage
+template <typename T, size_t N>
+using vector_type_helper_t = typename vector_type_helper<T, N>::type;


### PR DESCRIPTION
## Motivation

Currently the CI spend 75% of its time on tests that take less than 0.65 seconds. This means most of the runtime is initializing and de-initializing HIP.  This PR reduces the number amount of template types, by calling the TEMPLATE_TEST_CASE for each base type and its vectorised versions. I.e. A TestType of float, calls float, float1, float2, float4.

There is no reduction in test coverage with this change. Local measurements show a performance difference of 40.25 sec vs 176.96 sec. Which leads to a 77% Speed up, in Surface tests.

## Technical Details

We flatten TEMPLATE_TEST_CASE's into TEST_CASES and run each dtype inside a section.

## JIRA ID

Part of SWDEV-574976

## Test Plan

Refactor in testing, does not need its own tests

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
