### PR TITLE
[Rocprof-system]: Fix rocpd tracks with UCX and add rocpd validation tests

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/ucx_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/ucx_gotcha.cpp
@@ -256,6 +256,7 @@ ucx_gotcha::start()
     if(!get_ucx_gotcha().get<ucx_gotcha_t>()->get_is_running())
     {
         configure();
+        // Initializing comm_data metadata
         comm_data::start();
         get_ucx_gotcha().start();
     }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/ucx_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/ucx_gotcha.cpp
@@ -256,6 +256,7 @@ ucx_gotcha::start()
     if(!get_ucx_gotcha().get<ucx_gotcha_t>()->get_is_running())
     {
         configure();
+        comm_data::start();
         get_ucx_gotcha().start();
     }
 }

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/ucx/validation-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/ucx/validation-rules.json
@@ -17,7 +17,7 @@
             ]
         },
         {
-            "name_prefix": "regions",
+            "name": "regions",
             "required_columns": [
                 "tid",
                 "start",

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/ucx/validation-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/ucx/validation-rules.json
@@ -1,7 +1,7 @@
 {
     "required_tables": [
         {
-            "name": "rocpd_string",
+            "name_prefix": "rocpd_info_pmc_",
             "required_columns": [
                 "id",
                 "string"
@@ -12,13 +12,12 @@
                     "description": "Verify that 'UCX Comm' string is present in the table",
                     "error_message": "'UCX Comm' string not found in the table rocpd_string",
                     "expected_result": 2,
-                    "query": "SELECT COUNT(*) FROM rocpd_string WHERE string LIKE '%UCX Comm%';"
+                    "query": "SELECT COUNT(*) FROM {table_name} WHERE string LIKE '%UCX Comm%';"
                 }
             ]
         },
         {
-            "min_rows": 100,
-            "name": "regions",
+            "name_prefix": "regions",
             "required_columns": [
                 "tid",
                 "start",
@@ -32,14 +31,14 @@
                     "description": "Verify entries have non-zero start times",
                     "error_message": "Found entries with zero start times in table",
                     "expected_result": 0,
-                    "query": "SELECT COUNT(*) as count FROM regions WHERE start = 0"
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE start = 0"
                 },
                 {
                     "comparison": "greater_than",
                     "description": "Verify that 'ucx' appears in category at least 100 times in table regions",
                     "error_message": "'ucx' category entries are fewer than expected in regions",
                     "expected_result": 100,
-                    "query": "SELECT COUNT(*) FROM regions WHERE category = 'ucx';"
+                    "query": "SELECT COUNT(*) FROM {table_name} WHERE category = 'ucx';"
                 }
             ]
         }

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/ucx/validation-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/ucx/validation-rules.json
@@ -1,7 +1,7 @@
 {
     "required_tables": [
         {
-            "name_prefix": "rocpd_info_pmc_",
+            "name_prefix": "rocpd_string",
             "required_columns": [
                 "id",
                 "string"

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/ucx/validation-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/ucx/validation-rules.json
@@ -1,0 +1,47 @@
+{
+    "required_tables": [
+        {
+            "name": "rocpd_string",
+            "required_columns": [
+                "id",
+                "string"
+            ],
+            "validation_queries": [
+                {
+                    "comparison": "equals",
+                    "description": "Verify that 'UCX Comm' string is present in the table",
+                    "error_message": "'UCX Comm' string not found in the table rocpd_string",
+                    "expected_result": 2,
+                    "query": "SELECT COUNT(*) FROM rocpd_string WHERE string LIKE '%UCX Comm%';"
+                }
+            ]
+        },
+        {
+            "min_rows": 100,
+            "name": "regions",
+            "required_columns": [
+                "tid",
+                "start",
+                "end",
+                "name",
+                "category"
+            ],
+            "validation_queries": [
+                {
+                    "comparison": "equals",
+                    "description": "Verify entries have non-zero start times",
+                    "error_message": "Found entries with zero start times in table",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM regions WHERE start = 0"
+                },
+                {
+                    "comparison": "greater_than",
+                    "description": "Verify that 'ucx' appears in category at least 100 times in table regions",
+                    "error_message": "'ucx' category entries are fewer than expected in regions",
+                    "expected_result": 100,
+                    "query": "SELECT COUNT(*) FROM regions WHERE category = 'ucx';"
+                }
+            ]
+        }
+    ]
+}

--- a/projects/rocprofiler-systems/tests/rocprof-sys-gpu-connect-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-gpu-connect-tests.cmake
@@ -48,6 +48,15 @@ if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU})
     list(APPEND _gpu_connect_environment "ROCPROFSYS_USE_ROCPD=ON")
 endif()
 
+# Skip all tests if no valid GPU is detected
+if(NOT _VALID_GPU)
+    message(
+        STATUS
+        "transferBench requires a GPU and no valid GPUs were found; skipping GPU connect tests"
+    )
+    return()
+endif()
+
 # Add a runtime validation test that checks if transferBench can run successfully
 # This test runs before all other GPU connect tests and acts as a fixture
 if(TARGET transferBench)

--- a/projects/rocprofiler-systems/tests/rocprof-sys-gpu-connect-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-gpu-connect-tests.cmake
@@ -50,11 +50,15 @@ endif()
 
 # Add a runtime validation test that checks if transferBench can run successfully
 # This test runs before all other GPU connect tests and acts as a fixture
-add_test(
-    NAME transferbench-validation-check
-    COMMAND $<TARGET_FILE:transferBench>
-    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-)
+if(TARGET transferBench)
+    add_test(
+        NAME transferbench-validation-check
+        COMMAND $<TARGET_FILE:transferBench>
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    )
+else()
+    message(WARNING " transferBench not available; " "GPU connect tests will be skipped")
+endif()
 
 # Set this test as a fixture that must pass for GPU connect tests to run
 set_tests_properties(

--- a/projects/rocprofiler-systems/tests/rocprof-sys-gpu-connect-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-gpu-connect-tests.cmake
@@ -75,7 +75,7 @@ set_tests_properties(
     PROPERTIES
         LABELS "transferbench;validation"
         FIXTURES_SETUP transferbench_available
-        SKIP_REGULAR_EXPRESSION "Error: No valid transfers created"
+        FAIL_REGULAR_EXPRESSION "Error: No valid transfers created"
 )
 
 rocprofiler_systems_add_test(

--- a/projects/rocprofiler-systems/tests/rocprof-sys-gpu-connect-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-gpu-connect-tests.cmake
@@ -103,7 +103,12 @@ rocprofiler_systems_add_validation_test(
     LABELS "transferbench;perfetto"
     ARGS --counter-names "XGMI Read Data" "XGMI Write Data" -p
 )
-
+if(TEST validate-transferbench-sys-run-perfetto)
+    set_property(
+        TEST validate-transferbench-sys-run-perfetto
+        APPEND PROPERTY FIXTURES_REQUIRED transferbench_available
+    )
+endif()
 # Add ROCPD validation if enabled
 if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU})
     set_property(TEST transferbench-sys-run APPEND PROPERTY LABELS rocpd)

--- a/projects/rocprofiler-systems/tests/rocprof-sys-gpu-connect-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-gpu-connect-tests.cmake
@@ -26,6 +26,21 @@
 #
 # -------------------------------------------------------------------------------------- #
 
+# Skip all tests if no valid GPU is detected
+if(NOT _VALID_GPU)
+    message(
+        STATUS
+        "transferBench requires a GPU and no valid GPUs were found; skipping GPU connect tests"
+    )
+    return()
+endif()
+
+# Skip if transferBench target is not available
+if(NOT TARGET transferBench)
+    message(WARNING "transferBench not available; GPU connect tests will be skipped")
+    return()
+endif()
+
 # Use legacy trace mode for AMD SMI counters - cached mode doesn't support real-time counter tracking
 set(_gpu_connect_environment
     "ROCPROFSYS_TRACE=ON"
@@ -43,31 +58,18 @@ set(_gpu_connect_rocpd_validation_rules
     "${CMAKE_CURRENT_LIST_DIR}/rocpd-validation-rules/gpu-connect/amd-smi-rules.json"
 )
 
-# Enable ROCPD for tests only if valid ROCm is installed and a valid GPU is detected
-if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU})
+# Enable ROCPD for tests only if valid ROCm is installed
+if(ENABLE_ROCPD_TEST)
     list(APPEND _gpu_connect_environment "ROCPROFSYS_USE_ROCPD=ON")
-endif()
-
-# Skip all tests if no valid GPU is detected
-if(NOT _VALID_GPU)
-    message(
-        STATUS
-        "transferBench requires a GPU and no valid GPUs were found; skipping GPU connect tests"
-    )
-    return()
 endif()
 
 # Add a runtime validation test that checks if transferBench can run successfully
 # This test runs before all other GPU connect tests and acts as a fixture
-if(TARGET transferBench)
-    add_test(
-        NAME transferbench-validation-check
-        COMMAND $<TARGET_FILE:transferBench>
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-    )
-else()
-    message(WARNING " transferBench not available; " "GPU connect tests will be skipped")
-endif()
+add_test(
+    NAME transferbench-validation-check
+    COMMAND $<TARGET_FILE:transferBench>
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+)
 
 # Set this test as a fixture that must pass for GPU connect tests to run
 set_tests_properties(
@@ -90,10 +92,10 @@ rocprofiler_systems_add_test(
 
 # Make this test depend on the transferBench validation fixture
 if(TEST transferbench-sys-run)
-    set_tests_properties(
-        transferbench-sys-run
+    set_property(
+        TEST transferbench-sys-run
         APPEND
-        PROPERTIES FIXTURES_REQUIRED transferbench_available
+        PROPERTY FIXTURES_REQUIRED transferbench_available
     )
 endif()
 
@@ -111,8 +113,9 @@ if(TEST validate-transferbench-sys-run-perfetto)
         PROPERTY FIXTURES_REQUIRED transferbench_available
     )
 endif()
+
 # Add ROCPD validation if enabled
-if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU})
+if(${ENABLE_ROCPD_TEST} AND TEST transferbench-sys-run)
     set_property(TEST transferbench-sys-run APPEND PROPERTY LABELS rocpd)
 
     rocprofiler_systems_add_validation_test(
@@ -125,9 +128,10 @@ if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU})
 
     # Make ROCPD validation test depend on the transferBench fixture
     if(TEST validate-transferbench-sys-run-rocpd)
-        set_tests_properties(
-            validate-transferbench-sys-run-rocpd
-            PROPERTIES FIXTURES_REQUIRED transferbench_available
+        set_property(
+            TEST validate-transferbench-sys-run-rocpd
+            APPEND
+            PROPERTY FIXTURES_REQUIRED transferbench_available
         )
     endif()
 endif()

--- a/projects/rocprofiler-systems/tests/rocprof-sys-gpu-connect-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-gpu-connect-tests.cmake
@@ -92,7 +92,8 @@ rocprofiler_systems_add_test(
 if(TEST transferbench-sys-run)
     set_tests_properties(
         transferbench-sys-run
-        APPEND PROPERTIES FIXTURES_REQUIRED transferbench_available
+        APPEND
+        PROPERTIES FIXTURES_REQUIRED transferbench_available
     )
 endif()
 
@@ -106,7 +107,8 @@ rocprofiler_systems_add_validation_test(
 if(TEST validate-transferbench-sys-run-perfetto)
     set_property(
         TEST validate-transferbench-sys-run-perfetto
-        APPEND PROPERTY FIXTURES_REQUIRED transferbench_available
+        APPEND
+        PROPERTY FIXTURES_REQUIRED transferbench_available
     )
 endif()
 # Add ROCPD validation if enabled
@@ -120,4 +122,12 @@ if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU})
         ARGS --validation-rules
             ${_gpu_connect_rocpd_validation_rules}
     )
+
+    # Make ROCPD validation test depend on the transferBench fixture
+    if(TEST validate-transferbench-sys-run-rocpd)
+        set_tests_properties(
+            validate-transferbench-sys-run-rocpd
+            PROPERTIES FIXTURES_REQUIRED transferbench_available
+        )
+    endif()
 endif()

--- a/projects/rocprofiler-systems/tests/rocprof-sys-gpu-connect-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-gpu-connect-tests.cmake
@@ -92,7 +92,7 @@ rocprofiler_systems_add_test(
 if(TEST transferbench-sys-run)
     set_tests_properties(
         transferbench-sys-run
-        PROPERTIES FIXTURES_REQUIRED transferbench_available
+        APPEND PROPERTIES FIXTURES_REQUIRED transferbench_available
     )
 endif()
 

--- a/projects/rocprofiler-systems/tests/rocprof-sys-gpu-connect-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-gpu-connect-tests.cmake
@@ -48,24 +48,22 @@ if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU})
     list(APPEND _gpu_connect_environment "ROCPROFSYS_USE_ROCPD=ON")
 endif()
 
-set(skip_validation FALSE)
+# Add a runtime validation test that checks if transferBench can run successfully
+# This test runs before all other GPU connect tests and acts as a fixture
+add_test(
+    NAME transferbench-validation-check
+    COMMAND $<TARGET_FILE:transferBench>
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+)
 
-if(EXISTS "${PROJECT_BINARY_DIR}/transferBench")
-    execute_process(
-        COMMAND ${PROJECT_BINARY_DIR}/transferBench
-        OUTPUT_VARIABLE _transfer_output
-        ERROR_VARIABLE _transfer_output
-        RESULT_VARIABLE _transfer_result
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_STRIP_TRAILING_WHITESPACE
-    )
-
-    if(_transfer_output MATCHES "Error: No valid transfers created")
-        set(skip_validation TRUE)
-    endif()
-else()
-    set(skip_validation TRUE)
-endif()
+# Set this test as a fixture that must pass for GPU connect tests to run
+set_tests_properties(
+    transferbench-validation-check
+    PROPERTIES
+        LABELS "transferbench;validation"
+        FIXTURES_SETUP transferbench_available
+        SKIP_REGULAR_EXPRESSION "Error: No valid transfers created"
+)
 
 rocprofiler_systems_add_test(
     SKIP_BASELINE SKIP_REWRITE SKIP_SAMPLING SKIP_RUNTIME
@@ -77,25 +75,31 @@ rocprofiler_systems_add_test(
     SYS_RUN_SKIP_REGEX "Error: No valid transfers created"
 )
 
-if(NOT skip_validation)
+# Make this test depend on the transferBench validation fixture
+if(TEST transferbench-sys-run)
+    set_tests_properties(
+        transferbench-sys-run
+        PROPERTIES FIXTURES_REQUIRED transferbench_available
+    )
+endif()
+
+# Add validation test to check for XGMI data transfers
+rocprofiler_systems_add_validation_test(
+    NAME transferbench-sys-run
+    PERFETTO_FILE "perfetto-trace.proto"
+    LABELS "transferbench;perfetto"
+    ARGS --counter-names "XGMI Read Data" "XGMI Write Data" -p
+)
+
+# Add ROCPD validation if enabled
+if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU})
+    set_property(TEST transferbench-sys-run APPEND PROPERTY LABELS rocpd)
+
     rocprofiler_systems_add_validation_test(
         NAME transferbench-sys-run
-        PERFETTO_FILE "perfetto-trace.proto"
-        LABELS "transferbench;perfetto"
-        ARGS --counter-names "XGMI Read Data" "XGMI Write Data" -p
+        ROCPD_FILE "rocpd.db"
+        LABELS "transferbench;rocpd"
+        ARGS --validation-rules
+            ${_gpu_connect_rocpd_validation_rules}
     )
