### PR TITLE
ROCM-1494 - Reduce stream verification overhead

### DIFF
--- a/projects/clr/hipamd/src/hip_stream.cpp
+++ b/projects/clr/hipamd/src/hip_stream.cpp
@@ -115,17 +115,15 @@ void Stream::ReleaseCaptureGraph() {
 int Stream::DeviceId() const { return device_->deviceId(); }
 
 // ================================================================================================
-int Stream::DeviceId(const hipStream_t hStream) {
-  // Copying locally into non-const variable just to get const away
-  hipStream_t inputStream = hStream;
-  if (!hip::isValid(inputStream)) {
-    // return invalid device id
-    return -1;
+int Stream::DeviceId(hipStream_t hStream) {
+  assert(hip::isValid(hStream) && "Stream must be valid to get deviceId"); 
+
+  // Legacy or null stream case
+  if (hStream == nullptr || hStream == hipStreamLegacy) {
+    return ihipGetDevice();
   }
-  bool isNullOrLegacyStream = (hStream == nullptr || hStream == hipStreamLegacy);
-  hip::Stream* s = reinterpret_cast<hip::Stream*>(inputStream);
-  int deviceId = isNullOrLegacyStream ? ihipGetDevice() : s->DeviceId();
-  assert(deviceId >= 0 && deviceId < static_cast<int>(g_devices.size()));
+  int deviceId = reinterpret_cast<hip::Stream*>(hStream)->DeviceId();
+  assert(deviceId >= 0 && deviceId < static_cast<int>(g_devices.size()) && "Invalid deviceId has been returned");
   return deviceId;
 }
 


### PR DESCRIPTION
## Motivation

This change speeds up the hipamd layer in the CLR stack. We check if a given stream is valid by checking through all the devices stream sets. This can be expensive for machines with multiple GPU's as device 7 ends up making 8 hash table looks ups, before it finds the stream

## Technical Details

This PR reduces the number of calls to isValid and getting the device id. Measurements show that produces a reasonable speed up between the users call and the creation of the NDRangeKernelCommand. With a warm cache this drops from 172ns to 145ns ~16% speed up, and with a cold cache this drops from 424ns to 317ns, ~25% speed up. This isn't significant in terms of the overall kernel execution but does drop the overall latency and reduces GPU workload imbalances for multi-GPU machines.

## JIRA ID

Resolves - ROCM-1494

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
