### PR TITLE
Fix missing includes in logger.hpp for GCC 14 compatibility

### DIFF
--- a/projects/rocprofiler-systems/source/lib/logger/logger.hpp
+++ b/projects/rocprofiler-systems/source/lib/logger/logger.hpp
@@ -7,6 +7,8 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <cstdlib>
 #include <mutex>


### PR DESCRIPTION
## Summary
- Add explicit `#include <algorithm>` for `std::any_of`
- Add explicit `#include <array>` for `std::array`

GCC 14 is stricter about requiring explicit includes rather than relying on transitive includes from other headers. This fixes build failures on Ubuntu 24.04+ with GCC 14.

## Test plan
- [x] Verified build succeeds with GCC 14 on Ubuntu 25.04

Fixes ROCm/TheRock#3227

🤖 Generated with [Claude Code](https://claude.com/claude-code)