### PR TITLE
[rocprofiler-compute] Fix analysis db mode: noise clamp evaluation and roofline data validation

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -710,7 +710,7 @@ class db_analysis(OmniAnalyze_Base):
             roofline_data_df = self._arch_configs[gfx_arch].dfs[402]
 
             if roofline_data_df.empty:
-                console_warning(f"Roofline data not found or filtered for {workload_path}.")
+                console_warning(f"Roofline data is filtered out or not found for {workload_path}.")
                 continue
 
             roofline_data_expressions = dict(

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -52,6 +52,7 @@ from utils.parser import (
     to_round,
     to_std,
     to_sum,
+    to_noise_clamp,
 )
 from utils.roofline_calc import (
     CACHE_HIERARCHY,
@@ -470,6 +471,7 @@ class db_analysis(OmniAnalyze_Base):
                     "to_round": to_round,
                     "to_std": to_std,
                     "to_sum": to_sum,
+                    "to_noise_clamp": to_noise_clamp,
                 },
             )
 
@@ -706,6 +708,11 @@ class db_analysis(OmniAnalyze_Base):
             sys_info = self._runs[workload_path].sys_info.iloc[0].to_dict()
             gfx_arch = sys_info["gpu_arch"]
             roofline_data_df = self._arch_configs[gfx_arch].dfs[402]
+
+            if roofline_data_df.empty:
+                console_warning(f"Roofline data not found or filtered for {workload_path}.")
+                continue
+
             roofline_data_expressions = dict(
                 zip(roofline_data_df["Metric"], roofline_data_df["Value"])
             )

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -197,8 +197,8 @@ class RocProfCompute:
 
                 if self.__args.subpath != "gpu_model":
                     console_warning(
-                        "--subpath is deprecated and will be removed in future "
-                        "releases."
+                        "--subpath is deprecated and will be "
+                        "removed in future releases."
                     )
 
             if self.__args.name is not None and "/" in self.__args.name:

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -1002,7 +1002,8 @@ def test_output_directory_default_with_rank(
     binary_handler_profile_rocprof_compute, monkeypatch
 ):
     """
-    Test that rank is appended to the default output directory when MPI rank is set.
+    Test that rank is appended to the default output
+    directory when MPI rank is set.
     """
     from rocprof_compute_base import RocProfCompute
 

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -8330,3 +8330,68 @@ def test_resolve_rocm_library_path(tmp_path):
     missing = tmp_path / "libmissing.so"
     with pytest.raises(FileNotFoundError, match="ROCm library not found"):
         resolve_rocm_library_path(str(missing))
+
+
+# =============================================================================
+# TESTS FOR Analysis DB mode: Analysis DB mode code path
+# =============================================================================
+
+
+def test_calc_roofline_data_early_exit_on_empty_roofline_df(monkeypatch):
+    """Test calc_roofline_data exits early when roofline data is empty.
+
+    This test verifies that when the roofline dataframe (ID 402) is empty
+    or filtered out, the function logs a warning and skips that workload
+    without adding it to the result dictionary.
+    """
+    from rocprof_compute_analyze.analysis_db import db_analysis
+
+    # Create mock db_analysis instance
+    analyzer = mock.MagicMock(spec=db_analysis)
+
+    # Mock workload data
+    workload_path = "/mock/workload/path"
+    mock_runs = {
+        workload_path: mock.MagicMock(sys_info=pd.DataFrame([{"gpu_arch": "gfx90a"}]))
+    }
+
+    # Mock PMC dataframe with kernel data
+    mock_pmc_df = pd.DataFrame({
+        "Kernel_Name": ["kernel1", "kernel2"],
+        "Start_Timestamp": [100, 200],
+        "End_Timestamp": [150, 300],
+    })
+
+    # Mock architecture config with EMPTY roofline dataframe (ID 402)
+    mock_arch_config = mock.MagicMock()
+    mock_arch_config.dfs = {
+        402: pd.DataFrame()  # Empty roofline dataframe triggers early exit
+    }
+
+    # Setup instance variables
+    analyzer._runs = mock_runs
+    analyzer._pmc_df_per_workload = {workload_path: mock_pmc_df}
+    analyzer._arch_configs = {"gfx90a": mock_arch_config}
+    analyzer.get_args = mock.MagicMock(return_value=mock.MagicMock(max_stat_num=10))
+
+    # Mock console_warning to verify it's called
+    warning_messages = []
+
+    def mock_warning(msg):
+        warning_messages.append(msg)
+
+    monkeypatch.setattr(
+        "rocprof_compute_analyze.analysis_db.console_warning", mock_warning
+    )
+    monkeypatch.setattr(
+        "rocprof_compute_analyze.analysis_db.console_debug", lambda msg: None
+    )
+
+    # Call the actual function
+    result = db_analysis.calc_roofline_data(analyzer)
+
+    # Verify early exit behavior
+    assert len(result) == 0, "Should return empty dict when roofline data is empty"
+    assert len(warning_messages) == 1, "Should log one warning message"
+    assert "Roofline data is filtered out or not found" in warning_messages[0]
+    assert workload_path in warning_messages[0]


### PR DESCRIPTION
## Motivation

Fixed missing noise clamp metric evaluation and added proper validation for roofline data in analysis db mode.

## Technical Details

- Add `to_noise_clamp` to analysis_db evaluation context to enable noise clamp metric calculations
- Check for empty roofline data DataFrame before processing to prevent errors
- Emit warning and skip workload when roofline data is missing or filtered
- Apply ruff formatting fixes for line length compliance

## JIRA ID


## Test Plan

Ran analysis mode with `--output db` option and verified no warnings for `noise_clamp` metrics.

## Test Result

Test results pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.