### PR TITLE
[rocprofiler-sdk][rocprofv3] Optimize rocpd writes by caching prepared statements

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -62,6 +62,7 @@
 #include <unistd.h>
 
 #include <dlfcn.h>
+#include <algorithm>
 #include <atomic>
 #include <cctype>
 #include <chrono>
@@ -353,6 +354,145 @@ insert_value(std::string_view _name, const std::optional<Tp>& _value, TraitT = {
 
 using statement_cache_t = std::unordered_map<std::string, sqlite3_stmt*>;
 
+struct pending_insert_batch
+{
+    sqlite3*                                   conn      = nullptr;
+    statement_cache_t*                         cache     = nullptr;
+    std::string                                key       = {};
+    std::string                                table     = {};
+    std::vector<std::string>                   fields    = {};
+    std::vector<std::vector<sql_insert_value>> rows      = {};
+    size_t                                     max_rows  = 1;
+    bool                                       is_active = false;
+};
+
+auto&
+get_pending_insert_batch()
+{
+    static thread_local auto _v = pending_insert_batch{};
+    return _v;
+}
+
+size_t
+get_max_batch_rows(sqlite3* conn, size_t col_count)
+{
+    int var_limit = sqlite3_limit(conn, SQLITE_LIMIT_VARIABLE_NUMBER, -1);
+    if(var_limit <= 0) var_limit = 999;
+
+    auto max_rows =
+        static_cast<size_t>(var_limit / static_cast<int>(std::max<size_t>(1, col_count)));
+    if(max_rows == 0) max_rows = 1;
+    if(max_rows > 256) max_rows = 256;
+    return max_rows;
+}
+
+int
+bind_sql_value(sqlite3_stmt* stmt, int idx, const sql_insert_value& value)
+{
+    return std::visit(
+        [&](auto&& val) {
+            using value_type = common::mpl::unqualified_type_t<decltype(val)>;
+            if constexpr(std::is_same_v<value_type, std::monostate>)
+            {
+                return sqlite3_bind_null(stmt, idx);
+            }
+            else if constexpr(std::is_same_v<value_type, std::nullptr_t>)
+            {
+                return sqlite3_bind_null(stmt, idx);
+            }
+            else if constexpr(std::is_same_v<value_type, int64_t>)
+            {
+                return sqlite3_bind_int64(stmt, idx, val);
+            }
+            else if constexpr(std::is_same_v<value_type, uint64_t>)
+            {
+                return sqlite3_bind_int64(stmt, idx, static_cast<int64_t>(val));
+            }
+            else if constexpr(std::is_same_v<value_type, double>)
+            {
+                return sqlite3_bind_double(stmt, idx, val);
+            }
+            else if constexpr(common::mpl::is_string_type<value_type>::value)
+            {
+                return sqlite3_bind_text(stmt, idx, val.c_str(), -1, SQLITE_TRANSIENT);
+            }
+            else
+            {
+                static_assert(common::mpl::assert_false<value_type>::value,
+                              "Unsupported data type");
+            }
+        },
+        value.value);
+}
+
+void
+flush_pending_insert_batch()
+{
+    auto& pending = get_pending_insert_batch();
+    if(!pending.is_active || pending.rows.empty()) return;
+
+    ROCP_FATAL_IF(pending.conn == nullptr || pending.cache == nullptr)
+        << "Pending insert batch missing sqlite connection or statement cache";
+
+    const auto batch_size = pending.rows.size();
+    const auto field_size = pending.fields.size();
+    auto       batch_key =
+        fmt::format("{}:batch:{}:{}", pending.table, batch_size, fmt::join(pending.fields, ","));
+
+    auto& stmt = (*pending.cache)[batch_key];
+    if(!stmt)
+    {
+        auto row_placeholder = std::string{"("};
+        for(size_t i = 0; i < field_size; ++i)
+        {
+            if(i > 0) row_placeholder += ", ";
+            row_placeholder += "?";
+        }
+        row_placeholder += ")";
+
+        auto values_clause = std::string{};
+        values_clause.reserve(batch_size * row_placeholder.size());
+        for(size_t i = 0; i < batch_size; ++i)
+        {
+            if(i > 0) values_clause += ", ";
+            values_clause += row_placeholder;
+        }
+
+        auto sql = fmt::format("INSERT INTO {} ({}) VALUES {};",
+                               pending.table,
+                               fmt::join(pending.fields, ", "),
+                               values_clause);
+
+        SQLITE3_CHECK(sqlite3_prepare_v2(pending.conn, sql.c_str(), -1, &stmt, nullptr));
+    }
+
+    auto cleanup_guard = common::scope_destructor{[&]() {
+        if(stmt)
+        {
+            sqlite3_reset(stmt);
+            sqlite3_clear_bindings(stmt);
+        }
+    }};
+
+    int bind_idx = 1;
+    for(const auto& row : pending.rows)
+    {
+        for(const auto& value : row)
+            bind_sql_value(stmt, bind_idx++, value);
+    }
+
+    auto step_rc = sqlite3_step(stmt);
+    ROCP_FATAL_IF(step_rc != SQLITE_DONE) << "sqlite3_step failed with error code " << step_rc;
+
+    pending.rows.clear();
+    pending.is_active = false;
+    pending.key.clear();
+    pending.table.clear();
+    pending.fields.clear();
+    pending.conn  = nullptr;
+    pending.cache = nullptr;
+}
+
 void
 finalize_prepared_statements(statement_cache_t& cache)
 {
@@ -390,68 +530,30 @@ get_insert_statement_impl(sqlite3*                                  conn,
     auto table = replace_uuid(_table);
     auto key   = fmt::format("{}:{}", table, fmt::join(fields, ","));
 
-    auto& stmt = cache[key];
-    if(!stmt)
+    auto field_names = std::vector<std::string>{};
+    field_names.reserve(fields.size());
+    for(const auto& field : fields)
+        field_names.emplace_back(field);
+
+    auto& pending = get_pending_insert_batch();
+    if(pending.is_active && (pending.conn != conn || pending.cache != &cache || pending.key != key))
     {
-        auto placeholders = std::vector<std::string_view>(fields.size(), std::string_view{"?"});
-
-        auto sql = fmt::format("INSERT INTO {} ({}) VALUES ({});",
-                               table,
-                               fmt::join(fields, ", "),
-                               fmt::join(placeholders, ", "));
-
-        SQLITE3_CHECK(sqlite3_prepare_v2(conn, sql.c_str(), -1, &stmt, nullptr));
+        flush_pending_insert_batch();
     }
 
-    auto cleanup_guard = common::scope_destructor{[&]() {
-        if(stmt)
-        {
-            sqlite3_reset(stmt);
-            sqlite3_clear_bindings(stmt);
-        }
-    }};
-
-    for(size_t i = 0; i < values.size(); ++i)
+    if(!pending.is_active)
     {
-        int idx = static_cast<int>(i + 1);
-        std::visit(
-            [&](auto&& val) {
-                using value_type = common::mpl::unqualified_type_t<decltype(val)>;
-                if constexpr(std::is_same_v<value_type, std::monostate>)
-                {
-                    sqlite3_bind_null(stmt, idx);
-                }
-                else if constexpr(std::is_same_v<value_type, std::nullptr_t>)
-                {
-                    sqlite3_bind_null(stmt, idx);
-                }
-                else if constexpr(std::is_same_v<value_type, int64_t>)
-                {
-                    sqlite3_bind_int64(stmt, idx, val);
-                }
-                else if constexpr(std::is_same_v<value_type, uint64_t>)
-                {
-                    sqlite3_bind_int64(stmt, idx, static_cast<int64_t>(val));
-                }
-                else if constexpr(std::is_same_v<value_type, double>)
-                {
-                    sqlite3_bind_double(stmt, idx, val);
-                }
-                else if constexpr(common::mpl::is_string_type<value_type>::value)
-                {
-                    sqlite3_bind_text(stmt, idx, val.c_str(), -1, SQLITE_TRANSIENT);
-                }
-                else
-                {
-                    static_assert(common::mpl::assert_false<value_type>::value,
-                                  "Unsupported data type");
-                }
-            },
-            values[i].value);
+        pending.is_active = true;
+        pending.conn      = conn;
+        pending.cache     = &cache;
+        pending.key       = key;
+        pending.table     = table;
+        pending.fields    = std::move(field_names);
+        pending.max_rows  = get_max_batch_rows(conn, fields.size());
     }
 
-    auto step_rc = sqlite3_step(stmt);
-    ROCP_FATAL_IF(step_rc != SQLITE_DONE) << "sqlite3_step failed with error code " << step_rc;
+    pending.rows.emplace_back(std::move(values));
+    if(pending.rows.size() >= pending.max_rows) flush_pending_insert_batch();
 }
 
 template <template <typename...> class ContainerT, typename... TypesT>
@@ -1176,6 +1278,7 @@ write_rocpd(
 
     auto insert_kernel_dispatch_data = [&, node_id, this_pid](auto& dispatch_evt_ids) {
         auto _sqlgenperf_rocpd = get_simple_timer("rocpd_kernel_dispatch");
+        auto _deferred         = sql::deferred_transaction{conn};
 
         auto process_dispatch = [&](uint64_t    dispatch_id,
                                     uint64_t    kernel_id,
@@ -1268,7 +1371,6 @@ write_rocpd(
         {
             for(auto pctr : counter_collection_gen)
             {
-                auto _deferred = sql::deferred_transaction{conn};
                 for(const auto& record : counter_collection_gen.get(pctr))
                 {
                     const auto& dispatch_data = record.dispatch_data;
@@ -1303,7 +1405,6 @@ write_rocpd(
         {
             for(auto pitr : kernel_dispatch_gen)
             {
-                auto _deferred = sql::deferred_transaction{conn};
                 for(auto itr : kernel_dispatch_gen.get(pitr))
                 {
                     // Register thread ID
@@ -1332,10 +1433,10 @@ write_rocpd(
     auto insert_pmc_event_data =
         [&conn, &statement_cache, &tool_metadata, &counter_collection_gen](auto& dispatch_evt_ids) {
             auto   _sqlgenperf_rocpd = get_simple_timer("rocpd_pmc_event");
+            auto   _deferred         = sql::deferred_transaction{conn};
             size_t idx               = tool_metadata.pmc_event_offset;
             for(auto ditr : counter_collection_gen)
             {
-                auto _deferred = sql::deferred_transaction{conn};
                 for(const auto& record : counter_collection_gen.get(ditr))
                 {
                     const auto& info        = record.dispatch_data.dispatch_info;
@@ -1362,11 +1463,11 @@ write_rocpd(
         [&conn, &statement_cache, &tool_metadata, &string_entries, node_id, this_pid](
             const auto& _gen) {
             auto   _sqlgenperf_rocpd = get_simple_timer("rocpd_memory_copy");
+            auto   _deferred         = sql::deferred_transaction{conn};
             size_t copy_idx          = 1;
 
             for(auto pitr : _gen)
             {
-                auto _deferred = sql::deferred_transaction{conn};
                 for(auto itr : _gen.get(pitr))
                 {
                     // insert thread info if it doesn't already exist
@@ -1416,10 +1517,10 @@ write_rocpd(
             const auto& _gen) {
             auto address_to_agent_and_size =
                 std::unordered_map<rocprofiler_address_t, rocprofiler::agent::index_and_size>{};
+            auto _deferred = sql::deferred_transaction{conn};
 
             for(auto pitr : _gen)
             {
-                auto _deferred = sql::deferred_transaction{conn};
                 for(auto itr : _gen.get(pitr))
                 {
                     // insert thread info if it doesn't already exist
@@ -1528,10 +1629,10 @@ write_rocpd(
     auto insert_api_data =
         [&conn, &statement_cache, &tool_metadata, &string_entries, node_id, this_pid](
             const auto& _gen) {
+            auto _deferred = sql::deferred_transaction{conn};
+
             for(auto pitr : _gen)
             {
-                auto _deferred = sql::deferred_transaction{conn};
-
                 for(auto itr : _gen.get(pitr))
                 {
                     auto category = tool_metadata.buffer_names.at(itr.kind);
@@ -1633,6 +1734,7 @@ write_rocpd(
                                                      itr.thread_id,
                                                      string_entries.at(category),
                                                      "{}");
+
                         get_insert_statement(conn,
                                              statement_cache,
                                              "rocpd_sample{{uuid}}",
@@ -1804,6 +1906,7 @@ write_rocpd(
         execute_raw_sql_statements(conn, indexes_schema);
     }
 
+    flush_pending_insert_batch();
     finalize_prepared_statements(statement_cache);
     SQLITE3_CHECK(sqlite3_close_v2(conn));
 

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -477,8 +477,15 @@ flush_pending_insert_batch()
     int bind_idx = 1;
     for(const auto& row : pending.rows)
     {
+        ROCP_FATAL_IF(row.size() != field_size)
+            << "Pending insert batch row has " << row.size() << " values, expected " << field_size;
+
         for(const auto& value : row)
-            bind_sql_value(stmt, bind_idx++, value);
+        {
+            auto bind_rc = bind_sql_value(stmt, bind_idx++, value);
+            ROCP_FATAL_IF(bind_rc != SQLITE_OK)
+                << "sqlite3_bind failed with error code " << bind_rc;
+        }
     }
 
     auto step_rc = sqlite3_step(stmt);
@@ -530,11 +537,6 @@ get_insert_statement_impl(sqlite3*                                  conn,
     auto table = replace_uuid(_table);
     auto key   = fmt::format("{}:{}", table, fmt::join(fields, ","));
 
-    auto field_names = std::vector<std::string>{};
-    field_names.reserve(fields.size());
-    for(const auto& field : fields)
-        field_names.emplace_back(field);
-
     auto& pending = get_pending_insert_batch();
     if(pending.is_active && (pending.conn != conn || pending.cache != &cache || pending.key != key))
     {
@@ -548,8 +550,11 @@ get_insert_statement_impl(sqlite3*                                  conn,
         pending.cache     = &cache;
         pending.key       = key;
         pending.table     = table;
-        pending.fields    = std::move(field_names);
-        pending.max_rows  = get_max_batch_rows(conn, fields.size());
+        pending.fields.clear();
+        pending.fields.reserve(fields.size());
+        for(const auto& field : fields)
+            pending.fields.emplace_back(field);
+        pending.max_rows = get_max_batch_rows(conn, fields.size());
     }
 
     pending.rows.emplace_back(std::move(values));
@@ -1541,14 +1546,6 @@ write_rocpd(
                     auto _queue_id        = get_queue_id(extract_queue_field(itr));
                     auto _address         = extract_address_field(itr);
                     auto _allocation_size = extract_allocation_size_field(itr);
-
-                    // memory allocation counter track
-                    struct free_memory_information
-                    {
-                        rocprofiler_timestamp_t start_timestamp = 0;
-                        rocprofiler_timestamp_t end_timestamp   = 0;
-                        rocprofiler_address_t   address         = {.handle = 0};
-                    };
 
                     auto _node_id = std::optional<uint64_t>{};
                     if(_type == "ALLOC")

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -406,40 +406,40 @@ get_insert_statement_impl(sqlite3*                                  conn,
     auto cleanup_guard = common::scope_destructor{[&]() {
         if(stmt)
         {
-            SQLITE3_CHECK(sqlite3_reset(stmt));
-            SQLITE3_CHECK(sqlite3_clear_bindings(stmt));
+            sqlite3_reset(stmt);
+            sqlite3_clear_bindings(stmt);
         }
     }};
 
     for(size_t i = 0; i < values.size(); ++i)
     {
-        int  idx = static_cast<int>(i + 1);
-        auto rc  = std::visit(
+        int idx = static_cast<int>(i + 1);
+        std::visit(
             [&](auto&& val) {
                 using value_type = common::mpl::unqualified_type_t<decltype(val)>;
                 if constexpr(std::is_same_v<value_type, std::monostate>)
                 {
-                    return sqlite3_bind_null(stmt, idx);
+                    sqlite3_bind_null(stmt, idx);
                 }
                 else if constexpr(std::is_same_v<value_type, std::nullptr_t>)
                 {
-                    return sqlite3_bind_null(stmt, idx);
+                    sqlite3_bind_null(stmt, idx);
                 }
                 else if constexpr(std::is_same_v<value_type, int64_t>)
                 {
-                    return sqlite3_bind_int64(stmt, idx, val);
+                    sqlite3_bind_int64(stmt, idx, val);
                 }
                 else if constexpr(std::is_same_v<value_type, uint64_t>)
                 {
-                    return sqlite3_bind_int64(stmt, idx, static_cast<int64_t>(val));
+                    sqlite3_bind_int64(stmt, idx, static_cast<int64_t>(val));
                 }
                 else if constexpr(std::is_same_v<value_type, double>)
                 {
-                    return sqlite3_bind_double(stmt, idx, val);
+                    sqlite3_bind_double(stmt, idx, val);
                 }
                 else if constexpr(common::mpl::is_string_type<value_type>::value)
                 {
-                    return sqlite3_bind_text(stmt, idx, val.c_str(), -1, SQLITE_TRANSIENT);
+                    sqlite3_bind_text(stmt, idx, val.c_str(), -1, SQLITE_TRANSIENT);
                 }
                 else
                 {
@@ -448,15 +448,10 @@ get_insert_statement_impl(sqlite3*                                  conn,
                 }
             },
             values[i].value);
-
-        SQLITE3_CHECK(rc);
     }
 
     auto step_rc = sqlite3_step(stmt);
     ROCP_FATAL_IF(step_rc != SQLITE_DONE) << "sqlite3_step failed with error code " << step_rc;
-
-    SQLITE3_CHECK(sqlite3_reset(stmt));
-    SQLITE3_CHECK(sqlite3_clear_bindings(stmt));
 }
 
 template <template <typename...> class ContainerT, typename... TypesT>

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -165,32 +165,54 @@ get_hash_id(Tp&& _val)
         return get_hash_id(*_val);
 }
 
-auto&
-get_guid()
+struct rocpd_db
 {
-    static auto _v = std::string{};
-    return _v;
-}
+    using statement_map_t =
+        std::unordered_map<std::string_view, std::unordered_map<std::string, sqlite3_stmt*>>;
+    using schema_map_t = std::unordered_map<rocpd_sql_schema_kind_t, std::string>;
+    using track_map_t  = std::unordered_map<track_data, uint64_t>;
 
-auto&
-get_uuid()
+    rocpd_db() = default;
+    ~rocpd_db();
+    rocpd_db(const rocpd_db&) = delete;
+    rocpd_db& operator=(const rocpd_db&) = delete;
+    rocpd_db(rocpd_db&& other) noexcept  = delete;
+    rocpd_db& operator=(rocpd_db&&) = delete;
+
+    sqlite3*        conn             = nullptr;
+    std::string     uuid             = {};
+    std::string     guid             = {};
+    schema_map_t    schemas          = {};
+    track_map_t     tracks           = {};
+    size_t          event_id_counter = 0;
+    statement_map_t statements       = {};
+
+    auto get_event_id() { return ++event_id_counter; }
+};
+
+rocpd_db::~rocpd_db()
 {
-    static thread_local auto _v = std::string{};
-    return _v;
+    if(conn)
+    {
+        for(auto& [table, stmt_map] : statements)
+            for(auto& [stmt_name, stmt] : stmt_map)
+                sqlite3_finalize(stmt);
+        SQLITE3_CHECK(sqlite3_close_v2(conn));
+    }
 }
 
 auto
-replace_uuid(std::string_view inp)
+replace_uuid(const rocpd_db& db, std::string_view inp)
 {
-    const auto& _repl       = get_uuid();
+    const auto& _repl       = db.uuid;
     const auto  replacement = (_repl.empty()) ? std::string{} : fmt::format("_{}", _repl);
     return replace_all(std::string{inp}, std::string_view{"{{uuid}}"}, replacement);
 }
 
 auto
-replace_placeholders(std::string_view inp)
+replace_placeholders(const rocpd_db& db, std::string_view inp)
 {
-    return replace_uuid(inp);
+    return replace_uuid(db, inp);
 }
 
 template <typename... Args>
@@ -211,45 +233,26 @@ read_file(rocpd_sql_engine_t                        engine,
           const char*                               schema_content,
           void*                                     user_data)
 {
-    common::consume_args(engine, kind, options, variables, schema_path, schema_content, user_data);
+    common::consume_args(engine, kind, options, variables, schema_path, schema_content);
 
-    *static_cast<std::string*>(user_data) = replace_placeholders(schema_content);
+    auto* _db     = static_cast<rocpd_db*>(user_data);
+    auto& _schema = _db->schemas[kind];
+    _schema       = replace_placeholders(*_db, schema_content);
 }
 
 std::string
-read_schema_file(rocpd_sql_schema_kind_t schema_kind)
+read_schema_file(rocpd_db& db, rocpd_sql_schema_kind_t schema_kind)
 {
-    auto _variables     = common::init_public_api_struct(rocpd_sql_schema_jinja_variables_t{});
-    auto _options       = ROCPD_SQL_OPTIONS_NONE;
-    auto _schema_result = std::string{};
+    auto _variables = common::init_public_api_struct(rocpd_sql_schema_jinja_variables_t{});
+    auto _options   = ROCPD_SQL_OPTIONS_NONE;
 
-    _variables.uuid = get_uuid().c_str();
-    _variables.guid = get_guid().c_str();
+    _variables.uuid = db.uuid.c_str();
+    _variables.guid = db.guid.c_str();
 
-    ROCPD_CHECK(rocpd_sql_load_schema(ROCPD_SQL_ENGINE_SQLITE3,
-                                      schema_kind,
-                                      _options,
-                                      &_variables,
-                                      read_file,
-                                      nullptr,
-                                      0,
-                                      &_schema_result));
+    ROCPD_CHECK(rocpd_sql_load_schema(
+        ROCPD_SQL_ENGINE_SQLITE3, schema_kind, _options, &_variables, read_file, nullptr, 0, &db));
 
-    return _schema_result;
-}
-
-size_t
-get_event_id()
-{
-    static size_t event_id_index = 0;
-    return ++event_id_index;
-}
-
-auto&
-get_tracks()
-{
-    static auto _tracks = std::unordered_map<track_data, uint64_t>{};
-    return _tracks;
+    return db.schemas.at(schema_kind);
 }
 
 int
@@ -303,6 +306,14 @@ insert_value(std::string_view _name, const Tp& _value, TraitT = {})
 
     if constexpr(common::mpl::is_string_type<value_type>::value)
     {
+        if constexpr(std::is_pointer<value_type>::value)
+        {
+            if(!_value)
+            {
+                return insert_value(_name, std::string_view{}, TraitT{});
+            }
+        }
+
         if constexpr(!std::is_same<TraitT, allow_empty_string>::value)
         {
             if(std::string_view{_value}.empty())
@@ -352,40 +363,6 @@ insert_value(std::string_view _name, const std::optional<Tp>& _value, TraitT = {
     return insert_value(_name, _value.value(), TraitT{});
 }
 
-using statement_cache_t = std::unordered_map<std::string, sqlite3_stmt*>;
-
-struct pending_insert_batch
-{
-    sqlite3*                                   conn      = nullptr;
-    statement_cache_t*                         cache     = nullptr;
-    std::string                                key       = {};
-    std::string                                table     = {};
-    std::vector<std::string>                   fields    = {};
-    std::vector<std::vector<sql_insert_value>> rows      = {};
-    size_t                                     max_rows  = 1;
-    bool                                       is_active = false;
-};
-
-auto&
-get_pending_insert_batch()
-{
-    static thread_local auto _v = pending_insert_batch{};
-    return _v;
-}
-
-size_t
-get_max_batch_rows(sqlite3* conn, size_t col_count)
-{
-    int var_limit = sqlite3_limit(conn, SQLITE_LIMIT_VARIABLE_NUMBER, -1);
-    if(var_limit <= 0) var_limit = 999;
-
-    auto max_rows =
-        static_cast<size_t>(var_limit / static_cast<int>(std::max<size_t>(1, col_count)));
-    if(max_rows == 0) max_rows = 1;
-    if(max_rows > 256) max_rows = 256;
-    return max_rows;
-}
-
 int
 bind_sql_value(sqlite3_stmt* stmt, int idx, const sql_insert_value& value)
 {
@@ -425,95 +402,9 @@ bind_sql_value(sqlite3_stmt* stmt, int idx, const sql_insert_value& value)
         value.value);
 }
 
-void
-flush_pending_insert_batch()
-{
-    auto& pending = get_pending_insert_batch();
-    if(!pending.is_active || pending.rows.empty()) return;
-
-    ROCP_FATAL_IF(pending.conn == nullptr || pending.cache == nullptr)
-        << "Pending insert batch missing sqlite connection or statement cache";
-
-    const auto batch_size = pending.rows.size();
-    const auto field_size = pending.fields.size();
-    auto       batch_key =
-        fmt::format("{}:batch:{}:{}", pending.table, batch_size, fmt::join(pending.fields, ","));
-
-    auto& stmt = (*pending.cache)[batch_key];
-    if(!stmt)
-    {
-        auto row_placeholder = std::string{"("};
-        for(size_t i = 0; i < field_size; ++i)
-        {
-            if(i > 0) row_placeholder += ", ";
-            row_placeholder += "?";
-        }
-        row_placeholder += ")";
-
-        auto values_clause = std::string{};
-        values_clause.reserve(batch_size * row_placeholder.size());
-        for(size_t i = 0; i < batch_size; ++i)
-        {
-            if(i > 0) values_clause += ", ";
-            values_clause += row_placeholder;
-        }
-
-        auto sql = fmt::format("INSERT INTO {} ({}) VALUES {};",
-                               pending.table,
-                               fmt::join(pending.fields, ", "),
-                               values_clause);
-
-        SQLITE3_CHECK(sqlite3_prepare_v2(pending.conn, sql.c_str(), -1, &stmt, nullptr));
-    }
-
-    auto cleanup_guard = common::scope_destructor{[&]() {
-        if(stmt)
-        {
-            sqlite3_reset(stmt);
-            sqlite3_clear_bindings(stmt);
-        }
-    }};
-
-    int bind_idx = 1;
-    for(const auto& row : pending.rows)
-    {
-        ROCP_FATAL_IF(row.size() != field_size)
-            << "Pending insert batch row has " << row.size() << " values, expected " << field_size;
-
-        for(const auto& value : row)
-        {
-            auto bind_rc = bind_sql_value(stmt, bind_idx++, value);
-            ROCP_FATAL_IF(bind_rc != SQLITE_OK)
-                << "sqlite3_bind failed with error code " << bind_rc;
-        }
-    }
-
-    auto step_rc = sqlite3_step(stmt);
-    ROCP_FATAL_IF(step_rc != SQLITE_DONE) << "sqlite3_step failed with error code " << step_rc;
-
-    pending.rows.clear();
-    pending.is_active = false;
-    pending.key.clear();
-    pending.table.clear();
-    pending.fields.clear();
-    pending.conn  = nullptr;
-    pending.cache = nullptr;
-}
-
-void
-finalize_prepared_statements(statement_cache_t& cache)
-{
-    for(auto& [key, stmt] : cache)
-    {
-        if(stmt) SQLITE3_CHECK(sqlite3_finalize(stmt));
-    }
-    cache.clear();
-}
-
 template <template <typename...> class ContainerT, typename... TypesT>
 void
-get_insert_statement_impl(sqlite3*                                  conn,
-                          statement_cache_t&                        cache,
+get_insert_statement_impl(rocpd_db&                                 _db,
                           std::string_view                          _table,
                           ContainerT<sql_insert_value, TypesT...>&& _data)
 {
@@ -532,64 +423,60 @@ get_insert_statement_impl(sqlite3*                                  conn,
 
     if(fields.empty()) return;
 
-    ROCP_FATAL_IF(conn == nullptr) << "SQLite connection not set for prepared statements";
+    ROCP_FATAL_IF(_db.conn == nullptr) << "SQLite connection not set for prepared statements";
 
-    auto table = replace_uuid(_table);
-    auto key   = fmt::format("{}:{}", table, fmt::join(fields, ","));
+    auto   key  = fmt::format("{}", fmt::join(fields, ","));
+    auto*& stmt = _db.statements[_table][key];
 
-    auto& pending = get_pending_insert_batch();
-    if(pending.is_active && (pending.conn != conn || pending.cache != &cache || pending.key != key))
+    if(!stmt)
     {
-        flush_pending_insert_batch();
+        auto placeholders = std::vector<std::string_view>(fields.size(), "?");
+        auto sql          = fmt::format("INSERT INTO {} ({}) VALUES ({});",
+                               replace_uuid(_db, _table),
+                               fmt::join(fields, ", "),
+                               fmt::join(placeholders, ", "));
+
+        ROCP_INFO << fmt::format("Preparing SQL statement: '{}'", sql);
+        SQLITE3_CHECK(sqlite3_prepare_v2(_db.conn, sql.c_str(), -1, &stmt, nullptr));
     }
 
-    if(!pending.is_active)
+    for(size_t i = 0; i < fields.size(); ++i)
     {
-        pending.is_active = true;
-        pending.conn      = conn;
-        pending.cache     = &cache;
-        pending.key       = key;
-        pending.table     = table;
-        pending.fields.clear();
-        pending.fields.reserve(fields.size());
-        for(const auto& field : fields)
-            pending.fields.emplace_back(field);
-        pending.max_rows = get_max_batch_rows(conn, fields.size());
+        auto idx = static_cast<int>(i + 1);
+        ROCP_TRACE << fmt::format(
+            "Binding SQL value {} of {} (name={})", idx, fields.size(), fields.at(i));
+        SQLITE3_CHECK(bind_sql_value(stmt, idx, values.at(i)));
     }
 
-    pending.rows.emplace_back(std::move(values));
-    if(pending.rows.size() >= pending.max_rows) flush_pending_insert_batch();
+    SQLITE3_CHECK2(sqlite3_step(stmt), {SQLITE_OK, SQLITE_DONE, SQLITE_ROW});
+    SQLITE3_CHECK(sqlite3_reset(stmt));
+    SQLITE3_CHECK(sqlite3_clear_bindings(stmt));
 }
 
 template <template <typename...> class ContainerT, typename... TypesT>
 void
-get_insert_statement(sqlite3*                                  conn,
-                     statement_cache_t&                        cache,
+get_insert_statement(rocpd_db&                                 _db,
                      std::string_view                          _table,
                      ContainerT<sql_insert_value, TypesT...>&& _data)
 {
     get_insert_statement_impl(
-        conn, cache, _table, std::forward<ContainerT<sql_insert_value, TypesT...>>(_data));
+        _db, _table, std::forward<ContainerT<sql_insert_value, TypesT...>>(_data));
 }
 
 void
-get_insert_statement(sqlite3*                                  conn,
-                     statement_cache_t&                        cache,
+get_insert_statement(rocpd_db&                                 _db,
                      std::string_view                          _table,
                      std::initializer_list<sql_insert_value>&& _data)
 {
     get_insert_statement_impl(
-        conn, cache, _table, std::forward<std::initializer_list<sql_insert_value>>(_data));
+        _db, _table, std::forward<std::initializer_list<sql_insert_value>>(_data));
 }
 
 auto
-create_event_impl(sqlite3*                                  conn,
-                  statement_cache_t&                        cache,
-                  std::initializer_list<sql_insert_value>&& _data,
-                  int                                       line)
+create_event_impl(rocpd_db& _db, std::initializer_list<sql_insert_value>&& _data, int line)
 {
-    common::consume_args(conn, line);
-    auto evt_id    = get_event_id();
+    common::consume_args(_db, line);
+    auto evt_id    = _db.get_event_id();
     auto _data_vec = std::vector<sql_insert_value>{};
 
     _data_vec.reserve(_data.size() + 1);
@@ -597,30 +484,28 @@ create_event_impl(sqlite3*                                  conn,
     for(auto&& itr : _data)
         _data_vec.emplace_back(itr);
 
-    get_insert_statement(conn, cache, "rocpd_event{{uuid}}", std::move(_data_vec));
+    get_insert_statement(_db, "rocpd_event{{uuid}}", std::move(_data_vec));
 
     return evt_id;
 }
 
 uint64_t
-get_track_id_impl(sqlite3*           conn,
-                  statement_cache_t& cache,
-                  uint64_t           node_id,
-                  pid_t              pid,
-                  pid_t              tid,
-                  uint64_t           name_id,
-                  std::string_view   extdata,
-                  int                line)
+get_track_id_impl(rocpd_db&        _db,
+                  uint64_t         node_id,
+                  pid_t            pid,
+                  pid_t            tid,
+                  uint64_t         name_id,
+                  std::string_view extdata,
+                  int              line)
 {
-    common::consume_args(conn, line);
+    common::consume_args(_db, line);
     auto _track = track_data{node_id, pid, tid, name_id};
-    auto itr    = get_tracks().find(_track);
-    if(itr == get_tracks().end())
+    auto itr    = _db.tracks.find(_track);
+    if(itr == _db.tracks.end())
     {
-        auto idx = get_tracks().size() + 1;
-        itr      = get_tracks().emplace(_track, idx).first;
-        get_insert_statement(conn,
-                             cache,
+        auto idx = _db.tracks.size() + 1;
+        itr      = _db.tracks.emplace(_track, idx).first;
+        get_insert_statement(_db,
                              "rocpd_track{{uuid}}",
                              {
                                  insert_value("id", idx),
@@ -880,8 +765,8 @@ write_rocpd(
     ROCP_WARNING << fmt::format(
         "writing SQL database for process {} on node {}", this_pid, this_nid);
 
-    sqlite3* conn            = nullptr;
-    auto     statement_cache = statement_cache_t{};
+    auto      db   = rocpd_db{};
+    sqlite3*& conn = db.conn;
 
     {
         const auto& mach_id = tool_metadata.node_data.machine_id;
@@ -889,11 +774,11 @@ write_rocpd(
         auto        seed    = common::compute_system_seed(mach_id, this_pid, this_ppid, ticks);
         auto        uuid_v7 = common::generate_uuid_v7(this_pid_init_ns, seed);
 
-        get_guid() = fmt::format("{}", uuid_v7);
-        get_uuid() = fmt::format("{}", replace_all(uuid_v7, '-', "_"));
+        db.guid = fmt::format("{}", uuid_v7);
+        db.uuid = fmt::format("{}", replace_all(uuid_v7, '-', "_"));
 
         // reading schemata
-        auto table_schema = read_schema_file(ROCPD_SQL_SCHEMA_ROCPD_TABLES);
+        auto table_schema = read_schema_file(db, ROCPD_SQL_SCHEMA_ROCPD_TABLES);
         auto output_file  = get_output_filename(cfg, "results", "db");
         if(fs::exists(output_file)) fs::remove(output_file);
 
@@ -909,7 +794,7 @@ write_rocpd(
                         ROCPD_SQL_SCHEMA_ROCPD_MARKER_VIEWS,
                         ROCPD_SQL_SCHEMA_ROCPD_SUMMARY_VIEWS})
         {
-            auto views_schema = read_schema_file(itr);
+            auto views_schema = read_schema_file(db, itr);
             execute_raw_sql_statements(conn, views_schema);
         }
     }
@@ -969,7 +854,7 @@ write_rocpd(
     auto queue_set  = std::unordered_set<rocprofiler_queue_id_t>{};
 
     static auto get_stream_id =
-        [&conn, &statement_cache, &stream_set, &node_id, &this_pid](rocprofiler_stream_id_t val) {
+        [&db, &stream_set, &node_id, &this_pid](rocprofiler_stream_id_t val) {
             if(stream_set.count(val) == 0)
             {
                 ROCP_FATAL_IF(val.handle == 0 && !stream_set.empty()) << "Missing default stream";
@@ -982,8 +867,7 @@ write_rocpd(
                     _name = fmt::format("Stream {}", stream_set.size() - 1);
                 stream_set.emplace(val);
 
-                get_insert_statement(conn,
-                                     statement_cache,
+                get_insert_statement(db,
                                      "rocpd_info_stream{{uuid}}",
                                      {
                                          insert_value("id", val.handle),
@@ -996,43 +880,39 @@ write_rocpd(
             return val.handle;
         };
 
-    static auto get_queue_id =
-        [&conn, &statement_cache, &queue_set, &node_id, &this_pid](rocprofiler_queue_id_t val) {
-            if(queue_set.count(val) == 0)
-            {
-                ROCP_FATAL_IF(val.handle == 0 && !queue_set.empty()) << "Missing default queue";
-                ROCP_FATAL_IF(val.handle != 0 && queue_set.empty()) << "Missing default queue";
+    static auto get_queue_id = [&db, &queue_set, &node_id, &this_pid](rocprofiler_queue_id_t val) {
+        if(queue_set.count(val) == 0)
+        {
+            ROCP_FATAL_IF(val.handle == 0 && !queue_set.empty()) << "Missing default queue";
+            ROCP_FATAL_IF(val.handle != 0 && queue_set.empty()) << "Missing default queue";
 
-                auto _name = std::string{};
-                if(val.handle == 0)
-                    _name = std::string{"Default Queue"};
-                else
-                    _name = fmt::format("Queue {}", queue_set.size() - 1);
-                queue_set.emplace(val);
+            auto _name = std::string{};
+            if(val.handle == 0)
+                _name = std::string{"Default Queue"};
+            else
+                _name = fmt::format("Queue {}", queue_set.size() - 1);
+            queue_set.emplace(val);
 
-                get_insert_statement(conn,
-                                     statement_cache,
-                                     "rocpd_info_queue{{uuid}}",
-                                     {
-                                         insert_value("id", val.handle),
-                                         insert_value("nid", node_id),
-                                         insert_value("pid", this_pid),
-                                         insert_value("name", _name),
-                                     });
-            }
+            get_insert_statement(db,
+                                 "rocpd_info_queue{{uuid}}",
+                                 {
+                                     insert_value("id", val.handle),
+                                     insert_value("nid", node_id),
+                                     insert_value("pid", this_pid),
+                                     insert_value("name", _name),
+                                 });
+        }
 
-            return val.handle;
-        };
+        return val.handle;
+    };
 
     static auto get_thread_id =
-        [&conn, &statement_cache, &tool_metadata, &thread_ids, &node_id, &this_pid](
-            rocprofiler_thread_id_t val) {
+        [&db, &tool_metadata, &thread_ids, &node_id, &this_pid](rocprofiler_thread_id_t val) {
             if(thread_ids.count(val) == 0)
             {
                 thread_ids.emplace(val);
 
-                get_insert_statement(conn,
-                                     statement_cache,
+                get_insert_statement(db,
                                      "rocpd_info_thread{{uuid}}",
                                      {
                                          insert_value("id", val),
@@ -1055,8 +935,7 @@ write_rocpd(
         auto _deferred = sql::deferred_transaction{conn};
         for(const auto& itr : string_entries)
         {
-            get_insert_statement(conn,
-                                 statement_cache,
+            get_insert_statement(db,
                                  "rocpd_string{{uuid}}",
                                  {
                                      insert_value("id", itr.second),
@@ -1065,13 +944,12 @@ write_rocpd(
         }
     }
 
-    auto insert_node_data = [&conn, &statement_cache, &tool_metadata, node_id, node_hash]() {
+    auto insert_node_data = [&db, &tool_metadata, node_id, node_hash]() {
         auto        _sqlgenperf_rocpd = get_simple_timer("rocpd_info_node");
         const auto& _info             = tool_metadata.node_data;
 
         get_insert_statement(
-            conn,
-            statement_cache,
+            db,
             "rocpd_info_node{{uuid}}",
             {
                 insert_value("id", node_id),
@@ -1086,62 +964,57 @@ write_rocpd(
             });
     };
 
-    auto insert_process_data =
-        [&conn, &statement_cache, &tool_metadata, &cfg, node_id, this_pid]() {
-            auto _sqlgenperf_rocpd = get_simple_timer("rocpd_info_process");
-            auto json_cfg          = get_json_string([&cfg](auto& ar) { cfg.save(ar); });
-            auto json_env          = get_json_string([](auto& ar) {
-                size_t i = 0;
-                while(true)
+    auto insert_process_data = [&db, &tool_metadata, &cfg, node_id, this_pid]() {
+        auto _sqlgenperf_rocpd = get_simple_timer("rocpd_info_process");
+        auto json_cfg          = get_json_string([&cfg](auto& ar) { cfg.save(ar); });
+        auto json_env          = get_json_string([](auto& ar) {
+            size_t i = 0;
+            while(true)
+            {
+                const char* itr = environ[i++];
+                if(!itr) break;
+                if(auto pos = std::string_view{itr}.find('='); pos != std::string_view::npos)
                 {
-                    const char* itr = environ[i++];
-                    if(!itr) break;
-                    if(auto pos = std::string_view{itr}.find('='); pos != std::string_view::npos)
+                    auto evar = std::string{itr}.substr(0, pos);
+                    auto eval = std::string{itr}.substr(pos + 1);
+                    ROCP_TRACE << "ENV: " << evar << " = " << eval;
+                    if(eval.find(';') != std::string::npos)
                     {
-                        auto evar = std::string{itr}.substr(0, pos);
-                        auto eval = std::string{itr}.substr(pos + 1);
-                        ROCP_TRACE << "ENV: " << evar << " = " << eval;
-                        if(eval.find(';') != std::string::npos)
-                        {
-                            ROCP_INFO << fmt::format(
-                                "Env variable {} was sanitized due to semi-colon in the value",
-                                evar);
-                        }
-                        else if(!evar.empty())
-                        {
-                            ar(cereal::make_nvp(evar.c_str(), eval));
-                        }
+                        ROCP_INFO << fmt::format(
+                            "Env variable {} was sanitized due to semi-colon in the value", evar);
+                    }
+                    else if(!evar.empty())
+                    {
+                        ar(cereal::make_nvp(evar.c_str(), eval));
                     }
                 }
-            });
+            }
+        });
 
-            auto command = fmt::format(
-                "{}",
-                fmt::join(
-                    tool_metadata.command_line.begin(), tool_metadata.command_line.end(), " "));
-            auto _command = command;
+        auto _command = fmt::format(
+            "{}",
+            fmt::join(tool_metadata.command_line.begin(), tool_metadata.command_line.end(), " "));
 
-            get_insert_statement(conn,
-                                 statement_cache,
-                                 "rocpd_info_process{{uuid}}",
-                                 {
-                                     insert_value("id", this_pid),
-                                     insert_value("nid", node_id),
-                                     insert_value("ppid", tool_metadata.parent_process_id),
-                                     insert_value("pid", this_pid),
-                                     insert_value("init", tool_metadata.process_start_ns),
-                                     insert_value("fini", tool_metadata.process_end_ns),
-                                     insert_value("start", tool_metadata.process_start_ns),
-                                     insert_value("end", tool_metadata.process_end_ns),
-                                     insert_value("command", _command),
-                                     insert_value("environment", json_env),
-                                     insert_value("extdata", json_cfg),
-                                 });
-        };
+        get_insert_statement(db,
+                             "rocpd_info_process{{uuid}}",
+                             {
+                                 insert_value("id", this_pid),
+                                 insert_value("nid", node_id),
+                                 insert_value("ppid", tool_metadata.parent_process_id),
+                                 insert_value("pid", this_pid),
+                                 insert_value("init", tool_metadata.process_start_ns),
+                                 insert_value("fini", tool_metadata.process_end_ns),
+                                 insert_value("start", tool_metadata.process_start_ns),
+                                 insert_value("end", tool_metadata.process_end_ns),
+                                 insert_value("command", _command),
+                                 insert_value("environment", json_env),
+                                 insert_value("extdata", json_cfg),
+                             });
+    };
 
-    auto insert_agent_data = [&conn, &statement_cache, &tool_metadata, node_id, this_pid]() {
+    auto insert_agent_data = [&db, &tool_metadata, node_id, this_pid]() {
         auto _sqlgenperf_rocpd = get_simple_timer("rocpd_info_agent");
-        auto _deferred         = sql::deferred_transaction{conn};
+        auto _deferred         = sql::deferred_transaction{db.conn};
         for(auto itr : tool_metadata.agents)
         {
             auto json_info = get_json_string([&itr](auto& ar) { cereal::save(ar, itr); });
@@ -1152,8 +1025,7 @@ write_rocpd(
                 type = "GPU";
 
             get_insert_statement(
-                conn,
-                statement_cache,
+                db,
                 "rocpd_info_agent{{uuid}}",
                 {
                     insert_value("id", itr.node_id),
@@ -1174,13 +1046,9 @@ write_rocpd(
         }
     };
 
-    auto insert_kernel_code_object_data = [&conn,
-                                           &statement_cache,
-                                           &tool_metadata,
-                                           node_id,
-                                           this_pid]() {
+    auto insert_kernel_code_object_data = [&db, &tool_metadata, node_id, this_pid]() {
         auto _sqlgenperf_rocpd = get_simple_timer("rocpd kernel info");
-        auto _deferred         = sql::deferred_transaction{conn};
+        auto _deferred         = sql::deferred_transaction{db.conn};
         for(const auto& itr : tool_metadata.get_code_objects())
         {
             if(itr.size == 0) continue;
@@ -1189,8 +1057,7 @@ write_rocpd(
             auto        json_data =
                 get_json_string([](auto& ar, const auto oitr) { cereal::save(ar, oitr); }, itr);
 
-            get_insert_statement(conn,
-                                 statement_cache,
+            get_insert_statement(db,
                                  "rocpd_info_code_object{{uuid}}",
                                  {
                                      insert_value("id", itr.code_object_id),
@@ -1213,8 +1080,7 @@ write_rocpd(
                 get_json_string([](auto& ar, const auto& oitr) { cereal::save(ar, oitr); }, itr);
 
             get_insert_statement(
-                conn,
-                statement_cache,
+                db,
                 "rocpd_info_kernel_symbol{{uuid}}",
                 {
                     insert_value("id", itr.kernel_id),
@@ -1236,10 +1102,10 @@ write_rocpd(
         }
     };
 
-    auto insert_pmc_data = [&conn, &statement_cache, &tool_metadata, node_id, this_pid]() {
+    auto insert_pmc_data = [&db, &tool_metadata, node_id, this_pid]() {
         auto _sqlgenperf_rocpd = get_simple_timer("rocpd_info_pmc");
         auto recorded          = std::unordered_set<rocprofiler_counter_id_t>{};
-        auto _deferred         = sql::deferred_transaction{conn};
+        auto _deferred         = sql::deferred_transaction{db.conn};
         for(const auto& itr : tool_metadata.agent_counter_info)
         {
             for(const auto& aitr : itr.second)
@@ -1251,14 +1117,13 @@ write_rocpd(
                     if(agent) cereal::save(ar, *agent);
                 });
 
-                auto _name        = aitr.name;
-                auto _description = aitr.description;
-                auto _block       = aitr.block;
-                auto _expression  = aitr.expression;
+                const auto* _name        = aitr.name;
+                const auto* _description = aitr.description;
+                const auto* _block       = aitr.block;
+                const auto* _expression  = aitr.expression;
 
                 get_insert_statement(
-                    conn,
-                    statement_cache,
+                    db,
                     "rocpd_info_pmc{{uuid}}",
                     {
                         insert_value("id", aitr.id.handle),
@@ -1283,7 +1148,7 @@ write_rocpd(
 
     auto insert_kernel_dispatch_data = [&, node_id, this_pid](auto& dispatch_evt_ids) {
         auto _sqlgenperf_rocpd = get_simple_timer("rocpd_kernel_dispatch");
-        auto _deferred         = sql::deferred_transaction{conn};
+        auto _deferred         = sql::deferred_transaction{db.conn};
 
         auto process_dispatch = [&](uint64_t    dispatch_id,
                                     uint64_t    kernel_id,
@@ -1305,8 +1170,7 @@ write_rocpd(
                                  ? tool_metadata.get_kernel_symbol(kernel_id)->formatted_kernel_name
                                  : "unknown_kernel";
 
-            auto evt_id = create_event(conn,
-                                       statement_cache,
+            auto evt_id = create_event(db,
                                        {
                                            insert_value("category_id", string_entries.at(kind)),
                                            insert_value("stack_id", corr_id.internal),
@@ -1344,8 +1208,7 @@ write_rocpd(
 
             // Insert into kernel dispatch table
             get_insert_statement(
-                conn,
-                statement_cache,
+                db,
                 "rocpd_kernel_dispatch{{uuid}}",
                 {
                     insert_value("id", dispatch_id),
@@ -1436,9 +1299,9 @@ write_rocpd(
     };
 
     auto insert_pmc_event_data =
-        [&conn, &statement_cache, &tool_metadata, &counter_collection_gen](auto& dispatch_evt_ids) {
+        [&db, &tool_metadata, &counter_collection_gen](auto& dispatch_evt_ids) {
             auto   _sqlgenperf_rocpd = get_simple_timer("rocpd_pmc_event");
-            auto   _deferred         = sql::deferred_transaction{conn};
+            auto   _deferred         = sql::deferred_transaction{db.conn};
             size_t idx               = tool_metadata.pmc_event_offset;
             for(auto ditr : counter_collection_gen)
             {
@@ -1450,8 +1313,7 @@ write_rocpd(
                     auto evt_id = dispatch_evt_ids.at(dispatch_id);
                     for(const auto& count : record.read())
                     {
-                        get_insert_statement(conn,
-                                             statement_cache,
+                        get_insert_statement(db,
                                              "rocpd_pmc_event{{uuid}}",
                                              {
                                                  insert_value("id", idx++),
@@ -1465,10 +1327,9 @@ write_rocpd(
         };
 
     auto insert_memory_copy_data =
-        [&conn, &statement_cache, &tool_metadata, &string_entries, node_id, this_pid](
-            const auto& _gen) {
+        [&db, &tool_metadata, &string_entries, node_id, this_pid](const auto& _gen) {
             auto   _sqlgenperf_rocpd = get_simple_timer("rocpd_memory_copy");
-            auto   _deferred         = sql::deferred_transaction{conn};
+            auto   _deferred         = sql::deferred_transaction{db.conn};
             size_t copy_idx          = 1;
 
             for(auto pitr : _gen)
@@ -1482,8 +1343,7 @@ write_rocpd(
                     auto name = tool_metadata.buffer_names.at(itr.kind, itr.operation);
 
                     auto evt_id = create_event(
-                        conn,
-                        statement_cache,
+                        db,
                         {
                             insert_value("category_id", string_entries.at(kind)),
                             insert_value("stack_id", itr.correlation_id.internal),
@@ -1492,8 +1352,7 @@ write_rocpd(
                         });
 
                     get_insert_statement(
-                        conn,
-                        statement_cache,
+                        db,
                         "rocpd_memory_copy{{uuid}}",
                         {
                             insert_value("id", copy_idx++),
@@ -1518,11 +1377,10 @@ write_rocpd(
         };
 
     auto insert_memory_alloc_data =
-        [&conn, &statement_cache, &tool_metadata, &string_entries, node_id, this_pid](
-            const auto& _gen) {
+        [&db, &tool_metadata, &string_entries, node_id, this_pid](const auto& _gen) {
             auto address_to_agent_and_size =
                 std::unordered_map<rocprofiler_address_t, rocprofiler::agent::index_and_size>{};
-            auto _deferred = sql::deferred_transaction{conn};
+            auto _deferred = sql::deferred_transaction{db.conn};
 
             for(auto pitr : _gen)
             {
@@ -1584,8 +1442,7 @@ write_rocpd(
                     }
 
                     auto evt_id = create_event(
-                        conn,
-                        statement_cache,
+                        db,
                         {
                             insert_value("category_id", string_entries.at(_kind)),
                             insert_value("stack_id", itr.correlation_id.internal),
@@ -1596,8 +1453,7 @@ write_rocpd(
                     auto flags = extract_flags_field(itr);
 
                     get_insert_statement(
-                        conn,
-                        statement_cache,
+                        db,
                         "rocpd_memory_allocate{{uuid}}",
                         {
                             insert_value("nid", node_id),
@@ -1623,128 +1479,118 @@ write_rocpd(
         };
 
     // new string entries argument types and names can be added to _metadata
-    auto insert_api_data =
-        [&conn, &statement_cache, &tool_metadata, &string_entries, node_id, this_pid](
-            const auto& _gen) {
-            auto _deferred = sql::deferred_transaction{conn};
+    auto insert_api_data = [&db, &tool_metadata, &string_entries, node_id, this_pid](
+                               const auto& _gen) {
+        auto _deferred = sql::deferred_transaction{db.conn};
 
-            for(auto pitr : _gen)
+        for(auto pitr : _gen)
+        {
+            for(auto itr : _gen.get(pitr))
             {
-                for(auto itr : _gen.get(pitr))
-                {
-                    auto category = tool_metadata.buffer_names.at(itr.kind);
-                    auto name     = tool_metadata.buffer_names.at(itr.kind, itr.operation);
+                auto category = tool_metadata.buffer_names.at(itr.kind);
+                auto name     = tool_metadata.buffer_names.at(itr.kind, itr.operation);
 
-                    auto msg = std::string{"{}"};
-                    if(itr.kind == ROCPROFILER_BUFFER_TRACING_MARKER_CORE_RANGE_API)
+                auto msg = std::string{"{}"};
+                if(itr.kind == ROCPROFILER_BUFFER_TRACING_MARKER_CORE_RANGE_API)
+                {
+                    if(static_cast<rocprofiler_tracing_operation_t>(itr.operation) !=
+                       ROCPROFILER_MARKER_CORE_RANGE_API_ID_roctxGetThreadId)
                     {
-                        if(static_cast<rocprofiler_tracing_operation_t>(itr.operation) !=
-                           ROCPROFILER_MARKER_CORE_RANGE_API_ID_roctxGetThreadId)
-                        {
-                            // check generatePerfetto.cpp and generateOTF2.cpp, and the marker name
-                            // in the view
-                            auto message =
-                                tool_metadata.get_marker_message(itr.correlation_id.internal);
-                            if(!message.empty())
-                            {
-                                msg = get_json_string(
-                                    [](auto& ar, std::string_view _msg) {
-                                        ar(cereal::make_nvp("message", std::string{_msg}));
-                                    },
-                                    message);
-                            }
-                        }
-                        else
+                        // check generatePerfetto.cpp and generateOTF2.cpp, and the marker name
+                        // in the view
+                        auto message =
+                            tool_metadata.get_marker_message(itr.correlation_id.internal);
+                        if(!message.empty())
                         {
                             msg = get_json_string(
                                 [](auto& ar, std::string_view _msg) {
                                     ar(cereal::make_nvp("message", std::string{_msg}));
                                 },
-                                name);
+                                message);
                         }
-                    }
-
-                    auto args = function_args_t{};
-                    {
-                        auto _record = rocprofiler_record_header_t{
-                            .hash = rocprofiler_record_header_compute_hash(
-                                ROCPROFILER_BUFFER_CATEGORY_TRACING, itr.kind),
-                            .payload = &itr};
-
-                        rocprofiler_iterate_buffer_tracing_record_args(
-                            _record, iterate_args_callback, &args);
-                    }
-
-                    // insert thread info if it doesn't already exist
-                    get_thread_id(itr.thread_id);
-
-                    auto evt_id = create_event(
-                        conn,
-                        statement_cache,
-                        {
-                            insert_value("category_id", string_entries.at(category)),
-                            insert_value("stack_id", itr.correlation_id.internal),
-                            insert_value("parent_stack_id", itr.correlation_id.ancestor),
-                            insert_value("correlation_id", itr.correlation_id.external.value),
-                            insert_value("extdata", msg),
-                        });
-
-                    // insert arguments into rocpd_arg table
-                    for(const auto& arg_info : args)
-                    {
-                        auto demangled_type = common::cxx_demangle(arg_info.arg_type);
-
-                        get_insert_statement(conn,
-                                             statement_cache,
-                                             "rocpd_arg{{uuid}}",
-                                             {
-                                                 insert_value("event_id", evt_id),
-                                                 insert_value("position", arg_info.arg_number),
-                                                 insert_value("type", demangled_type),
-                                                 insert_value("name", arg_info.arg_name),
-                                                 insert_value("value", arg_info.arg_value),
-                                             });
-                    }
-
-                    if(itr.start_timestamp != itr.end_timestamp)
-                    {
-                        get_insert_statement(conn,
-                                             statement_cache,
-                                             "rocpd_region{{uuid}}",
-                                             {
-                                                 insert_value("id", itr.correlation_id.internal),
-                                                 insert_value("nid", node_id),
-                                                 insert_value("pid", this_pid),
-                                                 insert_value("tid", itr.thread_id),
-                                                 insert_value("start", itr.start_timestamp),
-                                                 insert_value("end", itr.end_timestamp),
-                                                 insert_value("name_id", string_entries.at(name)),
-                                                 insert_value("event_id", evt_id),
-                                             });
                     }
                     else
                     {
-                        auto track_id = get_track_id(conn,
-                                                     statement_cache,
-                                                     node_id,
-                                                     this_pid,
-                                                     itr.thread_id,
-                                                     string_entries.at(category),
-                                                     "{}");
-
-                        get_insert_statement(conn,
-                                             statement_cache,
-                                             "rocpd_sample{{uuid}}",
-                                             {
-                                                 insert_value("id", itr.correlation_id.internal),
-                                                 insert_value("track_id", track_id),
-                                                 insert_value("timestamp", itr.start_timestamp),
-                                                 insert_value("event_id", evt_id),
-                                             });
+                        msg = get_json_string(
+                            [](auto& ar, std::string_view _msg) {
+                                ar(cereal::make_nvp("message", std::string{_msg}));
+                            },
+                            name);
                     }
                 }
+
+                auto args = function_args_t{};
+                {
+                    auto _record = rocprofiler_record_header_t{
+                        .hash = rocprofiler_record_header_compute_hash(
+                            ROCPROFILER_BUFFER_CATEGORY_TRACING, itr.kind),
+                        .payload = &itr};
+
+                    rocprofiler_iterate_buffer_tracing_record_args(
+                        _record, iterate_args_callback, &args);
+                }
+
+                // insert thread info if it doesn't already exist
+                get_thread_id(itr.thread_id);
+
+                auto evt_id = create_event(
+                    db,
+                    {
+                        insert_value("category_id", string_entries.at(category)),
+                        insert_value("stack_id", itr.correlation_id.internal),
+                        insert_value("parent_stack_id", itr.correlation_id.ancestor),
+                        insert_value("correlation_id", itr.correlation_id.external.value),
+                        insert_value("extdata", msg),
+                    });
+
+                // insert arguments into rocpd_arg table
+                for(const auto& arg_info : args)
+                {
+                    auto demangled_type = common::cxx_demangle(arg_info.arg_type);
+
+                    get_insert_statement(db,
+                                         "rocpd_arg{{uuid}}",
+                                         {
+                                             insert_value("event_id", evt_id),
+                                             insert_value("position", arg_info.arg_number),
+                                             insert_value("type", demangled_type),
+                                             insert_value("name", arg_info.arg_name),
+                                             insert_value("value", arg_info.arg_value),
+                                         });
+                }
+
+                if(itr.start_timestamp != itr.end_timestamp)
+                {
+                    get_insert_statement(db,
+                                         "rocpd_region{{uuid}}",
+                                         {
+                                             insert_value("id", itr.correlation_id.internal),
+                                             insert_value("nid", node_id),
+                                             insert_value("pid", this_pid),
+                                             insert_value("tid", itr.thread_id),
+                                             insert_value("start", itr.start_timestamp),
+                                             insert_value("end", itr.end_timestamp),
+                                             insert_value("name_id", string_entries.at(name)),
+                                             insert_value("event_id", evt_id),
+                                         });
+                }
+                else
+                {
+                    auto track_id = get_track_id(
+                        db, node_id, this_pid, itr.thread_id, string_entries.at(category), "{}");
+
+                    get_insert_statement(db,
+                                         "rocpd_sample{{uuid}}",
+                                         {
+                                             insert_value("id", itr.correlation_id.internal),
+                                             insert_value("track_id", track_id),
+                                             insert_value("timestamp", itr.start_timestamp),
+                                             insert_value("event_id", evt_id),
+                                         });
+                }
             }
-        };
+        }
+    };
 
     auto insert_kfd_data = [&conn, &tool_metadata, node_id, this_pid](auto& pmc_ids) {
         auto _sqlgenperf_rocpd = get_simple_timer("rocpd_info_pmc: kfd");
@@ -1899,17 +1745,9 @@ write_rocpd(
 
     {
         auto _sqlgenperf_rocpd = get_simple_timer("SQL indexing");
-        auto indexes_schema    = read_schema_file(ROCPD_SQL_SCHEMA_ROCPD_INDEXES);
-        execute_raw_sql_statements(conn, indexes_schema);
+        auto indexes_schema    = read_schema_file(db, ROCPD_SQL_SCHEMA_ROCPD_INDEXES);
+        execute_raw_sql_statements(db.conn, indexes_schema);
     }
-
-    flush_pending_insert_batch();
-    finalize_prepared_statements(statement_cache);
-    SQLITE3_CHECK(sqlite3_close_v2(conn));
-
-    // Clear UUID/GUID state at end of write to prepare for potential re-attach
-    get_guid().clear();
-    get_uuid().clear();
 }
 }  // namespace tool
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -71,7 +71,6 @@
 #include <initializer_list>
 #include <limits>
 #include <map>
-#include <mutex>
 #include <thread>
 #include <type_traits>
 #include <unordered_map>
@@ -180,14 +179,13 @@ struct rocpd_db
     rocpd_db(rocpd_db&& other) noexcept  = delete;
     rocpd_db& operator=(rocpd_db&&) = delete;
 
-    sqlite3*           conn             = nullptr;
-    std::string        uuid             = {};
-    std::string        guid             = {};
-    schema_map_t       schemas          = {};
-    track_map_t        tracks           = {};
-    size_t             event_id_counter = 0;
-    mutable std::mutex statements_mutex = {};
-    statement_map_t    statements       = {};
+    sqlite3*        conn             = nullptr;
+    std::string     uuid             = {};
+    std::string     guid             = {};
+    schema_map_t    schemas          = {};
+    track_map_t     tracks           = {};
+    size_t          event_id_counter = 0;
+    statement_map_t statements       = {};
 
     auto get_event_id() { return ++event_id_counter; }
 };
@@ -196,7 +194,6 @@ rocpd_db::~rocpd_db()
 {
     if(conn)
     {
-        auto _lock = std::lock_guard<std::mutex>{statements_mutex};
         for(auto& [table, stmt_map] : statements)
             for(auto& [stmt_name, stmt] : stmt_map)
             {
@@ -451,26 +448,6 @@ reset_and_clear_statement(sqlite3_stmt* stmt)
     SQLITE3_CHECK(sqlite3_clear_bindings(stmt));
 }
 
-void
-check_bind_status(sqlite3_stmt* stmt, int status)
-{
-    if(status != SQLITE_OK)
-    {
-        reset_and_clear_statement(stmt);
-        SQLITE3_CHECK(status);
-    }
-}
-
-void
-check_step_status(sqlite3_stmt* stmt, int status)
-{
-    if(status != SQLITE_OK && status != SQLITE_DONE && status != SQLITE_ROW)
-    {
-        reset_and_clear_statement(stmt);
-        SQLITE3_CHECK2(status, {SQLITE_OK, SQLITE_DONE, SQLITE_ROW});
-    }
-}
-
 template <template <typename...> class ContainerT, typename... TypesT>
 uint64_t
 insert_row_impl(rocpd_db&                                 _db,
@@ -494,8 +471,6 @@ insert_row_impl(rocpd_db&                                 _db,
 
     ROCP_FATAL_IF(_db.conn == nullptr) << "SQLite connection not set for prepared statements";
 
-    auto _lock = std::lock_guard<std::mutex>{_db.statements_mutex};
-
     auto   key  = fmt::format("{}", fmt::join(fields, ","));
     auto*& stmt = _db.statements[_table][key];
 
@@ -516,15 +491,13 @@ insert_row_impl(rocpd_db&                                 _db,
         auto idx = static_cast<int>(i + 1);
         ROCP_TRACE << fmt::format(
             "Binding SQL value {} of {} (name={})", idx, fields.size(), fields.at(i));
-        check_bind_status(stmt, bind_sql_value(stmt, idx, values.at(i)));
+        SQLITE3_CHECK(bind_sql_value(stmt, idx, values.at(i)));
     }
 
-    check_step_status(stmt, sqlite3_step(stmt));
+    SQLITE3_CHECK2(sqlite3_step(stmt), {SQLITE_OK, SQLITE_DONE, SQLITE_ROW});
 
-    auto row_id = static_cast<uint64_t>(sqlite3_last_insert_rowid(_db.conn));
     reset_and_clear_statement(stmt);
-
-    return row_id;
+    return static_cast<uint64_t>(sqlite3_last_insert_rowid(_db.conn));
 }
 
 template <template <typename...> class ContainerT, typename... TypesT>

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -462,6 +462,15 @@ get_insert_statement_impl(std::string_view _table, ContainerT<sql_insert_value, 
         }
     }
 
+    auto needs_cleanup = true;
+    auto cleanup_guard = common::scope_destructor{[&]() {
+        if(needs_cleanup && stmt)
+        {
+            sqlite3_reset(stmt);
+            sqlite3_clear_bindings(stmt);
+        }
+    }};
+
     for(size_t i = 0; i < values.size(); ++i)
     {
         int idx = static_cast<int>(i + 1);
@@ -515,6 +524,7 @@ get_insert_statement_impl(std::string_view _table, ContainerT<sql_insert_value, 
 
     SQLITE3_CHECK(sqlite3_reset(stmt));
     SQLITE3_CHECK(sqlite3_clear_bindings(stmt));
+    needs_cleanup = false;
 
     return std::string{};
 }

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -71,6 +71,7 @@
 #include <initializer_list>
 #include <limits>
 #include <map>
+#include <mutex>
 #include <thread>
 #include <type_traits>
 #include <unordered_map>
@@ -179,13 +180,14 @@ struct rocpd_db
     rocpd_db(rocpd_db&& other) noexcept  = delete;
     rocpd_db& operator=(rocpd_db&&) = delete;
 
-    sqlite3*        conn             = nullptr;
-    std::string     uuid             = {};
-    std::string     guid             = {};
-    schema_map_t    schemas          = {};
-    track_map_t     tracks           = {};
-    size_t          event_id_counter = 0;
-    statement_map_t statements       = {};
+    sqlite3*           conn             = nullptr;
+    std::string        uuid             = {};
+    std::string        guid             = {};
+    schema_map_t       schemas          = {};
+    track_map_t        tracks           = {};
+    size_t             event_id_counter = 0;
+    mutable std::mutex statements_mutex = {};
+    statement_map_t    statements       = {};
 
     auto get_event_id() { return ++event_id_counter; }
 };
@@ -194,10 +196,36 @@ rocpd_db::~rocpd_db()
 {
     if(conn)
     {
+        auto _lock = std::lock_guard<std::mutex>{statements_mutex};
         for(auto& [table, stmt_map] : statements)
             for(auto& [stmt_name, stmt] : stmt_map)
-                sqlite3_finalize(stmt);
-        SQLITE3_CHECK(sqlite3_close_v2(conn));
+            {
+                if(!stmt) continue;
+
+                auto status = sqlite3_finalize(stmt);
+                if(status != SQLITE_OK)
+                {
+                    ROCP_WARNING << fmt::format(
+                        "Failed to finalize prepared statement for table '{}', key '{}': {} "
+                        "({})",
+                        table,
+                        stmt_name,
+                        sqlite3_errstr(status),
+                        status);
+                }
+
+                stmt = nullptr;
+            }
+
+        auto close_status = sqlite3_close_v2(conn);
+        if(close_status != SQLITE_OK)
+        {
+            ROCP_ERROR << fmt::format("Failed to close database connection: {} ({})",
+                                      sqlite3_errstr(close_status),
+                                      close_status);
+        }
+
+        conn = nullptr;
     }
 }
 
@@ -335,7 +363,14 @@ insert_value(std::string_view _name, const Tp& _value, TraitT = {})
         {
             auto _uval = static_cast<uint64_t>(_value);
             if(_uval > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
-                return sql_insert_value{_name, static_cast<double>(_uval)};
+            {
+                ROCP_WARNING << fmt::format(
+                    "Large unsigned value {} for field {} exceeds INT64_MAX; storing as TEXT "
+                    "to preserve precision",
+                    _uval,
+                    _name);
+                return sql_insert_value{_name, fmt::format("{}", _uval)};
+            }
             return sql_insert_value{_name, _uval};
         }
         else
@@ -385,6 +420,11 @@ bind_sql_value(sqlite3_stmt* stmt, int idx, const sql_insert_value& value)
             }
             else if constexpr(std::is_same_v<value_type, uint64_t>)
             {
+                if(val > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
+                {
+                    auto sval = fmt::format("{}", val);
+                    return sqlite3_bind_text(stmt, idx, sval.c_str(), -1, SQLITE_TRANSIENT);
+                }
                 return sqlite3_bind_int64(stmt, idx, static_cast<int64_t>(val));
             }
             else if constexpr(std::is_same_v<value_type, double>)
@@ -402,6 +442,33 @@ bind_sql_value(sqlite3_stmt* stmt, int idx, const sql_insert_value& value)
             }
         },
         value.value);
+}
+
+void
+reset_and_clear_statement(sqlite3_stmt* stmt)
+{
+    SQLITE3_CHECK(sqlite3_reset(stmt));
+    SQLITE3_CHECK(sqlite3_clear_bindings(stmt));
+}
+
+void
+check_bind_status(sqlite3_stmt* stmt, int status)
+{
+    if(status != SQLITE_OK)
+    {
+        reset_and_clear_statement(stmt);
+        SQLITE3_CHECK(status);
+    }
+}
+
+void
+check_step_status(sqlite3_stmt* stmt, int status)
+{
+    if(status != SQLITE_OK && status != SQLITE_DONE && status != SQLITE_ROW)
+    {
+        reset_and_clear_statement(stmt);
+        SQLITE3_CHECK2(status, {SQLITE_OK, SQLITE_DONE, SQLITE_ROW});
+    }
 }
 
 template <template <typename...> class ContainerT, typename... TypesT>
@@ -427,6 +494,8 @@ insert_row_impl(rocpd_db&                                 _db,
 
     ROCP_FATAL_IF(_db.conn == nullptr) << "SQLite connection not set for prepared statements";
 
+    auto _lock = std::lock_guard<std::mutex>{_db.statements_mutex};
+
     auto   key  = fmt::format("{}", fmt::join(fields, ","));
     auto*& stmt = _db.statements[_table][key];
 
@@ -447,13 +516,13 @@ insert_row_impl(rocpd_db&                                 _db,
         auto idx = static_cast<int>(i + 1);
         ROCP_TRACE << fmt::format(
             "Binding SQL value {} of {} (name={})", idx, fields.size(), fields.at(i));
-        SQLITE3_CHECK(bind_sql_value(stmt, idx, values.at(i)));
+        check_bind_status(stmt, bind_sql_value(stmt, idx, values.at(i)));
     }
 
-    SQLITE3_CHECK2(sqlite3_step(stmt), {SQLITE_OK, SQLITE_DONE, SQLITE_ROW});
+    check_step_status(stmt, sqlite3_step(stmt));
+
     auto row_id = static_cast<uint64_t>(sqlite3_last_insert_rowid(_db.conn));
-    SQLITE3_CHECK(sqlite3_reset(stmt));
-    SQLITE3_CHECK(sqlite3_clear_bindings(stmt));
+    reset_and_clear_statement(stmt);
 
     return row_id;
 }

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -513,7 +513,8 @@ get_insert_statement_impl(std::string_view _table, ContainerT<sql_insert_value, 
         throw std::runtime_error("sqlite3_step failed");
     }
 
-    sqlite3_reset(stmt);
+    SQLITE3_CHECK(sqlite3_reset(stmt));
+    SQLITE3_CHECK(sqlite3_clear_bindings(stmt));
 
     return std::string{};
 }

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -131,24 +131,6 @@ replace_all(std::string val, Tp from, std::string_view to)
     return val;
 }
 
-std::string
-sanitize_sql_string(std::string input)
-{
-    // Remove control/separator characters; no quote escaping when binding parameters.
-    constexpr auto ESCAPE_CHARS = std::string_view{";\n\r\t\b\f\v"};
-
-    for(char c : ESCAPE_CHARS)
-        input = replace_all(input, c, "");
-
-    return input;
-}
-
-std::string
-sanitize_sql_string(const char* input)
-{
-    return (input) ? sanitize_sql_string(std::string{input}) : std::string{};
-}
-
 template <typename FuncT, typename... Args>
 std::string
 get_json_string(FuncT&& _func, Args&&... _args)
@@ -165,7 +147,7 @@ get_json_string(FuncT&& _func, Args&&... _args)
         std::forward<FuncT>(_func)(ar, std::forward<Args>(_args)...);
     }
 
-    return sanitize_sql_string(json_ss.str());
+    return json_ss.str();
 }
 
 template <typename Tp>
@@ -329,9 +311,7 @@ insert_value(std::string_view _name, const Tp& _value, TraitT = {})
                 return sql_insert_value{_name, nullptr};
             }
         }
-        // Sanitize string values to remove problematic control/separator characters.
-        auto _sanitized = sanitize_sql_string(std::string{_value});
-        return sql_insert_value{_name, _sanitized};
+        return sql_insert_value{_name, std::string{_value}};
     }
     else if constexpr(std::is_enum_v<value_type>)
     {
@@ -371,51 +351,24 @@ insert_value(std::string_view _name, const std::optional<Tp>& _value, TraitT = {
     return insert_value(_name, _value.value(), TraitT{});
 }
 
-sqlite3*&
-get_active_sqlite_connection()
-{
-    static sqlite3* _conn = nullptr;
-    return _conn;
-}
-
-std::unordered_map<std::string, sqlite3_stmt*>&
-get_prepared_statement_cache()
-{
-    static auto _cache = std::unordered_map<std::string, sqlite3_stmt*>{};
-    return _cache;
-}
+using statement_cache_t = std::unordered_map<std::string, sqlite3_stmt*>;
 
 void
-set_active_sqlite_connection(sqlite3* conn)
+finalize_prepared_statements(statement_cache_t& cache)
 {
-    auto& current = get_active_sqlite_connection();
-    if(current == conn) return;
-
-    if(current != nullptr)
+    for(auto& [key, stmt] : cache)
     {
-        for(auto& [key, stmt] : get_prepared_statement_cache())
-        {
-            if(stmt) sqlite3_finalize(stmt);
-        }
-        get_prepared_statement_cache().clear();
+        if(stmt) SQLITE3_CHECK(sqlite3_finalize(stmt));
     }
-
-    current = conn;
-}
-
-void
-finalize_prepared_statements()
-{
-    for(auto& [key, stmt] : get_prepared_statement_cache())
-    {
-        if(stmt) sqlite3_finalize(stmt);
-    }
-    get_prepared_statement_cache().clear();
+    cache.clear();
 }
 
 template <template <typename...> class ContainerT, typename... TypesT>
-auto
-get_insert_statement_impl(std::string_view _table, ContainerT<sql_insert_value, TypesT...>&& _data)
+void
+get_insert_statement_impl(sqlite3*                                  conn,
+                          statement_cache_t&                        cache,
+                          std::string_view                          _table,
+                          ContainerT<sql_insert_value, TypesT...>&& _data)
 {
     auto fields = std::vector<std::string_view>{};
     auto values = std::vector<sql_insert_value>{};
@@ -430,10 +383,7 @@ get_insert_statement_impl(std::string_view _table, ContainerT<sql_insert_value, 
         values.emplace_back(itr);
     }
 
-    if(fields.empty()) return std::string{};
-
-    auto& conn  = get_active_sqlite_connection();
-    auto& cache = get_prepared_statement_cache();
+    if(fields.empty()) return;
 
     ROCP_FATAL_IF(conn == nullptr) << "SQLite connection not set for prepared statements";
 
@@ -443,110 +393,100 @@ get_insert_statement_impl(std::string_view _table, ContainerT<sql_insert_value, 
     auto& stmt = cache[key];
     if(!stmt)
     {
-        auto placeholders = std::string{};
-        for(size_t i = 0; i < fields.size(); ++i)
-        {
-            if(i > 0) placeholders += ", ";
-            placeholders += "?";
-        }
+        auto placeholders = std::vector<std::string_view>(fields.size(), std::string_view{"?"});
 
-        auto sql = fmt::format(
-            "INSERT INTO {} ({}) VALUES ({});", table, fmt::join(fields, ", "), placeholders);
+        auto sql = fmt::format("INSERT INTO {} ({}) VALUES ({});",
+                               table,
+                               fmt::join(fields, ", "),
+                               fmt::join(placeholders, ", "));
 
-        int rc = sqlite3_prepare_v2(conn, sql.c_str(), -1, &stmt, nullptr);
-        if(rc != SQLITE_OK)
-        {
-            ROCP_FATAL << fmt::format(
-                "[{}] Failed to prepare statement: {}", rc, sqlite3_errmsg(conn));
-            throw std::runtime_error("sqlite3_prepare_v2 failed");
-        }
+        SQLITE3_CHECK(sqlite3_prepare_v2(conn, sql.c_str(), -1, &stmt, nullptr));
     }
 
-    auto needs_cleanup = true;
     auto cleanup_guard = common::scope_destructor{[&]() {
-        if(needs_cleanup && stmt)
+        if(stmt)
         {
-            sqlite3_reset(stmt);
-            sqlite3_clear_bindings(stmt);
+            SQLITE3_CHECK(sqlite3_reset(stmt));
+            SQLITE3_CHECK(sqlite3_clear_bindings(stmt));
         }
     }};
 
     for(size_t i = 0; i < values.size(); ++i)
     {
-        int idx = static_cast<int>(i + 1);
-        std::visit(
+        int  idx = static_cast<int>(i + 1);
+        auto rc  = std::visit(
             [&](auto&& val) {
-                using T = std::decay_t<decltype(val)>;
-                int rc  = SQLITE_OK;
-                if constexpr(std::is_same_v<T, std::monostate>)
+                using value_type = common::mpl::unqualified_type_t<decltype(val)>;
+                if constexpr(std::is_same_v<value_type, std::monostate>)
                 {
-                    rc = sqlite3_bind_null(stmt, idx);
+                    return sqlite3_bind_null(stmt, idx);
                 }
-                else if constexpr(std::is_same_v<T, std::nullptr_t>)
+                else if constexpr(std::is_same_v<value_type, std::nullptr_t>)
                 {
-                    rc = sqlite3_bind_null(stmt, idx);
+                    return sqlite3_bind_null(stmt, idx);
                 }
-                else if constexpr(std::is_same_v<T, int64_t>)
+                else if constexpr(std::is_same_v<value_type, int64_t>)
                 {
-                    rc = sqlite3_bind_int64(stmt, idx, val);
+                    return sqlite3_bind_int64(stmt, idx, val);
                 }
-                else if constexpr(std::is_same_v<T, uint64_t>)
+                else if constexpr(std::is_same_v<value_type, uint64_t>)
                 {
-                    rc = sqlite3_bind_int64(stmt, idx, static_cast<int64_t>(val));
+                    return sqlite3_bind_int64(stmt, idx, static_cast<int64_t>(val));
                 }
-                else if constexpr(std::is_same_v<T, double>)
+                else if constexpr(std::is_same_v<value_type, double>)
                 {
-                    rc = sqlite3_bind_double(stmt, idx, val);
+                    return sqlite3_bind_double(stmt, idx, val);
                 }
-                else if constexpr(std::is_same_v<T, std::string>)
+                else if constexpr(common::mpl::is_string_type<value_type>::value)
                 {
-                    rc = sqlite3_bind_text(stmt, idx, val.c_str(), -1, SQLITE_TRANSIENT);
+                    return sqlite3_bind_text(stmt, idx, val.c_str(), -1, SQLITE_TRANSIENT);
                 }
-
-                if(rc != SQLITE_OK)
+                else
                 {
-                    ROCP_FATAL << fmt::format("[{}] Failed to bind parameter at index {}: {}",
-                                              rc,
-                                              idx,
-                                              sqlite3_errmsg(conn));
-                    throw std::runtime_error("sqlite3_bind failed");
+                    static_assert(common::mpl::assert_false<value_type>::value,
+                                  "Unsupported data type");
                 }
             },
             values[i].value);
+
+        SQLITE3_CHECK(rc);
     }
 
-    int rc = sqlite3_step(stmt);
-    if(rc != SQLITE_DONE)
-    {
-        ROCP_FATAL << fmt::format("[{}] Failed to execute statement: {}", rc, sqlite3_errmsg(conn));
-        throw std::runtime_error("sqlite3_step failed");
-    }
+    auto step_rc = sqlite3_step(stmt);
+    ROCP_FATAL_IF(step_rc != SQLITE_DONE) << "sqlite3_step failed with error code " << step_rc;
 
     SQLITE3_CHECK(sqlite3_reset(stmt));
     SQLITE3_CHECK(sqlite3_clear_bindings(stmt));
-    needs_cleanup = false;
-
-    return std::string{};
 }
 
 template <template <typename...> class ContainerT, typename... TypesT>
-auto
-get_insert_statement(std::string_view _table, ContainerT<sql_insert_value, TypesT...>&& _data)
+void
+get_insert_statement(sqlite3*                                  conn,
+                     statement_cache_t&                        cache,
+                     std::string_view                          _table,
+                     ContainerT<sql_insert_value, TypesT...>&& _data)
 {
-    return get_insert_statement_impl(_table,
-                                     std::forward<ContainerT<sql_insert_value, TypesT...>>(_data));
+    get_insert_statement_impl(
+        conn, cache, _table, std::forward<ContainerT<sql_insert_value, TypesT...>>(_data));
+}
+
+void
+get_insert_statement(sqlite3*                                  conn,
+                     statement_cache_t&                        cache,
+                     std::string_view                          _table,
+                     std::initializer_list<sql_insert_value>&& _data)
+{
+    get_insert_statement_impl(
+        conn, cache, _table, std::forward<std::initializer_list<sql_insert_value>>(_data));
 }
 
 auto
-get_insert_statement(std::string_view _table, std::initializer_list<sql_insert_value>&& _data)
+create_event_impl(sqlite3*                                  conn,
+                  statement_cache_t&                        cache,
+                  std::initializer_list<sql_insert_value>&& _data,
+                  int                                       line)
 {
-    return get_insert_statement_impl(_table,
-                                     std::forward<std::initializer_list<sql_insert_value>>(_data));
-}
-
-auto
-create_event_impl(sqlite3* conn, std::initializer_list<sql_insert_value>&& _data, int line)
-{
+    common::consume_args(conn, line);
     auto evt_id    = get_event_id();
     auto _data_vec = std::vector<sql_insert_value>{};
 
@@ -555,46 +495,46 @@ create_event_impl(sqlite3* conn, std::initializer_list<sql_insert_value>&& _data
     for(auto&& itr : _data)
         _data_vec.emplace_back(itr);
 
-    auto event_stmt = get_insert_statement("rocpd_event{{uuid}}", std::move(_data_vec));
-
-    sql::execute_raw_sql_statements_impl(conn, event_stmt, line);
+    get_insert_statement(conn, cache, "rocpd_event{{uuid}}", std::move(_data_vec));
 
     return evt_id;
 }
 
 uint64_t
-get_track_id_impl(sqlite3*         conn,
-                  uint64_t         node_id,
-                  pid_t            pid,
-                  pid_t            tid,
-                  uint64_t         name_id,
-                  std::string_view extdata,
-                  int              line)
+get_track_id_impl(sqlite3*           conn,
+                  statement_cache_t& cache,
+                  uint64_t           node_id,
+                  pid_t              pid,
+                  pid_t              tid,
+                  uint64_t           name_id,
+                  std::string_view   extdata,
+                  int                line)
 {
+    common::consume_args(conn, line);
     auto _track = track_data{node_id, pid, tid, name_id};
     auto itr    = get_tracks().find(_track);
     if(itr == get_tracks().end())
     {
-        auto idx  = get_tracks().size() + 1;
-        itr       = get_tracks().emplace(_track, idx).first;
-        auto stmt = get_insert_statement("rocpd_track{{uuid}}",
-                                         {
-                                             insert_value("id", idx),
-                                             insert_value("nid", node_id),
-                                             insert_value("pid", pid),
-                                             insert_value("tid", tid),
-                                             insert_value("name_id", name_id),
-                                             insert_value("extdata", extdata),
-                                         });
-
-        sql::execute_raw_sql_statements_impl(conn, stmt, line);
+        auto idx = get_tracks().size() + 1;
+        itr      = get_tracks().emplace(_track, idx).first;
+        get_insert_statement(conn,
+                             cache,
+                             "rocpd_track{{uuid}}",
+                             {
+                                 insert_value("id", idx),
+                                 insert_value("nid", node_id),
+                                 insert_value("pid", pid),
+                                 insert_value("tid", tid),
+                                 insert_value("name_id", name_id),
+                                 insert_value("extdata", extdata),
+                             });
         return idx;
     }
 
     return itr->second;
 }
 
-// so that execute_raw_sql_statements returns the correct line
+// keep macro wrappers for call-site consistency
 #define create_event(...) create_event_impl(__VA_ARGS__, __LINE__)
 #define get_track_id(...) get_track_id_impl(__VA_ARGS__, __LINE__)
 }  // namespace
@@ -838,7 +778,8 @@ write_rocpd(
     ROCP_WARNING << fmt::format(
         "writing SQL database for process {} on node {}", this_pid, this_nid);
 
-    sqlite3* conn = nullptr;
+    sqlite3* conn            = nullptr;
+    auto     statement_cache = statement_cache_t{};
 
     {
         const auto& mach_id = tool_metadata.node_data.machine_id;
@@ -857,8 +798,6 @@ write_rocpd(
         SQLITE3_CHECK(sqlite3_open_v2(
             output_file.c_str(), &conn, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr));
         SQLITE3_CHECK(sqlite3_busy_handler(conn, &sql::busy_handler, nullptr));
-        set_active_sqlite_connection(conn);
-
         ROCP_ERROR << fmt::format("Opened result file: {} (UUID={})", output_file, uuid_v7);
 
         execute_raw_sql_statements(conn, table_schema);
@@ -928,7 +867,7 @@ write_rocpd(
     auto queue_set  = std::unordered_set<rocprofiler_queue_id_t>{};
 
     static auto get_stream_id =
-        [&conn, &stream_set, &node_id, &this_pid](rocprofiler_stream_id_t val) {
+        [&conn, &statement_cache, &stream_set, &node_id, &this_pid](rocprofiler_stream_id_t val) {
             if(stream_set.count(val) == 0)
             {
                 ROCP_FATAL_IF(val.handle == 0 && !stream_set.empty()) << "Missing default stream";
@@ -941,22 +880,22 @@ write_rocpd(
                     _name = fmt::format("Stream {}", stream_set.size() - 1);
                 stream_set.emplace(val);
 
-                auto stmt = get_insert_statement("rocpd_info_stream{{uuid}}",
-                                                 {
-                                                     insert_value("id", val.handle),
-                                                     insert_value("nid", node_id),
-                                                     insert_value("pid", this_pid),
-                                                     insert_value("name", _name),
-                                                 });
-
-                execute_raw_sql_statements(conn, stmt);
+                get_insert_statement(conn,
+                                     statement_cache,
+                                     "rocpd_info_stream{{uuid}}",
+                                     {
+                                         insert_value("id", val.handle),
+                                         insert_value("nid", node_id),
+                                         insert_value("pid", this_pid),
+                                         insert_value("name", _name),
+                                     });
             }
 
             return val.handle;
         };
 
     static auto get_queue_id =
-        [&conn, &queue_set, &node_id, &this_pid](rocprofiler_queue_id_t val) {
+        [&conn, &statement_cache, &queue_set, &node_id, &this_pid](rocprofiler_queue_id_t val) {
             if(queue_set.count(val) == 0)
             {
                 ROCP_FATAL_IF(val.handle == 0 && !queue_set.empty()) << "Missing default queue";
@@ -969,37 +908,37 @@ write_rocpd(
                     _name = fmt::format("Queue {}", queue_set.size() - 1);
                 queue_set.emplace(val);
 
-                auto stmt = get_insert_statement("rocpd_info_queue{{uuid}}",
-                                                 {
-                                                     insert_value("id", val.handle),
-                                                     insert_value("nid", node_id),
-                                                     insert_value("pid", this_pid),
-                                                     insert_value("name", _name),
-                                                 });
-
-                execute_raw_sql_statements(conn, stmt);
+                get_insert_statement(conn,
+                                     statement_cache,
+                                     "rocpd_info_queue{{uuid}}",
+                                     {
+                                         insert_value("id", val.handle),
+                                         insert_value("nid", node_id),
+                                         insert_value("pid", this_pid),
+                                         insert_value("name", _name),
+                                     });
             }
 
             return val.handle;
         };
 
     static auto get_thread_id =
-        [&conn, &tool_metadata, &thread_ids, &node_id, &this_pid](rocprofiler_thread_id_t val) {
+        [&conn, &statement_cache, &tool_metadata, &thread_ids, &node_id, &this_pid](
+            rocprofiler_thread_id_t val) {
             if(thread_ids.count(val) == 0)
             {
                 thread_ids.emplace(val);
 
-                auto stmt =
-                    get_insert_statement("rocpd_info_thread{{uuid}}",
-                                         {
-                                             insert_value("id", val),
-                                             insert_value("nid", node_id),
-                                             insert_value("ppid", tool_metadata.parent_process_id),
-                                             insert_value("pid", this_pid),
-                                             insert_value("tid", val),
-                                         });
-
-                execute_raw_sql_statements(conn, stmt);
+                get_insert_statement(conn,
+                                     statement_cache,
+                                     "rocpd_info_thread{{uuid}}",
+                                     {
+                                         insert_value("id", val),
+                                         insert_value("nid", node_id),
+                                         insert_value("ppid", tool_metadata.parent_process_id),
+                                         insert_value("pid", this_pid),
+                                         insert_value("tid", val),
+                                     });
             }
 
             return val;
@@ -1014,21 +953,23 @@ write_rocpd(
         auto _deferred = sql::deferred_transaction{conn};
         for(const auto& itr : string_entries)
         {
-            auto stmt =
-                get_insert_statement("rocpd_string{{uuid}}",
-                                     {
-                                         insert_value("id", itr.second),
-                                         insert_value("string", itr.first, allow_empty_string{}),
-                                     });
-            execute_raw_sql_statements(conn, stmt);
+            get_insert_statement(conn,
+                                 statement_cache,
+                                 "rocpd_string{{uuid}}",
+                                 {
+                                     insert_value("id", itr.second),
+                                     insert_value("string", itr.first, allow_empty_string{}),
+                                 });
         }
     }
 
-    auto insert_node_data = [&conn, &tool_metadata, node_id, node_hash]() {
+    auto insert_node_data = [&conn, &statement_cache, &tool_metadata, node_id, node_hash]() {
         auto        _sqlgenperf_rocpd = get_simple_timer("rocpd_info_node");
         const auto& _info             = tool_metadata.node_data;
 
-        auto stmt = get_insert_statement(
+        get_insert_statement(
+            conn,
+            statement_cache,
             "rocpd_info_node{{uuid}}",
             {
                 insert_value("id", node_id),
@@ -1041,61 +982,62 @@ write_rocpd(
                 insert_value("hardware_name", _info.hardware_name, allow_empty_string{}),
                 insert_value("domain_name", _info.domain_name, allow_empty_string{}),
             });
-
-        execute_raw_sql_statements(conn, stmt);
     };
 
-    auto insert_process_data = [&conn, &tool_metadata, &cfg, node_id, this_pid]() {
-        auto _sqlgenperf_rocpd = get_simple_timer("rocpd_info_process");
-        auto json_cfg          = get_json_string([&cfg](auto& ar) { cfg.save(ar); });
-        auto json_env          = get_json_string([](auto& ar) {
-            size_t i = 0;
-            while(true)
-            {
-                const char* itr = environ[i++];
-                if(!itr) break;
-                if(auto pos = std::string_view{itr}.find('='); pos != std::string_view::npos)
+    auto insert_process_data =
+        [&conn, &statement_cache, &tool_metadata, &cfg, node_id, this_pid]() {
+            auto _sqlgenperf_rocpd = get_simple_timer("rocpd_info_process");
+            auto json_cfg          = get_json_string([&cfg](auto& ar) { cfg.save(ar); });
+            auto json_env          = get_json_string([](auto& ar) {
+                size_t i = 0;
+                while(true)
                 {
-                    auto evar = std::string{itr}.substr(0, pos);
-                    auto eval = std::string{itr}.substr(pos + 1);
-                    ROCP_TRACE << "ENV: " << evar << " = " << eval;
-                    if(eval.find(';') != std::string::npos)
+                    const char* itr = environ[i++];
+                    if(!itr) break;
+                    if(auto pos = std::string_view{itr}.find('='); pos != std::string_view::npos)
                     {
-                        ROCP_INFO << fmt::format(
-                            "Env variable {} was sanitized due to semi-colon in the value", evar);
-                    }
-                    else if(!evar.empty())
-                    {
-                        ar(cereal::make_nvp(evar.c_str(), eval));
+                        auto evar = std::string{itr}.substr(0, pos);
+                        auto eval = std::string{itr}.substr(pos + 1);
+                        ROCP_TRACE << "ENV: " << evar << " = " << eval;
+                        if(eval.find(';') != std::string::npos)
+                        {
+                            ROCP_INFO << fmt::format(
+                                "Env variable {} was sanitized due to semi-colon in the value",
+                                evar);
+                        }
+                        else if(!evar.empty())
+                        {
+                            ar(cereal::make_nvp(evar.c_str(), eval));
+                        }
                     }
                 }
-            }
-        });
+            });
 
-        auto command = fmt::format(
-            "{}",
-            fmt::join(tool_metadata.command_line.begin(), tool_metadata.command_line.end(), " "));
-        auto _command = sanitize_sql_string(command);
+            auto command = fmt::format(
+                "{}",
+                fmt::join(
+                    tool_metadata.command_line.begin(), tool_metadata.command_line.end(), " "));
+            auto _command = command;
 
-        auto stmt = get_insert_statement("rocpd_info_process{{uuid}}",
-                                         {
-                                             insert_value("id", this_pid),
-                                             insert_value("nid", node_id),
-                                             insert_value("ppid", tool_metadata.parent_process_id),
-                                             insert_value("pid", this_pid),
-                                             insert_value("init", tool_metadata.process_start_ns),
-                                             insert_value("fini", tool_metadata.process_end_ns),
-                                             insert_value("start", tool_metadata.process_start_ns),
-                                             insert_value("end", tool_metadata.process_end_ns),
-                                             insert_value("command", _command),
-                                             insert_value("environment", json_env),
-                                             insert_value("extdata", json_cfg),
-                                         });
+            get_insert_statement(conn,
+                                 statement_cache,
+                                 "rocpd_info_process{{uuid}}",
+                                 {
+                                     insert_value("id", this_pid),
+                                     insert_value("nid", node_id),
+                                     insert_value("ppid", tool_metadata.parent_process_id),
+                                     insert_value("pid", this_pid),
+                                     insert_value("init", tool_metadata.process_start_ns),
+                                     insert_value("fini", tool_metadata.process_end_ns),
+                                     insert_value("start", tool_metadata.process_start_ns),
+                                     insert_value("end", tool_metadata.process_end_ns),
+                                     insert_value("command", _command),
+                                     insert_value("environment", json_env),
+                                     insert_value("extdata", json_cfg),
+                                 });
+        };
 
-        execute_raw_sql_statements(conn, stmt);
-    };
-
-    auto insert_agent_data = [&conn, &tool_metadata, node_id, this_pid]() {
+    auto insert_agent_data = [&conn, &statement_cache, &tool_metadata, node_id, this_pid]() {
         auto _sqlgenperf_rocpd = get_simple_timer("rocpd_info_agent");
         auto _deferred         = sql::deferred_transaction{conn};
         for(auto itr : tool_metadata.agents)
@@ -1107,7 +1049,9 @@ write_rocpd(
             else if(itr.type == ROCPROFILER_AGENT_TYPE_GPU)
                 type = "GPU";
 
-            auto stmt = get_insert_statement(
+            get_insert_statement(
+                conn,
+                statement_cache,
                 "rocpd_info_agent{{uuid}}",
                 {
                     insert_value("id", itr.node_id),
@@ -1125,12 +1069,14 @@ write_rocpd(
                     insert_value("user_name", itr.product_name, allow_empty_string{}),
                     insert_value("extdata", json_info),
                 });
-
-            execute_raw_sql_statements(conn, stmt);
         }
     };
 
-    auto insert_kernel_code_object_data = [&conn, &tool_metadata, node_id, this_pid]() {
+    auto insert_kernel_code_object_data = [&conn,
+                                           &statement_cache,
+                                           &tool_metadata,
+                                           node_id,
+                                           this_pid]() {
         auto _sqlgenperf_rocpd = get_simple_timer("rocpd kernel info");
         auto _deferred         = sql::deferred_transaction{conn};
         for(const auto& itr : tool_metadata.get_code_objects())
@@ -1141,21 +1087,20 @@ write_rocpd(
             auto        json_data =
                 get_json_string([](auto& ar, const auto oitr) { cereal::save(ar, oitr); }, itr);
 
-            auto stmt =
-                get_insert_statement("rocpd_info_code_object{{uuid}}",
-                                     {
-                                         insert_value("id", itr.code_object_id),
-                                         insert_value("nid", node_id),
-                                         insert_value("pid", this_pid),
-                                         insert_value("agent_id", CHECK_NOTNULL(_agent)->node_id),
-                                         insert_value("uri", itr.uri),
-                                         insert_value("load_base", itr.load_base),
-                                         insert_value("load_size", itr.load_size),
-                                         insert_value("load_delta", itr.load_delta),
-                                         insert_value("extdata", json_data),
-                                     });
-
-            execute_raw_sql_statements(conn, stmt);
+            get_insert_statement(conn,
+                                 statement_cache,
+                                 "rocpd_info_code_object{{uuid}}",
+                                 {
+                                     insert_value("id", itr.code_object_id),
+                                     insert_value("nid", node_id),
+                                     insert_value("pid", this_pid),
+                                     insert_value("agent_id", CHECK_NOTNULL(_agent)->node_id),
+                                     insert_value("uri", itr.uri),
+                                     insert_value("load_base", itr.load_base),
+                                     insert_value("load_size", itr.load_size),
+                                     insert_value("load_delta", itr.load_delta),
+                                     insert_value("extdata", json_data),
+                                 });
         }
 
         for(const auto& itr : tool_metadata.get_kernel_symbols())
@@ -1165,7 +1110,9 @@ write_rocpd(
             auto json_data =
                 get_json_string([](auto& ar, const auto& oitr) { cereal::save(ar, oitr); }, itr);
 
-            auto stmt = get_insert_statement(
+            get_insert_statement(
+                conn,
+                statement_cache,
                 "rocpd_info_kernel_symbol{{uuid}}",
                 {
                     insert_value("id", itr.kernel_id),
@@ -1184,12 +1131,10 @@ write_rocpd(
                     insert_value("accum_vgpr_count", itr.accum_vgpr_count),
                     insert_value("extdata", json_data),
                 });
-
-            execute_raw_sql_statements(conn, stmt);
         }
     };
 
-    auto insert_pmc_data = [&conn, &tool_metadata, node_id, this_pid]() {
+    auto insert_pmc_data = [&conn, &statement_cache, &tool_metadata, node_id, this_pid]() {
         auto _sqlgenperf_rocpd = get_simple_timer("rocpd_info_pmc");
         auto recorded          = std::unordered_set<rocprofiler_counter_id_t>{};
         auto _deferred         = sql::deferred_transaction{conn};
@@ -1204,12 +1149,14 @@ write_rocpd(
                     if(agent) cereal::save(ar, *agent);
                 });
 
-                auto _name        = sanitize_sql_string(aitr.name);
-                auto _description = sanitize_sql_string(aitr.description);
-                auto _block       = sanitize_sql_string(aitr.block);
-                auto _expression  = sanitize_sql_string(aitr.expression);
+                auto _name        = aitr.name;
+                auto _description = aitr.description;
+                auto _block       = aitr.block;
+                auto _expression  = aitr.expression;
 
-                auto stmt = get_insert_statement(
+                get_insert_statement(
+                    conn,
+                    statement_cache,
                     "rocpd_info_pmc{{uuid}}",
                     {
                         insert_value("id", aitr.id.handle),
@@ -1228,8 +1175,6 @@ write_rocpd(
                         insert_value("is_derived", aitr.is_derived),
                         insert_value("extdata", json_data),
                     });
-
-                execute_raw_sql_statements(conn, stmt);
             }
         }
     };
@@ -1258,6 +1203,7 @@ write_rocpd(
                                  : "unknown_kernel";
 
             auto evt_id = create_event(conn,
+                                       statement_cache,
                                        {
                                            insert_value("category_id", string_entries.at(kind)),
                                            insert_value("stack_id", corr_id.internal),
@@ -1294,7 +1240,9 @@ write_rocpd(
             auto agent_node_id = tool_metadata.get_agent(info.agent_id)->node_id;
 
             // Insert into kernel dispatch table
-            auto stmt = get_insert_statement(
+            get_insert_statement(
+                conn,
+                statement_cache,
                 "rocpd_kernel_dispatch{{uuid}}",
                 {
                     insert_value("id", dispatch_id),
@@ -1319,8 +1267,6 @@ write_rocpd(
                     insert_value("region_name_id", string_entries.at(region_name)),
                     insert_value("event_id", evt_id),
                 });
-
-            execute_raw_sql_statements(conn, stmt);
         };
 
         if(kernel_dispatch_gen.empty())
@@ -1388,37 +1334,38 @@ write_rocpd(
         }
     };
 
-    auto insert_pmc_event_data = [&conn, &tool_metadata, &counter_collection_gen](
-                                     auto& dispatch_evt_ids) {
-        auto   _sqlgenperf_rocpd = get_simple_timer("rocpd_pmc_event");
-        size_t idx               = tool_metadata.pmc_event_offset;
-        for(auto ditr : counter_collection_gen)
-        {
-            auto _deferred = sql::deferred_transaction{conn};
-            for(const auto& record : counter_collection_gen.get(ditr))
+    auto insert_pmc_event_data =
+        [&conn, &statement_cache, &tool_metadata, &counter_collection_gen](auto& dispatch_evt_ids) {
+            auto   _sqlgenperf_rocpd = get_simple_timer("rocpd_pmc_event");
+            size_t idx               = tool_metadata.pmc_event_offset;
+            for(auto ditr : counter_collection_gen)
             {
-                const auto& info        = record.dispatch_data.dispatch_info;
-                auto        dispatch_id = info.dispatch_id;
-
-                auto evt_id = dispatch_evt_ids.at(dispatch_id);
-                for(const auto& count : record.read())
+                auto _deferred = sql::deferred_transaction{conn};
+                for(const auto& record : counter_collection_gen.get(ditr))
                 {
-                    auto stmt = get_insert_statement("rocpd_pmc_event{{uuid}}",
-                                                     {
-                                                         insert_value("id", idx++),
-                                                         insert_value("event_id", evt_id),
-                                                         insert_value("pmc_id", count.id.handle),
-                                                         insert_value("value", count.value),
-                                                     });
+                    const auto& info        = record.dispatch_data.dispatch_info;
+                    auto        dispatch_id = info.dispatch_id;
 
-                    execute_raw_sql_statements(conn, stmt);
+                    auto evt_id = dispatch_evt_ids.at(dispatch_id);
+                    for(const auto& count : record.read())
+                    {
+                        get_insert_statement(conn,
+                                             statement_cache,
+                                             "rocpd_pmc_event{{uuid}}",
+                                             {
+                                                 insert_value("id", idx++),
+                                                 insert_value("event_id", evt_id),
+                                                 insert_value("pmc_id", count.id.handle),
+                                                 insert_value("value", count.value),
+                                             });
+                    }
                 }
             }
-        }
-    };
+        };
 
     auto insert_memory_copy_data =
-        [&conn, &tool_metadata, &string_entries, node_id, this_pid](const auto& _gen) {
+        [&conn, &statement_cache, &tool_metadata, &string_entries, node_id, this_pid](
+            const auto& _gen) {
             auto   _sqlgenperf_rocpd = get_simple_timer("rocpd_memory_copy");
             size_t copy_idx          = 1;
 
@@ -1435,6 +1382,7 @@ write_rocpd(
 
                     auto evt_id = create_event(
                         conn,
+                        statement_cache,
                         {
                             insert_value("category_id", string_entries.at(kind)),
                             insert_value("stack_id", itr.correlation_id.internal),
@@ -1442,7 +1390,9 @@ write_rocpd(
                             insert_value("correlation_id", itr.correlation_id.external.value),
                         });
 
-                    auto stmt = get_insert_statement(
+                    get_insert_statement(
+                        conn,
+                        statement_cache,
                         "rocpd_memory_copy{{uuid}}",
                         {
                             insert_value("id", copy_idx++),
@@ -1462,14 +1412,13 @@ write_rocpd(
                             insert_value("stream_id", get_stream_id(itr.stream_id)),
                             insert_value("event_id", evt_id),
                         });
-
-                    execute_raw_sql_statements(conn, stmt);
                 }
             }
         };
 
     auto insert_memory_alloc_data =
-        [&conn, &tool_metadata, &string_entries, node_id, this_pid](const auto& _gen) {
+        [&conn, &statement_cache, &tool_metadata, &string_entries, node_id, this_pid](
+            const auto& _gen) {
             auto address_to_agent_and_size =
                 std::unordered_map<rocprofiler_address_t, rocprofiler::agent::index_and_size>{};
 
@@ -1543,6 +1492,7 @@ write_rocpd(
 
                     auto evt_id = create_event(
                         conn,
+                        statement_cache,
                         {
                             insert_value("category_id", string_entries.at(_kind)),
                             insert_value("stack_id", itr.correlation_id.internal),
@@ -1552,7 +1502,9 @@ write_rocpd(
 
                     auto flags = extract_flags_field(itr);
 
-                    auto stmt = get_insert_statement(
+                    get_insert_statement(
+                        conn,
+                        statement_cache,
                         "rocpd_memory_allocate{{uuid}}",
                         {
                             insert_value("nid", node_id),
@@ -1573,84 +1525,85 @@ write_rocpd(
                                              ar(cereal::make_nvp("flags", flags));
                                          })),
                         });
-
-                    execute_raw_sql_statements(conn, stmt);
                 }
             }
         };
 
     // new string entries argument types and names can be added to _metadata
-    auto insert_api_data = [&conn, &tool_metadata, &string_entries, node_id, this_pid](
-                               const auto& _gen) {
-        for(auto pitr : _gen)
-        {
-            auto _deferred = sql::deferred_transaction{conn};
-
-            for(auto itr : _gen.get(pitr))
+    auto insert_api_data =
+        [&conn, &statement_cache, &tool_metadata, &string_entries, node_id, this_pid](
+            const auto& _gen) {
+            for(auto pitr : _gen)
             {
-                auto category = tool_metadata.buffer_names.at(itr.kind);
-                auto name     = tool_metadata.buffer_names.at(itr.kind, itr.operation);
+                auto _deferred = sql::deferred_transaction{conn};
 
-                auto msg = std::string{"{}"};
-                if(itr.kind == ROCPROFILER_BUFFER_TRACING_MARKER_CORE_RANGE_API)
+                for(auto itr : _gen.get(pitr))
                 {
-                    if(static_cast<rocprofiler_tracing_operation_t>(itr.operation) !=
-                       ROCPROFILER_MARKER_CORE_RANGE_API_ID_roctxGetThreadId)
+                    auto category = tool_metadata.buffer_names.at(itr.kind);
+                    auto name     = tool_metadata.buffer_names.at(itr.kind, itr.operation);
+
+                    auto msg = std::string{"{}"};
+                    if(itr.kind == ROCPROFILER_BUFFER_TRACING_MARKER_CORE_RANGE_API)
                     {
-                        // check generatePerfetto.cpp and generateOTF2.cpp, and the marker name in
-                        // the view
-                        auto message =
-                            tool_metadata.get_marker_message(itr.correlation_id.internal);
-                        if(!message.empty())
+                        if(static_cast<rocprofiler_tracing_operation_t>(itr.operation) !=
+                           ROCPROFILER_MARKER_CORE_RANGE_API_ID_roctxGetThreadId)
+                        {
+                            // check generatePerfetto.cpp and generateOTF2.cpp, and the marker name
+                            // in the view
+                            auto message =
+                                tool_metadata.get_marker_message(itr.correlation_id.internal);
+                            if(!message.empty())
+                            {
+                                msg = get_json_string(
+                                    [](auto& ar, std::string_view _msg) {
+                                        ar(cereal::make_nvp("message", std::string{_msg}));
+                                    },
+                                    message);
+                            }
+                        }
+                        else
                         {
                             msg = get_json_string(
                                 [](auto& ar, std::string_view _msg) {
                                     ar(cereal::make_nvp("message", std::string{_msg}));
                                 },
-                                message);
+                                name);
                         }
                     }
-                    else
+
+                    auto args = function_args_t{};
                     {
-                        msg = get_json_string(
-                            [](auto& ar, std::string_view _msg) {
-                                ar(cereal::make_nvp("message", std::string{_msg}));
-                            },
-                            name);
+                        auto _record = rocprofiler_record_header_t{
+                            .hash = rocprofiler_record_header_compute_hash(
+                                ROCPROFILER_BUFFER_CATEGORY_TRACING, itr.kind),
+                            .payload = &itr};
+
+                        rocprofiler_iterate_buffer_tracing_record_args(
+                            _record, iterate_args_callback, &args);
                     }
-                }
 
-                auto args = function_args_t{};
-                {
-                    auto _record = rocprofiler_record_header_t{
-                        .hash = rocprofiler_record_header_compute_hash(
-                            ROCPROFILER_BUFFER_CATEGORY_TRACING, itr.kind),
-                        .payload = &itr};
+                    // insert thread info if it doesn't already exist
+                    get_thread_id(itr.thread_id);
 
-                    rocprofiler_iterate_buffer_tracing_record_args(
-                        _record, iterate_args_callback, &args);
-                }
+                    auto evt_id = create_event(
+                        conn,
+                        statement_cache,
+                        {
+                            insert_value("category_id", string_entries.at(category)),
+                            insert_value("stack_id", itr.correlation_id.internal),
+                            insert_value("parent_stack_id", itr.correlation_id.ancestor),
+                            insert_value("correlation_id", itr.correlation_id.external.value),
+                            insert_value("extdata", msg),
+                        });
 
-                // insert thread info if it doesn't already exist
-                get_thread_id(itr.thread_id);
-
-                auto evt_id = create_event(
-                    conn,
+                    // insert arguments into rocpd_arg table
+                    for(const auto& arg_info : args)
                     {
-                        insert_value("category_id", string_entries.at(category)),
-                        insert_value("stack_id", itr.correlation_id.internal),
-                        insert_value("parent_stack_id", itr.correlation_id.ancestor),
-                        insert_value("correlation_id", itr.correlation_id.external.value),
-                        insert_value("extdata", msg),
-                    });
+                        auto demangled_type = common::cxx_demangle(arg_info.arg_type);
 
-                // insert arguments into rocpd_arg table
-                for(const auto& arg_info : args)
-                {
-                    auto demangled_type = common::cxx_demangle(arg_info.arg_type);
-
-                    auto args_stmt =
-                        get_insert_statement("rocpd_arg{{uuid}}",
+                        get_insert_statement(conn,
+                                             statement_cache,
+                                             "rocpd_arg{{uuid}}",
                                              {
                                                  insert_value("event_id", evt_id),
                                                  insert_value("position", arg_info.arg_number),
@@ -1658,14 +1611,13 @@ write_rocpd(
                                                  insert_value("name", arg_info.arg_name),
                                                  insert_value("value", arg_info.arg_value),
                                              });
+                    }
 
-                    execute_raw_sql_statements(conn, args_stmt);
-                }
-
-                if(itr.start_timestamp != itr.end_timestamp)
-                {
-                    auto region_stmt =
-                        get_insert_statement("rocpd_region{{uuid}}",
+                    if(itr.start_timestamp != itr.end_timestamp)
+                    {
+                        get_insert_statement(conn,
+                                             statement_cache,
+                                             "rocpd_region{{uuid}}",
                                              {
                                                  insert_value("id", itr.correlation_id.internal),
                                                  insert_value("nid", node_id),
@@ -1676,27 +1628,29 @@ write_rocpd(
                                                  insert_value("name_id", string_entries.at(name)),
                                                  insert_value("event_id", evt_id),
                                              });
-
-                    execute_raw_sql_statements(conn, region_stmt);
-                }
-                else
-                {
-                    auto track_id = get_track_id(
-                        conn, node_id, this_pid, itr.thread_id, string_entries.at(category), "{}");
-                    auto sample_stmt =
-                        get_insert_statement("rocpd_sample{{uuid}}",
+                    }
+                    else
+                    {
+                        auto track_id = get_track_id(conn,
+                                                     statement_cache,
+                                                     node_id,
+                                                     this_pid,
+                                                     itr.thread_id,
+                                                     string_entries.at(category),
+                                                     "{}");
+                        get_insert_statement(conn,
+                                             statement_cache,
+                                             "rocpd_sample{{uuid}}",
                                              {
                                                  insert_value("id", itr.correlation_id.internal),
                                                  insert_value("track_id", track_id),
                                                  insert_value("timestamp", itr.start_timestamp),
                                                  insert_value("event_id", evt_id),
                                              });
-
-                    execute_raw_sql_statements(conn, sample_stmt);
+                    }
                 }
             }
-        }
-    };
+        };
 
     auto insert_kfd_data = [&conn, &tool_metadata, node_id, this_pid](auto& pmc_ids) {
         auto _sqlgenperf_rocpd = get_simple_timer("rocpd_info_pmc: kfd");
@@ -1855,8 +1809,7 @@ write_rocpd(
         execute_raw_sql_statements(conn, indexes_schema);
     }
 
-    finalize_prepared_statements();
-    set_active_sqlite_connection(nullptr);
+    finalize_prepared_statements(statement_cache);
     SQLITE3_CHECK(sqlite3_close_v2(conn));
 
     // Clear UUID/GUID state at end of write to prepare for potential re-attach

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -454,6 +454,60 @@ get_insert_statement_impl(rocpd_db&                                 _db,
 }
 
 template <template <typename...> class ContainerT, typename... TypesT>
+uint64_t
+get_insert_row_id_impl(rocpd_db&                                 _db,
+                       std::string_view                          _table,
+                       ContainerT<sql_insert_value, TypesT...>&& _data)
+{
+    auto fields = std::vector<std::string_view>{};
+    auto values = std::vector<sql_insert_value>{};
+
+    fields.reserve(_data.size() + 1);
+    values.reserve(_data.size() + 1);
+    for(auto&& itr : _data)
+    {
+        if(itr.name.empty()) continue;
+
+        fields.emplace_back(itr.name);
+        values.emplace_back(itr);
+    }
+
+    if(fields.empty()) return 0;
+
+    ROCP_FATAL_IF(_db.conn == nullptr) << "SQLite connection not set for prepared statements";
+
+    auto   key  = fmt::format("{}", fmt::join(fields, ","));
+    auto*& stmt = _db.statements[_table][key];
+
+    if(!stmt)
+    {
+        auto placeholders = std::vector<std::string_view>(fields.size(), "?");
+        auto sql          = fmt::format("INSERT INTO {} ({}) VALUES ({});",
+                               replace_uuid(_db, _table),
+                               fmt::join(fields, ", "),
+                               fmt::join(placeholders, ", "));
+
+        ROCP_INFO << fmt::format("Preparing SQL statement: '{}'", sql);
+        SQLITE3_CHECK(sqlite3_prepare_v2(_db.conn, sql.c_str(), -1, &stmt, nullptr));
+    }
+
+    for(size_t i = 0; i < fields.size(); ++i)
+    {
+        auto idx = static_cast<int>(i + 1);
+        ROCP_TRACE << fmt::format(
+            "Binding SQL value {} of {} (name={})", idx, fields.size(), fields.at(i));
+        SQLITE3_CHECK(bind_sql_value(stmt, idx, values.at(i)));
+    }
+
+    SQLITE3_CHECK2(sqlite3_step(stmt), {SQLITE_OK, SQLITE_DONE, SQLITE_ROW});
+    auto row_id = static_cast<uint64_t>(sqlite3_last_insert_rowid(_db.conn));
+    SQLITE3_CHECK(sqlite3_reset(stmt));
+    SQLITE3_CHECK(sqlite3_clear_bindings(stmt));
+
+    return row_id;
+}
+
+template <template <typename...> class ContainerT, typename... TypesT>
 void
 get_insert_statement(rocpd_db&                                 _db,
                      std::string_view                          _table,
@@ -469,6 +523,25 @@ get_insert_statement(rocpd_db&                                 _db,
                      std::initializer_list<sql_insert_value>&& _data)
 {
     get_insert_statement_impl(
+        _db, _table, std::forward<std::initializer_list<sql_insert_value>>(_data));
+}
+
+template <template <typename...> class ContainerT, typename... TypesT>
+uint64_t
+get_insert_row_id(rocpd_db&                                 _db,
+                  std::string_view                          _table,
+                  ContainerT<sql_insert_value, TypesT...>&& _data)
+{
+    return get_insert_row_id_impl(
+        _db, _table, std::forward<ContainerT<sql_insert_value, TypesT...>>(_data));
+}
+
+uint64_t
+get_insert_row_id(rocpd_db&                                 _db,
+                  std::string_view                          _table,
+                  std::initializer_list<sql_insert_value>&& _data)
+{
+    return get_insert_row_id_impl(
         _db, _table, std::forward<std::initializer_list<sql_insert_value>>(_data));
 }
 
@@ -1592,7 +1665,7 @@ write_rocpd(
         }
     };
 
-    auto insert_kfd_data = [&conn, &tool_metadata, node_id, this_pid](auto& pmc_ids) {
+    auto insert_kfd_data = [&db, &tool_metadata, node_id, this_pid](auto& pmc_ids) {
         auto _sqlgenperf_rocpd = get_simple_timer("rocpd_info_pmc: kfd");
 
         struct kfd_pmc_info_t
@@ -1621,33 +1694,33 @@ write_rocpd(
 
         for(const auto& info : kfd_info)
         {
-            auto name = tool_metadata.buffer_names.at(info.kind);
-            auto stmt =
-                get_insert_statement("rocpd_info_pmc{{uuid}}",
-                                     {
-                                         insert_value("nid", node_id),
-                                         insert_value("pid", this_pid),
-                                         insert_value("name", name),
-                                         insert_value("symbol", name),
-                                         insert_value("description", info.description),
-                                         insert_value("component", std::string_view{"rocm"}),
-                                         insert_value("value_type", std::string_view{"ABS"}),
-                                         insert_value("block", std::string_view{"KFD"}),
-                                         insert_value("is_constant", false),
-                                         insert_value("is_derived", false),
-                                     });
+            auto name   = tool_metadata.buffer_names.at(info.kind);
+            auto row_id = get_insert_row_id(db,
+                                            "rocpd_info_pmc{{uuid}}",
+                                            {
+                                                insert_value("nid", node_id),
+                                                insert_value("pid", this_pid),
+                                                insert_value("name", name),
+                                                insert_value("symbol", name),
+                                                insert_value("description", info.description),
+                                                insert_value("component", std::string_view{"rocm"}),
+                                                insert_value("value_type", std::string_view{"ABS"}),
+                                                insert_value("block", std::string_view{"KFD"}),
+                                                insert_value("is_constant", false),
+                                                insert_value("is_derived", false),
+                                            });
 
-            auto row_id = execute_raw_sql_statements(conn, stmt);
+            ROCP_FATAL_IF(row_id == 0) << "Failed to get row ID for KFD PMC insert";
             pmc_ids.emplace(info.kind, row_id);
         }
     };
 
-    auto insert_kfd_event_data = [&conn, &tool_metadata, &string_entries, node_id, this_pid](
+    auto insert_kfd_event_data = [&db, &tool_metadata, &string_entries, node_id, this_pid](
                                      const auto& _gen, const auto& _pmc_ids) {
         auto _sqlgenperf_rocpd = get_simple_timer("rocpd_pmc_event: kfd");
         for(auto pitr : _gen)
         {
-            auto _deferred = sql::deferred_transaction{conn};
+            auto _deferred = sql::deferred_transaction{db.conn};
             for(const auto& itr : _gen.get(pitr))
             {
                 auto data = std::visit(
@@ -1670,7 +1743,7 @@ write_rocpd(
                 // get KFD category and create event entry
                 auto category = tool_metadata.buffer_names.at(data.kind);
                 auto evt_id =
-                    create_event(conn,
+                    create_event(db,
                                  {
                                      insert_value("category_id", string_entries.at(category)),
                                      insert_value("stack_id", 0),
@@ -1680,28 +1753,25 @@ write_rocpd(
                                  });
 
                 // track timestamps with a region
-                auto region_stmt =
-                    get_insert_statement("rocpd_region{{uuid}}",
-                                         {
-                                             insert_value("nid", node_id),
-                                             insert_value("pid", this_pid),
-                                             insert_value("tid", data.tid),
-                                             insert_value("start", data.start),
-                                             insert_value("end", data.end),
-                                             insert_value("name_id", string_entries.at(data.name)),
-                                             insert_value("event_id", evt_id),
-                                         });
+                get_insert_statement(db,
+                                     "rocpd_region{{uuid}}",
+                                     {
+                                         insert_value("nid", node_id),
+                                         insert_value("pid", this_pid),
+                                         insert_value("tid", data.tid),
+                                         insert_value("start", data.start),
+                                         insert_value("end", data.end),
+                                         insert_value("name_id", string_entries.at(data.name)),
+                                         insert_value("event_id", evt_id),
+                                     });
 
-                execute_raw_sql_statements(conn, region_stmt);
-
-                auto stmt = get_insert_statement("rocpd_pmc_event{{uuid}}",
-                                                 {
-                                                     insert_value("event_id", evt_id),
-                                                     insert_value("pmc_id", _pmc_ids.at(data.kind)),
-                                                     insert_value("value", data.value),
-                                                 });
-
-                execute_raw_sql_statements(conn, stmt);
+                get_insert_statement(db,
+                                     "rocpd_pmc_event{{uuid}}",
+                                     {
+                                         insert_value("event_id", evt_id),
+                                         insert_value("pmc_id", _pmc_ids.at(data.kind)),
+                                         insert_value("value", data.value),
+                                     });
             }
         }
     };

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -339,7 +339,9 @@ insert_value(std::string_view _name, const Tp& _value, TraitT = {})
             return sql_insert_value{_name, _uval};
         }
         else
+        {
             return sql_insert_value{_name, static_cast<int64_t>(_value)};
+        }
     }
     else if constexpr(std::is_floating_point_v<value_type>)
     {
@@ -403,61 +405,10 @@ bind_sql_value(sqlite3_stmt* stmt, int idx, const sql_insert_value& value)
 }
 
 template <template <typename...> class ContainerT, typename... TypesT>
-void
-get_insert_statement_impl(rocpd_db&                                 _db,
-                          std::string_view                          _table,
-                          ContainerT<sql_insert_value, TypesT...>&& _data)
-{
-    auto fields = std::vector<std::string_view>{};
-    auto values = std::vector<sql_insert_value>{};
-
-    fields.reserve(_data.size() + 1);
-    values.reserve(_data.size() + 1);
-    for(auto&& itr : _data)
-    {
-        if(itr.name.empty()) continue;
-
-        fields.emplace_back(itr.name);
-        values.emplace_back(itr);
-    }
-
-    if(fields.empty()) return;
-
-    ROCP_FATAL_IF(_db.conn == nullptr) << "SQLite connection not set for prepared statements";
-
-    auto   key  = fmt::format("{}", fmt::join(fields, ","));
-    auto*& stmt = _db.statements[_table][key];
-
-    if(!stmt)
-    {
-        auto placeholders = std::vector<std::string_view>(fields.size(), "?");
-        auto sql          = fmt::format("INSERT INTO {} ({}) VALUES ({});",
-                               replace_uuid(_db, _table),
-                               fmt::join(fields, ", "),
-                               fmt::join(placeholders, ", "));
-
-        ROCP_INFO << fmt::format("Preparing SQL statement: '{}'", sql);
-        SQLITE3_CHECK(sqlite3_prepare_v2(_db.conn, sql.c_str(), -1, &stmt, nullptr));
-    }
-
-    for(size_t i = 0; i < fields.size(); ++i)
-    {
-        auto idx = static_cast<int>(i + 1);
-        ROCP_TRACE << fmt::format(
-            "Binding SQL value {} of {} (name={})", idx, fields.size(), fields.at(i));
-        SQLITE3_CHECK(bind_sql_value(stmt, idx, values.at(i)));
-    }
-
-    SQLITE3_CHECK2(sqlite3_step(stmt), {SQLITE_OK, SQLITE_DONE, SQLITE_ROW});
-    SQLITE3_CHECK(sqlite3_reset(stmt));
-    SQLITE3_CHECK(sqlite3_clear_bindings(stmt));
-}
-
-template <template <typename...> class ContainerT, typename... TypesT>
 uint64_t
-get_insert_row_id_impl(rocpd_db&                                 _db,
-                       std::string_view                          _table,
-                       ContainerT<sql_insert_value, TypesT...>&& _data)
+insert_row_impl(rocpd_db&                                 _db,
+                std::string_view                          _table,
+                ContainerT<sql_insert_value, TypesT...>&& _data)
 {
     auto fields = std::vector<std::string_view>{};
     auto values = std::vector<sql_insert_value>{};
@@ -508,40 +459,17 @@ get_insert_row_id_impl(rocpd_db&                                 _db,
 }
 
 template <template <typename...> class ContainerT, typename... TypesT>
-void
-get_insert_statement(rocpd_db&                                 _db,
-                     std::string_view                          _table,
-                     ContainerT<sql_insert_value, TypesT...>&& _data)
-{
-    get_insert_statement_impl(
-        _db, _table, std::forward<ContainerT<sql_insert_value, TypesT...>>(_data));
-}
-
-void
-get_insert_statement(rocpd_db&                                 _db,
-                     std::string_view                          _table,
-                     std::initializer_list<sql_insert_value>&& _data)
-{
-    get_insert_statement_impl(
-        _db, _table, std::forward<std::initializer_list<sql_insert_value>>(_data));
-}
-
-template <template <typename...> class ContainerT, typename... TypesT>
 uint64_t
-get_insert_row_id(rocpd_db&                                 _db,
-                  std::string_view                          _table,
-                  ContainerT<sql_insert_value, TypesT...>&& _data)
+insert_row(rocpd_db& _db, std::string_view _table, ContainerT<sql_insert_value, TypesT...>&& _data)
 {
-    return get_insert_row_id_impl(
+    return insert_row_impl(
         _db, _table, std::forward<ContainerT<sql_insert_value, TypesT...>>(_data));
 }
 
 uint64_t
-get_insert_row_id(rocpd_db&                                 _db,
-                  std::string_view                          _table,
-                  std::initializer_list<sql_insert_value>&& _data)
+insert_row(rocpd_db& _db, std::string_view _table, std::initializer_list<sql_insert_value>&& _data)
 {
-    return get_insert_row_id_impl(
+    return insert_row_impl(
         _db, _table, std::forward<std::initializer_list<sql_insert_value>>(_data));
 }
 
@@ -557,7 +485,7 @@ create_event_impl(rocpd_db& _db, std::initializer_list<sql_insert_value>&& _data
     for(auto&& itr : _data)
         _data_vec.emplace_back(itr);
 
-    get_insert_statement(_db, "rocpd_event{{uuid}}", std::move(_data_vec));
+    insert_row(_db, "rocpd_event{{uuid}}", std::move(_data_vec));
 
     return evt_id;
 }
@@ -578,16 +506,16 @@ get_track_id_impl(rocpd_db&        _db,
     {
         auto idx = _db.tracks.size() + 1;
         itr      = _db.tracks.emplace(_track, idx).first;
-        get_insert_statement(_db,
-                             "rocpd_track{{uuid}}",
-                             {
-                                 insert_value("id", idx),
-                                 insert_value("nid", node_id),
-                                 insert_value("pid", pid),
-                                 insert_value("tid", tid),
-                                 insert_value("name_id", name_id),
-                                 insert_value("extdata", extdata),
-                             });
+        insert_row(_db,
+                   "rocpd_track{{uuid}}",
+                   {
+                       insert_value("id", idx),
+                       insert_value("nid", node_id),
+                       insert_value("pid", pid),
+                       insert_value("tid", tid),
+                       insert_value("name_id", name_id),
+                       insert_value("extdata", extdata),
+                   });
         return idx;
     }
 
@@ -926,34 +854,33 @@ write_rocpd(
     auto stream_set = std::unordered_set<rocprofiler_stream_id_t>{};
     auto queue_set  = std::unordered_set<rocprofiler_queue_id_t>{};
 
-    static auto get_stream_id =
-        [&db, &stream_set, &node_id, &this_pid](rocprofiler_stream_id_t val) {
-            if(stream_set.count(val) == 0)
-            {
-                ROCP_FATAL_IF(val.handle == 0 && !stream_set.empty()) << "Missing default stream";
-                ROCP_FATAL_IF(val.handle != 0 && stream_set.empty()) << "Missing default stream";
+    auto get_stream_id = [&db, &stream_set, &node_id, &this_pid](rocprofiler_stream_id_t val) {
+        if(stream_set.count(val) == 0)
+        {
+            ROCP_FATAL_IF(val.handle == 0 && !stream_set.empty()) << "Missing default stream";
+            ROCP_FATAL_IF(val.handle != 0 && stream_set.empty()) << "Missing default stream";
 
-                auto _name = std::string{};
-                if(val.handle == 0)
-                    _name = std::string{"Default Stream"};
-                else
-                    _name = fmt::format("Stream {}", stream_set.size() - 1);
-                stream_set.emplace(val);
+            auto _name = std::string{};
+            if(val.handle == 0)
+                _name = std::string{"Default Stream"};
+            else
+                _name = fmt::format("Stream {}", stream_set.size() - 1);
+            stream_set.emplace(val);
 
-                get_insert_statement(db,
-                                     "rocpd_info_stream{{uuid}}",
-                                     {
-                                         insert_value("id", val.handle),
-                                         insert_value("nid", node_id),
-                                         insert_value("pid", this_pid),
-                                         insert_value("name", _name),
-                                     });
-            }
+            insert_row(db,
+                       "rocpd_info_stream{{uuid}}",
+                       {
+                           insert_value("id", val.handle),
+                           insert_value("nid", node_id),
+                           insert_value("pid", this_pid),
+                           insert_value("name", _name),
+                       });
+        }
 
-            return val.handle;
-        };
+        return val.handle;
+    };
 
-    static auto get_queue_id = [&db, &queue_set, &node_id, &this_pid](rocprofiler_queue_id_t val) {
+    auto get_queue_id = [&db, &queue_set, &node_id, &this_pid](rocprofiler_queue_id_t val) {
         if(queue_set.count(val) == 0)
         {
             ROCP_FATAL_IF(val.handle == 0 && !queue_set.empty()) << "Missing default queue";
@@ -966,34 +893,34 @@ write_rocpd(
                 _name = fmt::format("Queue {}", queue_set.size() - 1);
             queue_set.emplace(val);
 
-            get_insert_statement(db,
-                                 "rocpd_info_queue{{uuid}}",
-                                 {
-                                     insert_value("id", val.handle),
-                                     insert_value("nid", node_id),
-                                     insert_value("pid", this_pid),
-                                     insert_value("name", _name),
-                                 });
+            insert_row(db,
+                       "rocpd_info_queue{{uuid}}",
+                       {
+                           insert_value("id", val.handle),
+                           insert_value("nid", node_id),
+                           insert_value("pid", this_pid),
+                           insert_value("name", _name),
+                       });
         }
 
         return val.handle;
     };
 
-    static auto get_thread_id =
+    auto get_thread_id =
         [&db, &tool_metadata, &thread_ids, &node_id, &this_pid](rocprofiler_thread_id_t val) {
             if(thread_ids.count(val) == 0)
             {
                 thread_ids.emplace(val);
 
-                get_insert_statement(db,
-                                     "rocpd_info_thread{{uuid}}",
-                                     {
-                                         insert_value("id", val),
-                                         insert_value("nid", node_id),
-                                         insert_value("ppid", tool_metadata.parent_process_id),
-                                         insert_value("pid", this_pid),
-                                         insert_value("tid", val),
-                                     });
+                insert_row(db,
+                           "rocpd_info_thread{{uuid}}",
+                           {
+                               insert_value("id", val),
+                               insert_value("nid", node_id),
+                               insert_value("ppid", tool_metadata.parent_process_id),
+                               insert_value("pid", this_pid),
+                               insert_value("tid", val),
+                           });
             }
 
             return val;
@@ -1008,12 +935,12 @@ write_rocpd(
         auto _deferred = sql::deferred_transaction{conn};
         for(const auto& itr : string_entries)
         {
-            get_insert_statement(db,
-                                 "rocpd_string{{uuid}}",
-                                 {
-                                     insert_value("id", itr.second),
-                                     insert_value("string", itr.first, allow_empty_string{}),
-                                 });
+            insert_row(db,
+                       "rocpd_string{{uuid}}",
+                       {
+                           insert_value("id", itr.second),
+                           insert_value("string", itr.first, allow_empty_string{}),
+                       });
         }
     }
 
@@ -1021,20 +948,19 @@ write_rocpd(
         auto        _sqlgenperf_rocpd = get_simple_timer("rocpd_info_node");
         const auto& _info             = tool_metadata.node_data;
 
-        get_insert_statement(
-            db,
-            "rocpd_info_node{{uuid}}",
-            {
-                insert_value("id", node_id),
-                insert_value("hash", node_hash),
-                insert_value("machine_id", _info.machine_id),
-                insert_value("system_name", _info.system_name, allow_empty_string{}),
-                insert_value("hostname", _info.hostname, allow_empty_string{}),
-                insert_value("release", _info.release, allow_empty_string{}),
-                insert_value("version", _info.version, allow_empty_string{}),
-                insert_value("hardware_name", _info.hardware_name, allow_empty_string{}),
-                insert_value("domain_name", _info.domain_name, allow_empty_string{}),
-            });
+        insert_row(db,
+                   "rocpd_info_node{{uuid}}",
+                   {
+                       insert_value("id", node_id),
+                       insert_value("hash", node_hash),
+                       insert_value("machine_id", _info.machine_id),
+                       insert_value("system_name", _info.system_name, allow_empty_string{}),
+                       insert_value("hostname", _info.hostname, allow_empty_string{}),
+                       insert_value("release", _info.release, allow_empty_string{}),
+                       insert_value("version", _info.version, allow_empty_string{}),
+                       insert_value("hardware_name", _info.hardware_name, allow_empty_string{}),
+                       insert_value("domain_name", _info.domain_name, allow_empty_string{}),
+                   });
     };
 
     auto insert_process_data = [&db, &tool_metadata, &cfg, node_id, this_pid]() {
@@ -1068,21 +994,21 @@ write_rocpd(
             "{}",
             fmt::join(tool_metadata.command_line.begin(), tool_metadata.command_line.end(), " "));
 
-        get_insert_statement(db,
-                             "rocpd_info_process{{uuid}}",
-                             {
-                                 insert_value("id", this_pid),
-                                 insert_value("nid", node_id),
-                                 insert_value("ppid", tool_metadata.parent_process_id),
-                                 insert_value("pid", this_pid),
-                                 insert_value("init", tool_metadata.process_start_ns),
-                                 insert_value("fini", tool_metadata.process_end_ns),
-                                 insert_value("start", tool_metadata.process_start_ns),
-                                 insert_value("end", tool_metadata.process_end_ns),
-                                 insert_value("command", _command),
-                                 insert_value("environment", json_env),
-                                 insert_value("extdata", json_cfg),
-                             });
+        insert_row(db,
+                   "rocpd_info_process{{uuid}}",
+                   {
+                       insert_value("id", this_pid),
+                       insert_value("nid", node_id),
+                       insert_value("ppid", tool_metadata.parent_process_id),
+                       insert_value("pid", this_pid),
+                       insert_value("init", tool_metadata.process_start_ns),
+                       insert_value("fini", tool_metadata.process_end_ns),
+                       insert_value("start", tool_metadata.process_start_ns),
+                       insert_value("end", tool_metadata.process_end_ns),
+                       insert_value("command", _command),
+                       insert_value("environment", json_env),
+                       insert_value("extdata", json_cfg),
+                   });
     };
 
     auto insert_agent_data = [&db, &tool_metadata, node_id, this_pid]() {
@@ -1097,25 +1023,24 @@ write_rocpd(
             else if(itr.type == ROCPROFILER_AGENT_TYPE_GPU)
                 type = "GPU";
 
-            get_insert_statement(
-                db,
-                "rocpd_info_agent{{uuid}}",
-                {
-                    insert_value("id", itr.node_id),
-                    insert_value("nid", node_id),
-                    insert_value("pid", this_pid),
-                    insert_value("type", type),
-                    insert_value("absolute_index", itr.node_id),
-                    insert_value("logical_index", itr.logical_node_id),
-                    insert_value("type_index", itr.logical_node_type_id),
-                    insert_value("uuid", itr.device_id),
-                    insert_value("name", itr.name),
-                    insert_value("model_name", itr.model_name, allow_empty_string{}),
-                    insert_value("vendor_name", itr.vendor_name, allow_empty_string{}),
-                    insert_value("product_name", itr.product_name, allow_empty_string{}),
-                    insert_value("user_name", itr.product_name, allow_empty_string{}),
-                    insert_value("extdata", json_info),
-                });
+            insert_row(db,
+                       "rocpd_info_agent{{uuid}}",
+                       {
+                           insert_value("id", itr.node_id),
+                           insert_value("nid", node_id),
+                           insert_value("pid", this_pid),
+                           insert_value("type", type),
+                           insert_value("absolute_index", itr.node_id),
+                           insert_value("logical_index", itr.logical_node_id),
+                           insert_value("type_index", itr.logical_node_type_id),
+                           insert_value("uuid", itr.device_id),
+                           insert_value("name", itr.name),
+                           insert_value("model_name", itr.model_name, allow_empty_string{}),
+                           insert_value("vendor_name", itr.vendor_name, allow_empty_string{}),
+                           insert_value("product_name", itr.product_name, allow_empty_string{}),
+                           insert_value("user_name", itr.product_name, allow_empty_string{}),
+                           insert_value("extdata", json_info),
+                       });
         }
     };
 
@@ -1130,19 +1055,19 @@ write_rocpd(
             auto        json_data =
                 get_json_string([](auto& ar, const auto oitr) { cereal::save(ar, oitr); }, itr);
 
-            get_insert_statement(db,
-                                 "rocpd_info_code_object{{uuid}}",
-                                 {
-                                     insert_value("id", itr.code_object_id),
-                                     insert_value("nid", node_id),
-                                     insert_value("pid", this_pid),
-                                     insert_value("agent_id", CHECK_NOTNULL(_agent)->node_id),
-                                     insert_value("uri", itr.uri),
-                                     insert_value("load_base", itr.load_base),
-                                     insert_value("load_size", itr.load_size),
-                                     insert_value("load_delta", itr.load_delta),
-                                     insert_value("extdata", json_data),
-                                 });
+            insert_row(db,
+                       "rocpd_info_code_object{{uuid}}",
+                       {
+                           insert_value("id", itr.code_object_id),
+                           insert_value("nid", node_id),
+                           insert_value("pid", this_pid),
+                           insert_value("agent_id", CHECK_NOTNULL(_agent)->node_id),
+                           insert_value("uri", itr.uri),
+                           insert_value("load_base", itr.load_base),
+                           insert_value("load_size", itr.load_size),
+                           insert_value("load_delta", itr.load_delta),
+                           insert_value("extdata", json_data),
+                       });
         }
 
         for(const auto& itr : tool_metadata.get_kernel_symbols())
@@ -1152,7 +1077,7 @@ write_rocpd(
             auto json_data =
                 get_json_string([](auto& ar, const auto& oitr) { cereal::save(ar, oitr); }, itr);
 
-            get_insert_statement(
+            insert_row(
                 db,
                 "rocpd_info_kernel_symbol{{uuid}}",
                 {
@@ -1195,26 +1120,25 @@ write_rocpd(
                 const auto* _block       = aitr.block;
                 const auto* _expression  = aitr.expression;
 
-                get_insert_statement(
-                    db,
-                    "rocpd_info_pmc{{uuid}}",
-                    {
-                        insert_value("id", aitr.id.handle),
-                        insert_value("nid", node_id),
-                        insert_value("pid", this_pid),
-                        insert_value("target_arch", std::string_view{"GPU"}),
-                        insert_value("agent_id", agent->node_id),
-                        insert_value("name", _name, allow_empty_string{}),
-                        insert_value("symbol", _name, allow_empty_string{}),
-                        insert_value("description", _description, allow_empty_string{}),
-                        insert_value("component", std::string_view{"rocm"}),
-                        insert_value("value_type", std::string_view{"ABS"}),
-                        insert_value("block", _block, allow_empty_string{}),
-                        insert_value("expression", _expression, allow_empty_string{}),
-                        insert_value("is_constant", aitr.is_constant),
-                        insert_value("is_derived", aitr.is_derived),
-                        insert_value("extdata", json_data),
-                    });
+                insert_row(db,
+                           "rocpd_info_pmc{{uuid}}",
+                           {
+                               insert_value("id", aitr.id.handle),
+                               insert_value("nid", node_id),
+                               insert_value("pid", this_pid),
+                               insert_value("target_arch", std::string_view{"GPU"}),
+                               insert_value("agent_id", agent->node_id),
+                               insert_value("name", _name, allow_empty_string{}),
+                               insert_value("symbol", _name, allow_empty_string{}),
+                               insert_value("description", _description, allow_empty_string{}),
+                               insert_value("component", std::string_view{"rocm"}),
+                               insert_value("value_type", std::string_view{"ABS"}),
+                               insert_value("block", _block, allow_empty_string{}),
+                               insert_value("expression", _expression, allow_empty_string{}),
+                               insert_value("is_constant", aitr.is_constant),
+                               insert_value("is_derived", aitr.is_derived),
+                               insert_value("extdata", json_data),
+                           });
             }
         }
     };
@@ -1280,32 +1204,31 @@ write_rocpd(
             auto agent_node_id = tool_metadata.get_agent(info.agent_id)->node_id;
 
             // Insert into kernel dispatch table
-            get_insert_statement(
-                db,
-                "rocpd_kernel_dispatch{{uuid}}",
-                {
-                    insert_value("id", dispatch_id),
-                    insert_value("nid", node_id),
-                    insert_value("pid", this_pid),
-                    insert_value("tid", thread_id),
-                    insert_value("agent_id", agent_node_id),
-                    insert_value("kernel_id", kernel_id),
-                    insert_value("dispatch_id", dispatch_id),
-                    insert_value("queue_id", queue_id),
-                    insert_value("stream_id", stream_id),
-                    insert_value("start", start_timestamp),
-                    insert_value("end", end_timestamp),
-                    insert_value("private_segment_size", info.private_segment_size),
-                    insert_value("group_segment_size", info.group_segment_size),
-                    insert_value("workgroup_size_x", workgroup.x),
-                    insert_value("workgroup_size_y", workgroup.y),
-                    insert_value("workgroup_size_z", workgroup.z),
-                    insert_value("grid_size_x", grid.x),
-                    insert_value("grid_size_y", grid.y),
-                    insert_value("grid_size_z", grid.z),
-                    insert_value("region_name_id", string_entries.at(region_name)),
-                    insert_value("event_id", evt_id),
-                });
+            insert_row(db,
+                       "rocpd_kernel_dispatch{{uuid}}",
+                       {
+                           insert_value("id", dispatch_id),
+                           insert_value("nid", node_id),
+                           insert_value("pid", this_pid),
+                           insert_value("tid", thread_id),
+                           insert_value("agent_id", agent_node_id),
+                           insert_value("kernel_id", kernel_id),
+                           insert_value("dispatch_id", dispatch_id),
+                           insert_value("queue_id", queue_id),
+                           insert_value("stream_id", stream_id),
+                           insert_value("start", start_timestamp),
+                           insert_value("end", end_timestamp),
+                           insert_value("private_segment_size", info.private_segment_size),
+                           insert_value("group_segment_size", info.group_segment_size),
+                           insert_value("workgroup_size_x", workgroup.x),
+                           insert_value("workgroup_size_y", workgroup.y),
+                           insert_value("workgroup_size_z", workgroup.z),
+                           insert_value("grid_size_x", grid.x),
+                           insert_value("grid_size_y", grid.y),
+                           insert_value("grid_size_z", grid.z),
+                           insert_value("region_name_id", string_entries.at(region_name)),
+                           insert_value("event_id", evt_id),
+                       });
         };
 
         if(kernel_dispatch_gen.empty())
@@ -1386,21 +1309,22 @@ write_rocpd(
                     auto evt_id = dispatch_evt_ids.at(dispatch_id);
                     for(const auto& count : record.read())
                     {
-                        get_insert_statement(db,
-                                             "rocpd_pmc_event{{uuid}}",
-                                             {
-                                                 insert_value("id", idx++),
-                                                 insert_value("event_id", evt_id),
-                                                 insert_value("pmc_id", count.id.handle),
-                                                 insert_value("value", count.value),
-                                             });
+                        insert_row(db,
+                                   "rocpd_pmc_event{{uuid}}",
+                                   {
+                                       insert_value("id", idx++),
+                                       insert_value("event_id", evt_id),
+                                       insert_value("pmc_id", count.id.handle),
+                                       insert_value("value", count.value),
+                                   });
                     }
                 }
             }
         };
 
     auto insert_memory_copy_data =
-        [&db, &tool_metadata, &string_entries, node_id, this_pid](const auto& _gen) {
+        [&db, &tool_metadata, &string_entries, node_id, this_pid, &get_thread_id, &get_stream_id](
+            const auto& _gen) {
             auto   _sqlgenperf_rocpd = get_simple_timer("rocpd_memory_copy");
             auto   _deferred         = sql::deferred_transaction{db.conn};
             size_t copy_idx          = 1;
@@ -1424,136 +1348,145 @@ write_rocpd(
                             insert_value("correlation_id", itr.correlation_id.external.value),
                         });
 
-                    get_insert_statement(
-                        db,
-                        "rocpd_memory_copy{{uuid}}",
-                        {
-                            insert_value("id", copy_idx++),
-                            insert_value("nid", node_id),
-                            insert_value("pid", this_pid),
-                            insert_value("tid", itr.thread_id),
-                            insert_value("start", itr.start_timestamp),
-                            insert_value("end", itr.end_timestamp),
-                            insert_value("name_id", string_entries.at(name)),
-                            insert_value("dst_agent_id",
-                                         tool_metadata.get_agent(itr.dst_agent_id)->node_id),
-                            insert_value("src_agent_id",
-                                         tool_metadata.get_agent(itr.src_agent_id)->node_id),
-                            insert_value("dst_address", itr.dst_address.value),
-                            insert_value("src_address", itr.src_address.value),
-                            insert_value("size", itr.bytes),
-                            insert_value("stream_id", get_stream_id(itr.stream_id)),
-                            insert_value("event_id", evt_id),
-                        });
+                    insert_row(db,
+                               "rocpd_memory_copy{{uuid}}",
+                               {
+                                   insert_value("id", copy_idx++),
+                                   insert_value("nid", node_id),
+                                   insert_value("pid", this_pid),
+                                   insert_value("tid", itr.thread_id),
+                                   insert_value("start", itr.start_timestamp),
+                                   insert_value("end", itr.end_timestamp),
+                                   insert_value("name_id", string_entries.at(name)),
+                                   insert_value("dst_agent_id",
+                                                tool_metadata.get_agent(itr.dst_agent_id)->node_id),
+                                   insert_value("src_agent_id",
+                                                tool_metadata.get_agent(itr.src_agent_id)->node_id),
+                                   insert_value("dst_address", itr.dst_address.value),
+                                   insert_value("src_address", itr.src_address.value),
+                                   insert_value("size", itr.bytes),
+                                   insert_value("stream_id", get_stream_id(itr.stream_id)),
+                                   insert_value("event_id", evt_id),
+                               });
                 }
             }
         };
 
-    auto insert_memory_alloc_data =
-        [&db, &tool_metadata, &string_entries, node_id, this_pid](const auto& _gen) {
-            auto address_to_agent_and_size =
-                std::unordered_map<rocprofiler_address_t, rocprofiler::agent::index_and_size>{};
-            auto _deferred = sql::deferred_transaction{db.conn};
+    auto insert_memory_alloc_data = [&db,
+                                     &tool_metadata,
+                                     &string_entries,
+                                     node_id,
+                                     this_pid,
+                                     &get_thread_id,
+                                     &get_stream_id,
+                                     &get_queue_id](const auto& _gen) {
+        auto address_to_agent_and_size =
+            std::unordered_map<rocprofiler_address_t, rocprofiler::agent::index_and_size>{};
+        auto _deferred = sql::deferred_transaction{db.conn};
 
-            for(auto pitr : _gen)
+        for(auto pitr : _gen)
+        {
+            for(auto itr : _gen.get(pitr))
             {
-                for(auto itr : _gen.get(pitr))
+                // insert thread info if it doesn't already exist
+                get_thread_id(itr.thread_id);
+
+                auto _kind           = tool_metadata.buffer_names.at(itr.kind);
+                auto _cpptype        = tool_metadata.buffer_names.at(itr.kind, itr.operation);
+                auto [_type, _level] = memtype_to_db(_cpptype);
+
+                ROCP_FATAL_IF(_type != "ALLOC" && _type != "FREE" && _type != "RECLAIM" &&
+                              _type != "REALLOC")
+                    << "erroneous db type: " << _type;
+
+                ROCP_FATAL_IF(_level != "REAL" && _level != "VIRTUAL" && _level != "SCRATCH")
+                    << "erroneous db level: " << _level;
+
+                auto _stream_id       = get_stream_id(extract_stream_field(itr));
+                auto _queue_id        = get_queue_id(extract_queue_field(itr));
+                auto _address         = extract_address_field(itr);
+                auto _allocation_size = extract_allocation_size_field(itr);
+
+                auto _node_id = std::optional<uint64_t>{};
+                if(_type == "ALLOC")
                 {
-                    // insert thread info if it doesn't already exist
-                    get_thread_id(itr.thread_id);
-
-                    auto _kind           = tool_metadata.buffer_names.at(itr.kind);
-                    auto _cpptype        = tool_metadata.buffer_names.at(itr.kind, itr.operation);
-                    auto [_type, _level] = memtype_to_db(_cpptype);
-
-                    ROCP_FATAL_IF(_type != "ALLOC" && _type != "FREE" && _type != "RECLAIM" &&
-                                  _type != "REALLOC")
-                        << "erroneous db type: " << _type;
-
-                    ROCP_FATAL_IF(_level != "REAL" && _level != "VIRTUAL" && _level != "SCRATCH")
-                        << "erroneous db level: " << _level;
-
-                    auto _stream_id       = get_stream_id(extract_stream_field(itr));
-                    auto _queue_id        = get_queue_id(extract_queue_field(itr));
-                    auto _address         = extract_address_field(itr);
-                    auto _allocation_size = extract_allocation_size_field(itr);
-
-                    auto _node_id = std::optional<uint64_t>{};
-                    if(_type == "ALLOC")
+                    _node_id = tool_metadata.get_agent(itr.agent_id)->node_id;
+                    address_to_agent_and_size.emplace(
+                        rocprofiler_address_t{.handle = _address.handle},
+                        rocprofiler::agent::index_and_size{_node_id.value(), _allocation_size});
+                }
+                else if(_type == "FREE")
+                {
+                    if(address_to_agent_and_size.count(_address) == 0)
                     {
-                        _node_id = tool_metadata.get_agent(itr.agent_id)->node_id;
-                        address_to_agent_and_size.emplace(
-                            rocprofiler_address_t{.handle = _address.handle},
-                            rocprofiler::agent::index_and_size{_node_id.value(), _allocation_size});
-                    }
-                    else if(_type == "FREE")
-                    {
-                        if(address_to_agent_and_size.count(_address) == 0)
+                        if(_address.handle == 0)
                         {
-                            if(_address.handle == 0)
-                            {
-                                // Freeing null pointers is expected behavior and is occurs in HSA
-                                // functions like hipStreamDestroy
-                                ROCP_INFO << "null pointer freed due to HSA operation";
-                            }
-                            else
-                            {
-                                // Following should not occur
-                                ROCP_INFO << "Unpaired free operation occurred";
-                            }
+                            // Freeing null pointers is expected behavior and is occurs in HSA
+                            // functions like hipStreamDestroy
+                            ROCP_INFO << "null pointer freed due to HSA operation";
                         }
                         else
                         {
-                            auto [agent_abs_index, size] = address_to_agent_and_size[_address];
-                            _node_id                     = agent_abs_index;
-                            _allocation_size             = 0;
+                            // Following should not occur
+                            ROCP_INFO << "Unpaired free operation occurred";
                         }
                     }
                     else
                     {
-                        ROCP_CI_LOG(WARNING) << "unhandled memory allocation type " << _type;
+                        auto [agent_abs_index, size] = address_to_agent_and_size[_address];
+                        _node_id                     = agent_abs_index;
+                        _allocation_size             = 0;
                     }
-
-                    auto evt_id = create_event(
-                        db,
-                        {
-                            insert_value("category_id", string_entries.at(_kind)),
-                            insert_value("stack_id", itr.correlation_id.internal),
-                            insert_value("parent_stack_id", itr.correlation_id.ancestor),
-                            insert_value("correlation_id", itr.correlation_id.external.value),
-                        });
-
-                    auto flags = extract_flags_field(itr);
-
-                    get_insert_statement(
-                        db,
-                        "rocpd_memory_allocate{{uuid}}",
-                        {
-                            insert_value("nid", node_id),
-                            insert_value("pid", this_pid),
-                            insert_value("tid", itr.thread_id),
-                            insert_value("start", itr.start_timestamp),
-                            insert_value("end", itr.end_timestamp),
-                            insert_value("agent_id", _node_id),
-                            insert_value("type", _type),
-                            insert_value("level", _level),
-                            insert_value("queue_id", _queue_id),
-                            insert_value("stream_id", _stream_id),
-                            insert_value("event_id", evt_id),
-                            insert_value("address", _address.value),
-                            insert_value("size", _allocation_size),
-                            insert_value("extdata",
-                                         flags == "" ? "{}" : get_json_string([&flags](auto& ar) {
-                                             ar(cereal::make_nvp("flags", flags));
-                                         })),
-                        });
                 }
+                else
+                {
+                    ROCP_CI_LOG(WARNING) << "unhandled memory allocation type " << _type;
+                }
+
+                auto evt_id = create_event(
+                    db,
+                    {
+                        insert_value("category_id", string_entries.at(_kind)),
+                        insert_value("stack_id", itr.correlation_id.internal),
+                        insert_value("parent_stack_id", itr.correlation_id.ancestor),
+                        insert_value("correlation_id", itr.correlation_id.external.value),
+                    });
+
+                auto flags = extract_flags_field(itr);
+
+                insert_row(
+                    db,
+                    "rocpd_memory_allocate{{uuid}}",
+                    {
+                        insert_value("nid", node_id),
+                        insert_value("pid", this_pid),
+                        insert_value("tid", itr.thread_id),
+                        insert_value("start", itr.start_timestamp),
+                        insert_value("end", itr.end_timestamp),
+                        insert_value("agent_id", _node_id),
+                        insert_value("type", _type),
+                        insert_value("level", _level),
+                        insert_value("queue_id", _queue_id),
+                        insert_value("stream_id", _stream_id),
+                        insert_value("event_id", evt_id),
+                        insert_value("address", _address.value),
+                        insert_value("size", _allocation_size),
+                        insert_value("extdata",
+                                     flags == "" ? "{}" : get_json_string([&flags](auto& ar) {
+                                         ar(cereal::make_nvp("flags", flags));
+                                     })),
+                    });
             }
-        };
+        }
+    };
 
     // new string entries argument types and names can be added to _metadata
-    auto insert_api_data = [&db, &tool_metadata, &string_entries, node_id, this_pid](
-                               const auto& _gen) {
+    auto insert_api_data = [&db,
+                            &tool_metadata,
+                            &string_entries,
+                            node_id,
+                            this_pid,
+                            &get_thread_id](const auto& _gen) {
         auto _deferred = sql::deferred_transaction{db.conn};
 
         for(auto pitr : _gen)
@@ -1621,45 +1554,45 @@ write_rocpd(
                 {
                     auto demangled_type = common::cxx_demangle(arg_info.arg_type);
 
-                    get_insert_statement(db,
-                                         "rocpd_arg{{uuid}}",
-                                         {
-                                             insert_value("event_id", evt_id),
-                                             insert_value("position", arg_info.arg_number),
-                                             insert_value("type", demangled_type),
-                                             insert_value("name", arg_info.arg_name),
-                                             insert_value("value", arg_info.arg_value),
-                                         });
+                    insert_row(db,
+                               "rocpd_arg{{uuid}}",
+                               {
+                                   insert_value("event_id", evt_id),
+                                   insert_value("position", arg_info.arg_number),
+                                   insert_value("type", demangled_type),
+                                   insert_value("name", arg_info.arg_name),
+                                   insert_value("value", arg_info.arg_value),
+                               });
                 }
 
                 if(itr.start_timestamp != itr.end_timestamp)
                 {
-                    get_insert_statement(db,
-                                         "rocpd_region{{uuid}}",
-                                         {
-                                             insert_value("id", itr.correlation_id.internal),
-                                             insert_value("nid", node_id),
-                                             insert_value("pid", this_pid),
-                                             insert_value("tid", itr.thread_id),
-                                             insert_value("start", itr.start_timestamp),
-                                             insert_value("end", itr.end_timestamp),
-                                             insert_value("name_id", string_entries.at(name)),
-                                             insert_value("event_id", evt_id),
-                                         });
+                    insert_row(db,
+                               "rocpd_region{{uuid}}",
+                               {
+                                   insert_value("id", itr.correlation_id.internal),
+                                   insert_value("nid", node_id),
+                                   insert_value("pid", this_pid),
+                                   insert_value("tid", itr.thread_id),
+                                   insert_value("start", itr.start_timestamp),
+                                   insert_value("end", itr.end_timestamp),
+                                   insert_value("name_id", string_entries.at(name)),
+                                   insert_value("event_id", evt_id),
+                               });
                 }
                 else
                 {
                     auto track_id = get_track_id(
                         db, node_id, this_pid, itr.thread_id, string_entries.at(category), "{}");
 
-                    get_insert_statement(db,
-                                         "rocpd_sample{{uuid}}",
-                                         {
-                                             insert_value("id", itr.correlation_id.internal),
-                                             insert_value("track_id", track_id),
-                                             insert_value("timestamp", itr.start_timestamp),
-                                             insert_value("event_id", evt_id),
-                                         });
+                    insert_row(db,
+                               "rocpd_sample{{uuid}}",
+                               {
+                                   insert_value("id", itr.correlation_id.internal),
+                                   insert_value("track_id", track_id),
+                                   insert_value("timestamp", itr.start_timestamp),
+                                   insert_value("event_id", evt_id),
+                               });
                 }
             }
         }
@@ -1695,86 +1628,87 @@ write_rocpd(
         for(const auto& info : kfd_info)
         {
             auto name   = tool_metadata.buffer_names.at(info.kind);
-            auto row_id = get_insert_row_id(db,
-                                            "rocpd_info_pmc{{uuid}}",
-                                            {
-                                                insert_value("nid", node_id),
-                                                insert_value("pid", this_pid),
-                                                insert_value("name", name),
-                                                insert_value("symbol", name),
-                                                insert_value("description", info.description),
-                                                insert_value("component", std::string_view{"rocm"}),
-                                                insert_value("value_type", std::string_view{"ABS"}),
-                                                insert_value("block", std::string_view{"KFD"}),
-                                                insert_value("is_constant", false),
-                                                insert_value("is_derived", false),
-                                            });
+            auto row_id = insert_row(db,
+                                     "rocpd_info_pmc{{uuid}}",
+                                     {
+                                         insert_value("nid", node_id),
+                                         insert_value("pid", this_pid),
+                                         insert_value("name", name),
+                                         insert_value("symbol", name),
+                                         insert_value("description", info.description),
+                                         insert_value("component", std::string_view{"rocm"}),
+                                         insert_value("value_type", std::string_view{"ABS"}),
+                                         insert_value("block", std::string_view{"KFD"}),
+                                         insert_value("is_constant", false),
+                                         insert_value("is_derived", false),
+                                     });
 
             ROCP_FATAL_IF(row_id == 0) << "Failed to get row ID for KFD PMC insert";
             pmc_ids.emplace(info.kind, row_id);
         }
     };
 
-    auto insert_kfd_event_data = [&db, &tool_metadata, &string_entries, node_id, this_pid](
-                                     const auto& _gen, const auto& _pmc_ids) {
-        auto _sqlgenperf_rocpd = get_simple_timer("rocpd_pmc_event: kfd");
-        for(auto pitr : _gen)
-        {
-            auto _deferred = sql::deferred_transaction{db.conn};
-            for(const auto& itr : _gen.get(pitr))
+    auto insert_kfd_event_data =
+        [&db, &tool_metadata, &string_entries, node_id, this_pid, &get_thread_id](
+            const auto& _gen, const auto& _pmc_ids) {
+            auto _sqlgenperf_rocpd = get_simple_timer("rocpd_pmc_event: kfd");
+            for(auto pitr : _gen)
             {
-                auto data = std::visit(
-                    [&tool_metadata](const auto& record) {
-                        using record_type = common::mpl::unqualified_type_t<decltype(record)>;
+                auto _deferred = sql::deferred_transaction{db.conn};
+                for(const auto& itr : _gen.get(pitr))
+                {
+                    auto data = std::visit(
+                        [&tool_metadata](const auto& record) {
+                            using record_type = common::mpl::unqualified_type_t<decltype(record)>;
 
-                        if constexpr(!std::is_same<record_type, std::monostate>::value)
-                            return construct_kfd_pmc_event(tool_metadata, record);
+                            if constexpr(!std::is_same<record_type, std::monostate>::value)
+                                return construct_kfd_pmc_event(tool_metadata, record);
 
-                        return kfd_pmc_event_data_t{};
-                    },
-                    itr.record);
+                            return kfd_pmc_event_data_t{};
+                        },
+                        itr.record);
 
-                // skip invalid records
-                if(data.kind == ROCPROFILER_BUFFER_TRACING_NONE) continue;
+                    // skip invalid records
+                    if(data.kind == ROCPROFILER_BUFFER_TRACING_NONE) continue;
 
-                // insert thread info if it doesn't already exist
-                get_thread_id(data.tid);
+                    // insert thread info if it doesn't already exist
+                    get_thread_id(data.tid);
 
-                // get KFD category and create event entry
-                auto category = tool_metadata.buffer_names.at(data.kind);
-                auto evt_id =
-                    create_event(db,
-                                 {
-                                     insert_value("category_id", string_entries.at(category)),
-                                     insert_value("stack_id", 0),
-                                     insert_value("parent_stack_id", 0),
-                                     insert_value("correlation_id", 0),
-                                     insert_value("extdata", data.json_data),
-                                 });
-
-                // track timestamps with a region
-                get_insert_statement(db,
-                                     "rocpd_region{{uuid}}",
+                    // get KFD category and create event entry
+                    auto category = tool_metadata.buffer_names.at(data.kind);
+                    auto evt_id =
+                        create_event(db,
                                      {
-                                         insert_value("nid", node_id),
-                                         insert_value("pid", this_pid),
-                                         insert_value("tid", data.tid),
-                                         insert_value("start", data.start),
-                                         insert_value("end", data.end),
-                                         insert_value("name_id", string_entries.at(data.name)),
-                                         insert_value("event_id", evt_id),
+                                         insert_value("category_id", string_entries.at(category)),
+                                         insert_value("stack_id", 0),
+                                         insert_value("parent_stack_id", 0),
+                                         insert_value("correlation_id", 0),
+                                         insert_value("extdata", data.json_data),
                                      });
 
-                get_insert_statement(db,
-                                     "rocpd_pmc_event{{uuid}}",
-                                     {
-                                         insert_value("event_id", evt_id),
-                                         insert_value("pmc_id", _pmc_ids.at(data.kind)),
-                                         insert_value("value", data.value),
-                                     });
+                    // track timestamps with a region
+                    insert_row(db,
+                               "rocpd_region{{uuid}}",
+                               {
+                                   insert_value("nid", node_id),
+                                   insert_value("pid", this_pid),
+                                   insert_value("tid", data.tid),
+                                   insert_value("start", data.start),
+                                   insert_value("end", data.end),
+                                   insert_value("name_id", string_entries.at(data.name)),
+                                   insert_value("event_id", evt_id),
+                               });
+
+                    insert_row(db,
+                               "rocpd_pmc_event{{uuid}}",
+                               {
+                                   insert_value("event_id", evt_id),
+                                   insert_value("pmc_id", _pmc_ids.at(data.kind)),
+                                   insert_value("value", data.value),
+                               });
+                }
             }
-        }
-    };
+        };
 
     auto dispatch_to_evt_id = common::container::stable_vector<uint64_t, 512>{};
 

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -74,6 +74,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 
 ROCPROFILER_SDK_CEREAL_NAMESPACE_BEGIN
 
@@ -133,15 +134,11 @@ replace_all(std::string val, Tp from, std::string_view to)
 std::string
 sanitize_sql_string(std::string input)
 {
-    // Special characters that need to be escaped/sanitized in SQL strings
+    // Remove control/separator characters; no quote escaping when binding parameters.
     constexpr auto ESCAPE_CHARS = std::string_view{";\n\r\t\b\f\v"};
-    using strpair_t             = std::pair<std::string_view, std::string_view>;
 
     for(char c : ESCAPE_CHARS)
         input = replace_all(input, c, "");
-
-    for(auto&& itr : {strpair_t{"'", "''"}})
-        input = replace_all(input, itr.first, itr.second);
 
     return input;
 }
@@ -294,8 +291,8 @@ iterate_args_callback(rocprofiler_buffer_tracing_kind_t /*kind*/,
 
 struct sql_insert_value
 {
-    std::string_view name  = {};
-    std::string      value = {};
+    std::string_view                                                                     name  = {};
+    std::variant<std::monostate, int64_t, uint64_t, double, std::string, std::nullptr_t> value = {};
 };
 
 struct allow_empty_string
@@ -329,13 +326,32 @@ insert_value(std::string_view _name, const Tp& _value, TraitT = {})
             {
                 ROCP_CI_LOG(WARNING)
                     << fmt::format("sql text value for {} is empty. Using NULL instead", _name);
-                return sql_insert_value{_name, std::string{"NULL"}};
+                return sql_insert_value{_name, nullptr};
             }
         }
-        // Sanitize string values before embedding into SQL to escape quotes and remove
-        // problematic control/separator characters.
+        // Sanitize string values to remove problematic control/separator characters.
         auto _sanitized = sanitize_sql_string(std::string{_value});
-        return sql_insert_value{_name, fmt::format("'{}'", _sanitized)};
+        return sql_insert_value{_name, _sanitized};
+    }
+    else if constexpr(std::is_enum_v<value_type>)
+    {
+        return sql_insert_value{_name, static_cast<int64_t>(_value)};
+    }
+    else if constexpr(std::is_integral_v<value_type>)
+    {
+        if constexpr(std::is_unsigned_v<value_type>)
+        {
+            auto _uval = static_cast<uint64_t>(_value);
+            if(_uval > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
+                return sql_insert_value{_name, static_cast<double>(_uval)};
+            return sql_insert_value{_name, _uval};
+        }
+        else
+            return sql_insert_value{_name, static_cast<int64_t>(_value)};
+    }
+    else if constexpr(std::is_floating_point_v<value_type>)
+    {
+        return sql_insert_value{_name, static_cast<double>(_value)};
     }
     else
     {
@@ -355,27 +371,151 @@ insert_value(std::string_view _name, const std::optional<Tp>& _value, TraitT = {
     return insert_value(_name, _value.value(), TraitT{});
 }
 
+sqlite3*&
+get_active_sqlite_connection()
+{
+    static sqlite3* _conn = nullptr;
+    return _conn;
+}
+
+std::unordered_map<std::string, sqlite3_stmt*>&
+get_prepared_statement_cache()
+{
+    static auto _cache = std::unordered_map<std::string, sqlite3_stmt*>{};
+    return _cache;
+}
+
+void
+set_active_sqlite_connection(sqlite3* conn)
+{
+    auto& current = get_active_sqlite_connection();
+    if(current == conn) return;
+
+    if(current != nullptr)
+    {
+        for(auto& [key, stmt] : get_prepared_statement_cache())
+        {
+            if(stmt) sqlite3_finalize(stmt);
+        }
+        get_prepared_statement_cache().clear();
+    }
+
+    current = conn;
+}
+
+void
+finalize_prepared_statements()
+{
+    for(auto& [key, stmt] : get_prepared_statement_cache())
+    {
+        if(stmt) sqlite3_finalize(stmt);
+    }
+    get_prepared_statement_cache().clear();
+}
+
 template <template <typename...> class ContainerT, typename... TypesT>
 auto
 get_insert_statement_impl(std::string_view _table, ContainerT<sql_insert_value, TypesT...>&& _data)
 {
     auto fields = std::vector<std::string_view>{};
-    auto values = std::vector<std::string_view>{};
+    auto values = std::vector<sql_insert_value>{};
 
     fields.reserve(_data.size() + 1);
     values.reserve(_data.size() + 1);
     for(auto&& itr : _data)
     {
-        if(itr.name.empty() && itr.value.empty()) continue;
+        if(itr.name.empty()) continue;
 
         fields.emplace_back(itr.name);
-        values.emplace_back(itr.value);
+        values.emplace_back(itr);
     }
 
-    return fmt::format(R"(INSERT INTO {} ({}) VALUES ({});)",
-                       replace_uuid(_table),
-                       fmt::join(fields.begin(), fields.end(), ", "),
-                       fmt::join(values.begin(), values.end(), ", "));
+    if(fields.empty()) return std::string{};
+
+    auto& conn  = get_active_sqlite_connection();
+    auto& cache = get_prepared_statement_cache();
+
+    ROCP_FATAL_IF(conn == nullptr) << "SQLite connection not set for prepared statements";
+
+    auto table = replace_uuid(_table);
+    auto key   = fmt::format("{}:{}", table, fmt::join(fields, ","));
+
+    auto& stmt = cache[key];
+    if(!stmt)
+    {
+        auto placeholders = std::string{};
+        for(size_t i = 0; i < fields.size(); ++i)
+        {
+            if(i > 0) placeholders += ", ";
+            placeholders += "?";
+        }
+
+        auto sql = fmt::format(
+            "INSERT INTO {} ({}) VALUES ({});", table, fmt::join(fields, ", "), placeholders);
+
+        int rc = sqlite3_prepare_v2(conn, sql.c_str(), -1, &stmt, nullptr);
+        if(rc != SQLITE_OK)
+        {
+            ROCP_FATAL << fmt::format(
+                "[{}] Failed to prepare statement: {}", rc, sqlite3_errmsg(conn));
+            throw std::runtime_error("sqlite3_prepare_v2 failed");
+        }
+    }
+
+    for(size_t i = 0; i < values.size(); ++i)
+    {
+        int idx = static_cast<int>(i + 1);
+        std::visit(
+            [&](auto&& val) {
+                using T = std::decay_t<decltype(val)>;
+                int rc  = SQLITE_OK;
+                if constexpr(std::is_same_v<T, std::monostate>)
+                {
+                    rc = sqlite3_bind_null(stmt, idx);
+                }
+                else if constexpr(std::is_same_v<T, std::nullptr_t>)
+                {
+                    rc = sqlite3_bind_null(stmt, idx);
+                }
+                else if constexpr(std::is_same_v<T, int64_t>)
+                {
+                    rc = sqlite3_bind_int64(stmt, idx, val);
+                }
+                else if constexpr(std::is_same_v<T, uint64_t>)
+                {
+                    rc = sqlite3_bind_int64(stmt, idx, static_cast<int64_t>(val));
+                }
+                else if constexpr(std::is_same_v<T, double>)
+                {
+                    rc = sqlite3_bind_double(stmt, idx, val);
+                }
+                else if constexpr(std::is_same_v<T, std::string>)
+                {
+                    rc = sqlite3_bind_text(stmt, idx, val.c_str(), -1, SQLITE_TRANSIENT);
+                }
+
+                if(rc != SQLITE_OK)
+                {
+                    ROCP_FATAL << fmt::format("[{}] Failed to bind parameter at index {}: {}",
+                                              rc,
+                                              idx,
+                                              sqlite3_errmsg(conn));
+                    throw std::runtime_error("sqlite3_bind failed");
+                }
+            },
+            values[i].value);
+    }
+
+    int rc = sqlite3_step(stmt);
+    if(rc != SQLITE_DONE)
+    {
+        ROCP_FATAL << fmt::format("[{}] Failed to execute statement: {}", rc, sqlite3_errmsg(conn));
+        throw std::runtime_error("sqlite3_step failed");
+    }
+
+    sqlite3_reset(stmt);
+
+    return std::string{};
 }
 
 template <template <typename...> class ContainerT, typename... TypesT>
@@ -706,6 +846,7 @@ write_rocpd(
         SQLITE3_CHECK(sqlite3_open_v2(
             output_file.c_str(), &conn, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr));
         SQLITE3_CHECK(sqlite3_busy_handler(conn, &sql::busy_handler, nullptr));
+        set_active_sqlite_connection(conn);
 
         ROCP_ERROR << fmt::format("Opened result file: {} (UUID={})", output_file, uuid_v7);
 
@@ -1703,6 +1844,8 @@ write_rocpd(
         execute_raw_sql_statements(conn, indexes_schema);
     }
 
+    finalize_prepared_statements();
+    set_active_sqlite_connection(nullptr);
     SQLITE3_CHECK(sqlite3_close_v2(conn));
 
     // Clear UUID/GUID state at end of write to prepare for potential re-attach

--- a/projects/rocprofiler-sdk/source/lib/output/sql/common.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/sql/common.cpp
@@ -34,6 +34,7 @@
 #include <fmt/ranges.h>
 #include <sqlite3.h>
 
+#include <cctype>
 #include <iomanip>
 #include <sstream>
 #include <thread>
@@ -96,7 +97,16 @@ execute_raw_sql_statements_impl(sqlite3*         conn,
                                 void*            data,
                                 int              line)
 {
-    int64_t row_id = -1;
+    int64_t row_id   = -1;
+    auto    is_blank = [](std::string_view value) {
+        for(char c : value)
+        {
+            if(!std::isspace(static_cast<unsigned char>(c))) return false;
+        }
+        return true;
+    };
+
+    if(stmts.empty() || is_blank(stmts)) return row_id;
     // NOLINTNEXTLINE(performance-for-range-copy)
     for(auto stmt : sdk::parse::tokenize(stmts, ";"))
     {

--- a/projects/rocprofiler-sdk/source/lib/output/sql/common.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/sql/common.cpp
@@ -48,11 +48,15 @@ namespace sql
 namespace sdk = ::rocprofiler::sdk;
 
 void
-check(std::string_view function, int status, std::string_view stmt)
+check(std::string_view               function,
+      int                            status,
+      std::string_view               stmt,
+      const std::unordered_set<int>& valid_statuses)
 {
-    if(status != SQLITE_OK)
+    if(valid_statuses.find(status) == valid_statuses.end())
     {
-        ROCP_FATAL << "[" << function << "] " << stmt << " failed with error code " << status;
+        ROCP_FATAL << "[" << function << "] " << stmt << " failed with error code " << status
+                   << ": " << sqlite3_errstr(status);
     }
 }
 

--- a/projects/rocprofiler-sdk/source/lib/output/sql/common.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/sql/common.cpp
@@ -101,16 +101,7 @@ execute_raw_sql_statements_impl(sqlite3*         conn,
                                 void*            data,
                                 int              line)
 {
-    int64_t row_id   = -1;
-    auto    is_blank = [](std::string_view value) {
-        for(char c : value)
-        {
-            if(!std::isspace(static_cast<unsigned char>(c))) return false;
-        }
-        return true;
-    };
-
-    if(stmts.empty() || is_blank(stmts)) return row_id;
+    int64_t row_id = -1;
     // NOLINTNEXTLINE(performance-for-range-copy)
     for(auto stmt : sdk::parse::tokenize(stmts, ";"))
     {

--- a/projects/rocprofiler-sdk/source/lib/output/sql/common.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/sql/common.hpp
@@ -51,7 +51,10 @@ int
 exec_callback(void* user_data, int ncols, char** coltext, char** colnames);
 
 void
-check(std::string_view function, int status, std::string_view stmt);
+check(std::string_view               function,
+      int                            status,
+      std::string_view               stmt,
+      const std::unordered_set<int>& valid_statuses = {SQLITE_OK});
 
 int
 busy_handler(void* data, int count);
@@ -127,3 +130,7 @@ column_data_is_null(sqlite3_stmt* stmt, int32_t col)
 
 #define SQLITE3_CHECK(RESULT)                                                                      \
     ::rocprofiler::tool::sql::check(__FUNCTION__, (RESULT), std::string_view{#RESULT})
+
+#define SQLITE3_CHECK2(RESULT, ...)                                                                \
+    ::rocprofiler::tool::sql::check(                                                               \
+        __FUNCTION__, (RESULT), std::string_view{#RESULT}, {__VA_ARGS__})


### PR DESCRIPTION
## Motivation

For every single row insert the get_insert_statement() and insert_value() functions, build a complete sql string "INSERT INTO table (field1, field2) VALUES ('value1', 'value2');" and send it to SQLite using sqlite3_exec() which the SQLite parses and compiles before the execution. Doing this for every single row is expensive and burns a lot of time. This PR is create to avoid this repetitive SQL parsing.

## Technical Details

Introduced a cache for prepared statements, for the first insert into a table with specific fields the SQLite compiles the statement once and stores it in a cache: map["table:field1,field2"] = stmt_pointer. For subsequent rows with same table+fields Looks up cached sqlite3_stmt* from the map, Binds new values to the place holder and executes without recompiling the statement. Because Parsing/compiling SQL is expensive and doing it millions of times for similar inserts is extremely wasteful, with this cache we reduce the time compiling repetitive SQL statements.

## JIRA ID

## Test Plan

## Test Result

Ran all the rocpd integration tests, no regression seen.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
