### PR TITLE
[CLR] Added missed ostream include to amd_hip_bfloat16.h

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bfloat16.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_bfloat16.h
@@ -153,6 +153,8 @@ static_assert(__hip_internal::is_trivial<hip_bfloat16>{},
               "hip_bfloat16 is not a trivial type, and thus is "
               "incompatible with C.");
 #if !defined(__HIPCC_RTC__)
+#include <ostream>
+
 static_assert(sizeof(hip_bfloat16) == sizeof(hip_bfloat16_public) &&
                   offsetof(hip_bfloat16, data) == offsetof(hip_bfloat16_public, data),
               "internal hip_bfloat16 does not match public hip_bfloat16");


### PR DESCRIPTION
## Motivation

To fix compilation projects that includes `<hip/amd_detail/amd_hip_bfloat16.h>` with stricter rules for transitive includes (for example, on windows).

How to reproduce:

The `main.cpp` file:
```
#include <hip/amd_detail/amd_hip_bfloat16.h>

int main() {
    hip_bfloat16 bf16(1.0f);
    return 0;
}
```

The command line using TheRock:
```
/opt/TheRock/build/core/clr/dist/lib/llvm/bin/clang++ -std=c++17 -fsyntax-only -I/opt/TheRock/build/dist/rocm/include main.cpp -D__HIPCC__ -D__HIP_PLATFORM_AMD__
```

The output:
```
In file included from main.cpp:3:
/opt/TheRock/build/dist/rocm/include/hip/amd_detail/amd_hip_bfloat16.h:161:13: error: invalid operands to binary expression ('std::ostream' (aka 'basic_ostream<char>') and 'float')
  161 |   return os << float(bf16);
      |          ~~ ^  ~~~~~~~~~~~
/opt/TheRock/build/dist/rocm/include/hip/amd_detail/amd_hip_bfloat16.h:160:22: note: candidate function not viable: no known conversion from 'float' to 'const hip_bfloat16' for 2nd argument
  160 | inline std::ostream& operator<<(std::ostream& os, const hip_bfloat16& bf16) {
      |                      ^                            ~~~~~~~~~~~~~~~~~~~~~~~~
/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/cstddef:124:5: note: candidate function template not viable: cannot convert argument of incomplete type 'std::ostream' (aka 'basic_ostream<char>') to 'byte'
      for 1st argument
  124 |     operator<<(byte __b, _IntegerType __shift) noexcept
      |     ^          ~~~~~~~~
/opt/TheRock/build/dist/rocm/include/hip/amd_detail/amd_hip_vector_types.h:707:56: note: candidate template ignored: could not match 'HIP_vector_type' against 'basic_ostream'
  707 | __HOST_DEVICE__ inline constexpr HIP_vector_type<T, n> operator<<(
      |                                                        ^
/opt/TheRock/build/dist/rocm/include/hip/amd_detail/amd_hip_vector_types.h:713:56: note: candidate template ignored: could not match 'HIP_vector_type' against 'basic_ostream'
  713 | __HOST_DEVICE__ inline constexpr HIP_vector_type<T, n> operator<<(const HIP_vector_type<T, n>& x,
      |                                                        ^
/opt/TheRock/build/dist/rocm/include/hip/amd_detail/amd_hip_vector_types.h:720:56: note: candidate template ignored: could not match 'HIP_vector_type<T, n>' against 'float'
  720 | __HOST_DEVICE__ inline constexpr HIP_vector_type<T, n> operator<<(
      |                                                        ^
1 error generated.
```

Actually the error is caught in the [PR](https://github.com/ROCm/TheRock/pull/3129)  to TheRock to integrate hipblaslt-plugin: [job](https://github.com/ROCm/TheRock/actions/runs/21470268890/job/61840974048?pr=3129).

## Technical Details

The file `amd_hip_bfloat16.h` defined new class `hip_bfloat16` with overrided operator `<<` which uses `ostream`. But include of `ostream` library is missed in this header. This PR adds it to this file.

## JIRA ID

No JIRA ticket

## Test Plan

Check if the file above is compiled with this change.

## Test Result

With this change, the example is above successfully compiled.

The PR  https://github.com/ROCm/TheRock/pull/3140 with successful built of hipblaslt_plugin within therock with this fix.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
