### PR TITLE
clr: Make copyBufferBatch take non-const copyOps for metadata modification

### DIFF
--- a/projects/clr/rocclr/device/blit.cpp
+++ b/projects/clr/rocclr/device/blit.cpp
@@ -352,10 +352,10 @@ bool HostBlitManager::copyBufferRect(device::Memory& srcMemory, device::Memory& 
   return true;
 }
 
-bool HostBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& copyOps,
+bool HostBlitManager::copyBufferBatch(std::vector<amd::BatchCopyOp>& copyOps,
                                       bool entire) const {
   // Default implementation falls back to individual copies
-  for (const auto& op : copyOps) {
+  for (auto& op : copyOps) {
     if (op.srcMemory == nullptr || op.dstMemory == nullptr) {
       return false;
     }

--- a/projects/clr/rocclr/device/blit.hpp
+++ b/projects/clr/rocclr/device/blit.hpp
@@ -161,8 +161,8 @@ class BlitManager : public amd::HeapObject {
 
   //! Copies multiple buffer objects in a batch
   virtual bool copyBufferBatch(
-      const std::vector<amd::BatchCopyOp>& copyOps,  //!< Batch of copy operations
-      bool entire = false                            //!< Entire buffers will be updated
+      std::vector<amd::BatchCopyOp>& copyOps,  //!< Batch of copy operations
+      bool entire = false                      //!< Entire buffers will be updated
   ) const = 0;
 
   //! Copies an image object to a buffer object
@@ -360,8 +360,8 @@ class HostBlitManager : public device::BlitManager {
 
   //! Copies multiple buffer objects in a batch
   virtual bool copyBufferBatch(
-      const std::vector<amd::BatchCopyOp>& copyOps,  //!< Batch of copy operations
-      bool entire = false                            //!< Entire buffers will be updated
+      std::vector<amd::BatchCopyOp>& copyOps,  //!< Batch of copy operations
+      bool entire = false                      //!< Entire buffers will be updated
   ) const;
 
   //! Copies an image object to a buffer object

--- a/projects/clr/rocclr/device/pal/palvirtual.cpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.cpp
@@ -2117,7 +2117,7 @@ void VirtualGPU::submitBatchCopyMemory(amd::BatchCopyMemoryCommand& cmd) {
 
   profilingBegin(cmd);
 
-  const auto& copyOps = cmd.copyOps();
+  auto& copyOps = cmd.copyOps();
   if (copyOps.empty()) {
     profilingEnd(cmd);
     return;
@@ -2127,7 +2127,7 @@ void VirtualGPU::submitBatchCopyMemory(amd::BatchCopyMemoryCommand& cmd) {
   device::Memory::SyncFlags syncFlags;
   syncFlags.skipEntire_ = false;
 
-  for (const auto& op : copyOps) {
+  for (auto& op : copyOps) {
     Memory* srcDevMem = dev().getGpuMemory(op.srcMemory);
     Memory* dstDevMem = dev().getGpuMemory(op.dstMemory);
 

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -357,7 +357,7 @@ bool DmaBlitManager::copyBufferRect(device::Memory& srcMemory, device::Memory& d
 }
 
 // ================================================================================================
-bool DmaBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& copyOps,
+bool DmaBlitManager::copyBufferBatch(std::vector<amd::BatchCopyOp>& copyOps,
                                      bool entire) const {
   if (copyOps.empty()) {
     return true;
@@ -370,7 +370,7 @@ bool DmaBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& copyOp
   // Future optimization: use a shared completion signal for all operations
   bool result = true;
 
-  for (const auto& op : copyOps) {
+  for (auto& op : copyOps) {
     if (op.srcMemory == nullptr || op.dstMemory == nullptr) {
       LogError("DmaBlitManager::copyBufferBatch - Invalid memory objects!");
       return false;
@@ -392,9 +392,8 @@ bool DmaBlitManager::copyBufferBatch(const std::vector<amd::BatchCopyOp>& copyOp
     amd::Coord3D dstOrigin(op.dstOffset);
     amd::Coord3D size(op.size);
 
-    amd::CopyMetadata metadata = op.metadata;
-
-    if (!hsaCopy(gpuMem(*srcDevMem), gpuMem(*dstDevMem), srcOrigin, dstOrigin, size, metadata)) {
+    if (!hsaCopy(gpuMem(*srcDevMem), gpuMem(*dstDevMem), srcOrigin, dstOrigin, size,
+                 op.metadata)) {
       LogPrintfError("DmaBlitManager::copyBufferBatch - Copy failed for operation");
       result = false;
       break;

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -144,8 +144,8 @@ class DmaBlitManager : public device::HostBlitManager {
 
   //! Copies multiple buffer objects in a batch
   virtual bool copyBufferBatch(
-      const std::vector<amd::BatchCopyOp>& copyOps,  //!< Batch of copy operations
-      bool entire = false                            //!< Entire buffers will be updated
+      std::vector<amd::BatchCopyOp>& copyOps,  //!< Batch of copy operations
+      bool entire = false                      //!< Entire buffers will be updated
   ) const;
 
   //! Copies an image object to a buffer object

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -2858,7 +2858,7 @@ void VirtualGPU::submitBatchCopyMemory(amd::BatchCopyMemoryCommand& cmd) {
 
   profilingBegin(cmd, true);
 
-  const auto& copyOps = cmd.copyOps();
+  auto& copyOps = cmd.copyOps();
   if (copyOps.empty()) {
     profilingEnd();
     return;
@@ -2870,7 +2870,7 @@ void VirtualGPU::submitBatchCopyMemory(amd::BatchCopyMemoryCommand& cmd) {
   device::Memory::SyncFlags syncFlags;
   syncFlags.skipEntire_ = false;
 
-  for (const auto& op : copyOps) {
+  for (auto& op : copyOps) {
     Memory* srcDevMem = dev().getRocMemory(op.srcMemory);
     Memory* dstDevMem = dev().getRocMemory(op.dstMemory);
 

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -246,16 +246,23 @@ union CopyMetadata {
     uint32_t copyEnginePreference_ : 2;
     uint32_t srcAccessOrder_ : 2;       //!< Source access ordering for batch copies
     uint32_t preferOverlapCompute_ : 1; //!< Prefer overlap with compute work
+    uint32_t reserved_ : 26;            //!< Reserved for future use
   };
   uint32_t flags_;
   CopyMetadata() : flags_(0) {}
   CopyMetadata(bool isAsync, CopyEnginePreference copyEnginePreference)
-      : isAsync_(isAsync), copyEnginePreference_(copyEnginePreference),
-        srcAccessOrder_(kSrcAccessOrderStream), preferOverlapCompute_(0) {}
+      : isAsync_(isAsync),
+        copyEnginePreference_(copyEnginePreference),
+        srcAccessOrder_(kSrcAccessOrderStream),
+        preferOverlapCompute_(0),
+        reserved_(0) {}
   CopyMetadata(bool isAsync, CopyEnginePreference copyEnginePreference,
                SrcAccessOrder srcAccessOrder, bool preferOverlap = false)
-      : isAsync_(isAsync), copyEnginePreference_(copyEnginePreference),
-        srcAccessOrder_(srcAccessOrder), preferOverlapCompute_(preferOverlap ? 1 : 0) {}
+      : isAsync_(isAsync),
+        copyEnginePreference_(copyEnginePreference),
+        srcAccessOrder_(srcAccessOrder),
+        preferOverlapCompute_(preferOverlap ? 1 : 0),
+        reserved_(0) {}
 };
 
 // Interface to callback to allocate kernel args from the graph kernel arg pool.
@@ -1142,7 +1149,7 @@ class BatchCopyMemoryCommand : public Command {
   virtual void submit(device::VirtualDevice& device) { device.submitBatchCopyMemory(*this); }
 
   //! Return the vector of copy operations
-  const std::vector<BatchCopyOp>& copyOps() const { return copyOps_; }
+  std::vector<BatchCopyOp>& copyOps() { return copyOps_; }
 
   //! Return the number of copy operations in the batch
   size_t count() const { return copyOps_.size(); }


### PR DESCRIPTION
This allows hsaCopy and other low-level functions to modify copyMetadata and propagate changes back to the caller, enabling future enhancements without API changes.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
