### PR TITLE
[rocprofiler-systems] Add MPI rank/size and configuration to rocpd_process metadata

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -56,6 +56,7 @@
 
 #include "logger/debug.hpp"
 
+#include <nlohmann/json.hpp>
 #include <spdlog/fmt/ranges.h>
 
 #include <algorithm>
@@ -1709,6 +1710,22 @@ print_settings(
 
     tim::log::stream(_ros, tim::log::color::info()) << _os.str();
     _ros << std::flush;
+}
+
+void
+print_settings_json(std::ostream& _output_stream)
+{
+    nlohmann::json _config_result = {};
+
+    for(const auto& [key, setting] : *get_config())
+    {
+        if(setting->get_hidden() || !setting->get_enabled()) continue;
+        auto value = setting->as_string();
+        if(value.empty()) continue;
+        _config_result[setting->get_env_name()] = value;
+    }
+
+    _output_stream << _config_result.dump() << std::flush;
 }
 
 void

--- a/projects/rocprofiler-systems/source/lib/core/config.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.hpp
@@ -91,6 +91,9 @@ print_settings(
     std::function<bool(const std::string_view&, const std::set<std::string>&)>&& _filter);
 
 void
+print_settings_json(std::ostream& _output_stream);
+
+void
 print_settings(bool include_env = true);
 
 std::string&

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/metadata_registry.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/metadata_registry.hpp
@@ -58,6 +58,8 @@ struct process
     pid_t       pid;  // < Unique
     pid_t       ppid;
     std::string command;
+    std::string environment;
+    std::string extdata;
     uint32_t    start;
     uint32_t    end;
 };

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.cpp
@@ -723,9 +723,10 @@ rocpd_processor_t::post_process_metadata()
         n_info.machine.c_str(), n_info.domain_name.c_str());
 
     auto process_info = m_metadata->get_process_info();
-    m_data_processor->insert_process_info(n_info.id, process_info.ppid, process_info.pid,
-                                          0, 0, process_info.start, process_info.end,
-                                          process_info.command.c_str(), "{}");
+    m_data_processor->insert_process_info(
+        n_info.id, process_info.ppid, process_info.pid, 0, 0, process_info.start,
+        process_info.end, process_info.command.c_str(), process_info.environment.c_str(),
+        process_info.extdata.c_str());
 
     const auto& agents  = m_agent_manager->get_agents();
     int         counter = 0;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -141,7 +141,7 @@ set_metadata_process_end_timestamp(int64_t _ts)
 }
 
 void
-set_metadata_environement_json(const std::string& _environment_json)
+set_metadata_environment_json(const std::string& _environment_json)
 {
     auto process_info        = trace_cache::get_metadata_registry().get_process_info();
     process_info.environment = _environment_json;
@@ -149,7 +149,7 @@ set_metadata_environement_json(const std::string& _environment_json)
 }
 
 std::string
-escape_quotes_for_sql(std::string str)
+escape_quotes(std::string str)
 {
     std::string::size_type pos = 0;
     while((pos = str.find('"', pos)) != std::string::npos)
@@ -388,8 +388,7 @@ rocprofsys_preinit_cache()
     config::print_settings_json(_extdata_stream);
 
     trace_cache::get_metadata_registry().set_process(
-        { getpid(), getppid(), _command, "",
-          escape_quotes_for_sql(_extdata_stream.str()) });
+        { getpid(), getppid(), _command, "", escape_quotes(_extdata_stream.str()) });
 }
 
 void
@@ -800,14 +799,20 @@ rocprofsys_init_hidden(const char* _mode, bool _is_binary_rewrite, const char* _
         rocprofsys_preinit_hidden();
     }
 
