### PR TITLE
[SWDEV-549108] Increase gpu_metrics API execution test threshold

### DIFF
--- a/projects/rocm-smi-lib/tests/rocm_smi_test/functional/measure_api_execution_time.cc
+++ b/projects/rocm-smi-lib/tests/rocm_smi_test/functional/measure_api_execution_time.cc
@@ -101,6 +101,7 @@ void TestMeasureApiExecutionTime::Run(void) {
    * 3) Setup backwards compatiblity (~100 microseconds)
    * 4) Put data into structures (~100 microseconds)
    * 5) Pass to public structure (~100 microseconds)
+   * 6) Additional gpu_metric read time for Navi (~1000 microseconds)
    * ---------------------------
    * ~2100 worst case
    *
@@ -114,7 +115,7 @@ void TestMeasureApiExecutionTime::Run(void) {
    * procedures
    * c) Expirement with other file reading options
    **/
-  constexpr float kMETRICS_ELAPSED_MICROSEC_BASE = (2100);
+  constexpr float kMETRICS_ELAPSED_MICROSEC_BASE = (3100);
   bool skip = false;
 
   TestBase::Run();


### PR DESCRIPTION
## Motivation

rsmitest MeasureAPI performance failure on Navi.

## Technical Details

Increased threshold from 2100 μs to 3100 µs to accommodate gpu_metric read time variation across Navi systems.

## JIRA ID

SWDEV-549108

## Test Plan

rsmitstReadOnly.TestMeasureApiExecutionTime 

## Test Result

Passed

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
