### PR TITLE
Revert "Fixing ROCTracer Tests HIP/CLR CMake Config"

### DIFF
--- a/projects/roctracer/CMakeLists.txt
+++ b/projects/roctracer/CMakeLists.txt
@@ -20,7 +20,7 @@
 ## IN THE SOFTWARE.
 ################################################################################
 
-cmake_minimum_required(VERSION 3.21.0)
+cmake_minimum_required(VERSION 3.18.0)
 
 include( utils.cmake )
 set( CORE_TARGET "roctracer" )

--- a/projects/roctracer/test/CMakeLists.txt
+++ b/projects/roctracer/test/CMakeLists.txt
@@ -22,35 +22,17 @@
 
 get_property(HSA_RUNTIME_INCLUDE_DIRECTORIES TARGET hsa-runtime64::hsa-runtime64 PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
 
-# Find amdclang++ compiler for HIP language support
-if(NOT CMAKE_HIP_COMPILER)
-    find_program(
-        amdclangpp_EXECUTABLE
-        NAMES amdclang++
-        HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
-        PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
-        PATH_SUFFIXES bin llvm/bin NO_CACHE)
-    mark_as_advanced(amdclangpp_EXECUTABLE)
+# Set the HIP language runtime link flags as FindHIP does not set them.
+set(CMAKE_EXECUTABLE_RUNTIME_HIP_FLAG ${CMAKE_SHARED_LIBRARY_RUNTIME_CXX_FLAG})
+set(CMAKE_EXECUTABLE_RUNTIME_HIP_FLAG_SEP ${CMAKE_SHARED_LIBRARY_RUNTIME_CXX_FLAG_SEP})
+set(CMAKE_EXECUTABLE_RPATH_LINK_HIP_FLAG ${CMAKE_SHARED_LIBRARY_RPATH_LINK_CXX_FLAG})
 
-    if(amdclangpp_EXECUTABLE)
-        set(CMAKE_HIP_COMPILER "${amdclangpp_EXECUTABLE}")
-    endif()
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${ROCM_PATH}/lib/cmake/hip")
+set(CMAKE_HIP_ARCHITECTURES OFF)
+if(DEFINED ROCM_PATH)
+    set(HIP_ROOT_DIR "${ROCM_PATH}/bin")
 endif()
-
-# Enable HIP as a project language
-enable_language(HIP)
-
-# Set HIP compilation flags to match CXX flags
-foreach(_TYPE DEBUG MINSIZEREL RELEASE RELWITHDEBINFO)
-    if("${CMAKE_HIP_FLAGS_${_TYPE}}" STREQUAL "")
-        set(CMAKE_HIP_FLAGS_${_TYPE} "${CMAKE_CXX_FLAGS_${_TYPE}}")
-    endif()
-endforeach()
-
-# Set HIP standard flags
-set(CMAKE_HIP_STANDARD 17)
-set(CMAKE_HIP_EXTENSIONS OFF)
-set(CMAKE_HIP_STANDARD_REQUIRED ON)
+find_package(HIP REQUIRED MODULE)
 
 find_package(Clang REQUIRED CONFIG
              PATHS "${ROCM_PATH}"
@@ -61,22 +43,21 @@ add_custom_target(mytest)
 add_dependencies(mytest roctracer_tool hip_stats)
 add_custom_target(check COMMAND ${PROJECT_BINARY_DIR}/run.sh DEPENDS mytest)
 
-## Helper function to create HIP executables with common settings
-function(add_hip_executable TARGET_NAME SOURCE_FILE)
-  set_source_files_properties(${SOURCE_FILE} PROPERTIES LANGUAGE HIP)
-  add_executable(${TARGET_NAME} ${SOURCE_FILE})
-  target_link_options(${TARGET_NAME} PRIVATE "-Wl,--build-id=md5")
-endfunction()
-
 ## Build MatrixTranspose
-add_hip_executable(MatrixTranspose hip/MatrixTranspose.cpp)
+set_source_files_properties(hip/MatrixTranspose.cpp PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
+hip_add_executable(MatrixTranspose hip/MatrixTranspose.cpp)
+## Adding generated build-id as hip_add_executable doesn't generate automatically
+target_link_options(MatrixTranspose PRIVATE "-Wl,--build-id=md5")
 target_include_directories(MatrixTranspose PRIVATE ${PROJECT_SOURCE_DIR}/inc)
 target_link_libraries(MatrixTranspose PRIVATE roctracer roctx)
 add_dependencies(mytest MatrixTranspose)
 
 ## Build MatrixTranspose_test, MatrixTranspose_hipaact_test and MatrixTranspose_mgpu
+set_source_files_properties(app/MatrixTranspose_test.cpp PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
 function(build_matrix_transpose_test OUTPUT_FILE DEFINITIONS)
-  add_hip_executable(${OUTPUT_FILE} app/MatrixTranspose_test.cpp)
+  hip_add_executable(${OUTPUT_FILE} app/MatrixTranspose_test.cpp)
+  ## Adding generated build-id as hip_add_executable doesn't generate automatically
+  target_link_options(${OUTPUT_FILE} PRIVATE "-Wl,--build-id=md5")
   target_compile_definitions(${OUTPUT_FILE} PRIVATE ITERATIONS=100 HIP_TEST=1 ${DEFINITIONS})
   target_include_directories(${OUTPUT_FILE} PRIVATE ${PROJECT_SOURCE_DIR}/inc)
   target_link_libraries(${OUTPUT_FILE} PRIVATE roctracer roctx)
@@ -90,7 +71,9 @@ build_matrix_transpose_test(MatrixTranspose_mgpu MGPU_TEST=1)
 ## Build MatrixTranspose MatrixTranspose_ctest
 add_custom_command(OUTPUT MatrixTranspose.c
   COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/app/MatrixTranspose_test.cpp MatrixTranspose.c)
-add_hip_executable(MatrixTranspose_ctest MatrixTranspose.c)
+hip_add_executable(MatrixTranspose_ctest MatrixTranspose.c)
+## Adding generated build-id as hip_add_executable doesn't generate automatically
+target_link_options(MatrixTranspose_ctest PRIVATE "-Wl,--build-id=md5")
 target_compile_definitions(MatrixTranspose_ctest PRIVATE HIP_TEST=0 __HIP_PLATFORM_AMD__)
 target_include_directories(MatrixTranspose_ctest PRIVATE ${PROJECT_SOURCE_DIR}/inc)
 target_link_libraries(MatrixTranspose_ctest PRIVATE roctracer roctx)
@@ -139,7 +122,10 @@ add_dependencies(copy hsaco_targets)
 add_dependencies(mytest copy)
 
 ## Build the ROCTX test
-add_hip_executable(roctx_test app/roctx_test.cpp)
+set_source_files_properties(app/roctx_test.cpp PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
+hip_add_executable(roctx_test app/roctx_test.cpp)
+## Adding generated build-id as hip_add_executable doesn't generate automatically
+target_link_options(roctx_test PRIVATE "-Wl,--build-id=md5")
 target_link_libraries(roctx_test Threads::Threads roctx)
 add_dependencies(mytest roctx_test)
 
@@ -165,12 +151,18 @@ target_link_libraries(memory_pool Threads::Threads atomic)
 add_dependencies(mytest memory_pool)
 
 ## Build the activity_and_callback test
-add_hip_executable(activity_and_callback directed/activity_and_callback.cpp)
+set_source_files_properties(directed/activity_and_callback.cpp PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
+hip_add_executable(activity_and_callback directed/activity_and_callback.cpp)
+## Adding generated build-id as hip_add_executable doesn't generate automatically
+target_link_options(activity_and_callback PRIVATE "-Wl,--build-id=md5")
 target_link_libraries(activity_and_callback roctracer)
 add_dependencies(mytest activity_and_callback)
 
 ## Build the multi_pool_activities test
-add_hip_executable(multi_pool_activities directed/multi_pool_activities.cpp)
+set_source_files_properties(directed/multi_pool_activities.cpp PROPERTIES HIP_SOURCE_PROPERTY_FORMAT 1)
+hip_add_executable(multi_pool_activities directed/multi_pool_activities.cpp)
+## Adding generated build-id as hip_add_executable doesn't generate automatically
+target_link_options(multi_pool_activities PRIVATE "-Wl,--build-id=md5")
 target_link_libraries(multi_pool_activities roctracer)
 add_dependencies(mytest multi_pool_activities)
 

--- a/projects/roctracer/test/app/MatrixTranspose_test.cpp
+++ b/projects/roctracer/test/app/MatrixTranspose_test.cpp
@@ -138,7 +138,7 @@ int main() {
 #if HIP_TEST
   int gpuCount = 1;
 #if MGPU_TEST
-  CHECK_HIP(hipGetDeviceCount(&gpuCount));
+  hipGetDeviceCount(&gpuCount);
   fprintf(stderr, "Number of GPUs: %d\n", gpuCount);
 #endif
   iterations *= gpuCount;
@@ -150,7 +150,7 @@ int main() {
 #if HIP_TEST
     // set GPU
     const int devIndex = iterations % gpuCount;
-    CHECK_HIP(hipSetDevice(devIndex));
+    hipSetDevice(devIndex);
 
     hipDeviceProp_t devProp;
     CHECK_HIP(hipGetDeviceProperties(&devProp, 0));


### PR DESCRIPTION
Reverts ROCm/rocm-systems#3139

reason for revert is discussed here: https://teams.microsoft.com/l/message/19:f50d2d50fd094a8e8065b11a1cfd3496@thread.tacv2/1770833620435?tenantId=3dd8961f-e488-4e60-8e11-a82d994e183d&groupId=69e7275a-4d49-495d-8bd5-04fb519c8e9c&parentMessageId=1770833620435&teamName=AIG%20ROCm&channelName=Gardening%20-%20rocm-systems&createdTime=1770833620435