-#if defined(ROCPROFSYS_USE_MPI)
-    component::mpi_gotcha::set_on_init_callback([](int rank, int size) {
-        nlohmann::json _environment_json;
-        _environment_json["MPI_COMM_WORLD_SIZE"] = size;
-        _environment_json["MPI_COMM_WORLD_RANK"] = rank;
+#if(defined(ROCPROFSYS_USE_MPI_HEADERS) && ROCPROFSYS_USE_MPI_HEADERS > 0) ||            \
+    (defined(ROCPROFSYS_USE_MPI) && ROCPROFSYS_USE_MPI > 0)
 
-        set_metadata_environement_json(escape_quotes_for_sql(_environment_json.dump()));
-    });
+    if(get_use_mpip())
+    {
+        component::mpi_gotcha::set_on_init_callback([](int rank, int size) {
+            nlohmann::json _environment_json;
+            _environment_json["MPI_COMM_WORLD_SIZE"] = size;
+            _environment_json["MPI_COMM_WORLD_RANK"] = rank;
+
+            set_metadata_environment_json(escape_quotes(_environment_json.dump()));
+        });
+    }
+
 #endif
 }
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -595,6 +595,18 @@ rocprofsys_init_tooling_hidden(void)
 
         rocprofsys_preinit_cache();
 
+#if(defined(ROCPROFSYS_USE_MPI_HEADERS) && ROCPROFSYS_USE_MPI_HEADERS > 0) ||            \
+    (defined(ROCPROFSYS_USE_MPI) && ROCPROFSYS_USE_MPI > 0)
+
+        component::mpi_gotcha::subscribe_to_init_event([](int rank, int size) {
+            nlohmann::json _environment_json;
+            _environment_json["MPI_COMM_WORLD_SIZE"] = size;
+            _environment_json["MPI_COMM_WORLD_RANK"] = rank;
+
+            set_metadata_environment_json(escape_quotes(_environment_json.dump()));
+        });
+#endif
+
         if(get_use_process_sampling())
         {
             ROCPROFSYS_SCOPED_SAMPLING_ON_CHILD_THREADS(false);
@@ -798,22 +810,6 @@ rocprofsys_init_hidden(const char* _mode, bool _is_binary_rewrite, const char* _
     {
         rocprofsys_preinit_hidden();
     }
-
-#if(defined(ROCPROFSYS_USE_MPI_HEADERS) && ROCPROFSYS_USE_MPI_HEADERS > 0) ||            \
-    (defined(ROCPROFSYS_USE_MPI) && ROCPROFSYS_USE_MPI > 0)
-
-    if(get_use_mpip())
-    {
-        component::mpi_gotcha::subscribe_to_init_event([](int rank, int size) {
-            nlohmann::json _environment_json;
-            _environment_json["MPI_COMM_WORLD_SIZE"] = size;
-            _environment_json["MPI_COMM_WORLD_RANK"] = rank;
-
-            set_metadata_environment_json(escape_quotes(_environment_json.dump()));
-        });
-    }
-
-#endif
 }
 
 //======================================================================================//

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -89,6 +89,8 @@
 #    include <rocprofiler-sdk/registration.h>
 #endif
 
+#include <nlohmann/json.hpp>
+
 #include "logger/debug.hpp"
 
 #include <atomic>
@@ -136,6 +138,26 @@ set_metadata_process_end_timestamp(int64_t _ts)
     auto process_info = trace_cache::get_metadata_registry().get_process_info();
     process_info.end  = _ts;
     trace_cache::get_metadata_registry().set_process(process_info);
+}
+
+void
+set_metadata_environement_json(const std::string& _environment_json)
+{
+    auto process_info        = trace_cache::get_metadata_registry().get_process_info();
+    process_info.environment = _environment_json;
+    trace_cache::get_metadata_registry().set_process(process_info);
+}
+
+std::string
+escape_quotes_for_sql(std::string str)
+{
+    std::string::size_type pos = 0;
+    while((pos = str.find('"', pos)) != std::string::npos)
+    {
+        str.replace(pos, 1, "\"\"");
+        pos += 2;
+    }
+    return str;
 }
 
 bool
@@ -357,15 +379,17 @@ read_command_line(pid_t _pid)
 void
 rocprofsys_preinit_cache()
 {
-    auto _cmd_line = read_command_line(getpid());
+    const auto        _cmd_line = read_command_line(getpid());
+    const std::string _command  = _cmd_line.empty()
+                                      ? "rocprofiler-systems"
+                                      : fmt::format("{}", fmt::join(_cmd_line, " "));
 
-    if(_cmd_line.empty())
-    {
-        _cmd_line.emplace_back("rocprofiler-systems");
-    }
+    std::stringstream _extdata_stream;
+    config::print_settings_json(_extdata_stream);
 
     trace_cache::get_metadata_registry().set_process(
-        { getpid(), getppid(), _cmd_line.at(0) });
+        { getpid(), getppid(), _command, "",
+          escape_quotes_for_sql(_extdata_stream.str()) });
 }
 
 void
