### PR TITLE
[ROCM-1845] Fix amd-smi metric JSON output under watch mode

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -1742,16 +1742,12 @@ class AMDSMICommands():
                 # Reload original gpus
                 args.gpu = stored_gpus
 
-                # Print multiple device output
-                if not self.logger.is_json_format():
-                    self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
+                # Print multiple device output for all formats
+                self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
 
                 # Add output to total watch output and clear multiple device output
                 if watching_output:
                     self.logger.store_watch_output(multiple_device_enabled=True)
-
-                    # Flush the watching output
-                    self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
 
                 return
             elif len(args.gpu) == 1:
@@ -2777,8 +2773,8 @@ class AMDSMICommands():
             self.logger.store_multiple_device_output()
             return # Skip printing when there are multiple devices
 
-        if not self.logger.is_json_format():
-            self.logger.print_output(watching_output=watching_output)
+        # Print output for all formats
+        self.logger.print_output(watching_output=watching_output)
 
         if watching_output: # End of single gpu add to watch_output
             self.logger.store_watch_output(multiple_device_enabled=False)

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -1742,8 +1742,9 @@ class AMDSMICommands():
                 # Reload original gpus
                 args.gpu = stored_gpus
 
-                # Print multiple device output for all formats
-                self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
+                # Print multiple device output
+                if not self.logger.is_json_format() or watching_output:
+                    self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
 
                 # Add output to total watch output and clear multiple device output
                 if watching_output:


### PR DESCRIPTION
The print_output() is now only called for:
 - Non-JSON formats like human-readable and csv
   where per-device printing works.
 - JSON format when in watch mode where incremental
   output is expected.

Signed-off-by: Bindhiya Kanangot Balakrishnan <Bindhiya.KanangotBalakrishnan@amd.com>

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
