### PR TITLE
Fix graph API binary paths

### DIFF
--- a/projects/hip/docs/tutorial/graph_api.rst
+++ b/projects/hip/docs/tutorial/graph_api.rst
@@ -332,7 +332,7 @@ Inside the ``build`` directory you will now generate a trace:
 
 .. code-block:: bash
 
-  rocprofv3 -o streams -d outDir -f pftrace --hip-trace --kernel-trace --memory-copy-trace --memory-allocation-trace -- ./HIP-Doc/Tutorials/graph_api/src/hip_graph_api_tutorial_streams
+  rocprofv3 -o streams -d outDir -f pftrace --hip-trace --kernel-trace --memory-copy-trace --memory-allocation-trace -- ./bin/hip_graph_api_tutorial_streams
 
 .. note::
   For more information on the ``rocprofv3`` tool, please refer to its
@@ -464,7 +464,7 @@ this change and generate another trace:
 
 .. code-block:: bash
 
-  rocprofv3 -o graph_capture -d outDir -f pftrace --hip-trace --kernel-trace --memory-copy-trace --memory-allocation-trace -- ./HIP-Doc/Tutorials/graph_api/src/hip_graph_api_tutorial_graph_capture
+  rocprofv3 -o graph_capture -d outDir -f pftrace --hip-trace --kernel-trace --memory-copy-trace --memory-allocation-trace -- ./bin/hip_graph_api_tutorial_graph_capture
 
 Analyzing the trace
 -------------------
@@ -599,7 +599,7 @@ another trace:
 
 .. code-block:: bash
   
-  rocprofv3 -o graph_creation -d outDir -f pftrace --hip-trace --kernel-trace --memory-copy-trace --memory-allocation-trace -- ./HIP-Doc/Tutorials/graph_api/src/hip_graph_api_tutorial_graph_creation
+  rocprofv3 -o graph_creation -d outDir -f pftrace --hip-trace --kernel-trace --memory-copy-trace --memory-allocation-trace -- ./bin/hip_graph_api_tutorial_graph_creation
 
 Analyzing the trace
 -------------------


### PR DESCRIPTION
## Motivation

The current description of where the graph API tutorial's binaries reside is wrong. This PR fixes the issue.

## Technical Details

Updates the paths according to the changes made in https://github.com/ROCm/rocm-examples/pull/399.

## JIRA ID

AIROCDOC-550

## Test Plan

Tested locally.

## Test Result

Works.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
