### PR TITLE
[rocshmem] Fix a crash in allreduce for certain cases

### DIFF
--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -528,8 +528,10 @@ __device__ int GDAContext::reduce(rocshmem_team_t team, T *dest,
         int p_count = nreduce - (n_seg * seg_size);
         int p_chunk = p_count / PE_size;
 
-        internal_ring_allreduce<T, Op>(p_dst, p_src, p_count, team_obj, 1,
-                                      (p_chunk * PE_size), p_chunk);
+        if (p_chunk > 0) {
+          internal_ring_allreduce<T, Op>(p_dst, p_src, p_count, team_obj, 1,
+                                         (p_chunk * PE_size), p_chunk);
+        }
 
         if ((p_chunk * PE_size) < p_count) {
           // Final elements need to use direct_allreduce

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -529,8 +529,9 @@ __device__ int GDAContext::reduce(rocshmem_team_t team, T *dest,
         int p_chunk = p_count / PE_size;
 
         if (p_chunk > 0) {
-          internal_ring_allreduce<T, Op>(p_dst, p_src, p_count, team_obj, 1,
-                                         (p_chunk * PE_size), p_chunk);
+          internal_ring_allreduce<T, Op>(p_dst, p_src, (p_chunk * PE_size),
+                                         team_obj, 1, (p_chunk * PE_size),
+                                         p_chunk);
         }
 
         if ((p_chunk * PE_size) < p_count) {

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -301,7 +301,7 @@ __device__ void GDAContext::internal_direct_allreduce(
   int stride = team_obj->tinfo_wrt_world->stride;
   int PE_start = team_obj->tinfo_wrt_world->pe_start;
   int PE_size = team_obj->tinfo_wrt_world->size;
-  long *pSync = team_obj->barrier_pSync;
+  long *pSync = team_obj->reduce_pSync;
   T *pWrk = reinterpret_cast<T *>(team_obj->pWrk);
 
   int finish = PE_start + stride * PE_size;
@@ -418,7 +418,7 @@ __device__ void GDAContext::internal_ring_allreduce(
   int stride = team_obj->tinfo_wrt_world->stride;
   int PE_start = team_obj->tinfo_wrt_world->pe_start;
   int PE_size = team_obj->tinfo_wrt_world->size;
-  long *pSync = team_obj->barrier_pSync;
+  long *pSync = team_obj->reduce_pSync;
   T *pWrk = reinterpret_cast<T *>(team_obj->pWrk);
   int my_pe_in_team = team_obj->my_pe;
 
@@ -517,11 +517,11 @@ __device__ int GDAContext::reduce(rocshmem_team_t team, T *dest,
       int n_seg_up = (nreduce - 1) / seg_size + 1;
       // recalculate chunk_size
       chunk_size = seg_size / PE_size;
-      if (n_seg == 0) {
-        n_seg = 1;
+
+      if (n_seg > 0) {
+        internal_ring_allreduce<T, Op>(dest, source, nreduce, team_obj, n_seg,
+                                       seg_size, chunk_size);
       }
-      internal_ring_allreduce<T, Op>(dest, source, nreduce, team_obj, n_seg,
-                                     seg_size, chunk_size);
       if (n_seg_up > n_seg) {
         T *p_dst = (dest + (n_seg * seg_size));
         const T *p_src = (source + (n_seg * seg_size));
@@ -545,6 +545,7 @@ __device__ int GDAContext::reduce(rocshmem_team_t team, T *dest,
       return ROCSHMEM_ERROR;
     }
   }
+  barrier_wg(team);
   return ROCSHMEM_SUCCESS;
 }
 

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -380,11 +380,11 @@ __device__ int IPCContext::reduce(rocshmem_team_t team, T *dest,
       int n_seg_up = (nreduce - 1) / seg_size + 1;
       // recalculate chunk_size
       chunk_size = seg_size / PE_size;
-      if (n_seg == 0) {
-        n_seg = 1;
+
+      if (n_seg > 0) {
+        internal_ring_allreduce<T, Op>(dest, source, nreduce, team_obj, n_seg,
+                                       seg_size, chunk_size);
       }
-      internal_ring_allreduce<T, Op>(dest, source, nreduce, team_obj, n_seg,
-                                     seg_size, chunk_size);
       if (n_seg_up > n_seg) {
         T *p_dst = (dest + (n_seg * seg_size));
         const T *p_src = (source + (n_seg * seg_size));

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -391,7 +391,8 @@ __device__ int IPCContext::reduce(rocshmem_team_t team, T *dest,
         int p_count = nreduce - (n_seg * seg_size);
         int p_chunk = p_count / PE_size;
         if (p_chunk > 0) {
-          internal_ring_allreduce<T, Op>(p_dst, p_src, p_count, team_obj, 1,
+          internal_ring_allreduce<T, Op>(p_dst, p_src,
+                                         (p_chunk * PE_size), team_obj, 1,
                                          (p_chunk * PE_size), p_chunk);
         }
 

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -390,8 +390,10 @@ __device__ int IPCContext::reduce(rocshmem_team_t team, T *dest,
         const T *p_src = (source + (n_seg * seg_size));
         int p_count = nreduce - (n_seg * seg_size);
         int p_chunk = p_count / PE_size;
-        internal_ring_allreduce<T, Op>(p_dst, p_src, p_count, team_obj, 1,
-                                      (p_chunk * PE_size), p_chunk);
+        if (p_chunk > 0) {
+          internal_ring_allreduce<T, Op>(p_dst, p_src, p_count, team_obj, 1,
+                                         (p_chunk * PE_size), p_chunk);
+        }
 
         if ((p_chunk * PE_size) < p_count) {
           // Final elements need to use direct_allreduce


### PR DESCRIPTION
## Motivation

Fix a crash in allreduce for certain PE counts and message sizes.

## Technical Details

There was a bug in how the number of segments is calculated before calling ring-allreduce.
Bring in fixes applied to the IPC allreduce in a previous commit to the GDA conduit, which uses the same algorithm.

## JIRA ID

Resolves AIROCSHMEM-287
Resolves https://github.com/ROCm/rocm-systems/issues/3010

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
