### PR TITLE
Add automatic PyTorch library discovery for Python applications

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-run/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-run/impl.cpp
@@ -192,6 +192,8 @@ prepare_environment_for_run(parser_data_t& _data)
         rocprofsys::argparse::add_ld_preload(_data);
         rocprofsys::argparse::add_ld_library_path(_data);
     }
+
+    rocprofsys::argparse::add_torch_library_path(_data, _data.verbose > 0);
 }
 
 void

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-run/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-run/impl.cpp
@@ -194,6 +194,8 @@ prepare_environment_for_run(parser_data_t& _data)
     }
 
     rocprofsys::argparse::add_torch_library_path(_data, _data.verbose > 0);
+
+    rocprofsys::common::consolidate_env_entries(_data.current);
 }
 
 void

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/impl.cpp
@@ -933,3 +933,11 @@ parse_args(int argc, char** argv, std::vector<char*>& _env)
 
     return _outv;
 }
+
+void
+add_torch_library_path(std::vector<char*>& envp, const std::vector<char*>& argv,
+                       bool _verbose)
+{
+    rocprofsys::common::add_torch_library_path(envp, argv, _verbose, updated_envs,
+                                               original_envs);
+}

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/impl.cpp
@@ -935,9 +935,7 @@ parse_args(int argc, char** argv, std::vector<char*>& _env)
 }
 
 void
-add_torch_library_path(std::vector<char*>& envp, const std::vector<char*>& argv,
-                       bool _verbose)
+add_torch_library_path(std::vector<char*>& envp, const std::vector<char*>& argv)
 {
-    rocprofsys::common::add_torch_library_path(envp, argv, _verbose, updated_envs,
-                                               original_envs);
+    rocprofsys::common::add_torch_library_path(envp, argv, verbose > 0, updated_envs);
 }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/rocprof-sys-sample.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/rocprof-sys-sample.cpp
@@ -51,6 +51,8 @@ main(int argc, char** argv)
             _argv.emplace_back(argv[i]);
     }
 
+    add_torch_library_path(_env, _argv, false);
+
     print_updated_environment(_env);
 
     if(!_argv.empty())

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/rocprof-sys-sample.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/rocprof-sys-sample.cpp
@@ -51,7 +51,7 @@ main(int argc, char** argv)
             _argv.emplace_back(argv[i]);
     }
 
-    add_torch_library_path(_env, _argv, false);
+    add_torch_library_path(_env, _argv);
 
     print_updated_environment(_env);
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/rocprof-sys-sample.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/rocprof-sys-sample.hpp
@@ -35,3 +35,7 @@ get_initial_environment();
 
 std::vector<char*>
 parse_args(int argc, char** argv, std::vector<char*>& envp);
+
+void
+add_torch_library_path(std::vector<char*>& envp, const std::vector<char*>& argv,
+                       bool verbose = false);

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/rocprof-sys-sample.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-sample/rocprof-sys-sample.hpp
@@ -37,5 +37,4 @@ std::vector<char*>
 parse_args(int argc, char** argv, std::vector<char*>& envp);
 
 void
-add_torch_library_path(std::vector<char*>& envp, const std::vector<char*>& argv,
-                       bool verbose = false);
+add_torch_library_path(std::vector<char*>& envp, const std::vector<char*>& argv);

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -26,9 +26,11 @@
 
 #include "common/join.hpp"
 #include <algorithm>
+#include <cctype>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -266,6 +268,85 @@ discover_llvm_libdir_for_ompt(bool verbose = false)
     return {};
 }
 
