### PR TITLE
Fix for pntr attri query from a peer device

### DIFF
--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -3602,6 +3602,7 @@ hipError_t ihipPointerGetAttributes(void* data, hipPointer_attribute attribute,
     }
     case HIP_POINTER_ATTRIBUTE_DEVICE_POINTER: {
       if (memObj) {
+        amd::Device* currentDevice = hip::getCurrentDevice()->devices()[0];
         device::Memory* devMem = memObj->getDeviceMemory(*hip::getCurrentDevice()->devices()[0]);
 
         // getDeviceMemory can fail, hence validate the sanity of the mem obtained
@@ -3610,6 +3611,17 @@ hipError_t ihipPointerGetAttributes(void* data, hipPointer_attribute attribute,
                "getDeviceMemory for ptr failed : %p", ptr);
           return hipErrorMemoryAllocation;
         }
+
+        // Check if this is a cross-device access without peer access enabled
+        const std::vector<amd::Device*>& memDevices = memObj->getContext().devices();
+        if (memDevices.size() == 1 && memDevices[0] != currentDevice) {
+          device::Memory* origDevMem = memObj->getDeviceMemory(*memDevices[0]);
+          if (origDevMem != nullptr && !origDevMem->getAllowedPeerAccess()) {
+            *reinterpret_cast<hipDeviceptr_t*>(data) = nullptr;
+            return hipErrorInvalidValue;
+          }
+        }
+
         *reinterpret_cast<hipDeviceptr_t*>(data) =
             reinterpret_cast<hipDeviceptr_t*>(devMem->virtualAddress() + offset);
       } else {

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -3603,7 +3603,7 @@ hipError_t ihipPointerGetAttributes(void* data, hipPointer_attribute attribute,
     case HIP_POINTER_ATTRIBUTE_DEVICE_POINTER: {
       if (memObj) {
         amd::Device* currentDevice = hip::getCurrentDevice()->devices()[0];
-        device::Memory* devMem = memObj->getDeviceMemory(*hip::getCurrentDevice()->devices()[0]);
+        device::Memory* devMem = memObj->getDeviceMemory(*currentDevice);
 
         // getDeviceMemory can fail, hence validate the sanity of the mem obtained
         if (nullptr == devMem) {
@@ -3617,7 +3617,6 @@ hipError_t ihipPointerGetAttributes(void* data, hipPointer_attribute attribute,
         if (memDevices.size() == 1 && memDevices[0] != currentDevice) {
           device::Memory* origDevMem = memObj->getDeviceMemory(*memDevices[0]);
           if (origDevMem != nullptr && !origDevMem->getAllowedPeerAccess()) {
-            *reinterpret_cast<hipDeviceptr_t*>(data) = nullptr;
             return hipErrorInvalidValue;
           }
         }


### PR DESCRIPTION
Segmentation fault using a memory ptr where the peer access is not set correctly

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Pointer query for a peer device where the peer access is disabled should return an error 

<!-- Explain the changes along with any relevant GitHub links. -->

SWDEV-577116

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

HIP tests

<!-- Explain any relevant testing done to verify this PR. -->

PSDB

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
