### PR TITLE
[SWDEV-573156] Added fix to update GL2C counters instance count for GFX11.5

### DIFF
--- a/projects/aqlprofile/src/core/gfx115x_factory.cpp
+++ b/projects/aqlprofile/src/core/gfx115x_factory.cpp
@@ -48,7 +48,7 @@ Gfx115xFactory::Gfx115xFactory(const AgentInfo* agent_info)
         block_info->instance_count = 4;
         break;
       case Gl2cCounterBlockId:
-        block_info->instance_count = 4;
+        block_info->instance_count = 8;
         break;
       case TcpCounterBlockId:
         block_info->instance_count = 2;


### PR DESCRIPTION
## Motivation
FETCH_SIZE counter wasn't reporting the correct values on GFX11.5, e.g. gfx1151.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Updated `Gl2cCounterBlockId` instance_count in gfx115x_factory.cpp. Changed from 4 to 8 to correctly report FETCH_SIZE counter values for gfx1151.
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
Resolves SWDEV-573156
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
Verified the original test in ticket to report correct numbers for FETCH_SIZE
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
```
Before Fix:
grep read_kernel /tmp/fetch_size_test_counter_collection.csv | sed 's/.*FETCH_SIZE",//' | cut -d',' -f1
524306.812500

After Fix:
$(rocm-sdk path --bin)/rocprofv3 --pmc FETCH_SIZE --kernel-trace --output-format csv   -o /tmp/fetch_size_test -- ./fetch_size_reproducer
[AQLPROFILE DEBUG] Library loaded from: /proj/xsjhdstaff4/vipangul/rocm_venv/lib/python3.12/site-packages/_rocm_sdk_core/lib/libhsa-amd-aqlprofile64.so.1
[AQLPROFILE DEBUG] aqlprofile library constructor called
[AQLPROFILE DEBUG] Gfx115xCreate called - creating Gfx115xFactory
[AQLPROFILE DEBUG] Agent gfxip: gfx1151
[AQLPROFILE DEBUG] Gfx115xFactory constructor called
[AQLPROFILE DEBUG] Gl2cCounterBlockId instance_count set to 8
[AQLPROFILE DEBUG] Gfx115xFactory created successfully
W20260204 14:35:58.680210 126185253583424 simple_timer.cpp:55] [rocprofv3] tool initialization ::     0.097493 sec
W20260204 14:35:58.680528 126185253583424 simple_timer.cpp:55] [rocprofv3] './fetch_size_reproducer' ::     0.000000 sec
=== FETCH_SIZE Counter Unit Reproducer ===

Reading 1073741824 bytes (1 GB), element size: 16 bytes
W20260204 14:35:58.814808 126185253583424 tool.cpp:2424] HSA version 1.18.0 initialized (instance=0)
W20260204 14:35:58.976208 126185253583424 simple_timer.cpp:55] [rocprofv3] './fetch_size_reproducer' ::     0.295680 sec
E20260204 14:35:58.985810 126185253583424 output_stream.cpp:111] Opened result file: /tmp/fetch_size_test_kernel_trace.csv
E20260204 14:35:58.997237 126185253583424 output_stream.cpp:111] Opened result file: /tmp/fetch_size_test_counter_collection.csv
E20260204 14:35:59.001110 126185253583424 output_stream.cpp:111] Opened result file: /tmp/fetch_size_test_agent_info.csv
W20260204 14:35:59.003463 126185253583424 simple_timer.cpp:55] [rocprofv3] output generation ::     0.025753 sec
W20260204 14:35:59.003501 126185253583424 simple_timer.cpp:55] [rocprofv3] tool finalization ::     0.025889 sec
(rocm_venv) xsjstrhalo14:/scratch/vipangul/tickets/SWDEV-573156/tickets/SWDEV-573156 ]$
(rocm_venv) xsjstrhalo14:/scratch/vipangul/tickets/SWDEV-573156/tickets/SWDEV-573156 ]$
(rocm_venv) xsjstrhalo14:/scratch/vipangul/tickets/SWDEV-573156/tickets/SWDEV-573156 ]$
(rocm_venv) xsjstrhalo14:/scratch/vipangul/tickets/SWDEV-573156/tickets/SWDEV-573156 ]$
(rocm_venv) xsjstrhalo14:/scratch/vipangul/tickets/SWDEV-573156/tickets/SWDEV-573156 ]$ grep read_kernel /tmp/fetch_size_test_counter_collection.csv | sed 's/.*FETCH_SIZE",//' | cut -d',' -f1
1048614.312500
```

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
