### PR TITLE
AMDSMI CPU: Added support for family 1A Models 50h-57h

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -43,39 +43,39 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   ```console
   $amd-smi set --cpu-railisofreq-policy 0
   CPU: 0
-    CPURAILISO:
-        STATE: Set CPU ISO frequency policy operation successful
+      RAILISOFREQ_POLICY:
+          RESPONSE: Set to, 1, successful
 
   CPU: 1
-    CPURAILISO:
-        STATE: Set CPU ISO frequency policy operation successful
+      RAILISOFREQ_POLICY:
+          RESPONSE: Set to, 1, successful
 
   $amd-smi metric --cpu-railisofreq-policy
   CPU: 0
-    CPURAILISO:
-        CPURAILISOFREQ_POLICY: 0
+      RAILISOFREQ_POLICY:
+          VALUE: 1
 
   CPU: 1
-    CPURAILISO:
-        CPURAILISOFREQ_POLICY: 0
+      RAILISOFREQ_POLICY:
+          VALUE: 1
 
   $amd-smi set --cpu-dfcstate-ctrl 0
   CPU: 0
-    DFCSTATECTRL:
-        STATE: DFCState control operation successful
+      DFCSTATE_CTRL:
+          RESPONSE: Set to, 1, successful
 
   CPU: 1
-    DFCSTATECTRL:
-        STATE: DFCState control operation successful
+      DFCSTATE_CTRL:
+          RESPONSE: Set to, 1, successful
 
   $amd-smi metric --cpu-dfcstate-ctrl
   CPU: 0
-    DFCSTATE:
-        DFCSTATECTRL_STATUS: 0
+      DFCSTATE_CTRL:
+          VALUE: 1
 
   CPU: 1
-    DFCSTATE:
-        DFCSTATECTRL_STATUS: 0
+      DFCSTATE_CTRL:
+          VALUE: 1
  ```
  
 - **Added GPU and base board temperature `amd-smi monitor` CLI support**.  

--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -208,7 +208,7 @@ set(ROCM_INC_DIR "${PROJECT_SOURCE_DIR}/rocm_smi/include/rocm_smi")
 set(SHR_MUTEX_DIR "${PROJECT_SOURCE_DIR}/third_party/shared_mutex")
 if(ENABLE_ESMI_LIB)
     # Supported esmi library version tag
-    set(current_esmi_tag "esmi_pkg_ver-4.2")
+    set(current_esmi_tag "esmi_pkg_ver-5.1.1")
 
     if(NOT EXISTS ${PROJECT_SOURCE_DIR}/esmi_ib_library/src)
         # TODO: use ExternalProject_Add instead or a submodule

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -2790,7 +2790,9 @@ class AMDSMICommands():
                    cpu_metrics_ver=None, cpu_metrics_table=None, cpu_socket_energy=None,
                    cpu_ddr_bandwidth=None, cpu_temp=None, cpu_dimm_temp_range_rate=None,
                    cpu_dimm_pow_consumption=None, cpu_dimm_thermal_sensor=None,
-                   cpu_dfcstate_ctrl=None, cpu_railisofreq_policy=None):
+                   cpu_xgmi_pstate_range=None, cpu_railisofreq_policy=None, cpu_dfcstate_ctrl=None,
+                   cpu_pc6_enable=None, cpu_cc6_enable=None, cpu_dimm_sb_reg=None, cpu_tdelta=None,
+                   cpu_svi3_vr_controller_temp=None, cpu_enabled_commands=None, cpu_socket_sdps_limit=None):
         """Get Metric information for target cpu
 
         Args:
@@ -2813,8 +2815,16 @@ class AMDSMICommands():
             cpu_dimm_temp_range_rate (list, optional): Dimm address. Value override for args.cpu_dimm_temp_range_rate. Defaults to None
             cpu_dimm_pow_consumption (list, optional): Dimm address. Value override for args.cpu_dimm_pow_consumption. Defaults to None
             cpu_dimm_thermal_sensor (list, optional): Dimm address. Value override for args.cpu_dimm_thermal_sensor. Defaults to None
-            cpu_dfcstate_ctrl (bool, optional): Value override for args.cpu_dfcstate_ctrl. Defaults to None
+            cpu_xgmi_pstate_range (bool, optional): Value override for args.cpu_xgmi_pstate_range. Defaults to None
             cpu_railisofreq_policy (bool, optional): Value override for args.cpu_railisofreq_policy. Defaults to None
+            cpu_dfcstate_ctrl (bool, optional): Value override for args.cpu_dfcstate_ctrl. Defaults to None
+            cpu_pc6_enable (bool, optional): Value override for args.cpu_pc6_enable. Defaults to None
+            cpu_cc6_enable (bool, optional): Value override for args.cpu_cc6_enable. Defaults to None
+            cpu_dimm_sb_reg (list, optional): DIMM sideband register parameters [dimm_addr, lid, reg_offset, reg_space] for read operation. Value override for args.cpu_dimm_sb_reg. Defaults to None
+            cpu_tdelta (bool, optional): Value override for args.cpu_tdelta. Defaults to None
+            cpu_svi3_vr_controller_temp (list, optional): TYPE and optional RAIL_INDEX. Value override for args.cpu_svi3_vr_controller_temp. Defaults to None
+            cpu_enabled_commands (list, optional): Value override for args.cpu_enabled_commands. Defaults to None
+            cpu_socket_sdps_limit (bool, optional): Value override for args.cpu_socket_sdps_limit. Defaults to None
 
         Returns:
             None: Print output via AMDSMILogger to destination
@@ -2854,10 +2864,26 @@ class AMDSMICommands():
             args.cpu_dimm_pow_consumption = cpu_dimm_pow_consumption
         if cpu_dimm_thermal_sensor:
             args.cpu_dimm_thermal_sensor = cpu_dimm_thermal_sensor
-        if cpu_dfcstate_ctrl:
-            args.cpu_dfcstate_ctrl = cpu_dfcstate_ctrl
+        if cpu_xgmi_pstate_range:
+            args.cpu_xgmi_pstate_range = cpu_xgmi_pstate_range
         if cpu_railisofreq_policy:
             args.cpu_railisofreq_policy = cpu_railisofreq_policy
+        if cpu_dfcstate_ctrl:
+            args.cpu_dfcstate_ctrl = cpu_dfcstate_ctrl
+        if cpu_pc6_enable:
+            args.cpu_pc6_enable = cpu_pc6_enable
+        if cpu_cc6_enable:
+            args.cpu_cc6_enable = cpu_cc6_enable
+        if cpu_dimm_sb_reg:
+            args.cpu_dimm_sb_reg = cpu_dimm_sb_reg
+        if cpu_tdelta:
+            args.cpu_tdelta = cpu_tdelta
+        if cpu_svi3_vr_controller_temp:
+            args.cpu_svi3_vr_controller_temp = cpu_svi3_vr_controller_temp
+        if cpu_enabled_commands:
+            args.cpu_enabled_commands = cpu_enabled_commands
+        if cpu_socket_sdps_limit:
+            args.cpu_socket_sdps_limit = cpu_socket_sdps_limit
 
         #store cpu args that are applicable to the current platform
         curr_platform_cpu_args = ["cpu_power_metrics", "cpu_prochot", "cpu_freq_metrics",
@@ -2865,13 +2891,17 @@ class AMDSMICommands():
                                   "cpu_io_bandwidth", "cpu_xgmi_bandwidth", "cpu_metrics_ver",
                                   "cpu_metrics_table", "cpu_socket_energy", "cpu_ddr_bandwidth",
                                   "cpu_temp", "cpu_dimm_temp_range_rate", "cpu_dimm_pow_consumption",
-                                  "cpu_dimm_thermal_sensor", "cpu_dfcstate_ctrl", "cpu_railisofreq_policy"]
+                                  "cpu_dimm_thermal_sensor", "cpu_xgmi_pstate_range", "cpu_railisofreq_policy",
+                                  "cpu_dfcstate_ctrl", "cpu_pc6_enable", "cpu_cc6_enable", "cpu_dimm_sb_reg",
+                                  "cpu_tdelta", "cpu_svi3_vr_controller_temp", "cpu_enabled_commands", "cpu_socket_sdps_limit"]
         curr_platform_cpu_values = [args.cpu_power_metrics, args.cpu_prochot, args.cpu_freq_metrics,
                                     args.cpu_c0_res, args.cpu_lclk_dpm_level, args.cpu_pwr_svi_telemetry_rails,
                                     args.cpu_io_bandwidth, args.cpu_xgmi_bandwidth, args.cpu_metrics_ver,
                                     args.cpu_metrics_table, args.cpu_socket_energy, args.cpu_ddr_bandwidth,
                                     args.cpu_temp, args.cpu_dimm_temp_range_rate, args.cpu_dimm_pow_consumption,
-                                    args.cpu_dimm_thermal_sensor, args.cpu_dfcstate_ctrl, args.cpu_railisofreq_policy]
+                                    args.cpu_dimm_thermal_sensor, args.cpu_xgmi_pstate_range, args.cpu_railisofreq_policy,
+                                    args.cpu_dfcstate_ctrl, args.cpu_pc6_enable, args.cpu_cc6_enable, args.cpu_dimm_sb_reg,
+                                    args.cpu_tdelta, args.cpu_svi3_vr_controller_temp, args.cpu_enabled_commands, args.cpu_socket_sdps_limit]
 
         # Handle No CPU passed (fall back as this should be defined in metric())
         if args.cpu == None:
@@ -2880,7 +2910,7 @@ class AMDSMICommands():
         if not any(curr_platform_cpu_values):
             for arg in curr_platform_cpu_args:
                 if arg not in("cpu_lclk_dpm_level", "cpu_io_bandwidth", "cpu_xgmi_bandwidth",
-                              "cpu_dimm_temp_range_rate", "cpu_dimm_pow_consumption", "cpu_dimm_thermal_sensor"):
+                              "cpu_dimm_temp_range_rate", "cpu_dimm_pow_consumption", "cpu_dimm_thermal_sensor", "cpu_dimm_sb_reg"):
                     setattr(args, arg, True)
 
         handled_multiple_cpus, device_handle = self.helpers.handle_cpus(args,
@@ -3076,22 +3106,139 @@ class AMDSMICommands():
             except amdsmi_exception.AmdSmiLibraryException as e:
                 static_dict["dimm_thermal_sensor"]["response"] = "N/A"
                 logging.debug("Failed to get dimm temperature range and refresh rate for cpu %s | %s", cpu_id, e.get_error_info())
-        if args.cpu_dfcstate_ctrl:
-            static_dict["dfcstate"] = {}
+        if args.cpu_xgmi_pstate_range:
+            static_dict["xgmi_pstate_range"] = {}
             try:
-                dfcstatectrl_status = amdsmi_interface.amdsmi_get_dfc_ctrl(args.cpu)
-                static_dict["dfcstate"]["dfcstatectrl_status"] = dfcstatectrl_status
+                pstate_range = amdsmi_interface.amdsmi_get_cpu_xgmi_pstate_range(args.cpu)
+                static_dict["xgmi_pstate_range"]["min_pstate"] = pstate_range["min_pstate"]
+                static_dict["xgmi_pstate_range"]["max_pstate"] = pstate_range["max_pstate"]
             except amdsmi_exception.AmdSmiLibraryException as e:
-                static_dict["dfcstate"]["dfcstatectrl_status"] = "N/A"
-                logging.debug("Failed to get dfcstate control status for cpu %s | %s", cpu_id, e.get_error_info())
+                static_dict["xgmi_pstate_range"]["min_pstate"] = "N/A"
+                static_dict["xgmi_pstate_range"]["max_pstate"] = "N/A"
+                logging.debug("Failed to get xgmi pstate range for cpu %s | %s", cpu_id, e.get_error_info())
         if args.cpu_railisofreq_policy:
-            static_dict["cpurailiso"] = {}
+            static_dict["railisofreq_policy"] = {}
             try:
                 cpurailisofreq_policy = amdsmi_interface.amdsmi_get_cpu_rail_isofreq_policy(args.cpu)
-                static_dict["cpurailiso"]["cpurailisofreq_policy"] = cpurailisofreq_policy
+                static_dict["railisofreq_policy"]["value"] = cpurailisofreq_policy
             except amdsmi_exception.AmdSmiLibraryException as e:
-                static_dict["cpurailiso"]["cpurailisofreq_policy"] = "N/A"
+                static_dict["railisofreq_policy"]["value"] = "N/A"
                 logging.debug("Failed to get cpurailiso frequency policy for cpu %s | %s", cpu_id, e.get_error_info())
+        if args.cpu_dfcstate_ctrl:
+            static_dict["dfcstate_ctrl"] = {}
+            try:
+                dfcstatectrl_status = amdsmi_interface.amdsmi_get_dfc_ctrl(args.cpu)
+                static_dict["dfcstate_ctrl"]["value"] = dfcstatectrl_status
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["dfcstate_ctrl"]["value"] = "N/A"
+                logging.debug("Failed to get dfcstate control status for cpu %s | %s", cpu_id, e.get_error_info())
+        if args.cpu_pc6_enable:
+            static_dict["pc6_enable"] = {}
+            try:
+                pc6_enable_status = amdsmi_interface.amdsmi_get_pc6_enable(args.cpu)
+                static_dict["pc6_enable"]["value"] = pc6_enable_status
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["pc6_enable"]["value"] = "N/A"
+                logging.debug("Failed to get PC6 enable status for cpu %s | %s", cpu_id, e.get_error_info())
+        if args.cpu_cc6_enable:
+            static_dict["cc6_enable"] = {}
+            try:
+                cc6_enable_status = amdsmi_interface.amdsmi_get_cc6_enable(args.cpu)
+                static_dict["cc6_enable"]["value"] = cc6_enable_status
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["cc6_enable"]["value"] = "N/A"
+                logging.debug("Failed to get CC6 enable status for cpu %s | %s", cpu_id, e.get_error_info())
+        if args.cpu_dimm_sb_reg:
+            static_dict["dimm_sb_reg"] = {}
+            try:
+                dimm_addr = args.cpu_dimm_sb_reg[0][0]
+                lid = args.cpu_dimm_sb_reg[0][1]
+                reg_offset = args.cpu_dimm_sb_reg[0][2]
+                reg_space = args.cpu_dimm_sb_reg[0][3]
+                dimm_sb_data = amdsmi_interface.amdsmi_dimm_sb_reg_read(args.cpu, dimm_addr, lid, reg_offset, reg_space)
+                static_dict["dimm_sb_reg"]["DimmAddress"] = f"0x{dimm_addr:02X}"
+                static_dict["dimm_sb_reg"]["Lid"] = f"0x{lid:02X}"
+                static_dict["dimm_sb_reg"]["Offset"] = f"0x{reg_offset:04X}"
+                static_dict["dimm_sb_reg"]["RegSpace"] = reg_space
+                static_dict["dimm_sb_reg"]["Data"] = f"0x{dimm_sb_data:08X}"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["dimm_sb_reg"]["DimmAddress"] = f"0x{args.cpu_dimm_sb_reg[0][0]:02X}"
+                static_dict["dimm_sb_reg"]["Lid"] = f"0x{args.cpu_dimm_sb_reg[0][1]:02X}"
+                static_dict["dimm_sb_reg"]["Offset"] = f"0x{args.cpu_dimm_sb_reg[0][2]:04X}"
+                static_dict["dimm_sb_reg"]["RegSpace"] = args.cpu_dimm_sb_reg[0][3]
+                static_dict["dimm_sb_reg"]["Data"] = "N/A"
+                logging.debug("Failed to read DIMM sideband register for cpu %s | %s", cpu_id, e.get_error_info())
+        if args.cpu_tdelta:
+            static_dict["tdelta"] = {}
+            try:
+                tdelta_value = amdsmi_interface.amdsmi_read_tdelta(args.cpu)
+                static_dict["tdelta"]["value"] = tdelta_value
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["tdelta"]["value"] = "N/A"
+                logging.debug("Failed to get thermal delta (TDELTA) for cpu %s | %s", cpu_id, e.get_error_info())
+        if args.cpu_svi3_vr_controller_temp:
+            static_dict["svi3_vr_controller_temp"] = {}
+            try:
+                # Parse the arguments: TYPE [RAIL_INDEX]
+                vr_args = args.cpu_svi3_vr_controller_temp[0]
+                if len(vr_args) < 1 or len(vr_args) > 2:
+                    raise ValueError("Invalid number of arguments")
+
+                rail_type = vr_args[0]
+                if rail_type not in [0, 1]:
+                    raise ValueError("TYPE must be 0 (HottestRail) or 1 (IndividualRail)")
+
+                rail_index = 0
+                if rail_type == 1:
+                    if len(vr_args) != 2:
+                        raise ValueError("RAIL_INDEX required when TYPE=1")
+                    rail_index = vr_args[1]
+                    if rail_index < 0 or rail_index > 7:
+                        raise ValueError("RAIL_INDEX must be 0-7")
+
+                resp = amdsmi_interface.amdsmi_get_svi3_vr_controller_temp(
+                    args.cpu, rail_type, rail_index
+                )
+                static_dict["svi3_vr_controller_temp"]["RAIL_SELECTION"] = resp["rail_selection"]
+                static_dict["svi3_vr_controller_temp"]["RAIL_INDEX"] = resp["rail_index"]
+                temp_celsius = resp["temperature"]
+                static_dict["svi3_vr_controller_temp"]["TEMPERATURE"] = f"{temp_celsius:.1f} 'C"
+            except (amdsmi_exception.AmdSmiLibraryException, ValueError) as e:
+                static_dict["svi3_vr_controller_temp"]["RAIL_SELECTION"] = "N/A"
+                static_dict["svi3_vr_controller_temp"]["RAIL_INDEX"] = "N/A"
+                static_dict["svi3_vr_controller_temp"]["TEMPERATURE"] = "N/A"
+                if isinstance(e, ValueError):
+                    logging.debug("Invalid arguments for SVI3 VR controller temp: %s", str(e))
+                else:
+                    logging.debug("Failed to get SVI3 VR controller temperature for cpu %s | %s",cpu_id, e.get_error_info())
+        if args.cpu_enabled_commands:
+            static_dict["enabled_commands"] = {}
+            try:
+                enabled_cmds = amdsmi_interface.amdsmi_get_enabled_commands(args.cpu)
+                static_dict["enabled_commands"]["READ_ENABLED_COMMANDS_BITMASK0"] = f"0x{enabled_cmds['ReadEnabledCommandsBitMask0']:08X}"
+                static_dict["enabled_commands"]["READ_ENABLED_COMMANDS_BITMASK1"] = f"0x{enabled_cmds['ReadEnabledCommandsBitMask1']:08X}"
+                static_dict["enabled_commands"]["READ_ENABLED_COMMANDS_BITMASK2"] = f"0x{enabled_cmds['ReadEnabledCommandsBitMask2']:08X}"
+                static_dict["enabled_commands"]["WRITE_ENABLED_COMMANDS_BITMASK0"] = f"0x{enabled_cmds['WriteEnabledCommandsBitMask0']:08X}"
+                static_dict["enabled_commands"]["WRITE_ENABLED_COMMANDS_BITMASK1"] = f"0x{enabled_cmds['WriteEnabledCommandsBitMask1']:08X}"
+                static_dict["enabled_commands"]["WRITE_ENABLED_COMMANDS_BITMASK2"] = f"0x{enabled_cmds['WriteEnabledCommandsBitMask2']:08X}"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["enabled_commands"]["READ_ENABLED_COMMANDS_BITMASK0"] = "N/A"
+                static_dict["enabled_commands"]["READ_ENABLED_COMMANDS_BITMASK1"] = "N/A"
+                static_dict["enabled_commands"]["READ_ENABLED_COMMANDS_BITMASK2"] = "N/A"
+                static_dict["enabled_commands"]["WRITE_ENABLED_COMMANDS_BITMASK0"] = "N/A"
+                static_dict["enabled_commands"]["WRITE_ENABLED_COMMANDS_BITMASK1"] = "N/A"
+                static_dict["enabled_commands"]["WRITE_ENABLED_COMMANDS_BITMASK2"] = "N/A"
+                logging.debug("Failed to get enabled commands for cpu %s | %s", cpu_id, e.get_error_info())
+        if args.cpu_socket_sdps_limit:
+            static_dict["socket_sdps_limit"] = {}
+            try:
+                sdps_limit = amdsmi_interface.amdsmi_get_cpu_socket_sdps_limit(args.cpu)
+                # Convert from milli Watts to Watts for display
+                sdps_limit_watts = float(sdps_limit) / 1000
+                static_dict["socket_sdps_limit"]["value"] = f"{sdps_limit_watts:.3f} Watts"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["socket_sdps_limit"]["value"] = "N/A"
+                logging.debug("Failed to get socket SDPS limit for cpu %s | %s", cpu_id, e.get_error_info())
 
         multiple_devices_csv_override = False
         if not self.logger.is_json_format():
@@ -3106,7 +3253,8 @@ class AMDSMICommands():
 
 
     def metric_core(self, args, multiple_devices=False, core=None, core_boost_limit=None,
-                    core_curr_active_freq_core_limit=None, core_energy=None):
+                    core_curr_active_freq_core_limit=None, core_energy=None, core_ccd_power=None,
+                    core_floor_limit=None, core_eff_floor_limit=None):
         """Get Static information for target core
 
         Args:
@@ -3116,6 +3264,9 @@ class AMDSMICommands():
             core_boost_limit (bool, optional): Value override for args.core_boost_limit. Defaults to None
             core_curr_active_freq_core_limit (bool, optional): Value override for args.core_curr_active_freq_core_limit. Defaults to None
             core_energy (bool, optional): Value override for args.core_energy. Defaults to None
+            core_ccd_power (bool, optional): Value override for args.core_ccd_power. Defaults to None
+            core_floor_limit (bool, optional): Value override for args.core_floor_limit. Defaults to None
+            core_eff_floor_limit (bool, optional): Value override for args.core_eff_floor_limit. Defaults to None
         Returns:
             None: Print output via AMDSMILogger to destination
         """
@@ -3127,10 +3278,16 @@ class AMDSMICommands():
             args.core_curr_active_freq_core_limit = core_curr_active_freq_core_limit
         if core_energy:
             args.core_energy = core_energy
+        if core_ccd_power:
+            args.core_ccd_power = core_ccd_power
+        if core_floor_limit:
+            args.core_floor_limit = core_floor_limit
+        if core_eff_floor_limit:
+            args.core_eff_floor_limit = core_eff_floor_limit
 
         #store core args that are applicable to the current platform
-        curr_platform_core_args = ["core_boost_limit", "core_curr_active_freq_core_limit", "core_energy"]
-        curr_platform_core_values = [args.core_boost_limit, args.core_curr_active_freq_core_limit, args.core_energy]
+        curr_platform_core_args = ["core_boost_limit", "core_curr_active_freq_core_limit", "core_energy", "core_ccd_power", "core_floor_limit", "core_eff_floor_limit"]
+        curr_platform_core_values = [args.core_boost_limit, args.core_curr_active_freq_core_limit, args.core_energy, args.core_ccd_power, args.core_floor_limit, args.core_eff_floor_limit]
 
         # Handle No cores passed
         if args.core == None:
@@ -3180,6 +3337,34 @@ class AMDSMICommands():
                 static_dict["core_energy"]["value"] = "N/A"
                 logging.debug("Failed to get core energy for core %s | %s", core_id, e.get_error_info())
 
+        if args.core_ccd_power:
+            static_dict["ccd_power"] = {}
+            try:
+                ccd_id = core_id % 8  # Assume max 8 CCDs
+                power = amdsmi_interface.amdsmi_get_ccd_power(args.core, ccd_id)
+                static_dict["ccd_power"]["value"] = f"{power / 1000:.3f} Watts"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["ccd_power"]["value"] = "N/A"
+                logging.debug("Failed to get CCD power for core %s | %s", core_id, e.get_error_info())
+
+        if args.core_floor_limit:
+            static_dict["floor_limit"] = {}
+            try:
+                core_floor_limit = amdsmi_interface.amdsmi_get_cpu_core_floorlimit(args.core)
+                static_dict["floor_limit"]["value"] = f"{core_floor_limit} MHz"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["floor_limit"]["value"] = "N/A"
+                logging.debug("Failed to get core floor limit for core %s | %s", core_id, e.get_error_info())
+
+        if args.core_eff_floor_limit:
+            static_dict["eff_floor_limit"] = {}
+            try:
+                core_eff_floor_limit = amdsmi_interface.amdsmi_get_cpu_core_efffloorlimit(args.core)
+                static_dict["eff_floor_limit"]["value"] = f"{core_eff_floor_limit} MHz"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["eff_floor_limit"]["value"] = "N/A"
+                logging.debug("Failed to get core effective floor limit for core %s | %s", core_id, e.get_error_info())
+
         multiple_devices_csv_override = False
         if not self.logger.is_json_format():
             self.logger.store_core_output(args.core, 'values', static_dict)
@@ -3202,9 +3387,12 @@ class AMDSMICommands():
                 cpu_io_bandwidth=None, cpu_xgmi_bandwidth=None, cpu_metrics_ver=None,
                 cpu_metrics_table=None, cpu_socket_energy=None, cpu_ddr_bandwidth=None,
                 cpu_temp=None, cpu_dimm_temp_range_rate=None, cpu_dimm_pow_consumption=None,
-                cpu_dimm_thermal_sensor=None, cpu_dfcstate_ctrl=None, cpu_railisofreq_policy=None,
+                cpu_dimm_thermal_sensor=None, cpu_xgmi_pstate_range=None, cpu_railisofreq_policy=None,
+                cpu_dfcstate_ctrl=None, cpu_pc6_enable=None, cpu_cc6_enable=None, cpu_dimm_sb_reg=None,
+                cpu_tdelta=None, cpu_svi3_vr_controller_temp=None, cpu_enabled_commands=None, cpu_socket_sdps_limit=None,
                 core=None, core_boost_limit=None, core_curr_active_freq_core_limit=None,
-                core_energy=None, throttle=None, base_board=None, gpu_board=None):
+                core_energy=None, core_ccd_power=None, core_floor_limit=None, core_eff_floor_limit =None,
+                throttle=None, base_board=None, gpu_board=None):
         """Get Metric information for target gpu
 
         Args:
