### PR TITLE
SWDEV-539306 - fix address sanitizer warning in Unit_Rtc_ReduceRandom and re-enable test

### DIFF
--- a/projects/hip-tests/catch/hipTestMain/config/config_amd_linux
+++ b/projects/hip-tests/catch/hipTestMain/config/config_amd_linux
@@ -79,7 +79,6 @@
         "Unit_hipMultiThreadDevice_SerialPyramid",
         "Unit_Device___clzll_Sanity_Positive - unsigned long long int",
         "Unit_Test_makechar_functionality",
-        "Unit_Rtc_ReduceRandom",
         "Unit_test_generic_target_only_in_regular_fatbin",
         "Unit_test_generic_target_only_in_compressed_fatbin",
         "=== special values test, fix: comment out [HEX_DBL(-, 1, fffffffffffff, +, 31), HEX_DBL(+, 1, fffffffffffff, +, 31)]",

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -305,17 +305,15 @@ void genRandomMasks(LinearAllocGuard<T>& d_buf,
 
 // generates a random __half (instead of using uniform_real_distribution<float> casting to __half
 // which is problematic)
-// @expDist needs to be between [0-2^5-2]
 template <class Gen>
 __half genRandomHalf(std::uniform_int_distribution<unsigned short>& dist,
-                     Gen& gen)
+                     Gen& gen,
+                     unsigned char exponent)
 {
   __half_raw tmp;
+  unsigned short mantissa = dist(gen) & 0x7ff;
 
-  tmp.x = dist(gen);
-  // rewrite the exponent to force the number to be (-8<x<8) and at the same time avoid NaN or
-  // infinity
-  tmp.x &= 0xBBFF;
+  tmp.x = (exponent << 10) | mantissa;
   return tmp;
 }
 
@@ -334,12 +332,23 @@ void genRandomBuffers(LinearAllocGuard<T>& d_buf,
   buf = std::move(tmp);
   d_buf = std::move(d_tmp);
 
-  for (int i = 0; i < numItems; i++)
-    if constexpr (std::is_same<T, __half>::value)
-      buf.ptr()[i] = genRandomHalf(dist, gen);
-    else
-      buf.ptr()[i] = dist(gen);
+  if constexpr (std::is_same<T, __half>::value) {
+    // avoid denormals (exponent = 0) and NaN/infinite (exponent = 255).
+    // use numbers to be (-8<x<8) (just to avoid overflows)
+    // When using __half we create all the numbers with the same exponent. That
+    // makes testing easier, as if they are all different exponents, they will have
+    // very different precissions and we will get bigger differences between the
+    // CPU and the GPU
+    unsigned char exponent = dist(gen) % 17 + 1;
 
+    for (int i = 0; i < numItems; i++) {
+      buf.ptr()[i] = genRandomHalf(dist, gen, exponent);
+    }
+  } else {
+    for (int i = 0; i < numItems; i++) {
+      buf.ptr()[i] = dist(gen);
+    }
+  }
   HIP_CHECK(hipMemcpy(d_buf.ptr(), buf.ptr(), numBytes, hipMemcpyHostToDevice));
 }
 
@@ -398,10 +407,17 @@ void printMismatch(const T& result, const T& expected, const T* input, unsigned 
 
   for (int i = 0; i < getWarpSize(); i++) {
     if ((1ul << i) & mask) {
-      if constexpr (std::is_same<T, __half>::value)
-                     std::cout << "Lane " << i << ": " << __half2float(input[i]) << "\n";
-      else
+      if constexpr (std::is_same<T, __half>::value) {
+        const unsigned char* ptr = reinterpret_cast<const unsigned char*>(&input[i]);
+
+        std::cout << "Lane " << i << ": " << __half2float(input[i])
+                  << std::hex
+                  << " (0x" << static_cast<int>(ptr[1]) << static_cast<int>(ptr[0]) << ")"
+                  << "\n";
+        std::cout.copyfmt(init);
+      } else {
         std::cout << "Lane " << i << ": " << input[i] << "\n";
+      }
     }
   }
 
@@ -472,10 +488,9 @@ void runTestReduce(int iteration, Reduce reduce)
   LinearAllocGuard<T> output(LinearAllocs::malloc, kNumReduces * wavefrontSize * sizeof(T));
   std::mt19937_64 gen(iteration);
   // for float16, we generate any random unsigned short, but cap the exponent later on
-  // to keep it in the range (-8.0..8.0) (just to avoid overflows)
   // On the rest of the types, just use a bigger reduced range of numbers to avoid overflows too
-  T a = std::is_same<T, half>::value? std::numeric_limits<unsigned short>::lowest() : -1023;
-  T b = std::is_same<T, half>::value? std::numeric_limits<unsigned short>::max() : 1023;
+  typename distribution::result_type a = std::is_same<T, half>::value? std::numeric_limits<unsigned short>::lowest() : -1023;
+  typename distribution::result_type b = std::is_same<T, half>::value? std::numeric_limits<unsigned short>::max() : 1023;
   distribution dist(a, b);
   LinearAllocGuard<T> input, d_input;
   LinearAllocGuard<unsigned long long> masks, d_masks;

--- a/projects/hip-tests/catch/unit/rtc/rtc_reduce.cc
+++ b/projects/hip-tests/catch/unit/rtc/rtc_reduce.cc
@@ -46,13 +46,12 @@ void runRtcReduceOp(hiprtcProgram& prog, T* output, const T* input, const MaskTy
   const char* loweredName;
   hipFunction_t kernel;
   hipModule_t module;
-  int* d_numReduces;
+  LinearAllocGuard<int> d_numReduces(LinearAllocs::hipMalloc, sizeof(int));
 
-  HIP_CHECK(hipMalloc(&d_numReduces, sizeof(int)));
-  HIP_CHECK(hipMemcpy(d_numReduces, &numReduces, sizeof(int), hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(d_numReduces.ptr(), &numReduces, sizeof(int), hipMemcpyHostToDevice));
   std::vector<const void*> args = {
       reinterpret_cast<const void*>(output), reinterpret_cast<const void*>(input),
-      reinterpret_cast<const void*>(masks), reinterpret_cast<void*>(d_numReduces)};
+      reinterpret_cast<const void*>(masks), reinterpret_cast<void*>(d_numReduces.ptr())};
   std::size_t sizeBytes = args.size() * sizeof(void*);
   void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, args.data(), HIP_LAUNCH_PARAM_BUFFER_SIZE,
                     &sizeBytes, HIP_LAUNCH_PARAM_END};

--- a/projects/hip-tests/catch/unit/rtc/rtc_reduce.cc
+++ b/projects/hip-tests/catch/unit/rtc/rtc_reduce.cc
@@ -46,15 +46,16 @@ void runRtcReduceOp(hiprtcProgram& prog, T* output, const T* input, const MaskTy
   const char* loweredName;
   hipFunction_t kernel;
   hipModule_t module;
-  struct {
-    const T* d_output;
-    const T* d_input;
-    const MaskType* d_masks;
-    int numReduces;
-  } args{output, input, masks, numReduces};
-  int size = 4;
-  void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args, HIP_LAUNCH_PARAM_BUFFER_SIZE, &size,
-                    HIP_LAUNCH_PARAM_END};
+  int* d_numReduces;
+
+  HIP_CHECK(hipMalloc(&d_numReduces, sizeof(int)));
+  HIP_CHECK(hipMemcpy(d_numReduces, &numReduces, sizeof(int), hipMemcpyHostToDevice));
+  std::vector<const void*> args = {
+      reinterpret_cast<const void*>(output), reinterpret_cast<const void*>(input),
+      reinterpret_cast<const void*>(masks), reinterpret_cast<void*>(d_numReduces)};
+  std::size_t sizeBytes = args.size() * sizeof(void*);
+  void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, args.data(), HIP_LAUNCH_PARAM_BUFFER_SIZE,
+                    &sizeBytes, HIP_LAUNCH_PARAM_END};
   std::vector<char> code;
   size_t codeSize;
   std::string expression =
