### PR TITLE
AIRUNTIME-34 - Fix wrong timing in hipPerfDispatchSpeed

### DIFF
--- a/projects/hip-tests/catch/perftests/dispatch/hipPerfDispatchSpeed.cc
+++ b/projects/hip-tests/catch/perftests/dispatch/hipPerfDispatchSpeed.cc
@@ -51,10 +51,10 @@ __global__ void _dispatchSpeed(float* outBuf) {
 
 // kernel that has an execution of count, in GPU clock ticks
 __global__ void _TimingKernel(uint64_t count) {
-  uint64_t begin_time = __builtin_amdgcn_s_memrealtime();
+  uint64_t begin_time = wall_clock64();
   uint64_t curr_time = begin_time;
   do {
-    curr_time = __builtin_amdgcn_s_memrealtime();
+    curr_time = wall_clock64();
   } while (begin_time + count > curr_time);
 }
 


### PR DESCRIPTION
Use wall_clock64() instead of __builtin_amdgcn_s_memrealtime() for timing

## Motivation

wall_clock64 has specific frequency that can be queried.


## Technical Details

__builtin_amdgcn_s_memrealtime()   has no interface for query and it does not work for gfx11/12.

## JIRA ID
AIRUNTIME-34

## Test Plan

Make hipPerfDispatchSpeed work in right way

## Test Result

pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
