### PR TITLE
SWDEV-561708 Counted queue size from env var

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/counted_queues.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/counted_queues.cc
@@ -57,7 +57,7 @@ void CountedQueuesTest::SetUp() {
 
   // get the size of counted queue from env var
   const char* cq_size = rocrtst::GetEnv("HSA_COUNTED_QUEUE_SIZE");
-  cq_size == nullptr ? 16384 : atoi(cq_size);
+  counted_queue_size = (cq_size == nullptr) ? 16384 : atoi(cq_size);
 
   TestBase::SetUp();
 }

--- a/projects/rocr-runtime/rocrtst/suites/functional/counted_queues.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/counted_queues.cc
@@ -55,10 +55,6 @@ void CountedQueuesTest::SetUp() {
     rocrtst::SetEnv("GPU_MAX_HW_QUEUES", limit.c_str());
   }
 
-  // get the size of counted queue from env var
-  const char* cq_size = rocrtst::GetEnv("HSA_COUNTED_QUEUE_SIZE");
-  counted_queue_size = (cq_size == nullptr) ? 16384 : atoi(cq_size);
-
   TestBase::SetUp();
 }
 
@@ -851,9 +847,12 @@ void CountedQueuesTest::CountedQueuesOverflowWrapAroundTest() {
     th.join();
   }
 
-  // Verify value of max seen index
+  const char* size = rocrtst::GetEnv("HSA_COUNTED_QUEUE_SIZE");
+  size_t cq_size = !size ? 16384 : atoi(size);
+
+  // Verify value of max seen index based on counted queue size
   uint64_t maxId = maxIndexSeen.load();
-  EXPECT_EQ(maxId, (counted_queue_size + 5) * kThreads - 1);
+  EXPECT_EQ(maxId, (cq_size + 5) * kThreads - 1);
 
   hsa_amd_memory_pool_free(shared_src_buffer);
 }

