### PR TITLE
Update aqlprofile CI to have more verbose output

### DIFF
--- a/.github/workflows/aqlprofile-continuous_integration.yml
+++ b/.github/workflows/aqlprofile-continuous_integration.yml
@@ -118,7 +118,7 @@ jobs:
       run:
         PATH=~/.local/bin:${{ env.ROCM_PATH }}/bin:${PATH}
         LD_LIBRARY_PATH=$(pwd)/build:${{ env.ROCM_PATH }}/lib:$LD_LIBRARY_PATH
-        ctest --output-on-failure -DCTEST_SOURCE_DIRECTORY="$(pwd)"
+        ctest --output-on-failure --verbose -DCTEST_SOURCE_DIRECTORY="$(pwd)"
           -DCTEST_BINARY_DIRECTORY="$(pwd)/build" -DAQLPROFILE_BUILD_NUM_JOBS="16" -DCTEST_SITE="${{ matrix.system.runner }}"
           -DCTEST_BUILD_NAME=PR_${{ github.ref_name }}_${{ github.repository }}-${{ matrix.system.os }}-${{ matrix.system.gpu }}-core
           -DCMAKE_CTEST_ARGUMENTS=""
@@ -197,7 +197,7 @@ jobs:
       run:
         PATH=~/.local/bin:${{ env.ROCM_PATH }}/bin:${PATH}
         LD_LIBRARY_PATH=$(pwd)/build:${{ env.ROCM_PATH }}/lib:$LD_LIBRARY_PATH
-        ctest --output-on-failure -DCTEST_SOURCE_DIRECTORY="$(pwd)"
+        ctest --output-on-failure --verbose -DCTEST_SOURCE_DIRECTORY="$(pwd)"
           -DCTEST_BINARY_DIRECTORY="$(pwd)/build" -DAQLPROFILE_BUILD_NUM_JOBS="16"
           -DCTEST_SITE=${{ matrix.system.runner }}
           -DCTEST_BUILD_NAME=PR_${{ github.ref_name }}_${{ github.repository }}-${{ matrix.system.os }}-${{ matrix.system.gpu }}-core


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
We noticed that the `aqlprofile-continuous_integration.yml` CI workflow had minimal information in the test step, making it difficult to understand what the test results are

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Added `--verbose` option to the `ctest` commands in `.github/workflows/aqlprofile-continuous_integration.yml`

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Verify that jobs have detailed output on test results

## Test Result

<!-- Briefly summarize test outcomes. -->
- Workflow provides detailed test results

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
