### PR TITLE
Prevent the erroneous temp directory from being created

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -2520,7 +2520,7 @@ get_perfetto_output_filename_with_suffix(std::string_view suffix)
     auto _cfg = settings::compose_filename_config{
         !_explicitly_set && !suffix.empty(),  // use_suffix only if not explicitly set
         suffix,                               // suffix value
-        true,                                 // make_dir
+        false,                                // make_dir
         _dir                                  // explicit_path
     };
 


### PR DESCRIPTION
## Motivation

If output folder was not explicitly specified the temp folder, rocprof-%tag%-output, folder was being created.

For example, running `rocprof-sys-sample -v 2 -- ls` would create the `rocprofsys-ls-output` folder, which contains all the output files, and an empty `rocprofsys-%tag%-output`

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Do not set `make_dir` when calling `compose_filename_config`. This is how it is handled in other invocations of the function.

## JIRA ID

ROCM-2142

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
