### PR TITLE
[do not review] [rocprofiler-sdk] Add unified async wait manager with shutdown awareness

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
@@ -29,6 +29,7 @@
 #include "lib/rocprofiler-sdk/counters/core.hpp"
 #include "lib/rocprofiler-sdk/counters/id_decode.hpp"
 #include "lib/rocprofiler-sdk/hsa/agent_cache.hpp"
+#include "lib/rocprofiler-sdk/hsa/async_wait_manager.hpp"
 #include "lib/rocprofiler-sdk/hsa/details/fmt.hpp"
 #include "lib/rocprofiler-sdk/hsa/hsa.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
@@ -264,11 +265,12 @@ init_callback_data(rocprofiler::counters::agent_callback_data& callback_data,
             submitPacket(callback_data.queue, (void*) &pkt);
             constexpr auto timeout_hint =
                 std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::seconds{1});
-            if(hsa::get_core_table()->hsa_signal_wait_relaxed_fn(callback_data.completion,
-                                                                 HSA_SIGNAL_CONDITION_EQ,
-                                                                 0,
-                                                                 timeout_hint.count(),
-                                                                 HSA_WAIT_STATE_ACTIVE) != 0)
+            auto result = hsa::wait_or_shutdown(callback_data.completion,
+                                                HSA_SIGNAL_CONDITION_EQ,
+                                                0,
+                                                "device_counting::init_callback_data()",
+                                                timeout_hint.count());
+            if(result != hsa::wait_result::completed)
             {
                 ROCP_FATAL << "Could not set agent to be profiled";
             }
@@ -320,11 +322,10 @@ read_agent_ctx(const context::context*                    ctx,
             if((flags & ROCPROFILER_COUNTER_FLAG_ASYNC) == 0)
             {
                 // Wait for any inprogress samples to complete before returning
-                hsa::get_core_table()->hsa_signal_wait_relaxed_fn(callback_data.completion,
-                                                                  HSA_SIGNAL_CONDITION_EQ,
-                                                                  1,
-                                                                  UINT64_MAX,
-                                                                  HSA_WAIT_STATE_ACTIVE);
+                hsa::wait_or_shutdown(callback_data.completion,
+                                      HSA_SIGNAL_CONDITION_EQ,
+                                      1,
+                                      "device_counting::read_agent_ctx()");
             }
         };
 
@@ -510,11 +511,10 @@ start_agent_ctx(const context::context* ctx)
         submitPacket(agent->profile_queue(), &callback_data.packet->packets.start_packet);
 
         // Wait for startup to finish before continuing
-        hsa::get_core_table()->hsa_signal_wait_relaxed_fn(callback_data.start_signal,
-                                                          HSA_SIGNAL_CONDITION_EQ,
-                                                          0,
-                                                          UINT64_MAX,
-                                                          HSA_WAIT_STATE_ACTIVE);
+        hsa::wait_or_shutdown(callback_data.start_signal,
+                              HSA_SIGNAL_CONDITION_EQ,
+                              0,
+                              "device_counting::start_agent_ctx()");
     }
 
     agent_ctx.status.exchange(rocprofiler::context::device_counting_service::state::ENABLED);
@@ -566,11 +566,10 @@ stop_agent_ctx(const context::context* ctx)
         }
 
         // Wait for the stop packet to complete
-        hsa::get_core_table()->hsa_signal_wait_relaxed_fn(callback_data.completion,
-                                                          HSA_SIGNAL_CONDITION_EQ,
-                                                          1,
-                                                          UINT64_MAX,
-                                                          HSA_WAIT_STATE_ACTIVE);
+        hsa::wait_or_shutdown(callback_data.completion,
+                              HSA_SIGNAL_CONDITION_EQ,
+                              1,
+                              "device_counting::stop_agent_ctx()");
     }
 
     agent_ctx.status.exchange(rocprofiler::context::device_counting_service::state::DISABLED);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/core.cpp
@@ -478,7 +478,7 @@ TEST(core, check_callbacks)
     }
     registration::set_init_status(1);
 
-    registration::finalize();
+    registration::finalize(registration::finalize_mode::tool_induced);
 }
 
 TEST(core, destroy_counter_profile)
@@ -516,7 +516,7 @@ TEST(core, destroy_counter_profile)
     }
     registration::set_init_status(1);
 
-    registration::finalize();
+    registration::finalize(registration::finalize_mode::tool_induced);
 }
 
 TEST(core, start_stop_buffered_ctx)
@@ -586,7 +586,7 @@ TEST(core, start_stop_buffered_ctx)
 
     registration::set_init_status(1);
 
-    registration::finalize();
+    registration::finalize(registration::finalize_mode::tool_induced);
 }
 
 TEST(core, start_stop_callback_ctx)
@@ -709,7 +709,7 @@ TEST(core, test_profile_incremental)
 
     registration::set_init_status(1);
 
-    registration::finalize();
+    registration::finalize(registration::finalize_mode::tool_induced);
 }
 
 TEST(core, public_api_iterate_agents)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/device_counting.cpp
@@ -639,7 +639,7 @@ protected:
         CHECK(test_ran);
 
         registration::set_init_status(1);
