### PR TITLE
Use void* instead of int[] to write value to

### DIFF
--- a/projects/hip-tests/catch/unit/graph/hipGraphMemAllocNodeGetParams.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMemAllocNodeGetParams.cc
@@ -245,10 +245,10 @@ TEST_CASE("Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_2") {
   HIP_CHECK(hipGraphMemAllocNodeGetParams(allocNodeC, &params_out));
   REQUIRE(true == validateAllocParam(params_in, params_out));
 
-  int temp[] = {0};
-  HIP_CHECK(hipGraphMemFreeNodeGetParams(freeNodeA, reinterpret_cast<void*>(temp)));
-  HIP_CHECK(hipGraphMemFreeNodeGetParams(freeNodeB, reinterpret_cast<void*>(temp)));
-  HIP_CHECK(hipGraphMemFreeNodeGetParams(freeNodeC, reinterpret_cast<void*>(temp)));
+  void* paramPtr{};
+  HIP_CHECK(hipGraphMemFreeNodeGetParams(freeNodeA, reinterpret_cast<void*>(&paramPtr)));
+  HIP_CHECK(hipGraphMemFreeNodeGetParams(freeNodeB, reinterpret_cast<void*>(&paramPtr)));
+  HIP_CHECK(hipGraphMemFreeNodeGetParams(freeNodeC, reinterpret_cast<void*>(&paramPtr)));
 
   HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
   HIP_CHECK(hipGraphLaunch(graphExec, stream));


### PR DESCRIPTION
## Motivation

The API expects a void* and writes an address, the current value being an int array is simply not enough

## Technical Details

Changing from `int[]` to `void*` removes the overflow write which we see with current test.

## JIRA ID

NA

## Test Plan

Existing test should work fine with sanitizers

## Test Result

Tested locally, it passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
