### PR TITLE
attach: fix rocattach cmake libraries

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/CMakeLists.txt
@@ -23,8 +23,14 @@
 rocprofiler_activate_clang_tidy()
 
 add_library(rocprofiler-sdk-rocattach-shared-library SHARED)
-add_library(rocprofiler-sdk::rocprofiler-sdk-rocattach-shared-library ALIAS
-            rocprofiler-sdk-rocattach-shared-library)
+
+foreach(_NAMESPACE rocprofiler-sdk rocprofiler-sdk-rocattach)
+    foreach(_ALIAS library shared-library)
+        add_library(${_NAMESPACE}::rocprofiler-sdk-rocattach-${_ALIAS} ALIAS
+                    rocprofiler-sdk-rocattach-shared-library)
+    endforeach()
+endforeach()
+
 target_sources(rocprofiler-sdk-rocattach-shared-library
                PRIVATE rocattach.cpp auxv.cpp ptrace_session.cpp symbol_lookup.cpp)
 target_include_directories(


### PR DESCRIPTION
## Motivation

Fixes reported issue for CMake package exports
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

This change makes each permutation of shared library name aliased to the correct name. This matches the current approach in rocpd.

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

Fixes AIPROFSDK-38

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Tested find_package locally
Asking issue author to verify

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
