### PR TITLE
Fix rocprofv3 pmc crash on gfx1151 (#2169) (#2171)

### DIFF
--- a/projects/aqlprofile/src/core/pm4_factory.h
+++ b/projects/aqlprofile/src/core/pm4_factory.h
@@ -412,11 +412,13 @@ inline bool Pm4Factory::CheckConcurrent(const profile_t* profile) {
 
 // Return GPU id for a given agent
 inline gpu_id_t Pm4Factory::GetGpuId(std::string_view gfx_ip) {
+  // More specific GPU IDs must come before less specific IDs.
   std::vector<std::pair<std::string, gpu_id_t>> gfxip_map = {
       {"gfx908", MI100_GPU_ID}, {"gfx90a", MI200_GPU_ID}, {"gfx900", GFX9_GPU_ID},
       {"gfx902", GFX9_GPU_ID},  {"gfx906", GFX9_GPU_ID},  {"gfx94", MI300_GPU_ID},
-      {"gfx95", MI350_GPU_ID},  {"gfx10", GFX10_GPU_ID},  {"gfx11", GFX11_GPU_ID},
-      {"gfx115", GFX115X_GPU_ID}, {"gfx12", GFX12_GPU_ID},
+      {"gfx95", MI350_GPU_ID},  {"gfx10", GFX10_GPU_ID},
+      {"gfx115", GFX115X_GPU_ID}, {"gfx11", GFX11_GPU_ID},
+      {"gfx12", GFX12_GPU_ID},
   };
 
   for (const auto& [name, id] : gfxip_map) {

--- a/projects/aqlprofile/src/util/hsa_rsrc_factory.cpp
+++ b/projects/aqlprofile/src/util/hsa_rsrc_factory.cpp
@@ -46,11 +46,11 @@
 
 // Callback function to get available in the system agents
 hsa_status_t HsaRsrcFactory::GetHsaAgentsCallback(hsa_agent_t agent, void* data) {
-  hsa_status_t status = HSA_STATUS_ERROR;
   HsaRsrcFactory* hsa_rsrc = reinterpret_cast<HsaRsrcFactory*>(data);
-  const AgentInfo* agent_info = hsa_rsrc->AddAgentInfo(agent);
-  if (agent_info != NULL) status = HSA_STATUS_SUCCESS;
-  return status;
+  // AddAgentInfo may return NULL for unsupported agent types (e.g., NPU).
+  // We should continue iterating regardless.
+  hsa_rsrc->AddAgentInfo(agent);
+  return HSA_STATUS_SUCCESS;
 }
 
 // This function checks to see if the provided

--- a/projects/rocprofiler/src/util/hsa_rsrc_factory.cpp
+++ b/projects/rocprofiler/src/util/hsa_rsrc_factory.cpp
@@ -73,11 +73,11 @@ static const char* cpp_demangle(const char* symname) {
 
 // Callback function to get available in the system agents
 hsa_status_t HsaRsrcFactory::GetHsaAgentsCallback(hsa_agent_t agent, void* data) {
-  hsa_status_t status = HSA_STATUS_ERROR;
   HsaRsrcFactory* hsa_rsrc = reinterpret_cast<HsaRsrcFactory*>(data);
-  const AgentInfo* agent_info = hsa_rsrc->AddAgentInfo(agent);
-  if (agent_info != nullptr) status = HSA_STATUS_SUCCESS;
-  return status;
+  // AddAgentInfo may return NULL for unsupported agent types (e.g., NPU).
+  // We should continue iterating regardless.
+  hsa_rsrc->AddAgentInfo(agent);
+  return HSA_STATUS_SUCCESS;
 }
 
 // This function checks to see if the provided

--- a/projects/rocprofiler/test/util/hsa_rsrc_factory.cpp
+++ b/projects/rocprofiler/test/util/hsa_rsrc_factory.cpp
@@ -56,11 +56,11 @@ static const char* cpp_demangle(const char* symname) {
 
 // Callback function to get available in the system agents
 hsa_status_t HsaRsrcFactory::GetHsaAgentsCallback(hsa_agent_t agent, void* data) {
-  hsa_status_t status = HSA_STATUS_ERROR;
   HsaRsrcFactory* hsa_rsrc = reinterpret_cast<HsaRsrcFactory*>(data);
-  const AgentInfo* agent_info = hsa_rsrc->AddAgentInfo(agent);
-  if (agent_info != NULL) status = HSA_STATUS_SUCCESS;
-  return status;
+  // AddAgentInfo may return NULL for unsupported agent types (e.g., NPU).
+  // We should continue iterating regardless.
+  hsa_rsrc->AddAgentInfo(agent);
+  return HSA_STATUS_SUCCESS;
 }
 
 // This function checks to see if the provided


### PR DESCRIPTION
* Fix #2169: rocprofv3 pmc crash on gfx1151

This PR addresses two issues for gfx1151:
- In Pm4Factory::GetGpuId, the first matching entry from the gfxip_map vector was taken, but "gfx115" came after "gfx11".
- HsaRsrcFactory::GetHsaAgentsCallback would fail when it saw an NPU agent. Now it ignores it and continues.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
