### PR TITLE
Fixing ROCTracer Tests HIP/CLR CMake Config

### DIFF
--- a/projects/roctracer/CMakeLists.txt
+++ b/projects/roctracer/CMakeLists.txt
@@ -20,7 +20,7 @@
 ## IN THE SOFTWARE.
 ################################################################################
 
-cmake_minimum_required(VERSION 3.18.0)
+cmake_minimum_required(VERSION 3.21.0)
 
 include( utils.cmake )
 set( CORE_TARGET "roctracer" )

--- a/projects/roctracer/test/CMakeLists.txt
+++ b/projects/roctracer/test/CMakeLists.txt
@@ -38,6 +38,9 @@ if(NOT CMAKE_HIP_COMPILER)
 endif()
 
 # Enable HIP as a project language
+# Explicitly control HIP GPU architectures to avoid toolchain-dependent defaults.
+# Using OFF keeps behavior aligned with compiler defaults while remaining deterministic.
+set(CMAKE_HIP_ARCHITECTURES OFF CACHE STRING "HIP GPU architectures for tests" FORCE)
 enable_language(HIP)
 
 # Set HIP compilation flags to match CXX flags

--- a/projects/roctracer/test/CMakeLists.txt
+++ b/projects/roctracer/test/CMakeLists.txt
@@ -38,9 +38,6 @@ if(NOT CMAKE_HIP_COMPILER)
 endif()
 
 # Enable HIP as a project language
-# Explicitly control HIP GPU architectures to avoid toolchain-dependent defaults.
-# Using OFF keeps behavior aligned with compiler defaults while remaining deterministic.
-set(CMAKE_HIP_ARCHITECTURES OFF CACHE STRING "HIP GPU architectures for tests" FORCE)
 enable_language(HIP)
 
 # Set HIP compilation flags to match CXX flags

--- a/projects/roctracer/test/CMakeLists.txt
+++ b/projects/roctracer/test/CMakeLists.txt
@@ -61,19 +61,22 @@ add_custom_target(mytest)
 add_dependencies(mytest roctracer_tool hip_stats)
 add_custom_target(check COMMAND ${PROJECT_BINARY_DIR}/run.sh DEPENDS mytest)
 
+## Helper function to create HIP executables with common settings
+function(add_hip_executable TARGET_NAME SOURCE_FILE)
+  set_source_files_properties(${SOURCE_FILE} PROPERTIES LANGUAGE HIP)
+  add_executable(${TARGET_NAME} ${SOURCE_FILE})
+  target_link_options(${TARGET_NAME} PRIVATE "-Wl,--build-id=md5")
+endfunction()
+
 ## Build MatrixTranspose
-set_source_files_properties(hip/MatrixTranspose.cpp PROPERTIES LANGUAGE HIP)
-add_executable(MatrixTranspose hip/MatrixTranspose.cpp)
-target_link_options(MatrixTranspose PRIVATE "-Wl,--build-id=md5")
+add_hip_executable(MatrixTranspose hip/MatrixTranspose.cpp)
 target_include_directories(MatrixTranspose PRIVATE ${PROJECT_SOURCE_DIR}/inc)
 target_link_libraries(MatrixTranspose PRIVATE roctracer roctx)
 add_dependencies(mytest MatrixTranspose)
 
 ## Build MatrixTranspose_test, MatrixTranspose_hipaact_test and MatrixTranspose_mgpu
-set_source_files_properties(app/MatrixTranspose_test.cpp PROPERTIES LANGUAGE HIP)
 function(build_matrix_transpose_test OUTPUT_FILE DEFINITIONS)
-  add_executable(${OUTPUT_FILE} app/MatrixTranspose_test.cpp)
-  target_link_options(${OUTPUT_FILE} PRIVATE "-Wl,--build-id=md5")
+  add_hip_executable(${OUTPUT_FILE} app/MatrixTranspose_test.cpp)
   target_compile_definitions(${OUTPUT_FILE} PRIVATE ITERATIONS=100 HIP_TEST=1 ${DEFINITIONS})
   target_include_directories(${OUTPUT_FILE} PRIVATE ${PROJECT_SOURCE_DIR}/inc)
   target_link_libraries(${OUTPUT_FILE} PRIVATE roctracer roctx)
