### PR TITLE
rocr-runtime: fix segfault when queue allocation fails

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1792,7 +1792,9 @@ hsa_status_t GpuAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type, u
   scratch.main_queue_base = nullptr;
   scratch.main_queue_process_offset = 0;
 
-  MAKE_NAMED_SCOPE_GUARD(scratchGuard, [&]() { ReleaseQueueMainScratch(scratch); });
+  MAKE_NAMED_SCOPE_GUARD(scratchGuard, [&]() {
+    if (scratch.main_queue_base != nullptr) ReleaseQueueMainScratch(scratch);
+  });
 
   if (scratch.main_size != 0) {
     AcquireQueueMainScratch(scratch);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1799,6 +1799,9 @@ hsa_status_t GpuAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type, u
   if (scratch.main_size != 0) {
     AcquireQueueMainScratch(scratch);
     if (scratch.main_queue_base == nullptr) {
+      LogPrint(HSA_AMD_LOG_FLAG_INFO,
+               "Failed to allocate scratch memory for queue, size=%zu, node=%u",
+               scratch.main_size, node_id());
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
     }
   }
@@ -1827,7 +1830,11 @@ hsa_status_t GpuAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type, u
             node_id()));
   }
 
-  if (!shared_queue) return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  if (!shared_queue) {
+    LogPrint(HSA_AMD_LOG_FLAG_INFO,
+             "Failed to allocate shared queue descriptor memory, node=%u", node_id());
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
 
   auto aql_queue = new AqlQueue(shared_queue, this, size, node_id(), scratch, event_callback, data,
                                 flags);


### PR DESCRIPTION
## Motivation

@06kellyjac reported the following crash: https://gist.github.com/06kellyjac/49441bab0f8f84014415e56275d8185a

While the underlying cause was [a kernel bug, ](https://lore.kernel.org/linux-iommu/870872aa-28e9-412a-bac6-8020bf560e4f@amd.com/t/) crashing instead of returning a proper error made it much less obvious that there was a kernel issue.

rocr-runtime crashed because it tried to release a queue that was never allocated as the scope guard didn't check if the queue had been allocated, and `ReleaseQueueMainScratch` as precondition requires the queue to have been allocated.

## Technical Details

Added a check that the queue was allocated before releasing it in the scope guard.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

@06kellyjac manually tested this.

## Test Result

Applying this PR caused the kernel bug to manifest as a proper error message instead of a segfault:

```
Loading model... -/build/source/ggml/src/ggml-cuda/ggml-cuda.cu:96: ROCm error
ROCm error: out of memory
  current device: 0, in function stream at /build/source/ggml/src/ggml-hip/../ggml-cuda/common.cuh:1345
  hipStreamCreateWithFlags(&streams[device][stream], 0x01)
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
