### PR TITLE
SWDEV-540027,SWDEV-533546 - Add e8m0 struct

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
@@ -1004,9 +1004,9 @@ __FP8_HOST_DEVICE_STATIC__ T_int internal_cvt_e8m0_to_int_type(__hip_fp8_storage
   if (f > __hip_internal::numeric_limits<T_int>::max()) {
     return __hip_internal::numeric_limits<T_int>::max();
   }
-  if (f < __hip_internal::numeric_limits<T_int>::lowest()) {
-    return __hip_internal::numeric_limits<T_int>::lowest();
-  }
+  // e8m0 encodes only non-negative scales (2^-127..2^127) and NaN is handled
+  // above, so f is always >= 0. The lowest() clamp is therefore unreachable
+  // even when T_int is signed.
   return static_cast<T_int>(f);
 }
 

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
@@ -45,8 +45,6 @@
 #endif
 #endif
 
-#include "host_defines.h"  // __hip_internal::
-
 #if !defined(__HIPCC_RTC__)
 #include "amd_hip_bf16.h"
 #include "amd_hip_mx_common.h"
@@ -54,6 +52,7 @@
 #include <hip/amd_detail/amd_hip_common.h>
 #include <climits>
 
+#include "host_defines.h"
 #include "amd_hip_vector_types.h"  // float2 etc
 #include "amd_hip_fp16.h"          // __half_raw
 #include "math_fwd.h"              // ocml device functions

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
@@ -982,9 +982,6 @@ __FP8_HOST_DEVICE_STATIC__ double __internal_cvt_e8m0_to_double(const __hip_fp8_
   } ret;
 
   switch (x) {
-    case 0x00U:
-      ret.as_int = double_half_sig_bit;
-      break;
     case hip_detail::e8m0_NaN:
       ret.as_int = default_double_NaN;
       break;

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
@@ -47,11 +47,10 @@
 
 #include "host_defines.h"  // __hip_internal::
 
-// Include it explicitly for HIPRTC
+#if !defined(__HIPCC_RTC__)
 #include "amd_hip_bf16.h"
 #include "amd_hip_mx_common.h"
 
-#if !defined(__HIPCC_RTC__)
 #include <hip/amd_detail/amd_hip_common.h>
 #include <climits>
 

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
@@ -937,8 +937,8 @@ namespace hip_detail {
 
 constexpr __hip_fp8_storage_t e8m0_NaN = 0xFFU;
 constexpr __hip_internal::uint16_t bf16_NaN = 0x7FFFU;
-constexpr __hip_internal::uint32_t float_NaN = 0x7FFFFFFFU;
-constexpr __hip_internal::uint64_t double_NaN = 0x7FFFFFFFFFFFFFFFU;
+constexpr __hip_internal::uint32_t default_float_NaN = 0x7FFF0000U;
+constexpr __hip_internal::uint64_t default_double_NaN = 0x7FFF000000000000U;
 
 constexpr __hip_internal::uint16_t bf16_sig_mask = 0x007FU;
 constexpr __hip_internal::uint32_t float_sig_mask = 0x007FFFFFU;
@@ -968,7 +968,7 @@ __FP8_HOST_DEVICE_STATIC__ float __internal_cvt_e8m0_to_float(const __hip_fp8_st
       break;
     }
     case hip_detail::e8m0_NaN:
-      ret.as_int = float_NaN;
+      ret.as_int = default_float_NaN;
       break;
     default:
       ret.as_int = static_cast<__hip_internal::uint32_t>(x) << 23;
@@ -987,7 +987,7 @@ __FP8_HOST_DEVICE_STATIC__ double __internal_cvt_e8m0_to_double(const __hip_fp8_
       ret.as_int = double_half_sig_bit;
       break;
     case hip_detail::e8m0_NaN:
-      ret.as_int = double_NaN;
+      ret.as_int = default_double_NaN;
       break;
     default:
       // shift due to bias difference between double and single precision exponents

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
@@ -1125,7 +1125,6 @@ struct __hip_fp8_e8m0 {
 
   __hip_fp8_e8m0() = default;
   __FP8_HOST_DEVICE__ inline explicit __hip_fp8_e8m0(const __half f) {
-    float intermediate_float = static_cast<float>(f);
     __x = __hip_cvt_float_to_e8m0(f, __default_saturation, __default_interpret);
   }
   __FP8_HOST_DEVICE__ inline explicit __hip_fp8_e8m0(const __hip_bfloat16 f) {

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
@@ -1125,7 +1125,7 @@ struct __hip_fp8_e8m0 {
 
   __hip_fp8_e8m0() = default;
   __FP8_HOST_DEVICE__ inline explicit __hip_fp8_e8m0(const __half f) {
-    __x = __hip_cvt_float_to_e8m0(f, __default_saturation, __default_interpret);
+    __x = __hip_cvt_float_to_e8m0(__half2float(f), __default_saturation, __default_interpret);
   }
   __FP8_HOST_DEVICE__ inline explicit __hip_fp8_e8m0(const __hip_bfloat16 f) {
     __x = __hip_cvt_bfloat16raw_to_e8m0(f, __default_saturation, __default_interpret);

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
@@ -50,6 +50,7 @@
 #include "amd_hip_mx_common.h"
 #include <hip/amd_detail/amd_hip_common.h>
 #include <climits>
+#include <limits>
 
 #include "host_defines.h"          // __hip_internal::
 #include "amd_hip_vector_types.h"  // float2 etc
@@ -936,6 +937,8 @@ namespace hip_detail {
 
 constexpr __hip_fp8_storage_t e8m0_NaN = 0xFFU;
 constexpr __hip_internal::uint16_t bf16_NaN = 0x7FFFU;
+constexpr __hip_internal::uint32_t float_NaN = 0x7FFFFFFFU;
+constexpr __hip_internal::uint64_t double_NaN = 0x7FFFFFFFFFFFFFFFU;
 
 constexpr __hip_internal::uint16_t bf16_sig_mask = 0x007FU;
 constexpr __hip_internal::uint32_t float_sig_mask = 0x007FFFFFU;
@@ -952,6 +955,64 @@ constexpr __hip_internal::uint64_t double_sign_mask = 0x8000000000000000U;
 constexpr __hip_internal::uint16_t bf16_half_sig_bit = 0x0040U;
 constexpr __hip_internal::uint32_t float_half_sig_bit = 0x00400000U;
 constexpr __hip_internal::uint64_t double_half_sig_bit = 0x0008000000000000U;
+
+__FP8_HOST_DEVICE_STATIC__ float __internal_cvt_e8m0_to_float(const __hip_fp8_storage_t x) {
+  union {
+    float as_float;
+    __hip_internal::uint32_t as_int;
+  } ret;
+
+  switch (x) {
+    case 0x00U: {
+      ret.as_int = float_half_sig_bit;
+      break;
+    }
+    case hip_detail::e8m0_NaN:
+      ret.as_int = float_NaN;
+      break;
+    default:
+      ret.as_int = static_cast<__hip_internal::uint32_t>(x) << 23;
+  };
+  return ret.as_float;
+}
+
+__FP8_HOST_DEVICE_STATIC__ double __internal_cvt_e8m0_to_double(const __hip_fp8_storage_t x) {
+  union {
+    double as_double;
+    __hip_internal::uint64_t as_int;
+  } ret;
+
+  switch (x) {
+    case 0x00U:
+      ret.as_int = double_half_sig_bit;
+      break;
+    case hip_detail::e8m0_NaN:
+      ret.as_int = double_NaN;
+      break;
+    default:
+      // shift due to bias difference between double and single precision exponents
+      ret.as_int = (static_cast<__hip_internal::uint64_t>(x + 0x0380U) << 52);
+  }
+  return ret.as_double;
+}
+
+// Converts e8m0 to arbitrary integer type T
+// Uses conversion to float for bounds check
+// Double round not a concern as e8m0 is just the f32 mantissa
+template <typename T_int>
+__FP8_HOST_DEVICE_STATIC__ T_int internal_cvt_e8m0_to_int_type(__hip_fp8_storage_t x) {
+  float f = __internal_cvt_e8m0_to_float(x);
+  if (x == hip_detail::e8m0_NaN) {
+    return 0;
+  }
+  if (f > std::numeric_limits<T_int>::max()) {
+    return std::numeric_limits<T_int>::max();
+  }
+  if (f < std::numeric_limits<T_int>::lowest()) {
+    return std::numeric_limits<T_int>::lowest();
+  }
+  return static_cast<T_int>(f);
+}
 
 }  // namespace hip_detail
 
@@ -1049,13 +1110,122 @@ __FP8_HOST_DEVICE_STATIC__ __hip_bfloat16_raw
 __hip_cvt_e8m0_to_bf16raw(const __hip_fp8_storage_t x) {
   switch (x) {
     case 0x00U:
-      return __hip_bfloat16_raw{0x0040U};
+      return __hip_bfloat16_raw{hip_detail::bf16_half_sig_bit};
     case hip_detail::e8m0_NaN:
       return __hip_bfloat16_raw{hip_detail::bf16_NaN};
     default:
       return __hip_bfloat16_raw{static_cast<unsigned short>(x << 7)};
   }
 }
+
+struct __hip_fp8_e8m0 {
+  __hip_fp8_storage_t __x;  //! raw storage of fp8 number
+  constexpr static __hip_saturation_t __default_saturation = __HIP_SATFINITE;
+  constexpr static hipRoundMode __default_interpret = hipRoundPosInf;
+
+  __hip_fp8_e8m0() = default;
+  __FP8_HOST_DEVICE__ inline explicit __hip_fp8_e8m0(const __half f) {
+    float intermediate_float = static_cast<float>(f);
+    __x = __hip_cvt_float_to_e8m0(f, __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__ inline explicit __hip_fp8_e8m0(const __hip_bfloat16 f) {
+    __x = __hip_cvt_bfloat16raw_to_e8m0(f, __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__ inline explicit __hip_fp8_e8m0(const double f) {
+    __x = __hip_cvt_double_to_e8m0(f, __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__ inline explicit __hip_fp8_e8m0(const float f) {
+    __x = __hip_cvt_float_to_e8m0(f, __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__ inline explicit __hip_fp8_e8m0(const int val) {
+    __x =
+        __hip_cvt_float_to_e8m0(static_cast<float>(val), __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__ inline explicit __hip_fp8_e8m0(const long int val) {
+    __x =
+        __hip_cvt_float_to_e8m0(static_cast<float>(val), __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__
+  inline explicit __hip_fp8_e8m0(const long long int val) {
+    __x =
+        __hip_cvt_float_to_e8m0(static_cast<float>(val), __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__
+  inline explicit __hip_fp8_e8m0(const short int val) {
+    __x =
+        __hip_cvt_float_to_e8m0(static_cast<float>(val), __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__
+  inline explicit __hip_fp8_e8m0(const unsigned int val) {
+    __x =
+        __hip_cvt_float_to_e8m0(static_cast<float>(val), __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__
+  inline explicit __hip_fp8_e8m0(const unsigned long int val) {
+    __x =
+        __hip_cvt_float_to_e8m0(static_cast<float>(val), __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__
+  inline explicit __hip_fp8_e8m0(const unsigned long long int val) {
+    __x =
+        __hip_cvt_float_to_e8m0(static_cast<float>(val), __default_saturation, __default_interpret);
+  }
+  __FP8_HOST_DEVICE__
+  inline explicit __hip_fp8_e8m0(const unsigned short int val) {
+    __x =
+        __hip_cvt_float_to_e8m0(static_cast<float>(val), __default_saturation, __default_interpret);
+  }
+
+  __FP8_HOST_DEVICE__ inline explicit operator __half() const {
+    return __float2half_rn(static_cast<float>(*this));
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator __hip_bfloat16() const {
+    return static_cast<__hip_bfloat16>(__hip_cvt_e8m0_to_bf16raw(__x));
+  }
+
+  /* fp8_e8m0 can't represent a zero value, so always return true.*/
+  __FP8_HOST_DEVICE__ inline explicit operator bool() const { return true; }
+  __FP8_HOST_DEVICE__ inline explicit operator char() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<char>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator double() const {
+    return hip_detail::__internal_cvt_e8m0_to_double(__x);
+  }
+
+  __FP8_HOST_DEVICE__ inline explicit operator float() const {
+    return hip_detail::__internal_cvt_e8m0_to_float(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator int() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<int>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator long int() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<long int>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator long long int() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<long long int>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator short int() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<short int>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator signed char() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<signed char>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator unsigned char() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<unsigned char>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator unsigned int() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<unsigned int>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator unsigned long int() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<unsigned long int>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator unsigned long long int() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<unsigned long long int>(__x);
+  }
+  __FP8_HOST_DEVICE__ inline explicit operator unsigned short int() const {
+    return hip_detail::internal_cvt_e8m0_to_int_type<unsigned short int>(__x);
+  }
+};
 
 /**
  * \brief struct representing single fp8 number with e4m3 interpretation

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
@@ -1001,7 +1001,7 @@ __FP8_HOST_DEVICE_STATIC__ T_int internal_cvt_e8m0_to_int_type(__hip_fp8_storage
   if (x == hip_detail::e8m0_NaN) {
     return 0;
   }
-  if (f > __hip_internal::numeric_limits<T_int>::max()) {
+  if (f >= __hip_internal::numeric_limits<T_int>::max()) {
     return __hip_internal::numeric_limits<T_int>::max();
   }
   // e8m0 encodes only non-negative scales (2^-127..2^127) and NaN is handled

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
@@ -45,19 +45,20 @@
 #endif
 #endif
 
-#if !defined(__HIPCC_RTC__)
+#include "host_defines.h"  // __hip_internal::
+
+// Include it explicitly for HIPRTC
 #include "amd_hip_bf16.h"
 #include "amd_hip_mx_common.h"
+
+#if !defined(__HIPCC_RTC__)
 #include <hip/amd_detail/amd_hip_common.h>
 #include <climits>
-#include <limits>
 
-#include "host_defines.h"          // __hip_internal::
 #include "amd_hip_vector_types.h"  // float2 etc
 #include "amd_hip_fp16.h"          // __half_raw
 #include "math_fwd.h"              // ocml device functions
 #include "hip_assert.h"            // hip assertions
-
 #define __HIP_SCHAR_MAX SCHAR_MAX
 #define __HIP_SCHAR_MIN SCHAR_MIN
 #define __HIP_UCHAR_MAX UCHAR_MAX
@@ -1005,11 +1006,11 @@ __FP8_HOST_DEVICE_STATIC__ T_int internal_cvt_e8m0_to_int_type(__hip_fp8_storage
   if (x == hip_detail::e8m0_NaN) {
     return 0;
   }
-  if (f > std::numeric_limits<T_int>::max()) {
-    return std::numeric_limits<T_int>::max();
+  if (f > __hip_internal::numeric_limits<T_int>::max()) {
+    return __hip_internal::numeric_limits<T_int>::max();
   }
-  if (f < std::numeric_limits<T_int>::lowest()) {
-    return std::numeric_limits<T_int>::lowest();
+  if (f < __hip_internal::numeric_limits<T_int>::lowest()) {
+    return __hip_internal::numeric_limits<T_int>::lowest();
   }
   return static_cast<T_int>(f);
 }

--- a/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
@@ -111,12 +111,42 @@ template <typename _Tp> struct numeric_limits {
   static constexpr _Tp lowest() noexcept { return _Tp(); }
 };
 
-#define __HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER(_Type, _MinValue, _MaxValue)                  \
+template <size_t _NumBytes> struct __hip_internal_unsigned_of_size;
+template <> struct __hip_internal_unsigned_of_size<1> {
+  using type = unsigned char;
+};
+template <> struct __hip_internal_unsigned_of_size<2> {
+  using type = unsigned short;
+};
+template <> struct __hip_internal_unsigned_of_size<4> {
+  using type = unsigned int;
+};
+template <> struct __hip_internal_unsigned_of_size<8> {
+  using type = unsigned long long;
+};
+
+template <typename _Type>
+constexpr _Type __hip_internal_unsigned_max() noexcept {
+  return static_cast<_Type>(~static_cast<_Type>(0));
+}
+
+template <typename _Type>
+constexpr _Type __hip_internal_signed_max() noexcept {
+  using _UnsignedType = typename __hip_internal_unsigned_of_size<sizeof(_Type)>::type;
+  return static_cast<_Type>(__hip_internal_unsigned_max<_UnsignedType>() >> 1);
+}
+
+template <typename _Type>
+constexpr _Type __hip_internal_signed_min() noexcept {
+  return static_cast<_Type>(-__hip_internal_signed_max<_Type>() - 1);
+}
+
+#define __HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER(_Type)                                          \
   template <> struct numeric_limits<_Type> {                                                         \
     static constexpr bool is_specialized = true;                                                     \
     static constexpr bool is_signed = true;                                                          \
-    static constexpr _Type min() noexcept { return static_cast<_Type>(_MinValue); }                 \
-    static constexpr _Type max() noexcept { return static_cast<_Type>(_MaxValue); }                 \
+    static constexpr _Type min() noexcept { return __hip_internal_signed_min<_Type>(); }            \
+    static constexpr _Type max() noexcept { return __hip_internal_signed_max<_Type>(); }            \
     static constexpr _Type lowest() noexcept { return min(); }                                       \
   }
 
@@ -125,21 +155,32 @@ template <typename _Tp> struct numeric_limits {
     static constexpr bool is_specialized = true;                                                     \
     static constexpr bool is_signed = false;                                                         \
     static constexpr _Type min() noexcept { return static_cast<_Type>(0); }                         \
-    static constexpr _Type max() noexcept { return static_cast<_Type>(~static_cast<_Type>(0)); }    \
+    static constexpr _Type max() noexcept { return __hip_internal_unsigned_max<_Type>(); }          \
     static constexpr _Type lowest() noexcept { return min(); }                                       \
   }
 
-__HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER(signed char, (-__SCHAR_MAX__ - 1), __SCHAR_MAX__);
+__HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER(signed char);
 __HIP_INTERNAL_NUMERIC_LIMITS_UNSIGNED_INTEGER(unsigned char);
-__HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER(short, (-__SHRT_MAX__ - 1), __SHRT_MAX__);
+__HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER(short);
 __HIP_INTERNAL_NUMERIC_LIMITS_UNSIGNED_INTEGER(unsigned short);
-__HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER(int, (-__INT_MAX__ - 1), __INT_MAX__);
+__HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER(int);
 __HIP_INTERNAL_NUMERIC_LIMITS_UNSIGNED_INTEGER(unsigned int);
-__HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER(long, (-__LONG_MAX__ - 1L), __LONG_MAX__);
+__HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER(long);
 __HIP_INTERNAL_NUMERIC_LIMITS_UNSIGNED_INTEGER(unsigned long);
-__HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER(long long, (-__LONG_LONG_MAX__ - 1LL),
-                                             __LONG_LONG_MAX__);
+__HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER(long long);
 __HIP_INTERNAL_NUMERIC_LIMITS_UNSIGNED_INTEGER(unsigned long long);
+template <> struct numeric_limits<char> {
+  static constexpr bool is_specialized = true;
+  static constexpr bool is_signed = __hip_internal::is_signed<char>::value;
+  static constexpr char min() noexcept {
+    return is_signed ? __hip_internal_signed_min<char>() : static_cast<char>(0);
+  }
+  static constexpr char max() noexcept {
+    return is_signed ? __hip_internal_signed_max<char>()
+                     : static_cast<char>(__hip_internal_unsigned_max<unsigned char>());
+  }
+  static constexpr char lowest() noexcept { return min(); }
+};
 
 template <> struct numeric_limits<float> {
   static constexpr bool is_specialized = true;

--- a/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
@@ -182,22 +182,6 @@ template <> struct numeric_limits<char> {
   static constexpr char lowest() noexcept { return min(); }
 };
 
-template <> struct numeric_limits<float> {
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_signed = true;
-  static constexpr float min() noexcept { return __FLT_MIN__; }
-  static constexpr float max() noexcept { return __FLT_MAX__; }
-  static constexpr float lowest() noexcept { return -__FLT_MAX__; }
-};
-
-template <> struct numeric_limits<double> {
-  static constexpr bool is_specialized = true;
-  static constexpr bool is_signed = true;
-  static constexpr double min() noexcept { return __DBL_MIN__; }
-  static constexpr double max() noexcept { return __DBL_MAX__; }
-  static constexpr double lowest() noexcept { return -__DBL_MAX__; }
-};
-
 #undef __HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER
 #undef __HIP_INTERNAL_NUMERIC_LIMITS_UNSIGNED_INTEGER
 

--- a/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
@@ -104,6 +104,62 @@ template <typename _Tp> struct is_signed<_Tp, true> : public true_or_false_type<
 template< class... >
 using void_t = void;
 
+template <typename _Tp> struct numeric_limits {
+  static constexpr bool is_specialized = false;
+  static constexpr _Tp min() noexcept { return _Tp(); }
+  static constexpr _Tp max() noexcept { return _Tp(); }
+  static constexpr _Tp lowest() noexcept { return _Tp(); }
+};
+
+#define __HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER(_Type, _MinValue, _MaxValue)                  \
+  template <> struct numeric_limits<_Type> {                                                         \
+    static constexpr bool is_specialized = true;                                                     \
+    static constexpr bool is_signed = true;                                                          \
+    static constexpr _Type min() noexcept { return static_cast<_Type>(_MinValue); }                 \
+    static constexpr _Type max() noexcept { return static_cast<_Type>(_MaxValue); }                 \
+    static constexpr _Type lowest() noexcept { return min(); }                                       \
+  }
+
+#define __HIP_INTERNAL_NUMERIC_LIMITS_UNSIGNED_INTEGER(_Type)                                        \
+  template <> struct numeric_limits<_Type> {                                                         \
+    static constexpr bool is_specialized = true;                                                     \
+    static constexpr bool is_signed = false;                                                         \
+    static constexpr _Type min() noexcept { return static_cast<_Type>(0); }                         \
+    static constexpr _Type max() noexcept { return static_cast<_Type>(~static_cast<_Type>(0)); }    \
+    static constexpr _Type lowest() noexcept { return min(); }                                       \
+  }
+
+__HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER(signed char, (-__SCHAR_MAX__ - 1), __SCHAR_MAX__);
+__HIP_INTERNAL_NUMERIC_LIMITS_UNSIGNED_INTEGER(unsigned char);
+__HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER(short, (-__SHRT_MAX__ - 1), __SHRT_MAX__);
+__HIP_INTERNAL_NUMERIC_LIMITS_UNSIGNED_INTEGER(unsigned short);
+__HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER(int, (-__INT_MAX__ - 1), __INT_MAX__);
+__HIP_INTERNAL_NUMERIC_LIMITS_UNSIGNED_INTEGER(unsigned int);
+__HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER(long, (-__LONG_MAX__ - 1L), __LONG_MAX__);
+__HIP_INTERNAL_NUMERIC_LIMITS_UNSIGNED_INTEGER(unsigned long);
+__HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER(long long, (-__LONG_LONG_MAX__ - 1LL),
+                                             __LONG_LONG_MAX__);
+__HIP_INTERNAL_NUMERIC_LIMITS_UNSIGNED_INTEGER(unsigned long long);
+
+template <> struct numeric_limits<float> {
+  static constexpr bool is_specialized = true;
+  static constexpr bool is_signed = true;
+  static constexpr float min() noexcept { return __FLT_MIN__; }
+  static constexpr float max() noexcept { return __FLT_MAX__; }
+  static constexpr float lowest() noexcept { return -__FLT_MAX__; }
+};
+
+template <> struct numeric_limits<double> {
+  static constexpr bool is_specialized = true;
+  static constexpr bool is_signed = true;
+  static constexpr double min() noexcept { return __DBL_MIN__; }
+  static constexpr double max() noexcept { return __DBL_MAX__; }
+  static constexpr double lowest() noexcept { return -__DBL_MAX__; }
+};
+
+#undef __HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER
+#undef __HIP_INTERNAL_NUMERIC_LIMITS_UNSIGNED_INTEGER
+
 template <class T> auto test_returnable(int)
     -> decltype(void(static_cast<T (*)()>(nullptr)), true_type{});
 template <class> auto test_returnable(...) -> false_type;

--- a/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
@@ -104,6 +104,15 @@ template <typename _Tp> struct is_signed<_Tp, true> : public true_or_false_type<
 template< class... >
 using void_t = void;
 
+#if defined(_WIN32)
+#ifdef min
+#undef min
+#endif
+#ifdef max
+#undef max
+#endif
+#endif
+
 template <typename _Tp> struct numeric_limits {
   static constexpr bool is_specialized = false;
   static constexpr _Tp min() noexcept { return _Tp(); }

--- a/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/host_defines.h
@@ -105,6 +105,8 @@ template< class... >
 using void_t = void;
 
 #if defined(_WIN32)
+#pragma push_macro("min")
+#pragma push_macro("max")
 #ifdef min
 #undef min
 #endif
@@ -190,6 +192,11 @@ template <> struct numeric_limits<char> {
   }
   static constexpr char lowest() noexcept { return min(); }
 };
+
+#if defined(_WIN32)
+#pragma pop_macro("max")
+#pragma pop_macro("min")
+#endif
 
 #undef __HIP_INTERNAL_NUMERIC_LIMITS_SIGNED_INTEGER
 #undef __HIP_INTERNAL_NUMERIC_LIMITS_UNSIGNED_INTEGER

--- a/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
@@ -341,6 +341,21 @@ deviceLib:
   Unit__hip_cvt_e8m0_to_bf16raw:
     <<: *level_2
     tags: [types]
+  Unit_e8m0_float_constructors:
+    <<: *level_2
+    tags: [types]
+  Unit_e8m0_int_constructors:
+    <<: *level_2
+    tags: [types]
+  Unit_e8m0_float_conversions:
+    <<: *level_2
+    tags: [types]
+  Unit_e8m0_int_conversions:
+    <<: *level_2
+    tags: [types]
+  Unit_e8m0_int_conversions_saturation:
+    <<: *level_2
+    tags: [types]
   Unit_all_fp6_ocp_vector_cvt_interger_data:
     <<: *level_2
     tags: [types]

--- a/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
@@ -359,6 +359,9 @@ deviceLib:
   Unit_e8m0_int_conversions_saturation:
     <<: *level_2
     tags: [types]
+  Unit_e8m0_int_conversions_saturation_boundary:
+    <<: *level_2
+    tags: [types]
   Unit_all_fp6_ocp_vector_cvt_interger_data:
     <<: *level_2
     tags: [types]

--- a/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
@@ -353,6 +353,9 @@ deviceLib:
   Unit_e8m0_int_conversions:
     <<: *level_2
     tags: [types]
+  Unit__hip_cvt_e8m0_to_double_exhaustive_host:
+    <<: *level_2
+    tags: [types]
   Unit_e8m0_int_conversions_saturation:
     <<: *level_2
     tags: [types]

--- a/projects/hip-tests/catch/unit/deviceLib/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/deviceLib/CMakeLists.txt
@@ -69,7 +69,7 @@ set(AMD_TEST_SRC
     AtomicsWithRandomActiveLanesInWavefront.cc
     fp16_ops.cc
     fp8_host.cc
-    # fp8_e8m0.cc # TODO, reenable it, disabling this test due to failure seen on TheRock,
+    fp8_e8m0.cc
     fp6_ocp.cc
     fp4_ocp.cc
     memcpy_async.cc

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
@@ -373,7 +373,7 @@ template <typename T_in, typename T_out>
 void device_e8m0_constructors(const std::vector<T_in>& in, std::vector<T_out>& out) {
   T_in* in_d = nullptr;
   T_out* out_d = nullptr;
-  REQUIRE(in.size() =< 1024);
+  REQUIRE(in.size() <= 1024);
 
   HIP_CHECK(hipMalloc(&in_d, sizeof(T_in) * in.size()));
   HIP_CHECK(hipMalloc(&out_d, sizeof(T_out) * out.size()));
@@ -406,7 +406,7 @@ void compare_e8m0_results(const std::vector<T>& out, const std::vector<T>& exp) 
   }
 }
 
-TEMPLATE_TEST_CASE("Unit_e8m0_float_constructors", , half, __hip_bfloat16, float, double) {
+HIP_TEMPLATE_TEST_CASE(Unit_e8m0_float_constructors, , half, __hip_bfloat16, float, double) {
   bool run_on_host = GENERATE(true, false);
 
   std::vector<TestType> in = {0, 10, 16, -10, -16, std::nanf("0")};
@@ -435,8 +435,8 @@ TEMPLATE_TEST_CASE("Unit_e8m0_float_constructors", , half, __hip_bfloat16, float
   }
 }
 
-TEMPLATE_TEST_CASE("Unit_e8m0_int_constructors", , int, long int, long long int, short int,
-                   unsigned int, unsigned long int, unsigned long long int, unsigned short int) {
+HIP_TEMPLATE_TEST_CASE(Unit_e8m0_int_constructors, , int, long int, long long int, short int,
+                       unsigned int, unsigned long int, unsigned long long int, unsigned short int) {
   bool run_on_host = GENERATE(true, false);
 
   std::vector<TestType> in = {
@@ -507,7 +507,7 @@ void device_e8m0_float_conversions(const std::vector<float>& in, std::vector<T_o
   HIP_CHECK(hipFree(out_d));
 }
 
-TEMPLATE_TEST_CASE("Unit_e8m0_float_conversions", , half, __hip_bfloat16, float, double) {
+HIP_TEMPLATE_TEST_CASE(Unit_e8m0_float_conversions, , half, __hip_bfloat16, float, double) {
   bool run_on_host = GENERATE(true, false);
 
   std::vector<float> in = {0.0f, 10.0f, 16.0f, -10.0f, -16.0f, std::nanf("0")};
@@ -536,9 +536,9 @@ TEMPLATE_TEST_CASE("Unit_e8m0_float_conversions", , half, __hip_bfloat16, float,
   }
 }
 
-TEMPLATE_TEST_CASE("Unit_e8m0_int_conversions", , char, int, long int, long long int, short int,
-                   signed char, unsigned char, unsigned int, unsigned long int,
-                   unsigned long long int, unsigned short int) {
+HIP_TEMPLATE_TEST_CASE(Unit_e8m0_int_conversions, , char, int, long int, long long int, short int,
+                       signed char, unsigned char, unsigned int, unsigned long int,
+                       unsigned long long int, unsigned short int) {
   bool run_on_host = GENERATE(true, false);
 
   std::vector<float> in = {0.0f, 1.0f, 2.0f, 4.0f, 8.0f, 15.0f, 16.0f, 32.0f, 64.0f};
@@ -608,9 +608,9 @@ void device_e8m0_saturation_conversions(const std::vector<unsigned char>& in,
   HIP_CHECK(hipFree(out_d));
 }
 
-TEMPLATE_TEST_CASE("Unit_e8m0_int_conversions_saturation", , char, int, long int, long long int,
-                   short int, signed char, unsigned char, unsigned int, unsigned long int,
-                   unsigned long long int, unsigned short int) {
+HIP_TEMPLATE_TEST_CASE(Unit_e8m0_int_conversions_saturation, , char, int, long int, long long int,
+                       short int, signed char, unsigned char, unsigned int, unsigned long int,
+                       unsigned long long int, unsigned short int) {
   bool run_on_host = GENERATE(true, false);
 
   // Test with maximum non-NAN e8m0 value

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
@@ -345,3 +345,281 @@ HIP_TEST_CASE(Unit__hip_cvt_e8m0_to_bf16raw) {
     }
   }
 }
+
+template <typename T_in, typename T_out>
+void host_e8m0_constructors(const std::vector<T_in>& in, std::vector<T_out>& out) {
+  for (size_t i = 0; i < in.size(); ++i) {
+    __hip_fp8_e8m0 fp8(in[i]);
+    out[i] = static_cast<T_out>(fp8);
+  }
+}
+
+template <typename T_in, typename T_out>
+__global__ void e8m0_constructors_kernel(const T_in* in, T_out* out, size_t size) {
+  size_t tid = threadIdx.x + blockDim.x * blockIdx.x;
+
+  if (tid < size) {
+    __hip_fp8_e8m0 fp8(in[tid]);
+    out[tid] = static_cast<T_out>(fp8);
+  }
+}
+
+template <typename T_in, typename T_out>
+void device_e8m0_constructors(const std::vector<T_in>& in, std::vector<T_out>& out) {
+  T_in* in_d = nullptr;
+  T_out* out_d = nullptr;
+  REQUIRE(in.size() < 1024);
+
+  HIP_CHECK(hipMalloc(&in_d, sizeof(T_in) * in.size()));
+  HIP_CHECK(hipMalloc(&out_d, sizeof(T_out) * out.size()));
+
+  HIP_CHECK(hipMemcpy(in_d, in.data(), sizeof(T_in) * in.size(), hipMemcpyHostToDevice));
+
+  e8m0_constructors_kernel<T_in, T_out><<<1, 1024>>>(in_d, out_d, in.size());
+
+  HIP_CHECK(hipMemcpy(out.data(), out_d, sizeof(T_out) * out.size(), hipMemcpyDeviceToHost));
+
+  HIP_CHECK(hipFree(in_d));
+  HIP_CHECK(hipFree(out_d));
+}
+
+template <typename T>
+void compare_e8m0_results(const std::vector<T>& out, const std::vector<T>& exp) {
+  for (size_t i = 0; i < out.size(); ++i) {
+    INFO("out:" << out[i] << " exp:" << exp[i] << " for index:" << i);
+    if constexpr (std::is_floating_point_v<T>) {
+      if (std::isnan(exp[i])) {
+        REQUIRE(std::isnan(out[i]));
+      } else {
+        REQUIRE_THAT(out[i],
+                     Catch::WithinAbs(exp[i], (T)1e-6) || Catch::WithinRel(exp[i], (T)1e-3));
+      }
+    } else {
+      REQUIRE(out[i] == exp[i]);
+    }
+  }
+}
+
+TEMPLATE_TEST_CASE("Unit_e8m0_float_constructors", , half, __hip_bfloat16, float, double) {
+  bool run_on_host = GENERATE(true, false);
+
+  std::vector<TestType> in = {0, 10, 16, -10, -16, std::nanf("0")};
+  std::array<float, 6> exp_values = {0, 16, 16, 16, 16, std::nanf("0")};
+
+  if constexpr (std::is_same_v<TestType, half> || std::is_same_v<TestType, __hip_bfloat16>) {
+    std::vector<float> exp(exp_values.begin(), exp_values.end());
+    std::vector<float> out(exp.size());
+
+    if (run_on_host) {
+      host_e8m0_constructors<TestType, float>(in, out);
+    } else {
+      device_e8m0_constructors<TestType, float>(in, out);
+    }
+    compare_e8m0_results(out, exp);
+  } else {
+    std::vector<TestType> exp(exp_values.begin(), exp_values.end());
+    std::vector<TestType> out(exp.size());
+
+    if (run_on_host) {
+      host_e8m0_constructors<TestType, TestType>(in, out);
+    } else {
+      device_e8m0_constructors<TestType, TestType>(in, out);
+    }
+    compare_e8m0_results(out, exp);
+  }
+}
+
+TEMPLATE_TEST_CASE("Unit_e8m0_int_constructors", , int, long int, long long int, short int,
+                   unsigned int, unsigned long int, unsigned long long int, unsigned short int) {
+  bool run_on_host = GENERATE(true, false);
+
+  std::vector<TestType> in = {
+      static_cast<TestType>(0),  static_cast<TestType>(1),  static_cast<TestType>(2),
+      static_cast<TestType>(4),  static_cast<TestType>(8),  static_cast<TestType>(15),
+      static_cast<TestType>(16), static_cast<TestType>(32), static_cast<TestType>(64)};
+  std::vector<TestType> exp = {
+      static_cast<TestType>(0),  static_cast<TestType>(1),  static_cast<TestType>(2),
+      static_cast<TestType>(4),  static_cast<TestType>(8),  static_cast<TestType>(16),
+      static_cast<TestType>(16), static_cast<TestType>(32), static_cast<TestType>(64)};
+
+  if constexpr (std::is_signed_v<TestType>) {
+    in.insert(in.end(),
+              {static_cast<TestType>(-1), static_cast<TestType>(-2), static_cast<TestType>(-4),
+               static_cast<TestType>(-8), static_cast<TestType>(-15), static_cast<TestType>(-16),
+               static_cast<TestType>(-32), static_cast<TestType>(-64)});
+    exp.insert(exp.end(),
+               {static_cast<TestType>(1), static_cast<TestType>(2), static_cast<TestType>(4),
+                static_cast<TestType>(8), static_cast<TestType>(16), static_cast<TestType>(16),
+                static_cast<TestType>(32), static_cast<TestType>(64)});
+  }
+
+  std::vector<TestType> out(exp.size());
+
+  if (run_on_host) {
+    host_e8m0_constructors<TestType, TestType>(in, out);
+  } else {
+    device_e8m0_constructors<TestType, TestType>(in, out);
+  }
+  compare_e8m0_results(out, exp);
+}
+
+template <typename T_out>
+void host_e8m0_float_conversions(const std::vector<float>& in, std::vector<T_out>& out) {
+  for (size_t i = 0; i < in.size(); ++i) {
+    __hip_fp8_e8m0 fp8(in[i]);
+    out[i] = static_cast<T_out>(fp8);
+  }
+}
+
+template <typename T_out>
+__global__ void e8m0_float_conversions_kernel(const float* in, T_out* out, size_t size) {
+  size_t tid = threadIdx.x + blockDim.x * blockIdx.x;
+
+  if (tid < size) {
+    __hip_fp8_e8m0 fp8(in[tid]);
+    out[tid] = static_cast<T_out>(fp8);
+  }
+}
+
+template <typename T_out>
+void device_e8m0_float_conversions(const std::vector<float>& in, std::vector<T_out>& out) {
+  float* in_d = nullptr;
+  T_out* out_d = nullptr;
+  REQUIRE(in.size() < 1024);
+
+  HIP_CHECK(hipMalloc(&in_d, sizeof(float) * in.size()));
+  HIP_CHECK(hipMalloc(&out_d, sizeof(T_out) * out.size()));
+
+  HIP_CHECK(hipMemcpy(in_d, in.data(), sizeof(float) * in.size(), hipMemcpyHostToDevice));
+
+  e8m0_float_conversions_kernel<T_out><<<1, 1024>>>(in_d, out_d, in.size());
+
+  HIP_CHECK(hipMemcpy(out.data(), out_d, sizeof(T_out) * out.size(), hipMemcpyDeviceToHost));
+
+  HIP_CHECK(hipFree(in_d));
+  HIP_CHECK(hipFree(out_d));
+}
+
+TEMPLATE_TEST_CASE("Unit_e8m0_float_conversions", , half, __hip_bfloat16, float, double) {
+  bool run_on_host = GENERATE(true, false);
+
+  std::vector<float> in = {0.0f, 10.0f, 16.0f, -10.0f, -16.0f, std::nanf("0")};
+  std::array<float, 6> exp_values = {0.0f, 16.0f, 16.0f, 16.0f, 16.0f, std::nanf("0")};
+
+  if constexpr (std::is_same_v<TestType, half> || std::is_same_v<TestType, __hip_bfloat16>) {
+    std::vector<float> exp(exp_values.begin(), exp_values.end());
+    std::vector<float> out(exp.size());
+
+    if (run_on_host) {
+      host_e8m0_float_conversions<float>(in, out);
+    } else {
+      device_e8m0_float_conversions<float>(in, out);
+    }
+    compare_e8m0_results(out, exp);
+  } else {
+    std::vector<TestType> exp(exp_values.begin(), exp_values.end());
+    std::vector<TestType> out(exp.size());
+
+    if (run_on_host) {
+      host_e8m0_float_conversions<TestType>(in, out);
+    } else {
+      device_e8m0_float_conversions<TestType>(in, out);
+    }
+    compare_e8m0_results(out, exp);
+  }
+}
+
+TEMPLATE_TEST_CASE("Unit_e8m0_int_conversions", , char, double, float, int, long int, long long int,
+                   short int, signed char, unsigned char, unsigned int, unsigned long int,
+                   unsigned long long int, unsigned short int) {
+  bool run_on_host = GENERATE(true, false);
+
+  std::vector<float> in = {0.0f, 1.0f, 2.0f, 4.0f, 8.0f, 15.0f, 16.0f, 32.0f, 64.0f};
+  std::vector<TestType> exp = {
+      static_cast<TestType>(0),  static_cast<TestType>(1),  static_cast<TestType>(2),
+      static_cast<TestType>(4),  static_cast<TestType>(8),  static_cast<TestType>(16),
+      static_cast<TestType>(16), static_cast<TestType>(32), static_cast<TestType>(64)};
+  if constexpr (std::is_signed_v<TestType>) {
+    // Test negative values if signed
+    in.insert(in.end(), {-1.0f, -2.0f, -4.0f, -8.0f, -15.0f, -16.0f, -32.0f, -64.0f});
+    exp.insert(exp.end(),
+               {static_cast<TestType>(1), static_cast<TestType>(2), static_cast<TestType>(4),
+                static_cast<TestType>(8), static_cast<TestType>(16), static_cast<TestType>(16),
+                static_cast<TestType>(32), static_cast<TestType>(64)});
+  }
+
+  std::vector<TestType> out(exp.size());
+
+  if (run_on_host) {
+    host_e8m0_float_conversions<TestType>(in, out);
+  } else {
+    device_e8m0_float_conversions<TestType>(in, out);
+  }
+  compare_e8m0_results(out, exp);
+}
+
+template <typename T_out>
+void host_e8m0_saturation_conversions(const std::vector<unsigned char>& in,
+                                      std::vector<T_out>& out) {
+  for (size_t i = 0; i < in.size(); ++i) {
+    __hip_fp8_e8m0 fp8;
+    fp8.__x = in[i];
+    out[i] = static_cast<T_out>(fp8);
+  }
+}
+
+template <typename T_out>
+__global__ void e8m0_saturation_conversions_kernel(const unsigned char* in, T_out* out,
+                                                   size_t size) {
+  size_t tid = threadIdx.x + blockDim.x * blockIdx.x;
+
+  if (tid < size) {
+    __hip_fp8_e8m0 fp8;
+    fp8.__x = in[tid];
+    out[tid] = static_cast<T_out>(fp8);
+  }
+}
+
+template <typename T_out>
+void device_e8m0_saturation_conversions(const std::vector<unsigned char>& in,
+                                        std::vector<T_out>& out) {
+  unsigned char* in_d = nullptr;
+  T_out* out_d = nullptr;
+  REQUIRE(in.size() < 1024);
+
+  HIP_CHECK(hipMalloc(&in_d, sizeof(unsigned char) * in.size()));
+  HIP_CHECK(hipMalloc(&out_d, sizeof(T_out) * out.size()));
+
+  HIP_CHECK(hipMemcpy(in_d, in.data(), sizeof(unsigned char) * in.size(), hipMemcpyHostToDevice));
+
+  e8m0_saturation_conversions_kernel<T_out><<<1, 1024>>>(in_d, out_d, in.size());
+
+  HIP_CHECK(hipMemcpy(out.data(), out_d, sizeof(T_out) * out.size(), hipMemcpyDeviceToHost));
+
+  HIP_CHECK(hipFree(in_d));
+  HIP_CHECK(hipFree(out_d));
+}
+
+TEMPLATE_TEST_CASE("Unit_e8m0_int_conversions_saturation", , char, int, long int, long long int,
+                   short int, signed char, unsigned char, unsigned int, unsigned long int,
+                   unsigned long long int, unsigned short int) {
+  bool run_on_host = GENERATE(true, false);
+
+  // Test with maximum non-NAN e8m0 value
+  std::vector<unsigned char> in = {0xFE};
+  std::vector<TestType> out(in.size());
+
+  if (run_on_host) {
+    host_e8m0_saturation_conversions<TestType>(in, out);
+  } else {
+    device_e8m0_saturation_conversions<TestType>(in, out);
+  }
+
+  // Verify that the output is clamped to the maximum value of TestType
+  TestType expected_max = std::numeric_limits<TestType>::max();
+
+  for (size_t i = 0; i < out.size(); ++i) {
+    INFO("out:" << out[i] << " expected_max:" << expected_max << " for index:" << i);
+    REQUIRE(out[i] == expected_max);
+  }
+}

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
@@ -661,3 +661,41 @@ HIP_TEMPLATE_TEST_CASE(Unit_e8m0_int_conversions_saturation, char, int, long int
     REQUIRE(out[i] == expected_max);
   }
 }
+
+// Boundary-encoding saturation test for 32/64-bit integer types.
+//
+// For these widths, (float)numeric_limits<T>::max() rounds UP to 2^N (e.g.
+// (float)INT32_MAX rounds to 2^31). The e8m0 encoding (127 + N) decodes to
+// exactly 2^N as well, so the saturation comparison `f > max()` evaluated to
+// false at that boundary and the subsequent integer cast was UB per
+// [conv.fpint]/1. The boundary encodings:
+//   int32_t   -> enc 158 (= 127 + 31)
+//   uint32_t  -> enc 159 (= 127 + 32)
+//   int64_t   -> enc 190 (= 127 + 63)
+//   uint64_t  -> enc 191 (= 127 + 64)
+// Verify both the exact-boundary encoding and one step above it saturate to
+// numeric_limits<T>::max().
+HIP_TEMPLATE_TEST_CASE(Unit_e8m0_int_conversions_saturation_boundary, int, unsigned int,
+                       long long int, unsigned long long int) {
+  bool run_on_host = GENERATE(true, false);
+
+  constexpr unsigned int bit_width = sizeof(TestType) * 8u;
+  constexpr unsigned char boundary_enc = static_cast<unsigned char>(
+      127u + bit_width - (std::is_signed_v<TestType> ? 1u : 0u));
+
+  std::vector<unsigned char> in = {boundary_enc, static_cast<unsigned char>(boundary_enc + 1)};
+  std::vector<TestType> out(in.size());
+
+  if (run_on_host) {
+    host_e8m0_saturation_conversions<TestType>(in, out);
+  } else {
+    device_e8m0_saturation_conversions<TestType>(in, out);
+  }
+
+  TestType expected_max = std::numeric_limits<TestType>::max();
+  for (size_t i = 0; i < out.size(); ++i) {
+    INFO("encoding:0x" << std::hex << static_cast<unsigned>(in[i]) << std::dec
+                       << " out:" << out[i] << " expected_max:" << expected_max);
+    REQUIRE(out[i] == expected_max);
+  }
+}

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
@@ -529,8 +529,8 @@ TEMPLATE_TEST_CASE("Unit_e8m0_float_conversions", , half, __hip_bfloat16, float,
   }
 }
 
-TEMPLATE_TEST_CASE("Unit_e8m0_int_conversions", , char, double, float, int, long int, long long int,
-                   short int, signed char, unsigned char, unsigned int, unsigned long int,
+TEMPLATE_TEST_CASE("Unit_e8m0_int_conversions", , char, int, long int, long long int, short int,
+                   signed char, unsigned char, unsigned int, unsigned long int,
                    unsigned long long int, unsigned short int) {
   bool run_on_host = GENERATE(true, false);
 

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
@@ -392,7 +392,7 @@ void compare_e8m0_results(const std::vector<T>& out, const std::vector<T>& exp) 
         REQUIRE(std::isnan(out[i]));
       } else {
         REQUIRE_THAT(out[i],
-                     Catch::WithinAbs(exp[i], (T)1e-6) || Catch::WithinRel(exp[i], (T)1e-3));
+                     Catch::Matchers::WithinAbs(exp[i], (T)1e-6) || Catch::Matchers::WithinRel(exp[i], (T)1e-3));
       }
     } else {
       REQUIRE(out[i] == exp[i]);

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
@@ -491,7 +491,7 @@ template <typename T_out>
 void device_e8m0_float_conversions(const std::vector<float>& in, std::vector<T_out>& out) {
   float* in_d = nullptr;
   T_out* out_d = nullptr;
-  REQUIRE(in.size() < 1024);
+  REQUIRE(in.size() <= 1024);
 
   HIP_CHECK(hipMalloc(&in_d, sizeof(float) * in.size()));
   HIP_CHECK(hipMalloc(&out_d, sizeof(T_out) * out.size()));
@@ -592,7 +592,7 @@ void device_e8m0_saturation_conversions(const std::vector<unsigned char>& in,
                                         std::vector<T_out>& out) {
   unsigned char* in_d = nullptr;
   T_out* out_d = nullptr;
-  REQUIRE(in.size() < 1024);
+  REQUIRE(in.size() <= 1024);
 
   HIP_CHECK(hipMalloc(&in_d, sizeof(unsigned char) * in.size()));
   HIP_CHECK(hipMalloc(&out_d, sizeof(T_out) * out.size()));

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
@@ -608,6 +608,36 @@ void device_e8m0_saturation_conversions(const std::vector<unsigned char>& in,
   HIP_CHECK(hipFree(out_d));
 }
 
+// Exhaustively verify that the e8m0 -> double host conversion agrees with the
+// e8m0 -> float host conversion (upcast to double) for every one of the 256
+// encodings. The broader-than-pointwise coverage is intentional: a prior bug
+// produced 2^-1023 instead of 2^-127 at encoding 0x00 because the float
+// subnormal-mantissa trick was copy-pasted into the double path even though
+// double can represent 2^-127 as a normal number. Sweeping every encoding
+// against the float oracle catches that class of copy-paste drift wherever it
+// reappears, not just at the originally reported point.
+HIP_TEST_CASE(Unit__hip_cvt_e8m0_to_double_exhaustive_host) {
+  for (unsigned i = 0; i < 256u; ++i) {
+    unsigned char enc = static_cast<unsigned char>(i);
+    __hip_fp8_e8m0 fp8;
+    fp8.__x = enc;
+    double d = static_cast<double>(fp8);
+
+    if (enc == 0xFFu) {
+      INFO("encoding: 0x" << std::hex << static_cast<unsigned>(enc));
+      REQUIRE(std::isnan(d));
+    } else {
+      __hip_fp8_e8m0 fp8f;
+      fp8f.__x = enc;
+      float f = static_cast<float>(fp8f);
+      double expected = static_cast<double>(f);
+      INFO("encoding: 0x" << std::hex << static_cast<unsigned>(enc)
+                          << " out:" << d << " exp:" << expected);
+      REQUIRE(d == expected);
+    }
+  }
+}
+
 HIP_TEMPLATE_TEST_CASE(Unit_e8m0_int_conversions_saturation, char, int, long int, long long int,
                        short int, signed char, unsigned char, unsigned int, unsigned long int,
                        unsigned long long int, unsigned short int) {

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
@@ -39,6 +39,7 @@ void device_cvt_bfloat16raw_to_e8m0(const std::vector<__hip_bfloat16>& in,
   HIP_CHECK(hipMemcpy(in_d, in.data(), sizeof(__hip_bfloat16) * in.size(), hipMemcpyHostToDevice));
 
   bfloat16raw_to_e8m0<<<1, 1024>>>(in_d, out_d, in.size(), sat, round);
+  HIP_CHECK(hipGetLastError());
 
   HIP_CHECK(
       hipMemcpy(out.data(), out_d, sizeof(unsigned char) * out.size(), hipMemcpyDeviceToHost));
@@ -125,6 +126,7 @@ void device_cvt_float_to_e8m0(const std::vector<float>& in, std::vector<unsigned
   HIP_CHECK(hipMemcpy(in_d, in.data(), sizeof(float) * in.size(), hipMemcpyHostToDevice));
 
   float_to_e8m0_kernel<<<1, 1024>>>(in_d, out_d, in.size(), sat, round);
+  HIP_CHECK(hipGetLastError());
 
   HIP_CHECK(
       hipMemcpy(out.data(), out_d, sizeof(unsigned char) * out.size(), hipMemcpyDeviceToHost));
@@ -211,6 +213,7 @@ void device_cvt_double_to_e8m0(const std::vector<double>& in, std::vector<unsign
   HIP_CHECK(hipMemcpy(in_d, in.data(), sizeof(double) * in.size(), hipMemcpyHostToDevice));
 
   double_to_e8m0_kernel<<<1, 1024>>>(in_d, out_d, in.size(), sat, round);
+  HIP_CHECK(hipGetLastError());
 
   HIP_CHECK(
       hipMemcpy(out.data(), out_d, sizeof(unsigned char) * out.size(), hipMemcpyDeviceToHost));
@@ -317,6 +320,7 @@ void device_cvt_e8m0_to_bf16raw(const std::vector<unsigned char>& in, std::vecto
   HIP_CHECK(hipMemcpy(in_d, in.data(), sizeof(unsigned char) * in.size(), hipMemcpyHostToDevice));
 
   e8m0_to_bf16raw_kernel<<<1, 1024>>>(in_d, out_d, in.size());
+  HIP_CHECK(hipGetLastError());
 
   HIP_CHECK(hipMemcpy(out.data(), out_d, sizeof(float) * out.size(), hipMemcpyDeviceToHost));
 }
@@ -348,6 +352,7 @@ HIP_TEST_CASE(Unit__hip_cvt_e8m0_to_bf16raw) {
 
 template <typename T_in, typename T_out>
 void host_e8m0_constructors(const std::vector<T_in>& in, std::vector<T_out>& out) {
+  REQUIRE(in.size() == out.size());
   for (size_t i = 0; i < in.size(); ++i) {
     __hip_fp8_e8m0 fp8(in[i]);
     out[i] = static_cast<T_out>(fp8);
@@ -368,7 +373,7 @@ template <typename T_in, typename T_out>
 void device_e8m0_constructors(const std::vector<T_in>& in, std::vector<T_out>& out) {
   T_in* in_d = nullptr;
   T_out* out_d = nullptr;
-  REQUIRE(in.size() < 1024);
+  REQUIRE(in.size() =< 1024);
 
   HIP_CHECK(hipMalloc(&in_d, sizeof(T_in) * in.size()));
   HIP_CHECK(hipMalloc(&out_d, sizeof(T_out) * out.size()));
@@ -376,6 +381,7 @@ void device_e8m0_constructors(const std::vector<T_in>& in, std::vector<T_out>& o
   HIP_CHECK(hipMemcpy(in_d, in.data(), sizeof(T_in) * in.size(), hipMemcpyHostToDevice));
 
   e8m0_constructors_kernel<T_in, T_out><<<1, 1024>>>(in_d, out_d, in.size());
+  HIP_CHECK(hipGetLastError());
 
   HIP_CHECK(hipMemcpy(out.data(), out_d, sizeof(T_out) * out.size(), hipMemcpyDeviceToHost));
 
@@ -493,6 +499,7 @@ void device_e8m0_float_conversions(const std::vector<float>& in, std::vector<T_o
   HIP_CHECK(hipMemcpy(in_d, in.data(), sizeof(float) * in.size(), hipMemcpyHostToDevice));
 
   e8m0_float_conversions_kernel<T_out><<<1, 1024>>>(in_d, out_d, in.size());
+  HIP_CHECK(hipGetLastError());
 
   HIP_CHECK(hipMemcpy(out.data(), out_d, sizeof(T_out) * out.size(), hipMemcpyDeviceToHost));
 
@@ -593,6 +600,7 @@ void device_e8m0_saturation_conversions(const std::vector<unsigned char>& in,
   HIP_CHECK(hipMemcpy(in_d, in.data(), sizeof(unsigned char) * in.size(), hipMemcpyHostToDevice));
 
   e8m0_saturation_conversions_kernel<T_out><<<1, 1024>>>(in_d, out_d, in.size());
+  HIP_CHECK(hipGetLastError());
 
   HIP_CHECK(hipMemcpy(out.data(), out_d, sizeof(T_out) * out.size(), hipMemcpyDeviceToHost));
 

--- a/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
+++ b/projects/hip-tests/catch/unit/deviceLib/fp8_e8m0.cc
@@ -406,7 +406,7 @@ void compare_e8m0_results(const std::vector<T>& out, const std::vector<T>& exp) 
   }
 }
 
-HIP_TEMPLATE_TEST_CASE(Unit_e8m0_float_constructors, , half, __hip_bfloat16, float, double) {
+HIP_TEMPLATE_TEST_CASE(Unit_e8m0_float_constructors, half, __hip_bfloat16, float, double) {
   bool run_on_host = GENERATE(true, false);
 
   std::vector<TestType> in = {0, 10, 16, -10, -16, std::nanf("0")};
@@ -435,7 +435,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_e8m0_float_constructors, , half, __hip_bfloat16, flo
   }
 }
 
-HIP_TEMPLATE_TEST_CASE(Unit_e8m0_int_constructors, , int, long int, long long int, short int,
+HIP_TEMPLATE_TEST_CASE(Unit_e8m0_int_constructors, int, long int, long long int, short int,
                        unsigned int, unsigned long int, unsigned long long int, unsigned short int) {
   bool run_on_host = GENERATE(true, false);
 
@@ -507,7 +507,7 @@ void device_e8m0_float_conversions(const std::vector<float>& in, std::vector<T_o
   HIP_CHECK(hipFree(out_d));
 }
 
-HIP_TEMPLATE_TEST_CASE(Unit_e8m0_float_conversions, , half, __hip_bfloat16, float, double) {
+HIP_TEMPLATE_TEST_CASE(Unit_e8m0_float_conversions, half, __hip_bfloat16, float, double) {
   bool run_on_host = GENERATE(true, false);
 
   std::vector<float> in = {0.0f, 10.0f, 16.0f, -10.0f, -16.0f, std::nanf("0")};
@@ -536,7 +536,7 @@ HIP_TEMPLATE_TEST_CASE(Unit_e8m0_float_conversions, , half, __hip_bfloat16, floa
   }
 }
 
-HIP_TEMPLATE_TEST_CASE(Unit_e8m0_int_conversions, , char, int, long int, long long int, short int,
+HIP_TEMPLATE_TEST_CASE(Unit_e8m0_int_conversions, char, int, long int, long long int, short int,
                        signed char, unsigned char, unsigned int, unsigned long int,
                        unsigned long long int, unsigned short int) {
   bool run_on_host = GENERATE(true, false);
@@ -608,7 +608,7 @@ void device_e8m0_saturation_conversions(const std::vector<unsigned char>& in,
   HIP_CHECK(hipFree(out_d));
 }
 
-HIP_TEMPLATE_TEST_CASE(Unit_e8m0_int_conversions_saturation, , char, int, long int, long long int,
+HIP_TEMPLATE_TEST_CASE(Unit_e8m0_int_conversions_saturation, char, int, long int, long long int,
                        short int, signed char, unsigned char, unsigned int, unsigned long int,
                        unsigned long long int, unsigned short int) {
   bool run_on_host = GENERATE(true, false);


### PR DESCRIPTION
## Motivation

This PR adds the __hip_e8m0 fp8 struct. It is used to store the scaling value of a floating point/bf16 value. Primarily used for fast low precision arithmetic.

This PR is a re-rase of https://github.com/ROCm/rocm-systems/pull/2133 after being reverted due to a PyTorch compilation failure

## Technical Details

This PR adds the __hip_e8m0 fp8 struct and its associated conversions/constructors

## Test Plan

Testing has been added for these conversions and constructors. We test saturation, NaN's, negative values, and positive values on both host and devices.

## Test Result

Tests pass locally

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
