### PR TITLE
[AMD-SMI] [SWDEV-557305] Fix for VRAM_MEM shown as Zero for RVS test on MI300A

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -19,6 +19,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - Interactive prompt when file exists and no flag is specified:
     - User can choose: Overwrite (o) / Append (a) / Cancel (N)
 
+- **Updated process reporting for MI300A systems.**
+  - Since MI300A hardware exposes no dedicated VRAM, `amd-smi defualt output` now reports `VRAM_MEM: N/A` for running processes on those platforms.
+
 ### Removed
 
 - N/A

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -7706,7 +7706,11 @@ class AMDSMICommands():
                     proc_info_dict['pid'] = proc['pid']
                     proc_info_dict['name'] = proc['name']
                     proc_info_dict['gtt'] = self.helpers.convert_bytes_to_readable(proc['memory_usage']['gtt_mem'])
-                    proc_info_dict['vram'] = self.helpers.convert_bytes_to_readable(proc['memory_usage']['vram_mem'])
+                    is_mi300a = isinstance(market_name, str) and "MI300A" in market_name.upper()
+                    if is_mi300a:
+                        proc_info_dict['vram'] = "N/A"
+                    else:
+                        proc_info_dict['vram'] = self.helpers.convert_bytes_to_readable(proc['memory_usage']['vram_mem'])
                     proc_info_dict['mem_usage'] = self.helpers.convert_bytes_to_readable(proc['mem'])
                     # Handle cu_occupancy conversion safely
                     try:


### PR DESCRIPTION
Changed output so that VRAM_MEM usage reports N/A on MI300A systems only, as discussed by the team. Will add documentation as well:

<img width="596" height="488" alt="image" src="https://github.com/user-attachments/assets/77114c34-f3d3-46f1-a731-5f0b3cca31b3" />

On systems that are not MI300A:

<img width="1617" height="967" alt="image" src="https://github.com/user-attachments/assets/ed22bd79-8d41-400f-9294-2b3d54060921" />
