### PR TITLE
Update Sparse Checkout Instructions to Allow Pushes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for contributing! This guide outlines the development workflow, contri
 ### Option A: Clone the super-repo
 
 ```bash
-git clone https://github.com/ROCm/rocm-systems.git
+git clone git@github.com:ROCm/rocm-systems.git
 cd rocm-systems
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ cd rocm-systems
 To limit your local checkout to only the project(s) you work on and improve performance with a large codebase, you can configure sparse-checkout prior to cloning:
 
 ```bash
-git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-systems.git
+git clone --no-checkout --filter=blob:none git@github.com:ROCm/rocm-systems.git
 cd rocm-systems
 git sparse-checkout init --cone
 git sparse-checkout set projects/rocprofiler-sdk shared/rocprofiler-compute


### PR DESCRIPTION
This code will only allow read-only activities because github requires a ssh key for pushes.  

Let's fix that so that people don't get blocked on this.

## Motivation

Developer productivity.  Since these are the instructions for the contributing page, let's make the checkout actually supports pushing code.

## Technical Details

See above

## JIRA ID

N/A

## Test Plan

I ran it.  It should work.

## Test Result

I am able to push code after using this whereas I wasn't before.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
