### PR TITLE
SWDEV-531829 - Add implementation of cooperative_groups::reduce API

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
@@ -37,6 +37,8 @@ THE SOFTWARE.
 #include <hip/amd_detail/hip_cooperative_groups_helper.h>
 #endif
 
+#include <type_traits>
+#include <cstddef>
 namespace cooperative_groups {
 
 /** \brief The base type of all cooperative group types.
@@ -1362,6 +1364,7 @@ __CG_QUALIFIER__ auto reduce(const TyGroup& group, TyVal&& val, TyFn&& op) -> de
   using Val = std::decay_t<TyVal>;
   static_assert(is_op_type_same<TyVal, decltype(op(val, val))>::value, "Operator input and output types differ");
 
+  // TODO g-h-c check that all the threads in tile and only those the tile are active
   // we cannot simply use the __activemask() here, because more than one tile could have active
   // threads at a time
   unsigned long long mask = ~0ull >> (64 - group.num_threads());

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
@@ -1372,23 +1372,11 @@ __CG_QUALIFIER__ auto reduce(const TyGroup& group, TyVal&& val, TyFn&& op) -> de
 
   if constexpr (__hip_internal::is_same<Op, cooperative_groups::plus<Val>>::value) {
     return __reduce_add_sync(mask, val);
-  }
-  else if constexpr (__hip_internal::is_same<Op, cooperative_groups::bit_and<Val>>::value) {
-    return __reduce_and_sync(mask, val);
-  }
-  else if constexpr (__hip_internal::is_same<Op, cooperative_groups::bit_or<Val>>::value) {
-    return __reduce_or_sync(mask, val);
-  }
-  else if constexpr (__hip_internal::is_same<Op, cooperative_groups::less<Val>>::value) {
+  } else if constexpr (__hip_internal::is_same<Op, cooperative_groups::less<Val>>::value) {
     return __reduce_min_sync(mask, val);
-  }
-  else if constexpr (__hip_internal::is_same<Op, cooperative_groups::greater<Val>>::value) {
+  } else if constexpr (__hip_internal::is_same<Op, cooperative_groups::greater<Val>>::value) {
     return __reduce_max_sync(mask, val);
-  }
-  else if constexpr (__hip_internal::is_same<Op, cooperative_groups::bit_xor<Val>>::value) {
-    return __reduce_xor_sync(mask, val);
-  }
-  else {
+  } else {
     return __reduce_op_sync(mask, val, op, nullptr);
   }
 }

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
@@ -1308,65 +1308,77 @@ template <typename TyLhs, typename TyRhs>
 using is_op_type_same = __hip_internal::is_same<remove_qual<TyLhs>, remove_qual<TyRhs>
 >;
 
-// Retrieve mask of coalesced groups and tiles
-template <typename TyGroup>
-__CG_STATIC_QUALIFIER__ unsigned int get_mask(const TyGroup &group) {
-    return group.get_mask();
-}
-
 template <class T>
-struct MinOp {
-  T operator()(const T& lhs, const T& rhs) const
+struct plus {
+  __CG_QUALIFIER__ T operator()(const T& lhs, const T& rhs) const
   {
-    return std::min(lhs, rhs);
+    return lhs + rhs;
   }
 };
 
 template <class T>
-struct MaxOp {
-  T operator()(const T& lhs, const T& rhs) const
+struct less {
+  __CG_QUALIFIER__ T operator()(const T& lhs, const T& rhs) const
   {
-    return std::max(lhs, rhs);
+    return lhs < rhs? lhs : rhs;
   }
 };
 
 template <class T>
-struct XorOp {
-  __host__ __device__ T operator()(const T& lhs, const T& rhs)
+struct greater {
+  __CG_QUALIFIER__ T operator()(const T& lhs, const T& rhs) const
   {
-    return (!lhs) != (!rhs) == 1;
+    return lhs < rhs? rhs : lhs;
+  }
+};
+
+template <class T>
+struct bit_and {
+  __CG_QUALIFIER__ T operator()(const T& lhs, const T& rhs) const
+  {
+    return lhs | rhs;
+  }
+};
+
+template <class T>
+struct bit_xor {
+  __CG_QUALIFIER__ T operator()(const T& lhs, const T& rhs) const
+  {
+    return lhs ^ rhs;
+  }
+};
+
+template <class T>
+struct bit_or {
+  __CG_QUALIFIER__ T operator()(const T& lhs, const T& rhs) const
+  {
+    return lhs | rhs;
   }
 };
 
 template <typename TyGroup, typename TyVal, typename TyFn>
 __CG_QUALIFIER__ auto reduce(const TyGroup& group, TyVal&& val, TyFn&& op) -> decltype(op(val, val)) {
-  static_assert(is_op_type_same<TyVal, decltype(op(val, val))>::value, "Operator input and output types differ");
-
-  if constexpr (!std::is_same<TyGroup, cooperative_groups::tiled_group>::value &&
-                !std::is_same<TyGroup, cooperative_groups::coalesced_group>::value) {
-    static_assert(std::is_void<TyGroup>::value, "This group does not exclusively represent a tile");
-  }
-  unsigned mask = get_mask(group);
-
   using Op  = std::decay_t<TyFn>;
   using Val = std::decay_t<TyVal>;
+  static_assert(is_op_type_same<TyVal, decltype(op(val, val))>::value, "Operator input and output types differ");
+  lane_mask mask = __activemask();
 
-  if constexpr (std::is_same<Op, std::plus<Val>>::value) {
+  if constexpr (std::is_same<Op, cooperative_groups::plus<Val>>::value) {
     return __reduce_add_sync(mask, val);
   }
-  else if constexpr (std::is_same<Op, std::logical_and<Val>>::value) {
+  else if constexpr (std::is_same<Op, cooperative_groups::bit_and<Val>>::value) {
     return __reduce_and_sync(mask, val);
   }
-  else if constexpr (std::is_same<Op, std::logical_or<Val>>::value) {
+  else if constexpr (std::is_same<Op, cooperative_groups::bit_or<Val>>::value) {
     return __reduce_or_sync(mask, val);
   }
-  else if constexpr (std::is_same<Op, MinOp<Val>>::value) {
+  else if constexpr (std::is_same<Op, cooperative_groups::less<Val>>::value) {
     return __reduce_min_sync(mask, val);
   }
-  else if constexpr (std::is_same<Op, MaxOp<Val>>::value) {
+  else if constexpr (std::is_same<Op, cooperative_groups::greater<Val>>::value) {
     return __reduce_max_sync(mask, val);
   }
-  else if constexpr (std::is_same<Op, XorOp<Val>>::value) {
+  else if constexpr (std::is_same<Op, cooperative_groups::bit_xor<Val>>::value) {
     return __reduce_xor_sync(mask, val);
   }
   else {

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
@@ -1366,10 +1366,14 @@ __CG_QUALIFIER__ auto reduce(const TyGroup& group, TyVal&& val, TyFn&& op) -> de
 
   // we cannot simply use the __activemask() here, because more than one tile could have active
   // threads at a time
-  unsigned long long mask = ~0ull >> (64 - group.num_threads());
-  mask <<= (((threadIdx.x % warpSize) / group.num_threads()) * group.num_threads());
+  unsigned long long mask = ~0ull;
 
-  // is is legal for some threads in a tile to not participate
+  if constexpr (!std::is_same<TyGroup, cooperative_groups::coalesced_group>::value) {
+    mask >>= (64 - group.num_threads());
+    mask <<= (((threadIdx.x % warpSize) / group.num_threads()) * group.num_threads());
+  }
+
+  // it is legal for some threads in a tile to not participate
   mask &= __activemask();
 
   if constexpr (__hip_internal::is_same<Op, cooperative_groups::plus<Val>>::value) {

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
@@ -1356,6 +1356,47 @@ namespace impl {
   template <typename T, typename U>
   using is_param_type_same = __hip_internal::is_same<typename __hip_internal::remove_cvref<T>,
                                                      typename __hip_internal::remove_cvref<U>>;
+
+  // we can call reduce() only the block tiles that have a compile-time size
+  template <class TyGroup>
+  struct isTiledGroup : std::false_type {
+  };
+
+  template <>
+  struct isTiledGroup<cooperative_groups::thread_block_tile<1, cooperative_groups::thread_block>> : std::true_type {
+  };
+
+  template <>
+  struct isTiledGroup<cooperative_groups::thread_block_tile<2, cooperative_groups::thread_block>> : std::true_type {
+  };
+
+  template <>
+  struct isTiledGroup<cooperative_groups::thread_block_tile<4, cooperative_groups::thread_block>> : std::true_type {
+  };
+
+  template <>
+  struct isTiledGroup<cooperative_groups::thread_block_tile<8, cooperative_groups::thread_block>> : std::true_type {
+  };
+
+  template <>
+  struct isTiledGroup<cooperative_groups::thread_block_tile<16, cooperative_groups::thread_block>> : std::true_type {
+  };
+
+  template <>
+  struct isTiledGroup<cooperative_groups::thread_block_tile<32, cooperative_groups::thread_block>> : std::true_type {
+  };
+
+  template <>
+  struct isTiledGroup<cooperative_groups::thread_block_tile<64, cooperative_groups::thread_block>> : std::true_type {
+  };
+
+  template <class TyGroup>
+  struct isCoalescedGroup : std::false_type {
+  };
+
+  template <>
+  struct isCoalescedGroup<cooperative_groups::coalesced_group> : std::true_type {
+  };
 }
 
 template <typename TyGroup, typename TyVal, typename TyFn>
@@ -1363,6 +1404,10 @@ __CG_QUALIFIER__ auto reduce(const TyGroup& group, TyVal&& val, TyFn&& op) -> de
   using Op = typename __hip_internal::remove_cvref<TyFn>::type;
   using Val = typename __hip_internal::remove_cvref<TyVal>::type;
   static_assert(impl::is_param_type_same<Val, decltype(op(val, val))>::value, "Operator input and output types differ");
+
+  if constexpr (!impl::isTiledGroup<TyGroup>::value && !impl::isCoalescedGroup<TyGroup>::value) {
+    static_assert(std::is_void<TyGroup>::value, "This group does not exclusively represent a tile");
+  }
 
   // we cannot simply use the __activemask() here, because more than one tile could have active
   // threads at a time
@@ -1373,7 +1418,9 @@ __CG_QUALIFIER__ auto reduce(const TyGroup& group, TyVal&& val, TyFn&& op) -> de
     mask <<= (((threadIdx.x % warpSize) / group.num_threads()) * group.num_threads());
   }
 
-  // it is legal for some threads in a tile to not participate
+  // for coalesced_groups, the mask is simply the activemask
+  // for tiled groups, it is legal for some threads in a tile to not participate so we also
+  // need to apply the active mask
   mask &= __activemask();
 
   if constexpr (__hip_internal::is_same<Op, cooperative_groups::plus<Val>>::value) {

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
@@ -37,8 +37,10 @@ THE SOFTWARE.
 #include <hip/amd_detail/hip_cooperative_groups_helper.h>
 #endif
 
+#if !defined(__HIPCC_RTC__)
 #include <type_traits>
-#include <cstddef>
+#endif
+
 namespace cooperative_groups {
 
 /** \brief The base type of all cooperative group types.
@@ -1302,14 +1304,6 @@ __CG_QUALIFIER__ coalesced_group binary_partition(const thread_block_tile<size, 
   }
 }
 
-// Non-STL utility templates
-template <typename Ty>
-using remove_qual = typename __hip_internal::remove_cv<typename std::remove_reference<Ty>::type>::type;
-
-template <typename TyLhs, typename TyRhs>
-using is_op_type_same = __hip_internal::is_same<remove_qual<TyLhs>, remove_qual<TyRhs>
->;
-
 template <class T>
 struct plus {
   __CG_QUALIFIER__ T operator()(const T& lhs, const T& rhs) const
@@ -1358,11 +1352,17 @@ struct bit_or {
   }
 };
 
+namespace impl {
+  template <typename T, typename U>
+  using is_param_type_same = __hip_internal::is_same<typename __hip_internal::remove_cvref<T>,
+                                                     typename __hip_internal::remove_cvref<U>>;
+}
+
 template <typename TyGroup, typename TyVal, typename TyFn>
 __CG_QUALIFIER__ auto reduce(const TyGroup& group, TyVal&& val, TyFn&& op) -> decltype(op(val, val)) {
-  using Op  = std::decay_t<TyFn>;
-  using Val = std::decay_t<TyVal>;
-  static_assert(is_op_type_same<TyVal, decltype(op(val, val))>::value, "Operator input and output types differ");
+  using Op = typename __hip_internal::remove_cvref<TyFn>::type;
+  using Val = typename __hip_internal::remove_cvref<TyVal>::type;
+  static_assert(impl::is_param_type_same<Val, decltype(op(val, val))>::value, "Operator input and output types differ");
 
   // TODO g-h-c check that all the threads in tile and only those the tile are active
   // we cannot simply use the __activemask() here, because more than one tile could have active
@@ -1370,22 +1370,22 @@ __CG_QUALIFIER__ auto reduce(const TyGroup& group, TyVal&& val, TyFn&& op) -> de
   unsigned long long mask = ~0ull >> (64 - group.num_threads());
   mask <<= (((threadIdx.x % warpSize) / group.num_threads()) * group.num_threads());
 
-  if constexpr (std::is_same<Op, cooperative_groups::plus<Val>>::value) {
+  if constexpr (__hip_internal::is_same<Op, cooperative_groups::plus<Val>>::value) {
     return __reduce_add_sync(mask, val);
   }
-  else if constexpr (std::is_same<Op, cooperative_groups::bit_and<Val>>::value) {
+  else if constexpr (__hip_internal::is_same<Op, cooperative_groups::bit_and<Val>>::value) {
     return __reduce_and_sync(mask, val);
   }
-  else if constexpr (std::is_same<Op, cooperative_groups::bit_or<Val>>::value) {
+  else if constexpr (__hip_internal::is_same<Op, cooperative_groups::bit_or<Val>>::value) {
     return __reduce_or_sync(mask, val);
   }
-  else if constexpr (std::is_same<Op, cooperative_groups::less<Val>>::value) {
+  else if constexpr (__hip_internal::is_same<Op, cooperative_groups::less<Val>>::value) {
     return __reduce_min_sync(mask, val);
   }
-  else if constexpr (std::is_same<Op, cooperative_groups::greater<Val>>::value) {
+  else if constexpr (__hip_internal::is_same<Op, cooperative_groups::greater<Val>>::value) {
     return __reduce_max_sync(mask, val);
   }
-  else if constexpr (std::is_same<Op, cooperative_groups::bit_xor<Val>>::value) {
+  else if constexpr (__hip_internal::is_same<Op, cooperative_groups::bit_xor<Val>>::value) {
     return __reduce_xor_sync(mask, val);
   }
   else {

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
@@ -1306,7 +1306,7 @@ __CG_QUALIFIER__ coalesced_group binary_partition(const thread_block_tile<size, 
 
 template <class T>
 struct plus {
-  __CG_QUALIFIER__ T operator()(const T& lhs, const T& rhs) const
+  __CG_QUALIFIER__ T operator()(T lhs, T rhs) const
   {
     return lhs + rhs;
   }
@@ -1314,7 +1314,7 @@ struct plus {
 
 template <class T>
 struct less {
-  __CG_QUALIFIER__ T operator()(const T& lhs, const T& rhs) const
+  __CG_QUALIFIER__ T operator()(T lhs, T rhs) const
   {
     return lhs < rhs? lhs : rhs;
   }
@@ -1322,7 +1322,7 @@ struct less {
 
 template <class T>
 struct greater {
-  __CG_QUALIFIER__ T operator()(const T& lhs, const T& rhs) const
+  __CG_QUALIFIER__ T operator()(T lhs, T rhs) const
   {
     return lhs < rhs? rhs : lhs;
   }
@@ -1330,7 +1330,7 @@ struct greater {
 
 template <class T>
 struct bit_and {
-  __CG_QUALIFIER__ T operator()(const T& lhs, const T& rhs) const
+  __CG_QUALIFIER__ T operator()(T lhs, T rhs) const
   {
     return lhs & rhs;
   }
@@ -1338,7 +1338,7 @@ struct bit_and {
 
 template <class T>
 struct bit_xor {
-  __CG_QUALIFIER__ T operator()(const T& lhs, const T& rhs) const
+  __CG_QUALIFIER__ T operator()(T lhs, T rhs) const
   {
     return lhs ^ rhs;
   }
@@ -1346,7 +1346,7 @@ struct bit_xor {
 
 template <class T>
 struct bit_or {
-  __CG_QUALIFIER__ T operator()(const T& lhs, const T& rhs) const
+  __CG_QUALIFIER__ T operator()(T lhs, T rhs) const
   {
     return lhs | rhs;
   }

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
@@ -114,6 +114,10 @@ class thread_group {
    *           be avoided with synchronization of the group.
    */
   __CG_QUALIFIER__ void sync() const;
+  //! Returns the mask of the group.
+  __CG_QUALIFIER__ unsigned int get_mask() const {
+    return (coalesced_info.member_mask);
+  }
 };
 /**
  *  @defgroup CooperativeG Cooperative Groups
@@ -1297,6 +1301,80 @@ __CG_QUALIFIER__ coalesced_group binary_partition(const thread_block_tile<size, 
     return coalesced_group(mask);
   } else {
     return coalesced_group(tgrp.build_mask() ^ mask);
+  }
+}
+
+// Non-STL utility templates
+template <typename Ty>
+using remove_qual = typename __hip_internal::remove_cv<typename std::remove_reference<Ty>::type>::type;
+
+template <typename TyLhs, typename TyRhs>
+using is_op_type_same = __hip_internal::is_same<remove_qual<TyLhs>, remove_qual<TyRhs>
+>;
+
+// Retrieve mask of coalesced groups and tiles
+template <typename TyGroup>
+__CG_STATIC_QUALIFIER__ unsigned int get_mask(const TyGroup &group) {
+    return group.get_mask();
+}
+
+template <class T>
+struct MinOp {
+  T operator()(const T& lhs, const T& rhs) const
+  {
+    return std::min(lhs, rhs);
+  }
+};
+
+template <class T>
+struct MaxOp {
+  T operator()(const T& lhs, const T& rhs) const
+  {
+    return std::max(lhs, rhs);
+  }
+};
+
+template <class T>
+struct XorOp {
+  __host__ __device__ T operator()(const T& lhs, const T& rhs)
+  {
+    return (!lhs) != (!rhs) == 1;
+  }
+};
+
+template <typename TyGroup, typename TyVal, typename TyFn>
+__CG_QUALIFIER__ auto reduce(const TyGroup& group, TyVal&& val, TyFn&& op) -> decltype(op(val, val)) {
+  static_assert(is_op_type_same<TyVal, decltype(op(val, val))>::value, "Operator input and output types differ");
+
+  if constexpr (!std::is_same<TyGroup, cooperative_groups::tiled_group>::value &&
+                !std::is_same<TyGroup, cooperative_groups::coalesced_group>::value) {
+    static_assert(std::is_void<TyGroup>::value, "This group does not exclusively represent a tile");
+  }
+  unsigned mask = get_mask(group);
+
+  using Op  = std::decay_t<TyFn>;
+  using Val = std::decay_t<TyVal>;
+
+  if constexpr (std::is_same<Op, std::plus<Val>>::value) {
+    return __reduce_add_sync(mask, val);
+  }
+  else if constexpr (std::is_same<Op, std::logical_and<Val>>::value) {
+    return __reduce_and_sync(mask, val);
+  }
+  else if constexpr (std::is_same<Op, std::logical_or<Val>>::value) {
+    return __reduce_or_sync(mask, val);
+  }
+  else if constexpr (std::is_same<Op, MinOp<Val>>::value) {
+    return __reduce_min_sync(mask, val);
+  }
+  else if constexpr (std::is_same<Op, MaxOp<Val>>::value) {
+    return __reduce_max_sync(mask, val);
+  }
+  else if constexpr (std::is_same<Op, XorOp<Val>>::value) {
+    return __reduce_xor_sync(mask, val);
+  }
+  else {
+    return __reduce_op_sync(mask, val, op, nullptr);
   }
 }
 #endif

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
@@ -114,10 +114,6 @@ class thread_group {
    *           be avoided with synchronization of the group.
    */
   __CG_QUALIFIER__ void sync() const;
