### PR TITLE
[rocprofiler-compute] Fix path validation for spatial multiplexing in analyze mode

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -336,21 +336,21 @@ class OmniAnalyze_Base:
                 "Access denied. Cannot access parent directories in path (i.e. ../)"
             )
 
-        # ensure absolute path
+        # ensure absolute path and validate all paths
         seen_paths: set[str] = set()
         for dir_info in args.path:
-            full_path = Path(dir_info[0]).absolute().resolve()
-            dir_info[0] = str(full_path)
+            for i, path in enumerate(dir_info):
+                full_path = Path(path).absolute().resolve()
+                dir_info[i] = str(full_path)
 
-            if not full_path.is_dir():
-                console_error(
-                    "analysis", f"Invalid directory {full_path}\nPlease try again."
-                )
-            # validate profiling data
+                if not full_path.is_dir():
+                    console_error(
+                        "analysis", f"Invalid directory {full_path}\nPlease try again."
+                    )
 
-            if dir_info[0] in seen_paths:
-                console_error("analysis", "You cannot provide the same path twice.")
-            seen_paths.add(dir_info[0])
+                if dir_info[i] in seen_paths:
+                    console_error("analysis", "You cannot provide the same path twice.")
+                seen_paths.add(dir_info[i])
 
         self._profiling_config: dict[str, Any] = file_io.load_profiling_config(
             args.path[0][0]
@@ -364,7 +364,8 @@ class OmniAnalyze_Base:
                 args.spatial_multiplexing,
                 profiling_config.get("iteration_multiplexing"),
             ]):
-                is_workload_empty(dir_info[0])
+                for path in dir_info:
+                    is_workload_empty(path)
 
         # FIXME:
         #   The proper location of this func should be in pre_processing().


### PR DESCRIPTION
## Motivation

When using `rocprof-compute analyze` with multiple paths (spatial multiplexing), only the first path in each path group was validated. This caused:
- Invalid second paths to be silently ignored (without `--spatial-multiplexing` flag)
- Confusing `FileNotFoundError` tracebacks instead of clear error messages (with `--spatial-multiplexing` flag)

This PR ensures all paths provided via `--path` are properly validated for existence and duplicates.

## Technical Details

Modified `analysis_base.py` in the `sanitize()` method to iterate through ALL paths in `dir_info`, not just `dir_info[0]`:

- Changed path validation loop to use `enumerate(dir_info)` to validate each path
- Updated duplicate path checking to cover all paths
- Updated `is_workload_empty()` calls to check all paths

## JIRA ID

N/A

## Test Plan

- [x] Ruff lint check passes (`ruff check .`)
- [x] Ruff format check passes (`ruff format --check .`)
- [x] Manual testing: `--path valid_path INVALID_PATH` now shows clear "Invalid directory" error
- [x] Manual testing: `--spatial-multiplexing --path valid_path INVALID_PATH` now shows clear error instead of traceback
- [x] Manual testing: Valid single path still works correctly
- [x] Unit tests pass (`test_utils.py` path-related tests)
- [x] `test_analyze_vcopy_MI100` passes
- [x] Project builds successfully with cmake/make

## Test Result

All tests pass. The fix correctly catches invalid paths with a clear error message:
```
ERROR [analysis] Invalid directory /path/to/INVALID_PATH
Please try again.
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.