### PR TITLE
SWDEV-579664 - Disable memory object ref counting for HIP in DD mode (#3023)

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -3589,8 +3589,6 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
   const amd::KernelSignature& signature = kernel.signature();
   const amd::KernelParameters& kernelParams = kernel.parameters();
 
-  amd::Memory* const* memories =
-      reinterpret_cast<amd::Memory* const*>(parameters + kernelParams.memoryObjOffset());
   bool isGraphCapture = command_ != nullptr && command_->getPktCapturingState();
 
   ClPrint(amd::LOG_INFO, amd::LOG_KERN2, "ShaderName : %s", gpuKernel.getDemangledName().c_str());

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -499,12 +499,15 @@ class OneMemoryArgCommand : public Command {
   OneMemoryArgCommand(HostQueue& queue, cl_command_type type, const EventWaitList& eventWaitList,
                       Memory& memory)
       : Command(queue, type, eventWaitList, AMD_SERIALIZE_COPY), memory_(&memory) {
-    memory_->retain();
+    if (!(amd::IS_HIP && AMD_DIRECT_DISPATCH)) {
+      memory_->retain();
+    }
   }
 
   virtual void releaseResources() {
-    memory_->release();
-    DEBUG_ONLY(memory_ = NULL);
+    if (!(amd::IS_HIP && AMD_DIRECT_DISPATCH)) {
+      memory_->release();
+    }
     Command::releaseResources();
     ReleasePinnedMemory();
   }
@@ -538,14 +541,17 @@ class TwoMemoryArgsCommand : public Command {
       : Command(queue, type, eventWaitList, AMD_SERIALIZE_COPY),
         memory1_(&memory1),
         memory2_(&memory2) {
-    memory1_->retain();
-    memory2_->retain();
+    if (!(amd::IS_HIP && AMD_DIRECT_DISPATCH)) {
+      memory1_->retain();
+      memory2_->retain();
+    }
   }
 
   virtual void releaseResources() {
-    memory1_->release();
-    memory2_->release();
-    DEBUG_ONLY(memory1_ = memory2_ = NULL);
+    if (!(amd::IS_HIP && AMD_DIRECT_DISPATCH)) {
+      memory1_->release();
+      memory2_->release();
+    }
     Command::releaseResources();
   }
 
@@ -1182,7 +1188,9 @@ class MigrateMemObjectsCommand : public Command {
                            cl_mem_migration_flags flags)
       : Command(queue, type, eventWaitList), migrationFlags_(flags) {
     for (const auto& it : memObjects) {
-      it->retain();
+      if (!(amd::IS_HIP && AMD_DIRECT_DISPATCH)) {
+        it->retain();
+      }
       memObjects_.push_back(it);
     }
   }
@@ -1191,8 +1199,10 @@ class MigrateMemObjectsCommand : public Command {
 
   //! Release all resources associated with this command
   void releaseResources() {
-    for (const auto& it : memObjects_) {
-      it->release();
+    if (!(amd::IS_HIP && AMD_DIRECT_DISPATCH)) {
+      for (const auto& it : memObjects_) {
+        it->release();
+      }
     }
     Command::releaseResources();
   }
@@ -1431,15 +1441,19 @@ class ExtObjectsCommand : public Command {
                     const std::vector<amd::Memory*>& memoryObjects, cl_command_type type)
       : Command(queue, type, eventWaitList) {
     for (const auto& it : memoryObjects) {
-      it->retain();
+      if (!(amd::IS_HIP && AMD_DIRECT_DISPATCH)) {
+        it->retain();
+      }
       memObjects_.push_back(it);
     }
   }
 
   //! Release all resources associated with this command
   void releaseResources() {
-    for (const auto& it : memObjects_) {
-      it->release();
+    if (!(amd::IS_HIP && AMD_DIRECT_DISPATCH)) {
+      for (const auto& it : memObjects_) {
+        it->release();
+      }
     }
     Command::releaseResources();
   }
@@ -1658,7 +1672,9 @@ class MakeBuffersResidentCommand : public Command {
                              cl_bus_address_amd* busAddr)
       : Command(queue, type, eventWaitList), busAddresses_(busAddr) {
     for (const auto& it : memObjects) {
-      it->retain();
+      if (!(amd::IS_HIP && AMD_DIRECT_DISPATCH)) {
+        it->retain();
+      }
       memObjects_.push_back(it);
     }
   }
@@ -1667,7 +1683,9 @@ class MakeBuffersResidentCommand : public Command {
 
   void releaseResources() {
     for (const auto& it : memObjects_) {
-      it->release();
+      if (!(amd::IS_HIP && AMD_DIRECT_DISPATCH)) {
+        it->release();
+      }
     }
     Command::releaseResources();
   }
@@ -1902,12 +1920,15 @@ class VirtualMapCommand : public Command {
       : Command(queue, 1, eventWaitList), ptr_(ptr), size_(size), memory_(memory) {
     // Sanity checks
     assert(size > 0 && "invalid");
-    if (memory_) memory_->retain();
+    if (!(amd::IS_HIP && AMD_DIRECT_DISPATCH)) {
+      if (memory_) memory_->retain();
+    }
   }
 
   virtual void releaseResources() {
-    if (memory_) memory_->release();
-    DEBUG_ONLY(memory_ = nullptr);
+    if (!(amd::IS_HIP && AMD_DIRECT_DISPATCH)) {
+      if (memory_) memory_->release();
+    }
     Command::releaseResources();
   }
 

--- a/projects/clr/rocclr/platform/kernel.cpp
+++ b/projects/clr/rocclr/platform/kernel.cpp
@@ -121,8 +121,10 @@ bool KernelParameters::captureAndSet(void** kernelParams, address kernArgs, size
       LP64_SWITCH(uint32_value, uint64_value) = *(LP64_SWITCH(uint32_t*, uint64_t*))value;
       memArg = amd::MemObjMap::FindMemObj(*reinterpret_cast<const void* const*>(value));
       memories[desc.info_.arrayIndex_] = memArg;
-      if (memArg != nullptr) {
-        memArg->retain();
+      if (!(amd::IS_HIP && AMD_DIRECT_DISPATCH)) {
+        if (memArg != nullptr) {
+          memArg->retain();
+        }
       }
     } else if (desc.type_ == T_SAMPLER) {
       LogError("Cannot handle Sampler now");
@@ -257,7 +259,9 @@ address KernelParameters::capture(device::VirtualDevice& vDev, uint64_t lclMemSi
       if (desc.type_ == T_POINTER && (desc.addressQualifier_ != CL_KERNEL_ARG_ADDRESS_LOCAL)) {
         Memory* memArg = memoryObjects_[desc.info_.arrayIndex_];
         if (memArg != nullptr) {
-          memArg->retain();
+          if (!(amd::IS_HIP && AMD_DIRECT_DISPATCH)) {
+            memArg->retain();
+          }
           device::Memory* devMem = memArg->getDeviceMemory(device);
           if (nullptr == devMem) {
             LogPrintfError("Can't allocate memory size - 0x%08X bytes!", memArg->getSize());
@@ -346,8 +350,10 @@ void KernelParameters::release(address mem) const {
   amd::Memory* const* memories = reinterpret_cast<amd::Memory* const*>(mem + memoryObjOffset());
   for (uint32_t i = 0; i < signature_.numMemories(); ++i) {
     Memory* memArg = memories[i];
-    if (memArg != nullptr) {
-      memArg->release();
+    if (!(amd::IS_HIP && AMD_DIRECT_DISPATCH)) {
+      if (memArg != nullptr) {
+        memArg->release();
+      }
     }
   }
   if (signature_.numSamplers() > 0) {


### PR DESCRIPTION
## Motivation

Refcounters can delay memory object destruction, which affect some logic in the apps, written with CUDA's expectations in the behavior.

## Technical Details

Disable memory object ref counting for HIP in DD mode

## JIRA ID

SWDEV-579664

## Test Plan

NA

## Test Result

NA

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
