### PR TITLE
[ATT] Re-enable tests. Add option to specify perf to target CU only

### DIFF
--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -841,6 +841,13 @@ For attachment profiling of running processes:
     )
 
     att_options.add_argument(
+        "--att-perfcounter-target-only",
+        help="(gfx9) Enable performance counters only for the target CU. This heavily reduces bandwidth use.",
+        default=None,
+        type=bool,
+    )
+
+    att_options.add_argument(
         "--att-activity",
         help="(gfx9) Collect HW activity counters. Integer in [1,16] range specifying collection period. Recommended: 8",
         default=None,
@@ -1758,6 +1765,12 @@ def run(app_args, args, **kwargs):
                     args.att_perfcounter_ctrl,
                     overwrite=True,
                 )
+        if args.att_perfcounter_target_only:
+            update_env(
+                "ROCPROF_ATT_PARAM_TARGET_ONLY",
+                1 if args.att_perfcounter_target_only else 0,
+                overwrite=True,
+            )
         if args.att_activity:
             if args.pmc:
                 fatal_error("ATT activity cannot be enabled with PMC")

--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -840,11 +840,11 @@ For attachment profiling of running processes:
         type=int,
     )
 
-    att_options.add_argument(
+    add_parser_bool_argument(
+        att_options,
         "--att-perfcounter-target-only",
+        default=False,
         help="(gfx9) Enable performance counters only for the target CU. This heavily reduces bandwidth use.",
-        default=None,
-        type=bool,
     )
 
     att_options.add_argument(

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-thread-trace.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-thread-trace.rst
@@ -69,50 +69,53 @@ To collect thread trace with default parameters, use:
 
 The following table lists the parameters relevant to thread tracing:
 
-+--------------------------+---------+---------+-----------+--------------------------------------------------------------+
-| Parameter                | Type    | Range   | Typical   | Description                                                  |
-+==========================+=========+=========+===========+==============================================================+
-| att-target-cu            | Integer | 0 - 15  | 1         | Defines the CU used to gather detail tokens (WGP on Navi)    |
-+--------------------------+---------+---------+-----------+--------------------------------------------------------------+
-| att-shader-engine-mask   | Bitmask | 1 - ~0u | 0x1       | Defines the Shader Engines (SE) to be traced. Max 2^32 - 1   |
-+--------------------------+---------+---------+-----------+--------------------------------------------------------------+
-| att-simd-select          | Integer | 0 - 0xF | gfx9: 0xF | Defines one or more SIMDs to be traced, out of four.         |
-|                          |         |         | Navi: 0x0 | Bitmask on GFX9 and SIMD_ID[0,3] on Navi.                    |
-+--------------------------+---------+---------+-----------+--------------------------------------------------------------+
-| kernel-iteration-range   | List    |         |           | Defines dispatch iteration of the kernel to be profiled      |
-+--------------------------+---------+---------+-----------+--------------------------------------------------------------+
-| kernel-include-regex     | String  | Any     |           | Profiles kernel names matching the regex                     |
-+--------------------------+---------+---------+-----------+--------------------------------------------------------------+
-| kernel-exclude-regex     | String  | Any     |           | Doesn't profile kernel names matching the regex              |
-+--------------------------+---------+---------+-----------+--------------------------------------------------------------+
-| att-buffer-size          | Bytes   | 1MB-2GB | 96MB      | Specifies the trace buffer size. This is shared for all SEs. |
-|                          |         |         |           | Increase this value if the buffer tends to get full.         |
-+--------------------------+---------+---------+-----------+--------------------------------------------------------------+
-| att-serialize-all        | Bool    |         | False     | If set to "True", turns on serialization for untraced kernels|
-+--------------------------+---------+---------+-----------+--------------------------------------------------------------+
-| att-perfcounter-ctrl     | Integer | 1 - 32  | 2~8       | Available only in gfx9. Streams SQ performance counters to   |
-|                          |         |         |           | the thread trace buffer in the given relative period. As     |
-|                          |         |         |           | this uses high bandwidth, a value too low can cause or worsen|
-|                          |         |         |           | "Data Lost" events and warnings.                             |
-+--------------------------+---------+---------+-----------+--------------------------------------------------------------+
-| att-perfcounters         | String  | SQ-only |           | Available only in gfx9. Specifies the list of SQ counters.   |
-|                          |         |         |           | To list all counters, use "rocprofv3 --list-avail``.         |
-+--------------------------+---------+---------+-----------+--------------------------------------------------------------+
-| att-activity             | Integer | 1 - 16  | 5~10      | Available only in gfx9.                                      |
-|                          |         |         |           | Shorthand for att-perfcounter-ctrl and the att-perfcounters  |
-|                          |         |         |           | related to compute unit activity such as VALU, SALU, etc.    |
-+--------------------------+---------+---------+-----------+--------------------------------------------------------------+
-| att-gpu-index            | Integer |         |           | Comma-separated list of integers. If enabled, only the GPU   |
-|                          | (List)  |         |           | indexes in the list will be profiled by thread trace.        |
-+--------------------------+---------+---------+-----------+--------------------------------------------------------------+
-| att-consecutive-kernels  | Integer | >=0     |           | Starting at the targeted kernel, enables thread trace for the|
-|                          |         |         |           | next N kernel dispatches, sharing a single ATT file,         |
-|                          |         |         |           | stats.csv and UI dir. See --kernel-include-regex and         |
-|                          |         |         |           | --kernel-iteration-range. If multiple targeted kernels       |
-|                          |         |         |           | overlap, the count for N next dispatches starts again from 0.|
-|                          |         |         |           | Recommended use with --att-gpu-index due to thread trace     |
-|                          |         |         |           | being enabled for all GPUs.                                  |
-+--------------------------+---------+---------+-----------+--------------------------------------------------------------+
++-----------------------------+---------+---------+-----------+--------------------------------------------------------------+
+| Parameter                   | Type    | Range   | Typical   | Description                                                  |
++=============================+=========+=========+===========+==============================================================+
+| att-target-cu               | Integer | 0 - 15  | 1         | Defines the CU used to gather detail tokens (WGP on Navi)    |
++-----------------------------+---------+---------+-----------+--------------------------------------------------------------+
+| att-shader-engine-mask      | Bitmask | 1 - ~0u | 0x1       | Defines the Shader Engines (SE) to be traced. Max 2^32 - 1   |
++-----------------------------+---------+---------+-----------+--------------------------------------------------------------+
+| att-simd-select             | Integer | 0 - 0xF | gfx9: 0xF | Defines one or more SIMDs to be traced, out of four.         |
+|                             |         |         | Navi: 0x0 | Bitmask on GFX9 and SIMD_ID[0,3] on Navi.                    |
++-----------------------------+---------+---------+-----------+--------------------------------------------------------------+
+| kernel-iteration-range      | List    |         |           | Defines dispatch iteration of the kernel to be profiled      |
++-----------------------------+---------+---------+-----------+--------------------------------------------------------------+
+| kernel-include-regex        | String  | Any     |           | Profiles kernel names matching the regex                     |
++-----------------------------+---------+---------+-----------+--------------------------------------------------------------+
+| kernel-exclude-regex        | String  | Any     |           | Doesn't profile kernel names matching the regex              |
++-----------------------------+---------+---------+-----------+--------------------------------------------------------------+
+| att-buffer-size             | Bytes   | 1MB-2GB | 96MB      | Specifies the trace buffer size. This is shared for all SEs. |
+|                             |         |         |           | Increase this value if the buffer tends to get full.         |
++-----------------------------+---------+---------+-----------+--------------------------------------------------------------+
+| att-serialize-all           | Bool    |         | False     | If set to "True", turns on serialization for untraced kernels|
++-----------------------------+---------+---------+-----------+--------------------------------------------------------------+
+| att-perfcounter-ctrl        | Integer | 1 - 32  | 2~8       | Available only in gfx9. Streams SQ performance counters to   |
+|                             |         |         |           | the thread trace buffer in the given relative period. As     |
+|                             |         |         |           | this uses high bandwidth, a value too low can cause or worsen|
+|                             |         |         |           | "Data Lost" events and warnings.                             |
++-----------------------------+---------+---------+-----------+--------------------------------------------------------------+
+| att-perfcounters            | String  | SQ-only |           | Available only in gfx9. Specifies the list of SQ counters.   |
+|                             |         |         |           | To list all counters, use "rocprofv3 --list-avail``.         |
++-----------------------------+---------+---------+-----------+--------------------------------------------------------------+
+| att-activity                | Integer | 1 - 16  | 5~10      | Available only in gfx9.                                      |
+|                             |         |         |           | Shorthand for att-perfcounter-ctrl and the att-perfcounters  |
+|                             |         |         |           | related to compute unit activity such as VALU, SALU, etc.    |
++-----------------------------+---------+---------+-----------+--------------------------------------------------------------+
+| att-perfcounter-target-only | Bool    | True or |           | Enable performance counters only for the target_cu. This     |
+|                             |         | False   |           | option allows for a low value in att-activity and *-ctrl.    |
++-----------------------------+---------+---------+-----------+--------------------------------------------------------------+
+| att-gpu-index               | Integer |         |           | Comma-separated list of integers. If enabled, only the GPU   |
+|                             | (List)  |         |           | indexes in the list will be profiled by thread trace.        |
++-----------------------------+---------+---------+-----------+--------------------------------------------------------------+
+| att-consecutive-kernels     | Integer | >=0     |           | Starting at the targeted kernel, enables thread trace for the|
+|                             |         |         |           | next N kernel dispatches, sharing a single ATT file,         |
+|                             |         |         |           | stats.csv and UI dir. See --kernel-include-regex and         |
+|                             |         |         |           | --kernel-iteration-range. If multiple targeted kernels       |
+|                             |         |         |           | overlap, the count for N next dispatches starts again from 0.|
+|                             |         |         |           | Recommended use with --att-gpu-index due to thread trace     |
+|                             |         |         |           | being enabled for all GPUs.                                  |
++-----------------------------+---------+---------+-----------+--------------------------------------------------------------+
 
 For AMD Instinct accelerators, enable perfmon streaming using:
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.hpp
@@ -151,6 +151,7 @@ struct config : output_config
     uint64_t att_param_simd_select = get_env<uint64_t>("ROCPROF_ATT_PARAM_SIMD_SELECT", 0xF);
     uint64_t att_param_target_cu   = get_env<uint64_t>("ROCPROF_ATT_PARAM_TARGET_CU", 1);
     uint64_t att_param_perf_ctrl   = get_env<uint64_t>("ROCPROF_ATT_PARAM_PERFCOUNTER_CTRL", 0);
+    bool     att_param_target_only = get_env<int>("ROCPROF_ATT_PARAM_TARGET_ONLY", 0) != 0;
     uint64_t att_consecutive_kernels = get_env<uint64_t>("ROCPROF_ATT_CONSECUTIVE_KERNELS", 0);
 
     std::string kernel_filter_include   = get_env("ROCPROF_KERNEL_FILTER_INCLUDE_REGEX", ".*");

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2134,7 +2134,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
         uint64_t buffer_sz         = tool::get_config().att_param_buffer_size;
         uint64_t shader_mask       = tool::get_config().att_param_shader_engine_mask;
         uint64_t perfcounter_ctrl  = tool::get_config().att_param_perf_ctrl;
-        bool     exclude_nontarget = tool::get_config().att_param_target_only != 0;
+        bool     exclude_nontarget = tool::get_config().att_param_target_only;
         auto&    att_perf          = tool::get_config().att_param_perfcounters;
         bool     att_serialize_all = tool::get_config().att_serialize_all;
 
@@ -2151,7 +2151,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
         {
             // Create a bitmask with all ones except at the target_cu
             global_parameters.push_back(
-                {ROCPROFILER_THREAD_TRACE_PARAMETER_PERFCOUNTER_EXCLUDE_MASK, ~(1ul << target_cu)});
+                {ROCPROFILER_THREAD_TRACE_PARAMETER_PERFCOUNTER_EXCLUDE_MASK, {~(1ul << target_cu)}});
         }
 
         if(perfcounter_ctrl != 0 && !att_perf.empty())

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2134,6 +2134,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
         uint64_t buffer_sz         = tool::get_config().att_param_buffer_size;
         uint64_t shader_mask       = tool::get_config().att_param_shader_engine_mask;
         uint64_t perfcounter_ctrl  = tool::get_config().att_param_perf_ctrl;
+        bool     exclude_nontarget = tool::get_config().att_param_target_only != 0;
         auto&    att_perf          = tool::get_config().att_param_perfcounters;
         bool     att_serialize_all = tool::get_config().att_serialize_all;
 
@@ -2145,6 +2146,13 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
             {ROCPROFILER_THREAD_TRACE_PARAMETER_SHADER_ENGINE_MASK, {shader_mask}});
         global_parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_SERIALIZE_ALL,
                                      {static_cast<uint64_t>(att_serialize_all)}});
