### PR TITLE
rocr: Restore mmap flags back to MAP_PRIVATE

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -2107,7 +2107,7 @@ static void *fmm_allocate_host_gpu(HsaKFDContext *ctx,
 
 		/* Map anonymous pages */
 		if (mmap(mem, MemorySizeInBytes, PROT_READ | PROT_WRITE,
-			 MAP_ANONYMOUS | MAP_SHARED | MAP_FIXED, -1, 0)
+			 MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0)
 		    == MAP_FAILED)
 			goto out_release_area;
 


### PR DESCRIPTION
Change mmap flags back to MAP_PRIVATE as MAP_SHARED increases allocation
time. Transparent huge pages are disabled for MAP_SHARED by default.

## Motivation

Restore performance lost introduced by:
https://github.com/ROCm/rocm-systems/commit/53ba025a2e432a57499800d8b0726056016553f1

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

SWDEV-574956
