### PR TITLE
ROCM-1617 - Resolve potential issues with Drv memcpy tests

### DIFF
--- a/projects/hip-tests/catch/include/hip_test_common.hh
+++ b/projects/hip-tests/catch/include/hip_test_common.hh
@@ -62,6 +62,43 @@
 
 #define CHAR_BUF_SIZE 512
 
+class PeerAccessGuard {
+ public:
+  PeerAccessGuard() = default;
+
+  PeerAccessGuard(int src_device, int dst_device) { Enable(src_device, dst_device); }
+
+  void Enable(int src_device, int dst_device) {
+    if (enabled_ || src_device == dst_device) {
+      return;
+    }
+    src_device_ = src_device;
+    dst_device_ = dst_device;
+    int previous_device = 0;
+    HIP_CHECK(hipGetDevice(&previous_device));
+    HIP_CHECK(hipSetDevice(src_device_));
+    HIP_CHECK(hipDeviceEnablePeerAccess(dst_device_, 0));
+    HIP_CHECK(hipSetDevice(previous_device));
+    enabled_ = true;
+  }
+
+  ~PeerAccessGuard() {
+    if (!enabled_) {
+      return;
+    }
+    int current_device = 0;
+    hipGetDevice(&current_device);
+    hipSetDevice(src_device_);
+    static_cast<void>(hipDeviceDisablePeerAccess(dst_device_));
+    static_cast<void>(hipSetDevice(current_device));
+  }
+
+ private:
+  int src_device_{-1};
+  int dst_device_{-1};
+  bool enabled_{false};
+};
+
 #define CONSOLE_PRINT(fmt, ...)                                                                    \
   do {                                                                                             \
     std::printf(fmt "\n", ##__VA_ARGS__);                                                          \

--- a/projects/hip-tests/catch/unit/memory/hipDrvMemcpy2DUnaligned.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvMemcpy2DUnaligned.cc
@@ -46,11 +46,12 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy2DUnaligned_NegTst) {
   }
   HIP_CHECK(hipMemcpyHtoD(srcD, srcH, sizeof(int) * rows * cols));
 
-  hip_Memcpy2D pCopy;
+  hip_Memcpy2D pCopy{};
 
   SECTION(
       "srcY(second argument) + non-zero WidthInBytes(15th argument)\
            * Height(16th argument) points to unallocated memory") {
+    pCopy = {};
     pCopy.srcXInBytes = 0;
     pCopy.srcY = rows;
     pCopy.srcMemoryType = hipMemoryTypeDevice;
@@ -68,6 +69,7 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy2DUnaligned_NegTst) {
   SECTION(
       "srcHost(4th argument), srcDevice(5th argument), srcArray(6th\
           argument) passed nullptr") {
+    pCopy = {};
     pCopy.srcXInBytes = 0;
     pCopy.srcY = 0;
     pCopy.dstXInBytes = 0;
@@ -95,6 +97,7 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy2DUnaligned_NegTst) {
   SECTION(
       "dstY(second argument) + non-zero WidthInBytes(15th argument)\
            * Height(16th argument) points to unallocated memory") {
+    pCopy = {};
     pCopy.srcXInBytes = 0;
     pCopy.srcY = 0;
     pCopy.srcMemoryType = hipMemoryTypeDevice;
@@ -112,6 +115,7 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy2DUnaligned_NegTst) {
   SECTION(
       "dstHost(4th argument), dstDevice(5th argument), dstArray(6th\
           argument) passed nullptr") {
+    pCopy = {};
     pCopy.srcXInBytes = 0;
     pCopy.srcY = 0;
     pCopy.srcMemoryType = hipMemoryTypeDevice;
@@ -139,6 +143,7 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy2DUnaligned_NegTst) {
   SECTION(
       "WidthInBytes * Height greater than allocated memory(both src \
           and dst)") {
+    pCopy = {};
     pCopy.srcXInBytes = 0;
     pCopy.srcY = 0;
     pCopy.srcMemoryType = hipMemoryTypeDevice;
@@ -153,10 +158,10 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy2DUnaligned_NegTst) {
     pCopy.dstPitch = cols * sizeof(int);
     HIP_CHECK_ERROR(hipDrvMemcpy2DUnaligned(&pCopy), hipErrorInvalidValue);
   }
-  HIP_CHECK(hipFree(srcH));
+  HIP_CHECK(hipHostFree(srcH));
   HIP_CHECK(hipFree(srcD));
   HIP_CHECK(hipFree(dstD));
-  HIP_CHECK(hipFree(dstH));
+  HIP_CHECK(hipHostFree(dstH));
 }
 
 /**
@@ -178,19 +183,18 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy2DUnaligned_FuncTst) {
     int rows, cols;
     rows = GENERATE(3, 4, 100);
     cols = GENERATE(3, 4, 100);
-    int *srcD, *srcH;
-    int *dstD, *dstH;
+    int *srcD, *dstD;
     HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&srcD), sizeof(int) * rows * cols));
     HIP_CHECK(hipMalloc(reinterpret_cast<void**>(&dstD), sizeof(int) * rows * cols));
-    srcH = reinterpret_cast<int*>(malloc(sizeof(int) * rows * cols));
-    dstH = reinterpret_cast<int*>(malloc(sizeof(int) * rows * cols));
+    LinearAllocGuard<int> srcH(LinearAllocs::malloc, sizeof(int) * rows * cols);
+    LinearAllocGuard<int> dstH(LinearAllocs::malloc, sizeof(int) * rows * cols);
 
     // initialise array with corresponding index values
     for (int i = 0; i < rows * cols; i++) {
-      srcH[i] = i;
+      srcH.ptr()[i] = i;
     }
 
-    hip_Memcpy2D pCopy;
+    hip_Memcpy2D pCopy{};
     pCopy.srcXInBytes = 0;
     pCopy.srcY = 0;
     pCopy.dstXInBytes = 0;
@@ -201,46 +205,44 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy2DUnaligned_FuncTst) {
     pCopy.dstPitch = cols * sizeof(int);
 
     SECTION("Device to Device") {
-      HIP_CHECK(hipMemcpyHtoD(srcD, srcH, sizeof(int) * rows * cols));
+      HIP_CHECK(hipMemcpyHtoD(srcD, srcH.ptr(), sizeof(int) * rows * cols));
       pCopy.srcMemoryType = hipMemoryTypeDevice;
       pCopy.dstMemoryType = hipMemoryTypeDevice;
       pCopy.srcDevice = srcD;
       pCopy.dstDevice = dstD;
       HIP_CHECK(hipDrvMemcpy2DUnaligned(&pCopy));
-      HIP_CHECK(hipMemcpyDtoH(dstH, dstD, sizeof(int) * rows * cols));
+      HIP_CHECK(hipMemcpyDtoH(dstH.ptr(), dstD, sizeof(int) * rows * cols));
     }
     SECTION("Device to Host") {
-      HIP_CHECK(hipMemcpyHtoD(srcD, srcH, sizeof(int) * rows * cols));
+      HIP_CHECK(hipMemcpyHtoD(srcD, srcH.ptr(), sizeof(int) * rows * cols));
       pCopy.srcMemoryType = hipMemoryTypeDevice;
       pCopy.dstMemoryType = hipMemoryTypeHost;
       pCopy.srcDevice = srcD;
-      pCopy.dstHost = dstH;
+      pCopy.dstHost = dstH.ptr();
       HIP_CHECK(hipDrvMemcpy2DUnaligned(&pCopy));
     }
     SECTION("Host to Device") {
       pCopy.srcMemoryType = hipMemoryTypeHost;
       pCopy.dstMemoryType = hipMemoryTypeDevice;
-      pCopy.srcHost = srcH;
+      pCopy.srcHost = srcH.ptr();
       pCopy.dstDevice = dstD;
       HIP_CHECK(hipDrvMemcpy2DUnaligned(&pCopy));
-      HIP_CHECK(hipMemcpyDtoH(dstH, dstD, sizeof(int) * rows * cols));
+      HIP_CHECK(hipMemcpyDtoH(dstH.ptr(), dstD, sizeof(int) * rows * cols));
     }
     SECTION("Host to Host") {
       pCopy.srcMemoryType = hipMemoryTypeHost;
       pCopy.dstMemoryType = hipMemoryTypeHost;
-      pCopy.srcHost = srcH;
-      pCopy.dstHost = dstH;
+      pCopy.srcHost = srcH.ptr();
+      pCopy.dstHost = dstH.ptr();
       HIP_CHECK(hipDrvMemcpy2DUnaligned(&pCopy));
     }
 
     for (int i = 0; i < rows * cols; i++) {
-      REQUIRE(dstH[i] == i);
+      REQUIRE(dstH.ptr()[i] == i);
     }
 
     HIP_CHECK(hipFree(srcD));
     HIP_CHECK(hipFree(dstD));
-    free(srcH);
-    free(dstH);
   }
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3DAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3DAsync.cc
@@ -121,7 +121,7 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy3DAsync_Negative_Parameters) {
       int attr = 0;
       HIP_CHECK(hipDeviceGetAttribute(&attr, hipDeviceAttributeMaxPitch, 0));
       hipPitchedPtr invalid_ptr = dst_ptr;
-      invalid_ptr.pitch = attr;
+      invalid_ptr.pitch = static_cast<size_t>(attr) + 1;
       HIP_CHECK_ERROR(
           DrvMemcpy3DWrapper<async>(invalid_ptr, dst_pos, src_ptr, src_pos, extent, kind),
           hipErrorInvalidValue);
@@ -131,7 +131,7 @@ HIP_TEST_CASE(Unit_hipDrvMemcpy3DAsync_Negative_Parameters) {
       int attr = 0;
       HIP_CHECK(hipDeviceGetAttribute(&attr, hipDeviceAttributeMaxPitch, 0));
       hipPitchedPtr invalid_ptr = src_ptr;
-      invalid_ptr.pitch = attr;
+      invalid_ptr.pitch = static_cast<size_t>(attr) + 1;
       HIP_CHECK_ERROR(
           DrvMemcpy3DWrapper<async>(dst_ptr, dst_pos, invalid_ptr, src_pos, extent, kind),
           hipErrorInvalidValue);

--- a/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3DAsync_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3DAsync_old.cc
@@ -34,13 +34,14 @@
 
 template <typename T> class DrvMemcpy3DAsync {
   int width, height, depth;
-  unsigned int size;
+  size_t size;
   hipArray_Format formatKind;
   hipArray_t arr, arr1;
   hipStream_t stream;
   size_t pitch_D, pitch_E;
   HIP_MEMCPY3D myparms;
   hipDeviceptr_t D_m, E_m;
+  hipPitchedPtr pitched_D, pitched_E;
   T* hData{nullptr};
 
  public:
@@ -56,18 +57,24 @@ template <typename T> class DrvMemcpy3DAsync {
 };
 
 /* Intializes class variables */
-template <typename T> DrvMemcpy3DAsync<T>::DrvMemcpy3DAsync(int l_width, int l_height, int l_depth,
+template <typename T> DrvMemcpy3DAsync<T>::DrvMemcpy3DAsync(size_t l_width, size_t l_height, size_t l_depth,
                                                             hipArray_Format l_format) {
   width = l_width;
   height = l_height;
   depth = l_depth;
   formatKind = l_format;
+  stream = nullptr;
+  arr = nullptr;
+  arr1 = nullptr;
+  D_m = 0;
+  E_m = 0;
 }
 
 /* Allocating Memory */
 template <typename T> void DrvMemcpy3DAsync<T>::AllocateMemory() {
   size = width * height * depth * sizeof(T);
   hData = reinterpret_cast<T*>(malloc(size));
+  REQUIRE(hData != nullptr);
   memset(hData, 0, size);
   for (int i = 0; i < depth; i++) {
     for (int j = 0; j < height; j++) {
@@ -76,19 +83,23 @@ template <typename T> void DrvMemcpy3DAsync<T>::AllocateMemory() {
       }
     }
   }
-  HIP_CHECK(hipStreamCreate(&stream));
-  HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&D_m), &pitch_D, width * sizeof(T), height));
-  HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&E_m), &pitch_E, width * sizeof(T), height));
-  HIP_ARRAY3D_DESCRIPTOR* desc;
-  desc = reinterpret_cast<HIP_ARRAY3D_DESCRIPTOR*>(malloc(sizeof(HIP_ARRAY3D_DESCRIPTOR)));
-  desc->Format = formatKind;
-  desc->NumChannels = 1;
-  desc->Width = width;
-  desc->Height = height;
-  desc->Depth = depth;
-  desc->Flags = hipArrayDefault;
-  HIP_CHECK(hipArray3DCreate(&arr, desc));
-  HIP_CHECK(hipArray3DCreate(&arr1, desc));
+  hipExtent extent = make_hipExtent(width * sizeof(T), height, depth);
+  HIP_CHECK(hipMalloc3D(&pitched_D, extent));
+  HIP_CHECK(hipMalloc3D(&pitched_E, extent));
+  D_m = reinterpret_cast<hipDeviceptr_t>(pitched_D.ptr);
+  E_m = reinterpret_cast<hipDeviceptr_t>(pitched_E.ptr);
+  pitch_D = pitched_D.pitch;
+  pitch_E = pitched_E.pitch;
+
+  HIP_ARRAY3D_DESCRIPTOR desc{};
+  desc.Format = formatKind;
+  desc.NumChannels = 1;
+  desc.Width = width;
+  desc.Height = height;
+  desc.Depth = depth;
+  desc.Flags = hipArrayDefault;
+  HIP_CHECK(hipArray3DCreate(&arr, &desc));
+  HIP_CHECK(hipArray3DCreate(&arr1, &desc));
 }
 
 /* Setting the default data */
