### PR TITLE
[rocprofiler-sdk] Fixing docs build

### DIFF
--- a/.github/workflows/rocprofiler-sdk-docs.yml
+++ b/.github/workflows/rocprofiler-sdk-docs.yml
@@ -30,7 +30,7 @@ concurrency:
 env:
   GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
   ROCM_PATH: "/opt/rocm"
-  ROCM_VERSION: "7.0.0"
+  ROCM_VERSION: "7.1.1"
 
 jobs:
   build-docs:


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
All the `build_docs_from_source` jobs were failing. I suspect the reason is an outdated `ROCM_VERSION` field in `rocm-systems/.github/workflows/rocprofiler-sdk-docs.yml` becasue the error shows - 
`"tar: /opt/rocm-7.0.0: Cannot open: No such file or directory"`

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Updating the `ROCM_VERSION` field to `7.1.1` to see if that fixes the issue.
## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
