### PR TITLE
[rocprofiler-compute] Build standalone binary with cmake 

### DIFF
--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -83,7 +83,8 @@ endif()
 message(STATUS "Installation path: ${CMAKE_INSTALL_PREFIX}")
 
 option(CHECK_PYTHON_DEPS "Verify necessary python dependencies" ON)
-if(CHECK_PYTHON_DEPS)
+option(STANDALONEBINARY "Whether to build standalone binary" OFF)
+if(CHECK_PYTHON_DEPS AND NOT STANDALONEBINARY)
     # Python 3 is required
     message(STATUS "Detecting Python interpreter...")
     find_package(Python3 3.9 COMPONENTS Interpreter REQUIRED)
@@ -262,11 +263,29 @@ option(
     "Test from install directory rather than from source directory"
     OFF
 )
-if(TEST_FROM_INSTALL)
+if(TEST_FROM_INSTALL OR STANDALONEBINARY)
     set(WORKING_DIR_OPTION "")
 else()
     set(WORKING_DIR_OPTION WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 endif()
+
+set(STANDALONEBINARY_EXTRACT_DIR
+    "/tmp"
+    CACHE PATH
+    "Absolute path to where the standalone binary will extract its contents"
+)
+
+if(STANDALONEBINARY)
+    set(STANDALONEBINARY_TEST_OPTION "--call-binary")
+else()
+    set(STANDALONEBINARY_TEST_OPTION "")
+endif()
+
+option(
+    SKIP_NATIVE_TOOL_BUILD
+    "Skip building native counter collection tool library (for runtime compilation)"
+    OFF
+)
 
 # ---------------------------
 # profile mode tests
@@ -275,15 +294,15 @@ endif()
 add_test(
     NAME test_profile_kernel_execution
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -m kernel_execution
-        --junitxml=tests/test_profile_kernel_execution.xml ${COV_OPTION}
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -m
+        kernel_execution --junitxml=tests/test_profile_kernel_execution.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
     NAME test_profile_dispatch
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -m dispatch
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -m dispatch
         --junitxml=tests/test_profile_dispatch.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
@@ -291,42 +310,47 @@ add_test(
 add_test(
     NAME test_profile_mem
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -m mem --junitxml=tests/test_profile_mem.xml
-        ${COV_OPTION} tests/test_profile_general.py ${WORKING_DIR_OPTION}
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -m mem
+        --junitxml=tests/test_profile_mem.xml ${COV_OPTION} tests/test_profile_general.py
+        ${WORKING_DIR_OPTION}
 )
 
 add_test(
     NAME test_profile_join
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -m join --junitxml=tests/test_profile_join.xml
-        ${COV_OPTION} tests/test_profile_general.py ${WORKING_DIR_OPTION}
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -m join
+        --junitxml=tests/test_profile_join.xml ${COV_OPTION} tests/test_profile_general.py
+        ${WORKING_DIR_OPTION}
 )
 
 add_test(
     NAME test_profile_sort
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -m sort --junitxml=tests/test_profile_sort.xml
-        ${COV_OPTION} tests/test_profile_general.py ${WORKING_DIR_OPTION}
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -m sort
+        --junitxml=tests/test_profile_sort.xml ${COV_OPTION} tests/test_profile_general.py
+        ${WORKING_DIR_OPTION}
 )
 
 add_test(
     NAME test_profile_misc
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -m misc --junitxml=tests/test_profile_misc.xml
-        ${COV_OPTION} tests/test_profile_general.py ${WORKING_DIR_OPTION}
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -m misc
+        --junitxml=tests/test_profile_misc.xml ${COV_OPTION} tests/test_profile_general.py
+        ${WORKING_DIR_OPTION}
 )
 
 add_test(
     NAME test_profile_path
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -m path --junitxml=tests/test_profile_path.xml
-        ${COV_OPTION} tests/test_profile_general.py ${WORKING_DIR_OPTION}
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -m path
+        --junitxml=tests/test_profile_path.xml ${COV_OPTION} tests/test_profile_general.py
+        ${WORKING_DIR_OPTION}
 )
 
 add_test(
     NAME test_profile_roofline_1
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -m roofline_1
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -m roofline_1
         --junitxml=tests/test_profile_roofline_1.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
@@ -334,7 +358,7 @@ add_test(
 add_test(
     NAME test_profile_roofline_2
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -m roofline_2
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -m roofline_2
         --junitxml=tests/test_profile_roofline_2.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
@@ -342,7 +366,7 @@ add_test(
 add_test(
     NAME test_profile_section
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -m section
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -m section
         --junitxml=tests/test_profile_section.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
@@ -350,7 +374,7 @@ add_test(
 add_test(
     NAME test_profile_pc_sampling
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -s -m pc_sampling
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -s -m pc_sampling
         --junitxml=tests/test_profile_pc_sampling.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
@@ -358,7 +382,7 @@ add_test(
 add_test(
     NAME test_profile_sets_func
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -m sets_func
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -m sets_func
         --junitxml=tests/test_profile_sets_func.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
@@ -366,15 +390,16 @@ add_test(
 add_test(
     NAME test_profile_live_attach_detach
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -s -m live_attach_detach
-        --junitxml=tests/test_profile_live_attach_detach.xml ${COV_OPTION}
-        tests/test_profile_general.py ${WORKING_DIR_OPTION}
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -s -m
+        live_attach_detach --junitxml=tests/test_profile_live_attach_detach.xml
+        ${COV_OPTION} tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
     NAME test_profile_iteration_multiplexing_1
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -s -m iteration_multiplexing_1
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -s -m
+        iteration_multiplexing_1
         --junitxml=tests/test_profile_iteration_multiplexing_1.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
@@ -382,7 +407,8 @@ add_test(
 add_test(
     NAME test_profile_iteration_multiplexing_2
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -s -m iteration_multiplexing_2
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -s -m
+        iteration_multiplexing_2
         --junitxml=tests/test_profile_iteration_multiplexing_2.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
@@ -390,7 +416,8 @@ add_test(
 add_test(
     NAME test_profile_iteration_multiplexing_stochastic
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -s -m iteration_multiplexing_stochastic
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -s -m
+        iteration_multiplexing_stochastic
         --junitxml=tests/test_profile_iteration_multiplexing_stochastic.xml ${COV_OPTION}
         tests/test_profile_general.py ${WORKING_DIR_OPTION}
 )
@@ -412,8 +439,9 @@ endif()
 add_test(
     NAME test_metric_validation
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest --junitxml=tests/test_metric_validation.xml
-        ${COV_OPTION} tests/test_metric_validation.py ${WORKING_DIR_OPTION}
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION}
+        --junitxml=tests/test_metric_validation.xml ${COV_OPTION}
+        tests/test_metric_validation.py ${WORKING_DIR_OPTION}
 )
 
 set_tests_properties(
@@ -443,9 +471,9 @@ set_tests_properties(
 add_test(
     NAME test_analyze_commands
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -n ${PYTEST_NUMPROCS_ANALYSIS} --verbose
-        --junitxml=tests/test_analyze_commands.xml ${COV_OPTION}
-        tests/test_analyze_commands.py ${WORKING_DIR_OPTION}
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -n
+        ${PYTEST_NUMPROCS_ANALYSIS} --verbose --junitxml=tests/test_analyze_commands.xml
+        ${COV_OPTION} tests/test_analyze_commands.py ${WORKING_DIR_OPTION}
 )
 
 # ---------------------------
@@ -455,8 +483,8 @@ add_test(
 add_test(
     NAME test_analyze_workloads
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -n ${PYTEST_NUMPROCS}
-        --junitxml=tests/test_analyze_workloads.xml ${COV_OPTION}
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -n
+        ${PYTEST_NUMPROCS} --junitxml=tests/test_analyze_workloads.xml ${COV_OPTION}
         tests/test_analyze_workloads.py ${WORKING_DIR_OPTION}
 )
 
@@ -467,7 +495,7 @@ add_test(
 add_test(
     NAME test_L1_cache_counters
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -m L1_cache
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -m L1_cache
         --junitxml=tests/test_L1_cache_counters.xml ${COV_OPTION}
         tests/test_TCP_counters.py ${WORKING_DIR_OPTION}
 )
@@ -479,16 +507,16 @@ add_test(
 add_test(
     NAME test_num_xcds_spec_class
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -m num_xcds_spec_class
-        --junitxml=tests/test_num_xcds_spec_class.xml ${COV_OPTION}
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -m
+        num_xcds_spec_class --junitxml=tests/test_num_xcds_spec_class.xml ${COV_OPTION}
         tests/test_gpu_specs.py ${WORKING_DIR_OPTION}
 )
 
 add_test(
     NAME test_num_xcds_cli_output
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest -m num_xcds_cli_output
-        --junitxml=tests/test_num_xcds_cli_output.xml ${COV_OPTION}
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -m
+        num_xcds_cli_output --junitxml=tests/test_num_xcds_cli_output.xml ${COV_OPTION}
         tests/test_gpu_specs.py ${WORKING_DIR_OPTION}
 )
 
@@ -499,8 +527,9 @@ add_test(
 add_test(
     NAME test_utils
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest --junitxml=tests/test_utils.xml ${COV_OPTION}
-        tests/test_utils.py ${WORKING_DIR_OPTION}
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION}
+        --junitxml=tests/test_utils.xml ${COV_OPTION} tests/test_utils.py
+        ${WORKING_DIR_OPTION}
 )
 
 # -----------------------------------
@@ -510,8 +539,9 @@ add_test(
 add_test(
     NAME test_autogen_config
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest --junitxml=tests/test_autogen_config.xml
-        ${COV_OPTION} tests/test_autogen_config.py ${WORKING_DIR_OPTION}
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION}
+        --junitxml=tests/test_autogen_config.xml ${COV_OPTION}
+        tests/test_autogen_config.py ${WORKING_DIR_OPTION}
 )
 
 # -----------------------------------
@@ -562,7 +592,9 @@ endif()
 # -------------------
 # Setup tool library
 # -------------------
-add_subdirectory(src/lib)
+if(NOT SKIP_NATIVE_TOOL_BUILD)
+    add_subdirectory(src/lib)
+endif()
 
 # ---------
 # Install
@@ -663,11 +695,20 @@ install(
     COMPONENT main
 )
 
-# install librocprofiler-compute-tool.so
-install(
-    TARGETS rocprofiler-compute-tool
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/rocprofiler-compute COMPONENT main
-)
+# install librocprofiler-compute-tool.so or source files
+if(NOT SKIP_NATIVE_TOOL_BUILD)
+    install(
+        TARGETS rocprofiler-compute-tool
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/rocprofiler-compute COMPONENT main
+    )
+else()
+    # Install source files for runtime compilation
+    install(
+        FILES src/lib/rocprofiler_compute_tool.cpp src/lib/helper.cpp src/lib/helper.hpp
+        DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}/lib
+        COMPONENT main
+    )
+endif()
 
 # top-level symlink for bin/rocprof-compute
 install(
@@ -691,55 +732,6 @@ add_custom_target(
         ${PROJECT_SOURCE_DIR}/tools/update_license.py --source ${PROJECT_SOURCE_DIR}
         --license ${PROJECT_SOURCE_DIR}/LICENSE.md --file
         "src/${PACKAGE_NAME},cmake/Dockerfile,cmake/rocm_install.sh,docker/docker-entrypoint.sh,src/rocprof_compute_analyze/convertor/mongodb/convert"
-)
-
-set(STANDALONEBINARY_EXTRACT_DIR
-    "/tmp"
-    CACHE PATH
-    "Absolute path to where the standalone binary will extract its contents"
-)
-
-# Standalone binary creation
-add_custom_target(
-    standalonebinary
-    # Change working directory to src
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    # Install nuitka
-    COMMAND ${Python3_EXECUTABLE} -m pip install nuitka==2.6
-    # Install patchelf
-    COMMAND ${Python3_EXECUTABLE} -m pip install patchelf
-    # Check nuitka
-    COMMAND ${Python3_EXECUTABLE} -m pip list | grep -i nuitka > /dev/null 2>&1
-    # Check patchelf
-    COMMAND ${Python3_EXECUTABLE} -m pip list | grep -i patchelf > /dev/null 2>&1
-    # Create VERSION.sha file
-    COMMAND git rev-parse HEAD > VERSION.sha
-    # Build standalone binary
-    # NOTE: --no-deployment-flag=self-execution is used to avoid self-execution
-    # and fork bombs as explained in
-    # https://nuitka.net/user-documentation/common-issue-solutions.html#fork-bombs-self-execution
-    COMMAND
-        ${Python3_EXECUTABLE} -m nuitka --mode=onefile --no-deployment-flag=self-execution
-        --product-name=${STANDALONEBINARY_EXTRACT_DIR}
-        --onefile-tempdir-spec=/{PRODUCT}/rocprof_compute_standalonebinary_{PID}
-        --include-data-files=${PROJECT_SOURCE_DIR}/VERSION*=./ --enable-plugin=no-qt
-        --include-data-files=src/lib/rocprofiler_compute_tool.cpp=lib/rocprofiler_compute_tool.cpp
-        --include-data-files=src/lib/helper.cpp=lib/helper.cpp
-        --include-data-files=src/lib/helper.hpp=lib/helper.hpp --include-package=dash_svg
-        --include-package-data=dash_svg --include-package=dash_bootstrap_components
-        --include-package-data=dash_bootstrap_components --include-package=plotly
-        --include-package-data=plotly --include-package=rocprof_compute_analyze
-        --include-package-data=rocprof_compute_analyze
-        --include-package=rocprof_compute_profile
-        --include-package-data=rocprof_compute_profile
-        --include-package=rocprof_compute_tui --include-package-data=rocprof_compute_tui
-        --include-package=rocprof_compute_soc --include-package-data=rocprof_compute_soc
-        --include-package=utils --include-package-data=utils --include-package=hip
-        --include-package-data=hip src/rocprof-compute
-    # Remove library rpath from executable
-    COMMAND patchelf --remove-rpath rocprof-compute.bin
-    # Move to build directory
-    COMMAND mv rocprof-compute.bin ${CMAKE_BINARY_DIR}
 )
 
 install(
@@ -799,6 +791,113 @@ if(INSTALL_TESTS)
     )
 endif()
 message(STATUS "Install tests: ${INSTALL_TESTS}")
+
+# Standalone binary creation during install
+if(STANDALONEBINARY)
+    # Ensure Python3 is found for Nuitka
+    # We use Nuitka 2.6 which requires exactly Python 3.11.x (any patch version)
+    find_package(Python3 3.11 COMPONENTS Interpreter REQUIRED)
+
+    # Verify exactly 3.11.x (not 3.10.x or 3.12.x)
+    if(NOT (Python3_VERSION_MAJOR EQUAL 3 AND Python3_VERSION_MINOR EQUAL 11))
+        message(
+            FATAL_ERROR
+            "Standalone binary requires exactly Python 3.11.x (any patch version). "
+            "Found: Python ${Python3_VERSION}"
+        )
+    endif()
+
+    install(
+        CODE
+            "
+            message(STATUS \"Building standalone binary...\")
+            # Note: Variables defined here use \${VAR} escaping so they're evaluated at install time
+            # rather than configure time. Variables from configure time like ${PROJECT_BINARY_DIR}
+            # are expanded when CMake processes this file.
+            set(VENV_DIR \"${PROJECT_BINARY_DIR}/nuitka-build-venv\")
+            # Create virtual environment
+            message(STATUS \"Creating virtual environment at \${VENV_DIR}\")
+            execute_process(COMMAND ${Python3_EXECUTABLE} -m venv \${VENV_DIR} RESULT_VARIABLE VENV_RESULT)
+            if(NOT VENV_RESULT EQUAL 0)
+                message(FATAL_ERROR \"Failed to create virtual environment\")
+            endif()
+            set(VENV_PYTHON \"\${VENV_DIR}/bin/python\")
+            # Install requirements
+            message(STATUS \"Installing requirements.txt\")
+            execute_process(COMMAND \${VENV_PYTHON} -m pip install -r ${PROJECT_SOURCE_DIR}/requirements.txt RESULT_VARIABLE REQUIREMENTS_RESULT)
+            if(NOT REQUIREMENTS_RESULT EQUAL 0)
+                file(REMOVE_RECURSE \${VENV_DIR})
+                message(FATAL_ERROR \"Failed to install requirements.txt\")
+            endif()
+            # Install nuitka (Note that Nuitka 2.6 will require Python 3.11 interpreter)
+            message(STATUS \"Installing nuitka\")
+            execute_process(COMMAND \${VENV_PYTHON} -m pip install nuitka==2.6 RESULT_VARIABLE NUITKA_INSTALL_RESULT)
+            if(NOT NUITKA_INSTALL_RESULT EQUAL 0)
+                file(REMOVE_RECURSE \${VENV_DIR})
+                message(FATAL_ERROR \"Failed to install nuitka\")
+            endif()
+            # Install patchelf 0.17.2.4
+            message(STATUS \"Installing patchelf\")
+            execute_process(COMMAND \${VENV_PYTHON} -m pip install patchelf==0.17.2.4 RESULT_VARIABLE PATCHELF_INSTALL_RESULT)
+            if(NOT PATCHELF_INSTALL_RESULT EQUAL 0)
+                file(REMOVE_RECURSE \${VENV_DIR})
+                message(FATAL_ERROR \"Failed to install patchelf\")
+            endif()
+            # Build standalone binary
+            message(STATUS \"Building standalone binary with nuitka\")
+            execute_process(
+                COMMAND \${CMAKE_COMMAND} -E env PATH=\${VENV_DIR}/bin:\$ENV{PATH}
+                    \${VENV_PYTHON} -m nuitka --mode=onefile --no-deployment-flag=self-execution
+                    --product-name=${STANDALONEBINARY_EXTRACT_DIR}
+                    --onefile-tempdir-spec=/{PRODUCT}/rocprof_compute_standalonebinary_{PID}
+                    --include-data-files=${PROJECT_SOURCE_DIR}/VERSION*=./ --enable-plugin=no-qt
+                    --include-data-files=src/lib/rocprofiler_compute_tool.cpp=lib/rocprofiler_compute_tool.cpp
+                    --include-data-files=src/lib/helper.cpp=lib/helper.cpp
+                    --include-data-files=src/lib/helper.hpp=lib/helper.hpp --include-package=dash_svg
+                    --include-package-data=dash_svg --include-package=dash_bootstrap_components
+                    --include-package-data=dash_bootstrap_components --include-package=plotly
+                    --include-package-data=plotly --include-package=rocprof_compute_analyze
+                    --include-package-data=rocprof_compute_analyze
+                    --include-package=rocprof_compute_profile
+                    --include-package-data=rocprof_compute_profile
+                    --include-package=rocprof_compute_tui --include-package-data=rocprof_compute_tui
+                    --include-package=rocprof_compute_soc --include-package-data=rocprof_compute_soc
+                    --include-package=utils --include-package-data=utils --include-package=hip
+                    --include-package-data=hip --include-package=dateutil
+                    --include-package-data=dateutil --include-package=rich
+                    --include-package-data=rich src/${EXECUTABLE_NAME}
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                RESULT_VARIABLE NUITKA_RESULT
+            )
+            if(NOT NUITKA_RESULT EQUAL 0)
+                file(REMOVE_RECURSE \${VENV_DIR})
+                message(FATAL_ERROR \"Nuitka build failed\")
+            endif()
+            # Remove library rpath from executable
+            message(STATUS \"Removing rpath from binary\")
+            execute_process(COMMAND \${VENV_DIR}/bin/patchelf --remove-rpath ${EXECUTABLE_NAME}.bin WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} RESULT_VARIABLE PATCHELF_RESULT)
+            if(NOT PATCHELF_RESULT EQUAL 0)
+                file(REMOVE_RECURSE \${VENV_DIR})
+                message(FATAL_ERROR \"patchelf failed to remove rpath\")
+            endif()
+            # Clean up virtual environment
+            message(STATUS \"Cleaning up virtual environment\")
+            file(REMOVE_RECURSE \${VENV_DIR})
+            # Install to destination
+            file(INSTALL ${PROJECT_SOURCE_DIR}/${EXECUTABLE_NAME}.bin DESTINATION \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME})
+            # Explicitly set executable permission (required for volume-mounted filesystems)
+            execute_process(COMMAND chmod +x \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}/${EXECUTABLE_NAME}.bin)
+            # Clean up Nuitka build artifacts from source directory
+            message(STATUS \"Cleaning up Nuitka build artifacts\")
+            file(REMOVE ${PROJECT_SOURCE_DIR}/${EXECUTABLE_NAME}.bin)
+            file(REMOVE_RECURSE ${PROJECT_SOURCE_DIR}/${EXECUTABLE_NAME}.build)
+            file(REMOVE_RECURSE ${PROJECT_SOURCE_DIR}/${EXECUTABLE_NAME}.dist)
+            file(REMOVE_RECURSE ${PROJECT_SOURCE_DIR}/${EXECUTABLE_NAME}.onefile-build)
+            message(STATUS \"Standalone binary installed to \${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}/${EXECUTABLE_NAME}.bin\")
+        "
+        COMPONENT main
+    )
+endif()
 
 # ----------
 # Packaging

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -794,7 +794,6 @@ message(STATUS "Install tests: ${INSTALL_TESTS}")
 
 # Standalone binary creation during install
 if(STANDALONEBINARY)
-    # Ensure Python3 is found for Nuitka
     # We use Nuitka 2.6 which requires exactly Python 3.11.x (any patch version)
     find_package(Python3 3.11 COMPONENTS Interpreter REQUIRED)
 

--- a/projects/rocprofiler-compute/README.md
+++ b/projects/rocprofiler-compute/README.md
@@ -57,7 +57,7 @@ Note that per the above command, build assets will be stored under `build` direc
 
 Then, to run the automated test suite, run the following commands:
 ```
-mkdir build
+cd build
 ctest
 ```
 
@@ -67,7 +67,7 @@ For manual testing, you can find the executable at `install/bin/rocprof-compute`
 
 ### Create standalone binary using docker container
 
-This method uses the cmake target inside a docker container.
+This method uses the cmake target inside a RHEL 8 docker container with Python3.11 installed.
 
 To create a standalone binary, run the following commands:
 * `cd docker`
@@ -77,22 +77,23 @@ To create a standalone binary, run the following commands:
 
 ### Create standalone binary using cmake target locally without docker
 
+**NOTE: Python3.11 should be installed on the system to build the standalone binary**
+
 To create a standalone binary, run the following commands:
-* `pip install -r requirements.txt` (install python dependencies)
+
 * Optionally, provide `-D STANDALONEBINARY_EXTRACT_DIR=/<path>` option in cmake config. command to change the absolute path where standalone binary will extract its contents. Default is `/tmp`.
-* `cmake -B build -S .` (cmake config. command)
-* `cmake --build build --target standalonebinary` (call standalonebinary cmake target)
+* `cmake -B build -D CMAKE_INSTALL_PREFIX=install -D STANDALONEBINARY=ON -S .` (cmake config. command)
+* `cmake --build build --target install --parallel 8` (run cmake install target)
 
 ### Standalone binary creation methodology
 
 To build the binary we follow these steps:
 * Use RHEL 8.10 docker image as the base image (only in docker method)
-* Install python3.9 (only in docker method)
-* Install runtime dependencies (only in docker method)
-* Install dependencies for building standalone binary
-* Call the standalonebinary cmake target which uses Nuitka to build the standalone binary
+* Install python3.11
+* Install python dependencies
+* Call the install cmake target with STANDALONEBINARY=ON cmake args. which will use Nuitka to build the standalone binary
 
-You should find the rocprof-compute.bin standalone binary inside the `build` folder in the root directory of the project.
+You should find the rocprof-compute.bin standalone binary inside the `install/libexec/rocprofiler-compute/rocprof-compute.bin` folder in the root directory of the project.
 
 ### Things to note about standalone binary
 
@@ -100,12 +101,20 @@ You should find the rocprof-compute.bin standalone binary inside the `build` fol
 
 * By default, standalone binary extracts its contents to a directory `rocprof_compute_standalonebinary_<pid>` under `/tmp` parent directory upon execution, however, the parent directory can be configured as explained in standalone binary creation section.
 
-* When using docker method, since RHEL 8 ships with glibc version 2.28, this standalone binary can only be run on environment with glibc version greater than 2.28.
-glibc version can be checked using `ldd --version` command.
+* When using docker method, since RHEL 8 ships with glibc version 2.28, this standalone binary can only be run on environment with glibc version greater than or equal to 2.28. glibc version can be checked using `ldd --version` command.
 
 * If not using docker, the minimum glibc version is determined by the OS where cmake is run.
 
-To test the standalone binary provide the `--call-binary` option to pytest.
+* When using docker, native counter collection tool is not compiled due to unavailability of rocprofiler-sdk. Instead, native counter collection tool will be runtime compiled based on the environment where the binary is running.
+
+### Test standalone binary
+
+Create standalone binary with tests enabled, then run the tests:
+
+* `cmake -B build -D CMAKE_INSTALL_PREFIX=install -D ENABLE_TESTS=ON -D INSTALL_TESTS=ON -D STANDALONEBINARY=ON -S .`
+* `cmake --build build --target install --parallel 8`
+* `cd install/libexec/rocprofiler-compute`
+* `ctest`
 
 ## How to Cite
 

--- a/projects/rocprofiler-compute/docker/Dockerfile.standalone
+++ b/projects/rocprofiler-compute/docker/Dockerfile.standalone
@@ -7,40 +7,17 @@ RUN yum install -y curl git cmake gcc-c++
 # Allows running git commands in /app
 RUN git config --global --add safe.directory /app
 
-RUN yum install -y python39 python39-devel && \
+RUN yum install -y python3.11 python3.11-devel python3.11-pip && \
     yum clean all && \
     rm -rf /var/cache/yum && \
-    curl -sS https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python3 get-pip.py
+    alternatives --set python3 /usr/bin/python3.11
 
 # Should be absolute path to where the standalone binary will extract its contents
 ARG STANDALONEBINARY_EXTRACT_DIR=/tmp
 ENV STANDALONEBINARY_EXTRACT_DIR=${STANDALONEBINARY_EXTRACT_DIR}
 
+# Skip native tool build due to unavailability of rocprofiler-sdk in the container
 CMD ["/bin/bash", "-c", "\
-    python3 -m pip install -r requirements.txt \
-    && python3 -m pip install nuitka==2.6 patchelf \
-    && git rev-parse HEAD > VERSION.sha \
-    && python3 -m nuitka --mode=onefile --no-deployment-flag=self-execution \
-        --product-name=${STANDALONEBINARY_EXTRACT_DIR} \
-        --onefile-tempdir-spec=/{PRODUCT}/rocprof_compute_standalonebinary_{PID} \
-        --enable-plugin=no-qt \
-        --include-data-files=VERSION*=./ \
-        --include-data-files=src/lib/rocprofiler_compute_tool.cpp=lib/rocprofiler_compute_tool.cpp \
-        --include-data-files=src/lib/helper.cpp=lib/helper.cpp \
-        --include-data-files=src/lib/helper.hpp=lib/helper.hpp \
-        --include-package=dash_svg --include-package-data=dash_svg \
-        --include-package=dash_bootstrap_components \
-        --include-package-data=dash_bootstrap_components \
-        --include-package=plotly --include-package-data=plotly \
-        --include-package=rocprof_compute_analyze \
-        --include-package-data=rocprof_compute_analyze \
-        --include-package=rocprof_compute_profile \
-        --include-package-data=rocprof_compute_profile \
-        --include-package=rocprof_compute_tui --include-package-data=rocprof_compute_tui \
-        --include-package=rocprof_compute_soc --include-package-data=rocprof_compute_soc \
-        --include-package=utils --include-package-data=utils \
-        --include-package=hip --include-package-data=hip \
-        src/rocprof-compute \
-    && patchelf --remove-rpath rocprof-compute.bin \
+    cmake -B build -D CMAKE_INSTALL_PREFIX=install -D SKIP_NATIVE_TOOL_BUILD=ON -D STANDALONEBINARY=ON -D STANDALONEBINARY_EXTRACT_DIR=${STANDALONEBINARY_EXTRACT_DIR} -S . \
+    && cmake --build build --target install \
 "]

--- a/projects/rocprofiler-compute/src/rocprof-compute
+++ b/projects/rocprofiler-compute/src/rocprof-compute
@@ -25,6 +25,11 @@
 # SOFTWARE.
 ##############################################################################el
 
+import warnings
+
+# Suppress pandas FutureWarning about chained assignment
+warnings.filterwarnings("ignore", category=FutureWarning)
+
 import re
 import sys
 from pathlib import Path

--- a/projects/rocprofiler-compute/tests/conftest.py
+++ b/projects/rocprofiler-compute/tests/conftest.py
@@ -67,6 +67,18 @@ def pytest_addoption(parser):
     )
 
 
+@pytest.fixture(autouse=True)
+def skip_monkeypatch_with_binary(request):
+    """Auto-skip tests using monkeypatch when --call-binary is used.
+
+    Tests that use monkeypatch to patch Python functions/classes/modules
+    cannot work with --call-binary mode because the binary runs in a separate
+    process where Python patches don't apply.
+    """
+    if request.config.getoption("--call-binary") and "monkeypatch" in request.fixturenames:
+        pytest.skip("Test uses monkeypatch which is incompatible with --call-binary mode")
+
+
 @pytest.fixture
 def binary_handler_profile_rocprof_compute(request):
     """

--- a/projects/rocprofiler-compute/tests/conftest.py
+++ b/projects/rocprofiler-compute/tests/conftest.py
@@ -117,7 +117,7 @@ def binary_handler_profile_rocprof_compute(request):
             )
         if request.config.getoption("--call-binary"):
             baseline_opts = [
-                "build/rocprof-compute.bin",
+                "./rocprof-compute.bin",
                 "profile",
                 "-VVV",
             ]
@@ -160,9 +160,14 @@ def binary_handler_profile_rocprof_compute(request):
             process = subprocess.run(
                 command_rocprof_compute,
                 text=True,
-                capture_output=capture_output,
+                capture_output=True,
             )
-            # Verify run status
+            # Print output so capsys can capture it
+            if process.stdout:
+                print(process.stdout, end="")
+            if process.stderr:
+                print(process.stderr, end="", file=sys.stderr)
+            # verify run status
             if check_success:
                 assert process.returncode == 0
 
@@ -268,9 +273,15 @@ def binary_handler_analyze_rocprof_compute(request):
     def _handler(arguments):
         if request.config.getoption("--call-binary"):
             process = subprocess.run(
-                ["build/rocprof-compute.bin", *arguments],
+                ["./rocprof-compute.bin", *arguments],
                 text=True,
+                capture_output=True,
             )
+            # Print output so capsys can capture it
+            if process.stdout:
+                print(process.stdout, end="")
+            if process.stderr:
+                print(process.stderr, end="", file=sys.stderr)
             return process.returncode
         else:
             with pytest.raises(SystemExit) as e:


### PR DESCRIPTION
## Motivation

Add CMake options for standalone binary support:
- **STANDALONEBINARY**: Enable nuitka-based standalone binary build (default: OFF)
- **STANDALONEBINARY_EXTRACT_DIR**: Configure absolute path where binary extracts contents (default: /tmp)
- **SKIP_NATIVE_TOOL_BUILD**: Skip native counter collection tool build, install source files for runtime compilation instead (default: OFF)

Enforce Python 3.11.x requirement for building standalone binary since Nuitka 2.6 has static analysis issues with other Python versions (e.g., pandas module detection fails with Python 3.12).

Improve standalone binary building process with isolated virtual environment, automatic dependency installation, and proper cleanup of build artifacts.

## Technical Details

**CMakeLists.txt:**
- Enforce Python 3.11.x requirement (Nuitka 2.6 compatibility)
- Skip Python dependency checking when STANDALONEBINARY=ON (venv handles it)
- Create isolated venv for nuitka build with automatic cleanup on success/failure
- Install pinned dependencies in venv (requirements.txt, nuitka==2.6, patchelf==0.17.2.4)
- Use nuitka default libpython handling (--static-libpython=auto)
- Install tool source files (rocprofiler_compute_tool.cpp, helper.cpp/hpp) when SKIP_NATIVE_TOOL_BUILD=ON
- Add STANDALONEBINARY_TEST_OPTION to pass --call-binary to pytest when testing standalone binary
- Move STANDALONEBINARY_EXTRACT_DIR definition before test definitions for proper test setup

**Dockerfile.standalone:**
- Upgrade from Python 3.9 to Python 3.11 with pip
- Replace manual nuitka invocation with cmake install target
- Add SKIP_NATIVE_TOOL_BUILD=ON for container builds without rocprofiler-sdk
- Simplify build process and improve maintainability

**README.md:**
- Document Python 3.11 requirement for standalone binary builds
- Update build instructions to use cmake install target with STANDALONEBINARY=ON
- Fix test directory navigation (mkdir -> cd)
- Add standalone binary testing section with ctest instructions
- Clarify glibc version requirements (>= 2.28 for RHEL 8 builds)
- Document runtime compilation of native tool when SKIP_NATIVE_TOOL_BUILD=ON
- Add --parallel 8 to build commands for faster builds

**src/rocprof-compute:**
- Suppress pandas FutureWarning about chained assignment

**tests/conftest.py:**
- Update binary path from build/rocprof-compute.bin to ./rocprof-compute.bin
- Fix output capturing to use capture_output=True and print to stdout/stderr for pytest capsys compatibility
- Add autouse fixture to skip tests using monkeypatch when --call-binary is enabled (monkeypatch patches only affect the current Python process and cannot modify the standalone binary running in a separate subprocess)

## JIRA ID

AIPROFCOMP-5

## Test Plan

* Ensure successful build of standalone binary using both docker and cmake
* Ensure ctest suite passes on standalone binary
* Perform manual checks for profiling, analysis, GUI and TUI working

## Test Result

All tests pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.