### PR TITLE
[rocJPEG] updated 7.2.1 changelog and link to repo

### DIFF
--- a/projects/rocjpeg/CHANGELOG.md
+++ b/projects/rocjpeg/CHANGELOG.md
@@ -3,6 +3,13 @@
 Documentation for rocJPEG is available at
 [https://rocm.docs.amd.com/projects/rocJPEG/en/latest/](https://rocm.docs.amd.com/projects/rocJPEG/en/latest/)
 
+## rocJPEG 1.4.0 for ROCm 7.2.1
+ 
+## Changed
+
+* Bug fixes and performance improvements
+* GitHub repository moved to [https://github.com/ROCm/rocm-systems/tree/develop/projects/rocjpeg](https://github.com/ROCm/rocm-systems/tree/develop/projects/rocjpeg)
+
 ## rocJPEG 1.3.0 for ROCm 7.2.0
 
 ## Changed

--- a/projects/rocjpeg/docs/index.rst
+++ b/projects/rocjpeg/docs/index.rst
@@ -18,6 +18,7 @@ The rocJPEG project is located in https://github.com/ROCm/rocm-systems/tree/deve
   .. grid-item-card:: Install
 
     * :doc:`rocJPEG installation prerequisites <./install/rocjpeg-prerequisites>`
+    * :doc:`Cloning the rocJPEG project <./install/rocjpeg-clone-repo>`
     * :doc:`Installing rocJPEG with the package installer <./install/rocjpeg-package-install>`
     * :doc:`Building rocJPEG from source code <./install/rocjpeg-build-and-install>`
 

--- a/projects/rocjpeg/docs/index.rst
+++ b/projects/rocjpeg/docs/index.rst
@@ -29,7 +29,7 @@ The rocJPEG project is located in https://github.com/ROCm/rocm-systems/tree/deve
 
   .. grid-item-card:: Samples
 
-    * `rocJPEG samples on GitHub <https://github.com/ROCm/rocJPEG/tree/develop/samples>`_
+    * `rocJPEG samples on GitHub <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocjpeg/samples>`_
 
   .. grid-item-card:: Reference
 

--- a/projects/rocjpeg/docs/index.rst
+++ b/projects/rocjpeg/docs/index.rst
@@ -10,7 +10,7 @@ rocJPEG provides APIs and samples that you can use to easily access the JPEG dec
 features of your media engines (VCNs). It also allows interoperability with other compute engines on
 the GPU using Video Acceleration API (VA-API)/HIP. To learn more, see :doc:`what-is-rocJPEG`
 
-The rocJPEG public repository is located at `https://github.com/ROCm/rocJPEG <https://github.com/ROCm/rocJPEG>`_.
+The rocJPEG project is located in https://github.com/ROCm/rocm-systems/tree/develop/projects/rocjpeg.
 
 .. grid:: 2
   :gutter: 3

--- a/projects/rocjpeg/docs/install/rocjpeg-build-and-install.rst
+++ b/projects/rocjpeg/docs/install/rocjpeg-build-and-install.rst
@@ -6,13 +6,19 @@
 Building and installing rocJPEG from source code
 ********************************************************************
 
-These instructions are for building rocJPEG from its source code. If you will not be contributing to the rocJPEG code base or previewing features,  `package installers <https://rocm.docs.amd.com/projects/rocJPEG/en/latest/install/rocjpeg-package-install.html>`_ are available.
+These instructions are for building rocJPEG from its source code. If you will not be contributing to the rocJPEG code base or previewing features, :doc:`package installers <./rocjpeg-package-install.html>`_ are available.
 
 .. note::
 
   ROCm must be installed before installing rocJPEG. See `Quick start installation guide <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html>`_ for detailed ROCm installation instructions.
 
-Use `rocJPEG-setup.py <https://github.com/ROCm/rocJPEG/blob/develop/rocJPEG-setup.py>`_ available from the rocJPEG GitHub repo to install the prerequisites:
+:doc:`Clone the rocJPEG project <./rocjpeg-clone-repo>`. Change directory to ``projects/rocjpeg``:
+
+.. code:: shell
+
+  cd rocm-systems/projects/rocjpeg
+
+Use `rocJPEG-setup.py <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocjpeg/rocJPEG-setup.py>`_ to install prerequisites:
 
 .. code:: shell
 
@@ -22,8 +28,6 @@ Build and install rocJPEG using the following commands:
 
 .. code:: shell
 
-  git clone https://github.com/ROCm/rocJPEG.git
-  cd rocJPEG
   mkdir build && cd build
   cmake ../
   make -j8

--- a/projects/rocjpeg/docs/install/rocjpeg-build-and-install.rst
+++ b/projects/rocjpeg/docs/install/rocjpeg-build-and-install.rst
@@ -6,7 +6,7 @@
 Building and installing rocJPEG from source code
 ********************************************************************
 
-These instructions are for building rocJPEG from its source code. If you will not be contributing to the rocJPEG code base or previewing features, :doc:`package installers <./rocjpeg-package-install.html>`_ are available.
+These instructions are for building rocJPEG from its source code. If you will not be contributing to the rocJPEG code base or previewing features, :doc:`package installers <./rocjpeg-package-install>` are available.
 
 .. note::
 

--- a/projects/rocjpeg/docs/install/rocjpeg-clone-repo.rst
+++ b/projects/rocjpeg/docs/install/rocjpeg-clone-repo.rst
@@ -17,7 +17,8 @@ The rocJPEG source code is available from the `ROCm systems GitHub repository <h
 
 Then use ``git checkout`` to check out the branch you need.
 
-The develop branch is intended for users who want to preview new features or contribute to the rocJPEG code base.
+The develop branch is intended for users who want to preview new features or contribute to the rocJPEG codebase.
 
-If you don't intend to contribute to the rocJPEG code base and won't be previewing features, use a branch that matches the version of ROCm installed on your system.
+If you don't intend to contribute to the rocJPEG codebase and won't be previewing features, use a branch that matches the version of ROCm installed on your system.
+
 

--- a/projects/rocjpeg/docs/install/rocjpeg-clone-repo.rst
+++ b/projects/rocjpeg/docs/install/rocjpeg-clone-repo.rst
@@ -6,7 +6,7 @@
 Cloning the rocJPEG project  
 *********************************
 
-The rocJPEG source code is available from the `ROCm libraries GitHub Repository <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocjpeg>`_. Use sparse checkout when cloning the rocJPEG project:
+The rocJPEG source code is available from the `ROCm systems GitHub repository <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocjpeg>`_. Use sparse checkout when cloning the rocJPEG project:
 
 .. code::
 

--- a/projects/rocjpeg/docs/install/rocjpeg-clone-repo.rst
+++ b/projects/rocjpeg/docs/install/rocjpeg-clone-repo.rst
@@ -1,0 +1,23 @@
+.. meta::
+  :description: rocJPEG installation overview 
+  :keywords: install, rocJPEG, AMD, ROCm, installation, overview, general
+
+*********************************
+Cloning the rocJPEG project  
+*********************************
+
+The rocJPEG source code is available from the `ROCm libraries GitHub Repository <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocjpeg>`_. Use sparse checkout when cloning the rocJPEG project:
+
+.. code::
+
+  git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-systems.git
+  cd rocm-systems
+  git sparse-checkout init --cone
+  git sparse-checkout set projects/rocjpeg
+
+Then use ``git checkout`` to check out the branch you need.
+
+The develop branch is intended for users who want to preview new features or contribute to the rocJPEG code base.
+
+If you don't intend to contribute to the rocJPEG code base and won't be previewing features, use a branch that matches the version of ROCm installed on your system.
+

--- a/projects/rocjpeg/docs/install/rocjpeg-prerequisites.rst
+++ b/projects/rocjpeg/docs/install/rocjpeg-prerequisites.rst
@@ -18,7 +18,7 @@ rocJPEG has been tested on the following Linux environments:
 
 See `Supported operating systems <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-operating-systems>`_ for the complete list of ROCm supported Linux environments.
 
-The following prerequisites are installed by the package installer. If you are building and installing using the source code, use the `rocJPEG-setup.py <https://github.com/ROCm/rocJPEG/blob/develop/rocJPEG-setup.py>`_ setup script available in the rocJPEG GitHub repository to install these prerequisites. 
+The following prerequisites are installed by the package installer. If you are building and installing using the source code, use the `rocJPEG-setup.py <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocjpeg/rocJPEG-setup.py>`_ setup script available in the rocJPEG GitHub repository to install these prerequisites. 
 
 * CMake version 3.10 or later
 * AMD Clang++

--- a/projects/rocjpeg/docs/sphinx/_toc.yml.in
+++ b/projects/rocjpeg/docs/sphinx/_toc.yml.in
@@ -10,6 +10,8 @@ subtrees:
   entries:
   - file: install/rocjpeg-prerequisites.rst
     title: Installation prerequisites
+  - file: install/rocjpeg-clone-repo.rst    
+    title: Cloning the project
   - file: install/rocjpeg-package-install.rst
     title: Installing with the package installer
   - file: install/rocjpeg-build-and-install.rst

--- a/projects/rocjpeg/docs/sphinx/_toc.yml.in
+++ b/projects/rocjpeg/docs/sphinx/_toc.yml.in
@@ -26,7 +26,7 @@ subtrees:
 
 - caption: Samples
   entries:
-  - url: https://github.com/ROCm/rocJPEG/tree/develop/samples
+  - url: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocjpeg/samples
     title: rocJPEG samples on GitHub
 
     


### PR DESCRIPTION
## Motivation

Updated the 7.2.1 changelog with the newest version. Updated link to the repository, including install steps, due to move to monorepo.