### PR TITLE
SWDEV-1 - Fix hipMemPoolTrimTo failing tests

### DIFF
--- a/projects/hip-tests/catch/unit/memory/hipMemPoolTrimTo.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPoolTrimTo.cc
@@ -177,8 +177,8 @@ static bool checkhipMemPoolTrimTo(hipStream_t stream, int N, int dev = 0) {
     testObj.transferFromMempool(stream);
     testObj.freeDevBuf(stream);
     // verify and validate
-    REQUIRE(true == testObj.validateResult());
     HIP_CHECK(hipStreamSynchronize(stream));
+    REQUIRE(true == testObj.validateResult());
   }
   HIP_CHECK(hipMemPoolDestroy(mem_pool));
   return true;


### PR DESCRIPTION
## Motivation

Following tests are failing:
- Unit_hipMemPoolTrimTo_VaryingMinBytesToHold
- Unit_hipMemPoolTrimTo_Multithreaded

## Technical Details

Stream synchronization should be performed before result verification.

## JIRA ID

No JIRA ticket

## Test Plan

Run failing tests.

## Test Result

Failing tests are passing now.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
