### PR TITLE
Add ROCR Runtime WSL CI workflow for libhsakmt builds

### DIFF
--- a/.azuredevops/rocm_ci_caller.yml
+++ b/.azuredevops/rocm_ci_caller.yml
@@ -5,6 +5,10 @@ pr:
       - develop
       - release/rocm-rel-7.1
       - release/rocm-rel-7.2
+  # NOTE: this is temporary speed up to skip CI for WSL work
+  paths:
+    exclude:
+      - "projects/rocr-runtime/libhsakmt/src/dxg"
   drafts: false
 
 variables:

--- a/.github/workflows/azure-ci-dispatcher.yml
+++ b/.github/workflows/azure-ci-dispatcher.yml
@@ -36,6 +36,8 @@ on:
       - '**/.wordlist.txt'
       - 'docs/**'
       - 'projects/*/docs/**'
+      # NOTE: this is temporary speed up to skip CI for WSL work
+      - "projects/rocr-runtime/libhsakmt/src/dxg"
 
 concurrency:
   group: azure-ci-dispatcher-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/rocr-runtime-wsl.yml
+++ b/.github/workflows/rocr-runtime-wsl.yml
@@ -53,69 +53,59 @@ jobs:
           }
 
       - name: Set up WSL with Ubuntu
-        uses: Ubuntu/WSL/.github/actions/wsl-install@main
+        uses: Vampire/setup-wsl@v6
         with:
-          distro: ${{ env.DISTRO }}
+          distribution: ${{ env.DISTRO }}
+          update: true
+          additional-packages: build-essential cmake ninja-build
 
-      - name: Checkout repository into WSL
-        uses: Ubuntu/WSL/.github/actions/wsl-checkout@main
-        with:
-          distro: ${{ env.DISTRO }}
-          working-dir: "~/rocm-systems"
-
-      - name: Install build dependencies in WSL
-        uses: Ubuntu/WSL/.github/actions/wsl-bash@main
-        with:
-          distro: ${{ env.DISTRO }}
-          exec: |
-            set -eu
-            export DEBIAN_FRONTEND=noninteractive
-            sudo apt update
-            sudo apt install -y build-essential cmake ninja-build
+      - name: Copy repository into WSL
+        shell: wsl-bash {0}
+        run: |
+          set -euo pipefail
+          # Copy the checked out repository to WSL home directory
+          cp -r /mnt/c/a/rocm-systems/rocm-systems ~/rocm-systems
+          ls -la ~/rocm-systems/projects/rocr-runtime/
 
       - name: Verify WSL environment
-        uses: Ubuntu/WSL/.github/actions/wsl-bash@main
-        with:
-          distro: ${{ env.DISTRO }}
-          working-dir: "~/rocm-systems"
-          exec: |
-            set -eu
-            echo "Testing WSL environment..."
-            cmake --version
-            ninja --version
-            echo "ROCR Runtime project location:"
-            ls -la projects/rocr-runtime/
+        shell: wsl-bash {0}
+        run: |
+          set -euo pipefail
+          echo "Testing WSL environment..."
+          cmake --version
+          ninja --version
+          echo "ROCR Runtime project location:"
+          ls -la ~/rocm-systems/projects/rocr-runtime/
 
       - name: Build libhsakmt with Windows SDK
-        uses: Ubuntu/WSL/.github/actions/wsl-bash@main
+        shell: wsl-bash {0}
         env:
           WIN_SDK_VERSION: ${{ steps.detect-sdk.outputs.SDK_VERSION }}