+inline bool
+is_python_interpreter(std::string_view executable)
+{
+    if(executable.empty()) return false;
+
+    // Extract basename from path
+    auto pos = executable.rfind('/');
+    auto basename =
+        (pos != std::string_view::npos) ? executable.substr(pos + 1) : executable;
+
+    if(basename == "python" || basename == "python3") return true;
+
+    if(basename.size() >= 9 && basename.substr(0, 7) == "python3")
+    {
+        auto version_part = basename.substr(7);
+        if(version_part.empty()) return true;
+        if(version_part[0] != '.') return false;
+
+        for(size_t i = 1; i < version_part.size(); ++i)
+        {
+            if(std::isdigit(static_cast<unsigned char>(version_part[i])) == 0)
+                return false;
+        }
+        return true;
+    }
+
+    return false;
+}
+
+inline std::string
+discover_torch_libpath(const std::string& python_binary, bool verbose = false)
+{
+    if(python_binary.empty()) return {};
+
+    std::string cmd =
+        python_binary + " -c \"import torch; print(torch.__path__[0])\" 2>/dev/null";
+
+    FILE* pipe = popen(cmd.c_str(), "r");
+    if(!pipe)
+    {
+        ROCPROFSYS_ENVIRON_LOG(verbose, "Failed to execute command: %s\n", cmd.c_str());
+        return {};
+    }
+
+    char        buffer[512];
+    std::string result;
+    if(fgets(buffer, sizeof(buffer), pipe)) result = buffer;
+
+    int status = pclose(pipe);
+
+    if(status != 0 || result.empty())
+    {
+        ROCPROFSYS_ENVIRON_LOG(verbose, "torch not found for Python interpreter: %s\n",
+                               python_binary.c_str());
+        return {};
+    }
+
+    while(!result.empty() &&
+          (result.back() == '\n' || result.back() == '\r' || result.back() == ' '))
+    {
+        result.pop_back();
+    }
+
+    if(result.empty()) return {};
+
+    std::string torch_libdir = result + "/lib";
+
+    if(!::tim::filepath::direxists(torch_libdir))
+    {
+        ROCPROFSYS_ENVIRON_LOG(verbose, "torch lib directory does not exist: %s\n",
+                               torch_libdir.c_str());
+        return {};
+    }
+
+    ROCPROFSYS_ENVIRON_LOG(verbose, "Discovered torch library path: %s\n",
+                           torch_libdir.c_str());
+    return torch_libdir;
+}
+
 enum class update_mode : uint8_t
 {
     REPLACE = 0,
@@ -341,6 +422,50 @@ update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_va
         return;
     }
     _environ.emplace_back(strdup(join('=', _env_var, _env_val_str).c_str()));
+}
+
+template <typename UpdatedEnvsT, typename OriginalEnvsT>
+inline void
+add_torch_library_path(std::vector<char*>& envp, const std::vector<char*>& argv,
+                       bool verbose, UpdatedEnvsT& updated_envs,
+                       const OriginalEnvsT& original_envs)
+{
+    (void) original_envs;
+
+    if(argv.empty() || argv.front() == nullptr) return;
+    if(!is_python_interpreter(argv.front())) return;
+
+    auto torch_libpath = discover_torch_libpath(argv.front(), verbose);
+    if(torch_libpath.empty()) return;
+
+    std::unordered_set<std::string> seen{ torch_libpath };
+    std::string                     result = torch_libpath;
+
+    constexpr std::string_view ld_prefix = "LD_LIBRARY_PATH=";
+
+    auto is_ld_path = [&](char* entry) {
+        return entry &&
+               std::string_view{ entry }.substr(0, ld_prefix.length()) == ld_prefix;
+    };
+
+    for(auto& entry : envp)
+    {
+        if(!is_ld_path(entry)) continue;
+
+        std::istringstream stream{ std::string{ entry + ld_prefix.length() } };
+        for(std::string path; std::getline(stream, path, ':');)
+        {
+            if(!path.empty() && seen.insert(path).second) result += ":" + path;
+        }
+
+        free(entry);
+        entry = nullptr;
+    }
+
+    envp.erase(std::remove(envp.begin(), envp.end(), nullptr), envp.end());
+    envp.emplace_back(strdup(join("", ld_prefix, result).c_str()));
+
+    updated_envs.emplace(ld_prefix.substr(0, ld_prefix.length() - 1));
 }
 
 }  // namespace common

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -461,5 +461,92 @@ add_torch_library_path(std::vector<char*>& envp, const std::vector<char*>& argv,
     updated_envs.emplace(ld_prefix.substr(0, ld_prefix.length() - 1));
 }
 