-
-    if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU})
-        set_property(TEST transferbench-sys-run APPEND PROPERTY LABELS rocpd)
-
-        rocprofiler_systems_add_validation_test(
-            NAME transferbench-sys-run
-            ROCPD_FILE "rocpd.db"
-            LABELS "transferbench;rocpd"
-            ARGS --validation-rules
-                ${_gpu_connect_rocpd_validation_rules}
-        )
-    endif()
-else()
-    message(STATUS "TransferBench: No valid transfers created, skipping tests")
 endif()

--- a/projects/rocprofiler-systems/tests/rocprof-sys-ucx-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-ucx-tests.cmake
@@ -129,9 +129,10 @@ rocprofiler_systems_add_test(
 # Make this test depend on the UCX validation fixture
 foreach(_test_suffix sampling binary-rewrite binary-rewrite-run sys-run)
     if(TEST ucx-perfetto-${_test_suffix})
-        set_tests_properties(
-            ucx-perfetto-${_test_suffix}
-            PROPERTIES FIXTURES_REQUIRED ucx_available
+        set_property(
+            TEST ucx-perfetto-${_test_suffix}
+            APPEND
+            PROPERTY FIXTURES_REQUIRED ucx_available
         )
     endif()
 endforeach()
@@ -215,9 +216,10 @@ rocprofiler_systems_add_test(
 # Make this test depend on the UCX validation fixture
 foreach(_test_suffix sampling binary-rewrite binary-rewrite-run sys-run)
     if(TEST ucx-mpip-integration-${_test_suffix})
-        set_tests_properties(
-            ucx-mpip-integration-${_test_suffix}
-            PROPERTIES FIXTURES_REQUIRED ucx_available
+        set_property(
+            TEST ucx-mpip-integration-${_test_suffix}
+            APPEND
+            PROPERTY FIXTURES_REQUIRED ucx_available
         )
     endif()
 endforeach()
@@ -249,9 +251,10 @@ foreach(_MSG_SIZE 1024 4096 16384)
     # Make the test depend on the UCX validation fixture
     foreach(_test_suffix sampling binary-rewrite binary-rewrite-run sys-run)
         if(TEST ucx-bcast-${_MSG_SIZE}-${_test_suffix})
-            set_tests_properties(
-                ucx-bcast-${_MSG_SIZE}-${_test_suffix}
-                PROPERTIES FIXTURES_REQUIRED ucx_available
+            set_property(
+                TEST ucx-bcast-${_MSG_SIZE}-${_test_suffix}
+                APPEND
+                PROPERTY FIXTURES_REQUIRED ucx_available
             )
         endif()
     endforeach()
@@ -282,9 +285,10 @@ rocprofiler_systems_add_test(
 # Make this test depend on the UCX validation fixture
 foreach(_test_suffix sampling binary-rewrite binary-rewrite-run sys-run)
     if(TEST ucx-active-messages-${_test_suffix})
-        set_tests_properties(
-            ucx-active-messages-${_test_suffix}
-            PROPERTIES FIXTURES_REQUIRED ucx_available
+        set_property(
+            TEST ucx-active-messages-${_test_suffix}
+            APPEND
+            PROPERTY FIXTURES_REQUIRED ucx_available
         )
     endif()
 endforeach()

--- a/projects/rocprofiler-systems/tests/rocprof-sys-ucx-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-ucx-tests.cmake
@@ -58,6 +58,8 @@ set(_ucxp_mpi_environment
     "UCX_TLS=tcp,self" # Tell UCX to use TCP for inter-process, self for intra-process
     "OMPI_MCA_pml_base_verbose=100" # Show which PML is selected
     "UCX_LOG_LEVEL=info" # Enable UCX logging to show transport usage
+    "OMPI_ALLOW_RUN_AS_ROOT=1" # Allow running as root in CI environments
+    "OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1" # Confirm the choice to run as root
 )
 
 # Enhanced UCX environment with more detailed logging
@@ -85,7 +87,7 @@ add_test(
     NAME ucx-validation-check
     COMMAND
         ${CMAKE_COMMAND} -E env ${_ucxp_mpi_environment} ${MPIEXEC_EXECUTABLE}
-        ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:mpi-send-recv>
+        ${MPIEXEC_EXECUTABLE_ARGS} ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:mpi-send-recv>
 )
 
 # Set this test as a fixture that must pass for UCX tests to run

--- a/projects/rocprofiler-systems/tests/rocprof-sys-ucx-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-ucx-tests.cmake
@@ -79,7 +79,20 @@ if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU})
     list(APPEND _ucx_environment "ROCPROFSYS_USE_ROCPD=ON")
 endif()
 
-set(_UCX_PASS_REGEX "ucx_gotcha|category*ucx")
+set(_UCX_PASS_REGEX "ucx_gotcha|category::ucx")
+
+# Helper function to add fixture dependencies to UCX tests
+function(add_ucx_fixture_dependency TEST_BASE_NAME)
+    foreach(_test_suffix sampling binary-rewrite binary-rewrite-run sys-run)
+        if(TEST ${TEST_BASE_NAME}-${_test_suffix})
+            set_property(
+                TEST ${TEST_BASE_NAME}-${_test_suffix}
+                APPEND
+                PROPERTY FIXTURES_REQUIRED ucx_available
+            )
+        endif()
+    endforeach()
+endfunction()
 
 # Add a runtime validation test that checks if UCX is functional
 # This test runs before all other UCX tests and acts as a fixture
@@ -100,14 +113,14 @@ set_tests_properties(
             "PML ucx cannot be selected|UCX is not available|No UCX support found|Failed to select"
 )
 
-# UCX perfetto trace test
+# UCX trace test
 rocprofiler_systems_add_test(
     SKIP_BASELINE SKIP_RUNTIME SKIP_SAMPLING
-    NAME "ucx-perfetto"
+    NAME "ucx-send-recv"
     TARGET mpi-send-recv
     MPI ON
     NUM_PROCS 2
-    LABELS "ucx;perfetto"
+    LABELS "ucx;send-recv"
     REWRITE_ARGS
         -e
         -v
@@ -126,20 +139,12 @@ rocprofiler_systems_add_test(
         "${_UCX_PASS_REGEX}|Using UCX|pml.*ucx"
 )
 
-# Make this test depend on the UCX validation fixture
-foreach(_test_suffix sampling binary-rewrite binary-rewrite-run sys-run)
-    if(TEST ucx-perfetto-${_test_suffix})
-        set_property(
-            TEST ucx-perfetto-${_test_suffix}
-            APPEND
-            PROPERTY FIXTURES_REQUIRED ucx_available
-        )
-    endif()
-endforeach()
+# Add fixture dependency
+add_ucx_fixture_dependency(ucx-send-recv)
 
 # Validation test for UCX perfetto trace to ensure communication tracks are present
 rocprofiler_systems_add_validation_test(
-    NAME ucx-perfetto-sys-run
+    NAME ucx-send-recv-sys-run
     PERFETTO_METRIC "ucx"
     PERFETTO_FILE "merged.proto"
     LABELS "ucx;perfetto"
@@ -147,17 +152,17 @@ rocprofiler_systems_add_validation_test(
 )
 
 # Validation test for UCX rocpd output
-if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU} AND TEST ucx-perfetto-sys-run)
-    set_property(TEST ucx-perfetto-sys-run APPEND PROPERTY LABELS rocpd)
+if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU} AND TEST ucx-send-recv-sys-run)
+    set_property(TEST ucx-send-recv-sys-run APPEND PROPERTY LABELS rocpd)
 
     # For MPI tests, ROCPD creates separate DB files for each rank with PID suffix (rocpd-<pid>.db)
     # Create a setup test that finds and symlinks one of them to a predictable name
     set(UCX_ROCPD_OUTPUT_DIR
-        "${PROJECT_BINARY_DIR}/rocprof-sys-tests-output/ucx-perfetto-sys-run"
+        "${PROJECT_BINARY_DIR}/rocprof-sys-tests-output/ucx-send-recv-sys-run"
     )
 
     add_test(
-        NAME ucx-perfetto-sys-run-rocpd-setup
+        NAME ucx-send-recv-sys-run-rocpd-setup
         COMMAND
             ${CMAKE_COMMAND} -E env bash -c
             "ROCPD_DB=$(ls ${UCX_ROCPD_OUTPUT_DIR}/rocpd-*.db 2>/dev/null | head -1) && ln -sf $(basename \"$ROCPD_DB\") ${UCX_ROCPD_OUTPUT_DIR}/rocpd.db"
@@ -165,25 +170,33 @@ if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU} AND TEST ucx-perfetto-sys-run)
     )
 
     set_tests_properties(
-        ucx-perfetto-sys-run-rocpd-setup
-        PROPERTIES LABELS "ucx;rocpd;setup" DEPENDS ucx-perfetto-sys-run
+        ucx-send-recv-sys-run-rocpd-setup
+        PROPERTIES
+            LABELS "ucx;rocpd;setup"
+            DEPENDS ucx-send-recv-sys-run
+            FIXTURES_REQUIRED ucx_available
     )
 
     # Standard validation test - now it can use the predictable symlink name
     rocprofiler_systems_add_validation_test(
-        NAME ucx-perfetto-sys-run
+        NAME ucx-send-recv-sys-run
         ROCPD_FILE "rocpd.db"
         LABELS "ucx;rocpd"
         ARGS --validation-rules
             "${CMAKE_CURRENT_LIST_DIR}/rocpd-validation-rules/ucx/validation-rules.json"
     )
 
-    # Make validation depend on the setup test
-    if(TEST validate-ucx-perfetto-sys-run-rocpd)
+    # Make validation depend on the setup test and UCX fixture
+    if(TEST validate-ucx-send-recv-sys-run-rocpd)
         set_property(
-            TEST validate-ucx-perfetto-sys-run-rocpd
+            TEST validate-ucx-send-recv-sys-run-rocpd
             APPEND
-            PROPERTY DEPENDS ucx-perfetto-sys-run-rocpd-setup
+            PROPERTY DEPENDS ucx-send-recv-sys-run-rocpd-setup
+        )
+        set_property(
+            TEST validate-ucx-send-recv-sys-run-rocpd
+            APPEND
+            PROPERTY FIXTURES_REQUIRED ucx_available
         )
     endif()
 endif()
@@ -213,16 +226,8 @@ rocprofiler_systems_add_test(
     SAMPLING_PASS_REGEX "${_UCX_PASS_REGEX}"
 )
 
-# Make this test depend on the UCX validation fixture
-foreach(_test_suffix sampling binary-rewrite binary-rewrite-run sys-run)
-    if(TEST ucx-mpip-integration-${_test_suffix})
-        set_property(
-            TEST ucx-mpip-integration-${_test_suffix}
-            APPEND
-            PROPERTY FIXTURES_REQUIRED ucx_available
-        )
-    endif()
-endforeach()
+# Add fixture dependency
+add_ucx_fixture_dependency(ucx-mpip-integration)
 
 # UCX with different message sizes
 foreach(_MSG_SIZE 1024 4096 16384)
@@ -248,16 +253,8 @@ foreach(_MSG_SIZE 1024 4096 16384)
         SAMPLING_PASS_REGEX "${_UCX_PASS_REGEX}"
     )
 