-  //! Returns the mask of the group.
-  __CG_QUALIFIER__ unsigned int get_mask() const {
-    return (coalesced_info.member_mask);
-  }
 };
 /**
  *  @defgroup CooperativeG Cooperative Groups

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
@@ -1364,11 +1364,13 @@ __CG_QUALIFIER__ auto reduce(const TyGroup& group, TyVal&& val, TyFn&& op) -> de
   using Val = typename __hip_internal::remove_cvref<TyVal>::type;
   static_assert(impl::is_param_type_same<Val, decltype(op(val, val))>::value, "Operator input and output types differ");
 
-  // TODO g-h-c check that all the threads in tile and only those the tile are active
   // we cannot simply use the __activemask() here, because more than one tile could have active
   // threads at a time
   unsigned long long mask = ~0ull >> (64 - group.num_threads());
   mask <<= (((threadIdx.x % warpSize) / group.num_threads()) * group.num_threads());
+
+  // is is legal for some threads in a tile to not participate
+  mask &= __activemask();
 
   if constexpr (__hip_internal::is_same<Op, cooperative_groups::plus<Val>>::value) {
     return __reduce_add_sync(mask, val);

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
@@ -1359,43 +1359,43 @@ namespace impl {
 
   // we can call reduce() only the block tiles that have a compile-time size
   template <class TyGroup>
-  struct isTiledGroup : std::false_type {
+  struct isTiledGroup : __hip_internal::false_type {
   };
 
   template <>
-  struct isTiledGroup<cooperative_groups::thread_block_tile<1, cooperative_groups::thread_block>> : std::true_type {
+  struct isTiledGroup<cooperative_groups::thread_block_tile<1, cooperative_groups::thread_block>> : __hip_internal::true_type {
   };
 
   template <>
-  struct isTiledGroup<cooperative_groups::thread_block_tile<2, cooperative_groups::thread_block>> : std::true_type {
+  struct isTiledGroup<cooperative_groups::thread_block_tile<2, cooperative_groups::thread_block>> : __hip_internal::true_type {
   };
 
   template <>
-  struct isTiledGroup<cooperative_groups::thread_block_tile<4, cooperative_groups::thread_block>> : std::true_type {
+  struct isTiledGroup<cooperative_groups::thread_block_tile<4, cooperative_groups::thread_block>> : __hip_internal::true_type {
   };
 
   template <>
-  struct isTiledGroup<cooperative_groups::thread_block_tile<8, cooperative_groups::thread_block>> : std::true_type {
+  struct isTiledGroup<cooperative_groups::thread_block_tile<8, cooperative_groups::thread_block>> : __hip_internal::true_type {
   };
 
   template <>
-  struct isTiledGroup<cooperative_groups::thread_block_tile<16, cooperative_groups::thread_block>> : std::true_type {
+  struct isTiledGroup<cooperative_groups::thread_block_tile<16, cooperative_groups::thread_block>> : __hip_internal::true_type {
   };
 
   template <>
-  struct isTiledGroup<cooperative_groups::thread_block_tile<32, cooperative_groups::thread_block>> : std::true_type {
+  struct isTiledGroup<cooperative_groups::thread_block_tile<32, cooperative_groups::thread_block>> : __hip_internal::true_type {
   };
 
   template <>
-  struct isTiledGroup<cooperative_groups::thread_block_tile<64, cooperative_groups::thread_block>> : std::true_type {
+  struct isTiledGroup<cooperative_groups::thread_block_tile<64, cooperative_groups::thread_block>> : __hip_internal::true_type {
   };
 
   template <class TyGroup>
-  struct isCoalescedGroup : std::false_type {
+  struct isCoalescedGroup : __hip_internal::false_type {
   };
 
   template <>
-  struct isCoalescedGroup<cooperative_groups::coalesced_group> : std::true_type {
+  struct isCoalescedGroup<cooperative_groups::coalesced_group> : __hip_internal::true_type {
   };
 }
 
@@ -1406,14 +1406,14 @@ __CG_QUALIFIER__ auto reduce(const TyGroup& group, TyVal&& val, TyFn&& op) -> de
   static_assert(impl::is_param_type_same<Val, decltype(op(val, val))>::value, "Operator input and output types differ");
 
   if constexpr (!impl::isTiledGroup<TyGroup>::value && !impl::isCoalescedGroup<TyGroup>::value) {
-    static_assert(std::is_void<TyGroup>::value, "This group does not exclusively represent a tile");
+    static_assert(__hip_internal::is_void<TyGroup>::value, "This group does not exclusively represent a tile");
   }
 
   // we cannot simply use the __activemask() here, because more than one tile could have active
   // threads at a time
   unsigned long long mask = ~0ull;
 
-  if constexpr (!std::is_same<TyGroup, cooperative_groups::coalesced_group>::value) {
+  if constexpr (!__hip_internal::is_same<TyGroup, cooperative_groups::coalesced_group>::value) {
     mask >>= (64 - group.num_threads());
     mask <<= (((threadIdx.x % warpSize) / group.num_threads()) * group.num_threads());
   }

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
@@ -1332,7 +1332,7 @@ template <class T>
 struct bit_and {
   __CG_QUALIFIER__ T operator()(const T& lhs, const T& rhs) const
   {
-    return lhs | rhs;
+    return lhs & rhs;
   }
 };
 

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
@@ -1376,6 +1376,12 @@ __CG_QUALIFIER__ auto reduce(const TyGroup& group, TyVal&& val, TyFn&& op) -> de
     return __reduce_min_sync(mask, val);
   } else if constexpr (__hip_internal::is_same<Op, cooperative_groups::greater<Val>>::value) {
     return __reduce_max_sync(mask, val);
+  } else if constexpr (__hip_internal::is_same<Op, cooperative_groups::bit_and<Val>>::value) {
+    return __reduce_and_sync(mask, val);
+  } else if constexpr (__hip_internal::is_same<Op, cooperative_groups::bit_or<Val>>::value) {
+    return __reduce_or_sync(mask, val);
+  } else if constexpr (__hip_internal::is_same<Op, cooperative_groups::bit_xor<Val>>::value) {
+    return __reduce_xor_sync(mask, val);
   } else {
     return __reduce_op_sync(mask, val, op, nullptr);
   }

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h
@@ -1361,7 +1361,11 @@ __CG_QUALIFIER__ auto reduce(const TyGroup& group, TyVal&& val, TyFn&& op) -> de
   using Op  = std::decay_t<TyFn>;
   using Val = std::decay_t<TyVal>;
   static_assert(is_op_type_same<TyVal, decltype(op(val, val))>::value, "Operator input and output types differ");
-  lane_mask mask = __activemask();
+
+  // we cannot simply use the __activemask() here, because more than one tile could have active
+  // threads at a time
+  unsigned long long mask = ~0ull >> (64 - group.num_threads());
+  mask <<= (((threadIdx.x % warpSize) / group.num_threads()) * group.num_threads());
 
   if constexpr (std::is_same<Op, cooperative_groups::plus<Val>>::value) {
     return __reduce_add_sync(mask, val);

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
@@ -357,10 +357,12 @@ __device__ inline T __reduce_op_sync(MaskT mask, T val, BinaryOp op, WfReduce wf
 
 #ifdef __OPTIMIZE__  // at the time of this writing the ockl wfred functions do not compile when
                      // using -O0
-  if (maskNumBits == lastLane + 1)
-    // this means the mask "does not have holes", and starts from 0; we can use a specific intrinsic
-    // to calculate the aggregated result
-    return wfReduce(val);
+  if constexpr (!std::is_same<WfReduce, std::nullptr_t>::value){
+    if (maskNumBits == lastLane + 1)
+      // this means the mask "does not have holes", and starts from 0; we can use a specific intrinsic
+      // to calculate the aggregated result
+      return wfReduce(val);
+  }
 #endif
 
   firstLane = __builtin_ctzll(mask);

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
@@ -459,7 +459,7 @@ __device__ inline T __reduce_op_sync(MaskT mask, T val, BinaryOp op, WfReduce wf
 
 template <typename MaskT> __device__ inline int __reduce_add_sync(MaskT mask, int val) {
   // although C++ has std::plus and other functors, we do not use them because
-  // they are in the header <functional> and they were causing problem with hipRTC
+  // they are in the header <functional> and they were causing problems with hipRTC
   // at this time
   auto op = [](decltype(val)& a, decltype(val)& b) { return a + b; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_add_i32(v); };

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
@@ -357,7 +357,7 @@ __device__ inline T __reduce_op_sync(MaskT mask, T val, BinaryOp op, WfReduce wf
 
 #ifdef __OPTIMIZE__  // at the time of this writing the ockl wfred functions do not compile when
                      // using -O0
-  if constexpr (!std::is_same<WfReduce, std::nullptr_t>::value){
+  if constexpr (!__hip_internal::is_same<WfReduce, decltype(nullptr)>::value){
     if (maskNumBits == lastLane + 1)
       // this means the mask "does not have holes", and starts from 0; we can use a specific intrinsic
       // to calculate the aggregated result

--- a/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
@@ -157,6 +157,24 @@ template <class T> struct remove_cv<const volatile T> {
   typedef T type;
 };
 
+template <typename T>
+struct remove_reference
+{ using type = T; };
+
+template <typename T>
+struct remove_reference<T&>
+{ using type = T; };
+
+template <typename T>
+struct remove_reference<T&&>
+{ using type = T; };
+
+template <typename T>
+struct remove_cvref {
+  using type = typename remove_cv<typename remove_reference<T>::type>::type;
+};
+
+
 template <class T> struct is_void : public is_same<void, typename remove_cv<T>::type> {};
 
 template <class From, class To> struct is_convertible

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -38,7 +38,9 @@ const unsigned long long Every5thBit = 0x1084210842108421;
 const unsigned long long Every9thBit = 0x8040201008040201;
 const unsigned long long Every5thBut9th = Every5thBit & ~Every9thBit;
 const unsigned long long AllThreads = ~0;
-static constexpr int kNumReduces = 5000;
+// number of warps to reduce. Both when testing warp intrinsics and cooperative groups
+// must be a multiple of warpSize
+static constexpr int kNumReduces = 156 * 32;
 
 inline __device__ bool deactivate_thread(const uint64_t* const active_masks) {
   const auto warp =
@@ -559,7 +561,8 @@ void runTestReduce(int iteration, Reduce reduce)
   HIP_CHECK(hipMemcpy(output.ptr(), d_output.ptr(), d_output.size_bytes(), hipMemcpyDeviceToHost));
 
   while (numReduce < kNumReduces) {
-    T expected = calculateExpected<T>(input.ptr(), op, masks.ptr()[numReduce]);
+    T* waveInput = &input.ptr()[numReduce * wavefrontSize];
+    T expected = calculateExpected<T>(waveInput, op, masks.ptr()[numReduce]);
     int lane = 0;
 
     while (lane < wavefrontSize) {
@@ -574,12 +577,12 @@ void runTestReduce(int iteration, Reduce reduce)
             REQUIRE(__half2float(result) == __half2float(expected));
           else {
             if (result != expected) {
-              printMismatch(result, expected, input.ptr(), mask);
+              printMismatch(result, expected, waveInput, mask);
               REQUIRE(result == expected);
             }
           }
         } else
-          compareFloatingPoint(result, expected, mask, input.ptr());
+          compareFloatingPoint(result, expected, mask, waveInput);
 
       }
       lane++;

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -271,21 +271,33 @@ const char* typeToString()
   return "";
 }
 
-template<class T, template <typename> class Op>
+template<class T, class Op>
 const char* opToString()
 {
-  if constexpr (std::is_same<Op<T>, std::plus<T>>::value)
+  if constexpr (std::is_same<Op, std::plus<T>>::value)
     return "add";
-  else if constexpr (std::is_same<Op<T>, MinOp<T>>::value)
+  else if constexpr (std::is_same<Op, MinOp<T>>::value)
     return "min";
-  else if constexpr (std::is_same<Op<T>, MaxOp<T>>::value)
+  else if constexpr (std::is_same<Op, MaxOp<T>>::value)
     return "max";
-  else if constexpr (std::is_same<Op<T>, AndOp<T>>::value)
+  else if constexpr (std::is_same<Op, AndOp<T>>::value)
     return "logical_and";
-  else if constexpr (std::is_same<Op<T>, OrOp<T>>::value)
+  else if constexpr (std::is_same<Op, OrOp<T>>::value)
     return "logical_or";
-  else if constexpr (std::is_same<Op<T>, XorOp<T>>::value)
+  else if constexpr (std::is_same<Op, XorOp<T>>::value)
     return "logical_xor";
+  else if constexpr (std::is_same<Op, cooperative_groups::plus<T>>::value)
+    return "cooperative_groups::plus";
+  else if constexpr (std::is_same<Op, cooperative_groups::less<T>>::value)
+    return "cooperative_groups::less";
+  else if constexpr (std::is_same<Op, cooperative_groups::greater<T>>::value)
+    return "cooperative_groups::greater";
+  else if constexpr (std::is_same<Op, cooperative_groups::bit_and<T>>::value)
+    return "cooperative_groups::bit_and";
+  else if constexpr (std::is_same<Op, cooperative_groups::bit_or<T>>::value)
+    return "cooperative_groups::bit_or";
+  else if constexpr (std::is_same<Op, cooperative_groups::bit_xor<T>>::value)
+    return "cooperative_groups::bit_xor";
   else {
     static_assert(std::is_void<T>::value, "Unsupported operator");
     return "";

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -249,6 +249,14 @@ struct OrOp {
   }
 };
 
+template <class T>
+struct MaxOfAbsolute {
+  int __host__ __device__ operator()(T i, T j)
+  {
+    return std::max(std::abs(i), std::abs(j));
+  }
+};
+
 // typeid(T).name() does seem to return a very descriptive name for primitive types,
 // at least on clang, so we roll out an equivalent
 template<class T>
@@ -300,9 +308,10 @@ const char* opToString()
     return "cooperative_groups::bit_or";
   else if constexpr (std::is_same<Op, cooperative_groups::bit_xor<T>>::value)
     return "cooperative_groups::bit_xor";
+  else if constexpr (std::is_same<Op, MaxOfAbsolute<T>>::value)
+    return "MaxOfAbsolute";
   else {
-    static_assert(std::is_void<T>::value, "Unsupported operator");
-    return "";
+    return "unknown operator";
   }
 }
 
@@ -393,7 +402,7 @@ void genRandomBuffers(LinearAllocGuard<T>& d_buf,
 // given an operation produces the expected result of the warp-wide reduction
 // @mask indicates the lanes that will participate in the computation
 template <class T, class Op>
-T calculateExpected(const T* input, Op op, unsigned long long mask)
+T calculateExpected(const T* input, Op&& op, unsigned long long mask)
 {
   T result;
   int wavefrontSize = getWarpSize();

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -402,7 +402,7 @@ void genRandomBuffers(LinearAllocGuard<T>& d_buf,
 // given an operation produces the expected result of the warp-wide reduction
 // @mask indicates the lanes that will participate in the computation
 template <class T, class Op>
-T calculateExpected(const T* input, Op&& op, unsigned long long mask)
+T calculateExpected(const T* input, Op& op, unsigned long long mask)
 {
   T result;
   int wavefrontSize = getWarpSize();

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -386,7 +386,7 @@ T calculateExpected(const T* input, Op op, unsigned long long mask)
   T result;
   int wavefrontSize = getWarpSize();
 
-  if (std::is_same<Op, std::plus<T>>::value) {
+  if constexpr (std::is_same<Op, std::plus<T>>::value || std::is_same<Op, cooperative_groups::plus<T>>::value) {
     T tmp[64] = { 0 };
 
     for (int i = 0; i < wavefrontSize; i++) {

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -329,7 +329,7 @@ void genRandomMasks(LinearAllocGuard<T>& d_buf,
     if (i % 5 == 0) {
       // every five masks, create a mask that starts in position zero and has "no holes",
       // because those take a different code path, where DPP instructions are used
-      mask = 1 << distNoHoles(gen);
+      mask = 1ull << distNoHoles(gen);
       mask--;
     } else {
       mask = dist(gen);

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -404,6 +404,21 @@ T calculateExpected(const T* input, Op op, unsigned long long mask)
       }
     }
     result = tmp[0];
+  } else if constexpr (std::is_same<Op, cooperative_groups::less<T>>::value) {
+    MinOp<T> minOp;
+    return calculateExpected(input, minOp, mask);
+  } else if constexpr (std::is_same<Op, cooperative_groups::greater<T>>::value) {
+    MaxOp<T> maxOp;
+    return calculateExpected(input, maxOp, mask);
+  } else if constexpr (std::is_same<Op, cooperative_groups::bit_xor<T>>::value) {
+    std::bit_xor<T> xorOp;
+    return calculateExpected(input, xorOp, mask);
+  } else if constexpr (std::is_same<Op, cooperative_groups::bit_or<T>>::value) {
+    std::bit_or<T> orOp;
+    return calculateExpected(input, orOp, mask);
+  } else if constexpr (std::is_same<Op, cooperative_groups::bit_and<T>>::value) {
+    std::bit_and<T> andOp;
+    return calculateExpected(input, andOp, mask);
   } else {
     bool initialized = false;
 

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -247,6 +247,22 @@ struct OrOp {
   }
 };
 
+template <class T>
+struct AndOp {
+  __host__ __device__ T operator()(const T& lhs, const T& rhs)
+  {
+    return lhs == 1 && rhs == 1;
+  }
+};
+
+template <class T>
+struct OrOp {
+  __host__ __device__ T operator()(const T& lhs, const T& rhs)
+  {
+    return lhs == 1 || rhs == 1;
+  }
+};
+
 // typeid(T).name() does seem to return a very descriptive name for primitive types,
 // at least on clang, so we roll out an equivalent
 template<class T>

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -247,22 +247,6 @@ struct OrOp {
   }
 };
 
-template <class T>
-struct AndOp {
-  __host__ __device__ T operator()(const T& lhs, const T& rhs)
-  {
-    return lhs & rhs;
-  }
-};
-
-template <class T>
-struct OrOp {
-  __host__ __device__ T operator()(const T& lhs, const T& rhs)
-  {
-    return lhs | rhs;
-  }
-};
-
 // typeid(T).name() does seem to return a very descriptive name for primitive types,
 // at least on clang, so we roll out an equivalent
 template<class T>
@@ -394,7 +378,7 @@ void genRandomBuffers(LinearAllocGuard<T>& d_buf,
   HIP_CHECK(hipMemcpy(d_buf.ptr(), buf.ptr(), numBytes, hipMemcpyHostToDevice));
 }
 
-// given an operation produces the expected result of the reduction
+// given an operation produces the expected result of the warp-wide reduction
 // @mask indicates the lanes that will participate in the computation
 template <class T, class Op>
 T calculateExpected(const T* input, Op op, unsigned long long mask)

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -211,7 +211,7 @@ struct DistributionType<double> {
 
 template <class T>
 struct MinOp {
-  T operator()(const T& lhs, const T& rhs) const
+  T operator()(T lhs, T rhs) const
   {
     return std::min(lhs, rhs);
   }
@@ -219,7 +219,7 @@ struct MinOp {
 
 template <class T>
 struct MaxOp {
-  T operator()(const T& lhs, const T& rhs) const
+  T operator()(T lhs, T rhs) const
   {
     return std::max(lhs, rhs);
   }
@@ -227,7 +227,7 @@ struct MaxOp {
 
 template <class T>
 struct XorOp {
-  __host__ __device__ T operator()(const T& lhs, const T& rhs)
+  __host__ __device__ T operator()(T lhs, T rhs)
   {
     return lhs ^ rhs;
   }
@@ -235,7 +235,7 @@ struct XorOp {
 
 template <class T>
 struct AndOp {
-  __host__ __device__ T operator()(const T& lhs, const T& rhs)
+  __host__ __device__ T operator()(T lhs, T rhs)
   {
     return lhs & rhs;
   }
@@ -243,7 +243,7 @@ struct AndOp {
 
 template <class T>
 struct OrOp {
-  __host__ __device__ T operator()(const T& lhs, const T& rhs)
+  __host__ __device__ T operator()(T lhs, T rhs)
   {
     return lhs | rhs;
   }

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -313,7 +313,8 @@ void genRandomMasks(LinearAllocGuard<T>& d_buf,
                     int numItems)
 {
   // masks must be != 0, hence passing 1 as the 'a' distribution parameter
-  std::uniform_int_distribution<unsigned long long> dist(1);
+  int wavefrontSize = getWarpSize();
+  std::uniform_int_distribution<unsigned long long> dist(1, wavefrontSize == 64? ~0ull : (1ul << 32) - 1);
   std::uniform_int_distribution<unsigned long long> distNoHoles(1, getWarpSize() - 2);
   int numBytes = numItems * sizeof(T);
   LinearAllocGuard<T> tmp(LinearAllocs::malloc, numBytes);
@@ -332,9 +333,6 @@ void genRandomMasks(LinearAllocGuard<T>& d_buf,
       mask--;
     } else {
       mask = dist(gen);
-
-      if (getWarpSize() == 32)
-        mask &= 0xFFFFFFFF;
     }
 
     buf.ptr()[i] = mask;

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -251,7 +251,7 @@ template <class T>
 struct AndOp {
   __host__ __device__ T operator()(const T& lhs, const T& rhs)
   {
-    return lhs == 1 && rhs == 1;
+    return lhs & rhs;
   }
 };
 
@@ -259,7 +259,7 @@ template <class T>
 struct OrOp {
   __host__ __device__ T operator()(const T& lhs, const T& rhs)
   {
-    return lhs == 1 || rhs == 1;
+    return lhs | rhs;
   }
 };
 

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -40,7 +40,7 @@ const unsigned long long Every5thBut9th = Every5thBit & ~Every9thBit;
 const unsigned long long AllThreads = ~0;
 // number of warps to reduce. Both when testing warp intrinsics and cooperative groups
 // must be a multiple of warpSize
-static constexpr int kNumReduces = 156 * 32;
+static constexpr int kNumReduces = 78 * 32;
 
 inline __device__ bool deactivate_thread(const uint64_t* const active_masks) {
   const auto warp =

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -50,19 +50,19 @@ inline __device__ bool deactivate_thread(const uint64_t* const active_masks) {
   return !(active_masks[idx] & (static_cast<uint64_t>(1) << warp.thread_rank()));
 }
 
-inline std::mt19937& GetRandomGenerator() {
+inline std::mt19937& GetRandomGen() {
   static std::mt19937 mt(std::random_device{}());
   return mt;
 }
 
-template <typename T> inline T GenerateRandomInteger(const T min, const T max) {
+template <typename T> inline T GenRandomInteger(const T min, const T max) {
   std::uniform_int_distribution<T> dist(min, max);
-  return dist(GetRandomGenerator());
+  return dist(GetRandomGen());
 }
 
-template <typename T> inline T GenerateRandomReal(const T min, const T max) {
+template <typename T> inline T GenRandomReal(const T min, const T max) {
   std::uniform_real_distribution<T> dist(min, max);
-  return dist(GetRandomGenerator());
+  return dist(GetRandomGen());
 }
 
 inline int generate_width(int warp_size) {

--- a/projects/hip-tests/catch/performance/warpSync/warpSync.cc
+++ b/projects/hip-tests/catch/performance/warpSync/warpSync.cc
@@ -255,7 +255,7 @@ template <class T, template <typename> class Op> struct ReduceBenchmark {
                        high8BitsOn = halfBitsOn << (wavefrontSize - 8),
                        high4BitsOn = halfBitsOn << (wavefrontSize - 4), allButOne = -1 & ~1;
     const char* typeStr = typeToString<T>();
-    const char* opStr = opToString<T, Op>();
+    const char* opStr = opToString<T, Op<T>>();
     std::map<std::string, unsigned long long> masks;
     std::pair<std::string, unsigned long long> masksPairs[] = {
         {"full mask", fullMask},

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -742,7 +742,8 @@ void reduceForTypeAndOp()
       mask &= h_extraMasks.host_ptr()[numReduce];
 
       if ((1ull << laneId) & mask) {
-        expected = calculateExpected(input, Op {}, mask);
+        Op op {};
+        expected = calculateExpected(input, op, mask);
       }
 
       if constexpr (std::is_integral<T>::value) {

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -637,6 +637,19 @@ void __global__ reduceKernel(T* result, const T* input, unsigned long long* extr
   }
 }
 
+template <class Functor, class T>
+void __global__ reduceKernelCoalesced(T* result, const T* input, unsigned long long* extraMask)
+{
+  if ((1 << threadIdx.x) & *extraMask) {
+    auto coalesced = cg::coalesced_threads();
+
+    result[threadIdx.x] = cg::reduce(coalesced, input[threadIdx.x], Functor());
+  } else {
+    result[threadIdx.x] = 0;
+  }
+}
+
+// @TileSize the tile size or 0 when testing coalesced groups
 template <size_t TileSize, class Op, class T>
 void reduceForTypeAndOp()
 {
@@ -669,15 +682,17 @@ void reduceForTypeAndOp()
 
   std::array<void*, 4> devicePtrs = { d_result.ptr(), d_input.ptr(), d_extraMasks.ptr() };
   void* args[devicePtrs.size()];
+
   for (int i = 0; i < devicePtrs.size(); i++) {
     args[i] = &devicePtrs[i];
   }
-  status = hipLaunchCooperativeKernel((void*)reduceKernel<TileSize, Op, T>,
-                                       gridDim,
-                                       blockDim,
-                                       args,
-                                       0,
-                                       nullptr);
+
+  status = hipLaunchCooperativeKernel((void*)(TileSize == 0? reduceKernelCoalesced<Op, T> : reduceKernel<TileSize, Op, T>),
+                                      gridDim,
+                                      blockDim,
+                                      args,
+                                      0,
+                                      nullptr);
   HIP_CHECK(status);
   HIP_CHECK(hipDeviceSynchronize());
   HIP_CHECK(hipGetLastError());
@@ -685,10 +700,14 @@ void reduceForTypeAndOp()
                       h_result.size_bytes(), hipMemcpyDeviceToHost));
 
   for (int laneId = 0; laneId < wavefrontSize; laneId++) {
-    unsigned long long mask = ~0ull >> (64 - TileSize);
+    unsigned long long mask = ~0ull;
     T result = h_result.host_ptr()[laneId], expected = 0;
 
-    mask <<= ((laneId % wavefrontSize) / TileSize) * TileSize;
+    if (TileSize > 0) {
+      mask >>= (64 - TileSize);
+      mask <<= ((laneId % wavefrontSize) / TileSize) * TileSize;
+    }
+
     mask &= h_extraMasks.host_ptr()[0];
 
     if ((1 << laneId) & mask) {
@@ -723,10 +742,12 @@ void reduceCoopTiles(const std::index_sequence<TileSize, TileSizes...>)
   reduceCoopTiles<Op, T>(remainingTiles);
 }
 
-template <class Op, class T, int WarpSize>
+template <bool Coalesced, class Op, class T, int WarpSize>
 void runReduceRandomForType()
 {
-  if constexpr (WarpSize <= 32) {
+  if constexpr (Coalesced) {
+    reduceForTypeAndOp<0, Op, T>();
+  } else if constexpr (WarpSize <= 32) {
     std::index_sequence<1, 2, 4, 8, 16, 32> tileSizes;
     reduceCoopTiles<Op, T>(tileSizes);
   } else {
@@ -735,20 +756,18 @@ void runReduceRandomForType()
   }
 }
 
-template <class T, int WarpSize, class Op = void>
+template <bool Coalesced, class T, int WarpSize, class Op = void>
 void runReduceRandomForOps(const std::tuple<>)
 {
 }
 
-template <class T, int WarpSize, class Op, class... Ops>
+template <bool Coalesced, class T, int WarpSize, class Op, class... Ops>
 void runReduceRandomForOps(const std::tuple<Op, Ops...>)
 {
   const std::tuple<Ops...> remainingOps;
-  
 
-  
-  runReduceRandomForType<Op, T, WarpSize>();
-  runReduceRandomForOps<T, WarpSize>(remainingOps);
+  runReduceRandomForType<Coalesced, Op, T, WarpSize>();
+  runReduceRandomForOps<Coalesced, T, WarpSize>(remainingOps);
 }
 
 // for all the tile sizes and all input types, using random input values, calculates the reduce()
@@ -761,9 +780,9 @@ TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Reduce_Random_arithmetic", "", int, u
              cooperative_groups::greater<TestType>> types;
 
   if (getWarpSize() == 32) {
-    runReduceRandomForOps<TestType, 32>(types);
+    runReduceRandomForOps<false, TestType, 32>(types);
   } else {
-    runReduceRandomForOps<TestType, 64>(types);
+    runReduceRandomForOps<false, TestType, 64>(types);
   }
 }
 
@@ -775,9 +794,23 @@ TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Reduce_Random_boolean", "", int, unsi
              cooperative_groups::bit_xor<TestType>> types;
 
   if (getWarpSize() == 32) {
-    runReduceRandomForOps<TestType, 32>(types);
+    runReduceRandomForOps<false, TestType, 32>(types);
   } else {
-    runReduceRandomForOps<TestType, 64>(types);
+    runReduceRandomForOps<false, TestType, 64>(types);
+  }
+}
+
+TEMPLATE_TEST_CASE("Unit_Thread_Block_Coalesced_Reduce_arithmetic", "", int, unsigned int, long long,
+                   unsigned long long, float, half, double)
+{
+  std::tuple<cooperative_groups::plus<TestType>,
+             cooperative_groups::less<TestType>,
+             cooperative_groups::greater<TestType>> types;
+
+  if (getWarpSize() == 32) {
+    runReduceRandomForOps<true, TestType, 32>(types);
+  } else {
+    runReduceRandomForOps<true, TestType, 64>(types);
   }
 }
 

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -16,7 +16,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-
+#include "warp_common.hh"
 #include "cooperative_groups_common.hh"
 #include "cg_common_kernels.hh"
 #include <array>
@@ -600,7 +600,7 @@ void __global__ partialSum(int* result)
    cg::thread_block mygroup = cg::this_thread_block();
    auto mytile = cg::tiled_partition<32>(mygroup);
 
-  if (threadIdx.x % warpSize != warpSize - 1) {
+  if (threadIdx.x != warpSize - 1) {
      *result = cg::reduce(mytile, sum, cg::plus<int>());
   }
 }
@@ -620,7 +620,96 @@ TEST_CASE("Unit_Thread_Block_Tile_Reduce_Non_Participating_Threads")
   HIP_CHECK(hipGetLastError());
   HIP_CHECK(hipMemcpy(h_result.host_ptr(), d_result.ptr(),
                       h_result.size_bytes(), hipMemcpyDeviceToHost));
+  // because a thread did not participate; we get a partial sum
   REQUIRE(*h_result.host_ptr() == getWarpSize() - 1);
+}
+
+template <size_t TileSize, template <typename> class Functor, class T>
+void __global__ reduceKernel(T* result, const T* input, unsigned long long* extraMask)
+{
+  cg::thread_block mygroup = cg::this_thread_block();
+  auto mytile = cg::tiled_partition<TileSize>(mygroup);
+
+  if ((1 << threadIdx.x) & *extraMask) {
+    result[threadIdx.x] = cg::reduce(mytile, input[threadIdx.x], Functor<T>());
+  } else {
+    result[threadIdx.x] = 0;
+  }
+}
+
+// for all the tile sizes and all input types, using random input values, calculates the reduce()
+// values. Additionally, randomly make some threads not participate
+TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Reduce_Random", "", int, unsigned int, long long,
+                   unsigned long long, float, half, double)
+{
+  using distribution = typename DistributionType<TestType>::type;
+  static constexpr size_t tileSize = 32;
+  int wavefrontSize = getWarpSize();
+  int size_bytes = sizeof(TestType) * wavefrontSize;
+  LinearAllocGuard<TestType> h_result(LinearAllocs::malloc, size_bytes);
+  LinearAllocGuard<TestType> d_result(LinearAllocs::hipMalloc, size_bytes);
+  LinearAllocGuard<TestType> h_input(LinearAllocs::malloc, size_bytes);
+  LinearAllocGuard<TestType> d_input(LinearAllocs::hipMalloc, size_bytes);
+  LinearAllocGuard<unsigned long long> d_extraMasks(LinearAllocs::hipMalloc,
+                                                    sizeof(unsigned long long));
+  LinearAllocGuard<unsigned long long> h_extraMasks(LinearAllocs::malloc,
+                                                    sizeof(unsigned long long));
+  std::mt19937_64 gen(Catch::rngSeed());
+  dim3 gridDim = { 1 };
+  dim3 blockDim = { static_cast<unsigned short>(wavefrontSize) };
+  hipError_t status;
+  typename distribution::result_type a = std::is_same<TestType, half>::value? std::numeric_limits<unsigned short>::lowest() :
+                                         (std::is_signed<TestType>::value? -1023 : 0);
+  typename distribution::result_type b = std::is_same<TestType, half>::value? std::numeric_limits<unsigned short>::max() :
+                                         1023;
+  distribution distInput(a, b);
+  // TODO g-h-c
+  // __hip_internal::index_sequence<1, 2, 4, 8, 16, 32, 64> tileSizes;
+  genRandomBuffers(d_input, h_input, distInput, gen, wavefrontSize);
+  genRandomMasks(d_extraMasks,
+                 h_extraMasks,
+                 gen,
+                 1);
+
+  std::array<void*, 4> devicePtrs = { d_result.ptr(), d_input.ptr(), d_extraMasks.ptr() };
+  void* args[devicePtrs.size()];
+  for (int i = 0; i < devicePtrs.size(); i++) {
+    args[i] = &devicePtrs[i];
+  }
+  status = hipLaunchCooperativeKernel((void*)reduceKernel<tileSize, cooperative_groups::plus, TestType>,
+                                       gridDim,
+                                       blockDim,
+                                       args,
+                                       0,
+                                       nullptr);
+  HIP_CHECK(status);
+  HIP_CHECK(hipDeviceSynchronize());
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipMemcpy(h_result.host_ptr(), d_result.ptr(),
+                      h_result.size_bytes(), hipMemcpyDeviceToHost));
+
+  for (int laneId = 0; laneId < wavefrontSize; laneId++) {
+    unsigned long long mask = ~0ull >> (64 - tileSize);
+    TestType result = h_result.host_ptr()[laneId], expected = 0;
+
+    mask <<= ((laneId % wavefrontSize) / tileSize) * tileSize;
+    mask &= h_extraMasks.host_ptr()[0];
+
+    if ((1 << laneId) & mask) {
+      // TODO g-h-c try more operators
+      expected = calculateExpected(h_input.host_ptr(), cooperative_groups::plus<TestType> {}, mask);
+    }
+
+    if constexpr (std::is_integral<TestType>::value) {
+      // for integral types the result should match exactly
+      if (result != expected) {
+        printMismatch(result, expected, h_input.host_ptr(), mask);
+        REQUIRE(result == expected);
+      }
+    } else {
+      compareFloatingPoint(result, expected, mask, h_input.host_ptr());
+    }
+  }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -573,7 +573,7 @@ void testReduceForTileSize()
   void* devicePtr = d_result.ptr();
   void* args[] = { &devicePtr };
 
-  HIP_CHECK(hipLaunchCooperativeKernel((void*)simpleSum<TileSize>, gridDim, blockDim, args, 0, nullptr));
+  HIP_CHECK(hipLaunchCooperativeKernel(reinterpret_cast<void*>(simpleSum<TileSize>), gridDim, blockDim, args, 0, nullptr));
   HIP_CHECK(hipDeviceSynchronize());
   HIP_CHECK(hipGetLastError());
   HIP_CHECK(hipMemcpy(h_result.host_ptr(), d_result.ptr(),
@@ -594,11 +594,12 @@ TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Reduce_Basic", "", int)
   }
 }
 
+template <size_t TileSize>
 void __global__ partialSum(int* result)
 {
    int sum = 1;
    cg::thread_block mygroup = cg::this_thread_block();
-   auto mytile = cg::tiled_partition<32>(mygroup);
+   auto mytile = cg::tiled_partition<TileSize>(mygroup);
 
   if (threadIdx.x != warpSize - 1) {
      *result = cg::reduce(mytile, sum, cg::plus<int>());
@@ -614,8 +615,11 @@ TEST_CASE("Unit_Thread_Block_Tile_Reduce_Non_Participating_Threads")
   dim3 blockDim = { static_cast<unsigned short>(getWarpSize()) };
   void* devicePtr = d_result.ptr();
   void* args[] = { &devicePtr };
+  void* kernelPtr = reinterpret_cast<void*>(getWarpSize() == 32?
+                    partialSum<32> :
+                    partialSum<64>);
 
-  HIP_CHECK(hipLaunchCooperativeKernel((void*)partialSum, gridDim, blockDim, args, 0, nullptr));
+  HIP_CHECK(hipLaunchCooperativeKernel(kernelPtr, gridDim, blockDim, args, 0, nullptr));
   HIP_CHECK(hipDeviceSynchronize());
   HIP_CHECK(hipGetLastError());
   HIP_CHECK(hipMemcpy(h_result.host_ptr(), d_result.ptr(),
@@ -707,9 +711,9 @@ void reduceForTypeAndOp()
   }
 
   if constexpr (TileSize == 0) {
-    kernelPtr = (void*) reduceKernelCoalesced<Op, T>;
+    kernelPtr = reinterpret_cast<void*>(reduceKernelCoalesced<Op, T>);
   } else {
-    kernelPtr = (void*) reduceKernel<TileSize, Op, T>;
+    kernelPtr = reinterpret_cast<void*>(reduceKernel<TileSize, Op, T>);
   }
 
   status = hipLaunchCooperativeKernel(kernelPtr,

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -625,27 +625,44 @@ TEST_CASE("Unit_Thread_Block_Tile_Reduce_Non_Participating_Threads")
 }
 
 template <size_t TileSize, class Functor, class T>
-void __global__ reduceKernel(T* result, const T* input, unsigned long long* extraMask)
+void __global__ reduceKernel(T* output, const T* input, unsigned long long* extraMasks)
 {
+  int tid = threadIdx.x;
+  int laneId = tid % warpSize;
   cg::thread_block mygroup = cg::this_thread_block();
   auto mytile = cg::tiled_partition<TileSize>(mygroup);
 
-  if ((1 << threadIdx.x) & *extraMask) {
-    result[threadIdx.x] = cg::reduce(mytile, input[threadIdx.x], Functor());
-  } else {
-    result[threadIdx.x] = 0;
+  for (int i = 0; i < kNumReduces; i++) {
+    int idx = warpSize * i + laneId;
+    unsigned long long mask = extraMasks[i];
+    T& result = output[idx];
+
+    if ((1 << laneId) & mask) {
+      result = cg::reduce(mytile, input[idx], Functor());
+    } else {
+      result = 0;
+    }
   }
 }
 
 template <class Functor, class T>
-void __global__ reduceKernelCoalesced(T* result, const T* input, unsigned long long* extraMask)
+void __global__ reduceKernelCoalesced(T* output, const T* input, unsigned long long* extraMasks)
 {
-  if ((1 << threadIdx.x) & *extraMask) {
-    auto coalesced = cg::coalesced_threads();
+  int tid = threadIdx.x;
+  int laneId = tid % warpSize;
 
-    result[threadIdx.x] = cg::reduce(coalesced, input[threadIdx.x], Functor());
-  } else {
-    result[threadIdx.x] = 0;
+  for (int i = 0; i < kNumReduces; i++) {
+    int idx = warpSize * i + laneId;
+    unsigned long long mask = extraMasks[i];
+    T& result = output[idx];
+
+    if ((1 << laneId) & mask) {
+      auto coalesced = cg::coalesced_threads();
+
+      result = cg::reduce(coalesced, input[idx], Functor());
+    } else {
+      result = 0;
+    }
   }
 }
 
@@ -655,15 +672,15 @@ void reduceForTypeAndOp()
 {
   using distribution = typename DistributionType<T>::type;
   int wavefrontSize = getWarpSize();
-  int size_bytes = sizeof(T) * wavefrontSize;
+  int size_bytes = kNumReduces * sizeof(T) * wavefrontSize;
   LinearAllocGuard<T> h_result(LinearAllocs::malloc, size_bytes);
   LinearAllocGuard<T> d_result(LinearAllocs::hipMalloc, size_bytes);
   LinearAllocGuard<T> h_input(LinearAllocs::malloc, size_bytes);
   LinearAllocGuard<T> d_input(LinearAllocs::hipMalloc, size_bytes);
   LinearAllocGuard<unsigned long long> d_extraMasks(LinearAllocs::hipMalloc,
-                                                    sizeof(unsigned long long));
+                                                    kNumReduces * sizeof(unsigned long long));
   LinearAllocGuard<unsigned long long> h_extraMasks(LinearAllocs::malloc,
-                                                    sizeof(unsigned long long));
+                                                    kNumReduces * sizeof(unsigned long long));
   std::mt19937_64 gen(Catch::rngSeed());
   dim3 gridDim = { 1 };
   dim3 blockDim = { static_cast<unsigned short>(wavefrontSize) };
@@ -673,21 +690,29 @@ void reduceForTypeAndOp()
   typename distribution::result_type b = std::is_same<T, half>::value? std::numeric_limits<unsigned short>::max() :
                                          1023;
   distribution distInput(a, b);
+  int numReduce = 0;
+  void* kernelPtr;
 
-  genRandomBuffers(d_input, h_input, distInput, gen, wavefrontSize);
+  genRandomBuffers(d_input, h_input, distInput, gen, kNumReduces * wavefrontSize);
   genRandomMasks(d_extraMasks,
                  h_extraMasks,
                  gen,
-                 1);
+                 kNumReduces);
 
-  std::array<void*, 4> devicePtrs = { d_result.ptr(), d_input.ptr(), d_extraMasks.ptr() };
+  std::array<void*, 3> devicePtrs = { d_result.ptr(), d_input.ptr(), d_extraMasks.ptr() };
   void* args[devicePtrs.size()];
 
   for (int i = 0; i < devicePtrs.size(); i++) {
     args[i] = &devicePtrs[i];
   }
 
-  status = hipLaunchCooperativeKernel((void*)(TileSize == 0? reduceKernelCoalesced<Op, T> : reduceKernel<TileSize, Op, T>),
+  if constexpr (TileSize == 0) {
+    kernelPtr = (void*) reduceKernelCoalesced<Op, T>;
+  } else {
+    kernelPtr = (void*) reduceKernel<TileSize, Op, T>;
+  }
+
+  status = hipLaunchCooperativeKernel(kernelPtr,
                                       gridDim,
                                       blockDim,
                                       args,
@@ -699,32 +724,37 @@ void reduceForTypeAndOp()
   HIP_CHECK(hipMemcpy(h_result.host_ptr(), d_result.ptr(),
                       h_result.size_bytes(), hipMemcpyDeviceToHost));
 
-  for (int laneId = 0; laneId < wavefrontSize; laneId++) {
-    unsigned long long mask = ~0ull;
-    T result = h_result.host_ptr()[laneId], expected = 0;
+  while (numReduce < kNumReduces) {
+    for (int laneId = 0; laneId < wavefrontSize; laneId++) {
+      unsigned long long mask = ~0ull;
+      T result = h_result.host_ptr()[numReduce * wavefrontSize + laneId], expected = 0;
+      const T* input = &h_input.host_ptr()[numReduce * wavefrontSize];
 
-    if (TileSize > 0) {
-      mask >>= (64 - TileSize);
-      mask <<= ((laneId % wavefrontSize) / TileSize) * TileSize;
-    }
-
-    mask &= h_extraMasks.host_ptr()[0];
-
-    if ((1 << laneId) & mask) {
-      expected = calculateExpected(h_input.host_ptr(), Op {}, mask);
-    }
-
-    if constexpr (std::is_integral<T>::value) {
-      // for integral types the result should match exactly
-      if (result != expected) {
-        std::string opName = opToString<T, Op>();
-        printMismatch(result, expected, h_input.host_ptr(), mask);
-        INFO("Operator: " << opName);
-        REQUIRE(result == expected);
+      if constexpr (TileSize > 0) {
+        mask >>= (64 - TileSize);
+        mask <<= ((laneId % wavefrontSize) / TileSize) * TileSize;
       }
-    } else {
-      compareFloatingPoint(result, expected, mask, h_input.host_ptr());
+
+      mask &= h_extraMasks.host_ptr()[numReduce];
+
+      if ((1 << laneId) & mask) {
+        expected = calculateExpected(input, Op {}, mask);
+      }
+
+      if constexpr (std::is_integral<T>::value) {
+        // for integral types the result should match exactly
+        if (result != expected) {
+          std::string opName = opToString<T, Op>();
+          printMismatch(result, expected, input, mask);
+          INFO("Operator: " << opName);
+          REQUIRE(result == expected);
+        }
+      } else {
+        compareFloatingPoint(result, expected, mask, h_input.host_ptr());
+      }
     }
+
+    numReduce++;
   }
 }
 

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -624,20 +624,20 @@ TEST_CASE("Unit_Thread_Block_Tile_Reduce_Non_Participating_Threads")
   REQUIRE(*h_result.host_ptr() == getWarpSize() - 1);
 }
 
-template <size_t TileSize, template <typename> class Functor, class T>
+template <size_t TileSize, class Functor, class T>
 void __global__ reduceKernel(T* result, const T* input, unsigned long long* extraMask)
 {
   cg::thread_block mygroup = cg::this_thread_block();
   auto mytile = cg::tiled_partition<TileSize>(mygroup);
 
   if ((1 << threadIdx.x) & *extraMask) {
-    result[threadIdx.x] = cg::reduce(mytile, input[threadIdx.x], Functor<T>());
+    result[threadIdx.x] = cg::reduce(mytile, input[threadIdx.x], Functor());
   } else {
     result[threadIdx.x] = 0;
   }
 }
 
-template <size_t TileSize, template <typename> class Op, class T>
+template <size_t TileSize, class Op, class T>
 void reduceForTypeAndOp()
 {
   using distribution = typename DistributionType<T>::type;
@@ -707,12 +707,12 @@ void reduceForTypeAndOp()
   }
 }
 
-template <template <typename> class Op, class T>
+template <class Op, class T>
 void reduceCoopTiles(const std::index_sequence<>)
 {
 }
 
-template <template <typename> class Op, class T, size_t TileSize, size_t... TileSizes>
+template <class Op, class T, size_t TileSize, size_t... TileSizes>
 void reduceCoopTiles(const std::index_sequence<TileSize, TileSizes...>)
 {
   const std::index_sequence<TileSizes...> remainingTiles;
@@ -721,7 +721,7 @@ void reduceCoopTiles(const std::index_sequence<TileSize, TileSizes...>)
   reduceCoopTiles<Op, T>(remainingTiles);
 }
 
-template <template <typename> class Op, class T, int WarpSize>
+template <class Op, class T, int WarpSize>
 void runReduceRandomForType()
 {
   if constexpr (WarpSize <= 32) {
@@ -733,15 +733,31 @@ void runReduceRandomForType()
   }
 }
 
+template <class T, int WarpSize, class Op = void>
+void runReduceRandomForOps(const std::tuple<>)
+{
+}
+
+template <class T, int WarpSize, class Op, class... Ops>
+void runReduceRandomForOps(const std::tuple<Op, Ops...>)
+{
+  const std::tuple<Ops...> remainingOps;
+
+  runReduceRandomForType<Op, T, WarpSize>();
+  runReduceRandomForOps<T, WarpSize>(remainingOps);
+}
+
 // for all the tile sizes and all input types, using random input values, calculates the reduce()
 // values. Additionally, randomly make some threads not participate
 TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Reduce_Random", "", int, unsigned int, long long,
                    unsigned long long, float, half, double)
 {
+  std::tuple<cooperative_groups::plus<TestType>, cooperative_groups::less<TestType>> types;
+
   if (getWarpSize() == 32) {
-    runReduceRandomForType<cooperative_groups::plus, TestType, 32>();
+    runReduceRandomForOps<TestType, 32>(types);
   } else {
-    runReduceRandomForType<cooperative_groups::plus, TestType, 64>();
+    runReduceRandomForOps<TestType, 64>(types);
   }
 }
 

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -19,7 +19,6 @@ THE SOFTWARE.
 
 #include "cooperative_groups_common.hh"
 #include "cg_common_kernels.hh"
-
 #include <array>
 #include <random>
 
@@ -554,6 +553,39 @@ TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Sync_Positive_Basic", "", uint8_t, ui
   SECTION("Global memory") { BlockTileSyncTest<true, TestType, 2, 16, 32>(); }
   SECTION("Shared memory") { BlockTileSyncTest<false, TestType, 2, 16, 32>(); }
 }
+
+template <size_t WavefrontSize>
+void __global__ simpleSum(int* result)
+{
+   int sum = 1;
+   cg::thread_block mygroup = cg::this_thread_block();
+   auto mytile = cg::tiled_partition<WavefrontSize>(mygroup);
+   *result = cg::reduce(mytile, sum, cg::plus<int>());
+}
+
+TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Reduce_Basic", "", int)
+{
+  unsigned int wavefrontSize = getWarpSize();
+  LinearAllocGuard<int> h_result(LinearAllocs::malloc, sizeof(int));
+  LinearAllocGuard<int> d_result(LinearAllocs::hipMalloc, sizeof(int));
+  dim3 gridDim = { 1 };
+  dim3 blockDim = { wavefrontSize };
+  void* devicePtr = d_result.ptr();
+  void* args[] = { &devicePtr };
+
+  if (wavefrontSize == 32) {
+    HIP_CHECK(hipLaunchCooperativeKernel((void*)simpleSum<32>, gridDim, blockDim, args, 0, nullptr));
+  } else {
+    HIP_CHECK(hipLaunchCooperativeKernel((void*)simpleSum<64>, gridDim, blockDim, args, 0, nullptr));
+  }
+
+  HIP_CHECK(hipDeviceSynchronize());
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipMemcpy(h_result.host_ptr(), d_result.ptr(),
+                      h_result.size_bytes(), hipMemcpyDeviceToHost));
+  REQUIRE(*h_result.host_ptr() == wavefrontSize);
+}
+
 
 /**
  * End doxygen group DeviceLanguageTest.

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -692,13 +692,15 @@ void reduceForTypeAndOp()
     mask &= h_extraMasks.host_ptr()[0];
 
     if ((1 << laneId) & mask) {
-      expected = calculateExpected(h_input.host_ptr(), cooperative_groups::plus<T> {}, mask);
+      expected = calculateExpected(h_input.host_ptr(), Op {}, mask);
     }
 
     if constexpr (std::is_integral<T>::value) {
       // for integral types the result should match exactly
       if (result != expected) {
+        std::string opName = opToString<T, Op>();
         printMismatch(result, expected, h_input.host_ptr(), mask);
+        INFO("Operator: " << opName);
         REQUIRE(result == expected);
       }
     } else {
@@ -742,17 +744,35 @@ template <class T, int WarpSize, class Op, class... Ops>
 void runReduceRandomForOps(const std::tuple<Op, Ops...>)
 {
   const std::tuple<Ops...> remainingOps;
+  
 
+  
   runReduceRandomForType<Op, T, WarpSize>();
   runReduceRandomForOps<T, WarpSize>(remainingOps);
 }
 
 // for all the tile sizes and all input types, using random input values, calculates the reduce()
 // values. Additionally, randomly make some threads not participate
-TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Reduce_Random", "", int, unsigned int, long long,
+TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Reduce_Random_arithmetic", "", int, unsigned int, long long,
                    unsigned long long, float, half, double)
 {
-  std::tuple<cooperative_groups::plus<TestType>, cooperative_groups::less<TestType>> types;
+  std::tuple<cooperative_groups::plus<TestType>,
+             cooperative_groups::less<TestType>,
+             cooperative_groups::greater<TestType>> types;
+
+  if (getWarpSize() == 32) {
+    runReduceRandomForOps<TestType, 32>(types);
+  } else {
+    runReduceRandomForOps<TestType, 64>(types);
+  }
+}
+
+TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Reduce_Random_boolean", "", int, unsigned int, long long,
+                   unsigned long long)
+{
+  std::tuple<cooperative_groups::bit_and<TestType>,
+             cooperative_groups::bit_or<TestType>,
+             cooperative_groups::bit_xor<TestType>> types;
 
   if (getWarpSize() == 32) {
     runReduceRandomForOps<TestType, 32>(types);

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -28,7 +28,7 @@ THE SOFTWARE.
 #include <hip/hip_cooperative_groups.h>
 #include <resource_guards.hh>
 #include <utils.hh>
-
+#include <utility>
 
 /**
  * @addtogroup thread_block_tile thread_block_tile
@@ -637,19 +637,16 @@ void __global__ reduceKernel(T* result, const T* input, unsigned long long* extr
   }
 }
 
-// for all the tile sizes and all input types, using random input values, calculates the reduce()
-// values. Additionally, randomly make some threads not participate
-TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Reduce_Random", "", int, unsigned int, long long,
-                   unsigned long long, float, half, double)
+template <size_t TileSize, template <typename> class Op, class T>
+void reduceForTypeAndOp()
 {
-  using distribution = typename DistributionType<TestType>::type;
-  static constexpr size_t tileSize = 32;
+  using distribution = typename DistributionType<T>::type;
   int wavefrontSize = getWarpSize();
-  int size_bytes = sizeof(TestType) * wavefrontSize;
-  LinearAllocGuard<TestType> h_result(LinearAllocs::malloc, size_bytes);
-  LinearAllocGuard<TestType> d_result(LinearAllocs::hipMalloc, size_bytes);
-  LinearAllocGuard<TestType> h_input(LinearAllocs::malloc, size_bytes);
-  LinearAllocGuard<TestType> d_input(LinearAllocs::hipMalloc, size_bytes);
+  int size_bytes = sizeof(T) * wavefrontSize;
+  LinearAllocGuard<T> h_result(LinearAllocs::malloc, size_bytes);
+  LinearAllocGuard<T> d_result(LinearAllocs::hipMalloc, size_bytes);
+  LinearAllocGuard<T> h_input(LinearAllocs::malloc, size_bytes);
+  LinearAllocGuard<T> d_input(LinearAllocs::hipMalloc, size_bytes);
   LinearAllocGuard<unsigned long long> d_extraMasks(LinearAllocs::hipMalloc,
                                                     sizeof(unsigned long long));
   LinearAllocGuard<unsigned long long> h_extraMasks(LinearAllocs::malloc,
@@ -658,13 +655,12 @@ TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Reduce_Random", "", int, unsigned int
   dim3 gridDim = { 1 };
   dim3 blockDim = { static_cast<unsigned short>(wavefrontSize) };
   hipError_t status;
-  typename distribution::result_type a = std::is_same<TestType, half>::value? std::numeric_limits<unsigned short>::lowest() :
-                                         (std::is_signed<TestType>::value? -1023 : 0);
-  typename distribution::result_type b = std::is_same<TestType, half>::value? std::numeric_limits<unsigned short>::max() :
+  typename distribution::result_type a = std::is_same<T, half>::value? std::numeric_limits<unsigned short>::lowest() :
+                                         (std::is_signed<T>::value? -1023 : 0);
+  typename distribution::result_type b = std::is_same<T, half>::value? std::numeric_limits<unsigned short>::max() :
                                          1023;
   distribution distInput(a, b);
-  // TODO g-h-c
-  // __hip_internal::index_sequence<1, 2, 4, 8, 16, 32, 64> tileSizes;
+
   genRandomBuffers(d_input, h_input, distInput, gen, wavefrontSize);
   genRandomMasks(d_extraMasks,
                  h_extraMasks,
@@ -676,7 +672,7 @@ TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Reduce_Random", "", int, unsigned int
   for (int i = 0; i < devicePtrs.size(); i++) {
     args[i] = &devicePtrs[i];
   }
-  status = hipLaunchCooperativeKernel((void*)reduceKernel<tileSize, cooperative_groups::plus, TestType>,
+  status = hipLaunchCooperativeKernel((void*)reduceKernel<TileSize, Op, T>,
                                        gridDim,
                                        blockDim,
                                        args,
@@ -689,18 +685,17 @@ TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Reduce_Random", "", int, unsigned int
                       h_result.size_bytes(), hipMemcpyDeviceToHost));
 
   for (int laneId = 0; laneId < wavefrontSize; laneId++) {
-    unsigned long long mask = ~0ull >> (64 - tileSize);
-    TestType result = h_result.host_ptr()[laneId], expected = 0;
+    unsigned long long mask = ~0ull >> (64 - TileSize);
+    T result = h_result.host_ptr()[laneId], expected = 0;
 
-    mask <<= ((laneId % wavefrontSize) / tileSize) * tileSize;
+    mask <<= ((laneId % wavefrontSize) / TileSize) * TileSize;
     mask &= h_extraMasks.host_ptr()[0];
 
     if ((1 << laneId) & mask) {
-      // TODO g-h-c try more operators
-      expected = calculateExpected(h_input.host_ptr(), cooperative_groups::plus<TestType> {}, mask);
+      expected = calculateExpected(h_input.host_ptr(), cooperative_groups::plus<T> {}, mask);
     }
 
-    if constexpr (std::is_integral<TestType>::value) {
+    if constexpr (std::is_integral<T>::value) {
       // for integral types the result should match exactly
       if (result != expected) {
         printMismatch(result, expected, h_input.host_ptr(), mask);
@@ -709,6 +704,44 @@ TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Reduce_Random", "", int, unsigned int
     } else {
       compareFloatingPoint(result, expected, mask, h_input.host_ptr());
     }
+  }
+}
+
+template <template <typename> class Op, class T>
+void reduceCoopTiles(const std::index_sequence<>)
+{
+}
+
+template <template <typename> class Op, class T, size_t TileSize, size_t... TileSizes>
+void reduceCoopTiles(const std::index_sequence<TileSize, TileSizes...>)
+{
+  const std::index_sequence<TileSizes...> remainingTiles;
+
+  reduceForTypeAndOp<TileSize, Op, T>();
+  reduceCoopTiles<Op, T>(remainingTiles);
+}
+
+template <template <typename> class Op, class T, int WarpSize>
+void runReduceRandomForType()
+{
+  if constexpr (WarpSize <= 32) {
+    std::index_sequence<1, 2, 4, 8, 16, 32> tileSizes;
+    reduceCoopTiles<Op, T>(tileSizes);
+  } else {
+    std::index_sequence<1, 2, 4, 8, 16, 32, 64> tileSizes;
+    reduceCoopTiles<Op, T>(tileSizes);
+  }
+}
+
+// for all the tile sizes and all input types, using random input values, calculates the reduce()
+// values. Additionally, randomly make some threads not participate
+TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Reduce_Random", "", int, unsigned int, long long,
+                   unsigned long long, float, half, double)
+{
+  if (getWarpSize() == 32) {
+    runReduceRandomForType<cooperative_groups::plus, TestType, 32>();
+  } else {
+    runReduceRandomForType<cooperative_groups::plus, TestType, 64>();
   }
 }
 

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -834,6 +834,20 @@ TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Reduce_Random_boolean", "", int, unsi
   }
 }
 
+// passes a custom operator to cooperative_groups::reduce()
+TEST_CASE("Unit_Thread_Block_Tile_Reduce_Custom_Op")
+{
+  LinearAllocGuard<int> h_result(LinearAllocs::malloc, sizeof(int));
+  LinearAllocGuard<int> d_result(LinearAllocs::hipMalloc, sizeof(int));
+  LinearAllocGuard<int> d_input(LinearAllocs::hipMalloc, getWarpSize() * sizeof(int));
+
+  if (getWarpSize() == 32) {
+    runReduceRandomForType<false, MaxOfAbsolute<int>, int, 32>();
+  } else {
+    runReduceRandomForType<false, MaxOfAbsolute<int>, int, 64>();
+  }
+}
+
 TEMPLATE_TEST_CASE("Unit_Thread_Block_Coalesced_Reduce_arithmetic", "", int, unsigned int, long long,
                    unsigned long long, float, half, double)
 {
@@ -847,6 +861,7 @@ TEMPLATE_TEST_CASE("Unit_Thread_Block_Coalesced_Reduce_arithmetic", "", int, uns
     runReduceRandomForOps<true, TestType, 64>(types);
   }
 }
+
 
 /**
  * End doxygen group DeviceLanguageTest.

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -641,7 +641,7 @@ void __global__ reduceKernel(T* output, const T* input, unsigned long long* extr
     unsigned long long mask = extraMasks[i];
     T& result = output[idx];
 
-    if ((1 << laneId) & mask) {
+    if ((1ull << laneId) & mask) {
       result = cg::reduce(mytile, input[idx], Functor());
     } else {
       result = 0;
@@ -660,7 +660,7 @@ void __global__ reduceKernelCoalesced(T* output, const T* input, unsigned long l
     unsigned long long mask = extraMasks[i];
     T& result = output[idx];
 
-    if ((1 << laneId) & mask) {
+    if ((1ull << laneId) & mask) {
       auto coalesced = cg::coalesced_threads();
 
       result = cg::reduce(coalesced, input[idx], Functor());
@@ -741,7 +741,7 @@ void reduceForTypeAndOp()
 
       mask &= h_extraMasks.host_ptr()[numReduce];
 
-      if ((1 << laneId) & mask) {
+      if ((1ull << laneId) & mask) {
         expected = calculateExpected(input, Op {}, mask);
       }
 

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -594,6 +594,34 @@ TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Reduce_Basic", "", int)
   }
 }
 
+void __global__ partialSum(int* result)
+{
+   int sum = 1;
+   cg::thread_block mygroup = cg::this_thread_block();
+   auto mytile = cg::tiled_partition<32>(mygroup);
+
+  if (threadIdx.x % warpSize != warpSize - 1) {
+     *result = cg::reduce(mytile, sum, cg::plus<int>());
+  }
+}
+
+// Not all the threads of a tile have to participate in a reduce (unlike reduce sync operations)
+TEST_CASE("Unit_Thread_Block_Tile_Reduce_Non_Participating_Threads")
+{
+  LinearAllocGuard<int> h_result(LinearAllocs::malloc, sizeof(int));
+  LinearAllocGuard<int> d_result(LinearAllocs::hipMalloc, sizeof(int));
+  dim3 gridDim = { 1 };
+  dim3 blockDim = { static_cast<unsigned short>(getWarpSize()) };
+  void* devicePtr = d_result.ptr();
+  void* args[] = { &devicePtr };
+
+  HIP_CHECK(hipLaunchCooperativeKernel((void*)partialSum, gridDim, blockDim, args, 0, nullptr));
+  HIP_CHECK(hipDeviceSynchronize());
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipMemcpy(h_result.host_ptr(), d_result.ptr(),
+                      h_result.size_bytes(), hipMemcpyDeviceToHost));
+  REQUIRE(*h_result.host_ptr() == getWarpSize() - 1);
+}
 
 /**
  * End doxygen group DeviceLanguageTest.

--- a/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
+++ b/projects/hip-tests/catch/unit/cooperativeGrps/thread_block_tile.cc
@@ -554,36 +554,44 @@ TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Sync_Positive_Basic", "", uint8_t, ui
   SECTION("Shared memory") { BlockTileSyncTest<false, TestType, 2, 16, 32>(); }
 }
 
-template <size_t WavefrontSize>
+template <size_t TileSize>
 void __global__ simpleSum(int* result)
 {
    int sum = 1;
    cg::thread_block mygroup = cg::this_thread_block();
-   auto mytile = cg::tiled_partition<WavefrontSize>(mygroup);
+   auto mytile = cg::tiled_partition<TileSize>(mygroup);
    *result = cg::reduce(mytile, sum, cg::plus<int>());
+}
+
+template <size_t TileSize>
+void testReduceForTileSize()
+{
+  LinearAllocGuard<int> h_result(LinearAllocs::malloc, sizeof(int));
+  LinearAllocGuard<int> d_result(LinearAllocs::hipMalloc, sizeof(int));
+  dim3 gridDim = { 1 };
+  dim3 blockDim = { static_cast<unsigned short>(getWarpSize()) };
+  void* devicePtr = d_result.ptr();
+  void* args[] = { &devicePtr };
+
+  HIP_CHECK(hipLaunchCooperativeKernel((void*)simpleSum<TileSize>, gridDim, blockDim, args, 0, nullptr));
+  HIP_CHECK(hipDeviceSynchronize());
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipMemcpy(h_result.host_ptr(), d_result.ptr(),
+                      h_result.size_bytes(), hipMemcpyDeviceToHost));
+  REQUIRE(*h_result.host_ptr() == TileSize);
 }
 
 TEMPLATE_TEST_CASE("Unit_Thread_Block_Tile_Reduce_Basic", "", int)
 {
   unsigned int wavefrontSize = getWarpSize();
-  LinearAllocGuard<int> h_result(LinearAllocs::malloc, sizeof(int));
-  LinearAllocGuard<int> d_result(LinearAllocs::hipMalloc, sizeof(int));
-  dim3 gridDim = { 1 };
-  dim3 blockDim = { wavefrontSize };
-  void* devicePtr = d_result.ptr();
-  void* args[] = { &devicePtr };
 
-  if (wavefrontSize == 32) {
-    HIP_CHECK(hipLaunchCooperativeKernel((void*)simpleSum<32>, gridDim, blockDim, args, 0, nullptr));
-  } else {
-    HIP_CHECK(hipLaunchCooperativeKernel((void*)simpleSum<64>, gridDim, blockDim, args, 0, nullptr));
+  testReduceForTileSize<8>();
+  testReduceForTileSize<16>();
+  testReduceForTileSize<32>();
+
+  if (wavefrontSize > 32) {
+    testReduceForTileSize<64>();
   }
-
-  HIP_CHECK(hipDeviceSynchronize());
-  HIP_CHECK(hipGetLastError());
-  HIP_CHECK(hipMemcpy(h_result.host_ptr(), d_result.ptr(),
-                      h_result.size_bytes(), hipMemcpyDeviceToHost));
-  REQUIRE(*h_result.host_ptr() == wavefrontSize);
 }
 
 

--- a/projects/hip-tests/catch/unit/rtc/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/rtc/CMakeLists.txt
@@ -17,6 +17,7 @@ set(AMD_TEST_SRC
     shfl.cc
     shfl_sync.cc
     rtc_reduce.cc
+    rtc_coop.cc
     stdheaders.cc
     hiprtc_MathConstants_HeaderTst.cc
     hiprtc_VectorTypes_HeaderTst.cc

--- a/projects/hip-tests/catch/unit/rtc/rtc_coop.cc
+++ b/projects/hip-tests/catch/unit/rtc/rtc_coop.cc
@@ -1,0 +1,190 @@
+#include "warp_common.hh"
+#include <hip/hip_cooperative_groups.h>
+#include <hip/hip_runtime.h>
+#include <tuple>
+
+#define NELEMS(array) (sizeof(array) / sizeof(array[0]))
+
+namespace cg = cooperative_groups;
+
+
+template <class T, template <typename> class Op>
+const char* functorToString()
+{
+  if constexpr (std::is_same<Op<T>, cg::plus<T>>::value) {
+    return "cg::plus";
+  }
+
+  assert(false && "Missing conversion to string for type");
+  return "";
+}
+
+template <template <typename> class Op, class T, typename... Types>
+void compileProgram(hiprtcProgram& prog, const std::tuple<T, Types...>&) {
+  std::string expression;
+  std::tuple<Types...> remainingTypes;
+
+  expression = std::string("reduceCoopKernel<") +
+               functorToString<T, Op>() +
+               ", " +
+               typeToString<T>() + ">";
+  HIPRTC_CHECK(hiprtcAddNameExpression(prog, expression.c_str()));
+  compileProgram<Op>(prog, remainingTypes);
+}
+
+template <template <typename> class Op, class T = void>
+void compileProgram(hiprtcProgram& prog, const std::tuple<>&) {
+  size_t logSize;
+  hiprtcResult compileResult;
+  const char* options[] = {"-DHIP_ENABLE_WARP_SYNC_BUILTINS", "-DHIP_ENABLE_EXTRA_WARP_SYNC_TYPES"};
+
+  compileResult = hiprtcResult{hiprtcCompileProgram(prog, NELEMS(options), options)};
+  HIPRTC_CHECK(hiprtcGetProgramLogSize(prog, &logSize));
+
+  if (compileResult != HIPRTC_SUCCESS || logSize > 0) {
+    std::string log(logSize, '\0');
+
+    HIPRTC_CHECK(hiprtcGetProgramLog(prog, &log[0]));
+    std::cerr << "Runtime compilation failed or contained warnings\n";
+    std::cerr << log << '\n';
+    REQUIRE(false);
+  }
+}
+
+template <class T, template <typename> class Op>
+void runReduce(hiprtcProgram& prog) {
+  using distribution = typename DistributionType<T>::type;
+
+  static constexpr std::array<int, 6> tileSizes = {2, 4, 8, 16, 32, 64};
+  unsigned int wavefrontSize = getWarpSize();
+  const char* loweredName;
+  hipFunction_t kernel;
+  hipModule_t module;
+  LinearAllocGuard<T> d_input(LinearAllocs::hipMalloc, wavefrontSize * sizeof(T));
+  LinearAllocGuard<T> input(LinearAllocs::malloc, d_input.size_bytes());
+  LinearAllocGuard<T> d_output(LinearAllocs::hipMalloc, wavefrontSize * sizeof(T) * tileSizes.size());
+  LinearAllocGuard<T> output(LinearAllocs::malloc, d_output.size_bytes());
+  std::mt19937_64 gen(Catch::rngSeed());
+  // for float16, we generate any random unsigned short, but cap the exponent later on
+  // to keep it in the range (-8.0..8.0) (just to avoid overflows)
+  // On the rest of the types, just use a bigger reduced range of numbers to avoid overflows too
+  T a = std::is_same<T, half>::value? std::numeric_limits<unsigned short>::lowest() : -1023;
+  T b = std::is_same<T, half>::value? std::numeric_limits<unsigned short>::max() : 1023;
+  distribution dist(a, b);
+
+  genRandomBuffers(d_input, input, dist, gen, wavefrontSize);
+
+  struct {
+    const T* d_output;
+    const T* d_input;
+  } args{d_output.ptr(), d_input.ptr()};
+  size_t size;
+  void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args, HIP_LAUNCH_PARAM_BUFFER_SIZE, &size,
+                    HIP_LAUNCH_PARAM_END};
+  std::vector<char> code;
+  size_t codeSize;
+  std::string expression =
+      std::string("reduceCoopKernel<") + functorToString<T, Op>() + ", " + typeToString<T>() + ">";
+  dim3 grdDim{1u};
+  dim3 blkDim{wavefrontSize};
+  int numTile = 0;
+
+  HIPRTC_CHECK(hiprtcGetCodeSize(prog, &codeSize));
+  code.resize(codeSize);
+  HIPRTC_CHECK(hiprtcGetCode(prog, code.data()));
+  HIP_CHECK(hipModuleLoadData(&module, code.data()));
+  HIPRTC_CHECK(hiprtcGetLoweredName(prog, expression.c_str(), &loweredName));
+  HIP_CHECK(hipModuleGetFunction(&kernel, module, loweredName));
+  HIP_CHECK(hipModuleLaunchKernel(kernel, grdDim.x, grdDim.y, grdDim.z, blkDim.x, blkDim.y,
+                                  blkDim.z, 0, 0, nullptr, config));
+  HIP_CHECK(hipModuleUnload(module));
+  HIP_CHECK(hipDeviceSynchronize());
+  HIP_CHECK(hipMemcpy(output.ptr(), d_output.ptr(), d_output.size_bytes(), hipMemcpyDeviceToHost));
+
+  for (auto tileSize : tileSizes) {
+    for (int laneId = 0; laneId < wavefrontSize; laneId++) {
+      if (tileSize <= wavefrontSize) {
+        Op<T> op;
+        unsigned long long mask = ~0ull >> (64 - tileSize);
+        T expected;
+
+        mask <<= (((laneId % wavefrontSize) / tileSize) * tileSize);
+        expected = calculateExpected(input.host_ptr(), op, mask);
+        INFO("Tile: " << tileSize << " laneId: " << laneId);
+        REQUIRE(output.host_ptr()[numTile * laneId] == expected);
+      }
+    }
+
+    numTile++;
+  }
+}
+
+template <template <typename> class Op, class Type = void>
+void runTestReduceForTypes(hiprtcProgram&, const std::tuple<>) {}
+
+template <template <typename> class Op, class T, typename... Types>
+void runTestReduceForTypes(hiprtcProgram& prog, const std::tuple<T, Types...>) {
+  std::tuple<Types...> remainingTypes;
+
+  runReduce<T, Op>(prog);
+  runTestReduceForTypes<Op>(prog, remainingTypes);
+}
+
+template <template <typename> class Op, typename... Types>
+void runAndCompileTest(const std::tuple<Types...> types) {
+  std::string kernelStr;
+  hiprtcProgram prog;
+
+  kernelStr = R"(
+    using cg = coooperative_groups;
+
+    template <template <typename> class Op, class T, class TileSize = void>
+    __global__ void reduceTiles(T& output, const T* input, const std::tuple<> tileSizes) 
+    {
+    }
+
+    // run reduce for a specific type and for different tile sizes as  a variadic template parameter
+    // @output the result, per lane
+    template <template <typename> class Op, class T, size_t TileSize, typename... TileSizes>
+    __global__ void reduceTiles(T* output, const T* input, const std::tuple<T, TileSizes...>) 
+    {
+      std::integer_sequence<TyleSizes...> remainingTypes;
+      cg::thread_block group = cg::this_thread_block();
+      auto tile = cg::tiled_partition<TileSize>(group);
+      Op<T> op;
+      T accum;
+
+      output[threadIdx.x] = cg::reduce(tile, accum, op);
+      reduceTiles(output + warpSize, input, remainingTypes);
+    }
+
+    // @output will receive a different result per tile size
+    template <template <typename> class Op, class T, size_t WarpSize>
+    __global__ void reduceCoopKernel(T* output, const T* input)
+    {
+      if constexpr (WarpSize <= 32) {
+        std::integer_sequence<2, 4, 8, 16, 32> tileSizes;
+        reduceTiles<Op, T>(output, tileSizes);
+      } else {
+        std::integer_sequence<2, 4, 8, 16, 32, 64> tileSizes;
+        reduceTiles<Op, T>(input, tileSizes);
+      }
+    }
+  })";
+
+  HIPRTC_CHECK(
+      hiprtcCreateProgram(&prog, kernelStr.c_str(), "coop_reduce.hip", 0, nullptr, nullptr));
+  compileProgram<Op>(prog, types);
+  runTestReduceForTypes<Op>(prog, types);
+  HIPRTC_CHECK(hiprtcDestroyProgram(&prog));
+}
+
+TEST_CASE("Unit_Rtc_CoopReduce")
+{
+  const std::tuple<int/*, unsigned int, long long, unsigned long long, float, half, double*/> allTypes;
+  //const std::tuple<int, unsigned int, long long, unsigned long long> integralTypes;
+
+  SECTION("add") {
+    runAndCompileTest<cooperative_groups::plus>(allTypes);
+  }
+}

