### PR TITLE
ROCM-1580 - Select Monitor Type at compile time

### DIFF
--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -40,7 +40,7 @@ hipError_t ihipFree(void* ptr);
 hipError_t ihipMallocManaged(void** ptr, size_t size, size_t align = 0, bool use_host_ptr = 0);
 
 hipError_t DynCO::loadCodeObject(const char* fname, const void* image) {
-  amd::ScopedLock lock(dclock_);
+  std::scoped_lock lock(dclock_);
 
   // Number of devices = 1 in dynamic code object
   fb_info_ = new FatBinaryInfo(fname, image);
@@ -63,7 +63,7 @@ hipError_t DynCO::loadCodeObject(const char* fname, const void* image) {
 
 // Dynamic Code Object
 DynCO::~DynCO() {
-  amd::ScopedLock lock(dclock_);
+  std::scoped_lock lock(dclock_);
 
   for (auto& elem : vars_) {
     if (elem.second->getVarKind() == Var::DVK_Managed) {
@@ -96,7 +96,7 @@ DynCO::~DynCO() {
 }
 
 hipError_t DynCO::getDeviceVar(DeviceVar** dvar, const std::string& var_name) {
-  amd::ScopedLock lock(dclock_);
+  std::scoped_lock lock(dclock_);
 
   auto it = vars_.find(var_name);
   if (it == vars_.end()) {
@@ -109,7 +109,7 @@ hipError_t DynCO::getDeviceVar(DeviceVar** dvar, const std::string& var_name) {
 }
 
 hipError_t DynCO::getDynFunc(hipFunction_t* hfunc, const std::string& func_name) {
-  amd::ScopedLock lock(dclock_);
+  std::scoped_lock lock(dclock_);
 
   if (hfunc == nullptr) {
     return hipErrorInvalidValue;
@@ -126,7 +126,7 @@ hipError_t DynCO::getDynFunc(hipFunction_t* hfunc, const std::string& func_name)
 }
 
 hipError_t DynCO::getFuncCount(unsigned int* count) {
-  amd::ScopedLock lock(dclock_);
+  std::scoped_lock lock(dclock_);
   if (count == nullptr) {
     return hipErrorInvalidValue;
   }
@@ -135,13 +135,13 @@ hipError_t DynCO::getFuncCount(unsigned int* count) {
 }
 
 bool DynCO::isValidDynFunc(const void* hfunc) {
-  amd::ScopedLock lock(dclock_);
+  std::scoped_lock lock(dclock_);
   return std::any_of(functions_.begin(), functions_.end(),
                      [&](auto& it) { return it.second->isValidDynFunc(hfunc); });
 }
 
 hipError_t DynCO::initDynManagedVars(const std::string& managedVar) {
-  amd::ScopedLock lock(dclock_);
+  std::scoped_lock lock(dclock_);
   DeviceVar* dvar;
   void* pointer = nullptr;
   hipError_t status = hipSuccess;
@@ -194,7 +194,7 @@ hipError_t DynCO::initDynManagedVars(const std::string& managedVar) {
 }
 
 hipError_t DynCO::populateDynGlobalVars() {
-  amd::ScopedLock lock(dclock_);
+  std::scoped_lock lock(dclock_);
   hipError_t err = hipSuccess;
   std::vector<std::string> var_names;
   std::string managedVarExt = ".managed";
@@ -223,7 +223,7 @@ hipError_t DynCO::populateDynGlobalVars() {
 }
 
 hipError_t DynCO::populateDynGlobalFuncs() {
-  amd::ScopedLock lock(dclock_);
+  std::scoped_lock lock(dclock_);
 
   std::vector<std::string> func_names;
   device::Program* dev_program = fb_info_->GetProgram(ihipGetDevice())
@@ -246,7 +246,7 @@ hipError_t DynCO::populateDynGlobalFuncs() {
 StatCO::StatCO(const PlatformState& owner) : owner_(owner) {}
 
 StatCO::~StatCO() {
-  amd::ScopedLock lock(sclock_);
+  std::scoped_lock lock(sclock_);
 
   for (auto& elem : functions_) {
     delete elem.second;
@@ -260,7 +260,7 @@ StatCO::~StatCO() {
 }
 
 hipError_t StatCO::DigestFatBinary(const void* data, FatBinaryInfo*& programs) {
-  amd::ScopedLock lock(sclock_);
+  std::scoped_lock lock(sclock_);
 
   if (programs != nullptr) {
     return hipSuccess;
@@ -307,7 +307,7 @@ hipError_t StatCO::DigestFatBinary(const void* data, FatBinaryInfo*& programs) {
 }
 
 FatBinaryInfo** StatCO::AddFatBinary(const void* data, bool& success) {
-  amd::ScopedLock lock(sclock_);
+  std::scoped_lock lock(sclock_);
   module_to_hostModule_.insert(std::make_pair(&modules_[data], data));
 
   if (!owner_.IsInitialized()) {
@@ -323,7 +323,7 @@ FatBinaryInfo** StatCO::AddFatBinary(const void* data, bool& success) {
 
 FatBinaryInfo** StatCO::AddKpackBinary(const void* hipk_metadata, const void* wrapper_addr,
                                        bool& success) {
-  amd::ScopedLock lock(sclock_);
+  std::scoped_lock lock(sclock_);
 
   // Use wrapper_addr as the key (same as data pointer for normal path)
   // This allows DigestFatBinary to access the wrapper and detect HIPK magic
@@ -342,7 +342,7 @@ FatBinaryInfo** StatCO::AddKpackBinary(const void* hipk_metadata, const void* wr
 }
 
 hipError_t StatCO::RemoveFatBinary(FatBinaryInfo** module) {
-  amd::ScopedLock lock(sclock_);
+  std::scoped_lock lock(sclock_);
 
   auto hostVarsIter = module_to_hostVars_.find(module);
   if (hostVarsIter != module_to_hostVars_.end()) {
@@ -417,7 +417,7 @@ hipError_t StatCO::RemoveFatBinary(FatBinaryInfo** module) {
 
 // =================================================================================================
 void StatCO::RemoveAllFatBinaries() {
-  amd::ScopedLock lock(sclock_);
+  std::scoped_lock lock(sclock_);
 
   // Clear mapping tables that associate modules with host-side constructs
   module_to_hostModule_.clear();
@@ -472,7 +472,7 @@ void StatCO::RemoveAllFatBinaries() {
 }
 
 hipError_t StatCO::RegisterFunction(const void* hostFunction, Function* func) {
-  amd::ScopedLock lock(sclock_);
+  std::scoped_lock lock(sclock_);
 
   if (functions_.find(hostFunction) != functions_.end()) {
     ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_API,
@@ -487,7 +487,7 @@ hipError_t StatCO::RegisterFunction(const void* hostFunction, Function* func) {
 }
 
 const char* StatCO::GetFuncName(const void* hostFunction) {
-  amd::ScopedLock lock(sclock_);
+  std::scoped_lock lock(sclock_);
 
   const auto it = functions_.find(hostFunction);
   if (it == functions_.end()) {
@@ -505,7 +505,7 @@ hipError_t StatCO::GetFunc(hipFunction_t* hfunc, const void* hostFunction, int d
   // Lazy load
   FatBinaryInfo** module = it->second->moduleInfo();
   if (module != nullptr) {
-    amd::ScopedLock lock(sclock_);
+    std::scoped_lock lock(sclock_);
     if (*(module) == nullptr) {
       hipError_t err = DigestFatBinary(module_to_hostModule_[module], *module);
 
@@ -523,7 +523,7 @@ hipError_t StatCO::GetFunc(hipFunction_t* hfunc, const void* hostFunction, int d
 
 hipError_t StatCO::GetFuncAttr(hipFuncAttributes* func_attr, const void* hostFunction,
                                int deviceId) {
-  amd::ScopedLock lock(sclock_);
+  std::scoped_lock lock(sclock_);
 
   const auto it = functions_.find(hostFunction);
   if (it == functions_.end()) {
@@ -540,7 +540,7 @@ hipError_t StatCO::GetFuncAttr(hipFuncAttributes* func_attr, const void* hostFun
 }
 
 hipError_t StatCO::RegisterGlobalVar(const void* hostVar, Var* var) {
-  amd::ScopedLock lock(sclock_);
+  std::scoped_lock lock(sclock_);
 
   auto var_it = vars_.find(hostVar);
   if ((var_it != vars_.end()) && (var_it->second->getName() != var->getName())) {
@@ -554,7 +554,7 @@ hipError_t StatCO::RegisterGlobalVar(const void* hostVar, Var* var) {
 
 hipError_t StatCO::GetGlobalVar(const void* hostVar, int deviceId, hipDeviceptr_t* dev_ptr,
                                 size_t* size_ptr) {
-  amd::ScopedLock lock(sclock_);
+  std::scoped_lock lock(sclock_);
 
   const auto it = vars_.find(hostVar);
   if (it == vars_.end()) {
@@ -582,7 +582,7 @@ hipError_t StatCO::RegisterManagedVar(Var* var) {
 
 // ================================================================================================
 void StatCO::ResizeForDevices(size_t device_count) {
-  amd::ScopedLock lock(sclock_);
+  std::scoped_lock lock(sclock_);
   for (const auto& it : vars_) {
     it.second->resize_dVar(device_count);
   }
@@ -598,7 +598,7 @@ void StatCO::ResizeForDevices(size_t device_count) {
 
 // ================================================================================================
 hipError_t StatCO::InitManagedVarDevicePtr(int deviceId) {
-  amd::ScopedLock lock(sclock_);
+  std::scoped_lock lock(sclock_);
   hipError_t err = hipSuccess;
   if (managedVarsDevicePtrInitalized_.find(deviceId) == managedVarsDevicePtrInitalized_.end() ||
       !managedVarsDevicePtrInitalized_[deviceId]) {

--- a/projects/clr/hipamd/src/hip_code_object.hpp
+++ b/projects/clr/hipamd/src/hip_code_object.hpp
@@ -87,7 +87,7 @@ class CodeObject {
 // Dynamic Code Object
 class DynCO : public CodeObject {
   // Guards Dynamic Code object
-  amd::Monitor dclock_{true};
+  std::recursive_mutex dclock_;
 
  public:
   DynCO() : device_id_(ihipGetDevice()), fb_info_(nullptr), module_(nullptr) {}
@@ -165,7 +165,7 @@ class StatCO : public CodeObject {
   void ResizeForDevices(size_t device_count);
 
  private:
-  amd::Monitor sclock_{true};              //!< Guards Static Code object
+  std::recursive_mutex sclock_;            //!< Guards Static Code object
   const PlatformState& owner_;             //!< Reference to owning PlatformState
   //! Populated during __hipRegisterFatBinary
   std::unordered_map<const void*, FatBinaryInfo*> modules_;

--- a/projects/clr/hipamd/src/hip_comgr_helper.cpp
+++ b/projects/clr/hipamd/src/hip_comgr_helper.cpp
@@ -871,18 +871,18 @@ void RTCProgram::AppendOptions(const std::string app_env_var, std::vector<std::s
 }
 
 // HIPRTC Program lock
-amd::Monitor RTCProgram::lock_(true);
+std::recursive_mutex RTCProgram::lock_;
 
 LinkProgram::LinkProgram(std::string name) : RTCProgram(name) {
   if (link_input_.Create() != AMD_COMGR_STATUS_SUCCESS) {
     guarantee(false, "Failed to allocate internal comgr structure");
   }
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
   linker_set_.insert(this);
 }
 
 bool LinkProgram::isLinkerValid(LinkProgram* link_program) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
   if (linker_set_.find(link_program) == linker_set_.end()) {
     return false;
   }

--- a/projects/clr/hipamd/src/hip_comgr_helper.hpp
+++ b/projects/clr/hipamd/src/hip_comgr_helper.hpp
@@ -177,7 +177,7 @@ struct LinkArguments {
 class RTCProgram {
  protected:
   // Lock and control variables
-  static amd::Monitor lock_;
+  static std::recursive_mutex lock_;
   static std::once_flag initialized_;
 
   RTCProgram(std::string name);
@@ -222,7 +222,7 @@ class LinkProgram : public RTCProgram {
  public:
   LinkProgram(std::string name);
   ~LinkProgram() {
-    amd::ScopedLock lock(lock_);
+    std::scoped_lock lock(lock_);
     linker_set_.erase(this);
   }
   // Public Member Functions

--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -35,7 +35,7 @@ namespace hip {
 hip::Stream* Device::NullStream(bool wait) {
   ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_WAIT, "NullStream %p, wait %d", null_stream_, wait);
   if (null_stream_ == nullptr) {
-    amd::ScopedLock lock(lock_);
+    std::scoped_lock lock(lock_);
     if (null_stream_ == nullptr) {
       null_stream_ = new Stream(this, Stream::Priority::Normal, 0, true);
       // Stream creation might be failed from rcor and in that case, vdev is null.
@@ -98,14 +98,14 @@ bool Device::Create() {
 
 // ================================================================================================
 bool Device::IsMemoryPoolValid(MemoryPool* pool) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
   bool result = (mem_pools_.find(pool) != mem_pools_.end()) ? true : false;
   return result;
 }
 
 // ================================================================================================
 void Device::AddMemoryPool(MemoryPool* pool) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
   if (auto it = mem_pools_.find(pool); it == mem_pools_.end()) {
     mem_pools_.insert(pool);
   }
@@ -113,7 +113,7 @@ void Device::AddMemoryPool(MemoryPool* pool) {
 
 // ================================================================================================
 void Device::RemoveMemoryPool(MemoryPool* pool) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
   if (auto it = mem_pools_.find(pool); it != mem_pools_.end()) {
     mem_pools_.erase(it);
   }
@@ -121,7 +121,7 @@ void Device::RemoveMemoryPool(MemoryPool* pool) {
 
 // ================================================================================================
 bool Device::FreeMemory(amd::Memory* memory, Stream* stream, Event* event) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
   // Search for memory in the entire list of pools
   for (auto it : mem_pools_) {
     if (it->FreeMemory(memory, stream, event)) {
@@ -133,7 +133,7 @@ bool Device::FreeMemory(amd::Memory* memory, Stream* stream, Event* event) {
 
 // ================================================================================================
 void Device::ReleaseFreedMemory() {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
   // Search for memory in the entire list of pools
   for (auto it : mem_pools_) {
     it->ReleaseFreedMemory();
@@ -142,7 +142,7 @@ void Device::ReleaseFreedMemory() {
 
 // ================================================================================================
 void Device::RemoveStreamFromPools(Stream* stream) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
   // Update all pools with the destroyed stream
   for (auto it : mem_pools_) {
     it->RemoveStream(stream);
@@ -151,7 +151,7 @@ void Device::RemoveStreamFromPools(Stream* stream) {
 
 // ================================================================================================
 void Device::AddSafeStream(Stream* event_stream, Stream* wait_stream) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
   // Update all pools with the safe streams
   for (auto it : mem_pools_) {
     it->AddSafeStream(event_stream, wait_stream);
@@ -161,7 +161,7 @@ void Device::AddSafeStream(Stream* event_stream, Stream* wait_stream) {
 // ================================================================================================
 void Device::Reset() {
   {
-    amd::ScopedLock lock(lock_);
+    std::scoped_lock lock(lock_);
     auto it = mem_pools_.begin();
     while (it != mem_pools_.end()) {
       auto current = it++;

--- a/projects/clr/hipamd/src/hip_event.cpp
+++ b/projects/clr/hipamd/src/hip_event.cpp
@@ -51,7 +51,7 @@ bool EventDD::ready() {
 
 // ================================================================================================
 hipError_t Event::query() {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
 
   // If event is not recorded, event_ is null, hence return hipSuccess
   if (event_ == nullptr) {
@@ -63,7 +63,7 @@ hipError_t Event::query() {
 
 // ================================================================================================
 hipError_t Event::synchronize() {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
 
   // If event is not recorded, event_ is null, hence return hipSuccess
   if (event_ == nullptr) {
@@ -95,7 +95,7 @@ bool EventDD::awaitEventCompletion() {
 
 // ================================================================================================
 hipError_t Event::elapsedTime(Event& eStop, float& ms) {
-  amd::ScopedLock startLock(lock_);
+  std::scoped_lock startLock(lock_);
 
   // Handle same event case
   if (this == &eStop) {
@@ -106,7 +106,7 @@ hipError_t Event::elapsedTime(Event& eStop, float& ms) {
     return ready() ? hipSuccess : hipErrorNotReady;
   }
 
-  amd::ScopedLock stopLock(eStop.lock());
+  std::scoped_lock stopLock(eStop.lock());
 
   // Validate events
   if (event_ == nullptr || eStop.event() == nullptr) {
@@ -176,7 +176,7 @@ hipError_t Event::streamWaitCommand(amd::Command*& command, hip::Stream* stream)
 }
 // ================================================================================================
 hipError_t Event::streamWait(hip::Stream* stream, uint flags) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
 
   // Early return if event is not recorded, same stream, or already ready
   if ((event_ == nullptr) || (event_->command().queue() == stream) || ready()) {
@@ -239,7 +239,7 @@ hipError_t Event::enqueueRecordCommand(hip::Stream* stream, amd::Command* comman
 // ================================================================================================
 hipError_t Event::addMarker(hip::Stream* hip_stream, amd::Command* command, bool batch_flush) {
   // Keep the lock always at the beginning of this to avoid a race. SWDEV-277847
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
   if (const auto status = recordCommand(command, hip_stream, 0, batch_flush);
       status != hipSuccess) {
     return status;

--- a/projects/clr/hipamd/src/hip_event.hpp
+++ b/projects/clr/hipamd/src/hip_event.hpp
@@ -102,8 +102,7 @@ class Event {
   // Flushes CPU command batch in direct dispatch mode
   static constexpr bool kBatchFlush = true;
 
-  explicit Event(uint32_t flags)
-      : flags_(flags), lock_(true), event_(nullptr) {
+  explicit Event(uint32_t flags) : flags_(flags), event_(nullptr) {
     device_id_ = hip::getCurrentDevice()->deviceId();
   }
 
@@ -128,7 +127,7 @@ class Event {
   uint32_t flags() const { return flags_; }
 
   void BindCommand(amd::Command& command) {
-    amd::ScopedLock lock(lock_);
+    std::scoped_lock lock(lock_);
     if (event_ != nullptr) {
       event_->release();
     }
@@ -136,8 +135,8 @@ class Event {
     command.retain();
   }
 
-  amd::Monitor& lock() { return lock_; }
-  int deviceId() const { return device_id_; }
+  std::recursive_mutex& lock() { return lock_; }
+  const int deviceId() const { return device_id_; }
   void setDeviceId(int id) { device_id_ = id; }
   amd::Event* event() { return event_; }
 
@@ -164,10 +163,10 @@ class Event {
   virtual int64_t time(bool getStartTs) const;
 
  protected:
-  uint32_t flags_;         //!< Flags associated with the event
-  amd::Monitor lock_;      //!< Mutex for thread-safe access to event state
-  amd::Event* event_;      //!< Underlying ROCclr event object for GPU synchronization
-  int device_id_;          //!< Device ID where this event was created
+  uint32_t flags_;             //!< Flags associated with the event
+  std::recursive_mutex lock_;  //!< Mutex for thread-safe access to event state
+  amd::Event* event_;          //!< Underlying ROCclr event object for GPU synchronization
+  int device_id_;              //!< Device ID where this event was created
 };
 
 class EventDD : public Event {

--- a/projects/clr/hipamd/src/hip_fatbin.hpp
+++ b/projects/clr/hipamd/src/hip_fatbin.hpp
@@ -65,7 +65,7 @@ class FatBinaryInfo {
   }
 
   //! Returns the lock for this fatbinary access
-  amd::Monitor& FatBinaryLock() { return fb_lock_; }
+  std::recursive_mutex& FatBinaryLock() { return fb_lock_; }
 
  private:
   void ReleaseImageAndFile();
@@ -86,7 +86,7 @@ class FatBinaryInfo {
   std::vector<amd::Program*> dev_programs_;  //!< Program info per Device
 
   std::shared_ptr<UniqueFD> ufd_;                         //!< Unique file descriptor
-  amd::Monitor fb_lock_{true};                            //!< Lock for the fat binary access
+  std::recursive_mutex fb_lock_;                          //!< Lock for the fat binary access
   std::unordered_set<const void*> code_obj_allocations_;  //!< Track allocations for code objects
 };
 

--- a/projects/clr/hipamd/src/hip_global.cpp
+++ b/projects/clr/hipamd/src/hip_global.cpp
@@ -101,8 +101,7 @@ DeviceVar::~DeviceVar() {
 }
 
 // Device Functions
-DeviceFunc::DeviceFunc(std::string name, hipModule_t hmod)
-    : dflock_("function lock"), name_(name), kernel_(nullptr) {
+DeviceFunc::DeviceFunc(std::string name, hipModule_t hmod) : name_(name), kernel_(nullptr) {
   amd::Program* program = as_amd(reinterpret_cast<cl_program>(hmod));
 
   const amd::Symbol* symbol = program->findSymbol(name.c_str());
@@ -153,7 +152,7 @@ hipError_t Function::getStatFunc(hipFunction_t* hfunc, int deviceId) {
     *hfunc = dFunc_[deviceId]->asHipFunction();
     return hipSuccess;
   }
-  amd::ScopedLock lock((*modules_)->FatBinaryLock());
+  std::scoped_lock lock((*modules_)->FatBinaryLock());
   // Check for the compiled kernel again, to make sure only one thread does compilation
   if (dFunc_[deviceId] != nullptr) {
     *hfunc = dFunc_[deviceId]->asHipFunction();

--- a/projects/clr/hipamd/src/hip_global.hpp
+++ b/projects/clr/hipamd/src/hip_global.hpp
@@ -45,7 +45,7 @@ class DeviceFunc {
   DeviceFunc(std::string name, hipModule_t hmod);
   ~DeviceFunc();
 
-  amd::Monitor dflock_;
+  std::recursive_mutex dflock_;
 
   // Converts DeviceFunc to hipFunction_t(used by app) and vice versa.
   hipFunction_t asHipFunction() { return reinterpret_cast<hipFunction_t>(this); }

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -1630,7 +1630,7 @@ hipError_t hipGraphExecDestroy(hipGraphExec_t pGraphExec) {
   }
   hip::GraphExec* ge = reinterpret_cast<hip::GraphExec*>(pGraphExec);
   ge->release();
-  amd::ScopedLock lock(GraphExec::graphExecSetLock_);
+  std::scoped_lock lock(GraphExec::graphExecSetLock_);
   GraphExec::graphExecSet_.erase(ge);
   HIP_RETURN(hipSuccess);
 }

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -62,10 +62,10 @@ amd::Monitor Graph::graphSetLock_{};
 std::unordered_set<GraphExec*> GraphExec::graphExecSet_;
 // Guards global exec graph set
 // we have graphExec object as part of child graph and we need recursive lock
-amd::Monitor GraphExec::graphExecSetLock_(true);
+std::recursive_mutex GraphExec::graphExecSetLock_;
 // Serialize the creation of internal streams from multiple threads, ensuring that each stream is
 // mapped to different HSA queues.
-amd::Monitor GraphExec::graphExecStreamCreateLock_(true);
+std::recursive_mutex GraphExec::graphExecStreamCreateLock_;
 std::unordered_set<UserObject*> UserObject::ObjectSet_;
 // Guards global user object
 amd::Monitor UserObject::UserObjectLock_{};
@@ -808,7 +808,7 @@ Graph* Graph::clone() const {
 
 // ================================================================================================
 bool GraphExec::isGraphExecValid(GraphExec* pGraphExec) {
-  amd::ScopedLock lock(graphExecSetLock_);
+  std::scoped_lock lock(graphExecSetLock_);
   if (graphExecSet_.find(pGraphExec) == graphExecSet_.end()) {
     return false;
   }
@@ -817,7 +817,7 @@ bool GraphExec::isGraphExecValid(GraphExec* pGraphExec) {
 
 // ================================================================================================
 hipError_t GraphExec::CreateStreams(uint32_t num_streams, int devId) {
-  amd::ScopedLock lock(graphExecStreamCreateLock_);
+  std::scoped_lock lock(graphExecStreamCreateLock_);
 
   if (num_streams == 0) {
     ClPrint(amd::LOG_WARNING, amd::LOG_CODE,

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -948,12 +948,12 @@ class Graph {
 class GraphExec : public amd::ReferenceCountedObject, public Graph {
  public:
   static std::unordered_set<GraphExec*> graphExecSet_;
-  static amd::Monitor graphExecSetLock_;
-  static amd::Monitor graphExecStreamCreateLock_;
+  static std::recursive_mutex graphExecSetLock_;
+  static std::recursive_mutex graphExecStreamCreateLock_;
   bool graph_dumped_ = false;
   GraphExec(uint64_t flags = 0)
       : ReferenceCountedObject(), Graph(hip::getCurrentDevice()), flags_(flags) {
-    amd::ScopedLock lock(graphExecSetLock_);
+    std::scoped_lock lock(graphExecSetLock_);
     graphExecSet_.insert(this);
   }
 
@@ -1216,7 +1216,7 @@ class GraphKernelNode : public GraphNode {
     for (auto& command : commands_) {
       hipFunction_t func = getFunc(kernelParams_, dev_id_);
       hip::DeviceFunc* function = hip::DeviceFunc::asFunction(func);
-      amd::ScopedLock lock(function->dflock_);
+      std::scoped_lock lock(function->dflock_);
       command->enqueue();
       command->release();
     }
@@ -1475,7 +1475,7 @@ class GraphKernelNode : public GraphNode {
       return hipErrorInvalidDeviceFunction;
     }
     hip::DeviceFunc* function = hip::DeviceFunc::asFunction(func);
-    amd::ScopedLock lock(function->dflock_);
+    std::scoped_lock lock(function->dflock_);
     status = validateKernelParams(&kernelParams_, func, dev_id_);
     if (hipSuccess != status) {
       return status;

--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -286,41 +286,42 @@ public:
     enum Priority : int { High = -1, Normal = 0, Low = 1 };
 
   private:
-    mutable amd::Monitor lock_;
-    Device* device_;
-    Priority priority_;
-    unsigned int flags_;
-    bool null_;
-    const std::vector<uint32_t> cuMask_;
-    uint64_t stream_id_;
+   mutable std::recursive_mutex lock_;
+   Device* device_;
+   Priority priority_;
+   unsigned int flags_;
+   bool null_;
+   const std::vector<uint32_t> cuMask_;
+   uint64_t stream_id_;
 
-    /// Stream capture related parameters
+   /// Stream capture related parameters
 
-    /// Current capture status of the stream
-    hipStreamCaptureStatus captureStatus_;
-    /// Graph that is constructed with capture
-    hip::Graph* pCaptureGraph_;
-    /// Based on mode stream capture places restrictions on API calls that can be made within or
-    /// concurrently
-    hipStreamCaptureMode captureMode_{hipStreamCaptureModeGlobal};
-    bool originStream_;
-    /// Origin sream has no parent. Parent stream for the derived captured streams with event
-    /// dependencies
-    hipStream_t parentStream_ = nullptr;
-    /// Last graph node captured in the stream
-    std::vector<hip::GraphNode*> lastCapturedNodes_;
-    /// dependencies removed via API hipStreamUpdateCaptureDependencies
-    std::vector<hip::GraphNode*> removedDependencies_;
-    /// Derived streams/Paralell branches from the origin stream
-    std::vector<hipStream_t> parallelCaptureStreams_;
-    /// Capture events
-    std::unordered_set<hipEvent_t> captureEvents_;
-    unsigned long long captureID_;
+   /// Current capture status of the stream
+   hipStreamCaptureStatus captureStatus_;
+   /// Graph that is constructed with capture
+   hip::Graph* pCaptureGraph_;
+   /// Based on mode stream capture places restrictions on API calls that can be made within or
+   /// concurrently
+   hipStreamCaptureMode captureMode_{hipStreamCaptureModeGlobal};
+   bool originStream_;
+   /// Origin sream has no parent. Parent stream for the derived captured streams with event
+   /// dependencies
+   hipStream_t parentStream_ = nullptr;
+   /// Last graph node captured in the stream
+   std::vector<hip::GraphNode*> lastCapturedNodes_;
+   /// dependencies removed via API hipStreamUpdateCaptureDependencies
+   std::vector<hip::GraphNode*> removedDependencies_;
+   /// Derived streams/Paralell branches from the origin stream
+   std::vector<hipStream_t> parallelCaptureStreams_;
+   /// Capture events
+   std::unordered_set<hipEvent_t> captureEvents_;
+   unsigned long long captureID_;
 
-    static inline CommandQueue::Priority convertToQueuePriority(Priority p) {
-      return p == Priority::High ? amd::CommandQueue::Priority::High : p == Priority::Low ?
-                    amd::CommandQueue::Priority::Low : amd::CommandQueue::Priority::Normal;
-    }
+   static inline CommandQueue::Priority convertToQueuePriority(Priority p) {
+     return p == Priority::High  ? amd::CommandQueue::Priority::High
+            : p == Priority::Low ? amd::CommandQueue::Priority::Low
+                                 : amd::CommandQueue::Priority::Normal;
+   }
     /// Generates unique stream Id for the lifetime of the process
     uint64_t GenerateStreamId() {
       static std::atomic<uint64_t> uniqueId{0};
@@ -343,7 +344,7 @@ public:
     /// Returns if stream is null stream
     bool Null() const { return null_; }
     /// Returns the lock object for the current stream
-    amd::Monitor& Lock() const { return lock_; }
+    std::recursive_mutex& Lock() const { return lock_; }
     /// Returns the creation flags for the current stream
     unsigned int Flags() const { return flags_; }
     /// Returns the priority for the current stream
@@ -432,10 +433,10 @@ public:
     /// Get Capture ID
     unsigned long long GetCaptureID() { return captureID_; }
     void SetCaptureEvent(hipEvent_t e) {
-      amd::ScopedLock lock(lock_);
+      std::scoped_lock lock(lock_);
       captureEvents_.emplace(e); }
     bool IsEventCaptured(hipEvent_t e) {
-      amd::ScopedLock lock(lock_);
+      std::scoped_lock lock(lock_);
       auto it = captureEvents_.find(e);
       if (it != captureEvents_.end()) {
         return true;
@@ -443,7 +444,7 @@ public:
       return false;
     }
     void EraseCaptureEvent(hipEvent_t e) {
-      amd::ScopedLock lock(lock_);
+      std::scoped_lock lock(lock_);
       auto it = captureEvents_.find(e);
       if (it != captureEvents_.end()) {
         captureEvents_.erase(it);
@@ -504,7 +505,7 @@ public:
   /// HIP Device class
   class Device : public amd::ReferenceCountedObject {
     // Device lock
-    amd::Monitor lock_{true};
+    std::recursive_mutex lock_;
     // Guards device stream set
     std::shared_mutex streamSetLock;
     std::unordered_set<hip::Stream*> streamSet;
@@ -557,7 +558,7 @@ public:
     void release() const { context_->release(); }
     const std::vector<amd::Device*>& devices() const { return context_->devices(); }
     hipError_t EnablePeerAccess(int peerDeviceId){
-      amd::ScopedLock lock(lock_);
+      std::scoped_lock lock(lock_);
       bool found = (std::find(userEnabledPeers.begin(), userEnabledPeers.end(), peerDeviceId) != userEnabledPeers.end());
       if (found) {
         return hipErrorPeerAccessAlreadyEnabled;
@@ -566,7 +567,7 @@ public:
       return hipSuccess;
     }
     hipError_t DisablePeerAccess(int peerDeviceId) {
-      amd::ScopedLock lock(lock_);
+      std::scoped_lock lock(lock_);
       bool found = (std::find(userEnabledPeers.begin(), userEnabledPeers.end(), peerDeviceId) != userEnabledPeers.end());
       if (found) {
         userEnabledPeers.remove(peerDeviceId);
@@ -587,7 +588,7 @@ public:
     }
 
     bool GetActiveStatus() {
-      amd::ScopedLock lock(lock_);
+      std::scoped_lock lock(lock_);
       /// Either stream is active or device is active
       if (isActive_) return true;
       if (existsActiveStreamForDevice()) {

--- a/projects/clr/hipamd/src/hip_log.cpp
+++ b/projects/clr/hipamd/src/hip_log.cpp
@@ -6,7 +6,7 @@ namespace hip {
 
 hipError_t hipExtEnableLogging() {
   HIP_INIT_API(hipExtEnableLogging);
-  amd::ScopedLock lock(PlatformState::Instance().GetLogLock());
+  std::scoped_lock lock(PlatformState::Instance().GetLogLock());
   AMD_LOG_LEVEL = PlatformState::Instance().log_level_;
   AMD_LOG_MASK = PlatformState::Instance().log_mask_;
   HIP_RETURN(hipSuccess);
@@ -14,18 +14,18 @@ hipError_t hipExtEnableLogging() {
 
 hipError_t hipExtDisableLogging() {
   HIP_INIT_API(hipExtDisableLogging);
-  amd::ScopedLock lock(PlatformState::Instance().GetLogLock());
+  std::scoped_lock lock(PlatformState::Instance().GetLogLock());
   AMD_LOG_LEVEL = 0;
   HIP_RETURN(hipSuccess);
 }
 
 hipError_t hipExtSetLoggingParams(size_t log_level, size_t log_size, size_t log_mask) {
   HIP_INIT_API(hipExtSetLoggingParams, log_level, log_size, log_mask);
-  amd::ScopedLock lock(PlatformState::Instance().GetLogLock());
+  std::scoped_lock lock(PlatformState::Instance().GetLogLock());
   // Store logging parameters for later activation
   PlatformState::Instance().log_level_ = log_level;
   PlatformState::Instance().log_size_ = log_size;
   PlatformState::Instance().log_mask_ = log_mask;
   HIP_RETURN(hipSuccess);
 }
-} // namespace::hip
+}  // namespace hip

--- a/projects/clr/hipamd/src/hip_mempool_impl.cpp
+++ b/projects/clr/hipamd/src/hip_mempool_impl.cpp
@@ -179,7 +179,7 @@ void Heap::SetAccess(hip::Device* device, bool enable) {
 
 // ================================================================================================
 void* MemoryPool::AllocateMemory(size_t size, Stream* stream, void* dptr) {
-  amd::ScopedLock lock(lock_pool_ops_);
+  std::scoped_lock lock(lock_pool_ops_);
 
   void* dev_ptr = nullptr;
   MemoryTimestamp ts;
@@ -246,7 +246,7 @@ void* MemoryPool::AllocateMemory(size_t size, Stream* stream, void* dptr) {
 // ================================================================================================
 bool MemoryPool::FreeMemory(amd::Memory* memory, Stream* stream, Event* event) {
   {
-    amd::ScopedLock lock(lock_pool_ops_);
+    std::scoped_lock lock(lock_pool_ops_);
 
     if (!state_.use_vm_heap_ && memory->getUserData().phys_mem_obj != nullptr) {
       memory = memory->getUserData().phys_mem_obj;
@@ -327,28 +327,28 @@ void MemoryPool::ReleaseAllMemory() {
 
 // ================================================================================================
 void MemoryPool::ReleaseFreedMemory() {
-  amd::ScopedLock lock(lock_pool_ops_);
+  std::scoped_lock lock(lock_pool_ops_);
 
   free_heap_.ReleaseAllMemory();
 }
 
 // ================================================================================================
 void MemoryPool::RemoveStream(Stream* stream) {
-  amd::ScopedLock lock(lock_pool_ops_);
+  std::scoped_lock lock(lock_pool_ops_);
 
   free_heap_.RemoveStream(stream);
 }
 
 // ================================================================================================
 void MemoryPool::TrimTo(size_t min_bytes_to_hold) {
-  amd::ScopedLock lock(lock_pool_ops_);
+  std::scoped_lock lock(lock_pool_ops_);
 
   free_heap_.ReleaseAllMemory(min_bytes_to_hold);
 }
 
 // ================================================================================================
 hipError_t MemoryPool::SetAttribute(hipMemPoolAttr attr, void* value) {
-  amd::ScopedLock lock(lock_pool_ops_);
+  std::scoped_lock lock(lock_pool_ops_);
   uint64_t reset;
 
   switch (attr) {
@@ -400,7 +400,7 @@ hipError_t MemoryPool::SetAttribute(hipMemPoolAttr attr, void* value) {
 
 // ================================================================================================
 hipError_t MemoryPool::GetAttribute(hipMemPoolAttr attr, void* value) {
-  amd::ScopedLock lock(lock_pool_ops_);
+  std::scoped_lock lock(lock_pool_ops_);
 
   switch (attr) {
     case hipMemPoolReuseFollowEventDependencies:
@@ -445,7 +445,7 @@ hipError_t MemoryPool::GetAttribute(hipMemPoolAttr attr, void* value) {
 
 // ================================================================================================
 void MemoryPool::SetAccess(hip::Device* device, hipMemAccessFlags flags) {
-  amd::ScopedLock lock(lock_pool_ops_);
+  std::scoped_lock lock(lock_pool_ops_);
 
   // Check if the requested device is the pool device where memory was allocated
   if (device == device_) {
@@ -475,7 +475,7 @@ void MemoryPool::SetAccess(hip::Device* device, hipMemAccessFlags flags) {
 
 // ================================================================================================
 void MemoryPool::GetAccess(hip::Device* device, hipMemAccessFlags* flags) {
-  amd::ScopedLock lock(lock_pool_ops_);
+  std::scoped_lock lock(lock_pool_ops_);
 
   // Current pool device has full access to memory allocation
   *flags = (device == device_) ? hipMemAccessFlagsProtReadWrite : hipMemAccessFlagsProtNone;
@@ -495,7 +495,7 @@ void MemoryPool::FreeAllMemory(Stream* stream) {
 
 // ================================================================================================
 amd::Os::FileDesc MemoryPool::Export() {
-  amd::ScopedLock lock(lock_pool_ops_);
+  std::scoped_lock lock(lock_pool_ops_);
   if (shared_ != nullptr) {
     return shared_->handle_;
   }
@@ -524,7 +524,7 @@ amd::Os::FileDesc MemoryPool::Export() {
 
 // ================================================================================================
 bool MemoryPool::Import(amd::Os::FileDesc handle) {
-  amd::ScopedLock lock(lock_pool_ops_);
+  std::scoped_lock lock(lock_pool_ops_);
   bool result = false;
   auto shared = reinterpret_cast<SharedMemPool*>(
       amd::Os::OpenIpcMemory(nullptr, handle, sizeof(SharedMemPool)));

--- a/projects/clr/hipamd/src/hip_mempool_impl.hpp
+++ b/projects/clr/hipamd/src/hip_mempool_impl.hpp
@@ -204,7 +204,6 @@ class MemoryPool : public amd::ReferenceCountedObject, amd::VmHeapArray {
                     [this]() -> amd::HostQueue& { return *device_->NullStream(false); }),
         busy_heap_(device, *this),
         free_heap_(device, *this),
-        lock_pool_ops_(true),
         device_(device),
         shared_(nullptr),
         max_total_size_(0) {
@@ -270,7 +269,7 @@ class MemoryPool : public amd::ReferenceCountedObject, amd::VmHeapArray {
 
   /// Add a safe stream for quick looks-ups if event dependencies option is enabled
   void AddSafeStream(Stream* event_stream, Stream* wait_stream) {
-    amd::ScopedLock lock(lock_pool_ops_);
+    std::scoped_lock lock(lock_pool_ops_);
     if (EventDependencies()) {
       free_heap_.AddSafeStream(event_stream, wait_stream);
     }
@@ -335,7 +334,7 @@ class MemoryPool : public amd::ReferenceCountedObject, amd::VmHeapArray {
   } state_;
 
   hipMemPoolProps properties_;  //!< Properties of the memory pool
-  amd::Monitor lock_pool_ops_;  //!< Access to the pool must be lock protected
+  std::recursive_mutex lock_pool_ops_;  //!< Access to the pool must be lock protected
   std::map<hip::Device*, hipMemAccessFlags>
       access_map_;  //!< Map of access to the pool from devices
 

--- a/projects/clr/hipamd/src/hip_module.cpp
+++ b/projects/clr/hipamd/src/hip_module.cpp
@@ -20,6 +20,7 @@
 
 #include <hip/hip_runtime.h>
 #include <fstream>
+#include <optional>
 
 #include "hip_internal.hpp"
 #include "platform/ndrange.hpp"
@@ -469,7 +470,10 @@ hipError_t ihipModuleLaunchKernel(hipFunction_t f, amd::LaunchParams& launch_par
   }
   hip::DeviceFunc* function = hip::DeviceFunc::asFunction(f);
   amd::Kernel* kernel = function->kernel();
-  amd::ScopedLock lock(DEBUG_HIP_KERNARG_COPY_OPT ? nullptr : &function->dflock_);
+  std::optional<std::scoped_lock<std::recursive_mutex>> lock;
+  if (!DEBUG_HIP_KERNARG_COPY_OPT) {
+    lock.emplace(function->dflock_);
+  }
 
   hipError_t status =
       ihipLaunchKernel_validate(f, launch_params, kernelParams, extra, deviceId, params);

--- a/projects/clr/hipamd/src/hip_platform.cpp
+++ b/projects/clr/hipamd/src/hip_platform.cpp
@@ -806,7 +806,7 @@ extern "C"
 
 // ================================================================================================
 void PlatformState::Init() {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
   if (initialized_ || g_devices.empty()) {
     return;
   }
@@ -832,7 +832,7 @@ hipError_t PlatformState::LoadModule(hipModule_t* module, const char* fname, con
   *module = dynCo->getModule();
   assert(*module != nullptr);
 
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
   const auto [it, inserted] = dynCO_map_.try_emplace(*module, dynCo.get());
   if (!inserted) {
     return hipErrorAlreadyMapped;
@@ -844,7 +844,7 @@ hipError_t PlatformState::LoadModule(hipModule_t* module, const char* fname, con
 
 // ================================================================================================
 hipError_t PlatformState::UnloadModule(hipModule_t hmod) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
 
   if (auto it = dynCO_map_.find(hmod); it == dynCO_map_.end()) {
     return hipErrorNotFound;
@@ -872,7 +872,7 @@ hipError_t PlatformState::GetDynFunc(hipFunction_t* hfunc, hipModule_t hmod,
     return hipErrorNotFound;
   }
 
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
 
   const auto it = dynCO_map_.find(hmod);
   if (it == dynCO_map_.end()) {
@@ -885,7 +885,7 @@ hipError_t PlatformState::GetDynFunc(hipFunction_t* hfunc, hipModule_t hmod,
 
 // ================================================================================================
 hipError_t PlatformState::GetFuncCount(unsigned int* count, hipModule_t hmod) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
 
   const auto it = dynCO_map_.find(hmod);
   if (it == dynCO_map_.end()) {
@@ -897,7 +897,7 @@ hipError_t PlatformState::GetFuncCount(unsigned int* count, hipModule_t hmod) {
 
 // ================================================================================================
 bool PlatformState::IsValidDynFunc(const void* hfunc) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
   return std::any_of(dynCO_map_.begin(), dynCO_map_.end(),
                      [hfunc](const auto& entry) { return entry.second->isValidDynFunc(hfunc); });
 }
@@ -905,7 +905,7 @@ bool PlatformState::IsValidDynFunc(const void* hfunc) {
 // ================================================================================================
 hipError_t PlatformState::GetDynGlobalVar(const char* hostVar, hipModule_t hmod,
                                           hipDeviceptr_t* dev_ptr, size_t* size_ptr) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
 
   if (hostVar == nullptr) {
     return hipErrorInvalidValue;
@@ -937,7 +937,7 @@ hipError_t PlatformState::GetDynGlobalVar(const char* hostVar, hipModule_t hmod,
 // ================================================================================================
 hipError_t PlatformState::RegisterTexRef(textureReference* texRef, hipModule_t hmod,
                                          std::string name) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
   texRef_map_.insert(std::make_pair(texRef, std::make_pair(hmod, name)));
   return hipSuccess;
 }
@@ -945,7 +945,7 @@ hipError_t PlatformState::RegisterTexRef(textureReference* texRef, hipModule_t h
 // ================================================================================================
 hipError_t PlatformState::GetDynTexGlobalVar(textureReference* texRef, hipDeviceptr_t* dev_ptr,
                                              size_t* size_ptr) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
 
   const auto tex_it = texRef_map_.find(texRef);
   if (tex_it == texRef_map_.end()) {
@@ -971,7 +971,7 @@ hipError_t PlatformState::GetDynTexGlobalVar(textureReference* texRef, hipDevice
 // ================================================================================================
 hipError_t PlatformState::GetDynTexRef(const char* hostVar, hipModule_t hmod,
                                        textureReference** texRef) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
 
   const auto it = dynCO_map_.find(hmod);
   if (it == dynCO_map_.end()) {
@@ -1013,7 +1013,7 @@ void PlatformState::PopExec(ihipExec_t& exec) {
 
 // ================================================================================================
 std::shared_ptr<UniqueFD> PlatformState::GetUniqueFileHandle(const std::string& file_path) {
-  amd::ScopedLock lock(ufd_lock_);
+  std::scoped_lock lock(ufd_lock_);
 
   auto it = ufd_map_.find(file_path);
   if (it != ufd_map_.end()) {
@@ -1034,7 +1034,7 @@ std::shared_ptr<UniqueFD> PlatformState::GetUniqueFileHandle(const std::string& 
 
 // ================================================================================================
 bool PlatformState::CloseUniqueFileHandle(const std::shared_ptr<UniqueFD>& ufd) {
-  amd::ScopedLock lock(ufd_lock_);
+  std::scoped_lock lock(ufd_lock_);
 
   // if use_count is 2, then there is 1 entry in the map and the current entry is the last close.
   if (ufd.use_count() == 2) {
@@ -1048,7 +1048,7 @@ bool PlatformState::CloseUniqueFileHandle(const std::shared_ptr<UniqueFD>& ufd) 
 
 // ================================================================================================
 void* PlatformState::GetDynamicLibraryHandle() {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
 
   if (dynamicLibraryHandle_ != nullptr) {
     return dynamicLibraryHandle_;
@@ -1066,7 +1066,7 @@ void* PlatformState::GetDynamicLibraryHandle() {
 
 // ================================================================================================
 void PlatformState::SetDynamicLibraryHandle(void* handle) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
   dynamicLibraryHandle_ = handle;
 }
 

--- a/projects/clr/hipamd/src/hip_platform.hpp
+++ b/projects/clr/hipamd/src/hip_platform.hpp
@@ -69,7 +69,7 @@ class PlatformState {
   bool CloseUniqueFileHandle(const std::shared_ptr<UniqueFD>& ufd);
 
   // Logging lock accessor
-  amd::Monitor& GetLogLock() { return lg_lock_; }
+  std::recursive_mutex& GetLogLock() { return lg_lock_; }
 
   // Friend functions for logging access
   friend hipError_t hipExtEnableLogging();
@@ -77,17 +77,17 @@ class PlatformState {
   friend hipError_t hipExtSetLoggingParams(size_t log_level, size_t log_size, size_t log_mask);
 
   inline bool RegisterLibraryFunction(const hipKernel_t f, const hipLibrary_t l) {
-    amd::ScopedLock lock(lock_);
+    std::scoped_lock lock(lock_);
     return library_functions_.try_emplace(f, l).second;
   }
 
   inline bool UnregisterLibraryFunction(const hipKernel_t f) {
-    amd::ScopedLock lock(lock_);
+    std::scoped_lock lock(lock_);
     return library_functions_.erase(f) > 0;
   }
 
   inline bool GetFunctionLibrary(const hipKernel_t f, hipLibrary_t* lib) {
-    amd::ScopedLock lock(lock_);
+    std::scoped_lock lock(lock_);
     auto it = library_functions_.find(f);
     if (it != library_functions_.end()) {
       *lib = it->second;
@@ -103,9 +103,9 @@ class PlatformState {
   PlatformState() : statCO_(*this), log_level_(0), log_size_(0), log_mask_(0) {}
   ~PlatformState() {}
 
-  amd::Monitor lock_{true};         //!< Guards PlatformState globals
-  amd::Monitor ufd_lock_{true};     //!< Unique FD Store Lock
-  amd::Monitor lg_lock_{true};      //!< Lock for logging operations
+  std::recursive_mutex lock_;       //!< Guards PlatformState globals
+  std::recursive_mutex ufd_lock_;   //!< Unique FD Store Lock
+  std::recursive_mutex lg_lock_;    //!< Lock for logging operations
   static PlatformState* platform_;  //!< Singleton instance
 
   //! Dynamic Code Object map, keyin module to get the corresponding object

--- a/projects/clr/hipamd/src/hip_stream.cpp
+++ b/projects/clr/hipamd/src/hip_stream.cpp
@@ -33,7 +33,6 @@ Stream::Stream(hip::Device* dev, Priority p, unsigned int f, bool null_stream,
                const std::vector<uint32_t>& cuMask, hipStreamCaptureStatus captureStatus)
     : amd::HostQueue(*dev->asContext(), *dev->devices()[0], 0, amd::CommandQueue::RealTimeDisabled,
                      convertToQueuePriority(p), cuMask, null_stream),
-      lock_("Stream Callback lock"),
       device_(dev),
       priority_(p),
       flags_(f),

--- a/projects/clr/hipamd/src/hiprtc/hiprtcInternal.cpp
+++ b/projects/clr/hipamd/src/hiprtc/hiprtcInternal.cpp
@@ -239,7 +239,7 @@ void RTCCompileProgram::stripNamedExpression(std::string& strippedName) {
 }
 
 bool RTCCompileProgram::trackMangledName(std::string& name) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
 
   if (name.size() == 0) return false;
 

--- a/projects/clr/rocclr/device/blit.hpp
+++ b/projects/clr/rocclr/device/blit.hpp
@@ -224,7 +224,7 @@ class BlitManager : public amd::HeapObject {
   void enableSynchronization() { syncOperation_ = true; }
 
   //! Returns Xfer queue lock
-  virtual amd::Monitor* lockXfer() const { return nullptr; }
+  virtual std::recursive_mutex* lockXfer() const { return nullptr; }
 
   virtual bool initHeap(device::Memory* heap_to_initialize, device::Memory* initial_blocks,
                         uint heap_size, uint number_of_initial_blocks) const = 0;

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -87,7 +87,7 @@ static_assert(static_cast<uint32_t>(device::Memory::MemAccess::kMemAccessReadWri
 
 namespace amd {
 
-amd::Monitor Device::lockP2P_("Lock P2P ON/OFF");
+std::recursive_mutex Device::lockP2P_;
 std::pair<const Isa*, const Isa*> Isa::supportedIsas() {
   constexpr amd::Isa::Feature NONE = amd::Isa::Feature::Unsupported;
   constexpr amd::Isa::Feature ANY = amd::Isa::Feature::Any;
@@ -346,7 +346,7 @@ AppProfile Device::appProfile_;
 
 Context* Device::glb_ctx_ = nullptr;
 // P2P Staging Lock
-Monitor Device::p2p_stage_ops_(true);
+std::recursive_mutex Device::p2p_stage_ops_;
 Memory* Device::p2p_stage_ = nullptr;
 
 cl_int Device::gpu_error_ = CL_SUCCESS;
@@ -818,7 +818,7 @@ bool Device::create(const Isa& isa) {
   assert(!vaCacheAccess_ && !vaCacheMap_);
   isa_ = &isa;
   // VA Cache Ops Lock
-  vaCacheAccess_ = new amd::Monitor(true);
+  vaCacheAccess_ = new std::recursive_mutex();
   if (nullptr == vaCacheAccess_) {
     return false;
   }
@@ -862,7 +862,7 @@ void Device::addVACache(device::Memory* memory) const {
   // Make sure system memory has direct access
   if (memory->isHostMemDirectAccess()) {
     // VA cache access must be serialised
-    amd::ScopedLock lk(*vaCacheAccess_);
+    std::scoped_lock lk(*vaCacheAccess_);
     void* start = memory->owner()->getHostMem();
     size_t offset;
     device::Memory* doubleMap = findMemoryFromVA(start, &offset);
@@ -881,7 +881,7 @@ void Device::removeVACache(const device::Memory* memory) const {
   // Make sure system memory has direct access
   if (memory->isHostMemDirectAccess() && memory->owner()) {
     // VA cache access must be serialised
-    amd::ScopedLock lk(*vaCacheAccess_);
+    std::scoped_lock lk(*vaCacheAccess_);
     void* start = memory->owner()->getHostMem();
     vaCacheMap_->erase(reinterpret_cast<uintptr_t>(start));
   }
@@ -889,7 +889,7 @@ void Device::removeVACache(const device::Memory* memory) const {
 
 device::Memory* Device::findMemoryFromVA(const void* ptr, size_t* offset) const {
   // VA cache access must be serialised
-  amd::ScopedLock lk(*vaCacheAccess_);
+  std::scoped_lock lk(*vaCacheAccess_);
 
   uintptr_t key = reinterpret_cast<uintptr_t>(ptr);
   auto it = vaCacheMap_->upper_bound(reinterpret_cast<uintptr_t>(ptr));
@@ -982,7 +982,7 @@ bool Device::getDeviceIDs(cl_device_type deviceType, uint32_t numEntries, cl_dev
 
 bool Device::enableP2P(amd::Device* ptrDev) {
   assert(ptrDev != nullptr);
-  amd::ScopedLock lock(lockP2P_);
+  std::scoped_lock lock(lockP2P_);
   Device* peerDev = static_cast<Device*>(ptrDev);
   if (std::find(enabled_p2p_devices_.begin(), enabled_p2p_devices_.end(), peerDev) ==
       enabled_p2p_devices_.end()) {
@@ -995,7 +995,7 @@ bool Device::enableP2P(amd::Device* ptrDev) {
 
 bool Device::disableP2P(amd::Device* ptrDev) {
   assert(ptrDev != nullptr);
-  amd::ScopedLock lock(lockP2P_);
+  std::scoped_lock lock(lockP2P_);
   Device* peerDev = static_cast<Device*>(ptrDev);
   // if device is present then remove
   auto it = std::find(enabled_p2p_devices_.begin(), enabled_p2p_devices_.end(), peerDev);
@@ -1254,7 +1254,7 @@ void Memory::saveMapInfo(const void* mapAddress, const amd::Coord3D origin,
                          const amd::Coord3D region, uint mapFlags, bool entire,
                          amd::Image* baseMip) {
   // Map/Unmap must be serialized.
-  amd::ScopedLock lock(owner()->lockMemoryOps());
+  std::scoped_lock lock(owner()->lockMemoryOps());
 
   WriteMapInfo info = {};
   WriteMapInfo* pInfo = &info;

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -879,7 +879,7 @@ class Memory : public amd::HeapObject {
 
   const WriteMapInfo* writeMapInfo(const void* mapAddress) const {
     // Unmap must be serialized.
-    amd::ScopedLock lock(owner()->lockMemoryOps());
+    std::scoped_lock lock(owner()->lockMemoryOps());
 
     auto it = writeMapInfo_.find(mapAddress);
     if (it == writeMapInfo_.end()) {
@@ -897,7 +897,7 @@ class Memory : public amd::HeapObject {
   //! Clear memory object as mapped read only
   void clearUnmapInfo(const void* mapAddress) {
     // Unmap must be serialized.
-    amd::ScopedLock lock(owner()->lockMemoryOps());
+    std::scoped_lock lock(owner()->lockMemoryOps());
     auto it = writeMapInfo_.find(mapAddress);
     if (it == writeMapInfo_.end()) {
       // Get the first map info
@@ -1246,12 +1246,7 @@ class ThreadTrace : public amd::HeapObject {
 class VirtualDevice : public amd::ReferenceCountedObject {
  public:
   //! Construct a new virtual device for the given physical device.
-  VirtualDevice(amd::Device& device)
-      : device_(device),
-        blitMgr_(NULL),
-        execution_(true) /* Virtual device execution lock */
-        ,
-        index_(0) {}
+  VirtualDevice(amd::Device& device) : device_(device), blitMgr_(NULL), index_(0) {}
 
   //! Destroy this virtual device.
   virtual ~VirtualDevice() {}
@@ -1304,7 +1299,7 @@ class VirtualDevice : public amd::ReferenceCountedObject {
   device::BlitManager& blitMgr() const { return *blitMgr_; }
 
   //! Returns the monitor object for execution access by VirtualGPU
-  amd::Monitor& execution() { return execution_; }
+  std::recursive_mutex& execution() { return execution_; }
 
   //! Returns the virtual device unique index
   uint index() const { return index_; }
@@ -1338,7 +1333,7 @@ class VirtualDevice : public amd::ReferenceCountedObject {
  protected:
   device::BlitManager* blitMgr_;  //!< Blit manager
 
-  amd::Monitor execution_;  //!< Lock to serialise access to all device objects
+  std::recursive_mutex execution_;  //!< Lock to serialise access to all device objects
   uint index_;              //!< The virtual device unique index
   mutable std::atomic<uint64_t> queued_async_handlers_ = 0;  //!< Outstanding HSA async handlers
 
@@ -2119,7 +2114,7 @@ class Device : public RuntimeObject {
   amd::Context& GlbCtx() const { return *glb_ctx_; }
 
   //! Lock protect P2P staging operations
-  Monitor& P2PStageOps() const { return p2p_stage_ops_; }
+  std::recursive_mutex& P2PStageOps() const { return p2p_stage_ops_; }
 
   //! Staging buffer for P2P transfer
   Memory* P2PStage() const { return p2p_stage_; }
@@ -2230,7 +2225,7 @@ class Device : public RuntimeObject {
   amd::Context* context_;         //!< Context
 
   static amd::Context* glb_ctx_;              //!< Global context with all devices
-  static amd::Monitor p2p_stage_ops_;         //!< Lock to serialise cache for the P2P resources
+  static std::recursive_mutex p2p_stage_ops_;  //!< Lock to serialise cache for the P2P resources
   static Memory* p2p_stage_;                  //!< Staging resources
   std::vector<Device*> enabled_p2p_devices_;  //!< List of user enabled P2P devices for this device
 
@@ -2255,8 +2250,8 @@ class Device : public RuntimeObject {
 #endif
 
   static std::vector<Device*>* devices_;  //!< All known devices
-  static amd::Monitor lockP2P_;
-  Monitor* vaCacheAccess_;                            //!< Lock to serialize VA caching access
+  static std::recursive_mutex lockP2P_;
+  std::recursive_mutex* vaCacheAccess_;               //!< Lock to serialize VA caching access
   std::map<uintptr_t, device::Memory*>* vaCacheMap_;  //!< VA cache map
   uint32_t index_;                                    //!< Unique device index
 

--- a/projects/clr/rocclr/device/devprogram.cpp
+++ b/projects/clr/rocclr/device/devprogram.cpp
@@ -2147,13 +2147,13 @@ bool Program::getGlobalVarFromCodeObj(std::vector<std::string>* var_names) const
 }
 
 // Init Fini Launch Lock
-amd::Monitor Program::initFiniLock_(true);
+std::recursive_mutex Program::initFiniLock_;
 
 bool Program::runInitFiniKernel(const std::vector<const Kernel*>& kernels) const {
   amd::HostQueue* queue = nullptr;
 
   for (const auto& kernel : kernels) {
-    amd::ScopedLock sl(initFiniLock_);
+    std::scoped_lock sl(initFiniLock_);
 
     if (queue == nullptr) {
       queue = new amd::HostQueue(device_().context(), device_(), 0);

--- a/projects/clr/rocclr/device/devprogram.hpp
+++ b/projects/clr/rocclr/device/devprogram.hpp
@@ -131,7 +131,7 @@ class Program : public amd::HeapObject {
   uint32_t codeObjectVer_;                                              //!< version of code object
   std::map<std::string, amd_comgr_metadata_node_t> kernelMetadataMap_;  //!< Map of kernel metadata
   //! Sanitizer lock - lock when launching init/fini kernels
-  static amd::Monitor initFiniLock_;
+  static std::recursive_mutex initFiniLock_;
 
  public:
   //! Construct a section.

--- a/projects/clr/rocclr/device/pal/palblit.cpp
+++ b/projects/clr/rocclr/device/pal/palblit.cpp
@@ -656,10 +656,7 @@ bool DmaBlitManager::copyImage(device::Memory& srcMemory, device::Memory& dstMem
 }
 
 KernelBlitManager::KernelBlitManager(VirtualGPU& gpu, Setup setup)
-    : DmaBlitManager(gpu, setup),
-      program_(NULL),
-      xferBufferSize_(0),
-      lockXferOps_(true) /* Transfer Ops Lock */ {
+    : DmaBlitManager(gpu, setup), program_(NULL), xferBufferSize_(0) {
   for (uint i = 0; i < BlitTotal; ++i) {
     kernels_[i] = NULL;
   }
@@ -798,7 +795,7 @@ bool KernelBlitManager::copyBufferToImage(device::Memory& srcMemory, device::Mem
                                           const amd::Coord3D& dstOrigin, const amd::Coord3D& size,
                                           bool entire, size_t rowPitch, size_t slicePitch,
                                           amd::CopyMetadata copyMetadata) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
   static const bool CopyRect = false;
   // Flush DMA for ASYNC copy
@@ -1196,7 +1193,7 @@ bool KernelBlitManager::copyImageToBuffer(device::Memory& srcMemory, device::Mem
                                           const amd::Coord3D& dstOrigin, const amd::Coord3D& size,
                                           bool entire, size_t rowPitch, size_t slicePitch,
                                           amd::CopyMetadata copyMetadata) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
   static const bool CopyRect = false;
   // Flush DMA for ASYNC copy
@@ -1517,7 +1514,7 @@ bool KernelBlitManager::copyImage(device::Memory& srcMemory, device::Memory& dst
                                   const amd::Coord3D& srcOrigin, const amd::Coord3D& dstOrigin,
                                   const amd::Coord3D& size, bool entire,
                                   amd::CopyMetadata copyMetadata) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
   Memory* srcView = &gpuMem(srcMemory);
   Memory* dstView = &gpuMem(dstMemory);
@@ -1711,7 +1708,7 @@ bool KernelBlitManager::readImage(device::Memory& srcMemory, void* dstHost,
                                   const amd::Coord3D& origin, const amd::Coord3D& size,
                                   size_t rowPitch, size_t slicePitch, bool entire,
                                   amd::CopyMetadata copyMetadata) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
 
   // Use host copy if memory has direct access or it's persistent
@@ -1761,7 +1758,7 @@ bool KernelBlitManager::writeImage(const void* srcHost, device::Memory& dstMemor
                                    const amd::Coord3D& origin, const amd::Coord3D& size,
                                    size_t rowPitch, size_t slicePitch, bool entire,
                                    amd::CopyMetadata copyMetadata) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
 
   // Use host copy if memory has direct access or it's persistent
@@ -1823,7 +1820,7 @@ bool KernelBlitManager::copyBufferRect(device::Memory& srcMemory, device::Memory
                                        const amd::BufferRect& srcRectIn,
                                        const amd::BufferRect& dstRectIn, const amd::Coord3D& sizeIn,
                                        bool entire, amd::CopyMetadata copyMetadata) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
   bool rejected = false;
 
@@ -1937,7 +1934,7 @@ bool KernelBlitManager::copyBufferRect(device::Memory& srcMemory, device::Memory
 bool KernelBlitManager::readBuffer(device::Memory& srcMemory, void* dstHost,
                                    const amd::Coord3D& origin, const amd::Coord3D& size,
                                    bool entire, amd::CopyMetadata copyMetadata) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
 
   // Use host copy if memory has direct access
@@ -1988,7 +1985,7 @@ bool KernelBlitManager::readBufferRect(device::Memory& srcMemory, void* dstHost,
                                        const amd::BufferRect& bufRect,
                                        const amd::BufferRect& hostRect, const amd::Coord3D& size,
                                        bool entire, amd::CopyMetadata copyMetadata) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
 
   // Use host copy if memory has direct access
@@ -2038,7 +2035,7 @@ bool KernelBlitManager::readBufferRect(device::Memory& srcMemory, void* dstHost,
 bool KernelBlitManager::writeBuffer(const void* srcHost, device::Memory& dstMemory,
                                     const amd::Coord3D& origin, const amd::Coord3D& size,
                                     bool entire, amd::CopyMetadata copyMetadata) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
 
   // Use host copy if memory has direct access or it's persistent
@@ -2092,7 +2089,7 @@ bool KernelBlitManager::writeBufferRect(const void* srcHost, device::Memory& dst
                                         const amd::BufferRect& hostRect,
                                         const amd::BufferRect& bufRect, const amd::Coord3D& size,
                                         bool entire, amd::CopyMetadata copyMetadata) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
 
   // Use host copy if memory has direct access or it's persistent
@@ -2147,7 +2144,7 @@ bool KernelBlitManager::writeBufferRect(const void* srcHost, device::Memory& dst
 bool KernelBlitManager::fillBuffer(device::Memory& memory, const void* pattern, size_t patternSize,
                                    const amd::Coord3D& surface, const amd::Coord3D& origin,
                                    const amd::Coord3D& size, bool entire, bool forceBlit) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
 
   // Use host fill if memory has direct access
@@ -2231,7 +2228,7 @@ bool KernelBlitManager::copyBuffer(device::Memory& srcMemory, device::Memory& ds
                                    const amd::Coord3D& srcOrigin, const amd::Coord3D& dstOrigin,
                                    const amd::Coord3D& sizeIn, bool entire,
                                    amd::CopyMetadata copyMetadata) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
 
   if (!gpuMem(srcMemory).isHostMemDirectAccess() && !gpuMem(dstMemory).isHostMemDirectAccess()) {
@@ -2297,7 +2294,7 @@ bool KernelBlitManager::copyBuffer(device::Memory& srcMemory, device::Memory& ds
 bool KernelBlitManager::fillImage(device::Memory& memory, const void* pattern,
                                   const amd::Coord3D& origin, const amd::Coord3D& size,
                                   bool entire) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
   constexpr size_t kFillImageThreshold = 256 * 256;
 
@@ -2461,7 +2458,7 @@ bool KernelBlitManager::fillImage(device::Memory& memory, const void* pattern,
 // ================================================================================================
 bool KernelBlitManager::streamOpsWrite(device::Memory& memory, uint64_t value, size_t offset,
                                        size_t sizeBytes) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
   uint blitType = StreamOpsWrite;
   size_t dim = 1;
@@ -2492,7 +2489,7 @@ bool KernelBlitManager::streamOpsWrite(device::Memory& memory, uint64_t value, s
 // ================================================================================================
 bool KernelBlitManager::streamOpsWait(device::Memory& memory, uint64_t value, size_t offset,
                                       size_t sizeBytes, uint64_t flags, uint64_t mask) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
   uint blitType = StreamOpsWait;
   size_t dim = 1;
@@ -2557,7 +2554,7 @@ bool KernelBlitManager::initHeap(device::Memory* heap_to_initialize, device::Mem
 
 bool KernelBlitManager::runScheduler(device::Memory& vqueue, device::Memory& params, uint paramIdx,
                                      uint threads) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
 
   size_t globalWorkOffset[1] = {0};
   size_t globalWorkSize[1] = {threads};
@@ -2583,14 +2580,14 @@ bool KernelBlitManager::runScheduler(device::Memory& vqueue, device::Memory& par
 }
 
 void KernelBlitManager::writeRawData(device::Memory& memory, size_t size, const void* data) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   static_cast<pal::Memory&>(memory).writeRawData(gpu(), 0, size, data, false);
 
   synchronize();
 }
 
 bool KernelBlitManager::RunGwsInit(uint32_t value) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
 
   if (dev().settings().gwsInitSupported_ == false) {
     LogError("GWS Init is not supported on this target");

--- a/projects/clr/rocclr/device/pal/palblit.hpp
+++ b/projects/clr/rocclr/device/pal/palblit.hpp
@@ -430,7 +430,7 @@ class KernelBlitManager : public DmaBlitManager {
   bool RunGwsInit(uint32_t value  //!< Initial value for GWS resource
   ) const;
 
-  virtual amd::Monitor* lockXfer() const { return &lockXferOps_; }
+  virtual std::recursive_mutex* lockXfer() const { return &lockXferOps_; }
 
   //! Stream memory write operation - Write a 'value' at 'memory'.
   virtual bool streamOpsWrite(device::Memory& memory,  //!< Memory to write the 'value'
@@ -504,7 +504,7 @@ class KernelBlitManager : public DmaBlitManager {
   amd::Kernel* kernels_[BlitTotal];           //!< GPU kernels for blit
   amd::Memory* xferBuffers_[MaxXferBuffers];  //!< Transfer buffers for images
   size_t xferBufferSize_;                     //!< Transfer buffer size
-  mutable amd::Monitor lockXferOps_;          //!< Lock transfer operation
+  mutable std::recursive_mutex lockXferOps_;  //!< Lock transfer operation
 };
 
 static const char* BlitName[KernelBlitManager::BlitTotal] = {

--- a/projects/clr/rocclr/device/pal/palcounters.cpp
+++ b/projects/clr/rocclr/device/pal/palcounters.cpp
@@ -114,7 +114,7 @@ PalCounterReference* PalCounterReference::Create(VirtualGPU& gpu) {
 PalCounterReference::~PalCounterReference() {
   // The counter object is always associated with a particular queue,
   // so we have to lock just this queue
-  amd::ScopedLock lock(gpu_.execution());
+  std::scoped_lock lock(gpu_.execution());
 
   delete layout_;
   delete memory_;

--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -688,7 +688,7 @@ Memory& Device::XferBuffers::acquire() {
   size_t listSize;
 
   // Lock the operations with the staged buffer list
-  amd::ScopedLock l(lock_);
+  std::scoped_lock l(lock_);
   listSize = freeBuffers_.size();
 
   // If the list is empty, then attempt to allocate a staged buffer
@@ -724,7 +724,7 @@ void Device::XferBuffers::release(VirtualGPU& gpu, Memory& buffer) {
   // the next aquire can come from different queue
   buffer.wait(gpu);
   // Lock the operations with the staged buffer list
-  amd::ScopedLock l(lock_);
+  std::scoped_lock l(lock_);
   freeBuffers_.push_back(&buffer);
   --acquiredCnt_;
 }
@@ -755,13 +755,6 @@ Device::ScopedLockVgpus::~ScopedLockVgpus() {
 Device::Device()
     : NullDevice(),
       numOfVgpus_(0),
-      lockAsyncOps_(true),    /* Device Async Ops Lock */
-      lockForInitHeap_(true), /* Initialization of Heap Resource */
-      lockPAL_(true),         /* PAL Ops Lock */
-      vgpusAccess_(true),     /* Virtual GPU List Ops Lock */
-      scratchAlloc_(true),    /* Scratch Allocation Lock */
-      mapCacheOps_(true),     /* Map Cache Lock */
-      lockResourceOps_(true), /* Resource List Ops Lock */
       xferRead_(nullptr),
       mapCache_(nullptr),
       resourceCache_(nullptr),
@@ -1088,7 +1081,7 @@ void PAL_STDCALL Device::PalDeveloperCallback(void* pPrivateData, const Pal::uin
 
 // ================================================================================================
 bool Device::initializeHeapResources() {
-  amd::ScopedLock k(lockForInitHeap_);
+  std::scoped_lock k(lockForInitHeap_);
   if (!heapInitComplete_) {
     Pal::DeviceFinalizeInfo finalizeInfo = {};
 
@@ -1219,8 +1212,8 @@ device::VirtualDevice* Device::createVirtualDevice(amd::CommandQueue* queue) {
   }
 
   // Not safe to add a queue. So lock the device
-  amd::ScopedLock k(lockAsyncOps());
-  amd::ScopedLock lock(vgpusAccess());
+  std::scoped_lock k(lockAsyncOps());
+  std::scoped_lock lock(vgpusAccess());
 
   // Initialization of heap and other resources occur during the command queue creation time.
   if (!initializeHeapResources()) {
@@ -1512,7 +1505,7 @@ pal::Memory* Device::createBuffer(amd::Memory& owner, bool directAccess) const {
       amd::Memory* amdParent = owner.parent();
       {
         // Lock memory object, so only one commitment will occur
-        amd::ScopedLock lock(amdParent->lockMemoryOps());
+        std::scoped_lock lock(amdParent->lockMemoryOps());
         amdParent->commitSvmMemory();
         amdParent->setHostMem(amdParent->getSvmPtr());
       }
@@ -2074,7 +2067,7 @@ bool Device::amdFileWrite(amd::Os::FileDesc handle, void* devicePtr, uint64_t si
 
 amd::Memory* Device::findMapTarget(size_t size) const {
   // Must be serialised for access
-  amd::ScopedLock lk(mapCacheOps_);
+  std::scoped_lock lk(mapCacheOps_);
 
   amd::Memory* map = nullptr;
   size_t minSize = 0;
@@ -2129,7 +2122,7 @@ amd::Memory* Device::findMapTarget(size_t size) const {
 
 bool Device::addMapTarget(amd::Memory* memory) const {
   // Must be serialised for access
-  amd::ScopedLock lk(mapCacheOps_);
+  std::scoped_lock lk(mapCacheOps_);
 
   // the svm memory shouldn't be cached
   if (!memory->canBeCached()) {
@@ -2160,7 +2153,7 @@ void Device::ScratchBuffer::destroyMemory() {
 bool Device::allocScratch(uint regNum, const VirtualGPU* vgpu, uint vgprs) {
   if (regNum > 0 && vgprs > 0) {
     // Serialize the scratch buffer allocation code
-    amd::ScopedLock lk(scratchAlloc_);
+    std::scoped_lock lk(scratchAlloc_);
     uint sb = vgpu->hwRing();
     static const uint WaveSizeLimit = ((1 << 21) - 256);
     const uint threadSizeLimit = WaveSizeLimit / info().wavefrontWidth_;

--- a/projects/clr/rocclr/device/pal/paldevice.hpp
+++ b/projects/clr/rocclr/device/pal/paldevice.hpp
@@ -234,14 +234,10 @@ class Device : public NullDevice {
     int counter_;                    //!< Lock usage counter
     Pal::EngineType engineType_;     //!< Engine type
     uint32_t index_;                 //!< HW queue index for scratch buffer access
-    amd::Monitor queue_lock_;        //!< Queue lock for access
+    std::recursive_mutex queue_lock_;  //!< Queue lock for access
     AqlPacketMgmt aql_packet_mgmt_;  //!< AQL packets management class for debugger support
     QueueRecycleInfo(const Device& dev)
-        : counter_(1),
-          engineType_(Pal::EngineTypeCompute),
-          index_(0),
-          queue_lock_(true) /* Queue lock for sharing */,
-          aql_packet_mgmt_(dev) {}
+        : counter_(1), engineType_(Pal::EngineTypeCompute), index_(0), aql_packet_mgmt_(dev) {}
 
     //! Returns the MQD's read_dispatch_id's address.
     uintptr_t DebuggerData() const {
@@ -458,16 +454,16 @@ class Device : public NullDevice {
   pal::Memory* getGpuMemory(amd::Memory* mem  //!< Pointer to AMD memory object
   ) const;
 
-  amd::Monitor& lockAsyncOps() const { return lockAsyncOps_; }
+  std::recursive_mutex& lockAsyncOps() const { return lockAsyncOps_; }
 
   //! Returns the lock object for the virtual gpus list
-  amd::Monitor& vgpusAccess() const { return vgpusAccess_; }
+  std::recursive_mutex& vgpusAccess() const { return vgpusAccess_; }
 
   //! Returns the monitor object for PAL
-  amd::Monitor& lockPAL() const { return lockPAL_; }
+  std::recursive_mutex& lockPAL() const { return lockPAL_; }
 
   //! Returns the monitor object for PAL
-  amd::Monitor& lockResources() const { return lockResourceOps_; }
+  std::recursive_mutex& lockResources() const { return lockResourceOps_; }
 
   //! Returns the number of virtual GPUs allocated on this device
   uint numOfVgpus() const { return numOfVgpus_; }
@@ -621,7 +617,7 @@ class Device : public NullDevice {
 
   //! Adds a resource to the global list
   void addResource(Resource* res) const {
-    amd::ScopedLock lock(lockResources());
+    std::scoped_lock lock(lockResources());
     auto findIt = resourceList_->find(res);
     res->resizeGpuEvents(numOfVgpus() - 1);
     if (resourceList_->end() == findIt) {
@@ -631,7 +627,7 @@ class Device : public NullDevice {
 
   //! Removes a resource from the global list
   void removeResource(Resource* res) const {
-    amd::ScopedLock lock(lockResources());
+    std::scoped_lock lock(lockResources());
     resourceList_->erase(res);
   }
 
@@ -640,7 +636,7 @@ class Device : public NullDevice {
     // Not safe to resize the list when runtime creates/destroys a queue at the same time
     // or other queues process a command, since the size of the TS array can change
     Device::ScopedLockVgpus v(*this);
-    amd::ScopedLock r(lockResources());
+    std::scoped_lock r(lockResources());
     for (const auto& it : *resourceList_) {
       it->resizeGpuEvents(index);
     }
@@ -648,7 +644,7 @@ class Device : public NullDevice {
 
   //! Erases an old queue from the list
   void eraseResoureList(uint index) const {
-    amd::ScopedLock lock(lockResources());
+    std::scoped_lock lock(lockResources());
     for (const auto& it : *resourceList_) {
       it->eraseGpuEvents(index);
     }
@@ -731,14 +727,14 @@ class Device : public NullDevice {
   static char* platformObj_;         //!< Memory allocated for PAL platform object
   static Pal::IPlatform* platform_;  //!< Pointer to the PAL platform object
 
-  mutable amd::Monitor lockAsyncOps_;  //!< Lock to serialise all async ops on this device
+  mutable std::recursive_mutex lockAsyncOps_;  //!< Lock to serialise all async ops on this device
   //! Lock to serialise all async ops on initialization heap operation
-  mutable amd::Monitor lockForInitHeap_;
-  mutable amd::Monitor lockPAL_;          //!< Lock to serialise PAL access
-  mutable amd::Monitor vgpusAccess_;      //!< Lock to serialise virtual gpu list access
-  mutable amd::Monitor scratchAlloc_;     //!< Lock to serialise scratch allocation
-  mutable amd::Monitor mapCacheOps_;      //!< Lock to serialise cache for the map resources
-  mutable amd::Monitor lockResourceOps_;  //!< Lock to serialise resource access
+  mutable std::recursive_mutex lockForInitHeap_;
+  mutable std::recursive_mutex lockPAL_;          //!< Lock to serialise PAL access
+  mutable std::recursive_mutex vgpusAccess_;      //!< Lock to serialise virtual gpu list access
+  mutable std::recursive_mutex scratchAlloc_;     //!< Lock to serialise scratch allocation
+  mutable std::recursive_mutex mapCacheOps_;      //!< Lock to serialise cache for the map resources
+  mutable std::recursive_mutex lockResourceOps_;  //!< Lock to serialise resource access
   mutable std::mutex lockAllowAccess_;    //!< To serialize allow_access calls
   XferBuffers* xferRead_;                 //!< Transfer buffers read
   std::vector<amd::Memory*>* mapCache_;   //!< Map cache info structure

--- a/projects/clr/rocclr/device/pal/paldevicegl.cpp
+++ b/projects/clr/rocclr/device/pal/paldevicegl.cpp
@@ -846,7 +846,7 @@ bool Device::resGLAssociate(void* GLContext, uint name, uint type, Pal::OsExtern
                             Pal::DoppDesktopInfo& doppDesktopInfo
 #endif
 ) const {
-  amd::ScopedLock lk(lockPAL());
+  std::scoped_lock lk(lockPAL());
 
   GLResource hRes = {};
   GLResourceData hData = {};
@@ -910,7 +910,7 @@ bool Device::resGLAssociate(void* GLContext, uint name, uint type, Pal::OsExtern
 }
 
 bool Device::resGLAcquire(void* GLplatformContext, void* mbResHandle, uint type) const {
-  amd::ScopedLock lk(lockPAL());
+  std::scoped_lock lk(lockPAL());
 
   GLResource hRes = {};
   hRes.mbResHandle = (GLuintp)mbResHandle;
@@ -930,7 +930,7 @@ bool Device::resGLAcquire(void* GLplatformContext, void* mbResHandle, uint type)
 }
 
 bool Device::resGLRelease(void* GLplatformContext, void* mbResHandle, uint type) const {
-  amd::ScopedLock lk(lockPAL());
+  std::scoped_lock lk(lockPAL());
 
   GLResource hRes = {};
   hRes.mbResHandle = (GLuintp)mbResHandle;
@@ -952,7 +952,7 @@ bool Device::resGLRelease(void* GLplatformContext, void* mbResHandle, uint type)
 }
 
 bool Device::resGLFree(void* GLplatformContext, void* mbResHandle, uint type) const {
-  amd::ScopedLock lk(lockPAL());
+  std::scoped_lock lk(lockPAL());
 
   GLResource hRes = {};
   hRes.mbResHandle = (GLuintp)mbResHandle;

--- a/projects/clr/rocclr/device/pal/palmemory.cpp
+++ b/projects/clr/rocclr/device/pal/palmemory.cpp
@@ -468,7 +468,7 @@ Memory::~Memory() {
 }
 
 void Memory::syncCacheFromHost(VirtualGPU& gpu, device::Memory::SyncFlags syncFlags) {
-  amd::ScopedLock lock(owner()->lockMemoryOps());
+  std::scoped_lock lock(owner()->lockMemoryOps());
   // If the last writer was another GPU, then make a writeback
   if (isChacheCoherencySync() && (owner()->getLastWriter() != nullptr) &&
       (&dev() != owner()->getLastWriter())) {
@@ -493,7 +493,7 @@ void Memory::syncCacheFromHost(VirtualGPU& gpu, device::Memory::SyncFlags syncFl
       // Make sure the parent sync is an unique operation.
       // If the app uses multiple subbuffers from multiple queues,
       // then the parent sync can be called from multiple threads
-      amd::ScopedLock lock(owner()->parent()->lockMemoryOps());
+      std::scoped_lock lock(owner()->parent()->lockMemoryOps());
       gpuMemory->syncCacheFromHost(gpu, syncFlagsTmp);
       //! \note Don't do early exit here, since we still have to sync
       //! this view, if the parent sync operation was a NOP.
@@ -606,7 +606,7 @@ void Memory::syncHostFromCache(device::VirtualDevice* vDev, device::Memory::Sync
       // Make sure the parent sync is an unique operation.
       // If the app uses multiple subbuffers from multiple queues,
       // then the parent sync can be called from multiple threads
-      amd::ScopedLock lock(owner()->parent()->lockMemoryOps());
+      std::scoped_lock lock(owner()->parent()->lockMemoryOps());
       m->syncHostFromCache(gpu, syncFlagsTmp);
       //! \note Don't do early exit here, since we still have to sync
       //! this view, if the parent sync operation was a NOP.
@@ -634,7 +634,7 @@ void Memory::syncHostFromCache(device::VirtualDevice* vDev, device::Memory::Sync
         syncFlagsTmp.skipEntire_ = syncFlags.skipEntire_;
       }
 
-      amd::ScopedLock lock(owner()->lockMemoryOps());
+      std::scoped_lock lock(owner()->lockMemoryOps());
       for (auto& sub : owner()->subBuffers()) {
         //! \note Don't allow subbuffer's allocation in the worker thread.
         //! It may cause a system lock, because possible resource
@@ -733,7 +733,7 @@ pal::Memory* Memory::createBufferView(amd::Memory& subBufferOwner) {
 
 void Memory::decIndMapCount() {
   // Map/unmap must be serialized
-  amd::ScopedLock lock(owner()->lockMemoryOps());
+  std::scoped_lock lock(owner()->lockMemoryOps());
 
   if (indirectMapCount_ == 0) {
     if (!mipMapped()) {
@@ -772,7 +772,7 @@ void* Memory::allocMapTarget(const amd::Coord3D& origin, const amd::Coord3D& reg
   assert(owner() != nullptr);
 
   // Map/unmap must be serialized
-  amd::ScopedLock lock(owner()->lockMemoryOps());
+  std::scoped_lock lock(owner()->lockMemoryOps());
 
   address mapAddress = nullptr;
   size_t offset = origin[0];
@@ -976,7 +976,7 @@ Memory* Memory::mapMemory() const {
 
 void Memory::mgpuCacheWriteBack(VirtualGPU& gpu) {
   // Lock memory object, so only one write back can occur
-  amd::ScopedLock lock(owner()->lockMemoryOps());
+  std::scoped_lock lock(owner()->lockMemoryOps());
 
   // Attempt to allocate a staging buffer if don't have any
   if (!owner()->P2PAccess() && (owner()->getHostMem() == nullptr)) {
@@ -1048,7 +1048,7 @@ void* Image::allocMapTarget(const amd::Coord3D& origin, const amd::Coord3D& regi
   size_t depth = desc().depth_;
 
   // Map/unmap must be serialized
-  amd::ScopedLock lock(owner()->lockMemoryOps());
+  std::scoped_lock lock(owner()->lockMemoryOps());
 
   address mapAddress = nullptr;
   size_t offset = origin[0];

--- a/projects/clr/rocclr/device/pal/palprintf.cpp
+++ b/projects/clr/rocclr/device/pal/palprintf.cpp
@@ -247,7 +247,7 @@ static constexpr char Separator[] = ",\0";
 size_t PrintfDbg::outputArgument(const std::string& fmt, bool printFloat, size_t size,
                                  const void* argument) const {
   // Serialize the output to the screen
-  amd::ScopedLock k(dev().lockAsyncOps());
+  std::scoped_lock k(dev().lockAsyncOps());
 
   size_t copiedBytes = size;
   // Print the string argument, using standard PrintfDbg()

--- a/projects/clr/rocclr/device/pal/palprogram.cpp
+++ b/projects/clr/rocclr/device/pal/palprogram.cpp
@@ -28,6 +28,7 @@
 #include "amd_hsa_loader.hpp"
 
 #include <algorithm>
+#include <optional>
 #include <cstdio>
 #include <fstream>
 #include <memory>
@@ -143,7 +144,7 @@ void Segment::copy(size_t offset, const void* src, size_t size) {
     if (cpuMem_ != nullptr) {
       std::memcpy(cpuAddress(offset), src, size);
     }
-    amd::ScopedLock k(gpuAccess_->dev().xferMgr().lockXfer());
+    std::scoped_lock k(*(gpuAccess_->dev().xferMgr().lockXfer()));
     VirtualGPU& gpu = *gpuAccess_->dev().xferQueue();
     Memory& xferBuf = gpu.xferWrite().Acquire(size);
     size_t tmpSize = std::min(static_cast<size_t>(xferBuf.size()), size);
@@ -165,7 +166,7 @@ bool Segment::freeze(bool destroySysmem) {
   bool result = true;
   if (cpuAccess_ != nullptr) {
     assert(gpuAccess_->size() == cpuAccess_->size() && "Backing store size mismatch!");
-    amd::ScopedLock k(gpuAccess_->dev().xferMgr().lockXfer());
+    std::scoped_lock k(*(gpuAccess_->dev().xferMgr().lockXfer()));
     result = cpuAccess_->partialMemCopyTo(gpu, 0, 0, gpuAccess_->size(), *gpuAccess_, false, true);
     gpu.waitAllEngines();
   }

--- a/projects/clr/rocclr/device/pal/palprogram.cpp
+++ b/projects/clr/rocclr/device/pal/palprogram.cpp
@@ -28,7 +28,6 @@
 #include "amd_hsa_loader.hpp"
 
 #include <algorithm>
-#include <optional>
 #include <cstdio>
 #include <fstream>
 #include <memory>

--- a/projects/clr/rocclr/device/pal/palresource.cpp
+++ b/projects/clr/rocclr/device/pal/palresource.cpp
@@ -37,7 +37,6 @@
 #include <GL/gl.h>
 #include "GL/gl_interop.h"
 
-#include <optional>
 #include <string>
 #include <fstream>
 #include <sstream>
@@ -272,7 +271,7 @@ GpuMemoryReference::~GpuMemoryReference() {
     if (device_.vgpus().size() != 0) {
       assert(device_.vgpus()[0] == device_.xferQueue() && "Wrong transfer queue!");
       // Lock the transfer queue, since it's not handled by ScopedLockVgpus
-      std::scoped_lock k(*(gpuAccess_->dev().xferMgr().lockXfer()));
+      std::scoped_lock k(*(device_.xferMgr().lockXfer()));
       device_.vgpus()[0]->releaseMemory(this);
     }
   }

--- a/projects/clr/rocclr/device/pal/palresource.cpp
+++ b/projects/clr/rocclr/device/pal/palresource.cpp
@@ -37,6 +37,7 @@
 #include <GL/gl.h>
 #include "GL/gl_interop.h"
 
+#include <optional>
 #include <string>
 #include <fstream>
 #include <sstream>
@@ -265,13 +266,13 @@ GpuMemoryReference::~GpuMemoryReference() {
         device_.vgpus()[idx]->releaseMemory(this);
       }
     } else {
-      amd::ScopedLock l(gpu_->execution());
+      std::scoped_lock l(gpu_->execution());
       gpu_->releaseMemory(this);
     }
     if (device_.vgpus().size() != 0) {
       assert(device_.vgpus()[0] == device_.xferQueue() && "Wrong transfer queue!");
       // Lock the transfer queue, since it's not handled by ScopedLockVgpus
-      amd::ScopedLock k(device_.xferMgr().lockXfer());
+      std::scoped_lock k(*(gpuAccess_->dev().xferMgr().lockXfer()));
       device_.vgpus()[0]->releaseMemory(this);
     }
   }
@@ -1393,7 +1394,7 @@ void Resource::free() {
   // and resource can be reused on another async queue without a wait on a busy operation
   if (wait) {
     if (memRef_->gpu_ == nullptr) {
-      amd::ScopedLock l(dev().vgpusAccess());
+      std::scoped_lock l(dev().vgpusAccess());
       // Release all memory objects on all virtual GPUs
       for (uint idx = 1; idx < dev().vgpus().size(); ++idx) {
         dev().vgpus()[idx]->waitForEvent(&events_[idx]);
@@ -1832,7 +1833,7 @@ void* Resource::gpuMemoryMap(size_t* pitch, uint flags, Pal::IGpuMemory* resourc
     return nullptr;
     //        return const_cast<Device&>(dev()).resMapLocal(*pitch, resource, flags);
   } else {
-    amd::ScopedLock lk(dev().lockPAL());
+    std::scoped_lock lk(dev().lockPAL());
     void* address;
     if (image_ != nullptr) {
       constexpr Pal::SubresId ImgSubresId = {0, 0, 0};
@@ -1923,7 +1924,7 @@ bool Resource::isModified(VirtualGPU& gpu) const {
 // ================================================================================================
 void Resource::palFree() const {
   if (desc().type_ == OGLInterop) {
-    amd::ScopedLock lk(dev().lockPAL());
+    std::scoped_lock lk(dev().lockPAL());
     dev().resGLFree(glPlatformContext_, glInteropMbRes_, glType_);
   }
   memRef_->release();
@@ -2209,10 +2210,11 @@ GpuMemoryReference* MemorySubAllocator::Allocate(Pal::gpusize size, Pal::gpusize
 }
 
 // ================================================================================================
-bool MemorySubAllocator::Free(amd::Monitor* monitor, GpuMemoryReference* ref, Pal::gpusize offset) {
+bool MemorySubAllocator::Free(std::recursive_mutex& monitor, GpuMemoryReference* ref,
+                              Pal::gpusize offset) {
   bool release_mem = false;
   {
-    amd::ScopedLock l(monitor);
+    std::scoped_lock l(monitor);
     // Find if current memory reference is a chunk allocation
     auto it = heaps_.find(ref);
     if (it == heaps_.end()) {
@@ -2249,14 +2251,14 @@ bool ResourceCache::addGpuMemory(Resource::Descriptor* desc, GpuMemoryReference*
     // We do no sub allocate VA Range.
     result = false;
   } else if ((desc->type_ == Resource::Local) && !desc->SVMRes_) {
-    result = mem_sub_alloc_local_.Free(&lockCacheOps_, ref, offset);
+    result = mem_sub_alloc_local_.Free(lockCacheOps_, ref, offset);
   } else if ((desc->type_ == Resource::Local) && desc->SVMRes_) {
-    result = mem_sub_alloc_coarse_.Free(&lockCacheOps_, ref, offset);
+    result = mem_sub_alloc_coarse_.Free(lockCacheOps_, ref, offset);
   } else if (desc->SVMRes_) {
     if (desc->gl2CacheDisabled_) {
-      result = mem_sub_alloc_fine_uncached_.Free(&lockCacheOps_, ref, offset);
+      result = mem_sub_alloc_fine_uncached_.Free(lockCacheOps_, ref, offset);
     } else {
-      result = mem_sub_alloc_fine_.Free(&lockCacheOps_, ref, offset);
+      result = mem_sub_alloc_fine_.Free(lockCacheOps_, ref, offset);
     }
   }
 
@@ -2279,7 +2281,7 @@ bool ResourceCache::addGpuMemory(Resource::Descriptor* desc, GpuMemoryReference*
       // Copy the original desc to the cached version
       memcpy(descCached, desc, sizeof(Resource::Descriptor));
 
-      amd::ScopedLock l(&lockCacheOps_);
+      std::scoped_lock l(lockCacheOps_);
       // Add the current resource to the cache
       resCache_.push_front({descCached, ref});
       ref->gpu_ = nullptr;
@@ -2301,7 +2303,7 @@ GpuMemoryReference* ResourceCache::findGpuMemory(Resource::Descriptor* desc, Pal
                                                  Pal::gpusize alignment,
                                                  const Pal::IGpuMemory* reserved_va,
                                                  Pal::gpusize* offset) {
-  amd::ScopedLock l(&lockCacheOps_);
+  std::scoped_lock l(lockCacheOps_);
   GpuMemoryReference* ref = nullptr;
 
   // Check if the runtime can suballocate memory
@@ -2376,7 +2378,7 @@ void ResourceCache::removeLast() {
   std::pair<Resource::Descriptor*, GpuMemoryReference*> entry;
   {
     // Protect access to the global data
-    amd::ScopedLock l(&lockCacheOps_);
+    std::scoped_lock l(lockCacheOps_);
     if (resCache_.size() > 0) {
       entry = resCache_.back();
       resCache_.pop_back();

--- a/projects/clr/rocclr/device/pal/palresource.hpp
+++ b/projects/clr/rocclr/device/pal/palresource.hpp
@@ -532,7 +532,7 @@ class MemorySubAllocator : public amd::HeapObject {
   GpuMemoryReference* Allocate(Pal::gpusize size, Pal::gpusize alignment,
                                const Pal::IGpuMemory* reserved_va, Pal::gpusize* offset);
   //! Free suballocation
-  bool Free(amd::Monitor* monitor, GpuMemoryReference* mem_ref, Pal::gpusize offset);
+  bool Free(std::recursive_mutex& monitor, GpuMemoryReference* mem_ref, Pal::gpusize offset);
 
  protected:
   //! Allocate new chunk of memory
@@ -570,8 +570,7 @@ class ResourceCache : public amd::HeapObject {
  public:
   //! Default constructor
   ResourceCache(Device* device, size_t cacheSizeLimit)
-      : lockCacheOps_(true), /* PAL resource cache */
-        cacheSize_(0),
+      : cacheSize_(0),
         lclCacheSize_(0),
         persistentCacheSize_(0),
         cacheSizeLimit_(cacheSizeLimit),
@@ -619,7 +618,7 @@ class ResourceCache : public amd::HeapObject {
   //! Removes one last entry from the cache
   void removeLast();
 
-  amd::Monitor lockCacheOps_;  //!< Lock to serialise cache access
+  std::recursive_mutex lockCacheOps_;  //!< Lock to serialise cache access
 
   size_t cacheSize_;             //!< Current cache size in bytes
   size_t lclCacheSize_;          //!< Local memory stored in the cache

--- a/projects/clr/rocclr/device/pal/palthreadtrace.cpp
+++ b/projects/clr/rocclr/device/pal/palthreadtrace.cpp
@@ -56,7 +56,7 @@ PalThreadTraceReference* PalThreadTraceReference::Create(VirtualGPU& gpu) {
 PalThreadTraceReference::~PalThreadTraceReference() {
   // The thread trace object is always associated with a particular queue,
   // so we have to lock just this queue
-  amd::ScopedLock lock(gpu_.execution());
+  std::scoped_lock lock(gpu_.execution());
 
   delete layout_;
   delete memory_;

--- a/projects/clr/rocclr/device/pal/palvirtual.cpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.cpp
@@ -36,7 +36,6 @@
 #include "amd_hsa_kernel_code.h"
 #include "amd_hsa_queue.h"
 #include <fstream>
-#include <optional>
 #include <sstream>
 #include <algorithm>
 #include <thread>

--- a/projects/clr/rocclr/device/pal/palvirtual.cpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.cpp
@@ -36,6 +36,7 @@
 #include "amd_hsa_kernel_code.h"
 #include "amd_hsa_queue.h"
 #include <fstream>
+#include <optional>
 #include <sstream>
 #include <algorithm>
 #include <thread>
@@ -277,7 +278,7 @@ VirtualGPU::Queue::~Queue() {
   if (nullptr != iQueue_) {
     // Make sure the queues are idle
     // It's unclear why PAL could still have a busy queue
-    amd::ScopedLock l(lock_);
+    std::scoped_lock l(*lock_);
     iQueue_->WaitIdle();
   }
 
@@ -397,7 +398,7 @@ void VirtualGPU::Queue::addCmdDoppRef(Pal::IGpuMemory* iMem, bool lastDoppCmd, b
 
 // ================================================================================================
 bool VirtualGPU::Queue::flush() {
-  amd::ScopedLock l(lock_);
+  std::scoped_lock l(*lock_);
   const Settings& settings = gpu_.dev().settings();
 
   if (!settings.alwaysResident_ && palMemRefs_.size() != 0) {
@@ -538,7 +539,7 @@ bool VirtualGPU::Queue::flush() {
 
 // ================================================================================================
 bool VirtualGPU::Queue::waitForEvent(uint id) {
-  amd::ScopedLock l(lock_);
+  std::scoped_lock l(*lock_);
   if (isDone(id)) {
     return true;
   }
@@ -557,7 +558,7 @@ bool VirtualGPU::Queue::waitForEvent(uint id) {
 
 // ================================================================================================
 bool VirtualGPU::Queue::isDone(uint id) {
-  amd::ScopedLock l(lock_);
+  std::scoped_lock l(*lock_);
   if ((id <= cmbBufIdRetired_) || (id > cmdBufIdCurrent_)) {
     return true;
   }
@@ -1097,8 +1098,8 @@ bool VirtualGPU::allocHsaQueueMem() {
 
 VirtualGPU::~VirtualGPU() {
   // Not safe to remove a queue. So lock the device
-  amd::ScopedLock k(dev().lockAsyncOps());
-  amd::ScopedLock lock(dev().vgpusAccess());
+  std::scoped_lock k(dev().lockAsyncOps());
+  std::scoped_lock lock(dev().vgpusAccess());
 
   if (queues_[MainEngine] != nullptr) {
     // Clear all timestamps, associated with this virtual GPU
@@ -1173,7 +1174,7 @@ VirtualGPU::~VirtualGPU() {
 
     // Not safe to add a resource if create/destroy queue is in process, since
     // the size of the TS array can change
-    amd::ScopedLock r(dev().lockResources());
+    std::scoped_lock r(dev().lockResources());
     gpuDevice_.numOfVgpus_--;
     gpuDevice_.vgpus_.erase(gpuDevice_.vgpus_.begin() + index());
     for (uint idx = index(); idx < dev().vgpus().size(); ++idx) {
@@ -1198,7 +1199,7 @@ VirtualGPU::~VirtualGPU() {
 
 void VirtualGPU::submitReadMemory(amd::ReadMemoryCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   // Translate memory references and ensure cache up-to-date
   pal::Memory* memory = dev().getGpuMemory(&vcmd.source());
@@ -1328,7 +1329,7 @@ void VirtualGPU::submitReadMemory(amd::ReadMemoryCommand& vcmd) {
 
 void VirtualGPU::submitWriteMemory(amd::WriteMemoryCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   // Translate memory references and ensure cache up to date
   pal::Memory* memory = dev().getGpuMemory(&vcmd.destination());
@@ -1571,7 +1572,7 @@ bool VirtualGPU::copyMemory(cl_command_type type, amd::Memory& srcMem, amd::Memo
 
 void VirtualGPU::submitCopyMemory(amd::CopyMemoryCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(vcmd);
 
@@ -1589,7 +1590,7 @@ void VirtualGPU::submitCopyMemory(amd::CopyMemoryCommand& vcmd) {
 
 void VirtualGPU::submitSvmCopyMemory(amd::SvmCopyMemoryCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
   profilingBegin(vcmd);
 
   cl_command_type type = vcmd.type();
@@ -1664,7 +1665,7 @@ void VirtualGPU::submitSvmCopyMemory(amd::SvmCopyMemoryCommand& vcmd) {
 
 void VirtualGPU::submitMapMemory(amd::MapMemoryCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(vcmd);
 
@@ -1739,7 +1740,7 @@ void VirtualGPU::submitMapMemory(amd::MapMemoryCommand& vcmd) {
 
 void VirtualGPU::submitUnmapMemory(amd::UnmapMemoryCommand& vcmd) {
     // Make sure VirtualGPU has an exclusive access to the resources
-    amd::ScopedLock lock(execution());
+    std::scoped_lock lock(execution());
 
     pal::Memory* memory = dev().getGpuMemory(&vcmd.memory());
     amd::Memory* owner = memory->owner();
@@ -1764,7 +1765,7 @@ void VirtualGPU::submitUnmapMemory(amd::UnmapMemoryCommand& vcmd) {
     // and therefore are treated like a remote resource
     else if (memory->isPersistentMapped()) {
       // Map/unmap must be serialized
-      amd::ScopedLock lock(owner->lockMemoryOps());
+      std::scoped_lock lock(owner->lockMemoryOps());
       memory->unmap(this);
       if (memory->getMapCount() == 0) {
         memory->setPersistentMapFlag(false);
@@ -1891,7 +1892,7 @@ bool VirtualGPU::fillMemory(cl_command_type type, amd::Memory* amdMemory, const 
 
 void VirtualGPU::submitFillMemory(amd::FillMemoryCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(cmd);
   if (cmd.type() == CL_COMMAND_FILL_IMAGE) {
@@ -1933,7 +1934,7 @@ void VirtualGPU::submitFillMemory(amd::FillMemoryCommand& cmd) {
 
 void VirtualGPU::submitCopyMemoryP2P(amd::CopyMemoryP2PCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(cmd);
 
@@ -1969,7 +1970,7 @@ void VirtualGPU::submitCopyMemoryP2P(amd::CopyMemoryP2PCommand& cmd) {
         result = blitMgr().copyBuffer(*srcDevMem, *dstDevMem, srcOrigin, dstOrigin, size,
                                       cmd.isEntireMemory());
       } else {
-        amd::ScopedLock lock(dev().P2PStageOps());
+        std::scoped_lock lock(dev().P2PStageOps());
         Memory* dstStgMem = static_cast<pal::Memory*>(
             dev().P2PStage()->getDeviceMemory(*cmd.source().getContext().devices()[0]));
         Memory* srcStgMem = static_cast<pal::Memory*>(
@@ -2002,7 +2003,7 @@ void VirtualGPU::submitCopyMemoryP2P(amd::CopyMemoryP2PCommand& cmd) {
         result = blitMgr().copyBufferRect(*srcDevMem, *dstDevMem, cmd.srcRect(), cmd.dstRect(),
                                           size, cmd.isEntireMemory(), cmd.copyMetadata());
       } else {
-        amd::ScopedLock lock(dev().P2PStageOps());
+        std::scoped_lock lock(dev().P2PStageOps());
         Memory* dstStgMem = static_cast<pal::Memory*>(
             dev().P2PStage()->getDeviceMemory(*cmd.source().getContext().devices()[0]));
         Memory* srcStgMem = static_cast<pal::Memory*>(
@@ -2079,7 +2080,7 @@ void VirtualGPU::submitCopyMemoryP2P(amd::CopyMemoryP2PCommand& cmd) {
 
 void VirtualGPU::submitBatchCopyMemory(amd::BatchCopyMemoryCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(cmd);
 
@@ -2128,7 +2129,7 @@ void VirtualGPU::submitBatchCopyMemory(amd::BatchCopyMemoryCommand& cmd) {
 
 void VirtualGPU::submitSvmMapMemory(amd::SvmMapMemoryCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(vcmd);
 
@@ -2168,7 +2169,7 @@ void VirtualGPU::submitSvmMapMemory(amd::SvmMapMemoryCommand& vcmd) {
 
 void VirtualGPU::submitSvmUnmapMemory(amd::SvmUnmapMemoryCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
   profilingBegin(vcmd);
 
   // no op for FGS supported device
@@ -2203,7 +2204,7 @@ void VirtualGPU::submitSvmUnmapMemory(amd::SvmUnmapMemoryCommand& vcmd) {
 
 void VirtualGPU::submitSvmFillMemory(amd::SvmFillMemoryCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(vcmd);
 
@@ -2235,7 +2236,7 @@ void VirtualGPU::submitSvmFillMemory(amd::SvmFillMemoryCommand& vcmd) {
 
 void VirtualGPU::submitMigrateMemObjects(amd::MigrateMemObjectsCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(vcmd);
 
@@ -2262,7 +2263,7 @@ void VirtualGPU::submitMigrateMemObjects(amd::MigrateMemObjectsCommand& vcmd) {
 void VirtualGPU::submitSvmFreeMemory(amd::SvmFreeMemoryCommand& vcmd) {
   // in-order semantics: previous commands need to be done before we start
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(vcmd);
   std::vector<void*>& svmPointers = vcmd.svmPointers();
@@ -2280,7 +2281,7 @@ void VirtualGPU::submitSvmFreeMemory(amd::SvmFreeMemoryCommand& vcmd) {
 
 void VirtualGPU::submitStreamOperation(amd::StreamOperationCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
   profilingBegin(cmd);
 
   const cl_command_type type = cmd.type();
@@ -2322,7 +2323,7 @@ void VirtualGPU::submitStreamOperation(amd::StreamOperationCommand& cmd) {
 // ================================================================================================
 void VirtualGPU::submitVirtualMap(amd::VirtualMapCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(vcmd);
   amd::Memory* phys_mem_obj = vcmd.memory();
@@ -2639,7 +2640,7 @@ void VirtualGPU::submitKernel(amd::NDRangeKernelCommand& vcmd) {
     // Wait for the execution on the current queue, since the coop groups will use the device queue
     waitAllEngines();
 
-    amd::ScopedLock lock(queue->blitMgr().lockXfer());
+    std::scoped_lock k(*(queue->blitMgr().lockXfer()));
 
     queue->profilingBegin(vcmd);
 
@@ -2658,7 +2659,7 @@ void VirtualGPU::submitKernel(amd::NDRangeKernelCommand& vcmd) {
     queue->waitAllEngines();
   } else {
     // Make sure VirtualGPU has an exclusive access to the resources
-    amd::ScopedLock lock(execution());
+    std::scoped_lock lock(execution());
 
     profilingBegin(vcmd);
 
@@ -2860,7 +2861,7 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
 // ================================================================================================
 void VirtualGPU::submitNativeFn(amd::NativeFnCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   Unimplemented();  //!< @todo: Unimplemented
 }
@@ -2893,7 +2894,7 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
     // Use GPU based timing for HIP events
 
     // Make sure VirtualGPU has an exclusive access to the resources
-    amd::ScopedLock lock(execution());
+    std::scoped_lock lock(execution());
     GpuEvent event;
     profilingBegin(vcmd);
     eventBegin(MainEngine);
@@ -2933,7 +2934,7 @@ void VirtualGPU::releaseMemory(GpuMemoryReference* mem) {
 
 void VirtualGPU::submitPerfCounter(amd::PerfCounterCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   const amd::PerfCounterCommand::PerfCounterList counters = vcmd.getCounters();
 
@@ -3012,7 +3013,7 @@ void VirtualGPU::submitPerfCounter(amd::PerfCounterCommand& vcmd) {
 
 void VirtualGPU::submitThreadTraceMemObjects(amd::ThreadTraceMemObjectsCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(cmd);
 
@@ -3063,7 +3064,7 @@ void VirtualGPU::submitThreadTraceMemObjects(amd::ThreadTraceMemObjectsCommand& 
 
 void VirtualGPU::submitThreadTrace(amd::ThreadTraceCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(cmd);
 
@@ -3107,7 +3108,7 @@ void VirtualGPU::submitThreadTrace(amd::ThreadTraceCommand& cmd) {
 
 void VirtualGPU::submitAcquireExtObjects(amd::AcquireExtObjectsCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(vcmd);
 
@@ -3126,7 +3127,7 @@ void VirtualGPU::submitAcquireExtObjects(amd::AcquireExtObjectsCommand& vcmd) {
 
 void VirtualGPU::submitReleaseExtObjects(amd::ReleaseExtObjectsCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(vcmd);
 
@@ -3144,7 +3145,7 @@ void VirtualGPU::submitReleaseExtObjects(amd::ReleaseExtObjectsCommand& vcmd) {
 }
 
 void VirtualGPU::submitSignal(amd::SignalCommand& vcmd) {
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
   profilingBegin(vcmd);
   pal::Memory* pGpuMemory = dev().getGpuMemory(&vcmd.memory());
 
@@ -3193,7 +3194,7 @@ void VirtualGPU::submitSignal(amd::SignalCommand& vcmd) {
 }
 
 void VirtualGPU::submitMakeBuffersResident(amd::MakeBuffersResidentCommand& vcmd) {
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
   profilingBegin(vcmd);
 
   std::vector<amd::Memory*> memObjects = vcmd.memObjects();
@@ -3212,7 +3213,7 @@ void VirtualGPU::submitMakeBuffersResident(amd::MakeBuffersResidentCommand& vcmd
   dev().iDev()->AddGpuMemoryReferences(numObjects, pGpuMemRef, queues_[MainEngine]->iQueue_,
                                        Pal::GpuMemoryRefCantTrim);
   {
-    amd::ScopedLock l(queues_[MainEngine]->lock_);
+    std::scoped_lock l(*(queues_[MainEngine]->lock_));
     dev().iDev()->InitBusAddressableGpuMemory(queues_[MainEngine]->iQueue_, numObjects, pGpuMems);
   }
 
@@ -3301,7 +3302,7 @@ void VirtualGPU::flush(amd::Command* list, bool wait) {
 
   {
     //! @todo: Check if really need a lock
-    amd::ScopedLock lock(execution());
+    std::scoped_lock lock(execution());
     for (uint i = 0; i < AllEngines; ++i) {
       flushDMA(i);
       // Reset event so we won't try to wait again,
@@ -3399,7 +3400,7 @@ void VirtualGPU::waitEventLock(CommandBatch* cb) {
   GpuEvent eventsCopy[AllEngines];
 
   {
-    amd::ScopedLock lock(execution());
+    std::scoped_lock lock(execution());
 
     GpuEvent* events = (cb == nullptr) ? events_ : cb->events_;
 

--- a/projects/clr/rocclr/device/pal/palvirtual.hpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.hpp
@@ -180,7 +180,7 @@ class VirtualGPU : public device::VirtualDevice {
 
     static uint32_t AllocedQueues(const VirtualGPU& gpu, Pal::EngineType type);
 
-    amd::Monitor* lock_;                       //!< Lock PAL queue for access
+    std::recursive_mutex* lock_;               //!< Lock PAL queue for access
     Pal::IQueue* iQueue_;                      //!< PAL queue object
     std::vector<Pal::ICmdBuffer*> iCmdBuffs_;  //!< PAL command buffers
     std::vector<Pal::IFence*> iCmdFences_;     //!< PAL fences, associated with CMD

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -1009,10 +1009,7 @@ bool DmaBlitManager::hsaCopyStagedOrPinned(const_address hostSrc, address hostDs
 
 // ================================================================================================
 KernelBlitManager::KernelBlitManager(VirtualGPU& gpu, Setup setup)
-    : DmaBlitManager(gpu, setup),
-      program_(nullptr),
-      xferBufferSize_(0),
-      lockXferOps_(true) /* Transfer Ops Lock*/ {
+    : DmaBlitManager(gpu, setup), program_(nullptr), xferBufferSize_(0) {
   for (uint i = 0; i < BlitTotal; ++i) {
     kernels_[i] = nullptr;
   }
@@ -1122,7 +1119,7 @@ bool KernelBlitManager::copyBufferToImage(device::Memory& srcMemory, device::Mem
                                           amd::CopyMetadata copyMetadata) const {
   guarantee((dev().info().imageSupport_ != false), "Image not supported on this device");
 
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
   amd::Image* dstImage = static_cast<amd::Image*>(dstMemory.owner());
   size_t imgRowPitch = size[0] * dstImage->getImageFormat().getElementSize();
@@ -1333,7 +1330,7 @@ bool KernelBlitManager::copyImageToBuffer(device::Memory& srcMemory, device::Mem
                                           amd::CopyMetadata copyMetadata) const {
   guarantee((dev().info().imageSupport_ != false), "Image not supported on this device");
 
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
   amd::Image* srcImage = static_cast<amd::Image*>(srcMemory.owner());
   size_t imgRowPitch = size[0] * srcImage->getImageFormat().getElementSize();
@@ -1525,7 +1522,7 @@ bool KernelBlitManager::copyImage(device::Memory& srcMemory, device::Memory& dst
                                   amd::CopyMetadata copyMetadata) const {
   guarantee((dev().info().imageSupport_ != false), "Image not supported on this device");
 
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
   Memory* srcView = &gpuMem(srcMemory);
   Memory* dstView = &gpuMem(dstMemory);
@@ -1711,7 +1708,7 @@ bool KernelBlitManager::readImage(device::Memory& srcMemory, void* dstHost,
                                   amd::CopyMetadata copyMetadata) const {
   guarantee((dev().info().imageSupport_ != false), "Image not supported on this device");
 
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
 
   // Use host copy if memory has direct access
@@ -1764,7 +1761,7 @@ bool KernelBlitManager::writeImage(const void* srcHost, device::Memory& dstMemor
                                    amd::CopyMetadata copyMetadata) const {
   guarantee((dev().info().imageSupport_ != false), "Image not supported on this device");
 
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
 
   // Use host copy if memory has direct access
@@ -1814,7 +1811,7 @@ bool KernelBlitManager::copyBufferRect(device::Memory& srcMemory, device::Memory
                                        const amd::BufferRect& srcRectIn,
                                        const amd::BufferRect& dstRectIn, const amd::Coord3D& sizeIn,
                                        bool entire, amd::CopyMetadata copyMetadata) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
   bool rejected = false;
 
@@ -1941,7 +1938,7 @@ bool KernelBlitManager::copyBufferRect(device::Memory& srcMemory, device::Memory
 bool KernelBlitManager::readBuffer(device::Memory& srcMemory, void* dstHost,
                                    const amd::Coord3D& origin, const amd::Coord3D& size,
                                    bool entire, amd::CopyMetadata copyMetadata) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
 
   // Use host copy if memory has direct access
@@ -2022,7 +2019,7 @@ bool KernelBlitManager::readBufferRect(device::Memory& srcMemory, void* dstHost,
                                        const amd::BufferRect& bufRect,
                                        const amd::BufferRect& hostRect, const amd::Coord3D& size,
                                        bool entire, amd::CopyMetadata copyMetadata) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
 
   // Use host copy if memory has direct access
@@ -2075,7 +2072,7 @@ bool KernelBlitManager::readBufferRect(device::Memory& srcMemory, void* dstHost,
 bool KernelBlitManager::writeBuffer(const void* srcHost, device::Memory& dstMemory,
                                     const amd::Coord3D& origin, const amd::Coord3D& size,
                                     bool entire, amd::CopyMetadata copyMetadata) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
 
   // Use host copy if memory has direct access
@@ -2159,7 +2156,7 @@ bool KernelBlitManager::writeBufferRect(const void* srcHost, device::Memory& dst
                                         const amd::BufferRect& hostRect,
                                         const amd::BufferRect& bufRect, const amd::Coord3D& size,
                                         bool entire, amd::CopyMetadata copyMetadata) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
 
   // Use host copy if memory has direct access
@@ -2242,7 +2239,7 @@ bool KernelBlitManager::fillBuffer1D(device::Memory& memory, const void* pattern
                                      size_t patternSize, const amd::Coord3D& surface,
                                      const amd::Coord3D& origin, const amd::Coord3D& size,
                                      bool entire, bool forceBlit) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
 
   // Use host fill if memory has direct access
@@ -2328,7 +2325,7 @@ bool KernelBlitManager::fillBuffer2D(device::Memory& memory, const void* pattern
                                      size_t patternSize, const amd::Coord3D& surface,
                                      const amd::Coord3D& origin, const amd::Coord3D& size,
                                      bool entire, bool forceBlit) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
 
   // Use host fill if memory has direct access
@@ -2603,7 +2600,7 @@ bool KernelBlitManager::copyBuffer(device::Memory& srcMemory, device::Memory& ds
                                    const amd::Coord3D& srcOrigin, const amd::Coord3D& dstOrigin,
                                    const amd::Coord3D& sizeIn, bool entire,
                                    amd::CopyMetadata copyMetadata) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
   uint32_t blitWg = dev().settings().limit_blit_wg_;
 
@@ -2684,7 +2681,7 @@ bool KernelBlitManager::fillImage(device::Memory& memory, const void* pattern,
                                   bool entire) const {
   guarantee((dev().info().imageSupport_ != false), "Image not supported on this device");
 
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
   constexpr size_t kFillImageThreshold = 256 * 256;
 
@@ -2851,7 +2848,7 @@ bool KernelBlitManager::fillImage(device::Memory& memory, const void* pattern,
 // ================================================================================================
 bool KernelBlitManager::streamOpsWrite(device::Memory& memory, uint64_t value, size_t offset,
                                        size_t sizeBytes) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
   uint blitType = StreamOpsWrite;
   size_t dim = 1;
@@ -2884,7 +2881,7 @@ bool KernelBlitManager::streamOpsWrite(device::Memory& memory, uint64_t value, s
 // ================================================================================================
 bool KernelBlitManager::streamOpsWait(device::Memory& memory, uint64_t value, size_t offset,
                                       size_t sizeBytes, uint64_t flags, uint64_t mask) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
   uint blitType = StreamOpsWait;
   size_t dim = 1;
@@ -2926,7 +2923,7 @@ bool KernelBlitManager::streamOpsWait(device::Memory& memory, uint64_t value, si
 // ================================================================================================
 bool KernelBlitManager::batchMemOps(const void* paramArray, size_t paramSize,
                                     uint32_t count) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
   bool result = false;
   uint blitType = BatchMemOp;
   size_t dim = 1;
@@ -3127,7 +3124,7 @@ bool KernelBlitManager::runScheduler(uint64_t vqVM, hsa_queue_t* schedulerQueue,
 
 // ================================================================================================
 bool KernelBlitManager::RunGwsInit(uint32_t value) const {
-  amd::ScopedLock k(lockXferOps_);
+  std::scoped_lock k(lockXferOps_);
 
   if (dev().settings().gwsInitSupported_ == false) {
     LogError("GWS Init is not supported on this target");

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -513,7 +513,7 @@ class KernelBlitManager : public DmaBlitManager {
   //! Batch memory ops- Submits batch of streamWaits and streamWrite operations.
   virtual bool batchMemOps(const void* paramArray, size_t paramSize, uint32_t count) const;
 
-  virtual amd::Monitor* lockXfer() const { return &lockXferOps_; }
+  virtual std::recursive_mutex* lockXfer() const { return &lockXferOps_; }
 
   virtual bool initHeap(device::Memory* heap_to_initialize, device::Memory* initial_blocks,
                         uint heap_size, uint number_of_initial_blocks) const;
@@ -588,7 +588,7 @@ class KernelBlitManager : public DmaBlitManager {
   amd::Program* program_;             //!< GPU program object
   amd::Kernel* kernels_[BlitTotal];   //!< GPU kernels for blit
   size_t xferBufferSize_;             //!< Transfer buffer size
-  mutable amd::Monitor lockXferOps_;  //!< Lock transfer operation
+  mutable std::recursive_mutex lockXferOps_;  //!< Lock transfer operation
 };
 
 static const char* BlitName[KernelBlitManager::BlitTotal] = {

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -136,7 +136,6 @@ Device::Device(hsa_agent_t bkendDevice)
       alloc_granularity_(0),
       xferQueue_(nullptr),
       freeMem_(0),
-      vgpusAccess_(true), /* Virtual GPU List Ops Lock */
       hsa_exclusive_gpu_access_(false),
       coopHostcallBuffer_(nullptr),
       numOfVgpus_(0),
@@ -682,7 +681,7 @@ bool Device::create() {
   }
 
   // Map Cache Lock
-  mapCacheOps_ = new amd::Monitor(true);
+  mapCacheOps_ = new std::recursive_mutex();
   if (nullptr == mapCacheOps_) {
     return false;
   }
@@ -1705,7 +1704,7 @@ bool Device::populateOCLDeviceConstants() {
 
 // ================================================================================================
 device::VirtualDevice* Device::createVirtualDevice(amd::CommandQueue* queue) {
-  amd::ScopedLock lock(vgpusAccess());
+  std::scoped_lock lock(vgpusAccess());
 
   bool profiling = (queue != nullptr) && queue->properties().test(CL_QUEUE_PROFILING_ENABLE);
   bool cooperative = false;
@@ -1829,7 +1828,7 @@ bool Device::unbindExternalDevice(uint flags, void* const gfxDevice[], void* gfx
 
 amd::Memory* Device::findMapTarget(size_t size) const {
   // Must be serialised for access
-  amd::ScopedLock lk(*mapCacheOps_);
+  std::scoped_lock lk(*mapCacheOps_);
 
   amd::Memory* map = nullptr;
   size_t minSize = 0;
@@ -1877,7 +1876,7 @@ amd::Memory* Device::findMapTarget(size_t size) const {
 
 bool Device::addMapTarget(amd::Memory* memory) const {
   // Must be serialised for access
-  amd::ScopedLock lk(*mapCacheOps_);
+  std::scoped_lock lk(*mapCacheOps_);
 
   // the svm memory shouldn't be cached
   if (!memory->canBeCached()) {
@@ -3643,7 +3642,7 @@ void Device::HiddenHeapInit(const VirtualGPU& gpu) {
 // ================================================================================================
 uint32_t Device::SdmaEngineAllocator::AllocateEngine(VirtualGPU* vgpu, HwQueueEngine engine_type,
                                                       hsa_agent_t dstAgent, hsa_agent_t srcAgent) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
 
   // Get valid engine mask based on operation type (read vs write)
   uint32_t validEngineMask = (engine_type == HwQueueEngine::SdmaD2H)
@@ -3769,7 +3768,7 @@ uint32_t Device::SdmaEngineAllocator::AllocateEngine(VirtualGPU* vgpu, HwQueueEn
 
 // ================================================================================================
 void Device::SdmaEngineAllocator::ReleaseEngine(VirtualGPU* vgpu) {
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
 
   auto it = vgpu_to_engine_.find(vgpu);
   if (it != vgpu_to_engine_.end()) {
@@ -3782,14 +3781,14 @@ void Device::SdmaEngineAllocator::ReleaseEngine(VirtualGPU* vgpu) {
 
 // ================================================================================================
 void Device::AddKernel(Kernel& gpuKernel) const {
-  amd::ScopedLock lock(vgpusAccess());
+  std::scoped_lock lock(vgpusAccess());
   kernel_map_.insert({gpuKernel.KernelCodeHandle(), gpuKernel});
 }
 
 // ================================================================================================
 void Device::RemoveKernel(Kernel& gpuKernel) const {
   if (gpuKernel.KernelCodeHandle() != 0) {
-    amd::ScopedLock lock(vgpusAccess());
+    std::scoped_lock lock(vgpusAccess());
     auto it = kernel_map_.find(gpuKernel.KernelCodeHandle());
     if (it != kernel_map_.end()) {
       // Remove the old mapping

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -61,7 +61,7 @@ class ProfilingSignal : public amd::ReferenceCountedObject {
   hsa_signal_t signal_;   //!< HSA signal to track profiling information
   Timestamp* ts_;         //!< Timestamp object associated with the signal
   HwQueueEngine engine_;  //!< Engine used with this signal
-  amd::Monitor lock_;     //!< Signal lock for update
+  std::recursive_mutex lock_;  //!< Signal lock for update
 
   typedef union {
     struct {
@@ -83,25 +83,21 @@ class ProfilingSignal : public amd::ReferenceCountedObject {
   };
   CachedTiming cached_timing_;
 
-  ProfilingSignal()
-      : ts_(nullptr),
-        engine_(HwQueueEngine::Compute),
-        lock_(true) /* Signal Ops Lock */
-  {
+  ProfilingSignal() : ts_(nullptr), engine_(HwQueueEngine::Compute) {
     signal_.handle = 0;
     flags_.data_ = 0;
     flags_.done_ = true;
   }
 
   virtual ~ProfilingSignal();
-  amd::Monitor& LockSignalOps() { return lock_; }
+  std::recursive_mutex& LockSignalOps() { return lock_; }
 
   //! Cache timing data from HSA for this signal (called once when signal completes)
   void CacheTimingData(hsa_agent_t gpu_device);
 
   //! Reset cached timing for signal reuse
   void ResetCachedTiming() {
-    amd::ScopedLock lock(lock_);
+    std::scoped_lock lock(lock_);
     cached_timing_.start_ = 0;
     cached_timing_.end_ = 0;
     cached_timing_.valid_ = false;
@@ -112,7 +108,7 @@ class ProfilingSignal : public amd::ReferenceCountedObject {
 
   //! Get cached timing values
   void GetCachedTiming(uint64_t& start, uint64_t& end) {
-    amd::ScopedLock lock(lock_);
+    std::scoped_lock lock(lock_);
     start = cached_timing_.start_;
     end = cached_timing_.end_;
   }
@@ -529,7 +525,7 @@ class Device : public NullDevice {
   void updateFreeMemory(size_t size, bool free);
 
   //! Returns the lock object for the virtual gpus list
-  amd::Monitor& vgpusAccess() const { return vgpusAccess_; }
+  std::recursive_mutex& vgpusAccess() const { return vgpusAccess_; }
 
   typedef std::vector<VirtualGPU*> VirtualGPUs;
   //! Returns the list of all virtual GPUs running on this device
@@ -629,7 +625,7 @@ class Device : public NullDevice {
 
   static hsa_ven_amd_loader_1_00_pfn_t amd_loader_ext_table;
 
-  amd::Monitor* mapCacheOps_;            //!< Lock to serialise cache for the map resources
+  std::recursive_mutex* mapCacheOps_;    //!< Lock to serialise cache for the map resources
   std::vector<amd::Memory*>* mapCache_;  //!< Map cache info structure
 
   bool populateOCLDeviceConstants();
@@ -659,7 +655,7 @@ class Device : public NullDevice {
   VirtualGPU* xferQueue_;  //!< Transfer queue, created on demand
 
   std::atomic<size_t> freeMem_;       //!< Total of free memory available
-  mutable amd::Monitor vgpusAccess_;  //!< Lock to serialise virtual gpu list access
+  mutable std::recursive_mutex vgpusAccess_;  //!< Lock to serialise virtual gpu list access
   bool hsa_exclusive_gpu_access_;  //!< TRUE if current device was moved into exclusive GPU access
                                    //!< mode
   static address mg_sync_;         //!< MGPU grid launch sync memory (SVM location)
@@ -738,8 +734,7 @@ class Device : public NullDevice {
     std::atomic<uint32_t> next_rr_engine_{0};  //!< Simple RR counter for future use
     const Device& device_;  //!< Reference to parent device for accessing masks
 
-    SdmaEngineAllocator(const Device& device)
-        : lock_(true), device_(device) {}
+    SdmaEngineAllocator(const Device& device) : device_(device) {}
 
     //! Allocate an SDMA engine for a VirtualGPU
     //! Queries HSA for engine status and preferred engines, then allocates

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -103,7 +103,7 @@ bool Memory::allocateMapMemory(size_t allocationSize) {
 void* Memory::allocMapTarget(const amd::Coord3D& origin, const amd::Coord3D& region, uint mapFlags,
                              size_t* rowPitch, size_t* slicePitch) {
   // Map/Unmap must be serialized.
-  amd::ScopedLock lock(owner()->lockMemoryOps());
+  std::scoped_lock lock(owner()->lockMemoryOps());
 
   incIndMapCount();
   // If the device backing storage is direct accessible, use it.
@@ -151,7 +151,7 @@ void* Memory::allocMapTarget(const amd::Coord3D& origin, const amd::Coord3D& reg
 
 void Memory::decIndMapCount() {
   // Map/Unmap must be serialized.
-  amd::ScopedLock lock(owner()->lockMemoryOps());
+  std::scoped_lock lock(owner()->lockMemoryOps());
 
   if (indirectMapCount_ == 0) {
     LogError("decIndMapCount() called when indirectMapCount_ already zero");
@@ -368,7 +368,7 @@ bool Memory::pinSystemMemory(void* hostPtr, size_t size) {
 }
 
 void Memory::syncCacheFromHost(VirtualGPU& gpu, device::Memory::SyncFlags syncFlags) {
-  amd::ScopedLock lock(owner()->lockMemoryOps());
+  std::scoped_lock lock(owner()->lockMemoryOps());
   // If the last writer was another GPU, then make a writeback
   if (!isHostMemDirectAccess() && (owner()->getLastWriter() != nullptr) &&
       (&dev() != owner()->getLastWriter())) {
@@ -396,7 +396,7 @@ void Memory::syncCacheFromHost(VirtualGPU& gpu, device::Memory::SyncFlags syncFl
       // Make sure the parent sync is an unique operation.
       // If the app uses multiple subbuffers from multiple queues,
       // then the parent sync can be called from multiple threads
-      amd::ScopedLock lock(owner()->parent()->lockMemoryOps());
+      std::scoped_lock lock(owner()->parent()->lockMemoryOps());
       gpuMemory->syncCacheFromHost(gpu, syncFlagsTmp);
       //! \note Don't do early exit here, since we still have to sync
       //! this view, if the parent sync operation was a NOP.
@@ -509,7 +509,7 @@ void Memory::syncHostFromCache(device::VirtualDevice* vDev, device::Memory::Sync
       // Make sure the parent sync is an unique operation.
       // If the app uses multiple subbuffers from multiple queues,
       // then the parent sync can be called from multiple threads
-      amd::ScopedLock lock(owner()->parent()->lockMemoryOps());
+      std::scoped_lock lock(owner()->parent()->lockMemoryOps());
       m->syncHostFromCache(gpu, syncFlagsTmp);
       //! \note Don't do early exit here, since we still have to sync
       //! this view, if the parent sync operation was a NOP.
@@ -537,7 +537,7 @@ void Memory::syncHostFromCache(device::VirtualDevice* vDev, device::Memory::Sync
         syncFlagsTmp.skipEntire_ = syncFlags.skipEntire_;
       }
 
-      amd::ScopedLock lock(owner()->lockMemoryOps());
+      std::scoped_lock lock(owner()->lockMemoryOps());
       for (auto& sub : owner()->subBuffers()) {
         //! \note Don't allow subbuffer's allocation in the worker thread.
         //! It may cause a system lock, because possible resource
@@ -602,7 +602,7 @@ void Memory::syncHostFromCache(device::VirtualDevice* vDev, device::Memory::Sync
 
 void Memory::mgpuCacheWriteBack(VirtualGPU& gpu) {
   // Lock memory object, so only one write back can occur
-  amd::ScopedLock lock(owner()->lockMemoryOps());
+  std::scoped_lock lock(owner()->lockMemoryOps());
 
   // Attempt to allocate a staging buffer if don't have any
   if (owner()->getHostMem() == nullptr) {
@@ -1498,7 +1498,7 @@ bool Image::createView(const Memory& parent) {
 
 void* Image::allocMapTarget(const amd::Coord3D& origin, const amd::Coord3D& region, uint mapFlags,
                             size_t* rowPitch, size_t* slicePitch) {
-  amd::ScopedLock lock(owner()->lockMemoryOps());
+  std::scoped_lock lock(owner()->lockMemoryOps());
 
   incIndMapCount();
 
@@ -1618,7 +1618,7 @@ bool Image::ValidateMemory() {
 
 // ================================================================================================
 bool Image::AddView(amd::Image* image) {
-  amd::ScopedLock l(owner()->lockMemoryOps());
+  std::scoped_lock l(owner()->lockMemoryOps());
   for (auto it : view_cache_) {
     if ((it->getImageFormat().image_channel_data_type ==
          image->getImageFormat().image_channel_data_type) &&
@@ -1635,7 +1635,7 @@ bool Image::AddView(amd::Image* image) {
 
 // ================================================================================================
 amd::Image* Image::FindView(cl_image_format format) const {
-  amd::ScopedLock l(owner()->lockMemoryOps());
+  std::scoped_lock l(owner()->lockMemoryOps());
   for (auto it : view_cache_) {
     if ((it->getImageFormat().image_channel_data_type == format.image_channel_data_type) &&
         (it->getImageFormat().image_channel_order == format.image_channel_order)) {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -124,7 +124,7 @@ static unsigned extractAqlBits(unsigned v, unsigned pos, unsigned width) {
 // ================================================================================================
 void ProfilingSignal::CacheTimingData(hsa_agent_t gpu_device) {
   // Lock needed as async handler thread can also touch this structure
-  amd::ScopedLock lock(lock_);
+  std::scoped_lock lock(lock_);
 
   // Return if timing is already cached
   if (cached_timing_.valid_) {
@@ -156,7 +156,7 @@ void ProfilingSignal::CacheTimingData(hsa_agent_t gpu_device) {
 // If single_signal is nullptr, processes all signals and clears the list
 // If single_signal is provided, processes only that signal with merge enabled
 void Timestamp::checkGpuTime(ProfilingSignal* single_signal) {
-  amd::ScopedLock s(lock_);
+  std::scoped_lock s(lock_);
 
   // For single signal mode, validate it exists in the list
   if (single_signal != nullptr) {
@@ -242,7 +242,7 @@ void Timestamp::ExtractSignalTiming(ProfilingSignal* signal,
   signal->GetCachedTiming(sig_start, sig_end);
 
   // Lock signal for accessing engine_ and flags_
-  amd::ScopedLock sig_lock(signal->LockSignalOps());
+  std::scoped_lock sig_lock(signal->LockSignalOps());
 
   // Update appropriate accumulators based on engine type
   if (IsSdmaEngine(signal->engine_)) {
@@ -721,7 +721,7 @@ bool VirtualGPU::HwQueueTracker::CpuWaitForSignal(ProfilingSignal* signal) {
     signal->ts_ = nullptr;
   } else {
     // No timestamp - just mark signal as done
-    amd::ScopedLock lock(signal->LockSignalOps());
+    std::scoped_lock lock(signal->LockSignalOps());
     signal->flags_.done_ = true;
   }
 
@@ -1010,7 +1010,7 @@ bool VirtualGPU::processMemObjects(const amd::Kernel& kernel, const_address para
 
 // ================================================================================================
 uint64_t VirtualGPU::getQueueID() {
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
   // Dedicated queues keep their HW queue, never acquire from pool
   if (!dedicated_queue_ && gpu_queue_ == nullptr) {
     gpu_queue_ = roc_device_.AcquireActiveQueue(priority_);
@@ -1483,7 +1483,7 @@ bool VirtualGPU::dispatchAqlPacketBatch(const std::vector<uint8_t*>& packets,
     return false;
   }
 
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
   profilingBegin(*vcmd);
 
   dispatchBlockingWait();
@@ -1794,7 +1794,7 @@ VirtualGPU::~VirtualGPU() {
   delete blitMgr_;
 
   if (tracking_created_) {
-    amd::ScopedLock l(execution());
+    std::scoped_lock l(execution());
     // Dedicated queues keep their HW queue, never acquire from pool
     if (!dedicated_queue_ && gpu_queue_ == nullptr) {
       gpu_queue_ = roc_device_.AcquireActiveQueue(priority_);
@@ -1839,7 +1839,7 @@ VirtualGPU::~VirtualGPU() {
 
   {
     // Lock the device to make the following thread safe
-    amd::ScopedLock lock(roc_device_.vgpusAccess());
+    std::scoped_lock lock(roc_device_.vgpusAccess());
 
     --roc_device_.numOfVgpus_;  // Virtual gpu unique index decrementing
     roc_device_.vgpus_.erase(roc_device_.vgpus_.begin() + index());
@@ -2006,7 +2006,7 @@ void* VirtualGPU::allocKernArg(size_t size, size_t alignment) {
 address VirtualGPU::allocKernelArguments(size_t size, size_t alignment) {
   if (ROC_SKIP_KERNEL_ARG_COPY) {
     // Make sure VirtualGPU has an exclusive access to the resources
-    amd::ScopedLock lock(execution());
+    std::scoped_lock lock(execution());
     return reinterpret_cast<address>(allocKernArg(size, alignment));
   } else {
     return nullptr;
@@ -2034,7 +2034,7 @@ void VirtualGPU::ReleaseAllHwQueues() {
     }
     if (should_release) {
       // Lock the device to make the following thread safe
-      amd::ScopedLock lock(roc_device_.vgpusAccess());
+      std::scoped_lock lock(roc_device_.vgpusAccess());
       for (uint idx = 0; idx < roc_device_.vgpus().size(); ++idx) {
         roc_device_.vgpus()[idx]->ReleaseHwQueue();
       }
@@ -2056,7 +2056,7 @@ void VirtualGPU::ReleaseHwQueue() {
       (cuMask_.size() == 0)) {
     // If tryLock fails, skip the release - the queue will be released
     // on next opportunity
-    if (execution().tryLock()) {
+    if (execution().try_lock()) {
       if (gpu_queue_ != nullptr) {
         if (IsQueueIdle()) {
           if (roc_device_.ReleaseActiveQueue(gpu_queue_, priority_)) {
@@ -2249,7 +2249,7 @@ void VirtualGPU::updateCommandsState(amd::Command* list) const {
 
 void VirtualGPU::submitReadMemory(amd::ReadMemoryCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(cmd, true);
 
@@ -2353,7 +2353,7 @@ void VirtualGPU::submitReadMemory(amd::ReadMemoryCommand& cmd) {
 
 void VirtualGPU::submitWriteMemory(amd::WriteMemoryCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(cmd, true);
 
@@ -2449,7 +2449,7 @@ void VirtualGPU::submitWriteMemory(amd::WriteMemoryCommand& cmd) {
 // ================================================================================================
 void VirtualGPU::submitSvmFreeMemory(amd::SvmFreeMemoryCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   // in-order semantics: previous commands need to be done before we start
   releaseGpuMemoryFence();
@@ -2471,7 +2471,7 @@ void VirtualGPU::submitSvmFreeMemory(amd::SvmFreeMemoryCommand& cmd) {
 // ================================================================================================
 void VirtualGPU::submitSvmPrefetchAsync(amd::SvmPrefetchAsyncCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
   profilingBegin(cmd);
 
   if (dev().info().hmmSupported_) {
@@ -2627,7 +2627,7 @@ bool VirtualGPU::copyMemory(cl_command_type type, amd::Memory& srcMem, amd::Memo
 // ================================================================================================
 void VirtualGPU::submitCopyMemory(amd::CopyMemoryCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(cmd, true);
 
@@ -2650,7 +2650,7 @@ void VirtualGPU::submitCopyMemory(amd::CopyMemoryCommand& cmd) {
 // ================================================================================================
 void VirtualGPU::submitSvmCopyMemory(amd::SvmCopyMemoryCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(cmd, true);
   // no op for FGS supported device
@@ -2732,7 +2732,7 @@ void VirtualGPU::submitSvmCopyMemory(amd::SvmCopyMemoryCommand& cmd) {
 // ================================================================================================
 void VirtualGPU::submitCopyMemoryP2P(amd::CopyMemoryP2PCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(cmd, true);
 
@@ -2776,7 +2776,7 @@ void VirtualGPU::submitCopyMemoryP2P(amd::CopyMemoryP2PCommand& cmd) {
         // Sync the current queue, since P2P staging uses the device queues for transfer
         releaseGpuMemoryFence();
 
-        amd::ScopedLock lock(dev().P2PStageOps());
+        std::scoped_lock lock(dev().P2PStageOps());
         Memory* dstStgMem = static_cast<Memory*>(
             dev().P2PStage()->getDeviceMemory(*cmd.source().getContext().devices()[0]));
         Memory* srcStgMem = static_cast<Memory*>(
@@ -2812,7 +2812,7 @@ void VirtualGPU::submitCopyMemoryP2P(amd::CopyMemoryP2PCommand& cmd) {
         // Sync the current queue, since P2P staging uses the device queues for transfer
         releaseGpuMemoryFence();
 
-        amd::ScopedLock lock(dev().P2PStageOps());
+        std::scoped_lock lock(dev().P2PStageOps());
         Memory* dstStgMem = static_cast<Memory*>(
             dev().P2PStage()->getDeviceMemory(*cmd.source().getContext().devices()[0]));
         Memory* srcStgMem = static_cast<Memory*>(
@@ -2888,7 +2888,7 @@ void VirtualGPU::submitCopyMemoryP2P(amd::CopyMemoryP2PCommand& cmd) {
 // ================================================================================================
 void VirtualGPU::submitBatchCopyMemory(amd::BatchCopyMemoryCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(cmd, true);
 
@@ -2948,7 +2948,7 @@ void VirtualGPU::submitBatchCopyMemory(amd::BatchCopyMemoryCommand& cmd) {
 // ================================================================================================
 void VirtualGPU::submitSvmMapMemory(amd::SvmMapMemoryCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(cmd, true);
 
@@ -2985,7 +2985,7 @@ void VirtualGPU::submitSvmMapMemory(amd::SvmMapMemoryCommand& cmd) {
 // ================================================================================================
 void VirtualGPU::submitSvmUnmapMemory(amd::SvmUnmapMemoryCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(cmd, true);
 
@@ -3024,7 +3024,7 @@ void VirtualGPU::submitSvmUnmapMemory(amd::SvmUnmapMemoryCommand& cmd) {
 // ================================================================================================
 void VirtualGPU::submitMapMemory(amd::MapMemoryCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(cmd, true);
 
@@ -3123,7 +3123,7 @@ void VirtualGPU::submitMapMemory(amd::MapMemoryCommand& cmd) {
 // ================================================================================================
 void VirtualGPU::submitUnmapMemory(amd::UnmapMemoryCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   roc::Memory* devMemory = static_cast<roc::Memory*>(cmd.memory().getDeviceMemory(dev(), false));
 
@@ -3217,7 +3217,7 @@ bool VirtualGPU::fillMemory(cl_command_type type, amd::Memory* amdMemory, const 
                             size_t patternSize, const amd::Coord3D& surface,
                             const amd::Coord3D& origin, const amd::Coord3D& size, bool forceBlit) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   Memory* memory = dev().getRocMemory(amdMemory);
 
@@ -3278,7 +3278,7 @@ bool VirtualGPU::fillMemory(cl_command_type type, amd::Memory* amdMemory, const 
 // ================================================================================================
 void VirtualGPU::submitFillMemory(amd::FillMemoryCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(cmd);
 
@@ -3298,7 +3298,7 @@ void VirtualGPU::submitFillMemory(amd::FillMemoryCommand& cmd) {
 // ================================================================================================
 void VirtualGPU::submitStreamOperation(amd::StreamOperationCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
   profilingBegin(cmd);
 
   const cl_command_type type = cmd.type();
@@ -3379,7 +3379,7 @@ void VirtualGPU::submitStreamOperation(amd::StreamOperationCommand& cmd) {
 // ================================================================================================
 void VirtualGPU::submitBatchMemoryOperation(amd::BatchMemoryOperationCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
   profilingBegin(cmd);
 
   bool result = blitMgr().batchMemOps(cmd.getParamPtr(), cmd.paramSize(), cmd.count());
@@ -3392,7 +3392,7 @@ void VirtualGPU::submitBatchMemoryOperation(amd::BatchMemoryOperationCommand& cm
 // ================================================================================================
 void VirtualGPU::submitVirtualMap(amd::VirtualMapCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(vcmd);
 
@@ -3457,7 +3457,7 @@ void VirtualGPU::submitVirtualMap(amd::VirtualMapCommand& vcmd) {
 // ================================================================================================
 void VirtualGPU::submitSvmFillMemory(amd::SvmFillMemoryCommand& cmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(cmd);
 
@@ -3495,7 +3495,7 @@ void VirtualGPU::submitSvmFillMemory(amd::SvmFillMemoryCommand& cmd) {
 // ================================================================================================
 void VirtualGPU::submitMigrateMemObjects(amd::MigrateMemObjectsCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(vcmd);
 
@@ -4170,7 +4170,7 @@ void VirtualGPU::submitKernel(amd::NDRangeKernelCommand& vcmd) {
     }
 
     // Lock the queue, using the blit manager lock
-    amd::ScopedLock lock(queue->blitMgr().lockXfer());
+    std::scoped_lock k(*(queue->blitMgr().lockXfer()));
 
     queue->profilingBegin(vcmd);
 
@@ -4203,7 +4203,7 @@ void VirtualGPU::submitKernel(amd::NDRangeKernelCommand& vcmd) {
     queue->profilingEnd();
   } else {
     // Make sure VirtualGPU has an exclusive access to the resources
-    amd::ScopedLock lock(execution());
+    std::scoped_lock lock(execution());
 
     profilingBegin(vcmd);
 
@@ -4225,7 +4225,7 @@ void VirtualGPU::submitNativeFn(amd::NativeFnCommand& cmd) {}
 // ================================================================================================
 void VirtualGPU::submitMarker(amd::Marker& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
   if (vcmd.CpuWaitRequested()) {
     force_irq_ = IS_WINDOWS;
     // It should be safe to call flush directly if there are not pending dispatches without
@@ -4265,7 +4265,7 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
 // ================================================================================================
 void VirtualGPU::submitAccumulate(amd::AccumulateCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
   profilingBegin(vcmd);
 
   const Settings& settings = dev().settings();
@@ -4281,7 +4281,7 @@ void VirtualGPU::submitAccumulate(amd::AccumulateCommand& vcmd) {
 // ================================================================================================
 void VirtualGPU::submitAcquireExtObjects(amd::AcquireExtObjectsCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   profilingBegin(vcmd);
   addSystemScope();
@@ -4291,7 +4291,7 @@ void VirtualGPU::submitAcquireExtObjects(amd::AcquireExtObjectsCommand& vcmd) {
 // ================================================================================================
 void VirtualGPU::submitReleaseExtObjects(amd::ReleaseExtObjectsCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
   profilingBegin(vcmd);
   profilingEnd();
 }
@@ -4324,7 +4324,7 @@ void VirtualGPU::enableSyncBlit() const { blitMgr_->enableSynchronization(); }
 // ================================================================================================
 void VirtualGPU::submitPerfCounter(amd::PerfCounterCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
-  amd::ScopedLock lock(execution());
+  std::scoped_lock lock(execution());
 
   const amd::PerfCounterCommand::PerfCounterList counters = vcmd.getCounters();
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -103,7 +103,7 @@ class Timestamp : public amd::ReferenceCountedObject {
   amd::Command* parsedCommand_;            //!< Command down the list, considering command_ as head
   std::vector<ProfilingSignal*> signals_;  //!< The list of all signals, associated with the TS
   hsa_signal_t callback_signal_;  //!< Signal associated with a callback for possible later update
-  amd::Monitor lock_;             //!< Serialize timestamp update
+  std::recursive_mutex lock_;     //!< Serialize timestamp update
   bool accum_ena_ = false;        //!< If TRUE then the accumulation of execution times has started
   bool hasHwProfiling_ = false;   //!< If TRUE then HwProfiling is enabled for the command
   bool blocking_ = true;          //!< If TRUE callback is blocking
@@ -123,8 +123,7 @@ class Timestamp : public amd::ReferenceCountedObject {
         gpu_(gpu),
         command_(command),
         parsedCommand_(nullptr),
-        callback_signal_(hsa_signal_t{}),
-        lock_(true) /* Timestamp lock */ {}
+        callback_signal_(hsa_signal_t{}) {}
 
   ~Timestamp() {}
 

--- a/projects/clr/rocclr/platform/command.cpp
+++ b/projects/clr/rocclr/platform/command.cpp
@@ -390,7 +390,7 @@ void Command::enqueue() {
 
     // The batch update must be lock protected to avoid a race condition
     // when multiple threads submit/flush/update the batch at the same time
-    ScopedLock sl(queue_->vdev()->execution());
+    std::scoped_lock sl(queue_->vdev()->execution());
     queue_->FormSubmissionBatch(this);
 
     // Enqueue flushes, except profiling markers to avoid frequent expensive callbacks
@@ -802,7 +802,7 @@ bool CopyMemoryP2PCommand::validateMemory() {
   }
 
   if (devices[0]->P2PStage() != nullptr && p2pStaging) {
-    amd::ScopedLock lock(devices[0]->P2PStageOps());
+    std::scoped_lock lock(devices[0]->P2PStageOps());
     // Make sure runtime allocates memory on every device
     for (uint d = 0; d < devices[0]->GlbCtx().devices().size(); ++d) {
       device::Memory* mem =

--- a/projects/clr/rocclr/platform/commandqueue.cpp
+++ b/projects/clr/rocclr/platform/commandqueue.cpp
@@ -218,7 +218,7 @@ void HostQueue::finish(bool cpu_wait) {
     command->awaitCompletion();
   }
   if (IS_HIP) {
-    ScopedLock sl(vdev()->execution());
+    std::scoped_lock sl(vdev()->execution());
     ScopedLock l(lastCmdLock_);
     // Runtime can clear the last command only if no other submissions occured
     // during finish()
@@ -362,7 +362,7 @@ Command* HostQueue::getLastQueuedCommand(bool retain) {
   if (AMD_DIRECT_DISPATCH) {
     // The batch update must be lock protected to avoid a race condition
     // when multiple threads submit/flush/update the batch at the same time
-    ScopedLock sl(vdev()->execution());
+    std::scoped_lock sl(vdev()->execution());
     // Since the lastCmdLock_ is acquired, it is safe to read and retain the lastEnqueueCommand.
     // It is guaranteed that the pointer will not change.
     if (retain && lastEnqueueCommand_ != nullptr) {

--- a/projects/clr/rocclr/platform/commandqueue.hpp
+++ b/projects/clr/rocclr/platform/commandqueue.hpp
@@ -245,7 +245,7 @@ class HostQueue : public CommandQueue {
 
   //! Get the current batch size
   size_t GetSubmissionBatchSize() const {
-    ScopedLock sl(vdev()->execution());
+    std::scoped_lock sl(vdev()->execution());
     return size_;
   }
 

--- a/projects/clr/rocclr/platform/memory.cpp
+++ b/projects/clr/rocclr/platform/memory.cpp
@@ -97,7 +97,6 @@ Memory::Memory(Context& context, Type type, Flags flags, size_t size, void* svmP
       svmHostAddress_(svmPtr),
       resOffset_(0),
       flagsEx_(0),
-      lockMemoryOps_(true),
       alignment_(alignment) /* Memory Ops Lock */ {
   svmPtrCommited_ = (flags & CL_MEM_SVM_FINE_GRAIN_BUFFER) ? true : false;
   canBeCached_ = true;
@@ -121,8 +120,7 @@ Memory::Memory(Memory& parent, Flags flags, size_t origin, size_t size, Type typ
       mapCount_(0),
       svmHostAddress_(parent.getSvmPtr()),
       resOffset_(0),
-      flagsEx_(0),
-      lockMemoryOps_(true) /* Memory Ops Lock */ {
+      flagsEx_(0) {
   svmPtrCommited_ = parent.isSvmPtrCommited();
   canBeCached_ = true;
   parent_->retain();
@@ -192,12 +190,12 @@ void Memory::operator delete(void* p, const Context& context) { Memory::operator
 
 
 void Memory::addSubBuffer(Memory* view) {
-  amd::ScopedLock lock(lockMemoryOps());
+  std::scoped_lock lock(lockMemoryOps());
   subBuffers_.emplace(view);
 }
 
 void Memory::removeSubBuffer(Memory* view) {
-  amd::ScopedLock lock(lockMemoryOps());
+  std::scoped_lock lock(lockMemoryOps());
   subBuffers_.erase(view);
 }
 
@@ -331,7 +329,7 @@ bool Memory::addDeviceMemory(const Device* dev) {
   AllocState create = AllocCreate;
   AllocState init = AllocInit;
 
-  amd::ScopedLock lock(lockMemoryOps());
+  std::scoped_lock lock(lockMemoryOps());
   if (deviceAlloced_[dev].compare_exchange_strong(init, create, std::memory_order_acq_rel)) {
     // Check if runtime already allocated all available slots for device memory
     if (numDevices() == NumDevicesWithP2P()) {
@@ -533,7 +531,7 @@ bool Memory::usesSvmPointer() const {
 }
 
 void Memory::commitSvmMemory() {
-  ScopedLock lock(lockMemoryOps_);
+  std::scoped_lock lock(lockMemoryOps_);
   // if VRAM is visible for host, it is not necessary to mmap again
   if (!svmPtrCommited_ && !largeBarSystem_) {
     if (amd::Os::commitMemory(svmHostAddress_, size_, amd::Os::MEM_PROT_RW)) {
@@ -545,7 +543,7 @@ void Memory::commitSvmMemory() {
 }
 
 void Memory::uncommitSvmMemory() {
-  ScopedLock lock(lockMemoryOps_);
+  std::scoped_lock lock(lockMemoryOps_);
   if (svmPtrCommited_ && !(flags_ & CL_MEM_SVM_FINE_GRAIN_BUFFER)) {
     if (amd::Os::uncommitMemory(svmHostAddress_, size_)) {
       svmPtrCommited_ = false;
@@ -1517,21 +1515,21 @@ void Image::Format::formatColor(const void* colorRGBA, void* colorFormat) const 
   }
 }
 
-Monitor SvmBuffer::AllocatedLock_ ROCCLR_INIT_PRIORITY(101)("Guards SVM allocation list");
+std::recursive_mutex SvmBuffer::AllocatedLock_ ROCCLR_INIT_PRIORITY(101);
 std::map<uintptr_t, uintptr_t> SvmBuffer::Allocated_ ROCCLR_INIT_PRIORITY(101);
 
 void SvmBuffer::Add(uintptr_t k, uintptr_t v) {
-  ScopedLock lock(AllocatedLock_);
+  std::scoped_lock lock(AllocatedLock_);
   Allocated_.insert(std::pair<uintptr_t, uintptr_t>(k, v));
 }
 
 void SvmBuffer::Remove(uintptr_t k) {
-  ScopedLock lock(AllocatedLock_);
+  std::scoped_lock lock(AllocatedLock_);
   Allocated_.erase(k);
 }
 
 bool SvmBuffer::Contains(uintptr_t ptr) {
-  ScopedLock lock(AllocatedLock_);
+  std::scoped_lock lock(AllocatedLock_);
   auto it = Allocated_.upper_bound(ptr);
   if (it == Allocated_.begin()) {
     return false;

--- a/projects/clr/rocclr/platform/memory.hpp
+++ b/projects/clr/rocclr/platform/memory.hpp
@@ -212,7 +212,7 @@ class Memory : public amd::RuntimeObject {
   //! Disable default copy operator
   Memory(const Memory&);
 
-  Monitor lockMemoryOps_;         //!< Lock to serialize memory operations
+  std::recursive_mutex lockMemoryOps_;  //!< Lock to serialize memory operations
   std::set<Memory*> subBuffers_;  //!< List of all subbuffers for this memory object
   device::Memory* svmBase_;       //!< svmBase allocation for MGPU case
   size_t alignment_ = 0;          //!< alignment for allocation address
@@ -264,7 +264,7 @@ class Memory : public amd::RuntimeObject {
   );
 
   //! Returns the memory lock object
-  amd::Monitor& lockMemoryOps() { return lockMemoryOps_; }
+  std::recursive_mutex& lockMemoryOps() { return lockMemoryOps_; }
 
   //! Adds a view into the list
   void addSubBuffer(Memory* item);
@@ -682,7 +682,7 @@ class SvmBuffer : AllStatic {
   static bool Contains(uintptr_t ptr);
 
   static std::map<uintptr_t, uintptr_t> Allocated_;  // !< Allocated buffers
-  static Monitor AllocatedLock_;
+  static std::recursive_mutex AllocatedLock_;
 };
 
 class ArenaMemory : public Buffer {

--- a/projects/clr/rocclr/platform/object.hpp
+++ b/projects/clr/rocclr/platform/object.hpp
@@ -207,7 +207,7 @@ struct Coord3D {
 
 template <class T> class SysmemPool {
  public:
-  SysmemPool() : chunk_access_(true) /* Sysmem Pool Lock */ {}
+  SysmemPool() {}
   ~SysmemPool() {
     if (free_chunk_num_ != max_chunk_idx_) {
       for (int i = 0; i < kActiveAllocSize; ++i) {
@@ -234,7 +234,7 @@ template <class T> class SysmemPool {
     size_t current = current_alloc_++;
     auto idx = current / kAllocChunkSize;
     while (idx >= max_chunk_idx_) {
-      ScopedLock lock(chunk_access_);
+      std::scoped_lock lock(chunk_access_);
       // Second check in a case of multiple waiters
       if (idx == max_chunk_idx_) {
         auto allocs = new MemoryObject[kAllocChunkSize];
@@ -285,7 +285,7 @@ template <class T> class SysmemPool {
       auto base = obj->base_;
       {
         // Make sure active chunks don't have a stale pointer
-        ScopedLock lock(chunk_access_);
+        std::scoped_lock lock(chunk_access_);
         for (int i = 0; i < kActiveAllocSize; ++i) {
           if (base->allocs_ == active_allocs_[i]) {
             active_allocs_[i] = nullptr;
@@ -318,7 +318,7 @@ template <class T> class SysmemPool {
   std::atomic<uint64_t> current_alloc_ = 0;             //!< Current allocation, global index
   std::atomic<size_t> max_chunk_idx_ = 0;               //!< Current max chunk index
   size_t free_chunk_num_ = 0;                           //!< The number of freed chunks
-  amd::Monitor chunk_access_;                           //!< Lock for the chunk list access
+  std::recursive_mutex chunk_access_;                   //!< Lock for the chunk list access
   MemoryObject* active_allocs_[kActiveAllocSize] = {};  //!< Active chunks for fast access
 };
 

--- a/projects/clr/rocclr/platform/program.cpp
+++ b/projects/clr/rocclr/platform/program.cpp
@@ -190,7 +190,7 @@ int32_t Program::compile(const std::vector<Device*>& devices, size_t numHeaders,
                          const char** headerIncludeNames, const char* options,
                          void(CL_CALLBACK* notifyFptr)(cl_program, void*), void* data,
                          bool optionChangable) {
-  ScopedLock sl(&programLock_);
+  std::scoped_lock sl(programLock_);
 
   int32_t retval = CL_SUCCESS;
 
@@ -261,7 +261,7 @@ int32_t Program::link(const std::vector<Device*>& devices, size_t numInputs,
                       const std::vector<Program*>& inputPrograms, const char* options,
                       void(CL_CALLBACK* notifyFptr)(cl_program, void*), void* data,
                       bool optionChangable) {
-  ScopedLock sl(&programLock_);
+  std::scoped_lock sl(programLock_);
 
   int32_t retval = CL_SUCCESS;
 
@@ -407,7 +407,7 @@ void Program::StubProgramSource(const std::string& app_name) {
 int32_t Program::build(const std::vector<Device*>& devices, const char* options,
                        void(CL_CALLBACK* notifyFptr)(cl_program, void*), void* data,
                        bool optionChangable, bool newDevProg) {
-  ScopedLock sl(&programLock_);
+  std::scoped_lock sl(programLock_);
 
   int32_t retval = CL_SUCCESS;
 
@@ -513,7 +513,7 @@ int32_t Program::build(const std::vector<Device*>& devices, const char* options,
 }
 
 bool Program::load(const std::vector<Device*>& devices) {
-  ScopedLock sl(&programLock_);
+  std::scoped_lock sl(programLock_);
 
   for (const auto& it : devicePrograms_) {
     const Device& device = *(it.first);

--- a/projects/clr/rocclr/platform/program.hpp
+++ b/projects/clr/rocclr/platform/program.hpp
@@ -100,7 +100,7 @@ class Program : public RuntimeObject {
 
   std::string programLog_;  //!< Log for parsing options, etc.
 
-  Monitor programLock_;  //!< Lock to protect program data structure
+  std::recursive_mutex programLock_;  //!< Lock to protect program data structure
 
  protected:
   //! Destroy this program.
@@ -117,8 +117,7 @@ class Program : public RuntimeObject {
         sourceCode_(sourceCode),
         language_(language),
         symbolTable_(NULL),
-        programLog_(),
-        programLock_(true) /* Program lock */ {
+        programLog_() {
     for (auto i = 0; i != numHeaders; ++i) {
       headers_.emplace_back(headers[i]);
       headerNames_.emplace_back(headerNames[i]);
@@ -127,10 +126,7 @@ class Program : public RuntimeObject {
 
   //! Construct a new program associated with a context.
   Program(Context& context, Language language = Binary)
-      : context_(context),
-        language_(language),
-        symbolTable_(NULL),
-        programLock_(true) /* Program lock */ {}
+      : context_(context), language_(language), symbolTable_(NULL) {}
 
   //! Returns context, associated with the current program.
   const Context& context() const { return context_(); }

--- a/projects/clr/rocclr/platform/vmheap.cpp
+++ b/projects/clr/rocclr/platform/vmheap.cpp
@@ -99,7 +99,6 @@ bool VmHeap::UncommitMemory(void* addr, size_t size) {
 VmHeap::VmHeap(Device* device, size_t va_size, size_t chunk_size, GetQueueFunc get_queue)
     : block_alignment_(kMinBlockAlignment),
       chunk_size_(chunk_size),
-      lock_(true),
       device_(device),
       get_vm_queue_(get_queue) {
   va_size_ = alignUp(va_size, chunk_size);
@@ -109,7 +108,7 @@ VmHeap::VmHeap(Device* device, size_t va_size, size_t chunk_size, GetQueueFunc g
 // ================================================================================================
 VmHeap::~VmHeap() {
   if (created_) {
-    ScopedLock k(lock_);
+    std::scoped_lock k(lock_);
 
     // Release all heap blocks
     HeapBlock *walk, *next;
@@ -213,7 +212,7 @@ void VmHeap::UnmapPhysMemory(size_t offset, size_t size) {
 
 // ================================================================================================
 void VmHeap::TrimPhysMemory(size_t unmap_threshold) {
-  ScopedLock k(lock_);
+  std::scoped_lock k(lock_);
   auto current = free_list_;
   auto unmap_org = unmap_threshold_;
   unmap_threshold_ = unmap_threshold;
@@ -226,7 +225,7 @@ void VmHeap::TrimPhysMemory(size_t unmap_threshold) {
 
 // ================================================================================================
 address VmHeap::Alloc(size_t size) {
-  ScopedLock k(lock_);
+  std::scoped_lock k(lock_);
 
   if (!created_) {
     // Create VM heap if it's not created
@@ -273,7 +272,7 @@ void VmHeap::Free(Memory* memory) {
   if (!created_ || (addr < base_address_)) {
     return;
   }
-  ScopedLock k(lock_);
+  std::scoped_lock k(lock_);
   if (memory->getUserData().data != nullptr) {
     auto hb = reinterpret_cast<HeapBlock*>(memory->getUserData().data);
     ClPrint(LOG_INFO, LOG_MEM_POOL, "VmHeap Free: %p offset(%zx + %zx) hb(%p)", addr, hb->Offset(),
@@ -287,7 +286,7 @@ void VmHeap::Free(Memory* memory) {
 // ================================================================================================
 HeapBlock* VmHeap::AllocBlock(size_t un_size) {
   assert(un_size != 0);
-  ScopedLock k(lock_);
+  std::scoped_lock k(lock_);
   HeapBlock* walk = free_list_;
   HeapBlock* best = nullptr;
 

--- a/projects/clr/rocclr/platform/vmheap.hpp
+++ b/projects/clr/rocclr/platform/vmheap.hpp
@@ -153,7 +153,7 @@ class VmHeap {
   uint64_t mapped_size_ = 0;            //!< Size of mapped memory
   uint64_t max_mapped_size_ = 0;        //!< Max size of mapped memory in this heap
   bool created_ = false;                //!< Used for deferred VM heap allocation
-  amd::Monitor lock_;                   //!< Lock to serialise heap accesses
+  std::recursive_mutex lock_;           //!< Lock to serialise heap accesses
   Device* device_;                      //!< Device that owns this heap
   GetQueueFunc get_vm_queue_;           //!< Queue for VM operations
 

--- a/projects/clr/rocclr/thread/monitor.hpp
+++ b/projects/clr/rocclr/thread/monitor.hpp
@@ -14,40 +14,25 @@
 #include <atomic>
 #include <tuple>
 #include <utility>
-#include <variant>
 #include "os/os.hpp"
 
 namespace amd {
 
 class Monitor {
  public:
-  explicit Monitor(bool recursive = false) : recursive_(recursive) {
+  explicit Monitor() {
     waits_.store(0);                               // 0 waiting thread initially
     notifyState_.store(notifyState::notNotified);  // initially not notified
-    if (recursive) {
-      mutex_.emplace<std::recursive_mutex>();
-    } else {
-      mutex_.emplace<std::mutex>();
-    }
   }
 
   //! Try to acquire the lock, return true if successful, false if failed.
-  bool tryLock() {
-    return recursive_ ? std::get<std::recursive_mutex>(mutex_).try_lock()
-                      : std::get<std::mutex>(mutex_).try_lock();
-  }
+  bool tryLock() { return mutex_.try_lock(); }
 
   //! Acquire the lock or suspend the calling thread.
-  void lock() {
-    recursive_ ? std::get<std::recursive_mutex>(mutex_).lock()
-               : std::get<std::mutex>(mutex_).lock();
-  }
+  void lock() { mutex_.lock(); }
 
   //! Release the lock and wake a single waiting thread if any.
-  void unlock() {
-    recursive_ ? std::get<std::recursive_mutex>(mutex_).unlock()
-               : std::get<std::mutex>(mutex_).unlock();
-  }
+  void unlock() { mutex_.unlock(); }
 
   /*! \brief Give up the lock and go to sleep.
    *
@@ -57,10 +42,8 @@ class Monitor {
    *  \note The monitor must be owned before calling wait().
    */
   void wait() {
-    assert(recursive_ == false && "Error: wait() doesn't support recursive mode");
     assert(waits_.load(std::memory_order_acquire) >= 0 && "Error: waits_.load() < 0");
-    std::mutex& mut = std::get<std::mutex>(mutex_);
-    std::unique_lock lk(mut, std::adopt_lock);
+    std::unique_lock lk(mutex_, std::adopt_lock);
 
     int c = 0;
     while (unlikely(notifyState_.load(std::memory_order_acquire) == notifyState::allNotified)) {
@@ -154,11 +137,10 @@ class Monitor {
   }
 
  private:
-  std::variant<std::monostate, std::mutex, std::recursive_mutex> mutex_;
+  std::mutex mutex_;
 
   enum class notifyState : uint32_t { notNotified = 0, oneNotified = 1, allNotified = 2 };
   std::condition_variable cv_;  //!< The condition variable for sync on the mutex
-  const bool recursive_;        //!< True if this is a recursive mutex, false otherwise.
   std::atomic<int> waits_;
   std::atomic<notifyState> notifyState_;
   const int maxCount_{55};  //!< Max count of spins in wait()
@@ -167,10 +149,12 @@ class Monitor {
 
 class ScopedLock : StackObject {
  public:
-  ScopedLock(Monitor& lock) : lock_(&lock) { lock_->lock(); }
+  explicit ScopedLock(Monitor& lock) : lock_(&lock) { lock_->lock(); }
 
-  ScopedLock(Monitor* lock) : lock_(lock) {
-    if (lock_) lock_->lock();
+  explicit ScopedLock(Monitor* lock) : lock_(lock) {
+    if (lock_) {
+      lock_->lock();
+    }
   }
 
   ~ScopedLock() {


### PR DESCRIPTION
## Motivation

We currently select our monitor type dynamically at runtime, using a constructor and storing the object in an std::variant. From profiling RCCL benchmarks, this level of indirection is measurable and does contribute to latency. For a scoped lock, unlock loop it is around 2-5% of the total cost. Additionally we had functions which were only supported for std::mutex and not recursive mutex, these could be called, and were protected with debug asserts. Moving to compile time prevents these invalid functions from being called. I.e. this change is for both performance and safety.

## Technical Details

The std::variant inside Monitor has been removed, and replaced with two separate classes. std::Monitor and std::RecursiveMonitor, the type is now completely defined at compile-time. In practice this doesn't change the thread safety behaviour as we were defining the variant type at compile-time anyway. Mutex types are kept the same, i.e. if they were constructed with `true` then they are RecursiveMonitors

Performance measurements were taken for the scoped lock unlock. All mutex calls with this scoped lock-unlock in a kernel submission benchmark were measured, and averaged.

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/abeltons/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/abeltons/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Arial, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:Percent;}
.xl66
	{text-align:center;}
-->

</head>

<body link="#467886" vlink="#96607D">


  | Variant | Template |  
-- | -- | -- | --
  | Average Scope Time (ns) | Average Scope Time (ns) | %Speedup
Warm Cache | 1247.85 | 1180.5 | 5.40%
Cold Cache | 2098.09 | 2060.47 | 1.80%



</body>

</html>


## JIRA ID

Resolves - ROCM-1580

## Test Plan

Our existing multi-threading tests are sufficient to test this change

## Test Result

Local tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
