### PR TITLE
SWDEV-560359 [rdc] Add FPE guards

### DIFF
--- a/projects/rdc/rdc_libs/rdc/src/RdcCacheManagerImpl.cc
+++ b/projects/rdc/rdc_libs/rdc/src/RdcCacheManagerImpl.cc
@@ -462,6 +462,9 @@ rdc_status_t RdcCacheManagerImpl::rdc_job_get_stats(const char jobId[64],
 }
 
 void RdcCacheManagerImpl::set_average_summary(rdc_stats_summary_t& summary, uint32_t num_gpus) {
+  if (num_gpus == 0) {
+    return;
+  }
   summary.average = summary.average / num_gpus;
   summary.standard_deviation = summary.standard_deviation / num_gpus;
 }

--- a/projects/rdc/rdc_libs/rdc/src/RdcMetricFetcherImpl.cc
+++ b/projects/rdc/rdc_libs/rdc/src/RdcMetricFetcherImpl.cc
@@ -1062,7 +1062,7 @@ rdc_status_t RdcMetricFetcherImpl::fetch_gpu_partition_field_(uint32_t gpu_index
         return RDC_ST_OK;
       }
 
-      uint32_t chunk_size = vc / pCount;
+      uint32_t chunk_size = vc / (pCount > 0 ? pCount : 1);
       uint32_t start_idx = partIdx * chunk_size;
       uint32_t end_idx = start_idx + chunk_size;
 

--- a/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcRocpBase.cc
+++ b/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcRocpBase.cc
@@ -513,7 +513,7 @@ rdc_status_t RdcRocpBase::apply_field_transformation(
 
   switch (field) {
     case RDC_FI_PROF_GPU_UTIL_PERCENT:
-      output->dbl = raw_value / 100.0F;
+      output->dbl = raw_value / 100.0;
       break;
 
     case RDC_FI_PROF_OCC_ELAPSED: {
@@ -544,21 +544,24 @@ rdc_status_t RdcRocpBase::apply_field_transformation(
       }
       const std::string target_version = agents[agent_index].name;
       const bool isMI200 = (target_version.find("gfx90a") != std::string::npos);
+      const auto simd_count = agents[agent_index].simd_per_cu > 0 ? agents[agent_index].simd_per_cu : 1;
       if (isMI200) {
-        output->dbl = divided_dbl / (1024.0F / static_cast<double>(agents[agent_index].simd_per_cu));
+        output->dbl = divided_dbl / (1024.0 / simd_count);
       } else {  // Assume mi300
-        output->dbl = divided_dbl / (2048.0F / static_cast<double>(agents[agent_index].simd_per_cu));
+        output->dbl = divided_dbl / (2048.0 / simd_count);
       }
     } break;
 
     case RDC_FI_PROF_EVAL_FLOPS_32_PERCENT:
-    case RDC_FI_PROF_EVAL_FLOPS_64_PERCENT:
+    case RDC_FI_PROF_EVAL_FLOPS_64_PERCENT: {
       if (!is_eval_field) {
         RDC_LOG(RDC_ERROR, "Field expected to be in the eval_fields list but it isn't!");
         return RDC_ST_BAD_PARAMETER;
       }
-      output->dbl = divided_dbl / (256.0F / static_cast<double>(agents[agent_index].simd_per_cu));
+      const auto simd_count = agents[agent_index].simd_per_cu > 0 ? agents[agent_index].simd_per_cu : 1;
+      output->dbl = divided_dbl / (256.0 / simd_count);
       break;
+    }
 
     default:
       if (is_eval_field) {


### PR DESCRIPTION
`rdcd` in certain configurations fails with floating point exception. Likely div by zero.

This PR adds some guards to reduce them.