### PR TITLE
hsakmt: check if amdgpu_device_get_fd exists in drm lib 

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/memory.c
+++ b/projects/rocr-runtime/libhsakmt/src/memory.c
@@ -1068,6 +1068,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMemHandleFree(HsaMemoryObjectHandle Handle)
 HSAKMT_STATUS HSAKMTAPI hsaKmtMemoryCpuMap(HsaMemoryObjectHandle Handle,
 						void** out_cpu_ptr)
 {
+	CHECK_KFD_OPEN();
 	int ret = amdgpu_bo_cpu_map((amdgpu_bo_handle)Handle, out_cpu_ptr);
 	if (ret) {
 		return HSAKMT_STATUS_ERROR;
@@ -1078,14 +1079,20 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMemoryCpuMap(HsaMemoryObjectHandle Handle,
 HSAKMT_STATUS HSAKMTAPI hsaKmtMemoryGetCpuAddr(HsaAMDGPUDeviceHandle DeviceHandle,
   						HsaMemoryObjectHandle MemoryHandle, HSAint32* fd, HSAuint64* cpu_addr)
 {
-  	amdgpu_device_handle devhandle = (amdgpu_device_handle)DeviceHandle;
-  	int renderFd = amdgpu_device_get_fd(devhandle);
-  	if (renderFd < 0) return HSAKMT_STATUS_ERROR;
+	CHECK_KFD_OPEN();
+	int renderFd = -1;
+	if (hsakmt_fn_amdgpu_device_get_fd)
+		renderFd = hsakmt_fn_amdgpu_device_get_fd(DeviceHandle);
+
+	if (renderFd < 0) {
+		pr_err("amdgpu_device_get_fd failed: %d\n", renderFd);
+		return HSAKMT_STATUS_ERROR;
+	}
 
   	uint32_t gem_handle = 0;
   	int ret = amdgpu_bo_export((amdgpu_bo_handle)MemoryHandle, amdgpu_bo_handle_type_kms, &gem_handle);
   	if (ret) {
-  			return HSAKMT_STATUS_ERROR;
+		return HSAKMT_STATUS_ERROR;
   	}
 
   	union drm_amdgpu_gem_mmap args;
@@ -1095,7 +1102,7 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMemoryGetCpuAddr(HsaAMDGPUDeviceHandle DeviceHandl
   	args.in.handle = gem_handle;
   	ret = drmCommandWriteRead(renderFd, DRM_AMDGPU_GEM_MMAP, &args, sizeof(args));
   	if (ret) {
-  	  return HSAKMT_STATUS_ERROR;
+		return HSAKMT_STATUS_ERROR;
   	}
   	*fd = (HSAint32)renderFd;
   	*cpu_addr = (HSAuint64)args.out.addr_ptr;


### PR DESCRIPTION
## Motivation

- amdgpu_device_get_fd interface doesn't exist in older version of DRM
- on RHEL9 thunk compilation fails when this symbol is not found.
- Check if the symbol exists before using it.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
