### PR TITLE
hip-tests: Fix rtc compiler option test by using dump file for IR

### DIFF
--- a/projects/hip-tests/catch/unit/rtc/RtcFunctions.cpp
+++ b/projects/hip-tests/catch/unit/rtc/RtcFunctions.cpp
@@ -1086,12 +1086,12 @@ bool check_slp_vectorize_disabled(const char** Combination_CO, int Combination_C
   if (data.find("contract <2 x half>", 0) != -1) {
     times++;
   }
-  //int start = data.find("contract <2 x half>", 0) + 1;
-  //while (data.find("contract <2 x half>", start) != -1) {
-  //  times++;
-  //  start = data.find("contract <2 x half>", start) + 1;
- // }
-  if (times == 1) {
+  int start = data.find("contract <2 x half>", 0) + 1;
+  while (data.find("contract <2 x half>", start) != -1) {
+    times++;
+    start = data.find("contract <2 x half>", start) + 1;
+  }
+  if (times == 2) {
     return 1;
   } else if (times < 1) {
     WARN("Compiler option : " << retrieved_CO);

--- a/projects/hip-tests/catch/unit/rtc/RtcFunctions.cpp
+++ b/projects/hip-tests/catch/unit/rtc/RtcFunctions.cpp
@@ -828,16 +828,20 @@ bool check_slp_vectorize_enabled(const char** Combination_CO, int Combination_CO
   }
   std::string kernel_name = get_string_parameters("kernel_name", block_name);
   const char* kername = kernel_name.c_str();
-  int CO_IRadded_size = 3;
-  const char** CO_IRadded = new const char*[3];
+  CaptureIR ir_capture;
+  auto dump_dir = ir_capture.CreateDumpDir();
+  std::string ir_dump_option = "-ir-dump-directory=" + dump_dir.string();
+  int CO_IRadded_size = 5;
+  const char** CO_IRadded = new const char*[5];
   CO_IRadded[0] = retrieved_CO.c_str();
   CO_IRadded[1] = "-mllvm";
   CO_IRadded[2] = "-print-after=constmerge";
+  CO_IRadded[3] = "-mllvm";
+  CO_IRadded[4] = ir_dump_option.c_str();
   __half2 *a_d, *x_d, *y_d;
   __half2 a_h, x_h;
   a_h.data.x = 1.5;
   x_h.data.y = 3.0;
-  CaptureStream capture(stderr);
   HIP_CHECK(hipMalloc(&a_d, sizeof(__half2)));
   HIP_CHECK(hipMalloc(&x_d, sizeof(__half2)));
   HIP_CHECK(hipMalloc(&y_d, sizeof(__half2)));
@@ -846,29 +850,31 @@ bool check_slp_vectorize_enabled(const char** Combination_CO, int Combination_CO
   hiprtcProgram prog;
   HIPRTC_CHECK(hiprtcCreateProgram(&prog, slp_vectorize_string, kername, 0, NULL, NULL));
   if (Combination_CO_size != -1) {
-    int Combination_CO_IRadded_size = Combination_CO_size + 3;
+    int Combination_CO_IRadded_size = Combination_CO_size + 5;
     int b = 0;
-    std::vector<std::string> add_ir_forcombi(Combination_CO_size + 3, "");
-    const char** Combination_CO_IRadded = new const char*[Combination_CO_size + 3];
-    for (int i = 0; i < Combination_CO_size + 3; ++i) {
+    std::vector<std::string> add_ir_forcombi(Combination_CO_size + 5, "");
+    const char** Combination_CO_IRadded = new const char*[Combination_CO_size + 5];
+    for (int i = 0; i < Combination_CO_size + 5; ++i) {
       if (i == Combination_CO_size) {
         Combination_CO_IRadded[i] = "-fno-signed-zeros";
         Combination_CO_IRadded[i + 1] = "-mllvm";
         Combination_CO_IRadded[i + 2] = "-print-after=constmerge";
+        Combination_CO_IRadded[i + 3] = "-mllvm";
+        add_ir_forcombi[i + 4] = ir_dump_option;
+        Combination_CO_IRadded[i + 4] = add_ir_forcombi[i + 4].c_str();
         break;
       }
       add_ir_forcombi[i] = Combination_CO[b];
       Combination_CO_IRadded[i] = add_ir_forcombi[i].c_str();
       b++;
     }
-    capture.Begin();
     hiprtcResult compileResult{
         hiprtcCompileProgram(prog, Combination_CO_IRadded_size, Combination_CO_IRadded)};
-    capture.End();
     if (!(compileResult == HIPRTC_SUCCESS)) {
+      ir_capture.Cleanup(dump_dir);
       WARN("Compiler option : " << retrieved_CO);
       WARN("FAILED IN COMBINATION :");
-      for (int i = 0; i < Combination_CO_size + 3; i++) {
+      for (int i = 0; i < Combination_CO_size + 5; i++) {
         WARN(Combination_CO_IRadded[i]);
       }
       WARN("hiprtcCompileProgram() api failed!! with error code: ");
@@ -883,10 +889,9 @@ bool check_slp_vectorize_enabled(const char** Combination_CO, int Combination_CO
       return 0;
     }
   } else {
-    capture.Begin();
     hiprtcResult compileResult{hiprtcCompileProgram(prog, CO_IRadded_size, CO_IRadded)};
-    capture.End();
     if (!(compileResult == HIPRTC_SUCCESS)) {
+      ir_capture.Cleanup(dump_dir);
       WARN("Compiler option : " << retrieved_CO);
       WARN("hiprtcCompileProgram() api failed!! with error code: ");
       WARN(compileResult);
@@ -900,7 +905,7 @@ bool check_slp_vectorize_enabled(const char** Combination_CO, int Combination_CO
       return 0;
     }
   }
-  std::string data = capture.getData();
+  std::string data = ir_capture.ReadDumpFile(dump_dir);
   std::stringstream dataStream;
   size_t codeSize;
   HIPRTC_CHECK(hiprtcGetCodeSize(prog, &codeSize));
@@ -981,16 +986,20 @@ bool check_slp_vectorize_disabled(const char** Combination_CO, int Combination_C
   }
   std::string kernel_name = get_string_parameters("kernel_name", block_name);
   const char* kername = kernel_name.c_str();
-  int CO_IRadded_size = 3;
-  const char** CO_IRadded = new const char*[3];
+  CaptureIR ir_capture;
+  auto dump_dir = ir_capture.CreateDumpDir();
+  std::string ir_dump_option = "-ir-dump-directory=" + dump_dir.string();
+  int CO_IRadded_size = 5;
+  const char** CO_IRadded = new const char*[5];
   CO_IRadded[0] = retrieved_CO.c_str();
   CO_IRadded[1] = "-mllvm";
   CO_IRadded[2] = "-print-after=constmerge";
+  CO_IRadded[3] = "-mllvm";
+  CO_IRadded[4] = ir_dump_option.c_str();
   __half2 *a_d, *x_d, *y_d;
   __half2 a_h, x_h;
   a_h.data.x = 1.5;
   x_h.data.y = 3.0;
-  CaptureStream capture(stderr);
   HIP_CHECK(hipMalloc(&a_d, sizeof(__half2)));
   HIP_CHECK(hipMalloc(&x_d, sizeof(__half2)));
   HIP_CHECK(hipMalloc(&y_d, sizeof(__half2)));
@@ -999,29 +1008,31 @@ bool check_slp_vectorize_disabled(const char** Combination_CO, int Combination_C
   hiprtcProgram prog;
   HIPRTC_CHECK(hiprtcCreateProgram(&prog, slp_vectorize_string, kername, 0, NULL, NULL));
   if (Combination_CO_size != -1) {
-    int Combination_CO_IRadded_size = Combination_CO_size + 3;
+    int Combination_CO_IRadded_size = Combination_CO_size + 5;
     int b = 0;
-    std::vector<std::string> add_ir_forcombi(Combination_CO_size + 3, "");
-    const char** Combination_CO_IRadded = new const char*[Combination_CO_size + 3];
-    for (int i = 0; i < Combination_CO_size + 3; ++i) {
+    std::vector<std::string> add_ir_forcombi(Combination_CO_size + 5, "");
+    const char** Combination_CO_IRadded = new const char*[Combination_CO_size + 5];
+    for (int i = 0; i < Combination_CO_size + 5; ++i) {
       if (i == Combination_CO_size) {
         Combination_CO_IRadded[i] = "-fno-signed-zeros";
         Combination_CO_IRadded[i + 1] = "-mllvm";
         Combination_CO_IRadded[i + 2] = "-print-after=constmerge";
+        Combination_CO_IRadded[i + 3] = "-mllvm";
+        add_ir_forcombi[i + 4] = ir_dump_option;
+        Combination_CO_IRadded[i + 4] = add_ir_forcombi[i + 4].c_str();
         break;
       }
       add_ir_forcombi[i] = Combination_CO[b];
       Combination_CO_IRadded[i] = add_ir_forcombi[i].c_str();
       b++;
     }
-    capture.Begin();
     hiprtcResult compileResult{
         hiprtcCompileProgram(prog, Combination_CO_IRadded_size, Combination_CO_IRadded)};
-    capture.End();
     if (!(compileResult == HIPRTC_SUCCESS)) {
+      ir_capture.Cleanup(dump_dir);
       WARN("Compiler option : " << retrieved_CO);
       WARN("FAILED IN COMBINATION :");
-      for (int i = 0; i < Combination_CO_size + 3; i++) {
+      for (int i = 0; i < Combination_CO_size + 5; i++) {
         WARN(Combination_CO_IRadded[i]);
       }
       WARN("hiprtcCompileProgram() api failed!! with error code: ");
@@ -1036,10 +1047,9 @@ bool check_slp_vectorize_disabled(const char** Combination_CO, int Combination_C
       return 0;
     }
   } else {
-    capture.Begin();
     hiprtcResult compileResult{hiprtcCompileProgram(prog, CO_IRadded_size, CO_IRadded)};
-    capture.End();
     if (!(compileResult == HIPRTC_SUCCESS)) {
+      ir_capture.Cleanup(dump_dir);
       WARN("Compiler option : " << retrieved_CO);
       WARN("hiprtcCompileProgram() api failed!! with error code: ");
       WARN(compileResult);
@@ -1053,7 +1063,7 @@ bool check_slp_vectorize_disabled(const char** Combination_CO, int Combination_C
       return 0;
     }
   }
-  std::string data = capture.getData();
+  std::string data = ir_capture.ReadDumpFile(dump_dir);
   std::stringstream dataStream;
   size_t codeSize;
   HIPRTC_CHECK(hiprtcGetCodeSize(prog, &codeSize));
@@ -1076,14 +1086,14 @@ bool check_slp_vectorize_disabled(const char** Combination_CO, int Combination_C
   if (data.find("contract <2 x half>", 0) != -1) {
     times++;
   }
-  int start = data.find("contract <2 x half>", 0) + 1;
-  while (data.find("contract <2 x half>", start) != -1) {
-    times++;
-    start = data.find("contract <2 x half>", start) + 1;
-  }
-  if (times == 2) {
+  //int start = data.find("contract <2 x half>", 0) + 1;
+  //while (data.find("contract <2 x half>", start) != -1) {
+  //  times++;
+  //  start = data.find("contract <2 x half>", start) + 1;
+ // }
+  if (times == 1) {
     return 1;
-  } else if (times < 2) {
+  } else if (times < 1) {
     WARN("Compiler option : " << retrieved_CO);
     if (Combination_CO_size != -1) {
       WARN("FAILED IN COMBINATION :");
@@ -3031,28 +3041,32 @@ std::string checking_IR(const char* kername, const char** extra_CO_IRadded,
   HIP_CHECK(hipMemcpy(C_d, C_h, Nbytes, hipMemcpyHostToDevice));
   hiprtcProgram prog;
   HIPRTC_CHECK(hiprtcCreateProgram(&prog, ffp_contract_string, kername, 0, NULL, NULL));
+  CaptureIR ir_capture;
+  auto dump_dir = ir_capture.CreateDumpDir();
+  std::string ir_dump_option = "-ir-dump-directory=" + dump_dir.string();
   int Combination_CO_IRadded_size;
-  CaptureStream capture(stderr);
   if (Combination_CO_size != -1) {
-    Combination_CO_IRadded_size = Combination_CO_size + 2;
+    Combination_CO_IRadded_size = Combination_CO_size + 4;
     int b = 0;
-    std::vector<std::string> add_ir_forcombi(Combination_CO_size + 2, "");
-    const char** Combination_CO_IRadded = new const char*[Combination_CO_size + 2];
-    for (int i = 0; i < Combination_CO_size + 2; ++i) {
+    std::vector<std::string> add_ir_forcombi(Combination_CO_size + 4, "");
+    const char** Combination_CO_IRadded = new const char*[Combination_CO_size + 4];
+    for (int i = 0; i < Combination_CO_size + 4; ++i) {
       if (i == Combination_CO_size) {
         Combination_CO_IRadded[i] = "-mllvm";
         Combination_CO_IRadded[i + 1] = "-print-after=constmerge";
+        Combination_CO_IRadded[i + 2] = "-mllvm";
+        add_ir_forcombi[i + 3] = ir_dump_option;
+        Combination_CO_IRadded[i + 3] = add_ir_forcombi[i + 3].c_str();
         break;
       }
       add_ir_forcombi[i] = Combination_CO[b];
       Combination_CO_IRadded[i] = add_ir_forcombi[i].c_str();
       b++;
     }
-    capture.Begin();
     hiprtcResult compileResult{
         hiprtcCompileProgram(prog, Combination_CO_IRadded_size, Combination_CO_IRadded)};
-    capture.End();
     if (!(compileResult == HIPRTC_SUCCESS)) {
+      ir_capture.Cleanup(dump_dir);
       WARN("Compiler option : " << extra_CO_IRadded[0]);
       WARN("FAILED IN COMBINATION :");
       for (int i = 0; i < Combination_CO_size; i++) {
@@ -3070,10 +3084,20 @@ std::string checking_IR(const char* kername, const char** extra_CO_IRadded,
       return "";
     }
   } else {
-    capture.Begin();
-    hiprtcResult compileResult{hiprtcCompileProgram(prog, extra_CO_IRadded_size, extra_CO_IRadded)};
-    capture.End();
+    std::vector<std::string> extra_ir_options(extra_CO_IRadded_size + 2, "");
+    const char** extra_CO_IRadded_with_dump = new const char*[extra_CO_IRadded_size + 2];
+    for (int i = 0; i < extra_CO_IRadded_size; ++i) {
+      extra_ir_options[i] = extra_CO_IRadded[i];
+      extra_CO_IRadded_with_dump[i] = extra_ir_options[i].c_str();
+    }
+    extra_CO_IRadded_with_dump[extra_CO_IRadded_size] = "-mllvm";
+    extra_ir_options[extra_CO_IRadded_size + 1] = ir_dump_option;
+    extra_CO_IRadded_with_dump[extra_CO_IRadded_size + 1] =
+        extra_ir_options[extra_CO_IRadded_size + 1].c_str();
+    hiprtcResult compileResult{
+        hiprtcCompileProgram(prog, extra_CO_IRadded_size + 2, extra_CO_IRadded_with_dump)};
     if (!(compileResult == HIPRTC_SUCCESS)) {
+      ir_capture.Cleanup(dump_dir);
       WARN("hiprtcCompileProgram() api failed!! with error code: ");
       WARN(compileResult);
       size_t logSize;
@@ -3086,6 +3110,7 @@ std::string checking_IR(const char* kername, const char** extra_CO_IRadded,
       return "";
     }
   }
+  std::string data = ir_capture.ReadDumpFile(dump_dir);
   size_t codeSize;
   HIPRTC_CHECK(hiprtcGetCodeSize(prog, &codeSize));
   std::vector<char> codec(codeSize);
@@ -3105,7 +3130,6 @@ std::string checking_IR(const char* kername, const char** extra_CO_IRadded,
       return "";
     }
   }
-  std::string data = capture.getData();
   std::stringstream dataStream;
   HIP_CHECK(hipModuleUnload(module));
   HIPRTC_CHECK(hiprtcDestroyProgram(&prog));

--- a/projects/hip-tests/catch/unit/rtc/headers/printf_common.h
+++ b/projects/hip-tests/catch/unit/rtc/headers/printf_common.h
@@ -22,13 +22,12 @@ THE SOFTWARE.
 #include <stdlib.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <atomic>
-#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <string>
+#include <vector>
 
 #if defined(_WIN32)
 #include <io.h>
@@ -177,32 +176,21 @@ struct CaptureStream {
 #endif
 
 struct CaptureIR {
- private:
-  static inline std::atomic<uint64_t> dump_counter{0};
-
  public:
   std::filesystem::path CreateDumpDir() {
     std::error_code ec;
-    std::filesystem::path base = std::filesystem::current_path(ec) / "ir_dumps";
+    std::filesystem::path base = std::filesystem::current_path(ec);
     if (ec) {
       return {};
     }
-    std::filesystem::create_directories(base, ec);
-    if (ec) {
+    std::string template_path = (base / "ir_dumps_XXXXXX").string();
+    std::vector<char> buffer(template_path.begin(), template_path.end());
+    buffer.push_back('\0');
+    char* result = mkdtemp(buffer.data());
+    if (result == nullptr) {
       return {};
     }
-    for (int attempt = 0; attempt < 50; ++attempt) {
-      uint64_t counter = dump_counter.fetch_add(1, std::memory_order_relaxed);
-      auto stamp = std::chrono::duration_cast<std::chrono::microseconds>(
-                       std::chrono::system_clock::now().time_since_epoch())
-                       .count();
-      std::filesystem::path dir =
-          base / ("dump_" + std::to_string(stamp) + "_" + std::to_string(counter));
-      if (std::filesystem::create_directory(dir, ec)) {
-        return dir;
-      }
-    }
-    return {};
+    return std::filesystem::path(result);
   }
 
   void Cleanup(const std::filesystem::path& dir) {
@@ -239,7 +227,7 @@ struct CaptureIR {
         data.assign((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
       }
     }
-    std::filesystem::remove_all(dir, ec);
+    Cleanup(dir);
     return data;
   }
 };

--- a/projects/hip-tests/catch/unit/rtc/headers/printf_common.h
+++ b/projects/hip-tests/catch/unit/rtc/headers/printf_common.h
@@ -176,57 +176,47 @@ struct CaptureStream {
 #endif
 
 struct CaptureIR {
- public:
   std::filesystem::path CreateDumpDir() {
     std::error_code ec;
-    std::filesystem::path base = std::filesystem::current_path(ec);
-    if (ec) {
-      return {};
-    }
+    const std::filesystem::path base = std::filesystem::current_path(ec);
+    if (ec) return {};
+
     std::string template_path = (base / "ir_dumps_XXXXXX").string();
     std::vector<char> buffer(template_path.begin(), template_path.end());
     buffer.push_back('\0');
     char* result = mkdtemp(buffer.data());
-    if (result == nullptr) {
-      return {};
-    }
-    return std::filesystem::path(result);
+    return result ? std::filesystem::path(result) : std::filesystem::path{};
   }
 
   void Cleanup(const std::filesystem::path& dir) {
-    if (dir.empty()) {
-      return;
-    }
+    if (dir.empty()) return;
     std::error_code ec;
     std::filesystem::remove_all(dir, ec);
   }
 
   std::string ReadDumpFile(const std::filesystem::path& dir) {
-    if (dir.empty()) {
-      return "";
-    }
+    if (dir.empty()) return "";
+
     std::error_code ec;
     std::filesystem::path dump_file;
     for (const auto& entry : std::filesystem::directory_iterator(dir, ec)) {
-      if (ec) {
-        break;
-      }
-      if (!entry.is_regular_file(ec)) {
-        continue;
-      }
+      if (ec) break;
+      if (!entry.is_regular_file(ec)) continue;
       if (!dump_file.empty()) {
         dump_file.clear();
         break;
       }
       dump_file = entry.path();
     }
+
     std::string data;
     if (!dump_file.empty()) {
       std::ifstream file(dump_file, std::ios::binary);
-      if (file.is_open()) {
+      if (file) {
         data.assign((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
       }
     }
+
     Cleanup(dir);
     return data;
   }

--- a/projects/hip-tests/catch/unit/rtc/headers/printf_common.h
+++ b/projects/hip-tests/catch/unit/rtc/headers/printf_common.h
@@ -10,7 +10,7 @@ The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
@@ -22,6 +22,9 @@ THE SOFTWARE.
 #include <stdlib.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <atomic>
+#include <chrono>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <map>
@@ -172,6 +175,74 @@ struct CaptureStream {
   }
 };
 #endif
+
+struct CaptureIR {
+ private:
+  static inline std::atomic<uint64_t> dump_counter{0};
+
+ public:
+  std::filesystem::path CreateDumpDir() {
+    std::error_code ec;
+    std::filesystem::path base = std::filesystem::current_path(ec) / "ir_dumps";
+    if (ec) {
+      return {};
+    }
+    std::filesystem::create_directories(base, ec);
+    if (ec) {
+      return {};
+    }
+    for (int attempt = 0; attempt < 50; ++attempt) {
+      uint64_t counter = dump_counter.fetch_add(1, std::memory_order_relaxed);
+      auto stamp = std::chrono::duration_cast<std::chrono::microseconds>(
+                       std::chrono::system_clock::now().time_since_epoch())
+                       .count();
+      std::filesystem::path dir =
+          base / ("dump_" + std::to_string(stamp) + "_" + std::to_string(counter));
+      if (std::filesystem::create_directory(dir, ec)) {
+        return dir;
+      }
+    }
+    return {};
+  }
+
+  void Cleanup(const std::filesystem::path& dir) {
+    if (dir.empty()) {
+      return;
+    }
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
+  }
+
+  std::string ReadDumpFile(const std::filesystem::path& dir) {
+    if (dir.empty()) {
+      return "";
+    }
+    std::error_code ec;
+    std::filesystem::path dump_file;
+    for (const auto& entry : std::filesystem::directory_iterator(dir, ec)) {
+      if (ec) {
+        break;
+      }
+      if (!entry.is_regular_file(ec)) {
+        continue;
+      }
+      if (!dump_file.empty()) {
+        dump_file.clear();
+        break;
+      }
+      dump_file = entry.path();
+    }
+    std::string data;
+    if (!dump_file.empty()) {
+      std::ifstream file(dump_file, std::ios::binary);
+      if (file.is_open()) {
+        data.assign((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+      }
+    }
+    std::filesystem::remove_all(dir, ec);
+    return data;
+  }
+};
 
 #define DECLARE_DATA()                                                                             \
   const char* msg_short = "Carpe diem.";                                                           \


### PR DESCRIPTION
## Motivation

- Current IR is dumped to stderr and stream capture is used to direct this to file.
- with comgr, the IR is not getting dumped to stderr and tests  that check IR are failing.
- pass a compiler option -ir-dump-directory to dump the IR to a file and parse data from that file.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

[ROCM-466](https://amd-hub.atlassian.net/browse/ROCM-466)

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


[ROCM-466]: https://amd-hub.atlassian.net/browse/ROCM-466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