### PR TITLE
[7.2.1 backport] Add ROCPROFILER_DEVICE_LOCK_AT_START env var and PTL control

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 #include "lib/rocprofiler-sdk/counters/controller.hpp"
+#include "lib/common/environment.hpp"
 #include "lib/rocprofiler-sdk/agent.hpp"
 #include "lib/rocprofiler-sdk/buffer.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
@@ -107,6 +108,15 @@ CounterController::configure_agent_collection(rocprofiler_context_id_t          
     ctx.device_counter_collection->agent_data.back().agent_id = agent_id;
     ctx.device_counter_collection->agent_data.back().cb       = cb;
     ctx.device_counter_collection->agent_data.back().buffer   = buffer_id;
+
+    // OLD behavior: Lock the device at configuration time instead of context start
+    if(rocprofiler::common::get_env("ROCPROFILER_DEVICE_LOCK_AT_START", false))
+    {
+        if(counters::counter_collection_has_device_lock())
+        {
+            counters::counter_collection_device_lock(rocprofiler::agent::get_agent(agent_id), true);
+        }
+    }
 
     return ROCPROFILER_STATUS_SUCCESS;
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
@@ -109,13 +109,14 @@ CounterController::configure_agent_collection(rocprofiler_context_id_t          
     ctx.device_counter_collection->agent_data.back().cb       = cb;
     ctx.device_counter_collection->agent_data.back().buffer   = buffer_id;
 
-    // OLD behavior: Lock the device at configuration time instead of context start
+    // OLD behavior: Lock the device and disable PTL at configuration time instead of context start
     if(rocprofiler::common::get_env("ROCPROFILER_DEVICE_LOCK_AT_START", false))
     {
         if(counters::counter_collection_has_device_lock())
         {
             counters::counter_collection_device_lock(rocprofiler::agent::get_agent(agent_id), true);
         }
+        counters::counter_collection_ptl_disable(rocprofiler::agent::get_agent(agent_id));
     }
 
     return ROCPROFILER_STATUS_SUCCESS;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
@@ -457,7 +457,11 @@ start_agent_ctx(const context::context* ctx)
         }
 
         // Disable PTL (non-fatal if it fails)
-        counters::counter_collection_ptl_disable(agent->get_rocp_agent());
+        // Only disable here if using NEW behavior (at context start, not at configuration)
+        if(!use_device_lock_at_start())
+        {
+            counters::counter_collection_ptl_disable(agent->get_rocp_agent());
+        }
 
         callback_data.set_profile = false;
 
@@ -594,7 +598,11 @@ stop_agent_ctx(const context::context* ctx)
                                                           HSA_WAIT_STATE_ACTIVE);
 
         // Re-enable PTL (non-fatal if it fails)
-        counters::counter_collection_ptl_enable(agent->get_rocp_agent());
+        // Only re-enable here if using NEW behavior (at context start, not at configuration)
+        if(!use_device_lock_at_start())
+        {
+            counters::counter_collection_ptl_enable(agent->get_rocp_agent());
+        }
 
         // Unlock the device (non-fatal if it fails)
         // Only unlock here if using NEW behavior (lock at context start, not at configuration)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 #include "lib/rocprofiler-sdk/counters/device_counting.hpp"
+#include "lib/common/environment.hpp"
 #include "lib/common/logging.hpp"
 #include "lib/common/utility.hpp"
 #include "lib/rocprofiler-sdk/buffer.hpp"
@@ -94,6 +95,15 @@ submitPacket(hsa_queue_t* queue, const void* packet)
 
 namespace
 {
+// Returns true if device lock should be acquired at configuration time (OLD behavior).
+// Returns false if device lock should be acquired at context start time (NEW behavior, default).
+bool
+use_device_lock_at_start()
+{
+    static bool value = rocprofiler::common::get_env("ROCPROFILER_DEVICE_LOCK_AT_START", false);
+    return value;
+}
+
 uint16_t
 header_pkt(hsa_packet_type_t type)
 {
@@ -440,7 +450,8 @@ start_agent_ctx(const context::context* ctx)
         }
 
         // Lock the device for profiling (non-fatal if it fails)
-        if(counters::counter_collection_has_device_lock())
+        // Only lock here if using NEW behavior (lock at context start, not at configuration)
+        if(!use_device_lock_at_start() && counters::counter_collection_has_device_lock())
         {
             counters::counter_collection_device_lock(agent->get_rocp_agent(), true);
         }
@@ -586,7 +597,8 @@ stop_agent_ctx(const context::context* ctx)
         counters::counter_collection_ptl_enable(agent->get_rocp_agent());
 
         // Unlock the device (non-fatal if it fails)
-        if(counters::counter_collection_has_device_lock())
+        // Only unlock here if using NEW behavior (lock at context start, not at configuration)
+        if(!use_device_lock_at_start() && counters::counter_collection_has_device_lock())
         {
             counters::counter_collection_device_unlock(agent->get_rocp_agent());
         }


### PR DESCRIPTION
[SWDEV-575950](https://ontrack-internal.amd.com/browse/SWDEV-575950) - One of the fixes for it
## Summary

This PR backports two commits to the 7.2.1 release that add the `ROCPROFILER_DEVICE_LOCK_AT_START` environment variable for controlling device lock and PTL  timing behavior:

- **ROCPROFILER_DEVICE_LOCK_AT_START=true**: OLD behavior (device lock and PTL disabled at configuration time)
- **ROCPROFILER_DEVICE_LOCK_AT_START=false**: NEW behavior (device lock and PTL disabled at context start, default)

## Cherry-picked commits

1. `b7f4d169d0` - [rocprofiler-sdk] Add ROCPROFILER_DEVICE_LOCK_AT_START env var
2. `77334cdc00` - [rocprofiler-sdk] Add PTL control to ROCPROFILER_DEVICE_LOCK_AT_START

## Files changed

- `source/lib/rocprofiler-sdk/counters/controller.cpp`
- `source/lib/rocprofiler-sdk/counters/device_counting.cpp`

## Test plan

- [ ] Verify existing counter collection tests pass
- [ ] Test with `ROCPROFILER_DEVICE_LOCK_AT_START=true` to confirm old behavior
- [ ] Test with `ROCPROFILER_DEVICE_LOCK_AT_START=false` (or unset) to confirm new default behavior
- [ ] Run CI pipeline to validate no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)