### PR TITLE
[SWDEV-566543] amdsmitst fail TempR FreqsR FreqsRW

### DIFF
--- a/projects/amdsmi/tests/amd_smi_test/amdsmitst.exclude
+++ b/projects/amdsmi/tests/amd_smi_test/amdsmitst.exclude
@@ -80,14 +80,22 @@ $BLACKLIST_ALL_ASICS\
 FILTER[90400]=\
 $BLACKLIST_ALL_ASICS\
 "rsmitstReadOnly.TestVoltCurvRead"
-
 FILTER[90401]=${FILTER[90400]}
-
 FILTER[90402]=${FILTER[90400]}
 
+# SWDEV-566543
 # SWDEV-572968
-FILTER[gfx1151]=\
+# SWDEV-571572
+# SWDEV-571574
+# SWDEV-571576
+FILTER[strix_point]=\
 $BLACKLIST_ALL_ASICS\
-"amdsmitstReadWrite.TempRead:"\
-"amdsmitstReadOnly.TestFrequenciesRead"
+"amdsmitstReadOnly.TempRead:"\
+"amdsmitstReadOnly.TestFrequenciesRead:"\
+"amdsmitstReadWrite.TestFrequenciesReadWrite"
+FILTER[veo]=${FILTER[strix_point]}
+FILTER[gfx1150]=${FILTER[strix_point]}
+FILTER[gfx1151]=${FILTER[strix_point]}
+FILTER[gfx1152]=${FILTER[strix_point]}
+FILTER[gfx1153]=${FILTER[strix_point]}
 


### PR DESCRIPTION
## Motivation
These amdsmitst tests are failing on these machines because the driver is reporting a metrics version of 3.0 which is not supported at this time.  These tests are being blacklisted until the driver can successfully read/write to the metrics files.

## JIRA ID
SWDEV-566543](https://ontrack-internal.amd.com/browse/SWDEV-566543) [APU][AMD-SMI] amdsmitstReadOnly.TempRead and amdsmitstReadOnly.TestFrequenciesRead and amdsmitstReadWrite.TestFrequenciesReadWrite failed