### PR TITLE
ASAN: Increase space to write CU count

### DIFF
--- a/projects/hip-tests/catch/multiproc/hipNoGpuTsts.cc
+++ b/projects/hip-tests/catch/multiproc/hipNoGpuTsts.cc
@@ -712,9 +712,9 @@ static bool NoGpuTst_hipExtGetLinkTypeAndHopCount() {
 static bool NoGpuTst_hipExtStreamGetCUMask() {
   bool passed = false;
   hipError_t err;
-  uint32_t cuMaskSize = 1024;
-  uint32_t cuMask;
-  err = hipExtStreamGetCUMask(0, cuMaskSize, &cuMask);
+  uint32_t cuMaskSize = 16;  // Enough for 512 CUs
+  uint32_t cuMask[16];
+  err = hipExtStreamGetCUMask(0, cuMaskSize, cuMask);
   if (err == hipErrorNoDevice) {
     passed = true;
   } else {

--- a/projects/hip-tests/catch/multiproc/hipNoGpuTsts.cc
+++ b/projects/hip-tests/catch/multiproc/hipNoGpuTsts.cc
@@ -712,6 +712,7 @@ static bool NoGpuTst_hipExtGetLinkTypeAndHopCount() {
 static bool NoGpuTst_hipExtStreamGetCUMask() {
   bool passed = false;
   hipError_t err;
+  // Although we never will hit the condition, this test checks for NoGPU Error.
   uint32_t cuMaskSize = 16;  // Enough for 512 CUs
   uint32_t cuMask[16];
   err = hipExtStreamGetCUMask(0, cuMaskSize, cuMask);


### PR DESCRIPTION
## Motivation

size of array passed is much bigger than the pointer which is only 4 bytes

## Technical Details

Corrected the array size

## JIRA ID

## Test Plan

MI350 ASAN build testing

## Test Result

No stack overflow observed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
