### PR TITLE
Fix static --csv failing to print

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -1252,6 +1252,7 @@ class AMDSMICommands():
                     })
                     self.logger.store_output(args.gpu, 'values', row_dict)
                     self.logger.store_gpu_json_output.append(row_dict)
+                    self.logger.store_multiple_device_output()
             # expand if ras blocks are populated
             elif self.helpers.is_linux() and self.helpers.is_baremetal() and args.ras:
                 if isinstance(static_dict['ras']['ecc_block_state'], list):


### PR DESCRIPTION
## Motivation

Resolves https://github.com/ROCm/amdsmi/issues/177 (amd-smi fails to output static as csv). This regression was introduced with https://github.com/ROCm/rocm-systems/commit/5e56281eb0936161a34dbe3885dffef7e8b65863

## Technical Details

When NUMA data is present but cpu_affinity is empty or not a dict, the row gets stored in `self.output` but never pushed to `multiple_device_output`, and then print_output(multiple_device_enabled=True) reads from the empty list and prints nothing.

Added self.logger.store_multiple_device_output() to this case so data is correctly pushed to `multiple_device_output` and then printed.

## Test Plan

Built amd-smi with this patch and tested  `/opt/rocm/bin/amd-smi static --csv`

## Test Result

 `/opt/rocm/bin/amd-smi static --csv` works again.
 
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
