### PR TITLE
attach: fix ptrace signal crash

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/CMakeLists.txt
@@ -33,8 +33,8 @@ endforeach()
 
 target_sources(
     rocprofiler-sdk-rocattach-shared-library
-    PRIVATE rocattach.cpp auxv.cpp ptrace_runner.cpp ptrace_session.cpp symbol_lookup.cpp)
-
+    PRIVATE rocattach.cpp auxv.cpp ptrace_runner.cpp ptrace_session.cpp symbol_lookup.cpp
+            common/ptrace.cpp)
 target_include_directories(
     rocprofiler-sdk-rocattach-shared-library
     INTERFACE $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/source/include>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/CMakeLists.txt
@@ -33,8 +33,9 @@ endforeach()
 
 target_sources(
     rocprofiler-sdk-rocattach-shared-library
-    PRIVATE rocattach.cpp auxv.cpp ptrace_runner.cpp ptrace_session.cpp symbol_lookup.cpp
-            common/ptrace.cpp)
+    PRIVATE rocattach.cpp auxv.cpp ptrace_runner.cpp ptrace_session.cpp symbol_lookup.cpp)
+add_subdirectory(common)
+
 target_include_directories(
     rocprofiler-sdk-rocattach-shared-library
     INTERFACE $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/source/include>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/CMakeLists.txt
@@ -31,8 +31,10 @@ foreach(_NAMESPACE rocprofiler-sdk rocprofiler-sdk-rocattach)
     endforeach()
 endforeach()
 
-target_sources(rocprofiler-sdk-rocattach-shared-library
-               PRIVATE rocattach.cpp auxv.cpp ptrace_session.cpp symbol_lookup.cpp)
+target_sources(
+    rocprofiler-sdk-rocattach-shared-library
+    PRIVATE rocattach.cpp auxv.cpp ptrace_runner.cpp ptrace_session.cpp symbol_lookup.cpp)
+
 target_include_directories(
     rocprofiler-sdk-rocattach-shared-library
     INTERFACE $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/source/include>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/common/CMakeLists.txt
@@ -1,0 +1,23 @@
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+target_sources(rocprofiler-sdk-rocattach-shared-library PRIVATE ptrace.cpp)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/common/ptrace.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/common/ptrace.cpp
@@ -1,0 +1,62 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "ptrace.hpp"
+
+#include <errno.h>
+
+namespace rocprofiler
+{
+namespace rocattach
+{
+// Very limited list of operations for logging only.
+const char*
+ptrace_op_name(__ptrace_request op)
+{
+    switch(op)
+    {
+        case PTRACE_SEIZE: return "PTRACE_SEIZE";
+        case PTRACE_DETACH: return "PTRACE_DETACH";
+        case PTRACE_POKEDATA: return "PTRACE_POKEDATA";
+        case PTRACE_PEEKDATA: return "PTRACE_PEEKDATA";
+        case PTRACE_INTERRUPT: return "PTRACE_INTERRUPT";
+        case PTRACE_GETREGS: return "PTRACE_GETREGS";
+        case PTRACE_SETREGS: return "PTRACE_SETREGS";
+        case PTRACE_CONT: return "PTRACE_CONT";
+        default: return "unknown op";
+    }
+}
+
+// Translates ptrace errno into rocattach status errors
+rocattach_status_t
+convert_ptrace_error(int error)
+{
+    switch(error)
+    {
+        case EPERM: return ROCATTACH_STATUS_ERROR_PTRACE_OPERATION_NOT_PERMITTED;
+        case ESRCH: return ROCATTACH_STATUS_ERROR_PTRACE_PROCESS_NOT_FOUND;
+        default: return ROCATTACH_STATUS_ERROR_PTRACE_ERROR;
+    }
+}
+
+}  // namespace rocattach
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/common/ptrace.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/common/ptrace.hpp
@@ -1,0 +1,42 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <rocprofiler-sdk-rocattach/types.h>
+
+#include <sys/ptrace.h>
+
+namespace rocprofiler
+{
+namespace rocattach
+{
+// Returns enum name of given op
+const char*
+ptrace_op_name(__ptrace_request op);
+
+// Translates ptrace errno into rocattach status errors
+rocattach_status_t
+convert_ptrace_error(int error);
+
+}  // namespace rocattach
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/common/wait_for_atomic.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/common/wait_for_atomic.hpp
@@ -24,52 +24,59 @@
 
 #include <atomic>
 #include <chrono>
+#include <functional>
 #include <thread>
+#include <type_traits>
 
 namespace rocprofiler
 {
 namespace rocattach
 {
-template <typename T>
+// Blocks until predicate(flag) == true or timeout_ms milliseconds have elapsed.
+// Returns true if predicate(flag) was true
+// Returns false if timeout occurred
+template <typename Tp, typename PredicateT>
 bool
-wait_for(std::atomic<T>& flag, T condition, size_t timeout_ms, bool equal)
+wait_for(std::atomic<Tp>& flag, size_t timeout_ms, PredicateT&& predicate)
 {
-    auto cond_check = [&]() {
-        if(equal) return flag.load() == condition;
-        return flag.load() != condition;
-    };
+    static_assert(std::is_invocable<PredicateT, std::atomic<Tp>&>::value, "Invalid predicate");
+    using predicate_return_type = typename std::invoke_result<PredicateT, std::atomic<Tp>&>::type;
+    static_assert(std::is_same<predicate_return_type, bool>::value,
+                  "Predicate must return boolean");
+
     auto start_time       = std::chrono::steady_clock::now();
     auto timeout_duration = std::chrono::milliseconds(timeout_ms);
     auto end_time         = start_time + timeout_duration;
     while(std::chrono::steady_clock::now() < end_time)
     {
-        if(cond_check())
+        if(std::invoke(std::forward<PredicateT>(predicate), std::forward<std::atomic<Tp>&>(flag)))
         {
             return true;
         }
         std::this_thread::yield();
     }
     // Last chance check in case we were scheduled after timeout
-    return cond_check();
+    return std::invoke(std::forward<PredicateT>(predicate), std::forward<std::atomic<Tp>&>(flag));
 }
-// Blocks until flag is NOT equal to condition or timeout_ms milliseconds have elapsed.
+// Blocks until flag is NOT equal to value or timeout_ms milliseconds have elapsed.
 // Returns true if the flag is not equal
 // Returns false if timeout occurred
 template <typename T>
 bool
-wait_for_ne(std::atomic<T>& flag, T condition, size_t timeout_ms)
+wait_for_ne(std::atomic<T>& flag, T value, size_t timeout_ms)
 {
-    return wait_for(flag, condition, timeout_ms, false);
+    auto predicate = [value](std::atomic<T>& a) { return a.load() != value; };
+    return wait_for(flag, timeout_ms, predicate);
 }
-// Blocks until flag is equal to condition or timeout_ms milliseconds have elapsed.
+// Blocks until flag is equal to value or timeout_ms milliseconds have elapsed.
 // Returns true if the flag is equal
 // Returns false if timeout occurred
 template <typename T>
 bool
-wait_for_eq(std::atomic<T>& flag, T condition, size_t timeout_ms)
+wait_for_eq(std::atomic<T>& flag, T value, size_t timeout_ms)
 {
-    return wait_for(flag, condition, timeout_ms, true);
+    auto predicate = [value](std::atomic<T>& a) { return a.load() == value; };
+    return wait_for(flag, timeout_ms, predicate);
 }
-
 }  // namespace rocattach
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/common/wait_for_atomic.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/common/wait_for_atomic.hpp
@@ -30,6 +30,28 @@ namespace rocprofiler
 {
 namespace rocattach
 {
+template <typename T>
+bool
+wait_for(std::atomic<T>& flag, T condition, size_t timeout_ms, bool equal)
+{
+    auto cond_check = [&]() {
+        if(equal) return flag.load() == condition;
+        return flag.load() != condition;
+    };
+    auto start_time       = std::chrono::steady_clock::now();
+    auto timeout_duration = std::chrono::milliseconds(timeout_ms);
+    auto end_time         = start_time + timeout_duration;
+    while(std::chrono::steady_clock::now() < end_time)
+    {
+        if(cond_check())
+        {
+            return true;
+        }
+        std::this_thread::yield();
+    }
+    // Last chance check in case we were scheduled after timeout
+    return cond_check();
+}
 // Blocks until flag is NOT equal to condition or timeout_ms milliseconds have elapsed.
 // Returns true if the flag is not equal
 // Returns false if timeout occurred
@@ -37,22 +59,8 @@ template <typename T>
 bool
 wait_for_ne(std::atomic<T>& flag, T condition, size_t timeout_ms)
 {
-    auto start_time       = std::chrono::steady_clock::now();
-    auto timeout_duration = std::chrono::milliseconds(timeout_ms);
-    auto end_time         = start_time + timeout_duration;
-
-    while(std::chrono::steady_clock::now() < end_time)
-    {
-        if(flag.load() != condition)
-        {
-            return true;
-        }
-        std::this_thread::yield();
-    }
-    // Last chance check in case we were scheduled after timeout
-    return flag.load() != condition;
+    return wait_for(flag, condition, timeout_ms, false);
 }
-
 // Blocks until flag is equal to condition or timeout_ms milliseconds have elapsed.
 // Returns true if the flag is equal
 // Returns false if timeout occurred
@@ -60,20 +68,7 @@ template <typename T>
 bool
 wait_for_eq(std::atomic<T>& flag, T condition, size_t timeout_ms)
 {
-    auto start_time       = std::chrono::steady_clock::now();
-    auto timeout_duration = std::chrono::milliseconds(timeout_ms);
-    auto end_time         = start_time + timeout_duration;
-
-    while(std::chrono::steady_clock::now() < end_time)
-    {
-        if(flag.load() == condition)
-        {
-            return true;
-        }
-        std::this_thread::yield();
-    }
-    // Last chance check in case we were scheduled after timeout
-    return flag.load() == condition;
+    return wait_for(flag, condition, timeout_ms, true);
 }
 
 }  // namespace rocattach

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/common/wait_for_atomic.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/common/wait_for_atomic.hpp
@@ -1,0 +1,80 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+namespace rocprofiler
+{
+namespace rocattach
+{
+// Blocks until flag is NOT equal to condition or timeout_ms milliseconds have elapsed.
+// Returns true if the flag is not equal
+// Returns false if timeout occurred
+template <typename T>
+bool
+wait_for_ne(std::atomic<T>& flag, T condition, size_t timeout_ms)
+{
+    auto start_time       = std::chrono::steady_clock::now();
+    auto timeout_duration = std::chrono::milliseconds(timeout_ms);
+    auto end_time         = start_time + timeout_duration;
+
+    while(std::chrono::steady_clock::now() < end_time)
+    {
+        if(flag.load() != condition)
+        {
+            return true;
+        }
+        std::this_thread::yield();
+    }
+    // Last chance check in case we were scheduled after timeout
+    return flag.load() != condition;
+}
+
+// Blocks until flag is equal to condition or timeout_ms milliseconds have elapsed.
+// Returns true if the flag is equal
+// Returns false if timeout occurred
+template <typename T>
+bool
+wait_for_eq(std::atomic<T>& flag, T condition, size_t timeout_ms)
+{
+    auto start_time       = std::chrono::steady_clock::now();
+    auto timeout_duration = std::chrono::milliseconds(timeout_ms);
+    auto end_time         = start_time + timeout_duration;
+
+    while(std::chrono::steady_clock::now() < end_time)
+    {
+        if(flag.load() == condition)
+        {
+            return true;
+        }
+        std::this_thread::yield();
+    }
+    // Last chance check in case we were scheduled after timeout
+    return flag.load() == condition;
+}
+
+}  // namespace rocattach
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_runner.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_runner.cpp
@@ -26,6 +26,7 @@
 
 #include "lib/common/logging.hpp"
 #include "lib/common/static_object.hpp"
+#include "lib/common/synchronized.hpp"
 
 #include <memory>
 
@@ -74,12 +75,8 @@ ptrace_runner(pid_t                       _pid,
 
 class PTraceRunner
 {
-    struct ptrace_runner_t
+    struct ptrace_runner_data_t
     {
-        // Mutex acquired by run() and held for the entire single operation
-        // Protects all variables in this struct
-        std::mutex mutex = {};
-
         // Shared data for the ptrace operation
         std::atomic<ptrace_data_t> data = {};
 
@@ -96,21 +93,25 @@ class PTraceRunner
         // Runner thread
         std::thread thread = {};
     };
-
-    std::mutex                                                m_runners_mutex;
-    std::unordered_map<int, std::shared_ptr<ptrace_runner_t>> m_runners;
+    using ptrace_runner_t = common::Synchronized<ptrace_runner_data_t>;
+    using runner_map_t =
+        common::Synchronized<std::unordered_map<int, std::shared_ptr<ptrace_runner_t>>>;
+    runner_map_t m_runners;
 
 public:
-    PTraceRunner(){};
+    PTraceRunner() = default;
     ~PTraceRunner()
     {
-        for(auto& runner : m_runners)
-        {
-            runner.second->done.store(true);
-            runner.second->thread.join();
-            std::lock_guard map_lg(m_runners_mutex);
-            m_runners.erase(pid);
-        }
+        m_runners.wlock([&](auto& all_runners) {
+            for(auto& runner : all_runners)
+            {
+                runner.second->wlock([&](auto& data) {
+                    data.done.store(true);
+                    data.thread.join();
+                });
+            }
+            all_runners.clear();
+        });
     }
     rocattach_status_t run(pid_t              pid,
                            __ptrace_request   op,
@@ -146,98 +147,112 @@ public:
         // A shared_ptr is used so this thread can still safely wait on the mutex even if another
         // thread ends the worker thread
         std::shared_ptr<ptrace_runner_t> runner;
-        {
-            std::lock_guard map_lg(m_runners_mutex);
-            if(m_runners.count(pid) > 0)
+        m_runners.wlock([&](auto& runners) {
+            if(runners.count(pid) > 0)
             {
                 // if thread already exists, re-use it
-                runner = m_runners.at(pid);
+                runner = runners.at(pid);
             }
             else if(op == PTRACE_SEIZE)
             {
                 // if thread doesn't exist and this is a SEIZE, create it
-                runner         = std::make_shared<ptrace_runner_t>();
-                runner->thread = std::thread(ptrace_runner,
-                                             pid,
-                                             std::ref(runner->data),
-                                             std::ref(runner->running),
-                                             std::ref(runner->done));
-                m_runners.insert({pid, runner});
+                runner = std::make_shared<ptrace_runner_t>();
+                runner->wlock([&](auto& runner_data) {
+                    runner_data.thread = std::thread(ptrace_runner,
+                                                     pid,
+                                                     std::ref(runner_data.data),
+                                                     std::ref(runner_data.running),
+                                                     std::ref(runner_data.done));
+                });
+
+                runners.insert({pid, runner});
             }
             else
             {
                 // if thread doesn't exist and this isn't a SEIZE, state is incorrect
                 ROCP_ERROR
                     << "[rocprofiler-sdk-rocattach] PTraceRunner was called in an invalid state";
-                return ROCATTACH_STATUS_ERROR;
             }
-        }
+        });
 
-        std::lock_guard thread_lg(runner->mutex);
-
-        // If another thread called detach, the runner thread has been stopped and the
-        // ptrace_runner_t has been removed from PTraceRunner's maps. While the ptrace_runner_t is
-        // still valid in our shared_ptr copy, we should give up and release our reference
-        if(runner->done.load())
+        if(runner == nullptr)
         {
-            ROCP_ERROR << "[rocprofiler-sdk-rocattach] ptrace was detached while another operation "
-                          "was in-flight";
             return ROCATTACH_STATUS_ERROR;
         }
 
-        // Set up the next operation
-        {
-            ptrace_data_t ptrace_data = {
-                .pid          = pid,
-                .op           = op,
-                .addr         = addr,
-                .data         = data,
-                .retval       = 0,
-                .ptrace_errno = 0,
-            };
-            runner->data.store(ptrace_data);
-        }
+        ptrace_data_t ptrace_data = {
+            .pid          = pid,
+            .op           = op,
+            .addr         = addr,
+            .data         = data,
+            .retval       = 0,
+            .ptrace_errno = 0,
+        };
 
-        // Set running to true, requesting a ptrace operation be performed in ptrace_runner() with
-        // the parameters in data
-        runner->running.store(true);
+        bool runner_error = false;
+        runner->wlock([&](auto& runner_data) {
+            // If another thread called detach, the runner thread has been stopped and the
+            // ptrace_runner_t has been removed from PTraceRunner's maps. While the ptrace_runner_t
+            // is still valid in our shared_ptr copy, we should give up and release our reference
+            if(runner_data.done.load())
+            {
+                ROCP_ERROR
+                    << "[rocprofiler-sdk-rocattach] ptrace was detached while another operation "
+                       "was in-flight";
+                runner_error = true;
+                return;
+            }
 
-        // Wait for running to be set to false, which indicates ptrace_runner() has finished the
-        // requested ptrace operation.
-        if(!wait_for_eq(runner->running, false, timeout_ms))
+            // Set up the next operation
+            runner_data.data.store(ptrace_data);
+
+            // Set running to true, requesting a ptrace operation be performed in ptrace_runner()
+            // with the parameters in data
+            runner_data.running.store(true);
+
+            // Wait for running to be set to false, which indicates ptrace_runner() has finished the
+            // requested ptrace operation.
+            if(!wait_for_eq(runner_data.running, false, timeout_ms))
+            {
+                ROCP_ERROR << "[rocprofiler-sdk-rocattach] Timeout during ptrace(" << op << ", "
+                           << pid << ", " << addr << ", " << data << ") duration: " << timeout_ms
+                           << "ms";
+                runner_error = true;
+                return;
+            }
+
+            ptrace_data = runner_data.data.load();
+
+            // If detaching, join the thread and remove its references
+            if(op == PTRACE_DETACH)
+            {
+                runner_data.done.store(true);
+                runner_data.thread.join();
+                m_runners.wlock([&](auto& runners) { runners.erase(pid); });
+            }
+        });
+
+        if(runner_error)
         {
-            ROCP_ERROR << "[rocprofiler-sdk-rocattach] Timeout during ptrace(" << op << ", " << pid
-                       << ", " << addr << ", " << data << ") duration: " << timeout_ms << "ms";
             return ROCATTACH_STATUS_ERROR;
         }
-
-        auto result = runner->data.load();
-
         if(ptrace_retval)
         {
-            *ptrace_retval = result.retval;
+            *ptrace_retval = ptrace_data.retval;
         }
         if(ptrace_errno)
         {
-            *ptrace_errno = result.ptrace_errno;
+            *ptrace_errno = ptrace_data.ptrace_errno;
         }
-        if(result.ptrace_errno != 0)
+        if(ptrace_data.ptrace_errno != 0)
         {
             // log an error if it occurs, but the ptrace call was a success, so still return success
             ROCP_ERROR << "[rocprofiler-sdk-rocattach] ptrace call failed. errno: "
-                       << result.ptrace_errno << " - " << strerror(result.ptrace_errno)
+                       << ptrace_data.ptrace_errno << " - " << strerror(ptrace_data.ptrace_errno)
                        << ". params(" << ptrace_op_name(op) << "(" << op << "), " << pid << ", "
                        << addr << ", " << data << ")";
         }
 
-        // If detaching, join the thread and remove its references
-        if(op == PTRACE_DETACH)
-        {
-            runner->done.store(true);
-            runner->thread.join();
-            std::lock_guard map_lg(m_runners_mutex);
-            m_runners.erase(pid);
-        }
         return ROCATTACH_STATUS_SUCCESS;
     }
 };

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_runner.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_runner.cpp
@@ -25,106 +25,31 @@
 #include "common/wait_for_atomic.hpp"
 
 #include "lib/common/logging.hpp"
+#include "lib/common/static_object.hpp"
+
+#include <memory>
 
 namespace rocprofiler
 {
 namespace rocattach
 {
 namespace
-{}  // namespace
-
-PTraceRunner::PTraceRunner(pid_t _pid)
-: m_pid(_pid)
-, m_ptrace_data{}
-, m_running(false)
-, m_thread_done(false)
-, m_ptrace_thread(ptrace_runner,
-                  _pid,
-                  std::ref(m_ptrace_data),
-                  std::ref(m_running),
-                  std::ref(m_thread_done))
-{}
-
-PTraceRunner::~PTraceRunner()
 {
-    m_thread_done = true;
-    m_ptrace_thread.join();
-}
-
-rocattach_status_t
-PTraceRunner::ptrace_run(__ptrace_request   op,
-                         ptrace_parameter_t _addr,
-                         ptrace_parameter_t _data,
-                         uint64_t*          ptrace_retval,
-                         int*               ptrace_errno,
-                         size_t             timeout_ms)
+struct ptrace_data_t
 {
-    std::lock_guard<std::mutex> lg(m_ptrace_run_mutex);
-
-    // This does some work with variants to allow functions to send ptrace operations as if they
-    // were addressing the original ptrace function, that is without strict typing. This is only
-    // slightly safer than using a union, but it is no worse than ptrace's type punning. For our
-    // sake, internally, we address these as uint64_t blobs to make for easier logging and typing on
-    // our end.
-    auto convert_ptrace_parameter = [](ptrace_parameter_t param) {
-        if(std::holds_alternative<uint64_t>(param))
-        {
-            return std::get<uint64_t>(param);
-        }
-        else
-        {
-            return reinterpret_cast<uint64_t>(std::get<void*>(param));
-        }
-    };
-    uint64_t addr = convert_ptrace_parameter(_addr);
-    uint64_t data = convert_ptrace_parameter(_data);
-
-    ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace call params(" << ptrace_op_name(op) << "("
-               << op << "), " << m_pid << ", " << addr << ", " << data << ")";
-
-    ptrace_data_t ptrace_data{};
-    ptrace_data.op   = op;
-    ptrace_data.addr = addr;
-    ptrace_data.data = data;
-    // Store parameters for the ptrace operation in m_ptrace_data for retrieval by ptrace_runner()
-    m_ptrace_data.store(ptrace_data);
-
-    // Set m_running to true, requesting a ptrace operation be performed in ptrace_runner() with the
-    // parameters in m_ptrace_data
-    m_running.store(true);
-    // Wait for m_running to be set to false, which indicates ptrace_runner() has finished the
-    // requested ptrace operation.
-    if(!wait_for_eq(m_running, false, timeout_ms))
-    {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Timeout during ptrace(" << op << ", " << m_pid
-                   << ", " << addr << ", " << data << ") duration: " << timeout_ms << "ms";
-        return ROCATTACH_STATUS_ERROR;
-    }
-    auto result = m_ptrace_data.load();
-    if(ptrace_retval)
-    {
-        *ptrace_retval = result.retval;
-    }
-    if(ptrace_errno)
-    {
-        *ptrace_errno = result.ptrace_errno;
-    }
-    if(result.ptrace_errno != 0)
-    {
-        // log an error if it occurs, but the ptrace call was a success, so still return success
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] ptrace call failed. errno: "
-                   << result.ptrace_errno << " - " << strerror(result.ptrace_errno) << ". params("
-                   << ptrace_op_name(op) << "(" << op << "), " << m_pid << ", " << addr << ", "
-                   << data << ")";
-    }
-    return ROCATTACH_STATUS_SUCCESS;
-}
+    pid_t            pid;
+    __ptrace_request op;
+    uint64_t         addr;
+    uint64_t         data;
+    uint64_t         retval;
+    int              ptrace_errno;
+};
 
 void
-PTraceRunner::ptrace_runner(pid_t                       _pid,
-                            std::atomic<ptrace_data_t>& ptrace_data,
-                            std::atomic<bool>&          running,
-                            std::atomic<bool>&          thread_done)
+ptrace_runner(pid_t                       _pid,
+              std::atomic<ptrace_data_t>& ptrace_data,
+              std::atomic<bool>&          running,
+              std::atomic<bool>&          thread_done)
 {
     while(thread_done.load() == false)
     {
@@ -145,6 +70,192 @@ PTraceRunner::ptrace_runner(pid_t                       _pid,
         }
         std::this_thread::yield();
     }
+}
+
+class PTraceRunner
+{
+    struct ptrace_runner_t
+    {
+        // Mutex acquired by run() and held for the entire single operation
+        // Protects all variables in this struct
+        std::mutex mutex = {};
+
+        // Shared data for the ptrace operation
+        std::atomic<ptrace_data_t> data = {};
+
+        // Shared flag, indicates the runner thread should operate on data
+        // Set by run when data is ready
+        // Cleared by ptrace_runner when operation is complete
+        std::atomic<bool> running = {};
+
+        // Shared flag, indicates the runner thread should end
+        // Set by run after a PTRACE_DETACH operation is completed
+        // Set by PTraceRunner's destructor (called on program exit)
+        std::atomic<bool> done = {};
+
+        // Runner thread
+        std::thread thread = {};
+    };
+
+    std::mutex                                                m_runners_mutex;
+    std::unordered_map<int, std::shared_ptr<ptrace_runner_t>> m_runners;
+
+public:
+    PTraceRunner(){};
+    ~PTraceRunner()
+    {
+        for(auto& runner : m_runners)
+        {
+            runner.second->done.store(true);
+            runner.second->thread.join();
+            std::lock_guard map_lg(m_runners_mutex);
+            m_runners.erase(pid);
+        }
+    }
+    rocattach_status_t run(pid_t              pid,
+                           __ptrace_request   op,
+                           ptrace_parameter_t _addr,
+                           ptrace_parameter_t _data,
+                           uint64_t*          ptrace_retval,
+                           int*               ptrace_errno,
+                           size_t             timeout_ms)
+    {
+        // This does some work with variants to allow functions to send ptrace operations as if they
+        // were addressing the original ptrace function, that is without strict typing. This is only
+        // slightly safer than using a union, but it is no worse than ptrace's type punning. For our
+        // sake, internally, we address these as uint64_t blobs to make for easier logging and
+        // typing on our end.
+        auto convert_ptrace_parameter = [](ptrace_parameter_t param) {
+            if(std::holds_alternative<uint64_t>(param))
+            {
+                return std::get<uint64_t>(param);
+            }
+            else
+            {
+                return reinterpret_cast<uint64_t>(std::get<void*>(param));
+            }
+        };
+        uint64_t addr = convert_ptrace_parameter(_addr);
+        uint64_t data = convert_ptrace_parameter(_data);
+
+        ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace call params(" << ptrace_op_name(op) << "("
+                   << op << "), " << pid << ", " << addr << ", " << data << ")";
+
+        // Get the thread data for the target pid
+        // Create it if this is the first operation
+        // A shared_ptr is used so this thread can still safely wait on the mutex even if another
+        // thread ends the worker thread
+        std::shared_ptr<ptrace_runner_t> runner;
+        {
+            std::lock_guard map_lg(m_runners_mutex);
+            if(m_runners.count(pid) > 0)
+            {
+                // if thread already exists, re-use it
+                runner = m_runners.at(pid);
+            }
+            else if(op == PTRACE_SEIZE)
+            {
+                // if thread doesn't exist and this is a SEIZE, create it
+                runner         = std::make_shared<ptrace_runner_t>();
+                runner->thread = std::thread(ptrace_runner,
+                                             pid,
+                                             std::ref(runner->data),
+                                             std::ref(runner->running),
+                                             std::ref(runner->done));
+                m_runners.insert({pid, runner});
+            }
+            else
+            {
+                // if thread doesn't exist and this isn't a SEIZE, state is incorrect
+                ROCP_ERROR
+                    << "[rocprofiler-sdk-rocattach] PTraceRunner was called in an invalid state";
+                return ROCATTACH_STATUS_ERROR;
+            }
+        }
+
+        std::lock_guard thread_lg(runner->mutex);
+
+        // If another thread called detach, the runner thread has been stopped and the
+        // ptrace_runner_t has been removed from PTraceRunner's maps. While the ptrace_runner_t is
+        // still valid in our shared_ptr copy, we should give up and release our reference
+        if(runner->done.load())
+        {
+            ROCP_ERROR << "[rocprofiler-sdk-rocattach] ptrace was detached while another operation "
+                          "was in-flight";
+            return ROCATTACH_STATUS_ERROR;
+        }
+
+        // Set up the next operation
+        {
+            ptrace_data_t ptrace_data = {
+                .pid          = pid,
+                .op           = op,
+                .addr         = addr,
+                .data         = data,
+                .retval       = 0,
+                .ptrace_errno = 0,
+            };
+            runner->data.store(ptrace_data);
+        }
+
+        // Set running to true, requesting a ptrace operation be performed in ptrace_runner() with
+        // the parameters in data
+        runner->running.store(true);
+
+        // Wait for running to be set to false, which indicates ptrace_runner() has finished the
+        // requested ptrace operation.
+        if(!wait_for_eq(runner->running, false, timeout_ms))
+        {
+            ROCP_ERROR << "[rocprofiler-sdk-rocattach] Timeout during ptrace(" << op << ", " << pid
+                       << ", " << addr << ", " << data << ") duration: " << timeout_ms << "ms";
+            return ROCATTACH_STATUS_ERROR;
+        }
+
+        auto result = runner->data.load();
+
+        if(ptrace_retval)
+        {
+            *ptrace_retval = result.retval;
+        }
+        if(ptrace_errno)
+        {
+            *ptrace_errno = result.ptrace_errno;
+        }
+        if(result.ptrace_errno != 0)
+        {
+            // log an error if it occurs, but the ptrace call was a success, so still return success
+            ROCP_ERROR << "[rocprofiler-sdk-rocattach] ptrace call failed. errno: "
+                       << result.ptrace_errno << " - " << strerror(result.ptrace_errno)
+                       << ". params(" << ptrace_op_name(op) << "(" << op << "), " << pid << ", "
+                       << addr << ", " << data << ")";
+        }
+
+        // If detaching, join the thread and remove its references
+        if(op == PTRACE_DETACH)
+        {
+            runner->done.store(true);
+            runner->thread.join();
+            std::lock_guard map_lg(m_runners_mutex);
+            m_runners.erase(pid);
+        }
+        return ROCATTACH_STATUS_SUCCESS;
+    }
+};
+
+}  // namespace
+
+rocattach_status_t
+ptrace_run(pid_t              pid,
+           __ptrace_request   op,
+           ptrace_parameter_t addr,
+           ptrace_parameter_t data,
+           uint64_t*          ptrace_retval,
+           int*               ptrace_errno,
+           size_t             timeout)
+{
+    static auto*& ptrace_runner = common::static_object<PTraceRunner>::construct();
+
+    return ptrace_runner->run(pid, op, addr, data, ptrace_retval, ptrace_errno, timeout);
 }
 
 }  // namespace rocattach

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_runner.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_runner.cpp
@@ -1,0 +1,128 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "ptrace_runner.hpp"
+
+#include "lib/common/logging.hpp"
+
+namespace rocprofiler
+{
+namespace rocattach
+{
+namespace
+{
+template <typename T>
+bool
+wait_for_ne(std::atomic<T>& flag, T condition, size_t timeout_ms)
+{
+    auto start_time       = std::chrono::steady_clock::now();
+    auto timeout_duration = std::chrono::milliseconds(timeout_ms);
+    auto end_time         = start_time + timeout_duration;
+
+    while(std::chrono::steady_clock::now() < end_time)
+    {
+        if(flag.load() != condition)
+        {
+            return true;
+        }
+        std::this_thread::yield();
+    }
+    // Last chance check in case we were scheduled after timeout
+    return flag.load() != condition;
+}
+}  // namespace
+
+PTraceRunner::PTraceRunner(pid_t _pid)
+: m_pid(_pid)
+, m_ptrace_data{}
+, m_running(false)
+, m_thread_done(false)
+, m_ptrace_thread(ptrace_runner,
+                  _pid,
+                  std::ref(m_ptrace_data),
+                  std::ref(m_running),
+                  std::ref(m_thread_done))
+{}
+
+PTraceRunner::~PTraceRunner()
+{
+    m_thread_done = true;
+    m_ptrace_thread.join();
+}
+
+rocattach_status_t
+PTraceRunner::ptrace_run(__ptrace_request op,
+                         void*            addr,
+                         void*            data,
+                         uint64_t*        ptrace_retval,
+                         int*             ptrace_errno,
+                         size_t           timeout_ms)
+{
+    std::lock_guard<std::mutex> lg(m_ptrace_run_mutex);
+    ptrace_data_t               ptrace_data{};
+    ptrace_data.op   = op;
+    ptrace_data.addr = addr;
+    ptrace_data.data = data;
+    m_ptrace_data.store(ptrace_data);
+    m_running.store(true);
+    if(!wait_for_ne(m_running, true, timeout_ms))
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Timeout during ptrace(" << op << ", " << m_pid
+                   << ", " << addr << ", " << data << ") duration: " << timeout_ms << "ms";
+        return ROCATTACH_STATUS_ERROR;
+    }
+
+    if(ptrace_retval)
+    {
+        *ptrace_retval = m_ptrace_data.load().retval;
+    }
+    if(ptrace_errno)
+    {
+        *ptrace_errno = m_ptrace_data.load().ptrace_errno;
+    }
+    return ROCATTACH_STATUS_SUCCESS;
+}
+
+void
+PTraceRunner::ptrace_runner(pid_t                       _pid,
+                            std::atomic<ptrace_data_t>& ptrace_data,
+                            std::atomic<bool>&          running,
+                            std::atomic<bool>&          thread_done)
+{
+    while(thread_done.load() == false)
+    {
+        if(running.load() == true)
+        {
+            errno             = 0;
+            auto _ptrace_data = ptrace_data.load();
+            auto retval       = ptrace(_ptrace_data.op, _pid, _ptrace_data.addr, _ptrace_data.data);
+            _ptrace_data.retval       = retval;
+            _ptrace_data.ptrace_errno = errno;
+            ptrace_data.store(_ptrace_data);
+            running.store(false);
+        }
+        std::this_thread::yield();
+    }
+}
+
+}  // namespace rocattach
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_runner.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_runner.cpp
@@ -21,6 +21,8 @@
 // SOFTWARE.
 
 #include "ptrace_runner.hpp"
+#include "common/ptrace.hpp"
+#include "common/wait_for_atomic.hpp"
 
 #include "lib/common/logging.hpp"
 
@@ -29,27 +31,7 @@ namespace rocprofiler
 namespace rocattach
 {
 namespace
-{
-template <typename T>
-bool
-wait_for_ne(std::atomic<T>& flag, T condition, size_t timeout_ms)
-{
-    auto start_time       = std::chrono::steady_clock::now();
-    auto timeout_duration = std::chrono::milliseconds(timeout_ms);
-    auto end_time         = start_time + timeout_duration;
-
-    while(std::chrono::steady_clock::now() < end_time)
-    {
-        if(flag.load() != condition)
-        {
-            return true;
-        }
-        std::this_thread::yield();
-    }
-    // Last chance check in case we were scheduled after timeout
-    return flag.load() != condition;
-}
-}  // namespace
+{}  // namespace
 
 PTraceRunner::PTraceRunner(pid_t _pid)
 : m_pid(_pid)
@@ -70,34 +52,70 @@ PTraceRunner::~PTraceRunner()
 }
 
 rocattach_status_t
-PTraceRunner::ptrace_run(__ptrace_request op,
-                         void*            addr,
-                         void*            data,
-                         uint64_t*        ptrace_retval,
-                         int*             ptrace_errno,
-                         size_t           timeout_ms)
+PTraceRunner::ptrace_run(__ptrace_request   op,
+                         ptrace_parameter_t _addr,
+                         ptrace_parameter_t _data,
+                         uint64_t*          ptrace_retval,
+                         int*               ptrace_errno,
+                         size_t             timeout_ms)
 {
     std::lock_guard<std::mutex> lg(m_ptrace_run_mutex);
-    ptrace_data_t               ptrace_data{};
+
+    // This does some work with variants to allow functions to send ptrace operations as if they
+    // were addressing the original ptrace function, that is without strict typing. This is only
+    // slightly safer than using a union, but it is no worse than ptrace's type punning. For our
+    // sake, internally, we address these as uint64_t blobs to make for easier logging and typing on
+    // our end.
+    auto convert_ptrace_parameter = [](ptrace_parameter_t param) {
+        if(std::holds_alternative<uint64_t>(param))
+        {
+            return std::get<uint64_t>(param);
+        }
+        else
+        {
+            return reinterpret_cast<uint64_t>(std::get<void*>(param));
+        }
+    };
+    uint64_t addr = convert_ptrace_parameter(_addr);
+    uint64_t data = convert_ptrace_parameter(_data);
+
+    ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace call params(" << ptrace_op_name(op) << "("
+               << op << "), " << m_pid << ", " << addr << ", " << data << ")";
+
+    ptrace_data_t ptrace_data{};
     ptrace_data.op   = op;
     ptrace_data.addr = addr;
     ptrace_data.data = data;
+    // Store parameters for the ptrace operation in m_ptrace_data for retrieval by ptrace_runner()
     m_ptrace_data.store(ptrace_data);
+
+    // Set m_running to true, requesting a ptrace operation be performed in ptrace_runner() with the
+    // parameters in m_ptrace_data
     m_running.store(true);
-    if(!wait_for_ne(m_running, true, timeout_ms))
+    // Wait for m_running to be set to false, which indicates ptrace_runner() has finished the
+    // requested ptrace operation.
+    if(!wait_for_eq(m_running, false, timeout_ms))
     {
         ROCP_ERROR << "[rocprofiler-sdk-rocattach] Timeout during ptrace(" << op << ", " << m_pid
                    << ", " << addr << ", " << data << ") duration: " << timeout_ms << "ms";
         return ROCATTACH_STATUS_ERROR;
     }
-
+    auto result = m_ptrace_data.load();
     if(ptrace_retval)
     {
-        *ptrace_retval = m_ptrace_data.load().retval;
+        *ptrace_retval = result.retval;
     }
     if(ptrace_errno)
     {
-        *ptrace_errno = m_ptrace_data.load().ptrace_errno;
+        *ptrace_errno = result.ptrace_errno;
+    }
+    if(result.ptrace_errno != 0)
+    {
+        // log an error if it occurs, but the ptrace call was a success, so still return success
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] ptrace call failed. errno: "
+                   << result.ptrace_errno << " - " << strerror(result.ptrace_errno) << ". params("
+                   << ptrace_op_name(op) << "(" << op << "), " << m_pid << ", " << addr << ", "
+                   << data << ")";
     }
     return ROCATTACH_STATUS_SUCCESS;
 }
@@ -110,14 +128,19 @@ PTraceRunner::ptrace_runner(pid_t                       _pid,
 {
     while(thread_done.load() == false)
     {
+        // When running becomes true, a new ptrace operation has been requested with ptrace_data as
+        // its parameters
         if(running.load() == true)
         {
-            errno             = 0;
+            errno = 0;
+            // Load ptrace_data, then call ptrace with its parameters.
             auto _ptrace_data = ptrace_data.load();
             auto retval       = ptrace(_ptrace_data.op, _pid, _ptrace_data.addr, _ptrace_data.data);
+            // Write back the results of the ptrace operation, then store to ptrace_data.
             _ptrace_data.retval       = retval;
             _ptrace_data.ptrace_errno = errno;
             ptrace_data.store(_ptrace_data);
+            // Clear running, indicating the requested operation is complete.
             running.store(false);
         }
         std::this_thread::yield();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_runner.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_runner.hpp
@@ -56,7 +56,7 @@ public:
                                   int*             ptrace_errno,
                                   size_t           timeout_ms = DEFAULT_TIMEOUT_MS);
 
-    pid_t get_pid() { return m_pid; };
+    pid_t get_pid() const { return m_pid; };
 
 private:
     // Data for a single ptrace operation.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_runner.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_runner.hpp
@@ -1,0 +1,100 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <rocprofiler-sdk-rocattach/types.h>
+
+#include <sys/ptrace.h>
+
+#include <atomic>
+#include <mutex>
+#include <thread>
+
+namespace rocprofiler
+{
+namespace rocattach
+{
+// ptrace sessions are tracked per thread ID, which means all ptrace operations for a single PID
+// must originate from the same thread in our program. This class allows multiple threads (e.g. a
+// main thread and a signal handler thread) to both use ptrace by routing their calls through a
+// single worker thread.
+class PTraceRunner
+{
+    static constexpr size_t DEFAULT_TIMEOUT_MS = 10000;
+
+public:
+    explicit PTraceRunner(pid_t pid);
+    ~PTraceRunner();
+
+    // Intended to mirror ptrace(), but with parameters for its return value and errno
+    // A return value of ROCATTACH_STATUS_ERROR indicates a timeout while communicating with this
+    // class's worker thread.
+    rocattach_status_t ptrace_run(__ptrace_request op,
+                                  void*            addr,
+                                  void*            data,
+                                  uint64_t*        ptrace_retval,
+                                  int*             ptrace_errno,
+                                  size_t           timeout_ms = DEFAULT_TIMEOUT_MS);
+
+    pid_t get_pid() { return m_pid; };
+
+private:
+    // Data for a single ptrace operation.
+    // ptrace_run fills in op, addr, and data when invoking ptrace
+    // ptrace_runner worker thread fills in retval and ptrace_errno after running ptrace
+    struct ptrace_data_t
+    {
+        __ptrace_request op;
+        void*            addr;
+        void*            data;
+        uint64_t         retval;
+        int              ptrace_errno;
+    };
+
+    const pid_t m_pid = 0;
+    // Mutex controls access to m_ptrace_data, as well as ensuring ptrace_run is not run
+    // concurrently.
+    std::mutex m_ptrace_run_mutex;
+    // Mailbox containing ptrace parameters and results
+    std::atomic<ptrace_data_t> m_ptrace_data = {};
+
+    // Controls the m_ptrace_data mailbox and signals when data is valid
+    // Transition to true - Signals to ptrace_runner to invoke ptrace using the information in
+    // m_ptrace_data Transition to false - Signals to ptrace_run that ptrace was invoked and results
+    // are in m_ptrace_data
+    std::atomic<bool> m_running = false;
+
+    // Transition to true - Signals to ptrace_runner to terminate the thread
+    std::atomic<bool> m_thread_done = false;
+
+    // This definition must appear after m_ptrace_data, m_running, and m_thread_done to ensure
+    // initialization ordering.
+    std::thread m_ptrace_thread;
+
+    static void ptrace_runner(pid_t                       _pid,
+                              std::atomic<ptrace_data_t>& ptrace_data,
+                              std::atomic<bool>&          running,
+                              std::atomic<bool>&          thread_done);
+};
+}  // namespace rocattach
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_runner.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_runner.hpp
@@ -35,70 +35,20 @@ namespace rocprofiler
 {
 namespace rocattach
 {
-// ptrace sessions are tracked per thread ID, which means all ptrace operations for a single PID
-// must originate from the same thread in our program. This class allows multiple threads (e.g. a
-// main thread and a signal handler thread) to both use ptrace by routing their calls through a
-// single worker thread.
-class PTraceRunner
-{
-    static constexpr size_t DEFAULT_TIMEOUT_MS = 10000;
+using ptrace_parameter_t                          = std::variant<std::monostate, uint64_t, void*>;
+static constexpr size_t ptrace_default_timeout_ms = 10000;
 
-public:
-    explicit PTraceRunner(pid_t pid);
-    ~PTraceRunner();
+// Intended to mirror ptrace(), but with parameters for its return value and errno
+// A return value of ROCATTACH_STATUS_ERROR indicates a timeout while communicating with this
+// module's worker thread.
+rocattach_status_t
+ptrace_run(pid_t              pid,
+           __ptrace_request   op,
+           ptrace_parameter_t addr,
+           ptrace_parameter_t data,
+           uint64_t*          ptrace_retval,
+           int*               ptrace_errno,
+           size_t             timeout = ptrace_default_timeout_ms);
 
-    using ptrace_parameter_t = std::variant<uint64_t, void*>;
-
-    // Intended to mirror ptrace(), but with parameters for its return value and errno
-    // A return value of ROCATTACH_STATUS_ERROR indicates a timeout while communicating with this
-    // class's worker thread.
-    rocattach_status_t ptrace_run(__ptrace_request   op,
-                                  ptrace_parameter_t addr,
-                                  ptrace_parameter_t data,
-                                  uint64_t*          ptrace_retval,
-                                  int*               ptrace_errno,
-                                  size_t             timeout_ms = DEFAULT_TIMEOUT_MS);
-
-    pid_t get_pid() const { return m_pid; };
-
-private:
-    const pid_t m_pid = {};
-
-    // Data for a single ptrace operation.
-    // ptrace_run fills in op, addr, and data when invoking ptrace
-    // ptrace_runner worker thread fills in retval and ptrace_errno after running ptrace
-    struct ptrace_data_t
-    {
-        __ptrace_request op;
-        uint64_t         addr;
-        uint64_t         data;
-        uint64_t         retval;
-        int              ptrace_errno;
-    };
-
-    // Mutex controls access to m_ptrace_data, as well as ensuring ptrace_run is not run
-    // concurrently.
-    std::mutex m_ptrace_run_mutex;
-    // Mailbox containing ptrace parameters and results
-    std::atomic<ptrace_data_t> m_ptrace_data = {};
-
-    // Controls the m_ptrace_data mailbox and signals when data is valid
-    // Transition to true - Signals to ptrace_runner to invoke ptrace using the information in
-    // m_ptrace_data Transition to false - Signals to ptrace_run that ptrace was invoked and results
-    // are in m_ptrace_data
-    std::atomic<bool> m_running = false;
-
-    // Transition to true - Signals to ptrace_runner to terminate the thread
-    std::atomic<bool> m_thread_done = false;
-
-    // This definition must appear after m_ptrace_data, m_running, and m_thread_done to ensure
-    // initialization ordering.
-    std::thread m_ptrace_thread;
-
-    static void ptrace_runner(pid_t                       _pid,
-                              std::atomic<ptrace_data_t>& ptrace_data,
-                              std::atomic<bool>&          running,
-                              std::atomic<bool>&          thread_done);
-};
 }  // namespace rocattach
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_runner.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_runner.hpp
@@ -29,6 +29,7 @@
 #include <atomic>
 #include <mutex>
 #include <thread>
+#include <variant>
 
 namespace rocprofiler
 {
@@ -46,32 +47,35 @@ public:
     explicit PTraceRunner(pid_t pid);
     ~PTraceRunner();
 
+    using ptrace_parameter_t = std::variant<uint64_t, void*>;
+
     // Intended to mirror ptrace(), but with parameters for its return value and errno
     // A return value of ROCATTACH_STATUS_ERROR indicates a timeout while communicating with this
     // class's worker thread.
-    rocattach_status_t ptrace_run(__ptrace_request op,
-                                  void*            addr,
-                                  void*            data,
-                                  uint64_t*        ptrace_retval,
-                                  int*             ptrace_errno,
-                                  size_t           timeout_ms = DEFAULT_TIMEOUT_MS);
+    rocattach_status_t ptrace_run(__ptrace_request   op,
+                                  ptrace_parameter_t addr,
+                                  ptrace_parameter_t data,
+                                  uint64_t*          ptrace_retval,
+                                  int*               ptrace_errno,
+                                  size_t             timeout_ms = DEFAULT_TIMEOUT_MS);
 
     pid_t get_pid() const { return m_pid; };
 
 private:
+    const pid_t m_pid = {};
+
     // Data for a single ptrace operation.
     // ptrace_run fills in op, addr, and data when invoking ptrace
     // ptrace_runner worker thread fills in retval and ptrace_errno after running ptrace
     struct ptrace_data_t
     {
         __ptrace_request op;
-        void*            addr;
-        void*            data;
+        uint64_t         addr;
+        uint64_t         data;
         uint64_t         retval;
         int              ptrace_errno;
     };
 
-    const pid_t m_pid = 0;
     // Mutex controls access to m_ptrace_data, as well as ensuring ptrace_run is not run
     // concurrently.
     std::mutex m_ptrace_run_mutex;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -74,42 +74,55 @@ convert_ptrace_error(int error)
     }
 }
 
-// Boilerplate around ptrace calls.
+// Boilerplate around ptrace calls in m_ptrace_runner.
 // If an error occurs, logs the error and returns an appropriate rocattach_status_t.
-#define PTRACE_CALL(op, pid, addr, data)                                                           \
+#define PTRACE_CALL(op, addr, data) /*NOLINT(performance-no-int-to-ptr)*/                          \
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace call params(" << ptrace_op_name(op) << "("   \
-               << op << "), " << pid << ", " << (uint64_t) addr << ", " << (uint64_t) data << ")"; \
-    if(errno = 0, ptrace(op, pid, addr, data); errno != 0)                                         \
+               << op << "), " << m_ptrace_runner->get_pid() << ", " << (uint64_t) addr << ", "     \
+               << (uint64_t) data << ")";                                                          \
     {                                                                                              \
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] ptrace call failed. errno: " << errno << " - "  \
-                   << strerror(errno) << ". params(" << ptrace_op_name(op) << "(" << op << "), "   \
-                   << pid << ", " << (uint64_t) addr << ", " << (uint64_t) data << ")";            \
-        return convert_ptrace_error(errno);                                                        \
+        uint64_t           retval      = 0;                                                        \
+        int                local_errno = 0;                                                        \
+        void*              local_addr  = reinterpret_cast<void*>(addr);                            \
+        void*              local_data  = reinterpret_cast<void*>(data);                            \
+        rocattach_status_t status =                                                                \
+            m_ptrace_runner->ptrace_run(op, local_addr, local_data, &retval, &local_errno);        \
+        if(status != ROCATTACH_STATUS_SUCCESS)                                                     \
+        {                                                                                          \
+            return status;                                                                         \
+        }                                                                                          \
+        if(local_errno != 0)                                                                       \
+        {                                                                                          \
+            ROCP_ERROR << "[rocprofiler-sdk-rocattach] ptrace call failed. errno: " << local_errno \
+                       << " - " << strerror(local_errno) << ". params(" << ptrace_op_name(op)      \
+                       << "(" << op << "), " << m_ptrace_runner->get_pid() << ", "                 \
+                       << (uint64_t) addr << ", " << (uint64_t) data << ")";                       \
+            return convert_ptrace_error(local_errno);                                              \
+        }                                                                                          \
     }
 
 // Changes the order of parameters for PEEKDATA so it can be used like other operations.
-// value must be uint64_t
-#define PTRACE_PEEK(pid, addr, read_value)                                                         \
+// read_value must be uint64_t
+#define PTRACE_PEEK(addr, read_value) /*NOLINT(performance-no-int-to-ptr)*/                        \
     static_assert(std::is_same<decltype(read_value), uint64_t>::value);                            \
-    ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace call params(PTRACE_PEEKDATA(2), " << pid     \
-               << ", " << (uint64_t) addr << ", 0)";                                               \
-    if(errno = 0, read_value = ptrace(PTRACE_PEEKDATA, pid, addr, NULL); errno != 0)               \
+    ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace call params(PTRACE_PEEKDATA(2), "            \
+               << m_ptrace_runner->get_pid() << ", " << (uint64_t) addr << ", 0)";                 \
     {                                                                                              \
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] ptrace call failed. errno: " << errno           \
-                   << ". params(PTRACE_PEEKDATA(2), " << pid << ", " << (uint64_t) addr << ", 0)"; \
-        return convert_ptrace_error(errno);                                                        \
-    }
-
-// Helper macro for the signal_handler where cont is called but will not return inside the macro
-// error is left in errno for processing
-#define PTRACE_CONT_NO_RETURN(pid, addr, data)                                                     \
-    ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace call params(PTRACE_CONT(7), " << pid << ", " \
-               << (uint64_t) addr << ", " << (uint64_t) data << ")";                               \
-    if(errno = 0, ptrace(PTRACE_CONT, pid, addr, data); errno != 0)                                \
-    {                                                                                              \
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] ptrace call failed. errno: " << errno           \
-                   << ". params(PTRACE_CONT(7), " << pid << ", " << (uint64_t) addr << ", "        \
-                   << (uint64_t) data << ")";                                                      \
+        int                local_errno = 0;                                                        \
+        void*              local_addr  = reinterpret_cast<void*>(addr);                            \
+        rocattach_status_t status      = m_ptrace_runner->ptrace_run(                              \
+            PTRACE_PEEKDATA, local_addr, NULL, &read_value, &local_errno);                    \
+        if(status != ROCATTACH_STATUS_SUCCESS)                                                     \
+        {                                                                                          \
+            return status;                                                                         \
+        }                                                                                          \
+        if(local_errno != 0)                                                                       \
+        {                                                                                          \
+            ROCP_ERROR << "[rocprofiler-sdk-rocattach] ptrace call failed. errno: " << local_errno \
+                       << " - " << strerror(local_errno) << ". params(PTRACE_PEEKDATA(2), "        \
+                       << m_ptrace_runner->get_pid() << ", " << (uint64_t) addr << ", 0)";         \
+            return convert_ptrace_error(local_errno);                                              \
+        }                                                                                          \
     }
 
 // Helper macro for handling any rocattach_status returning call
@@ -155,7 +168,9 @@ wait_for_ne(std::atomic<T>& flag, T condition, size_t timeout_ms)
 
 PTraceSession::PTraceSession(int _pid)
 : m_pid{_pid}
-{}
+{
+    m_ptrace_runner = std::make_shared<PTraceRunner>(m_pid);
+}
 
 PTraceSession::~PTraceSession() { detach(); }
 
@@ -182,7 +197,7 @@ PTraceSession::attach()
         return ROCATTACH_STATUS_ERROR;
     }
     // SEIZE attaches without stopping the process
-    PTRACE_CALL(PTRACE_SEIZE, m_pid, NULL, NULL);
+    PTRACE_CALL(PTRACE_SEIZE, NULL, NULL);
     ROCP_INFO << "[rocprofiler-sdk-rocattach] Successfully attached to pid " << m_pid;
     ROCATTACH_CALL(start_signal_handler());
     m_state = PTRACE_SESSION_STATE_RUNNING;
@@ -204,7 +219,7 @@ PTraceSession::detach()
     }
 
     ROCATTACH_CALL(stop_signal_handler());
-    PTRACE_CALL(PTRACE_DETACH, m_pid, NULL, NULL);
+    PTRACE_CALL(PTRACE_DETACH, NULL, NULL);
     m_state = PTRACE_SESSION_STATE_DETACHED;
     ROCP_INFO << "[rocprofiler-sdk-rocattach] Detached from pid " << m_pid;
     return ROCATTACH_STATUS_SUCCESS;
@@ -221,6 +236,7 @@ PTraceSession::start_signal_handler()
     }
     m_ptrace_signal_handler_thread = std::thread(ptrace_signal_handler_func,
                                                  m_pid,
+                                                 m_ptrace_runner,
                                                  std::ref(m_ptrace_signal_handler_state),
                                                  std::ref(m_ptrace_signal_handler_error));
     if(!wait_for_ne(m_ptrace_signal_handler_state,
@@ -278,6 +294,7 @@ PTraceSession::stop_signal_handler()
 void
 PTraceSession::ptrace_signal_handler_func(
     int                                                 _pid,
+    std::shared_ptr<PTraceRunner>                       _runner,
     std::atomic<ptrace_session_signal_handler_state_t>& _state,
     std::atomic<rocattach_status_t>&                    _error)
 {
@@ -344,10 +361,29 @@ PTraceSession::ptrace_signal_handler_func(
             }
             else
             {
-                PTRACE_CONT_NO_RETURN(_pid, NULL, sig);
-                if(errno)
+                // Not our signal, forward the signal to the app using CONT
+                ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace call params(PTRACE_CONT(7), "
+                           << _runner->get_pid() << ", 0, " << sig << ")";
+                uint64_t           _retval = 0;
+                int                _errno  = 0;
+                rocattach_status_t _status =
+                    _runner->ptrace_run(PTRACE_CONT,
+                                        NULL,
+                                        reinterpret_cast<void*>(sig),
+                                        &_retval,
+                                        &_errno);  // NOLINT(performance-no-int-to-ptr)
+                if(_status != ROCATTACH_STATUS_SUCCESS)
                 {
-                    _error.store(convert_ptrace_error(errno));
+                    _error.store(_status);
+                    _state.store(PTRACE_SIGNAL_HANDLER_STATE_FINAL);
+                    return;
+                }
+                if(_errno != 0)
+                {
+                    ROCP_ERROR << "[rocprofiler-sdk-rocattach] ptrace call failed. errno: "
+                               << _errno << " - " << strerror(_errno) << ". params(PTRACE_CONT(7), "
+                               << _runner->get_pid() << ", 0, " << sig << ")";
+                    _error.store(convert_ptrace_error(_errno));
                     _state.store(PTRACE_SIGNAL_HANDLER_STATE_FINAL);
                     return;
                 }
@@ -389,7 +425,7 @@ PTraceSession::write_internal(size_t addr, const std::vector<uint8_t>& data, siz
         const size_t offset = (word_iter * word_size);
         uint64_t     word;
         std::memcpy(&word, data.data() + offset, word_size);
-        PTRACE_CALL(PTRACE_POKEDATA, m_pid, addr + offset, word);
+        PTRACE_CALL(PTRACE_POKEDATA, addr + offset, word);
     }
 
     // If not evenly divisible, read the last word to do a masked partial write.
@@ -398,9 +434,9 @@ PTraceSession::write_internal(size_t addr, const std::vector<uint8_t>& data, siz
     {
         const size_t offset    = (word_iter * word_size);
         uint64_t     last_word = 0;
-        PTRACE_PEEK(m_pid, addr + offset, last_word);
+        PTRACE_PEEK(addr + offset, last_word);
         std::memcpy(&last_word, data.data() + offset, remainder);
-        PTRACE_CALL(PTRACE_POKEDATA, m_pid, addr + offset, last_word);
+        PTRACE_CALL(PTRACE_POKEDATA, addr + offset, last_word);
     }
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace wrote " << size << " bytes at " << addr;
     return ROCATTACH_STATUS_SUCCESS;
@@ -434,7 +470,7 @@ PTraceSession::read_internal(size_t addr, std::vector<uint8_t>& data, size_t siz
     {
         const size_t offset = (word_iter * word_size);
         uint64_t     word   = 0;
-        PTRACE_PEEK(m_pid, addr + offset, word);
+        PTRACE_PEEK(addr + offset, word);
         std::memcpy(data.data() + offset, &word, word_size);
     }
 
@@ -444,7 +480,7 @@ PTraceSession::read_internal(size_t addr, std::vector<uint8_t>& data, size_t siz
     {
         const size_t offset    = (word_iter * word_size);
         uint64_t     last_word = 0;
-        PTRACE_PEEK(m_pid, addr + offset, last_word);
+        PTRACE_PEEK(addr + offset, last_word);
         std::memcpy(data.data() + offset, &last_word, remainder);
     }
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace read " << size << " bytes at " << addr;
@@ -549,7 +585,7 @@ PTraceSession::wait_for_stop()
     }
 
     // Call interrupt and wait until process is stopped
-    PTRACE_CALL(PTRACE_INTERRUPT, m_pid, NULL, NULL);
+    PTRACE_CALL(PTRACE_INTERRUPT, NULL, NULL);
     if(!wait_for_ne(m_ptrace_signal_handler_state,
                     PTRACE_SIGNAL_HANDLER_STATE_WAITING_FOR_BREAKPOINT,
                     PTRACE_BREAKPOINT_TIMEOUT_MS))
@@ -598,7 +634,7 @@ PTraceSession::simple_mmap(void*& addr, size_t length)
 
     // Save current register file
     struct user_regs_struct oldregs;
-    PTRACE_CALL(PTRACE_GETREGS, m_pid, NULL, &oldregs);
+    PTRACE_CALL(PTRACE_GETREGS, NULL, &oldregs);
     // Set register file for system call to mmap:
     // mmap(addr=NULL, length, prot, flags, -1, 0);
     struct user_regs_struct newregs = oldregs;
@@ -615,7 +651,7 @@ PTraceSession::simple_mmap(void*& addr, size_t length)
     newregs.rsp = oldregs.rsp - 128;    // move sp by at least 128 to not clobber redlined functions
     newregs.rsp -= (newregs.rsp % 16);  // base sp should be on 16-byte boundary
     // Set syscall registers
-    PTRACE_CALL(PTRACE_SETREGS, m_pid, NULL, &newregs);
+    PTRACE_CALL(PTRACE_SETREGS, NULL, &newregs);
 
     // x64 assembly to perform a syscall and breakpoint when done
     // 0f 05  syscall
@@ -632,13 +668,13 @@ PTraceSession::simple_mmap(void*& addr, size_t length)
 
     // Get registers to see mmap's return values
     struct user_regs_struct returnregs;
-    PTRACE_CALL(PTRACE_GETREGS, m_pid, NULL, &returnregs);
+    PTRACE_CALL(PTRACE_GETREGS, NULL, &returnregs);
 
     // Write in old opcodes
     ROCATTACH_CALL(write_internal(reinterpret_cast<size_t>(entry_addr), old_code, 3));
 
     // Restore register file
-    PTRACE_CALL(PTRACE_SETREGS, m_pid, NULL, &oldregs);
+    PTRACE_CALL(PTRACE_SETREGS, NULL, &oldregs);
 
     // Restart execution
     ROCATTACH_CALL(cont());
@@ -668,7 +704,7 @@ PTraceSession::simple_munmap(void*& addr, size_t length)
 
     // Save current register file
     struct user_regs_struct oldregs;
-    PTRACE_CALL(PTRACE_GETREGS, m_pid, NULL, &oldregs);
+    PTRACE_CALL(PTRACE_GETREGS, NULL, &oldregs);
     // Set register file for system call to munmap:
     // munmap(addr, length);
     struct user_regs_struct newregs = oldregs;
@@ -681,7 +717,7 @@ PTraceSession::simple_munmap(void*& addr, size_t length)
     newregs.rsp = oldregs.rsp - 128;    // move sp by at least 128 to not clobber redlined functions
     newregs.rsp -= (newregs.rsp % 16);  // base sp should be on 16-byte boundary
     // Set syscall registers
-    PTRACE_CALL(PTRACE_SETREGS, m_pid, NULL, &newregs);
+    PTRACE_CALL(PTRACE_SETREGS, NULL, &newregs);
 
     // x64 assembly to perform a syscall and breakpoint when done
     // 0f 05  syscall
@@ -698,13 +734,13 @@ PTraceSession::simple_munmap(void*& addr, size_t length)
 
     // Get registers to see mmap's return values
     struct user_regs_struct returnregs;
-    PTRACE_CALL(PTRACE_GETREGS, m_pid, NULL, &returnregs);
+    PTRACE_CALL(PTRACE_GETREGS, NULL, &returnregs);
 
     // Write in old opcodes
     ROCATTACH_CALL(write_internal(reinterpret_cast<size_t>(entry_addr), old_code, 3));
 
     // Restore register file
-    PTRACE_CALL(PTRACE_SETREGS, m_pid, NULL, &oldregs);
+    PTRACE_CALL(PTRACE_SETREGS, NULL, &oldregs);
 
     // Restart execution
     ROCATTACH_CALL(cont());
@@ -767,7 +803,7 @@ PTraceSession::call_function(const std::string& library,
 
     // Save current register file
     struct user_regs_struct oldregs;
-    PTRACE_CALL(PTRACE_GETREGS, m_pid, NULL, &oldregs);
+    PTRACE_CALL(PTRACE_GETREGS, NULL, &oldregs);
 
     // Construct registers to call a function with 2 parameters
     // symbol(first_param, second_param)
@@ -781,7 +817,7 @@ PTraceSession::call_function(const std::string& library,
     newregs.rsp = oldregs.rsp - 128;    // move sp by at least 128 to not clobber redlined functions
     newregs.rsp -= (newregs.rsp % 16);  // base sp should be on 16-byte boundary
     // Set function  registers
-    PTRACE_CALL(PTRACE_SETREGS, m_pid, NULL, &newregs);
+    PTRACE_CALL(PTRACE_SETREGS, NULL, &newregs);
 
     // x64 assembly to call a function by register and breakpoint when done
     // ff d0  call rax
@@ -799,13 +835,13 @@ PTraceSession::call_function(const std::string& library,
 
     // Get registers to see  return values
     struct user_regs_struct returnregs;
-    PTRACE_CALL(PTRACE_GETREGS, m_pid, NULL, &returnregs);
+    PTRACE_CALL(PTRACE_GETREGS, NULL, &returnregs);
 
     // Write in old opcodes
     ROCATTACH_CALL(write_internal(reinterpret_cast<size_t>(entry_addr), old_code, 3));
 
     // Restore register file
-    PTRACE_CALL(PTRACE_SETREGS, m_pid, NULL, &oldregs);
+    PTRACE_CALL(PTRACE_SETREGS, NULL, &oldregs);
 
     // Restart execution
     ROCATTACH_CALL(cont());
@@ -843,7 +879,7 @@ PTraceSession::cont()
         return ROCATTACH_STATUS_ERROR;
     }
 
-    PTRACE_CALL(PTRACE_CONT, m_pid, NULL, NULL);
+    PTRACE_CALL(PTRACE_CONT, NULL, NULL);
     m_state = PTRACE_SESSION_STATE_RUNNING;
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace resumed pid " << m_pid;
     return ROCATTACH_STATUS_SUCCESS;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.cpp
@@ -80,9 +80,7 @@ constexpr size_t PTRACE_HANDLER_START_STOP_TIMEOUT_MS = 10000;
 
 PTraceSession::PTraceSession(int _pid)
 : m_pid{_pid}
-{
-    m_ptrace_runner = std::make_shared<PTraceRunner>(m_pid);
-}
+{}
 
 PTraceSession::~PTraceSession() { detach(); }
 
@@ -112,7 +110,7 @@ PTraceSession::ptrace_call(__ptrace_request   op,
 {
     uint64_t           retval      = 0;
     int                local_errno = 0;
-    rocattach_status_t status = m_ptrace_runner->ptrace_run(op, addr, data, &retval, &local_errno);
+    rocattach_status_t status      = ptrace_run(m_pid, op, addr, data, &retval, &local_errno);
     if(status != ROCATTACH_STATUS_SUCCESS)
     {
         return status;
@@ -188,7 +186,6 @@ PTraceSession::start_signal_handler()
     }
     m_ptrace_signal_handler_thread = std::thread(ptrace_signal_handler_func,
                                                  m_pid,
-                                                 m_ptrace_runner,
                                                  std::ref(m_ptrace_signal_handler_state),
                                                  std::ref(m_ptrace_signal_handler_error));
     if(!wait_for_ne(m_ptrace_signal_handler_state,
@@ -246,7 +243,6 @@ PTraceSession::stop_signal_handler()
 void
 PTraceSession::ptrace_signal_handler_func(
     int                                                 _pid,
-    const std::shared_ptr<PTraceRunner>&                _runner,
     std::atomic<ptrace_session_signal_handler_state_t>& _state,
     std::atomic<rocattach_status_t>&                    _error)
 {
@@ -315,16 +311,11 @@ PTraceSession::ptrace_signal_handler_func(
             {
                 // Not our signal, forward the signal to the app using CONT
                 ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace call params(PTRACE_CONT(7), "
-                           << _runner->get_pid() << ", 0, " << sig << ")";
+                           << _pid << ", 0, " << sig << ")";
                 uint64_t           _retval = 0;
                 int                _errno  = 0;
-                rocattach_status_t _status = _runner->ptrace_run(
-                    PTRACE_CONT,
-                    nullptr,
-                    reinterpret_cast<void*>(  // NOLINT(performance-no-int-to-ptr)
-                        static_cast<uintptr_t>(sig)),
-                    &_retval,
-                    &_errno);
+                rocattach_status_t _status = ptrace_run(
+                    _pid, PTRACE_CONT, nullptr, static_cast<uint64_t>(sig), &_retval, &_errno);
                 if(_status != ROCATTACH_STATUS_SUCCESS)
                 {
                     _error.store(_status);
@@ -335,7 +326,7 @@ PTraceSession::ptrace_signal_handler_func(
                 {
                     ROCP_ERROR << "[rocprofiler-sdk-rocattach] ptrace call failed. errno: "
                                << _errno << " - " << strerror(_errno) << ". params(PTRACE_CONT(7), "
-                               << _runner->get_pid() << ", 0, " << sig << ")";
+                               << _pid << ", 0, " << sig << ")";
                     _error.store(convert_ptrace_error(_errno));
                     _state.store(PTRACE_SIGNAL_HANDLER_STATE_FINAL);
                     return;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.cpp
@@ -111,7 +111,7 @@ convert_ptrace_error(int error)
         int                local_errno = 0;                                                        \
         void*              local_addr  = reinterpret_cast<void*>(addr);                            \
         rocattach_status_t status      = m_ptrace_runner->ptrace_run(                              \
-            PTRACE_PEEKDATA, local_addr, NULL, &read_value, &local_errno);                    \
+            PTRACE_PEEKDATA, local_addr, nullptr, &read_value, &local_errno);                 \
         if(status != ROCATTACH_STATUS_SUCCESS)                                                     \
         {                                                                                          \
             return status;                                                                         \
@@ -197,7 +197,7 @@ PTraceSession::attach()
         return ROCATTACH_STATUS_ERROR;
     }
     // SEIZE attaches without stopping the process
-    PTRACE_CALL(PTRACE_SEIZE, NULL, NULL);
+    PTRACE_CALL(PTRACE_SEIZE, 0UL, 0UL);
     ROCP_INFO << "[rocprofiler-sdk-rocattach] Successfully attached to pid " << m_pid;
     ROCATTACH_CALL(start_signal_handler());
     m_state = PTRACE_SESSION_STATE_RUNNING;
@@ -219,7 +219,7 @@ PTraceSession::detach()
     }
 
     ROCATTACH_CALL(stop_signal_handler());
-    PTRACE_CALL(PTRACE_DETACH, NULL, NULL);
+    PTRACE_CALL(PTRACE_DETACH, 0UL, 0UL);
     m_state = PTRACE_SESSION_STATE_DETACHED;
     ROCP_INFO << "[rocprofiler-sdk-rocattach] Detached from pid " << m_pid;
     return ROCATTACH_STATUS_SUCCESS;
@@ -294,7 +294,7 @@ PTraceSession::stop_signal_handler()
 void
 PTraceSession::ptrace_signal_handler_func(
     int                                                 _pid,
-    std::shared_ptr<PTraceRunner>                       _runner,
+    const std::shared_ptr<PTraceRunner>&                _runner,
     std::atomic<ptrace_session_signal_handler_state_t>& _state,
     std::atomic<rocattach_status_t>&                    _error)
 {
@@ -366,12 +366,13 @@ PTraceSession::ptrace_signal_handler_func(
                            << _runner->get_pid() << ", 0, " << sig << ")";
                 uint64_t           _retval = 0;
                 int                _errno  = 0;
-                rocattach_status_t _status =
-                    _runner->ptrace_run(PTRACE_CONT,
-                                        NULL,
-                                        reinterpret_cast<void*>(sig),
-                                        &_retval,
-                                        &_errno);  // NOLINT(performance-no-int-to-ptr)
+                rocattach_status_t _status = _runner->ptrace_run(
+                    PTRACE_CONT,
+                    nullptr,
+                    reinterpret_cast<void*>(  // NOLINT(performance-no-int-to-ptr)
+                        static_cast<uintptr_t>(sig)),
+                    &_retval,
+                    &_errno);
                 if(_status != ROCATTACH_STATUS_SUCCESS)
                 {
                     _error.store(_status);
@@ -425,7 +426,9 @@ PTraceSession::write_internal(size_t addr, const std::vector<uint8_t>& data, siz
         const size_t offset = (word_iter * word_size);
         uint64_t     word;
         std::memcpy(&word, data.data() + offset, word_size);
-        PTRACE_CALL(PTRACE_POKEDATA, addr + offset, word);
+        PTRACE_CALL(PTRACE_POKEDATA,  // NOLINT(performance-no-int-to-ptr)
+                    reinterpret_cast<void*>(static_cast<uintptr_t>(addr + offset)),
+                    word);
     }
 
     // If not evenly divisible, read the last word to do a masked partial write.
@@ -434,9 +437,14 @@ PTraceSession::write_internal(size_t addr, const std::vector<uint8_t>& data, siz
     {
         const size_t offset    = (word_iter * word_size);
         uint64_t     last_word = 0;
-        PTRACE_PEEK(addr + offset, last_word);
+        PTRACE_PEEK(
+            reinterpret_cast<void*>(static_cast<uintptr_t>(  // NOLINT(performance-no-int-to-ptr)
+                addr + offset)),
+            last_word);
         std::memcpy(&last_word, data.data() + offset, remainder);
-        PTRACE_CALL(PTRACE_POKEDATA, addr + offset, last_word);
+        PTRACE_CALL(PTRACE_POKEDATA,  // NOLINT(performance-no-int-to-ptr)
+                    reinterpret_cast<void*>(static_cast<uintptr_t>(addr + offset)),
+                    last_word);
     }
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace wrote " << size << " bytes at " << addr;
     return ROCATTACH_STATUS_SUCCESS;
@@ -470,7 +478,10 @@ PTraceSession::read_internal(size_t addr, std::vector<uint8_t>& data, size_t siz
     {
         const size_t offset = (word_iter * word_size);
         uint64_t     word   = 0;
-        PTRACE_PEEK(addr + offset, word);
+        PTRACE_PEEK(
+            reinterpret_cast<void*>(static_cast<uintptr_t>(  // NOLINT(performance-no-int-to-ptr)
+                addr + offset)),
+            word);
         std::memcpy(data.data() + offset, &word, word_size);
     }
 
@@ -480,7 +491,10 @@ PTraceSession::read_internal(size_t addr, std::vector<uint8_t>& data, size_t siz
     {
         const size_t offset    = (word_iter * word_size);
         uint64_t     last_word = 0;
-        PTRACE_PEEK(addr + offset, last_word);
+        PTRACE_PEEK(
+            reinterpret_cast<void*>(static_cast<uintptr_t>(  // NOLINT(performance-no-int-to-ptr)
+                addr + offset)),
+            last_word);
         std::memcpy(data.data() + offset, &last_word, remainder);
     }
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace read " << size << " bytes at " << addr;
@@ -585,7 +599,7 @@ PTraceSession::wait_for_stop()
     }
 
     // Call interrupt and wait until process is stopped
-    PTRACE_CALL(PTRACE_INTERRUPT, NULL, NULL);
+    PTRACE_CALL(PTRACE_INTERRUPT, 0UL, 0UL);
     if(!wait_for_ne(m_ptrace_signal_handler_state,
                     PTRACE_SIGNAL_HANDLER_STATE_WAITING_FOR_BREAKPOINT,
                     PTRACE_BREAKPOINT_TIMEOUT_MS))
@@ -634,13 +648,13 @@ PTraceSession::simple_mmap(void*& addr, size_t length)
 
     // Save current register file
     struct user_regs_struct oldregs;
-    PTRACE_CALL(PTRACE_GETREGS, NULL, &oldregs);
+    PTRACE_CALL(PTRACE_GETREGS, 0UL, &oldregs);
     // Set register file for system call to mmap:
-    // mmap(addr=NULL, length, prot, flags, -1, 0);
+    // mmap(addr=nullptr, length, prot, flags, -1, 0);
     struct user_regs_struct newregs = oldregs;
 
     newregs.rax = 9;                            // calling convention: 9 is syscall ID for mmap
-    newregs.rdi = 0;                            // addr=NULL
+    newregs.rdi = 0;                            // addr=nullptr
     newregs.rsi = length;                       // length
     newregs.rdx = PROT_READ | PROT_WRITE;       // prot
     newregs.r10 = MAP_PRIVATE | MAP_ANONYMOUS;  // flags
@@ -651,7 +665,7 @@ PTraceSession::simple_mmap(void*& addr, size_t length)
     newregs.rsp = oldregs.rsp - 128;    // move sp by at least 128 to not clobber redlined functions
     newregs.rsp -= (newregs.rsp % 16);  // base sp should be on 16-byte boundary
     // Set syscall registers
-    PTRACE_CALL(PTRACE_SETREGS, NULL, &newregs);
+    PTRACE_CALL(PTRACE_SETREGS, 0UL, &newregs);
 
     // x64 assembly to perform a syscall and breakpoint when done
     // 0f 05  syscall
@@ -668,13 +682,13 @@ PTraceSession::simple_mmap(void*& addr, size_t length)
 
     // Get registers to see mmap's return values
     struct user_regs_struct returnregs;
-    PTRACE_CALL(PTRACE_GETREGS, NULL, &returnregs);
+    PTRACE_CALL(PTRACE_GETREGS, 0UL, &returnregs);
 
     // Write in old opcodes
     ROCATTACH_CALL(write_internal(reinterpret_cast<size_t>(entry_addr), old_code, 3));
 
     // Restore register file
-    PTRACE_CALL(PTRACE_SETREGS, NULL, &oldregs);
+    PTRACE_CALL(PTRACE_SETREGS, 0UL, &oldregs);
 
     // Restart execution
     ROCATTACH_CALL(cont());
@@ -704,7 +718,7 @@ PTraceSession::simple_munmap(void*& addr, size_t length)
 
     // Save current register file
     struct user_regs_struct oldregs;
-    PTRACE_CALL(PTRACE_GETREGS, NULL, &oldregs);
+    PTRACE_CALL(PTRACE_GETREGS, 0UL, &oldregs);
     // Set register file for system call to munmap:
     // munmap(addr, length);
     struct user_regs_struct newregs = oldregs;
@@ -717,7 +731,7 @@ PTraceSession::simple_munmap(void*& addr, size_t length)
     newregs.rsp = oldregs.rsp - 128;    // move sp by at least 128 to not clobber redlined functions
     newregs.rsp -= (newregs.rsp % 16);  // base sp should be on 16-byte boundary
     // Set syscall registers
-    PTRACE_CALL(PTRACE_SETREGS, NULL, &newregs);
+    PTRACE_CALL(PTRACE_SETREGS, 0UL, &newregs);
 
     // x64 assembly to perform a syscall and breakpoint when done
     // 0f 05  syscall
@@ -734,13 +748,13 @@ PTraceSession::simple_munmap(void*& addr, size_t length)
 
     // Get registers to see mmap's return values
     struct user_regs_struct returnregs;
-    PTRACE_CALL(PTRACE_GETREGS, NULL, &returnregs);
+    PTRACE_CALL(PTRACE_GETREGS, 0UL, &returnregs);
 
     // Write in old opcodes
     ROCATTACH_CALL(write_internal(reinterpret_cast<size_t>(entry_addr), old_code, 3));
 
     // Restore register file
-    PTRACE_CALL(PTRACE_SETREGS, NULL, &oldregs);
+    PTRACE_CALL(PTRACE_SETREGS, 0UL, &oldregs);
 
     // Restart execution
     ROCATTACH_CALL(cont());
@@ -803,7 +817,7 @@ PTraceSession::call_function(const std::string& library,
 
     // Save current register file
     struct user_regs_struct oldregs;
-    PTRACE_CALL(PTRACE_GETREGS, NULL, &oldregs);
+    PTRACE_CALL(PTRACE_GETREGS, 0UL, &oldregs);
 
     // Construct registers to call a function with 2 parameters
     // symbol(first_param, second_param)
@@ -817,7 +831,7 @@ PTraceSession::call_function(const std::string& library,
     newregs.rsp = oldregs.rsp - 128;    // move sp by at least 128 to not clobber redlined functions
     newregs.rsp -= (newregs.rsp % 16);  // base sp should be on 16-byte boundary
     // Set function  registers
-    PTRACE_CALL(PTRACE_SETREGS, NULL, &newregs);
+    PTRACE_CALL(PTRACE_SETREGS, 0UL, &newregs);
 
     // x64 assembly to call a function by register and breakpoint when done
     // ff d0  call rax
@@ -835,13 +849,13 @@ PTraceSession::call_function(const std::string& library,
 
     // Get registers to see  return values
     struct user_regs_struct returnregs;
-    PTRACE_CALL(PTRACE_GETREGS, NULL, &returnregs);
+    PTRACE_CALL(PTRACE_GETREGS, 0UL, &returnregs);
 
     // Write in old opcodes
     ROCATTACH_CALL(write_internal(reinterpret_cast<size_t>(entry_addr), old_code, 3));
 
     // Restore register file
-    PTRACE_CALL(PTRACE_SETREGS, NULL, &oldregs);
+    PTRACE_CALL(PTRACE_SETREGS, 0UL, &oldregs);
 
     // Restart execution
     ROCATTACH_CALL(cont());
@@ -879,7 +893,7 @@ PTraceSession::cont()
         return ROCATTACH_STATUS_ERROR;
     }
 
-    PTRACE_CALL(PTRACE_CONT, NULL, NULL);
+    PTRACE_CALL(PTRACE_CONT, 0UL, 0UL);
     m_state = PTRACE_SESSION_STATE_RUNNING;
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace resumed pid " << m_pid;
     return ROCATTACH_STATUS_SUCCESS;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.cpp
@@ -24,6 +24,9 @@
 #include "auxv.hpp"
 #include "symbol_lookup.hpp"
 
+#include "common/ptrace.hpp"
+#include "common/wait_for_atomic.hpp"
+
 #include "lib/common/logging.hpp"
 
 #include <fcntl.h>
@@ -44,88 +47,17 @@ namespace rocattach
 {
 namespace
 {
-// Very limited list of operations for logging only.
-constexpr const char*
-ptrace_op_name(__ptrace_request op)
-{
-    switch(op)
-    {
-        case PTRACE_SEIZE: return "PTRACE_SEIZE";
-        case PTRACE_DETACH: return "PTRACE_DETACH";
-        case PTRACE_POKEDATA: return "PTRACE_POKEDATA";
-        case PTRACE_PEEKDATA: return "PTRACE_PEEKDATA";
-        case PTRACE_INTERRUPT: return "PTRACE_INTERRUPT";
-        case PTRACE_GETREGS: return "PTRACE_GETREGS";
-        case PTRACE_SETREGS: return "PTRACE_SETREGS";
-        case PTRACE_CONT: return "PTRACE_CONT";
-        default: return "unknown op";
-    }
-}
-
-// Translates ptrace errno into rocattach status errors
-rocattach_status_t
-convert_ptrace_error(int error)
-{
-    switch(error)
-    {
-        case EPERM: return ROCATTACH_STATUS_ERROR_PTRACE_OPERATION_NOT_PERMITTED;
-        case ESRCH: return ROCATTACH_STATUS_ERROR_PTRACE_PROCESS_NOT_FOUND;
-        default: return ROCATTACH_STATUS_ERROR_PTRACE_ERROR;
-    }
-}
-
-// Boilerplate around ptrace calls in m_ptrace_runner.
-// If an error occurs, logs the error and returns an appropriate rocattach_status_t.
-#define PTRACE_CALL(op, addr, data) /*NOLINT(performance-no-int-to-ptr)*/                          \
-    ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace call params(" << ptrace_op_name(op) << "("   \
-               << op << "), " << m_ptrace_runner->get_pid() << ", " << (uint64_t) addr << ", "     \
-               << (uint64_t) data << ")";                                                          \
+// Boilerplate around in-class ptrace calls. Macro returns on error!
+#define PTRACE_CALL(op, addr, data)                                                                \
     {                                                                                              \
-        uint64_t           retval      = 0;                                                        \
-        int                local_errno = 0;                                                        \
-        void*              local_addr  = reinterpret_cast<void*>(addr);                            \
-        void*              local_data  = reinterpret_cast<void*>(data);                            \
-        rocattach_status_t status =                                                                \
-            m_ptrace_runner->ptrace_run(op, local_addr, local_data, &retval, &local_errno);        \
+        auto status = ptrace_call(op, addr, data);                                                 \
         if(status != ROCATTACH_STATUS_SUCCESS)                                                     \
         {                                                                                          \
             return status;                                                                         \
         }                                                                                          \
-        if(local_errno != 0)                                                                       \
-        {                                                                                          \
-            ROCP_ERROR << "[rocprofiler-sdk-rocattach] ptrace call failed. errno: " << local_errno \
-                       << " - " << strerror(local_errno) << ". params(" << ptrace_op_name(op)      \
-                       << "(" << op << "), " << m_ptrace_runner->get_pid() << ", "                 \
-                       << (uint64_t) addr << ", " << (uint64_t) data << ")";                       \
-            return convert_ptrace_error(local_errno);                                              \
-        }                                                                                          \
     }
 
-// Changes the order of parameters for PEEKDATA so it can be used like other operations.
-// read_value must be uint64_t
-#define PTRACE_PEEK(addr, read_value) /*NOLINT(performance-no-int-to-ptr)*/                        \
-    static_assert(std::is_same<decltype(read_value), uint64_t>::value);                            \
-    ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace call params(PTRACE_PEEKDATA(2), "            \
-               << m_ptrace_runner->get_pid() << ", " << (uint64_t) addr << ", 0)";                 \
-    {                                                                                              \
-        int                local_errno = 0;                                                        \
-        void*              local_addr  = reinterpret_cast<void*>(addr);                            \
-        rocattach_status_t status      = m_ptrace_runner->ptrace_run(                              \
-            PTRACE_PEEKDATA, local_addr, nullptr, &read_value, &local_errno);                 \
-        if(status != ROCATTACH_STATUS_SUCCESS)                                                     \
-        {                                                                                          \
-            return status;                                                                         \
-        }                                                                                          \
-        if(local_errno != 0)                                                                       \
-        {                                                                                          \
-            ROCP_ERROR << "[rocprofiler-sdk-rocattach] ptrace call failed. errno: " << local_errno \
-                       << " - " << strerror(local_errno) << ". params(PTRACE_PEEKDATA(2), "        \
-                       << m_ptrace_runner->get_pid() << ", " << (uint64_t) addr << ", 0)";         \
-            return convert_ptrace_error(local_errno);                                              \
-        }                                                                                          \
-    }
-
-// Helper macro for handling any rocattach_status returning call
+// Helper macro for handling any rocattach_status returning call. Macro returns on error!
 #define ROCATTACH_CALL(func)                                                                       \
     {                                                                                              \
         auto status = func;                                                                        \
@@ -143,26 +75,6 @@ convert_ptrace_error(int error)
 constexpr size_t PTRACE_BREAKPOINT_TIMEOUT_MS = 1800000;
 // How long to wait for the signal handler thread to start or stop
 constexpr size_t PTRACE_HANDLER_START_STOP_TIMEOUT_MS = 10000;
-
-template <typename T>
-bool
-wait_for_ne(std::atomic<T>& flag, T condition, size_t timeout_ms)
-{
-    auto start_time       = std::chrono::steady_clock::now();
-    auto timeout_duration = std::chrono::milliseconds(timeout_ms);
-    auto end_time         = start_time + timeout_duration;
-
-    while(std::chrono::steady_clock::now() < end_time)
-    {
-        if(flag.load() != condition)
-        {
-            return true;
-        }
-        std::this_thread::yield();
-    }
-    // Last chance check in case we were scheduled after timeout
-    return flag.load() != condition;
-}
 
 }  // namespace
 
@@ -187,6 +99,46 @@ PTraceSession::is_supported()
     const bool word_size_supported = (sizeof(void*) == 8);
 
     return (arch_supported && word_size_supported);
+}
+
+// Performs a ptrace operation using the given parameters with this PTraceSession's pid and
+// PTraceRunner. All ptrace operations work the same EXCEPT PTRACE_PEEKDATA which has been changed
+// to provide the 64-bit read data at the address given in data, instead of by return value. Returns
+// a non-success status on operation timeout or nonzero errno from ptrace.
+rocattach_status_t
+PTraceSession::ptrace_call(__ptrace_request   op,
+                           ptrace_parameter_t addr,
+                           ptrace_parameter_t data) const
+{
+    uint64_t           retval      = 0;
+    int                local_errno = 0;
+    rocattach_status_t status = m_ptrace_runner->ptrace_run(op, addr, data, &retval, &local_errno);
+    if(status != ROCATTACH_STATUS_SUCCESS)
+    {
+        return status;
+    }
+    if(local_errno != 0)
+    {
+        return convert_ptrace_error(local_errno);
+    }
+
+    // As a special case, rearrange the return value of PEEKDATA to be written to the address given
+    // in data. This standardizes the PEEKDATA operation to how other read operations (e.g. GETREGS)
+    // work.
+    if(op == PTRACE_PEEKDATA)
+    {
+        if(!std::holds_alternative<void*>(data))
+        {
+            return ROCATTACH_STATUS_ERROR;
+        }
+        auto* data_as_ptr = reinterpret_cast<uint64_t*>(std::get<void*>(data));
+        if(!data_as_ptr)
+        {
+            return ROCATTACH_STATUS_ERROR;
+        }
+        *data_as_ptr = retval;
+    }
+    return ROCATTACH_STATUS_SUCCESS;
 }
 
 rocattach_status_t
@@ -426,9 +378,7 @@ PTraceSession::write_internal(size_t addr, const std::vector<uint8_t>& data, siz
         const size_t offset = (word_iter * word_size);
         uint64_t     word;
         std::memcpy(&word, data.data() + offset, word_size);
-        PTRACE_CALL(PTRACE_POKEDATA,  // NOLINT(performance-no-int-to-ptr)
-                    reinterpret_cast<void*>(static_cast<uintptr_t>(addr + offset)),
-                    word);
+        PTRACE_CALL(PTRACE_POKEDATA, addr + offset, word);
     }
 
     // If not evenly divisible, read the last word to do a masked partial write.
@@ -437,14 +387,9 @@ PTraceSession::write_internal(size_t addr, const std::vector<uint8_t>& data, siz
     {
         const size_t offset    = (word_iter * word_size);
         uint64_t     last_word = 0;
-        PTRACE_PEEK(
-            reinterpret_cast<void*>(static_cast<uintptr_t>(  // NOLINT(performance-no-int-to-ptr)
-                addr + offset)),
-            last_word);
+        PTRACE_CALL(PTRACE_PEEKDATA, addr + offset, &last_word);
         std::memcpy(&last_word, data.data() + offset, remainder);
-        PTRACE_CALL(PTRACE_POKEDATA,  // NOLINT(performance-no-int-to-ptr)
-                    reinterpret_cast<void*>(static_cast<uintptr_t>(addr + offset)),
-                    last_word);
+        PTRACE_CALL(PTRACE_POKEDATA, addr + offset, last_word);
     }
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace wrote " << size << " bytes at " << addr;
     return ROCATTACH_STATUS_SUCCESS;
@@ -478,10 +423,7 @@ PTraceSession::read_internal(size_t addr, std::vector<uint8_t>& data, size_t siz
     {
         const size_t offset = (word_iter * word_size);
         uint64_t     word   = 0;
-        PTRACE_PEEK(
-            reinterpret_cast<void*>(static_cast<uintptr_t>(  // NOLINT(performance-no-int-to-ptr)
-                addr + offset)),
-            word);
+        PTRACE_CALL(PTRACE_PEEKDATA, addr + offset, &word);
         std::memcpy(data.data() + offset, &word, word_size);
     }
 
@@ -491,10 +433,7 @@ PTraceSession::read_internal(size_t addr, std::vector<uint8_t>& data, size_t siz
     {
         const size_t offset    = (word_iter * word_size);
         uint64_t     last_word = 0;
-        PTRACE_PEEK(
-            reinterpret_cast<void*>(static_cast<uintptr_t>(  // NOLINT(performance-no-int-to-ptr)
-                addr + offset)),
-            last_word);
+        PTRACE_CALL(PTRACE_PEEKDATA, addr + offset, &last_word);
         std::memcpy(data.data() + offset, &last_word, remainder);
     }
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] ptrace read " << size << " bytes at " << addr;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.hpp
@@ -35,6 +35,7 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <variant>
 #include <vector>
 
 namespace rocprofiler
@@ -44,6 +45,7 @@ namespace rocattach
 class PTraceSession
 {
 public:
+    using ptrace_parameter_t = PTraceRunner::ptrace_parameter_t;
     explicit PTraceSession(int);
     ~PTraceSession();
 
@@ -77,6 +79,9 @@ public:
                                      void*              second);
 
 private:
+    rocattach_status_t ptrace_call(__ptrace_request   op,
+                                   ptrace_parameter_t addr,
+                                   ptrace_parameter_t data) const;
     rocattach_status_t start_signal_handler();
     rocattach_status_t stop_signal_handler();
     rocattach_status_t wait_for_breakpoint();
@@ -138,7 +143,7 @@ private:
     };
 
     static void ptrace_signal_handler_func(
-        int                                                 pid,
+        pid_t                                               pid,
         const std::shared_ptr<PTraceRunner>&                runner,
         std::atomic<ptrace_session_signal_handler_state_t>& state,
         std::atomic<rocattach_status_t>&                    error);
@@ -150,7 +155,7 @@ private:
 
     std::thread m_ptrace_signal_handler_thread;
 
-    const int                     m_pid = -1;
+    const pid_t                   m_pid = -1;
     std::shared_ptr<PTraceRunner> m_ptrace_runner;
 };
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.hpp
@@ -45,7 +45,6 @@ namespace rocattach
 class PTraceSession
 {
 public:
-    using ptrace_parameter_t = PTraceRunner::ptrace_parameter_t;
     explicit PTraceSession(int);
     ~PTraceSession();
 
@@ -144,7 +143,6 @@ private:
 
     static void ptrace_signal_handler_func(
         pid_t                                               pid,
-        const std::shared_ptr<PTraceRunner>&                runner,
         std::atomic<ptrace_session_signal_handler_state_t>& state,
         std::atomic<rocattach_status_t>&                    error);
 
@@ -155,8 +153,7 @@ private:
 
     std::thread m_ptrace_signal_handler_thread;
 
-    const pid_t                   m_pid = -1;
-    std::shared_ptr<PTraceRunner> m_ptrace_runner;
+    const pid_t m_pid = -1;
 };
 
 }  // namespace rocattach

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.hpp
@@ -139,7 +139,7 @@ private:
 
     static void ptrace_signal_handler_func(
         int                                                 pid,
-        std::shared_ptr<PTraceRunner>                       runner,
+        const std::shared_ptr<PTraceRunner>&                runner,
         std::atomic<ptrace_session_signal_handler_state_t>& state,
         std::atomic<rocattach_status_t>&                    error);
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,12 +22,15 @@
 
 #pragma once
 
+#include "ptrace_runner.hpp"
+
 #include <rocprofiler-sdk-rocattach/types.h>
 #include <rocprofiler-sdk/rocprofiler.h>
 
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -136,6 +139,7 @@ private:
 
     static void ptrace_signal_handler_func(
         int                                                 pid,
+        std::shared_ptr<PTraceRunner>                       runner,
         std::atomic<ptrace_session_signal_handler_state_t>& state,
         std::atomic<rocattach_status_t>&                    error);
 
@@ -146,7 +150,8 @@ private:
 
     std::thread m_ptrace_signal_handler_thread;
 
-    const int m_pid = -1;
+    const int                     m_pid = -1;
+    std::shared_ptr<PTraceRunner> m_ptrace_runner;
 };
 
 }  // namespace rocattach

--- a/projects/rocprofiler-sdk/tests/bin/attachment-test/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/bin/attachment-test/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# attachment-test application for testing rocprofv3_attach
+# attachment-test application for testing rocprof_attach
 #
 
 cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)

--- a/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
@@ -156,7 +156,7 @@ int
 main(int argc, char** argv)
 {
     // Install signal handler for SIGINT
-    std::signal(SIGINT, signal_handler);
+    std::signal(SIGWINCH, signal_handler);
 
     size_t nthreads{8};
     int    ndevices{0};

--- a/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
@@ -93,7 +93,7 @@ execute_kernels(const size_t tid, const size_t device_id)
     // Run kernels in a loop for a while
     {
         // compose string first to avoid multithreaded handling of cout << operator
-        std::stringstream msg;
+        auto msg = std::stringstream{};
         msg << "Starting kernel execution loop for thread " << tid << " on device " << device_id
             << "...\n";
         std::cout << msg.str();
@@ -155,7 +155,7 @@ execute_kernels(const size_t tid, const size_t device_id)
 
     {
         // compose string first to avoid multithreaded handling of cout << operator
-        std::stringstream msg;
+        auto msg = std::stringstream{};
         msg << "Kernel execution loop completed for thread " << tid << " on device " << device_id
             << "...\n";
         std::cout << msg.str();

--- a/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
@@ -24,11 +24,19 @@
 #include <rocprofiler-sdk-roctx/roctx.h>
 #include <unistd.h>
 #include <chrono>
+#include <csignal>
 #include <cstdlib>
 #include <iostream>
 #include <string>
 #include <thread>
 #include <vector>
+
+// Signal handler - handles signal without affecting execution
+void
+signal_handler(int signum)
+{
+    std::cout << "Attachment test process " << getpid() << " received signal " << signum << "\n";
+}
 
 /* Macro for checking GPU API return values */
 #define HIP_ASSERT(call)                                                                           \
@@ -147,6 +155,9 @@ execute_kernels(const size_t tid, const size_t device_id)
 int
 main(int argc, char** argv)
 {
+    // Install signal handler for SIGINT
+    std::signal(SIGINT, signal_handler);
+
     size_t nthreads{8};
     int    ndevices{0};
     for(int i = 1; i < argc; ++i)

--- a/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
@@ -27,16 +27,21 @@
 #include <csignal>
 #include <cstdlib>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <vector>
 
 // Signal handler - handles signal without affecting execution
+namespace
+{
+int signal_received = 0;
 void
 signal_handler(int signum)
 {
-    std::cout << "Attachment test process " << getpid() << " received signal " << signum << "\n";
+    signal_received = signum;
 }
+}  // namespace
 
 /* Macro for checking GPU API return values */
 #define HIP_ASSERT(call)                                                                           \
@@ -86,8 +91,13 @@ execute_kernels(const size_t tid, const size_t device_id)
     }
 
     // Run kernels in a loop for a while
-    std::cout << "Starting kernel execution loop for thread " << tid << " on device " << device_id
-              << "...\n";
+    {
+        // compose string first to avoid multithreaded handling of cout << operator
+        std::stringstream msg;
+        msg << "Starting kernel execution loop for thread " << tid << " on device " << device_id
+            << "...\n";
+        std::cout << msg.str();
+    }
     const int num_iterations = 30;
 
     for(int iter = 0; iter < num_iterations; ++iter)
@@ -143,8 +153,13 @@ execute_kernels(const size_t tid, const size_t device_id)
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
-    std::cout << "Kernel execution loop completed for thread " << tid << " on device " << device_id
-              << "...\n";
+    {
+        // compose string first to avoid multithreaded handling of cout << operator
+        std::stringstream msg;
+        msg << "Kernel execution loop completed for thread " << tid << " on device " << device_id
+            << "...\n";
+        std::cout << msg.str();
+    }
 
     HIP_ASSERT(hipStreamDestroy(stream));
     // Cleanup
@@ -191,7 +206,7 @@ main(int argc, char** argv)
     if(ndevices > device_count)
     {
         std::cout << "Using " << device_count << " HIP devices instead of the requested "
-                  << ndevices << "\n";
+                  << ndevices << std::endl;
         ndevices = device_count;
     }
 
@@ -205,6 +220,11 @@ main(int argc, char** argv)
     for(auto& itr : _threads)
         itr.join();
 
+    if(signal_received)
+    {
+        std::cout << "Attachment test process " << getpid() << " received signal "
+                  << signal_received << std::endl;
+    }
     std::cout << "Attachment test app finished" << std::endl;
 
     return 0;

--- a/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
@@ -206,7 +206,7 @@ main(int argc, char** argv)
     if(ndevices > device_count)
     {
         std::cout << "Using " << device_count << " HIP devices instead of the requested "
-                  << ndevices << std::endl;
+                  << ndevices << "\n";
         ndevices = device_count;
     }
 
@@ -223,7 +223,7 @@ main(int argc, char** argv)
     if(signal_received)
     {
         std::cout << "Attachment test process " << getpid() << " received signal "
-                  << signal_received << std::endl;
+                  << signal_received << "\n";
     }
     std::cout << "Attachment test app finished" << std::endl;
 

--- a/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
@@ -32,16 +32,18 @@
 #include <thread>
 #include <vector>
 
-// Signal handler - handles signal without affecting execution
 namespace
 {
-int signal_received = 0;
-void
-signal_handler(int signum)
+// required type for signal handlers
+volatile std::sig_atomic_t signal_received = 0;
+}  // namespace
+
+// signal handler - must have C linkage
+extern "C" void
+attachment_test_signal_handler(int signum)
 {
     signal_received = signum;
 }
-}  // namespace
 
 /* Macro for checking GPU API return values */
 #define HIP_ASSERT(call)                                                                           \
@@ -171,7 +173,7 @@ int
 main(int argc, char** argv)
 {
     // Install signal handler for SIGINT
-    std::signal(SIGWINCH, signal_handler);
+    std::signal(SIGWINCH, attachment_test_signal_handler);
 
     size_t nthreads{8};
     int    ndevices{0};

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -61,7 +61,7 @@ set_tests_properties(
                ENVIRONMENT
                "${rocattach-test-env}"
                PASS_REGULAR_EXPRESSION
-               "Test C tool \\(priority=0\\) is using rocprofiler-sdk v"
+               "Attachment test process [0-9]+ received signal 2"
                FAIL_REGULAR_EXPRESSION
                "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
                DISABLED

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -81,7 +81,7 @@ set_tests_properties(
                ENVIRONMENT
                "${rocattach-test-env}"
                PASS_REGULAR_EXPRESSION
-               "Attachment test process [0-9]+ received signal [0-9]+"
+               "Attachment test process [0-9]+ received signal 28"
                FAIL_REGULAR_EXPRESSION
                "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
                DISABLED

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -43,6 +43,11 @@ add_test(NAME rocattach-parallel-attach-test-execute
          COMMAND $<TARGET_FILE:rocattach-parallel-attach-test>
                  $<TARGET_FILE:attachment-test> $<TARGET_FILE:rocprofiler-sdk-c-tool>)
 
+add_test(
+    NAME rocattach-parallel-attach-test-signal-execute
+    COMMAND $<TARGET_FILE:rocattach-parallel-attach-test> $<TARGET_FILE:attachment-test>
+            $<TARGET_FILE:rocprofiler-sdk-c-tool> --send-signal)
+
 set(rocattach-test-env
     "${ROCPROFILER_MEMCHECK_PRELOAD_ENV}"
     "ROCP_TOOL_ATTACH=1"
@@ -54,6 +59,21 @@ set(rocattach-test-env
 
 set_tests_properties(
     rocattach-parallel-attach-test-execute
+    PROPERTIES TIMEOUT
+               45
+               LABELS
+               "integration-tests"
+               ENVIRONMENT
+               "${rocattach-test-env}"
+               PASS_REGULAR_EXPRESSION
+               "Test C tool \\(priority=0\\) is using rocprofiler-sdk v"
+               FAIL_REGULAR_EXPRESSION
+               "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
+               DISABLED
+               "${IS_DISABLED}")
+
+set_tests_properties(
+    rocattach-parallel-attach-test-signal-execute
     PROPERTIES TIMEOUT
                45
                LABELS

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -81,7 +81,7 @@ set_tests_properties(
                ENVIRONMENT
                "${rocattach-test-env}"
                PASS_REGULAR_EXPRESSION
-               "Attachment test process [0-9]+ received signal 2"
+               "Attachment test process [0-9]+ received signal [0-9]+"
                FAIL_REGULAR_EXPRESSION
                "${ROCPROFILER_DEFAULT_FAIL_REGEX}"
                DISABLED

--- a/projects/rocprofiler-sdk/tests/rocattach/main.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/main.cpp
@@ -52,7 +52,7 @@
 int
 main(int argc, char** argv)
 {
-    if(argc != 3)
+    if(argc < 3)
     {
         std::cout << "error: wrong number of arguments\n";
         return 1;
@@ -100,13 +100,20 @@ main(int argc, char** argv)
         ROCATTACH_CALL(rocattach_attach(pid2));
 
         // Send signal to child processes after attaching
-        if(kill(pid1, SIGINT) == -1)
+        if(argc >= 4)
         {
-            std::cout << "error: Failed to send signal to pid1\n";
-        }
-        if(kill(pid2, SIGINT) == -1)
-        {
-            std::cout << "error: Failed to send signal to pid2\n";
+            std::string signal_arg{argv[3]};
+            if(signal_arg == "--send-signal")
+            {
+                if(kill(pid1, SIGWINCH) == -1)
+                {
+                    std::cout << "error: Failed to send signal to pid1\n";
+                }
+                if(kill(pid2, SIGWINCH) == -1)
+                {
+                    std::cout << "error: Failed to send signal to pid2\n";
+                }
+            }
         }
 
         // Wait for child processes to continue executing

--- a/projects/rocprofiler-sdk/tests/rocattach/main.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/main.cpp
@@ -24,6 +24,7 @@
 #include <rocprofiler-sdk-rocattach/rocattach.h>
 #include <rocprofiler-sdk-rocattach/types.h>
 
+#include <signal.h>
 #include <stdlib.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -90,7 +91,7 @@ main(int argc, char** argv)
     }
     else
     {
-        // Wait a small amount of time for child processes to start executing
+        // Wait for child processes to exec
         std::this_thread::sleep_for(std::chrono::milliseconds(2500));
 
         setenv("ROCPROF_ATTACH_TOOL_LIBRARY", argv[2], true);
@@ -98,7 +99,17 @@ main(int argc, char** argv)
         ROCATTACH_CALL(rocattach_attach(pid1));
         ROCATTACH_CALL(rocattach_attach(pid2));
 
-        // Wait a small amount of time for child processes to continue executing
+        // Send signal to child processes after attaching
+        if(kill(pid1, SIGINT) == -1)
+        {
+            std::cout << "error: Failed to send signal to pid1\n";
+        }
+        if(kill(pid2, SIGINT) == -1)
+        {
+            std::cout << "error: Failed to send signal to pid2\n";
+        }
+
+        // Wait for child processes to continue executing
         std::this_thread::sleep_for(std::chrono::milliseconds(5000));
 
         ROCATTACH_CALL(rocattach_detach(pid1));

--- a/projects/rocprofiler-sdk/tests/rocattach/main.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/main.cpp
@@ -105,10 +105,12 @@ main(int argc, char** argv)
             std::string signal_arg{argv[3]};
             if(signal_arg == "--send-signal")
             {
+                std::cout << "Sending SIGWINCH to PID " << pid1;
                 if(kill(pid1, SIGWINCH) == -1)
                 {
                     std::cout << "error: Failed to send signal to pid1\n";
                 }
+                std::cout << "Sending SIGWINCH to PID " << pid2;
                 if(kill(pid2, SIGWINCH) == -1)
                 {
                     std::cout << "error: Failed to send signal to pid2\n";

--- a/projects/rocprofiler-sdk/tests/rocattach/main.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/main.cpp
@@ -36,6 +36,7 @@
 
 #define ROCATTACH_CALL(func)                                                                       \
     {                                                                                              \
+        std::cout << "starting call to " #func << std::endl;                                       \
         rocattach_status_t status = func;                                                          \
         if(status != ROCATTACH_STATUS_SUCCESS)                                                     \
         {                                                                                          \
@@ -45,7 +46,7 @@
         }                                                                                          \
         else                                                                                       \
         {                                                                                          \
-            std::cout << "call to " #func " successful " << std::endl;                             \
+            std::cout << "call to " #func " successful" << std::endl;                              \
         }                                                                                          \
     }
 
@@ -105,12 +106,12 @@ main(int argc, char** argv)
             std::string signal_arg{argv[3]};
             if(signal_arg == "--send-signal")
             {
-                std::cout << "Sending SIGWINCH to PID " << pid1;
+                std::cout << "Sending SIGWINCH to PID " << pid1 << "\n";
                 if(kill(pid1, SIGWINCH) == -1)
                 {
                     std::cout << "error: Failed to send signal to pid1\n";
                 }
-                std::cout << "Sending SIGWINCH to PID " << pid2;
+                std::cout << "Sending SIGWINCH to PID " << pid2 << "\n";
                 if(kill(pid2, SIGWINCH) == -1)
                 {
                     std::cout << "error: Failed to send signal to pid2\n";


### PR DESCRIPTION
- Reworks ptrace calls to originate from the same thread per target pid, as required

## Motivation

Crashes were observed when extraneous signals were sent to an attached target. Bug introduced in #1653

Prior to #1653, all ptrace operations were handled from a singleton thread in rocattach.cpp. This was changed in favor of re-entrancy support to allow the library to attach to multiple processes simultaneously. This particular detail was lost in the transition.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

ptrace session are tracked per thread ID, so all ptrace operations targetting a given PID must originate from the same thread.
This reworks ptrace operations into a new class called PTraceRunner which aims to be as similar to the original ptrace call as possible.

PTraceRunner is a simple single worker thread that handles ptrace operations serially with mutex and atomic mailbox. Each PTraceSession owns a single PTraceRunner that is shared between the main thread and the signal handler thread via shared_ptr.

Aside: ptrace is defined as `long ptrace (int op, ...)`. For consistency's sake, we choose to define it as `uint64_t ptrace(__ptrace_operation op, void* addr, void* data)`. Some changes are made in PTraceSession to enforce the stricter typing.

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Ran parallel-attach test and resized window during test to send extraneous signals (SIGWINCH).
@itrowbri has developed a test which provides a signal mid-attach to ensure this behavior in the future

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Logging indicated the extraneous signal was handled and sent to the target program.

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
