### PR TITLE
SWDEV-570500 - Fixed graph node to stream scheduling in multistream path

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -202,10 +202,12 @@ void Graph::ScheduleOneNode(Node node, int stream_id) {
       reinterpret_cast<hip::ChildGraphNode*>(node)->GraphExec::TopologicalOrder();
     }
     for (auto edge : node->GetEdges()) {
-      ScheduleOneNode(edge, stream_id);
-      // 1. Each extra edge will get a new stream from the pool
-      // 2. Streams will be reused if the number of edges > streams
-      stream_id = (stream_id + 1) % DEBUG_HIP_FORCE_GRAPH_QUEUES;
+      if (edge->stream_id_ == -1) {
+        ScheduleOneNode(edge, stream_id);
+        // 1. Each extra edge will get a new stream from the pool
+        // 2. Streams will be reused if the number of edges > streams
+        stream_id = (stream_id + 1) % DEBUG_HIP_FORCE_GRAPH_QUEUES;
+      }
     }
   }
 }


### PR DESCRIPTION
## Motivation
This PR fixes a bug in graph node scheduling for multistream execution paths. The issue prevented correct stream assignment and in some cases nodes were unnecessarily sharing the same stream. In case of rccl perf test this dependency was causing the kernel to wait for the hostnode to complete and that created bubbles in the graph execution.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Due to a bug in the graph traversal during stream assignment the graph nodes were incorrectly mapped to streams and  in rccl alltoall_perf test every 4th hostnode was executed on the kernel stream. That caused the kernel to wait for the host to complete. This could be prevented if the hostNodes were dispatched on their own separate stream.

<!-- Explain the changes along with any relevant GitHub links. -->
## JIRA ID
SWDEV-570500
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
Tested rccl alltoall_perf test using 8 gpu nodes and setting  the environment NCCL_P2P_DISABLE=1 NCCL_SHM_DISABLE=1 to force network transfer). Confirmed this removes the large gaps (>30us) that showed up  after every 4th kernel

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
The fix  removes the large gaps (>30us) that showed up  after every 4th kernel. The small gaps (~6us) that still exist after every kernel are due to the barrier packet that is submitted before the kernel dispatch.

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
