### PR TITLE
[rocprofiler-sdk] Fix RHEL 8.8 CI job build failure

### DIFF
--- a/.github/workflows/aqlprofile-continuous_integration.yml
+++ b/.github/workflows/aqlprofile-continuous_integration.yml
@@ -27,7 +27,7 @@ concurrency:
 
 env:
   ROCM_PATH: "/opt/rocm"
-  ROCM_VERSION: "7.1.1"
+  ROCM_VERSION: "7.2.0"
   PYTHON_VENV_PATH: "aqlprofile"
   PYTHON_VENV_ACTIVATE: "aqlprofile/bin/activate"
   navi3_EXCLUDE_TESTS_REGEX: ""

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -188,6 +188,11 @@ jobs:
             ${{ env.ROCM_PATH }}*/lib/python*/site-packages/roctx \
             ${{ env.ROCM_PATH }}*/lib/python*/site-packages/rocpd
 
+      - name: Setup environment variables
+        shell: bash
+        run: |
+          echo "PKG_CONFIG_PATH=/opt/amdgpu/lib64/pkgconfig:/opt/amdgpu/lib/pkgconfig:/opt/amdgpu/lib/$(uname -p)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}" >> $GITHUB_ENV
+
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@63069e3931dedbf3b63792097479563182fe70d1 # v1.2.18
         with:
@@ -510,6 +515,12 @@ jobs:
             ${{ env.ROCM_PATH }}/share/*rocprofiler-sdk* \
             ${{ env.ROCM_PATH }}/libexec/*rocprofiler-sdk*
 
+        # on RHEL 8.8, this fixes an issue with finding libdrm_amdgpu in /usr instead of /opt/amdgpu
+      - name: Setup environment variables
+        shell: bash
+        run: |
+          echo "PKG_CONFIG_PATH=/opt/amdgpu/lib64/pkgconfig:/opt/amdgpu/lib/pkgconfig:/opt/amdgpu/lib/$(uname -p)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}" >> $GITHUB_ENV
+
       - name: Install Curl for RHEL 8.8
         if: ${{ matrix.system.os == 'rhel-8.8' }}
         run: |
@@ -747,6 +758,11 @@ jobs:
         update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_COMPILER_VERSION }} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_COMPILER_VERSION }} --slave /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_COMPILER_VERSION }}
         python3 -m pip install -U --user -r requirements.txt
         rm -rf ${{ env.ROCM_PATH }}/lib/*rocprofiler-sdk* ${{ env.ROCM_PATH }}/lib/cmake/*rocprofiler-sdk* ${{ env.ROCM_PATH }}/share/*rocprofiler-sdk* ${{ env.ROCM_PATH }}/libexec/*rocprofiler-sdk* ${{ env.ROCM_PATH }}*/lib/python*/site-packages/roctx ${{ env.ROCM_PATH }}*/lib/python*/site-packages/rocpd
+
+    - name: Setup environment variables
+      shell: bash
+      run: |
+        echo "PKG_CONFIG_PATH=/opt/amdgpu/lib64/pkgconfig:/opt/amdgpu/lib/pkgconfig:/opt/amdgpu/lib/$(uname -p)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}" >> $GITHUB_ENV
 
     - name: List Files
       shell: bash

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -44,7 +44,7 @@ permissions:
 env:
   # TODO(jrmadsen): replace LD_RUNPATH_FLAG, GPU_TARGETS, etc. with internal handling in cmake
   ROCM_PATH: "/opt/rocm"
-  ROCM_VERSION: "7.1.1"
+  ROCM_VERSION: "7.2.0"
   PYTHON_VENV_PATH: "rocprofiler-sdk"
   PYTHON_VENV_ACTIVATE: "rocprofiler-sdk/bin/activate"
   GPU_TARGETS: "gfx906 gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1102 gfx1201"

--- a/.github/workflows/rocprofiler-sdk-docs.yml
+++ b/.github/workflows/rocprofiler-sdk-docs.yml
@@ -30,7 +30,7 @@ concurrency:
 env:
   GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
   ROCM_PATH: "/opt/rocm"
