### PR TITLE
[rocprof-sys] Prevent misinterpretation of ROCPROFSYS_PAPI_EVENTS and ROCPROFSYS_SAMPLING_OVERFLOW_EVENT

### DIFF
--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -561,7 +561,7 @@ consolidate_env_entries(std::vector<char*>& envp)
         auto& data = it->second;
         if(data.skip)
         {
-            // Last value wins if duplicated
+            // Preserve value as-is (last value wins if duplicated)
             data.raw_value = std::string{ value };
         }
         else

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -475,24 +475,46 @@ add_torch_library_path(std::vector<char*>& envp, const std::vector<char*>& argv,
     updated_envs.emplace(ld_prefix.substr(0, ld_prefix.length() - 1));
 }
 
+/// @brief Consolidates duplicate environment variable entries by merging their values.
+///
+/// When building an environment for execve(), multiple entries for the same variable
+/// may accumulate. This function merges them into single entries with unique values.
+///
+/// For most variables, values are split and joined using ':' (e.g., PATH,
+/// LD_LIBRARY_PATH). Certain variables that use ':' in their value syntax use ',' as the
+/// delimiter instead.
+///
+/// @param envp Vector of environment strings in "KEY=VALUE" format. Modified in place.
+///             Original strings are freed; new strings are allocated with strdup().
+///
+/// Example transformations:
+///   - PATH=/usr/bin + PATH=/usr/local/bin -> PATH=/usr/bin:/usr/local/bin
+///   - ROCPROFSYS_PAPI_EVENTS=perf::A + ROCPROFSYS_PAPI_EVENTS=perf::B
+///         -> ROCPROFSYS_PAPI_EVENTS=perf::A,perf::B
 inline void
 consolidate_env_entries(std::vector<char*>& envp)
 {
-    constexpr char delim = ':';
-
-    // Variables that use : in their value syntax and should not be consolidated
-    auto skip_consolidation = [](std::string_view key) -> bool {
-        return key == "ROCPROFSYS_PAPI_EVENTS" ||
-               key == "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT";
+    /// Returns the appropriate delimiter character for splitting/joining values.
+    /// Most variables use ':' (like PATH), but some use ':' in their value syntax
+    /// and need ',' instead:
+    /// - ROCPROFSYS_PAPI_EVENTS: uses perf::EVENT_NAME or net:::interface:metric syntax
+    /// - ROCPROFSYS_SAMPLING_OVERFLOW_EVENT: uses perf::EVENT_NAME syntax
+    /// - ROCPROFSYS_ROCM_EVENTS: uses EVENT_NAME:device=N syntax
+    auto get_delimiter = [](std::string_view key) -> char {
+        if(key == "ROCPROFSYS_PAPI_EVENTS" ||
+           key == "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT" || key == "ROCPROFSYS_ROCM_EVENTS")
+            return ',';
+        return ':';
     };
 
+    /// Stores the parsed and deduplicated parts for a single environment variable.
     struct key_data
     {
-        std::vector<std::string>        parts;
-        std::unordered_set<std::string> seen;
-        bool                            skip = false;
-        std::string                     raw_value;
+        std::vector<std::string> parts;  ///< Unique value parts in order of appearance
+        std::unordered_set<std::string> seen;  ///< Tracks seen parts for deduplication
+        char                            delim = ':';  ///< Delimiter for this variable
 
+        /// Adds a part if non-empty and not already seen.
         void add_unique(std::string part)
         {
             if(!part.empty() && seen.insert(part).second)
@@ -500,6 +522,9 @@ consolidate_env_entries(std::vector<char*>& envp)
         }
     };
 
+    /// Parses an environment entry string into key and value components.
+    /// @param entry String in "KEY=VALUE" format
+    /// @return Optional pair of (key, value) views, or nullopt if no '=' found
     auto parse_entry = [](std::string_view entry)
         -> std::optional<std::pair<std::string_view, std::string_view>> {
         auto eq_pos = entry.find('=');
@@ -507,8 +532,13 @@ consolidate_env_entries(std::vector<char*>& envp)
         return std::make_pair(entry.substr(0, eq_pos), entry.substr(eq_pos + 1));
     };
 
-    auto join_parts = [delim](std::string_view                key,
-                              const std::vector<std::string>& parts) {
+    /// Reconstructs an environment entry string from key and value parts.
+    /// @param key   The environment variable name
+    /// @param parts The deduplicated value components
+    /// @param delim The delimiter to use when joining parts
+    /// @return String in "KEY=part1<delim>part2<delim>..." format
+    auto join_parts = [](std::string_view key, const std::vector<std::string>& parts,
+                         char delim) {
         std::string result;
 
         const auto total_parts_length = std::accumulate(
@@ -522,6 +552,7 @@ consolidate_env_entries(std::vector<char*>& envp)
         result.append(key);
         result += '=';
 
+        // Join all parts with the delimiter
         result =
             std::accumulate(parts.begin(), parts.end(), std::move(result),
                             [delim, &parts](std::string acc, const std::string& part) {
@@ -536,6 +567,7 @@ consolidate_env_entries(std::vector<char*>& envp)
     std::unordered_map<std::string_view, key_data> key_map;
     std::vector<std::string_view>                  key_order;
 
+    // Phase 1: Parse all entries and aggregate values by key
     for(auto* entry : envp)
     {
         if(!entry)
@@ -551,46 +583,34 @@ consolidate_env_entries(std::vector<char*>& envp)
 
         auto [key, value] = *parsed;
 
+        // Create new entry if key not seen before, recording its delimiter
         auto [it, inserted] = key_map.try_emplace(key);
         if(inserted)
         {
             key_order.emplace_back(key);
-            it->second.skip = skip_consolidation(key);
+            it->second.delim = get_delimiter(key);
         }
 
-        auto& data = it->second;
-        if(data.skip)
+        // Split value by delimiter and add unique parts
+        auto&              data = it->second;
+        std::istringstream stream{ std::string{ value } };
+        for(std::string part; std::getline(stream, part, data.delim);)
         {
-            // Preserve value as-is (last value wins if duplicated)
-            data.raw_value = std::string{ value };
-        }
-        else
-        {
-            std::istringstream stream{ std::string{ value } };
-            for(std::string part; std::getline(stream, part, delim);)
-            {
-                data.add_unique(part);
-            }
+            data.add_unique(part);
         }
     }
 
+    // Phase 2: Build consolidated result
     std::vector<char*> result;
     result.reserve(key_order.size());
 
     for(auto key : key_order)
     {
         const auto& data = key_map[key];
-        if(data.skip)
-        {
-            auto entry = std::string{ key } + "=" + data.raw_value;
-            result.emplace_back(strdup(entry.c_str()));
-        }
-        else
-        {
-            result.emplace_back(strdup(join_parts(key, data.parts).c_str()));
-        }
+        result.emplace_back(strdup(join_parts(key, data.parts, data.delim).c_str()));
     }
 
+    // Phase 3: Free original entries and replace with consolidated result
     for(auto* entry : envp)
     {
         std::free(entry);

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -1,24 +1,5 @@
-// MIT License
-//
-// Copyright (c) 2022-2025 Advanced Micro Devices, Inc. All Rights Reserved.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
 
 #pragma once
 
@@ -499,10 +480,18 @@ consolidate_env_entries(std::vector<char*>& envp)
 {
     constexpr char delim = ':';
 
+    // Variables that use : in their value syntax and should not be consolidated
+    auto skip_consolidation = [](std::string_view key) -> bool {
+        return key == "ROCPROFSYS_PAPI_EVENTS" ||
+               key == "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT";
+    };
+
     struct key_data
     {
         std::vector<std::string>        parts;
         std::unordered_set<std::string> seen;
+        bool                            skip = false;
+        std::string                     raw_value;
 
         void add_unique(std::string part)
         {
@@ -566,13 +555,22 @@ consolidate_env_entries(std::vector<char*>& envp)
         if(inserted)
         {
             key_order.emplace_back(key);
+            it->second.skip = skip_consolidation(key);
         }
 
-        auto&              data = it->second;
-        std::istringstream stream{ std::string{ value } };
-        for(std::string part; std::getline(stream, part, delim);)
+        auto& data = it->second;
+        if(data.skip)
         {
-            data.add_unique(part);
+            // Last value wins if duplicated
+            data.raw_value = std::string{ value };
+        }
+        else
+        {
+            std::istringstream stream{ std::string{ value } };
+            for(std::string part; std::getline(stream, part, delim);)
+            {
+                data.add_unique(part);
+            }
         }
     }
 
@@ -581,7 +579,16 @@ consolidate_env_entries(std::vector<char*>& envp)
 
     for(auto key : key_order)
     {
-        result.emplace_back(strdup(join_parts(key, key_map[key].parts).c_str()));
+        const auto& data = key_map[key];
+        if(data.skip)
+        {
+            auto entry = std::string{ key } + "=" + data.raw_value;
+            result.emplace_back(strdup(entry.c_str()));
+        }
+        else
+        {
+            result.emplace_back(strdup(join_parts(key, data.parts).c_str()));
+        }
     }
 
     for(auto* entry : envp)

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_environment.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_environment.cpp
@@ -96,6 +96,157 @@ TEST_F(DuplicatedEnvironmentEntriesTest, HandlesEmptyValues)
         std::free(entry);
 }
 
+TEST_F(DuplicatedEnvironmentEntriesTest, PapiEventsUsesCommaDelimiter)
+{
+    // PAPI events contain :: in their syntax, so they should use , as delimiter
+    std::vector<char*> env_vars = {
+        strdup("ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS"),
+        strdup("ROCPROFSYS_PAPI_EVENTS=perf::CACHE_MISSES"),
+    };
+    consolidate_env_entries(env_vars);
+    ASSERT_EQ(env_vars.size(), 1);
+    EXPECT_STREQ(env_vars[0],
+                 "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS,perf::CACHE_MISSES");
+
+    for(auto* entry : env_vars)
+        std::free(entry);
+}
+
+TEST_F(DuplicatedEnvironmentEntriesTest, PapiEventsPreservesColonInValue)
+{
+    // Single PAPI event entry should preserve the :: in the value
+    std::vector<char*> env_vars = {
+        strdup("ROCPROFSYS_PAPI_EVENTS=perf::PERF_COUNT_SW_CPU_CLOCK"),
+    };
+    consolidate_env_entries(env_vars);
+    ASSERT_EQ(env_vars.size(), 1);
+    EXPECT_STREQ(env_vars[0], "ROCPROFSYS_PAPI_EVENTS=perf::PERF_COUNT_SW_CPU_CLOCK");
+
+    for(auto* entry : env_vars)
+        std::free(entry);
+}
+
+TEST_F(DuplicatedEnvironmentEntriesTest, PapiEventsDeduplicates)
+{
+    // Duplicate PAPI events should be deduplicated
+    std::vector<char*> env_vars = {
+        strdup("ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS"),
+        strdup("ROCPROFSYS_PAPI_EVENTS=perf::CACHE_MISSES"),
+        strdup("ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS"),
+    };
+    consolidate_env_entries(env_vars);
+    ASSERT_EQ(env_vars.size(), 1);
+    EXPECT_STREQ(env_vars[0],
+                 "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS,perf::CACHE_MISSES");
+
+    for(auto* entry : env_vars)
+        std::free(entry);
+}
+
+TEST_F(DuplicatedEnvironmentEntriesTest, SamplingOverflowEventUsesCommaDelimiter)
+{
+    std::vector<char*> env_vars = {
+        strdup("ROCPROFSYS_SAMPLING_OVERFLOW_EVENT=perf::INSTRUCTIONS"),
+        strdup("ROCPROFSYS_SAMPLING_OVERFLOW_EVENT=perf::CYCLES"),
+    };
+    consolidate_env_entries(env_vars);
+    ASSERT_EQ(env_vars.size(), 1);
+    EXPECT_STREQ(env_vars[0],
+                 "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT=perf::INSTRUCTIONS,perf::CYCLES");
+
+    for(auto* entry : env_vars)
+        std::free(entry);
+}
+
+TEST_F(DuplicatedEnvironmentEntriesTest, MixedDelimiterVariables)
+{
+    // Test that regular variables use : and PAPI uses ,
+    std::vector<char*> env_vars = {
+        strdup("PATH=/usr/bin"),
+        strdup("ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS"),
+        strdup("PATH=/usr/local/bin"),
+        strdup("ROCPROFSYS_PAPI_EVENTS=perf::CACHE_MISSES"),
+        strdup("LD_LIBRARY_PATH=/lib"),
+    };
+    consolidate_env_entries(env_vars);
+    ASSERT_EQ(env_vars.size(), 3);
+    EXPECT_STREQ(env_vars[0], "PATH=/usr/bin:/usr/local/bin");
+    EXPECT_STREQ(env_vars[1],
+                 "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS,perf::CACHE_MISSES");
+    EXPECT_STREQ(env_vars[2], "LD_LIBRARY_PATH=/lib");
+
+    for(auto* entry : env_vars)
+        std::free(entry);
+}
+
+TEST_F(DuplicatedEnvironmentEntriesTest, PreservesKeyOrder)
+{
+    std::vector<char*> env_vars = {
+        strdup("ZEBRA=1"),
+        strdup("ALPHA=2"),
+        strdup("MIDDLE=3"),
+    };
+    consolidate_env_entries(env_vars);
+    ASSERT_EQ(env_vars.size(), 3);
+    // Order should be preserved based on first occurrence
+    EXPECT_STREQ(env_vars[0], "ZEBRA=1");
+    EXPECT_STREQ(env_vars[1], "ALPHA=2");
+    EXPECT_STREQ(env_vars[2], "MIDDLE=3");
+
+    for(auto* entry : env_vars)
+        std::free(entry);
+}
+
+TEST_F(DuplicatedEnvironmentEntriesTest, PapiEventsWithCommaInValue)
+{
+    // If PAPI events are already comma-separated in a single entry, they should be split
+    std::vector<char*> env_vars = {
+        strdup("ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS,perf::CYCLES"),
+        strdup("ROCPROFSYS_PAPI_EVENTS=perf::CACHE_MISSES"),
+    };
+    consolidate_env_entries(env_vars);
+    ASSERT_EQ(env_vars.size(), 1);
+    EXPECT_STREQ(
+        env_vars[0],
+        "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS,perf::CYCLES,perf::CACHE_MISSES");
+
+    for(auto* entry : env_vars)
+        std::free(entry);
+}
+
+TEST_F(DuplicatedEnvironmentEntriesTest, RocmEventsUsesCommaDelimiter)
+{
+    // ROCM events use :device=N syntax, so they should use , as delimiter
+    std::vector<char*> env_vars = {
+        strdup("ROCPROFSYS_ROCM_EVENTS=SQ_WAVES:device=0"),
+        strdup("ROCPROFSYS_ROCM_EVENTS=TA_TA_BUSY:device=1"),
+    };
+    consolidate_env_entries(env_vars);
+    ASSERT_EQ(env_vars.size(), 1);
+    EXPECT_STREQ(env_vars[0],
+                 "ROCPROFSYS_ROCM_EVENTS=SQ_WAVES:device=0,TA_TA_BUSY:device=1");
+
+    for(auto* entry : env_vars)
+        std::free(entry);
+}
+
+TEST_F(DuplicatedEnvironmentEntriesTest, RocmEventsPreservesDeviceSyntax)
+{
+    // Single ROCM event entry should preserve the :device= syntax
+    std::vector<char*> env_vars = {
+        strdup("ROCPROFSYS_ROCM_EVENTS=GRBM_COUNT,SQ_WAVES,SQ_INSTS_VALU,TA_TA_BUSY:"
+               "device=0"),
+    };
+    consolidate_env_entries(env_vars);
+    ASSERT_EQ(env_vars.size(), 1);
+    EXPECT_STREQ(
+        env_vars[0],
+        "ROCPROFSYS_ROCM_EVENTS=GRBM_COUNT,SQ_WAVES,SQ_INSTS_VALU,TA_TA_BUSY:device=0");
+
+    for(auto* entry : env_vars)
+        std::free(entry);
+}
+
 class AddTorchLibraryPathTest : public ::testing::Test
 {
 protected:


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

When working on the pytest PR, I noticed that the equivalent annotate test would fail. This happens because I would prioritize using env vars as opposed to config files to run the tests (opposite of what ctest does). In the annotate env, the following env var would be set: `ROCPROFSYS_PAPI_EVENTS=perf::PERF_COUNT_SW_CPU_CLOCK`. 

If this is NOT put in a config file, `rocprof-sys-run` would detect it as `perf:PERF_COUNT_SW_CPU_CLOCK` leading to the following warning when running:
```
[papi_config] Event 'perf:PERF_COUNT_SW_CPU_CLOCK' not valid'
```

This would cause the validation test to fail. To reproduce this using ctest, simply run:
```
export ROCPROFSYS_PAPI_EVENTS=perf::PERF_COUNT_SW_CPU_CLOCK
ctest -R annotate-binary-rewrite
// Validation test will fail
```

**NOTE**
This error is not seen with the overflow test as it uses (no `perf::` even though the docs say to use it with `perf::`):
`ROCPROFSYS_SAMPLING_OVERFLOW_EVENT=PERF_COUNT_SW_CPU_CLOCK`

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

When building the environment for `execve()`, duplicate env vars were consolidated by splitting and rejoining on `:`. That broke variables whose values contain colons:

- ROCPROFSYS_PAPI_EVENTS (e.g. `perf::EVENT_NAME`)
- ROCPROFSYS_SAMPLING_OVERFLOW_EVENT (same syntax)
- ROCPROFSYS_ROCM_EVENTS (e.g. `EVENT:device=N`)

This PR makes consolidation use `,` as the delimiter for these three variables and keeps `:` for others (e.g. PATH, LD_LIBRARY_PATH). Colons inside a value are preserved; multiple values are separated by commas. Unit tests were added for the new behavior.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

AIPROFSYST-191

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Manually tested.
Unit tests added. 

## Test Result

Using:
```
export ROCPROFSYS_PAPI_EVENTS=perf::PERF_COUNT_SW_CPU_CLOCK
ctest -R annotate-binary-rewrite
```
Validation test passes.

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
