### PR TITLE
SWDEV-575867: Fix hipGraphicsUnregisterResource error checking

### DIFF
--- a/projects/hip-tests/catch/unit/gl_interop/hipGraphicsUnregisterResource.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGraphicsUnregisterResource.cc
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2022 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -45,18 +45,18 @@ TEST_CASE("Unit_hipGraphicsUnregisterResource_Negative_Parameters") {
     HIP_CHECK_ERROR(hipGraphicsUnregisterResource(null_resource), hipErrorInvalidValue);
   }
 
-    SECTION("already unregistered resource") {
+  SECTION("already unregistered resource") {
     hipGraphicsResource* unregistered_resource;
     HIP_CHECK(
         hipGraphicsGLRegisterBuffer(&unregistered_resource, vbo, hipGraphicsRegisterFlagsNone));
     HIP_CHECK(hipGraphicsUnregisterResource(unregistered_resource));
-    HIP_CHECK_ERROR(hipGraphicsUnregisterResource(unregistered_resource), hipErrorInvalidHandle);
+    HIP_CHECK_ERROR(hipGraphicsUnregisterResource(unregistered_resource), hipErrorInvalidResourceHandle);
   }
 
   SECTION("mapped resource") {
     hipGraphicsResource* mapped_resource;
     HIP_CHECK(hipGraphicsGLRegisterBuffer(&mapped_resource, vbo, hipGraphicsRegisterFlagsNone));
     HIP_CHECK(hipGraphicsMapResources(1, &mapped_resource, 0));
-    HIP_CHECK_ERROR(hipGraphicsUnregisterResource(mapped_resource), hipErrorArrayIsMapped);
+    HIP_CHECK_ERROR(hipGraphicsUnregisterResource(mapped_resource), hipErrorAlreadyMapped);
   }
 }


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

For "already unregistered resource", the expected return code hipErrorInvalidContext appears to be incorrect; the correct error code is not documented, and the CUDA equivalent returns cudaErrorInvalidResourceHandle. Using hipErrorInvalidResourceHandle would be a more consistent and appropriate choice. the previously expected error code hipErrorAlreadyMapped is more consistent, since hipGraphicsUnregisterResource applies to both array and buffer resources.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

This patch makes hipGraphicsUnregisterResource return hipErrorInvalidResourceHandle for unregistered resources, and hipErrorAlreadyMapped for currently mapped resources.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

SWDEV-575867

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

hip-tests: Unit_hipGraphicsUnmapResources_Negative_Parameters

## Test Result

<!-- Briefly summarize test outcomes. -->

Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
