### PR TITLE
[RCCL] Inspector Plugin - Rename library from libnccl to librccl

### DIFF
--- a/projects/rccl/ext-profiler/inspector/Makefile
+++ b/projects/rccl/ext-profiler/inspector/Makefile
@@ -7,7 +7,7 @@
 # Variables
 NCCL_HOME := ../../build
 INC := -I$(NCCL_HOME)/include -I$(CUDA_HOME)/include -Inccl
-PLUGIN_SO := libnccl-profiler-inspector.so
+PLUGIN_SO := librccl-profiler-inspector.so
 VERSION_FILE := version.cc
 
 # Compiler and flags

--- a/projects/rccl/ext-profiler/inspector/README.md
+++ b/projects/rccl/ext-profiler/inspector/README.md
@@ -40,7 +40,7 @@ make DEBUG=1
 ### Build Output
 
 The build process creates:
-- `libnccl-profiler-inspector.so`: The main inspector plugin library
+- `librccl-profiler-inspector.so`: The main inspector plugin library
 - `version.cc`: Auto-generated version information from git
 
 ## Using NCCL Inspector
@@ -58,7 +58,7 @@ The main difference between running NCCL with the Inspector plugin versus runnin
 **NCCL Inspector Run:**
 ```bash
 # NCCL Inspector enabled execution
-export NCCL_PROFILER_PLUGIN=/path/to/nccl/ext-profiler/inspector/libnccl-profiler-inspector.so
+export NCCL_PROFILER_PLUGIN=/path/to/rccl/ext-profiler/inspector/librccl-profiler-inspector.so
 export NCCL_INSPECTOR_ENABLE=1
 export NCCL_INSPECTOR_DUMP_THREAD_INTERVAL_MICROSECONDS=500
 ./your_nccl_application
@@ -66,7 +66,7 @@ export NCCL_INSPECTOR_DUMP_THREAD_INTERVAL_MICROSECONDS=500
 
 ### Required Environment Variables
 
-- `NCCL_PROFILER_PLUGIN=/path/to/nccl/ext-profiler/inspector/libnccl-profiler-inspector.so`
+- `NCCL_PROFILER_PLUGIN=/path/to/rccl/ext-profiler/inspector/librccl-profiler-inspector.so`
   Loads the Inspector plugin into NCCL.
 - `NCCL_INSPECTOR_ENABLE=1`
   Enables the Inspector plugin.
@@ -81,7 +81,7 @@ export NCCL_INSPECTOR_DUMP_THREAD_INTERVAL_MICROSECONDS=500
 
 **Single Node:**
 ```bash
-export NCCL_PROFILER_PLUGIN=/path/to/nccl/ext-profiler/inspector/libnccl-profiler-inspector.so
+export NCCL_PROFILER_PLUGIN=/path/to/rccl/ext-profiler/inspector/librccl-profiler-inspector.so
 export NCCL_INSPECTOR_ENABLE=1
 export NCCL_INSPECTOR_DUMP_THREAD_INTERVAL_MICROSECONDS=500
 ./build/test/perf/all_reduce_perf -b 8 -e 16G -f 2 -g 8
@@ -90,7 +90,7 @@ export NCCL_INSPECTOR_DUMP_THREAD_INTERVAL_MICROSECONDS=500
 **Multi-Node (SLURM):**
 ```bash
 # Add these environment variables to your SLURM script
-export NCCL_PROFILER_PLUGIN=/path/to/nccl/ext-profiler/inspector/libnccl-profiler-inspector.so
+export NCCL_PROFILER_PLUGIN=/path/to/rccl/ext-profiler/inspector/librccl-profiler-inspector.so
 export NCCL_INSPECTOR_ENABLE=1
 export NCCL_INSPECTOR_DUMP_THREAD_INTERVAL_MICROSECONDS=500
 export NCCL_INSPECTOR_DUMP_DIR=/path/to/logs/${SLURM_JOB_ID}/


### PR DESCRIPTION
## Motivation

The inspector plugin currently builds as `libnccl-profiler-inspector.so` but should follow RCCL naming convention to be consistent with profiler plugin `librccl-profiler-example.so`

## Technical Details

1. Makefile : Update PLUGIN_SO variable from `libnccl-profiler-inspector.so` to `librccl-profiler-inspector.so`
2. README.md: Update all documentation references to use the new library name

## JIRA ID

AICOMRCCL-290

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
