### PR TITLE
Adjusted priority of python lib in cli import

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_init.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_init.py
@@ -31,8 +31,8 @@ from pathlib import Path
 
 current_path = os.path.dirname(os.path.abspath(__file__))
 python_lib_path = f"{current_path}/../../share/amd_smi"
-sys.path.append(python_lib_path)
-# If the python library is installed, it will overwrite the path above
+sys.path.insert(0, python_lib_path)
+# Prioritize the library from this installation over any pip-installed version
 
 try:
     from amdsmi import amdsmi_interface, amdsmi_exception


### PR DESCRIPTION
Default to local ROCm pathways for multi-ROCm installations

- Changed priority order: local ROCm path indexing now takes precedence over Python library path
- Previously, Python lib path was checked first, with local ROCm as fallback
- Fixes issue where users in multi-ROCm setups wouldn't get the Python lib installed since they were using `update-alternatives` 
- Local pathway indexing was already the fallback for multi-ROCm amd-smi CLI users; now it's the default for all amd-smi CLI users