### PR TITLE
add additional runtime checks and gfx1201 fix

### DIFF
--- a/projects/rocshmem/src/bootstrap/bootstrap.cpp
+++ b/projects/rocshmem/src/bootstrap/bootstrap.cpp
@@ -37,19 +37,6 @@
 
 namespace rocshmem {
 
-static void setFilesLimit() {
-  rlimit filesLimit;
-  if (getrlimit(RLIMIT_NOFILE, &filesLimit) != 0) {
-    DPRINTF("getrlimit failed\n");
-    return;
-  }
-  filesLimit.rlim_cur = filesLimit.rlim_max;
-  if (setrlimit(RLIMIT_NOFILE, &filesLimit) != 0) {
-    DPRINTF("setrlimit failed\n");
-    return;
-  }
-}
-
 /* Socket Interface Selection type */
 enum bootstrapInterface_t { findSubnetIf = -1, dontCareIf = -2 };
 
@@ -391,7 +378,6 @@ void TcpBootstrap::Impl::bootstrapRoot() {
 
   std::memset(rankAddresses.data(), 0, sizeof(SocketAddress) * nRanks_);
   std::memset(rankAddressesRoot.data(), 0, sizeof(SocketAddress) * nRanks_);
-  setFilesLimit();
 
   DPRINTF("BEGIN bootstrapRoot\n");
   /* Receive addresses from all ranks */

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -114,9 +114,9 @@ void IPCBackend::init() {
 
   char *arch_name = get_arch_name(hip_dev_id);
   if (strncmp(arch_name, "gfx1201", strlen("gfx1201")) == 0) {
-    fine_grained_allocator_ = new(HIPAllocatorFinegrained);
+    fine_grained_allocator_ = new HIPAllocatorFinegrained();
   } else {
-    fine_grained_allocator_ = new(HIPDefaultFinegrainedAllocator);
+    fine_grained_allocator_ = new HIPDefaultFinegrainedAllocator();
   }
 
   setup_team_world();

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -148,7 +148,14 @@ IPCBackend::~IPCBackend() {
   CHECK_HIP(hipFree(team_world));
 
   CHECK_HIP(hipFree(ctx_array));
-  delete fine_grained_allocator_;
+  if (fine_grained_allocator_) {
+    char *arch_name = get_arch_name(hip_dev_id);
+    if (strncmp(arch_name, "gfx1201", strlen("gfx1201")) == 0) {
+      delete static_cast<HIPAllocatorFinegrained *>(fine_grained_allocator_);
+    } else {
+      delete static_cast<HIPDefaultFinegrainedAllocator *>(fine_grained_allocator_);
+    }
+  }
 }
 
 void IPCBackend::setup_ctxs() {

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -112,7 +112,7 @@ IPCBackend::IPCBackend(TcpBootstrap *bootstrap):  Backend(bootstrap) {
 void IPCBackend::init() {
   ROCSHMEM_HOST_CTX_DEFAULT.ctx_opaque = default_host_ctx.get();
 
-  char *arch_name = get_arch_name(hip_dev_id);
+  const char *arch_name = get_arch_name(hip_dev_id);
   if (strncmp(arch_name, "gfx1201", strlen("gfx1201")) == 0) {
     fine_grained_allocator_ = new HIPAllocatorFinegrained();
   } else {
@@ -149,7 +149,7 @@ IPCBackend::~IPCBackend() {
 
   CHECK_HIP(hipFree(ctx_array));
   if (fine_grained_allocator_) {
-    char *arch_name = get_arch_name(hip_dev_id);
+    const char *arch_name = get_arch_name(hip_dev_id);
     if (strncmp(arch_name, "gfx1201", strlen("gfx1201")) == 0) {
       delete static_cast<HIPAllocatorFinegrained *>(fine_grained_allocator_);
     } else {

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -112,6 +112,13 @@ IPCBackend::IPCBackend(TcpBootstrap *bootstrap):  Backend(bootstrap) {
 void IPCBackend::init() {
   ROCSHMEM_HOST_CTX_DEFAULT.ctx_opaque = default_host_ctx.get();
 
+  char *arch_name = get_arch_name(hip_dev_id);
+  if (strncmp(arch_name, "gfx1201", strlen("gfx1201")) == 0) {
+    fine_grained_allocator_ = new(HIPAllocatorFinegrained);
+  } else {
+    fine_grained_allocator_ = new(HIPDefaultFinegrainedAllocator);
+  }
+
   setup_team_world();
 
   setup_wrk_sync_buffers();
@@ -141,6 +148,7 @@ IPCBackend::~IPCBackend() {
   CHECK_HIP(hipFree(team_world));
 
   CHECK_HIP(hipFree(ctx_array));
+  delete fine_grained_allocator_;
 }
 
 void IPCBackend::setup_ctxs() {
@@ -368,8 +376,8 @@ void IPCBackend::setup_wrk_sync_buffers() {
    * Allocate a buffer of size wrk_sync_pool_size_, using fine-grained
    * memory allocator
   */
-  fine_grained_allocator_.allocate((void**)&wrk_sync_pool_,
-                                   wrk_sync_pool_size_);
+  fine_grained_allocator_->allocate((void**)&wrk_sync_pool_,
+                                    wrk_sync_pool_size_);
   assert(wrk_sync_pool_);
   wrk_sync_pool_top_ = wrk_sync_pool_;
 
@@ -400,7 +408,7 @@ void IPCBackend::setup_wrk_sync_buffers() {
    * Allocate device-side fine grained memory to hold IPC addresses of
    * work/sync buffers
    */
-  fine_grained_allocator_.allocate(
+  fine_grained_allocator_->allocate(
     reinterpret_cast<void**>(&wrk_sync_pool_bases_),
     num_pes * sizeof(char*));
   assert(wrk_sync_pool_bases_);
@@ -427,8 +435,8 @@ void IPCBackend::cleanup_wrk_sync_buffer() {
       CHECK_HIP(hipIpcCloseMemHandle(wrk_sync_pool_bases_[i]));
     }
   }
-  fine_grained_allocator_.deallocate(wrk_sync_pool_bases_);
-  fine_grained_allocator_.deallocate(wrk_sync_pool_);
+  fine_grained_allocator_->deallocate(wrk_sync_pool_bases_);
+  fine_grained_allocator_->deallocate(wrk_sync_pool_);
 }
 
 void IPCBackend::setup_fence_buffer() {

--- a/projects/rocshmem/src/ipc/backend_ipc.hpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.hpp
@@ -258,7 +258,7 @@ class IPCBackend : public Backend {
   /**
    * Fine grained memory allocator for buffers used in collectives Routines
    */
-  HIPDefaultFinegrainedAllocator fine_grained_allocator_ {};
+  MemoryAllocator *fine_grained_allocator_{nullptr};
 
   /**
    * @brief Collective routines work/sync buffer size

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -60,6 +60,8 @@
 #include <random>
 #include <cassert>
 #include <unistd.h>
+#include <sys/time.h>
+#include <sys/resource.h>
 
 namespace rocshmem {
 
@@ -127,6 +129,18 @@ static BackendType select_backend_type() {
   return BackendType::IPC_BACKEND;
 }
 #endif
+static void setFilesLimit() {
+  rlimit filesLimit;
+  if (getrlimit(RLIMIT_NOFILE, &filesLimit) != 0) {
+    DPRINTF("getrlimit failed\n");
+    return;
+  }
+  filesLimit.rlim_cur = filesLimit.rlim_max;
+  if (setrlimit(RLIMIT_NOFILE, &filesLimit) != 0) {
+    DPRINTF("setrlimit failed\n");
+    return;
+  }
+}
 
 [[maybe_unused]] __host__ void inline library_init(MPI_Comm comm) {
   assert(!backend);
@@ -138,6 +152,7 @@ static BackendType select_backend_type() {
     abort();
   }
 
+  setFilesLimit();
   rocm_init();
 
   int ret;
@@ -255,6 +270,7 @@ static BackendType select_backend_type() {
     abort();
   }
 
+  setFilesLimit();
   rocm_init();
 
 #if defined(USE_GDA) && defined(USE_RO) && defined(USE_IPC)

--- a/projects/rocshmem/src/util.cpp
+++ b/projects/rocshmem/src/util.cpp
@@ -57,7 +57,8 @@ static void device_properties_init(void) {
     CHECK_HIP(hipGetDeviceProperties(&hipprop, i));
     prop.warpSize = hipprop.warpSize;
     prop.maxThreadsPerBlock = hipprop.maxThreadsPerBlock;
-    strncpy (prop.gcnArchName, hipprop.gcnArchName, strlen(hipprop.gcnArchName));
+    std::snprintf(prop.gcnArchName, sizeof(prop.gcnArchName), "%s",
+                  hipprop.gcnArchName);
     device_properties.push_back(prop);
 
     CHECK_HIP(hipDeviceGetAttribute (&has_large_bar, hipDeviceAttributeIsLargeBar, i));

--- a/projects/rocshmem/src/util.cpp
+++ b/projects/rocshmem/src/util.cpp
@@ -52,11 +52,20 @@ static void device_properties_init(void) {
 
   device_prop_t prop;
   hipDeviceProp_t hipprop;
+  int has_large_bar = 0;
   for (int i=0; i<numDevices; i++) {
     CHECK_HIP(hipGetDeviceProperties(&hipprop, i));
     prop.warpSize = hipprop.warpSize;
     prop.maxThreadsPerBlock = hipprop.maxThreadsPerBlock;
+    strncpy (prop.gcnArchName, hipprop.gcnArchName, strlen(hipprop.gcnArchName));
     device_properties.push_back(prop);
+
+    CHECK_HIP(hipDeviceGetAttribute (&has_large_bar, hipDeviceAttributeIsLargeBar, i));
+    if (has_large_bar == 0) {
+      // Large BAR required for IPC operations
+      printf("Warning: Large BAR support is not enabled on device %d. "
+             "This will impact IPC functionality on some systems.\n", i);
+    }
   }
 }
 hsa_status_t rocm_hsa_amd_memory_pool_callback(

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -172,7 +172,7 @@ static int get_wf_size(int device_id) {
   return device_properties[device_id].warpSize;
 }
 
-static char* get_arch_name(int device_id) {
+static const char* get_arch_name(int device_id) {
   assert(device_properties.size() > device_id);
   return device_properties[device_id].gcnArchName;
 }

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -157,6 +157,7 @@ extern const int gpu_clock_freq_mhz;
 typedef struct device_prop {
   int warpSize;
   int maxThreadsPerBlock;
+  char gcnArchName[256];
 } device_prop_t;
 
 extern std::vector<device_prop_t> device_properties;
@@ -169,6 +170,11 @@ static int get_threads_per_block(int device_id) {
 static int get_wf_size(int device_id) {
   assert(device_properties.size() > device_id);
   return device_properties[device_id].warpSize;
+}
+
+static char* get_arch_name(int device_id) {
+  assert(device_properties.size() > device_id);
+  return device_properties[device_id].gcnArchName;
 }
 
 /* Device-side internal functions */


### PR DESCRIPTION
## Motivation

Fix some issues observed with gfx1201 CI

## Technical Details

This commit contains three fixes:
 - increase the max. number of files at the beginning of the run to the max. allowed by the system
 - check for large BAR support. WE don not abort if its not available, but print a warning.
 - for gfx1201, do not use uncached memory at the moment.

## JIRA ID

Resolves AIROCSHMEM-237

## Test Plan

Tested on gfx1201 and gfx90a manually. More tests will be executed through the rocSHMEM CI.

## Test Result

all expected tests are passing

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
