### PR TITLE
[SWDEV-573565] Fix amd-smi metric JSON output under watch mode

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -1702,8 +1702,9 @@ class AMDSMICommands():
                 # Reload original gpus
                 args.gpu = stored_gpus
 
-                # Print multiple device output for all formats
-                self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
+                # Print multiple device output
+                if not self.logger.is_json_format() or watching_output:
+                    self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
 
                 # Add output to total watch output and clear multiple device output
                 if watching_output:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -1702,16 +1702,12 @@ class AMDSMICommands():
                 # Reload original gpus
                 args.gpu = stored_gpus
 
-                # Print multiple device output
-                if not self.logger.is_json_format():
-                    self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
+                # Print multiple device output for all formats
+                self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
 
                 # Add output to total watch output and clear multiple device output
                 if watching_output:
                     self.logger.store_watch_output(multiple_device_enabled=True)
-
-                    # Flush the watching output
-                    self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
 
                 return
             elif len(args.gpu) == 1:
@@ -2737,8 +2733,8 @@ class AMDSMICommands():
             self.logger.store_multiple_device_output()
             return # Skip printing when there are multiple devices
 
-        if not self.logger.is_json_format():
-            self.logger.print_output(watching_output=watching_output)
+        # Print output for all formats
+        self.logger.print_output(watching_output=watching_output)
 
         if watching_output: # End of single gpu add to watch_output
             self.logger.store_watch_output(multiple_device_enabled=False)


### PR DESCRIPTION
## Motivation

For commands such as amd-smi metric -w 1 --json, there was no output in watch mode for json output.

## Technical Details

Output was not being printed with json output for command .

## JIRA ID

SWDEV-573565


## Test Plan

amd-smi metric --watch=1 --json

## Test Result

<img width="341" height="260" alt="image" src="https://github.com/user-attachments/assets/bf06f267-d367-4a34-8936-be0e00e43a87" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
