### PR TITLE
code size should be more than header size (24 bytes) otherwise it cau…

### DIFF
--- a/projects/hip-tests/catch/unit/library/library_negative.cc
+++ b/projects/hip-tests/catch/unit/library/library_negative.cc
@@ -35,7 +35,9 @@ TEST_CASE("Unit_library_negative") {
   }
 
   SECTION("Load random code") {
-    const char* code = "call me ishmael";  // definitely not compile-able
+    // code size should be more than header size (24 bytes) otherwise it cause buffer overflow
+    // with ASAN enabled in std:memcmp.
+    const char* code = "call me ishmaelxxxxxxxxxxxxxxxx";  // definitely not compile-able
     hipLibrary_t lib;
     hipKernel_t kernel;
     // Default behavior is lazy load, so if we pass anything to it, it should pass


### PR DESCRIPTION
…se buffer overflow with ASAN enabled in std:memcmp.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
