### PR TITLE
SWDEV-544298_AINIC_implementation - Handle case where machine has no …

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -1764,7 +1764,7 @@ class AMDSMICommands():
             self.logger.print_output(multiple_device_enabled=multiple_devices_csv_override)
 
     def _static_nics(self, args, multiple_devices, nic):
-        if args.nic == None:
+        if not hasattr(args, "nic") or args.nic == None:
             nic = None
             if self.helpers.is_ainic_initialized():
                 nic = self.device_handles_ainics


### PR DESCRIPTION
…NIC and we are doing 'amd-smi static'

## Motivation

On machine with no AI-NIC card, running this command gives error:

amd-smi static
AttributeError: 'Namespace' object has no attribute 'nic'

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
