### PR TITLE
[ROCM-2950] amdsmi: soft-depend on libdrm

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -59,6 +59,10 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
     the fallback line now uses consistent padding so the table stays aligned.
   - Fixes `amd-smi` default output formatting.
 
+- **Fixed virtualization detection utilities when libDRM is unavailable or version < 3.62.0**.  
+  - New functions for detecting container, VM, SR-IOV, and vfio-pci binding status.
+  - Enables `amdsmi_get_gpu_virtualization_mode()` to work when libDRM is unavailable.
+
 ### Upcoming changes
 
 - N/A

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -49,10 +49,10 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
     instead of `AMDSMI_STATUS_NOT_SUPPORTED` when libDRM isn’t installed.
   - Fixes `amd-smi static --asic` output.
 
-- **Fixed ASIC info retrieval when libDRM is unavailable**.  
-  - `amdsmi_get_gpu_asic_info()` now returns the available ASIC fields and reports `AMDSMI_STATUS_SUCCESS`
-    instead of failing with `AMDSMI_STATUS_NOT_SUPPORTED` when libDRM isn’t installed.
-  - Fixes `amd-smi static --asic` output.
+- **Fixed manufacturer name display for AMD GPUs**.  
+  - Updated `amdsmi_get_gpu_board_info()` to correctly detect vendor ID `0x1002` and display
+    "Advanced Micro Devices Inc. [AMD/ATI]" instead of the raw ID.
+  - Fixes `amd-smi static --board` output.
   
 - **Fixed `amd-smi` default command alignment when libDRM is unavailable**.  
   - When `amdgpu Version` can’t be queried (libDRM missing), the default view falls back to `OS Kernel Version`;

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -19,6 +19,54 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - Selective display: Use `-p` for NPM only, `-b` for Baseboard only.
   - Default behavior (no flags): Shows both power management and baseboard temperatures.
 
+### Changed
+
+- **Standardized SYSFS path construction using DRM render minors (`renderD<N>`)**.  
+  - Switched internal device identification from libDRM’s device path to the DRM render minor.
+  - Updated SYSFS path construction to consistently use `renderD<N>` across ASIC info, PCIe info, and other SYSFS-backed utilities (board info, RAS/ECC, power, clocks, etc.).
+  - Improves consistency and reliability of SYSFS access.
+
+### Removed
+
+- N/A
+
+### Optimized
+
+- **Optimized `rsmi_dev_device_identifiers_get()` in the ROCm-SMI device layer**.  
+  - Removed unnecessary iteration by directly indexing the device list.
+  - Added bounds checking for `device_id`, with clearer error handling/logging.
+  - Improves performance for device identifier queries.
+
+### Resolved issues
+
+- **Fixed BDF retrieval when libDRM is unavailable**.  
+  - Updated `AMDSmiGPUDevice::get_bdf()` to fall back to ROCm-SMI/KFD when libDRM can’t be used.
+  - Added validation to prevent invalid device index access.
+  - Affects `amdsmi_get_gpu_device_bdf()` and `amdsmi_get_processor_handle_from_bdf()`.
+
+- **Fixed ASIC info retrieval when libDRM is unavailable**.  
+  - Updated `amdsmi_get_gpu_asic_info()` to return the available ASIC fields and report `AMDSMI_STATUS_SUCCESS`
+    instead of `AMDSMI_STATUS_NOT_SUPPORTED` when libDRM isn’t installed.
+  - Fixes `amd-smi static --asic` output.
+
+- **Fixed ASIC info retrieval when libDRM is unavailable**.  
+  - `amdsmi_get_gpu_asic_info()` now returns the available ASIC fields and reports `AMDSMI_STATUS_SUCCESS`
+    instead of failing with `AMDSMI_STATUS_NOT_SUPPORTED` when libDRM isn’t installed.
+  - Fixes `amd-smi static --asic` output.
+  
+- **Fixed `amd-smi` default command alignment when libDRM is unavailable**.  
+  - When `amdgpu Version` can’t be queried (libDRM missing), the default view falls back to `OS Kernel Version`;
+    the fallback line now uses consistent padding so the table stays aligned.
+  - Fixes `amd-smi` default output formatting.
+
+### Upcoming changes
+
+- N/A
+
+### Known issues
+
+- N/A
+
 ## amd_smi_lib for ROCm 7.11.0
 
 ### Added

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -1174,27 +1174,30 @@ class AMDSMILogger():
         vbios_version = str(output['version_info']['vbios version'])
         kernel_version = str(output['version_info']['kernel version'])
 
+        ######################################################
+        # Please make the lines add up to 80-character width #
+        ######################################################
         # print GPU info
         print(default_line_1)
         # Split the version line into 3 lines, each wrapping to the same width
-        print("| AMD-SMI          {0:40s} {1:19s}|".format(amd_smi_version.ljust(40), ""))
+        print("| AMD-SMI            {0:40s} {1:17s}|".format(amd_smi_version.ljust(40), ""))
 
         # Print amdgpu or kernel version based on availability, if neither then don't print
         if amdgpu_version.strip() != "N/A":
-            print("| amdgpu Version:  {0:40s} {1:19s}|".format(amdgpu_version, ""))
+            print("| amdgpu Version:    {0:40s} {1:17s}|".format(amdgpu_version, ""))
         elif kernel_version.strip() != "N/A":
-            print("| OS kernel Version:  {0:40s} {1:19s}|".format(kernel_version, ""))
+            print("| OS kernel Version: {0:40s} {1:17s}|".format(kernel_version, ""))
 
         if rocm_version != "N/A":
-            print("| ROCm Version:    {0:40s} {1:19s}|".format(rocm_version, ""))
+            print("| ROCm Version:      {0:40s} {1:17s}|".format(rocm_version, ""))
 
         # only print if the version is not "N/A"
         if vbios_version != "N/A":
-            print("| VBIOS Version:   {0:22s}  {1:35s} |".format(vbios_version, ""))
+            print("| VBIOS Version:     {0:22s}  {1:33s} |".format(vbios_version, ""))
         if fw_pldm_version != "N/A":
-            print("| FW PLDM:         {0:15s}  {1:42s} |".format(fw_pldm_version, ""))
+            print("| FW PLDM:           {0:15s}  {1:40s} |".format(fw_pldm_version, ""))
 
-        print("| Platform:        {0:25.25s} {1:34s}|".format(str(self.helpers.os_info()), ""))
+        print("| Platform:          {0:25.25s} {1:32s}|".format(str(self.helpers.os_info()), ""))
         print(default_line_2)
         print("| BDF                        GPU-Name | Mem-Uti   Temp   UEC       Power-Usage |")
         print("| GPU  HIP-ID  OAM-ID  Partition-Mode | GFX-Uti    Fan               Mem-Usage |")

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -1179,26 +1179,25 @@ class AMDSMILogger():
         ######################################################
         # print GPU info
         print(default_line_1)
-        print("| AMD-SMI            {0:<57s} |".format(amd_smi_version))
+        print("| AMD-SMI            {0:<57s} |".format(amd_smi_version[:57]))
 
         # Print amdgpu or kernel version based on availability, if neither then don't print
         # Split the version line into 3 lines, each wrapping to the same width
         if amdgpu_version.strip() != "N/A":
-            print("| amdgpu Version:    {0:<57s} |".format(amdgpu_version))
+            print("| amdgpu Version:    {0:<57s} |".format(amdgpu_version[:57]))
         elif kernel_version.strip() != "N/A":
-            print("| OS kernel Version: {0:<57s} |".format(kernel_version))
+            print("| OS kernel Version: {0:<57s} |".format(kernel_version[:57]))
 
         if rocm_version != "N/A":
-            print("| ROCm Version:      {0:<57s} |".format(rocm_version))
+            print("| ROCm Version:      {0:<57s} |".format(rocm_version[:57]))
 
         # only print if the version is not "N/A"
         if vbios_version != "N/A":
-            print("| VBIOS Version:     {0:<57s} |".format(vbios_version))
+            print("| VBIOS Version:     {0:<57s} |".format(vbios_version[:57]))
         if fw_pldm_version != "N/A":
-            print("| FW PLDM:           {0:<57s} |".format(fw_pldm_version))
+            print("| FW PLDM:           {0:<57s} |".format(fw_pldm_version[:57]))
 
-        print("| Platform:          {0:<57s} |".format(str(self.helpers.os_info())))
-
+        print("| Platform:          {0:<57s} |".format(str(self.helpers.os_info())[:57]))
         print(default_line_2)
         print("| BDF                        GPU-Name | Mem-Uti   Temp   UEC       Power-Usage |")
         print("| GPU  HIP-ID  OAM-ID  Partition-Mode | GFX-Uti    Fan               Mem-Usage |")

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -1174,15 +1174,12 @@ class AMDSMILogger():
         vbios_version = str(output['version_info']['vbios version'])
         kernel_version = str(output['version_info']['kernel version'])
 
-        ######################################################
-        # Please make the lines add up to 80-character width #
-        ######################################################
         # print GPU info
         print(default_line_1)
+        # Split the version line into 3 lines, each wrapping to the same width
         print("| AMD-SMI            {0:<57s} |".format(amd_smi_version[:57]))
 
         # Print amdgpu or kernel version based on availability, if neither then don't print
-        # Split the version line into 3 lines, each wrapping to the same width
         if amdgpu_version.strip() != "N/A":
             print("| amdgpu Version:    {0:<57s} |".format(amdgpu_version[:57]))
         elif kernel_version.strip() != "N/A":

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -1179,25 +1179,26 @@ class AMDSMILogger():
         ######################################################
         # print GPU info
         print(default_line_1)
-        # Split the version line into 3 lines, each wrapping to the same width
-        print("| AMD-SMI            {0:40s} {1:17s}|".format(amd_smi_version.ljust(40), ""))
+        print("| AMD-SMI            {0:<57s} |".format(amd_smi_version))
 
         # Print amdgpu or kernel version based on availability, if neither then don't print
+        # Split the version line into 3 lines, each wrapping to the same width
         if amdgpu_version.strip() != "N/A":
-            print("| amdgpu Version:    {0:40s} {1:17s}|".format(amdgpu_version, ""))
+            print("| amdgpu Version:    {0:<57s} |".format(amdgpu_version))
         elif kernel_version.strip() != "N/A":
-            print("| OS kernel Version: {0:40s} {1:17s}|".format(kernel_version, ""))
+            print("| OS kernel Version: {0:<57s} |".format(kernel_version))
 
         if rocm_version != "N/A":
-            print("| ROCm Version:      {0:40s} {1:17s}|".format(rocm_version, ""))
+            print("| ROCm Version:      {0:<57s} |".format(rocm_version))
 
         # only print if the version is not "N/A"
         if vbios_version != "N/A":
-            print("| VBIOS Version:     {0:22s}  {1:33s} |".format(vbios_version, ""))
+            print("| VBIOS Version:     {0:<57s} |".format(vbios_version))
         if fw_pldm_version != "N/A":
-            print("| FW PLDM:           {0:15s}  {1:40s} |".format(fw_pldm_version, ""))
+            print("| FW PLDM:           {0:<57s} |".format(fw_pldm_version))
 
