### PR TITLE
[rocprofiler-sdk] Improve stability and logging of finalization

### DIFF
--- a/projects/rocprofiler-sdk/samples/counter_collection/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/samples/counter_collection/CMakeLists.txt
@@ -49,7 +49,8 @@ target_link_libraries(counter-collection-buffer PRIVATE counter-collection-buffe
 rocprofiler_samples_get_ld_library_path_env(LIBRARY_PATH_ENV)
 rocprofiler_samples_get_preload_env(PRELOAD_ENV counter-collection-buffer-client)
 
-set(counter-collection-buffer-env "${PRELOAD_ENV}" "${LIBRARY_PATH_ENV}")
+set(counter-collection-buffer-env "${PRELOAD_ENV}" "${LIBRARY_PATH_ENV}"
+                                  "ROCPROFILER_LOG_FAILURE_HANDLER=true")
 
 add_test(NAME counter-collection-buffer COMMAND $<TARGET_FILE:counter-collection-buffer>)
 
@@ -76,8 +77,8 @@ target_link_libraries(counter-collection-buffer-device-serialization
 rocprofiler_samples_get_ld_library_path_env(LIBRARY_PATH_ENV)
 rocprofiler_samples_get_preload_env(PRELOAD_ENV counter-collection-buffer-client)
 
-set(counter-collection-buffer-device-serialization-env "${PRELOAD_ENV}"
-                                                       "${LIBRARY_PATH_ENV}")
+set(counter-collection-buffer-device-serialization-env
+    "${PRELOAD_ENV}" "${LIBRARY_PATH_ENV}" "ROCPROFILER_LOG_FAILURE_HANDLER=true")
 
 add_test(NAME counter-collection-buffer-device-serialization
          COMMAND $<TARGET_FILE:counter-collection-buffer-device-serialization>)
@@ -103,7 +104,8 @@ target_link_libraries(counter-collection-callback
 
 rocprofiler_samples_get_preload_env(PRELOAD_ENV counter-collection-callback-client)
 
-set(counter-collection-callback-env "${PRELOAD_ENV}" "${LIBRARY_PATH_ENV}")
+set(counter-collection-callback-env "${PRELOAD_ENV}" "${LIBRARY_PATH_ENV}"
+                                    "ROCPROFILER_LOG_FAILURE_HANDLER=true")
 
 add_test(NAME counter-collection-callback
          COMMAND $<TARGET_FILE:counter-collection-callback>)
@@ -138,7 +140,8 @@ target_link_libraries(
 rocprofiler_samples_get_preload_env(PRELOAD_ENV
                                     counter-collection-functional-counter-client)
 
-set(counter-collection-functional-counter-env "${PRELOAD_ENV}" "${LIBRARY_PATH_ENV}")
+set(counter-collection-functional-counter-env "${PRELOAD_ENV}" "${LIBRARY_PATH_ENV}"
+                                              "ROCPROFILER_LOG_FAILURE_HANDLER=true")
 
 add_test(NAME counter-collection-print-functional-counters
          COMMAND $<TARGET_FILE:counter-collection-print-functional-counters>)
@@ -165,7 +168,8 @@ target_link_libraries(counter-collection-device-profiling
 rocprofiler_samples_get_preload_env(PRELOAD_ENV
                                     counter-collection-device-profiling-client)
 
-set(counter-collection-functional-counter-env "${PRELOAD_ENV}" "${LIBRARY_PATH_ENV}")
+set(counter-collection-functional-counter-env "${PRELOAD_ENV}" "${LIBRARY_PATH_ENV}"
+                                              "ROCPROFILER_LOG_FAILURE_HANDLER=true")
 
 add_test(NAME counter-collection-device-profiling
          COMMAND $<TARGET_FILE:counter-collection-device-profiling>)
@@ -200,7 +204,8 @@ target_link_libraries(
 rocprofiler_samples_get_preload_env(PRELOAD_ENV
                                     counter-collection-device-profiling-sync-client)
 
-set(counter-collection-functional-counter-env "${PRELOAD_ENV}" "${LIBRARY_PATH_ENV}")
+set(counter-collection-functional-counter-env "${PRELOAD_ENV}" "${LIBRARY_PATH_ENV}"
+                                              "ROCPROFILER_LOG_FAILURE_HANDLER=true")
 
 add_test(NAME counter-collection-device-profiling-sync
          COMMAND $<TARGET_FILE:counter-collection-device-profiling-sync>)

--- a/projects/rocprofiler-sdk/samples/counter_collection/device_counting_sync_client.cpp
+++ b/projects/rocprofiler-sdk/samples/counter_collection/device_counting_sync_client.cpp
@@ -376,20 +376,25 @@ tool_init(rocprofiler_client_finalize_t fini_func, void*)
     sampler = std::make_shared<counter_sampler>(agents[0].id);
 
     sampler_thread = new std::thread{[=]() {
-        size_t                                    count = 1;
-        std::vector<rocprofiler_counter_record_t> records;
+        size_t count = 1;
         while(sampler && exit_toggle().load() == false)
         {
-            auto status = sampler->sample_counter_values({"SQ_WAVES"}, records);
+            auto records = std::vector<rocprofiler_counter_record_t>{};
+            auto status  = sampler->sample_counter_values({"SQ_WAVES"}, records);
             if(status == ROCPROFILER_STATUS_ERROR_HSA_NOT_LOADED)
             {
                 std::clog << "HSA not loaded yet....\n";
-                std::this_thread::sleep_for(std::chrono::milliseconds(50));
-                continue;
             }
-            std::clog << "Sample " << count << ":\n";
+            else if(status != ROCPROFILER_STATUS_SUCCESS)
+            {
+                std::clog << "Error sampling counter values: "
+                          << rocprofiler_get_status_name(status)
+                          << " :: " << rocprofiler_get_status_string(status) << "\n";
+            }
+
             if(status == ROCPROFILER_STATUS_SUCCESS)
             {
+                std::clog << "Sample " << count << ":\n";
                 for(const auto& record : records)
                 {
                     if(!sampler) break;
@@ -407,11 +412,12 @@ tool_init(rocprofiler_client_finalize_t fini_func, void*)
                         }
                     }
                 }
+                count++;
             }
-            count++;
-            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+            if(exit_toggle().load() == false)
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
         }
-        exit_toggle().store(false);
     }};
 
     // no errors
@@ -424,22 +430,27 @@ tool_fini(void* user_data)
     std::clog << "In tool fini\n" << std::flush;
 
     client_id = nullptr;
+    finalize  = nullptr;
 
     exit_toggle().store(true);
-    while(exit_toggle().load() == true)
-    {};
 
+    std::clog << "Waiting for sampler thread to exit...\n" << std::flush;
+    sampler_thread->join();
+
+    std::clog << "Stopping and flushing sampler...\n" << std::flush;
     sampler->stop();
     sampler->flush();
 
-    sampler_thread->join();
-
+    std::clog << "Flushing output stream...\n" << std::flush;
     auto* output_stream = static_cast<std::ostream*>(user_data);
     *output_stream << std::flush;
     if(output_stream != &std::cout && output_stream != &std::cerr) delete output_stream;
 
-    sampler.reset();
+    std::clog << "Deleting sampler thread...\n" << std::flush;
     delete sampler_thread;
+
+    std::clog << "Deleting sampler...\n" << std::flush;
+    sampler.reset();
 
     std::clog << "Completed tool fini\n" << std::flush;
 }

--- a/projects/rocprofiler-sdk/samples/counter_collection/print_functional_counters_client.cpp
+++ b/projects/rocprofiler-sdk/samples/counter_collection/print_functional_counters_client.cpp
@@ -369,8 +369,6 @@ tool_fini(void*)
 {
     rocprofiler_flush_buffer(get_buffer());
     rocprofiler_stop_context(get_client_ctx());
-    // Flush buffer isn't waiting....
-    sleep(2);
 
     std::clog << "In tool fini\n";
 

--- a/projects/rocprofiler-sdk/source/lib/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/common/CMakeLists.txt
@@ -15,6 +15,7 @@ set(common_sources
     static_object.cpp
     static_tl_object.cpp
     string_entry.cpp
+    thread_activity.cpp
     utility.cpp
     uuid_v7.cpp)
 set(common_headers
@@ -37,6 +38,7 @@ set(common_headers
     string_entry.hpp
     stringize_arg.hpp
     synchronized.hpp
+    thread_activity.hpp
     units.hpp
     utility.hpp
     uuid_v7.hpp)

--- a/projects/rocprofiler-sdk/source/lib/common/thread_activity.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/thread_activity.cpp
@@ -311,9 +311,10 @@ task_set_t
 get_tasks(pid_t _pid, const task_set_t& exclude_tasks)
 {
     auto _tasks = task_set_t{};
+    auto _ec    = std::error_code{};
 
     ROCP_TRACE << fmt::format("Reading tasks in /proc/{}/task/*", _pid);
-    for(const auto& itr : fs::directory_iterator{fs::path{fmt::format("/proc/{}/task", _pid)}})
+    for(const auto& itr : fs::directory_iterator{fs::path{fmt::format("/proc/{}/task", _pid)}, _ec})
     {
         if(auto path = fs::path{itr}; fs::exists(path / "stat") || fs::exists(path / "schedstat"))
         {
@@ -334,6 +335,9 @@ get_tasks(pid_t _pid, const task_set_t& exclude_tasks)
             }
         }
     }
+
+    ROCP_CI_LOG_IF(WARNING, _ec) << fmt::format(
+        "Error while reading tasks in /proc/{}/task: {} :: {}", _pid, _ec.value(), _ec.message());
 
     ROCP_TRACE << fmt::format("Found {} tasks in /proc/{}/task", _tasks.size(), _pid);
     return _tasks;
@@ -362,7 +366,7 @@ poll_tasks(task_set_t&               tasks,
     };
 
     auto get_tasks = [&tasks]() {
-        auto _tasks = tasks;
+        auto _tasks = task_set_t{};
         for(const auto& task : tasks)
         {
             if(task) _tasks.emplace(task);
@@ -420,6 +424,8 @@ poll_tasks(task_set_t&               tasks,
 
         if(bool should_stop = predicate(_data); should_stop) break;
 
+        // refresh baseline so that deltas are computed against the previous sample
+        _base_samples = std::move(_current_samples);
     } while(get_elapsed_time() < timeout);
 
     return _data;

--- a/projects/rocprofiler-sdk/source/lib/common/thread_activity.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/thread_activity.cpp
@@ -136,16 +136,21 @@ read_stat(const task_info& task)
 status
 classify(const sample& _data)
 {
+    constexpr auto min_runtime_ns   = 0UL;
+    constexpr auto min_time_ticks   = 0UL;
+    constexpr auto min_run_queue_ns = 0UL;
+
     // Strongest signals first
-    if(_data.schedstat.has_value() && _data.schedstat->run_time_ns > 0)
+    if(_data.schedstat.has_value() && _data.schedstat->run_time_ns > min_runtime_ns)
     {
         return status::ActiveOnCPU;
     }
-    else if(_data.stat.has_value() && (_data.stat->utime_ticks + _data.stat->stime_ticks) > 0)
+    else if(_data.stat.has_value() &&
+            (_data.stat->utime_ticks + _data.stat->stime_ticks) > min_time_ticks)
     {
         return status::ActiveOnCPU;
     }
-    else if(_data.schedstat.has_value() && _data.schedstat->run_queue_ns > 0)
+    else if(_data.schedstat.has_value() && _data.schedstat->run_queue_ns > min_run_queue_ns)
     {
         return status::RunnableWaiting;
     }
@@ -164,7 +169,7 @@ classify(const sample& _data)
 }
 
 bool
-default_poll_tasks_predicate(const std::map<task_info, status>& data)
+default_poll_tasks_predicate(const task_status_map_t& data)
 {
     uint64_t gone    = 0;
     uint64_t unknown = 0;
@@ -302,10 +307,10 @@ task_info::operator bool() const
 
 sample::operator bool() const { return (task && (schedstat.has_value() || stat.has_value())); }
 
-std::set<task_info>
-get_tasks(pid_t _pid, const std::set<task_info>& exclude_tasks)
+task_set_t
+get_tasks(pid_t _pid, const task_set_t& exclude_tasks)
 {
-    auto _tasks = std::set<task_info>{};
+    auto _tasks = task_set_t{};
 
     ROCP_TRACE << fmt::format("Reading tasks in /proc/{}/task/*", _pid);
     for(const auto& itr : fs::directory_iterator{fs::path{fmt::format("/proc/{}/task", _pid)}})
@@ -340,13 +345,13 @@ get_sample(const task_info& task)
     return sample{task, read_schedstat(task), read_stat(task)};
 }
 
-std::map<task_info, status>
-poll_tasks(std::set<task_info>&      tasks,
+task_status_map_t
+poll_tasks(task_set_t&               tasks,
            poll_tasks_predicate_t    predicate,
            std::chrono::milliseconds min_interval,
            std::chrono::milliseconds timeout)
 {
-    auto _data       = std::map<task_info, status>{};
+    auto _data       = task_status_map_t{};
     auto _start_time = std::chrono::steady_clock::now();
 
     if(!predicate) predicate = &default_poll_tasks_predicate;

--- a/projects/rocprofiler-sdk/source/lib/common/thread_activity.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/thread_activity.cpp
@@ -1,0 +1,425 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "lib/common/thread_activity.hpp"
+#include "lib/common/filesystem.hpp"
+#include "lib/common/logging.hpp"
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
+#include <sstream>
+#include <string>
+
+namespace rocprofiler
+{
+namespace common
+{
+namespace thread_activity
+{
+namespace
+{
+namespace fs = ::rocprofiler::common::filesystem;
+
+std::optional<task_schedstat>
+read_schedstat(const task_info& task)
+{
+    auto _inp = fs::path{task.path} / "schedstat";
+    if(!fs::exists(_inp)) return std::nullopt;
+
+    auto _data = task_schedstat{};
+    if(auto ifs = std::ifstream{_inp}; ifs.is_open())
+    {
+        auto line = std::string{};
+        std::getline(ifs, line);
+        if(!ifs) return std::nullopt;
+
+        auto iss = std::istringstream{line};
+        if(!(iss >> _data.run_time_ns >> _data.run_queue_ns >> _data.timeslices))
+            return std::nullopt;
+
+        return _data;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<task_stat>
+read_stat(const task_info& task)
+{
+    auto _inp = fs::path{task.path} / "stat";
+    if(!fs::exists(_inp)) return std::nullopt;
+
+    auto _data = task_stat{};
+    if(auto ifs = std::ifstream{_inp}; ifs.is_open())
+    {
+        auto line = std::string{};
+        std::getline(ifs, line);
+        if(!ifs || line.empty()) return std::nullopt;
+
+        // Find the last ')' that ends comm
+        auto rparen = line.rfind(')');
+        if(rparen == std::string::npos) return std::nullopt;
+
+        // After ") " should be: state then the rest of fields
+        // Example: "12345 (my thread) R 1 2 3 ... "
+        if(rparen + 2 >= line.size()) return std::nullopt;
+
+        auto _get_status = [&task](char _state) {
+            switch(_state)
+            {
+                // 'R' == runnable but we saw no CPU in our window
+                case 'R': return status::RunnableWaiting;
+                case 'S': return status::Sleeping;
+                case 'D': return status::BlockedUninterruptible;
+                case 'T':
+                case 't': return status::StoppedOrTraced;
+                case 'Z': return status::Zombie;
+                case 'X': return status::Dead;
+                case 'W': return status::Paging;
+                case 'P': return status::Parked;
+            }
+
+            ROCP_CI_LOG(INFO) << fmt::format(
+                "Unknown thread state for {} ({}): '{}'", task.id, task.path, _state);
+            return status::Unknown;
+        };
+
+        // state is the char after ") "
+        auto state  = line.at(rparen + 2);
+        _data.state = _get_status(state);
+
+        // The remainder after state+space contains fields starting from ppid (field 4)
+        // We need utime (field 14) and stime (field 15), counting from the beginning.
+        // Since we already consumed fields 1-3 (pid, comm, state),
+        // the remainder begins at field 4.
+        auto rest = std::string{};
+        if(rparen + 4 <= line.size()) rest = line.substr(rparen + 4);
+
+        auto iss = std::istringstream{rest};
+
+        // Fields 4..13: 10 numbers to skip (ppid..cmajflt)
+        // Then field 14: utime, field 15: stime.
+        for(int i = 0; i < 10; ++i)
+        {
+            uint64_t skip = 0;
+            if(!(iss >> skip)) return std::nullopt;
+        }
+
+        if(!(iss >> _data.utime_ticks >> _data.stime_ticks)) return std::nullopt;
+
+        return _data;
+    }
+
+    return std::nullopt;
+}
+
+status
+classify(const sample& _data)
+{
+    // Strongest signals first
+    if(_data.schedstat.has_value() && _data.schedstat->run_time_ns > 0)
+    {
+        return status::ActiveOnCPU;
+    }
+    else if(_data.stat.has_value() && (_data.stat->utime_ticks + _data.stat->stime_ticks) > 0)
+    {
+        return status::ActiveOnCPU;
+    }
+    else if(_data.schedstat.has_value() && _data.schedstat->run_queue_ns > 0)
+    {
+        return status::RunnableWaiting;
+    }
+    else if(_data.stat.has_value())
+    {
+        // If no CPU delta, use state as a hint
+        return _data.stat->state;
+    }
+    else if(!_data.task)
+    {
+        // task disappeared
+        return status::Gone;
+    }
+
+    return status::Unknown;
+}
+
+bool
+default_poll_tasks_predicate(const std::map<task_info, status>& data)
+{
+    uint64_t gone    = 0;
+    uint64_t unknown = 0;
+    for(const auto& [task, status] : data)
+    {
+        ROCP_TRACE << fmt::format("Task {} status: {}", task, status);
+        if(status == status::Unknown)
+            ++unknown;
+        else if(status == status::Gone)
+            ++gone;
+    }
+
+    ROCP_TRACE << fmt::format(
+        "default_poll_tasks_predicate: {}/{} tasks are Gone ({}) or Unknown ({})",
+        gone + unknown,
+        data.size(),
+        gone,
+        unknown);
+
+    // return true to stop because all tasks are either gone or unknown, false to keep polling until
+    // timeout
+    return ((gone + unknown) == data.size());
+}
+}  // namespace
+
+namespace operators
+{
+bool
+operator==(const task_info& lhs, const task_info& rhs)
+{
+    return std::tie(lhs.id, lhs.path) == std::tie(rhs.id, rhs.path);
+}
+
+bool
+operator<(const task_info& lhs, const task_info& rhs)
+{
+    return std::tie(lhs.id, lhs.path) < std::tie(rhs.id, rhs.path);
+}
+
+bool
+operator<(task_schedstat lhs, task_schedstat rhs)
+{
+    return std::tie(lhs.run_time_ns, lhs.run_queue_ns, lhs.timeslices) <
+           std::tie(rhs.run_time_ns, rhs.run_queue_ns, rhs.timeslices);
+}
+
+bool
+operator<(task_stat lhs, task_stat rhs)
+{
+    auto _lhs_ticks = lhs.utime_ticks + lhs.stime_ticks;
+    auto _rhs_ticks = rhs.utime_ticks + rhs.stime_ticks;
+    return std::tie(_lhs_ticks, lhs.state) < std::tie(_rhs_ticks, rhs.state);
+}
+
+task_schedstat&
+operator-=(task_schedstat& lhs, task_schedstat rhs)
+{
+    if(lhs < rhs) std::swap(lhs, rhs);
+
+    lhs.run_time_ns -= rhs.run_time_ns;
+    lhs.run_queue_ns -= rhs.run_queue_ns;
+    lhs.timeslices -= rhs.timeslices;
+
+    return lhs;
+}
+
+task_stat&
+operator-=(task_stat& lhs, task_stat rhs)
+{
+    if(lhs < rhs) std::swap(lhs, rhs);
+
+    lhs.utime_ticks -= rhs.utime_ticks;
+    lhs.stime_ticks -= rhs.stime_ticks;
+    lhs.state = std::min(lhs.state, rhs.state);  // keep the "less active" state
+    return lhs;
+}
+
+sample&
+operator-=(sample& lhs, const sample& rhs)
+{
+    if(lhs.task == rhs.task)
+    {
+        if(lhs.schedstat && rhs.schedstat)
+        {
+            *lhs.schedstat -= *rhs.schedstat;
+        }
+
+        if(lhs.stat && rhs.stat)
+        {
+            *lhs.stat -= *rhs.stat;
+        }
+    }
+    else
+    {
+        ROCP_CI_LOG(INFO) << fmt::format(
+            "operator-(sample, sample) called on two different tasks ({} vs {})",
+            lhs.task.id,
+            rhs.task.id);
+    }
+
+    return lhs;
+}
+
+task_schedstat
+operator-(task_schedstat lhs, task_schedstat rhs)
+{
+    return (lhs -= rhs);
+}
+
+task_stat
+operator-(task_stat lhs, task_stat rhs)
+{
+    return (lhs -= rhs);
+}
+
+sample
+operator-(const sample& lhs, const sample& rhs)
+{
+    if(lhs.task == rhs.task)
+    {
+        auto _ret = lhs;  // make a copy
+        return (_ret -= rhs);
+    }
+
+    // return a sample with only the task info if tasks don't match
+    return sample{lhs.task, std::nullopt, std::nullopt};
+}
+}  // namespace operators
+
+task_info::operator bool() const
+{
+    if(id == 0 || path.empty()) return false;
+    return fs::exists(fs::path{path} / "stat");
+}
+
+sample::operator bool() const { return (task && (schedstat.has_value() || stat.has_value())); }
+
+std::set<task_info>
+get_tasks(pid_t _pid, const std::set<task_info>& exclude_tasks)
+{
+    auto _tasks = std::set<task_info>{};
+
+    ROCP_TRACE << fmt::format("Reading tasks in /proc/{}/task/*", _pid);
+    for(const auto& itr : fs::directory_iterator{fs::path{fmt::format("/proc/{}/task", _pid)}})
+    {
+        if(auto path = fs::path{itr}; fs::exists(path / "stat") || fs::exists(path / "schedstat"))
+        {
+            ROCP_TRACE << fmt::format("- Reading task info from {}", path.string());
+
+            auto _id   = std::stoull(path.filename().string());
+            auto _task = task_info{_id, path.string()};
+            if(exclude_tasks.count(_task) == 0u)
+            {
+                ROCP_TRACE << fmt::format(
+                    "   - Including task {} ({}) in get_tasks result", _id, path.string());
+                _tasks.emplace(_task);
+            }
+            else
+            {
+                ROCP_TRACE << fmt::format(
+                    "   - Excluding task {} ({}) from get_tasks result", _id, path.string());
+            }
+        }
+    }
+
+    ROCP_TRACE << fmt::format("Found {} tasks in /proc/{}/task", _tasks.size(), _pid);
+    return _tasks;
+}
+
+sample
+get_sample(const task_info& task)
+{
+    return sample{task, read_schedstat(task), read_stat(task)};
+}
+
+std::map<task_info, status>
+poll_tasks(std::set<task_info>&      tasks,
+           poll_tasks_predicate_t    predicate,
+           std::chrono::milliseconds min_interval,
+           std::chrono::milliseconds timeout)
+{
+    auto _data       = std::map<task_info, status>{};
+    auto _start_time = std::chrono::steady_clock::now();
+
+    if(!predicate) predicate = &default_poll_tasks_predicate;
+
+    auto get_elapsed_time = [&_start_time]() {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - _start_time);
+    };
+
+    auto get_tasks = [&tasks]() {
+        auto _tasks = tasks;
+        for(const auto& task : tasks)
+        {
+            if(task) _tasks.emplace(task);
+        }
+        return _tasks;
+    };
+
+    auto get_samples = [](const auto& _tasks) {
+        auto _samples = std::unordered_map<task_info, sample>{};
+        _samples.reserve(_tasks.size());
+        for(const auto& itr : _tasks)
+        {
+            auto sample = get_sample(itr);
+            if(sample) _samples.emplace(itr, sample);
+        }
+        return _samples;
+    };
+
+    auto _base_samples = get_samples(tasks);
+    do
+    {
+        std::this_thread::sleep_for(min_interval);
+        auto _current_tasks   = get_tasks();
+        auto _current_samples = get_samples(_current_tasks);
+
+        _data.clear();
+
+        // update status for tasks that disappeared since last check
+        for(auto itr : tasks)
+        {
+            if(_current_tasks.count(itr) == 0u || _current_samples.count(itr) == 0u)
+            {
+                _data.emplace(itr, status::Gone);
+            }
+        }
+
+        for(const auto& itr : _current_samples)
+        {
+            const auto& task   = itr.first;
+            const auto& sample = itr.second;
+
+            if(_base_samples.count(task) != 0u)
+            {
+                auto _delta = sample - _base_samples.at(task);
+                auto status = classify(_delta);
+                _data.emplace(task, status);
+            }
+            else
+            {
+                ROCP_CI_LOG(INFO) << fmt::format(
+                    "New task detected! Not in baseline tasks: {} ({})", task.id, task.path);
+                _data.emplace(task, status::Unknown);
+            }
+        }
+
+        if(bool should_stop = predicate(_data); should_stop) break;
+
+    } while(get_elapsed_time() < timeout);
+
+    return _data;
+}
+
+}  // namespace thread_activity
+}  // namespace common
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/common/thread_activity.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/thread_activity.hpp
@@ -121,19 +121,21 @@ struct sample
     operator bool() const;
 };
 
+using task_set_t        = std::set<task_info>;
+using task_status_map_t = std::map<task_info, status>;
 // return true from predicate if we should stop polling, false to keep polling until timeout
-using poll_tasks_predicate_t = std::function<bool(const std::map<task_info, status>&)>;
+using poll_tasks_predicate_t = std::function<bool(const task_status_map_t&)>;
 
-std::set<task_info>
-get_tasks(pid_t pid = getpid(), const std::set<task_info>& exclude_tasks = {});
+task_set_t
+get_tasks(pid_t pid = getpid(), const task_set_t& exclude_tasks = {});
 
 sample
 get_sample(const task_info& task);
 
 // if predicate is not provided, will keep polling until all tasks are either Gone or Unknown, or
 // until timeout
-std::map<task_info, status>
-poll_tasks(std::set<task_info>&      tasks,
+task_status_map_t
+poll_tasks(task_set_t&               tasks,
            poll_tasks_predicate_t    predicate    = nullptr,
            std::chrono::milliseconds min_interval = std::chrono::milliseconds{1},
            std::chrono::milliseconds timeout      = std::chrono::milliseconds{1000});

--- a/projects/rocprofiler-sdk/source/lib/common/thread_activity.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/thread_activity.hpp
@@ -219,8 +219,7 @@ struct formatter<::rocprofiler::common::thread_activity::status>
             case status::Sleeping: return fmt::format_to(ctx.out(), "Sleeping");
             case status::RunnableWaiting: return fmt::format_to(ctx.out(), "RunnableWaiting");
             case status::ActiveOnCPU: return fmt::format_to(ctx.out(), "ActiveOnCPU");
-            case status::Unknown:
-            default: return fmt::format_to(ctx.out(), "Unknown");
+            case status::Unknown: return fmt::format_to(ctx.out(), "Unknown");
         }
     }
 };

--- a/projects/rocprofiler-sdk/source/lib/common/thread_activity.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/thread_activity.hpp
@@ -60,7 +60,7 @@ operator<(const task_info& lhs, const task_info& rhs);
 
 enum class status
 {
-    // should never been seen
+    // should never be seen
     Dead,
     // thread no longer exists
     Gone,

--- a/projects/rocprofiler-sdk/source/lib/common/thread_activity.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/thread_activity.hpp
@@ -221,6 +221,9 @@ struct formatter<::rocprofiler::common::thread_activity::status>
             case status::ActiveOnCPU: return fmt::format_to(ctx.out(), "ActiveOnCPU");
             case status::Unknown: return fmt::format_to(ctx.out(), "Unknown");
         }
+
+        ROCP_CI_LOG(INFO) << fmt::format("Unknown status value: {}", static_cast<int>(val));
+        return fmt::format_to(ctx.out(), "Unknown");
     }
 };
 

--- a/projects/rocprofiler-sdk/source/lib/common/thread_activity.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/thread_activity.hpp
@@ -1,0 +1,241 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "lib/common/logging.hpp"
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
+#include <chrono>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <functional>
+#include <map>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <sys/poll.h>
+#include <sys/types.h>
+#include <unistd.h>  // sysconf
+
+namespace rocprofiler
+{
+namespace common
+{
+namespace thread_activity
+{
+struct task_info;
+
+namespace operators
+{
+bool
+operator<(const task_info& lhs, const task_info& rhs);
+}  // namespace operators
+
+enum class status
+{
+    // should never been seen
+    Dead,
+    // thread no longer exists
+    Gone,
+    // terminated but not yet reaped by parent
+    Zombie,
+    // usually I/O operations that cannot be interrupted
+    BlockedUninterruptible,
+    // a state for kernel threads associated with offlined CPUs, uncommon for user processes
+    Parked,
+    // not valid since the 2.6.xx kernel
+    Paging,
+    // either by a job control signal (e.g., SIGSTOP) or because it is being traced by a debugger
+    StoppedOrTraced,
+    // Interruptible sleep, waiting for an event to complete. This is the most common sleeping state
+    // for user threads
+    Sleeping,
+    // Waiting in the run queue for CPU time.
+    RunnableWaiting,
+    // Actively executing on a CPU. This is the only state where we can be sure the thread is
+    // actively running and not just waiting to run
+    ActiveOnCPU,
+    Unknown,
+};
+
+struct task_info
+{
+    uint64_t    id   = 0;
+    std::string path = {};
+
+    operator bool() const;
+
+    friend bool operator<(const task_info& lhs, const task_info& rhs)
+    {
+        return operators::operator<(lhs, rhs);
+    }
+};
+
+struct task_schedstat
+{
+    uint64_t run_time_ns  = 0;
+    uint64_t run_queue_ns = 0;
+    uint64_t timeslices   = 0;
+};
+
+struct task_stat
+{
+    uint64_t utime_ticks = 0;
+    uint64_t stime_ticks = 0;
+    status   state       = status::Unknown;
+};
+
+struct sample
+{
+    task_info                     task      = {};
+    std::optional<task_schedstat> schedstat = std::nullopt;
+    std::optional<task_stat>      stat      = std::nullopt;
+
+    operator bool() const;
+};
+
+// return true from predicate if we should stop polling, false to keep polling until timeout
+using poll_tasks_predicate_t = std::function<bool(const std::map<task_info, status>&)>;
+
+std::set<task_info>
+get_tasks(pid_t pid = getpid(), const std::set<task_info>& exclude_tasks = {});
+
+sample
+get_sample(const task_info& task);
+
+// if predicate is not provided, will keep polling until all tasks are either Gone or Unknown, or
+// until timeout
+std::map<task_info, status>
+poll_tasks(std::set<task_info>&      tasks,
+           poll_tasks_predicate_t    predicate    = nullptr,
+           std::chrono::milliseconds min_interval = std::chrono::milliseconds{1},
+           std::chrono::milliseconds timeout      = std::chrono::milliseconds{1000});
+
+namespace operators
+{
+bool
+operator==(const task_info& lhs, const task_info& rhs);
+
+bool
+operator<(const task_info& lhs, const task_info& rhs);
+
+bool
+operator<(task_schedstat lhs, task_schedstat rhs);
+
+bool
+operator<(task_stat lhs, task_stat rhs);
+
+task_schedstat&
+operator-=(task_schedstat& lhs, task_schedstat rhs);
+
+task_stat&
+operator-=(task_stat& lhs, task_stat rhs);
+
+sample&
+operator-=(sample& lhs, const sample& rhs);
+
+task_schedstat
+operator-(task_schedstat lhs, task_schedstat rhs);
+
+task_stat
+operator-(task_stat lhs, task_stat rhs);
+
+sample
+operator-(const sample& lhs, const sample& rhs);
+}  // namespace operators
+}  // namespace thread_activity
+}  // namespace common
+}  // namespace rocprofiler
+
+// Bring operators into the common namespace for easier use
+using namespace ::rocprofiler::common::thread_activity::operators;
+
+namespace std
+{
+template <>
+struct hash<rocprofiler::common::thread_activity::task_info>
+{
+    std::size_t operator()(const rocprofiler::common::thread_activity::task_info& t) const noexcept
+    {
+        return std::hash<uint64_t>{}(t.id) ^ std::hash<std::string>{}(t.path);
+    }
+};
+}  // namespace std
+
+namespace fmt
+{
+template <>
+struct formatter<::rocprofiler::common::thread_activity::status>
+{
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
+
+    template <typename Ctx>
+    auto format(const ::rocprofiler::common::thread_activity::status& val, Ctx& ctx) const
+    {
+        using status = ::rocprofiler::common::thread_activity::status;
+        switch(val)
+        {
+            case status::Dead: return fmt::format_to(ctx.out(), "Dead");
+            case status::Paging: return fmt::format_to(ctx.out(), "Paging");
+            case status::Parked: return fmt::format_to(ctx.out(), "Parked");
+            case status::Gone: return fmt::format_to(ctx.out(), "Gone");
+            case status::Zombie: return fmt::format_to(ctx.out(), "Zombie");
+            case status::BlockedUninterruptible:
+                return fmt::format_to(ctx.out(), "BlockedUninterruptible");
+            case status::StoppedOrTraced: return fmt::format_to(ctx.out(), "StoppedOrTraced");
+            case status::Sleeping: return fmt::format_to(ctx.out(), "Sleeping");
+            case status::RunnableWaiting: return fmt::format_to(ctx.out(), "RunnableWaiting");
+            case status::ActiveOnCPU: return fmt::format_to(ctx.out(), "ActiveOnCPU");
+            case status::Unknown:
+            default: return fmt::format_to(ctx.out(), "Unknown");
+        }
+    }
+};
+
+template <>
+struct formatter<::rocprofiler::common::thread_activity::task_info>
+{
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
+
+    template <typename Ctx>
+    auto format(const ::rocprofiler::common::thread_activity::task_info& val, Ctx& ctx) const
+    {
+        return fmt::format_to(ctx.out(), "{{id: {}, path: {}}}", val.id, val.path);
+    }
+};
+}  // namespace fmt

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/core.cpp
@@ -478,7 +478,7 @@ TEST(core, check_callbacks)
     }
     registration::set_init_status(1);
 
-    registration::finalize();
+    registration::finalize(registration::finalize_mode::tool_induced);
 }
 
 TEST(core, destroy_counter_profile)
@@ -516,7 +516,7 @@ TEST(core, destroy_counter_profile)
     }
     registration::set_init_status(1);
 
-    registration::finalize();
+    registration::finalize(registration::finalize_mode::tool_induced);
 }
 
 TEST(core, start_stop_buffered_ctx)
@@ -586,7 +586,7 @@ TEST(core, start_stop_buffered_ctx)
 
     registration::set_init_status(1);
 
-    registration::finalize();
+    registration::finalize(registration::finalize_mode::tool_induced);
 }
 
 TEST(core, start_stop_callback_ctx)
@@ -709,7 +709,7 @@ TEST(core, test_profile_incremental)
 
     registration::set_init_status(1);
 
-    registration::finalize();
+    registration::finalize(registration::finalize_mode::tool_induced);
 }
 
 TEST(core, public_api_iterate_agents)
@@ -774,7 +774,7 @@ rocprofiler-sdk:
       description: cycles
       properties: []
       definitions:
-        - architectures:  
+        - architectures:
           - gfx950
           - gfx942
           - gfx10
@@ -822,12 +822,12 @@ TEST(core, check_load_counter_def)
     const std::string test_yaml = R"(
 rocprofiler-sdk:
   counters-schema-version: 1
-  counters:  
+  counters:
     - name: GRBM_GUI_ACTIVE
       description: The GUI is Active
       properties: []
       definitions:
-        - architectures:  
+        - architectures:
           - gfx950
           - gfx942
           - gfx941
@@ -859,7 +859,7 @@ rocprofiler-sdk:
       description: cycles
       properties: []
       definitions:
-        - architectures:  
+        - architectures:
           - gfx950
           - gfx942
           - gfx10

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/device_counting.cpp
@@ -639,7 +639,7 @@ protected:
         CHECK(test_ran);
 
         registration::set_init_status(1);
-        registration::finalize();
+        registration::finalize(registration::finalize_mode::tool_induced);
     }
 };
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/internal_threading.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/internal_threading.cpp
@@ -245,7 +245,7 @@ initialize()
         // registration or else the static objects it is pointing to
         // will be destroyed before finalize is invoked.
         create_callback_thread();
