### PR TITLE
[rocprofiler-compute] Add automatic version fallback for ROCm library path resolution

### DIFF
--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from typing import Optional
 
 from utils.logger import console_warning
-from utils.utils import METRIC_ID_RE
+from utils.utils import METRIC_ID_RE, resolve_rocm_library_path
 
 
 class ExperimentalAction(argparse.Action):
@@ -518,12 +518,14 @@ Examples:
     )
     profile_group.add_argument(
         "--rocprofiler-sdk-tool-path",
-        type=str,
+        type=resolve_rocm_library_path,
         dest="rocprofiler_sdk_tool_path",
         required=False,
-        default=str(
-            Path(os.getenv("ROCM_PATH", "/opt/rocm"))
-            / "lib/rocprofiler-sdk/librocprofiler-sdk-tool.so"
+        default=resolve_rocm_library_path(
+            str(
+                Path(os.getenv("ROCM_PATH", "/opt/rocm"))
+                / "lib/rocprofiler-sdk/librocprofiler-sdk-tool.so"
+            )
         ),
         help="\t\t\tSet the path to rocprofiler-sdk tool.",
     )

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -57,6 +57,7 @@ from utils.utils import (
     parse_sets_yaml,
     replace_env,
     replace_rank,
+    resolve_rocm_library_path,
     set_locale_encoding,
 )
 
@@ -158,13 +159,16 @@ class RocProfCompute:
             console_error("Cannot use --list-available-metrics with --blocks")
 
         # fallback to csv output format, if rocpd public api not available
+        rocpd_path = resolve_rocm_library_path(
+            str(
+                Path(self.__args.rocprofiler_sdk_tool_path).parents[1]
+                / "librocprofiler-sdk-rocpd.so"
+            )
+        )
         if (
             self.__mode == "profile"
             and self.__args.format_rocprof_output == "rocpd"
-            and not (
-                Path(self.__args.rocprofiler_sdk_tool_path).parents[1]
-                / "librocprofiler-sdk-rocpd.so"
-            ).exists()
+            and not Path(rocpd_path).exists()
         ):
             console_warning(
                 "rocpd output format is not supported with the "

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
@@ -31,6 +31,7 @@ from typing import Optional, Union
 from rocprof_compute_profile.profiler_base import RocProfCompute_Base
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import console_error, console_log, demarcate
+from utils.utils import consolidate_torch_trace_output, resolve_rocm_library_path
 
 
 class rocprofiler_sdk_profiler(RocProfCompute_Base):
@@ -89,9 +90,11 @@ class rocprofiler_sdk_profiler(RocProfCompute_Base):
             })
             options.pop("LD_PRELOAD", None)
 
