### PR TITLE
rocr: Fix SIOF crash in XDNA driver

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -48,7 +48,6 @@
 #include <unistd.h>
 
 #include <array>
-#include <filesystem>
 #include <fstream>
 #include <map>
 #include <memory>
@@ -87,14 +86,13 @@ static const std::map<XDNADeviceId, XDNADeviceType> supported_xdna_devices = {
     {{0x17f0}, XDNADeviceType::Stx},  // Strix Halo / Krackan
 };
 
-namespace fs = std::filesystem;
 
 /// @brief Devnode path for XDNA devices.
-static const fs::path devnodes_path = "/dev/accel";
+static constexpr const char* devnodes_path = "/dev/accel";
 /// @brief Sysfs path for XDNA devices.
-static const fs::path sysfs_path = "/sys/class/accel";
+static constexpr const char* sysfs_path = "/sys/class/accel";
 /// @brief Devnode prefix for XDNA devices.
-static const std::string devnode_prefix = "accel";
+static constexpr const char* devnode_prefix = "accel";
 /// @brief Maximum devnode minor number for XDNA devices.
 static const uint32_t devnode_max_minor_num = 64;
 
@@ -139,7 +137,7 @@ XdnaDriver::XdnaDriver(std::string devnode_name)
 
 hsa_status_t XdnaDriver::DiscoverDriver(std::unique_ptr<core::Driver>& driver) {
   for (uint32_t i = 0; i < devnode_max_minor_num; ++i) {
-    auto tmp_driver = std::make_unique<XdnaDriver>(devnode_prefix + std::to_string(i));
+    auto tmp_driver = std::make_unique<XdnaDriver>(std::string(devnode_prefix) + std::to_string(i));
     if (tmp_driver->Open() == HSA_STATUS_SUCCESS) {
       if (tmp_driver->QueryKernelModeDriver(core::DriverQuery::GET_DRIVER_VERSION) ==
           HSA_STATUS_SUCCESS) {
@@ -174,7 +172,7 @@ hsa_status_t XdnaDriver::QueryKernelModeDriver(core::DriverQuery query) {
 }
 
 hsa_status_t XdnaDriver::Open() {
-  const auto devnode_path = devnodes_path / devnode_name_;
+  const std::string devnode_path = std::string(devnodes_path) + "/" + devnode_name_;
   fd_ = open(devnode_path.c_str(), O_RDWR | O_CLOEXEC);
   if (fd_ < 0) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
@@ -210,13 +208,13 @@ hsa_status_t XdnaDriver::GetNodeProperties(HsaNodeProperties& node_props, uint32
     return HSA_STATUS_ERROR;
   }
 
-  const auto sysfs_device_path = sysfs_path / devnode_name_ / "device";
+  const std::string sysfs_device_path = std::string(sysfs_path) + "/" + devnode_name_ + "/device";
 
   // Find device type.
   XDNADeviceType device_type = XDNADeviceType::Unknown;
   {
-    const auto device_id_file = sysfs_device_path / "device";
-    if (!fs::exists(device_id_file)) {
+    const std::string device_id_file = sysfs_device_path + "/device";
+    if (access(device_id_file.c_str(), F_OK) != 0) {
       assert(false && "Device file not found in sysfs.");
       return HSA_STATUS_ERROR;
     }
@@ -262,8 +260,8 @@ hsa_status_t XdnaDriver::GetNodeProperties(HsaNodeProperties& node_props, uint32
 
   // Read device name from sysfs.
   {
-    const auto device_name_file = sysfs_device_path / "vbnv";
-    if (!fs::exists(device_name_file)) {
+    const std::string device_name_file = sysfs_device_path + "/vbnv";
+    if (access(device_name_file.c_str(), F_OK) != 0) {
       assert(false && "Device file name not found in sysfs.");
       return HSA_STATUS_ERROR;
     }


### PR DESCRIPTION
Static fs::path objects cause crashes during unload due to undefined destructor ordering. Replace with constexpr const char*.