+inline void
+consolidate_env_entries(std::vector<char*>& envp)
+{
+    constexpr char delim = ':';
+
+    struct key_data
+    {
+        std::vector<std::string>        parts;
+        std::unordered_set<std::string> seen;
+
+        void add_unique(std::string part)
+        {
+            if(!part.empty() && seen.insert(part).second)
+                parts.emplace_back(std::move(part));
+        }
+    };
+
+    auto parse_entry = [](std::string_view entry)
+        -> std::optional<std::pair<std::string_view, std::string_view>> {
+        auto eq_pos = entry.find('=');
+        if(eq_pos == std::string_view::npos) return std::nullopt;
+        return std::make_pair(entry.substr(0, eq_pos), entry.substr(eq_pos + 1));
+    };
+
+    auto join_parts = [delim](std::string_view                key,
+                              const std::vector<std::string>& parts) {
+        std::string result;
+        result.reserve(key.size() + 1 + parts.size() * 16);
+        result.append(key);
+        result += '=';
+
+        for(const auto& part : parts)
+        {
+            if(part != parts.front()) result += delim;
+            result.append(part);
+        }
+        return result;
+    };
+
+    std::unordered_map<std::string_view, key_data> key_map;
+    std::vector<std::string_view>                  key_order;
+
+    for(auto* entry : envp)
+    {
+        if(!entry)
+        {
+            continue;
+        }
+
+        auto parsed = parse_entry(entry);
+        if(!parsed)
+        {
+            continue;
+        }
+
+        auto [key, value] = *parsed;
+
+        auto [it, inserted] = key_map.try_emplace(key);
+        if(inserted)
+        {
+            key_order.emplace_back(key);
+        }
+
+        auto&              data = it->second;
+        std::istringstream stream{ std::string{ value } };
+        for(std::string part; std::getline(stream, part, delim);)
+        {
+            data.add_unique(part);
+        }
+    }
+
+    std::vector<char*> result;
+    result.reserve(key_order.size());
+
+    for(auto key : key_order)
+    {
+        result.emplace_back(strdup(join_parts(key, key_map[key].parts).c_str()));
+    }
+
+    for(auto* entry : envp)
+    {
+        free(entry);
+    }
+
+    envp = std::move(result);
+}
+
 }  // namespace common
 }  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -273,28 +273,24 @@ is_python_interpreter(std::string_view executable)
 {
     if(executable.empty()) return false;
 
-    // Extract basename from path
-    auto pos = executable.rfind('/');
-    auto basename =
-        (pos != std::string_view::npos) ? executable.substr(pos + 1) : executable;
+    const auto slash_pos = executable.rfind('/');
+    const auto basename  = (slash_pos != std::string_view::npos)
+                               ? executable.substr(slash_pos + 1)
+                               : executable;
 
     if(basename == "python" || basename == "python3") return true;
 
-    if(basename.size() >= 9 && basename.substr(0, 7) == "python3")
-    {
-        auto version_part = basename.substr(7);
-        if(version_part.empty()) return true;
-        if(version_part[0] != '.') return false;
+    constexpr std::string_view python3_prefix = "python3.";
 
-        for(size_t i = 1; i < version_part.size(); ++i)
-        {
-            if(std::isdigit(static_cast<unsigned char>(version_part[i])) == 0)
-                return false;
-        }
-        return true;
-    }
+    const bool has_valid_prefix =
+        basename.size() > python3_prefix.size() &&
+        basename.substr(0, python3_prefix.size()) == python3_prefix;
+    if(!has_valid_prefix) return false;
 
-    return false;
+    const auto version_digits = basename.substr(python3_prefix.size());
+
+    return std::all_of(version_digits.begin(), version_digits.end(),
+                       [](unsigned char c) { return std::isdigit(c) != 0; });
 }
 
 inline std::string
@@ -302,8 +298,8 @@ discover_torch_libpath(const std::string& python_binary, bool verbose = false)
 {
     if(python_binary.empty()) return {};
 
-    std::string cmd =
-        python_binary + " -c \"import torch; print(torch.__path__[0])\" 2>/dev/null";
+    const auto cmd = "\"" + python_binary +
+                     "\" -c \"import torch; print(torch.__path__[0])\" 2>/dev/null";
 
     FILE* pipe = popen(cmd.c_str(), "r");
     if(!pipe)
@@ -424,14 +420,11 @@ update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_va
     _environ.emplace_back(strdup(join('=', _env_var, _env_val_str).c_str()));
 }
 
