### PR TITLE
[rocprofiler-sdk] Set stop packet signal to callback_data.completion

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
@@ -587,10 +587,12 @@ stop_agent_ctx(const context::context* ctx)
         if(!callback_data.profile->reqired_hw_counters.empty())
         {
             // Remove when AQL is updated to not require stop to be called first
+            callback_data.packet->packets.stop_packet.completion_signal = callback_data.completion;
+            hsa::get_core_table()->hsa_signal_store_relaxed_fn(callback_data.completion, 2);
             submitPacket(agent->profile_queue(), &callback_data.packet->packets.stop_packet);
         }
 
-        // Wait for the stop packet to complete
+        // Wait for the stop packet to complete (device decrements signal from 2 to 1)
         hsa::get_core_table()->hsa_signal_wait_relaxed_fn(callback_data.completion,
                                                           HSA_SIGNAL_CONDITION_EQ,
                                                           1,


### PR DESCRIPTION
## Summary
- Cherry-pick of b8040711c3 to release/rocm-rel-7.2.0.1
- Sets the stop packet completion signal and initializes value to 2 before submission so the device auto-decrements to 1 upon completion
- Fixes stop packet signal handling in device counting service

## Test plan
- [ ] Verify device counter collection works correctly with the fix
- [ ] Run counter collection integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)