### PR TITLE
[ROCM-186] Add support for a VRAM and GTT tuning interface

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_cli.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_cli.py
@@ -166,6 +166,7 @@ if __name__ == "__main__":
                                     amd_smi_commands.partition,
                                     amd_smi_commands.ras,
                                     amd_smi_commands.node,
+                                    amd_smi_commands.memory,
                                     amd_smi_commands.rocm_smi,
                                     amd_smi_commands.default,
                                     sys_argv=sys.argv,

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -25,6 +25,7 @@ import json
 import logging
 import multiprocessing
 import os
+import shutil
 import signal
 import sys
 import threading
@@ -713,7 +714,8 @@ class AMDSMICommands():
     def static_gpu(self, args, multiple_devices=False, gpu=None, asic=None, bus=None, vbios=None,
                         limit=None, driver=None, ras=None, board=None, numa=None, vram=None,
                         cache=None, partition=None, dfc_ucode=None, fb_info=None, num_vf=None,
-                        soc_pstate=None, xgmi_plpd=None, process_isolation=None, clock=None, profile=None):
+                        soc_pstate=None, xgmi_plpd=None, process_isolation=None, clock=None, profile=None,
+                        mem_size=None):
         """Get Static information for target gpu
 
         Args:
@@ -767,6 +769,8 @@ class AMDSMICommands():
             args.partition = partition
         if clock:
             args.clock = clock
+        if mem_size:
+            args.mem_size = mem_size
 
         # args.clock defaults to False so if it was overwritten to empty list, that indicates that it was given as an arguments but with an empty list
         if args.clock == []:
@@ -1788,7 +1792,7 @@ class AMDSMICommands():
                 board=None, numa=None, vram=None, cache=None, partition=None,
                 dfc_ucode=None, fb_info=None, num_vf=None, cpu=None, nic=None,
                 interface_ver=None, soc_pstate=None, xgmi_plpd = None, process_isolation=None,
-                clock=None, profile=None):
+                clock=None, profile=None, mem_size=None):
         """Get Static information for target gpu and cpu
 
         Args:
@@ -1849,7 +1853,7 @@ class AMDSMICommands():
         gpu_attributes = ["asic", "bus", "vbios", "limit", "driver", "ras",
                           "board", "numa", "vram", "cache", "partition",
                           "dfc_ucode", "fb_info", "num_vf", "soc_pstate", "xgmi_plpd",
-                          "process_isolation", "clock", "profile"]
+                          "process_isolation", "clock", "profile", "mem_size"]
         for attr in gpu_attributes:
             if hasattr(args, attr):
                 if getattr(args, attr):
@@ -1880,7 +1884,7 @@ class AMDSMICommands():
                                     bus, vbios, limit, driver, ras,
                                     board, numa, vram, cache, partition,
                                     dfc_ucode, fb_info, num_vf, soc_pstate, xgmi_plpd,
-                                    process_isolation, clock, profile)
+                                    process_isolation, clock, profile, mem_size)
         elif self.helpers.is_amd_hsmp_initialized(): # Only CPU is initialized
             if args.cpu == None:
                 args.cpu = self.cpu_handles
@@ -1895,7 +1899,7 @@ class AMDSMICommands():
                                 bus, vbios, limit, driver, ras,
                                 board, numa, vram, cache, partition,
                                 dfc_ucode, fb_info, num_vf, soc_pstate, xgmi_plpd,
-                                process_isolation, clock, profile)
+                                process_isolation, clock, profile, mem_size)
 
         if args.nic:
             self.logger.output = {}
@@ -8651,6 +8655,239 @@ class AMDSMICommands():
                 else:
                     with self.logger.destination.open('a', encoding="utf-8") as output_file:
                         output_file.write(legend_output + '\n')
+
+
+    def memory(self, args, multiple_devices=False, gpu=None, vram=None, gtt=None, reset_gtt=None):
+        """ Display and configure GPU memory settings (VRAM carveout and GTT/shared memory)
+        param:
+            args - argparser args to pass to subcommand
+            multiple_devices (bool) - True if checking for multiple devices
+            gpu (device_handle) - device_handle for target device
+            vram (int) - VRAM carveout index to set
+            gtt (float) - GTT size in GB to set
+            reset_gtt (bool) - Reset GTT to system default
+        returns:
+            nothing
+        """
+
+        if gpu:
+            args.gpu = gpu
+        if vram is not None:
+            args.vram = vram
+        if gtt is not None:
+            args.gtt = gtt
+        if reset_gtt is not None:
+            args.reset_gtt = reset_gtt
+
+        # Default gpu to all devices if not specified
+        if args.gpu is None:
+            args.gpu = self.device_handles
+        if not isinstance(args.gpu, list):
+            args.gpu = [args.gpu]
+
+        if not self.group_check_printed:
+            self.helpers.check_required_groups(check_render=True, check_video=False)
+            self.group_check_printed = True
+
+        ###########################################
+        # amd-smi memory (no args - display)     #
+        ###########################################
+        if args.vram is None and args.gtt is None and not args.reset_gtt:
+            # Display current memory configuration
+            vram_col_width = 40
+            self.logger.table_header = ''.rjust(7)
+            current_header = "GPU_ID".ljust(8) + \
+                             "VRAM".ljust(vram_col_width) + \
+                             "GTT".ljust(13)
+            self.logger.table_header = current_header + self.logger.table_header.strip()
+
+            tabular_output = []
+
+            # Get TTM info once (it's system-wide)
+            gtt_display = "N/A"
+            try:
+                ttm_info = amdsmi_interface.amdsmi_get_ttm_info()
+                page_size = 4096
+                current_gb = (ttm_info['current_pages'] * page_size) / (1024 ** 3)
+                gtt_display = f"{current_gb:.2f} GB"
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                logging.debug("TTM pages_limit not available | %s", e.get_error_info())
+
+            for gpu_index, device in enumerate(args.gpu):
+                gpu_id = self.helpers.get_gpu_id_from_device_handle(device)
+
+                # VRAM Carveout (Dedicated GPU Memory)
+                try:
+                    uma_info = amdsmi_interface.amdsmi_get_gpu_uma_carveout_info(device)
+                    current_index = uma_info['current_index']
+
+                    # Display each option as a separate row, mark current with * at the beginning
+                    for opt_idx, opt in enumerate(uma_info['options']):
+                        if opt['index'] == current_index:
+                            vram_desc = f"* {opt['index']}: {opt['description']}".ljust(vram_col_width)
+                        else:
+                            vram_desc = f"  {opt['index']}: {opt['description']}".ljust(vram_col_width)
+
+                        tabular_output_dict = {
+                            "gpu_id": gpu_id if opt_idx == 0 else "",  # Only show GPU ID on first row
+                            "vram_carveout": vram_desc,
+                            "gtt": gtt_display if gpu_index == 0 and opt_idx == 0 else ""
+                        }
+                        tabular_output.append(tabular_output_dict)
+
+                except amdsmi_exception.AmdSmiLibraryException as e:
+                    logging.debug("UMA carveout not available for gpu %s | %s", gpu_id, e.get_error_info())
+                    # If UMA not available, show at least GTT
+                    tabular_output_dict = {
+                        "gpu_id": gpu_id,
+                        "vram_carveout": "N/A".ljust(vram_col_width),
+                        "gtt": gtt_display if gpu_index == 0 else ""
+                    }
+                    tabular_output.append(tabular_output_dict)
+
+            self.logger.multiple_device_output = tabular_output
+            self.logger.table_title = "MEMORY"
+            self.logger.print_output(multiple_device_enabled=True, tabular=True, dynamic=True)
+            self.logger.clear_multiple_devices_output()
+
+            return
+
+        ###########################################
+        # amd-smi memory --vram INDEX            #
+        ###########################################
+        if args.vram is not None:
+            # Only set on one GPU at a time
+            if len(args.gpu) > 1:
+                self.logger.store_output(args.gpu[0], 'vram_carveout',
+                    "VRAM carveout setting applies per-GPU. Please specify a single GPU with --gpu")
+                self.logger.print_output()
+                self.logger.clear_multiple_devices_output()
+                return
+
+            args.gpu = args.gpu[0]
+
+            # Get UMA carveout info using library function
+            try:
+                uma_info = amdsmi_interface.amdsmi_get_gpu_uma_carveout_info(args.gpu)
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED:
+                    self.logger.store_output(args.gpu, 'vram_carveout', "VRAM carveout not available on this GPU")
+                else:
+                    self.logger.store_output(args.gpu, 'vram_carveout', f"[{e.get_error_info(detailed=False)}] Unable to get UMA carveout info")
+                self.logger.print_output()
+                self.logger.clear_multiple_devices_output()
+                return
+
+            # Validate the index
+            requested_index = args.vram
+            if requested_index >= uma_info['num_options']:
+                options_list = [f"{opt['index']}: {opt['description']}" for opt in uma_info['options']]
+                self.logger.store_output(args.gpu, 'vram_carveout',
+                    f"Invalid carveout index {requested_index}. Valid options:\n\t" + "\n\t".join(options_list))
+                self.logger.print_output()
+                self.logger.clear_multiple_devices_output()
+                return
+
+            # Check if already set
+            current_index = uma_info['current_index']
+            if current_index == requested_index:
+                selected_option = uma_info['options'][requested_index]
+                self.logger.store_output(args.gpu, 'vram_carveout',
+                    f"VRAM carveout is already set to {requested_index}: {selected_option['description']}")
+                self.logger.print_output()
+                self.logger.clear_multiple_devices_output()
+                return
+
+            # Set using library function
+            try:
+                amdsmi_interface.amdsmi_set_gpu_uma_carveout(args.gpu, requested_index)
+                selected_option = uma_info['options'][requested_index]
+                self.logger.store_output(args.gpu, 'vram_carveout',
+                    f"Successfully set VRAM carveout to {requested_index}: {selected_option['description']}\n" +
+                    "**REBOOT REQUIRED** for changes to take effect")
+                self.logger.print_output()
+                self.logger.clear_multiple_devices_output()
+
+                # Prompt for reboot
+                self.helpers.prompt_reboot()
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
+                    self.logger.store_output(args.gpu, 'vram_carveout',
+                        "Permission denied. This command requires root/sudo privileges.")
+                else:
+                    self.logger.store_output(args.gpu, 'vram_carveout', f"[{e.get_error_info(detailed=False)}] Failed to set UMA carveout")
+                self.logger.print_output()
+                self.logger.clear_multiple_devices_output()
+
+            return
+
+        ###########################################
+        # amd-smi memory --gtt GB                #
+        ###########################################
+        if args.gtt is not None:
+            # GTT size setting (system-wide, not GPU-specific)
+            gb_value = args.gtt
+
+            # Convert GB to pages
+            pages = self.helpers.gb_to_pages(gb_value)
+
+            # Set using library function
+            try:
+                amdsmi_interface.amdsmi_set_ttm_pages_limit(pages)
+                message = f"Successfully configured GTT size to {gb_value:.2f} GB ({pages} pages)\n" + \
+                          "Configuration written to /etc/modprobe.d/ttm.conf"
+                # Check if dracut exists on PATH to inform user about initramfs rebuild
+                if shutil.which("dracut") is not None:
+                    message += "\nInitramfs rebuilt with dracut"
+                message += "\n**REBOOT REQUIRED** for changes to take effect"
+                self.logger.store_output(args.gpu[0], 'gtt_size', message)
+                self.logger.print_output()
+                self.logger.clear_multiple_devices_output()
+
+                # Prompt for reboot
+                self.helpers.prompt_reboot()
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
+                    self.logger.store_output(args.gpu[0], 'gtt_size',
+                        "Permission denied. This command requires root/sudo privileges.")
+                else:
+                    self.logger.store_output(args.gpu[0], 'gtt_size', f"[{e.get_error_info(detailed=False)}] Failed to set TTM pages limit")
+                self.logger.print_output()
+                self.logger.clear_multiple_devices_output()
+
+            return
+
+        ###########################################
+        # amd-smi memory --reset-gtt             #
+        ###########################################
+        if args.reset_gtt:
+            # GTT reset (system-wide, not GPU-specific)
+
+            # Reset using library function
+            try:
+                amdsmi_interface.amdsmi_reset_ttm_pages_limit()
+                message = "Successfully reset GTT to system default\n" + \
+                          "Configuration file /etc/modprobe.d/ttm.conf removed"
+                # Check if dracut exists on PATH to inform user about initramfs rebuild
+                if shutil.which("dracut") is not None:
+                    message += "\nInitramfs rebuilt with dracut"
+                message += "\n**REBOOT REQUIRED** for changes to take effect"
+                self.logger.store_output(args.gpu[0], 'gtt_reset', message)
+                self.logger.print_output()
+                self.logger.clear_multiple_devices_output()
+
+                # Prompt for reboot
+                self.helpers.prompt_reboot()
+            except amdsmi_exception.AmdSmiLibraryException as e:
+                if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
+                    self.logger.store_output(args.gpu[0], 'gtt_reset',
+                        "Permission denied. This command requires root/sudo privileges.")
+                else:
+                    self.logger.store_output(args.gpu[0], 'gtt_reset', f"[{e.get_error_info(detailed=False)}] Failed to reset TTM pages limit")
+                self.logger.print_output()
+                self.logger.clear_multiple_devices_output()
+
+            return
 
 
     def ras(self, args, multiple_devices=False, gpu=None, cper=None, afid=None,

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -1448,6 +1448,45 @@ class AMDSMIHelpers():
         return valid_clock_input, input_clock_type
 
 
+    # Memory Size Management Helper Functions (using library functions)
+
+    def gb_to_pages(self, gb):
+        """Convert GB to pages.
+
+        Args:
+            gb: Size in gigabytes (float)
+
+        Returns:
+            int: Number of pages
+        """
+        page_size = 4096
+        bytes_value = gb * (1024 ** 3)
+        return int(bytes_value / page_size)
+
+    def confirm_reboot_required_warning(self, auto_respond=False):
+        """Print warning that a reboot is required and prompt user.
+
+        Args:
+            auto_respond: Response to automatically provide for all prompts
+        """
+        print('''
+            ******WARNING******
+
+            This operation requires a system reboot to take effect.
+
+            Please save all your work before proceeding.
+            You will need to manually reboot the system after this operation completes.
+            ''')
+        if not auto_respond:
+            user_input = input('Do you want to continue? [y/n] ')
+        else:
+            user_input = auto_respond
+        if user_input in ['y', 'Y', 'yes', 'Yes', 'YES']:
+            return
+        else:
+            sys.exit('Confirmation not given. Exiting without making changes')
+
+
     def confirm_out_of_spec_warning(self, auto_respond=False):
         """ Print the warning for running outside of specification and prompt user to accept the terms.
 
@@ -2756,3 +2795,65 @@ class AMDSMIHelpers():
                     "message": error_msg
                 }
             return error_msg
+
+    def prompt_reboot(self):
+        """Prompt user to reboot and execute if confirmed
+
+        Returns:
+            bool: True if reboot was successful or user declined, False on error
+        """
+        try:
+            response = input("Would you like to reboot the system now? (y/n): ").strip().lower()
+            if response in ("y", "yes"):
+                return self._reboot_system()
+            return True
+        except (KeyboardInterrupt, EOFError):
+            print()  # New line after Ctrl+C
+            return True
+
+    def _reboot_system(self):
+        """Reboot the system using logind D-Bus interface
+
+        Returns:
+            bool: True if reboot initiated successfully, False otherwise
+        """
+        # Try systemd logind first (modern systems)
+        if self._reboot_logind():
+            return True
+
+        # Fallback to systemctl/reboot command
+        print("D-Bus reboot failed, falling back to systemctl...")
+        import subprocess
+        try:
+            subprocess.run(["systemctl", "reboot"], check=True)
+            return True
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            try:
+                subprocess.run(["reboot"], check=True)
+                return True
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                print("Failed to initiate reboot. Please reboot manually.")
+                return False
+
+    def _reboot_logind(self):
+        """Reboot using systemd-logind D-Bus interface
+
+        Returns:
+            bool: True if reboot initiated successfully, False otherwise
+        """
+        # Try dbus library (most common)
+        try:
+            import dbus
+            bus = dbus.SystemBus()
+            obj = bus.get_object("org.freedesktop.login1", "/org/freedesktop/login1")
+            intf = dbus.Interface(obj, "org.freedesktop.login1.Manager")
+            intf.Reboot(True)  # True = interactive authentication
+            # Give the system a brief moment to begin shutting down before continuing
+            time.sleep(5)
+            return True
+        except ImportError:
+            pass
+        except (dbus.DBusException, OSError, RuntimeError) as e:
+            logging.debug(f"D-Bus reboot failed: {e}")
+
+        return False

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -70,7 +70,7 @@ class AMDSMIParser(argparse.ArgumentParser):
     """
     def __init__(self, version, list, static, firmware, bad_pages, metric,
                  process, profile, event, topology, set_value, reset, monitor,
-                 xgmi, partition, ras, node, rocm_smi, default, sys_argv=None,
+                 xgmi, partition, ras, node, memory, _rocm_smi, default, sys_argv=None,
                  helpers=None):
 
         # Helper variables
@@ -144,7 +144,7 @@ class AMDSMIParser(argparse.ArgumentParser):
         self.possible_commands = ['version', 'list', 'static', 'firmware', 'ucode', 'bad-pages',
                                   'metric', 'process', 'profile', 'event', 'topology', 'set',
                                   'reset', 'monitor', 'dmon', 'xgmi', 'partition', 'ras',
-                                  'node', 'default']
+                                  'node', 'memory', 'default']
 
         # Add all subparsers
         if sys_argv is not None:
@@ -166,6 +166,7 @@ class AMDSMIParser(argparse.ArgumentParser):
                 self._add_partition_parser(self.subparsers, partition)
                 self._add_ras_parser(self.subparsers, ras)
                 self._add_node_parser(self.subparsers, node)
+                self._add_memory_parser(self.subparsers, memory)
             elif any(arg in sys_argv for arg in ['version']):
                 self._add_version_parser(self.subparsers, version)
             elif any(arg in sys_argv for arg in ['list']):
@@ -200,6 +201,8 @@ class AMDSMIParser(argparse.ArgumentParser):
                 self._add_ras_parser(self.subparsers, ras)
             elif any(arg in sys_argv for arg in ['node']):
                 self._add_node_parser(self.subparsers, node)
+            elif any(arg in sys_argv for arg in ['memory']):
+                self._add_memory_parser(self.subparsers, memory)
             else:
                 # If no subcommand is given, add the default parser
                 self._add_default_parser(self.subparsers, default)
@@ -227,6 +230,23 @@ class AMDSMIParser(argparse.ArgumentParser):
             raise amdsmi_cli_exceptions.AmdSmiMissingParameterValueException(sub_arg, outputformat)
         else:
             raise amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(sys.argv[1], int_value, outputformat)
+
+
+    def _positive_float(self, float_value, sub_arg=None):
+        # Argument type validator for positive float values
+        try:
+            value = float(float_value)
+            if value > 0:
+                return value
+        except ValueError:
+            # Non-numeric values are handled via custom CLI exceptions below
+            pass
+
+        outputformat = self.helpers.get_output_format()
+        if float_value == "":
+            raise amdsmi_cli_exceptions.AmdSmiMissingParameterValueException(sub_arg, outputformat)
+        else:
+            raise amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(sys.argv[1], float_value, outputformat)
 
 
     def _is_valid_string(self, string_value, sub_arg=None):
@@ -1750,6 +1770,42 @@ class AMDSMIParser(argparse.ArgumentParser):
         # Add Universal Arguments
         self._add_device_arguments(partition_parser, required=False)
         self._add_command_modifiers(partition_parser)
+
+
+    def _add_memory_parser(self, subparsers: argparse._SubParsersAction, func):
+        if not self.helpers.is_amdgpu_initialized():
+            # The memory subcommand is only applicable to systems with amdgpu initialized
+            return
+
+        # Subparser help text
+        memory_help = "Display and configure GPU memory settings"
+        memory_subcommand_help = f"{self.description}\n\nManage VRAM carveout (dedicated GPU memory) and GTT (shared GPU memory) settings.\
+                                \nWithout arguments, displays current memory configuration.\
+                                \nSetting memory values requires system reboot to take effect."
+        memory_optionals_title = "Memory arguments"
+
+        # Options help text
+        vram_help = "Set VRAM carveout size by option index. Use without arguments to see available options."
+        gtt_help = "Set GTT (shared GPU memory) size in GB."
+        reset_gtt_help = "Reset GTT (shared GPU memory) to system default."
+
+        # Create memory subparser
+        memory_parser = subparsers.add_parser('memory', help=memory_help, description=memory_subcommand_help)
+        memory_parser._optionals.title = memory_optionals_title
+        memory_parser.formatter_class = AMDSMISubparserHelpFormatter
+        memory_parser.set_defaults(func=func)
+
+        # Handle Memory Options
+        memory_parser.add_argument('-v', '--vram', action='store', type=lambda value: self._not_negative_int(value, '--vram'),
+                                  required=False, help=vram_help, metavar='INDEX')
+        memory_parser.add_argument('-t', '--gtt', action='store', type=lambda value: self._positive_float(value, '--gtt'),
+                                  required=False, help=gtt_help, metavar='GB')
+        memory_parser.add_argument('-r', '--reset-gtt', action='store_true',
+                                  required=False, help=reset_gtt_help)
+
+        # Add Universal Arguments
+        self._add_device_arguments(memory_parser, required=False)
+        self._add_command_modifiers(memory_parser)
 
 
     def _add_ras_parser(self, subparsers: argparse._SubParsersAction, func):

--- a/projects/amdsmi/goamdsmi.go
+++ b/projects/amdsmi/goamdsmi.go
@@ -30,6 +30,7 @@ package goamdsmi
 #include <amdsmi_go_shim.h>
 */
 import "C"
+import "unsafe"
 
 // ``GO_gpu_init`` initializes the GPU and reports whether the initialization was
 // successful. This function must be called before using other AMD SMI