-template <typename UpdatedEnvsT, typename OriginalEnvsT>
+template <typename UpdatedEnvsT>
 inline void
 add_torch_library_path(std::vector<char*>& envp, const std::vector<char*>& argv,
-                       bool verbose, UpdatedEnvsT& updated_envs,
-                       const OriginalEnvsT& original_envs)
+                       bool verbose, UpdatedEnvsT& updated_envs)
 {
-    (void) original_envs;
-
     if(argv.empty() || argv.front() == nullptr) return;
     if(!is_python_interpreter(argv.front())) return;
 

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -523,7 +523,7 @@ consolidate_env_entries(std::vector<char*>& envp)
         std::string result;
 
         const auto total_parts_length = std::accumulate(
-            parts.begin(), parts.end(), 0,
+            parts.begin(), parts.end(), std::size_t{ 0 },
             [](std::size_t acc, const std::string& part) { return acc + part.size(); });
 
         const auto delim_count       = parts.size() - 1;

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -30,6 +30,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <numeric>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -199,7 +200,7 @@ remove_env(std::vector<char*>& _environ, std::string_view _env_var,
     {
         if(match(itr))
         {
-            free(itr);
+            std::free(itr);
             itr = nullptr;
         }
     }
@@ -290,13 +291,40 @@ is_python_interpreter(std::string_view executable)
     const auto version_digits = basename.substr(python3_prefix.size());
 
     return std::all_of(version_digits.begin(), version_digits.end(),
-                       [](unsigned char c) { return std::isdigit(c) != 0; });
+                       [](unsigned char c) { return std::isdigit(c); });
 }
 
 inline std::string
 discover_torch_libpath(const std::string& python_binary, bool verbose = false)
 {
     if(python_binary.empty()) return {};
+
+    const auto is_safe_executable_path = [](const std::string& path) {
+        // Allow only a conservative set of characters in the executable path to
+        // avoid injection when used in a shell command.
+        for(unsigned char c : path)
+        {
+            if(std::isalnum(c) != 0) continue;
+            switch(c)
+            {
+                case '/':
+                case '.':
+                case '_':
+                case '-':
+                case '+': break;
+                default: return false;
+            }
+        }
+        return true;
+    };
+
+    if(!is_safe_executable_path(python_binary))
+    {
+        ROCPROFSYS_ENVIRON_LOG(
+            verbose, "Unsafe characters detected in Python interpreter path: %s\n",
+            python_binary.c_str());
+        return {};
+    }
 
     const auto cmd = "\"" + python_binary +
                      "\" -c \"import torch; print(torch.__path__[0])\" 2>/dev/null";
@@ -308,9 +336,14 @@ discover_torch_libpath(const std::string& python_binary, bool verbose = false)
         return {};
     }
 
-    char        buffer[512];
+    char        buffer[1024];
     std::string result;
-    if(fgets(buffer, sizeof(buffer), pipe)) result = buffer;
+    while(fgets(buffer, sizeof(buffer), pipe))
+    {
+        result.append(buffer);
+        // stop if we've read the full line (torch path is printed on a single line)
+        if(!result.empty() && result.back() == '\n') break;
+    }
 
     int status = pclose(pipe);
 
@@ -412,7 +445,7 @@ update_env(std::vector<char*>& _environ, std::string_view _env_var, Tp&& _env_va
         }
         else
         {
-            free(itr);
+            std::free(itr);
             itr = strdup(join('=', _env_var, _env_val_str).c_str());
         }
         return;
@@ -451,7 +484,7 @@ add_torch_library_path(std::vector<char*>& envp, const std::vector<char*>& argv,
             if(!path.empty() && seen.insert(path).second) result += ":" + path;
         }
 
-        free(entry);
+        std::free(entry);
         entry = nullptr;
     }
 
