### PR TITLE
rocr-runtime: fix arm64 build by adding fallbacks to x86 intrinsics

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -439,9 +439,17 @@ class GpuAgent : public GpuAgentInt {
   /// @brief Force a WC flush on PCIe devices by doing a write and then read-back
   __forceinline void PcieWcFlush(void *ptr, size_t size) const {
     if (!xgmi_cpu_gpu_) {
+#if defined(__x86_64__) || defined(__i386__)
       _mm_sfence();
+#else
+      std::atomic_thread_fence(std::memory_order_release);
+#endif
       *((uint8_t*)ptr + size - 1) = *((uint8_t*)ptr + size - 1);
+#if defined(__x86_64__) || defined(__i386__)
       _mm_mfence();
+#else
+      std::atomic_thread_fence(std::memory_order_seq_cst);
+#endif
       auto readback = *(reinterpret_cast<volatile uint8_t*>(ptr) + size - 1);
       UNUSED(readback);
     }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -474,7 +474,12 @@ void AqlQueue::StoreRelaxed(hsa_signal_value_t value) {
     HSAKMT_CALL(hsaKmtQueueRingDoorbell(queue_id_, value));
   } else {
     // Hardware doorbell supports AQL semantics.
+#if defined(__x86_64__) || defined(__i386__)
     _mm_sfence();
+#else
+    std::atomic_thread_fence(std::memory_order_release);
+#endif
+
     *(signal_.hardware_doorbell_ptr) = uint64_t(value);
     /* signal_ is allocated as uncached so we do not need read-back to flush WC */
   }
@@ -1559,7 +1564,11 @@ void AqlQueue::ExecutePM4(uint32_t* cmd_data, size_t cmd_size_b, hsa_fence_scope
   memcpy(&queue_slot[1], &slot_data[1], slot_size_b - sizeof(uint32_t));
   if (IsDeviceMemRingBuf() && needsPcieOrdering()) {
     // Ensure the packet body is written as header may get reordered when writing over PCIE
+#if defined(__x86_64__) || defined(__i386__)
     _mm_sfence();
+#else
+    std::atomic_thread_fence(std::memory_order_release);
+#endif
   }
   atomic::Store(&queue_slot[0], slot_data[0], std::memory_order_release);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_kernel.cpp
@@ -901,7 +901,11 @@ void BlitKernel::PopulateQueue(uint64_t index, uint64_t code_handle, void* args,
   std::atomic_thread_fence(std::memory_order_release);
   if (queue_->IsDeviceMemRingBuf() && queue_->needsPcieOrdering()) {
     // Ensure the packet body is written as header may get reordered when writing over PCIE
+    // atomic_thread_fence already being run would cover the case for architectures
+    // other than x86
+#if defined(__x86_64__) || defined(__i386__)
     _mm_sfence();
+#endif
   }
 #if defined(__linux__)
   __atomic_store_n(&(queue_buffer[index & queue_bitmask_].full_header),

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
@@ -271,7 +271,11 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
       ring[barrier & mask].barrier_and.completion_signal = Signal::Convert(async_doorbell_);
       if (wrapped->IsDeviceMemRingBuf() && needsPcieOrdering()) {
         // Ensure the packet body is written as header may get reordered when writing over PCIE
+#if defined(__x86_64__) || defined(__i386__)
         _mm_sfence();
+#else
+        std::atomic_thread_fence(std::memory_order_release);
+#endif
       }
       atomic::Store(&ring[barrier & mask].barrier_and.header, kBarrierHeader,
                     std::memory_order_release);
@@ -318,7 +322,11 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
       if (write_index != 0) {
         if (wrapped->IsDeviceMemRingBuf() && needsPcieOrdering()) {
           // Ensure the packet body is written as header may get reordered when writing over PCIE
+#if defined(__x86_64__) || defined(__i386__)
           _mm_sfence();
+#else
+          std::atomic_thread_fence(std::memory_order_release);
+#endif
         }
         atomic::Store(&ring[write & mask].packet.header, packets[first_written_packet_index].packet.header,
                       std::memory_order_release);
@@ -419,7 +427,11 @@ void InterceptQueue::StoreRelaxed(hsa_signal_value_t value) {
 
     if (IsDeviceMemRingBuf() && needsPcieOrdering()) {
       // Ensure the packet body is written as header may get reordered when writing over PCIE
+#if defined(__x86_64__) || defined(__i386__)
       _mm_sfence();
+#else
+      std::atomic_thread_fence(std::memory_order_release);
+#endif
     }
   }
   i = next_packet_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/utils.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/utils.h
@@ -409,7 +409,14 @@ inline void FlushCpuCache(const void* base, size_t offset, size_t len) {
   cur += offset;
   uintptr_t lastline = (uintptr_t)(cur + len - 1) | (cacheline_size - 1);
   do {
+#if defined(__x86_64__) || defined(__i386__)
     _mm_clflush((const void*)cur);
+#elif defined(__aarch64__)
+    asm volatile("dc civac, %0" :: "r"(cur) : "memory");
+#else
+    // No cache flush available for this architecture
+    (void)cur;
+#endif
     cur += cacheline_size;
   } while (cur <= (const char*)lastline);
 }


### PR DESCRIPTION
## Motivation

Ubuntu builds for arm64 was failing due to missing intrinsics, this changes adds guards around x86 specific intrinsics and falls back to cpp atomic_thread_fence which works for arm64 as well.

The x86 intrinsics _mm_clflush, _mm_sfence, and _mm_mfence are not available on ARM64. Add architecture guards to keep existing x86 behavior and provide ARM64 alternatives using std::atomic_thread_fence for memory barriers and DC CIVAC instruction for cache line flush.

## Test Plan

I dont have access to an arm machine with amd gpu attached but I am planning to at least have a successful build on an arm64 machine

## Test Result

Please see the successful build logs here with this patch applied: https://launchpad.net/~tchavadar/+archive/ubuntu/lp2138659/+build/32160384/+files/buildlog_ubuntu-resolute-arm64.rocr-runtime_7.1.0+dfsg-0ubuntu5+dev54git202601201103.74460e0_BUILDING.txt.gz

