### PR TITLE
[ci] Updating variable group-id for OSSCI

### DIFF
--- a/projects/rccl/.github/workflows/therock-test-packages-single-node.yml
+++ b/projects/rccl/.github/workflows/therock-test-packages-single-node.yml
@@ -35,7 +35,7 @@ jobs:
         --group-add video
         --device /dev/kfd
         --device /dev/dri
-        --group-add 110
+        --group-add 992
         --ulimit memlock=-1:-1
         --security-opt seccomp=unconfined
         --env-file /etc/podinfo/gha-gpu-isolation-settings


### PR DESCRIPTION
OSSCI migrated mi325s, so need a new groupID

Sanity works here: https://github.com/ROCm/TheRock/actions/runs/21723540679/job/62659665907
normal run works here: https://github.com/ROCm/TheRock/actions/runs/21723540679/job/62659791422

I've dabbled with organization variables, however, this does not work for forks so for now, we will do the manual update