@@ -488,15 +521,26 @@ consolidate_env_entries(std::vector<char*>& envp)
     auto join_parts = [delim](std::string_view                key,
                               const std::vector<std::string>& parts) {
         std::string result;
-        result.reserve(key.size() + 1 + parts.size() * 16);
+
+        const auto total_parts_length = std::accumulate(
+            parts.begin(), parts.end(), 0,
+            [](std::size_t acc, const std::string& part) { return acc + part.size(); });
+
+        const auto delim_count       = parts.size() - 1;
+        const auto equal_sign_length = 1;
+
+        result.reserve(key.size() + equal_sign_length + total_parts_length + delim_count);
         result.append(key);
         result += '=';
 
-        for(const auto& part : parts)
-        {
-            if(part != parts.front()) result += delim;
-            result.append(part);
-        }
+        result =
+            std::accumulate(parts.begin(), parts.end(), std::move(result),
+                            [delim, &parts](std::string acc, const std::string& part) {
+                                if(part != parts.front()) acc += delim;
+                                acc.append(part);
+                                return acc;
+                            });
+
         return result;
     };
 
@@ -542,7 +586,8 @@ consolidate_env_entries(std::vector<char*>& envp)
 
     for(auto* entry : envp)
     {
-        free(entry);
+        std::free(entry);
+        entry = nullptr;
     }
 
     envp = std::move(result);

