### PR TITLE
SWDEV-571782 - Ring the doorbell from host thread for OCL device enqueue with ROCr on Windows

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2769,11 +2769,11 @@ bool KernelBlitManager::runScheduler(uint64_t vqVM, hsa_queue_t* schedulerQueue,
   releaseArguments(parameters);
 
 #if defined(_WIN32)
-  // Ensure all scheduler kernel operations are visible before waking monitor thread
   std::atomic_thread_fence(std::memory_order_seq_cst);
   // Scheduler has enqueued a kernel, wake up the device queue monitor thread
   gpu().WakeupDeviceQueueMonitor();
-
+  // Wait for monitor thread to finish submitting all packets
+  gpu().WaitForMonitorCompletion();
 #endif  // _WIN32
 
   // Wait for the scheduler to finish all operations

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2767,6 +2767,12 @@ bool KernelBlitManager::runScheduler(uint64_t vqVM, hsa_queue_t* schedulerQueue,
     return false;
   }
   releaseArguments(parameters);
+
+#if defined(_WIN32)
+  // Scheduler has enqueued a kernel, wake up the device queue monitor thread
+  gpu().WakeupDeviceQueueMonitor();
+#endif  // _WIN32
+
   // Wait for the scheduler to finish all operations
   gpu().WaitCompleteSignal(sp->complete_signal);
 

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2769,9 +2769,7 @@ bool KernelBlitManager::runScheduler(uint64_t vqVM, hsa_queue_t* schedulerQueue,
   releaseArguments(parameters);
 
 #if defined(_WIN32)
-  std::atomic_thread_fence(std::memory_order_seq_cst);
-  // Scheduler has enqueued a kernel, wake up the device queue monitor thread
-  gpu().WakeupDeviceQueueMonitor();
+  gpu().addSchedulerEvent(sp->complete_signal);
 #endif  // _WIN32
 
   // Wait for the scheduler to finish all operations

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2769,8 +2769,11 @@ bool KernelBlitManager::runScheduler(uint64_t vqVM, hsa_queue_t* schedulerQueue,
   releaseArguments(parameters);
 
 #if defined(_WIN32)
+  // Ensure all scheduler kernel operations are visible before waking monitor thread
+  std::atomic_thread_fence(std::memory_order_seq_cst);
   // Scheduler has enqueued a kernel, wake up the device queue monitor thread
   gpu().WakeupDeviceQueueMonitor();
+
 #endif  // _WIN32
 
   // Wait for the scheduler to finish all operations

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2772,8 +2772,6 @@ bool KernelBlitManager::runScheduler(uint64_t vqVM, hsa_queue_t* schedulerQueue,
   std::atomic_thread_fence(std::memory_order_seq_cst);
   // Scheduler has enqueued a kernel, wake up the device queue monitor thread
   gpu().WakeupDeviceQueueMonitor();
-  // Wait for monitor thread to finish submitting all packets
-  gpu().WaitForMonitorCompletion();
 #endif  // _WIN32
 
   // Wait for the scheduler to finish all operations

--- a/projects/clr/rocclr/device/rocm/rocrctx.cpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.cpp
@@ -47,6 +47,7 @@ bool Hsa::LoadLib() {
   GET_ROCR_SYMBOL(hsa_queue_destroy)
   GET_ROCR_SYMBOL(hsa_queue_load_read_index_scacquire)
   GET_ROCR_SYMBOL(hsa_queue_load_read_index_relaxed)
+  GET_ROCR_SYMBOL(hsa_queue_load_write_index_scacquire)
   GET_ROCR_SYMBOL(hsa_queue_load_write_index_relaxed)
   GET_ROCR_SYMBOL(hsa_queue_add_write_index_screlease)
   GET_ROCR_SYMBOL(hsa_memory_register)

--- a/projects/clr/rocclr/device/rocm/rocrctx.hpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.hpp
@@ -55,6 +55,7 @@ struct RocrEntryPoints {
   decltype(hsa_queue_destroy)* hsa_queue_destroy_;
   decltype(hsa_queue_load_read_index_scacquire)* hsa_queue_load_read_index_scacquire_;
   decltype(hsa_queue_load_read_index_relaxed)* hsa_queue_load_read_index_relaxed_;
+  decltype(hsa_queue_load_write_index_scacquire)* hsa_queue_load_write_index_scacquire_;
   decltype(hsa_queue_load_write_index_relaxed)* hsa_queue_load_write_index_relaxed_;
   decltype(hsa_queue_add_write_index_screlease)* hsa_queue_add_write_index_screlease_;
   decltype(hsa_memory_register)* hsa_memory_register_;
@@ -201,6 +202,9 @@ class Hsa : public amd::AllStatic {
   }
   static uint64_t queue_load_read_index_relaxed(const hsa_queue_t* queue) {
     return ROCR_DYN(hsa_queue_load_read_index_relaxed)(queue);
+  }
+  static uint64_t queue_load_write_index_scacquire(const hsa_queue_t* queue) {
+    return ROCR_DYN(hsa_queue_load_write_index_scacquire)(queue);
   }
   static uint64_t queue_load_write_index_relaxed(const hsa_queue_t* queue) {
     return ROCR_DYN(hsa_queue_load_write_index_relaxed)(queue);

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1838,8 +1838,8 @@ VirtualGPU::~VirtualGPU() {
         deviceQueueMonitorThread_.join();
       }
     }
-    Hsa::queue_destroy(schedulerQueue_);
 #endif  // _WIN32
+    Hsa::queue_destroy(schedulerQueue_);
   }
 
   if (nullptr != virtualQueue_) {
@@ -3466,7 +3466,7 @@ bool VirtualGPU::createSchedulerParam() {
     }
 
 #if defined(_WIN32)
-    StartDeviceQueueMonitorThread(schedulerQueue_);
+    StartDeviceQueueMonitorThread();
 #endif  // _WIN32
     return true;
   }
@@ -3481,21 +3481,10 @@ bool VirtualGPU::createSchedulerParam() {
 
 // ================================================================================================
 #if defined(_WIN32)
-void VirtualGPU::StartDeviceQueueMonitorThread(hsa_queue_t* queue) {
-  if (queue == nullptr) {
-    LogError("StartDeviceQueueMonitorThread: queue is null");
-    return;
-  }
-  if (monitorThreadRunning_.load(std::memory_order_relaxed)) {
-    LogError("StartDeviceQueueMonitorThread: monitor thread already running");
-    return;
-  }
-
+void VirtualGPU::StartDeviceQueueMonitorThread() {
   monitorThreadRunning_.store(true, std::memory_order_relaxed);
 
   deviceQueueMonitorThread_ = std::thread([this]() {
-    ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE,
-            "Thread started to monitor scheduler queue: %p", schedulerQueue_);
 
     while (monitorThreadRunning_.load(std::memory_order_relaxed)) {
       // Wait for the monitor thread to wake up
@@ -3503,50 +3492,51 @@ void VirtualGPU::StartDeviceQueueMonitorThread(hsa_queue_t* queue) {
         std::unique_lock<std::mutex> lock(monitor_mutex_);
         monitor_cv_.wait(lock);
       }
-      ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE, "Monitor thread woke up");
 
-      if (!monitorThreadRunning_.load(std::memory_order_relaxed)) {
-        ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE, "Monitor thread terminated");
-        break;
-      }
+      std::atomic_thread_fence(std::memory_order_seq_cst);
+      // After wakeup, check the read index and write index
+      constexpr int kTotalIterations = 100;
+      int poll_iterations = 0;
 
-      if (schedulerQueue_ != nullptr) {
-        std::atomic_thread_fence(std::memory_order_seq_cst);
+      while (monitorThreadRunning_.load(std::memory_order_relaxed)) {
+        // Read queue indices with proper memory ordering
+        uint64_t read_index = Hsa::queue_load_read_index_scacquire(schedulerQueue_);
+        uint64_t write_index = Hsa::queue_load_write_index_scacquire(schedulerQueue_);
 
-        // After wakeup, poll for some time to check for new packets.
-        constexpr int kTotalIterations = 100;
-        int poll_iterations = 0;
-        uint64_t last_processed_write = 0;
+        if (write_index != read_index && write_index > 0) {
 
-        while (monitorThreadRunning_.load(std::memory_order_relaxed)) {
-          // Read queue indices with proper memory ordering
-          uint64_t read_index = Hsa::queue_load_read_index_scacquire(schedulerQueue_);
-          uint64_t write_index = Hsa::queue_load_write_index_scacquire(schedulerQueue_);
-          ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE, "Monitor thread read=%llu, write=%llu, last_processed=%llu",
-                  read_index, write_index, last_processed_write);
-
-          if (write_index > 0 && write_index > read_index && write_index > last_processed_write) {
-            ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE, "Processing new packets - write_index=%llu", write_index);
-
-            // Ring doorbell if there is new work
-            Hsa::signal_store_screlease(schedulerQueue_->doorbell_signal, write_index);
-            last_processed_write = write_index;
-            poll_iterations = 0;
-          } else {
-            // No new packets to process, wait for wakeup
-            if (++poll_iterations >= kTotalIterations) {
-              ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE, "No packets after %d polls, waiting for wakeup", poll_iterations);
-              break;
-            }
-            amd::Os::sleep(1);
+          // Ring doorbell if there is new work
+          Hsa::signal_store_screlease(schedulerQueue_->doorbell_signal, write_index - 1);
+          poll_iterations = 0;
+        } else {
+          // No new packets to process, wait for wakeup
+          if (++poll_iterations >= kTotalIterations) {
+            break;
           }
+          amd::Os::sleep(1);
         }
       }
     }
-
-    ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE,
-            "Monitor thread terminated for queue: %p", schedulerQueue_);
   });
+}
+
+void VirtualGPU::WaitForMonitorCompletion() {
+  const int kMaxWaitMs = 5000;
+  int elapsed_ms = 0;
+
+  while (elapsed_ms < kMaxWaitMs) {
+    uint64_t read_idx = Hsa::queue_load_read_index_scacquire(schedulerQueue_);
+    uint64_t write_idx = Hsa::queue_load_write_index_scacquire(schedulerQueue_);
+
+    if (read_idx >= write_idx && write_idx > 0) {
+      std::atomic_thread_fence(std::memory_order_seq_cst);
+      break;
+    }
+
+    amd::Os::sleep(1);
+    elapsed_ms++;
+  }
+  return;
 }
 #endif  // _WIN32
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -3517,7 +3517,7 @@ void VirtualGPU::startSchedulerQueueThread() {
                            }),
                     pendingSchedulerEvents_.end());
           has_active_events = !pendingSchedulerEvents_.empty();
-	}
+        }
       }
       // All scheduler completion signals completed, go back to wait
     }

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -3463,7 +3463,9 @@ bool VirtualGPU::createSchedulerParam() {
     }
 
 #if defined(_WIN32)
