### PR TITLE
[clr] Fix headers to allow gcc-13

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_types.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_ocp_types.h
@@ -67,7 +67,7 @@ typedef _Float16 __attribute__((ext_vector_type(8))) __amd_fp16x8_storage_t;
 typedef _Float16 __attribute__((ext_vector_type(32))) __amd_fp16x32_storage_t;
 typedef uint32_t __attribute__((ext_vector_type(6))) __amd_fp6x32_storage_t;
 typedef short __attribute__((ext_vector_type(2))) __amd_shortx2_storage_t;
-#elif defined(__GNUC__) && (__GNUC__ > 13)
+#elif defined(__GNUC__) && (__GNUC__ >= 13)
 /* GCC expects vector size in bytes */
 typedef unsigned int __attribute__((vector_size(8))) __amd_uintx2_storage_t;
 typedef uint8_t __attribute__((vector_size(8))) __amd_fp8x8_storage_t;
@@ -86,6 +86,6 @@ typedef short __attribute__((vector_size(4))) __amd_shortx2_storage_t;
 #endif
 
 #if (defined(__clang__) && (__clang_major__ > 17) && defined(__HIP__)) ||                          \
-    (defined(__GNUC__) && (__GNUC__ > 13))
+    (defined(__GNUC__) && (__GNUC__ >= 13))
 static_assert(sizeof(__amd_uintx2_storage_t) == sizeof(__amd_fp8x8_storage_t), "");
 #endif


### PR DESCRIPTION
## Motivation

These types should be defined for gcc-13 since that version already supports fp16.

## Technical Details

Updates the conditions in the amd_hip_ocp_types.h header to allow gcc-13 since this version already supports fp16 types.

## JIRA ID

https://amd-hub.atlassian.net/browse/AIHPSPAR-3

## Test Plan

CI passes

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