-        with:
-          distro: ${{ env.DISTRO }}
-          working-dir: "~/rocm-systems/projects/rocr-runtime/libhsakmt"
-          exec: |
-            set -eu
-            echo "Building libhsakmt in WSL with Windows SDK..."
-            
-            # Use the detected Windows SDK version from the host
-            WIN_SDK_VERSION="${WIN_SDK_VERSION:-10.0.26100.0}"
-            export win_sdk="/mnt/c/Program Files (x86)/Windows Kits/10/Include/${WIN_SDK_VERSION}/"
-            
-            echo "Using Windows SDK version: ${WIN_SDK_VERSION}"
-            echo "Windows SDK path: ${win_sdk}"
-            
-            # Verify the Windows SDK is accessible from WSL
-            if [ ! -d "${win_sdk}" ]; then
-              echo "ERROR: Windows SDK not found at ${win_sdk}"
-              echo "Available SDK versions:"
-              ls -la "/mnt/c/Program Files (x86)/Windows Kits/10/Include/" || echo "SDK directory not accessible"
-              exit 1
-            fi
-            
-            # Build the library
-            mkdir -p build
-            cd build
-            cmake .. -G Ninja -DWIN_SDK="${win_sdk}/shared"
-            make
-            
-            echo "libhsakmt build completed successfully!"
+        run: |
+          set -euo pipefail
+          cd ~/rocm-systems/projects/rocr-runtime/libhsakmt
+          
+          echo "Building libhsakmt in WSL with Windows SDK..."
+          
+          # Use the detected Windows SDK version from the host
+          WIN_SDK_VERSION="${WIN_SDK_VERSION:-10.0.26100.0}"
+          export win_sdk="/mnt/c/Program Files (x86)/Windows Kits/10/Include/${WIN_SDK_VERSION}/"
+          
+          echo "Using Windows SDK version: ${WIN_SDK_VERSION}"
+          echo "Windows SDK path: ${win_sdk}"
+          
+          # Verify the Windows SDK is accessible from WSL
+          if [ ! -d "${win_sdk}" ]; then
+            echo "ERROR: Windows SDK not found at ${win_sdk}"
+            echo "Available SDK versions:"
+            ls -la "/mnt/c/Program Files (x86)/Windows Kits/10/Include/" || echo "SDK directory not accessible"
+            exit 1
+          fi
+          
+          # Build the library
+          mkdir -p build
+          cd build
+          cmake .. -G Ninja -DWIN_SDK="${win_sdk}/shared"
+          ninja
+          
+          echo "libhsakmt build completed successfully!"

--- a/.github/workflows/rocr-runtime-wsl.yml
+++ b/.github/workflows/rocr-runtime-wsl.yml
@@ -51,7 +51,7 @@ jobs:
           }
 
       - name: Set up WSL with Ubuntu
-        uses: Vampire/setup-wsl@v6
+        uses: Vampire/setup-wsl@4f1b3a9edf0c4a6a5b8454c5b15b99d9c1dfb2f1 # v6.1.0
         with:
           distribution: Ubuntu-24.04
           update: true

--- a/.github/workflows/rocr-runtime-wsl.yml
+++ b/.github/workflows/rocr-runtime-wsl.yml
@@ -52,6 +52,38 @@ jobs:
             exit 1
           }
 
+      - name: Check WSL status
+        shell: powershell
+        run: |
+          Write-Host "Checking if WSL is available..."
+          try {
+            wsl --status
+          } catch {
+            Write-Host "WSL not available or not enabled"
+          }
+
+      - name: Enable WSL feature
+        shell: powershell
+        run: |
+          Write-Host "Enabling Windows Subsystem for Linux..."
+          # Check if WSL is already enabled
+          $wslFeature = Get-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux
+          if ($wslFeature.State -ne "Enabled") {
+            Write-Host "WSL feature not enabled, enabling now..."
+            Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux -NoRestart
+          } else {
+            Write-Host "WSL feature already enabled"
+          }
+          
+          # Check Virtual Machine Platform
+          $vmFeature = Get-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform
+          if ($vmFeature.State -ne "Enabled") {
+            Write-Host "Virtual Machine Platform not enabled, enabling now..."
+            Enable-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform -NoRestart
+          } else {
+            Write-Host "Virtual Machine Platform already enabled"
+          }
+
       - name: Set up WSL
         uses: Ubuntu/WSL/.github/actions/wsl-install@main
         with:

--- a/.github/workflows/rocr-runtime-wsl.yml
+++ b/.github/workflows/rocr-runtime-wsl.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   rocr-runtime-wsl-test:
     name: ROCR Runtime WSL Test
-    runs-on: azure-windows-scale-rocm
+    runs-on: ROCR-Runtime-libhsakmt-WSL
     env:
       DISTRO: Ubuntu-22.04
     defaults:
@@ -52,28 +52,10 @@ jobs:
             exit 1
           }
 
