### PR TITLE
[rocprofiler-systems] Fix naming and description of process_page category

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/categories.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/categories.hpp
@@ -131,7 +131,7 @@ ROCPROFSYS_DEFINE_CATEGORY(category, process_sampling, ROCPROFSYS_CATEGORY_PROCE
 ROCPROFSYS_DEFINE_CATEGORY(category, comm_data, ROCPROFSYS_CATEGORY_COMM_DATA, "comm_data", "MPI/RCCL counters for tracking amount of data sent or received")
 ROCPROFSYS_DEFINE_CATEGORY(category, causal, ROCPROFSYS_CATEGORY_CAUSAL, "causal", "Causal profiling data")
 ROCPROFSYS_DEFINE_CATEGORY(category, cpu_freq, ROCPROFSYS_CATEGORY_CPU_FREQ, "cpu_frequency", "CPU frequency (collected in background thread)")
-ROCPROFSYS_DEFINE_CATEGORY(category, process_page, ROCPROFSYS_CATEGORY_PROCESS_PAGE, "process_page_fault", "Memory page faults in process (collected in background thread)")
+ROCPROFSYS_DEFINE_CATEGORY(category, process_page, ROCPROFSYS_CATEGORY_PROCESS_PAGE, "process_physical_memory", "Physical memory usage (RSS) in process in MB (collected in background thread)")
 ROCPROFSYS_DEFINE_CATEGORY(category, process_virt, ROCPROFSYS_CATEGORY_PROCESS_VIRT, "process_virtual_memory", "Virtual memory usage in process in MB (collected in background thread)")
 ROCPROFSYS_DEFINE_CATEGORY(category, process_peak, ROCPROFSYS_CATEGORY_PROCESS_PEAK, "process_memory_hwm", "Memory High-Water Mark i.e. peak memory usage (collected in background thread)")
 ROCPROFSYS_DEFINE_CATEGORY(category, process_context_switch, ROCPROFSYS_CATEGORY_PROCESS_CONTEXT_SWITCH, "process_context_switch", "Context switches in process (collected in background thread)")


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The `process_page` category was incorrectly named "process_page_fault" and described as tracking "Memory page faults in process", when it actually tracks physical memory usage (RSS - Resident Set Size) in MB.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Changed category name from `process_page_fault` to `process_physical_memory`
- Updated description from "Memory page faults in process" to "Physical memory usage (RSS) in process in MB"

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFSYST-83

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Verify that the category is correctly displayed with the new name in rocprofiler-systems output
- Check that any documentation or help text referencing this category shows the updated description
- Ensure existing functionality that uses this category continues to work correctly

## Test Result

<!-- Briefly summarize test outcomes. -->
- The `process_physical_memory` category name should appear in profiling output and configuration
- Users should see the accurate description indicating RSS memory tracking in MB
- No functional changes to memory tracking behavior should occur

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