--- a/projects/rocr-runtime/rocrtst/suites/functional/counted_queues.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/counted_queues.cc
@@ -718,6 +718,7 @@ void CountedQueuesTest::CountedQueuesOverflowWrapAroundTest() {
 
   // To verify that after the queue has been used up, next index wraps around
   std::atomic<uint64_t> maxIndexSeen{0};
+  std::atomic<uint32_t> countedQueueSize{0};
 
   auto func = [&]() {
     // local dest buffer for each user application
@@ -745,6 +746,8 @@ void CountedQueuesTest::CountedQueuesOverflowWrapAroundTest() {
 
     uint32_t queue_size = queue->size;           // should be 16384
     const uint32_t queue_mask = queue_size - 1;  // used for index wraparound
+
+    countedQueueSize.store(queue_size);
 
     struct __attribute__((aligned(16))) local_args_t {
       uint32_t* dstArray;
@@ -847,12 +850,9 @@ void CountedQueuesTest::CountedQueuesOverflowWrapAroundTest() {
     th.join();
   }
 
-  const char* size = rocrtst::GetEnv("HSA_COUNTED_QUEUE_SIZE");
-  size_t cq_size = !size ? 16384 : atoi(size);
-
   // Verify value of max seen index based on counted queue size
   uint64_t maxId = maxIndexSeen.load();
-  EXPECT_EQ(maxId, (cq_size + 5) * kThreads - 1);
+  EXPECT_EQ(maxId, (countedQueueSize.load() + 5) * kThreads - 1);
 
   hsa_amd_memory_pool_free(shared_src_buffer);
 }

--- a/projects/rocr-runtime/rocrtst/suites/functional/counted_queues.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/counted_queues.cc
@@ -55,6 +55,10 @@ void CountedQueuesTest::SetUp() {
     rocrtst::SetEnv("GPU_MAX_HW_QUEUES", limit.c_str());
   }
 
+  // get the size of counted queue from env var
+  const char* cq_size = rocrtst::GetEnv("HSA_COUNTED_QUEUE_SIZE");
+  cq_size == nullptr ? 16384 : atoi(cq_size);
+
   TestBase::SetUp();
 }
 
@@ -849,7 +853,7 @@ void CountedQueuesTest::CountedQueuesOverflowWrapAroundTest() {
 
   // Verify value of max seen index
   uint64_t maxId = maxIndexSeen.load();
-  EXPECT_EQ(maxId, (16384 + 5) * kThreads - 1);
+  EXPECT_EQ(maxId, (counted_queue_size + 5) * kThreads - 1);
 
   hsa_amd_memory_pool_free(shared_src_buffer);
 }

--- a/projects/rocr-runtime/rocrtst/suites/functional/counted_queues.h
+++ b/projects/rocr-runtime/rocrtst/suites/functional/counted_queues.h
@@ -63,9 +63,6 @@ class CountedQueuesTest : public TestBase {
   /// @brief Test to verify ring buffer wrap around when more than queue_size number of 
   // AQL packets are enqueued
   void CountedQueuesOverflowWrapAroundTest();
-
- private:
-  size_t counted_queue_size;
 };
 
 #endif  // ROCRTST_SUITES_FUNCTIONAL_COUNTED_QUEUES_H

--- a/projects/rocr-runtime/rocrtst/suites/functional/counted_queues.h
+++ b/projects/rocr-runtime/rocrtst/suites/functional/counted_queues.h
@@ -63,6 +63,9 @@ class CountedQueuesTest : public TestBase {
   /// @brief Test to verify ring buffer wrap around when more than queue_size number of 
   // AQL packets are enqueued
   void CountedQueuesOverflowWrapAroundTest();
+
+ private:
+  size_t counted_queue_size;
 };
 
 #endif  // ROCRTST_SUITES_FUNCTIONAL_COUNTED_QUEUES_H

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/counted_queue_manager.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/counted_queue_manager.h
@@ -53,6 +53,7 @@ class CountedQueuePoolManager {
   
   core::Agent* agent_; // pointer to the gpu agent that owns this pool
   uint32_t max_hw_queues_;
+  size_t counted_queue_size_;
   std::mutex mutex_;
 
   // Pool of hw queues by priority on the agent

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/counted_queue_manager.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/counted_queue_manager.cpp
@@ -11,11 +11,10 @@
 namespace rocr {
 namespace core {
 
-constexpr size_t DEFAULT_QUEUE_SIZE = 16384;
-
 CountedQueuePoolManager::CountedQueuePoolManager(core::Agent* agent) : agent_(agent) {
-  // Read in GPU_MAX_HW_QUEUES flag value
+  // Read in GPU_MAX_HW_QUEUES and HSA_COUNTED_QUEUE_SIZE flags
   max_hw_queues_ = core::Runtime::runtime_singleton_->flag().cp_queues_limit();
+  counted_queue_size_ = core::Runtime::runtime_singleton_->flag().counted_queue_size();
 }
 
 hsa_status_t CountedQueuePoolManager::AcquireQueue(
@@ -78,7 +77,7 @@ core::Queue* CountedQueuePoolManager::FindOrCreateHardwareQueue(
   // Create a new hardware queue
   core::Queue* cmd_queue = nullptr;
   hsa_status_t status =
-      agent_->QueueCreate(DEFAULT_QUEUE_SIZE, type, 0, callback, data, 0, 0, &cmd_queue);
+      agent_->QueueCreate(counted_queue_size_, type, 0, callback, data, 0, 0, &cmd_queue);
   if (status != HSA_STATUS_SUCCESS) return nullptr;
 
   status = cmd_queue->SetPriority(priority);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -54,6 +54,8 @@
 
 namespace rocr {
 
+constexpr size_t DEFAULT_COUNTED_QUEUE_SIZE = 16384;
+
 class Flag {
  public:
   enum SDMA_OVERRIDE { SDMA_DISABLE, SDMA_ENABLE, SDMA_DEFAULT };
@@ -311,7 +313,7 @@ class Flag {
     cp_queues_limit_ = var.empty() ? 4 : atoi(var.c_str());
 
     var = os::GetEnvVar("HSA_COUNTED_QUEUE_SIZE");
-    counted_queue_size_ = var.empty() ? 16384 : atoi(var.c_str());
+    counted_queue_size_ = var.empty() ? DEFAULT_COUNTED_QUEUE_SIZE : atoi(var.c_str());
   }
 
   void parse_masks(uint32_t maxGpu, uint32_t maxCU) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -55,6 +55,7 @@
 namespace rocr {
 
 constexpr size_t DEFAULT_COUNTED_QUEUE_SIZE = 16384;
+constexpr size_t DEFAULT_GPU_HW_QUEUES_MAX = 4;
 
 class Flag {
  public:
@@ -309,9 +310,13 @@ class Flag {
 
     core_dump_pattern_ = os::GetEnvVar("HSA_COREDUMP_PATTERN");
 
+    // This limits the maximum number of hardware queues that can be created per 
+    // priority level for counted queues on every GPU agent. By default, the limit is set to 4.
     var = os::GetEnvVar("GPU_MAX_HW_QUEUES");
-    cp_queues_limit_ = var.empty() ? 4 : atoi(var.c_str());
+    cp_queues_limit_ = var.empty() ? DEFAULT_GPU_HW_QUEUES_MAX : atoi(var.c_str());
 
+    // This allows configuring the size of counted queues created through 
+    // hsa_amd_counted_queue_acquire API. If not set, default queue size is set to 16384.
     var = os::GetEnvVar("HSA_COUNTED_QUEUE_SIZE");
     counted_queue_size_ = var.empty() ? DEFAULT_COUNTED_QUEUE_SIZE : atoi(var.c_str());
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -306,8 +306,12 @@ class Flag {
     core_dump_disable_ = (var == "1");
 
     core_dump_pattern_ = os::GetEnvVar("HSA_COREDUMP_PATTERN");
+
     var = os::GetEnvVar("GPU_MAX_HW_QUEUES");
     cp_queues_limit_ = var.empty() ? 4 : atoi(var.c_str());
+
+    var = os::GetEnvVar("HSA_COUNTED_QUEUE_SIZE");
+    counted_queue_size_ = var.empty() ? 16384 : atoi(var.c_str());
   }
 
   void parse_masks(uint32_t maxGpu, uint32_t maxCU) {
@@ -430,6 +434,8 @@ class Flag {
 
   uint32_t cp_queues_limit() const { return cp_queues_limit_; }
 
+  size_t counted_queue_size() const { return counted_queue_size_; }
+
   bool dev_mem_queue_buf() const { return dev_mem_queue_buf_; }
 
   uint32_t signal_abort_timeout() const { return signal_abort_timeout_; }
@@ -550,6 +556,7 @@ class Flag {
   std::string core_dump_pattern_;
 
   uint32_t cp_queues_limit_;
+  size_t counted_queue_size_;
 
   // Map GPU index post RVD to its default cu mask.
   std::map<uint32_t, std::vector<uint32_t>> cu_mask_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -55,7 +55,7 @@
 namespace rocr {
 
 constexpr size_t DEFAULT_COUNTED_QUEUE_SIZE = 16384;
-constexpr size_t DEFAULT_GPU_HW_QUEUES_MAX = 4;
+constexpr uint32_t DEFAULT_GPU_HW_QUEUES_MAX = 4;
 
 class Flag {
  public:

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -3793,6 +3793,7 @@ hsa_status_t HSA_API hsa_amd_ais_file_read(hsa_amd_ais_file_handle_t handle, voi
  * @param[in] agent Agent where to create the queue
  *
  * @param[in] type  For future use. HSA_QUEUE_TYPE_MULTI is the only valid option.
+ * HSA_QUEUE_TYPE_COOPERATIVE queues are not supported.
  *
  * @param[in] priority Associated priority. The GPU_MAX_HW_QUEUES limit is counted for each priority
  *


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

For the counted_queue APIs, 
`hsa_status_t status = agent_->QueueCreate(DEFAULT_QUEUE_SIZE, type, 0, callback, data, 0, 0, &cmd_queue);`
 
We got a request from HIP team to add an option to override the DEFAULT_QUEUE_SIZE with an environment variable. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
