### PR TITLE
Fix timing of removals from memory object maps

### DIFF
--- a/projects/clr/hipamd/src/hip_vm.cpp
+++ b/projects/clr/hipamd/src/hip_vm.cpp
@@ -48,6 +48,7 @@ hipError_t hipMemAddressFree(void* devPtr, size_t size) {
   if (!(g_devices[0]->devices()[0]->virtualFree(devPtr))) {
     status = hipErrorUnknown;
   }
+  amd::MemObjMap::RemoveVirtualMemObj(devPtr);
   memObj->release();
   HIP_RETURN(status);
 }

--- a/projects/clr/rocclr/platform/memory.cpp
+++ b/projects/clr/rocclr/platform/memory.cpp
@@ -461,18 +461,6 @@ Memory::~Memory() {
     parent_->release();
   }
   hostMemRef_.deallocateMemory(context_());
-  if (parent_ == nullptr && (getMemFlags() & CL_MEM_VA_RANGE_AMD)) {
-    // The mapping may manually be removed prior to objects destruction
-    if (amd::MemObjMap::FindVirtualMemObj(getSvmPtr())) {
-      amd::MemObjMap::RemoveVirtualMemObj(getSvmPtr());
-    }
-    // If runtime executes graph mempool with VM, then VA can be mapped in space
-    // for graph validation logic during execution. And the reason it's not unmaped
-    // in graph itself because the app can have a graph without a free node
-    if (amd::MemObjMap::FindMemObj(getSvmPtr())) {
-      amd::MemObjMap::RemoveMemObj(getSvmPtr());
-    }
-  }
 }
 
 // ================================================================================================


### PR DESCRIPTION
## Motivation

Currently the memory object map updates (MemObjMap_ and VirtualMemObjMap_) are handled in the memory destructor. This creates issues of incorrect memory object map updates when asynchronous commands complete and release memory. One such issus is if we hipMemAddressFree an address and later reserve the same address with hipMemAddressReserve before a command retaining the memory releases. In this case, the VirtualMemObjMap_ will be invalid once the command completes as hipMemAddressReserve will not add anything to the map (as key already exists), but the command release will later remove it from the map.

## Technical Details

Remove memory object map updates in destructor. Add virtualMemObjMap_ removal in hipMemAddressFree. MemObjMap_ removal is already contained in hipMemUnmap.

## JIRA ID

N/A

## Test Plan

Test on pytorch expandable segments test which was originally encountering a segfault.

## Test Result

Test now passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
