### PR TITLE
Enable therock RCCL CI tests post migration to rocm-systems

### DIFF
--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -30,21 +30,19 @@ jobs:
       # The ccache.conf will be written by setup_ccache.py before this gets used.
       CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf
     steps:
+      - name: "Checking out repository for rocm-systems"
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
       - name: Checkout TheRock repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
+          path: "TheRock"
           ref: 9a8534f5e38c8c5e20b1a92185aca578c2840a7d # 02-05-2026 Commit
-
-      - name: Checkout rocm-systems repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: "ROCm/rocm-systems"
-          path: rocm-systems
 
       - name: Install python deps
         run: |
-          pip install -r requirements.txt
+          pip install -r TheRock/requirements.txt
 
       # safe.directory must be set before Runner Health Status
       - name: Adjust git config
@@ -54,18 +52,18 @@ jobs:
 
       - name: Setup ccache
         run: |
-          ./build_tools/setup_ccache.py \
+          ./TheRock/build_tools/setup_ccache.py \
             --config-preset "github-oss-presubmit" \
             --dir "$(dirname $CCACHE_CONFIGPATH)" \
             --local-path "$CACHE_DIR/ccache"
 
       - name: Runner health status
         run: |
-          ./build_tools/health_status.py
+          ./TheRock/build_tools/health_status.py
 
       - name: Fetch sources
         run: |
-          ./build_tools/fetch_sources.py --jobs 12
+          ./TheRock/build_tools/fetch_sources.py --jobs 12
 
       - name: Configure Projects
         env:
@@ -74,30 +72,30 @@ jobs:
           extra_cmake_options: ${{ inputs.extra_cmake_options }}
           BUILD_DIR: build
         run: |
-          python3 build_tools/github_actions/build_configure.py
+          python3 ./TheRock/build_tools/github_actions/build_configure.py
 
       - name: Build therock-dist
-        run: cmake --build build
+        run: cmake --build TheRock/build
 
       - name: Build therock-archives
-        run: cmake --build build --target therock-archives
+        run: cmake --build TheRock/build --target therock-archives
 
       - name: Report
         #if: ${{ !cancelled() }}
         run: |
           echo "Full SDK du:"
           echo "------------"
-          du -h -d 1 build/dist/rocm
+          du -h -d 1 TheRock/build/dist/rocm
           echo "Artifact Archives:"
           echo "------------------"
