### PR TITLE
[ci] Adding TSAN builds

### DIFF
--- a/projects/aqlprofile/test/integration/CMakeLists.txt
+++ b/projects/aqlprofile/test/integration/CMakeLists.txt
@@ -66,7 +66,5 @@ target_link_libraries(testv2 PRIVATE hsa-runtime64::hsa-runtime64 ${AQLPROFILE_T
 target_compile_definitions(testv2 PUBLIC AMD_INTERNAL_BUILD)
 
 # Add a PRELOAD environment with libintercept
-set(ENV{LD_PRELOAD} "$ENV{LD_PRELOAD}:${CMAKE_CURRENT_BINARY_DIR}/libintercept.so")
-
 add_test(NAME testv2 COMMAND testv2)
-set_tests_properties(testv2 PROPERTIES ENVIRONMENT "${LD_PRELOAD}" TIMEOUT 45 LABELS "unittests" FAIL_REGULAR_EXPRESSION "${AQLPROFILE_DEFAULT_FAIL_REGEX}")
+set_tests_properties(testv2 PROPERTIES ENVIRONMENT "${LD_PRELOAD}:${CMAKE_CURRENT_BINARY_DIR}/libintercept.so" TIMEOUT 45 LABELS "unittests" FAIL_REGULAR_EXPRESSION "${AQLPROFILE_DEFAULT_FAIL_REGEX}")


### PR DESCRIPTION
## Motivation

Enabling TSAN builds

## Technical Details

Permanent export of LD_PRELOAD env is causing TSAN build failures in another stage which run under same session context. So moved export of env to command context.

## Test Result

PASS TSAN Build: https://github.com/ROCm/TheRock/actions/runs/21434847328/job/61722937994