--- a/projects/rocprofiler-systems/source/lib/common/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/common/tests/CMakeLists.txt
@@ -24,7 +24,7 @@ add_library(
     lib-common-tests
     OBJECT
     test_discover_llvm_libdir.cpp
-    test_discover_torch_libpath.cpp
+    test_environment.cpp
     test_path.cpp
     test_remove_env.cpp
     test_update_env.cpp

--- a/projects/rocprofiler-systems/source/lib/common/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/common/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(
     lib-common-tests
     OBJECT
     test_discover_llvm_libdir.cpp
+    test_discover_torch_libpath.cpp
     test_path.cpp
     test_remove_env.cpp
     test_update_env.cpp

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_discover_torch_libpath.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_discover_torch_libpath.cpp
@@ -1,0 +1,102 @@
+// MIT License
+//
+// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "common/environment.hpp"
+
+#include <gtest/gtest.h>
+#include <string>
+
+using namespace rocprofsys::common;
+
+//------------------------------------------------------------------------------
+// Tests for is_python_interpreter()
+//------------------------------------------------------------------------------
+
+class IsPythonInterpreterTest : public ::testing::Test
+{};
+
+TEST_F(IsPythonInterpreterTest, RecognizesPython)
+{
+    EXPECT_TRUE(is_python_interpreter("python"));
+}
+
+TEST_F(IsPythonInterpreterTest, RecognizesPython3)
+{
+    EXPECT_TRUE(is_python_interpreter("python3"));
+}
+
+TEST_F(IsPythonInterpreterTest, RecognizesPython3WithMinorVersion)
+{
+    EXPECT_TRUE(is_python_interpreter("python3.8"));
+    EXPECT_TRUE(is_python_interpreter("python3.9"));
+    EXPECT_TRUE(is_python_interpreter("python3.10"));
+    EXPECT_TRUE(is_python_interpreter("python3.11"));
+    EXPECT_TRUE(is_python_interpreter("python3.12"));
+}
+
+TEST_F(IsPythonInterpreterTest, RecognizesFullPathPython)
+{
+    EXPECT_TRUE(is_python_interpreter("/usr/bin/python"));
+    EXPECT_TRUE(is_python_interpreter("/usr/bin/python3"));
+    EXPECT_TRUE(is_python_interpreter("/usr/bin/python3.10"));
+    EXPECT_TRUE(is_python_interpreter("/home/user/venv/bin/python"));
+    EXPECT_TRUE(is_python_interpreter("/opt/conda/bin/python3.11"));
+}
+
+TEST_F(IsPythonInterpreterTest, RejectsNonPythonExecutables)
+{
+    EXPECT_FALSE(is_python_interpreter("bash"));
+    EXPECT_FALSE(is_python_interpreter("sh"));
+    EXPECT_FALSE(is_python_interpreter("ruby"));
+    EXPECT_FALSE(is_python_interpreter("node"));
+    EXPECT_FALSE(is_python_interpreter("java"));
+    EXPECT_FALSE(is_python_interpreter("/usr/bin/bash"));
+    EXPECT_FALSE(is_python_interpreter("./my_app"));
+}
+
+TEST_F(IsPythonInterpreterTest, RejectsPythonLikeNames)
+{
+    // Names that contain "python" but aren't Python interpreters
+    EXPECT_FALSE(is_python_interpreter("pythonista"));
+    EXPECT_FALSE(is_python_interpreter("python_script.py"));
+    EXPECT_FALSE(is_python_interpreter("mypython"));
+    EXPECT_FALSE(is_python_interpreter("python2"));  // We only support python3
+}
+
+TEST_F(IsPythonInterpreterTest, RejectsInvalidVersionFormats)
+{
+    EXPECT_FALSE(is_python_interpreter("python3."));
+    EXPECT_FALSE(is_python_interpreter("python3.a"));
+    EXPECT_FALSE(is_python_interpreter("python3.10a"));
+    EXPECT_FALSE(is_python_interpreter("python3x10"));
+}
+
+TEST_F(IsPythonInterpreterTest, HandlesEmptyString)
+{
+    EXPECT_FALSE(is_python_interpreter(""));
+}
+
+TEST_F(IsPythonInterpreterTest, HandlesPathsWithTrailingSlash)
+{
+    // Edge case: path ending with slash (invalid but should not crash)
+    EXPECT_FALSE(is_python_interpreter("/usr/bin/"));
+}

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_environment.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_environment.cpp
@@ -76,4 +76,7 @@ TEST_F(DuplicatedEnvironmentEntriesTest, DuplicateEnvironmentEntries)
 
     ASSERT_EQ(env_vars.size(), 1);
     EXPECT_STREQ(env_vars[0], "PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/bin2");
+
+    for(auto* entry : env_vars)
+        free(entry);
 }

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_environment.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_environment.cpp
@@ -23,13 +23,8 @@
 #include "common/environment.hpp"
 
 #include <gtest/gtest.h>
-#include <string>
 
 using namespace rocprofsys::common;
-
-//------------------------------------------------------------------------------
-// Tests for is_python_interpreter()
-//------------------------------------------------------------------------------
 
 class IsPythonInterpreterTest : public ::testing::Test
 {};
@@ -37,33 +32,17 @@ class IsPythonInterpreterTest : public ::testing::Test
 TEST_F(IsPythonInterpreterTest, RecognizesPython)
 {
     EXPECT_TRUE(is_python_interpreter("python"));
-}
-
-TEST_F(IsPythonInterpreterTest, RecognizesPython3)
-{
     EXPECT_TRUE(is_python_interpreter("python3"));
-}
-
-TEST_F(IsPythonInterpreterTest, RecognizesPython3WithMinorVersion)
-{
     EXPECT_TRUE(is_python_interpreter("python3.8"));
     EXPECT_TRUE(is_python_interpreter("python3.9"));
     EXPECT_TRUE(is_python_interpreter("python3.10"));
     EXPECT_TRUE(is_python_interpreter("python3.11"));
     EXPECT_TRUE(is_python_interpreter("python3.12"));
-}
-
-TEST_F(IsPythonInterpreterTest, RecognizesFullPathPython)
-{
     EXPECT_TRUE(is_python_interpreter("/usr/bin/python"));
     EXPECT_TRUE(is_python_interpreter("/usr/bin/python3"));
     EXPECT_TRUE(is_python_interpreter("/usr/bin/python3.10"));
     EXPECT_TRUE(is_python_interpreter("/home/user/venv/bin/python"));
     EXPECT_TRUE(is_python_interpreter("/opt/conda/bin/python3.11"));
-}
-
-TEST_F(IsPythonInterpreterTest, RejectsNonPythonExecutables)
-{
     EXPECT_FALSE(is_python_interpreter("bash"));
     EXPECT_FALSE(is_python_interpreter("sh"));
     EXPECT_FALSE(is_python_interpreter("ruby"));
@@ -71,32 +50,30 @@ TEST_F(IsPythonInterpreterTest, RejectsNonPythonExecutables)
     EXPECT_FALSE(is_python_interpreter("java"));
     EXPECT_FALSE(is_python_interpreter("/usr/bin/bash"));
     EXPECT_FALSE(is_python_interpreter("./my_app"));
-}
-
-TEST_F(IsPythonInterpreterTest, RejectsPythonLikeNames)
-{
-    // Names that contain "python" but aren't Python interpreters
     EXPECT_FALSE(is_python_interpreter("pythonista"));
     EXPECT_FALSE(is_python_interpreter("python_script.py"));
     EXPECT_FALSE(is_python_interpreter("mypython"));
-    EXPECT_FALSE(is_python_interpreter("python2"));  // We only support python3
-}
-
-TEST_F(IsPythonInterpreterTest, RejectsInvalidVersionFormats)
-{
+    EXPECT_FALSE(is_python_interpreter("python2"));
     EXPECT_FALSE(is_python_interpreter("python3."));
     EXPECT_FALSE(is_python_interpreter("python3.a"));
     EXPECT_FALSE(is_python_interpreter("python3.10a"));
     EXPECT_FALSE(is_python_interpreter("python3x10"));
-}
-
-TEST_F(IsPythonInterpreterTest, HandlesEmptyString)
-{
     EXPECT_FALSE(is_python_interpreter(""));
+    EXPECT_FALSE(is_python_interpreter("/usr/bin/"));
 }
 
-TEST_F(IsPythonInterpreterTest, HandlesPathsWithTrailingSlash)
+class DuplicatedEnvironmentEntriesTest : public ::testing::Test
+{};
+
+TEST_F(DuplicatedEnvironmentEntriesTest, DuplicateEnvironmentEntries)
 {
-    // Edge case: path ending with slash (invalid but should not crash)
-    EXPECT_FALSE(is_python_interpreter("/usr/bin/"));
+    std::vector<char*> env_vars = {
+        strdup("PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/bin2"),
+        strdup("PATH=/usr/local/bin:/usr/bin:/bin"),
+    };
+
+    consolidate_env_entries(env_vars);
+
+    ASSERT_EQ(env_vars.size(), 1);
+    EXPECT_STREQ(env_vars[0], "PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/bin2");
 }

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_environment.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_environment.cpp
@@ -1,24 +1,5 @@
-// MIT License
-//
-// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All Rights Reserved.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
 
 #include "common/environment.hpp"
 
@@ -79,4 +60,87 @@ TEST_F(DuplicatedEnvironmentEntriesTest, DuplicateEnvironmentEntries)
 
     for(auto* entry : env_vars)
         free(entry);
+}
+
+TEST_F(DuplicatedEnvironmentEntriesTest, HandlesEmptyVector)
+{
+    std::vector<char*> env_vars;
+    consolidate_env_entries(env_vars);
+    EXPECT_TRUE(env_vars.empty());
+}
+
+TEST_F(DuplicatedEnvironmentEntriesTest, HandlesNullEntries)
+{
+    std::vector<char*> env_vars = {
+        strdup("PATH=/usr/bin"),
+        nullptr,
+        strdup("PATH=/bin"),
+    };
+    consolidate_env_entries(env_vars);
+    ASSERT_EQ(env_vars.size(), 1);
+    EXPECT_STREQ(env_vars[0], "PATH=/usr/bin:/bin");
+    for(auto* entry : env_vars)
+        std::free(entry);
+}
+
+TEST_F(DuplicatedEnvironmentEntriesTest, HandlesEmptyValues)
+{
+    std::vector<char*> env_vars = {
+        strdup("EMPTY_VAR="),
+        strdup("PATH=/usr/bin"),
+    };
+    consolidate_env_entries(env_vars);
+    ASSERT_EQ(env_vars.size(), 2);
+
+    for(auto* entry : env_vars)
+        std::free(entry);
+}
+
+class AddTorchLibraryPathTest : public ::testing::Test
+{
+protected:
+    std::unordered_set<std::string> updated_envs;
+};
+
+TEST_F(AddTorchLibraryPathTest, SkipsNonPythonExecutables)
+{
+    std::vector<char*> envp = {
+        strdup("LD_LIBRARY_PATH=/usr/lib"),
+    };
+    std::vector<char*> argv = {
+        strdup("/usr/bin/bash"),
+    };
+    add_torch_library_path(envp, argv, false, updated_envs);
+    // Should not modify environment
+    ASSERT_EQ(envp.size(), 1);
+    EXPECT_STREQ(envp[0], "LD_LIBRARY_PATH=/usr/lib");
+    for(auto* entry : envp)
+        std::free(entry);
+    for(auto* entry : argv)
+        std::free(entry);
+}
+
+TEST_F(AddTorchLibraryPathTest, HandlesEmptyArgv)
+{
+    std::vector<char*> envp = {
+        strdup("LD_LIBRARY_PATH=/usr/lib"),
+    };
+    std::vector<char*> argv;
+    add_torch_library_path(envp, argv, false, updated_envs);
+    ASSERT_EQ(envp.size(), 1);
+    EXPECT_STREQ(envp[0], "LD_LIBRARY_PATH=/usr/lib");
+    for(auto* entry : envp)
+        std::free(entry);
+}
+
+TEST_F(AddTorchLibraryPathTest, HandlesNullArgvFront)
+{
+    std::vector<char*> envp = {
+        strdup("LD_LIBRARY_PATH=/usr/lib"),
+    };
+    std::vector<char*> argv = { nullptr };
+    add_torch_library_path(envp, argv, false, updated_envs);
+    ASSERT_EQ(envp.size(), 1);
+    for(auto* entry : envp)
+        std::free(entry);
 }

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -169,6 +169,14 @@ add_ld_library_path(parser_data& _data)
 }
 
 parser_data&