-          ls -lh build/artifacts/*.tar.xz
+          ls -lh TheRock/build/artifacts/*.tar.xz
           echo "Artifacts:"
           echo "----------"
-          du -h -d 1 build/artifacts
+          du -h -d 1 TheRock/build/artifacts
           echo "CCache Stats:"
           echo "-------------"
           ccache -s -v
-          tail -v -n +1 .ccache/compiler_check_cache/* > build/logs/ccache_compiler_check_cache.log
+          tail -v -n +1 .ccache/compiler_check_cache/* > TheRock/build/logs/ccache_compiler_check_cache.log
 
       - name: Configure AWS Credentials for non-forked repos
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}
@@ -112,7 +110,7 @@ jobs:
           python3 build_tools/github_actions/post_build_upload.py \
             --run-id ${{ github.run_id }} \
             --artifact-group ${{ env.AMDGPU_FAMILIES }} \
-            --build-dir build \
+            --build-dir TheRock/build \
             --upload
 
   therock-test-linux-multi-node:

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -122,7 +122,7 @@ jobs:
       contents: read
       id-token: write
     needs: [therock-build-linux]
-    uses: ./.github/workflows/therock-test-packages-multi-node.yml
+    uses: ./.github/workflows/therock-rccl-test-packages-multi-node.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       artifact_group: ${{ inputs.artifact_group }}
@@ -133,7 +133,7 @@ jobs:
     name: "Test single-node"
     if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
     needs: [therock-build-linux]
-    uses: ./.github/workflows/therock-test-packages-single-node.yml
+    uses: ./.github/workflows/therock-rccl-test-packages-single-node.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       artifact_group: ${{ inputs.artifact_group }}

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           repository: "ROCm/rocm-systems"
           path: rocm-systems
-          ref: 0203842aa05864366ce225f154090de7114eb018 # Test Branch to fix RCCL perf-drop
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -1,4 +1,4 @@
-name: TheRock CI Linux
+name: TheRock CI Linux for rccl
 
 on:
   workflow_call:

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -34,13 +34,14 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 5523139d860b6430aa24baf044e6dfa59921df60 # 02/11/2026 commit
+          ref: 9a8534f5e38c8c5e20b1a92185aca578c2840a7d # 02-05-2026 Commit
 
       - name: Checkout rocm-systems repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/rocm-systems"
           path: rocm-systems
+          ref: 0203842aa05864366ce225f154090de7114eb018 # Test Branch to fix RCCL perf-drop
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           repository: "ROCm/rocm-systems"
           path: rocm-systems
+          ref: 996202f56033598b66cdc7d7c4473c6c283e6cb4 #Pinning test-branch
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -1,0 +1,141 @@
+name: TheRock CI Linux
+
+on:
+  workflow_call:
+    inputs:
+      amdgpu_families:
+        type: string
+      artifact_group:
+        type: string
+      extra_cmake_options:
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  therock-build-linux:
+    name: Build Linux Packages
+    runs-on: azure-linux-scale-rocm
+    permissions:
+      id-token: write
+    container:
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:1f1ce0ab151146c7f86ee4345be74c42d8ca83200d9d26843e8a71df01ecad4e
+      options: -v /runner/config:/home/awsconfig/
+    env:
+      AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+      TEATIME_FORCE_INTERACTIVE: 0
+      AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
+      CACHE_DIR: ${{ github.workspace }}/.container-cache
+      # The ccache.conf will be written by setup_ccache.py before this gets used.
+      CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf
+    steps:
+      - name: Checkout TheRock repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "ROCm/TheRock"
+          ref: 62ac2f8517f15f4d300d174fceb63590fb171bdf # amdsmi runtime dep branch
+
+      - name: Checkout rocm-systems repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "ROCm/rocm-systems"
+          path: rocm-systems
+
+      - name: Install python deps
+        run: |
+          pip install -r requirements.txt
+
+      # safe.directory must be set before Runner Health Status
+      - name: Adjust git config
+        run: |
+          git config --global --add safe.directory $PWD
+          git config fetch.parallel 10
+
+      - name: Setup ccache
+        run: |
+          ./build_tools/setup_ccache.py \
+            --config-preset "github-oss-presubmit" \
+            --dir "$(dirname $CCACHE_CONFIGPATH)" \
+            --local-path "$CACHE_DIR/ccache"
+
+      - name: Runner health status
+        run: |
+          ./build_tools/health_status.py
+
+      - name: Fetch sources
+        run: |
+          ./build_tools/fetch_sources.py --jobs 12
+
+      - name: Configure Projects
+        env:
+          amdgpu_families: ${{ env.AMDGPU_FAMILIES }}
+          package_version: ADHOCBUILD
+          extra_cmake_options: ${{ inputs.extra_cmake_options }}
+          BUILD_DIR: build
+        run: |
+          python3 build_tools/github_actions/build_configure.py
+
+      - name: Build therock-dist
+        run: cmake --build build
+
+      - name: Build therock-archives
+        run: cmake --build build --target therock-archives
+
+      - name: Report
+        #if: ${{ !cancelled() }}
+        run: |
+          echo "Full SDK du:"
+          echo "------------"
+          du -h -d 1 build/dist/rocm
+          echo "Artifact Archives:"
+          echo "------------------"
+          ls -lh build/artifacts/*.tar.xz
+          echo "Artifacts:"
+          echo "----------"
+          du -h -d 1 build/artifacts
+          echo "CCache Stats:"
+          echo "-------------"
+          ccache -s -v
+          tail -v -n +1 .ccache/compiler_check_cache/* > build/logs/ccache_compiler_check_cache.log
+
+      - name: Configure AWS Credentials for non-forked repos
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-artifacts-external
+
+      - name: Post Build Upload
+        if: always()
+        run: |
+          python3 build_tools/github_actions/post_build_upload.py \
+            --run-id ${{ github.run_id }} \
+            --artifact-group ${{ env.AMDGPU_FAMILIES }} \
+            --build-dir build \
+            --upload
+
+  therock-test-linux-multi-node:
+    name: "Test multi-node"
+    if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
+    permissions:
+      contents: read
+      id-token: write
+    needs: [therock-build-linux]
+    uses: ./.github/workflows/therock-test-packages-multi-node.yml
+    with:
+      amdgpu_families: ${{ inputs.amdgpu_families }}
+      artifact_group: ${{ inputs.artifact_group }}
+      test_runs_on: nova-linux-slurm-scale-runner
+      artifact_run_id: ${{ github.run_id }}
+
+  therock-test-linux-single-node:
+    name: "Test single-node"
+    if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
+    needs: [therock-build-linux]
+    uses: ./.github/workflows/therock-test-packages-single-node.yml
+    with:
+      amdgpu_families: ${{ inputs.amdgpu_families }}
+      artifact_group: ${{ inputs.artifact_group }}
+      test_runs_on: linux-mi325-4gpu-ossci-rocm
+      artifact_run_id: ${{ github.run_id }}

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 52b91def7754285ccda108609a7cc800c8615ac9 # switch-rccl commit
+          ref: 5523139d860b6430aa24baf044e6dfa59921df60 # 02/11/2026 commit
 
       - name: Checkout rocm-systems repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Post Build Upload
         if: always()
         run: |
-          python3 build_tools/github_actions/post_build_upload.py \
+          python3 TheRock/build_tools/github_actions/post_build_upload.py \
             --run-id ${{ github.run_id }} \
             --artifact-group ${{ env.AMDGPU_FAMILIES }} \
             --build-dir TheRock/build \

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: b74cc568204bd9c224f479303588b783331edb31 # 3143 branch with fix
+          ref: 5335180478008b249504863f3f4b9bb1690149bf # 2026-02-04 commit
 
       - name: Checkout rocm-systems repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 5335180478008b249504863f3f4b9bb1690149bf # 2026-02-04 commit
+          ref: 52b91def7754285ccda108609a7cc800c8615ac9 # switch-rccl commit
 
       - name: Checkout rocm-systems repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -34,14 +34,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 62ac2f8517f15f4d300d174fceb63590fb171bdf # amdsmi runtime dep branch
+          ref: b74cc568204bd9c224f479303588b783331edb31 # 3143 branch with fix
 
       - name: Checkout rocm-systems repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/rocm-systems"
           path: rocm-systems
-          ref: 996202f56033598b66cdc7d7c4473c6c283e6cb4 #Pinning test-branch
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -1,0 +1,91 @@
+name: TheRock CI for rccl
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    types:
+      - labeled
+      - opened
+      - synchronize
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit). The workflow name is prepended to avoid conflicts between
+  # different workflows.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  setup:
+    runs-on: ubuntu-24.04
+    env:
+      # The commit being checked out is the merge commit for a PR. Its first
+      # parent will be the tip of the base branch.
+      BASE_REF: HEAD^
+    outputs:
+      enable_therock_ci: ${{ steps.configure.outputs.enable_therock_ci }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          # We need the parent commit to do a diff
+          fetch-depth: 2
+
+      - name: "Configuring CI options"
+        id: configure
+        run: python .github/scripts/therock_configure_ci.py
+
+  therock-ci-linux:
+    name: TheRock CI Linux
+    needs: setup
+    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        amdgpu_family: [gfx94X-dcgpu, gfx950-dcgpu]
+    uses: ./.github/workflows/therock-ci-linux.yml
+    secrets: inherit
+    with:
+      amdgpu_families: ${{ matrix.amdgpu_family }}
+      artifact_group: ${{ matrix.amdgpu_family }}
+      extra_cmake_options: >
+        -DTHEROCK_ENABLE_ALL=OFF 
+        -DTHEROCK_BUILD_TESTING=ON 
+        -DTHEROCK_BUNDLE_SYSDEPS=ON 
+        -DTHEROCK_ENABLE_COMM_LIBS=ON 
+        -DTHEROCK_ENABLE_ROCPROFV3=ON 
+        -DTHEROCK_USE_EXTERNAL_RCCL=ON 
+        -DTHEROCK_USE_EXTERNAL_RCCL_TESTS=ON 
+        -DTHEROCK_RCCL_SOURCE_DIR=./rccl 
+        -DTHEROCK_RCCL_TESTS_SOURCE_DIR=./rccl-tests
+        -DTHEROCK_ENABLE_MPI=ON
+
+  therock_ci_summary:
+    name: TheRock CI Summary
+    if: always()
+    needs:
+      - setup
+      - therock-ci-linux
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Output failed jobs
+        run: |
+          echo '${{ toJson(needs) }}'
+          FAILED_JOBS="$(echo '${{ toJson(needs) }}' \
+            | jq --raw-output \
+            'map_values(select(.result!="success" and .result!="skipped")) | keys | join(",")' \
+          )"
+          if [[ "${FAILED_JOBS}" != "" ]]; then
+            echo "The following jobs failed: ${FAILED_JOBS}"
+            exit 1
+          fi

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         amdgpu_family: [gfx94X-dcgpu, gfx950-dcgpu]
-    uses: ./.github/workflows/therock-ci-linux.yml
+    uses: ./.github/workflows/therock-rccl-ci-linux.yml
     secrets: inherit
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -60,7 +60,7 @@ jobs:
   therock-ci-linux:
     name: TheRock CI Linux
     needs: setup
-    if: ${{ needs.setup.outputs.run_linux_ci == 'true' }}
+    #if: ${{ needs.setup.outputs.run_linux_ci == 'true' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - users/arravikum/rccl-ci-tests
   pull_request:
     types:
       - labeled
@@ -61,7 +60,7 @@ jobs:
   therock-ci-linux:
     name: TheRock CI Linux
     needs: setup
-    #if: ${{ needs.setup.outputs.run_linux_ci == 'true' }}
+    if: ${{ needs.setup.outputs.run_linux_ci == 'true' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -61,7 +61,7 @@ jobs:
   therock-ci-linux:
     name: TheRock CI Linux
     needs: setup
-    #if: ${{ needs.setup.outputs.run_linux_ci == 'true' }}
+    if: ${{ needs.setup.outputs.run_linux_ci == 'true' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - users/arravikum/rccl-ci-tests
   pull_request:
     types:
       - labeled

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - users/arravikum/rccl-ci-tests
   pull_request:
     types:
       - labeled

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -64,11 +64,7 @@ jobs:
         -DTHEROCK_BUILD_TESTING=ON 
         -DTHEROCK_BUNDLE_SYSDEPS=ON 
         -DTHEROCK_ENABLE_COMM_LIBS=ON 
-        -DTHEROCK_ENABLE_ROCPROFV3=ON 
-        -DTHEROCK_USE_EXTERNAL_RCCL=ON 
-        -DTHEROCK_USE_EXTERNAL_RCCL_TESTS=ON 
-        -DTHEROCK_RCCL_SOURCE_DIR=./rocm-systems/projects/rccl 
-        -DTHEROCK_RCCL_TESTS_SOURCE_DIR=./rocm-systems/projects/rccl-tests
+        -DTHEROCK_ENABLE_ROCPROFV3=ON
         -DTHEROCK_ENABLE_MPI=ON
 
   therock_ci_summary:

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -32,6 +32,8 @@ jobs:
       BASE_REF: HEAD^
     outputs:
       enable_therock_ci: ${{ steps.configure.outputs.enable_therock_ci }}
+      run_linux_ci: ${{ steps.rccl_check.outputs.run_linux_ci }}
+
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -43,10 +45,23 @@ jobs:
         id: configure
         run: python .github/scripts/therock_configure_ci.py
 
+      - name: "Check if RCCL project is affected"
+        id: rccl_check
+        run: |
+          echo "Projects JSON:"
+          echo '${{ steps.configure.outputs.projects }}'
+
+          if echo '${{ steps.configure.outputs.projects }}' | \
+             jq -e '.[] | select(.project_to_test | test("rccl"))' > /dev/null; then
+            echo "run_linux_ci=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_linux_ci=false" >> "$GITHUB_OUTPUT"
+          fi
+
   therock-ci-linux:
     name: TheRock CI Linux
     needs: setup
-    #if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    if: ${{ needs.setup.outputs.run_linux_ci == 'true' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -46,7 +46,7 @@ jobs:
   therock-ci-linux:
     name: TheRock CI Linux
     needs: setup
-    if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
+    #if: ${{ needs.setup.outputs.enable_therock_ci == 'true' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - users/arravikum/rccl-ci-tests
   pull_request:
     types:
       - labeled
@@ -66,8 +67,8 @@ jobs:
         -DTHEROCK_ENABLE_ROCPROFV3=ON 
         -DTHEROCK_USE_EXTERNAL_RCCL=ON 
         -DTHEROCK_USE_EXTERNAL_RCCL_TESTS=ON 
-        -DTHEROCK_RCCL_SOURCE_DIR=./rccl 
-        -DTHEROCK_RCCL_TESTS_SOURCE_DIR=./rccl-tests
+        -DTHEROCK_RCCL_SOURCE_DIR=./rocm-systems/projects/rccl 
+        -DTHEROCK_RCCL_TESTS_SOURCE_DIR=./rocm-systems/projects/rccl-tests
         -DTHEROCK_ENABLE_MPI=ON
 
   therock_ci_summary:

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -61,7 +61,7 @@ jobs:
   therock-ci-linux:
     name: TheRock CI Linux
     needs: setup
-    if: ${{ needs.setup.outputs.run_linux_ci == 'true' }}
+    #if: ${{ needs.setup.outputs.run_linux_ci == 'true' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -1,0 +1,88 @@
+name: TheRock Test Packages multi-node
+
+on:
+  workflow_call:
+    inputs:
+      amdgpu_families:
+        type: string
+      artifact_group:
+        type: string
+      test_runs_on:
+        type: string
+      artifact_run_id:
+        type: string
+  workflow_dispatch:
+    inputs:
+      amdgpu_families:
+        type: string
+      artifact_group:
+        type: string
+      test_runs_on:
+        type: string
+      artifact_run_id:
+        type: string
+        
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  test_rccl_multi_node:
+    name: 'Test multi-node'
+    runs-on: ${{ inputs.test_runs_on }}
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      VENV_DIR: ${{ github.workspace }}/.venv
+      ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}"
+      OUTPUT_ARTIFACTS_DIR: /apps/cvs_tests/dist_new/dist/rocm
+      THEROCK_BIN_DIR: "./build/bin"
+      AWS_SHARED_CREDENTIALS_FILE: /apps/cvs_tests/awsconfig/credentials.ini
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "ROCm/TheRock"
+          ref: ff46daa79b4c826c4f4676893d0d6586de567dfa # 2026-01-12 commit
+
+      - name: Run setup test environment workflow
+        uses: './.github/actions/setup_test_environment'
+        with:
+          ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
+          AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+          ARTIFACT_GROUP: ${{ inputs.artifact_group }}
+          OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
+          VENV_DIR: ${{ env.VENV_DIR }}
+          FETCH_ARTIFACT_ARGS: "--rccl --tests"
+          IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
+
+      # The following step leverages slurm to run multi node rccl tests on the slurm mi350x cluster.
+      # salloc will hold 4 nodes while the commands inside the block run. After the block completes, salloc automatically releases the nodes.
+      # sbatch script runs rccl_heatmap_cvs script which validates and generates a bandwidth heatmap file for different rccl collectives
+      - name: Test gfx950
+        if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
+        run: |
+          SETUP_NODES=1 sbatch --wait -N4 /apps/cvs_tests/cvs-sbatch/sbatch/default.sbatch
+
+      - name: Configure AWS Credentials for non-forked repos
+        if: ${{ always() && !github.event.pull_request.head.repo.fork }}
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          aws-region: us-east-2
+          role-to-assume: arn:aws:iam::692859939525:role/therock-artifacts-external
+
+      - name: Post test report upload
+        if: always()
+        working-directory: ${{ github.workspace }}
+        run: |
+          export PYTHONPATH="${PYTHONPATH}:${{ github.workspace }}/build_tools"
+          python3 build_tools/github_actions/upload_test_report_script.py \
+            --run-id "${{ github.run_id }}" \
+            --amdgpu-family "${{ inputs.amdgpu_families }}" \
+            --report-path "/apps/cvs_tests/test_reports" \
+            --log-destination "/logs/gfx950-dcgpu" \
+            --index-file-name "index_rccl_test_report.html"

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 52b91def7754285ccda108609a7cc800c8615ac9 # switch-rccl commit
+          ref: 5523139d860b6430aa24baf044e6dfa59921df60 # 02/11/2026 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: ff46daa79b4c826c4f4676893d0d6586de567dfa # 2026-01-12 commit
+          ref: 5335180478008b249504863f3f4b9bb1690149bf # 2026-02-04 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'
@@ -66,7 +66,8 @@ jobs:
       - name: Test gfx950
         if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
         run: |
-          SETUP_NODES=1 sbatch --wait -N4 /apps/cvs_tests/cvs-sbatch/sbatch/default.sbatch
+          chmod +x /apps/cvs_tests/ci-entrypoint.sh
+          /apps/cvs_tests/ci-entrypoint.sh
 
       - name: Configure AWS Credentials for non-forked repos
         if: ${{ always() && !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 5335180478008b249504863f3f4b9bb1690149bf # 2026-02-04 commit
+          ref: 52b91def7754285ccda108609a7cc800c8615ac9 # switch-rccl commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -1,4 +1,4 @@
-name: TheRock Test Packages multi-node
+name: TheRock Test Packages multi-node for rccl
 
 on:
   workflow_call:

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 5523139d860b6430aa24baf044e6dfa59921df60 # 02/11/2026 commit
+          ref: 9a8534f5e38c8c5e20b1a92185aca578c2840a7d # 02-05-2026 Commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-rccl-test-packages-single-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-single-node.yml
@@ -1,0 +1,77 @@
+name: TheRock Test Packages single-node
+
+on:
+  workflow_call:
+    inputs:
+      amdgpu_families:
+        type: string
+      artifact_group:
+        type: string
+      test_runs_on:
+        type: string
+      artifact_run_id:
+        type: string
+  workflow_dispatch:
+    inputs:
+      amdgpu_families:
+        type: string
+      artifact_group:
+        type: string
+      test_runs_on:
+        type: string
+      artifact_run_id:
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  test_rccl_single_node:
+    name: 'Test single-node'
+    runs-on: ${{ inputs.test_runs_on }}
+    container:
+      image: ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98
+      options: --ipc host
+        --group-add video
+        --device /dev/kfd
+        --device /dev/dri
+        --group-add 110
+        --ulimit memlock=-1:-1
+        --security-opt seccomp=unconfined
+        --env-file /etc/podinfo/gha-gpu-isolation-settings
+        --user 0:0
+    defaults:
+      run:
+        shell: bash
+    env:
+      VENV_DIR: ${{ github.workspace }}/.venv
+      ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}"
+      OUTPUT_ARTIFACTS_DIR: "./build"
+      THEROCK_BIN_DIR: "./build/bin"
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "ROCm/TheRock"
+          ref: ff46daa79b4c826c4f4676893d0d6586de567dfa # 2026-01-12 commit
+
+      - name: Run setup test environment workflow
+        uses: './.github/actions/setup_test_environment'
+        with:
+          ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
+          AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+          ARTIFACT_GROUP: ${{ inputs.artifact_group }}
+          OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
+          VENV_DIR: ${{ env.VENV_DIR }}
+          FETCH_ARTIFACT_ARGS: "--rccl --tests"
+          IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
+
+      - name: Test
+        timeout-minutes: 15
+        # Currently, TheRock CI in RCCL always builds with MPI-supported enabled which causes the
+        # RCCL correctness tests to fail on the mi325 runners which don't have MPI pre-installed.
+        # TODO (geomin12): Rebuild rccl-tests without MPI to enable RCCL correctness tests.
+        run: |
+          pytest ./build_tools/github_actions/test_executable_scripts/test_rccl.py -v -s \
+            -k "not test_rccl_correctness_tests" \
+            --log-cli-level=info

--- a/.github/workflows/therock-rccl-test-packages-single-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-single-node.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: ff46daa79b4c826c4f4676893d0d6586de567dfa # 2026-01-12 commit
+          ref: 5335180478008b249504863f3f4b9bb1690149bf # 2026-02-04 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-rccl-test-packages-single-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-single-node.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 52b91def7754285ccda108609a7cc800c8615ac9 # switch-rccl commit
+          ref: 5523139d860b6430aa24baf044e6dfa59921df60 # 02/11/2026 commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-rccl-test-packages-single-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-single-node.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 5335180478008b249504863f3f4b9bb1690149bf # 2026-02-04 commit
+          ref: 52b91def7754285ccda108609a7cc800c8615ac9 # switch-rccl commit
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-rccl-test-packages-single-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-single-node.yml
@@ -1,4 +1,4 @@
-name: TheRock Test Packages single-node
+name: TheRock Test Packages single-node for rccl
 
 on:
   workflow_call:


### PR DESCRIPTION
Motivation

RCCL CI in TheRock is being migrated from the rocm/rccl repository to rocm-systems (rocm-systems/projects/rccl). All future RCCL development will live in rocm-systems, and CI needs to follow that ownership.

This PR updates TheRock CI to ensure RCCL tests continue to run correctly after the migration.

Changes
RCCL CI workflow migration

RCCL-specific workflows have been renamed and moved to clearly reflect their new scope:

New

therock-rccl-test-packages-multi-node.yml

therock-rccl-test-packages-single-node.yml

therock-rccl-ci-linux.yml

therock-rccl-ci.yml

Previously

therock-test-packages-multi-node.yml

therock-test-packages-single-node.yml

therock-ci-linux.yml

therock-ci.yml

**RCCL Linux CI triggering**

- The workflow now inspects the projects output from therock_configure_ci.py
- 
- Linux CI runs only when projects/rccl is affected
- 
- RCCL-unrelated changes skip Linux CI
