### PR TITLE
SWDEV-578804 - Fix hipGetProcAddress_spt_Stream

### DIFF
--- a/projects/hip-tests/catch/unit/streamperthread/hipGetProcAddressSptApis.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipGetProcAddressSptApis.cc
@@ -2654,7 +2654,8 @@ TEST_CASE("Unit_hipGetProcAddress_spt_Stream") {
 
     for (int s = 0; s < Ns; s++) {
       int startIndex = s * (N / Ns);
-      addOneKernel<<<1, 1, 0, stream[s]>>>(devMem + startIndex, N / Ns);
+      int threadsPerBlock = 1024;
+      addOneKernel<<<N/threadsPerBlock, threadsPerBlock, 0, stream[s]>>>(devMem + startIndex, N / Ns);
     }
 
     for (int s = 0; s < Ns; s++) {


### PR DESCRIPTION
## Motivation

hipGetProcAddress_spt_Stream was creating a kernel with only one thread. We need to ensure that the kernel operates over the entire span of the device memory.

## Technical Details

Modified the number of threads in the addOneKernel to span the device memory.

## JIRA ID

SWDEV-578804

## Test Plan

Test hipGetProcAddress_spt_Stream

## Test Result

Test passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