@@ -153,11 +154,11 @@ void runAndCompileTest(const std::tuple<Types...> types) {
   opToString<int, Op>(scalarName, intrinsicName);
   kernelStr = R"(
     template <class T, class MaskType>
-    __global__ void reduceRtcKernel(T* output, const T* input, const MaskType* masks, int numReduces)
+    __global__ void reduceRtcKernel(T* output, const T* input, const MaskType* masks, int* numReduces)
     {
       int tid = threadIdx.x;
 
-      for (int i = 0; i < numReduces; i++) {
+      for (int i = 0; i < *numReduces; i++) {
         if (masks[i] & (1ul << tid)) {
           // call the operator only if the lane is mentioned in the mask
           T& result = output[warpSize * i + tid];

--- a/projects/hip-tests/catch/unit/rtc/rtc_reduce.cc
+++ b/projects/hip-tests/catch/unit/rtc/rtc_reduce.cc
@@ -49,9 +49,7 @@ void runRtcReduceOp(hiprtcProgram& prog, T* output, const T* input, const MaskTy
   LinearAllocGuard<int> d_numReduces(LinearAllocs::hipMalloc, sizeof(int));
 
   HIP_CHECK(hipMemcpy(d_numReduces.ptr(), &numReduces, sizeof(int), hipMemcpyHostToDevice));
-  std::vector<const void*> args = {
-      reinterpret_cast<const void*>(output), reinterpret_cast<const void*>(input),
-      reinterpret_cast<const void*>(masks), reinterpret_cast<void*>(d_numReduces.ptr())};
+  std::vector<const void*> args = {output, input, masks, d_numReduces.ptr()};
   std::size_t sizeBytes = args.size() * sizeof(void*);
   void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, args.data(), HIP_LAUNCH_PARAM_BUFFER_SIZE,
                     &sizeBytes, HIP_LAUNCH_PARAM_END};


### PR DESCRIPTION
## Motivation
The test Unit_Rtc_ReduceRandom was disabled when we moved to The Rock.
Address sanitizer reports a stack-buffer-overflow:

```
==137853==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7b1d783921c0 at pc 0x7f1d855cd74c bp 0x7ffec33dfa90 sp 0x7ffec33dfa88
READ of size 8 at 0x7b1d783921c0 thread T0
    #0 0x7f1d855cd74b in hip::ihipLaunchKernelCommand(amd::Command*&, ihipModuleSymbol_t*, amd::LaunchParams&, hip::Stream*, void**, void**, ihipEvent_t*, ihipEvent_t*, unsigned int, unsigned int, unsigned int, unsigned int, unsigned lonned long, unsigned int) /root/github/rocm-systems/projects/clr/hipamd/src/hip_module.cpp:395:21
```
## Technical Details

The problem is that when using hipModuleLaunchKernel(), the parameters of the kernel must be pointers, but the code was trying to pass a scalar as a parameter which causes undefined behaviour.
The `extra` parameters of hipModuleLaunchKernel() must be pointers (and they have to be device pointers)

## JIRA ID

SWDEV-539306

## Test Plan

Re-run test under ASan on MI300X

## Test Result

ASan does not report stack-buffer-overflow anymore and test passes

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
