### PR TITLE
SWDEV-576737 - Remove recursion in FindPathsRecursiveHierarchical and ScheduleOneNode

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -503,7 +503,7 @@ void Graph::FindPathsDFS(Node start, std::vector<Node>& current_path,
                          std::unordered_set<unsigned int>& visited,
                          hip::Graph::GraphExecutionPaths& graph_paths) {
   // Lambda to save current path as a HierarchicalPath
-  auto savePath = [&graph_paths](const std::vector<Node> path, int device_id,
+  auto savePath = [&graph_paths](std::vector<Node> path, int device_id,
                                   Node child_node = nullptr, int child_index = -1) {
     hip::Graph::HierarchicalPath h_path;
     h_path.nodes = std::move(path);

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -230,9 +230,9 @@ void Graph::ScheduleOneNode(Node start, int stream_id) {
       end_of_branch = false;
     }
 
-     if (end_of_branch) {
-        // Finished one depth traversal (one branch). Rotate for the next sibling/branch.
-        sid = (sid + 1) % DEBUG_HIP_FORCE_GRAPH_QUEUES;
+    if (end_of_branch) {
+      // Finished one depth traversal (one branch). Rotate for the next sibling/branch.
+      sid = (sid + 1) % DEBUG_HIP_FORCE_GRAPH_QUEUES;
     }
   }
 }

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -189,7 +189,6 @@ void Graph::ScheduleOneNode(Node start, int stream_id) {
 
   // stack of pending nodes for DFS
   std::vector<Node> pending;
-  pending.reserve(64);
   pending.push_back(start);
 
   int sid = stream_id;
@@ -199,49 +198,42 @@ void Graph::ScheduleOneNode(Node start, int stream_id) {
     pending.pop_back();
 
     // Skip if already scheduled
-    if (cur->stream_id_ != -1) continue;
+    if (cur->stream_id_ != -1) {
+      continue;
+    }
+   
+    // Schedule current node on this branch's stream
+    cur->stream_id_ = sid;
 
-    // Walk one depth path with a FIXED sid
-    while (cur && cur->stream_id_ == -1) {
-      // Schedule current node on this branch's stream
-      cur->stream_id_ = sid;
-      max_streams_ = std::max(max_streams_, sid + 1);
-      streams_dev_ids_[sid].insert(cur->dev_id_);
+    max_streams_ = std::max(max_streams_, sid + 1);
+    streams_dev_ids_[sid].insert(cur->dev_id_);
 
-      // Process child graph separately, since, there is no connection
-      if (cur->GetType() == hipGraphNodeTypeGraph) {
-        auto cgn   = reinterpret_cast<hip::ChildGraphNode*>(cur);
-        auto child = cgn->GetChildGraph();
-        hipError_t status = child->ScheduleNodes();
-        (void)status;
-        max_streams_ = std::max(max_streams_, child->max_streams_);
-        cgn->GraphExec::TopologicalOrder();
-      }
-
-      const auto& edges = cur->GetEdges();
-
-      // Choose a "primary" next edge to continue the depth walk.
-      // Push other edges as sibling branches to do later (with rotated stream ids).
-      Node next = nullptr;
-
-      // To preserve left-to-right behavior, push siblings in reverse so the earlier
-      // edges get processed first.
-      for (int i = static_cast<int>(edges.size()) - 1; i >= 0; --i) {
-        Node e = edges[static_cast<size_t>(i)];
-        if (e->stream_id_ != -1) continue;
-
-        if (!next) {
-          next = e; // last unscheduled seen becomes primary (because reverse loop)
-        } else {
-          pending.push_back(e); // sibling branch start
-        }
-      }
-
-      cur = next; // continue down the primary chain
+    // Process child graph separately, since, there is no connection
+    if (cur->GetType() == hipGraphNodeTypeGraph) {
+      auto cgn   = reinterpret_cast<hip::ChildGraphNode*>(cur);
+      auto child = cgn->GetChildGraph();
+      hipError_t status = child->ScheduleNodes();
+      (void)status;
+      max_streams_ = std::max(max_streams_, child->max_streams_);
+      cgn->GraphExec::TopologicalOrder();
     }
 
-    // Finished one depth traversal (one branch). Rotate for the next sibling/branch.
-    sid = (sid + 1) % DEBUG_HIP_FORCE_GRAPH_QUEUES;
+    const auto& edges = cur->GetEdges();
+    bool end_of_branch = true;
+
+    // To preserve left-to-right behavior, push siblings in reverse so the earlier
+    // edges get processed first.
+    for (int i = static_cast<int>(edges.size()) - 1; i >= 0; --i) {
+      Node e = edges[static_cast<size_t>(i)];
+      if (e->stream_id_ != -1) continue;
+      pending.push_back(e);
+      end_of_branch = false;
+    }
+
+     if (end_of_branch) {
+        // Finished one depth traversal (one branch). Rotate for the next sibling/branch.
+        sid = (sid + 1) % DEBUG_HIP_FORCE_GRAPH_QUEUES;
+    }
   }
 }
 
@@ -525,7 +517,6 @@ void Graph::FindPathsDFS(Node start, std::vector<Node>& current_path,
 
   // Stack of nodes to process.
   std::vector<Node> st;
-  st.reserve(64);
   st.push_back(start);
 
   while (!st.empty()) {

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -184,28 +184,64 @@ std::vector<std::pair<Node, Node>> Graph::GetEdges() const {
 }
 
 // ================================================================================================
-void Graph::ScheduleOneNode(Node node, int stream_id) {
-  if (node->stream_id_ == -1) {
-    // Assign active stream to the current node
-    node->stream_id_ = stream_id;
-    max_streams_ = std::max(max_streams_, (stream_id + 1));
-    // Track which devices are used by each stream for multi-device graph execution
-    streams_dev_ids_[stream_id].insert(node->dev_id_);
-    // Process child graph separately, since, there is no connection
-    if (node->GetType() == hipGraphNodeTypeGraph) {
-      auto child = reinterpret_cast<hip::ChildGraphNode*>(node)->GetChildGraph();
-      hipError_t status = child->ScheduleNodes();
-      max_streams_ = std::max(max_streams_, child->max_streams_);
-      reinterpret_cast<hip::ChildGraphNode*>(node)->GraphExec::TopologicalOrder();
-    }
-    for (auto edge : node->GetEdges()) {
-      if (edge->stream_id_ == -1) {
-        ScheduleOneNode(edge, stream_id);
-        // 1. Each extra edge will get a new stream from the pool
-        // 2. Streams will be reused if the number of edges > streams
-        stream_id = (stream_id + 1) % DEBUG_HIP_FORCE_GRAPH_QUEUES;
+void Graph::ScheduleOneNode(Node start, int stream_id) {
+  if (!start) return;
+
+  // stack of pending nodes for DFS
+  std::vector<Node> pending;
+  pending.reserve(64);
+  pending.push_back(start);
+
+  int sid = stream_id;
+
+  while (!pending.empty()) {
+    Node cur = pending.back();
+    pending.pop_back();
+
+    // Skip if already scheduled
+    if (cur->stream_id_ != -1) continue;
+
+    // Walk one depth path with a FIXED sid
+    while (cur && cur->stream_id_ == -1) {
+      // Schedule current node on this branch's stream
+      cur->stream_id_ = sid;
+      max_streams_ = std::max(max_streams_, sid + 1);
+      streams_dev_ids_[sid].insert(cur->dev_id_);
+
+      // Process child graph separately, since, there is no connection
+      if (cur->GetType() == hipGraphNodeTypeGraph) {
+        auto cgn   = reinterpret_cast<hip::ChildGraphNode*>(cur);
+        auto child = cgn->GetChildGraph();
+        hipError_t status = child->ScheduleNodes();
+        (void)status;
+        max_streams_ = std::max(max_streams_, child->max_streams_);
+        cgn->GraphExec::TopologicalOrder();
       }
+
+      const auto& edges = cur->GetEdges();
+
+      // Choose a "primary" next edge to continue the depth walk.
+      // Push other edges as sibling branches to do later (with rotated stream ids).
+      Node next = nullptr;
+
+      // To preserve left-to-right behavior, push siblings in reverse so the earlier
+      // edges get processed first.
+      for (int i = static_cast<int>(edges.size()) - 1; i >= 0; --i) {
+        Node e = edges[static_cast<size_t>(i)];
+        if (e->stream_id_ != -1) continue;
+
+        if (!next) {
+          next = e; // last unscheduled seen becomes primary (because reverse loop)
+        } else {
+          pending.push_back(e); // sibling branch start
+        }
+      }
+
+      cur = next; // continue down the primary chain
     }
+
+    // Finished one depth traversal (one branch). Rotate for the next sibling/branch.
+    sid = (sid + 1) % DEBUG_HIP_FORCE_GRAPH_QUEUES;
   }
 }
 
@@ -471,7 +507,7 @@ hip::Graph::GraphExecutionPaths Graph::FindExecutionPathsHierarchical() {
 }
 
 // ================================================================================================
-void Graph::FindPathsRecursiveHierarchical(Node node,
+void Graph::FindPathsRecursiveHierarchical(Node start,
                                            std::vector<Node>& current_path,
                                            std::unordered_set<unsigned int>& visited,
                                            hip::Graph::GraphExecutionPaths& graph_paths) {
@@ -486,135 +522,147 @@ void Graph::FindPathsRecursiveHierarchical(Node node,
     graph_paths.paths.push_back(std::move(h_path));
   };
 
-  // Check if already visited
-  if (visited.find(node->GetID()) != visited.end()) {
-    return;
-  }
+  if (!start) return;
 
-  // Mark regular nodes as visited
-  visited.insert(node->GetID());
+  // Stack of nodes to process.
+  std::vector<Node> st;
+  st.reserve(64);
+  st.push_back(start);
 
-  // Check if device ID changed from previous node in path
-  bool device_changed = false;
-  int current_device_id = node->GetDeviceId();
-  if (!current_path.empty()) {
-    int prev_device_id = current_path.back()->GetDeviceId();
-    if (prev_device_id != current_device_id) {
-      device_changed = true;
-      // Save current path before device change
-      savePath(current_path, prev_device_id);
-      current_path.clear();
-    }
-  }
+  while (!st.empty()) {
+    Node node = st.back();
+    st.pop_back();
+    if (!node) continue;
 
-  // Handle child graph nodes specially
-  if (node->GetType() == hipGraphNodeTypeGraph) {
-    // Save path before child graph node (if any)
-    if (!current_path.empty()) {
-      savePath(current_path, current_path.back()->GetDeviceId());
-      current_path.clear();
-    }
-
-    // Get the child graph and recursively process it
-    auto childGraphNode = reinterpret_cast<hip::ChildGraphNode*>(node);
-    auto childGraph = childGraphNode->GetChildGraph();
-
-    if (childGraph != nullptr) {
-      // Create a new GraphExecutionPaths for this child graph
-      hip::Graph::GraphExecutionPaths child_graph_exec_paths;
-      child_graph_exec_paths.graph_ptr = childGraph;
-
-      // Find all root nodes in the child graph
-      const auto& child_root_nodes = childGraph->GetRootNodes();
-      std::unordered_set<unsigned int> child_visited;
-
-      for (const auto& child_root : child_root_nodes) {
-        std::vector<Node> child_current_path;
-        childGraph->FindPathsRecursiveHierarchical(child_root, child_current_path,
-                                                   child_visited, child_graph_exec_paths);
-      }
-
-      // Store the child graph paths
-      int child_graph_index = graph_paths.child_graph_paths.size();
-      graph_paths.child_graph_paths.push_back(std::move(child_graph_exec_paths));
-
-      // Create a path containing just the child graph node
-      std::vector<Node> child_node_path = {childGraphNode};
-      savePath(child_node_path, current_device_id, childGraphNode, child_graph_index);
-    }
-
-    // Clear current path and continue with edges from the child graph node
-    current_path.clear();
-    const auto& edges = node->GetEdges();
-    for (const auto& edge : edges) {
-      FindPathsRecursiveHierarchical(edge, current_path, visited, graph_paths);
-    }
-
-    return;
-  }
-
-  // Regular node - add to current path
-  current_path.push_back(node);
-
-  // Edges are out degrees, Dependencies are in degrees
-  const auto& edges = node->GetEdges();
-  const auto& dependencies = node->GetDependencies();
-
-  // Check if this is a fork node (multiple outgoing edges)
-  bool is_fork = edges.size() > 1;
-  // Check if this is a join node (multiple incoming dependencies)
-  bool is_join = dependencies.size() > 1;
-
-  if (is_fork || is_join) {
-    // Save current path as a separate segment
-    if (!current_path.empty()) {
-      std::vector<Node> path_to_save = current_path;
-      Node saved_join_node = nullptr;
-
-      // For join nodes, save path without the join node itself
-      // For fork nodes, save the complete path
-      if (is_join) {
-        saved_join_node = path_to_save.back();
-        path_to_save.pop_back();
-      }
-
-      if (!path_to_save.empty()) {
-        savePath(path_to_save, path_to_save.back()->GetDeviceId());
-      }
-      current_path.clear();
-
-      // For nodes that are both fork and join, save them as their own segment
-      if (saved_join_node != nullptr && is_fork) {
-        std::vector<Node> fork_join_segment = {saved_join_node};
-        savePath(fork_join_segment, saved_join_node->GetDeviceId());
-      }
-
-      // Put the join node back in current_path for further traversal
-      // But not if it's also a fork node, because we'll traverse branches separately
-      if (saved_join_node != nullptr && !is_fork) {
-        current_path.push_back(saved_join_node);
-      }
-    }
-
-    // Traverse each branch until it hits a join
-    for (const auto& edge : edges) {
-      FindPathsRecursiveHierarchical(edge, current_path, visited, graph_paths);
-
-      // Save the path if it's not empty and this was a fork/join boundary
-      if (!current_path.empty() && (is_fork || is_join)) {
+    // Check if already visited
+    if (visited.find(node->GetID()) != visited.end()) {
+      // Save any remaining path (treat visited as a branch end)
+      if (!current_path.empty()) {
         savePath(current_path, current_path.back()->GetDeviceId());
         current_path.clear();
       }
+      continue;
     }
-  } else if (edges.size() == 1) {
-    // Single edge - continue on same path
-    FindPathsRecursiveHierarchical(edges[0], current_path, visited, graph_paths);
-  }
 
-  // Save any remaining path (handles leaf nodes and leaf join nodes)
-  if (!current_path.empty()) {
-    savePath(current_path, current_path.back()->GetDeviceId());
-    current_path.clear();
+    // Mark regular nodes as visited
+    visited.insert(node->GetID());
+
+    // Check if device ID changed from previous node in path
+    bool device_changed = false;
+    int current_device_id = node->GetDeviceId();
+    if (!current_path.empty()) {
+      int prev_device_id = current_path.back()->GetDeviceId();
+      if (prev_device_id != current_device_id) {
+        device_changed = true;
+        // Save current path before device change
+        savePath(current_path, prev_device_id);
+        current_path.clear();
+      }
+    }
+
+    // Handle child graph nodes specially
+    if (node->GetType() == hipGraphNodeTypeGraph) {
+      // Save path before child graph node (if any)
+      if (!current_path.empty()) {
+        savePath(current_path, current_path.back()->GetDeviceId());
+        current_path.clear();
+      }
+
+      // Get the child graph and recursively process it
+      auto childGraphNode = reinterpret_cast<hip::ChildGraphNode*>(node);
+      auto childGraph = childGraphNode->GetChildGraph();
+
+      if (childGraph != nullptr) {
+        // Create a new GraphExecutionPaths for this child graph
+        hip::Graph::GraphExecutionPaths child_graph_exec_paths;
+        child_graph_exec_paths.graph_ptr = childGraph;
+
+        // Find all root nodes in the child graph
+        const auto& child_root_nodes = childGraph->GetRootNodes();
+        std::unordered_set<unsigned int> child_visited;
+
+        for (const auto& child_root : child_root_nodes) {
+          std::vector<Node> child_current_path;
+          childGraph->FindPathsRecursiveHierarchical(child_root, child_current_path,
+                                                     child_visited, child_graph_exec_paths);
+        }
+
+        // Store the child graph paths
+        int child_graph_index = static_cast<int>(graph_paths.child_graph_paths.size());
+        graph_paths.child_graph_paths.push_back(std::move(child_graph_exec_paths));
+
+        // Create a path containing just the child graph node
+        std::vector<Node> child_node_path = {childGraphNode};
+        savePath(child_node_path, current_device_id, childGraphNode, child_graph_index);
+      }
+
+      // Clear current path and continue with edges from the child graph node
+      current_path.clear();
+      const auto& edges = node->GetEdges();
+      for (int i = static_cast<int>(edges.size()) - 1; i >= 0; --i) {
+        st.push_back(edges[static_cast<size_t>(i)]);
+      }
+
+      continue;
+    }
+
+    // Regular node - add to current path
+    current_path.push_back(node);
+
+    // Edges are out degrees, Dependencies are in degrees
+    const auto& edges = node->GetEdges();
+    const auto& dependencies = node->GetDependencies();
+
+    // Check if this is a fork node (multiple outgoing edges)
+    bool is_fork = edges.size() > 1;
+    // Check if this is a join node (multiple incoming dependencies)
+    bool is_join = dependencies.size() > 1;
+
+    if (is_fork || is_join) {
+      // Save current path as a separate segment
+      if (!current_path.empty()) {
+        std::vector<Node> path_to_save = current_path;
+        Node saved_join_node = nullptr;
+
+        // For join nodes, save path without the join node itself
+        // For fork nodes, save the complete path
+        if (is_join) {
+          saved_join_node = path_to_save.back();
+          path_to_save.pop_back();
+        }
+
+        if (!path_to_save.empty()) {
+          savePath(path_to_save, path_to_save.back()->GetDeviceId());
+        }
+        current_path.clear();
+
+        // For nodes that are both fork and join, save them as their own segment
+        if (saved_join_node != nullptr && is_fork) {
+          std::vector<Node> fork_join_segment = {saved_join_node};
+          savePath(fork_join_segment, saved_join_node->GetDeviceId());
+        }
+
+        // Put the join node back in current_path for further traversal
+        // But not if it's also a fork node, because we'll traverse branches separately
+        if (saved_join_node != nullptr && !is_fork) {
+          current_path.push_back(saved_join_node);
+        }
+      }
+
+      // Traverse each branch until it hits a join
+      for (int i = static_cast<int>(edges.size()) - 1; i >= 0; --i) {
+        st.push_back(edges[static_cast<size_t>(i)]);
+      }
+    } else if (edges.size() == 1) {
+      // Single edge - continue on same path
+      st.push_back(edges[0]);
+    }
+
+    // Save any remaining path (handles leaf nodes and leaf join nodes)
+    if (!current_path.empty() && edges.size() == 0) {
+      savePath(current_path, current_path.back()->GetDeviceId());
+      current_path.clear();
+    }
   }
 }
 

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -501,21 +501,20 @@ hip::Graph::GraphExecutionPaths Graph::FindExecutionPathsHierarchical() {
   for (const auto& root : root_nodes) {
     // For each root, find all possible paths starting from it
     std::vector<Node> current_path;
-    FindPathsRecursiveHierarchical(root, current_path, visited, graph_paths);
+    FindPathsDFS(root, current_path, visited, graph_paths);
   }
   return graph_paths;
 }
 
 // ================================================================================================
-void Graph::FindPathsRecursiveHierarchical(Node start,
-                                           std::vector<Node>& current_path,
-                                           std::unordered_set<unsigned int>& visited,
-                                           hip::Graph::GraphExecutionPaths& graph_paths) {
+void Graph::FindPathsDFS(Node start, std::vector<Node>& current_path,
+                         std::unordered_set<unsigned int>& visited,
+                         hip::Graph::GraphExecutionPaths& graph_paths) {
   // Lambda to save current path as a HierarchicalPath
-  auto savePath = [&graph_paths](const std::vector<Node>& path, int device_id,
+  auto savePath = [&graph_paths](const std::vector<Node> path, int device_id,
                                   Node child_node = nullptr, int child_index = -1) {
     hip::Graph::HierarchicalPath h_path;
-    h_path.nodes = path;
+    h_path.nodes = std::move(path);
     h_path.device_id = device_id;
     h_path.child_graph_node = child_node;
     h_path.child_graph_paths_index = child_index;
@@ -538,7 +537,8 @@ void Graph::FindPathsRecursiveHierarchical(Node start,
     if (visited.find(node->GetID()) != visited.end()) {
       // Save any remaining path (treat visited as a branch end)
       if (!current_path.empty()) {
-        savePath(current_path, current_path.back()->GetDeviceId());
+        int dev = current_path.back()->GetDeviceId();
+        savePath(std::move(current_path), dev);
         current_path.clear();
       }
       continue;
@@ -555,7 +555,7 @@ void Graph::FindPathsRecursiveHierarchical(Node start,
       if (prev_device_id != current_device_id) {
         device_changed = true;
         // Save current path before device change
-        savePath(current_path, prev_device_id);
+        savePath(std::move(current_path), prev_device_id);
         current_path.clear();
       }
     }
@@ -564,7 +564,8 @@ void Graph::FindPathsRecursiveHierarchical(Node start,
     if (node->GetType() == hipGraphNodeTypeGraph) {
       // Save path before child graph node (if any)
       if (!current_path.empty()) {
-        savePath(current_path, current_path.back()->GetDeviceId());
+        int dev = current_path.back()->GetDeviceId();
+        savePath(std::move(current_path), dev);
         current_path.clear();
       }
 
@@ -583,8 +584,8 @@ void Graph::FindPathsRecursiveHierarchical(Node start,
 
         for (const auto& child_root : child_root_nodes) {
           std::vector<Node> child_current_path;
-          childGraph->FindPathsRecursiveHierarchical(child_root, child_current_path,
-                                                     child_visited, child_graph_exec_paths);
+          childGraph->FindPathsDFS(child_root, child_current_path, child_visited,
+                                   child_graph_exec_paths);
         }
 
         // Store the child graph paths
@@ -621,25 +622,25 @@ void Graph::FindPathsRecursiveHierarchical(Node start,
     if (is_fork || is_join) {
       // Save current path as a separate segment
       if (!current_path.empty()) {
-        std::vector<Node> path_to_save = current_path;
         Node saved_join_node = nullptr;
 
         // For join nodes, save path without the join node itself
         // For fork nodes, save the complete path
         if (is_join) {
-          saved_join_node = path_to_save.back();
-          path_to_save.pop_back();
+          saved_join_node = current_path.back();
+          current_path.pop_back();
         }
 
-        if (!path_to_save.empty()) {
-          savePath(path_to_save, path_to_save.back()->GetDeviceId());
+        if (!current_path.empty()) {
+          int dev = current_path.back()->GetDeviceId();
+          savePath(current_path, dev);
         }
         current_path.clear();
 
         // For nodes that are both fork and join, save them as their own segment
         if (saved_join_node != nullptr && is_fork) {
           std::vector<Node> fork_join_segment = {saved_join_node};
-          savePath(fork_join_segment, saved_join_node->GetDeviceId());
+          savePath(std::move(fork_join_segment), saved_join_node->GetDeviceId());
         }
 
         // Put the join node back in current_path for further traversal
@@ -660,7 +661,8 @@ void Graph::FindPathsRecursiveHierarchical(Node start,
 
     // Save any remaining path (handles leaf nodes and leaf join nodes)
     if (!current_path.empty() && edges.size() == 0) {
-      savePath(current_path, current_path.back()->GetDeviceId());
+      int dev = current_path.back()->GetDeviceId();
+      savePath(std::move(current_path), dev);
       current_path.clear();
     }
   }

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -717,7 +717,8 @@ class Graph {
   //! Find execution paths hierarchically, keeping child graphs separate
   GraphExecutionPaths FindExecutionPathsHierarchical();
 
-  //! Recursively find all paths from a node with hierarchical child graph handling
+  //! Find all paths from a node using an explicit DFS over a node stack, with
+  //! hierarchical handling of child graphs (only child graphs recurse)
   void FindPathsDFS(Node node, std::vector<Node>& current_path,
                     std::unordered_set<unsigned int>& visited, GraphExecutionPaths& graph_paths);
 

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -718,10 +718,8 @@ class Graph {
   GraphExecutionPaths FindExecutionPathsHierarchical();
 
   //! Recursively find all paths from a node with hierarchical child graph handling
-  void FindPathsRecursiveHierarchical(Node node,
-                                      std::vector<Node>& current_path,
-                                      std::unordered_set<unsigned int>& visited,
-                                      GraphExecutionPaths& graph_paths);
+  void FindPathsDFS(Node node, std::vector<Node>& current_path,
+                    std::unordered_set<unsigned int>& visited, GraphExecutionPaths& graph_paths);
 
   //! Create segments from hierarchical execution paths
   void CreateSegmentsFromPaths(const GraphExecutionPaths& exec_paths);

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -688,7 +688,7 @@ class Graph {
   void RemoveUserObjGraph(UserObject* pUserObj) { graphUserObj_.erase(pUserObj); }
 
   //! Schedules one node on a vitual stream.
-  //! It will also process the nodes in edges, using recursion
+  //! It will also process the nodes in edges, using DFS
   void ScheduleOneNode(Node node,     //!< Node for scheduling on a virtual stream
                        int stream_id  //!< Current active virtual stream to use for scheduling
   );


### PR DESCRIPTION
## Motivation
Removes recursion from two algorithms that could cause stack overflow errors in hipGraphInstantiate:

1) ScheduleOneNode() that assigns graph nodes to streams, used in the legacy graph path. 
2) FindPathsRecursiveHierarchical() that splits the graph into segments, used in the segment scheduling graph path. 

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
1) Reworked Graph::ScheduleOneNode() to use an explicit stack of pending nodes instead of calling the function recursively for each outgoing edge of a node. Similarly to the previous version, the algorithm keeps a branch on a single stream. The stream rotation happens only when it finishes a branch and moves to the next pending sibling branch. 

2) Reworked Graph::FindPathsRecursiveHierarchical to use an explicit node stack instead of calling the function recursively for each outgoing edge of a node. Recursively calls are now used for child graphs only.

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
SWDEV-576737
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
The reproducer code posted here https://github.com/pytorch/pytorch/issues/155720#issuecomment-3774430419 should now pass with no errors.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
The reproducer test passes. Run the graph unit tests locally under both legacy and segment scheduling graph paths. The tests pass.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
