### PR TITLE
Bump TheRock version to enable hip-tests execution

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -8,7 +8,6 @@ on:
       project_to_test:
         type: string
 
-
 permissions:
   contents: read
 
@@ -38,7 +37,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: df5e21e3b8449ade0af12bcf94c0113510e97f6d # 2025-12-30 commit
+          ref: f5524a6ddbd928ec9a036002fdd8531c1a6f5eb2 # 2026-01-13 commit
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: f5524a6ddbd928ec9a036002fdd8531c1a6f5eb2 # 2026-01-13 commit
+          ref: 83d82a1665a79e3a63ea53df1588e12bb7a75835 # 2026-01-16 commit
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: f5524a6ddbd928ec9a036002fdd8531c1a6f5eb2 # 2026-01-13 commit
+          ref: 83d82a1665a79e3a63ea53df1588e12bb7a75835 # 2026-01-16 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -39,12 +39,12 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: df5e21e3b8449ade0af12bcf94c0113510e97f6d # 2025-12-30 commit
+          ref: f5524a6ddbd928ec9a036002fdd8531c1a6f5eb2 # 2026-01-13 commit
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: '3.12'
+          python-version: "3.12"
 
       - name: Install python deps
         run: |
@@ -70,7 +70,7 @@ jobs:
 
       - uses: iterative/setup-dvc@4bdfd2b0f6f1ad7e08afadb03b1a895c352a5239 # v2.0.0
         with:
-          version: '3.62.0'
+          version: "3.62.0"
 
       # After other installs, so MSVC get priority in the PATH.
       - name: Configure MSVC

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -29,7 +29,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
-          ref: df5e21e3b8449ade0af12bcf94c0113510e97f6d # 2025-12-30 commit
+          ref: 83d82a1665a79e3a63ea53df1588e12bb7a75835 # 2026-01-16 commit
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
       # Post-job cleanup isn't necessary since no executables are launched in this job.
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: df5e21e3b8449ade0af12bcf94c0113510e97f6d # 2025-12-30 commit
+          ref: 83d82a1665a79e3a63ea53df1588e12bb7a75835 # 2026-01-16 commit
 
       - name: "Configuring CI options"
         env:
@@ -52,7 +52,7 @@ jobs:
         run: python ./build_tools/github_actions/fetch_test_configurations.py
 
   test_components:
-    name: 'Test ${{ matrix.components.job_name }}'
+    name: "Test ${{ matrix.components.job_name }}"
     runs-on: ${{ inputs.test_runs_on }}
     container:
       image: ${{ inputs.platform == 'linux' && 'ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:405945a40deaff9db90b9839c0f41d4cba4a383c1a7459b28627047bf6302a26' || null }}
@@ -84,7 +84,7 @@ jobs:
           sparse-checkout: build_tools
           path: "prejob"
           repository: "ROCm/TheRock"
-          ref: df5e21e3b8449ade0af12bcf94c0113510e97f6d # 2025-12-30 commit
+          ref: 83d82a1665a79e3a63ea53df1588e12bb7a75835 # 2026-01-16 commit
 
       - name: Pre-job cleanup processes on Windows
         if: ${{ runner.os == 'Windows' }}
@@ -95,10 +95,10 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: df5e21e3b8449ade0af12bcf94c0113510e97f6d # 2025-12-30 commit
+          ref: 83d82a1665a79e3a63ea53df1588e12bb7a75835 # 2026-01-16 commit
 
       - name: Run setup test environment workflow
-        uses: './.github/actions/setup_test_environment'
+        uses: "./.github/actions/setup_test_environment"
         with:
           ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
           ARTIFACT_GROUP: ${{ inputs.amdgpu_families }}

--- a/projects/hip-tests/catch/unit/assertion/assert.cc
+++ b/projects/hip-tests/catch/unit/assertion/assert.cc
@@ -74,7 +74,6 @@ bool isAbortOnErrorEnabled() {
  *  - HIP_VERSION >= 5.2
  */
 TEST_CASE("Unit_Assert_Positive_Basic_KernelPass") {
-  
 #ifdef NDEBUG
   HipTest::HIP_SKIP_TEST("Assertions are disabled on this build.");
   return;
@@ -116,7 +115,6 @@ TEST_CASE("Unit_Assert_Positive_Basic_KernelPass") {
  *  - HIP_VERSION >= 5.2
  */
 TEST_CASE("Unit_Assert_Positive_Basic_KernelFail") {
-
 #ifdef NDEBUG
   HipTest::HIP_SKIP_TEST("Assertions are disabled on this build.");
   return;
@@ -145,6 +143,7 @@ TEST_CASE("Unit_Assert_Positive_Basic_KernelFail") {
   HIP_CHECK_ERROR(hipFree(d_a), hipErrorAssert);
 #endif
 }
+
 
 /**
  * End doxygen group DeviceLanguageTest.


### PR DESCRIPTION
## Motivation
We want to enable the hip-tests on TheRock for our repository. This PR bumps the version of TheRock dependency in github actions
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Only changes the checkout step of TheRock to the commit from 2026-01-16, https://github.com/ROCm/TheRock/commit/83d82a1665a79e3a63ea53df1588e12bb7a75835, which is enabling hip-tests and makes them target-dependent
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
NA
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
TheRock tests should start and finish successfully
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Waiting for CI result
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
