### PR TITLE
[rocprofiler-systems] Reverted the change that removed guards around CPU agents initialization when no ROCM is available or included

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -565,7 +565,9 @@ rocprofsys_init_tooling_hidden(void)
         // if set to finalized, don't continue
         if(get_state() > State::Active) return;
 
+#if !defined(ROCPROFSYS_USE_ROCM) || ROCPROFSYS_USE_ROCM == 0
         rocprofsys_preinit_cpu_agents();
+#endif
 
         rocprofsys_preinit_cache();
 

--- a/projects/rocprofiler-systems/tests/rocprof-sys-preset-tests.cmake
+++ b/projects/rocprofiler-systems/tests/rocprof-sys-preset-tests.cmake
@@ -47,14 +47,16 @@ rocprofiler_systems_add_bin_test(
     PASS_REGEX "Preset:        --trace-hpc"
 )
 
-rocprofiler_systems_add_bin_test(
-    NAME preset-sample-workload-trace
-    TARGET rocprofiler-systems-sample
-    ARGS --workload-trace -v 2 -- ls
-    LABELS preset sample
-    TIMEOUT 60
-    PASS_REGEX "Preset:        --workload-trace"
-)
+if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU})
+    rocprofiler_systems_add_bin_test(
+        NAME preset-sample-workload-trace
+        TARGET rocprofiler-systems-sample
+        ARGS --workload-trace -v 2 -- ls
+        LABELS preset sample
+        TIMEOUT 60
+        PASS_REGEX "Preset:        --workload-trace"
+    )
+endif()
 
 rocprofiler_systems_add_bin_test(
     NAME preset-sample-sys-trace
@@ -160,14 +162,16 @@ rocprofiler_systems_add_bin_test(
     PASS_REGEX "Preset:        --trace-hpc"
 )
 
-rocprofiler_systems_add_bin_test(
-    NAME preset-run-workload-trace
-    TARGET rocprofiler-systems-run
-    ARGS --workload-trace -v 2 -- ls
-    LABELS preset run
-    TIMEOUT 60
-    PASS_REGEX "Preset:        --workload-trace"
-)
+if(${ENABLE_ROCPD_TEST} AND ${_VALID_GPU})
+    rocprofiler_systems_add_bin_test(
+        NAME preset-run-workload-trace
+        TARGET rocprofiler-systems-run
+        ARGS --workload-trace -v 2 -- ls
+        LABELS preset run
+        TIMEOUT 60
+        PASS_REGEX "Preset:        --workload-trace"
+    )
+endif()
 
 rocprofiler_systems_add_bin_test(
     NAME preset-run-sys-trace


### PR DESCRIPTION
## Motivation

On of earlier PRs has removed the guards around CPU agents initialization that had the purpose of pre-initializing the CPU agents only when agent cannot be queried from ROCM stack. This caused duplication entries of CPU agents inside of the rocPD database.

## Technical Details


## JIRA ID

## Test Plan

## Test Result

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
