### PR TITLE
Fix missing JPEG_Activity tracks on MI35x

### DIFF
--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -11,6 +11,10 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
 - Simplify categorizing like pmc_info events by removing the _<idx> from the "symbol" field. ie., "JpegAct_0" -> "JpegAct".
 - Added `libhsa-runtime64.so` and `libomp.so` to the internal library exclusion list for runtime instrumentation to prevent instrumenting of runtime library internals.
 
+### Resolved issues
+
+- Fixed an issue where JPEG engine activity PMC events were not being collected for MI35X systems. Only the first 32 JPEG engines were being collected.
+
 ## ROCm Systems Profiler 1.4.0 for ROCm 7.11.0
 
 ### Added

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -75,6 +75,10 @@ namespace amd_smi
 using bundle_t          = std::deque<data>;
 using sampler_instances = thread_data<bundle_t, category::amd_smi>;
 
+#ifndef AMDSMI_MAX_NUM_JPEG_ENG_V1
+#    define AMDSMI_MAX_NUM_JPEG_ENG_V1 AMDSMI_MAX_NUM_JPEG
+#endif
+
 namespace
 {
 void
@@ -120,7 +124,7 @@ metadata_initialize_smi_tracks(size_t gpu_id)
     };
 
     auto add_jpeg_track = [&](std::optional<int> xcp_idx) {
-        for(auto clk = 0; clk < AMDSMI_MAX_NUM_JPEG; ++clk)
+        for(auto clk = 0; clk < AMDSMI_MAX_NUM_JPEG_ENG_V1; ++clk)
         {
             auto name = trace_cache::info::annotate_with_device_id<
                 category::amd_smi_jpeg_activity>(gpu_id, xcp_idx, clk);
@@ -269,7 +273,7 @@ metadata_initialize_smi_pmc(size_t gpu_id)
     };
 
     auto add_jpeg_pmc = [&](std::optional<int> xcp_idx) {
-        for(auto clk = 0; clk < AMDSMI_MAX_NUM_JPEG; ++clk)
+        for(auto clk = 0; clk < AMDSMI_MAX_NUM_JPEG_ENG_V1; ++clk)
         {
             std::stringstream name_ss;
             name_ss << trait::name<category::amd_smi_jpeg_activity>::value;


### PR DESCRIPTION
## Motivation

Split from #3088 

MI355 has 40 JPEG Codec Engines, and the track count for JPEG PMC events was limited to `AMDSMI_MAX_NUM_JPEG`, which is 32. This was causing errors on PMC event insertion for non-existent tracks.

## Technical Details

Change track count from `AMDSMI_MAX_NUM_JPEG` to `AMDSMI_MAX_NUM_JPEG_ENG_V1`, if it's defined.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
