### PR TITLE
rocr: Add hsa_amd_agent_preload API

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/performance/agent_preload.cc
+++ b/projects/rocr-runtime/rocrtst/suites/performance/agent_preload.cc
@@ -1,0 +1,416 @@
+/*
+* Copyright © Advanced Micro Devices, Inc., or its affiliates.
+*
+* SPDX-License-Identifier: MIT
+*/
+#include <algorithm>
+#include <chrono>
+#include <iostream>
+#include <iomanip>
+
+#include "suites/performance/agent_preload.h"
+#include "common/base_rocr_utils.h"
+#include "common/helper_funcs.h"
+#include "common/hsatimer.h"
+#include "gtest/gtest.h"
+
+// Find a global memory pool
+static hsa_status_t FindGlobalPool(hsa_amd_memory_pool_t pool, void* data) {
+  hsa_amd_segment_t segment;
+  hsa_amd_memory_pool_get_info(pool, HSA_AMD_MEMORY_POOL_INFO_SEGMENT, &segment);
+
+  if (segment != HSA_AMD_SEGMENT_GLOBAL) {
+    return HSA_STATUS_SUCCESS;
+  }
+
+  bool alloc_allowed = false;
+  hsa_amd_memory_pool_get_info(pool,
+                HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_ALLOWED, &alloc_allowed);
+
+  if (!alloc_allowed) {
+    return HSA_STATUS_SUCCESS;
+  }
+
+  hsa_amd_memory_pool_t* out_pool = static_cast<hsa_amd_memory_pool_t*>(data);
+  *out_pool = pool;
+  return HSA_STATUS_INFO_BREAK;
+}
+
+AgentPreloadTest::AgentPreloadTest() : TestBase() {
+  set_num_iteration(10);
+  set_title("Agent Preload Latency Test");
+  set_description("This test measures the latency reduction achieved by using "
+                  "hsa_amd_agent_preload() before calling "
+                  "hsa_amd_profiling_async_copy_enable(). The preload API warms"
+                  "up the clock counter cache to avoid first-call latency.");
+
+  latency_without_preload_us_ = 0.0;
+  latency_with_preload_us_ = 0.0;
+  latency_improvement_us_ = 0.0;
+  blit_latency_without_preload_us_ = 0.0;
+  blit_latency_with_preload_us_ = 0.0;
+  blit_latency_improvement_us_ = 0.0;
+}
+
+AgentPreloadTest::~AgentPreloadTest() {
+}
+
+void AgentPreloadTest::SetUp() {
+  hsa_status_t err;
+  TestBase::SetUp();
+
+  err = hsa_iterate_agents(rocrtst::IterateGPUAgents, &gpu_agents_);
+  ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+
+  err = hsa_iterate_agents(rocrtst::IterateCPUAgents, &cpu_agents_);
+  ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+
+  if (gpu_agents_.empty()) {
+    std::cout << "No GPU agents found. Test will be skipped." << std::endl;
+  }
+}
+
+void AgentPreloadTest::Run() {
+  if (!rocrtst::CheckProfile(this)) {
+    return;
+  }
+
+  TestBase::Run();
+
+  if (gpu_agents_.empty()) {
+    std::cout << "No GPU agents available. Skipping test." << std::endl;
+    return;
+  }
+
+  latency_without_preload_us_ = MeasureProfilingEnableLatencyWithoutPreload();
+  latency_with_preload_us_ = MeasureProfilingEnableLatencyWithPreload();
+  latency_improvement_us_ = latency_without_preload_us_ - latency_with_preload_us_;
+  EXPECT_GT(latency_improvement_us_, 0.0);
+
+  blit_latency_without_preload_us_ = MeasureFirstAsyncCopyLatencyWithoutPreload();
+  blit_latency_with_preload_us_ = MeasureFirstAsyncCopyLatencyWithPreload();
+  blit_latency_improvement_us_ = blit_latency_without_preload_us_ - blit_latency_with_preload_us_;
+  EXPECT_GT(blit_latency_improvement_us_, 0.0);
+}
+
+double AgentPreloadTest::MeasureProfilingEnableLatencyWithoutPreload() {
+  hsa_status_t err;
+
+  err = hsa_shut_down();
+  EXPECT_TRUE(err == HSA_STATUS_SUCCESS ||
+                                      err == HSA_STATUS_ERROR_NOT_INITIALIZED);
+
+  err = hsa_init();
+  EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+
+  std::vector<hsa_agent_t> gpus;
+  std::vector<hsa_agent_t> cpus;
+  err = hsa_iterate_agents(rocrtst::IterateGPUAgents, &gpus);
+  EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+  err = hsa_iterate_agents(rocrtst::IterateCPUAgents, &cpus);
+  EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+
+  if (gpus.empty()) {
+    return 0.0;
+  }
+
+  // Measure time for hsa_amd_profiling_async_copy_enable without preload
+  auto start = std::chrono::high_resolution_clock::now();
+  err = hsa_amd_profiling_async_copy_enable(true);
+  auto end = std::chrono::high_resolution_clock::now();
+
+  EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+
+  err = hsa_amd_profiling_async_copy_enable(false);
+  EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+
+  auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+  double latency_us = duration.count() / 1000.0;
+
+  if (verbosity() > 0) {
+    std::cout << "  Profiling enable latency WITHOUT preload: "
+              << std::fixed << std::setprecision(2) << latency_us << " us" << std::endl;
+  }
+
+  return latency_us;
+}
+
+double AgentPreloadTest::MeasureProfilingEnableLatencyWithPreload() {
+  hsa_status_t err;
+
+  err = hsa_shut_down();
+  EXPECT_TRUE(err == HSA_STATUS_SUCCESS ||
+                                      err == HSA_STATUS_ERROR_NOT_INITIALIZED);
+
+  err = hsa_init();
+  EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+
+  std::vector<hsa_agent_t> gpus;
+  std::vector<hsa_agent_t> cpus;
+  err = hsa_iterate_agents(rocrtst::IterateGPUAgents, &gpus);
+  EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+  err = hsa_iterate_agents(rocrtst::IterateCPUAgents, &cpus);
+  EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+
+  if (gpus.empty()) {
+    return 0.0;
+  }
+
+  // Preload clock sync for all GPU agents
+  for (const auto& gpu : gpus) {
+    err = hsa_amd_agent_preload(gpu, HSA_AMD_AGENT_PRELOAD_SKIP_BLITS);
+    EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+  }
+
+  // Measure time for hsa_amd_profiling_async_copy_enable with preload
+  auto start = std::chrono::high_resolution_clock::now();
+  err = hsa_amd_profiling_async_copy_enable(true);
+  auto end = std::chrono::high_resolution_clock::now();
+
+  EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+
+  err = hsa_amd_profiling_async_copy_enable(false);
+  EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+
+  auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+  double latency_us = duration.count() / 1000.0;
+
+  if (verbosity() > 0) {
+    std::cout << "  Profiling enable latency WITH preload: "
+              << std::fixed << std::setprecision(2) << latency_us << " us" << std::endl;
+  }
+
+  return latency_us;
+}
+
+double AgentPreloadTest::MeasureFirstAsyncCopyLatencyWithoutPreload() {
+  hsa_status_t err;
+  err = hsa_shut_down();
+  EXPECT_TRUE(err == HSA_STATUS_SUCCESS ||
+                                      err == HSA_STATUS_ERROR_NOT_INITIALIZED);
+
+  err = hsa_init();
+  EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+
+  std::vector<hsa_agent_t> gpus;
+  std::vector<hsa_agent_t> cpus;
+  err = hsa_iterate_agents(rocrtst::IterateGPUAgents, &gpus);
+  EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+  err = hsa_iterate_agents(rocrtst::IterateCPUAgents, &cpus);
+  EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+
+  if (gpus.empty() || cpus.empty()) {
+    return 0.0;
+  }
+
+  hsa_amd_memory_pool_t gpu_pool;
+  err = hsa_amd_agent_iterate_memory_pools(gpus[0], FindGlobalPool, &gpu_pool);
+  if (err != HSA_STATUS_INFO_BREAK) {
+    return 0.0;
+  }
+
+  hsa_amd_memory_pool_t cpu_pool;
+  err = hsa_amd_agent_iterate_memory_pools(cpus[0], FindGlobalPool, &cpu_pool);
+  if (err != HSA_STATUS_INFO_BREAK) {
+    return 0.0;
+  }
+
+  const size_t size = 4096;
+  void* src_ptr = nullptr;
+  void* dst_ptr = nullptr;
+
+  err = hsa_amd_memory_pool_allocate(cpu_pool, size, 0, &src_ptr);
+  if (err != HSA_STATUS_SUCCESS) {
+    EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+    return 0.0;
+  }
+
+  err = hsa_amd_memory_pool_allocate(gpu_pool, size, 0, &dst_ptr);
+  if (err != HSA_STATUS_SUCCESS) {
+    EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+    hsa_amd_memory_pool_free(src_ptr);
+    return 0.0;
+  }
+
+  err = hsa_amd_agents_allow_access(1, &gpus[0], nullptr, src_ptr);
+  if (err != HSA_STATUS_SUCCESS) {
+    EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+    hsa_amd_memory_pool_free(src_ptr);
+    hsa_amd_memory_pool_free(dst_ptr);
+    return 0.0;
+  }
+
+  hsa_signal_t signal;
+  err = hsa_signal_create(1, 0, nullptr, &signal);
+  if (err != HSA_STATUS_SUCCESS) {
+    EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+    hsa_amd_memory_pool_free(src_ptr);
+    hsa_amd_memory_pool_free(dst_ptr);
+    return 0.0;
+  }
+
+  // Measure first async copy without preloading blits
+  auto start = std::chrono::high_resolution_clock::now();
+  err = hsa_amd_memory_async_copy(dst_ptr, gpus[0], src_ptr, cpus[0], size, 0,
+                                                              nullptr, signal);
+  if (err != HSA_STATUS_SUCCESS) {
+    EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+    hsa_signal_destroy(signal);
+    hsa_amd_memory_pool_free(src_ptr);
+    hsa_amd_memory_pool_free(dst_ptr);
+    return 0.0;
+  }
+
+  hsa_signal_value_t signal_value =
+                      hsa_signal_wait_scacquire(signal, HSA_SIGNAL_CONDITION_LT,
+                                        1, UINT64_MAX, HSA_WAIT_STATE_BLOCKED);
+  if (signal_value != 0) {
+    EXPECT_EQ(signal_value, 0);
+    hsa_signal_destroy(signal);
+    hsa_amd_memory_pool_free(src_ptr);
+    hsa_amd_memory_pool_free(dst_ptr);
+    return 0.0;
+  }
+
+  auto end = std::chrono::high_resolution_clock::now();
+
+  hsa_signal_destroy(signal);
+  hsa_amd_memory_pool_free(src_ptr);
+  hsa_amd_memory_pool_free(dst_ptr);
+
+  auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+  double latency_us = duration.count() / 1000.0;
+
+  if (verbosity() > 0) {
+    std::cout << "  First async copy latency WITHOUT blit preload: "
+              << std::fixed << std::setprecision(2) << latency_us << " us" << std::endl;
+  }
+
+  return latency_us;
+}
+
+double AgentPreloadTest::MeasureFirstAsyncCopyLatencyWithPreload() {
+  hsa_status_t err;
+  err = hsa_shut_down();
+  EXPECT_TRUE(err == HSA_STATUS_SUCCESS ||
+                                      err == HSA_STATUS_ERROR_NOT_INITIALIZED);
+
+  err = hsa_init();
+  EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+
+  std::vector<hsa_agent_t> gpus;
+  std::vector<hsa_agent_t> cpus;
+  err = hsa_iterate_agents(rocrtst::IterateGPUAgents, &gpus);
+  EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+  err = hsa_iterate_agents(rocrtst::IterateCPUAgents, &cpus);
+  EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+
+  if (gpus.empty() || cpus.empty()) {
+    return 0.0;
+  }
+
+  // Preload blits
+  for (const auto& gpu : gpus) {
+    err = hsa_amd_agent_preload(gpu, HSA_AMD_AGENT_PRELOAD_SKIP_CLOCK_SYNC);
+    EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+  }
+
+  hsa_amd_memory_pool_t gpu_pool;
+  err = hsa_amd_agent_iterate_memory_pools(gpus[0], FindGlobalPool, &gpu_pool);
+  if (err != HSA_STATUS_INFO_BREAK) {
+    return 0.0;
+  }
+
+  hsa_amd_memory_pool_t cpu_pool;
+  err = hsa_amd_agent_iterate_memory_pools(cpus[0], FindGlobalPool, &cpu_pool);
+  if (err != HSA_STATUS_INFO_BREAK) {
+    return 0.0;
+  }
+
+  const size_t size = 4096;
+  void* src_ptr = nullptr;
+  void* dst_ptr = nullptr;
+
+  err = hsa_amd_memory_pool_allocate(cpu_pool, size, 0, &src_ptr);
+  if (err != HSA_STATUS_SUCCESS) {
+    EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+    return 0.0;
+  }
+
+  err = hsa_amd_memory_pool_allocate(gpu_pool, size, 0, &dst_ptr);
+  if (err != HSA_STATUS_SUCCESS) {
+    EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+    hsa_amd_memory_pool_free(src_ptr);
+    return 0.0;
+  }
+
+  err = hsa_amd_agents_allow_access(1, &gpus[0], nullptr, src_ptr);
+  if (err != HSA_STATUS_SUCCESS) {
+    EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+    hsa_amd_memory_pool_free(src_ptr);
+    hsa_amd_memory_pool_free(dst_ptr);
+    return 0.0;
+  }
+
+  hsa_signal_t signal;
+  err = hsa_signal_create(1, 0, nullptr, &signal);
+  if (err != HSA_STATUS_SUCCESS) {
+    EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+    hsa_amd_memory_pool_free(src_ptr);
+    hsa_amd_memory_pool_free(dst_ptr);
+    return 0.0;
+  }
+
+  // Measure first async copy with blits preloaded
+  auto start = std::chrono::high_resolution_clock::now();
+  err = hsa_amd_memory_async_copy(dst_ptr, gpus[0], src_ptr, cpus[0], size, 0, nullptr, signal);
+  if (err != HSA_STATUS_SUCCESS) {
+    EXPECT_EQ(err, HSA_STATUS_SUCCESS);
+    hsa_signal_destroy(signal);
+    hsa_amd_memory_pool_free(src_ptr);
+    hsa_amd_memory_pool_free(dst_ptr);
+    return 0.0;
+  }
+
+  hsa_signal_value_t signal_value =
+                      hsa_signal_wait_scacquire(signal, HSA_SIGNAL_CONDITION_LT,
+                                        1, UINT64_MAX, HSA_WAIT_STATE_BLOCKED);
+  if (signal_value != 0) {
+    EXPECT_EQ(signal_value, 0);
+    hsa_signal_destroy(signal);
+    hsa_amd_memory_pool_free(src_ptr);
+    hsa_amd_memory_pool_free(dst_ptr);
+    return 0.0;
+  }
+  auto end = std::chrono::high_resolution_clock::now();
+
+  hsa_signal_destroy(signal);
+  hsa_amd_memory_pool_free(src_ptr);
+  hsa_amd_memory_pool_free(dst_ptr);
+
+  auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
+  double latency_us = duration.count() / 1000.0;
+
+  if (verbosity() > 0) {
+    std::cout << "  First async copy latency WITH blit preload: "
+              << std::fixed << std::setprecision(2) << latency_us << " us" << std::endl;
+  }
+
+  return latency_us;
+}
+
+void AgentPreloadTest::DisplayTestInfo(void) {
+  TestBase::DisplayTestInfo();
+}
+
+void AgentPreloadTest::DisplayResults(void) const {
+  if (!rocrtst::CheckProfile(this)) {
+    return;
+  }
+
+  return;
+}
+
+void AgentPreloadTest::Close() {
+  TestBase::Close();
+}

