### PR TITLE
Fix catch-test build failure with address sanitizer

### DIFF
--- a/projects/hip-tests/catch/CMakeLists.txt
+++ b/projects/hip-tests/catch/CMakeLists.txt
@@ -29,8 +29,7 @@ find_package(Git)
 find_package(Python 3 COMPONENTS Interpreter REQUIRED)
 find_program(HIPCONFIG_EXEC hipconfig REQUIRED)
 
-# hip root dir is 3 levels down the hip-config.cmake file path
-set(HIP_PATH ${hip_DIR}/../../../)
+set(HIP_PATH ${HIP_PACKAGE_PREFIX_DIR})
 if(NOT DEFINED ROCM_PATH)
     set(ROCM_PATH "/opt/rocm")
     if(NOT EXISTS "${ROCM_PATH}")


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fixes CI build failures for asan builds
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
if `ENABLE_ADDRESS_SANITIZER` cmake option is set to true, modify `HIP_PATH` variable to point to correct directory
## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
SWDEV-571769
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
personal testing with CI scripts
## Test Result

<!-- Briefly summarize test outcomes. -->
building scripts successfully finished
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