@@ -3253,13 +3441,24 @@ class AMDSMICommands():
             cpu_dimm_temp_range_rate (list, optional): Dimm address. Value override for args.cpu_dimm_temp_range_rate. Defaults to None
             cpu_dimm_pow_consumption (list, optional): Dimm address. Value override for args.cpu_dimm_pow_consumption. Defaults to None
             cpu_dimm_thermal_sensor (list, optional): Dimm address. Value override for args.cpu_dimm_thermal_sensor. Defaults to None
-            cpu_dfcstate_ctrl (bool, optional): Value override for args.cpu_dfcstate_ctrl. Defaults to None
+            cpu_xgmi_pstate_range (bool, optional): Value override for args.cpu_xgmi_pstate_range. Defaults to None
             cpu_railisofreq_policy (bool, optional): Value override for args.cpu_railisofreq_policy. Defaults to None
+            cpu_dfcstate_ctrl (bool, optional): Value override for args.cpu_dfcstate_ctrl. Defaults to None
+            cpu_pc6_enable (bool, optional): Value override for args.cpu_pc6_enable. Defaults to None
+            cpu_cc6_enable (bool, optional): Value override for args.cpu_cc6_enable. Defaults to None
+            cpu_dimm_sb_reg (list, optional): DIMM sideband register parameters [dimm_addr, lid, reg_offset, reg_space] for read operation. Value override for args.cpu_dimm_sb_reg. Defaults to None
+            cpu_tdelta (bool, optional): Value override for args.cpu_tdelta. Defaults to None
+            cpu_svi3_vr_controller_temp (list, optional): TYPE and optional RAIL_INDEX. Value override for args.cpu_svi3_vr_controller_temp. Defaults to None
+            cpu_enabled_commands (list, optional): Value override for args.cpu_enabled_commands. Defaults to None
+            cpu_socket_sdps_limit (bool, optional): Value override for args.cpu_socket_sdps_limit. Defaults to None
 
             core (device_handle, optional): device_handle for target core. Defaults to None.
             core_boost_limit (bool, optional): Value override for args.core_boost_limit. Defaults to None
             core_curr_active_freq_core_limit (bool, optional): Value override for args.core_curr_active_freq_core_limit. Defaults to None
             core_energy (bool, optional): Value override for args.core_energy. Defaults to None
+            core_ccd_power (bool, optional): Value override for args.core_ccd_power. Defaults to None
+            core_floor_limit (bool, optional): Value override for args.core_floor_limit. Defaults to None
+            core_eff_floor_limit (bool, optional): Value override for args.core_eff_floor_limit. Defaults to None
 
         Raises:
             IndexError: Index error if gpu list is empty
@@ -3294,8 +3493,10 @@ class AMDSMICommands():
                           "cpu_lclk_dpm_level", "cpu_pwr_svi_telemetry_rails", "cpu_io_bandwidth",
                           "cpu_xgmi_bandwidth", "cpu_metrics_ver", "cpu_metrics_table",
                           "cpu_socket_energy", "cpu_ddr_bandwidth", "cpu_temp", "cpu_dimm_temp_range_rate",
-                          "cpu_dimm_pow_consumption", "cpu_dimm_thermal_sensor",
-                          "cpu_dfcstate_ctrl", "cpu_railisofreq_policy"]
+                          "cpu_dimm_pow_consumption", "cpu_dimm_thermal_sensor", "cpu_xgmi_pstate_range",
+                          "cpu_railisofreq_policy", "cpu_dfcstate_ctrl", "cpu_pc6_enable", "cpu_cc6_enable",
+                          "cpu_dimm_sb_reg", "cpu_tdelta", "cpu_svi3_vr_controller_temp",
+                          "cpu_enabled_commands", "cpu_socket_sdps_limit"]
         for attr in cpu_attributes:
             if hasattr(args, attr):
                 if getattr(args, attr):
@@ -3304,7 +3505,7 @@ class AMDSMICommands():
 
         # Check if a Core argument has been set
         core_args_enabled = False
-        core_attributes = ["core_boost_limit", "core_curr_active_freq_core_limit", "core_energy"]
+        core_attributes = ["core_boost_limit", "core_curr_active_freq_core_limit", "core_energy", "core_ccd_power", "core_floor_limit", "core_eff_floor_limit"]
         for attr in core_attributes:
             if hasattr(args, attr):
                 if getattr(args, attr):
@@ -3342,12 +3543,14 @@ class AMDSMICommands():
                                 cpu_metrics_ver, cpu_metrics_table, cpu_socket_energy,
                                 cpu_ddr_bandwidth, cpu_temp, cpu_dimm_temp_range_rate,
                                 cpu_dimm_pow_consumption, cpu_dimm_thermal_sensor,
-                                cpu_dfcstate_ctrl, cpu_railisofreq_policy)
+                                cpu_xgmi_pstate_range, cpu_railisofreq_policy, cpu_dfcstate_ctrl,
+                                cpu_pc6_enable, cpu_cc6_enable, cpu_dimm_sb_reg, cpu_tdelta,
+                                cpu_svi3_vr_controller_temp, cpu_enabled_commands, cpu_socket_sdps_limit)
             if args.core:
                 self.logger.output = {}
                 self.logger.clear_multiple_devices_output()
                 self.metric_core(args, multiple_devices, core, core_boost_limit,
-                                     core_curr_active_freq_core_limit, core_energy)
+                                     core_curr_active_freq_core_limit, core_energy, core_ccd_power, core_floor_limiti, core_eff_floor_limit)
             if args.gpu:
                 self.logger.output = {}
                 self.logger.clear_multiple_devices_output()
@@ -3377,12 +3580,14 @@ class AMDSMICommands():
                                 cpu_metrics_ver, cpu_metrics_table, cpu_socket_energy,
                                 cpu_ddr_bandwidth, cpu_temp, cpu_dimm_temp_range_rate,
                                 cpu_dimm_pow_consumption, cpu_dimm_thermal_sensor,
-                                cpu_dfcstate_ctrl, cpu_railisofreq_policy)
+                                cpu_xgmi_pstate_range, cpu_railisofreq_policy, cpu_dfcstate_ctrl,
+                                cpu_pc6_enable, cpu_cc6_enable, cpu_dimm_sb_reg, cpu_tdelta,
+                                cpu_svi3_vr_controller_temp, cpu_enabled_commands, cpu_socket_sdps_limit)
             if args.core:
                 self.logger.output = {}
                 self.logger.clear_multiple_devices_output()
                 self.metric_core(args, multiple_devices, core, core_boost_limit,
-                                     core_curr_active_freq_core_limit, core_energy)
+                                     core_curr_active_freq_core_limit, core_energy, core_ccd_power, core_floor_limit, core_eff_floor_limit)
         elif self.helpers.is_amdgpu_initialized(): # Only GPU is initialized
             if args.gpu == None:
                 args.gpu = self.device_handles
@@ -4328,14 +4533,16 @@ class AMDSMICommands():
             self.logger.print_output(multiple_device_enabled=True)
 
 
-    def set_core(self, args, multiple_devices=False, core=None, core_boost_limit=None):
+    def set_core(self, args, multiple_devices=False, core=None, core_boost_limit=None, core_floor_limit=None, core_msr_floor_limit=None):
         """Issue set commands to target core(s)
 
         Args:
             args (Namespace): Namespace containing the parsed CLI args
             multiple_devices (bool, optional): True if checking for multiple devices. Defaults to False.
             core (device_handle, optional): device_handle for target device. Defaults to None.
-            core_boost_limit (list, optional): Value override for args.core_boost_limit. Defaults to None. Defaults to None.
+            core_boost_limit (list, optional): Value override for args.core_boost_limit. Defaults to None.
+            core_floor_limit (list, optional): Value override for args.core_floor_limit. Defaults to None.
+            core_msr_floor_limit (list, optional): Value override for args.core_msr_floor_limit. Defaults to None.
 
         Raises:
             ValueError: Value error if no core value is provided
@@ -4348,6 +4555,10 @@ class AMDSMICommands():
             args.core = core
         if core_boost_limit:
             args.core_boost_limit = core_boost_limit
+        if core_floor_limit:
+            args.core_floor_limit = core_floor_limit
+        if core_msr_floor_limit:
+            args.core_msr_floor_limit = core_msr_floor_limit
 
         if args.core == None:
             raise ValueError('No Core provided, specific Core targets(S) are needed')
@@ -4358,7 +4569,7 @@ class AMDSMICommands():
             return # This function is recursive
 
         # Error if no subcommand args are passed
-        if not any([args.core_boost_limit]):
+        if not any([args.core_boost_limit, args.core_floor_limit, args.core_msr_floor_limit]):
             command = " ".join(sys.argv[1:])
             raise AmdSmiRequiredCommandException(command, self.logger.format)
 
@@ -4393,6 +4604,26 @@ class AMDSMICommands():
                 static_dict["set_core_boost_limit"]["Response"] = f"Error occurred for Core {core_id} - {e.get_error_info()}"
                 logging.debug("Failed to set core boost limit for core %s | %s", core_id, e.get_error_info())
 
+        # Set core floor limit
+        if args.core_floor_limit:
+            static_dict["floor_limit"] = {}
+            try:
+                amdsmi_interface.amdsmi_set_cpu_core_floorlimit(args.core, args.core_floor_limit[0][0])
+                static_dict["floor_limit"]["Response"] = f"Set, VALUE: {args.core_floor_limit[0][0]} MHz, successful"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["floor_limit"]["Response"] = f"Error occurred for Core {core_id} - {e.get_error_info()}"
+                logging.debug("Failed to set core floor limit for core %s | %s", core_id, e.get_error_info())
+
+        # Set core MSR floor limit
+        if args.core_msr_floor_limit:
+            static_dict["msr_floor_limit"] = {}
+            try:
+                amdsmi_interface.amdsmi_cpu_core_msr_floorlimit(args.core, args.core_msr_floor_limit[0][0])
+                static_dict["msr_floor_limit"]["Response"] = f"Set, VALUE: {args.core_msr_floor_limit[0][0]} MHz, successful"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["msr_floor_limit"]["Response"] = f"Error occurred for Core {core_id} - {e.get_error_info()}"
+                logging.debug("Failed to set core MSR floor limit for core %s | %s", core_id, e.get_error_info())
+
         multiple_devices_csv_override = False
         self.logger.store_core_output(args.core, 'values', static_dict)
         if multiple_devices:
@@ -4405,7 +4636,9 @@ class AMDSMICommands():
                 cpu_xgmi_link_width=None, cpu_lclk_dpm_level=None, cpu_pwr_eff_mode=None,
                 cpu_gmi3_link_width=None, cpu_pcie_link_rate=None, cpu_df_pstate_range=None,
                 cpu_enable_apb=None, cpu_disable_apb=None, soc_boost_limit=None,
-                cpu_dfcstate_ctrl=None, cpu_railisofreq_policy=None):
+                cpu_xgmi_pstate_range=None, cpu_railisofreq_policy=None, cpu_dfcstate_ctrl=None,
+                cpu_pc6_enable=None, cpu_cc6_enable=None, soc_floor_limit=None,cpu_msr_floor_limit=None,
+                cpu_dimm_sb_reg=None, cpu_socket_sdps_limit=None):
         """Issue set commands to target cpu(s)
 
         Args:
@@ -4415,15 +4648,22 @@ class AMDSMICommands():
             cpu_pwr_limit (int, optional): Value override for args.cpu_pwr_limit. Defaults to None.
             cpu_xgmi_link_width (List[int], optional): Value override for args.cpu_xgmi_link_width. Defaults to None.
             cpu_lclk_dpm_level (List[int], optional): Value override for args.cpu_lclk_dpm_level. Defaults to None.
-            cpu_pwr_eff_mode (int, optional): Value override for args.cpu_pwr_eff_mode. Defaults to None.
+            cpu_pwr_eff_mode (List[int], optional): Value override for args.cpu_pwr_eff_mode [mode, util, ppt_limit]. Defaults to None.
             cpu_gmi3_link_width (List[int], optional): Value override for args.cpu_gmi3_link_width. Defaults to None.
             cpu_pcie_link_rate (int, optional): Value override for args.cpu_pcie_link_rate. Defaults to None.
             cpu_df_pstate_range (List[int], optional): Value override for args.cpu_df_pstate_range. Defaults to None.
             cpu_enable_apb (bool, optional): Value override for args.cpu_enable_apb. Defaults to None.
             cpu_disable_apb (int, optional): Value override for args.cpu_disable_apb. Defaults to None.
             soc_boost_limit (int, optional): Value override for args.soc_boost_limit. Defaults to None.
-            cpu_dfcstate_ctrl (int, optional): Value override for args.cpu_dfcstate_ctrl. Defaults to None.
+            cpu_xgmi_pstate_range (List[int], optional): Value override for args.cpu_xgmi_pstate_range. Defaults to None.
             cpu_railisofreq_policy (int, optional): Value override for args.cpu_railisofreq_policy. Defaults to None.
+            cpu_dfcstate_ctrl (int, optional): Value override for args.cpu_dfcstate_ctrl. Defaults to None.
+            cpu_pc6_enable (int, optional): Value override for args.cpu_pc6_enable. Defaults to None.
+            cpu_cc6_enable (int, optional): Value override for args.cpu_cc6_enable. Defaults to None.
+            soc_floor_limit (int, optional): Value override for args.soc_floor_limit. Defaults to None.
+            cpu_msr_floor_limit (int, optional): Value override for args.cpu_msr_floor_limit. Defaults to None.
+            cpu_dimm_sb_reg (list, optional): DIMM sideband register write parameters [dimm_addr, lid, reg_offset, reg_space, write_data] for write operation. Value override for args.cpu_dimm_sb_reg. Defaults to None.
+            cpu_socket_sdps_limit (int, optional): Value override for args.cpu_socket_sdps_limit. Defaults to None.
 
         Raises:
             ValueError: Value error if no cpu value is provided
@@ -4454,10 +4694,24 @@ class AMDSMICommands():
             args.cpu_disable_apb = cpu_disable_apb
         if soc_boost_limit:
             args.soc_boost_limit = soc_boost_limit
-        if cpu_dfcstate_ctrl:
-            args.cpu_dfcstate_ctrl = cpu_dfcstate_ctrl
+        if cpu_xgmi_pstate_range:
+            args.cpu_xgmi_pstate_range = cpu_xgmi_pstate_range
         if cpu_railisofreq_policy:
             args.cpu_railisofreq_policy = cpu_railisofreq_policy
+        if cpu_dfcstate_ctrl:
+            args.cpu_dfcstate_ctrl = cpu_dfcstate_ctrl
+        if cpu_pc6_enable:
+            args.cpu_pc6_enable = cpu_pc6_enable
+        if cpu_cc6_enable:
+            args.cpu_cc6_enable = cpu_cc6_enable
+        if soc_floor_limit:
+            args.soc_floor_limit = soc_floor_limit
+        if cpu_msr_floor_limit:
+            args.cpu_msr_floor_limit = cpu_msr_floor_limit
+        if cpu_dimm_sb_reg:
+            args.cpu_dimm_sb_reg = cpu_dimm_sb_reg
+        if cpu_socket_sdps_limit:
+            args.cpu_socket_sdps_limit = cpu_socket_sdps_limit
 
         if args.cpu == None:
             raise ValueError('No CPU provided, specific CPU targets(S) are needed')
@@ -4472,7 +4726,10 @@ class AMDSMICommands():
         if not any([args.cpu_pwr_limit, args.cpu_xgmi_link_width, args.cpu_lclk_dpm_level,
                     args.cpu_pwr_eff_mode, args.cpu_gmi3_link_width, args.cpu_pcie_link_rate,
                     args.cpu_df_pstate_range, args.cpu_enable_apb, args.cpu_disable_apb,
-                    args.soc_boost_limit, args.cpu_dfcstate_ctrl, args.cpu_railisofreq_policy]):
+                    args.soc_boost_limit, args.cpu_xgmi_pstate_range, args.cpu_railisofreq_policy,
+                    args.cpu_dfcstate_ctrl, args.cpu_pc6_enable, args.cpu_cc6_enable,
+                    args.soc_floor_limit, args.cpu_msr_floor_limit, args.cpu_dimm_sb_reg,
+                    args.cpu_socket_sdps_limit]):
             command = " ".join(sys.argv[1:])
             raise AmdSmiRequiredCommandException(command, self.logger.format)
 
@@ -4523,8 +4780,12 @@ class AMDSMICommands():
         if args.cpu_pwr_eff_mode:
             static_dict["set_pwr_eff_mode"] = {}
             try:
-                amdsmi_interface.amdsmi_set_cpu_pwr_efficiency_mode(args.cpu, args.cpu_pwr_eff_mode[0][0])
-                static_dict["set_pwr_eff_mode"]["Response"] = f"{args.cpu_pwr_eff_mode[0][0]}"
+                mode = args.cpu_pwr_eff_mode[0][0]
+                util = args.cpu_pwr_eff_mode[0][1]
+                ppt_limit = args.cpu_pwr_eff_mode[0][2]
+                updated_util, updated_ppt_limit = amdsmi_interface.amdsmi_set_cpu_pwr_efficiency_mode(args.cpu, mode, util, ppt_limit)
+                #static_dict["set_pwr_eff_mode"]["Response"] = f"Mode: {mode}, Final Util: {updated_util}, Final PPT Limit: {updated_ppt_limit}"
+                static_dict["set_pwr_eff_mode"]["Response"] = f"Mode: {mode}"
             except amdsmi_exception.AmdSmiLibraryException as e:
                 static_dict["set_pwr_eff_mode"]["Response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 logging.debug("Failed to set power efficiency mode for cpu %s | %s", cpu_id, e.get_error_info())
@@ -4585,23 +4846,101 @@ class AMDSMICommands():
                 #static_dict["set_soc_boost_limit"]["Response"] = "N/A"
                 static_dict["set_soc_boost_limit"]["Response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 logging.debug("Failed to set socket boost limit for cpu %s | %s", cpu_id, e.get_error_info())
-        if args.cpu_dfcstate_ctrl:
-            static_dict["dfcstatectrl"] = {}
+
+        if args.cpu_xgmi_pstate_range:
+            static_dict["xgmi_pstate_range"] = {}
             try:
-                amdsmi_interface.amdsmi_set_dfc_ctrl(args.cpu, args.cpu_dfcstate_ctrl[0][0])
-                static_dict["dfcstatectrl"]["state"] = "DFCState control operation successful"
+                amdsmi_interface.amdsmi_set_cpu_xgmi_pstate_range(args.cpu, args.cpu_xgmi_pstate_range[0][0],
+                args.cpu_xgmi_pstate_range[0][1])
+                static_dict["xgmi_pstate_range"]["response"] = f"Set, MIN_PSTATE: {args.cpu_xgmi_pstate_range[0][0]}, MAX_PSTATE: {args.cpu_xgmi_pstate_range[0][1]}, successful"
             except amdsmi_exception.AmdSmiLibraryException as e:
-                static_dict["dfcstatectrl"]["state"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
-                logging.debug("Failed to set dfcstate control for cpu %s | %s", cpu_id, e.get_error_info())
+                static_dict["xgmi_pstate_range"]["response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                logging.debug("Failed to set xgmi pstate range for cpu %s | %s", cpu_id, e.get_error_info())
 
         if args.cpu_railisofreq_policy:
-            static_dict["cpurailiso"] = {}
+            static_dict["railisofreq_policy"] = {}
             try:
                 amdsmi_interface.amdsmi_set_cpu_rail_isofreq_policy(args.cpu, args.cpu_railisofreq_policy[0][0])
-                static_dict["cpurailiso"]["state"] = "Set CPU ISO frequency policy operation successful"
+                static_dict["railisofreq_policy"]["response"] = f"Set, VALUE: {args.cpu_railisofreq_policy[0][0]}, successful"
             except amdsmi_exception.AmdSmiLibraryException as e:
-                static_dict["cpurailiso"]["state"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                static_dict["railisofreq_policy"]["response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 logging.debug("Failed to set ISO frequency policy for cpu %s | %s", cpu_id, e.get_error_info())
+
+        if args.cpu_dfcstate_ctrl:
+            static_dict["dfcstate_ctrl"] = {}
+            try:
+                amdsmi_interface.amdsmi_set_dfc_ctrl(args.cpu, args.cpu_dfcstate_ctrl[0][0])
+                static_dict["dfcstate_ctrl"]["response"] = f"Set, VALUE: {args.cpu_dfcstate_ctrl[0][0]}, successful"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["dfcstate_ctrl"]["response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                logging.debug("Failed to set dfcstate control for cpu %s | %s", cpu_id, e.get_error_info())
+
+        if args.cpu_pc6_enable:
+            static_dict["pc6_enable"] = {}
+            try:
+                amdsmi_interface.amdsmi_set_pc6_enable(args.cpu, args.cpu_pc6_enable[0][0])
+                static_dict["pc6_enable"]["response"] = f"Set, VALUE: {args.cpu_pc6_enable[0][0]}, successful"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["pc6_enable"]["response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                logging.debug("Failed to set PC6 enable for cpu %s | %s", cpu_id, e.get_error_info())
+
+        if args.cpu_cc6_enable:
+            static_dict["cc6_enable"] = {}
+            try:
+                amdsmi_interface.amdsmi_set_cc6_enable(args.cpu, args.cpu_cc6_enable[0][0])
+                static_dict["cc6_enable"]["response"] = f"Set, VALUE: {args.cpu_cc6_enable[0][0]}, successful"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["cc6_enable"]["response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                logging.debug("Failed to set CC6 enable for cpu %s | %s", cpu_id, e.get_error_info())
+
+        if args.soc_floor_limit:
+            static_dict["soc_floor_limit"] = {}
+            try:
+                amdsmi_interface.amdsmi_set_cpu_floorlimit(args.cpu, args.soc_floor_limit[0][0])
+                static_dict["soc_floor_limit"]["Response"] = f"Set, VALUE: {args.soc_floor_limit[0][0]} MHz, successful"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["soc_floor_limit"]["Response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                logging.debug("Failed to set socket floor limit for cpu %s | %s", cpu_id, e.get_error_info())
+
+        if args.cpu_msr_floor_limit:
+            static_dict["msr_floor_limit"] = {}
+            try:
+                amdsmi_interface.amdsmi_cpu_msr_floorlimit(args.cpu, args.cpu_msr_floor_limit[0][0])
+                static_dict["msr_floor_limit"]["Response"] = f"Set, VALUE: {args.cpu_msr_floor_limit[0][0]} MHz, successful"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["msr_floor_limit"]["Response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                logging.debug("Failed to set CPU MSR floor limit for cpu %s | %s", cpu_id, e.get_error_info())
+
+        if args.cpu_dimm_sb_reg:
+            static_dict["dimm_sb_reg"] = {}
+            try:
+                dimm_addr = args.cpu_dimm_sb_reg[0][0]
+                lid = args.cpu_dimm_sb_reg[0][1]
+                reg_offset = args.cpu_dimm_sb_reg[0][2]
+                reg_space = args.cpu_dimm_sb_reg[0][3]
+                write_data = args.cpu_dimm_sb_reg[0][4]
+                amdsmi_interface.amdsmi_dimm_sb_reg_write(
+                    args.cpu, dimm_addr, lid, reg_offset, reg_space, write_data)
+                static_dict["dimm_sb_reg"]["DimmAddress"] = f"0x{dimm_addr:02X}"
+                static_dict["dimm_sb_reg"]["Lid"] = f"0x{lid:02X}"
+                static_dict["dimm_sb_reg"]["Offset"] = f"0x{reg_offset:04X}"
+                static_dict["dimm_sb_reg"]["RegSpace"] = reg_space
+                static_dict["dimm_sb_reg"]["Data"] = f"0x{write_data:08X}"
+                static_dict["dimm_sb_reg"]["Response"] = "Set DIMM sideband register write operation successful"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["dimm_sb_reg"]["Response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                logging.debug("Failed to write DIMM sideband register for cpu %s | %s", cpu_id, e.get_error_info())
+
+        if args.cpu_socket_sdps_limit:
+            static_dict["socket_sdps_limit"] = {}
+            try:
+                amdsmi_interface.amdsmi_set_cpu_socket_sdps_limit(args.cpu, args.cpu_socket_sdps_limit[0][0])
+                sdps_limit_watts = float(args.cpu_socket_sdps_limit[0][0]) / 1000
+                static_dict["socket_sdps_limit"]["Response"] = f"Set, VALUE: {sdps_limit_watts:.3f} Watts, successful"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                static_dict["socket_sdps_limit"]["Response"] = f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
+                logging.debug("Failed to set socket SDPS limit for cpu %s | %s", cpu_id, e.get_error_info())
+
 
         multiple_devices_csv_override = False
         self.logger.store_cpu_output(args.cpu, 'values', static_dict)
@@ -5218,8 +5557,10 @@ class AMDSMICommands():
                   cpu_pwr_eff_mode=None, cpu_gmi3_link_width=None, cpu_pcie_link_rate=None,
                   cpu_df_pstate_range=None, cpu_enable_apb=None, cpu_disable_apb=None,
                   soc_boost_limit=None, core=None, core_boost_limit=None, soc_pstate=None, xgmi_plpd=None,
-                  process_isolation=None, clk_limit=None, clk_level=None, cpu_dfcstate_ctrl=None,
-                  cpu_railisofreq_policy=None, ptl_status=None, ptl_format=None):
+                  process_isolation=None, clk_limit=None, clk_level=None, ptl_status=None, ptl_format=None,
+                  cpu_xgmi_pstate_range=None, cpu_railisofreq_policy=None, cpu_dfcstate_ctrl=None,
+                  cpu_pc6_enable=None, cpu_cc6_enable=None, soc_floor_limit=None, cpu_msr_floor_limit=None,
+                  cpu_dimm_sb_reg=None, cpu_socket_sdps_limit=None, core_floor_limit=None, core_msr_floor_limit=None):
         """Issue reset commands to target gpu(s)
 
         Args:
@@ -5238,7 +5579,7 @@ class AMDSMICommands():
             cpu_pwr_limit (int, optional): Value override for args.cpu_pwr_limit. Defaults to None.
             cpu_xgmi_link_width (List[int], optional): Value override for args.cpu_xgmi_link_width. Defaults to None.
             cpu_lclk_dpm_level (List[int], optional): Value override for args.cpu_lclk_dpm_level. Defaults to None.
-            cpu_pwr_eff_mode (int, optional): Value override for args.cpu_pwr_eff_mode. Defaults to None.
+            cpu_pwr_eff_mode (List[int], optional): Value override for args.cpu_pwr_eff_mode [mode, util, ppt_limit]. Defaults to None.
             cpu_gmi3_link_width (List[int], optional): Value override for args.cpu_gmi3_link_width. Defaults to None.
             cpu_pcie_link_rate (int, optional): Value override for args.cpu_pcie_link_rate. Defaults to None.
             cpu_df_pstate_range (List[int], optional): Value override for args.cpu_df_pstate_range. Defaults to None.
@@ -5247,9 +5588,18 @@ class AMDSMICommands():
             soc_boost_limit (int, optional): Value override for args.soc_boost_limit. Defaults to None.
             cpu_dfcstate_ctrl (int, optional): Value override for args.cpu_dfcstate_ctrl. Defaults to None.
             cpu_railisofreq_policy (int, optional): Value override for args.cpu_railisofreq_policy. Defaults to None.
+            cpu_xgmi_pstate_range (List[int], optional): Value override for args.cpu_xgmi_pstate_range. Defaults to None.
+            cpu_pc6_enable (int, optional): Value override for args.cpu_pc6_enable. Defaults to None.
+            cpu_cc6_enable (int, optional): Value override for args.cpu_cc6_enable. Defaults to None.
+            cpu_dimm_sb_reg (list, optional): DIMM sideband register write parameters [dimm_addr, lid, reg_offset, reg_space, write_data] for write operation. Value override for args.cpu_dimm_sb_reg. Defaults to None.
+            cpu_socket_sdps_limit (int, optional): Value override for args.cpu_socket_sdps_limit. Defaults to None.
+            soc_floor_limit (int, optional): Value override for args.soc_floor_limit. Defaults to None.
+            cpu_msr_floor_limit (int, optional): Value override for args.cpu_msr_floor_limit. Defaults to None.
 
             core (device_handle, optional): device_handle for target core. Defaults to None.
             core_boost_limit (int, optional): Value override for args.core_boost_limit. Defaults to None
+            core_floor_limit (int, optional): Value override for args.core_floor_limit. Defaults to None.
+            core_msr_floor_limit (int, optional): Value override for args.core_msr_floor_limit. Defaults to None.
             soc_pstate (int, optional): Value override for args.soc_pstate. Defaults to None.
             xgmi_plpd (int, optional): Value override for args.xgmi_plpd. Defaults to None.
             process_isolation (int, optional): Value override for args.process_isolation. Defaults to None.
@@ -5284,7 +5634,9 @@ class AMDSMICommands():
         cpu_attributes = ["cpu_pwr_limit", "cpu_xgmi_link_width", "cpu_lclk_dpm_level", "cpu_pwr_eff_mode",
                           "cpu_gmi3_link_width", "cpu_pcie_link_rate", "cpu_df_pstate_range",
                           "cpu_enable_apb", "cpu_disable_apb", "soc_boost_limit",
-                          "cpu_dfcstate_ctrl", "cpu_railisofreq_policy"]
+                          "cpu_xgmi_pstate_range", "cpu_railisofreq_policy", "cpu_dfcstate_ctrl",
+                          "cpu_pc6_enable", "cpu_cc6_enable", "soc_floor_limit", "cpu_msr_floor_limit",
+                          "cpu_dimm_sb_reg", "cpu_socket_sdps_limit"]
         for attr in cpu_attributes:
             if hasattr(args, attr):
                 if getattr(args, attr) not in [None, False]:
@@ -5293,7 +5645,7 @@ class AMDSMICommands():
 
         # Check if a Core argument has been set
         core_args_enabled = False
-        core_attributes = ["core_boost_limit"]
+        core_attributes = ["core_boost_limit", "core_floor_limit", "core_msr_floor_limit"]
         for attr in core_attributes:
             if hasattr(args, attr):
                 if getattr(args, attr) is not None:
@@ -5340,14 +5692,25 @@ class AMDSMICommands():
                             args.cpu_enable_apb,
                             args.cpu_disable_apb is not None,
                             args.soc_boost_limit is not None,
+                            args.cpu_xgmi_pstate_range is not None,
+                            args.cpu_railisofreq_policy is not None,
                             args.cpu_dfcstate_ctrl is not None,
-                            args.cpu_railisofreq_policy is not None
+                            args.cpu_pc6_enable is not None,
+                            args.cpu_cc6_enable is not None,
+                            args.soc_floor_limit is not None,
+                            args.cpu_msr_floor_limit is not None,
+                            args.cpu_dimm_sb_reg is not None,
+                            args.cpu_socket_sdps_limit is not None
                             ])
             except AttributeError:
                 # If attribute error for cpu, then we could be another subcommand
                 pass
             try:
                 if args.core_boost_limit:
+                    is_core_set = True
+                if args.core_floor_limit:
+                    is_core_set = True
+                if args.core_msr_floor_limit:
                     is_core_set = True
             except AttributeError:
                 # If attribute error for core, then we could be another subcommand
@@ -5395,11 +5758,13 @@ class AMDSMICommands():
                                 cpu_xgmi_link_width, cpu_lclk_dpm_level, cpu_pwr_eff_mode,
                                 cpu_gmi3_link_width, cpu_pcie_link_rate, cpu_df_pstate_range,
                                 cpu_enable_apb, cpu_disable_apb, soc_boost_limit,
-                                cpu_dfcstate_ctrl, cpu_railisofreq_policy)
+                                cpu_xgmi_pstate_range, cpu_railisofreq_policy, cpu_dfcstate_ctrl,
+                                cpu_pc6_enable, cpu_cc6_enable, soc_floor_limit, cpu_msr_floor_limit,
+                                cpu_dimm_sb_reg, cpu_socket_sdps_limit)
             if args.core:
                 self.logger.output = {}
                 self.logger.clear_multiple_devices_output()
-                self.set_core(args, multiple_devices, core, core_boost_limit)
+                self.set_core(args, multiple_devices, core, core_boost_limit, core_floor_limit, core_msr_floor_limit)
             if args.gpu:
                 self.logger.output = {}
                 self.logger.clear_multiple_devices_output()
@@ -5415,11 +5780,13 @@ class AMDSMICommands():
                                 cpu_xgmi_link_width, cpu_lclk_dpm_level, cpu_pwr_eff_mode,
                                 cpu_gmi3_link_width, cpu_pcie_link_rate, cpu_df_pstate_range,
                                 cpu_enable_apb, cpu_disable_apb, soc_boost_limit,
-                                cpu_dfcstate_ctrl, cpu_railisofreq_policy)
+                                cpu_xgmi_pstate_range, cpu_railisofreq_policy, cpu_dfcstate_ctrl,
+                                cpu_pc6_enable, cpu_cc6_enable, soc_floor_limit, cpu_msr_floor_limit,
+                                cpu_dimm_sb_reg, cpu_socket_sdps_limit)
             if args.core:
                 self.logger.output = {}
                 self.logger.clear_multiple_devices_output()
-                self.set_core(args, multiple_devices, core, core_boost_limit)
+                self.set_core(args, multiple_devices, core, core_boost_limit, core_floor_limit, core_msr_floor_limit)
         elif self.helpers.is_amdgpu_initialized(): # Only GPU is initialized
             if args.gpu == None:
                 args.gpu = self.device_handles

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -1099,13 +1099,25 @@ class AMDSMIParser(argparse.ArgumentParser):
         cpu_dimm_temp_range_rate_help = "Displays dimm temperature range and refresh rate"
         cpu_dimm_pow_consumption_help = "Displays dimm power consumption"
         cpu_dimm_thermal_sensor_help = "Displays dimm thermal sensor"
-        cpu_dfcstate_ctrl_help = "Displays DFCState control status"
+        cpu_xgmi_pstate_range_help = "Displays XGMI pstate range (min and max values) for the selected CPU"
         cpu_railisofreq_policy_help = "Displays CPU ISO frequency policy"
+        cpu_dfcstate_ctrl_help = "Displays DFCState control status"
+        cpu_pc6_enable_help = "Displays PC6 enable control"
+        cpu_cc6_enable_help = "Displays CC6 enable control"
+        cpu_dimm_sb_reg_help = "Read DIMM sideband register.Requires DIMM_ADDR, LID(0x2->TS0,0x6->TS1,0x9->PMIC0,0xA->SPDHub)\
+        \n REG_OFFSET (hex), REG_SPACE (REGSPACE:0->Volatile,1->NVM)"
+        cpu_tdelta_help = "Displays CPU thermal delta (TDELTA) value for the selected CPU socket"
+        cpu_svi3_vr_controller_temp_help = "Get SVI3 VR controller temperature. TYPE: 0=HottestRail, 1=IndividualRail. If TYPE=1, RAIL_INDEX (0-7) must be specified"
+        cpu_enabled_commands_help = "Displays HSMP enabled commands bit masks (Read/Write EnabledCommandsBitMask0-2)"
+        cpu_socket_sdps_limit_help = "Displays socket SDPS limit for the selected CPU socket (in Watts)"
 
         # Help text for core options
         core_energy_help = "Displays core energy for the selected core"
         core_boost_limit_help = "Get boost limit for the selected cores"
         core_curr_active_freq_core_limit_help = "Get Current CCLK limit set per Core"
+        core_ccd_power_help = "Displays CCD (Core Complex Die) power consumption for the selected core"
+        core_floor_limit_help = "Get floor limit frequency for the selected core (MHz)"
+        core_eff_floor_limit_help = "Get effective floor limit frequency for the selected core (MHz)"
 
         # Create metric subparser
         metric_parser = subparsers.add_parser('metric', help=metric_help, description=metric_subcommand_help)
@@ -1181,8 +1193,18 @@ class AMDSMIParser(argparse.ArgumentParser):
                                     nargs=1, metavar=("DIMM_ADDR"), help=cpu_dimm_pow_consumption_help)
             cpu_group.add_argument('--cpu-dimm-thermal-sensor', action='append', required=False, type=lambda x: int(x, 0),
                                     nargs=1, metavar=("DIMM_ADDR"), help=cpu_dimm_thermal_sensor_help)
-            cpu_group.add_argument('--cpu-dfcstate-ctrl', action='store_true', required=False, help=cpu_dfcstate_ctrl_help)
+            cpu_group.add_argument('--cpu-xgmi-pstate-range', action='store_true', required=False, help=cpu_xgmi_pstate_range_help)
             cpu_group.add_argument('--cpu-railisofreq-policy', action='store_true', required=False, help=cpu_railisofreq_policy_help)
+            cpu_group.add_argument('--cpu-dfcstate-ctrl', action='store_true', required=False, help=cpu_dfcstate_ctrl_help)
+            cpu_group.add_argument('--cpu-pc6-enable', action='store_true', required=False, help=cpu_pc6_enable_help)
+            cpu_group.add_argument('--cpu-cc6-enable', action='store_true', required=False, help=cpu_cc6_enable_help)
+            cpu_group.add_argument('--cpu-dimm-sb-reg', action='append', required=False, type=lambda x: int(x, 0),
+                                    nargs=4, metavar=("DIMM_ADDR", "LID", "REG_OFFSET", "REG_SPACE"), help=cpu_dimm_sb_reg_help)
+            cpu_group.add_argument('--cpu-tdelta', action='store_true', required=False, help=cpu_tdelta_help)
+            cpu_group.add_argument('--cpu-svi3-vr-controller-temp', action='append', required=False, type=int,
+                                    nargs='+', metavar=("TYPE", "RAIL_INDEX"), help=cpu_svi3_vr_controller_temp_help)
+            cpu_group.add_argument("--cpu-enabled-commands", action="store_true", required=False, help=cpu_enabled_commands_help)
+            cpu_group.add_argument('--cpu-socket-sdps-limit', action='store_true', required=False, help=cpu_socket_sdps_limit_help)
 
             # Optional Args for CPU cores
             core_group = metric_parser.add_argument_group("CPU Core Arguments")
@@ -1190,6 +1212,9 @@ class AMDSMIParser(argparse.ArgumentParser):
             core_group.add_argument('--core-curr-active-freq-core-limit', action='store_true', required=False,
                                     help=core_curr_active_freq_core_limit_help)
             core_group.add_argument('--core-energy', action='store_true', required=False, help=core_energy_help)
+            core_group.add_argument('--core-ccd-power', action='store_true', required=False, help=core_ccd_power_help)
+            core_group.add_argument('--core-floor-limit', action='store_true', required=False, help=core_floor_limit_help)
+            core_group.add_argument('--core-eff-floor-limit', action='store_true', required=False, help=core_eff_floor_limit_help)
 
         # Add Universal Arguments & watch Args
         self._add_watch_arguments(metric_parser)
@@ -1367,21 +1392,31 @@ class AMDSMIParser(argparse.ArgumentParser):
 
         # Help text for CPU set options
         set_cpu_pwr_limit_help = "Set power limit for the given socket. Input parameter is power limit value."
-        set_cpu_xgmi_link_width_help = "Set max and Min linkwidth. Input parameters are min and max link width values"
-        set_cpu_lclk_dpm_level_help = "Sets the max and min dpm level on a given NBIO.\
-        \n Input parameters are die_index, min dpm, max dpm."
-        set_cpu_pwr_eff_mode_help = "Sets the power efficency mode policy. Input parameter is mode."
-        set_cpu_gmi3_link_width_help = "Sets max and min gmi3 link width range"
+        set_cpu_xgmi_link_width_help = "Set min and max linkwidth. Input parameters are min and max link width values (MAX >= MIN)"
+        set_cpu_lclk_dpm_level_help = "Sets the min and max dpm level on a given NBIO.\
+        \n Input parameters are die_index, min dpm, max dpm (MAX >= MIN)."
+        set_cpu_pwr_eff_mode_help = "Sets the power efficency mode policy with utility and PPT limit parameters. Input parameters are mode, util, ppt_limit."
+        set_cpu_gmi3_link_width_help = "Sets min and max gmi3 link width range (MAX >= MIN)"
         set_cpu_pcie_link_rate_help = "Sets pcie link rate"
-        set_cpu_df_pstate_range_help = "Sets max and min df-pstates"
+        set_cpu_df_pstate_range_help = "Sets min and max df-pstates (MAX <= MIN)"
         set_cpu_enable_apb_help = "Enables the DF p-state performance boost algorithm"
         set_cpu_disable_apb_help = "Disables the DF p-state performance boost algorithm. Input parameter is DFPstate (0-3)"
         set_soc_boost_limit_help = "Sets the boost limit for the given socket. Input parameter is socket BOOST_LIMIT value"
-        set_cpu_dfcstate_ctrl_help = "Sets the DFCState control. Input parameter is value (0-1)"
+        set_cpu_xgmi_pstate_range_help = "Sets xgmi pstate range. Input parameter are min (0-1) and max (0-1), (MAX <= MIN)"
         set_cpu_railisofreq_policy_help = "Sets the CPU ISO frequency policy. Input parameter is value (0-1)"
+        set_cpu_dfcstate_ctrl_help = "Sets the DFCState control. Input parameter is value (0-1)"
+        set_cpu_pc6_enable_help = "Sets PC6 enable control. Input parameter is value (0-1)"
+        set_cpu_cc6_enable_help = "Sets CC6 enable control. Input parameter is value (0-1)"
+        set_soc_floor_limit_help = "Sets the floor limit for the given socket. Input parameter is socket FLOOR_LIMIT value MHz"
+        cpu_msr_floor_limit_help = "Sets the CPU MSR floor limit frequency for the given socket. Input parameter is MSR_FLOOR_LIMIT value in MHz"
+        cpu_dimm_sb_reg_write_help = "Write data to DIMM sideband register. Requires DIMM_ADDR, LID(0x2->TS0,0x6->TS1,0x9->PMIC0,0xA->SPDHub)\
+        \n REG_OFFSET (hex), REG_SPACE (REGSPACE:0->Volatile,1->NVM), WRITE_DATA (hex)"
+        set_cpu_socket_sdps_limit_help = "Set socket SDPS limit for the given socket. Input parameter is SDPS limit value in milliwatts (mW)."
 
         # Help text for CPU Core set options
         set_core_boost_limit_help = "Sets the boost limit for the given core. Input parameter is core BOOST_LIMIT value"
+        set_core_floor_limit_help = "Sets the floor limit for the given core. Input parameter is core FLOOR_LIMIT value in MHz"
+        set_core_msr_floor_limit_help = "Sets the MSR floor limit for the given core. Input parameter is core MSR_FLOOR_LIMIT value in MHz"
 
         # Create set_value subparser
         set_value_parser = subparsers.add_parser('set', help=set_value_help, description=set_value_subcommand_help)
@@ -1420,18 +1455,32 @@ class AMDSMIParser(argparse.ArgumentParser):
                 cpu_group.add_argument('--cpu-pwr-limit', action='append', required=False, type=self._positive_int, nargs=1, metavar=("PWR_LIMIT"), help=set_cpu_pwr_limit_help)
                 cpu_group.add_argument('--cpu-xgmi-link-width', action='append', required=False, type=self._not_negative_int, nargs=2, metavar=("MIN_WIDTH", "MAX_WIDTH"), help=set_cpu_xgmi_link_width_help)
                 cpu_group.add_argument('--cpu-lclk-dpm-level', action='append', required=False, type=self._not_negative_int, nargs=3, metavar=("NBIOID", "MIN_DPM", "MAX_DPM"), help=set_cpu_lclk_dpm_level_help)
-                cpu_group.add_argument('--cpu-pwr-eff-mode', action='append', required=False, type=self._not_negative_int, nargs=1, metavar=("MODE"), help=set_cpu_pwr_eff_mode_help)
+                cpu_group.add_argument('--cpu-pwr-eff-mode', action='append', required=False, type=self._not_negative_int, nargs=3, metavar=("MODE", "UTIL", "PPT_LIMIT"), help=set_cpu_pwr_eff_mode_help)
                 cpu_group.add_argument('--cpu-gmi3-link-width', action='append', required=False, type=self._not_negative_int, nargs=2, metavar=("MIN_LW", "MAX_LW"), help=set_cpu_gmi3_link_width_help)
                 cpu_group.add_argument('--cpu-pcie-link-rate', action='append', required=False, type=self._not_negative_int, nargs=1, metavar=("LINK_RATE"), help=set_cpu_pcie_link_rate_help)
-                cpu_group.add_argument('--cpu-df-pstate-range', action='append', required=False, type=self._not_negative_int, nargs=2, metavar=("MAX_PSTATE", "MIN_PSTATE"), help=set_cpu_df_pstate_range_help)
+                cpu_group.add_argument('--cpu-df-pstate-range', action='append', required=False, type=self._not_negative_int, nargs=2, metavar=("MIN_PSTATE", "MAX_PSTATE"), help=set_cpu_df_pstate_range_help)
                 cpu_group.add_argument('--cpu-enable-apb', action='store_true', required=False, help=set_cpu_enable_apb_help)
                 cpu_group.add_argument('--cpu-disable-apb', action='append', required=False, type=self._not_negative_int, nargs=1, metavar=("DF_PSTATE"), help=set_cpu_disable_apb_help)
                 cpu_group.add_argument('--soc-boost-limit', action='append', required=False, type=self._positive_int, nargs=1, metavar=("BOOST_LIMIT"), help=set_soc_boost_limit_help)
+                cpu_group.add_argument('--cpu-xgmi-pstate-range', action='append', required=False, type=self._not_negative_int,
+                                       nargs=2, metavar=("MIN_PSTATE", "MAX_PSTATE"), help=set_cpu_xgmi_pstate_range_help)
+                cpu_group.add_argument('--cpu-railisofreq-policy', action='append', required=False, type=self._not_negative_int,
+                                       nargs=1, metavar=("VALUE"), help=set_cpu_railisofreq_policy_help)
                 cpu_group.add_argument('--cpu-dfcstate-ctrl', action='append', required=False, type=self._not_negative_int, nargs=1, metavar=("VALUE"), help=set_cpu_dfcstate_ctrl_help)
-                cpu_group.add_argument('--cpu-railisofreq-policy', action='append', required=False, type=self._not_negative_int, nargs=1, metavar=("VALUE"), help=set_cpu_railisofreq_policy_help)
+                cpu_group.add_argument('--cpu-pc6-enable', action='append', required=False, type=self._not_negative_int, nargs=1, metavar=("VALUE"), help=set_cpu_pc6_enable_help)
+                cpu_group.add_argument('--cpu-cc6-enable', action='append', required=False, type=self._not_negative_int, nargs=1, metavar=("VALUE"), help=set_cpu_cc6_enable_help)
+                cpu_group.add_argument('--soc-floor-limit', action='append', required=False, type=self._positive_int, nargs=1, metavar=("FLOOR_LIMIT"), help=set_soc_floor_limit_help)
+                cpu_group.add_argument('--cpu-msr-floor-limit', action='append', required=False, type=self._positive_int, nargs=1, metavar=("MSR_FLOOR_LIMIT"), help=cpu_msr_floor_limit_help)
+                cpu_group.add_argument('--cpu-dimm-sb-reg', action='append', required=False, type=lambda x: int(x, 0),
+                                       nargs=5, metavar=("DIMM_ADDR", "LID", "REG_OFFSET", "REG_SPACE", "WRITE_DATA"), help=cpu_dimm_sb_reg_write_help)
+                cpu_group.add_argument('--cpu-socket-sdps-limit', action='append', required=False, type=self._positive_int,
+                                       nargs=1, metavar=('SDPS_LIMIT'), help=set_cpu_socket_sdps_limit_help)
                 # Optional CPU Core Args
                 core_group = set_value_parser.add_argument_group("CPU Core Arguments")
                 core_group.add_argument('--core-boost-limit', action='append', required=False, type=self._positive_int, nargs=1, metavar=("BOOST_LIMIT"), help=set_core_boost_limit_help)
+                core_group.add_argument('--core-floor-limit', action='append', required=False, type=self._positive_int, nargs=1, metavar=("FLOOR_LIMIT"), help=set_core_floor_limit_help)
+                core_group.add_argument('--core-msr-floor-limit', action='append', required=False, type=self._positive_int,
+                                        nargs=1, metavar=("MSR_FLOOR_LIMIT"), help=set_core_msr_floor_limit_help)
 
         # Set accepts default devices of all
         self._add_device_arguments(set_value_parser, required=False)

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -358,13 +358,26 @@ CPU Arguments:
   --cpu-dimm-temp-range-rate DIMM_ADDR      Displays dimm temperature range and refresh rate
   --cpu-dimm-pow-consumption DIMM_ADDR      Displays dimm power consumption
   --cpu-dimm-thermal-sensor DIMM_ADDR       Displays dimm thermal sensor
-  --cpu-dfcstate-ctrl                       Displays DFCState control status
+  --cpu-xgmi-pstate-range                   Displays XGMI pstate range (min and max values) for the selected CPU
   --cpu-railisofreq-policy                  Displays CPU ISO frequency policy
+  --cpu-dfcstate-ctrl                       Displays DFCState control status
+  --cpu-pc6-enable                          Displays PC6 enable control
+  --cpu-cc6-enable                          Displays CC6 enable control
+  --cpu-dimm-sb-reg                         Read DIMM sideband register.Requires DIMM_ADDR, LID(0x2->TS0,0x6->TS1,0x9->PMIC0,0xA->SPDHub),
+                                             REG_OFFSET (hex), REG_SPACE (REGSPACE:0->Volatile,1->NVM)
+  --cpu-tdelta                              Displays CPU thermal delta (TDELTA) value for the selected CPU socket
+  --cpu-svi3-vr-controller-temp TYPE [RAIL_INDEX ...]
+                                            Get SVI3 VR controller temperature. TYPE: 0=HottestRail, 1=IndividualRail. If TYPE=1, RAIL_INDEX (0-7) must be specified
+  --cpu-enabled-commands                    Displays HSMP enabled commands bit masks (Read/Write EnabledCommandsBitMask0-2)
+  --cpu-socket-sdps-limit                   Displays socket SDPS limit for the selected CPU socket (in Watts)
 
 CPU Core Arguments:
   --core-boost-limit                        Get boost limit for the selected cores
   --core-curr-active-freq-core-limit        Get Current CCLK limit set per Core
   --core-energy                             Displays core energy for the selected core
+  --core-ccd-power                          Displays CCD (Core Complex Die) power consumption for the selected core
+  --core-floor-limit                        Get floor limit frequency for the selected core (MHz)
+  --core-eff-floor-limit                    Get effective floor limit frequency for the selected core (MHz)
 
 Device Arguments:
   -g, --gpu GPU [GPU ...]      Select a GPU ID, BDF, or UUID from the possible choices:
@@ -549,10 +562,14 @@ usage: amd-smi set [-h] (-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...
                    [--cpu-pwr-limit PWR_LIMIT] [--cpu-xgmi-link-width MIN_WIDTH MAX_WIDTH]
                    [--cpu-lclk-dpm-level NBIOID MIN_DPM MAX_DPM] [--cpu-pwr-eff-mode MODE]
                    [--cpu-gmi3-link-width MIN_LW MAX_LW] [--cpu-pcie-link-rate LINK_RATE]
-                   [--cpu-df-pstate-range MAX_PSTATE MIN_PSTATE] [--cpu-enable-apb]
+                   [--cpu-df-pstate-range MIN_PSTATE MAX_PSTATE] [--cpu-enable-apb]
                    [--cpu-disable-apb DF_PSTATE] [--soc-boost-limit BOOST_LIMIT]
                    [--core-boost-limit BOOST_LIMIT] [--json | --csv] [--file FILE]
-                   [--loglevel LEVEL] [--cpu-dfcstate-ctrl VALUE] [--cpu-railisofreq-policy VALUE]
+                   [--loglevel LEVEL] [--cpu-xgmi-pstate-range MIN_PSTATE MAX_PSTATE] [--cpu-railisofreq-policy VALUE]
+                   [--cpu-dfcstate-ctrl VALUE] [--cpu-pc6-enable VALUE] [--cpu-cc6-enable VALUE]
+                   [--soc-floor-limit FLOOR_LIMIT] [--cpu-msr-floor-limit MSR_FLOOR_LIMIT]
+                   [--core-floor-limit FLOOR_LIMIT] [--core-msr-floor-limit MSR_FLOOR_LIMIT]
+                   [--cpu-dimm-sb-reg DIMM_ADDR LID REG_OFFSET REG_SPACE [WRITE_DATA]] [--cpu-socket-sdps-limit SDPS_LIMIT]
 
 If no GPU is specified, will select all GPUs on the system.
 A set argument must be provided; Multiple set arguments are accepted.
@@ -587,21 +604,32 @@ Set Arguments:
 
 CPU Arguments:
   --cpu-pwr-limit PWR_LIMIT                                      Set power limit for the given socket. Input parameter is power limit value.
-  --cpu-xgmi-link-width MIN_WIDTH MAX_WIDTH                      Set max and Min linkwidth. Input parameters are min and max link width values
-  --cpu-lclk-dpm-level NBIOID MIN_DPM MAX_DPM                    Sets the max and min dpm level on a given NBIO.
-                                                                  Input parameters are die_index, min dpm, max dpm.
+  --cpu-xgmi-link-width MIN_WIDTH MAX_WIDTH                      Set min and max linkwidth. Input parameters are min and max link width values (MAX >= MIN)
+  --cpu-lclk-dpm-level NBIOID MIN_DPM MAX_DPM                    Sets the min and max dpm level on a given NBIO.
+                                                                  Input parameters are die_index, min dpm, max dpm (MAX >= MIN).
   --cpu-pwr-eff-mode MODE                                        Sets the power efficency mode policy. Input parameter is mode.
-  --cpu-gmi3-link-width MIN_LW MAX_LW                            Sets max and min gmi3 link width range
+  --cpu-gmi3-link-width MIN_LW MAX_LW                            Sets min and max gmi3 link width range (MAX >= MIN)
   --cpu-pcie-link-rate LINK_RATE                                 Sets pcie link rate
-  --cpu-df-pstate-range MAX_PSTATE MIN_PSTATE                    Sets max and min df-pstates
+  --cpu-df-pstate-range MIN_PSTATE MAX_PSTATE                    Sets min and max df-pstates (MAX <= MIN)
   --cpu-enable-apb                                               Enables the DF p-state performance boost algorithm
   --cpu-disable-apb DF_PSTATE                                    Disables the DF p-state performance boost algorithm. Input parameter is DFPstate (0-3)
   --soc-boost-limit BOOST_LIMIT                                  Sets the boost limit for the given socket. Input parameter is socket BOOST_LIMIT value
-  --cpu-dfcstate-ctrl VALUE                                      Sets the DFCState control for the given socket. Input parameter is VALUE (0-1)
+  --cpu-xgmi-pstate-range MIN_PSTATE MAX_PSTATE                  Sets min and max for xgmi pstate range (MAX <= MIN)
   --cpu-railisofreq-policy VALUE                                 Sets the CPU ISO frequency policy. Input parameter is VALUE (0-1)
+  --cpu-dfcstate-ctrl VALUE                                      Sets the DFCState control for the given socket. Input parameter is VALUE (0-1)
+  --cpu-pc6-enable VALUE                                         Sets PC6 enable control. Input parameter is value (0-1)
+  --cpu-cc6-enable VALUE                                         Sets CC6 enable control. Input parameter is value (0-1)
+  --soc-floor-limit FLOOR_LIMIT                                  Sets the floor limit for the given socket. Input parameter is socket FLOOR_LIMIT value MHz
+  --cpu-msr-floor-limit MSR_FLOOR_LIMIT                          Sets the CPU MSR floor limit frequency for the given socket. Input parameter is MSR_FLOOR_LIMIT value in MHz
+  --cpu-dimm-sb-reg DIMM_ADDR LID REG_OFFSET REG_SPACE [WRITE_DATA]
+                                                                 Write data to DIMM sideband register. Requires DIMM_ADDR, LID(0x2->TS0,0x6->TS1,0x9->PMIC0,0xA->SPDHub)
+                                                                  REG_OFFSET (hex), REG_SPACE (REGSPACE:0->Volatile,1->NVM), WRITE_DATA (hex)
+  --cpu-socket-sdps-limit SDPS_LIMIT                             Set socket SDPS limit for the given socket. Input parameter is SDPS limit value in milliwatts (mW).
 
 CPU Core Arguments:
   --core-boost-limit BOOST_LIMIT                                 Sets the boost limit for the given core. Input parameter is core BOOST_LIMIT value
+  --core-floor-limit FLOOR_LIMIT                                 Sets the floor limit for the given core. Input parameter is core FLOOR_LIMIT value in MHz
+  --core-msr-floor-limit MSR_FLOOR_LIMIT                         Sets the MSR floor limit for the given core. Input parameter is core MSR_FLOOR_LIMIT value in MHz
 
 Device Arguments:
   -g, --gpu GPU [GPU ...]                      Select a GPU ID, BDF, or UUID from the possible choices:

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -6755,6 +6755,88 @@ except AmdSmiException as e:
     print(e)
 ```
 
+### amdsmi_set_cpu_xgmi_pstate_range
+
+Description: Set the Min and Max XGMI PState Range. This API configures the XGMI P-State frequency range for the specified processor socket.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to configure
+- `min_pstate` (int): Minimum XGMI P-State value (highest frequency setting)
+- `max_pstate` (int): Maximum XGMI P-State value (lowest frequency setting)
+
+Output: `None`
+
+Exceptions that can be thrown by `amdsmi_set_cpu_xgmi_pstate_range` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for processor in processor_handles:
+            # Set XGMI PState range (max_pstate <= min_pstate)
+            amdsmi_set_cpu_xgmi_pstate_range(processor, 1, 1)
+            print("XGMI PState range set successfully")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_cpu_xgmi_pstate_range
+
+Description: Get the Max and Min XGMI PState Range. This API retrieves the current XGMI P-State frequency range configuration for the specified processor socket.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+
+Output: Dictionary containing XGMI PState range values:
+    - `min_pstate`: Current minimum XGMI P-State setting (highest frequency)
+    - `max_pstate`: Current maximum XGMI P-State setting (lowest frequency)
+
+Exceptions that can be thrown by `amdsmi_get_cpu_xgmi_pstate_range` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for processor in processor_handles:
+            pstate_range = amdsmi_get_cpu_xgmi_pstate_range(processor)
+            print(f"Min PState: {pstate_range['min_pstate']}")
+            print(f"Max PState: {pstate_range['max_pstate']}")
+except AmdSmiException as e:
+    print(e)
+```
+
 ### amdsmi_set_cpu_rail_isofreq_policy
 
 Description: Set the CPU Rail Isofrequency Policy. This function configures the frequency policy for CPU power rails.
@@ -6925,6 +7007,335 @@ try:
                 print("DFCState control is enabled")
             else:
                 print(f"DFCState control: Unknown status {dfc_status}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_set_pc6_enable
+
+Description: Set the PC6 (Package C6) enable state. PC6 is a low power state used for package-level power management.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+- `value` (int): PC6 enable state value:
+  - 0: Disable PC6 state
+  - 1: Enable PC6 state
+
+Output: `None`
+
+Exceptions that can be thrown by `amdsmi_set_pc6_enable` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for processor in processor_handles:
+            # Enable PC6 state
+            amdsmi_set_pc6_enable(processor, 1)
+            print("PC6 enable state set to enabled")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_pc6_enable
+
+Description: Get the current PC6 (Package C6) enable state. PC6 is a low power state used for package-level power management.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+
+Output: Integer representing the PC6 enable state:
+    - 0: PC6 state is disabled
+    - 1: PC6 state is enabled
+
+Exceptions that can be thrown by `amdsmi_get_pc6_enable` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for processor in processor_handles:
+            pc6_status = amdsmi_get_pc6_enable(processor)
+            if pc6_status == 0:
+                print("PC6 state is disabled")
+            elif pc6_status == 1:
+                print("PC6 state is enabled")
+            else:
+                print(f"PC6 enable state: Unknown status {pc6_status}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_set_cc6_enable
+
+Description: Set the CC6 (Core C6) enable state. CC6 is a low power state used for CPU core-level power management.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+- `value` (int): CC6 enable state value:
+  - 0: Disable CC6 state
+  - 1: Enable CC6 state
+
+Output: `None`
+
+Exceptions that can be thrown by `amdsmi_set_cc6_enable` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for processor in processor_handles:
+            # Enable CC6 state
+            amdsmi_set_cc6_enable(processor, 1)
+            print("CC6 enable state set to enabled")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_cc6_enable
+
+Description: Get the current CC6 (Core C6) enable state. CC6 is a low power state used for CPU core-level power management.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+
+Output: Integer representing the CC6 enable state:
+    - 0: CC6 state is disabled
+    - 1: CC6 state is enabled
+
+Exceptions that can be thrown by `amdsmi_get_cc6_enable` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for processor in processor_handles:
+            cc6_status = amdsmi_get_cc6_enable(processor)
+            if cc6_status == 0:
+                print("CC6 state is disabled")
+            elif cc6_status == 1:
+                print("CC6 state is enabled")
+            else:
+                print(f"CC6 enable state: Unknown status {cc6_status}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_dimm_sb_reg_read
+
+Description: Read data from DIMM sideband register using JEDEC Sideband Bus protocol. This API executes a four-byte read transaction at a specified register offset in a designated device on the target DIMM.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+- `dimm_addr` (int): DIMM address identifier
+- `lid` (int): Local Identifier (LID) for the device on DIMM:
+  - 0x2: TS0 (Thermal Sensor 0)
+  - 0x6: TS1 (Thermal Sensor 1)
+  - 0xA: SPD Hub
+- `reg_offset` (int): Register offset within the specified register space (hexadecimal)
+- `reg_space` (int): Register space selector:
+  - 0: Volatile register space
+  - 1: Non-volatile memory (NVM) register space
+
+Output: Integer representing the 4-byte data read from the register
+
+Exceptions that can be thrown by `amdsmi_dimm_sb_reg_read` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for processor in processor_handles:
+            # Read from DIMM sideband register (SPD Hub, volatile space)
+            dimm_addr = 0x50  # Example DIMM address
+            lid = 0xA         # SPD Hub
+            reg_offset = 0x00 # Register offset
+            reg_space = 0     # Volatile register space
+
+            data = amdsmi_dimm_sb_reg_read(processor, dimm_addr, lid, reg_offset, reg_space)
+            print(f"DIMM sideband register data: 0x{data:08X}")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_dimm_sb_reg_write
+
+Description: Write data to DIMM sideband register using JEDEC Sideband Bus protocol. This API executes a four-byte write transaction at a specified register offset in a designated device on the target DIMM.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+- `dimm_addr` (int): DIMM address identifier
+- `lid` (int): Local Identifier (LID) for the device on DIMM:
+  - 0x2: TS0 (Thermal Sensor 0)
+  - 0x6: TS1 (Thermal Sensor 1)
+  - 0xA: SPD Hub
+- `reg_offset` (int): Register offset within the specified register space (hexadecimal)
+- `reg_space` (int): Register space selector:
+  - 0: Volatile register space
+  - 1: Non-volatile memory (NVM) register space
+- `write_data` (int): 4-byte data value to write to the target register (hexadecimal)
+
+Output: `True` on successful write operation
+
+Exceptions that can be thrown by `amdsmi_dimm_sb_reg_write` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for processor in processor_handles:
+            # Write to DIMM sideband register (SPD Hub, volatile space)
+            dimm_addr = 0x50    # Example DIMM address
+            lid = 0xA           # SPD Hub
+            reg_offset = 0x00   # Register offset
+            reg_space = 0       # Volatile register space
+            write_data = 0x12345678  # Data to write
+
+            result = amdsmi_dimm_sb_reg_write(processor, dimm_addr, lid, reg_offset, reg_space, write_data)
+            if result:
+                print("DIMM sideband register write successful")
+            else:
+                print("DIMM sideband register write failed")
+except AmdSmiException as e:
+    print(e)
+```
+
+### amdsmi_get_ccd_power
+
+Description: Get the power consumption of a specific CCD (Core Complex Die) within a CPU socket. This function reads the average power consumed by the specified CCD.
+
+Input parameters:
+- `processor_handle` (amdsmi_processor_handle): CPU socket handle to query
+- `ccd_id` (int): CCD identifier (typically 0-7 for most AMD CPU systems)
+
+Output: Integer representing the CCD power consumption in milliwatts (mW)
+
+Exceptions that can be thrown by `amdsmi_get_ccd_power` function:
+
+* `AmdSmiLibraryException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_NOT_YET_IMPLEMENTED` - Feature not yet implemented
+- `AMDSMI_STATUS_NO_HSMP_MSG_SUP` - HSMP message/feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_TIMEOUT` - Timeout in API call
+
+Example:
+
+```python
+from amdsmi import *
+try:
+    ret = amdsmi_init(AmdSmiInitFlags.INIT_AMD_CPUS)
+    processor_handles = amdsmi_get_cpusocket_handles()
+    if len(processor_handles) == 0:
+        print("No CPUs on machine")
+    else:
+        for processor in processor_handles:
+            # Read CCD power consumption for multiple CCDs
+            for ccd_id in range(8):  # Most AMD systems have up to 8 CCDs
+                try:
+                    ccd_power = amdsmi_get_ccd_power(processor, ccd_id)
+                    print(f"CCD {ccd_id} power consumption: {ccd_power} mW")
+                except AmdSmiException:
+                    print(f"CCD {ccd_id} not available or not supported")
 except AmdSmiException as e:
     print(e)
 ```

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -294,6 +294,36 @@ typedef struct {
     uint32_t minor;  //!< Minor version number
 } amdsmi_hsmp_driver_version_t;
 
+/** HSMP Enabled Commands Structure */
+typedef struct {
+    bool read_mask;    //!< Read mask indicator
+    uint32_t arg0;     //!< Bit mask 0
+    uint32_t arg1;     //!< Bit mask 1
+    uint32_t arg2;     //!< Bit mask 2
+} amdsmi_hsmp_enabled_commands_t;
+
+/**
+ * @brief SVI3 VR controller temperature information.
+ *
+ * @cond @tag{cpu_bm} @endcond
+ */
+typedef struct {
+    uint32_t rail_selection;    //!< SVI3 rail selection (0 or 1)
+    uint32_t rail_index;        //!< SVI3 rail index (0-7)
+    uint32_t temperature;       //!< Temperature value in millidegree Celsius
+} amdsmi_svi3_vr_controller_temp_t;
+
+/**
+ * @brief SPD DIMM register validation limits
+ *
+ * @cond @tag{cpu_bm} @endcond
+ */
+#define AMDSMI_MAX_SPD_DIMM_ADDRESS       0xFF   //!< Maximum SPD DIMM address [7:0]
+#define AMDSMI_MAX_SPD_LID                0xF    //!< Maximum SPD logical ID [11:8]
+#define AMDSMI_MAX_SPD_REG_OFFSET         0x7FF  //!< Maximum SPD register offset [22:12]
+#define AMDSMI_MAX_SPD_REG_SPACE          0x1    //!< Maximum SPD register space [23]
+#define AMDSMI_MAX_SPD_WRITE_DATA         0xFF    //!< Maximum SPD write data [31:24]
+
 #endif
 
 /**
@@ -3639,14 +3669,20 @@ amdsmi_status_t amdsmi_set_cpu_socket_power_cap(amdsmi_processor_handle processo
  *
  *  @platform{cpu_bm}
  *
- *  @param[in] processor_handle Cpu socket which to query
+ *  @param[in]  processor_handle Cpu socket which to configure
  *
- *  @param[in] mode - mode to be set
+ *  @param[in]  mode - power efficiency mode to be set
+ *
+ *  @param[inout]  util - pointer to utility value for power efficiency calculation
+ *
+ *  @param[inout]  ppt_limit - pointer to PPT (Package Power Tracking) limit value
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
 amdsmi_status_t amdsmi_set_cpu_pwr_efficiency_mode(amdsmi_processor_handle processor_handle,
-                                                   uint8_t mode);
+                                                   uint8_t mode,
+                                                   uint32_t *util,
+                                                   uint32_t *ppt_limit);
 
 /** @} End tagPowerControl */
 
@@ -7545,14 +7581,14 @@ amdsmi_status_t amdsmi_set_cpu_pcie_link_rate(amdsmi_processor_handle processor_
  *
  *  @param[in]  processor_handle Cpu socket which to query
  *
- *  @param[in]  max_pstate - maximum pstate value to be set
- *
  *  @param[in]  min_pstate - minimum pstate value to be set
+ *
+ *  @param[in]  max_pstate - maximum pstate value to be set
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
 amdsmi_status_t amdsmi_set_cpu_df_pstate_range(amdsmi_processor_handle processor_handle,
-                                               uint8_t max_pstate, uint8_t min_pstate);
+                                               uint8_t min_pstate, uint8_t max_pstate);
 
 /** @} End tagPstateSelect */
 
@@ -7760,6 +7796,64 @@ amdsmi_status_t amdsmi_get_cpu_socket_count(uint32_t *sock_count);
 /** @} End tagCPUAuxillary */
 
 /**
+ *  @brief Set the Max and Min XGMI PState Range
+ *
+ *  This API configures the XGMI P-State frequency range for the specified processor socket.
+ *  - XGMI P-States control the frequency of the external Global Memory Interconnect (xGMI) links.
+ *  - Lower P-State values correspond to higher frequencies.
+ *  - The maximum P-State value must be less than or equal to the minimum P-State value.
+ *  - XGMI P-States can be set through APML or HSMP; the last value is enforced.
+ *
+ *  P-State range constraints:
+ *  - min_pstate: Minimum allowed XGMI P-State (highest frequency)
+ *  - max_pstate: Maximum allowed XGMI P-State (lowest frequency)
+ *  - Constraint: max_pstate <= min_pstate
+ *
+ *  @ingroup tagXgmiPstateControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in] processor_handle Cpu socket which to configure
+ *
+ *  @param[in] min_pstate Minimum XGMI P-State value (highest frequency setting)
+ *
+ *  @param[in] max_pstate Maximum XGMI P-State value (lowest frequency setting)
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_set_cpu_xgmi_pstate_range(amdsmi_processor_handle processor_handle,
+                                                uint8_t min_pstate, uint8_t max_pstate);
+
+/**
+ *  @brief Get the Max and Min XGMI PState Range
+ *
+ *  This API retrieves the current XGMI P-State frequency range configuration for the specified processor socket.
+ *  - XGMI P-States control the frequency of the external Global Memory Interconnect (xGMI) links.
+ *  - Lower P-State values correspond to higher frequencies.
+ *  - The returned values represent the currently configured P-State range limits.
+ *
+ *  P-State range values returned:
+ *  - min_pstate: Current minimum XGMI P-State setting (highest frequency)
+ *  - max_pstate: Current maximum XGMI P-State setting (lowest frequency)
+ *  - Relationship: max_pstate <= min_pstate
+ *
+ *  @ingroup tagXgmiPstateControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in] processor_handle Cpu socket which to query
+ *
+ *  @param[out] min_pstate Pointer to store current minimum XGMI P-State value
+ *  @param[out] max_pstate Pointer to store current maximum XGMI P-State value
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_get_cpu_xgmi_pstate_range(amdsmi_processor_handle processor_handle,
+                                                uint8_t *min_pstate, uint8_t *max_pstate);
+
+/** @} End tagXgmiPstateControl */
+
+/**
  *  @brief Set the CPU Rail Isofrequency Policy
  *
  *  This API configures the frequency policy for CPU power rails.
@@ -7867,6 +7961,424 @@ amdsmi_status_t amdsmi_get_dfc_ctrl(amdsmi_processor_handle processor_handle, ui
 
 /** @} End tagDFCEnableControl */
 
+/**
+ *  @brief Get the PC6 Enable State
+ *
+ *  This API retrieves the current PC6 (Package C6) enable state for the specified processor socket.
+ *
+ *  PC6 enable state values returned:
+ *  - 0: PC6 disabled
+ *  - 1: PC6 enabled
+ *
+ *  @ingroup tagPC6Control
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in] processor_handle Cpu socket which to query
+ *
+ *  @param[out] enabled Pointer to store the current PC6 enable state
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_get_pc6_enable(amdsmi_processor_handle processor_handle,
+                                       uint8_t *enabled);
+
+/**
+ *  @brief Set the PC6 Enable State
+ *
+ *  This API configures the PC6 (Package C6) enable state for the specified processor socket.
+ *
+ *  PC6 enable state values:
+ *  - 0: PC6 disabled
+ *  - 1: PC6 enabled
+ *
+ *  @ingroup tagPC6Control
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in] processor_handle Cpu socket which to configure
+ *
+ *  @param[in] enable PC6 enable state (0=disable, 1=enable)
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_set_pc6_enable(amdsmi_processor_handle processor_handle,
+                                       uint8_t enable);
+
+/** @} End tagPC6Control */
+
+/**
+ *  @brief Get the Core C6 Enable State.
+ *
+ *  This API retrieves the current Core C6 (CC6) low-power state configuration.
+ *
+ *  CC6 enable state values returned:
+ *  - 0: CC6 state disabled
+ *  - 1: CC6 state enabled
+ *
+ *  @ingroup tagCC6Control
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]      processor_handle Cpu socket which to query
+ *
+ *  @param[in,out]  enabled Pointer to store the current CC6 enable state
+ *
+ *  @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on success, non-zero on failure
+ */
+amdsmi_status_t amdsmi_get_cc6_enable(amdsmi_processor_handle processor_handle,
+                                       uint8_t *enabled);
+
+/**
+ *  @brief Set the Core C6 Enable State.
+ *
+ *  This API configures the Core C6 (CC6) low-power state for CPU cores.
+ *
+ *  CC6 enable state values:
+ *  - 0: Disable CC6 state
+ *  - 1: Enable CC6 state
+ *
+ *  @ingroup tagCC6Control
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in] processor_handle Cpu socket which to configure
+ *
+ *  @param[in] enable CC6 enable state value:
+ *                     - 0: Disable CC6 low-power state
+ *                     - 1: Enable CC6 low-power state
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_set_cc6_enable(amdsmi_processor_handle processor_handle,
+                                       uint8_t enable);
+
+/** @} End tagCC6Control */
+
+/**
+ *  @brief Read DIMM sideband register data
+ *
+ *  This API executes a four-byte read transaction at a specified register offset
+ *  in a designated device on the target DIMM using the JEDEC Sideband Bus protocol.
+ *  - The target DIMM is identified by DIMM_ADDRESS .
+ *  - The Local Identifier (LID) specifies the device on the DIMM as per JEDEC SidebandBus spec (JESD403).
+ *  - Only specific LID codes are supported: LID code 1001 (PMIC0) and LID code 1010 (SPD Hub).
+ *  - Register access can target either volatile or non-volatile memory spaces.
+ *  - NVM register space is available only in select devices on the SPD sideband bus.
+ *
+ *  @ingroup tagDIMMRegister
+ *
+ *  @param[in] processor_handle Processor handle for the target socket
+ *
+ *  @param[in] dimm_addr DIMM address
+ *
+ *  @param[in] lid Link/Lane identifier for the device on DIMM
+ *
+ *  @param[in] reg_offset Register offset within the specified register space
+ *
+ *  @param[in] reg_space Register space selector:
+ *                        - 0: Volatile register space
+ *                        - 1: Non-volatile memory (NVM) register space
+ *
+ *  @param[out] data Pointer to store the 4-byte read data from the register
+ *
+ *  @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on successful register read, non-zero on failure
+ */
+amdsmi_status_t amdsmi_dimm_sb_reg_read(amdsmi_processor_handle processor_handle,
+                                        uint64_t dimm_addr,
+                                        uint64_t lid,
+                                        uint64_t reg_offset,
+                                        uint64_t reg_space,
+                                        uint32_t *data);
+/**
+ *  @brief Write Data to DIMM Sideband Register
+ *
+ *  This API executes a four-byte write transaction at a specified register offset
+ *  in a designated device on the target DIMM using the JEDEC Sideband Bus protocol.
+ *  - The target DIMM is identified by DIMM_ADDRESS.
+ *  - The Local Identifier (LID) specifies the device on the DIMM as per JEDEC SidebandBus spec (JESD403).
+ *  - Only specific LID codes are supported: LID code 1001 (PMIC0) and LID code 1010 (SPD Hub).
+ *  - Register access can target either volatile or non-volatile memory spaces.
+ *  - NVM register space is available only in select devices on the SPD sideband bus.
+ *  - Write operations modify the configuration or control state of the target device.
+ *
+ *  @ingroup tagDIMMRegister
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in] processor_handle Processor handle for the target socket
+ *
+ *  @param[in] dimm_addr DIMM address
+ *
+ *  @param[in] id Link/Lane identifier for the device on DIMM
+ *
+ *  @param[in] reg_offset Register offset within the specified register space
+ *
+ *  @param[in] reg_space Register space selector:
+ *                        - 0: Volatile register space
+ *                        - 1: Non-volatile memory (NVM) register space
+ *
+ *  @param[in] write_data 4-byte data value to write to the target register
+ *
+ *  @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on successful register write, non-zero on failure
+ */
+amdsmi_status_t amdsmi_dimm_sb_reg_write(amdsmi_processor_handle processor_handle,
+                                          uint64_t dimm_addr,
+                                          uint64_t lid,
+                                          uint64_t reg_offset,
+                                          uint64_t reg_space,
+                                          uint64_t write_data);
+
+/** @} End tagDIMMRegister */
+
+/**
+ *  @brief Read CCD (Core Complex Die) power consumption
+ *
+ *  @details This function reads the power consumption of a specific CCD within a CPU socket.
+ *
+ *  @ingroup tagCPUPowerQuery
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]      processor_handle   CPU socket handle to query
+ *  @param[in]      ccd_id             CCD identifier (typically 0-7)
+ *  @param[out]     power              Pointer to store power consumption in milliwatts
+ *
+ *   @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on successful register read, non-zero on failure
+ */
+amdsmi_status_t amdsmi_get_ccd_power(amdsmi_processor_handle processor_handle,
+                                     uint32_t ccd_id,
+                                     uint32_t *power);
+
+/** @} End tagCPUPowerQuery */
+
+/**
+ *  @brief Read Thermal Delta (TDELTA) Behavior
+ *
+ *  This API retrieves the thermal solution behavior value from the CPU socket
+ *
+ *  Thermal Behavior values returned:
+ *  - 0: Thermal solution behavior is normal (operating within expected thermal range)
+ *  - 1 or any other value: Thermal solution is out of expected range (thermal stress detected)
+ *
+ *  @ingroup tagCPUThermalQuery
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]      processor_handle CPU socket handle to query
+ *  @param[out]     tdelta Pointer to store the thermal delta behavior value:
+ *                         - 0: Normal thermal solution behavior
+ *                         - Non-zero: Thermal solution out of expected range
+ *
+ *   @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on successful register read, non-zero on failure
+ */
+amdsmi_status_t amdsmi_read_tdelta(amdsmi_processor_handle processor_handle,
+                                   uint8_t *tdelta);
+
+/** @} End tagCPUThermalQuery */
+
+
+/**
+ *  @brief Get Temperature of SVI3 VR Controller Rails
+ *
+ *  This API retrieves the temperature of SVI3 voltage regulator
+ *
+ *  @ingroup tagSVI3TempQuery
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]      processor_handle CPU socket handle to query
+ *
+ *  @param[in,out]  vr_temp_info Pointer to SVI3 VR controller temperature structure:
+ *                               Input: rail_selection and rail_index must be configured
+ *                                     - rail_selection[0]: 0=hottest rail, 1=specific rail
+ *                                     - rail_index[3:1]: SVI3 rail index (when rail_selection[0]=1)
+ *                               Output: temperature field populated with rail temperature in C
+ *                                      - temperature[27:0]: Temperature in degrees Celsius
+ *                                      - rail_index[30:28]: Actual rail index of returned data
+ *
+ *  @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on successful temperature read, non-zero on failure
+ */
+amdsmi_status_t amdsmi_get_svi3_vr_controller_temp(amdsmi_processor_handle processor_handle,
+                                                   amdsmi_svi3_vr_controller_temp_t *vr_temp_info);
+
+/** @} End tagSVI3TempQuery */
+
+/**
+ *  @brief Get HSMP Enabled Commands information for a given CPU socket.
+ *
+ *  @details This function retrieves enabled commands bit masks for both read and write commands
+ *  from the HSMP interface. The information includes ReadEnabledCommandsBitMask0-2 and
+ *  WriteEnabledCommandsBitMask0-2.
+ *
+ *  @ingroup tagHSMPEnCmdStats
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]      processor_handle CPU socket handle to query
+ *  @param[out]     enabled_cmds Output buffer for enabled commands information
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_get_enabled_commands(amdsmi_processor_handle processor_handle,
+                                           amdsmi_hsmp_enabled_commands_t *enabled_cmds);
+
+/** @} End  tagHSMPEnCmdStats*/
+/**
+ *  @brief Get the CPU core floor limit frequency.
+ *
+ *  @details This function retrieve the floor frequency limit for the specified CPU core.
+ *
+ *  @ingroup tagCPUFreqFloorControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]      processor_handle CPU core which to query
+ *
+ *  @param[in,out]  pfloorlimit - Input buffer to fill the floor limit frequency in MHz
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_get_cpu_core_floorlimit(amdsmi_processor_handle processor_handle,
+                                               uint32_t *pfloorlimit);
+
+/**
+ *  @brief Get the CPU core effective floor limit frequency.
+ *
+ *  @details This function returns the effective floor frequency limit for the specified CPU core.
+ *
+ *  @ingroup tagCPUFreqFloorControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in]      processor_handle CPU core which to query
+ *
+ *  @param[in,out]  pefffloorlimit - Input buffer to fill the effective floor limit frequency in MHz
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_get_cpu_core_efffloorlimit(amdsmi_processor_handle processor_handle,
+                                                  uint32_t *pefffloorlimit);
+
+/**
+ *  @brief Set the CPU core floor limit frequency.
+ *
+ *  @details This function sets the floor frequency limit for the specified CPU core.
+ *
+ *  @ingroup tagCPUFreqFloorControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in] processor_handle CPU core which to set
+ *
+ *  @param[in] floorlimit - floor limit frequency value to be set in MHz
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_set_cpu_core_floorlimit(amdsmi_processor_handle processor_handle,
+						uint32_t floorlimit);
+
+/**
+ *  @brief Set the CPU socket floor limit frequency.
+ *
+ *  @details This function sets the floor frequency limit for the specified CPU socket.
+ *
+ *  @ingroup tagCPUFreqFloorControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in] processor_handle CPU socket which to set
+ *
+ *  @param[in] floorlimit - floor limit frequency value to be set in MHz
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_set_cpu_floorlimit(amdsmi_processor_handle processor_handle,
+                                          uint32_t floorlimit);
+
+/**
+ *  @brief Set CPU MSR floor limit frequency.
+ *
+ *  @details This function sets the MSR floor frequency limit for the specified CPU socket.
+ *
+ *  @ingroup tagCPUFreqFloorControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in] processor_handle CPU socket which to set
+ *
+ *  @param[in] msrfloorlimit - MSR floor limit frequency value to be set in MHz
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_cpu_msr_floorlimit(amdsmi_processor_handle processor_handle,
+                                          uint32_t msrfloorlimit);
+
+/**
+ *  @brief Set CPU core MSR floor limit frequency.
+ *
+ *  @details This function sets the MSR floor frequency limit for the specified CPU core.
+ *           This is a core-level MSR operation that directly sets the floor frequency
+ *           at the hardware register level for individual CPU cores.
+ *
+ *  @ingroup tagCPUFreqFloorControl
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in] processor_handle CPU core which to set
+ *
+ *  @param[in] msrfloorlimit - MSR floor limit frequency value to be set in MHz
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_cpu_core_msr_floorlimit(amdsmi_processor_handle processor_handle,
+                                               uint32_t msrfloorlimit);
+
+/** @} End  tagCPUFreqFloorControl*/
+
+/**
+ *  @brief Set the SDPS limit for a given processor socket.
+ *
+ *  @details This function will set the SDPS (Software Defined Power Scaling) limit control.
+ *  The limit is specified in milliwatts.
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in] processor_handle Processor handle for which to set the limit
+ *  @param[in] sdps_limit SDPS limit value in milliwatts
+ *
+ *  @retval ::AMDSMI_STATUS_SUCCESS           Call was successful
+ *  @retval ::AMDSMI_STATUS_INVAL            Invalid processor_handle
+ *  @retval ::AMDSMI_STATUS_NOT_SUPPORTED    ESMI library not enabled or SDPS not available
+ *  @retval ::AMDSMI_STATUS_API_FAILED       ESMI API call failed
+ */
+amdsmi_status_t amdsmi_set_cpu_socket_sdps_limit(amdsmi_processor_handle processor_handle,
+                                                  uint32_t sdps_limit);
+
+/**
+ *  @brief Get the current SDPS limit for a given processor socket.
+ *
+ *  @details This function will retrieve the current SDPS (Software Defined Power Scaling) limit control.
+ *  The limit is returned in milliwatts.
+ *
+ *  @platform{cpu_bm}
+ *
+ *  @param[in] processor_handle Processor handle for which to query the limit
+ *  @param[out] sdps_limit Pointer to receive the current SDPS limit value in milliwatts
+ *
+ *  @retval ::AMDSMI_STATUS_SUCCESS           Call was successful
+ *  @retval ::AMDSMI_STATUS_INVAL            Invalid processor_handle or sdps_limit pointer
+ *  @retval ::AMDSMI_STATUS_NOT_SUPPORTED    ESMI library not enabled or SDPS not available
+ *  @retval ::AMDSMI_STATUS_API_FAILED       ESMI API call failed
+ */
+amdsmi_status_t amdsmi_get_cpu_socket_sdps_limit(amdsmi_processor_handle processor_handle,
+                                                  uint32_t *sdps_limit);
 #endif
 
 #ifdef __cplusplus

--- a/projects/amdsmi/include/amd_smi/impl/amd_hsmp.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_hsmp.h
@@ -13,80 +13,90 @@
  * HSMP Messages supported
  */
 enum hsmp_message_ids {
-    HSMP_TEST = 1,                  /* 01h Increments input value by 1 */
-    HSMP_GET_SMU_VER,               /* 02h SMU FW version */
-    HSMP_GET_PROTO_VER,             /* 03h HSMP interface version */
-    HSMP_GET_SOCKET_POWER,          /* 04h average package power consumption */
-    HSMP_SET_SOCKET_POWER_LIMIT,    /* 05h Set the socket power limit */
-    HSMP_GET_SOCKET_POWER_LIMIT,    /* 06h Get current socket power limit */
-    HSMP_GET_SOCKET_POWER_LIMIT_MAX,/* 07h Get maximum socket power value */
-    HSMP_SET_BOOST_LIMIT,           /* 08h Set a core maximum frequency limit */
-    HSMP_SET_BOOST_LIMIT_SOCKET,    /* 09h Set socket maximum frequency level */
-    HSMP_GET_BOOST_LIMIT,           /* 0Ah Get current frequency limit */
-    HSMP_GET_PROC_HOT,              /* 0Bh Get PROCHOT status */
-    HSMP_SET_XGMI_LINK_WIDTH,       /* 0Ch Set max and min width of xGMI Link */
-    HSMP_SET_DF_PSTATE,             /* 0Dh Alter APEnable/Disable messages behavior */
-    HSMP_SET_AUTO_DF_PSTATE,        /* 0Eh Enable DF P-State Performance Boost algorithm */
-    HSMP_GET_FCLK_MCLK,             /* 0Fh Get FCLK and MEMCLK for current socket */
-    HSMP_GET_CCLK_THROTTLE_LIMIT,   /* 10h Get CCLK frequency limit in socket */
-    HSMP_GET_C0_PERCENT,            /* 11h Get average C0 residency in socket */
-    HSMP_SET_NBIO_DPM_LEVEL,        /* 12h Set max/min LCLK DPM Level for a given NBIO */
-    HSMP_GET_NBIO_DPM_LEVEL,        /* 13h Get LCLK DPM level min and max for a given NBIO */
-    HSMP_GET_DDR_BANDWIDTH,         /* 14h Get theoretical maximum and current DDR Bandwidth */
-    HSMP_GET_TEMP_MONITOR,          /* 15h Get socket temperature */
-    HSMP_GET_DIMM_TEMP_RANGE,       /* 16h Get per-DIMM temperature range and refresh rate */
-    HSMP_GET_DIMM_POWER,            /* 17h Get per-DIMM power consumption */
-    HSMP_GET_DIMM_THERMAL,          /* 18h Get per-DIMM thermal sensors */
-    HSMP_GET_SOCKET_FREQ_LIMIT,     /* 19h Get current active frequency per socket */
-    HSMP_GET_CCLK_CORE_LIMIT,       /* 1Ah Get CCLK frequency limit per core */
-    HSMP_GET_RAILS_SVI,             /* 1Bh Get SVI-based Telemetry for all rails */
-    HSMP_GET_SOCKET_FMAX_FMIN,      /* 1Ch Get Fmax and Fmin per socket */
-    HSMP_GET_IOLINK_BANDWITH,       /* 1Dh Get current bandwidth on IO Link */
-    HSMP_GET_XGMI_BANDWITH,         /* 1Eh Get current bandwidth on xGMI Link */
-    HSMP_SET_GMI3_WIDTH,            /* 1Fh Set max and min GMI3 Link width */
-    HSMP_SET_PCI_RATE,              /* 20h Control link rate on PCIe devices */
-    HSMP_SET_POWER_MODE,            /* 21h Select power efficiency profile policy */
-    HSMP_SET_PSTATE_MAX_MIN,        /* 22h Set the max and min DF P-State  */
-    HSMP_GET_METRIC_TABLE_VER,      /* 23h Get metrics table version */
-    HSMP_GET_METRIC_TABLE,          /* 24h Get metrics table */
-    HSMP_GET_METRIC_TABLE_DRAM_ADDR,/* 25h Get metrics table dram address */
-    HSMP_SET_XGMI_PSTATE_RANGE,     /* 26h Set xGMI P-state range */
-    HSMP_CPU_RAIL_ISO_FREQ_POLICY,  /* 27h Get/Set Cpu Iso frequency policy */
-    HSMP_DFC_ENABLE_CTRL,           /* 28h Enable/Disable DF C-state */
-    HSMP_GET_RAPL_UNITS = 0x30,     /* 30h Get scaling factor for energy */
-    HSMP_GET_RAPL_CORE_COUNTER,     /* 31h Get core energy counter value */
-    HSMP_GET_RAPL_PACKAGE_COUNTER,  /* 32h Get package energy counter value */
-    HSMP_MSG_ID_MAX,
+	HSMP_TEST = 1,			/* 01h Increments input value by 1 */
+	HSMP_GET_SMU_VER,		/* 02h SMU FW version */
+	HSMP_GET_PROTO_VER,		/* 03h HSMP interface version */
+	HSMP_GET_SOCKET_POWER,		/* 04h average package power consumption */
+	HSMP_SET_SOCKET_POWER_LIMIT,	/* 05h Set the socket power limit */
+	HSMP_GET_SOCKET_POWER_LIMIT,	/* 06h Get current socket power limit */
+	HSMP_GET_SOCKET_POWER_LIMIT_MAX,/* 07h Get maximum socket power value */
+	HSMP_SET_BOOST_LIMIT,		/* 08h Set a core maximum frequency limit */
+	HSMP_SET_BOOST_LIMIT_SOCKET,	/* 09h Set socket maximum frequency level */
+	HSMP_GET_BOOST_LIMIT,		/* 0Ah Get current frequency limit */
+	HSMP_GET_PROC_HOT,		/* 0Bh Get PROCHOT status */
+	HSMP_SET_XGMI_LINK_WIDTH,	/* 0Ch Set max and min width of xGMI Link */
+	HSMP_SET_DF_PSTATE,		/* 0Dh Alter APEnable/Disable messages behavior */
+	HSMP_SET_AUTO_DF_PSTATE,	/* 0Eh Enable DF P-State Performance Boost algorithm */
+	HSMP_GET_FCLK_MCLK,		/* 0Fh Get FCLK and MEMCLK for current socket */
+	HSMP_GET_CCLK_THROTTLE_LIMIT,	/* 10h Get CCLK frequency limit in socket */
+	HSMP_GET_C0_PERCENT,		/* 11h Get average C0 residency in socket */
+	HSMP_SET_NBIO_DPM_LEVEL,	/* 12h Set max/min LCLK DPM Level for a given NBIO */
+	HSMP_GET_NBIO_DPM_LEVEL,	/* 13h Get LCLK DPM level min and max for a given NBIO */
+	HSMP_GET_DDR_BANDWIDTH,		/* 14h Get theoretical maximum and current DDR Bandwidth */
+	HSMP_GET_TEMP_MONITOR,		/* 15h Get socket temperature */
+	HSMP_GET_DIMM_TEMP_RANGE,	/* 16h Get per-DIMM temperature range and refresh rate */
+	HSMP_GET_DIMM_POWER,		/* 17h Get per-DIMM power consumption */
+	HSMP_GET_DIMM_THERMAL,		/* 18h Get per-DIMM thermal sensors */
+	HSMP_GET_SOCKET_FREQ_LIMIT,	/* 19h Get current active frequency per socket */
+	HSMP_GET_CCLK_CORE_LIMIT,	/* 1Ah Get CCLK frequency limit per core */
+	HSMP_GET_RAILS_SVI,		/* 1Bh Get SVI-based Telemetry for all rails */
+	HSMP_GET_SOCKET_FMAX_FMIN,	/* 1Ch Get Fmax and Fmin per socket */
+	HSMP_GET_IOLINK_BANDWITH,	/* 1Dh Get current bandwidth on IO Link */
+	HSMP_GET_XGMI_BANDWITH,		/* 1Eh Get current bandwidth on xGMI Link */
+	HSMP_SET_GMI3_WIDTH,		/* 1Fh Set max and min GMI3 Link width */
+	HSMP_SET_PCI_RATE,		/* 20h Control link rate on PCIe devices */
+	HSMP_SET_POWER_MODE,		/* 21h Select power efficiency profile policy */
+	HSMP_SET_PSTATE_MAX_MIN,	/* 22h Set the max and min DF P-State  */
+	HSMP_GET_METRIC_TABLE_VER,	/* 23h Get metrics table version */
+	HSMP_GET_METRIC_TABLE,		/* 24h Get metrics table */
+	HSMP_GET_METRIC_TABLE_DRAM_ADDR,/* 25h Get metrics table dram address */
+	HSMP_SET_XGMI_PSTATE_RANGE,	/* 26h Set xGMI P-state range */
+	HSMP_CPU_RAIL_ISO_FREQ_POLICY,	/* 27h Get/Set Cpu Iso frequency policy */
+	HSMP_DFC_ENABLE_CTRL,		/* 28h Enable/Disable DF C-state */
+	HSMP_PC6_ENABLE,		/* 29h Get/Set PC6 Enable/Disable Status */
+	HSMP_CC6_ENABLE,		/* 2Ah Get/Set CC6 Enable/Disable Status */
+	HSMP_GET_RAPL_UNITS = 0x30,	/* 30h Get scaling factor for energy */
+	HSMP_GET_RAPL_CORE_COUNTER,	/* 31h Get core energy counter value */
+	HSMP_GET_RAPL_PACKAGE_COUNTER,	/* 32h Get package energy counter value */
+	HSMP_DIMM_SB_RD,		/* 33h Get data from a specified device on the DIMM.*/
+	HSMP_READ_CCD_POWER,		/* 34h Get the average power consumed by CCD */
+	HSMP_READ_TDELTA,		/* 35h Get thermal solution behaviour */
+	HSMP_GET_SVI3_VR_CTRL_TEMP,	/* 36h Get temperature of SVI3 VR controlller rails */
+	HSMP_GET_ENABLED_HSMP_CMDS,	/* 37h Get/Set supported HSMP commands */
+	HSMP_SET_GET_FLOOR_LIMIT,       /* 38h Get/Set supported Floor Limit commands */
+	HSMP_DIMM_SB_WR,                /* 39h Set data to a specified device on the DIMM.*/
+	HSMP_SDPS_LIMIT,                /* 3Ah Get/Set SDPSLimit. */
+	HSMP_MSG_ID_MAX,
 };
 
 struct hsmp_message {
-    __u32    msg_id;                /* Message ID */
-    __u16    num_args;              /* Number of input argument words in message */
-    __u16    response_sz;           /* Number of expected output/response words */
-    __u32    args[HSMP_MAX_MSG_LEN];/* argument/response buffer */
-    __u16    sock_ind;              /* socket number */
+	__u32	msg_id;			/* Message ID */
+	__u16	num_args;		/* Number of input argument words in message */
+	__u16	response_sz;		/* Number of expected output/response words */
+	__u32	args[HSMP_MAX_MSG_LEN];	/* argument/response buffer */
+	__u16	sock_ind;		/* socket number */
 };
 
 enum hsmp_msg_type {
-    HSMP_RSVD    = -1,
-    HSMP_SET     = 0,
-    HSMP_GET     = 1,
-    HSMP_SET_GET = 2,
+	HSMP_RSVD	= -1,
+	HSMP_SET	= 0,
+	HSMP_GET	= 1,
+	HSMP_SET_GET 	= 2,
 };
 
 enum hsmp_proto_versions {
-    HSMP_PROTO_VER2 = 2,
-    HSMP_PROTO_VER3,
-    HSMP_PROTO_VER4,
-    HSMP_PROTO_VER5,
-    HSMP_PROTO_VER6,
-    HSMP_PROTO_VER7
+	HSMP_PROTO_VER2	= 2,
+	HSMP_PROTO_VER3,
+	HSMP_PROTO_VER4,
+	HSMP_PROTO_VER5,
+	HSMP_PROTO_VER6,
+	HSMP_PROTO_VER7
 };
 
 struct hsmp_msg_desc {
-    int num_args;
-    int response_sz;
-    enum hsmp_msg_type type;
+	int num_args;
+	int response_sz;
+	enum hsmp_msg_type type;
 };
 
 /*
@@ -97,380 +107,488 @@ struct hsmp_msg_desc {
  * Not supported messages would return -ENOMSG.
  */
 static const struct hsmp_msg_desc hsmp_msg_desc_table[] = {
-    /* RESERVED */
-    {0, 0, HSMP_RSVD},
+	/* RESERVED */
+	{0, 0, HSMP_RSVD},
 
-    /*
-     * HSMP_TEST, num_args = 1, response_sz = 1
-     * input:  args[0] = xx
-     * output: args[0] = xx + 1
-     */
-    {1, 1, HSMP_GET},
+	/*
+	 * HSMP_TEST, num_args = 1, response_sz = 1
+	 * input:  args[0] = xx
+	 * output: args[0] = xx + 1
+	 */
+	{1, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_SMU_VER, num_args = 0, response_sz = 1
-     * output: args[0] = smu fw ver
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_SMU_VER, num_args = 0, response_sz = 1
+	 * output: args[0] = smu fw ver
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_PROTO_VER, num_args = 0, response_sz = 1
-     * output: args[0] = proto version
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_PROTO_VER, num_args = 0, response_sz = 1
+	 * output: args[0] = proto version
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_SOCKET_POWER, num_args = 0, response_sz = 1
-     * output: args[0] = socket power in mWatts
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_SOCKET_POWER, num_args = 0, response_sz = 1
+	 * output: args[0] = socket power in mWatts
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_SET_SOCKET_POWER_LIMIT, num_args = 1, response_sz = 0
-     * input: args[0] = power limit value in mWatts
-     */
-    {1, 0, HSMP_SET},
+	/*
+	 * HSMP_SET_SOCKET_POWER_LIMIT, num_args = 1, response_sz = 0
+	 * input: args[0] = power limit value in mWatts
+	 */
+	{1, 0, HSMP_SET},
 
-    /*
-     * HSMP_GET_SOCKET_POWER_LIMIT, num_args = 0, response_sz = 1
-     * output: args[0] = socket power limit value in mWatts
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_SOCKET_POWER_LIMIT, num_args = 0, response_sz = 1
+	 * output: args[0] = socket power limit value in mWatts
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_SOCKET_POWER_LIMIT_MAX, num_args = 0, response_sz = 1
-     * output: args[0] = maximuam socket power limit in mWatts
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_SOCKET_POWER_LIMIT_MAX, num_args = 0, response_sz = 1
+	 * output: args[0] = maximuam socket power limit in mWatts
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_SET_BOOST_LIMIT, num_args = 1, response_sz = 0
-     * input: args[0] = apic id[31:16] + boost limit value in MHz[15:0]
-     */
-    {1, 0, HSMP_SET},
+	/*
+	 * HSMP_SET_BOOST_LIMIT, num_args = 1, response_sz = 0
+	 * input: args[0] = apic id[31:16] + boost limit value in MHz[15:0]
+	 */
+	{1, 0, HSMP_SET},
 
-    /*
-     * HSMP_SET_BOOST_LIMIT_SOCKET, num_args = 1, response_sz = 0
-     * input: args[0] = boost limit value in MHz
-     */
-    {1, 0, HSMP_SET},
+	/*
+	 * HSMP_SET_BOOST_LIMIT_SOCKET, num_args = 1, response_sz = 0
+	 * input: args[0] = boost limit value in MHz
+	 */
+	{1, 0, HSMP_SET},
 
-    /*
-     * HSMP_GET_BOOST_LIMIT, num_args = 1, response_sz = 1
-     * input: args[0] = apic id
-     * output: args[0] = boost limit value in MHz
-     */
-    {1, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_BOOST_LIMIT, num_args = 1, response_sz = 1
+	 * input: args[0] = apic id
+	 * output: args[0] = boost limit value in MHz
+	 */
+	{1, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_PROC_HOT, num_args = 0, response_sz = 1
-     * output: args[0] = proc hot status
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_PROC_HOT, num_args = 0, response_sz = 1
+	 * output: args[0] = proc hot status
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_SET_XGMI_LINK_WIDTH, num_args = 1, response_sz = 0
-     * input: args[0] = min link width[15:8] + max link width[7:0]
-     */
-    {1, 0, HSMP_SET},
+	/*
+	 * HSMP_SET_XGMI_LINK_WIDTH, num_args = 1, response_sz = 0/1
+	 * input: args[0] = set/get XGMI Link width[31] + min link width[15:8] + max link width[7:0]
+	 * output: args[0] = current min link width[15:8] + current max link width[7:0]
+	 */
+	{1, 1, HSMP_SET_GET},
 
-    /*
-     * HSMP_SET_DF_PSTATE, num_args = 1, response_sz = 0
-     * input: args[0] = df pstate[7:0]
-     */
-    {1, 0, HSMP_SET},
+	/*
+	 * HSMP_SET_DF_PSTATE, num_args = 1, response_sz = 0/1
+	 * input: args[0] = set/get df pstate[31] + df pstate[7:0]
+	* output: args[0] = APB Enabled/Disabled[8]+current df pstate[7:0]
+	 */
+	{1, 1, HSMP_SET_GET},
 
-    /* HSMP_SET_AUTO_DF_PSTATE, num_args = 0, response_sz = 0 */
-    {0, 0, HSMP_SET},
+	/* HSMP_SET_AUTO_DF_PSTATE, num_args = 0, response_sz = 0 */
+	{0, 0, HSMP_SET},
 
-    /*
-     * HSMP_GET_FCLK_MCLK, num_args = 0, response_sz = 2
-     * output: args[0] = fclk in MHz, args[1] = mclk in MHz
-     */
-    {0, 2, HSMP_GET},
+	/*
+	 * HSMP_GET_FCLK_MCLK, num_args = 0, response_sz = 2
+	 * output: args[0] = fclk in MHz, args[1] = mclk in MHz
+	 */
+	{0, 2, HSMP_GET},
 
-    /*
-     * HSMP_GET_CCLK_THROTTLE_LIMIT, num_args = 0, response_sz = 1
-     * output: args[0] = core clock in MHz
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_CCLK_THROTTLE_LIMIT, num_args = 0, response_sz = 1
+	 * output: args[0] = core clock in MHz
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_C0_PERCENT, num_args = 0, response_sz = 1
-     * output: args[0] = average c0 residency
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_C0_PERCENT, num_args = 0, response_sz = 1
+	 * output: args[0] = average c0 residency
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_SET_NBIO_DPM_LEVEL, num_args = 1, response_sz = 0
-     * input: args[0] = nbioid[23:16] + max dpm level[15:8] + min dpm level[7:0]
-     */
-    {1, 0, HSMP_SET},
+	/*
+	 * HSMP_SET_NBIO_DPM_LEVEL, num_args = 1, response_sz = 0
+	 * input: args[0] = nbioid[23:16] + max dpm level[15:8] + min dpm level[7:0]
+	 */
+	{1, 0, HSMP_SET},
 
-    /*
-     * HSMP_GET_NBIO_DPM_LEVEL, num_args = 1, response_sz = 1
-     * input: args[0] = nbioid[23:16]
-     * output: args[0] = max dpm level[15:8] + min dpm level[7:0]
-     */
-    {1, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_NBIO_DPM_LEVEL, num_args = 1, response_sz = 1
+	 * input: args[0] = nbioid[23:16]
+	 * output: args[0] = max dpm level[15:8] + min dpm level[7:0]
+	 */
+	{1, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_DDR_BANDWIDTH, num_args = 0, response_sz = 1
-     * output: args[0] = max bw in Gbps[31:20] + utilised bw in Gbps[19:8] +
-     * bw in percentage[7:0]
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_DDR_BANDWIDTH, num_args = 0, response_sz = 1
+	 * output: args[0] = max bw in Gbps[31:20] + utilised bw in Gbps[19:8] +
+	 * bw in percentage[7:0]
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_TEMP_MONITOR, num_args = 0, response_sz = 1
-     * output: args[0] = temperature in degree celsius. [15:8] integer part +
-     * [7:5] fractional part
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_TEMP_MONITOR, num_args = 0, response_sz = 1
+	 * output: args[0] = temperature in degree celsius. [15:8] integer part +
+	 * [7:5] fractional part
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_DIMM_TEMP_RANGE, num_args = 1, response_sz = 1
-     * input: args[0] = DIMM address[7:0]
-     * output: args[0] = refresh rate[3] + temperature range[2:0]
-     */
-    {1, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_DIMM_TEMP_RANGE, num_args = 1, response_sz = 1
+	 * input: args[0] = DIMM address[7:0]
+	 * output: args[0] = refresh rate[3] + temperature range[2:0]
+	 */
+	{1, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_DIMM_POWER, num_args = 1, response_sz = 1
-     * input: args[0] = DIMM address[7:0]
-     * output: args[0] = DIMM power in mW[31:17] + update rate in ms[16:8] +
-     * DIMM address[7:0]
-     */
-    {1, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_DIMM_POWER, num_args = 1, response_sz = 1
+	 * input: args[0] = DIMM address[7:0]
+	 * output: args[0] = DIMM power in mW[31:17] + update rate in ms[16:8] +
+	 * DIMM address[7:0]
+	 */
+	{1, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_DIMM_THERMAL, num_args = 1, response_sz = 1
-     * input: args[0] = DIMM address[7:0]
-     * output: args[0] = temperature in degree celsius[31:21] + update rate in ms[16:8] +
-     * DIMM address[7:0]
-     */
-    {1, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_DIMM_THERMAL, num_args = 1, response_sz = 1
+	 * input: args[0] = DIMM address[7:0]
+	 * output: args[0] = temperature in degree celcius[31:21] + update rate in ms[16:8] +
+	 * DIMM address[7:0]
+	 */
+	{1, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_SOCKET_FREQ_LIMIT, num_args = 0, response_sz = 1
-     * output: args[0] = frequency in MHz[31:16] + frequency source[15:0]
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_SOCKET_FREQ_LIMIT, num_args = 0, response_sz = 1
+	 * output: args[0] = frequency in MHz[31:16] + frequency source[15:0]
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_CCLK_CORE_LIMIT, num_args = 1, response_sz = 1
-     * input: args[0] = apic id of the core[31:0]
-     * output: args[0] = frequency in MHz[31:0]
-     */
-    {1, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_CCLK_CORE_LIMIT, num_args = 1, response_sz = 1
+	 * input: args[0] = apic id of the core[31:0]
+	 * output: args[0] = frequency in MHz[31:0]
+	 */
+	{1, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_RAILS_SVI, num_args = 0, response_sz = 1
-     * output: args[0] = power in mW[31:0]
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_RAILS_SVI, num_args = 0, response_sz = 1
+	 * output: args[0] = power in mW[31:0]
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_SOCKET_FMAX_FMIN, num_args = 0, response_sz = 1
-     * output: args[0] = fmax in MHz[31:16] + fmin in MHz[15:0]
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_SOCKET_FMAX_FMIN, num_args = 0, response_sz = 1
+	 * output: args[0] = fmax in MHz[31:16] + fmin in MHz[15:0]
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_IOLINK_BANDWITH, num_args = 1, response_sz = 1
-     * input: args[0] = link id[15:8] + bw type[2:0]
-     * output: args[0] = io bandwidth in Mbps[31:0]
-     */
-    {1, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_IOLINK_BANDWITH, num_args = 1, response_sz = 1
+	 * input: args[0] = link id[15:8] + bw type[2:0]
+	 * output: args[0] = io bandwidth in Mbps[31:0]
+	 */
+	{1, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_XGMI_BANDWITH, num_args = 1, response_sz = 1
-     * input: args[0] = link id[15:8] + bw type[2:0]
-     * output: args[0] = xgmi bandwidth in Mbps[31:0]
-     */
-    {1, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_XGMI_BANDWITH, num_args = 1, response_sz = 1
+	 * input: args[0] = link id[15:8] + bw type[2:0]
+	 * output: args[0] = xgmi bandwidth in Mbps[31:0]
+	 */
+	{1, 1, HSMP_GET},
 
-    /*
-     * HSMP_SET_GMI3_WIDTH, num_args = 1, response_sz = 0
-     * input: args[0] = min link width[15:8] + max link width[7:0]
-     */
-    {1, 0, HSMP_SET},
+	/*
+	 * HSMP_SET_GMI3_WIDTH, num_args = 1, response_sz = 0
+	 * input: args[0] = min link width[15:8] + max link width[7:0]
+	 */
+	{1, 0, HSMP_SET},
 
-    /*
-     * HSMP_SET_PCI_RATE, num_args = 1, response_sz = 1
-     * input: args[0] = link rate control value
-     * output: args[0] = previous link rate control value
-     */
-    {1, 1, HSMP_SET},
+	/*
+	 * HSMP_SET_PCI_RATE, num_args = 1, response_sz = 1
+	 * input: args[0] = link rate control value
+	 * output: args[0] = previous link rate control value
+	 */
+	{1, 1, HSMP_SET},
 
-    /*
-     * HSMP_SET_POWER_MODE, num_args = 1, response_sz = 0/1
-     * input: args[0] = set/get power mode[31] + power efficiency mode[2:0]
-     * output: args[0] = current power efficiency mode[2:0]
-     */
-    {1, 1, HSMP_SET_GET},
+	/*
+	 * HSMP_SET_POWER_MODE, num_args = 1, response_sz = 0/1
+	 * input: args[0] = set/get power mode[31] + power efficiency mode[2:0]
+	 * output: args[0] = current power efficiency mode[2:0]
+	 */
+	{1, 1, HSMP_SET_GET},
 
-    /*
-     * HSMP_SET_PSTATE_MAX_MIN, num_args = 1, response_sz = 0
-     * input: args[0] = min df pstate[15:8] + max df pstate[7:0]
-     */
-    {1, 0, HSMP_SET},
+	/*
+	 * HSMP_SET_PSTATE_MAX_MIN, num_args = 1, response_sz = 0/1
+	 * input: args[0] = set/get power mode[31] + min df pstate[15:8] + max df pstate[7:0]
+	* output: args[0] = min df pstate[15:8] + max df pstate[7:0]
+	 */
+	{1, 1, HSMP_SET_GET},
 
-    /*
-     * HSMP_GET_METRIC_TABLE_VER, num_args = 0, response_sz = 1
-     * output: args[0] = metrics table version
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_GET_METRIC_TABLE_VER, num_args = 0, response_sz = 1
+	 * output: args[0] = metrics table version
+	 */
+	{0, 1, HSMP_GET},
 
-    /*
-     * HSMP_GET_METRIC_TABLE, num_args = 0, response_sz = 0
-     */
-    {0, 0, HSMP_GET},
+	/*
+	 * HSMP_GET_METRIC_TABLE, num_args = 0, response_sz = 0
+	 */
+	{0, 0, HSMP_GET},
 
-    /*
-     * HSMP_GET_METRIC_TABLE_DRAM_ADDR, num_args = 0, response_sz = 2
-     * output: args[0] = lower 32 bits of the address
-     * output: args[1] = upper 32 bits of the address
-     */
-    {0, 2, HSMP_GET},
+	/*
+	 * HSMP_GET_METRIC_TABLE_DRAM_ADDR, num_args = 0, response_sz = 2
+	 * output: args[0] = lower 32 bits of the address
+	 * output: args[1] = upper 32 bits of the address
+	 */
+	{0, 2, HSMP_GET},
 
-    /*
-     * HSMP_SET_XGMI_PSTATE_RANGE, num_args = 1, response_sz = 0
-     * input: args[0] = min xGMI p-state[15:8] + max xGMI state[7:0]
-     */
-    {1, 0, HSMP_SET},
+	/*
+	 * HSMP_SET_XGMI_PSTATE_RANGE, num_args = 1, response_sz = 0/1
+	 * input: args[0] = set/get XGMI pstate range[31] + min xGMI p-state[15:8] + max xGMI state[7:0]
+	* output: args[0] = min xGMI p-state[15:8] + max xGMI state[7:0]
+	 */
+	{1, 1, HSMP_SET_GET},
 
-    /*
-     * HSMP_CPU_RAIL_ISO_FREQ_POLICY, num_args = 1, response_sz = 1
-     * input: args[0] = set/get policy[31] +
-     * disable/enable independent control[0]
-     * output: args[0] = current policy[0]
-     */
-    {1, 1, HSMP_SET_GET},
+	/*
+	 * HSMP_CPU_RAIL_ISO_FREQ_POLICY, num_args = 1, response_sz = 1
+	 * input: args[0] = set/get policy[31] +
+	 * disable/enable independent control[0]
+	 * output: args[0] = current policy[0]
+	 */
+	{1, 1, HSMP_SET_GET},
 
-    /*
-     * HSMP_DFC_ENABLE_CTRL, num_args = 1, response_sz = 1
-     * input: args[0] = set/get policy[31] + enable/disable DFC[0]
-     * output: args[0] = current policy[0]
-     */
-    {1, 1, HSMP_SET_GET},
+	/*
+	 * HSMP_DFC_ENABLE_CTRL, num_args = 1, response_sz = 1
+	 * input: args[0] = set/get policy[31] + enable/disable DFC[0]
+	 * output: args[0] = current policy[0]
+	 */
+	{1, 1, HSMP_SET_GET},
 
-    /* RESERVED(0x29-0x2f) */
-    {0, 0, HSMP_RSVD},
-    {0, 0, HSMP_RSVD},
-    {0, 0, HSMP_RSVD},
-    {0, 0, HSMP_RSVD},
-    {0, 0, HSMP_RSVD},
-    {0, 0, HSMP_RSVD},
-    {0, 0, HSMP_RSVD},
+	/*
+	 * HSMP_PC6_REQUEST, num_args = 1, response_sz = 0/1
+	 * input: args[0] = set/get PC6 control[31] + disable/enable PC6[0]
+	 * output: args[0] = current PC6 control status[0]
+	 */
+	{1, 1, HSMP_SET_GET},
 
-    /*
-     * HSMP_GET_RAPL_UNITS, response_sz = 1
-     * output: args[0] = tu value[19:16] + esu value[12:8]
-     */
-    {0, 1, HSMP_GET},
+	/*
+	 * HSMP_CC6_REQUEST, num_args = 1, response_sz = 0/1
+	 * input: args[0] = set/get CC6 control[31] + disable/enable CC6[0]
+	 * output: args[0] = current CC6 control status[0]
+	 */
+	{1, 1, HSMP_SET_GET},
 
-    /*
-     * HSMP_GET_RAPL_CORE_COUNTER, num_args = 1, response_sz = 1
-     * input: args[0] = Apic id[15:0]
-     * output: args[0] = lower 32 bits of energy
-     * output: args[1] = upper 32 bits of energy
-     */
-    {1, 2, HSMP_GET},
+	/* RESERVED(0x2B-0x2F) */
+	{0, 0, HSMP_RSVD},
+	{0, 0, HSMP_RSVD},
+	{0, 0, HSMP_RSVD},
+	{0, 0, HSMP_RSVD},
+	{0, 0, HSMP_RSVD},
 
-    /*
-     * HSMP_GET_RAPL_PACKAGE_COUNTER, num_args = 0, response_sz = 1
-     * output: args[0] = lower 32 bits of energy
-     * output: args[1] = upper 32 bits of energy
-     */
-    {0, 2, HSMP_GET},
+	/*
+	 * HSMP_GET_RAPL_UNITS, response_sz = 1
+	 * output: args[0] = tu value[19:16] + esu value[12:8]
+	 */
+	{0, 1, HSMP_GET},
+
+	/*
+	 * HSMP_GET_RAPL_CORE_COUNTER, num_args = 1, response_sz = 1
+	 * input: args[0] = Apic id[15:0]
+	 * output: args[0] = lower 32 bits of energy
+	 * output: args[1] = upper 32 bits of energy
+	 */
+	{1, 2, HSMP_GET},
+
+	/*
+	 * HSMP_GET_RAPL_PACKAGE_COUNTER, num_args = 0, response_sz = 1
+	 * output: args[0] = lower 32 bits of energy
+	 * output: args[1] = upper 32 bits of energy
+	 */
+	{0, 2, HSMP_GET},
+
+	/*
+	 * HSMP_DIMM_SB_RD, num_args = 1, response_sz = 1
+	 * input: args[0] =
+	 * 		     [07:00] DIMM address
+	 * 		     [11:08] LID of device
+	 * 		     [22:12] Register offset in given reg space
+	 * 		     [23]    Register space
+	 * output: args[0] = [03:00] Read data byte
+	 */
+	{1, 1, HSMP_GET},
+
+	/*
+	 * HSMP_READ_CCD_POWER, num_args = 1, response_sz = 1
+	 * input: args[0] = [15:00] ApicId of core
+	 * output: args[0] = [31:00] CCD power(mWatts)
+	 */
+	{1, 1, HSMP_GET},
+
+	/*
+	 * HSMP_READ_TDELTA, num_args = 0, response_sz = 1
+	 * input: None
+	 * output: args[0] = [31:00] Thermal Behaviour
+	 */
+	{0, 1, HSMP_GET},
+
+	/*
+	 * HSMP_GET_SVI3_VR_CTRL_TEMP, num_args = 1, response_sz = 1
+	 * input: args[0] =
+	 * 		     [00] Read SVI3 temperature data
+	 * 		     [03:01] SVI3 rail index
+	 * output: args[0] =
+	 * 		     [30:28] SVI3 rail index
+	 * 		     [27:00] SVI3 rail temperature(degree C)
+	 */
+	{1, 1, HSMP_GET},
+
+	/*
+	 * HSMP_GET_ENABLED_HSMP_CMDS, num_args = 1, response_sz = 3
+	 * input: args[0] = [00] HSMP command mask
+	 * output: args[0], args[1], args[2] = status of HSMP command
+	 */
+	{1, 3, HSMP_GET},
+
+	/*
+	 * HSMP_SET_GET_FLOOR_LIMIT, num_args = 1, response_sz = 1
+	 * input: args[0] =
+	 *                  [31:30]=Set or Get:
+	 *                     00=Set the Floor frequency per core.
+	 *                     01=Set the Floor frequency for all cores.
+	 *                     10=Get the Floor frequency of a core.
+	 * 	               11=Get the Effective Floor frequency per core.
+	 *                  [29:28]=Reserved.
+	 *                  [27:16]=ApicId.
+	 *                 Note: DataIn[27:16] are Reserved if DataIn[31:30]==01.
+	 *
+	 *                 If DataIn[31]=0
+	 *                  [15:0]=Floor frequency limit.
+	 *                 Else
+	 *                  [15:0]=Reserved.
+	 *
+	 * output: args[0] =
+	 *                 If DataIn[31:30]=11
+	 *                  [15:0]=Effective Floor frequency limit(MHz).
+	 *                 Else
+	 *                  [15:0]=Floor frequency limit (MHz).
+	 *                 The output will be None if DataIn[31]=0.
+	 */
+	 {1, 1, HSMP_SET_GET},
+
+	/*
+	 * HSMP_DIMM_SB_WR, num_args = 1, response_sz = 0
+	 * input: args[0] =
+	 *                   [07:00] DIMM address
+	 *                   [11:08] LID of device
+	 *                   [22:12] Register offset in given reg space
+	 *                   [23]    Register space
+	 *                   [31:24] Write Data
+	 * output: None
+	 */
+	{1, 0, HSMP_SET},
+
+	/*
+	 * HSMP_SDPS_LIMIT, num_args = 1, response_sz = 1
+	 * input: args[0] =
+	 *                   [30:00] SDPS Limit
+	 *                   [31] Set/Get
+	 * output: args[0] =
+	 *                   [30:00] SDPS Limit
+	 */
+	{1, 1, HSMP_SET_GET},
 };
 
 /* Metrics table (supported only with proto version 6) */
 struct hsmp_metric_table {
-    __u32 accumulation_counter;
+	__u32 accumulation_counter;
 
-    /* TEMPERATURE */
-    __u32 max_socket_temperature;
-    __u32 max_vr_temperature;
-    __u32 max_hbm_temperature;
-    __u64 max_socket_temperature_acc;
-    __u64 max_vr_temperature_acc;
-    __u64 max_hbm_temperature_acc;
+	/* TEMPERATURE */
+	__u32 max_socket_temperature;
+	__u32 max_vr_temperature;
+	__u32 max_hbm_temperature;
+	__u64 max_socket_temperature_acc;
+	__u64 max_vr_temperature_acc;
+	__u64 max_hbm_temperature_acc;
 
-    /* POWER */
-    __u32 socket_power_limit;
-    __u32 max_socket_power_limit;
-    __u32 socket_power;
+	/* POWER */
+	__u32 socket_power_limit;
+	__u32 max_socket_power_limit;
+	__u32 socket_power;
 
-    /* ENERGY */
-    __u64 timestamp;
-    __u64 socket_energy_acc;
-    __u64 ccd_energy_acc;
-    __u64 xcd_energy_acc;
-    __u64 aid_energy_acc;
-    __u64 hbm_energy_acc;
+	/* ENERGY */
+	__u64 timestamp;
+	__u64 socket_energy_acc;
+	__u64 ccd_energy_acc;
+	__u64 xcd_energy_acc;
+	__u64 aid_energy_acc;
+	__u64 hbm_energy_acc;
 
-    /* FREQUENCY */
-    __u32 cclk_frequency_limit;
-    __u32 gfxclk_frequency_limit;
-    __u32 fclk_frequency;
-    __u32 uclk_frequency;
-    __u32 socclk_frequency[4];
-    __u32 vclk_frequency[4];
-    __u32 dclk_frequency[4];
-    __u32 lclk_frequency[4];
-    __u64 gfxclk_frequency_acc[8];
-    __u64 cclk_frequency_acc[96];
+	/* FREQUENCY */
+	__u32 cclk_frequency_limit;
+	__u32 gfxclk_frequency_limit;
+	__u32 fclk_frequency;
+	__u32 uclk_frequency;
+	__u32 socclk_frequency[4];
+	__u32 vclk_frequency[4];
+	__u32 dclk_frequency[4];
+	__u32 lclk_frequency[4];
+	__u64 gfxclk_frequency_acc[8];
+	__u64 cclk_frequency_acc[96];
 
-    /* FREQUENCY RANGE */
-    __u32 max_cclk_frequency;
-    __u32 min_cclk_frequency;
-    __u32 max_gfxclk_frequency;
-    __u32 min_gfxclk_frequency;
-    __u32 fclk_frequency_table[4];
-    __u32 uclk_frequency_table[4];
-    __u32 socclk_frequency_table[4];
-    __u32 vclk_frequency_table[4];
-    __u32 dclk_frequency_table[4];
-    __u32 lclk_frequency_table[4];
-    __u32 max_lclk_dpm_range;
-    __u32 min_lclk_dpm_range;
+	/* FREQUENCY RANGE */
+	__u32 max_cclk_frequency;
+	__u32 min_cclk_frequency;
+	__u32 max_gfxclk_frequency;
+	__u32 min_gfxclk_frequency;
+	__u32 fclk_frequency_table[4];
+	__u32 uclk_frequency_table[4];
+	__u32 socclk_frequency_table[4];
+	__u32 vclk_frequency_table[4];
+	__u32 dclk_frequency_table[4];
+	__u32 lclk_frequency_table[4];
+	__u32 max_lclk_dpm_range;
+	__u32 min_lclk_dpm_range;
 
-    /* XGMI */
-    __u32 xgmi_width;
-    __u32 xgmi_bitrate;
-    __u64 xgmi_read_bandwidth_acc[8];
-    __u64 xgmi_write_bandwidth_acc[8];
+	/* XGMI */
+	__u32 xgmi_width;
+	__u32 xgmi_bitrate;
+	__u64 xgmi_read_bandwidth_acc[8];
+	__u64 xgmi_write_bandwidth_acc[8];
 
-    /* ACTIVITY */
-    __u32 socket_c0_residency;
-    __u32 socket_gfx_busy;
-    __u32 dram_bandwidth_utilization;
-    __u64 socket_c0_residency_acc;
-    __u64 socket_gfx_busy_acc;
-    __u64 dram_bandwidth_acc;
-    __u32 max_dram_bandwidth;
-    __u64 dram_bandwidth_utilization_acc;
-    __u64 pcie_bandwidth_acc[4];
+	/* ACTIVITY */
+	__u32 socket_c0_residency;
+	__u32 socket_gfx_busy;
+	__u32 dram_bandwidth_utilization;
+	__u64 socket_c0_residency_acc;
+	__u64 socket_gfx_busy_acc;
+	__u64 dram_bandwidth_acc;
+	__u32 max_dram_bandwidth;
+	__u64 dram_bandwidth_utilization_acc;
+	__u64 pcie_bandwidth_acc[4];
 
-    /* THROTTLERS */
-    __u32 prochot_residency_acc;
-    __u32 ppt_residency_acc;
-    __u32 socket_thm_residency_acc;
-    __u32 vr_thm_residency_acc;
-    __u32 hbm_thm_residency_acc;
-    __u32 spare;
+	/* THROTTLERS */
+	__u32 prochot_residency_acc;
+	__u32 ppt_residency_acc;
+	__u32 socket_thm_residency_acc;
+	__u32 vr_thm_residency_acc;
+	__u32 hbm_thm_residency_acc;
+	__u32 spare;
 
-    /* New items at the end to maintain driver compatibility */
-    __u32 gfxclk_frequency[8];
+	/* New items at the end to maintain driver compatibility */
+	__u32 gfxclk_frequency[8];
 };
 
 /* Reset to default packing */
 #pragma pack()
 
 /* Define unique ioctl command for hsmp msgs using generic _IOWR */
-#define HSMP_BASE_IOCTL_NR    0xF8
-#define HSMP_IOCTL_CMD        _IOWR(HSMP_BASE_IOCTL_NR, 0, struct hsmp_message)
+#define HSMP_BASE_IOCTL_NR	0xF8
+#define HSMP_IOCTL_CMD		_IOWR(HSMP_BASE_IOCTL_NR, 0, struct hsmp_message)
+int hsmp_send_message(struct hsmp_message *msg);
 
 #endif /*_ASM_X86_AMD_HSMP_H_*/

--- a/projects/amdsmi/py-interface/__init__.py
+++ b/projects/amdsmi/py-interface/__init__.py
@@ -81,10 +81,30 @@ try:
     from .amdsmi_interface import amdsmi_get_cpu_model
     from .amdsmi_interface import amdsmi_get_cpu_model_name
     from .amdsmi_interface import amdsmi_get_cpu_handles
-    from .amdsmi_interface import amdsmi_get_dfc_ctrl
-    from .amdsmi_interface import amdsmi_set_dfc_ctrl
-    from .amdsmi_interface import amdsmi_get_cpu_rail_isofreq_policy
+    from .amdsmi_interface import amdsmi_set_cpu_xgmi_pstate_range
+    from .amdsmi_interface import amdsmi_get_cpu_xgmi_pstate_range
     from .amdsmi_interface import amdsmi_set_cpu_rail_isofreq_policy
+    from .amdsmi_interface import amdsmi_get_cpu_rail_isofreq_policy
+    from .amdsmi_interface import amdsmi_set_dfc_ctrl
+    from .amdsmi_interface import amdsmi_get_dfc_ctrl
+    from .amdsmi_interface import amdsmi_set_cc6_enable
+    from .amdsmi_interface import amdsmi_get_cc6_enable
+    from .amdsmi_interface import amdsmi_set_pc6_enable
+    from .amdsmi_interface import amdsmi_get_pc6_enable
+    from .amdsmi_interface import amdsmi_dimm_sb_reg_read
+    from .amdsmi_interface import amdsmi_dimm_sb_reg_write
+    from .amdsmi_interface import amdsmi_get_ccd_power
+    from .amdsmi_interface import amdsmi_read_tdelta
+    from .amdsmi_interface import amdsmi_get_svi3_vr_controller_temp
+    from .amdsmi_interface import amdsmi_get_enabled_commands
+    from .amdsmi_interface import amdsmi_get_cpu_core_floorlimit
+    from .amdsmi_interface import amdsmi_get_cpu_core_efffloorlimit
+    from .amdsmi_interface import amdsmi_set_cpu_floorlimit
+    from .amdsmi_interface import amdsmi_cpu_msr_floorlimit
+    from .amdsmi_interface import amdsmi_set_cpu_core_floorlimit
+    from .amdsmi_interface import amdsmi_cpu_core_msr_floorlimit
+    from .amdsmi_interface import amdsmi_set_cpu_socket_sdps_limit
+    from .amdsmi_interface import amdsmi_get_cpu_socket_sdps_limit
 except AttributeError:
     pass
 

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -1142,6 +1142,27 @@ def amdsmi_get_cpu_core_energy(
 
     return f"{float(penergy.value * pow(10, -6))} J"
 
+def amdsmi_get_ccd_power(
+    processor_handle: processor_handle_t,
+    ccd_id: int
+) -> int:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    if not isinstance(ccd_id, int) or ccd_id < 0 or ccd_id > 7:
+        raise AmdSmiParameterException(ccd_id, "int (0-7)")
+
+    power = ctypes.c_uint32()
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_ccd_power(
+            processor_handle, ctypes.c_uint32(ccd_id), ctypes.byref(power)
+        )
+    )
+
+    return power.value
+
 def amdsmi_get_cpu_socket_energy(
     processor_handle: processor_handle_t
 ) -> str:
@@ -1377,20 +1398,29 @@ def amdsmi_set_cpu_socket_power_cap(
     )
 
 def amdsmi_set_cpu_pwr_efficiency_mode(
-    processor_handle: processor_handle_t, mode: int
-):
+    processor_handle: processor_handle_t, mode: int, util: int, ppt_limit: int
+) -> tuple:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(
             processor_handle, amdsmi_wrapper.amdsmi_processor_handle
         )
     if not isinstance(mode, int):
         raise AmdSmiParameterException(mode, int)
+    if not isinstance(util, int):
+        raise AmdSmiParameterException(util, int)
+    if not isinstance(ppt_limit, int):
+        raise AmdSmiParameterException(ppt_limit, int)
+
     mode_8 = ctypes.c_uint8(mode)
+    util_32 = ctypes.c_uint32(util)
+    ppt_limit_32 = ctypes.c_uint32(ppt_limit)
 
     _check_res(
         amdsmi_wrapper.amdsmi_set_cpu_pwr_efficiency_mode(
-            processor_handle, mode_8)
+            processor_handle, mode_8, ctypes.byref(util_32), ctypes.byref(ppt_limit_32))
     )
+
+    return (util_32.value, ppt_limit_32.value)
 
 def amdsmi_get_cpu_core_boostlimit(
     processor_handle: processor_handle_t
@@ -1701,23 +1731,23 @@ def amdsmi_set_cpu_pcie_link_rate(
 
 def amdsmi_set_cpu_df_pstate_range(
     processor_handle: processor_handle_t,
-    max_pstate: int, min_pstate: int
+    min_pstate: int, max_pstate: int
 ):
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(
             processor_handle, amdsmi_wrapper.amdsmi_processor_handle
         )
-    if not isinstance(max_pstate, int):
-        raise AmdSmiParameterException(max_pstate, int)
     if not isinstance(min_pstate, int):
         raise AmdSmiParameterException(min_pstate, int)
+    if not isinstance(max_pstate, int):
+        raise AmdSmiParameterException(max_pstate, int)
 
-    max_pstate_8 = ctypes.c_uint8(max_pstate)
     min_pstate_8 = ctypes.c_uint8(min_pstate)
+    max_pstate_8 = ctypes.c_uint8(max_pstate)
 
     _check_res(
         amdsmi_wrapper.amdsmi_set_cpu_df_pstate_range(
-            processor_handle, max_pstate_8, min_pstate_8))
+            processor_handle, min_pstate_8, max_pstate_8))
 
 def amdsmi_get_cpu_current_io_bandwidth(
     processor_handle: processor_handle_t,
@@ -1788,6 +1818,45 @@ def amdsmi_get_hsmp_metrics_table_version(
 
     return metric_tbl_version.value
 
+def amdsmi_set_cpu_xgmi_pstate_range(
+    processor_handle: processor_handle_t,
+    min_pstate: int, max_pstate: int
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(min_pstate, int):
+        raise AmdSmiParameterException(min_pstate, int)
+    if not isinstance(max_pstate, int):
+        raise AmdSmiParameterException(max_pstate, int)
+    min_pstate_8 = ctypes.c_uint8(min_pstate)
+    max_pstate_8 = ctypes.c_uint8(max_pstate)
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_cpu_xgmi_pstate_range(
+            processor_handle, min_pstate_8, max_pstate_8))
+
+def amdsmi_get_cpu_xgmi_pstate_range(
+    processor_handle: processor_handle_t
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    min_pstate = ctypes.c_uint8()
+    max_pstate = ctypes.c_uint8()
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_cpu_xgmi_pstate_range(
+            processor_handle, ctypes.byref(min_pstate), ctypes.byref(max_pstate)
+        )
+    )
+
+    return {
+        "min_pstate": min_pstate.value,
+        "max_pstate": max_pstate.value
+    }
+
 def amdsmi_set_cpu_rail_isofreq_policy(
     processor_handle: processor_handle_t,
     value: int):
@@ -1817,6 +1886,18 @@ def amdsmi_get_cpu_rail_isofreq_policy(
 
     return cpurailiso.value
 
+def amdsmi_set_dfc_ctrl(
+    processor_handle: processor_handle_t,
+    value: int):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_dfc_ctrl(processor_handle, value)
+    )
+
 def amdsmi_get_dfc_ctrl(
     processor_handle: processor_handle_t,
 ) -> int:
@@ -1834,17 +1915,364 @@ def amdsmi_get_dfc_ctrl(
 
     return dfc_ctrl.value
 
-def amdsmi_set_dfc_ctrl(
+def amdsmi_set_pc6_enable(
     processor_handle: processor_handle_t,
     value: int):
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(
             processor_handle, amdsmi_wrapper.amdsmi_processor_handle
         )
+    if not isinstance(value, int):
+        raise AmdSmiParameterException(value, int)
 
     _check_res(
-        amdsmi_wrapper.amdsmi_set_dfc_ctrl(processor_handle, value)
+        amdsmi_wrapper.amdsmi_set_pc6_enable(processor_handle, value)
     )
+
+def amdsmi_get_pc6_enable(
+    processor_handle: processor_handle_t,
+) -> int:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    pc6_enable = ctypes.c_uint8()
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_pc6_enable(
+            processor_handle, ctypes.byref(pc6_enable)
+        )
+    )
+
+    return pc6_enable.value
+
+def amdsmi_set_cc6_enable(
+    processor_handle: processor_handle_t,
+    value: int):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(value, int):
+        raise AmdSmiParameterException(value, int)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_cc6_enable(processor_handle, value)
+    )
+
+def amdsmi_get_cc6_enable(
+    processor_handle: processor_handle_t,
+) -> int:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    cc6_enable = ctypes.c_uint8()
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_cc6_enable(
+            processor_handle, ctypes.byref(cc6_enable)
+        )
+    )
+
+    return cc6_enable.value
+
+def amdsmi_dimm_sb_reg_read(
+    processor_handle: processor_handle_t,
+    dimm_addr: int,
+    lid: int,
+    reg_offset: int,
+    reg_space: int):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(dimm_addr, int):
+        raise AmdSmiParameterException(dimm_addr, int)
+    if not isinstance(lid, int):
+        raise AmdSmiParameterException(lid, int)
+    if not isinstance(reg_offset, int):
+        raise AmdSmiParameterException(reg_offset, int)
+    if not isinstance(reg_space, int):
+        raise AmdSmiParameterException(reg_space, int)
+
+    dimm_addr_64 = ctypes.c_uint64(dimm_addr)
+    lid_64 = ctypes.c_uint64(lid)
+    reg_offset_64 = ctypes.c_uint64(reg_offset)
+    reg_space_64 = ctypes.c_uint64(reg_space)
+    data = ctypes.c_uint32()
+
+    _check_res(amdsmi_wrapper.amdsmi_dimm_sb_reg_read(
+        processor_handle,
+        dimm_addr_64,
+        lid_64,
+        reg_offset_64,
+        reg_space_64,
+        ctypes.byref(data)
+    ))
+
+    return data.value
+
+def amdsmi_dimm_sb_reg_write(
+    processor_handle: processor_handle_t,
+    dimm_addr: int,
+    lid: int,
+    reg_offset: int,
+    reg_space: int,
+    write_data: int):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(dimm_addr, int):
+        raise AmdSmiParameterException(dimm_addr, int)
+    if not isinstance(lid, int):
+        raise AmdSmiParameterException(lid, int)
+    if not isinstance(reg_offset, int):
+        raise AmdSmiParameterException(reg_offset, int)
+    if not isinstance(reg_space, int):
+        raise AmdSmiParameterException(reg_space, int)
+    if not isinstance(write_data, int):
+        raise AmdSmiParameterException(write_data, int)
+
+    dimm_addr_64 = ctypes.c_uint64(dimm_addr)
+    lid_64 = ctypes.c_uint64(lid)
+    reg_offset_64 = ctypes.c_uint64(reg_offset)
+    reg_space_64 = ctypes.c_uint64(reg_space)
+    write_data_64 = ctypes.c_uint64(write_data)
+
+    _check_res(amdsmi_wrapper.amdsmi_dimm_sb_reg_write(
+        processor_handle,
+        dimm_addr_64,
+        lid_64,
+        reg_offset_64,
+        reg_space_64,
+        write_data_64
+    ))
+
+    # Write operations typically dont return data, just success/failure
+    return True
+
+def amdsmi_read_tdelta(
+    processor_handle: processor_handle_t,
+) -> int:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    tdelta = ctypes.c_uint8()
+    _check_res(
+        amdsmi_wrapper.amdsmi_read_tdelta(
+            processor_handle, ctypes.byref(tdelta)
+        )
+    )
+
+    return tdelta.value
+
+def amdsmi_get_svi3_vr_controller_temp(
+    processor_handle: processor_handle_t,
+    rail_selection: int,
+    rail_index: int = 0
+) -> dict:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(rail_selection, int) or rail_selection not in [0, 1]:
+        raise AmdSmiParameterException(rail_selection, "int (0 or 1)")
+    if rail_selection == 1 and (not isinstance(rail_index, int) or rail_index < 0 or rail_index > 7):
+        raise AmdSmiParameterException(rail_index, "int (0-7)")
+
+    vr_temp = amdsmi_wrapper.struct_amdsmi_svi3_vr_controller_temp_t()
+    vr_temp.rail_selection = rail_selection
+    vr_temp.rail_index = rail_index if rail_selection == 1 else 0
+    vr_temp.temperature = 0
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_svi3_vr_controller_temp(
+            processor_handle, ctypes.byref(vr_temp)
+        )
+    )
+
+    return {
+        "rail_selection": vr_temp.rail_selection,
+        "rail_index": vr_temp.rail_index,
+        "temperature": vr_temp.temperature
+    }
+
+def amdsmi_get_enabled_commands(
+    processor_handle: processor_handle_t
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    enabled_cmds = amdsmi_wrapper.amdsmi_hsmp_enabled_commands_t()
+
+    # First call for read commands
+    enabled_cmds.read_mask = True
+    _check_res(amdsmi_wrapper.amdsmi_get_enabled_commands(
+        processor_handle, enabled_cmds))
+    read_mask0 = enabled_cmds.arg0
+    read_mask1 = enabled_cmds.arg1
+    read_mask2 = enabled_cmds.arg2
+
+    # Second call for write commands
+    enabled_cmds.read_mask = False
+    _check_res(amdsmi_wrapper.amdsmi_get_enabled_commands(
+        processor_handle, enabled_cmds))
+    write_mask0 = enabled_cmds.arg0
+    write_mask1 = enabled_cmds.arg1
+    write_mask2 = enabled_cmds.arg2
+
+    return {
+        "ReadEnabledCommandsBitMask0": read_mask0,
+        "ReadEnabledCommandsBitMask1": read_mask1,
+        "ReadEnabledCommandsBitMask2": read_mask2,
+        "WriteEnabledCommandsBitMask0": write_mask0,
+        "WriteEnabledCommandsBitMask1": write_mask1,
+        "WriteEnabledCommandsBitMask2": write_mask2,
+    }
+
+def amdsmi_get_cpu_core_floorlimit(
+   processor_handle: processor_handle_t
+) -> int:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    floorlimit = ctypes.c_uint32()
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_cpu_core_floorlimit(
+            processor_handle, ctypes.byref(floorlimit)
+        )
+    )
+
+    # In MHz
+    return floorlimit.value
+
+def amdsmi_get_cpu_core_efffloorlimit(
+    processor_handle: processor_handle_t
+) -> int:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    efffloorlimit = ctypes.c_uint32()
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_cpu_core_efffloorlimit(
+            processor_handle, ctypes.byref(efffloorlimit)
+        )
+    )
+
+    # In MHz
+    return efffloorlimit.value
+
+def amdsmi_set_cpu_core_floorlimit(
+    processor_handle: processor_handle_t, floorlimit: int
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(floorlimit, int):
+        raise AmdSmiParameterException(floorlimit, int)
+
+    floorlimit_32 = ctypes.c_uint32(floorlimit)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_cpu_core_floorlimit(
+            processor_handle, floorlimit_32)
+    )
+
+def amdsmi_set_cpu_floorlimit(
+    processor_handle: processor_handle_t, floorlimit: int
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(floorlimit, int):
+        raise AmdSmiParameterException(floorlimit, int)
+
+    floorlimit_32 = ctypes.c_uint32(floorlimit)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_cpu_floorlimit(
+            processor_handle, floorlimit_32)
+    )
+
+def amdsmi_cpu_msr_floorlimit(
+    processor_handle: processor_handle_t, msrfloorlimit: int
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(msrfloorlimit, int):
+        raise AmdSmiParameterException(msrfloorlimit, int)
+
+    msrfloorlimit_32 = ctypes.c_uint32(msrfloorlimit)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_cpu_msr_floorlimit(
+            processor_handle, msrfloorlimit_32)
+    )
+
+def amdsmi_cpu_core_msr_floorlimit(
+    processor_handle: processor_handle_t, msrfloorlimit: int
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(msrfloorlimit, int):
+        raise AmdSmiParameterException(msrfloorlimit, int)
+
+    msrfloorlimit_32 = ctypes.c_uint32(msrfloorlimit)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_cpu_core_msr_floorlimit(
+            processor_handle, msrfloorlimit_32)
+    )
+
+def amdsmi_set_cpu_socket_sdps_limit(
+    processor_handle: processor_handle_t, sdps_limit: int
+):
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+    if not isinstance(sdps_limit, int):
+        raise AmdSmiParameterException(sdps_limit, int)
+
+    sdps_limit_32 = ctypes.c_uint32(sdps_limit)
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_set_cpu_socket_sdps_limit(
+            processor_handle, sdps_limit_32)
+    )
+
+def amdsmi_get_cpu_socket_sdps_limit(
+    processor_handle: processor_handle_t
+) -> str:
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(
+            processor_handle, amdsmi_wrapper.amdsmi_processor_handle
+        )
+
+    sdps_limit = ctypes.c_uint32()
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_cpu_socket_sdps_limit(
+            processor_handle, ctypes.byref(sdps_limit)
+        )
+    )
+
+    return f"{sdps_limit.value}"
 
 # Get 2's complement of 32 bit unsigned integer
 def check_msb_32(num):

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -2407,6 +2407,35 @@ struct_amdsmi_temp_range_refresh_rate_t._fields_ = [
 ]
 
 amdsmi_temp_range_refresh_rate_t = struct_amdsmi_temp_range_refresh_rate_t
+
+class struct_amdsmi_svi3_vr_controller_temp_t(Structure):
+    pass
+
+struct_amdsmi_svi3_vr_controller_temp_t._pack_ = 1 # source:False
+struct_amdsmi_svi3_vr_controller_temp_t._fields_ = [
+    ('rail_selection', ctypes.c_uint32),
+    ('rail_index', ctypes.c_uint32),
+    ('temperature', ctypes.c_uint32),
+]
+
+amdsmi_svi3_vr_controller_temp_t = struct_amdsmi_svi3_vr_controller_temp_t
+
+
+# HSMP Enabled Commands Structure
+class struct_amdsmi_hsmp_enabled_commands_t(Structure):
+    pass
+
+struct_amdsmi_hsmp_enabled_commands_t._pack_ = 1 # source:False
+struct_amdsmi_hsmp_enabled_commands_t_fields_ = [
+        ('read_mask', ctypes.c_bool),    # Input: tells function what to get
+        ('arg0', ctypes.c_uint32),       # Output: BitMask0
+        ('arg1', ctypes.c_uint32),       # Output: BitMask1
+        ('arg2', ctypes.c_uint32),       # Output: BitMask2
+    ]
+
+amdsmi_hsmp_enabled_commands_t = struct_amdsmi_hsmp_enabled_commands_t
+struct_amdsmi_hsmp_enabled_commands_t._fields_ = struct_amdsmi_hsmp_enabled_commands_t_fields_
+
 class struct_amdsmi_dimm_power_t(Structure):
     pass
 
@@ -2712,7 +2741,7 @@ amdsmi_set_cpu_socket_power_cap.argtypes = [amdsmi_processor_handle, uint32_t]
 uint8_t = ctypes.c_uint8
 amdsmi_set_cpu_pwr_efficiency_mode = _libraries['libamd_smi.so'].amdsmi_set_cpu_pwr_efficiency_mode
 amdsmi_set_cpu_pwr_efficiency_mode.restype = amdsmi_status_t
-amdsmi_set_cpu_pwr_efficiency_mode.argtypes = [amdsmi_processor_handle, uint8_t]
+amdsmi_set_cpu_pwr_efficiency_mode.argtypes = [amdsmi_processor_handle, uint8_t, ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint32)]
 amdsmi_get_gpu_memory_total = _libraries['libamd_smi.so'].amdsmi_get_gpu_memory_total
 amdsmi_get_gpu_memory_total.restype = amdsmi_status_t
 amdsmi_get_gpu_memory_total.argtypes = [amdsmi_processor_handle, amdsmi_memory_type_t, ctypes.POINTER(ctypes.c_uint64)]
@@ -3248,6 +3277,12 @@ amdsmi_get_cpu_cores_per_socket.argtypes = [uint32_t, ctypes.POINTER(struct_amds
 amdsmi_get_cpu_socket_count = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_count
 amdsmi_get_cpu_socket_count.restype = amdsmi_status_t
 amdsmi_get_cpu_socket_count.argtypes = [ctypes.POINTER(ctypes.c_uint32)]
+amdsmi_set_cpu_xgmi_pstate_range = _libraries['libamd_smi.so'].amdsmi_set_cpu_xgmi_pstate_range
+amdsmi_set_cpu_xgmi_pstate_range.restype = amdsmi_status_t
+amdsmi_set_cpu_xgmi_pstate_range.argtypes = [amdsmi_processor_handle, uint8_t, uint8_t]
+amdsmi_get_cpu_xgmi_pstate_range = _libraries['libamd_smi.so'].amdsmi_get_cpu_xgmi_pstate_range
+amdsmi_get_cpu_xgmi_pstate_range.restype = amdsmi_status_t
+amdsmi_get_cpu_xgmi_pstate_range.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint8), ctypes.POINTER(ctypes.c_uint8)]
 amdsmi_set_cpu_rail_isofreq_policy = _libraries['libamd_smi.so'].amdsmi_set_cpu_rail_isofreq_policy
 amdsmi_set_cpu_rail_isofreq_policy.restype = amdsmi_status_t
 amdsmi_set_cpu_rail_isofreq_policy.argtypes = [amdsmi_processor_handle, uint8_t]
@@ -3260,6 +3295,62 @@ amdsmi_set_dfc_ctrl.argtypes = [amdsmi_processor_handle, ctypes.c_bool]
 amdsmi_get_dfc_ctrl = _libraries['libamd_smi.so'].amdsmi_get_dfc_ctrl
 amdsmi_get_dfc_ctrl.restype = amdsmi_status_t
 amdsmi_get_dfc_ctrl.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint8)]
+amdsmi_set_pc6_enable = _libraries['libamd_smi.so'].amdsmi_set_pc6_enable
+amdsmi_set_pc6_enable.restype = amdsmi_status_t
+amdsmi_set_pc6_enable.argtypes = [amdsmi_processor_handle, ctypes.c_uint8]
+amdsmi_get_pc6_enable = _libraries['libamd_smi.so'].amdsmi_get_pc6_enable
+amdsmi_get_pc6_enable.restype = amdsmi_status_t
+amdsmi_get_pc6_enable.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint8)]
+amdsmi_set_cc6_enable = _libraries['libamd_smi.so'].amdsmi_set_cc6_enable
+amdsmi_set_cc6_enable.restype = amdsmi_status_t
+amdsmi_set_cc6_enable.argtypes = [amdsmi_processor_handle, ctypes.c_uint8]
+amdsmi_get_cc6_enable = _libraries['libamd_smi.so'].amdsmi_get_cc6_enable
+amdsmi_get_cc6_enable.restype = amdsmi_status_t
+amdsmi_get_cc6_enable.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint8)]
+amdsmi_dimm_sb_reg_read = _libraries['libamd_smi.so'].amdsmi_dimm_sb_reg_read
+amdsmi_dimm_sb_reg_read.restype = amdsmi_status_t
+amdsmi_dimm_sb_reg_read.argtypes = [amdsmi_processor_handle, uint64_t, uint64_t, uint64_t, uint64_t, ctypes.POINTER(ctypes.c_uint32)]
+amdsmi_dimm_sb_reg_write = _libraries['libamd_smi.so'].amdsmi_dimm_sb_reg_write
+amdsmi_dimm_sb_reg_write.restype = amdsmi_status_t
+amdsmi_dimm_sb_reg_write.argtypes = [amdsmi_processor_handle, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t]
+amdsmi_get_ccd_power = _libraries['libamd_smi.so'].amdsmi_get_ccd_power
+amdsmi_get_ccd_power.restype = amdsmi_status_t
+amdsmi_get_ccd_power.argtypes = [amdsmi_processor_handle, uint32_t, ctypes.POINTER(ctypes.c_uint32)]
+amdsmi_read_tdelta = _libraries['libamd_smi.so'].amdsmi_read_tdelta
+amdsmi_read_tdelta.restype = amdsmi_status_t
+amdsmi_read_tdelta.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint8)]
+amdsmi_get_svi3_vr_controller_temp = _libraries['libamd_smi.so'].amdsmi_get_svi3_vr_controller_temp
+amdsmi_get_svi3_vr_controller_temp.restype = amdsmi_status_t
+amdsmi_get_svi3_vr_controller_temp.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_svi3_vr_controller_temp_t)]
+amdsmi_get_enabled_commands = _libraries['libamd_smi.so'].amdsmi_get_enabled_commands
+amdsmi_get_enabled_commands.restype = amdsmi_status_t
+amdsmi_get_enabled_commands.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_hsmp_enabled_commands_t)]
+amdsmi_get_cpu_core_floorlimit = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_floorlimit
+amdsmi_get_cpu_core_floorlimit.restype = amdsmi_status_t
+amdsmi_get_cpu_core_floorlimit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+amdsmi_get_cpu_core_efffloorlimit = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_efffloorlimit
+amdsmi_get_cpu_core_efffloorlimit.restype = amdsmi_status_t
+amdsmi_get_cpu_core_efffloorlimit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+amdsmi_set_cpu_core_floorlimit = _libraries['libamd_smi.so'].amdsmi_set_cpu_core_floorlimit
+amdsmi_set_cpu_core_floorlimit.restype = amdsmi_status_t
+amdsmi_set_cpu_core_floorlimit.argtypes = [amdsmi_processor_handle, uint32_t]
+amdsmi_set_cpu_floorlimit = _libraries['libamd_smi.so'].amdsmi_set_cpu_floorlimit
+amdsmi_set_cpu_floorlimit.restype = amdsmi_status_t
+amdsmi_set_cpu_floorlimit.argtypes = [amdsmi_processor_handle, uint32_t]
+amdsmi_cpu_msr_floorlimit = _libraries['libamd_smi.so'].amdsmi_cpu_msr_floorlimit
+amdsmi_cpu_msr_floorlimit.restype = amdsmi_status_t
+amdsmi_cpu_msr_floorlimit.argtypes = [amdsmi_processor_handle, uint32_t]
+amdsmi_cpu_core_msr_floorlimit = _libraries['libamd_smi.so'].amdsmi_cpu_core_msr_floorlimit
+amdsmi_cpu_core_msr_floorlimit.restype = amdsmi_status_t
+amdsmi_cpu_core_msr_floorlimit.argtypes = [amdsmi_processor_handle, uint32_t]
+amdsmi_set_cpu_socket_sdps_limit = _libraries['libamd_smi.so'].amdsmi_set_cpu_socket_sdps_limit
+amdsmi_set_cpu_socket_sdps_limit.restype = amdsmi_status_t
+amdsmi_set_cpu_socket_sdps_limit.argtypes = [amdsmi_processor_handle, uint32_t]
+amdsmi_get_cpu_socket_sdps_limit = _libraries['libamd_smi.so'].amdsmi_get_cpu_socket_sdps_limit
+amdsmi_get_cpu_socket_sdps_limit.restype = amdsmi_status_t
+amdsmi_get_cpu_socket_sdps_limit.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint32)]
+
+
 __all__ = \
     ['AGG_BW0', 'AMDSMI_ACCELERATOR_DECODER',
     'AMDSMI_ACCELERATOR_DMA', 'AMDSMI_ACCELERATOR_ENCODER',
@@ -3598,8 +3689,18 @@ __all__ = \
     'amdsmi_get_cpu_socket_power_cap_max',
     'amdsmi_get_cpu_socket_temperature', 'amdsmi_get_cpucore_handles',
     'amdsmi_get_energy_count', 'amdsmi_get_esmi_err_msg',
-    'amdsmi_get_fw_info', 'amdsmi_get_dfc_ctrl', 'amdsmi_set_dfc_ctrl',
-    'amdsmi_get_cpu_rail_isofreq_policy', 'amdsmi_set_cpu_rail_isofreq_policy',
+    'amdsmi_get_fw_info', 'amdsmi_set_cpu_xgmi_pstate_range', 'amdsmi_get_cpu_xgmi_pstate_range,'
+    'amdsmi_set_cpu_rail_isofreq_policy', 'amdsmi_get_cpu_rail_isofreq_policy',
+    'amdsmi_set_dfc_ctrl', 'amdsmi_get_dfc_ctrl',
+    'amdsmi_set_pc6_enable', 'amdsmi_get_pc6_enable',
+    'amdsmi_set_cc6_enable', 'amdsmi_get_cc6_enable',
+    'amdsmi_dimm_sb_reg_read', 'amdsmi_dimm_sb_reg_write',
+    'amdsmi_get_ccd_power', 'amdsmi_read_tdelta', 'amdsmi_get_svi3_vr_controller_temp',
+    'amdsmi_get_enabled_commands',
+    'amdsmi_get_cpu_core_floorlimit', 'amdsmi_get_cpu_core_efffloorlimit',
+    'amdsmi_set_cpu_floorlimit', 'amdsmi_cpu_msr_floorlimit', 'amdsmi_set_cpu_core_floorlimit',
+    'amdsmi_cpu_core_msr_floorlimit', 'amdsmi_get_cpu_xgmi_pstate_range',
+    'amdsmi_set_cpu_socket_sdps_limit', 'amdsmi_get_cpu_socket_sdps_limit',
     'amdsmi_get_gpu_accelerator_partition_profile',
     'amdsmi_get_gpu_accelerator_partition_profile_config',
     'amdsmi_get_gpu_activity', 'amdsmi_get_gpu_asic_info',
@@ -3758,7 +3859,7 @@ __all__ = \
     'struct_amdsmi_gpu_ras_policy_info_t',
     'struct_amdsmi_gpu_ras_policy_v4_0_t',
     'struct_amdsmi_gpu_xcp_metrics_t',
-    'struct_amdsmi_hsmp_driver_version_t',
+    'struct_amdsmi_hsmp_driver_version_t', 'struct_amdsmi_hsmp_enabled_commands_t',
     'struct_amdsmi_hsmp_metrics_table_t', 'struct_amdsmi_kfd_info_t',
     'struct_amdsmi_link_id_bw_type_t', 'struct_amdsmi_link_metrics_t',
     'struct_amdsmi_memory_partition_config_t',
@@ -3774,6 +3875,7 @@ __all__ = \
     'struct_amdsmi_retired_page_record_t',
     'struct_amdsmi_smu_fw_version_t', 'struct_amdsmi_sock_info_t',
     'struct_amdsmi_temp_range_refresh_rate_t',
+    "struct_amdsmi_svi3_vr_controller_temp_t",
     'struct_amdsmi_topology_nearest_t',
     'struct_amdsmi_utilization_counter_t',
     'struct_amdsmi_vbios_info_t', 'struct_amdsmi_version_t',

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -6024,7 +6024,9 @@ amdsmi_status_t amdsmi_set_cpu_socket_power_cap(amdsmi_processor_handle processo
 }
 
 amdsmi_status_t amdsmi_set_cpu_pwr_efficiency_mode(amdsmi_processor_handle processor_handle,
-                                                   uint8_t mode)
+                                                   uint8_t mode,
+                                                   uint32_t *util,
+                                                   uint32_t *ppt_limit)
 {
     amdsmi_status_t status;
     uint8_t sock_ind;
@@ -6034,14 +6036,16 @@ amdsmi_status_t amdsmi_set_cpu_pwr_efficiency_mode(amdsmi_processor_handle proce
     if (processor_handle == nullptr)
         return AMDSMI_STATUS_INVAL;
 
+    if (util == nullptr || ppt_limit == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
     amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
     if (r != AMDSMI_STATUS_SUCCESS)
         return r;
 
     sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
 
-    status = static_cast<amdsmi_status_t>(esmi_pwr_efficiency_mode_set(sock_ind, mode));
-
+    status = static_cast<amdsmi_status_t>(esmi_pwr_efficiency_mode_set(sock_ind, mode, util, ppt_limit));
     if (status != AMDSMI_STATUS_SUCCESS)
         return amdsmi_errno_to_esmi_status(status);
 
@@ -6302,13 +6306,20 @@ amdsmi_status_t amdsmi_set_cpu_xgmi_width(amdsmi_processor_handle processor_hand
         uint8_t min, uint8_t max)
 {
     amdsmi_status_t status;
+    uint8_t sock_ind;
 
     AMDSMI_CHECK_INIT();
 
     if (processor_handle == nullptr)
         return AMDSMI_STATUS_INVAL;
 
-    status = static_cast<amdsmi_status_t>(esmi_xgmi_width_set(min, max));
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    status = static_cast<amdsmi_status_t>(esmi_xgmi_width_set(sock_ind, min, max));
     if (status != AMDSMI_STATUS_SUCCESS)
         return amdsmi_errno_to_esmi_status(status);
 
@@ -6469,7 +6480,7 @@ amdsmi_status_t amdsmi_set_cpu_pcie_link_rate(amdsmi_processor_handle processor_
 }
 
 amdsmi_status_t amdsmi_set_cpu_df_pstate_range(amdsmi_processor_handle processor_handle,
-        uint8_t max_pstate, uint8_t min_pstate)
+        uint8_t min_pstate, uint8_t max_pstate)
 {
     amdsmi_status_t status;
     uint8_t sock_ind;
@@ -6486,7 +6497,7 @@ amdsmi_status_t amdsmi_set_cpu_df_pstate_range(amdsmi_processor_handle processor
     sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
 
     status = static_cast<amdsmi_status_t>(esmi_df_pstate_range_set(sock_ind,
-                                                                        max_pstate, min_pstate));
+                                                                        min_pstate, max_pstate));
     if (status != AMDSMI_STATUS_SUCCESS)
         return amdsmi_errno_to_esmi_status(status);
 
@@ -6843,6 +6854,58 @@ amdsmi_status_t amdsmi_get_esmi_err_msg(amdsmi_status_t status, const char **sta
     return AMDSMI_STATUS_SUCCESS;
 }
 
+amdsmi_status_t amdsmi_set_cpu_xgmi_pstate_range(amdsmi_processor_handle processor_handle,
+						uint8_t min_pstate, uint8_t max_pstate)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    status = static_cast<amdsmi_status_t>(esmi_xgmi_pstate_range_set(sock_ind, min_pstate, max_pstate));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_xgmi_pstate_range(amdsmi_processor_handle processor_handle,
+                                                uint8_t *min_pstate, uint8_t *max_pstate)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    if (min_pstate == nullptr || max_pstate == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    status = static_cast<amdsmi_status_t>(esmi_xgmi_pstate_range_get(sock_ind, min_pstate, max_pstate));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
 amdsmi_status_t amdsmi_set_cpu_rail_isofreq_policy(amdsmi_processor_handle processor_handle,
                                                    uint8_t input)
 {
@@ -6942,6 +7005,590 @@ amdsmi_status_t amdsmi_get_dfc_ctrl(amdsmi_processor_handle processor_handle,
         return amdsmi_errno_to_esmi_status(status);
 
     *dfc_ctrl = (uint8_t)dfcctrl;
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_set_pc6_enable(amdsmi_processor_handle processor_handle,
+                                       uint8_t enable)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    if (enable > 1)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    status = static_cast<amdsmi_status_t>(esmi_pc6_enable_set(sock_ind, enable));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_pc6_enable(amdsmi_processor_handle processor_handle,
+                                       uint8_t *enabled)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    uint8_t pc6_enable;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    if (enabled == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    status = static_cast<amdsmi_status_t>(esmi_pc6_enable_get(sock_ind, &pc6_enable));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    *enabled = pc6_enable;
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_set_cc6_enable(amdsmi_processor_handle processor_handle,
+                                       uint8_t enable)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    if (enable > 1)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    status = static_cast<amdsmi_status_t>(esmi_cc6_enable_set(sock_ind, enable));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cc6_enable(amdsmi_processor_handle processor_handle,
+                                       uint8_t *enabled)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    uint8_t cc6_enable;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    if (enabled == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    status = static_cast<amdsmi_status_t>(esmi_cc6_enable_get(sock_ind, &cc6_enable));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    *enabled = cc6_enable;
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_dimm_sb_reg_read(amdsmi_processor_handle processor_handle,
+                                         uint64_t dimm_addr,
+                                         uint64_t lid,
+                                         uint64_t reg_offset,
+                                         uint64_t reg_space,
+                                         uint32_t *data)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    struct dimm_sb_info dimm_sb;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    if (data == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    // Validate input ranges based on dimm_sb_info structure
+    if ( (dimm_addr > AMDSMI_MAX_SPD_DIMM_ADDRESS) || (lid > AMDSMI_MAX_SPD_LID) || (reg_offset > AMDSMI_MAX_SPD_REG_OFFSET) || (reg_space > AMDSMI_MAX_SPD_REG_SPACE))
+    {
+        return AMDSMI_STATUS_INVAL;
+    }
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    dimm_sb.m_dimm_sb_info_inarg.info.dimm_addr = (uint32_t)dimm_addr;
+    dimm_sb.m_dimm_sb_info_inarg.info.lid = (uint32_t)lid;
+    dimm_sb.m_dimm_sb_info_inarg.info.reg_offset = (uint32_t)reg_offset;
+    dimm_sb.m_dimm_sb_info_inarg.info.reg_space = (uint32_t)reg_space;
+    dimm_sb.m_dimm_sb_info_inarg.info.write_data = 0;
+
+    status = static_cast<amdsmi_status_t>(esmi_dimm_sb_reg_read(sock_ind, &dimm_sb));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    *data = dimm_sb.read_data;
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_dimm_sb_reg_write(amdsmi_processor_handle processor_handle,
+                                          uint64_t dimm_addr,
+                                          uint64_t lid,
+                                          uint64_t reg_offset,
+                                          uint64_t reg_space,
+                                          uint64_t write_data)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    struct dimm_sb_info dimm_sb;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    // Validate input ranges based on dimm_sb_info structure
+    if ( (dimm_addr > AMDSMI_MAX_SPD_DIMM_ADDRESS) || (lid > AMDSMI_MAX_SPD_LID) || (reg_offset > AMDSMI_MAX_SPD_REG_OFFSET) || (reg_space > AMDSMI_MAX_SPD_REG_SPACE))
+    {
+        return AMDSMI_STATUS_INVAL;
+    }
+
+    if (write_data > AMDSMI_MAX_SPD_WRITE_DATA)  // 8 bit
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    dimm_sb.m_dimm_sb_info_inarg.info.dimm_addr = (uint32_t)dimm_addr;
+    dimm_sb.m_dimm_sb_info_inarg.info.lid = (uint32_t)lid;
+    dimm_sb.m_dimm_sb_info_inarg.info.reg_offset = (uint32_t)reg_offset;
+    dimm_sb.m_dimm_sb_info_inarg.info.reg_space = (uint32_t)reg_space;
+    dimm_sb.m_dimm_sb_info_inarg.info.write_data = (uint32_t)write_data;
+    dimm_sb.m_dimm_sb_info_inarg.reg_value = 0;
+
+    status = static_cast<amdsmi_status_t>(esmi_dimm_sb_reg_write(sock_ind, &dimm_sb));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_ccd_power(amdsmi_processor_handle processor_handle,
+                                     uint32_t ccd_id,
+                                     uint32_t *power)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    if (power == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    // Validate CCD ID range (typically 0-7 for most systems)
+    if (ccd_id > 7)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    status = static_cast<amdsmi_status_t>(esmi_read_ccd_power(ccd_id, power));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+     return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_read_tdelta(amdsmi_processor_handle processor_handle,
+                                   uint8_t *tdelta)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    if (tdelta == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    // Call ESMI function to read thermal delta
+    status = static_cast<amdsmi_status_t>(esmi_read_tdelta(sock_ind, tdelta));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+
+}
+
+amdsmi_status_t amdsmi_get_svi3_vr_controller_temp(amdsmi_processor_handle processor_handle,
+                                                   amdsmi_svi3_vr_controller_temp_t *vr_temp_info)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    char proc_id[SIZE];
+    struct svi3_info esmi_svi3_info;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    if (vr_temp_info == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    // Validate input parameters
+    if (vr_temp_info->rail_selection > 1) {
+        return AMDSMI_STATUS_INVAL;
+    }
+    if (vr_temp_info->rail_index > 7) {
+        return AMDSMI_STATUS_INVAL;
+    }
+
+    // Prepare ESMI SVI3 structure with input parameters
+    esmi_svi3_info.m_svi3_info_inarg.info.svi3_rail_selection = (vr_temp_info->rail_selection & 0x1);
+    esmi_svi3_info.m_svi3_info_inarg.info.svi3_rail_index = (vr_temp_info->rail_index & 0x7);
+    esmi_svi3_info.m_svi3_info_inarg.info.svi3_temperature = 0; // Initialize to 0
+
+    // Call ESMI function to get SVI3 VR controller temperature
+    status = static_cast<amdsmi_status_t>(esmi_get_svi3_vr_controller_temp(sock_ind, &esmi_svi3_info));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    // Extract temperature from ESMI response
+    vr_temp_info->temperature = esmi_svi3_info.m_svi3_info_inarg.info.svi3_temperature;
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_enabled_commands(amdsmi_processor_handle processor_handle,
+                                           amdsmi_hsmp_enabled_commands_t *enabled_cmds)
+{
+
+    amdsmi_status_t status;
+    struct hsmp_enabled_commands_info enabled_cmds_info;
+    uint8_t sock_ind;
+    char proc_id[16] = {0};
+
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr || enabled_cmds == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, 16, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+
+    // Use the read_mask from input to determine what to get
+    enabled_cmds_info.read_mask = enabled_cmds->read_mask;
+    status = static_cast<amdsmi_status_t>(esmi_get_enabled_commands(sock_ind, &enabled_cmds_info));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    // Store commands in the output structure (keep the same read_mask)
+    enabled_cmds->arg0 = enabled_cmds_info.arg0;
+    enabled_cmds->arg1 = enabled_cmds_info.arg1;
+    enabled_cmds->arg2 = enabled_cmds_info.arg2;
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_core_floorlimit(amdsmi_processor_handle processor_handle,
+                                               uint32_t *pfloorlimit)
+{
+    amdsmi_status_t status;
+    uint32_t floorlimit;
+    uint32_t core_ind;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    if (pfloorlimit == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    core_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    status = static_cast<amdsmi_status_t>(esmi_floorlimit_set_get(core_ind, &floorlimit, GET_FLOOR_FREQUENCY_CORE));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    *pfloorlimit = floorlimit;
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_core_efffloorlimit(amdsmi_processor_handle processor_handle,
+                                                 uint32_t *pefffloorlimit)
+{
+    amdsmi_status_t status;
+    uint32_t efffloorlimit;
+    uint32_t core_ind;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    if (pefffloorlimit == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    core_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    status = static_cast<amdsmi_status_t>(esmi_floorlimit_set_get(core_ind, &efffloorlimit, GET_EFF_FLOOR_FREQUENCY_CORE));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    *pefffloorlimit = efffloorlimit;
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_set_cpu_core_floorlimit(amdsmi_processor_handle processor_handle,
+                                               uint32_t floorlimit)
+{
+    amdsmi_status_t status;
+    uint32_t core_ind;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    core_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    status = static_cast<amdsmi_status_t>(esmi_floorlimit_set_get(core_ind, &floorlimit, SET_FLOOR_FREQUENCY_CORE));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_set_cpu_floorlimit(amdsmi_processor_handle processor_handle,
+                                          uint32_t floorlimit)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    status = static_cast<amdsmi_status_t>(esmi_floorlimit_set_get(sock_ind, &floorlimit, SET_FLOOR_FREQUENCY_SOCKET));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_cpu_msr_floorlimit(amdsmi_processor_handle processor_handle,
+                                          uint32_t msrfloorlimit)
+{
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    char proc_id[SIZE];
+    uint16_t fmax, fmin;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    // Get socket frequency range to obtain fmax and fmin as per reference implementation
+    status = static_cast<amdsmi_status_t>(esmi_socket_freq_range_get(sock_ind, &fmax, &fmin));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    // Call internal MSR floor limit function following the user specification:
+    // amdsmi_cpu_msr_floorlimit(sock_ind, msrfloorlimit, static_cast<set_get_floorlimit>(type), fmax)
+    // Note: This calls an internal overloaded version or helper function
+    status = static_cast<amdsmi_status_t>(esmi_floorlimit_set_get(sock_ind, &msrfloorlimit, SET_FLOOR_FREQUENCY_SOCKET));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_cpu_core_msr_floorlimit(amdsmi_processor_handle processor_handle,
+                                               uint32_t msrfloorlimit)
+{
+    amdsmi_status_t status;
+    uint32_t core_ind;
+    char proc_id[SIZE];
+    uint16_t fmax, fmin;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    core_ind = (uint32_t)std::stoi(proc_id, NULL, 0);
+
+    // Get socket frequency range to obtain fmax and fmin as per reference implementation
+    status = static_cast<amdsmi_status_t>(esmi_socket_freq_range_get(0, &fmax, &fmin));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    // Call ESMI MSR floor limit set function for core-level operation
+    status = static_cast<amdsmi_status_t>(esmi_msr_floorlimit_set(core_ind, msrfloorlimit, SET_FLOOR_FREQUENCY_CORE, fmax));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+
+amdsmi_status_t amdsmi_set_cpu_socket_sdps_limit(amdsmi_processor_handle processor_handle,
+                                                  uint32_t sdps_limit) {
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    char proc_id[SIZE];
+    uint32_t sdps_limit_value = sdps_limit;
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    // Call ESMI function to set SDPS limit
+    status = static_cast<amdsmi_status_t>(esmi_sdps_limit_set(sock_ind, &sdps_limit_value));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_cpu_socket_sdps_limit(amdsmi_processor_handle processor_handle,
+                                                  uint32_t *sdps_limit) {
+    amdsmi_status_t status;
+    uint8_t sock_ind;
+    char proc_id[SIZE];
+
+    AMDSMI_CHECK_INIT();
+
+    if (processor_handle == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    if (sdps_limit == nullptr)
+        return AMDSMI_STATUS_INVAL;
+
+    amdsmi_status_t r = amdsmi_get_processor_info(processor_handle, SIZE, proc_id);
+    if (r != AMDSMI_STATUS_SUCCESS)
+        return r;
+
+    sock_ind = (uint8_t)std::stoi(proc_id, NULL, 0);
+
+    // Call ESMI function to get SDPS limit
+    status = static_cast<amdsmi_status_t>(esmi_sdps_limit_get(sock_ind, sdps_limit));
+    if (status != AMDSMI_STATUS_SUCCESS)
+        return amdsmi_errno_to_esmi_status(status);
 
     return AMDSMI_STATUS_SUCCESS;
 }


### PR DESCRIPTION
Added support for

* Get XGMI Width
* Get DF Pstate Range
* Get XGMI PState Range
* Get CCD Power
* Get TDelta
* Get DIMM SB Data
* Get SVI3 Temperature
* Get PC6 Enable
* Get CC6 Enable
* Get HSMP Enabled Commands
* Get Core FloorLimit
* Get Core EffectiveFloorLimit
* Get SDPS(SOC Dimm Power Sloshing) Limit
* Set Commands
* Set XGMI Width
* Set PC6 Enable Control
* Set CC6 Enable Control
* Set Core FloorLimit via HSMP
* Set Socket FloorLimit via HSMP
* Set DIMM SB Data
* Set SDPS(SOC Dimm Power Sloshing) Limit
* Set Socket MSR Floor Limit
* Set Core MSR Floor Limit

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