-    # Make the test depend on the UCX validation fixture
-    foreach(_test_suffix sampling binary-rewrite binary-rewrite-run sys-run)
-        if(TEST ucx-bcast-${_MSG_SIZE}-${_test_suffix})
-            set_property(
-                TEST ucx-bcast-${_MSG_SIZE}-${_test_suffix}
-                APPEND
-                PROPERTY FIXTURES_REQUIRED ucx_available
-            )
-        endif()
-    endforeach()
+    # Add fixture dependency
+    add_ucx_fixture_dependency(ucx-bcast-${_MSG_SIZE})
 endforeach()
 
 # Test UCX active message functionality
@@ -282,13 +279,5 @@ rocprofiler_systems_add_test(
     REWRITE_RUN_PASS_REGEX "${_UCX_PASS_REGEX}"
 )
 
-# Make this test depend on the UCX validation fixture
-foreach(_test_suffix sampling binary-rewrite binary-rewrite-run sys-run)
-    if(TEST ucx-active-messages-${_test_suffix})
-        set_property(
-            TEST ucx-active-messages-${_test_suffix}
-            APPEND
-            PROPERTY FIXTURES_REQUIRED ucx_available
-        )
-    endif()
-endforeach()
+# Add fixture dependency
+add_ucx_fixture_dependency(ucx-active-messages)

