### PR TITLE
[rocprofiler-compute] Analysis of pytorch trace data

### DIFF
--- a/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
@@ -611,3 +611,61 @@ Analysis database example
       INFO ed45b0b189
    DEBUG Completed writing database
    WARNING Created file: test.db
+
+
+PyTorch Operator Analysis
+--------------------------
+
+.. note::
+   
+   PyTorch operator analysis is currently available only in CLI mode. GUI and TUI 
+   will provide different interfaces for operator selection and visualization.
+
+After profiling with ``--torch-trace`` (see :ref:`torch-operator-profiling`), use 
+the analyze CLI to explore captured operators with hierarchical names.
+
+Listing All Operators
+^^^^^^^^^^^^^^^^^^^^^^
+
+Display all PyTorch operators captured during profiling:
+
+.. code-block:: shell-session
+
+   $ rocprof-compute analyze --path ./workload --list-torch-operators
+
+   ================================================================================
+   PyTorch Operators in: ./workload
+   ================================================================================
+
+     1. ResNet_layer1_conv1
+     2. ResNet_layer1_bn1  
+     3. ResNet_layer4_conv2
+
+   ================================================================================
+   Total: 3 operators
+   ================================================================================
+
+The operators are shown with sanitized names (forward slashes replaced with underscores)
+matching the CSV filenames created in the ``torch_trace/`` directory.
+
+Filtering by Operator
+^^^^^^^^^^^^^^^^^^^^^^
+
+Analyze specific operators by name or pattern:
+
+.. code-block:: shell-session
+
+   $ rocprof-compute analyze --path ./workload --torch-operator "ResNet/layer4"
+
+This filters the analysis to show only kernels and metrics for the specified operator,
+enabling focused performance investigation of specific model components.
+
+**Filter multiple operators**:
+
+.. code-block:: shell-session
+
+   $ rocprof-compute analyze --path ./workload \
+       --torch-operator "Model/encoder" "Model/decoder"
+
+Use the hierarchical names (with forward slashes) as they appear in your model structure,
+not the sanitized underscore-separated names from the CSV files.

--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -930,6 +930,45 @@ Limitations
    * This feature adds instrumentation overhead to track operator boundaries. For
      performance-critical measurements, consider profiling without this option first.
 
+
+.. _torch-operator-profiling:
+
+Hierarchical Operator Names
+----------------------------
+
+Starting with version 3.4, PyTorch operators are captured with their full module
+hierarchy, providing complete context about where each operation occurs in your model:
+
+.. code-block:: text
+
+   ResNet/layer4/conv2
+   Transformer/encoder/attention/softmax
+   MyModel/decoder/output_layer
+
+This hierarchical naming enables:
+
+* **Context preservation**: See exactly which model layer triggered each kernel
+* **Debugging**: Identify performance issues in specific model components
+* **Optimization**: Focus tuning efforts on bottleneck operators
+
+Example with hierarchical naming:
+
+.. code-block:: python
+
+   class MyModel(nn.Module):
+       def __init__(self):
+           super().__init__()
+           self.encoder = nn.Linear(512, 1024)
+           self.decoder = nn.Linear(1024, 512)
+       
+       def forward(self, x):
+            x = self.encoder(x)  # Captured as: nn.Module.MyModel.forward/nn.Module.Linear.forward
+            x = self.decoder(x)  # Captured as: nn.Module.MyModel.forward/nn.Module.Linear.forward
+            return x
+
+**Analyzing captured operators**: After profiling, see :doc:`../analyze/cli` for 
+how to list and filter PyTorch operators in analyze mode.
+
 Combined with Other Options
 ----------------------------
 

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -748,7 +748,7 @@ Examples:
     analyze_group.add_argument(
         "--torch-operator",
         metavar="",
-        type=int,
+        type=str,
         dest="torch_operator",
         nargs="+",
         action="append",

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -730,6 +730,12 @@ Examples:
         action="store_true",
     )
     analyze_group.add_argument(
+        "--list-torch-operators",
+        dest="list_torch_operators",
+        help="\t\tList all operators from PyTorch trace.",
+        action="store_true",
+    )
+    analyze_group.add_argument(
         "-k",
         "--kernel",
         metavar="",
@@ -738,6 +744,15 @@ Examples:
         nargs="+",
         action="append",
         help="\t\tSpecify kernel id(s) from --list-stats for filtering.",
+    )
+    analyze_group.add_argument(
+        "--torch-operator",
+        metavar="",
+        type=int,
+        dest="torch_operator",
+        nargs="+",
+        action="append",
+        help="\t\tSpecify operator name for filtering.",
     )
     analyze_group.add_argument(
         "-d",

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -736,6 +736,14 @@ Examples:
         action="store_true",
     )
     analyze_group.add_argument(
+        "--torch-operator",
+        metavar="",
+        type=str,
+        dest="torch_operator",
+        nargs="+",
+        help="\t\tSpecify operator name for filtering.",
+    )
+    analyze_group.add_argument(
         "-k",
         "--kernel",
         metavar="",
@@ -744,15 +752,6 @@ Examples:
         nargs="+",
         action="append",
         help="\t\tSpecify kernel id(s) from --list-stats for filtering.",
-    )
-    analyze_group.add_argument(
-        "--torch-operator",
-        metavar="",
-        type=str,
-        dest="torch_operator",
-        nargs="+",
-        action="append",
-        help="\t\tSpecify operator name for filtering.",
     )
     analyze_group.add_argument(
         "-d",

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -211,7 +211,6 @@ class OmniAnalyze_Base:
         print(f"\n{'=' * 80}")
         print(f"PyTorch Operators in: {workload_path}")
         print(f"{'=' * 80}\n")
-        print(f"Found {len(all_operators)} operators:\n")
 
         for i, op in enumerate(all_operators, 1):
             print(f"  {i:3d}. {op}")

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -203,7 +203,7 @@ class OmniAnalyze_Base:
         all_operators = sorted([f.stem for f in torch_trace_dir.glob("*.csv")])
         if not all_operators:
             console_warning(
-                "No PyTorch operator data found"
+                "No PyTorch operator data found. "
                 "Please ensure profiling was done with --torch-trace option."
             )
             return

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -208,69 +208,17 @@ class OmniAnalyze_Base:
                 "with --torch-trace option.",
             )
             return
+        print(f"\n{'=' * 80}")
+        print(f"PyTorch Operators in: {workload_path}")
+        print(f"{'=' * 80}\n")
+        print(f"Found {len(all_operators)} operators:\n")
 
-        # Check if specific operators were requested
-        operator_filter = None
-        if hasattr(self.__args, "torch_operator") and self.__args.torch_operator:
-            # Flatten nested list
-            operator_filter = [
-                item for sublist in self.__args.torch_operator for item in sublist
-            ]
+        for i, op in enumerate(all_operators, 1):
+            print(f"  {i:3d}. {op}")
 
-        if operator_filter:
-            # Show operator→kernel mapping for selected operators
-            print(f"\n{'=' * 80}")
-            print("PyTorch Operator → Kernel Mapping")
-            print(f"{'=' * 80}\n")
-
-            for op_name in operator_filter:
-                op_file = torch_trace_dir / f"{op_name}.csv"
-                if not op_file.exists():
-                    console_warning(f"Operator not found: {op_name}")
-                    continue
-
-                try:
-                    df = pd.read_csv(op_file)
-                    if df.empty:
-                        print(f"\nOperator: {op_name}")
-                        print("  No data available")
-                        continue
-
-                    print(f"\nOperator: {op_name}")
-                    print(f"  Calls: {len(df)}")
-
-                    if "Kernel_Name" in df.columns:
-                        kernels = df["Kernel_Name"].unique()
-                        print(f"  Unique Kernels: {len(kernels)}")
-                        for i, kernel in enumerate(kernels[:10], 1):  # Show first 10
-                            print(f"    {i}. {kernel[:80]}")
-                        if len(kernels) > 10:
-                            print(f"    ... and {len(kernels) - 10} more")
-
-                    if "Duration" in df.columns:
-                        total_time = df["Duration"].sum()
-                        avg_time = df["Duration"].mean()
-                        print(f"  Total Time: {total_time:.2f} ns")
-                        print(f"  Avg Time: {avg_time:.2f} ns")
-
-                except Exception as e:
-                    console_warning(f"Error reading {op_name}: {e}")
-
-            print(f"\n{'=' * 80}\n")
-        else:
-            # List all operators
-            print(f"\n{'=' * 80}")
-            print(f"PyTorch Operators in: {workload_path}")
-            print(f"{'=' * 80}\n")
-            print(f"Found {len(all_operators)} operators:\n")
-
-            for i, op in enumerate(all_operators, 1):
-                print(f"  {i:3d}. {op}")
-
-            print(f"\n{'=' * 80}")
-            print(f"Total: {len(all_operators)} operators")
-            print(f"{'=' * 80}\n")
-
+        print(f"\n{'=' * 80}")
+        print(f"Total: {len(all_operators)} operators")
+        print(f"{'=' * 80}\n")
         sys.exit(0)
 
     @demarcate

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -37,7 +37,7 @@ import pandas as pd
 
 import config
 from rocprof_compute_soc.soc_base import OmniSoC_Base
-from utils import file_io, parser, schema
+from utils import file_io, parser, schema, tty
 from utils.logger import (
     console_debug,
     console_error,
@@ -191,8 +191,6 @@ class OmniAnalyze_Base:
     @demarcate
     def list_torch_operators(self) -> None:
         """List PyTorch operators or show operator-to-kernel mapping and exit."""
-        if not self.__args.path or not self.__args.path[0]:
-            console_error("'--path' to be specified")
         workload_path = (
             self.__args.path[0][0]
             if isinstance(self.__args.path[0], list)
@@ -200,22 +198,28 @@ class OmniAnalyze_Base:
         )
         process_torch_trace_output(workload_path)
         torch_trace_dir = Path(workload_path) / "torch_trace"
-        all_operators = sorted([f.stem for f in torch_trace_dir.glob("*.csv")])
-        if not all_operators:
+        all_files = list(torch_trace_dir.glob("*.csv"))
+        print(f"\n{'=' * 80}")
+        print(f"PyTorch Operators in: {workload_path}")
+        print(f"{'=' * 80}\n")
+        operator_count = 0
+        for f in all_files:
+            try:
+                df = pd.read_csv(f)
+                tty.show_torch_operator_hierarchy(str(f.name).replace(".csv", ""), df)
+                operator_count += 1
+            except Exception as e:
+                console_log(f"Failed to read operator from {f.name}: {e}")
+                sys.exit(1)
+
+        if not operator_count:
             console_warning(
                 "No PyTorch operator data found. "
                 "Please ensure profiling was done with --torch-trace option."
             )
-            return
-        print(f"\n{'=' * 80}")
-        print(f"PyTorch Operators in: {workload_path}")
-        print(f"{'=' * 80}\n")
-
-        for i, op in enumerate(all_operators, 1):
-            print(f"  {i:3d}. {op}")
 
         print(f"\n{'=' * 80}")
-        print(f"Total: {len(all_operators)} operators")
+        print(f"Total: {operator_count} operators")
         print(f"{'=' * 80}\n")
         sys.exit(0)
 

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -197,31 +197,31 @@ class OmniAnalyze_Base:
             self.__args.path[0][0]
             if isinstance(self.__args.path[0], list)
             else self.__args.path[0]
-            )
+        )
         process_torch_trace_output(workload_path)
         torch_trace_dir = Path(workload_path) / "torch_trace"
         all_operators = sorted([f.stem for f in torch_trace_dir.glob("*.csv")])
         if not all_operators:
-            console_warning("No PyTorch operator data found",
-                            "please ensure profiling was done ",
-                            "with --torch-trace option.")
+            console_warning(
+                "No PyTorch operator data found",
+                "please ensure profiling was done ",
+                "with --torch-trace option.",
+            )
             return
 
         # Check if specific operators were requested
         operator_filter = None
-        if hasattr(self.__args, 'torch_operator') and self.__args.torch_operator:
+        if hasattr(self.__args, "torch_operator") and self.__args.torch_operator:
             # Flatten nested list
             operator_filter = [
-                item
-                for sublist in self.__args.torch_operator
-                for item in sublist
-                ]
+                item for sublist in self.__args.torch_operator for item in sublist
+            ]
 
         if operator_filter:
             # Show operator→kernel mapping for selected operators
-            print(f"\n{'='*80}")
+            print(f"\n{'=' * 80}")
             print("PyTorch Operator → Kernel Mapping")
-            print(f"{'='*80}\n")
+            print(f"{'=' * 80}\n")
 
             for op_name in operator_filter:
                 op_file = torch_trace_dir / f"{op_name}.csv"
@@ -256,20 +256,20 @@ class OmniAnalyze_Base:
                 except Exception as e:
                     console_warning(f"Error reading {op_name}: {e}")
 
-            print(f"\n{'='*80}\n")
+            print(f"\n{'=' * 80}\n")
         else:
             # List all operators
-            print(f"\n{'='*80}")
+            print(f"\n{'=' * 80}")
             print(f"PyTorch Operators in: {workload_path}")
-            print(f"{'='*80}\n")
+            print(f"{'=' * 80}\n")
             print(f"Found {len(all_operators)} operators:\n")
 
             for i, op in enumerate(all_operators, 1):
                 print(f"  {i:3d}. {op}")
 
-            print(f"\n{'='*80}")
+            print(f"\n{'=' * 80}")
             print(f"Total: {len(all_operators)} operators")
-            print(f"{'='*80}\n")
+            print(f"{'=' * 80}\n")
 
         sys.exit(0)
 

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -34,7 +34,6 @@ from pathlib import Path
 from typing import Any, Optional, TextIO
 
 import pandas as pd
-from utils.utils import process_torch_trace_output
 
 import config
 from rocprof_compute_soc.soc_base import OmniSoC_Base

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -53,7 +53,7 @@ from utils.utils import (
     is_workload_empty,
     merge_counters_spatial_multiplex,
 )
