### PR TITLE
[rocprofiler-systems] Fix rocpd crash from use-after-free in statement executors

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/rocpd/data_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/rocpd/data_processor.cpp
@@ -256,9 +256,10 @@ data_processor::initialize_event_stmt()
                      .set_values('?', '?', '?', '?', '?', '?', '?', '?')
                      .get_query_string();
     _insert_event_statement =
-        _database->create_statement_executor<const char*, size_t, size_t, size_t, size_t,
-                                             const char*, const char*, const char*>(
-            query);
+        data_storage::database::create_statement_executor<const char*, size_t, size_t,
+                                                          size_t, size_t, const char*,
+                                                          const char*, const char*>(
+            query, _database);
 }
 
 void
@@ -270,9 +271,9 @@ data_processor::initialize_pmc_event_stmt()
                      .set_values('?', '?', '?', '?', '?')
                      .get_query_string();
     _insert_pmc_event_statement =
-        _database
-            ->create_statement_executor<const char*, size_t, size_t, double, const char*>(
-                query);
+        data_storage::database::create_statement_executor<const char*, size_t, size_t,
+                                                          double, const char*>(query,
+                                                                               _database);
 }
 
 void
@@ -284,8 +285,9 @@ data_processor::initialize_sample_stmt()
                      .set_values('?', '?', '?', '?', '?')
                      .get_query_string();
     _insert_sample_statement =
-        _database->create_statement_executor<const char*, size_t, uint64_t, size_t,
-                                             const char*>(query);
+        data_storage::database::create_statement_executor<const char*, size_t, uint64_t,
+                                                          size_t, const char*>(query,
+                                                                               _database);
 }
 
 void
@@ -298,9 +300,10 @@ data_processor::initialize_region_stmt()
                      .set_values('?', '?', '?', '?', '?', '?', '?', '?', '?')
                      .get_query_string();
     _insert_region_statement =
-        _database
-            ->create_statement_executor<const char*, size_t, size_t, size_t, uint64_t,
-                                        uint64_t, size_t, size_t, const char*>(query);
+        data_storage::database::create_statement_executor<const char*, size_t, size_t,
+                                                          size_t, uint64_t, uint64_t,
+                                                          size_t, size_t, const char*>(
+            query, _database);
 }
 
 void
@@ -317,10 +320,10 @@ data_processor::initialize_kernel_dispatch_stmt()
                      .set_values('?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?',
                                  '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?')
                      .get_query_string();
-    _insert_kernel_dispatch_statement = _database->create_statement_executor<
+    _insert_kernel_dispatch_statement = data_storage::database::create_statement_executor<
         const char*, size_t, size_t, size_t, size_t, size_t, size_t, size_t, size_t,
         uint64_t, uint64_t, size_t, size_t, size_t, size_t, size_t, size_t, size_t,
-        size_t, size_t, size_t, const char*>(query);
+        size_t, size_t, size_t, const char*>(query, _database);
 }
 
 void
@@ -335,9 +338,10 @@ data_processor::initialize_memory_copy_stmt()
                      .set_values('?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?',
                                  '?', '?', '?', '?', '?', '?')
                      .get_query_string();
-    _insert_memory_copy_statement = _database->create_statement_executor<
+    _insert_memory_copy_statement = data_storage::database::create_statement_executor<
         const char*, size_t, size_t, size_t, uint64_t, uint64_t, size_t, size_t, size_t,
-        size_t, size_t, size_t, size_t, size_t, size_t, size_t, const char*>(query);
+        size_t, size_t, size_t, size_t, size_t, size_t, size_t, const char*>(query,
+                                                                             _database);
 }
 
 void
@@ -354,12 +358,10 @@ data_processor::initialize_kernel_symbol_stmt()
             .set_values('?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?',
                         '?', '?', '?')
             .get_query_string();
-    _insert_kernel_symbol_statement =
-        _database->create_statement_executor<size_t, const char*, size_t, size_t,
-                                             uint64_t, const char*, const char*, uint64_t,
-                                             uint32_t, uint32_t, uint32_t, uint32_t,
-                                             uint32_t, uint32_t, uint32_t, const char*>(
-            query);
+    _insert_kernel_symbol_statement = data_storage::database::create_statement_executor<
+        size_t, const char*, size_t, size_t, uint64_t, const char*, const char*, uint64_t,
+        uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t,
+        const char*>(query, _database);
 }
 
 void
@@ -372,10 +374,9 @@ data_processor::initialize_code_object_stmt()
                          "load_size", "load_delta", "storage_type", "extdata")
             .set_values('?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?')
             .get_query_string();
-    _insert_code_object_statement =
-        _database->create_statement_executor<size_t, const char*, size_t, size_t, size_t,
-                                             const char*, uint64_t, uint64_t, uint64_t,
-                                             const char*, const char*>(query);
+    _insert_code_object_statement = data_storage::database::create_statement_executor<
+        size_t, const char*, size_t, size_t, size_t, const char*, uint64_t, uint64_t,
+        uint64_t, const char*, const char*>(query, _database);
 }
 
 void
@@ -387,10 +388,9 @@ data_processor::initialize_args_stmt()
                                   "extdata")
                      .set_values('?', '?', '?', '?', '?', '?', '?')
                      .get_query_string();
-    _insert_args_statement =
-        _database->create_statement_executor<const char*, size_t, size_t, const char*,
-                                             const char*, const char*, const char*>(
-            query);
+    _insert_args_statement = data_storage::database::create_statement_executor<
+        const char*, size_t, size_t, const char*, const char*, const char*, const char*>(
+        query, _database);
 }
 
 void