@@ -87,9 +90,7 @@ build_matrix_transpose_test(MatrixTranspose_mgpu MGPU_TEST=1)
 ## Build MatrixTranspose MatrixTranspose_ctest
 add_custom_command(OUTPUT MatrixTranspose.c
   COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/app/MatrixTranspose_test.cpp MatrixTranspose.c)
-set_source_files_properties(MatrixTranspose.c PROPERTIES LANGUAGE HIP)
-add_executable(MatrixTranspose_ctest MatrixTranspose.c)
-target_link_options(MatrixTranspose_ctest PRIVATE "-Wl,--build-id=md5")
+add_hip_executable(MatrixTranspose_ctest MatrixTranspose.c)
 target_compile_definitions(MatrixTranspose_ctest PRIVATE HIP_TEST=0 __HIP_PLATFORM_AMD__)
 target_include_directories(MatrixTranspose_ctest PRIVATE ${PROJECT_SOURCE_DIR}/inc)
 target_link_libraries(MatrixTranspose_ctest PRIVATE roctracer roctx)
@@ -138,9 +139,7 @@ add_dependencies(copy hsaco_targets)
 add_dependencies(mytest copy)
 
 ## Build the ROCTX test
-set_source_files_properties(app/roctx_test.cpp PROPERTIES LANGUAGE HIP)
-add_executable(roctx_test app/roctx_test.cpp)
-target_link_options(roctx_test PRIVATE "-Wl,--build-id=md5")
+add_hip_executable(roctx_test app/roctx_test.cpp)
 target_link_libraries(roctx_test Threads::Threads roctx)
 add_dependencies(mytest roctx_test)
 
@@ -166,16 +165,12 @@ target_link_libraries(memory_pool Threads::Threads atomic)
 add_dependencies(mytest memory_pool)
 
 ## Build the activity_and_callback test
-set_source_files_properties(directed/activity_and_callback.cpp PROPERTIES LANGUAGE HIP)
-add_executable(activity_and_callback directed/activity_and_callback.cpp)
-target_link_options(activity_and_callback PRIVATE "-Wl,--build-id=md5")
+add_hip_executable(activity_and_callback directed/activity_and_callback.cpp)
 target_link_libraries(activity_and_callback roctracer)
 add_dependencies(mytest activity_and_callback)
 
 ## Build the multi_pool_activities test
-set_source_files_properties(directed/multi_pool_activities.cpp PROPERTIES LANGUAGE HIP)
-add_executable(multi_pool_activities directed/multi_pool_activities.cpp)
-target_link_options(multi_pool_activities PRIVATE "-Wl,--build-id=md5")
+add_hip_executable(multi_pool_activities directed/multi_pool_activities.cpp)
 target_link_libraries(multi_pool_activities roctracer)
 add_dependencies(mytest multi_pool_activities)
 

