### PR TITLE
Fix libdrm discovery on RHEL 8.8

### DIFF
--- a/projects/rocprofiler-sdk/cmake/rocprofiler_config_interfaces.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_config_interfaces.cmake
@@ -262,6 +262,12 @@ rocprofiler_config_nolink_target(rocprofiler-sdk-hsakmt-nolink hsakmt::hsakmt)
 find_package(PkgConfig)
 
 if(PkgConfig_FOUND)
+    # Prepend ROCm pkg-config paths to ensure ROCm-provided libdrm is found first This
+    # fixes linking issues on older systems (e.g., RHEL 8.8) where system libdrm may be
+    # missing newer symbols like amdgpu_device_get_fd
+    set(ENV{PKG_CONFIG_PATH}
+        "${ROCPROFILER_DEFAULT_ROCM_PATH}/lib/pkgconfig:${ROCPROFILER_DEFAULT_ROCM_PATH}/lib64/pkgconfig:$ENV{PKG_CONFIG_PATH}"
+        )
     pkg_check_modules(DRM REQUIRED IMPORTED_TARGET libdrm)
     pkg_check_modules(DRM_AMDGPU REQUIRED IMPORTED_TARGET libdrm_amdgpu)
 


### PR DESCRIPTION
## Summary

- Prepends ROCm pkg-config paths (`${ROCPROFILER_DEFAULT_ROCM_PATH}/lib/pkgconfig` and `lib64/pkgconfig`) to `PKG_CONFIG_PATH` before `pkg_check_modules` calls for libdrm
- Ensures ROCm-provided libdrm is found first on older systems

## Problem

RHEL 8.8 has an older system libdrm that is missing the `amdgpu_device_get_fd` symbol. When building rocprofiler-sdk on RHEL 8.8, pkg-config finds the system libdrm instead of the ROCm-provided version, leading to undefined symbol errors at link time.

## Solution

By prepending the ROCm pkg-config paths to `PKG_CONFIG_PATH`, we ensure that the ROCm-provided libdrm (which includes the `amdgpu_device_get_fd` symbol) is found first by pkg_check_modules.

## Test plan

- [ ] CI validation on RHEL 8.8
- [ ] Verify libdrm linking succeeds with ROCm-provided libdrm
- [ ] Ensure no regression on other platforms (Ubuntu, SLES, etc.)

---
Generated with [Claude Code](https://claude.com/claude-code)