### PR TITLE
[rocshmem] rocshmem_info prints nic-gpu-numa map

### DIFF
--- a/projects/rocshmem/src/gda/numa_wrapper.cpp
+++ b/projects/rocshmem/src/gda/numa_wrapper.cpp
@@ -104,7 +104,7 @@ int NUMAWrapper::max_node(void) {
 
 long NUMAWrapper::move_pages(int pid, unsigned long count, void *pages[count],
                              const int nodes[count], int status[count], int flags) {
-  return move_pages(pid, count, pages, nodes, status, flags);
+  return numa.move_pages(pid, count, pages, nodes, status, flags);
 }
 
 int NUMAWrapper::distance(int node1, int node2) {

--- a/projects/rocshmem/src/gda/topology.cpp
+++ b/projects/rocshmem/src/gda/topology.cpp
@@ -54,24 +54,26 @@ namespace rocshmem
       pages[i] = (char*)pages[i-1] + pageSize;
     }
 
+    fprintf(stderr, "topology.cpp:57\n");
+
     long const retCode = numa.move_pages(0, numPages, pages.data(), NULL, status.data(), 0);
     if (retCode) {
-      fprintf(stderr,"Unable to collect page table information for allocated memory. "
-              "Ensure NUMA library is installed properly");
+      fprintf(stderr, "Unable to collect page table information for allocated memory. "
+              "Ensure NUMA library is installed properly\n");
       return -1;
     }
 
     size_t mistakeCount = 0;
     for (size_t i = 0; i < numPages; i++) {
       if (status[i] < 0) {
-        fprintf(stderr, "Unexpected page status (%d) for page %zu", status[i], i);
+        fprintf(stderr, "Unexpected page status (%d) for page %zu\n", status[i], i);
         return -1;
       }
       if (status[i] != targetId) mistakeCount++;
     }
     if (mistakeCount > 0) {
-      fprintf(stderr, "%lu out of %lu pages for memory allocation were not on NUMA node %d."
-              " This could be due to hardware memory issues, or the use of numa-rebalancing daemons such as numad",
+      fprintf(stderr, "%lu out of %lu pages for memory allocation were not on NUMA node %d.\n"
+              " This could be due to hardware memory issues, or the use of numa-rebalancing daemons such as numad\n",
               mistakeCount, numPages, targetId);
       return -1;
     }

--- a/projects/rocshmem/src/gda/topology.cpp
+++ b/projects/rocshmem/src/gda/topology.cpp
@@ -70,7 +70,7 @@ namespace rocshmem
       if (status[i] != targetId) mistakeCount++;
     }
     if (mistakeCount > 0) {
-      fprintf(stderr, "%lu out of %lu pages for memory allocation were not on NUMA node %d.\n"
+      fprintf(stderr, "%zu out of %zu pages for memory allocation were not on NUMA node %d.\n"
               " This could be due to hardware memory issues, or the use of numa-rebalancing daemons such as numad\n",
               mistakeCount, numPages, targetId);
       return -1;

--- a/projects/rocshmem/src/gda/topology.cpp
+++ b/projects/rocshmem/src/gda/topology.cpp
@@ -54,8 +54,6 @@ namespace rocshmem
       pages[i] = (char*)pages[i-1] + pageSize;
     }
 
-    fprintf(stderr, "topology.cpp:57\n");
-
     long const retCode = numa.move_pages(0, numPages, pages.data(), NULL, status.data(), 0);
     if (retCode) {
       fprintf(stderr, "Unable to collect page table information for allocated memory. "

--- a/projects/rocshmem/src/tools/rocshmem_info.cpp
+++ b/projects/rocshmem/src/tools/rocshmem_info.cpp
@@ -162,9 +162,7 @@ int main (int argc, char **argv) {
   }
 
   printf("################################################################################\n");
-//  rocshmem::rocshmem_init();
   rocshmem::DisplayTopology(false);
-//  rocshmem::rocshmem_finalize();
   printf("################################################################################\n");
   return 0;
 }

--- a/projects/rocshmem/src/tools/rocshmem_info.cpp
+++ b/projects/rocshmem/src/tools/rocshmem_info.cpp
@@ -32,6 +32,7 @@
 
 #include <rocm-core/rocm_version.h>
 #include <rocshmem/rocshmem.hpp>
+#include "gda/topology.hpp"
 
 #define NAME_COLUMN_WIDTH (28)
 #define INFO_COLUMN_WIDTH (47)
@@ -160,6 +161,10 @@ int main (int argc, char **argv) {
     parse_config_file();
   }
 
+  printf("################################################################################\n");
+//  rocshmem::rocshmem_init();
+  rocshmem::DisplayTopology(false);
+//  rocshmem::rocshmem_finalize();
   printf("################################################################################\n");
   return 0;
 }

--- a/projects/rocshmem/src/tools/rocshmem_info.cpp
+++ b/projects/rocshmem/src/tools/rocshmem_info.cpp
@@ -162,7 +162,9 @@ int main (int argc, char **argv) {
   }
 
   printf("################################################################################\n");
+#if defined(USE_GDA)
   rocshmem::DisplayTopology(false);
   printf("################################################################################\n");
+#endif //defined(USE_GDA)
   return 0;
 }

--- a/projects/rocshmem/src/tools/rocshmem_info.cpp
+++ b/projects/rocshmem/src/tools/rocshmem_info.cpp
@@ -32,7 +32,9 @@
 
 #include <rocm-core/rocm_version.h>
 #include <rocshmem/rocshmem.hpp>
+#if defined(USE_GDA)
 #include "gda/topology.hpp"
+#endif // defined(USE_GDA)
 
 #define NAME_COLUMN_WIDTH (28)
 #define INFO_COLUMN_WIDTH (47)


### PR DESCRIPTION
## Motivation

Report what the topology detection logic in rocshmem reports simply with rocshmem_info

## Technical Details

Just run the topology detection logic without initializing rocshmem. 
bugfix: numa.move_pages was calling the non-dlloaded symbol

## JIRA ID

AIROCSHMEM-155

## Test Plan

Should work with all build configurations

## Test Result

* [x] all-backends build (with and w/o active IBV devices)
* [x] ipc-only build
* [x] ro-only build

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
