### PR TITLE
[rocshmem] Add specialization for uint8 envvar reading

### DIFF
--- a/projects/rocshmem/src/envvar.hpp
+++ b/projects/rocshmem/src/envvar.hpp
@@ -197,20 +197,12 @@ namespace envvar {
       return is;
     }
 
-    // decimal integer parser
-    template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
-    struct parse_decimal {
-      std::istream& operator()(std::istream& is, T& value) const {
-        return is >> std::dec >> value;
-      }
-    };
-
     // Specialization for uint8_t
     template <> inline
     std::istream& parse<uint8_t>::operator()(std::istream& is, uint8_t& value) const {
       int temp;
       is >> std::dec >> temp;
-      if (is && temp >= 0 && temp <= 255) {
+      if (is && temp >= std::numeric_limits<uint8_t>::min() && temp <= std::numeric_limits<uint8_t>::max()) {
         value = static_cast<uint8_t>(temp);
       } else if (is) {
         is.setstate(std::ios::failbit);
@@ -218,17 +210,12 @@ namespace envvar {
       return is;
     }
 
-    // Specialization for int8_t
-    template <> inline
-    std::istream& parse<int8_t>::operator()(std::istream& is, int8_t& value) const {
-      int temp;
-      is >> std::dec >> temp;
-      if (is && temp >= -128 && temp <= 127) {
-        value = static_cast<int8_t>(temp);
-      } else if (is) {
-        is.setstate(std::ios::failbit);
+    // decimal integer parser
+    template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
+    struct parse_decimal {
+      std::istream& operator()(std::istream& is, T& value) const {
+        return is >> std::dec >> value;
       }
-      return is;
     };
 
     // hexadecimal integer parser

--- a/projects/rocshmem/src/envvar.hpp
+++ b/projects/rocshmem/src/envvar.hpp
@@ -201,7 +201,7 @@ namespace envvar {
     template <> inline
     std::istream& parse<uint8_t>::operator()(std::istream& is, uint8_t& value) const {
       int temp;
-      is >> std::dec >> temp;
+      is >> std::setbase(0) >> temp;
       if (is && temp >= std::numeric_limits<uint8_t>::min() && temp <= std::numeric_limits<uint8_t>::max()) {
         value = static_cast<uint8_t>(temp);
       } else if (is) {

--- a/projects/rocshmem/src/envvar.hpp
+++ b/projects/rocshmem/src/envvar.hpp
@@ -205,6 +205,32 @@ namespace envvar {
       }
     };
 
+    // Specialization for uint8_t
+    template <> inline
+    std::istream& parse<uint8_t>::operator()(std::istream& is, uint8_t& value) const {
+      int temp;
+      is >> std::dec >> temp;
+      if (is && temp >= 0 && temp <= 255) {
+        value = static_cast<uint8_t>(temp);
+      } else if (is) {
+        is.setstate(std::ios::failbit);
+      }
+      return is;
+    }
+
+    // Specialization for int8_t
+    template <> inline
+    std::istream& parse<int8_t>::operator()(std::istream& is, int8_t& value) const {
+      int temp;
+      is >> std::dec >> temp;
+      if (is && temp >= -128 && temp <= 127) {
+        value = static_cast<int8_t>(temp);
+      } else if (is) {
+        is.setstate(std::ios::failbit);
+      }
+      return is;
+    };
+
     // hexadecimal integer parser
     template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
     struct parse_hex {

--- a/projects/rocshmem/tests/unit_tests/envvar_gtest.cpp
+++ b/projects/rocshmem/tests/unit_tests/envvar_gtest.cpp
@@ -226,6 +226,38 @@ TEST_F(EnvVarTestFixture, parse_bool_other) {
   EXPECT_EQ(var_.get_value(), false);
 }
 
+TEST_F(EnvVarTestFixture, parse_uint8_zero) {
+  this->setenv("0");
+  const envvar::var<uint8_t> var_{this->var_name_, this->var_doc_};
+  EXPECT_FALSE(var_.is_default());
+  EXPECT_EQ(var_.get_default(), 0);
+  EXPECT_EQ(var_.get_value(), 0);
+}
+
+TEST_F(EnvVarTestFixture, parse_uint8_sixteen) {
+  this->setenv("16");
+  const envvar::var<uint8_t> var_{this->var_name_, this->var_doc_};
+  EXPECT_FALSE(var_.is_default());
+  EXPECT_EQ(var_.get_default(), 0);
+  EXPECT_EQ(var_.get_value(), 16);
+}
+
+TEST_F(EnvVarTestFixture, parse_uint8_negative) {
+  this->setenv("-1");
+  const envvar::var<uint8_t> var_{this->var_name_, this->var_doc_};
+  EXPECT_TRUE(var_.is_default());
+  EXPECT_EQ(var_.get_default(), 0);
+  EXPECT_EQ(var_.get_value(), var_.get_default());
+}
+
+TEST_F(EnvVarTestFixture, parse_uint8_too_large) {
+  this->setenv("256");
+  const envvar::var<uint8_t> var_{this->var_name_, this->var_doc_};
+  EXPECT_TRUE(var_.is_default());
+  EXPECT_EQ(var_.get_default(), 0);
+  EXPECT_EQ(var_.get_value(), var_.get_default());
+}
+
 TEST_F(EnvVarTestFixture, parse_socket_family_unspec) {
   this->setenv("UNSPEC");
   const envvar::var<envvar::types::socket_family> var_{this->var_name_, this->var_doc_};


### PR DESCRIPTION
## Motivation

Setting ROCSHMEM_GDA_TRAFFIC_CLASS would set the value to the first character instead of numeric value

## Technical Details

Added an operator to convert int8_t as integers not char. 

## JIRA ID

AIROCSHMEM-282

## Test Result

TC value set as expected when provided, error produced when out of scope

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