--- a/projects/rocr-runtime/rocrtst/suites/performance/agent_preload.h
+++ b/projects/rocr-runtime/rocrtst/suites/performance/agent_preload.h
@@ -1,0 +1,78 @@
+/*
+* Copyright © Advanced Micro Devices, Inc., or its affiliates.
+*
+* SPDX-License-Identifier: MIT
+*/
+#ifndef ROCRTST_SUITES_PERFORMANCE_AGENT_PRELOAD_H_
+#define ROCRTST_SUITES_PERFORMANCE_AGENT_PRELOAD_H_
+
+#include <vector>
+
+#include "suites/test_common/test_base.h"
+#include "common/base_rocr.h"
+#include "common/common.h"
+#include "hsa/hsa.h"
+#include "hsa/hsa_ext_amd.h"
+
+class AgentPreloadTest : public TestBase {
+ public:
+  // @Brief: Constructor
+  AgentPreloadTest();
+
+  // @Brief: Destructor
+  virtual ~AgentPreloadTest(void);
+
+  // @Brief: Set up the environment for the test
+  virtual void SetUp(void);
+
+  // @Brief: Run the test case
+  virtual void Run(void);
+
+  // @Brief: Display results
+  virtual void DisplayResults(void) const;
+
+  // @Brief: Display information about what this test does
+  virtual void DisplayTestInfo(void);
+
+  // @Brief: Clean up and close the runtime
+  virtual void Close(void);
+
+ private:
+  // @Brief: Measure profiling enable latency without preload
+  double MeasureProfilingEnableLatencyWithoutPreload();
+
+  // @Brief: Measure profiling enable latency with preload
+  double MeasureProfilingEnableLatencyWithPreload();
+
+  // @Brief: Measure first async copy latency without blit preload
+  double MeasureFirstAsyncCopyLatencyWithoutPreload();
+
+  // @Brief: Measure first async copy latency with blit preload
+  double MeasureFirstAsyncCopyLatencyWithPreload();
+
+  // GPU agents to test
+  std::vector<hsa_agent_t> gpu_agents_;
+
+  // CPU agents for profiling enable
+  std::vector<hsa_agent_t> cpu_agents_;
+
+  // Latency without preload (microseconds)
+  double latency_without_preload_us_;
+
+  // Latency with preload (microseconds)
+  double latency_with_preload_us_;
+
+  // Latency improvement (microseconds)
+  double latency_improvement_us_;
+
+  // Blit copy latency without preload (microseconds)
+  double blit_latency_without_preload_us_;
+
+  // Blit copy latency with preload (microseconds)
+  double blit_latency_with_preload_us_;
+
+  // Blit latency improvement (microseconds)
+  double blit_latency_improvement_us_;
+};
+
+#endif  // ROCRTST_SUITES_PERFORMANCE_AGENT_PRELOAD_H_

