### PR TITLE
[rocprofiler-systems] Rocpd add missing tracks for JPEG PMC events

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/rocpd/data_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/rocpd/data_processor.cpp
@@ -171,11 +171,10 @@ data_processor::insert_pmc_description(
     auto it = _pmc_descriptor_map.find({ agent_id, name });
     if(it != _pmc_descriptor_map.end())
     {
-        LOG_WARNING("Insert PMC description failed! Error: PMC descriptor "
-                    "Insert PMC description failed! Error: PMC descriptor "
-                    "(name: {}) (ID: {}) already exist!",
-                    name, agent_id);
-        return;
+        throw std::runtime_error(
+            fmt::format("Insert PMC description failed! Error: PMC descriptor "
+                        "agent id: {}, pmc name: {} !",
+                        agent_id, name));
     }
     data_storage::queries::table_insert_query query_builder;
 
@@ -207,10 +206,10 @@ data_processor::insert_pmc_event(size_t event_id, size_t agent_id, const char* p
     auto it = _pmc_descriptor_map.find({ agent_id, pmc_name });
     if(it == _pmc_descriptor_map.end())
     {
-        LOG_WARNING("Insert PMC event failed! Error: non-existing PMC description "
-                    "agent id: {}, pmc name: {} !",
-                    agent_id, pmc_name);
-        return;
+        throw std::runtime_error(
+            fmt::format("Insert PMC event failed! Error: non-existing PMC description "
+                        "agent id: {}, pmc name: {} !",
+                        agent_id, pmc_name));
     }
 
     const auto pmc_description_id = it->second;
@@ -227,8 +226,8 @@ data_processor::insert_sample(const char* track, uint64_t timestamp, size_t even
     auto it = _tracks.find(track);
     if(it == _tracks.end())
     {
-        LOG_WARNING("Insert sample failed! Error: Unexisting track {}!", track);
-        return;
+        throw std::runtime_error(
+            fmt::format("Insert sample failed! Error: Unexisting track {}!", track));
     }
     auto track_info = it->second;
     _insert_sample_statement(_upid.c_str(), track_info.track_id, timestamp, event_id,

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -75,6 +75,10 @@ namespace amd_smi
 using bundle_t          = std::deque<data>;
 using sampler_instances = thread_data<bundle_t, category::amd_smi>;
 
+#ifndef AMDSMI_MAX_NUM_JPEG_ENG_V1
+#    define AMDSMI_MAX_NUM_JPEG_ENG_V1 AMDSMI_MAX_NUM_JPEG
+#endif
+
 namespace
 {
 void
@@ -120,7 +124,7 @@ metadata_initialize_smi_tracks(size_t gpu_id)
     };
 
     auto add_jpeg_track = [&](std::optional<int> xcp_idx) {
-        for(auto clk = 0; clk < AMDSMI_MAX_NUM_JPEG; ++clk)
+        for(auto clk = 0; clk < AMDSMI_MAX_NUM_JPEG_ENG_V1; ++clk)
         {
             auto name = trace_cache::info::annotate_with_device_id<
                 category::amd_smi_jpeg_activity>(gpu_id, xcp_idx, clk);
@@ -269,7 +273,7 @@ metadata_initialize_smi_pmc(size_t gpu_id)
     };
 
     auto add_jpeg_pmc = [&](std::optional<int> xcp_idx) {
-        for(auto clk = 0; clk < AMDSMI_MAX_NUM_JPEG; ++clk)
+        for(auto clk = 0; clk < AMDSMI_MAX_NUM_JPEG_ENG_V1; ++clk)
         {
             std::stringstream name_ss;
             name_ss << trait::name<category::amd_smi_jpeg_activity>::value;


### PR DESCRIPTION
## Motivation

MI355 has 40 JPEG Codec Engines, and the track count for JPEG PMC events was limited to AMDSMI_MAX_NUM_JPEG, which is 32. This was causing errors on PMC event insertion for non-existent tracks

## Technical Details

Change track count from AMDSMI_MAX_NUM_JPEG to AMDSMI_MAX_NUM_JPEG_ENG_V1

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