--- a/projects/roctracer/test/CMakeLists.txt
+++ b/projects/roctracer/test/CMakeLists.txt
@@ -22,17 +22,35 @@
 
 get_property(HSA_RUNTIME_INCLUDE_DIRECTORIES TARGET hsa-runtime64::hsa-runtime64 PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
 
-# Set the HIP language runtime link flags as FindHIP does not set them.
-set(CMAKE_EXECUTABLE_RUNTIME_HIP_FLAG ${CMAKE_SHARED_LIBRARY_RUNTIME_CXX_FLAG})
-set(CMAKE_EXECUTABLE_RUNTIME_HIP_FLAG_SEP ${CMAKE_SHARED_LIBRARY_RUNTIME_CXX_FLAG_SEP})
-set(CMAKE_EXECUTABLE_RPATH_LINK_HIP_FLAG ${CMAKE_SHARED_LIBRARY_RPATH_LINK_CXX_FLAG})
+# Find amdclang++ compiler for HIP language support
+if(NOT CMAKE_HIP_COMPILER)
+    find_program(
+        amdclangpp_EXECUTABLE
+        NAMES amdclang++
+        HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+        PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+        PATH_SUFFIXES bin llvm/bin NO_CACHE)
+    mark_as_advanced(amdclangpp_EXECUTABLE)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${ROCM_PATH}/lib/cmake/hip")
-set(CMAKE_HIP_ARCHITECTURES OFF)
-if(DEFINED ROCM_PATH)
-    set(HIP_ROOT_DIR "${ROCM_PATH}/bin")
+    if(amdclangpp_EXECUTABLE)
+        set(CMAKE_HIP_COMPILER "${amdclangpp_EXECUTABLE}")
+    endif()
 endif()
-find_package(HIP REQUIRED MODULE)
+
+# Enable HIP as a project language
+enable_language(HIP)
+
+# Set HIP compilation flags to match CXX flags
+foreach(_TYPE DEBUG MINSIZEREL RELEASE RELWITHDEBINFO)
+    if("${CMAKE_HIP_FLAGS_${_TYPE}}" STREQUAL "")
+        set(CMAKE_HIP_FLAGS_${_TYPE} "${CMAKE_CXX_FLAGS_${_TYPE}}")
+    endif()
+endforeach()
+
+# Set HIP standard flags
+set(CMAKE_HIP_STANDARD 17)
+set(CMAKE_HIP_EXTENSIONS OFF)
+set(CMAKE_HIP_STANDARD_REQUIRED ON)
 
 find_package(Clang REQUIRED CONFIG
              PATHS "${ROCM_PATH}"
@@ -44,19 +62,17 @@ add_dependencies(mytest roctracer_tool hip_stats)
 add_custom_target(check COMMAND ${PROJECT_BINARY_DIR}/run.sh DEPENDS mytest)
 
 ## Build MatrixTranspose
-set_source_files_properties(hip/MatrixTranspose.cpp PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
-hip_add_executable(MatrixTranspose hip/MatrixTranspose.cpp)
-## Adding generated build-id as hip_add_executable doesn't generate automatically
+set_source_files_properties(hip/MatrixTranspose.cpp PROPERTIES LANGUAGE HIP)
+add_executable(MatrixTranspose hip/MatrixTranspose.cpp)
 target_link_options(MatrixTranspose PRIVATE "-Wl,--build-id=md5")
 target_include_directories(MatrixTranspose PRIVATE ${PROJECT_SOURCE_DIR}/inc)
 target_link_libraries(MatrixTranspose PRIVATE roctracer roctx)
 add_dependencies(mytest MatrixTranspose)
 
 ## Build MatrixTranspose_test, MatrixTranspose_hipaact_test and MatrixTranspose_mgpu
-set_source_files_properties(app/MatrixTranspose_test.cpp PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
+set_source_files_properties(app/MatrixTranspose_test.cpp PROPERTIES LANGUAGE HIP)
 function(build_matrix_transpose_test OUTPUT_FILE DEFINITIONS)
-  hip_add_executable(${OUTPUT_FILE} app/MatrixTranspose_test.cpp)
-  ## Adding generated build-id as hip_add_executable doesn't generate automatically
+  add_executable(${OUTPUT_FILE} app/MatrixTranspose_test.cpp)
   target_link_options(${OUTPUT_FILE} PRIVATE "-Wl,--build-id=md5")
   target_compile_definitions(${OUTPUT_FILE} PRIVATE ITERATIONS=100 HIP_TEST=1 ${DEFINITIONS})
   target_include_directories(${OUTPUT_FILE} PRIVATE ${PROJECT_SOURCE_DIR}/inc)
@@ -71,8 +87,8 @@ build_matrix_transpose_test(MatrixTranspose_mgpu MGPU_TEST=1)
 ## Build MatrixTranspose MatrixTranspose_ctest
 add_custom_command(OUTPUT MatrixTranspose.c
   COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/app/MatrixTranspose_test.cpp MatrixTranspose.c)
-hip_add_executable(MatrixTranspose_ctest MatrixTranspose.c)
-## Adding generated build-id as hip_add_executable doesn't generate automatically
+set_source_files_properties(MatrixTranspose.c PROPERTIES LANGUAGE HIP)
+add_executable(MatrixTranspose_ctest MatrixTranspose.c)
 target_link_options(MatrixTranspose_ctest PRIVATE "-Wl,--build-id=md5")
 target_compile_definitions(MatrixTranspose_ctest PRIVATE HIP_TEST=0 __HIP_PLATFORM_AMD__)
 target_include_directories(MatrixTranspose_ctest PRIVATE ${PROJECT_SOURCE_DIR}/inc)
@@ -122,9 +138,8 @@ add_dependencies(copy hsaco_targets)
 add_dependencies(mytest copy)
 
 ## Build the ROCTX test
-set_source_files_properties(app/roctx_test.cpp PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
-hip_add_executable(roctx_test app/roctx_test.cpp)
-## Adding generated build-id as hip_add_executable doesn't generate automatically
+set_source_files_properties(app/roctx_test.cpp PROPERTIES LANGUAGE HIP)
+add_executable(roctx_test app/roctx_test.cpp)
 target_link_options(roctx_test PRIVATE "-Wl,--build-id=md5")
 target_link_libraries(roctx_test Threads::Threads roctx)
 add_dependencies(mytest roctx_test)
@@ -151,17 +166,15 @@ target_link_libraries(memory_pool Threads::Threads atomic)
 add_dependencies(mytest memory_pool)
 
 ## Build the activity_and_callback test
-set_source_files_properties(directed/activity_and_callback.cpp PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
-hip_add_executable(activity_and_callback directed/activity_and_callback.cpp)
-## Adding generated build-id as hip_add_executable doesn't generate automatically
+set_source_files_properties(directed/activity_and_callback.cpp PROPERTIES LANGUAGE HIP)
+add_executable(activity_and_callback directed/activity_and_callback.cpp)
 target_link_options(activity_and_callback PRIVATE "-Wl,--build-id=md5")
 target_link_libraries(activity_and_callback roctracer)
 add_dependencies(mytest activity_and_callback)
 
 ## Build the multi_pool_activities test
-set_source_files_properties(directed/multi_pool_activities.cpp PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
-hip_add_executable(multi_pool_activities directed/multi_pool_activities.cpp)
-## Adding generated build-id as hip_add_executable doesn't generate automatically
+set_source_files_properties(directed/multi_pool_activities.cpp PROPERTIES LANGUAGE HIP)
+add_executable(multi_pool_activities directed/multi_pool_activities.cpp)
 target_link_options(multi_pool_activities PRIVATE "-Wl,--build-id=md5")
 target_link_libraries(multi_pool_activities roctracer)
 add_dependencies(mytest multi_pool_activities)

--- a/projects/roctracer/test/app/MatrixTranspose_test.cpp
+++ b/projects/roctracer/test/app/MatrixTranspose_test.cpp
@@ -138,7 +138,7 @@ int main() {
 #if HIP_TEST
   int gpuCount = 1;
 #if MGPU_TEST
-  hipGetDeviceCount(&gpuCount);
+  CHECK_HIP(hipGetDeviceCount(&gpuCount));
   fprintf(stderr, "Number of GPUs: %d\n", gpuCount);
 #endif
   iterations *= gpuCount;
@@ -150,7 +150,7 @@ int main() {
 #if HIP_TEST
     // set GPU
     const int devIndex = iterations % gpuCount;
-    hipSetDevice(devIndex);
+    CHECK_HIP(hipSetDevice(devIndex));
 
     hipDeviceProp_t devProp;
     CHECK_HIP(hipGetDeviceProperties(&devProp, 0));


### PR DESCRIPTION
## Motivation

The roctracer test suite was using the deprecated FindHIP.cmake module approach for HIP compilation, which relies on the legacy hip_add_executable() function and manual configuration of HIP compilation flags. This approach has several
  drawbacks:

  1. Deprecated Toolchain: The FindHIP module-based approach is no longer the recommended method for HIP compilation in modern ROCm/HIP projects
  2. Inconsistency: The rocprofiler-sdk test suite already uses the modern CMake HIP language support, creating inconsistency across the codebase
  3. Maintenance Burden: The old approach requires manual setup of compiler paths, runtime flags, and source properties that are handled automatically in the modern approach
  4. Compiler Strictness: The modern amdclang++ compiler has stricter checking and better standards compliance, which the old FindHIP approach wasn't exposing

  By migrating to the modern CMake HIP language support, we align with current ROCm best practices, improve maintainability, and ensure consistency with other projects in the rocm-systems repository.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