-    startSchedulerQueueThread();
+  if (!isSchedulerQueueThreadRunning()) {
+    std::call_once(scheduler_thread_init_, [this]() { startSchedulerQueueThread(); });
+  }
 #endif  // _WIN32
     return true;
   }
@@ -3492,7 +3494,8 @@ void VirtualGPU::startSchedulerQueueThread() {
       }
 
       // Actively monitor the scheduler queue while any sync event is pending.
-      while (!pendingSchedulerEvents_.empty() && isSchedulerQueueThreadRunning()) {
+      bool has_active_events = true;
+      while (has_active_events && isSchedulerQueueThreadRunning()) {
         uint64_t read_index = Hsa::queue_load_read_index_scacquire(schedulerQueue_);
         uint64_t write_index = Hsa::queue_load_write_index_scacquire(schedulerQueue_);
 
@@ -3510,10 +3513,11 @@ void VirtualGPU::startSchedulerQueueThread() {
             std::remove_if(pendingSchedulerEvents_.begin(),
                            pendingSchedulerEvents_.end(),
                            [](hsa_signal_t signal) {
-                             return Hsa::signal_load_relaxed(signal) == 0;
+                             return (Hsa::signal_load_relaxed(signal) == 0);
                            }),
                     pendingSchedulerEvents_.end());
-        }
+          has_active_events = !pendingSchedulerEvents_.empty();
+	}
       }
       // All scheduler completion signals completed, go back to wait
     }

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1737,11 +1737,8 @@ VirtualGPU::VirtualGPU(Device& device, bool profiling, bool cooperative,
       copy_command_type_(0),
       fence_state_(Device::CacheState::kCacheStateInvalid),
       fence_dirty_(false),
-      dedicated_queue_(dedicated_queue)
-#if defined(_WIN32)
-     ,monitorThreadRunning_(false)
-#endif
-     {
+      dedicated_queue_(dedicated_queue),
+      schedulerQueueThreadRunning_(false) {
   index_ = device.numOfVgpus_++;
   gpu_device_ = device.getBackendDevice();
   printfdbg_ = nullptr;
@@ -1828,14 +1825,14 @@ VirtualGPU::~VirtualGPU() {
   if (nullptr != schedulerQueue_) {
 #if defined(_WIN32)
     // Stop the monitor thread before destroying the queue
-    if (monitorThreadRunning_.load(std::memory_order_relaxed)) {
-      monitorThreadRunning_.store(false, std::memory_order_relaxed);
+    if (isSchedulerQueueThreadRunning()) {
+      schedulerQueueThreadRunning_.store(false, std::memory_order_relaxed);
       {
-        std::lock_guard<std::mutex> lock(monitor_mutex_);
-        monitor_cv_.notify_one();
+        std::lock_guard<std::mutex> lock(scheduler_mutex_);
+        scheduler_cv_.notify_one();
       }
-      if (deviceQueueMonitorThread_.joinable()) {
-        deviceQueueMonitorThread_.join();
+      if (schedulerQueueThread_.joinable()) {
+        schedulerQueueThread_.join();
       }
     }
 #endif  // _WIN32
@@ -3466,7 +3463,7 @@ bool VirtualGPU::createSchedulerParam() {
     }
 
 #if defined(_WIN32)
-    StartDeviceQueueMonitorThread();
+    startSchedulerQueueThread();
 #endif  // _WIN32
     return true;
   }
@@ -3479,38 +3476,49 @@ bool VirtualGPU::createSchedulerParam() {
   return false;
 }
 
-// ================================================================================================
-#if defined(_WIN32)
-void VirtualGPU::StartDeviceQueueMonitorThread() {
-  monitorThreadRunning_.store(true, std::memory_order_relaxed);
+void VirtualGPU::startSchedulerQueueThread() {
+  schedulerQueueThreadRunning_.store(true, std::memory_order_relaxed);
 
-  deviceQueueMonitorThread_ = std::thread([this]() {
+  schedulerQueueThread_ = std::thread([this]() {
+    while (isSchedulerQueueThreadRunning()) {
 
-    while (monitorThreadRunning_.load(std::memory_order_relaxed)) {
-      // Wait for the monitor thread to wake up
+      // Wait until scheduler events are added or thread termination
       {
-        std::unique_lock<std::mutex> lock(monitor_mutex_);
-        monitor_cv_.wait(lock);
+        std::unique_lock<std::mutex> lock(scheduler_mutex_);
+        scheduler_cv_.wait(lock, [this]() {
+          return !pendingSchedulerEvents_.empty() ||
+                 !isSchedulerQueueThreadRunning();
+        });
       }
-      // Ensure all scheduler kernel operations are visible
-      std::atomic_thread_fence(std::memory_order_seq_cst);
 
-      while (monitorThreadRunning_.load(std::memory_order_relaxed)) {
-        // Read queue indices with proper memory ordering
+      // Actively monitor the scheduler queue while any sync event is pending.
+      while (!pendingSchedulerEvents_.empty() && isSchedulerQueueThreadRunning()) {
         uint64_t read_index = Hsa::queue_load_read_index_scacquire(schedulerQueue_);
         uint64_t write_index = Hsa::queue_load_write_index_scacquire(schedulerQueue_);
-        if (write_index > read_index && write_index > 0) {
-          // Ring doorbell if there is new work
+
+        if (write_index > read_index) {
+          // New packets in the scheduler queue, ringing the doorbell
           Hsa::signal_store_screlease(schedulerQueue_->doorbell_signal, write_index - 1);
         } else {
-          // No new packets, yield the thread
+          // Yield briefly before re-checking.
           amd::Os::yield();
         }
+        // Check all scheduler completion signals, remove the completed ones
+        {
+          std::lock_guard<std::mutex> lock(scheduler_mutex_);
+          pendingSchedulerEvents_.erase(
+            std::remove_if(pendingSchedulerEvents_.begin(),
+                           pendingSchedulerEvents_.end(),
+                           [](hsa_signal_t signal) {
+                             return Hsa::signal_load_relaxed(signal) == 0;
+                           }),
+                    pendingSchedulerEvents_.end());
+        }
       }
+      // All scheduler completion signals completed, go back to wait
     }
   });
 }
-#endif  // _WIN32
 
 // ================================================================================================
 uint64_t VirtualGPU::getVQVirtualAddress() {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -3492,51 +3492,23 @@ void VirtualGPU::StartDeviceQueueMonitorThread() {
         std::unique_lock<std::mutex> lock(monitor_mutex_);
         monitor_cv_.wait(lock);
       }
-
+      // Ensure all scheduler kernel operations are visible
       std::atomic_thread_fence(std::memory_order_seq_cst);
-      // After wakeup, check the read index and write index
-      constexpr int kTotalIterations = 100;
-      int poll_iterations = 0;
 
       while (monitorThreadRunning_.load(std::memory_order_relaxed)) {
         // Read queue indices with proper memory ordering
         uint64_t read_index = Hsa::queue_load_read_index_scacquire(schedulerQueue_);
         uint64_t write_index = Hsa::queue_load_write_index_scacquire(schedulerQueue_);
-
-        if (write_index != read_index && write_index > 0) {
-
+        if (write_index > read_index && write_index > 0) {
           // Ring doorbell if there is new work
           Hsa::signal_store_screlease(schedulerQueue_->doorbell_signal, write_index - 1);
-          poll_iterations = 0;
         } else {
-          // No new packets to process, wait for wakeup
-          if (++poll_iterations >= kTotalIterations) {
-            break;
-          }
-          amd::Os::sleep(1);
+          // No new packets, yield the thread
+          amd::Os::yield();
         }
       }
     }
   });
-}
-
-void VirtualGPU::WaitForMonitorCompletion() {
-  const int kMaxWaitMs = 5000;
-  int elapsed_ms = 0;
-
-  while (elapsed_ms < kMaxWaitMs) {
-    uint64_t read_idx = Hsa::queue_load_read_index_scacquire(schedulerQueue_);
-    uint64_t write_idx = Hsa::queue_load_write_index_scacquire(schedulerQueue_);
-
-    if (read_idx >= write_idx && write_idx > 0) {
-      std::atomic_thread_fence(std::memory_order_seq_cst);
-      break;
-    }
-
-    amd::Os::sleep(1);
-    elapsed_ms++;
-  }
-  return;
 }
 #endif  // _WIN32
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1737,7 +1737,11 @@ VirtualGPU::VirtualGPU(Device& device, bool profiling, bool cooperative,
       copy_command_type_(0),
       fence_state_(Device::CacheState::kCacheStateInvalid),
       fence_dirty_(false),
-      dedicated_queue_(dedicated_queue) {
+      dedicated_queue_(dedicated_queue)
+#if defined(_WIN32)
+     ,deviceQueueMonitor_(nullptr)
+#endif
+     {
   index_ = device.numOfVgpus_++;
   gpu_device_ = device.getBackendDevice();
   printfdbg_ = nullptr;
@@ -1822,7 +1826,15 @@ VirtualGPU::~VirtualGPU() {
   delete printfdbg_;
 
   if (nullptr != schedulerQueue_) {
+#if defined(_WIN32)
+    // Stop the monitor thread before destroying the queue
+    if (deviceQueueMonitor_ != nullptr) {
+      deviceQueueMonitor_->Terminate();
+      delete deviceQueueMonitor_;
+      deviceQueueMonitor_ = nullptr;
+    }
     Hsa::queue_destroy(schedulerQueue_);
+#endif  // _WIN32
   }
 
   if (nullptr != virtualQueue_) {
@@ -3448,6 +3460,18 @@ bool VirtualGPU::createSchedulerParam() {
       break;
     }
 
+#if defined(_WIN32)
+    // Create and start the device queue monitor thread
+    deviceQueueMonitor_ = new DeviceQueueMonitor();
+    if (!deviceQueueMonitor_->Start(schedulerQueue_)) {
+      LogError("Failed to start monitor thread");
+      Hsa::queue_destroy(schedulerQueue_);
+      schedulerQueue_ = nullptr;
+      delete deviceQueueMonitor_;
+      deviceQueueMonitor_ = nullptr;
+      return false;
+    }
+#endif  // _WIN32
     return true;
   }
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -3483,11 +3483,14 @@ bool VirtualGPU::createSchedulerParam() {
 #if defined(_WIN32)
 void VirtualGPU::StartDeviceQueueMonitorThread(hsa_queue_t* queue) {
   if (queue == nullptr) {
+    LogError("StartDeviceQueueMonitorThread: queue is null");
     return;
   }
   if (monitorThreadRunning_.load(std::memory_order_relaxed)) {
+    LogError("StartDeviceQueueMonitorThread: monitor thread already running");
     return;
   }
+
   monitorThreadRunning_.store(true, std::memory_order_relaxed);
 
   deviceQueueMonitorThread_ = std::thread([this]() {
@@ -3500,22 +3503,43 @@ void VirtualGPU::StartDeviceQueueMonitorThread(hsa_queue_t* queue) {
         std::unique_lock<std::mutex> lock(monitor_mutex_);
         monitor_cv_.wait(lock);
       }
+      ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE, "Monitor thread woke up");
 
       if (!monitorThreadRunning_.load(std::memory_order_relaxed)) {
+        ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE, "Monitor thread terminated");
         break;
       }
 
       if (schedulerQueue_ != nullptr) {
-        uint64_t read_index = Hsa::queue_load_read_index_scacquire(schedulerQueue_);
-        uint64_t write_index = Hsa::queue_load_write_index_relaxed(schedulerQueue_);
+        std::atomic_thread_fence(std::memory_order_seq_cst);
 
-        // Process if there are pending packets in the scheduler queue
-        if (read_index != write_index) {
-          ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL,
-                  "Pending packets detected in scheduler queue, "
-                  "ring the doorbell - read=%lu, write=%lu", read_index, write_index);
-          // Ring the doorbell
-          Hsa::signal_store_screlease(schedulerQueue_->doorbell_signal, write_index - 1);
+        // After wakeup, poll for some time to check for new packets.
+        constexpr int kTotalIterations = 100;
+        int poll_iterations = 0;
+        uint64_t last_processed_write = 0;
+
+        while (monitorThreadRunning_.load(std::memory_order_relaxed)) {
+          // Read queue indices with proper memory ordering
+          uint64_t read_index = Hsa::queue_load_read_index_scacquire(schedulerQueue_);
+          uint64_t write_index = Hsa::queue_load_write_index_scacquire(schedulerQueue_);
+          ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE, "Monitor thread read=%llu, write=%llu, last_processed=%llu",
+                  read_index, write_index, last_processed_write);
+
+          if (write_index > 0 && write_index > read_index && write_index > last_processed_write) {
+            ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE, "Processing new packets - write_index=%llu", write_index);
+
+            // Ring doorbell if there is new work
+            Hsa::signal_store_screlease(schedulerQueue_->doorbell_signal, write_index);
+            last_processed_write = write_index;
+            poll_iterations = 0;
+          } else {
+            // No new packets to process, wait for wakeup
+            if (++poll_iterations >= kTotalIterations) {
+              ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE, "No packets after %d polls, waiting for wakeup", poll_iterations);
+              break;
+            }
+            amd::Os::sleep(1);
+          }
         }
       }
     }

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1739,7 +1739,7 @@ VirtualGPU::VirtualGPU(Device& device, bool profiling, bool cooperative,
       fence_dirty_(false),
       dedicated_queue_(dedicated_queue)
 #if defined(_WIN32)
-     ,deviceQueueMonitor_(nullptr)
+     ,monitorThreadRunning_(false)
 #endif
      {
   index_ = device.numOfVgpus_++;
@@ -1828,10 +1828,15 @@ VirtualGPU::~VirtualGPU() {
   if (nullptr != schedulerQueue_) {
 #if defined(_WIN32)
     // Stop the monitor thread before destroying the queue
-    if (deviceQueueMonitor_ != nullptr) {
-      deviceQueueMonitor_->Terminate();
-      delete deviceQueueMonitor_;
-      deviceQueueMonitor_ = nullptr;
+    if (monitorThreadRunning_.load(std::memory_order_relaxed)) {
+      monitorThreadRunning_.store(false, std::memory_order_relaxed);
+      {
+        std::lock_guard<std::mutex> lock(monitor_mutex_);
+        monitor_cv_.notify_one();
+      }
+      if (deviceQueueMonitorThread_.joinable()) {
+        deviceQueueMonitorThread_.join();
+      }
     }
     Hsa::queue_destroy(schedulerQueue_);
 #endif  // _WIN32
@@ -3461,16 +3466,7 @@ bool VirtualGPU::createSchedulerParam() {
     }
 
 #if defined(_WIN32)
-    // Create and start the device queue monitor thread
-    deviceQueueMonitor_ = new DeviceQueueMonitor();
-    if (!deviceQueueMonitor_->Start(schedulerQueue_)) {
-      LogError("Failed to start monitor thread");
-      Hsa::queue_destroy(schedulerQueue_);
-      schedulerQueue_ = nullptr;
-      delete deviceQueueMonitor_;
-      deviceQueueMonitor_ = nullptr;
-      return false;
-    }
+    StartDeviceQueueMonitorThread(schedulerQueue_);
 #endif  // _WIN32
     return true;
   }
@@ -3482,6 +3478,53 @@ bool VirtualGPU::createSchedulerParam() {
 
   return false;
 }
+
+// ================================================================================================
+#if defined(_WIN32)
+void VirtualGPU::StartDeviceQueueMonitorThread(hsa_queue_t* queue) {
+  if (queue == nullptr) {
+    return;
+  }
+  if (monitorThreadRunning_.load(std::memory_order_relaxed)) {
+    return;
+  }
+  monitorThreadRunning_.store(true, std::memory_order_relaxed);
+
+  deviceQueueMonitorThread_ = std::thread([this]() {
+    ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE,
+            "Thread started to monitor scheduler queue: %p", schedulerQueue_);
+
+    while (monitorThreadRunning_.load(std::memory_order_relaxed)) {
+      // Wait for the monitor thread to wake up
+      {
+        std::unique_lock<std::mutex> lock(monitor_mutex_);
+        monitor_cv_.wait(lock);
+      }
+
+      if (!monitorThreadRunning_.load(std::memory_order_relaxed)) {
+        break;
+      }
+
+      if (schedulerQueue_ != nullptr) {
+        uint64_t read_index = Hsa::queue_load_read_index_scacquire(schedulerQueue_);
+        uint64_t write_index = Hsa::queue_load_write_index_relaxed(schedulerQueue_);
+
+        // Process if there are pending packets in the scheduler queue
+        if (read_index != write_index) {
+          ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL,
+                  "Pending packets detected in scheduler queue, "
+                  "ring the doorbell - read=%lu, write=%lu", read_index, write_index);
+          // Ring the doorbell
+          Hsa::signal_store_screlease(schedulerQueue_->doorbell_signal, write_index - 1);
+        }
+      }
+    }
+
+    ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE,
+            "Monitor thread terminated for queue: %p", schedulerQueue_);
+  });
+}
+#endif  // _WIN32
 
 // ================================================================================================
 uint64_t VirtualGPU::getVQVirtualAddress() {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -3477,7 +3477,7 @@ bool VirtualGPU::createSchedulerParam() {
 }
 
 void VirtualGPU::startSchedulerQueueThread() {
-  schedulerQueueThreadRunning_.store(true, std::memory_order_relaxed);
+  schedulerQueueThreadRunning_.store(true, std::memory_order_release);
 
   schedulerQueueThread_ = std::thread([this]() {
     while (isSchedulerQueueThreadRunning()) {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -470,9 +470,6 @@ class VirtualGPU : public device::VirtualDevice {
   //! Wake up the device queue monitor thread when scheduler enqueues a kernel
   void WakeupDeviceQueueMonitor() {
     if (monitorThreadRunning_.load(std::memory_order_relaxed)) {
-      // Ensure all scheduler kernel operations are visible before wakeup
-      std::atomic_thread_fence(std::memory_order_seq_cst);
-
       {
         std::lock_guard<std::mutex> lock(monitor_mutex_);
         monitor_cv_.notify_one();
@@ -482,8 +479,6 @@ class VirtualGPU : public device::VirtualDevice {
 
   //! Start the device queue monitor thread on first use
   void StartDeviceQueueMonitorThread();
-  //! Wait for the monitor thread to finish processing all enqueued packets
-  void WaitForMonitorCompletion();
 #endif  // _WIN32
 
   //! Analyzes a crashed AQL queue to find a broken AQL packet

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -644,6 +644,7 @@ class VirtualGPU : public device::VirtualDevice {
   std::atomic<bool> schedulerQueueThreadRunning_;     //!< Flag to indicate if the thread is running
   std::mutex scheduler_mutex_;                        //!< Lock to synchronize scheduler thread
   std::condition_variable scheduler_cv_;              //!< Condition to wake scheduler thread
+  std::once_flag scheduler_thread_init_;              //!< Ensures thread is initialized exactly once
   std::vector<hsa_signal_t> pendingSchedulerEvents_;  //!< Pending scheduler completion signals
 
   HwQueueTracker barriers_;  //!< Tracks active barriers in ROCr

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -466,20 +466,23 @@ class VirtualGPU : public device::VirtualDevice {
   void HiddenHeapInit();
   uint64_t getQueueID();
 
-#if defined(_WIN32)
-  //! Wake up the device queue monitor thread when scheduler enqueues a kernel
-  void WakeupDeviceQueueMonitor() {
-    if (monitorThreadRunning_.load(std::memory_order_relaxed)) {
-      {
-        std::lock_guard<std::mutex> lock(monitor_mutex_);
-        monitor_cv_.notify_one();
-      }
+  //! Add completion signal to the scheduler queue thread's event list.
+  //! Wakes the scheduler queue thread if its sleeping.
+  void addSchedulerEvent(hsa_signal_t signal) {
+    {
+      std::lock_guard<std::mutex> lock(scheduler_mutex_);
+      pendingSchedulerEvents_.push_back(signal);
     }
+    scheduler_cv_.notify_one();
   }
 
-  //! Start the device queue monitor thread on first use
-  void StartDeviceQueueMonitorThread();
-#endif  // _WIN32
+  //! Returns true if the scheduler queue thread is running
+  bool isSchedulerQueueThreadRunning() const {
+    return schedulerQueueThreadRunning_.load(std::memory_order_relaxed);
+  }
+
+  //! Start the scheduler queue thread on first use
+  void startSchedulerQueueThread();
 
   //! Analyzes a crashed AQL queue to find a broken AQL packet
   void AnalyzeAqlQueue() const;
@@ -637,12 +640,11 @@ class VirtualGPU : public device::VirtualDevice {
 
   hsa_queue_t* schedulerQueue_;
 
-#if defined(_WIN32)
-  std::thread deviceQueueMonitorThread_;   //!< Monitor thread for scheduler queue
-  std::atomic<bool> monitorThreadRunning_; //!< Thread running flag
-  std::mutex monitor_mutex_;               //!< Lock to synchronize monitor thread
-  std::condition_variable monitor_cv_;     //!< Condition to wake monitor thread
-#endif  // _WIN32
+  std::thread schedulerQueueThread_;                  //!< Host thread that monitors the scheduler queue
+  std::atomic<bool> schedulerQueueThreadRunning_;     //!< Flag to indicate if the thread is running
+  std::mutex scheduler_mutex_;                        //!< Lock to synchronize scheduler thread
+  std::condition_variable scheduler_cv_;              //!< Condition to wake scheduler thread
+  std::vector<hsa_signal_t> pendingSchedulerEvents_;  //!< Pending scheduler completion signals
 
   HwQueueTracker barriers_;  //!< Tracks active barriers in ROCr
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -470,8 +470,6 @@ class VirtualGPU : public device::VirtualDevice {
   //! Wake up the device queue monitor thread when scheduler enqueues a kernel
   void WakeupDeviceQueueMonitor() {
     if (monitorThreadRunning_.load(std::memory_order_relaxed)) {
-      ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE,
-              "Waking up device queue monitor thread for queue: %p", schedulerQueue_);
       // Ensure all scheduler kernel operations are visible before wakeup
       std::atomic_thread_fence(std::memory_order_seq_cst);
 
@@ -479,16 +477,13 @@ class VirtualGPU : public device::VirtualDevice {
         std::lock_guard<std::mutex> lock(monitor_mutex_);
         monitor_cv_.notify_one();
       }
-      ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE,
-        "Notification sent to wake up monitor thread for queue: %p", schedulerQueue_);
-    } else {
-      ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE,
-              "Monitor thread not running, cannot wake up for queue: %p", schedulerQueue_);
     }
   }
 
   //! Start the device queue monitor thread on first use
-  void StartDeviceQueueMonitorThread(hsa_queue_t* queue);
+  void StartDeviceQueueMonitorThread();
+  //! Wait for the monitor thread to finish processing all enqueued packets
+  void WaitForMonitorCompletion();
 #endif  // _WIN32
 
   //! Analyzes a crashed AQL queue to find a broken AQL packet

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -469,8 +469,21 @@ class VirtualGPU : public device::VirtualDevice {
 #if defined(_WIN32)
   //! Wake up the device queue monitor thread when scheduler enqueues a kernel
   void WakeupDeviceQueueMonitor() {
-    if (monitorThreadRunning_) {
-      monitor_cv_.notify_one();
+    if (monitorThreadRunning_.load(std::memory_order_relaxed)) {
+      ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE,
+              "Waking up device queue monitor thread for queue: %p", schedulerQueue_);
+      // Ensure all scheduler kernel operations are visible before wakeup
+      std::atomic_thread_fence(std::memory_order_seq_cst);
+
+      {
+        std::lock_guard<std::mutex> lock(monitor_mutex_);
+        monitor_cv_.notify_one();
+      }
+      ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE,
+        "Notification sent to wake up monitor thread for queue: %p", schedulerQueue_);
+    } else {
+      ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE,
+              "Monitor thread not running, cannot wake up for queue: %p", schedulerQueue_);
     }
   }
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -467,7 +467,7 @@ class VirtualGPU : public device::VirtualDevice {
   uint64_t getQueueID();
 
   //! Add completion signal to the scheduler queue thread's event list.
-  //! Wakes the scheduler queue thread if its sleeping.
+  //! Wakes the scheduler queue thread if it's sleeping.
   void addSchedulerEvent(hsa_signal_t signal) {
     {
       std::lock_guard<std::mutex> lock(scheduler_mutex_);

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -462,6 +462,15 @@ class VirtualGPU : public device::VirtualDevice {
   void HiddenHeapInit();
   uint64_t getQueueID();
 
+#if defined(_WIN32)
+  //! Wake up the device queue monitor thread when scheduler enqueues a kernel
+  void WakeupDeviceQueueMonitor() {
+    if (deviceQueueMonitor_ != nullptr) {
+      deviceQueueMonitor_->WakeUp();
+    }
+  }
+#endif  // _WIN32
+
   //! Analyzes a crashed AQL queue to find a broken AQL packet
   void AnalyzeAqlQueue() const;
   bool ForceIrq() const { return force_irq_; }
@@ -617,6 +626,100 @@ class VirtualGPU : public device::VirtualDevice {
   uint schedulerThreads_;      //!< The number of scheduler threads
 
   hsa_queue_t* schedulerQueue_;
+
+#if defined(_WIN32)
+  //! Thread to monitor the scheduler queue when a kernel is enqueued
+  class DeviceQueueMonitor : public amd::Thread {
+   public:
+    DeviceQueueMonitor()
+        : amd::Thread("DeviceQueue Monitor", CQ_THREAD_STACK_SIZE),
+          running_(false),
+          queue_(nullptr) {}
+          //wakeup_signal_(),
+          //monitor_lock_() {}
+
+    ~DeviceQueueMonitor() {
+      Terminate();
+    }
+
+    //! Initialize and start the monitor thread
+    bool Start(hsa_queue_t* queue) {
+      if (queue == nullptr) {
+        return false;
+      }
+      queue_ = queue;
+      running_ = true;
+      return amd::Thread::start(this);
+    }
+
+    //! Wakes up the monitor thread to check the scheduler queue
+    void WakeUp() {
+      amd::ScopedLock lock(monitor_lock_);
+      monitor_lock_.notify();
+    }
+
+    //! Stop the monitor thread
+    void Terminate() {
+      if (running_) {
+        running_ = false;
+        WakeUp();
+        if (Os::isThreadAlive(*this)) {
+          // Wait for the thread to finish
+          while (state() < Thread::FINISHED) {
+            Os::yield();
+          }
+        }
+      }
+    }
+
+    //! The monitor thread entry point
+    void run(void* data) override {
+      VirtualGPU* vgpu = static_cast<VirtualGPU*>(data);
+      MonitorQueue(vgpu);
+    }
+
+   private:
+    //! Loop to monitor the scheduler queue
+    void MonitorQueue(VirtualGPU* vgpu) {
+      ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE,
+              "Thread started to monitor scheduler queue: %p", queue_);
+
+      while (running_) {
+        // Wait for the monitor thread to wake up
+        {
+          amd::ScopedLock lock(monitor_lock_);
+          monitor_lock_.wait();
+        }
+        if (!running_) {
+          break;
+        }
+
+        if (queue_ != nullptr) {
+          uint64_t read_index = Hsa::queue_load_read_index_scacquire(queue_);
+          uint64_t write_index = Hsa::queue_load_write_index_relaxed(queue_);
+
+          // Process if there are pending packets in the scheduler queue
+          if (read_index != write_index) {
+            ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL,
+                    "Pending packets detected in scheduler queue, "
+                    "ring the doorbell - read=%lu, write=%lu", read_index, write_index);
+            // Ring the doorbell
+            Hsa::signal_store_screlease(queue_->doorbell_signal, write_index - 1);
+          }
+        }
+      }
+
+      ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE,
+              "Monitor thread terminated for queue: %p", queue_);
+    }
+
+    std::atomic<bool> running_;   //!< Flag to control thread execution
+    hsa_queue_t* queue_;          //!< The scheduler queue to monitor
+    amd::Monitor monitor_lock_;   //!< Lock to synchronize monitor thread
+  };
+
+  DeviceQueueMonitor* deviceQueueMonitor_;  //!< Windows-specific device queue monitor
+#endif  // _WIN32
 
   HwQueueTracker barriers_;  //!< Tracks active barriers in ROCr
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -29,7 +29,11 @@
 #include "rocsched.hpp"
 #include "device/device.hpp"
 #include "os/os.hpp"
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
 #include <stack>
+#include <thread>
 
 namespace amd::roc {
 class Device;
@@ -465,10 +469,13 @@ class VirtualGPU : public device::VirtualDevice {
 #if defined(_WIN32)
   //! Wake up the device queue monitor thread when scheduler enqueues a kernel
   void WakeupDeviceQueueMonitor() {
-    if (deviceQueueMonitor_ != nullptr) {
-      deviceQueueMonitor_->WakeUp();
+    if (monitorThreadRunning_) {
+      monitor_cv_.notify_one();
     }
   }
+
+  //! Start the device queue monitor thread on first use
+  void StartDeviceQueueMonitorThread(hsa_queue_t* queue);
 #endif  // _WIN32
 
   //! Analyzes a crashed AQL queue to find a broken AQL packet
@@ -628,97 +635,10 @@ class VirtualGPU : public device::VirtualDevice {
   hsa_queue_t* schedulerQueue_;
 
 #if defined(_WIN32)
-  //! Thread to monitor the scheduler queue when a kernel is enqueued
-  class DeviceQueueMonitor : public amd::Thread {
-   public:
-    DeviceQueueMonitor()
-        : amd::Thread("DeviceQueue Monitor", CQ_THREAD_STACK_SIZE),
-          running_(false),
-          queue_(nullptr) {}
-          //wakeup_signal_(),
-          //monitor_lock_() {}
-
-    ~DeviceQueueMonitor() {
-      Terminate();
-    }
-
-    //! Initialize and start the monitor thread
-    bool Start(hsa_queue_t* queue) {
-      if (queue == nullptr) {
-        return false;
-      }
-      queue_ = queue;
-      running_ = true;
-      return amd::Thread::start(this);
-    }
-
-    //! Wakes up the monitor thread to check the scheduler queue
-    void WakeUp() {
-      amd::ScopedLock lock(monitor_lock_);
-      monitor_lock_.notify();
-    }
-
-    //! Stop the monitor thread
-    void Terminate() {
-      if (running_) {
-        running_ = false;
-        WakeUp();
-        if (Os::isThreadAlive(*this)) {
-          // Wait for the thread to finish
-          while (state() < Thread::FINISHED) {
-            Os::yield();
-          }
-        }
-      }
-    }
-
-    //! The monitor thread entry point
-    void run(void* data) override {
-      VirtualGPU* vgpu = static_cast<VirtualGPU*>(data);
-      MonitorQueue(vgpu);
-    }
-
-   private:
-    //! Loop to monitor the scheduler queue
-    void MonitorQueue(VirtualGPU* vgpu) {
-      ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE,
-              "Thread started to monitor scheduler queue: %p", queue_);
-
-      while (running_) {
-        // Wait for the monitor thread to wake up
-        {
-          amd::ScopedLock lock(monitor_lock_);
-          monitor_lock_.wait();
-        }
-        if (!running_) {
-          break;
-        }
-
-        if (queue_ != nullptr) {
-          uint64_t read_index = Hsa::queue_load_read_index_scacquire(queue_);
-          uint64_t write_index = Hsa::queue_load_write_index_relaxed(queue_);
-
-          // Process if there are pending packets in the scheduler queue
-          if (read_index != write_index) {
-            ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL,
-                    "Pending packets detected in scheduler queue, "
-                    "ring the doorbell - read=%lu, write=%lu", read_index, write_index);
-            // Ring the doorbell
-            Hsa::signal_store_screlease(queue_->doorbell_signal, write_index - 1);
-          }
-        }
-      }
-
-      ClPrint(amd::LOG_DEBUG, amd::LOG_QUEUE,
-              "Monitor thread terminated for queue: %p", queue_);
-    }
-
-    std::atomic<bool> running_;   //!< Flag to control thread execution
-    hsa_queue_t* queue_;          //!< The scheduler queue to monitor
-    amd::Monitor monitor_lock_;   //!< Lock to synchronize monitor thread
-  };
-
-  DeviceQueueMonitor* deviceQueueMonitor_;  //!< Windows-specific device queue monitor
+  std::thread deviceQueueMonitorThread_;   //!< Monitor thread for scheduler queue
+  std::atomic<bool> monitorThreadRunning_; //!< Thread running flag
+  std::mutex monitor_mutex_;               //!< Lock to synchronize monitor thread
+  std::condition_variable monitor_cv_;     //!< Condition to wake monitor thread
 #endif  // _WIN32
 
   HwQueueTracker barriers_;  //!< Tracks active barriers in ROCr


### PR DESCRIPTION
## Motivation

ROCr On Windows

Creates a new thread which rings the doorbell from host side on behalf of a device when device enqueue happens

## Technical Details

A new thread on host is created and when the scheduler kernel dispatches a child kernel from the device, it reads the packets and rings the doorbell on behalf of the device.

## JIRA ID

Implements SWDEV-571782

## Test Plan

Verified with the existing OCL dynamic tests for device enqueue with ROCr on Windows

## Test Result

Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
