### PR TITLE
SWDEV-575867: Fix error code for mapped graphics resources

### DIFF
--- a/projects/clr/hipamd/src/hip_gl.cpp
+++ b/projects/clr/hipamd/src/hip_gl.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2010 - 2021 Advanced Micro Devices, Inc.
+/* Copyright (c) 2010 - 2026 Advanced Micro Devices, Inc.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -234,7 +234,7 @@ hipError_t hipGraphicsSubResourceGetMappedArray(hipArray_t* array, hipGraphicsRe
     LogError("invalid arrayIndex, arrayIndex higher than zero not implemented");
     HIP_RETURN(hipErrorInvalidValue);
   }
-  
+
   size_t height = image->getHeight();
   size_t width = image->getWidth();
   size_t depth = image->getDepth();
@@ -724,7 +724,7 @@ hipError_t hipGraphicsGLRegisterBuffer(hipGraphicsResource** resource, GLuint bu
   }
   HIP_RETURN(hipSuccess);
 }
- 
+
 hipError_t hipGraphicsMapResources(int count, hipGraphicsResource_t* resources,
                                    hipStream_t stream) {
   HIP_INIT_API(hipGraphicsMapResources, count, resources, stream);
@@ -945,8 +945,8 @@ hipError_t hipGraphicsUnregisterResource(hipGraphicsResource_t resource) {
   }
 
   if (device->mappedGraphics().isValid(resource)) {
-    LogError("resource still mapped");
-    HIP_RETURN(hipErrorArrayIsMapped);
+    LogError("resource already mapped");
+    HIP_RETURN(hipErrorAlreadyMapped);
   }
 
   if (!device->registeredGraphics().isValid(resource)) {

--- a/projects/hip-tests/catch/unit/gl_interop/hipGraphicsUnregisterResource.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGraphicsUnregisterResource.cc
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2022 - 2026 Advanced Micro Devices, Inc. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -57,6 +57,6 @@ TEST_CASE("Unit_hipGraphicsUnregisterResource_Negative_Parameters") {
     hipGraphicsResource* mapped_resource;
     HIP_CHECK(hipGraphicsGLRegisterBuffer(&mapped_resource, vbo, hipGraphicsRegisterFlagsNone));
     HIP_CHECK(hipGraphicsMapResources(1, &mapped_resource, 0));
-    HIP_CHECK_ERROR(hipGraphicsUnregisterResource(mapped_resource), hipErrorArrayIsMapped);
+    HIP_CHECK_ERROR(hipGraphicsUnregisterResource(mapped_resource), hipErrorAlreadyMapped);
   }
 }


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

hipErrorArrayIsMapped is for hipArray_t; use hipErrorAlreadyMapped instead.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Fixed hipGraphicsUnregisterResource error code for already mapped resources.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

SWDEV-575867

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

hip-tests Unit_hipGraphicsUnregisterResource_Negative_Parameters

## Test Result

<!-- Briefly summarize test outcomes. -->

Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
