### PR TITLE
[rocprofiler-systems] [TheRock] Handle ccache and resource_info.py in launch-compiler script and fix a return bug

### DIFF
--- a/projects/rocprofiler-systems/scripts/rocprof-sys-launch-compiler
+++ b/projects/rocprofiler-systems/scripts/rocprof-sys-launch-compiler
@@ -102,19 +102,30 @@ if [ "$(basename ${1})" = "cmake" ] && [ "${2}" = "-E" ] && [ "${3}" = "__run_co
     fi
 fi
 
-# Handle ccache wrapper (the actual compiler is the next argument after ccache)
+# Known wrappers that may appear before the actual compiler
+KNOWN_WRAPPERS=(
+    "resource_info.py"  # TheRock build profiling
+    "ccache"            # Compiler cache
+)
+
 CCACHE_PREFIX=""
 ACTUAL_COMPILER="${1}"
-if [ "$(basename ${1})" = "ccache" ]; then
-    if [ -z "${2:-}" ]; then
-        echo -e "\nError: ${BASH_SOURCE[0]} detected 'ccache' as a compiler wrapper," >&2
-        echo "but no underlying compiler was specified as the next argument." >&2
-        echo "Usage: ccache <actual-compiler> [args...]" >&2
-        exit 1
+
+for wrapper in "${KNOWN_WRAPPERS[@]}"; do
+    if [[ "$(basename ${1})" == "${wrapper}" ]]; then
+        if [ -z "${2:-}" ]; then
+            echo -e "\nError: ${BASH_SOURCE[0]} detected '${wrapper}' as a wrapper," >&2
+            echo "but no underlying command was specified as the next argument." >&2
+            exit 1
+        fi
+        # Preserve ccache so we can re-apply it to the rocprofiler-systems compiler
+        if [[ "${wrapper}" == "ccache" ]]; then
+            CCACHE_PREFIX="${1}"
+        fi
+        shift
+        ACTUAL_COMPILER="${1}"
     fi
-    CCACHE_PREFIX="${1}"
-    ACTUAL_COMPILER="${2}"
-fi
+done
 
 if [[ "${CXX_COMPILER}" != "${ACTUAL_COMPILER}" ]]; then
     debug-message $@
@@ -127,12 +138,7 @@ else
         exit 1
     fi
 
-    # discard ccache if present
-    if [ -n "${CCACHE_PREFIX}" ]; then
-        shift
-    fi
-
-    # discard the compiler from the command
+    # discard the compiler from the command (wrappers were already shifted in the loop above)
     shift
 
     if [ -n "$(basename ${ROCPROFSYS_COMPILER} | egrep 'amdclang|amdllvm')" ]; then

--- a/projects/rocprofiler-systems/scripts/rocprof-sys-launch-compiler
+++ b/projects/rocprofiler-systems/scripts/rocprof-sys-launch-compiler
@@ -110,9 +110,10 @@ KNOWN_WRAPPERS=(
 
 CCACHE_PREFIX=""
 ACTUAL_COMPILER="${1}"
+CURRENT_BASENAME="$(basename "${1}")"
 
 for wrapper in "${KNOWN_WRAPPERS[@]}"; do
-    if [[ "$(basename ${1})" == "${wrapper}" ]]; then
+    if [[ "${CURRENT_BASENAME}" == "${wrapper}" ]]; then
         if [ -z "${2:-}" ]; then
             echo -e "\nError: ${BASH_SOURCE[0]} detected '${wrapper}' as a wrapper," >&2
             echo "but no underlying command was specified as the next argument." >&2
@@ -124,6 +125,7 @@ for wrapper in "${KNOWN_WRAPPERS[@]}"; do
         fi
         shift
         ACTUAL_COMPILER="${1}"
+        CURRENT_BASENAME="$(basename "${1}")"
     fi
 done
 

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -275,9 +275,8 @@ def pytest_report_header(config) -> list[str]:
 
     # Offload extractor
     offload_msg = None
-    offload_extractor = get_offload_extractor(rocprof_config.rocm_path)
-    if offload_extractor:
-        tool_path, is_llvm_too_old = offload_extractor
+    tool_path, is_llvm_too_old = get_offload_extractor(rocprof_config.rocm_path)
+    if tool_path:
         if tool_path.name == "llvm-objdump":
             offload_msg = f"{tool_path}"
         elif tool_path.name == "roc-obj-ls":


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

commit `83785b4a` (Jan 27) on TheRock introduced a resource_info.py as a compiler launcher for build profiling. `rocprof-sys-launch-compiler.sh` must be updated to handle this edge case. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Add explicit handling for resource_info.py compiler launcher used by TheRock CI for build profiling. Without this, the script incorrectly passes Clang-specific flags (e.g., -fopenmp, --offload-arch) to GCC, causing build failures.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
