### PR TITLE
[ROCM-1036] Dynamic fan support detection in set -h

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -945,6 +945,35 @@ class AMDSMIHelpers():
         return value
 
 
+    def get_fan_support(self):
+        """Check if fan control is supported on the first device.
+
+        Returns:
+            str: "0-255 or 0-100%%" if fan control is supported, "N/A" otherwise
+        """
+        device_handles = amdsmi_interface.amdsmi_get_processor_handles()
+        for dev in device_handles:
+            try:
+                # Try to get both fan speed and max fan speed
+                # If both succeed, fan control is supported
+                _ = amdsmi_interface.amdsmi_get_gpu_fan_speed(dev, 0)
+                _ = amdsmi_interface.amdsmi_get_gpu_fan_speed_max(dev, 0)
+                # Fan control is supported on this device
+                return "0-255 or 0-100%%"
+            except amdsmi_interface.AmdSmiLibraryException as e:
+                logging.debug(f"AMDSMIHelpers.get_fan_support - Unable to get fan info for device {dev}: {str(e)}")
+                if e.err_code == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED:
+                    logging.debug(f"AMDSMIHelpers.get_fan_support - Device {dev} does not support fan control")
+                    return "N/A"
+                return "N/A"
+            except Exception as e:
+                logging.debug(f"AMDSMIHelpers.get_fan_support - Unexpected error occurred --> Unable to get fan info for device {dev}: {str(e)}")
+                return "N/A"
+            # Only check the first device (socket device, never partition)
+            break
+        return "N/A"
+
+
     def get_soc_pstates(self):
         device_handles = amdsmi_interface.amdsmi_get_processor_handles()
         soc_pstate_profile_list = []

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -1352,7 +1352,8 @@ class AMDSMIParser(argparse.ArgumentParser):
         # Help text for Arguments only on BM platforms
         if self.helpers.is_amdgpu_initialized():
             if self.helpers.is_baremetal():
-                set_fan_help = "Set GPU fan speed (0-255 or 0-100%%)"
+                fan_support = self.helpers.get_fan_support()
+                set_fan_help = f"Set GPU fan speed ({fan_support})"
                 perf_level_help_choices_str = ", ".join(self.helpers.get_perf_levels()[0][0:-1])
                 set_perf_level_help = f"Set one of the following performance levels:\n\t{perf_level_help_choices_str}"
                 power_profile_choices_str = ", ".join(self.helpers.get_power_profiles()[0:-1])


### PR DESCRIPTION
Show "N/A" for ASICs without fan support instead of "0-255 or 0-100%" in amd-smi set -h help text.

## Motivation

set option for fan speed showed in help but does not support when executed

## Technical Details

We need to update the amd-smi set -h output so that, for ASICs without fan support, the amd-smi set -h help text shows N/A instead of the current 0–255 or 0–100% ranges.

For ASICs with fan support, we should continue showing the recommended input ranges.

Implementation approach:

Iterate over all devices and check the first device’s fan capability, since the first device is always a socket device (never a partition).

If amdsmi_get_gpu_fan_speed() and amdsmi_get_gpu_fan_speed_max() both return success, treat the ASIC as supporting fans; otherwise treat it as not supported.

Based on that, conditionally populate the fan-related fields in the amd-smi set -h output.

## JIRA ID
ROCM-1036
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
MI3x: Should display N/A for fan-related options.
Navi2x / Navi3x: Should display the normal fan range inputs.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
NAVI3x: 
<img width="569" height="218" alt="image" src="https://github.com/user-attachments/assets/34a452ab-4994-459c-8077-c3c0b864ceb2" />
MI308X:
<img width="958" height="535" alt="Screenshot 2026-01-21 181448" src="https://github.com/user-attachments/assets/f65154f3-7735-451a-8efd-b9347fbd760f" />

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
