### PR TITLE
Fix FindTBB version lookup logic

### DIFF
--- a/projects/rocprofiler-systems/cmake/Modules/FindTBB.cmake
+++ b/projects/rocprofiler-systems/cmake/Modules/FindTBB.cmake
@@ -149,9 +149,11 @@ find_path(
 #
 if(TBB_INCLUDE_DIRS)
     # Starting in 2020.1.1, tbb_stddef.h is replaced by version.h
+    # Starting in 2021.*, tbb/version.h is replaced by oneapi/tbb/version.h
     set(_version_files
         "${TBB_INCLUDE_DIRS}/tbb/tbb_stddef.h"
         "${TBB_INCLUDE_DIRS}/tbb/version.h"
+        "${TBB_INCLUDE_DIRS}/oneapi/tbb/version.h"
     )
     foreach(f IN ITEMS ${_version_files})
         if(EXISTS ${f})


### PR DESCRIPTION
## Motivation

Starting with version 2021, the version is not located in the file `tbb/version.h` but in `oneapi/tbb/version.h` instead.
Because the lookup tries to find the text in the file instead of in the preprocessor result, the move made the version check to fail.

## Technical Details

Adding the new file path to the list of files to search for fixes the problem.

## Test Plan

1. Configure and install using existing default `-DROCPROFSYS_BUILD_TBB=ON`.

2. Install TBB 2021 or later. For example [Ubuntu's DEB package](https://packages.ubuntu.com/jammy/libtbb-dev).
Configure and build successfully using `-DROCPROFSYS_BUILD_TBB=OFF`.

## Test Result

CMake project configures and builds correctly.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
