### PR TITLE
[ci] Adding mi350 required group ID

### DIFF
--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -61,6 +61,7 @@ jobs:
         --device /dev/kfd
         --device /dev/dri
         --group-add 992
+        --group-add 110
         --env-file /etc/podinfo/gha-gpu-isolation-settings
     needs: configure_test_matrix
     # skip tests if no test matrix to run

--- a/projects/rccl/.github/workflows/therock-test-packages-single-node.yml
+++ b/projects/rccl/.github/workflows/therock-test-packages-single-node.yml
@@ -36,6 +36,7 @@ jobs:
         --device /dev/kfd
         --device /dev/dri
         --group-add 992
+        --group-add 110
         --ulimit memlock=-1:-1
         --security-opt seccomp=unconfined
         --env-file /etc/podinfo/gha-gpu-isolation-settings


### PR DESCRIPTION
After updating mi325 group-id, we are noticing errors for mi350.

Tested here for mi350: https://github.com/ROCm/TheRock/actions/runs/21733399385/job/62692971370
Tested here for mi325: https://github.com/ROCm/TheRock/actions/runs/21759203211/job/62778060417

Adding both work properly