@@ -721,4 +722,119 @@ func GO_cpu_socket_power_cap_get(i int) (C.uint32_t) {
 //   }
 func GO_cpu_prochot_status_get(i int) (C.uint32_t) {
 	return C.goamdsmi_cpu_prochot_status_get(C.uint(i))
+}
+
+// ``GO_gpu_uma_carveout_info_get`` retrieves the UMA carveout configuration
+// information for the specified GPU device.
+//
+// Input parameters:
+//   - ``device_index int``: GPU device index
+//   - ``current_index *uint32``: pointer to store current carveout option index
+//   - ``num_options *uint32``: pointer to store number of available options
+//   - ``options *[16][256]byte``: pointer to array for option descriptions
+//
+// Output: ``int32``, returns ``0`` on success or ``-1`` on fail.
+//
+// Example:
+//
+//   import "github.com/ROCm/amdsmi"
+//
+//   if true == goamdsmi.GO_gpu_init() {
+//       var currentIdx, numOpts uint32
+//       var opts [16][256]byte
+//       ret := goamdsmi.GO_gpu_uma_carveout_info_get(0, &currentIdx, &numOpts, &opts)
+//       if ret == 0 {
+//           // Process UMA carveout info...
+//       }
+//   }
+func GO_gpu_uma_carveout_info_get(device_index int, current_index *uint32, num_options *uint32, options *[16][256]byte) int32 {
+	return int32(C.goamdsmi_gpu_uma_carveout_info_get(
+		C.uint32_t(device_index),
+		(*C.uint32_t)(current_index),
+		(*C.uint32_t)(num_options),
+		(*[16][256]C.char)(unsafe.Pointer(options))))
+}
+
+// ``GO_gpu_uma_carveout_set`` sets the UMA carveout size for the specified GPU
+// device by option index. Requires system reboot to take effect.
+//
+// Input parameters:
+//   - ``device_index int``: GPU device index
+//   - ``option_index uint32``: carveout option index to set
+//
+// Output: ``int32``, returns ``0`` on success or ``-1`` on fail.
+//
+// Example:
+//
+//   import "github.com/ROCm/amdsmi"
+//
+//   if true == goamdsmi.GO_gpu_init() {
+//       ret := goamdsmi.GO_gpu_uma_carveout_set(0, 3)
+//       if ret == 0 {
+//           // UMA carveout set successfully, reboot required
+//       }
+//   }
+func GO_gpu_uma_carveout_set(device_index int, option_index uint32) int32 {
+	return int32(C.goamdsmi_gpu_uma_carveout_set(C.uint32_t(device_index), C.uint32_t(option_index)))
+}
+
+// ``GO_ttm_info_get`` retrieves the TTM (shared GPU memory) pages limit.
+// This is a system-wide setting, not per-GPU.
+//
+// Input parameter:
+//   - ``current_pages *uint64``: pointer to store current TTM pages limit
+//
+// Output: ``int32``, returns ``0`` on success or ``-1`` on fail.
+//
+// Example:
+//
+//   import "github.com/ROCm/amdsmi"
+//
+//   var pages uint64
+//   ret := goamdsmi.GO_ttm_info_get(&pages)
+//   if ret == 0 {
+//       // Process TTM pages info...
+//   }
+func GO_ttm_info_get(current_pages *uint64) int32 {
+	return int32(C.goamdsmi_ttm_info_get((*C.uint64_t)(current_pages)))
+}
+
+// ``GO_ttm_pages_limit_set`` sets the TTM (shared GPU memory) pages limit.
+// This is a system-wide setting, not per-GPU. Requires system reboot to take effect.
+//
+// Input parameter:
+//   - ``pages uint64``: TTM pages limit to set
+//
+// Output: ``int32``, returns ``0`` on success or ``-1`` on fail.
+//
+// Example:
+//
+//   import "github.com/ROCm/amdsmi"
+//
+//   ret := goamdsmi.GO_ttm_pages_limit_set(3104239)
+//   if ret == 0 {
+//       // TTM pages limit set successfully, reboot required
+//   }
+func GO_ttm_pages_limit_set(pages uint64) int32 {
+	return int32(C.goamdsmi_ttm_pages_limit_set(C.uint64_t(pages)))
+}
+
+// ``GO_ttm_pages_limit_reset`` resets the TTM (shared GPU memory) pages limit
+// to its default value.
+//
+// This is a system-wide setting, not per-GPU. A system reboot may be required
+// for the change to take effect.
+//
+// Output: ``int32``, returns ``0`` on success or ``-1`` on fail.
+//
+// Example:
+//
+//   import "github.com/ROCm/amdsmi"
+//
+//   ret := goamdsmi.GO_ttm_pages_limit_reset()
+//   if ret == 0 {
+//       // TTM pages limit reset successfully, reboot may be required
+//   }
+func GO_ttm_pages_limit_reset() int32 {
+	return int32(C.goamdsmi_ttm_pages_limit_reset())
 }

--- a/projects/amdsmi/goamdsmi_shim/smiwrapper/amdsmi_go_shim.c
+++ b/projects/amdsmi/goamdsmi_shim/smiwrapper/amdsmi_go_shim.c
@@ -659,3 +659,131 @@ uint64_t goamdsmi_gpu_dev_gpu_memory_total_get(uint32_t dv_ind)
 
     return gpu_memory_total;
 }
+
+int32_t goamdsmi_gpu_uma_carveout_info_get(uint32_t dv_ind, uint32_t* current_index, uint32_t* num_options, char options[][256])
+{
+    amdsmi_uma_carveout_info_t uma_info;
+    amdsmi_status_t status;
+
+    if (dv_ind >= num_gpu_devices_inAllSocket) {
+        if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {
+            printf("AMDSMI, Failed for Gpu:%d (invalid device index)\n", dv_ind);
+        }
+        return -1;
+    }
+
+    status = amdsmi_get_gpu_uma_carveout_info(amdsmi_processor_handle_all_gpu_device_across_socket[dv_ind], &uma_info);
+
+    if (status != AMDSMI_STATUS_SUCCESS) {
+        if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {
+            printf("AMDSMI, Failed for Gpu:%d, Status:%d\n", dv_ind, status);
+        }
+        return -1;
+    }
+
+    *current_index = uma_info.current_index;
+    *num_options = uma_info.num_options;
+
+    for (uint32_t i = 0; i < uma_info.num_options && i < 16; i++) {
+        strncpy(options[i], uma_info.options[i].description, 255);
+        options[i][255] = '\0';
+    }
+
+    if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {
+        printf("AMDSMI, Success for Gpu:%d, CurrentIndex:%u, NumOptions:%u\n",
+               dv_ind, uma_info.current_index, uma_info.num_options);
+    }
+
+    return 0;
+}
+
+int32_t goamdsmi_gpu_uma_carveout_set(uint32_t dv_ind, uint32_t option_index)
+{
+    amdsmi_status_t status;
+
+    if (dv_ind >= num_gpu_devices_inAllSocket) {
+        if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {
+            printf("AMDSMI, Failed for Gpu:%d (invalid device index)\n", dv_ind);
+        }
+        return -1;
+    }
+
+    status = amdsmi_set_gpu_uma_carveout(amdsmi_processor_handle_all_gpu_device_across_socket[dv_ind], option_index);
+
+    if (status != AMDSMI_STATUS_SUCCESS) {
+        if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {
+            printf("AMDSMI, Failed for Gpu:%d, OptionIndex:%u, Status:%d\n", dv_ind, option_index, status);
+        }
+        return -1;
+    }
+
+    if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {
+        printf("AMDSMI, Success for Gpu:%d, OptionIndex:%u\n", dv_ind, option_index);
+    }
+
+    return 0;
+}
+
+int32_t goamdsmi_ttm_info_get(uint64_t* current_pages)
+{
+    amdsmi_ttm_info_t ttm_info;
+    amdsmi_status_t status;
+
+    status = amdsmi_get_ttm_info(&ttm_info);
+
+    if (status != AMDSMI_STATUS_SUCCESS) {
+        if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {
+            printf("AMDSMI, Failed to get TTM info, Status:%d\n", status);
+        }
+        return -1;
+    }
+
+    *current_pages = ttm_info.current_pages;
+
+    if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {
+        printf("AMDSMI, Success, CurrentPages:%llu\n", (unsigned long long)ttm_info.current_pages);
+    }
+
+    return 0;
+}
+
+int32_t goamdsmi_ttm_pages_limit_set(uint64_t pages)
+{
+    amdsmi_status_t status;
+
+    status = amdsmi_set_ttm_pages_limit(pages);
+
+    if (status != AMDSMI_STATUS_SUCCESS) {
+        if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {
+            printf("AMDSMI, Failed to set TTM pages limit, Pages:%llu, Status:%d\n",
+                   (unsigned long long)pages, status);
+        }
+        return -1;
+    }
+
+    if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {
+        printf("AMDSMI, Success, Pages:%llu\n", (unsigned long long)pages);
+    }
+
+    return 0;
+}
+
+int32_t goamdsmi_ttm_pages_limit_reset(void)
+{
+    amdsmi_status_t status;
+
+    status = amdsmi_reset_ttm_pages_limit();
+
+    if (status != AMDSMI_STATUS_SUCCESS) {
+        if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {
+            printf("AMDSMI, Failed to reset TTM pages limit, Status:%d\n", status);
+        }
+        return -1;
+    }
+
+    if (enable_debug_level(GOAMDSMI_DEBUG_LEVEL_1)) {
+        printf("AMDSMI, Success resetting TTM pages limit\n");
+    }
+
+    return 0;
+}

--- a/projects/amdsmi/goamdsmi_shim/smiwrapper/amdsmi_go_shim.h
+++ b/projects/amdsmi/goamdsmi_shim/smiwrapper/amdsmi_go_shim.h
@@ -22,6 +22,7 @@
  */
 
 #include "goamdsmi.h"
+#include <stdint.h>
 ////////////////////////////////////////////////------------CPU------------////////////////////////////////////////////////
 /**
  *  @brief Go language stub to initialize the AMDSMI library
@@ -557,3 +558,75 @@ uint64_t goamdsmi_gpu_dev_gpu_memory_usage_get(uint32_t dv_ind);
  *
  */
 uint64_t goamdsmi_gpu_dev_gpu_memory_total_get(uint32_t dv_ind);
