### PR TITLE
rocr: Fix IPC dmabuf hang with large allocations

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -916,7 +916,7 @@ class Runtime {
 
   // IPC DMA buf unix domain socket server dmabuf FD passing
   int ipc_sock_server_fd_;
-  std::map<uint64_t, int> ipc_sock_server_conns_;
+  std::map<uint64_t, size_t> ipc_sock_server_conns_;
   std::mutex ipc_sock_server_lock_;
   os::Thread ipc_sock_server_thread_;
 


### PR DESCRIPTION
## Motivation
Changed ipc_sock_server_conns_ map's value type to size_t. previous type of int caused allocations of sizes greater than 2GB to overflow, causing the message len to be stored as a negative value, preventing the IPC server from exporting dmabuf file descriptors, which lead to hangs.

