### PR TITLE
rocr: Return path for XDNA devices as a string

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -48,7 +48,6 @@
 #include <unistd.h>
 
 #include <array>
-#include <filesystem>
 #include <fstream>
 #include <map>
 #include <memory>
@@ -87,12 +86,11 @@ static const std::map<XDNADeviceId, XDNADeviceType> supported_xdna_devices = {
     {{0x17f0}, XDNADeviceType::Stx},  // Strix Halo / Krackan
 };
 
-namespace fs = std::filesystem;
-
+/// Returns the path as a string to avoid C++ ABI issues with std::filesystem::path.
 /// @brief Devnode path for XDNA devices.
-static const fs::path devnodes_path = "/dev/accel";
+static const std::string devnodes_path = "/dev/accel";
 /// @brief Sysfs path for XDNA devices.
-static const fs::path sysfs_path = "/sys/class/accel";
+static const std::string sysfs_path = "/sys/class/accel";
 /// @brief Devnode prefix for XDNA devices.
 static const std::string devnode_prefix = "accel";
 /// @brief Maximum devnode minor number for XDNA devices.
@@ -180,7 +178,7 @@ hsa_status_t XdnaDriver::QueryKernelModeDriver(core::DriverQuery query) {
 }
 
 hsa_status_t XdnaDriver::Open() {
-  const auto devnode_path = devnodes_path / devnode_name_;
+  const std::string devnode_path = devnodes_path + "/" + devnode_name_;
   fd_ = open(devnode_path.c_str(), O_RDWR | O_CLOEXEC);
   if (fd_ < 0) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
@@ -216,19 +214,19 @@ hsa_status_t XdnaDriver::GetNodeProperties(HsaNodeProperties& node_props, uint32
     return HSA_STATUS_ERROR;
   }
 
-  const auto sysfs_device_path = sysfs_path / devnode_name_ / "device";
+  const std::string sysfs_device_path = sysfs_path + "/" + devnode_name_ + "/device";
 
   // Find device type.
   XDNADeviceType device_type = XDNADeviceType::Unknown;
   {
-    const auto device_id_file = sysfs_device_path / "device";
-    if (!fs::exists(device_id_file)) {
+    const std::string device_id_file = sysfs_device_path + "/device";
+    std::ifstream is(device_id_file);
+    if (!is.good()) {
       assert(false && "Device file not found in sysfs.");
       return HSA_STATUS_ERROR;
     }
 
     XDNADeviceId device_id = {};
-    std::ifstream is(device_id_file);
     // Device ID is in hex.
     if (!(is >> std::hex >> device_id.device)) {
       assert(false && "Failed to read device ID from sysfs.");
@@ -268,13 +266,13 @@ hsa_status_t XdnaDriver::GetNodeProperties(HsaNodeProperties& node_props, uint32
 
   // Read device name from sysfs.
   {
-    const auto device_name_file = sysfs_device_path / "vbnv";
-    if (!fs::exists(device_name_file)) {
+    const std::string device_name_file = sysfs_device_path + "/vbnv";
+    std::array<char, HSA_PUBLIC_NAME_SIZE> device_name = {};
+    std::ifstream is(device_name_file);
+    if (!is.good()) {
       assert(false && "Device file name not found in sysfs.");
       return HSA_STATUS_ERROR;
     }
-    std::array<char, HSA_PUBLIC_NAME_SIZE> device_name = {};
-    std::ifstream is(device_name_file);
     if (!is.getline(device_name.data(), device_name.size() - 1)) {
       assert(false && "Failed to read device name from sysfs.");
       return HSA_STATUS_ERROR;


### PR DESCRIPTION
Return the Devnode and Sysfs paths for XDNA devices as a string to avoid C++ ABI issues with std::filesystem::path.

## Motivation

DaVinci Resolve's libProResRAW.so uses its own C++ standard library, causing ABI conflicts with ROCm's libhsa-runtime64.so when both use _std::filesystem::path_. During global initialization or runtime path construction, the wrong ABI version of __M_split_cmpts()_ was called, resulting in a segmentation fault.

## Technical Details

This fix is a temporary workaround with minimal changes. Replaced all std::filesystem usage in amd_xdna_driver.cpp with plain C++ string operations.

## JIRA ID

SWDEV-570029
