### PR TITLE
Add hsa_amd_memory_async_batch_copy API for batched memory copies

### DIFF
--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -2790,8 +2790,14 @@ static amd::CopyMetadata buildCopyMetadataFromAttrs(hipMemcpyAttributes* attrs, 
   }
 
   // Map flags
-  if (attrs[attrIdx].flags & hipMemcpyFlagPreferOverlapWithCompute) {
-    metadata.preferOverlapCompute_ = 1;
+  unsigned int flags = attrs[attrIdx].flags;
+  if (flags & hipMemcpyFlagExtPreferCE) {
+    metadata.preferCE_ = 1;
+  }
+  if (flags & hipMemcpyFlagExtOpSwap) {
+    metadata.copyOpType_ = amd::CopyMetadata::kCopyOpSwap;
+  } else if (flags & hipMemcpyFlagExtOpIndirect) {
+    metadata.copyOpType_ = amd::CopyMetadata::kCopyOpIndirect;
   }
 
   return metadata;
@@ -2883,7 +2889,10 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
     batchCmd->release();
   }
 
-  // Handle write buffer (host to device) copies
+  // Handle write buffer (host to device) copies.
+  // This path handles kSrcAccessOrderDuringApiCall and kSrcAccessOrderAny for host sources
+  // that lack a memory object (e.g. malloc'd or stack pointers). The writeBuffer path
+  // handles kSrcAccessOrderDuringApiCall
   for (size_t idx : writeBufferIndices) {
     status = ihipMemcpy(dsts[idx], srcs[idx], sizes[idx], hipMemcpyDefault, stream, isAsync, true);
     if (status != hipSuccess) {
@@ -2945,10 +2954,16 @@ hipError_t hipMemcpyBatchAsync(void** dsts, void** srcs, size_t* sizes, size_t c
         HIP_RETURN(hipErrorInvalidValue);
       }
     }
-    // Validate srcAccessOrder values
+    // Validate srcAccessOrder values and flags
     for (size_t i = 0; i < numAttrs; ++i) {
       if (attrs[i].srcAccessOrder < hipMemcpySrcAccessOrderStream ||
           attrs[i].srcAccessOrder > hipMemcpySrcAccessOrderAny) {
+        HIP_RETURN(hipErrorInvalidValue);
+      }
+      // ExtOp flags are mutually exclusive
+      unsigned int extOpBits = attrs[i].flags &
+          (hipMemcpyFlagExtOpSwap | hipMemcpyFlagExtOpIndirect);
+      if (extOpBits & (extOpBits - 1)) {
         HIP_RETURN(hipErrorInvalidValue);
       }
     }

--- a/projects/clr/rocclr/device/blit.cpp
+++ b/projects/clr/rocclr/device/blit.cpp
@@ -352,8 +352,7 @@ bool HostBlitManager::copyBufferRect(device::Memory& srcMemory, device::Memory& 
   return true;
 }
 
-bool HostBlitManager::copyBufferBatch(std::vector<amd::BatchCopyOp>& copyOps,
-                                      bool entire) const {
+bool HostBlitManager::copyBufferBatch(std::vector<amd::BatchCopyOp>& copyOps) const {
   // Default implementation falls back to individual copies
   for (auto& op : copyOps) {
     if (op.srcMemory == nullptr || op.dstMemory == nullptr) {
@@ -369,7 +368,7 @@ bool HostBlitManager::copyBufferBatch(std::vector<amd::BatchCopyOp>& copyOps,
     amd::Coord3D srcOrigin(op.srcOffset);
     amd::Coord3D dstOrigin(op.dstOffset);
     amd::Coord3D size(op.size);
-    if (!copyBuffer(*srcDevMem, *dstDevMem, srcOrigin, dstOrigin, size, entire, op.metadata)) {
+    if (!copyBuffer(*srcDevMem, *dstDevMem, srcOrigin, dstOrigin, size, false, op.metadata)) {
       return false;
     }
   }

--- a/projects/clr/rocclr/device/blit.hpp
+++ b/projects/clr/rocclr/device/blit.hpp
@@ -161,8 +161,7 @@ class BlitManager : public amd::HeapObject {
 
   //! Copies multiple buffer objects in a batch
   virtual bool copyBufferBatch(
-      std::vector<amd::BatchCopyOp>& copyOps,  //!< Batch of copy operations
-      bool entire = false                      //!< Entire buffers will be updated
+      std::vector<amd::BatchCopyOp>& copyOps  //!< Batch of copy operations
   ) const = 0;
 
   //! Copies an image object to a buffer object
@@ -360,8 +359,7 @@ class HostBlitManager : public device::BlitManager {
 
   //! Copies multiple buffer objects in a batch
   virtual bool copyBufferBatch(
-      std::vector<amd::BatchCopyOp>& copyOps,  //!< Batch of copy operations
-      bool entire = false                      //!< Entire buffers will be updated
+      std::vector<amd::BatchCopyOp>& copyOps  //!< Batch of copy operations
   ) const;
 
   //! Copies an image object to a buffer object

--- a/projects/clr/rocclr/device/pal/palvirtual.cpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.cpp
@@ -2111,7 +2111,7 @@ void VirtualGPU::submitBatchCopyMemory(amd::BatchCopyMemoryCommand& cmd) {
   bool result = true;
 
   // Execute batch copy through blit manager
-  result = blitMgr().copyBufferBatch(copyOps, false);
+  result = blitMgr().copyBufferBatch(copyOps);
 
   if (!result) {
     LogError("submitBatchCopyMemory failed!");

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -26,6 +26,7 @@
 #include "device/rocm/rocsched.hpp"
 #include "utils/debug.hpp"
 #include <algorithm>
+#include <map>
 
 namespace amd::roc {
 DmaBlitManager::DmaBlitManager(VirtualGPU& gpu, Setup setup)
@@ -131,6 +132,9 @@ bool DmaBlitManager::readImage(device::Memory& srcMemory, void* dstHost, const a
 }
 
 // ================================================================================================
+// This path handles kSrcAccessOrderDuringApiCall for ephemeral host sources:
+// hsaCopyStagedOrPinned performs a synchronous memcpy into a staging buffer, consuming the
+// source data before the async DMA is queued, so the source can safely go out of scope.
 bool DmaBlitManager::writeBuffer(const void* srcHost, device::Memory& dstMemory,
                                  const amd::Coord3D& origin, const amd::Coord3D& size, bool entire,
                                  amd::CopyMetadata copyMetadata) const {
@@ -288,18 +292,18 @@ bool DmaBlitManager::copyBufferRect(device::Memory& srcMemory, device::Memory& d
     HwQueueEngine engine = HwQueueEngine::Unknown;
     if (srcAgent.handle == dstAgent.handle) {
       // Same device transfer
-      engine = HwQueueEngine::SdmaIntra;
+      engine = HwQueueEngine::SdmaD2D;
     } else {
       // Different devices transfer
       if (srcAgent.handle == dev().getCpuAgent().handle) {
         // CPU to device
-        engine = HwQueueEngine::SdmaWrite;
+        engine = HwQueueEngine::SdmaH2D;
       } else if (dstAgent.handle == dev().getCpuAgent().handle) {
         // Device to CPU
-        engine = HwQueueEngine::SdmaRead;
+        engine = HwQueueEngine::SdmaD2H;
       } else {
         // Device to different device
-        engine = HwQueueEngine::SdmaInter;
+        engine = HwQueueEngine::SdmaP2P;
       }
     }
 
@@ -357,50 +361,19 @@ bool DmaBlitManager::copyBufferRect(device::Memory& srcMemory, device::Memory& d
 }
 
 // ================================================================================================
-bool DmaBlitManager::copyBufferBatch(std::vector<amd::BatchCopyOp>& copyOps,
-                                     bool entire) const {
+bool DmaBlitManager::copyBufferBatch(std::vector<amd::BatchCopyOp>& copyOps) const {
   if (copyOps.empty()) {
     return true;
   }
 
-  gpu().releaseGpuMemoryFence(true /* skipCpuWait */);
-
-  // Process each copy operation in the batch
-  // For now, we use the same signal completion approach as single copies
-  // Future optimization: use a shared completion signal for all operations
-  bool result = true;
-
-  for (auto& op : copyOps) {
-    if (op.srcMemory == nullptr || op.dstMemory == nullptr) {
-      LogError("DmaBlitManager::copyBufferBatch - Invalid memory objects!");
-      return false;
-    }
-
-    // Get device memory for source and destination
-    device::Memory* srcDevMem = op.srcMemory->getDeviceMemory(
-        *op.srcMemory->getContext().devices()[0]);
-    device::Memory* dstDevMem = op.dstMemory->getDeviceMemory(
-        *op.dstMemory->getContext().devices()[0]);
-
-    if (srcDevMem == nullptr || dstDevMem == nullptr) {
-      LogError("DmaBlitManager::copyBufferBatch - Failed to get device memory!");
-      return false;
-    }
-
-    // Fall back to individual copy using hsaCopy
-    amd::Coord3D srcOrigin(op.srcOffset);
-    amd::Coord3D dstOrigin(op.dstOffset);
-    amd::Coord3D size(op.size);
-
-    if (!hsaCopy(gpuMem(*srcDevMem), gpuMem(*dstDevMem), srcOrigin, dstOrigin, size,
-                 op.metadata)) {
-      LogPrintfError("DmaBlitManager::copyBufferBatch - Copy failed for operation");
-      result = false;
-      break;
-    }
+  // Memory objects are already validated in HIP API layer
+  // All operations here are inter-device; use the unified batch copy path
+  if (!hsaCopyBatch(copyOps)) {
+    LogPrintfError("DmaBlitManager::copyBufferBatch - Batch copy failed");
+    return false;
   }
 
-  return result;
+  return true;
 }
 
 // ================================================================================================
@@ -531,18 +504,18 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
   // Determine engine based on source and destination agents
   if (srcAgent.handle == dstAgent.handle) {
     // Device to same device
-    engine = HwQueueEngine::SdmaIntra;
+    engine = HwQueueEngine::SdmaD2D;
   } else {
     // Different devices
     if (srcAgent.handle == dev().getCpuAgent().handle) {
       // CPU to device
-      engine = HwQueueEngine::SdmaWrite;
+      engine = HwQueueEngine::SdmaH2D;
     } else if (dstAgent.handle == dev().getCpuAgent().handle) {
       // Device to CPU
-      engine = HwQueueEngine::SdmaRead;
+      engine = HwQueueEngine::SdmaD2H;
     } else {
       // Device to different device
-      engine = HwQueueEngine::SdmaInter;
+      engine = HwQueueEngine::SdmaP2P;
     }
   }
 
@@ -554,14 +527,10 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
     // Check if this VirtualGPU already has an assigned engine with affinity
     uint32_t assignedEngineMask = gpu().AssignedSdmaEngine();
 
-    // For inter-GPU copies, always query preferred engine based on agents
-    // because the allocator has special logic to select high-bandwidth engines
-    // for specific src/dst pairs, and we shouldn't reuse an engine from a different copy type
-
     // On GPUs with asymmetric engine restrictions copy_on_engine API will fail.
     // Guard against this by validating the cached engine
     uint32_t validMaskForEngine = dev().GetSdmaValidMask(engine);
-    if (assignedEngineMask != 0 && engine != HwQueueEngine::SdmaInter &&
+    if (assignedEngineMask != 0 && engine != HwQueueEngine::SdmaP2P &&
         (assignedEngineMask & validMaskForEngine)) {
       // This VirtualGPU/stream already has an assigned engine that is valid for the
       // current copy direction - just use it. Stream ordering handles any busy conditions.
@@ -593,17 +562,17 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
       // Copy on the first available free engine if ROCr returns a valid mask
       hsa_amd_sdma_engine_id_t copyEngine = static_cast<hsa_amd_sdma_engine_id_t>(copyMask);
 
-      // Check if engine type is SdmaInter and adjust agents accordingly
+      // Check if engine type is SdmaP2P and adjust agents accordingly
       // ROCr copy api would always choose SDMA engine of the srcAgent if its a GPU
-      if (engine == HwQueueEngine::SdmaInter) {
+      if (engine == HwQueueEngine::SdmaP2P) {
         srcAgent = dev().getBackendDevice();
         forceSDMA = true;
       }
 
       ClPrint(amd::LOG_DEBUG, amd::LOG_COPY2,
               "HSA Copy copy_engine=0x%x, dst=0x%zx, src=0x%zx, "
-              "size=%ld, forceSDMA=%d, engineType=%d, wait_event=0x%zx, completion_signal=0x%zx",
-              copyEngine, dst, src, size, forceSDMA, engine,
+              "size=%ld, forceSDMA=%d, engineOp=%s, wait_event=0x%zx, completion_signal=0x%zx",
+              copyEngine, dst, src, size, forceSDMA, EngineOpName(engine),
               (wait_events.size() != 0) ? wait_events[0].handle : 0, active.handle);
 
       status =
@@ -617,9 +586,9 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
   if (engine == HwQueueEngine::Unknown || kUseRegularCopyApi) {
     ClPrint(amd::LOG_DEBUG, amd::LOG_COPY2,
             "HSA Copy dst=0x%zx, src=0x%zx, size=%ld, wait_event=0x%zx, "
-            "completion_signal=0x%zx, engineType=%d",
+            "completion_signal=0x%zx, engineOp=%s",
             dst, src, size, (wait_events.size() != 0) ? wait_events[0].handle : 0, active.handle,
-            engine);
+            EngineOpName(engine));
 
     status = Hsa::memory_async_copy(dst, dstAgent, src, srcAgent, size, wait_events.size(),
                                     wait_events.data(), active);
@@ -639,6 +608,37 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
 
 
 // ================================================================================================
+// Resolves the real HSA agents for a src/dst memory pair using pointer_info
+inline void DmaBlitManager::resolveAgents(const Memory& srcMem, const Memory& dstMem,
+                                          address srcAddr, address dstAddr,
+                                          hsa_agent_t& srcAgent, hsa_agent_t& dstAgent) const {
+  if (&srcMem.dev() == &dstMem.dev()) {
+    // Same device -- detect agents from memory access type
+    srcAgent = srcMem.isHostMemDirectAccess() ? dev().getCpuAgent() : dev().getBackendDevice();
+    dstAgent = dstMem.isHostMemDirectAccess() ? dev().getCpuAgent() : dev().getBackendDevice();
+
+    // IPC buffers: the runtime doesn't know the real owning agent, query pointer_info
+    if (static_cast<const amd::Memory*>(srcMem.owner())->ipcShared()) {
+      hsa_amd_pointer_info_t info = {sizeof(hsa_amd_pointer_info_t)};
+      if (HSA_STATUS_SUCCESS ==
+          Hsa::pointer_info(const_cast<address>(srcAddr), &info, nullptr, nullptr, nullptr)) {
+        srcAgent = info.agentOwner;
+      }
+    }
+    if (static_cast<const amd::Memory*>(dstMem.owner())->ipcShared()) {
+      hsa_amd_pointer_info_t info = {sizeof(hsa_amd_pointer_info_t)};
+      if (HSA_STATUS_SUCCESS == Hsa::pointer_info(dstAddr, &info, nullptr, nullptr, nullptr)) {
+        dstAgent = info.agentOwner;
+      }
+    }
+  } else {
+    // Different devices -- use each memory's device backend agent
+    srcAgent = srcMem.dev().getBackendDevice();
+    dstAgent = dstMem.dev().getBackendDevice();
+  }
+}
+
+// ================================================================================================
 bool DmaBlitManager::hsaCopy(const Memory& srcMemory, const Memory& dstMemory,
                              const amd::Coord3D& srcOrigin, const amd::Coord3D& dstOrigin,
                              const amd::Coord3D& size, amd::CopyMetadata& copyMetadata) const {
@@ -652,32 +652,7 @@ bool DmaBlitManager::hsaCopy(const Memory& srcMemory, const Memory& dstMemory,
 
   hsa_agent_t srcAgent;
   hsa_agent_t dstAgent;
-
-  if (&srcMemory.dev() == &dstMemory.dev()) {
-    // Detect the agents for memory allocations
-    srcAgent = (srcMemory.isHostMemDirectAccess()) ? dev().getCpuAgent() : dev().getBackendDevice();
-    dstAgent = (dstMemory.isHostMemDirectAccess()) ? dev().getCpuAgent() : dev().getBackendDevice();
-
-    // When a memory is opened as IPCBuffer, the runtime is not aware of the agent that
-    // owns the memory, thus query the pointer info here.
-    if (static_cast<const amd::Memory*>(srcMemory.owner())->ipcShared()) {
-      hsa_amd_pointer_info_t info = {sizeof(hsa_amd_pointer_info_t)};
-      if (HSA_STATUS_SUCCESS ==
-          Hsa::pointer_info(const_cast<address>(src), &info, nullptr, nullptr, nullptr)) {
-        srcAgent = info.agentOwner;
-      }
-    }
-
-    if (static_cast<const amd::Memory*>(dstMemory.owner())->ipcShared()) {
-      hsa_amd_pointer_info_t info = {sizeof(hsa_amd_pointer_info_t)};
-      if (HSA_STATUS_SUCCESS == Hsa::pointer_info(dst, &info, nullptr, nullptr, nullptr)) {
-        dstAgent = info.agentOwner;
-      }
-    }
-  } else {
-    srcAgent = srcMemory.dev().getBackendDevice();
-    dstAgent = dstMemory.dev().getBackendDevice();
-  }
+  resolveAgents(srcMemory, dstMemory, src, dst, srcAgent, dstAgent);
 
   // Blocking D2H copies need a wait anyways so better wait here
   // than having to wait on the device for dependent signals for SDMA which is slow
@@ -691,6 +666,210 @@ bool DmaBlitManager::hsaCopy(const Memory& srcMemory, const Memory& dstMemory,
   return rocrCopyBuffer(dst, dstAgent, src, srcAgent, size[0], copyMetadata);
 }
 
+// ================================================================================================
+bool DmaBlitManager::hsaCopyBatch(const std::vector<amd::BatchCopyOp>& copyOps,
+                                  const std::vector<hsa_signal_t>* externalWaitEvents,
+                                  std::vector<ProfilingSignal*>* outBatchSignals) const {
+  if (copyOps.empty()) {
+    return true;
+  }
+
+  // Build the array of HSA copy operation descriptors
+  std::vector<hsa_amd_memory_copy_op_t> hsaCopyOps;
+  hsaCopyOps.reserve(copyOps.size());
+
+  for (const auto& op : copyOps) {
+    const Memory& srcMem = gpuMem(*op.srcMemory->getDeviceMemory(
+        *op.srcMemory->getContext().devices()[0]));
+    const Memory& dstMem = gpuMem(*op.dstMemory->getDeviceMemory(
+        *op.dstMemory->getContext().devices()[0]));
+
+    address src = reinterpret_cast<address>(srcMem.getDeviceMemory()) + op.srcOffset;
+    address dst = reinterpret_cast<address>(dstMem.getDeviceMemory()) + op.dstOffset;
+
+    hsa_agent_t srcAgent;
+    hsa_agent_t dstAgent;
+    resolveAgents(srcMem, dstMem, src, dst, srcAgent, dstAgent);
+
+    hsa_amd_memory_copy_op_t hsaOp = {};
+    hsaOp.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
+    hsaOp.src = src;
+    hsaOp.src_agent = srcAgent;
+    hsaOp.dst = dst;
+    hsaOp.dst_agent = dstAgent;
+    hsaOp.size = op.size;
+
+    switch (op.metadata.copyOpType_) {
+    case amd::CopyMetadata::kCopyOpSwap:
+      hsaOp.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP;
+      hsaOp.src_size = op.size;
+      hsaOp.dst_size = op.size;
+      break;
+    case amd::CopyMetadata::kCopyOpIndirect:
+      hsaOp.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT;
+      break;
+    default:
+      hsaOp.type = HSA_AMD_MEMORY_COPY_OP_LINEAR;
+      break;
+    }
+
+    hsaCopyOps.push_back(hsaOp);
+  }
+
+  return rocrCopyBufferBatch(hsaCopyOps, externalWaitEvents, outBatchSignals);
+}
+
+// ================================================================================================
+bool DmaBlitManager::rocrCopyBufferBatch(const std::vector<hsa_amd_memory_copy_op_t>& copyOps,
+                                         const std::vector<hsa_signal_t>* externalWaitEvents,
+                                         std::vector<ProfilingSignal*>* outBatchSignals) const {
+
+  if (copyOps.empty()) {
+    return true;
+  }
+
+  hsa_agent_t cpuAgent = dev().getCpuAgent();
+
+  // Group ops by engine type so each engine group gets its own completion signal.
+  // Only SdmaD2H(1), SdmaH2D(2), SdmaD2D(3) are used; size must cover max index + 1.
+  constexpr size_t kNumCopyOpBins = HwQueueEngine::SdmaD2D + 1;
+  std::vector<hsa_amd_memory_copy_op_t> engineOps[kNumCopyOpBins];
+
+  for (const auto& op : copyOps) {
+    HwQueueEngine engine;
+    if (op.src_agent.handle == cpuAgent.handle) {
+      engine = HwQueueEngine::SdmaH2D;
+    } else if (op.dst_agent.handle == cpuAgent.handle) {
+      engine = HwQueueEngine::SdmaD2H;
+    } else {
+      engine = HwQueueEngine::SdmaD2D;
+    }
+    engineOps[engine].push_back(op);
+  }
+
+  // Capture wait events once before dispatching any groups.
+  std::vector<hsa_signal_t> wait_events;
+  if (externalWaitEvents) {
+    wait_events = *externalWaitEvents;
+  } else {
+    wait_events = gpu().Barriers().WaitingSignal(HwQueueEngine::Unknown);
+  }
+
+  // Submit each non-empty engine group as a separate batch with its own signal.
+  // Within each group, ops sharing the same (src, src_agent, size) are
+  // collapsed into a single BROADCAST op.
+  hsa_status_t status = HSA_STATUS_SUCCESS;
+  std::vector<ProfilingSignal*> groupSignals;
+
+  for (uint32_t e = 0; e < kNumCopyOpBins; ++e) {
+    auto& ops = engineOps[e];
+    if (ops.empty()) continue;
+
+    HwQueueEngine engine = static_cast<HwQueueEngine>(e);
+
+    // Group ops by common source identity (src ptr, src_agent, size).
+    // Multi-destination groups become BROADCAST; single-destination stay LINEAR.
+    struct CopyOpKey {
+      const void* src;
+      uint64_t src_agent;
+      size_t size;
+      bool operator<(const CopyOpKey& o) const {
+        if (src != o.src) return src < o.src;
+        if (src_agent != o.src_agent) return src_agent < o.src_agent;
+        return size < o.size;
+      }
+    };
+
+    struct CopyOpGroup {
+      hsa_amd_memory_copy_op_t tmpl;
+      std::vector<void*> dsts;
+      std::vector<hsa_agent_t> dst_agents;
+    };
+    std::map<CopyOpKey, CopyOpGroup> op_groups;
+
+    for (const auto& op : ops) {
+      CopyOpKey key{op.src, op.src_agent.handle, op.size};
+      auto& grp = op_groups[key];
+      if (grp.dsts.empty()) {
+        grp.tmpl = op;
+      }
+      grp.dsts.push_back(op.dst);
+      grp.dst_agents.push_back(op.dst_agent);
+    }
+
+    // Build final ops: each gets its own completion signal with value 1.
+    gpu().Barriers().SetActiveEngine(engine);
+
+    std::vector<hsa_amd_memory_copy_op_t> finalOps;
+    finalOps.reserve(op_groups.size());
+
+    for (auto& [key, grp] : op_groups) {
+      hsa_signal_t completion_signal = gpu().Barriers().ActiveSignal(1, gpu().timestamp());
+
+      if (grp.dsts.size() > 1 && engine == HwQueueEngine::SdmaD2D) {
+        hsa_amd_memory_copy_op_t op = {};
+        op.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
+        op.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST;
+        op.src = grp.tmpl.src;
+        op.src_agent = grp.tmpl.src_agent;
+        op.dst_list = grp.dsts.data();
+        op.dst_agent_list = grp.dst_agents.data();
+        op.num_dsts = static_cast<uint32_t>(grp.dsts.size());
+        op.size = grp.tmpl.size;
+        op.completion_signal = completion_signal;
+        finalOps.push_back(op);
+      } else {
+        grp.tmpl.completion_signal = completion_signal;
+        finalOps.push_back(grp.tmpl);
+      }
+    }
+
+    for (size_t i = 0; i < finalOps.size(); ++i) {
+      const auto& op = finalOps[i];
+      if (op.type == HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST) {
+        for (uint32_t d = 0; d < op.num_dsts; ++d) {
+          ClPrint(amd::LOG_DEBUG, amd::LOG_COPY2,
+                  "HSA BatchCopy Broadcast [%u/%u] engineOp=%s, src=%p, dst=%p, "
+                  "size=%zu, wait_event=0x%zx, completion_signal=0x%zx",
+                  d, op.num_dsts, EngineOpName(engine), op.src, op.dst_list[d],
+                  op.size, (wait_events.size() != 0) ? wait_events[0].handle : 0,
+                  op.completion_signal.handle);
+        }
+      } else {
+        ClPrint(amd::LOG_DEBUG, amd::LOG_COPY2,
+                "HSA BatchCopy Linear [%zu/%zu] engineOp=%s, dst=%p, src=%p, size=%zu, "
+                "wait_event=0x%zx, completion_signal=0x%zx",
+                i, finalOps.size(), EngineOpName(engine), (void*)op.dst, op.src, op.size,
+                (wait_events.size() != 0) ? wait_events[0].handle : 0,
+                op.completion_signal.handle);
+      }
+    }
+
+    status = Hsa::memory_async_batch_copy(
+        finalOps.data(), static_cast<uint32_t>(finalOps.size()),
+        wait_events.size(), wait_events.data());
+
+    if (status != HSA_STATUS_SUCCESS) {
+      gpu().Barriers().ResetCurrentSignal();
+      LogPrintfError("HSA batch copy failed with code %d for engine %d", status, engine);
+      return false;
+    }
+
+    groupSignals.push_back(gpu().Barriers().GetLastSignal());
+  }
+
+  // All-but-last group signals go to outBatchSignals for external tracking.
+  // The last group's signal remains at GetLastSignal() for the caller.
+  if (outBatchSignals) {
+    for (size_t i = 0; i + 1 < groupSignals.size(); ++i) {
+      outBatchSignals->push_back(groupSignals[i]);
+    }
+  }
+
+  gpu().addSystemScope();
+  gpu().setFenceDirty(false);
+  return true;
+}
 
 // ================================================================================================
 // Get Staging or Pinned memory buffer
@@ -2304,6 +2483,120 @@ bool KernelBlitManager::shaderCopyBuffer(address dst, address src, const amd::Co
   releaseArguments(parameters);
 
   return result;
+}
+
+// ================================================================================================
+bool KernelBlitManager::copyBufferBatch(std::vector<amd::BatchCopyOp>& copyOps) const {
+  if (copyOps.empty()) {
+    return true;
+  }
+
+  //If there is intra-device copies, SDMA copies can overlap
+  const bool kSkipCpuWait = true;
+  gpu().releaseGpuMemoryFence(kSkipCpuWait);
+
+  // Capture prior wait events and signal before any work.
+  std::vector<hsa_signal_t> priorWaitEvents =
+      gpu().Barriers().WaitingSignal(HwQueueEngine::Unknown);
+  ProfilingSignal* priorSignal = gpu().Barriers().GetLastSignal();
+
+  // Partition into intra-device (kernel blit) and inter-device (DMA batch) groups.
+  std::vector<amd::BatchCopyOp> d2dCopyOps;
+  std::vector<amd::BatchCopyOp> p2pCopyOps;
+
+  for (auto& op : copyOps) {
+    device::Memory* srcDevMem = op.srcMemory->getDeviceMemory(
+        *op.srcMemory->getContext().devices()[0]);
+    device::Memory* dstDevMem = op.dstMemory->getDeviceMemory(
+        *op.dstMemory->getContext().devices()[0]);
+
+    if (srcDevMem == nullptr || dstDevMem == nullptr) {
+      LogError("KernelBlitManager::copyBufferBatch: Invalid memory objects!");
+      return false;
+    }
+
+    // Resolve real agents for partition decision (handles IPC shared memory)
+    const Memory& srcMem = gpuMem(*srcDevMem);
+    const Memory& dstMem = gpuMem(*dstDevMem);
+    address srcAddr = reinterpret_cast<address>(srcMem.getDeviceMemory()) + op.srcOffset;
+    address dstAddr = reinterpret_cast<address>(dstMem.getDeviceMemory()) + op.dstOffset;
+
+    hsa_agent_t srcAgent;
+    hsa_agent_t dstAgent;
+    resolveAgents(srcMem, dstMem, srcAddr, dstAddr, srcAgent, dstAgent);
+
+    if (srcAgent.handle == dstAgent.handle && !op.metadata.preferCE_) {
+      d2dCopyOps.push_back(op);
+    } else {
+      p2pCopyOps.push_back(op);
+    }
+  }
+
+  // Dispatch inter-device/pagelocked read/write batch first so SDMA engines start early.
+  // The batch uses a single completion signal tracked at current_id_.
+  std::vector<ProfilingSignal*> batchSignals;
+  ProfilingSignal* lastBatchSignal = nullptr;
+  if (!p2pCopyOps.empty()) {
+    // Always pass prior wait events to maintain stream ordering for the batch.
+    if (!hsaCopyBatch(p2pCopyOps, &priorWaitEvents, &batchSignals)) {
+      LogWarning(
+          "KernelBlitManager::copyBufferBatch: Batch copy failed, falling back to copyBuffer");
+      d2dCopyOps.insert(d2dCopyOps.end(), p2pCopyOps.begin(), p2pCopyOps.end());
+    } else {
+      // Save the last batch signal (at current_id_) before intra copies might advance it.
+      lastBatchSignal = gpu().Barriers().GetLastSignal();
+    }
+  }
+
+  // Dispatch intra-device copies for overlap with SDMA.
+  // Set engine to Compute so WaitingSignal(Compute) inside copyBuffer does not
+  // see an engine switch and does not add the batch's current_id_ as a dependency.
+  if (!d2dCopyOps.empty()) {
+    gpu().Barriers().SetActiveEngine(HwQueueEngine::Compute);
+    // Re-add priorSignal as external so intra copies depend on prior stream operations.
+    if (priorSignal != nullptr) {
+      gpu().Barriers().AddExternalSignal(priorSignal);
+    }
+
+    for (auto& op : d2dCopyOps) {
+      device::Memory* srcDevMem = op.srcMemory->getDeviceMemory(
+          *op.srcMemory->getContext().devices()[0]);
+      device::Memory* dstDevMem = op.dstMemory->getDeviceMemory(
+          *op.dstMemory->getContext().devices()[0]);
+
+      amd::Coord3D srcOrigin(op.srcOffset);
+      amd::Coord3D dstOrigin(op.dstOffset);
+      amd::Coord3D size(op.size);
+
+      if (!copyBuffer(*srcDevMem, *dstDevMem, srcOrigin, dstOrigin, size,
+                      false, op.metadata)) {
+        LogError("KernelBlitManager::copyBufferBatch: Intra-device copy failed!");
+        return false;
+      }
+
+      // Track non-Compute intra signals as external so the final barrier
+      // synchronizes the compute stream with them.
+      // Compute signals are implicitly ordered on the same AQL queue.
+      ProfilingSignal* sig = gpu().Barriers().GetLastSignal();
+      if (sig != nullptr && sig->engine_ != HwQueueEngine::Compute) {
+        gpu().Barriers().AddExternalSignal(sig);
+      }
+    }
+  }
+
+  // Re-add batch SDMA signals as external for the final barrier.
+  // batchSignals has all-but-last (they're not at current_id_).
+  for (auto* sig : batchSignals) {
+    gpu().Barriers().AddExternalSignal(sig);
+  }
+  // The last batch signal was at current_id_ after the batch. If intra copies
+  // advanced current_id_ past it, add it as external so the barrier picks it up.
+  // Check against GetLastSignal to avoid adding a duplicate of current_id_.
+  if (lastBatchSignal != nullptr && lastBatchSignal != gpu().Barriers().GetLastSignal()) {
+    gpu().Barriers().AddExternalSignal(lastBatchSignal);
+  }
+
+  return true;
 }
 
 // ================================================================================================

--- a/projects/clr/rocclr/device/rocm/rocblit.hpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.hpp
@@ -144,8 +144,7 @@ class DmaBlitManager : public device::HostBlitManager {
 
   //! Copies multiple buffer objects in a batch
   virtual bool copyBufferBatch(
-      std::vector<amd::BatchCopyOp>& copyOps,  //!< Batch of copy operations
-      bool entire = false                      //!< Entire buffers will be updated
+      std::vector<amd::BatchCopyOp>& copyOps  //!< Batch of copy operations
   ) const;
 
   //! Copies an image object to a buffer object
@@ -229,6 +228,12 @@ class DmaBlitManager : public device::HostBlitManager {
                              size_t& partial       //!< Extra offset for memory alignment
   ) const;
 
+  //! Resolves the real HSA agents for a src/dst memory pair.
+  //! Handles IPC shared memory where dev() may not reflect the true owning agent.
+  inline void resolveAgents(const Memory& srcMem, const Memory& dstMem,
+                            address srcAddr, address dstAddr,
+                            hsa_agent_t& srcAgent, hsa_agent_t& dstAgent) const;
+
   //! Assits in transferring data from Host to Local or vice versa
   //! taking into account the Hsail profile supported by Hsa Agent
   bool hsaCopy(const Memory& srcMemory, const Memory& dstMemory, const amd::Coord3D& srcOrigin,
@@ -238,6 +243,17 @@ class DmaBlitManager : public device::HostBlitManager {
   inline bool rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, const_address src,
                              hsa_agent_t& srcAgent, size_t size,
                              amd::CopyMetadata& copyMetadata) const;
+
+  //! Batch version of hsaCopy - resolves multiple Memory objects to addresses/agents
+  bool hsaCopyBatch(const std::vector<amd::BatchCopyOp>& copyOps,
+                    const std::vector<hsa_signal_t>* externalWaitEvents = nullptr,
+                    std::vector<ProfilingSignal*>* outBatchSignals = nullptr) const;
+
+  //! Batch version of rocrCopyBuffer
+  bool rocrCopyBufferBatch(
+      const std::vector<hsa_amd_memory_copy_op_t>& copyOps,
+      const std::vector<hsa_signal_t>* externalWaitEvents = nullptr,
+      std::vector<ProfilingSignal*>* outBatchSignals = nullptr) const;
 
   // Get Pinned Host Memory or Staging Buffer
   void getBuffer(const_address hostMem,  //!< Host Mem Address
@@ -361,6 +377,11 @@ class KernelBlitManager : public DmaBlitManager {
       const amd::Coord3D& size,                             //!< Size of the copy region
       bool entire = false,                                  //!< Entire buffer will be updated
       amd::CopyMetadata copyMetadata = amd::CopyMetadata()  //!< Memory copy MetaData
+  ) const;
+
+  //! Copies multiple buffer objects in a batch
+  virtual bool copyBufferBatch(
+      std::vector<amd::BatchCopyOp>& copyOps                //!< Batch of copy operations
   ) const;
 
   //! Copies a buffer object to an image object

--- a/projects/clr/rocclr/device/rocm/rocdefs.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdefs.hpp
@@ -34,16 +34,27 @@ constexpr bool kSkipCpuWait = true;
 
 enum HwQueueEngine : uint32_t {
   Compute = 0,
-  SdmaRead = 1,
-  SdmaWrite = 2,
-  SdmaIntra = 3,
-  SdmaInter = 4,
+  SdmaD2H = 1,
+  SdmaH2D = 2,
+  SdmaD2D = 3,
+  SdmaP2P = 4,
   Unknown = 5
 };
 
 //! Returns true if the engine is an SDMA engine (any type)
 inline bool IsSdmaEngine(HwQueueEngine engine) {
-  return engine >= HwQueueEngine::SdmaRead && engine <= HwQueueEngine::SdmaInter;
+  return engine >= HwQueueEngine::SdmaD2H && engine <= HwQueueEngine::SdmaP2P;
+}
+
+inline const char* EngineOpName(HwQueueEngine engine) {
+  switch (engine) {
+    case HwQueueEngine::SdmaD2H: return "D2H";
+    case HwQueueEngine::SdmaH2D: return "H2D";
+    case HwQueueEngine::SdmaD2D:
+    case HwQueueEngine::SdmaP2P: return "D2D/P2P";
+    case HwQueueEngine::Compute: return "Compute";
+    default:                     return "Unknown";
+  }
 }
 
 }  // namespace amd::roc

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -701,7 +701,9 @@ bool Device::create() {
 
   if (AMD_LOG_LEVEL >= LOG_EXTRA_DEBUG) {
     uint8_t logMask[8] = {0};
-    hsa_flag_set64(logMask, HSA_AMD_LOG_FLAG_BLIT_KERNEL_PKTS);
+    hsa_flag_set64(logMask, HSA_AMD_LOG_FLAG_AQL);
+    hsa_flag_set64(logMask, HSA_AMD_LOG_FLAG_SDMA);
+    hsa_flag_set64(logMask, HSA_AMD_LOG_FLAG_INFO);
     Hsa::enable_logging(logMask, outFile);
   }
 
@@ -1662,8 +1664,9 @@ bool Device::populateOCLDeviceConstants() {
     LogWarning("HSA_AMD_AGENT_INFO_HAS_EXPERT_SCHED_MODE query failed.");
   }
 
-  ClPrint(amd::LOG_INFO, amd::LOG_INIT, "Gfx Major/Minor/Stepping: %d/%d/%d", isa().versionMajor(),
-          isa().versionMinor(), isa().versionStepping());
+  ClPrint(amd::LOG_INFO, amd::LOG_INIT, "Gfx Major/Minor/Stepping: %d/%d/%d, Device ID: 0x%x",
+          isa().versionMajor(), isa().versionMinor(), isa().versionStepping(), pciDeviceId_);
+  ClPrint(amd::LOG_INFO, amd::LOG_INIT, "Using dev kernel arg wa = %d", settings().kernel_arg_impl_);
   ClPrint(amd::LOG_INFO, amd::LOG_INIT, "HMM support: %d, XNACK: %d, Direct host access: %d",
           info_.hmmSupported_, info_.hmmCpuMemoryAccessible_, info_.hmmDirectHostAccess_);
   ClPrint(amd::LOG_INFO, amd::LOG_INIT, "Max SDMA Read Mask: 0x%x, Max SDMA Write Mask: 0x%x",
@@ -3642,7 +3645,7 @@ uint32_t Device::SdmaEngineAllocator::AllocateEngine(VirtualGPU* vgpu, HwQueueEn
   amd::ScopedLock lock(lock_);
 
   // Get valid engine mask based on operation type (read vs write)
-  uint32_t validEngineMask = (engine_type == HwQueueEngine::SdmaRead)
+  uint32_t validEngineMask = (engine_type == HwQueueEngine::SdmaD2H)
                               ? device_.maxSdmaReadMask_
                               : device_.maxSdmaWriteMask_;
 
@@ -3707,7 +3710,7 @@ uint32_t Device::SdmaEngineAllocator::AllocateEngine(VirtualGPU* vgpu, HwQueueEn
   uint32_t allocated_mask = 0;
 
   // For inter-GPU copies, strongly prefer the recommended engines
-  bool is_inter_gpu = (engine_type == HwQueueEngine::SdmaInter);
+  bool is_inter_gpu = (engine_type == HwQueueEngine::SdmaP2P);
 
   if (is_inter_gpu && (preferredMask != 0)) {
     // Inter-GPU: prioritize preferredMask, even if engines are already allocated

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -777,7 +777,7 @@ class Device : public NullDevice {
 
   //! Returns the valid SDMA engine bitmask for the given operation type.
   uint32_t GetSdmaValidMask(HwQueueEngine engine_type) const {
-    return (engine_type == HwQueueEngine::SdmaRead) ? maxSdmaReadMask_ : maxSdmaWriteMask_;
+    return (engine_type == HwQueueEngine::SdmaD2H) ? maxSdmaReadMask_ : maxSdmaWriteMask_;
   }
 
 #if defined(__clang__)

--- a/projects/clr/rocclr/device/rocm/rocrctx.cpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.cpp
@@ -90,6 +90,7 @@ bool Hsa::LoadLib() {
   GET_ROCR_SYMBOL(hsa_amd_memory_pool_free)
   GET_ROCR_SYMBOL(hsa_amd_memory_async_copy)
   GET_ROCR_SYMBOL(hsa_amd_memory_async_copy_on_engine)
+  GET_ROCR_SYMBOL(hsa_amd_memory_async_batch_copy)
   GET_ROCR_SYMBOL(hsa_amd_memory_copy_engine_status)
   GET_ROCR_SYMBOL(hsa_amd_agent_memory_pool_get_info)
   GET_ROCR_SYMBOL(hsa_amd_agents_allow_access)

--- a/projects/clr/rocclr/device/rocm/rocrctx.hpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.hpp
@@ -99,6 +99,7 @@ struct RocrEntryPoints {
   decltype(hsa_amd_memory_pool_free)* hsa_amd_memory_pool_free_;
   decltype(hsa_amd_memory_async_copy)* hsa_amd_memory_async_copy_;
   decltype(hsa_amd_memory_async_copy_on_engine)* hsa_amd_memory_async_copy_on_engine_;
+  decltype(hsa_amd_memory_async_batch_copy)* hsa_amd_memory_async_batch_copy_;
   decltype(hsa_amd_memory_copy_engine_status)* hsa_amd_memory_copy_engine_status_;
   decltype(hsa_amd_agent_memory_pool_get_info)* hsa_amd_agent_memory_pool_get_info_;
   decltype(hsa_amd_agents_allow_access)* hsa_amd_agents_allow_access_;
@@ -369,6 +370,12 @@ class Hsa : public amd::AllStatic {
     return ROCR_DYN(hsa_amd_memory_async_copy_on_engine)(
         dst, dst_agent, src, src_agent, size, num_dep_signals, dep_signals, completion_signal,
         engine_id, force_copy_on_sdma);
+  }
+  static hsa_status_t memory_async_batch_copy(
+      const hsa_amd_memory_copy_op_t* copy_ops, uint32_t num_copy_ops,
+      uint32_t num_dep_signals, const hsa_signal_t* dep_signals) {
+    return ROCR_DYN(hsa_amd_memory_async_batch_copy)(
+        copy_ops, num_copy_ops, num_dep_signals, dep_signals);
   }
   static hsa_status_t memory_copy_engine_status(hsa_agent_t dst_agent,
     hsa_agent_t src_agent, uint32_t* engine_ids_mask) {

--- a/projects/clr/rocclr/device/rocm/rocsettings.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.cpp
@@ -271,7 +271,5 @@ void Settings::setKernelArgImpl(const amd::Isa& isa, bool isXgmi, bool hasValidH
   if (!flagIsDefault(HIP_FORCE_DEV_KERNARG)) {
     kernel_arg_impl_ = kernelArgImpl & (HIP_FORCE_DEV_KERNARG ? 0xF : 0x0);
   }
-
-  ClPrint(amd::LOG_INFO, amd::LOG_INIT, "Using dev kernel arg wa = %d", kernel_arg_impl_);
 }
 }  // namespace amd::roc

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -2911,11 +2911,11 @@ void VirtualGPU::submitBatchCopyMemory(amd::BatchCopyMemoryCommand& cmd) {
 
   bool result = true;
 
-  // Sync caches for all source and destination memory objects
+  // Sync caches for all ops
   device::Memory::SyncFlags syncFlags;
   syncFlags.skipEntire_ = false;
 
-  for (auto& op : copyOps) {
+  for (const auto& op : copyOps) {
     Memory* srcDevMem = dev().getRocMemory(op.srcMemory);
     Memory* dstDevMem = dev().getRocMemory(op.dstMemory);
 
@@ -2930,8 +2930,18 @@ void VirtualGPU::submitBatchCopyMemory(amd::BatchCopyMemoryCommand& cmd) {
     srcDevMem->syncCacheFromHost(*this);
   }
 
-  // Execute batch copy through blit manager
-  result = blitMgr().copyBufferBatch(copyOps, false);
+  // KernelBlitManager::copyBufferBatch handles the D2D/D2H/H2D/P2P split:
+  // D2D copies use copyBuffer (kernel blit), D2H/H2D/P2P use DMA batch
+  std::vector<amd::BatchCopyOp> batchOps(copyOps.begin(), copyOps.end());
+  if (!blitMgr().copyBufferBatch(batchOps)) {
+    LogError("submitBatchCopyMemory: Batch copy failed!");
+    result = false;
+  }
+
+  // Synchronize the launch (compute) stream with SDMA engines.
+  if (result) {
+    dispatchBarrierPacket(kNopPacketHeader);
+  }
 
   if (!result) {
     LogError("submitBatchCopyMemory failed!");

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -260,12 +260,16 @@ union CopyMetadata {
     kSrcAccessOrderAny = 2             //!< Source access can be out of stream order
   };
 
+  //! Copy operation type for batch copies (maps to hipMemcpyFlagsExt op bits)
+  enum CopyOpType { kCopyOpLinear = 0, kCopyOpBroadcast = 1, kCopyOpSwap = 2, kCopyOpIndirect = 3 };
+
   struct {
     uint32_t isAsync_ : 1;
     uint32_t copyEnginePreference_ : 2;
     uint32_t srcAccessOrder_ : 2;       //!< Source access ordering for batch copies
-    uint32_t preferOverlapCompute_ : 1; //!< Prefer overlap with compute work
-    uint32_t reserved_ : 26;            //!< Reserved for future use
+    uint32_t preferCE_ : 1;             //!< Prefer compute engine over SDMA
+    uint32_t copyOpType_ : 2;           //!< Operation type (CopyOpType)
+    uint32_t reserved_ : 24;            //!< Reserved for future use
   };
   uint32_t flags_;
   CopyMetadata() : flags_(0) {}
@@ -273,14 +277,16 @@ union CopyMetadata {
       : isAsync_(isAsync),
         copyEnginePreference_(copyEnginePreference),
         srcAccessOrder_(kSrcAccessOrderStream),
-        preferOverlapCompute_(0),
+        preferCE_(0),
+        copyOpType_(kCopyOpLinear),
         reserved_(0) {}
   CopyMetadata(bool isAsync, CopyEnginePreference copyEnginePreference,
-               SrcAccessOrder srcAccessOrder, bool preferOverlap = false)
+               SrcAccessOrder srcAccessOrder)
       : isAsync_(isAsync),
         copyEnginePreference_(copyEnginePreference),
         srcAccessOrder_(srcAccessOrder),
-        preferOverlapCompute_(preferOverlap ? 1 : 0),
+        preferCE_(0),
+        copyOpType_(kCopyOpLinear),
         reserved_(0) {}
 };
 

--- a/projects/hip/include/hip/driver_types.h
+++ b/projects/hip/include/hip/driver_types.h
@@ -473,8 +473,19 @@ typedef struct hipMemLocation {
  */
 typedef enum hipMemcpyFlags {
   hipMemcpyFlagDefault = 0x0,                  ///< Default flag
-  hipMemcpyFlagPreferOverlapWithCompute = 0x1  ///< Tries to overlap copy with compute work.
+  hipMemcpyFlagPreferOverlapWithCompute = 0x1, ///< Tries to overlap copy with compute work.
+  hipMemcpyFlagExtPreferCE = 0x100,            ///< Prefer copy engine over compute engine.
 } hipMemcpyFlags;
+
+/**
+ * Extended flags for batch memcpy operations. These values are OR'd into the
+ * same 'flags' field as hipMemcpyFlags (bits 8+). Used with hipMemcpyBatchAsync
+ * and hipMemcpy3DBatchAsync.
+ */
+typedef enum hipMemcpyFlagsExt {
+  hipMemcpyFlagExtOpSwap       = 0x200,  ///< Swap contents of src and dst buffers.
+  hipMemcpyFlagExtOpIndirect   = 0x400,  ///< src/dst are pointers-to-pointers; resolved at execution.
+} hipMemcpyFlagsExt;
 
 /**
  * Flags to specify order in which source pointer is accessed by Batch memcpy

--- a/projects/rocr-runtime/CMakeLists.txt
+++ b/projects/rocr-runtime/CMakeLists.txt
@@ -90,7 +90,7 @@ include(utils)
 
 
 ## Get version strings
-get_version("1.18.0")
+get_version("1.20.0")
 if (${ROCM_PATCH_VERSION})
   set(VERSION_PATCH ${ROCM_PATCH_VERSION})
 endif()

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
@@ -1005,6 +1005,17 @@ hsa_status_t HSA_API
 
 // Mirrors Amd Extension Apis
 hsa_status_t HSA_API
+    hsa_amd_memory_async_batch_copy(const hsa_amd_memory_copy_op_t* copy_ops,
+                              uint32_t num_copy_ops,
+                              uint32_t num_dep_signals,
+                              const hsa_signal_t* dep_signals) {
+  return amdExtTable->hsa_amd_memory_async_batch_copy_fn(
+                                     copy_ops, num_copy_ops,
+                                     num_dep_signals, dep_signals);
+}
+
+// Mirrors Amd Extension Apis
+hsa_status_t HSA_API
     hsa_amd_memory_copy_engine_status(hsa_agent_t dst_agent, hsa_agent_t src_agent,
                                       uint32_t *engine_ids_mask) {
   return amdExtTable->hsa_amd_memory_copy_engine_status_fn(dst_agent, src_agent,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/agent.h
@@ -214,6 +214,29 @@ class Agent : public Checked<0xF6BC25EB17E6F917> {
     return HSA_STATUS_ERROR;
   }
 
+  // @brief Submit a batch of DMA copy operations.
+  //
+  // @details Takes hsa_amd_memory_copy_op_t directly from the public API.
+  // The implementation resolves agents, signals, and preferred SDMA engines
+  // internally using rec_sdma_eng_id_peers_info_. Operations sharing the
+  // same copy_agent are grouped by the caller. Future optimizations can
+  // group items by engine to reduce redundant packets.
+  //
+  // @param [in] ops Array of copy operations (public API structs).
+  // @param [in] num_ops Number of operations in the array.
+  // @param [in] dep_signals Array of signal dependencies shared by all ops.
+  //
+  // The completion signal is obtained from each op's completion_signal field.
+  // All ops in a single call must share the same completion signal.
+  //
+  // @retval HSA_STATUS_SUCCESS All copies submitted successfully.
+  virtual hsa_status_t DmaCopyBatch(
+      const hsa_amd_memory_copy_op_t* ops,
+      uint32_t num_ops,
+      std::vector<core::Signal*>& dep_signals) {
+    return HSA_STATUS_ERROR;
+  }
+
   // @brief Submit DMA command to set the content of a pointer and wait
   // until it is finished.
   //

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_sdma.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_sdma.h
@@ -75,6 +75,34 @@ class BlitSdmaBase : public core::Blit {
   virtual hsa_status_t SubmitCommand(const void* cmds, size_t cmd_size, uint64_t size,
                                      const std::vector<core::Signal*>& dep_signals,
                                      core::Signal& out_signal, std::vector<core::Signal*>& gang_signals) = 0;
+
+  virtual hsa_status_t SubmitLinearCopyBroadcastCommand(
+      const std::vector<void*>& dsts, const void* src, size_t size,
+      std::vector<core::Signal*>& dep_signals,
+      core::Signal& out_signal) = 0;
+
+  virtual bool BroadcastSupported() const = 0;
+  virtual bool PlatformAtomicSupport() const = 0;
+
+  virtual hsa_status_t SubmitPrologue(const std::vector<core::Signal*>& dep_signals,
+                                      core::Signal& out_signal,
+                                      core::Signal& prologue_signal) = 0;
+
+  virtual hsa_status_t SubmitBody(const void* cmd, size_t cmd_size, uint64_t size,
+                                  core::Signal& prologue_signal,
+                                  core::Signal& body_signal) = 0;
+
+  /// @brief Submit epilogue that waits for bodies, then performs GCR writeback,
+  /// end timestamp, and sets out_signal to its final value.
+  /// When body_signals is non-empty, polls each body signal for 0 (non-atomic path).
+  /// When body_signals is empty, polls out_signal for body_complete_value (atomic path).
+  virtual hsa_status_t SubmitEpilogue(core::Signal& out_signal,
+                                      hsa_signal_value_t body_complete_value,
+                                      const std::vector<core::Signal*>& body_signals = {}) = 0;
+
+  virtual hsa_status_t SubmitLinearCopyBody(void* dst, const void* src, size_t size,
+                                            core::Signal& prologue_signal,
+                                            core::Signal& body_signal) = 0;
 };
 
 template <bool useGCR> class BlitSdma : public BlitSdmaBase {
@@ -132,6 +160,21 @@ template <bool useGCR> class BlitSdma : public BlitSdmaBase {
                                              std::vector<core::Signal*>& dep_signals,
                                              core::Signal& out_signal) override;
 
+  /// @brief Submit a broadcast linear copy command. Copies from a single source
+  /// to multiple destinations using SDMA broadcast packets (2 dsts per packet).
+  /// If the destination count is odd, the last destination uses a regular
+  /// linear copy packet. Large transfers are broken into size-chunked packets.
+  ///
+  /// @param dsts Vector of destination memory addresses.
+  /// @param src Memory address of the copy source.
+  /// @param size Size of the data to be copied to each destination.
+  /// @param dep_signals Arrays of dependent signal.
+  /// @param out_signal Output signal.
+  hsa_status_t SubmitLinearCopyBroadcastCommand(
+      const std::vector<void*>& dsts, const void* src, size_t size,
+      std::vector<core::Signal*>& dep_signals,
+      core::Signal& out_signal) override;
+
   /// @brief Submit a linear fill command to the queue buffer
   ///
   /// @param ptr Memory address of the fill destination.
@@ -145,6 +188,24 @@ template <bool useGCR> class BlitSdma : public BlitSdmaBase {
   virtual uint64_t PendingBytes() override;
   virtual void GangLeader(bool gang_leader) override { gang_leader_ = gang_leader; }
   virtual bool GangLeader() const override { return gang_leader_; }
+  bool BroadcastSupported() const override { return broadcast_supported_; }
+  bool PlatformAtomicSupport() const override { return platform_atomic_support_; }
+
+  hsa_status_t SubmitPrologue(const std::vector<core::Signal*>& dep_signals,
+                              core::Signal& out_signal,
+                              core::Signal& prologue_signal) override;
+
+  hsa_status_t SubmitBody(const void* cmd, size_t cmd_size, uint64_t size,
+                          core::Signal& prologue_signal,
+                          core::Signal& body_signal) override;
+
+  hsa_status_t SubmitEpilogue(core::Signal& out_signal,
+                              hsa_signal_value_t body_complete_value,
+                              const std::vector<core::Signal*>& body_signals = {}) override;
+
+  hsa_status_t SubmitLinearCopyBody(void* dst, const void* src, size_t size,
+                                    core::Signal& prologue_signal,
+                                    core::Signal& body_signal) override;
 
  private:
   /// @brief Acquires the address into queue buffer where a new command
@@ -196,6 +257,9 @@ template <bool useGCR> class BlitSdma : public BlitSdmaBase {
 
   void BuildCopyCommand(char* cmd_addr, uint32_t num_copy_command, void* dst,
                         const void* src, size_t size);
+
+  void BuildBroadcastCopyCommand(char* cmd_addr, uint32_t num_copy_command,
+                                 void* dst1, void* dst2, const void* src, size_t size);
 
   void BuildCopyRectCommand(const std::function<void*(size_t)>& append,
                             const hsa_pitched_ptr_t* dst, const hsa_dim3_t* dst_offset,
@@ -268,6 +332,8 @@ template <bool useGCR> class BlitSdma : public BlitSdmaBase {
 
   static const uint32_t linear_copy_command_size_;
 
+  static const uint32_t broadcast_copy_command_size_;
+
   static const uint32_t fill_command_size_;
 
   static const uint32_t fence_command_size_;
@@ -310,6 +376,12 @@ template <bool useGCR> class BlitSdma : public BlitSdmaBase {
 
   /// Minimum submission size in bytes.
   size_t min_submission_size_;
+
+  /// True if SDMA supports broadcast linear copy (one src -> two dst).
+  bool broadcast_supported_;
+
+  /// True if SDMA supports multicast copy  (one src -> multiple dst).
+  bool multicast_supported_;
 };
 
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -316,6 +316,11 @@ class GpuAgent : public GpuAgentInt {
                                   uint32_t* recommended_ids_mask) override;
 
   // @brief Override from core::Agent.
+  hsa_status_t DmaCopyBatch(const hsa_amd_memory_copy_op_t* ops,
+                            uint32_t num_ops,
+                            std::vector<core::Signal*>& dep_signals) override;
+
+  // @brief Override from core::Agent.
   hsa_status_t DmaCopyRect(const hsa_pitched_ptr_t* dst, const hsa_dim3_t* dst_offset,
                            const hsa_pitched_ptr_t* src, const hsa_dim3_t* src_offset,
                            const hsa_dim3_t* range, hsa_amd_copy_direction_t dir,
@@ -343,7 +348,7 @@ class GpuAgent : public GpuAgentInt {
   void AcquireQueueAltScratch(ScratchInfo& scratch) override;
   void ReleaseQueueAltScratch(ScratchInfo& scratch) override;
 
-  // @brief Create a pool of shared queues for multiple user applications within a max limit 
+  // @brief Create a pool of shared queues for multiple user applications within a max limit
   hsa_status_t AcquireCountedQueue(hsa_queue_type_t type,
                                    HSA::hsa_amd_queue_priority_internal_t priority,
                                    void (*callback)(hsa_status_t, hsa_queue_t*, void*),
@@ -727,6 +732,13 @@ class GpuAgent : public GpuAgentInt {
   // caller must hold scratch_lock_.
   void ReleaseScratch(void* base, size_t size, bool large);
 
+  // Broadcast copy: copies op.src to each destination in op.dst_list.
+  // Uses HW broadcast for transfers < 1 MB when supported; otherwise falls
+  // back to prologue/body/epilogue fan-out across available SDMA engines.
+  hsa_status_t DmaCopyBroadcast(
+      const hsa_amd_memory_copy_op_t& op,
+      std::vector<core::Signal*>& dep_signals);
+
   // Bind index of peer device that is connected via xGMI links
   lazy_ptr<core::Blit>& GetXgmiBlit(const core::Agent& peer_agent);
 
@@ -854,6 +866,9 @@ class GpuAgent : public GpuAgentInt {
 
   bool uses_rec_sdma_eng_id_mask_;
   bool rec_sdma_eng_override_;
+
+  // Round-robin index for spreading SDMA work across engines.
+  uint32_t sdma_rr_index_ = 0;
 
   // structure for host trap sampling
   pcs_data_t pcs_hosttrap_data_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
@@ -163,6 +163,13 @@ hsa_status_t
 
 // Mirrors Amd Extension Apis
 hsa_status_t
+    hsa_amd_memory_async_batch_copy(const hsa_amd_memory_copy_op_t* copy_ops,
+                              uint32_t num_copy_ops,
+                              uint32_t num_dep_signals,
+                              const hsa_signal_t* dep_signals);
+
+// Mirrors Amd Extension Apis
+hsa_status_t
     hsa_amd_memory_copy_engine_status(hsa_agent_t dst_agent, hsa_agent_t src_agent,
                                       uint32_t *engine_ids_mask);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/sdma_registers.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/sdma_registers.h
@@ -3,7 +3,7 @@
 // The University of Illinois/NCSA
 // Open Source License (NCSA)
 //
-// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 //
 // Developed by:
 //
@@ -61,6 +61,8 @@ const unsigned int SDMA_OP_CONST_FILL = 11;
 const unsigned int SDMA_OP_TIMESTAMP = 13;
 const unsigned int SDMA_OP_GCR = 17;
 const unsigned int SDMA_SUBOP_COPY_LINEAR = 0;
+// Broadcast linear copy uses the linear sub-op with the broadcast packet format.
+const unsigned int SDMA_SUBOP_COPY_LINEAR_BROADCAST = SDMA_SUBOP_COPY_LINEAR;
 const unsigned int SDMA_SUBOP_COPY_LINEAR_RECT = 4;
 const unsigned int SDMA_SUBOP_TIMESTAMP_GET_GLOBAL = 2;
 const unsigned int SDMA_SUBOP_USER_GCR = 1;
@@ -129,6 +131,97 @@ typedef struct SDMA_PKT_COPY_LINEAR_TAG {
 
   static const size_t kMaxSize_ = 0x3fffe0;
 } SDMA_PKT_COPY_LINEAR;
+
+// linear copy (broadcast) packet (SDMA5.2+)
+typedef struct SDMA_PKT_COPY_LINEAR_BROADCAST_TAG {
+  union {
+    struct {
+      unsigned int op : 8;
+      unsigned int sub_op : 8;
+      unsigned int enc : 1;
+      unsigned int reserved_0 : 1;
+      unsigned int tmz : 1;
+      unsigned int reserved_1 : 8;
+      unsigned int broadcast : 1;
+      unsigned int alg : 2;
+      unsigned int aes : 1;
+      unsigned int reserved_2 : 1;
+    };
+    unsigned int DW_0_DATA;
+  } HEADER_UNION;
+
+  union {
+    struct {
+      unsigned int count : 22;
+      unsigned int reserved_0 : 10;
+    } count;
+    struct {
+      unsigned int count : 30;
+      unsigned int reserved_0 : 2;
+    } count_ext;
+    unsigned int DW_1_DATA;
+  } COUNT_UNION;
+
+  union {
+    struct {
+      unsigned int reserved_0 : 8;
+      unsigned int dst2_swap : 2;
+      unsigned int dst2_cache_policy : 3;
+      unsigned int reserved_1 : 3;
+      unsigned int dst1_swap : 2;
+      unsigned int dst1_cache_policy : 3;
+      unsigned int reserved_2 : 3;
+      unsigned int src_swap : 2;
+      unsigned int src_cache_policy : 3;
+      unsigned int reserved_3 : 3;
+    };
+    unsigned int DW_2_DATA;
+  } PARAMETER_UNION;
+
+  union {
+    struct {
+      unsigned int src_addr_31_0 : 32;
+    };
+    unsigned int DW_3_DATA;
+  } SRC_ADDR_LO_UNION;
+
+  union {
+    struct {
+      unsigned int src_addr_63_32 : 32;
+    };
+    unsigned int DW_4_DATA;
+  } SRC_ADDR_HI_UNION;
+
+  union {
+    struct {
+      unsigned int dst_addr_31_0 : 32;
+    };
+    unsigned int DW_5_DATA;
+  } DST_ADDR_LO_UNION;
+
+  union {
+    struct {
+      unsigned int dst_addr_63_32 : 32;
+    };
+    unsigned int DW_6_DATA;
+  } DST_ADDR_HI_UNION;
+
+  union {
+    struct {
+      unsigned int dst2_addr_31_0 : 32;
+    };
+    unsigned int DW_7_DATA;
+  } DST2_ADDR_LO_UNION;
+
+  union {
+    struct {
+      unsigned int dst2_addr_63_32 : 32;
+    };
+    unsigned int DW_8_DATA;
+  } DST2_ADDR_HI_UNION;
+
+  static const size_t kMaxSize_ = 0x3fffe0;
+} SDMA_PKT_COPY_LINEAR_BROADCAST;
 
 // linear sub-window (pre-GFX12)
 typedef struct SDMA_PKT_COPY_LINEAR_RECT_TAG {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -82,6 +82,9 @@ template <bool useGCR>
 const uint32_t BlitSdma<useGCR>::linear_copy_command_size_ = sizeof(SDMA_PKT_COPY_LINEAR);
 
 template <bool useGCR>
+const uint32_t BlitSdma<useGCR>::broadcast_copy_command_size_ = sizeof(SDMA_PKT_COPY_LINEAR_BROADCAST);
+
+template <bool useGCR>
 const uint32_t BlitSdma<useGCR>::fill_command_size_ = sizeof(SDMA_PKT_CONSTANT_FILL);
 
 template <bool useGCR>
@@ -115,7 +118,9 @@ BlitSdma<useGCR>::BlitSdma()
       hdp_flush_support_(false),
       gang_leader_(false),
       is_ganged_(false),
-      min_submission_size_(0) {
+      min_submission_size_(0),
+      broadcast_supported_(false),
+      multicast_supported_(false) {
   std::memset(&queue_resource_, 0, sizeof(queue_resource_));
 }
 
@@ -140,17 +145,23 @@ hsa_status_t BlitSdma<useGCR>::Initialize(const core::Agent& agent, bool use_xgm
     return HSA_STATUS_ERROR;
   }
 
+  // Cache ISA version for capability detection below.
+  const auto isa_version = agent_->supported_isas()[0]->GetVersion();
+  const auto major = agent_->supported_isas()[0]->GetMajorVersion();
+  const auto minor = agent_->supported_isas()[0]->GetMinorVersion();
+  const auto stepping = agent_->supported_isas()[0]->GetStepping();
+
   // Some GFX9 devices require a minimum of 64 DWORDS per ring buffer submission.
-  if (agent_->supported_isas()[0]->GetVersion() >= core::Isa::Version(9, 0, 0) &&
-     (agent_->supported_isas()[0]->GetVersion() <= core::Isa::Version(9, 0, 4) ||
-     agent_->supported_isas()[0]->GetVersion() == core::Isa::Version(9, 0, 12))) {
+  if (isa_version >= core::Isa::Version(9, 0, 0) &&
+     (isa_version <= core::Isa::Version(9, 0, 4) ||
+      isa_version == core::Isa::Version(9, 0, 12))) {
     min_submission_size_ = 256;
   }
 
   const core::Runtime::LinkInfo& link =
             core::Runtime::runtime_singleton_->GetLinkInfo( agent_->node_id(),
                 core::Runtime::runtime_singleton_->cpu_agents()[0]->node_id());
-  if (agent_->supported_isas()[0]->GetVersion() == core::Isa::Version(7, 0, 1)) {
+  if (isa_version == core::Isa::Version(7, 0, 1)) {
     platform_atomic_support_ = false;
   } else {
     platform_atomic_support_ = link.info.atomic_support_64bit;
@@ -160,10 +171,19 @@ hsa_status_t BlitSdma<useGCR>::Initialize(const core::Agent& agent, bool use_xgm
   // gfx90a can support xGMI host to device connections so bypass HDP flush
   // in this case.
   // gfx101x seems to have issues with HDP flushes
-  if (agent_->supported_isas()[0]->GetMajorVersion() >= 9 &&
-      !(agent_->supported_isas()[0]->GetMajorVersion() == 10 && agent_->supported_isas()[0]->GetMinorVersion() == 1)) {
+  if (major >= 9 && !(major == 10 && minor == 1)) {
     hdp_flush_support_ = link.info.link_type != HSA_AMD_LINK_INFO_TYPE_XGMI;
   }
+
+  // Broadcast linear copy supported on MI200+ and all SDMA 5.x/6.x+.
+  if (major >= 10) {
+    broadcast_supported_ = true;
+  } else if (major == 9) {
+    broadcast_supported_ = (minor >= 4) || (minor == 0 && stepping >= 10);
+  }
+
+  // Multicast not yet supported on any current hardware.
+  multicast_supported_ = false;
 
   // Allocate queue buffer.
   queue_start_addr_ =
@@ -597,6 +617,367 @@ hsa_status_t BlitSdma<useGCR>::SubmitCommand(const void* cmd, size_t cmd_size, u
 }
 
 template <bool useGCR>
+hsa_status_t BlitSdma<useGCR>::SubmitPrologue(
+    const std::vector<core::Signal*>& dep_signals,
+    core::Signal& out_signal,
+    core::Signal& prologue_signal) {
+
+  uint32_t num_poll_command = 0;
+  uint64_t dep_signals_value[HSA_MAX_DEP_SIGNALS];
+
+  for (size_t i = 0; i < dep_signals.size(); ++i) {
+    dep_signals_value[i] = dep_signals[i]->LoadRelaxed();
+    if (dep_signals_value[i]) {
+      num_poll_command++;
+      if (dep_signals_value[i] >> 32)
+        num_poll_command++;
+    }
+  }
+
+  const uint32_t total_poll_command_size = num_poll_command * poll_command_size_;
+  const bool profiling_enabled = agent_->profiling_enabled();
+
+  uint64_t* start_ts_addr = nullptr;
+  uint64_t* end_ts_addr = nullptr;
+  uint32_t total_timestamp_command_size = 0;
+
+  if (profiling_enabled) {
+    out_signal.GetSdmaTsAddresses(start_ts_addr, end_ts_addr);
+    total_timestamp_command_size = timestamp_command_size_;
+  }
+
+  uint32_t flush_cmd_size = 0;
+  if (core::Runtime::runtime_singleton_->flag().enable_sdma_hdp_flush()) {
+    if (hdp_flush_support_)
+      flush_cmd_size = flush_command_size_;
+  }
+  if (useGCR) flush_cmd_size += gcr_command_size_;
+
+  // Prologue signal decrement to notify body engines.
+  const size_t prologue_signal_cmd_size = platform_atomic_support_
+      ? atomic_command_size_ : fence_command_size_;
+
+  const uint32_t total_command_size = total_poll_command_size +
+      total_timestamp_command_size + flush_cmd_size + prologue_signal_cmd_size;
+  const uint32_t pad_size = total_command_size < min_submission_size_
+      ? min_submission_size_ - total_command_size
+      : core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()
+            ? AlignUp(total_command_size, 64) - total_command_size : 0;
+
+  uint64_t curr_index;
+  char* command_addr;
+  uint64_t prior_bytes;
+  {
+    std::lock_guard<std::mutex> lock(reservation_lock_);
+    command_addr = AcquireWriteAddress(total_command_size + pad_size, curr_index);
+    if (command_addr == nullptr)
+      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+    prior_bytes = bytes_queued_;
+  }
+  uint32_t wrapped_index = WrapIntoRing(curr_index);
+
+  // Dependency signal polls.
+  for (size_t i = 0; i < dep_signals.size(); ++i) {
+    if (dep_signals_value[i]) {
+      uint32_t* signal_addr =
+          reinterpret_cast<uint32_t*>(dep_signals[i]->ValueLocation());
+
+      if (dep_signals_value[i] >> 32) {
+        BuildPollCommand(command_addr, &signal_addr[1], 0);
+        command_addr += poll_command_size_;
+        bytes_written_[wrapped_index] = prior_bytes;
+        wrapped_index += poll_command_size_;
+      }
+      BuildPollCommand(command_addr, &signal_addr[0], 0);
+      command_addr += poll_command_size_;
+      bytes_written_[wrapped_index] = prior_bytes;
+      wrapped_index += poll_command_size_;
+    }
+  }
+
+  // Start profiling timestamp.
+  if (profiling_enabled) {
+    BuildGetGlobalTimestampCommand(command_addr, reinterpret_cast<void*>(start_ts_addr));
+    command_addr += timestamp_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += timestamp_command_size_;
+  }
+
+  // HDP flush.
+  if (core::Runtime::runtime_singleton_->flag().enable_sdma_hdp_flush()) {
+    if (hdp_flush_support_) {
+      BuildHdpFlushCommand(command_addr);
+      command_addr += flush_command_size_;
+      bytes_written_[wrapped_index] = prior_bytes;
+      wrapped_index += flush_command_size_;
+    }
+  }
+
+  // GCR cache invalidate.
+  if (useGCR) {
+    BuildGCRCommand(command_addr, true);
+    command_addr += gcr_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += gcr_command_size_;
+  }
+
+  // Decrement prologue_signal to notify body engines that setup is complete.
+  if (platform_atomic_support_) {
+    BuildAtomicDecrementCommand(command_addr, prologue_signal.ValueLocation());
+    command_addr += atomic_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += atomic_command_size_;
+  } else {
+    uint32_t* sig_loc = reinterpret_cast<uint32_t*>(prologue_signal.ValueLocation());
+    BuildFenceCommand(command_addr, sig_loc, 0);
+    command_addr += fence_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += fence_command_size_;
+  }
+
+  if (pad_size) {
+    memset(command_addr, 0, pad_size);
+    uint32_t* dword_command_addr = reinterpret_cast<uint32_t*>(command_addr);
+    dword_command_addr[0] = (pad_size / 4 - 1) << 16;
+  }
+
+  ReleaseWriteAddress(curr_index, total_command_size + pad_size);
+  return HSA_STATUS_SUCCESS;
+}
+
+template <bool useGCR>
+hsa_status_t BlitSdma<useGCR>::SubmitBody(
+    const void* cmd, size_t cmd_size, uint64_t size,
+    core::Signal& prologue_signal,
+    core::Signal& body_signal) {
+
+  // One poll on the prologue signal (lower 32 bits reaching 0).
+  const uint32_t poll_size = poll_command_size_;
+
+  // Body signal decrement to notify the epilogue.
+  const size_t body_signal_cmd_size = platform_atomic_support_
+      ? atomic_command_size_ : fence_command_size_;
+
+  const uint32_t total_command_size = poll_size + cmd_size + body_signal_cmd_size;
+  const uint32_t pad_size = total_command_size < min_submission_size_
+      ? min_submission_size_ - total_command_size
+      : core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()
+            ? AlignUp(total_command_size, 64) - total_command_size : 0;
+
+  uint64_t curr_index;
+  char* command_addr;
+  uint64_t prior_bytes, post_bytes;
+  {
+    std::lock_guard<std::mutex> lock(reservation_lock_);
+    command_addr = AcquireWriteAddress(total_command_size + pad_size, curr_index);
+    if (command_addr == nullptr)
+      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+    prior_bytes = bytes_queued_;
+    bytes_queued_ += size;
+    post_bytes = bytes_queued_;
+  }
+  uint32_t wrapped_index = WrapIntoRing(curr_index);
+
+  // Wait for prologue to complete.
+  uint32_t* prologue_addr =
+      reinterpret_cast<uint32_t*>(prologue_signal.ValueLocation());
+  BuildPollCommand(command_addr, &prologue_addr[0], 0);
+  command_addr += poll_command_size_;
+  bytes_written_[wrapped_index] = prior_bytes;
+  wrapped_index += poll_command_size_;
+
+  // The copy command.
+  memcpy(command_addr, cmd, cmd_size);
+  command_addr += cmd_size;
+  bytes_written_.fill(wrapped_index, wrapped_index + cmd_size, prior_bytes);
+  wrapped_index += cmd_size;
+
+  // Decrement body_signal to notify epilogue that this body is done.
+  if (platform_atomic_support_) {
+    BuildAtomicDecrementCommand(command_addr, body_signal.ValueLocation());
+    command_addr += atomic_command_size_;
+    bytes_written_[wrapped_index] = post_bytes;
+    wrapped_index += atomic_command_size_;
+  } else {
+    uint32_t* sig_loc = reinterpret_cast<uint32_t*>(body_signal.ValueLocation());
+    BuildFenceCommand(command_addr, sig_loc, 0);
+    command_addr += fence_command_size_;
+    bytes_written_[wrapped_index] = post_bytes;
+    wrapped_index += fence_command_size_;
+  }
+
+  if (pad_size) {
+    memset(command_addr, 0, pad_size);
+    uint32_t* dword_command_addr = reinterpret_cast<uint32_t*>(command_addr);
+    dword_command_addr[0] = (pad_size / 4 - 1) << 16;
+  }
+
+  ReleaseWriteAddress(curr_index, total_command_size + pad_size);
+  return HSA_STATUS_SUCCESS;
+}
+
+template <bool useGCR>
+hsa_status_t BlitSdma<useGCR>::SubmitEpilogue(
+    core::Signal& out_signal,
+    hsa_signal_value_t body_complete_value,
+    const std::vector<core::Signal*>& body_signals) {
+
+  const bool use_body_signals = !body_signals.empty();
+  const bool profiling_enabled = agent_->profiling_enabled();
+
+  uint64_t* start_ts_addr = nullptr;
+  uint64_t* end_ts_addr = nullptr;
+  uint32_t total_timestamp_command_size = 0;
+
+  if (profiling_enabled) {
+    out_signal.GetSdmaTsAddresses(start_ts_addr, end_ts_addr);
+    total_timestamp_command_size = timestamp_command_size_;
+  }
+
+  const uint32_t body_poll_size = use_body_signals
+      ? static_cast<uint32_t>(body_signals.size()) * poll_command_size_
+      : poll_command_size_;
+
+  uint32_t gcr_cmd_size = 0;
+  if (useGCR) gcr_cmd_size = gcr_command_size_;
+
+  const uint64_t completion_signal_value = use_body_signals
+      ? 0
+      : static_cast<uint64_t>(body_complete_value - 1);
+  const size_t sync_command_size = (platform_atomic_support_)
+      ? atomic_command_size_
+      : (completion_signal_value > UINT32_MAX)
+            ? 2 * fence_command_size_
+            : fence_command_size_;
+
+  const size_t interrupt_command_size =
+      (out_signal.signal_.event_mailbox_ptr != 0)
+          ? (fence_command_size_ + trap_command_size_)
+          : 0;
+
+  const uint32_t total_command_size = body_poll_size + gcr_cmd_size +
+      total_timestamp_command_size + sync_command_size + interrupt_command_size;
+  const uint32_t pad_size = total_command_size < min_submission_size_
+      ? min_submission_size_ - total_command_size
+      : core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()
+            ? AlignUp(total_command_size, 64) - total_command_size : 0;
+
+  uint64_t curr_index;
+  char* command_addr;
+  uint64_t prior_bytes;
+  {
+    std::lock_guard<std::mutex> lock(reservation_lock_);
+    command_addr = AcquireWriteAddress(total_command_size + pad_size, curr_index);
+    if (command_addr == nullptr)
+      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+    prior_bytes = bytes_queued_;
+  }
+  uint32_t wrapped_index = WrapIntoRing(curr_index);
+
+  if (use_body_signals) {
+    for (size_t i = 0; i < body_signals.size(); ++i) {
+      uint32_t* body_addr =
+          reinterpret_cast<uint32_t*>(body_signals[i]->ValueLocation());
+      BuildPollCommand(command_addr, &body_addr[0], 0);
+      command_addr += poll_command_size_;
+      bytes_written_[wrapped_index] = prior_bytes;
+      wrapped_index += poll_command_size_;
+    }
+  } else {
+    uint32_t* out_addr = reinterpret_cast<uint32_t*>(out_signal.ValueLocation());
+    BuildPollCommand(command_addr, &out_addr[0],
+                     static_cast<uint32_t>(body_complete_value));
+    command_addr += poll_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += poll_command_size_;
+  }
+
+  // GCR cache writeback.
+  if (useGCR) {
+    BuildGCRCommand(command_addr, false);
+    command_addr += gcr_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += gcr_command_size_;
+  }
+
+  // End profiling timestamp.
+  if (profiling_enabled) {
+    assert(IsMultipleOf(end_ts_addr, 32));
+    BuildGetGlobalTimestampCommand(command_addr,
+                                   reinterpret_cast<void*>(end_ts_addr));
+    command_addr += timestamp_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += timestamp_command_size_;
+  }
+
+  // Set completion signal to final value.
+  if (platform_atomic_support_) {
+    BuildAtomicDecrementCommand(command_addr, out_signal.ValueLocation());
+    command_addr += atomic_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += atomic_command_size_;
+  } else {
+    uint32_t* signal_value_location =
+        reinterpret_cast<uint32_t*>(out_signal.ValueLocation());
+    if (completion_signal_value > UINT32_MAX) {
+      BuildFenceCommand(command_addr, signal_value_location + 1,
+                        static_cast<uint32_t>(completion_signal_value >> 32));
+      command_addr += fence_command_size_;
+      bytes_written_[wrapped_index] = prior_bytes;
+      wrapped_index += fence_command_size_;
+    }
+
+    BuildFenceCommand(command_addr, signal_value_location,
+                      static_cast<uint32_t>(completion_signal_value));
+    command_addr += fence_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += fence_command_size_;
+  }
+
+  // Interrupt mailbox and trap.
+  if (out_signal.signal_.event_mailbox_ptr != 0) {
+    BuildFenceCommand(command_addr,
+                      reinterpret_cast<uint32_t*>(out_signal.signal_.event_mailbox_ptr),
+                      static_cast<uint32_t>(out_signal.signal_.event_id));
+    command_addr += fence_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += fence_command_size_;
+
+    BuildTrapCommand(command_addr, out_signal.signal_.event_id);
+    command_addr += trap_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += trap_command_size_;
+  }
+
+  if (pad_size) {
+    memset(command_addr, 0, pad_size);
+    uint32_t* dword_command_addr = reinterpret_cast<uint32_t*>(command_addr);
+    dword_command_addr[0] = (pad_size / 4 - 1) << 16;
+  }
+
+  ReleaseWriteAddress(curr_index, total_command_size + pad_size);
+  return HSA_STATUS_SUCCESS;
+}
+
+template <bool useGCR>
+hsa_status_t BlitSdma<useGCR>::SubmitLinearCopyBody(
+    void* dst, const void* src, size_t size,
+    core::Signal& prologue_signal,
+    core::Signal& body_signal) {
+
+  const size_t max_copy_size = max_single_linear_copy_size_ ? max_single_linear_copy_size_ :
+                               kMaxSingleCopySize;
+  const uint32_t num_copy_command =
+      static_cast<uint32_t>((size + max_copy_size - 1) / max_copy_size);
+
+  std::vector<SDMA_PKT_COPY_LINEAR> buff(num_copy_command);
+  BuildCopyCommand(reinterpret_cast<char*>(&buff[0]), num_copy_command, dst, src, size);
+
+  return SubmitBody(&buff[0], buff.size() * sizeof(SDMA_PKT_COPY_LINEAR), size,
+                    prologue_signal, body_signal);
+}
+
+template <bool useGCR>
 hsa_status_t BlitSdma<useGCR>::SubmitLinearCopyCommand(void* dst, const void* src, size_t size) {
   // Break the copy into multiple copy operation incase the copy size exceeds
   // the SDMA linear copy limit.
@@ -627,6 +1008,61 @@ hsa_status_t BlitSdma<useGCR>::SubmitLinearCopyCommand(void* dst, const void* sr
 
   return SubmitCommand(&buff[0], buff.size() * sizeof(SDMA_PKT_COPY_LINEAR), size, dep_signals,
                        out_signal, gang_signals);
+}
+
+template <bool useGCR>
+hsa_status_t BlitSdma<useGCR>::SubmitLinearCopyBroadcastCommand(
+    const std::vector<void*>& dsts, const void* src, size_t size,
+    std::vector<core::Signal*>& dep_signals,
+    core::Signal& out_signal) {
+
+  if (!broadcast_supported_) {
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+
+  if (dsts.empty() || size == 0) {
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+
+  // Each broadcast packet copies from one src to two dsts.
+  // An odd trailing destination falls back to a regular linear copy.
+  const uint32_t num_pairs = static_cast<uint32_t>(dsts.size() / 2);
+  const bool has_remainder = (dsts.size() % 2) != 0;
+
+  const size_t max_copy_size = max_single_linear_copy_size_ ? max_single_linear_copy_size_ :
+                                                              kMaxSingleCopySize;
+  const uint32_t num_chunks = static_cast<uint32_t>((size + max_copy_size - 1) / max_copy_size);
+
+  // Total command buffer: broadcast packets for each pair, plus linear packets
+  // for the remainder destination, all multiplied by the number of size chunks.
+  const size_t broadcast_bytes = num_pairs * num_chunks *
+                                 static_cast<size_t>(broadcast_copy_command_size_);
+  const size_t linear_bytes = has_remainder ?
+                              (num_chunks * static_cast<size_t>(linear_copy_command_size_)) : 0;
+  const size_t total_cmd_size = broadcast_bytes + linear_bytes;
+
+  std::vector<char> cmd_buf(total_cmd_size, 0);
+  char* cmd_ptr = cmd_buf.data();
+
+  // Build broadcast packets for each destination pair.
+  for (uint32_t p = 0; p < num_pairs; ++p) {
+    BuildBroadcastCopyCommand(cmd_ptr, num_chunks,
+                              dsts[p * 2], dsts[p * 2 + 1], src, size);
+    cmd_ptr += num_chunks * broadcast_copy_command_size_;
+  }
+
+  // Handle the remaining odd destination with a regular linear copy.
+  if (has_remainder) {
+    BuildCopyCommand(cmd_ptr, num_chunks, dsts.back(),
+                     src, size);
+  }
+
+  // Total data moved across bus = size * number of destinations.
+  const uint64_t total_bytes_moved = static_cast<uint64_t>(size) * dsts.size();
+
+  std::vector<core::Signal*> no_gang;
+  return SubmitCommand(cmd_buf.data(), total_cmd_size, total_bytes_moved,
+                       dep_signals, out_signal, no_gang);
 }
 
 template <bool useGCR>
@@ -886,7 +1322,7 @@ void BlitSdma<useGCR>::BuildCopyCommand(char* cmd_addr, uint32_t num_copy_comman
     packet_addr->HEADER_UNION.op = SDMA_OP_COPY;
     packet_addr->HEADER_UNION.sub_op = SDMA_SUBOP_COPY_LINEAR;
 
-    if (max_copy_size == (1 << 30) -1)
+    if (max_copy_size == max_single_linear_copy_size_)
       packet_addr->COUNT_UNION.count_ext.count = copy_size - 1; /* count is 1-based */
     else
       packet_addr->COUNT_UNION.count.count = copy_size - 1; /* count is 1-based */
@@ -898,6 +1334,51 @@ void BlitSdma<useGCR>::BuildCopyCommand(char* cmd_addr, uint32_t num_copy_comman
     packet_addr->DST_ADDR_HI_UNION.dst_addr_63_32 = ptrhigh32(cur_dst);
 
     cmd_addr += linear_copy_command_size_;
+    cur_size += copy_size;
+  }
+
+  assert(cur_size == size);
+}
+
+template <bool useGCR>
+void BlitSdma<useGCR>::BuildBroadcastCopyCommand(char* cmd_addr, uint32_t num_copy_command,
+                                                  void* dst1, void* dst2,
+                                                  const void* src, size_t size) {
+  size_t cur_size = 0;
+  const size_t max_copy_size = max_single_linear_copy_size_ ? max_single_linear_copy_size_ :
+                                                              kMaxSingleCopySize;
+  for (uint32_t i = 0; i < num_copy_command; ++i) {
+    const uint32_t copy_size =
+        static_cast<uint32_t>(std::min((size - cur_size), max_copy_size));
+
+    void* cur_dst1 = static_cast<char*>(dst1) + cur_size;
+    void* cur_dst2 = static_cast<char*>(dst2) + cur_size;
+    const void* cur_src = static_cast<const char*>(src) + cur_size;
+
+    SDMA_PKT_COPY_LINEAR_BROADCAST* packet_addr =
+        reinterpret_cast<SDMA_PKT_COPY_LINEAR_BROADCAST*>(cmd_addr);
+
+    memset(packet_addr, 0, sizeof(SDMA_PKT_COPY_LINEAR_BROADCAST));
+
+    packet_addr->HEADER_UNION.op = SDMA_OP_COPY;
+    packet_addr->HEADER_UNION.sub_op = SDMA_SUBOP_COPY_LINEAR_BROADCAST;
+    packet_addr->HEADER_UNION.broadcast = 1;
+
+    if (max_copy_size == max_single_linear_copy_size_)
+      packet_addr->COUNT_UNION.count_ext.count = copy_size - 1;
+    else
+      packet_addr->COUNT_UNION.count.count = copy_size - 1;
+
+    packet_addr->SRC_ADDR_LO_UNION.src_addr_31_0 = ptrlow32(cur_src);
+    packet_addr->SRC_ADDR_HI_UNION.src_addr_63_32 = ptrhigh32(cur_src);
+
+    packet_addr->DST_ADDR_LO_UNION.dst_addr_31_0 = ptrlow32(cur_dst1);
+    packet_addr->DST_ADDR_HI_UNION.dst_addr_63_32 = ptrhigh32(cur_dst1);
+
+    packet_addr->DST2_ADDR_LO_UNION.dst2_addr_31_0 = ptrlow32(cur_dst2);
+    packet_addr->DST2_ADDR_HI_UNION.dst2_addr_63_32 = ptrhigh32(cur_dst2);
+
+    cmd_addr += broadcast_copy_command_size_;
     cur_size += copy_size;
   }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -734,7 +734,8 @@ core::Blit* GpuAgent::CreateBlitSdma(bool use_xgmi, int rec_eng) {
   switch (isa_->GetMajorVersion()) {
     case 9:
       sdma = new BlitSdmaV4();
-      copy_size_override = (isa_->GetMinorVersion() == 0 && isa_->GetStepping() == 10) ?
+      copy_size_override = (isa_->GetMinorVersion() > 4 ||
+                            (isa_->GetMinorVersion() == 0 && isa_->GetStepping() == 10)) ?
                             copy_size_overrides[1] : copy_size_overrides[0];
       break;
     case 10:
@@ -1032,7 +1033,7 @@ static bool GangCopyCompleteHandler(hsa_signal_value_t, void *arg ) {
       return false;
     }
   }
-  return true;
+  return false;
 }
 
 hsa_status_t GpuAgent::DmaCopy(void* dst, core::Agent& dst_agent,
@@ -1292,6 +1293,196 @@ hsa_status_t GpuAgent::DmaPreferredEngine(core::Agent& dst_agent, core::Agent& s
     }
   } else {
     *recommended_ids_mask = rec_sdma_eng_id_peers_info_[dst_agent.public_handle().handle];
+  }
+
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t GpuAgent::DmaCopyBroadcast(
+    const hsa_amd_memory_copy_op_t& op,
+    std::vector<core::Signal*>& dep_signals) {
+
+  core::Signal* out_signal_obj = core::Signal::Convert(op.completion_signal);
+  core::Signal& out_signal = *out_signal_obj;
+
+  SetCopyRequestRefCount(true);
+  MAKE_SCOPE_GUARD([&]() { SetCopyRequestRefCount(false); });
+
+  if (profiling_enabled())
+    out_signal.async_copy_agent(core::Agent::Convert(this->public_handle()));
+
+  const uint32_t num_dsts = op.num_dsts;
+  constexpr size_t kBroadcastMaxSize = 1024 * 1024;
+  constexpr bool kUseRRBalancing = false;
+  const uint32_t total_sdma =
+      properties_.NumSdmaEngines + properties_.NumSdmaXgmiEngines;
+
+  // Try HW broadcast for small transfers.
+  if (op.size < kBroadcastMaxSize && total_sdma > 0) {
+    uint32_t eng_idx = kUseRRBalancing
+        ? BlitHostToDev + (sdma_rr_index_++ % total_sdma)
+        : BlitHostToDev;
+    lazy_ptr<core::Blit>& blit = GetBlitObject(eng_idx);
+    if (blit->isSDMA()) {
+      BlitSdmaBase* sdma_blit = static_cast<BlitSdmaBase*>((*blit).get());
+      if (sdma_blit->BroadcastSupported()) {
+        LogPrint(HSA_AMD_LOG_FLAG_SDMA,
+                 "SDMA Broadcast using engine %02u, src=%p, num_dsts=%u, size=%zu, "
+                 "dep_signal=0x%zx, completion_signal=0x%zx",
+                 eng_idx, op.src, num_dsts, op.size,
+                 dep_signals[0] ? core::Signal::Convert(dep_signals[0]).handle : 0,
+                 out_signal_obj->signal_);
+        std::vector<void*> dsts(op.dst_list, op.dst_list + num_dsts);
+        return sdma_blit->SubmitLinearCopyBroadcastCommand(
+            dsts, op.src, op.size, dep_signals, out_signal);
+      }
+    }
+  }
+
+  // Fall back to prologue/body/epilogue fan-out.
+  lazy_ptr<core::Blit>& coord_blit = GetBlitObject(BlitHostToDev);
+  if (!coord_blit->isSDMA())
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  BlitSdmaBase* coordinator = static_cast<BlitSdmaBase*>((*coord_blit).get());
+
+  // Resolve per-destination SDMA engines.
+  struct EngineSlot { BlitSdmaBase* blit; uint32_t idx; };
+  std::vector<EngineSlot> engines(num_dsts, {coordinator, BlitHostToDev});
+  for (uint32_t d = 0; d < num_dsts; ++d) {
+    if (kUseRRBalancing && total_sdma > 0) {
+      uint32_t eng_idx = BlitHostToDev + (sdma_rr_index_++ % total_sdma);
+      lazy_ptr<core::Blit>& blit = GetBlitObject(eng_idx);
+      if (blit->isSDMA())
+        engines[d] = {static_cast<BlitSdmaBase*>((*blit).get()), eng_idx};
+    } else {
+      core::Agent* dst_agent = core::Agent::Convert(op.dst_agent_list[d]);
+      int rec_eng = rocr::os::Ffs(
+          rec_sdma_eng_id_peers_info_[dst_agent->public_handle().handle]);
+      if (rec_eng) {
+        lazy_ptr<core::Blit>& blit = GetBlitObject(rec_eng);
+        if (blit->isSDMA())
+          engines[d] = {static_cast<BlitSdmaBase*>((*blit).get()),
+                        static_cast<uint32_t>(rec_eng)};
+      }
+    }
+  }
+
+  // Allocate prologue synchronization signal with RAII cleanup.
+  core::unique_signal_ptr prologue_signal(new core::DefaultSignal(1));
+  if (!prologue_signal->IsValid()) return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+
+  bool use_body_signals = !coordinator->PlatformAtomicSupport();
+
+  // Without platform atomic support, bodies cannot atomically decrement a
+  // shared signal. Allocate per-body signals so each body writes to its own
+  // and the epilogue polls all of them.
+  std::vector<core::unique_signal_ptr> body_signals;
+  if (use_body_signals) {
+    body_signals.reserve(num_dsts);
+    for (uint32_t d = 0; d < num_dsts; ++d) {
+      core::unique_signal_ptr sig(new core::DefaultSignal(1));
+      if (!sig->IsValid())
+        return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+      body_signals.push_back(std::move(sig));
+    }
+  }
+
+  // Use raw pointers for use during submissions as Submit* APIs take raw signals.
+  core::Signal* prologue_raw = prologue_signal.get();
+  std::vector<core::Signal*> body_raw;
+  for (auto& s : body_signals) body_raw.push_back(s.get());
+
+  auto cleanup_signals = std::make_unique<std::vector<core::Signal*>>();
+  cleanup_signals->push_back(prologue_signal.release());
+  for (auto& s : body_signals) cleanup_signals->push_back(s.release());
+
+  core::Runtime::runtime_singleton_->SetAsyncSignalHandler(
+      core::Signal::Convert(&out_signal),
+      HSA_SIGNAL_CONDITION_EQ, 0,
+      [](hsa_signal_value_t, void* arg) -> bool {
+        auto* sigs = reinterpret_cast<std::vector<core::Signal*>*>(arg);
+        for (auto* s : *sigs) s->DestroySignal();
+        delete sigs;
+        return false;
+      },
+      reinterpret_cast<void*>(cleanup_signals.release()));
+
+  if (!use_body_signals) {
+    out_signal.AddRelaxed(num_dsts);
+  }
+
+  // Prologue: dep polls, HDP flush, GCR invalidate, decrement prologue_signal.
+  LogPrint(HSA_AMD_LOG_FLAG_SDMA,
+           "SDMA FanOut Prologue: engine %02u, dep_signal=0x%zx, "
+           "completion_signal=0x%zx, prologue_signal=0x%zx",
+           BlitHostToDev,
+           dep_signals.empty() ? 0 : core::Signal::Convert(dep_signals[0]).handle,
+           core::Signal::Convert(out_signal_obj).handle,
+           core::Signal::Convert(prologue_raw).handle);
+  hsa_status_t stat = coordinator->SubmitPrologue(dep_signals, out_signal,
+                                                  *prologue_raw);
+  if (stat != HSA_STATUS_SUCCESS) return stat;
+
+  // Fan out: one copy body per destination on its resolved engine.
+  for (uint32_t d = 0; d < num_dsts; ++d) {
+    core::Signal& body_sig = use_body_signals ? *body_raw[d] : out_signal;
+    LogPrint(HSA_AMD_LOG_FLAG_SDMA,
+             "SDMA FanOut Body[%u/%u]: engine %02u, src=%p, dst=%p, size=%zu, "
+             "prologue_signal=0x%zx, body_signal=0x%zx",
+             d, num_dsts, engines[d].idx, op.src, op.dst_list[d], op.size,
+             core::Signal::Convert(prologue_raw).handle,
+             core::Signal::Convert(&body_sig).handle);
+    stat = engines[d].blit->SubmitLinearCopyBody(
+        op.dst_list[d], op.src, op.size,
+        *prologue_raw, body_sig);
+    if (stat != HSA_STATUS_SUCCESS) return stat;
+  }
+
+  // Epilogue: waits for all bodies, GCR writeback, end timestamp, signal → 0.
+  LogPrint(HSA_AMD_LOG_FLAG_SDMA,
+           "SDMA FanOut Epilogue: engine %02u, completion_signal=0x%zx, "
+           "num_body_signals=%zu",
+           BlitHostToDev,
+           core::Signal::Convert(out_signal_obj).handle,
+           body_raw.size());
+  constexpr hsa_signal_value_t kWaitValue = 1;
+  return coordinator->SubmitEpilogue(out_signal, kWaitValue, body_raw);
+}
+
+hsa_status_t GpuAgent::DmaCopyBatch(const hsa_amd_memory_copy_op_t* ops,
+                                    uint32_t num_ops,
+                                    std::vector<core::Signal*>& dep_signals) {
+  if (num_ops == 0) {
+    return HSA_STATUS_SUCCESS;
+  }
+
+  for (uint32_t i = 0; i < num_ops; ++i) {
+    const auto& op = ops[i];
+    core::Signal* out_signal_obj = core::Signal::Convert(op.completion_signal);
+    core::Signal& out_signal = *out_signal_obj;
+
+    hsa_status_t status;
+
+    switch (op.type) {
+    case HSA_AMD_MEMORY_COPY_OP_LINEAR: {
+      core::Agent* dst_agent = core::Agent::Convert(op.dst_agent);
+      core::Agent* src_agent = core::Agent::Convert(op.src_agent);
+      status = DmaCopy(op.dst, *dst_agent, op.src, *src_agent, op.size,
+                       dep_signals, out_signal);
+      break;
+    }
+    case HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST:
+      status = DmaCopyBroadcast(op, dep_signals);
+      break;
+    case HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP:
+    case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT:
+      return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+    default:
+      return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (status != HSA_STATUS_SUCCESS)
+      return status;
   }
 
   return HSA_STATUS_SUCCESS;
@@ -1849,7 +2040,7 @@ hsa_status_t GpuAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type, u
 
   auto aql_queue = new AqlQueue(shared_queue, this, size, node_id(), scratch, event_callback, data,
                                 flags);
-  
+
   *queue = aql_queue;
   aql_queues_.push_back(aql_queue);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_api_trace.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_api_trace.cpp
@@ -87,7 +87,7 @@ void HsaApiTable::Init() {
   // they can add preprocessor macros on the new functions
 
   constexpr size_t expected_core_api_table_size = 1016;
-  constexpr size_t expected_amd_ext_table_size = 640;
+  constexpr size_t expected_amd_ext_table_size = 648;
   constexpr size_t expected_image_ext_table_size = 128;
   constexpr size_t expected_finalizer_ext_table_size = 64;
   constexpr size_t expected_tools_table_size = 64;
@@ -481,6 +481,7 @@ void HsaApiTable::UpdateAmdExts() {
   amd_ext_api.hsa_amd_signal_wait_all_fn = AMD::hsa_amd_signal_wait_all;
   amd_ext_api.hsa_amd_memory_get_preferred_copy_engine_fn = AMD::hsa_amd_memory_get_preferred_copy_engine;
   amd_ext_api.hsa_amd_portable_export_dmabuf_v2_fn = AMD::hsa_amd_portable_export_dmabuf_v2;
+  amd_ext_api.hsa_amd_memory_async_batch_copy_fn = AMD::hsa_amd_memory_async_batch_copy;
 }
 
 void HsaApiTable::UpdateTools() {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -339,6 +339,133 @@ hsa_status_t hsa_amd_memory_async_copy_on_engine(void* dst, hsa_agent_t dst_agen
   CATCH;
 }
 
+hsa_status_t hsa_amd_memory_async_batch_copy(const hsa_amd_memory_copy_op_t* copy_ops,
+                                             uint32_t num_copy_ops,
+                                             uint32_t num_dep_signals,
+                                             const hsa_signal_t* dep_signals) {
+  TRY;
+
+  if (copy_ops == nullptr || num_copy_ops == 0) {
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+
+  if ((num_dep_signals == 0 && dep_signals != nullptr) ||
+      (num_dep_signals > 0 && dep_signals == nullptr)) {
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+
+  // Convert dependency signals
+  std::vector<core::Signal*> dep_signal_list(num_dep_signals);
+  if (num_dep_signals > 0) {
+    for (size_t i = 0; i < num_dep_signals; ++i) {
+      core::Signal* dep_signal_obj = core::Signal::Convert(dep_signals[i]);
+      IS_VALID(dep_signal_obj);
+      dep_signal_list[i] = dep_signal_obj;
+    }
+  }
+
+  bool rev_copy_dir = core::Runtime::runtime_singleton_->flag().rev_copy_dir();
+
+  // Validate all ops and group by copy_agent.
+  std::map<core::Agent*, std::vector<hsa_amd_memory_copy_op_t>> agent_batches;
+
+  for (uint32_t i = 0; i < num_copy_ops; ++i) {
+    const hsa_amd_memory_copy_op_t& op = copy_ops[i];
+
+    if (op.version != HSA_AMD_MEMORY_COPY_OP_VERSION)
+      return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+    core::Signal* sig = core::Signal::Convert(op.completion_signal);
+    IS_VALID(sig);
+
+    IS_BAD_PTR(op.src);
+
+    core::Agent* src_agent = core::Agent::Convert(op.src_agent);
+    IS_VALID(src_agent);
+
+    if (op.type > HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT) {
+      return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+
+    for (const auto& r : op.reserved) {
+      if (r != 0) {
+        return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+      }
+    }
+
+    // Per-type field validation.
+    core::Agent* dst_agent = nullptr;
+    switch (op.type) {
+    case HSA_AMD_MEMORY_COPY_OP_LINEAR:
+    case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT:
+      IS_BAD_PTR(op.dst);
+      dst_agent = core::Agent::Convert(op.dst_agent);
+      IS_VALID(dst_agent);
+      if (op.num_dsts != 0 || op.unused_size != 0)
+        return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+      break;
+    case HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST:
+      if (op.dst_list == nullptr || op.dst_agent_list == nullptr ||
+          op.num_dsts == 0 || op.num_dsts > 1024 || op.unused_size != 0)
+        return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+      for (uint32_t d = 0; d < op.num_dsts; ++d) {
+        IS_BAD_PTR(op.dst_list[d]);
+        core::Agent* da = core::Agent::Convert(op.dst_agent_list[d]);
+        IS_VALID(da);
+      }
+      break;
+    case HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP:
+      IS_BAD_PTR(op.dst);
+      dst_agent = core::Agent::Convert(op.dst_agent);
+      IS_VALID(dst_agent);
+      if (op.num_dsts != 0) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+      if (op.src_size == 0 || op.dst_size == 0)
+        return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+      break;
+    default:
+      return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+
+    bool has_work = (op.type == HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP)
+        ? (op.src_size > 0)
+        : (op.size > 0);
+
+    if (has_work) {
+      core::Agent* copy_agent = nullptr;
+      if (op.type == HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST) {
+        if (src_agent->device_type() != core::Agent::DeviceType::kAmdGpuDevice)
+          return HSA_STATUS_ERROR_INVALID_AGENT;
+        copy_agent = src_agent;
+      } else {
+        core::Agent* eff_dst = rev_copy_dir ? src_agent : dst_agent;
+        core::Agent* eff_src = rev_copy_dir ? dst_agent : src_agent;
+        const bool src_gpu =
+            (eff_src->device_type() == core::Agent::DeviceType::kAmdGpuDevice);
+        copy_agent = src_gpu ? eff_src : eff_dst;
+      }
+
+      agent_batches[copy_agent].push_back(op);
+    }
+  }
+
+  // Dispatch each agent's batch via DmaCopyBatch.
+  for (auto& [copy_agent, ops] : agent_batches) {
+    if (copy_agent->device_type() != core::Agent::DeviceType::kAmdGpuDevice) {
+      return HSA_STATUS_ERROR_INVALID_AGENT;
+    }
+
+    hsa_status_t status = copy_agent->DmaCopyBatch(ops.data(),
+                                                    static_cast<uint32_t>(ops.size()),
+                                                    dep_signal_list);
+    if (status != HSA_STATUS_SUCCESS) {
+      return status;
+    }
+  }
+
+  return HSA_STATUS_SUCCESS;
+  CATCH;
+}
+
 hsa_status_t hsa_amd_memory_copy_engine_status(hsa_agent_t dst_agent_handle,
                                                hsa_agent_t src_agent_handle,
                                                uint32_t *engine_ids_mask) {
@@ -1188,12 +1315,12 @@ hsa_status_t hsa_amd_queue_set_priority(hsa_queue_t* queue,
   core::Queue* cmd_queue = core::Queue::Convert(queue);
   IS_VALID(cmd_queue);
 
-  // Check if this a counted queue; NACK if it is                                                
+  // Check if this a counted queue; NACK if it is
   if (cmd_queue->is_counted_queue) return HSA_STATUS_ERROR_INVALID_QUEUE;
 
   // Convert to ROCR internal priority type
   HSA::hsa_amd_queue_priority_internal_t priority_ = static_cast<HSA::hsa_amd_queue_priority_internal_t>(priority);
-  
+
   return cmd_queue->SetPriority(priority_);
   CATCH;
 }
@@ -1529,7 +1656,7 @@ hsa_status_t HSA_API hsa_amd_queue_get_info(hsa_queue_t* _queue,
 
   core::Queue* queue = core::Queue::Convert(_queue);
   IS_VALID(queue);
-  
+
   return queue->GetInfo(attribute, value);
   CATCH;
 }
@@ -1590,7 +1717,7 @@ hsa_amd_counted_queue_acquire(hsa_agent_t agent,
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }
 
-  // Check priority 
+  // Check priority
   if (priority < HSA_AMD_QUEUE_PRIORITY_LOW || priority > HSA_AMD_QUEUE_PRIORITY_HIGH) {
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }
@@ -1608,9 +1735,9 @@ hsa_amd_counted_queue_acquire(hsa_agent_t agent,
   }
   AMD::GpuAgent* gpu_agent = static_cast<AMD::GpuAgent*>(core_agent);
 
-  // Convert to ROCR internal priority type 
+  // Convert to ROCR internal priority type
   HSA::hsa_amd_queue_priority_internal_t priority_ = static_cast<HSA::hsa_amd_queue_priority_internal_t>(priority);
-  
+
   // Call the queue pool manager
   return gpu_agent->AcquireCountedQueue(type, priority_, callback, data, flags, queue);
   CATCH;
@@ -1619,8 +1746,8 @@ hsa_amd_counted_queue_acquire(hsa_agent_t agent,
 hsa_status_t HSA_API
 hsa_amd_counted_queue_release(hsa_queue_t* queue) {
   TRY;
-  IS_OPEN();   
-  // Basic validation                           
+  IS_OPEN();
+  // Basic validation
   if (queue == nullptr) {
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/hsacore.dll.def
+++ b/projects/rocr-runtime/runtime/hsa-runtime/hsacore.dll.def
@@ -147,6 +147,7 @@ EXPORTS
   hsa_amd_memory_fill
   hsa_amd_memory_async_copy
   hsa_amd_memory_async_copy_on_engine
+  hsa_amd_memory_async_batch_copy
   hsa_amd_memory_copy_engine_status
   hsa_amd_memory_get_preferred_copy_engine
   hsa_amd_memory_async_copy_rect

--- a/projects/rocr-runtime/runtime/hsa-runtime/hsacore.so.def
+++ b/projects/rocr-runtime/runtime/hsa-runtime/hsacore.so.def
@@ -183,6 +183,7 @@ global:
 	hsa_amd_memory_fill;
 	hsa_amd_memory_async_copy;
 	hsa_amd_memory_async_copy_on_engine;
+	hsa_amd_memory_async_batch_copy;
 	hsa_amd_memory_copy_engine_status;
 	hsa_amd_memory_get_preferred_copy_engine;
 	hsa_amd_memory_async_copy_rect;

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace.h
@@ -275,6 +275,7 @@ struct AmdExtTable {
   decltype(hsa_amd_ais_file_read)* hsa_amd_ais_file_read_fn;
   decltype(hsa_amd_counted_queue_acquire)* hsa_amd_counted_queue_acquire_fn;
   decltype(hsa_amd_counted_queue_release)* hsa_amd_counted_queue_release_fn;
+  decltype(hsa_amd_memory_async_batch_copy)* hsa_amd_memory_async_batch_copy_fn;
 };
 
 // Table to export HSA Core Runtime Apis

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace_version.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace_version.h
@@ -58,7 +58,7 @@
 // Step Ids of the Api tables exported by Hsa Core Runtime
 #define HSA_API_TABLE_STEP_VERSION                  0x01
 #define HSA_CORE_API_TABLE_STEP_VERSION             0x00
-#define HSA_AMD_EXT_API_TABLE_STEP_VERSION          0x09
+#define HSA_AMD_EXT_API_TABLE_STEP_VERSION          0x0A
 #define HSA_FINALIZER_API_TABLE_STEP_VERSION        0x00
 #define HSA_IMAGE_API_TABLE_STEP_VERSION            0x01
 // Rocprofiler just checks HSA_MAGE_EXT_API_TABLE_STEP_VERSION

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -66,9 +66,10 @@
  * - 1.13 - hsa_amd_pointer_info: Added new registered field to hsa_amd_pointer_info_t
  * - 1.14 - hsa_amd_ais_file_write, hsa_amd_ais_file_read
  * - 1.15 - hsa_amd_register_system_event_handler: HSA_AMD_SYSTEM_SHUTDOWN
+ * - 1.17 - hsa_amd_memory_async_batch_copy
  */
 #define HSA_AMD_INTERFACE_VERSION_MAJOR 1
-#define HSA_AMD_INTERFACE_VERSION_MINOR 16
+#define HSA_AMD_INTERFACE_VERSION_MINOR 17
 
 #ifdef __cplusplus
 extern "C" {
@@ -1812,6 +1813,138 @@ hsa_status_t HSA_API
                               hsa_signal_t completion_signal,
                               hsa_amd_sdma_engine_id_t engine_id,
                               bool force_copy_on_sdma);
+
+/**
+ * @brief Type of memory copy operation within a batch.
+ */
+typedef enum {
+  HSA_AMD_MEMORY_COPY_OP_LINEAR           = 0,  /**< Default: linear copy via copy engine */
+  HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST = 1,  /**< Linear broadcast: single src -> multiple dsts via copy engine */
+  HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP      = 2,  /**< Linear swap: swap contents of src and dst via copy engine */
+  HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT  = 3,  /**< src/dst are pointers to pointers; actual addresses resolved dynamically */
+} hsa_amd_memory_copy_op_type_t;
+
+/**
+ * @brief Version of the hsa_amd_memory_copy_op_t structure.
+ *
+ * Callers must set the @c version field to this value.  The runtime rejects
+ * operations whose version it does not recognise.
+ */
+#define HSA_AMD_MEMORY_COPY_OP_VERSION 1
+
+/**
+ * @brief Describes a single copy operation within a batch.
+ *
+ * The @c version field must be set to @c HSA_AMD_MEMORY_COPY_OP_VERSION.
+ *
+ * Common fields (all operation types):
+ *   version         -- must be HSA_AMD_MEMORY_COPY_OP_VERSION
+ *   type            -- one of hsa_amd_memory_copy_op_type_t
+ *   completion_signal -- per-operation completion signal
+ *   traffic_class   -- QoS traffic class (0 = default/unspecified)
+ *   reserved[]      -- must be zero
+ *
+ * Field usage per operation type:
+ *
+ * LINEAR (default):
+ *   src, src_agent  -- source pointer and agent
+ *   dst, dst_agent  -- destination pointer and agent
+ *   size            -- copy size in bytes
+ *   num_dsts        -- must be 0
+ *
+ * LINEAR_BROADCAST (single source -> multiple destinations):
+ *   src, src_agent    -- source pointer and agent
+ *   dst_list          -- caller-owned array of num_dsts destination pointers
+ *   dst_agent_list    -- caller-owned array of num_dsts destination agents
+ *   size              -- copy size in bytes (same for every destination)
+ *   num_dsts          -- number of entries in dst_list / dst_agent_list (>= 1, <= 1024)
+ *
+ * LINEAR_SWAP (exchange contents of two buffers):
+ *   src, src_agent  -- first buffer pointer and agent (modified in place)
+ *   dst, dst_agent  -- second buffer pointer and agent (modified in place)
+ *   src_size        -- size of the source region in bytes
+ *   dst_size        -- size of the destination region in bytes
+ *   num_dsts        -- must be 0
+ *
+ * LINEAR_INDIRECT (pointers resolved at execution time):
+ *   src, src_agent  -- pointer to source address (void**)
+ *   dst, dst_agent  -- pointer to destination address (void**)
+ *   size            -- copy size in bytes
+ *   num_dsts        -- must be 0
+ *
+ * Future-proofing unions (reserved, must not be used):
+ *   src_list, src_agent_list  -- reserved for future gather operations
+ *   unused_size               -- must be 0 for non-SWAP operations
+ */
+typedef struct hsa_amd_memory_copy_op_s {
+  uint32_t version;                       /**< Struct version. Must be HSA_AMD_MEMORY_COPY_OP_VERSION. */
+  hsa_amd_memory_copy_op_type_t type;     /**< Operation type */
+  uint32_t num_dsts;                      /**< BROADCAST: number of destinations; others: must be 0 */
+  uint32_t traffic_class;                 /**< QoS traffic class. 0 = default/unspecified. */
+  hsa_signal_t completion_signal;         /**< Completion signal for this operation */
+  union {
+    void* src;                            /**< Source pointer */
+    void** src_list;                      /**< Reserved for future use */
+  };
+  union {
+    hsa_agent_t src_agent;                /**< Source agent */
+    hsa_agent_t* src_agent_list;          /**< Reserved for future use */
+  };
+  union {
+    hsa_agent_t dst_agent;                /**< LINEAR/SWAP/INDIRECT: destination agent */
+    hsa_agent_t* dst_agent_list;          /**< BROADCAST: caller-owned array of num_dsts destination agents */
+  };
+  union {
+    void* dst;                            /**< LINEAR/SWAP/INDIRECT: destination pointer */
+    void** dst_list;                      /**< BROADCAST: caller-owned array of num_dsts destination pointers */
+  };
+  union {
+    struct {
+      size_t size;                        /**< LINEAR/BROADCAST/INDIRECT: copy size in bytes */
+      size_t unused_size;                 /**< LINEAR/BROADCAST/INDIRECT: must be 0 */
+    };
+    struct {
+      size_t src_size;                    /**< SWAP: source region size in bytes */
+      size_t dst_size;                    /**< SWAP: destination region size in bytes */
+    };
+  };
+  uint64_t reserved[3];                   /**< Reserved for future use. Must be zero. */
+} hsa_amd_memory_copy_op_t;
+
+/**
+ * @brief Submits a batch of asynchronous memory copy operations.
+ *
+ * @details Submits multiple memory copy operations as a batch. Each operation
+ * carries its own completion signal in @c hsa_amd_memory_copy_op_t.completion_signal.
+ * All operations within a single batch must share the same completion signal.
+ * The caller must initialise the signal value to @p num_copy_ops before calling
+ * this function; the runtime decrements it once per completed operation.
+ *
+ * Each operation is self-describing via its @c type field. A BROADCAST operation
+ * is a single op that copies one source to multiple destinations via @c dst_list
+ * and @c num_dsts. A SWAP operation exchanges two buffers using @c src_size and
+ * @c dst_size.
+ *
+ * @param[in] copy_ops Array of copy operation descriptors.
+ *
+ * @param[in] num_copy_ops Number of copy operations in the array.
+ *
+ * @param[in] num_dep_signals Number of dependent signals.
+ *
+ * @param[in] dep_signals Array of dependent signals that all copy operations
+ * must wait on before starting.
+ *
+ * @retval ::HSA_STATUS_SUCCESS The batch copy was submitted successfully.
+ *
+ * @retval ::HSA_STATUS_ERROR_INVALID_ARGUMENT copy_ops is NULL, num_copy_ops
+ * is 0, any src/dst pointers are NULL, or completion_signal is invalid.
+ */
+hsa_status_t HSA_API
+    hsa_amd_memory_async_batch_copy(const hsa_amd_memory_copy_op_t* copy_ops,
+                              uint32_t num_copy_ops,
+                              uint32_t num_dep_signals,
+                              const hsa_signal_t* dep_signals);
+
 /**
  * @brief Reports the availability of SDMA copy engines.
  *
@@ -3668,7 +3801,7 @@ typedef enum {
   HSA_AMD_QUEUE_INFO_DOORBELL_ID,
   /*
   * Returns how many times the underlying hardware queue has been shared.
-  * @p value will be set to -1 if this queue was not allocated using 
+  * @p value will be set to -1 if this queue was not allocated using
   * hsa_amd_counted_queue_acquire. The type of this attribute is uint32_t.
   */
   HSA_QUEUE_INFO_USE_COUNT,
@@ -3787,7 +3920,7 @@ hsa_status_t HSA_API hsa_amd_ais_file_read(hsa_amd_ais_file_handle_t handle, voi
  *
  * For each successful call, hsa_amd_counted_queue_release should be called to release the
  * HSA_QUEUE_INFO_USE_COUNT. After release, the queue handle becomes invalid and must not be used.
- * 
+ *
  * hsa_amd_queue_set_priority and hsa_amd_queue_cu_set_mask cannot be used on counted queues.
  *
  * @param[in] agent Agent where to create the queue
@@ -3818,7 +3951,7 @@ hsa_status_t HSA_API hsa_amd_ais_file_read(hsa_amd_ais_file_handle_t handle, voi
  * @retval ::HSA_STATUS_ERROR_INVALID_AGENT The agent is invalid or not a GPU agent.
  *
  * @retval ::HSA_STATUS_ERROR_INVALID_QUEUE_CREATION @p type is not HSA_QUEUE_TYPE_MULTI.
- * 
+ *
  * @retval ::HSA_STATUS_ERROR_INVALID_ARGUMENT Invalid priority or NULL queue pointer.
  */
 hsa_status_t HSA_API hsa_amd_counted_queue_acquire(hsa_agent_t agent, hsa_queue_type_t type,
@@ -3829,13 +3962,13 @@ hsa_status_t HSA_API hsa_amd_counted_queue_acquire(hsa_agent_t agent, hsa_queue_
 
 /**
  * @brief Release a counted queue and decrements its use count.
- * 
+ *
  * Releases a queue that was previously acquired using hsa_amd_counted_queue_acquire.
- * Each call to this API decrements the internal use count HSA_QUEUE_INFO_USE_COUNT 
+ * Each call to this API decrements the internal use count HSA_QUEUE_INFO_USE_COUNT
  * of the underlying hardware. After this call, queue handle is invalid and must not be used.
  * Once created, the hardware queue is retained until hsa_shutdown is called to avoid costly
- * overhead of repeatedly creating new hardware queues, allowing them to be reused. 
- * 
+ * overhead of repeatedly creating new hardware queues, allowing them to be reused.
+ *
  *
  * @param[in] queue Counted queue handle returned from hsa_amd_counted_queue_acquire.
  * Must not be NULL.


### PR DESCRIPTION
Introduce a new HSA AMD extension API `hsa_amd_memory_async_batch_copy` that accepts an array of copy operation descriptors. This enables submitting multiple memory copies as a single batch call, reducing API overhead.

ROCr runtime changes:
- Define `hsa_amd_memory_copy_op_t` struct with reserved fields for ABI future-proofing
- Implement `hsa_amd_memory_async_batch_copy` which internally selects the recommended SDMA engine per operation via DmaPreferredEngine and dispatches via DmaCopyOnEngine
- Wire up the new API through the HSA table interface, API trace, and export symbol definitions

CLR changes:
- Add `KernelBlitManager::copyBufferBatch` which partitions ops into intra-device (kernel blit via copyBuffer) and inter-device (DMA batch via hsaCopyBatch/rocrCopyBufferBatch), dispatching inter-device first for SDMA/compute overlap
- Signal management: outBatchSignals returns all-but-last batch signals for explicit barrier tracking; last signal stays at current_id_

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
