### PR TITLE
SWDEV-566854 - Improve memcpy obj handling

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_helper.hpp
+++ b/projects/clr/hipamd/src/hip_graph_helper.hpp
@@ -18,8 +18,23 @@ hipError_t hipMemcpy2DValidateBuffer(const void* buf, size_t pitch, size_t width
 
 hipError_t ihipMemcpy_validate(void* dst, const void* src, size_t sizeBytes, hipMemcpyKind kind);
 
-hipError_t ihipMemcpyCommand(amd::Command*& command, void* dst, const void* src, size_t sizeBytes,
-                             hipMemcpyKind kind, hip::Stream& stream, bool isAsync = true);
+hipError_t ihipMemcpy_validate_memory(amd::Memory* memObj, size_t sizeBytes, size_t offset,
+                                      bool read_write);
+
+hipError_t ihipMemcpy_validate(amd::Memory* dstMemory, amd::Memory* srcMemory, size_t sizeBytes,
+                                size_t dstOffset, size_t srcOffset);
+
+hipError_t ihipMemcpyCommand(amd::Command*& command, amd::Memory* dstMemory, const void* srcMemory,
+                             size_t sizeBytes, hipMemcpyKind kind, hip::Stream& stream,
+                             size_t dstOffset, bool isAsync = true);
+
+hipError_t ihipMemcpyCommand(amd::Command*& command, void* dstMemory, amd::Memory* srcMemory,
+                             size_t sizeBytes, hipMemcpyKind kind, hip::Stream& stream,
+                             size_t srcOffset, bool isAsync = true);
+
+hipError_t ihipMemcpyCommand(amd::Command*& command, amd::Memory* dstMemory, amd::Memory* srcMemory,
+                             size_t sizeBytes, hipMemcpyKind kind, hip::Stream& stream,
+                             size_t dstOffset, size_t srcOffset, bool isAsync = true);
 
 void ihipHtoHMemcpy(void* dst, const void* src, size_t sizeBytes, hip::Stream& stream);
 
@@ -135,5 +150,14 @@ hipError_t ihipMemcpyAtoHValidate(hipArray_t srcArray, void* dstHost, amd::Coord
 
 hipError_t ihipGraphMemsetParams_validate(const hipMemsetParams* pNodeParams);
 
-hip::MemcpyType ihipGetMemcpyType(const void* src, void* dst, hipMemcpyKind kind);
+constexpr hip::MemcpyType ihipGetMemcpyType(const void* src, void* dst) {
+  return hipHostToHost;
+}
+constexpr hip::MemcpyType ihipGetMemcpyType(const void* src, amd::Memory* dst) {
+  return hipWriteBuffer;
+}
+constexpr hip::MemcpyType ihipGetMemcpyType(amd::Memory* src, void* dst) {
+  return hipReadBuffer;
+}
+hip::MemcpyType ihipGetMemcpyType(amd::Memory* src, amd::Memory* dst, hipMemcpyKind kind);
 }  // namespace hip

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -60,9 +60,11 @@ amd::Monitor GraphNode::WorkerThreadLock_{};
 
 hipError_t GraphMemcpyNode1D::ValidateParams(void* dst, const void* src, size_t count,
                                              hipMemcpyKind kind) {
-  hipError_t status = ihipMemcpy_validate(dst, src, count, kind);
-  if (status != hipSuccess) {
-    return status;
+  if (dst == nullptr || src == nullptr) {
+      return hipErrorInvalidValue;
+  }
+  if (static_cast<uint32_t>(kind) > hipMemcpyDefault && kind != hipMemcpyDeviceToDeviceNoCU) {
+    return hipErrorInvalidMemcpyDirection;
   }
   size_t sOffset = 0;
   amd::Memory* srcMemory = getMemoryObject(src, sOffset);
@@ -76,6 +78,19 @@ hipError_t GraphMemcpyNode1D::ValidateParams(void* dst, const void* src, size_t 
   } else if ((srcMemory != nullptr) && (dstMemory == nullptr)) {  // device to host
     if ((kind != hipMemcpyDeviceToHost) && (kind != hipMemcpyDefault)) {
       return hipErrorInvalidValue;
+    }
+  }
+
+  if (srcMemory != nullptr) {
+    hipError_t status = ihipMemcpy_validate_memory(srcMemory, count, sOffset, /*read_write*/ false);
+    if (status != hipSuccess) {
+      return status;
+    }
+  }
+  if (dstMemory != nullptr) {
+    hipError_t status = ihipMemcpy_validate_memory(dstMemory, count, dOffset, /*read_write*/ true);
+    if (status != hipSuccess) {
+      return status;
     }
   }
 

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1916,7 +1916,16 @@ class GraphMemcpyNode1D : public GraphMemcpyNode {
     amd::Memory* srcMemory = getMemoryObject(src_, sOffset);
     size_t dOffset = 0;
     amd::Memory* dstMemory = getMemoryObject(dst_, dOffset);
-    hip::MemcpyType memType = ihipGetMemcpyType(src_, dst_, kind_);
+    
+    hip::MemcpyType memType = hipHostToHost;
+    if (srcMemory != nullptr && dstMemory == nullptr) {
+        memType = ihipGetMemcpyType(srcMemory, dst_);
+    } else if (srcMemory == nullptr && dstMemory != nullptr) {
+        memType = ihipGetMemcpyType(src_, dstMemory);
+    } else if (srcMemory != nullptr && dstMemory != nullptr) {
+        memType = ihipGetMemcpyType(srcMemory, dstMemory, kind_);
+    }
+
     switch (memType) {
       case hipCopyBuffer:
         // D2H/H2D source/dst is pinned memory
@@ -1969,8 +1978,36 @@ class GraphMemcpyNode1D : public GraphMemcpyNode {
     if (!AMD_DIRECT_DISPATCH) {
       WorkerThreadLock_.lock();
     }
-    status = ihipMemcpyCommand(command, dst_, src_, count_, kind_, *stream);
-    hip::MemcpyType type = ihipGetMemcpyType(src_, dst_, kind_);
+
+    hip::MemcpyType type = hipHostToHost;
+    size_t dOffset, sOffset;
+    amd::Memory* dstMemory = getMemoryObject(dst_, dOffset);
+    amd::Memory* srcMemory = getMemoryObject(src_, sOffset);
+
+    if (dstMemory != nullptr && srcMemory != nullptr) {
+      status = ihipMemcpyCommand(command, dstMemory, srcMemory, count_, kind_, *stream, dOffset,
+                                 sOffset);
+      type = ihipGetMemcpyType(srcMemory, dstMemory, kind_);
+    } else if (dstMemory == nullptr && srcMemory != nullptr) {
+      status = ihipMemcpyCommand(command, dst_, srcMemory, count_, kind_, *stream, sOffset);
+      type = ihipGetMemcpyType(srcMemory, dst_);
+    } else if (dstMemory != nullptr && srcMemory == nullptr) {
+      status = ihipMemcpyCommand(command, dstMemory, src_, count_, kind_, *stream, dOffset);
+      type = ihipGetMemcpyType(src_, dstMemory);
+    } else {
+      if (!AMD_DIRECT_DISPATCH) {
+        WorkerThreadLock_.unlock();
+      }
+      return hipErrorInvalidValue;
+    }
+    if (status != hipSuccess || command == nullptr) {
+      if (!AMD_DIRECT_DISPATCH) {
+        WorkerThreadLock_.unlock();
+      }
+      return (status != hipSuccess) ? status : hipErrorOutOfMemory;
+    }
+    assert(type != hipHostToHost && "This type should be handled by returning an error code");
+
     if (type == hipCopyBuffer) {
       amd::CopyMemoryCommand* cpycmd = reinterpret_cast<amd::CopyMemoryCommand*>(command);
       amd::CopyMetadata copyMetadata = cpycmd->copyMetadata();
@@ -2115,14 +2152,18 @@ class GraphMemcpyNode1D : public GraphMemcpyNode {
   }
   virtual bool GraphCaptureEnabled() override {
     if (parentGraph_ != nullptr && parentGraph_->IsSegmentSchedulingEnabled()) {
-      hip::MemcpyType type = ihipGetMemcpyType(src_, dst_, kind_);
-      switch (type) {
-        case hipCopyBuffer:
-          return true;
-          break;
-        default:
-          break;
-      }
+      hip::MemcpyType type = hipHostToHost;
+
+      size_t dOffset, sOffset;
+      amd::Memory* dstMemory = getMemoryObject(dst_, dOffset);
+      amd::Memory* srcMemory = getMemoryObject(src_, sOffset);
+
+      // The case below is only interested in hipCopyBuffer,
+      // which is only valid for device to device copies.
+      if (dstMemory != nullptr && srcMemory != nullptr) {
+        return (hipCopyBuffer == ihipGetMemcpyType(srcMemory, dstMemory, kind_));
+      } 
+      return false;
     }
     return false;
   }
@@ -2167,7 +2208,21 @@ class GraphMemcpyNodeFromSymbol : public GraphMemcpyNode1D {
     if (status != hipSuccess) {
       return status;
     }
-    status = ihipMemcpyCommand(command, dst_, device_ptr, count_, kind_, *stream);
+
+    size_t devOffset, dOffset;
+    amd::Memory* devMemory = getMemoryObject(device_ptr, devOffset);
+    amd::Memory* dstMemory = getMemoryObject(dst_, dOffset);
+
+    if (devMemory == nullptr) {
+        return hipErrorInvalidValue;
+    }
+
+    if (dstMemory != nullptr) {
+      status = ihipMemcpyCommand(command, dstMemory, devMemory, count_, kind_, *stream, dOffset, devOffset);
+    } else {
+      status = ihipMemcpyCommand(command, dst_, devMemory, count_, kind_, *stream, devOffset);
+    }
+
     if (status != hipSuccess) {
       return status;
     }
@@ -2267,7 +2322,21 @@ class GraphMemcpyNodeToSymbol : public GraphMemcpyNode1D {
     if (status != hipSuccess) {
       return status;
     }
-    status = ihipMemcpyCommand(command, device_ptr, src_, count_, kind_, *stream);
+
+    size_t devOffset, sOffset;
+    amd::Memory* devMemory = getMemoryObject(device_ptr, devOffset);
+    amd::Memory* srcMemory = getMemoryObject(src_, sOffset);
+
+    if (devMemory == nullptr) {
+        return hipErrorInvalidValue;
+    }
+
+    if (srcMemory != nullptr) {
+      status = ihipMemcpyCommand(command, devMemory, srcMemory, count_, kind_, *stream, devOffset, sOffset);
+    } else {
+      status = ihipMemcpyCommand(command, devMemory, src_, count_, kind_, *stream, devOffset);
+    }
+
     if (status != hipSuccess) {
       return status;
     }

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -152,8 +152,7 @@ hipError_t hipExternalMemoryGetMappedBuffer(void** devPtr, hipExternalMemory_t e
   auto buf = reinterpret_cast<amd::ExternalBuffer*>(extMem);
 
   // Validate bounds
-  if (bufferDesc->size > buf->getSize() ||
-      bufferDesc->offset > buf->getSize() - bufferDesc->size) {
+  if (bufferDesc->size > buf->getSize() || bufferDesc->offset > buf->getSize() - bufferDesc->size) {
     HIP_RETURN(hipErrorInvalidValue);
   }
 
@@ -434,187 +433,194 @@ bool IsHtoHMemcpyValid(void* dst, const void* src, hipMemcpyKind kind) {
 }
 
 // ================================================================================================
-hipError_t ihipMemcpy_validate(void* dst, const void* src, size_t sizeBytes, hipMemcpyKind kind) {
-  if (dst == nullptr || src == nullptr) {
-    return hipErrorInvalidValue;
-  }
-  if (static_cast<uint32_t>(kind) > hipMemcpyDefault && kind != hipMemcpyDeviceToDeviceNoCU) {
-    return hipErrorInvalidMemcpyDirection;
-  }
-  size_t sOffset = 0;
-  amd::Memory* srcMemory = getMemoryObject(src, sOffset);
-  size_t dOffset = 0;
-  amd::Memory* dstMemory = getMemoryObject(dst, dOffset);
-
-  if (srcMemory != nullptr) {
-    // Validate Mem Access in case of VMM Memory
-    if (!srcMemory->ValidateMemAccess(*hip::getCurrentDevice()->devices()[0], false)) {
-      return hipErrorUnknown;
-    }
-
-    // If the mem object is a VMM sub buffer (subbuffer has parent set),
-    // then use parent's size for validation.
-    if (srcMemory->parent() && (srcMemory->getMemFlags() & CL_MEM_VA_RANGE_AMD)) {
-      srcMemory = srcMemory->parent();
-    }
-
-    // Size validation
-    if (sizeBytes > (srcMemory->getSize() - sOffset)) {
-      return hipErrorInvalidValue;
-    }
+hipError_t ihipMemcpy_validate_memory(amd::Memory* memObj, size_t sizeBytes, size_t offset,
+                                      bool read_write) {
+  // Validate Mem Access in case of VMM Memory
+  if (!memObj->ValidateMemAccess(*hip::getCurrentDevice()->devices()[0], read_write)) {
+    return hipErrorUnknown;
   }
 
-  if (dstMemory != nullptr) {
-    // Validate Mem Access in case of VMM Memory
-    if (!dstMemory->ValidateMemAccess(*hip::getCurrentDevice()->devices()[0], true)) {
-      return hipErrorUnknown;
-    }
-
-    // If the mem object is a VMM sub buffer (subbuffer has parent set),
-    // then use parent's size for validation.
-    if (dstMemory->parent() && (dstMemory->getMemFlags() & CL_MEM_VA_RANGE_AMD)) {
-      dstMemory = dstMemory->parent();
-    }
-
-    // Size validation
-    if (sizeBytes > (dstMemory->getSize() - dOffset)) {
-      return hipErrorInvalidValue;
-    }
+  // If the mem object is a VMM sub buffer (subbuffer has parent set),
+  // then use parent's size for validation.
+  if (memObj->parent() && (memObj->getMemFlags() & CL_MEM_VA_RANGE_AMD)) {
+    memObj = memObj->parent();
   }
 
-  // If src and dst ptr are null then kind must be either h2h or def.
-  if (!IsHtoHMemcpyValid(dst, src, kind)) {
+  // Size validation
+  if (offset > memObj->getSize() || sizeBytes > (memObj->getSize() - offset)) {
     return hipErrorInvalidValue;
   }
   return hipSuccess;
-}
-
-hip::MemcpyType ihipGetMemcpyType(const void* src, void* dst, hipMemcpyKind kind) {
-  size_t sOffset = 0;
-  amd::Memory* srcMemory = getMemoryObject(src, sOffset);
-  size_t dOffset = 0;
-  amd::Memory* dstMemory = getMemoryObject(dst, dOffset);
-  hip::MemcpyType type;
-  if (srcMemory == nullptr && dstMemory == nullptr) {
-    type = hipHostToHost;
-  } else if ((srcMemory == nullptr) && (dstMemory != nullptr)) {
-    type = hipWriteBuffer;
-  } else if ((srcMemory != nullptr) && (dstMemory == nullptr)) {
-    type = hipReadBuffer;
-  } else if ((srcMemory != nullptr) && (dstMemory != nullptr)) {
-    // Check if the queue device doesn't match the device on any memory object.
-    // And any of them are not host allocation.
-    // Hence it's a P2P transfer, because the app has requested access to another GPU
-    if ((srcMemory->GetDeviceById() != dstMemory->GetDeviceById()) &&
-        ((srcMemory->getContext().devices().size() == 1) &&
-         (dstMemory->getContext().devices().size() == 1))) {
-      type = hipCopyBufferP2P;
-    } else if (kind == hipMemcpyDeviceToDeviceNoCU) {
-      type = hipCopyBufferSDMA;
-    } else {
-      type = hipCopyBuffer;
-    }
-  }
-  return type;
 }
 
 // ================================================================================================
-hipError_t ihipMemcpyCommand(amd::Command*& command, void* dst, const void* src, size_t sizeBytes,
-                             hipMemcpyKind kind, hip::Stream& stream, bool isAsync) {
-  amd::Command::EventWaitList waitList;
-  size_t sOffset = 0;
-  amd::Memory* srcMemory = getMemoryObject(src, sOffset);
-  size_t dOffset = 0;
-  amd::Memory* dstMemory = getMemoryObject(dst, dOffset);
-  amd::Device* queueDevice = &stream.device();
-  amd::CopyMetadata copyMetadata(isAsync, amd::CopyMetadata::CopyEnginePreference::NONE);
-  hip::MemcpyType type = ihipGetMemcpyType(src, dst, kind);
-  hip::Stream* pStream = &stream;
-  switch (type) {
-    case hipWriteBuffer:
-      if (queueDevice != dstMemory->GetDeviceById() &&
-          !(dstMemory->getMemFlags() & CL_MEM_VA_RANGE_AMD)) {
-        pStream = hip::getNullStream(dstMemory->GetDeviceById()->context());
-        amd::Command* cmd = stream.getLastQueuedCommand(true);
-        if (cmd != nullptr) {
-          waitList.push_back(cmd);
-        }
-      }
-      command = new amd::WriteMemoryCommand(*pStream, CL_COMMAND_WRITE_BUFFER, waitList,
-                                            *dstMemory->asBuffer(), dOffset, sizeBytes, src, 0, 0,
-                                            copyMetadata);
-      break;
-    case hipReadBuffer:
-      if (queueDevice != srcMemory->GetDeviceById() &&
-          !(srcMemory->getMemFlags() & CL_MEM_VA_RANGE_AMD)) {
-        pStream = hip::getNullStream(srcMemory->GetDeviceById()->context());
-        amd::Command* cmd = stream.getLastQueuedCommand(true);
-        if (cmd != nullptr) {
-          waitList.push_back(cmd);
-        }
-      }
-      command = new amd::ReadMemoryCommand(*pStream, CL_COMMAND_READ_BUFFER, waitList,
-                                           *srcMemory->asBuffer(), sOffset, sizeBytes, dst, 0, 0,
-                                           copyMetadata);
-      break;
-    case hipCopyBufferP2P:
-      command = new amd::CopyMemoryP2PCommand(stream, CL_COMMAND_COPY_BUFFER, waitList,
-                                              *srcMemory->asBuffer(), *dstMemory->asBuffer(),
-                                              sOffset, dOffset, sizeBytes);
-      if (command == nullptr) {
-        return hipErrorOutOfMemory;
-      }
-      // Make sure runtime has valid memory for the command execution. P2P access
-      // requires page table mapping on the current device to another GPU memory
-      if (!static_cast<amd::CopyMemoryP2PCommand*>(command)->validateMemory()) {
-        delete command;
-        return hipErrorInvalidValue;
-      }
-      break;
-    case hipCopyBufferSDMA:
-      copyMetadata.copyEnginePreference_ = amd::CopyMetadata::CopyEnginePreference::SDMA;
-    case hipCopyBuffer:
-      if ((srcMemory->GetDeviceById() == dstMemory->GetDeviceById()) &&
-          queueDevice != srcMemory->GetDeviceById()) {
-        pStream = hip::getNullStream(srcMemory->GetDeviceById()->context());
-        amd::Command* cmd = stream.getLastQueuedCommand(true);
-        if (cmd != nullptr) {
-          waitList.push_back(cmd);
-        }
-      } else if (srcMemory->GetDeviceById() != dstMemory->GetDeviceById()) {
-        // Scenarios such as DtoH where dst is pinned memory
-        if ((queueDevice != srcMemory->GetDeviceById()) &&
-            (dstMemory->getContext().devices().size() != 1) &&
-            !(srcMemory->getMemFlags() & CL_MEM_VA_RANGE_AMD)) {
-          pStream = hip::getNullStream(srcMemory->GetDeviceById()->context());
-          amd::Command* cmd = stream.getLastQueuedCommand(true);
-          if (cmd != nullptr) {
-            waitList.push_back(cmd);
-          }
-          // Scenarios such as HtoD where src is pinned memory
-        } else if ((queueDevice != dstMemory->GetDeviceById()) &&
-                   (srcMemory->getContext().devices().size() != 1) &&
-                   !(dstMemory->getMemFlags() & CL_MEM_VA_RANGE_AMD)) {
-          pStream = hip::getNullStream(dstMemory->GetDeviceById()->context());
-          amd::Command* cmd = stream.getLastQueuedCommand(true);
-          if (cmd != nullptr) {
-            waitList.push_back(cmd);
-          }
-        }
-      }
-      command = new amd::CopyMemoryCommand(*pStream, CL_COMMAND_COPY_BUFFER, waitList,
-                                           *srcMemory->asBuffer(), *dstMemory->asBuffer(), sOffset,
-                                           dOffset, sizeBytes, copyMetadata);
-      break;
-    case hipHostToHost:
-      break;
-  }
-  if (waitList.size() > 0) {
-    waitList[0]->release();
-  }
+hipError_t ihipMemcpy_validate(amd::Memory* dstMemory, amd::Memory* srcMemory, size_t sizeBytes,
+                               size_t dstOffset, size_t srcOffset) {
+  hipError_t status;
+
+  status = ihipMemcpy_validate_memory(srcMemory, sizeBytes, srcOffset, /*read_write*/ false);
+  if (status != hipSuccess) return status;
+  status = ihipMemcpy_validate_memory(dstMemory, sizeBytes, dstOffset, /*read_write*/ true);
+  if (status != hipSuccess) return status;
+
   return hipSuccess;
 }
 
+// ================================================================================================
+hip::MemcpyType ihipGetMemcpyType(amd::Memory* src, amd::Memory* dst, hipMemcpyKind kind) {
+  if ((src->GetDeviceById() != dst->GetDeviceById()) &&
+      ((src->getContext().devices().size() == 1) && (dst->getContext().devices().size() == 1))) {
+    return hipCopyBufferP2P;
+  } else if (kind == hipMemcpyDeviceToDeviceNoCU) {
+    return hipCopyBufferSDMA;
+  }
+  return hipCopyBuffer;
+}
+
+// ================================================================================================
+// Helper class to manage common memcpy command state and cleanup
+class MemcpyCommandHelper {
+ public:
+  MemcpyCommandHelper(hip::Stream& stream, bool isAsync)
+      : waitList_(),
+        copyMetadata_(isAsync, amd::CopyMetadata::CopyEnginePreference::NONE),
+        pStream_(&stream),
+        queueDevice_(&stream.device()) {}
+
+  ~MemcpyCommandHelper() {
+    // Cleanup: release waitList command if present
+    if (waitList_.size() > 0) {
+      waitList_[0]->release();
+    }
+  }
+
+  // Non-copyable, non-movable
+  MemcpyCommandHelper(const MemcpyCommandHelper&) = delete;
+  MemcpyCommandHelper& operator=(const MemcpyCommandHelper&) = delete;
+
+  amd::Command::EventWaitList& waitList() { return waitList_; }
+  amd::CopyMetadata& copyMetadata() { return copyMetadata_; }
+  hip::Stream*& pStream() { return pStream_; }
+  amd::Device* queueDevice() const { return queueDevice_; }
+
+  // Helper to add wait command from stream
+  void addWaitCommand(hip::Stream& stream) {
+    amd::Command* cmd = stream.getLastQueuedCommand(true);
+    if (cmd != nullptr) {
+      waitList_.push_back(cmd);
+    }
+  }
+
+  // Helper to switch stream and add wait command
+  void switchStreamAndWait(hip::Stream& originalStream, amd::Context& context) {
+    pStream_ = hip::getNullStream(context);
+    addWaitCommand(originalStream);
+  }
+
+  // Common error handling for command creation
+  static hipError_t checkCommand(amd::Command* command) {
+    if (command == nullptr) {
+      return hipErrorOutOfMemory;
+    }
+    return hipSuccess;
+  }
+
+ private:
+  amd::Command::EventWaitList waitList_;
+  amd::CopyMetadata copyMetadata_;
+  hip::Stream* pStream_;
+  amd::Device* queueDevice_;
+};
+
+// ================================================================================================
+hipError_t ihipMemcpyCommand(amd::Command*& command, amd::Memory* dstMemory, const void* srcMemory,
+                             size_t sizeBytes, hipMemcpyKind kind, hip::Stream& stream,
+                             size_t dstOffset, bool isAsync) {
+  MemcpyCommandHelper helper(stream, isAsync);
+
+  if (&stream.device() != dstMemory->GetDeviceById() &&
+      !(dstMemory->getMemFlags() & CL_MEM_VA_RANGE_AMD)) {
+    helper.switchStreamAndWait(stream, dstMemory->GetDeviceById()->context());
+  }
+  command = new amd::WriteMemoryCommand(
+      *helper.pStream(), CL_COMMAND_WRITE_BUFFER, helper.waitList(), *dstMemory->asBuffer(),
+      dstOffset, sizeBytes, srcMemory, 0, 0, helper.copyMetadata());
+  return MemcpyCommandHelper::checkCommand(command);
+}
+
+// ================================================================================================
+hipError_t ihipMemcpyCommand(amd::Command*& command, void* dstMemory, amd::Memory* srcMemory,
+                             size_t sizeBytes, hipMemcpyKind kind, hip::Stream& stream,
+                             size_t srcOffset, bool isAsync) {
+  MemcpyCommandHelper helper(stream, isAsync);
+
+  if (helper.queueDevice() != srcMemory->GetDeviceById() &&
+      !(srcMemory->getMemFlags() & CL_MEM_VA_RANGE_AMD)) {
+    helper.switchStreamAndWait(stream, srcMemory->GetDeviceById()->context());
+  }
+  command = new amd::ReadMemoryCommand(*helper.pStream(), CL_COMMAND_READ_BUFFER, helper.waitList(),
+                                       *srcMemory->asBuffer(), srcOffset, sizeBytes,
+                                       dstMemory, 0, 0, helper.copyMetadata());
+  return MemcpyCommandHelper::checkCommand(command);
+}
+
+// ================================================================================================
+hipError_t ihipMemcpyCommand(amd::Command*& command, amd::Memory* dstMemory, amd::Memory* srcMemory,
+                             size_t sizeBytes, hipMemcpyKind kind, hip::Stream& stream,
+                             size_t dstOffset, size_t srcOffset, bool isAsync) {
+  MemcpyCommandHelper helper(stream, isAsync);
+
+  hip::MemcpyType type = ihipGetMemcpyType(srcMemory, dstMemory, kind);
+  switch (type) {
+    case hipCopyBufferP2P:
+      command = new amd::CopyMemoryP2PCommand(
+          stream, CL_COMMAND_COPY_BUFFER, helper.waitList(), *srcMemory->asBuffer(),
+          *dstMemory->asBuffer(), srcOffset, dstOffset, sizeBytes);
+      {
+        hipError_t status = MemcpyCommandHelper::checkCommand(command);
+        if (status != hipSuccess) {
+          return status;
+        }
+        // Make sure runtime has valid memory for the command execution. P2P access
+        // requires page table mapping on the current device to another GPU memory
+        if (!static_cast<amd::CopyMemoryP2PCommand*>(command)->validateMemory()) {
+          delete command;
+          return hipErrorInvalidValue;
+        }
+      }
+      break;
+    case hipCopyBufferSDMA:
+      helper.copyMetadata().copyEnginePreference_ = amd::CopyMetadata::CopyEnginePreference::SDMA;
+    case hipCopyBuffer:
+      if ((srcMemory->GetDeviceById() == dstMemory->GetDeviceById()) &&
+          helper.queueDevice() != srcMemory->GetDeviceById()) {
+        helper.switchStreamAndWait(stream, srcMemory->GetDeviceById()->context());
+      } else if (srcMemory->GetDeviceById() != dstMemory->GetDeviceById()) {
+        // Scenarios such as DtoH where dst is pinned memory
+        if ((helper.queueDevice() != srcMemory->GetDeviceById()) &&
+            (dstMemory->getContext().devices().size() != 1) &&
+            !(srcMemory->getMemFlags() & CL_MEM_VA_RANGE_AMD)) {
+          helper.switchStreamAndWait(stream, srcMemory->GetDeviceById()->context());
+          // Scenarios such as HtoD where src is pinned memory
+        } else if ((helper.queueDevice() != dstMemory->GetDeviceById()) &&
+                   (srcMemory->getContext().devices().size() != 1) &&
+                   !(dstMemory->getMemFlags() & CL_MEM_VA_RANGE_AMD)) {
+          helper.switchStreamAndWait(stream, dstMemory->GetDeviceById()->context());
+        }
+      }
+      command = new amd::CopyMemoryCommand(
+          *helper.pStream(), CL_COMMAND_COPY_BUFFER, helper.waitList(), *srcMemory->asBuffer(),
+          *dstMemory->asBuffer(), srcOffset, dstOffset, sizeBytes,
+          helper.copyMetadata());
+      break;
+    case hipHostToHost:
+      assert(false && "Unreachable case");
+      break;
+  }
+  return MemcpyCommandHelper::checkCommand(command);
+}
+
+// ================================================================================================
 bool IsHtoHMemcpy(void* dst, const void* src) {
   size_t sOffset = 0;
   amd::Memory* srcMemory = getMemoryObject(src, sOffset);
@@ -635,61 +641,86 @@ void ihipHtoHMemcpy(void* dst, const void* src, size_t sizeBytes, hip::Stream& s
 // ================================================================================================
 hipError_t ihipMemcpy(void* dst, const void* src, size_t sizeBytes, hipMemcpyKind kind,
                       hip::Stream& stream, bool isHostAsync, bool isGPUAsync) {
-  hipError_t status;
   if (sizeBytes == 0) {
     // Skip if nothing needs writing.
     return hipSuccess;
   }
-  status = ihipMemcpy_validate(dst, src, sizeBytes, kind);
-  if (status != hipSuccess) {
-    return status;
+  if (dst == nullptr || src == nullptr) {
+    return hipErrorInvalidValue;
+  }
+  if (static_cast<uint32_t>(kind) > hipMemcpyDefault && kind != hipMemcpyDeviceToDeviceNoCU) {
+    return hipErrorInvalidMemcpyDirection;
   }
   if (src == dst && kind == hipMemcpyDefault) {
     return hipSuccess;
   }
+
   size_t sOffset = 0;
-  amd::Memory* srcMemory = getMemoryObject(src, sOffset);
+  amd::Memory* srcDeviceMemory = getMemoryObject(src, sOffset);
   size_t dOffset = 0;
-  amd::Memory* dstMemory = getMemoryObject(dst, dOffset);
-
-  hipMemoryType srcMemoryType = getMemoryType(srcMemory);
-  hipMemoryType dstMemoryType = getMemoryType(dstMemory);
-
-  if (srcMemory == nullptr && dstMemory == nullptr) {
-    ihipHtoHMemcpy(dst, src, sizeBytes, stream);
-    return hipSuccess;
-  } else if (((srcMemory == nullptr) && (dstMemory != nullptr)) ||
-             ((srcMemory != nullptr) && (dstMemory == nullptr))) {
-    // Unpinned copy wait behavior is enforced in the lower copy layers so skip
-    // wait at top level except for MT path
-    isHostAsync &= AMD_DIRECT_DISPATCH ? true : false;
-  } else if (srcMemory->GetDeviceById() == dstMemory->GetDeviceById()) {
-    // Device to Device copies do not need to host side synchronization.
-    if ((srcMemoryType == hipMemoryTypeDevice) && (dstMemoryType == hipMemoryTypeDevice) &&
-        (!srcMemory->getUserData().sync_mem_ops_ || !dstMemory->getUserData().sync_mem_ops_)) {
-      isHostAsync = true;
-    }
-    // Any Host to any Host need host side synchronization.
-    if ((srcMemoryType == hipMemoryTypeHost) && (dstMemoryType == hipMemoryTypeHost)) {
-      isHostAsync = false;
-    }
+  amd::Memory* dstDeviceMemory = getMemoryObject(dst, dOffset);
+  
+  // Handle kind vs memobject miss matches
+  if (kind == hipMemcpyDeviceToHost && srcDeviceMemory == nullptr) {
+    return hipErrorInvalidValue;
+  }
+  if (kind == hipMemcpyHostToDevice && dstDeviceMemory == nullptr) {
+    return hipErrorInvalidValue;
   }
 
   amd::Command* command = nullptr;
-  status = ihipMemcpyCommand(command, dst, src, sizeBytes, kind, stream, isHostAsync);
-  if (status != hipSuccess) {
-    return status;
+  if (srcDeviceMemory == nullptr && dstDeviceMemory == nullptr) {
+    if (kind != hipMemcpyHostToHost && kind != hipMemcpyDefault) {
+      return hipErrorInvalidValue;
+    }
+    ihipHtoHMemcpy(dst, src, sizeBytes, stream);
+    return hipSuccess;
+  } else if (dstDeviceMemory == nullptr || srcDeviceMemory == nullptr) {
+    // Unpinned copy wait behavior is enforced in the lower copy layers so skip
+    // wait at top level except for MT path
+    isHostAsync &= AMD_DIRECT_DISPATCH ? true : false;
+    if (dstDeviceMemory != nullptr) {
+      IHIP_RETURN_ONFAIL(ihipMemcpy_validate_memory(dstDeviceMemory, sizeBytes, dOffset, /*read_write*/ true));
+      IHIP_RETURN_ONFAIL(ihipMemcpyCommand(command, dstDeviceMemory, src, sizeBytes, kind, stream, dOffset, isHostAsync));
+    } else {
+      IHIP_RETURN_ONFAIL(ihipMemcpy_validate_memory(srcDeviceMemory, sizeBytes, sOffset, /*read_write*/ false));
+      IHIP_RETURN_ONFAIL(ihipMemcpyCommand(command, dst, srcDeviceMemory, sizeBytes, kind, stream, sOffset, isHostAsync));
+    }
+  } else {
+    // Both are AMD memory
+    hipMemoryType srcMemoryType = getMemoryType(srcDeviceMemory);
+    hipMemoryType dstMemoryType = getMemoryType(dstDeviceMemory);
+
+    IHIP_RETURN_ONFAIL(ihipMemcpy_validate(dstDeviceMemory, srcDeviceMemory, sizeBytes, dOffset, sOffset));
+
+    if (srcDeviceMemory->GetDeviceById() == dstDeviceMemory->GetDeviceById()) {
+      // Device to Device copies do not need to host side synchronization.
+      if ((srcMemoryType == hipMemoryTypeDevice) && (dstMemoryType == hipMemoryTypeDevice) &&
+          (!srcDeviceMemory->getUserData().sync_mem_ops_ ||
+           !dstDeviceMemory->getUserData().sync_mem_ops_)) {
+        isHostAsync = true;
+      }
+      // Any Host to any Host need host side synchronization.
+      if ((srcMemoryType == hipMemoryTypeHost) && (dstMemoryType == hipMemoryTypeHost)) {
+        isHostAsync = false;
+      }
+    }
+    IHIP_RETURN_ONFAIL(ihipMemcpyCommand(command, dstDeviceMemory, srcDeviceMemory, sizeBytes, kind, stream,
+                               dOffset, sOffset, isHostAsync));
   }
+
   command->enqueue();
   if (!isHostAsync) {
     command->queue()->finishCommand(command);
   } else if (!isGPUAsync) {
-    hip::Stream* pStream = hip::getNullStream(dstMemory->GetDeviceById()->context());
+    assert(dstDeviceMemory != nullptr || srcDeviceMemory != nullptr && "Must have device memory to have GPU async");
+    amd::Memory* syncMemory = (dstDeviceMemory != nullptr) ? dstDeviceMemory : srcDeviceMemory;
+    hip::Stream* pStream = hip::getNullStream(syncMemory->GetDeviceById()->context());
     amd::Command::EventWaitList waitList;
     waitList.push_back(command);
-    amd::Command* depdentMarker = new amd::Marker(*pStream, false, waitList);
-    depdentMarker->enqueue();
-    depdentMarker->release();
+    amd::Command* dependentMarker = new amd::Marker(*pStream, false, waitList);
+    dependentMarker->enqueue();
+    dependentMarker->release();
   } else {
     amd::HostQueue* newQueue = command->queue();
     if (newQueue != &stream) {
@@ -697,9 +728,9 @@ hipError_t ihipMemcpy(void* dst, const void* src, size_t sizeBytes, hipMemcpyKin
       amd::Command* cmd = newQueue->getLastQueuedCommand(true);
       if (cmd != nullptr) {
         waitList.push_back(cmd);
-        amd::Command* depdentMarker = new amd::Marker(stream, true, waitList);
-        depdentMarker->enqueue();
-        depdentMarker->release();
+        amd::Command* dependentMarker = new amd::Marker(stream, true, waitList);
+        dependentMarker->enqueue();
+        dependentMarker->release();
         cmd->release();
       }
     }
@@ -2286,9 +2317,9 @@ inline hipError_t ihipMemcpyCmdEnqueue(amd::Command* command, bool isAsync = fal
       amd::Command* cmd = newQueue->getLastQueuedCommand(true);
       if (cmd != nullptr) {
         waitList.push_back(cmd);
-        amd::Command* depdentMarker = new amd::Marker(*stream, true, waitList);
-        depdentMarker->enqueue();
-        depdentMarker->release();
+        amd::Command* dependentMarker = new amd::Marker(*stream, true, waitList);
+        dependentMarker->enqueue();
+        dependentMarker->release();
         cmd->release();
       }
     }
@@ -2810,9 +2841,37 @@ static amd::CopyMetadata buildCopyMetadataFromAttrs(hipMemcpyAttributes* attrs, 
 hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count,
                            hipMemcpyAttributes* attrs, size_t* attrsIdxs, size_t numAttrs,
                            hip::Stream& stream, bool isAsync) {
-  // Validate all copies first
+  // Pre-compute memory objects once per copy to avoid repeated expensive
+  // getMemoryObject calls later in validation, classification, and submission.
+  std::vector<amd::Memory*> srcMemories(count, nullptr);
+  std::vector<amd::Memory*> dstMemories(count, nullptr);
+  std::vector<size_t> srcOffsets(count, 0);
+  std::vector<size_t> dstOffsets(count, 0);
+
   for (size_t i = 0; i < count; ++i) {
-    hipError_t status = ihipMemcpy_validate(dsts[i], srcs[i], sizes[i], hipMemcpyDefault);
+    if (dsts[i] == nullptr || srcs[i] == nullptr) {
+      return hipErrorInvalidValue;
+    }
+    srcMemories[i] = getMemoryObject(srcs[i], srcOffsets[i]);
+    dstMemories[i] = getMemoryObject(dsts[i], dstOffsets[i]);
+
+    // Host-to-host (both pointers have no associated memory object) is always
+    // valid for hipMemcpyDefault.
+    if (srcMemories[i] == nullptr && dstMemories[i] == nullptr) {
+      continue;
+    }
+
+    hipError_t status;
+    if (srcMemories[i] != nullptr && dstMemories[i] != nullptr) {
+      status = ihipMemcpy_validate(dstMemories[i], srcMemories[i], sizes[i], dstOffsets[i],
+                                   srcOffsets[i]);
+    } else if (srcMemories[i] != nullptr) {
+      status = ihipMemcpy_validate_memory(srcMemories[i], sizes[i], srcOffsets[i],
+                                          /*read_write*/ false);
+    } else {
+      status = ihipMemcpy_validate_memory(dstMemories[i], sizes[i], dstOffsets[i],
+                                          /*read_write*/ true);
+    }
     if (status != hipSuccess) {
       return status;
     }
@@ -2834,7 +2893,16 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
   std::vector<size_t> p2pIndices;
 
   for (size_t i = 0; i < count; ++i) {
-    hip::MemcpyType type = ihipGetMemcpyType(srcs[i], dsts[i], hipMemcpyDefault);
+    hip::MemcpyType type;
+    if (srcMemories[i] == nullptr && dstMemories[i] == nullptr) {
+      type = hipHostToHost;
+    } else if (srcMemories[i] == nullptr) {
+      type = hipWriteBuffer;
+    } else if (dstMemories[i] == nullptr) {
+      type = hipReadBuffer;
+    } else {
+      type = ihipGetMemcpyType(srcMemories[i], dstMemories[i], hipMemcpyDefault);
+    }
     switch (type) {
       case hipCopyBuffer:
       case hipCopyBufferSDMA:
@@ -2871,17 +2939,13 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
     copyOps.reserve(bufferCopyIndices.size());
 
     for (size_t idx : bufferCopyIndices) {
-      size_t sOffset = 0;
-      amd::Memory* srcMemory = getMemoryObject(srcs[idx], sOffset);
-      size_t dOffset = 0;
-      amd::Memory* dstMemory = getMemoryObject(dsts[idx], dOffset);
-
-      if (srcMemory == nullptr || dstMemory == nullptr) {
+      if (srcMemories[idx] == nullptr || dstMemories[idx] == nullptr) {
         return hipErrorInvalidValue;
       }
 
       amd::CopyMetadata metadata = buildCopyMetadataFromAttrs(attrs, attrsIdxs, numAttrs, idx, isAsync);
-      copyOps.emplace_back(srcMemory, dstMemory, sOffset, dOffset, sizes[idx], metadata);
+      copyOps.emplace_back(srcMemories[idx], dstMemories[idx], srcOffsets[idx], dstOffsets[idx], sizes[idx],
+                           metadata);
     }
 
     // Create and enqueue batch copy command
@@ -3821,7 +3885,7 @@ hipError_t ihipPointerGetAttributes(void* data, hipPointer_attribute attribute,
     case HIP_POINTER_ATTRIBUTE_IS_LEGACY_HIP_IPC_CAPABLE: {
       if (memObj) {
         if (getMemoryType(memObj) == hipMemoryTypeHost) {
-	      // host pointer, pinned or registered memory
+          // host pointer, pinned or registered memory
           *reinterpret_cast<int*>(data) = 0;
         } else if ((memObj->getMemFlags() & kManagedAlloc) == kManagedAlloc) {
           // managed allocation


### PR DESCRIPTION
## Motivation

Reintorducing PR from #1939. With potential fix for rocPrim test failure. Includes a commit addressing potential undefined behaviour and some additional error checks

rocPrim failure has been resolved: https://github.com/ROCm/TheRock/actions/runs/21173614009

## Technical Details

This change causes ihipMemcpy to call getMemoryObject once for each user input. Previously this was called multiple times, this is expensive as it can use HSA to request pointer_info. We should expect performance improvements across all functions which use ihipMempcy internally. HtoH, HtoD, DtoD, and DtoH for both blocking and async memcpy.

## Test Plan

I have collected benchmark results to verify this improvement and checked with rocprof that the trace confirms my solution works as intended. No changes to hip-tests are neccessary.

Results collected on the MI300X

**hipMemcpy Results HtoD:**
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/abeltons/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/abeltons/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Arial, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:Percent;}
-->

</head>

<body link="#467886" vlink="#96607D">


Size(kB) | Develop (ns) | W/ Patch (ns) | Diff (ns) | % Change (Bigger is better)
-- | -- | -- | -- | --
2.048 | 38156 | 36947 | 1209 | 3.17%
4.096 | 38798 | 37170 | 1628 | 4.20%
8.192 | 40769 | 39029 | 1740 | 4.27%
16.384 | 44511 | 42288 | 2223 | 4.99%
32.768 | 45893 | 43194 | 2699 | 5.88%
65.536 | 58121 | 55220 | 2901 | 4.99%
131.072 | 85549 | 82154 | 3395 | 3.97%
262.144 | 133719 | 127065 | 6654 | 4.98%
</body>
</html>

**hipMemcpyAsync Results HtoD:**
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/abeltons/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/abeltons/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Arial, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:Percent;}
-->

</head>

<body link="#467886" vlink="#96607D">


Size(kB) | Develop (ns) | W/ Patch (ns) | Diff (ns) | % Change (Bigger is better)
-- | -- | -- | -- | --
2.048 | 8912 | 7739 | 1173 | 13.16%
4.096 | 10372 | 9353 | 1019 | 9.82%
8.192 | 10908 | 9732 | 1176 | 10.78%
16.384 | 13455 | 12688 | 767 | 5.70%
32.768 | 30863 | 30948 | -85 | -0.28%
65.536 | 33392 | 33449 | -57 | -0.17%
131.072 | 37244 | 37311 | -67 | -0.18%
262.144 | 45220 | 45259 | -39 | -0.09%
</body>
</html>


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