@@ -114,25 +125,39 @@ hipDrvMemcpy3DAsync API
 template <typename T> void DrvMemcpy3DAsync<T>::NegativeTests() {
   HIP_CHECK(hipSetDevice(0));
   AllocateMemory();
+  HIP_CHECK(hipStreamCreate(&stream));
   SetDefaultData();
   int deviceId;
   HIP_CHECK(hipGetDevice(&deviceId));
-  unsigned int MaxPitch;
-  HIP_CHECK(hipDeviceGetAttribute(reinterpret_cast<int*>(&MaxPitch), hipDeviceAttributeMaxPitch,
-                                  deviceId));
-  myparms.srcHost = hData;
-  myparms.dstArray = arr;
-  myparms.srcPitch = width * sizeof(T);
-  myparms.srcHeight = height;
-  myparms.srcMemoryType = hipMemoryTypeHost;
-  myparms.dstMemoryType = hipMemoryTypeArray;
+  int max_pitch = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&max_pitch, hipDeviceAttributeMaxPitch, deviceId));
+  unsigned int MaxPitch = static_cast<unsigned int>(max_pitch);
+  auto reset_params = [&]() {
+    SetDefaultData();
+    myparms.srcHost = hData;
+    myparms.dstHost = nullptr;
+    myparms.srcArray = nullptr;
+    myparms.dstArray = arr;
+    myparms.srcDevice = hipDeviceptr_t(nullptr);
+    myparms.dstDevice = hipDeviceptr_t(nullptr);
+    myparms.srcPitch = width * sizeof(T);
+    myparms.srcHeight = height;
+    myparms.dstPitch = 0;
+    myparms.dstHeight = 0;
+    myparms.srcMemoryType = hipMemoryTypeHost;
+    myparms.dstMemoryType = hipMemoryTypeArray;
+  };
+
+  reset_params();
 
   SECTION("Passing nullptr to Source Host") {
+    reset_params();
     myparms.srcHost = nullptr;
     REQUIRE(hipDrvMemcpy3DAsync(&myparms, stream) != hipSuccess);
   }
 
   SECTION("Passing both dst host and device") {
+    reset_params();
     myparms.dstHost = hData;
     myparms.dstArray = nullptr;
     myparms.dstDevice = D_m;
@@ -142,6 +167,7 @@ template <typename T> void DrvMemcpy3DAsync<T>::NegativeTests() {
   }
 
   SECTION("Passing max value to WidthInBytes") {
+    reset_params();
     myparms.WidthInBytes = std::numeric_limits<int>::max();
     myparms.Height = std::numeric_limits<int>::max();
     myparms.Depth = std::numeric_limits<int>::max();
@@ -149,21 +175,25 @@ template <typename T> void DrvMemcpy3DAsync<T>::NegativeTests() {
   }
 
   SECTION("Passing width > max width size") {
+    reset_params();
     myparms.WidthInBytes = width * sizeof(T) + 1;
     REQUIRE(hipDrvMemcpy3DAsync(&myparms, stream) != hipSuccess);
   }
 
   SECTION("Passing height > max height size") {
+    reset_params();
     myparms.Height = height + 1;
     REQUIRE(hipDrvMemcpy3DAsync(&myparms, stream) != hipSuccess);
   }
 
   SECTION("Passing depth > max depth size") {
+    reset_params();
     myparms.Depth = depth + 1;
     REQUIRE(hipDrvMemcpy3DAsync(&myparms, stream) != hipSuccess);
   }
 
   SECTION("widthinbytes + srcXinBytes is out of bound") {
+    reset_params();
     myparms.srcXInBytes = 1;
     myparms.dstArray = nullptr;
     myparms.dstDevice = hipDeviceptr_t(D_m);
@@ -174,6 +204,7 @@ template <typename T> void DrvMemcpy3DAsync<T>::NegativeTests() {
   }
 
   SECTION("widthinbytes + dstXinBytes is out of bound") {
+    reset_params();
     myparms.dstXInBytes = pitch_D;
     myparms.dstArray = nullptr;
     myparms.dstDevice = hipDeviceptr_t(D_m);
@@ -184,6 +215,7 @@ template <typename T> void DrvMemcpy3DAsync<T>::NegativeTests() {
   }
 
   SECTION("srcY + height is out of bound") {
+    reset_params();
     myparms.srcY = 1;
     myparms.dstArray = nullptr;
     myparms.dstDevice = hipDeviceptr_t(D_m);
@@ -194,6 +226,7 @@ template <typename T> void DrvMemcpy3DAsync<T>::NegativeTests() {
   }
 
   SECTION("dstY + height out of bounds") {
+    reset_params();
     myparms.dstY = 1;
     myparms.dstArray = nullptr;
     myparms.dstDevice = hipDeviceptr_t(D_m);
@@ -204,6 +237,7 @@ template <typename T> void DrvMemcpy3DAsync<T>::NegativeTests() {
   }
 
   SECTION("src pitch greater than Max allowed pitch") {
+    reset_params();
     myparms.srcMemoryType = hipMemoryTypeDevice;
     myparms.dstMemoryType = hipMemoryTypeHost;
     myparms.srcDevice = D_m;
@@ -218,6 +252,7 @@ template <typename T> void DrvMemcpy3DAsync<T>::NegativeTests() {
   }
 
   SECTION("dst pitch greater than Max allowed pitch") {
+    reset_params();
     myparms.dstDevice = hipDeviceptr_t(D_m);
     myparms.dstArray = nullptr;
     myparms.dstPitch = MaxPitch + 1;
@@ -227,6 +262,7 @@ template <typename T> void DrvMemcpy3DAsync<T>::NegativeTests() {
   }
 
   SECTION("Nullptr to src/dst device") {
+    reset_params();
     myparms.dstDevice = hipDeviceptr_t(nullptr);
     myparms.dstArray = nullptr;
     myparms.dstPitch = pitch_D;
@@ -236,6 +272,7 @@ template <typename T> void DrvMemcpy3DAsync<T>::NegativeTests() {
   }
 
   SECTION("Nullptr to src/dst array") {
+    reset_params();
     myparms.dstArray = nullptr;
     REQUIRE(hipDrvMemcpy3DAsync(&myparms, stream) != hipSuccess);
   }
@@ -254,6 +291,7 @@ template <typename T> void DrvMemcpy3DAsync<T>::Extent_Validation() {
   HIP_CHECK(hipSetDevice(0));
   // Allocating the memory
   AllocateMemory();
+  HIP_CHECK(hipStreamCreate(&stream));
 
   // Setting default data
   SetDefaultData();
@@ -303,6 +341,7 @@ void DrvMemcpy3DAsync<T>::HostDevice_DrvMemcpy3DAsync(bool device_context_change
   HIP_CHECK(hipSetDevice(0));
   bool skip_test = false;
   int peerAccess = 0;
+  bool peer_enabled = false;
   AllocateMemory();
   if (device_context_change) {
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 0, 1));
@@ -311,9 +350,12 @@ void DrvMemcpy3DAsync<T>::HostDevice_DrvMemcpy3DAsync(bool device_context_change
       skip_test = true;
     } else {
       HIP_CHECK(hipSetDevice(1));
+      HIP_CHECK(hipDeviceEnablePeerAccess(0, 0));
+      peer_enabled = true;
     }
   }
   if (!skip_test) {
+    HIP_CHECK(hipStreamCreate(&stream));
     SetDefaultData();
     myparms.srcMemoryType = hipMemoryTypeHost;
     myparms.dstMemoryType = hipMemoryTypeDevice;
@@ -339,6 +381,7 @@ void DrvMemcpy3DAsync<T>::HostDevice_DrvMemcpy3DAsync(bool device_context_change
     HIP_CHECK(hipDrvMemcpy3DAsync(&myparms, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
     T* hOutputData = reinterpret_cast<T*>(malloc(size));
+    REQUIRE(hOutputData != nullptr);
     memset(hOutputData, 0, size);
 
     // Device to host
@@ -357,6 +400,11 @@ void DrvMemcpy3DAsync<T>::HostDevice_DrvMemcpy3DAsync(bool device_context_change
     HipTest::checkArray(hData, hOutputData, width, height, depth);
     free(hOutputData);
   }
+  if (peer_enabled) {
+    HIP_CHECK(hipDeviceDisablePeerAccess(0));
+    peer_enabled = false;
+  }
+  HIP_CHECK(hipSetDevice(0));
   DeAllocateMemory();
 }
 
@@ -377,6 +425,7 @@ void DrvMemcpy3DAsync<T>::HostArray_DrvMemcpy3DAsync(bool device_context_change)
   HIP_CHECK(hipSetDevice(0));
   bool skip_test = false;
   int peerAccess = 0;
+  bool peer_enabled = false;
   AllocateMemory();
   if (device_context_change) {
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 0, 1));
@@ -385,9 +434,12 @@ void DrvMemcpy3DAsync<T>::HostArray_DrvMemcpy3DAsync(bool device_context_change)
       skip_test = true;
     } else {
       HIP_CHECK(hipSetDevice(1));
+      HIP_CHECK(hipDeviceEnablePeerAccess(0, 0));
+      peer_enabled = true;
     }
   }
   if (!skip_test) {
+    HIP_CHECK(hipStreamCreate(&stream));
     SetDefaultData();
     myparms.srcMemoryType = hipMemoryTypeHost;
     myparms.dstMemoryType = hipMemoryTypeArray;
@@ -406,6 +458,7 @@ void DrvMemcpy3DAsync<T>::HostArray_DrvMemcpy3DAsync(bool device_context_change)
     HIP_CHECK(hipDrvMemcpy3DAsync(&myparms, stream));
     HIP_CHECK(hipStreamSynchronize(stream));
     T* hOutputData = reinterpret_cast<T*>(malloc(size));
+    REQUIRE(hOutputData != nullptr);
     memset(hOutputData, 0, size);
     SetDefaultData();
     // Device to host
@@ -421,6 +474,11 @@ void DrvMemcpy3DAsync<T>::HostArray_DrvMemcpy3DAsync(bool device_context_change)
     HipTest::checkArray(hData, hOutputData, width, height, depth);
     free(hOutputData);
   }
+  if (peer_enabled) {
+    HIP_CHECK(hipDeviceDisablePeerAccess(0));
+    peer_enabled = false;
+  }
+  HIP_CHECK(hipSetDevice(0));
   DeAllocateMemory();
 }
 
@@ -428,7 +486,18 @@ void DrvMemcpy3DAsync<T>::HostArray_DrvMemcpy3DAsync(bool device_context_change)
 template <typename T> void DrvMemcpy3DAsync<T>::DeAllocateMemory() {
   HIP_CHECK(hipArrayDestroy(arr));
   HIP_CHECK(hipArrayDestroy(arr1));
-  HIP_CHECK(hipStreamDestroy(stream));
+  if (stream != nullptr) {
+    HIP_CHECK(hipStreamDestroy(stream));
+    stream = nullptr;
+  }
+  if (D_m) {
+    HIP_CHECK(hipFree(reinterpret_cast<void*>(D_m)));
+    D_m = 0;
+  }
+  if (E_m) {
+    HIP_CHECK(hipFree(reinterpret_cast<void*>(E_m)));
+    E_m = 0;
+  }
   free(hData);
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3D_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3D_old.cc
@@ -31,19 +31,20 @@
 
 #include <hip_test_common.hh>
 #include <hip_test_checkers.hh>
+#include <resource_guards.hh>
 
 template <typename T> class DrvMemcpy3D {
-  int width, height, depth;
+  size_t width, height, depth;
   unsigned int size;
   hipArray_Format formatKind;
   hipArray_t arr, arr1;
   size_t pitch_D, pitch_E;
   HIP_MEMCPY3D myparms;
   hipDeviceptr_t D_m, E_m;
-  T* hData{nullptr};
+  LinearAllocGuard<T> hData;
 
  public:
-  DrvMemcpy3D(int l_width, int l_height, int l_depth, hipArray_Format l_format);
+  DrvMemcpy3D(size_t l_width, size_t l_height, size_t l_depth, hipArray_Format l_format);
   DrvMemcpy3D() = delete;
   void AllocateMemory();
   void SetDefaultData();
@@ -56,7 +57,7 @@ template <typename T> class DrvMemcpy3D {
 
 /* Intializes class variables */
 template <typename T>
-DrvMemcpy3D<T>::DrvMemcpy3D(int l_width, int l_height, int l_depth, hipArray_Format l_format) {
+DrvMemcpy3D<T>::DrvMemcpy3D(size_t l_width, size_t l_height, size_t l_depth, hipArray_Format l_format) {
   width = l_width;
   height = l_height;
   depth = l_depth;
@@ -66,13 +67,13 @@ DrvMemcpy3D<T>::DrvMemcpy3D(int l_width, int l_height, int l_depth, hipArray_For
 /* Allocating Memory */
 template <typename T> void DrvMemcpy3D<T>::AllocateMemory() {
   size = width * height * depth * sizeof(T);
-  hData = reinterpret_cast<T*>(malloc(size));
-  REQUIRE(hData != nullptr);
-  memset(hData, 0, size);
+  hData = LinearAllocGuard<T>(LinearAllocs::malloc, size);
+  REQUIRE(hData.ptr() != nullptr);
+  memset(hData.ptr(), 0, size);
   for (int i = 0; i < depth; i++) {
     for (int j = 0; j < height; j++) {
       for (int k = 0; k < width; k++) {
-        hData[i * width * height + j * width + k] = i * width * height + j * width + k;
+        hData.ptr()[i * width * height + j * width + k] = i * width * height + j * width + k;
       }
     }
   }
@@ -125,7 +126,7 @@ template <typename T> void DrvMemcpy3D<T>::NegativeTests() {
                                   deviceId));
   auto reset_params = [&]() {
     SetDefaultData();
-    myparms.srcHost = hData;
+    myparms.srcHost = hData.ptr();
     myparms.dstArray = arr;
     myparms.srcPitch = width * sizeof(T);
     myparms.srcHeight = height;
@@ -141,7 +142,7 @@ template <typename T> void DrvMemcpy3D<T>::NegativeTests() {
 
   SECTION("Passing both dst host and device") {
     reset_params();
-    myparms.dstHost = hData;
+    myparms.dstHost = hData.ptr();
     myparms.dstArray = nullptr;
     myparms.dstDevice = D_m;
     myparms.dstPitch = pitch_D;
@@ -229,7 +230,7 @@ template <typename T> void DrvMemcpy3D<T>::NegativeTests() {
     myparms.srcHost = nullptr;
     myparms.srcPitch = MaxPitch;
     myparms.srcHeight = height;
-    myparms.dstHost = hData;
+    myparms.dstHost = hData.ptr();
     myparms.dstArray = nullptr;
     myparms.dstPitch = width * sizeof(T);
     myparms.dstHeight = height;
@@ -279,7 +280,7 @@ template <typename T> void DrvMemcpy3D<T>::Extent_Validation() {
   SetDefaultData();
   myparms.srcMemoryType = hipMemoryTypeHost;
   myparms.dstMemoryType = hipMemoryTypeDevice;
-  myparms.srcHost = hData;
+  myparms.srcHost = hData.ptr();
   myparms.srcPitch = width * sizeof(T);
   myparms.srcHeight = height;
   myparms.dstDevice = D_m;
@@ -335,7 +336,7 @@ template <typename T> void DrvMemcpy3D<T>::HostDevice_DrvMemcpy3D(bool device_co
     SetDefaultData();
     myparms.srcMemoryType = hipMemoryTypeHost;
     myparms.dstMemoryType = hipMemoryTypeDevice;
-    myparms.srcHost = hData;
+    myparms.srcHost = hData.ptr();
     myparms.srcPitch = width * sizeof(T);
     myparms.srcHeight = height;
     myparms.dstDevice = hipDeviceptr_t(D_m);
@@ -370,7 +371,7 @@ template <typename T> void DrvMemcpy3D<T>::HostDevice_DrvMemcpy3D(bool device_co
     myparms.dstHeight = height;
     HIP_CHECK(hipDrvMemcpy3D(&myparms));
 
-    HipTest::checkArray(hData, hOutputData, width, height, depth);
+    HipTest::checkArray(hData.ptr(), hOutputData, width, height, depth);
     free(hOutputData);
   }
   HIP_CHECK(hipSetDevice(0));
@@ -409,7 +410,7 @@ template <typename T> void DrvMemcpy3D<T>::HostArray_DrvMemcpy3D(bool device_con
     SetDefaultData();
     myparms.srcMemoryType = hipMemoryTypeHost;
     myparms.dstMemoryType = hipMemoryTypeArray;
-    myparms.srcHost = hData;
+    myparms.srcHost = hData.ptr();
     myparms.srcPitch = width * sizeof(T);
     myparms.srcHeight = height;
     myparms.dstArray = arr;
@@ -434,7 +435,7 @@ template <typename T> void DrvMemcpy3D<T>::HostArray_DrvMemcpy3D(bool device_con
     myparms.dstHeight = height;
     HIP_CHECK(hipDrvMemcpy3D(&myparms));
 
-    HipTest::checkArray(hData, hOutputData, width, height, depth);
+    HipTest::checkArray(hData.ptr(), hOutputData, width, height, depth);
     free(hOutputData);
   }
   HIP_CHECK(hipSetDevice(0));
@@ -446,7 +447,7 @@ template <typename T> void DrvMemcpy3D<T>::DeAllocateMemory() {
   HIP_CHECK(hipArrayDestroy(arr1));
   HIP_CHECK(hipFree(reinterpret_cast<void*>(D_m)));
   HIP_CHECK(hipFree(reinterpret_cast<void*>(E_m)));
-  free(hData);
+  hData = LinearAllocGuard<T>();
 }
 
 /**

--- a/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3D_old.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvMemcpy3D_old.cc
@@ -67,6 +67,7 @@ DrvMemcpy3D<T>::DrvMemcpy3D(int l_width, int l_height, int l_depth, hipArray_For
 template <typename T> void DrvMemcpy3D<T>::AllocateMemory() {
   size = width * height * depth * sizeof(T);
   hData = reinterpret_cast<T*>(malloc(size));
+  REQUIRE(hData != nullptr);
   memset(hData, 0, size);
   for (int i = 0; i < depth; i++) {
     for (int j = 0; j < height; j++) {
@@ -75,18 +76,23 @@ template <typename T> void DrvMemcpy3D<T>::AllocateMemory() {
       }
     }
   }
-  HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&D_m), &pitch_D, width * sizeof(T), height));
-  HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&E_m), &pitch_E, width * sizeof(T), height));
-  HIP_ARRAY3D_DESCRIPTOR* desc;
-  desc = reinterpret_cast<HIP_ARRAY3D_DESCRIPTOR*>(malloc(sizeof(HIP_ARRAY3D_DESCRIPTOR)));
-  desc->Format = formatKind;
-  desc->NumChannels = 1;
-  desc->Width = width;
-  desc->Height = height;
-  desc->Depth = depth;
-  desc->Flags = hipArrayDefault;
-  HIP_CHECK(hipArray3DCreate(&arr, desc));
-  HIP_CHECK(hipArray3DCreate(&arr1, desc));
+  const auto extent = make_hipExtent(width * sizeof(T), height, depth);
+  hipPitchedPtr pitched{};
+  HIP_CHECK(hipMalloc3D(&pitched, extent));
+  D_m = reinterpret_cast<hipDeviceptr_t>(pitched.ptr);
+  pitch_D = pitched.pitch;
+  HIP_CHECK(hipMalloc3D(&pitched, extent));
+  E_m = reinterpret_cast<hipDeviceptr_t>(pitched.ptr);
+  pitch_E = pitched.pitch;
+  HIP_ARRAY3D_DESCRIPTOR desc{};
+  desc.Format = formatKind;
+  desc.NumChannels = 1;
+  desc.Width = width;
+  desc.Height = height;
+  desc.Depth = depth;
+  desc.Flags = hipArrayDefault;
+  HIP_CHECK(hipArray3DCreate(&arr, &desc));
+  HIP_CHECK(hipArray3DCreate(&arr1, &desc));
 }
 
 /* Setting the default data */
@@ -112,34 +118,41 @@ hipDrvMemcpy3D API
 template <typename T> void DrvMemcpy3D<T>::NegativeTests() {
   HIP_CHECK(hipSetDevice(0));
   AllocateMemory();
-  SetDefaultData();
   int deviceId;
   HIP_CHECK(hipGetDevice(&deviceId));
   unsigned int MaxPitch;
   HIP_CHECK(hipDeviceGetAttribute(reinterpret_cast<int*>(&MaxPitch), hipDeviceAttributeMaxPitch,
                                   deviceId));
-  myparms.srcHost = hData;
-  myparms.dstArray = arr;
-  myparms.srcPitch = width * sizeof(T);
-  myparms.srcHeight = height;
-  myparms.srcMemoryType = hipMemoryTypeHost;
-  myparms.dstMemoryType = hipMemoryTypeArray;
+  auto reset_params = [&]() {
+    SetDefaultData();
+    myparms.srcHost = hData;
+    myparms.dstArray = arr;
+    myparms.srcPitch = width * sizeof(T);
+    myparms.srcHeight = height;
+    myparms.srcMemoryType = hipMemoryTypeHost;
+    myparms.dstMemoryType = hipMemoryTypeArray;
+  };
 
   SECTION("Passing nullptr to Source Host") {
+    reset_params();
     myparms.srcHost = nullptr;
     REQUIRE(hipDrvMemcpy3D(&myparms) != hipSuccess);
   }
 
   SECTION("Passing both dst host and device") {
+    reset_params();
     myparms.dstHost = hData;
     myparms.dstArray = nullptr;
     myparms.dstDevice = D_m;
+    myparms.dstPitch = pitch_D;
+    myparms.dstHeight = height;
     myparms.WidthInBytes = pitch_D;
     myparms.dstMemoryType = hipMemoryTypeDevice;
     REQUIRE(hipDrvMemcpy3D(&myparms) != hipSuccess);
   }
 
   SECTION("Passing max value to WidthInBytes") {
+    reset_params();
     myparms.WidthInBytes = std::numeric_limits<int>::max();
     myparms.Height = std::numeric_limits<int>::max();
     myparms.Depth = std::numeric_limits<int>::max();
@@ -147,21 +160,25 @@ template <typename T> void DrvMemcpy3D<T>::NegativeTests() {
   }
 
   SECTION("Passing width > max width size") {
+    reset_params();
     myparms.WidthInBytes = width * sizeof(T) + 1;
     REQUIRE(hipDrvMemcpy3D(&myparms) != hipSuccess);
   }
 
   SECTION("Passing height > max height size") {
+    reset_params();
     myparms.Height = height + 1;
     REQUIRE(hipDrvMemcpy3D(&myparms) != hipSuccess);
   }
 
   SECTION("Passing depth > max depth size") {
+    reset_params();
     myparms.Depth = depth + 1;
     REQUIRE(hipDrvMemcpy3D(&myparms) != hipSuccess);
   }
 
   SECTION("widthinbytes + srcXinBytes is out of bound") {
+    reset_params();
     myparms.srcXInBytes = 1;
     myparms.dstArray = nullptr;
     myparms.dstDevice = hipDeviceptr_t(D_m);
@@ -172,6 +189,7 @@ template <typename T> void DrvMemcpy3D<T>::NegativeTests() {
   }
 
   SECTION("widthinbytes + dstXinBytes is out of bound") {
+    reset_params();
     myparms.dstXInBytes = pitch_D;
     myparms.dstArray = nullptr;
     myparms.dstDevice = hipDeviceptr_t(D_m);
@@ -182,6 +200,7 @@ template <typename T> void DrvMemcpy3D<T>::NegativeTests() {
   }
 
   SECTION("srcY + height is out of bound") {
+    reset_params();
     myparms.srcY = 1;
     myparms.dstArray = nullptr;
     myparms.dstDevice = hipDeviceptr_t(D_m);
@@ -192,6 +211,7 @@ template <typename T> void DrvMemcpy3D<T>::NegativeTests() {
   }
 
   SECTION("dstY + height out of bounds") {
+    reset_params();
     myparms.dstY = 1;
     myparms.dstArray = nullptr;
     myparms.dstDevice = hipDeviceptr_t(D_m);
@@ -202,6 +222,7 @@ template <typename T> void DrvMemcpy3D<T>::NegativeTests() {
   }
 
   SECTION("src pitch greater than Max allowed pitch") {
+    reset_params();
     myparms.srcMemoryType = hipMemoryTypeDevice;
     myparms.dstMemoryType = hipMemoryTypeHost;
     myparms.srcDevice = D_m;
@@ -216,6 +237,7 @@ template <typename T> void DrvMemcpy3D<T>::NegativeTests() {
   }
 
   SECTION("dst pitch greater than Max allowed pitch") {
+    reset_params();
     myparms.dstDevice = hipDeviceptr_t(D_m);
     myparms.dstArray = nullptr;
     myparms.dstPitch = MaxPitch + 1;
@@ -225,6 +247,7 @@ template <typename T> void DrvMemcpy3D<T>::NegativeTests() {
   }
 
   SECTION("Nullptr to src/dst device") {
+    reset_params();
     myparms.dstDevice = hipDeviceptr_t(nullptr);
     myparms.dstArray = nullptr;
     myparms.dstPitch = pitch_D;
@@ -234,6 +257,7 @@ template <typename T> void DrvMemcpy3D<T>::NegativeTests() {
   }
 
   SECTION("Nullptr to src/dst array") {
+    reset_params();
     myparms.dstArray = nullptr;
     REQUIRE(hipDrvMemcpy3D(&myparms) != hipSuccess);
   }
@@ -295,6 +319,7 @@ template <typename T> void DrvMemcpy3D<T>::HostDevice_DrvMemcpy3D(bool device_co
   HIP_CHECK(hipSetDevice(0));
   bool skip_test = false;
   int peerAccess = 0;
+  PeerAccessGuard peer_guard;
   AllocateMemory();
   if (device_context_change) {
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 0, 1));
@@ -303,6 +328,7 @@ template <typename T> void DrvMemcpy3D<T>::HostDevice_DrvMemcpy3D(bool device_co
       skip_test = true;
     } else {
       HIP_CHECK(hipSetDevice(1));
+      peer_guard.Enable(1, 0);
     }
   }
   if (!skip_test) {
@@ -329,6 +355,7 @@ template <typename T> void DrvMemcpy3D<T>::HostDevice_DrvMemcpy3D(bool device_co
     myparms.dstHeight = height;
     HIP_CHECK(hipDrvMemcpy3D(&myparms));
     T* hOutputData = reinterpret_cast<T*>(malloc(size));
+    REQUIRE(hOutputData != nullptr);
     memset(hOutputData, 0, size);
 
     // Device to host
@@ -346,6 +373,7 @@ template <typename T> void DrvMemcpy3D<T>::HostDevice_DrvMemcpy3D(bool device_co
     HipTest::checkArray(hData, hOutputData, width, height, depth);
     free(hOutputData);
   }
+  HIP_CHECK(hipSetDevice(0));
   DeAllocateMemory();
 }
 
@@ -365,6 +393,7 @@ template <typename T> void DrvMemcpy3D<T>::HostArray_DrvMemcpy3D(bool device_con
   HIP_CHECK(hipSetDevice(0));
   bool skip_test = false;
   int peerAccess = 0;
+  PeerAccessGuard peer_guard;
   AllocateMemory();
   if (device_context_change) {
     HIP_CHECK(hipDeviceCanAccessPeer(&peerAccess, 0, 1));
@@ -373,6 +402,7 @@ template <typename T> void DrvMemcpy3D<T>::HostArray_DrvMemcpy3D(bool device_con
       skip_test = true;
     } else {
       HIP_CHECK(hipSetDevice(1));
+      peer_guard.Enable(1, 0);
     }
   }
   if (!skip_test) {
@@ -392,6 +422,7 @@ template <typename T> void DrvMemcpy3D<T>::HostArray_DrvMemcpy3D(bool device_con
     myparms.dstArray = arr1;
     HIP_CHECK(hipDrvMemcpy3D(&myparms));
     T* hOutputData = reinterpret_cast<T*>(malloc(size));
+    REQUIRE(hOutputData != nullptr);
     memset(hOutputData, 0, size);
     SetDefaultData();
     // Device to host
@@ -406,12 +437,15 @@ template <typename T> void DrvMemcpy3D<T>::HostArray_DrvMemcpy3D(bool device_con
     HipTest::checkArray(hData, hOutputData, width, height, depth);
     free(hOutputData);
   }
+  HIP_CHECK(hipSetDevice(0));
   DeAllocateMemory();
 }
 /* DeAllocating the memory */
 template <typename T> void DrvMemcpy3D<T>::DeAllocateMemory() {
   HIP_CHECK(hipArrayDestroy(arr));
   HIP_CHECK(hipArrayDestroy(arr1));
+  HIP_CHECK(hipFree(reinterpret_cast<void*>(D_m)));
+  HIP_CHECK(hipFree(reinterpret_cast<void*>(E_m)));
   free(hData);
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipDrvPtrGetAttributes.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDrvPtrGetAttributes.cc
@@ -36,7 +36,7 @@ HIP_TEST_CASE(Unit_hipDrvPtrGetAttributes_Negative) {
 
   HIP_CHECK(hipMalloc(&A_d, Nbytes));
   HIP_CHECK(hipGetDevice(&deviceId));
-  unsigned int device_ordinal;
+  int device_ordinal;
   int* dev_ptr{nullptr};
   void* data[2];
   data[0] = &dev_ptr;
@@ -68,14 +68,6 @@ HIP_TEST_CASE(Unit_hipDrvPtrGetAttributes_Negative) {
     REQUIRE(hipDrvPointerGetAttributes(2, attributes, data, ptr) == hipErrorInvalidValue);
   }
 #endif
-#if HT_NVIDIA
-  SECTION("Passing invalid dependencies") {
-    hipPointer_attribute attributes1[] = {HIP_POINTER_ATTRIBUTE_DEVICE_POINTER};
-    REQUIRE(
-        hipDrvPointerGetAttributes(2, attributes1, data, reinterpret_cast<hipDeviceptr_t>(A_d)) ==
-        hipErrorInvalidValue);
-  }
-#endif
 
   HIP_CHECK(hipFree(A_d));
 }
@@ -98,7 +90,7 @@ HIP_TEST_CASE(Unit_hipDrvPtrGetAttributes_Functional) {
     int* dev{nullptr};
     int* dev_ptr{nullptr};
     int* dev_ptr1{nullptr};
-    unsigned int range_size;
+    size_t range_size;
     int* start_addr{nullptr};
     void* data[5];
     data[0] = (&memory_type);

--- a/projects/hip-tests/catch/unit/memory/memcpy2d_tests_common.hh
+++ b/projects/hip-tests/catch/unit/memory/memcpy2d_tests_common.hh
@@ -67,11 +67,13 @@ void Memcpy2DDeviceToDeviceShell(F memcpy_func, const hipStream_t kernel_stream 
   }
 
   HIP_CHECK(hipSetDevice(src_device));
+  bool peer_access_enabled = false;
   if constexpr (enable_peer_access) {
     if (src_device == dst_device) {
       return;
     }
     HIP_CHECK(hipDeviceEnablePeerAccess(dst_device, 0));
+    peer_access_enabled = true;
   }
 
   LinearAllocGuard2D<int, unaligned> src_alloc(cols * src_cols_mult, rows);
@@ -100,6 +102,13 @@ void Memcpy2DDeviceToDeviceShell(F memcpy_func, const hipStream_t kernel_stream 
   constexpr auto f = [](size_t x, size_t y, size_t z) { return z * cols * rows + y * cols + x; };
   PitchedMemoryVerify(host_alloc.ptr(), dst_alloc.width(), dst_alloc.width_logical(),
                       dst_alloc.height(), 1, f);
+
+  if constexpr (enable_peer_access) {
+    if (peer_access_enabled) {
+      HIP_CHECK(hipSetDevice(src_device));
+      HIP_CHECK(hipDeviceDisablePeerAccess(dst_device));
+    }
+  }
 }
 
 template <bool should_synchronize, bool unaligned = false, typename F>


### PR DESCRIPTION
## Motivation

The current CI occationally is flakey with failures due to UB, and correctness issues. This change addresses some of those issues in the memory tests

## Technical Details

hipDrvMemcpy2DUnaligned.cc 
	* Reset parameters before each SECTION
	* Free pinned host memory with hipHostFree not hipFree
	* srcH and srcD need to check, that they are not nullptr's after malloc. Implemented this using RAII class LinearAllocGuard
hipDrvMemcpy3DAsync.cc
	* Passes actually invalid pitch, i.e. MaxPitch + 1
hipDrvMemcpy3DAsync_old.cc
	* Handle peer access enable/disable
	* Allocate 3D memory correctly, currently missing depth we are just allocating 2D
	* Reset parameters between SECTION's
	* Construct stream, I think previously it was left uninitialized and all work was on the default stream
	* Fix memory leak
hipDrvPtrGetAttributes.cc
	* Type mismatchs
	* remove incorrect nvidia test, with buffer overflow

## JIRA ID

Partial solution: ROCM-1617

## Test Plan

NA

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
