### PR TITLE
Avoid adding flow ids for slices where correlation id is not applicable [perfetto]

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
@@ -758,9 +758,18 @@ perfetto_processor_t::handle(const region_sample& _rs)
 
     auto emit_trace = [&](auto category_tag) {
         using CategoryT = decltype(category_tag);
-        tracing::push_perfetto_ts(CategoryT{}, _name.c_str(), _beg_ts,
-                                  ::perfetto::Flow::ProcessScoped(_corr_id),
-                                  add_annotations);
+        if(_corr_id != 0)
+        {
+            tracing::push_perfetto_ts(CategoryT{}, _name.c_str(), _beg_ts,
+                                      ::perfetto::Flow::ProcessScoped(_corr_id),
+                                      add_annotations);
+        }
+        else
+        {
+            tracing::push_perfetto_ts(CategoryT{}, _name.c_str(), _beg_ts,
+                                      add_annotations);
+        }
+
         tracing::pop_perfetto_ts(CategoryT{}, _name.c_str(), _end_ts);
     };
 


### PR DESCRIPTION
## Motivation

Certain slices in the Perfetto UI end up with the Flow lines that shouldn't be there. Givin the unrealistic picture of the traces.

## Technical Details

Underlying reason was the handling of `correlation_id` inside of the `region sample handler` in `perfetto_processor` for cached data. The check is added, so that captured samples where `correlation_id` is equal to 0 ( no applicable), will be traced not as a part of a certain flow, which was missed in initial implementation. 

## JIRA ID

AIPROFSYST-186

## Test Plan

- Test with the existing test suite. 
- Visual validation

## Test Result

- Existing tests are passing
- Visual validation of Perfetto UI after the change shows now lines for reported bug (MPI flows)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
