### PR TITLE
[rocshmem] Add ROCSHMEM_HCA_LIST to filter out NICs but retain topology mapping

### DIFF
--- a/projects/rocshmem/docs/api/env_variables.rst
+++ b/projects/rocshmem/docs/api/env_variables.rst
@@ -64,7 +64,7 @@ control the behavior of rocSHMEM.
     * - | ``ROCSHMEM_HCA_LIST``
         | Comma separated list of NIC names that can be used by rocSHMEM. Unlike ``ROCSHMEM_USE_IB_HCA``, when this variable is set,
         | NIC auto-detection and mapping still executes, but NICs that are not in the list are discarded before auto-detection runs.
-        | Prefixing the list with ``^`` turns the list in an _exclude_ list, NICs that are in the list are discarded before auto-detection runs.
+        | Prefixing the list with ``^`` turns the list in an *exclude* list, NICs that are in the list are discarded before auto-detection runs.
         | The default value is an empty string and rocSHMEM auto-detects the most appropriate NIC.
       - `` ``
       - | Example value: ``bnxt_re1,bnxt_re11``, ``^mlx5_0,mlx5_3``

--- a/projects/rocshmem/docs/api/env_variables.rst
+++ b/projects/rocshmem/docs/api/env_variables.rst
@@ -56,9 +56,17 @@ control the behavior of rocSHMEM.
         | ``1``: Force network conduit.
 
     * - | ``ROCSHMEM_USE_IB_HCA``
-        | Defines which NIC that this PE should be bound to. The default value is an empty string and rocSHMEM auto-detects the most appropriate NIC.
+        | Forces the NIC that this PE uses. When this value is set NIC auto-detection and mapping is disabled, the NIC specified in the variable
+        | will be selected. The default value is an empty string and rocSHMEM auto-detects the most appropriate NIC.
       - `` ``
       - | Example value: ``bnxt_re0``
+
+    * - | ``ROCSHMEM_EXCLUDE_IB_HCAS``
+        | Comma separated list of NIC names that should not be used by rocSHMEM. Unlike ``ROCSHMEM_USE_IB_HCA``, when this variable is set,
+        | NIC auto-detection and mapping still executes, but NICs from the exclude list are discarded before auto-detection runs.
+        | The default value is an empty string and rocSHMEM auto-detects the most appropriate NIC.
+      - `` ``
+      - | Example value: ``bnxt_re1,bnxt_re11``
 
     * - | ``ROCSHMEM_BOOTSTRAP_SOCKET_IFNAME``
         | Chooses the interface to bootstrap rocSHMEM with.

--- a/projects/rocshmem/docs/api/env_variables.rst
+++ b/projects/rocshmem/docs/api/env_variables.rst
@@ -61,12 +61,13 @@ control the behavior of rocSHMEM.
       - `` ``
       - | Example value: ``bnxt_re0``
 
-    * - | ``ROCSHMEM_EXCLUDE_IB_HCAS``
-        | Comma separated list of NIC names that should not be used by rocSHMEM. Unlike ``ROCSHMEM_USE_IB_HCA``, when this variable is set,
-        | NIC auto-detection and mapping still executes, but NICs from the exclude list are discarded before auto-detection runs.
+    * - | ``ROCSHMEM_HCA_LIST``
+        | Comma separated list of NIC names that can be used by rocSHMEM. Unlike ``ROCSHMEM_USE_IB_HCA``, when this variable is set,
+        | NIC auto-detection and mapping still executes, but NICs that are not in the list are discarded before auto-detection runs.
+        | Prefixing the list with ``^`` turns the list in an _exclude_ list, NICs that are in the list are discarded before auto-detection runs.
         | The default value is an empty string and rocSHMEM auto-detects the most appropriate NIC.
       - `` ``
