### PR TITLE
ROCM-1617 - Resolve hip mem array and some mempool issues

### DIFF
--- a/projects/hip-tests/catch/include/hip_test_checkers.hh
+++ b/projects/hip-tests/catch/include/hip_test_checkers.hh
@@ -79,7 +79,7 @@ bool checkArray(T* hData, T* hOutputData, size_t width, size_t height, size_t de
   for (size_t i = 0; i < depth; i++) {
     for (size_t j = 0; j < height; j++) {
       for (size_t k = 0; k < width; k++) {
-        int offset = i * width * height + j * width + k;
+        size_t offset = i * width * height + j * width + k;
         if (!isEqual(hData[offset], hOutputData[offset])) {
           INFO("Mismatch at [" << i << "," << j << "," << k << "]:" << getString(hData[offset])
                                << "----" << getString(hOutputData[offset]));

--- a/projects/hip-tests/catch/include/memcpy3d_tests_common.hh
+++ b/projects/hip-tests/catch/include/memcpy3d_tests_common.hh
@@ -176,6 +176,7 @@ void Memcpy3DDeviceToDeviceShell(F memcpy_func, hipStream_t kernel_stream = null
   INFO("Src device: " << src_device << ", Dst device: " << dst_device);
 
   HIP_CHECK(hipSetDevice(src_device));
+  PeerAccessGuard peer_guard;
   if (device_count > 0 && kernel_stream != nullptr && kernel_stream != hipStreamPerThread) {
     HIP_CHECK(hipStreamCreate(&kernel_stream));
   }
@@ -197,7 +198,7 @@ void Memcpy3DDeviceToDeviceShell(F memcpy_func, hipStream_t kernel_stream = null
       }
       return;
     }
-    HIP_CHECK(hipDeviceEnablePeerAccess(dst_device, 0));
+    peer_guard.Enable(src_device, dst_device);
   }
 
   LinearAllocGuard3D<int> src_alloc(extent);

--- a/projects/hip-tests/catch/unit/memory/hipArrayCommon.hh
+++ b/projects/hip-tests/catch/unit/memory/hipArrayCommon.hh
@@ -37,6 +37,9 @@ __global__ void readFromTexture(T* output, hipTextureObject_t texObj, size_t wid
   // Calculate normalized texture coordinates
   const unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
   const unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+  if (x >= width || (height != 0 && y >= height)) {
+    return;
+  }
   const float u = x / (float)width;
 
   // Read from texture and write to global memory

--- a/projects/hip-tests/catch/unit/memory/hipArrayCreate.cc
+++ b/projects/hip-tests/catch/unit/memory/hipArrayCreate.cc
@@ -155,7 +155,11 @@ void testArrayAsTexture(hipArray_t array, const size_t width, const size_t heigh
   // set hip array
   std::vector<scalar_type> hostData(width * h * vec_info::size);
   // assigned ascending values to the data array to show indexing is working
-  std::iota(std::begin(hostData), std::end(hostData), 0);
+  // Avoid signed char overflow (UB) by generating in a wider type first.
+  std::vector<int> hostDataSeed(hostData.size());
+  std::iota(std::begin(hostDataSeed), std::end(hostDataSeed), 0);
+  std::transform(hostDataSeed.begin(), hostDataSeed.end(), hostData.begin(),
+                 [](int value) { return static_cast<scalar_type>(value); });
 
   copyToArray(array, hostData, height);
 
@@ -180,9 +184,10 @@ void testArrayAsTexture(hipArray_t array, const size_t width, const size_t heigh
   // run kernel
   T* device_data{};
   HIP_CHECK(hipMalloc(&device_data, size));
-  readFromTexture<<<dim3(width / BlockSize, height ? height / BlockSize : 1, 1),
-                    dim3(BlockSize, height ? BlockSize : 1, 1)>>>(device_data, textObj, width,
-                                                                  height, false);
+  const auto grid_x = ceil_div(width, BlockSize);
+  const auto grid_y = height ? ceil_div(height, BlockSize) : 1;
+  readFromTexture<<<dim3(grid_x, grid_y, 1), dim3(BlockSize, height ? BlockSize : 1, 1)>>>(
+      device_data, textObj, width, height, false);
   HIP_CHECK(hipGetLastError());  // check for errors when running the kernel
 
   // copy data back and then test it

--- a/projects/hip-tests/catch/unit/memory/hipArrayGetDescriptor.cc
+++ b/projects/hip-tests/catch/unit/memory/hipArrayGetDescriptor.cc
@@ -20,14 +20,15 @@ THE SOFTWARE.
 #include <string.h>
 
 #include <cstring>
+#include <atomic>
 #include <vector>
 
 #include <hip_test_common.hh>
 #include <hip_test_defgroups.hh>
 #include <resource_guards.hh>
 
-static bool testPassed1D = false;
-static bool testPassed2D = false;
+static std::atomic<bool> testPassed1D{false};
+static std::atomic<bool> testPassed2D{false};
 static constexpr auto NUM_ELM{1024};
 /**
  * @addtogroup hipArrayGetDescriptor
@@ -52,6 +53,9 @@ hipArray_t arrayCreate1D(int format, int channel) {
     case 4:
       desc.NumChannels = channel;
       break;
+    default:
+      INFO("Unsupported number of channels: " << channel);
+      REQUIRE(false);
   }
   desc.Width = 16;
   desc.Height = 0;
@@ -165,11 +169,9 @@ void thread_funct1D(hipArray_t array) {
   HIP_ARRAY_DESCRIPTOR desc;
   HIP_CHECK(hipArrayGetDescriptor(&desc, array));
   // Verify array parameters
-  if ((desc.NumChannels == 2) && (desc.Width == 16) && (desc.Height == 0) &&
-      (desc.Format == HIP_AD_FORMAT_HALF)) {
-    testPassed1D = true;
-  } else {
-    testPassed1D = false;
+  if (!((desc.NumChannels == 2) && (desc.Width == 16) && (desc.Height == 0) &&
+        (desc.Format == HIP_AD_FORMAT_HALF))) {
+    testPassed1D.store(false, std::memory_order_relaxed);
   }
 }
 // Thread function for 2D Array
@@ -177,11 +179,9 @@ void thread_funct2D(hipArray_t array) {
   HIP_ARRAY_DESCRIPTOR desc;
   HIP_CHECK(hipArrayGetDescriptor(&desc, array));
   // Verify array parameters
-  if ((desc.NumChannels == 1) && (desc.Width == 4) && (desc.Height == 4) &&
-      (desc.Format == HIP_AD_FORMAT_FLOAT)) {
-    testPassed2D = true;
-  } else {
-    testPassed2D = false;
+  if (!((desc.NumChannels == 1) && (desc.Width == 4) && (desc.Height == 4) &&
+        (desc.Format == HIP_AD_FORMAT_FLOAT))) {
+    testPassed2D.store(false, std::memory_order_relaxed);
   }
 }
 // 1D Array of type float
@@ -211,13 +211,16 @@ float* funcToChkArray(hipArray_t array) {
   HIP_ARRAY_DESCRIPTOR desc;
   HIP_CHECK(hipArrayGetDescriptor(&desc, array));
   float* A_h = nullptr;
-  static constexpr auto NUM_ELM{1024};
-  size_t mem_size = NUM_ELM * sizeof(float);
+  const size_t elements = desc.Height ? desc.Width * desc.Height : desc.Width;
+  size_t mem_size = elements * sizeof(float);
   if (desc.Format == HIP_AD_FORMAT_FLOAT) {
     A_h = reinterpret_cast<float*>(malloc(mem_size));
-    for (int i = 0; i < NUM_ELM; i++) {
+    for (size_t i = 0; i < elements; i++) {
       A_h[i] = 2.0;
     }
+  } else {
+    INFO("Unsupported format: " << desc.Format);
+    return nullptr;
   }
   HIP_CHECK(hipMemcpyAtoH(A_h, array, 0, mem_size));
   return A_h;
@@ -336,6 +339,8 @@ TEST_CASE("Unit_hipArrayGetDescriptor_MultiThreadScenarioFor1D_2D_Array",
     hipArray_t array_t2 = arrayCreate2D_Thread();
     std::vector<std::thread> ThreadVector1D;
     std::vector<std::thread> ThreadVector2D;
+    testPassed1D.store(true, std::memory_order_relaxed);
+    testPassed2D.store(true, std::memory_order_relaxed);
     for (int j = 0; j < 10; j++) {
       ThreadVector1D.emplace_back([&]() { thread_funct1D(array_t1); });
       ThreadVector2D.emplace_back([&]() { thread_funct2D(array_t2); });
@@ -347,8 +352,8 @@ TEST_CASE("Unit_hipArrayGetDescriptor_MultiThreadScenarioFor1D_2D_Array",
       t.join();
     }
     // Validation
-    REQUIRE(testPassed1D);
-    REQUIRE(testPassed2D);
+    REQUIRE(testPassed1D.load(std::memory_order_relaxed));
+    REQUIRE(testPassed2D.load(std::memory_order_relaxed));
     HIP_CHECK(hipArrayDestroy(array_t1));
     HIP_CHECK(hipArrayDestroy(array_t2));
 #if HT_NVIDIA
@@ -403,23 +408,23 @@ TEST_CASE("Unit_hipArrayGetDescriptor_Host2Array_Array2Host", "[multigpu]") {
     HIP_CHECK(hipArrayDestroy(arraySimple1D));
     SECTION("2D Array Verification") {
       int count_2D = 0;
-      size_t mem_size1 = NUM_ELM * sizeof(float);
+      size_t mem_size1 = NUM_ELM * NUM_ELM * sizeof(float);
       float* A_h2;
       A_h2 = reinterpret_cast<float*>(malloc(mem_size1));
-      for (int i = 0; i < NUM_ELM; i++) {
+      for (int i = 0; i < NUM_ELM * NUM_ELM; i++) {
         A_h2[i] = 2.0;
       }
 
       hipArray_t arraySimple2D = arrayCreateSimple2D();
       HIP_CHECK(hipMemcpyHtoA(arraySimple2D, 0, A_h2, mem_size1));
       float* A_h3 = funcToChkArray(arraySimple2D);
-      for (int i = 0; i < NUM_ELM; i++) {
+      for (int i = 0; i < NUM_ELM * NUM_ELM; i++) {
         if (A_h2[i] == A_h3[i]) {
           count_2D += 1;
         }
       }
       // Validation
-      REQUIRE(count_2D == NUM_ELM);
+      REQUIRE(count_2D == NUM_ELM * NUM_ELM);
       free(A_h2);
       HIP_CHECK(hipArrayDestroy(arraySimple2D));
     }
@@ -538,9 +543,12 @@ TEST_CASE("Unit_hipArrayGetDescriptor_Negative_Parameters") {
   SECTION("array is freed") {
     HIP_CHECK(hipArrayDestroy(ptr));
     HIP_CHECK_ERROR(hipArrayGetDescriptor(&desc, ptr), hipErrorInvalidHandle);
+    ptr = nullptr;
   }
 
-  static_cast<void>(hipArrayDestroy(ptr));
+  if (ptr) {
+    static_cast<void>(hipArrayDestroy(ptr));
+  }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/memory/hipArrayGetInfo.cc
+++ b/projects/hip-tests/catch/unit/memory/hipArrayGetInfo.cc
@@ -80,7 +80,9 @@ TEST_CASE("Unit_hipArrayGetInfo_Positive_Basic") {
  */
 TEST_CASE("Unit_hipArrayGetInfo_Negative_Parameters") {
   CHECK_IMAGE_SUPPORT
-  ArrayAllocGuard<float> array(make_hipExtent(1024, 4, 4));
+  hipChannelFormatDesc desc_create = hipCreateChannelDesc<float>();
+  hipArray_t array = nullptr;
+  HIP_CHECK(hipMalloc3DArray(&array, &desc_create, make_hipExtent(1024, 4, 4), 0u));
 
   hipChannelFormatDesc desc;
   hipExtent extent;
@@ -91,8 +93,13 @@ TEST_CASE("Unit_hipArrayGetInfo_Negative_Parameters") {
   }
 
   SECTION("array is freed") {
-    HIP_CHECK(hipFreeArray(array.ptr()));
-    HIP_CHECK_ERROR(hipArrayGetInfo(&desc, &extent, &flags, array.ptr()), hipErrorInvalidHandle);
+    HIP_CHECK(hipFreeArray(array));
+    HIP_CHECK_ERROR(hipArrayGetInfo(&desc, &extent, &flags, array), hipErrorInvalidHandle);
+    array = nullptr;
+  }
+
+  if (array) {
+    static_cast<void>(hipFreeArray(array));
   }
 }
 

--- a/projects/hip-tests/catch/unit/memory/hipDeviceGetMemPool.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDeviceGetMemPool.cc
@@ -116,10 +116,11 @@ TEST_CASE("Unit_hipDeviceGetMemPool_Basic") {
 TEST_CASE("Unit_hipDeviceGetMemPool_Functional") {
   hipMemPool_t mem_pool = nullptr;
   checkMempoolSupported(0)
-      // assign current mem pool to device
-      HIP_CHECK(hipDeviceGetMemPool(&mem_pool, 0));
+  // assign current mem pool to device
+  HIP_CHECK(hipDeviceGetMemPool(&mem_pool, 0));
   // set attribute hipMemPoolAttrReleaseThreshold as UINT64_MAX
   hipMemPoolAttr attr = hipMemPoolAttrReleaseThreshold;
+  MemPoolAttrRestore restore(mem_pool, attr);
   std::uint64_t value = UINT64_MAX;
   HIP_CHECK(hipMemPoolSetAttribute(mem_pool, attr, &value));
   // call checkMallocAsync() and validate
@@ -168,10 +169,11 @@ TEST_CASE("Unit_hipDeviceGetMemPool_Multidevice", "[multigpu]") {
 TEST_CASE("Unit_hipDeviceGetDefaultMemPool_Functional") {
   hipMemPool_t mem_pool = nullptr;
   checkMempoolSupported(0)
-      // assign current mem pool to device
-      HIP_CHECK(hipDeviceGetDefaultMemPool(&mem_pool, 0));
+  // assign current mem pool to device
+  HIP_CHECK(hipDeviceGetDefaultMemPool(&mem_pool, 0));
   // set attribute hipMemPoolAttrReleaseThreshold as UINT64_MAX
   hipMemPoolAttr attr = hipMemPoolAttrReleaseThreshold;
+  MemPoolAttrRestore restore(mem_pool, attr);
   std::uint64_t value = UINT64_MAX;
   HIP_CHECK(hipMemPoolSetAttribute(mem_pool, attr, &value));
   // call checkMallocAsync() and validate

--- a/projects/hip-tests/catch/unit/memory/hipDeviceSetMemPool.cc
+++ b/projects/hip-tests/catch/unit/memory/hipDeviceSetMemPool.cc
@@ -182,6 +182,7 @@ TEST_CASE("Unit_hipDeviceSetMemPool_functionalAttribute") {
   HIP_CHECK(hipDeviceSetMemPool(0, mem_pool));
   // set attribute hipMemPoolAttrReleaseThreshold as UINT64_MAX
   hipMemPoolAttr attr = hipMemPoolAttrReleaseThreshold;
+  MemPoolAttrRestore restore(mem_pool, attr);
   std::uint64_t value = UINT64_MAX;
   HIP_CHECK(hipMemPoolSetAttribute(mem_pool, attr, &value));
   // call checkMallocAsync function

--- a/projects/hip-tests/catch/unit/memory/hipFreeArray.cc
+++ b/projects/hip-tests/catch/unit/memory/hipFreeArray.cc
@@ -98,7 +98,7 @@ TEMPLATE_TEST_CASE("Unit_hipFreeArray_MultiThreaded", "", char, int, float2, flo
 
   std::vector<std::thread> threads;
 
-  for (auto arr : arr_ptrs) {
+  for (auto& arr : arr_ptrs) {
     HIP_CHECK(hipMallocArray(&arr, &desc, extent.width, extent.height, hipArrayDefault));
 
     threads.emplace_back([arr] {

--- a/projects/hip-tests/catch/unit/memory/mempool_common.hh
+++ b/projects/hip-tests/catch/unit/memory/mempool_common.hh
@@ -39,6 +39,21 @@ namespace {
 constexpr auto wait_ms = 500;
 }  // anonymous namespace
 
+struct MemPoolAttrRestore {
+  hipMemPool_t pool;
+  hipMemPoolAttr attr;
+  std::uint64_t old_value;
+
+  MemPoolAttrRestore(hipMemPool_t mem_pool, hipMemPoolAttr attr_in)
+      : pool(mem_pool), attr(attr_in), old_value(0) {
+    HIP_CHECK(hipMemPoolGetAttribute(pool, attr, &old_value));
+  }
+
+  ~MemPoolAttrRestore() {
+    static_cast<void>(hipMemPoolSetAttribute(pool, attr, &old_value));
+  }
+};
+
 #define checkMempoolSupported(device) {\
   int deviceSupportsMemoryPools = 0;\
   HIP_CHECK(hipDeviceGetAttribute(&deviceSupportsMemoryPools,\
@@ -62,6 +77,9 @@ template <typename T> __global__ void kernel_500ms(T* host_res, int clk_rate) {
   __threadfence_system();
   // expecting that the data is getting flushed to host here!
   uint64_t start = clock64() / clk_rate, cur;
+  if (start == 0) {
+    start = 1;
+  }
   if (clk_rate > 1) {
     do {
       cur = clock64() / clk_rate - start;
@@ -80,6 +98,9 @@ template <typename T> __global__ void kernel_500ms_gfx11(T* host_res, int clk_ra
   __threadfence_system();
   // expecting that the data is getting flushed to host here!
   uint64_t start = clock_function() / clk_rate, cur;
+  if (start == 0) {
+    start = 1;
+  }
   if (clk_rate > 1) {
     do {
       cur = clock_function() / clk_rate - start;


### PR DESCRIPTION
## Motivation

The current CI occasionally is flakey with failures due to UB, and correctness issues. This change addresses some of those issues in the memory tests

## Technical Details

hip_test_checkers.hh
	* indexing with signed integer, size_t is a safer choice
hip_test_common.hh
	* Added ceiling division function, for kernel size calculations
memcpy3d_tests_common.hh
	* Use RAII class to handle peer access of device memory
hipArrayCommon.hh
	* Add guard to prevent out of bounds memory access
hipArrayCreate.cc
	* std::iota with signed char, can easily overflow. 
	* TODO: Change approach to this, as fix isn't really a fix
	* Alter kernel launch to better handle edge cases
hipArrayGetDescriptor.cc
	* Multi-threaded test case now updated passing/failing value atomically and safely
	* Handle missing default case by issuing warning and ending test
	* funcToChkArray updates to handle 2D case, as we pass 2D array in
	* Properly run Unit_hipArrayGetDescriptor_Host2Array_Array2Host for 2D cases
	* Handle potential double free, when testing negative parameters
hipArrayGetInfo.cc
	* Double free: Underlying pointer was of ArrayAllocGuard gets released, but object isn't aware memory has been released.
hipDeviceGetMemPool.cc && hipDeviceSetMemPool.cc
	* Reset the default mem pool after its attributes have been altered
hipFreeArray.cc
	* accessing array elements by value rather than reference
memcpy2d_tests_common.hh
	* Handle setting and unsetting device peer access
mempool_common.hh
	* Add RAII class for default mem pool
	* Handle potential zero division, caused by start time. Unlikely case, but worth handling non the less

## JIRA ID

Partial solution: ROCM-1617

## Test Plan

NA

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
