### PR TITLE
rocr: Fix restoring SCHED_MODE in gfx12 trap handler

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler_gfx12.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler_gfx12.s
@@ -224,7 +224,7 @@
     // Save SCHED_MODE from ttmp1[27:26] into ttmp11[27:26]. We will restore it on exit
     s_andn2_b32         ttmp11, ttmp11, TTMP11_SCHED_MODE_MASK
     s_and_b32           ttmp2,  ttmp1, TTMP1_SCHED_MODE_MASK
-    s_or_b32            ttmp11, ttmp2, TTMP1_SCHED_MODE_MASK
+    s_or_b32            ttmp11, ttmp11, ttmp2
   .endif
   s_mov_b32           ttmp3, 0
 


### PR DESCRIPTION
The code to restore SCHED_MODE on exit has an issue and incorrectly restores advanced scheduling mode unconditionally.  Fix this and restore the expected value.