-        registration::finalize();
+        registration::finalize(registration::finalize_mode::tool_induced);
     }
 };
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/CMakeLists.txt
@@ -4,6 +4,7 @@ set(ROCPROFILER_LIB_HSA_SOURCES
     agent_cache.cpp
     aql_packet.cpp
     async_copy.cpp
+    async_wait_manager.cpp
     hsa_barrier.cpp
     hsa.cpp
     memory_allocation.cpp
@@ -17,6 +18,7 @@ set(ROCPROFILER_LIB_HSA_HEADERS
     agent_cache.hpp
     aql_packet.hpp
     async_copy.hpp
+    async_wait_manager.hpp
     memory_allocation.hpp
     defines.hpp
     hsa_barrier.hpp

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_copy.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_copy.cpp
@@ -29,6 +29,7 @@
 #include "lib/common/utility.hpp"
 #include "lib/rocprofiler-sdk/agent.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
+#include "lib/rocprofiler-sdk/hsa/async_wait_manager.hpp"
 #include "lib/rocprofiler-sdk/hsa/hsa.hpp"
 #include "lib/rocprofiler-sdk/registration.hpp"
 #include "lib/rocprofiler-sdk/tracing/fwd.hpp"
@@ -282,11 +283,11 @@ active_signals::sync()
 
     if(m_count.load() > 0)
     {
-        auto _cnt_beg      = m_count.load();
-        auto _signal_value = get_core_table()->hsa_signal_wait_scacquire_fn(
-            m_signal, HSA_SIGNAL_CONDITION_LT, 1, timeout, HSA_WAIT_STATE_ACTIVE);
+        auto _cnt_beg = m_count.load();
+        auto result   = wait_or_shutdown(
+            m_signal, HSA_SIGNAL_CONDITION_LT, 1, "async_copy::active_signals::sync()", timeout);
         auto _cnt_end = m_count.load();
-        if(_signal_value != 0)
+        if(result != wait_result::completed)
         {
             ROCP_CI_LOG_IF(WARNING, _cnt_end > 0)
                 << "rocprofiler-sdk timed out after " << timeout_sec.count()

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_wait_manager.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_wait_manager.cpp
@@ -114,9 +114,9 @@ wait_or_shutdown(hsa_signal_t           signal,
                  uint64_t               poll_interval_ns,
                  const CoreApiTable*    core_api)
 {
-    auto& mgr          = async_wait_manager::instance();
-    auto* resolved_api = (core_api != nullptr) ? core_api : get_core_table();
-    auto  start        = std::chrono::steady_clock::now();
+    auto&       mgr          = async_wait_manager::instance();
+    const auto* resolved_api = (core_api != nullptr) ? core_api : get_core_table();
+    auto        start        = std::chrono::steady_clock::now();
 
     while(!mgr.is_shutdown())
     {
@@ -151,7 +151,7 @@ wait_or_shutdown(hsa_signal_t           signal,
 wait_result
 wait_or_shutdown(std::condition_variable&      cv,
                  std::unique_lock<std::mutex>& lock,
-                 std::function<bool()>         predicate,
+                 const std::function<bool()>&  predicate,
                  std::string_view              callsite,
                  uint64_t                      timeout_ns,
                  std::chrono::milliseconds     interval)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_wait_manager.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_wait_manager.cpp
@@ -34,6 +34,10 @@ namespace hsa
 {
 namespace
 {
+std::atomic<bool>     s_initialized{false};
+std::function<void()> s_shutdown_callback = nullptr;
+std::mutex            s_callback_mutex;
+
 class async_wait_manager
 {
 public:
@@ -51,15 +55,26 @@ private:
     std::atomic<bool> _shutdown{false};
 };
 
+#ifdef HSA_AMD_SYSTEM_ASYNC_HANDLER_DESTROY_EVENT
 hsa_status_t
 system_event_handler(const hsa_amd_event_t* event, void* /*data*/)
 {
     if(event && event->event_type == HSA_AMD_SYSTEM_ASYNC_HANDLER_DESTROY_EVENT)
     {
         async_wait_manager::instance().notify_shutdown();
+
+        // Invoke deferred finalization callback if registered
+        std::function<void()> cb;
+        {
+            std::lock_guard<std::mutex> lock(s_callback_mutex);
+            cb                  = std::move(s_shutdown_callback);
+            s_shutdown_callback = nullptr;
+        }
+        if(cb) cb();
     }
     return HSA_STATUS_SUCCESS;
 }
+#endif
 
 bool
 signal_condition_satisfied(hsa_signal_condition_t cond,
@@ -80,11 +95,16 @@ signal_condition_satisfied(hsa_signal_condition_t cond,
 void
 async_wait_manager_init()
 {
+    async_wait_manager::instance().reset();
+    s_initialized.store(true, std::memory_order_release);
+
+#ifdef HSA_AMD_SYSTEM_ASYNC_HANDLER_DESTROY_EVENT
     auto* ext_table = get_amd_ext_table();
     if(ext_table && ext_table->hsa_amd_register_system_event_handler_fn)
     {
         ext_table->hsa_amd_register_system_event_handler_fn(system_event_handler, nullptr);
     }
+#endif
 }
 
 void
@@ -103,6 +123,19 @@ bool
 is_async_shutdown()
 {
     return async_wait_manager::instance().is_shutdown();
+}
+
+bool
+is_async_wait_initialized()
+{
+    return s_initialized.load(std::memory_order_acquire);
+}
+
+void
+register_shutdown_callback(shutdown_callback_t callback)
+{
+    std::lock_guard<std::mutex> lock(s_callback_mutex);
+    s_shutdown_callback = std::move(callback);
 }
 
 wait_result

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_wait_manager.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_wait_manager.cpp
@@ -26,37 +26,31 @@
 
 #include <hsa/hsa_ext_amd.h>
 
+#include <thread>
+
 namespace rocprofiler
 {
 namespace hsa
 {
-async_wait_manager&
-async_wait_manager::instance()
-{
-    static async_wait_manager mgr;
-    return mgr;
-}
-
-bool
-async_wait_manager::is_shutdown() const
-{
-    return _shutdown.load(std::memory_order_acquire);
-}
-
-void
-async_wait_manager::notify_shutdown()
-{
-    _shutdown.store(true, std::memory_order_release);
-}
-
-void
-async_wait_manager::reset()
-{
-    _shutdown.store(false, std::memory_order_release);
-}
-
 namespace
 {
+class async_wait_manager
+{
+public:
+    static async_wait_manager& instance()
+    {
+        static async_wait_manager mgr;
+        return mgr;
+    }
+
+    bool is_shutdown() const { return _shutdown.load(std::memory_order_acquire); }
+    void notify_shutdown() { _shutdown.store(true, std::memory_order_release); }
+    void reset() { _shutdown.store(false, std::memory_order_release); }
+
+private:
+    std::atomic<bool> _shutdown{false};
+};
+
 hsa_status_t
 system_event_handler(const hsa_amd_event_t* event, void* /*data*/)
 {
@@ -66,20 +60,7 @@ system_event_handler(const hsa_amd_event_t* event, void* /*data*/)
     }
     return HSA_STATUS_SUCCESS;
 }
-}  // namespace
 
-void
-async_wait_manager_init()
-{
-    auto* ext_table = get_amd_ext_table();
-    if(ext_table && ext_table->hsa_amd_register_system_event_handler_fn)
-    {
-        ext_table->hsa_amd_register_system_event_handler_fn(system_event_handler, nullptr);
-    }
-}
-
-namespace
-{
 bool
 signal_condition_satisfied(hsa_signal_condition_t cond,
                            hsa_signal_value_t     result,
@@ -96,11 +77,39 @@ signal_condition_satisfied(hsa_signal_condition_t cond,
 }
 }  // namespace
 
+void
+async_wait_manager_init()
+{
+    auto* ext_table = get_amd_ext_table();
+    if(ext_table && ext_table->hsa_amd_register_system_event_handler_fn)
+    {
+        ext_table->hsa_amd_register_system_event_handler_fn(system_event_handler, nullptr);
+    }
+}
+
+void
+notify_async_shutdown()
+{
+    async_wait_manager::instance().notify_shutdown();
+}
+
+void
+reset_async_shutdown()
+{
+    async_wait_manager::instance().reset();
+}
+
+bool
+is_async_shutdown()
+{
+    return async_wait_manager::instance().is_shutdown();
+}
+
 wait_result
 wait_or_shutdown(hsa_signal_t           signal,
                  hsa_signal_condition_t cond,
                  hsa_signal_value_t     value,
-                 const std::string&     callsite,
+                 std::string_view       callsite,
                  uint64_t               timeout_ns,
                  uint64_t               poll_interval_ns,
                  const CoreApiTable*    core_api)
@@ -143,7 +152,7 @@ wait_result
 wait_or_shutdown(std::condition_variable&      cv,
                  std::unique_lock<std::mutex>& lock,
                  std::function<bool()>         predicate,
-                 const std::string&            callsite,
+                 std::string_view              callsite,
                  uint64_t                      timeout_ns,
                  std::chrono::milliseconds     interval)
 {
@@ -168,6 +177,38 @@ wait_or_shutdown(std::condition_variable&      cv,
     }
     return wait_result::completed;
 }
+
+template <typename T>
+wait_result
+wait_or_shutdown(std::atomic<T>&  atomic_val,
+                 T                expected,
+                 std::string_view callsite,
+                 uint64_t         timeout_ns)
+{
+    auto& mgr   = async_wait_manager::instance();
+    auto  start = std::chrono::steady_clock::now();
+
+    while(atomic_val.load(std::memory_order_acquire) != expected)
+    {
+        if(mgr.is_shutdown())
+        {
+            ROCP_WARNING << "atomic wait interrupted by HSA async handler shutdown at " << callsite;
+            return wait_result::shutdown;
+        }
+        auto now     = std::chrono::steady_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(now - start).count();
+        if(timeout_ns != UINT64_MAX && static_cast<uint64_t>(elapsed) >= timeout_ns)
+        {
+            ROCP_ERROR << "atomic wait timed out at " << callsite;
+            return wait_result::timeout;
+        }
+        std::this_thread::yield();
+    }
+    return wait_result::completed;
+}
+
+template wait_result
+wait_or_shutdown(std::atomic<int>&, int, std::string_view, uint64_t);
 
 }  // namespace hsa
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_wait_manager.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_wait_manager.cpp
@@ -1,0 +1,173 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "lib/rocprofiler-sdk/hsa/async_wait_manager.hpp"
+#include "lib/common/logging.hpp"
+#include "lib/rocprofiler-sdk/hsa/hsa.hpp"
+
+#include <hsa/hsa_ext_amd.h>
+
+namespace rocprofiler
+{
+namespace hsa
+{
+async_wait_manager&
+async_wait_manager::instance()
+{
+    static async_wait_manager mgr;
+    return mgr;
+}
+
+bool
+async_wait_manager::is_shutdown() const
+{
+    return _shutdown.load(std::memory_order_acquire);
+}
+
+void
+async_wait_manager::notify_shutdown()
+{
+    _shutdown.store(true, std::memory_order_release);
+}
+
+void
+async_wait_manager::reset()
+{
+    _shutdown.store(false, std::memory_order_release);
+}
+
+namespace
+{
+hsa_status_t
+system_event_handler(const hsa_amd_event_t* event, void* /*data*/)
+{
+    if(event && event->event_type == HSA_AMD_SYSTEM_ASYNC_HANDLER_DESTROY_EVENT)
+    {
+        async_wait_manager::instance().notify_shutdown();
+    }
+    return HSA_STATUS_SUCCESS;
+}
+}  // namespace
+
+void
+async_wait_manager_init()
+{
+    auto* ext_table = get_amd_ext_table();
+    if(ext_table && ext_table->hsa_amd_register_system_event_handler_fn)
+    {
+        ext_table->hsa_amd_register_system_event_handler_fn(system_event_handler, nullptr);
+    }
+}
+
+namespace
+{
+bool
+signal_condition_satisfied(hsa_signal_condition_t cond,
+                           hsa_signal_value_t     result,
+                           hsa_signal_value_t     value)
+{
+    switch(cond)
+    {
+        case HSA_SIGNAL_CONDITION_EQ: return (result == value);
+        case HSA_SIGNAL_CONDITION_NE: return (result != value);
+        case HSA_SIGNAL_CONDITION_LT: return (result < value);
+        case HSA_SIGNAL_CONDITION_GTE: return (result >= value);
+    }
+    return false;
+}
+}  // namespace
+
+wait_result
+wait_or_shutdown(hsa_signal_t           signal,
+                 hsa_signal_condition_t cond,
+                 hsa_signal_value_t     value,
+                 const std::string&     callsite,
+                 uint64_t               timeout_ns,
+                 uint64_t               poll_interval_ns,
+                 const CoreApiTable*    core_api)
+{
+    auto& mgr          = async_wait_manager::instance();
+    auto* resolved_api = (core_api != nullptr) ? core_api : get_core_table();
+    auto  start        = std::chrono::steady_clock::now();
+
+    while(!mgr.is_shutdown())
+    {
+        auto remaining_ns = timeout_ns;
+        if(timeout_ns != UINT64_MAX)
+        {
+            auto now        = std::chrono::steady_clock::now();
+            auto elapsed_ns = static_cast<uint64_t>(
+                std::chrono::duration_cast<std::chrono::nanoseconds>(now - start).count());
+            if(elapsed_ns >= timeout_ns)
+            {
+                ROCP_ERROR << "signal wait timed out at " << callsite;
+                return wait_result::timeout;
+            }
+            remaining_ns = timeout_ns - elapsed_ns;
+        }
+
+        auto interval = std::min(poll_interval_ns, remaining_ns);
+        auto result   = resolved_api->hsa_signal_wait_relaxed_fn(
+            signal, cond, value, interval, HSA_WAIT_STATE_BLOCKED);
+
+        if(signal_condition_satisfied(cond, result, value))
+        {
+            return wait_result::completed;
+        }
+    }
+
+    ROCP_WARNING << "signal wait interrupted by HSA async handler shutdown at " << callsite;
+    return wait_result::shutdown;
+}
+
+wait_result
+wait_or_shutdown(std::condition_variable&      cv,
+                 std::unique_lock<std::mutex>& lock,
+                 std::function<bool()>         predicate,
+                 const std::string&            callsite,
+                 uint64_t                      timeout_ns,
+                 std::chrono::milliseconds     interval)
+{
+    auto& mgr   = async_wait_manager::instance();
+    auto  start = std::chrono::steady_clock::now();
+
+    while(!predicate())
+    {
+        if(mgr.is_shutdown())
+        {
+            ROCP_WARNING << "cv wait interrupted by HSA async handler shutdown at " << callsite;
+            return wait_result::shutdown;
+        }
+        auto now     = std::chrono::steady_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(now - start).count();
+        if(timeout_ns != UINT64_MAX && static_cast<uint64_t>(elapsed) >= timeout_ns)
+        {
+            ROCP_ERROR << "cv wait timed out at " << callsite;
+            return wait_result::timeout;
+        }
+        cv.wait_for(lock, interval);
+    }
+    return wait_result::completed;
+}
+
+}  // namespace hsa
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_wait_manager.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_wait_manager.cpp
@@ -26,6 +26,7 @@
 
 #include <hsa/hsa_ext_amd.h>
 
+#include <optional>
 #include <thread>
 
 namespace rocprofiler
@@ -90,6 +91,34 @@ signal_condition_satisfied(hsa_signal_condition_t cond,
     }
     return false;
 }
+
+/// Returns shutdown or timeout if applicable, otherwise nullopt to continue polling.
+std::optional<wait_result>
+check_shutdown_or_timeout(std::string_view                      callsite,
+                          uint64_t                              timeout_ns,
+                          std::chrono::steady_clock::time_point start)
+{
+    if(async_wait_manager::instance().is_shutdown())
+    {
+        ROCP_WARNING << "wait interrupted by HSA async handler shutdown at " << callsite;
+        return wait_result::shutdown;
+    }
+
+    if(timeout_ns != UINT64_MAX)
+    {
+        auto elapsed_ns =
+            static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                      std::chrono::steady_clock::now() - start)
+                                      .count());
+        if(elapsed_ns >= timeout_ns)
+        {
+            ROCP_ERROR << "wait timed out at " << callsite;
+            return wait_result::timeout;
+        }
+    }
+
+    return std::nullopt;
+}
 }  // namespace
 
 void
@@ -147,23 +176,20 @@ wait_or_shutdown(hsa_signal_t           signal,
                  uint64_t               poll_interval_ns,
                  const CoreApiTable*    core_api)
 {
-    auto&       mgr          = async_wait_manager::instance();
     const auto* resolved_api = (core_api != nullptr) ? core_api : get_core_table();
     auto        start        = std::chrono::steady_clock::now();
 
-    while(!mgr.is_shutdown())
+    while(true)
     {
+        if(auto r = check_shutdown_or_timeout(callsite, timeout_ns, start)) return *r;
+
         auto remaining_ns = timeout_ns;
         if(timeout_ns != UINT64_MAX)
         {
-            auto now        = std::chrono::steady_clock::now();
-            auto elapsed_ns = static_cast<uint64_t>(
-                std::chrono::duration_cast<std::chrono::nanoseconds>(now - start).count());
-            if(elapsed_ns >= timeout_ns)
-            {
-                ROCP_ERROR << "signal wait timed out at " << callsite;
-                return wait_result::timeout;
-            }
+            auto elapsed_ns =
+                static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                          std::chrono::steady_clock::now() - start)
+                                          .count());
             remaining_ns = timeout_ns - elapsed_ns;
         }
 
@@ -171,14 +197,8 @@ wait_or_shutdown(hsa_signal_t           signal,
         auto result   = resolved_api->hsa_signal_wait_relaxed_fn(
             signal, cond, value, interval, HSA_WAIT_STATE_BLOCKED);
 
-        if(signal_condition_satisfied(cond, result, value))
-        {
-            return wait_result::completed;
-        }
+        if(signal_condition_satisfied(cond, result, value)) return wait_result::completed;
     }
-
-    ROCP_WARNING << "signal wait interrupted by HSA async handler shutdown at " << callsite;
-    return wait_result::shutdown;
 }
 
 wait_result
@@ -189,23 +209,11 @@ wait_or_shutdown(std::condition_variable&      cv,
                  uint64_t                      timeout_ns,
                  std::chrono::milliseconds     interval)
 {
-    auto& mgr   = async_wait_manager::instance();
-    auto  start = std::chrono::steady_clock::now();
+    auto start = std::chrono::steady_clock::now();
 
     while(!predicate())
     {
-        if(mgr.is_shutdown())
-        {
-            ROCP_WARNING << "cv wait interrupted by HSA async handler shutdown at " << callsite;
-            return wait_result::shutdown;
-        }
-        auto now     = std::chrono::steady_clock::now();
-        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(now - start).count();
-        if(timeout_ns != UINT64_MAX && static_cast<uint64_t>(elapsed) >= timeout_ns)
-        {
-            ROCP_ERROR << "cv wait timed out at " << callsite;
-            return wait_result::timeout;
-        }
+        if(auto r = check_shutdown_or_timeout(callsite, timeout_ns, start)) return *r;
         cv.wait_for(lock, interval);
     }
     return wait_result::completed;
@@ -218,23 +226,11 @@ wait_or_shutdown(std::atomic<T>&  atomic_val,
                  std::string_view callsite,
                  uint64_t         timeout_ns)
 {
-    auto& mgr   = async_wait_manager::instance();
-    auto  start = std::chrono::steady_clock::now();
+    auto start = std::chrono::steady_clock::now();
 
     while(atomic_val.load(std::memory_order_acquire) != expected)
     {
-        if(mgr.is_shutdown())
-        {
-            ROCP_WARNING << "atomic wait interrupted by HSA async handler shutdown at " << callsite;
-            return wait_result::shutdown;
-        }
-        auto now     = std::chrono::steady_clock::now();
-        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(now - start).count();
-        if(timeout_ns != UINT64_MAX && static_cast<uint64_t>(elapsed) >= timeout_ns)
-        {
-            ROCP_ERROR << "atomic wait timed out at " << callsite;
-            return wait_result::timeout;
-        }
+        if(auto r = check_shutdown_or_timeout(callsite, timeout_ns, start)) return *r;
         std::this_thread::yield();
     }
     return wait_result::completed;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_wait_manager.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_wait_manager.hpp
@@ -76,7 +76,7 @@ wait_or_shutdown(hsa_signal_t           signal,
 wait_result
 wait_or_shutdown(std::condition_variable&      cv,
                  std::unique_lock<std::mutex>& lock,
-                 std::function<bool()>         predicate,
+                 const std::function<bool()>&  predicate,
                  std::string_view              callsite,
                  uint64_t                      timeout_ns = UINT64_MAX,
                  std::chrono::milliseconds     interval   = std::chrono::milliseconds{100});

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_wait_manager.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_wait_manager.hpp
@@ -57,9 +57,22 @@ notify_async_shutdown();
 void
 reset_async_shutdown();
 
-/// Check if the async handler has been destroyed (for testing).
+/// Check if the async handler has been destroyed.
 bool
 is_async_shutdown();
+
+/// Check if async_wait_manager_init() has been called (i.e. HSA was loaded).
+bool
+is_async_wait_initialized();
+
+/// Register a callback to be invoked when HSA async handler shutdown is detected.
+/// Used for deferred finalization: if finalize() is called before HSA shuts down,
+/// it registers a callback here and returns. When the event fires, the callback
+/// triggers finalization at the right time.
+using shutdown_callback_t = std::function<void()>;
+
+void
+register_shutdown_callback(shutdown_callback_t callback);
 
 /// HSA signal wait with shutdown awareness. Polls the signal at poll_interval_ns intervals
 /// and checks the shutdown flag between polls.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_wait_manager.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_wait_manager.hpp
@@ -1,0 +1,119 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "lib/common/logging.hpp"
+
+#include <hsa/hsa.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+
+struct CoreApiTable;
+
+namespace rocprofiler
+{
+namespace hsa
+{
+enum class wait_result
+{
+    completed,
+    shutdown,
+    timeout
+};
+
+class async_wait_manager
+{
+public:
+    static async_wait_manager& instance();
+
+    bool is_shutdown() const;
+    void notify_shutdown();
+    void reset();
+
+private:
+    std::atomic<bool> _shutdown{false};
+};
+
+/// Register for HSA_AMD_SYSTEM_ASYNC_HANDLER_DESTROY_EVENT via the internal AMD ext table.
+void
+async_wait_manager_init();
+
+/// HSA signal wait with shutdown awareness. Polls the signal at poll_interval_ns intervals
+/// and checks the shutdown flag between polls.
+wait_result
+wait_or_shutdown(hsa_signal_t           signal,
+                 hsa_signal_condition_t cond,
+                 hsa_signal_value_t     value,
+                 const std::string&     callsite,
+                 uint64_t               timeout_ns       = UINT64_MAX,
+                 uint64_t               poll_interval_ns = 100000000ULL,
+                 const CoreApiTable*    core_api         = nullptr);
+
+/// Condition variable wait with shutdown awareness.
+wait_result
+wait_or_shutdown(std::condition_variable&      cv,
+                 std::unique_lock<std::mutex>& lock,
+                 std::function<bool()>         predicate,
+                 const std::string&            callsite,
+                 uint64_t                      timeout_ns = UINT64_MAX,
+                 std::chrono::milliseconds     interval   = std::chrono::milliseconds{100});
+
+/// Atomic wait with shutdown awareness. Polls the atomic value and yields between checks.
+template <typename T>
+wait_result
+wait_or_shutdown(std::atomic<T>&    atomic_val,
+                 T                  expected,
+                 const std::string& callsite,
+                 uint64_t           timeout_ns = UINT64_MAX)
+{
+    auto& mgr   = async_wait_manager::instance();
+    auto  start = std::chrono::steady_clock::now();
+
+    while(atomic_val.load(std::memory_order_acquire) != expected)
+    {
+        if(mgr.is_shutdown())
+        {
+            ROCP_WARNING << "atomic wait interrupted by HSA async handler shutdown at " << callsite;
+            return wait_result::shutdown;
+        }
+        auto now     = std::chrono::steady_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(now - start).count();
+        if(timeout_ns != UINT64_MAX && static_cast<uint64_t>(elapsed) >= timeout_ns)
+        {
+            ROCP_ERROR << "atomic wait timed out at " << callsite;
+            return wait_result::timeout;
+        }
+        std::this_thread::yield();
+    }
+    return wait_result::completed;
+}
+
+}  // namespace hsa
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_wait_manager.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/async_wait_manager.hpp
@@ -22,8 +22,6 @@
 
 #pragma once
 
-#include "lib/common/logging.hpp"
-
 #include <hsa/hsa.h>
 
 #include <atomic>
@@ -32,8 +30,7 @@
 #include <cstdint>
 #include <functional>
 #include <mutex>
-#include <string>
-#include <thread>
+#include <string_view>
 
 struct CoreApiTable;
 
@@ -48,22 +45,21 @@ enum class wait_result
     timeout
 };
 
-class async_wait_manager
-{
-public:
-    static async_wait_manager& instance();
-
-    bool is_shutdown() const;
-    void notify_shutdown();
-    void reset();
-
-private:
-    std::atomic<bool> _shutdown{false};
-};
-
 /// Register for HSA_AMD_SYSTEM_ASYNC_HANDLER_DESTROY_EVENT via the internal AMD ext table.
 void
 async_wait_manager_init();
+
+/// Notify that the async handler has been destroyed (for testing).
+void
+notify_async_shutdown();
+
+/// Reset the async shutdown flag (for testing).
+void
+reset_async_shutdown();
+
+/// Check if the async handler has been destroyed (for testing).
+bool
+is_async_shutdown();
 
 /// HSA signal wait with shutdown awareness. Polls the signal at poll_interval_ns intervals
 /// and checks the shutdown flag between polls.
@@ -71,7 +67,7 @@ wait_result
 wait_or_shutdown(hsa_signal_t           signal,
                  hsa_signal_condition_t cond,
                  hsa_signal_value_t     value,
-                 const std::string&     callsite,
+                 std::string_view       callsite,
                  uint64_t               timeout_ns       = UINT64_MAX,
                  uint64_t               poll_interval_ns = 100000000ULL,
                  const CoreApiTable*    core_api         = nullptr);
@@ -81,39 +77,17 @@ wait_result
 wait_or_shutdown(std::condition_variable&      cv,
                  std::unique_lock<std::mutex>& lock,
                  std::function<bool()>         predicate,
-                 const std::string&            callsite,
+                 std::string_view              callsite,
                  uint64_t                      timeout_ns = UINT64_MAX,
                  std::chrono::milliseconds     interval   = std::chrono::milliseconds{100});
 
 /// Atomic wait with shutdown awareness. Polls the atomic value and yields between checks.
 template <typename T>
 wait_result
-wait_or_shutdown(std::atomic<T>&    atomic_val,
-                 T                  expected,
-                 const std::string& callsite,
-                 uint64_t           timeout_ns = UINT64_MAX)
-{
-    auto& mgr   = async_wait_manager::instance();
-    auto  start = std::chrono::steady_clock::now();
-
-    while(atomic_val.load(std::memory_order_acquire) != expected)
-    {
-        if(mgr.is_shutdown())
-        {
-            ROCP_WARNING << "atomic wait interrupted by HSA async handler shutdown at " << callsite;
-            return wait_result::shutdown;
-        }
-        auto now     = std::chrono::steady_clock::now();
-        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(now - start).count();
-        if(timeout_ns != UINT64_MAX && static_cast<uint64_t>(elapsed) >= timeout_ns)
-        {
-            ROCP_ERROR << "atomic wait timed out at " << callsite;
-            return wait_result::timeout;
-        }
-        std::this_thread::yield();
-    }
-    return wait_result::completed;
-}
+wait_or_shutdown(std::atomic<T>&  atomic_val,
+                 T                expected,
+                 std::string_view callsite,
+                 uint64_t         timeout_ns = UINT64_MAX);
 
 }  // namespace hsa
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -25,6 +25,7 @@
 #include "lib/common/utility.hpp"
 #include "lib/rocprofiler-sdk/code_object/code_object.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
+#include "lib/rocprofiler-sdk/hsa/async_wait_manager.hpp"
 #include "lib/rocprofiler-sdk/hsa/details/fmt.hpp"
 #include "lib/rocprofiler-sdk/hsa/hsa.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
@@ -620,11 +621,14 @@ Queue::Queue(
                 counters::submitPacket(_intercept_queue, &pkt);
                 constexpr auto timeout_hint =
                     std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::seconds{1});
-                if(core_api.hsa_signal_wait_relaxed_fn(completion,
-                                                       HSA_SIGNAL_CONDITION_EQ,
-                                                       0,
-                                                       timeout_hint.count(),
-                                                       HSA_WAIT_STATE_ACTIVE) != 0)
+                auto result = wait_or_shutdown(completion,
+                                               HSA_SIGNAL_CONDITION_EQ,
+                                               0,
+                                               "Queue::profiler_activation()",
+                                               timeout_hint.count(),
+                                               100000000ULL,
+                                               &core_api);
+                if(result != wait_result::completed)
                 {
                     ROCP_FATAL << "Could not set agent to be profiled";
                 }
@@ -676,8 +680,13 @@ Queue::sync() const
 {
     if(_active_kernels.handle != 0u)
     {
-        _core_api.hsa_signal_wait_relaxed_fn(
-            _active_kernels, HSA_SIGNAL_CONDITION_EQ, 0, UINT64_MAX, HSA_WAIT_STATE_ACTIVE);
+        wait_or_shutdown(_active_kernels,
+                         HSA_SIGNAL_CONDITION_EQ,
+                         0,
+                         "Queue::sync()",
+                         UINT64_MAX,
+                         100000000ULL,
+                         &_core_api);
     }
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/internal_threading.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/internal_threading.cpp
@@ -245,7 +245,7 @@ initialize()
         // registration or else the static objects it is pointing to
         // will be destroyed before finalize is invoked.
         create_callback_thread();
-        ::atexit(&registration::finalize);
+        ::atexit([]() { registration::finalize(registration::finalize_mode::exit_handler); });
         // ensure the callback threads are created on the forked process
         ::pthread_atfork(nullptr, nullptr, create_forked_callback_threads);
     });

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -601,9 +601,9 @@ invoke_client_initializers()
     if(!get_clients()) return false;
 
     // if there is only one client, just fully finalize
-    rocprofiler_client_finalize_t client_fini_func =
-        (get_clients()->size() == 1) ? [](rocprofiler_client_id_t) -> void { finalize(); }
-                                     : &invoke_client_finalizer;
+    rocprofiler_client_finalize_t client_fini_func = (get_clients()->size() == 1)
+        ? [](rocprofiler_client_id_t) -> void { finalize(finalize_mode::tool_induced); }
+    : &invoke_client_finalizer;
 
     for(auto& itr : *get_clients())
     {
@@ -825,7 +825,7 @@ initialize()
         // initialization is in process
         set_init_status(-1);
         std::atexit([]() {
-            finalize();
+            finalize(finalize_mode::exit_handler);
             common::destroy_static_tl_objects();
             common::destroy_static_objects();
         });
@@ -865,7 +865,7 @@ initialize()
 }
 
 void
-finalize()
+finalize(finalize_mode mode)
 {
 #if defined(CODECOV) && CODECOV > 0
     if(get_fini_status() > 0) __gcov_dump();
@@ -874,6 +874,17 @@ finalize()
     if(get_fini_status() != 0)
     {
         ROCP_INFO << "ignoring finalization request (value=" << get_fini_status() << ")";
+        return;
+    }
+
+    // When called from an exit handler or static destructor, defer finalization
+    // until HSA fires HSA_AMD_SYSTEM_ASYNC_HANDLER_DESTROY_EVENT (which means
+    // HSA async threads are destroyed and it is safe to retire correlation IDs).
+    if((mode == finalize_mode::exit_handler || mode == finalize_mode::static_destructor) &&
+       hsa::is_async_wait_initialized() && !hsa::is_async_shutdown())
+    {
+        ROCP_INFO << "deferring finalization until HSA async handler shutdown";
+        hsa::register_shutdown_callback([]() { finalize(finalize_mode::exit_handler); });
         return;
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -826,8 +826,13 @@ initialize()
         set_init_status(-1);
         std::atexit([]() {
             finalize(finalize_mode::exit_handler);
-            common::destroy_static_tl_objects();
-            common::destroy_static_objects();
+            // Only destroy static objects if finalization was not deferred.
+            // When deferred, the shutdown callback handles cleanup.
+            if(get_fini_status() != 0)
+            {
+                common::destroy_static_tl_objects();
+                common::destroy_static_objects();
+            }
         });
         invoke_client_configures();
         invoke_client_initializers();
@@ -884,7 +889,18 @@ finalize(finalize_mode mode)
        hsa::is_async_wait_initialized() && !hsa::is_async_shutdown())
     {
         ROCP_INFO << "deferring finalization until HSA async handler shutdown";
-        hsa::register_shutdown_callback([]() { finalize(finalize_mode::exit_handler); });
+        hsa::register_shutdown_callback([]() {
+            // Temporarily clear the shutdown flag so that finalization
+            // code can use wait_or_shutdown() for its own cleanup
+            // (e.g., stopping device counters needs signal waits to complete).
+            // HSA async threads are already destroyed at this point, but
+            // signal waits still work via the core HSA API.
+            hsa::reset_async_shutdown();
+            finalize(finalize_mode::exit_handler);
+            hsa::notify_async_shutdown();
+            common::destroy_static_tl_objects();
+            common::destroy_static_objects();
+        });
         return;
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -36,6 +36,7 @@
 #include "lib/rocprofiler-sdk/hip/hip.hpp"
 #include "lib/rocprofiler-sdk/hip/stream.hpp"
 #include "lib/rocprofiler-sdk/hsa/async_copy.hpp"
+#include "lib/rocprofiler-sdk/hsa/async_wait_manager.hpp"
 #include "lib/rocprofiler-sdk/hsa/hsa.hpp"
 #include "lib/rocprofiler-sdk/hsa/memory_allocation.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue.hpp"
@@ -1099,6 +1100,9 @@ rocprofiler_set_api_table(const char* name,
         rocprofiler::hsa::queue_controller_init(hsa_api_table);
         // Process agent ctx's that were started prior to HSA init
         rocprofiler::counters::device_counting_service_hsa_registration();
+
+        // Register for async handler destruction notification
+        rocprofiler::hsa::async_wait_manager_init();
 
         rocprofiler::hsa::async_copy_init(hsa_api_table, lib_instance);
         rocprofiler::hsa::memory_allocation_init(hsa_api_table->core_, lib_instance);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.hpp
@@ -45,6 +45,13 @@ namespace rocprofiler
 {
 namespace registration
 {
+enum class finalize_mode
+{
+    tool_induced,
+    exit_handler,
+    static_destructor,
+};
+
 // initialize google logging
 void
 init_logging();
@@ -55,7 +62,7 @@ initialize();
 
 // finalize the clients
 void
-finalize();
+finalize(finalize_mode mode);
 
 // get the randomly generated client offset number
 uint32_t

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/shared_library.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/shared_library.cpp
@@ -56,7 +56,7 @@ lifetime::~lifetime()
     if(common::get_env("ROCPROFILER_LIBRARY_DTOR", false))
     {
         ROCP_INFO << "Finalizing rocprofiler-sdk library...";
-        registration::finalize();
+        registration::finalize(registration::finalize_mode::static_destructor);
         ROCP_INFO << "rocprofiler-sdk library finalized";
     }
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ include(GoogleTest)
 
 set(rocprofiler_lib_sources
     agent.cpp
+    async_wait_manager.cpp
     buffer.cpp
     contexts.cpp
     enum_string.cpp

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/async_wait_manager.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/async_wait_manager.cpp
@@ -35,28 +35,25 @@ using namespace rocprofiler::hsa;
 class async_wait_manager_test : public ::testing::Test
 {
 protected:
-    void TearDown() override { async_wait_manager::instance().reset(); }
+    void TearDown() override { reset_async_shutdown(); }
 };
 
 // --- async_wait_manager basic state tests ---
 
-TEST_F(async_wait_manager_test, initial_state_not_shutdown)
-{
-    EXPECT_FALSE(async_wait_manager::instance().is_shutdown());
-}
+TEST_F(async_wait_manager_test, initial_state_not_shutdown) { EXPECT_FALSE(is_async_shutdown()); }
 
 TEST_F(async_wait_manager_test, notify_sets_shutdown_flag)
 {
-    async_wait_manager::instance().notify_shutdown();
-    EXPECT_TRUE(async_wait_manager::instance().is_shutdown());
+    notify_async_shutdown();
+    EXPECT_TRUE(is_async_shutdown());
 }
 
 TEST_F(async_wait_manager_test, reset_clears_shutdown_flag)
 {
-    async_wait_manager::instance().notify_shutdown();
-    EXPECT_TRUE(async_wait_manager::instance().is_shutdown());
-    async_wait_manager::instance().reset();
-    EXPECT_FALSE(async_wait_manager::instance().is_shutdown());
+    notify_async_shutdown();
+    EXPECT_TRUE(is_async_shutdown());
+    reset_async_shutdown();
+    EXPECT_FALSE(is_async_shutdown());
 }
 
 // --- Atomic wait tests ---
@@ -97,7 +94,7 @@ TEST_F(async_wait_manager_test, atomic_shutdown_interrupts)
 
     std::thread shutdown_trigger([]() {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        async_wait_manager::instance().notify_shutdown();
+        notify_async_shutdown();
     });
 
     auto result = wait_or_shutdown(value, 1, "test::atomic_shutdown_interrupts", 30'000'000'000ULL);
@@ -163,7 +160,7 @@ TEST_F(async_wait_manager_test, cv_shutdown_interrupts)
 
     std::thread shutdown_trigger([]() {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        async_wait_manager::instance().notify_shutdown();
+        notify_async_shutdown();
     });
 
     std::unique_lock<std::mutex> lock(mtx);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/async_wait_manager.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/async_wait_manager.cpp
@@ -1,0 +1,175 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/rocprofiler-sdk/hsa/async_wait_manager.hpp"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+using namespace rocprofiler::hsa;
+
+class async_wait_manager_test : public ::testing::Test
+{
+protected:
+    void TearDown() override { async_wait_manager::instance().reset(); }
+};
+
+// --- async_wait_manager basic state tests ---
+
+TEST_F(async_wait_manager_test, initial_state_not_shutdown)
+{
+    EXPECT_FALSE(async_wait_manager::instance().is_shutdown());
+}
+
+TEST_F(async_wait_manager_test, notify_sets_shutdown_flag)
+{
+    async_wait_manager::instance().notify_shutdown();
+    EXPECT_TRUE(async_wait_manager::instance().is_shutdown());
+}
+
+TEST_F(async_wait_manager_test, reset_clears_shutdown_flag)
+{
+    async_wait_manager::instance().notify_shutdown();
+    EXPECT_TRUE(async_wait_manager::instance().is_shutdown());
+    async_wait_manager::instance().reset();
+    EXPECT_FALSE(async_wait_manager::instance().is_shutdown());
+}
+
+// --- Atomic wait tests ---
+
+TEST_F(async_wait_manager_test, atomic_completed_immediately)
+{
+    std::atomic<int> value{42};
+    auto             result = wait_or_shutdown(value, 42, "test::atomic_completed_immediately");
+    EXPECT_EQ(result, wait_result::completed);
+}
+
+TEST_F(async_wait_manager_test, atomic_completed_by_thread)
+{
+    std::atomic<int> value{0};
+
+    std::thread setter([&value]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        value.store(1, std::memory_order_release);
+    });
+
+    auto result = wait_or_shutdown(value, 1, "test::atomic_completed_by_thread", 5'000'000'000ULL);
+    EXPECT_EQ(result, wait_result::completed);
+
+    setter.join();
+}
+
+TEST_F(async_wait_manager_test, atomic_timeout)
+{
+    std::atomic<int> value{0};
+
+    auto result = wait_or_shutdown(value, 1, "test::atomic_timeout", 500'000'000ULL);
+    EXPECT_EQ(result, wait_result::timeout);
+}
+
+TEST_F(async_wait_manager_test, atomic_shutdown_interrupts)
+{
+    std::atomic<int> value{0};
+
+    std::thread shutdown_trigger([]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        async_wait_manager::instance().notify_shutdown();
+    });
+
+    auto result = wait_or_shutdown(value, 1, "test::atomic_shutdown_interrupts", 30'000'000'000ULL);
+    EXPECT_EQ(result, wait_result::shutdown);
+
+    shutdown_trigger.join();
+}
+
+// --- Condition variable wait tests ---
+
+TEST_F(async_wait_manager_test, cv_completed_immediately)
+{
+    std::mutex              mtx;
+    std::condition_variable cv;
+    bool                    ready = true;
+
+    std::unique_lock<std::mutex> lock(mtx);
+    auto                         result = wait_or_shutdown(
+        cv, lock, [&] { return ready; }, "test::cv_completed_immediately");
+    EXPECT_EQ(result, wait_result::completed);
+}
+
+TEST_F(async_wait_manager_test, cv_completed_by_thread)
+{
+    std::mutex              mtx;
+    std::condition_variable cv;
+    bool                    ready = false;
+
+    std::thread notifier([&]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        {
+            std::lock_guard<std::mutex> lock(mtx);
+            ready = true;
+        }
+        cv.notify_one();
+    });
+
+    std::unique_lock<std::mutex> lock(mtx);
+    auto                         result = wait_or_shutdown(
+        cv, lock, [&] { return ready; }, "test::cv_completed_by_thread", 5'000'000'000ULL);
+    EXPECT_EQ(result, wait_result::completed);
+
+    notifier.join();
+}
+
+TEST_F(async_wait_manager_test, cv_timeout)
+{
+    std::mutex              mtx;
+    std::condition_variable cv;
+    bool                    ready = false;
+
+    std::unique_lock<std::mutex> lock(mtx);
+    auto                         result = wait_or_shutdown(
+        cv, lock, [&] { return ready; }, "test::cv_timeout", 500'000'000ULL);
+    EXPECT_EQ(result, wait_result::timeout);
+}
+
+TEST_F(async_wait_manager_test, cv_shutdown_interrupts)
+{
+    std::mutex              mtx;
+    std::condition_variable cv;
+    bool                    ready = false;
+
+    std::thread shutdown_trigger([]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        async_wait_manager::instance().notify_shutdown();
+    });
+
+    std::unique_lock<std::mutex> lock(mtx);
+    auto                         result = wait_or_shutdown(
+        cv, lock, [&] { return ready; }, "test::cv_shutdown_interrupts", 30'000'000'000ULL);
+    EXPECT_EQ(result, wait_result::shutdown);
+
+    shutdown_trigger.join();
+}

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/hsa_barrier.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/hsa_barrier.cpp
@@ -217,7 +217,7 @@ TEST(hsa_barrier, no_block_single)
     }
 
     registration::set_init_status(1);
-    registration::finalize();
+    registration::finalize(registration::finalize_mode::tool_induced);
 }
 
 TEST(hsa_barrier, no_block_multi)
@@ -255,7 +255,7 @@ TEST(hsa_barrier, no_block_multi)
     }
 
     registration::set_init_status(1);
-    registration::finalize();
+    registration::finalize(registration::finalize_mode::tool_induced);
 }
 
 TEST(hsa_barrier, block_single)
@@ -315,7 +315,7 @@ TEST(hsa_barrier, block_single)
     }
 
     registration::set_init_status(1);
-    registration::finalize();
+    registration::finalize(registration::finalize_mode::tool_induced);
 }
 
 TEST(hsa_barrier, block_multi)
@@ -386,5 +386,5 @@ TEST(hsa_barrier, block_multi)
     }
 
     registration::set_init_status(1);
-    registration::finalize();
+    registration::finalize(registration::finalize_mode::tool_induced);
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -25,6 +25,7 @@
 #include "lib/rocprofiler-sdk/agent.hpp"
 #include "lib/rocprofiler-sdk/buffer.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
+#include "lib/rocprofiler-sdk/hsa/async_wait_manager.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
 #include "lib/rocprofiler-sdk/internal_threading.hpp"
 #include "lib/rocprofiler-sdk/registration.hpp"
@@ -114,9 +115,7 @@ public:
 
     void WaitOn() const
     {
-        auto wait_fn = hsa::get_core_table()->hsa_signal_wait_scacquire_fn;
-        while(wait_fn(signal, HSA_SIGNAL_CONDITION_EQ, 0, UINT64_MAX, HSA_WAIT_STATE_BLOCKED) != 0)
-        {}
+        hsa::wait_or_shutdown(signal, HSA_SIGNAL_CONDITION_EQ, 0, "thread_trace::Signal::WaitOn()");
     }
 
     hsa_signal_t      signal;


### PR DESCRIPTION
## Summary

Add a unified async wait manager to rocprofiler-sdk that wraps all HSA signal waits, atomic polling, and condition variable waits with shutdown detection. When the HSA async event handler thread is destroyed (notified via `HSA_AMD_SYSTEM_ASYNC_HANDLER_DESTROY_EVENT` from PR #3157), all pending waits exit gracefully instead of hanging indefinitely.

## Changes

### New Files
- `source/lib/rocprofiler-sdk/hsa/async_wait_manager.hpp` - Header with `async_wait_manager` singleton, `wait_result` enum, and `wait_or_shutdown()` overloads for HSA signals, atomics, and condition variables
- `source/lib/rocprofiler-sdk/hsa/async_wait_manager.cpp` - Implementation with system event handler registration and wait functions with ROCP_WARNING/ROCP_ERROR logging
- `source/lib/rocprofiler-sdk/tests/async_wait_manager.cpp` - Unit tests for all three wait mechanisms

### Modified Call Sites
- `source/lib/rocprofiler-sdk/hsa/queue.cpp` - Queue::sync() and profiler activation waits
- `source/lib/rocprofiler-sdk/counters/device_counting.cpp` - init, read, start, stop counter waits
- `source/lib/rocprofiler-sdk/thread_trace/core.cpp` - Thread trace buffer wait
- `source/lib/rocprofiler-sdk/hsa/async_copy.cpp` - Async copy sync wait

### Registration
- `source/lib/rocprofiler-sdk/registration.cpp` - Register system event handler during HSA table initialization

### Build
- `source/lib/rocprofiler-sdk/hsa/CMakeLists.txt` - Add async_wait_manager.cpp
- `source/lib/rocprofiler-sdk/tests/CMakeLists.txt` - Add unit test

## Motivation

Six locations in rocprofiler-sdk use infinite HSA signal waits (`UINT64_MAX` timeout) that are serviced by the HSA async event handler thread. If this thread is destroyed during shutdown while waits are pending, the process hangs indefinitely. This change makes all waits shutdown-aware by polling a global shutdown flag every 100ms.

## Design

- Single `std::atomic<bool>` shutdown flag -- no registration/bookkeeping overhead
- Three `wait_or_shutdown()` overloads: HSA signals, `std::atomic<T>`, `std::condition_variable`
- Returns `wait_result::completed`, `wait_result::shutdown`, or `wait_result::timeout`
- `ROCP_ERROR` on timeout, `ROCP_WARNING` on shutdown interruption, with callsite string
- Registered via `hsa_amd_register_system_event_handler` during HSA table setup

## Dependencies

- Requires `HSA_AMD_SYSTEM_ASYNC_HANDLER_DESTROY_EVENT` (PR #3157)

## Testing

- Unit tests for all three wait mechanisms (immediate completion, thread completion, timeout, shutdown interrupt)
- No GPU hardware required for unit tests (atomic and CV tests only)