### PR TITLE
Generate rocSHMEM AlltoAll and AlltoAllv GDA kernels only when building with rocSHMEM

### DIFF
--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -415,7 +415,7 @@ endif()
 
 # Execute the python script to generate required collective functions
 execute_process(
-    COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/src/device/generate.py ${GEN_DIR} ${IFC_ENABLED} ${COLLTRACE} ${ENABLE_MSCCL_KERNEL} ${BUILD_LOCAL_GPU_TARGET_ONLY} ${ONLY_FUNCS}
+    COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/src/device/generate.py ${GEN_DIR} ${IFC_ENABLED} ${COLLTRACE} ${ENABLE_MSCCL_KERNEL} ${BUILD_LOCAL_GPU_TARGET_ONLY} ${ENABLE_ROCSHMEM} ${ONLY_FUNCS}
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     RESULT_VARIABLE gen_py_result
     ERROR_VARIABLE gen_py_error

--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -79,12 +79,18 @@ is_ifc             = 1 if sys.argv[2] == "ON" else 0
 is_colltrace       = 1 if sys.argv[3] == "ON" else 0
 is_msccl_kernels   = 1 if sys.argv[4] == "ON" else 0
 is_local_arch_only = 1 if sys.argv[5] == "ON" else 0
+is_rocshmem        = 1 if sys.argv[6] == "ON" else 0
 
-func_pattern = sys.argv[6:7]
+func_pattern = sys.argv[7:8]
+
 if func_pattern and func_pattern[0]:
   func_pattern = func_pattern[0]
 else:
-  func_pattern = "AllGather|AllReduce|AlltoAllPivot|AlltoAllGda|AlltoAllvGda|Broadcast|Reduce|ReduceScatter|SendRecv"
+  # GDA (rocSHMEM-based) kernels only when rocshmem build requested
+  if is_rocshmem:
+    func_pattern = "AllGather|AllReduce|AlltoAllPivot|AlltoAllGda|AlltoAllvGda|Broadcast|Reduce|ReduceScatter|SendRecv"
+  else:
+    func_pattern = "AllGather|AllReduce|AlltoAllPivot|Broadcast|Reduce|ReduceScatter|SendRecv"
 
 ################################################################################
 
@@ -234,11 +240,16 @@ def calc_unroll_and_pipeline_for_local_arch():
 # except for gfx950. For gfx950, we also disable pipelining.
 local_unroll, local_pipeline = calc_unroll_and_pipeline_for_local_arch()
 
+# rocSHMEM/GDA-based collectives: only generated when ENABLE_ROCSHMEM build is requested
+gda_colls = {"AlltoAllGda", "AlltoAllvGda"}
+
 # Helper function to check if the conditions for the collective is being met
 def func_validate(coll, algo, proto, redop, ty, acc,  pipeline, unroll):
   if redop == "SumPostDiv" and ty[0] not in ("i","u"):
     return False
   if coll == "" or algo == "":
+    return False
+  if not is_rocshmem and coll in gda_colls:
     return False
   if (algo not in algos_of_coll[coll] or
       proto not in protos_of_coll[coll] or


### PR DESCRIPTION
## Motivation

AllToAllGda kernel is currently generated irrespective of rocshmem being enabled during build time or not

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

Resolves AICOMRCCL-379

## Test Plan

Invoke generate.py with the following configurations:

- default build (all colls)
- build (all colls) + rocshmem enabled
- ONLY_FUNCS="AllToAll"
- ONLY_FUNCS="AllToAll" + rocshmem enabled
- ONLY_FUNCS="AllToAll|AllGather"
- ONLY_FUNCS="AllToAll|AllGather" + rocshmem enabled

Ensure that the proper host_table and device_table files are generated.

## Test Result

- Satisfactory. Functioning as expected

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