@@ -775,6 +799,16 @@ rocprofsys_init_hidden(const char* _mode, bool _is_binary_rewrite, const char* _
     {
         rocprofsys_preinit_hidden();
     }
+
+#if defined(ROCPROFSYS_USE_MPI)
+    component::mpi_gotcha::set_on_init_callback([](int rank, int size) {
+        nlohmann::json _environment_json;
+        _environment_json["MPI_COMM_WORLD_SIZE"] = size;
+        _environment_json["MPI_COMM_WORLD_RANK"] = rank;
+
+        set_metadata_environement_json(escape_quotes_for_sql(_environment_json.dump()));
+    });
+#endif
 }
 
 //======================================================================================//

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -804,7 +804,7 @@ rocprofsys_init_hidden(const char* _mode, bool _is_binary_rewrite, const char* _
 
     if(get_use_mpip())
     {
-        component::mpi_gotcha::set_on_init_callback([](int rank, int size) {
+        component::mpi_gotcha::subscribe_to_init_event([](int rank, int size) {
             nlohmann::json _environment_json;
             _environment_json["MPI_COMM_WORLD_SIZE"] = size;
             _environment_json["MPI_COMM_WORLD_RANK"] = rank;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
@@ -356,6 +356,7 @@ mpi_gotcha::audit(const gotcha_data_t& _data, audit::outgoing, int _retval)
         if(!mproc_comm_record.updated())
         {
             populate_rank_and_size();
+            update();
             publish_rank_and_size(m_rank, m_size);
         }
     }
@@ -414,8 +415,11 @@ mpi_gotcha::populate_rank_and_size()
 
     if(_rank_ret == MPI_SUCCESS && _size_ret == MPI_SUCCESS)
     {
-        m_rank = _comm_rank;
-        m_size = _comm_size;
+        m_rank                 = _comm_rank;
+        mproc_comm_record.rank = m_rank;
+        m_size                 = _comm_size;
+        mproc_comm_record.size = m_size;
+        mproc_comm_record.comm = (uintptr_t) MPI_COMM_WORLD;  // NOLINT
     }
     else
     {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
@@ -405,13 +405,12 @@ mpi_gotcha::audit(const gotcha_data_t& _data, audit::outgoing, int _retval)
 void
 mpi_gotcha::populate_rank_and_size()
 {
-    int _comm_rank = -1;
-    int _comm_size = -1;
-
 #if defined(ROCPROFSYS_USE_MPI) && ROCPROFSYS_USE_MPI > 0
     // Full MPI is available
-    int _rank_ret = PMPI_Comm_rank(MPI_COMM_WORLD, &_comm_rank);  // NOLINT
-    int _size_ret = PMPI_Comm_size(MPI_COMM_WORLD, &_comm_size);  // NOLINT
+    int _comm_rank = -1;
+    int _comm_size = -1;
+    int _rank_ret  = PMPI_Comm_rank(MPI_COMM_WORLD, &_comm_rank);  // NOLINT
+    int _size_ret  = PMPI_Comm_size(MPI_COMM_WORLD, &_comm_size);  // NOLINT
 
     if(_rank_ret == MPI_SUCCESS && _size_ret == MPI_SUCCESS)
     {
@@ -425,9 +424,11 @@ mpi_gotcha::populate_rank_and_size()
     }
 #elif defined(ROCPROFSYS_USE_MPI_HEADERS) && ROCPROFSYS_USE_MPI_HEADERS > 0
     // Only MPI headers are available, proceed with process based index
-    auto _pid  = getpid();
-    auto _ppid = getppid();
-    _comm_size = mproc::get_concurrent_processes(_ppid).size();
+    int  _comm_rank = -1;
+    int  _comm_size = -1;
+    auto _pid       = getpid();
+    auto _ppid      = getppid();
+    _comm_size      = mproc::get_concurrent_processes(_ppid).size();
     if(_comm_size > 0)
     {
         mproc_comm_record.comm = _ppid;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
@@ -28,6 +28,7 @@
 #include "core/mproc.hpp"
 #include "library/components/category_region.hpp"
 #include "library/components/comm_data.hpp"
+#include "mpi_gotcha.hpp"
 #include "mpip.hpp"
 
 #include <timemory/backends/process.hpp>
@@ -150,6 +151,7 @@ auto permit_bindings = strset_t{};
 auto reject_bindings = strset_t{};
 }  // namespace
 
+std::mutex mpi_gotcha::s_on_init_callbacks_mutex                                     = {};
 std::vector<std::function<void(int rank, int size)>> mpi_gotcha::s_on_init_callbacks = {};
 
 void
@@ -197,6 +199,7 @@ void
 mpi_gotcha::subscribe_to_init_event(
     const std::function<void(int rank, int size)>& _callback)
 {
+    std::lock_guard<std::mutex> _lk{ s_on_init_callbacks_mutex };
     if(_callback)
     {
         s_on_init_callbacks.push_back(_callback);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
@@ -150,7 +150,7 @@ auto permit_bindings = strset_t{};
 auto reject_bindings = strset_t{};
 }  // namespace
 
-std::function<void(int, int)> mpi_gotcha::s_on_init_callback = {};
+std::vector<std::function<void(int rank, int size)>> mpi_gotcha::s_on_init_callbacks = {};
 
 void
 mpi_gotcha::configure()
@@ -194,16 +194,13 @@ mpi_gotcha::configure()
 }
 
 void
-mpi_gotcha::set_on_init_callback(
-    const std::function<void(int rank, int size)>& _on_init_callback)
+mpi_gotcha::subscribe_to_init_event(
+    const std::function<void(int rank, int size)>& _callback)
 {
-    if(s_on_init_callback)
+    if(_callback)
     {
-        LOG_CRITICAL("s_on_init_callback already set");
-        return;
+        s_on_init_callbacks.push_back(_callback);
     }
-
-    s_on_init_callback = _on_init_callback;
 }
 
 void
@@ -444,9 +441,12 @@ mpi_gotcha::populate_rank_and_size()
 void
 mpi_gotcha::publish_rank_and_size(int rank, int size)
 {
-    if(s_on_init_callback)
+    for(const auto& callback : s_on_init_callbacks)
     {
-        s_on_init_callback(rank, size);
+        if(callback)
+        {
+            callback(rank, size);
+        }
     }
 }
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
@@ -339,7 +339,7 @@ mpi_gotcha::audit(const gotcha_data_t& _data, audit::outgoing, int _retval)
        (_data.tool_id.find("MPI_Init") == 0 || _data.tool_id.find("PMPI_Init") == 0))
     {
         rocprofsys_mpi_set_attr();
-        // rocprof-sys will set this environement variable to true in binary rewrite mode
+        // rocprof-sys will set this environment variable to true in binary rewrite mode
         // when it detects MPI. Hides this env variable from the user to avoid this
         // being activated unwaringly during runtime instrumentation because that
         // will result in double instrumenting the MPI functions (unless the MPI functions
@@ -358,18 +358,8 @@ mpi_gotcha::audit(const gotcha_data_t& _data, audit::outgoing, int _retval)
         auto_lock_t _lk{ type_mutex<mpi_gotcha>() };
         if(!mproc_comm_record.updated())
         {
-            auto _pid  = getpid();
-            auto _ppid = getppid();
-            auto _size = mproc::get_concurrent_processes(_ppid).size();
-            if(_size > 0)
-            {
-                mproc_comm_record.comm = _ppid;
-                mproc_comm_record.size = m_size = _size;
-                auto _rank                      = mproc::get_process_index(_pid, _ppid);
-                if(_rank >= 0) mproc_comm_record.rank = m_rank = _rank;
-
-                if(s_on_init_callback) s_on_init_callback(m_rank, m_size);
-            }
+            populate_rank_and_size();
+            publish_rank_and_size(m_rank, m_size);
         }
     }
     else if(_retval == rocprofsys::mpi::success_v &&
@@ -414,6 +404,52 @@ mpi_gotcha::audit(const gotcha_data_t& _data, audit::outgoing, int _retval)
     }
     rocprofsys_pop_trace_hidden(_data.tool_id.c_str());
 }
+
+void
+mpi_gotcha::populate_rank_and_size()
+{
+    int _comm_rank = -1;
+    int _comm_size = -1;
+
+#if defined(ROCPROFSYS_USE_MPI) && ROCPROFSYS_USE_MPI > 0
+    // Full MPI is available
+    int _rank_ret = PMPI_Comm_rank(MPI_COMM_WORLD, &_comm_rank);  // NOLINT
+    int _size_ret = PMPI_Comm_size(MPI_COMM_WORLD, &_comm_size);  // NOLINT
+
+    if(_rank_ret == MPI_SUCCESS && _size_ret == MPI_SUCCESS)
+    {
+        m_rank = _comm_rank;
+        m_size = _comm_size;
+    }
+    else
+    {
+        LOG_CRITICAL("Error! PMPI_Comm_rank returned {}, PMPI_Comm_size returned {}",
+                     _rank_ret, _size_ret);
+    }
+#elif defined(ROCPROFSYS_USE_MPI_HEADERS) && ROCPROFSYS_USE_MPI_HEADERS > 0
+    // Only MPI headers are available, proceed with process based index
+    auto _pid  = getpid();
+    auto _ppid = getppid();
+    _comm_size = mproc::get_concurrent_processes(_ppid).size();
+    if(_comm_size > 0)
+    {
+        mproc_comm_record.comm = _ppid;
+        mproc_comm_record.size = m_size = _comm_size;
+        _comm_rank                      = mproc::get_process_index(_pid, _ppid);
+        if(_comm_rank >= 0) mproc_comm_record.rank = m_rank = _comm_rank;
+    }
+#endif
+}
+
+void
+mpi_gotcha::publish_rank_and_size(int rank, int size)
+{
+    if(s_on_init_callback)
+    {
+        s_on_init_callback(rank, size);
+    }
+}
+
 }  // namespace component
 }  // namespace rocprofsys
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
@@ -150,6 +150,8 @@ auto permit_bindings = strset_t{};
 auto reject_bindings = strset_t{};
 }  // namespace
 
+std::function<void(int, int)> mpi_gotcha::s_on_init_callback = {};
+
 void
 mpi_gotcha::configure()
 {
@@ -189,6 +191,19 @@ mpi_gotcha::configure()
         reject_bindings.emplace("PMPI_Comm_size");
 #endif
     };
+}
+
+void
+mpi_gotcha::set_on_init_callback(
+    const std::function<void(int rank, int size)>& _on_init_callback)
+{
+    if(s_on_init_callback)
+    {
+        LOG_CRITICAL("s_on_init_callback already set");
+        return;
+    }
+
+    s_on_init_callback = _on_init_callback;
 }
 
 void
@@ -352,6 +367,8 @@ mpi_gotcha::audit(const gotcha_data_t& _data, audit::outgoing, int _retval)
                 mproc_comm_record.size = m_size = _size;
                 auto _rank                      = mproc::get_process_index(_pid, _ppid);
                 if(_rank >= 0) mproc_comm_record.rank = m_rank = _rank;
+
+                if(s_on_init_callback) s_on_init_callback(m_rank, m_size);
             }
         }
     }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.hpp