--- a/projects/rocprofiler-systems/tests/rocprof-sys-ucx-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-ucx-tests.cmake
@@ -42,7 +42,7 @@ endif()
 # Only proceed if OpenMPI is detected
 if(NOT "${_DETECTED_MPI_IMPL}" STREQUAL "openmpi")
     message(
-        STATUS
+        WARNING
         "Skipping UCX tests - requires OpenMPI (detected: ${_DETECTED_MPI_IMPL}). UCX tests use OpenMPI-specific environment variables (OMPI_MCA_*)."
     )
     return()
@@ -60,27 +60,15 @@ set(_ucxp_mpi_environment
     "UCX_LOG_LEVEL=info" # Enable UCX logging to show transport usage
 )
 
-# Base environment for UCX tests
-set(_ucx_base_environment
-    "${_base_environment}"
-    "ROCPROFSYS_USE_UCX=ON"
-    "ROCPROFSYS_DEBUG=OFF"
-    "ROCPROFSYS_VERBOSE=2"
-    "ROCPROFSYS_DL_VERBOSE=2"
-    "${_ucxp_mpi_environment}"
-)
-
 # Enhanced UCX environment with more detailed logging
 set(_ucx_environment
     "${_base_environment}"
     "ROCPROFSYS_USE_UCX=ON"
-    "ROCPROFSYS_DEBUG=ON"
     "ROCPROFSYS_VERBOSE=3"
     "ROCPROFSYS_DL_VERBOSE=3"
     "ROCPROFSYS_PERFETTO_BACKEND=inprocess"
     "ROCPROFSYS_PERFETTO_FILL_POLICY=ring_buffer"
     "ROCPROFSYS_USE_PID=OFF"
-    "ROCPROFSYS_MPI_INIT=OFF"
     "${_ucxp_mpi_environment}"
 )
 