-        print("| Platform:          {0:25.25s} {1:32s}|".format(str(self.helpers.os_info()), ""))
+        print("| Platform:          {0:<57s} |".format(str(self.helpers.os_info())))
+
         print(default_line_2)
         print("| BDF                        GPU-Name | Mem-Uti   Temp   UEC       Power-Usage |")
         print("| GPU  HIP-ID  OAM-ID  Partition-Mode | GFX-Uti    Fan               Mem-Usage |")

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
@@ -60,7 +60,6 @@ constexpr uint32_t kSMI_MAX_STRING_LENGTH = 256;  // matches AMDSMI_MAX_STRING_L
 struct VirtModeDetectionResult {
   bool is_vm_guest = false;           // hypervisor flag in /proc/cpuinfo
   bool is_container = false;          // running inside docker/lxc/podman container
-  bool has_sriov_capability = false;  // device supports SR-IOV (sriov_totalvfs > 0)
   bool has_active_vfs = false;        // VFs are provisioned (sriov_numvfs > 0) -> indicates HOST
   bool is_vfio_bound = false;         // device bound to vfio-pci driver -> passthrough candidate
   bool sysfs_accessible = false;      // device sysfs path accessible

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
@@ -55,6 +55,7 @@
 #endif
 
 namespace amd::smi {
+constexpr uint32_t kSMI_MAX_STRING_LENGTH = 256;  // matches AMDSMI_MAX_STRING_LENGTH
 
 struct VirtModeDetectionResult {
   bool is_vm_guest = false;           // hypervisor flag in /proc/cpuinfo

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
@@ -56,6 +56,24 @@
 
 namespace amd::smi {
 constexpr uint32_t kSMI_MAX_STRING_LENGTH = 256;  // matches AMDSMI_MAX_STRING_LENGTH
+constexpr size_t kMAX_DRIVER_SYMLINK_LEN = 1024;  // Linux kernel limits symlink targets to
+                                                  // 4096 bytes (on most filesystems)
+                                                  // Conservative size: ~512-1024 bytes (sweet spot)
+
+// Container detection indicators
+constexpr std::string_view kDOCKER_ENV_Path = "/.dockerenv";
+constexpr std::string_view kCONTAINER_ENV_PATH = "/run/.containerenv";
+constexpr std::string_view kCGROUP_PATH = "/proc/1/cgroup";
+constexpr std::string_view kCONTAINER_ENV_VAR = "container";
+
+constexpr std::string_view kDOCKER = "docker";
+constexpr std::string_view kLXC = "lxc";
+constexpr std::string_view kKUBEPODS = "kubepods";
+constexpr std::string_view kCONTAINERD = "containerd";
+constexpr std::string_view kPODMAN = "podman";
+
+// Virtualization detection indicators
+constexpr std::string_view kVFIO_PCI = "vfio-pci";
 
 struct VirtModeDetectionResult {
   bool is_vm_guest = false;           // hypervisor flag in /proc/cpuinfo
@@ -123,8 +141,11 @@ bool is_sudo_user();
 rsmi_status_t rsmi_get_gfx_target_version(uint32_t dv_ind, std::string *gfx_version);
 rsmi_status_t rsmi_dev_number_of_computes_get(uint32_t dv_ind, uint32_t* num_computes);
 
-VirtModeDetectionResult detect_virtualization_mode_sysfs(
-    const std::string& render_path);
+VirtModeDetectionResult detect_virtualization_mode_sysfs(const std::string& render_path);
+
+inline auto contains(std::string_view text, std::string_view substr) -> bool {
+    return text.find(substr) != std::string_view::npos;
+}
 
 std::string leftTrim(const std::string &s);
 std::string rightTrim(const std::string &s);

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
@@ -114,6 +114,30 @@ bool is_sudo_user();
 rsmi_status_t rsmi_get_gfx_target_version(uint32_t dv_ind, std::string *gfx_version);
 rsmi_status_t rsmi_dev_number_of_computes_get(uint32_t dv_ind, uint32_t* num_computes);
 
+// Check if running inside a container (Docker, LXC, Podman, etc.)
+bool is_running_in_container();
+
+// Check if device is bound to vfio-pci driver (passthrough indicator)
+// pci_sysfs_path: e.g., "/sys/class/drm/renderD128/device"
+bool is_device_vfio_bound(const std::string& pci_sysfs_path);
+
+// Check SR-IOV status for a device
+// pci_sysfs_path: e.g., "/sys/class/drm/renderD128/device"
+// Returns: tuple<has_sriov_capability, has_active_vfs>
+std::tuple<bool, bool> get_sriov_status(const std::string& pci_sysfs_path);
+
+// Comprehensive virtualization mode detection via sysfs (no root required)
+// render_path: the render node name, e.g., "renderD128"
+// Returns tuple:
+//   0: is_vm_guest         - hypervisor flag detected in /proc/cpuinfo
+//   1: is_container        - running inside docker/lxc/podman container
+//   2: has_sriov_capability - device supports SR-IOV (could read sriov_totalvfs)
+//   3: has_active_vfs      - VFs are provisioned (indicates HOST mode)
+//   4: is_vfio_bound       - device bound to vfio-pci (passthrough indicator)
+//   5: sysfs_accessible    - could access device sysfs path at all
+std::tuple<bool, bool, bool, bool, bool, bool> detect_virtualization_mode_sysfs(
+    const std::string& render_path);
+
 std::string leftTrim(const std::string &s);
 std::string rightTrim(const std::string &s);
 std::string trim(const std::string &s);

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_utils.h
@@ -56,6 +56,15 @@
 
 namespace amd::smi {
 
+struct VirtModeDetectionResult {
+  bool is_vm_guest = false;           // hypervisor flag in /proc/cpuinfo
+  bool is_container = false;          // running inside docker/lxc/podman container
+  bool has_sriov_capability = false;  // device supports SR-IOV (sriov_totalvfs > 0)
+  bool has_active_vfs = false;        // VFs are provisioned (sriov_numvfs > 0) -> indicates HOST
+  bool is_vfio_bound = false;         // device bound to vfio-pci driver -> passthrough candidate
+  bool sysfs_accessible = false;      // device sysfs path accessible
+};
+
 pthread_mutex_t *GetMutex(uint32_t dv_ind);
 int SameFile(const std::string fileA, const std::string fileB);
 bool FileExists(char const *filename);
@@ -114,28 +123,7 @@ bool is_sudo_user();
 rsmi_status_t rsmi_get_gfx_target_version(uint32_t dv_ind, std::string *gfx_version);
 rsmi_status_t rsmi_dev_number_of_computes_get(uint32_t dv_ind, uint32_t* num_computes);
 
-// Check if running inside a container (Docker, LXC, Podman, etc.)
-bool is_running_in_container();
-
-// Check if device is bound to vfio-pci driver (passthrough indicator)
-// pci_sysfs_path: e.g., "/sys/class/drm/renderD128/device"
-bool is_device_vfio_bound(const std::string& pci_sysfs_path);
-
-// Check SR-IOV status for a device
-// pci_sysfs_path: e.g., "/sys/class/drm/renderD128/device"
-// Returns: tuple<has_sriov_capability, has_active_vfs>
-std::tuple<bool, bool> get_sriov_status(const std::string& pci_sysfs_path);
-
-// Comprehensive virtualization mode detection via sysfs (no root required)
-// render_path: the render node name, e.g., "renderD128"
-// Returns tuple:
-//   0: is_vm_guest         - hypervisor flag detected in /proc/cpuinfo
-//   1: is_container        - running inside docker/lxc/podman container
-//   2: has_sriov_capability - device supports SR-IOV (could read sriov_totalvfs)
-//   3: has_active_vfs      - VFs are provisioned (indicates HOST mode)
-//   4: is_vfio_bound       - device bound to vfio-pci (passthrough indicator)
-//   5: sysfs_accessible    - could access device sysfs path at all
-std::tuple<bool, bool, bool, bool, bool, bool> detect_virtualization_mode_sysfs(
+VirtModeDetectionResult detect_virtualization_mode_sysfs(
     const std::string& render_path);
 
 std::string leftTrim(const std::string &s);

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
@@ -1981,7 +1981,6 @@ std::string Device::readBootPartitionState<rsmi_memory_partition_type_t>(
 
 rsmi_status_t Device::get_smi_device_identifiers(uint32_t device_id,
         rsmi_device_identifiers_t *device_identifiers) {
-  bool found_device = false;
   std::ostringstream ss;
   rsmi_status_t ret = RSMI_STATUS_NOT_SUPPORTED;
   if (device_identifiers == nullptr) {
@@ -1992,44 +1991,31 @@ rsmi_status_t Device::get_smi_device_identifiers(uint32_t device_id,
   auto devices = smi.devices();
   ss << __PRETTY_FUNCTION__ << " | device_id = " << device_id
      << "; devices.size() = " << devices.size();
-  // std::cout << ss.str() << "\n";
   LOG_DEBUG(ss);
 
-  for (uint32_t i = 0; i < devices.size(); i++) {
-    if (i != device_id) {
-      continue;
-    }
+  if (device_id >= static_cast<uint32_t>(devices.size())) {
+    ss << __PRETTY_FUNCTION__ << " | Invalid device_id: " << device_id
+       << "; devices.size(): " << devices.size();
+    LOG_INFO(ss);
+    return RSMI_STATUS_INVALID_ARGS;
+  }
 
-    device_identifiers->card_index = devices[i]->index();
-    device_identifiers->drm_render_minor = devices[i]->drm_render_minor();
-    device_identifiers->bdfid = devices[i]->bdfid();
-    device_identifiers->kfd_gpu_id = devices[i]->kfd_gpu_id();
-    uint32_t temp_partition_id = 0;
-    rsmi_status_t ret = rsmi_dev_partition_id_get(
-        i, &temp_partition_id);
-    if (ret != RSMI_STATUS_SUCCESS) {
-      temp_partition_id = 0;
-    }
-    device_identifiers->partition_id = temp_partition_id;
-    device_identifiers->smi_device_id = i;
-    found_device = true;
-    ss << __PRETTY_FUNCTION__ << " | Found device: "
-       << "card_index = " << device_identifiers->card_index
-       << "; drm_render_minor = " << device_identifiers->drm_render_minor
-       << "; bdfid = " << std::hex << "0x" << device_identifiers->bdfid
-       << "; kfd_gpu_id = " << std::dec << device_identifiers->kfd_gpu_id
-       << "; partition_id = " << device_identifiers->partition_id
-       << "; smi_device_id = " << device_identifiers->smi_device_id;
-    // std::cout << ss.str() << "\n";
-    LOG_DEBUG(ss);
-    break;
+  device_identifiers->card_index = devices[device_id]->index();
+  device_identifiers->drm_render_minor = devices[device_id]->drm_render_minor();
+  device_identifiers->bdfid = devices[device_id]->bdfid();
+  device_identifiers->kfd_gpu_id = devices[device_id]->kfd_gpu_id();
+  uint32_t temp_partition_id = 0;
+  rsmi_status_t partition_id_ret = rsmi_dev_partition_id_get(
+      device_id, &temp_partition_id);
+  if (partition_id_ret != RSMI_STATUS_SUCCESS) {
+    temp_partition_id = 0;
   }
-  if (found_device) {
-    ret = RSMI_STATUS_SUCCESS;
-  }
+  device_identifiers->partition_id = temp_partition_id;
+  device_identifiers->smi_device_id = device_id;
+  ret = RSMI_STATUS_SUCCESS;
   return ret;
 }
 
 
 #undef RET_IF_NONZERO
-} // namespace amd::smi
+}  // namespace amd::smi

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
@@ -20,10 +20,8 @@
  * THE SOFTWARE.
  */
 
-#define _GNU_SOURCE 1 // REQUIRED: to utilize some GNU features/functions, see
-                      // _GNU_SOURCE functions which check
-#include <cassert>
-#include <cerrno>
+#define _GNU_SOURCE 1  // REQUIRED: to utilize some GNU features/functions, see
+                       // _GNU_SOURCE functions which check
 #include <sys/stat.h>
 #include <unistd.h>
 #include <dirent.h>
@@ -1342,4 +1340,189 @@ uint64_t bdfid_from_domain(uint64_t bdfid, uint64_t domain) {
   bdfid |= (domain & 0xFFFFFFFF) << 32;  // Add domain to top of pci_id
   return bdfid;
 }
-} // namespace amd::smi
+
+//--------------------------------------------------------------------------
+// TODO(amdsmi_team): May remove the below functions and add to anothe PR...
+//--------------------------------------------------------------------------
+
+// Structure to hold virtualization detection results
+// This provides multiple signals to help determine the virtualization mode
+// without false positives in container environments
+struct VirtModeDetectionResult {
+  bool is_vm_guest;           // hypervisor flag in /proc/cpuinfo
+  bool is_container;          // running inside docker/lxc/podman container
+  bool has_sriov_capability;  // device supports SR-IOV (sriov_totalvfs > 0)
+  bool has_active_vfs;        // VFs are provisioned (sriov_numvfs > 0) -> HOST
+  bool is_vfio_bound;         // device bound to vfio-pci driver -> passthrough candidate
+};
+
+// Check if running inside a container (Docker, LXC, Podman, etc.)
+// This is important because container environments can give false positives
+// for VM detection since they may not have access to all sysfs paths
+bool is_running_in_container() {
+  std::ostringstream ss;
+
+  // Check for Docker
+  if (FileExists("/.dockerenv")) {
+    ss << __PRETTY_FUNCTION__ << " | Detected Docker container (/.dockerenv exists)";
+    LOG_DEBUG(ss);
+    return true;
+  }
+
+  // Check for Podman/other container runtimes
+  if (FileExists("/run/.containerenv")) {
+    ss << __PRETTY_FUNCTION__ << " | Detected container (/run/.containerenv exists)";
+    LOG_DEBUG(ss);
+    return true;
+  }
+
+  // Check cgroup for container indicators
+  std::ifstream cgroup_file("/proc/1/cgroup");
+  if (cgroup_file.is_open()) {
+    std::string line;
+    while (std::getline(cgroup_file, line)) {
+      if (line.find("docker") != std::string::npos ||
+          line.find("lxc") != std::string::npos ||
+          line.find("kubepods") != std::string::npos ||
+          line.find("containerd") != std::string::npos) {
+        ss << __PRETTY_FUNCTION__ << " | Detected container via cgroup: " << line;
+        LOG_DEBUG(ss);
+        return true;
+      }
+    }
+  }
+
+  // Check for container environment variables (less reliable but useful)
+  const char* container_env = std::getenv("container");
+  if (container_env != nullptr) {
+    ss << __PRETTY_FUNCTION__ << " | Detected container via $container env var: " << container_env;
+    LOG_DEBUG(ss);
+    return true;
+  }
+
+  return false;
+}
+
+// Check if device is bound to vfio-pci driver (passthrough indicator)
+// pci_sysfs_path should be like "/sys/class/drm/renderD128/device"
+bool is_device_vfio_bound(const std::string& pci_sysfs_path) {
+  std::ostringstream ss;
+  std::string driver_link = pci_sysfs_path + "/driver";
+  char buf[256];
+
+  ssize_t len = readlink(driver_link.c_str(), buf, sizeof(buf) - 1);
+  if (len > 0) {
+    buf[len] = '\0';
+    std::string driver(buf);
+    ss << __PRETTY_FUNCTION__ << " | Device driver: " << driver;
+    LOG_DEBUG(ss);
+
+    if (driver.find("vfio-pci") != std::string::npos) {
+      ss << __PRETTY_FUNCTION__ << " | Device bound to vfio-pci (passthrough)";
+      LOG_INFO(ss);
+      return true;
+    }
+  }
+  return false;
+}
+
+// Check SR-IOV status for a device
+// pci_sysfs_path should be like "/sys/class/drm/renderD128/device"
+// Returns: tuple<has_sriov_capability, has_active_vfs>
+std::tuple<bool, bool> get_sriov_status(const std::string& pci_sysfs_path) {
+  std::ostringstream ss;
+  bool has_capability = false;
+  bool has_active_vfs = false;
+
+  // Check for SR-IOV total VFs (capability)
+  std::string sriov_total_path = pci_sysfs_path + "/sriov_totalvfs";
+  std::ifstream total_file(sriov_total_path);
+  if (total_file.is_open()) {
+    int total_vfs = 0;
+    total_file >> total_vfs;
+    total_file.close();
+
+    if (total_vfs > 0) {
+      has_capability = true;
+      ss << __PRETTY_FUNCTION__ << " | sriov_totalvfs = " << total_vfs;
+      LOG_DEBUG(ss);
+    }
+  }
+
+  // Check for active VFs (indicates HOST mode)
+  std::string sriov_num_path = pci_sysfs_path + "/sriov_numvfs";
+  std::ifstream num_file(sriov_num_path);
+  if (num_file.is_open()) {
+    int num_vfs = 0;
+    num_file >> num_vfs;
+    num_file.close();
+
+    if (num_vfs > 0) {
+      has_active_vfs = true;
+      ss << __PRETTY_FUNCTION__ << " | sriov_numvfs = " << num_vfs << " (HOST mode)";
+      LOG_INFO(ss);
+    }
+  }
+
+  return std::make_tuple(has_capability, has_active_vfs);
+}
+
+// Comprehensive virtualization mode detection via sysfs (no root required)
+// render_path: the render node name, e.g., "renderD128"
+// Returns tuple:
+//   0: is_vm_guest         - hypervisor flag detected in /proc/cpuinfo
+//   1: is_container        - running inside docker/lxc/podman container
+//   2: has_sriov_capability - device supports SR-IOV (could read sriov_totalvfs)
+//   3: has_active_vfs      - VFs are provisioned (indicates HOST mode)
+//   4: is_vfio_bound       - device bound to vfio-pci (passthrough indicator)
+//   5: sysfs_accessible    - could access device sysfs path at all
+std::tuple<bool, bool, bool, bool, bool, bool> detect_virtualization_mode_sysfs(
+    const std::string& render_path) {
+  std::ostringstream ss;
+  bool is_vm = is_vm_guest();
+  bool is_ctr = is_running_in_container();
+  bool has_sriov_cap = false;
+  bool has_active_vfs = false;
+  bool is_vfio = false;
+  bool sysfs_accessible = false;
+
+  ss << __PRETTY_FUNCTION__
+     << " | is_vm_guest: " << (is_vm ? "true" : "false")
+     << " | is_container: " << (is_ctr ? "true" : "false");
+  LOG_DEBUG(ss);
+
+  // If render_path is empty, we can only provide VM/container info
+  if (render_path.empty()) {
+    ss << __PRETTY_FUNCTION__ << " | render_path is empty, cannot check sysfs";
+    LOG_INFO(ss);
+    return std::make_tuple(is_vm, is_ctr, false, false, false, false);
+  }
+
+  // Build the PCI device sysfs path
+  std::string pci_sysfs_path = "/sys/class/drm/" + render_path + "/device";
+
+  // Check if we can access sysfs at all (for container awareness)
+  struct stat st;
+  if (stat(pci_sysfs_path.c_str(), &st) == 0) {
+    sysfs_accessible = true;
+  }
+
+  // Check SR-IOV status
+  std::tie(has_sriov_cap, has_active_vfs) = get_sriov_status(pci_sysfs_path);
+
+  // Check if device is bound to vfio-pci (passthrough indicator)
+  is_vfio = is_device_vfio_bound(pci_sysfs_path);
+
+  ss << __PRETTY_FUNCTION__
+     << " | render_path: " << render_path
+     << " | sysfs_accessible: " << (sysfs_accessible ? "true" : "false")
+     << " | has_sriov_capability: " << (has_sriov_cap ? "true" : "false")
+     << " | has_active_vfs: " << (has_active_vfs ? "true" : "false")
+     << " | is_vfio_bound: " << (is_vfio ? "true" : "false");
+  LOG_INFO(ss);
+
+  return std::make_tuple(is_vm, is_ctr, has_sriov_cap,
+                         has_active_vfs, is_vfio, sysfs_accessible);
+}
+
+}  // namespace amd::smi

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
@@ -1429,7 +1429,7 @@ bool is_device_vfio_bound(const std::string& pci_sysfs_path) {
 // have active VFs since they are not in HOST mode
 bool get_sriov_status(const std::string& pci_sysfs_path) {
   std::ostringstream ss;
-  bool has_capability = false;  // indicates if device supports SR-IOV (sriov_totalvfs > 0)
+  [[maybe_unused]] bool has_capability = false;  // if device supports SR-IOV (sriov_totalvfs > 0)
   bool has_active_vfs = false;  // only true in HOST mode (sriov_numvfs > 0)
 
   // Check for SR-IOV total VFs (capability)

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
@@ -1341,21 +1341,6 @@ uint64_t bdfid_from_domain(uint64_t bdfid, uint64_t domain) {
   return bdfid;
 }
 
-//--------------------------------------------------------------------------
-// TODO(amdsmi_team): May remove the below functions and add to anothe PR...
-//--------------------------------------------------------------------------
-
-// Structure to hold virtualization detection results
-// This provides multiple signals to help determine the virtualization mode
-// without false positives in container environments
-struct VirtModeDetectionResult {
-  bool is_vm_guest;           // hypervisor flag in /proc/cpuinfo
-  bool is_container;          // running inside docker/lxc/podman container
-  bool has_sriov_capability;  // device supports SR-IOV (sriov_totalvfs > 0)
-  bool has_active_vfs;        // VFs are provisioned (sriov_numvfs > 0) -> HOST
-  bool is_vfio_bound;         // device bound to vfio-pci driver -> passthrough candidate
-};
-
 // Check if running inside a container (Docker, LXC, Podman, etc.)
 // This is important because container environments can give false positives
 // for VM detection since they may not have access to all sysfs paths
@@ -1469,33 +1454,19 @@ std::tuple<bool, bool> get_sriov_status(const std::string& pci_sysfs_path) {
 
 // Comprehensive virtualization mode detection via sysfs (no root required)
 // render_path: the render node name, e.g., "renderD128"
-// Returns tuple:
-//   0: is_vm_guest         - hypervisor flag detected in /proc/cpuinfo
-//   1: is_container        - running inside docker/lxc/podman container
-//   2: has_sriov_capability - device supports SR-IOV (could read sriov_totalvfs)
-//   3: has_active_vfs      - VFs are provisioned (indicates HOST mode)
-//   4: is_vfio_bound       - device bound to vfio-pci (passthrough indicator)
-//   5: sysfs_accessible    - could access device sysfs path at all
-std::tuple<bool, bool, bool, bool, bool, bool> detect_virtualization_mode_sysfs(
-    const std::string& render_path) {
+// Returns VirtModeDetectionResult
+VirtModeDetectionResult detect_virtualization_mode_sysfs(
+                                            const std::string& render_path) {
   std::ostringstream ss;
-  bool is_vm = is_vm_guest();
-  bool is_ctr = is_running_in_container();
-  bool has_sriov_cap = false;
-  bool has_active_vfs = false;
-  bool is_vfio = false;
-  bool sysfs_accessible = false;
-
-  ss << __PRETTY_FUNCTION__
-     << " | is_vm_guest: " << (is_vm ? "true" : "false")
-     << " | is_container: " << (is_ctr ? "true" : "false");
-  LOG_DEBUG(ss);
+  VirtModeDetectionResult result{};
+  result.is_vm_guest = is_vm_guest();
+  result.is_container = is_running_in_container();
 
   // If render_path is empty, we can only provide VM/container info
   if (render_path.empty()) {
     ss << __PRETTY_FUNCTION__ << " | render_path is empty, cannot check sysfs";
     LOG_INFO(ss);
-    return std::make_tuple(is_vm, is_ctr, false, false, false, false);
+    return result;
   }
 
   // Build the PCI device sysfs path
@@ -1504,25 +1475,16 @@ std::tuple<bool, bool, bool, bool, bool, bool> detect_virtualization_mode_sysfs(
   // Check if we can access sysfs at all (for container awareness)
   struct stat st;
   if (stat(pci_sysfs_path.c_str(), &st) == 0) {
-    sysfs_accessible = true;
+    result.sysfs_accessible = true;
   }
 
   // Check SR-IOV status
-  std::tie(has_sriov_cap, has_active_vfs) = get_sriov_status(pci_sysfs_path);
+  std::tie(result.has_sriov_capability, result.has_active_vfs) = get_sriov_status(pci_sysfs_path);
 
   // Check if device is bound to vfio-pci (passthrough indicator)
-  is_vfio = is_device_vfio_bound(pci_sysfs_path);
+  result.is_vfio_bound = is_device_vfio_bound(pci_sysfs_path);
 
-  ss << __PRETTY_FUNCTION__
-     << " | render_path: " << render_path
-     << " | sysfs_accessible: " << (sysfs_accessible ? "true" : "false")
-     << " | has_sriov_capability: " << (has_sriov_cap ? "true" : "false")
-     << " | has_active_vfs: " << (has_active_vfs ? "true" : "false")
-     << " | is_vfio_bound: " << (is_vfio ? "true" : "false");
-  LOG_INFO(ss);
-
-  return std::make_tuple(is_vm, is_ctr, has_sriov_cap,
-                         has_active_vfs, is_vfio, sysfs_accessible);
+  return result;
 }
 
 }  // namespace amd::smi

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
@@ -1348,29 +1348,27 @@ bool is_running_in_container() {
   std::ostringstream ss;
 
   // Check for Docker
-  if (FileExists("/.dockerenv")) {
+  if (FileExists(kDOCKER_ENV_Path.data())) {
     ss << __PRETTY_FUNCTION__ << " | Detected Docker container (/.dockerenv exists)";
     LOG_DEBUG(ss);
     return true;
   }
 
   // Check for Podman/other container runtimes
-  if (FileExists("/run/.containerenv")) {
+  if (FileExists(kCONTAINER_ENV_PATH.data())) {
     ss << __PRETTY_FUNCTION__ << " | Detected container (/run/.containerenv exists)";
     LOG_DEBUG(ss);
     return true;
   }
 
   // Check cgroup for container indicators
-  std::ifstream cgroup_file("/proc/1/cgroup");
+  std::ifstream cgroup_file(kCGROUP_PATH.data());
   if (cgroup_file.is_open()) {
     std::string line;
     while (std::getline(cgroup_file, line)) {
-      if (line.find("docker") != std::string::npos ||
-          line.find("lxc") != std::string::npos ||
-          line.find("kubepods") != std::string::npos ||
-          line.find("containerd") != std::string::npos ||
-          line.find("podman") != std::string::npos) {
+      if (contains(line, kDOCKER) || contains(line, kLXC) ||
+          contains(line, kKUBEPODS) || contains(line, kCONTAINERD)||
+          contains(line, kPODMAN)) {
         ss << __PRETTY_FUNCTION__ << " | Detected container via cgroup: " << line;
         LOG_DEBUG(ss);
         return true;
@@ -1379,7 +1377,7 @@ bool is_running_in_container() {
   }
 
   // Check for container environment variables (less reliable but useful)
-  const char* container_env = std::getenv("container");
+  const char* container_env = std::getenv(kCONTAINER_ENV_VAR.data());
   if (container_env != nullptr) {
     ss << __PRETTY_FUNCTION__ << " | Detected container via $container env var: " << container_env;
     LOG_DEBUG(ss);
@@ -1394,16 +1392,25 @@ bool is_running_in_container() {
 bool is_device_vfio_bound(const std::string& pci_sysfs_path) {
   std::ostringstream ss;
   std::string driver_link = pci_sysfs_path + "/driver";
-  char buf[kSMI_MAX_STRING_LENGTH];
+  char buf[kMAX_DRIVER_SYMLINK_LEN];
 
   ssize_t len = readlink(driver_link.c_str(), buf, sizeof(buf) - 1);
   if (len > 0) {
+    // Reject if readlink truncated the data
+    if (static_cast<std::size_t>(len) >= (sizeof(buf) - 1)) {
+      ss << __PRETTY_FUNCTION__
+         << " | [WARNING] Driver path truncated (len=" << len
+         << "), cannot reliably detect vfio-pci (passthrough)";
+      LOG_INFO(ss);
+      return false;
+    }
+
     buf[len] = '\0';
     std::string driver(buf);
     ss << __PRETTY_FUNCTION__ << " | Device driver: " << driver;
     LOG_DEBUG(ss);
 
-    if (driver.find("vfio-pci") != std::string::npos) {
+    if (contains(driver, kVFIO_PCI)) {
       ss << __PRETTY_FUNCTION__ << " | Device bound to vfio-pci (passthrough)";
       LOG_INFO(ss);
       return true;

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
@@ -1369,7 +1369,8 @@ bool is_running_in_container() {
       if (line.find("docker") != std::string::npos ||
           line.find("lxc") != std::string::npos ||
           line.find("kubepods") != std::string::npos ||
-          line.find("containerd") != std::string::npos) {
+          line.find("containerd") != std::string::npos ||
+          line.find("podman") != std::string::npos) {
         ss << __PRETTY_FUNCTION__ << " | Detected container via cgroup: " << line;
         LOG_DEBUG(ss);
         return true;
@@ -1393,7 +1394,7 @@ bool is_running_in_container() {
 bool is_device_vfio_bound(const std::string& pci_sysfs_path) {
   std::ostringstream ss;
   std::string driver_link = pci_sysfs_path + "/driver";
-  char buf[256];
+  char buf[kSMI_MAX_STRING_LENGTH];
 
   ssize_t len = readlink(driver_link.c_str(), buf, sizeof(buf) - 1);
   if (len > 0) {

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_utils.cc
@@ -1414,11 +1414,16 @@ bool is_device_vfio_bound(const std::string& pci_sysfs_path) {
 
 // Check SR-IOV status for a device
 // pci_sysfs_path should be like "/sys/class/drm/renderD128/device"
-// Returns: tuple<has_sriov_capability, has_active_vfs>
-std::tuple<bool, bool> get_sriov_status(const std::string& pci_sysfs_path) {
+// Returns: True if device has active VFs (HOST mode), false otherwise
+//
+// Note: A device may support SR-IOV (sriov_totalvfs > 0)
+// but have no active VFs (sriov_numvfs = 0) if not in HOST mode
+// Example of this is partitions in BM mode - they support SR-IOV but will not
+// have active VFs since they are not in HOST mode
+bool get_sriov_status(const std::string& pci_sysfs_path) {
   std::ostringstream ss;
-  bool has_capability = false;
-  bool has_active_vfs = false;
+  bool has_capability = false;  // indicates if device supports SR-IOV (sriov_totalvfs > 0)
+  bool has_active_vfs = false;  // only true in HOST mode (sriov_numvfs > 0)
 
   // Check for SR-IOV total VFs (capability)
   std::string sriov_total_path = pci_sysfs_path + "/sriov_totalvfs";
@@ -1430,7 +1435,7 @@ std::tuple<bool, bool> get_sriov_status(const std::string& pci_sysfs_path) {
 
     if (total_vfs > 0) {
       has_capability = true;
-      ss << __PRETTY_FUNCTION__ << " | sriov_totalvfs = " << total_vfs;
+      ss << __PRETTY_FUNCTION__ << " | sriov_totalvfs (" << sriov_total_path << ") = " << total_vfs;
       LOG_DEBUG(ss);
     }
   }
@@ -1445,12 +1450,13 @@ std::tuple<bool, bool> get_sriov_status(const std::string& pci_sysfs_path) {
 
     if (num_vfs > 0) {
       has_active_vfs = true;
-      ss << __PRETTY_FUNCTION__ << " | sriov_numvfs = " << num_vfs << " (HOST mode)";
+      ss << __PRETTY_FUNCTION__ << " | sriov_numvfs (" << sriov_num_path
+         << ") = " << num_vfs << " (HOST mode)";
       LOG_INFO(ss);
     }
   }
 
-  return std::make_tuple(has_capability, has_active_vfs);
+  return has_active_vfs;
 }
 
 // Comprehensive virtualization mode detection via sysfs (no root required)
@@ -1479,8 +1485,8 @@ VirtModeDetectionResult detect_virtualization_mode_sysfs(
     result.sysfs_accessible = true;
   }
 
-  // Check SR-IOV status
-  std::tie(result.has_sriov_capability, result.has_active_vfs) = get_sriov_status(pci_sysfs_path);
+  // Check SR-IOV HOST status
+  result.has_active_vfs = get_sriov_status(pci_sysfs_path);
 
   // Check if device is bound to vfio-pci (passthrough indicator)
   result.is_vfio_bound = is_device_vfio_bound(pci_sysfs_path);

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -6203,21 +6203,17 @@ amdsmi_get_gpu_virtualization_mode(amdsmi_processor_handle processor_handle,
             // Device has active VFs = HOST mode
             *mode = AMDSMI_VIRTUALIZATION_MODE_HOST;
         } else if (result.is_vfio_bound) {
-            // Device bound to vfio-pci = PASSTHROUGH
+            // Device bound to vfio-pci = PASSTHROUGH mode
+            // Note: In nested virtualization (VM within VM), this reports the device's
+            // operational mode (PASSTHROUGH) rather than system context (GUEST).
+            // This aligns with DRM driver reporting and reflects device capabilities.
             *mode = AMDSMI_VIRTUALIZATION_MODE_PASSTHROUGH;
         } else if (result.is_vm_guest) {
             // hypervisor flag = GUEST (containers inherit this correctly)
             *mode = AMDSMI_VIRTUALIZATION_MODE_GUEST;
-        } else if (!result.is_vm_guest && !result.is_container) {
-            // Not VM, not container = safe to say BAREMETAL
+        } else if (!result.is_vm_guest) {
+            // Not VM, safe to say BAREMETAL
             *mode = AMDSMI_VIRTUALIZATION_MODE_BAREMETAL;
-        } else if (!result.is_vm_guest && result.is_container) {
-            // In container, no hypervisor flag = likely BAREMETAL
-            // BUT we can't be 100% sure without sysfs access
-            // Check if we could read any sysfs at all
-            if (result.sysfs_accessible) {
-                *mode = AMDSMI_VIRTUALIZATION_MODE_BAREMETAL;
-            }
         }
         return ((*mode == AMDSMI_VIRTUALIZATION_MODE_UNKNOWN) ?
                  AMDSMI_STATUS_NOT_SUPPORTED : AMDSMI_STATUS_SUCCESS);

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -6177,10 +6177,60 @@ amdsmi_get_gpu_virtualization_mode(amdsmi_processor_handle processor_handle,
     amdsmi_status_t status;
     SMIGPUDEVICE_MUTEX(gpu_device->get_mutex())
 
+    auto get_virt_mode_fallback = [&ss, gpu_device](const std::string& render_name,
+                                        amdsmi_virtualization_mode_t* mode)
+                                        -> amdsmi_status_t {
+        std::string render_name_local;
+        if (render_name.empty()) {
+            render_name_local = "renderD" + std::to_string(gpu_device->get_drm_render_minor());
+        } else {
+            render_name_local = render_name;
+        }
+        auto [is_vm_guest, is_container, has_sriov_cap, has_active_vfs, is_vfio, sysfs_accessible] =
+            amd::smi::detect_virtualization_mode_sysfs(render_name_local);
+
+        ss << __PRETTY_FUNCTION__ << " | sysfs fallback detection"
+        << " | is_vm_guest: " << std::boolalpha << is_vm_guest
+        << " | is_container: " << std::boolalpha << is_container
+        << " | has_sriov_cap: " << std::boolalpha << has_sriov_cap
+        << " | has_active_vfs: " << std::boolalpha << has_active_vfs
+        << " | is_vfio: " << std::boolalpha << is_vfio
+        << " | sysfs_accessible: " << std::boolalpha << sysfs_accessible;
+        LOG_INFO(ss);
+
+        if (has_active_vfs) {
+            // VFs are provisioned = HOST mode (definitive, if we can see sysfs)
+            *mode = AMDSMI_VIRTUALIZATION_MODE_HOST;
+        } else if (is_vfio) {
+            // Device bound to vfio-pci = PASSTHROUGH
+            *mode = AMDSMI_VIRTUALIZATION_MODE_PASSTHROUGH;
+        } else if (is_vm_guest) {
+            // hypervisor flag = GUEST (containers inherit this correctly)
+            *mode = AMDSMI_VIRTUALIZATION_MODE_GUEST;
+        } else if (!is_vm_guest && !is_container) {
+            // Not VM, not container = safe to say BAREMETAL
+            *mode = AMDSMI_VIRTUALIZATION_MODE_BAREMETAL;
+        } else if (!is_vm_guest && is_container) {
+            // In container, no hypervisor flag = likely BAREMETAL
+            // BUT we can't be 100% sure without sysfs access
+            // Check if we could read any sysfs at all
+            if (sysfs_accessible) {
+                *mode = AMDSMI_VIRTUALIZATION_MODE_BAREMETAL;
+            } else {
+                // Container with no sysfs access - be conservative
+                *mode = AMDSMI_VIRTUALIZATION_MODE_UNKNOWN;
+            }
+        } else {
+            *mode = AMDSMI_VIRTUALIZATION_MODE_UNKNOWN;
+        }
+        return ((*mode == AMDSMI_VIRTUALIZATION_MODE_UNKNOWN) ?
+                 AMDSMI_STATUS_NOT_SUPPORTED : AMDSMI_STATUS_SUCCESS);
+    };
+
     std::string render_name = gpu_device->get_gpu_path();
     std::string path = "/dev/dri/" + render_name;
     if (render_name.empty()) {
-        return AMDSMI_STATUS_NOT_SUPPORTED;
+        return get_virt_mode_fallback(render_name, mode);
     }
 
     ScopedFD drm_fd(path.c_str(), O_RDWR | O_CLOEXEC);
@@ -6252,7 +6302,7 @@ amdsmi_get_gpu_virtualization_mode(amdsmi_processor_handle processor_handle,
        << "." << patch_version << "\n"
        << "; Returning: " << (isDRMVersionSupported ?
             smi_amdgpu_get_status_string(AMDSMI_STATUS_SUCCESS, false):
-            smi_amdgpu_get_status_string(AMDSMI_STATUS_NOT_SUPPORTED, false));
+            "Need to use fallback method");
     LOG_INFO(ss);
 
     // Check if the version is supported
@@ -6260,7 +6310,7 @@ amdsmi_get_gpu_virtualization_mode(amdsmi_processor_handle processor_handle,
     if (isDRMVersionSupported == false) {
         drm_free_version(drm_version);
         libdrm.unload();
-        return AMDSMI_STATUS_NOT_SUPPORTED;
+        return get_virt_mode_fallback(render_name, mode);
     }
 
     // Get the device info

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -43,6 +43,7 @@
 #include <memory>
 #include <limits>
 #include <functional>
+#include <tuple>
 #include <exception>
 
 #include "amd_smi/impl/nic/smi_nic_interface.h"
@@ -5069,7 +5070,7 @@ amdsmi_get_gpu_vbios_info(amdsmi_processor_handle processor_handle, amdsmi_vbios
            << "Libdrm is likely not installed. ";
         LOG_INFO(ss);
         status = get_vbios_from_sysfs(processor_handle, info);
-        get_ifwi_version(processor_handle, info);  // ignore errors
+        std::ignore = get_ifwi_version(processor_handle, info);
         return status;  // Return what we have so far, even if libDRM parts fail
     }
 
@@ -5145,7 +5146,7 @@ amdsmi_get_gpu_vbios_info(amdsmi_processor_handle processor_handle, amdsmi_vbios
     libdrm.unload();
 
     // get vbios build string from rocm_smi which translates to ifwi version
-    auto _ = get_ifwi_version(processor_handle, info);  // ignore errors
+    std::ignore = get_ifwi_version(processor_handle, info);
 
     ss << __PRETTY_FUNCTION__
        << " | drmCommandWrite returned: " << strerror(errno) << "\n"

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -1545,7 +1545,7 @@ amdsmi_get_gpu_board_info(amdsmi_processor_handle processor_handle, amdsmi_board
         LOG_INFO(ss);
     }
 
-    if (std::string(board_info->manufacturer_name) == "0x1002") {
+    if (board_info != nullptr && std::string(board_info->manufacturer_name) == "0x1002") {
         std::string amd_name = "Advanced Micro Devices Inc. [AMD/ATI]";
         smi_clear_char_and_reinitialize(board_info->manufacturer_name,
                                     AMDSMI_MAX_STRING_LENGTH, amd_name);
@@ -2799,7 +2799,7 @@ amdsmi_status_t amdsmi_get_gpu_vram_info(
 
     SMIGPUDEVICE_MUTEX(gpu_device->get_mutex());
 
-    auto log_vram_info = [](std::ostringstream& ss, const amdsmi_vram_info_t* info) {
+    auto log_vram_info = [&ss](const amdsmi_vram_info_t* info) {
         ss << __PRETTY_FUNCTION__
            << " | info->vram_type: " << std::dec << info->vram_type << "\n"
            << "; info->vram_size (MB): " << std::dec << info->vram_size << "\n"
@@ -2843,7 +2843,7 @@ amdsmi_status_t amdsmi_get_gpu_vram_info(
            << " | render_name is empty, cannot get remaining vram info from libdrm. "
            << "Libdrm is likely not installed. ";
         LOG_INFO(ss);
-        log_vram_info(ss, info);
+        log_vram_info(info);
         return AMDSMI_STATUS_SUCCESS;  // Return what we have so far, even if libDRM parts fail
     }
 
@@ -2915,7 +2915,7 @@ amdsmi_status_t amdsmi_get_gpu_vram_info(
     libdrm.unload();
     // if vram type is greater than the max enum set it to unknown
     if (info->vram_type > AMDSMI_VRAM_TYPE__MAX) info->vram_type = AMDSMI_VRAM_TYPE_UNKNOWN;
-    log_vram_info(ss, info);
+    log_vram_info(info);
     return AMDSMI_STATUS_SUCCESS;
 }
 
@@ -6186,42 +6186,38 @@ amdsmi_get_gpu_virtualization_mode(amdsmi_processor_handle processor_handle,
         } else {
             render_name_local = render_name;
         }
-        auto [is_vm_guest, is_container, has_sriov_cap, has_active_vfs, is_vfio, sysfs_accessible] =
-            amd::smi::detect_virtualization_mode_sysfs(render_name_local);
+        auto result = amd::smi::detect_virtualization_mode_sysfs(render_name_local);
 
         ss << __PRETTY_FUNCTION__ << " | sysfs fallback detection"
-        << " | is_vm_guest: " << std::boolalpha << is_vm_guest
-        << " | is_container: " << std::boolalpha << is_container
-        << " | has_sriov_cap: " << std::boolalpha << has_sriov_cap
-        << " | has_active_vfs: " << std::boolalpha << has_active_vfs
-        << " | is_vfio: " << std::boolalpha << is_vfio
-        << " | sysfs_accessible: " << std::boolalpha << sysfs_accessible;
+           << " | render_path: " << (render_name_local.empty() ? "<empty>" : render_name_local)
+           << " | has_sriov_capability: " << std::boolalpha << result.has_sriov_capability
+           << " | has_active_vfs: " << std::boolalpha << result.has_active_vfs
+           << " | is_vfio_bound: " << std::boolalpha << result.is_vfio_bound
+           << " | is_vm_guest: " << std::boolalpha << result.is_vm_guest
+           << " | is_container: " << std::boolalpha << result.is_container
+           << " | sysfs_accessible: " << std::boolalpha << result.sysfs_accessible;
         LOG_INFO(ss);
 
-        if (has_active_vfs) {
-            // VFs are provisioned = HOST mode (definitive, if we can see sysfs)
+        *mode = AMDSMI_VIRTUALIZATION_MODE_UNKNOWN;
+        if (result.has_sriov_capability || result.has_active_vfs) {
+            // Device has SR-IOV capability OR active VFs = HOST mode
             *mode = AMDSMI_VIRTUALIZATION_MODE_HOST;
-        } else if (is_vfio) {
+        } else if (result.is_vfio_bound) {
             // Device bound to vfio-pci = PASSTHROUGH
             *mode = AMDSMI_VIRTUALIZATION_MODE_PASSTHROUGH;
-        } else if (is_vm_guest) {
+        } else if (result.is_vm_guest) {
             // hypervisor flag = GUEST (containers inherit this correctly)
             *mode = AMDSMI_VIRTUALIZATION_MODE_GUEST;
-        } else if (!is_vm_guest && !is_container) {
+        } else if (!result.is_vm_guest && !result.is_container) {
             // Not VM, not container = safe to say BAREMETAL
             *mode = AMDSMI_VIRTUALIZATION_MODE_BAREMETAL;
-        } else if (!is_vm_guest && is_container) {
+        } else if (!result.is_vm_guest && result.is_container) {
             // In container, no hypervisor flag = likely BAREMETAL
             // BUT we can't be 100% sure without sysfs access
             // Check if we could read any sysfs at all
-            if (sysfs_accessible) {
+            if (result.sysfs_accessible) {
                 *mode = AMDSMI_VIRTUALIZATION_MODE_BAREMETAL;
-            } else {
-                // Container with no sysfs access - be conservative
-                *mode = AMDSMI_VIRTUALIZATION_MODE_UNKNOWN;
             }
-        } else {
-            *mode = AMDSMI_VIRTUALIZATION_MODE_UNKNOWN;
         }
         return ((*mode == AMDSMI_VIRTUALIZATION_MODE_UNKNOWN) ?
                  AMDSMI_STATUS_NOT_SUPPORTED : AMDSMI_STATUS_SUCCESS);

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -6190,17 +6190,16 @@ amdsmi_get_gpu_virtualization_mode(amdsmi_processor_handle processor_handle,
 
         ss << __PRETTY_FUNCTION__ << " | sysfs fallback detection"
            << " | render_path: " << (render_name_local.empty() ? "<empty>" : render_name_local)
-           << " | has_sriov_capability: " << std::boolalpha << result.has_sriov_capability
-           << " | has_active_vfs: " << std::boolalpha << result.has_active_vfs
-           << " | is_vfio_bound: " << std::boolalpha << result.is_vfio_bound
+           << " | (HOST) has_active_vfs: " << std::boolalpha << result.has_active_vfs
+           << " | (PASSTHROUGH) is_vfio_bound: " << std::boolalpha << result.is_vfio_bound
            << " | is_vm_guest: " << std::boolalpha << result.is_vm_guest
            << " | is_container: " << std::boolalpha << result.is_container
            << " | sysfs_accessible: " << std::boolalpha << result.sysfs_accessible;
         LOG_INFO(ss);
 
         *mode = AMDSMI_VIRTUALIZATION_MODE_UNKNOWN;
-        if (result.has_sriov_capability || result.has_active_vfs) {
-            // Device has SR-IOV capability OR active VFs = HOST mode
+        if (result.has_active_vfs) {
+            // Device has active VFs = HOST mode
             *mode = AMDSMI_VIRTUALIZATION_MODE_HOST;
         } else if (result.is_vfio_bound) {
             // Device bound to vfio-pci = PASSTHROUGH

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -5145,7 +5145,7 @@ amdsmi_get_gpu_vbios_info(amdsmi_processor_handle processor_handle, amdsmi_vbios
     libdrm.unload();
 
     // get vbios build string from rocm_smi which translates to ifwi version
-    amdsmi_status_t ifwi_status = get_ifwi_version(processor_handle, info);  // ignore errors
+    auto _ = get_ifwi_version(processor_handle, info);  // ignore errors
 
     ss << __PRETTY_FUNCTION__
        << " | drmCommandWrite returned: " << strerror(errno) << "\n"

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -1545,6 +1545,12 @@ amdsmi_get_gpu_board_info(amdsmi_processor_handle processor_handle, amdsmi_board
         LOG_INFO(ss);
     }
 
+    if (std::string(board_info->manufacturer_name) == "0x1002") {
+        std::string amd_name = "Advanced Micro Devices Inc. [AMD/ATI]";
+        smi_clear_char_and_reinitialize(board_info->manufacturer_name,
+                                    AMDSMI_MAX_STRING_LENGTH, amd_name);
+    }
+
     ss << __PRETTY_FUNCTION__ << " | [After rocm smi correction] "
        << "Returning status = AMDSMI_STATUS_SUCCESS"
        << "\n; info->model_number: |" << board_info->model_number << "|"
@@ -2405,8 +2411,40 @@ amdsmi_get_gpu_asic_info(amdsmi_processor_handle processor_handle, amdsmi_asic_i
     }
     SMIGPUDEVICE_MUTEX(gpu_device->get_mutex())
 
+    auto log_asic_info = [&ss](const amdsmi_asic_info_t* info, amdsmi_status_t status) {
+        ss << __PRETTY_FUNCTION__
+           << " | info->market_name: " << info->market_name << "\n"
+           << " | info->vendor_id (dec): " << std::dec << info->vendor_id << "\n"
+           << " | info->vendor_id (hex): 0x"
+           << std::hex << std::setw(4) << std::setfill('0') << info->vendor_id << "\n"
+           << " | info->vendor_name: " << info->vendor_name << "\n"
+           << " | info->subvendor_id (dec): " << std::dec << info->subvendor_id << "\n"
+           << " | info->subvendor_id (hex): 0x"
+           << std::hex << std::setw(4) << std::setfill('0') << info->subvendor_id << "\n"
+           << " | info->device_id (dec): " << std::dec << info->device_id << "\n"
+           << " | info->device_id (hex): 0x"
+           << std::hex << std::setw(4) << std::setfill('0') << info->device_id << "\n"
+           << " | info->rev_id (dec): " << std::dec << info->rev_id << "\n"
+           << " | info->rev_id (hex): 0x"
+           << std::hex << std::setw(4) << std::setfill('0') << info->rev_id << "\n"
+           << " | info->asic_serial: 0x" << info->asic_serial << "\n"
+           << " | info->oam_id (dec): " << std::dec << info->oam_id << "\n"
+           << " | info->oam_id (hex): 0x"
+           << std::hex << std::setw(4) << std::setfill('0') << info->oam_id << "\n"
+           << " | info->num_of_compute_units (dec): " << std::dec
+           << info->num_of_compute_units << "\n"
+           << " | info->target_graphics_version: gfx"
+           << std::hex << info->target_graphics_version << "\n"
+           << " | info->subsystem_id (dec): " << std::dec << info->subsystem_id << "\n"
+           << " | info->subsystem_id (hex): 0x" << std::hex
+           << std::setw(4) << std::setfill('0') << info->subsystem_id << "\n"
+           << " | info->flags: 0x" << std::hex << info->flags << "\n"
+           << " | Returning: " << smi_amdgpu_get_status_string(status, true);
+        LOG_INFO(ss);
+    };
+
     // ---- ASIC info cache ----
-    const std::string key = gpu_device->get_gpu_path();
+    const std::string key = "renderD" + std::to_string(gpu_device->get_drm_render_minor());
 
     AsicInfoCache* cache_ptr = nullptr;
     {
@@ -2431,6 +2469,20 @@ amdsmi_get_gpu_asic_info(amdsmi_processor_handle processor_handle, amdsmi_asic_i
             return AMDSMI_STATUS_SUCCESS;
         }
     }
+
+    auto store_cache = [&key, &cache_ptr, &info, &ss](amdsmi_status_t my_status) {
+        if (my_status == AMDSMI_STATUS_SUCCESS
+            && kAsicInfoCacheDuration > std::chrono::milliseconds::zero()) {
+            auto now = std::chrono::steady_clock::now();
+            std::lock_guard<std::mutex> lk(cache_ptr->mtx);
+            cache_ptr->info = *info;
+            cache_ptr->last_read = now;
+            cache_ptr->valid = true;
+
+            ss << "Successfully Cached ASIC info for key=" << key;
+            LOG_INFO(ss);
+        }
+    };
 
     /**
      * For other sysfs related information, get from rocm-smi
@@ -2541,7 +2593,14 @@ amdsmi_get_gpu_asic_info(amdsmi_processor_handle processor_handle, amdsmi_asic_i
 
     std::string render_name = gpu_device->get_gpu_path();
     if (render_name.empty()) {
-        return AMDSMI_STATUS_NOT_SUPPORTED;
+        ss << __PRETTY_FUNCTION__
+           << " | render_name is empty, cannot get remaining vram info from libdrm. "
+           << "Libdrm is likely not installed.";
+        LOG_INFO(ss);
+        status = AMDSMI_STATUS_SUCCESS;
+        log_asic_info(info, status);
+        store_cache(status);
+        return status;  // Return what we have so far, even if libDRM parts fail
     }
     std::string path = "/dev/dri/" + render_name;
     ScopedFD drm_fd(path.c_str(), O_RDWR | O_CLOEXEC);
@@ -2604,45 +2663,8 @@ amdsmi_get_gpu_asic_info(amdsmi_processor_handle processor_handle, amdsmi_asic_i
     info->flags = static_cast<uint64_t>(dev_info.ids_flags);
     libdrm.unload();
 
-    ss << __PRETTY_FUNCTION__
-       << " | info->market_name: " << info->market_name << "\n"
-       << " | info->vendor_id (dec): " << std::dec << info->vendor_id << "\n"
-       << " | info->vendor_id (hex): 0x"
-       << std::hex << std::setw(4) << std::setfill('0') << info->vendor_id << "\n"
-       << " | info->vendor_name: " << info->vendor_name << "\n"
-       << " | info->subvendor_id (dec): " << std::dec << info->subvendor_id << "\n"
-       << " | info->subvendor_id (hex): 0x"
-       << std::hex << std::setw(4) << std::setfill('0') << info->subvendor_id << "\n"
-       << " | info->device_id (dec): " << std::dec << info->device_id << "\n"
-       << " | info->device_id (hex): 0x"
-       << std::hex << std::setw(4) << std::setfill('0') << info->device_id << "\n"
-       << " | info->rev_id (dec): " << std::dec << info->rev_id << "\n"
-       << " | info->rev_id (hex): 0x"
-       << std::hex << std::setw(4) << std::setfill('0') << info->rev_id << "\n"
-       << " | info->asic_serial: 0x" << info->asic_serial << "\n"
-       << " | info->oam_id (dec): " << std::dec << info->oam_id << "\n"
-       << " | info->oam_id (hex): 0x"
-       << std::hex << std::setw(4) << std::setfill('0') << info->oam_id << "\n"
-       << " | info->num_of_compute_units (dec): " << std::dec
-       << info->num_of_compute_units << "\n"
-       << " | info->target_graphics_version: gfx"
-       << std::hex << info->target_graphics_version << "\n"
-       << " | Returning: " << smi_amdgpu_get_status_string(AMDSMI_STATUS_SUCCESS, true);
-    LOG_INFO(ss);
-
-    // ---- Store cache success ----
-    if (status == AMDSMI_STATUS_SUCCESS &&
-        kAsicInfoCacheDuration > std::chrono::milliseconds::zero()) {
-
-        auto now = std::chrono::steady_clock::now();
-        std::lock_guard<std::mutex> lk(cache_ptr->mtx);
-        cache_ptr->info  = *info;
-        cache_ptr->last_read = now;
-        cache_ptr->valid = true;
-
-        ss << "Successfully Cached ASIC info for key=" << key;
-        LOG_INFO(ss);
-    }
+    log_asic_info(info, status);
+    store_cache(status);
     return AMDSMI_STATUS_SUCCESS;
 }
 
@@ -2776,10 +2798,53 @@ amdsmi_status_t amdsmi_get_gpu_vram_info(
     info->vram_max_bandwidth = std::numeric_limits<decltype(info->vram_max_bandwidth)>::max();
 
     SMIGPUDEVICE_MUTEX(gpu_device->get_mutex());
+
+    auto log_vram_info = [](std::ostringstream& ss, const amdsmi_vram_info_t* info) {
+        ss << __PRETTY_FUNCTION__
+           << " | info->vram_type: " << std::dec << info->vram_type << "\n"
+           << "; info->vram_size (MB): " << std::dec << info->vram_size << "\n"
+           << "; info->vram_vendor: " << std::dec << info->vram_vendor << "\n"
+           << "; info->vram_bit_width: " << std::dec
+           << (info->vram_bit_width == std::numeric_limits<uint64_t>::max() ?
+                   "N/A" : std::to_string(info->vram_bit_width)) << "\n"
+           << "; info->vram_max_bandwidth (GB/s): " << std::dec
+           << info->vram_max_bandwidth << "\n"
+           << "; Returning: " << smi_amdgpu_get_status_string(AMDSMI_STATUS_SUCCESS, false);
+        LOG_INFO(ss);
+    };
+
+    // set info->vram_max_bandwidth to gpu_metrics vram_max_bandwidth if it is not set
+    amdsmi_gpu_metrics_t metric_info = {};
+    r = amdsmi_get_gpu_metrics_info(processor_handle, &metric_info);
+    if (r == AMDSMI_STATUS_SUCCESS) {
+        info->vram_max_bandwidth = metric_info.vram_max_bandwidth;
+    }
+
+    // map the vendor name to enum
+    char brand[256] = {'\0'};
+    r = rsmi_wrapper(rsmi_dev_vram_vendor_get, processor_handle, 0, brand, 255);
+    if (r == AMDSMI_STATUS_SUCCESS) {
+        for (auto &x : brand)
+            x = static_cast<char>(toupper(x));
+        snprintf(info->vram_vendor, AMDSMI_MAX_STRING_LENGTH, "%s", brand);
+    }
+    uint64_t total = 0;
+    r = rsmi_wrapper(rsmi_dev_memory_total_get, processor_handle, 0,
+                    RSMI_MEM_TYPE_VRAM, &total);
+    if (r == AMDSMI_STATUS_SUCCESS) {
+        info->vram_size = total / (1024 * 1024);
+    }
+
+    // Get rest of data from libdrm
     std::string render_name = gpu_device->get_gpu_path();
     std::string path = "/dev/dri/" + render_name;
     if (render_name.empty()) {
-        return AMDSMI_STATUS_NOT_SUPPORTED;
+        ss << __PRETTY_FUNCTION__
+           << " | render_name is empty, cannot get remaining vram info from libdrm. "
+           << "Libdrm is likely not installed. ";
+        LOG_INFO(ss);
+        log_vram_info(ss, info);
+        return AMDSMI_STATUS_SUCCESS;  // Return what we have so far, even if libDRM parts fail
     }
 
     ScopedFD drm_fd(path.c_str(), O_RDWR | O_CLOEXEC);
@@ -2850,40 +2915,7 @@ amdsmi_status_t amdsmi_get_gpu_vram_info(
     libdrm.unload();
     // if vram type is greater than the max enum set it to unknown
     if (info->vram_type > AMDSMI_VRAM_TYPE__MAX) info->vram_type = AMDSMI_VRAM_TYPE_UNKNOWN;
-
-    // set info->vram_max_bandwidth to gpu_metrics vram_max_bandwidth if it is not set
-    amdsmi_gpu_metrics_t metric_info = {};
-    r = amdsmi_get_gpu_metrics_info(processor_handle, &metric_info);
-    if (r == AMDSMI_STATUS_SUCCESS) {
-        info->vram_max_bandwidth = metric_info.vram_max_bandwidth;
-    }
-
-    // map the vendor name to enum
-    char brand[256] = {'\0'};
-    r = rsmi_wrapper(rsmi_dev_vram_vendor_get, processor_handle, 0, brand, 255);
-    if (r == AMDSMI_STATUS_SUCCESS) {
-        for (auto &x : brand)
-            x = static_cast<char>(toupper(x));
-        snprintf(info->vram_vendor, AMDSMI_MAX_STRING_LENGTH, "%s", brand);
-    }
-    uint64_t total = 0;
-    r = rsmi_wrapper(rsmi_dev_memory_total_get, processor_handle, 0,
-                    RSMI_MEM_TYPE_VRAM, &total);
-    if (r == AMDSMI_STATUS_SUCCESS) {
-        info->vram_size = total / (1024 * 1024);
-    }
-
-    ss << __PRETTY_FUNCTION__
-       << " | info->vram_type: " << std::dec << info->vram_type << "\n"
-       << "; info->vram_size (MB): " << std::dec << info->vram_size << "\n"
-       << "; info->vram_vendor: " << std::dec << info->vram_vendor << "\n"
-       << "; info->vram_bit_width: " << std::dec
-       << (info->vram_bit_width == std::numeric_limits<uint64_t>::max() ?
-            "N/A" : std::to_string(info->vram_bit_width)) << "\n"
-       << "; info->vram_max_bandwidth (GB/s): " << std::dec
-       << info->vram_max_bandwidth << "\n"
-       << "; Returning: " << smi_amdgpu_get_status_string(AMDSMI_STATUS_SUCCESS, false);
-    LOG_INFO(ss);
+    log_vram_info(ss, info);
     return AMDSMI_STATUS_SUCCESS;
 }
 
@@ -4998,10 +5030,47 @@ amdsmi_get_gpu_vbios_info(amdsmi_processor_handle processor_handle, amdsmi_vbios
     }
 
     SMIGPUDEVICE_MUTEX(gpu_device->get_mutex());
+
+    auto get_vbios_from_sysfs = [&](amdsmi_processor_handle processor_handle,
+                                    amdsmi_vbios_info_t* info) {
+        amdsmi_status_t status = AMDSMI_STATUS_NOT_SUPPORTED;
+        char vbios_version[AMDSMI_MAX_STRING_LENGTH];
+        status = rsmi_wrapper(rsmi_dev_vbios_version_get, processor_handle, 0,
+                            vbios_version, AMDSMI_MAX_STRING_LENGTH);
+
+        if (status == AMDSMI_STATUS_SUCCESS) {
+            snprintf(info->part_number, AMDSMI_MAX_STRING_LENGTH, "%s", vbios_version);
+        }
+        return status;
+    };
+
+    auto get_ifwi_version = [&](amdsmi_processor_handle processor_handle,
+                                amdsmi_vbios_info_t* info) {
+        amdsmi_status_t build_status;
+        char vbios_build_number[AMDSMI_MAX_STRING_LENGTH];
+
+        build_status = rsmi_wrapper(rsmi_dev_vbios_build_number_get, processor_handle, 0,
+                                    vbios_build_number, AMDSMI_MAX_STRING_LENGTH);
+
+        // Continue if sysfs doesn't exist
+        if (build_status == AMDSMI_STATUS_SUCCESS) {
+            // This device has an ifwi version so swap the version and boot_firmware
+            snprintf(info->boot_firmware, AMDSMI_MAX_STRING_LENGTH, "%s", info->version);
+            snprintf(info->version, AMDSMI_MAX_STRING_LENGTH, "%s", vbios_build_number);
+        }
+        return build_status;
+    };
+
     std::string render_name = gpu_device->get_gpu_path();
     std::string path = "/dev/dri/" + render_name;
     if (render_name.empty()) {
-        return AMDSMI_STATUS_NOT_SUPPORTED;
+        ss << __PRETTY_FUNCTION__
+           << " | render_name is empty, cannot get remaining vram info from libdrm. "
+           << "Libdrm is likely not installed. ";
+        LOG_INFO(ss);
+        status = get_vbios_from_sysfs(processor_handle, info);
+        get_ifwi_version(processor_handle, info);  // ignore errors
+        return status;  // Return what we have so far, even if libDRM parts fail
     }
 
     ScopedFD drm_fd(path.c_str(), O_RDWR | O_CLOEXEC);
@@ -5061,36 +5130,22 @@ amdsmi_get_gpu_vbios_info(amdsmi_processor_handle processor_handle, amdsmi_vbios
 
     if (drm_write == 0) {
         snprintf(info->name, AMDSMI_MAX_STRING_LENGTH, "%s", reinterpret_cast<char *>(vbios.name));
-        snprintf(info->build_date, AMDSMI_MAX_STRING_LENGTH - 1, "%s", reinterpret_cast<char *>(vbios.date) );
+        snprintf(info->build_date, AMDSMI_MAX_STRING_LENGTH - 1, "%s",
+                 reinterpret_cast<char *>(vbios.date));
         info->build_date[AMDSMI_MAX_STRING_LENGTH - 1] = '\0';
-        snprintf(info->part_number, AMDSMI_MAX_STRING_LENGTH, "%s", reinterpret_cast<char *>(vbios.vbios_pn));
+        snprintf(info->part_number, AMDSMI_MAX_STRING_LENGTH, "%s",
+                 reinterpret_cast<char *>(vbios.vbios_pn));
         // Navi devices still interpret vbios version from drm vbios_ver_str
-        snprintf(info->version, AMDSMI_MAX_STRING_LENGTH, "%s", reinterpret_cast<char *>(vbios.vbios_ver_str));
+        snprintf(info->version, AMDSMI_MAX_STRING_LENGTH, "%s",
+                 reinterpret_cast<char *>(vbios.vbios_ver_str));
     } else {
         // get sysfs vbios_version string which is known as the part number
-        char vbios_version[AMDSMI_MAX_STRING_LENGTH];
-        status = rsmi_wrapper(rsmi_dev_vbios_version_get, processor_handle, 0,
-                              vbios_version, AMDSMI_MAX_STRING_LENGTH);
-
-        // fail if cannot get vbios version from sysfs
-        if (status == AMDSMI_STATUS_SUCCESS) {
-            snprintf(info->part_number, AMDSMI_MAX_STRING_LENGTH, "%s", vbios_version);
-        }
+        status = get_vbios_from_sysfs(processor_handle, info);
     }
     libdrm.unload();
 
     // get vbios build string from rocm_smi which translates to ifwi version
-    char vbios_build_number[AMDSMI_MAX_STRING_LENGTH];
-    amdsmi_status_t build_status;
-    build_status = rsmi_wrapper(rsmi_dev_vbios_build_number_get, processor_handle, 0,
-                                vbios_build_number, AMDSMI_MAX_STRING_LENGTH);
-
-    // Continue if sysfs doesn't exist
-    if (build_status == AMDSMI_STATUS_SUCCESS) {
-        // This device has an ifwi version so swap the version and boot_firmware
-        snprintf(info->boot_firmware, AMDSMI_MAX_STRING_LENGTH, "%s", info->version);
-        snprintf(info->version, AMDSMI_MAX_STRING_LENGTH, "%s", vbios_build_number);
-    }
+    amdsmi_status_t ifwi_status = get_ifwi_version(processor_handle, info);  // ignore errors
 
     ss << __PRETTY_FUNCTION__
        << " | drmCommandWrite returned: " << strerror(errno) << "\n"
@@ -5753,8 +5808,8 @@ amdsmi_status_t amdsmi_get_pcie_info(amdsmi_processor_handle processor_handle, a
 
     memset((void *)info, 0, sizeof(*info));
 
-    std::string path_max_link_width = "/sys/class/drm/" +
-        gpu_device->get_gpu_path() + "/device/max_link_width";
+    std::string path_max_link_width = "/sys/class/drm/renderD" +
+        std::to_string(gpu_device->get_drm_render_minor()) + "/device/max_link_width";
     fp = fopen(path_max_link_width.c_str(), "r");
     if (fp) {
         fscanf(fp, "%d", &pcie_width);
@@ -5768,8 +5823,8 @@ amdsmi_status_t amdsmi_get_pcie_info(amdsmi_processor_handle processor_handle, a
     }
     info->pcie_static.max_pcie_width = (uint16_t)pcie_width;
 
-    std::string path_max_link_speed = "/sys/class/drm/" +
-        gpu_device->get_gpu_path() + "/device/max_link_speed";
+    std::string path_max_link_speed = "/sys/class/drm/renderD" +
+        std::to_string(gpu_device->get_drm_render_minor()) + "/device/max_link_speed";
     fp = fopen(path_max_link_speed.c_str(), "r");
     if (fp) {
         fscanf(fp, "%lf %s", &pcie_speed, buff);

--- a/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
@@ -19,18 +19,20 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
-#include <memory>
-#include <unordered_set>
 #include <dirent.h>
 #include <sys/types.h>
+
 #include <atomic>
+#include <memory>
+#include <unordered_set>
 
 #include "amd_smi/impl/amd_smi_gpu_device.h"
+#include "amd_smi/impl/amd_smi_drm.h"
 #include "amd_smi/impl/fdinfo.h"
 #include "rocm_smi/rocm_smi_kfd.h"
 #include "rocm_smi/rocm_smi_utils.h"
 #include "rocm_smi/rocm_smi_logger.h"
+#include "rocm_smi/rocm_smi_main.h"
 
 namespace amd::smi {
 
@@ -83,11 +85,37 @@ uint64_t AMDSmiGPUDevice::get_kfd_gpu_id() {
     return this->kfd_gpu_id_;
 }
 
+// This is the libDRM path, if its empty then we have issues loading libDRM
 std::string& AMDSmiGPUDevice::get_gpu_path() {
     return path_;
 }
 
 amdsmi_bdf_t AMDSmiGPUDevice::get_bdf() {
+    // If libDRM is not initialized, we have to get from ROCm-SMI APIs
+    // For some reason we only initialize the BDFs if libdrm is successful
+    // This was incorrect, we can still get through KFD/ROCm SMI (we don't even
+    // get through libdrm anyways...)
+    if (!amd::smi::AMDSmiGPUDevice::check_if_drm_is_supported()) {
+        // Use rocm-smi device interface directly to get BDF info
+        this->bdf_ = amdsmi_bdf_t{};
+        amd::smi::RocmSMI& smi = amd::smi::RocmSMI::getInstance();
+        // Validate gpu_id_ before using it, we cannot get BDF info if its
+        // larger than number of available devices
+        size_t device_size = smi.devices().size();
+        if (gpu_id_ >= static_cast<uint32_t>(device_size)) {
+            std::ostringstream ss;
+            ss << __PRETTY_FUNCTION__ << " | Specified GPU ID " << gpu_id_
+               << " is out of range. Total available devices: " << device_size;
+            LOG_ERROR(ss);
+            return this->bdf_;
+        }
+
+        uint64_t rocm_bdf = smi.devices()[gpu_id_]->bdfid();
+        this->bdf_.domain_number = static_cast<uint64_t>(((rocm_bdf >> 32) & 0xFFFFFFFF));
+        this->bdf_.bus_number = static_cast<uint64_t>(((rocm_bdf >> 8) & 0xFF));
+        this->bdf_.device_number = static_cast<uint64_t>(((rocm_bdf >> 3) & 0x1F));
+        this->bdf_.function_number = static_cast<uint64_t>((rocm_bdf & 0x7));
+    }
     return this->bdf_;
 }
 

--- a/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
@@ -174,7 +174,8 @@ amdsmi_status_t smi_amdgpu_find_hwmon_dir(amd::smi::AMDSmiGPUDevice *device, std
     SMIGPUDEVICE_MUTEX(device->get_mutex())
         DIR *dh;
     struct dirent * contents;
-    std::string device_path = "/sys/class/drm/" + device->get_gpu_path();
+    std::string device_path = "/sys/class/drm/renderD" +
+        std::to_string(device->get_drm_render_minor());
     std::string directory_path = device_path + "/device/hwmon/";
 
     if (!isAMDGPU(device_path)) {
@@ -204,11 +205,16 @@ amdsmi_status_t smi_amdgpu_find_hwmon_dir(amd::smi::AMDSmiGPUDevice *device, std
 
 amdsmi_status_t smi_amdgpu_get_board_info(amd::smi::AMDSmiGPUDevice* device, amdsmi_board_info_t *info) {
     SMIGPUDEVICE_MUTEX(device->get_mutex())
-    std::string model_number_path = "/sys/class/drm/" + device->get_gpu_path() + std::string("/device/product_number");
-    std::string product_serial_path = "/sys/class/drm/" + device->get_gpu_path() + std::string("/device/serial_number");
-    std::string fru_id_path = "/sys/class/drm/" + device->get_gpu_path() + std::string("/device/fru_id");
-    std::string manufacturer_name_path = "/sys/class/drm/" + device->get_gpu_path() + std::string("/device/manufacturer");
-    std::string product_name_path = "/sys/class/drm/" + device->get_gpu_path() + std::string("/device/product_name");
+    std::string model_number_path = "/sys/class/drm/renderD" +
+        std::to_string(device->get_drm_render_minor()) + std::string("/device/product_number");
+    std::string product_serial_path = "/sys/class/drm/renderD" +
+        std::to_string(device->get_drm_render_minor()) + std::string("/device/serial_number");
+    std::string fru_id_path = "/sys/class/drm/renderD" +
+        std::to_string(device->get_drm_render_minor()) + std::string("/device/fru_id");
+    std::string manufacturer_name_path = "/sys/class/drm/renderD" +
+        std::to_string(device->get_drm_render_minor()) + std::string("/device/manufacturer");
+    std::string product_name_path = "/sys/class/drm/renderD" +
+        std::to_string(device->get_drm_render_minor()) + std::string("/device/product_name");
 
     auto ret_mod = openFileAndModifyBuffer(model_number_path, info->model_number,
                                            AMDSMI_MAX_STRING_LENGTH);
@@ -277,7 +283,8 @@ amdsmi_status_t smi_amdgpu_get_ranges(amd::smi::AMDSmiGPUDevice* device, amdsmi_
         int *max_freq, int *min_freq, int *num_dpm, int *sleep_state_freq)
 {
     SMIGPUDEVICE_MUTEX(device->get_mutex())
-    std::string fullpath = "/sys/class/drm/" + device->get_gpu_path() + "/device";
+    std::string fullpath = "/sys/class/drm/renderD" +
+        std::to_string(device->get_drm_render_minor()) + "/device";
     std::string smclk_min_max_fullpath = "";
 
     bool sclk = false;
@@ -451,7 +458,8 @@ amdsmi_status_t smi_amdgpu_get_ranges(amd::smi::AMDSmiGPUDevice* device, amdsmi_
 
 amdsmi_status_t smi_amdgpu_get_enabled_blocks(amd::smi::AMDSmiGPUDevice* device, uint64_t *enabled_blocks) {
     SMIGPUDEVICE_MUTEX(device->get_mutex())
-    std::string fullpath = "/sys/class/drm/" + device->get_gpu_path() + "/device/ras/features";
+    std::string fullpath = "/sys/class/drm/renderD" +
+        std::to_string(device->get_drm_render_minor()) + "/device/ras/features";
     std::ifstream f(fullpath.c_str());
     std::string tmp_str;
 
@@ -484,7 +492,9 @@ amdsmi_status_t smi_amdgpu_get_bad_page_info(amd::smi::AMDSmiGPUDevice* device,
         std::string line;
     std::vector<std::string> badPagesVec;
 
-    std::string fullpath = "/sys/class/drm/" + device->get_gpu_path() + std::string("/device/ras/gpu_vram_bad_pages");
+    std::string fullpath = "/sys/class/drm/renderD" +
+        std::to_string(device->get_drm_render_minor()) +
+        std::string("/device/ras/gpu_vram_bad_pages");
     std::ifstream fs(fullpath.c_str());
 
     if (fs.fail()) {
@@ -579,12 +589,14 @@ amdsmi_status_t smi_amdgpu_get_ecc_error_count(amd::smi::AMDSmiGPUDevice* device
     SMIGPUDEVICE_MUTEX(device->get_mutex())
         char str[10];
 
-    std::string fullpath = "/sys/class/drm/" + device->get_gpu_path() + std::string("/device/ras/umc_err_count");
+    std::string fullpath = "/sys/class/drm/renderD" +
+        std::to_string(device->get_drm_render_minor()) + std::string("/device/ras/umc_err_count");
     std::ifstream f(fullpath.c_str());
 
     if (f.fail()) {
         //fall back to aca file
-        fullpath = "/sys/class/drm/" + device->get_gpu_path() + std::string("/device/ras/aca_umc");
+        fullpath = "/sys/class/drm/renderD" +
+            std::to_string(device->get_drm_render_minor()) + std::string("/device/ras/aca_umc");
         f.open(fullpath.c_str());
         if (f.fail()) {
             return AMDSMI_STATUS_NOT_SUPPORTED;
@@ -753,7 +765,8 @@ amdsmi_status_t smi_amdgpu_is_gpu_power_management_enabled(amd::smi::AMDSmiGPUDe
     }
 
     SMIGPUDEVICE_MUTEX(device->get_mutex())
-    std::string fullpath = "/sys/class/drm/" + device->get_gpu_path() + std::string("/device/pp_features");
+    std::string fullpath = "/sys/class/drm/renderD" +
+        std::to_string(device->get_drm_render_minor()) + std::string("/device/pp_features");
     std::ifstream fs(fullpath.c_str());
 
     if (fs.fail()) {


### PR DESCRIPTION
[ROCM-2950] amdsmi: soft-depend on libdrm

Make AMD SMI work reliably when libdrm is unavailable by improving fallback
mechanisms and virtualization detection.

Key improvements:
- Fix amd-smi commands (static --asic, --board, default view) when libdrm is missing
- Add robust virtualization mode detection for VMs, SR-IOV HOST, and GPU passthrough without requiring root access (When libdrm version is too low or unavailable)
- Optimize device identifier queries with direct indexing
- Fix table alignment in CLI output when amdgpu version unavailable

This enables AMD SMI to work correctly in minimal environments (containers,
restricted VMs) while maintaining full functionality when libdrm is available.

----------------


## Motivation

This PR improves AMD SMI behavior in environments where libdrm is not present or cannot be loaded. The primary goal is to keep core queries working (and keep CLI output stable) by using consistent DRM render-minor based sysfs paths and adding safe fallbacks, rather than treating missing libdrm as a hard failure.

## Technical Details

- Standardizes internal SYSFS path construction to use DRM render minors in the renderD<N> form for more consistent device mapping and sysfs access.
- Improves device-identifier retrieval in the ROCm-SMI device layer by removing unnecessary iteration and adding bounds checking for invalid device_id inputs.
- Fixes GPU BDF retrieval when libdrm is unavailable by falling back to ROCm-SMI/KFD-based paths and validating indices before dereferencing.
- Fixes manufacturer name handling so AMD’s vendor ID (0x1002) is normalized to the expected “Advanced Micro Devices Inc. [AMD/ATI]” string in board info output.
- Updates ASIC info retrieval to return partial information (and succeed) when libdrm isn’t installed, instead of failing as not supported.
- Ensures amd-smi default output remains aligned when falling back to OS Kernel Version (when amdgpu Version can’t be queried via libdrm).

## JIRA ID

ROCM-2950

## Test Plan

- **Before changes: Get Golden Values (with libDRM)**
  - Run:
    - `amd-smi` (default command)
    - `amd-smi static --bus --ifwi --asic --board --vbios --driver --vram --ras`
    - `amd-smi metric --clock --power`
  - Verify: N/A - use values to verify against with and without libDRM.
 
- **Before changes: Display issues in a container (without libDRM)**
  - Run:
    - `amd-smi` (default command)
    - `amd-smi static --bus --ifwi --asic --board --vbios --driver --vram --ras`
    - `amd-smi metric --clock --power`
  - Verify: N/A - use values to track fixes seen after libDRM soft dependency changes.

- **After changes: Functional sanity (with `libdrm` available)**
  - Run:
    - `amd-smi` (default command)
    - `amd-smi static --bus --ifwi --asic --board --vbios --driver --vram --ras`
    - `amd-smi metric --clock --power`
  - Verify expected values and alignment. Verify against "Golden Values" confirm no changes (except for alignment fixes).

- **After changes: Functional sanity (without `libdrm`)**
  - Test in an environment/container where `libdrm` is not installed (or where loading it is prevented).
  - Run:
    - `amd-smi` (default command)
    - `amd-smi static --bus --ifwi --asic --board --vbios --driver --vram --ras`
    - `amd-smi metric --clock --power`
  - Verify expected values and alignment. Verify against "Golden Values"  & confirm the minimal partial data comes in as expected.

## Test Result
**_Note_**: Device is in NPS1, DPX (to confirm partition nodes get partial data - when available). We will be primarily looking at gpu 0 and 1 (for simplicity).

- **Before changes: Get Golden Values (with libDRM)**
 
<img width="400" height="636" alt="image" src="https://github.com/user-attachments/assets/a9ba6a58-7447-4013-ad47-91744ea36092" />

```console
$ amd-smi static --bus --ifwi --asic --board --vbios --driver --vram --ras -g 0 1
GPU: 0
    ASIC:
        MARKET_NAME: AMD Instinct MI350X
        VENDOR_ID: 0x1002
        VENDOR_NAME: Advanced Micro Devices Inc. [AMD/ATI]
        SUBVENDOR_ID: 0x1002
        DEVICE_ID: 0x75a0
        SUBSYSTEM_ID: 0x75a0
        REV_ID: 0x00
        ASIC_SERIAL: <redacted>
        OAM_ID: 6
        NUM_COMPUTE_UNITS: 128
        TARGET_GRAPHICS_VERSION: gfx950
        FLAGS: 16
    BUS:
        BDF: 0000:05:00.0
        MAX_PCIE_WIDTH: 16
        MAX_PCIE_SPEED: 32 GT/s
        PCIE_LEVELS: N/A
        PCIE_INTERFACE_VERSION: Gen 5
        SLOT_TYPE: OAM
    IFWI:
        NAME: AMD MI350X
        BUILD_DATE: 2025/06/19 21:03
        PART_NUMBER: 113-M350-01-1K0-920A
        VERSION: 00154951
    DRIVER:
        NAME: amdgpu
        VERSION: 6.18.3
        OS_KERNEL_VERSION: 5.15.0-164-generic
    BOARD:
        MODEL_NUMBER: 102-G36212-0C
        PRODUCT_SERIAL: <redacted>
        FRU_ID: 113-AMDG362120C01-100-300000082
        PRODUCT_NAME: AMD Instinct MI350 OAM
        MANUFACTURER_NAME: AMD
    RAS:
        EEPROM_VERSION: 0x10000
        BAD_PAGE_THRESHOLD: N/A
        BAD_PAGE_THRESHOLD_EXCEEDED: N/A
        PARITY_SCHEMA: DISABLED
        SINGLE_BIT_SCHEMA: DISABLED
        DOUBLE_BIT_SCHEMA: DISABLED
        POISON_SCHEMA: ENABLED
        ECC_BLOCK_STATE:
            UMC: ENABLED
            SDMA: ENABLED
            GFX: ENABLED
            MMHUB: ENABLED
            ATHUB: ENABLED
            PCIE_BIF: ENABLED
            HDP: ENABLED
            XGMI_WAFL: ENABLED
            DF: ENABLED
            SMN: ENABLED
            SEM: DISABLED
            MP0: ENABLED
            MP1: ENABLED
            FUSE: DISABLED
            MCA: ENABLED
            VCN: DISABLED
            JPEG: DISABLED
            IH: ENABLED
            MPIO: ENABLED
    VRAM:
        TYPE: HBM3E
        VENDOR: SAMSUNG
        SIZE: 258032 MB
        BIT_WIDTH: 8192
        MAX_BANDWIDTH: 6810 GB/s

GPU: 1
    ASIC:
        MARKET_NAME: AMD Instinct MI350X
        VENDOR_ID: 0x1002
        VENDOR_NAME: Advanced Micro Devices Inc. [AMD/ATI]
        SUBVENDOR_ID: N/A
        DEVICE_ID: 0x75a0
        SUBSYSTEM_ID: N/A
        REV_ID: 0x00
        ASIC_SERIAL: <redacted>
        OAM_ID: N/A
        NUM_COMPUTE_UNITS: 128
        TARGET_GRAPHICS_VERSION: gfx950
        FLAGS: 16
    BUS:
        BDF: 0000:05:00.1
        MAX_PCIE_WIDTH: N/A
        MAX_PCIE_SPEED: N/A
        PCIE_LEVELS: N/A
        PCIE_INTERFACE_VERSION: N/A
        SLOT_TYPE: N/A
    IFWI:
        NAME: AMD MI350X
        BUILD_DATE: 2025/06/19 21:03
        PART_NUMBER: 113-M350-01-1K0-920A
        VERSION: 023.040.001.008.000001
    DRIVER:
        NAME: amdgpu
        VERSION: 6.18.3
        OS_KERNEL_VERSION: 5.15.0-164-generic
    BOARD:
        MODEL_NUMBER: N/A
        PRODUCT_SERIAL: N/A
        FRU_ID: N/A
        PRODUCT_NAME: N/A
        MANUFACTURER_NAME: Advanced Micro Devices, Inc. [AMD/ATI]
    RAS:
        EEPROM_VERSION: N/A
        BAD_PAGE_THRESHOLD: N/A
        BAD_PAGE_THRESHOLD_EXCEEDED: N/A
        PARITY_SCHEMA: N/A
        SINGLE_BIT_SCHEMA: N/A
        DOUBLE_BIT_SCHEMA: N/A
        POISON_SCHEMA: N/A
        ECC_BLOCK_STATE: N/A
    VRAM:
        TYPE: HBM3E
        VENDOR: UNKNOWN
        SIZE: 129016 MB
        BIT_WIDTH: 8192
        MAX_BANDWIDTH: N/A
```
```console
$ amd-smi metric --power --clock -g 0 1                                          
GPU: 0
    POWER:
        SOCKET_POWER: 225 W
        GFX_VOLTAGE: N/A
        SOC_VOLTAGE: N/A
        MEM_VOLTAGE: N/A
        THROTTLE_STATUS: N/A
        POWER_MANAGEMENT: ENABLED
    CLOCK:
        GFX_0:
            CLK: 145 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_1:
            CLK: 145 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_2:
            CLK: 144 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_3:
            CLK: 145 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_4:
            CLK: 168 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_5:
            CLK: 167 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_6:
            CLK: 145 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_7:
            CLK: 145 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        MEM_0:
            CLK: 1900 MHz
            MIN_CLK: 1900 MHz
            MAX_CLK: 1900 MHz
            DEEP_SLEEP: DISABLED
        VCLK_0:
            CLK: 59 MHz
            MIN_CLK: 1900 MHz
            MAX_CLK: 1900 MHz
            DEEP_SLEEP: ENABLED
        VCLK_1:
            CLK: 59 MHz
            MIN_CLK: 1900 MHz
            MAX_CLK: 1900 MHz
            DEEP_SLEEP: ENABLED
        VCLK_2:
            CLK: 59 MHz
            MIN_CLK: 1900 MHz
            MAX_CLK: 1900 MHz
            DEEP_SLEEP: ENABLED
        VCLK_3:
            CLK: 59 MHz
            MIN_CLK: 1900 MHz
            MAX_CLK: 1900 MHz
            DEEP_SLEEP: ENABLED
        DCLK_0:
            CLK: 48 MHz
            MIN_CLK: 1520 MHz
            MAX_CLK: 1520 MHz
            DEEP_SLEEP: ENABLED
        DCLK_1:
            CLK: 48 MHz
            MIN_CLK: 1520 MHz
            MAX_CLK: 1520 MHz
            DEEP_SLEEP: ENABLED
        DCLK_2:
            CLK: 48 MHz
            MIN_CLK: 1520 MHz
            MAX_CLK: 1520 MHz
            DEEP_SLEEP: ENABLED
        DCLK_3:
            CLK: 48 MHz
            MIN_CLK: 1520 MHz
            MAX_CLK: 1520 MHz
            DEEP_SLEEP: ENABLED
        FCLK_0:
            CLK: 1500 MHz
            MIN_CLK: 1250 MHz
            MAX_CLK: 1500 MHz
            DEEP_SLEEP: DISABLED
        SOCCLK_0:
            CLK: 40 MHz
            MIN_CLK: 1200 MHz
            MAX_CLK: 1200 MHz
            DEEP_SLEEP: ENABLED

GPU: 1
    POWER:
        SOCKET_POWER: N/A
        GFX_VOLTAGE: N/A
        SOC_VOLTAGE: N/A
        MEM_VOLTAGE: N/A
        THROTTLE_STATUS: N/A
        POWER_MANAGEMENT: N/A
    CLOCK: N/A
```

- **Before changes: Display issues in a container (without libDRM)**
 
<img width="500" height="512" alt="image" src="https://github.com/user-attachments/assets/8a5b0905-7593-46f1-af88-286c91cdd9b4" />

```console
$ amd-smi static --bus --ifwi --asic --board --vbios --driver --vram --ras -g 0 1
Fail to open libdrm_amdgpu.so.1: libdrm_amdgpu.so.1: cannot open shared object file: No such file or directory
GPU: 0
    ASIC:
        MARKET_NAME: N/A
        VENDOR_ID: N/A
        VENDOR_NAME: N/A
        SUBVENDOR_ID: N/A
        DEVICE_ID: N/A
        SUBSYSTEM_ID: N/A
        REV_ID: N/A
        ASIC_SERIAL: N/A
        OAM_ID: N/A
        NUM_COMPUTE_UNITS: N/A
        TARGET_GRAPHICS_VERSION: N/A
    BUS:
        BDF: 695f7570672f:31:05.7
        MAX_PCIE_WIDTH: N/A
        MAX_PCIE_SPEED: N/A
        PCIE_LEVELS: N/A
        PCIE_INTERFACE_VERSION: N/A
        SLOT_TYPE: N/A
    IFWI: N/A
    DRIVER:
        NAME: N/A
        VERSION: N/A
        OS_KERNEL_VERSION: 5.15.0-164-generic
    BOARD:
        MODEL_NUMBER: N/A
        PRODUCT_SERIAL: 692517010989
        FRU_ID: N/A
        PRODUCT_NAME: AMD Instinct MI350 OAM
        MANUFACTURER_NAME: 0x1002
    RAS:
        EEPROM_VERSION: 0x10000
        BAD_PAGE_THRESHOLD: N/A
        BAD_PAGE_THRESHOLD_EXCEEDED: N/A
        PARITY_SCHEMA: DISABLED
        SINGLE_BIT_SCHEMA: DISABLED
        DOUBLE_BIT_SCHEMA: DISABLED
        POISON_SCHEMA: ENABLED
        ECC_BLOCK_STATE: N/A
    VRAM:
        TYPE: N/A
        VENDOR: N/A
        SIZE: N/A
        BIT_WIDTH: N/A
        MAX_BANDWIDTH: N/A

GPU: 1
    ASIC:
        MARKET_NAME: N/A
        VENDOR_ID: N/A
        VENDOR_NAME: N/A
        SUBVENDOR_ID: N/A
        DEVICE_ID: N/A
        SUBSYSTEM_ID: N/A
        REV_ID: N/A
        ASIC_SERIAL: N/A
        OAM_ID: N/A
        NUM_COMPUTE_UNITS: N/A
        TARGET_GRAPHICS_VERSION: N/A
    BUS:
        BDF: 0000:00:00.0
        MAX_PCIE_WIDTH: N/A
        MAX_PCIE_SPEED: N/A
        PCIE_LEVELS: N/A
        PCIE_INTERFACE_VERSION: N/A
        SLOT_TYPE: N/A
    IFWI: N/A
    DRIVER:
        NAME: N/A
        VERSION: N/A
        OS_KERNEL_VERSION: 5.15.0-164-generic
    BOARD:
        MODEL_NUMBER: N/A
        PRODUCT_SERIAL: N/A
        FRU_ID: N/A
        PRODUCT_NAME: N/A
        MANUFACTURER_NAME: 0x1002
    RAS:
        EEPROM_VERSION: N/A
        BAD_PAGE_THRESHOLD: N/A
        BAD_PAGE_THRESHOLD_EXCEEDED: N/A
        PARITY_SCHEMA: N/A
        SINGLE_BIT_SCHEMA: N/A
        DOUBLE_BIT_SCHEMA: N/A
        POISON_SCHEMA: N/A
        ECC_BLOCK_STATE: N/A
    VRAM:
        TYPE: N/A
        VENDOR: N/A
        SIZE: N/A
        BIT_WIDTH: N/A
        MAX_BANDWIDTH: N/A
```

```console
$ amd-smi metric --power --clock -g 0 1
Fail to open libdrm_amdgpu.so.1: libdrm_amdgpu.so.1: cannot open shared object file: No such file or directory
GPU: 0
    POWER:
        SOCKET_POWER: 225 W
        GFX_VOLTAGE: N/A
        SOC_VOLTAGE: N/A
        MEM_VOLTAGE: N/A
        THROTTLE_STATUS: N/A
        POWER_MANAGEMENT: N/A
    CLOCK:
        GFX_0:
            CLK: 145 MHz
            CLK_LOCKED: DISABLED
        GFX_1:
            CLK: 145 MHz
            CLK_LOCKED: DISABLED
        GFX_2:
            CLK: 144 MHz
            CLK_LOCKED: DISABLED
        GFX_3:
            CLK: 145 MHz
            CLK_LOCKED: DISABLED
        GFX_4:
            CLK: 146 MHz
            CLK_LOCKED: DISABLED
        GFX_5:
            CLK: 147 MHz
            CLK_LOCKED: DISABLED
        GFX_6:
            CLK: 145 MHz
            CLK_LOCKED: DISABLED
        GFX_7:
            CLK: 145 MHz
            CLK_LOCKED: DISABLED
        MEM_0:
            CLK: 1900 MHz
        VCLK_0:
            CLK: 59 MHz
        VCLK_1:
            CLK: 59 MHz
        VCLK_2:
            CLK: 59 MHz
        VCLK_3:
            CLK: 59 MHz
        DCLK_0:
            CLK: 48 MHz
        DCLK_1:
            CLK: 48 MHz
        DCLK_2:
            CLK: 48 MHz
        DCLK_3:
            CLK: 48 MHz
        FCLK_0:
            CLK: 1500 MHz
        SOCCLK_0:
            CLK: 38 MHz

GPU: 1
    POWER:
        SOCKET_POWER: N/A
        GFX_VOLTAGE: N/A
        SOC_VOLTAGE: N/A
        MEM_VOLTAGE: N/A
        THROTTLE_STATUS: N/A
        POWER_MANAGEMENT: N/A
    CLOCK: N/A
```

- **After changes: Functional sanity (with `libdrm` available)**
<img width="400" height="636" alt="image" src="https://github.com/user-attachments/assets/23f3c253-f97e-4d18-9d52-068ddf85d412" />

```console
$ amd-smi static --bus --ifwi --asic --board --vbios --driver --vram --ras -g 0 1
GPU: 0
    ASIC:
        MARKET_NAME: AMD Instinct MI350X
        VENDOR_ID: 0x1002
        VENDOR_NAME: Advanced Micro Devices Inc. [AMD/ATI]
        SUBVENDOR_ID: 0x1002
        DEVICE_ID: 0x75a0
        SUBSYSTEM_ID: 0x75a0
        REV_ID: 0x00
        ASIC_SERIAL: <redacted>
        OAM_ID: 6
        NUM_COMPUTE_UNITS: 128
        TARGET_GRAPHICS_VERSION: gfx950
        FLAGS: 16
    BUS:
        BDF: 0000:05:00.0
        MAX_PCIE_WIDTH: 16
        MAX_PCIE_SPEED: 32 GT/s
        PCIE_LEVELS: N/A
        PCIE_INTERFACE_VERSION: Gen 5
        SLOT_TYPE: OAM
    IFWI:
        NAME: AMD MI350X
        BUILD_DATE: 2025/06/19 21:03
        PART_NUMBER: 113-M350-01-1K0-920A
        VERSION: 00154951
    DRIVER:
        NAME: amdgpu
        VERSION: 6.18.3
        OS_KERNEL_VERSION: 5.15.0-164-generic
    BOARD:
        MODEL_NUMBER: 102-G36212-0C
        PRODUCT_SERIAL: <redacted>
        FRU_ID: 113-AMDG362120C01-100-300000082
        PRODUCT_NAME: AMD Instinct MI350 OAM
        MANUFACTURER_NAME: AMD
    RAS:
        EEPROM_VERSION: 0x10000
        BAD_PAGE_THRESHOLD: N/A
        BAD_PAGE_THRESHOLD_EXCEEDED: N/A
        PARITY_SCHEMA: DISABLED
        SINGLE_BIT_SCHEMA: DISABLED
        DOUBLE_BIT_SCHEMA: DISABLED
        POISON_SCHEMA: ENABLED
        ECC_BLOCK_STATE:
            UMC: ENABLED
            SDMA: ENABLED
            GFX: ENABLED
            MMHUB: ENABLED
            ATHUB: ENABLED
            PCIE_BIF: ENABLED
            HDP: ENABLED
            XGMI_WAFL: ENABLED
            DF: ENABLED
            SMN: ENABLED
            SEM: DISABLED
            MP0: ENABLED
            MP1: ENABLED
            FUSE: DISABLED
            MCA: ENABLED
            VCN: DISABLED
            JPEG: DISABLED
            IH: ENABLED
            MPIO: ENABLED
    VRAM:
        TYPE: HBM3E
        VENDOR: SAMSUNG
        SIZE: 258032 MB
        BIT_WIDTH: 8192
        MAX_BANDWIDTH: 6810 GB/s

GPU: 1
    ASIC:
        MARKET_NAME: AMD Instinct MI350X
        VENDOR_ID: 0x1002
        VENDOR_NAME: Advanced Micro Devices Inc. [AMD/ATI]
        SUBVENDOR_ID: N/A
        DEVICE_ID: 0x75a0
        SUBSYSTEM_ID: N/A
        REV_ID: 0x00
        ASIC_SERIAL: <redacted>
        OAM_ID: N/A
        NUM_COMPUTE_UNITS: 128
        TARGET_GRAPHICS_VERSION: gfx950
        FLAGS: 16
    BUS:
        BDF: 0000:05:00.1
        MAX_PCIE_WIDTH: N/A
        MAX_PCIE_SPEED: N/A
        PCIE_LEVELS: N/A
        PCIE_INTERFACE_VERSION: N/A
        SLOT_TYPE: N/A
    IFWI:
        NAME: AMD MI350X
        BUILD_DATE: 2025/06/19 21:03
        PART_NUMBER: 113-M350-01-1K0-920A
        VERSION: 023.040.001.008.000001
    DRIVER:
        NAME: amdgpu
        VERSION: 6.18.3
        OS_KERNEL_VERSION: 5.15.0-164-generic
    BOARD:
        MODEL_NUMBER: N/A
        PRODUCT_SERIAL: N/A
        FRU_ID: N/A
        PRODUCT_NAME: N/A
        MANUFACTURER_NAME: Advanced Micro Devices, Inc. [AMD/ATI]
    RAS:
        EEPROM_VERSION: N/A
        BAD_PAGE_THRESHOLD: N/A
        BAD_PAGE_THRESHOLD_EXCEEDED: N/A
        PARITY_SCHEMA: N/A
        SINGLE_BIT_SCHEMA: N/A
        DOUBLE_BIT_SCHEMA: N/A
        POISON_SCHEMA: N/A
        ECC_BLOCK_STATE: N/A
    VRAM:
        TYPE: HBM3E
        VENDOR: UNKNOWN
        SIZE: 129016 MB
        BIT_WIDTH: 8192
        MAX_BANDWIDTH: N/A

```

```console
$ amd-smi metric --power --clock -g 0 1
GPU: 0
    POWER:
        SOCKET_POWER: 225 W
        GFX_VOLTAGE: N/A
        SOC_VOLTAGE: N/A
        MEM_VOLTAGE: N/A
        THROTTLE_STATUS: N/A
        POWER_MANAGEMENT: ENABLED
    CLOCK:
        GFX_0:
            CLK: 145 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_1:
            CLK: 145 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_2:
            CLK: 144 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_3:
            CLK: 145 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_4:
            CLK: 159 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_5:
            CLK: 160 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_6:
            CLK: 145 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_7:
            CLK: 145 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        MEM_0:
            CLK: 1900 MHz
            MIN_CLK: 1900 MHz
            MAX_CLK: 1900 MHz
            DEEP_SLEEP: DISABLED
        VCLK_0:
            CLK: 59 MHz
            MIN_CLK: 1900 MHz
            MAX_CLK: 1900 MHz
            DEEP_SLEEP: ENABLED
        VCLK_1:
            CLK: 59 MHz
            MIN_CLK: 1900 MHz
            MAX_CLK: 1900 MHz
            DEEP_SLEEP: ENABLED
        VCLK_2:
            CLK: 59 MHz
            MIN_CLK: 1900 MHz
            MAX_CLK: 1900 MHz
            DEEP_SLEEP: ENABLED
        VCLK_3:
            CLK: 59 MHz
            MIN_CLK: 1900 MHz
            MAX_CLK: 1900 MHz
            DEEP_SLEEP: ENABLED
        DCLK_0:
            CLK: 48 MHz
            MIN_CLK: 1520 MHz
            MAX_CLK: 1520 MHz
            DEEP_SLEEP: ENABLED
        DCLK_1:
            CLK: 48 MHz
            MIN_CLK: 1520 MHz
            MAX_CLK: 1520 MHz
            DEEP_SLEEP: ENABLED
        DCLK_2:
            CLK: 48 MHz
            MIN_CLK: 1520 MHz
            MAX_CLK: 1520 MHz
            DEEP_SLEEP: ENABLED
        DCLK_3:
            CLK: 48 MHz
            MIN_CLK: 1520 MHz
            MAX_CLK: 1520 MHz
            DEEP_SLEEP: ENABLED
        FCLK_0:
            CLK: 1500 MHz
            MIN_CLK: 1250 MHz
            MAX_CLK: 1500 MHz
            DEEP_SLEEP: DISABLED
        SOCCLK_0:
            CLK: 40 MHz
            MIN_CLK: 1200 MHz
            MAX_CLK: 1200 MHz
            DEEP_SLEEP: ENABLED

GPU: 1
    POWER:
        SOCKET_POWER: N/A
        GFX_VOLTAGE: N/A
        SOC_VOLTAGE: N/A
        MEM_VOLTAGE: N/A
        THROTTLE_STATUS: N/A
        POWER_MANAGEMENT: N/A
    CLOCK: N/A
```

- **After changes: Functional sanity (without `libdrm`)**
<img width="400" height="636" alt="image" src="https://github.com/user-attachments/assets/e49a2197-148b-474b-84ad-d5bd1a32a7a9" />

```console
$ amd-smi static --bus --ifwi --asic --board --vbios --driver --vram --ras -g 0 1
Fail to open libdrm_amdgpu.so.1: libdrm_amdgpu.so.1: cannot open shared object file: No such file or directory
GPU: 0
    ASIC:
        MARKET_NAME: AMD Instinct MI350 OAM
        VENDOR_ID: 0x1002
        VENDOR_NAME: Advanced Micro Devices Inc. [AMD/ATI]
        SUBVENDOR_ID: 0x1002
        DEVICE_ID: 0x75a0
        SUBSYSTEM_ID: 0x75a0
        REV_ID: 0x00
        ASIC_SERIAL: <redacted>
        OAM_ID: 6
        NUM_COMPUTE_UNITS: 128
        TARGET_GRAPHICS_VERSION: gfx950
        FLAGS: 0
    BUS:
        BDF: 0000:05:00.0
        MAX_PCIE_WIDTH: 16
        MAX_PCIE_SPEED: 32 GT/s
        PCIE_LEVELS: N/A
        PCIE_INTERFACE_VERSION: Gen 5
        SLOT_TYPE: OAM
    IFWI:
        NAME: N/A
        BUILD_DATE: N/A
        PART_NUMBER: 113-M350-01-1K0-920A
        VERSION: 00154951
    DRIVER:
        NAME: N/A
        VERSION: N/A
        OS_KERNEL_VERSION: 5.15.0-164-generic
    BOARD:
        MODEL_NUMBER: 102-G36212-0C
        PRODUCT_SERIAL: <redacted>
        FRU_ID: 113-AMDG362120C01-100-300000082
        PRODUCT_NAME: AMD Instinct MI350 OAM
        MANUFACTURER_NAME: AMD
    RAS:
        EEPROM_VERSION: 0x10000
        BAD_PAGE_THRESHOLD: N/A
        BAD_PAGE_THRESHOLD_EXCEEDED: N/A
        PARITY_SCHEMA: DISABLED
        SINGLE_BIT_SCHEMA: DISABLED
        DOUBLE_BIT_SCHEMA: DISABLED
        POISON_SCHEMA: ENABLED
        ECC_BLOCK_STATE:
            UMC: ENABLED
            SDMA: ENABLED
            GFX: ENABLED
            MMHUB: ENABLED
            ATHUB: ENABLED
            PCIE_BIF: ENABLED
            HDP: ENABLED
            XGMI_WAFL: ENABLED
            DF: ENABLED
            SMN: ENABLED
            SEM: DISABLED
            MP0: ENABLED
            MP1: ENABLED
            FUSE: DISABLED
            MCA: ENABLED
            VCN: DISABLED
            JPEG: DISABLED
            IH: ENABLED
            MPIO: ENABLED
    VRAM:
        TYPE: UNKNOWN
        VENDOR: SAMSUNG
        SIZE: 258032 MB
        BIT_WIDTH: N/A
        MAX_BANDWIDTH: 6810 GB/s

GPU: 1
    ASIC:
        MARKET_NAME: N/A
        VENDOR_ID: 0x1002
        VENDOR_NAME: Advanced Micro Devices Inc. [AMD/ATI]
        SUBVENDOR_ID: N/A
        DEVICE_ID: 0x75a0
        SUBSYSTEM_ID: N/A
        REV_ID: 0x00
        ASIC_SERIAL: <redacted>
        OAM_ID: N/A
        NUM_COMPUTE_UNITS: 128
        TARGET_GRAPHICS_VERSION: gfx950
        FLAGS: 0
    BUS:
        BDF: 0000:05:00.1
        MAX_PCIE_WIDTH: N/A
        MAX_PCIE_SPEED: N/A
        PCIE_LEVELS: N/A
        PCIE_INTERFACE_VERSION: N/A
        SLOT_TYPE: N/A
    IFWI: N/A
    DRIVER:
        NAME: N/A
        VERSION: N/A
        OS_KERNEL_VERSION: 5.15.0-164-generic
    BOARD:
        MODEL_NUMBER: N/A
        PRODUCT_SERIAL: N/A
        FRU_ID: N/A
        PRODUCT_NAME: N/A
        MANUFACTURER_NAME: Advanced Micro Devices Inc. [AMD/ATI]
    RAS:
        EEPROM_VERSION: N/A
        BAD_PAGE_THRESHOLD: N/A
        BAD_PAGE_THRESHOLD_EXCEEDED: N/A
        PARITY_SCHEMA: N/A
        SINGLE_BIT_SCHEMA: N/A
        DOUBLE_BIT_SCHEMA: N/A
        POISON_SCHEMA: N/A
        ECC_BLOCK_STATE: N/A
    VRAM:
        TYPE: UNKNOWN
        VENDOR: UNKNOWN
        SIZE: 129016 MB
        BIT_WIDTH: N/A
        MAX_BANDWIDTH: N/A
```
```console
$ amd-smi metric --power --clock -g 0 1                     
Fail to open libdrm_amdgpu.so.1: libdrm_amdgpu.so.1: cannot open shared object file: No such file or directory
GPU: 0
    POWER:
        SOCKET_POWER: 225 W
        GFX_VOLTAGE: N/A
        SOC_VOLTAGE: N/A
        MEM_VOLTAGE: N/A
        THROTTLE_STATUS: N/A
        POWER_MANAGEMENT: ENABLED
    CLOCK:
        GFX_0:
            CLK: 145 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_1:
            CLK: 145 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_2:
            CLK: 144 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_3:
            CLK: 145 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_4:
            CLK: 172 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_5:
            CLK: 171 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_6:
            CLK: 145 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        GFX_7:
            CLK: 145 MHz
            MIN_CLK: 500 MHz
            MAX_CLK: 2200 MHz
            CLK_LOCKED: DISABLED
            DEEP_SLEEP: ENABLED
        MEM_0:
            CLK: 1900 MHz
            MIN_CLK: 1900 MHz
            MAX_CLK: 1900 MHz
            DEEP_SLEEP: DISABLED
        VCLK_0:
            CLK: 59 MHz
            MIN_CLK: 1900 MHz
            MAX_CLK: 1900 MHz
            DEEP_SLEEP: ENABLED
        VCLK_1:
            CLK: 59 MHz
            MIN_CLK: 1900 MHz
            MAX_CLK: 1900 MHz
            DEEP_SLEEP: ENABLED
        VCLK_2:
            CLK: 59 MHz
            MIN_CLK: 1900 MHz
            MAX_CLK: 1900 MHz
            DEEP_SLEEP: ENABLED
        VCLK_3:
            CLK: 59 MHz
            MIN_CLK: 1900 MHz
            MAX_CLK: 1900 MHz
            DEEP_SLEEP: ENABLED
        DCLK_0:
            CLK: 48 MHz
            MIN_CLK: 1520 MHz
            MAX_CLK: 1520 MHz
            DEEP_SLEEP: ENABLED
        DCLK_1:
            CLK: 48 MHz
            MIN_CLK: 1520 MHz
            MAX_CLK: 1520 MHz
            DEEP_SLEEP: ENABLED
        DCLK_2:
            CLK: 48 MHz
            MIN_CLK: 1520 MHz
            MAX_CLK: 1520 MHz
            DEEP_SLEEP: ENABLED
        DCLK_3:
            CLK: 48 MHz
            MIN_CLK: 1520 MHz
            MAX_CLK: 1520 MHz
            DEEP_SLEEP: ENABLED
        FCLK_0:
            CLK: 1500 MHz
            MIN_CLK: 1250 MHz
            MAX_CLK: 1500 MHz
            DEEP_SLEEP: DISABLED
        SOCCLK_0:
            CLK: 38 MHz
            MIN_CLK: 1200 MHz
            MAX_CLK: 1200 MHz
            DEEP_SLEEP: ENABLED

GPU: 1
    POWER:
        SOCKET_POWER: N/A
        GFX_VOLTAGE: N/A
        SOC_VOLTAGE: N/A
        MEM_VOLTAGE: N/A
        THROTTLE_STATUS: N/A
        POWER_MANAGEMENT: N/A
    CLOCK: N/A
```


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

[ROCM-2950]: https://amd-hub.atlassian.net/browse/ROCM-2950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