--- a/projects/hip-tests/catch/unit/rtc/rtc_coop.cc
+++ b/projects/hip-tests/catch/unit/rtc/rtc_coop.cc
@@ -12,7 +12,7 @@ template <class T, template <typename> class Op>
 const char* functorToString()
 {
   if constexpr (std::is_same<Op<T>, cg::plus<T>>::value) {
-    return "cg::plus";
+    return "cooperative_groups::plus";
   }
 
   assert(false && "Missing conversion to string for type");
@@ -27,7 +27,9 @@ void compileProgram(hiprtcProgram& prog, const std::tuple<T, Types...>&) {
   expression = std::string("reduceCoopKernel<") +
                functorToString<T, Op>() +
                ", " +
-               typeToString<T>() + ">";
+               typeToString<T>() +
+               ", " +
+               std::to_string(getWarpSize()) + ">";
   HIPRTC_CHECK(hiprtcAddNameExpression(prog, expression.c_str()));
   compileProgram<Op>(prog, remainingTypes);
 }
@@ -73,18 +75,19 @@ void runReduce(hiprtcProgram& prog) {
   distribution dist(a, b);
 
   genRandomBuffers(d_input, input, dist, gen, wavefrontSize);
-
-  struct {
-    const T* d_output;
-    const T* d_input;
-  } args{d_output.ptr(), d_input.ptr()};
-  size_t size;
-  void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args, HIP_LAUNCH_PARAM_BUFFER_SIZE, &size,
+  std::vector<const void*> args = { d_output.ptr(), d_input.ptr() };
+  std::size_t sizeBytes = args.size() * sizeof(void*);
+  void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, args.data(), HIP_LAUNCH_PARAM_BUFFER_SIZE, &sizeBytes,
                     HIP_LAUNCH_PARAM_END};
   std::vector<char> code;
   size_t codeSize;
   std::string expression =
-      std::string("reduceCoopKernel<") + functorToString<T, Op>() + ", " + typeToString<T>() + ">";
+      std::string("reduceCoopKernel<") +
+      functorToString<T, Op>() +
+      ", " +
+      typeToString<T>() +
+      ", " +
+      std::to_string(wavefrontSize) + ">";
   dim3 grdDim{1u};
   dim3 blkDim{wavefrontSize};
   int numTile = 0;
@@ -102,7 +105,7 @@ void runReduce(hiprtcProgram& prog) {
   HIP_CHECK(hipMemcpy(output.ptr(), d_output.ptr(), d_output.size_bytes(), hipMemcpyDeviceToHost));
 
   for (auto tileSize : tileSizes) {
-    for (int laneId = 0; laneId < wavefrontSize; laneId++) {
+    for (unsigned int laneId = 0; laneId < wavefrontSize; laneId++) {
       if (tileSize <= wavefrontSize) {
         Op<T> op;
         unsigned long long mask = ~0ull >> (64 - tileSize);
@@ -110,8 +113,12 @@ void runReduce(hiprtcProgram& prog) {
 
         mask <<= (((laneId % wavefrontSize) / tileSize) * tileSize);
         expected = calculateExpected(input.host_ptr(), op, mask);
-        INFO("Tile: " << tileSize << " laneId: " << laneId);
-        REQUIRE(output.host_ptr()[numTile * laneId] == expected);
+        INFO("Tile: " << tileSize << " laneId: " << laneId << " mask " << mask);
+
+        for (unsigned int i = 0; i < wavefrontSize; i++) {
+          UNSCOPED_INFO("laneId: " << i << ": " << input.host_ptr()[i]);
+        }
+        REQUIRE(output.host_ptr()[numTile * wavefrontSize + laneId] == expected);
       }
     }
 
@@ -136,41 +143,40 @@ void runAndCompileTest(const std::tuple<Types...> types) {
   hiprtcProgram prog;
 
   kernelStr = R"(
-    using cg = coooperative_groups;
+    namespace cg = cooperative_groups;
 
-    template <template <typename> class Op, class T, class TileSize = void>
-    __global__ void reduceTiles(T& output, const T* input, const std::tuple<> tileSizes) 
+    template <template <typename> class Op, class T>
+    __device__ void reduceTiles(T*, const T*, const __hip_internal::index_sequence<>) 
     {
     }
 
     // run reduce for a specific type and for different tile sizes as  a variadic template parameter
     // @output the result, per lane
-    template <template <typename> class Op, class T, size_t TileSize, typename... TileSizes>
-    __global__ void reduceTiles(T* output, const T* input, const std::tuple<T, TileSizes...>) 
+    template <template <typename> class Op, class T, size_t TileSize, size_t... TileSizes>
+    __device__ void reduceTiles(T* output, const T* input, const __hip_internal::index_sequence<TileSize, TileSizes...>) 
     {
-      std::integer_sequence<TyleSizes...> remainingTypes;
+      const __hip_internal::index_sequence<TileSizes...> remainingTiles;
       cg::thread_block group = cg::this_thread_block();
       auto tile = cg::tiled_partition<TileSize>(group);
       Op<T> op;
-      T accum;
 
-      output[threadIdx.x] = cg::reduce(tile, accum, op);
-      reduceTiles(output + warpSize, input, remainingTypes);
+      output[threadIdx.x] = cg::reduce(tile, input[threadIdx.x], op);
+      reduceTiles<Op, T>(output + warpSize, input, remainingTiles);
     }
 
     // @output will receive a different result per tile size
-    template <template <typename> class Op, class T, size_t WarpSize>
+    template <template <typename> class Op, class T, int WarpSize>
     __global__ void reduceCoopKernel(T* output, const T* input)
     {
       if constexpr (WarpSize <= 32) {
-        std::integer_sequence<2, 4, 8, 16, 32> tileSizes;
-        reduceTiles<Op, T>(output, tileSizes);
+        __hip_internal::index_sequence<2, 4, 8, 16, 32> tileSizes;
+        reduceTiles<Op, T>(output, input, tileSizes);
       } else {
-        std::integer_sequence<2, 4, 8, 16, 32, 64> tileSizes;
-        reduceTiles<Op, T>(input, tileSizes);
+        __hip_internal::index_sequence<2, 4, 8, 16, 32, 64> tileSizes;
+        reduceTiles<Op, T>(output, input, tileSizes);
       }
     }
-  })";
+  )";
 
   HIPRTC_CHECK(
       hiprtcCreateProgram(&prog, kernelStr.c_str(), "coop_reduce.hip", 0, nullptr, nullptr));

--- a/projects/hip-tests/catch/unit/rtc/rtc_coop.cc
+++ b/projects/hip-tests/catch/unit/rtc/rtc_coop.cc
@@ -136,7 +136,7 @@ void runReduce(hiprtcProgram& prog) {
     for (unsigned int laneId = 0; laneId < wavefrontSize; laneId++) {
       unsigned long long mask = ~0ull >> (64 - tileSize);
 
-      mask <<= (((laneId % wavefrontSize) / tileSize) * tileSize);
+      mask <<= ((laneId % wavefrontSize) / tileSize) * tileSize;
 
       if (tileSize <= wavefrontSize) {
         T expected;
@@ -151,14 +151,14 @@ void runReduce(hiprtcProgram& prog) {
 }
 
 template <template <typename> class Op, class Type = void>
-void runTestReduceForTypes(hiprtcProgram&, const std::tuple<>) {}
+void runCoopTestReduceForTypes(hiprtcProgram&, const std::tuple<>) {}
 
 template <template <typename> class Op, class T, typename... Types>
-void runTestReduceForTypes(hiprtcProgram& prog, const std::tuple<T, Types...>) {
+void runCoopTestReduceForTypes(hiprtcProgram& prog, const std::tuple<T, Types...>) {
   std::tuple<Types...> remainingTypes;
 
   runReduce<T, Op>(prog);
-  runTestReduceForTypes<Op>(prog, remainingTypes);
+  runCoopTestReduceForTypes<Op>(prog, remainingTypes);
 }
 
 template <template <typename> class Op, typename... Types>
@@ -174,7 +174,7 @@ void runAndCompileTest(const std::tuple<Types...> types) {
     {
     }
 
-    // run reduce for a specific type and for different tile sizes as  a variadic template parameter
+    // run reduce for a specific type and for different tile sizes as a variadic template parameter
     // @output the result, per lane
     template <template <typename> class Op, class T, size_t TileSize, size_t... TileSizes>
     __device__ void reduceTiles(T* output, const T* input, const __hip_internal::index_sequence<TileSize, TileSizes...>) 
@@ -205,7 +205,7 @@ void runAndCompileTest(const std::tuple<Types...> types) {
   HIPRTC_CHECK(
       hiprtcCreateProgram(&prog, kernelStr.c_str(), "coop_reduce.hip", 0, nullptr, nullptr));
   compileProgram<Op>(prog, types);
-  runTestReduceForTypes<Op>(prog, types);
+  runCoopTestReduceForTypes<Op>(prog, types);
   HIPRTC_CHECK(hiprtcDestroyProgram(&prog));
 }
 

--- a/projects/hip-tests/catch/unit/rtc/rtc_coop.cc
+++ b/projects/hip-tests/catch/unit/rtc/rtc_coop.cc
@@ -13,6 +13,16 @@ const char* functorToString()
 {
   if constexpr (std::is_same<Op<T>, cg::plus<T>>::value) {
     return "cooperative_groups::plus";
+  } else if constexpr (std::is_same<Op<T>, cg::less<T>>::value) {
+    return "cooperative_groups::less";
+  } else if constexpr (std::is_same<Op<T>, cg::greater<T>>::value) {
+    return "cooperative_groups::greater";
+  } else if constexpr (std::is_same<Op<T>, cg::bit_and<T>>::value) {
+    return "cooperative_groups::bit_and";
+  } else if constexpr (std::is_same<Op<T>, cg::bit_or<T>>::value) {
+    return "cooperative_groups::bit_or";
+  } else if constexpr (std::is_same<Op<T>, cg::bit_xor<T>>::value) {
+    return "cooperative_groups::bit_xor";
   }
 
   assert(false && "Missing conversion to string for type");
@@ -57,7 +67,7 @@ template <class T, template <typename> class Op>
 void runReduce(hiprtcProgram& prog) {
   using distribution = typename DistributionType<T>::type;
 
-  static constexpr std::array<int, 6> tileSizes = {2, 4, 8, 16, 32, 64};
+  static constexpr std::array<int, 7> tileSizes = {1, 2, 4, 8, 16, 32, 64};
   unsigned int wavefrontSize = getWarpSize();
   const char* loweredName;
   hipFunction_t kernel;
@@ -104,20 +114,34 @@ void runReduce(hiprtcProgram& prog) {
   HIP_CHECK(hipDeviceSynchronize());
   HIP_CHECK(hipMemcpy(output.ptr(), d_output.ptr(), d_output.size_bytes(), hipMemcpyDeviceToHost));
 
+  INFO("Type: " << typeToString<T>());
   for (auto tileSize : tileSizes) {
+    UNSCOPED_INFO("Tile size: " << tileSize);
     for (unsigned int laneId = 0; laneId < wavefrontSize; laneId++) {
+      unsigned long long mask = ~0ull >> (64 - tileSize);
+
+      mask <<= (((laneId % wavefrontSize) / tileSize) * tileSize);
+
       if (tileSize <= wavefrontSize) {
-        Op<T> op;
-        unsigned long long mask = ~0ull >> (64 - tileSize);
-        T expected;
+        std::string inputStr;
 
-        mask <<= (((laneId % wavefrontSize) / tileSize) * tileSize);
-        expected = calculateExpected(input.host_ptr(), op, mask);
-        INFO("Tile: " << tileSize << " laneId: " << laneId << " mask " << mask);
-
-        for (unsigned int i = 0; i < wavefrontSize; i++) {
-          UNSCOPED_INFO("laneId: " << i << ": " << input.host_ptr()[i]);
+        if constexpr (!std::is_same<T, half>::value) {
+          inputStr = std::string(" input: ") + std::to_string(input.host_ptr()[laneId]);
         }
+
+        UNSCOPED_INFO("laneId: " << laneId << " mask: " << mask << inputStr);
+      }
+    }
+
+    for (unsigned int laneId = 0; laneId < wavefrontSize; laneId++) {
+      unsigned long long mask = ~0ull >> (64 - tileSize);
+
+      mask <<= (((laneId % wavefrontSize) / tileSize) * tileSize);
+
+      if (tileSize <= wavefrontSize) {
+        T expected;
+        Op<T> op;
+        expected = calculateExpected(input.host_ptr(), op, mask);
         REQUIRE(output.host_ptr()[numTile * wavefrontSize + laneId] == expected);
       }
     }
@@ -169,10 +193,10 @@ void runAndCompileTest(const std::tuple<Types...> types) {
     __global__ void reduceCoopKernel(T* output, const T* input)
     {
       if constexpr (WarpSize <= 32) {
-        __hip_internal::index_sequence<2, 4, 8, 16, 32> tileSizes;
+        __hip_internal::index_sequence<1, 2, 4, 8, 16, 32> tileSizes;
         reduceTiles<Op, T>(output, input, tileSizes);
       } else {
-        __hip_internal::index_sequence<2, 4, 8, 16, 32, 64> tileSizes;
+        __hip_internal::index_sequence<1, 2, 4, 8, 16, 32, 64> tileSizes;
         reduceTiles<Op, T>(output, input, tileSizes);
       }
     }
@@ -187,10 +211,30 @@ void runAndCompileTest(const std::tuple<Types...> types) {
 
 TEST_CASE("Unit_Rtc_CoopReduce")
 {
-  const std::tuple<int/*, unsigned int, long long, unsigned long long, float, half, double*/> allTypes;
-  //const std::tuple<int, unsigned int, long long, unsigned long long> integralTypes;
+  const std::tuple<int, unsigned int, long long, unsigned long long, float, half, double> allTypes;
+  const std::tuple<int, unsigned int, long long, unsigned long long> integralTypes;
 
   SECTION("add") {
     runAndCompileTest<cooperative_groups::plus>(allTypes);
+  }
+
+  SECTION("less") {
+    runAndCompileTest<cooperative_groups::less>(allTypes);
+  }
+
+  SECTION("greater") {
+    runAndCompileTest<cooperative_groups::greater>(allTypes);
+  }
+
+  SECTION("and") {
+    runAndCompileTest<cooperative_groups::bit_and>(integralTypes);
+  }
+
+  SECTION("or") {
+    runAndCompileTest<cooperative_groups::bit_or>(integralTypes);
+  }
+
+  SECTION("xor") {
+    runAndCompileTest<cooperative_groups::bit_xor>(integralTypes);
   }
 }

--- a/projects/hip-tests/catch/unit/rtc/rtc_reduce.cc
+++ b/projects/hip-tests/catch/unit/rtc/rtc_reduce.cc
@@ -109,13 +109,16 @@ void opToString(std::string& scalarName, std::string& intrinsicName) {
     scalarName = "MaxOp";
     intrinsicName = "__reduce_max_sync";
   } else if constexpr (std::is_same<Op<T>, AndOp<T>>::value) {
-    scalarName = "std::logical_and";
+    scalarName = "std::bit_and";
     intrinsicName = "__reduce_and_sync";
   } else if constexpr (std::is_same<Op<T>, OrOp<T>>::value) {
-    scalarName = "std::logical_or";
+    scalarName = "std::bit_or";
     intrinsicName = "__reduce_or_sync";
   } else if constexpr (std::is_same<Op<T>, XorOp<T>>::value) {
-    scalarName = "LogicalXor";
+    scalarName = "std::bit_xor";
+    intrinsicName = "__reduce_xor_sync";
+  } else if constexpr (std::is_same<Op<T>, XorOp<T>>::value) {
+    scalarName = "std::bit_xor";
     intrinsicName = "__reduce_xor_sync";
   } else
     static_assert(std::is_void<T>::value, "Unexpected operator");

--- a/projects/hip-tests/catch/unit/warp/warp_reduce.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_reduce.cc
@@ -183,7 +183,7 @@ void runTestReduceForTypes(const std::tuple<T, Types...>) {
   bool customNumIterations = cmd_options.reduce_iterations != 1;
 
   if (customNumIterations)
-    std::cout << "\n" << opToString<T, Op>() << " - " << typeToString<T>() << "\n";
+    std::cout << "\n" << opToString<T, Op<T>>() << " - " << typeToString<T>() << "\n";
 
   while (iteration < cmd_options.reduce_iterations) {
     runTestReduce<T, decltype(reduceFunc), Op>(iteration, reduceFunc);

--- a/projects/hip-tests/catch/unit/warp/warp_reduce.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_reduce.cc
@@ -58,24 +58,26 @@ __global__ void multipleMasksKernel(T* output, const T* input, const unsigned lo
 template <class T, class Op, class MaskType>
 __global__ void reduceOp(T* output, const T* input, const MaskType* masks, int numReduces, Op) {
   int tid = threadIdx.x;
+  int laneId = tid % warpSize;
 
   for (int i = 0; i < numReduces; i++) {
-    if (masks[i] & (1ul << tid)) {
+    if (masks[i] & (1ul << laneId)) {
+      int idx = warpSize * i + laneId;
       // call the operator only if the lane is mentioned in the mask
-      T& result = output[warpSize * i + tid];
+      T& result = output[idx];
 
       if constexpr (std::is_same<Op, std::plus<T>>::value)
-        result = __reduce_add_sync(masks[i], input[tid]);
+        result = __reduce_add_sync(masks[i], input[idx]);
       else if constexpr (std::is_same<Op, MinOp<T>>::value)
-        result = __reduce_min_sync(masks[i], input[tid]);
+        result = __reduce_min_sync(masks[i], input[idx]);
       else if constexpr (std::is_same<Op, MaxOp<T>>::value)
-        result = __reduce_max_sync(masks[i], input[tid]);
+        result = __reduce_max_sync(masks[i], input[idx]);
       else if constexpr (std::is_same<Op, AndOp<T>>::value)
-        result = __reduce_and_sync(masks[i], input[tid]);
+        result = __reduce_and_sync(masks[i], input[idx]);
       else if (std::is_same<Op, OrOp<T>>::value)
-        result = __reduce_or_sync(masks[i], input[tid]);
+        result = __reduce_or_sync(masks[i], input[idx]);
       else if (std::is_same<Op, XorOp<T>>::value)
-        result = __reduce_xor_sync(masks[i], input[tid]);
+        result = __reduce_xor_sync(masks[i], input[idx]);
       else
         assert(false && "Unsupported operator");
     }

--- a/projects/hip-tests/catch/unit/warp/warp_shfl.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_shfl.cc
@@ -52,7 +52,7 @@ template <typename T> class WarpShfl : public WarpShflTest<WarpShfl<T>, T> {
     LinearAllocGuard<uint8_t> src_lanes_dev(LinearAllocs::hipMalloc, alloc_size);
     src_lanes_.resize(width_);
     std::generate(src_lanes_.begin(), src_lanes_.end(),
-                  [this] { return GenerateRandomInteger(0, static_cast<int>(2 * width_)); });
+                  [this] { return GenRandomInteger(0, static_cast<int>(2 * width_)); });
 
     HIP_CHECK(hipMemcpy(src_lanes_dev.ptr(), src_lanes_.data(), alloc_size, hipMemcpyHostToDevice));
     shfl<<<this->grid_.grid_dim_, this->grid_.block_dim_>>>(arr_dev, input_dev, active_masks,

--- a/projects/hip-tests/catch/unit/warp/warp_shfl_common.hh
+++ b/projects/hip-tests/catch/unit/warp/warp_shfl_common.hh
@@ -83,27 +83,27 @@ template <typename Derived, typename T> class WarpShflTest {
   void generate_input(T* input, bool random) {
     if (random) {
       std::generate(active_masks_.begin(), active_masks_.end(), [] {
-        return GenerateRandomInteger<unsigned long long>(0ul, std::numeric_limits<uint64_t>().max());
+        return GenRandomInteger<unsigned long long>(0ul, std::numeric_limits<uint64_t>().max());
       });
 
       if constexpr (std::is_same_v<float, T> || std::is_same_v<double, T>) {
         std::generate_n(input, grid_.thread_count_, [] {
           return static_cast<T>(
-              GenerateRandomReal(std::numeric_limits<T>().min(), std::numeric_limits<T>().max()));
+              GenRandomReal(std::numeric_limits<T>().min(), std::numeric_limits<T>().max()));
         });
       } else if constexpr (std::is_same_v<__half, T>) {
         std::generate_n(input, grid_.thread_count_, [] {
-          return __float2half(GenerateRandomReal(std::numeric_limits<float>().min(),
+          return __float2half(GenRandomReal(std::numeric_limits<float>().min(),
                                                  std::numeric_limits<float>().max()));
         });
       } else if constexpr (std::is_same_v<__half2, T>) {
         std::generate_n(input, grid_.thread_count_, [] {
-          return __float2half2_rn(GenerateRandomReal(std::numeric_limits<float>().min(),
+          return __float2half2_rn(GenRandomReal(std::numeric_limits<float>().min(),
                                                      std::numeric_limits<float>().max()));
         });
       } else {
         std::generate_n(input, grid_.thread_count_, [] {
-          return static_cast<T>(GenerateRandomInteger(std::numeric_limits<T>().min(),
+          return static_cast<T>(GenRandomInteger(std::numeric_limits<T>().min(),
                                                       std::numeric_limits<T>().max()));
         });
       }

--- a/projects/hip-tests/catch/unit/warp/warp_shfl_down.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_shfl_down.cc
@@ -53,7 +53,7 @@ template <typename T> class WarpShflDown : public WarpShflTest<WarpShflDown<T>, 
     LinearAllocGuard<unsigned int> deltas_dev(LinearAllocs::hipMalloc, alloc_size);
     deltas_.resize(width_);
     std::generate(deltas_.begin(), deltas_.end(),
-                  [this] { return GenerateRandomInteger(0u, static_cast<unsigned int>(width_)); });
+                  [this] { return GenRandomInteger(0u, static_cast<unsigned int>(width_)); });
     HIP_CHECK(hipMemcpy(deltas_dev.ptr(), deltas_.data(), alloc_size, hipMemcpyHostToDevice));
     shfl_down<<<this->grid_.grid_dim_, this->grid_.block_dim_>>>(arr_dev, input_dev, active_masks,
                                                                  deltas_dev.ptr(), width_);

--- a/projects/hip-tests/catch/unit/warp/warp_shfl_up.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_shfl_up.cc
@@ -53,7 +53,7 @@ template <typename T> class WarpShflUp : public WarpShflTest<WarpShflUp<T>, T> {
     LinearAllocGuard<unsigned int> deltas_dev(LinearAllocs::hipMalloc, alloc_size);
     deltas_.resize(width_);
     std::generate(deltas_.begin(), deltas_.end(),
-                  [this] { return GenerateRandomInteger(0u, static_cast<unsigned int>(width_)); });
+                  [this] { return GenRandomInteger(0u, static_cast<unsigned int>(width_)); });
     HIP_CHECK(hipMemcpy(deltas_dev.ptr(), deltas_.data(), alloc_size, hipMemcpyHostToDevice));
     shfl_up<<<this->grid_.grid_dim_, this->grid_.block_dim_>>>(arr_dev, input_dev, active_masks,
                                                                deltas_dev.ptr(), width_);

--- a/projects/hip-tests/catch/unit/warp/warp_vote_common.hh
+++ b/projects/hip-tests/catch/unit/warp/warp_vote_common.hh
@@ -80,7 +80,7 @@ template <typename Derived, typename T> class WarpVoteTest {
 
     if (random) {
       std::generate(active_masks_.begin(), active_masks_.end(), [] {
-        return GenerateRandomInteger<unsigned long long>(0ul, std::numeric_limits<uint64_t>().max());
+        return GenRandomInteger<unsigned long long>(0ul, std::numeric_limits<uint64_t>().max());
       });
     } else {
       unsigned long long int i = 0;


### PR DESCRIPTION
## Motivation

Add implementation of cooperative_groups::reduce API

Technical Details

## Technical Details
Implements cooperative_groups::reduce() for the types supported by CUDA plus the types that the reduce sync operations already supported (this includes floating point types)

## JIRA ID

SWDEV-531829

## Test Plan
Updated tests groups:
* RTC
* coopGrpTest

## Test Result
Passed

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