-      - | Example value: ``bnxt_re1,bnxt_re11``
+      - | Example value: ``bnxt_re1,bnxt_re11``, ``^mlx5_0,mlx5_3``
 
     * - | ``ROCSHMEM_BOOTSTRAP_SOCKET_IFNAME``
         | Chooses the interface to bootstrap rocSHMEM with.

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -44,7 +44,8 @@ namespace envvar {
     const var<size_t> max_num_host_contexts("MAX_NUM_HOST_CONTEXTS", "", 1);
     const var<size_t> max_num_contexts("MAX_NUM_CONTEXTS", "", 32);
     const var<size_t> max_wavefront_buffers("MAX_WF_BUFFERS", "", 1024);
-    const var<std::string> requested_dev("USE_IB_HCA", "");
+    const var<std::string> requested_nic("USE_IB_HCA", "");
+    const var<std::string> excluded_nics("EXCLUDE_IB_HCAS", "");
     const var<uint32_t> sq_size("SQ_SIZE", "", 1024);
     const var<std::string> backend("BACKEND", "");
     const var<bool> disable_mixed_ipc("DISABLE_MIXED_IPC", "", false);

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -45,7 +45,7 @@ namespace envvar {
     const var<size_t> max_num_contexts("MAX_NUM_CONTEXTS", "", 32);
     const var<size_t> max_wavefront_buffers("MAX_WF_BUFFERS", "", 1024);
     const var<std::string> requested_nic("USE_IB_HCA", "");
-    const var<std::string> excluded_nics("EXCLUDE_IB_HCAS", "");
+    const var<std::string> hca_list("HCA_LIST", "");
     const var<uint32_t> sq_size("SQ_SIZE", "", 1024);
     const var<std::string> backend("BACKEND", "");
     const var<bool> disable_mixed_ipc("DISABLE_MIXED_IPC", "", false);

--- a/projects/rocshmem/src/envvar.hpp
+++ b/projects/rocshmem/src/envvar.hpp
@@ -428,7 +428,7 @@ namespace envvar {
     extern const var<size_t> max_wavefront_buffers;
 
     extern const var<std::string> requested_nic;
-    extern const var<std::string> excluded_nics;
+    extern const var<std::string> hca_list;
     extern const var<uint32_t> sq_size;
   }  // inline namespace _base
 

--- a/projects/rocshmem/src/envvar.hpp
+++ b/projects/rocshmem/src/envvar.hpp
@@ -427,7 +427,8 @@ namespace envvar {
      */
     extern const var<size_t> max_wavefront_buffers;
 
-    extern const var<std::string> requested_dev;
+    extern const var<std::string> requested_nic;
+    extern const var<std::string> excluded_nics;
     extern const var<uint32_t> sq_size;
   }  // inline namespace _base
 

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -127,12 +127,12 @@ GDABackend::~GDABackend() {
 }
 
 void GDABackend::select_nic() {
-  if (!envvar::requested_dev.is_default()) {
-    requested_dev = envvar::requested_dev.get_value().c_str();
+  if (!envvar::requested_nic.is_default()) {
+    requested_nic = envvar::requested_nic.get_value().c_str();
   } else {
     int gpu_dev = 0;
     CHECK_HIP(hipGetDevice(&gpu_dev));
-    int nic_dev = rocshmem::GetClosestNicToGpu(gpu_dev, &requested_dev);
+    int nic_dev = rocshmem::GetClosestNicToGpu(gpu_dev, envvar::excluded_nics.get_value().c_str(), &requested_nic);
     assert (nic_dev != -1);
   }
 }
@@ -947,12 +947,12 @@ void GDABackend::open_ib_device() {
 
   device = device_list[0]; //TODO default to HIP selected device?
 
-  if (requested_dev) {
+  if (requested_nic) {
     for (int i = 0; i < num_devices; i++) {
       const char *select_device = ibv.get_device_name(device_list[i]);
       CHECK_NNULL(select_device, "ibv_get_device_name");
 
-      if (strstr(select_device, requested_dev)) {
+      if (strstr(select_device, requested_nic)) {
         device = device_list[i];
         break;
       }

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -952,7 +952,7 @@ void GDABackend::open_ib_device() {
       const char *select_device = ibv.get_device_name(device_list[i]);
       CHECK_NNULL(select_device, "ibv_get_device_name");
 
-      if (strstr(select_device, requested_nic)) {
+      if (0 == strcmp(select_device, requested_nic)) {
         device = device_list[i];
         break;
       }

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -132,7 +132,7 @@ void GDABackend::select_nic() {
   } else {
     int gpu_dev = 0;
     CHECK_HIP(hipGetDevice(&gpu_dev));
-    int nic_dev = rocshmem::GetClosestNicToGpu(gpu_dev, envvar::excluded_nics.get_value().c_str(), &requested_nic);
+    int nic_dev = rocshmem::GetClosestNicToGpu(gpu_dev, envvar::hca_list.get_value().c_str(), &requested_nic);
     assert (nic_dev != -1);
   }
 }

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -132,8 +132,7 @@ void GDABackend::select_nic() {
   } else {
     int gpu_dev = 0;
     CHECK_HIP(hipGetDevice(&gpu_dev));
-    int nic_dev = rocshmem::GetClosestNicToGpu(gpu_dev, envvar::hca_list.get_value().c_str(), &requested_nic);
-    assert (nic_dev != -1);
+    rocshmem::GetClosestNicToGpu(gpu_dev, envvar::hca_list.get_value().c_str(), &requested_nic);
   }
 }
 
@@ -936,7 +935,6 @@ void GDABackend::cleanup_gpu_qps() {
   gpu_qps = nullptr;
 }
 
-//TODO this ifdef sequence should go in a nic-specific file, like it is for bnxt, maybe whats above too?
 void GDABackend::open_ib_device() {
   struct ibv_device **device_list = nullptr;
   int num_devices = 0;
@@ -944,8 +942,6 @@ void GDABackend::open_ib_device() {
 
   device_list = ibv.get_device_list(&num_devices);
   CHECK_NNULL(device_list, "ibv_get_device_list");
-
-  device = device_list[0]; //TODO default to HIP selected device?
 
   if (requested_nic) {
     for (int i = 0; i < num_devices; i++) {
@@ -957,6 +953,14 @@ void GDABackend::open_ib_device() {
         break;
       }
     }
+  }
+
+  if (nullptr == device) {
+    fprintf(stderr,
+      "rocshmem error: failed to select a NIC when initializing GDA backend.\n"
+      "  ROCSHMEM_HCA_LIST or ROCSHMEM_USE_IB_HCA may have excluded all available NICs.\n"
+      "  Please adjust HCA_LIST or NIC configuration.\n");
+    exit(1);
   }
 
   context = ibv.open_device(device);

--- a/projects/rocshmem/src/gda/backend_gda.hpp
+++ b/projects/rocshmem/src/gda/backend_gda.hpp
@@ -68,7 +68,7 @@ class GDABackend : public Backend {
     union ibv_gid gid;
   } dest_info_t;
 
-  const char *requested_dev = nullptr;
+  const char *requested_nic = nullptr;
   struct ibv_device *device = nullptr;
   struct ibv_context *context = nullptr;;
   struct ibv_device_attr device_attr;

--- a/projects/rocshmem/src/gda/topology.cpp
+++ b/projects/rocshmem/src/gda/topology.cpp
@@ -697,7 +697,7 @@ namespace rocshmem
   }
 
 
-  int GetClosestNicToGpu(int gpuIndex, const char** dev_name)
+  int GetClosestNicToGpu(int gpuIndex, const char* exclude_list, const char** dev_name)
   {
     static bool isInitialized = false;
     static std::vector<int> closestNicId;
@@ -712,8 +712,10 @@ namespace rocshmem
 
       // Build up list of NIC bus addresses
       std::vector<std::string> ibvAddressList;
-      for (auto const& ibvDevice : ibvDeviceList)
-        ibvAddressList.push_back(ibvDevice.hasActivePort ? ibvDevice.busId : "");
+      for (auto const& ibvDevice : ibvDeviceList) {
+        auto is_excluded = (nullptr != strstr(exclude_list, ibvDevice.name.c_str()));
+        ibvAddressList.push_back((ibvDevice.hasActivePort && !is_excluded) ? ibvDevice.busId : "");
+      }
 
       // Track how many times a device has been assigned as "closest"
       // This allows distributed work across devices using multiple ports (sharing the same busID)
@@ -810,7 +812,7 @@ namespace rocshmem
 
       std::string closestGpusStr = "";
       for (int j = 0; j < numGpus; j++) {
-        if (rocshmem::GetClosestNicToGpu(j, nullptr) == i) {
+        if (rocshmem::GetClosestNicToGpu(j, nullptr, nullptr) == i) {
           if (closestGpusStr != "") closestGpusStr += ",";
           closestGpusStr += std::to_string(j);
         }

--- a/projects/rocshmem/src/gda/topology.cpp
+++ b/projects/rocshmem/src/gda/topology.cpp
@@ -723,8 +723,8 @@ namespace rocshmem
 
       // Build up list of NIC bus addresses
       std::vector<std::string> ibvAddressList;
-      std::string excludeList((nullptr == hca_list || hca_list[0] != '^')? "": hca_list);
-      std::string includeList((nullptr == hca_list || hca_list[0] == '^')? "": hca_list);
+      std::string excludeList((nullptr != hca_list && hca_list[0] == '^')? &hca_list[1]: "");
+      std::string includeList((nullptr != hca_list && hca_list[0] != '^')? hca_list: "");
       for (auto const& ibvDevice : ibvDeviceList) {
         auto is_excluded = hasExactMatch(excludeList, ibvDevice.name)
                         || (includeList.length() && !hasExactMatch(includeList, ibvDevice.name));
@@ -864,6 +864,9 @@ namespace rocshmem
       printf("  %d Supported NIC device(s)\n", numNics);
     }
 
+    // Print out detected NIC topology
+    PrintNicToGPUTopo(outputToCsv);
+
     // Print out detected CPU topology
     printf("\n            %c", sep);
     for (int j = 0; j < numCpus; j++)
@@ -899,8 +902,5 @@ namespace rocshmem
       printf("\n");
     }
     printf("\n");
-
-    // Print out detected NIC topology
-    PrintNicToGPUTopo(outputToCsv);
   }
 }

--- a/projects/rocshmem/src/gda/topology.cpp
+++ b/projects/rocshmem/src/gda/topology.cpp
@@ -708,7 +708,7 @@ namespace rocshmem
     return false;
   }
 
-  int GetClosestNicToGpu(int gpuIndex, const char* exclude_list, const char** dev_name)
+  int GetClosestNicToGpu(int gpuIndex, const char* hca_list, const char** dev_name)
   {
     static bool isInitialized = false;
     static std::vector<int> closestNicId;
@@ -723,9 +723,11 @@ namespace rocshmem
 
       // Build up list of NIC bus addresses
       std::vector<std::string> ibvAddressList;
-      std::string excludeList(nullptr == exclude_list? "": exclude_list);
+      std::string excludeList((nullptr == hca_list || hca_list[0] != '^')? "": hca_list);
+      std::string includeList((nullptr == hca_list || hca_list[0] == '^')? "": hca_list);
       for (auto const& ibvDevice : ibvDeviceList) {
-        auto is_excluded = hasExactMatch(excludeList, ibvDevice.name);
+        auto is_excluded = hasExactMatch(excludeList, ibvDevice.name)
+                        || (includeList.length() && !hasExactMatch(includeList, ibvDevice.name));
         ibvAddressList.push_back((ibvDevice.hasActivePort && !is_excluded) ? ibvDevice.busId : "");
       }
 

--- a/projects/rocshmem/src/gda/topology.cpp
+++ b/projects/rocshmem/src/gda/topology.cpp
@@ -696,6 +696,17 @@ namespace rocshmem
     return GetIbvDeviceList()[nicIndex].numaNode;
   }
 
+  static bool hasExactMatch(const std::string& namesList, const std::string& name) {
+    std::stringstream ss(namesList);
+    std::string token;
+
+    while (std::getline(ss, token, ',')) {
+      if (token == name) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   int GetClosestNicToGpu(int gpuIndex, const char* exclude_list, const char** dev_name)
   {
@@ -712,8 +723,9 @@ namespace rocshmem
 
       // Build up list of NIC bus addresses
       std::vector<std::string> ibvAddressList;
+      std::string excludeList(nullptr == exclude_list? "": exclude_list);
       for (auto const& ibvDevice : ibvDeviceList) {
-        auto is_excluded = (nullptr != strstr(exclude_list, ibvDevice.name.c_str()));
+        auto is_excluded = hasExactMatch(excludeList, ibvDevice.name);
         ibvAddressList.push_back((ibvDevice.hasActivePort && !is_excluded) ? ibvDevice.busId : "");
       }
 

--- a/projects/rocshmem/src/gda/topology.cpp
+++ b/projects/rocshmem/src/gda/topology.cpp
@@ -791,10 +791,11 @@ namespace rocshmem
       isInitialized = true;
     }
 
-    DPRINTF("GPU Device id: %d closest NIC id : %d name: %s\n", gpuIndex, closestNicId[gpuIndex],
-           ibvDeviceList[closestNicId[gpuIndex]].name.c_str());
-    if (dev_name != nullptr && closestNicId[gpuIndex] != -1) {
-      *dev_name = strdup(ibvDeviceList[closestNicId[gpuIndex]].name.c_str());
+    int closestIdx = closestNicId[gpuIndex];
+    DPRINTF("GPU Device id: %d closest NIC id : %d name: %s\n", gpuIndex, closestIdx,
+           (-1 != closestIdx)? ibvDeviceList[closestIdx].name.c_str(): "none-found");
+    if (dev_name != nullptr && closestIdx != -1) {
+      *dev_name = strdup(ibvDeviceList[closestIdx].name.c_str());
     }
 
     return closestNicId[gpuIndex];

--- a/projects/rocshmem/src/gda/topology.cpp
+++ b/projects/rocshmem/src/gda/topology.cpp
@@ -775,9 +775,9 @@ namespace rocshmem
 #endif
 
           int minDistance = std::numeric_limits<int>::max();
-          for (int j = 0; j < ibvDeviceList.size(); j++) {
-            if (ibvDeviceList[j].busId != "") {
-              int distance = GetBusIdDistance(hipPciBusId, ibvDeviceList[j].busId);
+          for (int j = 0; j < ibvAddressList.size(); j++) {
+            if (ibvAddressList[j] != "") {
+              int distance = GetBusIdDistance(hipPciBusId, ibvAddressList[j]);
               if (distance < minDistance && distance >= 0) {
                 minDistance = distance;
                 closestIdx = j;
@@ -793,7 +793,7 @@ namespace rocshmem
 
     DPRINTF("GPU Device id: %d closest NIC id : %d name: %s\n", gpuIndex, closestNicId[gpuIndex],
            ibvDeviceList[closestNicId[gpuIndex]].name.c_str());
-    if (dev_name != nullptr) {
+    if (dev_name != nullptr && closestNicId[gpuIndex] != -1) {
       *dev_name = strdup(ibvDeviceList[closestNicId[gpuIndex]].name.c_str());
     }
 

--- a/projects/rocshmem/src/gda/topology.hpp
+++ b/projects/rocshmem/src/gda/topology.hpp
@@ -158,11 +158,11 @@ namespace rocshmem
    * Returns the index of the NIC closest to the given GPU
    *
    * @param[in] gpuIndex Index of the GPU to query
-   * @param[in] exclude_list Exlude list of device names that should not be used
+   * @param[in] hca_list Include list of device names that can be used (Exlude if prefixed by ^)
    * @param[out] dev_name Name of of IB Verbs capable NIC index closest to GPU gpuIndex
    * @returns index of IB Verbs capable NIC index closest to GPU gpuIndex, or -1 if unable to detect
    */
-  int GetClosestNicToGpu(int gpuIndex, const char* exclude_list, const char** dev_name);
+  int GetClosestNicToGpu(int gpuIndex, const char* hca_list, const char** dev_name);
 
   /**
    * Returns information about number of available Devices

--- a/projects/rocshmem/src/gda/topology.hpp
+++ b/projects/rocshmem/src/gda/topology.hpp
@@ -158,10 +158,11 @@ namespace rocshmem
    * Returns the index of the NIC closest to the given GPU
    *
    * @param[in] gpuIndex Index of the GPU to query
+   * @param[in] exclude_list Exlude list of device names that should not be used
    * @param[out] dev_name Name of of IB Verbs capable NIC index closest to GPU gpuIndex
    * @returns index of IB Verbs capable NIC index closest to GPU gpuIndex, or -1 if unable to detect
    */
-  int GetClosestNicToGpu(int gpuIndex, const char** dev_name);
+  int GetClosestNicToGpu(int gpuIndex, const char* exclude_list, const char** dev_name);
 
   /**
    * Returns information about number of available Devices

--- a/projects/rocshmem/src/gda/topology.hpp
+++ b/projects/rocshmem/src/gda/topology.hpp
@@ -158,7 +158,7 @@ namespace rocshmem
    * Returns the index of the NIC closest to the given GPU
    *
    * @param[in] gpuIndex Index of the GPU to query
-   * @param[in] hca_list Include list of device names that can be used (Exlude if prefixed by ^)
+   * @param[in] hca_list Include list of device names that can be used (Exclude if prefixed by ^)
    * @param[out] dev_name Name of of IB Verbs capable NIC index closest to GPU gpuIndex
    * @returns index of IB Verbs capable NIC index closest to GPU gpuIndex, or -1 if unable to detect
    */


### PR DESCRIPTION
topology aware NIC mapping

## Motivation

On some systems there are extraneous nics that we should not use for GDA traffic.
Using USE_IB_HCA requires using a wrapper script and disables automatic topological assignment of nics to GPUs.

## Technical Details

This PR introduces a list to selectively enabled/disable listed NICs and still use topological detection and assignment.

## JIRA ID

## Test Plan

`all_backends -DDEBUG=ON`
`mpirun -n 2 -x ROCSHMEM_HCA_LIST=^ionic_0,ionic_1 tests/functional_tests/rocshmem_functional_tests -a 3 -w 1 -z 1`

## Test Result

passing no params has no effect (same as before PR)
passing param HCA_LIST as expected outcomes (picks a different NIC than disabled ones)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