+
+/**
+ *  @brief Go language stub to get UMA carveout information
+ *
+ *  @details This function will call the amdsmi_get_gpu_uma_carveout_info()
+ *  function to get the current UMA carveout configuration and available options.
+ *
+ *  @param[in] dv_ind is the device index
+ *  @param[out] current_index current carveout option index
+ *  @param[out] num_options number of available carveout options
+ *  @param[out] options array of option descriptions (up to 16 options, 256 chars each)
+ *
+ *  @retval ::int32_t 0 on success, -1 on failure
+ *
+ */
+int32_t goamdsmi_gpu_uma_carveout_info_get(uint32_t dv_ind, uint32_t* current_index,
+                                           uint32_t* num_options, char options[][256]);
+
+/**
+ *  @brief Go language stub to set UMA carveout size
+ *
+ *  @details This function will call the amdsmi_set_gpu_uma_carveout()
+ *  function to set the UMA carveout size by option index.
+ *  Requires system reboot to take effect.
+ *
+ *  @param[in] dv_ind is the device index
+ *  @param[in] option_index the carveout option index to set
+ *
+ *  @retval ::int32_t 0 on success, -1 on failure
+ *
+ */
+int32_t goamdsmi_gpu_uma_carveout_set(uint32_t dv_ind, uint32_t option_index);
+
+/**
+ *  @brief Go language stub to get TTM (shared GPU memory) information
+ *
+ *  @details This function will call the amdsmi_get_ttm_info()
+ *  function to get the current TTM pages limit. This is system-wide,
+ *  not per-GPU.
+ *
+ *  @param[out] current_pages current TTM pages limit
+ *
+ *  @retval ::int32_t 0 on success, -1 on failure
+ *
+ */
+int32_t goamdsmi_ttm_info_get(uint64_t* current_pages);
+
+/**
+ *  @brief Go language stub to set TTM (shared GPU memory) pages limit
+ *
+ *  @details This function will call the amdsmi_set_ttm_pages_limit()
+ *  function to set the TTM pages limit. This is system-wide, not per-GPU.
+ *  Requires system reboot to take effect.
+ *
+ *  @param[in] pages the pages limit to set
+ *
+ *  @retval ::int32_t 0 on success, -1 on failure
+ *
+ */
+int32_t goamdsmi_ttm_pages_limit_set(uint64_t pages);
+
+/**
+ *  @brief Go language stub to reset TTM pages limit to system default
+ *
+ *  @details This function will call the amdsmi_reset_ttm_pages_limit()
+ *  function to reset the TTM pages limit to system default. This is
+ *  system-wide, not per-GPU. Requires system reboot to take effect.
+ *
+ *  @retval ::int32_t 0 on success, -1 on failure
+ *
+ */
+int32_t goamdsmi_ttm_pages_limit_reset(void);

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -8028,6 +8028,130 @@ amdsmi_status_t amdsmi_get_nic_rdma_port_statistics(amdsmi_processor_handle proc
 
 /** @} End tagNicInfo */
 
+/*****************************************************************************/
+/** @defgroup MemConfig Memory Configuration
+ *  These functions are used to configure UMA (Unified Memory Architecture)
+ *  carveout and TTM (Translation Table Manager) settings.
+ *  @{
+ */
+
+/**
+ * UMA carveout option descriptor
+ */
+typedef struct {
+    uint32_t index;                             /**< Option index */
+    char description[AMDSMI_MAX_STRING_LENGTH]; /**< Human-readable description */
+} amdsmi_uma_carveout_option_t;
+
+/**
+ * UMA carveout configuration information
+ */
+typedef struct {
+    uint32_t current_index;                     /**< Currently active carveout index */
+    uint32_t num_options;                       /**< Number of available options */
+    amdsmi_uma_carveout_option_t options[16];   /**< Available carveout options */
+} amdsmi_uma_carveout_info_t;
+
+/**
+ * TTM (Translation Table Manager) configuration information
+ */
+typedef struct {
+    uint64_t current_pages;                     /**< Current TTM pages limit */
+} amdsmi_ttm_info_t;
+
+/**
+ *  @brief Get UMA carveout configuration information
+ *
+ *  This function retrieves the current UMA (Unified Memory Architecture) carveout
+ *  configuration for the specified GPU. UMA carveout controls dedicated GPU memory
+ *  allocation on APU systems.
+ *
+ *  @platform{gpu_bm_linux}
+ *
+ *  @param[in] processor_handle GPU device handle
+ *  @param[out] info Pointer to receive UMA carveout information
+ *
+ *  @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on success
+ *          ::AMDSMI_STATUS_NOT_SUPPORTED if UMA carveout is not available on this device
+ *          ::AMDSMI_STATUS_INVAL if info is nullptr
+ */
+amdsmi_status_t amdsmi_get_gpu_uma_carveout_info(
+    amdsmi_processor_handle processor_handle,
+    amdsmi_uma_carveout_info_t *info);
+
+/**
+ *  @brief Set UMA carveout configuration
+ *
+ *  This function sets the UMA carveout configuration for the specified GPU.
+ *  The system must be rebooted for changes to take effect.
+ *
+ *  @platform{gpu_bm_linux}
+ *
+ *  @param[in] processor_handle GPU device handle
+ *  @param[in] option_index Index of the carveout option to set
+ *
+ *  @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on success
+ *          ::AMDSMI_STATUS_NOT_SUPPORTED if UMA carveout is not available on this device
+ *          ::AMDSMI_STATUS_NO_PERM if insufficient permissions
+ *          ::AMDSMI_STATUS_INVAL if option_index is out of range
+ */
+amdsmi_status_t amdsmi_set_gpu_uma_carveout(
+    amdsmi_processor_handle processor_handle,
+    uint32_t option_index);
+
+/**
+ *  @brief Get TTM configuration information
+ *
+ *  This function retrieves the current TTM (Translation Table Manager) pages limit.
+ *  TTM controls shared GPU memory (GTT) allocation.
+ *
+ *  @platform{gpu_bm_linux}
+ *
+ *  @param[out] info Pointer to receive TTM configuration information
+ *
+ *  @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on success
+ *          ::AMDSMI_STATUS_NOT_SUPPORTED if TTM configuration is not available
+ *          ::AMDSMI_STATUS_INVAL if info is nullptr
+ */
+amdsmi_status_t amdsmi_get_ttm_info(amdsmi_ttm_info_t *info);
+
+/**
+ *  @brief Set TTM pages limit
+ *
+ *  This function configures the TTM pages limit by creating/updating
+ *  /etc/modprobe.d/ttm.conf. The system must be rebooted for changes to take effect.
+ *
+ *  @platform{gpu_bm_linux}
+ *
+ *  @param[in] pages Number of pages to allocate for TTM
+ *
+ *  @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on success
+ *          ::AMDSMI_STATUS_NO_PERM if insufficient permissions
+ *          ::AMDSMI_STATUS_INVAL if pages is 0
+ */
+amdsmi_status_t amdsmi_set_ttm_pages_limit(uint64_t pages);
+
+/**
+ *  @brief Reset TTM pages limit to system default
+ *
+ *  This function resets the TTM pages limit to system default by removing
+ *  /etc/modprobe.d/ttm.conf. The system must be rebooted for changes to take effect.
+ *
+ *  @platform{gpu_bm_linux}
+ *
+ *  @return ::amdsmi_status_t
+ *          ::AMDSMI_STATUS_SUCCESS on success
+ *          ::AMDSMI_STATUS_NO_PERM if insufficient permissions
+ */
+amdsmi_status_t amdsmi_reset_ttm_pages_limit(void);
+
+/** @} End MemConfig */
+
+
 #ifdef __cplusplus
 }
 #endif  // __cplusplus

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_drm.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_drm.h
@@ -23,6 +23,7 @@
 #ifndef AMD_SMI_INCLUDE_IMPL_AMD_SMI_DRM_H_
 #define AMD_SMI_INCLUDE_IMPL_AMD_SMI_DRM_H_
 
+#include <libdrm/amdgpu_drm.h>
 #include <unistd.h>
 
 #include <vector>
@@ -32,7 +33,6 @@
 
 #include "amd_smi/amdsmi.h"
 #include "amd_smi/impl/amd_smi_lib_loader.h"
-#include "amd_smi/impl/amdgpu_drm.h"
 #include "amd_smi/impl/xf86drm.h"
 #include "amd_smi/impl/scoped_fd.h"
 

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -6760,3 +6760,101 @@ def amdsmi_get_gpu_busy_percent(processor_handle: processor_handle_t):
     gpu_busy_percent = ctypes.c_uint32(0)
     _check_res(amdsmi_wrapper.amdsmi_get_gpu_busy_percent(processor_handle, ctypes.byref(gpu_busy_percent)))
     return gpu_busy_percent.value
+
+
+# Memory Size Management Functions
+
+def amdsmi_get_gpu_uma_carveout_info(processor_handle: processor_handle_t):
+    """
+    Get UMA carveout information for a GPU.
+
+    Args:
+        processor_handle: GPU processor handle
+
+    Returns:
+        dict: Dictionary with 'current_index', 'num_options', and 'options' list
+
+    Raises:
+        AmdSmiParameterException: If processor_handle is invalid
+        AmdSmiException: If the function fails
+    """
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
+
+    info = amdsmi_wrapper.amdsmi_uma_carveout_info_t()
+    _check_res(amdsmi_wrapper.amdsmi_get_gpu_uma_carveout_info(processor_handle, ctypes.byref(info)))
+
+    # Convert to Python dict
+    result = {
+        'current_index': info.current_index,
+        'num_options': info.num_options,
+        'options': []
+    }
+
+    for i in range(info.num_options):
+        opt = {
+            'index': info.options[i].index,
+            'description': info.options[i].description.decode('utf-8') if isinstance(info.options[i].description, bytes) else info.options[i].description
+        }
+        result['options'].append(opt)
+
+    return result
+
+
+def amdsmi_set_gpu_uma_carveout(processor_handle: processor_handle_t, option_index: int):
+    """
+    Set UMA carveout size by option index.
+
+    Args:
+        processor_handle: GPU processor handle
+        option_index: Index of the carveout option to set
+
+    Raises:
+        AmdSmiParameterException: If processor_handle is invalid
+        AmdSmiException: If the function fails
+    """
+    if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
+
+    _check_res(amdsmi_wrapper.amdsmi_set_gpu_uma_carveout(processor_handle, option_index))
+
+
+def amdsmi_get_ttm_info():
+    """
+    Get Translation Table Manager (TTM) memory information.
+
+    Returns:
+        dict: Dictionary with 'current_pages'
+
+    Raises:
+        AmdSmiException: If the function fails
+    """
+    info = amdsmi_wrapper.amdsmi_ttm_info_t()
+    _check_res(amdsmi_wrapper.amdsmi_get_ttm_info(ctypes.byref(info)))
+
+    return {
+        'current_pages': info.current_pages
+    }
+
+
+def amdsmi_set_ttm_pages_limit(pages: int):
+    """
+    Set TTM memory limit in pages.
+
+    Args:
+        pages: Number of pages to set as TTM limit
+
+    Raises:
+        AmdSmiException: If the function fails
+    """
+    _check_res(amdsmi_wrapper.amdsmi_set_ttm_pages_limit(pages))
+
+
+def amdsmi_reset_ttm_pages_limit():
+    """
+    Reset TTM memory limit to system default.
+
+    Raises:
+        AmdSmiException: If the function fails
+    """
+    _check_res(amdsmi_wrapper.amdsmi_reset_ttm_pages_limit())

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -3088,6 +3088,41 @@ struct_amdsmi_cper_hdr_t._fields_ = [
 ]
 
 amdsmi_cper_hdr_t = struct_amdsmi_cper_hdr_t
+
+# UMA/TTM memory management structures
+class struct_amdsmi_uma_carveout_option_t(Structure):
+    pass
+
+struct_amdsmi_uma_carveout_option_t._pack_ = 1
+struct_amdsmi_uma_carveout_option_t._fields_ = [
+    ('index', ctypes.c_uint32),
+    ('description', ctypes.c_char * 256),
+]
+
+amdsmi_uma_carveout_option_t = struct_amdsmi_uma_carveout_option_t
+
+class struct_amdsmi_uma_carveout_info_t(Structure):
+    pass
+
+struct_amdsmi_uma_carveout_info_t._pack_ = 1
+struct_amdsmi_uma_carveout_info_t._fields_ = [
+    ('current_index', ctypes.c_uint32),
+    ('num_options', ctypes.c_uint32),
+    ('options', struct_amdsmi_uma_carveout_option_t * 16),
+]
+
+amdsmi_uma_carveout_info_t = struct_amdsmi_uma_carveout_info_t
+
+class struct_amdsmi_ttm_info_t(Structure):
+    pass
+
+struct_amdsmi_ttm_info_t._pack_ = 1
+struct_amdsmi_ttm_info_t._fields_ = [
+    ('current_pages', ctypes.c_uint64),
+]
+
+amdsmi_ttm_info_t = struct_amdsmi_ttm_info_t
+
 amdsmi_get_afids_from_cper = _libraries['libamd_smi.so'].amdsmi_get_afids_from_cper
 amdsmi_get_afids_from_cper.restype = amdsmi_status_t
 amdsmi_get_afids_from_cper.argtypes = [ctypes.POINTER(ctypes.c_char), uint32_t, ctypes.POINTER(ctypes.c_uint64), ctypes.POINTER(ctypes.c_uint32)]
