### PR TITLE
SWDEV-539306 - fix some ASan warnings

### DIFF
--- a/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
@@ -359,7 +359,7 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
 #endif
     SECTION("Get Dev Count from Child") {
       if (uuid_map.size() >= 2) {
-        std::string uuid =getNthElem(0).data();
+        std::string uuid = getNthElem(0).data();
         std::string uuidEnv = uuid.substr(0, 20);
         std::string uuid1 =  getNthElem(1).data();
         std::string uuidEnv1 = uuid1.substr(0, 20);
@@ -375,7 +375,7 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
     }
 #ifdef __linux__
     SECTION("Get UUID from Child proc rocminfo") {
-      std::string setUuid =getNthElem(0).data();
+      std::string setUuid = getNthElem(0).data();
       std::string uuidEnv = setUuid.substr(0, 20);
       unsetenv("HIP_VISIBLE_DEVICES");
       setenv("HIP_VISIBLE_DEVICES", uuidEnv.c_str(), 1);
@@ -456,7 +456,7 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
       }
     }
     SECTION("Set Env Variable in child process") {
-      std::string uuid =getNthElem(0).data();
+      std::string uuid = getNthElem(0).data();
       std::string uuidEnv = uuid.substr(0, 20);
       hip::SpawnProc proc("setEnvInChildProc", true);
       REQUIRE(proc.run(uuidEnv) == 1);
@@ -468,7 +468,7 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
     SECTION("Chk RocmInfo Uuid list before and after set Env") {
       std::map<int, std::vector<char>> uuid_map;
       uuid_map = getUUIDlistFromRocmInfo();
-      std::string uuid =getNthElem(0).data();
+      std::string uuid = getNthElem(0).data();
       unsetenv("HIP_VISIBLE_DEVICES");
       setenv("HIP_VISIBLE_DEVICES", uuid.c_str(), 1);
       std::map<int, std::vector<char>> uuid_map1;
@@ -506,7 +506,7 @@ void ChkUUID() {
   uuid_map = getUUIDlistWithoutRocmInfo();
 #endif
   if (!uuid_map.empty()) {
-    std::string uuid =getNthElem(0).data();
+    std::string uuid = getNthElem(0).data();
     std::string t_uuid = uuid.substr(4, 19);
     if (memcmp(d_uuid.bytes, t_uuid.c_str(), 16) == 0) {
       tState = 1;

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
@@ -263,8 +263,9 @@ auto getUUIDlistFromRocmInfo() {
       continue;
     } else if (auto loc = rocminfo_line.find("GPU-"); loc != std::string::npos) {
       if (std::string::npos == rocminfo_line.find("GPU-XX")) {
-        std::vector<char> t_uuid(20, 0);
+        std::vector<char> t_uuid(21, 0);
         std::memcpy(t_uuid.data(), &rocminfo_line[loc], 20);
+        t_uuid.back() = '\0';
         uuid_map[j] = t_uuid;
       }
     }

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
@@ -361,7 +361,7 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
       if (uuid_map.size() >= 2) {
         std::string uuid = getNthElem(0).data();
         std::string uuidEnv = uuid.substr(0, 20);
-        std::string uuid1 =  getNthElem(1).data();
+        std::string uuid1 = getNthElem(1).data();
         std::string uuidEnv1 = uuid1.substr(0, 20);
         std::string totalString = uuidEnv + "," + uuidEnv1;
         unsetenv("HIP_VISIBLE_DEVICES");

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
@@ -38,10 +38,14 @@ THE SOFTWARE.
 #define setenv(x, y, z) _putenv_s(x, y)
 #define unsetenv(x) _putenv(x)
 #endif
-#define COMMAND_LEN 256
-#define BUFFER_LEN 512
+static constexpr uint64_t COMMAND_LEN = 256;
+static constexpr uint64_t BUFFER_LEN = 512;
+static constexpr uint64_t PREFIX_LEN = 4;
+static constexpr uint64_t UUID_LEN = 16;
+static constexpr uint64_t TOTAL_UUID_LEN = PREFIX_LEN + UUID_LEN;
 
 std::atomic<int> tState{1};  // 0:fail, 1:pass, 2:skip
+
 
 /**
  * @addtogroup hipDeviceGetUuid hipDeviceGetUuid
@@ -165,7 +169,7 @@ TEST_CASE("Unit_hipDeviceGetUuid_From_RocmInfo", "[multigpu]") {
   }
   char command_op[BUFFER_LEN];
   int j = 0;
-  std::map<int, std::vector<char>> uuid_map;
+  std::map<int, std::string> uuid_map;
   while (fgets(command_op, BUFFER_LEN, fpipe)) {
     std::string rocminfo_line(command_op);
     if (std::string::npos != rocminfo_line.find("CPU-")) {
@@ -174,8 +178,8 @@ TEST_CASE("Unit_hipDeviceGetUuid_From_RocmInfo", "[multigpu]") {
       if (std::string::npos ==
           rocminfo_line.find(
               "GPU-XX")) {  // Only make an entry if the device is not an iGPU  // NOLINT
-        std::vector<char> t_uuid(16, 0);
-        std::memcpy(t_uuid.data(), &rocminfo_line[loc + 4], 16);
+        std::string t_uuid(UUID_LEN, 0);
+        std::memcpy(t_uuid.data(), &rocminfo_line[loc + PREFIX_LEN], UUID_LEN);
         uuid_map[j] = t_uuid;
       }
     }
@@ -186,7 +190,7 @@ TEST_CASE("Unit_hipDeviceGetUuid_From_RocmInfo", "[multigpu]") {
   if (visible_devices.size() > 0) {
     // We have visible devices set, basically parse the visible devices and remove the entries
     size_t start = 0;  // The devices will be reported from 0..
-    std::map<int, std::vector<char>> uuid_map_copy;
+    std::map<int, std::string> uuid_map_copy;
     for (auto device : visible_devices) {
       uuid_map_copy[start] = uuid_map[device];
     }
@@ -203,7 +207,7 @@ TEST_CASE("Unit_hipDeviceGetUuid_From_RocmInfo", "[multigpu]") {
     HIP_CHECK(hipDeviceGet(&device, dev));
     hipUUID d_uuid{0};
     HIP_CHECK(hipDeviceGetUuid(&d_uuid, device));
-    REQUIRE(memcmp(d_uuid.bytes, i.second.data(), 16) == 0);
+    REQUIRE(memcmp(d_uuid.bytes, i.second.data(), UUID_LEN) == 0);
   }
 }
 #endif
@@ -233,7 +237,7 @@ TEST_CASE("Unit_hipDeviceGetUuid_VerifyUuidFrm_hipGetDeviceProperties",
     HIP_CHECK(hipDeviceGet(&device, dev));
     HIP_CHECK(hipDeviceGetUuid(&uuid, device));
     HIP_CHECK(hipGetDeviceProperties(&prop, dev));
-    REQUIRE(memcmp(uuid.bytes, prop.uuid.bytes, 16) == 0);
+    REQUIRE(memcmp(uuid.bytes, prop.uuid.bytes, UUID_LEN) == 0);
   }
 }
 #endif
@@ -256,16 +260,16 @@ auto getUUIDlistFromRocmInfo() {
   }
   char command_op[BUFFER_LEN];
   int j = 0;
-  std::map<int, std::vector<char>> uuid_map;
+  std::map<int, std::string> uuid_map;
   while (fgets(command_op, BUFFER_LEN, fpipe)) {
     std::string rocminfo_line(command_op);
     if (std::string::npos != rocminfo_line.find("CPU-")) {
       continue;
     } else if (auto loc = rocminfo_line.find("GPU-"); loc != std::string::npos) {
       if (std::string::npos == rocminfo_line.find("GPU-XX")) {
-        std::vector<char> t_uuid(21, 0);
-        std::memcpy(t_uuid.data(), &rocminfo_line[loc], 20);
-        t_uuid.back() = '\0';
+        std::string t_uuid(TOTAL_UUID_LEN, 0);
+        std::memcpy(t_uuid.data(), &rocminfo_line[loc], TOTAL_UUID_LEN);
+
         uuid_map[j] = t_uuid;
       }
     }
@@ -282,16 +286,16 @@ auto getUUIDlistWithoutRocmInfo() {
   std::string delimiter = ",";
   size_t pos = 0;
   int first = 0;
-  std::map<int, std::vector<char>> uuid_map;
+  std::map<int, std::string> uuid_map;
   while ((pos = strList.find(delimiter)) != std::string::npos) {
-    std::vector<char> t_uuid(20, 0);
-    std::memcpy(t_uuid.data(), &strList[0], 20);
+    std::string t_uuid(TOTAL_UUID_LEN, 0);
+    std::memcpy(t_uuid.data(), &strList[0], TOTAL_UUID_LEN);
     uuid_map[first] = t_uuid;
     first++;
     strList.erase(0, pos + delimiter.length());
   }
-  std::vector<char> tmp_uuid(20, 0);
-  std::memcpy(tmp_uuid.data(), &strList[0], 20);
+  std::string tmp_uuid(TOTAL_UUID_LEN, 0);
+  std::memcpy(tmp_uuid.data(), &strList[0], TOTAL_UUID_LEN);
   uuid_map[first] = tmp_uuid;
   return uuid_map;
 }
@@ -311,7 +315,7 @@ auto getUUIDlistWithoutRocmInfo() {
  *  - HIP_VERSION >= 6.2
  */
 TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
-  std::map<int, std::vector<char>> uuid_map;
+  std::map<int, std::string> uuid_map;
   auto getNthElem = [&uuid_map](int pos) {
      return std::next(uuid_map.begin(), pos)->second;
   };
@@ -323,19 +327,19 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
   if (uuid_map.size() > 0) {
     SECTION("Set Env in parent and verify UUID in child ") {
       // Set Env Var with first GPU
-      std::string uuid = getNthElem(0).data();
-      std::string uuidEnv = uuid.substr(0, 20);
+      std::string uuid = getNthElem(0);
+      std::string uuidEnv = uuid.substr(0, TOTAL_UUID_LEN);
       unsetenv("HIP_VISIBLE_DEVICES");
       setenv("HIP_VISIBLE_DEVICES", uuidEnv.c_str(), 1);
       hip::SpawnProc proc("chkUUIDFrmChildProc_Exe", true);
-      std::string t_uuid = uuidEnv.substr(4, 19);
+      std::string t_uuid = uuidEnv.substr(PREFIX_LEN, TOTAL_UUID_LEN - 1);
       REQUIRE(proc.run(t_uuid) == 1);
       unsetenv("HIP_VISIBLE_DEVICES");
     }
 #if 0  // Disabling below 2 tests due to the defect SWDEV-467665
     SECTION("Set Env in parent and verify UUID in Grand child") {
-      std::string uuid = getNthElem(0).data();
-      std::string uuidEnv = uuid.substr(0, 20);
+      std::string uuid = getNthElem(0);
+      std::string uuidEnv = uuid.substr(0, TOTAL_UUID_LEN);
       unsetenv("HIP_VISIBLE_DEVICES");
       setenv("HIP_VISIBLE_DEVICES", uuidEnv.c_str(), 1);
       hip::SpawnProc proc("passUUIDToGrandChild_Exe", true);
@@ -345,8 +349,8 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
 
     SECTION("Reset Env in child and verify UUID in Grand child") {
       if (uuid_map.size() >= 2) {
-        std::string uuid = getNthElem(1).data();
-        std::string uuidEnv = uuid.substr(0, 20);
+        std::string uuid = getNthElem(1);
+        std::string uuidEnv = uuid.substr(0, TOTAL_UUID_LEN);
         unsetenv("HIP_VISIBLE_DEVICES");
         setenv("HIP_VISIBLE_DEVICES", uuidEnv.c_str(), 1);
         hip::SpawnProc proc("ResetUUIDInChild_Exe", true);
@@ -359,10 +363,10 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
 #endif
     SECTION("Get Dev Count from Child") {
       if (uuid_map.size() >= 2) {
-        std::string uuid = getNthElem(0).data();
-        std::string uuidEnv = uuid.substr(0, 20);
-        std::string uuid1 = getNthElem(1).data();
-        std::string uuidEnv1 = uuid1.substr(0, 20);
+        std::string uuid = getNthElem(0);
+        std::string uuidEnv = uuid.substr(0, TOTAL_UUID_LEN);
+        std::string uuid1 = getNthElem(1);
+        std::string uuidEnv1 = uuid1.substr(0, TOTAL_UUID_LEN);
         std::string totalString = uuidEnv + "," + uuidEnv1;
         unsetenv("HIP_VISIBLE_DEVICES");
         setenv("HIP_VISIBLE_DEVICES", totalString.c_str(), 1);
@@ -375,8 +379,8 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
     }
 #ifdef __linux__
     SECTION("Get UUID from Child proc rocminfo") {
-      std::string setUuid = getNthElem(0).data();
-      std::string uuidEnv = setUuid.substr(0, 20);
+      std::string setUuid = getNthElem(0);
+      std::string uuidEnv = setUuid.substr(0, TOTAL_UUID_LEN);
       unsetenv("HIP_VISIBLE_DEVICES");
       setenv("HIP_VISIBLE_DEVICES", uuidEnv.c_str(), 1);
       std::string wholeString;
@@ -387,7 +391,7 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
           continue;
         } else {
           wholeString = it->second.data();
-          uuid = wholeString.substr(0, 20);
+          uuid = wholeString.substr(0, TOTAL_UUID_LEN);
           if (it->first == uuid_map.size() - 1) {
             finalUuid = finalUuid + uuid;
           } else {
@@ -409,7 +413,7 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
           continue;
         } else {
           wholeString = it->second.data();
-          uuid = wholeString.substr(0, 20);
+          uuid = wholeString.substr(0, TOTAL_UUID_LEN);
           if (it->first == uuid_map.size() - 1) {
             finalUuid = finalUuid + uuid;
           } else {
@@ -426,8 +430,8 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
     SECTION("Set mix Env variables") {
       if (uuid_map.size() >= 2) {
         std::string uuid = "0";
-        std::string uuid1 = getNthElem(1).data();
-        std::string uuidEnv1 = uuid1.substr(0, 20);
+        std::string uuid1 = getNthElem(1);
+        std::string uuidEnv1 = uuid1.substr(0, TOTAL_UUID_LEN);
         std::string totalString = uuid + "," + uuidEnv1;
         unsetenv("HIP_VISIBLE_DEVICES");
         setenv("HIP_VISIBLE_DEVICES", totalString.c_str(), 1);
@@ -441,10 +445,10 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
     SECTION("Set Same UUID/Device ordinal more than once ") {
       if (uuid_map.size() >= 2) {
         std::string uuid = "0";
-        std::string uuid1 = getNthElem(0).data();
-        std::string uuidEnv1 = uuid1.substr(0, 20);
-        std::string uuid2 =  getNthElem(1).data();
-        std::string uuidEnv2 = uuid2.substr(0, 20);
+        std::string uuid1 = getNthElem(0);
+        std::string uuidEnv1 = uuid1.substr(0, TOTAL_UUID_LEN);
+        std::string uuid2 =  getNthElem(1);
+        std::string uuidEnv2 = uuid2.substr(0, TOTAL_UUID_LEN);
         std::string totalString = uuid + "," + uuidEnv2 + "," + uuidEnv1 + "," + uuid;
         unsetenv("HIP_VISIBLE_DEVICES");
         setenv("HIP_VISIBLE_DEVICES", totalString.c_str(), 1);
@@ -456,8 +460,8 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
       }
     }
     SECTION("Set Env Variable in child process") {
-      std::string uuid = getNthElem(0).data();
-      std::string uuidEnv = uuid.substr(0, 20);
+      std::string uuid = getNthElem(0);
+      std::string uuidEnv = uuid.substr(0, TOTAL_UUID_LEN);
       hip::SpawnProc proc("setEnvInChildProc", true);
       REQUIRE(proc.run(uuidEnv) == 1);
       int devCount = 0;
@@ -466,12 +470,12 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
     }
 #ifdef __linux__
     SECTION("Chk RocmInfo Uuid list before and after set Env") {
-      std::map<int, std::vector<char>> uuid_map;
+      std::map<int, std::string> uuid_map;
       uuid_map = getUUIDlistFromRocmInfo();
-      std::string uuid = getNthElem(0).data();
+      std::string uuid = getNthElem(0);
       unsetenv("HIP_VISIBLE_DEVICES");
       setenv("HIP_VISIBLE_DEVICES", uuid.c_str(), 1);
-      std::map<int, std::vector<char>> uuid_map1;
+      std::map<int, std::string> uuid_map1;
       uuid_map1 = getUUIDlistFromRocmInfo();
       REQUIRE(uuid_map.size() == uuid_map1.size());
     }
@@ -496,7 +500,7 @@ void ChkUUID() {
   HIP_CHECK(hipDeviceGet(&device, 0));
   hipUUID d_uuid{0};
   HIP_CHECK(hipDeviceGetUuid(&d_uuid, device));
-  std::map<int, std::vector<char>> uuid_map;
+  std::map<int, std::string> uuid_map;
   auto getNthElem = [&uuid_map](int pos) {
      return std::next(uuid_map.begin(), pos)->second;
   };
@@ -506,16 +510,16 @@ void ChkUUID() {
   uuid_map = getUUIDlistWithoutRocmInfo();
 #endif
   if (!uuid_map.empty()) {
-    std::string uuid = getNthElem(0).data();
-    std::string t_uuid = uuid.substr(4, 19);
-    if (memcmp(d_uuid.bytes, t_uuid.c_str(), 16) == 0) {
+    std::string uuid = getNthElem(0);
+    std::string t_uuid = uuid.substr(PREFIX_LEN, TOTAL_UUID_LEN - 1);
+    if (memcmp(d_uuid.bytes, t_uuid.c_str(), UUID_LEN) == 0) {
       tState = 1;
     }
   }
 }
 
 void setEnv() {
-  std::map<int, std::vector<char>> uuid_map;
+  std::map<int, std::string> uuid_map;
   auto getNthElem = [&uuid_map](int pos) {
      return std::next(uuid_map.begin(), pos)->second;
   };
@@ -525,8 +529,8 @@ void setEnv() {
   uuid_map = getUUIDlistWithoutRocmInfo();
 #endif
   if (uuid_map.size() >= 2) {
-    std::string uuid = getNthElem(1).data();
-    std::string uuidEnv = uuid.substr(0, 20);
+    std::string uuid = getNthElem(1);
+    std::string uuidEnv = uuid.substr(0, TOTAL_UUID_LEN);
     unsetenv("HIP_VISIBLE_DEVICES");
     setenv("HIP_VISIBLE_DEVICES", uuidEnv.c_str(), 1);
   } else {

--- a/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc
@@ -32,6 +32,7 @@ THE SOFTWARE.
 #include <vector>
 #include <thread>  // NOLINT
 #include <mutex>   //NOLINT
+#include <iterator>
 
 #ifdef _WIN64
 #define setenv(x, y, z) _putenv_s(x, y)
@@ -310,6 +311,9 @@ auto getUUIDlistWithoutRocmInfo() {
  */
 TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
   std::map<int, std::vector<char>> uuid_map;
+  auto getNthElem = [&uuid_map](int pos) {
+     return std::next(uuid_map.begin(), pos)->second;
+  };
 #ifdef __linux__
   uuid_map = getUUIDlistFromRocmInfo();
 #else
@@ -318,7 +322,7 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
   if (uuid_map.size() > 0) {
     SECTION("Set Env in parent and verify UUID in child ") {
       // Set Env Var with first GPU
-      std::string uuid = uuid_map[0].data();
+      std::string uuid = getNthElem(0).data();
       std::string uuidEnv = uuid.substr(0, 20);
       unsetenv("HIP_VISIBLE_DEVICES");
       setenv("HIP_VISIBLE_DEVICES", uuidEnv.c_str(), 1);
@@ -329,7 +333,7 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
     }
 #if 0  // Disabling below 2 tests due to the defect SWDEV-467665
     SECTION("Set Env in parent and verify UUID in Grand child") {
-      std::string uuid = uuid_map[0].data();
+      std::string uuid = getNthElem(0).data();
       std::string uuidEnv = uuid.substr(0, 20);
       unsetenv("HIP_VISIBLE_DEVICES");
       setenv("HIP_VISIBLE_DEVICES", uuidEnv.c_str(), 1);
@@ -340,7 +344,7 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
 
     SECTION("Reset Env in child and verify UUID in Grand child") {
       if (uuid_map.size() >= 2) {
-        std::string uuid = uuid_map[1].data();
+        std::string uuid = getNthElem(1).data();
         std::string uuidEnv = uuid.substr(0, 20);
         unsetenv("HIP_VISIBLE_DEVICES");
         setenv("HIP_VISIBLE_DEVICES", uuidEnv.c_str(), 1);
@@ -354,9 +358,9 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
 #endif
     SECTION("Get Dev Count from Child") {
       if (uuid_map.size() >= 2) {
-        std::string uuid = uuid_map[0].data();
+        std::string uuid =getNthElem(0).data();
         std::string uuidEnv = uuid.substr(0, 20);
-        std::string uuid1 = uuid_map[1].data();
+        std::string uuid1 =  getNthElem(1).data();
         std::string uuidEnv1 = uuid1.substr(0, 20);
         std::string totalString = uuidEnv + "," + uuidEnv1;
         unsetenv("HIP_VISIBLE_DEVICES");
@@ -370,7 +374,7 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
     }
 #ifdef __linux__
     SECTION("Get UUID from Child proc rocminfo") {
-      std::string setUuid = uuid_map[0].data();
+      std::string setUuid =getNthElem(0).data();
       std::string uuidEnv = setUuid.substr(0, 20);
       unsetenv("HIP_VISIBLE_DEVICES");
       setenv("HIP_VISIBLE_DEVICES", uuidEnv.c_str(), 1);
@@ -421,7 +425,7 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
     SECTION("Set mix Env variables") {
       if (uuid_map.size() >= 2) {
         std::string uuid = "0";
-        std::string uuid1 = uuid_map[1].data();
+        std::string uuid1 = getNthElem(1).data();
         std::string uuidEnv1 = uuid1.substr(0, 20);
         std::string totalString = uuid + "," + uuidEnv1;
         unsetenv("HIP_VISIBLE_DEVICES");
@@ -436,9 +440,9 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
     SECTION("Set Same UUID/Device ordinal more than once ") {
       if (uuid_map.size() >= 2) {
         std::string uuid = "0";
-        std::string uuid1 = uuid_map[0].data();
+        std::string uuid1 = getNthElem(0).data();
         std::string uuidEnv1 = uuid1.substr(0, 20);
-        std::string uuid2 = uuid_map[1].data();
+        std::string uuid2 =  getNthElem(1).data();
         std::string uuidEnv2 = uuid2.substr(0, 20);
         std::string totalString = uuid + "," + uuidEnv2 + "," + uuidEnv1 + "," + uuid;
         unsetenv("HIP_VISIBLE_DEVICES");
@@ -451,7 +455,7 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
       }
     }
     SECTION("Set Env Variable in child process") {
-      std::string uuid = uuid_map[0].data();
+      std::string uuid =getNthElem(0).data();
       std::string uuidEnv = uuid.substr(0, 20);
       hip::SpawnProc proc("setEnvInChildProc", true);
       REQUIRE(proc.run(uuidEnv) == 1);
@@ -463,7 +467,7 @@ TEST_CASE("Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES") {
     SECTION("Chk RocmInfo Uuid list before and after set Env") {
       std::map<int, std::vector<char>> uuid_map;
       uuid_map = getUUIDlistFromRocmInfo();
-      std::string uuid = uuid_map[0].data();
+      std::string uuid =getNthElem(0).data();
       unsetenv("HIP_VISIBLE_DEVICES");
       setenv("HIP_VISIBLE_DEVICES", uuid.c_str(), 1);
       std::map<int, std::vector<char>> uuid_map1;
@@ -492,13 +496,16 @@ void ChkUUID() {
   hipUUID d_uuid{0};
   HIP_CHECK(hipDeviceGetUuid(&d_uuid, device));
   std::map<int, std::vector<char>> uuid_map;
+  auto getNthElem = [&uuid_map](int pos) {
+     return std::next(uuid_map.begin(), pos)->second;
+  };
 #ifdef __linux__
   uuid_map = getUUIDlistFromRocmInfo();
 #else
   uuid_map = getUUIDlistWithoutRocmInfo();
 #endif
   if (!uuid_map.empty()) {
-    std::string uuid = uuid_map[0].data();
+    std::string uuid =getNthElem(0).data();
     std::string t_uuid = uuid.substr(4, 19);
     if (memcmp(d_uuid.bytes, t_uuid.c_str(), 16) == 0) {
       tState = 1;
@@ -508,13 +515,16 @@ void ChkUUID() {
 
 void setEnv() {
   std::map<int, std::vector<char>> uuid_map;
+  auto getNthElem = [&uuid_map](int pos) {
+     return std::next(uuid_map.begin(), pos)->second;
+  };
 #ifdef __linux__
   uuid_map = getUUIDlistFromRocmInfo();
 #else
   uuid_map = getUUIDlistWithoutRocmInfo();
 #endif
   if (uuid_map.size() >= 2) {
-    std::string uuid = uuid_map[1].data();
+    std::string uuid = getNthElem(1).data();
     std::string uuidEnv = uuid.substr(0, 20);
     unsetenv("HIP_VISIBLE_DEVICES");
     setenv("HIP_VISIBLE_DEVICES", uuidEnv.c_str(), 1);

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParams.cc
@@ -231,14 +231,33 @@ TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams_Negative_Parameters") {
  *    - HIP_VERSION >= 5.2
  */
 TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Direction") {
-  int *host, *dev;
+  int *host, *dev, *src, *dst;
   HIP_CHECK(hipHostMalloc(&host, sizeof(int)));
   HIP_CHECK(hipMalloc(&dev, sizeof(int)));
 
-  const auto [dir, src, dst] = GENERATE_REF(std::make_tuple(hipMemcpyHostToHost, host, host),
-                                            std::make_tuple(hipMemcpyHostToDevice, host, dev),
-                                            std::make_tuple(hipMemcpyDeviceToHost, dev, host),
-                                            std::make_tuple(hipMemcpyDeviceToDevice, dev, dev));
+  const auto dir = GENERATE(hipMemcpyHostToHost, hipMemcpyHostToDevice,
+                            hipMemcpyDeviceToHost, hipMemcpyDeviceToDevice);
+
+  switch (dir) {
+  case hipMemcpyHostToHost:
+    src = host;
+    dst = host;
+    break;
+  case hipMemcpyHostToDevice:
+    src = host;
+    dst = dev;
+    break;
+  case hipMemcpyDeviceToHost:
+    src = dev;
+    dst = host;
+    break;
+  case hipMemcpyDeviceToDevice:
+    src = dev;
+    dst = dev;
+    break;
+  default:
+    assert(false);
+  }
 
   hipGraph_t graph = nullptr;
   HIP_CHECK(hipGraphCreate(&graph, 0));

--- a/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphExecMemcpyNodeSetParams.cc
@@ -256,6 +256,7 @@ TEST_CASE("Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Directi
     dst = dev;
     break;
   default:
+    REQUIRE(false);
     assert(false);
   }
 


### PR DESCRIPTION
## Motivation

ASan reports:
- heap-buffer-overflow in several Unit_Uuid tests
- heap-use-after-free in Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Direction

## Technical Details
* The Unit_Uuid tests do something like this:

```cpp
std::map<int, std::vector<char>> uuid_map;
uuid_map = getUUIDlistFromRocmInfo();
// Set Env Var with first GPU
std::string uuid = uuid_map[0].data();
```
but there are no guarantees that the first GPU will have a index of 0 because a CPU might be the first device displayed by rocminfo. If a CPU is the index 0 then there are no guarantees that uuid_map[0].data() points to a null pointer string.

Additionally the code did not account for the null character in the vector<char>.

* Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Direction uses GENERATE_REF() incorrectly. 

GENERATE_REF() could be used instead of GENERATE() when variables are used (as opposed to literals), to run a TEST_CASE for different values that need updating for each iteration. Unfortunately when run the test you can realize that the initial pointers that are allocated in the first execution of the test are reused for all invocations, causing a heap-after-free.
 
GENERATE_REF() is used with a tuple type, when actually the components of the tuple (which are pointers) are the ones we need to prevent from dangling. GENERATE_REF() would have work if used with the pointers directly. In any case, this PR removes the tuple type and avoids the re-use of the pointers in each iteration.

## JIRA ID

Part of SWDEV-539306 

## Test Plan
Check that the associated ASan warnings are fixed on MI300X:

```
==44452==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7b76cc5f68f4 at pc 0x7f46db1d8cbb bp 0x7b066bbf6f80 sp 0x7b066bbf6748
READ of size 21 at 0x7b76cc5f68f4 thread T4
    #0 0x7f46db1d8cba in strlen /longer_pathname_so_that_rpms_can_support_packaging_the_debug_info_for_all_os_profiles/src/llvm-project/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:425:5
    #1 0x0000002f55e6 in std::char_traits<char>::length(char const*) /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/char_traits.h:399:9
    #2 0x0000002f55e6 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::allocator<char> >(char const*, std::allocator<char> const&) /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/basic_string.h:649:30
    #3 0x0000002f55e6 in setEnv() /longer_pathname_so_that_rpms_can_support_packaging_the_debug_info_for_all_os_profiles/src/rocm-systems/projects/hip-tests/catch/unit/device/hipDeviceGetUuid.cc:517:24
    #4 0x7f46d91ad252  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xdc252) (BuildId: e72c155b714bc42a767ec9c0dd94589110e5b42f)
    #5 0x7f46db262256 in asan_thread_start(void*) /longer_pathname_so_that_rpms_can_support_packaging_the_debug_info_for_all_os_profiles/src/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:240:28
    #6 0x7f46d8e35ac2 in start_thread nptl/./nptl/pthread_create.c:442:8
    #7 0x7f46d8ec78bf  misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
```
```
Test project /longer_pathname_so_that_rpms_can_support_packaging_the_debug_info_for_all_os_profiles/src/rocm-systems/projects/hip-tests/build
    Start 257: Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Direction
1/1 Test #257: Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Direction ...***Failed    2.36 sec
=================================================================
==8846==ERROR: AddressSanitizer: heap-use-after-free on address 0x7ae7e9139000 at pc 0x7f17fd7d2904 bp 0x7ffe65ae4e60 sp 0x7ffe65ae4618
READ of size 4 at 0x7ae7e9139000 thread T0
    #0 0x7f17fd7d2903 in memcpy /longer_pathname_so_that_rpms_can_support_packaging_the_debug_info_for_all_os_profiles/src/llvm-project/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc:117:5
    #1 0x7f17fbed51fe in amd::device::HostBlitManager::copyBufferRect(amd::device::Memory&, amd::device::Memory&, amd::BufferRect const&, amd::BufferRect const&, amd::Coord3D const&, bool, amd::CopyMetadata) const /longer_pathname_so_that_rpms_can_support_packaging_the_debug_info_for_all_os_profiles/src/rocm-systems/projects/clr/rocclr/device/blit.cpp:343:7
```

## Test Result

Tests now passed correctly with ASan:

```
root@f0a0630a3777:/longer_pathname_so_that_rpms_can_support_packaging_the_debug_info_for_all_os_profiles/src/rocm-systems/projects/hip-tests/build# ctest --output-on-failure -R "hipGetProcAddress_MemoryApisManagedMemory|Unit_hipDeviceGetPCIBusId_CheckPciBusIDWithLspci|Unit_hipMemRangeGetAttributes_NegativeTst|Unit_Uuid*|Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Direction"
Test project /longer_pathname_so_that_rpms_can_support_packaging_the_debug_info_for_all_os_profiles/src/rocm-systems/projects/hip-tests/build
    Start  257: Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Direction
1/5 Test  #257: Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Direction ...   Passed    1.62 sec
    Start 1062: Unit_hipGetProcAddress_MemoryApisManagedMemory
2/5 Test #1062: Unit_hipGetProcAddress_MemoryApisManagedMemory ............................   Passed    1.45 sec
    Start 1512: Unit_hipMemRangeGetAttributes_NegativeTst
3/5 Test #1512: Unit_hipMemRangeGetAttributes_NegativeTst .................................   Passed    1.17 sec
    Start 1860: Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES
4/5 Test #1860: Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES ..........................   Passed   10.44 sec
    Start 5108: Unit_hipDeviceGetPCIBusId_CheckPciBusIDWithLspci
5/5 Test #5108: Unit_hipDeviceGetPCIBusId_CheckPciBusIDWithLspci ..........................   Passed    0.87 sec

100% tests passed, 0 tests failed out of 5
```

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