-      - name: Set up WSL and Ubuntu
-        shell: powershell
-        run: |
-          Write-Host "Enabling WSL Optional Feature..."
-          dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart
-          
-          Write-Host "Installing WSL2..."
-          choco install wsl2 --version=2.4.13 --yes --no-progress
-          
-          Write-Host "Installing Ubuntu 22.04 for WSL..."
-          # NOTE: Chocolatey package has outdated checksum - we override with actual current checksum.
-          # Package issue: https://community.chocolatey.org/packages/wsl-ubuntu-2204#discussion
-          # Package expects: c5028547edfe72be8f7d44ef52cee5aacaf9b1ae1ed4f7e39b94dae3cf286bc2
-          # Actual checksum: 6AD6D88763451A50F98F2469CE80464D666204C08D07F8F6A89E0D5CA05B097A
-          # Source: aka.ms/wslubuntu2204 (official Microsoft CDN)
-          choco install wsl-ubuntu-2204 --version=22.4.0.20220819 --ignore-checksums --yes --no-progress --checksum=6AD6D88763451A50F98F2469CE80464D666204C08D07F8F6A89E0D5CA05B097A --checksum-type=sha256
-          
-          Write-Host "Checking WSL installation..."
-          wsl --list --verbose
-          
-          Write-Host "Setting WSL default version to 2..."
-          wsl --set-default-version 2
+      - name: Set up WSL with Ubuntu
+        uses: Ubuntu/WSL/.github/actions/wsl-install@main
+        with:
+          distro: ${{ env.DISTRO }}
 
       - name: Checkout repository into WSL
         uses: Ubuntu/WSL/.github/actions/wsl-checkout@main

--- a/.github/workflows/rocr-runtime-wsl.yml
+++ b/.github/workflows/rocr-runtime-wsl.yml
@@ -1,0 +1,121 @@
+name: ROCR Runtime WSL
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'projects/rocr-runtime/**'
+      - '.github/workflows/rocr-runtime-wsl.yml'
+  push:
+    branches:
+      - develop
+    paths:
+      - 'projects/rocr-runtime/**'
+      - '.github/workflows/rocr-runtime-wsl.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  rocr-runtime-wsl-test:
+    name: ROCR Runtime WSL Test
+    runs-on: azure-windows-scale-rocm
+    env:
+      DISTRO: Ubuntu-24.04
+    defaults:
+      run:
+        shell: powershell
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          sparse-checkout: |
+            projects/rocr-runtime
+          sparse-checkout-cone-mode: true
+
+      - name: Configure MSVC and Windows SDK
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
+      - name: Detect Windows SDK version
+        id: detect-sdk
+        shell: powershell
+        run: |
+          $sdkPath = "C:\Program Files (x86)\Windows Kits\10\Include"
+          if (Test-Path $sdkPath) {
+            $versions = Get-ChildItem $sdkPath -Directory | Sort-Object Name -Descending
+            $latestVersion = $versions[0].Name
+            echo "Found Windows SDK version: $latestVersion"
+            echo "SDK_VERSION=$latestVersion" >> $env:GITHUB_OUTPUT
+            echo "SDK_BASE_PATH=$sdkPath\$latestVersion" >> $env:GITHUB_OUTPUT
+          } else {
+            echo "Windows SDK not found at $sdkPath"
+            exit 1
+          }
+
+      - name: Set up WSL
+        uses: Ubuntu/WSL/.github/actions/wsl-install@main
+        with:
+          distro: ${{ env.DISTRO }}
+
+      - name: Checkout repository into WSL
+        uses: Ubuntu/WSL/.github/actions/wsl-checkout@main
+        with:
+          distro: ${{ env.DISTRO }}
+          working-dir: "~/rocm-systems"
+
+      - name: Install build dependencies in WSL
+        uses: Ubuntu/WSL/.github/actions/wsl-bash@main
+        with:
+          distro: ${{ env.DISTRO }}
+          exec: |
+            set -eu
+            export DEBIAN_FRONTEND=noninteractive
+            sudo apt update
+            sudo apt install -y build-essential cmake ninja-build
+
+      - name: Verify WSL environment
+        uses: Ubuntu/WSL/.github/actions/wsl-bash@main
+        with:
+          distro: ${{ env.DISTRO }}
+          working-dir: "~/rocm-systems"
+          exec: |
+            set -eu
+            echo "Testing WSL environment..."
+            cmake --version
+            ninja --version
+            echo "ROCR Runtime project location:"
+            ls -la projects/rocr-runtime/
+
+      - name: Build libhsakmt with Windows SDK
+        uses: Ubuntu/WSL/.github/actions/wsl-bash@main
+        env:
+          WIN_SDK_VERSION: ${{ steps.detect-sdk.outputs.SDK_VERSION }}
+        with:
+          distro: ${{ env.DISTRO }}
+          working-dir: "~/rocm-systems/projects/rocr-runtime/libhsakmt"
+          exec: |
+            set -eu
+            echo "Building libhsakmt in WSL with Windows SDK..."
+            
+            # Use the detected Windows SDK version from the host
+            WIN_SDK_VERSION="${WIN_SDK_VERSION:-10.0.26100.0}"
+            export win_sdk="/mnt/c/Program Files (x86)/Windows Kits/10/Include/${WIN_SDK_VERSION}/"
+            
+            echo "Using Windows SDK version: ${WIN_SDK_VERSION}"
+            echo "Windows SDK path: ${win_sdk}"
+            
+            # Verify the Windows SDK is accessible from WSL
+            if [ ! -d "${win_sdk}" ]; then
+              echo "ERROR: Windows SDK not found at ${win_sdk}"
+              echo "Available SDK versions:"
+              ls -la "/mnt/c/Program Files (x86)/Windows Kits/10/Include/" || echo "SDK directory not accessible"
+              exit 1
+            fi
+            
+            # Build the library
+            mkdir -p build
+            cd build
+            cmake .. -DWIN_SDK="${win_sdk}/shared"
+            make
+            
+            echo "libhsakmt build completed successfully!"

