### PR TITLE
[Docs] Fix code example in HIP C++ language extensions

### DIFF
--- a/projects/hip/docs/how-to/hip_cpp_language_extensions.rst
+++ b/projects/hip/docs/how-to/hip_cpp_language_extensions.rst
@@ -103,7 +103,7 @@ The kernel arguments are listed after the configuration parameters.
 
 .. code-block:: cpp
 
-  .. literalinclude:: ../tools/example_codes/calling_global_functions.hip
+  .. literalinclude:: ../../tools/example_codes/calling_global_functions.hip
       :start-after: // [sphinx-start]
       :end-before: // [sphinx-end]
       :language: cpp


### PR DESCRIPTION
## Motivation

This PR attempts to fix rendering of the [HIP C++ language extensions](https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/hip_cpp_language_extensions.html#calling-global-functions) documentation web page where instead of a code snippet a raw `.rst` snippet for file inclusion is displayed.

## Test Plan

There is no obvious documentation on how to build the documentation, so this change is untested

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

The guidelines say that documentation is hosted in a separate repo, but it doesn't seem to be the case here