+add_torch_library_path(parser_data& _data, bool verbose)
+{
+    rocprofsys::common::add_torch_library_path(_data.current, _data.command, verbose,
+                                               _data.updated, _data.initial);
+    return _data;
+}
+
+parser_data&
 add_core_arguments(parser_t& _parser, parser_data& _data)
 {
     const auto* _cputime_desc =

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -172,7 +172,7 @@ parser_data&
 add_torch_library_path(parser_data& _data, bool verbose)
 {
     rocprofsys::common::add_torch_library_path(_data.current, _data.command, verbose,
-                                               _data.updated, _data.initial);
+                                               _data.updated);
     return _data;
 }
 

--- a/projects/rocprofiler-systems/source/lib/core/argparse.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.hpp
@@ -84,6 +84,9 @@ parser_data&
 add_ld_library_path(parser_data&);
 
 parser_data&
+add_torch_library_path(parser_data&, bool verbose = false);
+
+parser_data&
 add_core_arguments(parser_t&, parser_data&);
 
 parser_data&


### PR DESCRIPTION
## Motivation

When profiling PyTorch applications with rocprof-sys-run or rocprof-sys-sample, the PyTorch libraries may not be in LD_LIBRARY_PATH, causing runtime linking issues. This change automatically discovers and adds the PyTorch library path when profiling Python applications that use PyTorch.