--- a/.github/workflows/rocr-runtime-wsl.yml
+++ b/.github/workflows/rocr-runtime-wsl.yml
@@ -19,9 +19,9 @@ permissions:
 jobs:
   rocr-runtime-wsl-test:
     name: ROCR Runtime WSL Test
-    runs-on: ROCR-Runtime-libhsakmt-WSL
+    runs-on: rocr-runtime-libhsakmt-wsl
     env:
-      DISTRO: Ubuntu-22.04
+      DISTRO: Ubuntu-24.04
     defaults:
       run:
         shell: powershell

--- a/.github/workflows/rocr-runtime-wsl.yml
+++ b/.github/workflows/rocr-runtime-wsl.yml
@@ -4,14 +4,20 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - 'projects/rocr-runtime/**'
-      - '.github/workflows/rocr-runtime-wsl.yml'
+      - "projects/rocr-runtime/**"
+      - "projects/clr/**"
+      - "projects/hip/**"
+      - "projects/hip-tests/**"
+      - ".github/workflows/rocr-runtime-wsl.yml"
   push:
     branches:
       - develop
     paths:
-      - 'projects/rocr-runtime/**'
-      - '.github/workflows/rocr-runtime-wsl.yml'
+      - "projects/rocr-runtime/**"
+      - "projects/clr/**"
+      - "projects/hip/**"
+      - "projects/hip-tests/**"
+      - ".github/workflows/rocr-runtime-wsl.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/rocr-runtime-wsl.yml
+++ b/.github/workflows/rocr-runtime-wsl.yml
@@ -21,7 +21,7 @@ jobs:
     name: ROCR Runtime WSL Test
     runs-on: azure-windows-scale-rocm
     env:
-      DISTRO: Ubuntu-24.04
+      DISTRO: Ubuntu-22.04
     defaults:
       run:
         shell: powershell
@@ -52,42 +52,20 @@ jobs:
             exit 1
           }
 
-      - name: Check WSL status
+      - name: Set up WSL and Ubuntu
         shell: powershell
         run: |
-          Write-Host "Checking if WSL is available..."
-          try {
-            wsl --status
-          } catch {
-            Write-Host "WSL not available or not enabled"
-          }
-
-      - name: Enable WSL feature
-        shell: powershell
-        run: |
-          Write-Host "Enabling Windows Subsystem for Linux..."
-          # Check if WSL is already enabled
-          $wslFeature = Get-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux
-          if ($wslFeature.State -ne "Enabled") {
-            Write-Host "WSL feature not enabled, enabling now..."
-            Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux -NoRestart
-          } else {
-            Write-Host "WSL feature already enabled"
-          }
+          Write-Host "Installing WSL2..."
+          choco install wsl2 --version=2.4.13 --yes --no-progress
           
-          # Check Virtual Machine Platform
-          $vmFeature = Get-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform
-          if ($vmFeature.State -ne "Enabled") {
-            Write-Host "Virtual Machine Platform not enabled, enabling now..."
-            Enable-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform -NoRestart
-          } else {
-            Write-Host "Virtual Machine Platform already enabled"
-          }
-
-      - name: Set up WSL
-        uses: Ubuntu/WSL/.github/actions/wsl-install@main
-        with:
-          distro: ${{ env.DISTRO }}
+          Write-Host "Installing Ubuntu 22.04 for WSL..."
+          choco install wsl-ubuntu-2204 --version=22.4.0.20220819 --yes --no-progress
+          
+          Write-Host "Checking WSL installation..."
+          wsl --list --verbose
+          
+          Write-Host "Setting WSL default version to 2..."
+          wsl --set-default-version 2
 
       - name: Checkout repository into WSL
         uses: Ubuntu/WSL/.github/actions/wsl-checkout@main
