### PR TITLE
Enable CTest tag-based test filtering

### DIFF
--- a/projects/hip-tests/catch/cmake/hip-tests.cmake
+++ b/projects/hip-tests/catch/cmake/hip-tests.cmake
@@ -116,7 +116,13 @@ function(hip_gen_exe_target)
     endforeach()
     # add binary to global list of binaries to install
     set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS ${_EXE_NAME})
-    catch_discover_tests("${_EXE_NAME}" DISCOVERY_MODE PRE_TEST PROPERTIES SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST")
+    catch_discover_tests(
+      "${_EXE_NAME}"
+      DISCOVERY_MODE PRE_TEST
+      ADD_TAGS_AS_LABELS
+      PROPERTIES
+        SKIP_REGULAR_EXPRESSION "HIP_SKIP_THIS_TEST"
+    )
     file(GLOB CTEST_INC_FILES "${CMAKE_CURRENT_BINARY_DIR}/${_EXE_NAME}-*_include.cmake")
     set_property(GLOBAL APPEND PROPERTY G_INSTALL_CTEST_INCLUDE_FILES ${CTEST_INC_FILES})
 

--- a/projects/hip-tests/catch/hipTestMain/config/hip_tests_config.yaml
+++ b/projects/hip-tests/catch/hipTestMain/config/hip_tests_config.yaml
@@ -17,7 +17,7 @@ definitions:
     level: 0
   level_1: &level_1
     level: 1
-  level_2: &level_2
+  level_2: &level_2 
     level: 2
   level_3: &level_3
     level: 3
@@ -60,7 +60,7 @@ cmd_options:
     memory_sizes: [1K, 1M, 10M]
     block_sizes: [64, 256]
     max_memory: 1G
-
+  
   # Level 1 - Standard Tests
   level_1:
     <<: *default_cmd_options
@@ -69,14 +69,14 @@ cmd_options:
     memory_sizes: [1K, 4K, 64K, 1M, 10M, 50M, 100M]
     block_sizes: [32, 64, 128, 256, 512, 1024]
     max_memory: 4G
-
+  
   # Level 2 - Comprehensive Tests
   level_2:
     <<: *default_cmd_options
     memory_sizes: [64, 256, 1K, 4K, 16K, 64K, 256K, 1M, 10M, 50M, 100M, 500M, 1G, 2G]
     block_sizes: [32, 64, 96, 128, 192, 256, 384, 512, 768, 1024]
     max_memory: 8G
-
+  
   # Level 5 - Performance/Stress Tests
   level_5:
     <<: *default_cmd_options
@@ -87,13 +87,10 @@ cmd_options:
 unit:
   assertion:
     Unit_StaticAssert_Positive_Basic_RTC:
-      tags: [device_lib, assert]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/210
       disabled: [amd_windows]
-    Unit_StaticAssert_Negative_Basic_RTC:
-      <<: *level_2
-      tags: [device_lib, assert]
+    Unit_StaticAssert_Negative_Basic_RTC: *level_2
     Unit_Assert_Positive_Basic_KernelPass: *level_2
     Unit_Assert_Positive_Basic_KernelFail:
       <<: *level_2
@@ -106,9 +103,7 @@ unit:
     Unit_atomicAnd_Positive_Multi_Kernel_Same_Address: *level_2
     Unit_atomicAnd_Positive_Multi_Kernel_Adjacent_Addresses: *level_2
     Unit_atomicAnd_Positive_Multi_Kernel_Scattered_Addresses: *level_2
-    Unit_atomicAnd_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, ops]
+    Unit_atomicAnd_Negative_Parameters_RTC: *level_2
     Unit_atomicAnd_system_Positive_Peer_GPUs_Same_Address:
       <<: *level_2
       tags: [multigpu]
@@ -124,9 +119,7 @@ unit:
     Unit_atomicOr_Positive_Multi_Kernel_Same_Address: *level_2
     Unit_atomicOr_Positive_Multi_Kernel_Adjacent_Addresses: *level_2
     Unit_atomicOr_Positive_Multi_Kernel_Scattered_Addresses: *level_2
-    Unit_atomicOr_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, ops]
+    Unit_atomicOr_Negative_Parameters_RTC: *level_2
     Unit_atomicOr_system_Positive_Peer_GPUs_Same_Address:
       <<: *level_2
       tags: [multigpu]
@@ -142,9 +135,7 @@ unit:
     Unit_atomicXor_Positive_Multi_Kernel_Same_Address: *level_2
     Unit_atomicXor_Positive_Multi_Kernel_Adjacent_Addresses: *level_2
     Unit_atomicXor_Positive_Multi_Kernel_Scattered_Addresses: *level_2
-    Unit_atomicXor_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, ops]
+    Unit_atomicXor_Negative_Parameters_RTC: *level_2
     Unit_atomicXor_system_Positive_Peer_GPUs_Same_Address:
       <<: *level_2
       tags: [multigpu]
@@ -160,9 +151,7 @@ unit:
     Unit_atomicMin_Positive_Multi_Kernel_Same_Address: *level_2
     Unit_atomicMin_Positive_Multi_Kernel_Adjacent_Addresses: *level_2
     Unit_atomicMin_Positive_Multi_Kernel_Scattered_Addresses: *level_2
-    Unit_atomicMin_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, ops]
+    Unit_atomicMin_Negative_Parameters_RTC: *level_2
     Unit_atomicMin_system_Positive_Peer_GPUs_Same_Address:
       <<: *level_2
       tags: [multigpu]
@@ -178,9 +167,7 @@ unit:
     Unit_atomicMax_Positive_Multi_Kernel_Same_Address: *level_2
     Unit_atomicMax_Positive_Multi_Kernel_Adjacent_Addresses: *level_2
     Unit_atomicMax_Positive_Multi_Kernel_Scattered_Addresses: *level_2
-    Unit_atomicMax_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, ops]
+    Unit_atomicMax_Negative_Parameters_RTC: *level_2
     Unit_atomicMax_system_Positive_Peer_GPUs_Same_Address:
       <<: *level_2
       tags: [multigpu]
@@ -226,74 +213,30 @@ unit:
     Unit___hip_atomic_fetch_max_Positive_Workgroup_SameAddress: *level_2
     Unit___hip_atomic_fetch_max_Positive_Workgroup_Adjacent_Addresses: *level_2
     Unit___hip_atomic_fetch_max_Positive_Workgroup_Scattered_Addresses: *level_2
-    Unit_AtomicBuiltins_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, builtin]
-    Unit___hip_atomic_load_store_Positive_Acquire_Release:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_exchange_Positive_Acquire_Release:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_compare_exchange_strong_Positive_Acquire_Release:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_compare_exchange_weak_Positive_Acquire_Release:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_fetch_add_Positive_Acquire_Release:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_fetch_and_Positive_Acquire_Release:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_fetch_or_Positive_Acquire_Release:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_fetch_xor_Positive_Acquire_Release:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_fetch_min_Positive_Acquire_Release:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_fetch_max_Positive_Acquire_Release:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_load_store_Positive_Sequential_Consistency:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_exchange_Positive_Sequential_Consistency:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_compare_exchange_strong_Positive_Sequential_Consistency:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_compare_exchange_weak_Positive_Sequential_Consistency:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_fetch_add_Positive_Sequential_Consistency:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_fetch_and_Positive_Sequential_Consistency:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_fetch_or_Positive_Sequential_Consistency:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_fetch_xor_Positive_Sequential_Consistency:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_fetch_min_Positive_Sequential_Consistency:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
-    Unit___hip_atomic_fetch_max_Positive_Sequential_Consistency:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, memorder]
+    Unit_AtomicBuiltins_Negative_Parameters_RTC: *level_2
+    Unit___hip_atomic_load_store_Positive_Acquire_Release: *level_2
+    Unit___hip_atomic_exchange_Positive_Acquire_Release: *level_2
+    Unit___hip_atomic_compare_exchange_strong_Positive_Acquire_Release: *level_2
+    Unit___hip_atomic_compare_exchange_weak_Positive_Acquire_Release: *level_2
+    Unit___hip_atomic_fetch_add_Positive_Acquire_Release: *level_2
+    Unit___hip_atomic_fetch_and_Positive_Acquire_Release: *level_2
+    Unit___hip_atomic_fetch_or_Positive_Acquire_Release: *level_2
+    Unit___hip_atomic_fetch_xor_Positive_Acquire_Release: *level_2
+    Unit___hip_atomic_fetch_min_Positive_Acquire_Release: *level_2
+    Unit___hip_atomic_fetch_max_Positive_Acquire_Release: *level_2
+    Unit___hip_atomic_load_store_Positive_Sequential_Consistency: *level_2
+    Unit___hip_atomic_exchange_Positive_Sequential_Consistency: *level_2
+    Unit___hip_atomic_compare_exchange_strong_Positive_Sequential_Consistency: *level_2
+    Unit___hip_atomic_compare_exchange_weak_Positive_Sequential_Consistency: *level_2
+    Unit___hip_atomic_fetch_add_Positive_Sequential_Consistency: *level_2
+    Unit___hip_atomic_fetch_and_Positive_Sequential_Consistency: *level_2
+    Unit___hip_atomic_fetch_or_Positive_Sequential_Consistency: *level_2
+    Unit___hip_atomic_fetch_xor_Positive_Sequential_Consistency: *level_2
+    Unit___hip_atomic_fetch_min_Positive_Sequential_Consistency: *level_2
+    Unit___hip_atomic_fetch_max_Positive_Sequential_Consistency: *level_2
     Unit_atomicAdd_Positive: *level_2
     Unit_atomicAdd_Positive_Multi_Kernel: *level_2
-    Unit_atomicAdd_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, ops]
+    Unit_atomicAdd_Negative_Parameters_RTC: *level_2
     Unit_atomicAdd_system_Positive_Peer_GPUs:
       <<: *level_2
       tags: [multigpu]
@@ -308,13 +251,12 @@ unit:
     Unit_unsafeAtomicAdd_Positive: *level_2
     Unit_unsafeAtomicAdd_Positive_Multi_Kernel: *level_2
     Unit_unsafe_atomic_add_half_and_bfloat: *level_2
+    Unit_unsafe_atomic_add_half_and_bfloat: *level_2
     Unit_safeAtomicAdd_Positive: *level_2
     Unit_safeAtomicAdd_Positive_Multi_Kernel: *level_2
     Unit_atomicSub_Positive: *level_2
     Unit_atomicSub_Positive_Multi_Kernel: *level_2
-    Unit_atomicSub_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, ops]
+    Unit_atomicSub_Negative_Parameters_RTC: *level_2
     Unit_atomicSub_system_Positive_Peer_GPUs:
       <<: *level_2
       tags: [multigpu]
@@ -326,9 +268,7 @@ unit:
       tags: [multigpu]
     Unit_atomicCAS_Positive: *level_2
     Unit_atomicCAS_Positive_Multi_Kernel: *level_2
-    Unit_atomicCAS_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, ops]
+    Unit_atomicCAS_Negative_Parameters_RTC: *level_2
     Unit_atomicCAS_system_Positive_Peer_GPUs:
       <<: *level_2
       tags: [multigpu]
@@ -351,9 +291,7 @@ unit:
       <<: *level_2
       # SWDEV-435667: Below tests failing randomly in stress test on 01/12/23
       disabled: [amd_wsl]
-    Unit_atomicExch_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, ops]
+    Unit_atomicExch_Negative_Parameters_RTC: *level_2
     Unit_atomicExch_system_Positive_Peer_GPUs:
       <<: *level_2
       tags: [multigpu]
@@ -369,9 +307,7 @@ unit:
       tags: [multigpu]
       # SWDEV-435667: Below tests failing randomly in stress test on 01/12/23
       disabled: [amd_wsl]
-    Unit_atomicExch_system_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, system]
+    Unit_atomicExch_system_Negative_Parameters_RTC: *level_2
     Unit___hip_atomic_fetch_and_Positive_Wavefront_SameAddress: *level_2
     Unit___hip_atomic_fetch_and_Positive_Wavefront_Adjacent_Addresses: *level_2
     Unit___hip_atomic_fetch_and_Positive_Wavefront_Scattered_Addresses: *level_2
@@ -394,54 +330,34 @@ unit:
     Unit___hip_atomic_exchange_Positive_Workgroup: *level_2
     Unit_atomicInc_Positive: *level_2
     Unit_atomicInc_Positive_Multi_Kernel: *level_2
-    Unit_atomicInc_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, ops]
+    Unit_atomicInc_Negative_Parameters_RTC: *level_2
     Unit_atomicDec_Positive: *level_2
     Unit_atomicDec_Positive_Multi_Kernel: *level_2
-    Unit_atomicDec_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lib, device_lib, atomic, ops]
+    Unit_atomicDec_Negative_Parameters_RTC: *level_2
   c_compilation:
-    Unit_hipGetDeviceProp_ctest:
-      <<: *level_2
-      tags: [rtc, integration]
+    Unit_hipGetDeviceProp_ctest: *level_2
   callback:
-    Unit_hipApiName_Positive_Basic:
-      <<: *level_2
-      tags: [callback]
+    Unit_hipApiName_Positive_Basic: *level_2
     Unit_hipApiName_Negative_ReservedIds: *level_2
-    Unit_hipGetStreamDeviceId_Positive_Threaded_Basic:
-      <<: *level_2
-      tags: [callback]
+    Unit_hipGetStreamDeviceId_Positive_Threaded_Basic: *level_2
     Unit_hipGetStreamDeviceId_Positive_Multithreaded_Basic:
-      tags: [multigpu, callback]
       <<: *level_2
-    Unit_hipGetStreamDeviceId_Negative_Parameters:
-      <<: *level_2
-      tags: [callback]
+      tags: [multigpu]
+    Unit_hipGetStreamDeviceId_Negative_Parameters: *level_2
     Unit_hipKernelNameRef_Positive_Basic:
-      tags: [callback]
       <<: *level_2
       # (amd_windows) Note: intermittent Seg fault failure
       # (amd_wsl) Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipKernelNameRef_Negative_Parameters:
-      tags: [callback]
       <<: *level_2
       # (amd_windows) Note: intermittent Seg fault failure
       # (amd_wsl) Note: intermittent Seg fault failure
       # (amd_wsl) Note: Linux disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipKernelNameRefByPtr_Positive_Basic:
-      <<: *level_2
-      tags: [callback]
-    Unit_hipKernelNameRefByPtr_Negative_StreamNullptr:
-      <<: *level_2
-      tags: [callback]
-    Unit_hipKernelNameRefByPtr_Negative_KernelNullptr:
-      <<: *level_2
-      tags: [callback]
+    Unit_hipKernelNameRefByPtr_Positive_Basic: *level_2
+    Unit_hipKernelNameRefByPtr_Negative_StreamNullptr: *level_2
+    Unit_hipKernelNameRefByPtr_Negative_KernelNullptr: *level_2
   channelDescriptor:
     Unit_ChannelDescriptor_Positive_Basic_1D:
       <<: *level_2
@@ -461,60 +377,32 @@ unit:
       disabled: [nvidia_windows]
     Unit_ChannelDescriptor_Positive_FormatNone: *level_2
     Unit_ChannelDescriptor_Positive_16BitFloatingPoint:
-      tags: [texture]
       <<: *level_2
       # (amd_wsl) Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
   clock:
     Unit_hipClock64_Positive_Basic:
-      tags: [device_lib, timing]
       <<: *level_2
       # SWDEV-555665
       disabled: [amd_windows]
     Unit_hipClock_Positive_Basic:
-      tags: [device_lib, timing]
       <<: *level_2
       # SWDEV-555665
       disabled: [amd_windows]
-    Unit_hipWallClock64_Positive_Basic:
-      <<: *level_2
-      tags: [device_lib, timing]
+    Unit_hipWallClock64_Positive_Basic: *level_2
   compiler:
-    Unit_hipClassKernel_Overload_Override:
-      <<: *level_2
-      tags: [rtc, integration]
-    Unit_hipClassKernel_Friend:
-      <<: *level_2
-      tags: [rtc, integration]
-    Unit_hipClassKernel_Empty:
-      <<: *level_2
-      tags: [rtc, integration]
-    Unit_hipClassKernel_BSize:
-      <<: *level_2
-      tags: [rtc, integration]
-    Unit_hipClassKernel_Size:
-      <<: *level_2
-      tags: [rtc, integration]
-    Unit_hipClassKernel_Virtual:
-      <<: *level_2
-      tags: [rtc, integration]
-    Unit_hipClassKernel_Value:
-      <<: *level_2
-      tags: [rtc, integration]
-    Unit_test_spirv_mode:
-      <<: *level_2
-      tags: [rtc, integration]
-    Unit_test_compressed_codeobject:
-      <<: *level_2
-      tags: [rtc, integration]
-    Unit_test_generic_target_in_compressed_fatbin:
-      <<: *level_2
-      tags: [rtc, integration]
-    Unit_test_generic_target_in_regular_fatbin:
-      <<: *level_2
-      tags: [rtc, integration]
+    Unit_hipClassKernel_Overload_Override: *level_2
+    Unit_hipClassKernel_Friend: *level_2
+    Unit_hipClassKernel_Empty: *level_2
+    Unit_hipClassKernel_BSize: *level_2
+    Unit_hipClassKernel_Size: *level_2
+    Unit_hipClassKernel_Virtual: *level_2
+    Unit_hipClassKernel_Value: *level_2
+    Unit_test_spirv_mode: *level_2
+    Unit_test_compressed_codeobject: *level_2
+    Unit_test_generic_target_in_compressed_fatbin: *level_2
+    Unit_test_generic_target_in_regular_fatbin: *level_2
     Unit_test_generic_target_only_in_compressed_fatbin:
-      tags: [rtc, integration]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
@@ -523,53 +411,23 @@ unit:
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
   complex:
-    Unit_Device_Complex_Unary_Device_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_Device_Complex_Unary_Host_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_Device_Complex_Binary_Device_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_Device_Complex_Binary_Host_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_Device_Complex_hipCfma_Device_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_Device_Complex_hipCfma_Host_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_Device_make_Complex_Device_Positive:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_Device_make_Complex_Host_Positive:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_Device_make_hipComplex_Device_Positive:
-      <<: *level_2
-      tags: [complex]
-    Unit_Device_make_hipComplex_Host_Positive:
-      <<: *level_2
-      tags: [complex]
-    Unit_Device_Complex_Cast_Device_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_Device_Complex_Cast_Host_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_Device_Complex_Constructor_Host:
-      <<: *level_2
-      tags: [device_lib, types]
+    Unit_Device_Complex_Unary_Device_Sanity_Positive: *level_2
+    Unit_Device_Complex_Unary_Host_Sanity_Positive: *level_2
+    Unit_Device_Complex_Binary_Device_Sanity_Positive: *level_2
+    Unit_Device_Complex_Binary_Host_Sanity_Positive: *level_2
+    Unit_Device_Complex_hipCfma_Device_Sanity_Positive: *level_2
+    Unit_Device_Complex_hipCfma_Host_Sanity_Positive: *level_2
+    Unit_Device_make_Complex_Device_Positive: *level_2
+    Unit_Device_make_Complex_Host_Positive: *level_2
+    Unit_Device_make_hipComplex_Device_Positive: *level_2
+    Unit_Device_make_hipComplex_Host_Positive: *level_2
+    Unit_Device_Complex_Cast_Device_Sanity_Positive: *level_2
+    Unit_Device_Complex_Cast_Host_Sanity_Positive: *level_2
+    Unit_Device_Complex_Constructor_Host: *level_2
   context:
     Unit_hipDeviceGetPCIBusId_Functional: *level_2
-    Unit_hipDrvMemcpy_Functional:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemsetD8_Functional:
-      <<: *level_2
-      tags: [memory, memset]
+    Unit_hipDrvMemcpy_Functional: *level_2
+    Unit_hipMemsetD8_Functional: *level_2
     Unit_hipDevicePrimaryCtxSetFlags_Negative: *level_2
     Unit_hipDeviceAPIs_not_supported: *level_2
     Unit_hipCtxGetSetCacheConfig_not_supported: *level_2
@@ -579,24 +437,17 @@ unit:
     hipDevicePrimaryCtxGetState_Negative: *level_2
   cooperativeGrps:
     Unit_Thread_Block_Getters_Positive_Basic:
-      tags: [cooperative, groups, cooperativeLaunch]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_Thread_Block_Getters_Via_Base_Type_Positive_Basic:
-      <<: *level_2
-      tags: [cooperative, groups, cooperativeLaunch]
-    Unit_Thread_Block_Getters_Via_Non_Member_Functions_Positive_Basic:
-      <<: *level_2
-      tags: [cooperative, groups, cooperativeLaunch]
+    Unit_Thread_Block_Getters_Via_Base_Type_Positive_Basic: *level_2
+    Unit_Thread_Block_Getters_Via_Non_Member_Functions_Positive_Basic: *level_2
     Unit_Thread_Block_Sync_Positive_Basic: *level_2
     Unit_Thread_Block_Tile_Getters_Positive_Basic:
-      tags: [cooperative, groups, cooperativeLaunch]
       <<: *level_2
       # SWDEV-441604: Below tests take long time to run in stress test on 12/01/24
       disabled: [amd_windows]
     Unit_Thread_Block_Tile_Dynamic_Getters_Positive_Basic:
-      tags: [cooperative, groups, cooperativeLaunch]
       <<: *level_2
       # SWDEV-441604: Below tests take long time to run in stress test on 12/01/24
       disabled: [amd_windows]
@@ -621,7 +472,6 @@ unit:
       # Below tests hang in Jenkins PSDB
       disabled: [amd_windows]
     Unit_Coalesced_Group_Tiled_Partition_Getters_Positive_Basic:
-      tags: [cooperative, groups, cooperativeLaunch]
       <<: *level_2
       # SWDEV-486448 - Following tests disabled due to taking too much time to execute, ~700s per test
       disabled: [amd_windows]
@@ -638,74 +488,51 @@ unit:
       <<: *level_2
       # (amd_linux) Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/210
       disabled: [amd_linux, amd_windows]
-    Unit_hipCGThreadBlockType:
-      <<: *level_2
-      tags: [cooperative, groups, cooperativeLaunch]
+    Unit_hipCGThreadBlockType: *level_2
     Unit_hipCGMultiGridGroupType_Basic:
-      tags: [multigpu, cooperative, groups, cooperativeLaunch]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipCGMultiGridGroupType_Barrier:
-      tags: [multigpu, cooperative, groups, cooperativeLaunch]
       <<: *level_2
-    Unit_hipCGGridGroupType_Basic:
-      <<: *level_2
-      tags: [cooperative, groups, cooperativeLaunch]
-    Unit_hipCGGridGroupType_DataSharing:
-      <<: *level_2
-      tags: [cooperative, groups, cooperativeLaunch]
-    Unit_hipCGGridGroupType_Barrier:
-      <<: *level_2
-      tags: [cooperative, groups, cooperativeLaunch]
-    Unit_hipCGThreadBlockTileType:
-      <<: *level_2
-      tags: [cooperative, groups, cooperativeLaunch]
-    Unit_hipCGThreadBlockTileType_Shfl:
-      <<: *level_2
-      tags: [cooperative, ops, cooperativeLaunch]
+      tags: [multigpu]
+    Unit_hipCGGridGroupType_Basic: *level_2
+    Unit_hipCGGridGroupType_DataSharing: *level_2
+    Unit_hipCGGridGroupType_Barrier: *level_2
+    Unit_hipCGThreadBlockTileType: *level_2
+    Unit_hipCGThreadBlockTileType_Shfl: *level_2
     Unit_coalesced_groups:
-      tags: [cooperative, groups, cooperativeLaunch]
       <<: *level_2
       # Below tests hang in Jenkins PSDB
       disabled: [amd_windows]
-    Unit_hipLaunchCooperativeKernel_Basic:
-      <<: *level_2
-      tags: [cooperative, launch, cooperativeLaunch]
+    Unit_hipLaunchCooperativeKernel_Basic: *level_2
     Unit_hipLaunchCooperativeKernelMultiDevice_Basic:
-      tags: [multigpu, cooperative, launch, cooperativeLaunch]
       <<: *level_2
+      tags: [multigpu]
     Unit_Multi_Grid_Group_Getters_Positive_Basic:
-      tags: [multigpu, cooperative, groups, cooperativeLaunch]
       <<: *level_2
+      tags: [multigpu]
     Unit_Multi_Grid_Group_Getters_Positive_Base_Type:
-      tags: [multigpu, cooperative, groups, cooperativeLaunch]
       <<: *level_2
+      tags: [multigpu]
     Unit_Multi_Grid_Group_Getters_Positive_Non_Member_Functions:
-      tags: [multigpu, cooperative, groups, cooperativeLaunch]
       <<: *level_2
+      tags: [multigpu]
     Unit_Multi_Grid_Group_Positive_Sync:
-      tags: [multigpu, cooperative, groups, cooperativeLaunch]
       <<: *level_2
+      tags: [multigpu]
       # SWDEV-443630 : Below test failed in stress test on 19/01/24
       disabled: [gfx90a, gfx942, gfx950]
     Unit_coalesced_groups_shfl_down:
-      tags: [cooperative, ops, cooperativeLaunch]
       <<: *level_2
       # Below tests hang in Jenkins PSDB
       disabled: [amd_windows]
     Unit_coalesced_groups_shfl_up:
-      tags: [cooperative, ops, cooperativeLaunch]
       <<: *level_2
       # Below tests hang in Jenkins PSDB
       disabled: [amd_windows]
-    Unit_Coalesced_Group_Getters_Positive_Basic:
-      <<: *level_2
-      tags: [cooperative, groups, cooperativeLaunch]
-    Unit_Coalesced_Group_Getters_Via_Base_Type_Positive_Basic:
-      <<: *level_2
-      tags: [cooperative, groups, cooperativeLaunch]
-    Unit_Coalesced_Group_Getters_Via_Non_Member_Functions_Positive_Basic:
-      <<: *level_2
-      tags: [cooperative, groups, cooperativeLaunch]
+    Unit_Coalesced_Group_Getters_Positive_Basic: *level_2
+    Unit_Coalesced_Group_Getters_Via_Base_Type_Positive_Basic: *level_2
+    Unit_Coalesced_Group_Getters_Via_Non_Member_Functions_Positive_Basic: *level_2
     Unit_Coalesced_Group_Shfl_Up_Positive_Basic:
       <<: *level_2
       # SWDEV-438524: Below tests taking long time to run in stress test on 15/12/23
@@ -722,431 +549,237 @@ unit:
       <<: *level_2
       # SWDEV-434171: Below tests took long time to complete in stress test on 17/11/23
       disabled: [amd_windows]
-    Unit_Grid_Group_Getters_Positive_Basic:
-      <<: *level_2
-      tags: [cooperative, groups, cooperativeLaunch]
-    Unit_Grid_Group_Getters_Via_Non_Member_Functions_Positive_Basic:
-      <<: *level_2
-      tags: [cooperative, groups, cooperativeLaunch]
-    Unit_Grid_Group_Sync_Positive_Basic:
-      <<: *level_2
-      tags: [cooperative, groups, cooperativeLaunch]
-    Unit_tiled_groups_metagrp_basic:
-      <<: *level_2
-      tags: [cooperative, groups, cooperativeLaunch]
-    Unit_coalesced_groups_metagrp_basic:
-      <<: *level_2
-      tags: [cooperative, groups, cooperativeLaunch]
-    Unit_cg_binary_part:
-      <<: *level_2
-      tags: [cooperative, ops, cooperativeLaunch]
-    Unit_coopgroups_ballot:
-      <<: *level_2
-      tags: [cooperative, ops, cooperativeLaunch]
-    Unit_binary_part_ballot:
-      <<: *level_2
-      tags: [cooperative, ops, cooperativeLaunch]
-    Unit_coopgroups_any:
-      <<: *level_2
-      tags: [cooperative, ops, cooperativeLaunch]
-    Unit_coopgroups_coal_all:
-      <<: *level_2
-      tags: [cooperative, ops, cooperativeLaunch]
-    Unit_coopgroups_match_any_coal:
-      <<: *level_2
-      tags: [cooperative, ops, cooperativeLaunch]
-    Unit_coopgroups_match_all_coal:
-      <<: *level_2
-      tags: [cooperative, ops, cooperativeLaunch]
+    Unit_Grid_Group_Getters_Positive_Basic: *level_2
+    Unit_Grid_Group_Getters_Via_Non_Member_Functions_Positive_Basic: *level_2
+    Unit_Grid_Group_Sync_Positive_Basic: *level_2
+    Unit_tiled_groups_metagrp_basic: *level_2
+    Unit_coalesced_groups_metagrp_basic: *level_2
+    Unit_cg_binary_part: *level_2
+    Unit_coopgroups_ballot: *level_2
+    Unit_binary_part_ballot: *level_2
+    Unit_coopgroups_any: *level_2
+    Unit_coopgroups_coal_all: *level_2
+    Unit_coopgroups_match_any_coal: *level_2
+    Unit_coopgroups_match_all_coal: *level_2
   device:
-    Unit_hipChooseDevice_ValidateDevId:
+    # Example tests demonstrating level-based parameter system
+    # ONE test with multiple level tags - parameters adapt based on which level you run
+    Unit_hipDeviceMemAlloc_Functional:
+      level: 0
+      tags: [level_0, level_1, level_2, device, memory]
+    Unit_hipDeviceMemAlloc_MultiDevice:
+      level: 0
+      tags: [level_0, level_1, level_2, device, memory, multigpu]
+    Unit_hipDeviceMemAlloc_VerifyLevelConfig:
       <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipChooseDevice_NegTst:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipDeviceComputeCapability_Negative:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipDeviceComputeCapability_ValidateVersion:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipDeviceGetByPCIBusId_Functional:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipDeviceGetByPCIBusId_NegativeNullChk:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipDeviceGetByPCIBusId_NegativeInputString:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipDeviceGetByPCIBusId_WrongBusID:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipDeviceGetLimit_NegTst:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipDeviceGetLimit_CheckValidityOfOutputVal:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipDeviceGetName_NegTst:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipDeviceGetName_CheckPropName:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipDeviceGetName_PartialFill:
-      <<: *level_2
-      tags: [device_mgmt, query]
+      tags: [.verify, config]
+    Unit_hipChooseDevice_ValidateDevId: *level_2
+    Unit_hipChooseDevice_NegTst: *level_2
+    Unit_hipDeviceComputeCapability_Negative: *level_2
+    Unit_hipDeviceComputeCapability_ValidateVersion: *level_2
+    Unit_hipDeviceGetByPCIBusId_Functional: *level_2
+    Unit_hipDeviceGetByPCIBusId_NegativeNullChk: *level_2
+    Unit_hipDeviceGetByPCIBusId_NegativeInputString: *level_2
+    Unit_hipDeviceGetByPCIBusId_WrongBusID: *level_2
+    Unit_hipDeviceGetLimit_NegTst: *level_2
+    Unit_hipDeviceGetLimit_CheckValidityOfOutputVal: *level_2
+    Unit_hipDeviceGetName_NegTst: *level_2
+    Unit_hipDeviceGetName_CheckPropName: *level_2
+    Unit_hipDeviceGetName_PartialFill: *level_2
     Unit_hipDeviceName_gcnArchName_And_rocm_agent_enumerator:
-      tags: [device_mgmt, query, multigpu]
       <<: *level_2
-    Unit_hipDeviceGetPCIBusId_Check_PciBusID_WithAttr:
-      <<: *level_2
-      tags: [device_mgmt, query]
+      tags: [multigpu]
+    Unit_hipDeviceGetPCIBusId_Check_PciBusID_WithAttr: *level_2
     Unit_hipDeviceGetPCIBusId_Negative_PartialFill:
-      tags: [device_mgmt, query]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       disabled: [amd_windows, amd_wsl]
-    Unit_hipDeviceGetPCIBusId_NegTst:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipDeviceSetCacheConfig_Positive_Basic:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceGetCacheConfig_Positive_Default:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceSynchronize_Positive_Empty_Streams:
-      <<: *level_2
-      tags: [device_mgmt, sync]
+    Unit_hipDeviceGetPCIBusId_NegTst: *level_2
+    Unit_hipDeviceSetCacheConfig_Positive_Basic: *level_2
+    Unit_hipDeviceGetCacheConfig_Positive_Default: *level_2
+    Unit_hipDeviceSynchronize_Positive_Empty_Streams: *level_2
     Unit_hipDeviceSynchronize_Positive_Nullstream:
-      tags: [device_mgmt, sync]
       <<: *level_2
       # Disabling tests which no longer behave the same on nvidia platform
       disabled: [nvidia_windows]
     Unit_hipDeviceSynchronize_Functional:
-      tags: [device_mgmt, sync]
       <<: *level_2
       # Disabling tests which no longer behave the same on nvidia platform
       disabled: [nvidia_windows]
-    Unit_hipDeviceTotalMem_NegTst:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipDeviceTotalMem_ValidateTotalMem:
-      <<: *level_2
-      tags: [device_mgmt, query]
+    Unit_hipDeviceTotalMem_NegTst: *level_2
+    Unit_hipDeviceTotalMem_ValidateTotalMem: *level_2
     Unit_hipDeviceTotalMem_NonSelectedDevice:
-      tags: [device_mgmt, query, multigpu]
       <<: *level_2
-    Unit_hipGetDeviceAttribute_CheckAttrValues:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipDeviceGetAttribute_NegTst:
-      <<: *level_2
-      tags: [device_mgmt, query]
+      tags: [multigpu]
+    Unit_hipGetDeviceAttribute_CheckAttrValues: *level_2
+    Unit_hipDeviceGetAttribute_NegTst: *level_2
     Print_Out_Attributes: *level_2
-    Unit_hipGetDeviceAttribute_hipDevAttrHostRegisterSupported:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipGetDeviceCount_NegTst:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipGetDeviceCount_HideDevices:
-      <<: *level_2
-      tags: [device_mgmt, query]
+    Unit_hipGetDeviceAttribute_hipDevAttrHostRegisterSupported: *level_2
+    Unit_hipGetDeviceCount_NegTst: *level_2
+    Unit_hipGetDeviceCount_HideDevices: *level_2
     Print_Out_Device_Count: *level_2
     Unit_hipGetDeviceProperties_ArchPropertiesTst:
-      tags: [device_mgmt, query, multigpu]
       <<: *level_2
-    Unit_hipGetDeviceProperties_NegTst:
-      <<: *level_2
-      tags: [device_mgmt, query]
+      tags: [multigpu]
+    Unit_hipGetDeviceProperties_NegTst: *level_2
     Print_Out_Properties: *level_2
     Print_Out_Properties_6_0: *level_2
-    Unit_hipRuntimeGetVersion_Positive:
-      <<: *level_2
-      tags: [device_mgmt, init]
-    Unit_hipRuntimeGetVersion_Negative:
-      <<: *level_2
-      tags: [device_mgmt, init]
-    Unit_hipGetSetDeviceFlags_NullptrFlag:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipGetSetDeviceFlags_ValidFlag:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipGetSetDeviceFlags_SetThenGet:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipGetSetDeviceFlags_Threaded:
-      <<: *level_2
-      tags: [device_mgmt, config]
+    Unit_hipRuntimeGetVersion_Positive: *level_2
+    Unit_hipRuntimeGetVersion_Negative: *level_2
+    Unit_hipGetSetDeviceFlags_NullptrFlag: *level_2
+    Unit_hipGetSetDeviceFlags_ValidFlag: *level_2
+    Unit_hipGetSetDeviceFlags_SetThenGet: *level_2
+    Unit_hipGetSetDeviceFlags_Threaded: *level_2
     Unit_hipGetDeviceFlags_Positive_Context:
-      tags: [device_mgmt, config]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGetSetDeviceFlags_InvalidFlag:
-      <<: *level_2
-      tags: [device_mgmt, config]
+    Unit_hipGetSetDeviceFlags_InvalidFlag: *level_2
     Unit_hipSetDevice_BasicSetGet:
-      tags: [device_mgmt, query, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGetSetDevice_MultiThreaded:
-      tags: [device_mgmt, query, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipSetGetDevice_Positive_Threaded_Basic:
-      tags: [device_mgmt, query, multigpu]
       <<: *level_2
-    Unit_hipSetGetDevice_Negative:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipDeviceGet_Negative:
-      <<: *level_2
-      tags: [device_mgmt, query]
+      tags: [multigpu]
+    Unit_hipSetGetDevice_Negative: *level_2
+    Unit_hipDeviceGet_Negative: *level_2
     Unit_hipDeviceGetUuid_Positive:
-      tags: [device_mgmt, query]
       <<: *level_2
       # (amd_windows) Note: UUID returned empty on some windows nodes
       # (amd_wsl) Note: UUID returned empty on some windows nodes
       disabled: [amd_windows, amd_wsl]
-    Unit_hipDeviceGetUuid_Negative:
-      <<: *level_2
-      tags: [device_mgmt, query]
+    Unit_hipDeviceGetUuid_Negative: *level_2
     Unit_hipDeviceGetUuid_From_RocmInfo:
-      tags: [device_mgmt, query, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipDeviceGetUuid_VerifyUuidFrm_hipGetDeviceProperties:
-      tags: [device_mgmt, query, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES:
-      tags: [device_mgmt, query]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_UUID_setEnv_Thread:
-      tags: [device_mgmt, query]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipDeviceAPUCheck:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipDeviceGetDefaultMemPool_Positive_Basic:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipDeviceGetDefaultMemPool_Negative_Parameters:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipDeviceCanAccessPeer_positive:
-      <<: *level_2
-      tags: [device_mgmt]
-    Unit_hipDeviceCanAccessPeer_negative:
-      <<: *level_2
-      tags: [device_mgmt]
+    Unit_hipDeviceAPUCheck: *level_2
+    Unit_hipDeviceGetDefaultMemPool_Positive_Basic: *level_2
+    Unit_hipDeviceGetDefaultMemPool_Negative_Parameters: *level_2
+    Unit_hipDeviceCanAccessPeer_positive: *level_2
+    Unit_hipDeviceCanAccessPeer_negative: *level_2
     Unit_hipDeviceEnableDisablePeerAccess_positive:
-      tags: [device_mgmt, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipDeviceEnablePeerAccess_negative:
-      tags: [device_mgmt, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipDeviceDisablePeerAccess_negative:
-      tags: [device_mgmt, multigpu]
       <<: *level_2
-    Unit_hipExtGetLinkTypeAndHopCount_Positive_Basic:
-      <<: *level_2
-      tags: [device_mgmt, query]
-    Unit_hipExtGetLinkTypeAndHopCount_Negative_Parameters:
-      <<: *level_2
-      tags: [device_mgmt, query]
+      tags: [multigpu]
+    Unit_hipExtGetLinkTypeAndHopCount_Positive_Basic: *level_2
+    Unit_hipExtGetLinkTypeAndHopCount_Negative_Parameters: *level_2
     Unit_hipDeviceSetLimit_SetGet:
-      tags: [device_mgmt, config, multigpu]
       <<: *level_2
-    Unit_hipDeviceSetLimit_Positive_StackSize:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceSetLimit_Positive_PrintfFifoSize:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceSetLimit_Negative_PrintfFifoSize:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceSetLimit_Positive_MallocHeapSize:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceSetLimit_Negative_MallocHeapSize:
-      <<: *level_2
-      tags: [device_mgmt, config]
+      tags: [multigpu]
+    Unit_hipDeviceSetLimit_Positive_StackSize: *level_2
+    Unit_hipDeviceSetLimit_Positive_PrintfFifoSize: *level_2
+    Unit_hipDeviceSetLimit_Negative_PrintfFifoSize: *level_2
+    Unit_hipDeviceSetLimit_Positive_MallocHeapSize: *level_2
+    Unit_hipDeviceSetLimit_Negative_MallocHeapSize: *level_2
     Unit_hipDeviceSetLimit_Negative_Parameters:
-      tags: [device_mgmt, config]
       <<: *level_2
       # Below 2 tests are disabled due to defect EXSWHTEC-342
       disabled: [nvidia_windows]
     Unit_hipDeviceGetLimit_Negative_Parameters:
-      tags: [device_mgmt, config]
       <<: *level_2
       # Below 2 tests are disabled due to defect EXSWHTEC-342
       disabled: [nvidia_windows]
-    Unit_hipDeviceGetSetLimit_Scratch_Negative:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceGetSetLimit_Scratch_SetMinAndMaxAsCurrent:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceGetSetLimit_Scratch_DecreaseIncrease:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceGetSetLimit_Scratch_SetBeforeKernelLaunch:
-      <<: *level_2
-      tags: [device_mgmt, config]
+    Unit_hipDeviceGetSetLimit_Scratch_Negative: *level_2
+    Unit_hipDeviceGetSetLimit_Scratch_SetMinAndMaxAsCurrent: *level_2
+    Unit_hipDeviceGetSetLimit_Scratch_DecreaseIncrease: *level_2
+    Unit_hipDeviceGetSetLimit_Scratch_SetBeforeKernelLaunch: *level_2
     Unit_hipDeviceGetSetLimit_Scratch_MultiDevice:
-      tags: [device_mgmt, config, multigpu]
       <<: *level_2
-    Unit_hipDeviceGetSetLimit_Scratch_InThread:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceGetSetLimit_Scratch_InChildProcess:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceGetSetLimit_Scratch_SetGetThreads:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceSetSharedMemConfig_Positive_Basic:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceSetSharedMemConfig_Negative_Parameters:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceGetSharedMemConfig_Positive_Default:
-      <<: *level_2
-      tags: [device_mgmt, config]
+      tags: [multigpu]
+    Unit_hipDeviceGetSetLimit_Scratch_InThread: *level_2
+    Unit_hipDeviceGetSetLimit_Scratch_InChildProcess: *level_2
+    Unit_hipDeviceGetSetLimit_Scratch_SetGetThreads: *level_2
+    Unit_hipDeviceSetSharedMemConfig_Positive_Basic: *level_2
+    Unit_hipDeviceSetSharedMemConfig_Negative_Parameters: *level_2
+    Unit_hipDeviceGetSharedMemConfig_Positive_Default: *level_2
     Unit_hipDeviceGetSharedMemConfig_Positive_Basic:
-      tags: [device_mgmt, config]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Linux disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipDeviceGetSharedMemConfig_Positive_Threaded:
-      tags: [device_mgmt, config]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Linux disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipDeviceGetSharedMemConfig_Negative_Parameters:
-      <<: *level_2
-      tags: [device_mgmt, config]
+    Unit_hipDeviceGetSharedMemConfig_Negative_Parameters: *level_2
     Unit_hipDeviceReset_Positive_Basic:
-      tags: [device_mgmt, sync]
       <<: *level_2
       # (amd_wsl) Note: Windows disabled
       # (nvidia_windows) Disabling tests which no longer behave the same on nvidia platform
       disabled: [amd_wsl, nvidia_windows]
     Unit_hipDeviceReset_Positive_Threaded:
-      tags: [device_mgmt, sync]
       <<: *level_2
       # (amd_wsl) Note: Windows disabled
       # (nvidia_windows) Disabling tests which no longer behave the same on nvidia platform
       disabled: [amd_wsl, nvidia_windows]
-    Unit_hipDeviceSetMemPool_Positive_Basic:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceSetMemPool_Negative_Parameters:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceGetMemPool_Positive_Default:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceGetMemPool_Positive_Basic:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceGetMemPool_Positive_Threaded:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipDeviceGetMemPool_Negative_Parameters:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipInit_Positive:
-      <<: *level_2
-      tags: [device_mgmt, init]
+    Unit_hipDeviceSetMemPool_Positive_Basic: *level_2
+    Unit_hipDeviceSetMemPool_Negative_Parameters: *level_2
+    Unit_hipDeviceGetMemPool_Positive_Default: *level_2
+    Unit_hipDeviceGetMemPool_Positive_Basic: *level_2
+    Unit_hipDeviceGetMemPool_Positive_Threaded: *level_2
+    Unit_hipDeviceGetMemPool_Negative_Parameters: *level_2
+    Unit_hipInit_Positive: *level_2
     Unit_hipInit_Negative:
-      tags: [device_mgmt, init]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipDriverGetVersion_Positive:
-      <<: *level_2
-      tags: [device_mgmt, init]
-    Unit_hipDriverGetVersion_Negative:
-      <<: *level_2
-      tags: [device_mgmt, init]
-    Unit_hipSetValidDevices_Negative:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipSetValidDevices_Negative_Length_Lessthan_DeviceArrSize:
-      <<: *level_2
-      tags: [device_mgmt, config]
+    Unit_hipDriverGetVersion_Positive: *level_2
+    Unit_hipDriverGetVersion_Negative: *level_2
+    Unit_hipSetValidDevices_Negative: *level_2
+    Unit_hipSetValidDevices_Negative_Length_Lessthan_DeviceArrSize: *level_2
     Unit_hipSetValidDevices_Positive_Basic:
-      tags: [device_mgmt, config, multigpu]
       <<: *level_2
-    Unit_hipSetValidDevices_WithAllDevicesInSystem:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipSetValidDevices_Positive_Cases:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipSetValidDevices_MultiProcess:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipSetValidDevices_MultiThread:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipSetValidDevices_with_hipMemcpyPeer:
-      <<: *level_2
-      tags: [device_mgmt, config]
-    Unit_hipGetProcAddress_ValidateDeviceApis:
-      <<: *level_2
-      tags: [device_mgmt]
+      tags: [multigpu]
+    Unit_hipSetValidDevices_WithAllDevicesInSystem: *level_2
+    Unit_hipSetValidDevices_Positive_Cases: *level_2
+    Unit_hipSetValidDevices_MultiProcess: *level_2
+    Unit_hipSetValidDevices_MultiThread: *level_2
+    Unit_hipSetValidDevices_with_hipMemcpyPeer: *level_2
+    Unit_hipGetProcAddress_ValidateDeviceApis: *level_2
     Unit_hipGetProcAddress_PeerDeviceAccessAPIs:
-      tags: [device_mgmt, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGetProcAddress_SetGetMemPoolAPIs:
-      tags: [device_mgmt, multigpu]
       <<: *level_2
-    Unit_hipGetDriverEntryPoint_Positive:
-      <<: *level_2
-      tags: [device_mgmt]
-    Unit_hipGetDriverEntryPoint_Negative:
-      <<: *level_2
-      tags: [device_mgmt]
-    Unit_hipGetDriverEntryPoint_spt_Positive:
-      <<: *level_2
-      tags: [device_mgmt]
-    Unit_hipGetDriverEntryPoint_spt_Negative:
-      <<: *level_2
-      tags: [device_mgmt]
-    Unit_hipGetProcAddress_IPC_Memory:
-      <<: *level_2
-      tags: [device_mgmt]
-    Unit_hipGetProcAddress_IPC_Event:
-      <<: *level_2
-      tags: [device_mgmt]
+      tags: [multigpu]
+    Unit_hipGetDriverEntryPoint_Positive: *level_2
+    Unit_hipGetDriverEntryPoint_Negative: *level_2
+    Unit_hipGetDriverEntryPoint_spt_Positive: *level_2
+    Unit_hipGetDriverEntryPoint_spt_Negative: *level_2
+    Unit_hipGetProcAddress_IPC_Memory: *level_2
+    Unit_hipGetProcAddress_IPC_Event: *level_2
     Unit_hipIpcOpenMemHandle_Negative_Open_In_Creating_Process:
-      tags: [device_mgmt]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_wsl]
     Unit_hipIpcOpenMemHandle_Negative_Open_In_Two_Contexts_Same_Device:
-      tags: [device_mgmt]
       <<: *level_2
       # (amd_linux) SWDEV-511679 : Below tests fail in stress test
       # (amd_wsl) Note: hsa_amd_ipc_ is dummy
       disabled: [amd_linux, amd_wsl]
     Unit_hipIpcGetMemHandle_Positive_Unique_Handles_Separate_Allocations:
-      tags: [device_mgmt]
       <<: *level_2
       # Note: Test disabled due to defect - EXSWHTEC-207
       disabled: [amd_wsl]
@@ -1154,20 +787,14 @@ unit:
       <<: *level_2
       # Note: hsa_amd_ipc_ is dummy
       disabled: [amd_wsl]
-    Unit_hipIpcGetMemHandle_Negative_Handle_For_Freed_Memory:
-      <<: *level_2
-      tags: [device_mgmt]
-    Unit_hipIpcGetMemHandle_Negative_Out_Of_Bound_Pointer:
-      <<: *level_2
-      tags: [device_mgmt]
+    Unit_hipIpcGetMemHandle_Negative_Handle_For_Freed_Memory: *level_2
+    Unit_hipIpcGetMemHandle_Negative_Out_Of_Bound_Pointer: *level_2
     Unit_hipIpcCloseMemHandle_Positive_Reference_Counting:
-      tags: [device_mgmt]
       <<: *level_2
       # (amd_linux) SWDEV-511679 : Below tests fail in stress test
       # (amd_wsl) Note: hsa_amd_ipc_ is dummy
       disabled: [amd_linux, amd_wsl]
     Unit_hipIpcCloseMemHandle_Negative_Close_In_Originating_Process:
-      tags: [device_mgmt]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_wsl]
@@ -1176,495 +803,248 @@ unit:
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_Device_memcpy_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lang]
+    Unit_Device_memcpy_Negative_Parameters_RTC: *level_2
     Unit_Device_memset_Positive: *level_2
-    Unit_Device_memset_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lang]
+    Unit_Device_memset_Negative_Parameters_RTC: *level_2
   deviceLib:
-    Unit_deviceFunctions_CompileTest:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_AnyAll_CompileTest:
-      <<: *level_2
-      tags: [device_lib, warp]
-    Unit_ballot:
-      <<: *level_2
-      tags: [device_lib, warp]
-    Unit_clz:
-      <<: *level_2
-      tags: [device_lib, bitops]
-    Unit_ffs:
-      <<: *level_2
-      tags: [device_lib, bitops]
-    Unit_funnelshift:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_brev:
-      <<: *level_2
-      tags: [device_lib, bitops]
-    Unit_popc:
-      <<: *level_2
-      tags: [device_lib, bitops]
-    Unit_ldg:
-      <<: *level_2
-      tags: [device_lib, bitops]
+    Unit_deviceFunctions_CompileTest: *level_2
+    Unit_AnyAll_CompileTest: *level_2
+    Unit_ballot: *level_2
+    Unit_clz: *level_2
+    Unit_ffs: *level_2
+    Unit_funnelshift: *level_2
+    Unit_brev: *level_2
+    Unit_popc: *level_2
+    Unit_ldg: *level_2
     Unit_threadfence_system:
-      tags: [multigpu, device_lib]
       <<: *level_2
-    Unit_syncthreads_and:
-      <<: *level_2
-      tags: [device_lib, sync]
-    Unit_syncthreads_count:
-      <<: *level_2
-      tags: [device_lib, sync]
-    Unit_syncthreads_or:
-      <<: *level_2
-      tags: [device_lib, sync]
+      tags: [multigpu]
+    Unit_syncthreads_and: *level_2
+    Unit_syncthreads_count: *level_2
+    Unit_syncthreads_or: *level_2
     Unit_deviceAllocation_Malloc_PerThread_PrimitiveDataType:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_New_PerThread_PrimitiveDataType:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_Malloc_PerThread_StructDataType:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_New_PerThread_StructDataType:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_InOneThread_AccessInAllThreads:
-      tags: [device_lib, memory]
       <<: *level_2
       # (amd_windows) Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # (amd_windows) all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       # (amd_wsl) SWDEV-427101:Below test fails randomly in PSDB
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_Malloc_AcrossKernels:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_New_AcrossKernels:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_Malloc_ComplexDataType:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows]
     Unit_deviceAllocation_New_ComplexDataType:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_Malloc_UnionType:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_New_UnionType:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_Malloc_SingleCodeObj:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_New_SingleCodeObj:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_deviceAllocation_Malloc_PerThread_MultKerMultStrm:
-      <<: *level_2
-      tags: [device_lib, memory]
-    Unit_deviceAllocation_New_PerThread_MultKerMultStrm:
-      <<: *level_2
-      tags: [device_lib, memory]
+    Unit_deviceAllocation_Malloc_PerThread_MultKerMultStrm: *level_2
+    Unit_deviceAllocation_New_PerThread_MultKerMultStrm: *level_2
     Unit_deviceAllocation_Malloc_PerThread_Graph:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_New_PerThread_Graph:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_Malloc_DeviceFunc:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_New_DeviceFunc:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_VirtualFunction:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_Malloc_MulKernels_MulThreads:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_New_MulKernels_MulThreads:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
-    Unit_deviceAllocation_Malloc_SingKernels_MulThreads:
-      <<: *level_2
-      tags: [device_lib, memory]
-    Unit_deviceAllocation_New_SingKernels_MulThreads:
-      <<: *level_2
-      tags: [device_lib, memory]
+    Unit_deviceAllocation_Malloc_SingKernels_MulThreads: *level_2
+    Unit_deviceAllocation_New_SingKernels_MulThreads: *level_2
     Unit_deviceAllocation_Malloc_MulCodeObj:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_New_MulCodeObj:
-      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
-    Unit_AtomicFunctions_Inc:
-      <<: *level_2
-      tags: [device_lib, atomic]
-    Unit_AtomicFunctions_Dec:
-      <<: *level_2
-      tags: [device_lib, atomic]
-    Unit_DoublePrecisionIntrinsics:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_DoublePrecisionMathDevice:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_DoublePrecisionMathHost:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_FloatMathPrecise:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_IntegerIntrinsics:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_SinglePrecisionIntrinsics:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_SinglePrecisionMathDevice:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_SinglePrecisionMathHost:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_SimpleAtomicsTest:
-      <<: *level_2
-      tags: [device_lib, atomic]
-    Unit_hipTestAtomicAdd:
-      <<: *level_2
-      tags: [device_lib, atomic]
-    Unit_StdComplex:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_hipTestClock:
-      <<: *level_2
-      tags: [device_lib, misc]
-    Unit_kernel_trigger:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_ToAndFroMemCpyToDevice:
-      <<: *level_2
-      tags: [device_lib, memory]
-    Unit_TestIncludeMathPreciseFloat:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_hipTestDotFunctions:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_hipMemcpyToSymbolAsync_ToNFrom:
-      <<: *level_2
-      tags: [device_lib, misc]
-    Unit_hipGetSymbolAddressAndSize_Validation:
-      <<: *level_2
-      tags: [device_lib, misc]
-    Unit_hipGetSymbolAddress_Negative:
-      <<: *level_2
-      tags: [device_lib, misc]
-    Unit_hipGetSymbolSize_Negative:
-      <<: *level_2
-      tags: [device_lib, misc]
-    Unit_hipTest_DeviceNewOperator:
-      <<: *level_2
-      tags: [device_lib, misc]
-    Unit_hipThreadFence:
-      <<: *level_2
-      tags: [device_lib, sync]
-    Unit_hipDeviceTrigFunc_Float:
-      <<: *level_2
-      tags: [device_lib, misc]
-    Unit_hipTestDeviceLimit_Basic:
-      <<: *level_2
-      tags: [device_lib, misc]
-    Unit_hipTrigDeviceFunc_Double:
-      <<: *level_2
-      tags: [device_lib, misc]
-    Unit_TestDevice_DoublePrecisionMathFunc:
-      <<: *level_2
-      tags: [device_lib, misc]
-    Unit_hadd_int_varaint:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_rhadd_int_varaint:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_uhadd_int_varaint:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_urhadd_int_varaint:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_unsafeAtomicAdd:
-      <<: *level_2
-      tags: [device_lib, atomic]
-    Unit_mbcnt:
-      <<: *level_2
-      tags: [device_lib, bitops]
-    Unit_bitExtract:
-      <<: *level_2
-      tags: [device_lib, bitops]
-    Unit_bitInsert:
-      <<: *level_2
-      tags: [device_lib, bitops]
-    Unit_floatTM:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_abs_int64_Verification:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_pown_Verification:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_hmax_hmin_Tsts:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_hmax_hmin_Tsts_Negative:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_hmax_hmin_Tsts_With_Array:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_hipBfloat16:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_hipVectorTypes_test_on_host:
-      <<: *level_2
-      tags: [device_lib, types]
+    Unit_AtomicFunctions_Inc: *level_2
+    Unit_AtomicFunctions_Dec: *level_2
+    Unit_DoublePrecisionIntrinsics: *level_2
+    Unit_DoublePrecisionMathDevice: *level_2
+    Unit_DoublePrecisionMathHost: *level_2
+    Unit_FloatMathPrecise: *level_2
+    Unit_IntegerIntrinsics: *level_2
+    Unit_SinglePrecisionIntrinsics: *level_2
+    Unit_SinglePrecisionMathDevice: *level_2
+    Unit_SinglePrecisionMathHost: *level_2
+    Unit_SimpleAtomicsTest: *level_2
+    Unit_hipTestAtomicAdd: *level_2
+    Unit_StdComplex: *level_2
+    Unit_hipTestClock: *level_2
+    Unit_kernel_trigger: *level_2
+    Unit_ToAndFroMemCpyToDevice: *level_2
+    Unit_TestIncludeMathPreciseFloat: *level_2
+    Unit_hipTestDotFunctions: *level_2
+    Unit_hipMemcpyToSymbolAsync_ToNFrom: *level_2
+    Unit_hipGetSymbolAddressAndSize_Validation: *level_2
+    Unit_hipGetSymbolAddress_Negative: *level_2
+    Unit_hipGetSymbolSize_Negative: *level_2
+    Unit_hipTest_DeviceNewOperator: *level_2
+    Unit_hipThreadFence: *level_2
+    Unit_hipDeviceTrigFunc_Float: *level_2
+    Unit_hipTestDeviceLimit_Basic: *level_2
+    Unit_hipTrigDeviceFunc_Double: *level_2
+    Unit_TestDevice_DoublePrecisionMathFunc: *level_2
+    Unit_hadd_int_varaint: *level_2
+    Unit_rhadd_int_varaint: *level_2
+    Unit_uhadd_int_varaint: *level_2
+    Unit_urhadd_int_varaint: *level_2
+    Unit_unsafeAtomicAdd: *level_2
+    Unit_mbcnt: *level_2
+    Unit_bitExtract: *level_2
+    Unit_bitInsert: *level_2
+    Unit_floatTM: *level_2
+    Unit_abs_int64_Verification: *level_2
+    Unit_pown_Verification: *level_2
+    Unit_hmax_hmin_Tsts: *level_2
+    Unit_hmax_hmin_Tsts_Negative: *level_2
+    Unit_hmax_hmin_Tsts_With_Array: *level_2
+    Unit_hipBfloat16: *level_2
+    Unit_hipVectorTypes_test_on_host: *level_2
     Unit_hipVectorTypes_test_on_device:
-      tags: [device_lib, types]
       <<: *level_2
       # SWDEV-444987 - Below tests fail in stress testing on 25/01/2023
       disabled: [amd_windows, amd_wsl]
-    Unit_hipTestHalf:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_TestMathFuncComplex:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_hipTestFMA:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_hipTestNativeHalf:
-      <<: *level_2
-      tags: [device_lib, types]
+    Unit_hipTestHalf: *level_2
+    Unit_TestMathFuncComplex: *level_2
+    Unit_hipTestFMA: *level_2
+    Unit_hipTestNativeHalf: *level_2
     Unit_Test_makechar_functionality:
-      tags: [device_lib, types]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_bf16_basic:
-      <<: *level_2
-      tags: [device_lib, types]
+    Unit_bf16_basic: *level_2
     Unit_bf16_conversion_to_integral_type: *level_2
-    Unit_bf162_basic:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_bf16_operators_host:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_bf162_operators_host:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_bf16_bf162_convert_tests:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_bf16_shfl:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_bf162_shfl:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_bf16_value_ops:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_bf16_floor_ceil:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_bf162_floor_ceil:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_AtomicsWithRandomActiveLanesInWavefront_UniformInteger:
-      <<: *level_2
-      tags: [device_lib, atomic]
-    Unit_AtomicsWithRandomActiveLanesInWavefront_UniformFloat:
-      <<: *level_2
-      tags: [device_lib, atomic]
-    Unit_AtomicsWithRandomActiveLanesInWavefront_DivergentInteger:
-      <<: *level_2
-      tags: [device_lib, atomic]
-    Unit_AtomicsWithRandomActiveLanesInWavefront_DivergentFloat:
-      <<: *level_2
-      tags: [device_lib, atomic]
-    Unit_fp16_arith:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_fp162_arith:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_fp16_host_operations:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_half_isnan_host:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_half_abs_host:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_half_min_max_host:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_fp8_ocp_bool_host:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_all_fp8_ocp_vector_cvt:
-      <<: *level_2
-      tags: [device_lib, types]
+    Unit_bf162_basic: *level_2
+    Unit_bf16_operators_host: *level_2
+    Unit_bf162_operators_host: *level_2
+    Unit_bf16_bf162_convert_tests: *level_2
+    Unit_bf16_shfl: *level_2
+    Unit_bf162_shfl: *level_2
+    Unit_bf16_value_ops: *level_2
+    Unit_bf16_floor_ceil: *level_2
+    Unit_bf162_floor_ceil: *level_2
+    Unit_AtomicsWithRandomActiveLanesInWavefront_UniformInteger: *level_2
+    Unit_AtomicsWithRandomActiveLanesInWavefront_UniformFloat: *level_2
+    Unit_AtomicsWithRandomActiveLanesInWavefront_DivergentInteger: *level_2
+    Unit_AtomicsWithRandomActiveLanesInWavefront_DivergentFloat: *level_2
+    Unit_fp16_arith: *level_2
+    Unit_fp162_arith: *level_2
+    Unit_fp16_host_operations: *level_2
+    Unit_half_isnan_host: *level_2
+    Unit_half_abs_host: *level_2
+    Unit_half_min_max_host: *level_2
+    Unit_fp8_ocp_bool_host: *level_2
+    Unit_all_fp8_ocp_vector_cvt: *level_2
     Unit_fp8_ocp_correctness: *level_2
-    Unit_fp8_ocp_vector_basic_conversions:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_fp8_fnuz_bool_host:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_all_fp8_fnuz_vector_cvt:
-      <<: *level_2
-      tags: [device_lib, types]
+    Unit_fp8_ocp_vector_basic_conversions: *level_2
+    Unit_fp8_fnuz_bool_host: *level_2
+    Unit_all_fp8_fnuz_vector_cvt: *level_2
     Unit_fp8_fnuz_correctness: *level_2
-    Unit_fp8_fnuz_vector_basic_conversions:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit__hip_cvt_bfloat16raw_to_e8m0:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit__hip_cvt_float_to_e8m0:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit__hip_cvt_double_to_e8m0:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit__hip_cvt_e8m0_to_bf16raw:
-      <<: *level_2
-      tags: [device_lib, types]
+    Unit_fp8_fnuz_vector_basic_conversions: *level_2
+    Unit__hip_cvt_bfloat16raw_to_e8m0: *level_2
+    Unit__hip_cvt_float_to_e8m0: *level_2
+    Unit__hip_cvt_double_to_e8m0: *level_2
+    Unit__hip_cvt_e8m0_to_bf16raw: *level_2
     Unit_all_fp6_ocp_vector_cvt_interger_data: *level_2
     Unit_all_fp6_ocp_vector_cvt_unsigned_interger_data: *level_2
     Unit_all_fp6_ocp_vector_cvt_unsigned_integer_device: *level_2
     Unit_all_fp6_ocp_vector_cvt_interger_data_device: *level_2
-    Unit_all_fp4_from_double:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_all_fp4_from_double_device:
-      <<: *level_2
-      tags: [device_lib, types]
+    Unit_all_fp4_from_double: *level_2
+    Unit_all_fp4_from_double_device: *level_2
     Unit_all_fp4_from_interger_data: *level_2
     Unit_all_fp4_from__unsigned_integer_data: *level_2
     Unit_all_fp4_from_integer_data_device: *level_2
     Unit_all_fp4_from__unsigned_integer_data_device: *level_2
-    Unit_ocp_fp4_from_double_full_range_host:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_ocp_fp4_from_double_full_range_device:
-      <<: *level_2
-      tags: [device_lib, types]
+    Unit_ocp_fp4_from_double_full_range_host: *level_2
+    Unit_ocp_fp4_from_double_full_range_device: *level_2
     Unit_AtomicAdd_CoherentwithUnsafeflag: *level_2
     Unit_AtomicAdd_Coherentwithoutflag: *level_2
     Unit_AtomicAdd_Coherentwithnounsafeflag: *level_2
     Unit_AtomicAdd_NonCoherentwithoutflag: *level_2
     Unit_AtomicAdd_NonCoherentwithnounsafeflag: *level_2
     Unit_AtomicAdd_NonCoherentwithUnsafeflag: *level_2
-    Unit_BuiltinAtomics_fmaxCoherentGlobalMem:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_BuiltinAtomics_fmaxNonCoherentGlobalFlatMem:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_BuiltinAtomicsRTC_fmaxCoherentGlobalMem:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_BuiltinAtomicsRTC_fmaxNonCoherentGlobalFlatMem:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_BuiltinAtomics_fminCoherentGlobalMem:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_BuiltinAtomics_fminNonCoherentGlobalFlatMem:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_BuiltinAtomicsRTC__fminCoherentGlobalMem:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_BuiltinAtomicsRTC_fminNonCoherentGlobalFlatMem:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_BuiltInAtomicAdd_CoherentGlobalMem:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_BuiltInAtomicAdd_NonCoherentGlobalMem:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_BuiltInAtomicAdd_CoherentGlobalMemWithRtc:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_BuiltinAtomics_fmaxCoherentGlobalMem: *level_2
+    Unit_BuiltinAtomics_fmaxNonCoherentGlobalFlatMem: *level_2
+    Unit_BuiltinAtomicsRTC_fmaxCoherentGlobalMem: *level_2
+    Unit_BuiltinAtomicsRTC_fmaxNonCoherentGlobalFlatMem: *level_2
+    Unit_BuiltinAtomics_fminCoherentGlobalMem: *level_2
+    Unit_BuiltinAtomics_fminNonCoherentGlobalFlatMem: *level_2
+    Unit_BuiltinAtomicsRTC__fminCoherentGlobalMem: *level_2
+    Unit_BuiltinAtomicsRTC_fminNonCoherentGlobalFlatMem: *level_2
+    Unit_BuiltInAtomicAdd_CoherentGlobalMem: *level_2
+    Unit_BuiltInAtomicAdd_NonCoherentGlobalMem: *level_2
+    Unit_BuiltInAtomicAdd_CoherentGlobalMemWithRtc: *level_2
     Unit_BuiltInAtomicAdd_NonCoherentGlobalMemWithRtc:
-      tags: [device_lib, math]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
@@ -1681,2728 +1061,1327 @@ unit:
     Unit_unsafeAtomicAdd_NonCoherentnounsafeatomicsflag: *level_2
     Unit_unsafeAtomicAdd_NonCoherentwithunsafeatomicsflag: *level_2
     Unit_fp8_fnuz_compare_host_device: *level_2
-    Unit_fp8x2_fnuz_compare_host_device:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_fp8x2_fnuz_split_compare:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_fp8x4_fnuz_split_compare:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_fp8_fnuz_bool_device:
-      <<: *level_2
-      tags: [device_lib, types]
-    Unit_all_fp8_fnuz_cvt:
-      <<: *level_2
-      tags: [device_lib, types]
+    Unit_fp8x2_fnuz_compare_host_device: *level_2
+    Unit_fp8x2_fnuz_split_compare: *level_2
+    Unit_fp8x4_fnuz_split_compare: *level_2
+    Unit_fp8_fnuz_bool_device: *level_2
+    Unit_all_fp8_fnuz_cvt: *level_2
     Unit_fp8_fnuz_correctness_device: *level_2
     Dynamic_Alloca: *level_2
   dynamicLoading:
     Unit_dynamic_loading_device_kernels_from_library:
-      tags: [module]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_hipApiDynamicLoad_hipGetProcAddress:
-      <<: *level_2
-      tags: [module]
-    Unit_hipApiDynamicLoad:
-      <<: *level_2
-      tags: [module]
+    Unit_hipApiDynamicLoad_hipGetProcAddress: *level_2
+    Unit_hipApiDynamicLoad: *level_2
   errorHandling:
-    Unit_hipGetErrorName_Positive_Basic:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetErrorName_Negative_Parameters:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetErrorString_Positive_Basic:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetErrorString_Negative_Parameters:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipDrvGetErrorName_Positive_Basic:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipDrvGetErrorName_Negative_Parameters:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipDrvGetErrorString_Positive_Basic:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipDrvGetErrorString_Negative_Parameters:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_Positive_Basic:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_Positive_Threaded:
-      <<: *level_2
-      tags: [error_handling]
+    Unit_hipGetErrorName_Positive_Basic: *level_2
+    Unit_hipGetErrorName_Negative_Parameters: *level_2
+    Unit_hipGetErrorString_Positive_Basic: *level_2
+    Unit_hipGetErrorString_Negative_Parameters: *level_2
+    Unit_hipDrvGetErrorName_Positive_Basic: *level_2
+    Unit_hipDrvGetErrorName_Negative_Parameters: *level_2
+    Unit_hipDrvGetErrorString_Positive_Basic: *level_2
+    Unit_hipDrvGetErrorString_Negative_Parameters: *level_2
+    Unit_hipGetLastError_Positive_Basic: *level_2
+    Unit_hipGetLastError_Positive_Threaded: *level_2
     Unit_hipGetLastError_with_hipMemcpyPeerAsync:
-      tags: [error_handling, multigpu]
       <<: *level_2
-    Unit_hipGetLastError_with_hipMemcpyDtoHAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_with_hipMemcpyParam2DAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_with_hipDrvMemcpy3DAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_with_hipMemcpy3DAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_with_hipMemcpy2D_To_From_ArrayAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_with_hipStreamAttachMemAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_with_hipWaitExternalSemaphoresAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_with_hipSignalExternalSemaphoresAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_with_hipMemPrefetchAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_with_hipMemcpy2DAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_with_hipMemsetAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_with_MemCpyAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_with_MemCpyAsync_thread:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_with_hipGraphAddMemcpyNode1D:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_with_hipStreamBegin_EndCapture:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_error_check_with_hipGraphCreate:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_success_before_hipGetLastError:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_success_before_hipGetLastError_check_again:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_with_Kernel_divide_by_zero:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_with_Kernel_Invalid_Configuration:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_With_Chk_Updated_Status:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_Chk_Along_hipPeekAtLastError:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_Error_Combinations:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_With_Thread:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_MultiProcess:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_Kernel_Invalid_Config:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipPeekAtLastError_Positive_Basic:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipPeekAtLastError_Positive_Threaded:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipPeekAtLastError_Positive:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipPeekAtLastError_Chk_Updated_Status:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipPeekAtLastError_Chk_Along_hipGetLastError:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipPeekAtLastError_Error_Combinations:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipPeekAtLastError_With_Thread:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipPeekAtLastError_MultiProcess:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipPeekAtLastError_Kernel_Invalid_Config:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipGetLastError_KernelFailure_ValidAndInvalidOperations:
-      <<: *level_2
-      tags: [error_handling]
+      tags: [multigpu]
+    Unit_hipGetLastError_with_hipMemcpyDtoHAsync: *level_2
+    Unit_hipGetLastError_with_hipMemcpyParam2DAsync: *level_2
+    Unit_hipGetLastError_with_hipDrvMemcpy3DAsync: *level_2
+    Unit_hipGetLastError_with_hipMemcpy3DAsync: *level_2
+    Unit_hipGetLastError_with_hipMemcpy2D_To_From_ArrayAsync: *level_2
+    Unit_hipGetLastError_with_hipStreamAttachMemAsync: *level_2
+    Unit_hipGetLastError_with_hipWaitExternalSemaphoresAsync: *level_2
+    Unit_hipGetLastError_with_hipSignalExternalSemaphoresAsync: *level_2
+    Unit_hipGetLastError_with_hipMemPrefetchAsync: *level_2
+    Unit_hipGetLastError_with_hipMemcpy2DAsync: *level_2
+    Unit_hipGetLastError_with_hipMemsetAsync: *level_2
+    Unit_hipGetLastError_with_MemCpyAsync: *level_2
+    Unit_hipGetLastError_with_MemCpyAsync_thread: *level_2
+    Unit_hipGetLastError_with_hipGraphAddMemcpyNode1D: *level_2
+    Unit_hipGetLastError_with_hipStreamBegin_EndCapture: *level_2
+    Unit_hipGetLastError_error_check_with_hipGraphCreate: *level_2
+    Unit_hipGetLastError_success_before_hipGetLastError: *level_2
+    Unit_hipGetLastError_success_before_hipGetLastError_check_again: *level_2
+    Unit_hipGetLastError_with_Kernel_divide_by_zero: *level_2
+    Unit_hipGetLastError_with_Kernel_Invalid_Configuration: *level_2
+    Unit_hipGetLastError_With_Chk_Updated_Status: *level_2
+    Unit_hipGetLastError_Chk_Along_hipPeekAtLastError: *level_2
+    Unit_hipGetLastError_Error_Combinations: *level_2
+    Unit_hipGetLastError_With_Thread: *level_2
+    Unit_hipGetLastError_MultiProcess: *level_2
+    Unit_hipGetLastError_Kernel_Invalid_Config: *level_2
+    Unit_hipPeekAtLastError_Positive_Basic: *level_2
+    Unit_hipPeekAtLastError_Positive_Threaded: *level_2
+    Unit_hipPeekAtLastError_Positive: *level_2
+    Unit_hipPeekAtLastError_Chk_Updated_Status: *level_2
+    Unit_hipPeekAtLastError_Chk_Along_hipGetLastError: *level_2
+    Unit_hipPeekAtLastError_Error_Combinations: *level_2
+    Unit_hipPeekAtLastError_With_Thread: *level_2
+    Unit_hipPeekAtLastError_MultiProcess: *level_2
+    Unit_hipPeekAtLastError_Kernel_Invalid_Config: *level_2
+    Unit_hipGetLastError_KernelFailure_ValidAndInvalidOperations: *level_2
     Unit_hipGetLastError_KernelFailure_TwoDevices:
-      tags: [error_handling, multigpu]
       <<: *level_2
-    Unit_hipGetLastError_KernelFailure_TwoStreams:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_Positive_Basic:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_Positive_Threaded:
-      <<: *level_2
-      tags: [error_handling]
+      tags: [multigpu]
+    Unit_hipGetLastError_KernelFailure_TwoStreams: *level_2
+    Unit_hipExtGetLastError_Positive_Basic: *level_2
+    Unit_hipExtGetLastError_Positive_Threaded: *level_2
     Unit_hipExtGetLastError_with_hipMemcpyPeerAsync:
-      tags: [error_handling, multigpu]
       <<: *level_2
-    Unit_hipExtGetLastError_with_hipMemcpyDtoHAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_with_hipMemcpyParam2DAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_with_hipDrvMemcpy3DAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_with_hipMemcpy3DAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_with_hipMemcpy2D_To_From_ArrayAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_with_hipStreamAttachMemAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_with_hipWaitExternalSemaphoresAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_with_hipSignalExternalSemaphoresAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_with_hipMemPrefetchAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_with_hipMemcpy2DAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_with_hipMemsetAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_with_MemCpyAsync:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_with_MemCpyAsync_thread:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_with_hipGraphAddMemcpyNode1D:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_with_hipStreamBegin_EndCapture:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_error_check_with_hipGraphCreate:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_success_before_error_check_again:
-      <<: *level_2
-      tags: [error_handling]
-    Unit_hipExtGetLastError_with_Kernel_divide_by_zero:
-      <<: *level_2
-      tags: [error_handling]
+      tags: [multigpu]
+    Unit_hipExtGetLastError_with_hipMemcpyDtoHAsync: *level_2
+    Unit_hipExtGetLastError_with_hipMemcpyParam2DAsync: *level_2
+    Unit_hipExtGetLastError_with_hipDrvMemcpy3DAsync: *level_2
+    Unit_hipExtGetLastError_with_hipMemcpy3DAsync: *level_2
+    Unit_hipExtGetLastError_with_hipMemcpy2D_To_From_ArrayAsync: *level_2
+    Unit_hipExtGetLastError_with_hipStreamAttachMemAsync: *level_2
+    Unit_hipExtGetLastError_with_hipWaitExternalSemaphoresAsync: *level_2
+    Unit_hipExtGetLastError_with_hipSignalExternalSemaphoresAsync: *level_2
+    Unit_hipExtGetLastError_with_hipMemPrefetchAsync: *level_2
+    Unit_hipExtGetLastError_with_hipMemcpy2DAsync: *level_2
+    Unit_hipExtGetLastError_with_hipMemsetAsync: *level_2
+    Unit_hipExtGetLastError_with_MemCpyAsync: *level_2
+    Unit_hipExtGetLastError_with_MemCpyAsync_thread: *level_2
+    Unit_hipExtGetLastError_with_hipGraphAddMemcpyNode1D: *level_2
+    Unit_hipExtGetLastError_with_hipStreamBegin_EndCapture: *level_2
+    Unit_hipExtGetLastError_error_check_with_hipGraphCreate: *level_2
+    Unit_hipExtGetLastError_success_before_error_check_again: *level_2
+    Unit_hipExtGetLastError_with_Kernel_divide_by_zero: *level_2
   event:
-    Unit_hipEventCreate_NullCheck:
-      <<: *level_2
-      tags: [event]
-    Unit_hipEventCreateWithFlags_NullCheck:
-      <<: *level_2
-      tags: [event]
-    Unit_hipEventCreate_IncompatibleFlags:
-      <<: *level_2
-      tags: [event]
-    Unit_hipEventSynchronize_NullCheck:
-      <<: *level_2
-      tags: [event]
-    Unit_hipEventQuery_NullCheck:
-      <<: *level_2
-      tags: [event]
-    Unit_hipEventDestroy_NullCheck:
-      <<: *level_2
-      tags: [event]
+    Unit_hipEventCreate_NullCheck: *level_2
+    Unit_hipEventCreateWithFlags_NullCheck: *level_2
+    Unit_hipEventCreate_IncompatibleFlags: *level_2
+    Unit_hipEventSynchronize_NullCheck: *level_2
+    Unit_hipEventQuery_NullCheck: *level_2
+    Unit_hipEventDestroy_NullCheck: *level_2
     Unit_hipEvent:
-      tags: [event]
       <<: *level_2
       # SWDEV-411303 fails in WSL. Profiling not support in WSL
       disabled: [amd_wsl]
-    Unit_hipEventElapsedTime_NullCheck:
-      <<: *level_2
-      tags: [event, sync]
-    Unit_hipEventElapsedTime_DisableTiming:
-      <<: *level_2
-      tags: [event, sync]
+    Unit_hipEventElapsedTime_NullCheck: *level_2
+    Unit_hipEventElapsedTime_DisableTiming: *level_2
     Unit_hipEventElapsedTime_DifferentDevices:
-      tags: [event, sync, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipEventElapsedTime_NotReady_Negative:
-      tags: [event, sync]
       <<: *level_2
       # SWDEV-411303 fails in WSL. Profiling not support in WSL
       disabled: [amd_wsl]
-    Unit_hipEventElapsedTime:
-      <<: *level_2
-      tags: [event, sync]
-    Unit_hipEventElapsedTime_Verify_Capture:
-      <<: *level_2
-      tags: [event, sync]
+    Unit_hipEventElapsedTime: *level_2
+    Unit_hipEventElapsedTime_Verify_Capture: *level_2
     Unit_hipEventRecord:
-      tags: [event, sync]
       <<: *level_2
       disabled: [amd_windows]
     Unit_hipEventRecord_Negative:
-      tags: [event, sync, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipEventIpc:
-      tags: [event, ipc]
       <<: *level_2
       # (amd_wsl) Below tests fail in stress test on 24/07/23
       disabled: [amd_windows, amd_wsl]
     Unit_hipEventDestroy_Unfinished:
-      tags: [event, lifecycle]
       <<: *level_2
       # SWDEV-411303 fails in WSL. Profiling not support in WSL
       disabled: [amd_wsl]
     Unit_hipEventDestroy_WithWaitingStream:
-      tags: [event, lifecycle]
       <<: *level_2
       # SWDEV-402054 fails in external github build
       disabled: [amd_windows, amd_wsl]
-    Unit_hipEventDestroy_Negative:
-      <<: *level_2
-      tags: [event, lifecycle]
-    Unit_hipEventDestroy_Verify_Capture:
-      <<: *level_2
-      tags: [event, lifecycle]
-    Unit_hipEventCreate_Positive:
-      <<: *level_2
-      tags: [event, lifecycle]
-    Unit_hipEventCreate_Verify_Capture:
-      <<: *level_2
-      tags: [event, lifecycle]
-    Unit_hipEventCreateWithFlags_Positive:
-      <<: *level_2
-      tags: [event, lifecycle]
+    Unit_hipEventDestroy_Negative: *level_2
+    Unit_hipEventDestroy_Verify_Capture: *level_2
+    Unit_hipEventCreate_Positive: *level_2
+    Unit_hipEventCreate_Verify_Capture: *level_2
+    Unit_hipEventCreateWithFlags_Positive: *level_2
     Unit_hipEventCreateWithFlags_DisableSystemFence_HstVisMem:
-      tags: [event, lifecycle]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipEventCreateWithFlags_DefaultFlg_HstVisMem:
-      tags: [event, lifecycle]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipEventCreateWithFlags_DisableSystemFence_NonCohHstMem:
-      tags: [event, lifecycle]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipEventCreateWithFlags_DefaultFlg_NonCohHstMem:
-      tags: [event, lifecycle]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipEventCreateWithFlags_DisableSystemFence_CohHstMem:
-      tags: [event, lifecycle]
       <<: *level_2
       # (amd_linux) SWDEV-470751 : Fine Grain memory is MTYPE_NC due to HW bug.
       # (amd_windows) Note: intermittent Seg fault failure
       disabled: [gfx1200, gfx1201, amd_windows, amd_wsl]
     Unit_hipEventCreateWithFlags_DefaultFlg_CohHstMem:
-      tags: [event, lifecycle]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
-    Unit_hipEventCreateWithFlags_Verify_Capture:
-      <<: *level_2
-      tags: [event, lifecycle]
-    Unit_hipEventSynchronize_Default_Positive:
-      <<: *level_2
-      tags: [event, sync]
-    Unit_hipEventSynchronize_NoEventRecord_Positive:
-      <<: *level_2
-      tags: [event, sync]
-    Unit_hipEventMGpuMThreads_1:
-      <<: *level_2
-      tags: [event]
+    Unit_hipEventCreateWithFlags_Verify_Capture: *level_2
+    Unit_hipEventSynchronize_Default_Positive: *level_2
+    Unit_hipEventSynchronize_NoEventRecord_Positive: *level_2
+    Unit_hipEventMGpuMThreads_1: *level_2
     Unit_hipEventMGpuMThreads_2:
-      tags: [event, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipEventMGpuMThreads_3:
-      tags: [event, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipEventQuery_DifferentDevice:
-      tags: [event, sync, multigpu]
       <<: *level_2
-    Unit_hipEventIpc_shm_cleanup:
-      <<: *level_2
-      tags: [event, ipc]
+      tags: [multigpu]
+    Unit_hipEventIpc_shm_cleanup: *level_2
   executionControl:
     Unit_hipFuncGetAttributes_Positive_Basic:
-      tags: [kernel, attributes]
       <<: *level_2
       # NOTE: The following test is disabled due to defect - EXSWHTEC-242
       disabled: [amd_linux, amd_windows]
-    Unit_hipFuncGetAttributes_Negative_Parameters:
-      <<: *level_2
-      tags: [kernel, attributes]
-    Unit_hipLaunchKernel_Positive_Basic:
-      <<: *level_2
-      tags: [kernel, launch]
-    Unit_hipLaunchKernel_Positive_Parameters:
-      <<: *level_2
-      tags: [kernel, launch]
+    Unit_hipFuncGetAttributes_Negative_Parameters: *level_2
+    Unit_hipLaunchKernel_Positive_Basic: *level_2
+    Unit_hipLaunchKernel_Positive_Parameters: *level_2
     Unit_hipLaunchKernel_Negative_Parameters:
-      tags: [kernel, launch]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipLaunchKernel_Verify_Capture: *level_2
-    Unit_hipLaunchCooperativeKernel_Positive_Basic:
-      <<: *level_2
-      tags: [kernel]
-    Unit_hipLaunchCooperativeKernel_Positive_Parameters:
-      <<: *level_2
-      tags: [kernel]
-    Unit_hipLaunchCooperativeKernel_Negative_Parameters:
-      <<: *level_2
-      tags: [kernel]
+    Unit_hipLaunchCooperativeKernel_Positive_Basic: *level_2
+    Unit_hipLaunchCooperativeKernel_Positive_Parameters: *level_2
+    Unit_hipLaunchCooperativeKernel_Negative_Parameters: *level_2
     Unit_hipLaunchCooperativeKernel_Verify_Capture: *level_2
     Unit_hipLaunchCooperativeKernelMultiDevice_Positive_Basic:
-      tags: [multigpu, kernel]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipLaunchCooperativeKernelMultiDevice_Negative_Parameters:
-      tags: [multigpu, kernel]
       <<: *level_2
-    Unit_hipLaunchCooperativeKernelMultiDevice_Negative_MultiKernelSameDevice:
-      <<: *level_2
-      tags: [kernel]
-    Unit_hipExtLaunchKernel_Positive_Basic:
-      <<: *level_2
-      tags: [kernel, launch]
-    Unit_hipExtLaunchKernel_Positive_Parameters:
-      <<: *level_2
-      tags: [kernel, launch]
-    Unit_hipExtLaunchKernel_Negative_Parameters:
-      <<: *level_2
-      tags: [kernel, launch]
-    Unit_hipExtLaunchKernel_capturehipExtLaunchKernel:
-      <<: *level_2
-      tags: [kernel, launch]
+      tags: [multigpu]
+    Unit_hipLaunchCooperativeKernelMultiDevice_Negative_MultiKernelSameDevice: *level_2
+    Unit_hipExtLaunchKernel_Positive_Basic: *level_2
+    Unit_hipExtLaunchKernel_Positive_Parameters: *level_2
+    Unit_hipExtLaunchKernel_Negative_Parameters: *level_2
+    Unit_hipExtLaunchKernel_capturehipExtLaunchKernel: *level_2
     Unit_hipExtLaunchMultiKernelMultiDevice_Positive_Basic:
-      tags: [multigpu, kernel, launch]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipExtLaunchMultiKernelMultiDevice_Negative_Parameters:
-      tags: [multigpu, kernel, launch]
       <<: *level_2
+      tags: [multigpu]
       # NOTE: The following test is disabled due to defect - EXSWHTEC-244
       disabled: [amd_linux, amd_windows]
-    Unit_hipExtLaunchMultiKernelMultiDevice_Negative_MultiKernelSameDevice:
-      <<: *level_2
-      tags: [kernel, launch]
-    Unit_hipLaunchByPtr_Positive_Basic:
-      <<: *level_2
-      tags: [kernel, launch]
-    Unit_hipLaunchByPtr_Negative_Parameters:
-      <<: *level_2
-      tags: [kernel, launch]
-    Unit___hipPushCallConfiguration_Positive_Basic:
-      <<: *level_2
-      tags: [kernel, launch]
+    Unit_hipExtLaunchMultiKernelMultiDevice_Negative_MultiKernelSameDevice: *level_2
+    Unit_hipLaunchByPtr_Positive_Basic: *level_2
+    Unit_hipLaunchByPtr_Negative_Parameters: *level_2
+    Unit___hipPushCallConfiguration_Positive_Basic: *level_2
     Unit_hipLaunchByPtr_Verify_Capture: *level_2
-    Unit_hipGetProcAddress_KernelLaunchApis:
-      <<: *level_2
-      tags: [kernel]
-    Unit_hipGetProcAddress_CallbackActivityAPIs:
-      <<: *level_2
-      tags: [kernel]
-    Unit_hipGetProcAddress_ExecutionControlAPIs:
-      <<: *level_2
-      tags: [kernel]
+    Unit_hipGetProcAddress_KernelLaunchApis: *level_2
+    Unit_hipGetProcAddress_CallbackActivityAPIs: *level_2
+    Unit_hipGetProcAddress_ExecutionControlAPIs: *level_2
     Unit_hipFuncSetCacheConfig_Positive_Basic:
-      tags: [kernel, attributes]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipFuncSetCacheConfig_Negative_Parameters:
-      tags: [kernel, attributes]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
-    Unit_hipFuncSetCacheConfig_Negative_Not_Supported:
-      <<: *level_2
-      tags: [kernel, attributes]
+    Unit_hipFuncSetCacheConfig_Negative_Not_Supported: *level_2
     Unit_hipFuncSetSharedMemConfig_Positive_Basic:
-      tags: [kernel, attributes]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
-    Unit_hipFuncSetSharedMemConfig_Negative_Parameters:
-      <<: *level_2
-      tags: [kernel, attributes]
-    Unit_hipFuncSetSharedMemConfig_Negative_Not_Supported:
-      <<: *level_2
-      tags: [kernel, attributes]
-    Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize:
-      <<: *level_2
-      tags: [kernel, attributes]
+    Unit_hipFuncSetSharedMemConfig_Negative_Parameters: *level_2
+    Unit_hipFuncSetSharedMemConfig_Negative_Not_Supported: *level_2
+    Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize: *level_2
     Unit_hipFuncSetAttribute_Positive_PreferredSharedMemoryCarveout:
-      tags: [kernel, attributes]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
-    Unit_hipFuncSetAttribute_Positive_Parameters:
-      <<: *level_2
-      tags: [kernel, attributes]
-    Unit_hipFuncSetAttribute_Negative_Parameters:
-      <<: *level_2
-      tags: [kernel, attributes]
-    Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize_Not_Supported:
-      <<: *level_2
-      tags: [kernel, attributes]
-    Unit_hipFuncSetAttribute_Positive_PreferredSharedMemoryCarveout_Not_Supported:
-      <<: *level_2
-      tags: [kernel, attributes]
+    Unit_hipFuncSetAttribute_Positive_Parameters: *level_2
+    Unit_hipFuncSetAttribute_Negative_Parameters: *level_2
+    Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize_Not_Supported: *level_2
+    Unit_hipFuncSetAttribute_Positive_PreferredSharedMemoryCarveout_Not_Supported: *level_2
   g++:
-    Unit_hipMalloc_gpptest:
-      <<: *level_2
-      tags: [compiler]
+    Unit_hipMalloc_gpptest: *level_2
   gcc:
-    Unit_LaunchKernelgccTests:
-      <<: *level_2
-      tags: [compiler]
-    Unit_hipMallocgccTests:
-      <<: *level_2
-      tags: [compiler]
+    Unit_LaunchKernelgccTests: *level_2
+    Unit_hipMallocgccTests: *level_2
   gl_interop:
     Unit_hipGLGetDevices_Positive_Basic:
-      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGLGetDevices_Positive_Parameters:
-      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGLGetDevices_Negative_Parameters:
-      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsGLRegisterBuffer_Positive_Basic:
-      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsGLRegisterBuffer_Positive_Register_Twice:
-      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsGLRegisterBuffer_Negative_Parameters:
-      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsGLRegisterImage_Positive_Basic:
-      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsGLRegisterImage_Positive_Register_Twice:
-      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsGLRegisterImage_Negative_Parameters:
-      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsMapResources_Positive_Basic:
-      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsMapResources_Negative_Parameters:
-      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_linux, amd_wsl]
     Unit_hipGraphicsResourceGetMappedPointer_Positive_Basic:
-      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsResourceGetMappedPointer_Positive_Parameters:
-      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_linux, amd_wsl]
     Unit_hipGraphicsResourceGetMappedPointer_Negative_Parameters:
-      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_linux, amd_wsl]
     Unit_hipGraphicsSubResourceGetMappedArray_Positive_Basic:
-      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsSubResourceGetMappedArray_Negative_Parameters:
-      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_linux, amd_wsl]
     Unit_hipGraphicsUnmapResources_Negative_Parameters:
-      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_linux, amd_wsl]
     Unit_hipGraphicsUnregisterResource_Negative_Parameters:
-      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_linux, amd_wsl]
   graph:
-    Unit_hipGraphAddEmptyNode_Functional:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddEmptyNode_NegTest:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddEmptyNode_BarrierFunc:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddDependencies_Positive_Functional:
-      <<: *level_2
-      tags: [graph, dependency]
-    Unit_hipGraphAddDependencies_Positive_Parameters:
-      <<: *level_2
-      tags: [graph, dependency]
-    Unit_hipGraphAddDependencies_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, dependency]
-    Unit_hipGraphAddDependencies_Functional:
-      <<: *level_2
-      tags: [graph, dependency]
-    Unit_hipGraphAddDependencies_NegTest:
-      <<: *level_2
-      tags: [graph, dependency]
-    Unit_hipGraphAddEventRecordNode_Functional_Simple:
-      <<: *level_2
-      tags: [graph, node]
+    Unit_hipGraphAddEmptyNode_Functional: *level_2
+    Unit_hipGraphAddEmptyNode_NegTest: *level_2
+    Unit_hipGraphAddEmptyNode_BarrierFunc: *level_2
+    Unit_hipGraphAddDependencies_Positive_Functional: *level_2
+    Unit_hipGraphAddDependencies_Positive_Parameters: *level_2
+    Unit_hipGraphAddDependencies_Negative_Parameters: *level_2
+    Unit_hipGraphAddDependencies_Functional: *level_2
+    Unit_hipGraphAddDependencies_NegTest: *level_2
+    Unit_hipGraphAddEventRecordNode_Functional_Simple: *level_2
     Unit_hipGraphAddEventRecordNode_Functional_WithoutFlags:
-      tags: [graph, node]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipGraphAddEventRecordNode_Functional_ElapsedTime:
-      tags: [graph, node]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphAddEventRecordNode_Functional_WithFlags:
-      <<: *level_2
-      tags: [graph, node]
+    Unit_hipGraphAddEventRecordNode_Functional_WithFlags: *level_2
     Unit_hipGraphAddEventRecordNode_MultipleRun:
-      tags: [graph, node]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphAddEventRecordNode_Functional_TimingDisabled:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddEventRecordNode_Positive_Parameters:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddEventRecordNode_Negative:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddEventWaitNode_Functional_Simple:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddEventWaitNode_MultGraphMultStrmDependency:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddEventWaitNode_MultipleRun:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddEventWaitNode_MultGraphOneStrmDependency:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddEventWaitNode_differentFlags:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddEventWaitNode_Positive_Parameters:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddEventWaitNode_Negative:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraph_BasicFunctional:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraph_SimpleGraphWithKernel:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphAddMemcpyNode_Positive_Basic:
-      <<: *level_2
-      tags: [graph, node]
+    Unit_hipGraphAddEventRecordNode_Functional_TimingDisabled: *level_2
+    Unit_hipGraphAddEventRecordNode_Positive_Parameters: *level_2
+    Unit_hipGraphAddEventRecordNode_Negative: *level_2
+    Unit_hipGraphAddEventWaitNode_Functional_Simple: *level_2
+    Unit_hipGraphAddEventWaitNode_MultGraphMultStrmDependency: *level_2
+    Unit_hipGraphAddEventWaitNode_MultipleRun: *level_2
+    Unit_hipGraphAddEventWaitNode_MultGraphOneStrmDependency: *level_2
+    Unit_hipGraphAddEventWaitNode_differentFlags: *level_2
+    Unit_hipGraphAddEventWaitNode_Positive_Parameters: *level_2
+    Unit_hipGraphAddEventWaitNode_Negative: *level_2
+    Unit_hipGraph_BasicFunctional: *level_2
+    Unit_hipGraph_SimpleGraphWithKernel: *level_2
+    Unit_hipGraphAddMemcpyNode_Positive_Basic: *level_2
     Unit_hipGraphAddMemcpyNode_Negative_Parameters:
-      tags: [graph, node]
       <<: *level_2
       # NOTE: The following test is disabled due to defect - EXSWHTEC-245
       disabled: [amd_windows]
-    Unit_hipGraphAddMemcpyNode_Negative:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemcpyNode_BasicFunctional:
-      <<: *level_2
-      tags: [graph, node]
+    Unit_hipGraphAddMemcpyNode_Negative: *level_2
+    Unit_hipGraphAddMemcpyNode_BasicFunctional: *level_2
     Unit_hipGraphAddMemcpyNode_PeerAccessFunctional:
-      tags: [graph, node, multigpu]
       <<: *level_2
-    Unit_hipGraphAddMemcpyNode_HostToHost:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphClone_Negative:
-      <<: *level_2
-      tags: [graph, lifecycle]
+      tags: [multigpu]
+    Unit_hipGraphAddMemcpyNode_HostToHost: *level_2
+    Unit_hipGraphClone_Negative: *level_2
     Unit_hipGraphClone_Functional:
-      tags: [graph, lifecycle, multigpu]
       <<: *level_2
-    Unit_hipGraphClone_MultiThreaded:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphInstantiateWithFlags_Negative:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphInstantiateWithFlags_DependencyGraph:
-      <<: *level_2
-      tags: [graph, lifecycle]
+      tags: [multigpu]
+    Unit_hipGraphClone_MultiThreaded: *level_2
+    Unit_hipGraphInstantiateWithFlags_Negative: *level_2
+    Unit_hipGraphInstantiateWithFlags_DependencyGraph: *level_2
     Unit_hipGraphInstantiateWithFlags_DependencyGraphDeviceCtxtChg:
-      tags: [graph, lifecycle, multigpu]
       <<: *level_2
+      tags: [multigpu]
       # Enable the below test when multi-device graph launches are fully supported
       disabled: [amd_linux]
-    Unit_hipGraphInstantiateWithFlags_StreamCapture:
-      <<: *level_2
-      tags: [graph, lifecycle]
+    Unit_hipGraphInstantiateWithFlags_StreamCapture: *level_2
     Unit_hipGraphInstantiateWithFlags_StreamCaptureDeviceContextChg:
-      tags: [graph, lifecycle, multigpu]
       <<: *level_2
+      tags: [multigpu]
       # SWDEV-445928: These tests fail in PSDB stress test on 09/02/2024
       disabled: [amd_linux]
     Unit_hipGraphInstantiateWithFlags_FlagAutoFreeOnLaunch_check:
-      tags: [graph, lifecycle]
       <<: *level_2
       # SWDEV-402082 - PAL Backend fails to reserve address on GPU except first one
       disabled: [amd_windows, amd_wsl]
     Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchInLoop:
-      tags: [graph, lifecycle]
       <<: *level_2
       # SWDEV-517063 Below tests are temporarily disabled due to PSDB failure
       disabled: [amd_windows]
     Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchFillKernel:
-      tags: [graph, lifecycle]
       <<: *level_2
       # SWDEV-517063 Below tests are temporarily disabled due to PSDB failure
       disabled: [amd_windows]
     Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchDoubleKernel:
-      tags: [graph, lifecycle]
       <<: *level_2
       # SWDEV-517063 Below tests are temporarily disabled due to PSDB failure
       disabled: [amd_windows]
     Unit_hipGraphInstantiateWithFlags_WithDefaultAndAutoFreeOnLaunch:
-      tags: [graph, lifecycle]
       <<: *level_2
       # SWDEV-517063 Below tests are temporarily disabled due to PSDB failure
       disabled: [amd_windows]
     Unit_hipGraphInstantiateWithParams_Negative:
-      tags: [graph, lifecycle]
       <<: *level_2
       # Unit_hipGraphInstantiateWithParams_Negative
       disabled: [nvidia_windows]
-    Unit_hipGraphInstantiateWithParams_DependencyGraph:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphInstantiateWithParams_StreamCapture:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphAddHostNode_Negative:
-      <<: *level_2
-      tags: [graph, node]
+    Unit_hipGraphInstantiateWithParams_DependencyGraph: *level_2
+    Unit_hipGraphInstantiateWithParams_StreamCapture: *level_2
+    Unit_hipGraphAddHostNode_Negative: *level_2
     Unit_hipGraphAddHostNode_ClonedGraphWithHostNode:
-      tags: [graph, node]
       <<: *level_2
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphAddHostNode_VectorSquare:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddHostNode_BasicFunc:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemcpyNodeFromSymbol_Negative:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemory:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalConstMemory:
-      <<: *level_2
-      tags: [graph, node]
+    Unit_hipGraphAddHostNode_VectorSquare: *level_2
+    Unit_hipGraphAddHostNode_BasicFunc: *level_2
+    Unit_hipGraphAddMemcpyNodeFromSymbol_Negative: *level_2
+    Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemory: *level_2
+    Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalConstMemory: *level_2
     Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemoryPeerDevice:
-      tags: [graph, node, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalConstMemoryPeerDevice:
-      tags: [graph, node, multigpu]
       <<: *level_2
-    Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemoryWithKernel:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemcpyNodeFromSymbol_Positive_Basic:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemcpyNodeFromSymbol_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphChildGraphNodeGetGraph_Functional:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphChildGraphNodeGetGraph_Negative:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphNodeFindInClone_Negative:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphNodeFindInClone_Functional:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphNodeFindInClone_MultipleClone:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphExecHostNodeSetParams_Negative:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecHostNodeSetParams_ClonedGraphWithHostNode:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecHostNodeSetParams_BasicFunc:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphAddMemcpyNodeToSymbol_Negative:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemcpyNodeToSymbol_GlobalMemory:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemcpyNodeToSymbol_GlobalConstMemory:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemcpyNodeToSymbol_GlobalMemoryPeerDevice:
-      <<: *level_2
-      tags: [graph, node]
+      tags: [multigpu]
+    Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemoryWithKernel: *level_2
+    Unit_hipGraphAddMemcpyNodeFromSymbol_Positive_Basic: *level_2
+    Unit_hipGraphAddMemcpyNodeFromSymbol_Negative_Parameters: *level_2
+    Unit_hipGraphChildGraphNodeGetGraph_Functional: *level_2
+    Unit_hipGraphChildGraphNodeGetGraph_Negative: *level_2
+    Unit_hipGraphNodeFindInClone_Negative: *level_2
+    Unit_hipGraphNodeFindInClone_Functional: *level_2
+    Unit_hipGraphNodeFindInClone_MultipleClone: *level_2
+    Unit_hipGraphExecHostNodeSetParams_Negative: *level_2
+    Unit_hipGraphExecHostNodeSetParams_ClonedGraphWithHostNode: *level_2
+    Unit_hipGraphExecHostNodeSetParams_BasicFunc: *level_2
+    Unit_hipGraphAddMemcpyNodeToSymbol_Negative: *level_2
+    Unit_hipGraphAddMemcpyNodeToSymbol_GlobalMemory: *level_2
+    Unit_hipGraphAddMemcpyNodeToSymbol_GlobalConstMemory: *level_2
+    Unit_hipGraphAddMemcpyNodeToSymbol_GlobalMemoryPeerDevice: *level_2
     Unit_hipGraphAddMemcpyNodeToSymbol_GlobalConstMemoryPeerDevice:
-      tags: [graph, node, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGraphAddMemcpyNodeToSymbol_MemcpyToSymbolNodeWithKernel:
-      tags: [graph, node, multigpu]
       <<: *level_2
-    Unit_hipGraphAddMemcpyNodeToSymbol_Positive_Basic:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemcpyNodeToSymbol_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, node]
+      tags: [multigpu]
+    Unit_hipGraphAddMemcpyNodeToSymbol_Positive_Basic: *level_2
+    Unit_hipGraphAddMemcpyNodeToSymbol_Negative_Parameters: *level_2
     Unit_hipGraphExecMemsetNodeSetParams_Positive_Basic: *level_2
     Unit_hipGraphExecMemsetNodeSetParams_Negative_Parameters:
-      tags: [graph, exec, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGraphExecMemsetNodeSetParams_Negative_Updating_Non1D_Node:
-      tags: [graph, exec]
       <<: *level_2
       # Note: Test disabled due to defect - EXSWHTEC-207
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphMemcpyNodeSetParamsToSymbol_Negative:
-      <<: *level_2
-      tags: [graph, node]
+    Unit_hipGraphMemcpyNodeSetParamsToSymbol_Negative: *level_2
     Unit_hipGraphMemcpyNodeSetParamsToSymbol_Functional:
-      tags: [graph, node]
       <<: *level_2
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipGraphMemcpyNodeSetParamsToSymbol_Positive_Basic:
-      tags: [graph, node]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphMemcpyNodeSetParamsToSymbol_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphDestroyNode_Negative:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphDestroyNode_BasicFunctionality:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphDestroyNode_DestroyDependencyNode:
-      <<: *level_2
-      tags: [graph, lifecycle]
+    Unit_hipGraphMemcpyNodeSetParamsToSymbol_Negative_Parameters: *level_2
+    Unit_hipGraphDestroyNode_Negative: *level_2
+    Unit_hipGraphDestroyNode_BasicFunctionality: *level_2
+    Unit_hipGraphDestroyNode_DestroyDependencyNode: *level_2
     Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep:
-      tags: [graph, lifecycle]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ClonedGrph:
-      tags: [graph, lifecycle]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ChldNode:
-      tags: [graph, lifecycle]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphGetNodes_Positive_Functional:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphGetNodes_Positive_CapturedStream:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphGetNodes_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphGetNodes_Functional:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphGetNodes_CapturedStream:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphGetNodes_ParamValidation:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphGetRootNodes_Positive_Functional:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphGetRootNodes_Positive_CapturedStream:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphGetRootNodes_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphGetRootNodes_Functional:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphGetRootNodes_CapturedStream:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphGetRootNodes_ParamValidation:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphGetRootNodes_Complx_NumRootNodes:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphGetRootNodes_Complx_NumRootNodes_ClonedGrph:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphGetRootNodes_Complx_NRootNodesAsChildGraph:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphHostNodeSetParams_Negative:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphHostNodeSetParams_ClonedGraphWithHostNode:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphHostNodeSetParams_BasicFunc:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemcpyNode1D_Positive_Basic:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemcpyNode1D_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddChildGraphNode_Negative:
-      <<: *level_2
-      tags: [graph, node]
+    Unit_hipGraphGetNodes_Positive_Functional: *level_2
+    Unit_hipGraphGetNodes_Positive_CapturedStream: *level_2
+    Unit_hipGraphGetNodes_Negative_Parameters: *level_2
+    Unit_hipGraphGetNodes_Functional: *level_2
+    Unit_hipGraphGetNodes_CapturedStream: *level_2
+    Unit_hipGraphGetNodes_ParamValidation: *level_2
+    Unit_hipGraphGetRootNodes_Positive_Functional: *level_2
+    Unit_hipGraphGetRootNodes_Positive_CapturedStream: *level_2
+    Unit_hipGraphGetRootNodes_Negative_Parameters: *level_2
+    Unit_hipGraphGetRootNodes_Functional: *level_2
+    Unit_hipGraphGetRootNodes_CapturedStream: *level_2
+    Unit_hipGraphGetRootNodes_ParamValidation: *level_2
+    Unit_hipGraphGetRootNodes_Complx_NumRootNodes: *level_2
+    Unit_hipGraphGetRootNodes_Complx_NumRootNodes_ClonedGrph: *level_2
+    Unit_hipGraphGetRootNodes_Complx_NRootNodesAsChildGraph: *level_2
+    Unit_hipGraphHostNodeSetParams_Negative: *level_2
+    Unit_hipGraphHostNodeSetParams_ClonedGraphWithHostNode: *level_2
+    Unit_hipGraphHostNodeSetParams_BasicFunc: *level_2
+    Unit_hipGraphAddMemcpyNode1D_Positive_Basic: *level_2
+    Unit_hipGraphAddMemcpyNode1D_Negative_Parameters: *level_2
+    Unit_hipGraphAddChildGraphNode_Negative: *level_2
     Unit_hipGraphAddChildGraphNode_OrgGraphAsChildGraph:
-      tags: [graph, node]
       <<: *level_2
       # Disabling tests which no longer behave the same on nvidia platform
       disabled: [nvidia_windows]
-    Unit_hipGraphAddChildGraphNode_ExecuteChildGraph:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddChildGraphNode_CloneChildGraph:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddChildGraphNode_MultipleChildNodes:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddChildGraphNode_SingleChildNode:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddChildGraphNode_Cmplx_NestedGraphs:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddChildGraphNode_CmplxClone_NestedGraphs:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddChildGraphNode_EmptyGraphAsChildNode:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerFun:
-      <<: *level_2
-      tags: [graph, node]
+    Unit_hipGraphAddChildGraphNode_ExecuteChildGraph: *level_2
+    Unit_hipGraphAddChildGraphNode_CloneChildGraph: *level_2
+    Unit_hipGraphAddChildGraphNode_MultipleChildNodes: *level_2
+    Unit_hipGraphAddChildGraphNode_SingleChildNode: *level_2
+    Unit_hipGraphAddChildGraphNode_Cmplx_NestedGraphs: *level_2
+    Unit_hipGraphAddChildGraphNode_CmplxClone_NestedGraphs: *level_2
+    Unit_hipGraphAddChildGraphNode_EmptyGraphAsChildNode: *level_2
+    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerFun: *level_2
     Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerFun_Clone:
-      tags: [graph, node]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/92
       disabled: [amd_wsl]
-    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerDim:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_DelAddNode:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddNode_Clone:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddChdNode:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddChdNode_Clone:
-      <<: *level_2
-      tags: [graph, node]
+    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerDim: *level_2
+    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_DelAddNode: *level_2
+    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddNode_Clone: *level_2
+    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddChdNode: *level_2
+    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddChdNode_Clone: *level_2
     Unit_hipGraphAddChildGraphNode_MultGraphsAsSingleGraph:
-      tags: [graph, node]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipGraphAddChildGraphNode_CmplxNstGrph_MultGPU:
-      tags: [graph, node, multigpu]
       <<: *level_2
-    Unit_hipGraphNodeGetType_Negative:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphNodeGetType_Functional:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphNodeGetType_NodeType:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphNodeGetType_NodeTypeOfClonedGraph_NodeTypeInThread:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphNodeGetType_NodeTypeOfChildGraph:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphNodeGetType_ClonedGraph_InThread_WithDependencies:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphNodeGetType_NodeTypeOfChildGraph_WithDependency:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphExecMemcpyNodeSetParams1D_Functional:
-      <<: *level_2
-      tags: [graph, exec]
+      tags: [multigpu]
+    Unit_hipGraphNodeGetType_Negative: *level_2
+    Unit_hipGraphNodeGetType_Functional: *level_2
+    Unit_hipGraphNodeGetType_NodeType: *level_2
+    Unit_hipGraphNodeGetType_NodeTypeOfClonedGraph_NodeTypeInThread: *level_2
+    Unit_hipGraphNodeGetType_NodeTypeOfChildGraph: *level_2
+    Unit_hipGraphNodeGetType_ClonedGraph_InThread_WithDependencies: *level_2
+    Unit_hipGraphNodeGetType_NodeTypeOfChildGraph_WithDependency: *level_2
+    Unit_hipGraphExecMemcpyNodeSetParams1D_Functional: *level_2
     Unit_hipGraphExecMemcpyNodeSetParams1D_Negative:
-      tags: [graph, exec]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
-    Unit_hipGraphExecMemcpyNodeSetParams1D_Positive_Basic:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecMemcpyNodeSetParams1D_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecMemcpyNodeSetParams1D_Negative_Changing_Memcpy_Direction:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphGetEdges_Positive_Functional:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphGetEdges_Positive_CapturedStream:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphGetEdges_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphGetEdges_Functionality:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphGetEdges_Negative:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphRemoveDependencies_Positive_Functional:
-      <<: *level_2
-      tags: [graph, dependency]
-    Unit_hipGraphRemoveDependenciesPositive_CapturedStream:
-      <<: *level_2
-      tags: [graph, dependency]
-    Unit_hipGraphRemoveDependencies_Positive_ChangeComputeFunc:
-      <<: *level_2
-      tags: [graph, dependency]
-    Unit_hipGraphRemoveDependencies_Positive_Parameters:
-      <<: *level_2
-      tags: [graph, dependency]
-    Unit_hipGraphRemoveDependencies_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, dependency]
-    Unit_hipGraphRemoveDependencies_Func_Manual:
-      <<: *level_2
-      tags: [graph, dependency]
-    Unit_hipGraphRemoveDependencies_Func_StrmCapture:
-      <<: *level_2
-      tags: [graph, dependency]
-    Unit_hipGraphRemoveDependencies_ChangeComputeFunc:
-      <<: *level_2
-      tags: [graph, dependency]
-    Unit_hipGraphRemoveDependencies_Negative:
-      <<: *level_2
-      tags: [graph, dependency]
-    Unit_hipGraphInstantiate_Negative:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphInstantiate_Basic:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphInstantiate_InvalidCyclicGraph:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphInstantiate_functionalScenarios:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphExecUpdate_Negative_Basic:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecUpdate_Negative_TypeChange:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecUpdate_Negative_CountDiffer:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecUpdate_Functional:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecUpdate_Negative_Functional_ParametersChanged:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecUpdate_Negative_Functional_CountDiffer_1:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecUpdate_Negative_Functional_CountDiffer_2:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecUpdate_Negative_Dependent_NodesDiffer:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecUpdate_Negative_NodeType_Changed:
-      <<: *level_2
-      tags: [graph, exec]
+    Unit_hipGraphExecMemcpyNodeSetParams1D_Positive_Basic: *level_2
+    Unit_hipGraphExecMemcpyNodeSetParams1D_Negative_Parameters: *level_2
+    Unit_hipGraphExecMemcpyNodeSetParams1D_Negative_Changing_Memcpy_Direction: *level_2
+    Unit_hipGraphGetEdges_Positive_Functional: *level_2
+    Unit_hipGraphGetEdges_Positive_CapturedStream: *level_2
+    Unit_hipGraphGetEdges_Negative_Parameters: *level_2
+    Unit_hipGraphGetEdges_Functionality: *level_2
+    Unit_hipGraphGetEdges_Negative: *level_2
+    Unit_hipGraphRemoveDependencies_Positive_Functional: *level_2
+    Unit_hipGraphRemoveDependenciesPositive_CapturedStream: *level_2
+    Unit_hipGraphRemoveDependencies_Positive_ChangeComputeFunc: *level_2
+    Unit_hipGraphRemoveDependencies_Positive_Parameters: *level_2
+    Unit_hipGraphRemoveDependencies_Negative_Parameters: *level_2
+    Unit_hipGraphRemoveDependencies_Func_Manual: *level_2
+    Unit_hipGraphRemoveDependencies_Func_StrmCapture: *level_2
+    Unit_hipGraphRemoveDependencies_ChangeComputeFunc: *level_2
+    Unit_hipGraphRemoveDependencies_Negative: *level_2
+    Unit_hipGraphInstantiate_Negative: *level_2
+    Unit_hipGraphInstantiate_Basic: *level_2
+    Unit_hipGraphInstantiate_InvalidCyclicGraph: *level_2
+    Unit_hipGraphInstantiate_functionalScenarios: *level_2
+    Unit_hipGraphExecUpdate_Negative_Basic: *level_2
+    Unit_hipGraphExecUpdate_Negative_TypeChange: *level_2
+    Unit_hipGraphExecUpdate_Negative_CountDiffer: *level_2
+    Unit_hipGraphExecUpdate_Functional: *level_2
+    Unit_hipGraphExecUpdate_Negative_Functional_ParametersChanged: *level_2
+    Unit_hipGraphExecUpdate_Negative_Functional_CountDiffer_1: *level_2
+    Unit_hipGraphExecUpdate_Negative_Functional_CountDiffer_2: *level_2
+    Unit_hipGraphExecUpdate_Negative_Dependent_NodesDiffer: *level_2
+    Unit_hipGraphExecUpdate_Negative_NodeType_Changed: *level_2
     Unit_hipGraphExecUpdate_Negative_MultiDevice_Context_Changed:
-      tags: [graph, exec, multigpu]
       <<: *level_2
+      tags: [multigpu]
       # SWDEV-446588 - Disable graph multi gpu testcases until graph has support for it
       disabled: [amd_windows]
-    Unit_hipGraphExecUpdate_Functional_KernelFunction_Changed:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecEventRecordNodeSetEvent_Functional:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecEventRecordNodeSetEvent_VerifyEventNotChanged:
-      <<: *level_2
-      tags: [graph, exec]
+    Unit_hipGraphExecUpdate_Functional_KernelFunction_Changed: *level_2
+    Unit_hipGraphExecEventRecordNodeSetEvent_Functional: *level_2
+    Unit_hipGraphExecEventRecordNodeSetEvent_VerifyEventNotChanged: *level_2
     Unit_hipGraphExecEventRecordNodeSetEvent_Positive_DifferentDevices:
-      tags: [graph, exec, multigpu]
       <<: *level_2
-    Unit_hipGraphExecEventRecordNodeSetEvent_Negative:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphEventWaitNodeSetEvent_SetProp:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphEventWaitNodeSetEvent_SetGet:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphEventWaitNodeSetEvent_Negative:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphMemsetNodeGetParams_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, query]
+      tags: [multigpu]
+    Unit_hipGraphExecEventRecordNodeSetEvent_Negative: *level_2
+    Unit_hipGraphEventWaitNodeSetEvent_SetProp: *level_2
+    Unit_hipGraphEventWaitNodeSetEvent_SetGet: *level_2
+    Unit_hipGraphEventWaitNodeSetEvent_Negative: *level_2
+    Unit_hipGraphMemsetNodeGetParams_Negative_Parameters: *level_2
     Unit_hipGraphMemsetNodeSetParams_Positive_Basic:
       <<: *level_2
       # Note: Following four tests disabled due to defect - EXSWHTEC-203
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphMemsetNodeSetParams_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Negative:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Functional:
-      <<: *level_2
-      tags: [graph, exec]
+    Unit_hipGraphMemsetNodeSetParams_Negative_Parameters: *level_2
+    Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Negative: *level_2
+    Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Functional: *level_2
     Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Positive_Basic:
-      tags: [graph, exec]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Negative_Parameters:
-      tags: [graph, exec]
       <<: *level_2
       # SWDEV-396617 ExecMemcpyNodeSetParamsFromSymbol fails in direction
       disabled: [amd_wsl]
-    Unit_hipGraphEventRecordNodeGetEvent_Functional:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphEventRecordNodeGetEvent_Negative:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphEventRecordNodeSetEvent_SetEventProperty:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphEventRecordNodeSetEvent_SetGet:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphEventRecordNodeSetEvent_Negative:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphEventWaitNodeGetEvent_Functional:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphEventWaitNodeGetEvent_Negative:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphExecMemcpyNodeSetParams_Positive_Basic:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecMemcpyNodeSetParams_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Direction:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecMemcpyNodeSetParams_Negative:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecMemcpyNodeSetParams_Functional:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipStreamBeginCapture_Positive_Functional:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Positive_Basic:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Positive_InterStrmEventSync_Flags:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Positive_InterStrmEventSync_Priority:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Positive_ColligatedStrmCapture_Flags:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Positive_ColligatedStrmCapture_Prio:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Positive_ColligatedStrmCaptureFunc:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Positive_Multithreaded:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Positive_Multiplestrms:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Positive_CapturingFromWithinStrms:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Negative_DetectingInvalidCapture:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Positive_CapturingMultGraphsFrom1Strm:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Negative_CheckingSyncDuringCapture:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Negative_Concurrent_CheckingSyncDuringCapture:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Negative_UnsafeCallsDuringCapture:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Negative_EndingCapwhenCapInProg:
-      <<: *level_2
-      tags: [graph, capture]
+    Unit_hipGraphEventRecordNodeGetEvent_Functional: *level_2
+    Unit_hipGraphEventRecordNodeGetEvent_Negative: *level_2
+    Unit_hipGraphEventRecordNodeSetEvent_SetEventProperty: *level_2
+    Unit_hipGraphEventRecordNodeSetEvent_SetGet: *level_2
+    Unit_hipGraphEventRecordNodeSetEvent_Negative: *level_2
+    Unit_hipGraphEventWaitNodeGetEvent_Functional: *level_2
+    Unit_hipGraphEventWaitNodeGetEvent_Negative: *level_2
+    Unit_hipGraphExecMemcpyNodeSetParams_Positive_Basic: *level_2
+    Unit_hipGraphExecMemcpyNodeSetParams_Negative_Parameters: *level_2
+    Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Direction: *level_2
+    Unit_hipGraphExecMemcpyNodeSetParams_Negative: *level_2
+    Unit_hipGraphExecMemcpyNodeSetParams_Functional: *level_2
+    Unit_hipStreamBeginCapture_Positive_Functional: *level_2
+    Unit_hipStreamBeginCapture_Negative_Parameters: *level_2
+    Unit_hipStreamBeginCapture_Positive_Basic: *level_2
+    Unit_hipStreamBeginCapture_Positive_InterStrmEventSync_Flags: *level_2
+    Unit_hipStreamBeginCapture_Positive_InterStrmEventSync_Priority: *level_2
+    Unit_hipStreamBeginCapture_Positive_ColligatedStrmCapture_Flags: *level_2
+    Unit_hipStreamBeginCapture_Positive_ColligatedStrmCapture_Prio: *level_2
+    Unit_hipStreamBeginCapture_Positive_ColligatedStrmCaptureFunc: *level_2
+    Unit_hipStreamBeginCapture_Positive_Multithreaded: *level_2
+    Unit_hipStreamBeginCapture_Positive_Multiplestrms: *level_2
+    Unit_hipStreamBeginCapture_Positive_CapturingFromWithinStrms: *level_2
+    Unit_hipStreamBeginCapture_Negative_DetectingInvalidCapture: *level_2
+    Unit_hipStreamBeginCapture_Positive_CapturingMultGraphsFrom1Strm: *level_2
+    Unit_hipStreamBeginCapture_Negative_CheckingSyncDuringCapture: *level_2
+    Unit_hipStreamBeginCapture_Negative_Concurrent_CheckingSyncDuringCapture: *level_2
+    Unit_hipStreamBeginCapture_Negative_UnsafeCallsDuringCapture: *level_2
+    Unit_hipStreamBeginCapture_Negative_EndingCapwhenCapInProg: *level_2
     Unit_hipStreamBeginCapture_Positive_MultiGPU:
-      tags: [graph, capture, multigpu]
       <<: *level_2
-    Unit_hipStreamBeginCapture_Positive_nestedStreamCapture:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Positive_streamReuse:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Positive_captureComplexGraph:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Positive_captureEmptyStreams:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_StreamSync_OngoingCapture:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_StreamSync_OngoingCapture_MThread:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_MultipleStreams_ReuseEvent:
-      <<: *level_2
-      tags: [graph, capture]
+      tags: [multigpu]
+    Unit_hipStreamBeginCapture_Positive_nestedStreamCapture: *level_2
+    Unit_hipStreamBeginCapture_Positive_streamReuse: *level_2
+    Unit_hipStreamBeginCapture_Positive_captureComplexGraph: *level_2
+    Unit_hipStreamBeginCapture_Positive_captureEmptyStreams: *level_2
+    Unit_hipStreamBeginCapture_StreamSync_OngoingCapture: *level_2
+    Unit_hipStreamBeginCapture_StreamSync_OngoingCapture_MThread: *level_2
+    Unit_hipStreamBeginCapture_MultipleStreams_ReuseEvent: *level_2
     Unit_hipGraphAddMemcpyNode1D_Functional:
-      tags: [graph, node, multigpu]
       <<: *level_2
-    Unit_hipGraphAddMemcpyNode1D_Negative:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemcpyNode1D_HostToHost:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipStreamBeginCapture_BasicFunctional:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_hipStreamPerThread:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Negative:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Basic:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_InterStrmEventSync_defaultflag:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_InterStrmEventSync_blockingflag:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_InterStrmEventSync_diffflags:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_InterStrmEventSync_diffprio:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_ColligatedStrmCapture_defaultflag:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_ColligatedStrmCapture_blockingflag:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_ColligatedStrmCapture_diffflags:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_ColligatedStrmCapture_diffprio:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_multiplestrms:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_ColligatedStrmCapture_func:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Multithreaded_Global:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Multithreaded_ThreadLocal:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_Multithreaded_Relaxed:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_CapturingFromWithinStrms:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_DetectingInvalidCapture:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_CapturingMultGraphsFrom1Strm:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_CheckingSyncDuringCapture:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_EndingCapturewhenCaptureInProgress:
-      <<: *level_2
-      tags: [graph, capture]
+      tags: [multigpu]
+    Unit_hipGraphAddMemcpyNode1D_Negative: *level_2
+    Unit_hipGraphAddMemcpyNode1D_HostToHost: *level_2
+    Unit_hipStreamBeginCapture_BasicFunctional: *level_2
+    Unit_hipStreamBeginCapture_hipStreamPerThread: *level_2
+    Unit_hipStreamBeginCapture_Negative: *level_2
+    Unit_hipStreamBeginCapture_Basic: *level_2
+    Unit_hipStreamBeginCapture_InterStrmEventSync_defaultflag: *level_2
+    Unit_hipStreamBeginCapture_InterStrmEventSync_blockingflag: *level_2
+    Unit_hipStreamBeginCapture_InterStrmEventSync_diffflags: *level_2
+    Unit_hipStreamBeginCapture_InterStrmEventSync_diffprio: *level_2
+    Unit_hipStreamBeginCapture_ColligatedStrmCapture_defaultflag: *level_2
+    Unit_hipStreamBeginCapture_ColligatedStrmCapture_blockingflag: *level_2
+    Unit_hipStreamBeginCapture_ColligatedStrmCapture_diffflags: *level_2
+    Unit_hipStreamBeginCapture_ColligatedStrmCapture_diffprio: *level_2
+    Unit_hipStreamBeginCapture_multiplestrms: *level_2
+    Unit_hipStreamBeginCapture_ColligatedStrmCapture_func: *level_2
+    Unit_hipStreamBeginCapture_Multithreaded_Global: *level_2
+    Unit_hipStreamBeginCapture_Multithreaded_ThreadLocal: *level_2
+    Unit_hipStreamBeginCapture_Multithreaded_Relaxed: *level_2
+    Unit_hipStreamBeginCapture_CapturingFromWithinStrms: *level_2
+    Unit_hipStreamBeginCapture_DetectingInvalidCapture: *level_2
+    Unit_hipStreamBeginCapture_CapturingMultGraphsFrom1Strm: *level_2
+    Unit_hipStreamBeginCapture_CheckingSyncDuringCapture: *level_2
+    Unit_hipStreamBeginCapture_EndingCapturewhenCaptureInProgress: *level_2
     Unit_hipStreamBeginCapture_MultiGPU:
-      tags: [graph, capture, multigpu]
       <<: *level_2
-    Unit_hipStreamBeginCapture_nestedStreamCapture:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCapture_streamReuse:
-      <<: *level_2
-      tags: [graph, capture]
+      tags: [multigpu]
+    Unit_hipStreamBeginCapture_nestedStreamCapture: *level_2
+    Unit_hipStreamBeginCapture_streamReuse: *level_2
     Unit_hipStreamBeginCapture_captureComplexGraph:
-      tags: [graph, capture]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamBeginCapture_captureEmptyStreams:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamIsCapturing_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamIsCapturing_Positive_Basic:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamIsCapturing_Positive_Functional:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamIsCapturing_Positive_Thread:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamIsCapturing_Negative:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamIsCapturing_Functional_Basic:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamIsCapturing_Functional:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamIsCapturing_hipStreamPerThread:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamIsCapturing_ParentAndForkedStream:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamIsCapturing_CheckCaptureStatus_FromThread:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamIsCapturing_ChkNullStrmStatus:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipGraphMemFreeNodeGetParams_ValidArgs:
-      <<: *level_2
-      tags: [graph, query]
+    Unit_hipStreamBeginCapture_captureEmptyStreams: *level_2
+    Unit_hipStreamIsCapturing_Negative_Parameters: *level_2
+    Unit_hipStreamIsCapturing_Positive_Basic: *level_2
+    Unit_hipStreamIsCapturing_Positive_Functional: *level_2
+    Unit_hipStreamIsCapturing_Positive_Thread: *level_2
+    Unit_hipStreamIsCapturing_Negative: *level_2
+    Unit_hipStreamIsCapturing_Functional_Basic: *level_2
+    Unit_hipStreamIsCapturing_Functional: *level_2
+    Unit_hipStreamIsCapturing_hipStreamPerThread: *level_2
+    Unit_hipStreamIsCapturing_ParentAndForkedStream: *level_2
+    Unit_hipStreamIsCapturing_CheckCaptureStatus_FromThread: *level_2
+    Unit_hipStreamIsCapturing_ChkNullStrmStatus: *level_2
+    Unit_hipGraphMemFreeNodeGetParams_ValidArgs: *level_2
     Unit_hipGraphMemFreeNodeGetParams_InvalidArgs:
-      tags: [graph, query]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_hipGraphUserObj_Int_float_Objects:
-      <<: *level_2
-      tags: [graph, userobj]
-    Unit_hipGraphUserObj_HostRegister:
-      <<: *level_2
-      tags: [graph, userobj]
-    Unit_hipGraphUserObj_Struct_Class_Ojects:
-      <<: *level_2
-      tags: [graph, userobj]
+    Unit_hipGraphUserObj_Int_float_Objects: *level_2
+    Unit_hipGraphUserObj_HostRegister: *level_2
+    Unit_hipGraphUserObj_Struct_Class_Ojects: *level_2
     Unit_hipGraphUserObj_ClonedGraph:
-      tags: [graph, userobj]
       <<: *level_2
       # Test Unit_hipGraphUserObj_ClonedGraph disabled due to SWDEV-483112
       disabled: [amd_windows]
-    Unit_hipGraphUserObj_ManualGraph:
-      <<: *level_2
-      tags: [graph, userobj]
-    Unit_hipGraphExecBatchMemOpNodeSetParams_NegativeTsts:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphAddBatchMemOpNode_NegativeTsts:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphBatchMemOpNodeSetParams_NegativeTsts:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphBatchMemOpNodeGetParams_NegativeTsts:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipDrvGraphExecMemcpyNodeSetParams_Negative:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipDrvGraphExecMemcpyNodeSetParams_Positive:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipDrvGraphAddMemFreeNode_Negative_Params:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipDrvGraphAddMemFreeNode_Positive:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipStreamCapture_ExtModuleLaunchKernel:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCaptureToGraph_BasicFunctional:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCaptureToGraph_CaptureIndepGraph:
-      <<: *level_2
-      tags: [graph, capture]
+    Unit_hipGraphUserObj_ManualGraph: *level_2
+    Unit_hipGraphExecBatchMemOpNodeSetParams_NegativeTsts: *level_2
+    Unit_hipGraphAddBatchMemOpNode_NegativeTsts: *level_2
+    Unit_hipGraphBatchMemOpNodeSetParams_NegativeTsts: *level_2
+    Unit_hipGraphBatchMemOpNodeGetParams_NegativeTsts: *level_2
+    Unit_hipDrvGraphExecMemcpyNodeSetParams_Negative: *level_2
+    Unit_hipDrvGraphExecMemcpyNodeSetParams_Positive: *level_2
+    Unit_hipDrvGraphAddMemFreeNode_Negative_Params: *level_2
+    Unit_hipDrvGraphAddMemFreeNode_Positive: *level_2
+    Unit_hipStreamCapture_ExtModuleLaunchKernel: *level_2
+    Unit_hipStreamBeginCaptureToGraph_BasicFunctional: *level_2
+    Unit_hipStreamBeginCaptureToGraph_CaptureIndepGraph: *level_2
     Unit_hipStreamBeginCaptureToGraph_CaptureDepGraph:
-      tags: [graph, capture]
       <<: *level_2
       # SWDEV-454245, SWDEV-454247 : Below tests fail on 29/03/24
       disabled: [amd_windows]
-    Unit_hipStreamBeginCaptureToGraph_ComplexGraph:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCaptureToGraph_CaptureTwice:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCaptureToGraph_ModifyCloneGraph:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCaptureToGraph_CaptureChildpGraph:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCaptureToGraph_ModifyChildpGraph:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCaptureToGraph_Negative:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCaptureToGraph_StateTesting:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCaptureToGraph_GetCaptureInfo:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCaptureToGraph_EndingWhileCaptureInProgress:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCaptureToGraph_MultipleFlags:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamBeginCaptureToGraph_CapturePartialInThreads:
-      <<: *level_2
-      tags: [graph, capture]
+    Unit_hipStreamBeginCaptureToGraph_ComplexGraph: *level_2
+    Unit_hipStreamBeginCaptureToGraph_CaptureTwice: *level_2
+    Unit_hipStreamBeginCaptureToGraph_ModifyCloneGraph: *level_2
+    Unit_hipStreamBeginCaptureToGraph_CaptureChildpGraph: *level_2
+    Unit_hipStreamBeginCaptureToGraph_ModifyChildpGraph: *level_2
+    Unit_hipStreamBeginCaptureToGraph_Negative: *level_2
+    Unit_hipStreamBeginCaptureToGraph_StateTesting: *level_2
+    Unit_hipStreamBeginCaptureToGraph_GetCaptureInfo: *level_2
+    Unit_hipStreamBeginCaptureToGraph_EndingWhileCaptureInProgress: *level_2
+    Unit_hipStreamBeginCaptureToGraph_MultipleFlags: *level_2
+    Unit_hipStreamBeginCaptureToGraph_CapturePartialInThreads: *level_2
     Unit_hipStreamBeginCaptureToGraph_IndepGraphsThreads:
-      tags: [graph, capture]
       <<: *level_2
       # SWDEV-454245, SWDEV-454247 : Below tests fail on 29/03/24
       disabled: [amd_windows]
-    Unit_hipGetProcAddress_GraphAPIs_StreamCapture:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGetProcAddress_GraphAPIs_AddMemcpy1DKernelNodes:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGetProcAddress_GraphAPIs_AddMemsetMemcpyNodes:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGetProcAddress_GraphAPIs_SetGetParamsMemsetMemcpy:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGetProcAddress_GraphAPIs_KernelNodeSetGetParams:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGetProcAddress_GraphAPIs_KernelNodeSetGetAttribute:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGetProcAddress_GraphAPIs_HostNode:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGetProcAddress_GraphAPIs_ExecUpdate:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGetProcAddress_GraphAPIs_Memcpy1DSetParams:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGetProcAddress_GraphAPIs_MemAllocAndFree:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGetProcAddress_GraphAPIs_ExecMemsetMemcpySetParams:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphExecNodeSetParams_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecNodeSetParams_Positive:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphNodeSetParams_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphNodeSetParams_Positive:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphExecGetFlags_Negative:
-      <<: *level_2
-      tags: [graph, exec]
+    Unit_hipGetProcAddress_GraphAPIs_StreamCapture: *level_2
+    Unit_hipGetProcAddress_GraphAPIs_AddMemcpy1DKernelNodes: *level_2
+    Unit_hipGetProcAddress_GraphAPIs_AddMemsetMemcpyNodes: *level_2
+    Unit_hipGetProcAddress_GraphAPIs_SetGetParamsMemsetMemcpy: *level_2
+    Unit_hipGetProcAddress_GraphAPIs_KernelNodeSetGetParams: *level_2
+    Unit_hipGetProcAddress_GraphAPIs_KernelNodeSetGetAttribute: *level_2
+    Unit_hipGetProcAddress_GraphAPIs_HostNode: *level_2
+    Unit_hipGetProcAddress_GraphAPIs_ExecUpdate: *level_2
+    Unit_hipGetProcAddress_GraphAPIs_Memcpy1DSetParams: *level_2
+    Unit_hipGetProcAddress_GraphAPIs_MemAllocAndFree: *level_2
+    Unit_hipGetProcAddress_GraphAPIs_ExecMemsetMemcpySetParams: *level_2
+    Unit_hipGraphExecNodeSetParams_Negative_Parameters: *level_2
+    Unit_hipGraphExecNodeSetParams_Positive: *level_2
+    Unit_hipGraphNodeSetParams_Negative_Parameters: *level_2
+    Unit_hipGraphNodeSetParams_Positive: *level_2
+    Unit_hipGraphExecGetFlags_Negative: *level_2
     Unit_hipGraphExecGetFlags_Positive: *level_2
-    Unit_hipStreamGetCaptureInfo_Positive_Functional:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamGetCaptureInfo_Positive_UniqueID:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamGetCaptureInfo_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamGetCaptureInfo_BasicFunctional:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamGetCaptureInfo_hipStreamPerThread:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamGetCaptureInfo_UniqueID:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamGetCaptureInfo_ArgValidation:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamGetCaptureInfo_ParentAndForkedStrm_CaptureStatus:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamGetCaptureInfo_CaptureStatus_InThread:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamGetCaptureInfo_CaptureStatus_Througout_Capture:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamGetCaptureInfo_Nullstream_CaptureInfo:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamEndCapture_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamEndCapture_Positive_GraphDestroy:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamEndCapture_Negative_Thread:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamEndCapture_Positive_Thread:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamEndCapture_Negative:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamEndCapture_Thread_Negative:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamEndCapture_mode_hipStreamCaptureModeRelaxed:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamEndCapture_chkError_on_wrongStream:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamEndCapture_streamMerge_in_thread:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Negative:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Functional:
-      <<: *level_2
-      tags: [graph, node]
+    Unit_hipStreamGetCaptureInfo_Positive_Functional: *level_2
+    Unit_hipStreamGetCaptureInfo_Positive_UniqueID: *level_2
+    Unit_hipStreamGetCaptureInfo_Negative_Parameters: *level_2
+    Unit_hipStreamGetCaptureInfo_BasicFunctional: *level_2
+    Unit_hipStreamGetCaptureInfo_hipStreamPerThread: *level_2
+    Unit_hipStreamGetCaptureInfo_UniqueID: *level_2
+    Unit_hipStreamGetCaptureInfo_ArgValidation: *level_2
+    Unit_hipStreamGetCaptureInfo_ParentAndForkedStrm_CaptureStatus: *level_2
+    Unit_hipStreamGetCaptureInfo_CaptureStatus_InThread: *level_2
+    Unit_hipStreamGetCaptureInfo_CaptureStatus_Througout_Capture: *level_2
+    Unit_hipStreamGetCaptureInfo_Nullstream_CaptureInfo: *level_2
+    Unit_hipStreamEndCapture_Negative_Parameters: *level_2
+    Unit_hipStreamEndCapture_Positive_GraphDestroy: *level_2
+    Unit_hipStreamEndCapture_Negative_Thread: *level_2
+    Unit_hipStreamEndCapture_Positive_Thread: *level_2
+    Unit_hipStreamEndCapture_Negative: *level_2
+    Unit_hipStreamEndCapture_Thread_Negative: *level_2
+    Unit_hipStreamEndCapture_mode_hipStreamCaptureModeRelaxed: *level_2
+    Unit_hipStreamEndCapture_chkError_on_wrongStream: *level_2
+    Unit_hipStreamEndCapture_streamMerge_in_thread: *level_2
+    Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Negative: *level_2
+    Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Functional: *level_2
     Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Positive_Basic:
-      tags: [graph, node]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphExecEventWaitNodeSetEvent_SetAndVerifyMemory:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecEventWaitNodeSetEvent_VerifyEventNotChanged:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecEventWaitNodeSetEvent_Negative:
-      <<: *level_2
-      tags: [graph, exec]
+    Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Negative_Parameters: *level_2
+    Unit_hipGraphExecEventWaitNodeSetEvent_SetAndVerifyMemory: *level_2
+    Unit_hipGraphExecEventWaitNodeSetEvent_VerifyEventNotChanged: *level_2
+    Unit_hipGraphExecEventWaitNodeSetEvent_Negative: *level_2
     Unit_hipGraphAddMemsetNode_Positive_Basic: *level_2
-    Unit_hipGraphAddMemsetNode_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemsetNode_hipMallocPitch_2D:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemsetNode_hipMallocPitch_1D:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemsetNode_hipMalloc3D_2D:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemsetNode_hipMalloc3D_1D:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemsetNode_hipMalloc_1D:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemsetNode_hipMallocManaged:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddKernelNode_Negative:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddKernelNode_moduleLoadKernelFn_graphNclonedGraph:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddKernelNode_moduleLoadKernelFn_kernelFnUpdate:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddKernelNode_moduleLoadKernelFn_childGraph:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddKernelNode_moduleLoadKernelFn_streamCapture:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphMemcpyNodeGetParams_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphMemcpyNodeGetParams_Negative:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphMemcpyNodeGetParams_Functional:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphMemcpyNodeSetParams_Positive_Basic:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphMemcpyNodeSetParams_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphMemcpyNodeSetParams_Negative:
-      <<: *level_2
-      tags: [graph, node]
+    Unit_hipGraphAddMemsetNode_Negative_Parameters: *level_2
+    Unit_hipGraphAddMemsetNode_hipMallocPitch_2D: *level_2
+    Unit_hipGraphAddMemsetNode_hipMallocPitch_1D: *level_2
+    Unit_hipGraphAddMemsetNode_hipMalloc3D_2D: *level_2
+    Unit_hipGraphAddMemsetNode_hipMalloc3D_1D: *level_2
+    Unit_hipGraphAddMemsetNode_hipMalloc_1D: *level_2
+    Unit_hipGraphAddMemsetNode_hipMallocManaged: *level_2
+    Unit_hipGraphAddKernelNode_Negative: *level_2
+    Unit_hipGraphAddKernelNode_moduleLoadKernelFn_graphNclonedGraph: *level_2
+    Unit_hipGraphAddKernelNode_moduleLoadKernelFn_kernelFnUpdate: *level_2
+    Unit_hipGraphAddKernelNode_moduleLoadKernelFn_childGraph: *level_2
+    Unit_hipGraphAddKernelNode_moduleLoadKernelFn_streamCapture: *level_2
+    Unit_hipGraphMemcpyNodeGetParams_Negative_Parameters: *level_2
+    Unit_hipGraphMemcpyNodeGetParams_Negative: *level_2
+    Unit_hipGraphMemcpyNodeGetParams_Functional: *level_2
+    Unit_hipGraphMemcpyNodeSetParams_Positive_Basic: *level_2
+    Unit_hipGraphMemcpyNodeSetParams_Negative_Parameters: *level_2
+    Unit_hipGraphMemcpyNodeSetParams_Negative: *level_2
     Unit_hipGraphMemcpyNodeSetParams_Functional:
-      tags: [graph, node]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphKernelNodeGetParams_Negative:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphKernelNodeGetParams_Functional:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphKernelNodeSetParams_Negative:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphKernelNodeSetParams_Functional:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphKernelNodeGetSetParams_Functional:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphExecKernelNodeSetParams_Negative:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecKernelNodeSetParams_Functional:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphLaunch_Positive:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphLaunch_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphLaunch_Negative:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphLaunch_Functional_hipStreamPerThread:
-      <<: *level_2
-      tags: [graph, exec]
+    Unit_hipGraphKernelNodeGetParams_Negative: *level_2
+    Unit_hipGraphKernelNodeGetParams_Functional: *level_2
+    Unit_hipGraphKernelNodeSetParams_Negative: *level_2
+    Unit_hipGraphKernelNodeSetParams_Functional: *level_2
+    Unit_hipGraphKernelNodeGetSetParams_Functional: *level_2
+    Unit_hipGraphExecKernelNodeSetParams_Negative: *level_2
+    Unit_hipGraphExecKernelNodeSetParams_Functional: *level_2
+    Unit_hipGraphLaunch_Positive: *level_2
+    Unit_hipGraphLaunch_Negative_Parameters: *level_2
+    Unit_hipGraphLaunch_Negative: *level_2
+    Unit_hipGraphLaunch_Functional_hipStreamPerThread: *level_2
     Unit_hipGraphLaunch_Functional_multidevice_test:
-      tags: [graph, exec, multigpu]
       <<: *level_2
-    Unit_hipGraphLaunch_Functional_MultipleLaunch:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphMemcpyNodeSetParams1D_Positive_Basic:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphMemcpyNodeSetParams1D_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphMemcpyNodeSetParams1D_Negative:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphMemcpyNodeSetParams1D_Functional:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Negative:
-      <<: *level_2
-      tags: [graph, exec]
+      tags: [multigpu]
+    Unit_hipGraphLaunch_Functional_MultipleLaunch: *level_2
+    Unit_hipGraphMemcpyNodeSetParams1D_Positive_Basic: *level_2
+    Unit_hipGraphMemcpyNodeSetParams1D_Negative_Parameters: *level_2
+    Unit_hipGraphMemcpyNodeSetParams1D_Negative: *level_2
+    Unit_hipGraphMemcpyNodeSetParams1D_Functional: *level_2
+    Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Negative: *level_2
     Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Functional:
-      tags: [graph, exec]
       <<: *level_2
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Positive_Basic:
-      tags: [graph, exec]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Negative_Parameters:
-      tags: [graph, exec, multigpu]
       <<: *level_2
-    Unit_hipGraphNodeGetDependentNodes_Positive_Functional:
-      <<: *level_2
-      tags: [graph, dependency]
-    Unit_hipGraphNodeGetDependentNodes_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, dependency]
+      tags: [multigpu]
+    Unit_hipGraphNodeGetDependentNodes_Positive_Functional: *level_2
+    Unit_hipGraphNodeGetDependentNodes_Negative_Parameters: *level_2
     Unit_hipGraphNodeGetDependentNodes_Functional:
-      tags: [graph, dependency]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphNodeGetDependentNodes_ParamValidation:
-      <<: *level_2
-      tags: [graph, dependency]
-    Unit_hipGraphNodeGetDependencies_Positive_Functional:
-      <<: *level_2
-      tags: [graph, dependency]
-    Unit_hipGraphNodeGetDependencies_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, dependency]
+    Unit_hipGraphNodeGetDependentNodes_ParamValidation: *level_2
+    Unit_hipGraphNodeGetDependencies_Positive_Functional: *level_2
+    Unit_hipGraphNodeGetDependencies_Negative_Parameters: *level_2
     Unit_hipGraphNodeGetDependencies_Functional:
-      tags: [graph, dependency]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphNodeGetDependencies_ParamValidation:
-      <<: *level_2
-      tags: [graph, dependency]
-    Unit_hipGraphHostNodeGetParams_Negative:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphHostNodeGetParams_ClonedGraphWithHostNode:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphHostNodeGetParams_BasicFunc:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphHostNodeGetParams_SetParams:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphExecChildGraphNodeSetParams_Negative:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipGraphExecChildGraphNodeSetParams_BasicFunc:
-      <<: *level_2
-      tags: [graph, exec]
+    Unit_hipGraphNodeGetDependencies_ParamValidation: *level_2
+    Unit_hipGraphHostNodeGetParams_Negative: *level_2
+    Unit_hipGraphHostNodeGetParams_ClonedGraphWithHostNode: *level_2
+    Unit_hipGraphHostNodeGetParams_BasicFunc: *level_2
+    Unit_hipGraphHostNodeGetParams_SetParams: *level_2
+    Unit_hipGraphExecChildGraphNodeSetParams_Negative: *level_2
+    Unit_hipGraphExecChildGraphNodeSetParams_BasicFunc: *level_2
     Unit_hipGraphExecChildGraphNodeSetParams_ChildTopology:
-      tags: [graph, exec]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamGetCaptureInfo_v2_Positive_Functional:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamGetCaptureInfo_v2_Positive_UniqueID:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamGetCaptureInfo_v2_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipGraphCreate_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphCreate_Positive_Basic:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphDestroy_Positive_Basic:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphDestroy_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, lifecycle]
+    Unit_hipStreamGetCaptureInfo_v2_Positive_Functional: *level_2
+    Unit_hipStreamGetCaptureInfo_v2_Positive_UniqueID: *level_2
+    Unit_hipStreamGetCaptureInfo_v2_Negative_Parameters: *level_2
+    Unit_hipGraphCreate_Negative_Parameters: *level_2
+    Unit_hipGraphCreate_Positive_Basic: *level_2
+    Unit_hipGraphDestroy_Positive_Basic: *level_2
+    Unit_hipGraphDestroy_Negative_Parameters: *level_2
     Unit_hipStreamSetCaptureDependencies_Positive_Functional:
-      tags: [graph, capture]
       <<: *level_2
       # Note: Following four tests disabled due to defect - EXSWHTEC-203
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamAddCaptureDependencies_Positive_Functional:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamUpdateCaptureDependencies_Positive_Parameters:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamUpdateCaptureDependencies_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipThreadExchangeStreamCaptureMode_Positive_Functional:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipThreadExchangeStreamCaptureMode_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipLaunchHostFunc_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipLaunchHostFunc_Positive_Functional:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipLaunchHostFunc_Positive_Thread:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipLaunchHostFunc_H2D_Kernel_D2H_Capture:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamGetCaptureInfo_v2_BasicFunctional:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamGetCaptureInfo_v2_hipStreamPerThread:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamGetCaptureInfo_v2_UniqueID:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipStreamGetCaptureInfo_v2_ParamValidation:
-      <<: *level_2
-      tags: [graph, capture]
-    Unit_hipUserObjectCreate_Functional_1:
-      <<: *level_2
-      tags: [graph, userobj]
-    Unit_hipUserObjectCreate_Functional_2:
-      <<: *level_2
-      tags: [graph, userobj]
-    Unit_hipUserObjectCreate_Functional_3:
-      <<: *level_2
-      tags: [graph, userobj]
-    Unit_hipUserObjectCreate_Functional_4:
-      <<: *level_2
-      tags: [graph, userobj]
-    Unit_hipUserObjectCreate_Negative:
-      <<: *level_2
-      tags: [graph, userobj]
-    Unit_hipUserObj_Negative_Test:
-      <<: *level_2
-      tags: [graph, userobj]
-    Unit_hipUserObjectRelease_Negative:
-      <<: *level_2
-      tags: [graph, userobj]
-    Unit_hipUserObjectRetain_Negative:
-      <<: *level_2
-      tags: [graph, userobj]
-    Unit_hipGraphReleaseUserObject_Negative:
-      <<: *level_2
-      tags: [graph, userobj]
-    Unit_hipGraphRetainUserObject_Functional_1:
-      <<: *level_2
-      tags: [graph, userobj]
-    Unit_hipGraphRetainUserObject_Functional_2:
-      <<: *level_2
-      tags: [graph, userobj]
-    Unit_hipGraphRetainUserObject_Negative:
-      <<: *level_2
-      tags: [graph, userobj]
-    Unit_hipGraphRetainUserObject_Negative_Basic:
-      <<: *level_2
-      tags: [graph, userobj]
+    Unit_hipStreamAddCaptureDependencies_Positive_Functional: *level_2
+    Unit_hipStreamUpdateCaptureDependencies_Positive_Parameters: *level_2
+    Unit_hipStreamUpdateCaptureDependencies_Negative_Parameters: *level_2
+    Unit_hipThreadExchangeStreamCaptureMode_Positive_Functional: *level_2
+    Unit_hipThreadExchangeStreamCaptureMode_Negative_Parameters: *level_2
+    Unit_hipLaunchHostFunc_Negative_Parameters: *level_2
+    Unit_hipLaunchHostFunc_Positive_Functional: *level_2
+    Unit_hipLaunchHostFunc_Positive_Thread: *level_2
+    Unit_hipLaunchHostFunc_H2D_Kernel_D2H_Capture: *level_2
+    Unit_hipStreamGetCaptureInfo_v2_BasicFunctional: *level_2
+    Unit_hipStreamGetCaptureInfo_v2_hipStreamPerThread: *level_2
+    Unit_hipStreamGetCaptureInfo_v2_UniqueID: *level_2
+    Unit_hipStreamGetCaptureInfo_v2_ParamValidation: *level_2
+    Unit_hipUserObjectCreate_Functional_1: *level_2
+    Unit_hipUserObjectCreate_Functional_2: *level_2
+    Unit_hipUserObjectCreate_Functional_3: *level_2
+    Unit_hipUserObjectCreate_Functional_4: *level_2
+    Unit_hipUserObjectCreate_Negative: *level_2
+    Unit_hipUserObj_Negative_Test: *level_2
+    Unit_hipUserObjectRelease_Negative: *level_2
+    Unit_hipUserObjectRetain_Negative: *level_2
+    Unit_hipGraphReleaseUserObject_Negative: *level_2
+    Unit_hipGraphRetainUserObject_Functional_1: *level_2
+    Unit_hipGraphRetainUserObject_Functional_2: *level_2
+    Unit_hipGraphRetainUserObject_Negative: *level_2
+    Unit_hipGraphRetainUserObject_Negative_Basic: *level_2
     Unit_hipGraphRetainUserObject_Negative_Null_Object: *level_2
-    Unit_hipGraphDebugDotPrint_Functional:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphDebugDotPrint_Argument_Check:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphClone_Test_hipGraphKernelNodeSetParams:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphClone_Test_hipGraphExecKernelNodeSetParams:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphClone_Test_hipGraphAddMemcpy_and_memset:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphClone_Test_hipGraphMemcpyNodeSetParams:
-      <<: *level_2
-      tags: [graph, lifecycle]
+    Unit_hipGraphDebugDotPrint_Functional: *level_2
+    Unit_hipGraphDebugDotPrint_Argument_Check: *level_2
+    Unit_hipGraphClone_Test_hipGraphKernelNodeSetParams: *level_2
+    Unit_hipGraphClone_Test_hipGraphExecKernelNodeSetParams: *level_2
+    Unit_hipGraphClone_Test_hipGraphAddMemcpy_and_memset: *level_2
+    Unit_hipGraphClone_Test_hipGraphMemcpyNodeSetParams: *level_2
     Unit_hipGraphClone_Test_hipGraphExecMemcpyNodeSetParams:
-      tags: [graph, lifecycle]
       <<: *level_2
       # Below tests fail in stress test on 23/06/23
       disabled: [amd_wsl]
     Unit_hipGraphClone_Test_hipGraphMemcpyNodeSetParams1D_and_exec:
-      tags: [graph, lifecycle]
       <<: *level_2
       # Below tests fail in stress test on 23/06/23
       disabled: [amd_wsl]
-    Unit_hipGraphClone_hipGraphMemcpyNodeSetParamsFromSymbol_exec:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphClone_hipGraphMemcpyNodeSetParamsToSymbol_exec:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphClone_Test_hipGraphMemsetNodeSetParams_exec:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphClone_Test_hipGraphRemoveDependencies:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphClone_Test_hipGraphExecChildGraphNodeSetParams:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphClone_Test_hipGraphEventRecordNodeSetEvent_and_Exec:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphClone_Test_hipGraphEventWaitNodeSetEvent_and_Exec:
-      <<: *level_2
-      tags: [graph, lifecycle]
+    Unit_hipGraphClone_hipGraphMemcpyNodeSetParamsFromSymbol_exec: *level_2
+    Unit_hipGraphClone_hipGraphMemcpyNodeSetParamsToSymbol_exec: *level_2
+    Unit_hipGraphClone_Test_hipGraphMemsetNodeSetParams_exec: *level_2
+    Unit_hipGraphClone_Test_hipGraphRemoveDependencies: *level_2
+    Unit_hipGraphClone_Test_hipGraphExecChildGraphNodeSetParams: *level_2
+    Unit_hipGraphClone_Test_hipGraphEventRecordNodeSetEvent_and_Exec: *level_2
+    Unit_hipGraphClone_Test_hipGraphEventWaitNodeSetEvent_and_Exec: *level_2
     Unit_hipGraphClone_address_change_in_loop:
-      tags: [graph, lifecycle, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGraphClone_address_change_in_thread:
-      tags: [graph, lifecycle, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGraphClone_multi_GPU_test:
-      tags: [graph, lifecycle, multigpu]
       <<: *level_2
-    Unit_hipGraphClone_hipUserObject_hipGraphUserObject:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphClone_hipUserObject_hipGraphUserObject_Negative:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphChild_hipUserObject_hipGraphUserObject:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphNodeSetEnabled_Functional_Basic:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphNodeSetEnabled_Functional_KernelNode:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphNodeSetEnabled_Functional_MemSet:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphNodeSetEnabled_Functional_MemCpy:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphNodeSetEnabled_Negative_Functional:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphNodeGetEnabled_Functional_Basic:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphNodeGetEnabled_Negative_Functional:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphExecDestroy_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphExecDestroy_Positive_Basic:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraphUpload_Functional:
-      <<: *level_2
-      tags: [graph, exec]
+      tags: [multigpu]
+    Unit_hipGraphClone_hipUserObject_hipGraphUserObject: *level_2
+    Unit_hipGraphClone_hipUserObject_hipGraphUserObject_Negative: *level_2
+    Unit_hipGraphChild_hipUserObject_hipGraphUserObject: *level_2
+    Unit_hipGraphNodeSetEnabled_Functional_Basic: *level_2
+    Unit_hipGraphNodeSetEnabled_Functional_KernelNode: *level_2
+    Unit_hipGraphNodeSetEnabled_Functional_MemSet: *level_2
+    Unit_hipGraphNodeSetEnabled_Functional_MemCpy: *level_2
+    Unit_hipGraphNodeSetEnabled_Negative_Functional: *level_2
+    Unit_hipGraphNodeGetEnabled_Functional_Basic: *level_2
+    Unit_hipGraphNodeGetEnabled_Negative_Functional: *level_2
+    Unit_hipGraphExecDestroy_Negative_Parameters: *level_2
+    Unit_hipGraphExecDestroy_Positive_Basic: *level_2
+    Unit_hipGraphUpload_Functional: *level_2
     Unit_hipGraphUpload_Functional_multidevice_test:
-      tags: [graph, exec, multigpu]
       <<: *level_2
+      tags: [multigpu]
       # (amd_linux) SWDEV-553920 disabled until multi device graph issues are resolved
       # (amd_windows) SWDEV-446588 - Disable graph multi gpu testcases until graph has support for it
       disabled: [amd_linux, amd_windows]
-    Unit_hipGraphUpload_Functional_With_Priority_Stream:
-      <<: *level_2
-      tags: [graph, exec]
+    Unit_hipGraphUpload_Functional_With_Priority_Stream: *level_2
     Unit_hipGraphUpload_Negative_Parameters:
-      tags: [graph, exec]
       <<: *level_2
       # SWDEV-434878: Below tests failed in stress test on 24/11/23
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphKernelNodeCopyAttributes_Functional:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphKernelNodeCopyAttributes_Attribute_Negative:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipStreamBeginCapture_with_hipGraphAddHostNode:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipStreamEndCapture_later_and_add_a_node_inbetween:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipStreamEndCapture_first_and_add_a_node_later:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipStreamEndCapture_first_and_add_other_graph_node_later:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipStreamEndCapture_later_and_addEmptyNode:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraph_BasicCyclic1:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraph_BasicCyclic2:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraph_BasicCyclic3:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraph_BasicCyclic4:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraph_BasicCyclic5:
-      <<: *level_2
-      tags: [graph, lifecycle]
-    Unit_hipGraph_PerfCheck_MemcpyKernelMixCall:
-      <<: *level_2
-      tags: [graph, exec]
+    Unit_hipGraphKernelNodeCopyAttributes_Functional: *level_2
+    Unit_hipGraphKernelNodeCopyAttributes_Attribute_Negative: *level_2
+    Unit_hipStreamBeginCapture_with_hipGraphAddHostNode: *level_2
+    Unit_hipStreamEndCapture_later_and_add_a_node_inbetween: *level_2
+    Unit_hipStreamEndCapture_first_and_add_a_node_later: *level_2
+    Unit_hipStreamEndCapture_first_and_add_other_graph_node_later: *level_2
+    Unit_hipStreamEndCapture_later_and_addEmptyNode: *level_2
+    Unit_hipGraph_BasicCyclic1: *level_2
+    Unit_hipGraph_BasicCyclic2: *level_2
+    Unit_hipGraph_BasicCyclic3: *level_2
+    Unit_hipGraph_BasicCyclic4: *level_2
+    Unit_hipGraph_BasicCyclic5: *level_2
+    Unit_hipGraph_PerfCheck_MemcpyKernelMixCall: *level_2
     Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams:
-      tags: [graph, exec, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams_inLoop:
-      tags: [graph, exec, multigpu]
       <<: *level_2
-    Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams:
-      <<: *level_2
-      tags: [graph, exec]
+      tags: [multigpu]
+    Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams: *level_2
     Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams_inLoop:
-      tags: [graph, exec, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams1D_inLoop:
-      tags: [graph, exec, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsFrmSymbol:
-      tags: [graph, exec, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsToSymbol:
-      tags: [graph, exec, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecMemsetNodeSetParams:
-      tags: [graph, exec, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecChildGraphNodeSetParams:
-      tags: [graph, exec, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecEventRecordNodeSetEvent:
-      tags: [graph, exec, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecEventWaitNodeSetEvent:
-      tags: [graph, exec, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecHostNodeSetParams:
-      tags: [graph, exec, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecUpdate:
-      tags: [graph, exec, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecUpdate_kernel_inLoop:
-      tags: [graph, exec, multigpu]
       <<: *level_2
-    Unit_hipGraphKernelNodeGetAttribute_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipGraphKernelNodeSetAttribute_Positive_AccessPolicyWindow:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphKernelNodeSetAttribute_Positive_Cooperative:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphKernelNodeSetAttribute_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional:
-      <<: *level_2
-      tags: [graph, query]
+      tags: [multigpu]
+    Unit_hipGraphKernelNodeGetAttribute_Negative_Parameters: *level_2
+    Unit_hipGraphKernelNodeSetAttribute_Positive_AccessPolicyWindow: *level_2
+    Unit_hipGraphKernelNodeSetAttribute_Positive_Cooperative: *level_2
+    Unit_hipGraphKernelNodeSetAttribute_Negative_Parameters: *level_2
+    Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional: *level_2
     Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_MultiDevice:
-      tags: [graph, query, multigpu]
       <<: *level_2
+      tags: [multigpu]
       # SWDEV-446588 - Disable graph multi gpu testcases until graph has support for it
       disabled: [amd_windows]
-    Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_2:
-      <<: *level_2
-      tags: [graph, query]
+    Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_2: *level_2
     Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_3:
-      tags: [graph, query]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipGraphMem_Alloc_Free_NodeGetParams_Negative:
-      tags: [graph, query]
       <<: *level_2
       # (amd_linux) Rock_Linux_Failures_on_gfx94X
       # (amd_wsl) SWDEV-430116:Below tests failed in stress test on 27/10/23
       disabled: [amd_linux, amd_wsl]
-    Unit_hipGraphAddMemAllocNode_Negative_Params:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemAllocNode_Negative_NotSupported:
-      <<: *level_2
-      tags: [graph, node]
+    Unit_hipGraphAddMemAllocNode_Negative_Params: *level_2
+    Unit_hipGraphAddMemAllocNode_Negative_NotSupported: *level_2
     Unit_hipGraphAddMemAllocNode_Positive_FreeInGraph:
-      tags: [graph, node]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipGraphAddMemAllocNode_Positive_FreeOutsideStream:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemAllocNode_Positive_FreeOutsideGraph:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemAllocNode_Positive_FreeSeparateGraph:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemAllocNode_Functional_1:
-      <<: *level_2
-      tags: [graph, node]
+    Unit_hipGraphAddMemAllocNode_Positive_FreeOutsideStream: *level_2
+    Unit_hipGraphAddMemAllocNode_Positive_FreeOutsideGraph: *level_2
+    Unit_hipGraphAddMemAllocNode_Positive_FreeSeparateGraph: *level_2
+    Unit_hipGraphAddMemAllocNode_Functional_1: *level_2
     Unit_hipGraphAddMemAllocNode_Functional_2:
-      tags: [graph, node, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGraphAddMemAllocNode_Functional_3:
-      tags: [graph, node, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipGraphAddMemAllocNode_Functional_4:
-      tags: [graph, node, multigpu]
       <<: *level_2
-    Unit_hipGraphAddMemAllocNode_Argument_Check:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemAllocNode_Negative_Instanciate_Graph_Again:
-      <<: *level_2
-      tags: [graph, node]
+      tags: [multigpu]
+    Unit_hipGraphAddMemAllocNode_Argument_Check: *level_2
+    Unit_hipGraphAddMemAllocNode_Negative_Instanciate_Graph_Again: *level_2
     Unit_hipGraphAddMemAllocNode_Negative_Free_Alloc_Memory_Again:
-      tags: [graph, node]
       <<: *level_2
       # (amd_linux) SWDEV-457316 Below test is skipped due ref count logic (Discussed with German)
       # (amd_windows) SWDEV-457316 Below test is skipped due ref count logic (Discussed with German)
       disabled: [amd_linux, amd_windows]
-    Unit_hipGraphAddMemAllocNode_Negative_With_Cloneed_Graph:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddMemFreeNode_Negative_Params:
-      <<: *level_2
-      tags: [graph, node]
+    Unit_hipGraphAddMemAllocNode_Negative_With_Cloneed_Graph: *level_2
+    Unit_hipGraphAddMemFreeNode_Negative_Params: *level_2
     Unit_hipGraphAddMemFreeNode_Negative_NotSupported:
-      tags: [graph, node]
       <<: *level_2
       # SWDEV-457316 Below tests are disabled temporarily to avoid combined PSDB
       disabled: [amd_windows]
-    Unit_hipGraphAddMemFreeNode_Functional:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipDrvGraphMemcpyNodeGetParams_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipDrvGraphMemcpyNodeGetParams_Positive:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipDrvGraphMemcpyNodeSetParams_Positive_Basic:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipDrvGraphMemcpyNodeSetParams_Positive_Array:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipDrvGraphMemcpyNodeSetParams_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipDeviceSetGraphMemAttribute_Positive_Default:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipDeviceSetGraphMemAttribute_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipDeviceGetGraphMemAttribute_Positive_DoubleMemory:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipDeviceGetGraphMemAttribute_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipDeviceGetGraphMemAttribute_Functional:
-      <<: *level_2
-      tags: [graph, query]
+    Unit_hipGraphAddMemFreeNode_Functional: *level_2
+    Unit_hipDrvGraphMemcpyNodeGetParams_Negative_Parameters: *level_2
+    Unit_hipDrvGraphMemcpyNodeGetParams_Positive: *level_2
+    Unit_hipDrvGraphMemcpyNodeSetParams_Positive_Basic: *level_2
+    Unit_hipDrvGraphMemcpyNodeSetParams_Positive_Array: *level_2
+    Unit_hipDrvGraphMemcpyNodeSetParams_Negative_Parameters: *level_2
+    Unit_hipDeviceSetGraphMemAttribute_Positive_Default: *level_2
+    Unit_hipDeviceSetGraphMemAttribute_Negative_Parameters: *level_2
+    Unit_hipDeviceGetGraphMemAttribute_Positive_DoubleMemory: *level_2
+    Unit_hipDeviceGetGraphMemAttribute_Negative_Parameters: *level_2
+    Unit_hipDeviceGetGraphMemAttribute_Functional: *level_2
     Unit_hipDeviceGetGraphMemAttribute_Functional_Multi_Device:
-      tags: [graph, query, multigpu]
       <<: *level_2
-    Unit_hipDeviceGetGraphMemAttribute_Negative:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipDeviceSetGraphMemAttribute_Negative:
-      <<: *level_2
-      tags: [graph, query]
-    Unit_hipDeviceGraphMemTrim_Positive_Default:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipDeviceGraphMemTrim_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipDrvGraphExecMemsetNodeSetParams_BasicPositive:
-      <<: *level_2
-      tags: [graph, exec]
-    Unit_hipDrvGraphExecMemsetNodeSetParams_Negative:
-      <<: *level_2
-      tags: [graph, exec]
+      tags: [multigpu]
+    Unit_hipDeviceGetGraphMemAttribute_Negative: *level_2
+    Unit_hipDeviceSetGraphMemAttribute_Negative: *level_2
+    Unit_hipDeviceGraphMemTrim_Positive_Default: *level_2
+    Unit_hipDeviceGraphMemTrim_Negative_Parameters: *level_2
+    Unit_hipDrvGraphExecMemsetNodeSetParams_BasicPositive: *level_2
+    Unit_hipDrvGraphExecMemsetNodeSetParams_Negative: *level_2
     Unit_hipGraphAddNodeTypeMemset_Positive_Basic: *level_2
-    Unit_hipGraphAddNodeTypeKernel_Positive_Basic:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddNodeTypeHost_Positive_Basic:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddNodeTypeChildGraph_Positive_Basic:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddNodeTypeMemcpy_Positive_Basic:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddNodeTypeEventRecord_Positive_Basic:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddNodeTypeEventWait_Positive_Basic:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddNodeTypeMemAlloc_Positive_Basic:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipGraphAddNode_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, node]
+    Unit_hipGraphAddNodeTypeKernel_Positive_Basic: *level_2
+    Unit_hipGraphAddNodeTypeHost_Positive_Basic: *level_2
+    Unit_hipGraphAddNodeTypeChildGraph_Positive_Basic: *level_2
+    Unit_hipGraphAddNodeTypeMemcpy_Positive_Basic: *level_2
+    Unit_hipGraphAddNodeTypeEventRecord_Positive_Basic: *level_2
+    Unit_hipGraphAddNodeTypeEventWait_Positive_Basic: *level_2
+    Unit_hipGraphAddNodeTypeMemAlloc_Positive_Basic: *level_2
+    Unit_hipGraphAddNode_Negative_Parameters: *level_2
     Unit_hipDrvGraphAddMemsetNode_Positive_Basic: *level_2
-    Unit_hipDrvGraphAddMemsetNode_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, node]
+    Unit_hipDrvGraphAddMemsetNode_Negative_Parameters: *level_2
     Unit_hipDrvGraphAddMemsetNode_hipMallocPitch_2D:
-      tags: [graph, node]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipDrvGraphAddMemsetNode_hipMallocPitch_1D:
-      tags: [graph, node]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipDrvGraphAddMemsetNode_hipMalloc3D_2D:
-      tags: [graph, node]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipDrvGraphAddMemsetNode_hipMalloc3D_1D:
-      tags: [graph, node]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipDrvGraphAddMemsetNode_hipMalloc_1D:
-      tags: [graph, node]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipDrvGraphAddMemsetNode_hipMallocManaged:
-      tags: [graph, node]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipDrvGraphAddMemcpyNode_Negative:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipDrvGraphAddMemcpyNode_test:
-      <<: *level_2
-      tags: [graph, node]
+    Unit_hipDrvGraphAddMemcpyNode_Negative: *level_2
+    Unit_hipDrvGraphAddMemcpyNode_test: *level_2
     Unit_hipDrvGraphAddMemcpyNode_MulitDevice:
-      tags: [graph, node, multigpu]
       <<: *level_2
-    Unit_hipDrvGraphAddMemcpyNode_Positive_Basic:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipDrvGraphAddMemcpyNode_Positive_Array:
-      <<: *level_2
-      tags: [graph, node]
-    Unit_hipDrvGraphAddMemcpyNode_Negative_Parameters:
-      <<: *level_2
-      tags: [graph, node]
+      tags: [multigpu]
+    Unit_hipDrvGraphAddMemcpyNode_Positive_Basic: *level_2
+    Unit_hipDrvGraphAddMemcpyNode_Positive_Array: *level_2
+    Unit_hipDrvGraphAddMemcpyNode_Negative_Parameters: *level_2
   hip_specific:
-    Unit_Device__hip_hc_add8pk_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, hip_ext]
-    Unit_Device__hip_hc_sub8pk_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, hip_ext]
-    Unit_Device__hip_hc_mul8pk_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, hip_ext]
-    Unit_Device__hip_hc_8pk_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lib, hip_ext]
-    Unit_Device__hip_check_VGPRs:
-      <<: *level_2
+    Unit_Device__hip_hc_add8pk_Sanity_Positive: *level_2
+    Unit_Device__hip_hc_sub8pk_Sanity_Positive: *level_2
+    Unit_Device__hip_hc_mul8pk_Sanity_Positive: *level_2
+    Unit_Device__hip_hc_8pk_Negative_Parameters_RTC: *level_2
+    Unit_Device__hip_check_VGPRs: *level_2
   kernel:
-    Unit_hipMemFaultStackAllocation_Check:
-      <<: *level_2
-      tags: [kernel, memory]
-    Unit_hipLaunchBounds_With_maxThreadsPerBlock_Check:
-      <<: *level_2
-      tags: [kernel, attributes]
-    Unit_hipLaunchBounds_With_maxThreadsPerBlock_blocksPerCU_Check:
-      <<: *level_2
-      tags: [kernel, attributes]
+    Unit_hipMemFaultStackAllocation_Check: *level_2
+    Unit_hipLaunchBounds_With_maxThreadsPerBlock_Check: *level_2
+    Unit_hipLaunchBounds_With_maxThreadsPerBlock_blocksPerCU_Check: *level_2
     Unit_hipDynamicShared:
-      tags: [kernel, memory]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipDynamicShared2:
-      <<: *level_2
-      tags: [kernel, memory]
-    Unit_hipEmptyKernel:
-      <<: *level_2
-      tags: [kernel, language]
-    Unit_hipGridLaunch:
-      <<: *level_2
-      tags: [kernel, launch]
-    Unit_hipLanguageExtensions:
-      <<: *level_2
-      tags: [kernel, language]
-    Unit_hipLaunchParm:
-      <<: *level_2
-      tags: [kernel, launch]
-    Unit_hipLaunchParmFunctor:
-      <<: *level_2
-      tags: [kernel, launch]
-    Unit_kernel_chkConstantViaKernel:
-      <<: *level_2
-      tags: [kernel, memory]
-    Unit_kernel_chkGlobalArrAndGlobalVaribleViaKernelFn:
-      <<: *level_2
-      tags: [kernel, memory]
-    Unit_kernel_MemoryOperationsViaKernels:
-      <<: *level_2
-      tags: [kernel, memory]
-    Unit_kernel_LaunchBounds_Functional:
-      <<: *level_2
-      tags: [kernel, attributes]
-    Unit_kernel_Assign_threadIdx_to_auto:
-      <<: *level_2
-      tags: [kernel, language]
-    Unit_hipLaunchKernelExC_NegetiveTsts:
-      <<: *level_2
-      tags: [kernel, launch]
-    Unit_hipLaunchKernelEx_NegetiveTsts:
-      <<: *level_2
-      tags: [kernel, launch]
-    Unit_hipLaunchKernelEx_Functional:
-      <<: *level_2
-      tags: [kernel, launch]
-    Unit_hipLaunchKernelEx_With_Different_Kernels:
-      <<: *level_2
-      tags: [kernel, launch]
-    Unit_hipLaunchKernelEx_With_CooperativeKernelWithArgs:
-      <<: *level_2
-      tags: [kernel, launch]
-    Unit_hipLaunchKernelEx_With_MaxBlockDims:
-      <<: *level_2
-      tags: [kernel, launch]
+    Unit_hipDynamicShared2: *level_2
+    Unit_hipEmptyKernel: *level_2
+    Unit_hipGridLaunch: *level_2
+    Unit_hipLanguageExtensions: *level_2
+    Unit_hipLaunchParm: *level_2
+    Unit_hipLaunchParmFunctor: *level_2
+    Unit_kernel_chkConstantViaKernel: *level_2
+    Unit_kernel_chkGlobalArrAndGlobalVaribleViaKernelFn: *level_2
+    Unit_kernel_MemoryOperationsViaKernels: *level_2
+    Unit_kernel_LaunchBounds_Functional: *level_2
+    Unit_kernel_Assign_threadIdx_to_auto: *level_2
+    Unit_hipLaunchKernelExC_NegetiveTsts: *level_2
+    Unit_hipLaunchKernelEx_NegetiveTsts: *level_2
+    Unit_hipLaunchKernelEx_Functional: *level_2
+    Unit_hipLaunchKernelEx_With_Different_Kernels: *level_2
+    Unit_hipLaunchKernelEx_With_CooperativeKernelWithArgs: *level_2
+    Unit_hipLaunchKernelEx_With_MaxBlockDims: *level_2
     Unit_kernel_ChkPrintf:
-      tags: [multigpu, kernel, language]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipExtLaunchKernelGGL:
-      tags: [kernel, launch]
       <<: *level_2
       # SWDEV-438524: Below tests causing TDR & machine down in stress test on 15/12/23
       disabled: [amd_windows, amd_wsl]
-    Unit_hipSetupArgument_Simple:
-      <<: *level_2
-      tags: [kernel, launch]
-    Unit_hipSetupArgument_Execute_Kernel_And_Check_Result:
-      <<: *level_2
-      tags: [kernel, launch]
-    Unit_ConfigureCall:
-      <<: *level_2
-      tags: [kernel, launch]
-    Unit_ConfigureCall_CheckParams:
-      <<: *level_2
-      tags: [kernel, launch]
+    Unit_hipSetupArgument_Simple: *level_2
+    Unit_hipSetupArgument_Execute_Kernel_And_Check_Result: *level_2
+    Unit_ConfigureCall: *level_2
+    Unit_ConfigureCall_CheckParams: *level_2
   launchBounds:
-    Unit_Kernel_Launch_bounds_Positive_Basic:
-      <<: *level_2
-      tags: [kernel, attributes]
+    Unit_Kernel_Launch_bounds_Positive_Basic: *level_2
     Unit_Kernel_Launch_bounds_Negative_OutOfBounds:
-      tags: [kernel, attributes]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_Kernel_Launch_bounds_Negative_Parameters_RTC:
-      tags: [kernel, attributes]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
   library:
-    Unit_library_negative:
-      <<: *level_2
-      tags: [module, library]
-    Unit_hip_library_load_co:
-      <<: *level_2
-      tags: [module, library]
-    Unit_hipKernelGetParamInfo_Negative:
-      <<: *level_2
-      tags: [module, library]
-    Unit_hip_library_load_rtc:
-      <<: *level_2
-      tags: [module, library]
+    Unit_library_negative: *level_2
+    Unit_hip_library_load_co: *level_2
+    Unit_hipKernelGetParamInfo_Negative: *level_2
+    Unit_hip_library_load_rtc: *level_2
   math:
     Unit_Device_sin_Accuracy_Positive_float: *level_2
     Unit_Device_sin_Accuracy_Positive_double: *level_2
-    Unit_Device_sin_sinf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_sin_sinf_Negative_RTC: *level_2
     Unit_Device_cos_Accuracy_Positive_float: *level_2
     Unit_Device_cos_Accuracy_Positive_double: *level_2
-    Unit_Device_cos_cosf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_cos_cosf_Negative_RTC: *level_2
     Unit_Device_tan_Accuracy_Positive_float: *level_2
     Unit_Device_tan_Accuracy_Positive_double: *level_2
-    Unit_Device_tan_tanf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_tan_tanf_Negative_RTC: *level_2
     Unit_Device_asin_Accuracy_Positive_float: *level_2
     Unit_Device_asin_Accuracy_Positive_double: *level_2
-    Unit_Device_asin_asinf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_asin_asinf_Negative_RTC: *level_2
     Unit_Device_acos_Accuracy_Positive_float: *level_2
     Unit_Device_acos_Accuracy_Positive_double: *level_2
-    Unit_Device_acos_acosf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_acos_acosf_Negative_RTC: *level_2
     Unit_Device_atan_Accuracy_Positive_float: *level_2
     Unit_Device_atan_Accuracy_Positive_double: *level_2
-    Unit_Device_atan_atanf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_atan_atanf_Negative_RTC: *level_2
     Unit_Device_sinh_Accuracy_Positive_float: *level_2
     Unit_Device_sinh_Accuracy_Positive_double: *level_2
-    Unit_Device_sinh_sinhf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_sinh_sinhf_Negative_RTC: *level_2
     Unit_Device_cosh_Accuracy_Positive_float: *level_2
     Unit_Device_cosh_Accuracy_Positive_double: *level_2
-    Unit_Device_cosh_coshf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_cosh_coshf_Negative_RTC: *level_2
     Unit_Device_tanh_Accuracy_Positive_float: *level_2
     Unit_Device_tanh_Accuracy_Positive_double: *level_2
-    Unit_Device_tanh_tanhf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_tanh_tanhf_Negative_RTC: *level_2
     Unit_Device_asinh_Accuracy_Positive_float: *level_2
     Unit_Device_asinh_Accuracy_Positive_double: *level_2
-    Unit_Device_asinh_asinhf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_asinh_asinhf_Negative_RTC: *level_2
     Unit_Device_acosh_Accuracy_Positive_float: *level_2
     Unit_Device_acosh_Accuracy_Positive_double: *level_2
-    Unit_Device_acosh_acoshf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_acosh_acoshf_Negative_RTC: *level_2
     Unit_Device_atanh_Accuracy_Positive_float: *level_2
     Unit_Device_atanh_Accuracy_Positive_double: *level_2
-    Unit_Device_atanh_atanhf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_atanh_atanhf_Negative_RTC: *level_2
     Unit_Device_sinpi_Accuracy_Positive_float: *level_2
     Unit_Device_sinpi_Accuracy_Positive_double:
       <<: *level_2
       # special values test, fix: comment out [HEX_DBL(-, 1, fffffffffffff, +, 31), HEX_DBL(+, 1, fffffffffffff, +, 31)]
       <<: *disabled_linux
-    Unit_Device_sinpi_sinpif_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_sinpi_sinpif_Negative_RTC: *level_2
     Unit_Device_cospi_Accuracy_Positive_float: *level_2
     Unit_Device_cospi_Accuracy_Positive_double:
       <<: *level_2
       # special values test, fix: comment out [HEX_DBL(-, 1, fffffffffffff, +, 31), HEX_DBL(+, 1, fffffffffffff, +, 31)]
       <<: *disabled_linux
-    Unit_Device_cospi_cospif_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_cospi_cospif_Negative_RTC: *level_2
     Unit_Device_atan2_Accuracy_Positive: *level_2
-    Unit_Device_atan2_atan2f_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_atan2_atan2f_Negative_RTC: *level_2
     Unit_Device_sincos_Accuracy_Positive_float: *level_2
     Unit_Device_sincos_Accuracy_Positive_double: *level_2
-    Unit_Device_sincos_sincosf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_sincos_sincosf_Negative_RTC: *level_2
     Unit_Device_sincospi_Accuracy_Positive_float: *level_2
     Unit_Device_sincospi_Accuracy_Positive_double:
       <<: *level_2
       # special values test, fix: comment out [HEX_DBL(-, 1, fffffffffffff, +, 31), HEX_DBL(+, 1, fffffffffffff, +, 31)]
       <<: *disabled_linux
-    Unit_Device_sincospi_sincospif_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_sincospi_sincospif_Negative_RTC: *level_2
     Unit_Device_fabs_Accuracy_Positive_float: *level_2
     Unit_Device_fabs_Accuracy_Positive_double: *level_2
-    Unit_Device_fabs_fabsf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_fabs_fabsf_Negative_RTC: *level_2
     Unit_Device_copysign_Accuracy_Positive: *level_2
-    Unit_Device_copysign_copysignf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_copysign_copysignf_Negative_RTC: *level_2
     Unit_Device_fmax_Accuracy_Positive: *level_2
-    Unit_Device_fmax_fmaxf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_fmax_fmaxf_Negative_RTC: *level_2
     Unit_Device_fmin_Accuracy_Positive: *level_2
-    Unit_Device_fmin_fminf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_fmin_fminf_Negative_RTC: *level_2
     Unit_Device_nextafter_Accuracy_Positive: *level_2
-    Unit_Device_nextafter_nextafterf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_nextafter_nextafterf_Negative_RTC: *level_2
     Unit_Device_fma_Accuracy_Positive:
       <<: *level_2
       # special values test, fix: comment out [-3.0f, -1.5f, HEX_FLT(-, 0, 00000c, -, 126), HEX_FLT(-, 0, 000006, -, 126), +3.0f, 1.5f, HEX_FLT(+, 0, 00000c, -, 126), HEX_FLT(+, 0, 000006, -, 126),]
       <<: *disabled_linux
-    Unit_Device_fma_fmaf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_fdividef_Accuracy_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_fdividef_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_fma_fmaf_Negative_RTC: *level_2
+    Unit_Device_fdividef_Accuracy_Positive: *level_2
+    Unit_Device_fdividef_Negative_RTC: *level_2
     Unit_Device_isfinite_Accuracy_Positive_float: *level_2
     Unit_Device_isfinite_Accuracy_Positive_double: *level_2
-    Unit_Device_isfinite_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_isfinite_Negative_RTC: *level_2
     Unit_Device_isinf_Accuracy_Positive_float: *level_2
     Unit_Device_isinf_Accuracy_Positive_double: *level_2
-    Unit_Device_isinf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_isinf_Negative_RTC: *level_2
     Unit_Device_isnan_Accuracy_Positive_float: *level_2
     Unit_Device_isnan_Accuracy_Positive_double: *level_2
-    Unit_Device_isnan_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_isnan_Negative_RTC: *level_2
     Unit_Device_signbit_Accuracy_Positive_float: *level_2
     Unit_Device_signbit_Accuracy_Positive_double: *level_2
-    Unit_Device_signbit_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_signbit_Negative_RTC: *level_2
     Unit_Device_fmod_Accuracy_Positive: *level_2
-    Unit_Device_fmod_fmodf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_fmod_fmodf_Negative_RTC: *level_2
     Unit_Device_remainder_Accuracy_Positive: *level_2
-    Unit_Device_remainder_remainder_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_remainder_remainder_Negative_RTC: *level_2
     Unit_Device_fdim_Accuracy_Positive:
       <<: *level_2
       # special values test, fix: comment out [HEX_DBL(-, 1, fffffffffffff, +, 31), HEX_DBL(-, 1, fffffffffffff, +, 30), HEX_DBL(+, 1, fffffffffffff, +, 31), HEX_DBL(+, 1, fffffffffffff, +, 30)]
       <<: *disabled_linux
-    Unit_Device_fdim_fdimf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_fdim_fdimf_Negative_RTC: *level_2
     Unit_Device_trunc_Accuracy_Positive_float: *level_2
     Unit_Device_trunc_Accuracy_Positive_double: *level_2
-    Unit_Device_trunc_truncf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_trunc_truncf_Negative_RTC: *level_2
     Unit_Device_round_Accuracy_Positive_float: *level_2
     Unit_Device_round_Accuracy_Positive_double: *level_2
-    Unit_Device_round_roundf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_round_roundf_Negative_RTC: *level_2
     Unit_Device_rint_Accuracy_Positive_float: *level_2
     Unit_Device_rint_Accuracy_Positive_double: *level_2
-    Unit_Device_rint_rintf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_rint_rintf_Negative_RTC: *level_2
     Unit_Device_nearbyint_Accuracy_Positive_float: *level_2
     Unit_Device_nearbyint_Accuracy_Positive_double: *level_2
-    Unit_Device_nearbyint_nearbyintf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_nearbyint_nearbyintf_Negative_RTC: *level_2
     Unit_Device_ceil_Accuracy_Positive_float: *level_2
     Unit_Device_ceil_Accuracy_Positive_double: *level_2
-    Unit_Device_ceil_ceilf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_ceil_ceilf_Negative_RTC: *level_2
     Unit_Device_floor_Accuracy_Positive_float: *level_2
     Unit_Device_floor_Accuracy_Positive_double: *level_2
-    Unit_Device_floor_floorf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_floor_floorf_Negative_RTC: *level_2
     Unit_Device_lrint_Accuracy_Positive_float: *level_2
     Unit_Device_lrint_Accuracy_Positive_double: *level_2
-    Unit_Device_lrint_lrintf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_lrint_lrintf_Negative_RTC: *level_2
     Unit_Device_lround_Accuracy_Positive_float: *level_2
     Unit_Device_lround_Accuracy_Positive_double: *level_2
-    Unit_Device_lround_lroundf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_lround_lroundf_Negative_RTC: *level_2
     Unit_Device_llrint_Accuracy_Positive_float: *level_2
     Unit_Device_llrint_Accuracy_Positive_double: *level_2
-    Unit_Device_llrint_llrintf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_llrint_llrintf_Negative_RTC: *level_2
     Unit_Device_llround_Accuracy_Positive_float: *level_2
     Unit_Device_llround_Accuracy_Positive_double: *level_2
-    Unit_Device_llround_llroundf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_llround_llroundf_Negative_RTC: *level_2
     Unit_Device_remquo_Accuracy_Positive:
       <<: *level_2
       # TODO special value test error, fix: comment out special value test
       <<: *disabled_linux
-    Unit_Device_remquo_remquof_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_remquo_remquof_Negative_RTC: *level_2
     Unit_Device_modf_Accuracy_Positive_float: *level_2
     Unit_Device_modf_Accuracy_Positive_double: *level_2
     Unit_Device_modf_modff_Negative_RTC:
-      tags: [device_lib, math]
       <<: *level_2
       # float* can be casted to double* [math_remainder_rounding_negative_kernels_rtc.hh:247]
       <<: *disabled_linux
@@ -4514,12 +2493,8 @@ unit:
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
-    Unit_Device___brev_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___brevll_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___brev_Sanity_Positive: *level_2
+    Unit_Device___brevll_Sanity_Positive: *level_2
     Unit_Device___clz_Sanity_Positive: *level_2
     Unit_Device___clzll_Sanity_Positive:
       <<: *level_2
@@ -4527,490 +2502,243 @@ unit:
       disabled: [amd_linux]
     Unit_Device___ffs_Sanity_Positive: *level_2
     Unit_Device___ffsll_Sanity_Positive: *level_2
-    Unit_Device___popc_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___popcll_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___mul24_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___umul24_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___funnelshift_l_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___funnelshift_lc_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___funnelshift_r_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___funnelshift_rc_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___popc_Sanity_Positive: *level_2
+    Unit_Device___popcll_Sanity_Positive: *level_2
+    Unit_Device___mul24_Sanity_Positive: *level_2
+    Unit_Device___umul24_Sanity_Positive: *level_2
+    Unit_Device___funnelshift_l_Sanity_Positive: *level_2
+    Unit_Device___funnelshift_lc_Sanity_Positive: *level_2
+    Unit_Device___funnelshift_r_Sanity_Positive: *level_2
+    Unit_Device___funnelshift_rc_Sanity_Positive: *level_2
     Unit_Device___hadd_Sanity_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below 4 tests are disable due to defect EXSWHTEC-355
       disabled: [amd_windows]
     Unit_Device___uhadd_Sanity_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below 4 tests are disable due to defect EXSWHTEC-355
       disabled: [amd_windows]
     Unit_Device___rhadd_Sanity_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below 4 tests are disable due to defect EXSWHTEC-355
       disabled: [amd_windows]
     Unit_Device___urhadd_Sanity_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below 4 tests are disable due to defect EXSWHTEC-355
       disabled: [amd_windows]
-    Unit_Device___mulhi_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___umulhi_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___mul64hi_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___umul64hi_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___sad_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___usad_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___byte_perm_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_sqrtf_Accuracy_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_sqrt_Accuracy_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_sqrt_sqrtf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_rsqrtf_Accuracy_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_rsqrt_Accuracy_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_rsqrt_rsqrtf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___mulhi_Sanity_Positive: *level_2
+    Unit_Device___umulhi_Sanity_Positive: *level_2
+    Unit_Device___mul64hi_Sanity_Positive: *level_2
+    Unit_Device___umul64hi_Sanity_Positive: *level_2
+    Unit_Device___sad_Sanity_Positive: *level_2
+    Unit_Device___usad_Sanity_Positive: *level_2
+    Unit_Device___byte_perm_Sanity_Positive: *level_2
+    Unit_Device_sqrtf_Accuracy_Positive: *level_2
+    Unit_Device_sqrt_Accuracy_Positive: *level_2
+    Unit_Device_sqrt_sqrtf_Negative_RTC: *level_2
+    Unit_Device_rsqrtf_Accuracy_Positive: *level_2
+    Unit_Device_rsqrt_Accuracy_Positive: *level_2
+    Unit_Device_rsqrt_rsqrtf_Negative_RTC: *level_2
     Unit_Device_cbrt_Accuracy_Positive_float: *level_2
     Unit_Device_cbrt_Accuracy_Positive_double: *level_2
-    Unit_Device_cbrt_cbrtf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_rcbrtf_Accuracy_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_rcbrt_Accuracy_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_rcbrt_rcbrtf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_cbrt_cbrtf_Negative_RTC: *level_2
+    Unit_Device_rcbrtf_Accuracy_Positive: *level_2
+    Unit_Device_rcbrt_Accuracy_Positive: *level_2
+    Unit_Device_rcbrt_rcbrtf_Negative_RTC: *level_2
     Unit_Device_hypot_Accuracy_Positive: *level_2
-    Unit_Device_hypot_hypotf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_hypot_hypotf_Negative_RTC: *level_2
     Unit_Device_rhypot_Accuracy_Positive: *level_2
-    Unit_Device_rhypot_rhypotf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_rhypot_rhypotf_Negative_RTC: *level_2
     Unit_Device_norm3d_Accuracy_Positive: *level_2
-    Unit_Device_norm3d_norm3df_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_norm3d_norm3df_Negative_RTC: *level_2
     Unit_Device_rnorm3d_Accuracy_Positive: *level_2
-    Unit_Device_rnorm3d_rnorm3df_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_rnorm3d_rnorm3df_Negative_RTC: *level_2
     Unit_Device_norm4d_Accuracy_Positive: *level_2
-    Unit_Device_norm4d_norm4df_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_norm4d_norm4df_Negative_RTC: *level_2
     Unit_Device_rnorm4d_Accuracy_Positive: *level_2
-    Unit_Device_rnorm4d_rnorm4df_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_rnorm4d_rnorm4df_Negative_RTC: *level_2
     Unit_Device_norm_Sanity_Positive: *level_2
-    Unit_Device_norm_normf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_norm_normf_Negative_RTC: *level_2
     Unit_Device_rnorm_Sanity_Positive: *level_2
-    Unit_Device_rnorm_rnormf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_rnorm_rnormf_Negative_RTC: *level_2
     Unit_Device_log_Accuracy_Positive_float: *level_2
     Unit_Device_log_Accuracy_Positive_double: *level_2
-    Unit_Device_log_logf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_log_logf_Negative_RTC: *level_2
     Unit_Device_log2_Accuracy_Positive_float: *level_2
     Unit_Device_log2_Accuracy_Positive_double: *level_2
-    Unit_Device_log2_log2f_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_log2_log2f_Negative_RTC: *level_2
     Unit_Device_log10_Accuracy_Positive_float: *level_2
     Unit_Device_log10_Accuracy_Positive_double: *level_2
-    Unit_Device_log10_log10f_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_log10_log10f_Negative_RTC: *level_2
     Unit_Device_log1p_Accuracy_Positive_float: *level_2
     Unit_Device_log1p_Accuracy_Positive_double:
       <<: *level_2
       # special values test, fix: comment out [HEX_DBL(-, 0, 0000000000001, -, 1022)]
       disabled: [amd_linux]
-    Unit_Device_log1p_log1pf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_log1p_log1pf_Negative_RTC: *level_2
     Unit_Device_logb_Accuracy_Positive_float: *level_2
     Unit_Device_logb_Accuracy_Positive_double: *level_2
-    Unit_Device_logb_logbf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_logb_logbf_Negative_RTC: *level_2
     Unit_Device_ilogbf_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below 2 tests are disable due to defect EXSWHTEC-369
       disabled: [amd_linux, amd_windows]
     Unit_Device_ilogb_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below 2 tests are disable due to defect EXSWHTEC-369
       disabled: [amd_linux, amd_windows]
-    Unit_Device_ilogb_ilogbf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_ilogb_ilogbf_Negative_RTC: *level_2
     Unit_Device_erf_Accuracy_Positive_float: *level_2
     Unit_Device_erf_Accuracy_Positive_double: *level_2
-    Unit_Device_erf_erff_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_erf_erff_Negative_RTC: *level_2
     Unit_Device_erfc_Accuracy_Positive_float: *level_2
     Unit_Device_erfc_Accuracy_Positive_double: *level_2
-    Unit_Device_erfc_erfcf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_erfinvf_Accuracy_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_erfinv_Accuracy_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_erfinv_erfinvf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_erfcinvf_Accuracy_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_erfcinv_Accuracy_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_erfcinv_erfcinvf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_erfcxf_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_erfcx_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_erfcx_erfcxf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_normcdff_Accuracy_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_normcdf_Accuracy_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_normcdf_normcdff_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_normcdfinvf_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_normcdfinv_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_normcdfinv_normcdfinvf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_erfc_erfcf_Negative_RTC: *level_2
+    Unit_Device_erfinvf_Accuracy_Positive: *level_2
+    Unit_Device_erfinv_Accuracy_Positive: *level_2
+    Unit_Device_erfinv_erfinvf_Negative_RTC: *level_2
+    Unit_Device_erfcinvf_Accuracy_Positive: *level_2
+    Unit_Device_erfcinv_Accuracy_Positive: *level_2
+    Unit_Device_erfcinv_erfcinvf_Negative_RTC: *level_2
+    Unit_Device_erfcxf_Sanity_Positive: *level_2
+    Unit_Device_erfcx_Sanity_Positive: *level_2
+    Unit_Device_erfcx_erfcxf_Negative_RTC: *level_2
+    Unit_Device_normcdff_Accuracy_Positive: *level_2
+    Unit_Device_normcdf_Accuracy_Positive: *level_2
+    Unit_Device_normcdf_normcdff_Negative_RTC: *level_2
+    Unit_Device_normcdfinvf_Sanity_Positive: *level_2
+    Unit_Device_normcdfinv_Sanity_Positive: *level_2
+    Unit_Device_normcdfinv_normcdfinvf_Negative_RTC: *level_2
     Unit_Device_tgammaf_Accuracy_Limited_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # TODO
       disabled: [amd_linux]
-    Unit_Device_tgamma_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_tgamma_tgammaf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_lgammaf_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_lgamma_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_lgamma_lgammaf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_cyl_bessel_i0f_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_cyl_bessel_i0_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_cyl_bessel_i0_cyl_bessel_i0f_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_cyl_bessel_i1f_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_cyl_bessel_i1_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_cyl_bessel_i1_cyl_bessel_i1f_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_y0f_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_y0_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_y0_y0f_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_y1f_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_y1_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_y1_y1f_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_ynf_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_yn_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_yn_ynf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_j0f_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_j0_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_j0_j0f_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_j1f_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_j1_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_j1_j1f_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_jnf_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_jn_Accuracy_Limited_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_jn_jnf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_tgamma_Accuracy_Limited_Positive: *level_2
+    Unit_Device_tgamma_tgammaf_Negative_RTC: *level_2
+    Unit_Device_lgammaf_Accuracy_Limited_Positive: *level_2
+    Unit_Device_lgamma_Accuracy_Limited_Positive: *level_2
+    Unit_Device_lgamma_lgammaf_Negative_RTC: *level_2
+    Unit_Device_cyl_bessel_i0f_Accuracy_Limited_Positive: *level_2
+    Unit_Device_cyl_bessel_i0_Accuracy_Limited_Positive: *level_2
+    Unit_Device_cyl_bessel_i0_cyl_bessel_i0f_Negative_RTC: *level_2
+    Unit_Device_cyl_bessel_i1f_Accuracy_Limited_Positive: *level_2
+    Unit_Device_cyl_bessel_i1_Accuracy_Limited_Positive: *level_2
+    Unit_Device_cyl_bessel_i1_cyl_bessel_i1f_Negative_RTC: *level_2
+    Unit_Device_y0f_Accuracy_Limited_Positive: *level_2
+    Unit_Device_y0_Accuracy_Limited_Positive: *level_2
+    Unit_Device_y0_y0f_Negative_RTC: *level_2
+    Unit_Device_y1f_Accuracy_Limited_Positive: *level_2
+    Unit_Device_y1_Accuracy_Limited_Positive: *level_2
+    Unit_Device_y1_y1f_Negative_RTC: *level_2
+    Unit_Device_ynf_Accuracy_Limited_Positive: *level_2
+    Unit_Device_yn_Accuracy_Limited_Positive: *level_2
+    Unit_Device_yn_ynf_Negative_RTC: *level_2
+    Unit_Device_j0f_Accuracy_Limited_Positive: *level_2
+    Unit_Device_j0_Accuracy_Limited_Positive: *level_2
+    Unit_Device_j0_j0f_Negative_RTC: *level_2
+    Unit_Device_j1f_Accuracy_Limited_Positive: *level_2
+    Unit_Device_j1_Accuracy_Limited_Positive: *level_2
+    Unit_Device_j1_j1f_Negative_RTC: *level_2
+    Unit_Device_jnf_Accuracy_Limited_Positive: *level_2
+    Unit_Device_jn_Accuracy_Limited_Positive: *level_2
+    Unit_Device_jn_jnf_Negative_RTC: *level_2
     Unit_Device___double2int_rd_Positive: *level_2
     Unit_Device___double2int_rn_Positive: *level_2
     Unit_Device___double2int_ru_Positive: *level_2
     Unit_Device___double2int_rz_Positive: *level_2
-    Unit_Device___double2int_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___double2int_Negative_RTC: *level_2
     Unit_Device___double2uint_rd_Positive: *level_2
     Unit_Device___double2uint_rn_Positive: *level_2
     Unit_Device___double2uint_ru_Positive: *level_2
     Unit_Device___double2uint_rz_Positive: *level_2
-    Unit_Device___double2uint_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___double2uint_Negative_RTC: *level_2
     Unit_Device___double2ll_rd_Positive: *level_2
     Unit_Device___double2ll_rn_Positive: *level_2
     Unit_Device___double2ll_ru_Positive: *level_2
     Unit_Device___double2ll_rz_Positive: *level_2
-    Unit_Device___double2ll_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___double2ll_Negative_RTC: *level_2
     Unit_Device___double2ull_rd_Positive: *level_2
     Unit_Device___double2ull_rn_Positive: *level_2
     Unit_Device___double2ull_ru_Positive: *level_2
     Unit_Device___double2ull_rz_Positive: *level_2
-    Unit_Device___double2ull_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___double2ull_Negative_RTC: *level_2
     Unit_Device___double2float_rd_Positive: *level_2
     Unit_Device___double2float_rn_Positive: *level_2
     Unit_Device___double2float_ru_Positive: *level_2
     Unit_Device___double2float_rz_Positive: *level_2
-    Unit_Device___double2float_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___double2hiint_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___double2hiint_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___double2loint_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___double2loint_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___double_as_longlong_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___double_as_longlong_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___double2float_Negative_RTC: *level_2
+    Unit_Device___double2hiint_Positive: *level_2
+    Unit_Device___double2hiint_Negative_RTC: *level_2
+    Unit_Device___double2loint_Positive: *level_2
+    Unit_Device___double2loint_Negative_RTC: *level_2
+    Unit_Device___double_as_longlong_Positive: *level_2
+    Unit_Device___double_as_longlong_Negative_RTC: *level_2
     Unit_Device___float2int_rd_Positive: *level_2
     Unit_Device___float2int_rn_Positive: *level_2
     Unit_Device___float2int_ru_Positive: *level_2
     Unit_Device___float2int_rz_Positive: *level_2
-    Unit_Device___float2int_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___float2int_Negative_RTC: *level_2
     Unit_Device___float2uint_rd_Positive: *level_2
     Unit_Device___float2uint_rn_Positive: *level_2
     Unit_Device___float2uint_ru_Positive: *level_2
     Unit_Device___float2uint_rz_Positive: *level_2
-    Unit_Device___float2uint_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___float2uint_Negative_RTC: *level_2
     Unit_Device___float2ll_rd_Positive: *level_2
     Unit_Device___float2ll_rn_Positive: *level_2
     Unit_Device___float2ll_ru_Positive: *level_2
     Unit_Device___float2ll_rz_Positive: *level_2
-    Unit_Device___float2ll_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___float2ll_Negative_RTC: *level_2
     Unit_Device___float2ull_rd_Positive: *level_2
     Unit_Device___float2ull_rn_Positive: *level_2
     Unit_Device___float2ull_ru_Positive: *level_2
     Unit_Device___float2ull_rz_Positive: *level_2
-    Unit_Device___float2ull_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___float_as_int_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___float_as_int_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___float_as_uint_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___float_as_uint_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___float2ull_Negative_RTC: *level_2
+    Unit_Device___float_as_int_Positive: *level_2
+    Unit_Device___float_as_int_Negative_RTC: *level_2
+    Unit_Device___float_as_uint_Positive: *level_2
+    Unit_Device___float_as_uint_Negative_RTC: *level_2
     Unit_Device___int2float_rd_Positive: *level_2
     Unit_Device___int2float_rn_Positive: *level_2
     Unit_Device___int2float_ru_Positive: *level_2
     Unit_Device___int2float_rz_Positive: *level_2
-    Unit_Device_int2float___Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_int2float___Negative_RTC: *level_2
     Unit_Device___uint2float_rd_Positive: *level_2
     Unit_Device___uint2float_rn_Positive: *level_2
     Unit_Device___uint2float_ru_Positive: *level_2
     Unit_Device___uint2float_rz_Positive: *level_2
-    Unit_Device___uint2float_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___uint2float_Negative_RTC: *level_2
     Unit_Device___int2double_rn_Positive: *level_2
-    Unit_Device___int2double_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___int2double_Negative_RTC: *level_2
     Unit_Device___uint2double_rn_Positive: *level_2
-    Unit_Device___uint2double_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___uint2double_Negative_RTC: *level_2
     Unit_Device___ll2float_rd_Positive: *level_2
     Unit_Device___ll2float_rn_Positive: *level_2
     Unit_Device___ll2float_ru_Positive: *level_2
     Unit_Device___ll2float_rz_Positive: *level_2
-    Unit_Device___ll2float_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___ll2float_Negative_RTC: *level_2
     Unit_Device___ull2float_rd_Positive: *level_2
     Unit_Device___ull2float_rn_Positive: *level_2
     Unit_Device___ull2float_ru_Positive: *level_2
     Unit_Device___ull2float_rz_Positive: *level_2
-    Unit_Device___ull2float_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___ull2float_Negative_RTC: *level_2
     Unit_Device___ll2double_rd_Positive: *level_2
     Unit_Device___ll2double_rn_Positive: *level_2
     Unit_Device___ll2double_ru_Positive: *level_2
     Unit_Device___ll2double_rz_Positive: *level_2
-    Unit_Device___ll2double_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___ll2double_Negative_RTC: *level_2
     Unit_Device___ull2double_rd_Positive: *level_2
     Unit_Device___ull2double_rn_Positive: *level_2
     Unit_Device___ull2double_ru_Positive: *level_2
     Unit_Device___ull2double_rz_Positive: *level_2
-    Unit_Device___ull2double_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___int_as_float_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___int_as_float_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___uint_as_float_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___uint_as_float_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___longlong_as_double_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___longlong_as_double_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___hiloint2double_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___hiloint2double_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___ull2double_Negative_RTC: *level_2
+    Unit_Device___int_as_float_Positive: *level_2
+    Unit_Device___int_as_float_Negative_RTC: *level_2
+    Unit_Device___uint_as_float_Positive: *level_2
+    Unit_Device___uint_as_float_Negative_RTC: *level_2
+    Unit_Device___longlong_as_double_Positive: *level_2
+    Unit_Device___longlong_as_double_Negative_RTC: *level_2
+    Unit_Device___hiloint2double_Positive: *level_2
+    Unit_Device___hiloint2double_Negative_RTC: *level_2
     Unit_Device___half2int_rn_Accuracy_Positive:
       <<: *level_2
       # (amd_windows) Below tests cause timeout in stress test of 09/02/24
@@ -5123,12 +2851,10 @@ unit:
       # (nvidia_linux) TODO rounding error
       disabled: [amd_windows, nvidia_linux]
     Unit_Device___half_as_short_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___half_as_ushort_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
@@ -5246,12 +2972,10 @@ unit:
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___short_as_half_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___ushort_as_half_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
@@ -5275,153 +2999,102 @@ unit:
       <<: *level_2
       # rounding float16 types not supported?
       <<: *disabled_linux
-    Unit_Device___float2half_rd_SmallVals_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___float2half_ru_SmallVals_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device___float2half_rz_SmallVals_Sanity_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device___float2half_rd_SmallVals_Sanity_Positive: *level_2
+    Unit_Device___float2half_ru_SmallVals_Sanity_Positive: *level_2
+    Unit_Device___float2half_rz_SmallVals_Sanity_Positive: *level_2
     Unit_Device___half2float_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device_exp_Accuracy_Positive_float: *level_2
     Unit_Device_exp_Accuracy_Positive_double: *level_2
-    Unit_Device_exp_expf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_exp_expf_Negative_RTC: *level_2
     Unit_Device_exp2_Accuracy_Positive_float: *level_2
     Unit_Device_exp2_Accuracy_Positive_double: *level_2
-    Unit_Device_exp2_exp2f_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_exp2_exp2f_Negative_RTC: *level_2
     Unit_Device_expm1_Accuracy_Positive_float: *level_2
     Unit_Device_expm1_Accuracy_Positive_double: *level_2
-    Unit_Device_expm1_expm1f_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_exp10f_Accuracy_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_exp10_Accuracy_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_exp10_exp10f_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_frexpf_Accuracy_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_frexp_Accuracy_Positive:
-      <<: *level_2
-      tags: [device_lib, math]
-    Unit_Device_frexp_frexpf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_expm1_expm1f_Negative_RTC: *level_2
+    Unit_Device_exp10f_Accuracy_Positive: *level_2
+    Unit_Device_exp10_Accuracy_Positive: *level_2
+    Unit_Device_exp10_exp10f_Negative_RTC: *level_2
+    Unit_Device_frexpf_Accuracy_Positive: *level_2
+    Unit_Device_frexp_Accuracy_Positive: *level_2
+    Unit_Device_frexp_frexpf_Negative_RTC: *level_2
     Unit_Device_pow_Accuracy_Positive: *level_2
-    Unit_Device_pow_powf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_pow_powf_Negative_RTC: *level_2
     Unit_Device_ldexp_Accuracy_Positive: *level_2
-    Unit_Device_ldexp_ldexpf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_ldexp_ldexpf_Negative_RTC: *level_2
     Unit_Device_powi_Accuracy_Positive: *level_2
-    Unit_Device_powi_powif_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_powi_powif_Negative_RTC: *level_2
     Unit_Device_scalbn_Accuracy_Positive: *level_2
-    Unit_Device_scalbn_scalbnf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_scalbn_scalbnf_Negative_RTC: *level_2
     Unit_Device_scalbln_Accuracy_Positive:
       <<: *level_2
       # long int exponents are too large, works fine with int
       disabled: [amd_linux]
-    Unit_Device_scalbln_scalblnf_Negative_RTC:
-      <<: *level_2
-      tags: [device_lib, math]
+    Unit_Device_scalbln_scalblnf_Negative_RTC: *level_2
     Unit_Device___half2half2_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device_make_half2_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___halves2half2_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___low2half_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___high2half_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___low2half2_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___high2half2_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___lowhigh2highlow_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___lows2half2_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___highs2half2_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___float2half2_rn_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___floats2half2_rn_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___float22half2_rn_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___low2float_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___high2float_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___half22float2_Accuracy_Positive:
-      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
@@ -5823,146 +3496,78 @@ unit:
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
   memory:
-    Unit_hipMemset_4bytes:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset_4bytes_hostMem:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipHostMalloc_4bytes:
-      <<: *level_2
-      tags: [memory]
-    Unit_hipMalloc_4bytes:
-      <<: *level_2
-      tags: [memory]
+    Unit_hipMemset_4bytes: *level_2
+    Unit_hipMemset_4bytes_hostMem: *level_2
+    Unit_hipHostMalloc_4bytes: *level_2
+    Unit_hipMalloc_4bytes: *level_2
     Unit_hipMemcpy2DToArray_Positive_Default:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
-    Unit_hipMemcpy2DToArray_Positive_Synchronization_Behavior:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DToArray_Positive_ZeroWidthHeight:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DToArray_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DToArray_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DToArray_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DToArray_ExtentValidation:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DToArray_PinnedMemSameGPU:
-      <<: *level_2
-      tags: [memory, transfer]
+      tags: [multigpu]
+    Unit_hipMemcpy2DToArray_Positive_Synchronization_Behavior: *level_2
+    Unit_hipMemcpy2DToArray_Positive_ZeroWidthHeight: *level_2
+    Unit_hipMemcpy2DToArray_Negative_Parameters: *level_2
+    Unit_hipMemcpy2DToArray_Capture: *level_2
+    Unit_hipMemcpy2DToArray_Basic: *level_2
+    Unit_hipMemcpy2DToArray_ExtentValidation: *level_2
+    Unit_hipMemcpy2DToArray_PinnedMemSameGPU: *level_2
     Unit_hipMemcpy2DToArray_multiDevicePinnedMemPeerGpu:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpy2DToArray_multiDeviceDeviceContextChange:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
-    Unit_hipMemcpy2DToArray_Negative:
-      <<: *level_2
-      tags: [memory, transfer]
+      tags: [multigpu]
+    Unit_hipMemcpy2DToArray_Negative: *level_2
     Unit_hipMemcpy2DToArrayAsync_Positive_Default:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpy2DToArrayAsync_Positive_Synchronization_Behavior:
-      tags: [memory, transfer]
       <<: *level_2
       # Disabling tests tracked with SWDEV-389647..
       disabled: [amd_wsl]
-    Unit_hipMemcpy2DToArrayAsync_Positive_ZeroWidthHeight:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DToArrayAsync_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DToArrayAsync_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DToArrayAsync_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DToArrayAsync_ExtentValidation:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DToArrayAsync_PinnedHostMemSameGpu:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpy2DToArrayAsync_Positive_ZeroWidthHeight: *level_2
+    Unit_hipMemcpy2DToArrayAsync_Negative_Parameters: *level_2
+    Unit_hipMemcpy2DToArrayAsync_Capture: *level_2
+    Unit_hipMemcpy2DToArrayAsync_Basic: *level_2
+    Unit_hipMemcpy2DToArrayAsync_ExtentValidation: *level_2
+    Unit_hipMemcpy2DToArrayAsync_PinnedHostMemSameGpu: *level_2
     Unit_hipMemcpy2DToArrayAsync_multiDevicePinnedHostMem:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpy2DToArrayAsync_multiDeviceDeviceContextChange:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
-    Unit_hipMemcpy2DToArrayAsync_Negative:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy3D_Positive_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
+      tags: [multigpu]
+    Unit_hipMemcpy2DToArrayAsync_Negative: *level_2
+    Unit_hipMemcpy3D_Positive_Basic: *level_2
     Unit_hipMemcpy3D_Positive_Synchronization_Behavior:
-      tags: [memory, transfer]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
-    Unit_hipMemcpy3D_Positive_DeviceToDevice_Synchronization_Behavior:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy3D_Positive_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy3D_Positive_Array:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy3D_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy3D_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpy3D_Positive_DeviceToDevice_Synchronization_Behavior: *level_2
+    Unit_hipMemcpy3D_Positive_Parameters: *level_2
+    Unit_hipMemcpy3D_Positive_Array: *level_2
+    Unit_hipMemcpy3D_Negative_Parameters: *level_2
+    Unit_hipMemcpy3D_Capture: *level_2
     Unit_hipMemcpy3D_Basic:
       <<: *level_2
       tags: [hipMemcpy3D]
-    Unit_hipMemcpy3D_ExtentValidation:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpy3D_ExtentValidation: *level_2
     Unit_hipMemcpy3D_multiDevice_Negative: *level_2
     Unit_hipMemcpy3D_multiDevice_OnPeerDevice:
       <<: *level_2
       tags: [multigpu]
     Unit_hipMemcpy3D_multiDevice_Basic_Size_Test:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
-    Unit_hipMemcpy3DAsync_Positive_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy3DAsync_Positive_Synchronization_Behavior:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy3DAsync_Positive_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy3DAsync_Positive_Array:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy3DAsync_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy3DAsync_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
+      tags: [multigpu]
+    Unit_hipMemcpy3DAsync_Positive_Basic: *level_2
+    Unit_hipMemcpy3DAsync_Positive_Synchronization_Behavior: *level_2
+    Unit_hipMemcpy3DAsync_Positive_Parameters: *level_2
+    Unit_hipMemcpy3DAsync_Positive_Array: *level_2
+    Unit_hipMemcpy3DAsync_Negative_Parameters: *level_2
+    Unit_hipMemcpy3DAsync_Capture: *level_2
     Unit_hipMemcpy3DAsync_Basic:
       <<: *level_2
       tags: [hipMemcpy3DAsync]
-    Unit_hipMemcpy3DAsync_ExtentValidation:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpy3DAsync_ExtentValidation: *level_2
     Unit_hipMemcpy3DAsync_multiDevice_Negative: *level_2
     Unit_hipMemcpy3DAsync_multiDevice_D2D:
       <<: *level_2
@@ -5970,59 +3575,34 @@ unit:
     Unit_hipMemcpy3DAsync_multiDevice_DiffStream:
       <<: *level_2
       tags: [multigpu]
-    Unit_hipMemcpy3DAsync_Basic_Size_Test:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpy3DAsync_Basic_Size_Test: *level_2
     Unit_hipMemcpyParam2D_Positive_Basic:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpyParam2D_Positive_Synchronization_Behavior:
-      tags: [memory, transfer]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
-    Unit_hipMemcpyParam2D_Positive_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyParam2D_Positive_Array:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyParam2D_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyParam2D_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpyParam2D_Positive_Parameters: *level_2
+    Unit_hipMemcpyParam2D_Positive_Array: *level_2
+    Unit_hipMemcpyParam2D_Negative_Parameters: *level_2
+    Unit_hipMemcpyParam2D_Capture: *level_2
     Unit_hipMemcpyParam2D_multiDevice_D2D:
       <<: *level_2
       tags: [hipMemcpyParam2D, multigpu]
     Unit_hipMemcpyParam2D_multiDevice_H2D_D2H:
       <<: *level_2
       tags: [hipMemcpyParam2D]
-    Unit_hipMemcpyParam2D_ExtentValidation:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyParam2D_Negative:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpyParam2D_ExtentValidation: *level_2
+    Unit_hipMemcpyParam2D_Negative: *level_2
     Unit_hipMemcpyParam2DAsync_Positive_Basic:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
-    Unit_hipMemcpyParam2DAsync_Positive_Synchronization_Behavior:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyParam2DAsync_Positive_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyParam2DAsync_Positive_Array:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyParam2DAsync_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyParam2DAsync_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
+      tags: [multigpu]
+    Unit_hipMemcpyParam2DAsync_Positive_Synchronization_Behavior: *level_2
+    Unit_hipMemcpyParam2DAsync_Positive_Parameters: *level_2
+    Unit_hipMemcpyParam2DAsync_Positive_Array: *level_2
+    Unit_hipMemcpyParam2DAsync_Negative_Parameters: *level_2
+    Unit_hipMemcpyParam2DAsync_Capture: *level_2
     Unit_hipMemcpyParam2DAsync_multiDevice_StreamOnDiffDevice:
       <<: *level_2
       tags: [hipMemcpyParam2DAsync, multigpu]
@@ -6034,29 +3614,18 @@ unit:
     Unit_hipMemcpyParam2DAsync_multiDevice_H2D_D2H:
       <<: *level_2
       tags: [hipMemcpyParam2DAsync, multigpu]
-    Unit_hipMemcpyParam2DAsync_ExtentValidation:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyParam2DAsync_Negative:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpyParam2DAsync_ExtentValidation: *level_2
+    Unit_hipMemcpyParam2DAsync_Negative: *level_2
     Unit_hipMemcpy2D_Positive_Basic:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpy2D_Positive_Synchronization_Behavior:
-      tags: [memory, transfer]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
-    Unit_hipMemcpy2D_Positive_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2D_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2D_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpy2D_Positive_Parameters: *level_2
+    Unit_hipMemcpy2D_Negative_Parameters: *level_2
+    Unit_hipMemcpy2D_Capture: *level_2
     Unit_hipMemcpy2D_H2D_D2D_D2H:
       <<: *level_2
       # Below tests are failing PSDB
@@ -6072,27 +3641,17 @@ unit:
     Unit_hipMemcpy2D_multiDevice_D2D:
       <<: *level_2
       tags: [multigpu]
-    Unit_hipMemcpy2D_SizeCheck:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2D_Negative:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpy2D_SizeCheck: *level_2
+    Unit_hipMemcpy2D_Negative: *level_2
     Unit_hipMemcpy2D_multiDevice_Basic_Size_Test:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpy2DAsync_Positive_Basic:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
-    Unit_hipMemcpy2DAsync_Positive_Synchronization_Behavior:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DAsync_Positive_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DAsync_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
+      tags: [multigpu]
+    Unit_hipMemcpy2DAsync_Positive_Synchronization_Behavior: *level_2
+    Unit_hipMemcpy2DAsync_Positive_Parameters: *level_2
+    Unit_hipMemcpy2DAsync_Negative_Parameters: *level_2
     Unit_hipMemcpy2DAsync_Capture: *level_2
     Unit_hipMemcpy2DAsync_Host_N_PinnedMem:
       <<: *level_2
@@ -6104,180 +3663,94 @@ unit:
     Unit_hipMemcpy2DAsync_multiDevice_StreamOnDiffDevice:
       <<: *level_2
       tags: [multigpu]
-    Unit_hipMemcpy2DAsync_SizeCheck:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DAsync_Negative:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpy2DAsync_SizeCheck: *level_2
+    Unit_hipMemcpy2DAsync_Negative: *level_2
     Unit_hipMemcpy2DAsync_multiDevice_Basic_Size_Test:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpy2DFromArray_Positive_Default:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
-    Unit_hipMemcpy2DFromArray_Positive_Synchronization_Behavior:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DFromArray_Positive_ZeroWidthHeight:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DFromArray_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DFromArray_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DFromArray_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DFromArray_ExtentValidation:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DFromArray_PinnedMemSameGPU:
-      <<: *level_2
-      tags: [memory, transfer]
+      tags: [multigpu]
+    Unit_hipMemcpy2DFromArray_Positive_Synchronization_Behavior: *level_2
+    Unit_hipMemcpy2DFromArray_Positive_ZeroWidthHeight: *level_2
+    Unit_hipMemcpy2DFromArray_Negative_Parameters: *level_2
+    Unit_hipMemcpy2DFromArray_Capture: *level_2
+    Unit_hipMemcpy2DFromArray_Basic: *level_2
+    Unit_hipMemcpy2DFromArray_ExtentValidation: *level_2
+    Unit_hipMemcpy2DFromArray_PinnedMemSameGPU: *level_2
     Unit_hipMemcpy2DFromArray_multiDevicePinnedMemPeerGpu:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpy2DFromArray_multiDeviceContextChange:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
-    Unit_hipMemcpy2DFromArray_Negative:
-      <<: *level_2
-      tags: [memory, transfer]
+      tags: [multigpu]
+    Unit_hipMemcpy2DFromArray_Negative: *level_2
     Unit_hipMemcpy2DFromArrayAsync_Positive_Default:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpy2DFromArrayAsync_Positive_Synchronization_Behavior:
-      tags: [memory, transfer]
       <<: *level_2
       # SWDEV-396963
       disabled: [amd_wsl]
-    Unit_hipMemcpy2DFromArrayAsync_Positive_ZeroWidthHeight:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DFromArrayAsync_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DFromArrayAsync_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DFromArrayAsync_ExtentValidation:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DFromArrayAsync_PinnedHostMemSameGpu:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpy2DFromArrayAsync_Positive_ZeroWidthHeight: *level_2
+    Unit_hipMemcpy2DFromArrayAsync_Negative_Parameters: *level_2
+    Unit_hipMemcpy2DFromArrayAsync_Basic: *level_2
+    Unit_hipMemcpy2DFromArrayAsync_ExtentValidation: *level_2
+    Unit_hipMemcpy2DFromArrayAsync_PinnedHostMemSameGpu: *level_2
     Unit_hipMemcpy2DFromArrayAsync_multiDevicePinnedHostMem:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpy2DFromArrayAsync_multiDeviceContextChange:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
-    Unit_hipMemcpy2DFromArrayAsync_Negative:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DFromArrayAsync_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyAtoD_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyAtoH_Positive_Default:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyAtoH_Positive_Synchronization_Behavior:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyAtoH_Positive_ZeroCount:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyAtoH_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyAtoH_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyAtoHAsync_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyAtoHAsync_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
+      tags: [multigpu]
+    Unit_hipMemcpy2DFromArrayAsync_Negative: *level_2
+    Unit_hipMemcpy2DFromArrayAsync_Capture: *level_2
+    Unit_hipMemcpyAtoD_Basic: *level_2
+    Unit_hipMemcpyAtoH_Positive_Default: *level_2
+    Unit_hipMemcpyAtoH_Positive_Synchronization_Behavior: *level_2
+    Unit_hipMemcpyAtoH_Positive_ZeroCount: *level_2
+    Unit_hipMemcpyAtoH_Negative_Parameters: *level_2
+    Unit_hipMemcpyAtoH_Capture: *level_2
+    Unit_hipMemcpyAtoHAsync_Basic: *level_2
+    Unit_hipMemcpyAtoHAsync_Capture: *level_2
     Unit_hipMemcpyDtoA_Basic: *level_2
-    Unit_hipMemcpyDtoA_Negative:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyDtoA_BasicPositive:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpyDtoA_Negative: *level_2
+    Unit_hipMemcpyDtoA_BasicPositive: *level_2
     Unit_hipMemcpyAtoH_Basic:
       <<: *level_2
       tags: [hipMemcpyAtoH]
     Unit_hipMemcpyAtoH_multiDevice_PeerDeviceContext:
       <<: *level_2
       tags: [hipMemcpyAtoH, multigpu]
-    Unit_hipMemcpyAtoH_Negative:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyAtoH_SizeCheck:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyHtoA_Positive_Default:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyHtoA_Positive_Synchronization_Behavior:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyHtoA_Positive_ZeroCount:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyHtoA_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyHtoA_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpyAtoH_Negative: *level_2
+    Unit_hipMemcpyAtoH_SizeCheck: *level_2
+    Unit_hipMemcpyHtoA_Positive_Default: *level_2
+    Unit_hipMemcpyHtoA_Positive_Synchronization_Behavior: *level_2
+    Unit_hipMemcpyHtoA_Positive_ZeroCount: *level_2
+    Unit_hipMemcpyHtoA_Negative_Parameters: *level_2
+    Unit_hipMemcpyHtoA_Capture: *level_2
     Unit_hipMemcpyHtoAAsync_Basic: *level_2
-    Unit_hipMemcpyHtoAAsync_Negative:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpyHtoAAsync_Negative: *level_2
     Unit_hipMemcpyHtoAAsync_BasicTstsWithDiffStreams:
-      tags: [memory, transfer]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
     Unit_hipMemcpyHtoAAsync_MultiDevice:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
-    UnitHipMemcpyHtoAAsync_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyAtoA_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
+      tags: [multigpu]
+    UnitHipMemcpyHtoAAsync_Capture: *level_2
+    Unit_hipMemcpyAtoA_Basic: *level_2
     Unit_hipMemcpyHtoA_Basic:
       <<: *level_2
       tags: [hipMemcpyHtoA]
     Unit_hipMemcpyHtoA_multiDevice_PeerDeviceContext:
       <<: *level_2
       tags: [hipMemcpyHtoA, multigpu]
-    Unit_hipMemcpyHtoA_Negative:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyHtoA_SizeCheck:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy_Negative:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy_NullCheck:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy_HalfMemCopy:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpyHtoA_Negative: *level_2
+    Unit_hipMemcpyHtoA_SizeCheck: *level_2
+    Unit_hipMemcpy_Negative: *level_2
+    Unit_hipMemcpy_NullCheck: *level_2
+    Unit_hipMemcpy_HalfMemCopy: *level_2
     Unit_hipMemcpy_MultiThread_AllAPIs:
       <<: *level_2
       tags: [multigpu]
@@ -6290,135 +3763,62 @@ unit:
       tags: [multigpu]
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_hipHostRegister_SameChunkRepeat:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostRegister_Chunks_SingleAttempt:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostRegister_Chunks_RoundRobin:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostRegister_Perform_hipMemset:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostRegister_Perform_hipMemcpy:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostRegister_Oversubscription:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostRegister_AsyncApis:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostRegister_Graphs:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostRegister_RegUnreg_Perf_SameChunk:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostRegister_RegUnreg_Perf_DiffChunk:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostRegister_RegUnreg_Perf_SameChunk_MGPU:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostRegister_MemAdvise_SetGet:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipHostRegister_SameChunkRepeat: *level_2
+    Unit_hipHostRegister_Chunks_SingleAttempt: *level_2
+    Unit_hipHostRegister_Chunks_RoundRobin: *level_2
+    Unit_hipHostRegister_Perform_hipMemset: *level_2
+    Unit_hipHostRegister_Perform_hipMemcpy: *level_2
+    Unit_hipHostRegister_Oversubscription: *level_2
+    Unit_hipHostRegister_AsyncApis: *level_2
+    Unit_hipHostRegister_Graphs: *level_2
+    Unit_hipHostRegister_RegUnreg_Perf_SameChunk: *level_2
+    Unit_hipHostRegister_RegUnreg_Perf_DiffChunk: *level_2
+    Unit_hipHostRegister_RegUnreg_Perf_SameChunk_MGPU: *level_2
+    Unit_hipHostRegister_MemAdvise_SetGet: *level_2
     Unit_hipHostRegister_Memcpy: *level_2
     Unit_hipHostRegister_Flags: *level_2
     Unit_hipHostRegister_Negative: *level_2
-    Unit_hipHostRegister_Capture:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostUnregister_MemoryNotAccessableAfterUnregister:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostUnregister_NullPtr:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostUnregister_Ptr_Different_Than_Specified_To_Register:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostUnregister_NotRegisteredPointer:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostUnregister_AlreadyUnregisteredPointer:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostUnregister_Capture:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipHostRegister_Capture: *level_2
+    Unit_hipHostUnregister_MemoryNotAccessableAfterUnregister: *level_2
+    Unit_hipHostUnregister_NullPtr: *level_2
+    Unit_hipHostUnregister_Ptr_Different_Than_Specified_To_Register: *level_2
+    Unit_hipHostUnregister_NotRegisteredPointer: *level_2
+    Unit_hipHostUnregister_AlreadyUnregisteredPointer: *level_2
+    Unit_hipHostUnregister_Capture: *level_2
     Unit_hipHostGetFlags_flagCombos:
-      tags: [memory, query]
       <<: *level_2
       # Note: CONFIG_NUMA disabled
       disabled: [amd_wsl]
     Unit_hipHostGetFlags_DifferentThreads:
-      tags: [memory, query]
       <<: *level_2
       # Note: CONFIG_NUMA disabled
       disabled: [amd_wsl]
-    Unit_hipHostGetFlags_InvalidArgs:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipHostGetFlags_Capture:
-      <<: *level_2
-      tags: [memory, query]
+    Unit_hipHostGetFlags_InvalidArgs: *level_2
+    Unit_hipHostGetFlags_Capture: *level_2
     Unit_hipHostGetDevicePointer_Negative:
-      tags: [memory, query]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/96
       disabled: [amd_windows, amd_wsl]
-    Unit_hipHostGetDevicePointer_UseCase:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipHostGetDevicePointer_Capture:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMallocHost_Positive:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocHost_DataValidation:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocHost_Negative:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocHost_Capture:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemAllocHost_Positive:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemAllocHost_DataValidation:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemAllocHost_Negative:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipHostGetDevicePointer_UseCase: *level_2
+    Unit_hipHostGetDevicePointer_Capture: *level_2
+    Unit_hipMallocHost_Positive: *level_2
+    Unit_hipMallocHost_DataValidation: *level_2
+    Unit_hipMallocHost_Negative: *level_2
+    Unit_hipMallocHost_Capture: *level_2
+    Unit_hipMemAllocHost_Positive: *level_2
+    Unit_hipMemAllocHost_DataValidation: *level_2
+    Unit_hipMemAllocHost_Negative: *level_2
     Unit_hipMemAllocHost_VerifyAccess:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
-    Unit_hipMemAllocHost_Capture:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocManaged_HostDeviceConcurrent:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocManaged_MultiChunkSingleDevice:
-      <<: *level_2
-      tags: [memory, alloc]
+      tags: [multigpu]
+    Unit_hipMemAllocHost_Capture: *level_2
+    Unit_hipMallocManaged_HostDeviceConcurrent: *level_2
+    Unit_hipMallocManaged_MultiChunkSingleDevice: *level_2
     Unit_hipMallocManaged_MultiChunkMultiDevice:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
-    Unit_hipMallocManaged_OverSubscription:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocManaged_Negative:
-      <<: *level_2
-      tags: [memory, alloc]
+      tags: [multigpu]
+    Unit_hipMallocManaged_OverSubscription: *level_2
+    Unit_hipMallocManaged_Negative: *level_2
     Unit_hipMallocManaged_TwoPointers:
       <<: *level_2
       tags: [multigpu]
@@ -6427,987 +3827,504 @@ unit:
       tags: [multigpu]
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemset_Negative_InvalidPtr:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset_Negative_OutOfBoundsSize:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset_Negative_OutOfBoundsPtr:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset2D_Negative_InvalidPtr:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset2D_Negative_InvalidSizes:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset2D_Negative_OutOfBoundsPtr:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset3D_Negative_InvalidPtr:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset3D_Negative_ModifiedPtr:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset3D_Negative_InvalidSizes:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset3D_Negative_OutOfBounds:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset_SetMemoryWithOffset:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetAsync_SetMemoryWithOffset:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset_SmallBufferSizes:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset_2AsyncOperations:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset3D_BasicFunctional:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset3DAsync_BasicFunctional:
-      <<: *level_2
-      tags: [memory, memset]
+    Unit_hipMemset_Negative_InvalidPtr: *level_2
+    Unit_hipMemset_Negative_OutOfBoundsSize: *level_2
+    Unit_hipMemset_Negative_OutOfBoundsPtr: *level_2
+    Unit_hipMemset2D_Negative_InvalidPtr: *level_2
+    Unit_hipMemset2D_Negative_InvalidSizes: *level_2
+    Unit_hipMemset2D_Negative_OutOfBoundsPtr: *level_2
+    Unit_hipMemset3D_Negative_InvalidPtr: *level_2
+    Unit_hipMemset3D_Negative_ModifiedPtr: *level_2
+    Unit_hipMemset3D_Negative_InvalidSizes: *level_2
+    Unit_hipMemset3D_Negative_OutOfBounds: *level_2
+    Unit_hipMemset_SetMemoryWithOffset: *level_2
+    Unit_hipMemsetAsync_SetMemoryWithOffset: *level_2
+    Unit_hipMemset_SmallBufferSizes: *level_2
+    Unit_hipMemset_2AsyncOperations: *level_2
+    Unit_hipMemset3D_BasicFunctional: *level_2
+    Unit_hipMemset3DAsync_BasicFunctional: *level_2
     Unit_hipMemset3DAsync_capturehipMemset3DAsync:
-      tags: [memory, memset]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipMemset2D_BasicFunctional:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset2DAsync_BasicFunctional:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset2D_UniqueWidthHeight:
-      <<: *level_2
-      tags: [memory, memset]
+    Unit_hipMemset2D_BasicFunctional: *level_2
+    Unit_hipMemset2DAsync_BasicFunctional: *level_2
+    Unit_hipMemset2D_UniqueWidthHeight: *level_2
     Unit_hipMemset2DAsync_capturehipMemset2DAsync:
-      tags: [memory, memset]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipHostMalloc_ArgValidation:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemset3D_MemsetWithExtent:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset3DAsync_MemsetWithExtent:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset3D_MemsetMaxValue:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset3DAsync_MemsetMaxValue:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset3D_SeekSetSlice:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset3DAsync_SeekSetSlice:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset3D_SeekSetArrayPortion:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset3DAsync_SeekSetArrayPortion:
-      <<: *level_2
-      tags: [memory, memset]
+    Unit_hipHostMalloc_ArgValidation: *level_2
+    Unit_hipMemset3D_MemsetWithExtent: *level_2
+    Unit_hipMemset3DAsync_MemsetWithExtent: *level_2
+    Unit_hipMemset3D_MemsetMaxValue: *level_2
+    Unit_hipMemset3DAsync_MemsetMaxValue: *level_2
+    Unit_hipMemset3D_SeekSetSlice: *level_2
+    Unit_hipMemset3DAsync_SeekSetSlice: *level_2
+    Unit_hipMemset3D_SeekSetArrayPortion: *level_2
+    Unit_hipMemset3DAsync_SeekSetArrayPortion: *level_2
     Unit_hipMemset3D_RegressInLoop:
-      tags: [memory, memset, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemset3DAsync_RegressInLoop:
-      tags: [memory, memset, multigpu]
       <<: *level_2
-    Unit_hipMemset3DAsync_ConcurrencyMthread:
-      <<: *level_2
-      tags: [memory, memset]
+      tags: [multigpu]
+    Unit_hipMemset3DAsync_ConcurrencyMthread: *level_2
     Unit_hipMallocManaged_FlgParam:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMallocManaged_AccessMultiStream:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
-    Unit_hipMemPrefetchAsyncAdviseFlgTst:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemPrefetchAsyncAccsdByTst:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemPrefetchAsyncNegativeTst:
-      <<: *level_2
-      tags: [memory, query]
+      tags: [multigpu]
+    Unit_hipMemPrefetchAsyncAdviseFlgTst: *level_2
+    Unit_hipMemPrefetchAsyncAccsdByTst: *level_2
+    Unit_hipMemPrefetchAsyncNegativeTst: *level_2
     Unit_hipMemPrefetchAsync_NonPageSz:
-      tags: [memory, query]
       <<: *level_2
       # Disabling below tests temporarily due to change in API behavior
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemAdvise_MmapMem:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMallocManaged_Basic:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMemAdvise_MmapMem: *level_2
+    Unit_hipMallocManaged_Basic: *level_2
     Unit_hipMallocManaged_Advanced:
-      tags: [memory, alloc]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMallocManaged_Large:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Basic:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Partial_Range:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Basic:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_CPU:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Partial_Range:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Basic:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_CPU:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Partial_Range:
-      <<: *level_2
-      tags: [memory, query]
+    Unit_hipMallocManaged_Large: *level_2
+    Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Basic: *level_2
+    Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Partial_Range: *level_2
+    Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Basic: *level_2
+    Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_CPU: *level_2
+    Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Partial_Range: *level_2
+    Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Basic: *level_2
+    Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_CPU: *level_2
+    Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Partial_Range: *level_2
     Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Basic:
-      tags: [memory, query]
       <<: *level_2
       # NOTE: The following 2 tests are disabled due to defect - EXSWHTEC-238
       disabled: [amd_linux, amd_wsl]
     Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Partial_Range:
-      tags: [memory, query]
       <<: *level_2
       # NOTE: The following 2 tests are disabled due to defect - EXSWHTEC-238
       disabled: [amd_linux, amd_wsl]
-    Unit_hipMemRangeGetAttribute_Positive_AccessedBy_MultiDevice:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemRangeGetAttribute_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemRangeGetAttribute_TstCountParam:
-      <<: *level_2
-      tags: [memory, query]
+    Unit_hipMemRangeGetAttribute_Positive_AccessedBy_MultiDevice: *level_2
+    Unit_hipMemRangeGetAttribute_Negative_Parameters: *level_2
+    Unit_hipMemRangeGetAttribute_TstCountParam: *level_2
     Unit_hipMemRangeGetAttribute_NegativeTests:
-      tags: [memory, query]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemRangeGetAttribute_AccessedBy1:
-      tags: [memory, query]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemRangeGetAttribte_3:
-      tags: [memory, query]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemRangeGetAttribute_4:
-      tags: [memory, query]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemRangeGetAttribute_PrefetchAndGtAttr:
-      tags: [memory, query]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
-    Unit_hipHostMalloc_CoherentTst:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMallocManaged_CoherentTst:
-      <<: *level_2
-      tags: [memory, query]
+    Unit_hipHostMalloc_CoherentTst: *level_2
+    Unit_hipMallocManaged_CoherentTst: *level_2
     Unit_hipMallocManaged_CoherentTstWthAdvise:
-      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipMalloc_CoherentTst:
-      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipExtMallocWithFlags_CoherentTst:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemsetD32_ValidBuffer:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD32_InvalidArg:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD32_KernelBuffer:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD16_ValidBuffer:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD16_InvalidArg:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD16_KernelBuffer:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD16Async_ValidBuffer:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD16Async_InvalidArg:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD16Async_KernelBuffer:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD32Async_ValidBuffer:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD32Async_InvalidArg:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD32Async_KernelBuffer:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD8Async_ValidBuffer:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD8Async_InvalidArg:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD8Async_KernelBuffer:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemcpy2DArrayToArray_Negative:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DArrayToArray_Positive:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DArrayToArray_BasicPositive:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipExtMallocWithFlags_CoherentTst: *level_2
+    Unit_hipMemsetD32_ValidBuffer: *level_2
+    Unit_hipMemsetD32_InvalidArg: *level_2
+    Unit_hipMemsetD32_KernelBuffer: *level_2
+    Unit_hipMemsetD16_ValidBuffer: *level_2
+    Unit_hipMemsetD16_InvalidArg: *level_2
+    Unit_hipMemsetD16_KernelBuffer: *level_2
+    Unit_hipMemsetD16Async_ValidBuffer: *level_2
+    Unit_hipMemsetD16Async_InvalidArg: *level_2
+    Unit_hipMemsetD16Async_KernelBuffer: *level_2
+    Unit_hipMemsetD32Async_ValidBuffer: *level_2
+    Unit_hipMemsetD32Async_InvalidArg: *level_2
+    Unit_hipMemsetD32Async_KernelBuffer: *level_2
+    Unit_hipMemsetD8Async_ValidBuffer: *level_2
+    Unit_hipMemsetD8Async_InvalidArg: *level_2
+    Unit_hipMemsetD8Async_KernelBuffer: *level_2
+    Unit_hipMemcpy2DArrayToArray_Negative: *level_2
+    Unit_hipMemcpy2DArrayToArray_Positive: *level_2
+    Unit_hipMemcpy2DArrayToArray_BasicPositive: *level_2
     Unit_hipMemcpy3DBatchAsync_Ptr2PtrBatchOps: *level_2
     Unit_hipMemcpy3DBatchAsync_ArrayMemCpyBatchOps: *level_2
-    Unit_hipMemcpy3DBatchAsync_NegativeTests:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpy3DBatchAsync_NegativeTests: *level_2
     Unit_hipMemcpyBatchAsync_D2D_Functional: *level_2
     Unit_hipMemcpyBatchAsync_H2D_Functional: *level_2
     Unit_hipMemcpyBatchAsync_D2H_Functional: *level_2
     Unit_hipMemcpyBatchAsync_H2H_Functional: *level_2
-    Unit_hipMemcpyBatchAsync_NegativeTsts:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemsetD2D8_BasicFunctional:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD2D8_UnEvenRowsCols:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD2D8_NegTsts:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD2D8Async_BasicFunctional:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD2D8Async_UnEvenRowsCols:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD2D8Async_NegTsts:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD2D16_BasicFunctional:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD2D16_UnEvenRowsCols:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD2D16_NegTsts:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD2D16Async_BasicFunctional:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD2D16Async_UnEvenRowsCols:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD2D16Async_NegTsts:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD2D32_BasicFunctional:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD2D32_UnEvenRowsCols:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD2D32_NegTsts:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD2D32Async_BasicFunctional:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD2D32Async_UnEvenRowsCols:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetD2D32Async_NegTsts:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemcpy3DPeer_BasicFunctional:
-      <<: *level_2
-      tags: [memory, transfer, multigpu]
-    Unit_hipMemcpy3DPeer_NegativeTsts:
-      <<: *level_2
-      tags: [memory, transfer, multigpu]
+    Unit_hipMemcpyBatchAsync_NegativeTsts: *level_2
+    Unit_hipMemsetD2D8_BasicFunctional: *level_2
+    Unit_hipMemsetD2D8_UnEvenRowsCols: *level_2
+    Unit_hipMemsetD2D8_NegTsts: *level_2
+    Unit_hipMemsetD2D8Async_BasicFunctional: *level_2
+    Unit_hipMemsetD2D8Async_UnEvenRowsCols: *level_2
+    Unit_hipMemsetD2D8Async_NegTsts: *level_2
+    Unit_hipMemsetD2D16_BasicFunctional: *level_2
+    Unit_hipMemsetD2D16_UnEvenRowsCols: *level_2
+    Unit_hipMemsetD2D16_NegTsts: *level_2
+    Unit_hipMemsetD2D16Async_BasicFunctional: *level_2
+    Unit_hipMemsetD2D16Async_UnEvenRowsCols: *level_2
+    Unit_hipMemsetD2D16Async_NegTsts: *level_2
+    Unit_hipMemsetD2D32_BasicFunctional: *level_2
+    Unit_hipMemsetD2D32_UnEvenRowsCols: *level_2
+    Unit_hipMemsetD2D32_NegTsts: *level_2
+    Unit_hipMemsetD2D32Async_BasicFunctional: *level_2
+    Unit_hipMemsetD2D32Async_UnEvenRowsCols: *level_2
+    Unit_hipMemsetD2D32Async_NegTsts: *level_2
+    Unit_hipMemcpy3DPeer_BasicFunctional: *level_2
+    Unit_hipMemcpy3DPeer_NegativeTsts: *level_2
     Unit_hipMemcpy3DPeerAsync_BasicFunctional:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_hipMemcpy3DPeerAsync_NegativeTsts:
-      <<: *level_2
-      tags: [memory, transfer, multigpu]
-    Unit_hipMemPoolExportPointer_Negative:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolExportToShareableHandle_SameProc:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolExportToShareableHandle_ChldUseHdl:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolExportToShareableHandle_ChldCheckAccess:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolExportToShareableHandle_GrndChldUseHdl:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolExportToShareableHandle_Negative:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolImportFromShareableHandle_Negative:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolImportPointer_Negative:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPtrGetInfo_Basic:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemPtrGetInfo_SizeZeroAllocation:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipPointerGetAttributes_Basic:
-      <<: *level_2
-      tags: [memory, query]
+    Unit_hipMemcpy3DPeerAsync_NegativeTsts: *level_2
+    Unit_hipMemPoolExportPointer_Negative: *level_2
+    Unit_hipMemPoolExportToShareableHandle_SameProc: *level_2
+    Unit_hipMemPoolExportToShareableHandle_ChldUseHdl: *level_2
+    Unit_hipMemPoolExportToShareableHandle_ChldCheckAccess: *level_2
+    Unit_hipMemPoolExportToShareableHandle_GrndChldUseHdl: *level_2
+    Unit_hipMemPoolExportToShareableHandle_Negative: *level_2
+    Unit_hipMemPoolImportFromShareableHandle_Negative: *level_2
+    Unit_hipMemPoolImportPointer_Negative: *level_2
+    Unit_hipMemPtrGetInfo_Basic: *level_2
+    Unit_hipMemPtrGetInfo_SizeZeroAllocation: *level_2
+    Unit_hipPointerGetAttributes_Basic: *level_2
     Unit_hipPointerGetAttributes_ClusterAlloc:
-      tags: [memory, query, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipPointerGetAttributes_TinyClusterAlloc:
-      tags: [memory, query, multigpu]
       <<: *level_2
-    Unit_hipPointerGetAttributes_Negative:
-      <<: *level_2
-      tags: [memory, query]
+      tags: [multigpu]
+    Unit_hipPointerGetAttributes_Negative: *level_2
     Unit_hipPointerGetAttributes_GpuIter:
-      tags: [memory, query, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipPointerGetAttributes_GpuIter_Managed__Memory:
-      tags: [memory, query, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipPointerGetAttributes_GpuIter_Unregistered_Memory:
-      tags: [memory, query, multigpu]
       <<: *level_2
-    Unit_hipExtMallocWithFlags_Positive_Basic:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipExtMallocWithFlags_Positive_Zero_Size:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipExtMallocWithFlags_Positive_Alignment:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipExtMallocWithFlags_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, alloc]
+      tags: [multigpu]
+    Unit_hipExtMallocWithFlags_Positive_Basic: *level_2
+    Unit_hipExtMallocWithFlags_Positive_Zero_Size: *level_2
+    Unit_hipExtMallocWithFlags_Positive_Alignment: *level_2
+    Unit_hipExtMallocWithFlags_Negative_Parameters: *level_2
     Unit_hipMallocManaged_MultiThread:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMallocManaged_MGpuMThread:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
-    Unit_hipMallocManaged_MultiKrnlComnHmm:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocManaged_MultiKrnlComnMalloc:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocManaged_MultiThrdMultiStrm:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocManaged_TwoKrnlsComnHmmMem:
-      <<: *level_2
-      tags: [memory, alloc]
+      tags: [multigpu]
+    Unit_hipMallocManaged_MultiKrnlComnHmm: *level_2
+    Unit_hipMallocManaged_MultiKrnlComnMalloc: *level_2
+    Unit_hipMallocManaged_MultiThrdMultiStrm: *level_2
+    Unit_hipMallocManaged_TwoKrnlsComnHmmMem: *level_2
     Unit_hipMemVmm_Basic:
-      tags: [vmm]
       <<: *level_2
       # SWDEV-396616 hipMemMap returns invalid error
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemVmm_Uncached:
-      tags: [memory, alloc]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipArray_Valid:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipArray_Invalid:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipArray_Nullptr:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipArray_DoubleFree:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipArray_TrippleDestroy:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipArray_DoubleNullptr:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipArray_DoubleInvalid:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemcpyDeviceToDeviceNoCU_SingleStream:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyDeviceToDeviceNoCU_WithCU_NoCU_Comb_SingleStrm:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyDeviceToDeviceNoCU_NoCU_MulStrm:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyDeviceToDeviceNoCU_Memcpy_Kernel_InParallel:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipGetProcAddress_MemoryApisMallocFree:
-      <<: *level_2
-      tags: [memory]
-    Unit_hipGetProcAddress_MemoryApisRegisterUnReg:
-      <<: *level_2
-      tags: [memory]
-    Unit_hipGetProcAddress_MemoryApisArrayRelated:
-      <<: *level_2
-      tags: [memory]
-    Unit_hipGetProcAddress_MemoryApisSetAndGetAttributes:
-      <<: *level_2
-      tags: [memory]
-    Unit_hipGetProcAddress_MemoryApisMemCopy:
-      <<: *level_2
-      tags: [memory]
-    Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams:
-      <<: *level_2
-      tags: [memory]
-    Unit_hipGetProcAddress_MemoryApisMemset:
-      <<: *level_2
-      tags: [memory]
-    Unit_hipGetProcAddress_MemoryApisMemset2D3D:
-      <<: *level_2
-      tags: [memory]
-    Unit_hipGetProcAddress_MemoryApisGetMemInfoRelated:
-      <<: *level_2
-      tags: [memory]
+    Unit_hipArray_Valid: *level_2
+    Unit_hipArray_Invalid: *level_2
+    Unit_hipArray_Nullptr: *level_2
+    Unit_hipArray_DoubleFree: *level_2
+    Unit_hipArray_TrippleDestroy: *level_2
+    Unit_hipArray_DoubleNullptr: *level_2
+    Unit_hipArray_DoubleInvalid: *level_2
+    Unit_hipMemcpyDeviceToDeviceNoCU_SingleStream: *level_2
+    Unit_hipMemcpyDeviceToDeviceNoCU_WithCU_NoCU_Comb_SingleStrm: *level_2
+    Unit_hipMemcpyDeviceToDeviceNoCU_NoCU_MulStrm: *level_2
+    Unit_hipMemcpyDeviceToDeviceNoCU_Memcpy_Kernel_InParallel: *level_2
+    Unit_hipGetProcAddress_MemoryApisMallocFree: *level_2
+    Unit_hipGetProcAddress_MemoryApisRegisterUnReg: *level_2
+    Unit_hipGetProcAddress_MemoryApisArrayRelated: *level_2
+    Unit_hipGetProcAddress_MemoryApisSetAndGetAttributes: *level_2
+    Unit_hipGetProcAddress_MemoryApisMemCopy: *level_2
+    Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams: *level_2
+    Unit_hipGetProcAddress_MemoryApisMemset: *level_2
+    Unit_hipGetProcAddress_MemoryApisMemset2D3D: *level_2
+    Unit_hipGetProcAddress_MemoryApisGetMemInfoRelated: *level_2
     Unit_hipGetProcAddress_MemoryApisMemcpy2DRelated:
-      tags: [memory, multigpu]
       <<: *level_2
-    Unit_hipGetProcAddress_MemoryApisMemcpy3DRelated:
-      <<: *level_2
-      tags: [memory]
-    Unit_hipGetProcAddress_MemoryApisAddressRelated:
-      <<: *level_2
-      tags: [memory]
-    Unit_hipGetProcAddress_MemoryApisManagedMemory:
-      <<: *level_2
-      tags: [memory]
-    Unit_hipGetProcAddress_MemoryApisStreamOrderedMemory:
-      <<: *level_2
-      tags: [memory]
+      tags: [multigpu]
+    Unit_hipGetProcAddress_MemoryApisMemcpy3DRelated: *level_2
+    Unit_hipGetProcAddress_MemoryApisAddressRelated: *level_2
+    Unit_hipGetProcAddress_MemoryApisManagedMemory: *level_2
+    Unit_hipGetProcAddress_MemoryApisStreamOrderedMemory: *level_2
     Unit_hipGetProcAddress_MemoryApisPeerToPeer:
-      tags: [memory, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemPrefetchAsync_v2_Device_Host:
-      tags: [memory, query, multigpu]
       <<: *level_2
-    Unit_hipMemPrefetchAsync_v2_HostNuma_HostNumaCurrent:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemPrefetchAsync_v2_Negative:
-      <<: *level_2
-      tags: [memory, query]
+      tags: [multigpu]
+    Unit_hipMemPrefetchAsync_v2_HostNuma_HostNumaCurrent: *level_2
+    Unit_hipMemPrefetchAsync_v2_Negative: *level_2
     Unit_hipMemAdvise_v2_Device_Host:
-      tags: [memory, query, multigpu]
       <<: *level_2
-    Unit_hipMemAdvise_v2_HostNuma_HostNumaCurrent:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemAdvise_v2_Negative:
-      <<: *level_2
-      tags: [memory, query]
+      tags: [multigpu]
+    Unit_hipMemAdvise_v2_HostNuma_HostNumaCurrent: *level_2
+    Unit_hipMemAdvise_v2_Negative: *level_2
     Unit_hipPointerSetAttribute_Positive_SyncMemops:
-      tags: [memory, query]
       <<: *level_2
       # Below test is disabled due to defect EXSWHTEC-347
       disabled: [amd_windows]
-    Unit_hipPointerSetAttribute_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemcpyFromToSymbol_Negative:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyToFromSymbol_SyncAndAsync:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyToFromSymbol_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipPointerSetAttribute_Negative_Parameters: *level_2
+    Unit_hipMemcpyFromToSymbol_Negative: *level_2
+    Unit_hipMemcpyToFromSymbol_SyncAndAsync: *level_2
+    Unit_hipMemcpyToFromSymbol_Capture: *level_2
     Unit_hipPtrGetAttribute_Simple:
-      tags: [memory, query, multigpu]
       <<: *level_2
-    Unit_hipMemPoolApi_Basic:
-      <<: *level_2
-      tags: [stream]
+      tags: [multigpu]
+    Unit_hipMemPoolApi_Basic: *level_2
     Unit_hipMemPoolApi_BasicAlloc:
-      tags: [memory, alloc]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemPoolApi_BasicTrim:
-      tags: [memory, alloc]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemPoolApi_BasicReuse:
-      tags: [memory, alloc]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemPoolApi_Opportunistic:
-      tags: [memory, alloc]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemPoolApi_Default:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipDeviceGetMemPool_Basic:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipDeviceGetMemPool_Functional:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMemPoolApi_Default: *level_2
+    Unit_hipDeviceGetMemPool_Basic: *level_2
+    Unit_hipDeviceGetMemPool_Functional: *level_2
     Unit_hipDeviceGetMemPool_Multidevice:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
-    Unit_hipDeviceGetDefaultMemPool_Functional:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipDeviceSetMemPool_Basic:
-      <<: *level_2
-      tags: [memory, alloc]
+      tags: [multigpu]
+    Unit_hipDeviceGetDefaultMemPool_Functional: *level_2
+    Unit_hipDeviceSetMemPool_Basic: *level_2
     Unit_hipDeviceSetMemPool_DestroyCurrentMempool:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
-    Unit_hipDeviceSetMemPool_functional:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipDeviceSetMemPool_functionalAttribute:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolSetGetAccess_Positive_Basic:
-      <<: *level_2
-      tags: [memory, alloc]
+      tags: [multigpu]
+    Unit_hipDeviceSetMemPool_functional: *level_2
+    Unit_hipDeviceSetMemPool_functionalAttribute: *level_2
+    Unit_hipMemPoolSetGetAccess_Positive_Basic: *level_2
     Unit_hipMemPoolSetGetAccess_Positive_MultipleGPU:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
+      tags: [multigpu]
       disabled: [amd_windows]
     Unit_hipMemPoolSetGetAccess_Positive_P2P:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemPoolSetAccess_Negative_Parameters:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-435667: Below tests failing randomly in stress test on 08/12/23
       disabled: [amd_windows]
     Unit_hipMemPoolSetAccess_SetAccess:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
-    Unit_hipMemPoolSetAccess_NegTst:
-      <<: *level_2
-      tags: [memory, alloc]
+      tags: [multigpu]
+    Unit_hipMemPoolSetAccess_NegTst: *level_2
     Unit_hipMemPoolGetAccess_Negative_Parameters:
-      tags: [memory, alloc]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipMemPoolGetAccess_SetGet:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolGetAccess_GetDefMempoolOfEachDevice:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolSetGetAttribute_Positive_Default:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolSetGetAttribute_Positive_MemBasic:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolSetAttribute_Opportunistic:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMemPoolGetAccess_SetGet: *level_2
+    Unit_hipMemPoolGetAccess_GetDefMempoolOfEachDevice: *level_2
+    Unit_hipMemPoolSetGetAttribute_Positive_Default: *level_2
+    Unit_hipMemPoolSetGetAttribute_Positive_MemBasic: *level_2
+    Unit_hipMemPoolSetAttribute_Opportunistic: *level_2
     Unit_hipMemPoolSetAttribute_EventDependencies:
-      tags: [memory, alloc]
       <<: *level_2
       # mlsejenkins_Window_Failures_on_gfx1201
       disabled: [amd_windows]
     Unit_hipMemPoolSetAttribute_Negative_Parameters:
-      tags: [memory, alloc]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipMemPoolSetAttribute_ResetMemHighAttr:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMemPoolSetAttribute_ResetMemHighAttr: *level_2
     Unit_hipMemPoolGetAttribute_Negative_Parameters:
-      tags: [memory, alloc]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipMemPoolGetAttribute_SetGet:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolGetAttribute_UsedMem:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolGetAttribute_ReservedMem:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolGetAttribute_UsageStatistics:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolGetAttribute_hipMalloc_DefMempool:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolGetAttribute_CheckDefaultValues:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolCreate_Negative_Parameter:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolCreate_With_maxSize:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolCreate_Without_maxSize:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMemPoolGetAttribute_SetGet: *level_2
+    Unit_hipMemPoolGetAttribute_UsedMem: *level_2
+    Unit_hipMemPoolGetAttribute_ReservedMem: *level_2
+    Unit_hipMemPoolGetAttribute_UsageStatistics: *level_2
+    Unit_hipMemPoolGetAttribute_hipMalloc_DefMempool: *level_2
+    Unit_hipMemPoolGetAttribute_CheckDefaultValues: *level_2
+    Unit_hipMemPoolCreate_Negative_Parameter: *level_2
+    Unit_hipMemPoolCreate_With_maxSize: *level_2
+    Unit_hipMemPoolCreate_Without_maxSize: *level_2
     Unit_hipMemPoolCreate_DeviceTest:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
-    Unit_hipMemPoolDestroy_Negative_Parameter:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolMaxAlloc:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolTrimTo_Negative_Parameter:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolTrimTo_Positive_Basic:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolTrimTo_VaryingMinBytesToHold:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemPoolTrimTo_MGpuVaryingMinBytesToHold:
-      <<: *level_2
-      tags: [memory, alloc]
+      tags: [multigpu]
+    Unit_hipMemPoolDestroy_Negative_Parameter: *level_2
+    Unit_hipMemPoolMaxAlloc: *level_2
+    Unit_hipMemPoolTrimTo_Negative_Parameter: *level_2
+    Unit_hipMemPoolTrimTo_Positive_Basic: *level_2
+    Unit_hipMemPoolTrimTo_VaryingMinBytesToHold: *level_2
+    Unit_hipMemPoolTrimTo_MGpuVaryingMinBytesToHold: *level_2
     Unit_hipMemPoolTrimTo_Multithreaded:
-      tags: [memory, alloc]
       <<: *level_2
       disabled: [amd_windows]
-    Unit_hipMallocFromPoolAsync_Basic_OneAlloc:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocFromPoolAsync_Basic_TwoAllocs:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocFromPoolAsync_Basic_Reuse:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocFromPoolAsync_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocFromPoolAsync_ReleaseThreshold:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocFromPoolAsync_NullStream:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocFromPoolAsync_hipStreamPerThread:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMallocFromPoolAsync_Basic_OneAlloc: *level_2
+    Unit_hipMallocFromPoolAsync_Basic_TwoAllocs: *level_2
+    Unit_hipMallocFromPoolAsync_Basic_Reuse: *level_2
+    Unit_hipMallocFromPoolAsync_Negative_Parameters: *level_2
+    Unit_hipMallocFromPoolAsync_ReleaseThreshold: *level_2
+    Unit_hipMallocFromPoolAsync_NullStream: *level_2
+    Unit_hipMallocFromPoolAsync_hipStreamPerThread: *level_2
     Unit_hipMallocFromPoolAsync_ReleaseThreshold_Mgpu:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMallocFromPoolAsync_Multidevice_Concurrent:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMallocFromPoolAsync_Multidevice_MultiStream:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
-    Unit_hipMallocFromPoolAsync_MThread_DefaultThresh:
-      <<: *level_2
-      tags: [memory, alloc]
+      tags: [multigpu]
+    Unit_hipMallocFromPoolAsync_MThread_DefaultThresh: *level_2
     Unit_hipMallocFromPoolAsync_MThread_MaxThresh:
-      tags: [memory, alloc]
       <<: *level_2
       disabled: [amd_windows]
     Unit_hipMallocFromPoolAsync_MThread_CommonMpool_DefaultMempool:
-      tags: [memory, alloc]
       <<: *level_2
       disabled: [amd_windows]
-    Unit_hipMallocFromPoolAsync_MThread_CommonMpool_MaxThresh:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocFromPoolAsync_MultStream_Sync:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocFromPoolAsync_MultStream_DefaultStreams:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocFromPoolAsync_MultStream_UserStreams:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocFromPoolAsync_ReuseFollowEventDependencies:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocFromPoolAsync_ReuseAllowOpportunistic:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocFromPoolAsync_ReuseAllowInternalDependencies:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMallocFromPoolAsync_MThread_CommonMpool_MaxThresh: *level_2
+    Unit_hipMallocFromPoolAsync_MultStream_Sync: *level_2
+    Unit_hipMallocFromPoolAsync_MultStream_DefaultStreams: *level_2
+    Unit_hipMallocFromPoolAsync_MultStream_UserStreams: *level_2
+    Unit_hipMallocFromPoolAsync_ReuseFollowEventDependencies: *level_2
+    Unit_hipMallocFromPoolAsync_ReuseAllowOpportunistic: *level_2
+    Unit_hipMallocFromPoolAsync_ReuseAllowInternalDependencies: *level_2
     Unit_hipMemcpyPeer_Positive_Default:
-      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpyPeer_Positive_Synchronization_Behavior:
-      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpyPeer_Positive_ZeroSize:
-      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
+      tags: [multigpu]
       # Disabling test tracked SWDEV-391555
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemcpyPeer_Negative_Parameters:
-      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpyPeer_Negative:
-      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpyPeer_Basic:
-      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpyPeerAsync_Positive_Default:
-      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpyPeerAsync_Positive_Synchronization_Behavior:
-      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpyPeerAsync_Positive_ZeroSize:
-      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
+      tags: [multigpu]
       # Disabling test tracked SWDEV-391555
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemcpyPeerAsync_Negative_Parameters:
-      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
-    Unit_hipMemcpyPeerAsync_Capture:
-      <<: *level_2
-      tags: [memory, transfer, multigpu]
+      tags: [multigpu]
+    Unit_hipMemcpyPeerAsync_Capture: *level_2
     Unit_hipMemcpyPeerAsync_Negative:
-      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpyPeerAsync_Basic:
-      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpyPeerAsync_StreamOnDiffDevice:
-      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
-    Unit_hipMemcpyWithStream_TestWithOneStream:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyWithStream_TestwithTwoStream:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyWithStream_TestkindDtoH:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyWithStream_TestkindHtoH:
-      <<: *level_2
-      tags: [memory, transfer]
+      tags: [multigpu]
+    Unit_hipMemcpyWithStream_TestWithOneStream: *level_2
+    Unit_hipMemcpyWithStream_TestwithTwoStream: *level_2
+    Unit_hipMemcpyWithStream_TestkindDtoH: *level_2
+    Unit_hipMemcpyWithStream_TestkindHtoH: *level_2
     Unit_hipMemcpyWithStream_TestkindDtoD:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpyWithStream_TestOnMultiGPUwithOneStream:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
-    Unit_hipMemcpyWithStream_TestkindDefault:
-      <<: *level_2
-      tags: [memory, transfer]
+      tags: [multigpu]
+    Unit_hipMemcpyWithStream_TestkindDefault: *level_2
     Unit_hipMemcpyWithStream_TestkindDefaultForDtoD:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
-    Unit_hipMemcpyWithStream_TestDtoDonSameDevice:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy_Positive_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
+      tags: [multigpu]
+    Unit_hipMemcpyWithStream_TestDtoDonSameDevice: *level_2
+    Unit_hipMemcpy_Positive_Basic: *level_2
     Unit_hipMemcpy_Positive_Synchronization_Behavior:
-      tags: [memory, transfer]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
-    Unit_hipMemcpy_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyWithStream_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpy_Negative_Parameters: *level_2
+    Unit_hipMemcpyWithStream_Capture: *level_2
     Unit_hipMemcpyWithStream_MultiThread:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
-    Unit_hipMemsetAsync_VerifyExecutionWithKernel:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset2DAsync_WithKernel:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset2DAsync_MultiThread:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMalloc_ArgumentValidation:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMalloc_LoopRegressionAllocFreeCycles:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMalloc_AllocateAndPoolBuffers:
-      <<: *level_2
-      tags: [memory, alloc]
+      tags: [multigpu]
+    Unit_hipMemsetAsync_VerifyExecutionWithKernel: *level_2
+    Unit_hipMemset2DAsync_WithKernel: *level_2
+    Unit_hipMemset2DAsync_MultiThread: *level_2
+    Unit_hipMalloc_ArgumentValidation: *level_2
+    Unit_hipMalloc_LoopRegressionAllocFreeCycles: *level_2
+    Unit_hipMalloc_AllocateAndPoolBuffers: *level_2
     Unit_hipMalloc_Multithreaded_MultiGPU:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemcpyDtoD_Basic:
       <<: *level_2
       tags: [multigpu]
     Unit_hipMemcpyDtoDAsync_Basic:
       <<: *level_2
       tags: [multigpu]
-    Unit_hipMemcpyDtoDAsync_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipHostMalloc_Basic:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostMalloc_Negative:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostMalloc_NonCoherent:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostMalloc_Coherent:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostMalloc_Default:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostGetDevicePointer_NullCheck:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMemcpyDtoDAsync_Capture: *level_2
+    Unit_hipHostMalloc_Basic: *level_2
+    Unit_hipHostMalloc_Negative: *level_2
+    Unit_hipHostMalloc_NonCoherent: *level_2
+    Unit_hipHostMalloc_Coherent: *level_2
+    Unit_hipHostMalloc_Default: *level_2
+    Unit_hipHostGetDevicePointer_NullCheck: *level_2
     Unit_hipHostMalloc_AllocateMoreThanAvailGPUMemory:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-431191:Below tests failed in stress test on 03/11/23
       disabled: [amd_windows, amd_wsl]
     Unit_hipHostMalloc_AllocateUseMoreThanAvailGPUMemory:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-431191:Below tests failed in stress test on 03/11/23
       disabled: [amd_windows, amd_wsl]
-    Unit_hipHostMalloc_Capture:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipHostMalloc_Capture: *level_2
     Unit_hipMemcpy_KernelLaunch: *level_2
     Unit_hipMemcpy_H2H_H2D_D2H_H2PinMem:
       <<: *level_2
       tags: [multigpu]
-    Unit_hipMemcpy_MultiThreadWithSerialization:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpy_MultiThreadWithSerialization: *level_2
     Unit_hipMemcpy_PinnedRegMemWithKernelLaunch:
       <<: *level_2
       tags: [multigpu]
-    Unit_hipMemcpyDtoH_Positive_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyDtoH_Positive_Synchronization_Behavior:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyDtoH_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyHtoD_Positive_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyHtoD_Positive_Synchronization_Behavior:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyHtoD_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyDtoD_Positive_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyDtoD_Positive_Synchronization_Behavior:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyDtoD_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyAsync_Positive_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyAsync_Positive_Synchronization_Behavior:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpyDtoH_Positive_Basic: *level_2
+    Unit_hipMemcpyDtoH_Positive_Synchronization_Behavior: *level_2
+    Unit_hipMemcpyDtoH_Negative_Parameters: *level_2
+    Unit_hipMemcpyHtoD_Positive_Basic: *level_2
+    Unit_hipMemcpyHtoD_Positive_Synchronization_Behavior: *level_2
+    Unit_hipMemcpyHtoD_Negative_Parameters: *level_2
+    Unit_hipMemcpyDtoD_Positive_Basic: *level_2
+    Unit_hipMemcpyDtoD_Positive_Synchronization_Behavior: *level_2
+    Unit_hipMemcpyDtoD_Negative_Parameters: *level_2
+    Unit_hipMemcpyAsync_Positive_Basic: *level_2
+    Unit_hipMemcpyAsync_Positive_Synchronization_Behavior: *level_2
     Unit_hipMemcpyAsync_Negative_Parameters:
-      tags: [memory, transfer]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/18
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemcpyAsync_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpyAsync_Capture: *level_2
     Unit_hipMemcpyAsync_KernelLaunch: *level_2
     Unit_hipMemcpyAsync_H2H_H2D_D2H_H2PinMem:
       <<: *level_2
@@ -7417,45 +4334,26 @@ unit:
     Unit_hipMemcpyAsync_PinnedRegMemWithKernelLaunch:
       <<: *level_2
       tags: [multigpu]
-    Unit_hipMemcpyDtoHAsync_Positive_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyDtoHAsync_Positive_Synchronization_Behavior:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpyDtoHAsync_Positive_Basic: *level_2
+    Unit_hipMemcpyDtoHAsync_Positive_Synchronization_Behavior: *level_2
     Unit_hipMemcpyDtoHAsync_Negative_Parameters:
-      tags: [memory, transfer]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/18
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemcpyHtoDAsync_Positive_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyHtoDAsync_Positive_Synchronization_Behavior:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpyHtoDAsync_Positive_Basic: *level_2
+    Unit_hipMemcpyHtoDAsync_Positive_Synchronization_Behavior: *level_2
     Unit_hipMemcpyHtoDAsync_Negative_Parameters:
-      tags: [memory, transfer]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/18
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemcpyDtoDAsync_Positive_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyDtoDAsync_Positive_Synchronization_Behavior:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpyDtoDAsync_Positive_Basic: *level_2
+    Unit_hipMemcpyDtoDAsync_Positive_Synchronization_Behavior: *level_2
     Unit_hipMemcpyDtoDAsync_Negative_Parameters:
-      tags: [memory, transfer]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/18
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemcpyDtoHAsync_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpyHtoDAsync_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipMemcpyDtoHAsync_Capture: *level_2
+    Unit_hipMemcpyHtoDAsync_Capture: *level_2
     Unit_hipMemsetFunctional_ZeroValue_hipMemset: *level_2
     Unit_hipMemsetFunctional_ZeroValue_hipMemsetD32: *level_2
     Unit_hipMemsetFunctional_ZeroValue_hipMemsetD16:
@@ -7471,77 +4369,39 @@ unit:
     Unit_hipMemsetFunctional_ZeroSize_hipMemsetD32: *level_2
     Unit_hipMemsetFunctional_ZeroSize_hipMemsetD16: *level_2
     Unit_hipMemsetFunctional_ZeroSize_hipMemsetD8: *level_2
-    Unit_hipMemsetFunctional_PartialSet_1D:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetFunctional_ZeroValue_2D:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetFunctional_SmallSize_2D:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetFunctional_ZeroSize_2D:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetFunctional_PartialSet_2D:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetFunctional_ZeroValue_3D:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetFunctional_SmallSize_3D:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetFunctional_ZeroSize_3D:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemsetFunctional_PartialSet_3D:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMalloc_Positive_Basic:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMalloc_Positive_Zero_Size:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMalloc_Positive_Alignment:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMalloc_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMemsetFunctional_PartialSet_1D: *level_2
+    Unit_hipMemsetFunctional_ZeroValue_2D: *level_2
+    Unit_hipMemsetFunctional_SmallSize_2D: *level_2
+    Unit_hipMemsetFunctional_ZeroSize_2D: *level_2
+    Unit_hipMemsetFunctional_PartialSet_2D: *level_2
+    Unit_hipMemsetFunctional_ZeroValue_3D: *level_2
+    Unit_hipMemsetFunctional_SmallSize_3D: *level_2
+    Unit_hipMemsetFunctional_ZeroSize_3D: *level_2
+    Unit_hipMemsetFunctional_PartialSet_3D: *level_2
+    Unit_hipMalloc_Positive_Basic: *level_2
+    Unit_hipMalloc_Positive_Zero_Size: *level_2
+    Unit_hipMalloc_Positive_Alignment: *level_2
+    Unit_hipMalloc_Negative_Parameters: *level_2
     Unit_hipMalloc_Allocate90PercentOfDeviceMemory:
-      tags: [memory, alloc]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipMalloc3D_ValidatePitch:
-      tags: [memory, alloc]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemAllocPitch_ValidatePitch:
-      tags: [memory, alloc]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMallocPitch_ValidatePitch:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMallocPitch_ValidatePitch: *level_2
     Unit_hipMalloc3D_Negative:
-      tags: [memory, alloc]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMallocPitch_Negative:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocPitch_Zero_Dims:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemAllocPitch_Negative:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMallocPitch_Negative: *level_2
+    Unit_hipMallocPitch_Zero_Dims: *level_2
+    Unit_hipMemAllocPitch_Negative: *level_2
     Unit_hipMallocPitch_Basic:
       <<: *level_2
       tags: [hipMallocPitch]
@@ -7550,288 +4410,155 @@ unit:
       tags: [hipMallocPitch]
     Unit_hipMallocPitch_Memcpy2D: *level_2
     Unit_hipMallocPitch_MultiThread:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMallocPitch_KernelLaunch: *level_2
-    Unit_hipMalloc3D_Basic:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMalloc3D_SmallandBigChunks:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMalloc3D_Basic: *level_2
+    Unit_hipMalloc3D_SmallandBigChunks: *level_2
     Unit_hipMalloc3D_MultiThread:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
-    Unit_hipMalloc3DArray_DiffSizes:
-      <<: *level_2
-      tags: [memory, alloc]
+      tags: [multigpu]
+    Unit_hipMalloc3DArray_DiffSizes: *level_2
     Unit_hipMalloc3DArray_MultiThread:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMalloc3DArray_happy: *level_2
     Unit_hipMalloc3DArray_MaxTexture: *level_2
-    Unit_hipMalloc3DArray_Negative_NullArrayPtr:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMalloc3DArray_Negative_NullDescPtr:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMalloc3DArray_Negative_ZeroWidth:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMalloc3DArray_Negative_ZeroHeight:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMalloc3DArray_Negative_InvalidFlags:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMalloc3DArray_Negative_NullArrayPtr: *level_2
+    Unit_hipMalloc3DArray_Negative_NullDescPtr: *level_2
+    Unit_hipMalloc3DArray_Negative_ZeroWidth: *level_2
+    Unit_hipMalloc3DArray_Negative_ZeroHeight: *level_2
+    Unit_hipMalloc3DArray_Negative_InvalidFlags: *level_2
     Unit_hipMalloc3DArray_Negative_InvalidFormat:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMalloc3DArray_Negative_BadChannelLayout:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMalloc3DArray_Negative_8BitFloat:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMalloc3DArray_Negative_DifferentChannelSizes:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMalloc3DArray_Negative_BadChannelSize:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
-    Unit_hipMalloc3DArray_Negative_NumericLimit:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMalloc3DArray_Negative_NumericLimit: *level_2
     Unit_hipMalloc3DArray_Negative_Non2DTextureGather: *level_2
     Unit_hipArray3DCreate_happy: *level_2
     Unit_hipArray3DCreate_MaxTexture: *level_2
-    Unit_hipArray3DCreate_Negative_NullArrayPtr:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipArray3DCreate_Negative_NullDescPtr:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipArray3DCreate_Negative_ZeroWidth:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipArray3DCreate_Negative_ZeroHeight:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipArray3DCreate_Negative_InvalidFormat:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipArray3DCreate_Negative_NumChannels:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipArray3DCreate_Negative_InvalidFlags:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipArray3DCreate_Negative_NumericLimit:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipArray3DCreate_Negative_NullArrayPtr: *level_2
+    Unit_hipArray3DCreate_Negative_NullDescPtr: *level_2
+    Unit_hipArray3DCreate_Negative_ZeroWidth: *level_2
+    Unit_hipArray3DCreate_Negative_ZeroHeight: *level_2
+    Unit_hipArray3DCreate_Negative_InvalidFormat: *level_2
+    Unit_hipArray3DCreate_Negative_NumChannels: *level_2
+    Unit_hipArray3DCreate_Negative_InvalidFlags: *level_2
+    Unit_hipArray3DCreate_Negative_NumericLimit: *level_2
     Unit_hipArray3DCreate_Negative_Non2DTextureGather: *level_2
-    Unit_hipDrvMemcpy3D_Positive_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipDrvMemcpy3D_Positive_Basic: *level_2
     Unit_hipDrvMemcpy3D_Positive_Synchronization_Behavior:
-      tags: [memory, transfer]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
-    Unit_hipDrvMemcpy3D_Positive_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipDrvMemcpy3D_Positive_Parameters: *level_2
     Unit_hipDrvMemcpy3D_Positive_Array:
-      tags: [memory, transfer]
       <<: *level_2
       # NOTE: The following 2 tests are disabled due to defect - EXSWHTEC-238
       disabled: [amd_windows, amd_wsl]
-    Unit_hipDrvMemcpy3D_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipDrvMemcpy3D_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipDrvMemcpy3D_Negative_Parameters: *level_2
+    Unit_hipDrvMemcpy3D_Capture: *level_2
     Unit_hipDrvMemcpy3D_MultipleDataTypes: *level_2
-    Unit_hipDrvMemcpy3D_HosttoDevice:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipDrvMemcpy3D_Negative:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipDrvMemcpy3D_ExtentValidation:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipDrvMemcpy3D_HosttoDevice: *level_2
+    Unit_hipDrvMemcpy3D_Negative: *level_2
+    Unit_hipDrvMemcpy3D_ExtentValidation: *level_2
     Unit_hipDrvMemcpy3D_H2DDeviceContextChange:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipDrvMemcpy3D_Host2ArrayDeviceContextChange:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipDrvMemcpy3D_multiDevice_Basic_Size_Test:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
-    Unit_hipDrvMemcpy3DAsync_Positive_Basic:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipDrvMemcpy3DAsync_Positive_Synchronization_Behavior:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipDrvMemcpy3DAsync_Positive_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
+      tags: [multigpu]
+    Unit_hipDrvMemcpy3DAsync_Positive_Basic: *level_2
+    Unit_hipDrvMemcpy3DAsync_Positive_Synchronization_Behavior: *level_2
+    Unit_hipDrvMemcpy3DAsync_Positive_Parameters: *level_2
     Unit_hipDrvMemcpy3DAsync_Positive_Array:
-      tags: [memory, transfer]
       <<: *level_2
       # NOTE: The following 2 tests are disabled due to defect - EXSWHTEC-238
       disabled: [amd_windows, amd_wsl]
-    Unit_hipDrvMemcpy3DAsync_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipDrvMemcpy3DAsync_Capture:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipDrvMemcpy3DAsync_Negative_Parameters: *level_2
+    Unit_hipDrvMemcpy3DAsync_Capture: *level_2
     Unit_hipDrvMemcpy3DAsync_MultipleDataTypes: *level_2
-    Unit_hipDrvMemcpy3DAsync_HosttoDevice:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipDrvMemcpy3DAsync_Negative:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipDrvMemcpy3DAsync_ExtentValidation:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipDrvMemcpy3DAsync_HosttoDevice: *level_2
+    Unit_hipDrvMemcpy3DAsync_Negative: *level_2
+    Unit_hipDrvMemcpy3DAsync_ExtentValidation: *level_2
     Unit_hipDrvMemcpy3DAsync_H2DDeviceContextChange:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipDrvMemcpy3DAsync_Host2ArrayDeviceContextChange:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipDrvMemcpy3DAsync_multiDevice_Basic_Size_Test:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
-    Unit_hipPointerGetAttribute_MemoryTypes:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipPointerGetAttribute_KernelUpdation:
-      <<: *level_2
-      tags: [memory, query]
+      tags: [multigpu]
+    Unit_hipPointerGetAttribute_MemoryTypes: *level_2
+    Unit_hipPointerGetAttribute_KernelUpdation: *level_2
     Unit_hipPointerGetAttribute_PeerGPU:
-      tags: [memory, query, multigpu]
       <<: *level_2
-    Unit_hipPointerGetAttribute_BufferID:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipPointerGetAttribute_HostDeviceOrdinal:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipPointerGetAttribute_MappedMem:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipPointerGetAttribute_Negative:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipPointerGetAttribute_ipc_capable:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipDrvPtrGetAttributes_Negative:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipDrvPtrGetAttributes_Functional:
-      <<: *level_2
-      tags: [memory, query]
+      tags: [multigpu]
+    Unit_hipPointerGetAttribute_BufferID: *level_2
+    Unit_hipPointerGetAttribute_HostDeviceOrdinal: *level_2
+    Unit_hipPointerGetAttribute_MappedMem: *level_2
+    Unit_hipPointerGetAttribute_Negative: *level_2
+    Unit_hipPointerGetAttribute_ipc_capable: *level_2
+    Unit_hipDrvPtrGetAttributes_Negative: *level_2
+    Unit_hipDrvPtrGetAttributes_Functional: *level_2
     Unit_hipMemPrefetchAsync_Basic_AllDevices:
       <<: *level_2
       tags: [multigpu]
-    Unit_hipMemPrefetchAsync_Sync_Behavior:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemPrefetchAsync_Rounding_Behavior:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemPrefetchAsync_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemGetInfo_FreeLessThanTotal:
-      <<: *level_2
-      tags: [memory, query]
+    Unit_hipMemPrefetchAsync_Sync_Behavior: *level_2
+    Unit_hipMemPrefetchAsync_Rounding_Behavior: *level_2
+    Unit_hipMemPrefetchAsync_Negative_Parameters: *level_2
+    Unit_hipMemGetInfo_FreeLessThanTotal: *level_2
     Unit_hipFreeImplicitSyncDev:
-      tags: [memory, alloc]
       <<: *level_2
       # Note: TDR
       disabled: [amd_wsl]
     Unit_hipFreeImplicitSyncHost:
-      tags: [memory, alloc]
       <<: *level_2
       # Note: TDR
       disabled: [amd_wsl]
     Unit_hipFreeImplicitSyncArray: *level_2
-    Unit_hipFreeNegativeDev:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipFreeNegativeHost:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipFreeNegativeArray:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipFreeDoubleDevice:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipFreeDoubleHost:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipFreeDoubleArrayFree:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipFreeDoubleArray:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipFreeNegativeDev: *level_2
+    Unit_hipFreeNegativeHost: *level_2
+    Unit_hipFreeNegativeArray: *level_2
+    Unit_hipFreeDoubleDevice: *level_2
+    Unit_hipFreeDoubleHost: *level_2
+    Unit_hipFreeDoubleArrayFree: *level_2
+    Unit_hipFreeDoubleArray: *level_2
     Unit_hipFreeMultiTDev: *level_2
     Unit_hipFreeMultiTHost: *level_2
     Unit_hipFreeMultiTArray: *level_2
     Unit_hipFreeArray_DifferentSizes: *level_2
-    Unit_hipFreeArray_NegativeArray:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipFreeArray_DoubleFree:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipFreeArray_NegativeArray: *level_2
+    Unit_hipFreeArray_DoubleFree: *level_2
     Unit_hipFreeArray_MultiThreaded: *level_2
-    Unit_hipHostFree_InvalidMemory:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostFree_DoubleFree:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostFree_Multithreading:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostFree_Capture:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMemcpySync:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy2DSync:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipMemcpy3DSync:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipHostFree_InvalidMemory: *level_2
+    Unit_hipHostFree_DoubleFree: *level_2
+    Unit_hipHostFree_Multithreading: *level_2
+    Unit_hipHostFree_Capture: *level_2
+    Unit_hipMemcpySync: *level_2
+    Unit_hipMemcpy2DSync: *level_2
+    Unit_hipMemcpy3DSync: *level_2
     Unit_hipMemsetSync:
-      tags: [memory, memset]
       <<: *level_2
       # Note: TDR (random fail)
       disabled: [amd_wsl]
@@ -7840,455 +4567,286 @@ unit:
       # SWDEV-400049 tdr intermittently
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemset2DSync:
-      tags: [memory, memset]
       <<: *level_2
       # SWDEV-398977 fails in stress tests
       disabled: [amd_wsl]
     Unit_hipMemset3DSync:
-      tags: [memory, memset]
       <<: *level_2
       # Note: Following four tests disabled due to defect - EXSWHTEC-203
       disabled: [amd_wsl]
-    Unit_hipMemsetASyncMulti:
-      <<: *level_2
-      tags: [memory, memset]
+    Unit_hipMemsetASyncMulti: *level_2
     Unit_hipMemsetDASyncMulti: *level_2
-    Unit_hipMemset2DASyncMulti:
-      <<: *level_2
-      tags: [memory, memset]
-    Unit_hipMemset3DASyncMulti:
-      <<: *level_2
-      tags: [memory, memset]
+    Unit_hipMemset2DASyncMulti: *level_2
+    Unit_hipMemset3DASyncMulti: *level_2
     Unit_hipMemAdvise_TstFlags:
-      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemAdvise_NegtveTsts:
-      tags: [memory, query]
       <<: *level_2
       # intermittent issue: failure expected but success returned
       disabled: [amd_wsl]
     Unit_hipMemAdvise_PrefrdLoc:
-      tags: [memory, query, multigpu]
       <<: *level_2
+      tags: [multigpu]
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemAdvise_ReadMostly:
-      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemAdvise_TstFlgOverrideEffect:
-      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemAdvise_TstAccessedByPeer:
-      tags: [memory, query, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemAdvise_TstAccessedByFlg:
-      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemAdvise_TstAccessedByFlg2:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemAdvise_TstAccessedByFlg3:
-      <<: *level_2
-      tags: [memory, query]
+    Unit_hipMemAdvise_TstAccessedByFlg2: *level_2
+    Unit_hipMemAdvise_TstAccessedByFlg3: *level_2
     Unit_hipMemAdvise_TstAccessedByFlg4:
-      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemAdvise_TstAlignedAllocMem:
-      <<: *level_2
-      tags: [memory, query]
+    Unit_hipMemAdvise_TstAlignedAllocMem: *level_2
     Unit_hipMemAdvise_TstAlignedAllocMem_XNACK:
-      tags: [memory, query]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
     Unit_hipMemAdvise_TstMemAdvisePrefrdLoc:
-      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemAdvise_TstMemAdviseLstPreftchLoc:
-      tags: [memory, query, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemAdvise_TstMemAdviseMultiFlag:
-      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemAdvise_ReadMosltyMgpuTst:
-      tags: [memory, query, multigpu]
       <<: *level_2
+      tags: [multigpu]
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemAdvise_TstSetUnsetPrfrdLoc:
-      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemAdvise_Set_Unset_Basic:
-      <<: *level_2
-      tags: [memory, query]
+    Unit_hipMemAdvise_Set_Unset_Basic: *level_2
     Unit_hipMemAdvise_No_Flag_Interference:
-      tags: [memory, query]
       <<: *level_2
       # (amd_linux) NOTE: The following test is disabled due to defect - EXSWHTEC-244
       # (amd_windows) Note: intermittent Seg fault failure
       # (amd_wsl) Note: intermittent Seg fault failure
       <<: *disabled_amd
-    Unit_hipMemAdvise_Rounding:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemAdvise_Flags_Do_Not_Cause_Prefetch:
-      <<: *level_2
-      tags: [memory, query]
+    Unit_hipMemAdvise_Rounding: *level_2
+    Unit_hipMemAdvise_Flags_Do_Not_Cause_Prefetch: *level_2
     Unit_hipMemAdvise_Read_Write_After_Advise:
-      tags: [memory, query, multigpu]
       <<: *level_2
-    Unit_hipMemAdvise_Prefetch_After_Advise:
-      <<: *level_2
-      tags: [memory, query]
+      tags: [multigpu]
+    Unit_hipMemAdvise_Prefetch_After_Advise: *level_2
     Unit_hipMemAdvise_AccessedBy_All_Devices:
-      tags: [memory, query]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_wsl]
-    Unit_hipMemAdvise_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemRangeGetAttributes_Positive_Basic:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemRangeGetAttributes_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, query]
+    Unit_hipMemAdvise_Negative_Parameters: *level_2
+    Unit_hipMemRangeGetAttributes_Positive_Basic: *level_2
+    Unit_hipMemRangeGetAttributes_Negative_Parameters: *level_2
     Unit_hipFreeAsync_Negative_Parameters:
-      tags: [memory, alloc]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipFreeAsync_capturehipFreeAsync:
-      tags: [memory, alloc]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_hipFreeHost_InvalidMemory:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipFreeHost_DoubleFree:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipFreeHost_Multithreading:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipFreeHost_Capture:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocAsync_Basic_OneAlloc:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocAsync_Basic_TwoAllocs:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocAsync_Basic_Reuse:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocAsync_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocAsync_basic:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocAsync_Multistream_Concurrent:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocAsync_StreamEvent_CrissCross:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipFreeHost_InvalidMemory: *level_2
+    Unit_hipFreeHost_DoubleFree: *level_2
+    Unit_hipFreeHost_Multithreading: *level_2
+    Unit_hipFreeHost_Capture: *level_2
+    Unit_hipMallocAsync_Basic_OneAlloc: *level_2
+    Unit_hipMallocAsync_Basic_TwoAllocs: *level_2
+    Unit_hipMallocAsync_Basic_Reuse: *level_2
+    Unit_hipMallocAsync_Negative_Parameters: *level_2
+    Unit_hipMallocAsync_basic: *level_2
+    Unit_hipMallocAsync_Multistream_Concurrent: *level_2
+    Unit_hipMallocAsync_StreamEvent_CrissCross: *level_2
     Unit_hipMallocAsync_Multidevice:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMallocAsync_Multidevice_Concurrent:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMallocAsync_Multidevice_MultiStream:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
-    Unit_hipMallocAsync_ByUsinghipMalloc:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocAsync_ByUsinghipFree:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocAsync_MThread_ThreadLocalStream:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocAsync_MThread_ThreadSharedStream:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocAsync_DefaultStreams_Concurrent:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipStreamAttachMemAsync_Positive_Basic:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipStreamAttachMemAsync_Positive_Pageable:
-      <<: *level_2
-      tags: [memory, query]
+      tags: [multigpu]
+    Unit_hipMallocAsync_ByUsinghipMalloc: *level_2
+    Unit_hipMallocAsync_ByUsinghipFree: *level_2
+    Unit_hipMallocAsync_MThread_ThreadLocalStream: *level_2
+    Unit_hipMallocAsync_MThread_ThreadSharedStream: *level_2
+    Unit_hipMallocAsync_DefaultStreams_Concurrent: *level_2
+    Unit_hipStreamAttachMemAsync_Positive_Basic: *level_2
+    Unit_hipStreamAttachMemAsync_Positive_Pageable: *level_2
     Unit_hipStreamAttachMemAsync_Positive_AttachGlobal:
-      tags: [memory, query, multigpu]
       <<: *level_2
-    Unit_hipStreamAttachMemAsync_Positive_AttachHost:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipStreamAttachMemAsync_Positive_AttachSingle:
-      <<: *level_2
-      tags: [memory, query]
+      tags: [multigpu]
+    Unit_hipStreamAttachMemAsync_Positive_AttachHost: *level_2
+    Unit_hipStreamAttachMemAsync_Positive_AttachSingle: *level_2
     Unit_hipStreamAttachMemAsync_Negative_Parameters:
-      tags: [memory, query]
       <<: *level_2
       # Below tests soft hang in stress test on 13/09/23
       disabled: [amd_wsl]
-    Unit_hipMemRangeGetAttributes_TstFlgs:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemRangeGetAttributes_NegativeTst:
-      <<: *level_2
-      tags: [memory, query]
+    Unit_hipMemRangeGetAttributes_TstFlgs: *level_2
+    Unit_hipMemRangeGetAttributes_NegativeTst: *level_2
     Unit_hipMemGetAddressRange_Positive:
-      tags: [memory, query]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemGetAddressRange_Negative:
-      tags: [memory, query]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_wsl]
     Unit_hipMallocMipmappedArray_DiffSizes:
-      tags: [memory, alloc]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipMallocMipmappedArray_MultiThread:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
+      tags: [multigpu]
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipMallocMipmappedArray_happy: *level_2
-    Unit_hipMallocMipmappedArray_Negative_NullArrayPtr:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocMipmappedArray_Negative_NullDescPtr:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocMipmappedArray_Negative_ZeroWidth:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocMipmappedArray_Negative_ZeroHeight:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMallocMipmappedArray_Negative_NullArrayPtr: *level_2
+    Unit_hipMallocMipmappedArray_Negative_NullDescPtr: *level_2
+    Unit_hipMallocMipmappedArray_Negative_ZeroWidth: *level_2
+    Unit_hipMallocMipmappedArray_Negative_ZeroHeight: *level_2
     Unit_hipMallocMipmappedArray_Negative_InvalidFlags:
-      tags: [memory, alloc]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipMallocMipmappedArray_Negative_InvalidFormat:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMallocMipmappedArray_Negative_BadChannelLayout:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMallocMipmappedArray_Negative_8BitFloat:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMallocMipmappedArray_Negative_DifferentChannelSizes:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMallocMipmappedArray_Negative_BadChannelSize:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
-    Unit_hipMallocMipmappedArray_Negative_NumericLimit:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMallocMipmappedArray_Negative_NumericLimit: *level_2
     Unit_hipMallocMipmappedArray_Negative_Non2DTextureGather: *level_2
-    Unit_hipMallocMipmappedArray_Negative_NumLevels:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMallocMipmappedArray_Negative_NumLevels: *level_2
     Unit_hipGetMipmappedArrayLevel_Negative:
-      tags: [memory, alloc]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipFreeMipmappedArrayImplicitSyncArray: *level_2
-    Unit_hipFreeMipmappedArray_Negative_Nullptr:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipFreeMipmappedArray_Negative_Nullptr: *level_2
     Unit_hipFreeMipmappedArrayMultiTArray:
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipMallocArray_DiffSizes:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMallocArray_DiffSizes: *level_2
     Unit_hipMallocArray_MultiThread:
-      tags: [memory, alloc, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMallocArray_happy: *level_2
     Unit_hipMallocArray_MaxTexture_Default: *level_2
     Unit_hipMallocArray_Negative_DifferentChannelSizes:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
-    Unit_hipMallocArray_Negative_ZeroWidth:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocArray_Negative_NullArrayPtr:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocArray_Negative_NullDescPtr:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipMallocArray_Negative_BadFlags:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMallocArray_Negative_ZeroWidth: *level_2
+    Unit_hipMallocArray_Negative_NullArrayPtr: *level_2
+    Unit_hipMallocArray_Negative_NullDescPtr: *level_2
+    Unit_hipMallocArray_Negative_BadFlags: *level_2
     Unit_hipMallocArray_Negative_8bitFloat:
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMallocArray_Negative_BadNumberOfBits:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMallocArray_Negative_3ChannelElement:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMallocArray_Negative_ChannelAfterZeroChannel:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMallocArray_Negative_InvalidChannelFormat:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
-    Unit_hipMallocArray_Negative_NumericLimit:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostAlloc_Positive:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostAlloc_DataValidation:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostAlloc_Negative:
-      <<: *level_2
-      tags: [memory, alloc]
+    Unit_hipMallocArray_Negative_NumericLimit: *level_2
+    Unit_hipHostAlloc_Positive: *level_2
+    Unit_hipHostAlloc_DataValidation: *level_2
+    Unit_hipHostAlloc_Negative: *level_2
     Unit_hipHostAlloc_Basic:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
       disabled: [amd_windows]
     Unit_hipHostAlloc_Default:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
       disabled: [amd_windows]
     Unit_hipHostAlloc_Negative_NonCoherent:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
       disabled: [amd_windows]
     Unit_hipHostAlloc_Negative_Coherent:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
       disabled: [amd_windows]
     Unit_hipHostAlloc_Negative_NumaUser:
-      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
       disabled: [amd_windows]
-    Unit_hipHostAlloc_AllocateMoreThanAvailGPUMemory:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostAlloc_ArgValidation:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipHostAlloc_Capture:
-      <<: *level_2
-      tags: [memory, alloc]
-    Unit_hipDrvMemcpy2DUnaligned_NegTst:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipDrvMemcpy2DUnaligned_FuncTst:
-      <<: *level_2
-      tags: [memory, transfer]
+    Unit_hipHostAlloc_AllocateMoreThanAvailGPUMemory: *level_2
+    Unit_hipHostAlloc_ArgValidation: *level_2
+    Unit_hipHostAlloc_Capture: *level_2
+    Unit_hipDrvMemcpy2DUnaligned_NegTst: *level_2
+    Unit_hipDrvMemcpy2DUnaligned_FuncTst: *level_2
     Unit_hipDrvMemcpy2DUnaligned_Positive_Basic:
-      tags: [memory, transfer, multigpu]
       <<: *level_2
-    Unit_hipDrvMemcpy2DUnaligned_Positive_Synchronization_Behavior:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipDrvMemcpy2DUnaligned_Positive_Parameters:
-      <<: *level_2
-      tags: [memory, transfer]
-    Unit_hipArrayGetInfo_Positive_Basic:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipArrayGetInfo_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, query]
+      tags: [multigpu]
+    Unit_hipDrvMemcpy2DUnaligned_Positive_Synchronization_Behavior: *level_2
+    Unit_hipDrvMemcpy2DUnaligned_Positive_Parameters: *level_2
+    Unit_hipArrayGetInfo_Positive_Basic: *level_2
+    Unit_hipArrayGetInfo_Negative_Parameters: *level_2
     Unit_hipArrayGetDescriptor_1D_2D_ArrayParameterChk:
-      tags: [memory, query, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipArrayGetDescriptor_MultiThreadScenarioFor1D_2D_Array:
-      tags: [memory, query, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipArrayGetDescriptor_Host2Array_Array2Host:
-      tags: [memory, query, multigpu]
       <<: *level_2
-    Unit_hipArrayGetDescriptor_Negative_Scenarios:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipArrayGetDescriptor_Positive_Basic:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipArrayGetDescriptor_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipArray3DGetDescriptor_Positive_Basic:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipArray3DGetDescriptor_Negative_Parameters:
-      <<: *level_2
-      tags: [memory, query]
-    Unit_hipMemcpyToFromSymbol_GlobalConstVar:
-      <<: *level_2
-      tags: [memory]
+      tags: [multigpu]
+    Unit_hipArrayGetDescriptor_Negative_Scenarios: *level_2
+    Unit_hipArrayGetDescriptor_Positive_Basic: *level_2
+    Unit_hipArrayGetDescriptor_Negative_Parameters: *level_2
+    Unit_hipArray3DGetDescriptor_Positive_Basic: *level_2
+    Unit_hipArray3DGetDescriptor_Negative_Parameters: *level_2
+    Unit_hipMemcpyToFromSymbol_GlobalConstVar: *level_2
     test_svm_byte_granularity:
       <<: *level_2
       tags: [multigpu]
@@ -8304,216 +4862,124 @@ unit:
       tags: [multigpu]
   module:
     Unit_hipModuleLaunchCooperativeKernel_Positive_Basic:
-      tags: [module, launch]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipModuleLaunchCooperativeKernel_Positive_Parameters:
-      tags: [module, launch]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipModuleLaunchCooperativeKernel_Negative_Parameters:
-      tags: [module, launch]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipModuleLaunchCooperativeKernel_Verify_Capture: *level_2
     Unit_hipModuleLaunchKernel_Positive_Basic:
-      tags: [module, launch]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipModuleLaunchKernel_Positive_Parameters:
-      tags: [module, launch]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipModuleLaunchKernel_Negative_Parameters:
-      tags: [multigpu, module, launch]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipModuleLaunchKernel_Fntl:
-      <<: *level_2
-      tags: [module, launch]
+    Unit_hipModuleLaunchKernel_Fntl: *level_2
     Unit_hipModuleLaunchKernel_Verify_Capture:
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipExtLaunchKernelGGL_Functional:
-      <<: *level_2
-      tags: [module, launch]
+    Unit_hipExtLaunchKernelGGL_Functional: *level_2
     Unit_hipModuleLoadDataEx_Positive_Basic:
-      tags: [module, load]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
     Unit_hipModuleLoadDataEx_Negative_Parameters:
-      tags: [module, load]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
     Unit_hipModuleLoadDataEx_Negative_Image_Is_An_Empty_String:
-      tags: [module, load]
       <<: *level_2
       # Note: Following two tests disabled due to defect - EXSWHTEC-153
       disabled: [amd_windows]
-    Unit_hipGetFuncBySymbol_PositiveTest:
-      <<: *level_2
-      tags: [module, function]
-    Unit_hipGetFuncBySymbol_NegativeTests:
-      <<: *level_2
-      tags: [module, function]
-    Unit_hipGetFuncBySymbol_InChildProcess:
-      <<: *level_2
-      tags: [module, function]
-    Unit_hipGetFuncBySymbol_MultiDev:
-      <<: *level_2
-      tags: [multigpu, module, function]
-    Unit_hipGetFuncBySymbol_MultiDevMultiThread:
-      <<: *level_2
-      tags: [multigpu, module, function]
-    Unit_hipModuleGetFunction_Positive_Basic:
-      <<: *level_2
-      tags: [module, function]
-    Unit_hipModuleGetFunction_Negative_Parameters:
-      <<: *level_2
-      tags: [module, function]
-    Unit_hipModuleGetFunction_DiffDevice:
-      <<: *level_2
-      tags: [multigpu, module, function]
-    Unit_KerArgOptimization_Saxpy:
-      <<: *level_2
-      tags: [module, function]
-    Unit_hipGetProcAddress_ModuleApis:
-      <<: *level_2
-      tags: [module, resource]
-    Unit_hipGetProcAddress_ModuleApisLoadData:
-      <<: *level_2
-      tags: [module, resource]
-    Unit_hipGetProcAddress_ModuleApisCooperativeKernels:
-      <<: *level_2
-      tags: [multigpu, module, resource]
-    Unit_hipGetProcAddress_ModuleApisOccupancy:
-      <<: *level_2
-      tags: [module, resource]
-    Unit_hipFuncGetAttribute_Positive_Basic:
-      <<: *level_2
-      tags: [module, function]
-    Unit_hipFuncGetAttribute_Negative_Parameters:
-      <<: *level_2
-      tags: [module, function]
-    Unit_hipHccModuleLaunchKernel_basic:
-      <<: *level_2
-      tags: [module, launch]
-    Unit_hipHccModuleLaunchKernel_NegTst:
-      <<: *level_2
-      tags: [module, launch]
-    Unit_hipModuleLoadFatBinary_NegativeTsts:
-      <<: *level_2
-      tags: [module, load]
-    Unit_hipModuleLoadFatBinary_PosiiveTsts:
-      <<: *level_2
-      tags: [module, load]
-    Unit_hipDrvLaunchKernelEx_NegTsts:
-      <<: *level_2
-      tags: [module, launch]
-    Unit_hipDrvLaunchKernelEx_Functional:
-      <<: *level_2
-      tags: [module, launch]
-    Unit_hipDrvLaunchKernelEx_With_Different_Kernels:
-      <<: *level_2
-      tags: [module, launch]
+    Unit_hipGetFuncBySymbol_PositiveTest: *level_2
+    Unit_hipGetFuncBySymbol_NegativeTests: *level_2
+    Unit_hipGetFuncBySymbol_InChildProcess: *level_2
+    Unit_hipGetFuncBySymbol_MultiDev: *level_2
+    Unit_hipGetFuncBySymbol_MultiDevMultiThread: *level_2
+    Unit_hipModuleGetFunction_Positive_Basic: *level_2
+    Unit_hipModuleGetFunction_Negative_Parameters: *level_2
+    Unit_hipModuleGetFunction_DiffDevice: *level_2
+    Unit_KerArgOptimization_Saxpy: *level_2
+    Unit_hipGetProcAddress_ModuleApis: *level_2
+    Unit_hipGetProcAddress_ModuleApisLoadData: *level_2
+    Unit_hipGetProcAddress_ModuleApisCooperativeKernels: *level_2
+    Unit_hipGetProcAddress_ModuleApisOccupancy: *level_2
+    Unit_hipFuncGetAttribute_Positive_Basic: *level_2
+    Unit_hipFuncGetAttribute_Negative_Parameters: *level_2
+    Unit_hipHccModuleLaunchKernel_basic: *level_2
+    Unit_hipHccModuleLaunchKernel_NegTst: *level_2
+    Unit_hipModuleLoadFatBinary_NegativeTsts: *level_2
+    Unit_hipModuleLoadFatBinary_PosiiveTsts: *level_2
+    Unit_hipDrvLaunchKernelEx_NegTsts: *level_2
+    Unit_hipDrvLaunchKernelEx_Functional: *level_2
+    Unit_hipDrvLaunchKernelEx_With_Different_Kernels: *level_2
     Unit_hipDrvLaunchKernelEx_With_CooperativeKernelWithArgs:
-      tags: [module, launch]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_hipDrvLaunchKernelEx_With_MaxBlockDims:
-      <<: *level_2
-      tags: [module, launch]
-    Unit_hipExtLaunchMultiKernelMultiDevice_Functional:
-      <<: *level_2
-      tags: [multigpu, module, launch]
+    Unit_hipDrvLaunchKernelEx_With_MaxBlockDims: *level_2
+    Unit_hipExtLaunchMultiKernelMultiDevice_Functional: *level_2
     Unit_hipModuleLoadData_Positive_Basic:
-      tags: [module, load]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
     Unit_hipModuleLoadData_Negative_Parameters:
-      tags: [module, load]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
     Unit_hipModuleLoadData_Negative_Image_Is_An_Empty_String:
-      tags: [module, load]
       <<: *level_2
       # Note: Following two tests disabled due to defect - EXSWHTEC-153
       disabled: [amd_windows]
-    Unit_hipModuleLoadData_Functional:
-      <<: *level_2
-      tags: [module, load]
+    Unit_hipModuleLoadData_Functional: *level_2
     Unit_hipModuleLoad_Positive_Basic:
-      tags: [module, load]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
-    Unit_hipModuleLoad_Negative_Parameters:
-      <<: *level_2
-      tags: [module, load]
+    Unit_hipModuleLoad_Negative_Parameters: *level_2
     Unit_hipModuleLoad_Negative_Load_From_A_File_That_Is_Not_A_Module:
-      tags: [module, load]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
-    Unit_hipFuncSetSharedMemConfig_functional:
-      <<: *level_2
-      tags: [module, function]
+    Unit_hipFuncSetSharedMemConfig_functional: *level_2
     Unit_hipModuleUnload_Negative_Module_Is_Nullptr:
-      tags: [module, load]
       <<: *level_2
       # Note: Test disabled due to defect - EXSWHTEC-152
       disabled: [amd_windows]
     Unit_hipModuleUnload_Negative_Double_Unload:
-      tags: [module, load]
       <<: *level_2
       # Below test fails in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/215
       <<: *disabled_nvidia
-    Unit_hipModuleLoad_basic:
-      <<: *level_2
-      tags: [module, load]
+    Unit_hipModuleLoad_basic: *level_2
     Unit_hipModuleGetFunctionCount_Functional:
-      tags: [module, function]
       <<: *level_2
       # (amd_linux) Rock_Linux_Failures_on_gfx94X
       # (amd_windows) Rock_Window_Failures_on_gfx1151
       disabled: [amd_linux, amd_windows]
-    Unit_hipModuleGetFunctionCount_NegativeTsts:
-      <<: *level_2
-      tags: [module, function]
-    Unit_hipModuleGetGlobal_Functional:
-      <<: *level_2
-      tags: [multigpu, module, function]
-    Unit_hipModuleLoad_MultProcess_MultGPU:
-      <<: *level_2
-      tags: [multigpu, module, load]
+    Unit_hipModuleGetFunctionCount_NegativeTsts: *level_2
+    Unit_hipModuleGetGlobal_Functional: *level_2
+    Unit_hipModuleLoad_MultProcess_MultGPU: *level_2
     Unit_hip_linker_spirv_input:
-      tags: [module, resource]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipLinkCreate_Negative:
-      <<: *level_2
-      tags: [module, resource]
-    Unit_hipLinkCreate_AddLinker_CUDA_only_options:
-      <<: *level_2
-      tags: [module, resource]
-    Unit_hipLinkAddFile_Negative:
-      <<: *level_2
-      tags: [module, resource]
+    Unit_hipLinkCreate_Negative: *level_2
+    Unit_hipLinkCreate_AddLinker_CUDA_only_options: *level_2
+    Unit_hipLinkAddFile_Negative: *level_2
     Unit_hipModuleLaunchCooperativeKernelMultiDevice_Positive_Basic:
-      tags: [multigpu, module, launch]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
@@ -8526,199 +4992,124 @@ unit:
       tags: [multigpu]
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipModuleGetGlobal_Positive_Basic:
-      <<: *level_2
-      tags: [module, resource]
-    Unit_hipModuleGetGlobal_Positive_Parameters:
-      <<: *level_2
-      tags: [module, resource]
-    Unit_hipModuleGetGlobal_Negative_Parameters:
-      <<: *level_2
-      tags: [module, resource]
+    Unit_hipModuleGetGlobal_Positive_Basic: *level_2
+    Unit_hipModuleGetGlobal_Positive_Parameters: *level_2
+    Unit_hipModuleGetGlobal_Negative_Parameters: *level_2
     Unit_hipModuleGetGlobal_Negative_Hmod_Is_Nullptr:
-      tags: [module, resource]
       <<: *level_2
       # Note: Test disabled due to defect - EXSWHTEC-163
       disabled: [amd_windows]
     Unit_hipModuleGetGlobal_Negative_Name_Is_Empty_String:
-      tags: [module, resource]
       <<: *level_2
       # Note: Test disabled due to defect - EXSWHTEC-164
       disabled: [amd_windows]
     Unit_hipModuleGetGlobal_Negative_Dptr_And_Bytes_Are_Nullptr:
-      tags: [module, resource]
       <<: *level_2
       # Note: Test disabled due to defect - EXSWHTEC-165
       disabled: [amd_windows]
-    Unit_hipModuleGetGlobal_DiffDevice:
-      <<: *level_2
-      tags: [multigpu, module, resource]
-    Unit_hipModule_Functional:
-      <<: *level_2
-      tags: [module, load]
+    Unit_hipModuleGetGlobal_DiffDevice: *level_2
+    Unit_hipModule_Functional: *level_2
     Unit_hipModuleGetTexRef_Positive_Basic:
-      tags: [module, resource]
       <<: *level_2
       # (amd_windows) Below tests are failing PSDB
       # (nvidia_windows) Disabling tests which no longer behave the same on nvidia platform
       <<: *disabled_windows
     Unit_hipModuleGetTexRef_Negative_Parameters:
-      tags: [module, resource]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipModuleGetTexRef_Negative_Hmod_Is_Nullptr:
-      tags: [module, resource]
       <<: *level_2
       # Note: Test disabled due to defect - EXSWHTEC-166
       disabled: [amd_windows]
     Unit_hipModuleGetTexRef_Negative_Name_Is_Empty_String:
-      tags: [module, resource]
       <<: *level_2
       # Note: Test disabled due to defect - EXSWHTEC-167
       disabled: [amd_windows]
-    Unit_hipFuncSetAttribute_Basic:
-      <<: *level_2
-      tags: [module, function]
-    Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr:
-      <<: *level_2
-      tags: [module, launch]
+    Unit_hipFuncSetAttribute_Basic: *level_2
+    Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr: *level_2
     Unit_hipExtModuleLaunchKernel_NonUniformWorkGroup:
-      tags: [module, launch]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/96
       disabled: [amd_windows, amd_wsl]
-    Unit_hipExtModuleLaunchKernel_UniformWorkGroup:
-      <<: *level_2
-      tags: [module, launch]
+    Unit_hipExtModuleLaunchKernel_UniformWorkGroup: *level_2
     Unit_hipExtModuleLaunchKernel_Positive_Parameters:
-      tags: [module, launch]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipExtModuleLaunchKernel_Negative_Parameters:
-      tags: [multigpu, module, launch]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipExtModuleLaunchKernel_Functional:
-      tags: [module, launch]
       <<: *level_2
       # SWDEV-438524: Below tests causing TDR & machine down in stress test on 15/12/23
       disabled: [amd_windows, amd_wsl]
-    Unit_hipFuncGetAttributes_basic:
-      <<: *level_2
-      tags: [module, function]
+    Unit_hipFuncGetAttributes_basic: *level_2
   multiThread:
-    Unit_hipMemsetAsync_QueueJobsMultithreaded:
-      <<: *level_2
-      tags: [memory, multithread]
-    Unit_hipMultiThreadDevice_Streams:
-      <<: *level_2
-      tags: [device_mgmt, multithread]
+    Unit_hipMemsetAsync_QueueJobsMultithreaded: *level_2
+    Unit_hipMultiThreadDevice_Streams: *level_2
     Unit_hipMultiThreadDevice_SerialPyramid:
-      tags: [device_mgmt, multithread]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_hipMultiThreadDevice_ParallelPyramid:
-      <<: *level_2
-      tags: [device_mgmt, multithread]
+    Unit_hipMultiThreadDevice_ParallelPyramid: *level_2
     Unit_hipMultiThreadDevice_NearZero:
-      tags: [device_mgmt, multithread]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMultiThreadStreams1_AsyncSync:
-      <<: *level_2
-      tags: [stream, multithread]
+    Unit_hipMultiThreadStreams1_AsyncSync: *level_2
     Unit_hipMultiThreadStreams1_AsyncAsync:
-      tags: [stream, multithread]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipMultiThreadStreams1_AsyncSame:
-      tags: [stream, multithread]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipMultiThreadStreams2:
-      <<: *level_2
-      tags: [stream, multithread]
+    Unit_hipMultiThreadStreams2: *level_2
   occupancy:
     Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative_Parameters:
-      tags: [occupancy]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
-    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation:
-      <<: *level_2
-      tags: [occupancy]
-    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_TemplateInvocation:
-      <<: *level_2
-      tags: [occupancy]
-    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative:
-      <<: *level_2
-      tags: [occupancy]
-    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_rangeValidation:
-      <<: *level_2
-      tags: [occupancy]
-    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_templateInvocation:
-      <<: *level_2
-      tags: [occupancy]
-    Unit_hipOccupancyMaxPotentialBlockSize_Negative_Parameters:
-      <<: *level_2
-      tags: [occupancy]
-    Unit_hipOccupancyMaxPotentialBlockSize_Positive_RangeValidation:
-      <<: *level_2
-      tags: [occupancy]
-    Unit_hipOccupancyMaxPotentialBlockSize_Positive_TemplateInvocation:
-      <<: *level_2
-      tags: [occupancy]
-    Unit_hipOccupancyMaxPotentialBlockSize_Negative:
-      <<: *level_2
-      tags: [occupancy]
-    Unit_hipOccupancyMaxPotentialBlockSize_rangeValidation:
-      <<: *level_2
-      tags: [occupancy]
-    Unit_hipOccupancyMaxPotentialBlockSize_templateInvocation:
-      <<: *level_2
-      tags: [occupancy]
+    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation: *level_2
+    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_TemplateInvocation: *level_2
+    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative: *level_2
+    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_rangeValidation: *level_2
+    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_templateInvocation: *level_2
+    Unit_hipOccupancyMaxPotentialBlockSize_Negative_Parameters: *level_2
+    Unit_hipOccupancyMaxPotentialBlockSize_Positive_RangeValidation: *level_2
+    Unit_hipOccupancyMaxPotentialBlockSize_Positive_TemplateInvocation: *level_2
+    Unit_hipOccupancyMaxPotentialBlockSize_Negative: *level_2
+    Unit_hipOccupancyMaxPotentialBlockSize_rangeValidation: *level_2
+    Unit_hipOccupancyMaxPotentialBlockSize_templateInvocation: *level_2
     Unit_hipModuleOccupancyMaxPotentialBlockSize_Negative_Parameters:
-      tags: [occupancy]
       <<: *level_2
       # SWDEV-434878: Below tests failed in stress test on 24/11/23
       disabled: [amd_windows, amd_wsl]
     Unit_hipModuleOccupancyMaxPotentialBlockSize_Positive_RangeValidation:
-      tags: [occupancy]
       <<: *level_2
       # SWDEV-434878: Below tests failed in stress test on 24/11/23
       disabled: [amd_windows, amd_wsl]
     Unit_hipModuleOccupancyMaxPotentialBlockSizeWithFlags_Negative_Parameters:
-      tags: [occupancy]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipModuleOccupancyMaxPotentialBlockSizeWithFlags_Positive_RangeValidation:
-      tags: [occupancy]
       <<: *level_2
       # SWDEV-434878: Below tests failed in stress test on 24/11/23
       disabled: [amd_windows, amd_wsl]
     Unit_hipModuleOccupancyMaxActiveBlocksPerMultiprocessor_Negative_Parameters:
-      tags: [occupancy]
       <<: *level_2
       # SWDEV-434878: Below tests failed in stress test on 24/11/23
       disabled: [amd_windows, amd_wsl]
     Unit_hipModuleOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation:
-      tags: [occupancy]
       <<: *level_2
       # SWDEV-434878: Below tests failed in stress test on 24/11/23
       disabled: [amd_windows, amd_wsl]
-    Unit_OccupancyAPIs_StreamCapture:
-      <<: *level_2
-      tags: [occupancy]
+    Unit_OccupancyAPIs_StreamCapture: *level_2
     Unit_hipModuleOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_Negative_Parameters:
-      tags: [occupancy]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
@@ -8726,204 +5117,92 @@ unit:
       <<: *level_2
       # SWDEV-434878: Below tests failed in stress test on 24/11/23
       disabled: [amd_windows, amd_wsl]
-    Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_chkRange:
-      <<: *level_2
-      tags: [occupancy]
+    Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_chkRange: *level_2
     Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_mgpu:
-      tags: [multigpu, occupancy]
       <<: *level_2
-    Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Functor:
-      <<: *level_2
-      tags: [occupancy]
-    Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Lambda:
-      <<: *level_2
-      tags: [occupancy]
-    Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_NegTst:
-      <<: *level_2
-      tags: [occupancy]
+      tags: [multigpu]
+    Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Functor: *level_2
+    Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Lambda: *level_2
+    Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_NegTst: *level_2
     Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Functional:
-      tags: [occupancy]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_ValidArgs:
-      <<: *level_2
-      tags: [occupancy]
-    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_InvalidArgs:
-      <<: *level_2
-      tags: [occupancy]
-    Unit_hipOccupancyAvailableDynamicSMemPerBlock_Negative:
-      <<: *level_2
-      tags: [occupancy]
-    Unit_hipOccupancyAvailableDynamicSMemPerBlock_Positive:
-      <<: *level_2
-      tags: [occupancy]
+    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_ValidArgs: *level_2
+    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_InvalidArgs: *level_2
+    Unit_hipOccupancyAvailableDynamicSMemPerBlock_Negative: *level_2
+    Unit_hipOccupancyAvailableDynamicSMemPerBlock_Positive: *level_2
   p2p:
-    Unit_hipDeviceGetP2PAttribute_Basic:
-      <<: *level_2
-      tags: [peer]
-    Unit_hipDeviceGetP2PAttribute_Negative:
-      <<: *level_2
-      tags: [peer]
-    Unit_hipP2pLinkTypeAndHopFunc:
-      <<: *level_2
-      tags: [peer]
+    Unit_hipDeviceGetP2PAttribute_Basic: *level_2
+    Unit_hipDeviceGetP2PAttribute_Negative: *level_2
+    Unit_hipP2pLinkTypeAndHopFunc: *level_2
   printf:
     Unit_Printf_flags_Sanity_Positive:
-      tags: [printf]
       <<: *level_2
       # Below test fails in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/274
       disabled: [amd_windows]
     Unit_Printf_length_Sanity_Positive:
-      tags: [printf]
       <<: *level_2
       # Below test fails in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/274
       disabled: [amd_windows]
-    Unit_Printf_specifier_Sanity_Positive:
-      <<: *level_2
-      tags: [printf]
-    Unit_Printf_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [printf]
-    Unit_Buffered_Printf_Flags:
-      <<: *level_2
-      tags: [printf]
-    Unit_Buffered_Printf_Specifier:
-      <<: *level_2
-      tags: [printf]
-    Unit_Host_Printf:
-      <<: *level_2
-      tags: [printf]
-    Unit_NonHost_Printf_basic:
-      <<: *level_2
-      tags: [printf]
-    Unit_NonHost_Printf_loop:
-      <<: *level_2
-      tags: [printf]
-    Unit_NonHost_Printf_multiple_Threads:
-      <<: *level_2
-      tags: [printf]
-    Unit_NonHost_Printf_BufferAvailability:
-      <<: *level_2
-      tags: [printf]
+    Unit_Printf_specifier_Sanity_Positive: *level_2
+    Unit_Printf_Negative_Parameters_RTC: *level_2
+    Unit_Buffered_Printf_Flags: *level_2
+    Unit_Buffered_Printf_Specifier: *level_2
+    Unit_Host_Printf: *level_2
+    Unit_NonHost_Printf_basic: *level_2
+    Unit_NonHost_Printf_loop: *level_2
+    Unit_NonHost_Printf_multiple_Threads: *level_2
+    Unit_NonHost_Printf_BufferAvailability: *level_2
     Unit_Printf_ManyDevicesTest:
-      tags: [multigpu, printf]
       <<: *level_2
-    Unit_Printf_PrintfStar:
-      <<: *level_2
-      tags: [printf]
-    Unit_Printf_PrintfManyWaves:
-      <<: *level_2
-      tags: [printf]
-    Unit_Printf_PrintfWidthPrecision:
-      <<: *level_2
-      tags: [printf]
-    Unit_Printf_PrintfBasicTsts:
-      <<: *level_2
-      tags: [printf]
-    Unit_Printf_PrintfAltFormsTsts:
-      <<: *level_2
-      tags: [printf]
+      tags: [multigpu]
+    Unit_Printf_PrintfStar: *level_2
+    Unit_Printf_PrintfManyWaves: *level_2
+    Unit_Printf_PrintfWidthPrecision: *level_2
+    Unit_Printf_PrintfBasicTsts: *level_2
+    Unit_Printf_PrintfAltFormsTsts: *level_2
   rtc:
-    Unit_hiprtc_saxpy:
-      <<: *level_2
-      tags: [rtc, compile]
-    Unit_hiprtc_warpsize:
-      <<: *level_2
-      tags: [rtc, compile]
-    Unit_hiprtc_functional:
-      <<: *level_2
-      tags: [rtc, compile]
-    Unit_hipStreamCaptureRtc:
-      <<: *level_2
-      tags: [rtc, integration]
-    Unit_hiprtc_includepath:
-      <<: *level_2
-      tags: [rtc, link]
-    Unit_hiprtc_devicemalloc:
-      <<: *level_2
-      tags: [rtc, integration]
-    Unit_hiprtcGetLoweredName_templateKrnls:
-      <<: *level_2
-      tags: [rtc, compile]
-    Unit_hiprtc_cpp17:
-      <<: *level_2
-      tags: [rtc, compile]
-    Unit_hiprtc_namehandling:
-      <<: *level_2
-      tags: [rtc, compile]
-    Unit_hiprtc_getloweredname:
-      <<: *level_2
-      tags: [rtc, compile]
-    Unit_hiprtc_test_hip_bfloat16:
-      <<: *level_2
-      tags: [rtc, header]
-    Unit_RTC_LinkerAPI_Negative:
-      <<: *level_2
-      tags: [rtc, link]
-    Unit_RTC_LinkDestroy_Negative:
-      <<: *level_2
-      tags: [rtc, link]
+    Unit_hiprtc_saxpy: *level_2
+    Unit_hiprtc_warpsize: *level_2
+    Unit_hiprtc_functional: *level_2
+    Unit_hipStreamCaptureRtc: *level_2
+    Unit_hiprtc_includepath: *level_2
+    Unit_hiprtc_devicemalloc: *level_2
+    Unit_hiprtcGetLoweredName_templateKrnls: *level_2
+    Unit_hiprtc_cpp17: *level_2
+    Unit_hiprtc_namehandling: *level_2
+    Unit_hiprtc_getloweredname: *level_2
+    Unit_hiprtc_test_hip_bfloat16: *level_2
+    Unit_RTC_LinkerAPI_Negative: *level_2
+    Unit_RTC_LinkDestroy_Negative: *level_2
     Unit_RTC_LinkDestroy_Default:
-      tags: [rtc, link]
       <<: *level_2
       # SWDEV-450909: Test failed in stress testing
       disabled: [amd_windows]
-    Unit_RTC_LinkerAPI:
-      <<: *level_2
-      tags: [rtc, link]
-    Unit_RTC_LinkAddFile_Negative:
-      <<: *level_2
-      tags: [rtc, link]
-    Unit_RTC_LinkAddFile_Default:
-      <<: *level_2
-      tags: [rtc, link]
-    Unit_hiprtc_half_shuffle:
-      <<: *level_2
-      tags: [rtc, integration]
-    Unit_hiprtc_half_shuffle_sync:
-      <<: *level_2
-      tags: [rtc, integration]
+    Unit_RTC_LinkerAPI: *level_2
+    Unit_RTC_LinkAddFile_Negative: *level_2
+    Unit_RTC_LinkAddFile_Default: *level_2
+    Unit_hiprtc_half_shuffle: *level_2
+    Unit_hiprtc_half_shuffle_sync: *level_2
     Unit_Rtc_ReduceRandom:
-      tags: [rtc, compile]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
     Unit_hiprtc_stdheaders:
-      tags: [rtc, header]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
-    Unit_Rtc_MathConstants_header:
-      <<: *level_2
-      tags: [rtc, header]
-    Unit_Rtc_VectorTypes_header:
-      <<: *level_2
-      tags: [rtc, header]
-    Unit_Rtc_MathFunctions_header:
-      <<: *level_2
-      tags: [rtc, header]
-    Unit_Rtc_fp16_header:
-      <<: *level_2
-      tags: [rtc, header]
-    Unit_Rtc_TextureTypes_header:
-      <<: *level_2
-      tags: [rtc, header]
-    Unit_Rtc_HipComplex_header:
-      <<: *level_2
-      tags: [rtc, header]
-    Unit_hipRTC_Ptrdiff_t_Check:
-      <<: *level_2
-      tags: [rtc, compile]
-    Unit_hipRTC_Check_Ptrdiff_t_FrmChildProcess:
-      <<: *level_2
-      tags: [rtc, compile]
-    Unit_hiprtc_bitcode_undefined_function:
-      <<: *level_2
-      tags: [rtc, link]
-    Unit_Rtc_bfloat16_header:
-      <<: *level_2
-      tags: [rtc, header]
+    Unit_Rtc_MathConstants_header: *level_2
+    Unit_Rtc_VectorTypes_header: *level_2
+    Unit_Rtc_MathFunctions_header: *level_2
+    Unit_Rtc_fp16_header: *level_2
+    Unit_Rtc_TextureTypes_header: *level_2
+    Unit_Rtc_HipComplex_header: *level_2
+    Unit_hipRTC_Ptrdiff_t_Check: *level_2
+    Unit_hipRTC_Check_Ptrdiff_t_FrmChildProcess: *level_2
+    Unit_hiprtc_bitcode_undefined_function: *level_2
+    Unit_Rtc_bfloat16_header: *level_2
     Unit_hiprtcGpuArchComplrOptnTst: *level_2
     Unit_hiprtcGpuRdcComplrOptnTst:
       <<: *level_2
@@ -8969,128 +5248,62 @@ unit:
     Unit_hiprtcEnabledTrappingMathComplrOptnTst: *level_2
     Unit_hiprtcDisabledTrappingMathComplrOptnTst: *level_2
     Unit_hiprtcCombiComplrOptnTst:
-      tags: [rtc, compile]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/327
       disabled: [amd_wsl]
   stream:
-    Unit_hipStreamCreate_default:
-      <<: *level_2
-      tags: [stream, lifecycle]
-    Unit_hipStreamCreate_Negative:
-      <<: *level_2
-      tags: [stream, lifecycle]
-    Unit_hipStreamGetFlags_Basic:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamGetFlags_Negative:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamGetFlags_StreamsCreatedWithCUMask:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamGetPriority_happy:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamGetPriority_nullptr_nullptr:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamGetPriority_stream_nullptr:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamGetPriority_nullptr_priority:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamGetPriority_stream_priority:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamGetPriority_StreamsWithCUMask:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipMultiStream_sameDevice:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipMultiStream_multimeDevice:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamAddCallback_ParamTst_Positive:
-      <<: *level_2
-      tags: [stream, callback]
-    Unit_hipStreamAddCallback_ParamTst_Negative:
-      <<: *level_2
-      tags: [stream, callback]
-    Unit_hipStreamAddCallback_WithDefaultStream:
-      <<: *level_2
-      tags: [stream, callback]
-    Unit_hipStreamAddCallback_WithCreatedStream:
-      <<: *level_2
-      tags: [stream, callback]
-    Unit_hipStreamCreateWithFlags_Negative_NullStream:
-      <<: *level_2
-      tags: [stream, lifecycle]
-    Unit_hipStreamCreateWithFlags_Negative_InvalidFlag:
-      <<: *level_2
-      tags: [stream, lifecycle]
-    Unit_hipStreamCreateWithFlags_Default:
-      <<: *level_2
-      tags: [stream, lifecycle]
+    Unit_hipStreamCreate_default: *level_2
+    Unit_hipStreamCreate_Negative: *level_2
+    Unit_hipStreamGetFlags_Basic: *level_2
+    Unit_hipStreamGetFlags_Negative: *level_2
+    Unit_hipStreamGetFlags_StreamsCreatedWithCUMask: *level_2
+    Unit_hipStreamGetPriority_happy: *level_2
+    Unit_hipStreamGetPriority_nullptr_nullptr: *level_2
+    Unit_hipStreamGetPriority_stream_nullptr: *level_2
+    Unit_hipStreamGetPriority_nullptr_priority: *level_2
+    Unit_hipStreamGetPriority_stream_priority: *level_2
+    Unit_hipStreamGetPriority_StreamsWithCUMask: *level_2
+    Unit_hipMultiStream_sameDevice: *level_2
+    Unit_hipMultiStream_multimeDevice: *level_2
+    Unit_hipStreamAddCallback_ParamTst_Positive: *level_2
+    Unit_hipStreamAddCallback_ParamTst_Negative: *level_2
+    Unit_hipStreamAddCallback_WithDefaultStream: *level_2
+    Unit_hipStreamAddCallback_WithCreatedStream: *level_2
+    Unit_hipStreamCreateWithFlags_Negative_NullStream: *level_2
+    Unit_hipStreamCreateWithFlags_Negative_InvalidFlag: *level_2
+    Unit_hipStreamCreateWithFlags_Default: *level_2
     Unit_hipStreamCreateWithFlags_DefaultStreamInteraction:
-      tags: [stream, lifecycle]
       <<: *level_2
       # (amd_windows) Disabling below tests temporarily due to change in API behavior
       # (amd_wsl) Note: Following four tests disabled due to defect - EXSWHTEC-203
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamCreateWithPriority_FunctionalForAllPriorities:
-      <<: *level_2
-      tags: [stream, lifecycle]
+    Unit_hipStreamCreateWithPriority_FunctionalForAllPriorities: *level_2
     Unit_hipStreamCreateWithPriority_MulthreadDefaultflag:
-      tags: [stream, lifecycle]
       <<: *level_2
       # SWDEV-398981 fails in stress test
       disabled: [amd_wsl]
     Unit_hipStreamCreateWithPriority_MulthreadNonblockingflag:
-      tags: [stream, lifecycle]
       <<: *level_2
       # Disabling test tracked SWDEV-394199
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamCreateWithPriority_NegTst:
-      <<: *level_2
-      tags: [stream, lifecycle]
-    Unit_hipStreamCreateWithPriority_CheckPriorityVal:
-      <<: *level_2
-      tags: [stream, lifecycle]
+    Unit_hipStreamCreateWithPriority_NegTst: *level_2
+    Unit_hipStreamCreateWithPriority_CheckPriorityVal: *level_2
     Unit_hipStreamCreateWithPriority_ValidateWithEvents:
-      tags: [stream, lifecycle]
       <<: *level_2
       # Below tests fail in stress test on 24/07/23
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamCreateWithPriority_TestMultipleStreamWithPriority:
-      <<: *level_2
-      tags: [stream, lifecycle]
-    Unit_hipStreamDestroy_Default:
-      <<: *level_2
-      tags: [stream, lifecycle]
-    Unit_hipStreamDestroy_Negative_NullStream:
-      <<: *level_2
-      tags: [stream, lifecycle]
-    Unit_hipStreamDestroy_WithFinishedWork:
-      <<: *level_2
-      tags: [stream, lifecycle]
+    Unit_hipStreamCreateWithPriority_TestMultipleStreamWithPriority: *level_2
+    Unit_hipStreamDestroy_Default: *level_2
+    Unit_hipStreamDestroy_Negative_NullStream: *level_2
+    Unit_hipStreamDestroy_WithFinishedWork: *level_2
     Unit_hipStreamDestroy_WithPendingWork:
-      tags: [stream, lifecycle]
       <<: *level_2
       # Note: TDR
       disabled: [amd_wsl]
-    Unit_hipStreamCreate_MultistreamBasicFunctionalities:
-      <<: *level_2
-      tags: [stream]
+    Unit_hipStreamCreate_MultistreamBasicFunctionalities: *level_2
     Unit_hipMemcpyAsync_hipStreamLegacy_H2H_H2D_D2H_H2PinMem: *level_2
-    Unit_hipStreamGetCaptureInfo_hipStreamLegacy_CaptureInfo:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipMemPrefetchAsync_Basic:
-      <<: *level_2
-      tags: [stream]
+    Unit_hipStreamGetCaptureInfo_hipStreamLegacy_CaptureInfo: *level_2
+    Unit_hipMemPrefetchAsync_Basic: *level_2
     Unit_hipMemPoolApi_hipStreamLegacy_Basic: *level_2
     Unit_hipStreamValue_Write:
       <<: *level_2
@@ -9181,936 +5394,496 @@ unit:
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipStreamValue_Wait64_NonBlocking_NoMask_Nor: *level_2
-    Unit_hipStreamValue_Negative_InvalidMemory:
-      <<: *level_2
-      tags: [stream]
+    Unit_hipStreamValue_Negative_InvalidMemory: *level_2
     Unit_hipStreamValue_Negative_UninitializedStream: *level_2
     Unit_hipStreamValue_Negative_InvalidFlag: *level_2
     Unit_hipStreamWriteValue_Default: *level_2
     Unit_hipStreamWaitValue_Default: *level_2
-    Unit_hipStreamSynchronize_EmptyStream:
-      <<: *level_2
-      tags: [stream, sync]
+    Unit_hipStreamSynchronize_EmptyStream: *level_2
     Unit_hipStreamSynchronize_FinishWork:
-      tags: [stream, sync]
       <<: *level_2
       # Note: TDR (pass)
       disabled: [amd_wsl]
     Unit_hipStreamSynchronize_NullStreamSynchronization:
-      tags: [stream, sync]
       <<: *level_2
       # (amd_windows) mlsejenkins_Window_Failures_on_gfx1201
       # (amd_wsl) Note: TDR (pass)
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamSynchronize_SynchronizeStreamAndQueryNullStream:
-      <<: *level_2
-      tags: [stream, sync]
+    Unit_hipStreamSynchronize_SynchronizeStreamAndQueryNullStream: *level_2
     Unit_hipStreamSynchronize_NullStreamAndStreamPerThread:
-      tags: [stream, sync]
       <<: *level_2
       # Note: needs to be enabled when streamPerThread issues are fixed
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamQuery_WithNoWork:
-      <<: *level_2
-      tags: [stream, sync]
+    Unit_hipStreamQuery_WithNoWork: *level_2
     Unit_hipStreamQuery_WithFinishedWork:
-      tags: [stream, sync]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipStreamQuery_SubmitWorkOnStreamAndQueryNullStream:
-      tags: [stream, sync]
       <<: *level_2
       # Note: TDR (pass)
       disabled: [amd_wsl]
     Unit_hipStreamQuery_NullStreamQuery:
-      tags: [stream, sync]
       <<: *level_2
       # Note: TDR (pass)
       disabled: [amd_wsl]
     Unit_hipStreamQuery_WithPendingWork:
-      tags: [stream, sync]
       <<: *level_2
       # (amd_linux) Rock_Linux_Failures_on_gfx94X
       # (amd_wsl) Note: TDR (pass)
       disabled: [amd_linux, amd_wsl]
-    Unit_hipDeviceGetStreamPriorityRange_Default:
-      <<: *level_2
-      tags: [stream]
+    Unit_hipDeviceGetStreamPriorityRange_Default: *level_2
     Unit_hipStreamAddCallback_StrmSyncTiming:
-      tags: [stream, callback]
       <<: *level_2
       # (amd_windows) SWDEV-400049 tdr intermittently
       # (amd_wsl) Note: Following four tests disabled due to defect - EXSWHTEC-203
       disabled: [amd_windows, amd_wsl]
-    Unit_hipLaunchHostFunc_basic:
-      <<: *level_2
-      tags: [stream, callback]
-    Unit_hipLaunchHostFunc_Negative:
-      <<: *level_2
-      tags: [stream, callback]
+    Unit_hipLaunchHostFunc_basic: *level_2
+    Unit_hipLaunchHostFunc_Negative: *level_2
     Unit_hipLaunchHostFunc_streams:
-      tags: [stream, callback]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
     Unit_hipLaunchHostFunc_multistreams:
-      tags: [stream, callback]
       <<: *level_2
       # SWDEV-430116:Below tests failed in stress test on 27/10/23
       disabled: [amd_wsl]
     Unit_hipLaunchHostFunc_KernelHost:
-      tags: [stream, callback]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipLaunchHostFunc_multidevice:
-      tags: [stream, callback, multigpu]
       <<: *level_2
-    Unit_hipLaunchHostFunc_Samepriority:
-      <<: *level_2
-      tags: [stream, callback]
-    Unit_hipLaunchHostFunc_Diffpriority:
-      <<: *level_2
-      tags: [stream, callback]
+      tags: [multigpu]
+    Unit_hipLaunchHostFunc_Samepriority: *level_2
+    Unit_hipLaunchHostFunc_Diffpriority: *level_2
     Unit_hipLaunchHostFunc_Graph:
-      tags: [stream, callback]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamGetDevice_Negative:
-      <<: *level_2
-      tags: [stream]
+    Unit_hipStreamGetDevice_Negative: *level_2
     Unit_hipStreamGetDevice_Usecase:
-      tags: [stream, multigpu]
       <<: *level_2
-    Unit_hipStreamGetDevice_MThread:
-      <<: *level_2
-      tags: [stream]
+      tags: [multigpu]
+    Unit_hipStreamGetDevice_MThread: *level_2
     Unit_hipStreamGetDevice_SetDiffDevice:
-      tags: [stream, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipStreamGetDevice_NullStream:
-      tags: [stream, multigpu]
       <<: *level_2
-    Unit_hipStreamLegacy_WithBlockingStream:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamLegacy_MultipleThreads:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamLegacy_NegetiveCase:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamLegacy_WithNonBlockingStream:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamLegacy_WithStreamPerThread:
-      <<: *level_2
-      tags: [stream]
+      tags: [multigpu]
+    Unit_hipStreamLegacy_WithBlockingStream: *level_2
+    Unit_hipStreamLegacy_MultipleThreads: *level_2
+    Unit_hipStreamLegacy_NegetiveCase: *level_2
+    Unit_hipStreamLegacy_WithNonBlockingStream: *level_2
+    Unit_hipStreamLegacy_WithStreamPerThread: *level_2
     Unit_hipStreamLegacy_MultiDevice:
-      tags: [stream, multigpu]
       <<: *level_2
-    Unit_hipStreamLegacy_H2H_H2D_D2D_D2H_Default:
-      <<: *level_2
-      tags: [stream]
+      tags: [multigpu]
+    Unit_hipStreamLegacy_H2H_H2D_D2D_D2H_Default: *level_2
     Unit_hipStreamLegacy_MultiDeviceMultiOperation:
-      tags: [stream, multigpu]
       <<: *level_2
-    Unit_hipStreamLegacy_TwoThreadsEachOneDiffOperation:
-      <<: *level_2
-      tags: [stream]
+      tags: [multigpu]
+    Unit_hipStreamLegacy_TwoThreadsEachOneDiffOperation: *level_2
     Unit_hipStreamLegacy_TwoDevicesEachOneDiffOperation:
-      tags: [stream, multigpu]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipStreamLegacy_TwoThreadsInTwoDevicesEachOneDiffOperation:
-      tags: [stream, multigpu]
       <<: *level_2
-    Unit_hipStreamLegacy_InChildProcess:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamLegacy_WithKernel:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamLegacy_hipStreamSynchronize:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamLegacy_WithSptCompilerOption:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamLegacy_TwoThreadsDiffOperationWithSptCompOption:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamGetId_Negative:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamGetId_Basic:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamGetId_WithDifferentStreamCreateAPIs:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamGetId_MultipleThreads:
-      <<: *level_2
-      tags: [stream]
+      tags: [multigpu]
+    Unit_hipStreamLegacy_InChildProcess: *level_2
+    Unit_hipStreamLegacy_WithKernel: *level_2
+    Unit_hipStreamLegacy_hipStreamSynchronize: *level_2
+    Unit_hipStreamLegacy_WithSptCompilerOption: *level_2
+    Unit_hipStreamLegacy_TwoThreadsDiffOperationWithSptCompOption: *level_2
+    Unit_hipStreamGetId_Negative: *level_2
+    Unit_hipStreamGetId_Basic: *level_2
+    Unit_hipStreamGetId_WithDifferentStreamCreateAPIs: *level_2
+    Unit_hipStreamGetId_MultipleThreads: *level_2
     Unit_hipStreamGetId_MultiDevice:
-      tags: [stream, multigpu]
       <<: *level_2
-    Unit_hipStreamGetId_MultiProcess:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipExtStreamGetCUMask_verifyDefaultAndCustomMask:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipExtStreamGetCUMask_Negative:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipExtStreamCreateWithCUMask_ValidateCallbackFunc:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipExtStreamCreateWithCUMask_Functionality:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipExtStreamCreateWithCUMask_AllCUsMasked:
-      <<: *level_2
-      tags: [stream]
+      tags: [multigpu]
+    Unit_hipStreamGetId_MultiProcess: *level_2
+    Unit_hipExtStreamGetCUMask_verifyDefaultAndCustomMask: *level_2
+    Unit_hipExtStreamGetCUMask_Negative: *level_2
+    Unit_hipExtStreamCreateWithCUMask_ValidateCallbackFunc: *level_2
+    Unit_hipExtStreamCreateWithCUMask_Functionality: *level_2
+    Unit_hipExtStreamCreateWithCUMask_AllCUsMasked: *level_2
     Unit_hipExtStreamCreateWithCUMask_NegTst:
-      tags: [stream]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_hipStreamAddCallback_MultipleThreads:
-      <<: *level_2
-      tags: [stream, callback]
-    Unit_hipStreamWaitEvent_Negative:
-      <<: *level_2
-      tags: [stream, sync]
-    Unit_hipStreamWaitEvent_Default:
-      <<: *level_2
-      tags: [stream, sync]
+    Unit_hipStreamAddCallback_MultipleThreads: *level_2
+    Unit_hipStreamWaitEvent_Negative: *level_2
+    Unit_hipStreamWaitEvent_Default: *level_2
     Unit_hipStreamWaitEvent_DifferentStreams:
-      tags: [stream, sync]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamGetFlags_spt_Basic:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamGetFlags_spt_Negative:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamGetFlags_spt_StreamsCreatedWithCUMask:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamGetPriority_spt_BasicTst:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamGetPriority_spt_NegativeCases:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamGetPriority_spt_StreamsWithCUMask:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamQuery_spt_WithNoWork:
-      <<: *level_2
-      tags: [stream, sync]
+    Unit_hipStreamGetFlags_spt_Basic: *level_2
+    Unit_hipStreamGetFlags_spt_Negative: *level_2
+    Unit_hipStreamGetFlags_spt_StreamsCreatedWithCUMask: *level_2
+    Unit_hipStreamGetPriority_spt_BasicTst: *level_2
+    Unit_hipStreamGetPriority_spt_NegativeCases: *level_2
+    Unit_hipStreamGetPriority_spt_StreamsWithCUMask: *level_2
+    Unit_hipStreamQuery_spt_WithNoWork: *level_2
     Unit_hipStreamQuery_spt_WithFinishedWork:
-      tags: [stream, sync]
       <<: *level_2
       # Following tests disabled due to SWDEV-486363
       disabled: [amd_windows]
     Unit_hipStreamQuery_spt_NegativeCases:
-      tags: [stream, sync]
       <<: *level_2
       # Following tests disabled due to SWDEV-486363
       disabled: [amd_windows]
     Unit_hipStreamQuery_spt_WithPendingWork:
-      tags: [stream, sync]
       <<: *level_2
       # Following tests disabled due to SWDEV-486363
       disabled: [amd_windows]
-    Unit_hipStreamSynchronize_spt_EmptyStream:
-      <<: *level_2
-      tags: [stream, sync]
+    Unit_hipStreamSynchronize_spt_EmptyStream: *level_2
     Unit_hipStreamSynchronize_spt_FinishWork:
-      tags: [stream, sync]
       <<: *level_2
       # Following tests disabled due to SWDEV-486363
       disabled: [amd_windows]
     Unit_hipStreamSynchronize_spt_SynchronizeStreamAndQueryNullStream:
-      tags: [stream, sync]
       <<: *level_2
       # Following tests disabled due to SWDEV-486363
       disabled: [amd_windows]
-    Unit_hipStreamBatchMemOp_Negative_Tests:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamSetAttribute_hipStreamGetAttribute_Basic:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamGetAttribute_Negative:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamSetAttribute_Negative:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamCopyAttributes_Basic:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamCopyAttributes_Negative:
-      <<: *level_2
-      tags: [stream]
-    Unit_hipStreamCopyAttributes_WithAllSyncPolicyValues:
-      <<: *level_2
-      tags: [stream]
+    Unit_hipStreamBatchMemOp_Negative_Tests: *level_2
+    Unit_hipStreamSetAttribute_hipStreamGetAttribute_Basic: *level_2
+    Unit_hipStreamGetAttribute_Negative: *level_2
+    Unit_hipStreamSetAttribute_Negative: *level_2
+    Unit_hipStreamCopyAttributes_Basic: *level_2
+    Unit_hipStreamCopyAttributes_Negative: *level_2
+    Unit_hipStreamCopyAttributes_WithAllSyncPolicyValues: *level_2
   streamperthread:
-    Unit_hipStreamPerThread_Basic:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipStreamPerThread_StreamQuery:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipStreamPerThread_StreamSynchronize:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipStreamPerThread_StreamGetPriority:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipStreamPerThread_StreamGetFlags:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipStreamPerThread_StreamDestroy:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipStreamPerThread_MemcpyAsync:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipStreamPerThread_EventRecord:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipStreamPerThread_EventSynchronize:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
+    Unit_hipStreamPerThread_Basic: *level_2
+    Unit_hipStreamPerThread_StreamQuery: *level_2
+    Unit_hipStreamPerThread_StreamSynchronize: *level_2
+    Unit_hipStreamPerThread_StreamGetPriority: *level_2
+    Unit_hipStreamPerThread_StreamGetFlags: *level_2
+    Unit_hipStreamPerThread_StreamDestroy: *level_2
+    Unit_hipStreamPerThread_MemcpyAsync: *level_2
+    Unit_hipStreamPerThread_EventRecord: *level_2
+    Unit_hipStreamPerThread_EventSynchronize: *level_2
     Unit_hipStreamPerThread_MultiThread:
-      tags: [stream, stream_per_thread]
       <<: *level_2
       # Disabling test tracked SWDEV-395683
       disabled: [amd_wsl]
     Unit_hipStreamPerThread_DeviceReset_1:
-      tags: [stream, stream_per_thread]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamPerThread_DeviceReset_2:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipStreamPerThreadTst_StrmQuery:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipStreamPerThread_MangdMem:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipStreamPerThread_ChildProc:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipStreamPerThread_EvtRcrdMThrd:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
+    Unit_hipStreamPerThread_DeviceReset_2: *level_2
+    Unit_hipStreamPerThreadTst_StrmQuery: *level_2
+    Unit_hipStreamPerThread_MangdMem: *level_2
+    Unit_hipStreamPerThread_ChildProc: *level_2
+    Unit_hipStreamPerThread_EvtRcrdMThrd: *level_2
     Unit_hipStreamPerThread_StrmWaitEvt:
-      tags: [stream, stream_per_thread]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamPerThread_CoopLaunch:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipStrmPerThrdDefault:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipGetProcAddress_spt_MemCpy:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipGetProcAddress_spt_Memset:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipGetProcAddress_spt_Memset2D3D:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipGetProcAddress_spt_Memcpy2D:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipGetProcAddress_spt_Memcpy3D:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipGetProcAddress_spt_LaunchKernel:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipGetProcAddress_spt_LaunchCooperativeKernel:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipGetProcAddress_spt_Stream:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipGetProcAddress_spt_Graph:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
-    Unit_hipGetProcAddress_spt_Event:
-      <<: *level_2
-      tags: [stream, stream_per_thread]
+    Unit_hipStreamPerThread_CoopLaunch: *level_2
+    Unit_hipStrmPerThrdDefault: *level_2
+    Unit_hipGetProcAddress_spt_MemCpy: *level_2
+    Unit_hipGetProcAddress_spt_Memset: *level_2
+    Unit_hipGetProcAddress_spt_Memset2D3D: *level_2
+    Unit_hipGetProcAddress_spt_Memcpy2D: *level_2
+    Unit_hipGetProcAddress_spt_Memcpy3D: *level_2
+    Unit_hipGetProcAddress_spt_LaunchKernel: *level_2
+    Unit_hipGetProcAddress_spt_LaunchCooperativeKernel: *level_2
+    Unit_hipGetProcAddress_spt_Stream: *level_2
+    Unit_hipGetProcAddress_spt_Graph: *level_2
+    Unit_hipGetProcAddress_spt_Event: *level_2
   surface:
-    Unit_hipCreateSurfaceObject_Negative_Parameters:
-      <<: *level_2
-      tags: [texture, surface, surfobj]
-    Unit_hipDestroySurfaceObject_Negative_Parameters:
-      <<: *level_2
-      tags: [texture, surface, surfobj]
-    Unit_surf1Dread_Positive_Basic:
-      <<: *level_2
-      tags: [texture, surface, surfop]
-    Unit_surf1Dwrite_Positive_Basic:
-      <<: *level_2
-      tags: [texture, surface, surfop]
-    Unit_surf1D_Positive_ReadWrite:
-      <<: *level_2
-      tags: [texture, surface, surfop]
-    Unit_surf1DLayeredread_Positive_Basic:
-      <<: *level_2
-      tags: [texture, surface, surfop]
-    Unit_surf1DLayeredwrite_Positive_Basic:
-      <<: *level_2
-      tags: [texture, surface, surfop]
-    Unit_surf1DLayered_Positive_ReadWrite:
-      <<: *level_2
-      tags: [texture, surface, surfop]
-    Unit_surf2Dread_Positive_Basic:
-      <<: *level_2
-      tags: [texture, surface, surfop]
-    Unit_surf2Dwrite_Positive_Basic:
-      <<: *level_2
-      tags: [texture, surface, surfop]
-    Unit_surf2D_Positive_ReadWrite:
-      <<: *level_2
-      tags: [texture, surface, surfop]
-    Unit_surf2DLayeredread_Positive_Basic:
-      <<: *level_2
-      tags: [texture, surface, surfop]
-    Unit_surf2DLayeredwrite_Positive_Basic:
-      <<: *level_2
-      tags: [texture, surface, surfop]
-    Unit_surf2DLayered_Positive_ReadWrite:
-      <<: *level_2
-      tags: [texture, surface, surfop]
-    Unit_surf3Dread_Positive_Basic:
-      <<: *level_2
-      tags: [texture, surface, surfop]
-    Unit_surf3Dwrite_Positive_Basic:
-      <<: *level_2
-      tags: [texture, surface, surfop]
-    Unit_surf3D_Positive_ReadWrite:
-      <<: *level_2
-      tags: [texture, surface, surfop]
-    Unit_surfCubemapread_Positive_Basic:
-      <<: *level_2
-      tags: [texture, surface, surfop]
-    Unit_surfCubemapwrite_Positive_Basic:
-      <<: *level_2
-      tags: [texture, surface, surfop]
-    Unit_surfCubemap_Positive_ReadWrite:
-      <<: *level_2
-      tags: [texture, surface, surfop]
+    Unit_hipCreateSurfaceObject_Negative_Parameters: *level_2
+    Unit_hipDestroySurfaceObject_Negative_Parameters: *level_2
+    Unit_surf1Dread_Positive_Basic: *level_2
+    Unit_surf1Dwrite_Positive_Basic: *level_2
+    Unit_surf1D_Positive_ReadWrite: *level_2
+    Unit_surf1DLayeredread_Positive_Basic: *level_2
+    Unit_surf1DLayeredwrite_Positive_Basic: *level_2
+    Unit_surf1DLayered_Positive_ReadWrite: *level_2
+    Unit_surf2Dread_Positive_Basic: *level_2
+    Unit_surf2Dwrite_Positive_Basic: *level_2
+    Unit_surf2D_Positive_ReadWrite: *level_2
+    Unit_surf2DLayeredread_Positive_Basic: *level_2
+    Unit_surf2DLayeredwrite_Positive_Basic: *level_2
+    Unit_surf2DLayered_Positive_ReadWrite: *level_2
+    Unit_surf3Dread_Positive_Basic: *level_2
+    Unit_surf3Dwrite_Positive_Basic: *level_2
+    Unit_surf3D_Positive_ReadWrite: *level_2
+    Unit_surfCubemapread_Positive_Basic: *level_2
+    Unit_surfCubemapwrite_Positive_Basic: *level_2
+    Unit_surfCubemap_Positive_ReadWrite: *level_2
   synchronization:
-    Unit_Copy_Coherency:
-      <<: *level_2
-      tags: [sync, coherency]
-    Unit_cache_coherency_cpu_gpu:
-      <<: *level_2
-      tags: [sync, coherency]
+    Unit_Copy_Coherency: *level_2
+    Unit_cache_coherency_cpu_gpu: *level_2
     Unit_cache_coherency_gpu_gpu:
-      tags: [multigpu, sync, coherency]
       <<: *level_2
+      tags: [multigpu]
   syncthreads:
     Unit___syncthreads_Positive_Basic:
-      tags: [device_lib, sync, block]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit___syncthreads_count_Positive_Basic:
-      tags: [device_lib, sync, block]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit___syncthreads_count_Positive_Predicate_Zero:
-      <<: *level_2
-      tags: [device_lib, sync, block]
-    Unit___syncthreads_count_Positive_Predicate_One:
-      <<: *level_2
-      tags: [device_lib, sync, block]
-    Unit___syncthreads_count_Positive_Predicate_OddEven:
-      <<: *level_2
-      tags: [device_lib, sync, block]
-    Unit___syncthreads_count_Positive_Predicate_Negative:
-      <<: *level_2
-      tags: [device_lib, sync, block]
-    Unit___syncthreads_count_Positive_Predicate_Id:
-      <<: *level_2
-      tags: [device_lib, sync, block]
-    Unit___syncthreads_count_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lib, sync, block]
+    Unit___syncthreads_count_Positive_Predicate_Zero: *level_2
+    Unit___syncthreads_count_Positive_Predicate_One: *level_2
+    Unit___syncthreads_count_Positive_Predicate_OddEven: *level_2
+    Unit___syncthreads_count_Positive_Predicate_Negative: *level_2
+    Unit___syncthreads_count_Positive_Predicate_Id: *level_2
+    Unit___syncthreads_count_Negative_Parameters_RTC: *level_2
     Unit___syncthreads_and_Positive_Basic:
-      tags: [device_lib, sync, block]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit___syncthreads_and_Positive_Predicate_Zero:
-      <<: *level_2
-      tags: [device_lib, sync, block]
-    Unit___syncthreads_and_Positive_Predicate_One:
-      <<: *level_2
-      tags: [device_lib, sync, block]
-    Unit___syncthreads_and_Positive_Predicate_OddEven:
-      <<: *level_2
-      tags: [device_lib, sync, block]
-    Unit___syncthreads_and_Positive_Predicate_Negative:
-      <<: *level_2
-      tags: [device_lib, sync, block]
-    Unit___syncthreads_and_Positive_Predicate_Id:
-      <<: *level_2
-      tags: [device_lib, sync, block]
-    Unit___syncthreads_and_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lib, sync, block]
+    Unit___syncthreads_and_Positive_Predicate_Zero: *level_2
+    Unit___syncthreads_and_Positive_Predicate_One: *level_2
+    Unit___syncthreads_and_Positive_Predicate_OddEven: *level_2
+    Unit___syncthreads_and_Positive_Predicate_Negative: *level_2
+    Unit___syncthreads_and_Positive_Predicate_Id: *level_2
+    Unit___syncthreads_and_Negative_Parameters_RTC: *level_2
     Unit___syncthreads_or_Positive_Basic:
-      tags: [device_lib, sync, block]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit___syncthreads_or_Positive_Predicate_Zero:
-      <<: *level_2
-      tags: [device_lib, sync, block]
-    Unit___syncthreads_or_Positive_Predicate_One:
-      <<: *level_2
-      tags: [device_lib, sync, block]
-    Unit___syncthreads_or_Positive_Predicate_OddEven:
-      <<: *level_2
-      tags: [device_lib, sync, block]
-    Unit___syncthreads_or_Positive_Predicate_Negative:
-      <<: *level_2
-      tags: [device_lib, sync, block]
-    Unit___syncthreads_or_Positive_Predicate_Id:
-      <<: *level_2
-      tags: [device_lib, sync, block]
-    Unit___syncthreads_or_Negative_Parameters_RTC:
-      <<: *level_2
-      tags: [device_lib, sync, block]
+    Unit___syncthreads_or_Positive_Predicate_Zero: *level_2
+    Unit___syncthreads_or_Positive_Predicate_One: *level_2
+    Unit___syncthreads_or_Positive_Predicate_OddEven: *level_2
+    Unit___syncthreads_or_Positive_Predicate_Negative: *level_2
+    Unit___syncthreads_or_Positive_Predicate_Id: *level_2
+    Unit___syncthreads_or_Negative_Parameters_RTC: *level_2
   texture:
-    Unit_hipCreateTextureObject_ArgValidation:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipCreateTextureObject_LinearResource:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipCreateTextureObject_Pitch2DResource:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipCreateTextureObject_ArrayResource:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipCreateTextureObject_MmArrayResource:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipTextureFetch_vector:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipTextureObj2D_Check:
-      <<: *level_2
-      tags: [texture, texobj]
+    Unit_hipCreateTextureObject_ArgValidation: *level_2
+    Unit_hipCreateTextureObject_LinearResource: *level_2
+    Unit_hipCreateTextureObject_Pitch2DResource: *level_2
+    Unit_hipCreateTextureObject_ArrayResource: *level_2
+    Unit_hipCreateTextureObject_MmArrayResource: *level_2
+    Unit_hipTextureFetch_vector: *level_2
+    Unit_hipTextureObj2D_Check: *level_2
     Unit_Layered1DTexture_Check_HostBufferToFromLayered1DArray:
-      tags: [texture, sample]
       <<: *level_2
       # SWDEV-431191:Below tests failed in stress test on 03/11/23
       disabled: [amd_wsl]
     Unit_Layered1DTexture_Check_DeviceBufferToFromLayered1DArray:
-      tags: [texture, sample]
       <<: *level_2
       # SWDEV-431191:Below tests failed in stress test on 03/11/23
       # SWDEV-432250:Below tests failed in stress test on 10/11/23
       disabled: [amd_wsl]
-    Unit_Layered2DTexture_Check_HostBufferToFromLayered2DArray:
-      <<: *level_2
-      tags: [texture, sample]
+    Unit_Layered2DTexture_Check_HostBufferToFromLayered2DArray: *level_2
     Unit_Layered2DTexture_Check_DeviceBufferToFromLayered2DArray:
-      tags: [texture, sample]
       <<: *level_2
       # SWDEV-431191:Below tests failed in stress test on 03/11/23
       # SWDEV-432250:Below tests failed in stress test on 10/11/23
       disabled: [amd_wsl]
-    Unit_hipBindTexture_Positive:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipBindTexture_1DfetchVerification:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipBindTexture_Negative:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipBindTexture2D_Positive:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipBindTexture2D_Pitch:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipBindTexture2D_Negative:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_tex1Dfetch_CheckModes:
-      <<: *level_2
-      tags: [texture, sample]
-    Unit_hipGetChannelDesc_CreateAndGet:
-      <<: *level_2
-      tags: [texture, texobj]
+    Unit_hipBindTexture_Positive: *level_2
+    Unit_hipBindTexture_1DfetchVerification: *level_2
+    Unit_hipBindTexture_Negative: *level_2
+    Unit_hipBindTexture2D_Positive: *level_2
+    Unit_hipBindTexture2D_Pitch: *level_2
+    Unit_hipBindTexture2D_Negative: *level_2
+    Unit_tex1Dfetch_CheckModes: *level_2
+    Unit_hipGetChannelDesc_CreateAndGet: *level_2
     Unit_hipGetChannelDesc_Negative_Parameters:
-      tags: [texture, texobj]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/92
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGetTextureAlignmentOffset_Positive:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipGetTextureAlignmentOffset_Negative:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipGetTextureReference_Positive:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipGetTextureReference_Negative:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipTexObjPitch_texture2D:
-      <<: *level_2
-      tags: [texture, texobj]
+    Unit_hipGetTextureAlignmentOffset_Positive: *level_2
+    Unit_hipGetTextureAlignmentOffset_Negative: *level_2
+    Unit_hipGetTextureReference_Positive: *level_2
+    Unit_hipGetTextureReference_Negative: *level_2
+    Unit_hipTexObjPitch_texture2D: *level_2
     Unit_hipTexRefSetArray_Positive:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetArray_CheckData:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetArray_Negative:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetArray_Positive:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetArray_Negative:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetBorderColor_Negative:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetBorderColor_Negative:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetAddress_Positive:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetAddress_Negative:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetAddress_AdressNotSet:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetAddress_Basic:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetAddress_Positive:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetAddress_Negative:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetFormat_Basic:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetFormat_Positive:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetFormat_Negative:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetFormat_Positive:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetFormat_Negative:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipCreateTextureObject_tex1DfetchVerification:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipTextureObj1DCheckModes:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipTextureObj2DCheckModes:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipTextureObj3DCheckModes:
-      <<: *level_2
-      tags: [texture, texobj]
+    Unit_hipCreateTextureObject_tex1DfetchVerification: *level_2
+    Unit_hipTextureObj1DCheckModes: *level_2
+    Unit_hipTextureObj2DCheckModes: *level_2
+    Unit_hipTextureObj3DCheckModes: *level_2
     Unit_hipTextureObj1DCheckRGBAModes_array: *level_2
     Unit_hipTextureObj1DCheckSRGBAModes_array: *level_2
     Unit_hipTextureObj1DCheckRGBAModes_buffer: *level_2
     Unit_hipTextureObj1DCheckSRGBAModes_buffer: *level_2
-    Unit_hipTextureObj2DCheckRGBAModes:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipTextureObj2DCheckSRGBAModes:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_TexObjectCreate_NullptrParams:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_TexObjectCreate_TypeLinear:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_TexObjectCreate_TypeLinear_IncompleteInit:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_TexObjectCreate_TypeLinear_EdgeCases:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_TexObjectCreate_TypeArray:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_TexObjectCreate_TypeArray_NullptrArray:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_TexObjectCreate_TypeMipmapped:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_TexObjectCreate_TypeMipmaped_IncompleteInit:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_TexObjectCreate_TypePitch2D:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_TexObjectCreate_TypePitch2D_IncompleteInit:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_TexObjectCreate_TypePitch2D_EdgeCases:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipGetTexObjectResourceDesc_positive:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipGetTexObjectResourceDesc_Negative_Parameters:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipGetTexObjectResourceViewDesc_positive:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipGetTexObjectResourceViewDesc_Negative_Parameters:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipGetTexObjectTextureDesc_positive:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipGetTexObjectTextureDesc_Negative_Parameters:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipTexObjectDestroy_positive:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipGetTextureObjectResourceDesc_positive:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipGetTextureObjectResourceDesc_Negative_Parameters:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipGetTextureObjectResourceViewDesc_positive:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipGetTextureObjectResourceViewDesc_Negative_Parameters:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipGetTextureObjectTextureDesc_positive:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipGetTextureObjectTextureDesc_Negative_Parameters:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipDestroyTextureObject_positive:
-      <<: *level_2
-      tags: [texture, texobj]
+    Unit_hipTextureObj2DCheckRGBAModes: *level_2
+    Unit_hipTextureObj2DCheckSRGBAModes: *level_2
+    Unit_TexObjectCreate_NullptrParams: *level_2
+    Unit_TexObjectCreate_TypeLinear: *level_2
+    Unit_TexObjectCreate_TypeLinear_IncompleteInit: *level_2
+    Unit_TexObjectCreate_TypeLinear_EdgeCases: *level_2
+    Unit_TexObjectCreate_TypeArray: *level_2
+    Unit_TexObjectCreate_TypeArray_NullptrArray: *level_2
+    Unit_TexObjectCreate_TypeMipmapped: *level_2
+    Unit_TexObjectCreate_TypeMipmaped_IncompleteInit: *level_2
+    Unit_TexObjectCreate_TypePitch2D: *level_2
+    Unit_TexObjectCreate_TypePitch2D_IncompleteInit: *level_2
+    Unit_TexObjectCreate_TypePitch2D_EdgeCases: *level_2
+    Unit_hipGetTexObjectResourceDesc_positive: *level_2
+    Unit_hipGetTexObjectResourceDesc_Negative_Parameters: *level_2
+    Unit_hipGetTexObjectResourceViewDesc_positive: *level_2
+    Unit_hipGetTexObjectResourceViewDesc_Negative_Parameters: *level_2
+    Unit_hipGetTexObjectTextureDesc_positive: *level_2
+    Unit_hipGetTexObjectTextureDesc_Negative_Parameters: *level_2
+    Unit_hipTexObjectDestroy_positive: *level_2
+    Unit_hipGetTextureObjectResourceDesc_positive: *level_2
+    Unit_hipGetTextureObjectResourceDesc_Negative_Parameters: *level_2
+    Unit_hipGetTextureObjectResourceViewDesc_positive: *level_2
+    Unit_hipGetTextureObjectResourceViewDesc_Negative_Parameters: *level_2
+    Unit_hipGetTextureObjectTextureDesc_positive: *level_2
+    Unit_hipGetTextureObjectTextureDesc_Negative_Parameters: *level_2
+    Unit_hipDestroyTextureObject_positive: *level_2
     Unit_hipTexRefSetAddress2D_Negative_Parameters:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetAddress2D_Positive:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetMaxAnisotropy_Negative_Parameters:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetMaxAnisotropy_Positive:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetMaxAnisotropy_Negative_Parameters:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetMaxAnisotropy_Positive:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipUnbindTexture_Null_Texture:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipUnbindTexture_Positive_1D:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipUnbindTexture_Positive_2D:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipUnbindTexture_Positive_3D:
-      <<: *level_2
-      tags: [texture, texref]
+    Unit_hipUnbindTexture_Null_Texture: *level_2
+    Unit_hipUnbindTexture_Positive_1D: *level_2
+    Unit_hipUnbindTexture_Positive_2D: *level_2
+    Unit_hipUnbindTexture_Positive_3D: *level_2
     Unit_hipTexRefSetFlags_Negative_Parameters:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetFlags_Positive:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipBindTextureToArray_Negative_Parameters:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipBindTextureToArray_Positive_1D:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipBindTextureToArray_Positive_2D:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipBindTextureToArray_Positive_3D:
-      <<: *level_2
-      tags: [texture, texref]
+    Unit_hipBindTextureToArray_Negative_Parameters: *level_2
+    Unit_hipBindTextureToArray_Positive_1D: *level_2
+    Unit_hipBindTextureToArray_Positive_2D: *level_2
+    Unit_hipBindTextureToArray_Positive_3D: *level_2
     Unit_hipTexRefGetFlags_Negative_Parameters:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetFlags_Positive:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetAddressMode_Negative_Parameters:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetAddressMode_Positive:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetAddressMode_Negative_Parameters:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetAddressMode_Positive:
-      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipTexRefSetGetFilterMode:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipTexRefSetGetMipmapFilterMode:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipTexRefSetGetMipmapLevelBias:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_texRefSetGetMipmapLevelClamp:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipTexRefSetGetMipmappedArray:
-      <<: *level_2
-      tags: [texture, texref]
+    Unit_hipTexRefSetGetFilterMode: *level_2
+    Unit_hipTexRefSetGetMipmapFilterMode: *level_2
+    Unit_hipTexRefSetGetMipmapLevelBias: *level_2
+    Unit_texRefSetGetMipmapLevelClamp: *level_2
+    Unit_hipTexRefSetGetMipmappedArray: *level_2
     Unit_hipTextureMipmapRef2D_Positive_Check:
-      tags: [texture, texref]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/92
       disabled: [amd_wsl]
     Unit_hipTextureMipmapRef2D_Negative_Parameters:
-      tags: [texture, texref]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/92
       disabled: [amd_wsl]
-    Unit_hipMallocMipmappedArray_Negative_Parameters:
-      <<: *level_2
-      tags: [texture, mipmap]
-    Unit_hipFreeMipmappedArray_Negative_Parameters:
-      <<: *level_2
-      tags: [texture, mipmap]
-    Unit_hipGetMipmappedArrayLevel_Negative_Parameters:
-      <<: *level_2
-      tags: [texture, mipmap]
-    Unit_hipMipmappedArrayCreate_Negative_Parameters:
-      <<: *level_2
-      tags: [texture, mipmap]
-    Unit_hipMipmappedArrayDestroy_Negative_Parameters:
-      <<: *level_2
-      tags: [texture, mipmap]
-    Unit_hipMipmappedArrayGetLevel_Negative_Parameters:
-      <<: *level_2
-      tags: [texture, mipmap]
+    Unit_hipMallocMipmappedArray_Negative_Parameters: *level_2
+    Unit_hipFreeMipmappedArray_Negative_Parameters: *level_2
+    Unit_hipGetMipmappedArrayLevel_Negative_Parameters: *level_2
+    Unit_hipMipmappedArrayCreate_Negative_Parameters: *level_2
+    Unit_hipMipmappedArrayDestroy_Negative_Parameters: *level_2
+    Unit_hipMipmappedArrayGetLevel_Negative_Parameters: *level_2
     Unit_hipTextureMipmapObj1D_Check_hipReadModeElementType: *level_2
     Unit_hipTextureMipmapObj1D_Check_hipReadModeNormalizedFloat: *level_2
     Unit_hipTextureMipmapObj1D_Check_hipReadModeElementType_float_only: *level_2
@@ -10129,91 +5902,41 @@ unit:
     Unit_hipTextureMipmapObj3D_Check_hipReadModeElementType: *level_2
     Unit_hipTextureMipmapObj3D_Check_hipReadModeNormalizedFloat: *level_2
     Unit_hipTextureMipmapObj3D_Check_hipReadModeElementType_float_only: *level_2
-    Unit_tex1DLod_Positive_ReadModeElementType:
-      <<: *level_2
-      tags: [texture, sample]
-    Unit_tex1DLod_Positive_ReadModeNormalizedFloat:
-      <<: *level_2
-      tags: [texture, sample]
-    Unit_tex1DLayeredLod_Positive_ReadModeElementType:
-      <<: *level_2
-      tags: [texture, sample]
-    Unit_tex1DLayeredLod_Positive_ReadModeNormalizedFloat:
-      <<: *level_2
-      tags: [texture, sample]
-    Unit_tex2DLod_Positive_ReadModeElementType:
-      <<: *level_2
-      tags: [texture, sample]
-    Unit_tex2DLod_Positive_ReadModeNormalizedFloat:
-      <<: *level_2
-      tags: [texture, sample]
-    Unit_tex2DLayeredLod_Positive_ReadModeElementType:
-      <<: *level_2
-      tags: [texture, sample]
-    Unit_tex2DLayeredLod_Positive_ReadModeNormalizedFloat:
-      <<: *level_2
-      tags: [texture, sample]
-    Unit_tex3DLod_Positive_ReadModeElementType:
-      <<: *level_2
-      tags: [texture, sample]
-    Unit_tex3DLod_Positive_ReadModeNormalizedFloat:
-      <<: *level_2
-      tags: [texture, sample]
-    Unit_hipTexRefSetGetMipmapFilterMode:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipTexRefSetGetMipmapLevelBias:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_texRefSetGetMipmapLevelClamp:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipTexRefSetGetMipmappedArray:
-      <<: *level_2
-      tags: [texture, texref]
-    Unit_hipDeviceGetTexture1DLinearMaxWidth_Positive:
-      <<: *level_2
-      tags: [texture, texobj]
-    Unit_hipDeviceGetTexture1DLinearMaxWidth_Negative:
-      <<: *level_2
-      tags: [texture, texobj]
+    Unit_tex1DLod_Positive_ReadModeElementType: *level_2
+    Unit_tex1DLod_Positive_ReadModeNormalizedFloat: *level_2
+    Unit_tex1DLayeredLod_Positive_ReadModeElementType: *level_2
+    Unit_tex1DLayeredLod_Positive_ReadModeNormalizedFloat: *level_2
+    Unit_tex2DLod_Positive_ReadModeElementType: *level_2
+    Unit_tex2DLod_Positive_ReadModeNormalizedFloat: *level_2
+    Unit_tex2DLayeredLod_Positive_ReadModeElementType: *level_2
+    Unit_tex2DLayeredLod_Positive_ReadModeNormalizedFloat: *level_2
+    Unit_tex3DLod_Positive_ReadModeElementType: *level_2
+    Unit_tex3DLod_Positive_ReadModeNormalizedFloat: *level_2
+    Unit_hipTexRefSetGetMipmapFilterMode: *level_2
+    Unit_hipTexRefSetGetMipmapLevelBias: *level_2
+    Unit_texRefSetGetMipmapLevelClamp: *level_2
+    Unit_hipTexRefSetGetMipmappedArray: *level_2
+    Unit_hipDeviceGetTexture1DLinearMaxWidth_Positive: *level_2
+    Unit_hipDeviceGetTexture1DLinearMaxWidth_Negative: *level_2
   threadfence:
-    Unit___threadfence_block_Positive_Basic_Shared:
-      <<: *level_2
-      tags: [sync, fence]
-    Unit___threadfence_block_Positive_Basic_Global:
-      <<: *level_2
-      tags: [sync, fence]
-    Unit___threadfence_block_Positive_Basic_Pinned:
-      <<: *level_2
-      tags: [sync, fence]
-    Unit___threadfence_block_Positive_Basic_Managed:
-      <<: *level_2
-      tags: [sync, fence]
+    Unit___threadfence_block_Positive_Basic_Shared: *level_2
+    Unit___threadfence_block_Positive_Basic_Global: *level_2
+    Unit___threadfence_block_Positive_Basic_Pinned: *level_2
+    Unit___threadfence_block_Positive_Basic_Managed: *level_2
     Unit___threadfence_block_Positive_Basic_Peer:
-      tags: [multigpu, sync, fence]
       <<: *level_2
-    Unit___threadfence_Positive_Basic_Shared:
-      <<: *level_2
-      tags: [sync, fence]
-    Unit___threadfence_Positive_Basic_Global:
-      <<: *level_2
-      tags: [sync, fence]
-    Unit___threadfence_Positive_Basic_Pinned:
-      <<: *level_2
-      tags: [sync, fence]
-    Unit___threadfence_Positive_Basic_Managed:
-      <<: *level_2
-      tags: [sync, fence]
+      tags: [multigpu]
+    Unit___threadfence_Positive_Basic_Shared: *level_2
+    Unit___threadfence_Positive_Basic_Global: *level_2
+    Unit___threadfence_Positive_Basic_Pinned: *level_2
+    Unit___threadfence_Positive_Basic_Managed: *level_2
     Unit___threadfence_Positive_Basic_Peer:
-      tags: [multigpu, sync, fence]
       <<: *level_2
+      tags: [multigpu]
     Unit___threadfence_system_Positive_Basic_Peer:
-      tags: [multigpu, sync, fence]
       <<: *level_2
-    Unit___threadfence_system_Positive_Basic_Host:
-      <<: *level_2
-      tags: [sync, fence]
+      tags: [multigpu]
+    Unit___threadfence_system_Positive_Basic_Host: *level_2
   vector_types:
     Unit_make_vector_SanityCheck_Basic_Host: *level_2
     Unit_make_vector_SanityCheck_Basic_Device: *level_2
@@ -10222,39 +5945,17 @@ unit:
     Unit_VectorAndVectorOperations_SanityCheck_Basic_Device: *level_2
     Unit_VectorAndValueTypeOperations_SanityCheck_Basic_Device: *level_2
     Unit_VectorStructuredBindings_SanityCheck_Basic_host: *level_2
-    Unit_VectorConstexpr_SanityCheck_Basic_host_device:
-      <<: *level_2
-      tags: [vector_types]
-    Unit_Vector_alignment_check:
-      <<: *level_2
-      tags: [vector_types]
-    Unit_Vector_size_check:
-      <<: *level_2
-      tags: [vector_types]
-    Unit_dim3_Empty_Positive_Device:
-      <<: *level_2
-      tags: [vector_types]
-    Unit_dim3_X_Positive_Device:
-      <<: *level_2
-      tags: [vector_types]
-    Unit_dim3_XY_Positive_Device:
-      <<: *level_2
-      tags: [vector_types]
-    Unit_dim3_XYZ_Positive_Device:
-      <<: *level_2
-      tags: [vector_types]
-    Unit_dim3_Empty_Positive_Host:
-      <<: *level_2
-      tags: [vector_types]
-    Unit_dim3_X_Positive_Host:
-      <<: *level_2
-      tags: [vector_types]
-    Unit_dim3_XY_Positive_Host:
-      <<: *level_2
-      tags: [vector_types]
-    Unit_dim3_XYZ_Positive_Host:
-      <<: *level_2
-      tags: [vector_types]
+    Unit_VectorConstexpr_SanityCheck_Basic_host_device: *level_2
+    Unit_Vector_alignment_check: *level_2
+    Unit_Vector_size_check: *level_2
+    Unit_dim3_Empty_Positive_Device: *level_2
+    Unit_dim3_X_Positive_Device: *level_2
+    Unit_dim3_XY_Positive_Device: *level_2
+    Unit_dim3_XYZ_Positive_Device: *level_2
+    Unit_dim3_Empty_Positive_Host: *level_2
+    Unit_dim3_X_Positive_Host: *level_2
+    Unit_dim3_XY_Positive_Host: *level_2
+    Unit_dim3_XYZ_Positive_Host: *level_2
   virtualMemoryManagement:
     Unit_hipMemGetAllocationGranularity_MinGranularity:
       <<: *level_2
@@ -10265,515 +5966,301 @@ unit:
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemGetAllocationGranularity_AllGPUs:
-      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemGetAllocationGranularity_NegativeTests:
-      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
-    Unit_hipMemGetAllocationGranularity_Capture:
-      <<: *level_2
-      tags: [vmm]
+    Unit_hipMemGetAllocationGranularity_Capture: *level_2
     Unit_hipMemRetainAllocationHandle_SetGet:
-      tags: [vmm]
       <<: *level_2
       disabled: [amd_wsl]
     Unit_hipMemRetainAllocationHandle_NegTst:
-      tags: [vmm]
       <<: *level_2
       disabled: [amd_wsl]
-    Unit_hipMemRetainAllocationHandle_Capture:
-      <<: *level_2
-      tags: [vmm]
-    Unit_hipMemImportFromShareableHandle_Positive_Basic:
-      <<: *level_2
-      tags: [vmm]
-    Unit_hipMemImportFromShareableHandle_Negative_Parameters:
-      <<: *level_2
-      tags: [vmm]
-    Unit_hipMemImportFromShareableHandle_MulProc_ChldUseHdl:
-      <<: *level_2
-      tags: [vmm]
-    Unit_hipMemImportFromShareableHandle_MulProc_ParntChldUseHdl:
-      <<: *level_2
-      tags: [vmm]
-    Unit_hipMemImportFromShareableHandle_MulProc_GrndChldUseHdl:
-      <<: *level_2
-      tags: [vmm]
-    Unit_hipMemImportFromShareableHandle_Capture:
-      <<: *level_2
-      tags: [vmm]
-    Unit_hipMemGetHandleForAddressRange_Negative:
-      <<: *level_2
-      tags: [vmm]
-    Unit_hipMemGetHandleForAddressRange_DeviceMemory:
-      <<: *level_2
-      tags: [vmm]
-    Unit_hipMemGetHandleForAddressRange_VM:
-      <<: *level_2
-      tags: [vmm]
+    Unit_hipMemRetainAllocationHandle_Capture: *level_2
+    Unit_hipMemImportFromShareableHandle_Positive_Basic: *level_2
+    Unit_hipMemImportFromShareableHandle_Negative_Parameters: *level_2
+    Unit_hipMemImportFromShareableHandle_MulProc_ChldUseHdl: *level_2
+    Unit_hipMemImportFromShareableHandle_MulProc_ParntChldUseHdl: *level_2
+    Unit_hipMemImportFromShareableHandle_MulProc_GrndChldUseHdl: *level_2
+    Unit_hipMemImportFromShareableHandle_Capture: *level_2
+    Unit_hipMemGetHandleForAddressRange_Negative: *level_2
+    Unit_hipMemGetHandleForAddressRange_DeviceMemory: *level_2
+    Unit_hipMemGetHandleForAddressRange_VM: *level_2
     Unit_hipMemGetHandleForAddressRange_DeviceMemory_InAnotherDevice:
-      tags: [multigpu, vmm]
       <<: *level_2
+      tags: [multigpu]
     Unit_hipMemGetHandleForAddressRange_VM_InAnotherDevice:
-      tags: [multigpu, vmm]
       <<: *level_2
-    Unit_hipMemGetHandleForAddressRange_MulProc_Socket_DeviceMem:
-      <<: *level_2
-      tags: [vmm]
-    Unit_hipMemGetHandleForAddressRange_MulProc_Socket_VM:
-      <<: *level_2
-      tags: [vmm]
-    Unit_hipMemGetHandleForAddressRange_MultipleThreads:
-      <<: *level_2
-      tags: [vmm]
-    Unit_hipMemGetHandleForAddressRange_DifferentOffsets:
-      <<: *level_2
-      tags: [vmm]
-    Unit_hipMemExportToShareableHandle_Positive_Basic:
-      <<: *level_2
-      tags: [vmm]
-    Unit_hipMemExportToShareableHandle_Negative_Parameters:
-      <<: *level_2
-      tags: [vmm]
-    Unit_hipMemExportToShareableHandle_Capture:
-      <<: *level_2
-      tags: [vmm]
-    Unit_hipGetProcAddress_VMM:
-      <<: *level_2
-      tags: [vmm]
+      tags: [multigpu]
+    Unit_hipMemGetHandleForAddressRange_MulProc_Socket_DeviceMem: *level_2
+    Unit_hipMemGetHandleForAddressRange_MulProc_Socket_VM: *level_2
+    Unit_hipMemGetHandleForAddressRange_MultipleThreads: *level_2
+    Unit_hipMemGetHandleForAddressRange_DifferentOffsets: *level_2
+    Unit_hipMemExportToShareableHandle_Positive_Basic: *level_2
+    Unit_hipMemExportToShareableHandle_Negative_Parameters: *level_2
+    Unit_hipMemExportToShareableHandle_Capture: *level_2
+    Unit_hipGetProcAddress_VMM: *level_2
     Unit_hipMemAddressFree_negative:
-      tags: [vmm]
       <<: *level_2
       # (amd_windows) NOTE: The following test is disabled due to defect - EXSWHTEC-244
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemAddressFree_Capture:
-      <<: *level_2
-      tags: [vmm]
+    Unit_hipMemAddressFree_Capture: *level_2
     Unit_hipMemAddressReserve_AlignmentTest:
-      tags: [vmm]
       <<: *level_2
       # (amd_windows) NOTE: The following test is disabled due to defect - EXSWHTEC-245
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemAddressReserve_Negative:
-      <<: *level_2
-      tags: [vmm]
-    Unit_hipMemAddressReserve_Capture:
-      <<: *level_2
-      tags: [vmm]
+    Unit_hipMemAddressReserve_Negative: *level_2
+    Unit_hipMemAddressReserve_Capture: *level_2
     Unit_hipMemCreate_BasicAllocateDeAlloc_MultGranularity:
-      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemCreate_ChkDev2HstMemcpy_ReleaseHdlPostUnmap:
-      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemCreate_ChkDev2HstMemcpy_ReleaseHdlPreUse:
-      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemCreate_ChkWithKerLaunch:
-      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemCreate_MapNonContiguousChunks:
-      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemCreate_ChkWithMemset:
-      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemCreate_Negative:
-      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
-    Unit_hipMemCreate_Capture:
-      <<: *level_2
-      tags: [vmm]
+    Unit_hipMemCreate_Capture: *level_2
     Unit_hipMemSetAccess_SetGet:
-      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_MultDevSetGet:
-      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_EntireVMMRangeSetGet:
-      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemGetAccess_NegTst:
-      tags: [vmm]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_FuncTstOnMultDev:
-      tags: [multigpu, vmm]
       <<: *level_2
+      tags: [multigpu]
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_ChangeAccessProp:
-      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-413997: VMM test still failing in windows
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_Vmm2UnifiedMemCpy:
-      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_Vmm2DevMemCpy:
-      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-444041: These tests fail randomly in gfx1030 MGU
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_Vmm2PeerDevMemCpy:
-      tags: [multigpu, vmm]
       <<: *level_2
+      tags: [multigpu]
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_Vmm2PeerPeerMemCpy:
-      tags: [multigpu, vmm]
       <<: *level_2
+      tags: [multigpu]
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemSetAccess_Vmm2VMMMemCpy:
-      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-444041: These tests fail in gfx1100 MGPU
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_Vmm2VMMInterDevMemCpy:
-      tags: [multigpu, vmm]
       <<: *level_2
+      tags: [multigpu]
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_GrowVMM:
-      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_Multithreaded:
-      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-444031: This test fails in gfx1101 MGPU
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_negative:
-      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemSetGetAccess_Capture:
-      <<: *level_2
-      tags: [vmm]
+    Unit_hipMemSetGetAccess_Capture: *level_2
     Unit_hipMemSetAccessHostDevice_hostalloc:
-      tags: [vmm]
       <<: *level_2
       # SWDEV-555665
       disabled: [amd_windows]
-    Unit_hipMemSetAccessHost_devicealloc:
-      <<: *level_2
-      tags: [vmm]
+    Unit_hipMemSetAccessHost_devicealloc: *level_2
     Unit_hipMemGetAllocationPropertiesFromHandle_functional:
-      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemGetAllocationPropertiesFromHandle_Negative:
-      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
-    Unit_hipMemGetAllocationPropertiesFromHandle_Capture:
-      <<: *level_2
-      tags: [vmm]
+    Unit_hipMemGetAllocationPropertiesFromHandle_Capture: *level_2
     Unit_hipMemMap_SameMemoryReuse:
-      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-444041: These tests fail randomly in gfx1030 MGU
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemMap_PhysicalMemoryReuse_SingleGPU:
-      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-444041: These tests fail in gfx1100 MGPU
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemMap_PhysicalMemory_Map2MultVMMs:
-      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-444041: These tests fail in gfx1100 MGPU
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemMap_PhysicalMemoryReuse_MultiDev:
-      tags: [multigpu, vmm]
       <<: *level_2
+      tags: [multigpu]
       # (amd_windows) SWDEV-444041: These tests fail in gfx1100 MGPU
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemMap_VMMMemoryReuse_SingleGPU:
-      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemMap_VMMMemoryReuse_MultiGPU:
-      tags: [multigpu, vmm]
       <<: *level_2
+      tags: [multigpu]
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemMap_MapPartialVMMMem:
-      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemMap_negative:
-      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-444041: These tests fail randomly in gfx1030 MGU
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemMap_Capture:
-      <<: *level_2
-      tags: [vmm]
+    Unit_hipMemMap_Capture: *level_2
     Unit_hipMemRelease_negative:
-      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
-    Unit_hipMemRelease_Capture:
-      <<: *level_2
-      tags: [vmm]
+    Unit_hipMemRelease_Capture: *level_2
     Unit_hipMemUnmap_negative:
-      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
-    Unit_hipMemUnmap_Capture:
-      <<: *level_2
-      tags: [vmm]
+    Unit_hipMemUnmap_Capture: *level_2
     Unit_hipMemMapArrayAsync_Positive_Basic:
-      tags: [vmm]
       <<: *level_2
       # Below tests are failing PSDB
       <<: *disabled_nvidia
   vulkan_interop:
-    Unit_hipDestroyExternalMemory_Vulkan_Negative_Parameters:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipDestroyExternalMemory_Vulkan_Capture:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipDestroyExternalSemaphore_Vulkan_Negative_Parameters:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipDestroyExternalSemaphore_Vulkan_Capture:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_With_Offset:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Negative_Parameters:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Capture:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_Device_Memory:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_With_Offset_Device_Memory:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Positive_Read_Write:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Array_Layered:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Array_Cubemap:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Negative_Parameters:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Capture:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipGraphAddExternalSemaphoresSignalNode_Positive_Basic:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Positive_Timeline_Semaphore:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Positive_Multiple_Semaphores:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Negative_Parameters:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipGraphAddExternalSemaphoresWaitNode_Positive_Basic:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Positive_Timeline_Semaphore:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Positive_Multiple_Semaphores:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Negative_Parameters:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Positive_Basic:
-      <<: *level_2
-      tags: [interop, vulkan]
+    Unit_hipDestroyExternalMemory_Vulkan_Negative_Parameters: *level_2
+    Unit_hipDestroyExternalMemory_Vulkan_Capture: *level_2
+    Unit_hipDestroyExternalSemaphore_Vulkan_Negative_Parameters: *level_2
+    Unit_hipDestroyExternalSemaphore_Vulkan_Capture: *level_2
+    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write: *level_2
+    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_With_Offset: *level_2
+    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Negative_Parameters: *level_2
+    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Capture: *level_2
+    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_Device_Memory: *level_2
+    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_With_Offset_Device_Memory: *level_2
+    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Positive_Read_Write: *level_2
+    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Array_Layered: *level_2
+    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Array_Cubemap: *level_2
+    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Negative_Parameters: *level_2
+    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Capture: *level_2
+    Unit_hipGraphAddExternalSemaphoresSignalNode_Positive_Basic: *level_2
+    Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Positive_Timeline_Semaphore: *level_2
+    Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Positive_Multiple_Semaphores: *level_2
+    Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Negative_Parameters: *level_2
+    Unit_hipGraphAddExternalSemaphoresWaitNode_Positive_Basic: *level_2
+    Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Positive_Timeline_Semaphore: *level_2
+    Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Positive_Multiple_Semaphores: *level_2
+    Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Negative_Parameters: *level_2
+    Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Positive_Basic: *level_2
     Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Timeline_Semaphore: *level_2
     Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Multiple_Semaphores: *level_2
-    Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Vulkan_Negative_Parameters:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Positive_Basic:
-      <<: *level_2
-      tags: [interop, vulkan]
+    Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Vulkan_Negative_Parameters: *level_2
+    Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Positive_Basic: *level_2
     Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Timeline_Semaphore: *level_2
     Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Multiple_Semaphores: *level_2
-    Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Vulkan_Negative_Parameters:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipGraphExternalSemaphoresSignalNodeGetParams_Negative_Parameters:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Positive_Basic:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Timeline_Semaphore:
-      <<: *level_2
-      tags: [interop, vulkan]
+    Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Vulkan_Negative_Parameters: *level_2
+    Unit_hipGraphExternalSemaphoresSignalNodeGetParams_Negative_Parameters: *level_2
+    Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Positive_Basic: *level_2
+    Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Timeline_Semaphore: *level_2
     Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Multiple_Semaphores: *level_2
-    Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Vulkan_Negative_Parameters:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipGraphExternalSemaphoresWaitNodeGetParams_Negative_Parameters:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Positive_Basic:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Timeline_Semaphore:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Multiple_Semaphores:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Negative_Parameters:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipImportExternalMemory_Vulkan_Negative_Parameters:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipImportExternalMemory_Vulkan_Capture:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipImportExternalSemaphore_Vulkan_Negative_Parameters:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipImportExternalSemaphore_Vulkan_Capture:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipSignalExternalSemaphoresAsync_Vulkan_Positive_Binary_Semaphore:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipSignalExternalSemaphoresAsync_Vulkan_Positive_Timeline_Semaphore:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipSignalExternalSemaphoresAsync_Vulkan_Positive_Multiple_Semaphores:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipSignalExternalSemaphoresAsync_Vulkan_Negative_Parameters:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipWaitExternalSemaphoresAsync_Vulkan_Positive_Binary_Semaphore:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipWaitExternalSemaphoresAsync_Vulkan_Positive_Timeline_Semaphore:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipWaitExternalSemaphoresAsync_Vulkan_Positive_Multiple_Semaphores:
-      <<: *level_2
-      tags: [interop, vulkan]
-    Unit_hipWaitExternalSemaphoresAsync_Vulkan_Negative_Parameters:
-      <<: *level_2
-      tags: [interop, vulkan]
+    Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Vulkan_Negative_Parameters: *level_2
+    Unit_hipGraphExternalSemaphoresWaitNodeGetParams_Negative_Parameters: *level_2
+    Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Positive_Basic: *level_2
+    Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Timeline_Semaphore: *level_2
+    Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Multiple_Semaphores: *level_2
+    Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Negative_Parameters: *level_2
+    Unit_hipImportExternalMemory_Vulkan_Negative_Parameters: *level_2
+    Unit_hipImportExternalMemory_Vulkan_Capture: *level_2
+    Unit_hipImportExternalSemaphore_Vulkan_Negative_Parameters: *level_2
+    Unit_hipImportExternalSemaphore_Vulkan_Capture: *level_2
+    Unit_hipSignalExternalSemaphoresAsync_Vulkan_Positive_Binary_Semaphore: *level_2
+    Unit_hipSignalExternalSemaphoresAsync_Vulkan_Positive_Timeline_Semaphore: *level_2
+    Unit_hipSignalExternalSemaphoresAsync_Vulkan_Positive_Multiple_Semaphores: *level_2
+    Unit_hipSignalExternalSemaphoresAsync_Vulkan_Negative_Parameters: *level_2
+    Unit_hipWaitExternalSemaphoresAsync_Vulkan_Positive_Binary_Semaphore: *level_2
+    Unit_hipWaitExternalSemaphoresAsync_Vulkan_Positive_Timeline_Semaphore: *level_2
+    Unit_hipWaitExternalSemaphoresAsync_Vulkan_Positive_Multiple_Semaphores: *level_2
+    Unit_hipWaitExternalSemaphoresAsync_Vulkan_Negative_Parameters: *level_2
   warp:
-    Unit_Warp_Ballot_Positive_Basic:
-      <<: *level_2
-      tags: [device_lib, warp, vote]
-    Unit_Warp_Vote_Any_Positive_Basic:
-      <<: *level_2
-      tags: [device_lib, warp, vote]
-    Unit_Warp_Vote_All_Positive_Basic:
-      <<: *level_2
-      tags: [device_lib, warp, vote]
-    Unit_hipMatchSync_All:
-      <<: *level_2
-      tags: [device_lib, warp, vote]
-    Unit_hipMatchSync_Any:
-      <<: *level_2
-      tags: [device_lib, warp, vote]
-    Unit_hipShflSync_Down:
-      <<: *level_2
-      tags: [device_lib, warp, shuffle]
-    Unit_hipShflSync_Up:
-      <<: *level_2
-      tags: [device_lib, warp, shuffle]
-    Unit_hipShflSync_Xor:
-      <<: *level_2
-      tags: [device_lib, warp, shuffle]
-    Unit_hipShflSync:
-      <<: *level_2
-      tags: [device_lib, warp, shuffle]
-    Unit_hipVoteSync_Any:
-      <<: *level_2
-      tags: [device_lib, warp, vote]
-    Unit_hipVoteSync_All:
-      <<: *level_2
-      tags: [device_lib, warp, vote]
-    Unit_hipVoteSync_Ballot:
-      <<: *level_2
-      tags: [device_lib, warp, vote]
+    Unit_Warp_Ballot_Positive_Basic: *level_2
+    Unit_Warp_Vote_Any_Positive_Basic: *level_2
+    Unit_Warp_Vote_All_Positive_Basic: *level_2
+    Unit_hipMatchSync_All: *level_2
+    Unit_hipMatchSync_Any: *level_2
+    Unit_hipShflSync_Down: *level_2
+    Unit_hipShflSync_Up: *level_2
+    Unit_hipShflSync_Xor: *level_2
+    Unit_hipShflSync: *level_2
+    Unit_hipVoteSync_Any: *level_2
+    Unit_hipVoteSync_All: *level_2
+    Unit_hipVoteSync_Ballot: *level_2
     Unit_Warp_Shfl_Positive_Basic:
       <<: *level_2
       # SWDEV-434171: Below tests took long time to complete in stress test on 17/11/23
@@ -10792,24 +6279,12 @@ unit:
       disabled: [gfx90a, gfx942, gfx950]
     Unit_hipReduceSingleMasks: *level_2
     Unit_hipReduceMultipleMasks: *level_2
-    Unit_hipReduceRandom:
-      <<: *level_2
-      tags: [device_lib, warp, reduce]
-    Unit_runTestShfl_up:
-      <<: *level_2
-      tags: [device_lib, warp, shuffle]
-    Unit_runTestShfl_Down:
-      <<: *level_2
-      tags: [device_lib, warp, shuffle]
-    Unit_runTestShfl_Xor:
-      <<: *level_2
-      tags: [device_lib, warp, shuffle]
-    Unit_hipShflTests:
-      <<: *level_2
-      tags: [device_lib, warp, shuffle]
-    Unit_hipShflUndefArgs:
-      <<: *level_2
-      tags: [device_lib, warp, shuffle]
+    Unit_hipReduceRandom: *level_2
+    Unit_runTestShfl_up: *level_2
+    Unit_runTestShfl_Down: *level_2
+    Unit_runTestShfl_Xor: *level_2
+    Unit_hipShflTests: *level_2
+    Unit_hipShflUndefArgs: *level_2
 
 ABM:
   ABM_AddKernel_MultiTypeMultiSize: *level_2

--- a/projects/hip-tests/catch/hipTestMain/config/hip_tests_config.yaml
+++ b/projects/hip-tests/catch/hipTestMain/config/hip_tests_config.yaml
@@ -17,7 +17,7 @@ definitions:
     level: 0
   level_1: &level_1
     level: 1
-  level_2: &level_2 
+  level_2: &level_2
     level: 2
   level_3: &level_3
     level: 3
@@ -60,7 +60,7 @@ cmd_options:
     memory_sizes: [1K, 1M, 10M]
     block_sizes: [64, 256]
     max_memory: 1G
-  
+
   # Level 1 - Standard Tests
   level_1:
     <<: *default_cmd_options
@@ -69,14 +69,14 @@ cmd_options:
     memory_sizes: [1K, 4K, 64K, 1M, 10M, 50M, 100M]
     block_sizes: [32, 64, 128, 256, 512, 1024]
     max_memory: 4G
-  
+
   # Level 2 - Comprehensive Tests
   level_2:
     <<: *default_cmd_options
     memory_sizes: [64, 256, 1K, 4K, 16K, 64K, 256K, 1M, 10M, 50M, 100M, 500M, 1G, 2G]
     block_sizes: [32, 64, 96, 128, 192, 256, 384, 512, 768, 1024]
     max_memory: 8G
-  
+
   # Level 5 - Performance/Stress Tests
   level_5:
     <<: *default_cmd_options
@@ -87,10 +87,13 @@ cmd_options:
 unit:
   assertion:
     Unit_StaticAssert_Positive_Basic_RTC:
+      tags: [device_lib, assert]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/210
       disabled: [amd_windows]
-    Unit_StaticAssert_Negative_Basic_RTC: *level_2
+    Unit_StaticAssert_Negative_Basic_RTC:
+      <<: *level_2
+      tags: [device_lib, assert]
     Unit_Assert_Positive_Basic_KernelPass: *level_2
     Unit_Assert_Positive_Basic_KernelFail:
       <<: *level_2
@@ -103,7 +106,9 @@ unit:
     Unit_atomicAnd_Positive_Multi_Kernel_Same_Address: *level_2
     Unit_atomicAnd_Positive_Multi_Kernel_Adjacent_Addresses: *level_2
     Unit_atomicAnd_Positive_Multi_Kernel_Scattered_Addresses: *level_2
-    Unit_atomicAnd_Negative_Parameters_RTC: *level_2
+    Unit_atomicAnd_Negative_Parameters_RTC:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, ops]
     Unit_atomicAnd_system_Positive_Peer_GPUs_Same_Address:
       <<: *level_2
       tags: [multigpu]
@@ -119,7 +124,9 @@ unit:
     Unit_atomicOr_Positive_Multi_Kernel_Same_Address: *level_2
     Unit_atomicOr_Positive_Multi_Kernel_Adjacent_Addresses: *level_2
     Unit_atomicOr_Positive_Multi_Kernel_Scattered_Addresses: *level_2
-    Unit_atomicOr_Negative_Parameters_RTC: *level_2
+    Unit_atomicOr_Negative_Parameters_RTC:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, ops]
     Unit_atomicOr_system_Positive_Peer_GPUs_Same_Address:
       <<: *level_2
       tags: [multigpu]
@@ -135,7 +142,9 @@ unit:
     Unit_atomicXor_Positive_Multi_Kernel_Same_Address: *level_2
     Unit_atomicXor_Positive_Multi_Kernel_Adjacent_Addresses: *level_2
     Unit_atomicXor_Positive_Multi_Kernel_Scattered_Addresses: *level_2
-    Unit_atomicXor_Negative_Parameters_RTC: *level_2
+    Unit_atomicXor_Negative_Parameters_RTC:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, ops]
     Unit_atomicXor_system_Positive_Peer_GPUs_Same_Address:
       <<: *level_2
       tags: [multigpu]
@@ -151,7 +160,9 @@ unit:
     Unit_atomicMin_Positive_Multi_Kernel_Same_Address: *level_2
     Unit_atomicMin_Positive_Multi_Kernel_Adjacent_Addresses: *level_2
     Unit_atomicMin_Positive_Multi_Kernel_Scattered_Addresses: *level_2
-    Unit_atomicMin_Negative_Parameters_RTC: *level_2
+    Unit_atomicMin_Negative_Parameters_RTC:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, ops]
     Unit_atomicMin_system_Positive_Peer_GPUs_Same_Address:
       <<: *level_2
       tags: [multigpu]
@@ -167,7 +178,9 @@ unit:
     Unit_atomicMax_Positive_Multi_Kernel_Same_Address: *level_2
     Unit_atomicMax_Positive_Multi_Kernel_Adjacent_Addresses: *level_2
     Unit_atomicMax_Positive_Multi_Kernel_Scattered_Addresses: *level_2
-    Unit_atomicMax_Negative_Parameters_RTC: *level_2
+    Unit_atomicMax_Negative_Parameters_RTC:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, ops]
     Unit_atomicMax_system_Positive_Peer_GPUs_Same_Address:
       <<: *level_2
       tags: [multigpu]
@@ -213,30 +226,74 @@ unit:
     Unit___hip_atomic_fetch_max_Positive_Workgroup_SameAddress: *level_2
     Unit___hip_atomic_fetch_max_Positive_Workgroup_Adjacent_Addresses: *level_2
     Unit___hip_atomic_fetch_max_Positive_Workgroup_Scattered_Addresses: *level_2
-    Unit_AtomicBuiltins_Negative_Parameters_RTC: *level_2
-    Unit___hip_atomic_load_store_Positive_Acquire_Release: *level_2
-    Unit___hip_atomic_exchange_Positive_Acquire_Release: *level_2
-    Unit___hip_atomic_compare_exchange_strong_Positive_Acquire_Release: *level_2
-    Unit___hip_atomic_compare_exchange_weak_Positive_Acquire_Release: *level_2
-    Unit___hip_atomic_fetch_add_Positive_Acquire_Release: *level_2
-    Unit___hip_atomic_fetch_and_Positive_Acquire_Release: *level_2
-    Unit___hip_atomic_fetch_or_Positive_Acquire_Release: *level_2
-    Unit___hip_atomic_fetch_xor_Positive_Acquire_Release: *level_2
-    Unit___hip_atomic_fetch_min_Positive_Acquire_Release: *level_2
-    Unit___hip_atomic_fetch_max_Positive_Acquire_Release: *level_2
-    Unit___hip_atomic_load_store_Positive_Sequential_Consistency: *level_2
-    Unit___hip_atomic_exchange_Positive_Sequential_Consistency: *level_2
-    Unit___hip_atomic_compare_exchange_strong_Positive_Sequential_Consistency: *level_2
-    Unit___hip_atomic_compare_exchange_weak_Positive_Sequential_Consistency: *level_2
-    Unit___hip_atomic_fetch_add_Positive_Sequential_Consistency: *level_2
-    Unit___hip_atomic_fetch_and_Positive_Sequential_Consistency: *level_2
-    Unit___hip_atomic_fetch_or_Positive_Sequential_Consistency: *level_2
-    Unit___hip_atomic_fetch_xor_Positive_Sequential_Consistency: *level_2
-    Unit___hip_atomic_fetch_min_Positive_Sequential_Consistency: *level_2
-    Unit___hip_atomic_fetch_max_Positive_Sequential_Consistency: *level_2
+    Unit_AtomicBuiltins_Negative_Parameters_RTC:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, builtin]
+    Unit___hip_atomic_load_store_Positive_Acquire_Release:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_exchange_Positive_Acquire_Release:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_compare_exchange_strong_Positive_Acquire_Release:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_compare_exchange_weak_Positive_Acquire_Release:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_fetch_add_Positive_Acquire_Release:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_fetch_and_Positive_Acquire_Release:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_fetch_or_Positive_Acquire_Release:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_fetch_xor_Positive_Acquire_Release:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_fetch_min_Positive_Acquire_Release:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_fetch_max_Positive_Acquire_Release:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_load_store_Positive_Sequential_Consistency:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_exchange_Positive_Sequential_Consistency:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_compare_exchange_strong_Positive_Sequential_Consistency:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_compare_exchange_weak_Positive_Sequential_Consistency:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_fetch_add_Positive_Sequential_Consistency:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_fetch_and_Positive_Sequential_Consistency:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_fetch_or_Positive_Sequential_Consistency:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_fetch_xor_Positive_Sequential_Consistency:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_fetch_min_Positive_Sequential_Consistency:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
+    Unit___hip_atomic_fetch_max_Positive_Sequential_Consistency:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, memorder]
     Unit_atomicAdd_Positive: *level_2
     Unit_atomicAdd_Positive_Multi_Kernel: *level_2
-    Unit_atomicAdd_Negative_Parameters_RTC: *level_2
+    Unit_atomicAdd_Negative_Parameters_RTC:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, ops]
     Unit_atomicAdd_system_Positive_Peer_GPUs:
       <<: *level_2
       tags: [multigpu]
@@ -251,12 +308,13 @@ unit:
     Unit_unsafeAtomicAdd_Positive: *level_2
     Unit_unsafeAtomicAdd_Positive_Multi_Kernel: *level_2
     Unit_unsafe_atomic_add_half_and_bfloat: *level_2
-    Unit_unsafe_atomic_add_half_and_bfloat: *level_2
     Unit_safeAtomicAdd_Positive: *level_2
     Unit_safeAtomicAdd_Positive_Multi_Kernel: *level_2
     Unit_atomicSub_Positive: *level_2
     Unit_atomicSub_Positive_Multi_Kernel: *level_2
-    Unit_atomicSub_Negative_Parameters_RTC: *level_2
+    Unit_atomicSub_Negative_Parameters_RTC:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, ops]
     Unit_atomicSub_system_Positive_Peer_GPUs:
       <<: *level_2
       tags: [multigpu]
@@ -268,7 +326,9 @@ unit:
       tags: [multigpu]
     Unit_atomicCAS_Positive: *level_2
     Unit_atomicCAS_Positive_Multi_Kernel: *level_2
-    Unit_atomicCAS_Negative_Parameters_RTC: *level_2
+    Unit_atomicCAS_Negative_Parameters_RTC:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, ops]
     Unit_atomicCAS_system_Positive_Peer_GPUs:
       <<: *level_2
       tags: [multigpu]
@@ -291,7 +351,9 @@ unit:
       <<: *level_2
       # SWDEV-435667: Below tests failing randomly in stress test on 01/12/23
       disabled: [amd_wsl]
-    Unit_atomicExch_Negative_Parameters_RTC: *level_2
+    Unit_atomicExch_Negative_Parameters_RTC:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, ops]
     Unit_atomicExch_system_Positive_Peer_GPUs:
       <<: *level_2
       tags: [multigpu]
@@ -307,7 +369,9 @@ unit:
       tags: [multigpu]
       # SWDEV-435667: Below tests failing randomly in stress test on 01/12/23
       disabled: [amd_wsl]
-    Unit_atomicExch_system_Negative_Parameters_RTC: *level_2
+    Unit_atomicExch_system_Negative_Parameters_RTC:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, system]
     Unit___hip_atomic_fetch_and_Positive_Wavefront_SameAddress: *level_2
     Unit___hip_atomic_fetch_and_Positive_Wavefront_Adjacent_Addresses: *level_2
     Unit___hip_atomic_fetch_and_Positive_Wavefront_Scattered_Addresses: *level_2
@@ -330,34 +394,54 @@ unit:
     Unit___hip_atomic_exchange_Positive_Workgroup: *level_2
     Unit_atomicInc_Positive: *level_2
     Unit_atomicInc_Positive_Multi_Kernel: *level_2
-    Unit_atomicInc_Negative_Parameters_RTC: *level_2
+    Unit_atomicInc_Negative_Parameters_RTC:
+      <<: *level_2
+      tags: [device_lib, device_lib, atomic, ops]
     Unit_atomicDec_Positive: *level_2
     Unit_atomicDec_Positive_Multi_Kernel: *level_2
-    Unit_atomicDec_Negative_Parameters_RTC: *level_2
-  c_compilation:
-    Unit_hipGetDeviceProp_ctest: *level_2
-  callback:
-    Unit_hipApiName_Positive_Basic: *level_2
-    Unit_hipApiName_Negative_ReservedIds: *level_2
-    Unit_hipGetStreamDeviceId_Positive_Threaded_Basic: *level_2
-    Unit_hipGetStreamDeviceId_Positive_Multithreaded_Basic:
+    Unit_atomicDec_Negative_Parameters_RTC:
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGetStreamDeviceId_Negative_Parameters: *level_2
+      tags: [device_lib, device_lib, atomic, ops]
+  c_compilation:
+    Unit_hipGetDeviceProp_ctest:
+      <<: *level_2
+      tags: [rtc, integration]
+  callback:
+    Unit_hipApiName_Positive_Basic:
+      <<: *level_2
+      tags: [callback]
+    Unit_hipApiName_Negative_ReservedIds: *level_2
+    Unit_hipGetStreamDeviceId_Positive_Threaded_Basic:
+      <<: *level_2
+      tags: [callback]
+    Unit_hipGetStreamDeviceId_Positive_Multithreaded_Basic:
+      tags: [multigpu, callback]
+      <<: *level_2
+    Unit_hipGetStreamDeviceId_Negative_Parameters:
+      <<: *level_2
+      tags: [callback]
     Unit_hipKernelNameRef_Positive_Basic:
+      tags: [callback]
       <<: *level_2
       # (amd_windows) Note: intermittent Seg fault failure
       # (amd_wsl) Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipKernelNameRef_Negative_Parameters:
+      tags: [callback]
       <<: *level_2
       # (amd_windows) Note: intermittent Seg fault failure
       # (amd_wsl) Note: intermittent Seg fault failure
       # (amd_wsl) Note: Linux disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipKernelNameRefByPtr_Positive_Basic: *level_2
-    Unit_hipKernelNameRefByPtr_Negative_StreamNullptr: *level_2
-    Unit_hipKernelNameRefByPtr_Negative_KernelNullptr: *level_2
+    Unit_hipKernelNameRefByPtr_Positive_Basic:
+      <<: *level_2
+      tags: [callback]
+    Unit_hipKernelNameRefByPtr_Negative_StreamNullptr:
+      <<: *level_2
+      tags: [callback]
+    Unit_hipKernelNameRefByPtr_Negative_KernelNullptr:
+      <<: *level_2
+      tags: [callback]
   channelDescriptor:
     Unit_ChannelDescriptor_Positive_Basic_1D:
       <<: *level_2
@@ -377,32 +461,60 @@ unit:
       disabled: [nvidia_windows]
     Unit_ChannelDescriptor_Positive_FormatNone: *level_2
     Unit_ChannelDescriptor_Positive_16BitFloatingPoint:
+      tags: [texture]
       <<: *level_2
       # (amd_wsl) Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
   clock:
     Unit_hipClock64_Positive_Basic:
+      tags: [device_lib, timing]
       <<: *level_2
       # SWDEV-555665
       disabled: [amd_windows]
     Unit_hipClock_Positive_Basic:
+      tags: [device_lib, timing]
       <<: *level_2
       # SWDEV-555665
       disabled: [amd_windows]
-    Unit_hipWallClock64_Positive_Basic: *level_2
+    Unit_hipWallClock64_Positive_Basic:
+      <<: *level_2
+      tags: [device_lib, timing]
   compiler:
-    Unit_hipClassKernel_Overload_Override: *level_2
-    Unit_hipClassKernel_Friend: *level_2
-    Unit_hipClassKernel_Empty: *level_2
-    Unit_hipClassKernel_BSize: *level_2
-    Unit_hipClassKernel_Size: *level_2
-    Unit_hipClassKernel_Virtual: *level_2
-    Unit_hipClassKernel_Value: *level_2
-    Unit_test_spirv_mode: *level_2
-    Unit_test_compressed_codeobject: *level_2
-    Unit_test_generic_target_in_compressed_fatbin: *level_2
-    Unit_test_generic_target_in_regular_fatbin: *level_2
+    Unit_hipClassKernel_Overload_Override:
+      <<: *level_2
+      tags: [rtc, integration]
+    Unit_hipClassKernel_Friend:
+      <<: *level_2
+      tags: [rtc, integration]
+    Unit_hipClassKernel_Empty:
+      <<: *level_2
+      tags: [rtc, integration]
+    Unit_hipClassKernel_BSize:
+      <<: *level_2
+      tags: [rtc, integration]
+    Unit_hipClassKernel_Size:
+      <<: *level_2
+      tags: [rtc, integration]
+    Unit_hipClassKernel_Virtual:
+      <<: *level_2
+      tags: [rtc, integration]
+    Unit_hipClassKernel_Value:
+      <<: *level_2
+      tags: [rtc, integration]
+    Unit_test_spirv_mode:
+      <<: *level_2
+      tags: [rtc, integration]
+    Unit_test_compressed_codeobject:
+      <<: *level_2
+      tags: [rtc, integration]
+    Unit_test_generic_target_in_compressed_fatbin:
+      <<: *level_2
+      tags: [rtc, integration]
+    Unit_test_generic_target_in_regular_fatbin:
+      <<: *level_2
+      tags: [rtc, integration]
     Unit_test_generic_target_only_in_compressed_fatbin:
+      tags: [rtc, integration]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
@@ -411,23 +523,53 @@ unit:
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
   complex:
-    Unit_Device_Complex_Unary_Device_Sanity_Positive: *level_2
-    Unit_Device_Complex_Unary_Host_Sanity_Positive: *level_2
-    Unit_Device_Complex_Binary_Device_Sanity_Positive: *level_2
-    Unit_Device_Complex_Binary_Host_Sanity_Positive: *level_2
-    Unit_Device_Complex_hipCfma_Device_Sanity_Positive: *level_2
-    Unit_Device_Complex_hipCfma_Host_Sanity_Positive: *level_2
-    Unit_Device_make_Complex_Device_Positive: *level_2
-    Unit_Device_make_Complex_Host_Positive: *level_2
-    Unit_Device_make_hipComplex_Device_Positive: *level_2
-    Unit_Device_make_hipComplex_Host_Positive: *level_2
-    Unit_Device_Complex_Cast_Device_Sanity_Positive: *level_2
-    Unit_Device_Complex_Cast_Host_Sanity_Positive: *level_2
-    Unit_Device_Complex_Constructor_Host: *level_2
+    Unit_Device_Complex_Unary_Device_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_Device_Complex_Unary_Host_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_Device_Complex_Binary_Device_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_Device_Complex_Binary_Host_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_Device_Complex_hipCfma_Device_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_Device_Complex_hipCfma_Host_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_Device_make_Complex_Device_Positive:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_Device_make_Complex_Host_Positive:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_Device_make_hipComplex_Device_Positive:
+      <<: *level_2
+      tags: [complex]
+    Unit_Device_make_hipComplex_Host_Positive:
+      <<: *level_2
+      tags: [complex]
+    Unit_Device_Complex_Cast_Device_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_Device_Complex_Cast_Host_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_Device_Complex_Constructor_Host:
+      <<: *level_2
+      tags: [device_lib, types]
   context:
     Unit_hipDeviceGetPCIBusId_Functional: *level_2
-    Unit_hipDrvMemcpy_Functional: *level_2
-    Unit_hipMemsetD8_Functional: *level_2
+    Unit_hipDrvMemcpy_Functional:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemsetD8_Functional:
+      <<: *level_2
+      tags: [memory, memset]
     Unit_hipDevicePrimaryCtxSetFlags_Negative: *level_2
     Unit_hipDeviceAPIs_not_supported: *level_2
     Unit_hipCtxGetSetCacheConfig_not_supported: *level_2
@@ -437,17 +579,24 @@ unit:
     hipDevicePrimaryCtxGetState_Negative: *level_2
   cooperativeGrps:
     Unit_Thread_Block_Getters_Positive_Basic:
+      tags: [cooperative, groups, cooperativeLaunch]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_Thread_Block_Getters_Via_Base_Type_Positive_Basic: *level_2
-    Unit_Thread_Block_Getters_Via_Non_Member_Functions_Positive_Basic: *level_2
+    Unit_Thread_Block_Getters_Via_Base_Type_Positive_Basic:
+      <<: *level_2
+      tags: [cooperative, groups, cooperativeLaunch]
+    Unit_Thread_Block_Getters_Via_Non_Member_Functions_Positive_Basic:
+      <<: *level_2
+      tags: [cooperative, groups, cooperativeLaunch]
     Unit_Thread_Block_Sync_Positive_Basic: *level_2
     Unit_Thread_Block_Tile_Getters_Positive_Basic:
+      tags: [cooperative, groups, cooperativeLaunch]
       <<: *level_2
       # SWDEV-441604: Below tests take long time to run in stress test on 12/01/24
       disabled: [amd_windows]
     Unit_Thread_Block_Tile_Dynamic_Getters_Positive_Basic:
+      tags: [cooperative, groups, cooperativeLaunch]
       <<: *level_2
       # SWDEV-441604: Below tests take long time to run in stress test on 12/01/24
       disabled: [amd_windows]
@@ -472,6 +621,7 @@ unit:
       # Below tests hang in Jenkins PSDB
       disabled: [amd_windows]
     Unit_Coalesced_Group_Tiled_Partition_Getters_Positive_Basic:
+      tags: [cooperative, groups, cooperativeLaunch]
       <<: *level_2
       # SWDEV-486448 - Following tests disabled due to taking too much time to execute, ~700s per test
       disabled: [amd_windows]
@@ -488,51 +638,74 @@ unit:
       <<: *level_2
       # (amd_linux) Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/210
       disabled: [amd_linux, amd_windows]
-    Unit_hipCGThreadBlockType: *level_2
+    Unit_hipCGThreadBlockType:
+      <<: *level_2
+      tags: [cooperative, groups, cooperativeLaunch]
     Unit_hipCGMultiGridGroupType_Basic:
+      tags: [multigpu, cooperative, groups, cooperativeLaunch]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipCGMultiGridGroupType_Barrier:
+      tags: [multigpu, cooperative, groups, cooperativeLaunch]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipCGGridGroupType_Basic: *level_2
-    Unit_hipCGGridGroupType_DataSharing: *level_2
-    Unit_hipCGGridGroupType_Barrier: *level_2
-    Unit_hipCGThreadBlockTileType: *level_2
-    Unit_hipCGThreadBlockTileType_Shfl: *level_2
+    Unit_hipCGGridGroupType_Basic:
+      <<: *level_2
+      tags: [cooperative, groups, cooperativeLaunch]
+    Unit_hipCGGridGroupType_DataSharing:
+      <<: *level_2
+      tags: [cooperative, groups, cooperativeLaunch]
+    Unit_hipCGGridGroupType_Barrier:
+      <<: *level_2
+      tags: [cooperative, groups, cooperativeLaunch]
+    Unit_hipCGThreadBlockTileType:
+      <<: *level_2
+      tags: [cooperative, groups, cooperativeLaunch]
+    Unit_hipCGThreadBlockTileType_Shfl:
+      <<: *level_2
+      tags: [cooperative, ops, cooperativeLaunch]
     Unit_coalesced_groups:
+      tags: [cooperative, groups, cooperativeLaunch]
       <<: *level_2
       # Below tests hang in Jenkins PSDB
       disabled: [amd_windows]
-    Unit_hipLaunchCooperativeKernel_Basic: *level_2
+    Unit_hipLaunchCooperativeKernel_Basic:
+      <<: *level_2
+      tags: [cooperative, launch, cooperativeLaunch]
     Unit_hipLaunchCooperativeKernelMultiDevice_Basic:
+      tags: [multigpu, cooperative, launch, cooperativeLaunch]
       <<: *level_2
-      tags: [multigpu]
     Unit_Multi_Grid_Group_Getters_Positive_Basic:
+      tags: [multigpu, cooperative, groups, cooperativeLaunch]
       <<: *level_2
-      tags: [multigpu]
     Unit_Multi_Grid_Group_Getters_Positive_Base_Type:
+      tags: [multigpu, cooperative, groups, cooperativeLaunch]
       <<: *level_2
-      tags: [multigpu]
     Unit_Multi_Grid_Group_Getters_Positive_Non_Member_Functions:
+      tags: [multigpu, cooperative, groups, cooperativeLaunch]
       <<: *level_2
-      tags: [multigpu]
     Unit_Multi_Grid_Group_Positive_Sync:
+      tags: [multigpu, cooperative, groups, cooperativeLaunch]
       <<: *level_2
-      tags: [multigpu]
       # SWDEV-443630 : Below test failed in stress test on 19/01/24
       disabled: [gfx90a, gfx942, gfx950]
     Unit_coalesced_groups_shfl_down:
+      tags: [cooperative, ops, cooperativeLaunch]
       <<: *level_2
       # Below tests hang in Jenkins PSDB
       disabled: [amd_windows]
     Unit_coalesced_groups_shfl_up:
+      tags: [cooperative, ops, cooperativeLaunch]
       <<: *level_2
       # Below tests hang in Jenkins PSDB
       disabled: [amd_windows]
-    Unit_Coalesced_Group_Getters_Positive_Basic: *level_2
-    Unit_Coalesced_Group_Getters_Via_Base_Type_Positive_Basic: *level_2
-    Unit_Coalesced_Group_Getters_Via_Non_Member_Functions_Positive_Basic: *level_2
+    Unit_Coalesced_Group_Getters_Positive_Basic:
+      <<: *level_2
+      tags: [cooperative, groups, cooperativeLaunch]
+    Unit_Coalesced_Group_Getters_Via_Base_Type_Positive_Basic:
+      <<: *level_2
+      tags: [cooperative, groups, cooperativeLaunch]
+    Unit_Coalesced_Group_Getters_Via_Non_Member_Functions_Positive_Basic:
+      <<: *level_2
+      tags: [cooperative, groups, cooperativeLaunch]
     Unit_Coalesced_Group_Shfl_Up_Positive_Basic:
       <<: *level_2
       # SWDEV-438524: Below tests taking long time to run in stress test on 15/12/23
@@ -549,237 +722,431 @@ unit:
       <<: *level_2
       # SWDEV-434171: Below tests took long time to complete in stress test on 17/11/23
       disabled: [amd_windows]
-    Unit_Grid_Group_Getters_Positive_Basic: *level_2
-    Unit_Grid_Group_Getters_Via_Non_Member_Functions_Positive_Basic: *level_2
-    Unit_Grid_Group_Sync_Positive_Basic: *level_2
-    Unit_tiled_groups_metagrp_basic: *level_2
-    Unit_coalesced_groups_metagrp_basic: *level_2
-    Unit_cg_binary_part: *level_2
-    Unit_coopgroups_ballot: *level_2
-    Unit_binary_part_ballot: *level_2
-    Unit_coopgroups_any: *level_2
-    Unit_coopgroups_coal_all: *level_2
-    Unit_coopgroups_match_any_coal: *level_2
-    Unit_coopgroups_match_all_coal: *level_2
+    Unit_Grid_Group_Getters_Positive_Basic:
+      <<: *level_2
+      tags: [cooperative, groups, cooperativeLaunch]
+    Unit_Grid_Group_Getters_Via_Non_Member_Functions_Positive_Basic:
+      <<: *level_2
+      tags: [cooperative, groups, cooperativeLaunch]
+    Unit_Grid_Group_Sync_Positive_Basic:
+      <<: *level_2
+      tags: [cooperative, groups, cooperativeLaunch]
+    Unit_tiled_groups_metagrp_basic:
+      <<: *level_2
+      tags: [cooperative, groups, cooperativeLaunch]
+    Unit_coalesced_groups_metagrp_basic:
+      <<: *level_2
+      tags: [cooperative, groups, cooperativeLaunch]
+    Unit_cg_binary_part:
+      <<: *level_2
+      tags: [cooperative, ops, cooperativeLaunch]
+    Unit_coopgroups_ballot:
+      <<: *level_2
+      tags: [cooperative, ops, cooperativeLaunch]
+    Unit_binary_part_ballot:
+      <<: *level_2
+      tags: [cooperative, ops, cooperativeLaunch]
+    Unit_coopgroups_any:
+      <<: *level_2
+      tags: [cooperative, ops, cooperativeLaunch]
+    Unit_coopgroups_coal_all:
+      <<: *level_2
+      tags: [cooperative, ops, cooperativeLaunch]
+    Unit_coopgroups_match_any_coal:
+      <<: *level_2
+      tags: [cooperative, ops, cooperativeLaunch]
+    Unit_coopgroups_match_all_coal:
+      <<: *level_2
+      tags: [cooperative, ops, cooperativeLaunch]
   device:
-    # Example tests demonstrating level-based parameter system
-    # ONE test with multiple level tags - parameters adapt based on which level you run
-    Unit_hipDeviceMemAlloc_Functional:
-      level: 0
-      tags: [level_0, level_1, level_2, device, memory]
-    Unit_hipDeviceMemAlloc_MultiDevice:
-      level: 0
-      tags: [level_0, level_1, level_2, device, memory, multigpu]
-    Unit_hipDeviceMemAlloc_VerifyLevelConfig:
+    Unit_hipChooseDevice_ValidateDevId:
       <<: *level_2
-      tags: [.verify, config]
-    Unit_hipChooseDevice_ValidateDevId: *level_2
-    Unit_hipChooseDevice_NegTst: *level_2
-    Unit_hipDeviceComputeCapability_Negative: *level_2
-    Unit_hipDeviceComputeCapability_ValidateVersion: *level_2
-    Unit_hipDeviceGetByPCIBusId_Functional: *level_2
-    Unit_hipDeviceGetByPCIBusId_NegativeNullChk: *level_2
-    Unit_hipDeviceGetByPCIBusId_NegativeInputString: *level_2
-    Unit_hipDeviceGetByPCIBusId_WrongBusID: *level_2
-    Unit_hipDeviceGetLimit_NegTst: *level_2
-    Unit_hipDeviceGetLimit_CheckValidityOfOutputVal: *level_2
-    Unit_hipDeviceGetName_NegTst: *level_2
-    Unit_hipDeviceGetName_CheckPropName: *level_2
-    Unit_hipDeviceGetName_PartialFill: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipChooseDevice_NegTst:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceComputeCapability_Negative:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceComputeCapability_ValidateVersion:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceGetByPCIBusId_Functional:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceGetByPCIBusId_NegativeNullChk:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceGetByPCIBusId_NegativeInputString:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceGetByPCIBusId_WrongBusID:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceGetLimit_NegTst:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceGetLimit_CheckValidityOfOutputVal:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceGetName_NegTst:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceGetName_CheckPropName:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceGetName_PartialFill:
+      <<: *level_2
+      tags: [device_mgmt, query]
     Unit_hipDeviceName_gcnArchName_And_rocm_agent_enumerator:
+      tags: [device_mgmt, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipDeviceGetPCIBusId_Check_PciBusID_WithAttr: *level_2
+    Unit_hipDeviceGetPCIBusId_Check_PciBusID_WithAttr:
+      <<: *level_2
+      tags: [device_mgmt, query]
     Unit_hipDeviceGetPCIBusId_Negative_PartialFill:
+      tags: [device_mgmt, query]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       disabled: [amd_windows, amd_wsl]
-    Unit_hipDeviceGetPCIBusId_NegTst: *level_2
-    Unit_hipDeviceSetCacheConfig_Positive_Basic: *level_2
-    Unit_hipDeviceGetCacheConfig_Positive_Default: *level_2
-    Unit_hipDeviceSynchronize_Positive_Empty_Streams: *level_2
+    Unit_hipDeviceGetPCIBusId_NegTst:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceSetCacheConfig_Positive_Basic:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceGetCacheConfig_Positive_Default:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceSynchronize_Positive_Empty_Streams:
+      <<: *level_2
+      tags: [device_mgmt, sync]
     Unit_hipDeviceSynchronize_Positive_Nullstream:
+      tags: [device_mgmt, sync]
       <<: *level_2
       # Disabling tests which no longer behave the same on nvidia platform
       disabled: [nvidia_windows]
     Unit_hipDeviceSynchronize_Functional:
+      tags: [device_mgmt, sync]
       <<: *level_2
       # Disabling tests which no longer behave the same on nvidia platform
       disabled: [nvidia_windows]
-    Unit_hipDeviceTotalMem_NegTst: *level_2
-    Unit_hipDeviceTotalMem_ValidateTotalMem: *level_2
-    Unit_hipDeviceTotalMem_NonSelectedDevice:
+    Unit_hipDeviceTotalMem_NegTst:
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGetDeviceAttribute_CheckAttrValues: *level_2
-    Unit_hipDeviceGetAttribute_NegTst: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceTotalMem_ValidateTotalMem:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceTotalMem_NonSelectedDevice:
+      tags: [device_mgmt, query, multigpu]
+      <<: *level_2
+    Unit_hipGetDeviceAttribute_CheckAttrValues:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceGetAttribute_NegTst:
+      <<: *level_2
+      tags: [device_mgmt, query]
     Print_Out_Attributes: *level_2
-    Unit_hipGetDeviceAttribute_hipDevAttrHostRegisterSupported: *level_2
-    Unit_hipGetDeviceCount_NegTst: *level_2
-    Unit_hipGetDeviceCount_HideDevices: *level_2
+    Unit_hipGetDeviceAttribute_hipDevAttrHostRegisterSupported:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipGetDeviceCount_NegTst:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipGetDeviceCount_HideDevices:
+      <<: *level_2
+      tags: [device_mgmt, query]
     Print_Out_Device_Count: *level_2
     Unit_hipGetDeviceProperties_ArchPropertiesTst:
+      tags: [device_mgmt, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGetDeviceProperties_NegTst: *level_2
+    Unit_hipGetDeviceProperties_NegTst:
+      <<: *level_2
+      tags: [device_mgmt, query]
     Print_Out_Properties: *level_2
     Print_Out_Properties_6_0: *level_2
-    Unit_hipRuntimeGetVersion_Positive: *level_2
-    Unit_hipRuntimeGetVersion_Negative: *level_2
-    Unit_hipGetSetDeviceFlags_NullptrFlag: *level_2
-    Unit_hipGetSetDeviceFlags_ValidFlag: *level_2
-    Unit_hipGetSetDeviceFlags_SetThenGet: *level_2
-    Unit_hipGetSetDeviceFlags_Threaded: *level_2
+    Unit_hipRuntimeGetVersion_Positive:
+      <<: *level_2
+      tags: [device_mgmt, init]
+    Unit_hipRuntimeGetVersion_Negative:
+      <<: *level_2
+      tags: [device_mgmt, init]
+    Unit_hipGetSetDeviceFlags_NullptrFlag:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipGetSetDeviceFlags_ValidFlag:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipGetSetDeviceFlags_SetThenGet:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipGetSetDeviceFlags_Threaded:
+      <<: *level_2
+      tags: [device_mgmt, config]
     Unit_hipGetDeviceFlags_Positive_Context:
+      tags: [device_mgmt, config]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGetSetDeviceFlags_InvalidFlag: *level_2
+    Unit_hipGetSetDeviceFlags_InvalidFlag:
+      <<: *level_2
+      tags: [device_mgmt, config]
     Unit_hipSetDevice_BasicSetGet:
+      tags: [device_mgmt, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGetSetDevice_MultiThreaded:
+      tags: [device_mgmt, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipSetGetDevice_Positive_Threaded_Basic:
+      tags: [device_mgmt, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipSetGetDevice_Negative: *level_2
-    Unit_hipDeviceGet_Negative: *level_2
+    Unit_hipSetGetDevice_Negative:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceGet_Negative:
+      <<: *level_2
+      tags: [device_mgmt, query]
     Unit_hipDeviceGetUuid_Positive:
+      tags: [device_mgmt, query]
       <<: *level_2
       # (amd_windows) Note: UUID returned empty on some windows nodes
       # (amd_wsl) Note: UUID returned empty on some windows nodes
       disabled: [amd_windows, amd_wsl]
-    Unit_hipDeviceGetUuid_Negative: *level_2
+    Unit_hipDeviceGetUuid_Negative:
+      <<: *level_2
+      tags: [device_mgmt, query]
     Unit_hipDeviceGetUuid_From_RocmInfo:
+      tags: [device_mgmt, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipDeviceGetUuid_VerifyUuidFrm_hipGetDeviceProperties:
+      tags: [device_mgmt, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES:
+      tags: [device_mgmt, query]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_UUID_setEnv_Thread:
+      tags: [device_mgmt, query]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipDeviceAPUCheck: *level_2
-    Unit_hipDeviceGetDefaultMemPool_Positive_Basic: *level_2
-    Unit_hipDeviceGetDefaultMemPool_Negative_Parameters: *level_2
-    Unit_hipDeviceCanAccessPeer_positive: *level_2
-    Unit_hipDeviceCanAccessPeer_negative: *level_2
+    Unit_hipDeviceAPUCheck:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceGetDefaultMemPool_Positive_Basic:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceGetDefaultMemPool_Negative_Parameters:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipDeviceCanAccessPeer_positive:
+      <<: *level_2
+      tags: [device_mgmt]
+    Unit_hipDeviceCanAccessPeer_negative:
+      <<: *level_2
+      tags: [device_mgmt]
     Unit_hipDeviceEnableDisablePeerAccess_positive:
+      tags: [device_mgmt, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipDeviceEnablePeerAccess_negative:
+      tags: [device_mgmt, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipDeviceDisablePeerAccess_negative:
+      tags: [device_mgmt, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipExtGetLinkTypeAndHopCount_Positive_Basic: *level_2
-    Unit_hipExtGetLinkTypeAndHopCount_Negative_Parameters: *level_2
+    Unit_hipExtGetLinkTypeAndHopCount_Positive_Basic:
+      <<: *level_2
+      tags: [device_mgmt, query]
+    Unit_hipExtGetLinkTypeAndHopCount_Negative_Parameters:
+      <<: *level_2
+      tags: [device_mgmt, query]
     Unit_hipDeviceSetLimit_SetGet:
+      tags: [device_mgmt, config, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipDeviceSetLimit_Positive_StackSize: *level_2
-    Unit_hipDeviceSetLimit_Positive_PrintfFifoSize: *level_2
-    Unit_hipDeviceSetLimit_Negative_PrintfFifoSize: *level_2
-    Unit_hipDeviceSetLimit_Positive_MallocHeapSize: *level_2
-    Unit_hipDeviceSetLimit_Negative_MallocHeapSize: *level_2
+    Unit_hipDeviceSetLimit_Positive_StackSize:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceSetLimit_Positive_PrintfFifoSize:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceSetLimit_Negative_PrintfFifoSize:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceSetLimit_Positive_MallocHeapSize:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceSetLimit_Negative_MallocHeapSize:
+      <<: *level_2
+      tags: [device_mgmt, config]
     Unit_hipDeviceSetLimit_Negative_Parameters:
+      tags: [device_mgmt, config]
       <<: *level_2
       # Below 2 tests are disabled due to defect EXSWHTEC-342
       disabled: [nvidia_windows]
     Unit_hipDeviceGetLimit_Negative_Parameters:
+      tags: [device_mgmt, config]
       <<: *level_2
       # Below 2 tests are disabled due to defect EXSWHTEC-342
       disabled: [nvidia_windows]
-    Unit_hipDeviceGetSetLimit_Scratch_Negative: *level_2
-    Unit_hipDeviceGetSetLimit_Scratch_SetMinAndMaxAsCurrent: *level_2
-    Unit_hipDeviceGetSetLimit_Scratch_DecreaseIncrease: *level_2
-    Unit_hipDeviceGetSetLimit_Scratch_SetBeforeKernelLaunch: *level_2
-    Unit_hipDeviceGetSetLimit_Scratch_MultiDevice:
+    Unit_hipDeviceGetSetLimit_Scratch_Negative:
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipDeviceGetSetLimit_Scratch_InThread: *level_2
-    Unit_hipDeviceGetSetLimit_Scratch_InChildProcess: *level_2
-    Unit_hipDeviceGetSetLimit_Scratch_SetGetThreads: *level_2
-    Unit_hipDeviceSetSharedMemConfig_Positive_Basic: *level_2
-    Unit_hipDeviceSetSharedMemConfig_Negative_Parameters: *level_2
-    Unit_hipDeviceGetSharedMemConfig_Positive_Default: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceGetSetLimit_Scratch_SetMinAndMaxAsCurrent:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceGetSetLimit_Scratch_DecreaseIncrease:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceGetSetLimit_Scratch_SetBeforeKernelLaunch:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceGetSetLimit_Scratch_MultiDevice:
+      tags: [device_mgmt, config, multigpu]
+      <<: *level_2
+    Unit_hipDeviceGetSetLimit_Scratch_InThread:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceGetSetLimit_Scratch_InChildProcess:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceGetSetLimit_Scratch_SetGetThreads:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceSetSharedMemConfig_Positive_Basic:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceSetSharedMemConfig_Negative_Parameters:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceGetSharedMemConfig_Positive_Default:
+      <<: *level_2
+      tags: [device_mgmt, config]
     Unit_hipDeviceGetSharedMemConfig_Positive_Basic:
+      tags: [device_mgmt, config]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Linux disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipDeviceGetSharedMemConfig_Positive_Threaded:
+      tags: [device_mgmt, config]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Linux disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipDeviceGetSharedMemConfig_Negative_Parameters: *level_2
+    Unit_hipDeviceGetSharedMemConfig_Negative_Parameters:
+      <<: *level_2
+      tags: [device_mgmt, config]
     Unit_hipDeviceReset_Positive_Basic:
+      tags: [device_mgmt, sync]
       <<: *level_2
       # (amd_wsl) Note: Windows disabled
       # (nvidia_windows) Disabling tests which no longer behave the same on nvidia platform
       disabled: [amd_wsl, nvidia_windows]
     Unit_hipDeviceReset_Positive_Threaded:
+      tags: [device_mgmt, sync]
       <<: *level_2
       # (amd_wsl) Note: Windows disabled
       # (nvidia_windows) Disabling tests which no longer behave the same on nvidia platform
       disabled: [amd_wsl, nvidia_windows]
-    Unit_hipDeviceSetMemPool_Positive_Basic: *level_2
-    Unit_hipDeviceSetMemPool_Negative_Parameters: *level_2
-    Unit_hipDeviceGetMemPool_Positive_Default: *level_2
-    Unit_hipDeviceGetMemPool_Positive_Basic: *level_2
-    Unit_hipDeviceGetMemPool_Positive_Threaded: *level_2
-    Unit_hipDeviceGetMemPool_Negative_Parameters: *level_2
-    Unit_hipInit_Positive: *level_2
+    Unit_hipDeviceSetMemPool_Positive_Basic:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceSetMemPool_Negative_Parameters:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceGetMemPool_Positive_Default:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceGetMemPool_Positive_Basic:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceGetMemPool_Positive_Threaded:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipDeviceGetMemPool_Negative_Parameters:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipInit_Positive:
+      <<: *level_2
+      tags: [device_mgmt, init]
     Unit_hipInit_Negative:
+      tags: [device_mgmt, init]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipDriverGetVersion_Positive: *level_2
-    Unit_hipDriverGetVersion_Negative: *level_2
-    Unit_hipSetValidDevices_Negative: *level_2
-    Unit_hipSetValidDevices_Negative_Length_Lessthan_DeviceArrSize: *level_2
+    Unit_hipDriverGetVersion_Positive:
+      <<: *level_2
+      tags: [device_mgmt, init]
+    Unit_hipDriverGetVersion_Negative:
+      <<: *level_2
+      tags: [device_mgmt, init]
+    Unit_hipSetValidDevices_Negative:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipSetValidDevices_Negative_Length_Lessthan_DeviceArrSize:
+      <<: *level_2
+      tags: [device_mgmt, config]
     Unit_hipSetValidDevices_Positive_Basic:
+      tags: [device_mgmt, config, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipSetValidDevices_WithAllDevicesInSystem: *level_2
-    Unit_hipSetValidDevices_Positive_Cases: *level_2
-    Unit_hipSetValidDevices_MultiProcess: *level_2
-    Unit_hipSetValidDevices_MultiThread: *level_2
-    Unit_hipSetValidDevices_with_hipMemcpyPeer: *level_2
-    Unit_hipGetProcAddress_ValidateDeviceApis: *level_2
+    Unit_hipSetValidDevices_WithAllDevicesInSystem:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipSetValidDevices_Positive_Cases:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipSetValidDevices_MultiProcess:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipSetValidDevices_MultiThread:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipSetValidDevices_with_hipMemcpyPeer:
+      <<: *level_2
+      tags: [device_mgmt, config]
+    Unit_hipGetProcAddress_ValidateDeviceApis:
+      <<: *level_2
+      tags: [device_mgmt]
     Unit_hipGetProcAddress_PeerDeviceAccessAPIs:
+      tags: [device_mgmt, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGetProcAddress_SetGetMemPoolAPIs:
+      tags: [device_mgmt, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGetDriverEntryPoint_Positive: *level_2
-    Unit_hipGetDriverEntryPoint_Negative: *level_2
-    Unit_hipGetDriverEntryPoint_spt_Positive: *level_2
-    Unit_hipGetDriverEntryPoint_spt_Negative: *level_2
-    Unit_hipGetProcAddress_IPC_Memory: *level_2
-    Unit_hipGetProcAddress_IPC_Event: *level_2
+    Unit_hipGetDriverEntryPoint_Positive:
+      <<: *level_2
+      tags: [device_mgmt]
+    Unit_hipGetDriverEntryPoint_Negative:
+      <<: *level_2
+      tags: [device_mgmt]
+    Unit_hipGetDriverEntryPoint_spt_Positive:
+      <<: *level_2
+      tags: [device_mgmt]
+    Unit_hipGetDriverEntryPoint_spt_Negative:
+      <<: *level_2
+      tags: [device_mgmt]
+    Unit_hipGetProcAddress_IPC_Memory:
+      <<: *level_2
+      tags: [device_mgmt]
+    Unit_hipGetProcAddress_IPC_Event:
+      <<: *level_2
+      tags: [device_mgmt]
     Unit_hipIpcOpenMemHandle_Negative_Open_In_Creating_Process:
+      tags: [device_mgmt]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_wsl]
     Unit_hipIpcOpenMemHandle_Negative_Open_In_Two_Contexts_Same_Device:
+      tags: [device_mgmt]
       <<: *level_2
       # (amd_linux) SWDEV-511679 : Below tests fail in stress test
       # (amd_wsl) Note: hsa_amd_ipc_ is dummy
       disabled: [amd_linux, amd_wsl]
     Unit_hipIpcGetMemHandle_Positive_Unique_Handles_Separate_Allocations:
+      tags: [device_mgmt]
       <<: *level_2
       # Note: Test disabled due to defect - EXSWHTEC-207
       disabled: [amd_wsl]
@@ -787,14 +1154,20 @@ unit:
       <<: *level_2
       # Note: hsa_amd_ipc_ is dummy
       disabled: [amd_wsl]
-    Unit_hipIpcGetMemHandle_Negative_Handle_For_Freed_Memory: *level_2
-    Unit_hipIpcGetMemHandle_Negative_Out_Of_Bound_Pointer: *level_2
+    Unit_hipIpcGetMemHandle_Negative_Handle_For_Freed_Memory:
+      <<: *level_2
+      tags: [device_mgmt]
+    Unit_hipIpcGetMemHandle_Negative_Out_Of_Bound_Pointer:
+      <<: *level_2
+      tags: [device_mgmt]
     Unit_hipIpcCloseMemHandle_Positive_Reference_Counting:
+      tags: [device_mgmt]
       <<: *level_2
       # (amd_linux) SWDEV-511679 : Below tests fail in stress test
       # (amd_wsl) Note: hsa_amd_ipc_ is dummy
       disabled: [amd_linux, amd_wsl]
     Unit_hipIpcCloseMemHandle_Negative_Close_In_Originating_Process:
+      tags: [device_mgmt]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_wsl]
@@ -803,248 +1176,495 @@ unit:
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_Device_memcpy_Negative_Parameters_RTC: *level_2
-    Unit_Device_memset_Positive: *level_2
-    Unit_Device_memset_Negative_Parameters_RTC: *level_2
-  deviceLib:
-    Unit_deviceFunctions_CompileTest: *level_2
-    Unit_AnyAll_CompileTest: *level_2
-    Unit_ballot: *level_2
-    Unit_clz: *level_2
-    Unit_ffs: *level_2
-    Unit_funnelshift: *level_2
-    Unit_brev: *level_2
-    Unit_popc: *level_2
-    Unit_ldg: *level_2
-    Unit_threadfence_system:
+    Unit_Device_memcpy_Negative_Parameters_RTC:
       <<: *level_2
-      tags: [multigpu]
-    Unit_syncthreads_and: *level_2
-    Unit_syncthreads_count: *level_2
-    Unit_syncthreads_or: *level_2
+      tags: [device_lang]
+    Unit_Device_memset_Positive: *level_2
+    Unit_Device_memset_Negative_Parameters_RTC:
+      <<: *level_2
+      tags: [device_lang]
+  deviceLib:
+    Unit_deviceFunctions_CompileTest:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_AnyAll_CompileTest:
+      <<: *level_2
+      tags: [device_lib, warp]
+    Unit_ballot:
+      <<: *level_2
+      tags: [device_lib, warp]
+    Unit_clz:
+      <<: *level_2
+      tags: [device_lib, bitops]
+    Unit_ffs:
+      <<: *level_2
+      tags: [device_lib, bitops]
+    Unit_funnelshift:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_brev:
+      <<: *level_2
+      tags: [device_lib, bitops]
+    Unit_popc:
+      <<: *level_2
+      tags: [device_lib, bitops]
+    Unit_ldg:
+      <<: *level_2
+      tags: [device_lib, bitops]
+    Unit_threadfence_system:
+      tags: [multigpu, device_lib]
+      <<: *level_2
+    Unit_syncthreads_and:
+      <<: *level_2
+      tags: [device_lib, sync]
+    Unit_syncthreads_count:
+      <<: *level_2
+      tags: [device_lib, sync]
+    Unit_syncthreads_or:
+      <<: *level_2
+      tags: [device_lib, sync]
     Unit_deviceAllocation_Malloc_PerThread_PrimitiveDataType:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_New_PerThread_PrimitiveDataType:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_Malloc_PerThread_StructDataType:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_New_PerThread_StructDataType:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_InOneThread_AccessInAllThreads:
+      tags: [device_lib, memory]
       <<: *level_2
       # (amd_windows) Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # (amd_windows) all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       # (amd_wsl) SWDEV-427101:Below test fails randomly in PSDB
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_Malloc_AcrossKernels:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_New_AcrossKernels:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_Malloc_ComplexDataType:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows]
     Unit_deviceAllocation_New_ComplexDataType:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_Malloc_UnionType:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_New_UnionType:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_Malloc_SingleCodeObj:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_New_SingleCodeObj:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_deviceAllocation_Malloc_PerThread_MultKerMultStrm: *level_2
-    Unit_deviceAllocation_New_PerThread_MultKerMultStrm: *level_2
+    Unit_deviceAllocation_Malloc_PerThread_MultKerMultStrm:
+      <<: *level_2
+      tags: [device_lib, memory]
+    Unit_deviceAllocation_New_PerThread_MultKerMultStrm:
+      <<: *level_2
+      tags: [device_lib, memory]
     Unit_deviceAllocation_Malloc_PerThread_Graph:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_New_PerThread_Graph:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: this tests were disabled because some seemed to hang the machine on Windows with Navi32;
       # all the ones calling TestMemoryAcrossMulKernels()/TestMemoryAcrossMulKernelsUsingGraph() were disabled
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_Malloc_DeviceFunc:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_New_DeviceFunc:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_VirtualFunction:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_Malloc_MulKernels_MulThreads:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_New_MulKernels_MulThreads:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
-    Unit_deviceAllocation_Malloc_SingKernels_MulThreads: *level_2
-    Unit_deviceAllocation_New_SingKernels_MulThreads: *level_2
+    Unit_deviceAllocation_Malloc_SingKernels_MulThreads:
+      <<: *level_2
+      tags: [device_lib, memory]
+    Unit_deviceAllocation_New_SingKernels_MulThreads:
+      <<: *level_2
+      tags: [device_lib, memory]
     Unit_deviceAllocation_Malloc_MulCodeObj:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
     Unit_deviceAllocation_New_MulCodeObj:
+      tags: [device_lib, memory]
       <<: *level_2
       # Note: devicelib hangs and failures
       disabled: [amd_windows, amd_wsl]
-    Unit_AtomicFunctions_Inc: *level_2
-    Unit_AtomicFunctions_Dec: *level_2
-    Unit_DoublePrecisionIntrinsics: *level_2
-    Unit_DoublePrecisionMathDevice: *level_2
-    Unit_DoublePrecisionMathHost: *level_2
-    Unit_FloatMathPrecise: *level_2
-    Unit_IntegerIntrinsics: *level_2
-    Unit_SinglePrecisionIntrinsics: *level_2
-    Unit_SinglePrecisionMathDevice: *level_2
-    Unit_SinglePrecisionMathHost: *level_2
-    Unit_SimpleAtomicsTest: *level_2
-    Unit_hipTestAtomicAdd: *level_2
-    Unit_StdComplex: *level_2
-    Unit_hipTestClock: *level_2
-    Unit_kernel_trigger: *level_2
-    Unit_ToAndFroMemCpyToDevice: *level_2
-    Unit_TestIncludeMathPreciseFloat: *level_2
-    Unit_hipTestDotFunctions: *level_2
-    Unit_hipMemcpyToSymbolAsync_ToNFrom: *level_2
-    Unit_hipGetSymbolAddressAndSize_Validation: *level_2
-    Unit_hipGetSymbolAddress_Negative: *level_2
-    Unit_hipGetSymbolSize_Negative: *level_2
-    Unit_hipTest_DeviceNewOperator: *level_2
-    Unit_hipThreadFence: *level_2
-    Unit_hipDeviceTrigFunc_Float: *level_2
-    Unit_hipTestDeviceLimit_Basic: *level_2
-    Unit_hipTrigDeviceFunc_Double: *level_2
-    Unit_TestDevice_DoublePrecisionMathFunc: *level_2
-    Unit_hadd_int_varaint: *level_2
-    Unit_rhadd_int_varaint: *level_2
-    Unit_uhadd_int_varaint: *level_2
-    Unit_urhadd_int_varaint: *level_2
-    Unit_unsafeAtomicAdd: *level_2
-    Unit_mbcnt: *level_2
-    Unit_bitExtract: *level_2
-    Unit_bitInsert: *level_2
-    Unit_floatTM: *level_2
-    Unit_abs_int64_Verification: *level_2
-    Unit_pown_Verification: *level_2
-    Unit_hmax_hmin_Tsts: *level_2
-    Unit_hmax_hmin_Tsts_Negative: *level_2
-    Unit_hmax_hmin_Tsts_With_Array: *level_2
-    Unit_hipBfloat16: *level_2
-    Unit_hipVectorTypes_test_on_host: *level_2
+    Unit_AtomicFunctions_Inc:
+      <<: *level_2
+      tags: [device_lib, atomic]
+    Unit_AtomicFunctions_Dec:
+      <<: *level_2
+      tags: [device_lib, atomic]
+    Unit_DoublePrecisionIntrinsics:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_DoublePrecisionMathDevice:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_DoublePrecisionMathHost:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_FloatMathPrecise:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_IntegerIntrinsics:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_SinglePrecisionIntrinsics:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_SinglePrecisionMathDevice:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_SinglePrecisionMathHost:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_SimpleAtomicsTest:
+      <<: *level_2
+      tags: [device_lib, atomic]
+    Unit_hipTestAtomicAdd:
+      <<: *level_2
+      tags: [device_lib, atomic]
+    Unit_StdComplex:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_hipTestClock:
+      <<: *level_2
+      tags: [device_lib, misc]
+    Unit_kernel_trigger:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_ToAndFroMemCpyToDevice:
+      <<: *level_2
+      tags: [device_lib, memory]
+    Unit_TestIncludeMathPreciseFloat:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_hipTestDotFunctions:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_hipMemcpyToSymbolAsync_ToNFrom:
+      <<: *level_2
+      tags: [device_lib, misc]
+    Unit_hipGetSymbolAddressAndSize_Validation:
+      <<: *level_2
+      tags: [device_lib, misc]
+    Unit_hipGetSymbolAddress_Negative:
+      <<: *level_2
+      tags: [device_lib, misc]
+    Unit_hipGetSymbolSize_Negative:
+      <<: *level_2
+      tags: [device_lib, misc]
+    Unit_hipTest_DeviceNewOperator:
+      <<: *level_2
+      tags: [device_lib, misc]
+    Unit_hipThreadFence:
+      <<: *level_2
+      tags: [device_lib, sync]
+    Unit_hipDeviceTrigFunc_Float:
+      <<: *level_2
+      tags: [device_lib, misc]
+    Unit_hipTestDeviceLimit_Basic:
+      <<: *level_2
+      tags: [device_lib, misc]
+    Unit_hipTrigDeviceFunc_Double:
+      <<: *level_2
+      tags: [device_lib, misc]
+    Unit_TestDevice_DoublePrecisionMathFunc:
+      <<: *level_2
+      tags: [device_lib, misc]
+    Unit_hadd_int_varaint:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_rhadd_int_varaint:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_uhadd_int_varaint:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_urhadd_int_varaint:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_unsafeAtomicAdd:
+      <<: *level_2
+      tags: [device_lib, atomic]
+    Unit_mbcnt:
+      <<: *level_2
+      tags: [device_lib, bitops]
+    Unit_bitExtract:
+      <<: *level_2
+      tags: [device_lib, bitops]
+    Unit_bitInsert:
+      <<: *level_2
+      tags: [device_lib, bitops]
+    Unit_floatTM:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_abs_int64_Verification:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_pown_Verification:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_hmax_hmin_Tsts:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_hmax_hmin_Tsts_Negative:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_hmax_hmin_Tsts_With_Array:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_hipBfloat16:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_hipVectorTypes_test_on_host:
+      <<: *level_2
+      tags: [device_lib, types]
     Unit_hipVectorTypes_test_on_device:
+      tags: [device_lib, types]
       <<: *level_2
       # SWDEV-444987 - Below tests fail in stress testing on 25/01/2023
       disabled: [amd_windows, amd_wsl]
-    Unit_hipTestHalf: *level_2
-    Unit_TestMathFuncComplex: *level_2
-    Unit_hipTestFMA: *level_2
-    Unit_hipTestNativeHalf: *level_2
+    Unit_hipTestHalf:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_TestMathFuncComplex:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_hipTestFMA:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_hipTestNativeHalf:
+      <<: *level_2
+      tags: [device_lib, types]
     Unit_Test_makechar_functionality:
+      tags: [device_lib, types]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_bf16_basic: *level_2
+    Unit_bf16_basic:
+      <<: *level_2
+      tags: [device_lib, types]
     Unit_bf16_conversion_to_integral_type: *level_2
-    Unit_bf162_basic: *level_2
-    Unit_bf16_operators_host: *level_2
-    Unit_bf162_operators_host: *level_2
-    Unit_bf16_bf162_convert_tests: *level_2
-    Unit_bf16_shfl: *level_2
-    Unit_bf162_shfl: *level_2
-    Unit_bf16_value_ops: *level_2
-    Unit_bf16_floor_ceil: *level_2
-    Unit_bf162_floor_ceil: *level_2
-    Unit_AtomicsWithRandomActiveLanesInWavefront_UniformInteger: *level_2
-    Unit_AtomicsWithRandomActiveLanesInWavefront_UniformFloat: *level_2
-    Unit_AtomicsWithRandomActiveLanesInWavefront_DivergentInteger: *level_2
-    Unit_AtomicsWithRandomActiveLanesInWavefront_DivergentFloat: *level_2
-    Unit_fp16_arith: *level_2
-    Unit_fp162_arith: *level_2
-    Unit_fp16_host_operations: *level_2
-    Unit_half_isnan_host: *level_2
-    Unit_half_abs_host: *level_2
-    Unit_half_min_max_host: *level_2
-    Unit_fp8_ocp_bool_host: *level_2
-    Unit_all_fp8_ocp_vector_cvt: *level_2
+    Unit_bf162_basic:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_bf16_operators_host:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_bf162_operators_host:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_bf16_bf162_convert_tests:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_bf16_shfl:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_bf162_shfl:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_bf16_value_ops:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_bf16_floor_ceil:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_bf162_floor_ceil:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_AtomicsWithRandomActiveLanesInWavefront_UniformInteger:
+      <<: *level_2
+      tags: [device_lib, atomic]
+    Unit_AtomicsWithRandomActiveLanesInWavefront_UniformFloat:
+      <<: *level_2
+      tags: [device_lib, atomic]
+    Unit_AtomicsWithRandomActiveLanesInWavefront_DivergentInteger:
+      <<: *level_2
+      tags: [device_lib, atomic]
+    Unit_AtomicsWithRandomActiveLanesInWavefront_DivergentFloat:
+      <<: *level_2
+      tags: [device_lib, atomic]
+    Unit_fp16_arith:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_fp162_arith:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_fp16_host_operations:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_half_isnan_host:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_half_abs_host:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_half_min_max_host:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_fp8_ocp_bool_host:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_all_fp8_ocp_vector_cvt:
+      <<: *level_2
+      tags: [device_lib, types]
     Unit_fp8_ocp_correctness: *level_2
-    Unit_fp8_ocp_vector_basic_conversions: *level_2
-    Unit_fp8_fnuz_bool_host: *level_2
-    Unit_all_fp8_fnuz_vector_cvt: *level_2
+    Unit_fp8_ocp_vector_basic_conversions:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_fp8_fnuz_bool_host:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_all_fp8_fnuz_vector_cvt:
+      <<: *level_2
+      tags: [device_lib, types]
     Unit_fp8_fnuz_correctness: *level_2
-    Unit_fp8_fnuz_vector_basic_conversions: *level_2
-    Unit__hip_cvt_bfloat16raw_to_e8m0: *level_2
-    Unit__hip_cvt_float_to_e8m0: *level_2
-    Unit__hip_cvt_double_to_e8m0: *level_2
-    Unit__hip_cvt_e8m0_to_bf16raw: *level_2
+    Unit_fp8_fnuz_vector_basic_conversions:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit__hip_cvt_bfloat16raw_to_e8m0:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit__hip_cvt_float_to_e8m0:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit__hip_cvt_double_to_e8m0:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit__hip_cvt_e8m0_to_bf16raw:
+      <<: *level_2
+      tags: [device_lib, types]
     Unit_all_fp6_ocp_vector_cvt_interger_data: *level_2
     Unit_all_fp6_ocp_vector_cvt_unsigned_interger_data: *level_2
     Unit_all_fp6_ocp_vector_cvt_unsigned_integer_device: *level_2
     Unit_all_fp6_ocp_vector_cvt_interger_data_device: *level_2
-    Unit_all_fp4_from_double: *level_2
-    Unit_all_fp4_from_double_device: *level_2
+    Unit_all_fp4_from_double:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_all_fp4_from_double_device:
+      <<: *level_2
+      tags: [device_lib, types]
     Unit_all_fp4_from_interger_data: *level_2
     Unit_all_fp4_from__unsigned_integer_data: *level_2
     Unit_all_fp4_from_integer_data_device: *level_2
     Unit_all_fp4_from__unsigned_integer_data_device: *level_2
-    Unit_ocp_fp4_from_double_full_range_host: *level_2
-    Unit_ocp_fp4_from_double_full_range_device: *level_2
+    Unit_ocp_fp4_from_double_full_range_host:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_ocp_fp4_from_double_full_range_device:
+      <<: *level_2
+      tags: [device_lib, types]
     Unit_AtomicAdd_CoherentwithUnsafeflag: *level_2
     Unit_AtomicAdd_Coherentwithoutflag: *level_2
     Unit_AtomicAdd_Coherentwithnounsafeflag: *level_2
     Unit_AtomicAdd_NonCoherentwithoutflag: *level_2
     Unit_AtomicAdd_NonCoherentwithnounsafeflag: *level_2
     Unit_AtomicAdd_NonCoherentwithUnsafeflag: *level_2
-    Unit_BuiltinAtomics_fmaxCoherentGlobalMem: *level_2
-    Unit_BuiltinAtomics_fmaxNonCoherentGlobalFlatMem: *level_2
-    Unit_BuiltinAtomicsRTC_fmaxCoherentGlobalMem: *level_2
-    Unit_BuiltinAtomicsRTC_fmaxNonCoherentGlobalFlatMem: *level_2
-    Unit_BuiltinAtomics_fminCoherentGlobalMem: *level_2
-    Unit_BuiltinAtomics_fminNonCoherentGlobalFlatMem: *level_2
-    Unit_BuiltinAtomicsRTC__fminCoherentGlobalMem: *level_2
-    Unit_BuiltinAtomicsRTC_fminNonCoherentGlobalFlatMem: *level_2
-    Unit_BuiltInAtomicAdd_CoherentGlobalMem: *level_2
-    Unit_BuiltInAtomicAdd_NonCoherentGlobalMem: *level_2
-    Unit_BuiltInAtomicAdd_CoherentGlobalMemWithRtc: *level_2
+    Unit_BuiltinAtomics_fmaxCoherentGlobalMem:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_BuiltinAtomics_fmaxNonCoherentGlobalFlatMem:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_BuiltinAtomicsRTC_fmaxCoherentGlobalMem:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_BuiltinAtomicsRTC_fmaxNonCoherentGlobalFlatMem:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_BuiltinAtomics_fminCoherentGlobalMem:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_BuiltinAtomics_fminNonCoherentGlobalFlatMem:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_BuiltinAtomicsRTC__fminCoherentGlobalMem:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_BuiltinAtomicsRTC_fminNonCoherentGlobalFlatMem:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_BuiltInAtomicAdd_CoherentGlobalMem:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_BuiltInAtomicAdd_NonCoherentGlobalMem:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_BuiltInAtomicAdd_CoherentGlobalMemWithRtc:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_BuiltInAtomicAdd_NonCoherentGlobalMemWithRtc:
+      tags: [device_lib, math]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
@@ -1061,1327 +1681,2728 @@ unit:
     Unit_unsafeAtomicAdd_NonCoherentnounsafeatomicsflag: *level_2
     Unit_unsafeAtomicAdd_NonCoherentwithunsafeatomicsflag: *level_2
     Unit_fp8_fnuz_compare_host_device: *level_2
-    Unit_fp8x2_fnuz_compare_host_device: *level_2
-    Unit_fp8x2_fnuz_split_compare: *level_2
-    Unit_fp8x4_fnuz_split_compare: *level_2
-    Unit_fp8_fnuz_bool_device: *level_2
-    Unit_all_fp8_fnuz_cvt: *level_2
+    Unit_fp8x2_fnuz_compare_host_device:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_fp8x2_fnuz_split_compare:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_fp8x4_fnuz_split_compare:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_fp8_fnuz_bool_device:
+      <<: *level_2
+      tags: [device_lib, types]
+    Unit_all_fp8_fnuz_cvt:
+      <<: *level_2
+      tags: [device_lib, types]
     Unit_fp8_fnuz_correctness_device: *level_2
     Dynamic_Alloca: *level_2
   dynamicLoading:
     Unit_dynamic_loading_device_kernels_from_library:
+      tags: [module]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_hipApiDynamicLoad_hipGetProcAddress: *level_2
-    Unit_hipApiDynamicLoad: *level_2
+    Unit_hipApiDynamicLoad_hipGetProcAddress:
+      <<: *level_2
+      tags: [module]
+    Unit_hipApiDynamicLoad:
+      <<: *level_2
+      tags: [module]
   errorHandling:
-    Unit_hipGetErrorName_Positive_Basic: *level_2
-    Unit_hipGetErrorName_Negative_Parameters: *level_2
-    Unit_hipGetErrorString_Positive_Basic: *level_2
-    Unit_hipGetErrorString_Negative_Parameters: *level_2
-    Unit_hipDrvGetErrorName_Positive_Basic: *level_2
-    Unit_hipDrvGetErrorName_Negative_Parameters: *level_2
-    Unit_hipDrvGetErrorString_Positive_Basic: *level_2
-    Unit_hipDrvGetErrorString_Negative_Parameters: *level_2
-    Unit_hipGetLastError_Positive_Basic: *level_2
-    Unit_hipGetLastError_Positive_Threaded: *level_2
+    Unit_hipGetErrorName_Positive_Basic:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetErrorName_Negative_Parameters:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetErrorString_Positive_Basic:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetErrorString_Negative_Parameters:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipDrvGetErrorName_Positive_Basic:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipDrvGetErrorName_Negative_Parameters:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipDrvGetErrorString_Positive_Basic:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipDrvGetErrorString_Negative_Parameters:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_Positive_Basic:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_Positive_Threaded:
+      <<: *level_2
+      tags: [error_handling]
     Unit_hipGetLastError_with_hipMemcpyPeerAsync:
+      tags: [error_handling, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGetLastError_with_hipMemcpyDtoHAsync: *level_2
-    Unit_hipGetLastError_with_hipMemcpyParam2DAsync: *level_2
-    Unit_hipGetLastError_with_hipDrvMemcpy3DAsync: *level_2
-    Unit_hipGetLastError_with_hipMemcpy3DAsync: *level_2
-    Unit_hipGetLastError_with_hipMemcpy2D_To_From_ArrayAsync: *level_2
-    Unit_hipGetLastError_with_hipStreamAttachMemAsync: *level_2
-    Unit_hipGetLastError_with_hipWaitExternalSemaphoresAsync: *level_2
-    Unit_hipGetLastError_with_hipSignalExternalSemaphoresAsync: *level_2
-    Unit_hipGetLastError_with_hipMemPrefetchAsync: *level_2
-    Unit_hipGetLastError_with_hipMemcpy2DAsync: *level_2
-    Unit_hipGetLastError_with_hipMemsetAsync: *level_2
-    Unit_hipGetLastError_with_MemCpyAsync: *level_2
-    Unit_hipGetLastError_with_MemCpyAsync_thread: *level_2
-    Unit_hipGetLastError_with_hipGraphAddMemcpyNode1D: *level_2
-    Unit_hipGetLastError_with_hipStreamBegin_EndCapture: *level_2
-    Unit_hipGetLastError_error_check_with_hipGraphCreate: *level_2
-    Unit_hipGetLastError_success_before_hipGetLastError: *level_2
-    Unit_hipGetLastError_success_before_hipGetLastError_check_again: *level_2
-    Unit_hipGetLastError_with_Kernel_divide_by_zero: *level_2
-    Unit_hipGetLastError_with_Kernel_Invalid_Configuration: *level_2
-    Unit_hipGetLastError_With_Chk_Updated_Status: *level_2
-    Unit_hipGetLastError_Chk_Along_hipPeekAtLastError: *level_2
-    Unit_hipGetLastError_Error_Combinations: *level_2
-    Unit_hipGetLastError_With_Thread: *level_2
-    Unit_hipGetLastError_MultiProcess: *level_2
-    Unit_hipGetLastError_Kernel_Invalid_Config: *level_2
-    Unit_hipPeekAtLastError_Positive_Basic: *level_2
-    Unit_hipPeekAtLastError_Positive_Threaded: *level_2
-    Unit_hipPeekAtLastError_Positive: *level_2
-    Unit_hipPeekAtLastError_Chk_Updated_Status: *level_2
-    Unit_hipPeekAtLastError_Chk_Along_hipGetLastError: *level_2
-    Unit_hipPeekAtLastError_Error_Combinations: *level_2
-    Unit_hipPeekAtLastError_With_Thread: *level_2
-    Unit_hipPeekAtLastError_MultiProcess: *level_2
-    Unit_hipPeekAtLastError_Kernel_Invalid_Config: *level_2
-    Unit_hipGetLastError_KernelFailure_ValidAndInvalidOperations: *level_2
+    Unit_hipGetLastError_with_hipMemcpyDtoHAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_with_hipMemcpyParam2DAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_with_hipDrvMemcpy3DAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_with_hipMemcpy3DAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_with_hipMemcpy2D_To_From_ArrayAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_with_hipStreamAttachMemAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_with_hipWaitExternalSemaphoresAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_with_hipSignalExternalSemaphoresAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_with_hipMemPrefetchAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_with_hipMemcpy2DAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_with_hipMemsetAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_with_MemCpyAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_with_MemCpyAsync_thread:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_with_hipGraphAddMemcpyNode1D:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_with_hipStreamBegin_EndCapture:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_error_check_with_hipGraphCreate:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_success_before_hipGetLastError:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_success_before_hipGetLastError_check_again:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_with_Kernel_divide_by_zero:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_with_Kernel_Invalid_Configuration:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_With_Chk_Updated_Status:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_Chk_Along_hipPeekAtLastError:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_Error_Combinations:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_With_Thread:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_MultiProcess:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_Kernel_Invalid_Config:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipPeekAtLastError_Positive_Basic:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipPeekAtLastError_Positive_Threaded:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipPeekAtLastError_Positive:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipPeekAtLastError_Chk_Updated_Status:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipPeekAtLastError_Chk_Along_hipGetLastError:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipPeekAtLastError_Error_Combinations:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipPeekAtLastError_With_Thread:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipPeekAtLastError_MultiProcess:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipPeekAtLastError_Kernel_Invalid_Config:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipGetLastError_KernelFailure_ValidAndInvalidOperations:
+      <<: *level_2
+      tags: [error_handling]
     Unit_hipGetLastError_KernelFailure_TwoDevices:
+      tags: [error_handling, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGetLastError_KernelFailure_TwoStreams: *level_2
-    Unit_hipExtGetLastError_Positive_Basic: *level_2
-    Unit_hipExtGetLastError_Positive_Threaded: *level_2
+    Unit_hipGetLastError_KernelFailure_TwoStreams:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_Positive_Basic:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_Positive_Threaded:
+      <<: *level_2
+      tags: [error_handling]
     Unit_hipExtGetLastError_with_hipMemcpyPeerAsync:
+      tags: [error_handling, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipExtGetLastError_with_hipMemcpyDtoHAsync: *level_2
-    Unit_hipExtGetLastError_with_hipMemcpyParam2DAsync: *level_2
-    Unit_hipExtGetLastError_with_hipDrvMemcpy3DAsync: *level_2
-    Unit_hipExtGetLastError_with_hipMemcpy3DAsync: *level_2
-    Unit_hipExtGetLastError_with_hipMemcpy2D_To_From_ArrayAsync: *level_2
-    Unit_hipExtGetLastError_with_hipStreamAttachMemAsync: *level_2
-    Unit_hipExtGetLastError_with_hipWaitExternalSemaphoresAsync: *level_2
-    Unit_hipExtGetLastError_with_hipSignalExternalSemaphoresAsync: *level_2
-    Unit_hipExtGetLastError_with_hipMemPrefetchAsync: *level_2
-    Unit_hipExtGetLastError_with_hipMemcpy2DAsync: *level_2
-    Unit_hipExtGetLastError_with_hipMemsetAsync: *level_2
-    Unit_hipExtGetLastError_with_MemCpyAsync: *level_2
-    Unit_hipExtGetLastError_with_MemCpyAsync_thread: *level_2
-    Unit_hipExtGetLastError_with_hipGraphAddMemcpyNode1D: *level_2
-    Unit_hipExtGetLastError_with_hipStreamBegin_EndCapture: *level_2
-    Unit_hipExtGetLastError_error_check_with_hipGraphCreate: *level_2
-    Unit_hipExtGetLastError_success_before_error_check_again: *level_2
-    Unit_hipExtGetLastError_with_Kernel_divide_by_zero: *level_2
+    Unit_hipExtGetLastError_with_hipMemcpyDtoHAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_with_hipMemcpyParam2DAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_with_hipDrvMemcpy3DAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_with_hipMemcpy3DAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_with_hipMemcpy2D_To_From_ArrayAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_with_hipStreamAttachMemAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_with_hipWaitExternalSemaphoresAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_with_hipSignalExternalSemaphoresAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_with_hipMemPrefetchAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_with_hipMemcpy2DAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_with_hipMemsetAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_with_MemCpyAsync:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_with_MemCpyAsync_thread:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_with_hipGraphAddMemcpyNode1D:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_with_hipStreamBegin_EndCapture:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_error_check_with_hipGraphCreate:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_success_before_error_check_again:
+      <<: *level_2
+      tags: [error_handling]
+    Unit_hipExtGetLastError_with_Kernel_divide_by_zero:
+      <<: *level_2
+      tags: [error_handling]
   event:
-    Unit_hipEventCreate_NullCheck: *level_2
-    Unit_hipEventCreateWithFlags_NullCheck: *level_2
-    Unit_hipEventCreate_IncompatibleFlags: *level_2
-    Unit_hipEventSynchronize_NullCheck: *level_2
-    Unit_hipEventQuery_NullCheck: *level_2
-    Unit_hipEventDestroy_NullCheck: *level_2
+    Unit_hipEventCreate_NullCheck:
+      <<: *level_2
+      tags: [event]
+    Unit_hipEventCreateWithFlags_NullCheck:
+      <<: *level_2
+      tags: [event]
+    Unit_hipEventCreate_IncompatibleFlags:
+      <<: *level_2
+      tags: [event]
+    Unit_hipEventSynchronize_NullCheck:
+      <<: *level_2
+      tags: [event]
+    Unit_hipEventQuery_NullCheck:
+      <<: *level_2
+      tags: [event]
+    Unit_hipEventDestroy_NullCheck:
+      <<: *level_2
+      tags: [event]
     Unit_hipEvent:
+      tags: [event]
       <<: *level_2
       # SWDEV-411303 fails in WSL. Profiling not support in WSL
       disabled: [amd_wsl]
-    Unit_hipEventElapsedTime_NullCheck: *level_2
-    Unit_hipEventElapsedTime_DisableTiming: *level_2
+    Unit_hipEventElapsedTime_NullCheck:
+      <<: *level_2
+      tags: [event, sync]
+    Unit_hipEventElapsedTime_DisableTiming:
+      <<: *level_2
+      tags: [event, sync]
     Unit_hipEventElapsedTime_DifferentDevices:
+      tags: [event, sync, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipEventElapsedTime_NotReady_Negative:
+      tags: [event, sync]
       <<: *level_2
       # SWDEV-411303 fails in WSL. Profiling not support in WSL
       disabled: [amd_wsl]
-    Unit_hipEventElapsedTime: *level_2
-    Unit_hipEventElapsedTime_Verify_Capture: *level_2
+    Unit_hipEventElapsedTime:
+      <<: *level_2
+      tags: [event, sync]
+    Unit_hipEventElapsedTime_Verify_Capture:
+      <<: *level_2
+      tags: [event, sync]
     Unit_hipEventRecord:
+      tags: [event, sync]
       <<: *level_2
       disabled: [amd_windows]
     Unit_hipEventRecord_Negative:
+      tags: [event, sync, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipEventIpc:
+      tags: [event, ipc]
       <<: *level_2
       # (amd_wsl) Below tests fail in stress test on 24/07/23
       disabled: [amd_windows, amd_wsl]
     Unit_hipEventDestroy_Unfinished:
+      tags: [event, lifecycle]
       <<: *level_2
       # SWDEV-411303 fails in WSL. Profiling not support in WSL
       disabled: [amd_wsl]
     Unit_hipEventDestroy_WithWaitingStream:
+      tags: [event, lifecycle]
       <<: *level_2
       # SWDEV-402054 fails in external github build
       disabled: [amd_windows, amd_wsl]
-    Unit_hipEventDestroy_Negative: *level_2
-    Unit_hipEventDestroy_Verify_Capture: *level_2
-    Unit_hipEventCreate_Positive: *level_2
-    Unit_hipEventCreate_Verify_Capture: *level_2
-    Unit_hipEventCreateWithFlags_Positive: *level_2
+    Unit_hipEventDestroy_Negative:
+      <<: *level_2
+      tags: [event, lifecycle]
+    Unit_hipEventDestroy_Verify_Capture:
+      <<: *level_2
+      tags: [event, lifecycle]
+    Unit_hipEventCreate_Positive:
+      <<: *level_2
+      tags: [event, lifecycle]
+    Unit_hipEventCreate_Verify_Capture:
+      <<: *level_2
+      tags: [event, lifecycle]
+    Unit_hipEventCreateWithFlags_Positive:
+      <<: *level_2
+      tags: [event, lifecycle]
     Unit_hipEventCreateWithFlags_DisableSystemFence_HstVisMem:
+      tags: [event, lifecycle]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipEventCreateWithFlags_DefaultFlg_HstVisMem:
+      tags: [event, lifecycle]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipEventCreateWithFlags_DisableSystemFence_NonCohHstMem:
+      tags: [event, lifecycle]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipEventCreateWithFlags_DefaultFlg_NonCohHstMem:
+      tags: [event, lifecycle]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipEventCreateWithFlags_DisableSystemFence_CohHstMem:
+      tags: [event, lifecycle]
       <<: *level_2
       # (amd_linux) SWDEV-470751 : Fine Grain memory is MTYPE_NC due to HW bug.
       # (amd_windows) Note: intermittent Seg fault failure
       disabled: [gfx1200, gfx1201, amd_windows, amd_wsl]
     Unit_hipEventCreateWithFlags_DefaultFlg_CohHstMem:
+      tags: [event, lifecycle]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
-    Unit_hipEventCreateWithFlags_Verify_Capture: *level_2
-    Unit_hipEventSynchronize_Default_Positive: *level_2
-    Unit_hipEventSynchronize_NoEventRecord_Positive: *level_2
-    Unit_hipEventMGpuMThreads_1: *level_2
+    Unit_hipEventCreateWithFlags_Verify_Capture:
+      <<: *level_2
+      tags: [event, lifecycle]
+    Unit_hipEventSynchronize_Default_Positive:
+      <<: *level_2
+      tags: [event, sync]
+    Unit_hipEventSynchronize_NoEventRecord_Positive:
+      <<: *level_2
+      tags: [event, sync]
+    Unit_hipEventMGpuMThreads_1:
+      <<: *level_2
+      tags: [event]
     Unit_hipEventMGpuMThreads_2:
+      tags: [event, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipEventMGpuMThreads_3:
+      tags: [event, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipEventQuery_DifferentDevice:
+      tags: [event, sync, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipEventIpc_shm_cleanup: *level_2
+    Unit_hipEventIpc_shm_cleanup:
+      <<: *level_2
+      tags: [event, ipc]
   executionControl:
     Unit_hipFuncGetAttributes_Positive_Basic:
+      tags: [kernel, attributes]
       <<: *level_2
       # NOTE: The following test is disabled due to defect - EXSWHTEC-242
       disabled: [amd_linux, amd_windows]
-    Unit_hipFuncGetAttributes_Negative_Parameters: *level_2
-    Unit_hipLaunchKernel_Positive_Basic: *level_2
-    Unit_hipLaunchKernel_Positive_Parameters: *level_2
+    Unit_hipFuncGetAttributes_Negative_Parameters:
+      <<: *level_2
+      tags: [kernel, attributes]
+    Unit_hipLaunchKernel_Positive_Basic:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit_hipLaunchKernel_Positive_Parameters:
+      <<: *level_2
+      tags: [kernel, launch]
     Unit_hipLaunchKernel_Negative_Parameters:
+      tags: [kernel, launch]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipLaunchKernel_Verify_Capture: *level_2
-    Unit_hipLaunchCooperativeKernel_Positive_Basic: *level_2
-    Unit_hipLaunchCooperativeKernel_Positive_Parameters: *level_2
-    Unit_hipLaunchCooperativeKernel_Negative_Parameters: *level_2
+    Unit_hipLaunchCooperativeKernel_Positive_Basic:
+      <<: *level_2
+      tags: [kernel]
+    Unit_hipLaunchCooperativeKernel_Positive_Parameters:
+      <<: *level_2
+      tags: [kernel]
+    Unit_hipLaunchCooperativeKernel_Negative_Parameters:
+      <<: *level_2
+      tags: [kernel]
     Unit_hipLaunchCooperativeKernel_Verify_Capture: *level_2
     Unit_hipLaunchCooperativeKernelMultiDevice_Positive_Basic:
+      tags: [multigpu, kernel]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipLaunchCooperativeKernelMultiDevice_Negative_Parameters:
+      tags: [multigpu, kernel]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipLaunchCooperativeKernelMultiDevice_Negative_MultiKernelSameDevice: *level_2
-    Unit_hipExtLaunchKernel_Positive_Basic: *level_2
-    Unit_hipExtLaunchKernel_Positive_Parameters: *level_2
-    Unit_hipExtLaunchKernel_Negative_Parameters: *level_2
-    Unit_hipExtLaunchKernel_capturehipExtLaunchKernel: *level_2
+    Unit_hipLaunchCooperativeKernelMultiDevice_Negative_MultiKernelSameDevice:
+      <<: *level_2
+      tags: [kernel]
+    Unit_hipExtLaunchKernel_Positive_Basic:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit_hipExtLaunchKernel_Positive_Parameters:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit_hipExtLaunchKernel_Negative_Parameters:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit_hipExtLaunchKernel_capturehipExtLaunchKernel:
+      <<: *level_2
+      tags: [kernel, launch]
     Unit_hipExtLaunchMultiKernelMultiDevice_Positive_Basic:
+      tags: [multigpu, kernel, launch]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipExtLaunchMultiKernelMultiDevice_Negative_Parameters:
+      tags: [multigpu, kernel, launch]
       <<: *level_2
-      tags: [multigpu]
       # NOTE: The following test is disabled due to defect - EXSWHTEC-244
       disabled: [amd_linux, amd_windows]
-    Unit_hipExtLaunchMultiKernelMultiDevice_Negative_MultiKernelSameDevice: *level_2
-    Unit_hipLaunchByPtr_Positive_Basic: *level_2
-    Unit_hipLaunchByPtr_Negative_Parameters: *level_2
-    Unit___hipPushCallConfiguration_Positive_Basic: *level_2
+    Unit_hipExtLaunchMultiKernelMultiDevice_Negative_MultiKernelSameDevice:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit_hipLaunchByPtr_Positive_Basic:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit_hipLaunchByPtr_Negative_Parameters:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit___hipPushCallConfiguration_Positive_Basic:
+      <<: *level_2
+      tags: [kernel, launch]
     Unit_hipLaunchByPtr_Verify_Capture: *level_2
-    Unit_hipGetProcAddress_KernelLaunchApis: *level_2
-    Unit_hipGetProcAddress_CallbackActivityAPIs: *level_2
-    Unit_hipGetProcAddress_ExecutionControlAPIs: *level_2
+    Unit_hipGetProcAddress_KernelLaunchApis:
+      <<: *level_2
+      tags: [kernel]
+    Unit_hipGetProcAddress_CallbackActivityAPIs:
+      <<: *level_2
+      tags: [kernel]
+    Unit_hipGetProcAddress_ExecutionControlAPIs:
+      <<: *level_2
+      tags: [kernel]
     Unit_hipFuncSetCacheConfig_Positive_Basic:
+      tags: [kernel, attributes]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipFuncSetCacheConfig_Negative_Parameters:
+      tags: [kernel, attributes]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
-    Unit_hipFuncSetCacheConfig_Negative_Not_Supported: *level_2
+    Unit_hipFuncSetCacheConfig_Negative_Not_Supported:
+      <<: *level_2
+      tags: [kernel, attributes]
     Unit_hipFuncSetSharedMemConfig_Positive_Basic:
+      tags: [kernel, attributes]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
-    Unit_hipFuncSetSharedMemConfig_Negative_Parameters: *level_2
-    Unit_hipFuncSetSharedMemConfig_Negative_Not_Supported: *level_2
-    Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize: *level_2
+    Unit_hipFuncSetSharedMemConfig_Negative_Parameters:
+      <<: *level_2
+      tags: [kernel, attributes]
+    Unit_hipFuncSetSharedMemConfig_Negative_Not_Supported:
+      <<: *level_2
+      tags: [kernel, attributes]
+    Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize:
+      <<: *level_2
+      tags: [kernel, attributes]
     Unit_hipFuncSetAttribute_Positive_PreferredSharedMemoryCarveout:
+      tags: [kernel, attributes]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
-    Unit_hipFuncSetAttribute_Positive_Parameters: *level_2
-    Unit_hipFuncSetAttribute_Negative_Parameters: *level_2
-    Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize_Not_Supported: *level_2
-    Unit_hipFuncSetAttribute_Positive_PreferredSharedMemoryCarveout_Not_Supported: *level_2
+    Unit_hipFuncSetAttribute_Positive_Parameters:
+      <<: *level_2
+      tags: [kernel, attributes]
+    Unit_hipFuncSetAttribute_Negative_Parameters:
+      <<: *level_2
+      tags: [kernel, attributes]
+    Unit_hipFuncSetAttribute_Positive_MaxDynamicSharedMemorySize_Not_Supported:
+      <<: *level_2
+      tags: [kernel, attributes]
+    Unit_hipFuncSetAttribute_Positive_PreferredSharedMemoryCarveout_Not_Supported:
+      <<: *level_2
+      tags: [kernel, attributes]
   g++:
-    Unit_hipMalloc_gpptest: *level_2
+    Unit_hipMalloc_gpptest:
+      <<: *level_2
+      tags: [compiler]
   gcc:
-    Unit_LaunchKernelgccTests: *level_2
-    Unit_hipMallocgccTests: *level_2
+    Unit_LaunchKernelgccTests:
+      <<: *level_2
+      tags: [compiler]
+    Unit_hipMallocgccTests:
+      <<: *level_2
+      tags: [compiler]
   gl_interop:
     Unit_hipGLGetDevices_Positive_Basic:
+      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGLGetDevices_Positive_Parameters:
+      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGLGetDevices_Negative_Parameters:
+      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsGLRegisterBuffer_Positive_Basic:
+      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsGLRegisterBuffer_Positive_Register_Twice:
+      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsGLRegisterBuffer_Negative_Parameters:
+      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsGLRegisterImage_Positive_Basic:
+      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsGLRegisterImage_Positive_Register_Twice:
+      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsGLRegisterImage_Negative_Parameters:
+      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsMapResources_Positive_Basic:
+      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsMapResources_Negative_Parameters:
+      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_linux, amd_wsl]
     Unit_hipGraphicsResourceGetMappedPointer_Positive_Basic:
+      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsResourceGetMappedPointer_Positive_Parameters:
+      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_linux, amd_wsl]
     Unit_hipGraphicsResourceGetMappedPointer_Negative_Parameters:
+      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_linux, amd_wsl]
     Unit_hipGraphicsSubResourceGetMappedArray_Positive_Basic:
+      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
     Unit_hipGraphicsSubResourceGetMappedArray_Negative_Parameters:
+      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_linux, amd_wsl]
     Unit_hipGraphicsUnmapResources_Negative_Parameters:
+      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_linux, amd_wsl]
     Unit_hipGraphicsUnregisterResource_Negative_Parameters:
+      tags: [interop, gl]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_linux, amd_wsl]
   graph:
-    Unit_hipGraphAddEmptyNode_Functional: *level_2
-    Unit_hipGraphAddEmptyNode_NegTest: *level_2
-    Unit_hipGraphAddEmptyNode_BarrierFunc: *level_2
-    Unit_hipGraphAddDependencies_Positive_Functional: *level_2
-    Unit_hipGraphAddDependencies_Positive_Parameters: *level_2
-    Unit_hipGraphAddDependencies_Negative_Parameters: *level_2
-    Unit_hipGraphAddDependencies_Functional: *level_2
-    Unit_hipGraphAddDependencies_NegTest: *level_2
-    Unit_hipGraphAddEventRecordNode_Functional_Simple: *level_2
+    Unit_hipGraphAddEmptyNode_Functional:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddEmptyNode_NegTest:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddEmptyNode_BarrierFunc:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddDependencies_Positive_Functional:
+      <<: *level_2
+      tags: [graph, dependency]
+    Unit_hipGraphAddDependencies_Positive_Parameters:
+      <<: *level_2
+      tags: [graph, dependency]
+    Unit_hipGraphAddDependencies_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, dependency]
+    Unit_hipGraphAddDependencies_Functional:
+      <<: *level_2
+      tags: [graph, dependency]
+    Unit_hipGraphAddDependencies_NegTest:
+      <<: *level_2
+      tags: [graph, dependency]
+    Unit_hipGraphAddEventRecordNode_Functional_Simple:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipGraphAddEventRecordNode_Functional_WithoutFlags:
+      tags: [graph, node]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipGraphAddEventRecordNode_Functional_ElapsedTime:
+      tags: [graph, node]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphAddEventRecordNode_Functional_WithFlags: *level_2
+    Unit_hipGraphAddEventRecordNode_Functional_WithFlags:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipGraphAddEventRecordNode_MultipleRun:
+      tags: [graph, node]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphAddEventRecordNode_Functional_TimingDisabled: *level_2
-    Unit_hipGraphAddEventRecordNode_Positive_Parameters: *level_2
-    Unit_hipGraphAddEventRecordNode_Negative: *level_2
-    Unit_hipGraphAddEventWaitNode_Functional_Simple: *level_2
-    Unit_hipGraphAddEventWaitNode_MultGraphMultStrmDependency: *level_2
-    Unit_hipGraphAddEventWaitNode_MultipleRun: *level_2
-    Unit_hipGraphAddEventWaitNode_MultGraphOneStrmDependency: *level_2
-    Unit_hipGraphAddEventWaitNode_differentFlags: *level_2
-    Unit_hipGraphAddEventWaitNode_Positive_Parameters: *level_2
-    Unit_hipGraphAddEventWaitNode_Negative: *level_2
-    Unit_hipGraph_BasicFunctional: *level_2
-    Unit_hipGraph_SimpleGraphWithKernel: *level_2
-    Unit_hipGraphAddMemcpyNode_Positive_Basic: *level_2
+    Unit_hipGraphAddEventRecordNode_Functional_TimingDisabled:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddEventRecordNode_Positive_Parameters:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddEventRecordNode_Negative:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddEventWaitNode_Functional_Simple:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddEventWaitNode_MultGraphMultStrmDependency:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddEventWaitNode_MultipleRun:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddEventWaitNode_MultGraphOneStrmDependency:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddEventWaitNode_differentFlags:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddEventWaitNode_Positive_Parameters:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddEventWaitNode_Negative:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraph_BasicFunctional:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraph_SimpleGraphWithKernel:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphAddMemcpyNode_Positive_Basic:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipGraphAddMemcpyNode_Negative_Parameters:
+      tags: [graph, node]
       <<: *level_2
       # NOTE: The following test is disabled due to defect - EXSWHTEC-245
       disabled: [amd_windows]
-    Unit_hipGraphAddMemcpyNode_Negative: *level_2
-    Unit_hipGraphAddMemcpyNode_BasicFunctional: *level_2
+    Unit_hipGraphAddMemcpyNode_Negative:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemcpyNode_BasicFunctional:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipGraphAddMemcpyNode_PeerAccessFunctional:
+      tags: [graph, node, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGraphAddMemcpyNode_HostToHost: *level_2
-    Unit_hipGraphClone_Negative: *level_2
+    Unit_hipGraphAddMemcpyNode_HostToHost:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphClone_Negative:
+      <<: *level_2
+      tags: [graph, lifecycle]
     Unit_hipGraphClone_Functional:
+      tags: [graph, lifecycle, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGraphClone_MultiThreaded: *level_2
-    Unit_hipGraphInstantiateWithFlags_Negative: *level_2
-    Unit_hipGraphInstantiateWithFlags_DependencyGraph: *level_2
+    Unit_hipGraphClone_MultiThreaded:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphInstantiateWithFlags_Negative:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphInstantiateWithFlags_DependencyGraph:
+      <<: *level_2
+      tags: [graph, lifecycle]
     Unit_hipGraphInstantiateWithFlags_DependencyGraphDeviceCtxtChg:
+      tags: [graph, lifecycle, multigpu]
       <<: *level_2
-      tags: [multigpu]
       # Enable the below test when multi-device graph launches are fully supported
       disabled: [amd_linux]
-    Unit_hipGraphInstantiateWithFlags_StreamCapture: *level_2
-    Unit_hipGraphInstantiateWithFlags_StreamCaptureDeviceContextChg:
+    Unit_hipGraphInstantiateWithFlags_StreamCapture:
       <<: *level_2
-      tags: [multigpu]
+      tags: [graph, lifecycle]
+    Unit_hipGraphInstantiateWithFlags_StreamCaptureDeviceContextChg:
+      tags: [graph, lifecycle, multigpu]
+      <<: *level_2
       # SWDEV-445928: These tests fail in PSDB stress test on 09/02/2024
       disabled: [amd_linux]
     Unit_hipGraphInstantiateWithFlags_FlagAutoFreeOnLaunch_check:
+      tags: [graph, lifecycle]
       <<: *level_2
       # SWDEV-402082 - PAL Backend fails to reserve address on GPU except first one
       disabled: [amd_windows, amd_wsl]
     Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchInLoop:
+      tags: [graph, lifecycle]
       <<: *level_2
       # SWDEV-517063 Below tests are temporarily disabled due to PSDB failure
       disabled: [amd_windows]
     Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchFillKernel:
+      tags: [graph, lifecycle]
       <<: *level_2
       # SWDEV-517063 Below tests are temporarily disabled due to PSDB failure
       disabled: [amd_windows]
     Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchDoubleKernel:
+      tags: [graph, lifecycle]
       <<: *level_2
       # SWDEV-517063 Below tests are temporarily disabled due to PSDB failure
       disabled: [amd_windows]
     Unit_hipGraphInstantiateWithFlags_WithDefaultAndAutoFreeOnLaunch:
+      tags: [graph, lifecycle]
       <<: *level_2
       # SWDEV-517063 Below tests are temporarily disabled due to PSDB failure
       disabled: [amd_windows]
     Unit_hipGraphInstantiateWithParams_Negative:
+      tags: [graph, lifecycle]
       <<: *level_2
       # Unit_hipGraphInstantiateWithParams_Negative
       disabled: [nvidia_windows]
-    Unit_hipGraphInstantiateWithParams_DependencyGraph: *level_2
-    Unit_hipGraphInstantiateWithParams_StreamCapture: *level_2
-    Unit_hipGraphAddHostNode_Negative: *level_2
+    Unit_hipGraphInstantiateWithParams_DependencyGraph:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphInstantiateWithParams_StreamCapture:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphAddHostNode_Negative:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipGraphAddHostNode_ClonedGraphWithHostNode:
+      tags: [graph, node]
       <<: *level_2
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphAddHostNode_VectorSquare: *level_2
-    Unit_hipGraphAddHostNode_BasicFunc: *level_2
-    Unit_hipGraphAddMemcpyNodeFromSymbol_Negative: *level_2
-    Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemory: *level_2
-    Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalConstMemory: *level_2
+    Unit_hipGraphAddHostNode_VectorSquare:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddHostNode_BasicFunc:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemcpyNodeFromSymbol_Negative:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemory:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalConstMemory:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemoryPeerDevice:
+      tags: [graph, node, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalConstMemoryPeerDevice:
+      tags: [graph, node, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemoryWithKernel: *level_2
-    Unit_hipGraphAddMemcpyNodeFromSymbol_Positive_Basic: *level_2
-    Unit_hipGraphAddMemcpyNodeFromSymbol_Negative_Parameters: *level_2
-    Unit_hipGraphChildGraphNodeGetGraph_Functional: *level_2
-    Unit_hipGraphChildGraphNodeGetGraph_Negative: *level_2
-    Unit_hipGraphNodeFindInClone_Negative: *level_2
-    Unit_hipGraphNodeFindInClone_Functional: *level_2
-    Unit_hipGraphNodeFindInClone_MultipleClone: *level_2
-    Unit_hipGraphExecHostNodeSetParams_Negative: *level_2
-    Unit_hipGraphExecHostNodeSetParams_ClonedGraphWithHostNode: *level_2
-    Unit_hipGraphExecHostNodeSetParams_BasicFunc: *level_2
-    Unit_hipGraphAddMemcpyNodeToSymbol_Negative: *level_2
-    Unit_hipGraphAddMemcpyNodeToSymbol_GlobalMemory: *level_2
-    Unit_hipGraphAddMemcpyNodeToSymbol_GlobalConstMemory: *level_2
-    Unit_hipGraphAddMemcpyNodeToSymbol_GlobalMemoryPeerDevice: *level_2
+    Unit_hipGraphAddMemcpyNodeFromSymbol_GlobalMemoryWithKernel:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemcpyNodeFromSymbol_Positive_Basic:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemcpyNodeFromSymbol_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphChildGraphNodeGetGraph_Functional:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphChildGraphNodeGetGraph_Negative:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphNodeFindInClone_Negative:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphNodeFindInClone_Functional:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphNodeFindInClone_MultipleClone:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphExecHostNodeSetParams_Negative:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecHostNodeSetParams_ClonedGraphWithHostNode:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecHostNodeSetParams_BasicFunc:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphAddMemcpyNodeToSymbol_Negative:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemcpyNodeToSymbol_GlobalMemory:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemcpyNodeToSymbol_GlobalConstMemory:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemcpyNodeToSymbol_GlobalMemoryPeerDevice:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipGraphAddMemcpyNodeToSymbol_GlobalConstMemoryPeerDevice:
+      tags: [graph, node, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGraphAddMemcpyNodeToSymbol_MemcpyToSymbolNodeWithKernel:
+      tags: [graph, node, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGraphAddMemcpyNodeToSymbol_Positive_Basic: *level_2
-    Unit_hipGraphAddMemcpyNodeToSymbol_Negative_Parameters: *level_2
+    Unit_hipGraphAddMemcpyNodeToSymbol_Positive_Basic:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemcpyNodeToSymbol_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipGraphExecMemsetNodeSetParams_Positive_Basic: *level_2
     Unit_hipGraphExecMemsetNodeSetParams_Negative_Parameters:
+      tags: [graph, exec, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGraphExecMemsetNodeSetParams_Negative_Updating_Non1D_Node:
+      tags: [graph, exec]
       <<: *level_2
       # Note: Test disabled due to defect - EXSWHTEC-207
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphMemcpyNodeSetParamsToSymbol_Negative: *level_2
+    Unit_hipGraphMemcpyNodeSetParamsToSymbol_Negative:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipGraphMemcpyNodeSetParamsToSymbol_Functional:
+      tags: [graph, node]
       <<: *level_2
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipGraphMemcpyNodeSetParamsToSymbol_Positive_Basic:
+      tags: [graph, node]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphMemcpyNodeSetParamsToSymbol_Negative_Parameters: *level_2
-    Unit_hipGraphDestroyNode_Negative: *level_2
-    Unit_hipGraphDestroyNode_BasicFunctionality: *level_2
-    Unit_hipGraphDestroyNode_DestroyDependencyNode: *level_2
+    Unit_hipGraphMemcpyNodeSetParamsToSymbol_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphDestroyNode_Negative:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphDestroyNode_BasicFunctionality:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphDestroyNode_DestroyDependencyNode:
+      <<: *level_2
+      tags: [graph, lifecycle]
     Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep:
+      tags: [graph, lifecycle]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ClonedGrph:
+      tags: [graph, lifecycle]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipGraphDestroyNode_Complx_ChkNumOfNodesNDep_ChldNode:
+      tags: [graph, lifecycle]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphGetNodes_Positive_Functional: *level_2
-    Unit_hipGraphGetNodes_Positive_CapturedStream: *level_2
-    Unit_hipGraphGetNodes_Negative_Parameters: *level_2
-    Unit_hipGraphGetNodes_Functional: *level_2
-    Unit_hipGraphGetNodes_CapturedStream: *level_2
-    Unit_hipGraphGetNodes_ParamValidation: *level_2
-    Unit_hipGraphGetRootNodes_Positive_Functional: *level_2
-    Unit_hipGraphGetRootNodes_Positive_CapturedStream: *level_2
-    Unit_hipGraphGetRootNodes_Negative_Parameters: *level_2
-    Unit_hipGraphGetRootNodes_Functional: *level_2
-    Unit_hipGraphGetRootNodes_CapturedStream: *level_2
-    Unit_hipGraphGetRootNodes_ParamValidation: *level_2
-    Unit_hipGraphGetRootNodes_Complx_NumRootNodes: *level_2
-    Unit_hipGraphGetRootNodes_Complx_NumRootNodes_ClonedGrph: *level_2
-    Unit_hipGraphGetRootNodes_Complx_NRootNodesAsChildGraph: *level_2
-    Unit_hipGraphHostNodeSetParams_Negative: *level_2
-    Unit_hipGraphHostNodeSetParams_ClonedGraphWithHostNode: *level_2
-    Unit_hipGraphHostNodeSetParams_BasicFunc: *level_2
-    Unit_hipGraphAddMemcpyNode1D_Positive_Basic: *level_2
-    Unit_hipGraphAddMemcpyNode1D_Negative_Parameters: *level_2
-    Unit_hipGraphAddChildGraphNode_Negative: *level_2
+    Unit_hipGraphGetNodes_Positive_Functional:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphGetNodes_Positive_CapturedStream:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphGetNodes_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphGetNodes_Functional:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphGetNodes_CapturedStream:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphGetNodes_ParamValidation:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphGetRootNodes_Positive_Functional:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphGetRootNodes_Positive_CapturedStream:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphGetRootNodes_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphGetRootNodes_Functional:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphGetRootNodes_CapturedStream:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphGetRootNodes_ParamValidation:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphGetRootNodes_Complx_NumRootNodes:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphGetRootNodes_Complx_NumRootNodes_ClonedGrph:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphGetRootNodes_Complx_NRootNodesAsChildGraph:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphHostNodeSetParams_Negative:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphHostNodeSetParams_ClonedGraphWithHostNode:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphHostNodeSetParams_BasicFunc:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemcpyNode1D_Positive_Basic:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemcpyNode1D_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddChildGraphNode_Negative:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipGraphAddChildGraphNode_OrgGraphAsChildGraph:
+      tags: [graph, node]
       <<: *level_2
       # Disabling tests which no longer behave the same on nvidia platform
       disabled: [nvidia_windows]
-    Unit_hipGraphAddChildGraphNode_ExecuteChildGraph: *level_2
-    Unit_hipGraphAddChildGraphNode_CloneChildGraph: *level_2
-    Unit_hipGraphAddChildGraphNode_MultipleChildNodes: *level_2
-    Unit_hipGraphAddChildGraphNode_SingleChildNode: *level_2
-    Unit_hipGraphAddChildGraphNode_Cmplx_NestedGraphs: *level_2
-    Unit_hipGraphAddChildGraphNode_CmplxClone_NestedGraphs: *level_2
-    Unit_hipGraphAddChildGraphNode_EmptyGraphAsChildNode: *level_2
-    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerFun: *level_2
+    Unit_hipGraphAddChildGraphNode_ExecuteChildGraph:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddChildGraphNode_CloneChildGraph:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddChildGraphNode_MultipleChildNodes:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddChildGraphNode_SingleChildNode:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddChildGraphNode_Cmplx_NestedGraphs:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddChildGraphNode_CmplxClone_NestedGraphs:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddChildGraphNode_EmptyGraphAsChildNode:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerFun:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerFun_Clone:
+      tags: [graph, node]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/92
       disabled: [amd_wsl]
-    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerDim: *level_2
-    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_DelAddNode: *level_2
-    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddNode_Clone: *level_2
-    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddChdNode: *level_2
-    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddChdNode_Clone: *level_2
+    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_UpdKerDim:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_DelAddNode:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddNode_Clone:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddChdNode:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddChildGraphNode_CmplxNstGrph_AddChdNode_Clone:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipGraphAddChildGraphNode_MultGraphsAsSingleGraph:
+      tags: [graph, node]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipGraphAddChildGraphNode_CmplxNstGrph_MultGPU:
+      tags: [graph, node, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGraphNodeGetType_Negative: *level_2
-    Unit_hipGraphNodeGetType_Functional: *level_2
-    Unit_hipGraphNodeGetType_NodeType: *level_2
-    Unit_hipGraphNodeGetType_NodeTypeOfClonedGraph_NodeTypeInThread: *level_2
-    Unit_hipGraphNodeGetType_NodeTypeOfChildGraph: *level_2
-    Unit_hipGraphNodeGetType_ClonedGraph_InThread_WithDependencies: *level_2
-    Unit_hipGraphNodeGetType_NodeTypeOfChildGraph_WithDependency: *level_2
-    Unit_hipGraphExecMemcpyNodeSetParams1D_Functional: *level_2
+    Unit_hipGraphNodeGetType_Negative:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphNodeGetType_Functional:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphNodeGetType_NodeType:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphNodeGetType_NodeTypeOfClonedGraph_NodeTypeInThread:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphNodeGetType_NodeTypeOfChildGraph:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphNodeGetType_ClonedGraph_InThread_WithDependencies:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphNodeGetType_NodeTypeOfChildGraph_WithDependency:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphExecMemcpyNodeSetParams1D_Functional:
+      <<: *level_2
+      tags: [graph, exec]
     Unit_hipGraphExecMemcpyNodeSetParams1D_Negative:
+      tags: [graph, exec]
       <<: *level_2
       # SWDEV-439004: Below tests failing randomly in CQE staging
       disabled: [amd_wsl]
-    Unit_hipGraphExecMemcpyNodeSetParams1D_Positive_Basic: *level_2
-    Unit_hipGraphExecMemcpyNodeSetParams1D_Negative_Parameters: *level_2
-    Unit_hipGraphExecMemcpyNodeSetParams1D_Negative_Changing_Memcpy_Direction: *level_2
-    Unit_hipGraphGetEdges_Positive_Functional: *level_2
-    Unit_hipGraphGetEdges_Positive_CapturedStream: *level_2
-    Unit_hipGraphGetEdges_Negative_Parameters: *level_2
-    Unit_hipGraphGetEdges_Functionality: *level_2
-    Unit_hipGraphGetEdges_Negative: *level_2
-    Unit_hipGraphRemoveDependencies_Positive_Functional: *level_2
-    Unit_hipGraphRemoveDependenciesPositive_CapturedStream: *level_2
-    Unit_hipGraphRemoveDependencies_Positive_ChangeComputeFunc: *level_2
-    Unit_hipGraphRemoveDependencies_Positive_Parameters: *level_2
-    Unit_hipGraphRemoveDependencies_Negative_Parameters: *level_2
-    Unit_hipGraphRemoveDependencies_Func_Manual: *level_2
-    Unit_hipGraphRemoveDependencies_Func_StrmCapture: *level_2
-    Unit_hipGraphRemoveDependencies_ChangeComputeFunc: *level_2
-    Unit_hipGraphRemoveDependencies_Negative: *level_2
-    Unit_hipGraphInstantiate_Negative: *level_2
-    Unit_hipGraphInstantiate_Basic: *level_2
-    Unit_hipGraphInstantiate_InvalidCyclicGraph: *level_2
-    Unit_hipGraphInstantiate_functionalScenarios: *level_2
-    Unit_hipGraphExecUpdate_Negative_Basic: *level_2
-    Unit_hipGraphExecUpdate_Negative_TypeChange: *level_2
-    Unit_hipGraphExecUpdate_Negative_CountDiffer: *level_2
-    Unit_hipGraphExecUpdate_Functional: *level_2
-    Unit_hipGraphExecUpdate_Negative_Functional_ParametersChanged: *level_2
-    Unit_hipGraphExecUpdate_Negative_Functional_CountDiffer_1: *level_2
-    Unit_hipGraphExecUpdate_Negative_Functional_CountDiffer_2: *level_2
-    Unit_hipGraphExecUpdate_Negative_Dependent_NodesDiffer: *level_2
-    Unit_hipGraphExecUpdate_Negative_NodeType_Changed: *level_2
-    Unit_hipGraphExecUpdate_Negative_MultiDevice_Context_Changed:
+    Unit_hipGraphExecMemcpyNodeSetParams1D_Positive_Basic:
       <<: *level_2
-      tags: [multigpu]
+      tags: [graph, exec]
+    Unit_hipGraphExecMemcpyNodeSetParams1D_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecMemcpyNodeSetParams1D_Negative_Changing_Memcpy_Direction:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphGetEdges_Positive_Functional:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphGetEdges_Positive_CapturedStream:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphGetEdges_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphGetEdges_Functionality:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphGetEdges_Negative:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphRemoveDependencies_Positive_Functional:
+      <<: *level_2
+      tags: [graph, dependency]
+    Unit_hipGraphRemoveDependenciesPositive_CapturedStream:
+      <<: *level_2
+      tags: [graph, dependency]
+    Unit_hipGraphRemoveDependencies_Positive_ChangeComputeFunc:
+      <<: *level_2
+      tags: [graph, dependency]
+    Unit_hipGraphRemoveDependencies_Positive_Parameters:
+      <<: *level_2
+      tags: [graph, dependency]
+    Unit_hipGraphRemoveDependencies_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, dependency]
+    Unit_hipGraphRemoveDependencies_Func_Manual:
+      <<: *level_2
+      tags: [graph, dependency]
+    Unit_hipGraphRemoveDependencies_Func_StrmCapture:
+      <<: *level_2
+      tags: [graph, dependency]
+    Unit_hipGraphRemoveDependencies_ChangeComputeFunc:
+      <<: *level_2
+      tags: [graph, dependency]
+    Unit_hipGraphRemoveDependencies_Negative:
+      <<: *level_2
+      tags: [graph, dependency]
+    Unit_hipGraphInstantiate_Negative:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphInstantiate_Basic:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphInstantiate_InvalidCyclicGraph:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphInstantiate_functionalScenarios:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphExecUpdate_Negative_Basic:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecUpdate_Negative_TypeChange:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecUpdate_Negative_CountDiffer:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecUpdate_Functional:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecUpdate_Negative_Functional_ParametersChanged:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecUpdate_Negative_Functional_CountDiffer_1:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecUpdate_Negative_Functional_CountDiffer_2:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecUpdate_Negative_Dependent_NodesDiffer:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecUpdate_Negative_NodeType_Changed:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecUpdate_Negative_MultiDevice_Context_Changed:
+      tags: [graph, exec, multigpu]
+      <<: *level_2
       # SWDEV-446588 - Disable graph multi gpu testcases until graph has support for it
       disabled: [amd_windows]
-    Unit_hipGraphExecUpdate_Functional_KernelFunction_Changed: *level_2
-    Unit_hipGraphExecEventRecordNodeSetEvent_Functional: *level_2
-    Unit_hipGraphExecEventRecordNodeSetEvent_VerifyEventNotChanged: *level_2
-    Unit_hipGraphExecEventRecordNodeSetEvent_Positive_DifferentDevices:
+    Unit_hipGraphExecUpdate_Functional_KernelFunction_Changed:
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGraphExecEventRecordNodeSetEvent_Negative: *level_2
-    Unit_hipGraphEventWaitNodeSetEvent_SetProp: *level_2
-    Unit_hipGraphEventWaitNodeSetEvent_SetGet: *level_2
-    Unit_hipGraphEventWaitNodeSetEvent_Negative: *level_2
-    Unit_hipGraphMemsetNodeGetParams_Negative_Parameters: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecEventRecordNodeSetEvent_Functional:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecEventRecordNodeSetEvent_VerifyEventNotChanged:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecEventRecordNodeSetEvent_Positive_DifferentDevices:
+      tags: [graph, exec, multigpu]
+      <<: *level_2
+    Unit_hipGraphExecEventRecordNodeSetEvent_Negative:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphEventWaitNodeSetEvent_SetProp:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphEventWaitNodeSetEvent_SetGet:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphEventWaitNodeSetEvent_Negative:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphMemsetNodeGetParams_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, query]
     Unit_hipGraphMemsetNodeSetParams_Positive_Basic:
       <<: *level_2
       # Note: Following four tests disabled due to defect - EXSWHTEC-203
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphMemsetNodeSetParams_Negative_Parameters: *level_2
-    Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Negative: *level_2
-    Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Functional: *level_2
+    Unit_hipGraphMemsetNodeSetParams_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Negative:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Functional:
+      <<: *level_2
+      tags: [graph, exec]
     Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Positive_Basic:
+      tags: [graph, exec]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Negative_Parameters:
+      tags: [graph, exec]
       <<: *level_2
       # SWDEV-396617 ExecMemcpyNodeSetParamsFromSymbol fails in direction
       disabled: [amd_wsl]
-    Unit_hipGraphEventRecordNodeGetEvent_Functional: *level_2
-    Unit_hipGraphEventRecordNodeGetEvent_Negative: *level_2
-    Unit_hipGraphEventRecordNodeSetEvent_SetEventProperty: *level_2
-    Unit_hipGraphEventRecordNodeSetEvent_SetGet: *level_2
-    Unit_hipGraphEventRecordNodeSetEvent_Negative: *level_2
-    Unit_hipGraphEventWaitNodeGetEvent_Functional: *level_2
-    Unit_hipGraphEventWaitNodeGetEvent_Negative: *level_2
-    Unit_hipGraphExecMemcpyNodeSetParams_Positive_Basic: *level_2
-    Unit_hipGraphExecMemcpyNodeSetParams_Negative_Parameters: *level_2
-    Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Direction: *level_2
-    Unit_hipGraphExecMemcpyNodeSetParams_Negative: *level_2
-    Unit_hipGraphExecMemcpyNodeSetParams_Functional: *level_2
-    Unit_hipStreamBeginCapture_Positive_Functional: *level_2
-    Unit_hipStreamBeginCapture_Negative_Parameters: *level_2
-    Unit_hipStreamBeginCapture_Positive_Basic: *level_2
-    Unit_hipStreamBeginCapture_Positive_InterStrmEventSync_Flags: *level_2
-    Unit_hipStreamBeginCapture_Positive_InterStrmEventSync_Priority: *level_2
-    Unit_hipStreamBeginCapture_Positive_ColligatedStrmCapture_Flags: *level_2
-    Unit_hipStreamBeginCapture_Positive_ColligatedStrmCapture_Prio: *level_2
-    Unit_hipStreamBeginCapture_Positive_ColligatedStrmCaptureFunc: *level_2
-    Unit_hipStreamBeginCapture_Positive_Multithreaded: *level_2
-    Unit_hipStreamBeginCapture_Positive_Multiplestrms: *level_2
-    Unit_hipStreamBeginCapture_Positive_CapturingFromWithinStrms: *level_2
-    Unit_hipStreamBeginCapture_Negative_DetectingInvalidCapture: *level_2
-    Unit_hipStreamBeginCapture_Positive_CapturingMultGraphsFrom1Strm: *level_2
-    Unit_hipStreamBeginCapture_Negative_CheckingSyncDuringCapture: *level_2
-    Unit_hipStreamBeginCapture_Negative_Concurrent_CheckingSyncDuringCapture: *level_2
-    Unit_hipStreamBeginCapture_Negative_UnsafeCallsDuringCapture: *level_2
-    Unit_hipStreamBeginCapture_Negative_EndingCapwhenCapInProg: *level_2
+    Unit_hipGraphEventRecordNodeGetEvent_Functional:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphEventRecordNodeGetEvent_Negative:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphEventRecordNodeSetEvent_SetEventProperty:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphEventRecordNodeSetEvent_SetGet:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphEventRecordNodeSetEvent_Negative:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphEventWaitNodeGetEvent_Functional:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphEventWaitNodeGetEvent_Negative:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphExecMemcpyNodeSetParams_Positive_Basic:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecMemcpyNodeSetParams_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecMemcpyNodeSetParams_Negative_Changing_Memcpy_Direction:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecMemcpyNodeSetParams_Negative:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecMemcpyNodeSetParams_Functional:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipStreamBeginCapture_Positive_Functional:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Positive_Basic:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Positive_InterStrmEventSync_Flags:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Positive_InterStrmEventSync_Priority:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Positive_ColligatedStrmCapture_Flags:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Positive_ColligatedStrmCapture_Prio:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Positive_ColligatedStrmCaptureFunc:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Positive_Multithreaded:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Positive_Multiplestrms:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Positive_CapturingFromWithinStrms:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Negative_DetectingInvalidCapture:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Positive_CapturingMultGraphsFrom1Strm:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Negative_CheckingSyncDuringCapture:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Negative_Concurrent_CheckingSyncDuringCapture:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Negative_UnsafeCallsDuringCapture:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Negative_EndingCapwhenCapInProg:
+      <<: *level_2
+      tags: [graph, capture]
     Unit_hipStreamBeginCapture_Positive_MultiGPU:
+      tags: [graph, capture, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipStreamBeginCapture_Positive_nestedStreamCapture: *level_2
-    Unit_hipStreamBeginCapture_Positive_streamReuse: *level_2
-    Unit_hipStreamBeginCapture_Positive_captureComplexGraph: *level_2
-    Unit_hipStreamBeginCapture_Positive_captureEmptyStreams: *level_2
-    Unit_hipStreamBeginCapture_StreamSync_OngoingCapture: *level_2
-    Unit_hipStreamBeginCapture_StreamSync_OngoingCapture_MThread: *level_2
-    Unit_hipStreamBeginCapture_MultipleStreams_ReuseEvent: *level_2
+    Unit_hipStreamBeginCapture_Positive_nestedStreamCapture:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Positive_streamReuse:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Positive_captureComplexGraph:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Positive_captureEmptyStreams:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_StreamSync_OngoingCapture:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_StreamSync_OngoingCapture_MThread:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_MultipleStreams_ReuseEvent:
+      <<: *level_2
+      tags: [graph, capture]
     Unit_hipGraphAddMemcpyNode1D_Functional:
+      tags: [graph, node, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGraphAddMemcpyNode1D_Negative: *level_2
-    Unit_hipGraphAddMemcpyNode1D_HostToHost: *level_2
-    Unit_hipStreamBeginCapture_BasicFunctional: *level_2
-    Unit_hipStreamBeginCapture_hipStreamPerThread: *level_2
-    Unit_hipStreamBeginCapture_Negative: *level_2
-    Unit_hipStreamBeginCapture_Basic: *level_2
-    Unit_hipStreamBeginCapture_InterStrmEventSync_defaultflag: *level_2
-    Unit_hipStreamBeginCapture_InterStrmEventSync_blockingflag: *level_2
-    Unit_hipStreamBeginCapture_InterStrmEventSync_diffflags: *level_2
-    Unit_hipStreamBeginCapture_InterStrmEventSync_diffprio: *level_2
-    Unit_hipStreamBeginCapture_ColligatedStrmCapture_defaultflag: *level_2
-    Unit_hipStreamBeginCapture_ColligatedStrmCapture_blockingflag: *level_2
-    Unit_hipStreamBeginCapture_ColligatedStrmCapture_diffflags: *level_2
-    Unit_hipStreamBeginCapture_ColligatedStrmCapture_diffprio: *level_2
-    Unit_hipStreamBeginCapture_multiplestrms: *level_2
-    Unit_hipStreamBeginCapture_ColligatedStrmCapture_func: *level_2
-    Unit_hipStreamBeginCapture_Multithreaded_Global: *level_2
-    Unit_hipStreamBeginCapture_Multithreaded_ThreadLocal: *level_2
-    Unit_hipStreamBeginCapture_Multithreaded_Relaxed: *level_2
-    Unit_hipStreamBeginCapture_CapturingFromWithinStrms: *level_2
-    Unit_hipStreamBeginCapture_DetectingInvalidCapture: *level_2
-    Unit_hipStreamBeginCapture_CapturingMultGraphsFrom1Strm: *level_2
-    Unit_hipStreamBeginCapture_CheckingSyncDuringCapture: *level_2
-    Unit_hipStreamBeginCapture_EndingCapturewhenCaptureInProgress: *level_2
+    Unit_hipGraphAddMemcpyNode1D_Negative:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemcpyNode1D_HostToHost:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipStreamBeginCapture_BasicFunctional:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_hipStreamPerThread:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Negative:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Basic:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_InterStrmEventSync_defaultflag:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_InterStrmEventSync_blockingflag:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_InterStrmEventSync_diffflags:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_InterStrmEventSync_diffprio:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_ColligatedStrmCapture_defaultflag:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_ColligatedStrmCapture_blockingflag:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_ColligatedStrmCapture_diffflags:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_ColligatedStrmCapture_diffprio:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_multiplestrms:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_ColligatedStrmCapture_func:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Multithreaded_Global:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Multithreaded_ThreadLocal:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_Multithreaded_Relaxed:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_CapturingFromWithinStrms:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_DetectingInvalidCapture:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_CapturingMultGraphsFrom1Strm:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_CheckingSyncDuringCapture:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_EndingCapturewhenCaptureInProgress:
+      <<: *level_2
+      tags: [graph, capture]
     Unit_hipStreamBeginCapture_MultiGPU:
+      tags: [graph, capture, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipStreamBeginCapture_nestedStreamCapture: *level_2
-    Unit_hipStreamBeginCapture_streamReuse: *level_2
+    Unit_hipStreamBeginCapture_nestedStreamCapture:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCapture_streamReuse:
+      <<: *level_2
+      tags: [graph, capture]
     Unit_hipStreamBeginCapture_captureComplexGraph:
+      tags: [graph, capture]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamBeginCapture_captureEmptyStreams: *level_2
-    Unit_hipStreamIsCapturing_Negative_Parameters: *level_2
-    Unit_hipStreamIsCapturing_Positive_Basic: *level_2
-    Unit_hipStreamIsCapturing_Positive_Functional: *level_2
-    Unit_hipStreamIsCapturing_Positive_Thread: *level_2
-    Unit_hipStreamIsCapturing_Negative: *level_2
-    Unit_hipStreamIsCapturing_Functional_Basic: *level_2
-    Unit_hipStreamIsCapturing_Functional: *level_2
-    Unit_hipStreamIsCapturing_hipStreamPerThread: *level_2
-    Unit_hipStreamIsCapturing_ParentAndForkedStream: *level_2
-    Unit_hipStreamIsCapturing_CheckCaptureStatus_FromThread: *level_2
-    Unit_hipStreamIsCapturing_ChkNullStrmStatus: *level_2
-    Unit_hipGraphMemFreeNodeGetParams_ValidArgs: *level_2
+    Unit_hipStreamBeginCapture_captureEmptyStreams:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamIsCapturing_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamIsCapturing_Positive_Basic:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamIsCapturing_Positive_Functional:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamIsCapturing_Positive_Thread:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamIsCapturing_Negative:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamIsCapturing_Functional_Basic:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamIsCapturing_Functional:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamIsCapturing_hipStreamPerThread:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamIsCapturing_ParentAndForkedStream:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamIsCapturing_CheckCaptureStatus_FromThread:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamIsCapturing_ChkNullStrmStatus:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipGraphMemFreeNodeGetParams_ValidArgs:
+      <<: *level_2
+      tags: [graph, query]
     Unit_hipGraphMemFreeNodeGetParams_InvalidArgs:
+      tags: [graph, query]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_hipGraphUserObj_Int_float_Objects: *level_2
-    Unit_hipGraphUserObj_HostRegister: *level_2
-    Unit_hipGraphUserObj_Struct_Class_Ojects: *level_2
+    Unit_hipGraphUserObj_Int_float_Objects:
+      <<: *level_2
+      tags: [graph, userobj]
+    Unit_hipGraphUserObj_HostRegister:
+      <<: *level_2
+      tags: [graph, userobj]
+    Unit_hipGraphUserObj_Struct_Class_Ojects:
+      <<: *level_2
+      tags: [graph, userobj]
     Unit_hipGraphUserObj_ClonedGraph:
+      tags: [graph, userobj]
       <<: *level_2
       # Test Unit_hipGraphUserObj_ClonedGraph disabled due to SWDEV-483112
       disabled: [amd_windows]
-    Unit_hipGraphUserObj_ManualGraph: *level_2
-    Unit_hipGraphExecBatchMemOpNodeSetParams_NegativeTsts: *level_2
-    Unit_hipGraphAddBatchMemOpNode_NegativeTsts: *level_2
-    Unit_hipGraphBatchMemOpNodeSetParams_NegativeTsts: *level_2
-    Unit_hipGraphBatchMemOpNodeGetParams_NegativeTsts: *level_2
-    Unit_hipDrvGraphExecMemcpyNodeSetParams_Negative: *level_2
-    Unit_hipDrvGraphExecMemcpyNodeSetParams_Positive: *level_2
-    Unit_hipDrvGraphAddMemFreeNode_Negative_Params: *level_2
-    Unit_hipDrvGraphAddMemFreeNode_Positive: *level_2
-    Unit_hipStreamCapture_ExtModuleLaunchKernel: *level_2
-    Unit_hipStreamBeginCaptureToGraph_BasicFunctional: *level_2
-    Unit_hipStreamBeginCaptureToGraph_CaptureIndepGraph: *level_2
+    Unit_hipGraphUserObj_ManualGraph:
+      <<: *level_2
+      tags: [graph, userobj]
+    Unit_hipGraphExecBatchMemOpNodeSetParams_NegativeTsts:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphAddBatchMemOpNode_NegativeTsts:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphBatchMemOpNodeSetParams_NegativeTsts:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphBatchMemOpNodeGetParams_NegativeTsts:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipDrvGraphExecMemcpyNodeSetParams_Negative:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipDrvGraphExecMemcpyNodeSetParams_Positive:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipDrvGraphAddMemFreeNode_Negative_Params:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipDrvGraphAddMemFreeNode_Positive:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipStreamCapture_ExtModuleLaunchKernel:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCaptureToGraph_BasicFunctional:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCaptureToGraph_CaptureIndepGraph:
+      <<: *level_2
+      tags: [graph, capture]
     Unit_hipStreamBeginCaptureToGraph_CaptureDepGraph:
+      tags: [graph, capture]
       <<: *level_2
       # SWDEV-454245, SWDEV-454247 : Below tests fail on 29/03/24
       disabled: [amd_windows]
-    Unit_hipStreamBeginCaptureToGraph_ComplexGraph: *level_2
-    Unit_hipStreamBeginCaptureToGraph_CaptureTwice: *level_2
-    Unit_hipStreamBeginCaptureToGraph_ModifyCloneGraph: *level_2
-    Unit_hipStreamBeginCaptureToGraph_CaptureChildpGraph: *level_2
-    Unit_hipStreamBeginCaptureToGraph_ModifyChildpGraph: *level_2
-    Unit_hipStreamBeginCaptureToGraph_Negative: *level_2
-    Unit_hipStreamBeginCaptureToGraph_StateTesting: *level_2
-    Unit_hipStreamBeginCaptureToGraph_GetCaptureInfo: *level_2
-    Unit_hipStreamBeginCaptureToGraph_EndingWhileCaptureInProgress: *level_2
-    Unit_hipStreamBeginCaptureToGraph_MultipleFlags: *level_2
-    Unit_hipStreamBeginCaptureToGraph_CapturePartialInThreads: *level_2
+    Unit_hipStreamBeginCaptureToGraph_ComplexGraph:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCaptureToGraph_CaptureTwice:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCaptureToGraph_ModifyCloneGraph:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCaptureToGraph_CaptureChildpGraph:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCaptureToGraph_ModifyChildpGraph:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCaptureToGraph_Negative:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCaptureToGraph_StateTesting:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCaptureToGraph_GetCaptureInfo:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCaptureToGraph_EndingWhileCaptureInProgress:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCaptureToGraph_MultipleFlags:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamBeginCaptureToGraph_CapturePartialInThreads:
+      <<: *level_2
+      tags: [graph, capture]
     Unit_hipStreamBeginCaptureToGraph_IndepGraphsThreads:
+      tags: [graph, capture]
       <<: *level_2
       # SWDEV-454245, SWDEV-454247 : Below tests fail on 29/03/24
       disabled: [amd_windows]
-    Unit_hipGetProcAddress_GraphAPIs_StreamCapture: *level_2
-    Unit_hipGetProcAddress_GraphAPIs_AddMemcpy1DKernelNodes: *level_2
-    Unit_hipGetProcAddress_GraphAPIs_AddMemsetMemcpyNodes: *level_2
-    Unit_hipGetProcAddress_GraphAPIs_SetGetParamsMemsetMemcpy: *level_2
-    Unit_hipGetProcAddress_GraphAPIs_KernelNodeSetGetParams: *level_2
-    Unit_hipGetProcAddress_GraphAPIs_KernelNodeSetGetAttribute: *level_2
-    Unit_hipGetProcAddress_GraphAPIs_HostNode: *level_2
-    Unit_hipGetProcAddress_GraphAPIs_ExecUpdate: *level_2
-    Unit_hipGetProcAddress_GraphAPIs_Memcpy1DSetParams: *level_2
-    Unit_hipGetProcAddress_GraphAPIs_MemAllocAndFree: *level_2
-    Unit_hipGetProcAddress_GraphAPIs_ExecMemsetMemcpySetParams: *level_2
-    Unit_hipGraphExecNodeSetParams_Negative_Parameters: *level_2
-    Unit_hipGraphExecNodeSetParams_Positive: *level_2
-    Unit_hipGraphNodeSetParams_Negative_Parameters: *level_2
-    Unit_hipGraphNodeSetParams_Positive: *level_2
-    Unit_hipGraphExecGetFlags_Negative: *level_2
+    Unit_hipGetProcAddress_GraphAPIs_StreamCapture:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGetProcAddress_GraphAPIs_AddMemcpy1DKernelNodes:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGetProcAddress_GraphAPIs_AddMemsetMemcpyNodes:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGetProcAddress_GraphAPIs_SetGetParamsMemsetMemcpy:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGetProcAddress_GraphAPIs_KernelNodeSetGetParams:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGetProcAddress_GraphAPIs_KernelNodeSetGetAttribute:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGetProcAddress_GraphAPIs_HostNode:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGetProcAddress_GraphAPIs_ExecUpdate:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGetProcAddress_GraphAPIs_Memcpy1DSetParams:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGetProcAddress_GraphAPIs_MemAllocAndFree:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGetProcAddress_GraphAPIs_ExecMemsetMemcpySetParams:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphExecNodeSetParams_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecNodeSetParams_Positive:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphNodeSetParams_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphNodeSetParams_Positive:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphExecGetFlags_Negative:
+      <<: *level_2
+      tags: [graph, exec]
     Unit_hipGraphExecGetFlags_Positive: *level_2
-    Unit_hipStreamGetCaptureInfo_Positive_Functional: *level_2
-    Unit_hipStreamGetCaptureInfo_Positive_UniqueID: *level_2
-    Unit_hipStreamGetCaptureInfo_Negative_Parameters: *level_2
-    Unit_hipStreamGetCaptureInfo_BasicFunctional: *level_2
-    Unit_hipStreamGetCaptureInfo_hipStreamPerThread: *level_2
-    Unit_hipStreamGetCaptureInfo_UniqueID: *level_2
-    Unit_hipStreamGetCaptureInfo_ArgValidation: *level_2
-    Unit_hipStreamGetCaptureInfo_ParentAndForkedStrm_CaptureStatus: *level_2
-    Unit_hipStreamGetCaptureInfo_CaptureStatus_InThread: *level_2
-    Unit_hipStreamGetCaptureInfo_CaptureStatus_Througout_Capture: *level_2
-    Unit_hipStreamGetCaptureInfo_Nullstream_CaptureInfo: *level_2
-    Unit_hipStreamEndCapture_Negative_Parameters: *level_2
-    Unit_hipStreamEndCapture_Positive_GraphDestroy: *level_2
-    Unit_hipStreamEndCapture_Negative_Thread: *level_2
-    Unit_hipStreamEndCapture_Positive_Thread: *level_2
-    Unit_hipStreamEndCapture_Negative: *level_2
-    Unit_hipStreamEndCapture_Thread_Negative: *level_2
-    Unit_hipStreamEndCapture_mode_hipStreamCaptureModeRelaxed: *level_2
-    Unit_hipStreamEndCapture_chkError_on_wrongStream: *level_2
-    Unit_hipStreamEndCapture_streamMerge_in_thread: *level_2
-    Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Negative: *level_2
-    Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Functional: *level_2
+    Unit_hipStreamGetCaptureInfo_Positive_Functional:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamGetCaptureInfo_Positive_UniqueID:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamGetCaptureInfo_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamGetCaptureInfo_BasicFunctional:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamGetCaptureInfo_hipStreamPerThread:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamGetCaptureInfo_UniqueID:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamGetCaptureInfo_ArgValidation:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamGetCaptureInfo_ParentAndForkedStrm_CaptureStatus:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamGetCaptureInfo_CaptureStatus_InThread:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamGetCaptureInfo_CaptureStatus_Througout_Capture:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamGetCaptureInfo_Nullstream_CaptureInfo:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamEndCapture_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamEndCapture_Positive_GraphDestroy:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamEndCapture_Negative_Thread:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamEndCapture_Positive_Thread:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamEndCapture_Negative:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamEndCapture_Thread_Negative:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamEndCapture_mode_hipStreamCaptureModeRelaxed:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamEndCapture_chkError_on_wrongStream:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamEndCapture_streamMerge_in_thread:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Negative:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Functional:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Positive_Basic:
+      tags: [graph, node]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Negative_Parameters: *level_2
-    Unit_hipGraphExecEventWaitNodeSetEvent_SetAndVerifyMemory: *level_2
-    Unit_hipGraphExecEventWaitNodeSetEvent_VerifyEventNotChanged: *level_2
-    Unit_hipGraphExecEventWaitNodeSetEvent_Negative: *level_2
+    Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphExecEventWaitNodeSetEvent_SetAndVerifyMemory:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecEventWaitNodeSetEvent_VerifyEventNotChanged:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecEventWaitNodeSetEvent_Negative:
+      <<: *level_2
+      tags: [graph, exec]
     Unit_hipGraphAddMemsetNode_Positive_Basic: *level_2
-    Unit_hipGraphAddMemsetNode_Negative_Parameters: *level_2
-    Unit_hipGraphAddMemsetNode_hipMallocPitch_2D: *level_2
-    Unit_hipGraphAddMemsetNode_hipMallocPitch_1D: *level_2
-    Unit_hipGraphAddMemsetNode_hipMalloc3D_2D: *level_2
-    Unit_hipGraphAddMemsetNode_hipMalloc3D_1D: *level_2
-    Unit_hipGraphAddMemsetNode_hipMalloc_1D: *level_2
-    Unit_hipGraphAddMemsetNode_hipMallocManaged: *level_2
-    Unit_hipGraphAddKernelNode_Negative: *level_2
-    Unit_hipGraphAddKernelNode_moduleLoadKernelFn_graphNclonedGraph: *level_2
-    Unit_hipGraphAddKernelNode_moduleLoadKernelFn_kernelFnUpdate: *level_2
-    Unit_hipGraphAddKernelNode_moduleLoadKernelFn_childGraph: *level_2
-    Unit_hipGraphAddKernelNode_moduleLoadKernelFn_streamCapture: *level_2
-    Unit_hipGraphMemcpyNodeGetParams_Negative_Parameters: *level_2
-    Unit_hipGraphMemcpyNodeGetParams_Negative: *level_2
-    Unit_hipGraphMemcpyNodeGetParams_Functional: *level_2
-    Unit_hipGraphMemcpyNodeSetParams_Positive_Basic: *level_2
-    Unit_hipGraphMemcpyNodeSetParams_Negative_Parameters: *level_2
-    Unit_hipGraphMemcpyNodeSetParams_Negative: *level_2
+    Unit_hipGraphAddMemsetNode_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemsetNode_hipMallocPitch_2D:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemsetNode_hipMallocPitch_1D:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemsetNode_hipMalloc3D_2D:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemsetNode_hipMalloc3D_1D:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemsetNode_hipMalloc_1D:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemsetNode_hipMallocManaged:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddKernelNode_Negative:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddKernelNode_moduleLoadKernelFn_graphNclonedGraph:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddKernelNode_moduleLoadKernelFn_kernelFnUpdate:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddKernelNode_moduleLoadKernelFn_childGraph:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddKernelNode_moduleLoadKernelFn_streamCapture:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphMemcpyNodeGetParams_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphMemcpyNodeGetParams_Negative:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphMemcpyNodeGetParams_Functional:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphMemcpyNodeSetParams_Positive_Basic:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphMemcpyNodeSetParams_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphMemcpyNodeSetParams_Negative:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipGraphMemcpyNodeSetParams_Functional:
+      tags: [graph, node]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphKernelNodeGetParams_Negative: *level_2
-    Unit_hipGraphKernelNodeGetParams_Functional: *level_2
-    Unit_hipGraphKernelNodeSetParams_Negative: *level_2
-    Unit_hipGraphKernelNodeSetParams_Functional: *level_2
-    Unit_hipGraphKernelNodeGetSetParams_Functional: *level_2
-    Unit_hipGraphExecKernelNodeSetParams_Negative: *level_2
-    Unit_hipGraphExecKernelNodeSetParams_Functional: *level_2
-    Unit_hipGraphLaunch_Positive: *level_2
-    Unit_hipGraphLaunch_Negative_Parameters: *level_2
-    Unit_hipGraphLaunch_Negative: *level_2
-    Unit_hipGraphLaunch_Functional_hipStreamPerThread: *level_2
-    Unit_hipGraphLaunch_Functional_multidevice_test:
+    Unit_hipGraphKernelNodeGetParams_Negative:
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGraphLaunch_Functional_MultipleLaunch: *level_2
-    Unit_hipGraphMemcpyNodeSetParams1D_Positive_Basic: *level_2
-    Unit_hipGraphMemcpyNodeSetParams1D_Negative_Parameters: *level_2
-    Unit_hipGraphMemcpyNodeSetParams1D_Negative: *level_2
-    Unit_hipGraphMemcpyNodeSetParams1D_Functional: *level_2
-    Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Negative: *level_2
+      tags: [graph, query]
+    Unit_hipGraphKernelNodeGetParams_Functional:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphKernelNodeSetParams_Negative:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphKernelNodeSetParams_Functional:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphKernelNodeGetSetParams_Functional:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphExecKernelNodeSetParams_Negative:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecKernelNodeSetParams_Functional:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphLaunch_Positive:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphLaunch_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphLaunch_Negative:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphLaunch_Functional_hipStreamPerThread:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphLaunch_Functional_multidevice_test:
+      tags: [graph, exec, multigpu]
+      <<: *level_2
+    Unit_hipGraphLaunch_Functional_MultipleLaunch:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphMemcpyNodeSetParams1D_Positive_Basic:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphMemcpyNodeSetParams1D_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphMemcpyNodeSetParams1D_Negative:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphMemcpyNodeSetParams1D_Functional:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Negative:
+      <<: *level_2
+      tags: [graph, exec]
     Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Functional:
+      tags: [graph, exec]
       <<: *level_2
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Positive_Basic:
+      tags: [graph, exec]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipGraphExecMemcpyNodeSetParamsToSymbol_Negative_Parameters:
+      tags: [graph, exec, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGraphNodeGetDependentNodes_Positive_Functional: *level_2
-    Unit_hipGraphNodeGetDependentNodes_Negative_Parameters: *level_2
+    Unit_hipGraphNodeGetDependentNodes_Positive_Functional:
+      <<: *level_2
+      tags: [graph, dependency]
+    Unit_hipGraphNodeGetDependentNodes_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, dependency]
     Unit_hipGraphNodeGetDependentNodes_Functional:
+      tags: [graph, dependency]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphNodeGetDependentNodes_ParamValidation: *level_2
-    Unit_hipGraphNodeGetDependencies_Positive_Functional: *level_2
-    Unit_hipGraphNodeGetDependencies_Negative_Parameters: *level_2
+    Unit_hipGraphNodeGetDependentNodes_ParamValidation:
+      <<: *level_2
+      tags: [graph, dependency]
+    Unit_hipGraphNodeGetDependencies_Positive_Functional:
+      <<: *level_2
+      tags: [graph, dependency]
+    Unit_hipGraphNodeGetDependencies_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, dependency]
     Unit_hipGraphNodeGetDependencies_Functional:
+      tags: [graph, dependency]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphNodeGetDependencies_ParamValidation: *level_2
-    Unit_hipGraphHostNodeGetParams_Negative: *level_2
-    Unit_hipGraphHostNodeGetParams_ClonedGraphWithHostNode: *level_2
-    Unit_hipGraphHostNodeGetParams_BasicFunc: *level_2
-    Unit_hipGraphHostNodeGetParams_SetParams: *level_2
-    Unit_hipGraphExecChildGraphNodeSetParams_Negative: *level_2
-    Unit_hipGraphExecChildGraphNodeSetParams_BasicFunc: *level_2
+    Unit_hipGraphNodeGetDependencies_ParamValidation:
+      <<: *level_2
+      tags: [graph, dependency]
+    Unit_hipGraphHostNodeGetParams_Negative:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphHostNodeGetParams_ClonedGraphWithHostNode:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphHostNodeGetParams_BasicFunc:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphHostNodeGetParams_SetParams:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphExecChildGraphNodeSetParams_Negative:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipGraphExecChildGraphNodeSetParams_BasicFunc:
+      <<: *level_2
+      tags: [graph, exec]
     Unit_hipGraphExecChildGraphNodeSetParams_ChildTopology:
+      tags: [graph, exec]
       <<: *level_2
       # (amd_windows) SWDEV-347670 - blocking tests have TDR, causing hangs
       # (amd_wsl) Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamGetCaptureInfo_v2_Positive_Functional: *level_2
-    Unit_hipStreamGetCaptureInfo_v2_Positive_UniqueID: *level_2
-    Unit_hipStreamGetCaptureInfo_v2_Negative_Parameters: *level_2
-    Unit_hipGraphCreate_Negative_Parameters: *level_2
-    Unit_hipGraphCreate_Positive_Basic: *level_2
-    Unit_hipGraphDestroy_Positive_Basic: *level_2
-    Unit_hipGraphDestroy_Negative_Parameters: *level_2
+    Unit_hipStreamGetCaptureInfo_v2_Positive_Functional:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamGetCaptureInfo_v2_Positive_UniqueID:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamGetCaptureInfo_v2_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipGraphCreate_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphCreate_Positive_Basic:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphDestroy_Positive_Basic:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphDestroy_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, lifecycle]
     Unit_hipStreamSetCaptureDependencies_Positive_Functional:
+      tags: [graph, capture]
       <<: *level_2
       # Note: Following four tests disabled due to defect - EXSWHTEC-203
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamAddCaptureDependencies_Positive_Functional: *level_2
-    Unit_hipStreamUpdateCaptureDependencies_Positive_Parameters: *level_2
-    Unit_hipStreamUpdateCaptureDependencies_Negative_Parameters: *level_2
-    Unit_hipThreadExchangeStreamCaptureMode_Positive_Functional: *level_2
-    Unit_hipThreadExchangeStreamCaptureMode_Negative_Parameters: *level_2
-    Unit_hipLaunchHostFunc_Negative_Parameters: *level_2
-    Unit_hipLaunchHostFunc_Positive_Functional: *level_2
-    Unit_hipLaunchHostFunc_Positive_Thread: *level_2
-    Unit_hipLaunchHostFunc_H2D_Kernel_D2H_Capture: *level_2
-    Unit_hipStreamGetCaptureInfo_v2_BasicFunctional: *level_2
-    Unit_hipStreamGetCaptureInfo_v2_hipStreamPerThread: *level_2
-    Unit_hipStreamGetCaptureInfo_v2_UniqueID: *level_2
-    Unit_hipStreamGetCaptureInfo_v2_ParamValidation: *level_2
-    Unit_hipUserObjectCreate_Functional_1: *level_2
-    Unit_hipUserObjectCreate_Functional_2: *level_2
-    Unit_hipUserObjectCreate_Functional_3: *level_2
-    Unit_hipUserObjectCreate_Functional_4: *level_2
-    Unit_hipUserObjectCreate_Negative: *level_2
-    Unit_hipUserObj_Negative_Test: *level_2
-    Unit_hipUserObjectRelease_Negative: *level_2
-    Unit_hipUserObjectRetain_Negative: *level_2
-    Unit_hipGraphReleaseUserObject_Negative: *level_2
-    Unit_hipGraphRetainUserObject_Functional_1: *level_2
-    Unit_hipGraphRetainUserObject_Functional_2: *level_2
-    Unit_hipGraphRetainUserObject_Negative: *level_2
-    Unit_hipGraphRetainUserObject_Negative_Basic: *level_2
+    Unit_hipStreamAddCaptureDependencies_Positive_Functional:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamUpdateCaptureDependencies_Positive_Parameters:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamUpdateCaptureDependencies_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipThreadExchangeStreamCaptureMode_Positive_Functional:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipThreadExchangeStreamCaptureMode_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipLaunchHostFunc_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipLaunchHostFunc_Positive_Functional:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipLaunchHostFunc_Positive_Thread:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipLaunchHostFunc_H2D_Kernel_D2H_Capture:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamGetCaptureInfo_v2_BasicFunctional:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamGetCaptureInfo_v2_hipStreamPerThread:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamGetCaptureInfo_v2_UniqueID:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipStreamGetCaptureInfo_v2_ParamValidation:
+      <<: *level_2
+      tags: [graph, capture]
+    Unit_hipUserObjectCreate_Functional_1:
+      <<: *level_2
+      tags: [graph, userobj]
+    Unit_hipUserObjectCreate_Functional_2:
+      <<: *level_2
+      tags: [graph, userobj]
+    Unit_hipUserObjectCreate_Functional_3:
+      <<: *level_2
+      tags: [graph, userobj]
+    Unit_hipUserObjectCreate_Functional_4:
+      <<: *level_2
+      tags: [graph, userobj]
+    Unit_hipUserObjectCreate_Negative:
+      <<: *level_2
+      tags: [graph, userobj]
+    Unit_hipUserObj_Negative_Test:
+      <<: *level_2
+      tags: [graph, userobj]
+    Unit_hipUserObjectRelease_Negative:
+      <<: *level_2
+      tags: [graph, userobj]
+    Unit_hipUserObjectRetain_Negative:
+      <<: *level_2
+      tags: [graph, userobj]
+    Unit_hipGraphReleaseUserObject_Negative:
+      <<: *level_2
+      tags: [graph, userobj]
+    Unit_hipGraphRetainUserObject_Functional_1:
+      <<: *level_2
+      tags: [graph, userobj]
+    Unit_hipGraphRetainUserObject_Functional_2:
+      <<: *level_2
+      tags: [graph, userobj]
+    Unit_hipGraphRetainUserObject_Negative:
+      <<: *level_2
+      tags: [graph, userobj]
+    Unit_hipGraphRetainUserObject_Negative_Basic:
+      <<: *level_2
+      tags: [graph, userobj]
     Unit_hipGraphRetainUserObject_Negative_Null_Object: *level_2
-    Unit_hipGraphDebugDotPrint_Functional: *level_2
-    Unit_hipGraphDebugDotPrint_Argument_Check: *level_2
-    Unit_hipGraphClone_Test_hipGraphKernelNodeSetParams: *level_2
-    Unit_hipGraphClone_Test_hipGraphExecKernelNodeSetParams: *level_2
-    Unit_hipGraphClone_Test_hipGraphAddMemcpy_and_memset: *level_2
-    Unit_hipGraphClone_Test_hipGraphMemcpyNodeSetParams: *level_2
+    Unit_hipGraphDebugDotPrint_Functional:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphDebugDotPrint_Argument_Check:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphClone_Test_hipGraphKernelNodeSetParams:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphClone_Test_hipGraphExecKernelNodeSetParams:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphClone_Test_hipGraphAddMemcpy_and_memset:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphClone_Test_hipGraphMemcpyNodeSetParams:
+      <<: *level_2
+      tags: [graph, lifecycle]
     Unit_hipGraphClone_Test_hipGraphExecMemcpyNodeSetParams:
+      tags: [graph, lifecycle]
       <<: *level_2
       # Below tests fail in stress test on 23/06/23
       disabled: [amd_wsl]
     Unit_hipGraphClone_Test_hipGraphMemcpyNodeSetParams1D_and_exec:
+      tags: [graph, lifecycle]
       <<: *level_2
       # Below tests fail in stress test on 23/06/23
       disabled: [amd_wsl]
-    Unit_hipGraphClone_hipGraphMemcpyNodeSetParamsFromSymbol_exec: *level_2
-    Unit_hipGraphClone_hipGraphMemcpyNodeSetParamsToSymbol_exec: *level_2
-    Unit_hipGraphClone_Test_hipGraphMemsetNodeSetParams_exec: *level_2
-    Unit_hipGraphClone_Test_hipGraphRemoveDependencies: *level_2
-    Unit_hipGraphClone_Test_hipGraphExecChildGraphNodeSetParams: *level_2
-    Unit_hipGraphClone_Test_hipGraphEventRecordNodeSetEvent_and_Exec: *level_2
-    Unit_hipGraphClone_Test_hipGraphEventWaitNodeSetEvent_and_Exec: *level_2
+    Unit_hipGraphClone_hipGraphMemcpyNodeSetParamsFromSymbol_exec:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphClone_hipGraphMemcpyNodeSetParamsToSymbol_exec:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphClone_Test_hipGraphMemsetNodeSetParams_exec:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphClone_Test_hipGraphRemoveDependencies:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphClone_Test_hipGraphExecChildGraphNodeSetParams:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphClone_Test_hipGraphEventRecordNodeSetEvent_and_Exec:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphClone_Test_hipGraphEventWaitNodeSetEvent_and_Exec:
+      <<: *level_2
+      tags: [graph, lifecycle]
     Unit_hipGraphClone_address_change_in_loop:
+      tags: [graph, lifecycle, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGraphClone_address_change_in_thread:
+      tags: [graph, lifecycle, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGraphClone_multi_GPU_test:
+      tags: [graph, lifecycle, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGraphClone_hipUserObject_hipGraphUserObject: *level_2
-    Unit_hipGraphClone_hipUserObject_hipGraphUserObject_Negative: *level_2
-    Unit_hipGraphChild_hipUserObject_hipGraphUserObject: *level_2
-    Unit_hipGraphNodeSetEnabled_Functional_Basic: *level_2
-    Unit_hipGraphNodeSetEnabled_Functional_KernelNode: *level_2
-    Unit_hipGraphNodeSetEnabled_Functional_MemSet: *level_2
-    Unit_hipGraphNodeSetEnabled_Functional_MemCpy: *level_2
-    Unit_hipGraphNodeSetEnabled_Negative_Functional: *level_2
-    Unit_hipGraphNodeGetEnabled_Functional_Basic: *level_2
-    Unit_hipGraphNodeGetEnabled_Negative_Functional: *level_2
-    Unit_hipGraphExecDestroy_Negative_Parameters: *level_2
-    Unit_hipGraphExecDestroy_Positive_Basic: *level_2
-    Unit_hipGraphUpload_Functional: *level_2
+    Unit_hipGraphClone_hipUserObject_hipGraphUserObject:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphClone_hipUserObject_hipGraphUserObject_Negative:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphChild_hipUserObject_hipGraphUserObject:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphNodeSetEnabled_Functional_Basic:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphNodeSetEnabled_Functional_KernelNode:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphNodeSetEnabled_Functional_MemSet:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphNodeSetEnabled_Functional_MemCpy:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphNodeSetEnabled_Negative_Functional:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphNodeGetEnabled_Functional_Basic:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphNodeGetEnabled_Negative_Functional:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphExecDestroy_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphExecDestroy_Positive_Basic:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraphUpload_Functional:
+      <<: *level_2
+      tags: [graph, exec]
     Unit_hipGraphUpload_Functional_multidevice_test:
+      tags: [graph, exec, multigpu]
       <<: *level_2
-      tags: [multigpu]
       # (amd_linux) SWDEV-553920 disabled until multi device graph issues are resolved
       # (amd_windows) SWDEV-446588 - Disable graph multi gpu testcases until graph has support for it
       disabled: [amd_linux, amd_windows]
-    Unit_hipGraphUpload_Functional_With_Priority_Stream: *level_2
+    Unit_hipGraphUpload_Functional_With_Priority_Stream:
+      <<: *level_2
+      tags: [graph, exec]
     Unit_hipGraphUpload_Negative_Parameters:
+      tags: [graph, exec]
       <<: *level_2
       # SWDEV-434878: Below tests failed in stress test on 24/11/23
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGraphKernelNodeCopyAttributes_Functional: *level_2
-    Unit_hipGraphKernelNodeCopyAttributes_Attribute_Negative: *level_2
-    Unit_hipStreamBeginCapture_with_hipGraphAddHostNode: *level_2
-    Unit_hipStreamEndCapture_later_and_add_a_node_inbetween: *level_2
-    Unit_hipStreamEndCapture_first_and_add_a_node_later: *level_2
-    Unit_hipStreamEndCapture_first_and_add_other_graph_node_later: *level_2
-    Unit_hipStreamEndCapture_later_and_addEmptyNode: *level_2
-    Unit_hipGraph_BasicCyclic1: *level_2
-    Unit_hipGraph_BasicCyclic2: *level_2
-    Unit_hipGraph_BasicCyclic3: *level_2
-    Unit_hipGraph_BasicCyclic4: *level_2
-    Unit_hipGraph_BasicCyclic5: *level_2
-    Unit_hipGraph_PerfCheck_MemcpyKernelMixCall: *level_2
+    Unit_hipGraphKernelNodeCopyAttributes_Functional:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphKernelNodeCopyAttributes_Attribute_Negative:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipStreamBeginCapture_with_hipGraphAddHostNode:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipStreamEndCapture_later_and_add_a_node_inbetween:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipStreamEndCapture_first_and_add_a_node_later:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipStreamEndCapture_first_and_add_other_graph_node_later:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipStreamEndCapture_later_and_addEmptyNode:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraph_BasicCyclic1:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraph_BasicCyclic2:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraph_BasicCyclic3:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraph_BasicCyclic4:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraph_BasicCyclic5:
+      <<: *level_2
+      tags: [graph, lifecycle]
+    Unit_hipGraph_PerfCheck_MemcpyKernelMixCall:
+      <<: *level_2
+      tags: [graph, exec]
     Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams:
+      tags: [graph, exec, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecKernelNodeSetParams_inLoop:
+      tags: [graph, exec, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams: *level_2
+    Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams:
+      <<: *level_2
+      tags: [graph, exec]
     Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams_inLoop:
+      tags: [graph, exec, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParams1D_inLoop:
+      tags: [graph, exec, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsFrmSymbol:
+      tags: [graph, exec, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecMemcpyNodeSetParamsToSymbol:
+      tags: [graph, exec, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecMemsetNodeSetParams:
+      tags: [graph, exec, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecChildGraphNodeSetParams:
+      tags: [graph, exec, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecEventRecordNodeSetEvent:
+      tags: [graph, exec, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecEventWaitNodeSetEvent:
+      tags: [graph, exec, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecHostNodeSetParams:
+      tags: [graph, exec, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecUpdate:
+      tags: [graph, exec, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGraph_PerfCheck_hipGraphExecUpdate_kernel_inLoop:
+      tags: [graph, exec, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGraphKernelNodeGetAttribute_Negative_Parameters: *level_2
-    Unit_hipGraphKernelNodeSetAttribute_Positive_AccessPolicyWindow: *level_2
-    Unit_hipGraphKernelNodeSetAttribute_Positive_Cooperative: *level_2
-    Unit_hipGraphKernelNodeSetAttribute_Negative_Parameters: *level_2
-    Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional: *level_2
+    Unit_hipGraphKernelNodeGetAttribute_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipGraphKernelNodeSetAttribute_Positive_AccessPolicyWindow:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphKernelNodeSetAttribute_Positive_Cooperative:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphKernelNodeSetAttribute_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional:
+      <<: *level_2
+      tags: [graph, query]
     Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_MultiDevice:
+      tags: [graph, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
       # SWDEV-446588 - Disable graph multi gpu testcases until graph has support for it
       disabled: [amd_windows]
-    Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_2: *level_2
+    Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_2:
+      <<: *level_2
+      tags: [graph, query]
     Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_3:
+      tags: [graph, query]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipGraphMem_Alloc_Free_NodeGetParams_Negative:
+      tags: [graph, query]
       <<: *level_2
       # (amd_linux) Rock_Linux_Failures_on_gfx94X
       # (amd_wsl) SWDEV-430116:Below tests failed in stress test on 27/10/23
       disabled: [amd_linux, amd_wsl]
-    Unit_hipGraphAddMemAllocNode_Negative_Params: *level_2
-    Unit_hipGraphAddMemAllocNode_Negative_NotSupported: *level_2
+    Unit_hipGraphAddMemAllocNode_Negative_Params:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemAllocNode_Negative_NotSupported:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipGraphAddMemAllocNode_Positive_FreeInGraph:
+      tags: [graph, node]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipGraphAddMemAllocNode_Positive_FreeOutsideStream: *level_2
-    Unit_hipGraphAddMemAllocNode_Positive_FreeOutsideGraph: *level_2
-    Unit_hipGraphAddMemAllocNode_Positive_FreeSeparateGraph: *level_2
-    Unit_hipGraphAddMemAllocNode_Functional_1: *level_2
+    Unit_hipGraphAddMemAllocNode_Positive_FreeOutsideStream:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemAllocNode_Positive_FreeOutsideGraph:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemAllocNode_Positive_FreeSeparateGraph:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemAllocNode_Functional_1:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipGraphAddMemAllocNode_Functional_2:
+      tags: [graph, node, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGraphAddMemAllocNode_Functional_3:
+      tags: [graph, node, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipGraphAddMemAllocNode_Functional_4:
+      tags: [graph, node, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGraphAddMemAllocNode_Argument_Check: *level_2
-    Unit_hipGraphAddMemAllocNode_Negative_Instanciate_Graph_Again: *level_2
+    Unit_hipGraphAddMemAllocNode_Argument_Check:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemAllocNode_Negative_Instanciate_Graph_Again:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipGraphAddMemAllocNode_Negative_Free_Alloc_Memory_Again:
+      tags: [graph, node]
       <<: *level_2
       # (amd_linux) SWDEV-457316 Below test is skipped due ref count logic (Discussed with German)
       # (amd_windows) SWDEV-457316 Below test is skipped due ref count logic (Discussed with German)
       disabled: [amd_linux, amd_windows]
-    Unit_hipGraphAddMemAllocNode_Negative_With_Cloneed_Graph: *level_2
-    Unit_hipGraphAddMemFreeNode_Negative_Params: *level_2
+    Unit_hipGraphAddMemAllocNode_Negative_With_Cloneed_Graph:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddMemFreeNode_Negative_Params:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipGraphAddMemFreeNode_Negative_NotSupported:
+      tags: [graph, node]
       <<: *level_2
       # SWDEV-457316 Below tests are disabled temporarily to avoid combined PSDB
       disabled: [amd_windows]
-    Unit_hipGraphAddMemFreeNode_Functional: *level_2
-    Unit_hipDrvGraphMemcpyNodeGetParams_Negative_Parameters: *level_2
-    Unit_hipDrvGraphMemcpyNodeGetParams_Positive: *level_2
-    Unit_hipDrvGraphMemcpyNodeSetParams_Positive_Basic: *level_2
-    Unit_hipDrvGraphMemcpyNodeSetParams_Positive_Array: *level_2
-    Unit_hipDrvGraphMemcpyNodeSetParams_Negative_Parameters: *level_2
-    Unit_hipDeviceSetGraphMemAttribute_Positive_Default: *level_2
-    Unit_hipDeviceSetGraphMemAttribute_Negative_Parameters: *level_2
-    Unit_hipDeviceGetGraphMemAttribute_Positive_DoubleMemory: *level_2
-    Unit_hipDeviceGetGraphMemAttribute_Negative_Parameters: *level_2
-    Unit_hipDeviceGetGraphMemAttribute_Functional: *level_2
-    Unit_hipDeviceGetGraphMemAttribute_Functional_Multi_Device:
+    Unit_hipGraphAddMemFreeNode_Functional:
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipDeviceGetGraphMemAttribute_Negative: *level_2
-    Unit_hipDeviceSetGraphMemAttribute_Negative: *level_2
-    Unit_hipDeviceGraphMemTrim_Positive_Default: *level_2
-    Unit_hipDeviceGraphMemTrim_Negative_Parameters: *level_2
-    Unit_hipDrvGraphExecMemsetNodeSetParams_BasicPositive: *level_2
-    Unit_hipDrvGraphExecMemsetNodeSetParams_Negative: *level_2
+      tags: [graph, node]
+    Unit_hipDrvGraphMemcpyNodeGetParams_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipDrvGraphMemcpyNodeGetParams_Positive:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipDrvGraphMemcpyNodeSetParams_Positive_Basic:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipDrvGraphMemcpyNodeSetParams_Positive_Array:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipDrvGraphMemcpyNodeSetParams_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipDeviceSetGraphMemAttribute_Positive_Default:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipDeviceSetGraphMemAttribute_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipDeviceGetGraphMemAttribute_Positive_DoubleMemory:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipDeviceGetGraphMemAttribute_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipDeviceGetGraphMemAttribute_Functional:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipDeviceGetGraphMemAttribute_Functional_Multi_Device:
+      tags: [graph, query, multigpu]
+      <<: *level_2
+    Unit_hipDeviceGetGraphMemAttribute_Negative:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipDeviceSetGraphMemAttribute_Negative:
+      <<: *level_2
+      tags: [graph, query]
+    Unit_hipDeviceGraphMemTrim_Positive_Default:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipDeviceGraphMemTrim_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipDrvGraphExecMemsetNodeSetParams_BasicPositive:
+      <<: *level_2
+      tags: [graph, exec]
+    Unit_hipDrvGraphExecMemsetNodeSetParams_Negative:
+      <<: *level_2
+      tags: [graph, exec]
     Unit_hipGraphAddNodeTypeMemset_Positive_Basic: *level_2
-    Unit_hipGraphAddNodeTypeKernel_Positive_Basic: *level_2
-    Unit_hipGraphAddNodeTypeHost_Positive_Basic: *level_2
-    Unit_hipGraphAddNodeTypeChildGraph_Positive_Basic: *level_2
-    Unit_hipGraphAddNodeTypeMemcpy_Positive_Basic: *level_2
-    Unit_hipGraphAddNodeTypeEventRecord_Positive_Basic: *level_2
-    Unit_hipGraphAddNodeTypeEventWait_Positive_Basic: *level_2
-    Unit_hipGraphAddNodeTypeMemAlloc_Positive_Basic: *level_2
-    Unit_hipGraphAddNode_Negative_Parameters: *level_2
+    Unit_hipGraphAddNodeTypeKernel_Positive_Basic:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddNodeTypeHost_Positive_Basic:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddNodeTypeChildGraph_Positive_Basic:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddNodeTypeMemcpy_Positive_Basic:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddNodeTypeEventRecord_Positive_Basic:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddNodeTypeEventWait_Positive_Basic:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddNodeTypeMemAlloc_Positive_Basic:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipGraphAddNode_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipDrvGraphAddMemsetNode_Positive_Basic: *level_2
-    Unit_hipDrvGraphAddMemsetNode_Negative_Parameters: *level_2
+    Unit_hipDrvGraphAddMemsetNode_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipDrvGraphAddMemsetNode_hipMallocPitch_2D:
+      tags: [graph, node]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipDrvGraphAddMemsetNode_hipMallocPitch_1D:
+      tags: [graph, node]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipDrvGraphAddMemsetNode_hipMalloc3D_2D:
+      tags: [graph, node]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipDrvGraphAddMemsetNode_hipMalloc3D_1D:
+      tags: [graph, node]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipDrvGraphAddMemsetNode_hipMalloc_1D:
+      tags: [graph, node]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipDrvGraphAddMemsetNode_hipMallocManaged:
+      tags: [graph, node]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipDrvGraphAddMemcpyNode_Negative: *level_2
-    Unit_hipDrvGraphAddMemcpyNode_test: *level_2
+    Unit_hipDrvGraphAddMemcpyNode_Negative:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipDrvGraphAddMemcpyNode_test:
+      <<: *level_2
+      tags: [graph, node]
     Unit_hipDrvGraphAddMemcpyNode_MulitDevice:
+      tags: [graph, node, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipDrvGraphAddMemcpyNode_Positive_Basic: *level_2
-    Unit_hipDrvGraphAddMemcpyNode_Positive_Array: *level_2
-    Unit_hipDrvGraphAddMemcpyNode_Negative_Parameters: *level_2
+    Unit_hipDrvGraphAddMemcpyNode_Positive_Basic:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipDrvGraphAddMemcpyNode_Positive_Array:
+      <<: *level_2
+      tags: [graph, node]
+    Unit_hipDrvGraphAddMemcpyNode_Negative_Parameters:
+      <<: *level_2
+      tags: [graph, node]
   hip_specific:
-    Unit_Device__hip_hc_add8pk_Sanity_Positive: *level_2
-    Unit_Device__hip_hc_sub8pk_Sanity_Positive: *level_2
-    Unit_Device__hip_hc_mul8pk_Sanity_Positive: *level_2
-    Unit_Device__hip_hc_8pk_Negative_Parameters_RTC: *level_2
-    Unit_Device__hip_check_VGPRs: *level_2
+    Unit_Device__hip_hc_add8pk_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, hip_ext]
+    Unit_Device__hip_hc_sub8pk_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, hip_ext]
+    Unit_Device__hip_hc_mul8pk_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, hip_ext]
+    Unit_Device__hip_hc_8pk_Negative_Parameters_RTC:
+      <<: *level_2
+      tags: [device_lib, hip_ext]
+    Unit_Device__hip_check_VGPRs:
+      <<: *level_2
   kernel:
-    Unit_hipMemFaultStackAllocation_Check: *level_2
-    Unit_hipLaunchBounds_With_maxThreadsPerBlock_Check: *level_2
-    Unit_hipLaunchBounds_With_maxThreadsPerBlock_blocksPerCU_Check: *level_2
+    Unit_hipMemFaultStackAllocation_Check:
+      <<: *level_2
+      tags: [kernel, memory]
+    Unit_hipLaunchBounds_With_maxThreadsPerBlock_Check:
+      <<: *level_2
+      tags: [kernel, attributes]
+    Unit_hipLaunchBounds_With_maxThreadsPerBlock_blocksPerCU_Check:
+      <<: *level_2
+      tags: [kernel, attributes]
     Unit_hipDynamicShared:
+      tags: [kernel, memory]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipDynamicShared2: *level_2
-    Unit_hipEmptyKernel: *level_2
-    Unit_hipGridLaunch: *level_2
-    Unit_hipLanguageExtensions: *level_2
-    Unit_hipLaunchParm: *level_2
-    Unit_hipLaunchParmFunctor: *level_2
-    Unit_kernel_chkConstantViaKernel: *level_2
-    Unit_kernel_chkGlobalArrAndGlobalVaribleViaKernelFn: *level_2
-    Unit_kernel_MemoryOperationsViaKernels: *level_2
-    Unit_kernel_LaunchBounds_Functional: *level_2
-    Unit_kernel_Assign_threadIdx_to_auto: *level_2
-    Unit_hipLaunchKernelExC_NegetiveTsts: *level_2
-    Unit_hipLaunchKernelEx_NegetiveTsts: *level_2
-    Unit_hipLaunchKernelEx_Functional: *level_2
-    Unit_hipLaunchKernelEx_With_Different_Kernels: *level_2
-    Unit_hipLaunchKernelEx_With_CooperativeKernelWithArgs: *level_2
-    Unit_hipLaunchKernelEx_With_MaxBlockDims: *level_2
-    Unit_kernel_ChkPrintf:
+    Unit_hipDynamicShared2:
       <<: *level_2
-      tags: [multigpu]
+      tags: [kernel, memory]
+    Unit_hipEmptyKernel:
+      <<: *level_2
+      tags: [kernel, language]
+    Unit_hipGridLaunch:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit_hipLanguageExtensions:
+      <<: *level_2
+      tags: [kernel, language]
+    Unit_hipLaunchParm:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit_hipLaunchParmFunctor:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit_kernel_chkConstantViaKernel:
+      <<: *level_2
+      tags: [kernel, memory]
+    Unit_kernel_chkGlobalArrAndGlobalVaribleViaKernelFn:
+      <<: *level_2
+      tags: [kernel, memory]
+    Unit_kernel_MemoryOperationsViaKernels:
+      <<: *level_2
+      tags: [kernel, memory]
+    Unit_kernel_LaunchBounds_Functional:
+      <<: *level_2
+      tags: [kernel, attributes]
+    Unit_kernel_Assign_threadIdx_to_auto:
+      <<: *level_2
+      tags: [kernel, language]
+    Unit_hipLaunchKernelExC_NegetiveTsts:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit_hipLaunchKernelEx_NegetiveTsts:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit_hipLaunchKernelEx_Functional:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit_hipLaunchKernelEx_With_Different_Kernels:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit_hipLaunchKernelEx_With_CooperativeKernelWithArgs:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit_hipLaunchKernelEx_With_MaxBlockDims:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit_kernel_ChkPrintf:
+      tags: [multigpu, kernel, language]
+      <<: *level_2
     Unit_hipExtLaunchKernelGGL:
+      tags: [kernel, launch]
       <<: *level_2
       # SWDEV-438524: Below tests causing TDR & machine down in stress test on 15/12/23
       disabled: [amd_windows, amd_wsl]
-    Unit_hipSetupArgument_Simple: *level_2
-    Unit_hipSetupArgument_Execute_Kernel_And_Check_Result: *level_2
-    Unit_ConfigureCall: *level_2
-    Unit_ConfigureCall_CheckParams: *level_2
+    Unit_hipSetupArgument_Simple:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit_hipSetupArgument_Execute_Kernel_And_Check_Result:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit_ConfigureCall:
+      <<: *level_2
+      tags: [kernel, launch]
+    Unit_ConfigureCall_CheckParams:
+      <<: *level_2
+      tags: [kernel, launch]
   launchBounds:
-    Unit_Kernel_Launch_bounds_Positive_Basic: *level_2
+    Unit_Kernel_Launch_bounds_Positive_Basic:
+      <<: *level_2
+      tags: [kernel, attributes]
     Unit_Kernel_Launch_bounds_Negative_OutOfBounds:
+      tags: [kernel, attributes]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_Kernel_Launch_bounds_Negative_Parameters_RTC:
+      tags: [kernel, attributes]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
   library:
-    Unit_library_negative: *level_2
-    Unit_hip_library_load_co: *level_2
-    Unit_hipKernelGetParamInfo_Negative: *level_2
-    Unit_hip_library_load_rtc: *level_2
+    Unit_library_negative:
+      <<: *level_2
+      tags: [module, library]
+    Unit_hip_library_load_co:
+      <<: *level_2
+      tags: [module, library]
+    Unit_hipKernelGetParamInfo_Negative:
+      <<: *level_2
+      tags: [module, library]
+    Unit_hip_library_load_rtc:
+      <<: *level_2
+      tags: [module, library]
   math:
     Unit_Device_sin_Accuracy_Positive_float: *level_2
     Unit_Device_sin_Accuracy_Positive_double: *level_2
-    Unit_Device_sin_sinf_Negative_RTC: *level_2
+    Unit_Device_sin_sinf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_cos_Accuracy_Positive_float: *level_2
     Unit_Device_cos_Accuracy_Positive_double: *level_2
-    Unit_Device_cos_cosf_Negative_RTC: *level_2
+    Unit_Device_cos_cosf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_tan_Accuracy_Positive_float: *level_2
     Unit_Device_tan_Accuracy_Positive_double: *level_2
-    Unit_Device_tan_tanf_Negative_RTC: *level_2
+    Unit_Device_tan_tanf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_asin_Accuracy_Positive_float: *level_2
     Unit_Device_asin_Accuracy_Positive_double: *level_2
-    Unit_Device_asin_asinf_Negative_RTC: *level_2
+    Unit_Device_asin_asinf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_acos_Accuracy_Positive_float: *level_2
     Unit_Device_acos_Accuracy_Positive_double: *level_2
-    Unit_Device_acos_acosf_Negative_RTC: *level_2
+    Unit_Device_acos_acosf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_atan_Accuracy_Positive_float: *level_2
     Unit_Device_atan_Accuracy_Positive_double: *level_2
-    Unit_Device_atan_atanf_Negative_RTC: *level_2
+    Unit_Device_atan_atanf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_sinh_Accuracy_Positive_float: *level_2
     Unit_Device_sinh_Accuracy_Positive_double: *level_2
-    Unit_Device_sinh_sinhf_Negative_RTC: *level_2
+    Unit_Device_sinh_sinhf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_cosh_Accuracy_Positive_float: *level_2
     Unit_Device_cosh_Accuracy_Positive_double: *level_2
-    Unit_Device_cosh_coshf_Negative_RTC: *level_2
+    Unit_Device_cosh_coshf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_tanh_Accuracy_Positive_float: *level_2
     Unit_Device_tanh_Accuracy_Positive_double: *level_2
-    Unit_Device_tanh_tanhf_Negative_RTC: *level_2
+    Unit_Device_tanh_tanhf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_asinh_Accuracy_Positive_float: *level_2
     Unit_Device_asinh_Accuracy_Positive_double: *level_2
-    Unit_Device_asinh_asinhf_Negative_RTC: *level_2
+    Unit_Device_asinh_asinhf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_acosh_Accuracy_Positive_float: *level_2
     Unit_Device_acosh_Accuracy_Positive_double: *level_2
-    Unit_Device_acosh_acoshf_Negative_RTC: *level_2
+    Unit_Device_acosh_acoshf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_atanh_Accuracy_Positive_float: *level_2
     Unit_Device_atanh_Accuracy_Positive_double: *level_2
-    Unit_Device_atanh_atanhf_Negative_RTC: *level_2
+    Unit_Device_atanh_atanhf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_sinpi_Accuracy_Positive_float: *level_2
     Unit_Device_sinpi_Accuracy_Positive_double:
       <<: *level_2
       # special values test, fix: comment out [HEX_DBL(-, 1, fffffffffffff, +, 31), HEX_DBL(+, 1, fffffffffffff, +, 31)]
       <<: *disabled_linux
-    Unit_Device_sinpi_sinpif_Negative_RTC: *level_2
+    Unit_Device_sinpi_sinpif_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_cospi_Accuracy_Positive_float: *level_2
     Unit_Device_cospi_Accuracy_Positive_double:
       <<: *level_2
       # special values test, fix: comment out [HEX_DBL(-, 1, fffffffffffff, +, 31), HEX_DBL(+, 1, fffffffffffff, +, 31)]
       <<: *disabled_linux
-    Unit_Device_cospi_cospif_Negative_RTC: *level_2
+    Unit_Device_cospi_cospif_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_atan2_Accuracy_Positive: *level_2
-    Unit_Device_atan2_atan2f_Negative_RTC: *level_2
+    Unit_Device_atan2_atan2f_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_sincos_Accuracy_Positive_float: *level_2
     Unit_Device_sincos_Accuracy_Positive_double: *level_2
-    Unit_Device_sincos_sincosf_Negative_RTC: *level_2
+    Unit_Device_sincos_sincosf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_sincospi_Accuracy_Positive_float: *level_2
     Unit_Device_sincospi_Accuracy_Positive_double:
       <<: *level_2
       # special values test, fix: comment out [HEX_DBL(-, 1, fffffffffffff, +, 31), HEX_DBL(+, 1, fffffffffffff, +, 31)]
       <<: *disabled_linux
-    Unit_Device_sincospi_sincospif_Negative_RTC: *level_2
+    Unit_Device_sincospi_sincospif_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_fabs_Accuracy_Positive_float: *level_2
     Unit_Device_fabs_Accuracy_Positive_double: *level_2
-    Unit_Device_fabs_fabsf_Negative_RTC: *level_2
+    Unit_Device_fabs_fabsf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_copysign_Accuracy_Positive: *level_2
-    Unit_Device_copysign_copysignf_Negative_RTC: *level_2
+    Unit_Device_copysign_copysignf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_fmax_Accuracy_Positive: *level_2
-    Unit_Device_fmax_fmaxf_Negative_RTC: *level_2
+    Unit_Device_fmax_fmaxf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_fmin_Accuracy_Positive: *level_2
-    Unit_Device_fmin_fminf_Negative_RTC: *level_2
+    Unit_Device_fmin_fminf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_nextafter_Accuracy_Positive: *level_2
-    Unit_Device_nextafter_nextafterf_Negative_RTC: *level_2
+    Unit_Device_nextafter_nextafterf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_fma_Accuracy_Positive:
       <<: *level_2
       # special values test, fix: comment out [-3.0f, -1.5f, HEX_FLT(-, 0, 00000c, -, 126), HEX_FLT(-, 0, 000006, -, 126), +3.0f, 1.5f, HEX_FLT(+, 0, 00000c, -, 126), HEX_FLT(+, 0, 000006, -, 126),]
       <<: *disabled_linux
-    Unit_Device_fma_fmaf_Negative_RTC: *level_2
-    Unit_Device_fdividef_Accuracy_Positive: *level_2
-    Unit_Device_fdividef_Negative_RTC: *level_2
+    Unit_Device_fma_fmaf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_fdividef_Accuracy_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_fdividef_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_isfinite_Accuracy_Positive_float: *level_2
     Unit_Device_isfinite_Accuracy_Positive_double: *level_2
-    Unit_Device_isfinite_Negative_RTC: *level_2
+    Unit_Device_isfinite_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_isinf_Accuracy_Positive_float: *level_2
     Unit_Device_isinf_Accuracy_Positive_double: *level_2
-    Unit_Device_isinf_Negative_RTC: *level_2
+    Unit_Device_isinf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_isnan_Accuracy_Positive_float: *level_2
     Unit_Device_isnan_Accuracy_Positive_double: *level_2
-    Unit_Device_isnan_Negative_RTC: *level_2
+    Unit_Device_isnan_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_signbit_Accuracy_Positive_float: *level_2
     Unit_Device_signbit_Accuracy_Positive_double: *level_2
-    Unit_Device_signbit_Negative_RTC: *level_2
+    Unit_Device_signbit_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_fmod_Accuracy_Positive: *level_2
-    Unit_Device_fmod_fmodf_Negative_RTC: *level_2
+    Unit_Device_fmod_fmodf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_remainder_Accuracy_Positive: *level_2
-    Unit_Device_remainder_remainder_Negative_RTC: *level_2
+    Unit_Device_remainder_remainder_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_fdim_Accuracy_Positive:
       <<: *level_2
       # special values test, fix: comment out [HEX_DBL(-, 1, fffffffffffff, +, 31), HEX_DBL(-, 1, fffffffffffff, +, 30), HEX_DBL(+, 1, fffffffffffff, +, 31), HEX_DBL(+, 1, fffffffffffff, +, 30)]
       <<: *disabled_linux
-    Unit_Device_fdim_fdimf_Negative_RTC: *level_2
+    Unit_Device_fdim_fdimf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_trunc_Accuracy_Positive_float: *level_2
     Unit_Device_trunc_Accuracy_Positive_double: *level_2
-    Unit_Device_trunc_truncf_Negative_RTC: *level_2
+    Unit_Device_trunc_truncf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_round_Accuracy_Positive_float: *level_2
     Unit_Device_round_Accuracy_Positive_double: *level_2
-    Unit_Device_round_roundf_Negative_RTC: *level_2
+    Unit_Device_round_roundf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_rint_Accuracy_Positive_float: *level_2
     Unit_Device_rint_Accuracy_Positive_double: *level_2
-    Unit_Device_rint_rintf_Negative_RTC: *level_2
+    Unit_Device_rint_rintf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_nearbyint_Accuracy_Positive_float: *level_2
     Unit_Device_nearbyint_Accuracy_Positive_double: *level_2
-    Unit_Device_nearbyint_nearbyintf_Negative_RTC: *level_2
+    Unit_Device_nearbyint_nearbyintf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_ceil_Accuracy_Positive_float: *level_2
     Unit_Device_ceil_Accuracy_Positive_double: *level_2
-    Unit_Device_ceil_ceilf_Negative_RTC: *level_2
+    Unit_Device_ceil_ceilf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_floor_Accuracy_Positive_float: *level_2
     Unit_Device_floor_Accuracy_Positive_double: *level_2
-    Unit_Device_floor_floorf_Negative_RTC: *level_2
+    Unit_Device_floor_floorf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_lrint_Accuracy_Positive_float: *level_2
     Unit_Device_lrint_Accuracy_Positive_double: *level_2
-    Unit_Device_lrint_lrintf_Negative_RTC: *level_2
+    Unit_Device_lrint_lrintf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_lround_Accuracy_Positive_float: *level_2
     Unit_Device_lround_Accuracy_Positive_double: *level_2
-    Unit_Device_lround_lroundf_Negative_RTC: *level_2
+    Unit_Device_lround_lroundf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_llrint_Accuracy_Positive_float: *level_2
     Unit_Device_llrint_Accuracy_Positive_double: *level_2
-    Unit_Device_llrint_llrintf_Negative_RTC: *level_2
+    Unit_Device_llrint_llrintf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_llround_Accuracy_Positive_float: *level_2
     Unit_Device_llround_Accuracy_Positive_double: *level_2
-    Unit_Device_llround_llroundf_Negative_RTC: *level_2
+    Unit_Device_llround_llroundf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_remquo_Accuracy_Positive:
       <<: *level_2
       # TODO special value test error, fix: comment out special value test
       <<: *disabled_linux
-    Unit_Device_remquo_remquof_Negative_RTC: *level_2
+    Unit_Device_remquo_remquof_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_modf_Accuracy_Positive_float: *level_2
     Unit_Device_modf_Accuracy_Positive_double: *level_2
     Unit_Device_modf_modff_Negative_RTC:
+      tags: [device_lib, math]
       <<: *level_2
       # float* can be casted to double* [math_remainder_rounding_negative_kernels_rtc.hh:247]
       <<: *disabled_linux
@@ -2493,8 +4514,12 @@ unit:
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
-    Unit_Device___brev_Sanity_Positive: *level_2
-    Unit_Device___brevll_Sanity_Positive: *level_2
+    Unit_Device___brev_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___brevll_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___clz_Sanity_Positive: *level_2
     Unit_Device___clzll_Sanity_Positive:
       <<: *level_2
@@ -2502,243 +4527,490 @@ unit:
       disabled: [amd_linux]
     Unit_Device___ffs_Sanity_Positive: *level_2
     Unit_Device___ffsll_Sanity_Positive: *level_2
-    Unit_Device___popc_Sanity_Positive: *level_2
-    Unit_Device___popcll_Sanity_Positive: *level_2
-    Unit_Device___mul24_Sanity_Positive: *level_2
-    Unit_Device___umul24_Sanity_Positive: *level_2
-    Unit_Device___funnelshift_l_Sanity_Positive: *level_2
-    Unit_Device___funnelshift_lc_Sanity_Positive: *level_2
-    Unit_Device___funnelshift_r_Sanity_Positive: *level_2
-    Unit_Device___funnelshift_rc_Sanity_Positive: *level_2
+    Unit_Device___popc_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___popcll_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___mul24_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___umul24_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___funnelshift_l_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___funnelshift_lc_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___funnelshift_r_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___funnelshift_rc_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___hadd_Sanity_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below 4 tests are disable due to defect EXSWHTEC-355
       disabled: [amd_windows]
     Unit_Device___uhadd_Sanity_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below 4 tests are disable due to defect EXSWHTEC-355
       disabled: [amd_windows]
     Unit_Device___rhadd_Sanity_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below 4 tests are disable due to defect EXSWHTEC-355
       disabled: [amd_windows]
     Unit_Device___urhadd_Sanity_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below 4 tests are disable due to defect EXSWHTEC-355
       disabled: [amd_windows]
-    Unit_Device___mulhi_Sanity_Positive: *level_2
-    Unit_Device___umulhi_Sanity_Positive: *level_2
-    Unit_Device___mul64hi_Sanity_Positive: *level_2
-    Unit_Device___umul64hi_Sanity_Positive: *level_2
-    Unit_Device___sad_Sanity_Positive: *level_2
-    Unit_Device___usad_Sanity_Positive: *level_2
-    Unit_Device___byte_perm_Sanity_Positive: *level_2
-    Unit_Device_sqrtf_Accuracy_Positive: *level_2
-    Unit_Device_sqrt_Accuracy_Positive: *level_2
-    Unit_Device_sqrt_sqrtf_Negative_RTC: *level_2
-    Unit_Device_rsqrtf_Accuracy_Positive: *level_2
-    Unit_Device_rsqrt_Accuracy_Positive: *level_2
-    Unit_Device_rsqrt_rsqrtf_Negative_RTC: *level_2
+    Unit_Device___mulhi_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___umulhi_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___mul64hi_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___umul64hi_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___sad_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___usad_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___byte_perm_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_sqrtf_Accuracy_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_sqrt_Accuracy_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_sqrt_sqrtf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_rsqrtf_Accuracy_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_rsqrt_Accuracy_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_rsqrt_rsqrtf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_cbrt_Accuracy_Positive_float: *level_2
     Unit_Device_cbrt_Accuracy_Positive_double: *level_2
-    Unit_Device_cbrt_cbrtf_Negative_RTC: *level_2
-    Unit_Device_rcbrtf_Accuracy_Positive: *level_2
-    Unit_Device_rcbrt_Accuracy_Positive: *level_2
-    Unit_Device_rcbrt_rcbrtf_Negative_RTC: *level_2
+    Unit_Device_cbrt_cbrtf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_rcbrtf_Accuracy_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_rcbrt_Accuracy_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_rcbrt_rcbrtf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_hypot_Accuracy_Positive: *level_2
-    Unit_Device_hypot_hypotf_Negative_RTC: *level_2
+    Unit_Device_hypot_hypotf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_rhypot_Accuracy_Positive: *level_2
-    Unit_Device_rhypot_rhypotf_Negative_RTC: *level_2
+    Unit_Device_rhypot_rhypotf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_norm3d_Accuracy_Positive: *level_2
-    Unit_Device_norm3d_norm3df_Negative_RTC: *level_2
+    Unit_Device_norm3d_norm3df_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_rnorm3d_Accuracy_Positive: *level_2
-    Unit_Device_rnorm3d_rnorm3df_Negative_RTC: *level_2
+    Unit_Device_rnorm3d_rnorm3df_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_norm4d_Accuracy_Positive: *level_2
-    Unit_Device_norm4d_norm4df_Negative_RTC: *level_2
+    Unit_Device_norm4d_norm4df_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_rnorm4d_Accuracy_Positive: *level_2
-    Unit_Device_rnorm4d_rnorm4df_Negative_RTC: *level_2
+    Unit_Device_rnorm4d_rnorm4df_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_norm_Sanity_Positive: *level_2
-    Unit_Device_norm_normf_Negative_RTC: *level_2
+    Unit_Device_norm_normf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_rnorm_Sanity_Positive: *level_2
-    Unit_Device_rnorm_rnormf_Negative_RTC: *level_2
+    Unit_Device_rnorm_rnormf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_log_Accuracy_Positive_float: *level_2
     Unit_Device_log_Accuracy_Positive_double: *level_2
-    Unit_Device_log_logf_Negative_RTC: *level_2
+    Unit_Device_log_logf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_log2_Accuracy_Positive_float: *level_2
     Unit_Device_log2_Accuracy_Positive_double: *level_2
-    Unit_Device_log2_log2f_Negative_RTC: *level_2
+    Unit_Device_log2_log2f_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_log10_Accuracy_Positive_float: *level_2
     Unit_Device_log10_Accuracy_Positive_double: *level_2
-    Unit_Device_log10_log10f_Negative_RTC: *level_2
+    Unit_Device_log10_log10f_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_log1p_Accuracy_Positive_float: *level_2
     Unit_Device_log1p_Accuracy_Positive_double:
       <<: *level_2
       # special values test, fix: comment out [HEX_DBL(-, 0, 0000000000001, -, 1022)]
       disabled: [amd_linux]
-    Unit_Device_log1p_log1pf_Negative_RTC: *level_2
+    Unit_Device_log1p_log1pf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_logb_Accuracy_Positive_float: *level_2
     Unit_Device_logb_Accuracy_Positive_double: *level_2
-    Unit_Device_logb_logbf_Negative_RTC: *level_2
+    Unit_Device_logb_logbf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_ilogbf_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below 2 tests are disable due to defect EXSWHTEC-369
       disabled: [amd_linux, amd_windows]
     Unit_Device_ilogb_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below 2 tests are disable due to defect EXSWHTEC-369
       disabled: [amd_linux, amd_windows]
-    Unit_Device_ilogb_ilogbf_Negative_RTC: *level_2
+    Unit_Device_ilogb_ilogbf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_erf_Accuracy_Positive_float: *level_2
     Unit_Device_erf_Accuracy_Positive_double: *level_2
-    Unit_Device_erf_erff_Negative_RTC: *level_2
+    Unit_Device_erf_erff_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_erfc_Accuracy_Positive_float: *level_2
     Unit_Device_erfc_Accuracy_Positive_double: *level_2
-    Unit_Device_erfc_erfcf_Negative_RTC: *level_2
-    Unit_Device_erfinvf_Accuracy_Positive: *level_2
-    Unit_Device_erfinv_Accuracy_Positive: *level_2
-    Unit_Device_erfinv_erfinvf_Negative_RTC: *level_2
-    Unit_Device_erfcinvf_Accuracy_Positive: *level_2
-    Unit_Device_erfcinv_Accuracy_Positive: *level_2
-    Unit_Device_erfcinv_erfcinvf_Negative_RTC: *level_2
-    Unit_Device_erfcxf_Sanity_Positive: *level_2
-    Unit_Device_erfcx_Sanity_Positive: *level_2
-    Unit_Device_erfcx_erfcxf_Negative_RTC: *level_2
-    Unit_Device_normcdff_Accuracy_Positive: *level_2
-    Unit_Device_normcdf_Accuracy_Positive: *level_2
-    Unit_Device_normcdf_normcdff_Negative_RTC: *level_2
-    Unit_Device_normcdfinvf_Sanity_Positive: *level_2
-    Unit_Device_normcdfinv_Sanity_Positive: *level_2
-    Unit_Device_normcdfinv_normcdfinvf_Negative_RTC: *level_2
+    Unit_Device_erfc_erfcf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_erfinvf_Accuracy_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_erfinv_Accuracy_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_erfinv_erfinvf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_erfcinvf_Accuracy_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_erfcinv_Accuracy_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_erfcinv_erfcinvf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_erfcxf_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_erfcx_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_erfcx_erfcxf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_normcdff_Accuracy_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_normcdf_Accuracy_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_normcdf_normcdff_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_normcdfinvf_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_normcdfinv_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_normcdfinv_normcdfinvf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_tgammaf_Accuracy_Limited_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # TODO
       disabled: [amd_linux]
-    Unit_Device_tgamma_Accuracy_Limited_Positive: *level_2
-    Unit_Device_tgamma_tgammaf_Negative_RTC: *level_2
-    Unit_Device_lgammaf_Accuracy_Limited_Positive: *level_2
-    Unit_Device_lgamma_Accuracy_Limited_Positive: *level_2
-    Unit_Device_lgamma_lgammaf_Negative_RTC: *level_2
-    Unit_Device_cyl_bessel_i0f_Accuracy_Limited_Positive: *level_2
-    Unit_Device_cyl_bessel_i0_Accuracy_Limited_Positive: *level_2
-    Unit_Device_cyl_bessel_i0_cyl_bessel_i0f_Negative_RTC: *level_2
-    Unit_Device_cyl_bessel_i1f_Accuracy_Limited_Positive: *level_2
-    Unit_Device_cyl_bessel_i1_Accuracy_Limited_Positive: *level_2
-    Unit_Device_cyl_bessel_i1_cyl_bessel_i1f_Negative_RTC: *level_2
-    Unit_Device_y0f_Accuracy_Limited_Positive: *level_2
-    Unit_Device_y0_Accuracy_Limited_Positive: *level_2
-    Unit_Device_y0_y0f_Negative_RTC: *level_2
-    Unit_Device_y1f_Accuracy_Limited_Positive: *level_2
-    Unit_Device_y1_Accuracy_Limited_Positive: *level_2
-    Unit_Device_y1_y1f_Negative_RTC: *level_2
-    Unit_Device_ynf_Accuracy_Limited_Positive: *level_2
-    Unit_Device_yn_Accuracy_Limited_Positive: *level_2
-    Unit_Device_yn_ynf_Negative_RTC: *level_2
-    Unit_Device_j0f_Accuracy_Limited_Positive: *level_2
-    Unit_Device_j0_Accuracy_Limited_Positive: *level_2
-    Unit_Device_j0_j0f_Negative_RTC: *level_2
-    Unit_Device_j1f_Accuracy_Limited_Positive: *level_2
-    Unit_Device_j1_Accuracy_Limited_Positive: *level_2
-    Unit_Device_j1_j1f_Negative_RTC: *level_2
-    Unit_Device_jnf_Accuracy_Limited_Positive: *level_2
-    Unit_Device_jn_Accuracy_Limited_Positive: *level_2
-    Unit_Device_jn_jnf_Negative_RTC: *level_2
+    Unit_Device_tgamma_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_tgamma_tgammaf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_lgammaf_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_lgamma_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_lgamma_lgammaf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_cyl_bessel_i0f_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_cyl_bessel_i0_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_cyl_bessel_i0_cyl_bessel_i0f_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_cyl_bessel_i1f_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_cyl_bessel_i1_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_cyl_bessel_i1_cyl_bessel_i1f_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_y0f_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_y0_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_y0_y0f_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_y1f_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_y1_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_y1_y1f_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_ynf_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_yn_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_yn_ynf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_j0f_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_j0_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_j0_j0f_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_j1f_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_j1_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_j1_j1f_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_jnf_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_jn_Accuracy_Limited_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_jn_jnf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___double2int_rd_Positive: *level_2
     Unit_Device___double2int_rn_Positive: *level_2
     Unit_Device___double2int_ru_Positive: *level_2
     Unit_Device___double2int_rz_Positive: *level_2
-    Unit_Device___double2int_Negative_RTC: *level_2
+    Unit_Device___double2int_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___double2uint_rd_Positive: *level_2
     Unit_Device___double2uint_rn_Positive: *level_2
     Unit_Device___double2uint_ru_Positive: *level_2
     Unit_Device___double2uint_rz_Positive: *level_2
-    Unit_Device___double2uint_Negative_RTC: *level_2
+    Unit_Device___double2uint_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___double2ll_rd_Positive: *level_2
     Unit_Device___double2ll_rn_Positive: *level_2
     Unit_Device___double2ll_ru_Positive: *level_2
     Unit_Device___double2ll_rz_Positive: *level_2
-    Unit_Device___double2ll_Negative_RTC: *level_2
+    Unit_Device___double2ll_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___double2ull_rd_Positive: *level_2
     Unit_Device___double2ull_rn_Positive: *level_2
     Unit_Device___double2ull_ru_Positive: *level_2
     Unit_Device___double2ull_rz_Positive: *level_2
-    Unit_Device___double2ull_Negative_RTC: *level_2
+    Unit_Device___double2ull_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___double2float_rd_Positive: *level_2
     Unit_Device___double2float_rn_Positive: *level_2
     Unit_Device___double2float_ru_Positive: *level_2
     Unit_Device___double2float_rz_Positive: *level_2
-    Unit_Device___double2float_Negative_RTC: *level_2
-    Unit_Device___double2hiint_Positive: *level_2
-    Unit_Device___double2hiint_Negative_RTC: *level_2
-    Unit_Device___double2loint_Positive: *level_2
-    Unit_Device___double2loint_Negative_RTC: *level_2
-    Unit_Device___double_as_longlong_Positive: *level_2
-    Unit_Device___double_as_longlong_Negative_RTC: *level_2
+    Unit_Device___double2float_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___double2hiint_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___double2hiint_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___double2loint_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___double2loint_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___double_as_longlong_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___double_as_longlong_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___float2int_rd_Positive: *level_2
     Unit_Device___float2int_rn_Positive: *level_2
     Unit_Device___float2int_ru_Positive: *level_2
     Unit_Device___float2int_rz_Positive: *level_2
-    Unit_Device___float2int_Negative_RTC: *level_2
+    Unit_Device___float2int_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___float2uint_rd_Positive: *level_2
     Unit_Device___float2uint_rn_Positive: *level_2
     Unit_Device___float2uint_ru_Positive: *level_2
     Unit_Device___float2uint_rz_Positive: *level_2
-    Unit_Device___float2uint_Negative_RTC: *level_2
+    Unit_Device___float2uint_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___float2ll_rd_Positive: *level_2
     Unit_Device___float2ll_rn_Positive: *level_2
     Unit_Device___float2ll_ru_Positive: *level_2
     Unit_Device___float2ll_rz_Positive: *level_2
-    Unit_Device___float2ll_Negative_RTC: *level_2
+    Unit_Device___float2ll_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___float2ull_rd_Positive: *level_2
     Unit_Device___float2ull_rn_Positive: *level_2
     Unit_Device___float2ull_ru_Positive: *level_2
     Unit_Device___float2ull_rz_Positive: *level_2
-    Unit_Device___float2ull_Negative_RTC: *level_2
-    Unit_Device___float_as_int_Positive: *level_2
-    Unit_Device___float_as_int_Negative_RTC: *level_2
-    Unit_Device___float_as_uint_Positive: *level_2
-    Unit_Device___float_as_uint_Negative_RTC: *level_2
+    Unit_Device___float2ull_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___float_as_int_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___float_as_int_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___float_as_uint_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___float_as_uint_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___int2float_rd_Positive: *level_2
     Unit_Device___int2float_rn_Positive: *level_2
     Unit_Device___int2float_ru_Positive: *level_2
     Unit_Device___int2float_rz_Positive: *level_2
-    Unit_Device_int2float___Negative_RTC: *level_2
+    Unit_Device_int2float___Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___uint2float_rd_Positive: *level_2
     Unit_Device___uint2float_rn_Positive: *level_2
     Unit_Device___uint2float_ru_Positive: *level_2
     Unit_Device___uint2float_rz_Positive: *level_2
-    Unit_Device___uint2float_Negative_RTC: *level_2
+    Unit_Device___uint2float_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___int2double_rn_Positive: *level_2
-    Unit_Device___int2double_Negative_RTC: *level_2
+    Unit_Device___int2double_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___uint2double_rn_Positive: *level_2
-    Unit_Device___uint2double_Negative_RTC: *level_2
+    Unit_Device___uint2double_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___ll2float_rd_Positive: *level_2
     Unit_Device___ll2float_rn_Positive: *level_2
     Unit_Device___ll2float_ru_Positive: *level_2
     Unit_Device___ll2float_rz_Positive: *level_2
-    Unit_Device___ll2float_Negative_RTC: *level_2
+    Unit_Device___ll2float_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___ull2float_rd_Positive: *level_2
     Unit_Device___ull2float_rn_Positive: *level_2
     Unit_Device___ull2float_ru_Positive: *level_2
     Unit_Device___ull2float_rz_Positive: *level_2
-    Unit_Device___ull2float_Negative_RTC: *level_2
+    Unit_Device___ull2float_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___ll2double_rd_Positive: *level_2
     Unit_Device___ll2double_rn_Positive: *level_2
     Unit_Device___ll2double_ru_Positive: *level_2
     Unit_Device___ll2double_rz_Positive: *level_2
-    Unit_Device___ll2double_Negative_RTC: *level_2
+    Unit_Device___ll2double_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___ull2double_rd_Positive: *level_2
     Unit_Device___ull2double_rn_Positive: *level_2
     Unit_Device___ull2double_ru_Positive: *level_2
     Unit_Device___ull2double_rz_Positive: *level_2
-    Unit_Device___ull2double_Negative_RTC: *level_2
-    Unit_Device___int_as_float_Positive: *level_2
-    Unit_Device___int_as_float_Negative_RTC: *level_2
-    Unit_Device___uint_as_float_Positive: *level_2
-    Unit_Device___uint_as_float_Negative_RTC: *level_2
-    Unit_Device___longlong_as_double_Positive: *level_2
-    Unit_Device___longlong_as_double_Negative_RTC: *level_2
-    Unit_Device___hiloint2double_Positive: *level_2
-    Unit_Device___hiloint2double_Negative_RTC: *level_2
+    Unit_Device___ull2double_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___int_as_float_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___int_as_float_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___uint_as_float_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___uint_as_float_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___longlong_as_double_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___longlong_as_double_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___hiloint2double_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___hiloint2double_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___half2int_rn_Accuracy_Positive:
       <<: *level_2
       # (amd_windows) Below tests cause timeout in stress test of 09/02/24
@@ -2851,10 +5123,12 @@ unit:
       # (nvidia_linux) TODO rounding error
       disabled: [amd_windows, nvidia_linux]
     Unit_Device___half_as_short_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___half_as_ushort_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
@@ -2972,10 +5246,12 @@ unit:
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___short_as_half_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___ushort_as_half_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
@@ -2999,102 +5275,153 @@ unit:
       <<: *level_2
       # rounding float16 types not supported?
       <<: *disabled_linux
-    Unit_Device___float2half_rd_SmallVals_Sanity_Positive: *level_2
-    Unit_Device___float2half_ru_SmallVals_Sanity_Positive: *level_2
-    Unit_Device___float2half_rz_SmallVals_Sanity_Positive: *level_2
+    Unit_Device___float2half_rd_SmallVals_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___float2half_ru_SmallVals_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device___float2half_rz_SmallVals_Sanity_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___half2float_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device_exp_Accuracy_Positive_float: *level_2
     Unit_Device_exp_Accuracy_Positive_double: *level_2
-    Unit_Device_exp_expf_Negative_RTC: *level_2
+    Unit_Device_exp_expf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_exp2_Accuracy_Positive_float: *level_2
     Unit_Device_exp2_Accuracy_Positive_double: *level_2
-    Unit_Device_exp2_exp2f_Negative_RTC: *level_2
+    Unit_Device_exp2_exp2f_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_expm1_Accuracy_Positive_float: *level_2
     Unit_Device_expm1_Accuracy_Positive_double: *level_2
-    Unit_Device_expm1_expm1f_Negative_RTC: *level_2
-    Unit_Device_exp10f_Accuracy_Positive: *level_2
-    Unit_Device_exp10_Accuracy_Positive: *level_2
-    Unit_Device_exp10_exp10f_Negative_RTC: *level_2
-    Unit_Device_frexpf_Accuracy_Positive: *level_2
-    Unit_Device_frexp_Accuracy_Positive: *level_2
-    Unit_Device_frexp_frexpf_Negative_RTC: *level_2
+    Unit_Device_expm1_expm1f_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_exp10f_Accuracy_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_exp10_Accuracy_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_exp10_exp10f_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_frexpf_Accuracy_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_frexp_Accuracy_Positive:
+      <<: *level_2
+      tags: [device_lib, math]
+    Unit_Device_frexp_frexpf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_pow_Accuracy_Positive: *level_2
-    Unit_Device_pow_powf_Negative_RTC: *level_2
+    Unit_Device_pow_powf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_ldexp_Accuracy_Positive: *level_2
-    Unit_Device_ldexp_ldexpf_Negative_RTC: *level_2
+    Unit_Device_ldexp_ldexpf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_powi_Accuracy_Positive: *level_2
-    Unit_Device_powi_powif_Negative_RTC: *level_2
+    Unit_Device_powi_powif_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_scalbn_Accuracy_Positive: *level_2
-    Unit_Device_scalbn_scalbnf_Negative_RTC: *level_2
+    Unit_Device_scalbn_scalbnf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device_scalbln_Accuracy_Positive:
       <<: *level_2
       # long int exponents are too large, works fine with int
       disabled: [amd_linux]
-    Unit_Device_scalbln_scalblnf_Negative_RTC: *level_2
+    Unit_Device_scalbln_scalblnf_Negative_RTC:
+      <<: *level_2
+      tags: [device_lib, math]
     Unit_Device___half2half2_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device_make_half2_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___halves2half2_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___low2half_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___high2half_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___low2half2_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___high2half2_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___lowhigh2highlow_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___lows2half2_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___highs2half2_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___float2half2_rn_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___floats2half2_rn_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___float22half2_rn_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___low2float_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___high2float_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
     Unit_Device___half22float2_Accuracy_Positive:
+      tags: [device_lib, math]
       <<: *level_2
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
@@ -3496,78 +5823,146 @@ unit:
       # Below tests cause timeout in stress test of 09/02/24
       disabled: [amd_windows]
   memory:
-    Unit_hipMemset_4bytes: *level_2
-    Unit_hipMemset_4bytes_hostMem: *level_2
-    Unit_hipHostMalloc_4bytes: *level_2
-    Unit_hipMalloc_4bytes: *level_2
+    Unit_hipMemset_4bytes:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset_4bytes_hostMem:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipHostMalloc_4bytes:
+      <<: *level_2
+      tags: [memory]
+    Unit_hipMalloc_4bytes:
+      <<: *level_2
+      tags: [memory]
     Unit_hipMemcpy2DToArray_Positive_Default:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemcpy2DToArray_Positive_Synchronization_Behavior: *level_2
-    Unit_hipMemcpy2DToArray_Positive_ZeroWidthHeight: *level_2
-    Unit_hipMemcpy2DToArray_Negative_Parameters: *level_2
-    Unit_hipMemcpy2DToArray_Capture: *level_2
-    Unit_hipMemcpy2DToArray_Basic: *level_2
-    Unit_hipMemcpy2DToArray_ExtentValidation: *level_2
-    Unit_hipMemcpy2DToArray_PinnedMemSameGPU: *level_2
+    Unit_hipMemcpy2DToArray_Positive_Synchronization_Behavior:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DToArray_Positive_ZeroWidthHeight:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DToArray_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DToArray_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DToArray_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DToArray_ExtentValidation:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DToArray_PinnedMemSameGPU:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy2DToArray_multiDevicePinnedMemPeerGpu:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpy2DToArray_multiDeviceDeviceContextChange:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemcpy2DToArray_Negative: *level_2
+    Unit_hipMemcpy2DToArray_Negative:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy2DToArrayAsync_Positive_Default:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpy2DToArrayAsync_Positive_Synchronization_Behavior:
+      tags: [memory, transfer]
       <<: *level_2
       # Disabling tests tracked with SWDEV-389647..
       disabled: [amd_wsl]
-    Unit_hipMemcpy2DToArrayAsync_Positive_ZeroWidthHeight: *level_2
-    Unit_hipMemcpy2DToArrayAsync_Negative_Parameters: *level_2
-    Unit_hipMemcpy2DToArrayAsync_Capture: *level_2
-    Unit_hipMemcpy2DToArrayAsync_Basic: *level_2
-    Unit_hipMemcpy2DToArrayAsync_ExtentValidation: *level_2
-    Unit_hipMemcpy2DToArrayAsync_PinnedHostMemSameGpu: *level_2
+    Unit_hipMemcpy2DToArrayAsync_Positive_ZeroWidthHeight:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DToArrayAsync_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DToArrayAsync_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DToArrayAsync_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DToArrayAsync_ExtentValidation:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DToArrayAsync_PinnedHostMemSameGpu:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy2DToArrayAsync_multiDevicePinnedHostMem:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpy2DToArrayAsync_multiDeviceDeviceContextChange:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemcpy2DToArrayAsync_Negative: *level_2
-    Unit_hipMemcpy3D_Positive_Basic: *level_2
+    Unit_hipMemcpy2DToArrayAsync_Negative:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy3D_Positive_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy3D_Positive_Synchronization_Behavior:
+      tags: [memory, transfer]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
-    Unit_hipMemcpy3D_Positive_DeviceToDevice_Synchronization_Behavior: *level_2
-    Unit_hipMemcpy3D_Positive_Parameters: *level_2
-    Unit_hipMemcpy3D_Positive_Array: *level_2
-    Unit_hipMemcpy3D_Negative_Parameters: *level_2
-    Unit_hipMemcpy3D_Capture: *level_2
+    Unit_hipMemcpy3D_Positive_DeviceToDevice_Synchronization_Behavior:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy3D_Positive_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy3D_Positive_Array:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy3D_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy3D_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy3D_Basic:
       <<: *level_2
       tags: [hipMemcpy3D]
-    Unit_hipMemcpy3D_ExtentValidation: *level_2
+    Unit_hipMemcpy3D_ExtentValidation:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy3D_multiDevice_Negative: *level_2
     Unit_hipMemcpy3D_multiDevice_OnPeerDevice:
       <<: *level_2
       tags: [multigpu]
     Unit_hipMemcpy3D_multiDevice_Basic_Size_Test:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemcpy3DAsync_Positive_Basic: *level_2
-    Unit_hipMemcpy3DAsync_Positive_Synchronization_Behavior: *level_2
-    Unit_hipMemcpy3DAsync_Positive_Parameters: *level_2
-    Unit_hipMemcpy3DAsync_Positive_Array: *level_2
-    Unit_hipMemcpy3DAsync_Negative_Parameters: *level_2
-    Unit_hipMemcpy3DAsync_Capture: *level_2
+    Unit_hipMemcpy3DAsync_Positive_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy3DAsync_Positive_Synchronization_Behavior:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy3DAsync_Positive_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy3DAsync_Positive_Array:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy3DAsync_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy3DAsync_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy3DAsync_Basic:
       <<: *level_2
       tags: [hipMemcpy3DAsync]
-    Unit_hipMemcpy3DAsync_ExtentValidation: *level_2
+    Unit_hipMemcpy3DAsync_ExtentValidation:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy3DAsync_multiDevice_Negative: *level_2
     Unit_hipMemcpy3DAsync_multiDevice_D2D:
       <<: *level_2
@@ -3575,34 +5970,59 @@ unit:
     Unit_hipMemcpy3DAsync_multiDevice_DiffStream:
       <<: *level_2
       tags: [multigpu]
-    Unit_hipMemcpy3DAsync_Basic_Size_Test: *level_2
-    Unit_hipMemcpyParam2D_Positive_Basic:
+    Unit_hipMemcpy3DAsync_Basic_Size_Test:
       <<: *level_2
-      tags: [multigpu]
+      tags: [memory, transfer]
+    Unit_hipMemcpyParam2D_Positive_Basic:
+      tags: [memory, transfer, multigpu]
+      <<: *level_2
     Unit_hipMemcpyParam2D_Positive_Synchronization_Behavior:
+      tags: [memory, transfer]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
-    Unit_hipMemcpyParam2D_Positive_Parameters: *level_2
-    Unit_hipMemcpyParam2D_Positive_Array: *level_2
-    Unit_hipMemcpyParam2D_Negative_Parameters: *level_2
-    Unit_hipMemcpyParam2D_Capture: *level_2
+    Unit_hipMemcpyParam2D_Positive_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyParam2D_Positive_Array:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyParam2D_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyParam2D_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpyParam2D_multiDevice_D2D:
       <<: *level_2
       tags: [hipMemcpyParam2D, multigpu]
     Unit_hipMemcpyParam2D_multiDevice_H2D_D2H:
       <<: *level_2
       tags: [hipMemcpyParam2D]
-    Unit_hipMemcpyParam2D_ExtentValidation: *level_2
-    Unit_hipMemcpyParam2D_Negative: *level_2
-    Unit_hipMemcpyParam2DAsync_Positive_Basic:
+    Unit_hipMemcpyParam2D_ExtentValidation:
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemcpyParam2DAsync_Positive_Synchronization_Behavior: *level_2
-    Unit_hipMemcpyParam2DAsync_Positive_Parameters: *level_2
-    Unit_hipMemcpyParam2DAsync_Positive_Array: *level_2
-    Unit_hipMemcpyParam2DAsync_Negative_Parameters: *level_2
-    Unit_hipMemcpyParam2DAsync_Capture: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyParam2D_Negative:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyParam2DAsync_Positive_Basic:
+      tags: [memory, transfer, multigpu]
+      <<: *level_2
+    Unit_hipMemcpyParam2DAsync_Positive_Synchronization_Behavior:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyParam2DAsync_Positive_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyParam2DAsync_Positive_Array:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyParam2DAsync_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyParam2DAsync_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpyParam2DAsync_multiDevice_StreamOnDiffDevice:
       <<: *level_2
       tags: [hipMemcpyParam2DAsync, multigpu]
@@ -3614,18 +6034,29 @@ unit:
     Unit_hipMemcpyParam2DAsync_multiDevice_H2D_D2H:
       <<: *level_2
       tags: [hipMemcpyParam2DAsync, multigpu]
-    Unit_hipMemcpyParam2DAsync_ExtentValidation: *level_2
-    Unit_hipMemcpyParam2DAsync_Negative: *level_2
-    Unit_hipMemcpy2D_Positive_Basic:
+    Unit_hipMemcpyParam2DAsync_ExtentValidation:
       <<: *level_2
-      tags: [multigpu]
+      tags: [memory, transfer]
+    Unit_hipMemcpyParam2DAsync_Negative:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2D_Positive_Basic:
+      tags: [memory, transfer, multigpu]
+      <<: *level_2
     Unit_hipMemcpy2D_Positive_Synchronization_Behavior:
+      tags: [memory, transfer]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
-    Unit_hipMemcpy2D_Positive_Parameters: *level_2
-    Unit_hipMemcpy2D_Negative_Parameters: *level_2
-    Unit_hipMemcpy2D_Capture: *level_2
+    Unit_hipMemcpy2D_Positive_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2D_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2D_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy2D_H2D_D2D_D2H:
       <<: *level_2
       # Below tests are failing PSDB
@@ -3641,17 +6072,27 @@ unit:
     Unit_hipMemcpy2D_multiDevice_D2D:
       <<: *level_2
       tags: [multigpu]
-    Unit_hipMemcpy2D_SizeCheck: *level_2
-    Unit_hipMemcpy2D_Negative: *level_2
+    Unit_hipMemcpy2D_SizeCheck:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2D_Negative:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy2D_multiDevice_Basic_Size_Test:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpy2DAsync_Positive_Basic:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemcpy2DAsync_Positive_Synchronization_Behavior: *level_2
-    Unit_hipMemcpy2DAsync_Positive_Parameters: *level_2
-    Unit_hipMemcpy2DAsync_Negative_Parameters: *level_2
+    Unit_hipMemcpy2DAsync_Positive_Synchronization_Behavior:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DAsync_Positive_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DAsync_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy2DAsync_Capture: *level_2
     Unit_hipMemcpy2DAsync_Host_N_PinnedMem:
       <<: *level_2
@@ -3663,94 +6104,180 @@ unit:
     Unit_hipMemcpy2DAsync_multiDevice_StreamOnDiffDevice:
       <<: *level_2
       tags: [multigpu]
-    Unit_hipMemcpy2DAsync_SizeCheck: *level_2
-    Unit_hipMemcpy2DAsync_Negative: *level_2
+    Unit_hipMemcpy2DAsync_SizeCheck:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DAsync_Negative:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy2DAsync_multiDevice_Basic_Size_Test:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpy2DFromArray_Positive_Default:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemcpy2DFromArray_Positive_Synchronization_Behavior: *level_2
-    Unit_hipMemcpy2DFromArray_Positive_ZeroWidthHeight: *level_2
-    Unit_hipMemcpy2DFromArray_Negative_Parameters: *level_2
-    Unit_hipMemcpy2DFromArray_Capture: *level_2
-    Unit_hipMemcpy2DFromArray_Basic: *level_2
-    Unit_hipMemcpy2DFromArray_ExtentValidation: *level_2
-    Unit_hipMemcpy2DFromArray_PinnedMemSameGPU: *level_2
+    Unit_hipMemcpy2DFromArray_Positive_Synchronization_Behavior:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DFromArray_Positive_ZeroWidthHeight:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DFromArray_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DFromArray_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DFromArray_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DFromArray_ExtentValidation:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DFromArray_PinnedMemSameGPU:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy2DFromArray_multiDevicePinnedMemPeerGpu:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpy2DFromArray_multiDeviceContextChange:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemcpy2DFromArray_Negative: *level_2
+    Unit_hipMemcpy2DFromArray_Negative:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy2DFromArrayAsync_Positive_Default:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpy2DFromArrayAsync_Positive_Synchronization_Behavior:
+      tags: [memory, transfer]
       <<: *level_2
       # SWDEV-396963
       disabled: [amd_wsl]
-    Unit_hipMemcpy2DFromArrayAsync_Positive_ZeroWidthHeight: *level_2
-    Unit_hipMemcpy2DFromArrayAsync_Negative_Parameters: *level_2
-    Unit_hipMemcpy2DFromArrayAsync_Basic: *level_2
-    Unit_hipMemcpy2DFromArrayAsync_ExtentValidation: *level_2
-    Unit_hipMemcpy2DFromArrayAsync_PinnedHostMemSameGpu: *level_2
+    Unit_hipMemcpy2DFromArrayAsync_Positive_ZeroWidthHeight:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DFromArrayAsync_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DFromArrayAsync_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DFromArrayAsync_ExtentValidation:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DFromArrayAsync_PinnedHostMemSameGpu:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy2DFromArrayAsync_multiDevicePinnedHostMem:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpy2DFromArrayAsync_multiDeviceContextChange:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemcpy2DFromArrayAsync_Negative: *level_2
-    Unit_hipMemcpy2DFromArrayAsync_Capture: *level_2
-    Unit_hipMemcpyAtoD_Basic: *level_2
-    Unit_hipMemcpyAtoH_Positive_Default: *level_2
-    Unit_hipMemcpyAtoH_Positive_Synchronization_Behavior: *level_2
-    Unit_hipMemcpyAtoH_Positive_ZeroCount: *level_2
-    Unit_hipMemcpyAtoH_Negative_Parameters: *level_2
-    Unit_hipMemcpyAtoH_Capture: *level_2
-    Unit_hipMemcpyAtoHAsync_Basic: *level_2
-    Unit_hipMemcpyAtoHAsync_Capture: *level_2
+    Unit_hipMemcpy2DFromArrayAsync_Negative:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DFromArrayAsync_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyAtoD_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyAtoH_Positive_Default:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyAtoH_Positive_Synchronization_Behavior:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyAtoH_Positive_ZeroCount:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyAtoH_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyAtoH_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyAtoHAsync_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyAtoHAsync_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpyDtoA_Basic: *level_2
-    Unit_hipMemcpyDtoA_Negative: *level_2
-    Unit_hipMemcpyDtoA_BasicPositive: *level_2
+    Unit_hipMemcpyDtoA_Negative:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyDtoA_BasicPositive:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpyAtoH_Basic:
       <<: *level_2
       tags: [hipMemcpyAtoH]
     Unit_hipMemcpyAtoH_multiDevice_PeerDeviceContext:
       <<: *level_2
       tags: [hipMemcpyAtoH, multigpu]
-    Unit_hipMemcpyAtoH_Negative: *level_2
-    Unit_hipMemcpyAtoH_SizeCheck: *level_2
-    Unit_hipMemcpyHtoA_Positive_Default: *level_2
-    Unit_hipMemcpyHtoA_Positive_Synchronization_Behavior: *level_2
-    Unit_hipMemcpyHtoA_Positive_ZeroCount: *level_2
-    Unit_hipMemcpyHtoA_Negative_Parameters: *level_2
-    Unit_hipMemcpyHtoA_Capture: *level_2
+    Unit_hipMemcpyAtoH_Negative:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyAtoH_SizeCheck:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyHtoA_Positive_Default:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyHtoA_Positive_Synchronization_Behavior:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyHtoA_Positive_ZeroCount:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyHtoA_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyHtoA_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpyHtoAAsync_Basic: *level_2
-    Unit_hipMemcpyHtoAAsync_Negative: *level_2
+    Unit_hipMemcpyHtoAAsync_Negative:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpyHtoAAsync_BasicTstsWithDiffStreams:
+      tags: [memory, transfer]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
     Unit_hipMemcpyHtoAAsync_MultiDevice:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    UnitHipMemcpyHtoAAsync_Capture: *level_2
-    Unit_hipMemcpyAtoA_Basic: *level_2
+    UnitHipMemcpyHtoAAsync_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyAtoA_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpyHtoA_Basic:
       <<: *level_2
       tags: [hipMemcpyHtoA]
     Unit_hipMemcpyHtoA_multiDevice_PeerDeviceContext:
       <<: *level_2
       tags: [hipMemcpyHtoA, multigpu]
-    Unit_hipMemcpyHtoA_Negative: *level_2
-    Unit_hipMemcpyHtoA_SizeCheck: *level_2
-    Unit_hipMemcpy_Negative: *level_2
-    Unit_hipMemcpy_NullCheck: *level_2
-    Unit_hipMemcpy_HalfMemCopy: *level_2
+    Unit_hipMemcpyHtoA_Negative:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyHtoA_SizeCheck:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy_Negative:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy_NullCheck:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy_HalfMemCopy:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy_MultiThread_AllAPIs:
       <<: *level_2
       tags: [multigpu]
@@ -3763,62 +6290,135 @@ unit:
       tags: [multigpu]
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_hipHostRegister_SameChunkRepeat: *level_2
-    Unit_hipHostRegister_Chunks_SingleAttempt: *level_2
-    Unit_hipHostRegister_Chunks_RoundRobin: *level_2
-    Unit_hipHostRegister_Perform_hipMemset: *level_2
-    Unit_hipHostRegister_Perform_hipMemcpy: *level_2
-    Unit_hipHostRegister_Oversubscription: *level_2
-    Unit_hipHostRegister_AsyncApis: *level_2
-    Unit_hipHostRegister_Graphs: *level_2
-    Unit_hipHostRegister_RegUnreg_Perf_SameChunk: *level_2
-    Unit_hipHostRegister_RegUnreg_Perf_DiffChunk: *level_2
-    Unit_hipHostRegister_RegUnreg_Perf_SameChunk_MGPU: *level_2
-    Unit_hipHostRegister_MemAdvise_SetGet: *level_2
+    Unit_hipHostRegister_SameChunkRepeat:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostRegister_Chunks_SingleAttempt:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostRegister_Chunks_RoundRobin:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostRegister_Perform_hipMemset:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostRegister_Perform_hipMemcpy:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostRegister_Oversubscription:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostRegister_AsyncApis:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostRegister_Graphs:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostRegister_RegUnreg_Perf_SameChunk:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostRegister_RegUnreg_Perf_DiffChunk:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostRegister_RegUnreg_Perf_SameChunk_MGPU:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostRegister_MemAdvise_SetGet:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipHostRegister_Memcpy: *level_2
     Unit_hipHostRegister_Flags: *level_2
     Unit_hipHostRegister_Negative: *level_2
-    Unit_hipHostRegister_Capture: *level_2
-    Unit_hipHostUnregister_MemoryNotAccessableAfterUnregister: *level_2
-    Unit_hipHostUnregister_NullPtr: *level_2
-    Unit_hipHostUnregister_Ptr_Different_Than_Specified_To_Register: *level_2
-    Unit_hipHostUnregister_NotRegisteredPointer: *level_2
-    Unit_hipHostUnregister_AlreadyUnregisteredPointer: *level_2
-    Unit_hipHostUnregister_Capture: *level_2
+    Unit_hipHostRegister_Capture:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostUnregister_MemoryNotAccessableAfterUnregister:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostUnregister_NullPtr:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostUnregister_Ptr_Different_Than_Specified_To_Register:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostUnregister_NotRegisteredPointer:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostUnregister_AlreadyUnregisteredPointer:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostUnregister_Capture:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipHostGetFlags_flagCombos:
+      tags: [memory, query]
       <<: *level_2
       # Note: CONFIG_NUMA disabled
       disabled: [amd_wsl]
     Unit_hipHostGetFlags_DifferentThreads:
+      tags: [memory, query]
       <<: *level_2
       # Note: CONFIG_NUMA disabled
       disabled: [amd_wsl]
-    Unit_hipHostGetFlags_InvalidArgs: *level_2
-    Unit_hipHostGetFlags_Capture: *level_2
+    Unit_hipHostGetFlags_InvalidArgs:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipHostGetFlags_Capture:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipHostGetDevicePointer_Negative:
+      tags: [memory, query]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/96
       disabled: [amd_windows, amd_wsl]
-    Unit_hipHostGetDevicePointer_UseCase: *level_2
-    Unit_hipHostGetDevicePointer_Capture: *level_2
-    Unit_hipMallocHost_Positive: *level_2
-    Unit_hipMallocHost_DataValidation: *level_2
-    Unit_hipMallocHost_Negative: *level_2
-    Unit_hipMallocHost_Capture: *level_2
-    Unit_hipMemAllocHost_Positive: *level_2
-    Unit_hipMemAllocHost_DataValidation: *level_2
-    Unit_hipMemAllocHost_Negative: *level_2
+    Unit_hipHostGetDevicePointer_UseCase:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipHostGetDevicePointer_Capture:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMallocHost_Positive:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocHost_DataValidation:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocHost_Negative:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocHost_Capture:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemAllocHost_Positive:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemAllocHost_DataValidation:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemAllocHost_Negative:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMemAllocHost_VerifyAccess:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemAllocHost_Capture: *level_2
-    Unit_hipMallocManaged_HostDeviceConcurrent: *level_2
-    Unit_hipMallocManaged_MultiChunkSingleDevice: *level_2
+    Unit_hipMemAllocHost_Capture:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocManaged_HostDeviceConcurrent:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocManaged_MultiChunkSingleDevice:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMallocManaged_MultiChunkMultiDevice:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMallocManaged_OverSubscription: *level_2
-    Unit_hipMallocManaged_Negative: *level_2
+    Unit_hipMallocManaged_OverSubscription:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocManaged_Negative:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMallocManaged_TwoPointers:
       <<: *level_2
       tags: [multigpu]
@@ -3827,504 +6427,987 @@ unit:
       tags: [multigpu]
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemset_Negative_InvalidPtr: *level_2
-    Unit_hipMemset_Negative_OutOfBoundsSize: *level_2
-    Unit_hipMemset_Negative_OutOfBoundsPtr: *level_2
-    Unit_hipMemset2D_Negative_InvalidPtr: *level_2
-    Unit_hipMemset2D_Negative_InvalidSizes: *level_2
-    Unit_hipMemset2D_Negative_OutOfBoundsPtr: *level_2
-    Unit_hipMemset3D_Negative_InvalidPtr: *level_2
-    Unit_hipMemset3D_Negative_ModifiedPtr: *level_2
-    Unit_hipMemset3D_Negative_InvalidSizes: *level_2
-    Unit_hipMemset3D_Negative_OutOfBounds: *level_2
-    Unit_hipMemset_SetMemoryWithOffset: *level_2
-    Unit_hipMemsetAsync_SetMemoryWithOffset: *level_2
-    Unit_hipMemset_SmallBufferSizes: *level_2
-    Unit_hipMemset_2AsyncOperations: *level_2
-    Unit_hipMemset3D_BasicFunctional: *level_2
-    Unit_hipMemset3DAsync_BasicFunctional: *level_2
+    Unit_hipMemset_Negative_InvalidPtr:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset_Negative_OutOfBoundsSize:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset_Negative_OutOfBoundsPtr:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset2D_Negative_InvalidPtr:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset2D_Negative_InvalidSizes:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset2D_Negative_OutOfBoundsPtr:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset3D_Negative_InvalidPtr:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset3D_Negative_ModifiedPtr:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset3D_Negative_InvalidSizes:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset3D_Negative_OutOfBounds:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset_SetMemoryWithOffset:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetAsync_SetMemoryWithOffset:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset_SmallBufferSizes:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset_2AsyncOperations:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset3D_BasicFunctional:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset3DAsync_BasicFunctional:
+      <<: *level_2
+      tags: [memory, memset]
     Unit_hipMemset3DAsync_capturehipMemset3DAsync:
+      tags: [memory, memset]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipMemset2D_BasicFunctional: *level_2
-    Unit_hipMemset2DAsync_BasicFunctional: *level_2
-    Unit_hipMemset2D_UniqueWidthHeight: *level_2
+    Unit_hipMemset2D_BasicFunctional:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset2DAsync_BasicFunctional:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset2D_UniqueWidthHeight:
+      <<: *level_2
+      tags: [memory, memset]
     Unit_hipMemset2DAsync_capturehipMemset2DAsync:
+      tags: [memory, memset]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipHostMalloc_ArgValidation: *level_2
-    Unit_hipMemset3D_MemsetWithExtent: *level_2
-    Unit_hipMemset3DAsync_MemsetWithExtent: *level_2
-    Unit_hipMemset3D_MemsetMaxValue: *level_2
-    Unit_hipMemset3DAsync_MemsetMaxValue: *level_2
-    Unit_hipMemset3D_SeekSetSlice: *level_2
-    Unit_hipMemset3DAsync_SeekSetSlice: *level_2
-    Unit_hipMemset3D_SeekSetArrayPortion: *level_2
-    Unit_hipMemset3DAsync_SeekSetArrayPortion: *level_2
+    Unit_hipHostMalloc_ArgValidation:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemset3D_MemsetWithExtent:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset3DAsync_MemsetWithExtent:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset3D_MemsetMaxValue:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset3DAsync_MemsetMaxValue:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset3D_SeekSetSlice:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset3DAsync_SeekSetSlice:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset3D_SeekSetArrayPortion:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset3DAsync_SeekSetArrayPortion:
+      <<: *level_2
+      tags: [memory, memset]
     Unit_hipMemset3D_RegressInLoop:
+      tags: [memory, memset, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemset3DAsync_RegressInLoop:
+      tags: [memory, memset, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemset3DAsync_ConcurrencyMthread: *level_2
+    Unit_hipMemset3DAsync_ConcurrencyMthread:
+      <<: *level_2
+      tags: [memory, memset]
     Unit_hipMallocManaged_FlgParam:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMallocManaged_AccessMultiStream:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemPrefetchAsyncAdviseFlgTst: *level_2
-    Unit_hipMemPrefetchAsyncAccsdByTst: *level_2
-    Unit_hipMemPrefetchAsyncNegativeTst: *level_2
+    Unit_hipMemPrefetchAsyncAdviseFlgTst:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemPrefetchAsyncAccsdByTst:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemPrefetchAsyncNegativeTst:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipMemPrefetchAsync_NonPageSz:
+      tags: [memory, query]
       <<: *level_2
       # Disabling below tests temporarily due to change in API behavior
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemAdvise_MmapMem: *level_2
-    Unit_hipMallocManaged_Basic: *level_2
+    Unit_hipMemAdvise_MmapMem:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMallocManaged_Basic:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMallocManaged_Advanced:
+      tags: [memory, alloc]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMallocManaged_Large: *level_2
-    Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Basic: *level_2
-    Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Partial_Range: *level_2
-    Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Basic: *level_2
-    Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_CPU: *level_2
-    Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Partial_Range: *level_2
-    Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Basic: *level_2
-    Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_CPU: *level_2
-    Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Partial_Range: *level_2
+    Unit_hipMallocManaged_Large:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Basic:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemRangeGetAttribute_Positive_ReadMostly_Partial_Range:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Basic:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_CPU:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemRangeGetAttribute_Positive_PreferredLocation_Partial_Range:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Basic:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_CPU:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemRangeGetAttribute_Positive_LastPrefetchLocation_Partial_Range:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Basic:
+      tags: [memory, query]
       <<: *level_2
       # NOTE: The following 2 tests are disabled due to defect - EXSWHTEC-238
       disabled: [amd_linux, amd_wsl]
     Unit_hipMemRangeGetAttribute_Positive_AccessedBy_Partial_Range:
+      tags: [memory, query]
       <<: *level_2
       # NOTE: The following 2 tests are disabled due to defect - EXSWHTEC-238
       disabled: [amd_linux, amd_wsl]
-    Unit_hipMemRangeGetAttribute_Positive_AccessedBy_MultiDevice: *level_2
-    Unit_hipMemRangeGetAttribute_Negative_Parameters: *level_2
-    Unit_hipMemRangeGetAttribute_TstCountParam: *level_2
+    Unit_hipMemRangeGetAttribute_Positive_AccessedBy_MultiDevice:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemRangeGetAttribute_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemRangeGetAttribute_TstCountParam:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipMemRangeGetAttribute_NegativeTests:
+      tags: [memory, query]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemRangeGetAttribute_AccessedBy1:
+      tags: [memory, query]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemRangeGetAttribte_3:
+      tags: [memory, query]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemRangeGetAttribute_4:
+      tags: [memory, query]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemRangeGetAttribute_PrefetchAndGtAttr:
+      tags: [memory, query]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
-    Unit_hipHostMalloc_CoherentTst: *level_2
-    Unit_hipMallocManaged_CoherentTst: *level_2
+    Unit_hipHostMalloc_CoherentTst:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMallocManaged_CoherentTst:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipMallocManaged_CoherentTstWthAdvise:
+      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipMalloc_CoherentTst:
+      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipExtMallocWithFlags_CoherentTst: *level_2
-    Unit_hipMemsetD32_ValidBuffer: *level_2
-    Unit_hipMemsetD32_InvalidArg: *level_2
-    Unit_hipMemsetD32_KernelBuffer: *level_2
-    Unit_hipMemsetD16_ValidBuffer: *level_2
-    Unit_hipMemsetD16_InvalidArg: *level_2
-    Unit_hipMemsetD16_KernelBuffer: *level_2
-    Unit_hipMemsetD16Async_ValidBuffer: *level_2
-    Unit_hipMemsetD16Async_InvalidArg: *level_2
-    Unit_hipMemsetD16Async_KernelBuffer: *level_2
-    Unit_hipMemsetD32Async_ValidBuffer: *level_2
-    Unit_hipMemsetD32Async_InvalidArg: *level_2
-    Unit_hipMemsetD32Async_KernelBuffer: *level_2
-    Unit_hipMemsetD8Async_ValidBuffer: *level_2
-    Unit_hipMemsetD8Async_InvalidArg: *level_2
-    Unit_hipMemsetD8Async_KernelBuffer: *level_2
-    Unit_hipMemcpy2DArrayToArray_Negative: *level_2
-    Unit_hipMemcpy2DArrayToArray_Positive: *level_2
-    Unit_hipMemcpy2DArrayToArray_BasicPositive: *level_2
+    Unit_hipExtMallocWithFlags_CoherentTst:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemsetD32_ValidBuffer:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD32_InvalidArg:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD32_KernelBuffer:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD16_ValidBuffer:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD16_InvalidArg:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD16_KernelBuffer:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD16Async_ValidBuffer:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD16Async_InvalidArg:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD16Async_KernelBuffer:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD32Async_ValidBuffer:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD32Async_InvalidArg:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD32Async_KernelBuffer:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD8Async_ValidBuffer:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD8Async_InvalidArg:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD8Async_KernelBuffer:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemcpy2DArrayToArray_Negative:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DArrayToArray_Positive:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DArrayToArray_BasicPositive:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy3DBatchAsync_Ptr2PtrBatchOps: *level_2
     Unit_hipMemcpy3DBatchAsync_ArrayMemCpyBatchOps: *level_2
-    Unit_hipMemcpy3DBatchAsync_NegativeTests: *level_2
+    Unit_hipMemcpy3DBatchAsync_NegativeTests:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpyBatchAsync_D2D_Functional: *level_2
     Unit_hipMemcpyBatchAsync_H2D_Functional: *level_2
     Unit_hipMemcpyBatchAsync_D2H_Functional: *level_2
     Unit_hipMemcpyBatchAsync_H2H_Functional: *level_2
-    Unit_hipMemcpyBatchAsync_NegativeTsts: *level_2
-    Unit_hipMemsetD2D8_BasicFunctional: *level_2
-    Unit_hipMemsetD2D8_UnEvenRowsCols: *level_2
-    Unit_hipMemsetD2D8_NegTsts: *level_2
-    Unit_hipMemsetD2D8Async_BasicFunctional: *level_2
-    Unit_hipMemsetD2D8Async_UnEvenRowsCols: *level_2
-    Unit_hipMemsetD2D8Async_NegTsts: *level_2
-    Unit_hipMemsetD2D16_BasicFunctional: *level_2
-    Unit_hipMemsetD2D16_UnEvenRowsCols: *level_2
-    Unit_hipMemsetD2D16_NegTsts: *level_2
-    Unit_hipMemsetD2D16Async_BasicFunctional: *level_2
-    Unit_hipMemsetD2D16Async_UnEvenRowsCols: *level_2
-    Unit_hipMemsetD2D16Async_NegTsts: *level_2
-    Unit_hipMemsetD2D32_BasicFunctional: *level_2
-    Unit_hipMemsetD2D32_UnEvenRowsCols: *level_2
-    Unit_hipMemsetD2D32_NegTsts: *level_2
-    Unit_hipMemsetD2D32Async_BasicFunctional: *level_2
-    Unit_hipMemsetD2D32Async_UnEvenRowsCols: *level_2
-    Unit_hipMemsetD2D32Async_NegTsts: *level_2
-    Unit_hipMemcpy3DPeer_BasicFunctional: *level_2
-    Unit_hipMemcpy3DPeer_NegativeTsts: *level_2
+    Unit_hipMemcpyBatchAsync_NegativeTsts:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemsetD2D8_BasicFunctional:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD2D8_UnEvenRowsCols:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD2D8_NegTsts:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD2D8Async_BasicFunctional:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD2D8Async_UnEvenRowsCols:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD2D8Async_NegTsts:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD2D16_BasicFunctional:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD2D16_UnEvenRowsCols:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD2D16_NegTsts:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD2D16Async_BasicFunctional:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD2D16Async_UnEvenRowsCols:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD2D16Async_NegTsts:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD2D32_BasicFunctional:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD2D32_UnEvenRowsCols:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD2D32_NegTsts:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD2D32Async_BasicFunctional:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD2D32Async_UnEvenRowsCols:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetD2D32Async_NegTsts:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemcpy3DPeer_BasicFunctional:
+      <<: *level_2
+      tags: [memory, transfer, multigpu]
+    Unit_hipMemcpy3DPeer_NegativeTsts:
+      <<: *level_2
+      tags: [memory, transfer, multigpu]
     Unit_hipMemcpy3DPeerAsync_BasicFunctional:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_hipMemcpy3DPeerAsync_NegativeTsts: *level_2
-    Unit_hipMemPoolExportPointer_Negative: *level_2
-    Unit_hipMemPoolExportToShareableHandle_SameProc: *level_2
-    Unit_hipMemPoolExportToShareableHandle_ChldUseHdl: *level_2
-    Unit_hipMemPoolExportToShareableHandle_ChldCheckAccess: *level_2
-    Unit_hipMemPoolExportToShareableHandle_GrndChldUseHdl: *level_2
-    Unit_hipMemPoolExportToShareableHandle_Negative: *level_2
-    Unit_hipMemPoolImportFromShareableHandle_Negative: *level_2
-    Unit_hipMemPoolImportPointer_Negative: *level_2
-    Unit_hipMemPtrGetInfo_Basic: *level_2
-    Unit_hipMemPtrGetInfo_SizeZeroAllocation: *level_2
-    Unit_hipPointerGetAttributes_Basic: *level_2
+    Unit_hipMemcpy3DPeerAsync_NegativeTsts:
+      <<: *level_2
+      tags: [memory, transfer, multigpu]
+    Unit_hipMemPoolExportPointer_Negative:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolExportToShareableHandle_SameProc:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolExportToShareableHandle_ChldUseHdl:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolExportToShareableHandle_ChldCheckAccess:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolExportToShareableHandle_GrndChldUseHdl:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolExportToShareableHandle_Negative:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolImportFromShareableHandle_Negative:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolImportPointer_Negative:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPtrGetInfo_Basic:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemPtrGetInfo_SizeZeroAllocation:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipPointerGetAttributes_Basic:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipPointerGetAttributes_ClusterAlloc:
+      tags: [memory, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipPointerGetAttributes_TinyClusterAlloc:
+      tags: [memory, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipPointerGetAttributes_Negative: *level_2
+    Unit_hipPointerGetAttributes_Negative:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipPointerGetAttributes_GpuIter:
+      tags: [memory, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipPointerGetAttributes_GpuIter_Managed__Memory:
+      tags: [memory, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipPointerGetAttributes_GpuIter_Unregistered_Memory:
+      tags: [memory, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipExtMallocWithFlags_Positive_Basic: *level_2
-    Unit_hipExtMallocWithFlags_Positive_Zero_Size: *level_2
-    Unit_hipExtMallocWithFlags_Positive_Alignment: *level_2
-    Unit_hipExtMallocWithFlags_Negative_Parameters: *level_2
+    Unit_hipExtMallocWithFlags_Positive_Basic:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipExtMallocWithFlags_Positive_Zero_Size:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipExtMallocWithFlags_Positive_Alignment:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipExtMallocWithFlags_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMallocManaged_MultiThread:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMallocManaged_MGpuMThread:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMallocManaged_MultiKrnlComnHmm: *level_2
-    Unit_hipMallocManaged_MultiKrnlComnMalloc: *level_2
-    Unit_hipMallocManaged_MultiThrdMultiStrm: *level_2
-    Unit_hipMallocManaged_TwoKrnlsComnHmmMem: *level_2
+    Unit_hipMallocManaged_MultiKrnlComnHmm:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocManaged_MultiKrnlComnMalloc:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocManaged_MultiThrdMultiStrm:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocManaged_TwoKrnlsComnHmmMem:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMemVmm_Basic:
+      tags: [vmm]
       <<: *level_2
       # SWDEV-396616 hipMemMap returns invalid error
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemVmm_Uncached:
+      tags: [memory, alloc]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipArray_Valid: *level_2
-    Unit_hipArray_Invalid: *level_2
-    Unit_hipArray_Nullptr: *level_2
-    Unit_hipArray_DoubleFree: *level_2
-    Unit_hipArray_TrippleDestroy: *level_2
-    Unit_hipArray_DoubleNullptr: *level_2
-    Unit_hipArray_DoubleInvalid: *level_2
-    Unit_hipMemcpyDeviceToDeviceNoCU_SingleStream: *level_2
-    Unit_hipMemcpyDeviceToDeviceNoCU_WithCU_NoCU_Comb_SingleStrm: *level_2
-    Unit_hipMemcpyDeviceToDeviceNoCU_NoCU_MulStrm: *level_2
-    Unit_hipMemcpyDeviceToDeviceNoCU_Memcpy_Kernel_InParallel: *level_2
-    Unit_hipGetProcAddress_MemoryApisMallocFree: *level_2
-    Unit_hipGetProcAddress_MemoryApisRegisterUnReg: *level_2
-    Unit_hipGetProcAddress_MemoryApisArrayRelated: *level_2
-    Unit_hipGetProcAddress_MemoryApisSetAndGetAttributes: *level_2
-    Unit_hipGetProcAddress_MemoryApisMemCopy: *level_2
-    Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams: *level_2
-    Unit_hipGetProcAddress_MemoryApisMemset: *level_2
-    Unit_hipGetProcAddress_MemoryApisMemset2D3D: *level_2
-    Unit_hipGetProcAddress_MemoryApisGetMemInfoRelated: *level_2
+    Unit_hipArray_Valid:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipArray_Invalid:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipArray_Nullptr:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipArray_DoubleFree:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipArray_TrippleDestroy:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipArray_DoubleNullptr:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipArray_DoubleInvalid:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemcpyDeviceToDeviceNoCU_SingleStream:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyDeviceToDeviceNoCU_WithCU_NoCU_Comb_SingleStrm:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyDeviceToDeviceNoCU_NoCU_MulStrm:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyDeviceToDeviceNoCU_Memcpy_Kernel_InParallel:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipGetProcAddress_MemoryApisMallocFree:
+      <<: *level_2
+      tags: [memory]
+    Unit_hipGetProcAddress_MemoryApisRegisterUnReg:
+      <<: *level_2
+      tags: [memory]
+    Unit_hipGetProcAddress_MemoryApisArrayRelated:
+      <<: *level_2
+      tags: [memory]
+    Unit_hipGetProcAddress_MemoryApisSetAndGetAttributes:
+      <<: *level_2
+      tags: [memory]
+    Unit_hipGetProcAddress_MemoryApisMemCopy:
+      <<: *level_2
+      tags: [memory]
+    Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams:
+      <<: *level_2
+      tags: [memory]
+    Unit_hipGetProcAddress_MemoryApisMemset:
+      <<: *level_2
+      tags: [memory]
+    Unit_hipGetProcAddress_MemoryApisMemset2D3D:
+      <<: *level_2
+      tags: [memory]
+    Unit_hipGetProcAddress_MemoryApisGetMemInfoRelated:
+      <<: *level_2
+      tags: [memory]
     Unit_hipGetProcAddress_MemoryApisMemcpy2DRelated:
+      tags: [memory, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipGetProcAddress_MemoryApisMemcpy3DRelated: *level_2
-    Unit_hipGetProcAddress_MemoryApisAddressRelated: *level_2
-    Unit_hipGetProcAddress_MemoryApisManagedMemory: *level_2
-    Unit_hipGetProcAddress_MemoryApisStreamOrderedMemory: *level_2
+    Unit_hipGetProcAddress_MemoryApisMemcpy3DRelated:
+      <<: *level_2
+      tags: [memory]
+    Unit_hipGetProcAddress_MemoryApisAddressRelated:
+      <<: *level_2
+      tags: [memory]
+    Unit_hipGetProcAddress_MemoryApisManagedMemory:
+      <<: *level_2
+      tags: [memory]
+    Unit_hipGetProcAddress_MemoryApisStreamOrderedMemory:
+      <<: *level_2
+      tags: [memory]
     Unit_hipGetProcAddress_MemoryApisPeerToPeer:
+      tags: [memory, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemPrefetchAsync_v2_Device_Host:
+      tags: [memory, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemPrefetchAsync_v2_HostNuma_HostNumaCurrent: *level_2
-    Unit_hipMemPrefetchAsync_v2_Negative: *level_2
+    Unit_hipMemPrefetchAsync_v2_HostNuma_HostNumaCurrent:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemPrefetchAsync_v2_Negative:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipMemAdvise_v2_Device_Host:
+      tags: [memory, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemAdvise_v2_HostNuma_HostNumaCurrent: *level_2
-    Unit_hipMemAdvise_v2_Negative: *level_2
+    Unit_hipMemAdvise_v2_HostNuma_HostNumaCurrent:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemAdvise_v2_Negative:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipPointerSetAttribute_Positive_SyncMemops:
+      tags: [memory, query]
       <<: *level_2
       # Below test is disabled due to defect EXSWHTEC-347
       disabled: [amd_windows]
-    Unit_hipPointerSetAttribute_Negative_Parameters: *level_2
-    Unit_hipMemcpyFromToSymbol_Negative: *level_2
-    Unit_hipMemcpyToFromSymbol_SyncAndAsync: *level_2
-    Unit_hipMemcpyToFromSymbol_Capture: *level_2
-    Unit_hipPtrGetAttribute_Simple:
+    Unit_hipPointerSetAttribute_Negative_Parameters:
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemPoolApi_Basic: *level_2
+      tags: [memory, query]
+    Unit_hipMemcpyFromToSymbol_Negative:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyToFromSymbol_SyncAndAsync:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyToFromSymbol_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipPtrGetAttribute_Simple:
+      tags: [memory, query, multigpu]
+      <<: *level_2
+    Unit_hipMemPoolApi_Basic:
+      <<: *level_2
+      tags: [stream]
     Unit_hipMemPoolApi_BasicAlloc:
+      tags: [memory, alloc]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemPoolApi_BasicTrim:
+      tags: [memory, alloc]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemPoolApi_BasicReuse:
+      tags: [memory, alloc]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemPoolApi_Opportunistic:
+      tags: [memory, alloc]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemPoolApi_Default: *level_2
-    Unit_hipDeviceGetMemPool_Basic: *level_2
-    Unit_hipDeviceGetMemPool_Functional: *level_2
+    Unit_hipMemPoolApi_Default:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipDeviceGetMemPool_Basic:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipDeviceGetMemPool_Functional:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipDeviceGetMemPool_Multidevice:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipDeviceGetDefaultMemPool_Functional: *level_2
-    Unit_hipDeviceSetMemPool_Basic: *level_2
+    Unit_hipDeviceGetDefaultMemPool_Functional:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipDeviceSetMemPool_Basic:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipDeviceSetMemPool_DestroyCurrentMempool:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipDeviceSetMemPool_functional: *level_2
-    Unit_hipDeviceSetMemPool_functionalAttribute: *level_2
-    Unit_hipMemPoolSetGetAccess_Positive_Basic: *level_2
+    Unit_hipDeviceSetMemPool_functional:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipDeviceSetMemPool_functionalAttribute:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolSetGetAccess_Positive_Basic:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMemPoolSetGetAccess_Positive_MultipleGPU:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
       disabled: [amd_windows]
     Unit_hipMemPoolSetGetAccess_Positive_P2P:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemPoolSetAccess_Negative_Parameters:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-435667: Below tests failing randomly in stress test on 08/12/23
       disabled: [amd_windows]
     Unit_hipMemPoolSetAccess_SetAccess:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemPoolSetAccess_NegTst: *level_2
+    Unit_hipMemPoolSetAccess_NegTst:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMemPoolGetAccess_Negative_Parameters:
+      tags: [memory, alloc]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipMemPoolGetAccess_SetGet: *level_2
-    Unit_hipMemPoolGetAccess_GetDefMempoolOfEachDevice: *level_2
-    Unit_hipMemPoolSetGetAttribute_Positive_Default: *level_2
-    Unit_hipMemPoolSetGetAttribute_Positive_MemBasic: *level_2
-    Unit_hipMemPoolSetAttribute_Opportunistic: *level_2
+    Unit_hipMemPoolGetAccess_SetGet:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolGetAccess_GetDefMempoolOfEachDevice:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolSetGetAttribute_Positive_Default:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolSetGetAttribute_Positive_MemBasic:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolSetAttribute_Opportunistic:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMemPoolSetAttribute_EventDependencies:
+      tags: [memory, alloc]
       <<: *level_2
       # mlsejenkins_Window_Failures_on_gfx1201
       disabled: [amd_windows]
     Unit_hipMemPoolSetAttribute_Negative_Parameters:
+      tags: [memory, alloc]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipMemPoolSetAttribute_ResetMemHighAttr: *level_2
+    Unit_hipMemPoolSetAttribute_ResetMemHighAttr:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMemPoolGetAttribute_Negative_Parameters:
+      tags: [memory, alloc]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipMemPoolGetAttribute_SetGet: *level_2
-    Unit_hipMemPoolGetAttribute_UsedMem: *level_2
-    Unit_hipMemPoolGetAttribute_ReservedMem: *level_2
-    Unit_hipMemPoolGetAttribute_UsageStatistics: *level_2
-    Unit_hipMemPoolGetAttribute_hipMalloc_DefMempool: *level_2
-    Unit_hipMemPoolGetAttribute_CheckDefaultValues: *level_2
-    Unit_hipMemPoolCreate_Negative_Parameter: *level_2
-    Unit_hipMemPoolCreate_With_maxSize: *level_2
-    Unit_hipMemPoolCreate_Without_maxSize: *level_2
-    Unit_hipMemPoolCreate_DeviceTest:
+    Unit_hipMemPoolGetAttribute_SetGet:
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemPoolDestroy_Negative_Parameter: *level_2
-    Unit_hipMemPoolMaxAlloc: *level_2
-    Unit_hipMemPoolTrimTo_Negative_Parameter: *level_2
-    Unit_hipMemPoolTrimTo_Positive_Basic: *level_2
-    Unit_hipMemPoolTrimTo_VaryingMinBytesToHold: *level_2
-    Unit_hipMemPoolTrimTo_MGpuVaryingMinBytesToHold: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolGetAttribute_UsedMem:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolGetAttribute_ReservedMem:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolGetAttribute_UsageStatistics:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolGetAttribute_hipMalloc_DefMempool:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolGetAttribute_CheckDefaultValues:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolCreate_Negative_Parameter:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolCreate_With_maxSize:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolCreate_Without_maxSize:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolCreate_DeviceTest:
+      tags: [memory, alloc, multigpu]
+      <<: *level_2
+    Unit_hipMemPoolDestroy_Negative_Parameter:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolMaxAlloc:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolTrimTo_Negative_Parameter:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolTrimTo_Positive_Basic:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolTrimTo_VaryingMinBytesToHold:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemPoolTrimTo_MGpuVaryingMinBytesToHold:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMemPoolTrimTo_Multithreaded:
+      tags: [memory, alloc]
       <<: *level_2
       disabled: [amd_windows]
-    Unit_hipMallocFromPoolAsync_Basic_OneAlloc: *level_2
-    Unit_hipMallocFromPoolAsync_Basic_TwoAllocs: *level_2
-    Unit_hipMallocFromPoolAsync_Basic_Reuse: *level_2
-    Unit_hipMallocFromPoolAsync_Negative_Parameters: *level_2
-    Unit_hipMallocFromPoolAsync_ReleaseThreshold: *level_2
-    Unit_hipMallocFromPoolAsync_NullStream: *level_2
-    Unit_hipMallocFromPoolAsync_hipStreamPerThread: *level_2
+    Unit_hipMallocFromPoolAsync_Basic_OneAlloc:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocFromPoolAsync_Basic_TwoAllocs:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocFromPoolAsync_Basic_Reuse:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocFromPoolAsync_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocFromPoolAsync_ReleaseThreshold:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocFromPoolAsync_NullStream:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocFromPoolAsync_hipStreamPerThread:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMallocFromPoolAsync_ReleaseThreshold_Mgpu:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMallocFromPoolAsync_Multidevice_Concurrent:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMallocFromPoolAsync_Multidevice_MultiStream:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMallocFromPoolAsync_MThread_DefaultThresh: *level_2
+    Unit_hipMallocFromPoolAsync_MThread_DefaultThresh:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMallocFromPoolAsync_MThread_MaxThresh:
+      tags: [memory, alloc]
       <<: *level_2
       disabled: [amd_windows]
     Unit_hipMallocFromPoolAsync_MThread_CommonMpool_DefaultMempool:
+      tags: [memory, alloc]
       <<: *level_2
       disabled: [amd_windows]
-    Unit_hipMallocFromPoolAsync_MThread_CommonMpool_MaxThresh: *level_2
-    Unit_hipMallocFromPoolAsync_MultStream_Sync: *level_2
-    Unit_hipMallocFromPoolAsync_MultStream_DefaultStreams: *level_2
-    Unit_hipMallocFromPoolAsync_MultStream_UserStreams: *level_2
-    Unit_hipMallocFromPoolAsync_ReuseFollowEventDependencies: *level_2
-    Unit_hipMallocFromPoolAsync_ReuseAllowOpportunistic: *level_2
-    Unit_hipMallocFromPoolAsync_ReuseAllowInternalDependencies: *level_2
+    Unit_hipMallocFromPoolAsync_MThread_CommonMpool_MaxThresh:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocFromPoolAsync_MultStream_Sync:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocFromPoolAsync_MultStream_DefaultStreams:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocFromPoolAsync_MultStream_UserStreams:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocFromPoolAsync_ReuseFollowEventDependencies:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocFromPoolAsync_ReuseAllowOpportunistic:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocFromPoolAsync_ReuseAllowInternalDependencies:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMemcpyPeer_Positive_Default:
+      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpyPeer_Positive_Synchronization_Behavior:
+      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpyPeer_Positive_ZeroSize:
+      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
-      tags: [multigpu]
       # Disabling test tracked SWDEV-391555
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemcpyPeer_Negative_Parameters:
+      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpyPeer_Negative:
+      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpyPeer_Basic:
+      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpyPeerAsync_Positive_Default:
+      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpyPeerAsync_Positive_Synchronization_Behavior:
+      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpyPeerAsync_Positive_ZeroSize:
+      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
-      tags: [multigpu]
       # Disabling test tracked SWDEV-391555
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemcpyPeerAsync_Negative_Parameters:
+      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemcpyPeerAsync_Capture: *level_2
+    Unit_hipMemcpyPeerAsync_Capture:
+      <<: *level_2
+      tags: [memory, transfer, multigpu]
     Unit_hipMemcpyPeerAsync_Negative:
+      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpyPeerAsync_Basic:
+      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpyPeerAsync_StreamOnDiffDevice:
+      tags: [memory, transfer, multigpu, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemcpyWithStream_TestWithOneStream: *level_2
-    Unit_hipMemcpyWithStream_TestwithTwoStream: *level_2
-    Unit_hipMemcpyWithStream_TestkindDtoH: *level_2
-    Unit_hipMemcpyWithStream_TestkindHtoH: *level_2
+    Unit_hipMemcpyWithStream_TestWithOneStream:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyWithStream_TestwithTwoStream:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyWithStream_TestkindDtoH:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyWithStream_TestkindHtoH:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpyWithStream_TestkindDtoD:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpyWithStream_TestOnMultiGPUwithOneStream:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemcpyWithStream_TestkindDefault: *level_2
+    Unit_hipMemcpyWithStream_TestkindDefault:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpyWithStream_TestkindDefaultForDtoD:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemcpyWithStream_TestDtoDonSameDevice: *level_2
-    Unit_hipMemcpy_Positive_Basic: *level_2
+    Unit_hipMemcpyWithStream_TestDtoDonSameDevice:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy_Positive_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy_Positive_Synchronization_Behavior:
+      tags: [memory, transfer]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
-    Unit_hipMemcpy_Negative_Parameters: *level_2
-    Unit_hipMemcpyWithStream_Capture: *level_2
+    Unit_hipMemcpy_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyWithStream_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpyWithStream_MultiThread:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemsetAsync_VerifyExecutionWithKernel: *level_2
-    Unit_hipMemset2DAsync_WithKernel: *level_2
-    Unit_hipMemset2DAsync_MultiThread: *level_2
-    Unit_hipMalloc_ArgumentValidation: *level_2
-    Unit_hipMalloc_LoopRegressionAllocFreeCycles: *level_2
-    Unit_hipMalloc_AllocateAndPoolBuffers: *level_2
+    Unit_hipMemsetAsync_VerifyExecutionWithKernel:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset2DAsync_WithKernel:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset2DAsync_MultiThread:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMalloc_ArgumentValidation:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMalloc_LoopRegressionAllocFreeCycles:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMalloc_AllocateAndPoolBuffers:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMalloc_Multithreaded_MultiGPU:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemcpyDtoD_Basic:
       <<: *level_2
       tags: [multigpu]
     Unit_hipMemcpyDtoDAsync_Basic:
       <<: *level_2
       tags: [multigpu]
-    Unit_hipMemcpyDtoDAsync_Capture: *level_2
-    Unit_hipHostMalloc_Basic: *level_2
-    Unit_hipHostMalloc_Negative: *level_2
-    Unit_hipHostMalloc_NonCoherent: *level_2
-    Unit_hipHostMalloc_Coherent: *level_2
-    Unit_hipHostMalloc_Default: *level_2
-    Unit_hipHostGetDevicePointer_NullCheck: *level_2
+    Unit_hipMemcpyDtoDAsync_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipHostMalloc_Basic:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostMalloc_Negative:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostMalloc_NonCoherent:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostMalloc_Coherent:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostMalloc_Default:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostGetDevicePointer_NullCheck:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipHostMalloc_AllocateMoreThanAvailGPUMemory:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-431191:Below tests failed in stress test on 03/11/23
       disabled: [amd_windows, amd_wsl]
     Unit_hipHostMalloc_AllocateUseMoreThanAvailGPUMemory:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-431191:Below tests failed in stress test on 03/11/23
       disabled: [amd_windows, amd_wsl]
-    Unit_hipHostMalloc_Capture: *level_2
+    Unit_hipHostMalloc_Capture:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMemcpy_KernelLaunch: *level_2
     Unit_hipMemcpy_H2H_H2D_D2H_H2PinMem:
       <<: *level_2
       tags: [multigpu]
-    Unit_hipMemcpy_MultiThreadWithSerialization: *level_2
+    Unit_hipMemcpy_MultiThreadWithSerialization:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpy_PinnedRegMemWithKernelLaunch:
       <<: *level_2
       tags: [multigpu]
-    Unit_hipMemcpyDtoH_Positive_Basic: *level_2
-    Unit_hipMemcpyDtoH_Positive_Synchronization_Behavior: *level_2
-    Unit_hipMemcpyDtoH_Negative_Parameters: *level_2
-    Unit_hipMemcpyHtoD_Positive_Basic: *level_2
-    Unit_hipMemcpyHtoD_Positive_Synchronization_Behavior: *level_2
-    Unit_hipMemcpyHtoD_Negative_Parameters: *level_2
-    Unit_hipMemcpyDtoD_Positive_Basic: *level_2
-    Unit_hipMemcpyDtoD_Positive_Synchronization_Behavior: *level_2
-    Unit_hipMemcpyDtoD_Negative_Parameters: *level_2
-    Unit_hipMemcpyAsync_Positive_Basic: *level_2
-    Unit_hipMemcpyAsync_Positive_Synchronization_Behavior: *level_2
+    Unit_hipMemcpyDtoH_Positive_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyDtoH_Positive_Synchronization_Behavior:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyDtoH_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyHtoD_Positive_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyHtoD_Positive_Synchronization_Behavior:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyHtoD_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyDtoD_Positive_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyDtoD_Positive_Synchronization_Behavior:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyDtoD_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyAsync_Positive_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyAsync_Positive_Synchronization_Behavior:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpyAsync_Negative_Parameters:
+      tags: [memory, transfer]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/18
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemcpyAsync_Capture: *level_2
+    Unit_hipMemcpyAsync_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpyAsync_KernelLaunch: *level_2
     Unit_hipMemcpyAsync_H2H_H2D_D2H_H2PinMem:
       <<: *level_2
@@ -4334,26 +7417,45 @@ unit:
     Unit_hipMemcpyAsync_PinnedRegMemWithKernelLaunch:
       <<: *level_2
       tags: [multigpu]
-    Unit_hipMemcpyDtoHAsync_Positive_Basic: *level_2
-    Unit_hipMemcpyDtoHAsync_Positive_Synchronization_Behavior: *level_2
+    Unit_hipMemcpyDtoHAsync_Positive_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyDtoHAsync_Positive_Synchronization_Behavior:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpyDtoHAsync_Negative_Parameters:
+      tags: [memory, transfer]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/18
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemcpyHtoDAsync_Positive_Basic: *level_2
-    Unit_hipMemcpyHtoDAsync_Positive_Synchronization_Behavior: *level_2
+    Unit_hipMemcpyHtoDAsync_Positive_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyHtoDAsync_Positive_Synchronization_Behavior:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpyHtoDAsync_Negative_Parameters:
+      tags: [memory, transfer]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/18
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemcpyDtoDAsync_Positive_Basic: *level_2
-    Unit_hipMemcpyDtoDAsync_Positive_Synchronization_Behavior: *level_2
+    Unit_hipMemcpyDtoDAsync_Positive_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyDtoDAsync_Positive_Synchronization_Behavior:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemcpyDtoDAsync_Negative_Parameters:
+      tags: [memory, transfer]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/18
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemcpyDtoHAsync_Capture: *level_2
-    Unit_hipMemcpyHtoDAsync_Capture: *level_2
+    Unit_hipMemcpyDtoHAsync_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpyHtoDAsync_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemsetFunctional_ZeroValue_hipMemset: *level_2
     Unit_hipMemsetFunctional_ZeroValue_hipMemsetD32: *level_2
     Unit_hipMemsetFunctional_ZeroValue_hipMemsetD16:
@@ -4369,39 +7471,77 @@ unit:
     Unit_hipMemsetFunctional_ZeroSize_hipMemsetD32: *level_2
     Unit_hipMemsetFunctional_ZeroSize_hipMemsetD16: *level_2
     Unit_hipMemsetFunctional_ZeroSize_hipMemsetD8: *level_2
-    Unit_hipMemsetFunctional_PartialSet_1D: *level_2
-    Unit_hipMemsetFunctional_ZeroValue_2D: *level_2
-    Unit_hipMemsetFunctional_SmallSize_2D: *level_2
-    Unit_hipMemsetFunctional_ZeroSize_2D: *level_2
-    Unit_hipMemsetFunctional_PartialSet_2D: *level_2
-    Unit_hipMemsetFunctional_ZeroValue_3D: *level_2
-    Unit_hipMemsetFunctional_SmallSize_3D: *level_2
-    Unit_hipMemsetFunctional_ZeroSize_3D: *level_2
-    Unit_hipMemsetFunctional_PartialSet_3D: *level_2
-    Unit_hipMalloc_Positive_Basic: *level_2
-    Unit_hipMalloc_Positive_Zero_Size: *level_2
-    Unit_hipMalloc_Positive_Alignment: *level_2
-    Unit_hipMalloc_Negative_Parameters: *level_2
+    Unit_hipMemsetFunctional_PartialSet_1D:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetFunctional_ZeroValue_2D:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetFunctional_SmallSize_2D:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetFunctional_ZeroSize_2D:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetFunctional_PartialSet_2D:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetFunctional_ZeroValue_3D:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetFunctional_SmallSize_3D:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetFunctional_ZeroSize_3D:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemsetFunctional_PartialSet_3D:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMalloc_Positive_Basic:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMalloc_Positive_Zero_Size:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMalloc_Positive_Alignment:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMalloc_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMalloc_Allocate90PercentOfDeviceMemory:
+      tags: [memory, alloc]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipMalloc3D_ValidatePitch:
+      tags: [memory, alloc]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemAllocPitch_ValidatePitch:
+      tags: [memory, alloc]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMallocPitch_ValidatePitch: *level_2
+    Unit_hipMallocPitch_ValidatePitch:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMalloc3D_Negative:
+      tags: [memory, alloc]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMallocPitch_Negative: *level_2
-    Unit_hipMallocPitch_Zero_Dims: *level_2
-    Unit_hipMemAllocPitch_Negative: *level_2
+    Unit_hipMallocPitch_Negative:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocPitch_Zero_Dims:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemAllocPitch_Negative:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMallocPitch_Basic:
       <<: *level_2
       tags: [hipMallocPitch]
@@ -4410,155 +7550,288 @@ unit:
       tags: [hipMallocPitch]
     Unit_hipMallocPitch_Memcpy2D: *level_2
     Unit_hipMallocPitch_MultiThread:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMallocPitch_KernelLaunch: *level_2
-    Unit_hipMalloc3D_Basic: *level_2
-    Unit_hipMalloc3D_SmallandBigChunks: *level_2
+    Unit_hipMalloc3D_Basic:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMalloc3D_SmallandBigChunks:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMalloc3D_MultiThread:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMalloc3DArray_DiffSizes: *level_2
+    Unit_hipMalloc3DArray_DiffSizes:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMalloc3DArray_MultiThread:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMalloc3DArray_happy: *level_2
     Unit_hipMalloc3DArray_MaxTexture: *level_2
-    Unit_hipMalloc3DArray_Negative_NullArrayPtr: *level_2
-    Unit_hipMalloc3DArray_Negative_NullDescPtr: *level_2
-    Unit_hipMalloc3DArray_Negative_ZeroWidth: *level_2
-    Unit_hipMalloc3DArray_Negative_ZeroHeight: *level_2
-    Unit_hipMalloc3DArray_Negative_InvalidFlags: *level_2
+    Unit_hipMalloc3DArray_Negative_NullArrayPtr:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMalloc3DArray_Negative_NullDescPtr:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMalloc3DArray_Negative_ZeroWidth:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMalloc3DArray_Negative_ZeroHeight:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMalloc3DArray_Negative_InvalidFlags:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMalloc3DArray_Negative_InvalidFormat:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMalloc3DArray_Negative_BadChannelLayout:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMalloc3DArray_Negative_8BitFloat:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMalloc3DArray_Negative_DifferentChannelSizes:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMalloc3DArray_Negative_BadChannelSize:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
-    Unit_hipMalloc3DArray_Negative_NumericLimit: *level_2
+    Unit_hipMalloc3DArray_Negative_NumericLimit:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMalloc3DArray_Negative_Non2DTextureGather: *level_2
     Unit_hipArray3DCreate_happy: *level_2
     Unit_hipArray3DCreate_MaxTexture: *level_2
-    Unit_hipArray3DCreate_Negative_NullArrayPtr: *level_2
-    Unit_hipArray3DCreate_Negative_NullDescPtr: *level_2
-    Unit_hipArray3DCreate_Negative_ZeroWidth: *level_2
-    Unit_hipArray3DCreate_Negative_ZeroHeight: *level_2
-    Unit_hipArray3DCreate_Negative_InvalidFormat: *level_2
-    Unit_hipArray3DCreate_Negative_NumChannels: *level_2
-    Unit_hipArray3DCreate_Negative_InvalidFlags: *level_2
-    Unit_hipArray3DCreate_Negative_NumericLimit: *level_2
+    Unit_hipArray3DCreate_Negative_NullArrayPtr:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipArray3DCreate_Negative_NullDescPtr:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipArray3DCreate_Negative_ZeroWidth:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipArray3DCreate_Negative_ZeroHeight:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipArray3DCreate_Negative_InvalidFormat:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipArray3DCreate_Negative_NumChannels:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipArray3DCreate_Negative_InvalidFlags:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipArray3DCreate_Negative_NumericLimit:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipArray3DCreate_Negative_Non2DTextureGather: *level_2
-    Unit_hipDrvMemcpy3D_Positive_Basic: *level_2
+    Unit_hipDrvMemcpy3D_Positive_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipDrvMemcpy3D_Positive_Synchronization_Behavior:
+      tags: [memory, transfer]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
-    Unit_hipDrvMemcpy3D_Positive_Parameters: *level_2
+    Unit_hipDrvMemcpy3D_Positive_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipDrvMemcpy3D_Positive_Array:
+      tags: [memory, transfer]
       <<: *level_2
       # NOTE: The following 2 tests are disabled due to defect - EXSWHTEC-238
       disabled: [amd_windows, amd_wsl]
-    Unit_hipDrvMemcpy3D_Negative_Parameters: *level_2
-    Unit_hipDrvMemcpy3D_Capture: *level_2
+    Unit_hipDrvMemcpy3D_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipDrvMemcpy3D_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipDrvMemcpy3D_MultipleDataTypes: *level_2
-    Unit_hipDrvMemcpy3D_HosttoDevice: *level_2
-    Unit_hipDrvMemcpy3D_Negative: *level_2
-    Unit_hipDrvMemcpy3D_ExtentValidation: *level_2
+    Unit_hipDrvMemcpy3D_HosttoDevice:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipDrvMemcpy3D_Negative:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipDrvMemcpy3D_ExtentValidation:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipDrvMemcpy3D_H2DDeviceContextChange:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipDrvMemcpy3D_Host2ArrayDeviceContextChange:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipDrvMemcpy3D_multiDevice_Basic_Size_Test:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipDrvMemcpy3DAsync_Positive_Basic: *level_2
-    Unit_hipDrvMemcpy3DAsync_Positive_Synchronization_Behavior: *level_2
-    Unit_hipDrvMemcpy3DAsync_Positive_Parameters: *level_2
+    Unit_hipDrvMemcpy3DAsync_Positive_Basic:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipDrvMemcpy3DAsync_Positive_Synchronization_Behavior:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipDrvMemcpy3DAsync_Positive_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipDrvMemcpy3DAsync_Positive_Array:
+      tags: [memory, transfer]
       <<: *level_2
       # NOTE: The following 2 tests are disabled due to defect - EXSWHTEC-238
       disabled: [amd_windows, amd_wsl]
-    Unit_hipDrvMemcpy3DAsync_Negative_Parameters: *level_2
-    Unit_hipDrvMemcpy3DAsync_Capture: *level_2
+    Unit_hipDrvMemcpy3DAsync_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipDrvMemcpy3DAsync_Capture:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipDrvMemcpy3DAsync_MultipleDataTypes: *level_2
-    Unit_hipDrvMemcpy3DAsync_HosttoDevice: *level_2
-    Unit_hipDrvMemcpy3DAsync_Negative: *level_2
-    Unit_hipDrvMemcpy3DAsync_ExtentValidation: *level_2
+    Unit_hipDrvMemcpy3DAsync_HosttoDevice:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipDrvMemcpy3DAsync_Negative:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipDrvMemcpy3DAsync_ExtentValidation:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipDrvMemcpy3DAsync_H2DDeviceContextChange:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipDrvMemcpy3DAsync_Host2ArrayDeviceContextChange:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipDrvMemcpy3DAsync_multiDevice_Basic_Size_Test:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipPointerGetAttribute_MemoryTypes: *level_2
-    Unit_hipPointerGetAttribute_KernelUpdation: *level_2
+    Unit_hipPointerGetAttribute_MemoryTypes:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipPointerGetAttribute_KernelUpdation:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipPointerGetAttribute_PeerGPU:
+      tags: [memory, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipPointerGetAttribute_BufferID: *level_2
-    Unit_hipPointerGetAttribute_HostDeviceOrdinal: *level_2
-    Unit_hipPointerGetAttribute_MappedMem: *level_2
-    Unit_hipPointerGetAttribute_Negative: *level_2
-    Unit_hipPointerGetAttribute_ipc_capable: *level_2
-    Unit_hipDrvPtrGetAttributes_Negative: *level_2
-    Unit_hipDrvPtrGetAttributes_Functional: *level_2
+    Unit_hipPointerGetAttribute_BufferID:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipPointerGetAttribute_HostDeviceOrdinal:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipPointerGetAttribute_MappedMem:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipPointerGetAttribute_Negative:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipPointerGetAttribute_ipc_capable:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipDrvPtrGetAttributes_Negative:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipDrvPtrGetAttributes_Functional:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipMemPrefetchAsync_Basic_AllDevices:
       <<: *level_2
       tags: [multigpu]
-    Unit_hipMemPrefetchAsync_Sync_Behavior: *level_2
-    Unit_hipMemPrefetchAsync_Rounding_Behavior: *level_2
-    Unit_hipMemPrefetchAsync_Negative_Parameters: *level_2
-    Unit_hipMemGetInfo_FreeLessThanTotal: *level_2
+    Unit_hipMemPrefetchAsync_Sync_Behavior:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemPrefetchAsync_Rounding_Behavior:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemPrefetchAsync_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemGetInfo_FreeLessThanTotal:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipFreeImplicitSyncDev:
+      tags: [memory, alloc]
       <<: *level_2
       # Note: TDR
       disabled: [amd_wsl]
     Unit_hipFreeImplicitSyncHost:
+      tags: [memory, alloc]
       <<: *level_2
       # Note: TDR
       disabled: [amd_wsl]
     Unit_hipFreeImplicitSyncArray: *level_2
-    Unit_hipFreeNegativeDev: *level_2
-    Unit_hipFreeNegativeHost: *level_2
-    Unit_hipFreeNegativeArray: *level_2
-    Unit_hipFreeDoubleDevice: *level_2
-    Unit_hipFreeDoubleHost: *level_2
-    Unit_hipFreeDoubleArrayFree: *level_2
-    Unit_hipFreeDoubleArray: *level_2
+    Unit_hipFreeNegativeDev:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipFreeNegativeHost:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipFreeNegativeArray:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipFreeDoubleDevice:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipFreeDoubleHost:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipFreeDoubleArrayFree:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipFreeDoubleArray:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipFreeMultiTDev: *level_2
     Unit_hipFreeMultiTHost: *level_2
     Unit_hipFreeMultiTArray: *level_2
     Unit_hipFreeArray_DifferentSizes: *level_2
-    Unit_hipFreeArray_NegativeArray: *level_2
-    Unit_hipFreeArray_DoubleFree: *level_2
+    Unit_hipFreeArray_NegativeArray:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipFreeArray_DoubleFree:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipFreeArray_MultiThreaded: *level_2
-    Unit_hipHostFree_InvalidMemory: *level_2
-    Unit_hipHostFree_DoubleFree: *level_2
-    Unit_hipHostFree_Multithreading: *level_2
-    Unit_hipHostFree_Capture: *level_2
-    Unit_hipMemcpySync: *level_2
-    Unit_hipMemcpy2DSync: *level_2
-    Unit_hipMemcpy3DSync: *level_2
+    Unit_hipHostFree_InvalidMemory:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostFree_DoubleFree:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostFree_Multithreading:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostFree_Capture:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMemcpySync:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy2DSync:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipMemcpy3DSync:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipMemsetSync:
+      tags: [memory, memset]
       <<: *level_2
       # Note: TDR (random fail)
       disabled: [amd_wsl]
@@ -4567,286 +7840,455 @@ unit:
       # SWDEV-400049 tdr intermittently
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemset2DSync:
+      tags: [memory, memset]
       <<: *level_2
       # SWDEV-398977 fails in stress tests
       disabled: [amd_wsl]
     Unit_hipMemset3DSync:
+      tags: [memory, memset]
       <<: *level_2
       # Note: Following four tests disabled due to defect - EXSWHTEC-203
       disabled: [amd_wsl]
-    Unit_hipMemsetASyncMulti: *level_2
+    Unit_hipMemsetASyncMulti:
+      <<: *level_2
+      tags: [memory, memset]
     Unit_hipMemsetDASyncMulti: *level_2
-    Unit_hipMemset2DASyncMulti: *level_2
-    Unit_hipMemset3DASyncMulti: *level_2
+    Unit_hipMemset2DASyncMulti:
+      <<: *level_2
+      tags: [memory, memset]
+    Unit_hipMemset3DASyncMulti:
+      <<: *level_2
+      tags: [memory, memset]
     Unit_hipMemAdvise_TstFlags:
+      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemAdvise_NegtveTsts:
+      tags: [memory, query]
       <<: *level_2
       # intermittent issue: failure expected but success returned
       disabled: [amd_wsl]
     Unit_hipMemAdvise_PrefrdLoc:
+      tags: [memory, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemAdvise_ReadMostly:
+      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemAdvise_TstFlgOverrideEffect:
+      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemAdvise_TstAccessedByPeer:
+      tags: [memory, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemAdvise_TstAccessedByFlg:
+      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemAdvise_TstAccessedByFlg2: *level_2
-    Unit_hipMemAdvise_TstAccessedByFlg3: *level_2
+    Unit_hipMemAdvise_TstAccessedByFlg2:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemAdvise_TstAccessedByFlg3:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipMemAdvise_TstAccessedByFlg4:
+      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemAdvise_TstAlignedAllocMem: *level_2
+    Unit_hipMemAdvise_TstAlignedAllocMem:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipMemAdvise_TstAlignedAllocMem_XNACK:
+      tags: [memory, query]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
     Unit_hipMemAdvise_TstMemAdvisePrefrdLoc:
+      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemAdvise_TstMemAdviseLstPreftchLoc:
+      tags: [memory, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemAdvise_TstMemAdviseMultiFlag:
+      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemAdvise_ReadMosltyMgpuTst:
+      tags: [memory, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemAdvise_TstSetUnsetPrfrdLoc:
+      tags: [memory, query]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemAdvise_Set_Unset_Basic: *level_2
+    Unit_hipMemAdvise_Set_Unset_Basic:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipMemAdvise_No_Flag_Interference:
+      tags: [memory, query]
       <<: *level_2
       # (amd_linux) NOTE: The following test is disabled due to defect - EXSWHTEC-244
       # (amd_windows) Note: intermittent Seg fault failure
       # (amd_wsl) Note: intermittent Seg fault failure
       <<: *disabled_amd
-    Unit_hipMemAdvise_Rounding: *level_2
-    Unit_hipMemAdvise_Flags_Do_Not_Cause_Prefetch: *level_2
-    Unit_hipMemAdvise_Read_Write_After_Advise:
+    Unit_hipMemAdvise_Rounding:
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemAdvise_Prefetch_After_Advise: *level_2
+      tags: [memory, query]
+    Unit_hipMemAdvise_Flags_Do_Not_Cause_Prefetch:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemAdvise_Read_Write_After_Advise:
+      tags: [memory, query, multigpu]
+      <<: *level_2
+    Unit_hipMemAdvise_Prefetch_After_Advise:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipMemAdvise_AccessedBy_All_Devices:
+      tags: [memory, query]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_wsl]
-    Unit_hipMemAdvise_Negative_Parameters: *level_2
-    Unit_hipMemRangeGetAttributes_Positive_Basic: *level_2
-    Unit_hipMemRangeGetAttributes_Negative_Parameters: *level_2
+    Unit_hipMemAdvise_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemRangeGetAttributes_Positive_Basic:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemRangeGetAttributes_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipFreeAsync_Negative_Parameters:
+      tags: [memory, alloc]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipFreeAsync_capturehipFreeAsync:
+      tags: [memory, alloc]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_hipFreeHost_InvalidMemory: *level_2
-    Unit_hipFreeHost_DoubleFree: *level_2
-    Unit_hipFreeHost_Multithreading: *level_2
-    Unit_hipFreeHost_Capture: *level_2
-    Unit_hipMallocAsync_Basic_OneAlloc: *level_2
-    Unit_hipMallocAsync_Basic_TwoAllocs: *level_2
-    Unit_hipMallocAsync_Basic_Reuse: *level_2
-    Unit_hipMallocAsync_Negative_Parameters: *level_2
-    Unit_hipMallocAsync_basic: *level_2
-    Unit_hipMallocAsync_Multistream_Concurrent: *level_2
-    Unit_hipMallocAsync_StreamEvent_CrissCross: *level_2
+    Unit_hipFreeHost_InvalidMemory:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipFreeHost_DoubleFree:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipFreeHost_Multithreading:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipFreeHost_Capture:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocAsync_Basic_OneAlloc:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocAsync_Basic_TwoAllocs:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocAsync_Basic_Reuse:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocAsync_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocAsync_basic:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocAsync_Multistream_Concurrent:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocAsync_StreamEvent_CrissCross:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMallocAsync_Multidevice:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMallocAsync_Multidevice_Concurrent:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMallocAsync_Multidevice_MultiStream:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMallocAsync_ByUsinghipMalloc: *level_2
-    Unit_hipMallocAsync_ByUsinghipFree: *level_2
-    Unit_hipMallocAsync_MThread_ThreadLocalStream: *level_2
-    Unit_hipMallocAsync_MThread_ThreadSharedStream: *level_2
-    Unit_hipMallocAsync_DefaultStreams_Concurrent: *level_2
-    Unit_hipStreamAttachMemAsync_Positive_Basic: *level_2
-    Unit_hipStreamAttachMemAsync_Positive_Pageable: *level_2
+    Unit_hipMallocAsync_ByUsinghipMalloc:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocAsync_ByUsinghipFree:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocAsync_MThread_ThreadLocalStream:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocAsync_MThread_ThreadSharedStream:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocAsync_DefaultStreams_Concurrent:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipStreamAttachMemAsync_Positive_Basic:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipStreamAttachMemAsync_Positive_Pageable:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipStreamAttachMemAsync_Positive_AttachGlobal:
+      tags: [memory, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipStreamAttachMemAsync_Positive_AttachHost: *level_2
-    Unit_hipStreamAttachMemAsync_Positive_AttachSingle: *level_2
+    Unit_hipStreamAttachMemAsync_Positive_AttachHost:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipStreamAttachMemAsync_Positive_AttachSingle:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipStreamAttachMemAsync_Negative_Parameters:
+      tags: [memory, query]
       <<: *level_2
       # Below tests soft hang in stress test on 13/09/23
       disabled: [amd_wsl]
-    Unit_hipMemRangeGetAttributes_TstFlgs: *level_2
-    Unit_hipMemRangeGetAttributes_NegativeTst: *level_2
+    Unit_hipMemRangeGetAttributes_TstFlgs:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemRangeGetAttributes_NegativeTst:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipMemGetAddressRange_Positive:
+      tags: [memory, query]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemGetAddressRange_Negative:
+      tags: [memory, query]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_wsl]
     Unit_hipMallocMipmappedArray_DiffSizes:
+      tags: [memory, alloc]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipMallocMipmappedArray_MultiThread:
+      tags: [memory, alloc, multigpu]
       <<: *level_2
-      tags: [multigpu]
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipMallocMipmappedArray_happy: *level_2
-    Unit_hipMallocMipmappedArray_Negative_NullArrayPtr: *level_2
-    Unit_hipMallocMipmappedArray_Negative_NullDescPtr: *level_2
-    Unit_hipMallocMipmappedArray_Negative_ZeroWidth: *level_2
-    Unit_hipMallocMipmappedArray_Negative_ZeroHeight: *level_2
+    Unit_hipMallocMipmappedArray_Negative_NullArrayPtr:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocMipmappedArray_Negative_NullDescPtr:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocMipmappedArray_Negative_ZeroWidth:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocMipmappedArray_Negative_ZeroHeight:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMallocMipmappedArray_Negative_InvalidFlags:
+      tags: [memory, alloc]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipMallocMipmappedArray_Negative_InvalidFormat:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMallocMipmappedArray_Negative_BadChannelLayout:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMallocMipmappedArray_Negative_8BitFloat:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMallocMipmappedArray_Negative_DifferentChannelSizes:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMallocMipmappedArray_Negative_BadChannelSize:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
-    Unit_hipMallocMipmappedArray_Negative_NumericLimit: *level_2
+    Unit_hipMallocMipmappedArray_Negative_NumericLimit:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMallocMipmappedArray_Negative_Non2DTextureGather: *level_2
-    Unit_hipMallocMipmappedArray_Negative_NumLevels: *level_2
+    Unit_hipMallocMipmappedArray_Negative_NumLevels:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipGetMipmappedArrayLevel_Negative:
+      tags: [memory, alloc]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipFreeMipmappedArrayImplicitSyncArray: *level_2
-    Unit_hipFreeMipmappedArray_Negative_Nullptr: *level_2
+    Unit_hipFreeMipmappedArray_Negative_Nullptr:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipFreeMipmappedArrayMultiTArray:
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipMallocArray_DiffSizes: *level_2
-    Unit_hipMallocArray_MultiThread:
+    Unit_hipMallocArray_DiffSizes:
       <<: *level_2
-      tags: [multigpu]
+      tags: [memory, alloc]
+    Unit_hipMallocArray_MultiThread:
+      tags: [memory, alloc, multigpu]
+      <<: *level_2
     Unit_hipMallocArray_happy: *level_2
     Unit_hipMallocArray_MaxTexture_Default: *level_2
     Unit_hipMallocArray_Negative_DifferentChannelSizes:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
-    Unit_hipMallocArray_Negative_ZeroWidth: *level_2
-    Unit_hipMallocArray_Negative_NullArrayPtr: *level_2
-    Unit_hipMallocArray_Negative_NullDescPtr: *level_2
-    Unit_hipMallocArray_Negative_BadFlags: *level_2
+    Unit_hipMallocArray_Negative_ZeroWidth:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocArray_Negative_NullArrayPtr:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocArray_Negative_NullDescPtr:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipMallocArray_Negative_BadFlags:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipMallocArray_Negative_8bitFloat:
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMallocArray_Negative_BadNumberOfBits:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMallocArray_Negative_3ChannelElement:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMallocArray_Negative_ChannelAfterZeroChannel:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
     Unit_hipMallocArray_Negative_InvalidChannelFormat:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-475987 : Disable tests to merge hipother change 12/08/2024
       disabled: [nvidia_windows]
-    Unit_hipMallocArray_Negative_NumericLimit: *level_2
-    Unit_hipHostAlloc_Positive: *level_2
-    Unit_hipHostAlloc_DataValidation: *level_2
-    Unit_hipHostAlloc_Negative: *level_2
+    Unit_hipMallocArray_Negative_NumericLimit:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostAlloc_Positive:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostAlloc_DataValidation:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostAlloc_Negative:
+      <<: *level_2
+      tags: [memory, alloc]
     Unit_hipHostAlloc_Basic:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
       disabled: [amd_windows]
     Unit_hipHostAlloc_Default:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
       disabled: [amd_windows]
     Unit_hipHostAlloc_Negative_NonCoherent:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
       disabled: [amd_windows]
     Unit_hipHostAlloc_Negative_Coherent:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
       disabled: [amd_windows]
     Unit_hipHostAlloc_Negative_NumaUser:
+      tags: [memory, alloc]
       <<: *level_2
       # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
       disabled: [amd_windows]
-    Unit_hipHostAlloc_AllocateMoreThanAvailGPUMemory: *level_2
-    Unit_hipHostAlloc_ArgValidation: *level_2
-    Unit_hipHostAlloc_Capture: *level_2
-    Unit_hipDrvMemcpy2DUnaligned_NegTst: *level_2
-    Unit_hipDrvMemcpy2DUnaligned_FuncTst: *level_2
+    Unit_hipHostAlloc_AllocateMoreThanAvailGPUMemory:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostAlloc_ArgValidation:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipHostAlloc_Capture:
+      <<: *level_2
+      tags: [memory, alloc]
+    Unit_hipDrvMemcpy2DUnaligned_NegTst:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipDrvMemcpy2DUnaligned_FuncTst:
+      <<: *level_2
+      tags: [memory, transfer]
     Unit_hipDrvMemcpy2DUnaligned_Positive_Basic:
+      tags: [memory, transfer, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipDrvMemcpy2DUnaligned_Positive_Synchronization_Behavior: *level_2
-    Unit_hipDrvMemcpy2DUnaligned_Positive_Parameters: *level_2
-    Unit_hipArrayGetInfo_Positive_Basic: *level_2
-    Unit_hipArrayGetInfo_Negative_Parameters: *level_2
+    Unit_hipDrvMemcpy2DUnaligned_Positive_Synchronization_Behavior:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipDrvMemcpy2DUnaligned_Positive_Parameters:
+      <<: *level_2
+      tags: [memory, transfer]
+    Unit_hipArrayGetInfo_Positive_Basic:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipArrayGetInfo_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, query]
     Unit_hipArrayGetDescriptor_1D_2D_ArrayParameterChk:
+      tags: [memory, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipArrayGetDescriptor_MultiThreadScenarioFor1D_2D_Array:
+      tags: [memory, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipArrayGetDescriptor_Host2Array_Array2Host:
+      tags: [memory, query, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipArrayGetDescriptor_Negative_Scenarios: *level_2
-    Unit_hipArrayGetDescriptor_Positive_Basic: *level_2
-    Unit_hipArrayGetDescriptor_Negative_Parameters: *level_2
-    Unit_hipArray3DGetDescriptor_Positive_Basic: *level_2
-    Unit_hipArray3DGetDescriptor_Negative_Parameters: *level_2
-    Unit_hipMemcpyToFromSymbol_GlobalConstVar: *level_2
+    Unit_hipArrayGetDescriptor_Negative_Scenarios:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipArrayGetDescriptor_Positive_Basic:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipArrayGetDescriptor_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipArray3DGetDescriptor_Positive_Basic:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipArray3DGetDescriptor_Negative_Parameters:
+      <<: *level_2
+      tags: [memory, query]
+    Unit_hipMemcpyToFromSymbol_GlobalConstVar:
+      <<: *level_2
+      tags: [memory]
     test_svm_byte_granularity:
       <<: *level_2
       tags: [multigpu]
@@ -4862,124 +8304,216 @@ unit:
       tags: [multigpu]
   module:
     Unit_hipModuleLaunchCooperativeKernel_Positive_Basic:
+      tags: [module, launch]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipModuleLaunchCooperativeKernel_Positive_Parameters:
+      tags: [module, launch]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipModuleLaunchCooperativeKernel_Negative_Parameters:
+      tags: [module, launch]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipModuleLaunchCooperativeKernel_Verify_Capture: *level_2
     Unit_hipModuleLaunchKernel_Positive_Basic:
+      tags: [module, launch]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipModuleLaunchKernel_Positive_Parameters:
+      tags: [module, launch]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipModuleLaunchKernel_Negative_Parameters:
+      tags: [multigpu, module, launch]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipModuleLaunchKernel_Fntl: *level_2
+    Unit_hipModuleLaunchKernel_Fntl:
+      <<: *level_2
+      tags: [module, launch]
     Unit_hipModuleLaunchKernel_Verify_Capture:
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipExtLaunchKernelGGL_Functional: *level_2
+    Unit_hipExtLaunchKernelGGL_Functional:
+      <<: *level_2
+      tags: [module, launch]
     Unit_hipModuleLoadDataEx_Positive_Basic:
+      tags: [module, load]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
     Unit_hipModuleLoadDataEx_Negative_Parameters:
+      tags: [module, load]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
     Unit_hipModuleLoadDataEx_Negative_Image_Is_An_Empty_String:
+      tags: [module, load]
       <<: *level_2
       # Note: Following two tests disabled due to defect - EXSWHTEC-153
       disabled: [amd_windows]
-    Unit_hipGetFuncBySymbol_PositiveTest: *level_2
-    Unit_hipGetFuncBySymbol_NegativeTests: *level_2
-    Unit_hipGetFuncBySymbol_InChildProcess: *level_2
-    Unit_hipGetFuncBySymbol_MultiDev: *level_2
-    Unit_hipGetFuncBySymbol_MultiDevMultiThread: *level_2
-    Unit_hipModuleGetFunction_Positive_Basic: *level_2
-    Unit_hipModuleGetFunction_Negative_Parameters: *level_2
-    Unit_hipModuleGetFunction_DiffDevice: *level_2
-    Unit_KerArgOptimization_Saxpy: *level_2
-    Unit_hipGetProcAddress_ModuleApis: *level_2
-    Unit_hipGetProcAddress_ModuleApisLoadData: *level_2
-    Unit_hipGetProcAddress_ModuleApisCooperativeKernels: *level_2
-    Unit_hipGetProcAddress_ModuleApisOccupancy: *level_2
-    Unit_hipFuncGetAttribute_Positive_Basic: *level_2
-    Unit_hipFuncGetAttribute_Negative_Parameters: *level_2
-    Unit_hipHccModuleLaunchKernel_basic: *level_2
-    Unit_hipHccModuleLaunchKernel_NegTst: *level_2
-    Unit_hipModuleLoadFatBinary_NegativeTsts: *level_2
-    Unit_hipModuleLoadFatBinary_PosiiveTsts: *level_2
-    Unit_hipDrvLaunchKernelEx_NegTsts: *level_2
-    Unit_hipDrvLaunchKernelEx_Functional: *level_2
-    Unit_hipDrvLaunchKernelEx_With_Different_Kernels: *level_2
+    Unit_hipGetFuncBySymbol_PositiveTest:
+      <<: *level_2
+      tags: [module, function]
+    Unit_hipGetFuncBySymbol_NegativeTests:
+      <<: *level_2
+      tags: [module, function]
+    Unit_hipGetFuncBySymbol_InChildProcess:
+      <<: *level_2
+      tags: [module, function]
+    Unit_hipGetFuncBySymbol_MultiDev:
+      <<: *level_2
+      tags: [multigpu, module, function]
+    Unit_hipGetFuncBySymbol_MultiDevMultiThread:
+      <<: *level_2
+      tags: [multigpu, module, function]
+    Unit_hipModuleGetFunction_Positive_Basic:
+      <<: *level_2
+      tags: [module, function]
+    Unit_hipModuleGetFunction_Negative_Parameters:
+      <<: *level_2
+      tags: [module, function]
+    Unit_hipModuleGetFunction_DiffDevice:
+      <<: *level_2
+      tags: [multigpu, module, function]
+    Unit_KerArgOptimization_Saxpy:
+      <<: *level_2
+      tags: [module, function]
+    Unit_hipGetProcAddress_ModuleApis:
+      <<: *level_2
+      tags: [module, resource]
+    Unit_hipGetProcAddress_ModuleApisLoadData:
+      <<: *level_2
+      tags: [module, resource]
+    Unit_hipGetProcAddress_ModuleApisCooperativeKernels:
+      <<: *level_2
+      tags: [multigpu, module, resource]
+    Unit_hipGetProcAddress_ModuleApisOccupancy:
+      <<: *level_2
+      tags: [module, resource]
+    Unit_hipFuncGetAttribute_Positive_Basic:
+      <<: *level_2
+      tags: [module, function]
+    Unit_hipFuncGetAttribute_Negative_Parameters:
+      <<: *level_2
+      tags: [module, function]
+    Unit_hipHccModuleLaunchKernel_basic:
+      <<: *level_2
+      tags: [module, launch]
+    Unit_hipHccModuleLaunchKernel_NegTst:
+      <<: *level_2
+      tags: [module, launch]
+    Unit_hipModuleLoadFatBinary_NegativeTsts:
+      <<: *level_2
+      tags: [module, load]
+    Unit_hipModuleLoadFatBinary_PosiiveTsts:
+      <<: *level_2
+      tags: [module, load]
+    Unit_hipDrvLaunchKernelEx_NegTsts:
+      <<: *level_2
+      tags: [module, launch]
+    Unit_hipDrvLaunchKernelEx_Functional:
+      <<: *level_2
+      tags: [module, launch]
+    Unit_hipDrvLaunchKernelEx_With_Different_Kernels:
+      <<: *level_2
+      tags: [module, launch]
     Unit_hipDrvLaunchKernelEx_With_CooperativeKernelWithArgs:
+      tags: [module, launch]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_hipDrvLaunchKernelEx_With_MaxBlockDims: *level_2
-    Unit_hipExtLaunchMultiKernelMultiDevice_Functional: *level_2
+    Unit_hipDrvLaunchKernelEx_With_MaxBlockDims:
+      <<: *level_2
+      tags: [module, launch]
+    Unit_hipExtLaunchMultiKernelMultiDevice_Functional:
+      <<: *level_2
+      tags: [multigpu, module, launch]
     Unit_hipModuleLoadData_Positive_Basic:
+      tags: [module, load]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
     Unit_hipModuleLoadData_Negative_Parameters:
+      tags: [module, load]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
     Unit_hipModuleLoadData_Negative_Image_Is_An_Empty_String:
+      tags: [module, load]
       <<: *level_2
       # Note: Following two tests disabled due to defect - EXSWHTEC-153
       disabled: [amd_windows]
-    Unit_hipModuleLoadData_Functional: *level_2
+    Unit_hipModuleLoadData_Functional:
+      <<: *level_2
+      tags: [module, load]
     Unit_hipModuleLoad_Positive_Basic:
+      tags: [module, load]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
-    Unit_hipModuleLoad_Negative_Parameters: *level_2
+    Unit_hipModuleLoad_Negative_Parameters:
+      <<: *level_2
+      tags: [module, load]
     Unit_hipModuleLoad_Negative_Load_From_A_File_That_Is_Not_A_Module:
+      tags: [module, load]
       <<: *level_2
       # Below tests tests fail in PSDB
       disabled: [nvidia_windows]
-    Unit_hipFuncSetSharedMemConfig_functional: *level_2
+    Unit_hipFuncSetSharedMemConfig_functional:
+      <<: *level_2
+      tags: [module, function]
     Unit_hipModuleUnload_Negative_Module_Is_Nullptr:
+      tags: [module, load]
       <<: *level_2
       # Note: Test disabled due to defect - EXSWHTEC-152
       disabled: [amd_windows]
     Unit_hipModuleUnload_Negative_Double_Unload:
+      tags: [module, load]
       <<: *level_2
       # Below test fails in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/215
       <<: *disabled_nvidia
-    Unit_hipModuleLoad_basic: *level_2
+    Unit_hipModuleLoad_basic:
+      <<: *level_2
+      tags: [module, load]
     Unit_hipModuleGetFunctionCount_Functional:
+      tags: [module, function]
       <<: *level_2
       # (amd_linux) Rock_Linux_Failures_on_gfx94X
       # (amd_windows) Rock_Window_Failures_on_gfx1151
       disabled: [amd_linux, amd_windows]
-    Unit_hipModuleGetFunctionCount_NegativeTsts: *level_2
-    Unit_hipModuleGetGlobal_Functional: *level_2
-    Unit_hipModuleLoad_MultProcess_MultGPU: *level_2
+    Unit_hipModuleGetFunctionCount_NegativeTsts:
+      <<: *level_2
+      tags: [module, function]
+    Unit_hipModuleGetGlobal_Functional:
+      <<: *level_2
+      tags: [multigpu, module, function]
+    Unit_hipModuleLoad_MultProcess_MultGPU:
+      <<: *level_2
+      tags: [multigpu, module, load]
     Unit_hip_linker_spirv_input:
+      tags: [module, resource]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipLinkCreate_Negative: *level_2
-    Unit_hipLinkCreate_AddLinker_CUDA_only_options: *level_2
-    Unit_hipLinkAddFile_Negative: *level_2
+    Unit_hipLinkCreate_Negative:
+      <<: *level_2
+      tags: [module, resource]
+    Unit_hipLinkCreate_AddLinker_CUDA_only_options:
+      <<: *level_2
+      tags: [module, resource]
+    Unit_hipLinkAddFile_Negative:
+      <<: *level_2
+      tags: [module, resource]
     Unit_hipModuleLaunchCooperativeKernelMultiDevice_Positive_Basic:
+      tags: [multigpu, module, launch]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
@@ -4992,124 +8526,199 @@ unit:
       tags: [multigpu]
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipModuleGetGlobal_Positive_Basic: *level_2
-    Unit_hipModuleGetGlobal_Positive_Parameters: *level_2
-    Unit_hipModuleGetGlobal_Negative_Parameters: *level_2
+    Unit_hipModuleGetGlobal_Positive_Basic:
+      <<: *level_2
+      tags: [module, resource]
+    Unit_hipModuleGetGlobal_Positive_Parameters:
+      <<: *level_2
+      tags: [module, resource]
+    Unit_hipModuleGetGlobal_Negative_Parameters:
+      <<: *level_2
+      tags: [module, resource]
     Unit_hipModuleGetGlobal_Negative_Hmod_Is_Nullptr:
+      tags: [module, resource]
       <<: *level_2
       # Note: Test disabled due to defect - EXSWHTEC-163
       disabled: [amd_windows]
     Unit_hipModuleGetGlobal_Negative_Name_Is_Empty_String:
+      tags: [module, resource]
       <<: *level_2
       # Note: Test disabled due to defect - EXSWHTEC-164
       disabled: [amd_windows]
     Unit_hipModuleGetGlobal_Negative_Dptr_And_Bytes_Are_Nullptr:
+      tags: [module, resource]
       <<: *level_2
       # Note: Test disabled due to defect - EXSWHTEC-165
       disabled: [amd_windows]
-    Unit_hipModuleGetGlobal_DiffDevice: *level_2
-    Unit_hipModule_Functional: *level_2
+    Unit_hipModuleGetGlobal_DiffDevice:
+      <<: *level_2
+      tags: [multigpu, module, resource]
+    Unit_hipModule_Functional:
+      <<: *level_2
+      tags: [module, load]
     Unit_hipModuleGetTexRef_Positive_Basic:
+      tags: [module, resource]
       <<: *level_2
       # (amd_windows) Below tests are failing PSDB
       # (nvidia_windows) Disabling tests which no longer behave the same on nvidia platform
       <<: *disabled_windows
     Unit_hipModuleGetTexRef_Negative_Parameters:
+      tags: [module, resource]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipModuleGetTexRef_Negative_Hmod_Is_Nullptr:
+      tags: [module, resource]
       <<: *level_2
       # Note: Test disabled due to defect - EXSWHTEC-166
       disabled: [amd_windows]
     Unit_hipModuleGetTexRef_Negative_Name_Is_Empty_String:
+      tags: [module, resource]
       <<: *level_2
       # Note: Test disabled due to defect - EXSWHTEC-167
       disabled: [amd_windows]
-    Unit_hipFuncSetAttribute_Basic: *level_2
-    Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr: *level_2
+    Unit_hipFuncSetAttribute_Basic:
+      <<: *level_2
+      tags: [module, function]
+    Unit_hipExtModuleLaunchKernel_CheckCodeObjAttr:
+      <<: *level_2
+      tags: [module, launch]
     Unit_hipExtModuleLaunchKernel_NonUniformWorkGroup:
+      tags: [module, launch]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/96
       disabled: [amd_windows, amd_wsl]
-    Unit_hipExtModuleLaunchKernel_UniformWorkGroup: *level_2
+    Unit_hipExtModuleLaunchKernel_UniformWorkGroup:
+      <<: *level_2
+      tags: [module, launch]
     Unit_hipExtModuleLaunchKernel_Positive_Parameters:
+      tags: [module, launch]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipExtModuleLaunchKernel_Negative_Parameters:
+      tags: [multigpu, module, launch]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit_hipExtModuleLaunchKernel_Functional:
+      tags: [module, launch]
       <<: *level_2
       # SWDEV-438524: Below tests causing TDR & machine down in stress test on 15/12/23
       disabled: [amd_windows, amd_wsl]
-    Unit_hipFuncGetAttributes_basic: *level_2
+    Unit_hipFuncGetAttributes_basic:
+      <<: *level_2
+      tags: [module, function]
   multiThread:
-    Unit_hipMemsetAsync_QueueJobsMultithreaded: *level_2
-    Unit_hipMultiThreadDevice_Streams: *level_2
+    Unit_hipMemsetAsync_QueueJobsMultithreaded:
+      <<: *level_2
+      tags: [memory, multithread]
+    Unit_hipMultiThreadDevice_Streams:
+      <<: *level_2
+      tags: [device_mgmt, multithread]
     Unit_hipMultiThreadDevice_SerialPyramid:
+      tags: [device_mgmt, multithread]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_hipMultiThreadDevice_ParallelPyramid: *level_2
+    Unit_hipMultiThreadDevice_ParallelPyramid:
+      <<: *level_2
+      tags: [device_mgmt, multithread]
     Unit_hipMultiThreadDevice_NearZero:
+      tags: [device_mgmt, multithread]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMultiThreadStreams1_AsyncSync: *level_2
+    Unit_hipMultiThreadStreams1_AsyncSync:
+      <<: *level_2
+      tags: [stream, multithread]
     Unit_hipMultiThreadStreams1_AsyncAsync:
+      tags: [stream, multithread]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipMultiThreadStreams1_AsyncSame:
+      tags: [stream, multithread]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipMultiThreadStreams2: *level_2
+    Unit_hipMultiThreadStreams2:
+      <<: *level_2
+      tags: [stream, multithread]
   occupancy:
     Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative_Parameters:
+      tags: [occupancy]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
-    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation: *level_2
-    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_TemplateInvocation: *level_2
-    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative: *level_2
-    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_rangeValidation: *level_2
-    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_templateInvocation: *level_2
-    Unit_hipOccupancyMaxPotentialBlockSize_Negative_Parameters: *level_2
-    Unit_hipOccupancyMaxPotentialBlockSize_Positive_RangeValidation: *level_2
-    Unit_hipOccupancyMaxPotentialBlockSize_Positive_TemplateInvocation: *level_2
-    Unit_hipOccupancyMaxPotentialBlockSize_Negative: *level_2
-    Unit_hipOccupancyMaxPotentialBlockSize_rangeValidation: *level_2
-    Unit_hipOccupancyMaxPotentialBlockSize_templateInvocation: *level_2
+    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation:
+      <<: *level_2
+      tags: [occupancy]
+    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_TemplateInvocation:
+      <<: *level_2
+      tags: [occupancy]
+    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative:
+      <<: *level_2
+      tags: [occupancy]
+    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_rangeValidation:
+      <<: *level_2
+      tags: [occupancy]
+    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_templateInvocation:
+      <<: *level_2
+      tags: [occupancy]
+    Unit_hipOccupancyMaxPotentialBlockSize_Negative_Parameters:
+      <<: *level_2
+      tags: [occupancy]
+    Unit_hipOccupancyMaxPotentialBlockSize_Positive_RangeValidation:
+      <<: *level_2
+      tags: [occupancy]
+    Unit_hipOccupancyMaxPotentialBlockSize_Positive_TemplateInvocation:
+      <<: *level_2
+      tags: [occupancy]
+    Unit_hipOccupancyMaxPotentialBlockSize_Negative:
+      <<: *level_2
+      tags: [occupancy]
+    Unit_hipOccupancyMaxPotentialBlockSize_rangeValidation:
+      <<: *level_2
+      tags: [occupancy]
+    Unit_hipOccupancyMaxPotentialBlockSize_templateInvocation:
+      <<: *level_2
+      tags: [occupancy]
     Unit_hipModuleOccupancyMaxPotentialBlockSize_Negative_Parameters:
+      tags: [occupancy]
       <<: *level_2
       # SWDEV-434878: Below tests failed in stress test on 24/11/23
       disabled: [amd_windows, amd_wsl]
     Unit_hipModuleOccupancyMaxPotentialBlockSize_Positive_RangeValidation:
+      tags: [occupancy]
       <<: *level_2
       # SWDEV-434878: Below tests failed in stress test on 24/11/23
       disabled: [amd_windows, amd_wsl]
     Unit_hipModuleOccupancyMaxPotentialBlockSizeWithFlags_Negative_Parameters:
+      tags: [occupancy]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
     Unit_hipModuleOccupancyMaxPotentialBlockSizeWithFlags_Positive_RangeValidation:
+      tags: [occupancy]
       <<: *level_2
       # SWDEV-434878: Below tests failed in stress test on 24/11/23
       disabled: [amd_windows, amd_wsl]
     Unit_hipModuleOccupancyMaxActiveBlocksPerMultiprocessor_Negative_Parameters:
+      tags: [occupancy]
       <<: *level_2
       # SWDEV-434878: Below tests failed in stress test on 24/11/23
       disabled: [amd_windows, amd_wsl]
     Unit_hipModuleOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation:
+      tags: [occupancy]
       <<: *level_2
       # SWDEV-434878: Below tests failed in stress test on 24/11/23
       disabled: [amd_windows, amd_wsl]
-    Unit_OccupancyAPIs_StreamCapture: *level_2
+    Unit_OccupancyAPIs_StreamCapture:
+      <<: *level_2
+      tags: [occupancy]
     Unit_hipModuleOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_Negative_Parameters:
+      tags: [occupancy]
       <<: *level_2
       # Note: intermittent Seg fault failure
       disabled: [amd_windows, amd_wsl]
@@ -5117,92 +8726,204 @@ unit:
       <<: *level_2
       # SWDEV-434878: Below tests failed in stress test on 24/11/23
       disabled: [amd_windows, amd_wsl]
-    Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_chkRange: *level_2
-    Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_mgpu:
+    Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_chkRange:
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Functor: *level_2
-    Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Lambda: *level_2
-    Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_NegTst: *level_2
+      tags: [occupancy]
+    Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_mgpu:
+      tags: [multigpu, occupancy]
+      <<: *level_2
+    Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Functor:
+      <<: *level_2
+      tags: [occupancy]
+    Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Lambda:
+      <<: *level_2
+      tags: [occupancy]
+    Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_NegTst:
+      <<: *level_2
+      tags: [occupancy]
     Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Functional:
+      tags: [occupancy]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_ValidArgs: *level_2
-    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_InvalidArgs: *level_2
-    Unit_hipOccupancyAvailableDynamicSMemPerBlock_Negative: *level_2
-    Unit_hipOccupancyAvailableDynamicSMemPerBlock_Positive: *level_2
+    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_ValidArgs:
+      <<: *level_2
+      tags: [occupancy]
+    Unit_hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_InvalidArgs:
+      <<: *level_2
+      tags: [occupancy]
+    Unit_hipOccupancyAvailableDynamicSMemPerBlock_Negative:
+      <<: *level_2
+      tags: [occupancy]
+    Unit_hipOccupancyAvailableDynamicSMemPerBlock_Positive:
+      <<: *level_2
+      tags: [occupancy]
   p2p:
-    Unit_hipDeviceGetP2PAttribute_Basic: *level_2
-    Unit_hipDeviceGetP2PAttribute_Negative: *level_2
-    Unit_hipP2pLinkTypeAndHopFunc: *level_2
+    Unit_hipDeviceGetP2PAttribute_Basic:
+      <<: *level_2
+      tags: [peer]
+    Unit_hipDeviceGetP2PAttribute_Negative:
+      <<: *level_2
+      tags: [peer]
+    Unit_hipP2pLinkTypeAndHopFunc:
+      <<: *level_2
+      tags: [peer]
   printf:
     Unit_Printf_flags_Sanity_Positive:
+      tags: [printf]
       <<: *level_2
       # Below test fails in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/274
       disabled: [amd_windows]
     Unit_Printf_length_Sanity_Positive:
+      tags: [printf]
       <<: *level_2
       # Below test fails in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/274
       disabled: [amd_windows]
-    Unit_Printf_specifier_Sanity_Positive: *level_2
-    Unit_Printf_Negative_Parameters_RTC: *level_2
-    Unit_Buffered_Printf_Flags: *level_2
-    Unit_Buffered_Printf_Specifier: *level_2
-    Unit_Host_Printf: *level_2
-    Unit_NonHost_Printf_basic: *level_2
-    Unit_NonHost_Printf_loop: *level_2
-    Unit_NonHost_Printf_multiple_Threads: *level_2
-    Unit_NonHost_Printf_BufferAvailability: *level_2
-    Unit_Printf_ManyDevicesTest:
+    Unit_Printf_specifier_Sanity_Positive:
       <<: *level_2
-      tags: [multigpu]
-    Unit_Printf_PrintfStar: *level_2
-    Unit_Printf_PrintfManyWaves: *level_2
-    Unit_Printf_PrintfWidthPrecision: *level_2
-    Unit_Printf_PrintfBasicTsts: *level_2
-    Unit_Printf_PrintfAltFormsTsts: *level_2
+      tags: [printf]
+    Unit_Printf_Negative_Parameters_RTC:
+      <<: *level_2
+      tags: [printf]
+    Unit_Buffered_Printf_Flags:
+      <<: *level_2
+      tags: [printf]
+    Unit_Buffered_Printf_Specifier:
+      <<: *level_2
+      tags: [printf]
+    Unit_Host_Printf:
+      <<: *level_2
+      tags: [printf]
+    Unit_NonHost_Printf_basic:
+      <<: *level_2
+      tags: [printf]
+    Unit_NonHost_Printf_loop:
+      <<: *level_2
+      tags: [printf]
+    Unit_NonHost_Printf_multiple_Threads:
+      <<: *level_2
+      tags: [printf]
+    Unit_NonHost_Printf_BufferAvailability:
+      <<: *level_2
+      tags: [printf]
+    Unit_Printf_ManyDevicesTest:
+      tags: [multigpu, printf]
+      <<: *level_2
+    Unit_Printf_PrintfStar:
+      <<: *level_2
+      tags: [printf]
+    Unit_Printf_PrintfManyWaves:
+      <<: *level_2
+      tags: [printf]
+    Unit_Printf_PrintfWidthPrecision:
+      <<: *level_2
+      tags: [printf]
+    Unit_Printf_PrintfBasicTsts:
+      <<: *level_2
+      tags: [printf]
+    Unit_Printf_PrintfAltFormsTsts:
+      <<: *level_2
+      tags: [printf]
   rtc:
-    Unit_hiprtc_saxpy: *level_2
-    Unit_hiprtc_warpsize: *level_2
-    Unit_hiprtc_functional: *level_2
-    Unit_hipStreamCaptureRtc: *level_2
-    Unit_hiprtc_includepath: *level_2
-    Unit_hiprtc_devicemalloc: *level_2
-    Unit_hiprtcGetLoweredName_templateKrnls: *level_2
-    Unit_hiprtc_cpp17: *level_2
-    Unit_hiprtc_namehandling: *level_2
-    Unit_hiprtc_getloweredname: *level_2
-    Unit_hiprtc_test_hip_bfloat16: *level_2
-    Unit_RTC_LinkerAPI_Negative: *level_2
-    Unit_RTC_LinkDestroy_Negative: *level_2
+    Unit_hiprtc_saxpy:
+      <<: *level_2
+      tags: [rtc, compile]
+    Unit_hiprtc_warpsize:
+      <<: *level_2
+      tags: [rtc, compile]
+    Unit_hiprtc_functional:
+      <<: *level_2
+      tags: [rtc, compile]
+    Unit_hipStreamCaptureRtc:
+      <<: *level_2
+      tags: [rtc, integration]
+    Unit_hiprtc_includepath:
+      <<: *level_2
+      tags: [rtc, link]
+    Unit_hiprtc_devicemalloc:
+      <<: *level_2
+      tags: [rtc, integration]
+    Unit_hiprtcGetLoweredName_templateKrnls:
+      <<: *level_2
+      tags: [rtc, compile]
+    Unit_hiprtc_cpp17:
+      <<: *level_2
+      tags: [rtc, compile]
+    Unit_hiprtc_namehandling:
+      <<: *level_2
+      tags: [rtc, compile]
+    Unit_hiprtc_getloweredname:
+      <<: *level_2
+      tags: [rtc, compile]
+    Unit_hiprtc_test_hip_bfloat16:
+      <<: *level_2
+      tags: [rtc, header]
+    Unit_RTC_LinkerAPI_Negative:
+      <<: *level_2
+      tags: [rtc, link]
+    Unit_RTC_LinkDestroy_Negative:
+      <<: *level_2
+      tags: [rtc, link]
     Unit_RTC_LinkDestroy_Default:
+      tags: [rtc, link]
       <<: *level_2
       # SWDEV-450909: Test failed in stress testing
       disabled: [amd_windows]
-    Unit_RTC_LinkerAPI: *level_2
-    Unit_RTC_LinkAddFile_Negative: *level_2
-    Unit_RTC_LinkAddFile_Default: *level_2
-    Unit_hiprtc_half_shuffle: *level_2
-    Unit_hiprtc_half_shuffle_sync: *level_2
+    Unit_RTC_LinkerAPI:
+      <<: *level_2
+      tags: [rtc, link]
+    Unit_RTC_LinkAddFile_Negative:
+      <<: *level_2
+      tags: [rtc, link]
+    Unit_RTC_LinkAddFile_Default:
+      <<: *level_2
+      tags: [rtc, link]
+    Unit_hiprtc_half_shuffle:
+      <<: *level_2
+      tags: [rtc, integration]
+    Unit_hiprtc_half_shuffle_sync:
+      <<: *level_2
+      tags: [rtc, integration]
     Unit_Rtc_ReduceRandom:
+      tags: [rtc, compile]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
     Unit_hiprtc_stdheaders:
+      tags: [rtc, header]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
-    Unit_Rtc_MathConstants_header: *level_2
-    Unit_Rtc_VectorTypes_header: *level_2
-    Unit_Rtc_MathFunctions_header: *level_2
-    Unit_Rtc_fp16_header: *level_2
-    Unit_Rtc_TextureTypes_header: *level_2
-    Unit_Rtc_HipComplex_header: *level_2
-    Unit_hipRTC_Ptrdiff_t_Check: *level_2
-    Unit_hipRTC_Check_Ptrdiff_t_FrmChildProcess: *level_2
-    Unit_hiprtc_bitcode_undefined_function: *level_2
-    Unit_Rtc_bfloat16_header: *level_2
+    Unit_Rtc_MathConstants_header:
+      <<: *level_2
+      tags: [rtc, header]
+    Unit_Rtc_VectorTypes_header:
+      <<: *level_2
+      tags: [rtc, header]
+    Unit_Rtc_MathFunctions_header:
+      <<: *level_2
+      tags: [rtc, header]
+    Unit_Rtc_fp16_header:
+      <<: *level_2
+      tags: [rtc, header]
+    Unit_Rtc_TextureTypes_header:
+      <<: *level_2
+      tags: [rtc, header]
+    Unit_Rtc_HipComplex_header:
+      <<: *level_2
+      tags: [rtc, header]
+    Unit_hipRTC_Ptrdiff_t_Check:
+      <<: *level_2
+      tags: [rtc, compile]
+    Unit_hipRTC_Check_Ptrdiff_t_FrmChildProcess:
+      <<: *level_2
+      tags: [rtc, compile]
+    Unit_hiprtc_bitcode_undefined_function:
+      <<: *level_2
+      tags: [rtc, link]
+    Unit_Rtc_bfloat16_header:
+      <<: *level_2
+      tags: [rtc, header]
     Unit_hiprtcGpuArchComplrOptnTst: *level_2
     Unit_hiprtcGpuRdcComplrOptnTst:
       <<: *level_2
@@ -5248,62 +8969,128 @@ unit:
     Unit_hiprtcEnabledTrappingMathComplrOptnTst: *level_2
     Unit_hiprtcDisabledTrappingMathComplrOptnTst: *level_2
     Unit_hiprtcCombiComplrOptnTst:
+      tags: [rtc, compile]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/327
       disabled: [amd_wsl]
   stream:
-    Unit_hipStreamCreate_default: *level_2
-    Unit_hipStreamCreate_Negative: *level_2
-    Unit_hipStreamGetFlags_Basic: *level_2
-    Unit_hipStreamGetFlags_Negative: *level_2
-    Unit_hipStreamGetFlags_StreamsCreatedWithCUMask: *level_2
-    Unit_hipStreamGetPriority_happy: *level_2
-    Unit_hipStreamGetPriority_nullptr_nullptr: *level_2
-    Unit_hipStreamGetPriority_stream_nullptr: *level_2
-    Unit_hipStreamGetPriority_nullptr_priority: *level_2
-    Unit_hipStreamGetPriority_stream_priority: *level_2
-    Unit_hipStreamGetPriority_StreamsWithCUMask: *level_2
-    Unit_hipMultiStream_sameDevice: *level_2
-    Unit_hipMultiStream_multimeDevice: *level_2
-    Unit_hipStreamAddCallback_ParamTst_Positive: *level_2
-    Unit_hipStreamAddCallback_ParamTst_Negative: *level_2
-    Unit_hipStreamAddCallback_WithDefaultStream: *level_2
-    Unit_hipStreamAddCallback_WithCreatedStream: *level_2
-    Unit_hipStreamCreateWithFlags_Negative_NullStream: *level_2
-    Unit_hipStreamCreateWithFlags_Negative_InvalidFlag: *level_2
-    Unit_hipStreamCreateWithFlags_Default: *level_2
+    Unit_hipStreamCreate_default:
+      <<: *level_2
+      tags: [stream, lifecycle]
+    Unit_hipStreamCreate_Negative:
+      <<: *level_2
+      tags: [stream, lifecycle]
+    Unit_hipStreamGetFlags_Basic:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamGetFlags_Negative:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamGetFlags_StreamsCreatedWithCUMask:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamGetPriority_happy:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamGetPriority_nullptr_nullptr:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamGetPriority_stream_nullptr:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamGetPriority_nullptr_priority:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamGetPriority_stream_priority:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamGetPriority_StreamsWithCUMask:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipMultiStream_sameDevice:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipMultiStream_multimeDevice:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamAddCallback_ParamTst_Positive:
+      <<: *level_2
+      tags: [stream, callback]
+    Unit_hipStreamAddCallback_ParamTst_Negative:
+      <<: *level_2
+      tags: [stream, callback]
+    Unit_hipStreamAddCallback_WithDefaultStream:
+      <<: *level_2
+      tags: [stream, callback]
+    Unit_hipStreamAddCallback_WithCreatedStream:
+      <<: *level_2
+      tags: [stream, callback]
+    Unit_hipStreamCreateWithFlags_Negative_NullStream:
+      <<: *level_2
+      tags: [stream, lifecycle]
+    Unit_hipStreamCreateWithFlags_Negative_InvalidFlag:
+      <<: *level_2
+      tags: [stream, lifecycle]
+    Unit_hipStreamCreateWithFlags_Default:
+      <<: *level_2
+      tags: [stream, lifecycle]
     Unit_hipStreamCreateWithFlags_DefaultStreamInteraction:
+      tags: [stream, lifecycle]
       <<: *level_2
       # (amd_windows) Disabling below tests temporarily due to change in API behavior
       # (amd_wsl) Note: Following four tests disabled due to defect - EXSWHTEC-203
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamCreateWithPriority_FunctionalForAllPriorities: *level_2
+    Unit_hipStreamCreateWithPriority_FunctionalForAllPriorities:
+      <<: *level_2
+      tags: [stream, lifecycle]
     Unit_hipStreamCreateWithPriority_MulthreadDefaultflag:
+      tags: [stream, lifecycle]
       <<: *level_2
       # SWDEV-398981 fails in stress test
       disabled: [amd_wsl]
     Unit_hipStreamCreateWithPriority_MulthreadNonblockingflag:
+      tags: [stream, lifecycle]
       <<: *level_2
       # Disabling test tracked SWDEV-394199
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamCreateWithPriority_NegTst: *level_2
-    Unit_hipStreamCreateWithPriority_CheckPriorityVal: *level_2
+    Unit_hipStreamCreateWithPriority_NegTst:
+      <<: *level_2
+      tags: [stream, lifecycle]
+    Unit_hipStreamCreateWithPriority_CheckPriorityVal:
+      <<: *level_2
+      tags: [stream, lifecycle]
     Unit_hipStreamCreateWithPriority_ValidateWithEvents:
+      tags: [stream, lifecycle]
       <<: *level_2
       # Below tests fail in stress test on 24/07/23
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamCreateWithPriority_TestMultipleStreamWithPriority: *level_2
-    Unit_hipStreamDestroy_Default: *level_2
-    Unit_hipStreamDestroy_Negative_NullStream: *level_2
-    Unit_hipStreamDestroy_WithFinishedWork: *level_2
+    Unit_hipStreamCreateWithPriority_TestMultipleStreamWithPriority:
+      <<: *level_2
+      tags: [stream, lifecycle]
+    Unit_hipStreamDestroy_Default:
+      <<: *level_2
+      tags: [stream, lifecycle]
+    Unit_hipStreamDestroy_Negative_NullStream:
+      <<: *level_2
+      tags: [stream, lifecycle]
+    Unit_hipStreamDestroy_WithFinishedWork:
+      <<: *level_2
+      tags: [stream, lifecycle]
     Unit_hipStreamDestroy_WithPendingWork:
+      tags: [stream, lifecycle]
       <<: *level_2
       # Note: TDR
       disabled: [amd_wsl]
-    Unit_hipStreamCreate_MultistreamBasicFunctionalities: *level_2
+    Unit_hipStreamCreate_MultistreamBasicFunctionalities:
+      <<: *level_2
+      tags: [stream]
     Unit_hipMemcpyAsync_hipStreamLegacy_H2H_H2D_D2H_H2PinMem: *level_2
-    Unit_hipStreamGetCaptureInfo_hipStreamLegacy_CaptureInfo: *level_2
-    Unit_hipMemPrefetchAsync_Basic: *level_2
+    Unit_hipStreamGetCaptureInfo_hipStreamLegacy_CaptureInfo:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipMemPrefetchAsync_Basic:
+      <<: *level_2
+      tags: [stream]
     Unit_hipMemPoolApi_hipStreamLegacy_Basic: *level_2
     Unit_hipStreamValue_Write:
       <<: *level_2
@@ -5394,496 +9181,936 @@ unit:
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipStreamValue_Wait64_NonBlocking_NoMask_Nor: *level_2
-    Unit_hipStreamValue_Negative_InvalidMemory: *level_2
+    Unit_hipStreamValue_Negative_InvalidMemory:
+      <<: *level_2
+      tags: [stream]
     Unit_hipStreamValue_Negative_UninitializedStream: *level_2
     Unit_hipStreamValue_Negative_InvalidFlag: *level_2
     Unit_hipStreamWriteValue_Default: *level_2
     Unit_hipStreamWaitValue_Default: *level_2
-    Unit_hipStreamSynchronize_EmptyStream: *level_2
+    Unit_hipStreamSynchronize_EmptyStream:
+      <<: *level_2
+      tags: [stream, sync]
     Unit_hipStreamSynchronize_FinishWork:
+      tags: [stream, sync]
       <<: *level_2
       # Note: TDR (pass)
       disabled: [amd_wsl]
     Unit_hipStreamSynchronize_NullStreamSynchronization:
+      tags: [stream, sync]
       <<: *level_2
       # (amd_windows) mlsejenkins_Window_Failures_on_gfx1201
       # (amd_wsl) Note: TDR (pass)
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamSynchronize_SynchronizeStreamAndQueryNullStream: *level_2
+    Unit_hipStreamSynchronize_SynchronizeStreamAndQueryNullStream:
+      <<: *level_2
+      tags: [stream, sync]
     Unit_hipStreamSynchronize_NullStreamAndStreamPerThread:
+      tags: [stream, sync]
       <<: *level_2
       # Note: needs to be enabled when streamPerThread issues are fixed
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamQuery_WithNoWork: *level_2
+    Unit_hipStreamQuery_WithNoWork:
+      <<: *level_2
+      tags: [stream, sync]
     Unit_hipStreamQuery_WithFinishedWork:
+      tags: [stream, sync]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
     Unit_hipStreamQuery_SubmitWorkOnStreamAndQueryNullStream:
+      tags: [stream, sync]
       <<: *level_2
       # Note: TDR (pass)
       disabled: [amd_wsl]
     Unit_hipStreamQuery_NullStreamQuery:
+      tags: [stream, sync]
       <<: *level_2
       # Note: TDR (pass)
       disabled: [amd_wsl]
     Unit_hipStreamQuery_WithPendingWork:
+      tags: [stream, sync]
       <<: *level_2
       # (amd_linux) Rock_Linux_Failures_on_gfx94X
       # (amd_wsl) Note: TDR (pass)
       disabled: [amd_linux, amd_wsl]
-    Unit_hipDeviceGetStreamPriorityRange_Default: *level_2
+    Unit_hipDeviceGetStreamPriorityRange_Default:
+      <<: *level_2
+      tags: [stream]
     Unit_hipStreamAddCallback_StrmSyncTiming:
+      tags: [stream, callback]
       <<: *level_2
       # (amd_windows) SWDEV-400049 tdr intermittently
       # (amd_wsl) Note: Following four tests disabled due to defect - EXSWHTEC-203
       disabled: [amd_windows, amd_wsl]
-    Unit_hipLaunchHostFunc_basic: *level_2
-    Unit_hipLaunchHostFunc_Negative: *level_2
+    Unit_hipLaunchHostFunc_basic:
+      <<: *level_2
+      tags: [stream, callback]
+    Unit_hipLaunchHostFunc_Negative:
+      <<: *level_2
+      tags: [stream, callback]
     Unit_hipLaunchHostFunc_streams:
+      tags: [stream, callback]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
     Unit_hipLaunchHostFunc_multistreams:
+      tags: [stream, callback]
       <<: *level_2
       # SWDEV-430116:Below tests failed in stress test on 27/10/23
       disabled: [amd_wsl]
     Unit_hipLaunchHostFunc_KernelHost:
+      tags: [stream, callback]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipLaunchHostFunc_multidevice:
+      tags: [stream, callback, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipLaunchHostFunc_Samepriority: *level_2
-    Unit_hipLaunchHostFunc_Diffpriority: *level_2
+    Unit_hipLaunchHostFunc_Samepriority:
+      <<: *level_2
+      tags: [stream, callback]
+    Unit_hipLaunchHostFunc_Diffpriority:
+      <<: *level_2
+      tags: [stream, callback]
     Unit_hipLaunchHostFunc_Graph:
+      tags: [stream, callback]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamGetDevice_Negative: *level_2
+    Unit_hipStreamGetDevice_Negative:
+      <<: *level_2
+      tags: [stream]
     Unit_hipStreamGetDevice_Usecase:
+      tags: [stream, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipStreamGetDevice_MThread: *level_2
+    Unit_hipStreamGetDevice_MThread:
+      <<: *level_2
+      tags: [stream]
     Unit_hipStreamGetDevice_SetDiffDevice:
+      tags: [stream, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipStreamGetDevice_NullStream:
+      tags: [stream, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipStreamLegacy_WithBlockingStream: *level_2
-    Unit_hipStreamLegacy_MultipleThreads: *level_2
-    Unit_hipStreamLegacy_NegetiveCase: *level_2
-    Unit_hipStreamLegacy_WithNonBlockingStream: *level_2
-    Unit_hipStreamLegacy_WithStreamPerThread: *level_2
+    Unit_hipStreamLegacy_WithBlockingStream:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamLegacy_MultipleThreads:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamLegacy_NegetiveCase:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamLegacy_WithNonBlockingStream:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamLegacy_WithStreamPerThread:
+      <<: *level_2
+      tags: [stream]
     Unit_hipStreamLegacy_MultiDevice:
+      tags: [stream, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipStreamLegacy_H2H_H2D_D2D_D2H_Default: *level_2
+    Unit_hipStreamLegacy_H2H_H2D_D2D_D2H_Default:
+      <<: *level_2
+      tags: [stream]
     Unit_hipStreamLegacy_MultiDeviceMultiOperation:
+      tags: [stream, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipStreamLegacy_TwoThreadsEachOneDiffOperation: *level_2
+    Unit_hipStreamLegacy_TwoThreadsEachOneDiffOperation:
+      <<: *level_2
+      tags: [stream]
     Unit_hipStreamLegacy_TwoDevicesEachOneDiffOperation:
+      tags: [stream, multigpu]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipStreamLegacy_TwoThreadsInTwoDevicesEachOneDiffOperation:
+      tags: [stream, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipStreamLegacy_InChildProcess: *level_2
-    Unit_hipStreamLegacy_WithKernel: *level_2
-    Unit_hipStreamLegacy_hipStreamSynchronize: *level_2
-    Unit_hipStreamLegacy_WithSptCompilerOption: *level_2
-    Unit_hipStreamLegacy_TwoThreadsDiffOperationWithSptCompOption: *level_2
-    Unit_hipStreamGetId_Negative: *level_2
-    Unit_hipStreamGetId_Basic: *level_2
-    Unit_hipStreamGetId_WithDifferentStreamCreateAPIs: *level_2
-    Unit_hipStreamGetId_MultipleThreads: *level_2
+    Unit_hipStreamLegacy_InChildProcess:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamLegacy_WithKernel:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamLegacy_hipStreamSynchronize:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamLegacy_WithSptCompilerOption:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamLegacy_TwoThreadsDiffOperationWithSptCompOption:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamGetId_Negative:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamGetId_Basic:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamGetId_WithDifferentStreamCreateAPIs:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamGetId_MultipleThreads:
+      <<: *level_2
+      tags: [stream]
     Unit_hipStreamGetId_MultiDevice:
+      tags: [stream, multigpu]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipStreamGetId_MultiProcess: *level_2
-    Unit_hipExtStreamGetCUMask_verifyDefaultAndCustomMask: *level_2
-    Unit_hipExtStreamGetCUMask_Negative: *level_2
-    Unit_hipExtStreamCreateWithCUMask_ValidateCallbackFunc: *level_2
-    Unit_hipExtStreamCreateWithCUMask_Functionality: *level_2
-    Unit_hipExtStreamCreateWithCUMask_AllCUsMasked: *level_2
+    Unit_hipStreamGetId_MultiProcess:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipExtStreamGetCUMask_verifyDefaultAndCustomMask:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipExtStreamGetCUMask_Negative:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipExtStreamCreateWithCUMask_ValidateCallbackFunc:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipExtStreamCreateWithCUMask_Functionality:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipExtStreamCreateWithCUMask_AllCUsMasked:
+      <<: *level_2
+      tags: [stream]
     Unit_hipExtStreamCreateWithCUMask_NegTst:
+      tags: [stream]
       <<: *level_2
       # Rock_Linux_Failures_on_gfx94X
       disabled: [amd_linux]
-    Unit_hipStreamAddCallback_MultipleThreads: *level_2
-    Unit_hipStreamWaitEvent_Negative: *level_2
-    Unit_hipStreamWaitEvent_Default: *level_2
+    Unit_hipStreamAddCallback_MultipleThreads:
+      <<: *level_2
+      tags: [stream, callback]
+    Unit_hipStreamWaitEvent_Negative:
+      <<: *level_2
+      tags: [stream, sync]
+    Unit_hipStreamWaitEvent_Default:
+      <<: *level_2
+      tags: [stream, sync]
     Unit_hipStreamWaitEvent_DifferentStreams:
+      tags: [stream, sync]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamGetFlags_spt_Basic: *level_2
-    Unit_hipStreamGetFlags_spt_Negative: *level_2
-    Unit_hipStreamGetFlags_spt_StreamsCreatedWithCUMask: *level_2
-    Unit_hipStreamGetPriority_spt_BasicTst: *level_2
-    Unit_hipStreamGetPriority_spt_NegativeCases: *level_2
-    Unit_hipStreamGetPriority_spt_StreamsWithCUMask: *level_2
-    Unit_hipStreamQuery_spt_WithNoWork: *level_2
+    Unit_hipStreamGetFlags_spt_Basic:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamGetFlags_spt_Negative:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamGetFlags_spt_StreamsCreatedWithCUMask:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamGetPriority_spt_BasicTst:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamGetPriority_spt_NegativeCases:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamGetPriority_spt_StreamsWithCUMask:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamQuery_spt_WithNoWork:
+      <<: *level_2
+      tags: [stream, sync]
     Unit_hipStreamQuery_spt_WithFinishedWork:
+      tags: [stream, sync]
       <<: *level_2
       # Following tests disabled due to SWDEV-486363
       disabled: [amd_windows]
     Unit_hipStreamQuery_spt_NegativeCases:
+      tags: [stream, sync]
       <<: *level_2
       # Following tests disabled due to SWDEV-486363
       disabled: [amd_windows]
     Unit_hipStreamQuery_spt_WithPendingWork:
+      tags: [stream, sync]
       <<: *level_2
       # Following tests disabled due to SWDEV-486363
       disabled: [amd_windows]
-    Unit_hipStreamSynchronize_spt_EmptyStream: *level_2
+    Unit_hipStreamSynchronize_spt_EmptyStream:
+      <<: *level_2
+      tags: [stream, sync]
     Unit_hipStreamSynchronize_spt_FinishWork:
+      tags: [stream, sync]
       <<: *level_2
       # Following tests disabled due to SWDEV-486363
       disabled: [amd_windows]
     Unit_hipStreamSynchronize_spt_SynchronizeStreamAndQueryNullStream:
+      tags: [stream, sync]
       <<: *level_2
       # Following tests disabled due to SWDEV-486363
       disabled: [amd_windows]
-    Unit_hipStreamBatchMemOp_Negative_Tests: *level_2
-    Unit_hipStreamSetAttribute_hipStreamGetAttribute_Basic: *level_2
-    Unit_hipStreamGetAttribute_Negative: *level_2
-    Unit_hipStreamSetAttribute_Negative: *level_2
-    Unit_hipStreamCopyAttributes_Basic: *level_2
-    Unit_hipStreamCopyAttributes_Negative: *level_2
-    Unit_hipStreamCopyAttributes_WithAllSyncPolicyValues: *level_2
+    Unit_hipStreamBatchMemOp_Negative_Tests:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamSetAttribute_hipStreamGetAttribute_Basic:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamGetAttribute_Negative:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamSetAttribute_Negative:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamCopyAttributes_Basic:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamCopyAttributes_Negative:
+      <<: *level_2
+      tags: [stream]
+    Unit_hipStreamCopyAttributes_WithAllSyncPolicyValues:
+      <<: *level_2
+      tags: [stream]
   streamperthread:
-    Unit_hipStreamPerThread_Basic: *level_2
-    Unit_hipStreamPerThread_StreamQuery: *level_2
-    Unit_hipStreamPerThread_StreamSynchronize: *level_2
-    Unit_hipStreamPerThread_StreamGetPriority: *level_2
-    Unit_hipStreamPerThread_StreamGetFlags: *level_2
-    Unit_hipStreamPerThread_StreamDestroy: *level_2
-    Unit_hipStreamPerThread_MemcpyAsync: *level_2
-    Unit_hipStreamPerThread_EventRecord: *level_2
-    Unit_hipStreamPerThread_EventSynchronize: *level_2
+    Unit_hipStreamPerThread_Basic:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipStreamPerThread_StreamQuery:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipStreamPerThread_StreamSynchronize:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipStreamPerThread_StreamGetPriority:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipStreamPerThread_StreamGetFlags:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipStreamPerThread_StreamDestroy:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipStreamPerThread_MemcpyAsync:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipStreamPerThread_EventRecord:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipStreamPerThread_EventSynchronize:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
     Unit_hipStreamPerThread_MultiThread:
+      tags: [stream, stream_per_thread]
       <<: *level_2
       # Disabling test tracked SWDEV-395683
       disabled: [amd_wsl]
     Unit_hipStreamPerThread_DeviceReset_1:
+      tags: [stream, stream_per_thread]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamPerThread_DeviceReset_2: *level_2
-    Unit_hipStreamPerThreadTst_StrmQuery: *level_2
-    Unit_hipStreamPerThread_MangdMem: *level_2
-    Unit_hipStreamPerThread_ChildProc: *level_2
-    Unit_hipStreamPerThread_EvtRcrdMThrd: *level_2
+    Unit_hipStreamPerThread_DeviceReset_2:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipStreamPerThreadTst_StrmQuery:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipStreamPerThread_MangdMem:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipStreamPerThread_ChildProc:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipStreamPerThread_EvtRcrdMThrd:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
     Unit_hipStreamPerThread_StrmWaitEvt:
+      tags: [stream, stream_per_thread]
       <<: *level_2
       # Note: Windows disabled
       disabled: [amd_windows, amd_wsl]
-    Unit_hipStreamPerThread_CoopLaunch: *level_2
-    Unit_hipStrmPerThrdDefault: *level_2
-    Unit_hipGetProcAddress_spt_MemCpy: *level_2
-    Unit_hipGetProcAddress_spt_Memset: *level_2
-    Unit_hipGetProcAddress_spt_Memset2D3D: *level_2
-    Unit_hipGetProcAddress_spt_Memcpy2D: *level_2
-    Unit_hipGetProcAddress_spt_Memcpy3D: *level_2
-    Unit_hipGetProcAddress_spt_LaunchKernel: *level_2
-    Unit_hipGetProcAddress_spt_LaunchCooperativeKernel: *level_2
-    Unit_hipGetProcAddress_spt_Stream: *level_2
-    Unit_hipGetProcAddress_spt_Graph: *level_2
-    Unit_hipGetProcAddress_spt_Event: *level_2
-  surface:
-    Unit_hipCreateSurfaceObject_Negative_Parameters: *level_2
-    Unit_hipDestroySurfaceObject_Negative_Parameters: *level_2
-    Unit_surf1Dread_Positive_Basic: *level_2
-    Unit_surf1Dwrite_Positive_Basic: *level_2
-    Unit_surf1D_Positive_ReadWrite: *level_2
-    Unit_surf1DLayeredread_Positive_Basic: *level_2
-    Unit_surf1DLayeredwrite_Positive_Basic: *level_2
-    Unit_surf1DLayered_Positive_ReadWrite: *level_2
-    Unit_surf2Dread_Positive_Basic: *level_2
-    Unit_surf2Dwrite_Positive_Basic: *level_2
-    Unit_surf2D_Positive_ReadWrite: *level_2
-    Unit_surf2DLayeredread_Positive_Basic: *level_2
-    Unit_surf2DLayeredwrite_Positive_Basic: *level_2
-    Unit_surf2DLayered_Positive_ReadWrite: *level_2
-    Unit_surf3Dread_Positive_Basic: *level_2
-    Unit_surf3Dwrite_Positive_Basic: *level_2
-    Unit_surf3D_Positive_ReadWrite: *level_2
-    Unit_surfCubemapread_Positive_Basic: *level_2
-    Unit_surfCubemapwrite_Positive_Basic: *level_2
-    Unit_surfCubemap_Positive_ReadWrite: *level_2
-  synchronization:
-    Unit_Copy_Coherency: *level_2
-    Unit_cache_coherency_cpu_gpu: *level_2
-    Unit_cache_coherency_gpu_gpu:
+    Unit_hipStreamPerThread_CoopLaunch:
       <<: *level_2
-      tags: [multigpu]
+      tags: [stream, stream_per_thread]
+    Unit_hipStrmPerThrdDefault:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipGetProcAddress_spt_MemCpy:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipGetProcAddress_spt_Memset:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipGetProcAddress_spt_Memset2D3D:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipGetProcAddress_spt_Memcpy2D:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipGetProcAddress_spt_Memcpy3D:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipGetProcAddress_spt_LaunchKernel:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipGetProcAddress_spt_LaunchCooperativeKernel:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipGetProcAddress_spt_Stream:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipGetProcAddress_spt_Graph:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+    Unit_hipGetProcAddress_spt_Event:
+      <<: *level_2
+      tags: [stream, stream_per_thread]
+  surface:
+    Unit_hipCreateSurfaceObject_Negative_Parameters:
+      <<: *level_2
+      tags: [texture, surface, surfobj]
+    Unit_hipDestroySurfaceObject_Negative_Parameters:
+      <<: *level_2
+      tags: [texture, surface, surfobj]
+    Unit_surf1Dread_Positive_Basic:
+      <<: *level_2
+      tags: [texture, surface, surfop]
+    Unit_surf1Dwrite_Positive_Basic:
+      <<: *level_2
+      tags: [texture, surface, surfop]
+    Unit_surf1D_Positive_ReadWrite:
+      <<: *level_2
+      tags: [texture, surface, surfop]
+    Unit_surf1DLayeredread_Positive_Basic:
+      <<: *level_2
+      tags: [texture, surface, surfop]
+    Unit_surf1DLayeredwrite_Positive_Basic:
+      <<: *level_2
+      tags: [texture, surface, surfop]
+    Unit_surf1DLayered_Positive_ReadWrite:
+      <<: *level_2
+      tags: [texture, surface, surfop]
+    Unit_surf2Dread_Positive_Basic:
+      <<: *level_2
+      tags: [texture, surface, surfop]
+    Unit_surf2Dwrite_Positive_Basic:
+      <<: *level_2
+      tags: [texture, surface, surfop]
+    Unit_surf2D_Positive_ReadWrite:
+      <<: *level_2
+      tags: [texture, surface, surfop]
+    Unit_surf2DLayeredread_Positive_Basic:
+      <<: *level_2
+      tags: [texture, surface, surfop]
+    Unit_surf2DLayeredwrite_Positive_Basic:
+      <<: *level_2
+      tags: [texture, surface, surfop]
+    Unit_surf2DLayered_Positive_ReadWrite:
+      <<: *level_2
+      tags: [texture, surface, surfop]
+    Unit_surf3Dread_Positive_Basic:
+      <<: *level_2
+      tags: [texture, surface, surfop]
+    Unit_surf3Dwrite_Positive_Basic:
+      <<: *level_2
+      tags: [texture, surface, surfop]
+    Unit_surf3D_Positive_ReadWrite:
+      <<: *level_2
+      tags: [texture, surface, surfop]
+    Unit_surfCubemapread_Positive_Basic:
+      <<: *level_2
+      tags: [texture, surface, surfop]
+    Unit_surfCubemapwrite_Positive_Basic:
+      <<: *level_2
+      tags: [texture, surface, surfop]
+    Unit_surfCubemap_Positive_ReadWrite:
+      <<: *level_2
+      tags: [texture, surface, surfop]
+  synchronization:
+    Unit_Copy_Coherency:
+      <<: *level_2
+      tags: [sync, coherency]
+    Unit_cache_coherency_cpu_gpu:
+      <<: *level_2
+      tags: [sync, coherency]
+    Unit_cache_coherency_gpu_gpu:
+      tags: [multigpu, sync, coherency]
+      <<: *level_2
   syncthreads:
     Unit___syncthreads_Positive_Basic:
+      tags: [device_lib, sync, block]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
     Unit___syncthreads_count_Positive_Basic:
+      tags: [device_lib, sync, block]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit___syncthreads_count_Positive_Predicate_Zero: *level_2
-    Unit___syncthreads_count_Positive_Predicate_One: *level_2
-    Unit___syncthreads_count_Positive_Predicate_OddEven: *level_2
-    Unit___syncthreads_count_Positive_Predicate_Negative: *level_2
-    Unit___syncthreads_count_Positive_Predicate_Id: *level_2
-    Unit___syncthreads_count_Negative_Parameters_RTC: *level_2
+    Unit___syncthreads_count_Positive_Predicate_Zero:
+      <<: *level_2
+      tags: [device_lib, sync, block]
+    Unit___syncthreads_count_Positive_Predicate_One:
+      <<: *level_2
+      tags: [device_lib, sync, block]
+    Unit___syncthreads_count_Positive_Predicate_OddEven:
+      <<: *level_2
+      tags: [device_lib, sync, block]
+    Unit___syncthreads_count_Positive_Predicate_Negative:
+      <<: *level_2
+      tags: [device_lib, sync, block]
+    Unit___syncthreads_count_Positive_Predicate_Id:
+      <<: *level_2
+      tags: [device_lib, sync, block]
+    Unit___syncthreads_count_Negative_Parameters_RTC:
+      <<: *level_2
+      tags: [device_lib, sync, block]
     Unit___syncthreads_and_Positive_Basic:
+      tags: [device_lib, sync, block]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit___syncthreads_and_Positive_Predicate_Zero: *level_2
-    Unit___syncthreads_and_Positive_Predicate_One: *level_2
-    Unit___syncthreads_and_Positive_Predicate_OddEven: *level_2
-    Unit___syncthreads_and_Positive_Predicate_Negative: *level_2
-    Unit___syncthreads_and_Positive_Predicate_Id: *level_2
-    Unit___syncthreads_and_Negative_Parameters_RTC: *level_2
+    Unit___syncthreads_and_Positive_Predicate_Zero:
+      <<: *level_2
+      tags: [device_lib, sync, block]
+    Unit___syncthreads_and_Positive_Predicate_One:
+      <<: *level_2
+      tags: [device_lib, sync, block]
+    Unit___syncthreads_and_Positive_Predicate_OddEven:
+      <<: *level_2
+      tags: [device_lib, sync, block]
+    Unit___syncthreads_and_Positive_Predicate_Negative:
+      <<: *level_2
+      tags: [device_lib, sync, block]
+    Unit___syncthreads_and_Positive_Predicate_Id:
+      <<: *level_2
+      tags: [device_lib, sync, block]
+    Unit___syncthreads_and_Negative_Parameters_RTC:
+      <<: *level_2
+      tags: [device_lib, sync, block]
     Unit___syncthreads_or_Positive_Basic:
+      tags: [device_lib, sync, block]
       <<: *level_2
       # Below tests are failing PSDB
       disabled: [amd_windows]
-    Unit___syncthreads_or_Positive_Predicate_Zero: *level_2
-    Unit___syncthreads_or_Positive_Predicate_One: *level_2
-    Unit___syncthreads_or_Positive_Predicate_OddEven: *level_2
-    Unit___syncthreads_or_Positive_Predicate_Negative: *level_2
-    Unit___syncthreads_or_Positive_Predicate_Id: *level_2
-    Unit___syncthreads_or_Negative_Parameters_RTC: *level_2
+    Unit___syncthreads_or_Positive_Predicate_Zero:
+      <<: *level_2
+      tags: [device_lib, sync, block]
+    Unit___syncthreads_or_Positive_Predicate_One:
+      <<: *level_2
+      tags: [device_lib, sync, block]
+    Unit___syncthreads_or_Positive_Predicate_OddEven:
+      <<: *level_2
+      tags: [device_lib, sync, block]
+    Unit___syncthreads_or_Positive_Predicate_Negative:
+      <<: *level_2
+      tags: [device_lib, sync, block]
+    Unit___syncthreads_or_Positive_Predicate_Id:
+      <<: *level_2
+      tags: [device_lib, sync, block]
+    Unit___syncthreads_or_Negative_Parameters_RTC:
+      <<: *level_2
+      tags: [device_lib, sync, block]
   texture:
-    Unit_hipCreateTextureObject_ArgValidation: *level_2
-    Unit_hipCreateTextureObject_LinearResource: *level_2
-    Unit_hipCreateTextureObject_Pitch2DResource: *level_2
-    Unit_hipCreateTextureObject_ArrayResource: *level_2
-    Unit_hipCreateTextureObject_MmArrayResource: *level_2
-    Unit_hipTextureFetch_vector: *level_2
-    Unit_hipTextureObj2D_Check: *level_2
+    Unit_hipCreateTextureObject_ArgValidation:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipCreateTextureObject_LinearResource:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipCreateTextureObject_Pitch2DResource:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipCreateTextureObject_ArrayResource:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipCreateTextureObject_MmArrayResource:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipTextureFetch_vector:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipTextureObj2D_Check:
+      <<: *level_2
+      tags: [texture, texobj]
     Unit_Layered1DTexture_Check_HostBufferToFromLayered1DArray:
+      tags: [texture, sample]
       <<: *level_2
       # SWDEV-431191:Below tests failed in stress test on 03/11/23
       disabled: [amd_wsl]
     Unit_Layered1DTexture_Check_DeviceBufferToFromLayered1DArray:
+      tags: [texture, sample]
       <<: *level_2
       # SWDEV-431191:Below tests failed in stress test on 03/11/23
       # SWDEV-432250:Below tests failed in stress test on 10/11/23
       disabled: [amd_wsl]
-    Unit_Layered2DTexture_Check_HostBufferToFromLayered2DArray: *level_2
+    Unit_Layered2DTexture_Check_HostBufferToFromLayered2DArray:
+      <<: *level_2
+      tags: [texture, sample]
     Unit_Layered2DTexture_Check_DeviceBufferToFromLayered2DArray:
+      tags: [texture, sample]
       <<: *level_2
       # SWDEV-431191:Below tests failed in stress test on 03/11/23
       # SWDEV-432250:Below tests failed in stress test on 10/11/23
       disabled: [amd_wsl]
-    Unit_hipBindTexture_Positive: *level_2
-    Unit_hipBindTexture_1DfetchVerification: *level_2
-    Unit_hipBindTexture_Negative: *level_2
-    Unit_hipBindTexture2D_Positive: *level_2
-    Unit_hipBindTexture2D_Pitch: *level_2
-    Unit_hipBindTexture2D_Negative: *level_2
-    Unit_tex1Dfetch_CheckModes: *level_2
-    Unit_hipGetChannelDesc_CreateAndGet: *level_2
+    Unit_hipBindTexture_Positive:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipBindTexture_1DfetchVerification:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipBindTexture_Negative:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipBindTexture2D_Positive:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipBindTexture2D_Pitch:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipBindTexture2D_Negative:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_tex1Dfetch_CheckModes:
+      <<: *level_2
+      tags: [texture, sample]
+    Unit_hipGetChannelDesc_CreateAndGet:
+      <<: *level_2
+      tags: [texture, texobj]
     Unit_hipGetChannelDesc_Negative_Parameters:
+      tags: [texture, texobj]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/92
       disabled: [amd_windows, amd_wsl]
-    Unit_hipGetTextureAlignmentOffset_Positive: *level_2
-    Unit_hipGetTextureAlignmentOffset_Negative: *level_2
-    Unit_hipGetTextureReference_Positive: *level_2
-    Unit_hipGetTextureReference_Negative: *level_2
-    Unit_hipTexObjPitch_texture2D: *level_2
+    Unit_hipGetTextureAlignmentOffset_Positive:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipGetTextureAlignmentOffset_Negative:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipGetTextureReference_Positive:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipGetTextureReference_Negative:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipTexObjPitch_texture2D:
+      <<: *level_2
+      tags: [texture, texobj]
     Unit_hipTexRefSetArray_Positive:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetArray_CheckData:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetArray_Negative:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetArray_Positive:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetArray_Negative:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetBorderColor_Negative:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetBorderColor_Negative:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetAddress_Positive:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetAddress_Negative:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetAddress_AdressNotSet:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetAddress_Basic:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetAddress_Positive:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetAddress_Negative:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetFormat_Basic:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetFormat_Positive:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetFormat_Negative:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetFormat_Positive:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetFormat_Negative:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipCreateTextureObject_tex1DfetchVerification: *level_2
-    Unit_hipTextureObj1DCheckModes: *level_2
-    Unit_hipTextureObj2DCheckModes: *level_2
-    Unit_hipTextureObj3DCheckModes: *level_2
+    Unit_hipCreateTextureObject_tex1DfetchVerification:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipTextureObj1DCheckModes:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipTextureObj2DCheckModes:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipTextureObj3DCheckModes:
+      <<: *level_2
+      tags: [texture, texobj]
     Unit_hipTextureObj1DCheckRGBAModes_array: *level_2
     Unit_hipTextureObj1DCheckSRGBAModes_array: *level_2
     Unit_hipTextureObj1DCheckRGBAModes_buffer: *level_2
     Unit_hipTextureObj1DCheckSRGBAModes_buffer: *level_2
-    Unit_hipTextureObj2DCheckRGBAModes: *level_2
-    Unit_hipTextureObj2DCheckSRGBAModes: *level_2
-    Unit_TexObjectCreate_NullptrParams: *level_2
-    Unit_TexObjectCreate_TypeLinear: *level_2
-    Unit_TexObjectCreate_TypeLinear_IncompleteInit: *level_2
-    Unit_TexObjectCreate_TypeLinear_EdgeCases: *level_2
-    Unit_TexObjectCreate_TypeArray: *level_2
-    Unit_TexObjectCreate_TypeArray_NullptrArray: *level_2
-    Unit_TexObjectCreate_TypeMipmapped: *level_2
-    Unit_TexObjectCreate_TypeMipmaped_IncompleteInit: *level_2
-    Unit_TexObjectCreate_TypePitch2D: *level_2
-    Unit_TexObjectCreate_TypePitch2D_IncompleteInit: *level_2
-    Unit_TexObjectCreate_TypePitch2D_EdgeCases: *level_2
-    Unit_hipGetTexObjectResourceDesc_positive: *level_2
-    Unit_hipGetTexObjectResourceDesc_Negative_Parameters: *level_2
-    Unit_hipGetTexObjectResourceViewDesc_positive: *level_2
-    Unit_hipGetTexObjectResourceViewDesc_Negative_Parameters: *level_2
-    Unit_hipGetTexObjectTextureDesc_positive: *level_2
-    Unit_hipGetTexObjectTextureDesc_Negative_Parameters: *level_2
-    Unit_hipTexObjectDestroy_positive: *level_2
-    Unit_hipGetTextureObjectResourceDesc_positive: *level_2
-    Unit_hipGetTextureObjectResourceDesc_Negative_Parameters: *level_2
-    Unit_hipGetTextureObjectResourceViewDesc_positive: *level_2
-    Unit_hipGetTextureObjectResourceViewDesc_Negative_Parameters: *level_2
-    Unit_hipGetTextureObjectTextureDesc_positive: *level_2
-    Unit_hipGetTextureObjectTextureDesc_Negative_Parameters: *level_2
-    Unit_hipDestroyTextureObject_positive: *level_2
+    Unit_hipTextureObj2DCheckRGBAModes:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipTextureObj2DCheckSRGBAModes:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_TexObjectCreate_NullptrParams:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_TexObjectCreate_TypeLinear:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_TexObjectCreate_TypeLinear_IncompleteInit:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_TexObjectCreate_TypeLinear_EdgeCases:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_TexObjectCreate_TypeArray:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_TexObjectCreate_TypeArray_NullptrArray:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_TexObjectCreate_TypeMipmapped:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_TexObjectCreate_TypeMipmaped_IncompleteInit:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_TexObjectCreate_TypePitch2D:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_TexObjectCreate_TypePitch2D_IncompleteInit:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_TexObjectCreate_TypePitch2D_EdgeCases:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipGetTexObjectResourceDesc_positive:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipGetTexObjectResourceDesc_Negative_Parameters:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipGetTexObjectResourceViewDesc_positive:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipGetTexObjectResourceViewDesc_Negative_Parameters:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipGetTexObjectTextureDesc_positive:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipGetTexObjectTextureDesc_Negative_Parameters:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipTexObjectDestroy_positive:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipGetTextureObjectResourceDesc_positive:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipGetTextureObjectResourceDesc_Negative_Parameters:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipGetTextureObjectResourceViewDesc_positive:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipGetTextureObjectResourceViewDesc_Negative_Parameters:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipGetTextureObjectTextureDesc_positive:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipGetTextureObjectTextureDesc_Negative_Parameters:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipDestroyTextureObject_positive:
+      <<: *level_2
+      tags: [texture, texobj]
     Unit_hipTexRefSetAddress2D_Negative_Parameters:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetAddress2D_Positive:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetMaxAnisotropy_Negative_Parameters:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetMaxAnisotropy_Positive:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetMaxAnisotropy_Negative_Parameters:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetMaxAnisotropy_Positive:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipUnbindTexture_Null_Texture: *level_2
-    Unit_hipUnbindTexture_Positive_1D: *level_2
-    Unit_hipUnbindTexture_Positive_2D: *level_2
-    Unit_hipUnbindTexture_Positive_3D: *level_2
+    Unit_hipUnbindTexture_Null_Texture:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipUnbindTexture_Positive_1D:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipUnbindTexture_Positive_2D:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipUnbindTexture_Positive_3D:
+      <<: *level_2
+      tags: [texture, texref]
     Unit_hipTexRefSetFlags_Negative_Parameters:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetFlags_Positive:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipBindTextureToArray_Negative_Parameters: *level_2
-    Unit_hipBindTextureToArray_Positive_1D: *level_2
-    Unit_hipBindTextureToArray_Positive_2D: *level_2
-    Unit_hipBindTextureToArray_Positive_3D: *level_2
+    Unit_hipBindTextureToArray_Negative_Parameters:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipBindTextureToArray_Positive_1D:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipBindTextureToArray_Positive_2D:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipBindTextureToArray_Positive_3D:
+      <<: *level_2
+      tags: [texture, texref]
     Unit_hipTexRefGetFlags_Negative_Parameters:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetFlags_Positive:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetAddressMode_Negative_Parameters:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefSetAddressMode_Positive:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetAddressMode_Negative_Parameters:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
     Unit_hipTexRefGetAddressMode_Positive:
+      tags: [texture, texref]
       <<: *level_2
       # Rock_Window_Failures_on_gfx1151
       disabled: [amd_windows]
-    Unit_hipTexRefSetGetFilterMode: *level_2
-    Unit_hipTexRefSetGetMipmapFilterMode: *level_2
-    Unit_hipTexRefSetGetMipmapLevelBias: *level_2
-    Unit_texRefSetGetMipmapLevelClamp: *level_2
-    Unit_hipTexRefSetGetMipmappedArray: *level_2
+    Unit_hipTexRefSetGetFilterMode:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipTexRefSetGetMipmapFilterMode:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipTexRefSetGetMipmapLevelBias:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_texRefSetGetMipmapLevelClamp:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipTexRefSetGetMipmappedArray:
+      <<: *level_2
+      tags: [texture, texref]
     Unit_hipTextureMipmapRef2D_Positive_Check:
+      tags: [texture, texref]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/92
       disabled: [amd_wsl]
     Unit_hipTextureMipmapRef2D_Negative_Parameters:
+      tags: [texture, texref]
       <<: *level_2
       # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/92
       disabled: [amd_wsl]
-    Unit_hipMallocMipmappedArray_Negative_Parameters: *level_2
-    Unit_hipFreeMipmappedArray_Negative_Parameters: *level_2
-    Unit_hipGetMipmappedArrayLevel_Negative_Parameters: *level_2
-    Unit_hipMipmappedArrayCreate_Negative_Parameters: *level_2
-    Unit_hipMipmappedArrayDestroy_Negative_Parameters: *level_2
-    Unit_hipMipmappedArrayGetLevel_Negative_Parameters: *level_2
+    Unit_hipMallocMipmappedArray_Negative_Parameters:
+      <<: *level_2
+      tags: [texture, mipmap]
+    Unit_hipFreeMipmappedArray_Negative_Parameters:
+      <<: *level_2
+      tags: [texture, mipmap]
+    Unit_hipGetMipmappedArrayLevel_Negative_Parameters:
+      <<: *level_2
+      tags: [texture, mipmap]
+    Unit_hipMipmappedArrayCreate_Negative_Parameters:
+      <<: *level_2
+      tags: [texture, mipmap]
+    Unit_hipMipmappedArrayDestroy_Negative_Parameters:
+      <<: *level_2
+      tags: [texture, mipmap]
+    Unit_hipMipmappedArrayGetLevel_Negative_Parameters:
+      <<: *level_2
+      tags: [texture, mipmap]
     Unit_hipTextureMipmapObj1D_Check_hipReadModeElementType: *level_2
     Unit_hipTextureMipmapObj1D_Check_hipReadModeNormalizedFloat: *level_2
     Unit_hipTextureMipmapObj1D_Check_hipReadModeElementType_float_only: *level_2
@@ -5902,41 +10129,91 @@ unit:
     Unit_hipTextureMipmapObj3D_Check_hipReadModeElementType: *level_2
     Unit_hipTextureMipmapObj3D_Check_hipReadModeNormalizedFloat: *level_2
     Unit_hipTextureMipmapObj3D_Check_hipReadModeElementType_float_only: *level_2
-    Unit_tex1DLod_Positive_ReadModeElementType: *level_2
-    Unit_tex1DLod_Positive_ReadModeNormalizedFloat: *level_2
-    Unit_tex1DLayeredLod_Positive_ReadModeElementType: *level_2
-    Unit_tex1DLayeredLod_Positive_ReadModeNormalizedFloat: *level_2
-    Unit_tex2DLod_Positive_ReadModeElementType: *level_2
-    Unit_tex2DLod_Positive_ReadModeNormalizedFloat: *level_2
-    Unit_tex2DLayeredLod_Positive_ReadModeElementType: *level_2
-    Unit_tex2DLayeredLod_Positive_ReadModeNormalizedFloat: *level_2
-    Unit_tex3DLod_Positive_ReadModeElementType: *level_2
-    Unit_tex3DLod_Positive_ReadModeNormalizedFloat: *level_2
-    Unit_hipTexRefSetGetMipmapFilterMode: *level_2
-    Unit_hipTexRefSetGetMipmapLevelBias: *level_2
-    Unit_texRefSetGetMipmapLevelClamp: *level_2
-    Unit_hipTexRefSetGetMipmappedArray: *level_2
-    Unit_hipDeviceGetTexture1DLinearMaxWidth_Positive: *level_2
-    Unit_hipDeviceGetTexture1DLinearMaxWidth_Negative: *level_2
+    Unit_tex1DLod_Positive_ReadModeElementType:
+      <<: *level_2
+      tags: [texture, sample]
+    Unit_tex1DLod_Positive_ReadModeNormalizedFloat:
+      <<: *level_2
+      tags: [texture, sample]
+    Unit_tex1DLayeredLod_Positive_ReadModeElementType:
+      <<: *level_2
+      tags: [texture, sample]
+    Unit_tex1DLayeredLod_Positive_ReadModeNormalizedFloat:
+      <<: *level_2
+      tags: [texture, sample]
+    Unit_tex2DLod_Positive_ReadModeElementType:
+      <<: *level_2
+      tags: [texture, sample]
+    Unit_tex2DLod_Positive_ReadModeNormalizedFloat:
+      <<: *level_2
+      tags: [texture, sample]
+    Unit_tex2DLayeredLod_Positive_ReadModeElementType:
+      <<: *level_2
+      tags: [texture, sample]
+    Unit_tex2DLayeredLod_Positive_ReadModeNormalizedFloat:
+      <<: *level_2
+      tags: [texture, sample]
+    Unit_tex3DLod_Positive_ReadModeElementType:
+      <<: *level_2
+      tags: [texture, sample]
+    Unit_tex3DLod_Positive_ReadModeNormalizedFloat:
+      <<: *level_2
+      tags: [texture, sample]
+    Unit_hipTexRefSetGetMipmapFilterMode:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipTexRefSetGetMipmapLevelBias:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_texRefSetGetMipmapLevelClamp:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipTexRefSetGetMipmappedArray:
+      <<: *level_2
+      tags: [texture, texref]
+    Unit_hipDeviceGetTexture1DLinearMaxWidth_Positive:
+      <<: *level_2
+      tags: [texture, texobj]
+    Unit_hipDeviceGetTexture1DLinearMaxWidth_Negative:
+      <<: *level_2
+      tags: [texture, texobj]
   threadfence:
-    Unit___threadfence_block_Positive_Basic_Shared: *level_2
-    Unit___threadfence_block_Positive_Basic_Global: *level_2
-    Unit___threadfence_block_Positive_Basic_Pinned: *level_2
-    Unit___threadfence_block_Positive_Basic_Managed: *level_2
+    Unit___threadfence_block_Positive_Basic_Shared:
+      <<: *level_2
+      tags: [sync, fence]
+    Unit___threadfence_block_Positive_Basic_Global:
+      <<: *level_2
+      tags: [sync, fence]
+    Unit___threadfence_block_Positive_Basic_Pinned:
+      <<: *level_2
+      tags: [sync, fence]
+    Unit___threadfence_block_Positive_Basic_Managed:
+      <<: *level_2
+      tags: [sync, fence]
     Unit___threadfence_block_Positive_Basic_Peer:
+      tags: [multigpu, sync, fence]
       <<: *level_2
-      tags: [multigpu]
-    Unit___threadfence_Positive_Basic_Shared: *level_2
-    Unit___threadfence_Positive_Basic_Global: *level_2
-    Unit___threadfence_Positive_Basic_Pinned: *level_2
-    Unit___threadfence_Positive_Basic_Managed: *level_2
+    Unit___threadfence_Positive_Basic_Shared:
+      <<: *level_2
+      tags: [sync, fence]
+    Unit___threadfence_Positive_Basic_Global:
+      <<: *level_2
+      tags: [sync, fence]
+    Unit___threadfence_Positive_Basic_Pinned:
+      <<: *level_2
+      tags: [sync, fence]
+    Unit___threadfence_Positive_Basic_Managed:
+      <<: *level_2
+      tags: [sync, fence]
     Unit___threadfence_Positive_Basic_Peer:
+      tags: [multigpu, sync, fence]
       <<: *level_2
-      tags: [multigpu]
     Unit___threadfence_system_Positive_Basic_Peer:
+      tags: [multigpu, sync, fence]
       <<: *level_2
-      tags: [multigpu]
-    Unit___threadfence_system_Positive_Basic_Host: *level_2
+    Unit___threadfence_system_Positive_Basic_Host:
+      <<: *level_2
+      tags: [sync, fence]
   vector_types:
     Unit_make_vector_SanityCheck_Basic_Host: *level_2
     Unit_make_vector_SanityCheck_Basic_Device: *level_2
@@ -5945,17 +10222,39 @@ unit:
     Unit_VectorAndVectorOperations_SanityCheck_Basic_Device: *level_2
     Unit_VectorAndValueTypeOperations_SanityCheck_Basic_Device: *level_2
     Unit_VectorStructuredBindings_SanityCheck_Basic_host: *level_2
-    Unit_VectorConstexpr_SanityCheck_Basic_host_device: *level_2
-    Unit_Vector_alignment_check: *level_2
-    Unit_Vector_size_check: *level_2
-    Unit_dim3_Empty_Positive_Device: *level_2
-    Unit_dim3_X_Positive_Device: *level_2
-    Unit_dim3_XY_Positive_Device: *level_2
-    Unit_dim3_XYZ_Positive_Device: *level_2
-    Unit_dim3_Empty_Positive_Host: *level_2
-    Unit_dim3_X_Positive_Host: *level_2
-    Unit_dim3_XY_Positive_Host: *level_2
-    Unit_dim3_XYZ_Positive_Host: *level_2
+    Unit_VectorConstexpr_SanityCheck_Basic_host_device:
+      <<: *level_2
+      tags: [vector_types]
+    Unit_Vector_alignment_check:
+      <<: *level_2
+      tags: [vector_types]
+    Unit_Vector_size_check:
+      <<: *level_2
+      tags: [vector_types]
+    Unit_dim3_Empty_Positive_Device:
+      <<: *level_2
+      tags: [vector_types]
+    Unit_dim3_X_Positive_Device:
+      <<: *level_2
+      tags: [vector_types]
+    Unit_dim3_XY_Positive_Device:
+      <<: *level_2
+      tags: [vector_types]
+    Unit_dim3_XYZ_Positive_Device:
+      <<: *level_2
+      tags: [vector_types]
+    Unit_dim3_Empty_Positive_Host:
+      <<: *level_2
+      tags: [vector_types]
+    Unit_dim3_X_Positive_Host:
+      <<: *level_2
+      tags: [vector_types]
+    Unit_dim3_XY_Positive_Host:
+      <<: *level_2
+      tags: [vector_types]
+    Unit_dim3_XYZ_Positive_Host:
+      <<: *level_2
+      tags: [vector_types]
   virtualMemoryManagement:
     Unit_hipMemGetAllocationGranularity_MinGranularity:
       <<: *level_2
@@ -5966,301 +10265,515 @@ unit:
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemGetAllocationGranularity_AllGPUs:
+      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemGetAllocationGranularity_NegativeTests:
+      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
-    Unit_hipMemGetAllocationGranularity_Capture: *level_2
+    Unit_hipMemGetAllocationGranularity_Capture:
+      <<: *level_2
+      tags: [vmm]
     Unit_hipMemRetainAllocationHandle_SetGet:
+      tags: [vmm]
       <<: *level_2
       disabled: [amd_wsl]
     Unit_hipMemRetainAllocationHandle_NegTst:
+      tags: [vmm]
       <<: *level_2
       disabled: [amd_wsl]
-    Unit_hipMemRetainAllocationHandle_Capture: *level_2
-    Unit_hipMemImportFromShareableHandle_Positive_Basic: *level_2
-    Unit_hipMemImportFromShareableHandle_Negative_Parameters: *level_2
-    Unit_hipMemImportFromShareableHandle_MulProc_ChldUseHdl: *level_2
-    Unit_hipMemImportFromShareableHandle_MulProc_ParntChldUseHdl: *level_2
-    Unit_hipMemImportFromShareableHandle_MulProc_GrndChldUseHdl: *level_2
-    Unit_hipMemImportFromShareableHandle_Capture: *level_2
-    Unit_hipMemGetHandleForAddressRange_Negative: *level_2
-    Unit_hipMemGetHandleForAddressRange_DeviceMemory: *level_2
-    Unit_hipMemGetHandleForAddressRange_VM: *level_2
+    Unit_hipMemRetainAllocationHandle_Capture:
+      <<: *level_2
+      tags: [vmm]
+    Unit_hipMemImportFromShareableHandle_Positive_Basic:
+      <<: *level_2
+      tags: [vmm]
+    Unit_hipMemImportFromShareableHandle_Negative_Parameters:
+      <<: *level_2
+      tags: [vmm]
+    Unit_hipMemImportFromShareableHandle_MulProc_ChldUseHdl:
+      <<: *level_2
+      tags: [vmm]
+    Unit_hipMemImportFromShareableHandle_MulProc_ParntChldUseHdl:
+      <<: *level_2
+      tags: [vmm]
+    Unit_hipMemImportFromShareableHandle_MulProc_GrndChldUseHdl:
+      <<: *level_2
+      tags: [vmm]
+    Unit_hipMemImportFromShareableHandle_Capture:
+      <<: *level_2
+      tags: [vmm]
+    Unit_hipMemGetHandleForAddressRange_Negative:
+      <<: *level_2
+      tags: [vmm]
+    Unit_hipMemGetHandleForAddressRange_DeviceMemory:
+      <<: *level_2
+      tags: [vmm]
+    Unit_hipMemGetHandleForAddressRange_VM:
+      <<: *level_2
+      tags: [vmm]
     Unit_hipMemGetHandleForAddressRange_DeviceMemory_InAnotherDevice:
+      tags: [multigpu, vmm]
       <<: *level_2
-      tags: [multigpu]
     Unit_hipMemGetHandleForAddressRange_VM_InAnotherDevice:
+      tags: [multigpu, vmm]
       <<: *level_2
-      tags: [multigpu]
-    Unit_hipMemGetHandleForAddressRange_MulProc_Socket_DeviceMem: *level_2
-    Unit_hipMemGetHandleForAddressRange_MulProc_Socket_VM: *level_2
-    Unit_hipMemGetHandleForAddressRange_MultipleThreads: *level_2
-    Unit_hipMemGetHandleForAddressRange_DifferentOffsets: *level_2
-    Unit_hipMemExportToShareableHandle_Positive_Basic: *level_2
-    Unit_hipMemExportToShareableHandle_Negative_Parameters: *level_2
-    Unit_hipMemExportToShareableHandle_Capture: *level_2
-    Unit_hipGetProcAddress_VMM: *level_2
+    Unit_hipMemGetHandleForAddressRange_MulProc_Socket_DeviceMem:
+      <<: *level_2
+      tags: [vmm]
+    Unit_hipMemGetHandleForAddressRange_MulProc_Socket_VM:
+      <<: *level_2
+      tags: [vmm]
+    Unit_hipMemGetHandleForAddressRange_MultipleThreads:
+      <<: *level_2
+      tags: [vmm]
+    Unit_hipMemGetHandleForAddressRange_DifferentOffsets:
+      <<: *level_2
+      tags: [vmm]
+    Unit_hipMemExportToShareableHandle_Positive_Basic:
+      <<: *level_2
+      tags: [vmm]
+    Unit_hipMemExportToShareableHandle_Negative_Parameters:
+      <<: *level_2
+      tags: [vmm]
+    Unit_hipMemExportToShareableHandle_Capture:
+      <<: *level_2
+      tags: [vmm]
+    Unit_hipGetProcAddress_VMM:
+      <<: *level_2
+      tags: [vmm]
     Unit_hipMemAddressFree_negative:
+      tags: [vmm]
       <<: *level_2
       # (amd_windows) NOTE: The following test is disabled due to defect - EXSWHTEC-244
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemAddressFree_Capture: *level_2
+    Unit_hipMemAddressFree_Capture:
+      <<: *level_2
+      tags: [vmm]
     Unit_hipMemAddressReserve_AlignmentTest:
+      tags: [vmm]
       <<: *level_2
       # (amd_windows) NOTE: The following test is disabled due to defect - EXSWHTEC-245
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemAddressReserve_Negative: *level_2
-    Unit_hipMemAddressReserve_Capture: *level_2
+    Unit_hipMemAddressReserve_Negative:
+      <<: *level_2
+      tags: [vmm]
+    Unit_hipMemAddressReserve_Capture:
+      <<: *level_2
+      tags: [vmm]
     Unit_hipMemCreate_BasicAllocateDeAlloc_MultGranularity:
+      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemCreate_ChkDev2HstMemcpy_ReleaseHdlPostUnmap:
+      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemCreate_ChkDev2HstMemcpy_ReleaseHdlPreUse:
+      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemCreate_ChkWithKerLaunch:
+      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemCreate_MapNonContiguousChunks:
+      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemCreate_ChkWithMemset:
+      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemCreate_Negative:
+      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
-    Unit_hipMemCreate_Capture: *level_2
+    Unit_hipMemCreate_Capture:
+      <<: *level_2
+      tags: [vmm]
     Unit_hipMemSetAccess_SetGet:
+      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_MultDevSetGet:
+      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_EntireVMMRangeSetGet:
+      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemGetAccess_NegTst:
+      tags: [vmm]
       <<: *level_2
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_FuncTstOnMultDev:
+      tags: [multigpu, vmm]
       <<: *level_2
-      tags: [multigpu]
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_ChangeAccessProp:
+      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-413997: VMM test still failing in windows
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_Vmm2UnifiedMemCpy:
+      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_Vmm2DevMemCpy:
+      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-444041: These tests fail randomly in gfx1030 MGU
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_Vmm2PeerDevMemCpy:
+      tags: [multigpu, vmm]
       <<: *level_2
-      tags: [multigpu]
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_Vmm2PeerPeerMemCpy:
+      tags: [multigpu, vmm]
       <<: *level_2
-      tags: [multigpu]
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemSetAccess_Vmm2VMMMemCpy:
+      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-444041: These tests fail in gfx1100 MGPU
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_Vmm2VMMInterDevMemCpy:
+      tags: [multigpu, vmm]
       <<: *level_2
-      tags: [multigpu]
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_GrowVMM:
+      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_Multithreaded:
+      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-444031: This test fails in gfx1101 MGPU
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemSetAccess_negative:
+      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemSetGetAccess_Capture: *level_2
+    Unit_hipMemSetGetAccess_Capture:
+      <<: *level_2
+      tags: [vmm]
     Unit_hipMemSetAccessHostDevice_hostalloc:
+      tags: [vmm]
       <<: *level_2
       # SWDEV-555665
       disabled: [amd_windows]
-    Unit_hipMemSetAccessHost_devicealloc: *level_2
+    Unit_hipMemSetAccessHost_devicealloc:
+      <<: *level_2
+      tags: [vmm]
     Unit_hipMemGetAllocationPropertiesFromHandle_functional:
+      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemGetAllocationPropertiesFromHandle_Negative:
+      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
-    Unit_hipMemGetAllocationPropertiesFromHandle_Capture: *level_2
+    Unit_hipMemGetAllocationPropertiesFromHandle_Capture:
+      <<: *level_2
+      tags: [vmm]
     Unit_hipMemMap_SameMemoryReuse:
+      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-444041: These tests fail randomly in gfx1030 MGU
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemMap_PhysicalMemoryReuse_SingleGPU:
+      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-444041: These tests fail in gfx1100 MGPU
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemMap_PhysicalMemory_Map2MultVMMs:
+      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-444041: These tests fail in gfx1100 MGPU
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemMap_PhysicalMemoryReuse_MultiDev:
+      tags: [multigpu, vmm]
       <<: *level_2
-      tags: [multigpu]
       # (amd_windows) SWDEV-444041: These tests fail in gfx1100 MGPU
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemMap_VMMMemoryReuse_SingleGPU:
+      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemMap_VMMMemoryReuse_MultiGPU:
+      tags: [multigpu, vmm]
       <<: *level_2
-      tags: [multigpu]
       # (amd_windows) SWDEV-396615 mGPUs not considered correctly
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
     Unit_hipMemMap_MapPartialVMMMem:
+      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
     Unit_hipMemMap_negative:
+      tags: [vmm]
       <<: *level_2
       # (amd_windows) SWDEV-444041: These tests fail randomly in gfx1030 MGU
       # (amd_wsl) Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_windows, amd_wsl]
-    Unit_hipMemMap_Capture: *level_2
+    Unit_hipMemMap_Capture:
+      <<: *level_2
+      tags: [vmm]
     Unit_hipMemRelease_negative:
+      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
-    Unit_hipMemRelease_Capture: *level_2
+    Unit_hipMemRelease_Capture:
+      <<: *level_2
+      tags: [vmm]
     Unit_hipMemUnmap_negative:
+      tags: [vmm]
       <<: *level_2
       # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
       disabled: [amd_wsl]
-    Unit_hipMemUnmap_Capture: *level_2
+    Unit_hipMemUnmap_Capture:
+      <<: *level_2
+      tags: [vmm]
     Unit_hipMemMapArrayAsync_Positive_Basic:
+      tags: [vmm]
       <<: *level_2
       # Below tests are failing PSDB
       <<: *disabled_nvidia
   vulkan_interop:
-    Unit_hipDestroyExternalMemory_Vulkan_Negative_Parameters: *level_2
-    Unit_hipDestroyExternalMemory_Vulkan_Capture: *level_2
-    Unit_hipDestroyExternalSemaphore_Vulkan_Negative_Parameters: *level_2
-    Unit_hipDestroyExternalSemaphore_Vulkan_Capture: *level_2
-    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write: *level_2
-    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_With_Offset: *level_2
-    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Negative_Parameters: *level_2
-    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Capture: *level_2
-    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_Device_Memory: *level_2
-    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_With_Offset_Device_Memory: *level_2
-    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Positive_Read_Write: *level_2
-    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Array_Layered: *level_2
-    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Array_Cubemap: *level_2
-    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Negative_Parameters: *level_2
-    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Capture: *level_2
-    Unit_hipGraphAddExternalSemaphoresSignalNode_Positive_Basic: *level_2
-    Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Positive_Timeline_Semaphore: *level_2
-    Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Positive_Multiple_Semaphores: *level_2
-    Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Negative_Parameters: *level_2
-    Unit_hipGraphAddExternalSemaphoresWaitNode_Positive_Basic: *level_2
-    Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Positive_Timeline_Semaphore: *level_2
-    Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Positive_Multiple_Semaphores: *level_2
-    Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Negative_Parameters: *level_2
-    Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Positive_Basic: *level_2
+    Unit_hipDestroyExternalMemory_Vulkan_Negative_Parameters:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipDestroyExternalMemory_Vulkan_Capture:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipDestroyExternalSemaphore_Vulkan_Negative_Parameters:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipDestroyExternalSemaphore_Vulkan_Capture:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_With_Offset:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Negative_Parameters:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Capture:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_Device_Memory:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipExternalMemoryGetMappedBuffer_Vulkan_Positive_Read_Write_With_Offset_Device_Memory:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Positive_Read_Write:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Array_Layered:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Array_Cubemap:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Negative_Parameters:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipExternalMemoryGetMappedMipmappedArray_Vulkan_Capture:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipGraphAddExternalSemaphoresSignalNode_Positive_Basic:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Positive_Timeline_Semaphore:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Positive_Multiple_Semaphores:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipGraphAddExternalSemaphoresSignalNode_Vulkan_Negative_Parameters:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipGraphAddExternalSemaphoresWaitNode_Positive_Basic:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Positive_Timeline_Semaphore:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Positive_Multiple_Semaphores:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipGraphAddExternalSemaphoresWaitNode_Vulkan_Negative_Parameters:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Positive_Basic:
+      <<: *level_2
+      tags: [interop, vulkan]
     Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Timeline_Semaphore: *level_2
     Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Multiple_Semaphores: *level_2
-    Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Vulkan_Negative_Parameters: *level_2
-    Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Positive_Basic: *level_2
+    Unit_hipGraphExecExternalSemaphoresSignalNodeSetParams_Vulkan_Negative_Parameters:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Positive_Basic:
+      <<: *level_2
+      tags: [interop, vulkan]
     Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Timeline_Semaphore: *level_2
     Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Multiple_Semaphores: *level_2
-    Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Vulkan_Negative_Parameters: *level_2
-    Unit_hipGraphExternalSemaphoresSignalNodeGetParams_Negative_Parameters: *level_2
-    Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Positive_Basic: *level_2
-    Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Timeline_Semaphore: *level_2
+    Unit_hipGraphExecExternalSemaphoresWaitNodeSetParams_Vulkan_Negative_Parameters:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipGraphExternalSemaphoresSignalNodeGetParams_Negative_Parameters:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Positive_Basic:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Timeline_Semaphore:
+      <<: *level_2
+      tags: [interop, vulkan]
     Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Vulkan_Positive_Multiple_Semaphores: *level_2
-    Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Vulkan_Negative_Parameters: *level_2
-    Unit_hipGraphExternalSemaphoresWaitNodeGetParams_Negative_Parameters: *level_2
-    Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Positive_Basic: *level_2
-    Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Timeline_Semaphore: *level_2
-    Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Multiple_Semaphores: *level_2
-    Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Negative_Parameters: *level_2
-    Unit_hipImportExternalMemory_Vulkan_Negative_Parameters: *level_2
-    Unit_hipImportExternalMemory_Vulkan_Capture: *level_2
-    Unit_hipImportExternalSemaphore_Vulkan_Negative_Parameters: *level_2
-    Unit_hipImportExternalSemaphore_Vulkan_Capture: *level_2
-    Unit_hipSignalExternalSemaphoresAsync_Vulkan_Positive_Binary_Semaphore: *level_2
-    Unit_hipSignalExternalSemaphoresAsync_Vulkan_Positive_Timeline_Semaphore: *level_2
-    Unit_hipSignalExternalSemaphoresAsync_Vulkan_Positive_Multiple_Semaphores: *level_2
-    Unit_hipSignalExternalSemaphoresAsync_Vulkan_Negative_Parameters: *level_2
-    Unit_hipWaitExternalSemaphoresAsync_Vulkan_Positive_Binary_Semaphore: *level_2
-    Unit_hipWaitExternalSemaphoresAsync_Vulkan_Positive_Timeline_Semaphore: *level_2
-    Unit_hipWaitExternalSemaphoresAsync_Vulkan_Positive_Multiple_Semaphores: *level_2
-    Unit_hipWaitExternalSemaphoresAsync_Vulkan_Negative_Parameters: *level_2
+    Unit_hipGraphExternalSemaphoresSignalNodeSetParams_Vulkan_Negative_Parameters:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipGraphExternalSemaphoresWaitNodeGetParams_Negative_Parameters:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Positive_Basic:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Timeline_Semaphore:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Positive_Multiple_Semaphores:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipGraphExternalSemaphoresWaitNodeSetParams_Vulkan_Negative_Parameters:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipImportExternalMemory_Vulkan_Negative_Parameters:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipImportExternalMemory_Vulkan_Capture:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipImportExternalSemaphore_Vulkan_Negative_Parameters:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipImportExternalSemaphore_Vulkan_Capture:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipSignalExternalSemaphoresAsync_Vulkan_Positive_Binary_Semaphore:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipSignalExternalSemaphoresAsync_Vulkan_Positive_Timeline_Semaphore:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipSignalExternalSemaphoresAsync_Vulkan_Positive_Multiple_Semaphores:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipSignalExternalSemaphoresAsync_Vulkan_Negative_Parameters:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipWaitExternalSemaphoresAsync_Vulkan_Positive_Binary_Semaphore:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipWaitExternalSemaphoresAsync_Vulkan_Positive_Timeline_Semaphore:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipWaitExternalSemaphoresAsync_Vulkan_Positive_Multiple_Semaphores:
+      <<: *level_2
+      tags: [interop, vulkan]
+    Unit_hipWaitExternalSemaphoresAsync_Vulkan_Negative_Parameters:
+      <<: *level_2
+      tags: [interop, vulkan]
   warp:
-    Unit_Warp_Ballot_Positive_Basic: *level_2
-    Unit_Warp_Vote_Any_Positive_Basic: *level_2
-    Unit_Warp_Vote_All_Positive_Basic: *level_2
-    Unit_hipMatchSync_All: *level_2
-    Unit_hipMatchSync_Any: *level_2
-    Unit_hipShflSync_Down: *level_2
-    Unit_hipShflSync_Up: *level_2
-    Unit_hipShflSync_Xor: *level_2
-    Unit_hipShflSync: *level_2
-    Unit_hipVoteSync_Any: *level_2
-    Unit_hipVoteSync_All: *level_2
-    Unit_hipVoteSync_Ballot: *level_2
+    Unit_Warp_Ballot_Positive_Basic:
+      <<: *level_2
+      tags: [device_lib, warp, vote]
+    Unit_Warp_Vote_Any_Positive_Basic:
+      <<: *level_2
+      tags: [device_lib, warp, vote]
+    Unit_Warp_Vote_All_Positive_Basic:
+      <<: *level_2
+      tags: [device_lib, warp, vote]
+    Unit_hipMatchSync_All:
+      <<: *level_2
+      tags: [device_lib, warp, vote]
+    Unit_hipMatchSync_Any:
+      <<: *level_2
+      tags: [device_lib, warp, vote]
+    Unit_hipShflSync_Down:
+      <<: *level_2
+      tags: [device_lib, warp, shuffle]
+    Unit_hipShflSync_Up:
+      <<: *level_2
+      tags: [device_lib, warp, shuffle]
+    Unit_hipShflSync_Xor:
+      <<: *level_2
+      tags: [device_lib, warp, shuffle]
+    Unit_hipShflSync:
+      <<: *level_2
+      tags: [device_lib, warp, shuffle]
+    Unit_hipVoteSync_Any:
+      <<: *level_2
+      tags: [device_lib, warp, vote]
+    Unit_hipVoteSync_All:
+      <<: *level_2
+      tags: [device_lib, warp, vote]
+    Unit_hipVoteSync_Ballot:
+      <<: *level_2
+      tags: [device_lib, warp, vote]
     Unit_Warp_Shfl_Positive_Basic:
       <<: *level_2
       # SWDEV-434171: Below tests took long time to complete in stress test on 17/11/23
@@ -6279,12 +10792,24 @@ unit:
       disabled: [gfx90a, gfx942, gfx950]
     Unit_hipReduceSingleMasks: *level_2
     Unit_hipReduceMultipleMasks: *level_2
-    Unit_hipReduceRandom: *level_2
-    Unit_runTestShfl_up: *level_2
-    Unit_runTestShfl_Down: *level_2
-    Unit_runTestShfl_Xor: *level_2
-    Unit_hipShflTests: *level_2
-    Unit_hipShflUndefArgs: *level_2
+    Unit_hipReduceRandom:
+      <<: *level_2
+      tags: [device_lib, warp, reduce]
+    Unit_runTestShfl_up:
+      <<: *level_2
+      tags: [device_lib, warp, shuffle]
+    Unit_runTestShfl_Down:
+      <<: *level_2
+      tags: [device_lib, warp, shuffle]
+    Unit_runTestShfl_Xor:
+      <<: *level_2
+      tags: [device_lib, warp, shuffle]
+    Unit_hipShflTests:
+      <<: *level_2
+      tags: [device_lib, warp, shuffle]
+    Unit_hipShflUndefArgs:
+      <<: *level_2
+      tags: [device_lib, warp, shuffle]
 
 ABM:
   ABM_AddKernel_MultiTypeMultiSize: *level_2


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

CTest labels can be applied by mapping Catch2 test tags to CTest labels.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Add ADD_TAGS_AS_LABELS to catch_discover_tests() to automatically convert Catch2 test tags into CTest labels, enabling test filtering and selection via ctest -L.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

N/A

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Build and run hip-tests.

## Test Result

<!-- Briefly summarize test outcomes. -->

hip-tests built and ran successfully.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
