### PR TITLE
Fix invalid use of hipEventElapsedTime

### DIFF
--- a/projects/hip-tests/catch/unit/device/hipGetProcAddressIpcApis.cc
+++ b/projects/hip-tests/catch/unit/device/hipGetProcAddressIpcApis.cc
@@ -221,10 +221,6 @@ TEST_CASE("Unit_hipGetProcAddress_IPC_Event") {
 
     REQUIRE(validateHostArray(hostMem, N, 11) == true);
 
-    float time = 0.0f;
-    HIP_CHECK(hipEventElapsedTime(&time, start, stop));
-    REQUIRE(time > 0.0f);
-
     HIP_CHECK(hipEventDestroy(stop));
     HIP_CHECK(hipStreamDestroy(stream));
     free(hostMem);


### PR DESCRIPTION
## Motivation

Unit_hipGetProcAddress_IPC_Event uses hipEventElapsed time with events that have timing disabled.

## Technical Details

hipEventElapsed returns h ipErrorInvalidHandle when either of start or stop event was created with hipEventDisableTiming which is the case in this test.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
[SWDEV-576422](https://ontrack-internal.amd.com/browse/SWDEV-576422)

## Test Plan

Run Unit_hipGetProcAddress_IPC_Event.

## Test Result

Test passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
