### PR TITLE
Match build gfx arch with gfx1151 test machines

### DIFF
--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -28,8 +28,8 @@ jobs:
       CCACHE_DIR: "${{ github.workspace }}/.container-cache/ccache"
       CCACHE_MAXSIZE: "700M"
       # TODO(geomin12): Add matrix of families
-      # To get a fast signal of windows building for TheRock, adding gfx115X-all
-      AMDGPU_FAMILIES: "gfx115X-all"
+      # To get a fast signal of windows building for TheRock, adding gfx1151
+      AMDGPU_FAMILIES: "gfx1151"
     steps:
       - name: "Checking out repository for rocm-systems"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -28,8 +28,8 @@ jobs:
       CCACHE_DIR: "${{ github.workspace }}/.container-cache/ccache"
       CCACHE_MAXSIZE: "700M"
       # TODO(geomin12): Add matrix of families
-      # To get a fast signal of windows building for TheRock, adding gfx110X
-      AMDGPU_FAMILIES: "gfx110X-dgpu"
+      # To get a fast signal of windows building for TheRock, adding gfx115X-all
+      AMDGPU_FAMILIES: "gfx115X-all"
     steps:
       - name: "Checking out repository for rocm-systems"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -153,5 +153,5 @@ jobs:
     with:
       projects_to_test: ${{ inputs.projects_to_test }}
       amdgpu_families: ${{ needs.therock-build-windows.outputs.AMDGPU_FAMILIES }}
-      test_runs_on: "windows-strix-halo-gpu-rocm"
+      test_runs_on: "windows-gfx1151-gpu-rocm"
       platform: "windows"


### PR DESCRIPTION
## Motivation

Mitigates https://github.com/ROCm/rocm-systems/issues/3221 until https://github.com/ROCm/rocm-systems/pull/2317 (dynamic selection of targets) is re-implemented as it was reverted here https://github.com/ROCm/rocm-systems/pull/2416

This will resolve test failures due to mismatched hard coded build gfx arch and test machine gfx arch.


## Technical Details

Discovered bug where hard coded amdgpu_families `gfx110X-dgpu` in workflow `therock-ci-windows.yml` would not correspond to the same hard coded test_runs_on: `windows-strix-halo-gpu-rocm`

Also normalize the target test label to using `windows-gfx1151-gpu-rocm`

## Test Plan

observe CI

## Test Result

TBD

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
