### PR TITLE
Move units scaling for traced metrics into post-processing

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.cpp
@@ -413,11 +413,13 @@ rocpd_processor_t::handle([[maybe_unused]] const amd_smi_sample& _amd_smi)
         info::annotate_with_device_id<category::amd_smi_power>(_amd_smi.device_id)
             .c_str(),
         _amd_smi.power);
+
+    auto mem_usage_mb = _amd_smi.mem_usage / static_cast<double>(units::megabyte);
     insert_event_and_sample(
         is_mem_usage_enabled, trait::name<category::amd_smi_memory_usage>::value,
         info::annotate_with_device_id<category::amd_smi_memory_usage>(_amd_smi.device_id)
             .c_str(),
-        _amd_smi.mem_usage);
+        mem_usage_mb);
 
     if(!is_vcn_enabled && !is_jpeg_enabled && !is_xgmi_enabled && !is_pcie_enabled)
         return;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/amd_smi.cpp
@@ -692,8 +692,7 @@ data::sample(uint32_t _device_id)
                 serialize_settings(m_dev_id), _device_id, _timestamp,
                 m_busy_perc.gfx_activity, m_busy_perc.umc_activity,
                 m_busy_perc.mm_activity, m_power.current_socket_power, m_temp,
-                (m_mem_usage / units::megabyte),
-                serialize_gpu_metrics(m_dev_id, metrics, capabilities) });
+                m_mem_usage, serialize_gpu_metrics(m_dev_id, metrics, capabilities) });
 
             if(has_data) m_gpu_metrics.push_back(metrics);
         }


### PR DESCRIPTION
## Motivation

- Move the units scaling logic for smi memory trace into the postprocessors

## Technical Details

## JIRA ID

## Test Plan


## Test Result

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
