### PR TITLE
SWDEV-574976 - Partially flatten vector template tests cases

### DIFF
--- a/projects/hip-tests/catch/unit/vector_types/vector_types.cc
+++ b/projects/hip-tests/catch/unit/vector_types/vector_types.cc
@@ -55,15 +55,33 @@ THE SOFTWARE.
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_make_vector_SanityCheck_Basic_Host", "", char1, uchar1, char2, uchar2,
-                   char3, uchar3, char4, uchar4, short1, ushort1, short2, ushort2, short3, ushort3,
-                   short4, ushort4, int1, uint1, int2, uint2, int3, uint3, int4, uint4, long1,
-                   ulong1, long2, ulong2, long3, ulong3, long4, ulong4, longlong1, ulonglong1,
-                   longlong2, ulonglong2, longlong3, ulonglong3, longlong4, ulonglong4, float1,
-                   float2, float3, float4, double1, double2, double3, double4) {
-  auto value = GetTestValue<decltype(TestType().x)>(0);
-  TestType vector = MakeVectorTypeHost<TestType>(value);
-  SanityCheck(vector, value);
+TEMPLATE_TEST_CASE("Unit_make_vector_SanityCheck_Basic_Host", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, long, unsigned long, long long,
+                   unsigned long long, float, double) {
+  {
+    using VectorType1 = vector_type_helper_t<TestType, 1>;
+    auto value1 = GetTestValue<decltype(VectorType1().x)>(0);
+    VectorType1 vector1 = MakeVectorTypeHost<VectorType1>(value1);
+    SanityCheck(vector1, value1);
+  }
+  {
+    using VectorType2 = vector_type_helper_t<TestType, 2>;
+    auto value2 = GetTestValue<decltype(VectorType2().x)>(0);
+    VectorType2 vector2 = MakeVectorTypeHost<VectorType2>(value2);
+    SanityCheck(vector2, value2);
+  }
+  {
+    using VectorType3 = vector_type_helper_t<TestType, 3>;
+    auto value3 = GetTestValue<decltype(VectorType3().x)>(0);
+    VectorType3 vector3 = MakeVectorTypeHost<VectorType3>(value3);
+    SanityCheck(vector3, value3);
+  }
+  {
+    using VectorType4 = vector_type_helper_t<TestType, 4>;
+    auto value4 = GetTestValue<decltype(VectorType4().x)>(0);
+    VectorType4 vector4 = MakeVectorTypeHost<VectorType4>(value4);
+    SanityCheck(vector4, value4);
+  }
 }
 
 /**
@@ -75,7 +93,7 @@ TEMPLATE_TEST_CASE("Unit_make_vector_SanityCheck_Basic_Host", "", char1, uchar1,
  *        -# make_short1, make_short2, make_short3, make_short4
  *        -# make_ushort1, make_ushort2, make_ushort3, make_ushort4
  *        -# make_int1, make_int2, make_int3, make_int4
- *        -# make_uint1, make_uint2, make_uint4, make_uint4
+ *        -# make_uint1, make_uint2, make_uint3, make_uint4
  *        -# make_long1, make_long2, make_long3, make_long4
  *        -# make_ulong1, make_ulong2, make_ulong3, make_ulong4
  *        -# make_longlong1, make_longlong2, make_longlong3, make_longlong4
@@ -91,15 +109,33 @@ TEMPLATE_TEST_CASE("Unit_make_vector_SanityCheck_Basic_Host", "", char1, uchar1,
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_make_vector_SanityCheck_Basic_Device", "", char1, uchar1, char2, uchar2,
-                   char3, uchar3, char4, uchar4, short1, ushort1, short2, ushort2, short3, ushort3,
-                   short4, ushort4, int1, uint1, int2, uint2, int3, uint3, int4, uint4, long1,
-                   ulong1, long2, ulong2, long3, ulong3, long4, ulong4, longlong1, ulonglong1,
-                   longlong2, ulonglong2, longlong3, ulonglong3, longlong4, ulonglong4, float1,
-                   float2, float3, float4, double1, double2, double3, double4) {
-  auto value = GetTestValue<decltype(TestType().x)>(0);
-  TestType vector = MakeVectorTypeDevice<TestType>(value);
-  SanityCheck(vector, value);
+TEMPLATE_TEST_CASE("Unit_make_vector_SanityCheck_Basic_Device", "", char, unsigned char, short,
+                   unsigned short, int, unsigned int, long, unsigned long, long long,
+                   unsigned long long, float, double) {
+  {
+    using VectorType1 = vector_type_helper_t<TestType, 1>;
+    auto value1 = GetTestValue<decltype(VectorType1().x)>(0);
+    VectorType1 vector1 = MakeVectorTypeDevice<VectorType1>(value1);
+    SanityCheck(vector1, value1);
+  }
+  {
+    using VectorType2 = vector_type_helper_t<TestType, 2>;
+    auto value2 = GetTestValue<decltype(VectorType2().x)>(0);
+    VectorType2 vector2 = MakeVectorTypeDevice<VectorType2>(value2);
+    SanityCheck(vector2, value2);
+  }
+  {
+    using VectorType3 = vector_type_helper_t<TestType, 3>;
+    auto value3 = GetTestValue<decltype(VectorType3().x)>(0);
+    VectorType3 vector3 = MakeVectorTypeDevice<VectorType3>(value3);
+    SanityCheck(vector3, value3);
+  }
+  {
+    using VectorType4 = vector_type_helper_t<TestType, 4>;
+    auto value4 = GetTestValue<decltype(VectorType4().x)>(0);
+    VectorType4 vector4 = MakeVectorTypeDevice<VectorType4>(value4);
+    SanityCheck(vector4, value4);
+  }
 }
 
 #if HT_AMD
@@ -117,47 +153,67 @@ TEMPLATE_TEST_CASE("Unit_make_vector_SanityCheck_Basic_Device", "", char1, uchar
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_VectorAndVectorOperations_SanityCheck_Basic_Host", "", char1, uchar1,
-                   char2, uchar2, char3, uchar3, char4, uchar4, short1, ushort1, short2, ushort2,
-                   short3, ushort3, short4, ushort4, int1, uint1, int2, uint2, int3, uint3, int4,
-                   uint4, long1, ulong1, long2, ulong2, long3, ulong3, long4, ulong4, longlong1,
-                   ulonglong1, longlong2, ulonglong2, longlong3, ulonglong3, longlong4, ulonglong4,
-                   float1, float2, float3, float4, double1, double2, double3, double4) {
-  auto value1 = GetTestValue<decltype(TestType().x)>(0);
-  auto value2 = GetTestValue<decltype(TestType().x)>(1);
-
-  for (const auto operation : {VectorOperation::kIncrementPrefix,
-                               VectorOperation::kIncrementPostfix,
-                               VectorOperation::kDecrementPrefix,
-                               VectorOperation::kDecrementPostfix,
-                               VectorOperation::kAddAssign,
-                               VectorOperation::kSubtractAssign,
-                               VectorOperation::kMultiplyAssign,
-                               VectorOperation::kDivideAssign,
-                               VectorOperation::kNegate,
-                               VectorOperation::kBitwiseNot,
-                               VectorOperation::kModuloAssign,
-                               VectorOperation::kBitwiseXorAssign,
-                               VectorOperation::kBitwiseOrAssign,
-                               VectorOperation::kBitwiseAndAssign,
-                               VectorOperation::kRightShiftAssign,
-                               VectorOperation::kLeftShiftAssign,
-                               VectorOperation::kAdd,
-                               VectorOperation::kSubtract,
-                               VectorOperation::kMultiply,
-                               VectorOperation::kDivide,
-                               VectorOperation::kEqual,
-                               VectorOperation::kNotEqual,
-                               VectorOperation::kModulo,
-                               VectorOperation::kBitwiseXor,
-                               VectorOperation::kBitwiseOr,
-                               VectorOperation::kBitwiseAnd,
-                               VectorOperation::kRightShift,
-                               VectorOperation::kLeftShift,
-                               VectorOperation::kSubscript}) {
-    DYNAMIC_SECTION("operation: " << to_string(operation)) {
-      TestType vector = PerformVectorOperationHost<TestType>(operation, value1, value2);
-      SanityCheck(operation, vector, value1, value2);
+TEMPLATE_TEST_CASE("Unit_VectorAndVectorOperations_SanityCheck_Basic_Host", "", char,
+                   unsigned char, short, unsigned short, int, unsigned int, long, unsigned long,
+                   long long, unsigned long long, float, double) {
+  const VectorOperation operations[] = {
+      VectorOperation::kIncrementPrefix,  VectorOperation::kIncrementPostfix,
+      VectorOperation::kDecrementPrefix, VectorOperation::kDecrementPostfix,
+      VectorOperation::kAddAssign,       VectorOperation::kSubtractAssign,
+      VectorOperation::kMultiplyAssign,  VectorOperation::kDivideAssign,
+      VectorOperation::kNegate,           VectorOperation::kBitwiseNot,
+      VectorOperation::kModuloAssign,     VectorOperation::kBitwiseXorAssign,
+      VectorOperation::kBitwiseOrAssign,  VectorOperation::kBitwiseAndAssign,
+      VectorOperation::kRightShiftAssign,  VectorOperation::kLeftShiftAssign,
+      VectorOperation::kAdd,              VectorOperation::kSubtract,
+      VectorOperation::kMultiply,         VectorOperation::kDivide,
+      VectorOperation::kEqual,            VectorOperation::kNotEqual,
+      VectorOperation::kModulo,           VectorOperation::kBitwiseXor,
+      VectorOperation::kBitwiseOr,        VectorOperation::kBitwiseAnd,
+      VectorOperation::kRightShift,      VectorOperation::kLeftShift,
+      VectorOperation::kSubscript};
+  {
+    using VectorType1 = vector_type_helper_t<TestType, 1>;
+    auto value1 = GetTestValue<decltype(VectorType1().x)>(0);
+    auto value2 = GetTestValue<decltype(VectorType1().x)>(1);
+    for (const auto operation : operations) {
+      DYNAMIC_SECTION("dim1 operation: " << to_string(operation)) {
+        VectorType1 vector = PerformVectorOperationHost<VectorType1>(operation, value1, value2);
+        SanityCheck(operation, vector, value1, value2);
+      }
+    }
+  }
+  {
+    using VectorType2 = vector_type_helper_t<TestType, 2>;
+    auto value1 = GetTestValue<decltype(VectorType2().x)>(0);
+    auto value2 = GetTestValue<decltype(VectorType2().x)>(1);
+    for (const auto operation : operations) {
+      DYNAMIC_SECTION("dim2 operation: " << to_string(operation)) {
+        VectorType2 vector = PerformVectorOperationHost<VectorType2>(operation, value1, value2);
+        SanityCheck(operation, vector, value1, value2);
+      }
+    }
+  }
+  {
+    using VectorType3 = vector_type_helper_t<TestType, 3>;
+    auto value1 = GetTestValue<decltype(VectorType3().x)>(0);
+    auto value2 = GetTestValue<decltype(VectorType3().x)>(1);
+    for (const auto operation : operations) {
+      DYNAMIC_SECTION("dim3 operation: " << to_string(operation)) {
+        VectorType3 vector = PerformVectorOperationHost<VectorType3>(operation, value1, value2);
+        SanityCheck(operation, vector, value1, value2);
+      }
+    }
+  }
+  {
+    using VectorType4 = vector_type_helper_t<TestType, 4>;
+    auto value1 = GetTestValue<decltype(VectorType4().x)>(0);
+    auto value2 = GetTestValue<decltype(VectorType4().x)>(1);
+    for (const auto operation : operations) {
+      DYNAMIC_SECTION("dim4 operation: " << to_string(operation)) {
+        VectorType4 vector = PerformVectorOperationHost<VectorType4>(operation, value1, value2);
+        SanityCheck(operation, vector, value1, value2);
+      }
     }
   }
 }
@@ -176,25 +232,61 @@ TEMPLATE_TEST_CASE("Unit_VectorAndVectorOperations_SanityCheck_Basic_Host", "", 
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_VectorAndValueTypeOperations_SanityCheck_Basic_Host", "", char1, uchar1,
-                   char2, uchar2, char3, uchar3, char4, uchar4, short1, ushort1, short2, ushort2,
-                   short3, ushort3, short4, ushort4, int1, uint1, int2, uint2, int3, uint3, int4,
-                   uint4, long1, ulong1, long2, ulong2, long3, ulong3, long4, ulong4, longlong1,
-                   ulonglong1, longlong2, ulonglong2, longlong3, ulonglong3, longlong4, ulonglong4,
-                   float1, float2, float3, float4, double1, double2, double3, double4) {
-  auto value1 = GetTestValue<decltype(TestType().x)>(0);
-  auto value2 = GetTestValue<decltype(TestType().x)>(1);
-
-  for (const auto operation :
-       {VectorOperation::kAddAssign, VectorOperation::kSubtractAssign,
-        VectorOperation::kMultiplyAssign, VectorOperation::kDivideAssign, VectorOperation::kAdd,
-        VectorOperation::kSubtract, VectorOperation::kMultiply, VectorOperation::kDivide,
-        VectorOperation::kEqual, VectorOperation::kNotEqual, VectorOperation::kModulo,
-        VectorOperation::kBitwiseXor, VectorOperation::kBitwiseOr, VectorOperation::kBitwiseAnd,
-        VectorOperation::kRightShift, VectorOperation::kLeftShift, VectorOperation::kSubscript}) {
-    DYNAMIC_SECTION("operation: " << to_string(operation)) {
-      TestType vector = PerformVectorOperationHost<TestType, false>(operation, value1, value2);
-      SanityCheck(operation, vector, value1, value2);
+TEMPLATE_TEST_CASE("Unit_VectorAndValueTypeOperations_SanityCheck_Basic_Host", "", char,
+                   unsigned char, short, unsigned short, int, unsigned int, long, unsigned long,
+                   long long, unsigned long long, float, double) {
+  const VectorOperation operations[] = {
+      VectorOperation::kAddAssign,      VectorOperation::kSubtractAssign,
+      VectorOperation::kMultiplyAssign, VectorOperation::kDivideAssign,
+      VectorOperation::kAdd,            VectorOperation::kSubtract,
+      VectorOperation::kMultiply,       VectorOperation::kDivide,
+      VectorOperation::kEqual,          VectorOperation::kNotEqual,
+      VectorOperation::kModulo,         VectorOperation::kBitwiseXor,
+      VectorOperation::kBitwiseOr,      VectorOperation::kBitwiseAnd,
+      VectorOperation::kRightShift,     VectorOperation::kLeftShift,
+      VectorOperation::kSubscript};
+  {
+    using VectorType1 = vector_type_helper_t<TestType, 1>;
+    auto value1 = GetTestValue<decltype(VectorType1().x)>(0);
+    auto value2 = GetTestValue<decltype(VectorType1().x)>(1);
+    for (const auto operation : operations) {
+      DYNAMIC_SECTION("dim1 operation: " << to_string(operation)) {
+        VectorType1 vector = PerformVectorOperationHost<VectorType1, false>(operation, value1, value2);
+        SanityCheck(operation, vector, value1, value2);
+      }
+    }
+  }
+  {
+    using VectorType2 = vector_type_helper_t<TestType, 2>;
+    auto value1 = GetTestValue<decltype(VectorType2().x)>(0);
+    auto value2 = GetTestValue<decltype(VectorType2().x)>(1);
+    for (const auto operation : operations) {
+      DYNAMIC_SECTION("dim2 operation: " << to_string(operation)) {
+        VectorType2 vector = PerformVectorOperationHost<VectorType2, false>(operation, value1, value2);
+        SanityCheck(operation, vector, value1, value2);
+      }
+    }
+  }
+  {
+    using VectorType3 = vector_type_helper_t<TestType, 3>;
+    auto value1 = GetTestValue<decltype(VectorType3().x)>(0);
+    auto value2 = GetTestValue<decltype(VectorType3().x)>(1);
+    for (const auto operation : operations) {
+      DYNAMIC_SECTION("dim3 operation: " << to_string(operation)) {
+        VectorType3 vector = PerformVectorOperationHost<VectorType3, false>(operation, value1, value2);
+        SanityCheck(operation, vector, value1, value2);
+      }
+    }
+  }
+  {
+    using VectorType4 = vector_type_helper_t<TestType, 4>;
+    auto value1 = GetTestValue<decltype(VectorType4().x)>(0);
+    auto value2 = GetTestValue<decltype(VectorType4().x)>(1);
+    for (const auto operation : operations) {
+      DYNAMIC_SECTION("dim4 operation: " << to_string(operation)) {
+        VectorType4 vector = PerformVectorOperationHost<VectorType4, false>(operation, value1, value2);
+        SanityCheck(operation, vector, value1, value2);
+      }
     }
   }
 }
@@ -213,47 +305,67 @@ TEMPLATE_TEST_CASE("Unit_VectorAndValueTypeOperations_SanityCheck_Basic_Host", "
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_VectorAndVectorOperations_SanityCheck_Basic_Device", "", char1, uchar1,
-                   char2, uchar2, char3, uchar3, char4, uchar4, short1, ushort1, short2, ushort2,
-                   short3, ushort3, short4, ushort4, int1, uint1, int2, uint2, int3, uint3, int4,
-                   uint4, long1, ulong1, long2, ulong2, long3, ulong3, long4, ulong4, longlong1,
-                   ulonglong1, longlong2, ulonglong2, longlong3, ulonglong3, longlong4, ulonglong4,
-                   float1, float2, float3, float4, double1, double2, double3, double4) {
-  auto value1 = GetTestValue<decltype(TestType().x)>(0);
-  auto value2 = GetTestValue<decltype(TestType().x)>(1);
-
-  for (const auto operation : {VectorOperation::kIncrementPrefix,
-                               VectorOperation::kIncrementPostfix,
-                               VectorOperation::kDecrementPrefix,
-                               VectorOperation::kDecrementPostfix,
-                               VectorOperation::kAddAssign,
-                               VectorOperation::kSubtractAssign,
-                               VectorOperation::kMultiplyAssign,
-                               VectorOperation::kDivideAssign,
-                               VectorOperation::kNegate,
-                               VectorOperation::kBitwiseNot,
-                               VectorOperation::kModuloAssign,
-                               VectorOperation::kBitwiseXorAssign,
-                               VectorOperation::kBitwiseOrAssign,
-                               VectorOperation::kBitwiseAndAssign,
-                               VectorOperation::kRightShiftAssign,
-                               VectorOperation::kLeftShiftAssign,
-                               VectorOperation::kAdd,
-                               VectorOperation::kSubtract,
-                               VectorOperation::kMultiply,
-                               VectorOperation::kDivide,
-                               VectorOperation::kEqual,
-                               VectorOperation::kNotEqual,
-                               VectorOperation::kModulo,
-                               VectorOperation::kBitwiseXor,
-                               VectorOperation::kBitwiseOr,
-                               VectorOperation::kBitwiseAnd,
-                               VectorOperation::kRightShift,
-                               VectorOperation::kLeftShift,
-                               VectorOperation::kSubscript}) {
-    DYNAMIC_SECTION("operation: " << to_string(operation)) {
-      TestType vector = PerformVectorOperationDevice<TestType>(operation, value1, value2);
-      SanityCheck(operation, vector, value1, value2);
+TEMPLATE_TEST_CASE("Unit_VectorAndVectorOperations_SanityCheck_Basic_Device", "", char,
+                   unsigned char, short, unsigned short, int, unsigned int, long, unsigned long,
+                   long long, unsigned long long, float, double) {
+  const VectorOperation operations[] = {
+      VectorOperation::kIncrementPrefix,  VectorOperation::kIncrementPostfix,
+      VectorOperation::kDecrementPrefix, VectorOperation::kDecrementPostfix,
+      VectorOperation::kAddAssign,       VectorOperation::kSubtractAssign,
+      VectorOperation::kMultiplyAssign,  VectorOperation::kDivideAssign,
+      VectorOperation::kNegate,           VectorOperation::kBitwiseNot,
+      VectorOperation::kModuloAssign,     VectorOperation::kBitwiseXorAssign,
+      VectorOperation::kBitwiseOrAssign,  VectorOperation::kBitwiseAndAssign,
+      VectorOperation::kRightShiftAssign,  VectorOperation::kLeftShiftAssign,
+      VectorOperation::kAdd,              VectorOperation::kSubtract,
+      VectorOperation::kMultiply,         VectorOperation::kDivide,
+      VectorOperation::kEqual,            VectorOperation::kNotEqual,
+      VectorOperation::kModulo,           VectorOperation::kBitwiseXor,
+      VectorOperation::kBitwiseOr,        VectorOperation::kBitwiseAnd,
+      VectorOperation::kRightShift,      VectorOperation::kLeftShift,
+      VectorOperation::kSubscript};
+  {
+    using VectorType1 = vector_type_helper_t<TestType, 1>;
+    auto value1 = GetTestValue<decltype(VectorType1().x)>(0);
+    auto value2 = GetTestValue<decltype(VectorType1().x)>(1);
+    for (const auto operation : operations) {
+      DYNAMIC_SECTION("dim1 operation: " << to_string(operation)) {
+        VectorType1 vector = PerformVectorOperationDevice<VectorType1>(operation, value1, value2);
+        SanityCheck(operation, vector, value1, value2);
+      }
+    }
+  }
+  {
+    using VectorType2 = vector_type_helper_t<TestType, 2>;
+    auto value1 = GetTestValue<decltype(VectorType2().x)>(0);
+    auto value2 = GetTestValue<decltype(VectorType2().x)>(1);
+    for (const auto operation : operations) {
+      DYNAMIC_SECTION("dim2 operation: " << to_string(operation)) {
+        VectorType2 vector = PerformVectorOperationDevice<VectorType2>(operation, value1, value2);
+        SanityCheck(operation, vector, value1, value2);
+      }
+    }
+  }
+  {
+    using VectorType3 = vector_type_helper_t<TestType, 3>;
+    auto value1 = GetTestValue<decltype(VectorType3().x)>(0);
+    auto value2 = GetTestValue<decltype(VectorType3().x)>(1);
+    for (const auto operation : operations) {
+      DYNAMIC_SECTION("dim3 operation: " << to_string(operation)) {
+        VectorType3 vector = PerformVectorOperationDevice<VectorType3>(operation, value1, value2);
+        SanityCheck(operation, vector, value1, value2);
+      }
+    }
+  }
+  {
+    using VectorType4 = vector_type_helper_t<TestType, 4>;
+    auto value1 = GetTestValue<decltype(VectorType4().x)>(0);
+    auto value2 = GetTestValue<decltype(VectorType4().x)>(1);
+    for (const auto operation : operations) {
+      DYNAMIC_SECTION("dim4 operation: " << to_string(operation)) {
+        VectorType4 vector = PerformVectorOperationDevice<VectorType4>(operation, value1, value2);
+        SanityCheck(operation, vector, value1, value2);
+      }
     }
   }
 }
@@ -272,25 +384,61 @@ TEMPLATE_TEST_CASE("Unit_VectorAndVectorOperations_SanityCheck_Basic_Device", ""
  * ------------------------
  *    - HIP_VERSION >= 5.2
  */
-TEMPLATE_TEST_CASE("Unit_VectorAndValueTypeOperations_SanityCheck_Basic_Device", "", char1, uchar1,
-                   char2, uchar2, char3, uchar3, char4, uchar4, short1, ushort1, short2, ushort2,
-                   short3, ushort3, short4, ushort4, int1, uint1, int2, uint2, int3, uint3, int4,
-                   uint4, long1, ulong1, long2, ulong2, long3, ulong3, long4, ulong4, longlong1,
-                   ulonglong1, longlong2, ulonglong2, longlong3, ulonglong3, longlong4, ulonglong4,
-                   float1, float2, float3, float4, double1, double2, double3, double4) {
-  auto value1 = GetTestValue<decltype(TestType().x)>(0);
-  auto value2 = GetTestValue<decltype(TestType().x)>(1);
-
-  for (const auto operation :
-       {VectorOperation::kAddAssign, VectorOperation::kSubtractAssign,
-        VectorOperation::kMultiplyAssign, VectorOperation::kDivideAssign, VectorOperation::kAdd,
-        VectorOperation::kSubtract, VectorOperation::kMultiply, VectorOperation::kDivide,
-        VectorOperation::kEqual, VectorOperation::kNotEqual, VectorOperation::kModulo,
-        VectorOperation::kBitwiseXor, VectorOperation::kBitwiseOr, VectorOperation::kBitwiseAnd,
-        VectorOperation::kRightShift, VectorOperation::kLeftShift, VectorOperation::kSubscript}) {
-    DYNAMIC_SECTION("operation: " << to_string(operation)) {
-      TestType vector = PerformVectorOperationDevice<TestType, false>(operation, value1, value2);
-      SanityCheck(operation, vector, value1, value2);
+TEMPLATE_TEST_CASE("Unit_VectorAndValueTypeOperations_SanityCheck_Basic_Device", "", char,
+                   unsigned char, short, unsigned short, int, unsigned int, long, unsigned long,
+                   long long, unsigned long long, float, double) {
+  const VectorOperation operations[] = {
+      VectorOperation::kAddAssign,      VectorOperation::kSubtractAssign,
+      VectorOperation::kMultiplyAssign,  VectorOperation::kDivideAssign,
+      VectorOperation::kAdd,             VectorOperation::kSubtract,
+      VectorOperation::kMultiply,       VectorOperation::kDivide,
+      VectorOperation::kEqual,          VectorOperation::kNotEqual,
+      VectorOperation::kModulo,         VectorOperation::kBitwiseXor,
+      VectorOperation::kBitwiseOr,      VectorOperation::kBitwiseAnd,
+      VectorOperation::kRightShift,     VectorOperation::kLeftShift,
+      VectorOperation::kSubscript};
+  {
+    using VectorType1 = vector_type_helper_t<TestType, 1>;
+    auto value1 = GetTestValue<decltype(VectorType1().x)>(0);
+    auto value2 = GetTestValue<decltype(VectorType1().x)>(1);
+    for (const auto operation : operations) {
+      DYNAMIC_SECTION("dim1 operation: " << to_string(operation)) {
+        VectorType1 vector = PerformVectorOperationDevice<VectorType1, false>(operation, value1, value2);
+        SanityCheck(operation, vector, value1, value2);
+      }
+    }
+  }
+  {
+    using VectorType2 = vector_type_helper_t<TestType, 2>;
+    auto value1 = GetTestValue<decltype(VectorType2().x)>(0);
+    auto value2 = GetTestValue<decltype(VectorType2().x)>(1);
+    for (const auto operation : operations) {
+      DYNAMIC_SECTION("dim2 operation: " << to_string(operation)) {
+        VectorType2 vector = PerformVectorOperationDevice<VectorType2, false>(operation, value1, value2);
+        SanityCheck(operation, vector, value1, value2);
+      }
+    }
+  }
+  {
+    using VectorType3 = vector_type_helper_t<TestType, 3>;
+    auto value1 = GetTestValue<decltype(VectorType3().x)>(0);
+    auto value2 = GetTestValue<decltype(VectorType3().x)>(1);
+    for (const auto operation : operations) {
+      DYNAMIC_SECTION("dim3 operation: " << to_string(operation)) {
+        VectorType3 vector = PerformVectorOperationDevice<VectorType3, false>(operation, value1, value2);
+        SanityCheck(operation, vector, value1, value2);
+      }
+    }
+  }
+  {
+    using VectorType4 = vector_type_helper_t<TestType, 4>;
+    auto value1 = GetTestValue<decltype(VectorType4().x)>(0);
+    auto value2 = GetTestValue<decltype(VectorType4().x)>(1);
+    for (const auto operation : operations) {
+      DYNAMIC_SECTION("dim4 operation: " << to_string(operation)) {
+        VectorType4 vector = PerformVectorOperationDevice<VectorType4, false>(operation, value1, value2);
+        SanityCheck(operation, vector, value1, value2);
+      }
     }
   }
 }

--- a/projects/hip-tests/catch/unit/vector_types/vector_types_common.hh
+++ b/projects/hip-tests/catch/unit/vector_types/vector_types_common.hh
@@ -18,6 +18,7 @@ THE SOFTWARE.
 */
 
 #include <hip_test_common.hh>
+#include <type_traits>
 
 constexpr auto kIntegerTestValueFirst = 42;
 constexpr auto kIntegerTestValueSecond = 4;
@@ -191,3 +192,333 @@ template <typename T> T MakeVectorTypeDevice(decltype(T().x) value) {
   HIP_CHECK(hipFree(vector_d));
   return vector_h;
 }
+
+/**
+ * @brief Template helper to map base types and dimensions to HIP vector types.
+ *
+ * This trait maps a base type T and dimension N to the corresponding HIP vector type.
+ * For example: vector_type_helper<char, 2>::type is char2
+ * Dimension 0 returns the base type itself.
+ *
+ * @tparam T Base type (char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned long, long long, unsigned long long, float, double)
+ * @tparam N Vector dimension (0 = base type, 1, 2, 3, or 4)
+ */
+template <typename T, size_t N>
+struct vector_type_helper {
+  // Primary template is undefined - only valid specializations are defined below
+  // This ensures compile-time errors for invalid type/dimension combinations
+  static_assert(!std::is_same_v<T, T>,
+                "vector_type_helper: Invalid base type or dimension. "
+                "Valid base types: char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned long, long long, unsigned long long, float, double. "
+                "Valid dimensions: 0 (base type), 1, 2, 3, 4");
+};
+
+// Specialization for dimension 0 (base type itself)
+template <typename T>
+struct vector_type_helper<T, 0> {
+  using type = T;
+};
+
+// Specialization for char base type
+template <>
+struct vector_type_helper<char, 1> {
+  using type = char1;
+  static_assert(sizeof(type) == sizeof(char), "char1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<char, 2> {
+  using type = char2;
+  static_assert(sizeof(type) == 2 * sizeof(char), "char2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<char, 3> {
+  using type = char3;
+  static_assert(sizeof(type) == 3 * sizeof(char), "char3 size mismatch");
+};
+
+template <>
+struct vector_type_helper<char, 4> {
+  using type = char4;
+  static_assert(sizeof(type) == 4 * sizeof(char), "char4 size mismatch");
+};
+
+// Specialization for unsigned char base type
+template <>
+struct vector_type_helper<unsigned char, 1> {
+  using type = uchar1;
+  static_assert(sizeof(type) == sizeof(unsigned char), "uchar1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned char, 2> {
+  using type = uchar2;
+  static_assert(sizeof(type) == 2 * sizeof(unsigned char), "uchar2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned char, 3> {
+  using type = uchar3;
+  static_assert(sizeof(type) == 3 * sizeof(unsigned char), "uchar3 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned char, 4> {
+  using type = uchar4;
+  static_assert(sizeof(type) == 4 * sizeof(unsigned char), "uchar4 size mismatch");
+};
+
+// Specialization for short base type
+template <>
+struct vector_type_helper<short, 1> {
+  using type = short1;
+  static_assert(sizeof(type) == sizeof(short), "short1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<short, 2> {
+  using type = short2;
+  static_assert(sizeof(type) == 2 * sizeof(short), "short2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<short, 3> {
+  using type = short3;
+  static_assert(sizeof(type) == 3 * sizeof(short), "short3 size mismatch");
+};
+
+template <>
+struct vector_type_helper<short, 4> {
+  using type = short4;
+  static_assert(sizeof(type) == 4 * sizeof(short), "short4 size mismatch");
+};
+
+// Specialization for unsigned short base type
+template <>
+struct vector_type_helper<unsigned short, 1> {
+  using type = ushort1;
+  static_assert(sizeof(type) == sizeof(unsigned short), "ushort1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned short, 2> {
+  using type = ushort2;
+  static_assert(sizeof(type) == 2 * sizeof(unsigned short), "ushort2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned short, 3> {
+  using type = ushort3;
+  static_assert(sizeof(type) == 3 * sizeof(unsigned short), "ushort3 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned short, 4> {
+  using type = ushort4;
+  static_assert(sizeof(type) == 4 * sizeof(unsigned short), "ushort4 size mismatch");
+};
+
+// Specialization for int base type
+template <>
+struct vector_type_helper<int, 1> {
+  using type = int1;
+  static_assert(sizeof(type) == sizeof(int), "int1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<int, 2> {
+  using type = int2;
+  static_assert(sizeof(type) == 2 * sizeof(int), "int2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<int, 3> {
+  using type = int3;
+  static_assert(sizeof(type) == 3 * sizeof(int), "int3 size mismatch");
+};
+
+template <>
+struct vector_type_helper<int, 4> {
+  using type = int4;
+  static_assert(sizeof(type) == 4 * sizeof(int), "int4 size mismatch");
+};
+
+// Specialization for unsigned int base type
+template <>
+struct vector_type_helper<unsigned int, 1> {
+  using type = uint1;
+  static_assert(sizeof(type) == sizeof(unsigned int), "uint1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned int, 2> {
+  using type = uint2;
+  static_assert(sizeof(type) == 2 * sizeof(unsigned int), "uint2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned int, 3> {
+  using type = uint3;
+  static_assert(sizeof(type) == 3 * sizeof(unsigned int), "uint3 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned int, 4> {
+  using type = uint4;
+  static_assert(sizeof(type) == 4 * sizeof(unsigned int), "uint4 size mismatch");
+};
+
+// Specialization for long base type
+template <>
+struct vector_type_helper<long, 1> {
+  using type = long1;
+  static_assert(sizeof(type) == sizeof(long), "long1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<long, 2> {
+  using type = long2;
+  static_assert(sizeof(type) == 2 * sizeof(long), "long2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<long, 3> {
+  using type = long3;
+  static_assert(sizeof(type) == 3 * sizeof(long), "long3 size mismatch");
+};
+
+template <>
+struct vector_type_helper<long, 4> {
+  using type = long4;
+  static_assert(sizeof(type) == 4 * sizeof(long), "long4 size mismatch");
+};
+
+// Specialization for unsigned long base type
+template <>
+struct vector_type_helper<unsigned long, 1> {
+  using type = ulong1;
+  static_assert(sizeof(type) == sizeof(unsigned long), "ulong1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned long, 2> {
+  using type = ulong2;
+  static_assert(sizeof(type) == 2 * sizeof(unsigned long), "ulong2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned long, 3> {
+  using type = ulong3;
+  static_assert(sizeof(type) == 3 * sizeof(unsigned long), "ulong3 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned long, 4> {
+  using type = ulong4;
+  static_assert(sizeof(type) == 4 * sizeof(unsigned long), "ulong4 size mismatch");
+};
+
+// Specialization for long long base type
+template <>
+struct vector_type_helper<long long, 1> {
+  using type = longlong1;
+  static_assert(sizeof(type) == sizeof(long long), "longlong1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<long long, 2> {
+  using type = longlong2;
+  static_assert(sizeof(type) == 2 * sizeof(long long), "longlong2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<long long, 3> {
+  using type = longlong3;
+  static_assert(sizeof(type) == 3 * sizeof(long long), "longlong3 size mismatch");
+};
+
+template <>
+struct vector_type_helper<long long, 4> {
+  using type = longlong4;
+  static_assert(sizeof(type) == 4 * sizeof(long long), "longlong4 size mismatch");
+};
+
+// Specialization for unsigned long long base type
+template <>
+struct vector_type_helper<unsigned long long, 1> {
+  using type = ulonglong1;
+  static_assert(sizeof(type) == sizeof(unsigned long long), "ulonglong1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned long long, 2> {
+  using type = ulonglong2;
+  static_assert(sizeof(type) == 2 * sizeof(unsigned long long), "ulonglong2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned long long, 3> {
+  using type = ulonglong3;
+  static_assert(sizeof(type) == 3 * sizeof(unsigned long long), "ulonglong3 size mismatch");
+};
+
+template <>
+struct vector_type_helper<unsigned long long, 4> {
+  using type = ulonglong4;
+  static_assert(sizeof(type) == 4 * sizeof(unsigned long long), "ulonglong4 size mismatch");
+};
+
+// Specialization for float base type
+template <>
+struct vector_type_helper<float, 1> {
+  using type = float1;
+  static_assert(sizeof(type) == sizeof(float), "float1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<float, 2> {
+  using type = float2;
+  static_assert(sizeof(type) == 2 * sizeof(float), "float2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<float, 3> {
+  using type = float3;
+  static_assert(sizeof(type) == 3 * sizeof(float), "float3 size mismatch");
+};
+
+template <>
+struct vector_type_helper<float, 4> {
+  using type = float4;
+  static_assert(sizeof(type) == 4 * sizeof(float), "float4 size mismatch");
+};
+
+// Specialization for double base type
+template <>
+struct vector_type_helper<double, 1> {
+  using type = double1;
+  static_assert(sizeof(type) == sizeof(double), "double1 size mismatch");
+};
+
+template <>
+struct vector_type_helper<double, 2> {
+  using type = double2;
+  static_assert(sizeof(type) == 2 * sizeof(double), "double2 size mismatch");
+};
+
+template <>
+struct vector_type_helper<double, 3> {
+  using type = double3;
+  static_assert(sizeof(type) == 3 * sizeof(double), "double3 size mismatch");
+};
+
+template <>
+struct vector_type_helper<double, 4> {
+  using type = double4;
+  static_assert(sizeof(type) == 4 * sizeof(double), "double4 size mismatch");
+};
+
+// Convenience alias template for easier usage
+template <typename T, size_t N>
+using vector_type_helper_t = typename vector_type_helper<T, N>::type;


### PR DESCRIPTION
## Motivation

Currently the CI spend 75% of its time on tests that take less than 0.65 seconds. This means most of the runtime is initializing and de-initializing HIP.  This PR reduces the number amount of template types, by calling the TEMPLATE_TEST_CASE for each base type and its vectorised versions. I.e. A TestType of float, calls float, float1, float2, float4.

There is no reduction in test coverage with this change. Local measurements show a performance difference of 30.01 sec vs 84.25 sec. Which leads to a 64% Speed up, in Vector tests.

## Technical Details

We flatten TEMPLATE_TEST_CASE's into TEST_CASES and run each dtype inside a section.

## JIRA ID

Part of SWDEV-574976

## Test Plan

Refactor in testing, does not need its own tests

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