-        ::atexit(&registration::finalize);
+        ::atexit([]() { registration::finalize(registration::finalize_mode::exit_handler); });
         // ensure the callback threads are created on the forked process
         ::pthread_atfork(nullptr, nullptr, create_forked_callback_threads);
     });

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -910,8 +910,8 @@ finalize(finalize_mode mode)
         {
             namespace thread_activity = common::thread_activity;
 
-            // poll the thread activity at least every 0.1 seconds.
-            // after 1 second, stop polling and return.
+            // poll the thread activity at least every 10 milliseconds (0.01 seconds).
+            // after 500 milliseconds (0.5 seconds), stop polling and return.
             constexpr auto min_interval = std::chrono::milliseconds{10};
             constexpr auto timeout      = std::chrono::milliseconds{500};
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -29,6 +29,7 @@
 #include "lib/common/logging.hpp"
 #include "lib/common/static_object.hpp"
 #include "lib/common/static_tl_object.hpp"
+#include "lib/common/thread_activity.hpp"
 #include "lib/rocprofiler-sdk/agent.hpp"
 #include "lib/rocprofiler-sdk/code_object/code_object.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
@@ -511,6 +512,13 @@ get_registration_mutex()
     return _v;
 }
 
+auto*
+get_initial_tasks()
+{
+    static auto*& _v = common::static_object<common::thread_activity::task_set_t>::construct();
+    return _v;
+}
+
 bool
 invoke_client_configures()
 {
@@ -600,9 +608,9 @@ invoke_client_initializers()
     if(!get_clients()) return false;
 
     // if there is only one client, just fully finalize
-    rocprofiler_client_finalize_t client_fini_func =
-        (get_clients()->size() == 1) ? [](rocprofiler_client_id_t) -> void { finalize(); }
-                                     : &invoke_client_finalizer;
+    rocprofiler_client_finalize_t client_fini_func = (get_clients()->size() == 1)
+        ? [](rocprofiler_client_id_t) -> void { finalize(finalize_mode::tool_induced); }
+    : &invoke_client_finalizer;
 
     for(auto& itr : *get_clients())
     {
@@ -824,7 +832,7 @@ initialize()
         // initialization is in process
         set_init_status(-1);
         std::atexit([]() {
-            finalize();
+            finalize(finalize_mode::exit_handler);
             common::destroy_static_tl_objects();
             common::destroy_static_objects();
         });
@@ -836,6 +844,14 @@ initialize()
 
         if(get_num_clients() > 0)
         {
+            // right after configuration, populate the initial tasks so that we know the main tid
+            // and all of the tids created by rocprofiler-sdk (and maybe the clients) so that we
+            // can exclude them from our polling during finalization
+            if(auto* initial_tasks = get_initial_tasks(); initial_tasks)
+            {
+                *initial_tasks = common::thread_activity::get_tasks(getpid());
+            }
+
             for(const auto& itr : *get_clients())
             {
                 if(!itr) continue;
@@ -864,7 +880,7 @@ initialize()
 }
 
 void
-finalize()
+finalize(finalize_mode mode)
 {
 #if defined(CODECOV) && CODECOV > 0
     if(get_fini_status() > 0) __gcov_dump();
@@ -888,8 +904,74 @@ finalize()
     ROCP_INFO << "finalizing rocprofiler (value=" << get_fini_status() << ")";
 
     static auto _once = std::once_flag{};
-    std::call_once(_once, []() {
+    std::call_once(_once, [mode]() {
         auto num_clients = get_num_clients();
+        if(mode == finalize_mode::exit_handler || mode == finalize_mode::static_destructor)
+        {
+            namespace thread_activity = common::thread_activity;
+
+            // poll the thread activity at least every 0.1 seconds.
+            // after 1 second, stop polling and return.
+            constexpr auto min_interval = std::chrono::milliseconds{10};
+            constexpr auto timeout      = std::chrono::milliseconds{500};
+
+            auto _tasks_predicate = [](const thread_activity::task_status_map_t& data) {
+                uint64_t waiting = 0;
+                uint64_t active  = 0;
+                for(const auto& [task, status] : data)
+                {
+                    ROCP_TRACE << fmt::format("Task {} status: {}", task, status);
+                    if(status == thread_activity::status::RunnableWaiting)
+                        ++waiting;
+                    else if(status == thread_activity::status::ActiveOnCPU)
+                        ++active;
+                }
+
+                ROCP_TRACE << fmt::format("finalize thread activity: {}/{} tasks are runnable but "
+                                          "waiting ({}) or actively running ({})",
+                                          waiting + active,
+                                          data.size(),
+                                          waiting,
+                                          active);
+
+                // return true if all tasks are neither runnable but waiting or active, if any tasks
+                // are waiting/active, keep polling by returning false
+                return ((waiting + active) == 0);
+            };
+
+            auto _initial_tasks =
+                get_initial_tasks() ? *get_initial_tasks() : common::thread_activity::task_set_t{};
+            auto _tasks    = common::thread_activity::get_tasks(getpid(), _initial_tasks);
+            auto _activity = common::thread_activity::poll_tasks(
+                _tasks, _tasks_predicate, min_interval, timeout);
+
+            for(const auto& itr : _activity)
+            {
+                const auto& task   = itr.first;
+                const auto& status = itr.second;
+                ROCP_TRACE << fmt::format("Task {} status: {}", task, status);
+                if(status != thread_activity::status::Gone)
+                {
+                    auto get_msg = [&]() {
+                        return fmt::format(
+                            "rocprofiler-sdk is proceeding with finalization (after "
+                            "waiting {} msec) despite thread {} still having status {}",
+                            timeout.count(),
+                            task.id,
+                            status);
+                    };
+                    if(status == thread_activity::status::RunnableWaiting ||
+                       status == thread_activity::status::ActiveOnCPU)
+                    {
+                        ROCP_WARNING << get_msg();
+                    }
+                    else
+                    {
+                        ROCP_INFO << get_msg();
+                    }
+                }
+            }
+        }
         set_fini_status(-1);
         hsa::async_copy_fini();
         counters::device_counting_service_finalize();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -770,7 +770,9 @@ supports_attachment()
 void
 init_logging()
 {
-    common::init_logging("ROCPROFILER");
+    auto logging_cfg = rocprofiler::common::logging_config{
+        .install_failure_handler = common::get_env("ROCPROFILER_LOG_FAILURE_HANDLER", false)};
+    common::init_logging("ROCPROFILER", logging_cfg);
 }
 
 // ensure that logging is always initialized when library is loaded

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.hpp
@@ -45,6 +45,13 @@ namespace rocprofiler
 {
 namespace registration
 {
+enum class finalize_mode
+{
+    tool_induced,
+    exit_handler,
+    static_destructor,
+};
+
 // initialize google logging
 void
 init_logging();
@@ -54,8 +61,7 @@ void
 initialize();
 
 // finalize the clients
-void
-finalize();
+void finalize(finalize_mode);
 
 // get the randomly generated client offset number
 uint32_t

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/shared_library.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/shared_library.cpp
@@ -56,7 +56,7 @@ lifetime::~lifetime()
     if(common::get_env("ROCPROFILER_LIBRARY_DTOR", false))
     {
         ROCP_INFO << "Finalizing rocprofiler-sdk library...";
-        registration::finalize();
+        registration::finalize(registration::finalize_mode::static_destructor);
         ROCP_INFO << "rocprofiler-sdk library finalized";
     }
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/hsa_barrier.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/hsa_barrier.cpp
@@ -217,7 +217,7 @@ TEST(hsa_barrier, no_block_single)
     }
 
     registration::set_init_status(1);
-    registration::finalize();
+    registration::finalize(registration::finalize_mode::tool_induced);
 }
 
 TEST(hsa_barrier, no_block_multi)
@@ -255,7 +255,7 @@ TEST(hsa_barrier, no_block_multi)
     }
 
     registration::set_init_status(1);
-    registration::finalize();
+    registration::finalize(registration::finalize_mode::tool_induced);
 }
 
 TEST(hsa_barrier, block_single)
@@ -315,7 +315,7 @@ TEST(hsa_barrier, block_single)
     }
 
     registration::set_init_status(1);
-    registration::finalize();
+    registration::finalize(registration::finalize_mode::tool_induced);
 }
 
 TEST(hsa_barrier, block_multi)
@@ -386,5 +386,5 @@ TEST(hsa_barrier, block_multi)
     }
 
     registration::set_init_status(1);
-    registration::finalize();
+    registration::finalize(registration::finalize_mode::tool_induced);
 }

--- a/projects/rocprofiler-sdk/source/lib/tests/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/tests/common/CMakeLists.txt
@@ -12,6 +12,7 @@ set(common_sources
     parse.cpp
     regex.cpp
     sha256.cpp
+    thread_activity.cpp
     uuid_v7.cpp)
 
 add_executable(common-tests)

--- a/projects/rocprofiler-sdk/source/lib/tests/common/thread_activity.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/common/thread_activity.cpp
@@ -1,0 +1,218 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/common/thread_activity.hpp"
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <sstream>
+#include <string>
+
+// namespace
+// {
+// }  // namespace
+
+TEST(common, thread_activity)
+{
+    namespace thread_activity = ::rocprofiler::common::thread_activity;
+
+    constexpr auto num_threads  = 4UL;
+    constexpr auto min_interval = std::chrono::milliseconds{10};
+    constexpr auto timeout      = std::chrono::milliseconds{500};
+
+    const auto _initial_tasks = thread_activity::get_tasks(getpid());
+
+    auto get_elapsed_time = [](auto _start_time) {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - _start_time);
+    };
+
+    auto _busy_thread = [](auto& _started_threads, auto& _flag, std::atomic<uint64_t>& _result) {
+        // increment started threads count so main thread knows when all threads are running
+        ++_started_threads;
+
+        // create rng to do busy work
+        auto _random_gen = std::mt19937_64{std::random_device{}()};
+        auto _rng = std::uniform_int_distribution<uint64_t>{std::numeric_limits<uint8_t>::max(),
+                                                            std::numeric_limits<uint16_t>::max()};
+        auto _random_value = [&_random_gen, &_rng]() { return _rng(_random_gen); }();
+
+        // update shared value until flag is cleared
+        while(_flag.load(std::memory_order_relaxed))
+            _result += _random_value;
+    };
+
+    auto _sleeping_thread = [](auto&                     _started_threads,
+                               auto&                     _flag,
+                               std::chrono::milliseconds _sleep_duration) {
+        // increment started threads count so main thread knows when all threads are running
+        ++_started_threads;
+
+        while(_flag.load(std::memory_order_relaxed))
+            std::this_thread::yield();  // yield until flag is cleared to simulate sleeping thread
+
+        // sleep for specified duration to simulate sleeping thread
+        std::this_thread::sleep_for(_sleep_duration);
+    };
+
+    //=============================================================================================//
+    //
+    //      Busy thread tests
+    //
+    //=============================================================================================//
+
+    auto _busy_value           = std::atomic<uint64_t>{0};
+    auto _busy_flag            = std::atomic<bool>{true};
+    auto _busy_threads         = std::vector<std::thread>{};
+    auto _busy_started_threads = std::atomic<uint64_t>{0};
+    for(size_t i = 0; i < num_threads; ++i)
+    {
+        _busy_threads.emplace_back(
+            [&]() { _busy_thread(_busy_started_threads, _busy_flag, _busy_value); });
+    }
+
+    // wait for all threads to start and be detected in get_tasks before proceeding
+    while(_busy_started_threads.load(std::memory_order_relaxed) < num_threads)
+        ;
+
+    // get current tasks again to include the newly started threads and remove the initial tasks
+    // from the current tasks so we can focus on the new threads we just started
+    auto _busy_tasks = thread_activity::get_tasks(getpid(), _initial_tasks);
+
+    ASSERT_EQ(_busy_tasks.size(), num_threads);
+
+    {
+        auto _busy_start = std::chrono::steady_clock::now();
+        auto _busy_activity =
+            thread_activity::poll_tasks(_busy_tasks, nullptr, min_interval, timeout);
+        auto _busy_elapsed = get_elapsed_time(_busy_start);
+
+        EXPECT_GE(_busy_elapsed.count(), timeout.count());
+        EXPECT_LE(_busy_activity.size(), num_threads);
+        for(const auto& [task, status] : _busy_activity)
+        {
+            EXPECT_EQ(_initial_tasks.count(task), 0u);
+            EXPECT_GT(_busy_tasks.count(task), 0u);
+            EXPECT_GT(status, thread_activity::status::Sleeping)
+                << fmt::format("Task {} status: {}", task, status);
+            EXPECT_LT(status, thread_activity::status::Unknown)
+                << fmt::format("Task {} status: {}", task, status);
+        }
+    }
+
+    // release the threads
+    _busy_flag.store(false, std::memory_order_relaxed);
+
+    {
+        auto _busy_start = std::chrono::steady_clock::now();
+        auto _busy_activity =
+            thread_activity::poll_tasks(_busy_tasks, nullptr, min_interval, timeout);
+        auto _busy_elapsed = get_elapsed_time(_busy_start);
+
+        EXPECT_LT(_busy_elapsed.count(), timeout.count());
+        EXPECT_EQ(_busy_activity.size(), num_threads);
+        for(const auto& [task, status] : _busy_activity)
+        {
+            EXPECT_EQ(_initial_tasks.count(task), 0u);
+            EXPECT_GT(_busy_tasks.count(task), 0u);
+            EXPECT_EQ(status, thread_activity::status::Gone)
+                << fmt::format("Task {} status: {}", task, status);
+        }
+    }
+
+    for(auto& itr : _busy_threads)
+    {
+        if(itr.joinable()) itr.join();
+    }
+
+    //=============================================================================================//
+    //
+    //      Sleeping thread tests
+    //
+    //=============================================================================================//
+
+    auto _sleeping_flag            = std::atomic<bool>{true};
+    auto _sleeping_started_threads = std::atomic<uint64_t>{0};
+    auto _sleeping_threads         = std::vector<std::thread>{};
+
+    for(size_t i = 0; i < num_threads; ++i)
+    {
+        _sleeping_threads.emplace_back(
+            [&]() { _sleeping_thread(_sleeping_started_threads, _sleeping_flag, timeout * 2); });
+    }
+
+    // wait for all threads to start and be detected in get_tasks before proceeding
+    while(_sleeping_started_threads.load(std::memory_order_relaxed) < num_threads)
+        std::this_thread::yield();
+
+    // set flag to false to exit loop and enter timed sleep in sleeping thread function
+    _sleeping_flag.store(false, std::memory_order_relaxed);
+
+    // get current tasks again to include the newly started threads and remove the initial tasks
+    // from the current tasks so we can focus on the new threads we just started
+    auto _sleeping_tasks = thread_activity::get_tasks(getpid(), _initial_tasks);
+
+    ASSERT_EQ(_sleeping_tasks.size(), num_threads);
+
+    {
+        auto _sleeping_start = std::chrono::steady_clock::now();
+        auto _sleeping_activity =
+            thread_activity::poll_tasks(_sleeping_tasks, nullptr, min_interval, timeout);
+        auto _sleeping_elapsed = get_elapsed_time(_sleeping_start);
+
+        EXPECT_GE(_sleeping_elapsed.count(), timeout.count());
+        EXPECT_LE(_sleeping_activity.size(), num_threads);
+        for(const auto& [task, status] : _sleeping_activity)
+        {
+            EXPECT_EQ(_initial_tasks.count(task), 0u);
+            EXPECT_GT(_sleeping_tasks.count(task), 0u);
+            EXPECT_GT(status, thread_activity::status::StoppedOrTraced)
+                << fmt::format("Task {} status: {}", task, status);
+            EXPECT_LT(status, thread_activity::status::ActiveOnCPU)
+                << fmt::format("Task {} status: {}", task, status);
+        }
+    }
+
+    {
+        auto _sleeping_activity =
+            thread_activity::poll_tasks(_sleeping_tasks, nullptr, min_interval, timeout);
+
+        EXPECT_EQ(_sleeping_activity.size(), num_threads);
+        for(const auto& [task, status] : _sleeping_activity)
+        {
+            EXPECT_EQ(_initial_tasks.count(task), 0u);
+            EXPECT_GT(_sleeping_tasks.count(task), 0u);
+            EXPECT_EQ(status, thread_activity::status::Gone)
+                << fmt::format("Task {} status: {}", task, status);
+        }
+    }
+
+    // make sure threads are all joined
+    for(auto& itr : _sleeping_threads)
+    {
+        if(itr.joinable()) itr.join();
+    }
+}

--- a/projects/rocprofiler-sdk/source/lib/tests/common/thread_activity.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/common/thread_activity.cpp
@@ -30,6 +30,7 @@
 #include <random>
 #include <sstream>
 #include <string>
+#include <thread>
 
 // namespace
 // {
@@ -96,7 +97,9 @@ TEST(common, thread_activity)
 
     // wait for all threads to start and be detected in get_tasks before proceeding
     while(_busy_started_threads.load(std::memory_order_relaxed) < num_threads)
-        ;
+    {
+        std::this_thread::sleep_for(std::chrono::microseconds{100});
+    }
 
     // get current tasks again to include the newly started threads and remove the initial tasks
     // from the current tasks so we can focus on the new threads we just started

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -2851,7 +2851,19 @@ void Runtime::CloseTools() {
 void Runtime::AsyncEventsControl::Shutdown() {
   exit = true;
   hsa_signal_handle(wake)->StoreRelaxed(1);
-  os::WaitForThread(thread_);
+
+  constexpr size_t num_attempts = 10;
+  bool clean_wait = false;
+  for(size_t i = 0; i < num_attempts; ++i)
+  {
+   clean_wait = os::WaitForThread(thread_);
+   if(clean_wait)
+     break;
+  }
+  if (!clean_wait)
+   fprintf(stderr, "[rocr] Async event thread did not exit cleanly after %zu attempts, forcing shutdown.\n",
+                  num_attempts);
+
   os::CloseThread(thread_);
   thread_ = NULL;
   core::Signal::Convert(wake)->DestroySignal();

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
@@ -74,6 +74,12 @@
 
 namespace rocr {
 namespace os {
+namespace {
+auto& get_thread_idx_counter() {
+  static auto _val = std::atomic<uint64_t>{0};
+  return _val;
+}
+}  // namespace
 
 struct ThreadArgs {
   void* entry_args;
@@ -227,8 +233,9 @@ class os_thread {
   ~os_thread() {
     if (lock != nullptr) DestroyMutex(lock);
     if ((state == RUNNING) && (thread != 0)) {
+      fprintf(stderr, "[rocr] Detaching thread %lu\n", idx);
       int err = pthread_detach(thread);
-      if (err != 0) fprintf(stderr, "pthread_detach failed: %s\n", strerror(err));
+      if (err != 0) fprintf(stderr, "[rocr] pthread_detach failed: %s\n", strerror(err));
     }
   }
 
@@ -243,7 +250,12 @@ class os_thread {
     }
     int err = pthread_join(thread, NULL);
     bool success = (err == 0);
-    if (success) state = FINISHED;
+    if (success) {
+      state = FINISHED;
+    } else {
+      fprintf(stderr, "[rocr] pthread_join for thread %lu returned non-zero error code %d :: %s\n",
+                     idx, err, strerror(err));
+    }
     ReleaseMutex(lock);
     return success;
   }
@@ -253,6 +265,7 @@ class os_thread {
   struct ThreadArgs args;
   Mutex lock;
   std::atomic<int> state;
+  uint64_t idx = ++get_thread_idx_counter();
   enum { FINISHED = 0, RUNNING = 1 };
 };
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Rocprofiler-SDK samples/tests, especially the correlation ID retirement sample, has sporadic failures due to ROCr-Runtime triggering asynchronous work in their exit handler. In some situations, that work is finished by the time rocprofiler-sdk checks to see all the correlation IDs have been retired. In other situations, that work has not started by the time rocprofiler-sdk checks to see all the correlation IDs have been retired. In both those scenarios, rocprofiler-sdk exits cleanly. However, when the two happen concurrently, a correlation ID is created right before rocprofiler-sdk starts finalizing and hasn't been retired by the time rocprofiler-sdk checks to see all the correlation IDs have been retired. This results in rocprofiler-sdk retiring the correlation ID and producing a fatal error. Typically, at the same time it produces the fatal error, the background thread tries to retire the correlation ID and produces a fatal error because the correlation ID has already been retired. 

At the very least, this PR improves the logging in the finalization by noting that rocprofiler-sdk is proceeding with finalization despite background threads still actively doing work.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- polls `/proc/<pid>/task/<tid>/schedstat` and `/proc/<pid>/task/<tid>/stat` to estimate the activity state of a thread
- uses the above for finalization in rocprofiler-sdk to determine if there are background threads still performing work in their exit handlers, e.g. HSA-Runtime. It gives the background thread time to complete it's work when it recognizes there are still active threads.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- The core functionality is unit tested. The ultimate success of this PR with regard to testing is whether the existing tests stability and/or are logged better when they fail.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