@@ -82,6 +82,9 @@ private:
     int*      m_size_ptr = nullptr;
     uintptr_t m_comm_val = null_comm();
 
+    void        populate_rank_and_size();
+    static void publish_rank_and_size(int rank, int size);
+
     static std::function<void(int rank, int size)> s_on_init_callback;
 };
 }  // namespace component

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.hpp
@@ -72,12 +72,17 @@ struct mpi_gotcha : comp::base<mpi_gotcha, void>
     static uintptr_t null_comm() { return std::numeric_limits<uintptr_t>::max(); }
     static void      disable_comm_intercept();
 
+    static void set_on_init_callback(
+        const std::function<void(int rank, int size)>& _on_init_callback);
+
 private:
     int       m_rank     = 0;
     int       m_size     = 1;
     int*      m_rank_ptr = nullptr;
     int*      m_size_ptr = nullptr;
     uintptr_t m_comm_val = null_comm();
+
+    static std::function<void(int rank, int size)> s_on_init_callback;
 };
 }  // namespace component
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.hpp
@@ -72,8 +72,8 @@ struct mpi_gotcha : comp::base<mpi_gotcha, void>
     static uintptr_t null_comm() { return std::numeric_limits<uintptr_t>::max(); }
     static void      disable_comm_intercept();
 
