### PR TITLE
SWDEV-574976 - Combine similar deviceLibs tests into larger TEST_CASE's

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
@@ -44,81 +44,17 @@ deviceLib:
     # Note: devicelib hangs and failures
     disabled: [amd_windows, amd_wsl]
     tags: [memory]
-  Unit_deviceAllocation_New_PerThread_PrimitiveDataType:
-    <<: *level_2
-    # Note: devicelib hangs and failures
-    disabled: [amd_windows, amd_wsl]
-    tags: [memory]
-  Unit_deviceAllocation_Malloc_PerThread_StructDataType:
-    <<: *level_2
-    # Note: devicelib hangs and failures
-    disabled: [amd_windows, amd_wsl]
-    tags: [memory]
-  Unit_deviceAllocation_New_PerThread_StructDataType:
-    <<: *level_2
-    # Note: devicelib hangs and failures
-    disabled: [amd_windows, amd_wsl]
-    tags: [memory]
-  Unit_deviceAllocation_InOneThread_AccessInAllThreads:
-    <<: *level_2
-    # (amd_windows) Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
-    # (amd_windows) all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
-    # (amd_wsl) SWDEV-427101:Below test fails randomly in PSDB
-    disabled: [amd_windows, amd_wsl]
-    tags: [memory]
-  Unit_deviceAllocation_Malloc_AcrossKernels:
+  Unit_deviceAllocation_ComplexDataType:
     <<: *level_2
     # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
     # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
     disabled: [amd_windows, amd_wsl]
     tags: [memory]
-  Unit_deviceAllocation_New_AcrossKernels:
+  Unit_deviceAllocation_CodeObjects:
     <<: *level_2
     # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
     # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
     disabled: [amd_windows, amd_wsl]
-    tags: [memory]
-  Unit_deviceAllocation_Malloc_ComplexDataType:
-    <<: *level_2
-    # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
-    # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
-    disabled: [amd_windows]
-    tags: [memory]
-  Unit_deviceAllocation_New_ComplexDataType:
-    <<: *level_2
-    # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
-    # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
-    disabled: [amd_windows, amd_wsl]
-    tags: [memory]
-  Unit_deviceAllocation_Malloc_UnionType:
-    <<: *level_2
-    # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
-    # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
-    disabled: [amd_windows, amd_wsl]
-    tags: [memory]
-  Unit_deviceAllocation_New_UnionType:
-    <<: *level_2
-    # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
-    # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
-    disabled: [amd_windows, amd_wsl]
-    tags: [memory]
-  Unit_deviceAllocation_Malloc_SingleCodeObj:
-    <<: *level_2
-    # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
-    # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
-    disabled: [amd_windows, amd_wsl]
-    tags: [memory]
-  Unit_deviceAllocation_New_SingleCodeObj:
-    <<: *level_2
-    # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
-    # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
-    disabled: [amd_windows, amd_wsl]
-    tags: [memory]
-  Unit_deviceAllocation_Malloc_PerThread_MultKerMultStrm:
-    <<: *level_2
-    tags: [memory]
-  Unit_deviceAllocation_New_PerThread_MultKerMultStrm:
-    <<: *level_2
     tags: [memory]
   Unit_deviceAllocation_Malloc_PerThread_Graph:
     <<: *level_2
@@ -132,12 +68,7 @@ deviceLib:
     # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
     disabled: [amd_windows, amd_wsl]
     tags: [memory]
-  Unit_deviceAllocation_Malloc_DeviceFunc:
-    <<: *level_2
-    # Note: devicelib hangs and failures
-    disabled: [amd_windows, amd_wsl]
-    tags: [memory]
-  Unit_deviceAllocation_New_DeviceFunc:
+  Unit_deviceAllocation_DeviceFunc:
     <<: *level_2
     # Note: devicelib hangs and failures
     disabled: [amd_windows, amd_wsl]
@@ -147,20 +78,7 @@ deviceLib:
     # Note: devicelib hangs and failures
     disabled: [amd_windows, amd_wsl]
     tags: [memory]
-  Unit_deviceAllocation_Malloc_MulKernels_MulThreads:
-    <<: *level_2
-    # Note: devicelib hangs and failures
-    disabled: [amd_windows, amd_wsl]
-    tags: [memory]
-  Unit_deviceAllocation_New_MulKernels_MulThreads:
-    <<: *level_2
-    # Note: devicelib hangs and failures
-    disabled: [amd_windows, amd_wsl]
-    tags: [memory]
-  Unit_deviceAllocation_Malloc_SingKernels_MulThreads:
-    <<: *level_2
-    tags: [memory]
-  Unit_deviceAllocation_New_SingKernels_MulThreads:
+  Unit_deviceAllocation_SingKernels_MulThreads:
     <<: *level_2
     tags: [memory]
   Unit_deviceAllocation_Malloc_MulCodeObj:
@@ -360,16 +278,7 @@ deviceLib:
   Unit_bf162_floor_ceil:
     <<: *level_2
     tags: [types]
