### PR TITLE
[rocprofiler-compute] Pin dependencies version in requirements-test.txt

### DIFF
--- a/projects/rocprofiler-compute/requirements-test.txt
+++ b/projects/rocprofiler-compute/requirements-test.txt
@@ -1,5 +1,5 @@
-mock
-pytest
-pytest-cov
-pytest-xdist
-scipy
+mock==5.1.0
+pytest==8.0.2
+pytest-cov==5.0.0
+pytest-xdist==3.5.0
+scipy==1.11.4

--- a/projects/rocprofiler-compute/requirements-test.txt
+++ b/projects/rocprofiler-compute/requirements-test.txt
@@ -1,4 +1,3 @@
-mock==5.1.0
 pytest==8.0.2
 pytest-cov==5.0.0
 pytest-xdist==3.5.0


### PR DESCRIPTION
## Motivation

Pin dependencies version in requirements-test.txt

This is similar to https://github.com/ROCm/rocm-systems/pull/2821 where we pinned versions in requirements.txt

Remove `mock` from requirements-test.txt

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

- Validated compatibility to version pins in requirements.txt
- Validated compatibility with pytest, ctest, automatic test suite
- Validated compatibility with Python 3.9, 3.10, 3.11, and 3.12.

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
