### PR TITLE
Revert "fix: prevent double-free crash during process exit in amd-smi…

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/gpu.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/gpu.cpp
@@ -31,6 +31,8 @@
     }                                                                                    \
     }  // namespace ::tim::cereal
 
+#include "common/defines.h"
+
 #if !defined(ROCPROFSYS_USE_ROCM)
 #    define ROCPROFSYS_USE_ROCM 0
 #endif
@@ -40,7 +42,6 @@
 
 #include <timemory/manager.hpp>
 
-#include <dlfcn.h>
 #include <string>
 
 #include "core/agent_manager.hpp"
@@ -92,17 +93,6 @@ _amdsmi_is_initialized()
     return initialized;
 }
 
-void
-prevent_amdsmi_library_unload()
-{
-    static bool _initialized = false;
-    if(_initialized) return;
-    _initialized = true;
-
-    dlopen("libamd_smi.so", RTLD_NOW | RTLD_NOLOAD | RTLD_NODELETE);
-    dlopen("librocm_smi64.so", RTLD_NOW | RTLD_NOLOAD | RTLD_NODELETE);
-}
-
 bool
 amdsmi_init()
 {
@@ -113,8 +103,6 @@ amdsmi_init()
             ROCPROFSYS_AMD_SMI_CALL(::amdsmi_init(AMDSMI_INIT_AMD_GPUS));
             get_processor_handles();
             _amdsmi_is_initialized() = true;  // Mark as initialized
-
-            prevent_amdsmi_library_unload();
         } catch(std::exception& _e)
         {
             LOG_ERROR("Exception thrown initializing amd-smi: {}", _e.what());

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -1272,7 +1272,10 @@ shutdown()
 
     try
     {
-        data::shutdown();
+        if(data::shutdown())
+        {
+            ROCPROFSYS_AMD_SMI_CALL(amdsmi_shut_down());
+        }
     } catch(std::runtime_error& _e)
     {
         LOG_WARNING("Exception thrown when shutting down amd-smi: {}", _e.what());

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/exit_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/exit_gotcha.cpp
@@ -24,6 +24,7 @@
 #include "core/common.hpp"
 #include "core/config.hpp"
 #include "core/state.hpp"
+#include "core/timemory.hpp"
 #include "library/runtime.hpp"
 
 #include <timemory/backends/threading.hpp>
@@ -33,9 +34,7 @@
 #include "logger/debug.hpp"
 
 #include <cstddef>
-#include <cstdio>
 #include <cstdlib>
-#include <unistd.h>
 
 namespace rocprofsys
 {
@@ -89,26 +88,6 @@ void
 exit_gotcha::operator()(const gotcha_data& _data, exit_func_t _func, int _ec) const
 {
     _exit_info = { true, _data.tool_id.find("quick") != std::string::npos, _ec };
-
-    if(config::get_use_amd_smi())
-    {
-        threading::clear_callbacks();
-
-        if(get_state() < ::rocprofsys::State::Finalized && !is_child_process())
-        {
-            LOG_DEBUG("Finalizing {} before calling {}({})...", get_exe_name(),
-                      _data.tool_id, _ec);
-
-            rocprofsys_finalize();
-        }
-
-        LOG_DEBUG("Calling _exit({}) in {} to avoid AMD SMI cleanup issues...", _ec,
-                  get_exe_name().c_str());
-
-        std::fflush(nullptr);
-        _exit(_ec);
-    }
-
     invoke_exit_gotcha(_data, _func, _ec);
 }
 


### PR DESCRIPTION
… (#2213)"

This reverts commit 7b00d3a89b43bdd084454843db0c8412f44414dd.

The workaround is no longer needed - root cause fixed in amd-smi and rocm-smi-lib.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
