### PR TITLE
[rocprofiler-compute] Install pyproject.toml with tests and add missing pytest markers

### DIFF
--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -788,7 +788,7 @@ if(INSTALL_TESTS)
         )
     endif()
     install(
-        FILES requirements-test.txt
+        FILES requirements-test.txt pyproject.toml
         DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
         COMPONENT tests
     )

--- a/projects/rocprofiler-compute/pyproject.toml
+++ b/projects/rocprofiler-compute/pyproject.toml
@@ -107,6 +107,7 @@ markers = [
     "roofline_2",
     "path",
     "sci_notion",
+    "iteration_multiplexing",
     "iteration_multiplexing_1",
     "iteration_multiplexing_2",
     "iteration_multiplexing_stochastic",
@@ -114,4 +115,8 @@ markers = [
     "torch_ops",
     "multi_rank",
     "experimental_feature",
+    "skip",
+    "time_unit_conversion",
+    "time_unit_edge_cases",
+    "time_unit_integration",
 ]


### PR DESCRIPTION
## Motivation

Allow running tests from the install directory without depending on the project root, and fix pytest warnings for unregistered custom markers (e.g., "PytestUnknownMarkWarning: Unknown pytest.mark.noise_clamp - is this a typo?"). Previously, pyproject.toml (which contains pythonpath and markers configurations) was not installed with the tests.

## Technical Details

- **CMakeLists.txt**: Install `pyproject.toml` to `${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}` when `INSTALL_TESTS=ON` to ensure pytest can find the configuration when running from the install directory
- **pyproject.toml**: Add missing pytest markers that were in use but not registered:
  - `iteration_multiplexing`
  - `skip`
  - `time_unit_conversion`
  - `time_unit_edge_cases`
  - `time_unit_integration`

## JIRA ID



## Test Plan

Install outside of project root with TEST_FROM_INSTALL=ON, then cd to install_dir/libexec/rocprofiler-compute and run ctest and ensure no warnings for missing markers.

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.