### PR TITLE
Remove HeapObject Wrapper

### DIFF
--- a/projects/clr/rocclr/device/blit.hpp
+++ b/projects/clr/rocclr/device/blit.hpp
@@ -19,7 +19,7 @@
 namespace amd::device {
 
 //! Blit Manager Abstraction class
-class BlitManager : public amd::HeapObject {
+class BlitManager {
  public:
   //! HW accelerated setup
   union Setup {

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -675,7 +675,7 @@ struct Info : public amd::EmbeddedObject {
 };
 
 //! Device settings
-class Settings : public amd::HeapObject {
+class Settings {
  public:
   enum KernelArgImpl {
     HostKernelArgs = 0,        //!< Kernel Arguments are put into host memory
@@ -749,7 +749,7 @@ class Settings : public amd::HeapObject {
 
 //! Device-independent cache memory, base class for the device-specific
 //! memories. One Memory instance refers to one or more of these.
-class Memory : public amd::HeapObject {
+class Memory {
  public:
   //! Resource map flags
   enum CpuMapFlags {
@@ -775,7 +775,7 @@ class Memory : public amd::HeapObject {
     SyncFlags() : value_(0) {}
   };
 
-  struct WriteMapInfo : public amd::HeapObject {
+  struct WriteMapInfo {
     amd::Coord3D origin_;  //!< Origin of the map location
     amd::Coord3D region_;  //!< Mapped region
     amd::Image* baseMip_;  //!< The base mip level for images
@@ -1015,7 +1015,7 @@ class Memory : public amd::HeapObject {
   Memory(const Memory&) = delete;
 };
 
-class Sampler : public amd::HeapObject {
+class Sampler {
  public:
   //! Constructor
   Sampler() : hwSrd_(0), hwState_(nullptr) {}
@@ -1041,7 +1041,7 @@ class Sampler : public amd::HeapObject {
   Sampler(const Sampler&);
 };
 
-class ClBinary : public amd::HeapObject {
+class ClBinary {
  public:
   enum BinaryImageFormat {
     BIF_VERSION2 = 0,  //!< Binary Image Format version 2.0 (ELF)
@@ -1225,7 +1225,7 @@ inline Program::binary_t Program::binary() {
  *
  *  \brief The device interface class for the performance counters
  */
-class PerfCounter : public amd::HeapObject {
+class PerfCounter {
  public:
   //! Constructor for the device performance
   PerfCounter() {}
@@ -1247,7 +1247,7 @@ class PerfCounter : public amd::HeapObject {
  *
  *  \brief The device interface class for the performance counters
  */
-class ThreadTrace : public amd::HeapObject {
+class ThreadTrace {
  public:
   //! Constructor for the device performance
   ThreadTrace() {}
@@ -1711,7 +1711,7 @@ class Device : public RuntimeObject {
 
   typedef std::list<CommandQueue*> CommandQueues;
 
-  struct BlitProgram : public amd::HeapObject {
+  struct BlitProgram {
     Program* program_;  //!< GPU program object
     Context* context_;  //!< A dummy context
 

--- a/projects/clr/rocclr/device/devkernel.hpp
+++ b/projects/clr/rocclr/device/devkernel.hpp
@@ -181,7 +181,7 @@ struct PrintfInfo {
 };
 
 //! \class DeviceKernel, which will contain the common fields for any device
-class Kernel : public amd::HeapObject {
+class Kernel {
  public:
   typedef std::vector<amd::KernelParameterDescriptor> parameters_t;
 

--- a/projects/clr/rocclr/device/devprogram.hpp
+++ b/projects/clr/rocclr/device/devprogram.hpp
@@ -49,7 +49,7 @@ struct SymbolLoweredName {
 };
 
 //! A program object for a specific device.
-class Program : public amd::HeapObject {
+class Program {
  public:
   typedef std::pair<const void* /* binary_image */, size_t /* binary size */> binary_t;
   typedef std::pair<amd::Os::FileDesc /* file_desc */, size_t /* file_offset */> finfo_t;

--- a/projects/clr/rocclr/device/devsignal.hpp
+++ b/projects/clr/rocclr/device/devsignal.hpp
@@ -15,7 +15,7 @@ class Device;
 namespace amd::device {
 
 // Light abstraction over HSA/PAL signals
-class Signal : public amd::HeapObject {
+class Signal {
  public:
   enum class Condition : uint32_t {
     Eq = 0,

--- a/projects/clr/rocclr/device/pal/palconstbuf.hpp
+++ b/projects/clr/rocclr/device/pal/palconstbuf.hpp
@@ -79,11 +79,7 @@ class ManagedBuffer : public amd::EmbeddedObject {
 };
 
 //! Constant buffer
-#ifdef ATI_OS_WIN
-class ConstantBuffer : public amd::HeapObject {
-#else
 class ConstantBuffer {
-#endif
  public:
   //! Constructor for the ConstBuffer class
   ConstantBuffer(ManagedBuffer& mbuf,  //!< Managed buffer

--- a/projects/clr/rocclr/device/pal/palconstbuf.hpp
+++ b/projects/clr/rocclr/device/pal/palconstbuf.hpp
@@ -79,7 +79,11 @@ class ManagedBuffer : public amd::EmbeddedObject {
 };
 
 //! Constant buffer
+#ifdef ATI_OS_WIN
 class ConstantBuffer : public amd::HeapObject {
+#else
+class ConstantBuffer {
+#endif
  public:
   //! Constructor for the ConstBuffer class
   ConstantBuffer(ManagedBuffer& mbuf,  //!< Managed buffer

--- a/projects/clr/rocclr/device/pal/paldefs.hpp
+++ b/projects/clr/rocclr/device/pal/paldefs.hpp
@@ -13,6 +13,46 @@
 #include "palFormatInfo.h"
 #include "util/palSysMemory.h"
 
+#include <cstdlib>
+#include <new>
+#include <utility>
+
+namespace amd {
+
+//! Allocate `sizeof(T) + extSize` bytes via std::malloc and placement-construct T at the
+//! start. The trailing `extSize` bytes are intended for caller-provided placement of
+//! supplementary data (e.g. a PAL object whose size is reported by IDevice::Get*Size()).
+//! Returns nullptr if allocation fails. If T's constructor throws, the storage is freed and
+//! the exception is rethrown — preserving the cleanup guarantee that HeapObject's matching
+//! placement-style operator delete used to provide.
+template <class T, class... Args>
+T* AllocWithTrailing(size_t extSize, Args&&... args) {
+  void* mem = std::malloc(sizeof(T) + extSize);
+  if (mem == nullptr) {
+    return nullptr;
+  }
+  try {
+    return new (mem) T(std::forward<Args>(args)...);
+  } catch (...) {
+    std::free(mem);
+    throw;
+  }
+}
+
+//! Counterpart to AllocWithTrailing: invokes T's destructor and frees the storage. Null-safe.
+//! Must be paired with AllocWithTrailing — calling it on memory obtained from any other
+//! allocator (including global ::operator new) is undefined behavior.
+template <class T>
+void DestroyWithTrailing(T* obj) {
+  if (obj == nullptr) {
+    return;
+  }
+  obj->~T();
+  std::free(obj);
+}
+
+}  // namespace amd
+
 //
 /// Memory Object Type
 //

--- a/projects/clr/rocclr/device/pal/paldevice.hpp
+++ b/projects/clr/rocclr/device/pal/paldevice.hpp
@@ -243,6 +243,14 @@ class Device : public NullDevice {
     QueueRecycleInfo(const Device& dev)
         : counter_(1), engineType_(Pal::EngineTypeCompute), index_(0), aql_packet_mgmt_(dev) {}
 
+    // Allocated exclusively via amd::AllocWithTrailing<QueueRecycleInfo>(extSize, ...) so the
+    // wrapper can carry an optional PAL IQueue placed in trailing storage. Plain new / delete
+    // would route through global ::operator new while DestroyWithTrailing calls std::free.
+    // Deleting these forces the contract at compile time. Use extSize == 0 on the path that
+    // carries no PAL trailing payload.
+    void* operator new(size_t) = delete;
+    void operator delete(void*) = delete;
+
     //! Returns the MQD's read_dispatch_id's address.
     uintptr_t DebuggerData() const {
       return reinterpret_cast<uintptr_t>(&aql_packet_mgmt_.amd_queue_.read_dispatch_id);

--- a/projects/clr/rocclr/device/pal/paldevice.hpp
+++ b/projects/clr/rocclr/device/pal/paldevice.hpp
@@ -230,11 +230,7 @@ class Sampler : public device::Sampler {
 //! A GPU device ordinal (physical GPU device)
 class Device : public NullDevice {
  public:
-#ifdef ATI_OS_WIN
-  struct QueueRecycleInfo : public amd::HeapObject {
-#else
   struct QueueRecycleInfo {
-#endif
     int counter_;                    //!< Lock usage counter
     Pal::EngineType engineType_;     //!< Engine type
     uint32_t index_;                 //!< HW queue index for scratch buffer access
@@ -271,11 +267,7 @@ class Device : public NullDevice {
   };
 
   //! Transfer buffers
-#ifdef ATI_OS_WIN
-  class XferBuffers : public amd::HeapObject {
-#else
   class XferBuffers {
-#endif
    public:
     static constexpr size_t MaxXferBufListSize = 8;
 
@@ -318,11 +310,7 @@ class Device : public NullDevice {
     const Device& gpuDevice_;         //!< GPU device object
   };
 
-#ifdef ATI_OS_WIN
-  struct ScratchBuffer : public amd::HeapObject {
-#else
   struct ScratchBuffer {
-#endif
     Memory* memObj_;   //!< Memory objects for scratch buffers
     uint64_t offset_;  //!< Offset from the global scratch store
     uint64_t size_;    //!< Scratch buffer size on this queue
@@ -338,11 +326,7 @@ class Device : public NullDevice {
   };
 
 
-#ifdef ATI_OS_WIN
-  class SrdManager : public amd::HeapObject {
-#else
   class SrdManager {
-#endif
    public:
     SrdManager(const Device& dev, uint srdSize, uint bufSize)
         : dev_(dev),

--- a/projects/clr/rocclr/device/pal/paldevice.hpp
+++ b/projects/clr/rocclr/device/pal/paldevice.hpp
@@ -239,11 +239,8 @@ class Device : public NullDevice {
     QueueRecycleInfo(const Device& dev)
         : counter_(1), engineType_(Pal::EngineTypeCompute), index_(0), aql_packet_mgmt_(dev) {}
 
-    // Allocated exclusively via amd::AllocWithTrailing<QueueRecycleInfo>(extSize, ...) so the
-    // wrapper can carry an optional PAL IQueue placed in trailing storage. Plain new / delete
-    // would route through global ::operator new while DestroyWithTrailing calls std::free.
-    // Deleting these forces the contract at compile time. Use extSize == 0 on the path that
-    // carries no PAL trailing payload.
+    // Allocated exclusively via amd::AllocWithTrailing<QueueRecycleInfo>(extSize, ...)
+    // Use extSize == 0 on the path that carries no PAL trailing payload.
     void* operator new(size_t) = delete;
     void operator delete(void*) = delete;
 

--- a/projects/clr/rocclr/device/pal/paldevice.hpp
+++ b/projects/clr/rocclr/device/pal/paldevice.hpp
@@ -230,7 +230,11 @@ class Sampler : public device::Sampler {
 //! A GPU device ordinal (physical GPU device)
 class Device : public NullDevice {
  public:
+#ifdef ATI_OS_WIN
   struct QueueRecycleInfo : public amd::HeapObject {
+#else
+  struct QueueRecycleInfo {
+#endif
     int counter_;                    //!< Lock usage counter
     Pal::EngineType engineType_;     //!< Engine type
     uint32_t index_;                 //!< HW queue index for scratch buffer access
@@ -259,7 +263,11 @@ class Device : public NullDevice {
   };
 
   //! Transfer buffers
+#ifdef ATI_OS_WIN
   class XferBuffers : public amd::HeapObject {
+#else
+  class XferBuffers {
+#endif
    public:
     static constexpr size_t MaxXferBufListSize = 8;
 
@@ -302,7 +310,11 @@ class Device : public NullDevice {
     const Device& gpuDevice_;         //!< GPU device object
   };
 
+#ifdef ATI_OS_WIN
   struct ScratchBuffer : public amd::HeapObject {
+#else
+  struct ScratchBuffer {
+#endif
     Memory* memObj_;   //!< Memory objects for scratch buffers
     uint64_t offset_;  //!< Offset from the global scratch store
     uint64_t size_;    //!< Scratch buffer size on this queue
@@ -318,7 +330,11 @@ class Device : public NullDevice {
   };
 
 
+#ifdef ATI_OS_WIN
   class SrdManager : public amd::HeapObject {
+#else
+  class SrdManager {
+#endif
    public:
     SrdManager(const Device& dev, uint srdSize, uint bufSize)
         : dev_(dev),

--- a/projects/clr/rocclr/device/pal/paldevice.hpp
+++ b/projects/clr/rocclr/device/pal/paldevice.hpp
@@ -243,6 +243,8 @@ class Device : public NullDevice {
     // Use extSize == 0 on the path that carries no PAL trailing payload.
     void* operator new(size_t) = delete;
     void operator delete(void*) = delete;
+    // Placement new overload required by MSVC when operator new(size_t) is deleted
+    void* operator new(size_t, void* p) noexcept { return p; }
 
     //! Returns the MQD's read_dispatch_id's address.
     uintptr_t DebuggerData() const {

--- a/projects/clr/rocclr/device/pal/palprintf.hpp
+++ b/projects/clr/rocclr/device/pal/palprintf.hpp
@@ -40,7 +40,11 @@ class Kernel;
 class VirtualGPU;
 class Memory;
 
+#ifdef ATI_OS_WIN
 class PrintfDbg : public amd::HeapObject {
+#else
+class PrintfDbg {
+#endif
  public:
   //! Debug buffer size per workitem
   static constexpr uint WorkitemDebugSize = 4096;

--- a/projects/clr/rocclr/device/pal/palprintf.hpp
+++ b/projects/clr/rocclr/device/pal/palprintf.hpp
@@ -40,11 +40,7 @@ class Kernel;
 class VirtualGPU;
 class Memory;
 
-#ifdef ATI_OS_WIN
-class PrintfDbg : public amd::HeapObject {
-#else
 class PrintfDbg {
-#endif
  public:
   //! Debug buffer size per workitem
   static constexpr uint WorkitemDebugSize = 4096;

--- a/projects/clr/rocclr/device/pal/palprogram.hpp
+++ b/projects/clr/rocclr/device/pal/palprogram.hpp
@@ -32,11 +32,7 @@ namespace amd::pal {
 using namespace amd::hsa::loader;
 class Program;
 
-#ifdef ATI_OS_WIN
-class Segment : public amd::HeapObject {
-#else
 class Segment {
-#endif
  public:
   Segment();
   ~Segment();

--- a/projects/clr/rocclr/device/pal/palprogram.hpp
+++ b/projects/clr/rocclr/device/pal/palprogram.hpp
@@ -32,7 +32,11 @@ namespace amd::pal {
 using namespace amd::hsa::loader;
 class Program;
 
+#ifdef ATI_OS_WIN
 class Segment : public amd::HeapObject {
+#else
+class Segment {
+#endif
  public:
   Segment();
   ~Segment();

--- a/projects/clr/rocclr/device/pal/palresource.hpp
+++ b/projects/clr/rocclr/device/pal/palresource.hpp
@@ -73,11 +73,7 @@ class GpuMemoryReference : public amd::ReferenceCountedObject {
 static constexpr Pal::gpusize MaxGpuAlignment = 4 * Ki;
 
 //! GPU resource
-#ifdef ATI_OS_WIN
-class Resource : public amd::HeapObject {
-#else
 class Resource {
-#endif
  public:
   enum InteropType {
     InteropTypeless = 0,
@@ -185,11 +181,7 @@ class Resource {
   };
 
   //! Resource descriptor
-#ifdef ATI_OS_WIN
-  struct Descriptor : public amd::HeapObject {
-#else
   struct Descriptor {
-#endif
     MemoryType type_;              //!< Memory type
     size_t width_;                 //!< Resource width
     size_t height_;                //!< Resource height
@@ -529,11 +521,7 @@ class Resource {
 
 typedef Util::BuddyAllocator<Device> MemBuddyAllocator;
 
-#ifdef ATI_OS_WIN
-class MemorySubAllocator : public amd::HeapObject {
-#else
 class MemorySubAllocator {
-#endif
  public:
   MemorySubAllocator(Device* device, bool retain_final_chunk = false)
       : device_(device), retain_final_chunk_(retain_final_chunk) {}
@@ -578,11 +566,7 @@ class FineUncachedMemorySubAllocator : public MemorySubAllocator {
   bool CreateChunk(const Pal::IGpuMemory* reserved_va) override;
 };
 
-#ifdef ATI_OS_WIN
-class ResourceCache : public amd::HeapObject {
-#else
 class ResourceCache {
-#endif
  public:
   //! Default constructor
   ResourceCache(Device* device, size_t cacheSizeLimit)

--- a/projects/clr/rocclr/device/pal/palresource.hpp
+++ b/projects/clr/rocclr/device/pal/palresource.hpp
@@ -73,7 +73,11 @@ class GpuMemoryReference : public amd::ReferenceCountedObject {
 static constexpr Pal::gpusize MaxGpuAlignment = 4 * Ki;
 
 //! GPU resource
+#ifdef ATI_OS_WIN
 class Resource : public amd::HeapObject {
+#else
+class Resource {
+#endif
  public:
   enum InteropType {
     InteropTypeless = 0,
@@ -181,7 +185,11 @@ class Resource : public amd::HeapObject {
   };
 
   //! Resource descriptor
+#ifdef ATI_OS_WIN
   struct Descriptor : public amd::HeapObject {
+#else
+  struct Descriptor {
+#endif
     MemoryType type_;              //!< Memory type
     size_t width_;                 //!< Resource width
     size_t height_;                //!< Resource height
@@ -521,7 +529,11 @@ class Resource : public amd::HeapObject {
 
 typedef Util::BuddyAllocator<Device> MemBuddyAllocator;
 
+#ifdef ATI_OS_WIN
 class MemorySubAllocator : public amd::HeapObject {
+#else
+class MemorySubAllocator {
+#endif
  public:
   MemorySubAllocator(Device* device, bool retain_final_chunk = false)
       : device_(device), retain_final_chunk_(retain_final_chunk) {}
@@ -566,7 +578,11 @@ class FineUncachedMemorySubAllocator : public MemorySubAllocator {
   bool CreateChunk(const Pal::IGpuMemory* reserved_va) override;
 };
 
+#ifdef ATI_OS_WIN
 class ResourceCache : public amd::HeapObject {
+#else
+class ResourceCache {
+#endif
  public:
   //! Default constructor
   ResourceCache(Device* device, size_t cacheSizeLimit)

--- a/projects/clr/rocclr/device/pal/paltimestamp.hpp
+++ b/projects/clr/rocclr/device/pal/paltimestamp.hpp
@@ -20,7 +20,11 @@ class Device;
 class VirtualGPU;
 class Memory;
 
+#ifdef ATI_OS_WIN
 class TimeStamp : public amd::HeapObject {
+#else
+class TimeStamp {
+#endif
  public:
   //! Enums for the timestamp information
   //! \note *4 is the limitaiton of SDMA HW
@@ -83,7 +87,11 @@ class TimeStamp : public amd::HeapObject {
   volatile uint64_t* values_;  //!< CPU pointer to the timer values
 };
 
+#ifdef ATI_OS_WIN
 class TimeStampCache : public amd::HeapObject {
+#else
+class TimeStampCache {
+#endif
  public:
   //! Default constructor
   TimeStampCache(VirtualGPU& gpu  //!< Virtual GPU object

--- a/projects/clr/rocclr/device/pal/paltimestamp.hpp
+++ b/projects/clr/rocclr/device/pal/paltimestamp.hpp
@@ -20,11 +20,7 @@ class Device;
 class VirtualGPU;
 class Memory;
 
-#ifdef ATI_OS_WIN
-class TimeStamp : public amd::HeapObject {
-#else
 class TimeStamp {
-#endif
  public:
   //! Enums for the timestamp information
   //! \note *4 is the limitaiton of SDMA HW
@@ -87,11 +83,7 @@ class TimeStamp {
   volatile uint64_t* values_;  //!< CPU pointer to the timer values
 };
 
-#ifdef ATI_OS_WIN
-class TimeStampCache : public amd::HeapObject {
-#else
 class TimeStampCache {
-#endif
  public:
   //! Default constructor
   TimeStampCache(VirtualGPU& gpu  //!< Virtual GPU object

--- a/projects/clr/rocclr/device/pal/palvirtual.cpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.cpp
@@ -162,8 +162,8 @@ VirtualGPU::Queue* VirtualGPU::Queue::Create(VirtualGPU& gpu, Pal::QueueType que
   }
 
   size_t allocSize = qSize + max_command_buffers * (cmdSize + fSize);
-  VirtualGPU::Queue* queue =
-      new (allocSize) VirtualGPU::Queue(gpu, palDev, residency_limit, max_command_buffers);
+  VirtualGPU::Queue* queue = amd::AllocWithTrailing<VirtualGPU::Queue>(
+      allocSize, gpu, palDev, residency_limit, max_command_buffers);
   
   if (queue != nullptr) {
     address addrQ = nullptr;
@@ -173,7 +173,8 @@ VirtualGPU::Queue* VirtualGPU::Queue::Create(VirtualGPU& gpu, Pal::QueueType que
       uint32_t index = AllocedQueues(gpu, qCreateInfo.engineType);
       // Create PAL queue object
       if (index < GPU_MAX_HW_QUEUES) {
-        Device::QueueRecycleInfo* info = new (qSize) Device::QueueRecycleInfo(gpu.dev());
+        Device::QueueRecycleInfo* info =
+            amd::AllocWithTrailing<Device::QueueRecycleInfo>(qSize, gpu.dev());
         if (info == nullptr) {
           LogError("Could not create QueueRecycleInfo!");
           return nullptr;
@@ -187,7 +188,7 @@ VirtualGPU::Queue* VirtualGPU::Queue::Create(VirtualGPU& gpu, Pal::QueueType que
           // Save uniqueue index for scratch buffer access
           info->index_ = index;
         } else {
-          delete queue;
+          amd::DestroyWithTrailing(queue);
           return nullptr;
         }
       } else {
@@ -215,7 +216,10 @@ VirtualGPU::Queue* VirtualGPU::Queue::Create(VirtualGPU& gpu, Pal::QueueType que
       queue->lock_ = &info->queue_lock_;
       addrQ = reinterpret_cast<address>(&queue[1]);
     } else {
-      Device::QueueRecycleInfo* info = new Device::QueueRecycleInfo(gpu.dev());
+      // Exclusive-compute path: the PAL IQueue is placed into the Queue wrapper's trailing
+      // region (see addrQ assignment below), so QueueRecycleInfo carries no trailing payload.
+      Device::QueueRecycleInfo* info =
+          amd::AllocWithTrailing<Device::QueueRecycleInfo>(0, gpu.dev());
       if (info == nullptr) {
         LogError("Could not create QueueRecycleInfo!");
         return nullptr;
@@ -228,7 +232,7 @@ VirtualGPU::Queue* VirtualGPU::Queue::Create(VirtualGPU& gpu, Pal::QueueType que
       result = palDev->CreateQueue(qCreateInfo, addrQ, &queue->iQueue_);
     }
     if (result != Pal::Result::Success) {
-      delete queue;
+      amd::DestroyWithTrailing(queue);
       return nullptr;
     }
     queue->UpdateAppPowerProfile();
@@ -239,7 +243,7 @@ VirtualGPU::Queue* VirtualGPU::Queue::Create(VirtualGPU& gpu, Pal::QueueType que
     for (uint i = 0; i < max_command_buffers; ++i) {
       result = palDev->CreateCmdBuffer(cmdCreateInfo, &addrCmd[i * cmdSize], &queue->iCmdBuffs_[i]);
       if (result != Pal::Result::Success) {
-        delete queue;
+        amd::DestroyWithTrailing(queue);
         return nullptr;
       }
 
@@ -247,13 +251,13 @@ VirtualGPU::Queue* VirtualGPU::Queue::Create(VirtualGPU& gpu, Pal::QueueType que
       fenceCreateinfo.flags.signaled = false;
       result = palDev->CreateFence(fenceCreateinfo, &addrF[i * fSize], &queue->iCmdFences_[i]);
       if (result != Pal::Result::Success) {
-        delete queue;
+        amd::DestroyWithTrailing(queue);
         return nullptr;
       }
       if (i == StartCmdBufIdx) {
         result = queue->iCmdBuffs_[i]->Begin(cmdBuildInfo);
         if (result != Pal::Result::Success) {
-          delete queue;
+          amd::DestroyWithTrailing(queue);
           return nullptr;
         }
       }
@@ -263,7 +267,7 @@ VirtualGPU::Queue* VirtualGPU::Queue::Create(VirtualGPU& gpu, Pal::QueueType que
 }
 
 VirtualGPU::Queue::~Queue() {
-  delete reinterpret_cast<Device::QueueRecycleInfo*>(info_);
+  amd::DestroyWithTrailing(reinterpret_cast<Device::QueueRecycleInfo*>(info_));
 
   if (nullptr != iQueue_) {
     // Make sure the queues are idle
@@ -306,7 +310,7 @@ VirtualGPU::Queue::~Queue() {
             queue.second->index_--;
           }
         }
-        delete gpu_.dev().QueuePool().find(iQueue_)->second;
+        amd::DestroyWithTrailing(gpu_.dev().QueuePool().find(iQueue_)->second);
         const_cast<Device&>(gpu_.dev()).QueuePool().erase(iQueue_);
       }
     } else {
@@ -1144,8 +1148,8 @@ VirtualGPU::~VirtualGPU() {
 
   {
     // Destroy queues
-    delete queues_[MainEngine];
-    delete queues_[SdmaEngine];
+    amd::DestroyWithTrailing(queues_[MainEngine]);
+    amd::DestroyWithTrailing(queues_[SdmaEngine]);
 
     if (nullptr != cmdAllocator_) {
       cmdAllocator_->Destroy();

--- a/projects/clr/rocclr/device/pal/palvirtual.cpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.cpp
@@ -26,6 +26,9 @@
 #include <sstream>
 #include <algorithm>
 #include <thread>
+#include <cstddef>
+#include <limits>
+#include <utility>
 #include "palQueue.h"
 #include "palFence.h"
 #include "palQueueSemaphore.h"
@@ -161,6 +164,7 @@ VirtualGPU::Queue* VirtualGPU::Queue::Create(VirtualGPU& gpu, Pal::QueueType que
   size_t allocSize = qSize + max_command_buffers * (cmdSize + fSize);
   VirtualGPU::Queue* queue =
       new (allocSize) VirtualGPU::Queue(gpu, palDev, residency_limit, max_command_buffers);
+  
   if (queue != nullptr) {
     address addrQ = nullptr;
     if (((qCreateInfo.engineType == Pal::EngineTypeCompute) ||

--- a/projects/clr/rocclr/device/pal/palvirtual.hpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.hpp
@@ -81,9 +81,7 @@ class VirtualGPU : public device::VirtualDevice {
 
     // This type is allocated exclusively via amd::AllocWithTrailing<Queue>(extSize, ...) so
     // that a single block holds the wrapper plus PAL's IQueue / ICmdBuffer / IFence objects
-    // placed in the trailing region. Plain new / delete would route through global
-    // ::operator new while DestroyWithTrailing calls std::free — a silent allocator mismatch.
-    // Deleting these forces the contract at compile time.
+    // placed in the trailing region.
     void* operator new(size_t) = delete;
     void operator delete(void*) = delete;
 

--- a/projects/clr/rocclr/device/pal/palvirtual.hpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.hpp
@@ -68,11 +68,7 @@ enum class BarrierType : uint8_t {
 //! Virtual GPU
 class VirtualGPU : public device::VirtualDevice {
  public:
-#ifdef ATI_OS_WIN
-  class Queue : public amd::HeapObject {
-#else
   class Queue {
-#endif
    public:
     static constexpr uint MaxCommands = 256;
     static constexpr uint StartCmdBufIdx = 1;
@@ -220,11 +216,7 @@ class VirtualGPU : public device::VirtualDevice {
     uint max_command_buffers_;
   };
 
-#ifdef ATI_OS_WIN
-  struct CommandBatch : public amd::HeapObject {
-#else
   struct CommandBatch {
-#endif
     amd::Command* head_;           //!< Command batch head
     GpuEvent events_[AllEngines];  //!< Last known GPU events
     TimeStamp* lastTS_;            //!< TS associated with command batch

--- a/projects/clr/rocclr/device/pal/palvirtual.hpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.hpp
@@ -68,7 +68,11 @@ enum class BarrierType : uint8_t {
 //! Virtual GPU
 class VirtualGPU : public device::VirtualDevice {
  public:
+#ifdef ATI_OS_WIN
   class Queue : public amd::HeapObject {
+#else
+  class Queue {
+#endif
    public:
     static constexpr uint MaxCommands = 256;
     static constexpr uint StartCmdBufIdx = 1;
@@ -208,7 +212,11 @@ class VirtualGPU : public device::VirtualDevice {
     uint max_command_buffers_;
   };
 
+#ifdef ATI_OS_WIN
   struct CommandBatch : public amd::HeapObject {
+#else
+  struct CommandBatch {
+#endif
     amd::Command* head_;           //!< Command batch head
     GpuEvent events_[AllEngines];  //!< Last known GPU events
     TimeStamp* lastTS_;            //!< TS associated with command batch

--- a/projects/clr/rocclr/device/pal/palvirtual.hpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.hpp
@@ -83,6 +83,14 @@ class VirtualGPU : public device::VirtualDevice {
     Queue(const Queue&) = delete;
     Queue& operator=(const Queue&) = delete;
 
+    // This type is allocated exclusively via amd::AllocWithTrailing<Queue>(extSize, ...) so
+    // that a single block holds the wrapper plus PAL's IQueue / ICmdBuffer / IFence objects
+    // placed in the trailing region. Plain new / delete would route through global
+    // ::operator new while DestroyWithTrailing calls std::free — a silent allocator mismatch.
+    // Deleting these forces the contract at compile time.
+    void* operator new(size_t) = delete;
+    void operator delete(void*) = delete;
+
     static Queue* Create(VirtualGPU& gpu,                       //!< ROCCLR virtual GPU object
                          Pal::QueueType queueType,              //!< PAL queue type
                          uint engineIdx,                        //!< Select particular engine index

--- a/projects/clr/rocclr/device/pal/palvirtual.hpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.hpp
@@ -84,6 +84,9 @@ class VirtualGPU : public device::VirtualDevice {
     // placed in the trailing region.
     void* operator new(size_t) = delete;
     void operator delete(void*) = delete;
+    // Placement new overloads required by MSVC when operator new(size_t) is deleted
+    void* operator new(size_t, void* p) noexcept { return p; }
+    void* operator new(size_t, std::align_val_t, void* p) noexcept { return p; }
 
     static Queue* Create(VirtualGPU& gpu,                       //!< ROCCLR virtual GPU object
                          Pal::QueueType queueType,              //!< PAL queue type

--- a/projects/clr/rocclr/device/rocm/rocprintf.hpp
+++ b/projects/clr/rocclr/device/rocm/rocprintf.hpp
@@ -17,7 +17,7 @@ class Kernel;
 class VirtualGPU;
 class Device;
 
-class PrintfDbg : public amd::HeapObject {
+class PrintfDbg {
  public:
   //! Debug buffer size per workitem
   static constexpr uint WorkitemDebugSize = 4096;

--- a/projects/clr/rocclr/include/top.hpp
+++ b/projects/clr/rocclr/include/top.hpp
@@ -150,7 +150,10 @@ class MemoryPoolObject {
   void operator delete(void*, void* address) {}
 };
 
+#ifdef ATI_OS_WIN
 /*! \brief For objects allocated on the C-heap.
+ *  \note Windows-only: Required for PAL backend to ensure consistent
+ *        heap allocation/deallocation across DLL boundaries.
  */
 class HeapObject {
  public:
@@ -161,6 +164,7 @@ class HeapObject {
   };
   void operator delete(void* obj, size_t extSize) { HeapObject::operator delete(obj); }
 };
+#endif  // ATI_OS_WIN
 
 /*! \brief For all reference counted objects.
  */

--- a/projects/clr/rocclr/include/top.hpp
+++ b/projects/clr/rocclr/include/top.hpp
@@ -150,22 +150,6 @@ class MemoryPoolObject {
   void operator delete(void*, void* address) {}
 };
 
-#ifdef ATI_OS_WIN
-/*! \brief For objects allocated on the C-heap.
- *  \note Windows-only: Required for PAL backend to ensure consistent
- *        heap allocation/deallocation across DLL boundaries.
- */
-class HeapObject {
- public:
-  void* operator new(size_t size);
-  void operator delete(void* obj);
-  void* operator new(size_t size, size_t extSize) {
-    return HeapObject::operator new(size + extSize);
-  };
-  void operator delete(void* obj, size_t extSize) { HeapObject::operator delete(obj); }
-};
-#endif  // ATI_OS_WIN
-
 /*! \brief For all reference counted objects.
  */
 class ReferenceCountedObject {

--- a/projects/clr/rocclr/os/alloc.cpp
+++ b/projects/clr/rocclr/os/alloc.cpp
@@ -63,10 +63,4 @@ void GuardedMemory::deallocate(void* ptr) {
   Os::releaseMemory(static_cast<address>(ptr) - offset, size);
 }
 
-#ifdef ATI_OS_WIN
-void* HeapObject::operator new(size_t size) { return malloc(size); }
-
-void HeapObject::operator delete(void* obj) { free(obj); }
-#endif  // ATI_OS_WIN
-
 }  // namespace amd

--- a/projects/clr/rocclr/os/alloc.cpp
+++ b/projects/clr/rocclr/os/alloc.cpp
@@ -63,9 +63,10 @@ void GuardedMemory::deallocate(void* ptr) {
   Os::releaseMemory(static_cast<address>(ptr) - offset, size);
 }
 
+#ifdef ATI_OS_WIN
 void* HeapObject::operator new(size_t size) { return malloc(size); }
 
 void HeapObject::operator delete(void* obj) { free(obj); }
-
+#endif  // ATI_OS_WIN
 
 }  // namespace amd

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -53,7 +53,7 @@ class Event : public RuntimeObject {
   typedef void(CL_CALLBACK* CallBackFunction)(cl_event event, int32_t command_exec_status,
                                               void* user_data);
 
-  struct CallBackEntry : public HeapObject {
+  struct CallBackEntry {
     struct CallBackEntry* next_;  //!< the next entry in the callback list.
 
     std::atomic<CallBackFunction> callback_;  //!< callback function pointer.

--- a/projects/clr/rocclr/platform/kernel.hpp
+++ b/projects/clr/rocclr/platform/kernel.hpp
@@ -35,7 +35,7 @@ class Program;
  *  @{
  */
 
-class KernelSignature : public HeapObject {
+class KernelSignature {
  private:
   std::vector<KernelParameterDescriptor> params_;
   std::string attributes_;  //!< The kernel attributes
@@ -103,7 +103,7 @@ class KernelSignature : public HeapObject {
 
 // @todo: look into a copy-on-write model instead of copy-on-read.
 //
-class KernelParameters : protected HeapObject {
+class KernelParameters {
  private:
   //! The signature describing these parameters.
   KernelSignature& signature_;

--- a/projects/clr/rocclr/platform/ndrange.hpp
+++ b/projects/clr/rocclr/platform/ndrange.hpp
@@ -196,7 +196,7 @@ struct HIPLaunchParams : public LaunchParams {
 };
 
 //! A container for the local and global worksizes.
-class NDRangeContainer : public HeapObject {
+class NDRangeContainer {
  private:
   const size_t dimensions_;  //!< Number of dimensions.
   NDRange offset_;           //!< Global work-item offset.

--- a/projects/clr/rocclr/platform/program.hpp
+++ b/projects/clr/rocclr/platform/program.hpp
@@ -36,7 +36,7 @@ namespace amd {
  */
 
 //! A kernel function symbol
-class Symbol : public HeapObject {
+class Symbol {
  public:
   typedef std::unordered_map<const Device*, const device::Kernel*> devicekernels_t;
 

--- a/projects/clr/rocclr/platform/runtime.hpp
+++ b/projects/clr/rocclr/platform/runtime.hpp
@@ -47,7 +47,7 @@ class Runtime : AllStatic {
 
 /*@}*/
 
-class RuntimeTearDown : public HeapObject {
+class RuntimeTearDown {
  public:
   using TearDownCallback = std::function<void()>;
 

--- a/projects/clr/rocclr/platform/vmheap.hpp
+++ b/projects/clr/rocclr/platform/vmheap.hpp
@@ -18,7 +18,7 @@ class HeapBlock;
 class VmHeap;
 class VmHeapArray;
 
-class HeapBlock : public amd::HeapObject {
+class HeapBlock {
  public:
   friend VmHeap;
   //! Constructor

--- a/projects/clr/rocclr/thread/thread.hpp
+++ b/projects/clr/rocclr/thread/thread.hpp
@@ -30,7 +30,7 @@ namespace amd {
 
 class Monitor;
 
-class Thread : public HeapObject {
+class Thread {
   friend const void* Os::createOsThread(Thread*);
 
  public:

--- a/projects/clr/rocclr/utils/concurrent.hpp
+++ b/projects/clr/rocclr/utils/concurrent.hpp
@@ -52,7 +52,7 @@ template <typename T, int N> struct TaggedPointerHelper {
  * FIXME_lmoriche: Implement the new/delete operators for SimplyLinkedNode
  * using thread-local allocation buffers.
  */
-template <typename T, int N = 5> class ConcurrentLinkedQueue : public HeapObject {
+template <typename T, int N = 5> class ConcurrentLinkedQueue {
   //! A simply-linked node
   struct Node {
     typedef details::TaggedPointerHelper<Node, N> TaggedPointerHelper;


### PR DESCRIPTION
## Motivation

The HeapObject wrapper is an inherited struct which was supposed to simplify the dynamic allocation and deallocation of types. In practice it is best to use new and free to allocate memory on the heap. The class does create issues with aligning certain types and classes, so it should be removed.

## Technical Details

Rebase and update of https://github.com/ROCm/rocm-systems/pull/1355

## Test Plan

No new tests are needed

## Test Result

Passing locally

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