@@ -147,7 +125,7 @@ jobs:
             # Build the library
             mkdir -p build
             cd build
-            cmake .. -DWIN_SDK="${win_sdk}/shared"
+            cmake .. -G Ninja -DWIN_SDK="${win_sdk}/shared"
             make
             
             echo "libhsakmt build completed successfully!"

--- a/.github/workflows/rocr-runtime-wsl.yml
+++ b/.github/workflows/rocr-runtime-wsl.yml
@@ -55,11 +55,19 @@ jobs:
       - name: Set up WSL and Ubuntu
         shell: powershell
         run: |
+          Write-Host "Enabling WSL Optional Feature..."
+          dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart
+          
           Write-Host "Installing WSL2..."
           choco install wsl2 --version=2.4.13 --yes --no-progress
           
           Write-Host "Installing Ubuntu 22.04 for WSL..."
-          choco install wsl-ubuntu-2204 --version=22.4.0.20220819 --yes --no-progress
+          # NOTE: Chocolatey package has outdated checksum - we override with actual current checksum.
+          # Package issue: https://community.chocolatey.org/packages/wsl-ubuntu-2204#discussion
+          # Package expects: c5028547edfe72be8f7d44ef52cee5aacaf9b1ae1ed4f7e39b94dae3cf286bc2
+          # Actual checksum: 6AD6D88763451A50F98F2469CE80464D666204C08D07F8F6A89E0D5CA05B097A
+          # Source: aka.ms/wslubuntu2204 (official Microsoft CDN)
+          choco install wsl-ubuntu-2204 --version=22.4.0.20220819 --ignore-checksums --yes --no-progress --checksum=6AD6D88763451A50F98F2469CE80464D666204C08D07F8F6A89E0D5CA05B097A --checksum-type=sha256
           
           Write-Host "Checking WSL installation..."
           wsl --list --verbose

--- a/.github/workflows/rocr-runtime-wsl.yml
+++ b/.github/workflows/rocr-runtime-wsl.yml
@@ -20,8 +20,6 @@ jobs:
   rocr-runtime-wsl-test:
     name: ROCR Runtime WSL Test
     runs-on: rocr-runtime-libhsakmt-wsl
-    env:
-      DISTRO: Ubuntu-24.04
     defaults:
       run:
         shell: powershell
@@ -55,7 +53,7 @@ jobs:
       - name: Set up WSL with Ubuntu
         uses: Vampire/setup-wsl@v6
         with:
-          distribution: ${{ env.DISTRO }}
+          distribution: Ubuntu-24.04
           update: true
           additional-packages: build-essential cmake ninja-build
 

--- a/.github/workflows/rocr-runtime-wsl.yml
+++ b/.github/workflows/rocr-runtime-wsl.yml
@@ -51,7 +51,7 @@ jobs:
           }
 
       - name: Set up WSL with Ubuntu
-        uses: Vampire/setup-wsl@4f1b3a9edf0c4a6a5b8454c5b15b99d9c1dfb2f1 # v6.1.0
+        uses: Vampire/setup-wsl@6a8db447be7ed35f2f499c02c6e60ff77ef11278 # v6.0.0
         with:
           distribution: Ubuntu-24.04
           update: true

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - develop
       - release/therock-*
+    # NOTE: this is temporary speed up to skip CI for WSL work
+    paths-ignore:
+      - "projects/rocr-runtime/libhsakmt/src/dxg"
   pull_request:
     types:
       - opened


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow to build ROCR Runtime's `libhsakmt` library using WSL (Windows Subsystem for Linux) with Windows SDK.

## Technical Details

### Runner Configuration
- Runs on GitHub-hosted runner group: `rocr-runtime-libhsakmt-wsl`

### Workflow Steps
1. **Sparse checkout** of `projects/rocr-runtime` for efficiency
2. **MSVC/Windows SDK setup** via `ilammy/msvc-dev-cmd`
3. **WSL installation** using `Vampire/setup-wsl@v6` with Ubuntu 24.04
4. **Package installation**: `build-essential`, `cmake`, `ninja-build`
5. **Build**: CMake with Ninja generator, linking to Windows SDK headers via `/mnt/c/`

## Test Plan

- [x] Workflow triggers on PR, push to develop, and manual dispatch
- [X] Verify WSL setup completes successfully
- [X] Confirm cmake and ninja are available
- [X] Successfully build libhsakmt