### PR TITLE
Remove purposeful overflow read in graph tests

### DIFF
--- a/projects/hip-tests/catch/unit/graph/graph_tests_common.hh
+++ b/projects/hip-tests/catch/unit/graph/graph_tests_common.hh
@@ -55,12 +55,6 @@ template <typename F> void GraphAddNodeCommonNegativeTests(F f, hipGraph_t graph
   }
 #endif
 
-  SECTION("Invalid numNodes") {
-    hipGraphNode_t dep_node = nullptr;
-    HIP_CHECK(hipGraphAddEmptyNode(&dep_node, graph, nullptr, 0));
-    HIP_CHECK_ERROR(f(&node, graph, &dep_node, 2), hipErrorInvalidValue);
-  }
-
 // Disabled on AMD due to defect - EXSWHTEC-201
 #if HT_NVIDIA
   SECTION("Duplicate node in dependencies") {


### PR DESCRIPTION
## Motivation

The particular section is invalid and does a purposeful read of OOB memory.

## Technical Details

When passing a pointer and a size, the only bounds API can check is the size provided. If the size is invalid, there will be OOB memory read. The test can randomly segfault, hence removed the section.

## JIRA ID

NA

## Test Plan

Existing test should pass ASAN checks

## Test Result

tested locally.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
