### PR TITLE
Fix ROCM_VERSION guard used for the scratch_memory_record structure

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -570,7 +570,7 @@ get_scratch_mem_alloc_size(
     [[maybe_unused]] const rocprofiler_buffer_tracing_scratch_memory_record_t& record)
 {
 // The version of rocprofiler_buffer_tracing_scratch_memory_record_t from ROCm < 7.1 does
-// not have the allocation_size field ROCPROFILER_VERSION for both ROCm 7.0 and 7.1
+// not have the allocation_size field. ROCPROFILER_VERSION for both ROCm 7.0 and 7.1
 // is 1.0.0, so we need to check the ROCm version.
 #if(ROCPROFSYS_USE_ROCM > 0 && ROCPROFSYS_ROCM_VERSION >= 70100)
     return record.allocation_size;
@@ -1835,7 +1835,7 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
                 if(get_use_perfetto())
                 {
 // The version of rocprofiler_buffer_tracing_scratch_memory_record_t from ROCm < 7.1 does
-// not have the allocation_size field ROCPROFILER_VERSION for both ROCm 7.0 and 7.1
+// not have the allocation_size field. ROCPROFILER_VERSION for both ROCm 7.0 and 7.1
 // is 1.0.0, so we need to check the ROCm version.
 #if(ROCPROFSYS_USE_ROCM > 0 && ROCPROFSYS_ROCM_VERSION >= 70100)
                     using counter_track = perfetto_counter_track<

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -569,8 +569,10 @@ uint64_t
 get_scratch_mem_alloc_size(
     [[maybe_unused]] const rocprofiler_buffer_tracing_scratch_memory_record_t& record)
 {
-// Scratch memory samples from SDK versions prior to 7.0.2 do not include allocation_size
-#if(ROCPROFSYS_USE_ROCM > 0 && ROCPROFSYS_ROCM_VERSION >= 70002)
+// The version of rocprofiler_buffer_tracing_scratch_memory_record_t from ROCm < 7.1 does
+// not have the allocation_size field ROCPROFILER_VERSION for both ROCm 7.0 and 7.1
+// is 1.0.0, so we need to check the ROCm version.
+#if(ROCPROFSYS_USE_ROCM > 0 && ROCPROFSYS_ROCM_VERSION >= 70100)
     return record.allocation_size;
 #else
     return 0;
@@ -1832,9 +1834,10 @@ tool_tracing_buffered(rocprofiler_context_id_t /*context*/,
 
                 if(get_use_perfetto())
                 {
-// Scratch memory samples from SDK versions prior to 7.0.2 do not include
-// allocation_size field, so counter tracks are not needed
-#if(ROCPROFSYS_USE_ROCM > 0 && ROCPROFSYS_ROCM_VERSION >= 70002)
+// The version of rocprofiler_buffer_tracing_scratch_memory_record_t from ROCm < 7.1 does
+// not have the allocation_size field ROCPROFILER_VERSION for both ROCm 7.0 and 7.1
+// is 1.0.0, so we need to check the ROCm version.
+#if(ROCPROFSYS_USE_ROCM > 0 && ROCPROFSYS_ROCM_VERSION >= 70100)
                     using counter_track = perfetto_counter_track<
                         rocprofiler_buffer_tracing_scratch_memory_record_t>;
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This fixes a rocm/7.0.2 build failure

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Fixed the compile-time guard used for accessing `rocprofiler_buffer_tracing_scratch_memory_record_t` structure. 

`buffer_tracing.h` from rocm-7.1.x include `uint64_t allocation_size;  ///< size of scratch memory allocation in bytes`:
https://github.com/ROCm/rocm-systems/blob/release/rocm-rel-7.1/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/buffer_tracing.h#L500

`buffer_tracing.h` from rocm-7.0.x does not:
From https://github.com/ROCm/rocm-systems/blob/release/rocm-rel-7.0/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/buffer_tracing.h#L500. 

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
Part of AIPROFSYST-82

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
