### PR TITLE
rocr/hsakmt: Restore MADV_DONTFORK on host allocations

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -2092,12 +2092,6 @@ static void *fmm_allocate_host_gpu(HsaKFDContext *ctx,
 	 * memory is allocated from KFD
 	 */
 	if (!mflags.ui32.NonPaged && svm.userptr_for_paged_mem) {
-		int advice = MADV_NORMAL;
-
-		/* set madvise flags to HUGEPAGE always for 2MB pages */
-		if (MemorySizeInBytes >= (2 * 1024 * 1024))
-			advice = MADV_HUGEPAGE;
-
 		/* Allocate address space */
 		pthread_mutex_lock(&aperture->fmm_mutex);
 		mem = aperture_allocate_area_aligned(aperture, address, size, alignment);
@@ -2115,7 +2109,11 @@ static void *fmm_allocate_host_gpu(HsaKFDContext *ctx,
 		if (bind_mem_to_numa(node_id, mem, MemorySizeInBytes, mflags))
 			goto out_release_area;
 
-		madvise(mem, MemorySizeInBytes, advice);
+		/* set madvise flags to HUGEPAGE always for 2MB pages */
+		if (MemorySizeInBytes >= (2 * 1024 * 1024))
+			madvise(mem, MemorySizeInBytes, MADV_HUGEPAGE);
+
+		madvise(mem, MemorySizeInBytes, MADV_DONTFORK);
 
 		/* Create userptr BO */
 		mmap_offset = (uint64_t)mem;


### PR DESCRIPTION
Restore MADV_DONTFORK flag on host memory allocations. Previous combination of calling mmap with MAP_SHARED flag and without MADV_DONTFORK flag increased allocation times.

## Motivation

Restore performance lost introduced by:
https://github.com/ROCm/rocm-systems/commit/53ba025a2e432a57499800d8b0726056016553f1

## Technical Details

## JIRA ID
SWDEV-574956

## Test Plan
Unit test with hipStreamCrate

## Test Result

PASS

## Submission Checklist

- [Y] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