-
+from utils.utils import process_torch_trace_output
 # the build-in config to list kernel names purpose only
 TOP_STATS_BUILD_IN_CONFIG: OrderedDict[int, dict[str, Any]] = OrderedDict([
     (
@@ -188,6 +188,83 @@ class OmniAnalyze_Base:
         sys.exit(0)
 
     @demarcate
+    def list_torch_operators(self) -> None:
+        """List PyTorch operators or show operator-to-kernel mapping and exit."""
+        if not self.__args.path or not self.__args.path[0]:
+            console_error("--list-torch-operators or --torch-operator requires --path to be specified")
+        
+        workload_path = self.__args.path[0][0] if isinstance(self.__args.path[0], list) else self.__args.path[0]
+        process_torch_trace_output(workload_path)
+        torch_trace_dir = Path(workload_path) / "torch_trace"
+        all_operators = sorted([f.stem for f in torch_trace_dir.glob("*.csv")])
+        if not all_operators:
+            console_warning("No PyTorch operator data found",
+                            "please ensure profiling was done with --torch-trace option.")
+            return
+        
+        # Check if specific operators were requested
+        operator_filter = None
+        if hasattr(self.__args, 'torch_operator') and self.__args.torch_operator:
+            # Flatten nested list
+            operator_filter = [item for sublist in self.__args.torch_operator for item in sublist]
+        
+        if operator_filter:
+            # Show operator→kernel mapping for selected operators
+            print(f"\n{'='*80}")
+            print(f"PyTorch Operator → Kernel Mapping")
+            print(f"{'='*80}\n")
+            
+            for op_name in operator_filter:
+                op_file = torch_trace_dir / f"{op_name}.csv"
+                if not op_file.exists():
+                    console_warning(f"Operator not found: {op_name}")
+                    continue
+                
+                try:
+                    df = pd.read_csv(op_file)
+                    if df.empty:
+                        print(f"\nOperator: {op_name}")
+                        print("  No data available")
+                        continue
+                    
+                    print(f"\nOperator: {op_name}")
+                    print(f"  Calls: {len(df)}")
+                    
+                    if "Kernel_Name" in df.columns:
+                        kernels = df["Kernel_Name"].unique()
+                        print(f"  Unique Kernels: {len(kernels)}")
+                        for i, kernel in enumerate(kernels[:10], 1):  # Show first 10
+                            print(f"    {i}. {kernel[:80]}")
+                        if len(kernels) > 10:
+                            print(f"    ... and {len(kernels) - 10} more")
+                    
+                    if "Duration" in df.columns:
+                        total_time = df["Duration"].sum()
+                        avg_time = df["Duration"].mean()
+                        print(f"  Total Time: {total_time:.2f} ns")
+                        print(f"  Avg Time: {avg_time:.2f} ns")
+                
+                except Exception as e:
+                    console_warning(f"Error reading {op_name}: {e}")
+            
+            print(f"\n{'='*80}\n")
+        else:
+            # List all operators
+            print(f"\n{'='*80}")
+            print(f"PyTorch Operators in: {workload_path}")
+            print(f"{'='*80}\n")
+            print(f"Found {len(all_operators)} operators:\n")
+            
+            for i, op in enumerate(all_operators, 1):
+                print(f"  {i:3d}. {op}")
+            
+            print(f"\n{'='*80}")
+            print(f"Total: {len(all_operators)} operators")
+            print(f"{'='*80}\n")
+        
+        sys.exit(0)
+
+    @demarcate
     def list_blocks(self) -> None:
         args = self.get_args()
         arch = args.list_blocks
@@ -246,6 +323,9 @@ class OmniAnalyze_Base:
 
         if args.list_blocks:
             self.list_blocks()
+
+        if getattr(args, "list_torch_operators", False):
+            self.list_torch_operators()
 
         def get_sysinfo_path(data_path: str) -> Optional[str]:
             return (
@@ -457,6 +537,7 @@ class OmniAnalyze_Base:
             (args.gpu_id, "filter_gpu_ids"),
             (args.gpu_dispatch_id, "filter_dispatch_ids"),
             (args.nodes, "nodes"),
+            (args.torch_operator, "filter_torch_operators"),
         ]
 
         for filter_list, attr_name in filter_configs:

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -52,8 +52,9 @@ from utils.utils import (
     impute_counters_iteration_multiplex,
     is_workload_empty,
     merge_counters_spatial_multiplex,
+    process_torch_trace_output,
 )
-from utils.utils import process_torch_trace_output
+
 # the build-in config to list kernel names purpose only
 TOP_STATS_BUILD_IN_CONFIG: OrderedDict[int, dict[str, Any]] = OrderedDict([
     (
@@ -191,45 +192,53 @@ class OmniAnalyze_Base:
     def list_torch_operators(self) -> None:
         """List PyTorch operators or show operator-to-kernel mapping and exit."""
         if not self.__args.path or not self.__args.path[0]:
-            console_error("--list-torch-operators or --torch-operator requires --path to be specified")
-        
-        workload_path = self.__args.path[0][0] if isinstance(self.__args.path[0], list) else self.__args.path[0]
+            console_error("'--path' to be specified")
+        workload_path = (
+            self.__args.path[0][0]
+            if isinstance(self.__args.path[0], list)
+            else self.__args.path[0]
+            )
         process_torch_trace_output(workload_path)
         torch_trace_dir = Path(workload_path) / "torch_trace"
         all_operators = sorted([f.stem for f in torch_trace_dir.glob("*.csv")])
         if not all_operators:
             console_warning("No PyTorch operator data found",
-                            "please ensure profiling was done with --torch-trace option.")
+                            "please ensure profiling was done ",
+                            "with --torch-trace option.")
             return
-        
+
         # Check if specific operators were requested
         operator_filter = None
         if hasattr(self.__args, 'torch_operator') and self.__args.torch_operator:
             # Flatten nested list
-            operator_filter = [item for sublist in self.__args.torch_operator for item in sublist]
-        
+            operator_filter = [
+                item
+                for sublist in self.__args.torch_operator
+                for item in sublist
+                ]
+
         if operator_filter:
             # Show operator→kernel mapping for selected operators
             print(f"\n{'='*80}")
-            print(f"PyTorch Operator → Kernel Mapping")
+            print("PyTorch Operator → Kernel Mapping")
             print(f"{'='*80}\n")
-            
+
             for op_name in operator_filter:
                 op_file = torch_trace_dir / f"{op_name}.csv"
                 if not op_file.exists():
                     console_warning(f"Operator not found: {op_name}")
                     continue
-                
+
                 try:
                     df = pd.read_csv(op_file)
                     if df.empty:
                         print(f"\nOperator: {op_name}")
                         print("  No data available")
                         continue
-                    
+
                     print(f"\nOperator: {op_name}")
                     print(f"  Calls: {len(df)}")
-                    
+
                     if "Kernel_Name" in df.columns:
                         kernels = df["Kernel_Name"].unique()
                         print(f"  Unique Kernels: {len(kernels)}")
@@ -237,16 +246,16 @@ class OmniAnalyze_Base:
                             print(f"    {i}. {kernel[:80]}")
                         if len(kernels) > 10:
                             print(f"    ... and {len(kernels) - 10} more")
-                    
+
                     if "Duration" in df.columns:
                         total_time = df["Duration"].sum()
                         avg_time = df["Duration"].mean()
                         print(f"  Total Time: {total_time:.2f} ns")
                         print(f"  Avg Time: {avg_time:.2f} ns")
-                
+
                 except Exception as e:
                     console_warning(f"Error reading {op_name}: {e}")
-            
+
             print(f"\n{'='*80}\n")
         else:
             # List all operators
@@ -254,14 +263,14 @@ class OmniAnalyze_Base:
             print(f"PyTorch Operators in: {workload_path}")
             print(f"{'='*80}\n")
             print(f"Found {len(all_operators)} operators:\n")
-            
+
             for i, op in enumerate(all_operators, 1):
                 print(f"  {i:3d}. {op}")
-            
+
             print(f"\n{'='*80}")
             print(f"Total: {len(all_operators)} operators")
             print(f"{'='*80}\n")
-        
+
         sys.exit(0)
 
     @demarcate

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -34,7 +34,7 @@ from pathlib import Path
 from typing import Any, Optional, TextIO
 
 import pandas as pd
-from utils.utils import consolidate_torch_trace_output, process_torch_trace_output
+from utils.utils import process_torch_trace_output
 
 import config
 from rocprof_compute_soc.soc_base import OmniSoC_Base

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -203,9 +203,7 @@ class OmniAnalyze_Base:
         all_operators = sorted([f.stem for f in torch_trace_dir.glob("*.csv")])
         if not all_operators:
             console_warning(
-                "No PyTorch operator data found",
-                "please ensure profiling was done ",
-                "with --torch-trace option.",
+                "No PyTorch operator data found; please ensure profiling was done with --torch-trace option."
             )
             return
         print(f"\n{'=' * 80}")

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import Any, Optional, TextIO
 
 import pandas as pd
+from utils.utils import consolidate_torch_trace_output, process_torch_trace_output
 
 import config
 from rocprof_compute_soc.soc_base import OmniSoC_Base

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -203,7 +203,8 @@ class OmniAnalyze_Base:
         all_operators = sorted([f.stem for f in torch_trace_dir.glob("*.csv")])
         if not all_operators:
             console_warning(
-                "No PyTorch operator data found; please ensure profiling was done with --torch-trace option."
+                "No PyTorch operator data found"
+                "Please ensure profiling was done with --torch-trace option."
             )
             return
         print(f"\n{'=' * 80}")

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -23,7 +23,6 @@
 
 ##############################################################################
 
-
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
 from utils import file_io, parser, tty
 from utils.kernel_name_shortener import kernel_name_shortener

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -103,6 +103,13 @@ class cli_analysis(OmniAnalyze_Base):
         arch_config = self._arch_configs[gpu_arch]
 
         if getattr(args, "torch_operator", False) and workload.filter_torch_operators:
+            if not workload.filter_torch_operators:
+                console_error(
+                    "No torch operators found in the profiling data. "
+                    "Please ensure that profile mode is run with '--torch-trace' and"
+                    "analyze mode is run with '--list-torch-operators' flag"
+                    "before using '--torch-operator'."
+                )
             for op in workload.filter_torch_operators:
                 df = workload.torch_operators.get(op)
                 if df is not None:

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -108,6 +108,7 @@ class cli_analysis(OmniAnalyze_Base):
                     "analyze mode is run with '--list-torch-operators' flag"
                     " analyze mode is run with '--list-torch-operators' flag"
                     " before using '--torch-operator'."
+                )
             for op in workload.filter_torch_operators:
                 df = workload.torch_operators.get(op)
                 if df is not None:

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -23,12 +23,13 @@
 
 ##############################################################################
 
+
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
 from utils import file_io, parser, tty
 from utils.kernel_name_shortener import kernel_name_shortener
 from utils.logger import console_error, demarcate
-from pathlib import Path
 from utils.utils import process_torch_trace_output
+
 
 class cli_analysis(OmniAnalyze_Base):
     # -----------------------

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -104,9 +104,9 @@ class cli_analysis(OmniAnalyze_Base):
             if not workload.filter_torch_operators:
                 console_error(
                     "No torch operators found in the profiling data. "
-                    'Please ensure that workload is profiled with "--torch-trace" option'
-                    ' and analyze mode is run with "--list-torch-operators" option'
-                    ' before using "--torch-operator" in analyze mode.'
+                    'Please ensure that workload is profiled with "--torch-trace"'
+                    'option and analyze mode is run with "--list-torch-operators"'
+                    'option before using "--torch-operator" in analyze mode.'
                 )
             for op in workload.filter_torch_operators:
                 df = workload.torch_operators.get(op)

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -105,7 +105,6 @@ class cli_analysis(OmniAnalyze_Base):
                 console_error(
                     "No torch operators found in the profiling data. "
                     "Please ensure that profile mode is run with '--torch-trace' and"
-                    "analyze mode is run with '--list-torch-operators' flag"
                     " analyze mode is run with '--list-torch-operators' flag"
                     " before using '--torch-operator'."
                 )

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -26,7 +26,7 @@
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
 from utils import file_io, parser, tty
 from utils.kernel_name_shortener import kernel_name_shortener
-from utils.logger import console_error, demarcate
+from utils.logger import console_error, console_log, demarcate
 
 
 class cli_analysis(OmniAnalyze_Base):
@@ -104,16 +104,16 @@ class cli_analysis(OmniAnalyze_Base):
             if not workload.filter_torch_operators:
                 console_error(
                     "No torch operators found in the profiling data. "
-                    "Please ensure that profile mode is run with '--torch-trace' and"
-                    " analyze mode is run with '--list-torch-operators' flag"
-                    " before using '--torch-operator'."
+                    'Please ensure that workload is profiled with "--torch-trace" option'
+                    ' and analyze mode is run with "--list-torch-operators" option'
+                    ' before using "--torch-operator" in analyze mode.'
                 )
             for op in workload.filter_torch_operators:
                 df = workload.torch_operators.get(op)
                 if df is not None:
                     tty.show_torch_operator_hierarchy(op, df)
                 else:
-                    print(f"No data for operator: {op}")
+                    console_log(f"No data for operator: {op}")
 
         if args.list_stats:
             tty.show_kernel_stats(

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -108,12 +108,34 @@ class cli_analysis(OmniAnalyze_Base):
                     'option and analyze mode is run with "--list-torch-operators"'
                     'option before using "--torch-operator" in analyze mode.'
                 )
-            for op in workload.filter_torch_operators:
-                df = workload.torch_operators.get(op)
-                if df is not None:
-                    tty.show_torch_operator_hierarchy(op, df)
+
+            operator_args = getattr(args, "torch_operator", [])
+            operator_list = []
+            for op in operator_args:
+                # Support comma-separated or space-separated input
+                operator_list.extend([
+                    o.strip() for o in str(op).split(",") if o.strip()
+                ])
+            operator_list = [o for o in operator_list if o]
+
+            for op in operator_list:
+                if "/" in op:
+                    # Hierarchy case: last part is operator name, rest is hierarchy
+                    hierarchy = op
+                    op_name = hierarchy.split("/")[-1]
+                    df = workload.torch_operators.get(op_name)
+                    if df is not None:
+                        filtered_df = df[df["Operator_Name"] == hierarchy]
+                        tty.show_torch_operator_table(hierarchy, filtered_df)
+                    else:
+                        console_log(f"No data for operator: {hierarchy}")
                 else:
-                    console_log(f"No data for operator: {op}")
+                    # Simple operator case
+                    df = workload.torch_operators.get(op)
+                    if df is not None:
+                        tty.show_torch_operator_table(op, df)
+                    else:
+                        console_log(f"No data for operator: {op}")
 
         if args.list_stats:
             tty.show_kernel_stats(

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -24,7 +24,6 @@
 ##############################################################################
 
 
-
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
 from utils import file_io, parser, tty
 from utils.kernel_name_shortener import kernel_name_shortener

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -24,12 +24,12 @@
 ##############################################################################
 
 
-from pathlib import Path
 
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
 from utils import file_io, parser, tty
 from utils.kernel_name_shortener import kernel_name_shortener
 from utils.logger import console_error, demarcate
+
 
 class cli_analysis(OmniAnalyze_Base):
     # -----------------------

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -27,7 +27,8 @@ from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
 from utils import file_io, parser, tty
 from utils.kernel_name_shortener import kernel_name_shortener
 from utils.logger import console_error, demarcate
-
+from pathlib import Path
+from utils.utils import consolidate_torch_trace_output, process_torch_trace_output
 
 class cli_analysis(OmniAnalyze_Base):
     # -----------------------
@@ -99,6 +100,11 @@ class cli_analysis(OmniAnalyze_Base):
         workload = self._runs[workload_path]
         gpu_arch = workload.sys_info.iloc[0]["gpu_arch"]
         arch_config = self._arch_configs[gpu_arch]
+
+        if getattr(args, "list_torch_operators", False):
+            if workload_path.exists() is False:
+                console_error(f"Workload path does not exist: {workload_path}")
+            process_torch_trace_output(workload)
 
         if args.list_stats:
             tty.show_kernel_stats(

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -28,7 +28,7 @@ from utils import file_io, parser, tty
 from utils.kernel_name_shortener import kernel_name_shortener
 from utils.logger import console_error, demarcate
 from pathlib import Path
-from utils.utils import consolidate_torch_trace_output, process_torch_trace_output
+from utils.utils import process_torch_trace_output
 
 class cli_analysis(OmniAnalyze_Base):
     # -----------------------

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -103,9 +103,9 @@ class cli_analysis(OmniAnalyze_Base):
         arch_config = self._arch_configs[gpu_arch]
 
         if getattr(args, "list_torch_operators", False):
-            if workload_path.exists() is False:
+            if Path(workload_path).exists() is False:
                 console_error(f"Workload path does not exist: {workload_path}")
-            process_torch_trace_output(workload)
+            process_torch_trace_output(str(workload_path))
 
         if args.list_stats:
             tty.show_kernel_stats(

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -24,6 +24,8 @@
 ##############################################################################
 
 
+from pathlib import Path
+
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
 from utils import file_io, parser, tty
 from utils.kernel_name_shortener import kernel_name_shortener

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -100,7 +100,7 @@ class cli_analysis(OmniAnalyze_Base):
         gpu_arch = workload.sys_info.iloc[0]["gpu_arch"]
         arch_config = self._arch_configs[gpu_arch]
 
-        if getattr(args, "torch_operator", False) and workload.filter_torch_operators:
+        if getattr(args, "torch_operator", False):
             if not workload.filter_torch_operators:
                 console_error(
                     "No torch operators found in the profiling data. "

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -30,8 +30,6 @@ from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
 from utils import file_io, parser, tty
 from utils.kernel_name_shortener import kernel_name_shortener
 from utils.logger import console_error, demarcate
-from utils.utils import process_torch_trace_output
-
 
 class cli_analysis(OmniAnalyze_Base):
     # -----------------------
@@ -104,10 +102,13 @@ class cli_analysis(OmniAnalyze_Base):
         gpu_arch = workload.sys_info.iloc[0]["gpu_arch"]
         arch_config = self._arch_configs[gpu_arch]
 
-        if getattr(args, "list_torch_operators", False):
-            if Path(workload_path).exists() is False:
-                console_error(f"Workload path does not exist: {workload_path}")
-            process_torch_trace_output(str(workload_path))
+        if getattr(args, "torch_operator", False) and workload.filter_torch_operators:
+            for op in workload.filter_torch_operators:
+                df = workload.torch_operators.get(op)
+                if df is not None:
+                    tty.show_torch_operator_hierarchy(op, df)
+                else:
+                    print(f"No data for operator: {op}")
 
         if args.list_stats:
             tty.show_kernel_stats(

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -106,8 +106,8 @@ class cli_analysis(OmniAnalyze_Base):
                     "No torch operators found in the profiling data. "
                     "Please ensure that profile mode is run with '--torch-trace' and"
                     "analyze mode is run with '--list-torch-operators' flag"
-                    "before using '--torch-operator'."
-                )
+                    " analyze mode is run with '--list-torch-operators' flag"
+                    " before using '--torch-operator'."
             for op in workload.filter_torch_operators:
                 df = workload.torch_operators.get(op)
                 if df is not None:

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -59,7 +59,6 @@ from utils.utils import (
     replace_rank,
     set_locale_encoding,
 )
-from utils.utils import process_torch_trace_output
 
 class RocProfCompute:
     def __init__(self) -> None:
@@ -338,11 +337,6 @@ class RocProfCompute:
 
     def handle_analyze_args(self) -> None:
         """Handle analyze-specific argument processing"""
-        # Handle list operations first - they exit immediately
-        if getattr(self.__args, "list_torch_operators", False):
-            process_torch_trace_output(self.__args.path[0][0])
-            self.list_torch_operators()
-            return
         # Block all filters during spatial-multiplexing
         if self.__args.spatial_multiplexing:
             self.__args.gpu_id = None

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -59,7 +59,7 @@ from utils.utils import (
     replace_rank,
     set_locale_encoding,
 )
-
+from utils.utils import process_torch_trace_output
 
 class RocProfCompute:
     def __init__(self) -> None:
@@ -338,6 +338,11 @@ class RocProfCompute:
 
     def handle_analyze_args(self) -> None:
         """Handle analyze-specific argument processing"""
+        # Handle list operations first - they exit immediately
+        if getattr(self.__args, "list_torch_operators", False):
+            process_torch_trace_output(self.__args.path[0][0])
+            self.list_torch_operators()
+            return
         # Block all filters during spatial-multiplexing
         if self.__args.spatial_multiplexing:
             self.__args.gpu_id = None

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -60,6 +60,7 @@ from utils.utils import (
     set_locale_encoding,
 )
 
+
 class RocProfCompute:
     def __init__(self) -> None:
         self.__args: Optional[argparse.Namespace] = None

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprof_v3.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprof_v3.py
@@ -136,10 +136,6 @@ class rocprof_v3_profiler(RocProfCompute_Base):
         if self.ready_to_profile:
             # Manually join each pmc_perf*.csv output
             self.join_prof()
-            # Consolidate torch trace output if --torch-trace was used
-            # if self.get_args().torch_trace:
-            #     consolidate_torch_trace_output(self.get_args().path)
-
             # Run roofline microbenchmark
             super().post_processing()
         else:

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprof_v3.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprof_v3.py
@@ -31,6 +31,7 @@ from rocprof_compute_profile.profiler_base import RocProfCompute_Base
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import console_error, console_log, demarcate
 
+
 class rocprof_v3_profiler(RocProfCompute_Base):
     def __init__(
         self,

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprof_v3.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprof_v3.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from rocprof_compute_profile.profiler_base import RocProfCompute_Base
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import console_error, console_log, demarcate
+
 # from utils.utils import consolidate_torch_trace_output
 
 

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprof_v3.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprof_v3.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from rocprof_compute_profile.profiler_base import RocProfCompute_Base
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import console_error, console_log, demarcate
-from utils.utils import consolidate_torch_trace_output
+# from utils.utils import consolidate_torch_trace_output
 
 
 class rocprof_v3_profiler(RocProfCompute_Base):
@@ -136,8 +136,8 @@ class rocprof_v3_profiler(RocProfCompute_Base):
             # Manually join each pmc_perf*.csv output
             self.join_prof()
             # Consolidate torch trace output if --torch-trace was used
-            if self.get_args().torch_trace:
-                consolidate_torch_trace_output(self.get_args().path)
+            # if self.get_args().torch_trace:
+            #     consolidate_torch_trace_output(self.get_args().path)
 
             # Run roofline microbenchmark
             super().post_processing()

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprof_v3.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprof_v3.py
@@ -31,9 +31,6 @@ from rocprof_compute_profile.profiler_base import RocProfCompute_Base
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import console_error, console_log, demarcate
 
-# from utils.utils import consolidate_torch_trace_output
-
-
 class rocprof_v3_profiler(RocProfCompute_Base):
     def __init__(
         self,

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
@@ -32,6 +32,7 @@ from rocprof_compute_profile.profiler_base import RocProfCompute_Base
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import console_error, console_log, demarcate
 
+
 class rocprofiler_sdk_profiler(RocProfCompute_Base):
     def __init__(
         self,

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
@@ -165,9 +165,6 @@ class rocprofiler_sdk_profiler(RocProfCompute_Base):
         if self.ready_to_profile:
             # Manually join each pmc_perf*.csv output
             self.join_prof()
-            # if self.get_args().torch_trace:
-            #     consolidate_torch_trace_output(self.get_args().path)
-
             # Run roofline microbenchmark
             super().post_processing()
         else:

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
@@ -31,7 +31,7 @@ from typing import Optional, Union
 from rocprof_compute_profile.profiler_base import RocProfCompute_Base
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import console_error, console_log, demarcate
-from utils.utils import consolidate_torch_trace_output
+# from utils.utils import consolidate_torch_trace_output
 
 
 class rocprofiler_sdk_profiler(RocProfCompute_Base):
@@ -164,8 +164,8 @@ class rocprofiler_sdk_profiler(RocProfCompute_Base):
         if self.ready_to_profile:
             # Manually join each pmc_perf*.csv output
             self.join_prof()
-            if self.get_args().torch_trace:
-                consolidate_torch_trace_output(self.get_args().path)
+            # if self.get_args().torch_trace:
+            #     consolidate_torch_trace_output(self.get_args().path)
 
             # Run roofline microbenchmark
             super().post_processing()

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
@@ -32,9 +32,6 @@ from rocprof_compute_profile.profiler_base import RocProfCompute_Base
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import console_error, console_log, demarcate
 
-# from utils.utils import consolidate_torch_trace_output
-
-
 class rocprofiler_sdk_profiler(RocProfCompute_Base):
     def __init__(
         self,

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
@@ -31,6 +31,7 @@ from typing import Optional, Union
 from rocprof_compute_profile.profiler_base import RocProfCompute_Base
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import console_error, console_log, demarcate
+
 # from utils.utils import consolidate_torch_trace_output
 
 

--- a/projects/rocprofiler-compute/src/utils/inject_roctx.py
+++ b/projects/rocprofiler-compute/src/utils/inject_roctx.py
@@ -37,9 +37,7 @@ from pathlib import Path
 # Add parent directory to Python path for config module
 script_dir = Path(__file__).resolve().parent
 sys.path.insert(0, str(script_dir.parent))
-
-from utils.logger import console_log, console_warning
-
+# Attempt to load ROCTX module from ROCm installation
 rocm_root = os.environ.get("ROCM_PATH", "/opt/rocm")
 python_version = f"python{sys.version_info.major}.{sys.version_info.minor}"
 candidate_paths = [
@@ -51,8 +49,31 @@ for candidate in candidate_paths:
     if candidate not in sys.path:
         sys.path.insert(0, candidate)
 
+from utils.logger import console_error, console_log, console_warning
+
+console_log("torch trace", f"Python version: {python_version}")
+
+try:
+    from roctx import rangePop, rangePush
+
+    console_log(
+        "torch trace",
+        f"ROCTX module loaded from: {Path(rangePush.__code__.co_filename).parent}",
+    )
+except ImportError:
+    console_error(
+        f"Looked for Roctx in :{candidate_paths}"
+        "ROCTX Python module not found.\n"
+        "Please ensure that the rocprofiler-sdk is installed"
+        " and that the roctx Python bindings are available for your Python version."
+        "You may need to reinstall or rebuild ROCm for your current Python environment.\n"
+        "The --torch-trace option requires a valid roctx installation.\n",
+    )
+    sys.exit(1)
+
 try:
     import torch
+    import torch._C
 
     console_log(f"PyTorch version: {torch.__version__}")
 except ImportError:
@@ -68,7 +89,173 @@ import inspect
 from functools import wraps
 
 import torch.nn.functional as F
-from roctx import rangePop, rangePush
+
+import threading
+
+# Thread-local stacks for hierarchical marker names
+_thread_local = threading.local()
+
+
+def get_marker_stack():
+    if not hasattr(_thread_local, "marker_stack"):
+        _thread_local.marker_stack = []
+    return _thread_local.marker_stack
+
+
+def get_context_stack():
+    if not hasattr(_thread_local, "context_stack"):
+        _thread_local.context_stack = []
+    return _thread_local.context_stack
+
+
+if hasattr(torch._C, "_dispatch_call"):
+    original_dispatch_call = torch._C._dispatch_call
+
+    def dispatch_call_with_roctx(*args, **kwargs):
+        marker_stack = get_marker_stack()
+        context_stack = get_context_stack()
+        op_name = str(args[0]) if args else "aten_op"
+        marker_stack.append(f"aten::{op_name}")
+        # Use call count and caller location for context, similar to other wrappers
+        current_frame = inspect.currentframe()
+        caller_frame = current_frame.f_back if current_frame is not None else None
+        if caller_frame is not None:
+            filename = caller_frame.f_code.co_filename
+            location = f"{Path(filename).name}:{caller_frame.f_lineno}"
+        else:
+            location = "unknown:0"
+        # Optionally, use a call counter (not strictly necessary, but for consistency)
+        if not hasattr(dispatch_call_with_roctx, "_call_count"):
+            dispatch_call_with_roctx._call_count = 0
+        dispatch_call_with_roctx._call_count += 1
+        context_stack.append(f"#{dispatch_call_with_roctx._call_count}@{location}")
+        full_marker_name = "/".join(marker_stack) + ":" + "/".join(context_stack)
+        rangePush(full_marker_name)
+        # using try / finally to ensure rangePop is called.
+        try:
+            return original_dispatch_call(*args, **kwargs)
+        except Exception as e:
+            console_warning("torch trace", f"Error in {full_marker_name}: {e}")
+            console_warning(
+                "torch trace", "Cannot inject ROCTX markers for torch._C._dispatch_call"
+            )
+        finally:
+            rangePop()
+            marker_stack.pop()
+            context_stack.pop()
+
+    torch._C._dispatch_call = dispatch_call_with_roctx
+else:
+    console_log("torch._C._dispatch_call not found; skipping dispatcher patching.")
+
+try:
+    import torchvision
+
+    original_tv_dispatch_call = torchvision._C._dispatch_call
+
+    def tv_dispatch_call_with_roctx(*args, **kwargs):
+        marker_stack = get_marker_stack()
+        context_stack = get_context_stack()
+        op_name = str(args[0]) if args else "vision_op"
+        marker_stack.append(f"torchvision::{op_name}")
+
+        current_frame = inspect.currentframe()
+        caller_frame = current_frame.f_back if current_frame is not None else None
+        if caller_frame is not None:
+            filename = caller_frame.f_code.co_filename
+            location = f"{Path(filename).name}:{caller_frame.f_lineno}"
+        else:
+            location = "unknown:0"
+
+        if not hasattr(tv_dispatch_call_with_roctx, "_call_count"):
+            tv_dispatch_call_with_roctx._call_count = 0
+        tv_dispatch_call_with_roctx._call_count += 1
+        context_stack.append(f"#{tv_dispatch_call_with_roctx._call_count}@{location}")
+
+        full_marker_name = "/".join(marker_stack) + ":" + "/".join(context_stack)
+        rangePush(full_marker_name)
+        try:
+            return original_tv_dispatch_call(*args, **kwargs)
+        finally:
+            rangePop()
+            marker_stack.pop()
+            context_stack.pop()
+
+    torchvision._C._dispatch_call = tv_dispatch_call_with_roctx
+except Exception:
+    pass  # torchvision not installed or no _C._dispatch_call
+
+try:
+    import torch.distributed as dist
+
+    original_all_reduce = dist.all_reduce
+
+    def all_reduce_with_roctx(*args, **kwargs):
+        marker_stack = get_marker_stack()
+        context_stack = get_context_stack()
+        marker_stack.append("torch.distributed.all_reduce")
+
+        current_frame = inspect.currentframe()
+        caller_frame = current_frame.f_back if current_frame is not None else None
+        if caller_frame is not None:
+            filename = caller_frame.f_code.co_filename
+            location = f"{Path(filename).name}:{caller_frame.f_lineno}"
+        else:
+            location = "unknown:0"
+
+        if not hasattr(all_reduce_with_roctx, "_call_count"):
+            all_reduce_with_roctx._call_count = 0
+        all_reduce_with_roctx._call_count += 1
+        context_stack.append(f"#{all_reduce_with_roctx._call_count}@{location}")
+
+        full_marker_name = "/".join(marker_stack) + ":" + "/".join(context_stack)
+        rangePush(full_marker_name)
+        try:
+            return original_all_reduce(*args, **kwargs)
+        finally:
+            rangePop()
+            marker_stack.pop()
+            context_stack.pop()
+
+    dist.all_reduce = all_reduce_with_roctx
+except Exception as e:
+    console_warning("torch trace", f"Could not patch torch.distributed.all_reduce: {e}")
+
+try:
+    import torch.cuda
+
+    original_set_device = torch.cuda.set_device
+
+    def set_device_with_roctx(*args, **kwargs):
+        marker_stack = get_marker_stack()
+        context_stack = get_context_stack()
+        marker_stack.append("torch.cuda.set_device")
+
+        current_frame = inspect.currentframe()
+        caller_frame = current_frame.f_back if current_frame is not None else None
+        if caller_frame is not None:
+            filename = caller_frame.f_code.co_filename
+            location = f"{Path(filename).name}:{caller_frame.f_lineno}"
+        else:
+            location = "unknown:0"
+
+        if not hasattr(set_device_with_roctx, "_call_count"):
+            set_device_with_roctx._call_count = 0
+        set_device_with_roctx._call_count += 1
+        context_stack.append(f"#{set_device_with_roctx._call_count}@{location}")
+
+        full_marker_name = "/".join(marker_stack) + ":" + "/".join(context_stack)
+        rangePush(full_marker_name)
+        try:
+            return original_set_device(*args, **kwargs)
+        finally:
+            rangePop()
+            marker_stack.pop()
+            context_stack.pop()
+
+    torch.cuda.set_device = set_device_with_roctx
+except Exception:
+    pass
 
 
 def roctx_wrapper(func, name=None):
@@ -86,12 +273,20 @@ def roctx_wrapper(func, name=None):
         else:
             location = "unknown:0"
 
-        # Unique marker: function + call_number + source_location
-        rangePush(f"{func_name}:#{call_counter['count']}@{location}")
+        # Build hierarchical marker name with separate context
+        marker_stack = get_marker_stack()
+        context_stack = get_context_stack()
+        marker_stack.append(func_name)
+        context_stack.append(f"#{call_counter['count']}@{location}")
+        full_marker_name = "/".join(marker_stack) + ":" + "/".join(context_stack)
+
+        rangePush(full_marker_name)
         try:
             result = func(*args, **kwargs)
         finally:
             rangePop()
+            marker_stack.pop()
+            context_stack.pop()
         return result
 
     return wrapper
@@ -190,14 +385,21 @@ def inject_roctx_into_torch():
         else:
             location = "unknown:0"
 
-        rangePush(f"torch.Tensor.backward:#{backward_counter['count']}@{location}")
+        marker_stack = get_marker_stack()
+        context_stack = get_context_stack()
+        marker_stack.append("torch.Tensor.backward")
+        context_stack.append(f"#{backward_counter['count']}@{location}")
+        full_marker_name = "/".join(marker_stack) + ":" + "/".join(context_stack)
+
+        rangePush(full_marker_name)
         try:
             return original_backward(self, *args, **kwargs)
         finally:
             rangePop()
+            marker_stack.pop()
+            context_stack.pop()
 
     torch.Tensor.backward = backward_with_roctx
-
     wrapped_count += 1
     console_log("Wrapped: torch.Tensor.backward")
 
@@ -215,11 +417,31 @@ def inject_roctx_into_optimizer():
     original_step = Optimizer.step
 
     def step_with_roctx(self, *args, **kwargs):
-        rangePush(f"optimizer.{self.__class__.__name__}.step")
+        marker_stack = get_marker_stack()
+        context_stack = get_context_stack()
+        marker_stack.append(f"optimizer.{self.__class__.__name__}.step")
+
+        current_frame = inspect.currentframe()
+        caller_frame = current_frame.f_back if current_frame is not None else None
+        if caller_frame is not None:
+            filename = caller_frame.f_code.co_filename
+            location = f"{Path(filename).name}:{caller_frame.f_lineno}"
+        else:
+            location = "unknown:0"
+
+        if not hasattr(self, "_roctx_step_call_count"):
+            self._roctx_step_call_count = 0
+        self._roctx_step_call_count += 1
+        context_stack.append(f"#{self._roctx_step_call_count}@{location}")
+
+        full_marker_name = "/".join(marker_stack) + ":" + "/".join(context_stack)
+        rangePush(full_marker_name)
         try:
             return original_step(self, *args, **kwargs)
         finally:
             rangePop()
+            marker_stack.pop()
+            context_stack.pop()
 
     Optimizer.step = step_with_roctx
     console_log("Wrapped optimizer.step() with ROCTX markers\n")
@@ -229,20 +451,16 @@ def inject_roctx_into_model():
     """Wrap nn.Module forward() method with call counter."""
 
     from torch import nn
-    from typing import Any
 
     original_call = nn.Module.__call__
 
     # Per-instance call counters
     def call_with_roctx(self, *args, **kwargs):
         class_name = self.__class__.__name__
-
-        # Initialize counter for this instance if not exists
         if not hasattr(self, "_roctx_call_count"):
             self._roctx_call_count = 0
         self._roctx_call_count += 1
 
-        # Get caller location
         current_frame = inspect.currentframe()
         caller_frame = current_frame.f_back if current_frame is not None else None
         if caller_frame is not None:
@@ -251,17 +469,94 @@ def inject_roctx_into_model():
         else:
             location = "unknown:0"
 
-        # Create detailed marker
-        rangePush(
-            f"nn.Module.{class_name}.forward:#{self._roctx_call_count}@{location}"
-        )
+        marker_stack = get_marker_stack()
+        context_stack = get_context_stack()
+        marker_stack.append(f"nn.Module.{class_name}.forward")
+        context_stack.append(f"#{self._roctx_call_count}@{location}")
+        full_marker_name = "/".join(marker_stack) + ":" + "/".join(context_stack)
+
+        rangePush(full_marker_name)
         try:
             return original_call(self, *args, **kwargs)
         finally:
             rangePop()
+            marker_stack.pop()
+            context_stack.pop()
 
     nn.Module.__call__ = call_with_roctx
     console_log("Wrapped nn.Module forward() with ROCTX markers\n")
+
+
+def instrument_all_torch_ops():
+    # Base operator namespaces to instrument across backends
+    op_namespaces = ["aten", "quantized", "ml", "prims"]
+    # Only include NVIDIA-specific nvfuser ops when running on a CUDA build
+    torch_version = getattr(torch, "version", None)
+    cuda_version = (
+        getattr(torch_version, "cuda", None) if torch_version is not None else None
+    )
+    hip_version = (
+        getattr(torch_version, "hip", None) if torch_version is not None else None
+    )
+    if cuda_version is not None and hip_version is None:
+        op_namespaces.append("nvfuser")
+    wrapped_count = 0
+    failed_count = 0
+
+    console_log("Instrumenting torch.ops namespace for C++ ATen operations...")
+    for ns in op_namespaces:
+        ops = getattr(torch.ops, ns, None)
+        if ops is None:
+            continue
+        ns_count = 0
+        for op_name in dir(ops):
+            if op_name.startswith("__"):
+                continue
+            try:
+                op = getattr(ops, op_name, None)
+                if not callable(op):
+                    continue
+                if hasattr(op, "_roctx_wrapped"):
+                    continue
+
+                def make_wrapper(original_op, namespace, operation_name):
+                    def wrapper(*args, **kwargs):
+                        marker_name = f"torch.ops.{namespace}.{operation_name}"
+                        marker_stack = get_marker_stack()
+                        context_stack = get_context_stack()
+                        marker_stack.append(marker_name)
+                        # Filter empty strings from context_stack
+                        filtered_context = [c for c in context_stack if c]
+                        full_marker_name = "/".join(marker_stack) + (
+                            ":" + "/".join(filtered_context) if filtered_context else ""
+                        )
+
+                        rangePush(full_marker_name)
+                        try:
+                            return original_op(*args, **kwargs)
+                        finally:
+                            rangePop()
+                            marker_stack.pop()
+
+                    wrapper._roctx_wrapped = True
+                    return wrapper
+
+                wrapped_op = make_wrapper(op, ns, op_name)
+                setattr(ops, op_name, wrapped_op)
+                wrapped_count += 1
+                ns_count += 1
+            except Exception as e:
+                failed_count += 1
+                if failed_count <= 10:
+                    console_log(f"  Failed to wrap {ns}.{op_name}: {e}")
+
+        if ns_count > 0:
+            console_log(f"  Wrapped {ns_count} operations in torch.ops.{ns}")
+
+    console_log(f"[ROCTX] Total: {wrapped_count} torch.ops operations wrapped")
+    if failed_count > 0:
+        console_log(f"[ROCTX] ({failed_count} operations failed to wrap)")
+    console_log("")
 
 
 if __name__ == "__main__":
@@ -277,6 +572,7 @@ if __name__ == "__main__":
     inject_roctx_into_torch()
     inject_roctx_into_optimizer()
     inject_roctx_into_model()
+    instrument_all_torch_ops()
 
     console_log("=" * 70)
     console_log("Starting target script with ROCTX instrumentation...")

--- a/projects/rocprofiler-compute/src/utils/parser.py
+++ b/projects/rocprofiler-compute/src/utils/parser.py
@@ -2026,6 +2026,7 @@ def load_non_mertrics_table(
 
     workload.dfs.update(tmp)
 
+
 @demarcate
 def load_torch_trace_data(workload: schema.Workload, dir_path: str) -> None:
     """
@@ -2042,6 +2043,7 @@ def load_torch_trace_data(workload: schema.Workload, dir_path: str) -> None:
                 workload.torch_operators[operator_name] = df
             except Exception as e:
                 console_warning(f"Could not load {csv_file}: {e}")
+
 
 @demarcate
 def load_table_data(

--- a/projects/rocprofiler-compute/src/utils/parser.py
+++ b/projects/rocprofiler-compute/src/utils/parser.py
@@ -2026,6 +2026,21 @@ def load_non_mertrics_table(
 
     workload.dfs.update(tmp)
 
+@demarcate
+def load_torch_trace_data(workload, dir_path):
+    """
+    Loads all torch operator CSVs from torch_trace directory into workload.torch_operators.
+    """
+    torch_trace_dir = Path(dir_path) / "torch_trace"
+    workload.torch_operators = {}
+    if torch_trace_dir.exists() and torch_trace_dir.is_dir():
+        for csv_file in torch_trace_dir.glob("*.csv"):
+            operator_name = csv_file.stem  # filename without .csv
+            try:
+                df = pd.read_csv(csv_file)
+                workload.torch_operators[operator_name] = df
+            except Exception as e:
+                console_warning(f"Could not load {csv_file}: {e}")
 
 @demarcate
 def load_table_data(
@@ -2044,6 +2059,9 @@ def load_table_data(
     if not skip_kernel_top:
         load_non_mertrics_table(workload, dir_path, args)
 
+    # Load torch operator trace data if present
+    load_torch_trace_data(workload, dir_path)
+    
     eval_metric(
         workload.dfs,
         workload.dfs_type,

--- a/projects/rocprofiler-compute/src/utils/parser.py
+++ b/projects/rocprofiler-compute/src/utils/parser.py
@@ -2027,9 +2027,10 @@ def load_non_mertrics_table(
     workload.dfs.update(tmp)
 
 @demarcate
-def load_torch_trace_data(workload, dir_path):
+def load_torch_trace_data(workload: schema.Workload, dir_path: str) -> None:
     """
-    Loads all torch operator CSVs from torch_trace directory into workload.torch_operators.
+    Loads all torch operator CSVs from torch_trace directory
+    into workload.torch_operators.
     """
     torch_trace_dir = Path(dir_path) / "torch_trace"
     workload.torch_operators = {}
@@ -2061,7 +2062,7 @@ def load_table_data(
 
     # Load torch operator trace data if present
     load_torch_trace_data(workload, dir_path)
-    
+
     eval_metric(
         workload.dfs,
         workload.dfs_type,

--- a/projects/rocprofiler-compute/src/utils/schema.py
+++ b/projects/rocprofiler-compute/src/utils/schema.py
@@ -69,7 +69,7 @@ class Workload:
     path: str = field(default_factory=str)
     filter_top_n: str = field(default_factory=str)
     torch_operators: dict[str, pd.DataFrame] = field(default_factory=dict)
-
+    filter_torch_operators: list[str] = field(default_factory=list)
 
 # Metrics will be calculated ONLY when the header(key) is in below list
 SUPPORTED_FIELD = [

--- a/projects/rocprofiler-compute/src/utils/schema.py
+++ b/projects/rocprofiler-compute/src/utils/schema.py
@@ -68,6 +68,7 @@ class Workload:
     roofline_metrics: dict[int, dict[str, Any]] = field(default_factory=dict)
     path: str = field(default_factory=str)
     filter_top_n: str = field(default_factory=str)
+    torch_operators: dict[str, pd.DataFrame] = field(default_factory=dict)
 
 
 # Metrics will be calculated ONLY when the header(key) is in below list

--- a/projects/rocprofiler-compute/src/utils/schema.py
+++ b/projects/rocprofiler-compute/src/utils/schema.py
@@ -71,6 +71,7 @@ class Workload:
     torch_operators: dict[str, pd.DataFrame] = field(default_factory=dict)
     filter_torch_operators: list[str] = field(default_factory=list)
 
+
 # Metrics will be calculated ONLY when the header(key) is in below list
 SUPPORTED_FIELD = [
     "Value",

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -280,7 +280,7 @@ def show_torch_operator_hierarchy(operator_name: str, df: pd.DataFrame) -> None:
     Display the hierarchy for each unique operator name in the DataFrame,
     showing marker hierarchy on the left and kernel launches on the right.
     """
-    print(f"\n" + "-" * 80)
+    print(f"\n{'-' * 80}")
     print("Marker Hierarchy (Stack)".ljust(40) + "Kernel Launches")
     print("-" * 80)
 

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -242,6 +242,7 @@ def is_roofline_shown(
         show_roof_plot(roof_plot)
     return True
 
+
 def show_torch_operator_hierarchy(operator_name: str, df: pd.DataFrame) -> None:
     """
     Display the hierarchy for each unique operator name in the DataFrame.

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -275,76 +275,139 @@ def extract_kernel_name(full_kernel_name: str) -> str:
     return main_part.strip()
 
 
+def show_torch_operator_table(operator_name: str, df: pd.DataFrame) -> None:
+    """Display torch operator data in a properly formatted table."""
+    if df is None or df.empty:
+        console_log(f"No data available for operator: {operator_name}")
+        return
+
+    console_log(f"\n{operator_name}")
+    console_log("=" * len(operator_name))
+
+    # Create a copy for display formatting
+    display_df = df.copy()
+
+    # Define max widths for different column types
+    column_widths = {
+        "Operator_Name": 40,
+        "Context": 35,
+        "Kernel_Name": 35,
+        "default": 20,
+    }
+
+    # Truncate columns to reasonable widths
+    for col in display_df.columns:
+        if display_df[col].dtype == "object":  # String columns
+            max_width = column_widths.get(col, column_widths["default"])
+            display_df[col] = (
+                display_df[col]
+                .astype(str)
+                .apply(
+                    lambda x: (
+                        string_multiple_lines(x, max_width, 2)
+                        if len(x) > max_width
+                        else x
+                    )
+                )
+            )
+
+    # Reset index for row numbering
+    display_df = display_df.reset_index(drop=True)
+
+    # Use tabulate for consistent formatting
+    table_str = tabulate(
+        display_df,
+        headers=display_df.columns,
+        tablefmt="fancy_grid",
+        showindex=True,
+        floatfmt=".2f",
+        maxcolwidths=list(column_widths.values()),
+    )
+
+    console_log(table_str)
+
+
 def show_torch_operator_hierarchy(operator_name: str, df: pd.DataFrame) -> None:
     """
     Display the hierarchy for each unique operator name in the DataFrame,
     showing marker hierarchy on the left and kernel launches on the right.
     """
     print(f"\n{'-' * 80}")
-    print("Marker Hierarchy (Stack)".ljust(40) + "Kernel Launches")
+    print(f"Torch Operator Hierarchy for: {operator_name}")
     print("-" * 80)
 
-    if df is not None and not df.empty and "Operator_Name" in df.columns:
-        unique_ops = df["Operator_Name"].unique()
-        for op in unique_ops:
-            parts = str(op).split("/")
+    # Expect the DataFrame to have columns "Operator_Name", "Kernel_Name",
+    # "Context_Id", etc.
 
-            hierarchy_lines = []
-            # Display the hierarchy tree
-            for i, part in enumerate(parts):
-                if i == 0:
-                    # Top level - just the module name
-                    hierarchy_lines.append(f"{part}")
+    unique_op_hierarchies = df["Operator_Name"].unique()
+    for i, op in enumerate(unique_op_hierarchies, start=1):
+        print(f"  {i:3d}. {op}")
+        print("\nOperator Hierarchy".ljust(50) + "Kernels Launched")
+        print("-" * 80)
+        parts = str(op).split("/")
+
+        hierarchy_lines = []
+        # Display the hierarchy tree
+        for i, part in enumerate(parts):
+            if i == 0:
+                # Top level - just the module name
+                hierarchy_lines.append(f"{part}")
+            else:
+                indent = "  " * i
+                prefix = "└─ "
+                hierarchy_lines.append(f"{indent}{prefix}{part}")
+
+        # Get kernels for this operator hierarchy
+        kernels_info = []
+        op_data = df[df["Operator_Name"] == op]
+        # Group by extracted kernel name
+        kernel_counts = {}
+        kernel_context = {}
+        for _, row in op_data.iterrows():
+            full_kernel_name = row["Kernel_Name"]
+            kernel_name = extract_kernel_name(full_kernel_name)
+
+            if kernel_name not in kernel_counts:
+                kernel_counts[kernel_name] = 0
+                kernel_context[kernel_name] = {
+                    "full_name": full_kernel_name,
+                    "contexts": {},
+                }
+            kernel_counts[kernel_name] += 1
+            topmost_location = str(row["Context_Id"]).split("/")[0]
+            _, location = topmost_location.split("@")
+            file_name, line_num = location.split(":")
+            if file_name not in kernel_context[kernel_name]["contexts"]:
+                kernel_context[kernel_name]["contexts"][file_name] = {line_num: 1}
+            else:
+                if line_num not in kernel_context[kernel_name]["contexts"][file_name]:
+                    kernel_context[kernel_name]["contexts"][file_name][line_num] = 1
                 else:
-                    indent = "  " * i
-                    prefix = "└─ "
-                    hierarchy_lines.append(f"{indent}{prefix}{part}")
+                    kernel_context[kernel_name]["contexts"][file_name][line_num] += 1
 
-            # Get kernels for this operator
-            kernels_info = []
-            op_data = df[df["Operator_Name"] == op]
-            if not op_data.empty and "Kernel_Name" in op_data.columns:
-                # Group by extracted kernel name and aggregate correlation IDs
-                kernel_groups = {}
-                for idx, row in op_data.iterrows():
-                    full_kernel_name = row["Kernel_Name"]
-                    kernel_name = extract_kernel_name(full_kernel_name)
-
-                    if kernel_name not in kernel_groups:
-                        kernel_groups[kernel_name] = []
-
-                    # Get correlation ID and context ID
-                    corr_id = ""
-                    if "Correlation_Id" in row:
-                        corr_id = str(row["Correlation_Id"])
-                    context_id_str = str(row["Context_Id"])
-                    kernel_groups[kernel_name].append(corr_id + "_" + context_id_str)
-
-                # Format output for each unique kernel
-                for kernel_name, corr_ids in kernel_groups.items():
-                    count = len(corr_ids)
-                    corr_list = ", ".join(corr_ids)
-                    kernel_info = (
-                        f"|--> {kernel_name} ({count} calls)\n"
-                        f"     Correlation_Ids: {corr_list}\n"
-                        f"     Context Info: ..."
+        # Format output for each unique kernel
+        for kernel_name, num_launches in kernel_counts.items():
+            kernel_info = f"|--> {kernel_name} ({num_launches} launches)\n"
+            kernels_info.append(kernel_info)
+            for file_name, line_count in kernel_context[kernel_name][
+                "contexts"
+            ].items():
+                for line_num, count in line_count.items():
+                    kernels_info.append(
+                        f"      {file_name}:{line_num} ({count} launches)\n"
                     )
-                    kernels_info.append(kernel_info)
 
-            # Print hierarchy lines (left column)
-            for line in hierarchy_lines:
-                print(f"{line.ljust(40)}|")
+        # Print hierarchy lines (left column)
+        for line in hierarchy_lines:
+            print(f"{line.ljust(40)}|")
 
-            # Print kernel lines aligned to the deepest level
-            deepest_indent = "  " * len(parts)
-            for kernel_line in kernels_info:
-                left_padding = deepest_indent + "    "
-                print(f"{left_padding.ljust(40)}{kernel_line}")
+        # Print kernel lines aligned to the deepest level
+        deepest_indent = "  " * len(parts)
+        for kernel_line in kernels_info:
+            left_padding = deepest_indent + "    "
+            print(f"{left_padding.ljust(40)}{kernel_line}")
 
-            print()
-    else:
-        console_log("No operator names found in data.")
-    print("-" * 80)
+        print()
 
 
 def process_table_data(

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -242,13 +242,12 @@ def is_roofline_shown(
         show_roof_plot(roof_plot)
     return True
 
-def show_torch_operator_hierarchy(operator_name, df):
+def show_torch_operator_hierarchy(operator_name: str , df: pd.DataFrame) -> None:
     """
     Display the hierarchy for each unique operator name in the DataFrame.
     """
     print("\n" + "-" * 80)
-    print("Operator Hierarchies in Data:")
-
+    print("Torch Operator Hierarchy for",operator_name)
     if df is not None and not df.empty and "Operator_Name" in df.columns:
         unique_ops = df["Operator_Name"].unique()
         for op in unique_ops:

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -242,12 +242,12 @@ def is_roofline_shown(
         show_roof_plot(roof_plot)
     return True
 
-
 def show_torch_operator_hierarchy(operator_name: str, df: pd.DataFrame) -> None:
     """
     Display the hierarchy for each unique operator name in the DataFrame.
     """
     print("\n" + "-" * 80)
+    print("Torch Operator Hierarchy for", operator_name)
     print("Torch Operator Hierarchy for", operator_name)
     if df is not None and not df.empty and "Operator_Name" in df.columns:
         unique_ops = df["Operator_Name"].unique()

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -248,7 +248,6 @@ def show_torch_operator_hierarchy(operator_name: str, df: pd.DataFrame) -> None:
     """
     print("\n" + "-" * 80)
     print("Torch Operator Hierarchy for", operator_name)
-    print("Torch Operator Hierarchy for", operator_name)
     if df is not None and not df.empty and "Operator_Name" in df.columns:
         unique_ops = df["Operator_Name"].unique()
         for op in unique_ops:

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -242,12 +242,13 @@ def is_roofline_shown(
         show_roof_plot(roof_plot)
     return True
 
-def show_torch_operator_hierarchy(operator_name: str , df: pd.DataFrame) -> None:
+
+def show_torch_operator_hierarchy(operator_name: str, df: pd.DataFrame) -> None:
     """
     Display the hierarchy for each unique operator name in the DataFrame.
     """
     print("\n" + "-" * 80)
-    print("Torch Operator Hierarchy for",operator_name)
+    print("Torch Operator Hierarchy for", operator_name)
     if df is not None and not df.empty and "Operator_Name" in df.columns:
         unique_ops = df["Operator_Name"].unique()
         for op in unique_ops:
@@ -258,6 +259,7 @@ def show_torch_operator_hierarchy(operator_name: str , df: pd.DataFrame) -> None
             print()
     else:
         print("No operator names found in data.")
+
 
 def process_table_data(
     args: argparse.Namespace,

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -242,6 +242,23 @@ def is_roofline_shown(
         show_roof_plot(roof_plot)
     return True
 
+def show_torch_operator_hierarchy(operator_name, df):
+    """
+    Display the hierarchy for each unique operator name in the DataFrame.
+    """
+    print("\n" + "-" * 80)
+    print("Operator Hierarchies in Data:")
+
+    if df is not None and not df.empty and "Operator_Name" in df.columns:
+        unique_ops = df["Operator_Name"].unique()
+        for op in unique_ops:
+            parts = str(op).split("/")
+            for i, part in enumerate(parts):
+                prefix = "    " * i + ("└─ " if i == len(parts) - 1 else "├─ ")
+                print(f"{prefix}{part}")
+            print()
+    else:
+        print("No operator names found in data.")
 
 def process_table_data(
     args: argparse.Namespace,

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -243,22 +243,108 @@ def is_roofline_shown(
     return True
 
 
+def extract_kernel_name(full_kernel_name: str) -> str:
+    """
+    Extract the short kernel function name from a mangled C++ kernel name.
+
+    Examples:
+    - "void at::native::vectorized_elementwise_kernel<...>"
+       -> "vectorized_elementwise_kernel"
+    - "Cijk_Ailk_Bljk_SB_MT128x128x16..." -> "Cijk_Ailk_Bljk_SB_MT128x128x16..."
+    """
+    # Remove return type prefix (void, etc.)
+    kernel_name = full_kernel_name.strip()
+    if kernel_name.startswith("void "):
+        kernel_name = kernel_name[5:]
+
+    # First, extract the main function name before any template parameters
+    # Split on '<' to get the part before template parameters
+    if "<" in kernel_name:
+        main_part = kernel_name.split("<")[0]
+    elif "(" in kernel_name:
+        main_part = kernel_name.split("(")[0]
+    else:
+        main_part = kernel_name
+
+    # Now extract the function name from namespaces
+    if "::" in main_part:
+        # Get the last part after the last :: in the main part (before templates)
+        function_name = main_part.split("::")[-1].strip()
+        return function_name if function_name else kernel_name.strip()
+
+    return main_part.strip()
+
+
 def show_torch_operator_hierarchy(operator_name: str, df: pd.DataFrame) -> None:
     """
-    Display the hierarchy for each unique operator name in the DataFrame.
+    Display the hierarchy for each unique operator name in the DataFrame,
+    showing marker hierarchy on the left and kernel launches on the right.
     """
     print("\n" + "-" * 80)
-    print("Torch Operator Hierarchy for", operator_name)
+    print("Marker Hierarchy (Stack)".ljust(40) + "Kernel Launches")
+    print("-" * 80)
+
     if df is not None and not df.empty and "Operator_Name" in df.columns:
         unique_ops = df["Operator_Name"].unique()
         for op in unique_ops:
             parts = str(op).split("/")
+
+            hierarchy_lines = []
+            # Display the hierarchy tree
             for i, part in enumerate(parts):
-                prefix = "    " * i + ("└─ " if i == len(parts) - 1 else "├─ ")
-                print(f"{prefix}{part}")
+                if i == 0:
+                    # Top level - just the module name
+                    hierarchy_lines.append(f"{part}")
+                else:
+                    indent = "  " * i
+                    prefix = "└─ "
+                    hierarchy_lines.append(f"{indent}{prefix}{part}")
+
+            # Get kernels for this operator
+            kernels_info = []
+            op_data = df[df["Operator_Name"] == op]
+            if not op_data.empty and "Kernel_Name" in op_data.columns:
+                # Group by extracted kernel name and aggregate correlation IDs
+                kernel_groups = {}
+                for idx, row in op_data.iterrows():
+                    full_kernel_name = row["Kernel_Name"]
+                    kernel_name = extract_kernel_name(full_kernel_name)
+
+                    if kernel_name not in kernel_groups:
+                        kernel_groups[kernel_name] = []
+
+                    # Get correlation ID and context ID
+                    corr_id = ""
+                    if "Correlation_Id" in row:
+                        corr_id = str(row["Correlation_Id"])
+                    context_id_str = str(row["Context_Id"])
+                    kernel_groups[kernel_name].append(corr_id + "_" + context_id_str)
+
+                # Format output for each unique kernel
+                for kernel_name, corr_ids in kernel_groups.items():
+                    count = len(corr_ids)
+                    corr_list = ", ".join(corr_ids)
+                    kernel_info = (
+                        f"|--> {kernel_name} ({count} calls)\n"
+                        f"     Correlation_Ids: {corr_list}\n"
+                        f"     Context Info: ..."
+                    )
+                    kernels_info.append(kernel_info)
+
+            # Print hierarchy lines (left column)
+            for line in hierarchy_lines:
+                print(f"{line.ljust(40)}|")
+
+            # Print kernel lines aligned to the deepest level
+            deepest_indent = "  " * len(parts)
+            for kernel_line in kernels_info:
+                left_padding = deepest_indent + "    "
+                print(f"{left_padding.ljust(40)}{kernel_line}")
+
             print()
     else:
         print("No operator names found in data.")
+    print("-" * 80)
 
 
 def process_table_data(

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -280,7 +280,7 @@ def show_torch_operator_hierarchy(operator_name: str, df: pd.DataFrame) -> None:
     Display the hierarchy for each unique operator name in the DataFrame,
     showing marker hierarchy on the left and kernel launches on the right.
     """
-    print("\n" + "-" * 80)
+    print(f"\n" + "-" * 80)
     print("Marker Hierarchy (Stack)".ljust(40) + "Kernel Launches")
     print("-" * 80)
 
@@ -343,7 +343,7 @@ def show_torch_operator_hierarchy(operator_name: str, df: pd.DataFrame) -> None:
 
             print()
     else:
-        print("No operator names found in data.")
+        console_log("No operator names found in data.")
     print("-" * 80)
 
 

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1335,7 +1335,7 @@ def process_torch_trace_output(
     """
     # marker_trace_csv_file_path = f"{workload_dir}/out/pmc_1/"
     # Find all marker_api_trace CSV files
-    console_log("Looking for marker and counter csv files in ", workload_dir)
+    console_log(f"Looking for marker and counter csv files in {workload_dir}")
     marker_api_trace_csvs = list(Path(workload_dir).glob("**/*_marker_api_trace.csv"))
     counter_collection_csvs = [
         markers_file.parent

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1321,6 +1321,7 @@ def save_torch_trace_inputs(
             f"Unknown output_format: {output_format}", "in save_torch_trace_inputs"
         )
 
+
 @demarcate
 def process_torch_trace_output(
     workload_dir: str,
@@ -1345,20 +1346,23 @@ def process_torch_trace_output(
         if counter_collection_csvs[i].is_file() and marker_api_trace_csvs[i].is_file()
     ]
     if Path(f"{workload_dir}/torch_trace").exists() and not existing_csv_files:
-        console_log("Torch data has already been processed ",
-                    f"and saved to {workload_dir}/torch_trace")
+        console_log(
+            "Torch data has already been processed ",
+            f"and saved to {workload_dir}/torch_trace",
+        )
         return
     if not existing_csv_files:
         console_warning(
             "No marker files with corresponding counter files found for torch tracing."
         )
         return
-    #Delete existing torch_trace directory if present
+    # Delete existing torch_trace directory if present
     if Path(f"{workload_dir}/torch_trace").exists():
         shutil.rmtree(Path(f"{workload_dir}/torch_trace"))
         console_log(
             f"Removed previous torch_trace directory : {workload_dir}/torch_trace"
         )
+
     # Join marker and counter data
     def _merge_pair(
         marker_path: Path,

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1382,6 +1382,7 @@ def process_torch_trace_output(
         console_error(
             f"Consolidated torch trace is missing required columns {missing_columns}"
         )
+        return
     consolidated_df = consolidated_df[required_columns]
     if consolidated_df.isnull().values.any():
         console_warning("Consolidated torch trace contains missing values")

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1282,7 +1282,8 @@ def save_torch_trace_inputs(
     output_format: str = "rocpd",
 ) -> None:
     """
-    Move counter_collection and marker_api_trace data to workload_dir for creation of PyTorch operator trace in Analyze mode.
+    Move counter_collection and marker_api_trace data to workload_dir,
+    for creation of PyTorch operator trace in Analyze mode.
     """
     src_dir = Path(workload_dir) / "out" / "pmc_1"
     if output_format == "rocpd":
@@ -1293,7 +1294,8 @@ def save_torch_trace_inputs(
         dst_marker = Path(workload_dir) / f"{fbase}_marker_api_trace.csv"
         shutil.copyfile(src_counter, dst_counter)
         shutil.copyfile(src_marker, dst_marker)
-        console_log("Moved counter collection and marker trace files to workload dir for PyTorch trace creation.")
+        console_log("Moved counter collection and marker trace files",
+                    "to workload dir for PyTorch trace creation.")
         console_log("Counter Collection: ", str(dst_counter))
         console_log("Marker API Trace: ", str(dst_marker))
     elif output_format == "csv":
@@ -1310,7 +1312,8 @@ def save_torch_trace_inputs(
             shutil.copyfile(src_marker, dst_marker)
             console_log("Copied Marker API Trace: ", dst_marker)
     else:
-        console_warning(f"Unknown output_format: {output_format} in save_torch_trace_inputs")
+        console_warning(f"Unknown output_format: {output_format}",
+                        "in save_torch_trace_inputs")
 @demarcate
 def process_torch_trace_output(
     workload_dir: str,
@@ -1322,7 +1325,7 @@ def process_torch_trace_output(
     """
     # marker_trace_csv_file_path = f"{workload_dir}/out/pmc_1/"
     # Find all marker_api_trace CSV files
-    
+
     marker_api_trace_csvs = list(
         Path(workload_dir).glob("**/*_marker_api_trace.csv")
     )
@@ -1338,7 +1341,7 @@ def process_torch_trace_output(
     ]
     if not existing_csv_files:
         console_warning(
-            f"No marker files with corresponding counter files found."
+            "No marker files with corresponding counter files found."
         )
         return
     # Join marker and counter data
@@ -1358,11 +1361,11 @@ def process_torch_trace_output(
         )
     # If rocpd format, pairs are present in workload_dir, one pair per fbase
     # If csv format, pairs are present in workload/{fbase}/ one pair per process
-    # Extracting the output_format used in profiling from the path of the first marker file
+    # Extracting the output_format used in profiling from the path of a marker file
     if existing_csv_files[0][0].parent.name == workload_dir:
         join_keys = ("Correlation_Id", "GUID") # output_format "rocpd"
     else:
-        join_keys = ("Correlation_Id",) # output_format "csv"        
+        join_keys = ("Correlation_Id",) # output_format "csv"
     consolidated_df = pd.concat(
         [_merge_pair(f[0], f[1], join_keys) for f in existing_csv_files],
         ignore_index=True,
@@ -1377,7 +1380,10 @@ def process_torch_trace_output(
         "Start_Timestamp_kernel",
         "End_Timestamp_kernel",
     ]
-    missing_columns = [col for col in required_columns if col not in consolidated_df.columns]
+    missing_columns = [
+            col for col in required_columns
+            if col not in consolidated_df.columns
+    ]
     if missing_columns:
         console_error(
             f"Consolidated torch trace is missing required columns {missing_columns}"

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -973,7 +973,6 @@ def run_prof(
         )
         combined_df.to_csv(workload_dir + f"/results_{fbase}.csv", index=False)
         if torch_trace_enabled:
-            # process_torch_trace_output(workload_dir, fbase, format_rocprof_output)
             # move counter collection and marker trace to workload dir
             save_torch_trace_inputs(workload_dir, fbase, format_rocprof_output)
         if retain_rocpd_output:
@@ -1016,7 +1015,6 @@ def run_prof(
                 process_hip_trace_output(workload_dir, fbase)
         # Add torch operator trace processing
         if torch_trace_enabled:
-            # process_torch_trace_output(workload_dir, fbase, format_rocprof_output)
             # move counter collection and marker trace to workload dir
             save_torch_trace_inputs(workload_dir, fbase, format_rocprof_output)
         # Combine results into single CSV file
@@ -1319,7 +1317,6 @@ def save_torch_trace_inputs(
             f"Unknown output_format: {output_format}", "in save_torch_trace_inputs"
         )
 
-
 @demarcate
 def process_torch_trace_output(
     workload_dir: str,
@@ -1331,7 +1328,7 @@ def process_torch_trace_output(
     """
     # marker_trace_csv_file_path = f"{workload_dir}/out/pmc_1/"
     # Find all marker_api_trace CSV files
-
+    console_log("Looking for marker and counter csv files in ", workload_dir)
     marker_api_trace_csvs = list(Path(workload_dir).glob("**/*_marker_api_trace.csv"))
     counter_collection_csvs = [
         markers_file.parent
@@ -1343,10 +1340,20 @@ def process_torch_trace_output(
         for i in range(len(marker_api_trace_csvs))
         if counter_collection_csvs[i].is_file() and marker_api_trace_csvs[i].is_file()
     ]
-    if not existing_csv_files:
-        console_warning("No marker files with corresponding counter files found.")
+    if Path(f"{workload_dir}/torch_trace").exists() and not existing_csv_files:
+        console_log(f"Torch data has already been processed and saved to {workload_dir}/torch_trace")
         return
-
+    if not existing_csv_files:
+        console_warning(
+            "No marker files with corresponding counter files found for torch tracing."
+        )
+        return
+    #Delete existing torch_trace directory if present
+    if Path(f"{workload_dir}/torch_trace").exists():
+        shutil.rmtree(Path(f"{workload_dir}/torch_trace"))
+        console_log(
+            f"Removed previous torch_trace directory : {workload_dir}/torch_trace"
+        )
     # Join marker and counter data
     def _merge_pair(
         marker_path: Path,

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1330,7 +1330,7 @@ def process_torch_trace_output(
 ) -> None:
     """
     Joins counter_collection and marker_api_trace data.
-        - Performs inner join on Correlation_Id, filtering out unmatched entries
+        - Performs inner join on Correlation_ID, filtering out unmatched entries
         - Consolidates data across passes
         - Groups by Operator_Name, saving one CSV per operator
         - Output file is saved to workload/torch_trace/ directory
@@ -1376,6 +1376,9 @@ def process_torch_trace_output(
         counter_path: Path,
         join_keys: list = ("Correlation_ID"),
     ) -> pd.DataFrame:
+        """Merge a pair of marker and counter csv files on specified keys,
+           return the merged dataframe.
+        """
         marker_df = pd.read_csv(marker_path)
         counter_df = pd.read_csv(counter_path)
         # Normalize column names to handle case inconsistencies

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1327,9 +1327,11 @@ def process_torch_trace_output(
     workload_dir: str,
 ) -> None:
     """
-    Creates PyTorch operator trace from counter_collection and marker_api_trace data.
+    Joins counter_collection and marker_api_trace data.
         - Performs inner join on Correlation_Id, filtering out unmatched entries
-        - Output file is saved to workload root, not the temporary out/ directory
+        - Consolidates data across passes
+        - Groups by Operator_Name, saving one CSV per operator
+        - Output file is saved to workload/torch_trace/ directory
     """
     # marker_trace_csv_file_path = f"{workload_dir}/out/pmc_1/"
     # Find all marker_api_trace CSV files

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -973,7 +973,9 @@ def run_prof(
         )
         combined_df.to_csv(workload_dir + f"/results_{fbase}.csv", index=False)
         if torch_trace_enabled:
-            process_torch_trace_output(workload_dir, fbase, format_rocprof_output)
+            # process_torch_trace_output(workload_dir, fbase, format_rocprof_output)
+            # move counter collection and marker trace to workload dir
+            save_torch_trace_inputs(workload_dir, fbase, format_rocprof_output)
         if retain_rocpd_output:
             for db_path in glob.glob(workload_dir + "/out/pmc_1/*/*.db"):
                 pid = Path(db_path).stem.split("_")[0]
@@ -1014,7 +1016,9 @@ def run_prof(
                 process_hip_trace_output(workload_dir, fbase)
         # Add torch operator trace processing
         if torch_trace_enabled:
-            process_torch_trace_output(workload_dir, fbase, format_rocprof_output)
+            # process_torch_trace_output(workload_dir, fbase, format_rocprof_output)
+            # move counter collection and marker trace to workload dir
+            save_torch_trace_inputs(workload_dir, fbase, format_rocprof_output)
         # Combine results into single CSV file
         if results_files:
             combined_results = pd.concat(
@@ -1271,22 +1275,56 @@ def process_rocprofv3_output(workload_dir: str, using_native_tool: bool) -> list
 
     return results_files_csv
 
-
 @demarcate
-def process_torch_trace_output(
+def save_torch_trace_inputs(
     workload_dir: str,
     fbase: str,
     output_format: str = "rocpd",
+) -> None:
+    """
+    Move counter_collection and marker_api_trace data to workload_dir for creation of PyTorch operator trace in Analyze mode.
+    """
+    src_dir = Path(workload_dir) / "out" / "pmc_1"
+    if output_format == "rocpd":
+        # Only one pair expected
+        src_counter = src_dir / f"{fbase}_counter_collection.csv"
+        src_marker = src_dir / f"{fbase}_marker_api_trace.csv"
+        dst_counter = Path(workload_dir) / f"{fbase}_counter_collection.csv"
+        dst_marker = Path(workload_dir) / f"{fbase}_marker_api_trace.csv"
+        shutil.copyfile(src_counter, dst_counter)
+        shutil.copyfile(src_marker, dst_marker)
+        console_log("Moved counter collection and marker trace files to workload dir for PyTorch trace creation.")
+        console_log("Counter Collection: ", str(dst_counter))
+        console_log("Marker API Trace: ", str(dst_marker))
+    elif output_format == "csv":
+        # Multiple pairs possible (one per PID/process)
+        counter_files = glob.glob(str(src_dir / "*/*_counter_collection.csv"))
+        marker_files = glob.glob(str(src_dir / "*/*_marker_api_trace.csv"))
+        for src_counter in counter_files:
+            dst_counter = str(Path(workload_dir) / f"{fbase}" / Path(src_counter).name)
+            shutil.copyfile(src_counter, dst_counter)
+            console_log("Copied Counter Collection: ", dst_counter)
+        for src_marker in marker_files:
+            dst_marker = str(Path(workload_dir) / f"{fbase}" / Path(src_marker).name)
+            shutil.copyfile(src_marker, dst_marker)
+            console_log("Copied Marker API Trace: ", dst_marker)
+    else:
+        console_warning(f"Unknown output_format: {output_format} in move_torch_trace_inputs")
+    
+@demarcate
+def process_torch_trace_output(
+    workload_dir: str,
 ) -> None:
     """
     Creates PyTorch operator trace from counter_collection and marker_api_trace data.
         - Performs inner join on Correlation_Id, filtering out unmatched entries
         - Output file is saved to workload root, not the temporary out/ directory
     """
-    marker_trace_csv_file_path = f"{workload_dir}/out/pmc_1/"
+    # marker_trace_csv_file_path = f"{workload_dir}/out/pmc_1/"
     # Find all marker_api_trace CSV files
+    
     marker_api_trace_csvs = list(
-        Path(marker_trace_csv_file_path).glob("**/*_marker_api_trace.csv")
+        Path(workload_dir).glob("**/*_marker_api_trace.csv")
     )
     counter_collection_csvs = [
         markers_file.parent
@@ -1300,10 +1338,9 @@ def process_torch_trace_output(
     ]
     if not existing_csv_files:
         console_warning(
-            f"No marker files with corresponding counter files found for {fbase}"
+            f"No marker files with corresponding counter files found."
         )
         return
-
     # Join marker and counter data
     def _merge_pair(
         marker_path: Path,
@@ -1319,38 +1356,17 @@ def process_torch_trace_output(
             how="inner",
             suffixes=("_function", "_kernel"),
         )
-
-    if output_format == "csv":
-        merged_results = pd.concat(
-            [_merge_pair(f[0], f[1]) for f in existing_csv_files],
-            ignore_index=True,
+    # If rocpd format, pairs are present in workload_dir, one pair per fbase
+    # If csv format, pairs are present in workload/{fbase}/ one pair per process
+    # Extracting the output_format used in profiling from the path of the first marker file
+    if existing_csv_files[0][0].parent.name == workload_dir:
+        join_keys = ("Correlation_Id", "GUID") #output_format "rocpd"
+    else:
+        join_keys = ("Correlation_Id",) # output_format "csv"        
+    consolidated_df = pd.concat(
+        [_merge_pair(f[0], f[1],join_keys) for f in existing_csv_files],
+        ignore_index=True,
         )
-    elif output_format == "rocpd":
-        # There will one pair of csv files extracted from rocpd db and consolidated.
-        merged_results = _merge_pair(
-            existing_csv_files[0][0],
-            existing_csv_files[0][1],
-            ("Correlation_Id", "GUID"),
-        )
-    # Save merged results
-    merged_results.to_csv(
-        f"{workload_dir}/{fbase}_torch_trace.csv",
-        index=False,
-    )
-    console_log("Created ", f"{workload_dir}/{fbase}_torch_trace.csv")
-
-
-@demarcate
-def consolidate_torch_trace_output(workload_dir: str) -> None:
-    # Consolidate torch operator trace CSV files from multiple processes
-    console_log("Consolidating torch operator trace output...")
-    # Find all torch trace CSV files in workload directory
-    torch_trace_files = glob.glob(f"{workload_dir}/*_torch_trace.csv")
-    if not torch_trace_files:
-        console_warning("No torch trace files found.")
-        return
-    # Read and concatenate all torch trace files
-    all_traces = []
     required_columns = [
         "Function",
         "Kernel_Name",
@@ -1361,41 +1377,16 @@ def consolidate_torch_trace_output(workload_dir: str) -> None:
         "Start_Timestamp_kernel",
         "End_Timestamp_kernel",
     ]
-    for trace_file in torch_trace_files:
-        try:
-            df = pd.read_csv(trace_file)
-        except pd.errors.ParserError as e:
-            console_warning(f"Parser error while reading {trace_file}: {e}")
-            continue
-        except OSError as e:
-            console_warning(f"I/O error while reading {trace_file}: {e}")
-            continue
-        except Exception as e:
-            # Unexpected error; log full details for debugging
-            console_warning(
-                f"Unexpected error while reading {trace_file}: {e}\n"
-                f"{traceback.format_exc()}"
-            )
-            continue
-
-        missing_columns = [col for col in required_columns if col not in df.columns]
-        if missing_columns:
-            console_warning(
-                f"Skipping {trace_file}: missing required columns {missing_columns}"
-            )
-            continue
-
-        all_traces.append(df[required_columns])
-    if not all_traces:
-        console_warning("No valid torch trace data to consolidate.")
-        return
-
-    consolidated_df = pd.concat(all_traces, ignore_index=True)
+    missing_columns = [col for col in required_columns if col not in consolidated_df.columns]
+    if missing_columns:
+        console_error(
+            f"Consolidated torch trace is missing required columns {missing_columns}"
+        )
+    consolidated_df = consolidated_df[required_columns]
     if consolidated_df.isnull().values.any():
         console_warning("Consolidated torch trace contains missing values")
         return
     consolidated_df = consolidated_df.sort_values(by=["Function", "Counter_Name"])
-
     split_columns = consolidated_df["Function"].str.split(":#", expand=True)
     consolidated_df["Operator_Name"] = (
         split_columns[0] if len(split_columns.columns) > 0 else None
@@ -1417,14 +1408,12 @@ def consolidate_torch_trace_output(workload_dir: str) -> None:
             "End_Timestamp_kernel",
         ]
     ]
-
     if consolidated_df.isnull().values.any():
         console_error(
             "Missing values in consolidated torch trace after splitting ",
             "the Function name.",
         )
         return
-
     grouped = consolidated_df.groupby("Operator_Name")
     for operator_name, group in grouped:
         sanitized_operator_name = operator_name.replace("torch.", "").replace(".", "_")
@@ -1435,14 +1424,12 @@ def consolidate_torch_trace_output(workload_dir: str) -> None:
         console_log(
             f"Saved consolidated trace for {sanitized_operator_name} to {output_file}"
         )
-
-    for trace_file in torch_trace_files:
+    for trace_file in marker_api_trace_csvs + counter_collection_csvs:
         try:
             Path(trace_file).unlink()
             console_debug(f"Removed temporary torch trace file: {trace_file}")
         except OSError as e:
             console_warning(f"Error removing temporary file {trace_file}: {e}")
-
 
 @demarcate
 def process_kokkos_trace_output(workload_dir: str, fbase: str) -> None:

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1289,8 +1289,8 @@ def save_torch_trace_inputs(
         # Only one pair expected
         src_counter = src_dir / f"{fbase}_counter_collection.csv"
         src_marker = src_dir / f"{fbase}_marker_api_trace.csv"
-        dst_counter = Path(workload_dir) / f"{fbase}_counter_collection.csv"
-        dst_marker = Path(workload_dir) / f"{fbase}_marker_api_trace.csv"
+        dst_counter = Path(workload_dir) / f"torch_trace_{fbase}_counter_collection.csv"
+        dst_marker = Path(workload_dir) / f"torch_trace_{fbase}_marker_api_trace.csv"
         # These files are expected to exist
         # Letting shutil.copyfile raise error if files not found
         shutil.copyfile(src_counter, dst_counter)
@@ -1309,14 +1309,20 @@ def save_torch_trace_inputs(
         (Path(workload_dir) / f"{fbase}").mkdir(parents=True, exist_ok=True)
         # Expecting the files to be present
         # Letting shutil.copyfile raise error if files not found
+        # Path: workload_dir/fbase/torch_trace_<src_basename> (discovered by
+        # process_torch_trace_output via glob **/torch_trace*_marker_api_trace.csv)
         for src_counter in counter_files:
-            dst_counter = str(Path(workload_dir) / f"{fbase}" / Path(src_counter).name)
+            dst_counter = str(
+                Path(workload_dir) / f"{fbase}" / ("torch_trace_" + Path(src_counter).name)
+            )
             shutil.copyfile(src_counter, dst_counter)
             console_log("torch trace", f"Copied Counter Collection: {dst_counter}")
         for src_marker in marker_files:
-            dst_marker = str(Path(workload_dir) / f"{fbase}" / Path(src_marker).name)
+            dst_marker = str(
+                Path(workload_dir) / f"{fbase}" / ("torch_trace_" + Path(src_marker).name)
+            )
             shutil.copyfile(src_marker, dst_marker)
-            console_log("torch trace", "Copied Marker API Trace: {dst_marker}")
+            console_log("torch trace", f"Copied Marker API Trace: {dst_marker}")
     else:
         console_warning(
             "torch trace",
@@ -1337,7 +1343,7 @@ def process_torch_trace_output(
     """
     # Find all marker_api_trace CSV files
     console_log(f"Looking for marker and counter csv files in {workload_dir}")
-    marker_api_trace_csvs = list(Path(workload_dir).glob("**/*_marker_api_trace.csv"))
+    marker_api_trace_csvs = list(Path(workload_dir).glob("**/torch_trace*_marker_api_trace.csv"))
     counter_collection_csvs = [
         markers_file.parent
         / markers_file.name.replace("_marker_api_trace.", "_counter_collection.")

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1335,7 +1335,6 @@ def process_torch_trace_output(
         - Groups by Operator_Name, saving one CSV per operator
         - Output file is saved to workload/torch_trace/ directory
     """
-    # marker_trace_csv_file_path = f"{workload_dir}/out/pmc_1/"
     # Find all marker_api_trace CSV files
     console_log(f"Looking for marker and counter csv files in {workload_dir}")
     marker_api_trace_csvs = list(Path(workload_dir).glob("**/*_marker_api_trace.csv"))
@@ -1368,17 +1367,25 @@ def process_torch_trace_output(
     if Path(f"{workload_dir}/torch_trace").exists():
         shutil.rmtree(Path(f"{workload_dir}/torch_trace"))
         console_log(
-            f"Removed previous torch_trace directory : {workload_dir}/torch_trace"
+            f"Removed previous torch_trace directory: {workload_dir}/torch_trace"
         )
 
     # Join marker and counter data
     def _merge_pair(
         marker_path: Path,
         counter_path: Path,
-        join_keys: list = ("Correlation_Id"),
+        join_keys: list = ("Correlation_ID"),
     ) -> pd.DataFrame:
         marker_df = pd.read_csv(marker_path)
         counter_df = pd.read_csv(counter_path)
+        # Normalize column names to handle case inconsistencies
+        marker_df.columns = marker_df.columns.str.replace(
+            "Correlation_Id", "Correlation_ID"
+        )
+        counter_df.columns = counter_df.columns.str.replace(
+            "Correlation_Id", "Correlation_ID"
+        )
+
         return pd.merge(
             marker_df,
             counter_df,
@@ -1391,9 +1398,9 @@ def process_torch_trace_output(
     # If csv format, pairs are present in workload/{fbase}/ one pair per process
     # Extracting the output_format used in profiling from the path of a marker file
     if Path(workload_dir).resolve() == existing_csv_files[0][0].parent.resolve():
-        join_keys = ("Correlation_Id", "GUID")  # output_format "rocpd"
+        join_keys = ("Correlation_ID", "GUID")  # output_format "rocpd"
     else:
-        join_keys = ("Correlation_Id",)  # output_format "csv"
+        join_keys = ("Correlation_ID",)  # output_format "csv"
     consolidated_df = pd.concat(
         [_merge_pair(f[0], f[1], join_keys) for f in existing_csv_files],
         ignore_index=True,
@@ -1450,14 +1457,19 @@ def process_torch_trace_output(
         return
     grouped = consolidated_df.groupby("Operator_Name")
     for operator_name, group in grouped:
-        sanitized_operator_name = operator_name.replace("torch.", "").replace(".", "_")
+        # Extract the operator name from hierarchy
+        last_operator = operator_name.split("/")[-1]
+        sanitized_operator_name = last_operator.replace("torch.", "").replace(".", "_")
         # Ensure output directory exists
         Path(f"{workload_dir}/torch_trace").mkdir(parents=True, exist_ok=True)
         output_file = f"{workload_dir}/torch_trace/{sanitized_operator_name}.csv"
-        group.to_csv(output_file, index=False)
-        console_log(
-            f"Saved consolidated trace for {sanitized_operator_name} to {output_file}"
-        )
+        # If the file already exists, append to it, else create new file.
+        if Path(output_file).is_file():
+            group.to_csv(output_file, mode="a", header=False, index=False)
+            console_log(f"Appended trace to existing file {output_file}")
+        else:
+            group.to_csv(output_file, index=False)
+            console_log(f"Saved consolidated trace to {output_file}")
     for trace_file in marker_api_trace_csvs + counter_collection_csvs:
         try:
             Path(trace_file).unlink()

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1300,6 +1300,7 @@ def save_torch_trace_inputs(
         # Multiple pairs possible (one per PID/process)
         counter_files = glob.glob(str(src_dir / "*/*_counter_collection.csv"))
         marker_files = glob.glob(str(src_dir / "*/*_marker_api_trace.csv"))
+        Path(workload_dir / f"{fbase}").mkdir(parents=True, exist_ok=True)
         for src_counter in counter_files:
             dst_counter = str(Path(workload_dir) / f"{fbase}" / Path(src_counter).name)
             shutil.copyfile(src_counter, dst_counter)

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1347,17 +1347,18 @@ def process_torch_trace_output(
         for i in range(len(marker_api_trace_csvs))
         if counter_collection_csvs[i].is_file() and marker_api_trace_csvs[i].is_file()
     ]
-        console_log(
-            f"Torch data has already been processed and saved to {workload_dir}/torch_trace"
-        )
-            "Torch data has already been processed ",
-            f"and saved to {workload_dir}/torch_trace",
-        )
-        return
+
     if not existing_csv_files:
-        console_warning(
-            "No marker files with corresponding counter files found for torch tracing."
-        )
+        if Path(f"{workload_dir}/torch_trace").exists():
+            console_log(
+                "Torch data has already been processed",
+                f"and saved to {workload_dir}/torch_trace",
+            )
+        else:
+            console_warning(
+                "No marker files with corresponding counter files found.",
+                "Ensure profiling was done with '--torch-trace'.",
+            )
         return
     # Delete existing torch_trace directory if present
     if Path(f"{workload_dir}/torch_trace").exists():

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1364,7 +1364,7 @@ def process_torch_trace_output(
     else:
         join_keys = ("Correlation_Id",) # output_format "csv"        
     consolidated_df = pd.concat(
-        [_merge_pair(f[0], f[1],join_keys) for f in existing_csv_files],
+        [_merge_pair(f[0], f[1], join_keys) for f in existing_csv_files],
         ignore_index=True,
         )
     required_columns = [

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1275,6 +1275,7 @@ def process_rocprofv3_output(workload_dir: str, using_native_tool: bool) -> list
 
     return results_files_csv
 
+
 @demarcate
 def save_torch_trace_inputs(
     workload_dir: str,
@@ -1294,8 +1295,10 @@ def save_torch_trace_inputs(
         dst_marker = Path(workload_dir) / f"{fbase}_marker_api_trace.csv"
         shutil.copyfile(src_counter, dst_counter)
         shutil.copyfile(src_marker, dst_marker)
-        console_log("Moved counter collection and marker trace files",
-                    "to workload dir for PyTorch trace creation.")
+        console_log(
+            "Moved counter collection and marker trace files",
+            "to workload dir for PyTorch trace creation.",
+        )
         console_log("Counter Collection: ", str(dst_counter))
         console_log("Marker API Trace: ", str(dst_marker))
     elif output_format == "csv":
@@ -1312,8 +1315,11 @@ def save_torch_trace_inputs(
             shutil.copyfile(src_marker, dst_marker)
             console_log("Copied Marker API Trace: ", dst_marker)
     else:
-        console_warning(f"Unknown output_format: {output_format}",
-                        "in save_torch_trace_inputs")
+        console_warning(
+            f"Unknown output_format: {output_format}", "in save_torch_trace_inputs"
+        )
+
+
 @demarcate
 def process_torch_trace_output(
     workload_dir: str,
@@ -1326,9 +1332,7 @@ def process_torch_trace_output(
     # marker_trace_csv_file_path = f"{workload_dir}/out/pmc_1/"
     # Find all marker_api_trace CSV files
 
-    marker_api_trace_csvs = list(
-        Path(workload_dir).glob("**/*_marker_api_trace.csv")
-    )
+    marker_api_trace_csvs = list(Path(workload_dir).glob("**/*_marker_api_trace.csv"))
     counter_collection_csvs = [
         markers_file.parent
         / markers_file.name.replace("_marker_api_trace.", "_counter_collection.")
@@ -1340,10 +1344,9 @@ def process_torch_trace_output(
         if counter_collection_csvs[i].is_file() and marker_api_trace_csvs[i].is_file()
     ]
     if not existing_csv_files:
-        console_warning(
-            "No marker files with corresponding counter files found."
-        )
+        console_warning("No marker files with corresponding counter files found.")
         return
+
     # Join marker and counter data
     def _merge_pair(
         marker_path: Path,
@@ -1359,17 +1362,18 @@ def process_torch_trace_output(
             how="inner",
             suffixes=("_function", "_kernel"),
         )
+
     # If rocpd format, pairs are present in workload_dir, one pair per fbase
     # If csv format, pairs are present in workload/{fbase}/ one pair per process
     # Extracting the output_format used in profiling from the path of a marker file
     if existing_csv_files[0][0].parent.name == workload_dir:
-        join_keys = ("Correlation_Id", "GUID") # output_format "rocpd"
+        join_keys = ("Correlation_Id", "GUID")  # output_format "rocpd"
     else:
-        join_keys = ("Correlation_Id",) # output_format "csv"
+        join_keys = ("Correlation_Id",)  # output_format "csv"
     consolidated_df = pd.concat(
         [_merge_pair(f[0], f[1], join_keys) for f in existing_csv_files],
         ignore_index=True,
-        )
+    )
     required_columns = [
         "Function",
         "Kernel_Name",
@@ -1381,8 +1385,7 @@ def process_torch_trace_output(
         "End_Timestamp_kernel",
     ]
     missing_columns = [
-            col for col in required_columns
-            if col not in consolidated_df.columns
+        col for col in required_columns if col not in consolidated_df.columns
     ]
     if missing_columns:
         console_error(
@@ -1437,6 +1440,7 @@ def process_torch_trace_output(
             console_debug(f"Removed temporary torch trace file: {trace_file}")
         except OSError as e:
             console_warning(f"Error removing temporary file {trace_file}: {e}")
+
 
 @demarcate
 def process_kokkos_trace_output(workload_dir: str, fbase: str) -> None:

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1296,8 +1296,8 @@ def save_torch_trace_inputs(
         shutil.copyfile(src_counter, dst_counter)
         shutil.copyfile(src_marker, dst_marker)
         console_log(
-            "Moved counter collection and marker trace files",
-            "to workload dir for PyTorch trace creation.",
+            "Moved counter collection and marker trace files"
+            "to workload dir for PyTorch trace creation."
         )
         console_log("Counter Collection: ", str(dst_counter))
         console_log("Marker API Trace: ", str(dst_marker))
@@ -1311,14 +1311,14 @@ def save_torch_trace_inputs(
         for src_counter in counter_files:
             dst_counter = str(Path(workload_dir) / f"{fbase}" / Path(src_counter).name)
             shutil.copyfile(src_counter, dst_counter)
-            console_log(f"Copied Counter Collection: {dst_counter}")
+            console_log("torch trace", f"Copied Counter Collection: {dst_counter}")
         for src_marker in marker_files:
             dst_marker = str(Path(workload_dir) / f"{fbase}" / Path(src_marker).name)
             shutil.copyfile(src_marker, dst_marker)
-            console_log("Copied Marker API Trace: ", dst_marker)
+            console_log("torch trace","Copied Marker API Trace: {dst_marker}")
     else:
-        console_warning(
-            f"Unknown output_format: {output_format}", "in save_torch_trace_inputs"
+        console_warning("torch trace",
+            f"Unknown output_format: {output_format} in save_torch_trace_inputs"
         )
 
 
@@ -1350,14 +1350,14 @@ def process_torch_trace_output(
 
     if not existing_csv_files:
         if Path(f"{workload_dir}/torch_trace").exists():
-            console_log(
-                "Torch data has already been processed",
-                f"and saved to {workload_dir}/torch_trace",
+            console_log("torch trace",
+                "Torch data has already been processed"
+                f"and saved to {workload_dir}/torch_trace"
             )
         else:
-            console_warning(
-                "No marker files with corresponding counter files found.",
-                "Ensure profiling was done with '--torch-trace'.",
+            console_warning("torch trace",
+                "No marker files with corresponding counter files found."
+                "Ensure profiling was done with '--torch-trace'."
             )
         return
     # Delete existing torch_trace directory if present

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1313,13 +1313,17 @@ def save_torch_trace_inputs(
         # process_torch_trace_output via glob **/torch_trace*_marker_api_trace.csv)
         for src_counter in counter_files:
             dst_counter = str(
-                Path(workload_dir) / f"{fbase}" / ("torch_trace_" + Path(src_counter).name)
+                Path(workload_dir)
+                /
+                f"{fbase}" / ("torch_trace_" + Path(src_counter).name)
             )
             shutil.copyfile(src_counter, dst_counter)
             console_log("torch trace", f"Copied Counter Collection: {dst_counter}")
         for src_marker in marker_files:
             dst_marker = str(
-                Path(workload_dir) / f"{fbase}" / ("torch_trace_" + Path(src_marker).name)
+                Path(workload_dir)
+                /
+                f"{fbase}" / ("torch_trace_" + Path(src_marker).name)
             )
             shutil.copyfile(src_marker, dst_marker)
             console_log("torch trace", f"Copied Marker API Trace: {dst_marker}")
@@ -1343,7 +1347,9 @@ def process_torch_trace_output(
     """
     # Find all marker_api_trace CSV files
     console_log(f"Looking for marker and counter csv files in {workload_dir}")
-    marker_api_trace_csvs = list(Path(workload_dir).glob("**/torch_trace*_marker_api_trace.csv"))
+    marker_api_trace_csvs = list(
+        Path(workload_dir).glob("**/torch_trace*_marker_api_trace.csv")
+        )
     counter_collection_csvs = [
         markers_file.parent
         / markers_file.name.replace("_marker_api_trace.", "_counter_collection.")

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1295,7 +1295,7 @@ def save_torch_trace_inputs(
         # Letting shutil.copyfile raise error if files not found
         shutil.copyfile(src_counter, dst_counter)
         shutil.copyfile(src_marker, dst_marker)
-        console_log(
+        console_log("torch trace",
             "Moved counter collection and marker trace files"
             "to workload dir for PyTorch trace creation."
         )

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1360,7 +1360,7 @@ def process_torch_trace_output(
     # If csv format, pairs are present in workload/{fbase}/ one pair per process
     # Extracting the output_format used in profiling from the path of the first marker file
     if existing_csv_files[0][0].parent.name == workload_dir:
-        join_keys = ("Correlation_Id", "GUID") #output_format "rocpd"
+        join_keys = ("Correlation_Id", "GUID") # output_format "rocpd"
     else:
         join_keys = ("Correlation_Id",) # output_format "csv"        
     consolidated_df = pd.concat(

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1311,7 +1311,6 @@ def save_torch_trace_inputs(
             console_log("Copied Marker API Trace: ", dst_marker)
     else:
         console_warning(f"Unknown output_format: {output_format} in save_torch_trace_inputs")
-    
 @demarcate
 def process_torch_trace_output(
     workload_dir: str,

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1341,7 +1341,8 @@ def process_torch_trace_output(
         if counter_collection_csvs[i].is_file() and marker_api_trace_csvs[i].is_file()
     ]
     if Path(f"{workload_dir}/torch_trace").exists() and not existing_csv_files:
-        console_log(f"Torch data has already been processed and saved to {workload_dir}/torch_trace")
+        console_log("Torch data has already been processed ",
+                    f"and saved to {workload_dir}/torch_trace")
         return
     if not existing_csv_files:
         console_warning(

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1310,7 +1310,7 @@ def save_torch_trace_inputs(
             shutil.copyfile(src_marker, dst_marker)
             console_log("Copied Marker API Trace: ", dst_marker)
     else:
-        console_warning(f"Unknown output_format: {output_format} in move_torch_trace_inputs")
+        console_warning(f"Unknown output_format: {output_format} in save_torch_trace_inputs")
     
 @demarcate
 def process_torch_trace_output(

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1291,6 +1291,8 @@ def save_torch_trace_inputs(
         src_marker = src_dir / f"{fbase}_marker_api_trace.csv"
         dst_counter = Path(workload_dir) / f"{fbase}_counter_collection.csv"
         dst_marker = Path(workload_dir) / f"{fbase}_marker_api_trace.csv"
+        # These files are expected to exist
+        # Letting shutil.copyfile raise error if files not found
         shutil.copyfile(src_counter, dst_counter)
         shutil.copyfile(src_marker, dst_marker)
         console_log(
@@ -1304,6 +1306,8 @@ def save_torch_trace_inputs(
         counter_files = glob.glob(str(src_dir / "*/*_counter_collection.csv"))
         marker_files = glob.glob(str(src_dir / "*/*_marker_api_trace.csv"))
         (Path(workload_dir) / f"{fbase}").mkdir(parents=True, exist_ok=True)
+        # Expecting the files to be present
+        # Letting shutil.copyfile raise error if files not found
         for src_counter in counter_files:
             dst_counter = str(Path(workload_dir) / f"{fbase}" / Path(src_counter).name)
             shutil.copyfile(src_counter, dst_counter)
@@ -1374,7 +1378,7 @@ def process_torch_trace_output(
     # If rocpd format, pairs are present in workload_dir, one pair per fbase
     # If csv format, pairs are present in workload/{fbase}/ one pair per process
     # Extracting the output_format used in profiling from the path of a marker file
-    if existing_csv_files[0][0].parent.name == workload_dir:
+    if Path(workload_dir).resolve() == existing_csv_files[0][0].parent.resolve():
         join_keys = ("Correlation_Id", "GUID")  # output_format "rocpd"
     else:
         join_keys = ("Correlation_Id",)  # output_format "csv"

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1311,7 +1311,7 @@ def save_torch_trace_inputs(
         for src_counter in counter_files:
             dst_counter = str(Path(workload_dir) / f"{fbase}" / Path(src_counter).name)
             shutil.copyfile(src_counter, dst_counter)
-            console_log("Copied Counter Collection: ", dst_counter)
+            console_log(f"Copied Counter Collection: {dst_counter}")
         for src_marker in marker_files:
             dst_marker = str(Path(workload_dir) / f"{fbase}" / Path(src_marker).name)
             shutil.copyfile(src_marker, dst_marker)

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1377,7 +1377,7 @@ def process_torch_trace_output(
         join_keys: list = ("Correlation_ID"),
     ) -> pd.DataFrame:
         """Merge a pair of marker and counter csv files on specified keys,
-           return the merged dataframe.
+        return the merged dataframe.
         """
         marker_df = pd.read_csv(marker_path)
         counter_df = pd.read_csv(counter_path)

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1300,7 +1300,7 @@ def save_torch_trace_inputs(
         # Multiple pairs possible (one per PID/process)
         counter_files = glob.glob(str(src_dir / "*/*_counter_collection.csv"))
         marker_files = glob.glob(str(src_dir / "*/*_marker_api_trace.csv"))
-        Path(workload_dir / f"{fbase}").mkdir(parents=True, exist_ok=True)
+        (Path(workload_dir) / f"{fbase}").mkdir(parents=True, exist_ok=True)
         for src_counter in counter_files:
             dst_counter = str(Path(workload_dir) / f"{fbase}" / Path(src_counter).name)
             shutil.copyfile(src_counter, dst_counter)

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1347,8 +1347,9 @@ def process_torch_trace_output(
         for i in range(len(marker_api_trace_csvs))
         if counter_collection_csvs[i].is_file() and marker_api_trace_csvs[i].is_file()
     ]
-    if Path(f"{workload_dir}/torch_trace").exists() and not existing_csv_files:
         console_log(
+            f"Torch data has already been processed and saved to {workload_dir}/torch_trace"
+        )
             "Torch data has already been processed ",
             f"and saved to {workload_dir}/torch_trace",
         )

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -1295,9 +1295,10 @@ def save_torch_trace_inputs(
         # Letting shutil.copyfile raise error if files not found
         shutil.copyfile(src_counter, dst_counter)
         shutil.copyfile(src_marker, dst_marker)
-        console_log("torch trace",
+        console_log(
+            "torch trace",
             "Moved counter collection and marker trace files"
-            "to workload dir for PyTorch trace creation."
+            "to workload dir for PyTorch trace creation.",
         )
         console_log("Counter Collection: ", str(dst_counter))
         console_log("Marker API Trace: ", str(dst_marker))
@@ -1315,10 +1316,11 @@ def save_torch_trace_inputs(
         for src_marker in marker_files:
             dst_marker = str(Path(workload_dir) / f"{fbase}" / Path(src_marker).name)
             shutil.copyfile(src_marker, dst_marker)
-            console_log("torch trace","Copied Marker API Trace: {dst_marker}")
+            console_log("torch trace", "Copied Marker API Trace: {dst_marker}")
     else:
-        console_warning("torch trace",
-            f"Unknown output_format: {output_format} in save_torch_trace_inputs"
+        console_warning(
+            "torch trace",
+            f"Unknown output_format: {output_format} in save_torch_trace_inputs",
         )
 
 
@@ -1350,14 +1352,16 @@ def process_torch_trace_output(
 
     if not existing_csv_files:
         if Path(f"{workload_dir}/torch_trace").exists():
-            console_log("torch trace",
+            console_log(
+                "torch trace",
                 "Torch data has already been processed"
-                f"and saved to {workload_dir}/torch_trace"
+                f"and saved to {workload_dir}/torch_trace",
             )
         else:
-            console_warning("torch trace",
+            console_warning(
+                "torch trace",
                 "No marker files with corresponding counter files found."
-                "Ensure profiling was done with '--torch-trace'."
+                "Ensure profiling was done with '--torch-trace'.",
             )
         return
     # Delete existing torch_trace directory if present

--- a/projects/rocprofiler-compute/tests/test_analyze_commands.py
+++ b/projects/rocprofiler-compute/tests/test_analyze_commands.py
@@ -1688,3 +1688,109 @@ def test_iteration_multiplexing(binary_handler_analyze_rocprof_compute):
     assert code == 0
 
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
+
+
+# ============================================================================
+# PyTorch Operator Analysis Tests
+# ============================================================================
+# These tests validate --list-torch-operators and --torch-operator flags
+# Note: Tests will be skipped if torch workload doesn't exist
+
+
+@pytest.mark.torch_operators
+def test_list_torch_operators_no_path(binary_handler_analyze_rocprof_compute):
+    """Test --list-torch-operators fails gracefully without --path"""
+    code = binary_handler_analyze_rocprof_compute([
+        "analyze",
+        "--list-torch-operators",
+    ])
+    assert code == 1
+
+
+@pytest.mark.torch_operators
+def test_list_torch_operators_no_trace_data(binary_handler_analyze_rocprof_compute):
+    """Test graceful handling when torch_trace/ directory doesn't exist"""
+    # Use regular vcopy workload (no torch data)
+    workload_dir = test_utils.setup_workload_dir(indirs[0])
+    code = binary_handler_analyze_rocprof_compute([
+        "analyze",
+        "--path",
+        workload_dir,
+        "--list-torch-operators",
+    ])
+    # Should show warning but exit successfully
+    assert code == 0
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)
+
+
+@pytest.mark.torch_operators
+def test_torch_trace_operator_output(binary_handler_analyze_rocprof_compute):
+    """
+    Verifies torch_trace directory, operator CSV file creation, and presence
+    of hierarchy and mapping (operator, kernel, counter values) in output files.
+    """
+    workload_dir = test_utils.get_output_dir(param_id="torch_ops_analyze")
+    # Move files from preexisting profiling run
+    source_dir = workload_dir.replace(
+        "test_torch_trace_operator_output", "test_torch_trace_profile"
+    )
+    # Get preexisting profiling data from workload_dir
+    if not Path(source_dir).exists():
+        pytest.skip(
+            "Consider running 'python -m pytest -k test_torch_trace_profile -v -s' "
+            "to generate the necessary data."
+        )
+
+    shutil.copytree(source_dir, workload_dir, dirs_exist_ok=True)
+
+    returncode = binary_handler_analyze_rocprof_compute([
+        "analyze",
+        "--path",
+        workload_dir,
+        "--list-torch-operators",
+    ])
+    # 1. Check analyze success
+    assert returncode == 0, "Analysis failed"
+
+    # 2. Check torch_trace directory creation
+    torch_trace_dir = Path(workload_dir) / "torch_trace"
+    assert torch_trace_dir.exists(), "torch_trace directory not created"
+
+    # 3. Check operator CSV file creation
+    operator_csv_files = list(torch_trace_dir.glob("*.csv"))
+    assert operator_csv_files, "No operator CSV files found in torch_trace"
+
+    # 4. Check hierarchy info and mapping in operator CSV files
+    hierarchy_present = False
+    for op_file in operator_csv_files:
+        df = pd.read_csv(op_file)
+        assert not df.empty, f"{op_file} is empty"
+        # Hierarchy info: check for operator name column and separator
+        # op_name_col = "Operator Name" if "Operator Name" in df.columns else "Name"
+        assert "Operator_Name" in df.columns, (
+            f"Operator_Name column missing in {op_file}"
+        )
+        # Skip files that only contain initialization ops
+        if not hierarchy_present:
+            hierarchy_present = (
+                df["Operator_Name"]
+                .apply(lambda x: "/" in str(x) or "::" in str(x))
+                .any()
+            )
+        # Mapping columns
+        assert "Kernel_Name" in df.columns, f"Kernel info column missing in {op_file}"
+        assert df["Kernel_Name"].notnull().all() and (df["Kernel_Name"] != "").all(), (
+            f"Empty Kernel_Name in {op_file}"
+        )
+
+        assert "Counter_Value" in df.columns, (
+            f"Counter_Value column missing in {op_file}"
+        )
+        assert df["Counter_Value"].notnull().all()
+        assert (df["Counter_Value"] != "").all(), f"Empty Counter Value in {op_file}"
+
+    assert hierarchy_present, (
+        f"No hierarchy information in operator CSV files. "
+        f"Files checked: {[f.name for f in operator_csv_files]}"
+    )
+    test_utils.clean_output_dir(config["cleanup"], workload_dir)

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -28,8 +28,8 @@ import importlib.util
 import inspect
 import os
 import re
-import socket
 import shutil
+import socket
 import sqlite3
 import subprocess
 import sys
@@ -1001,7 +1001,9 @@ def test_output_directory_all_placeholders_combined(
 def test_output_directory_default_with_rank(
     binary_handler_profile_rocprof_compute, monkeypatch
 ):
-    """Test that rank is appended to the default output directory when MPI rank is set."""
+    """
+    Test that rank is appended to the default output directory when MPI rank is set.
+    """
     from rocprof_compute_base import RocProfCompute
 
     rank = "3"

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -23,11 +23,13 @@
 
 ##############################################################################
 
+import csv
 import importlib.util
 import inspect
 import os
 import re
 import socket
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -3160,12 +3162,17 @@ def test_iteration_multiplexing_all_counter_accuracy(
     )
 
 
-skip_if_no_torch = pytest.mark.skipif(
-    importlib.util.find_spec("torch") is None, reason="torch is required for this test"
+skip_if_no_torch_gpu = pytest.mark.skipif(
+    (
+        importlib.util.find_spec("torch") is None
+        or not __import__("torch").cuda.is_available()
+    ),
+    reason=("PyTorch and GPU access are required for this test"),
 )
 
 
-@skip_if_no_torch
+@skip_if_no_torch_gpu
+@pytest.mark.torch_operators
 def test_torch_trace_profile(binary_handler_profile_rocprof_compute):
     """
     Test profiling a PyTorch application with --torch-trace option.
@@ -3231,21 +3238,104 @@ if __name__ == "__main__":
     num_devices = config.get("num_devices", 1)
     file_dict = test_utils.check_csv_files(workload_dir, num_devices, 1)
     assert "pmc_perf.csv" in file_dict, "pmc_perf.csv not generated"
-    # 2. Check torch trace directory
-    torch_trace_dir = Path(workload_dir) / "torch_trace"
-    assert torch_trace_dir.exists(), "torch_trace directory not created"
-    assert torch_trace_dir.is_dir(), "torch_trace is not a directory"
-    # 3. Check per-operator CSV files exist
-    operator_csv_files = list(torch_trace_dir.glob("*.csv"))
-    assert len(operator_csv_files) > 0, "No per-operator CSV files generated"
-    # 4. Verify per-operator CSV structure
-    for op_csv in operator_csv_files:
-        op_df = pd.read_csv(op_csv)
-        assert len(op_df) > 0, f"Per-operator CSV {op_csv.name} is empty"
+
+    # 2. Look for corresponding marker_api_trace.csv file
+    # and counter_collection.csv file in workload_dir/ and workload/*/
+    marker_api_trace_files = list(Path(workload_dir).glob("**/*marker_api_trace.csv"))
+    counter_collection_files = list(
+        Path(workload_dir).glob("**/*counter_collection.csv")
+    )
+    # Check if there is one-to-one mapping between marker_api_trace
+    # and counter_collection files.
+    # They should be present in the same subdirectories.
+    assert len(marker_api_trace_files) == len(counter_collection_files), (
+        "Mismatch in number of marker_api_trace.csv and counter_collection.csv files"
+    )
+    for marker_file in marker_api_trace_files:
+        # Build corresponding counter_collection file path by replacing filename
+        corresponding_counter_file = marker_file.parent / marker_file.name.replace(
+            "marker_api_trace", "counter_collection"
+        )
+        assert corresponding_counter_file.exists(), (
+            f"counter_collection.csv not found for {marker_file}"
+        )
+        # Check marker_api_trace.csv
+        expected_marker_columns = {
+            "Domain",
+            "Function",
+            "Process_Id",
+            "Thread_Id",
+            "Correlation_Id",
+            "Start_Timestamp",
+            "End_Timestamp",
+        }
+        with open(marker_file, newline="") as f:
+            reader = csv.DictReader(f)
+            fieldnames = reader.fieldnames
+            assert fieldnames is not None, f"No columns in {marker_file}"
+            for column in expected_marker_columns:
+                assert column in fieldnames, (
+                    f"Column '{column}' missing in {marker_file}"
+                )
+            found_row = False
+            for row in reader:
+                found_row = True
+                assert row["Function"], f"Empty Function in {marker_file}"
+                assert row["Correlation_Id"], f"Empty Correlation ID in {marker_file}"
+                assert row["Start_Timestamp"], f"Empty Start_Timestamp in {marker_file}"
+                assert row["End_Timestamp"], f"Empty End_Timestamp in {marker_file}"
+            assert found_row, f"{marker_file} is empty"
+        # Check counter_collection.csv
+        expected_counter_columns = {
+            "Correlation_Id",
+            "Kernel_Name",
+            "Counter_Name",
+            "Counter_Value",
+            "Start_Timestamp",
+            "End_Timestamp",
+        }
+        with open(corresponding_counter_file, newline="") as f:
+            reader = csv.DictReader(f)
+            fieldnames = reader.fieldnames
+            assert fieldnames is not None, f"No columns in {corresponding_counter_file}"
+            for column in expected_counter_columns:
+                assert column in fieldnames, (
+                    f"Column '{column}' missing in {corresponding_counter_file}"
+                )
+            found_row = False
+            for row in reader:
+                found_row = True
+
+                assert row["Correlation_Id"], (
+                    f"Empty Correlation_Id in {corresponding_counter_file}"
+                )
+
+                assert row["Kernel_Name"], (
+                    f"Empty Kernel_Name in {corresponding_counter_file}"
+                )
+
+                assert row["Counter_Name"], (
+                    f"Empty Counter_Name in {corresponding_counter_file}"
+                )
+
+                assert row["Start_Timestamp"], (
+                    f"Empty Start_Timestamp in {corresponding_counter_file}"
+                )
+
+                assert row["End_Timestamp"], (
+                    f"Empty End_Timestamp in {corresponding_counter_file}"
+                )
+
+            assert found_row, f"{corresponding_counter_file} is empty"
+
+    destination_dir = test_utils.get_output_dir(param_id="torch_ops_analyze")
+    # Saving the profiler output to analyze with the torch trace analyzer script
+    shutil.copytree(workload_dir, destination_dir, dirs_exist_ok=True)
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
-@skip_if_no_torch
+@skip_if_no_torch_gpu
+@pytest.mark.torch_operators
 def test_torch_trace_overhead(binary_handler_profile_rocprof_compute):
     """
     Measure overhead introduced by --torch-trace flag.
@@ -3353,11 +3443,7 @@ if __name__ == "__main__":
     print(f"  With flag kernel duration:    {with_flag_kernel_duration_total:.0f} ns")
     print(f"  Kernel execution overhead:    {kernel_overhead:.1f}%")
     print(f"{'=' * 70}\n")
-    # Verify torch trace directory was created
-    torch_trace_dir = Path(workload_dir_with_flag) / "torch_trace"
-    assert torch_trace_dir.exists(), "torch_trace directory should be created"
-    operator_csv_files = list(torch_trace_dir.glob("*.csv"))
-    assert len(operator_csv_files) > 0, "Operator CSV files should be generated"
+
     test_utils.clean_output_dir(config["cleanup"], workload_dir_with_flag)
     # Assert overhead is reasonable (< 100% wall-clock, < 50% kernel)
     assert wall_clock_overhead < 100, (


### PR DESCRIPTION
## Motivation

1)Torch Operator Trace Processing Moved to Analyze
2)Operator Filtering and Display of Hierarchy
3) Added flags in Analyze mode - ' --list-torch-operators', ' --torch-operator'
## Technical Details

```

rocprof-compute profile -b 2.1.1 --torch-trace --format-rocprof-output csv -n mnist --verbose -- python3 ./main.py --dry-run --epochs 1 --batch-size 1
rocprof-compute analyze --list-torch-operators -p workloads/mnist/MI300A_A1/

ls workloads/mnist/MI300A_A1/torch_trace/
max_pool2d.csv            nn_functional_dropout.csv  nn_functional_log_softmax.csv  ones_like.csv  zeros_like.csv
nn_functional_conv2d.csv  nn_functional_linear.csv   nn_functional_nll_loss.csv     relu.csv
```

Output of '--list-torch-operators'
<img width="409" height="205" alt="Screenshot 2026-02-05 185751" src="https://github.com/user-attachments/assets/171dfff7-6147-4a5d-b8f3-88be91317322" />


`rocprof-compute analyze --torch-operator relu -p workloads/mnist/MI300A_A1/`

<img width="1703" height="528" alt="Screenshot 2026-02-10 150754" src="https://github.com/user-attachments/assets/aeb819b2-c4cf-487e-ad7a-258f448d0207" />


Other ways to run '--torch-operator'

```
rocprof-compute analyze --torch-operator relu,ones_like -p workloads/mnist/MI300A_A1/
rocprof-compute analyze --torch-operator nn.Module.Net.forward/nn.Module.Conv2d.forward/torch.nn.functional.conv2d,nn_functional_linear -p workloads/mnist/MI300A_A1/

```

## JIRA ID

AIPROFCOMP-154

## Test Plan

```

python -m pytest -k test_torch_trace_profile -v -s
python -m pytest -k test_torch_trace_overhead -v -s

python -m pytest -k test_list_torch_operators_no_path -v -s
python -m pytest -k test_list_torch_operators_no_trace_data -v -s
python -m pytest -k test_torch_trace_operator_output -v -s
```

## Test Result

All the tests pass.
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