@@ -89,46 +77,32 @@ if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU})
     list(APPEND _ucx_environment "ROCPROFSYS_USE_ROCPD=ON")
 endif()
 
-# Check if UCX is functional by running mpi-example without rocprof-sys
-set(skip_validation FALSE)
+set(_UCX_PASS_REGEX "ucx_gotcha|category*ucx")
 
-if(EXISTS "${PROJECT_BINARY_DIR}/mpi-example")
-    # Set up UCX environment for the baseline test
-    set(_ucx_test_env_list)
-    foreach(_env_var ${_ucxp_mpi_environment})
-        list(APPEND _ucx_test_env_list "${_env_var}")
-    endforeach()
+# Add a runtime validation test that checks if UCX is functional
+# This test runs before all other UCX tests and acts as a fixture
+add_test(
+    NAME ucx-validation-check
+    COMMAND
+        ${CMAKE_COMMAND} -E env ${_ucxp_mpi_environment} ${MPIEXEC_EXECUTABLE}
+        ${MPIEXEC_NUMPROC_FLAG} 2 $<TARGET_FILE:mpi-send-recv>
+)
 
-    execute_process(
-        COMMAND
-            ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
-            ${PROJECT_BINARY_DIR}/mpi-example
-        OUTPUT_VARIABLE _ucx_output
-        ERROR_VARIABLE _ucx_output
-        RESULT_VARIABLE _ucx_result
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_STRIP_TRAILING_WHITESPACE
-        ENVIRONMENT
-        ${_ucx_test_env_list}
-    )
-
-    # Check for error patterns indicating UCX is not available
-    if(
-        _ucx_output
-            MATCHES
+# Set this test as a fixture that must pass for UCX tests to run
+set_tests_properties(
+    ucx-validation-check
+    PROPERTIES
+        LABELS "ucx;validation"
+        FIXTURES_SETUP ucx_available
+        FAIL_REGULAR_EXPRESSION
             "PML ucx cannot be selected|UCX is not available|No UCX support found|Failed to select"
-    )
-        set(skip_validation TRUE)
-    endif()
-else()
-    set(skip_validation TRUE)
-endif()
+)
 
 # UCX perfetto trace test
 rocprofiler_systems_add_test(
-    SKIP_RUNTIME
+    SKIP_BASELINE SKIP_RUNTIME SKIP_SAMPLING
     NAME "ucx-perfetto"
-    TARGET mpi-example
+    TARGET mpi-send-recv
     MPI ON
     NUM_PROCS 2
     LABELS "ucx;perfetto"
@@ -141,71 +115,79 @@ rocprofiler_systems_add_test(
         line
         --min-instructions
         0
-    ENVIRONMENT "${_ucx_environment};ROCPROFSYS_VERBOSE=1;ROCPROFSYS_TRACE_LEGACY=ON;ROCPROFSYS_PERFETTO_COMBINE_TRACES=ON"
+    ENVIRONMENT "${_ucx_environment};ROCPROFSYS_TRACE_LEGACY=ON;ROCPROFSYS_PERFETTO_COMBINE_TRACES=ON"
     REWRITE_RUN_PASS_REGEX
-        "Successfully executed: .+rocprof-sys-merge-output.sh.*"
+        "${_UCX_PASS_REGEX}|Successfully executed: .+rocprof-sys-merge-output.sh.*"
     REWRITE_RUN_FAIL_REGEX
         "Script not found|Failed to execute|ROCPROFSYS_ABORT_FAIL_REGEX"
     SYS_RUN_PASS_REGEX
-        "ucp_tag_send|ucp_tag_recv|UCX.*configured|Using UCX|pml.*ucx"
+        "${_UCX_PASS_REGEX}|Using UCX|pml.*ucx"
 )
 
-if(NOT skip_validation)
-    # Validation test for UCX perfetto trace to ensure communication tracks are present
-    rocprofiler_systems_add_validation_test(
-        NAME ucx-perfetto-sys-run
-        PERFETTO_METRIC "ucx"
-        PERFETTO_FILE "merged.proto"
-        LABELS "ucx;perfetto"
-        ARGS --counter-names "UCX Comm Recv" "UCX Comm Send" -p
-    )
-else()
-    message(
-        STATUS
-        "UCX: UCX is not available or cannot be selected, skipping validation tests"
-    )
-endif()
-
-# Test all MPI example binaries with UCX transport
-foreach(
-    _UCX_EXAMPLE
-    all2all
-    allgather
-    allreduce
-    scatter-gather
-    send-recv
-)
-    rocprofiler_systems_add_test(
-        SKIP_BASELINE SKIP_RUNTIME SKIP_SAMPLING
-        NAME "ucx-${_UCX_EXAMPLE}"
-        TARGET mpi-${_UCX_EXAMPLE}
-        MPI ON
-        NUM_PROCS 2
-        LABELS "ucx"
-        REWRITE_ARGS -e -v 2 --label file line --min-instructions 0
-        RUN_ARGS 30
-    ENVIRONMENT "${_ucx_environment};ROCPROFSYS_VERBOSE=1;ROCPROFSYS_TRACE_LEGACY=ON;ROCPROFSYS_PERFETTO_COMBINE_TRACES=ON"
-    REWRITE_RUN_PASS_REGEX
-        "UCX.*trace|ucp_.*trace|Category.*ucx|UCX function.*called"
-    SYS_RUN_PASS_REGEX
-        "ucp_tag_send|ucp_tag_recv|write_perfetto_counter_track.*ucx"
-    )
-
-    if(NOT skip_validation)
-        # Add validation test to check for UCX communication tracks and bytes
-        rocprofiler_systems_add_validation_test(
-            NAME ucx-${_UCX_EXAMPLE}-sys-run
-            PERFETTO_METRIC "ucx"
-            PERFETTO_FILE "merged.proto"
-            LABELS "ucx"
-            ARGS --counter-names "UCX Comm Recv" "UCX Comm Send" -p
+# Make this test depend on the UCX validation fixture
+foreach(_test_suffix sampling binary-rewrite binary-rewrite-run sys-run)
+    if(TEST ucx-perfetto-${_test_suffix})
+        set_tests_properties(
+            ucx-perfetto-${_test_suffix}
+            PROPERTIES FIXTURES_REQUIRED ucx_available
         )
     endif()
 endforeach()
 
+# Validation test for UCX perfetto trace to ensure communication tracks are present
+rocprofiler_systems_add_validation_test(
+    NAME ucx-perfetto-sys-run
+    PERFETTO_METRIC "ucx"
+    PERFETTO_FILE "merged.proto"
+    LABELS "ucx;perfetto"
+    ARGS --counter-names "UCX Comm Recv" "UCX Comm Send" -p
+)
+
+# Validation test for UCX rocpd output
+if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU} AND TEST ucx-perfetto-sys-run)
+    set_property(TEST ucx-perfetto-sys-run APPEND PROPERTY LABELS rocpd)
+
+    # For MPI tests, ROCPD creates separate DB files for each rank with PID suffix (rocpd-<pid>.db)
+    # Create a setup test that finds and symlinks one of them to a predictable name
+    set(UCX_ROCPD_OUTPUT_DIR
+        "${PROJECT_BINARY_DIR}/rocprof-sys-tests-output/ucx-perfetto-sys-run"
+    )
+
+    add_test(
+        NAME ucx-perfetto-sys-run-rocpd-setup
+        COMMAND
+            ${CMAKE_COMMAND} -E env bash -c
+            "ROCPD_DB=$(ls ${UCX_ROCPD_OUTPUT_DIR}/rocpd-*.db 2>/dev/null | head -1) && ln -sf $(basename \"$ROCPD_DB\") ${UCX_ROCPD_OUTPUT_DIR}/rocpd.db"
+        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    )
+
+    set_tests_properties(
+        ucx-perfetto-sys-run-rocpd-setup
+        PROPERTIES LABELS "ucx;rocpd;setup" DEPENDS ucx-perfetto-sys-run
+    )
+
+    # Standard validation test - now it can use the predictable symlink name
+    rocprofiler_systems_add_validation_test(
+        NAME ucx-perfetto-sys-run
+        ROCPD_FILE "rocpd.db"
+        LABELS "ucx;rocpd"
+        ARGS --validation-rules
+            "${CMAKE_CURRENT_LIST_DIR}/rocpd-validation-rules/ucx/validation-rules.json"
+    )
+
+    # Make validation depend on the setup test
+    if(TEST validate-ucx-perfetto-sys-run-rocpd)
+        set_property(
+            TEST validate-ucx-perfetto-sys-run-rocpd
+            APPEND
+            PROPERTY DEPENDS ucx-perfetto-sys-run-rocpd-setup
+        )
+    endif()
+endif()
+
 # UCX with MPIP integration test
 rocprofiler_systems_add_test(
-    SKIP_RUNTIME
+    SKIP_BASELINE SKIP_RUNTIME
     NAME "ucx-mpip-integration"
     TARGET mpi-all2all
     MPI ON
@@ -224,9 +206,19 @@ rocprofiler_systems_add_test(
     ENVIRONMENT
         "${_ucx_environment};ROCPROFSYS_USE_MPIP=ON"
     RUN_ARGS 30
-    REWRITE_RUN_PASS_REGEX
-        "UCX.*trace.*MPI.*trace|ucp_.*MPI_|Category.*ucx.*Category.*mpi"
+    REWRITE_RUN_PASS_REGEX "${_UCX_PASS_REGEX}"
+    SAMPLING_PASS_REGEX "${_UCX_PASS_REGEX}"
 )
+
+# Make this test depend on the UCX validation fixture
+foreach(_test_suffix sampling binary-rewrite binary-rewrite-run sys-run)
+    if(TEST ucx-mpip-integration-${_test_suffix})
+        set_tests_properties(
+            ucx-mpip-integration-${_test_suffix}
+            PROPERTIES FIXTURES_REQUIRED ucx_available
+        )
+    endif()
+endforeach()
 
 # UCX with different message sizes
 foreach(_MSG_SIZE 1024 4096 16384)
@@ -248,14 +240,24 @@ foreach(_MSG_SIZE 1024 4096 16384)
             0
         ENVIRONMENT "${_ucx_environment}"
         RUN_ARGS ${_MSG_SIZE}
-        REWRITE_RUN_PASS_REGEX
-            "UCX.*trace|ucp_.*send|ucp_.*recv|Category.*ucx"
+        REWRITE_RUN_PASS_REGEX "${_UCX_PASS_REGEX}"
+        SAMPLING_PASS_REGEX "${_UCX_PASS_REGEX}"
     )
