### PR TITLE
[rocprofiler-compute] [Test Fix] Dont test roofline related metric such as HBM Bandwidth on MI 100 since it doesnt support roofline

### DIFF
--- a/projects/rocprofiler-compute/tests/test_metric_validation.py
+++ b/projects/rocprofiler-compute/tests/test_metric_validation.py
@@ -36,15 +36,6 @@ soc = test_utils.gpu_soc()
 # workload -> gfx -> metric definition
 VALIDATE_METRICS = {
     "memcopy": {
-        "MI100": [
-            {
-                "name": "HBM Bandwidth",
-                "metric_id": "4.1.8",
-                "csv_file": "4.1_Roofline_Performance_Rates.csv",
-                "column": "Value",
-                "expected_values": [1044.48],
-            },
-        ],
         "MI200": [
             {
                 "name": "HBM Bandwidth",


### PR DESCRIPTION
## Motivation

Dont test roofline related metric such as HBM Bandwidth on MI 100 since it doesnt support roofline

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Update metric validation dict in tests/test_metric_validation.py to not perform any test for memcopy for MI 100 for roofline related metric HBM Bandwidth

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Run `pytest -s --verbose tests/test_metric_validation.py` on MI 100

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

No metric validation is performed, and test passes due to the skip

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
