### PR TITLE
[ROCM-1782] Fix crash in ReadKFDDeviceProperties() 

### DIFF
--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -201,11 +201,17 @@ int ReadKFDDeviceProperties(uint32_t kfd_node_id,
     return ENOENT;
   }
   // Remove any *trailing* empty (whitespace) lines
-  while (retVec->back().find_first_not_of(" \t\n\v\f\r") == std::string::npos) {
+  while (!retVec->empty() && retVec->back().find_first_not_of(" \t\n\v\f\r") == std::string::npos) {
     retVec->pop_back();
   }
 
   fs.close();
+
+  // Return error if vector became empty after removing whitespace-only lines
+  if (retVec->empty()) {
+    return ENOENT;
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
## Motivation

Fix a crash in ReadKFDDeviceProperties() found during fuzz testing. The function crashes when the properties file contains only whitespace lines. 

## Technical Details

The while loop removing trailing whitespace lines calls back() without checking if the vector is empty. If all lines are whitespace-only, the loop pops all elements and then crashes on back() of an empty vector (undefined behavior detected by AddressSanitizer).

Fix:
Added !retVec->empty() check before back() in the while condition
Added check to return ENOENT if vector becomes empty after removing whitespace lines

## JIRA ID

Resolves [SWDEV-565780] 

## Test Plan

- Verified fix prevents crash with fuzzer test case that triggered the original issue
- Code review confirms short-circuit evaluation prevents UB 

## Test Result

Fix prevents the AddressSanitizer crash. Function now gracefully returns ENOENT for whitespace-only files.

## Submission Checklist

Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
