### PR TITLE
[CI] Update TheRock ref for ci tests

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: df5e21e3b8449ade0af12bcf94c0113510e97f6d # 2025-12-30 commit
+          ref: f5524a6ddbd928ec9a036002fdd8531c1a6f5eb2 # 2025-12-30 commit
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: df5e21e3b8449ade0af12bcf94c0113510e97f6d # 2025-12-30 commit
+          ref: f5524a6ddbd928ec9a036002fdd8531c1a6f5eb2 # 2025-12-30 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -29,7 +29,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
-          ref: df5e21e3b8449ade0af12bcf94c0113510e97f6d # 2025-12-30 commit
+          ref: f5524a6ddbd928ec9a036002fdd8531c1a6f5eb2 # 2025-12-30 commit
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
       # Post-job cleanup isn't necessary since no executables are launched in this job.
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: df5e21e3b8449ade0af12bcf94c0113510e97f6d # 2025-12-30 commit
+          ref: f5524a6ddbd928ec9a036002fdd8531c1a6f5eb2 # 2025-12-30 commit
 
       - name: "Configuring CI options"
         env:
@@ -84,7 +84,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
-          ref: df5e21e3b8449ade0af12bcf94c0113510e97f6d # 2025-12-30 commit
+          ref: f5524a6ddbd928ec9a036002fdd8531c1a6f5eb2 # 2025-12-30 commit
 
       - name: Pre-job cleanup processes on Windows
         if: ${{ runner.os == 'Windows' }}
@@ -95,7 +95,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: df5e21e3b8449ade0af12bcf94c0113510e97f6d # 2025-12-30 commit
+          ref: f5524a6ddbd928ec9a036002fdd8531c1a6f5eb2 # 2025-12-30 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'


### PR DESCRIPTION
## Motivation

https://github.com/ROCm/rocm-systems/pull/2896 fails to run hip-tests, as the ref for theRock the ci points to is missing the changes. 

updating theRock to the the latest passing version of theRock with the correct ci changes

## Technical Details

updating theRock to the the latest passing version of theRock with the correct ci changes including the enablement of hip-tests ([df5e21e3b8449ade0af12bcf94c0113510e97f6d](https://github.com/ROCm/TheRock/blob/df5e21e3b8449ade0af12bcf94c0113510e97f6d/build_tools/github_actions/fetch_test_configurations.py) -> [f5524a6ddbd928ec9a036002fdd8531c1a6f5eb2](https://github.com/ROCm/TheRock/blob/f5524a6ddbd928ec9a036002fdd8531c1a6f5eb2/build_tools/github_actions/fetch_test_configurations.py#L34-L41))

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