-  Unit_AtomicsWithRandomActiveLanesInWavefront_UniformInteger:
-    <<: *level_2
-    tags: [atomics]
-  Unit_AtomicsWithRandomActiveLanesInWavefront_UniformFloat:
-    <<: *level_2
-    tags: [atomics]
-  Unit_AtomicsWithRandomActiveLanesInWavefront_DivergentInteger:
-    <<: *level_2
-    tags: [atomics]
-  Unit_AtomicsWithRandomActiveLanesInWavefront_DivergentFloat:
+  Unit_AtomicsWithRandomActiveLanesInWavefront:
     <<: *level_2
     tags: [atomics]
   Unit_fp16_arith:

--- a/projects/hip-tests/catch/unit/deviceLib/AtomicsWithRandomActiveLanesInWavefront.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/AtomicsWithRandomActiveLanesInWavefront.cc
@@ -767,57 +767,27 @@ static void runDivFloatTest() {
 }
 
 /*
-This testcases perform the following scenario of atomic opearations on Uniform value
-for INT and UNSIGNED INT types
-  // 1. atomicAdd
-  // 2. atomicSub
-  // 3. atomicMax
-  // 4. atomicMin
-  // 5. atomicAnd
-  // 6. atomicOr
-  // 7. atomicXor
+This testcases perform the following scenario of atomic opearations on Uniform and Divergent values
+for INT, UNSIGNED INT, and FLOAT types:
+  Uniform and Divergent Integer (int, unsigned int):
+    // 1. atomicAdd
+    // 2. atomicSub
+    // 3. atomicMax
+    // 4. atomicMin
+    // 5. atomicAnd
+    // 6. atomicOr
+    // 7. atomicXor
+  Uniform and Divergent Float:
+    // 1. atomicAdd
+    // 2. atomicSub
+    // 3. atomicMax
+    // 4. atomicMin
 */
