### PR TITLE
rocr: Add HSA_AMD_SYSTEM_ASYNC_HANDLER_DESTROY_EVENT system event

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3478,6 +3478,7 @@ hsa_status_t Device::BackendErrorCallBackHandler(const hsa_amd_event_t* event, v
       LogError("GPU Memory Error");
       break;
     case HSA_AMD_SYSTEM_SHUTDOWN_EVENT:
+    case HSA_AMD_SYSTEM_ASYNC_HANDLER_DESTROY_EVENT:
       // This is not a fatal error just ignore it.
       return HSA_STATUS_SUCCESS;
     default:

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -2469,6 +2469,20 @@ void Runtime::Unload() {
   asyncSignals_.reset();
   asyncExceptions_.reset();
 
+  // Notify tools that async handler threads have been destroyed.
+  // System event handlers are still valid here (tool libraries not dlclose'd
+  // until CloseTools() at the end of Unload).
+  {
+    auto system_event_handlers = GetSystemEventHandlers();
+    if (!system_event_handlers.empty()) {
+      hsa_amd_event_t async_destroy_event = {};
+      async_destroy_event.event_type = HSA_AMD_SYSTEM_ASYNC_HANDLER_DESTROY_EVENT;
+      for (auto& callback : system_event_handlers) {
+        callback.first(&async_destroy_event, callback.second);
+      }
+    }
+  }
+
   if (vm_fault_signal_ != nullptr) {
     vm_fault_signal_.reset();
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -2681,6 +2681,14 @@ typedef enum hsa_amd_event_type_s {
     - All other fields in hsa_amd_event_t are unused
    */
   HSA_AMD_SYSTEM_SHUTDOWN_EVENT,
+  /*
+   Async event handler threads have been destroyed.
+   Fired after asyncSignals and asyncExceptions threads are torn down
+   during runtime shutdown. Tools should use this event to detect that
+   async signal/exception handlers (e.g., PC sampling) are no longer operational.
+    - All other fields in hsa_amd_event_t are unused
+   */
+  HSA_AMD_SYSTEM_ASYNC_HANDLER_DESTROY_EVENT,
 } hsa_amd_event_type_t;
 
 /**


### PR DESCRIPTION
## Summary

Add a new system event type `HSA_AMD_SYSTEM_ASYNC_HANDLER_DESTROY_EVENT` that fires after the async event handler threads (`asyncSignals_` and `asyncExceptions_`) are destroyed during runtime shutdown. This allows profiling tools to detect when async signal/exception handlers are no longer operational.

## Changes

### Public API
- `runtime/hsa-runtime/inc/hsa_ext_amd.h` - Added `HSA_AMD_SYSTEM_ASYNC_HANDLER_DESTROY_EVENT` to the `hsa_amd_event_type_t` enum after `HSA_AMD_SYSTEM_SHUTDOWN_EVENT`

### Runtime Implementation
- `runtime/hsa-runtime/core/runtime/runtime.cpp` - Fire the new event in `Runtime::Unload()` immediately after `asyncSignals_.reset()` and `asyncExceptions_.reset()`, using the same pattern as `HSA_AMD_SYSTEM_SHUTDOWN_EVENT` in `Runtime::Release()`

## Motivation

During runtime shutdown, tools like rocprofiler-sdk register async signal handlers (via `hsa_amd_signal_async_handler`) for kernel dispatch completion tracking, async memory copy tracing, device counter collection, and PC sampling data delivery. These handlers are serviced by the async event handler threads.

Currently there is no notification when these threads are destroyed. The existing `HSA_AMD_SYSTEM_SHUTDOWN_EVENT` fires in `Release()` before `Unload()` begins, which is too early — the async threads are still alive at that point. This new event fires after the threads have been joined and cleaned up, giving tools a precise signal that the async handler infrastructure is gone.

The event fires between `UnloadTools()` (line 2458) and `CloseTools()` (line 2495) in `Unload()`, so system event handler callback pointers are still valid (tool libraries have not been dlclose'd yet).

## Design Notes

- **ABI safe**: Enum value appended at end, no struct size changes
- **Backward compatible**: Old tools ignore unknown event types via default switch case
- **Zero overhead**: Just an `.empty()` check when no handler is registered
- **Follows existing pattern**: Uses identical code structure as `HSA_AMD_SYSTEM_SHUTDOWN_EVENT` firing in `Release()`

## Testing

- Smoke test with a C program that registers a system event handler and verifies both `HSA_AMD_SYSTEM_SHUTDOWN_EVENT` and `HSA_AMD_SYSTEM_ASYNC_HANDLER_DESTROY_EVENT` fire in the correct order during `hsa_shut_down()`