### PR TITLE
rocrtst: set HSA_ENABLE_INTERRUPT after TestExample creation

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
@@ -136,8 +136,8 @@ TEST(rocrtst, Test_Example) {
 }
 
 TEST(rocrtst, Test_Example_InterruptDisabled) {
-  rocrtst::SetEnv("HSA_ENABLE_INTERRUPT", "0");
   TestExample tst;
+  rocrtst::SetEnv("HSA_ENABLE_INTERRUPT", "0");
   RunGenericTest(&tst);
 }
 


### PR DESCRIPTION
## Motivation

Ensure Test_Example_InterruptDisabled runs with the intended interrupt setting and does not read a stale environment value during setup.

## Technical Details

Move rocrtst::SetEnv("HSA_ENABLE_INTERRUPT", "0") to after TestExample construction so the runtime environment is applied at test execution time.