### PR TITLE
 [SWDEV-578515] Fix duplicate json output for amd-smi metric

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -2734,8 +2734,8 @@ class AMDSMICommands():
             self.logger.store_multiple_device_output()
             return # Skip printing when there are multiple devices
 
-        # Print output for all formats
-        self.logger.print_output(watching_output=watching_output)
+        if not self.logger.is_json_format() or watching_output:
+            self.logger.print_output(watching_output=watching_output)
 
         if watching_output: # End of single gpu add to watch_output
             self.logger.store_watch_output(multiple_device_enabled=False)


### PR DESCRIPTION
## Motivation

Duplicate JSON outputs for amd-smi metric commands with gpu args.

## Technical Details

A recent change to support watch for AMD-SMI metric JSON format introduced this.

## JIRA ID

SWDEV-578515

## Test Plan

amd-smi metric --gpu=0 --json
amd-smi metric --watch=1 --json

## Test Result

<img width="511" height="375" alt="image" src="https://github.com/user-attachments/assets/369e815b-6166-44b8-a47a-bd940a970ab4" />

<img width="261" height="202" alt="image" src="https://github.com/user-attachments/assets/6b3e9f48-df5b-4a35-a8f5-204ce46e070c" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
