### PR TITLE
[RCCL] Profiler Plugin - Fix invalid JSON 

### DIFF
--- a/projects/rccl/ext-profiler/example/print_event.cc
+++ b/projects/rccl/ext-profiler/example/print_event.cc
@@ -29,7 +29,7 @@ __hidden void printGroupApiEventTrailer(FILE* fh, struct groupApi* event) {
 
 static __thread int p2pApiId;
 __hidden void printP2pApiEventHeader(FILE* fh, struct p2pApi* event) {
-  fprintf(fh, "{\"name\": \"%s\", \"cat\": \"P2P_API\", \"ph\": \"b\", \"id\": %d, \"pid\": %d, \"tid\": %d, \"ts\": %f, \"args\": {\"count\": %lu, \"datatype\": %s, \"GraphCaptured\":%d, \"Stream\": %p}},\n",
+  fprintf(fh, "{\"name\": \"%s\", \"cat\": \"P2P_API\", \"ph\": \"b\", \"id\": %d, \"pid\": %d, \"tid\": %d, \"ts\": %f, \"args\": {\"count\": %lu, \"datatype\": \"%s\", \"GraphCaptured\":%d, \"Stream\": \"%p\"}},\n",
       event->func, p2pApiId, getpid(), 1, event->startTs, event->count, event->datatype, event->graphCaptured, event->stream);
 }
 
@@ -40,7 +40,7 @@ __hidden void printP2pApiEventTrailer(FILE* fh, struct p2pApi* event) {
 
 static __thread int collApiId;
 __hidden void printCollApiEventHeader(FILE* fh, struct collApi* event) {
-  fprintf(fh, "{\"name\": \"%s\", \"cat\": \"COLL_API\", \"ph\": \"b\", \"id\": %d, \"pid\": %d, \"tid\": %d, \"ts\": %f, \"args\": {\"count\": %lu, \"datatype\": %s, \"root\": %d, \"GraphCaptured\":%d, \"Stream\": %p}},\n",
+  fprintf(fh, "{\"name\": \"%s\", \"cat\": \"COLL_API\", \"ph\": \"b\", \"id\": %d, \"pid\": %d, \"tid\": %d, \"ts\": %f, \"args\": {\"count\": %lu, \"datatype\": \"%s\", \"root\": %d, \"GraphCaptured\":%d, \"Stream\": \"%p\"}},\n",
       event->func, collApiId, getpid(), 1, event->startTs, event->count, event->datatype, event->root, event->graphCaptured, event->stream);
 }
 
@@ -51,7 +51,7 @@ __hidden void printCollApiEventTrailer(FILE* fh, struct collApi* event) {
 
 static __thread int kernelLaunchId;
 __hidden void printKernelLaunchEventHeader(FILE* fh, struct kernelLaunch* event) {
-  fprintf(fh, "{\"name\": \"%s\", \"cat\": \"KERNEL_LAUNCH\", \"ph\": \"b\", \"id\": %d, \"pid\": %d, \"tid\": %d, \"ts\": %f, \"args\": {\"groupId\": %d, \"Stream\": %p}},\n", "KernelLaunch", kernelLaunchId, getpid(), 1, event->startTs, event->kernelLaunchId, event->stream);
+  fprintf(fh, "{\"name\": \"%s\", \"cat\": \"KERNEL_LAUNCH\", \"ph\": \"b\", \"id\": %d, \"pid\": %d, \"tid\": %d, \"ts\": %f, \"args\": {\"groupId\": %d, \"Stream\": \"%p\"}},\n", "KernelLaunch", kernelLaunchId, getpid(), 1, event->startTs, event->kernelLaunchId, event->stream);
 }
 
 __hidden void printKernelLaunchEventTrailer(FILE* fh, struct kernelLaunch* event) {


### PR DESCRIPTION
## Motivation

Fix invalid JSON output in the ext-profiler plugin

## Technical Details

Add missing JSON string quotes around datatype `(%s → \"%s\")` and Stream `(%p → \"%p\")` format specifiers

## JIRA ID

AICOMRCCL-600

## Test Plan

Test changes against `rccl-tests`

## Test Result

Before:

{"name": "AllGather", "cat": "COLL_API", "ph": "b", "id": 0, "pid": 604352, "tid": 1, "ts": 0.000000, "args": {"count": 524288, "datatype": **_ncclFloat32_**, "root": 0, "GraphCaptured":0, "Stream": **_0x7f12d00_**}}

After:

{"name": "AllGather", "cat": "COLL_API", "ph": "b", "id": 3, "pid": 629292, "tid": 1, "ts": 0.000000, "args": {"count": 524288, "datatype": **_"ncclFloat32"_**, "root": 0, "GraphCaptured":0, "Stream": **_"0x6dd4800"_**}}

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