+
+    # Make the test depend on the UCX validation fixture
+    foreach(_test_suffix sampling binary-rewrite binary-rewrite-run sys-run)
+        if(TEST ucx-bcast-${_MSG_SIZE}-${_test_suffix})
+            set_tests_properties(
+                ucx-bcast-${_MSG_SIZE}-${_test_suffix}
+                PROPERTIES FIXTURES_REQUIRED ucx_available
+            )
+        endif()
+    endforeach()
 endforeach()
 
 # Test UCX active message functionality
 rocprofiler_systems_add_test(
-    SKIP_BASELINE SKIP_RUNTIME
+    SKIP_BASELINE SKIP_RUNTIME SKIP_SAMPLING
     NAME "ucx-active-messages"
     TARGET mpi-allreduce
     MPI ON
@@ -272,25 +274,15 @@ rocprofiler_systems_add_test(
         0
     ENVIRONMENT "${_ucx_environment};OMPI_MCA_btl=^vader,tcp,openib,uct"
     RUN_ARGS 64
-    REWRITE_RUN_PASS_REGEX
-        "ucp_am_send|ucp_am_recv|uct_ep_am|Active.*Message"
+    REWRITE_RUN_PASS_REGEX "${_UCX_PASS_REGEX}"
 )
 
-# -------------------------------------------------------------------------------------- #
-#
-# ROCpd tests for UCX
-#
-# -------------------------------------------------------------------------------------- #
-
-if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU} AND TEST ucx-perfetto-sys-run)
-    set_property(TEST ucx-perfetto-sys-run APPEND PROPERTY LABELS rocpd)
-
-    rocprofiler_systems_add_validation_test(
-        NAME ucx-perfetto-sys-run
-        ROCPD_FILE "rocpd.db"
-        ARGS --validation-rules
-        "${CMAKE_CURRENT_LIST_DIR}/rocpd-validation-rules/ucx/validation-rules.json"
-        "${CMAKE_CURRENT_LIST_DIR}/rocpd-validation-rules/default-rules.json"
-        LABELS "rocpd"
-    )
-endif()
+# Make this test depend on the UCX validation fixture
+foreach(_test_suffix sampling binary-rewrite binary-rewrite-run sys-run)
+    if(TEST ucx-active-messages-${_test_suffix})
+        set_tests_properties(
+            ucx-active-messages-${_test_suffix}
+            PROPERTIES FIXTURES_REQUIRED ucx_available
+        )
+    endif()
+endforeach()

