### PR TITLE
backend/ipc: add backend_can_run method

### DIFF
--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -158,6 +158,29 @@ IPCBackend::~IPCBackend() {
   }
 }
 
+int IPCBackend::backend_can_run(MPI_Comm comm, TcpBootstrap* bootstrap) {
+  int ret = ROCSHMEM_ERROR;
+
+  if (comm != MPI_COMM_NULL) {
+    int comm_size;
+    mpilib_ftable_.Comm_size(comm, &comm_size);
+    MPI_Comm shmcomm;
+    mpilib_ftable_.Comm_split_type(comm, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL,
+                                  &shmcomm);
+    int shm_comm_size;
+    mpilib_ftable_.Comm_size(shmcomm, &shm_comm_size);
+    if (shm_comm_size == comm_size)
+      ret = ROCSHMEM_SUCCESS;
+
+  } else if (bootstrap != nullptr) {
+      int world_size = bootstrap->getNranks();
+      int shm_size = bootstrap->getNranksPerNode();
+      if (shm_size == world_size)
+        ret = ROCSHMEM_SUCCESS;
+  }
+
+  return ret;
+}
 void IPCBackend::setup_ctxs() {
   CHECK_HIP(hipMalloc(&ctx_array, sizeof(IPCContext) * envvar::max_num_contexts));
   // 0th context is default context

--- a/projects/rocshmem/src/ipc/backend_ipc.hpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.hpp
@@ -161,6 +161,11 @@ class IPCBackend : public Backend {
   */
   int *fence_pool{nullptr};
 
+  /**
+   * @brief Check whether all PEs are on a single node
+   */
+   static int backend_can_run(MPI_Comm comm, TcpBootstrap *bootstrap);
+
  protected:
    /**
    * @copydoc Backend::dump_backend_stats()

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -86,7 +86,7 @@ rocshmem_ctx_t ROCSHMEM_HOST_CTX_DEFAULT;
 BackendType get_backend_type() { return backend->get_backend_type(); }
 
 #if defined(USE_GDA) && defined(USE_RO) && defined(USE_IPC)
-static BackendType select_backend_type() {
+static BackendType select_backend_type(MPI_Comm comm, TcpBootstrap *bootstrap) {
   BackendType type;
 
   /* Check whether the user explicitely requests a particular backend type */
@@ -113,10 +113,19 @@ static BackendType select_backend_type() {
       return BackendType::RO_BACKEND;
     }
     if (envstr.find("ipc") != std::string::npos) {
+      if (IPCBackend::backend_can_run(comm, bootstrap) != ROCSHMEM_SUCCESS) {
+          fprintf(stderr, "Error: ROCSHMEM_BACKEND=ipc requested but IPC backend cannot run.\n"
+                        "Most likely cause is PEs distributed to more than one node.\n");
+        exit(1);
+      }
       return BackendType::IPC_BACKEND;
     }
   }
 
+  if (IPCBackend::backend_can_run(comm, bootstrap) == ROCSHMEM_SUCCESS) {
+    DPRINTF("IPCBackend::backend_can_run returned success\n");
+    return BackendType::IPC_BACKEND;
+  }
   if (GDABackend::backend_can_run() == ROCSHMEM_SUCCESS) {
     DPRINTF("GDABackend::backend_can_run returned success\n");
     return BackendType::GDA_BACKEND;
@@ -126,6 +135,11 @@ static BackendType select_backend_type() {
     return BackendType::RO_BACKEND;
   }
 
+  fprintf(stderr, "No backend capable of executing the job. This is most likely\n"
+                  "a system or runtime configuration error. Aborting.\n");
+  exit(1);
+
+  // Return code left in to satisfy compiler.
   return BackendType::IPC_BACKEND;
 }
 #endif
@@ -165,7 +179,7 @@ static void setFilesLimit() {
   mpi_instance = new MPIInstance(comm);
 
 #if defined(USE_GDA) && defined(USE_RO) && defined(USE_IPC)
-  BackendType type = select_backend_type();
+  BackendType type = select_backend_type(comm, nullptr);
   switch (type) {
   case BackendType::GDA_BACKEND:
     DPRINTF("Initializing GDA backend using MPI\n");
@@ -274,7 +288,7 @@ static void setFilesLimit() {
   rocm_init();
 
 #if defined(USE_GDA) && defined(USE_RO) && defined(USE_IPC)
-  BackendType type = select_backend_type();
+  BackendType type = select_backend_type(MPI_COMM_NULL, bootstrap);
   switch (type) {
   case BackendType::GDA_BACKEND:
     DPRINTF("Initializing GDA backend with TCP bootstrapping\n");


### PR DESCRIPTION
## Motivation

- add a backend_can_run method to the IPC backend as well, gda and ro had it already.
- prioritize the IPC backend over other backends if it can run and the user did not explicitely request another backend.

AIROCSHMEM-216

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
