### PR TITLE
ROCM-1435: Fix RCCL_UT hang for gfx11*

### DIFF
--- a/projects/rccl/test/common/EnvVars.cpp
+++ b/projects/rccl/test/common/EnvVars.cpp
@@ -204,6 +204,8 @@ namespace RcclUnitTesting
     getArchInfo(&isGfx94, "gfx94");
     isGfx95 = false;
     getArchInfo(&isGfx95, "gfx95");
+    isGfx11 = false;
+    getArchInfo(&isGfx11, "gfx11");
     isGfx12 = false;
     getArchInfo(&isGfx12, "gfx12");
     isGfx90 = false;

--- a/projects/rccl/test/common/EnvVars.hpp
+++ b/projects/rccl/test/common/EnvVars.hpp
@@ -34,6 +34,7 @@ namespace RcclUnitTesting
 
     bool isGfx94;        // Detects if architecture is gfx94
     bool isGfx95;        // Detects if architecture is gfx95
+    bool isGfx11;        // Detects if architecture is gfx11
     bool isGfx12;        // Detects if architecture is gfx12
     bool isGfx90;        // Detects if architecture is gfx90
 

--- a/projects/rccl/test/common/TestBed.cpp
+++ b/projects/rccl/test/common/TestBed.cpp
@@ -712,8 +712,9 @@ namespace RcclUnitTesting
       for (int ftIdx = 0; ftIdx < funcTypes.size()      && isCorrect; ++ftIdx)
       for (int dtIdx = 0; dtIdx < dataTypes.size()      && isCorrect; ++dtIdx)
       {
-      //Skipping AllReduce FP8 test on 9 to 16 ranks (gfx90a).
-      if(ev.isGfx90 && numRanks > 8 && funcTypes[ftIdx] == ncclCollAllReduce
+      // FP8 multi-rank collectives are not supported on gfx11* architectures
+      // Single-rank works on all architectures (no actual reduction kernel executed)
+      if (numRanks > 1 && ev.isGfx11
                     && (dataTypes[dtIdx] == ncclFloat8e4m3
                     || dataTypes[dtIdx] == ncclFloat8e5m2))
       {


### PR DESCRIPTION
## Motivation

Fix RCCL_UT hang for gfx11*

## Technical Details

gfx11* does not support FP8 datatypes (ncclFloat8e4m3, ncclFloat8e5m2) for multi-rank collective operations. The reduction kernels hang, causing the test to block indefinitely. Single-rank tests pass because AllReduce is a no-op with one rank (no reduction kernel is executed). 

## JIRA ID

Resolves ROCM-1435

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
