### PR TITLE
[rocdecode] updated the changelog to have the right versions

### DIFF
--- a/projects/rocdecode/CHANGELOG.md
+++ b/projects/rocdecode/CHANGELOG.md
@@ -2,12 +2,20 @@
 
 Full documentation for rocDecode is available at [https://rocm.docs.amd.com/projects/rocDecode/en/latest/](https://rocm.docs.amd.com/projects/rocDecode/en/latest/)
 
-## rocDecode 1.6.0 for ROCm 7.2.0
+## rocDecode 1.7.0 for ROCm 7.2.1
 
 ### Changed
+
+* The rocDecode GitHub repository has moved to [https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode](https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode).
+
+## rocDecode 1.5.0 for ROCm 7.2.0
+
+### Changed
+
 * Updated libdrm path configuration and libva version requirements for ROCm and TheRock platforms
 
 ### Added
+
 * Logging control. Message output from the core components is now controlled by the logging level threshold, which can be set by an environment variable or other methods.
 * rocdecode-host package - rocdecode-host library and samples
 

--- a/projects/rocdecode/docs/conceptual/video-decoding-pipeline.rst
+++ b/projects/rocdecode/docs/conceptual/video-decoding-pipeline.rst
@@ -42,4 +42,4 @@ Steps in decoding video content for applications (available in the rocDecode Too
    components (U and V) for color information.
 
 The preceding steps are demonstrated in the sample applications located in our
-`GitHub repository <https://github.com/ROCm/rocDecode/tree/develop/samples>`_ directory.
+`GitHub repository <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples>`_ directory.

--- a/projects/rocdecode/docs/how-to/using-rocDecode-bitstream.rst
+++ b/projects/rocdecode/docs/how-to/using-rocDecode-bitstream.rst
@@ -57,19 +57,19 @@ The ``videodecoderaw.cpp`` example also demonstrates how to use the bitstream re
 
 
 .. |videodecode| replace:: ``videodecode.cpp``
-.. _videodecode: https://github.com/ROCm/rocDecode/tree/develop/samples/videoDecode/videodecode.cpp
+.. _videodecode: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/videoDecode/videodecode.cpp
 
 .. |videodecoderaw| replace:: ``videodecoderaw.cpp``
-.. _videodecoderaw: https://github.com/ROCm/rocDecode/tree/develop/samples/videoDecodeRaw
+.. _videodecoderaw: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/videoDecodeRaw
 
 .. |common| replace:: ``common.h``
-.. _common: https://github.com/ROCm/rocDecode/blob/develop/samples/common.h
+.. _common: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/common.h
 
 .. |apifolder| replace:: ``api`` folder
-.. _apifolder: https://github.com/ROCm/rocDecode/tree/develop/api
+.. _apifolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api
 
 .. |utilsfolder| replace:: ``utils`` folder
-.. _utilsfolder: https://github.com/ROCm/rocDecode/tree/develop/utils
+.. _utilsfolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/utils
 
 
 .. |reconfig_struct| replace:: ``ReconfigParams_t``

--- a/projects/rocdecode/docs/how-to/using-rocDecode-ffmpeg.rst
+++ b/projects/rocdecode/docs/how-to/using-rocDecode-ffmpeg.rst
@@ -76,19 +76,19 @@ Delete the demuxer once demultiplexing is complete.
   delete demuxer;
 
 .. |videodecode| replace:: ``videodecode.cpp``
-.. _videodecode: https://github.com/ROCm/rocDecode/tree/develop/samples/videoDecode/videodecode.cpp
+.. _videodecode: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/videoDecode/videodecode.cpp
 
 .. |videodecoderaw| replace:: ``videodecoderaw.cpp``
-.. _videodecoderaw: https://github.com/ROCm/rocDecode/tree/develop/samples/videoDecodeRaw
+.. _videodecoderaw: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/videoDecodeRaw
 
 .. |common| replace:: ``common.h``
-.. _common: https://github.com/ROCm/rocDecode/blob/develop/samples/common.h
+.. _common: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/common.h
 
 .. |apifolder| replace:: ``api`` folder
-.. _apifolder: https://github.com/ROCm/rocDecode/tree/develop/api
+.. _apifolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api
 
 .. |utilsfolder| replace:: ``utils`` folder
-.. _utilsfolder: https://github.com/ROCm/rocDecode/tree/develop/utils
+.. _utilsfolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/utils
 
 
 .. |reconfig_struct| replace:: ``ReconfigParams_t``

--- a/projects/rocdecode/docs/how-to/using-rocDecode-rocdecdecoder.rst
+++ b/projects/rocdecode/docs/how-to/using-rocDecode-rocdecdecoder.rst
@@ -236,10 +236,10 @@ From the ``rocdecdecode.cpp`` sample:
 Once decoding is complete, ``rocDecDestroyVideoParser()`` needs to be called to destroy the parser, and either ``rocDecDestroyDecoderHost()`` or ``rocDecDestroyDecoder()`` needs to be called to destroy the decoder.
 
 .. |rocdecdecode| replace:: ``rocdecdecode``
-.. _rocdecdecode: https://github.com/ROCm/rocDecode/tree/develop/samples/rocdecDecode/README.md
+.. _rocdecdecode: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/rocdecDecode/README.md
 
 .. |apifolder| replace:: ``api/rocdecode/``
-.. _apifolder: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode
+.. _apifolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode
 
 .. |utilsfolder| replace:: ``utils`` folder
-.. _utilsfolder: https://github.com/ROCm/rocDecode/tree/develop/utils
+.. _utilsfolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/utils

--- a/projects/rocdecode/docs/how-to/using-rocDecode-video-decoder.rst
+++ b/projects/rocdecode/docs/how-to/using-rocDecode-video-decoder.rst
@@ -119,22 +119,22 @@ The reconfiguration parameters need to be defined prior to entering the decoding
 In the decode loop, the demultiplexed coded picture is passed to ``DecodeFrame``. Once the frame is decoded and processed, it is released with ``ReleaseFrame``. 
 
 .. |videodecode| replace:: ``videodecode.cpp``
-.. _videodecode: https://github.com/ROCm/rocDecode/tree/develop/samples/videoDecode/videodecode.cpp
+.. _videodecode: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/videoDecode/videodecode.cpp
 
 .. |videodecoderaw| replace:: ``videodecoderaw.cpp``
-.. _videodecoderaw: https://github.com/ROCm/rocDecode/tree/develop/samples/videoDecodeRaw
+.. _videodecoderaw: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/videoDecodeRaw
 
 .. |common| replace:: ``common.h``
-.. _common: https://github.com/ROCm/rocDecode/blob/develop/samples/common.h
+.. _common: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/common.h
 
 .. |apifolder| replace:: ``api`` folder
-.. _apifolder: https://github.com/ROCm/rocDecode/tree/develop/api
+.. _apifolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api
 
 .. |utilsfolder| replace:: ``utils`` folder
-.. _utilsfolder: https://github.com/ROCm/rocDecode/tree/develop/utils
+.. _utilsfolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/utils
 
 .. |roc_video_dec| replace:: ``roc_video_dec.h``
-.. _roc_video_dec: https://github.com/ROCm/rocDecode/tree/develop/utils/rocvideodecode/roc_video_dec.h
+.. _roc_video_dec: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/utils/rocvideodecode/roc_video_dec.h
 
 .. |reconfig_struct| replace:: ``ReconfigParams_t``
 .. _reconfig_struct: https://rocm.docs.amd.com/projects/rocDecode/en/latest/doxygen/html/structReconfigParams__t.html

--- a/projects/rocdecode/docs/how-to/using-rocDecode-videodecode-sample.rst
+++ b/projects/rocdecode/docs/how-to/using-rocDecode-videodecode-sample.rst
@@ -232,22 +232,22 @@ The demuxer is deleted once decoding is done.
   delete demuxer;
 
 .. |videodecode| replace:: ``videodecode.cpp``
-.. _videodecode: https://github.com/ROCm/rocDecode/tree/develop/samples/videoDecode/videodecode.cpp
+.. _videodecode: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/videoDecode/videodecode.cpp
 
 .. |videodecoderaw| replace:: ``videodecoderaw.cpp``
-.. _videodecoderaw: https://github.com/ROCm/rocDecode/tree/develop/samples/videoDecodeRaw
+.. _videodecoderaw: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/videoDecodeRaw
 
 .. |common| replace:: ``common.h``
-.. _common: https://github.com/ROCm/rocDecode/blob/develop/samples/common.h
+.. _common: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/common.h
 
 .. |apifolder| replace:: ``api`` folder
-.. _apifolder: https://github.com/ROCm/rocDecode/tree/develop/api
+.. _apifolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api
 
 .. |utilsfolder| replace:: ``utils`` folder
-.. _utilsfolder: https://github.com/ROCm/rocDecode/tree/develop/utils
+.. _utilsfolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/utils
 
 .. |samplefolder| replace:: ``samples`` folder
-.. _samplefolder: https://github.com/ROCm/rocDecode/tree/develop/samples
+.. _samplefolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples
 
 .. |reconfig_struct| replace:: ``ReconfigParams_t``
 .. _reconfig_struct: https://rocm.docs.amd.com/projects/rocDecode/en/latest/doxygen/html/structReconfigParams__t.html

--- a/projects/rocdecode/docs/index.rst
+++ b/projects/rocdecode/docs/index.rst
@@ -10,7 +10,7 @@ rocDecode provides APIs, utilities, and samples that you can use to easily acces
 features of your media engines (VCNs). It also allows interoperability with other compute engines on
 the GPU using Video Acceleration API (VA-API)/HIP. To learn more, see :doc:`what-is-rocDecode`
 
-The rocDecode public repository is located at `https://github.com/ROCm/rocDecode <https://github.com/ROCm/rocDecode>`_.
+The rocDecode project is located in https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode.
 
 .. grid:: 2
   :gutter: 3

--- a/projects/rocdecode/docs/index.rst
+++ b/projects/rocdecode/docs/index.rst
@@ -20,7 +20,7 @@ The rocDecode project is located in https://github.com/ROCm/rocm-systems/tree/de
     * :doc:`rocDecode prerequisites <./install/rocDecode-prerequisites>`
     * :doc:`Installing rocDecode with the package installer <./install/rocDecode-package-install>`
     * :doc:`Building and installing rocDecode from source code <./install/rocDecode-build-and-install>`
-    * `rocDecode Docker containers <https://github.com/ROCm/rocDecode/tree/develop/docker>`_
+    * `rocDecode Docker containers <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/docker>`_
 
 .. grid:: 2
   :gutter: 3

--- a/projects/rocdecode/docs/index.rst
+++ b/projects/rocdecode/docs/index.rst
@@ -18,6 +18,7 @@ The rocDecode project is located in https://github.com/ROCm/rocm-systems/tree/de
   .. grid-item-card:: Install
 
     * :doc:`rocDecode prerequisites <./install/rocDecode-prerequisites>`
+    * :doc:`Cloning the rocDecode project <./install/rocDecode-clone-project>`
     * :doc:`Installing rocDecode with the package installer <./install/rocDecode-package-install>`
     * :doc:`Building and installing rocDecode from source code <./install/rocDecode-build-and-install>`
     * `rocDecode Docker containers <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/docker>`_

--- a/projects/rocdecode/docs/install/rocDecode-build-and-install.rst
+++ b/projects/rocdecode/docs/install/rocDecode-build-and-install.rst
@@ -10,7 +10,15 @@ If you will be contributing to the rocDecode code base, or if you want to previe
 
 If you will not be previewing features or contributing to the code base, use the :doc:`package installers <./rocDecode-package-install>` to install rocDecode. 
 
-Before building rocDecode, use `rocDecode-setup.py <https://github.com/ROCm/rocDecode/blob/develop/rocDecode-setup.py>`_ to install all the required prerequisites:
+:doc:`Clone the rocDecode project <./rocDecode-clone-project>`.
+
+Change directory to the rocDecode project directory.
+
+.. code:: shell
+
+  cd rocm-systems/projects/rocdecode
+
+Use `rocDecode-setup.py <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/rocDecode-setup.py>`_ to install the required prerequisites:
 
 .. code:: shell
 
@@ -28,8 +36,6 @@ Build and install rocDecode using the following commands:
 
 .. code:: shell
 
-  git clone https://github.com/ROCm/rocDecode.git
-  cd rocDecode
   mkdir build && cd build
   cmake ../
   make -j8

--- a/projects/rocdecode/docs/install/rocDecode-clone-project.rst
+++ b/projects/rocdecode/docs/install/rocDecode-clone-project.rst
@@ -6,7 +6,7 @@
 Cloning the rocDecode project  
 *********************************
 
-The rocDecode source code is available from the `ROCm systems GitHub repository <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode>`_. Use sparse checkout when cloning the rocJPEG project:
+The rocDecode source code is available from the `ROCm systems GitHub repository <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode>`_. Use sparse checkout when cloning the rocDecode project:
 
 .. code::
 
@@ -17,7 +17,8 @@ The rocDecode source code is available from the `ROCm systems GitHub repository 
 
 Then use ``git checkout`` to check out the branch you need.
 
-The develop branch is intended for users who want to preview new features or contribute to the rocdecode code base.
+The develop branch is intended for users who want to preview new features or contribute to the rocDecode codebase.
 
-If you don't intend to contribute to the rocdecode code base and won't be previewing features, use a branch that matches the version of ROCm installed on your system.
+If you don't intend to contribute to the rocDecode codebase and won't be previewing features, use a branch that matches the version of ROCm installed on your system.
+
 

--- a/projects/rocdecode/docs/install/rocDecode-clone-project.rst
+++ b/projects/rocdecode/docs/install/rocDecode-clone-project.rst
@@ -1,0 +1,23 @@
+.. meta::
+  :description: Clone the rocDecode project  
+  :keywords: install, rocDecode, AMD, ROCm, clone 
+
+*********************************
+Cloning the rocDecode project  
+*********************************
+
+The rocDecode source code is available from the `ROCm systems GitHub repository <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode>`_. Use sparse checkout when cloning the rocJPEG project:
+
+.. code::
+
+  git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-systems.git
+  cd rocm-systems
+  git sparse-checkout init --cone
+  git sparse-checkout set projects/rocdecode
+
+Then use ``git checkout`` to check out the branch you need.
+
+The develop branch is intended for users who want to preview new features or contribute to the rocdecode code base.
+
+If you don't intend to contribute to the rocdecode code base and won't be previewing features, use a branch that matches the version of ROCm installed on your system.
+

--- a/projects/rocdecode/docs/install/rocDecode-prerequisites.rst
+++ b/projects/rocdecode/docs/install/rocDecode-prerequisites.rst
@@ -22,7 +22,7 @@ rocDecode has been tested on the following Linux environments:
 
 See `Supported operating systems <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-operating-systems>`_ for the complete list of ROCm supported Linux environments.
 
-The following prerequisites are installed by the package installer. If you are building and installing using the source code, use the `rocDecode-setup.py <https://github.com/ROCm/rocDecode/blob/develop/rocDecode-setup.py>`_ to install these prerequisites. 
+The following prerequisites are installed by the package installer. If you are building and installing using the source code, use the `rocDecode-setup.py <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/rocDecode-setup.py>`_ to install these prerequisites. 
 
 .. note:: 
 

--- a/projects/rocdecode/docs/reference/rocDecode-core-APIs.rst
+++ b/projects/rocdecode/docs/reference/rocDecode-core-APIs.rst
@@ -8,7 +8,7 @@ The rocDecode core APIs
 
 The rocDecode core APIs are intended for users who want to have full control of the decoding pipeline and interact with the core components instead of the utility classes. The :doc:`Using the rocDecode videodecode sample <../how-to/using-rocDecode-videodecode-sample>` provides an introduction to using the utility classes.
 
-The rocDecode core APIs are exposed in header files in the |apifolder|_ folder of the `rocDecode GitHub repository <https://github.com/ROCm/rocDecode>`_. 
+The rocDecode core APIs are exposed in header files in the |apifolder|_ folder of the `rocDecode project <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode>`_. 
 
 :doc:`The rocDecode parser API <./rocDecode-parser>` is exposed in |rocparser|_. It contains functions that create and destroy the parser, as well as functions that parse the bitstream.
 
@@ -19,19 +19,19 @@ The rocDecode core APIs are exposed in header files in the |apifolder|_ folder o
 :doc:`The bitstream reader API <../how-to/using-rocDecode-bitstream>` is exposed in |bitstreamreader|_. It provides an alternative to the FFMpeg demuxer and contains a simple stream file parser that can read elementary files and IVF container files.
 
 .. |apifolder| replace:: ``api/rocdecode``
-.. _apifolder: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode
+.. _apifolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode
 
 .. |rocparser| replace:: ``api/rocdecode/rocparser.h``
-.. _rocparser: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode/rocparser.h
+.. _rocparser: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode/rocparser.h
 
 .. |rocdecode| replace:: ``api/rocDecode/rocdecode.h``
-.. _rocdecode: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode/rocdecode.h
+.. _rocdecode: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode/rocdecode.h
 
 .. |rocdecodehost| replace:: ``api/rocDecode/rocdecode_host.h``
-.. _rocdecodehost: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode/rocdecode_host.h
+.. _rocdecodehost: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode/rocdecode_host.h
 
 .. |bitstreamreader| replace:: ``api/rocDecode/roc_bitstream_reader.h``
-.. _bitstreamreader: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode/roc_bitstream_reader.h
+.. _bitstreamreader: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode/roc_bitstream_reader.h
 
 .. |utilsfolder| replace:: ``utils`` folder
-.. _utilsfolder: https://github.com/ROCm/rocDecode/tree/develop/utils
+.. _utilsfolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/utils

--- a/projects/rocdecode/docs/reference/rocDecode-hw-decoder.rst
+++ b/projects/rocdecode/docs/reference/rocDecode-hw-decoder.rst
@@ -44,19 +44,19 @@ type is ``OUT_SURFACE_MEM_DEV_COPIED`` or ``OUT_SURFACE_MEM_HOST_COPIED``, the i
 Once decoding is complete, ``rocDecDestroyVideoParser()`` and ``rocDecDestroyDecoder()`` must be called to destroy the parser and the decoding session, and free resources.
 
 .. |apifolder| replace:: ``api/rocdecode``
-.. _apifolder: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode
+.. _apifolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode
 
 .. |rocparser| replace:: ``api/rocdecode/rocparser.h``
-.. _rocparser: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode/rocparser.h
+.. _rocparser: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode/rocparser.h
 
 .. |rocdecode| replace:: ``api/rocDecode/rocdecode.h``
-.. _rocdecode: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode/rocdecode.h
+.. _rocdecode: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode/rocdecode.h
 
 .. |rocdecodehost| replace:: ``api/rocDecode/rocdecode_host.h``
-.. _rocdecodehost: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode/rocdecode_host.h
+.. _rocdecodehost: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode/rocdecode_host.h
 
 .. |bitstreamreader| replace:: ``api/rocDecode/roc_bitstream_reader.h``
-.. _bitstreamreader: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode/roc_bitstream_reader.h
+.. _bitstreamreader: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode/roc_bitstream_reader.h
 
 .. |utilsfolder| replace:: ``utils`` folder
-.. _utilsfolder: https://github.com/ROCm/rocDecode/tree/develop/utils
+.. _utilsfolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/utils

--- a/projects/rocdecode/docs/reference/rocDecode-logging-control.rst
+++ b/projects/rocdecode/docs/reference/rocDecode-logging-control.rst
@@ -32,22 +32,22 @@ or
 
 
 .. |apifolder| replace:: ``api/rocdecode``
-.. _apifolder: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode
+.. _apifolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode
 
 .. |rocparser| replace:: ``api/rocdecode/rocparser.h``
-.. _rocparser: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode/rocparser.h
+.. _rocparser: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode/rocparser.h
 
 .. |rocdecode| replace:: ``api/rocDecode/rocdecode.h``
-.. _rocdecode: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode/rocdecode.h
+.. _rocdecode: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode/rocdecode.h
 
 .. |rocdecodehost| replace:: ``api/rocDecode/rocdecode_host.h``
-.. _rocdecodehost: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode/rocdecode_host.h
+.. _rocdecodehost: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode/rocdecode_host.h
 
 .. |bitstreamreader| replace:: ``api/rocDecode/roc_bitstream_reader.h``
-.. _bitstreamreader: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode/roc_bitstream_reader.h
+.. _bitstreamreader: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode/roc_bitstream_reader.h
 
 .. |utilsfolder| replace:: ``utils`` folder
-.. _utilsfolder: https://github.com/ROCm/rocDecode/tree/develop/utils
+.. _utilsfolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/utils
 
 .. |commons| replace:: ``commons.h``
-.. _commons: https://github.com/ROCm/rocDecode/tree/develop/src/commons.h
+.. _commons: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/src/commons.h

--- a/projects/rocdecode/docs/reference/rocDecode-parser.rst
+++ b/projects/rocdecode/docs/reference/rocDecode-parser.rst
@@ -45,10 +45,10 @@ Once the stream is fully decoded, ``rocDecDestroyVideoParser()`` must be called 
 
 
 .. |rocparser| replace:: ``rocparser.h``
-.. _rocparser: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode/rocparser.h
+.. _rocparser: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode/rocparser.h
 
 .. |utilsfolder| replace:: ``utils`` folder
-.. _utilsfolder: https://github.com/ROCm/rocDecode/tree/develop/utils
+.. _utilsfolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/utils
 
 .. |rocdecdecode| replace:: ``rocdecdecode.cpp``
-.. _rocdecdecode: https://github.com/ROCm/rocDecode/tree/develop/samples/rocdecDecode/rocdecdecode.cpp
+.. _rocdecdecode: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/rocdecDecode/rocdecdecode.cpp

--- a/projects/rocdecode/docs/reference/rocDecode-sw-decoder.rst
+++ b/projects/rocdecode/docs/reference/rocDecode-sw-decoder.rst
@@ -43,19 +43,19 @@ type is ``OUT_SURFACE_MEM_DEV_COPIED`` or ``OUT_SURFACE_MEM_HOST_COPIED``, the i
 Once decoding is complete, ``rocDecDestroyDecoderHost()`` must be called to destroy the decoder and free resources.
 
 .. |apifolder| replace:: ``api/rocdecode``
-.. _apifolder: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode
+.. _apifolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode
 
 .. |rocparser| replace:: ``api/rocdecode/rocparser.h``
-.. _rocparser: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode/rocparser.h
+.. _rocparser: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode/rocparser.h
 
 .. |rocdecode| replace:: ``api/rocDecode/rocdecode.h``
-.. _rocdecode: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode/rocdecode.h
+.. _rocdecode: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode/rocdecode.h
 
 .. |rocdecodehost| replace:: ``api/rocDecode/rocdecode_host.h``
-.. _rocdecodehost: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode/rocdecode_host.h
+.. _rocdecodehost: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode/rocdecode_host.h
 
 .. |bitstreamreader| replace:: ``api/rocDecode/roc_bitstream_reader.h``
-.. _bitstreamreader: https://github.com/ROCm/rocDecode/tree/develop/api/rocdecode/roc_bitstream_reader.h
+.. _bitstreamreader: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/api/rocdecode/roc_bitstream_reader.h
 
 .. |utilsfolder| replace:: ``utils`` folder
-.. _utilsfolder: https://github.com/ROCm/rocDecode/tree/develop/utils
+.. _utilsfolder: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/utils

--- a/projects/rocdecode/docs/sphinx/_toc.yml.in
+++ b/projects/rocdecode/docs/sphinx/_toc.yml.in
@@ -14,7 +14,7 @@ subtrees:
     title: Installing rocDecode with the package installer
   - file: install/rocDecode-build-and-install.rst
     title: Installing rocDecode from its source code
-  - url: https://github.com/ROCm/rocDecode/tree/develop/docker
+  - url: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/docker
     title: rocDecode Docker containers
 
 - caption: Conceptual

--- a/projects/rocdecode/docs/sphinx/_toc.yml.in
+++ b/projects/rocdecode/docs/sphinx/_toc.yml.in
@@ -9,25 +9,27 @@ subtrees:
 - caption: Install
   entries:
   - file: install/rocDecode-prerequisites.rst
-    title: rocDecode prerequisites
+    title: Prerequisites
+  - file: install/rocDecode-clone-project.rst
+    title: Cloning the project
   - file: install/rocDecode-package-install.rst
-    title: Installing rocDecode with the package installer
+    title: Installing with the package installer
   - file: install/rocDecode-build-and-install.rst
-    title: Installing rocDecode from its source code
+    title: Installing from source code
   - url: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/docker
-    title: rocDecode Docker containers
+    title: Docker containers
 
 - caption: Conceptual
   entries:
   - file: conceptual/video-decoding-pipeline.rst
     title: Video decoding pipeline
   - file: conceptual/rocDecode-memory-types.rst
-    title: rocDecode surface memory locations
+    title: Surface memory locations
 
 - caption: Samples
   entries:
   - file: tutorials/rocDecode-samples.rst
-    title: rocDecode samples
+    title: Samples
 
 - caption: How to
   entries:

--- a/projects/rocdecode/docs/tutorials/rocDecode-samples.rst
+++ b/projects/rocdecode/docs/tutorials/rocDecode-samples.rst
@@ -6,7 +6,7 @@
 rocDecode samples
 ********************************************************************
 
-rocDecode samples are available in the `rocDecode GitHub repository <https://github.com/ROCm/rocDecode/tree/develop/samples>`_.
+rocDecode samples are available in the `rocDecode GitHub repository <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples>`_.
 
 You can find a walkthrough of the ``videodecode.cpp`` sample at :doc:`Understanding the videodecode.cpp sample <../how-to/using-rocDecode-videodecode-sample>`.
 


### PR DESCRIPTION
## Motivation

The changelog for 7.2.0 and 7.2.1 needed to be updated because it shows version 1.6.0 for 7.2.0, when the version for 7.2.0 was 1.5.0.

I also added a changelog for 7.2.1 for version 1.7.0 that has as only entry the change in the git repo. I also changed the link to the git repo in the doc landing page.
