### PR TITLE
Disable HitMemoryViolation KFDTest for NV1x

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDDBGTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDDBGTest.cpp
@@ -492,7 +492,9 @@ exit:
 
 TEST_F(KFDDBGTest, HitMemoryViolation) {
     TEST_START(TESTPROFILE_RUNALL)
-    if (m_FamilyId >= FAMILY_AI) {
+    if (m_FamilyId >= FAMILY_AI && m_FamilyId != FAMILY_NV) {
+        // GFX10 (FAMILY_NV) does not have per-VMID support, skip the test also
+        // Check kfd_dbg_is_per_vmid_supported function in kfd_debug.h
 
         int defaultGPUNode = m_NodeInfo.HsaDefaultGPUNode();
 


### PR DESCRIPTION
## Motivation

KFDDBGTest.HitMemoryViolation failed while running KFD test on Navi12 device.

## Technical Details

After reviewing related code, older families using GFX10 doesnt support per vmid debug, hence this test should be skipped running on those devices.

## JIRA ID

SWDEV-573617

## Test Plan

Run KFDDBGTest.HitMemoryViolationon GFX10 device and it should skip the test. Run KFDDBGTest.HitMemoryViolation on other devices should have the test result unchanged.

## Test Result

Ran the test on Navi12 device and the test skipped. Ran the test on a Navi31 device and the test ran and passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
