### PR TITLE
Fix perf and correctness in rccl+rocshmem GDA alltoall

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -102,16 +102,6 @@
 	path = projects/rocprofiler-systems/external/spdlog
 	url = https://github.com/gabime/spdlog.git
 	tag = v1.16.0
-[submodule "projects/rccl/ext-src/mscclpp"]
-	path = projects/rccl/ext-src/mscclpp
-	url = https://github.com/microsoft/mscclpp.git
-	ignore = dirty
-	shallow = true
-[submodule "projects/rccl/ext-src/json"]
-	path = projects/rccl/ext-src/json
-	url = https://github.com/nlohmann/json.git
-	ignore = dirty
-	shallow = true
 [submodule "projects/rccl/ext-src/rocSHMEM"]
 	path = projects/rccl/ext-src/rocSHMEM
 	url = https://github.com/ROCm/rocSHMEM.git

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -2893,7 +2893,7 @@ static ncclResult_t collTaskAppend(
   t->root = info->root;
   t->datatype = info->datatype;
   size_t elementSize = ncclTypeSize(t->datatype);
-  if (t->func == ncclFuncAllGather || t->func == ncclFuncBroadcast || t->func == ncclFuncAlltoAllPivot) {
+  if (t->func == ncclFuncAllGather || t->func == ncclFuncBroadcast || t->func == ncclFuncAlltoAllPivot || t->func == ncclFuncAllToAllGda) {
     t->count *= elementSize;
     t->datatype = ncclInt8;
     elementSize = 1;

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -697,8 +697,10 @@ static ncclResult_t scheduleCollTasksToPlan(
   int channelId = 0;
   size_t currentTraffic = 0;
 
+#ifdef ENABLE_TRACE
   size_t channelCounts[MAXCHANNELS];
   for (int c=0; c<MAXCHANNELS; c++) channelCounts[c] = 0;
+#endif
 
   while (nPlanColls!=0 && !ncclIntruQueueEmpty(&planner->collTaskQueue)) {
     struct ncclTaskColl* task = ncclIntruQueueHead(&planner->collTaskQueue);
@@ -944,9 +946,11 @@ static ncclResult_t scheduleCollTasksToPlan(
           int(devWork->cbd.chunkGrainsMid*rcclProtoGrainSize(task->protocol, comm)),
           int(devWork->cbd.chunkGrainsHi*rcclProtoGrainSize(task->protocol, comm)));
           // channel traffic counter
+#ifdef ENABLE_TRACE
           channelCounts[devWork->channelLo] += (long)devWork->cbd.countLo;
           if (devWork->channelLo != devWork->channelHi) channelCounts[devWork->channelHi] += (long)devWork->cbd.countHi;
           for (int c=devWork->channelLo+1; c<devWork->channelHi; c++) channelCounts[c] += (long)devWork->cbd.countMid;
+#endif
       }
     }
 
@@ -962,6 +966,7 @@ static ncclResult_t scheduleCollTasksToPlan(
     plan->workBytes += workNode->size;
   }
 
+#ifdef ENABLE_TRACE
   char line[1024];
   int offset = 0;
   for (int c=0; c<MAXCHANNELS; c++) {
@@ -969,6 +974,7 @@ static ncclResult_t scheduleCollTasksToPlan(
     offset = strlen(line);
   }
   TRACE(NCCL_COLL, "Channel traffic counts: %s", line);
+#endif
 
   return ncclSuccess;
 }


### PR DESCRIPTION
## Motivation

1) Fix 10us perf regression in rccl+rocshmem gda alltoall
2) Fix data validation error that occurs in rccl+rocshmem gda paths following the last NCCL merge.

## Technical Details

1) Add ENABLE_TRACE around tracing functions that were introducing perf overhead
2) Adds AllToAllGda to the list of ops where count is converted to bytes and datatype is forced to ncclInt8. This fixes the GDA alltoall validation error after the NCCL sync

## JIRA ID

AICOMRCCL-441

## Test Plan & Test Result

I've validated performance and correctness are now as expected. Ran on 2 node switched fabric, 8 gpus, 1B-8MB



- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