-  ROCM_VERSION: "7.1.1"
+  ROCM_VERSION: "7.2.0"
 
 jobs:
   build-docs:

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_config_interfaces.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_config_interfaces.cmake
@@ -288,13 +288,15 @@ else()
         drm_LIBRARY
         NAMES drm
         HINTS ${rocm_version_DIR} ${ROCM_PATH} /opt/amdgpu
-        PATHS ${rocm_version_DIR} ${ROCM_PATH} /opt/amdgpu REQUIRED)
+        PATHS ${rocm_version_DIR} ${ROCM_PATH} /opt/amdgpu
+        PATH_SUFFIXES ${CMAKE_SYSTEM_PROCESSOR}-linux-gnu REQUIRED)
 
     find_library(
         drm_amdgpu_LIBRARY
         NAMES drm_amdgpu
         HINTS ${rocm_version_DIR} ${ROCM_PATH} /opt/amdgpu
-        PATHS ${rocm_version_DIR} ${ROCM_PATH} /opt/amdgpu REQUIRED)
+        PATHS ${rocm_version_DIR} ${ROCM_PATH} /opt/amdgpu
+        PATH_SUFFIXES ${CMAKE_SYSTEM_PROCESSOR}-linux-gnu REQUIRED)
 
     target_include_directories(rocprofiler-sdk-drm SYSTEM
                                INTERFACE ${drm_INCLUDE_DIR} ${xf86drm_INCLUDE_DIR})

--- a/projects/rocprofiler-sdk/docker/Dockerfile.ci
+++ b/projects/rocprofiler-sdk/docker/Dockerfile.ci
@@ -30,6 +30,7 @@ RUN set-euo pipefail; \
         apt-get install -y git rocm-openmp-sdk libva-amdgpu-dev rocm-llvm-dev && \
         python3 -m pip install -U awscli pipx && \
         python3 -m pip install -U --user -r /root/requirements.txt; \
+        echo -e 'PKG_CONFIG_PATH="/opt/amdgpu/lib64/pkgconfig:/opt/amdgpu/lib/pkgconfig:/opt/amdgpu/lib/$(uname -p)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}"\nexport PKG_CONFIG_PATH' > /etc/profile.d/amdgpu-pkg-config.sh; \
     fi;
 
 # RHEL
@@ -64,6 +65,7 @@ RUN set -euo pipefail; \
         export PATH=/opt/rh/gcc-toolset-11/root/usr/bin:${PATH}; \
         python3 -m pip install --upgrade pip; \
         python3 -m pip install --upgrade -r /root/requirements.txt; \
+        echo -e 'PKG_CONFIG_PATH="/opt/amdgpu/lib64/pkgconfig:/opt/amdgpu/lib/pkgconfig:/opt/amdgpu/lib/$(uname -p)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}"\nexport PKG_CONFIG_PATH' > /etc/profile.d/amdgpu-pkg-config.sh; \
     fi;
 
 # SLES
@@ -84,6 +86,7 @@ RUN set -euo pipefail; \
         cd /tmp; wget https://www.kernel.org/pub/software/scm/git/git-2.52.0.tar.xz; \
         tar -xf git-2.52.0.tar.xz; cd git-2.52.0; make prefix=/usr all -j 32; make prefix=/usr install; \
         cd /tmp; ln -s -f /usr/bin/git /usr/local/bin/git; rm -rf git-2.52.0*; \
+        echo -e 'PKG_CONFIG_PATH="/opt/amdgpu/lib64/pkgconfig:/opt/amdgpu/lib/pkgconfig:/opt/amdgpu/lib/$(uname -p)-linux-gnu/pkgconfig:${PKG_CONFIG_PATH}"\nexport PKG_CONFIG_PATH' > /etc/profile.d/amdgpu-pkg-config.sh; \
     fi;
 
 # Nightly Tarball


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
- RHEL 8.8 build failure is resulting from outdated libdrm_amdgpu in `/usr` vs. `/opt/amdgpu`
- ensures `pkg-config` finds libdrm_amdgpu in `/opt/amdgpu` instead of `/usr`

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Adds `PKG_CONFIG_PATH` env variable to CI jobs
- Ensures shell within docker container set `PKG_CONFIG_PATH`
- Improve support for non-`pkg-config` search for libdrm_amdgpu

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Fixes testing workflow

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
