### PR TITLE
Fix compilation issues against newer libdrm versions

### DIFF
--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_drm.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_drm.h
@@ -26,15 +26,13 @@
 #include <unistd.h>
 
 #include <vector>
-#include <memory>
 #include <mutex>  // NOLINT
 #include <string>
 
 #include "amd_smi/amdsmi.h"
 #include "amd_smi/impl/amd_smi_lib_loader.h"
+#include <libdrm/amdgpu_drm.h>
 #include "amd_smi/impl/amdgpu_drm.h"
-#include "amd_smi/impl/xf86drm.h"
-#include "amd_smi/impl/scoped_fd.h"
 
 namespace amd::smi {
 

--- a/projects/amdsmi/include/amd_smi/impl/xf86drm.h
+++ b/projects/amdsmi/include/amd_smi/impl/xf86drm.h
@@ -34,7 +34,7 @@
 #ifndef _XF86DRM_H_
 #define _XF86DRM_H_
 
-#include <stdarg.h>
+#include <cstdarg>
 #include <sys/types.h>
 #include <cstdint>
 #ifndef __LIBDRM__

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -21,11 +21,11 @@
  * THE SOFTWARE.
  */
 
-#include <assert.h>
-#include <errno.h>
+#include <cassert>
+#include <cerrno>
 #include <sys/utsname.h>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <fcntl.h>
 
 
@@ -35,7 +35,6 @@
 #include <sstream>
 #include <iomanip>
 #include <iostream>
-#include <fstream>
 #include <queue>
 #include <vector>
 #include <set>
@@ -44,10 +43,11 @@
 #include <limits>
 #include <functional>
 #include <exception>
+#include <libdrm/amdgpu_drm.h>
 
 #include "config/amd_smi_config.h"
 #include "amd_smi/amdsmi.h"
-#include "amd_smi/impl/fdinfo.h"
+#include "amd_smi/impl/scoped_fd.h"
 #include "amd_smi/impl/amd_smi_common.h"
 #include "amd_smi/impl/amd_smi_cper.h"
 #include "amd_smi/impl/amd_smi_system.h"
@@ -58,7 +58,6 @@
 #include "amd_smi/impl/amd_smi_utils.h"
 #include "amd_smi/impl/amd_smi_processor.h"
 #include "rocm_smi/rocm_smi.h"
-#include "rocm_smi/rocm_smi_common.h"
 #include "rocm_smi/rocm_smi_logger.h"
 #include "rocm_smi/rocm_smi_utils.h"
 #include "rocm_smi/rocm_smi_kfd.h"

--- a/projects/amdsmi/src/amd_smi/amd_smi_drm.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_drm.cc
@@ -29,6 +29,7 @@
 #include <regex>
 #include "config/amd_smi_config.h"
 #include "amd_smi/impl/amd_smi_drm.h"
+#include "amd_smi/impl/xf86drm.h"
 #include "impl/scoped_fd.h"
 #include "rocm_smi/rocm_smi.h"
 #include "rocm_smi/rocm_smi_main.h"

--- a/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
@@ -20,17 +20,17 @@
  * THE SOFTWARE.
  */
 
-#include <limits.h>
+#include <climits>
 #include <sys/ioctl.h>
 #include <libdrm/amdgpu.h>
 #include <libdrm/drm.h>
 #include <fcntl.h>
 #include <cstdint>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <sys/mman.h>
-#include <time.h>
+#include <ctime>
 #include <unistd.h>
 #include <dirent.h>
 #include <sys/types.h>
@@ -41,14 +41,12 @@
 #include <iostream>
 #include <iterator>
 #include <memory>
-#include <random>
 #include <regex>
 #include <sstream>
 
 #include "config/amd_smi_config.h"
+#include "amd_smi/impl/scoped_fd.h"
 #include "amd_smi/impl/amd_smi_utils.h"
-#include "amd_smi/impl/amd_smi_system.h"
-#include "shared_mutex.h"  // NOLINT
 #include "rocm_smi/rocm_smi_logger.h"
 #include "rocm_smi/rocm_smi_utils.h"
 


### PR DESCRIPTION
This PR fixes compilation issues against newer versions of libdrm by resolving struct declaration conflicts between the system libdrm and local copies. The changes modernize header includes and reorganize dependencies to ensure compatibility.

Modernizes C headers to C++ equivalents (e.g., <limits.h> to <climits>, <stdio.h> to <cstdio>)
Includes system <libdrm/amdgpu_drm.h> before local copies to prevent struct redefinition conflicts
Reorganizes includes by moving implementation-specific headers from header files to source files where appropriate