### PR TITLE
[rocprofiler-systems] [PyTests for TheRock] Part 1 - Example Install paths

### DIFF
--- a/projects/rocprofiler-systems/examples/causal-helpers.cmake
+++ b/projects/rocprofiler-systems/examples/causal-helpers.cmake
@@ -1,3 +1,6 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
 #
 #   function for
 #
@@ -142,11 +145,27 @@ function(rocprofiler_systems_causal_example_executable _NAME)
     endif()
 
     if(ROCPROFSYS_INSTALL_EXAMPLES)
-        install(
-            TARGETS ${_NAME} ${_NAME}-rocprofsys ${_NAME}-coz
-            DESTINATION bin
-            COMPONENT rocprofiler-systems-examples
-            OPTIONAL
+        set(_TARGETS
+            ${_NAME}
+            ${_NAME}-rocprofsys
+            ${_NAME}-ndebug
+            ${_NAME}-rocprofsys-ndebug
+            ${_NAME}-coz
         )
+        set(_EXISTING_TARGETS)
+
+        foreach(_TARGET IN LISTS _TARGETS)
+            if(TARGET ${_TARGET})
+                list(APPEND _EXISTING_TARGETS ${_TARGET})
+            endif()
+        endforeach()
+
+        if(_EXISTING_TARGETS)
+            install(
+                TARGETS ${_EXISTING_TARGETS}
+                DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+                COMPONENT rocprofiler-systems-examples
+            )
+        endif()
     endif()
 endfunction()

--- a/projects/rocprofiler-systems/examples/code-coverage/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/code-coverage/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(rocprofiler-systems-code-coverage-example LANGUAGES CXX)
@@ -22,7 +25,11 @@ target_link_libraries(code-coverage PRIVATE Threads::Threads)
 target_compile_options(code-coverage PRIVATE ${_FLAGS})
 
 if(ROCPROFSYS_INSTALL_EXAMPLES)
-    install(TARGETS code-coverage DESTINATION bin COMPONENT rocprofiler-systems-examples)
+    install(
+        TARGETS code-coverage
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+        COMPONENT rocprofiler-systems-examples
+    )
 endif()
 
 set(PYTHON_FILES code-coverage.py)
@@ -42,7 +49,7 @@ if(Python3_FOUND)
         if(ROCPROFSYS_INSTALL_EXAMPLES)
             install(
                 PROGRAMS ${PROJECT_BINARY_DIR}/${_FILE}
-                DESTINATION bin
+                DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
                 COMPONENT rocprofiler-systems-examples
             )
         endif()

--- a/projects/rocprofiler-systems/examples/fork/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/fork/CMakeLists.txt
@@ -90,7 +90,7 @@ if(HIPCC_EXECUTABLE)
             rocprofiler_systems_custom_compilation(COMPILER ${HIPCC_EXECUTABLE} TARGET hipMallocConcurrencyMproc)
         endif()
 
-        if(ROCPROFSYS_INSTALL_EXAMPLES and TARGET hipMallocConcurrencyMproc)
+        if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET hipMallocConcurrencyMproc)
             install(
                 TARGETS hipMallocConcurrencyMproc
                 DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples

--- a/projects/rocprofiler-systems/examples/fork/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/fork/CMakeLists.txt
@@ -21,11 +21,13 @@ target_link_libraries(
 target_compile_options(fork-example PRIVATE ${_FLAGS})
 
 if(ROCPROFSYS_INSTALL_EXAMPLES)
-    install(
-        TARGETS fork-example
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
-        COMPONENT rocprofiler-systems-examples
-    )
+    if(TARGET fork-example)
+        install(
+            TARGETS fork-example
+            DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+            COMPONENT rocprofiler-systems-examples
+        )
+    endif()
 endif()
 
 # HIP fork example (multi-process concurrency test)
@@ -88,7 +90,7 @@ if(HIPCC_EXECUTABLE)
             rocprofiler_systems_custom_compilation(COMPILER ${HIPCC_EXECUTABLE} TARGET hipMallocConcurrencyMproc)
         endif()
 
-        if(ROCPROFSYS_INSTALL_EXAMPLES)
+        if(ROCPROFSYS_INSTALL_EXAMPLES and TARGET hipMallocConcurrencyMproc)
             install(
                 TARGETS hipMallocConcurrencyMproc
                 DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples

--- a/projects/rocprofiler-systems/examples/fork/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/fork/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(rocprofiler-systems-fork LANGUAGES CXX)
@@ -18,7 +21,11 @@ target_link_libraries(
 target_compile_options(fork-example PRIVATE ${_FLAGS})
 
 if(ROCPROFSYS_INSTALL_EXAMPLES)
-    install(TARGETS fork-example DESTINATION bin COMPONENT rocprofiler-systems-examples)
+    install(
+        TARGETS fork-example
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+        COMPONENT rocprofiler-systems-examples
+    )
 endif()
 
 # HIP fork example (multi-process concurrency test)
@@ -84,7 +91,7 @@ if(HIPCC_EXECUTABLE)
         if(ROCPROFSYS_INSTALL_EXAMPLES)
             install(
                 TARGETS hipMallocConcurrencyMproc
-                DESTINATION bin
+                DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
                 COMPONENT rocprofiler-systems-examples
             )
         endif()

--- a/projects/rocprofiler-systems/examples/jpegdecode/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/jpegdecode/CMakeLists.txt
@@ -1,25 +1,5 @@
-################################################################################
-# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-#
-################################################################################
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
@@ -158,10 +138,14 @@ if(HIP_FOUND AND rocjpeg_FOUND AND Threads_FOUND AND rocprofiler-register_FOUND)
     copy_image_files_and_make_copies()
 
     if(ROCPROFSYS_INSTALL_EXAMPLES)
-        install(TARGETS jpegdecode DESTINATION bin COMPONENT rocprofiler-systems-examples)
         install(
-            FILES ${CMAKE_BINARY_DIR}/images
-            DESTINATION share/rocprofiler-systems/tests/images
+            TARGETS jpegdecode
+            DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+            COMPONENT rocprofiler-systems-examples
+        )
+        install(
+            DIRECTORY ${CMAKE_BINARY_DIR}/images/
+            DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples/images
             COMPONENT rocprofiler-systems-examples
         )
     endif()

--- a/projects/rocprofiler-systems/examples/jpegdecode/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/jpegdecode/CMakeLists.txt
@@ -137,7 +137,7 @@ if(HIP_FOUND AND rocjpeg_FOUND AND Threads_FOUND AND rocprofiler-register_FOUND)
     target_compile_options(jpegdecode PRIVATE ${_FLAGS})
     copy_image_files_and_make_copies()
 
-    if(ROCPROFSYS_INSTALL_EXAMPLES)
+    if(ROCPROFSYS_INSTALL_EXAMPLES and TARGET jpegdecode)
         install(
             TARGETS jpegdecode
             DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples

--- a/projects/rocprofiler-systems/examples/jpegdecode/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/jpegdecode/CMakeLists.txt
@@ -137,7 +137,7 @@ if(HIP_FOUND AND rocjpeg_FOUND AND Threads_FOUND AND rocprofiler-register_FOUND)
     target_compile_options(jpegdecode PRIVATE ${_FLAGS})
     copy_image_files_and_make_copies()
 
-    if(ROCPROFSYS_INSTALL_EXAMPLES and TARGET jpegdecode)
+    if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET jpegdecode)
         install(
             TARGETS jpegdecode
             DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples

--- a/projects/rocprofiler-systems/examples/lulesh/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/lulesh/CMakeLists.txt
@@ -85,7 +85,7 @@ rocprofiler_systems_causal_example_executable(
     INCLUDE_DIRECTORIES ${PROJECT_SOURCE_DIR}/includes
 )
 
-if(ROCPROFSYS_INSTALL_EXAMPLES and LULESH_BUILD_KOKKOS)
+if(ROCPROFSYS_INSTALL_EXAMPLES AND LULESH_BUILD_KOKKOS)
     install(
         TARGETS kokkoscore kokkoscontainers kokkossimd
         LIBRARY

--- a/projects/rocprofiler-systems/examples/lulesh/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/lulesh/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(rocprofiler-systems-lulesh-example LANGUAGES C CXX)
@@ -82,16 +85,11 @@ rocprofiler_systems_causal_example_executable(
     INCLUDE_DIRECTORIES ${PROJECT_SOURCE_DIR}/includes
 )
 
-if(ROCPROFSYS_INSTALL_EXAMPLES)
-    if(LULESH_BUILD_KOKKOS)
-        install(
-            TARGETS kokkoscore kokkoscontainers
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+if(ROCPROFSYS_INSTALL_EXAMPLES and LULESH_BUILD_KOKKOS)
+    install(
+        TARGETS kokkoscore kokkoscontainers kokkossimd
+        LIBRARY
+            DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples/lib
             COMPONENT rocprofiler-systems-examples
-        )
-        set_target_properties(
-            lulesh
-            PROPERTIES INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
-        )
-    endif()
+    )
 endif()

--- a/projects/rocprofiler-systems/examples/mpi/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/mpi/CMakeLists.txt
@@ -79,18 +79,23 @@ target_link_libraries(
 add_executable(mpi-example mpi.cpp)
 target_link_libraries(mpi-example PRIVATE mpi-cxx-interface-library)
 
-if(ROCPROFSYS_INSTALL_EXAMPLES)
-    install(
-        TARGETS
-            mpi-example
-            mpi-allgather
-            mpi-bcast
-            mpi-all2all
-            mpi-reduce
-            mpi-scatter-gather
-            mpi-send-recv
-            mpi-allreduce
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
-        COMPONENT rocprofiler-systems-examples
-    )
-endif()
+set(MPI_EXAMPLES
+    mpi-example
+    mpi-allgather
+    mpi-bcast
+    mpi-all2all
+    mpi-reduce
+    mpi-scatter-gather
+    mpi-send-recv
+    mpi-allreduce
+)
+
+foreach(MPI_EXAMPLE IN LISTS MPI_EXAMPLES)
+    if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET ${MPI_EXAMPLE})
+        install(
+            TARGETS ${MPI_EXAMPLE}
+            DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+            COMPONENT rocprofiler-systems-examples
+        )
+    endif()
+endforeach()

--- a/projects/rocprofiler-systems/examples/mpi/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/mpi/CMakeLists.txt
@@ -79,23 +79,25 @@ target_link_libraries(
 add_executable(mpi-example mpi.cpp)
 target_link_libraries(mpi-example PRIVATE mpi-cxx-interface-library)
 
-set(MPI_EXAMPLES
-    mpi-example
-    mpi-allgather
-    mpi-bcast
-    mpi-all2all
-    mpi-reduce
-    mpi-scatter-gather
-    mpi-send-recv
-    mpi-allreduce
-)
-
-foreach(MPI_EXAMPLE IN LISTS MPI_EXAMPLES)
-    if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET ${MPI_EXAMPLE})
+if(ROCPROFSYS_INSTALL_EXAMPLES)
+  set(MPI_EXAMPLES
+      mpi-example
+      mpi-allgather
+      mpi-bcast
+      mpi-all2all
+      mpi-reduce
+      mpi-scatter-gather
+      mpi-send-recv
+      mpi-allreduce
+  )
+  
+  foreach(MPI_EXAMPLE IN LISTS MPI_EXAMPLES)
+      if(TARGET ${MPI_EXAMPLE})
         install(
             TARGETS ${MPI_EXAMPLE}
             DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
             COMPONENT rocprofiler-systems-examples
         )
-    endif()
-endforeach()
+      endif()
+  endforeach()
+endif()

--- a/projects/rocprofiler-systems/examples/mpi/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/mpi/CMakeLists.txt
@@ -80,24 +80,24 @@ add_executable(mpi-example mpi.cpp)
 target_link_libraries(mpi-example PRIVATE mpi-cxx-interface-library)
 
 if(ROCPROFSYS_INSTALL_EXAMPLES)
-  set(MPI_EXAMPLES
-      mpi-example
-      mpi-allgather
-      mpi-bcast
-      mpi-all2all
-      mpi-reduce
-      mpi-scatter-gather
-      mpi-send-recv
-      mpi-allreduce
-  )
-  
-  foreach(MPI_EXAMPLE IN LISTS MPI_EXAMPLES)
-      if(TARGET ${MPI_EXAMPLE})
-        install(
-            TARGETS ${MPI_EXAMPLE}
-            DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
-            COMPONENT rocprofiler-systems-examples
-        )
-      endif()
-  endforeach()
+    set(MPI_EXAMPLES
+        mpi-example
+        mpi-allgather
+        mpi-bcast
+        mpi-all2all
+        mpi-reduce
+        mpi-scatter-gather
+        mpi-send-recv
+        mpi-allreduce
+    )
+
+    foreach(MPI_EXAMPLE IN LISTS MPI_EXAMPLES)
+        if(TARGET ${MPI_EXAMPLE})
+            install(
+                TARGETS ${MPI_EXAMPLE}
+                DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+                COMPONENT rocprofiler-systems-examples
+            )
+        endif()
+    endforeach()
 endif()

--- a/projects/rocprofiler-systems/examples/mpi/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/mpi/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(rocprofiler-systems-mpi-examples LANGUAGES C CXX)
@@ -86,7 +89,8 @@ if(ROCPROFSYS_INSTALL_EXAMPLES)
             mpi-reduce
             mpi-scatter-gather
             mpi-send-recv
-        DESTINATION bin
+            mpi-allreduce
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
         COMPONENT rocprofiler-systems-examples
     )
 endif()

--- a/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
@@ -89,13 +89,17 @@ endif()
 target_link_libraries(openmp-cg PRIVATE openmp-common)
 target_link_libraries(openmp-lu PRIVATE openmp-common)
 
-if(ROCPROFSYS_INSTALL_EXAMPLES)
-    install(
-        TARGETS openmp-cg openmp-lu
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
-        COMPONENT rocprofiler-systems-examples
-    )
-endif()
+set(OPENMP_EXAMPLES openmp-cg openmp-lu)
+
+foreach(OPENMP_EXAMPLE IN LISTS OPENMP_EXAMPLES)
+    if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET ${OPENMP_EXAMPLE})
+        install(
+            TARGETS ${OPENMP_EXAMPLE}
+            DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+            COMPONENT rocprofiler-systems-examples
+        )
+    endif()
+endforeach()
 
 set(DEFAULT_GPU_TARGETS
     "gfx900"

--- a/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
@@ -92,7 +92,7 @@ target_link_libraries(openmp-lu PRIVATE openmp-common)
 if(ROCPROFSYS_INSTALL_EXAMPLES)
     install(
         TARGETS openmp-cg openmp-lu
-        DESTINATION bin
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
         COMPONENT rocprofiler-systems-examples
     )
 endif()

--- a/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/external/CMakeLists.txt
@@ -280,3 +280,19 @@ set(ROCPROFSYS_OMPVV_OFFLOAD_TESTS
 rocprofiler_systems_message(STATUS
                             "Successfully configured OMPVV"
 )
+
+if(ROCPROFSYS_INSTALL_EXAMPLES)
+    foreach(
+        test_target
+        IN
+        LISTS ROCPROFSYS_OMPVV_HOST_TESTS ROCPROFSYS_OMPVV_OFFLOAD_TESTS
+    )
+        if(TARGET "${test_target}-build")
+            install(
+                PROGRAMS "${OMPVV_BIN_DEST}/${test_target}"
+                DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+                COMPONENT rocprofiler-systems-examples
+            )
+        endif()
+    endforeach()
+endif()

--- a/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
@@ -71,7 +71,7 @@ endif()
 # Use the directory that actually contains the library we found
 get_filename_component(_rocm_llvm_lib "${LIBOMPTARGET_SO}" DIRECTORY)
 set(_rocm_clang_lib "${ROCM_ROOT_DIR}/lib")
-set(_COMMON_RPATH "${_rocm_llvm_lib};${_rocm_clang_lib};$ORIGIN")
+set(_COMMON_RPATH "${_rocm_llvm_lib};${_rocm_clang_lib};$ORIGIN;$ORIGIN/lib")
 if(ROCmVersion_DIR)
     list(APPEND _COMMON_RPATH "${ROCmVersion_DIR}/llvm/lib")
 endif()
@@ -126,3 +126,15 @@ rocprofiler_systems_custom_compilation(
 rocprofiler_systems_custom_compilation(TARGET openmp-target
                                        COMPILER ${OMP_TARGET_COMPILER}
 )
+
+if(ROCPROFSYS_INSTALL_EXAMPLES)
+    if(TARGET openmp-target AND TARGET openmp-target-lib)
+        install(
+            TARGETS openmp-target openmp-target-lib
+            RUNTIME DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+            LIBRARY
+                DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples/lib
+                COMPONENT rocprofiler-systems-examples
+        )
+    endif()
+endif()

--- a/projects/rocprofiler-systems/examples/parallel-overhead/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/parallel-overhead/CMakeLists.txt
@@ -35,10 +35,13 @@ target_link_libraries(
 )
 target_compile_definitions(parallel-overhead-locks PRIVATE USE_LOCKS=1)
 
-if(ROCPROFSYS_INSTALL_EXAMPLES)
-    install(
-        TARGETS parallel-overhead parallel-overhead-locks
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
-        COMPONENT rocprofiler-systems-examples
-    )
-endif()
+set(PARALLEL_OVERHEAD_EXAMPLES parallel-overhead parallel-overhead-locks)
+foreach(PARALLEL_OVERHEAD_EXAMPLE IN LISTS PARALLEL_OVERHEAD_EXAMPLES)
+    if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET ${PARALLEL_OVERHEAD_EXAMPLE})
+        install(
+            TARGETS ${PARALLEL_OVERHEAD_EXAMPLE}
+            DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+            COMPONENT rocprofiler-systems-examples
+        )
+    endif()
+endforeach()

--- a/projects/rocprofiler-systems/examples/parallel-overhead/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/parallel-overhead/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(rocprofiler-systems-parallel-overhead-example LANGUAGES CXX)
@@ -35,7 +38,7 @@ target_compile_definitions(parallel-overhead-locks PRIVATE USE_LOCKS=1)
 if(ROCPROFSYS_INSTALL_EXAMPLES)
     install(
         TARGETS parallel-overhead parallel-overhead-locks
-        DESTINATION bin
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
         COMPONENT rocprofiler-systems-examples
     )
 endif()

--- a/projects/rocprofiler-systems/examples/python/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/python/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(rocprofiler-systems-python)
@@ -36,7 +39,7 @@ if(Python3_FOUND)
         if(ROCPROFSYS_INSTALL_EXAMPLES)
             install(
                 PROGRAMS ${PROJECT_BINARY_DIR}/${_FILE}
-                DESTINATION bin
+                DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
                 COMPONENT rocprofiler-systems-examples
             )
         endif()

--- a/projects/rocprofiler-systems/examples/rccl/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/rccl/CMakeLists.txt
@@ -138,6 +138,14 @@ if(hip_FOUND AND rccl_FOUND)
         add_dependencies(rccl-tests::${_EXE_NAME} copy-${_EXE_NAME})
 
         list(APPEND _RCCL_TEST_TARGETS "rccl-tests::${_EXE_NAME}")
+
+        if(ROCPROFSYS_INSTALL_EXAMPLES)
+            install(
+                PROGRAMS ${_EXE_DEST_PATH}
+                DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+                COMPONENT rocprofiler-systems-examples
+            )
+        endif()
     endforeach()
 
     set(RCCL_TEST_TARGETS "${_RCCL_TEST_TARGETS}" CACHE INTERNAL "rccl-test targets")

--- a/projects/rocprofiler-systems/examples/rewrite-caller/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/rewrite-caller/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_BUILD_TYPE "Debug")
 add_executable(rewrite-caller rewrite-caller.cpp)
 target_compile_options(rewrite-caller PRIVATE ${_FLAGS})
 
-if(ROCPROFSYS_INSTALL_EXAMPLES)
+if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET rewrite-caller)
     install(
         TARGETS rewrite-caller
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples

--- a/projects/rocprofiler-systems/examples/rewrite-caller/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/rewrite-caller/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(rocprofiler-systems-rewrite-caller-example LANGUAGES CXX)
@@ -19,5 +22,9 @@ add_executable(rewrite-caller rewrite-caller.cpp)
 target_compile_options(rewrite-caller PRIVATE ${_FLAGS})
 
 if(ROCPROFSYS_INSTALL_EXAMPLES)
-    install(TARGETS rewrite-caller DESTINATION bin COMPONENT rocprofiler-systems-examples)
+    install(
+        TARGETS rewrite-caller
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+        COMPONENT rocprofiler-systems-examples
+    )
 endif()

--- a/projects/rocprofiler-systems/examples/roctx/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/roctx/CMakeLists.txt
@@ -94,7 +94,7 @@ if(NOT CMAKE_CXX_COMPILER_IS_HIPCC AND HIPCC_EXECUTABLE)
     rocprofiler_systems_custom_compilation(COMPILER ${HIPCC_EXECUTABLE} TARGET roctx)
 endif()
 
-if(ROCPROFSYS_INSTALL_EXAMPLES)
+if(ROCPROFSYS_INSTALL_EXAMPLES and TARGET roctx)
     install(
         TARGETS roctx
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples

--- a/projects/rocprofiler-systems/examples/roctx/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/roctx/CMakeLists.txt
@@ -1,24 +1,5 @@
-# MIT License
-#
-# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
 
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
@@ -114,5 +95,9 @@ if(NOT CMAKE_CXX_COMPILER_IS_HIPCC AND HIPCC_EXECUTABLE)
 endif()
 
 if(ROCPROFSYS_INSTALL_EXAMPLES)
-    install(TARGETS roctx DESTINATION bin COMPONENT rocprofiler-systems-examples)
+    install(
+        TARGETS roctx
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+        COMPONENT rocprofiler-systems-examples
+    )
 endif()

--- a/projects/rocprofiler-systems/examples/roctx/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/roctx/CMakeLists.txt
@@ -94,7 +94,7 @@ if(NOT CMAKE_CXX_COMPILER_IS_HIPCC AND HIPCC_EXECUTABLE)
     rocprofiler_systems_custom_compilation(COMPILER ${HIPCC_EXECUTABLE} TARGET roctx)
 endif()
 
-if(ROCPROFSYS_INSTALL_EXAMPLES and TARGET roctx)
+if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET roctx)
     install(
         TARGETS roctx
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples

--- a/projects/rocprofiler-systems/examples/thread-limit/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/thread-limit/CMakeLists.txt
@@ -40,3 +40,11 @@ target_compile_options(tests-compile-options INTERFACE -g)
 add_executable(thread-limit thread-limit.cpp)
 target_compile_definitions(thread-limit PRIVATE MAX_THREADS=${ROCPROFSYS_MAX_THREADS})
 target_link_libraries(thread-limit PRIVATE Threads::Threads tests-compile-options)
+
+if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET thread-limit)
+    install(
+        TARGETS thread-limit
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+        COMPONENT rocprofiler-systems-examples
+    )
+endif()

--- a/projects/rocprofiler-systems/examples/trace-time-window/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/trace-time-window/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_BUILD_TYPE "Debug")
 add_executable(trace-time-window trace-time-window.cpp)
 target_compile_options(trace-time-window PRIVATE ${_FLAGS})
 
-if(ROCPROFSYS_INSTALL_EXAMPLES)
+if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET trace-time-window)
     install(
         TARGETS trace-time-window
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples

--- a/projects/rocprofiler-systems/examples/trace-time-window/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/trace-time-window/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(rocprofiler-systems-trace-time-window-example LANGUAGES CXX)
@@ -21,7 +24,7 @@ target_compile_options(trace-time-window PRIVATE ${_FLAGS})
 if(ROCPROFSYS_INSTALL_EXAMPLES)
     install(
         TARGETS trace-time-window
-        DESTINATION bin
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
         COMPONENT rocprofiler-systems-examples
     )
 endif()

--- a/projects/rocprofiler-systems/examples/transferBench/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/transferBench/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(rocprofiler-systems-transferBench-example LANGUAGES CXX)
@@ -121,5 +124,9 @@ if(NOT CMAKE_CXX_COMPILER_IS_HIPCC AND HIPCC_EXECUTABLE)
 endif()
 
 if(ROCPROFSYS_INSTALL_EXAMPLES)
-    install(TARGETS transferBench DESTINATION bin COMPONENT rocprofiler-systems-examples)
+    install(
+        TARGETS transferBench
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+        COMPONENT rocprofiler-systems-examples
+    )
 endif()

--- a/projects/rocprofiler-systems/examples/transferBench/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/transferBench/CMakeLists.txt
@@ -123,7 +123,7 @@ if(NOT CMAKE_CXX_COMPILER_IS_HIPCC AND HIPCC_EXECUTABLE)
     rocprofiler_systems_custom_compilation(COMPILER ${HIPCC_EXECUTABLE} TARGET transferBench)
 endif()
 
-if(ROCPROFSYS_INSTALL_EXAMPLES)
+if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET transferBench)
     install(
         TARGETS transferBench
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples

--- a/projects/rocprofiler-systems/examples/transpose/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/transpose/CMakeLists.txt
@@ -96,7 +96,7 @@ if(NOT CMAKE_CXX_COMPILER_IS_HIPCC AND HIPCC_EXECUTABLE)
     rocprofiler_systems_custom_compilation(COMPILER ${HIPCC_EXECUTABLE} TARGET transpose)
 endif()
 
-if(ROCPROFSYS_INSTALL_EXAMPLES)
+if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET transpose)
     install(
         TARGETS transpose
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples

--- a/projects/rocprofiler-systems/examples/transpose/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/transpose/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(rocprofiler-systems-transpose-example LANGUAGES CXX)
@@ -94,5 +97,9 @@ if(NOT CMAKE_CXX_COMPILER_IS_HIPCC AND HIPCC_EXECUTABLE)
 endif()
 
 if(ROCPROFSYS_INSTALL_EXAMPLES)
-    install(TARGETS transpose DESTINATION bin COMPONENT rocprofiler-systems-examples)
+    install(
+        TARGETS transpose
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+        COMPONENT rocprofiler-systems-examples
+    )
 endif()

--- a/projects/rocprofiler-systems/examples/user-api/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/user-api/CMakeLists.txt
@@ -27,7 +27,7 @@ target_link_libraries(
     PRIVATE Threads::Threads rocprofiler-systems::rocprofiler-systems-user-library
 )
 
-if(ROCPROFSYS_INSTALL_EXAMPLES)
+if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET user-api)
     install(
         TARGETS user-api
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples

--- a/projects/rocprofiler-systems/examples/user-api/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/user-api/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(rocprofiler-systems-user-api-example LANGUAGES CXX)
@@ -25,5 +28,9 @@ target_link_libraries(
 )
 
 if(ROCPROFSYS_INSTALL_EXAMPLES)
-    install(TARGETS user-api DESTINATION bin COMPONENT rocprofiler-systems-examples)
+    install(
+        TARGETS user-api
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+        COMPONENT rocprofiler-systems-examples
+    )
 endif()

--- a/projects/rocprofiler-systems/examples/videodecode/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/videodecode/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(rocprofiler-systems-videodecode-example LANGUAGES CXX)
@@ -179,12 +182,12 @@ if(FFMPEG_FOUND AND rocdecode_FOUND)
     if(ROCPROFSYS_INSTALL_EXAMPLES)
         install(
             TARGETS videodecode
-            DESTINATION bin
+            DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
             COMPONENT rocprofiler-systems-examples
         )
         install(
-            FILES ${CMAKE_BINARY_DIR}/videos
-            DESTINATION share/rocprofiler-systems/tests/videos
+            DIRECTORY ${CMAKE_BINARY_DIR}/videos/
+            DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples/videos
             COMPONENT rocprofiler-systems-examples
         )
     endif()

--- a/projects/rocprofiler-systems/examples/videodecode/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/videodecode/CMakeLists.txt
@@ -179,7 +179,7 @@ if(FFMPEG_FOUND AND rocdecode_FOUND)
         target_compile_definitions(videodecode PUBLIC USE_AVCODEC_GREATER_THAN_58_134=1)
     endif()
 
-    if(ROCPROFSYS_INSTALL_EXAMPLES)
+    if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET videodecode)
         install(
             TARGETS videodecode
             DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR updates CMake installation paths for rocprofiler-systems examples across multiple files, standardizing the installation destination from bin to ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples. Additionally, it consolidates copyright headers to use the shorter SPDX format and adds target existence checks before installing.

Part of https://github.com/ROCm/rocm-systems/pull/2253

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
Part of AIPROFSYST-26

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