-            rocprofiler_attach_library_path = str(
-                Path(args.rocprofiler_sdk_tool_path).parent.parent
-                / "librocprofiler-sdk-rocattach.so"
+            rocprofiler_attach_library_path = resolve_rocm_library_path(
+                str(
+                    Path(args.rocprofiler_sdk_tool_path).parent.parent
+                    / "librocprofiler-sdk-rocattach.so"
+                )
             )
             options.update({
                 "ROCPROF_ATTACH_LIBRARY": rocprofiler_attach_library_path,

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -59,6 +59,7 @@ from utils.utils import (
     is_tcc_channel_counter,
     merge_counters_spatial_multiplex,
     parse_sets_yaml,
+    resolve_rocm_library_path,
 )
 
 
@@ -437,8 +438,8 @@ class OmniSoC_Base:
             except ImportError:
                 console_error("Failed to import rocprofiler-sdk avail module.")
 
-        avail.loadLibrary.libname = str(
-            Path(args.rocprofiler_sdk_tool_path).parent / "librocprofv3-list-avail.so"
+        avail.loadLibrary.libname = resolve_rocm_library_path(
+            str(Path(args.rocprofiler_sdk_tool_path).parent / "librocprofv3-list-avail.so")
         )
         counters = avail.get_counters()
         rocprof_counters = {

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -67,7 +67,15 @@ rocprof_cmd = ""
 rocprof_args = ""
 
 
-def resolve_rocm_library_path(library_path: str) -> str:
+def version_to_numeric(version_parts: list[int], max_len: int) -> int:
+    """Convert version tuple to numeric value using base-1000 positional system."""
+    version_numeric = 0
+    for i, part in enumerate(version_parts):
+        version_numeric += part * (1000 ** (max_len - i - 1))
+    return version_numeric
+
+
+def resolve_rocm_library_path(library_path: Optional[str]) -> Optional[str]:
     """
     Resolve ROCm library path with automatic version fallback.
     Tries exact path first, then falls back to versioned variants
@@ -83,20 +91,42 @@ def resolve_rocm_library_path(library_path: str) -> str:
         console_debug(f"Resolved library (exact match): {path}")
         return str(path)
 
-    # Try finding any versioned variant: libfoo.so.*
-    # This will match .so.1, .so.1.2.3, .so.15, etc.
-    matches = glob.glob(f"{library_path}.*")
+    # Escape the input path so any glob metacharacters are treated literally.
+    matches = glob.glob(f"{glob.escape(library_path)}.*")
 
-    if matches:
-        # Sort to get most specific version (e.g., .so.1.2.3 before .so.1)
-        # Then pick the most specific one
-        resolved = sorted(matches, key=lambda x: x.count("."), reverse=True)[0]
-        console_debug(f"Resolved library (versioned): {library_path} -> {resolved}")
-        return resolved
+    # First pass: filter to numeric versions and collect version tuples
+    version_tuples: list[tuple[list[int], str]] = []
+    for candidate in matches:
+        # Compute the suffix relative to the requested library path.
+        if not candidate.startswith(library_path):
+            continue
+        suffix = candidate[len(library_path) :]
+        # Expect a suffix like ".1" or ".1.2.3"
+        if not suffix.startswith("."):
+            continue
+        parts = suffix.split(".")[1:]  # drop leading empty element
+        if not parts:
+            continue
+        if not all(part.isdigit() for part in parts):
+            continue
+        version_tuples.append(([int(p) for p in parts], candidate))
 
-    # Not found, return original (validation will handle error later)
-    console_debug(f"Library not found (will try original path): {library_path}")
-    return library_path
+    # Find max version length to normalize all versions
+    if not version_tuples:
+        raise FileNotFoundError(f"ROCm library not found: {library_path}")
+
+    # Second pass: convert to numeric values with normalized length
+    max_version_len = max(len(vt[0]) for vt in version_tuples)
+    versioned_candidates: list[tuple[int, str]] = []
+    for version_parts, candidate in version_tuples:
+        version_numeric = version_to_numeric(version_parts, max_version_len)
+        versioned_candidates.append((version_numeric, candidate))
+
+    # Select the candidate with the highest numeric version.
+    versioned_candidates.sort(key=lambda item: item[0], reverse=True)
+    resolved = versioned_candidates[0][1]
+    console_debug(f"Resolved library (versioned): {library_path} -> {resolved}")
+    return resolved
 
 
 def is_tcc_channel_counter(counter: str) -> bool:

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -67,6 +67,57 @@ rocprof_cmd = ""
 rocprof_args = ""
 
 
+def resolve_rocm_library_path(library_path: str) -> str:
+    """
+    Resolve ROCm library path with automatic version fallback.
+
+    Linux shared libraries follow the pattern:
+      libfoo.so -> libfoo.so.X -> libfoo.so.X.Y.Z
+
+    This function tries:
+    1. Exact path (e.g., libfoo.so)
+    2. Any versioned variant in same directory (e.g., libfoo.so.*)
+
+    Args:
+        library_path: Path to library (versioned or unversioned)
+
+    Returns:
+        Resolved library path (original if not found)
+
+    Example:
+        Input:  /path/libfoo.so
+        Tries:  /path/libfoo.so
+                /path/libfoo.so.* (using glob)
+        Returns: /path/libfoo.so.1 (if that's what exists)
+    """
+    if not library_path:
+        return library_path
+
+    path = Path(library_path)
+
+    # Try exact path first (handles both unversioned and explicit versioned paths)
+    if path.exists():
+        console_debug(f"Resolved library (exact match): {path}")
+        return str(path)
+
+    # Try finding any versioned variant: libfoo.so.*
+    # This will match .so.1, .so.1.2.3, .so.15, etc.
+    versioned_pattern = f"{library_path}.*"
+    matches = glob.glob(versioned_pattern)
+
+    if matches:
+        # Sort to get most specific version (e.g., .so.1.2.3 before .so.1)
+        # Then pick the most specific one
+        matches_sorted = sorted(matches, key=lambda x: x.count('.'), reverse=True)
+        resolved = matches_sorted[0]
+        console_debug(f"Resolved library (versioned): {library_path} -> {resolved}")
+        return resolved
+
+    # Not found, return original (validation will handle error later)
+    console_debug(f"Library not found (will try original path): {library_path}")
+    return library_path
+
+
 def is_tcc_channel_counter(counter: str) -> bool:
     return counter.startswith("TCC") and counter.endswith("]")
 

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -70,25 +70,8 @@ rocprof_args = ""
 def resolve_rocm_library_path(library_path: str) -> str:
     """
     Resolve ROCm library path with automatic version fallback.
-
-    Linux shared libraries follow the pattern:
-      libfoo.so -> libfoo.so.X -> libfoo.so.X.Y.Z
-
-    This function tries:
-    1. Exact path (e.g., libfoo.so)
-    2. Any versioned variant in same directory (e.g., libfoo.so.*)
-
-    Args:
-        library_path: Path to library (versioned or unversioned)
-
-    Returns:
-        Resolved library path (original if not found)
-
-    Example:
-        Input:  /path/libfoo.so
-        Tries:  /path/libfoo.so
-                /path/libfoo.so.* (using glob)
-        Returns: /path/libfoo.so.1 (if that's what exists)
+    Tries exact path first, then falls back to versioned variants
+    (e.g., .so.1, .so.1.2.3).
     """
     if not library_path:
         return library_path
@@ -102,14 +85,12 @@ def resolve_rocm_library_path(library_path: str) -> str:
 
     # Try finding any versioned variant: libfoo.so.*
     # This will match .so.1, .so.1.2.3, .so.15, etc.
-    versioned_pattern = f"{library_path}.*"
-    matches = glob.glob(versioned_pattern)
+    matches = glob.glob(f"{library_path}.*")
 
     if matches:
         # Sort to get most specific version (e.g., .so.1.2.3 before .so.1)
         # Then pick the most specific one
-        matches_sorted = sorted(matches, key=lambda x: x.count('.'), reverse=True)
-        resolved = matches_sorted[0]
+        resolved = sorted(matches, key=lambda x: x.count("."), reverse=True)[0]
         console_debug(f"Resolved library (versioned): {library_path} -> {resolved}")
         return resolved
 

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -8233,3 +8233,49 @@ def test_experimental_action_help_suppression():
 
     # Help should be suppressed
     assert "--test-exp-feature" not in help_text, f"{help_text}"
+
+
+# =============================================================================
+# Test rocm library resolver
+# =============================================================================
+
+
+@pytest.mark.misc
+def test_resolve_rocm_library_path(monkeypatch, tmp_path):
+    """Test resolve_rocm_library_path with various scenarios."""
+    from utils.utils import resolve_rocm_library_path
+
+    # Test case 1: Empty path returns as-is
+    assert resolve_rocm_library_path("") == ""
+    assert resolve_rocm_library_path(None) is None
+
+    # Test case 2: Exact path exists (unversioned)
+    unversioned = tmp_path / "libtest.so"
+    unversioned.touch()
+    assert resolve_rocm_library_path(str(unversioned)) == str(unversioned)
+
+    # Test case 3: Exact path exists (already versioned)
+    versioned = tmp_path / "libfoo.so.1"
+    versioned.touch()
+    assert resolve_rocm_library_path(str(versioned)) == str(versioned)
+
+    # Test case 4: Unversioned doesn't exist, fallback to versioned variant
+    nonexistent = tmp_path / "libbar.so"
+    versioned_bar = tmp_path / "libbar.so.1"
+    versioned_bar.touch()
+    assert resolve_rocm_library_path(str(nonexistent)) == str(versioned_bar)
+
+    # Test case 5: Multiple versioned files, pick most specific
+    multi_base = tmp_path / "libmulti.so"
+    v1 = tmp_path / "libmulti.so.1"
+    v123 = tmp_path / "libmulti.so.1.2.3"
+    v12 = tmp_path / "libmulti.so.1.2"
+    v1.touch()
+    v123.touch()
+    v12.touch()
+    # Should pick .so.1.2.3 (most dots)
+    assert resolve_rocm_library_path(str(multi_base)) == str(v123)
+
+    # Test case 6: No match at all, return original path
+    missing = tmp_path / "libmissing.so"
+    assert resolve_rocm_library_path(str(missing)) == str(missing)

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -8241,7 +8241,36 @@ def test_experimental_action_help_suppression():
 
 
 @pytest.mark.misc
-def test_resolve_rocm_library_path(monkeypatch, tmp_path):
+def test_version_to_numeric():
+    """Test version_to_numeric helper function."""
+    from utils.utils import version_to_numeric
+
+    # Test normalized to max_len=3
+    max_len = 3
+
+    # Single component versions
+    assert version_to_numeric([2], max_len) == 2_000_000  # 2 * 1000^2
+    assert version_to_numeric([10], max_len) == 10_000_000  # 10 * 1000^2
+    assert version_to_numeric([15], max_len) == 15_000_000  # 15 * 1000^2
+
+    # Multi-component versions
+    assert version_to_numeric([1, 2, 3], max_len) == 1_002_003  # 1*1000^2 + 2*1000 + 3
+    assert version_to_numeric([2, 5, 3], max_len) == 2_005_003  # 2*1000^2 + 5*1000 + 3
+    assert version_to_numeric([1, 2], max_len) == 1_002_000  # 1*1000^2 + 2*1000
+
+    # Version comparisons - higher version numbers should produce higher values
+    assert version_to_numeric([10], max_len) > version_to_numeric([2], max_len)
+    assert version_to_numeric([10], max_len) > version_to_numeric([1, 2, 3], max_len)
+    assert version_to_numeric([2], max_len) > version_to_numeric([1, 2, 3], max_len)
+    assert version_to_numeric([2, 5, 3], max_len) > version_to_numeric([2], max_len)
+    assert version_to_numeric([1, 2, 3], max_len) > version_to_numeric([1, 2], max_len)
+
+    # Edge case: version components support 0-999
+    assert version_to_numeric([999, 999, 999], max_len) == 999_999_999
+
+
+@pytest.mark.misc
+def test_resolve_rocm_library_path(tmp_path):
     """Test resolve_rocm_library_path with various scenarios."""
     from utils.utils import resolve_rocm_library_path
 
@@ -8265,17 +8294,39 @@ def test_resolve_rocm_library_path(monkeypatch, tmp_path):
     versioned_bar.touch()
     assert resolve_rocm_library_path(str(nonexistent)) == str(versioned_bar)
 
-    # Test case 5: Multiple versioned files, pick most specific
+    # Test case 5: Multiple versioned files, pick highest version deterministically
     multi_base = tmp_path / "libmulti.so"
     v1 = tmp_path / "libmulti.so.1"
     v123 = tmp_path / "libmulti.so.1.2.3"
     v12 = tmp_path / "libmulti.so.1.2"
+    v2 = tmp_path / "libmulti.so.2"
     v1.touch()
     v123.touch()
     v12.touch()
-    # Should pick .so.1.2.3 (most dots)
-    assert resolve_rocm_library_path(str(multi_base)) == str(v123)
+    v2.touch()
+    # Should pick .so.2 (highest major version)
+    assert resolve_rocm_library_path(str(multi_base)) == str(v2)
 
-    # Test case 6: No match at all, return original path
+    # Test case 6: Filters out non-numeric suffixes (e.g., .so.debug)
+    filter_base = tmp_path / "libfilter.so"
+    numeric_version = tmp_path / "libfilter.so.1"
+    debug_file = tmp_path / "libfilter.so.debug"
+    numeric_version.touch()
+    debug_file.touch()
+    # Should pick .so.1, not .so.debug
+    assert resolve_rocm_library_path(str(filter_base)) == str(numeric_version)
+
+    # Test case 7: Version comparison edge cases
+    # 10.0 should beat 2.5.3 (not string comparison)
+    version_base = tmp_path / "libversion.so"
+    v10 = tmp_path / "libversion.so.10"
+    v253 = tmp_path / "libversion.so.2.5.3"
+    v10.touch()
+    v253.touch()
+    # Should pick .so.10 (10 > 2 in first position)
+    assert resolve_rocm_library_path(str(version_base)) == str(v10)
+
+    # Test case 8: No match at all, raises FileNotFoundError
     missing = tmp_path / "libmissing.so"
-    assert resolve_rocm_library_path(str(missing)) == str(missing)
+    with pytest.raises(FileNotFoundError, match="ROCm library not found"):
+        resolve_rocm_library_path(str(missing))


### PR DESCRIPTION
## Motivation
rocprofiler-compute fails in environments where ROCm libraries are installed only as versioned .so files (e.g., librocprofiler-sdk-tool.so.1) without unversioned symlinks. This commonly occurs in PyTorch ROCm containers where ROCm is installed via pip packages. This change adds automatic version fallback to find and use versioned libraries when unversioned ones don't exist, eliminating the need for container modifications or manual symlink creation.

## Technical Details
- Implemented `resolve_rocm_library_path()` utility function in `src/utils/utils.py` that uses glob pattern matching to find versioned .so files
- Resolution strategy: tries exact path first, then falls back to `*.so.*` pattern to find any versioned variant (e.g., .so.1, .so.1.2.3, .so.15)
- Applied version resolution to all ROCm SDK library paths:
  * `--rocprofiler-sdk-tool-path` argument in argparser.py (both type and default parameters)
  * librocprofiler-sdk-rocattach.so in profiler_rocprofiler_sdk.py
  * librocprofv3-list-avail.so in soc_base.py
  * librocprofiler-sdk-rocpd.so in rocprof_compute_base.py
- Resolution happens during argument parsing for the main tool path, and at runtime for derived library paths
- Includes debug logging to show which path was resolved
- No hardcoded version numbers or ROCm version detection - uses glob to discover any version dynamically

## JIRA ID

## Test Plan
Simulated PyTorch container environment by removing unversioned .so symlinks. Verified failure with original code, success with fix. Tested backward compatibility with unversioned files restored. Added comprehensive unit tests.

## Test Result
Fix successfully resolves versioned library paths (e.g., librocprofiler-sdk-tool.so.1) when unversioned files are missing. Backward compatibility confirmed - unversioned .so files still work correctly when present. Unit tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.