### PR TITLE
[rocprofiler-systems] Fix MPI_RECV calculation and remove duplicate code

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/comm_data.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/comm_data.cpp
@@ -374,7 +374,7 @@ comm_data::audit(const gotcha_data& _data, audit::incoming, const void*, int sen
 
     {
         cache_comm_data_events<mpi_send>(0, sendcount * _send_size);
-        cache_comm_data_events<mpi_recv>(0, recvcount * _send_size);
+        cache_comm_data_events<mpi_recv>(0, recvcount * _recv_size);
     }
 
     if(rocprofsys::get_use_timemory())
@@ -424,7 +424,7 @@ comm_data::audit(const gotcha_data& _data, audit::incoming, const void*, int sen
 
     {
         cache_comm_data_events<mpi_send>(0, sendcount * _send_size);
-        cache_comm_data_events<mpi_recv>(0, recvcount * _send_size);
+        cache_comm_data_events<mpi_recv>(0, recvcount * _recv_size);
     }
 
     if(rocprofsys::get_use_timemory())
@@ -524,9 +524,6 @@ comm_data::audit(const gotcha_data& _data, audit::incoming, const void*, size_t 
     {
         ROCPROFSYS_CI_THROW(true, "RCCL function not handled: %s", _data.tool_id.c_str());
     }
-
-    if(get_use_perfetto()) write_perfetto_counter_track<rccl_recv>(count * _size);
-    if(get_use_rocpd()) rocpd_process_cpu_usage_events<rccl_recv>(0, count * _size);
 
     if(rocprofsys::get_use_timemory())
     {


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Fix incorrect `mpi_recv` calculation. It was using `_send_size` instead of `_recv_size` for `mpi_recv`. 
Removed what appears to be a duplicated if statements within `comm_data::audit`
 - The removed if statements should be run only during `recv`

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFSYST-149
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
