### PR TITLE
[SWDEV-573565] Fix amd-smi metric JSON output under watch mode

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -1754,16 +1754,12 @@ class AMDSMICommands():
                 # Reload original gpus
                 args.gpu = stored_gpus
 
-                # Print multiple device output
-                if not self.logger.is_json_format():
-                    self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
+                # Print multiple device output for all formats
+                self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
 
                 # Add output to total watch output and clear multiple device output
                 if watching_output:
                     self.logger.store_watch_output(multiple_device_enabled=True)
-
-                    # Flush the watching output
-                    self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
 
                 return
             elif len(args.gpu) == 1:
@@ -2789,8 +2785,8 @@ class AMDSMICommands():
             self.logger.store_multiple_device_output()
             return # Skip printing when there are multiple devices
 
-        if not self.logger.is_json_format():
-            self.logger.print_output(watching_output=watching_output)
+        # Print output for all formats
+        self.logger.print_output(watching_output=watching_output)
 
         if watching_output: # End of single gpu add to watch_output
             self.logger.store_watch_output(multiple_device_enabled=False)

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -1754,8 +1754,9 @@ class AMDSMICommands():
                 # Reload original gpus
                 args.gpu = stored_gpus
 
-                # Print multiple device output for all formats
-                self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
+                # Print multiple device output
+                if not self.logger.is_json_format() or watching_output:
+                    self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
 
                 # Add output to total watch output and clear multiple device output
                 if watching_output:


### PR DESCRIPTION
## Motivation

Fixes https://github.com/ROCm/amdsmi/issues/168

For commands such as `amd-smi metric -w 1 --json`, there was no output in watch mode for json output
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

- Output was not being printed with json output
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Tested `amd-smi metric -w 1 --json` has output:
```
(.venv) rocm@rocm-HP-Z2-Mini-G1a-Workstation-Desktop-PC:~/darren$ amd-smi metric -w 1 --json
'CTRL' + 'C' to stop watching output:
[
    {
        "timestamp": 1769014607,
        "gpu": 0,
        "usage": "N/A",
        "power": {
            "socket_power": "N/A",
            "gfx_voltage": "N/A",
            "soc_voltage": "N/A",
            "mem_voltage": "N/A",
            "throttle_status": "N/A",
            "power_management": "N/A"
        },
        "clock": {
            "gfx_0": {
                "clk": "N/A",
                "min_clk": "N/A",
                "max_clk": "N/A",
                "clk_locked": "N/A",
                "deep_sleep": "N/A"
            },
            "gfx_1": {
                "clk": "N/A",
                "min_clk": "N/A",
                "max_clk": "N/A",
                "clk_locked": "N/A",
                "deep_sleep": "N/A"
            },
            "gfx_2": {
                "clk": "N/A",
                "min_clk": "N/A",
                "max_clk": "N/A",
                "clk_locked": "N/A",
                "deep_sleep": "N/A"
            },
# Continued
```
<!-- Explain any relevant testing done to verify this PR. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
