### PR TITLE
rocrtst: Enable rocrtstPerf.Memory_Async_Copy emu

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy.cc
+++ b/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy.cc
@@ -74,7 +74,11 @@ static const uint32_t kDtifBdfId = 0xC81407;
 
 std::vector<MemoryAsyncCopy::Granularity> MemoryAsyncCopy::initGranularities() {
   if (rocrtst::isEmuModeEnabled()) {
-    return {{"1k", 1024}};
+    return {{"1k", 1024},
+            {"4K", 4 * 1024},
+            {"8K", 8 * 1024},
+            {"128K", 128 * 1024},
+            {"1M", 1024 * 1024}};
   } else {
     return {{"1k", 1024},
             {"2K", 2 * 1024},
@@ -99,15 +103,10 @@ std::vector<MemoryAsyncCopy::Granularity> MemoryAsyncCopy::initGranularities() {
   }
 }
 
-const int MemoryAsyncCopy::kNumGranularity = rocrtst::isEmuModeEnabled() ? 1 : 20;
 const std::vector<MemoryAsyncCopy::Granularity> MemoryAsyncCopy::Granularities = MemoryAsyncCopy::initGranularities();
 const int MemoryAsyncCopy::kMaxCopySize = MemoryAsyncCopy::Granularities.back().Size;
 
 MemoryAsyncCopy::MemoryAsyncCopy(void) : TestBase() {
-  if (Granularities.size() != kNumGranularity) {
-    throw std::runtime_error("kNumGranularity does not match size of arrays");
-  }
-
   cpu_agent_.handle = 0;  // Ignore any previous initialization
   gpu_local_agent1_.handle = 0;
   gpu_local_agent2_.handle = 0;
@@ -400,7 +399,7 @@ void MemoryAsyncCopy::RunBenchmarkWithVerification(Transaction *t) {
     return;
   }
 
-  for (int i = 0; i < kNumGranularity; i++) {
+  for (int i = 0; i < Granularities.size(); i++) {
     if (Granularities[i].Size > size) {
       printf("Skip test with block size %s\n", Granularities[i].Str);
       break;
@@ -582,7 +581,7 @@ void MemoryAsyncCopy::DisplayBenchmark(Transaction *t) const {
   printf("Data Size             Avg Time(us)         Avg BW(GB/s)"
       "          Min Time(us)          Peak BW(GB/s)\n");
 
-  for (int i = 0; i < kNumGranularity; i++) {
+  for (int i = 0; i < Granularities.size(); i++) {
     if (Granularities[i].Size > size) {
       printf("Notice: Data Size >= %s is skipped due to hard limit of 1/2 vram size \n\n", Granularities[i].Str);
       break;

--- a/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy.h
+++ b/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy.h
@@ -204,7 +204,6 @@ class MemoryAsyncCopy : public TestBase {
     size_t Size;
   };
 
-  static const int kNumGranularity;
   static const std::vector<Granularity> Granularities;
   static const int kMaxCopySize;
 

--- a/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy_numa.cc
+++ b/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy_numa.cc
@@ -297,7 +297,7 @@ void MemoryAsyncCopyNUMA::RunBenchmarkWithVerification(Transaction *t) {
   }
   ASSERT_NE(cpy_ag, nullptr);
 
-  for (int i = 0; i < kNumGranularity; i++) {
+  for (int i = 0; i < Granularities.size(); i++) {
     if (Granularities[i].Size > size) {
       break;
     }

--- a/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy_on_engine.cc
+++ b/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy_on_engine.cc
@@ -174,7 +174,7 @@ void MemoryAsyncCopyOnEngine::RunBenchmarkWithVerification(Transaction *t) {
     return;
   }
 
-  for (int i = 0; i < kNumGranularity; i++) {
+  for (int i = 0; i < Granularities.size(); i++) {
     if (Granularities[i].Size > size) {
       printf("Skip test with block size %s\n", Granularities[i].Str);
       break;

--- a/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
@@ -751,17 +751,15 @@ TEST(rocrtstStress, Queue_LoadStore_Write_Index_ConcurrentTest) {
 }
 
 TEST(rocrtstPerf, Memory_Async_Copy) {
-  RUN_IF_NOT_EMU_MODE(
-    MemoryAsyncCopy mac;
-    // To do full test, uncomment this:
-    //  mac.set_full_test(true);
-    // To test only 1 path, add lines like this:
-    //  mac.set_src_pool(<src pool id>);
-    //  mac.set_dst_pool(<dst pool id>);
-    // The default is to and from the cpu to 1 gpu, and to/from a gpu to
-    // another gpu
-    RunGenericTest(&mac);
-  );
+  MemoryAsyncCopy mac;
+  // To do full test, uncomment this:
+  //  mac.set_full_test(true);
+  // To test only 1 path, add lines like this:
+  //  mac.set_src_pool(<src pool id>);
+  //  mac.set_dst_pool(<dst pool id>);
+  // The default is to and from the cpu to 1 gpu, and to/from a gpu to
+  // another gpu
+  RunGenericTest(&mac);
 }
 
 TEST(rocrtstPerf, Memory_Async_Copy_On_Engine) {

--- a/projects/rocr-runtime/rocrtst/suites/test_common/test_case_template.cc
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/test_case_template.cc
@@ -123,20 +123,6 @@ static const uint32_t kNumBufferElements = rocrtst::isEmuModeEnabled() ? 4 : 256
 
 // Many test cases want to perform an operation on memory sizes of various
 // granularities.
-#if 0
-static const int kNumGranularity = 20;
-const char* Str[kNumGranularity] = {"1k", "2K", "4K", "8K", "16K", "32K",
-    "64K", "128K", "256K", "512K", "1M", "2M", "4M", "8M", "16M", "32M",
-                                               "64M", "128M", "256M", "512M"};
-
-const size_t Size[kNumGranularity] = {
-    1024, 2*1024, 4*1024, 8*1024, 16*1024, 32*1024, 64*1024, 128*1024,
-    256*1024, 512*1024, 1024*1024, 2048*1024, 4096*1024, 8*1024*1024,
-    16*1024*1024, 32*1024*1024, 64*1024*1024, 128*1024*1024, 256*1024*1024,
-    512*1024*1024};
-
-static const int kMaxCopySize = Size[kNumGranularity - 1];
-#endif
 TestExample::TestExample(void) :
     TestBase() {
   set_num_iteration(10);  // Number of iterations to execute of the main test;


### PR DESCRIPTION
Enable Memory_Async_Copy test on emulator. We have code to reduce the copy sizes to limit duration on emulator.