@@ -404,9 +404,9 @@ data_processor::initialize_memory_alloc_stmt()
                      .set_values('?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?',
                                  '?', '?', '?', '?')
                      .get_query_string();
-    _insert_memory_alloc_statement = _database->create_statement_executor<
+    _insert_memory_alloc_statement = data_storage::database::create_statement_executor<
         const char*, size_t, size_t, size_t, size_t, const char*, const char*, uint64_t,
-        uint64_t, size_t, size_t, size_t, size_t, size_t, const char*>(query);
+        uint64_t, size_t, size_t, size_t, size_t, size_t, const char*>(query, _database);
 
     // Statement without agent_id
     query = query_builder.set_table_name("rocpd_memory_allocate_" + _upid)
@@ -416,9 +416,11 @@ data_processor::initialize_memory_alloc_stmt()
                 .set_values('?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?',
                             '?', '?')
                 .get_query_string();
-    _insert_memory_alloc_no_agent_statement = _database->create_statement_executor<
-        const char*, size_t, size_t, size_t, const char*, const char*, uint64_t, uint64_t,
-        size_t, size_t, size_t, size_t, size_t, const char*>(query);
+    _insert_memory_alloc_no_agent_statement =
+        data_storage::database::create_statement_executor<
+            const char*, size_t, size_t, size_t, const char*, const char*, uint64_t,
+            uint64_t, size_t, size_t, size_t, size_t, size_t, const char*>(query,
+                                                                           _database);
 }
 
 void

--- a/projects/rocprofiler-systems/source/lib/core/rocpd/data_storage/database.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/rocpd/data_storage/database.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 #include "common/traits.hpp"
+#include "logger/debug.hpp"
+
 #include <memory>
 #include <mutex>
 #include <sqlite3.h>
@@ -41,8 +43,8 @@ public:
     database()                      = delete;
     database(database&)             = delete;
     database& operator=(database&)  = delete;
-    database(database&&)            = default;
-    database& operator=(database&&) = default;
+    database(database&&)            = delete;
+    database& operator=(database&&) = delete;
 
     void flush();
 
@@ -170,23 +172,47 @@ public:
      * This function prepares an SQLite statement based on the provided SQL query and
      * returns a lambda that can execute the prepared statement, binding the provided
      * values to the respective placeholders in the query.
+     *
+     * @param db_ref A shared_ptr to this database instance. The statement's deleter
+     *               captures it to guarantee the connection stays open until all
+     *               statements are finalized.
      */
     template <typename... Values>
-    auto create_statement_executor(const std::string& query)
+    static auto create_statement_executor(const std::string&        query,
+                                          std::shared_ptr<database> db_ref)
     {
-        sqlite3_stmt* p_stmt;
-        validate_sqlite3_result(
-            sqlite3_prepare_v2(_sqlite3_db_temp, query.c_str(), -1, &p_stmt, nullptr),
-            query.c_str(), "Failed to create statement!");
-        std::shared_ptr<sqlite3_stmt> stmt{ p_stmt, sqlite3_finalize };
+        if(db_ref == nullptr)
+        {
+            throw std::runtime_error("Database cannot be nullptr!");
+        }
 
-        return [stmt, query, this](Values... value) {
+        sqlite3_stmt* p_stmt;
+        db_ref->validate_sqlite3_result(sqlite3_prepare_v2(db_ref->_sqlite3_db_temp,
+                                                           query.c_str(), -1, &p_stmt,
+                                                           nullptr),
+                                        query.c_str(), "Failed to create statement!");
+
+        std::shared_ptr<sqlite3_stmt> stmt{ p_stmt, [db = db_ref](sqlite3_stmt* s) {
+                                               if(db == nullptr)
+                                               {
+                                                   return;
+                                               }
+                                               sqlite3_finalize(s);
+                                           } };
+
+        return [stmt, query, db_ref](Values... value) {
+            if(db_ref == nullptr)
+            {
+                return;
+            }
+
             int position = 1;
 
-            ((bind_value(stmt.get(), position++, value, query)), ...);
+            ((db_ref->bind_value(stmt.get(), position++, value, query)), ...);
 
-            validate_sqlite3_result(sqlite3_step(stmt.get()), query.c_str(),
-                                    "Failed to execute step!\n", "Values: ", value...);
+            db_ref->validate_sqlite3_result(sqlite3_step(stmt.get()), query.c_str(),
+                                            "Failed to execute step!\n",
+                                            "Values: ", value...);
             sqlite3_reset(stmt.get());
         };
     }


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
rocpd was crashing because prepared-statement executors (lambdas) captured a raw `this` pointer to the database. If the database was moved or destroyed before those executors finished (e.g. when `database` was moved), the lambdas could run against an invalid object and cause a use-after-free crash.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- In `database.hpp`, `create_statement_executor` is changed from an instance method to a static method taking `std::shared_ptr<database> db_ref`. The returned executor’s deleter captures this shared_ptr so the database connection outlives all prepared statements. Move constructor and move assignment of `database` are deleted to avoid invalidating existing executors that might still hold references.
- In `data_processor.cpp`, all call sites are updated to call `data_storage::database::create_statement_executor<...>(query, _database)` instead of `_database->create_statement_executor<...>(query)`.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
ROCM-2117

## Test Plan
- Run rocpd-based workflows (e.g. capture and process traces) and confirm no crash when the database is used under normal load and teardown.
- Optionally stress scenarios where many statements are created and the processor/database may be torn down or moved.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
- No crash when using rocpd; trace capture and processing complete successfully. No use-after-free or access to moved/destroyed database from statement executors.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.