### PR TITLE
Update rocprofiler-compute-rhel-8.yml to fix broken URLs

### DIFF
--- a/.github/workflows/rocprofiler-compute-rhel-8.yml
+++ b/.github/workflows/rocprofiler-compute-rhel-8.yml
@@ -40,6 +40,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  ROCM_VERSION: "7.2.0"
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build:
@@ -80,10 +83,13 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           command: |
+            ROCM_MAJOR=$(echo ${{ env.ROCM_VERSION }} | sed 's/\./ /g' | awk '{print $1}')
+            ROCM_MINOR=$(echo ${{ env.ROCM_VERSION }} | sed 's/\./ /g' | awk '{print $2}')
+            ROCM_VERSN=$(( (${ROCM_MAJOR}*10000)+(${ROCM_MINOR}*100) ))
             if [ ${{ matrix.os-release }} == "8.10" ]; then
-              yum install -y https://repo.radeon.com/amdgpu-install/latest/rhel/8.10/amdgpu-install-7.1.1.70101-1.el8.noarch.rpm
+              yum install -y https://repo.radeon.com/amdgpu-install/${ROCM_MAJOR}.${ROCM_MINOR}/rhel/8.10/amdgpu-install-${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1.el8.noarch.rpm
             else
-              yum install -y https://repo.radeon.com/amdgpu-install/latest/rhel/9.4/amdgpu-install-7.1.1.70101-1.el9.noarch.rpm
+              yum install -y https://repo.radeon.com/amdgpu-install/${ROCM_MAJOR}.${ROCM_MINOR}/rhel/9.4/amdgpu-install-${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1.el9.noarch.rpm
             fi
             yum install -y rocm-dev
       - name: Checkout


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fix failing RHEL compute workflow due to radeon repo URL changes.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Updated `.github/workflows/rocprofiler-compute-rhel-8.yml`
  - Removed hardcoded version numbers in URL and replaced with a defined ROCM_VERSION to pull from
  - Previously, we were always pulling from latest which changes as new releases are made

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Ensure workflow passes and ROCm install works as expected

## Test Result

<!-- Briefly summarize test outcomes. -->
- No workflow issues present after changes made

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
