### PR TITLE
[hip] Fix hipMemSetAccess intermittent failures with sequential alloc…

### DIFF
--- a/projects/clr/hipamd/src/hip_vm.cpp
+++ b/projects/clr/hipamd/src/hip_vm.cpp
@@ -304,6 +304,11 @@ hipError_t hipMemMap(void* ptr, size_t size, size_t offset, hipMemGenericAllocat
   cmd->awaitCompletion();
   cmd->release();
 
+  // Ensure the mapping is fully visible at HSA layer before returning.
+  // This prevents race conditions where subsequent hipMemSetAccess calls
+  // may not find the mapped handle in sequential allocation scenarios.
+  queue.finish();
+
   HIP_RETURN(hipSuccess);
 }
 


### PR DESCRIPTION

This fixes a race condition where sequential virtual memory allocations (hipMemCreate -> hipMemMap -> hipMemSetAccess) could fail intermittently because hipMemSetAccess was called before the HSA layer had completed processing the mapping operation.

The issue manifested as random hipErrorInvalidArgument (code 1) errors on the second or third allocation in a sequence, particularly on gfx950 (MI355X) hardware.

Fixes: https://github.com/ROCm/rocm-systems/issues/2667

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
