### PR TITLE
libhsakmt: Fix error--Close KFD fd before clearing context to prevent fd leak

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/openclose.c
+++ b/projects/rocr-runtime/libhsakmt/src/openclose.c
@@ -110,8 +110,8 @@ static void clear_after_fork(HsaKFDContext *ctx)
 
 	int fd = ctx->fd;
 	if (fd >= 0) {
-		hsakmt_kfdcontext_clear_context(ctx);
 		close(fd);
+		hsakmt_kfdcontext_clear_context(ctx);
  	}
 	if (hsakmt_udmabuf_dev_fd > 0) {
 		close(hsakmt_udmabuf_dev_fd);


### PR DESCRIPTION
In clear_after_fork(), calling hsakmt_kfdcontext_clear_context() before close(fd) causes an fd leak because clear_context() sets fd=-1, making the subsequent close() a no-op. Swap the order to ensure the fd is properly closed.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
kfdtest
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
kfdtest passed.