--- a/projects/rocprofiler-systems/tests/rocprof-sys-ucx-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-ucx-tests.cmake
@@ -70,35 +70,6 @@ set(_ucx_base_environment
     "${_ucxp_mpi_environment}"
 )
 
-# First test: UCX availability check using mpi-example (basic test)
-# This test checks if UCX is available. If not, subsequent UCX tests will be marked as skipped.
-rocprofiler_systems_add_test(
-    SKIP_BASELINE SKIP_RUNTIME SKIP_REWRITE SKIP_SYS_RUN
-    NAME "ucx-availability-check"
-    TARGET mpi-example
-    MPI ON
-    NUM_PROCS 2
-    LABELS "ucx;availability"
-    REWRITE_ARGS
-        -e
-        -v
-        2
-        --label
-        file
-        line
-        return
-        args
-        --min-instructions
-        0
-    ENVIRONMENT "${_ucx_base_environment};ROCPROFSYS_VERBOSE=1"
-    REWRITE_RUN_PASS_REGEX
-        "UCX.*configured|ucp_|uct_|UCX transport|pml.*ucx"
-    REWRITE_RUN_FAIL_REGEX
-        "PML ucx cannot be selected|UCX is not available|No UCX support found|Failed to select|ROCPROFSYS_ABORT_FAIL_REGEX"
-    REWRITE_RUN_SKIP_REGEX
-        "PML ucx cannot be selected|UCX is not available|No UCX support found|Failed to select"
-)
-
 # Enhanced UCX environment with more detailed logging
 set(_ucx_environment
     "${_base_environment}"
@@ -113,12 +84,45 @@ set(_ucx_environment
     "${_ucxp_mpi_environment}"
 )
 
-# Debug environment - extra verbose for troubleshooting CI issues
-set(_ucx_debug_environment
-    "${_ucx_environment}"
-    "UCX_LOG_LEVEL=debug" # Maximum UCX logging
-    "OMPI_MCA_mpi_show_mca_params=all" # Show all MCA parameters
-)
+# Enable ROCPD for UCX tests if valid ROCm is installed and a valid GPU is detected
+if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU})
+    list(APPEND _ucx_environment "ROCPROFSYS_USE_ROCPD=ON")
+endif()
+
+# Check if UCX is functional by running mpi-example without rocprof-sys
+set(skip_validation FALSE)
+
+if(EXISTS "${PROJECT_BINARY_DIR}/mpi-example")
+    # Set up UCX environment for the baseline test
+    set(_ucx_test_env_list)
+    foreach(_env_var ${_ucxp_mpi_environment})
+        list(APPEND _ucx_test_env_list "${_env_var}")
+    endforeach()
+
+    execute_process(
+        COMMAND
+            ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
+            ${PROJECT_BINARY_DIR}/mpi-example
+        OUTPUT_VARIABLE _ucx_output
+        ERROR_VARIABLE _ucx_output
+        RESULT_VARIABLE _ucx_result
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_STRIP_TRAILING_WHITESPACE
+        ENVIRONMENT
+        ${_ucx_test_env_list}
+    )
+
+    # Check for error patterns indicating UCX is not available
+    if(
+        _ucx_output
+            MATCHES
+            "PML ucx cannot be selected|UCX is not available|No UCX support found|Failed to select"
+    )
+        set(skip_validation TRUE)
+    endif()
+else()
+    set(skip_validation TRUE)
+endif()
 
 # UCX perfetto trace test
 rocprofiler_systems_add_test(
@@ -146,14 +150,21 @@ rocprofiler_systems_add_test(
         "ucp_tag_send|ucp_tag_recv|UCX.*configured|Using UCX|pml.*ucx"
 )
 
-# Validation test for UCX perfetto trace to ensure communication tracks are present
-rocprofiler_systems_add_validation_test(
-    NAME ucx-perfetto-sys-run
-    PERFETTO_METRIC "ucx"
-    PERFETTO_FILE "merged.proto"
-    LABELS "ucx;perfetto"
-    ARGS --counter-names "UCX Comm Recv" "UCX Comm Send" -p
-)
+if(NOT skip_validation)
+    # Validation test for UCX perfetto trace to ensure communication tracks are present
+    rocprofiler_systems_add_validation_test(
+        NAME ucx-perfetto-sys-run
+        PERFETTO_METRIC "ucx"
+        PERFETTO_FILE "merged.proto"
+        LABELS "ucx;perfetto"
+        ARGS --counter-names "UCX Comm Recv" "UCX Comm Send" -p
+    )
+else()
+    message(
+        STATUS
+        "UCX: UCX is not available or cannot be selected, skipping validation tests"
+    )
+endif()
 
 # Test all MPI example binaries with UCX transport
 foreach(
@@ -180,14 +191,16 @@ foreach(
         "ucp_tag_send|ucp_tag_recv|write_perfetto_counter_track.*ucx"
     )
 
-    # Add validation test to check for UCX communication tracks and bytes
-    rocprofiler_systems_add_validation_test(
-        NAME ucx-${_UCX_EXAMPLE}-sys-run
-        PERFETTO_METRIC "ucx"
-        PERFETTO_FILE "merged.proto"
-        LABELS "ucx"
-        ARGS --counter-names "UCX Comm Recv" "UCX Comm Send" -p
-    )
+    if(NOT skip_validation)
+        # Add validation test to check for UCX communication tracks and bytes
+        rocprofiler_systems_add_validation_test(
+            NAME ucx-${_UCX_EXAMPLE}-sys-run
+            PERFETTO_METRIC "ucx"
+            PERFETTO_FILE "merged.proto"
+            LABELS "ucx"
+            ARGS --counter-names "UCX Comm Recv" "UCX Comm Send" -p
+        )
+    endif()
 endforeach()
 
 # UCX with MPIP integration test
@@ -262,3 +275,22 @@ rocprofiler_systems_add_test(
     REWRITE_RUN_PASS_REGEX
         "ucp_am_send|ucp_am_recv|uct_ep_am|Active.*Message"
 )
+
+# -------------------------------------------------------------------------------------- #
+#
+# ROCpd tests for UCX
+#
+# -------------------------------------------------------------------------------------- #
+
+if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU} AND TEST ucx-perfetto-sys-run)
+    set_property(TEST ucx-perfetto-sys-run APPEND PROPERTY LABELS rocpd)
+
+    rocprofiler_systems_add_validation_test(
+        NAME ucx-perfetto-sys-run
+        ROCPD_FILE "rocpd.db"
+        ARGS --validation-rules
+        "${CMAKE_CURRENT_LIST_DIR}/rocpd-validation-rules/ucx/validation-rules.json"
+        "${CMAKE_CURRENT_LIST_DIR}/rocpd-validation-rules/default-rules.json"
+        LABELS "rocpd"
+    )
+endif()


### PR DESCRIPTION
## Motivation

With MPI headers only build, rocpd output does not have UCX Comm Send and UCX Comm Recv tracks and the insert fails with 
```
[insert_sample][warning] Insert sample failed! Error: Unexisting track UCX Comm Recv!
```
When full MPI is not enabled, `comm_data` tracks were not getting created for UCX.

## Technical Details

The fix ensures that `comm_data` start function is called which creates the required tracks for capturing UCX Send and Recv bytes.
Add rocpd validation tests.
Modify existing ctest to do UCX availability validation more efficiently.

## JIRA ID

AIPROFSYST-176

## Test Plan

Tested the automated ctest for UCX

## Test Result

The tests now capture the rocpd output and verifies the data in the output.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