--- a/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
@@ -66,6 +66,7 @@
 #endif
 #include "suites/performance/memory_async_copy_on_engine.h"
 #include "suites/performance/enqueueLatency.h"
+#include "suites/performance/agent_preload.h"
 #include "suites/negative/memory_allocate_negative_tests.h"
 #include "suites/negative/queue_validation.h"
 #include "suites/stress/memory_concurrent_tests.h"
@@ -813,6 +814,11 @@ TEST(rocrtstPerf, AQL_Dispatch_Time_Multi_SpinWait) {
 TEST(rocrtstPerf, AQL_Dispatch_Time_Multi_Interrupt) {
   DispatchTime dt(false, false);
   RunGenericTest(&dt);
+}
+
+TEST(rocrtstPerf, Agent_Preload_Latency) {
+  AgentPreloadTest apt;
+  RunGenericTest(&apt);
 }
 
 int main(int argc, char** argv) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
@@ -870,6 +870,11 @@ hsa_status_t HSA_API
     return amdExtTable->hsa_amd_profiling_async_copy_enable_fn(enable);
 }
 
+hsa_status_t HSA_API
+  hsa_amd_agent_preload(hsa_agent_t agent, uint64_t flags) {
+    return amdExtTable->hsa_amd_agent_preload_fn(agent, flags);
+}
+
 // Mirrors Amd Extension Apis
 hsa_status_t HSA_API hsa_amd_profiling_get_dispatch_time(
     hsa_agent_t agent, hsa_signal_t signal,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -377,6 +377,8 @@ class GpuAgent : public GpuAgentInt {
     return current_coherency_type_;
   }
 
+  hsa_status_t Preload(uint64_t flags);
+
   core::Agent* GetNearestCpuAgent(void) const;
 
   void RegisterGangPeer(core::Agent& gang_peer, unsigned int bandwidth_factor) override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
@@ -70,6 +70,9 @@ hsa_status_t
     hsa_amd_profiling_async_copy_enable(bool enable);
 
 // Mirrors Amd Extension Apis
+hsa_status_t hsa_amd_agent_preload(hsa_agent_t agent, uint64_t flags);
+
+// Mirrors Amd Extension Apis
 hsa_status_t hsa_amd_profiling_get_dispatch_time(
     hsa_agent_t agent, hsa_signal_t signal,
     hsa_amd_profiling_dispatch_time_t* time);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -3867,5 +3867,18 @@ hsa_status_t GpuAgent::ReleaseCountedQueue(hsa_queue_t* queue) {
   return queue_pool_.ReleaseQueue(queue);
 }
 
+hsa_status_t GpuAgent::Preload(uint64_t flags) {
+  // By default preload everything; flags are used to skip specific resources
+  if (!(flags & HSA_AMD_AGENT_PRELOAD_SKIP_CLOCK_SYNC)) {
+    CheckClockTicks();
+  }
+
+  if (!(flags & HSA_AMD_AGENT_PRELOAD_SKIP_BLITS)) {
+    PreloadBlits();
+  }
+
+  return HSA_STATUS_SUCCESS;
+}
+
 }  // namespace amd
 }  // namespace rocr

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_api_trace.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_api_trace.cpp
@@ -87,7 +87,7 @@ void HsaApiTable::Init() {
   // they can add preprocessor macros on the new functions
 
   constexpr size_t expected_core_api_table_size = 1016;
-  constexpr size_t expected_amd_ext_table_size = 648;
+  constexpr size_t expected_amd_ext_table_size = 656;
   constexpr size_t expected_image_ext_table_size = 128;
   constexpr size_t expected_finalizer_ext_table_size = 64;
   constexpr size_t expected_tools_table_size = 64;
@@ -482,6 +482,7 @@ void HsaApiTable::UpdateAmdExts() {
   amd_ext_api.hsa_amd_memory_get_preferred_copy_engine_fn = AMD::hsa_amd_memory_get_preferred_copy_engine;
   amd_ext_api.hsa_amd_portable_export_dmabuf_v2_fn = AMD::hsa_amd_portable_export_dmabuf_v2;
   amd_ext_api.hsa_amd_memory_async_batch_copy_fn = AMD::hsa_amd_memory_async_batch_copy;
+  amd_ext_api.hsa_amd_agent_preload_fn = AMD::hsa_amd_agent_preload;
 }
 
 void HsaApiTable::UpdateTools() {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -638,6 +638,23 @@ hsa_status_t hsa_amd_profiling_async_copy_enable(bool enable) {
   CATCH;
 }
 
+hsa_status_t hsa_amd_agent_preload(hsa_agent_t agent, uint64_t flags) {
+  TRY;
+  IS_OPEN();
+
+  core::Agent* agent_ptr = core::Agent::Convert(agent);
+  IS_VALID(agent_ptr);
+
+  if (agent_ptr->device_type() != core::Agent::kAmdGpuDevice) {
+    return HSA_STATUS_ERROR_INVALID_AGENT;
+  }
+
+  AMD::GpuAgent* gpu_agent = static_cast<AMD::GpuAgent*>(agent_ptr);
+  return gpu_agent->Preload(flags);
+
+  CATCH;
+}
+
 hsa_status_t hsa_amd_profiling_get_dispatch_time(
     hsa_agent_t agent_handle, hsa_signal_t hsa_signal,
     hsa_amd_profiling_dispatch_time_t* time) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/hsacore.dll.def
+++ b/projects/rocr-runtime/runtime/hsa-runtime/hsacore.dll.def
@@ -231,3 +231,4 @@ EXPORTS
   hsa_ext_image_create_v2
   hsa_ext_image_data_get_info_v2
   hsa_ext_image_destroy_v2
+  hsa_amd_agent_preload

--- a/projects/rocr-runtime/runtime/hsa-runtime/hsacore.so.def
+++ b/projects/rocr-runtime/runtime/hsa-runtime/hsacore.so.def
@@ -171,6 +171,7 @@ global:
 	hsa_amd_profiling_set_profiler_enabled;
 	hsa_amd_profiling_get_dispatch_time;
 	hsa_amd_profiling_async_copy_enable;
+	hsa_amd_agent_preload;
 	hsa_amd_profiling_get_async_copy_time;
 	hsa_amd_profiling_convert_tick_to_system_domain;
 	hsa_amd_signal_create;

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace.h
@@ -276,6 +276,7 @@ struct AmdExtTable {
   decltype(hsa_amd_counted_queue_acquire)* hsa_amd_counted_queue_acquire_fn;
   decltype(hsa_amd_counted_queue_release)* hsa_amd_counted_queue_release_fn;
   decltype(hsa_amd_memory_async_batch_copy)* hsa_amd_memory_async_batch_copy_fn;
+  decltype(hsa_amd_agent_preload) *hsa_amd_agent_preload_fn;
 };
 
 // Table to export HSA Core Runtime Apis

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace_version.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace_version.h
@@ -58,7 +58,7 @@
 // Step Ids of the Api tables exported by Hsa Core Runtime
 #define HSA_API_TABLE_STEP_VERSION                  0x01
 #define HSA_CORE_API_TABLE_STEP_VERSION             0x00
-#define HSA_AMD_EXT_API_TABLE_STEP_VERSION          0x0A
+#define HSA_AMD_EXT_API_TABLE_STEP_VERSION          0x0B
 #define HSA_FINALIZER_API_TABLE_STEP_VERSION        0x00
 #define HSA_IMAGE_API_TABLE_STEP_VERSION            0x01
 // Rocprofiler just checks HSA_MAGE_EXT_API_TABLE_STEP_VERSION

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -69,9 +69,10 @@
  * - 1.16 - hsa_amd_counted_queue APIs
  * - 1.17 - hsa_amd_memory_async_batch_copy
  * - 1.18 - hsa_amd_pointer_info: Added alloc_flags field to hsa_amd_pointer_info_t
+ * - 1.19 - hsa_amd_agent_preload
  */
 #define HSA_AMD_INTERFACE_VERSION_MAJOR 1
-#define HSA_AMD_INTERFACE_VERSION_MINOR 18
+#define HSA_AMD_INTERFACE_VERSION_MINOR 19
 
 #ifdef __cplusplus
 extern "C" {
@@ -940,6 +941,43 @@ hsa_status_t HSA_API
  */
 hsa_status_t HSA_API
     hsa_amd_profiling_async_copy_enable(bool enable);
+
+/**
+ * @brief Flags for hsa_amd_agent_preload.
+ *
+ * @details By default, hsa_amd_agent_preload preloads all resources.
+ * These flags can be used to skip specific resources.
+ */
+typedef enum hsa_amd_agent_preload_flag_s {
+  /**
+   * Skip preloading clock synchronization data.
+   */
+  HSA_AMD_AGENT_PRELOAD_SKIP_CLOCK_SYNC = (1 << 0),
+  /**
+   * Skip preloading blit kernel objects.
+   */
+  HSA_AMD_AGENT_PRELOAD_SKIP_BLITS = (1 << 1)
+} hsa_amd_agent_preload_flag_t;
+
+/**
+ * @brief Performance hint to preload agent resources.
+ *
+ * @details Trigger early initialization of agent resources. By default,
+ * all resources are preloaded. Use flags to skip specific resources.
+ *
+ * @param[in] agent The agent to preload resources for. Must be a GPU agent.
+ *
+ * @param[in] flags A bitwise OR of ::hsa_amd_agent_preload_flag_t values
+ * specifying which resources to skip.
+ *
+ * @retval ::HSA_STATUS_SUCCESS The function has been executed successfully.
+ *
+ * @retval ::HSA_STATUS_ERROR_NOT_INITIALIZED The HSA runtime has not been
+ * initialized.
+ *
+ * @retval ::HSA_STATUS_ERROR_INVALID_AGENT The agent is invalid or not a GPU.
+ */
+hsa_status_t HSA_API hsa_amd_agent_preload(hsa_agent_t agent, uint64_t flags);
 
 /**
  * @brief Retrieve packet processing time stamps.


### PR DESCRIPTION
Add hsa_amd_agent_preload API to preload
clock sync and blit kernels to avoid cache-cold
latency on first profiling enable or async copy.

Add rocrtst performance test.