@@ -3277,6 +3312,24 @@ amdsmi_get_gpu_ptl_formats.argtypes = [amdsmi_processor_handle, ctypes.POINTER(a
 amdsmi_set_gpu_ptl_formats = _libraries['libamd_smi.so'].amdsmi_set_gpu_ptl_formats
 amdsmi_set_gpu_ptl_formats.restype = amdsmi_status_t
 amdsmi_set_gpu_ptl_formats.argtypes = [amdsmi_processor_handle, amdsmi_ptl_data_format_t, amdsmi_ptl_data_format_t]
+
+# UMA/TTM memory management functions
+amdsmi_get_gpu_uma_carveout_info = _libraries['libamd_smi.so'].amdsmi_get_gpu_uma_carveout_info
+amdsmi_get_gpu_uma_carveout_info.restype = amdsmi_status_t
+amdsmi_get_gpu_uma_carveout_info.argtypes = [amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_uma_carveout_info_t)]
+amdsmi_set_gpu_uma_carveout = _libraries['libamd_smi.so'].amdsmi_set_gpu_uma_carveout
+amdsmi_set_gpu_uma_carveout.restype = amdsmi_status_t
+amdsmi_set_gpu_uma_carveout.argtypes = [amdsmi_processor_handle, ctypes.c_uint32]
+amdsmi_get_ttm_info = _libraries['libamd_smi.so'].amdsmi_get_ttm_info
+amdsmi_get_ttm_info.restype = amdsmi_status_t
+amdsmi_get_ttm_info.argtypes = [ctypes.POINTER(struct_amdsmi_ttm_info_t)]
+amdsmi_set_ttm_pages_limit = _libraries['libamd_smi.so'].amdsmi_set_ttm_pages_limit
+amdsmi_set_ttm_pages_limit.restype = amdsmi_status_t
+amdsmi_set_ttm_pages_limit.argtypes = [ctypes.c_uint64]
+amdsmi_reset_ttm_pages_limit = _libraries['libamd_smi.so'].amdsmi_reset_ttm_pages_limit
+amdsmi_reset_ttm_pages_limit.restype = amdsmi_status_t
+amdsmi_reset_ttm_pages_limit.argtypes = []
+
 amdsmi_get_cpu_core_energy = _libraries['libamd_smi.so'].amdsmi_get_cpu_core_energy
 amdsmi_get_cpu_core_energy.restype = amdsmi_status_t
 amdsmi_get_cpu_core_energy.argtypes = [amdsmi_processor_handle, ctypes.POINTER(ctypes.c_uint64)]

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 
 #include <cstdlib>
@@ -7915,3 +7916,298 @@ amdsmi_status_t amdsmi_get_dfc_ctrl(amdsmi_processor_handle processor_handle,
 }
 
 #endif
+
+amdsmi_status_t amdsmi_get_gpu_uma_carveout_info(
+    amdsmi_processor_handle processor_handle,
+    amdsmi_uma_carveout_info_t *info) {
+
+    AMDSMI_CHECK_INIT();
+
+    if (info == nullptr) {
+        return AMDSMI_STATUS_INVAL;
+    }
+
+    amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
+    amdsmi_status_t ret = get_gpu_device_from_handle(processor_handle, &gpu_device);
+    if (ret != AMDSMI_STATUS_SUCCESS) {
+        return ret;
+    }
+
+    SMIGPUDEVICE_MUTEX(gpu_device->get_mutex());
+
+    // Get GPU path for sysfs
+    std::string gpu_path = gpu_device->get_gpu_path();
+
+    // Construct sysfs paths for UMA carveout
+    std::string carveout_path = "/sys/class/drm/" + gpu_path + "/device/uma/carveout";
+    std::string options_path = "/sys/class/drm/" + gpu_path + "/device/uma/carveout_options";
+
+    // Check if UMA carveout is available
+    std::ifstream carveout_file(carveout_path);
+    if (!carveout_file.good()) {
+        return AMDSMI_STATUS_NOT_SUPPORTED;
+    }
+
+    // Read current carveout index
+    carveout_file >> info->current_index;
+    if (!carveout_file.good()) {
+        carveout_file.close();
+        return AMDSMI_STATUS_FILE_ERROR;
+    }
+    carveout_file.close();
+
+    // Read available options
+    std::ifstream options_file(options_path);
+    if (!options_file.good()) {
+        return AMDSMI_STATUS_FILE_ERROR;
+    }
+
+    info->num_options = 0;
+    std::string line;
+    while (std::getline(options_file, line) && info->num_options < 16) {
+        // Parse format: "0: Minimum (512 MB)" or "1:  (1 GB)"
+        size_t colon_pos = line.find(':');
+        if (colon_pos == std::string::npos) continue;
+
+        std::string index_str = line.substr(0, colon_pos);
+        std::string description = line.substr(colon_pos + 1);
+
+        // Trim leading whitespace from description
+        size_t first_non_space = description.find_first_not_of(" \t");
+        if (first_non_space != std::string::npos) {
+            description = description.substr(first_non_space);
+        }
+
+        uint32_t index = 0;
+        try {
+            size_t pos = 0;
+            unsigned long tmp = std::stoul(index_str, &pos, 10);
+            // Ensure the entire string was parsed and value fits in uint32_t
+            if (pos != index_str.length() ||
+                tmp > std::numeric_limits<uint32_t>::max()) {
+                continue;
+            }
+            index = static_cast<uint32_t>(tmp);
+        } catch (const std::invalid_argument&) {
+            // Malformed index; skip this line
+            continue;
+        } catch (const std::out_of_range&) {
+            // Index out of range; skip this line
+            continue;
+        }
+
+        info->options[info->num_options].index = index;
+
+        // Check for potential truncation before copying description
+        size_t description_len = description.length();
+        if (description_len >= AMDSMI_MAX_STRING_LENGTH) {
+            fprintf(stderr,
+                    "Warning: UMA carveout description for index %u is too long "
+                    "(%zu characters, max %d). It will be truncated.\n",
+                    index,
+                    description_len,
+                    AMDSMI_MAX_STRING_LENGTH - 1);
+        }
+
+        strncpy(info->options[info->num_options].description,
+                description.c_str(),
+                AMDSMI_MAX_STRING_LENGTH - 1);
+        info->options[info->num_options].description[AMDSMI_MAX_STRING_LENGTH - 1] = '\0';
+
+        info->num_options++;
+    }
+
+    options_file.close();
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_set_gpu_uma_carveout(
+    amdsmi_processor_handle processor_handle,
+    uint32_t option_index) {
+
+    AMDSMI_CHECK_INIT();
+
+    amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
+    amdsmi_status_t ret = get_gpu_device_from_handle(processor_handle, &gpu_device);
+    if (ret != AMDSMI_STATUS_SUCCESS) {
+        return ret;
+    }
+
+    SMIGPUDEVICE_MUTEX(gpu_device->get_mutex());
+
+    // Get GPU path for sysfs
+    std::string gpu_path = gpu_device->get_gpu_path();
+
+    // Construct sysfs path for UMA carveout
+    std::string carveout_path = "/sys/class/drm/" + gpu_path + "/device/uma/carveout";
+
+    // Check if UMA carveout is available
+    std::ifstream check_file(carveout_path);
+    if (!check_file.good()) {
+        return AMDSMI_STATUS_NOT_SUPPORTED;
+    }
+    check_file.close();
+
+    // Validate option_index is within range (regardless of DRY_RUN mode)
+    amdsmi_uma_carveout_info_t info;
+    ret = amdsmi_get_gpu_uma_carveout_info(processor_handle, &info);
+    if (ret != AMDSMI_STATUS_SUCCESS) {
+        return ret;
+    }
+
+    if (option_index >= info.num_options) {
+        return AMDSMI_STATUS_INVAL;
+    }
+
+    // Check for DRY_RUN mode
+    const char* dry_run = std::getenv("AMDSMI_DRY_RUN");
+    if (dry_run != nullptr && std::string(dry_run) == "1") {
+        std::cout << "[DRY_RUN] Would write UMA carveout index " << option_index
+                  << " to " << carveout_path << std::endl;
+        return AMDSMI_STATUS_SUCCESS;
+    }
+
+    // Write the new carveout index
+    std::ofstream carveout_file(carveout_path);
+    if (!carveout_file.good()) {
+        return AMDSMI_STATUS_NO_PERM;
+    }
+
+    carveout_file << option_index;
+    carveout_file.flush();
+    if (!carveout_file) {
+        carveout_file.close();
+        return AMDSMI_STATUS_FILE_ERROR;
+    }
+
+    carveout_file.close();
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_get_ttm_info(amdsmi_ttm_info_t *info) {
+
+    AMDSMI_CHECK_INIT();
+
+    if (info == nullptr) {
+        return AMDSMI_STATUS_INVAL;
+    }
+
+    // Read current TTM pages limit from sysfs
+    std::string ttm_path = "/sys/module/ttm/parameters/pages_limit";
+    std::ifstream ttm_file(ttm_path);
+
+    if (!ttm_file.good()) {
+        return AMDSMI_STATUS_NOT_SUPPORTED;
+    }
+
+    ttm_file >> info->current_pages;
+    if (ttm_file.fail()) {
+        ttm_file.close();
+        return AMDSMI_STATUS_FILE_ERROR;
+    }
+    ttm_file.close();
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_set_ttm_pages_limit(uint64_t pages) {
+
+    AMDSMI_CHECK_INIT();
+
+    if (pages == 0) {
+        return AMDSMI_STATUS_INVAL;
+    }
+
+    // Check for DRY_RUN mode
+    const char* dry_run = std::getenv("AMDSMI_DRY_RUN");
+    if (dry_run != nullptr && std::string(dry_run) == "1") {
+        std::string modprobe_path = "/etc/modprobe.d/ttm.conf";
+        std::cout << "[DRY_RUN] Would write to " << modprobe_path << ":" << std::endl;
+        std::cout << "[DRY_RUN]   options ttm pages_limit=" << pages << std::endl;
+
+        // Check if dracut is available
+        if (access("/usr/bin/dracut", X_OK) == 0 || access("/bin/dracut", X_OK) == 0 || access("/sbin/dracut", X_OK) == 0) {
+            std::cout << "[DRY_RUN] Would rebuild initramfs with: dracut -f" << std::endl;
+        }
+
+        return AMDSMI_STATUS_SUCCESS;
+    }
+
+    // Create/update modprobe configuration
+    std::string modprobe_path = "/etc/modprobe.d/ttm.conf";
+    std::ofstream modprobe_file(modprobe_path);
+
+    if (!modprobe_file.good()) {
+        return AMDSMI_STATUS_NO_PERM;
+    }
+
+    modprobe_file << "options ttm pages_limit=" << pages << std::endl;
+    modprobe_file.flush();
+    if (!modprobe_file) {
+        modprobe_file.close();
+        return AMDSMI_STATUS_FILE_ERROR;
+    }
+
+    modprobe_file.close();
+
+    // Check if dracut is available and rebuild initramfs
+    if (access("/usr/bin/dracut", X_OK) == 0 || access("/bin/dracut", X_OK) == 0 || access("/sbin/dracut", X_OK) == 0) {
+        int ret = system("dracut -f > /dev/null 2>&1");
+        if (ret != 0) {
+            // Log warning but don't fail - the modprobe.d file is written successfully
+            // The system will still work after reboot, just without initramfs update
+            std::cerr << "Warning: Failed to rebuild initramfs with dracut" << std::endl;
+        }
+    }
+
+    return AMDSMI_STATUS_SUCCESS;
+}
+
+amdsmi_status_t amdsmi_reset_ttm_pages_limit(void) {
+
+    AMDSMI_CHECK_INIT();
+
+    // Remove modprobe configuration to reset to default
+    std::string modprobe_path = "/etc/modprobe.d/ttm.conf";
+
+    // Check if file exists
+    if (access(modprobe_path.c_str(), F_OK) != 0) {
+        // File doesn't exist, nothing to do
+        return AMDSMI_STATUS_SUCCESS;
+    }
+
+    // Check for DRY_RUN mode
+    const char* dry_run = std::getenv("AMDSMI_DRY_RUN");
+    if (dry_run != nullptr && std::string(dry_run) == "1") {
+        std::cout << "[DRY_RUN] Would remove file: " << modprobe_path << std::endl;
+
+        // Check if dracut is available
+        if (access("/usr/bin/dracut", X_OK) == 0 || access("/bin/dracut", X_OK) == 0 || access("/sbin/dracut", X_OK) == 0) {
+            std::cout << "[DRY_RUN] Would rebuild initramfs with: dracut -f" << std::endl;
+        }
+
+        return AMDSMI_STATUS_SUCCESS;
+    }
+
+    // Try to remove the file
+    if (unlink(modprobe_path.c_str()) != 0) {
+        if (errno == EACCES || errno == EPERM) {
+            return AMDSMI_STATUS_NO_PERM;
+        }
+        return AMDSMI_STATUS_FILE_ERROR;
+    }
+
+    // Check if dracut is available and rebuild initramfs
+    if (access("/usr/bin/dracut", X_OK) == 0 || access("/bin/dracut", X_OK) == 0 || access("/sbin/dracut", X_OK) == 0) {
+        int ret = system("dracut -f > /dev/null 2>&1");
+        if (ret != 0) {
+            // Log warning but don't fail - the modprobe.d file is removed successfully
+            // The system will still work after reboot, just without initramfs update
+            std::cerr << "Warning: Failed to rebuild initramfs with dracut" << std::endl;
+        }
+    }
+
+    return AMDSMI_STATUS_SUCCESS;
+}

--- a/projects/amdsmi/tests/MEMORY_TESTS_README.md
+++ b/projects/amdsmi/tests/MEMORY_TESTS_README.md
@@ -1,0 +1,237 @@
+# Memory Management Tests
+
+This document describes the test coverage for AMD SMI memory management features (UMA carveout and TTM configuration).
+
+## Features Tested
+
+### 1. UMA Carveout (VRAM - Dedicated GPU Memory)
+- Reading current carveout configuration
+- Validating available options
+- Setting carveout index (DRY_RUN mode)
+
+### 2. TTM Configuration (GTT - Shared GPU Memory)
+- Reading current TTM pages limit
+- Setting TTM pages limit (DRY_RUN mode)
+- Resetting TTM to system default (DRY_RUN mode)
+
+## DRY_RUN Mode
+
+To enable comprehensive testing of write operations without actually modifying system configuration, all memory management write functions support a **DRY_RUN** mode.
+
+### How DRY_RUN Works
+
+When the `AMDSMI_DRY_RUN` environment variable is set to `1`:
+
+1. **All validation is performed** - The functions validate inputs, check permissions, and verify file existence
+2. **No files are modified** - System files (sysfs, /etc/modprobe.d/) are not written
+3. **No system commands run** - Commands like `dracut -f` are not executed
+4. **Status is printed** - Debug output shows what would have been done
+5. **Return codes are accurate** - Functions return the same status codes as real execution
+
+### Enabling DRY_RUN Mode
+
+#### Bash/Shell:
+```bash
+export AMDSMI_DRY_RUN=1
+amd-smi memory --vram 2  # Simulates setting VRAM carveout to index 2
+```
+
+#### Python:
+```python
+import os
+os.environ['AMDSMI_DRY_RUN'] = '1'
+amdsmi.amdsmi_set_gpu_uma_carveout(processor_handle, 2)
+```
+
+#### C++:
+```cpp
+setenv("AMDSMI_DRY_RUN", "1", 1);
+amdsmi_set_gpu_uma_carveout(processor_handle, 2);
+```
+
+### Disabling DRY_RUN Mode
+
+#### Bash/Shell:
+```bash
+unset AMDSMI_DRY_RUN
+```
+
+#### Python:
+```python
+del os.environ['AMDSMI_DRY_RUN']
+```
+
+#### C++:
+```cpp
+unsetenv("AMDSMI_DRY_RUN");
+```
+
+## Test Files
+
+### C++ Functional Tests (GTest)
+
+**Location:** `tests/amd_smi_test/functional/`
+
+**Files:**
+- `memory_read_write.h` - Test class definition
+- `memory_read_write.cc` - Test implementation
+
+**What's Tested:**
+- ✅ Read UMA carveout information
+- ✅ Validate carveout options structure
+- ✅ Set UMA carveout (DRY_RUN) - current value
+- ✅ Set UMA carveout (DRY_RUN) - different valid value
+- ✅ Set UMA carveout (DRY_RUN) - invalid value (expect failure)
+- ✅ Read TTM information
+- ✅ Validate TTM pages value
+- ✅ Set TTM pages limit (DRY_RUN) - current value
+- ✅ Set TTM pages limit (DRY_RUN) - different value
+- ✅ Set TTM pages limit (DRY_RUN) - invalid value (expect failure)
+- ✅ Reset TTM pages limit (DRY_RUN)
+
+**Running C++ Tests:**
+```bash
+cd build/tests/amd_smi_test
+./amdsmitst -v 1  # Run all tests
+```
+
+### Python Integration Tests
+
+**Location:** `tests/python_unittest/integration_test.py`
+
+**Test Functions:**
+- `test_uma_carveout_info()` - Read-only UMA carveout info test
+- `test_uma_carveout_set_dry_run()` - UMA carveout write operations (DRY_RUN)
+- `test_ttm_info()` - Read-only TTM info test
+- `test_ttm_set_dry_run()` - TTM write operations (DRY_RUN)
+
+**What's Tested:**
+- ✅ Read UMA carveout for all GPUs
+- ✅ Validate dictionary structure
+- ✅ Set UMA carveout (DRY_RUN) - various scenarios
+- ✅ Read TTM information
+- ✅ Set TTM pages limit (DRY_RUN) - various scenarios
+- ✅ Reset TTM (DRY_RUN)
+
+**Running Python Integration Tests:**
+```bash
+# All tests
+/opt/rocm/share/amd_smi/tests/python_unittest/integration_test.py -v
+
+# Memory tests only
+/opt/rocm/share/amd_smi/tests/python_unittest/integration_test.py -k "uma\|ttm" -v
+```
+
+### Python CLI Tests
+
+**Location:** `tests/python_unittest/cli_unit_test.py`
+
+**Test Function:**
+- `test_memory()` - CLI command testing (display mode only)
+
+**What's Tested:**
+- ✅ `amd-smi memory` - Display current configuration
+- ✅ `amd-smi memory --json` - JSON output format
+- ✅ `amd-smi memory --csv` - CSV output format
+- ✅ `amd-smi memory --help` - Help text
+
+**Note:** Write operations (--vram, --gtt, --reset-gtt) are not tested in automated CLI tests to avoid requiring root permissions and system reboots. Use DRY_RUN mode for testing these operations.
+
+**Running Python CLI Tests:**
+```bash
+# All CLI tests
+sudo /opt/rocm/share/amd_smi/tests/python_unittest/cli_unit_test.py -v
+
+# Memory tests only
+sudo /opt/rocm/share/amd_smi/tests/python_unittest/cli_unit_test.py -k "memory" -v
+```
+
+## Manual Testing (Real Write Operations)
+
+For testing actual write operations that modify system configuration:
+
+### Prerequisites
+- Root/sudo permissions
+- Ability to reboot the system
+- Backup of critical data
+
+### Test UMA Carveout
+
+```bash
+# View current configuration
+amd-smi memory
+
+# Change VRAM carveout to index 2 (example)
+sudo amd-smi memory --vram 2
+
+# Reboot required
+sudo reboot
+
+# After reboot, verify
+amd-smi memory
+```
+
+### Test GTT Configuration
+
+```bash
+# View current configuration
+amd-smi memory
+
+# Set GTT to 12 GB (example)
+sudo amd-smi memory --gtt 12
+
+# Reboot required
+sudo reboot
+
+# After reboot, verify
+amd-smi memory
+
+# Reset to default
+sudo amd-smi memory --reset-gtt
+
+# Reboot required
+sudo reboot
+```
+
+## Test Coverage Summary
+
+| Feature | Read | Write (DRY_RUN) | Write (Real) |
+|---------|------|-----------------|--------------|
+| UMA Carveout Info | ✅ Automated | ✅ Automated | ⚠️ Manual Only |
+| UMA Carveout Set | - | ✅ Automated | ⚠️ Manual Only |
+| TTM Info | ✅ Automated | ✅ Automated | ⚠️ Manual Only |
+| TTM Set | - | ✅ Automated | ⚠️ Manual Only |
+| TTM Reset | - | ✅ Automated | ⚠️ Manual Only |
+
+**Legend:**
+- ✅ Automated - Runs in CI/CD and automated test suites
+- ⚠️ Manual Only - Requires manual testing due to system modification requirements
+
+## Benefits of DRY_RUN Mode
+
+1. **No Root Required** - Tests can run without elevated permissions
+2. **No Reboot Required** - Tests don't require system restart
+3. **Safe for CI/CD** - Can run in automated pipelines without affecting test systems
+4. **Full Code Coverage** - Exercises all code paths including validation and error handling
+5. **Developer Friendly** - Easy to test changes without risk to development system
+6. **Fast Feedback** - Get immediate test results without waiting for reboots
+
+## Example DRY_RUN Output
+
+```bash
+$ export AMDSMI_DRY_RUN=1
+
+$ amd-smi memory --vram 2
+[DRY_RUN] Would write UMA carveout index 2 to /sys/class/drm/card0/device/uma/carveout
+Successfully set VRAM carveout to 2: (4 GB)
+**REBOOT REQUIRED** for changes to take effect
+
+$ amd-smi memory --gtt 12
+[DRY_RUN] Would write to /etc/modprobe.d/ttm.conf:
+[DRY_RUN]   options ttm pages_limit=3145728
+[DRY_RUN] Would rebuild initramfs with: dracut -f
+Successfully configured GTT size to 12.00 GB (3145728 pages)
+Configuration written to /etc/modprobe.d/ttm.conf
+Initramfs rebuilt with dracut
+**REBOOT REQUIRED** for changes to take effect
+```

--- a/projects/amdsmi/tests/amd_smi_test/functional/memory_read_write.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/memory_read_write.cc
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "memory_read_write.h"
+
+#include <gtest/gtest.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <cstring>
+#include <iostream>
+#include <string>
+
+#include "amd_smi/amdsmi.h"
+
+TestMemoryReadWrite::TestMemoryReadWrite() : TestBase() {
+  set_title("AMDSMI Memory Configuration Read/Write Test");
+  set_description(
+      "The Memory Configuration tests verify that "
+      "UMA carveout and TTM configuration can be read and written properly.");
+}
+
+TestMemoryReadWrite::~TestMemoryReadWrite(void) {}
+
+void TestMemoryReadWrite::SetUp(void) {
+  TestBase::SetUp();
+
+  return;
+}
+
+void TestMemoryReadWrite::DisplayTestInfo(void) { TestBase::DisplayTestInfo(); }
+
+void TestMemoryReadWrite::DisplayResults(void) const {
+  TestBase::DisplayResults();
+  return;
+}
+
+void TestMemoryReadWrite::Close() {
+  // This will close handles opened within amdsmitst utility calls and call
+  // amdsmi_shut_down(), so it should be done after other hsa cleanup
+  TestBase::Close();
+}
+
+void TestMemoryReadWrite::Run(void) {
+  amdsmi_status_t err;
+
+  TestBase::Run();
+  if (setup_failed_) {
+    std::cout << "** SetUp Failed for this test. Skipping.**" << std::endl;
+    return;
+  }
+
+  // Test UMA Carveout (per-GPU)
+  IF_VERB(STANDARD) { std::cout << "\n=== Testing UMA Carveout (VRAM) ===" << std::endl; }
+
+  for (uint32_t i = 0; i < num_monitor_devs(); ++i) {
+    PrintDeviceHeader(processor_handles_[i]);
+
+    amdsmi_uma_carveout_info_t uma_info;
+    memset(&uma_info, 0, sizeof(uma_info));
+
+    err = amdsmi_get_gpu_uma_carveout_info(processor_handles_[i], &uma_info);
+    if (err == AMDSMI_STATUS_NOT_SUPPORTED) {
+      IF_VERB(STANDARD) {
+        std::cout << "\t**UMA Carveout not supported on this device." << std::endl;
+      }
+      ASSERT_EQ(err, AMDSMI_STATUS_NOT_SUPPORTED);
+      continue;
+    }
+
+    CHK_ERR_ASRT(err)
+
+    IF_VERB(STANDARD) {
+      std::cout << "\t**Current UMA Carveout Index: " << uma_info.current_index << std::endl;
+      std::cout << "\t**Number of Options: " << uma_info.num_options << std::endl;
+
+      for (uint32_t j = 0; j < uma_info.num_options; ++j) {
+        std::cout << "\t  Option " << uma_info.options[j].index << ": "
+                  << uma_info.options[j].description << std::endl;
+      }
+    }
+
+    // Validate that current_index is within valid range
+    ASSERT_LT(uma_info.current_index, uma_info.num_options);
+
+    // Validate that num_options is reasonable (should be > 0 if supported)
+    ASSERT_GT(uma_info.num_options, 0u);
+    ASSERT_LE(uma_info.num_options, 16u);  // Max array size
+
+    // Validate that option indices are sequential
+    for (uint32_t j = 0; j < uma_info.num_options; ++j) {
+      ASSERT_EQ(uma_info.options[j].index, j);
+    }
+
+    // Validate that descriptions are not empty
+    for (uint32_t j = 0; j < uma_info.num_options; ++j) {
+      ASSERT_GT(strlen(uma_info.options[j].description), 0u);
+    }
+
+    // Test setting UMA carveout in DRY_RUN mode
+    IF_VERB(STANDARD) {
+      std::cout << "\t**Testing set UMA carveout in DRY_RUN mode..." << std::endl;
+    }
+
+    // Enable DRY_RUN mode for testing
+    setenv("AMDSMI_DRY_RUN", "1", 1);
+
+    // Test setting to current value (should succeed)
+    err = amdsmi_set_gpu_uma_carveout(processor_handles_[i], uma_info.current_index);
+    CHK_ERR_ASRT(err)
+    IF_VERB(STANDARD) { std::cout << "\t  Set to current index succeeded (DRY_RUN)" << std::endl; }
+
+    // Test setting to a different valid index if available
+    if (uma_info.num_options > 1) {
+      uint32_t test_index = (uma_info.current_index + 1) % uma_info.num_options;
+      err = amdsmi_set_gpu_uma_carveout(processor_handles_[i], test_index);
+      CHK_ERR_ASRT(err)
+      IF_VERB(STANDARD) {
+        std::cout << "\t  Set to different index " << test_index << " succeeded (DRY_RUN)"
+                  << std::endl;
+      }
+    }
+
+    // Test setting to invalid index (should fail with AMDSMI_STATUS_INVAL)
+    err = amdsmi_set_gpu_uma_carveout(processor_handles_[i], uma_info.num_options + 10);
+    ASSERT_EQ(err, AMDSMI_STATUS_INVAL);
+    IF_VERB(STANDARD) {
+      std::cout << "\t  Invalid index correctly rejected (DRY_RUN)" << std::endl;
+    }
+
+    // Disable DRY_RUN mode
+    unsetenv("AMDSMI_DRY_RUN");
+  }
+
+  // Test TTM Configuration (system-wide)
+  IF_VERB(STANDARD) {
+    std::cout << "\n=== Testing TTM Configuration (GTT/Shared Memory) ===" << std::endl;
+  }
+
+  amdsmi_ttm_info_t ttm_info;
+  memset(&ttm_info, 0, sizeof(ttm_info));
+
+  err = amdsmi_get_ttm_info(&ttm_info);
+  if (err == AMDSMI_STATUS_NOT_SUPPORTED) {
+    IF_VERB(STANDARD) {
+      std::cout << "\t**TTM pages_limit not supported on this system." << std::endl;
+    }
+    ASSERT_EQ(err, AMDSMI_STATUS_NOT_SUPPORTED);
+  } else {
+    CHK_ERR_ASRT(err)
+
+    IF_VERB(STANDARD) {
+      std::cout << "\t**Current TTM Pages Limit: " << ttm_info.current_pages << " pages"
+                << std::endl;
+
+      // Convert to GB for display (page size = 4096 bytes)
+      const uint64_t page_size = 4096;
+      double gb =
+          (static_cast<double>(ttm_info.current_pages) * page_size) / (1024.0 * 1024.0 * 1024.0);
+      std::cout << "\t**Current TTM Size: " << gb << " GB" << std::endl;
+    }
+
+    // Validate that pages value is reasonable
+    ASSERT_GT(ttm_info.current_pages, 0u);
+
+    // Test TTM write operations in DRY_RUN mode
+    IF_VERB(STANDARD) {
+      std::cout << "\t**Testing TTM write operations in DRY_RUN mode..." << std::endl;
+    }
+
+    // Enable DRY_RUN mode for testing
+    setenv("AMDSMI_DRY_RUN", "1", 1);
+
+    // Test setting TTM pages limit to current value
+    err = amdsmi_set_ttm_pages_limit(ttm_info.current_pages);
+    CHK_ERR_ASRT(err)
+    IF_VERB(STANDARD) {
+      std::cout << "\t  Set TTM to current value succeeded (DRY_RUN)" << std::endl;
+    }
+
+    // Test setting TTM to a different value
+    uint64_t test_pages = ttm_info.current_pages / 2;
+    if (test_pages > 0) {
+      err = amdsmi_set_ttm_pages_limit(test_pages);
+      CHK_ERR_ASRT(err)
+      IF_VERB(STANDARD) {
+        std::cout << "\t  Set TTM to different value succeeded (DRY_RUN)" << std::endl;
+      }
+    }
+
+    // Test setting TTM to 0 (should fail with AMDSMI_STATUS_INVAL)
+    err = amdsmi_set_ttm_pages_limit(0);
+    ASSERT_EQ(err, AMDSMI_STATUS_INVAL);
+    IF_VERB(STANDARD) {
+      std::cout << "\t  Invalid pages value (0) correctly rejected (DRY_RUN)" << std::endl;
+    }
+
+    // Test resetting TTM pages limit
+    err = amdsmi_reset_ttm_pages_limit();
+    CHK_ERR_ASRT(err)
+    IF_VERB(STANDARD) { std::cout << "\t  Reset TTM succeeded (DRY_RUN)" << std::endl; }
+
+    // Disable DRY_RUN mode
+    unsetenv("AMDSMI_DRY_RUN");
+  }
+
+  IF_VERB(STANDARD) { std::cout << "\n=== Memory Configuration Tests Completed ===" << std::endl; }
+}

--- a/projects/amdsmi/tests/amd_smi_test/functional/memory_read_write.h
+++ b/projects/amdsmi/tests/amd_smi_test/functional/memory_read_write.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TESTS_AMD_SMI_TEST_FUNCTIONAL_MEMORY_READ_WRITE_H_
+#define TESTS_AMD_SMI_TEST_FUNCTIONAL_MEMORY_READ_WRITE_H_
+
+#include "../test_base.h"
+
+class TestMemoryReadWrite : public TestBase {
+ public:
+  TestMemoryReadWrite();
+
+  // @Brief: Destructor for test case of TestMemoryReadWrite
+  virtual ~TestMemoryReadWrite();
+
+  // @Brief: Setup the environment for measurement
+  virtual void SetUp();
+
+  // @Brief: Core measurement execution
+  virtual void Run();
+
+  // @Brief: Clean up and retrieve the resource
+  virtual void Close();
+
+  // @Brief: Display  results
+  virtual void DisplayResults() const;
+
+  // @Brief: Display information about what this test does
+  virtual void DisplayTestInfo(void);
+};
+
+#endif  // TESTS_AMD_SMI_TEST_FUNCTIONAL_MEMORY_READ_WRITE_H_

--- a/projects/amdsmi/tests/amd_smi_test/main.cc
+++ b/projects/amdsmi/tests/amd_smi_test/main.cc
@@ -46,6 +46,7 @@
 #include "functional/mem_page_info_read.h"
 #include "functional/frequencies_read.h"
 #include "functional/frequencies_read_write.h"
+#include "functional/memory_read_write.h"
 #include "functional/overdrive_read.h"
 #include "functional/overdrive_read_write.h"
 #include "functional/temp_read.h"
@@ -282,6 +283,11 @@ TEST(amdsmitstReadWrite, TestEvtNotifReadWrite) {
 
 TEST(amdsmitstReadOnly, TestGPUCacheRead) {
   TestGPUCacheRead tst;
+  RunGenericTest(&tst);
+}
+
+TEST(amdsmitstReadWrite, TestMemoryReadWrite) {
+  TestMemoryReadWrite tst;
   RunGenericTest(&tst);
 }
 /*

--- a/projects/amdsmi/tests/python_unittest/cli_unit_test.py
+++ b/projects/amdsmi/tests/python_unittest/cli_unit_test.py
@@ -1174,6 +1174,49 @@ class TestAmdSmiCli(unittest.TestCase):
         self.RunCmds(cmds)
         return
 
+    def test_memory(self):
+        """Test memory command (display mode only - no write operations in automated tests)"""
+        self.common.print_func_name('')
+        msg = f'{self.tab}### amd-smi memory'
+        self.common.print(msg)
+
+        # Test display mode (no arguments - read-only)
+        cmd = 'amd-smi memory'
+        (rc, data, std_err) = self.util.RunCmdSync(cmd)
+        self.assertEqual(rc, self.PASS, f"Command '{cmd}' failed with rc={rc}")
+
+        # Test display mode with JSON output
+        cmd = 'amd-smi memory --json'
+        (rc, data, std_err) = self.util.RunCmdSync(cmd)
+        self.assertEqual(rc, self.PASS, f"Command '{cmd}' failed with rc={rc}")
+        if data:
+            try:
+                json_data = json.loads(data)
+                self.assertIsInstance(json_data, (list, dict))
+            except json.JSONDecodeError:
+                self.fail(f"Invalid JSON output for command '{cmd}'")
+
+        # Test display mode with CSV output
+        cmd = 'amd-smi memory --csv'
+        (rc, data, std_err) = self.util.RunCmdSync(cmd)
+        self.assertEqual(rc, self.PASS, f"Command '{cmd}' failed with rc={rc}")
+
+        # Test help
+        cmd = 'amd-smi memory --help'
+        (rc, data, std_err) = self.util.RunCmdSync(cmd)
+        self.assertEqual(rc, self.PASS, f"Command '{cmd}' failed with rc={rc}")
+        self.assertIn('memory', data.lower())
+
+        # Note: We do NOT test --vram, --gtt, or --reset-gtt in automated tests because:
+        # 1. They require root/sudo permissions
+        # 2. They require system reboot to take effect
+        # 3. They could interfere with the test system configuration
+        # These options should be tested manually or in dedicated integration test environments
+
+        msg = f'{self.tab}Memory command tests passed (display mode only)'
+        self.common.print(msg)
+        return
+
 
 if __name__ == '__main__':
     verbose=1

--- a/projects/amdsmi/tests/python_unittest/integration_test.py
+++ b/projects/amdsmi/tests/python_unittest/integration_test.py
@@ -1384,6 +1384,180 @@ class TestAmdSmiPythonInterface(unittest.TestCase):
     #         # t3.join()
     #     print("\n========> test_z_gpureset_asicinfo_multithread end <========\n")
 
+    def test_uma_carveout_info(self):
+        """Test UMA carveout (VRAM) information retrieval"""
+        processors = amdsmi.amdsmi_get_processor_handles()
+        self.assertGreaterEqual(len(processors), 1)
+        self.assertLessEqual(len(processors), self.max_num_physical_devices)
+
+        for i in range(0, len(processors)):
+            bdf = amdsmi.amdsmi_get_gpu_device_bdf(processors[i])
+            print(f"\n\n###Test Processor {i}, bdf: {bdf}")
+
+            try:
+                print("\n###Test amdsmi_get_gpu_uma_carveout_info \n")
+                uma_info = amdsmi.amdsmi_get_gpu_uma_carveout_info(processors[i])
+            except amdsmi.AmdSmiLibraryException as e:
+                self._check_exception(e)
+                continue
+
+            # Validate returned data structure
+            self.assertIn('current_index', uma_info)
+            self.assertIn('num_options', uma_info)
+            self.assertIn('options', uma_info)
+
+            print(f"  current_index: {uma_info['current_index']}")
+            print(f"  num_options: {uma_info['num_options']}")
+
+            # Validate that current_index is within valid range
+            self.assertGreaterEqual(uma_info['current_index'], 0)
+            self.assertLess(uma_info['current_index'], uma_info['num_options'])
+
+            # Validate that we have at least one option
+            self.assertGreater(uma_info['num_options'], 0)
+            self.assertLessEqual(uma_info['num_options'], 16)
+
+            # Validate options list
+            self.assertEqual(len(uma_info['options']), uma_info['num_options'])
+
+            for j, opt in enumerate(uma_info['options']):
+                self.assertIn('index', opt)
+                self.assertIn('description', opt)
+                self.assertEqual(opt['index'], j)
+                self.assertGreater(len(opt['description']), 0)
+
+                marker = "*" if opt['index'] == uma_info['current_index'] else " "
+                print(f"  {marker} Option {opt['index']}: {opt['description']}")
+
+            print("\n  UMA carveout info test passed\n")
+
+    def test_uma_carveout_set_dry_run(self):
+        """Test UMA carveout write operations in DRY_RUN mode"""
+        processors = amdsmi.amdsmi_get_processor_handles()
+        self.assertGreaterEqual(len(processors), 1)
+        self.assertLessEqual(len(processors), self.max_num_physical_devices)
+
+        # Enable DRY_RUN mode
+        os.environ['AMDSMI_DRY_RUN'] = '1'
+
+        for i in range(0, len(processors)):
+            bdf = amdsmi.amdsmi_get_gpu_device_bdf(processors[i])
+            print(f"\n\n###Test Processor {i}, bdf: {bdf}")
+
+            try:
+                print("\n###Test amdsmi_set_gpu_uma_carveout (DRY_RUN)\n")
+                uma_info = amdsmi.amdsmi_get_gpu_uma_carveout_info(processors[i])
+            except amdsmi.AmdSmiLibraryException as e:
+                self._check_exception(e)
+                continue
+
+            # Test setting to current value
+            try:
+                amdsmi.amdsmi_set_gpu_uma_carveout(processors[i], uma_info['current_index'])
+                print(f"  Set to current index {uma_info['current_index']} succeeded (DRY_RUN)")
+            except amdsmi.AmdSmiLibraryException as e:
+                self.fail(f"Failed to set UMA carveout to current value in DRY_RUN mode: {e}")
+
+            # Test setting to different valid index if available
+            if uma_info['num_options'] > 1:
+                test_index = (uma_info['current_index'] + 1) % uma_info['num_options']
+                try:
+                    amdsmi.amdsmi_set_gpu_uma_carveout(processors[i], test_index)
+                    print(f"  Set to different index {test_index} succeeded (DRY_RUN)")
+                except amdsmi.AmdSmiLibraryException as e:
+                    self.fail(f"Failed to set UMA carveout to valid index in DRY_RUN mode: {e}")
+
+            # Test setting to invalid index (should fail)
+            invalid_index = uma_info['num_options'] + 10
+            try:
+                amdsmi.amdsmi_set_gpu_uma_carveout(processors[i], invalid_index)
+                self.fail(f"Should have raised exception for invalid index {invalid_index}")
+            except amdsmi.AmdSmiLibraryException as e:
+                error_code = e.get_error_code()
+                self.assertEqual(error_code, amdsmi.amdsmi_wrapper.AMDSMI_STATUS_INVAL)
+                print(f"  Invalid index {invalid_index} correctly rejected (DRY_RUN)")
+
+            print("\n  UMA carveout set test passed (DRY_RUN)\n")
+
+        # Disable DRY_RUN mode
+        del os.environ['AMDSMI_DRY_RUN']
+
+    def test_ttm_info(self):
+        """Test TTM (GTT/shared memory) information retrieval"""
+        print("\n\n###Test amdsmi_get_ttm_info \n")
+
+        try:
+            ttm_info = amdsmi.amdsmi_get_ttm_info()
+        except amdsmi.AmdSmiLibraryException as e:
+            self._check_exception(e)
+            return
+
+        # Validate returned data structure
+        self.assertIn('current_pages', ttm_info)
+
+        print(f"  current_pages: {ttm_info['current_pages']}")
+
+        # Validate that pages value is reasonable (> 0)
+        self.assertGreater(ttm_info['current_pages'], 0)
+
+        # Convert to GB for display
+        page_size = 4096
+        gb = (ttm_info['current_pages'] * page_size) / (1024 ** 3)
+        print(f"  TTM size: {gb:.2f} GB")
+
+        print("\n  TTM info test passed\n")
+
+    def test_ttm_set_dry_run(self):
+        """Test TTM write operations in DRY_RUN mode"""
+        print("\n\n###Test TTM write operations (DRY_RUN)\n")
+
+        # Get current TTM info first
+        try:
+            ttm_info = amdsmi.amdsmi_get_ttm_info()
+        except amdsmi.AmdSmiLibraryException as e:
+            self._check_exception(e)
+            return
+
+        # Enable DRY_RUN mode
+        os.environ['AMDSMI_DRY_RUN'] = '1'
+
+        # Test setting TTM pages limit to current value
+        try:
+            amdsmi.amdsmi_set_ttm_pages_limit(ttm_info['current_pages'])
+            print(f"  Set TTM to current value ({ttm_info['current_pages']} pages) succeeded (DRY_RUN)")
+        except amdsmi.AmdSmiLibraryException as e:
+            self.fail(f"Failed to set TTM to current value in DRY_RUN mode: {e}")
+
+        # Test setting TTM to a different value
+        test_pages = ttm_info['current_pages'] // 2
+        if test_pages > 0:
+            try:
+                amdsmi.amdsmi_set_ttm_pages_limit(test_pages)
+                print(f"  Set TTM to different value ({test_pages} pages) succeeded (DRY_RUN)")
+            except amdsmi.AmdSmiLibraryException as e:
+                self.fail(f"Failed to set TTM to different value in DRY_RUN mode: {e}")
+
+        # Test setting TTM to 0 (should fail)
+        try:
+            amdsmi.amdsmi_set_ttm_pages_limit(0)
+            self.fail("Should have raised exception for pages=0")
+        except amdsmi.AmdSmiLibraryException as e:
+            error_code = e.get_error_code()
+            self.assertEqual(error_code, amdsmi.amdsmi_wrapper.AMDSMI_STATUS_INVAL)
+            print("  Invalid pages value (0) correctly rejected (DRY_RUN)")
+
+        # Test resetting TTM pages limit
+        try:
+            amdsmi.amdsmi_reset_ttm_pages_limit()
+            print("  Reset TTM succeeded (DRY_RUN)")
+        except amdsmi.AmdSmiLibraryException as e:
+            self.fail(f"Failed to reset TTM in DRY_RUN mode: {e}")
+
+        # Disable DRY_RUN mode
+        del os.environ['AMDSMI_DRY_RUN']
+
+        print("\n  TTM write operations test passed (DRY_RUN)\n")
+
 
 def print_test_ids(suite):
     for test in suite:


### PR DESCRIPTION
Introduce a new command `amd-smi memory` which is used for viewing what VRAM and GTT settings are for a machine.

Systems that support VRAM tuning (such as APUs) can have the value of the carveout changed.  It is changed using the sysfs interface present in Linux kernel 6.20+.

All systems can have GTT tuning set to override the kernel policy. The default kernel policy is 50% if it hasn't been modified. Options are stored in the sysfs file `/etc/modprobe.d/ttm.conf`.

# Sample output

Get information on system that supports VRAM tuning
```
$ /opt/rocm/bin/amd-smi memory
MEMORY:
GPU_ID  VRAM                                    GTT          
0         0: Minimum (512 MB)                   26.16 GB
        * 1: (1 GB)
          2: (2 GB)
          3: (4 GB)
          4: (6 GB)
          5: (8 GB)
          6: (12 GB)
          7: Medium (16 GB)
          8: (24 GB)
          9: High (32 GB)
```

Apply vram tuning without privs
```
$ /opt/rocm/bin/amd-smi memory -v 0
GPU: 0
    VRAM_CARVEOUT: Permission denied. This command requires root/sudo privileges.
```

Apply VRAM tuning with privs
```
$ sudo /opt/rocm/bin/amd-smi memory -v 0
[sudo: authenticate] Password: 
GPU: 0
    VRAM_CARVEOUT: Successfully set VRAM carveout to 0: Minimum (512 MB)
**REBOOT REQUIRED** for changes to take effect

Would you like to reboot the system now? (y/n): y
$ Read from remote host 10.236.51.196: Connection reset by peer
Connection to 10.236.51.196 closed.
```

VRAM tuning not supported:
```
$ /opt/rocm/bin/amd-smi memory 
MEMORY:
GPU_ID  VRAM                                    GTT          
0       8.0 GB                                  30.36 GB
```