### PR TITLE
Cherry-pick PR #3138: Adding rocm_ci_caller to release/rocm-rel-7.2

### DIFF
--- a/.github/workflows/rocm_ci_caller.yml
+++ b/.github/workflows/rocm_ci_caller.yml
@@ -11,13 +11,12 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@v2.1.1
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: ${{ secrets.INTERNAL_ORG }}
-          repositories: ${{ secrets.INTERNAL_REPO }}
-
+          owner: ${{ github.repository_owner }}
+          
       - name: Trigger ROCm CI workflow
         env:
           TARGET_REPO: "${{ secrets.INTERNAL_ORG }}/${{ secrets.INTERNAL_REPO }}"

--- a/.github/workflows/rocm_ci_caller.yml
+++ b/.github/workflows/rocm_ci_caller.yml
@@ -1,0 +1,54 @@
+name: Trigger ROCm CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [develop]
+
+jobs:
+  trigger-rocm-ci:
+    runs-on: azure-vms
+    steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v2.1.1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ secrets.INTERNAL_ORG }}
+          repositories: ${{ secrets.INTERNAL_REPO }}
+
+      - name: Trigger ROCm CI workflow
+        env:
+          TARGET_REPO: "${{ secrets.INTERNAL_ORG }}/${{ secrets.INTERNAL_REPO }}"
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          echo "Triggering ROCm CI workflow"
+          echo "PR Number: ${{ github.event.pull_request.number }}"
+          
+          response=$(curl -s -w "%{http_code}" -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/$TARGET_REPO/dispatches \
+            -d "{
+              \"event_type\": \"public-psdb-run\",
+              \"client_payload\": {
+                \"input_sha\": \"${{ github.event.pull_request.head.sha }}\",
+                \"input_pr_num\": \"${{ github.event.pull_request.number }}\",
+                \"input_pr_url\": \"${{ github.event.pull_request.html_url }}\",
+                \"input_pr_title\": \"${{ github.event.pull_request.title }}\",
+                \"repository_name\": \"${{ github.repository }}\",
+                \"base_ref\": \"${{ github.event.pull_request.base.ref }}\",
+                \"trigger_event_type\": \"pull_request\",
+                \"comment_text\": \"\"
+              }
+            }")
+          
+          http_code="${response: -3}"
+          if [ "$http_code" = "204" ]; then
+            echo "Successfully triggered ROCm CI workflow"
+          else
+            echo "Failed to trigger ROCm CI workflow (HTTP $http_code)"
+            exit 1
+          fi

--- a/.github/workflows/rocm_ci_caller.yml
+++ b/.github/workflows/rocm_ci_caller.yml
@@ -15,7 +15,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          owner: ${{ secrets.INTERNAL_ORG }}
+          repositories: ${{ secrets.INTERNAL_REPO }}
           
       - name: Trigger ROCm CI workflow
         env:

--- a/.github/workflows/rocm_ci_caller.yml
+++ b/.github/workflows/rocm_ci_caller.yml
@@ -3,7 +3,7 @@ name: Trigger ROCm CI
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [develop]
+    branches: [release/rocm-rel-7.2]
 
 jobs:
   trigger-rocm-ci:


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/rocm-systems/pull/3138 onto release/rocm-rel-7.2.

**Original PR:** Adding rocm_ci_caller github action after decommission of azure

**Commits cherry-picked:**
- Adding rocm_ci_caller
- Fixing token generation
- Fix for App not found