+
+        if(exclude_nontarget)
+        {
+            // Create a bitmask with all ones except at the target_cu
+            global_parameters.push_back(
+                {ROCPROFILER_THREAD_TRACE_PARAMETER_PERFCOUNTER_EXCLUDE_MASK, ~(1ul << target_cu)});
+        }
 
         if(perfcounter_ctrl != 0 && !att_perf.empty())
         {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2151,7 +2151,8 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
         {
             // Create a bitmask with all ones except at the target_cu
             global_parameters.push_back(
-                {ROCPROFILER_THREAD_TRACE_PARAMETER_PERFCOUNTER_EXCLUDE_MASK, {~(1ul << target_cu)}});
+                {ROCPROFILER_THREAD_TRACE_PARAMETER_PERFCOUNTER_EXCLUDE_MASK,
+                 {~(1ul << target_cu)}});
         }
 
         if(perfcounter_ctrl != 0 && !att_perf.empty())

--- a/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/CMakeLists.txt
@@ -270,3 +270,37 @@ rocprofiler_add_integration_execute_test(
     WILL_FAIL
     DISABLED ${IS_DISABLED}
     FAIL_REGULAR_EXPRESSION "Invalid GPU Device Index")
+
+#
+# Test --att-perfcounter-target-cu option This test verifies that perfcounter events are
+# only generated for the specified target CU
+#
+set(TARGET_CU 2)
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-att-perfcounter-target-cu
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> ${COMMON_PARAMS}/perfcounter_target_cu
+        --att-activity 6 --att-target-cu ${TARGET_CU} --att-perfcounter-target-only True
+        -o out --kernel-include-regex matrixTranspose -- $<TARGET_FILE:simple-transpose>
+    DEPENDS simple-transpose
+    TIMEOUT 45
+    LABELS "integration-tests"
+    DISABLED ${IS_DISABLED}
+    FIXTURES_SETUP rocprofv3-test-att-perfcounter-target-cu)
+
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-att-perfcounter-target-cu-validate
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    TIMEOUT 45
+    LABELS "integration-tests"
+    DISABLED ${IS_DISABLED}
+    FIXTURES_REQUIRED rocprofv3-test-att-perfcounter-target-cu
+    ARGS --input
+         ${CMAKE_CURRENT_BINARY_DIR}/simple-transpose-trace/perfcounter_target_cu/out_results.json
+         --output-path
+         ${CMAKE_CURRENT_BINARY_DIR}/simple-transpose-trace/perfcounter_target_cu
+         --target-cu
+         ${TARGET_CU}
+    FAIL_REGULAR_EXPRESSION "AssertionError")

