### PR TITLE
rocr: refactor wallclock retrieval

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
@@ -136,6 +136,23 @@ hsaKmtGetNodeMemoryProperties(
     );
 
 /**
+  Retrieves the wall clock frequency of a specific HSA node.
+
+  The returned frequency is in hertz (Hz), i.e., KHz * 1000.
+  When possible, prefer using HsaNodeProperties.WallClockKHz from
+  hsaKmtGetNodeProperties(), as this function is mainly for compatibility
+  with clients that expect this API to exist.
+  Not all implementations are required to support this API.
+*/
+
+HSAKMT_STATUS
+HSAKMTAPI
+hsaKmtGetNodeWallclockFrequency(
+    HSAuint32 NodeId,      // IN
+    uint64_t* Frequency    // OUT (Hz)
+    );
+
+/**
   Retrieves the cache properties of a specific HSA node and processor ID.
   ProcessorID refers to either a CPU core or a SIMD unit as enumerated earlier
   via the hsaKmtGetNodeProperties() call.

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.ver
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.ver
@@ -7,6 +7,7 @@ hsaKmtGetVersion;
 hsaKmtAcquireSystemProperties;
 hsaKmtReleaseSystemProperties;
 hsaKmtGetNodeProperties;
+hsaKmtGetNodeWallclockFrequency;
 hsaKmtGetNodeMemoryProperties;
 hsaKmtGetNodeCacheProperties;
 hsaKmtGetNodeIoLinkProperties;

--- a/projects/rocr-runtime/libhsakmt/src/topology.c
+++ b/projects/rocr-runtime/libhsakmt/src/topology.c
@@ -2646,6 +2646,18 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtGetNodeProperties(HSAuint32 NodeId,
 	return hsaKmtGetNodePropertiesCtx(&hsakmt_primary_kfd_ctx, NodeId, NodeProperties);
 }
 
+HSAKMT_STATUS HSAKMTAPI
+hsaKmtGetNodeWallclockFrequency(HSAuint32 NodeId, uint64_t* Frequency)
+{
+	struct hsa_kfd_topology_context *topology_ctx =
+				hsakmt_kfdcontext_get_topology_context(&hsakmt_primary_kfd_ctx);
+	HsaNodeProperties *NodeProperties = &(topology_ctx->node_props[NodeId].node);
+
+	*Frequency = NodeProperties->WallClockKHz * 1000ull;
+
+	return HSAKMT_STATUS_NOT_IMPLEMENTED;
+}
+
 HSAKMT_STATUS HSAKMTAPI hsaKmtGetNodeMemoryProperties(HSAuint32 NodeId,
 						      HSAuint32 NumBanks,
 						      HsaMemoryProperties *MemoryProperties)

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -749,12 +749,7 @@ hsa_status_t KfdDriver::IsModelEnabled(bool* enable) const {
 hsa_status_t KfdDriver::GetWallclockFrequency(uint32_t node_id, uint64_t* frequency) const {
   assert(frequency);
 
-  HsaNodeProperties props;
-  if (GetNodeProperties(props, node_id) != HSA_STATUS_SUCCESS) {
-    return HSA_STATUS_ERROR;
-  }
-
-  *frequency = uint64_t(props.WallClockKHz) * 1000ull;
+  HSAKMT_CALL(hsaKmtGetNodeWallclockFrequency(node_id, frequency));
 
   return HSA_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
@@ -355,6 +355,8 @@ class ThunkLoader {
                                       HSAuint64* cpu_addr);
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtMemoryCpuMap))(HsaMemoryObjectHandle Handle, \
                                       void** out_cpu_ptr);
+    typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtGetNodeWallclockFrequency))(HSAuint32 NodeId, \
+                                      uint64_t* Frequency);
     /* drm API */
     typedef int (DRM_DEF(amdgpu_device_initialize))(int fd, \
                                       uint32_t *major_version, \
@@ -509,6 +511,7 @@ class ThunkLoader {
     HSAKMT_DEF(hsaKmtMemHandleFree)* HSAKMT_PFN(hsaKmtMemHandleFree);
     HSAKMT_DEF(hsaKmtMemoryGetCpuAddr)* HSAKMT_PFN(hsaKmtMemoryGetCpuAddr);
     HSAKMT_DEF(hsaKmtMemoryCpuMap)* HSAKMT_PFN(hsaKmtMemoryCpuMap);
+    HSAKMT_DEF(hsaKmtGetNodeWallclockFrequency)* HSAKMT_PFN(hsaKmtGetNodeWallclockFrequency);
 
     DRM_DEF(amdgpu_device_initialize)* DRM_PFN(amdgpu_device_initialize);
     DRM_DEF(amdgpu_device_deinitialize)* DRM_PFN(amdgpu_device_deinitialize);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -218,10 +218,15 @@ GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xna
   if (model_enabled) {
     wallclock_frequency_ = 0;
   } else {
-    // Get wallclock freq
-    err = driver().GetWallclockFrequency(node_id(), &wallclock_frequency_);
-    if (err != HSA_STATUS_SUCCESS) {
-      throw AMD::hsa_exception(err, "Agent creation failed.\nGetWallclockFrequency error.\n");
+    // Prefer cached node properties when available (in KHz)
+    if (properties_.WallClockKHz != 0) {
+      wallclock_frequency_ = uint64_t(properties_.WallClockKHz) * 1000ull;
+    } else {
+      // Fallback to driver query if properties do not provide it
+      err = driver().GetWallclockFrequency(node_id(), &wallclock_frequency_);
+      if (err != HSA_STATUS_SUCCESS) {
+        throw AMD::hsa_exception(err, "Agent creation failed.\nGetWallclockFrequency error.\n");
+      }
     }
   }
 #endif

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
@@ -411,6 +411,9 @@ namespace core {
       HSAKMT_PFN(hsaKmtMemoryCpuMap) = (HSAKMT_DEF(hsaKmtMemoryCpuMap)*)dlsym(thunk_handle, "hsaKmtMemoryCpuMap");
       if (HSAKMT_PFN(hsaKmtMemoryCpuMap) == nullptr) goto ERROR;
 
+      HSAKMT_PFN(hsaKmtGetNodeWallclockFrequency) = (HSAKMT_DEF(hsaKmtGetNodeWallclockFrequency)*)dlsym(thunk_handle, "hsaKmtGetNodeWallclockFrequency");
+      if (HSAKMT_PFN(hsaKmtGetNodeWallclockFrequency) == nullptr) goto ERROR;
+
       DRM_PFN(amdgpu_device_deinitialize) = (DRM_DEF(amdgpu_device_deinitialize)*)dlsym(thunk_handle, "amdgpu_device_deinitialize");
       if (DRM_PFN(amdgpu_device_deinitialize) == nullptr) goto ERROR;
 
@@ -549,6 +552,7 @@ ERROR:
       HSAKMT_PFN(hsaKmtMemHandleFree) = (HSAKMT_DEF(hsaKmtMemHandleFree)*)(&hsaKmtMemHandleFree);
       HSAKMT_PFN(hsaKmtMemoryGetCpuAddr) = (HSAKMT_DEF(hsaKmtMemoryGetCpuAddr)*)(&hsaKmtMemoryGetCpuAddr);
       HSAKMT_PFN(hsaKmtMemoryCpuMap) = (HSAKMT_DEF(hsaKmtMemoryCpuMap)*)(&hsaKmtMemoryCpuMap);
+      HSAKMT_PFN(hsaKmtGetNodeWallclockFrequency) = (HSAKMT_DEF(hsaKmtGetNodeWallclockFrequency)*)(&hsaKmtGetNodeWallclockFrequency);
 
       DRM_PFN(amdgpu_device_initialize) = (DRM_DEF(amdgpu_device_initialize)*)(&amdgpu_device_initialize);
       DRM_PFN(amdgpu_device_deinitialize) = (DRM_DEF(amdgpu_device_deinitialize)*)(&amdgpu_device_deinitialize);


### PR DESCRIPTION
## Motivation
This change refactors wallclock retrieval to prefer HsaNodeProperties.WallClockKHz via hsaKmtGetNodeProperties(), falling back to the driver’s GetWallclockFrequency() only when the property is zero; the hsaKmtGetNodeWallclockFrequency symbol is optional and exists to preserve compatibility for dynamically loaded clients


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
