### PR TITLE
[rocprofiler-systems] Enable Offload OpenMP-VV CTests

### DIFF
--- a/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-openmp-tests.cmake
@@ -145,7 +145,6 @@ if(ROCPROFSYS_OMPVV_HOST_TESTS)
 
     foreach(OFFLOAD_TEST_NAME ${ROCPROFSYS_OMPVV_OFFLOAD_TESTS})
         rocprofiler_systems_add_test(
-            SKIP_RUNTIME
             NAME ${OFFLOAD_TEST_NAME}
             TARGET ${OFFLOAD_TEST_NAME}-exec
             GPU ON
@@ -154,7 +153,7 @@ if(ROCPROFSYS_OMPVV_HOST_TESTS)
             SAMPLING_TIMEOUT 300
             REWRITE_TIMEOUT 300
             ENVIRONMENT
-              "${_ompvv_offload_environment}"
+              "${_ompvv_offload_environment};ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK=ON"
             REWRITE_RUN_PASS_REGEX
               "${_OMPVV_OFFLOAD_PASS_REGEX}"
         )


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Remove `SKIP_RUNTIME` and add `ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK=ON` to OpenMP-VV offload CTests

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

AIPROFSYST-142

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Tested locally. Note that this adds 240 seconds of extra testing as each one takes 120 seconds.

## Test Result

<!-- Briefly summarize test outcomes. -->

Tests pass locally.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
