### PR TITLE
[AMD-SMI] [SWDEV-560702] amd-smi per process MEM usages does not add up to per GPU MEM usage.

### DIFF
--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -1426,7 +1426,7 @@ Field | Description
 ---|---
 `name` | Name of process. If user does not have permission this will be "N/A"
 `pid` | Process ID
-`mem` | Total memory usage by GPU during process in Bytes
+`mem` | Total memory usage by GPU during process in Bytes (sum of the process memory is not expected to be the total memory usage.)
 `engine_usage` | <table><thead><tr> <th> Subfield </th> <th> Description</th> </tr></thead><tbody><tr><td>`gfx`</td><td>GFX engine usage in ns</td></tr><tr><td>`enc`</td><td>Encode engine usage in ns</td></tr></tbody></table>
 `memory_usage` | <table><thead><tr> <th> Subfield </th> <th> Description</th> </tr></thead><tbody><tr><td>`gtt_mem`</td><td>GTT memory usage in Bytes</td></tr><tr><td>`cpu_mem`</td><td>CPU memory usage in Bytes</td></tr><tr><td>`vram_mem`</td><td>Process VRAM memory usage in Bytes</td></tr> </tbody></table>
 `cu_occupancy` | Number of Compute Units utilized

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -4224,6 +4224,8 @@ Field | Description
 `cu_occupancy` | Compute Unit usage in percents
 `evicted_time` | Time that queues are evicted on a GPU in milliseconds
 
+Sum of the process memory is not expected to be the total memory usage.
+
 Exceptions that can be thrown by `amdsmi_get_gpu_compute_process_info` function:
 
 * `AmdSmiLibraryException`

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -4224,7 +4224,7 @@ Field | Description
 `cu_occupancy` | Compute Unit usage in percents
 `evicted_time` | Time that queues are evicted on a GPU in milliseconds
 
-Sum of the process memory is not expected to be the total memory usage.
+note: Sum of the process memory is not expected to be the total memory usage.
 
 Exceptions that can be thrown by `amdsmi_get_gpu_compute_process_info` function:
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -2165,6 +2165,7 @@ typedef struct {
 
 /**
  * @brief This structure contains information specific to a process.
+ * Sum of the process memory is not expected to be the total memory usage.
  *
  * @cond @tag{gpu_bm_linux} @endcond
  */
@@ -6791,7 +6792,7 @@ amdsmi_get_violation_status(amdsmi_processor_handle processor_handle,
 /**
  *  @brief Returns the list of process information running on a given GPU.
  *  If pdh.dll is not present on the system, this API returns
- *  AMDSMI_STATUS_NOT_SUPPORTED.
+ *  AMDSMI_STATUS_NOT_SUPPORTED. Sum of the process memory is not expected to be the total memory usage.
  *
  *  @ingroup tagProcessInfo
  *


### PR DESCRIPTION
## Motivation

Purpose of PR is to update the amdsmi.h documentation and Python documentation to let the user know that the sum of processes running are not expected to be the total mem_usage.

## Technical Details

Added documentation in amdsmi.h and amdsmi-py-api.md to let the user know.

## JIRA ID

https://ontrack-internal.amd.com/browse/SWDEV-560702

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

N/A