-HIP_TEST_CASE(Unit_AtomicsWithRandomActiveLanesInWavefront_UniformInteger) {
-  SECTION("test for int") { runIntTest<int>(); }
-  SECTION("test for unsigned int") { runIntTest<unsigned int>(); }
-}
-
-/*
-This testcases perform the following scenario of atomic opearations on Uniform value
-for FLOAT types
-  // 1. atomicAdd
-  // 2. atomicSub
-  // 3. atomicMax
-  // 4. atomicMin
-*/
-HIP_TEST_CASE(Unit_AtomicsWithRandomActiveLanesInWavefront_UniformFloat) {
-  SECTION("test for float") { runFloatTest(); }
-}
-
-/*
-This testcases perform the following scenario of atomic opearations on Divergent values
-for INT and UNSIGNED INT types
-  // 1. atomicAdd
-  // 2. atomicSub
-  // 3. atomicMax
-  // 4. atomicMin
-  // 5. atomicAnd
-  // 6. atomicOr
-  // 7. atomicXor
-*/
-HIP_TEST_CASE(Unit_AtomicsWithRandomActiveLanesInWavefront_DivergentInteger) {
-  SECTION("test for int") { runDivIntTest<int>(); }
-  SECTION("test for unsigned int") { runDivIntTest<unsigned int>(); }
-}
-
-/*
-This testcases perform the following scenario of atomic opearations on Divergent values
-for FLOAT types
-  // 1. atomicAdd
-  // 2. atomicSub
-  // 3. atomicMax
-  // 4. atomicMin
-*/
-HIP_TEST_CASE(Unit_AtomicsWithRandomActiveLanesInWavefront_DivergentFloat) {
-  SECTION("test for float") { runDivFloatTest(); }
+HIP_TEST_CASE(Unit_AtomicsWithRandomActiveLanesInWavefront) {
+  SECTION("Uniform Integer - int") { runIntTest<int>(); }
+  SECTION("Uniform Integer - unsigned int") { runIntTest<unsigned int>(); }
+  SECTION("Uniform Float") { runFloatTest(); }
+  SECTION("Divergent Integer - int") { runDivIntTest<int>(); }
+  SECTION("Divergent Integer - unsigned int") { runDivIntTest<unsigned int>(); }
+  SECTION("Divergent Float") { runDivFloatTest(); }
 }

--- a/projects/hip-tests/catch/unit/deviceLib/deviceAllocation.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/deviceAllocation.cc
@@ -857,388 +857,336 @@ static bool TestAllocInDeviceFunc(int test_type) {
 
 /**
  * Scenario: This test validates device allocation and deallocation
- * using malloc/free in every gpu thread and block for primitive data
- * types like char, short, int etc.
+ * using malloc/free and new/delete for primitive data types (char, short, int, float, double)
+ * across various scenarios: per thread, one thread access, across kernels, graph execution,
+ * and multi-threaded kernels.
  */
 HIP_TEST_CASE(Unit_deviceAllocation_Malloc_PerThread_PrimitiveDataType) {
   int pcieAtomic = 0;
+  constexpr size_t sizePerThread = 128;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
     return;
   }
-  constexpr size_t sizePerThread = 128;
 
-  // malloc()/free() tests
-  SECTION("Test char datatype allocation with malloc") {
+  SECTION("PerThread - char with malloc") {
     REQUIRE(true == TestAllocInAllThread<char>(TEST_MALLOC_FREE, SCHAR_MAX, sizePerThread));
   }
 
-  SECTION("Test short datatype allocation with malloc") {
+  SECTION("PerThread - short with malloc") {
     REQUIRE(true == TestAllocInAllThread<int16_t>(TEST_MALLOC_FREE, SHRT_MAX, sizePerThread));
   }
 
-  SECTION("Test int datatype allocation with malloc") {
+  SECTION("PerThread - int with malloc") {
     REQUIRE(true == TestAllocInAllThread<int32_t>(TEST_MALLOC_FREE, INT_MAX, sizePerThread));
   }
 
-  SECTION("Test float datatype allocation with malloc") {
+  SECTION("PerThread - float with malloc") {
     REQUIRE(true == TestAllocInAllThread<float>(TEST_MALLOC_FREE, FLT_MAX, sizePerThread));
   }
 
-  SECTION("Test double datatype allocation with malloc") {
+  SECTION("PerThread - double with malloc") {
     REQUIRE(true == TestAllocInAllThread<double>(TEST_MALLOC_FREE, DBL_MAX, sizePerThread));
   }
-}
 
-/**
- * Scenario: This test validates device allocation and deallocation
- * using new/delete in every gpu thread and block for primitive data
- * types like char, short, int etc.
- */
-HIP_TEST_CASE(Unit_deviceAllocation_New_PerThread_PrimitiveDataType) {
-  int pcieAtomic = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
-  if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
-  }
-  constexpr size_t sizePerThread = 128;
-
-  // new/delete tests
-  SECTION("Test char datatype allocation with new") {
+  SECTION("PerThread - char with new") {
     REQUIRE(true == TestAllocInAllThread<char>(TEST_NEW_DELETE, SCHAR_MAX, sizePerThread));
   }
 
-  SECTION("Test short datatype allocation with new") {
+  SECTION("PerThread - short with new") {
     REQUIRE(true == TestAllocInAllThread<int16_t>(TEST_NEW_DELETE, SHRT_MAX, sizePerThread));
   }
 
-  SECTION("Test int datatype allocation with new") {
+  SECTION("PerThread - int with new") {
     REQUIRE(true == TestAllocInAllThread<int32_t>(TEST_NEW_DELETE, INT_MAX, sizePerThread));
   }
 
-  SECTION("Test float datatype allocation with new") {
+  SECTION("PerThread - float with new") {
     REQUIRE(true == TestAllocInAllThread<float>(TEST_NEW_DELETE, FLT_MAX, sizePerThread));
   }
 
-  SECTION("Test double datatype allocation with new") {
+  SECTION("PerThread - double with new") {
     REQUIRE(true == TestAllocInAllThread<double>(TEST_NEW_DELETE, DBL_MAX, sizePerThread));
   }
-}
 
-/**
- * Scenario: This test validates device allocation and deallocation
- * using malloc/free in every gpu thread and block for structure.
- */
-HIP_TEST_CASE(Unit_deviceAllocation_Malloc_PerThread_StructDataType) {
-  int pcieAtomic = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
-  if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
-  }
-  constexpr size_t sizePerThread = 64;
-  struct simpleStruct sampleStr{INT_MAX,  DBL_MAX,   FLT_MAX,
-                                SHRT_MAX, SCHAR_MAX, {1, 2, 3, 4, 5, 6, 7, 8}};
-  REQUIRE(true ==
-          TestAllocInAllThread<struct simpleStruct>(TEST_MALLOC_FREE, sampleStr, sizePerThread));
-}
-
-/**
- * Scenario: This test validates device allocation and deallocation
- * using new/delete in every gpu thread and block for structure.
- */
-HIP_TEST_CASE(Unit_deviceAllocation_New_PerThread_StructDataType) {
-  int pcieAtomic = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
-  if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
-  }
-  constexpr size_t sizePerThread = 64;
-  struct simpleStruct sampleStr{INT_MAX,  DBL_MAX,   FLT_MAX,
-                                SHRT_MAX, SCHAR_MAX, {1, 2, 3, 4, 5, 6, 7, 8}};
-  REQUIRE(true ==
-          TestAllocInAllThread<struct simpleStruct>(TEST_NEW_DELETE, sampleStr, sizePerThread));
-}
-
-/**
- * Scenario: This test validates device memory allocation and free
- * in 1 thread and access in block for different primitive types like
- * char, short, int etc.
- */
-HIP_TEST_CASE(Unit_deviceAllocation_InOneThread_AccessInAllThreads) {
-  int pcieAtomic = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
-  if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
-  }
-
-  // malloc()/free() tests
-  SECTION("Test char datatype allocation with malloc") {
+  SECTION("InOneThread_AccessInAllThreads - char with malloc") {
     REQUIRE(true == TestMemoryAccessInAllThread<char>(TEST_MALLOC_FREE, 0));
   }
 
-  SECTION("Test short datatype allocation with malloc") {
+  SECTION("InOneThread_AccessInAllThreads - short with malloc") {
     REQUIRE(true == TestMemoryAccessInAllThread<int16_t>(TEST_MALLOC_FREE, 0));
   }
 
-  SECTION("Test int datatype allocation with malloc") {
+  SECTION("InOneThread_AccessInAllThreads - int with malloc") {
     REQUIRE(true == TestMemoryAccessInAllThread<int32_t>(TEST_MALLOC_FREE, 0));
   }
 
-  SECTION("Test float datatype allocation with malloc") {
+  SECTION("InOneThread_AccessInAllThreads - float with malloc") {
     REQUIRE(true == TestMemoryAccessInAllThread<float>(TEST_MALLOC_FREE, 0));
   }
 
-  SECTION("Test double datatype allocation with malloc") {
+  SECTION("InOneThread_AccessInAllThreads - double with malloc") {
     REQUIRE(true == TestMemoryAccessInAllThread<double>(TEST_MALLOC_FREE, 0));
   }
 
-  // new/delete tests
-  SECTION("Test char datatype allocation with new") {
+  SECTION("InOneThread_AccessInAllThreads - char with new") {
     REQUIRE(true == TestMemoryAccessInAllThread<char>(TEST_NEW_DELETE, 0));
   }
 
-  SECTION("Test short datatype allocation with new") {
+  SECTION("InOneThread_AccessInAllThreads - short with new") {
     REQUIRE(true == TestMemoryAccessInAllThread<int16_t>(TEST_NEW_DELETE, 0));
   }
 
-  SECTION("Test int datatype allocation with new") {
+  SECTION("InOneThread_AccessInAllThreads - int with new") {
     REQUIRE(true == TestMemoryAccessInAllThread<int32_t>(TEST_NEW_DELETE, 0));
   }
 
-  SECTION("Test float datatype allocation with new") {
+  SECTION("InOneThread_AccessInAllThreads - float with new") {
     REQUIRE(true == TestMemoryAccessInAllThread<float>(TEST_NEW_DELETE, 0));
   }
 
-  SECTION("Test double datatype allocation with new") {
+  SECTION("InOneThread_AccessInAllThreads - double with new") {
     REQUIRE(true == TestMemoryAccessInAllThread<double>(TEST_NEW_DELETE, 0));
   }
-}
 
-/**
- * Scenario: This test validates device allocation malloc, access and free
- * across multiple kernels for different primitive types like char, short,
- * int etc.
- */
-HIP_TEST_CASE(Unit_deviceAllocation_Malloc_AcrossKernels) {
-  int pcieAtomic = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
-  if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
-  }
-  // malloc()/free() tests
-  SECTION("Test char datatype allocation with malloc") {
+  SECTION("AcrossKernels - char with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernels<char>(TEST_MALLOC_FREE));
   }
 
-  SECTION("Test short datatype allocation with malloc") {
+  SECTION("AcrossKernels - short with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernels<int16_t>(TEST_MALLOC_FREE));
   }
 
-  SECTION("Test int datatype allocation with malloc") {
+  SECTION("AcrossKernels - int with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernels<int32_t>(TEST_MALLOC_FREE));
   }
 
-  SECTION("Test float datatype allocation with malloc") {
+  SECTION("AcrossKernels - float with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernels<float>(TEST_MALLOC_FREE));
   }
 
-  SECTION("Test double datatype allocation with malloc") {
+  SECTION("AcrossKernels - double with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernels<double>(TEST_MALLOC_FREE));
   }
-}
 
-/**
- * Scenario: This test validates device new, access and delete
- * across multiple kernels for different primitive types like char, short,
- * int etc.
- */
-HIP_TEST_CASE(Unit_deviceAllocation_New_AcrossKernels) {
-  int pcieAtomic = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
-  if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
-  }
-  // new/delete tests
-  SECTION("Test char datatype allocation with new") {
+  SECTION("AcrossKernels - char with new") {
     REQUIRE(true == TestMemoryAcrossMulKernels<char>(TEST_NEW_DELETE));
   }
 
-  SECTION("Test short datatype allocation with new") {
+  SECTION("AcrossKernels - short with new") {
     REQUIRE(true == TestMemoryAcrossMulKernels<int16_t>(TEST_NEW_DELETE));
   }
 
-  SECTION("Test int datatype allocation with new") {
+  SECTION("AcrossKernels - int with new") {
     REQUIRE(true == TestMemoryAcrossMulKernels<int32_t>(TEST_NEW_DELETE));
   }
 
-  SECTION("Test float datatype allocation with new") {
+  SECTION("AcrossKernels - float with new") {
     REQUIRE(true == TestMemoryAcrossMulKernels<float>(TEST_NEW_DELETE));
   }
 
-  SECTION("Test double datatype allocation with new") {
+  SECTION("AcrossKernels - double with new") {
     REQUIRE(true == TestMemoryAcrossMulKernels<double>(TEST_NEW_DELETE));
   }
+
+  SECTION("Graph - char with malloc") {
+    REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<char>(TEST_MALLOC_FREE));
+  }
+
+  SECTION("Graph - short with malloc") {
+    REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<int16_t>(TEST_MALLOC_FREE));
+  }
+
+  SECTION("Graph - int with malloc") {
+    REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<int32_t>(TEST_MALLOC_FREE));
+  }
+
+  SECTION("Graph - float with malloc") {
+    REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<float>(TEST_MALLOC_FREE));
+  }
+
+  SECTION("Graph - double with malloc") {
+    REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<double>(TEST_MALLOC_FREE));
+  }
+
+  SECTION("Graph - char with new") {
+    REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<char>(TEST_NEW_DELETE));
+  }
+
+  SECTION("Graph - short with new") {
+    REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<int16_t>(TEST_NEW_DELETE));
+  }
+
+  SECTION("Graph - int with new") {
+    REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<int32_t>(TEST_NEW_DELETE));
+  }
+
+  SECTION("Graph - float with new") {
+    REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<float>(TEST_NEW_DELETE));
+  }
+
+  SECTION("Graph - double with new") {
+    REQUIRE(true == TestMemoryAcrossMulKernelsUsingGraph<double>(TEST_NEW_DELETE));
+  }
+
+  SECTION("MulKernels_MulThreads - char with malloc") {
+    REQUIRE(true == TestDevMemAllocMulKerMulThrd<char>(TEST_MALLOC_FREE));
+  }
+
+  SECTION("MulKernels_MulThreads - short with malloc") {
+    REQUIRE(true == TestDevMemAllocMulKerMulThrd<int16_t>(TEST_MALLOC_FREE));
+  }
+
+  SECTION("MulKernels_MulThreads - int with malloc") {
+    REQUIRE(true == TestDevMemAllocMulKerMulThrd<int32_t>(TEST_MALLOC_FREE));
+  }
+
+  SECTION("MulKernels_MulThreads - float with malloc") {
+    REQUIRE(true == TestDevMemAllocMulKerMulThrd<float>(TEST_MALLOC_FREE));
+  }
+
+  SECTION("MulKernels_MulThreads - double with malloc") {
+    REQUIRE(true == TestDevMemAllocMulKerMulThrd<double>(TEST_MALLOC_FREE));
+  }
+
+  SECTION("MulKernels_MulThreads - char with new") {
+    REQUIRE(true == TestDevMemAllocMulKerMulThrd<char>(TEST_NEW_DELETE));
+  }
+
+  SECTION("MulKernels_MulThreads - short with new") {
+    REQUIRE(true == TestDevMemAllocMulKerMulThrd<int16_t>(TEST_NEW_DELETE));
+  }
+
+  SECTION("MulKernels_MulThreads - int with new") {
+    REQUIRE(true == TestDevMemAllocMulKerMulThrd<int32_t>(TEST_NEW_DELETE));
+  }
+
+  SECTION("MulKernels_MulThreads - float with new") {
+    REQUIRE(true == TestDevMemAllocMulKerMulThrd<float>(TEST_NEW_DELETE));
+  }
+
+  SECTION("MulKernels_MulThreads - double with new") {
+    REQUIRE(true == TestDevMemAllocMulKerMulThrd<double>(TEST_NEW_DELETE));
+  }
 }
 
+
 /**
- * Scenarios:
- * A) This test validates device allocation malloc, access and free
- * across multiple kernels for nested structure.
- * B) This test also validates memory allocation and deallocation through
- * __device__ functions.
+ * Scenario: This test validates device allocation and deallocation
+ * using malloc/free and new/delete for complex data types (struct, complex structure, union).
  */
-HIP_TEST_CASE(Unit_deviceAllocation_Malloc_ComplexDataType) {
+HIP_TEST_CASE(Unit_deviceAllocation_ComplexDataType) {
   int pcieAtomic = 0;
+  constexpr size_t sizePerThread = 64;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
     return;
   }
 
-  // malloc()/free() tests
-  REQUIRE(true == TestMemoryAccessInAllThread_CmplxStr(TEST_MALLOC_FREE));
-}
-
-/**
- * Scenario:
- * A) This test validates device allocation malloc, access and free
- * across multiple kernels for nested structure.
- * B) This test also validates memory allocation and deallocation through
- * __device__ functions.
- */
-HIP_TEST_CASE(Unit_deviceAllocation_New_ComplexDataType) {
-  int pcieAtomic = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
-  if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+  SECTION("Struct - malloc") {
+    struct simpleStruct sampleStr{INT_MAX,  DBL_MAX,   FLT_MAX,
+                                  SHRT_MAX, SCHAR_MAX, {1, 2, 3, 4, 5, 6, 7, 8}};
+    REQUIRE(true ==
+            TestAllocInAllThread<struct simpleStruct>(TEST_MALLOC_FREE, sampleStr, sizePerThread));
   }
-  // new/delete tests
-  REQUIRE(true == TestMemoryAccessInAllThread_CmplxStr(TEST_NEW_DELETE));
-}
 
-/**
- * Scenario: This test validates device allocation malloc, access and free
- * across multiple kernels for Union data type.
- */
-HIP_TEST_CASE(Unit_deviceAllocation_Malloc_UnionType) {
-  int pcieAtomic = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
-  if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+  SECTION("Struct - new") {
+    struct simpleStruct sampleStr{INT_MAX,  DBL_MAX,   FLT_MAX,
+                                  SHRT_MAX, SCHAR_MAX, {1, 2, 3, 4, 5, 6, 7, 8}};
+    REQUIRE(true ==
+            TestAllocInAllThread<struct simpleStruct>(TEST_NEW_DELETE, sampleStr, sizePerThread));
   }
-  // malloc()/free() tests
-  REQUIRE(true == TestMemoryAccessInAllThread_Union(TEST_MALLOC_FREE));
-}
 
-/**
- * Scenario: This test validates device allocation new, access and delete
- * across multiple kernels for Union data type.
- */
-HIP_TEST_CASE(Unit_deviceAllocation_New_UnionType) {
-  int pcieAtomic = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
-  if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+  SECTION("ComplexStructure - malloc") {
+    REQUIRE(true == TestMemoryAccessInAllThread_CmplxStr(TEST_MALLOC_FREE));
   }
-  // new/delete tests
-  REQUIRE(true == TestMemoryAccessInAllThread_Union(TEST_NEW_DELETE));
+
+  SECTION("ComplexStructure - new") {
+    REQUIRE(true == TestMemoryAccessInAllThread_CmplxStr(TEST_NEW_DELETE));
+  }
+
+  SECTION("Union - malloc") {
+    REQUIRE(true == TestMemoryAccessInAllThread_Union(TEST_MALLOC_FREE));
+  }
+
+  SECTION("Union - new") { REQUIRE(true == TestMemoryAccessInAllThread_Union(TEST_NEW_DELETE)); }
 }
 
 /**
  * Scenario: This test validates device allocation and deallocation
- * using malloc/free in every gpu thread and block using Single
- * Code Object kernel.
+ * using malloc/free and new/delete with code objects (single and multiple code objects).
  */
-HIP_TEST_CASE(Unit_deviceAllocation_Malloc_SingleCodeObj) {
+HIP_TEST_CASE(Unit_deviceAllocation_CodeObjects) {
   int pcieAtomic = 0;
+  constexpr size_t sizePerThread = 128;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
     return;
   }
-  constexpr size_t sizePerThread = 128;
 
-  REQUIRE(true == TestAlloc_Load_SingleKer_AllocFree(TEST_MALLOC_FREE, INT_MAX, sizePerThread));
-}
-
-/**
- * Scenario: This test validates device allocation and deallocation
- * using new/delete in every gpu thread and block using Single
- * Code Object kernel.
- */
-HIP_TEST_CASE(Unit_deviceAllocation_New_SingleCodeObj) {
-  int pcieAtomic = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
-  if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+  SECTION("SingleCodeObj - malloc") {
+    REQUIRE(true == TestAlloc_Load_SingleKer_AllocFree(TEST_MALLOC_FREE, INT_MAX, sizePerThread));
   }
-  constexpr size_t sizePerThread = 128;
 
-  REQUIRE(true == TestAlloc_Load_SingleKer_AllocFree(TEST_NEW_DELETE, INT_MAX, sizePerThread));
+  SECTION("SingleCodeObj - new") {
+    REQUIRE(true == TestAlloc_Load_SingleKer_AllocFree(TEST_NEW_DELETE, INT_MAX, sizePerThread));
+  }
+
+  SECTION("MulCodeObj - malloc") {
+    REQUIRE(true == TestAlloc_Load_MultKernels(TEST_MALLOC_FREE, INT_MAX));
+  }
+
+  SECTION("MulCodeObj - new") {
+    REQUIRE(true == TestAlloc_Load_MultKernels(TEST_NEW_DELETE, INT_MAX));
+  }
 }
 
 #if HT_NVIDIA
 /**
  * Scenario: This test validates device allocation and deallocation
- * using malloc/free in multikernel and multistream environment.
+ * using malloc/free and new/delete in multikernel and multistream environment.
  */
-HIP_TEST_CASE(Unit_deviceAllocation_Malloc_PerThread_MultKerMultStrm) {
   // malloc()/free() tests
-  SECTION("Test char datatype allocation with malloc") {
+  SECTION("char with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernels<char>(TEST_MALLOC_FREE, true));
   }
 
-  SECTION("Test short datatype allocation with malloc") {
+  SECTION("short with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernels<int16_t>(TEST_MALLOC_FREE, true));
   }
 
-  SECTION("Test int datatype allocation with malloc") {
+  SECTION("int with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernels<int32_t>(TEST_MALLOC_FREE, true));
   }
 
-  SECTION("Test float datatype allocation with malloc") {
+  SECTION("float with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernels<float>(TEST_MALLOC_FREE, true));
   }
 
-  SECTION("Test double datatype allocation with malloc") {
+  SECTION("double with malloc") {
     REQUIRE(true == TestMemoryAcrossMulKernels<double>(TEST_MALLOC_FREE, true));
   }
-}
 
-/**
- * Scenario: This test validates device allocation and deallocation
- * using new/delete in multikernel and multistream environment.
- */
-HIP_TEST_CASE(Unit_deviceAllocation_New_PerThread_MultKerMultStrm) {
-  // new/delete tests
-  SECTION("Test char datatype allocation with new") {
+  SECTION("char with new") {
     REQUIRE(true == TestMemoryAcrossMulKernels<char>(TEST_NEW_DELETE, true));
   }
 
-  SECTION("Test short datatype allocation with new") {
+  SECTION("short with new") {
     REQUIRE(true == TestMemoryAcrossMulKernels<int16_t>(TEST_NEW_DELETE, true));
   }
 
-  SECTION("Test int datatype allocation with new") {
+  SECTION("int with new") {
     REQUIRE(true == TestMemoryAcrossMulKernels<int32_t>(TEST_NEW_DELETE, true));
   }
 
-  SECTION("Test float datatype allocation with new") {
+  SECTION("float with new") {
     REQUIRE(true == TestMemoryAcrossMulKernels<float>(TEST_NEW_DELETE, true));
   }
 
-  SECTION("Test double datatype allocation with new") {
+  SECTION("double with new") {
     REQUIRE(true == TestMemoryAcrossMulKernels<double>(TEST_NEW_DELETE, true));
   }
 }
@@ -1311,33 +1259,24 @@ HIP_TEST_CASE(Unit_deviceAllocation_New_PerThread_Graph) {
 }
 
 /**
- * Scenario: This test validates device allocation malloc, access and free
+ * Scenario: This test validates device allocation malloc/new, access and free/delete
  * using pointers to device functions.
  */
-HIP_TEST_CASE(Unit_deviceAllocation_Malloc_DeviceFunc) {
+HIP_TEST_CASE(Unit_deviceAllocation_DeviceFunc) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
     return;
   }
-  // malloc/free tests
-  REQUIRE(true == TestAllocInDeviceFunc(TEST_MALLOC_FREE));
-}
 
-/**
- * Scenario: This test validates device allocation new, access and delete
- * using pointers to device functions.
- */
-HIP_TEST_CASE(Unit_deviceAllocation_New_DeviceFunc) {
-  int pcieAtomic = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
-  if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+  SECTION("Test device function allocation with malloc") {
+    REQUIRE(true == TestAllocInDeviceFunc(TEST_MALLOC_FREE));
   }
-  // new/delete tests
-  REQUIRE(true == TestAllocInDeviceFunc(TEST_NEW_DELETE));
+
+  SECTION("Test device function allocation with new") {
+    REQUIRE(true == TestAllocInDeviceFunc(TEST_NEW_DELETE));
+  }
 }
 
 /**
@@ -1373,128 +1312,52 @@ HIP_TEST_CASE(Unit_deviceAllocation_VirtualFunction) {
   free(outputVec_h);
 }
 
-/**
- * Scenario: This test validates device allocation malloc, access and free
- * across multiple kernels launched using threads.
- */
-HIP_TEST_CASE(Unit_deviceAllocation_Malloc_MulKernels_MulThreads) {
-  int pcieAtomic = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
-  if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
-  }
-  // malloc()/free() tests
-  SECTION("Test char datatype allocation with malloc") {
-    REQUIRE(true == TestDevMemAllocMulKerMulThrd<char>(TEST_MALLOC_FREE));
-  }
-
-  SECTION("Test short datatype allocation with malloc") {
-    REQUIRE(true == TestDevMemAllocMulKerMulThrd<int16_t>(TEST_MALLOC_FREE));
-  }
-
-  SECTION("Test int datatype allocation with malloc") {
-    REQUIRE(true == TestDevMemAllocMulKerMulThrd<int32_t>(TEST_MALLOC_FREE));
-  }
-
-  SECTION("Test float datatype allocation with malloc") {
-    REQUIRE(true == TestDevMemAllocMulKerMulThrd<float>(TEST_MALLOC_FREE));
-  }
-
-  SECTION("Test double datatype allocation with malloc") {
-    REQUIRE(true == TestDevMemAllocMulKerMulThrd<double>(TEST_MALLOC_FREE));
-  }
-}
-
-/**
- * Scenario: This test validates device new, access and delete
- * across multiple kernels launched using threads.
- */
-HIP_TEST_CASE(Unit_deviceAllocation_New_MulKernels_MulThreads) {
-  int pcieAtomic = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
-  if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
-  }
-  // new/delete tests
-  SECTION("Test char datatype allocation with new") {
-    REQUIRE(true == TestDevMemAllocMulKerMulThrd<char>(TEST_NEW_DELETE));
-  }
-
-  SECTION("Test short datatype allocation with new") {
-    REQUIRE(true == TestDevMemAllocMulKerMulThrd<int16_t>(TEST_NEW_DELETE));
-  }
-
-  SECTION("Test int datatype allocation with new") {
-    REQUIRE(true == TestDevMemAllocMulKerMulThrd<int32_t>(TEST_NEW_DELETE));
-  }
-
-  SECTION("Test float datatype allocation with new") {
-    REQUIRE(true == TestDevMemAllocMulKerMulThrd<float>(TEST_NEW_DELETE));
-  }
-
-  SECTION("Test double datatype allocation with new") {
-    REQUIRE(true == TestDevMemAllocMulKerMulThrd<double>(TEST_NEW_DELETE));
-  }
-}
-
 #if HT_AMD
-// Scenarios Unit_deviceAllocation_Malloc_SingKernels_MulThreads and
-// are failing on NVIDIA platform.
+// Scenarios Unit_deviceAllocation_SingKernels_MulThreads are failing on NVIDIA platform.
 /**
- * Scenario: This test validates device allocation malloc, access and free
+ * Scenario: This test validates device allocation malloc/new, access and free/delete
  * in a single kernel launched using threads.
  */
-HIP_TEST_CASE(Unit_deviceAllocation_Malloc_SingKernels_MulThreads) {
+HIP_TEST_CASE(Unit_deviceAllocation_SingKernels_MulThreads) {
   int pcieAtomic = 0;
   HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
   if (!pcieAtomic) {
     HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
     return;
   }
-  // malloc()/free() tests
-  std::vector<std::thread> tests;
-  // Spawn the test threads
-  for (int idx = 0; idx < num_threads; idx++) {
-    thread_results[idx] = false;
-    tests.push_back(std::thread(runTestMemoryAccessInAllThread<int32_t>, TEST_MALLOC_FREE, idx));
-  }
-  // Wait for all threads to complete
-  for (std::thread& t : tests) {
-    t.join();
-  }
-  // Verify All Results
-  for (int idx = 0; idx < num_threads; idx++) {
-    REQUIRE(thread_results[idx]);
-  }
-}
 
-/**
- * Scenario: This test validates device new, access and delete
- * in a single kernel launched using threads.
- */
-HIP_TEST_CASE(Unit_deviceAllocation_New_SingKernels_MulThreads) {
-  int pcieAtomic = 0;
-  HIP_CHECK(hipDeviceGetAttribute(&pcieAtomic, hipDeviceAttributeHostNativeAtomicSupported, 0));
-  if (!pcieAtomic) {
-    HipTest::HIP_SKIP_TEST(HipTest::SkipReason::kPcieAtomicUnsupported);
-    return;
+  SECTION("Test single kernel multi-thread allocation with malloc") {
+    std::vector<std::thread> tests;
+    // Spawn the test threads
+    for (int idx = 0; idx < num_threads; idx++) {
+      thread_results[idx] = false;
+      tests.push_back(std::thread(runTestMemoryAccessInAllThread<int32_t>, TEST_MALLOC_FREE, idx));
+    }
+    // Wait for all threads to complete
+    for (std::thread& t : tests) {
+      t.join();
+    }
+    // Verify All Results
+    for (int idx = 0; idx < num_threads; idx++) {
+      REQUIRE(thread_results[idx]);
+    }
   }
-  // new/delete tests
-  std::vector<std::thread> tests;
-  // Spawn the test threads
-  for (int idx = 0; idx < num_threads; idx++) {
-    thread_results[idx] = false;
-    tests.push_back(std::thread(runTestMemoryAccessInAllThread<int32_t>, TEST_NEW_DELETE, idx));
-  }
-  // Wait for all threads to complete
-  for (std::thread& t : tests) {
-    t.join();
-  }
-  // Verify All Results
-  for (int idx = 0; idx < num_threads; idx++) {
-    REQUIRE(thread_results[idx]);
+
+  SECTION("Test single kernel multi-thread allocation with new") {
+    std::vector<std::thread> tests;
+    // Spawn the test threads
+    for (int idx = 0; idx < num_threads; idx++) {
+      thread_results[idx] = false;
+      tests.push_back(std::thread(runTestMemoryAccessInAllThread<int32_t>, TEST_NEW_DELETE, idx));
+    }
+    // Wait for all threads to complete
+    for (std::thread& t : tests) {
+      t.join();
+    }
+    // Verify All Results
+    for (int idx = 0; idx < num_threads; idx++) {
+      REQUIRE(thread_results[idx]);
+    }
   }
 }
 #endif


### PR DESCRIPTION
## Motivation

Currently the CI spend 75% of its time on tests that take less than 0.65 seconds. This means most of the runtime is initializing and de-initializing HIP.  This PR reduces the number of TEST_CASES by combining the test files together. This also reduces duplicate code and results in fewer total lines,.

There is no reduction in test coverage with this change

## Technical Details

We merge multiple TEST_CASE's into single TEST_CASE's and separate them with SECTION.

## JIRA ID

Part of SWDEV-574976

## Test Plan

Refactor in testing, does not need its own tests

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
