### PR TITLE
[rocshmem] Add rocshmem_hipmodule_init API for CUDA graph compatibility

### DIFF
--- a/projects/rocshmem/include/rocshmem/rocshmem.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem.hpp
@@ -77,15 +77,22 @@ constexpr char VERSION[] = "3.2.1";
  */
 __host__ void rocshmem_init(void);
 
+
 /**
- * @brief Query rocSHMEM context from host API
+ * @brief Initialize rocSHMEM device context for a specific HIP module
  *
- * @param[out] ctx      Returns ROCSHMEM_CTX_DEFAULT device pointer that users
- *                      can query from one instance of rocshmem host library and
- *                      use use later for dynamic module initialization in
- *                      kernel bitcode device library in the same application
+ * This function queries the ROCSHMEM_CTX_DEFAULT symbol from the provided
+ * HIP module and initializes it with the host-side context using stream-ordered
+ * memory operations. This is required for CUDA graph compatibility.
+ *
+ * @param[in] module    HIP module containing rocSHMEM device code
+ * @param[in] stream    HIP stream to use for context initialization (optional,
+ *                      uses current stream if NULL)
+ *
+ * @return int          0 on success, non-zero on failure
+ *
  */
-__host__ void * rocshmem_get_device_ctx();
+__host__ int rocshmem_hipmodule_init(hipModule_t module, hipStream_t stream = nullptr);
 
 /**
  * @brief Query rocSHMEM remote symmetric heap pointer

--- a/projects/rocshmem/include/rocshmem/rocshmem.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem.hpp
@@ -79,6 +79,21 @@ __host__ void rocshmem_init(void);
 
 
 /**
+ * @brief Query rocSHMEM context from host API (DEPRECATED)
+ *
+ * @deprecated This API is deprecated. Use rocshmem_hipmodule_init() instead,
+ *             which provides better CUDA graph compatibility and automatic
+ *             module initialization.
+ *
+ * @param[out] ctx      Returns ROCSHMEM_CTX_DEFAULT device pointer that users
+ *                      can query from one instance of rocshmem host library and
+ *                      use later for dynamic module initialization in
+ *                      kernel bitcode device library in the same application
+ */
+[[deprecated("Use rocshmem_hipmodule_init() instead")]]
+__host__ void * rocshmem_get_device_ctx();
+
+/**
  * @brief Initialize rocSHMEM device context for a specific HIP module
  *
  * This function queries the ROCSHMEM_CTX_DEFAULT symbol from the provided
@@ -87,10 +102,13 @@ __host__ void rocshmem_init(void);
  *
  * @param[in] module    HIP module containing rocSHMEM device code
  * @param[in] stream    HIP stream to use for context initialization (optional,
- *                      uses current stream if NULL)
+ *                      uses hipStreamPerThread if nullptr)
  *
  * @return int          0 on success, non-zero on failure
  *
+ * @note This function does not synchronize the stream, allowing it to be
+ *       used in CUDA graph capture contexts. The caller is responsible for
+ *       synchronization if needed.
  */
 __host__ int rocshmem_hipmodule_init(hipModule_t module, hipStream_t stream = nullptr);
 

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -472,6 +472,7 @@ TestOther() {
   #       | Name             | Ranks | Workgroups | Threads | Max Message Size #
   ##############################################################################
   ExecTest  "init"             2       1            1
+ExecTest  "hipmodule_init    2       1            1
 
   ExecTest  "pingpong"         2       1            1
   ExecTest  "pingpong"         2       8            1
@@ -666,6 +667,7 @@ TestGDA() {
   #       | Name             | Ranks | Workgroups | Threads | Max Message Size #
   ##############################################################################
   ExecTest  "init"             2       1            1
+ExecTest  "hipmodule_init    2       1            1
 
   ExecTest  "pingpong"         2       1            1
   ExecTest  "pingpong"         2       8            1

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -122,6 +122,7 @@ declare -A TEST_NUMBERS=(
   ["flood_get"]="86"
   ["flood_getnbi"]="87"
   ["flood_g"]="88"
+  ["hipmodule_init"]="89"
 )
 
 ExecTest() {

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -472,7 +472,7 @@ TestOther() {
   #       | Name             | Ranks | Workgroups | Threads | Max Message Size #
   ##############################################################################
   ExecTest  "init"             2       1            1
-ExecTest  "hipmodule_init    2       1            1
+  ExecTest  "hipmodule_init"   2       1            1
 
   ExecTest  "pingpong"         2       1            1
   ExecTest  "pingpong"         2       8            1
@@ -667,7 +667,7 @@ TestGDA() {
   #       | Name             | Ranks | Workgroups | Threads | Max Message Size #
   ##############################################################################
   ExecTest  "init"             2       1            1
-ExecTest  "hipmodule_init    2       1            1
+  ExecTest  "hipmodule_init"   2       1            1
 
   ExecTest  "pingpong"         2       1            1
   ExecTest  "pingpong"         2       8            1

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -118,25 +118,36 @@ __device__ void rocshmem_wg_finalize() {}
 * to stay here to avoid getting pulled into other places in compilation
 ******************************************************************************/
 
-__host__ int rocshmem_hipmodule_init(hipModule_t module, hipStream_t stream) {
-  // Step 1: Get the host-side device context
+__host__ void * rocshmem_get_device_ctx() {
   rocshmem_ctx_t ctx = {nullptr, nullptr};
   CHECK_HIP(hipMemcpyFromSymbol(&ctx, HIP_SYMBOL(ROCSHMEM_CTX_DEFAULT),
-                                 sizeof(rocshmem_ctx_t)));
-  void *host_ctx = ctx.ctx_opaque;
+                                sizeof(rocshmem_ctx_t)));
+  return ctx.ctx_opaque;
+}
 
-  if (host_ctx == nullptr) {
-    fprintf(stderr, "[rocSHMEM] Error: Failed to get ROCSHMEM_CTX_DEFAULT\n");
+__host__ int rocshmem_hipmodule_init(hipModule_t module, hipStream_t stream) {
+  // Step 1: Get device address of rocSHMEM's built-in ROCSHMEM_CTX_DEFAULT symbol
+  // Use hipGetSymbolAddress for graph-capture compatibility (device-to-device path)
+  void *source_ctx_device = nullptr;
+  hipError_t err = hipGetSymbolAddress(&source_ctx_device, HIP_SYMBOL(ROCSHMEM_CTX_DEFAULT));
+
+  if (err != hipSuccess) {
+    fprintf(stderr, "[rocSHMEM] Error: Failed to get address of built-in ROCSHMEM_CTX_DEFAULT: %s\n",
+            hipGetErrorString(err));
     return -1;
   }
 
-  // Step 2: Query the device symbol from the HIP module
-  void *device_ctx = nullptr;
+  if (source_ctx_device == nullptr) {
+    fprintf(stderr, "[rocSHMEM] Error: Built-in ROCSHMEM_CTX_DEFAULT has null address\n");
+    return -1;
+  }
+
+  // Step 2: Query the device symbol address from the user's HIP module
+  void *target_ctx_device = nullptr;
   size_t symbol_size = 0;
 
-  // Try to get the symbol address from the module
-  hipError_t err = hipModuleGetGlobal(
-      &device_ctx,
+  err = hipModuleGetGlobal(
+      &target_ctx_device,
       &symbol_size,
       module,
       "ROCSHMEM_CTX_DEFAULT"
@@ -154,17 +165,17 @@ __host__ int rocshmem_hipmodule_init(hipModule_t module, hipStream_t stream) {
     return -1;
   }
 
-  // Step 3: Copy the context to device using stream-ordered memcpy
-  // hipMemcpyAsync is compatible with CUDA graphs and explicit streams
+  // Step 3: Device-to-device copy using stream-ordered memcpy
+  // This is fully graph-capture compatible since both source and target are device memory
   if (stream == nullptr) {
     stream = hipStreamPerThread;
   }
 
   err = hipMemcpyAsync(
-      device_ctx,
-      &host_ctx,
+      target_ctx_device,
+      source_ctx_device,
       sizeof(rocshmem_ctx_t),
-      hipMemcpyHostToDevice,
+      hipMemcpyDeviceToDevice,  // Device-to-device copy for graph capture compatibility
       stream
   );
 
@@ -172,15 +183,6 @@ __host__ int rocshmem_hipmodule_init(hipModule_t module, hipStream_t stream) {
     fprintf(stderr, "[rocSHMEM] Error: Failed to copy context to device: %s\n",
             hipGetErrorString(err));
     return -1;
-  }
-
-  // Optionally synchronize the stream to ensure initialization completes
-  // Comment this out if you want fully async behavior
-  err = hipStreamSynchronize(stream);
-  if (err != hipSuccess) {
-    fprintf(stderr, "[rocSHMEM] Warning: Failed to synchronize stream: %s\n",
-            hipGetErrorString(err));
-    // Don't fail here, as async initialization might still work
   }
 
   return 0;

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -114,17 +114,76 @@ __device__ void rocshmem_wg_finalize() {}
 
 
 /******************************************************************************
-* These host APIs use Device side symbol - ROCSHMEM_CTX_DEFAULT so it needs
+* These host API use Device side symbol - ROCSHMEM_CTX_DEFAULT so it needs
 * to stay here to avoid getting pulled into other places in compilation
 ******************************************************************************/
 
-__host__ void * rocshmem_get_device_ctx() {
-  rocshmem_ctx_t ctx;
-
+__host__ int rocshmem_hipmodule_init(hipModule_t module, hipStream_t stream) {
+  // Step 1: Get the host-side device context
+  rocshmem_ctx_t ctx = {nullptr, nullptr};
   CHECK_HIP(hipMemcpyFromSymbol(&ctx, HIP_SYMBOL(ROCSHMEM_CTX_DEFAULT),
-                             sizeof(rocshmem_ctx_t)));
-  return ctx.ctx_opaque;
+                                 sizeof(rocshmem_ctx_t)));
+  void *host_ctx = ctx.ctx_opaque;
 
+  if (host_ctx == nullptr) {
+    fprintf(stderr, "[rocSHMEM] Error: Failed to get ROCSHMEM_CTX_DEFAULT\n");
+    return -1;
+  }
+
+  // Step 2: Query the device symbol from the HIP module
+  void *device_ctx = nullptr;
+  size_t symbol_size = 0;
+
+  // Try to get the symbol address from the module
+  hipError_t err = hipModuleGetGlobal(
+      &device_ctx,
+      &symbol_size,
+      module,
+      "ROCSHMEM_CTX_DEFAULT"
+  );
+
+  if (err != hipSuccess) {
+    fprintf(stderr, "[rocSHMEM] Error: Failed to get ROCSHMEM_CTX_DEFAULT symbol from module: %s\n",
+            hipGetErrorString(err));
+    return -1;
+  }
+
+  if (symbol_size != sizeof(rocshmem_ctx_t)) {
+    fprintf(stderr, "[rocSHMEM] Error: Symbol size mismatch. Expected %zu, got %zu\n",
+            sizeof(rocshmem_ctx_t), symbol_size);
+    return -1;
+  }
+
+  // Step 3: Copy the context to device using stream-ordered memcpy
+  // hipMemcpyAsync is compatible with CUDA graphs and explicit streams
+  if (stream == nullptr) {
+    stream = hipStreamPerThread;
+  }
+
+  err = hipMemcpyAsync(
+      device_ctx,
+      &host_ctx,
+      sizeof(rocshmem_ctx_t),
+      hipMemcpyHostToDevice,
+      stream
+  );
+
+  if (err != hipSuccess) {
+    fprintf(stderr, "[rocSHMEM] Error: Failed to copy context to device: %s\n",
+            hipGetErrorString(err));
+    return -1;
+  }
+
+  // Optionally synchronize the stream to ensure initialization completes
+  // Comment this out if you want fully async behavior
+  err = hipStreamSynchronize(stream);
+  if (err != hipSuccess) {
+    fprintf(stderr, "[rocSHMEM] Warning: Failed to synchronize stream: %s\n",
+            hipGetErrorString(err));
+    // Don't fail here, as async initialization might still work
+  }
+
+  return 0;
 }
 
 /******************************************************************************

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -134,12 +134,12 @@ __host__ int rocshmem_hipmodule_init(hipModule_t module, hipStream_t stream) {
   if (err != hipSuccess) {
     fprintf(stderr, "[rocSHMEM] Error: Failed to get address of built-in ROCSHMEM_CTX_DEFAULT: %s\n",
             hipGetErrorString(err));
-    return -1;
+    return ROCSHMEM_ERROR;
   }
 
   if (source_ctx_device == nullptr) {
     fprintf(stderr, "[rocSHMEM] Error: Built-in ROCSHMEM_CTX_DEFAULT has null address\n");
-    return -1;
+    return ROCSHMEM_ERROR;
   }
 
   // Step 2: Query the device symbol address from the user's HIP module
@@ -156,13 +156,13 @@ __host__ int rocshmem_hipmodule_init(hipModule_t module, hipStream_t stream) {
   if (err != hipSuccess) {
     fprintf(stderr, "[rocSHMEM] Error: Failed to get ROCSHMEM_CTX_DEFAULT symbol from module: %s\n",
             hipGetErrorString(err));
-    return -1;
+    return ROCSHMEM_ERROR;
   }
 
   if (symbol_size != sizeof(rocshmem_ctx_t)) {
     fprintf(stderr, "[rocSHMEM] Error: Symbol size mismatch. Expected %zu, got %zu\n",
             sizeof(rocshmem_ctx_t), symbol_size);
-    return -1;
+    return ROCSHMEM_ERROR;
   }
 
   // Step 3: Device-to-device copy using stream-ordered memcpy
@@ -182,7 +182,7 @@ __host__ int rocshmem_hipmodule_init(hipModule_t module, hipStream_t stream) {
   if (err != hipSuccess) {
     fprintf(stderr, "[rocSHMEM] Error: Failed to copy context to device: %s\n",
             hipGetErrorString(err));
-    return -1;
+    return ROCSHMEM_ERROR;
   }
 
   return 0;

--- a/projects/rocshmem/tests/functional_tests/CMakeLists.txt
+++ b/projects/rocshmem/tests/functional_tests/CMakeLists.txt
@@ -93,6 +93,8 @@ target_compile_definitions(
   ${PROJECT_NAME}
   PRIVATE
     $<$<TARGET_EXISTS:PMIx::pmix>:HAVE_PMIX=1>
+    CMAKE_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+    CMAKE_BINARY_DIR="${CMAKE_BINARY_DIR}"
 )
 
 configure_file(../../scripts/functional_tests/driver.sh rocshmem_functional_driver.sh COPYONLY)
@@ -105,4 +107,5 @@ target_link_libraries(
     roc::rocshmem
     $<TARGET_NAME_IF_EXISTS:MPI::MPI_CXX>
     $<TARGET_NAME_IF_EXISTS:PMIx::pmix>
+    hiprtc
 )

--- a/projects/rocshmem/tests/functional_tests/hipmodule_init_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/hipmodule_init_tester.cpp
@@ -161,7 +161,7 @@ void HipModuleInitTester::launchKernel(dim3 gridSize, dim3 blockSize,
   (void)size;
 
   if (my_pe == 0) {
-    printf("\n=== CUDA/HIP graph capture test ===\n");
+    printf("\n=== HIP graph capture test ===\n");
   }
 
   // Reset result buffer

--- a/projects/rocshmem/tests/functional_tests/hipmodule_init_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/hipmodule_init_tester.cpp
@@ -1,0 +1,200 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+#include <rocshmem/rocshmem.hpp>
+#include <hip/hip_runtime.h>
+#include <hip/hiprtc.h>
+#include <cstring>
+#include <cassert>
+
+// Helper macro for HIPRTC error checking
+#define CHECK_HIPRTC(cmd) \
+  do { \
+    hiprtcResult result = cmd; \
+    if (result != HIPRTC_SUCCESS) { \
+      fprintf(stderr, "error: %s (%d) at %s:%d\n", \
+              hiprtcGetErrorString(result), result, __FILE__, __LINE__); \
+      abort(); \
+    } \
+  } while(0)
+
+// Kernel source that defines ROCSHMEM_CTX_DEFAULT
+// This kernel mimics the rocshmem device context definition to ensure 
+// the device global symbol exists in the module's device symbol table and 
+// can be queried later in rocshmem_hipmodule_init() host API for verification.
+const char* test_kernel_src = R"(
+#include <hip/hip_runtime.h>
+
+typedef struct rocshmem_ctx {
+  void *ctx_opaque;
+  void *team_opaque;
+} rocshmem_ctx_t;
+
+// Define the ROCSHMEM_CTX_DEFAULT symbol. rocshmem_hipmodule_init() looks for
+// this device symbol in the given kernel module
+extern "C" __device__ rocshmem_ctx_t __attribute__((visibility("default"))) ROCSHMEM_CTX_DEFAULT{};
+
+// stub kernel function used for module verification
+extern "C" __global__ void simple_test_kernel(int *result) {
+  // Simple test kernel that has the ROCSHMEM_CTX_DEFAULT symbol compiled in its module
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    // Just write a test value
+    *result = 42;
+  }
+}
+)";
+
+/******************************************************************************
+ * HOST TESTER CLASS METHODS
+ *****************************************************************************/
+HipModuleInitTester::HipModuleInitTester(TesterArguments args)
+    : Tester(args),
+      test_module(nullptr),
+      kernel_func(nullptr),
+      device_result(nullptr) {
+  my_pe = rocshmem_my_pe();
+  n_pes = rocshmem_n_pes();
+
+  // Allocate device memory for test result
+  CHECK_HIP(hipMalloc(&device_result, sizeof(int)));
+
+  // Compile the kernel using HIPRTC with rocshmem headers
+  hiprtcProgram prog;
+  CHECK_HIPRTC(hiprtcCreateProgram(&prog, test_kernel_src, "simple_test_kernel.cpp", 0, nullptr, nullptr));
+
+  // Get device architecture for compilation
+  hipDeviceProp_t props;
+  CHECK_HIP(hipGetDeviceProperties(&props, 0));
+  std::string arch = std::string("--offload-arch=") + props.gcnArchName;
+
+  // Add include paths for rocshmem headers
+  std::string include_path = "-I" + std::string(CMAKE_SOURCE_DIR) + "/include";
+  std::string build_include = "-I" + std::string(CMAKE_BINARY_DIR) + "/include";
+  std::string src_include = "-I" + std::string(CMAKE_SOURCE_DIR) + "/src";
+
+  const char* options[] = {
+    arch.c_str(),
+    include_path.c_str(),
+    build_include.c_str(),
+    src_include.c_str(),
+    "-D__HIP_PLATFORM_AMD__"
+  };
+
+  hiprtcResult compileResult = hiprtcCompileProgram(prog, 5, options);
+
+  // Check compilation result
+  if (compileResult != HIPRTC_SUCCESS) {
+    size_t logSize;
+    hiprtcGetProgramLogSize(prog, &logSize);
+    if (logSize) {
+      char* log = new char[logSize];
+      hiprtcGetProgramLog(prog, log);
+      fprintf(stderr, "HIPRTC compilation failed:\n%s\n", log);
+      delete[] log;
+    }
+    CHECK_HIPRTC(compileResult);
+  }
+
+  // Get compiled code
+  size_t codeSize;
+  CHECK_HIPRTC(hiprtcGetCodeSize(prog, &codeSize));
+  char* code = new char[codeSize];
+  CHECK_HIPRTC(hiprtcGetCode(prog, code));
+
+  // Load the compiled module
+  // Note: This creates a HIP module that we'll pass to rocshmem_hipmodule_init
+  // this HIP module has device global symbol ROCSHMEM_CTX_DEFAULT in device symbol table.
+  CHECK_HIP(hipModuleLoadData(&test_module, code));
+
+  // Clean up
+  delete[] code;
+  CHECK_HIPRTC(hiprtcDestroyProgram(&prog));
+
+  // Get the kernel function from the module
+  CHECK_HIP(hipModuleGetFunction(&kernel_func, test_module, "simple_test_kernel"));
+}
+
+HipModuleInitTester::~HipModuleInitTester() {
+  if (device_result) {
+    CHECK_HIP(hipFree(device_result));
+  }
+  if (test_module) {
+    CHECK_HIP(hipModuleUnload(test_module));
+  }
+}
+
+void HipModuleInitTester::resetBuffers(size_t size) {
+  // Reset device result to 0
+  CHECK_HIP(hipMemset(device_result, 0, sizeof(int)));
+}
+
+void HipModuleInitTester::launchKernel(dim3 gridSize, dim3 blockSize,
+                                        int loop, size_t size) {
+
+  // This API reads ROCSHMEM_CTX_DEFAULT from host context and 
+  // copies to device global symbol residing in given moddule.
+  int ret = rocshmem_hipmodule_init(test_module, nullptr);
+
+  if (ret != 0) {
+    if (my_pe == 0) { // to avoid duplicate prints in case of failure from multiple ranks
+      fprintf(stderr, "❌ rocshmem_hipmodule_init failed with code %d\n", ret);
+    }
+    return;
+  }
+
+  if (my_pe == 0) {
+    printf("✅ rocshmem_hipmodule_init succeeded\n");
+  }
+
+  // Launch the test kernel to verify the module works
+  void *args[] = {&device_result};
+  CHECK_HIP(hipModuleLaunchKernel(
+      kernel_func,
+      1, 1, 1,    // gridDim
+      1, 1, 1,    // blockDim
+      0,          // sharedMem
+      nullptr,    // stream
+      args,       // kernel arguments
+      nullptr));  // extra
+
+  CHECK_HIP(hipDeviceSynchronize());
+}
+
+void HipModuleInitTester::verifyResults(size_t size) {
+  // Verify the kernel executed correctly
+  int host_result = 0;
+  CHECK_HIP(hipMemcpy(&host_result, device_result, sizeof(int),
+                      hipMemcpyDeviceToHost));
+
+  if (host_result == 42) {
+    if (my_pe == 0) {
+      printf("✅ Kernel execution verified (result = %d)\n", host_result);
+    }
+  } else {
+    if (my_pe == 0) {
+      fprintf(stderr, "❌ Kernel verification failed (expected 42, got %d)\n",
+              host_result);
+    }
+  }
+}

--- a/projects/rocshmem/tests/functional_tests/hipmodule_init_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/hipmodule_init_tester.cpp
@@ -95,15 +95,21 @@ HipModuleInitTester::HipModuleInitTester(TesterArguments args)
   std::string build_include = "-I" + std::string(CMAKE_BINARY_DIR) + "/include";
   std::string src_include = "-I" + std::string(CMAKE_SOURCE_DIR) + "/src";
 
+  const char* rocm_path = std::getenv("ROCM_PATH");
+  std::string hip_include = rocm_path ?
+    "-I" + std::string(rocm_path) + "/include" :
+    "-I/opt/rocm/include";
+
   const char* options[] = {
     arch.c_str(),
+    hip_include.c_str(),
     include_path.c_str(),
     build_include.c_str(),
     src_include.c_str(),
     "-D__HIP_PLATFORM_AMD__"
   };
 
-  hiprtcResult compileResult = hiprtcCompileProgram(prog, 5, options);
+  hiprtcResult compileResult = hiprtcCompileProgram(prog, 6, options);
 
   // Check compilation result
   if (compileResult != HIPRTC_SUCCESS) {

--- a/projects/rocshmem/tests/functional_tests/hipmodule_init_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/hipmodule_init_tester.cpp
@@ -27,6 +27,8 @@
 #include <hip/hiprtc.h>
 #include <cstring>
 #include <cassert>
+#include <cstdio>
+#include <cstdlib>
 
 // Helper macro for HIPRTC error checking
 #define CHECK_HIPRTC(cmd) \
@@ -151,37 +153,96 @@ void HipModuleInitTester::resetBuffers(size_t size) {
 
 void HipModuleInitTester::launchKernel(dim3 gridSize, dim3 blockSize,
                                         int loop, size_t size) {
-
-  // This API reads ROCSHMEM_CTX_DEFAULT from host context and 
-  // copies to device global symbol residing in given moddule.
-  int ret = rocshmem_hipmodule_init(test_module, nullptr);
-
-  if (ret != 0) {
-    if (my_pe == 0) { // to avoid duplicate prints in case of failure from multiple ranks
-      fprintf(stderr, "❌ rocshmem_hipmodule_init failed with code %d\n", ret);
-    }
-    return;
-  }
+  // Note: This test intentionally ignores gridSize/blockSize parameters and uses
+  // a simple 1x1x1 launch.
+  (void)gridSize;
+  (void)blockSize;
+  (void)loop;
+  (void)size;
 
   if (my_pe == 0) {
-    printf("✅ rocshmem_hipmodule_init succeeded\n");
+    printf("\n=== CUDA/HIP graph capture test ===\n");
   }
 
-  // Launch the test kernel to verify the module works
+  // Reset result buffer
+  CHECK_HIP(hipMemset(device_result, 0, sizeof(int)));
+
+  // Create a stream for graph capture
+  hipStream_t stream;
+  CHECK_HIP(hipStreamCreate(&stream));
+
+  // Begin graph capture
+  hipGraph_t graph;
+  CHECK_HIP(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+
+  // Call rocshmem_hipmodule_init within graph capture
+  // verifies device-to-device copy for device global symbols work in graph.
+  // Make sure this API does not issue any operation on legacy/default stream
+  // while HIP graph capturing is active on another stream.
+  int ret = rocshmem_hipmodule_init(test_module, stream);
+
+  if (ret != 0) {
+    fprintf(stderr, "[Rank %d] FAIL: rocshmem_hipmodule_init in graph failed with code %d\n", my_pe, ret);
+    CHECK_HIP(hipStreamEndCapture(stream, &graph));  // Clean up
+    rocshmem_global_exit(1);
+  }
+
+  // Launch kernel within the graph
   void *args[] = {&device_result};
   CHECK_HIP(hipModuleLaunchKernel(
       kernel_func,
       1, 1, 1,    // gridDim
       1, 1, 1,    // blockDim
       0,          // sharedMem
-      nullptr,    // stream
-      args,       // kernel arguments
-      nullptr));  // extra
+      stream,     // Use the capturing stream
+      args,
+      nullptr));
 
-  CHECK_HIP(hipDeviceSynchronize());
+  // End graph capture
+  CHECK_HIP(hipStreamEndCapture(stream, &graph));
+  if (my_pe == 0) {
+    printf("PASS: Graph capture completed successfully\n");
+  }
+
+  // Instantiate the captured graph
+  hipGraphExec_t graph_exec;
+  CHECK_HIP(hipGraphInstantiate(&graph_exec, graph, nullptr, nullptr, 0));
+  if (my_pe == 0) {
+    printf("PASS: Graph instantiated successfully\n");
+  }
+
+  // Execute the graph
+  CHECK_HIP(hipGraphLaunch(graph_exec, stream));
+  CHECK_HIP(hipStreamSynchronize(stream));
+  if (my_pe == 0) {
+    printf("PASS: Graph executed successfully\n");
+  }
+
+  // Verify result from graph execution
+  int host_result = 0;
+  CHECK_HIP(hipMemcpy(&host_result, device_result, sizeof(int),
+                      hipMemcpyDeviceToHost));
+
+  if (host_result != 42) {
+    fprintf(stderr, "[Rank %d] FAIL: Graph execution failed (expected 42, got %d)\n",
+            my_pe, host_result);
+    rocshmem_global_exit(1);
+  }
+
+  if (my_pe == 0) {
+    printf("PASS: Graph execution verified (result = %d)\n", host_result);
+    printf("PASS: rocshmem_hipmodule_init is CUDA graph compatible!\n");
+  }
+
+  // Cleanup graph resources
+  CHECK_HIP(hipGraphExecDestroy(graph_exec));
+  CHECK_HIP(hipGraphDestroy(graph));
+  CHECK_HIP(hipStreamDestroy(stream));
 }
 
 void HipModuleInitTester::verifyResults(size_t size) {
+  (void)size;  // Not used in this verification test
+
   // Verify the kernel executed correctly
   int host_result = 0;
   CHECK_HIP(hipMemcpy(&host_result, device_result, sizeof(int),
@@ -189,12 +250,13 @@ void HipModuleInitTester::verifyResults(size_t size) {
 
   if (host_result == 42) {
     if (my_pe == 0) {
-      printf("✅ Kernel execution verified (result = %d)\n", host_result);
+      printf("PASS: Kernel execution verified (result = %d)\n", host_result);
     }
   } else {
-    if (my_pe == 0) {
-      fprintf(stderr, "❌ Kernel verification failed (expected 42, got %d)\n",
-              host_result);
-    }
+    // Explicitly fail the test when verification fails
+    fprintf(stderr, "[Rank %d] FAIL: Kernel verification failed (expected 42, got %d)\n",
+            my_pe, host_result);
+    // Exit with error to ensure test is reported as failed
+    rocshmem_global_exit(1);
   }
 }

--- a/projects/rocshmem/tests/functional_tests/hipmodule_init_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/hipmodule_init_tester.hpp
@@ -1,0 +1,59 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+#ifndef _HIPMODULE_INIT_TESTER_HPP_
+#define _HIPMODULE_INIT_TESTER_HPP_
+
+#include "tester.hpp"
+#include <hip/hip_runtime.h>
+
+using namespace rocshmem;
+
+/******************************************************************************
+ * HOST TESTER CLASS
+ *****************************************************************************/
+class HipModuleInitTester : public Tester {
+ public:
+  explicit HipModuleInitTester(TesterArguments args);
+  virtual ~HipModuleInitTester();
+
+ protected:
+  virtual void resetBuffers(size_t size) override;
+
+  virtual void launchKernel(dim3 gridSize, dim3 blockSize, int loop,
+                            size_t size) override;
+
+  virtual void verifyResults(size_t size) override;
+
+ private:
+  int my_pe;
+  int n_pes;
+  hipModule_t test_module;
+  hipFunction_t kernel_func;
+  int *device_result;
+};
+
+#include "hipmodule_init_tester.cpp"
+
+#endif

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -63,6 +63,7 @@
 #include "wavefront_primitives.hpp"
 #include "workgroup_primitives.hpp"
 #include "flood_tester.hpp"
+#include "hipmodule_init_tester.hpp"
 
 #include "backend_bc.hpp"
 extern Backend* backend;
@@ -554,6 +555,10 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
     case FloodGTestType:
       if (rank == 0) std::cout << "Flood G (multidirectional) ###" << std::endl;
       testers.push_back(new FloodTester(args));
+      return testers;
+    case HipModuleInitTestType:
+      if (rank == 0) std::cout << "HIP Module Init Test ###" << std::endl;
+      testers.push_back(new HipModuleInitTester(args));
       return testers;
     default:
       if (rank == 0) std::cout << "Empty Test ###" << std::endl;

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -680,6 +680,7 @@ bool Tester::peLaunchesKernel() {
     case FloodGetTestType:
     case FloodGetNBITestType:
     case FloodGTestType:
+    case HipModuleInitTestType:
       is_launcher = true;
       break;
     default:

--- a/projects/rocshmem/tests/functional_tests/tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/tester.hpp
@@ -126,6 +126,7 @@ enum TestType {
   FloodGetTestType = 86,
   FloodGetNBITestType = 87,
   FloodGTestType = 88,
+  HipModuleInitTestType = 89,
 };
 
 enum OpType { PutType = 0, GetType = 1 };


### PR DESCRIPTION
This commit adds a new API rocshmem_hipmodule_init() that allows
user-compiled HIP modules or device bitcode modules to be initialized with
rocSHMEM device contexts. This is essential for CUDA graph compatibility.

This API replaces manual rocshmem ctx management via rocshmem_get_device_ctx()
during JIT compilation.

Resolves: https://github.com/ROCm/rocm-systems/issues/2741

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
 Resolves AIROCSHMEM-145

## Test Plan

Functional test is added to verify module loading after successfully setting device global symbol.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
