### PR TITLE
rocr: Fix use-after-free during hsa_shut_down()

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -2464,14 +2464,12 @@ void Runtime::Unload() {
   asyncExceptions_.reset();
 
   if (vm_fault_signal_ != nullptr) {
-    vm_fault_signal_->DestroySignal();
     vm_fault_signal_.reset();
   }
   
   vm_fault_event_.reset();
 
   if (hw_exception_signal_ != nullptr) {
-    hw_exception_signal_->DestroySignal();
     hw_exception_signal_.reset();
   }
   


### PR DESCRIPTION
Remove the redundant DestroySignal() calls for vm_fault_signal_ and hw_exception_signal_, since the unique_ptr's SignalDeleter already calls DestroySignal() when reset() is invoked.