-    static void set_on_init_callback(
-        const std::function<void(int rank, int size)>& _on_init_callback);
+    static void subscribe_to_init_event(
+        const std::function<void(int rank, int size)>& _callback);
 
 private:
     int       m_rank     = 0;
@@ -85,7 +85,7 @@ private:
     void        populate_rank_and_size();
     static void publish_rank_and_size(int rank, int size);
 
-    static std::function<void(int rank, int size)> s_on_init_callback;
+    static std::vector<std::function<void(int rank, int size)>> s_on_init_callbacks;
 };
 }  // namespace component
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.hpp
@@ -28,6 +28,7 @@
 #include "core/timemory.hpp"
 
 #include <cstdint>
+#include <mutex>
 
 namespace rocprofsys
 {
@@ -85,6 +86,7 @@ private:
     void        populate_rank_and_size();
     static void publish_rank_and_size(int rank, int size);
 
+    static std::mutex                                           s_on_init_callbacks_mutex;
     static std::vector<std::function<void(int rank, int size)>> s_on_init_callbacks;
 };
 }  // namespace component

--- a/projects/rocprofiler-systems/tests/rocprof-sys-mpi-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-mpi-tests.cmake
@@ -51,7 +51,7 @@ rocprofiler_systems_add_test(
     REWRITE_RUN_PASS_REGEX
         "(/[A-Za-z-]+/perfetto-trace-0.proto).*(/[A-Za-z-]+/wall_clock-0.txt')"
     REWRITE_RUN_FAIL_REGEX
-        "Outputting.*(perfetto-trace|trip_count|sampling_percent|sampling_cpu_clock|sampling_wall_clock|wall_clock)-[0-9][0-9]+.(json|txt|proto)|ROCPROFSYS_ABORT_FAIL_REGEX"
+        "(perfetto-trace|trip_count|sampling_percent|sampling_cpu_clock|sampling_wall_clock|wall_clock)-[0-9][0-9]+.(json|txt|proto)|ROCPROFSYS_ABORT_FAIL_REGEX"
 )
 
 # mpi-perfetto-merge requires legacy trace mode because MPI trace combining


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
When profiling MPI applications, the rocpd database's `rocpd_process` table lacked  critical context about the MPI environment (rank, communicator size) and profiler configuration settings. This made it difficult to correlate profiling data with specific MPI processes and understand the configuration used during profiling.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Extended `process` metadata struct with `environment` and `extdata` JSON fields
- Added `print_settings_json()` to serialize profiler configuration to JSON format
- Implemented MPI init callback mechanism in `mpi_gotcha` to capture `MPI_COMM_WORLD_RANK` 
  and `MPI_COMM_WORLD_SIZE` after MPI initialization
- Configuration settings are now stored in `extdata` column; MPI environment in `environment` column
- Added SQL quote escaping helper for JSON strings containing double quotes

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFSYST-175

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Run profiler on MPI application with multiple ranks
- Verify rocpd database contains correct MPI rank/size in `rocpd_process.environment`
- Verify profiler configuration is stored in `rocpd_process.extdata`
- Test with non-MPI applications to ensure no regressions

## Test Result

<!-- Briefly summarize test outcomes. -->
- `rocpd_process` table should contain JSON with `MPI_COMM_WORLD_RANK` and   `MPI_COMM_WORLD_SIZE` for each MPI process
- `extdata` column should contain JSON with all non-hidden, enabled configuration settings (e.g., `ROCPROFSYS_OUTPUT_PATH`, sampling settings, etc.)
- Non-MPI applications should have empty environment but still populate extdata

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
