### PR TITLE
Add extra check on refCount for memory object in hipMemAddressFree

### DIFF
--- a/projects/clr/hipamd/src/hip_vm.cpp
+++ b/projects/clr/hipamd/src/hip_vm.cpp
@@ -47,6 +47,10 @@ hipError_t hipMemAddressFree(void* devPtr, size_t size) {
   if (!(g_devices[0]->devices()[0]->virtualFree(devPtr))) {
     status = hipErrorUnknown;
   }
+  g_devices[memObj->getUserData().deviceId]->SyncAllStreams();
+  while (memObj->referenceCount() > 1) {
+    amd::Os::yield();
+  }
   memObj->release();
   HIP_RETURN(status);
 }


### PR DESCRIPTION
## Motivation

Removal of a memory object from the memory object maps occurs in the memory destructor. As such, at the end of hipMemAddressFree we need to be certain that we enter the memory destructor so as to clean the memory object maps.

## Technical Details

Add a device synchronize and a check on the reference count for the memory object to ensure that we enter the memory destructor.

## JIRA ID

N/A

## Test Plan

Pytorch expandable segments test.

## Test Result

Test is passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