--- a/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/conftest.py
@@ -50,6 +50,12 @@ def pytest_addoption(parser):
         action="store",
         help="Output Path.",
     )
+    parser.addoption(
+        "--target-cu",
+        action="store",
+        default=None,
+        help="Target CU for perfcounter validation.",
+    )
 
 
 @pytest.fixture
@@ -67,6 +73,8 @@ def output_path(request):
 @pytest.fixture
 def code_object_file_path(request):
     file_path = request.config.getoption("--code-object-input")
+    if file_path is None:
+        pytest.skip("--code-object-input not provided")
     # hsa_file_load = re.compile(".*copy.hsaco$")
     code_object_files = {}
     code_object_memory = []

--- a/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/validate.py
@@ -67,6 +67,41 @@ def test_code_object_memory(code_object_file_path, json_data, output_path):
     assert found == True
 
 
+def test_perfcounter_target_cu(output_path, request):
+    """
+    Test that when --att-perfcounter-target-cu is specified, all perfcounter
+    events are tagged only for the target CU (or no events at all).
+    """
+    # Get the target CU from pytest command line if provided
+    target_cu = request.config.getoption("--target-cu", default=None)
+
+    if target_cu is None:
+        pytest.skip("--target-cu not specified, skipping perfcounter target CU test")
+
+    target_cu = int(target_cu)
+
+    # Find all perfcounter JSON files
+    pattern = os.path.join(output_path, "ui_output_*", "se*_perfcounter.json")
+    perfcounter_files = glob.glob(pattern)
+    print(perfcounter_files)
+
+    # It's acceptable to have no perfcounter files (target CU may not have any events)
+    for pc_file in perfcounter_files:
+        with open(pc_file, "r", encoding="utf-8") as f:
+            json_data = json.load(f)
+
+        data = json_data.get("data", [])
+
+        # Check that all events are for the target CU
+        for event in data:
+            # CU is at index 5
+            event_cu = event[5]
+            assert event_cu == target_cu, (
+                f"Found perfcounter event for CU {event_cu}, "
+                f"but target CU is {target_cu} in file {pc_file}"
+            )
+
+
 def test_realtime_clock(output_path):
 
     def verify_sorted(timestamps):


### PR DESCRIPTION
## Motivation

This PR re-enables rocprofv3 ATT tests, as they seem to be disabled by default. Additionally:

It is desirable some sqtt performance counters be polled at the maximum rate (att-perfcounter-ctrl 1), especially when trying to match these counters with the ISA. For instance:
* per-assembly line memory latency in the rocprof compute viewer
* per-assembly line LDS Bank conflicts
* cycle-by-cycle TOPs and MFMA util calculations.

However, SQTT perfmons uses too much bandwidth and rarely one can sustain a high polling rate without losing part of the trace.
This PR adds the option to run SQTT perfmons only on the target cu, thus heavily mitigating the bandwidth use of this technique. Moreover, matching perfmons with the ISA only happens on the target cu, and therefore there is no downside here, except for --att-activity.

## Technical Details

This PR adds --att-perfcounter-target-only as an option to disable sqtt perfmon on nondetailed CUs.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

The test launches a kernel, collects SQTT perfmons and make sure no perfmons are generated other than the target cu.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