## Technical Details

- Added `is_python_interpreter()` function to detect if the target executable is a Python interpreter (python, python3, python3.X)
- Added `discover_torch_libpath()` function that runs Python to query torch installation path via `torch.__path__`
- Added `add_torch_library_path()` template function to prepend discovered torch lib directory to LD_LIBRARY_PATH
- Added `consolidate_env_entries()` function to deduplicate environment variable entries (removes duplicate paths in colon-separated values)
- Integrated torch library path discovery into both `rocprof-sys-run` and `rocprof-sys-sample` tools

Known issue:
- Unable to detect when to add LD_LIBRARY_PATH if Python is run via a shell script, for example

## JIRA ID

AIPROFSYST-107

## Test Plan

- Unit tests for `is_python_interpreter()` covering various Python interpreter names and paths
- Unit tests for `consolidate_env_entries()` verifying deduplication of environment variable entries
- Manual testing: Profile a PyTorch Python application with rocprof-sys-run and verify torch libraries are loaded correctly

## Test Result

- `is_python_interpreter()` should correctly identify python, python3, python3.X executables (including full paths) and reject non-Python executables
- `consolidate_env_entries()` should merge duplicate environment variable keys and deduplicate path entries
- PyTorch applications should run successfully under profiling without manual LD_LIBRARY_PATH configuration
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
