### PR TITLE
Adding TempRead to test blacklist

### DIFF
--- a/projects/amdsmi/tests/amd_smi_test/amdsmitst.exclude
+++ b/projects/amdsmi/tests/amd_smi_test/amdsmitst.exclude
@@ -88,5 +88,6 @@ FILTER[90402]=${FILTER[90400]}
 # SWDEV-572968
 FILTER[gfx1151]=\
 $BLACKLIST_ALL_ASICS\
+"amdsmitstReadWrite.TempRead:"\
 "amdsmitstReadOnly.TestFrequenciesRead"
 


### PR DESCRIPTION
## Technical Details
The TempRead test tries to read metrics data with version 3.0 which has not been implemented in amdsmi.  Until the metrics data can be read, this test should not be run and is being blacklisted.

## JIRA ID
[ROCM-1769] AMD-SMI Readonly test failures on gfx1151

[ROCM-1769]: https://amd-hub.atlassian.net/browse/ROCM-1769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