### PR TITLE
[rocprofiler-sdk] Handle validate tests script when Blit kernels are used for mem copies

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters.cpp
@@ -109,7 +109,7 @@ get_first_agent_for_metric(rocprofiler_counter_id_t counter_id)
         // Find the first GPU agent with this architecture
         for(const auto* agent : rocprofiler::agent::get_agents())
         {
-            if(agent && agent->type == ROCPROFILER_AGENT_TYPE_GPU &&
+            if(agent != nullptr && agent->type == ROCPROFILER_AGENT_TYPE_GPU &&
                std::string(agent->name) == arch_name)
             {
                 return agent->id;

--- a/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
@@ -54,8 +54,7 @@ simple_kernel(float* data, int size)
 }
 
 void
-execute_kernels(const size_t      tid,
-                const size_t      device_id)
+execute_kernels(const size_t tid, const size_t device_id)
 {
     // Set device
     HIP_ASSERT(hipSetDevice(device_id));
@@ -79,7 +78,8 @@ execute_kernels(const size_t      tid,
     }
 
     // Run kernels in a loop for a while
-    std::cout << "Starting kernel execution loop for thread " << tid << " on device " << device_id << "...\n";
+    std::cout << "Starting kernel execution loop for thread " << tid << " on device " << device_id
+              << "...\n";
     const int num_iterations = 30;
 
     for(int iter = 0; iter < num_iterations; ++iter)
@@ -93,7 +93,8 @@ execute_kernels(const size_t      tid,
         auto err = hipMemcpyAsync(d_data, h_data, bytes, hipMemcpyHostToDevice, stream);
         if(err != hipSuccess)
         {
-            std::cerr << "Failed to copy data for thread " << tid << " on device " << device_id << "...\n";
+            std::cerr << "Failed to copy data for thread " << tid << " on device " << device_id
+                      << "...\n";
             roctxRangePop();  // Removed - ROCTx not linked
             break;
         }
@@ -111,7 +112,8 @@ execute_kernels(const size_t      tid,
         err = hipMemcpyAsync(h_data, d_data, bytes, hipMemcpyDeviceToHost, stream);
         if(err != hipSuccess)
         {
-            std::cerr << "Failed to copy data for thread " << tid << " on device " << device_id << "...\n";
+            std::cerr << "Failed to copy data for thread " << tid << " on device " << device_id
+                      << "...\n";
             roctxRangePop();  // Removed - ROCTx not linked
             break;
         }
@@ -133,7 +135,8 @@ execute_kernels(const size_t      tid,
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
-    std::cout << "Kernel execution loop completed for thread " << tid << " on device " << device_id << "...\n";
+    std::cout << "Kernel execution loop completed for thread " << tid << " on device " << device_id
+              << "...\n";
 
     HIP_ASSERT(hipStreamDestroy(stream));
     // Cleanup
@@ -172,7 +175,6 @@ main(int argc, char** argv)
         return 1;
     }
 
-
     // Default ndevices to device_count. Ensure that we do not use more devices than are available
     ndevices = ndevices == 0 ? device_count : ndevices;
     if(ndevices > device_count)
@@ -188,8 +190,7 @@ main(int argc, char** argv)
     _threads.reserve(nthreads);
 
     for(size_t i = 0; i < nthreads; ++i)
-        _threads.emplace_back(
-            execute_kernels, i, i % ndevices);
+        _threads.emplace_back(execute_kernels, i, i % ndevices);
     for(auto& itr : _threads)
         itr.join();
 

--- a/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/attachment-test/attachment_test.cpp
@@ -55,12 +55,13 @@ simple_kernel(float* data, int size)
 
 void
 execute_kernels(const size_t      tid,
-                const hipStream_t stream,
-                const size_t      stream_id,
                 const size_t      device_id)
 {
     // Set device
     HIP_ASSERT(hipSetDevice(device_id));
+
+    auto* stream = hipStream_t{nullptr};
+    HIP_ASSERT(hipStreamCreate(&stream));
 
     // Allocate memory
     const int    size  = 1024 * 1024;  // 1M elements
@@ -78,8 +79,7 @@ execute_kernels(const size_t      tid,
     }
 
     // Run kernels in a loop for a while
-    std::cout << "Starting kernel execution loop for thread " << tid << " with stream " << stream_id
-              << " on device " << device_id << "...\n";
+    std::cout << "Starting kernel execution loop for thread " << tid << " on device " << device_id << "...\n";
     const int num_iterations = 30;
 
     for(int iter = 0; iter < num_iterations; ++iter)
@@ -93,8 +93,7 @@ execute_kernels(const size_t      tid,
         auto err = hipMemcpyAsync(d_data, h_data, bytes, hipMemcpyHostToDevice, stream);
         if(err != hipSuccess)
         {
-            std::cerr << "Failed to copy data for thread " << tid << " with stream " << stream_id
-                      << " on device " << device_id << "...\n";
+            std::cerr << "Failed to copy data for thread " << tid << " on device " << device_id << "...\n";
             roctxRangePop();  // Removed - ROCTx not linked
             break;
         }
@@ -112,8 +111,7 @@ execute_kernels(const size_t      tid,
         err = hipMemcpyAsync(h_data, d_data, bytes, hipMemcpyDeviceToHost, stream);
         if(err != hipSuccess)
         {
-            std::cerr << "Failed to copy data for thread " << tid << " with stream " << stream_id
-                      << " on device " << device_id << "...\n";
+            std::cerr << "Failed to copy data for thread " << tid << " on device " << device_id << "...\n";
             roctxRangePop();  // Removed - ROCTx not linked
             break;
         }
@@ -123,7 +121,7 @@ execute_kernels(const size_t      tid,
         err = hipStreamSynchronize(stream);
         if(err != hipSuccess)
         {
-            std::cerr << "Failed to synchronize stream " << stream_id << " with thread " << tid
+            std::cerr << "Failed to synchronize stream " << stream << " with thread " << tid
                       << " on device " << device_id << "...\n";
             roctxRangePop();  // Removed - ROCTx not linked
             break;
@@ -135,9 +133,9 @@ execute_kernels(const size_t      tid,
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
-    std::cout << "Kernel execution loop completed for thread " << tid << " with stream "
-              << stream_id << " on device " << device_id << "...\n";
+    std::cout << "Kernel execution loop completed for thread " << tid << " on device " << device_id << "...\n";
 
+    HIP_ASSERT(hipStreamDestroy(stream));
     // Cleanup
     HIP_ASSERT(hipFree(d_data));
     delete[] h_data;
@@ -146,8 +144,7 @@ execute_kernels(const size_t      tid,
 int
 main(int argc, char** argv)
 {
-    size_t nthreads{32};
-    size_t nstreams{8};
+    size_t nthreads{8};
     int    ndevices{0};
     for(int i = 1; i < argc; ++i)
     {
@@ -155,17 +152,14 @@ main(int argc, char** argv)
         if(_arg == "?" || _arg == "-h" || _arg == "--help")
         {
             fprintf(stderr,
-                    "usage: attachment-test [NUM_THREADS (%zu)] [NUM_STREAMS (%zu)] "
-                    "[NUM_DEVICES (%d)]\n",
+                    "usage: attachment-test [NUM_THREADS (%zu)] [NUM_DEVICES (%d)]\n",
                     nthreads,
-                    nstreams,
                     ndevices);
             exit(EXIT_SUCCESS);
         }
     }
     if(argc > 1) nthreads = std::atoll(argv[1]);
-    if(argc > 2) nstreams = std::atoll(argv[2]);
-    if(argc > 3) ndevices = std::stoi(argv[3]);
+    if(argc > 2) ndevices = std::stoi(argv[2]);
 
     std::cout << "Attachment test app started with PID: " << getpid() << std::endl;
 
@@ -177,7 +171,9 @@ main(int argc, char** argv)
         std::cerr << "No HIP devices found or error getting device count" << std::endl;
         return 1;
     }
-    // Default ndecives to device_count. Ensure that we do not use more devices than are available
+
+
+    // Default ndevices to device_count. Ensure that we do not use more devices than are available
     ndevices = ndevices == 0 ? device_count : ndevices;
     if(ndevices > device_count)
     {
@@ -189,20 +185,13 @@ main(int argc, char** argv)
     std::cout << "After first call " << getpid() << std::endl;
 
     auto _threads = std::vector<std::thread>{};
-    auto _streams = std::vector<hipStream_t>(nstreams);
     _threads.reserve(nthreads);
 
-    for(auto& itr : _streams)
-        HIP_ASSERT(hipStreamCreate(&itr));
     for(size_t i = 0; i < nthreads; ++i)
         _threads.emplace_back(
-            execute_kernels, i, _streams.at(i % nstreams), i % nstreams, i % ndevices);
+            execute_kernels, i, i % ndevices);
     for(auto& itr : _threads)
         itr.join();
-
-    // Destroy streams
-    for(auto itr : _streams)
-        HIP_ASSERT(hipStreamDestroy(itr));
 
     std::cout << "Attachment test app finished" << std::endl;
 

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/CMakeLists.txt
@@ -19,6 +19,9 @@ else()
     set(IS_DISABLED OFF)
 endif()
 
+# Until this test is fixed in PSDB-tests
+set(IS_DISABLED ON)
+
 if(ROCPROFILER_MEMCHECK STREQUAL "LeakSanitizer")
     set(LOG_LEVEL "warning") # info produces memory leak
 else()

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-once/CMakeLists.txt
@@ -19,9 +19,6 @@ else()
     set(IS_DISABLED OFF)
 endif()
 
-# Until this test is fixed in PSDB-tests
-set(IS_DISABLED ON)
-
 if(ROCPROFILER_MEMCHECK STREQUAL "LeakSanitizer")
     set(LOG_LEVEL "warning") # info produces memory leak
 else()
@@ -50,6 +47,7 @@ rocprofiler_add_integration_execute_test(
     SKIP_REGULAR_EXPRESSION "This test is skipped."
     FIXTURES_SETUP rocprofv3-test-attachment-attach-once
     FAIL_REGULAR_EXPRESSION "ERROR|FATAL|${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
 # Validate the output from the attached profiling
 rocprofiler_add_integration_validate_test(
     rocprofv3-test-attachment-attach-once-csv

--- a/projects/rocprofiler-sdk/tests/rocprofv3/tracing/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/tracing/validate.py
@@ -295,7 +295,10 @@ def test_memory_copy_json_trace(json_data):
         assert len(memory_copy_data) > 0, f"{memory_copy_data}"
 
     directions = set()
-    valid_directions = ("MEMORY_COPY_HOST_TO_DEVICE", "MEMORY_COPY_DEVICE_TO_HOST")
+    expected_directions = {
+        "MEMORY_COPY_HOST_TO_DEVICE",
+        "MEMORY_COPY_DEVICE_TO_HOST",
+    }
     for row in memory_copy_data:
         src_agent = get_agent(row["src_agent_id"])
         dst_agent = get_agent(row["dst_agent_id"])
@@ -313,7 +316,6 @@ def test_memory_copy_json_trace(json_data):
         assert row["correlation_id"]["internal"] > 0
         assert row["end_timestamp"] >= row["start_timestamp"]
 
-    expected_directions = set(valid_directions)
     if has_blit_kernel:
         assert directions.issubset(expected_directions)
     else:

--- a/projects/rocprofiler-sdk/tests/rocprofv3/tracing/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/tracing/validate.py
@@ -126,8 +126,11 @@ def test_kernel_trace(kernel_input_data):
         "matrixTranspose(float*, float*, int)",
     )
 
-    assert len(kernel_input_data) == 1
+    # memory copies maybe less than two if rocr decides to use blit kernels they show up in kernel data.
+    assert len(kernel_input_data) >= 1
     for row in kernel_input_data:
+        if re.search(r"__amd_rocclr_copyBuffer.*", row["Kernel_Name"]):
+            continue
         assert row["Kind"] == "KERNEL_DISPATCH"
         assert int(row["Agent_Id"].split(" ")[-1]) >= 0
         assert int(row["Queue_Id"]) > 0
@@ -185,7 +188,8 @@ def test_kernel_trace_json(json_data):
         "matrixTranspose(float*, float*, int)",
     )
     kernel_dispatch_data = data["buffer_records"]["kernel_dispatch"]
-    assert len(kernel_dispatch_data) == 1
+    # memory copies maybe less than two if rocr decides to use blit kernels they show up in kernel data.
+    assert len(kernel_dispatch_data) >= 1
     for dispatch in kernel_dispatch_data:
         dispatch_info = dispatch["dispatch_info"]
         kernel_name = get_kernel_name(dispatch_info["kernel_id"])
@@ -195,9 +199,9 @@ def test_kernel_trace_json(json_data):
         assert dispatch_info["agent_id"]["handle"] > 0
         assert dispatch_info["queue_id"]["handle"] > 0
         assert dispatch_info["kernel_id"] > 0
-        if not re.search(r"__amd_rocclr_.*", kernel_name):
-            assert kernel_name in valid_kernel_names
-
+        if re.search(r"__amd_rocclr_copyBuffer.*", kernel_name):
+            continue
+        assert kernel_name in valid_kernel_names
         assert dispatch_info["workgroup_size"]["x"] == 4
         assert dispatch_info["workgroup_size"]["y"] == 4
         assert dispatch_info["workgroup_size"]["z"] == 1
@@ -214,15 +218,16 @@ def test_memory_copy_trace(agent_info_input_data, memory_copy_input_data):
                 return row
         return None
 
+    # memory copies maybe less than two if rocr decides to use blit kernels
+    assert len(memory_copy_input_data) > 0
+
+    directions = set()
+    valid_directions = ("MEMORY_COPY_HOST_TO_DEVICE", "MEMORY_COPY_DEVICE_TO_HOST")
     for row in memory_copy_input_data:
         assert row["Kind"] == "MEMORY_COPY"
-
-    assert len(memory_copy_input_data) == 2
-
-    def test_row(idx, direction):
-        assert direction in ("MEMORY_COPY_HOST_TO_DEVICE", "MEMORY_COPY_DEVICE_TO_HOST")
-        row = memory_copy_input_data[idx]
-        assert row["Direction"] == direction
+        direction = row["Direction"]
+        assert direction in valid_directions
+        directions.add(direction)
         src_agent = get_agent(row["Source_Agent_Id"].split(" ")[-1])
         dst_agent = get_agent(row["Destination_Agent_Id"].split(" ")[-1])
         assert src_agent is not None and dst_agent is not None, f"{agent_info_input_data}"
@@ -235,8 +240,7 @@ def test_memory_copy_trace(agent_info_input_data, memory_copy_input_data):
         assert int(row["Correlation_Id"]) > 0
         assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
 
-    test_row(0, "MEMORY_COPY_HOST_TO_DEVICE")
-    test_row(1, "MEMORY_COPY_DEVICE_TO_HOST")
+    assert directions, "Expected at least one memory copy direction"
 
 
 def test_memory_copy_json_trace(json_data):
@@ -256,28 +260,29 @@ def test_memory_copy_json_trace(json_data):
         return None
 
     # one threads * two directions
-    assert len(memory_copy_data) >= 2, f"{memory_copy_data}"
-    assert (len(memory_copy_data) % 2) == 0, f"{memory_copy_data}"
+    # memory copies maybe less than two if rocr decides to use blit kernels
+    assert len(memory_copy_data) > 0, f"{memory_copy_data}"
 
-    def test_row(idx, direction):
-        assert direction in ("MEMORY_COPY_HOST_TO_DEVICE", "MEMORY_COPY_DEVICE_TO_HOST")
-        row = memory_copy_data[idx]
+    directions = set()
+    valid_directions = ("MEMORY_COPY_HOST_TO_DEVICE", "MEMORY_COPY_DEVICE_TO_HOST")
+    for row in memory_copy_data:
         src_agent = get_agent(row["src_agent_id"])
         dst_agent = get_agent(row["dst_agent_id"])
         assert get_kind_name(row["kind"]) == "MEMORY_COPY"
         assert src_agent is not None, f"{row}"
         assert dst_agent is not None, f"{row}"
-        if direction == "MEMORY_COPY_HOST_TO_DEVICE":
-            assert src_agent["type"] == 1
-            assert dst_agent["type"] == 2
+        if src_agent["type"] == 1 and dst_agent["type"] == 2:
+            directions.add("MEMORY_COPY_HOST_TO_DEVICE")
+        elif src_agent["type"] == 2 and dst_agent["type"] == 1:
+            directions.add("MEMORY_COPY_DEVICE_TO_HOST")
         else:
-            assert src_agent["type"] == 2
-            assert dst_agent["type"] == 1
+            assert (
+                False
+            ), f"Unexpected agent types: {src_agent['type']} -> {dst_agent['type']}"
         assert row["correlation_id"]["internal"] > 0
         assert row["end_timestamp"] >= row["start_timestamp"]
 
-    test_row(0, "MEMORY_COPY_HOST_TO_DEVICE")
-    test_row(1, "MEMORY_COPY_DEVICE_TO_HOST")
+    assert directions, "Expected at least one memory copy direction"
 
 
 def test_marker_api_trace(marker_input_data):

--- a/projects/rocprofiler-sdk/tests/rocprofv3/tracing/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/tracing/validate.py
@@ -125,11 +125,12 @@ def test_kernel_trace(kernel_input_data):
         "_Z15matrixTransposePfS_i.kd",
         "matrixTranspose(float*, float*, int)",
     )
+    found_valid_kernel = False
 
-    # memory copies maybe less than two if rocr decides to use blit kernels they show up in kernel data.
+    # Blit kernel maybe recorded, when greater than 1.
     assert len(kernel_input_data) >= 1
     for row in kernel_input_data:
-        if re.search(r"__amd_rocclr_copyBuffer.*", row["Kernel_Name"]):
+        if re.search(r"__amd_rocclr_.*", row["Kernel_Name"]):
             continue
         assert row["Kind"] == "KERNEL_DISPATCH"
         assert int(row["Agent_Id"].split(" ")[-1]) >= 0
@@ -144,6 +145,8 @@ def test_kernel_trace(kernel_input_data):
         assert int(row["Grid_Size_Y"]) == 1024
         assert int(row["Grid_Size_Z"]) == 1
         assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
+        found_valid_kernel = True
+    assert found_valid_kernel
 
 
 def test_host_functions_json(json_data):
@@ -187,8 +190,9 @@ def test_kernel_trace_json(json_data):
         "_Z15matrixTransposePfS_i.kd",
         "matrixTranspose(float*, float*, int)",
     )
+    found_valid_kernel = False
     kernel_dispatch_data = data["buffer_records"]["kernel_dispatch"]
-    # memory copies maybe less than two if rocr decides to use blit kernels they show up in kernel data.
+    # Blit kernel maybe recorded, when greater than 1.
     assert len(kernel_dispatch_data) >= 1
     for dispatch in kernel_dispatch_data:
         dispatch_info = dispatch["dispatch_info"]
@@ -199,7 +203,7 @@ def test_kernel_trace_json(json_data):
         assert dispatch_info["agent_id"]["handle"] > 0
         assert dispatch_info["queue_id"]["handle"] > 0
         assert dispatch_info["kernel_id"] > 0
-        if re.search(r"__amd_rocclr_copyBuffer.*", kernel_name):
+        if re.search(r"__amd_rocclr_.*", kernel_name):
             continue
         assert kernel_name in valid_kernel_names
         assert dispatch_info["workgroup_size"]["x"] == 4
@@ -209,17 +213,27 @@ def test_kernel_trace_json(json_data):
         assert dispatch_info["grid_size"]["y"] == 1024
         assert dispatch_info["grid_size"]["z"] == 1
         assert dispatch["end_timestamp"] >= dispatch["start_timestamp"]
+        found_valid_kernel = True
+    assert found_valid_kernel
 
 
-def test_memory_copy_trace(agent_info_input_data, memory_copy_input_data):
+def test_memory_copy_trace(
+    agent_info_input_data,
+    memory_copy_input_data,
+    kernel_input_data,
+):
     def get_agent(node_id):
         for row in agent_info_input_data:
             if row["Logical_Node_Id"] == node_id:
                 return row
         return None
 
-    # memory copies maybe less than two if rocr decides to use blit kernels
-    assert len(memory_copy_input_data) > 0
+    has_blit_kernel = any(
+        re.search(r"__amd_rocclr_.*", row["Kernel_Name"]) for row in kernel_input_data
+    )
+    # memory copies may be missing if rocr decides to use blit kernels
+    if not has_blit_kernel:
+        assert len(memory_copy_input_data) > 0
 
     directions = set()
     valid_directions = ("MEMORY_COPY_HOST_TO_DEVICE", "MEMORY_COPY_DEVICE_TO_HOST")
@@ -240,7 +254,13 @@ def test_memory_copy_trace(agent_info_input_data, memory_copy_input_data):
         assert int(row["Correlation_Id"]) > 0
         assert int(row["End_Timestamp"]) >= int(row["Start_Timestamp"])
 
-    assert directions, "Expected at least one memory copy direction"
+    expected_directions = set(valid_directions)
+    if has_blit_kernel:
+        assert directions.issubset(expected_directions)
+    else:
+        assert (
+            directions == expected_directions
+        ), f"Expected directions {expected_directions}, got {directions}"
 
 
 def test_memory_copy_json_trace(json_data):
@@ -260,8 +280,19 @@ def test_memory_copy_json_trace(json_data):
         return None
 
     # one threads * two directions
-    # memory copies maybe less than two if rocr decides to use blit kernels
-    assert len(memory_copy_data) > 0, f"{memory_copy_data}"
+    kernel_dispatch_data = buffer_records.get("kernel_dispatch", [])
+    has_blit_kernel = False
+    for dispatch in kernel_dispatch_data:
+        dispatch_info = dispatch["dispatch_info"]
+        kernel_name = data["kernel_symbols"][dispatch_info["kernel_id"]][
+            "formatted_kernel_name"
+        ]
+        if re.search(r"__amd_rocclr_.*", kernel_name):
+            has_blit_kernel = True
+            break
+    # memory copies may be missing if rocr decides to use blit kernels
+    if not has_blit_kernel:
+        assert len(memory_copy_data) > 0, f"{memory_copy_data}"
 
     directions = set()
     valid_directions = ("MEMORY_COPY_HOST_TO_DEVICE", "MEMORY_COPY_DEVICE_TO_HOST")
@@ -282,7 +313,13 @@ def test_memory_copy_json_trace(json_data):
         assert row["correlation_id"]["internal"] > 0
         assert row["end_timestamp"] >= row["start_timestamp"]
 
-    assert directions, "Expected at least one memory copy direction"
+    expected_directions = set(valid_directions)
+    if has_blit_kernel:
+        assert directions.issubset(expected_directions)
+    else:
+        assert (
+            directions == expected_directions
+        ), f"Expected directions {expected_directions}, got {directions}"
 
 
 def test_marker_api_trace(marker_input_data):

--- a/projects/rocprofiler-sdk/tests/rocprofv3/tracing/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/tracing/validate.py
@@ -26,6 +26,8 @@ import sys
 import pytest
 import re
 
+BLIT_KERN_REGEX = re.compile(r"__amd_rocclr_.*")
+
 
 def test_agent_info(agent_info_input_data):
     logical_node_id = max([int(itr["Logical_Node_Id"]) for itr in agent_info_input_data])
@@ -130,7 +132,7 @@ def test_kernel_trace(kernel_input_data):
     # Blit kernel maybe recorded, when greater than 1.
     assert len(kernel_input_data) >= 1
     for row in kernel_input_data:
-        if re.search(r"__amd_rocclr_.*", row["Kernel_Name"]):
+        if BLIT_KERN_REGEX.search(row["Kernel_Name"]):
             continue
         assert row["Kind"] == "KERNEL_DISPATCH"
         assert int(row["Agent_Id"].split(" ")[-1]) >= 0
@@ -203,7 +205,7 @@ def test_kernel_trace_json(json_data):
         assert dispatch_info["agent_id"]["handle"] > 0
         assert dispatch_info["queue_id"]["handle"] > 0
         assert dispatch_info["kernel_id"] > 0
-        if re.search(r"__amd_rocclr_.*", kernel_name):
+        if BLIT_KERN_REGEX.search(kernel_name):
             continue
         assert kernel_name in valid_kernel_names
         assert dispatch_info["workgroup_size"]["x"] == 4
@@ -229,7 +231,7 @@ def test_memory_copy_trace(
         return None
 
     has_blit_kernel = any(
-        re.search(r"__amd_rocclr_.*", row["Kernel_Name"]) for row in kernel_input_data
+        BLIT_KERN_REGEX.search(row["Kernel_Name"]) for row in kernel_input_data
     )
     # memory copies may be missing if rocr decides to use blit kernels
     if not has_blit_kernel:
@@ -287,7 +289,7 @@ def test_memory_copy_json_trace(json_data):
         kernel_name = data["kernel_symbols"][dispatch_info["kernel_id"]][
             "formatted_kernel_name"
         ]
-        if re.search(r"__amd_rocclr_.*", kernel_name):
+        if BLIT_KERN_REGEX.search(kernel_name):
             has_blit_kernel = True
             break
     # memory copies may be missing if rocr decides to use blit kernels


### PR DESCRIPTION
## Motivation

Fix test failures in http://rocm-ci.amd.com//job/rocm-tests/40057/testReport/junit/tests/TestSuite/test_rocprofilerSdk/

## Technical Details

- sometimes simple-transpose binary is using blit kernels for mem copies, which causes tests to fail in psdb. 

## JIRA ID

SWDEV-578807

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
