### PR TITLE
SWDEV-579356: Take into account thread-local capture mode in checks for valid capture (#2177)

### DIFF
--- a/projects/clr/hipamd/src/hip_stream.cpp
+++ b/projects/clr/hipamd/src/hip_stream.cpp
@@ -154,12 +154,14 @@ bool Stream::StreamCaptureOngoing(hipStream_t hStream) {
       return false;
     }
     // If any stream in current/concurrent thread is capturing in global mode
-    amd::ScopedLock lock(g_captureStreamsLock);
-    if (!g_captureStreams.empty()) {
-      for (auto stream : hip::g_captureStreams) {
-        stream->SetCaptureStatus(hipStreamCaptureStatusInvalidated);
+    if (hip::tls.stream_capture_mode_ == hipStreamCaptureModeGlobal) {
+      amd::ScopedLock lock(g_captureStreamsLock);
+      if (!g_captureStreams.empty()) {
+        for (auto stream : hip::g_captureStreams) {
+          stream->SetCaptureStatus(hipStreamCaptureStatusInvalidated);
+        }
+        return true;
       }
-      return true;
     }
     // If any stream in current thread is capturing in ThreadLocal mode
     if (!hip::tls.capture_streams_.empty()) {


### PR DESCRIPTION
## Motivation

This PR addresses https://github.com/ROCm/hip/issues/3876

## Technical Details

In the case where one thread captures a stream in global capture mode, an action like hipEventQuery on a different thread for a different stream under thread-local capture mode currently returns hipErrorStreamCaptureUnsupported.
However In thread-local capture mode sequences in other threads should be ignored.

## JIRA ID

SWDEV-579356

## Test Plan

NA

## Test Result

NA

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
