### PR TITLE
[rccl] Add Broadcom RCCL CAST external Network Plugin

### DIFF
--- a/projects/rccl/ext-net/brcm-cast-plugin/Makefile
+++ b/projects/rccl/ext-net/brcm-cast-plugin/Makefile
@@ -1,0 +1,44 @@
+# *************************************************************************
+# Copyright (c) 2025-2026 Broadcom. The term "Broadcom" refers solely to the Broadcom Inc. corporate affiliate that distributes this software. All rights reserved.
+# 
+# See LICENSE.txt for license information
+# ************************************************************************
+
+RCCL_HOME:=../..
+RCCL_BUILD:=$(RCCL_HOME)/build
+RCCL_SRC:=$(RCCL_HOME)/src
+RCCL_HIP:=$(RCCL_BUILD)/hipify
+
+INC:= -I. -I$(RCCL_BUILD)/_deps/fmt-src/include -I$(RCCL_BUILD)/hipify/src/include/plugin -I$(RCCL_BUILD)/hipify/src/include -I$(RCCL_BUILD)/hipify/src  -I$(RCCL_SRC)/include -I$(RCCL_BUILD)/include
+INC+= -I$(RCCL_HIP)/src/device -I$(RCCL_HIP)/gensrc
+
+SHOW_UNDEF_SYMBOLS:= # -Wl,-z,defs
+LIBS:= -L$(RCCL_BUILD) -lrccl
+
+CC:= /opt/rocm/bin/hipcc
+
+PLUGIN_SO:=librccl-net-bnxt.so
+
+OBJECTS=\
+$(RCCL_BUILD)/CMakeFiles/rccl.dir/hipify/src/misc/socket.cc.o \
+$(RCCL_BUILD)/CMakeFiles/rccl.dir/hipify/src/misc/ibvwrap.cc.o \
+$(RCCL_BUILD)/CMakeFiles/rccl.dir/hipify/src/misc/utils.cc.o \
+$(RCCL_BUILD)/CMakeFiles/rccl.dir/hipify/src/misc/param.cc.o \
+$(RCCL_BUILD)/CMakeFiles/rccl.dir/hipify/src/misc/ibvsymbols.cc.o \
+$(RCCL_BUILD)/CMakeFiles/rccl.dir/hipify/src/debug.cc.o \
+$(RCCL_BUILD)/CMakeFiles/rccl.dir/hipify/src/graph/xml.cc.o \
+$(RCCL_BUILD)/CMakeFiles/rccl.dir/hipify/src/misc/archinfo.cc.o \
+$(RCCL_BUILD)/CMakeFiles/rccl.dir/hipify/src/misc/rocm_smi_wrap.cc.o \
+$(RCCL_BUILD)/CMakeFiles/rccl.dir/hipify/src/misc/alt_rsmi.cc.o \
+
+
+
+
+default: $(PLUGIN_SO)
+
+$(PLUGIN_SO): net_ib_bnxt.cc
+        # $(CC) $(INC) -fPIC -shared -o $@ -Wl,-soname,$(PLUGIN_SO) $^
+	$(CC) -O3 $(INC) -DROCM_VERSION=70002 -fPIC -shared -o $@ $(OBJECTS) -Wl,-soname,$(PLUGIN_SO) $(SHOW_UNDEF_SYMBOLS) -Wl,--error-limit,0 $(LIBS) $^
+
+clean:
+	rm -f $(PLUGIN_SO)

--- a/projects/rccl/ext-net/brcm-cast-plugin/Makefile
+++ b/projects/rccl/ext-net/brcm-cast-plugin/Makefile
@@ -9,7 +9,7 @@ RCCL_BUILD:=$(RCCL_HOME)/build
 RCCL_SRC:=$(RCCL_HOME)/src
 RCCL_HIP:=$(RCCL_BUILD)/hipify
 
-INC:= -I. -I$(RCCL_BUILD)/_deps/fmt-src/include -I$(RCCL_BUILD)/hipify/src/include/plugin -I$(RCCL_BUILD)/hipify/src/include -I$(RCCL_BUILD)/hipify/src  -I$(RCCL_SRC)/include -I$(RCCL_BUILD)/include
+INC:= -Inccl -I. -I$(RCCL_BUILD)/_deps/fmt-src/include -I$(RCCL_BUILD)/hipify/src/include/plugin -I$(RCCL_BUILD)/hipify/src/include -I$(RCCL_BUILD)/hipify/src  -I$(RCCL_SRC)/include -I$(RCCL_BUILD)/include
 INC+= -I$(RCCL_HIP)/src/device -I$(RCCL_HIP)/gensrc
 
 SHOW_UNDEF_SYMBOLS:= # -Wl,-z,defs

--- a/projects/rccl/ext-net/brcm-cast-plugin/README.md
+++ b/projects/rccl/ext-net/brcm-cast-plugin/README.md
@@ -1,0 +1,47 @@
+# Broadcom RCCL CAST Network Plugin
+
+This document describes a RCCL Network Plugin that achieves congestion aware
+traffic distribution using standard RoCEv2.
+
+## Overview
+
+The RCCL Network Plugin supports Broadcom's Congestion Aware Sprayed Traffic
+(CAST) feature, which is an implementation of QP Load Balance (LB) Scheduling
+that provides performance improvements over typical QP Load Balancing. The
+idea is to use Round Trip Time (RTT) measurements to schedule more traffic
+over the QPs that are experiencing the least congestion. 
+
+## Installing and Building the CAST Network Plugin
+
+This document describes in-tree installation, where the CAST Network Plugin
+is installed in the ext-net area of the RCCL tree.
+
+The following description assumes the RCCL_HOME variable is set to the
+path to the root of the RCCL tree. For example:
+
+export RCCL_HOME=/rccl/rccl-rocm-7.0.2
+
+To install the CAST Network Plugin:
+
+cd $RCCL_HOME/ext-net/brcm-cast
+
+To build the CAST Network Plugin:
+
+make
+
+To copy the CAST Network Plugin to the RCCL tree build directory:
+
+cp librccl-net-bnxt.so ../../../build/librccl-net.so
+
+## Run rccl with CAST Net plugin
+An example RCCL command line that invokes the CAST Network Plugin is shown 
+below:
+
+export RCCL_HOME=/rccl/rccl-rocm-7.0.2; 
+/root/benchmarks_build/ubuntu_22.04/openmpi_4.1.6_ucx_1.15.0/install/bin/mpirun --mca orte_base_help_aggregate 0 -np 32 -host 1.1.70.15:8,1.1.72.15:8,1.1.14.15:8,1.1.16.15:8 --allow-run-as-root --gmca btl_tcp_if_include eno8303 --gmca oob_tcp_if_include eno8303 --gmca btl tcp,self -x NCCL_IB_DISABLE=0 -x NCCL_IB_HCA=bnxt_re0:1,bnxt_re1:1,bnxt_re2:1,bnxt_re3:1,bnxt_re4:1,bnxt_re5:1,bnxt_re6:1,bnxt_re7:1 -x NCCL_IB_TC=104 -x NCCL_IB_GID_INDEX=3 -x NCCL_IGNORE_CPU_AFFINITY=1 -x NCCL_IB_QPS_PER_CONNECTION=4 -x NCCL_IB_QP_SCHED_ENABLE=1 -x NCCL_IB_SPLIT_DATA_ON_QPS=1 -x NCCL_DEBUG=VERSION -x LD_LIBRARY_PATH=$RCCL_HOME/build /root/rccl/rccl-tests_7.0.2/build/all_gather_perf -b 1M -e 16G -f 2 -n 20 -w 5 -g 1 -c 1 -p 1 -t 1 
+
+## Network Plugin API Version
+
+The CAST Plugin is implemented using the Network Transport Plugin API v10.
+
+

--- a/projects/rccl/ext-net/brcm-cast-plugin/nccl/common.h
+++ b/projects/rccl/ext-net/brcm-cast-plugin/nccl/common.h
@@ -1,0 +1,23 @@
+/*************************************************************************
+ * Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef COMMON_H_
+#define COMMON_H_
+
+#ifndef NCCL_DEBUG_H_
+#include <stdint.h>
+
+typedef enum {NCCL_LOG_NONE=0, NCCL_LOG_ERROR=1, NCCL_LOG_VERSION=2, NCCL_LOG_WARN=3, NCCL_LOG_INFO=4, NCCL_LOG_ABORT=5, NCCL_LOG_TRACE=6} ncclDebugLogLevel;
+typedef enum {NCCL_INIT=1, NCCL_COLL=2, NCCL_P2P=4, NCCL_SHM=8, NCCL_NET=16, NCCL_GRAPH=32, NCCL_TUNING=64, NCCL_ENV=128, NCCL_ALLOC=256, NCCL_CALL=512, NCCL_PROXY=1024, NCCL_NVLS=2048, NCCL_BOOTSTRAP=4096, NCCL_REG=8192, NCCL_ALL=~0} ncclDebugLogSubSys;
+
+typedef void (*ncclDebugLogger_t)(ncclDebugLogLevel level, unsigned long flags, const char *file, int line, const char *fmt, ...);
+
+enum { ncclProfilerNetEventStart = 0, ncclProfilerNetEventStop, ncclProfilerNetEventUpdate, ncclProfilerNetEventUpdateAndStop };
+
+typedef ncclResult_t (*ncclProfilerCallback_t)(void** eHandle, int type, void* phandle, int64_t pluginId, void* extData);
+#endif
+
+#endif

--- a/projects/rccl/ext-net/brcm-cast-plugin/nccl/err.h
+++ b/projects/rccl/ext-net/brcm-cast-plugin/nccl/err.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2017-2022, NVIDIA CORPORATION. All rights reserved.
+ */
+
+#ifndef NCCL_ERR_H_
+#define NCCL_ERR_H_
+
+#ifndef NCCL_H_
+/* Error type for plugins */
+typedef enum { ncclSuccess                 =  0,
+               ncclUnhandledCudaError      =  1,
+               ncclSystemError             =  2,
+               ncclInternalError           =  3,
+               ncclInvalidArgument         =  4,
+               ncclInvalidUsage            =  5,
+               ncclRemoteError             =  6 } ncclResult_t;
+#endif
+
+#endif

--- a/projects/rccl/ext-net/brcm-cast-plugin/nccl/net.h
+++ b/projects/rccl/ext-net/brcm-cast-plugin/nccl/net.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017-2022, NVIDIA CORPORATION. All rights reserved.
+ */
+
+#ifndef NET_H_
+#define NET_H_
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "err.h"
+#include "net_device.h"
+#include "common.h"
+
+#define NCCL_NET_HANDLE_MAXSIZE 128
+#define NCCL_MAX_NET_SIZE_BYTES (1*1024*1024*1024*1024L) //1TB
+#define NCCL_NET_OPTIONAL_RECV_COMPLETION 0x1
+
+#define NCCL_PTR_HOST 0x1
+#define NCCL_PTR_CUDA 0x2
+#define NCCL_PTR_DMABUF 0x4
+
+// Maximum number of requests per comm object
+#define NCCL_NET_MAX_REQUESTS 32
+#define NCCL_NET_MAX_DEVS_PER_NIC 4
+
+#include "net_v10.h"
+/*
+#include "net_v9.h"
+#include "net_v8.h"
+#include "net_v7.h"
+#include "net_v6.h"
+#include "net_v5.h"
+#include "net_v4.h"
+#include "net_v3.h"
+#include "net_v2.h"
+*/
+typedef ncclNet_v10_t ncclNet_t;
+typedef ncclNetProperties_v10_t ncclNetProperties_t;
+typedef ncclNetVDeviceProps_v10_t ncclNetVDeviceProps_t;
+typedef ncclNetCommConfig_v10_t ncclNetCommConfig_t;
+
+#endif // end include guard

--- a/projects/rccl/ext-net/brcm-cast-plugin/nccl/net_device.h
+++ b/projects/rccl/ext-net/brcm-cast-plugin/nccl/net_device.h
@@ -1,0 +1,35 @@
+/*************************************************************************
+ * Copyright (c) 2023-2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef NET_DEVICE_H_
+#define NET_DEVICE_H_
+
+#ifndef NCCL_NET_DEVICE_H_
+#define NCCL_NET_DEVICE_INVALID_VERSION      0x0
+#define NCCL_NET_MTU_SIZE                    4096
+
+// Arbitrary version number - A given NCCL build will only be compatible with a single device networking plugin
+// version. NCCL will check the supplied version number from net->getProperties() and compare to its internal version.
+#define NCCL_NET_DEVICE_UNPACK_VERSION 0x7
+
+typedef enum {NCCL_NET_DEVICE_HOST=0, NCCL_NET_DEVICE_UNPACK=1} ncclNetDeviceType;
+
+typedef struct {
+  ncclNetDeviceType netDeviceType; // Network offload type
+  int netDeviceVersion;            // Version number for network offload
+  void* handle;
+  size_t size;
+  int needsProxyProgress;
+} ncclNetDeviceHandle_v7_t;
+
+typedef ncclNetDeviceHandle_v7_t ncclNetDeviceHandle_v8_t;
+typedef ncclNetDeviceHandle_v8_t ncclNetDeviceHandle_v9_t;
+typedef ncclNetDeviceHandle_v9_t ncclNetDeviceHandle_v10_t;
+typedef ncclNetDeviceHandle_v10_t ncclNetDeviceHandle_v11_t;
+typedef ncclNetDeviceHandle_v11_t ncclNetDeviceHandle_t;
+#endif
+
+#endif

--- a/projects/rccl/ext-net/brcm-cast-plugin/nccl/net_v10.h
+++ b/projects/rccl/ext-net/brcm-cast-plugin/nccl/net_v10.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2017-2022, NVIDIA CORPORATION. All rights reserved.
+ */
+
+#ifndef NET_V10_H_
+#define NET_V10_H_
+
+typedef struct {
+  int ndevs;
+  int devs[NCCL_NET_MAX_DEVS_PER_NIC];
+} ncclNetVDeviceProps_v10_t;
+
+
+#define NCCL_NET_TRAFFIC_CLASS_UNDEF -1
+typedef struct {
+  // Plugin-specific TC value
+  int trafficClass;
+} ncclNetCommConfig_v10_t;
+
+
+typedef struct {
+  char* name;                      // Used mostly for logging.
+  char* pciPath;                   // Path to the PCI device in /sys.
+  uint64_t guid;                   // Unique identifier for the NIC chip. Important for
+                                   // cards with multiple PCI functions (Physical or virtual).
+  int ptrSupport;                  // [NCCL_PTR_HOST|NCCL_PTR_CUDA|NCCL_PTR_DMABUF]
+  int regIsGlobal;                 // regMr is not tied to a particular comm
+  int forceFlush;                  // Force a flush on receives
+  int speed;                       // Port speed in Mbps.
+  int port;                        // Port number.
+  float latency;                   // Network latency
+  int maxComms;                    // Maximum number of comms we can create
+  int maxRecvs;                    // Maximum number of grouped receives.
+  ncclNetDeviceType netDeviceType; // Network offload type
+  int netDeviceVersion;            // Version number for network offload
+  ncclNetVDeviceProps_v10_t vProps;
+  size_t maxP2pBytes;              // Max transfer size for point-to-point operations
+  size_t maxCollBytes;             // Max transfer size for collective operations
+} ncclNetProperties_v10_t;
+
+typedef struct {
+  // Name of the network (mainly for logs)
+  const char* name;
+  // Initialize the network.
+  ncclResult_t (*init)(ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction);
+  // Return the number of adapters.
+  ncclResult_t (*devices)(int* ndev);
+  // Get various device properties.
+  ncclResult_t (*getProperties)(int dev, ncclNetProperties_v10_t* props);
+  // Create a receiving object and provide a handle to connect to it. The
+  // handle can be up to NCCL_NET_HANDLE_MAXSIZE bytes and will be exchanged
+  // between ranks to create a connection.
+  ncclResult_t (*listen)(int dev, void* handle, void** listenComm);
+  // Connect to a handle and return a sending comm object for that peer.
+  // This call must not block for the connection to be established, and instead
+  // should return successfully with sendComm == NULL with the expectation that
+  // it will be called again until sendComm != NULL.
+  // If *sendDevComm points to a valid object, then NCCL is requesting device offload for this connection
+  ncclResult_t (*connect)(int dev, ncclNetCommConfig_v10_t* config, void* handle, void** sendComm, ncclNetDeviceHandle_v10_t** sendDevComm);
+  // Finalize connection establishment after remote peer has called connect.
+  // This call must not block for the connection to be established, and instead
+  // should return successfully with recvComm == NULL with the expectation that
+  // it will be called again until recvComm != NULL.
+  // If *recvDevComm points to a valid object, then NCCL is requesting device offload for this connection
+  ncclResult_t (*accept)(void* listenComm, void** recvComm, ncclNetDeviceHandle_v10_t** recvDevComm);
+  // Register/Deregister memory. Comm can be either a sendComm or a recvComm.
+  // Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
+  ncclResult_t (*regMr)(void* comm, void* data, size_t size, int type, void** mhandle);
+  /* DMA-BUF support */
+  ncclResult_t (*regMrDmaBuf)(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+  ncclResult_t (*deregMr)(void* comm, void* mhandle);
+  // Asynchronous send to a peer.
+  // May return request == NULL if the call cannot be performed (or would block)
+  ncclResult_t (*isend)(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request);
+  // Asynchronous recv from a peer.
+  // May return request == NULL if the call cannot be performed (or would block)
+  ncclResult_t (*irecv)(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request);
+  // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
+  // visible to the GPU
+  ncclResult_t (*iflush)(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request);
+  // Test whether a request is complete. If size is not NULL, it returns the
+  // number of bytes sent/received.
+  ncclResult_t (*test)(void* request, int* done, int* sizes);
+  // Close and free send/recv comm objects
+  ncclResult_t (*closeSend)(void* sendComm);
+  ncclResult_t (*closeRecv)(void* recvComm);
+  ncclResult_t (*closeListen)(void* listenComm);
+
+  // Copy the given mhandle to a dptr in a format usable by this plugin's device code
+  ncclResult_t (*getDeviceMr)(void* comm, void* mhandle, void** dptr_mhandle);
+
+  // Notify the plugin that a recv has completed by the device
+  ncclResult_t (*irecvConsumed)(void* recvComm, int n, void* request);
+
+  // Virtual NIC APIs. makeVDevice will create a virtual NIC given the specified properties, and tell the caller
+  // what index this new vNIC exists at
+  ncclResult_t (*makeVDevice)(int* d, ncclNetVDeviceProps_v10_t* props);
+} ncclNet_v10_t;
+
+#endif // end include guard

--- a/projects/rccl/ext-net/brcm-cast-plugin/nccl/types.h
+++ b/projects/rccl/ext-net/brcm-cast-plugin/nccl/types.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2017-2022, NVIDIA CORPORATION. All rights reserved.
+ */
+
+#ifndef NCCL_TYPES_H_
+#define NCCL_TYPES_H_
+
+/* Data types */
+typedef enum { ncclInt8       = 0, ncclChar       = 0,
+               ncclUint8      = 1,
+               ncclInt32      = 2, ncclInt        = 2,
+               ncclUint32     = 3,
+               ncclInt64      = 4,
+               ncclUint64     = 5,
+               ncclFloat16    = 6, ncclHalf       = 6,
+               ncclFloat32    = 7, ncclFloat      = 7,
+               ncclFloat64    = 8, ncclDouble     = 8,
+               ncclBfloat16   = 9,
+               ncclFloat8e4m3 = 10,
+               ncclFloat8e5m2 = 11,
+} ncclDataType_t;
+
+#endif

--- a/projects/rccl/ext-net/brcm-cast-plugin/net_ib_bnxt.cc
+++ b/projects/rccl/ext-net/brcm-cast-plugin/net_ib_bnxt.cc
@@ -1,0 +1,3397 @@
+/*************************************************************************
+ * Copyright (c) 2016-2022, NVIDIA CORPORATION. All rights reserved.
+ * Modifications Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Modifications Copyright (c) 2025-2026 Broadcom. The term "Broadcom" refers solely to the Broadcom Inc. corporate affiliate that distributes this software. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include "nccl.h"
+#include "core.h"
+#include "socket.h"
+#include "net.h"
+#include "graph.h"
+#include "utils.h"
+#include "param.h"
+#include "profiler/net_ib.h"
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <poll.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <iostream>
+#include <cfloat>
+#define ENABLE_TIMER 0
+#include "timer.h"
+#include <sys/utsname.h>
+
+#include "ibvwrap.h"
+#include "graph/xml.h"
+
+#include "nccl_common.h"
+#include "net_plugin_tuner_api.h"
+
+#define MAXNAMESIZE 64
+static char ncclIbIfName[MAX_IF_NAME_SIZE+1];
+static union ncclSocketAddress ncclIbIfAddr;
+
+struct ncclIbMr {
+  uintptr_t addr;
+  size_t pages;
+  int refs;
+  ibv_mr *mr;
+};
+
+struct ncclIbMrCache {
+  struct ncclIbMr *slots;
+  int capacity, population;
+};
+
+static int ncclNMergedIbDevs = -1;
+#define NCCL_IB_MAX_DEVS_PER_NIC 4
+#define MAX_MERGED_DEV_NAME (MAXNAMESIZE*NCCL_IB_MAX_DEVS_PER_NIC)+NCCL_IB_MAX_DEVS_PER_NIC
+struct alignas(64) ncclIbMergedDev {
+  ncclNetVDeviceProps_t vProps;
+  int speed;
+  char devName[MAX_MERGED_DEV_NAME]; // Up to NCCL_IB_MAX_DEVS_PER_NIC * name size, and a character for each '+'
+};
+
+struct ncclIbStats {
+  int fatalErrorCount;
+};
+
+static int ncclNIbDevs = -1;
+struct alignas(64) ncclIbDev {
+  pthread_mutex_t lock;
+  int device;
+  uint64_t guid;
+  uint8_t portNum;
+  uint8_t link;
+  int speed;
+  ibv_context* context;
+  int pdRefs;
+  ibv_pd* pd;
+  char devName[MAXNAMESIZE];
+  char* pciPath;
+  char* virtualPciPath;
+  int realPort;
+  int maxQp;
+  float latency;
+  struct ncclIbMrCache mrCache;
+  int ar; // ADAPTIVE_ROUTING
+  struct ibv_port_attr portAttr;
+  struct ncclIbStats stats;
+  int dmaBufSupported;
+};
+
+#define MAX_IB_DEVS  32
+#define MAX_IB_VDEVS MAX_IB_DEVS*8
+struct ncclIbMergedDev ncclIbMergedDevs[MAX_IB_VDEVS];
+struct ncclIbDev ncclIbDevs[MAX_IB_DEVS];
+pthread_mutex_t ncclIbLock = PTHREAD_MUTEX_INITIALIZER;
+static int ncclIbRelaxedOrderingEnabled = 0;
+
+#define NCCL_IB_LLSTR(ll) (((ll) == IBV_LINK_LAYER_INFINIBAND) ? "IB" : (((ll) == IBV_LINK_LAYER_ETHERNET) ? "RoCE" : "UNSPECIFIED"))
+
+#define NCCL_IB_SL_DEFAULT 0
+#define NCCL_IB_TC_DEFAULT 0
+
+NCCL_PARAM(IbGidIndex, "IB_GID_INDEX", -1);
+NCCL_PARAM(IbRoutableFlidIbGidIndex, "IB_ROUTABLE_FLID_GID_INDEX", 1);
+NCCL_PARAM(IbRoceVersionNum, "IB_ROCE_VERSION_NUM", 2);
+NCCL_PARAM(IbTimeout, "IB_TIMEOUT", 20);
+NCCL_PARAM(IbRetryCnt, "IB_RETRY_CNT", 7);
+NCCL_PARAM(IbPkey, "IB_PKEY", 0);
+NCCL_PARAM(IbUseInline, "IB_USE_INLINE", 0);
+NCCL_PARAM(IbSl, "IB_SL", -1);
+NCCL_PARAM(IbTc, "IB_TC", -1);
+NCCL_PARAM(IbArThreshold, "IB_AR_THRESHOLD", 8192);
+NCCL_PARAM(IbPciRelaxedOrdering, "IB_PCI_RELAXED_ORDERING", 2);
+NCCL_PARAM(IbAdaptiveRouting, "IB_ADAPTIVE_ROUTING", -2);
+NCCL_PARAM(IbFifoTc, "IB_FIFO_TC", -1);
+NCCL_PARAM(IbAsyncEvents,"IB_RETURN_ASYNC_EVENTS",1);
+NCCL_PARAM(IbEceEnable,"IB_ECE_ENABLE",1);
+
+/* AB501 20251024  */
+struct allocationTracker allocTracker[MAX_ALLOC_TRACK_NGPU] = {};
+ncclResult_t rocmLibraryInit() {
+  //assert(0);
+  return ncclSuccess;
+}
+int ncclCuMemEnable() {
+  return 0;
+}
+/* AB501 20251024  */
+
+static ncclResult_t ncclIbStatsInit(struct ncclIbStats* stat) {
+  __atomic_store_n(&stat->fatalErrorCount, 0, __ATOMIC_RELAXED);
+  return ncclSuccess;
+}
+static void ncclIbStatsFatalError(struct ncclIbStats* stat){
+  __atomic_fetch_add(&stat->fatalErrorCount, 1, __ATOMIC_RELAXED);
+}
+static ncclResult_t ncclIbStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName) {
+  if (ncclParamIbAsyncEvents() && __atomic_load_n(&stat->fatalErrorCount, __ATOMIC_RELAXED)) {
+    WARN("communicator encountered a fatal error (detected in %s)\n", funcName);
+    return ncclSystemError;
+  }
+  return ncclSuccess;
+}
+static void ncclIbQpFatalError(struct ibv_qp* qp) {
+  ncclIbStatsFatalError((struct ncclIbStats*)qp->qp_context);
+}
+static void ncclIbCqFatalError(struct ibv_cq* cq) {
+  ncclIbStatsFatalError((struct ncclIbStats*)cq->cq_context);
+}
+static void ncclIbDevFatalError(struct ncclIbDev* dev) {
+  ncclIbStatsFatalError(&dev->stats);
+}
+
+pthread_t ncclIbAsyncThread;
+static void* ncclIbAsyncThreadMain(void* args) {
+  struct ncclIbDev* dev = (struct ncclIbDev*)args;
+  while (1) {
+    struct ibv_async_event event;
+    if (ncclSuccess != wrap_ibv_get_async_event(dev->context, &event)) { break; }
+    char *str;
+    struct ibv_cq* cq = event.element.cq;    // only valid if CQ error
+    struct ibv_qp* qp = event.element.qp;    // only valid if QP error
+    struct ibv_srq* srq = event.element.srq; // only valid if SRQ error
+    if (ncclSuccess != wrap_ibv_event_type_str(&str, event.event_type)) { break; }
+    switch (event.event_type) {
+    case IBV_EVENT_DEVICE_FATAL:
+      // the above is device fatal error
+      WARN("NET/IB : %s:%d async fatal event: %s", dev->devName, dev->portNum, str);
+      ncclIbDevFatalError(dev);
+      break;
+    case IBV_EVENT_CQ_ERR:
+      // the above is a CQ fatal error
+      WARN("NET/IB : %s:%d async fatal event on CQ (%p): %s", dev->devName, dev->portNum, cq, str);
+      ncclIbCqFatalError(cq);
+      break;
+    case IBV_EVENT_QP_FATAL:
+    case IBV_EVENT_QP_REQ_ERR:
+    case IBV_EVENT_QP_ACCESS_ERR:
+      // the above are QP fatal errors
+      WARN("NET/IB : %s:%d async fatal event on QP (%p): %s", dev->devName, dev->portNum, qp, str);
+      ncclIbQpFatalError(qp);
+      break;
+    case IBV_EVENT_SRQ_ERR:
+      // SRQ are not used in NCCL
+      WARN("NET/IB : %s:%d async fatal event on SRQ, unused for now (%p): %s", dev->devName, dev->portNum, srq, str);
+      break;
+    case IBV_EVENT_PATH_MIG_ERR:
+    case IBV_EVENT_PORT_ERR:
+    case IBV_EVENT_PATH_MIG:
+    case IBV_EVENT_PORT_ACTIVE:
+    case IBV_EVENT_SQ_DRAINED:
+    case IBV_EVENT_LID_CHANGE:
+    case IBV_EVENT_PKEY_CHANGE:
+    case IBV_EVENT_SM_CHANGE:
+    case IBV_EVENT_QP_LAST_WQE_REACHED:
+    case IBV_EVENT_CLIENT_REREGISTER:
+    case IBV_EVENT_SRQ_LIMIT_REACHED:
+      // the above are non-fatal
+      WARN("NET/IB : %s:%d Got async error event: %s", dev->devName, dev->portNum, str);
+      break;
+    case IBV_EVENT_COMM_EST:
+      break;
+    default:
+      WARN("NET/IB : %s:%d unknown event type (%d)", dev->devName, dev->portNum, event.event_type);
+      break;
+    }
+    // acknowledgment needs to happen last to avoid user-after-free
+    if (ncclSuccess != wrap_ibv_ack_async_event(&event)) { break; }
+  }
+  return NULL;
+}
+
+static sa_family_t envIbAddrFamily(void) {
+  sa_family_t family = AF_INET;
+  const char* env = ncclGetEnv("NCCL_IB_ADDR_FAMILY");
+  if (env == NULL || strlen(env) == 0) {
+    return family;
+  }
+
+  INFO(NCCL_ENV, "NCCL_IB_ADDR_FAMILY set by environment to %s", env);
+
+  if (strcmp(env, "AF_INET") == 0) {
+    family = AF_INET;
+  } else if (strcmp(env, "AF_INET6") == 0) {
+    family = AF_INET6;
+  }
+
+  return family;
+}
+
+static void* envIbAddrRange(sa_family_t af, int* mask) {
+  *mask = 0;
+  static struct in_addr addr;
+  static struct in6_addr addr6;
+  void *ret = (af == AF_INET) ? (void *)&addr : (void *)&addr6;
+
+  const char* env = ncclGetEnv("NCCL_IB_ADDR_RANGE");
+  if (NULL == env || strlen(env) == 0) {
+    return NULL;
+  }
+
+  INFO(NCCL_ENV, "NCCL_IB_ADDR_RANGE set by environment to %s", env);
+
+  char addrString[128] = { 0 };
+  snprintf(addrString, 128, "%s", env);
+  char *addrStrPtr = addrString;
+  char *maskStrPtr = strstr(addrString, "/");
+  if (NULL == maskStrPtr) {
+    return NULL;
+  }
+  *(maskStrPtr++) = '\0';
+
+  if (inet_pton(af, addrStrPtr, ret) == 0) {
+    INFO(NCCL_INIT|NCCL_NET, "NET/IB: Ip address '%s' is invalid for family %s, ignoring address", addrStrPtr, (af == AF_INET) ? "AF_INET" : "AF_INET6");
+    return NULL;
+  }
+
+  *mask = (int)strtol(maskStrPtr, NULL, 10);
+  if (af == AF_INET && *mask > 32) {
+    INFO(NCCL_INIT|NCCL_NET, "NET/IB: Ip address mask '%d' is invalid for family %s, ignoring mask", *mask, (af == AF_INET) ? "AF_INET" : "AF_INET6");
+    *mask = 0;
+    ret = NULL;
+  } else if (af == AF_INET6 && *mask > 128) {
+    INFO(NCCL_INIT|NCCL_NET, "NET/IB: Ip address mask '%d' is invalid for family %s, ignoring mask", *mask, (af == AF_INET) ? "AF_INET" : "AF_INET6");
+    *mask = 0;
+    ret = NULL;
+  }
+
+  return ret;
+}
+
+static sa_family_t getGidAddrFamily(union ibv_gid* gid) {
+  const struct in6_addr *a = (struct in6_addr *)gid->raw;
+  bool isIpV4Mapped = ((a->s6_addr32[0] | a->s6_addr32[1]) | (a->s6_addr32[2] ^ htonl(0x0000ffff))) == 0UL;
+  bool isIpV4MappedMulticast = (a->s6_addr32[0] == htonl(0xff0e0000) && ((a->s6_addr32[1] | (a->s6_addr32[2] ^ htonl(0x0000ffff))) == 0UL));
+  return (isIpV4Mapped || isIpV4MappedMulticast) ? AF_INET : AF_INET6;
+}
+
+static bool matchGidAddrPrefix(sa_family_t af, void* prefix, int prefixlen, union ibv_gid* gid) {
+  struct in_addr *base = NULL;
+  struct in6_addr *base6 = NULL;
+  struct in6_addr *addr6 = NULL;;
+  if (af == AF_INET) {
+    base = (struct in_addr *)prefix;
+  } else {
+    base6 = (struct in6_addr *)prefix;
+  }
+  addr6 = (struct in6_addr *)gid->raw;
+
+#define NETMASK(bits) (htonl(0xffffffff ^ ((1 << (32 - bits)) - 1)))
+
+  int i = 0;
+  while (prefixlen > 0 && i < 4) {
+    if (af == AF_INET) {
+      int mask = NETMASK(prefixlen);
+      if ((base->s_addr & mask) ^ (addr6->s6_addr32[3] & mask)) {
+        break;
+      }
+      prefixlen = 0;
+      break;
+    } else {
+      if (prefixlen >= 32) {
+        if (base6->s6_addr32[i] ^ addr6->s6_addr32[i]) {
+          break;
+        }
+        prefixlen -= 32;
+        ++i;
+      } else {
+        int mask = NETMASK(prefixlen);
+        if ((base6->s6_addr32[i] & mask) ^ (addr6->s6_addr32[i] & mask)) {
+          break;
+        }
+        prefixlen = 0;
+      }
+    }
+  }
+
+  return (prefixlen == 0) ? true : false;
+}
+
+static bool configuredGid(union ibv_gid* gid) {
+  const struct in6_addr *a = (struct in6_addr *)gid->raw;
+  int trailer = (a->s6_addr32[1] | a->s6_addr32[2] | a->s6_addr32[3]);
+  if (((a->s6_addr32[0] | trailer) == 0UL) || ((a->s6_addr32[0] == htonl(0xfe800000)) && (trailer == 0UL))) {
+    return false;
+  }
+  return true;
+}
+
+static bool linkLocalGid(union ibv_gid* gid) {
+  const struct in6_addr *a = (struct in6_addr *)gid->raw;
+  if (a->s6_addr32[0] == htonl(0xfe800000) && a->s6_addr32[1] == 0UL) {
+    return true;
+  }
+  return false;
+}
+
+static bool validGid(union ibv_gid* gid) {
+  return (configuredGid(gid) && !linkLocalGid(gid));
+}
+
+static ncclResult_t ncclIbRoceGetVersionNum(const char* deviceName, int portNum, int gidIndex, int* version) {
+  char gidRoceVerStr[16] = { 0 };
+  char roceTypePath[PATH_MAX] = { 0 };
+  snprintf(roceTypePath, sizeof(roceTypePath), "/sys/class/infiniband/%s/ports/%d/gid_attrs/types/%d", deviceName, portNum, gidIndex);
+
+  int fd = open(roceTypePath, O_RDONLY);
+  if (fd == -1) {
+    WARN("NET/IB: open failed in ncclIbRoceGetVersionNum: %s", strerror(errno));
+    return ncclSystemError;
+  }
+  int ret = read(fd, gidRoceVerStr, 15);
+  close(fd);
+
+  if (ret == -1) {
+    // In containerized environments, read could return EINVAL if the GID index is not mapped to the
+    // container sysfs. In this case return ncclSuccess and let the caller move to next GID index.
+    if (errno == EINVAL) return ncclSuccess;
+    WARN("NET/IB: read failed in ncclIbRoceGetVersionNum: %s", strerror(errno));
+    return ncclSystemError;
+  }
+
+  if (strlen(gidRoceVerStr)) {
+    if (strncmp(gidRoceVerStr, "IB/RoCE v1", strlen("IB/RoCE v1")) == 0 || strncmp(gidRoceVerStr, "RoCE v1", strlen("RoCE v1")) == 0) {
+      *version = 1;
+    } else if (strncmp(gidRoceVerStr, "RoCE v2", strlen("RoCE v2")) == 0) {
+      *version = 2;
+    }
+  }
+
+  return ncclSuccess;
+}
+
+static ncclResult_t ncclUpdateGidIndex(struct ibv_context* context, uint8_t portNum, sa_family_t af, void* prefix, int prefixlen, int roceVer, int gidIndexCandidate, int* gidIndex) {
+  union ibv_gid gid, gidCandidate;
+  NCCLCHECK(wrap_ibv_query_gid(context, portNum, *gidIndex, &gid));
+  NCCLCHECK(wrap_ibv_query_gid(context, portNum, gidIndexCandidate, &gidCandidate));
+
+  sa_family_t usrFam = af;
+  sa_family_t gidFam = getGidAddrFamily(&gid);
+  sa_family_t gidCandidateFam = getGidAddrFamily(&gidCandidate);
+  bool gidCandidateMatchSubnet = matchGidAddrPrefix(usrFam, prefix, prefixlen, &gidCandidate);
+
+  if (gidCandidateFam != gidFam && gidCandidateFam == usrFam && gidCandidateMatchSubnet) {
+    *gidIndex = gidIndexCandidate;
+  } else {
+    if (gidCandidateFam != usrFam || !validGid(&gidCandidate) || !gidCandidateMatchSubnet) {
+      return ncclSuccess;
+    }
+    int usrRoceVer = roceVer;
+    int gidRoceVerNum, gidRoceVerNumCandidate = -1;
+    const char* deviceName = wrap_ibv_get_device_name(context->device);
+    NCCLCHECK(ncclIbRoceGetVersionNum(deviceName, portNum, *gidIndex, &gidRoceVerNum));
+    NCCLCHECK(ncclIbRoceGetVersionNum(deviceName, portNum, gidIndexCandidate, &gidRoceVerNumCandidate));
+    if ((gidRoceVerNum != gidRoceVerNumCandidate || !validGid(&gid)) && gidRoceVerNumCandidate == usrRoceVer) {
+      *gidIndex = gidIndexCandidate;
+    }
+  }
+
+  return ncclSuccess;
+}
+
+// GID Format
+// global:  |              64b  - subnet-prefix                |                 64b - EUI                          |
+// raw   :  | 10b fixed | 22b 0 | 16b FLID | 16b subnet-prefix |                 64b - EUI                          |
+static uint16_t ncclIbExtractLocalSubnetPrefix(uint64_t subnet_prefix)
+{
+  return (be64toh(subnet_prefix) & 0xffff);
+}
+
+static int ncclIbExtractFlid (union ibv_gid *gid)
+{
+  return ntohs(*((uint16_t*)((uintptr_t)(gid->raw) + 4)));
+}
+
+static ncclResult_t ncclIbGetGidIndex(struct ibv_context *context, uint8_t portNum, struct ibv_port_attr* portAttr, int *gidIndex) {
+  int gidTblLen = portAttr->gid_tbl_len;
+
+  //for IB, choose GID Index that will have routable FLID if present
+  if (portAttr->link_layer == IBV_LINK_LAYER_INFINIBAND) {
+    union ibv_gid gid;
+    int routableGidIndex = ncclParamIbRoutableFlidIbGidIndex();
+    if (routableGidIndex < gidTblLen) {
+      NCCLCHECK(wrap_ibv_query_gid(context, portNum, routableGidIndex, &gid));
+      if (ncclIbExtractFlid(&gid) != 0) {
+        *gidIndex = routableGidIndex;
+        return ncclSuccess;
+      }
+    }
+    *gidIndex = 0;
+    return ncclSuccess;
+  }
+
+  //for ROCE
+  *gidIndex = ncclParamIbGidIndex();
+  if (*gidIndex >= 0) {
+    return ncclSuccess;
+  }
+
+  sa_family_t userAddrFamily = envIbAddrFamily();
+  int userRoceVersion = ncclParamIbRoceVersionNum();
+  int prefixlen;
+  void *prefix = envIbAddrRange(userAddrFamily, &prefixlen);
+
+  *gidIndex = 0;
+  for (int gidIndexNext = 1; gidIndexNext < gidTblLen; ++gidIndexNext) {
+    NCCLCHECK(ncclUpdateGidIndex(context, portNum, userAddrFamily, prefix, prefixlen, userRoceVersion, gidIndexNext, gidIndex));
+  }
+
+  return ncclSuccess;
+}
+
+NCCL_PARAM(IbDisable, "IB_DISABLE", 0);
+NCCL_PARAM(IbMergeVfs, "IB_MERGE_VFS", 1);
+NCCL_PARAM(IbMergeNics, "IB_MERGE_NICS", 1);
+
+// Returns 0 if this is the path of two VFs of the same physical device
+static int ncclIbMatchVfPath(char* path1, char* path2) {
+  // Merge multi-port NICs into the same PCI device
+  if (ncclParamIbMergeVfs()) {
+    return strncmp(path1, path2, strlen(path1)-4) == 0;
+  } else {
+    return strncmp(path1, path2, strlen(path1)-1) == 0;
+  }
+}
+
+static ncclResult_t ncclIbGetPciPath(char* devName, char** path, int* realPort) {
+  char devicePath[PATH_MAX];
+  snprintf(devicePath, PATH_MAX, "/sys/class/infiniband/%s/device", devName);
+  char* p = realpath(devicePath, NULL);
+  if (p == NULL) {
+    WARN("Could not find real path of %s (%s)", devName, devicePath);
+  } else {
+    // Keep the real port aside (the ibv port is always 1 on recent cards)
+    *realPort = 0;
+    for (int d=0; d<ncclNIbDevs; d++) {
+      if (ncclIbMatchVfPath(p, ncclIbDevs[d].pciPath)) (*realPort)++;
+    }
+  }
+  *path = p;
+  return ncclSuccess;
+}
+
+static int ibvWidths[] = { 1, 4, 8, 12, 2 };
+static int ibvSpeeds[] = {
+  2500,  /* SDR */
+  5000,  /* DDR */
+  10000, /* QDR */
+  10000, /* QDR */
+  14000, /* FDR */
+  25000, /* EDR */
+  50000, /* HDR */
+  100000 /* NDR */ };
+
+static int firstBitSet(int val, int max) {
+  int i = 0;
+  while (i<max && ((val & (1<<i)) == 0)) i++;
+  return i;
+}
+static int ncclIbWidth(int width) {
+  return ibvWidths[firstBitSet(width, sizeof(ibvWidths)/sizeof(int)-1)];
+}
+static int ncclIbSpeed(int speed) {
+  return ibvSpeeds[firstBitSet(speed, sizeof(ibvSpeeds)/sizeof(int)-1)];
+}
+
+// Determine whether RELAXED_ORDERING is enabled and possible
+static int ncclIbRelaxedOrderingCapable(void) {
+  int roMode = ncclParamIbPciRelaxedOrdering();
+  ncclResult_t r = ncclInternalError;
+  if (roMode == 1 || roMode == 2) {
+    // Query IBVERBS_1.8 API - needed for IBV_ACCESS_RELAXED_ORDERING support
+    r = wrap_ibv_reg_mr_iova2(NULL, NULL, NULL, 0, 0, 0);
+  }
+  return r == ncclInternalError ? 0 : 1;
+}
+
+ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
+  if (ncclParamIbMergeNics() == 0 && props->ndevs > 1) {
+    WARN("NET/IB : Trying to merge multiple devices together when NCCL_IB_MERGE_NICS=0. Please enable it or disable device merging in NCCL.");
+    return ncclInvalidUsage;
+  }
+
+  if (props->ndevs == 0) {
+      WARN("NET/IB : Can't make virtual NIC with 0 devices");
+      return ncclInvalidUsage;
+  }
+
+  if (ncclNMergedIbDevs == MAX_IB_VDEVS) {
+    WARN("NET/IB : Cannot allocate any more virtual devices (%d)", MAX_IB_VDEVS);
+    return ncclInvalidUsage;
+  }
+
+  // Always count up number of merged devices
+  ncclIbMergedDev* mDev = ncclIbMergedDevs + ncclNMergedIbDevs;
+  mDev->vProps.ndevs = 0;
+  mDev->speed = 0;
+
+  for (int i = 0; i < props->ndevs; i++) {
+    ncclIbDev* dev = ncclIbDevs + props->devs[i];
+    if (mDev->vProps.ndevs == NCCL_IB_MAX_DEVS_PER_NIC) return ncclInvalidUsage;
+    mDev->vProps.devs[mDev->vProps.ndevs++] = props->devs[i];
+    mDev->speed += dev->speed;
+    // Each successive time, copy the name '+' new name
+    if (mDev->vProps.ndevs > 1) {
+      snprintf(mDev->devName + strlen(mDev->devName), sizeof(mDev->devName) - strlen(mDev->devName), "+%s", dev->devName);
+    // First time, copy the plain name
+    } else {
+      strncpy(mDev->devName, dev->devName, MAXNAMESIZE);
+    }
+  }
+
+  // Check link layers
+  ncclIbDev* dev0 = ncclIbDevs + props->devs[0];
+  for (int i = 1; i < props->ndevs; i++) {
+    if (props->devs[i] >= ncclNIbDevs) {
+      WARN("NET/IB : Cannot use physical device %d, max %d", props->devs[i], ncclNIbDevs);
+      return ncclInvalidUsage;
+    }
+    ncclIbDev* dev = ncclIbDevs + props->devs[i];
+    if (dev->link != dev0->link) {
+      WARN("NET/IB : Attempted to merge incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
+        props->devs[0], dev0->devName, dev0->portNum, NCCL_IB_LLSTR(dev0->link), props->devs[i], dev->devName, dev->portNum, NCCL_IB_LLSTR(dev->link));
+      return ncclInvalidUsage;
+    }
+  }
+
+  *d = ncclNMergedIbDevs++;
+  INFO(NCCL_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d", *d, mDev->devName, mDev->speed, mDev->vProps.ndevs);
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbMakeVDevice(int* d, ncclNetVDeviceProps_t* props) {
+  pthread_mutex_lock(&ncclIbLock);
+  ncclResult_t res = ncclIbMakeVDeviceInternal(d, props);
+  pthread_mutex_unlock(&ncclIbLock);
+  return res;
+}
+
+static ncclProfilerCallback_t ncclProfilerFunction;
+
+#define NCCL_IB_MAX_QPS 128
+
+#define NSEC_PER_USEC           1000ULL
+#define NSEC_PER_MSEC           (NSEC_PER_USEC * 1000)
+#define NSEC_PER_SEC            (NSEC_PER_MSEC * 1000)
+#define NSEC_PER_MIN            (NSEC_PER_SEC * 60)
+
+#define QP_SCHED_RESET_MIN      NSEC_PER_MSEC
+#define QP_SCHED_RESET_NEVER    0
+
+#define QP_SCHED_UPDATE_MIN     NSEC_PER_USEC
+#define QP_SCHED_UPDATE_MAX     NSEC_PER_MIN
+
+#define QP_SCHED_WEIGHT_NONE    0
+#define QP_SCHED_WEIGHT_MIN     QP_SCHED_WEIGHT_NONE
+#define QP_SCHED_WEIGHT_MAX     1.0
+
+#define QP_SCHED_DISABLE        0
+#define QP_SCHED_ENABLE         1
+
+#define QP_SCHED_ENABLE_DEF             QP_SCHED_DISABLE
+#define QP_SCHED_WRR_ENABLE_DEF         QP_SCHED_DISABLE
+#define QP_SCHED_RESET_DEF              (NSEC_PER_SEC * 60)
+#define QP_SCHED_UPDATE_DEF             (NSEC_PER_USEC * 50)
+#define QP_SCHED_WEIGHT_DEF             QP_SCHED_WEIGHT_NONE
+#define QP_SCHED_SPLIT_DATA_MIN_DEF     (64 * 1024)
+#define QP_SCHED_LOG_DEF                NSEC_PER_SEC
+
+#define QP_SCHED_ENABLE_ENV_VAR         "NCCL_IB_QP_SCHED_ENABLE"
+#define QP_SCHED_WRR_ENABLE_ENV_VAR     "NCCL_IB_QP_SCHED_WRR_ENABLE"
+#define QP_SCHED_RESET_ENV_VAR          "NCCL_IB_QP_SCHED_RESET_INTERVAL"
+#define QP_SCHED_UPDATE_ENV_VAR         "NCCL_IB_QP_SCHED_UPDATE_INTERVAL"
+#define QP_SCHED_WEIGHT_ENV_VAR         "NCCL_IB_QP_SCHED_WEIGHT"
+#define QP_SCHED_SPLIT_DATA_MIN_ENV_VAR "NCCL_IB_QP_SCHED_SPLIT_DATA_MIN"
+#define QP_SCHED_LOG_PATH_ENV_VAR       "NCCL_IB_QP_SCHED_LOG_PATH"
+#define QP_SCHED_LOG_ENV_VAR            "NCCL_IB_QP_SCHED_LOG_INTERVAL"
+
+#define QP_SCHED_LOG_FILE_NAME_PREFIX  "cast_log_"
+#define NCCL_NET_IB_REMAP_UNUSED 0
+#define NCCL_NET_IB_REMAP_USED   1
+
+#define BITS_PER_BYTE 8
+#define MEG           1000000
+
+#define TIMESPEC_TO_NSEC(TS_PTR)                   \
+  (((uint64_t) (TS_PTR)->tv_sec) * NSEC_PER_SEC) + \
+   ((uint64_t) (TS_PTR)->tv_nsec)
+
+struct ncclIbQpSchedParms globalQpSchedParms;
+
+// Data about QP transmission
+struct ncclIbQpTxData {
+  uint64_t startTimeNs;
+  uint64_t bytes;
+};
+
+// For remapping work request ID so that additional info is avail at
+// completion time of sends
+struct ncclIbRemapWrId {
+  int state; // in use or unused
+  uint64_t origWrId;
+  int qpIndex;
+  struct ncclIbQpTxData tx;
+  struct ncclIbQpSchedParms parms;
+};
+
+// Stats for scheduling QP transmissions
+struct ncclIbQpTxStats {
+  uint64_t minRttSample;
+  uint64_t totRtt;
+  uint64_t numMeasurements;
+  double rtt;
+};
+
+// Scratchpad for computing scheduler weights
+struct ncclIbQpTxSchedScratchpad {
+  double rtt[NCCL_IB_MAX_QPS];
+};
+
+// Scheduler for QP transmissions
+struct ncclIbQpTxSched {
+  double weight;    // fraction of sub-chunk to be transmitted on QP
+  double minWeight; // min value of weight used 
+  double maxWeight; // max value of weight used 
+};
+
+#define NCCL_IB_TARGET_TOT_TOKENS 100
+
+// Tokens for weighted round-robin QP scheduler
+struct ncclIbRrTokens {
+  int totTokens;
+  int qpTokens[NCCL_IB_MAX_QPS];
+};
+
+// Scheduler for weighted round-robin QP transmissions
+struct ncclIbRrQpTxSched {
+  struct ncclIbRrTokens initTokens;
+  struct ncclIbRrTokens activeTokens;
+  int qpIndex;
+};
+
+// QP scheduling descriptor
+struct ncclIbQpSchedDesc {
+  bool wrrSched;
+  int nqps;
+  int startQpIndex;
+  struct ncclIbQpSchedParms parms;
+};
+
+// Control block for staged dynamic scheduling parameters
+struct stagedSchedParmsCB {
+  ncclFunc_t collType;
+  size_t msgSz;
+  uint64_t prodEpoch;
+  struct ncclIbQpSchedParms parms;
+};
+
+pthread_mutex_t schedParmsLock = PTHREAD_MUTEX_INITIALIZER;
+struct stagedSchedParmsCB stagedSchedParms { ncclNumFuncs };
+ncclFunc_t proxyPrevCollType = ncclNumFuncs;
+size_t proxyPrevMsgSz;
+
+NCCL_PARAM(IbSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
+
+FILE *logStream;
+
+ncclResult_t initQpSchedParms(struct ncclIbQpSchedParms *parms) {
+  char *str, *logFileName = NULL;
+  int val;
+  double weight;
+  uint64_t nsec;
+  ncclResult_t ret = ncclSuccess;
+
+  parms->enable = QP_SCHED_ENABLE_DEF;
+  parms->wrrEnable = QP_SCHED_WRR_ENABLE_DEF;
+  parms->resetInterval = QP_SCHED_RESET_DEF;
+  parms->updateInterval = QP_SCHED_UPDATE_DEF;
+  parms->weightNew = QP_SCHED_WEIGHT_DEF;
+  parms->splitData = ncclParamIbSplitDataOnQps();
+  parms->splitDataMin = QP_SCHED_SPLIT_DATA_MIN_DEF;
+  parms->logInterval = QP_SCHED_LOG_DEF;
+  parms->logEnable = false;
+  if (!parms->enable)
+    parms->doWrr = false;
+  else if (!parms->splitData)
+    parms->doWrr = true;
+  else if (parms->wrrEnable)
+    parms->doWrr = true;
+  else
+    parms->doWrr = false;
+
+  str = getenv(QP_SCHED_ENABLE_ENV_VAR);
+  if (str == NULL)
+    goto exit;
+  val = atoi(str);
+  if (val == QP_SCHED_ENABLE) {
+    parms->enable = true;
+    INFO(NCCL_NET|NCCL_ENV, "(in librccl-net plugin) NCCL_IB_QP_SCHED_ENABLE set to enabled");
+  } else {
+    parms->enable = false;
+    INFO(NCCL_NET|NCCL_ENV, "(in librccl-net plugin) NCCL_IB_QP_SCHED_ENABLE set to disabled");
+    goto exit;
+  }
+  if (parms->splitData) {
+    str = getenv(QP_SCHED_WRR_ENABLE_ENV_VAR);
+    if (str) {
+      val = atoi(str);
+      if (val == QP_SCHED_ENABLE) {
+        parms->doWrr = true;
+        INFO(NCCL_NET|NCCL_ENV, "(in librccl-net plugin) NCCL_IB_QP_SCHED_WRR_ENABLE set to enabled");
+      }
+    }
+  } else
+    parms->doWrr = true;
+
+  str = getenv(QP_SCHED_RESET_ENV_VAR);
+  if (str) {
+    val = atoi(str);
+    if (val >= 0) {
+      nsec = (val * NSEC_PER_MSEC);
+      if (nsec > 0) {
+        if (nsec < QP_SCHED_RESET_MIN)
+          goto getUpdateParm;
+      }
+      parms->resetInterval = nsec;
+      INFO(NCCL_NET|NCCL_ENV, "(in librccl-net plugin) NCCL_IB_QP_SCHED_RESET_INTERVAL set to %lu nsec", nsec);
+    }
+  }
+
+getUpdateParm:
+  str = getenv(QP_SCHED_UPDATE_ENV_VAR);
+  if (str) {
+    val = atoi(str);
+    if (val >= 0) {
+      nsec = (val * NSEC_PER_USEC);
+      if ((val >= QP_SCHED_UPDATE_MIN) && (val <= QP_SCHED_UPDATE_MAX)) {
+        parms->updateInterval = nsec;
+        INFO(NCCL_NET|NCCL_ENV, "(in librccl-net plugin) NCCL_IB_QP_SCHED_UPDATE_INTERVAL set to %lu nsec", nsec);
+      }
+    }
+  }
+
+  str = getenv(QP_SCHED_WEIGHT_ENV_VAR);
+  if (str) {
+    weight = atof(str);
+    if (weight != QP_SCHED_WEIGHT_NONE) {
+      if (val <= QP_SCHED_WEIGHT_MAX) {
+        parms->weightNew = weight;
+        INFO(NCCL_NET|NCCL_ENV, "(in librccl-net plugin) NCCL_IB_QP_SCHED_WEIGHT set to %f", weight);
+      }
+    }
+  }
+
+  str = getenv(QP_SCHED_SPLIT_DATA_MIN_ENV_VAR);
+  if (str) {
+    val = atoi(str);
+    if (val > 0) {
+        parms->splitDataMin = val;
+        INFO(NCCL_NET|NCCL_ENV, "(in librccl-net plugin) NCCL_IB_QP_SCHED_SPLIT_DATA_MIN set to %d bytes", val);
+    }
+  }
+
+  str = getenv(QP_SCHED_LOG_PATH_ENV_VAR);
+  if (str != NULL) {
+    char hostName[64], pid[32];
+    size_t fileNameLen;
+
+    gethostname(hostName, 64);
+    sprintf(pid, "%d", getpid());
+    fileNameLen = strlen(str) + 1 + strlen(QP_SCHED_LOG_FILE_NAME_PREFIX) +
+            strlen(hostName) + 1 + strlen(pid);
+    logFileName = (char *) calloc(1, fileNameLen + 1);
+    if (logFileName == NULL) {
+      WARN("(in librccl-net plugin) NCCL_IB_QP_SCHED_LOG_PATH: calloc failed");
+      goto err_exit;
+    }
+    strcpy(logFileName, str);
+    strcat(logFileName, "/");
+    strcat(logFileName, QP_SCHED_LOG_FILE_NAME_PREFIX);
+    strcat(logFileName, hostName);
+    strcat(logFileName, "_");
+    strcat(logFileName, pid);
+    logStream = fopen(logFileName, "w");
+    if (logStream == NULL) {
+      WARN("(in librccl-net plugin) NCCL_IB_QP_SCHED_LOG_PATH: fopen failed: %s", strerror(errno));
+      goto err_exit;
+    }
+    INFO(NCCL_NET|NCCL_ENV, "(in librccl-net plugin) NCCL_IB_QP_SCHED_LOG_PATH: opened %s", logFileName);
+    parms->logEnable = true;
+
+    str = getenv(QP_SCHED_LOG_ENV_VAR);
+    if (str) {
+      val = atoi(str);
+      if (val >= 0) {
+        nsec = (val * NSEC_PER_USEC);
+        if ((val >= QP_SCHED_UPDATE_MIN) && (val <= QP_SCHED_UPDATE_MAX)) {
+          parms->logInterval = nsec;
+          INFO(NCCL_NET|NCCL_ENV, "(in librccl-net plugin) NCCL_IB_QP_SCHED_LOG_INTERVAL set to %lu nsec", nsec);
+        }
+      }
+    }
+  }
+
+exit:
+  free(logFileName);
+  return ret;
+
+err_exit:
+  ret = ncclInternalError;
+  goto exit;
+}
+
+extern "C" {
+void ncclTunerPluginNotify(struct tunerSchedParms *tunerParms) {
+  bool collTypeChanged = false, msgSzChanged = false;
+
+  pthread_mutex_lock(&schedParmsLock);
+
+  if (tunerParms->collType != stagedSchedParms.collType)
+    collTypeChanged = true;
+  if (tunerParms->msgSz != stagedSchedParms.msgSz)
+    msgSzChanged = true;
+
+  struct ncclIbQpSchedParms newParms = globalQpSchedParms;
+
+  if ((!collTypeChanged) && (!msgSzChanged))
+    goto exit;
+
+  if (!tunerParms->match)
+    goto setNewParms;
+
+  if ((collTypeChanged && tunerParms->collResetRtt) ||
+      (msgSzChanged && tunerParms->msgSzResetRtt))
+    newParms.resetRtt = true;
+
+  if (tunerParms->splitDataValid)
+    newParms.splitData = tunerParms->parms.splitData;
+  if (tunerParms->enableValid)
+    newParms.enable = tunerParms->parms.enable;
+  if (newParms.enable) {
+    if (!newParms.splitData)
+      newParms.doWrr = true;
+    else if (tunerParms->wrrEnableValid)
+        newParms.doWrr = tunerParms->parms.wrrEnable;
+  } else {
+    newParms.doWrr = false;
+    goto setNewParms;
+  }
+
+  if (tunerParms->updateIntervalValid)
+    newParms.updateInterval = tunerParms->parms.updateInterval;
+  if (tunerParms->resetIntervalValid)
+    newParms.resetInterval = tunerParms->parms.resetInterval;
+  if (tunerParms->weightNewValid)
+    newParms.weightNew = tunerParms->parms.weightNew;
+  if (tunerParms->splitDataMinValid)
+    newParms.splitDataMin = tunerParms->parms.splitDataMin;
+
+setNewParms:
+  stagedSchedParms.collType = tunerParms->collType;
+  stagedSchedParms.msgSz = tunerParms->msgSz;
+  stagedSchedParms.parms = newParms;
+  stagedSchedParms.prodEpoch++;
+
+exit:
+  pthread_mutex_unlock(&schedParmsLock);
+}
+}
+
+ncclResult_t ncclIbInit(ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction) {
+  ncclResult_t ret = ncclSuccess;
+  ncclProfilerFunction = profFunction;
+  INFO(NCCL_INIT, "Broadcom NET_IB CAST Plugin for rocm-7.0.2 rccl-2.26");
+  if (ncclParamIbDisable()) return ncclInternalError;
+  static int shownIbHcaEnv = 0;
+  if(wrap_ibv_symbols() != ncclSuccess) { return ncclInternalError; }
+
+  // Detect IB cards
+  int nIbDevs = 0;
+  struct ibv_device** devices = NULL;
+
+  if (ncclNIbDevs == -1) {
+    pthread_mutex_lock(&ncclIbLock);
+    wrap_ibv_fork_init();
+    if (ncclNIbDevs == -1) {
+      ncclNIbDevs = 0;
+      ncclNMergedIbDevs = 0;
+      if (ncclFindInterfaces(ncclIbIfName, &ncclIbIfAddr, MAX_IF_NAME_SIZE, 1) != 1) {
+        WARN("NET/IB : No IP interface found.");
+        ret = ncclInternalError;
+        goto fail;
+      }   
+
+      // Check if user defined which IB device:port to use
+      const char* userIbEnv = ncclGetEnv("NCCL_IB_HCA");
+      if (userIbEnv != NULL && shownIbHcaEnv++ == 0) INFO(NCCL_NET|NCCL_ENV, "NCCL_IB_HCA set to %s", userIbEnv);
+      struct netIf userIfs[MAX_IB_DEVS];
+      bool searchNot = userIbEnv && userIbEnv[0] == '^';
+      if (searchNot) userIbEnv++;
+      bool searchExact = userIbEnv && userIbEnv[0] == '=';
+      if (searchExact) userIbEnv++;
+      int nUserIfs = parseStringList(userIbEnv, userIfs, MAX_IB_DEVS);
+
+      if (ncclSuccess != wrap_ibv_get_device_list(&devices, &nIbDevs)) { ret = ncclInternalError; goto fail; }
+
+      for (int d=0; d<nIbDevs && ncclNIbDevs<MAX_IB_DEVS; d++) {
+        struct ibv_context * context;
+        if (ncclSuccess != wrap_ibv_open_device(&context, devices[d]) || context == NULL) {
+          WARN("NET/IB : Unable to open device %s", devices[d]->name);
+          continue;
+        }
+        int nPorts = 0;
+        struct ibv_device_attr devAttr;
+        memset(&devAttr, 0, sizeof(devAttr));
+        if (ncclSuccess != wrap_ibv_query_device(context, &devAttr)) {
+          WARN("NET/IB : Unable to query device %s", devices[d]->name);
+          if (ncclSuccess != wrap_ibv_close_device(context))
+          {
+            ret = ncclInternalError;
+            goto fail;
+          }
+          continue;
+        }
+        for (int port_num = 1; port_num <= devAttr.phys_port_cnt; port_num++) {
+          struct ibv_port_attr portAttr;
+          if (ncclSuccess != wrap_ibv_query_port(context, port_num, &portAttr)) {
+            WARN("NET/IB : Unable to query port_num %d", port_num);
+            continue;
+          }
+          if (portAttr.state != IBV_PORT_ACTIVE) continue;
+          if (portAttr.link_layer != IBV_LINK_LAYER_INFINIBAND
+              && portAttr.link_layer != IBV_LINK_LAYER_ETHERNET) continue;
+
+          // check against user specified HCAs/ports
+          if (! (matchIfList(devices[d]->name, port_num, userIfs, nUserIfs, searchExact) ^ searchNot)) {
+            continue;
+          }
+          pthread_mutex_init(&ncclIbDevs[ncclNIbDevs].lock, NULL);
+          ncclIbDevs[ncclNIbDevs].device = d;
+          ncclIbDevs[ncclNIbDevs].guid = devAttr.sys_image_guid;
+          ncclIbDevs[ncclNIbDevs].portAttr = portAttr;
+          ncclIbDevs[ncclNIbDevs].portNum = port_num;
+          ncclIbDevs[ncclNIbDevs].link = portAttr.link_layer;
+          ncclIbDevs[ncclNIbDevs].speed = ncclIbSpeed(portAttr.active_speed) * ncclIbWidth(portAttr.active_width);
+          ncclIbDevs[ncclNIbDevs].context = context;
+          ncclIbDevs[ncclNIbDevs].pdRefs = 0;
+          ncclIbDevs[ncclNIbDevs].pd = NULL;
+          strncpy(ncclIbDevs[ncclNIbDevs].devName, devices[d]->name, MAXNAMESIZE);
+          NCCLCHECKGOTO(ncclIbGetPciPath(ncclIbDevs[ncclNIbDevs].devName, &ncclIbDevs[ncclNIbDevs].pciPath, &ncclIbDevs[ncclNIbDevs].realPort), ret, fail);
+          ncclIbDevs[ncclNIbDevs].maxQp = devAttr.max_qp;
+          ncclIbDevs[ncclNIbDevs].mrCache.capacity = 0;
+          ncclIbDevs[ncclNIbDevs].mrCache.population = 0;
+          ncclIbDevs[ncclNIbDevs].mrCache.slots = NULL;
+          NCCLCHECK(ncclIbStatsInit(&ncclIbDevs[ncclNIbDevs].stats));
+
+          // Enable ADAPTIVE_ROUTING by default on IB networks
+          // But allow it to be overloaded by an env parameter
+          ncclIbDevs[ncclNIbDevs].ar = (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) ? 1 : 0;
+          if (ncclParamIbAdaptiveRouting() != -2) ncclIbDevs[ncclNIbDevs].ar = ncclParamIbAdaptiveRouting();
+
+          TRACE(NCCL_NET,"NET/IB: [%d] %s:%s:%d/%s speed=%d context=%p pciPath=%s ar=%d", d, devices[d]->name, devices[d]->dev_name, ncclIbDevs[ncclNIbDevs].portNum,
+              NCCL_IB_LLSTR(portAttr.link_layer), ncclIbDevs[ncclNIbDevs].speed, context, ncclIbDevs[ncclNIbDevs].pciPath, ncclIbDevs[ncclNIbDevs].ar);
+
+          PTHREADCHECKGOTO(pthread_create(&ncclIbAsyncThread, NULL, ncclIbAsyncThreadMain, ncclIbDevs + ncclNIbDevs), "pthread_create", ret, fail);
+          ncclSetThreadName(ncclIbAsyncThread, "NCCL IbAsync %2d", ncclNIbDevs);
+          PTHREADCHECKGOTO(pthread_detach(ncclIbAsyncThread), "pthread_detach", ret, fail); // will not be pthread_join()'d
+
+          // Add this plain physical device to the list of virtual devices
+          int vDev;
+          ncclNetVDeviceProps_t vProps = {0};
+          vProps.ndevs = 1;
+          vProps.devs[0] = ncclNIbDevs;
+          NCCLCHECK(ncclIbMakeVDeviceInternal(&vDev, &vProps));
+
+          ncclNIbDevs++;
+          nPorts++;
+        }
+        if (nPorts == 0 && ncclSuccess != wrap_ibv_close_device(context)) { ret = ncclInternalError; goto fail; }
+      }
+      if (ncclSuccess != wrap_ibv_free_device_list(devices)) { ret = ncclInternalError; goto fail;}
+    }
+    if (ncclNIbDevs == 0) {
+      INFO(NCCL_INIT|NCCL_NET, "NET/IB : No device found.");
+    }
+
+    // Print out all net devices to the user (in the same format as before)
+    char line[2048];
+    line[0] = '\0';
+    // Determine whether RELAXED_ORDERING is enabled and possible
+    ncclIbRelaxedOrderingEnabled = ncclIbRelaxedOrderingCapable();
+    for (int d = 0; d < ncclNIbDevs; d++) {
+        snprintf(line+strlen(line), sizeof(line)-strlen(line), " [%d]%s:%d/%s", d, ncclIbDevs[d].devName,
+          ncclIbDevs[d].portNum, NCCL_IB_LLSTR(ncclIbDevs[d].link));
+    }
+    char addrline[SOCKET_NAME_MAXLEN+1];
+    INFO(NCCL_INIT|NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, ncclIbRelaxedOrderingEnabled ? "[RO]" : "",
+          ncclIbIfName, ncclSocketToString(&ncclIbIfAddr, addrline));
+
+    pthread_mutex_unlock(&ncclIbLock);
+  }
+exit:
+  if (ret == ncclSuccess)
+    ret = initQpSchedParms(&globalQpSchedParms);
+  return ret;
+fail:
+  if(ncclSuccess != wrap_ibv_free_device_list(devices)){WARN("NET/IB : Unable to free device list");}
+  pthread_mutex_unlock(&ncclIbLock);
+  goto exit;
+}
+
+ncclResult_t ncclIbDevices(int* ndev) {
+  *ndev = ncclNMergedIbDevs;
+  return ncclSuccess;
+}
+
+// Introduce RCCL_FORCE_ENABLE_GDRDMA to force load GPU-NIC RDMA module
+// Use ONLY for debugging!
+RCCL_PARAM(ForceEnableGdrdma, "FORCE_ENABLE_GDRDMA", -1);
+
+// Detect whether GDR can work on a given NIC with the current CUDA device
+// Returns :
+// ncclSuccess : GDR works
+// ncclSystemError : no module or module loaded but not supported by GPU
+#define KNL_MODULE_LOADED(a) ((access(a, F_OK) == -1) ? 0 : 1)
+static int ncclIbGdrModuleLoaded = 0; // 1 = true, 0 = false
+static void ibGdrSupportInitOnce() {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  if (rcclParamForceEnableGdrdma() == 1) {
+    // RCCL_FORCE_ENABLE_GDRDMA=1 enables GPU-NIC RDMA only from RCCL-side
+    // Requires support from NIC driver modules
+    // Use ONLY for debugging!
+    ncclIbGdrModuleLoaded = 1;
+    INFO(NCCL_INIT, "RCCL_FORCE_ENABLE_GDRDMA = 1, so explicitly setting ncclIbGdrModuleLoaded = 1");
+  }
+
+  if (ncclIbGdrModuleLoaded == 0) {
+    // Check for `memory_peers` directory containing `amdkfd/version`
+    // This `memory_peers` directory is created by NIC-GPU driver interaction
+    // On Linux kernel 5.15.0 (e.g. Ubuntu 22.04), `memory_peers` is created under `/sys/kernel/mm/`
+    // However, on newer kernels like Ubuntu 24.04.1 (Linux kernel 6.8.0) or Ubuntu 22.04.4 HWE (Linux kernel 6.5.0),
+    // this `memory_peers` directory is either not created (go to else-if condition)
+    // or created under a different path like `/sys/kernel/` or `/sys/` (depending on your ib_peer_mem module)
+    const char* memory_peers_paths[] = {"/sys/kernel/mm/memory_peers/amdkfd/version",
+                                  "/sys/kernel/memory_peers/amdkfd/version",
+                                  "/sys/memory_peers/amdkfd/version",
+                                  NULL};
+    int i = 0;
+
+    while (memory_peers_paths[i]) {
+      if (access(memory_peers_paths[i], F_OK) == 0) {
+        ncclIbGdrModuleLoaded = 1;
+        INFO(NCCL_INIT,"Found %s", memory_peers_paths[i]);
+        break;
+      } else {
+        ncclIbGdrModuleLoaded = 0;
+      }
+      ++i;
+    }
+
+    char strValue[MAX_STR_LEN];
+    ncclTopoGetStrFromSys("/sys/devices/virtual/dmi/id", "bios_version", strValue);
+    if (strncmp("Hyper-V UEFI Release", strValue, 20) == 0) {
+      int roMode = ncclParamIbPciRelaxedOrdering();
+      ncclTopoGetStrFromSys("/proc/sys/kernel", "numa_balancing", strValue);
+      if (strcmp(strValue, "1") == 0 && roMode == 0)
+        ncclIbGdrModuleLoaded = 0;
+    }
+
+    if (ncclIbGdrModuleLoaded == 0) {
+      // Check for `ib_register_peer_memory_client` symbol in `/proc/kallsyms`
+      // if your system uses native OS ib_peer module
+      char buf[256];
+      FILE *fp = NULL;
+      fp = fopen("/proc/kallsyms", "r");
+
+      if (fp == NULL) {
+        INFO(NCCL_INIT,"Could not open /proc/kallsyms");
+      } else {
+        while (fgets(buf, sizeof(buf), fp) != NULL) {
+          if (strstr(buf, "t ib_register_peer_memory_client") != NULL ||
+              strstr(buf, "T ib_register_peer_memory_client") != NULL) {
+            ncclIbGdrModuleLoaded = 1;
+            INFO(NCCL_INIT,"Found ib_register_peer_memory_client in /proc/kallsyms");
+            break;
+          }
+        }
+      }
+    }
+  }
+#else
+  // Check for the nv_peer_mem module being loaded
+  ncclIbGdrModuleLoaded = KNL_MODULE_LOADED("/sys/kernel/mm/memory_peers/nv_mem/version") ||
+                          KNL_MODULE_LOADED("/sys/kernel/mm/memory_peers/nv_mem_nc/version") ||
+                          KNL_MODULE_LOADED("/sys/module/nvidia_peermem/version");
+#endif
+}
+
+ncclResult_t ncclIbGdrSupport() {
+  static pthread_once_t once = PTHREAD_ONCE_INIT;
+  pthread_once(&once, ibGdrSupportInitOnce);
+  if (!ncclIbGdrModuleLoaded)
+    return ncclSystemError;
+  return ncclSuccess;
+}
+
+static __thread int ibDmaSupportInitDev; // which device to init, must be thread local
+static void ibDmaBufSupportInitOnce(){
+  ncclResult_t res;
+  int dev_fail = 0;
+
+  // This is a physical device, not a virtual one, so select from ibDevs
+  ncclIbMergedDev* mergedDev = ncclIbMergedDevs + ibDmaSupportInitDev;
+  ncclIbDev* ibDev = ncclIbDevs + mergedDev->vProps.devs[0];
+  struct ibv_pd* pd;
+  struct ibv_context* ctx = ibDev->context;
+  res = rocmLibraryInit();
+  if (res != ncclSuccess) goto failure;
+  NCCLCHECKGOTO(wrap_ibv_alloc_pd(&pd, ctx), res, failure);
+  // Test kernel DMA-BUF support with a dummy call (fd=-1)
+  (void)wrap_direct_ibv_reg_dmabuf_mr(pd, 0ULL /*offset*/, 0ULL /*len*/, 0ULL /*iova*/, -1 /*fd*/, 0 /*flags*/);
+  // ibv_reg_dmabuf_mr() will fail with EOPNOTSUPP/EPROTONOSUPPORT if not supported (EBADF otherwise)
+  dev_fail |= (errno == EOPNOTSUPP) || (errno == EPROTONOSUPPORT);
+  NCCLCHECKGOTO(wrap_ibv_dealloc_pd(pd), res, failure);
+  // stop the search and goto failure
+  if (dev_fail) goto failure;
+  ibDev->dmaBufSupported = 1;
+  return;
+failure:
+  ibDev->dmaBufSupported = -1;
+  return;
+}
+// Detect whether DMA-BUF support is present in the kernel
+// Returns :
+// ncclSuccess : DMA-BUF support is available
+// ncclSystemError : DMA-BUF is not supported by the kernel
+ncclResult_t ncclIbDmaBufSupport(int dev) {
+  struct oncewrap {
+    pthread_once_t once = PTHREAD_ONCE_INIT;
+  };
+  static oncewrap onces[MAX_IB_DEVS];
+  // init the device only once
+  ibDmaSupportInitDev = dev;
+  pthread_once(&onces[dev].once, ibDmaBufSupportInitOnce);
+  ncclIbMergedDev* mergedDev = ncclIbMergedDevs + ibDmaSupportInitDev;
+  ncclIbDev* ibDev = ncclIbDevs + mergedDev->vProps.devs[0];
+  int dmaBufSupported = ibDev->dmaBufSupported;
+  if (dmaBufSupported == 1) return ncclSuccess;
+  return ncclSystemError;
+}
+
+#define NCCL_NET_IB_MAX_RECVS 8
+
+ncclResult_t ncclIbGetPhysProperties(int dev, ncclNetProperties_t* props) {
+  struct ncclIbDev* ibDev = ncclIbDevs + dev;
+  pthread_mutex_lock(&ibDev->lock);
+  props->name = ibDev->devName;
+  props->speed = ibDev->speed;
+  props->pciPath = ibDev->pciPath;
+  props->guid = ibDev->guid;
+  props->ptrSupport = NCCL_PTR_HOST;
+  if (ncclIbGdrSupport() == ncclSuccess) {
+    props->ptrSupport |= NCCL_PTR_CUDA; // GDR support via nv_peermem
+  }
+  props->regIsGlobal = 1;
+  if (ncclIbDmaBufSupport(dev) == ncclSuccess) {
+    props->ptrSupport |= NCCL_PTR_DMABUF; // GDR support via DMA-BUF
+  }
+  props->forceFlush = 0;
+  props->latency = 0; // Not set
+  props->port = ibDev->portNum + ibDev->realPort;
+  props->maxComms = ibDev->maxQp;
+  props->maxRecvs = NCCL_NET_IB_MAX_RECVS;
+  props->netDeviceType    = NCCL_NET_DEVICE_HOST;
+  props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
+  props->maxP2pBytes = NCCL_MAX_NET_SIZE_BYTES;
+  pthread_mutex_unlock(&ibDev->lock);
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbGetProperties(int dev, ncclNetProperties_t* props) {
+  if (dev >= ncclNMergedIbDevs) {
+    WARN("NET/IB : Requested properties for vNic %d, only %d vNics have been created", dev, ncclNMergedIbDevs);
+    return ncclInvalidUsage;
+  }
+  struct ncclIbMergedDev* mergedDev = ncclIbMergedDevs + dev;
+  // Take the rest of the properties from an arbitrary sub-device (should be the same)
+  NCCLCHECK(ncclIbGetPhysProperties(mergedDev->vProps.devs[0], props));
+  props->name = mergedDev->devName;
+  props->speed = mergedDev->speed;
+  memcpy(&props->vProps, &mergedDev->vProps, sizeof(ncclNetVDeviceProps_t));
+  return ncclSuccess;
+}
+
+// We need to support NCCL_NET_MAX_REQUESTS for each concurrent receive
+#define MAX_REQUESTS (NCCL_NET_MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS)
+static_assert(MAX_REQUESTS <= 256, "request id are encoded in wr_id and we need up to 8 requests ids per completion");
+
+// Per-QP connection metatdata
+struct ncclIbQpInfo {
+  uint32_t qpn;
+
+  // Fields needed for ece (enhanced connection establishment)
+  struct ibv_ece ece;
+  int ece_supported;
+  int devIndex;
+};
+
+// Per-Dev connection metadata
+struct ncclIbDevInfo {
+  uint32_t lid;
+  uint8_t ib_port;
+  enum ibv_mtu mtu;
+  uint8_t link_layer;
+
+  // For RoCE and IB Rounter
+  union ibv_gid gid;
+
+  // FIFO RDMA info
+  uint32_t fifoRkey;
+
+  //remote dev info
+  union ibv_gid remoteGid;
+
+  int ibv_dev_index;
+};
+
+// Struct containing everything needed to establish connections
+struct ncclIbConnectionMetadata {
+  struct ncclIbQpInfo qpInfo[NCCL_IB_MAX_QPS];
+  struct ncclIbDevInfo devs[NCCL_IB_MAX_DEVS_PER_NIC];
+  char devName[MAX_MERGED_DEV_NAME];
+  uint64_t fifoAddr;
+  int ndevs;
+  int tc;
+  int sl;
+};
+
+enum ncclIbCommState {
+  ncclIbCommStateStart = 0,
+  ncclIbCommStateConnect = 1,
+  ncclIbCommStateAccept = 3,
+  ncclIbCommStateSend = 4,
+  ncclIbCommStateRecv = 5,
+  ncclIbCommStateConnecting = 6,
+  ncclIbCommStateConnected = 7,
+  ncclIbCommStatePendingReady = 8,
+  ncclIbCommStateSendDevList = 9,
+  ncclIbCommStateRecvDevList = 10,
+};
+
+struct ncclIbCommStage {
+  enum ncclIbCommState state;
+  int offset;
+  void* buffer;
+  void* comm;
+};
+
+struct ncclIbHandle {
+  union ncclSocketAddress connectAddr; // Filled by the target
+  uint64_t magic; // random number to help debugging
+  struct ncclIbCommStage stage; // Used by the other side when connecting
+};
+
+// Retain local RoCE address for error logging
+struct ncclIbGidInfo {
+  uint8_t link_layer;
+  union ibv_gid localGid;
+  int32_t localGidIndex;
+};
+
+#define NCCL_NET_IB_REQ_UNUSED 0
+#define NCCL_NET_IB_REQ_SEND 1
+#define NCCL_NET_IB_REQ_RECV 2
+#define NCCL_NET_IB_REQ_FLUSH 3
+const char* reqTypeStr[] = { "Unused", "Send", "Recv", "Flush" };
+
+#define MAX_QPS_PER_REQ 8
+struct ncclProfilerInfo {
+  void* qpEventHandles[MAX_QPS_PER_REQ];
+  int qpIndex[MAX_QPS_PER_REQ];
+  int nEventHandles;
+  ncclProfilerNetIbDescr_v1_t data;
+};
+
+struct ncclIbRequest {
+  struct ncclIbNetCommBase* base;
+  int type;
+  struct ncclSocket* sock;
+  int events[NCCL_IB_MAX_DEVS_PER_NIC];
+  int ctsEvents[NCCL_IB_MAX_DEVS_PER_NIC];
+  struct ncclIbNetCommDevBase* devBases[NCCL_IB_MAX_DEVS_PER_NIC];
+#ifdef NCCL_ENABLE_NET_PROFILING
+  struct ncclProfilerInfo pInfo[NCCL_NET_IB_MAX_RECVS];
+#endif
+  int nreqs;
+  struct ncclIbQpSchedDesc desc;
+  union {
+    struct {
+      int size;
+      void* data;
+      uint32_t lkeys[NCCL_IB_MAX_DEVS_PER_NIC];
+      int offset;
+    } send;
+    struct {
+      int* sizes;
+    } recv;
+  };
+};
+
+struct ncclIbNetCommDevBase {
+  int ibDevN;
+  struct ibv_pd* pd;
+  struct ibv_cq* cq;
+  uint64_t pad[2];
+  struct ncclIbGidInfo gidInfo;
+};
+
+struct ncclIbListenComm {
+  int dev;
+  struct ncclSocket sock;
+  struct ncclIbCommStage stage;
+};
+
+struct alignas(64) ncclIbSendFifo {
+  uint64_t addr;
+  uint64_t size;
+  uint32_t rkeys[NCCL_IB_MAX_DEVS_PER_NIC];
+  uint16_t nreqs;
+  uint16_t rxReqIndex;
+  uint32_t tag;
+  uint64_t idx;
+  char padding[16];
+};
+
+struct ncclIbQp {
+  struct ibv_qp* qp;
+  int devIndex;
+  int remDevIdx;
+};
+
+struct ncclIbRemSizesFifo {
+  int elems[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
+  uint64_t fifoTail;
+  uint64_t addr;
+  uint32_t rkeys[NCCL_IB_MAX_DEVS_PER_NIC];
+  uint32_t flags;
+  struct ibv_mr* mrs[NCCL_IB_MAX_DEVS_PER_NIC];
+  struct ibv_sge sge;
+};
+
+// A per-dev struct for netIbSendComm
+struct alignas(8) ncclIbSendCommDev {
+  struct ncclIbNetCommDevBase base;
+  struct ibv_mr* fifoMr;
+};
+
+
+// Wrapper to track an MR per-device, if needed
+struct ncclIbMrHandle {
+  ibv_mr* mrs[NCCL_IB_MAX_DEVS_PER_NIC];
+};
+
+struct alignas(32) ncclIbNetCommBase {
+  ncclNetVDeviceProps_t vProps;
+  bool isSend;
+  struct ncclIbRequest reqs[MAX_REQUESTS];
+  struct ncclIbQp qps[NCCL_IB_MAX_QPS];
+  struct ncclIbRemapWrId remapWrId[MAX_REQUESTS];
+  struct ncclIbQpTxStats qpTxStats[NCCL_IB_MAX_QPS];
+  uint64_t nextQpTxStatsResetNs;
+  struct ncclIbQpTxSched qpTxSched[NCCL_IB_MAX_QPS];
+  struct ncclIbRrQpTxSched rrQpTxSched;
+  bool qpTxSchedInit;
+  uint64_t nextQpTxSchedUpdateNs;
+  uint64_t nextSchedLogNs;
+  int remapHead;
+  uint64_t stagedParmsConEpoch;
+  bool schedParmsInit;
+  struct ncclIbQpSchedParms schedParms;
+  bool resetRttDone;
+  int nqps;
+  int qpIndex;
+  int devIndex;
+  struct ncclSocket sock;
+  int ready;
+  int rxPosts[NCCL_IB_MAX_QPS * NCCL_NET_IB_MAX_RECVS];
+  // Track necessary remDevInfo here
+  int nRemDevs;
+  int nDataQps;
+  struct ncclIbDevInfo remDevs[NCCL_IB_MAX_DEVS_PER_NIC];
+  // statistics about the comm
+  struct ncclIbStats stats;
+};
+
+struct ncclIbSendComm {
+  struct ncclIbNetCommBase base;
+  // Start with fifo and ibv structs as they have alignment restrictions
+  struct ncclIbSendFifo fifo[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
+  struct ibv_sge sges[NCCL_NET_IB_MAX_RECVS];
+  struct ibv_send_wr wrs[NCCL_NET_IB_MAX_RECVS + 1];
+  // Each dev correlates to a mergedIbDev
+  struct ncclIbSendCommDev devs[NCCL_IB_MAX_DEVS_PER_NIC];
+  struct ncclIbRequest* fifoReqs[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
+  struct ncclIbRemSizesFifo remSizesFifo;
+  uint64_t fifoHead;
+  int ar; // Use adaptive routing when all merged devices have it enabled
+};
+// The SendFifo needs to be 32-byte aligned and each element needs
+// to be a 32-byte multiple, so that an entry does not get split and
+// written out of order when IB Relaxed Ordering is enabled
+static_assert((sizeof(struct ncclIbNetCommBase) % 32) == 0, "ncclIbNetCommBase size must be 32-byte multiple to ensure fifo is at proper offset");
+static_assert((offsetof(struct ncclIbSendComm, fifo) % 32) == 0, "ncclIbSendComm fifo must be 32-byte aligned");
+static_assert((sizeof(struct ncclIbSendFifo) % 32) == 0, "ncclIbSendFifo element size must be 32-byte multiples");
+static_assert((offsetof(struct ncclIbSendComm, sges) % 32) == 0, "sges must be 32-byte aligned");
+static_assert((offsetof(struct ncclIbSendComm, wrs) % 32) == 0, "wrs must be 32-byte aligned");
+
+struct ncclIbGpuFlush {
+  struct ibv_mr* hostMr;
+  struct ibv_mr* gpuMr;
+  int* gpuFlushGpuMem;
+  struct ibv_sge sge;
+  struct ncclIbQp qp;
+  int dmabuf_fd;
+};
+
+struct ncclIbRemFifo {
+  struct ncclIbSendFifo elems[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
+  uint64_t fifoTail;
+  uint64_t addr;
+  uint32_t flags;
+};
+
+struct alignas(16) ncclIbRecvCommDev {
+  struct ncclIbNetCommDevBase base;
+  struct ncclIbGpuFlush gpuFlush;
+  struct ibv_mr* fifoMr;
+  struct ibv_sge fifoSge;
+  struct ibv_mr* sizesFifoMr;
+};
+
+struct ncclIbRecvComm {
+  struct ncclIbNetCommBase base;
+  struct ncclIbRecvCommDev devs[NCCL_IB_MAX_DEVS_PER_NIC];
+  struct ncclIbRemFifo remFifo;
+  int sizesFifo[MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
+  int gpuFlushHostMem;
+  int flushEnabled;
+};
+static_assert((offsetof(struct ncclIbRecvComm, remFifo) % 32) == 0, "ncclIbRecvComm fifo must be 32-byte aligned");
+
+NCCL_PARAM(IbQpsPerConn, "IB_QPS_PER_CONNECTION", 1);
+
+static void ncclIbAddEvent(struct ncclIbRequest* req, int devIndex,
+                           struct ncclIbNetCommDevBase* base, bool ctsEvent) {
+  req->events[devIndex]++;
+  if (ctsEvent)
+    req->ctsEvents[devIndex]++;
+  req->devBases[devIndex] = base;
+}
+
+ncclResult_t ncclIbInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base, void* cq_context) {
+  base->ibDevN = ibDevN;
+  ncclIbDev* ibDev = ncclIbDevs + ibDevN;
+  pthread_mutex_lock(&ibDev->lock);
+  if (0 == ibDev->pdRefs++) {
+    ncclResult_t res;
+    NCCLCHECKGOTO(wrap_ibv_alloc_pd(&ibDev->pd, ibDev->context), res, failure);
+    if (0) {
+    failure:
+      pthread_mutex_unlock(&ibDev->lock);
+      return res;
+    }
+  }
+  base->pd = ibDev->pd;
+  pthread_mutex_unlock(&ibDev->lock);
+
+  // CQ is sized to accommodate the max SQ + RQ WQE completions. If each SQ WQE could be signaled, then,
+  // for each QP, there can be 2*MAX_REQUESTS completions for SQ and MAX_REQUESTS completions for RQ. 
+  NCCLCHECK(wrap_ibv_create_cq(&base->cq, ibDev->context, 3*MAX_REQUESTS*ncclParamIbQpsPerConn(), cq_context, NULL, 0));
+
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbDestroyBase(struct ncclIbNetCommDevBase* base) {
+  ncclResult_t res;
+  NCCLCHECK(wrap_ibv_destroy_cq(base->cq));
+
+  pthread_mutex_lock(&ncclIbDevs[base->ibDevN].lock);
+  if (0 == --ncclIbDevs[base->ibDevN].pdRefs) {
+    NCCLCHECKGOTO(wrap_ibv_dealloc_pd(ncclIbDevs[base->ibDevN].pd), res, returning);
+  }
+  res = ncclSuccess;
+returning:
+  pthread_mutex_unlock(&ncclIbDevs[base->ibDevN].lock);
+  return res;
+}
+
+ncclResult_t ncclIbCreateQp(uint8_t ib_port, struct ncclIbNetCommDevBase* base, int access_flags, void* qp_context, struct ncclIbQp* qp) {
+  struct ibv_qp_init_attr qpInitAttr;
+  memset(&qpInitAttr, 0, sizeof(struct ibv_qp_init_attr));
+  qpInitAttr.qp_context = qp_context;
+  qpInitAttr.send_cq = base->cq;
+  qpInitAttr.recv_cq = base->cq;
+  qpInitAttr.qp_type = IBV_QPT_RC;
+  // We might send 2 messages per send (RDMA and RDMA_WITH_IMM)
+  qpInitAttr.cap.max_send_wr = 2*MAX_REQUESTS;
+  qpInitAttr.cap.max_recv_wr = MAX_REQUESTS;
+  qpInitAttr.cap.max_send_sge = 1;
+  qpInitAttr.cap.max_recv_sge = 1;
+  qpInitAttr.cap.max_inline_data = ncclParamIbUseInline() ? sizeof(struct ncclIbSendFifo) : 0;
+  NCCLCHECK(wrap_ibv_create_qp(&qp->qp, base->pd, &qpInitAttr));
+  struct ibv_qp_attr qpAttr;
+  memset(&qpAttr, 0, sizeof(struct ibv_qp_attr));
+  qpAttr.qp_state = IBV_QPS_INIT;
+  qpAttr.pkey_index = ncclParamIbPkey();
+  qpAttr.port_num = ib_port;
+  qpAttr.qp_access_flags = access_flags;
+  NCCLCHECK(wrap_ibv_modify_qp(qp->qp, &qpAttr, IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS));
+  TRACE(NCCL_NET, "NET/IB : ncclIbCreateQp port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qpn=%u pkey=%u pd=%p",
+    ib_port, base->ibDevN, ncclIbDevs[base->ibDevN].devName, ncclNIbDevs, ncclNMergedIbDevs, qp->qp->qp_num, qpAttr.pkey_index, base->pd);
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbRtrQp(struct ibv_qp* qp, struct ncclIbGidInfo* sGidInfo, uint32_t dest_qp_num, struct ncclIbDevInfo* info, bool fifoTc, int tc, int sl) {
+  struct ibv_qp_attr qpAttr;
+  memset(&qpAttr, 0, sizeof(struct ibv_qp_attr));
+  qpAttr.qp_state = IBV_QPS_RTR;
+  qpAttr.path_mtu = info->mtu;
+  qpAttr.dest_qp_num = dest_qp_num;
+  qpAttr.rq_psn = 0;
+  qpAttr.max_dest_rd_atomic = 1;
+  qpAttr.min_rnr_timer = 12;
+  if (info->link_layer == IBV_LINK_LAYER_ETHERNET) {
+    qpAttr.ah_attr.is_global = 1;
+    qpAttr.ah_attr.grh.dgid.global.subnet_prefix = info->gid.global.subnet_prefix;
+    qpAttr.ah_attr.grh.dgid.global.interface_id = info->gid.global.interface_id;
+    qpAttr.ah_attr.grh.flow_label = 0;
+    qpAttr.ah_attr.grh.sgid_index = sGidInfo->localGidIndex;
+    qpAttr.ah_attr.grh.hop_limit = 255;
+    qpAttr.ah_attr.grh.traffic_class = fifoTc && ncclParamIbFifoTc() != -1 ? ncclParamIbFifoTc() : tc;
+  } else {
+    //pick lid if subnet prefixs are same, FLID if they are not
+    if (ncclIbExtractLocalSubnetPrefix(sGidInfo->localGid.global.subnet_prefix) ==
+        ncclIbExtractLocalSubnetPrefix(info->gid.global.subnet_prefix)) {
+        qpAttr.ah_attr.is_global = 0;
+        qpAttr.ah_attr.dlid = info->lid;
+    } else {
+  uint16_t flid = ncclIbExtractFlid(&info->gid);
+        if (flid == 0) {
+          WARN("Warning: remote FLID configured as zero even when endpoints are on different subnets, using dlid as fallback");
+          qpAttr.ah_attr.dlid = info->lid;
+  } else {
+          qpAttr.ah_attr.dlid = ncclIbExtractFlid(&info->gid);
+  }
+        qpAttr.ah_attr.is_global = 1;
+        qpAttr.ah_attr.grh.dgid.global.subnet_prefix = info->gid.global.subnet_prefix;
+        qpAttr.ah_attr.grh.dgid.global.interface_id = info->gid.global.interface_id;
+        qpAttr.ah_attr.grh.sgid_index = sGidInfo->localGidIndex;
+  qpAttr.ah_attr.grh.hop_limit = 255;
+    }
+  }
+  qpAttr.ah_attr.sl = sl;
+  qpAttr.ah_attr.src_path_bits = 0;
+  qpAttr.ah_attr.port_num = info->ib_port;
+  TRACE(NCCL_NET, "NET/IB : ncclIbRtrQp qpn=%u mtu=%d dst=%u ll=%u port=%u sl: %d tc: %d", qp->qp_num, info->mtu, dest_qp_num, info->link_layer, info->ib_port, qpAttr.ah_attr.sl, qpAttr.ah_attr.grh.traffic_class);
+  NCCLCHECK(wrap_ibv_modify_qp(qp, &qpAttr, IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN | IBV_QP_RQ_PSN | IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER));
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbRtsQp(struct ibv_qp* qp) {
+  struct ibv_qp_attr qpAttr;
+  memset(&qpAttr, 0, sizeof(struct ibv_qp_attr));
+  qpAttr.qp_state = IBV_QPS_RTS;
+  qpAttr.timeout = ncclParamIbTimeout();
+  qpAttr.retry_cnt = ncclParamIbRetryCnt();
+  qpAttr.rnr_retry = 7;
+  qpAttr.sq_psn = 0;
+  qpAttr.max_rd_atomic = 1;
+  NCCLCHECK(wrap_ibv_modify_qp(qp, &qpAttr, IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN | IBV_QP_MAX_QP_RD_ATOMIC));
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbListen(int dev, void* opaqueHandle, void** listenComm) {
+  ncclResult_t ret = ncclSuccess;
+  struct ncclIbListenComm* comm;
+  NCCLCHECK(ncclCalloc(&comm, 1));
+  struct ncclIbHandle* handle = (struct ncclIbHandle*) opaqueHandle;
+  static_assert(sizeof(struct ncclIbHandle) < NCCL_NET_HANDLE_MAXSIZE, "ncclIbHandle size too large");
+  memset(handle, 0, sizeof(struct ncclIbHandle));
+  comm->dev = dev;
+  handle->magic = NCCL_SOCKET_MAGIC;
+  NCCLCHECKGOTO(ncclSocketInit(&comm->sock, &ncclIbIfAddr, handle->magic, ncclSocketTypeNetIb, NULL, 1), ret, fail);
+  NCCLCHECKGOTO(ncclSocketListen(&comm->sock), ret, fail);
+  NCCLCHECKGOTO(ncclSocketGetAddr(&comm->sock, &handle->connectAddr), ret, fail);
+  *listenComm = comm;
+exit:
+  return ret;
+fail:
+  (void)ncclSocketClose(&comm->sock);
+  free(comm);
+  goto exit;
+}
+
+ncclResult_t ncclIbConnect(int dev, ncclNetCommConfig_t* config, void* opaqueHandle, void** sendComm, ncclNetDeviceHandle_t** /*sendDevComm*/) {
+  ncclResult_t ret = ncclSuccess;
+  struct ncclIbHandle* handle = (struct ncclIbHandle*) opaqueHandle;
+  struct ncclIbCommStage* stage = &handle->stage;
+  struct ncclIbSendComm* comm = (struct ncclIbSendComm*)stage->comm;
+  int ready;
+  uint8_t link_layer = IBV_LINK_LAYER_UNSPECIFIED;
+  *sendComm = NULL;
+
+  if (stage->state == ncclIbCommStateConnect)      goto ib_connect_check;
+  if (stage->state == ncclIbCommStateSendDevList)  goto ib_send_dev_list;
+  if (stage->state == ncclIbCommStateRecvDevList)  goto ib_recv_dev_list;
+  if (stage->state == ncclIbCommStateSend)         goto ib_send;
+  if (stage->state == ncclIbCommStateConnecting)   goto ib_connect;
+  if (stage->state == ncclIbCommStateConnected)    goto ib_send_ready;
+  if (stage->state != ncclIbCommStateStart) {
+    WARN("Error: trying to connect already connected sendComm");
+    return ncclInternalError;
+  }
+  stage->buffer = NULL;
+
+  NCCLCHECK(ncclIbMalloc((void**)&comm, sizeof(struct ncclIbSendComm)));
+  NCCLCHECKGOTO(ncclIbStatsInit(&comm->base.stats), ret, fail);
+  NCCLCHECKGOTO(ncclSocketInit(&comm->base.sock, &handle->connectAddr, handle->magic, ncclSocketTypeNetIb, NULL, 1), ret, fail);
+  stage->comm = comm;
+  stage->state = ncclIbCommStateConnect;
+  NCCLCHECKGOTO(ncclSocketConnect(&comm->base.sock), ret, fail);
+
+ib_connect_check:
+  /* since ncclSocketConnect is async, we must check if connection is complete */
+  NCCLCHECKGOTO(ncclSocketReady(&comm->base.sock, &ready), ret, fail);
+  if (!ready) return ncclSuccess;
+
+  // IB Setup
+  struct ncclIbMergedDev* mergedDev;
+  if (dev >= ncclNMergedIbDevs) {
+    WARN("NET/IB : Trying to use non-existent virtual device %d", dev);
+    return ncclInternalError;
+  }
+
+  mergedDev = ncclIbMergedDevs + dev;
+  comm->base.vProps = mergedDev->vProps;
+  comm->base.isSend = true;
+  stage->state = ncclIbCommStateSendDevList;
+  stage->offset = 0;
+  struct ncclIbConnectionMetadata meta;
+  NCCLCHECKGOTO(ncclIbMalloc((void**)&stage->buffer, sizeof(meta)), ret, fail);
+  memcpy(stage->buffer, &mergedDev->vProps, sizeof(ncclNetVDeviceProps_t));
+
+// In the case of mismatched nDevs, we will make sure that both sides of a logical connection have the same number of RC qps
+ib_send_dev_list:
+  NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_SEND, &comm->base.sock, stage->buffer, sizeof(ncclNetVDeviceProps_t), &stage->offset));
+  if (stage->offset != sizeof(ncclNetVDeviceProps_t)) return ncclSuccess;
+
+  stage->state = ncclIbCommStateRecvDevList;
+  stage->offset = 0;
+
+ib_recv_dev_list:
+  NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_RECV, &comm->base.sock, stage->buffer, sizeof(ncclNetVDeviceProps_t), &stage->offset));
+  if (stage->offset != sizeof(ncclNetVDeviceProps_t)) return ncclSuccess;
+  stage->offset = 0;
+  ncclNetVDeviceProps_t remoteVProps;
+  memcpy(&remoteVProps, stage->buffer, sizeof(ncclNetVDeviceProps_t));
+  mergedDev = ncclIbMergedDevs + dev;
+  comm->base.vProps = mergedDev->vProps;
+  int localNqps, remoteNqps;
+  localNqps  = ncclParamIbQpsPerConn() * comm->base.vProps.ndevs; // We must have at least 1 qp per-device
+  remoteNqps = ncclParamIbQpsPerConn() * remoteVProps.ndevs;
+  comm->base.nqps = remoteNqps > localNqps ? remoteNqps : localNqps; // Select max nqps (local or remote)
+
+  // Init PD, Ctx for each IB device
+  comm->ar = 1; // Set to 1 for logic
+  for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+    int ibDevN = comm->base.vProps.devs[i];
+    NCCLCHECKGOTO(ncclIbInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats), ret, fail);
+    comm->ar = comm->ar && ncclIbDevs[ibDevN].ar; // ADAPTIVE_ROUTING - if all merged devs have it enabled
+  }
+
+  memset(&meta, 0, sizeof(meta));
+  meta.ndevs = comm->base.vProps.ndevs;
+
+  // Alternate QPs between devices
+  int devIndex;
+  devIndex = 0;
+  for (int q = 0; q < comm->base.nqps; q++) {
+    ncclIbSendCommDev* commDev = comm->devs + devIndex;
+    ncclIbDev* ibDev = ncclIbDevs + commDev->base.ibDevN;
+    NCCLCHECKGOTO(ncclIbCreateQp(ibDev->portNum, &commDev->base, IBV_ACCESS_REMOTE_WRITE, &comm->base.stats, comm->base.qps + q), ret, fail);
+    comm->base.qps[q].devIndex = devIndex;
+    meta.qpInfo[q].qpn      = comm->base.qps[q].qp->qp_num;
+    meta.qpInfo[q].devIndex = comm->base.qps[q].devIndex;
+
+    if (ncclParamIbEceEnable()) {
+      // Query ece capabilities (enhanced connection establishment)
+      NCCLCHECKGOTO(wrap_ibv_query_ece(comm->base.qps[q].qp, &meta.qpInfo[q].ece, &meta.qpInfo[q].ece_supported), ret, fail);
+    } else {
+      meta.qpInfo[q].ece_supported = 0;
+    }
+    devIndex = (devIndex + 1) % comm->base.vProps.ndevs;
+  }
+
+  for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+    ncclIbSendCommDev* commDev = comm->devs + i;
+    ncclIbDev* ibDev = ncclIbDevs + commDev->base.ibDevN;
+
+    // Write to the metadata struct via this pointer
+    ncclIbDevInfo* devInfo = meta.devs + i;
+    devInfo->ib_port       = ibDev->portNum;
+    devInfo->mtu           = ibDev->portAttr.active_mtu;
+    devInfo->lid           = ibDev->portAttr.lid;
+    devInfo->ibv_dev_index = commDev->base.ibDevN;
+    // Prepare my fifo
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->fifoMr, commDev->base.pd, comm->fifo, sizeof(struct ncclIbSendFifo)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
+    devInfo->fifoRkey = commDev->fifoMr->rkey;
+
+    // Pack local GID info
+    devInfo->link_layer = commDev->base.gidInfo.link_layer = ibDev->portAttr.link_layer;
+    NCCLCHECKGOTO(ncclIbGetGidIndex(ibDev->context, ibDev->portNum, &ibDev->portAttr, &commDev->base.gidInfo.localGidIndex), ret, fail);
+    NCCLCHECKGOTO(wrap_ibv_query_gid(ibDev->context, ibDev->portNum, commDev->base.gidInfo.localGidIndex, &commDev->base.gidInfo.localGid), ret, fail);
+    devInfo->gid.global.subnet_prefix = commDev->base.gidInfo.localGid.global.subnet_prefix;
+    devInfo->gid.global.interface_id = commDev->base.gidInfo.localGid.global.interface_id;
+
+    // info logging
+    if (devInfo->link_layer == IBV_LINK_LAYER_INFINIBAND) { // IB
+      for (int q = 0; q < comm->base.nqps; q++) {
+        // Print just the QPs for this dev
+        if (comm->base.qps[q].devIndex == i)
+          INFO(NCCL_NET,"NET/IB: %s %d IbDev %d Port %d qpn %d mtu %d LID %d subnet-prefix %lu  FLID %d fifoRkey=0x%x fifoLkey=0x%x",
+            comm->base.vProps.ndevs > 2 ? "NCCL MergedDev" : "NCCL Dev",
+            dev, commDev->base.ibDevN, ibDev->portNum, meta.qpInfo[q].qpn, devInfo->mtu, devInfo->lid,
+      devInfo->gid.global.subnet_prefix, ncclIbExtractFlid(&devInfo->gid), devInfo->fifoRkey, commDev->fifoMr->lkey);
+      }
+    } else { // RoCE
+      for (int q = 0; q < comm->base.nqps; q++) {
+        // Print just the QPs for this dev
+        if (comm->base.qps[q].devIndex == i)
+          INFO(NCCL_NET,"NET/IB: %s %d IbDev %d Port %d qpn %d mtu %d query_ece={supported=%d, vendor_id=0x%x, options=0x%x, comp_mask=0x%x} GID %ld (%lX/%lX) fifoRkey=0x%x fifoLkey=0x%x",
+            comm->base.vProps.ndevs > 2 ? "NCCL MergedDev" : "NCCL Dev", dev,
+            commDev->base.ibDevN, ibDev->portNum, meta.qpInfo[q].qpn, devInfo->mtu, meta.qpInfo[q].ece_supported, meta.qpInfo[q].ece.vendor_id, meta.qpInfo[q].ece.options, meta.qpInfo[q].ece.comp_mask, (int64_t)commDev->base.gidInfo.localGidIndex,
+            devInfo->gid.global.subnet_prefix, devInfo->gid.global.interface_id, devInfo->fifoRkey, commDev->fifoMr->lkey);
+      }
+    }
+    if (link_layer == IBV_LINK_LAYER_UNSPECIFIED) link_layer = devInfo->link_layer;
+    if (link_layer != devInfo->link_layer) {
+      int ibDev0 = comm->devs[0].base.ibDevN;
+      WARN("NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
+           commDev->base.ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
+      return ncclInternalError;
+    }
+  }
+  meta.fifoAddr = (uint64_t)comm->fifo;
+  meta.sl = (ncclParamIbSl() != -1) ? ncclParamIbSl() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_SL_DEFAULT;
+  meta.tc = (ncclParamIbTc() != -1) ? ncclParamIbTc() : (config && config->trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? config->trafficClass : NCCL_IB_TC_DEFAULT;
+  strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
+
+  stage->state = ncclIbCommStateSend;
+  stage->offset = 0;
+
+  memcpy(stage->buffer, &meta, sizeof(meta));
+
+ib_send:
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &comm->base.sock, stage->buffer, sizeof(meta), &stage->offset), ret, fail);
+  if (stage->offset != sizeof(meta)) return ncclSuccess;
+
+  stage->state = ncclIbCommStateConnecting;
+  stage->offset = 0;
+  // Clear the staging buffer for re-use
+  memset(stage->buffer, 0, sizeof(meta));
+
+ib_connect:
+  struct ncclIbConnectionMetadata remMeta;
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_RECV, &comm->base.sock, stage->buffer, sizeof(ncclIbConnectionMetadata), &stage->offset), ret, fail);
+  if (stage->offset != sizeof(remMeta)) return ncclSuccess;
+
+  memcpy(&remMeta, stage->buffer, sizeof(ncclIbConnectionMetadata));
+
+  comm->base.nRemDevs = remMeta.ndevs;
+
+  // ensure that the remote devices have the same link layer than the local devices used in the connection.
+  if (comm->base.vProps.ndevs > 0) {
+    int ibDev0 = comm->devs[0].base.ibDevN;
+    link_layer = ncclIbDevs[ibDev0].portAttr.link_layer;
+    for (int i = 0; i < remMeta.ndevs; i++) {
+      if (remMeta.devs[i].link_layer != link_layer) {
+        WARN("NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
+             NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
+        return ncclInternalError;
+      }
+    }
+  }
+
+  // Copy remDevInfo for things like remGidInfo, remFifoAddr, etc.
+  for (int i = 0; i < remMeta.ndevs; i++) {
+    comm->base.remDevs[i] = remMeta.devs[i];
+    comm->base.remDevs[i].remoteGid.global.interface_id = comm->base.remDevs[i].gid.global.interface_id;
+    comm->base.remDevs[i].remoteGid.global.subnet_prefix = comm->base.remDevs[i].gid.global.subnet_prefix;
+    // Retain remote sizes fifo info and prepare RDMA ops
+    comm->remSizesFifo.rkeys[i] = remMeta.devs[i].fifoRkey;
+    comm->remSizesFifo.addr = remMeta.fifoAddr;
+  }
+
+  for (int i=0; i < comm->base.vProps.ndevs; i++) {
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(comm->remSizesFifo.mrs+i, comm->devs[i].base.pd, &comm->remSizesFifo.elems, sizeof(int)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
+  }
+  comm->base.nRemDevs = remMeta.ndevs;
+
+  for (int q = 0; q < comm->base.nqps; q++) {
+    struct ncclIbQpInfo* remQpInfo   = remMeta.qpInfo + q;
+    struct ncclIbDevInfo* remDevInfo = remMeta.devs + remQpInfo->devIndex;
+
+    // Assign per-QP remDev
+    comm->base.qps[q].remDevIdx = remQpInfo->devIndex;
+    int devIndex = comm->base.qps[q].devIndex;
+    ncclIbSendCommDev* commDev = comm->devs + devIndex;
+
+    struct ibv_qp* qp = comm->base.qps[q].qp;
+    if (remQpInfo->ece_supported)
+      NCCLCHECKGOTO(wrap_ibv_set_ece(qp, &remQpInfo->ece, &remQpInfo->ece_supported), ret, fail);
+
+    ncclIbDev* ibDev = ncclIbDevs + commDev->base.ibDevN;
+    remDevInfo->mtu = std::min(remDevInfo->mtu, ibDev->portAttr.active_mtu);
+    NCCLCHECKGOTO(ncclIbRtrQp(qp, &commDev->base.gidInfo, remQpInfo->qpn, remDevInfo, false, remMeta.tc, remMeta.sl), ret, fail);
+    NCCLCHECKGOTO(ncclIbRtsQp(qp), ret, fail);
+  }
+
+  if (link_layer == IBV_LINK_LAYER_ETHERNET ) { // RoCE
+    for (int q = 0; q < comm->base.nqps; q++) {
+      struct ncclIbQp* qp = comm->base.qps + q;
+      int ibDevN = comm->devs[qp->devIndex].base.ibDevN;
+      struct ncclIbDev* ibDev = ncclIbDevs + ibDevN;
+      INFO(NCCL_NET,"NET/IB: IbDev %d Port %d qpn %d set_ece={supported=%d, vendor_id=0x%x, options=0x%x, comp_mask=0x%x}",
+        ibDevN, ibDev->portNum, remMeta.qpInfo[q].qpn, remMeta.qpInfo[q].ece_supported, remMeta.qpInfo[q].ece.vendor_id, remMeta.qpInfo[q].ece.options, remMeta.qpInfo[q].ece.comp_mask);
+    }
+  }
+
+  comm->base.nDataQps = std::max(comm->base.vProps.ndevs, comm->base.nRemDevs);
+
+  comm->base.ready = 1;
+  stage->state = ncclIbCommStateConnected;
+  stage->offset = 0;
+
+ib_send_ready:
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &comm->base.sock, &comm->base.ready, sizeof(int), &stage->offset), ret, fail);
+  if (stage->offset != sizeof(int)) return ncclSuccess;
+
+  *sendComm = comm;
+exit:
+  if (stage->buffer) free(stage->buffer);
+  stage->state = ncclIbCommStateStart;
+  return ret;
+fail:
+  free(comm);
+  goto exit;
+}
+
+NCCL_PARAM(IbWarnRailLocal, "IB_WARN_RAIL_LOCAL", 0);
+
+ncclResult_t ncclIbCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDeviceProps_t* vProps2) {
+  ncclNetVDeviceProps_t  outVProps = {0};
+  ncclNetVDeviceProps_t* minVProps = vProps2;
+  ncclNetVDeviceProps_t* maxVProps = vProps1;
+  if (vProps2->ndevs > vProps1->ndevs) {
+    minVProps = vProps1;
+    maxVProps = vProps2;
+  }
+
+  // Find the intersection of devices
+  for (int i = 0; i < minVProps->ndevs; i++) {
+    int dev = minVProps->devs[i];
+    for (int j = 0; j < maxVProps->ndevs; j++) {
+      // Found
+      if (maxVProps->devs[j] == dev) {
+        outVProps.devs[outVProps.ndevs++] = dev;
+      }
+    }
+  }
+
+  // In the case that at least one side has a fused NIC but there are no matching physical NICs, we should check if the user wants this
+  if (ncclParamIbWarnRailLocal() && outVProps.ndevs < maxVProps->ndevs) {
+    char local[128];
+    int cursor = 1;
+    snprintf(local, sizeof(local), "%d", vProps1->devs[0]);
+    for (int i = 1; i < vProps1->ndevs; i++) {
+      snprintf(local+cursor, sizeof(local)-cursor, ",%d", vProps1->devs[i]);
+      cursor += 2;
+    }
+    char remote[128];
+    snprintf(remote, sizeof(remote), "%d", vProps2->devs[0]);
+    cursor = 1;
+    for (int i = 1; i < vProps2->ndevs; i++) {
+      snprintf(remote+cursor, sizeof(remote)-cursor, ",%d", vProps2->devs[i]);
+      cursor += 2;
+    }
+    INFO(NCCL_NET, "NET/IB : There are mismatched physical devices between local (%s) and remote (%s). To disable this warning, set NCCL_IB_WARN_RAIL_LOCAL=0", local, remote);
+  }
+
+  return ncclSuccess;
+}
+
+NCCL_PARAM(IbGdrFlushDisable, "GDR_FLUSH_DISABLE", 0);
+RCCL_PARAM(IbGdrFlushGpuMemNoRelaxedOrdering, "GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING", 1);
+
+ncclResult_t ncclIbAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle_t** /*recvDevComm*/) {
+  ncclResult_t ret = ncclSuccess;
+  struct ncclIbListenComm* lComm = (struct ncclIbListenComm*)listenComm;
+  struct ncclIbCommStage* stage = &lComm->stage;
+  struct ncclIbRecvComm* rComm = (struct ncclIbRecvComm*)stage->comm;
+  int ready;
+  int link_layer = IBV_LINK_LAYER_UNSPECIFIED;
+  *recvComm = NULL;
+
+  if (stage->state == ncclIbCommStateAccept)   goto ib_accept_check;
+  if (stage->state == ncclIbCommStateRecvDevList) goto ib_recv_dev_list;
+  if (stage->state == ncclIbCommStateSendDevList) goto ib_send_dev_list;
+  if (stage->state == ncclIbCommStateRecv) goto ib_recv;
+  if (stage->state == ncclIbCommStateSend) goto ib_send;
+  if (stage->state == ncclIbCommStatePendingReady) goto ib_recv_ready;
+  if (stage->state != ncclIbCommStateStart) {
+    WARN("Listencomm in unknown state %d", stage->state);
+    return ncclInternalError;
+  }
+
+  NCCLCHECK(ncclIbMalloc((void**)&rComm, sizeof(struct ncclIbRecvComm)));
+  NCCLCHECKGOTO(ncclIbStatsInit(&rComm->base.stats), ret, fail);
+  stage->comm = rComm;
+  stage->state = ncclIbCommStateAccept;
+  NCCLCHECKGOTO(ncclSocketInit(&rComm->base.sock), ret, fail);
+  NCCLCHECKGOTO(ncclSocketAccept(&rComm->base.sock, &lComm->sock), ret, fail);
+
+  // Alloc stage->buffer here to be used for all following steps
+  struct ncclIbConnectionMetadata remMeta;
+  stage->offset = 0;
+  NCCLCHECK(ncclIbMalloc((void**)&stage->buffer, sizeof(remMeta)));
+
+ib_accept_check:
+  NCCLCHECKGOTO(ncclSocketReady(&rComm->base.sock, &ready), ret, fail);
+  if (!ready) return ncclSuccess;
+  stage->state = ncclIbCommStateRecvDevList;
+  stage->offset = 0;
+
+// In the case of mismatched nDevs, we will make sure that both sides of a logical connection have the same number of RC qps
+ib_recv_dev_list:
+  NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_RECV, &rComm->base.sock, stage->buffer, sizeof(ncclNetVDeviceProps_t), &stage->offset));
+  if (stage->offset != sizeof(ncclNetVDeviceProps_t)) return ncclSuccess;
+  ncclNetVDeviceProps_t remoteVProps;
+  memcpy(&remoteVProps, stage->buffer, sizeof(ncclNetVDeviceProps_t));
+  if (lComm->dev >= ncclNMergedIbDevs) {
+    WARN("NET/IB : Trying to use non-existent virtual device %d", lComm->dev);
+    return ncclInternalError;
+  }
+
+  // Reduce the physical device list and store in the connection base
+  struct ncclIbMergedDev* mergedDev;
+  mergedDev = ncclIbMergedDevs + lComm->dev;
+  NCCLCHECK(ncclIbCheckVProps(&mergedDev->vProps, &remoteVProps));
+  rComm->base.vProps = mergedDev->vProps;
+  memcpy(stage->buffer, &rComm->base.vProps, sizeof(ncclNetVDeviceProps_t));
+  rComm->base.isSend = false;
+  int localNqps, remoteNqps;
+  localNqps  = ncclParamIbQpsPerConn() * rComm->base.vProps.ndevs; // We must have at least 1 qp per-device
+  remoteNqps = ncclParamIbQpsPerConn() * remoteVProps.ndevs;
+  rComm->base.nqps = remoteNqps > localNqps ? remoteNqps : localNqps; // Select max nqps (local or remote)
+
+  stage->offset = 0;
+  stage->state = ncclIbCommStateSendDevList;
+
+ib_send_dev_list:
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &rComm->base.sock, stage->buffer, sizeof(ncclNetVDeviceProps_t), &stage->offset), ret, fail);
+  if (stage->offset != sizeof(ncclNetVDeviceProps_t)) return ncclSuccess;
+
+  stage->offset = 0;
+  stage->state = ncclIbCommStateRecv;
+
+ib_recv:
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_RECV, &rComm->base.sock, stage->buffer, sizeof(remMeta), &stage->offset), ret, fail);
+  if (stage->offset != sizeof(remMeta)) return ncclSuccess;
+
+  /* copy back the received info */
+  memcpy(&remMeta, stage->buffer, sizeof(struct ncclIbConnectionMetadata));
+
+  // IB setup
+  // Pre-declare variables because of goto
+  struct ncclIbDev* ibDev;
+  int ibDevN;
+  struct ncclIbRecvCommDev* rCommDev;
+  struct ncclIbDevInfo* remDevInfo;
+  struct ncclIbQp* qp;
+  bool useDmaBuf; 
+
+  mergedDev = ncclIbMergedDevs + lComm->dev;
+  rComm->base.nRemDevs = remMeta.ndevs;
+  if (rComm->base.nRemDevs != rComm->base.vProps.ndevs) {
+    INFO(NCCL_NET, "NET/IB : Local mergedDev %s has a different number of devices=%d as remote %s %d",
+      mergedDev->devName, rComm->base.vProps.ndevs, remMeta.devName, rComm->base.nRemDevs);
+  }
+
+  // Metadata to send back to requestor (sender)
+  struct ncclIbConnectionMetadata meta;
+  memset(&meta, 0, sizeof(meta));
+  for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+    rCommDev = rComm->devs + i;
+    ibDevN = rComm->base.vProps.devs[i];
+    NCCLCHECKGOTO(ncclIbInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats), ret, fail);
+    ibDev = ncclIbDevs + ibDevN;
+    NCCLCHECKGOTO(ncclIbGetGidIndex(ibDev->context, ibDev->portNum, &ibDev->portAttr, &rCommDev->base.gidInfo.localGidIndex), ret, fail);
+    NCCLCHECKGOTO(wrap_ibv_query_gid(ibDev->context, ibDev->portNum, rCommDev->base.gidInfo.localGidIndex, &rCommDev->base.gidInfo.localGid), ret, fail);
+    if (link_layer == IBV_LINK_LAYER_UNSPECIFIED) link_layer = ibDev->portAttr.link_layer;
+    if (link_layer != ibDev->portAttr.link_layer) {
+      int ibDev0 = rComm->devs[0].base.ibDevN;
+      WARN("NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
+           ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
+      return ncclInternalError;
+    }
+  }
+
+  // Copy remDevInfo for things like remGidInfo, remFifoAddr, etc.
+  for (int i = 0; i < remMeta.ndevs; i++) {
+    rComm->base.remDevs[i] = remMeta.devs[i];
+    rComm->base.remDevs[i].remoteGid.global.interface_id  = rComm->base.remDevs[i].gid.global.interface_id;
+    rComm->base.remDevs[i].remoteGid.global.subnet_prefix = rComm->base.remDevs[i].gid.global.subnet_prefix;
+    if (remMeta.devs[i].link_layer != link_layer) {
+      int ibDev0 = rComm->devs[0].base.ibDevN;
+      WARN("NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
+           NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
+      return ncclInternalError;
+    }
+  }
+
+  // Stripe QP creation across merged devs
+  // Make sure to get correct remote peer dev and QP info
+  int remDevIndex;
+  int devIndex;
+  devIndex = 0;
+  for (int q = 0; q < rComm->base.nqps; q++) {
+    remDevIndex = remMeta.qpInfo[q].devIndex;
+    remDevInfo = remMeta.devs + remDevIndex;
+    qp = rComm->base.qps+q;
+    rCommDev = rComm->devs + devIndex;
+    qp->remDevIdx = remDevIndex;
+
+    // Local ibDevN
+    ibDevN = rComm->devs[devIndex].base.ibDevN;
+    ibDev = ncclIbDevs + ibDevN;
+    NCCLCHECKGOTO(ncclIbCreateQp(ibDev->portNum, &rCommDev->base, IBV_ACCESS_REMOTE_WRITE, &rComm->base.stats, qp), ret, fail);
+    qp->devIndex = devIndex;
+    devIndex = (devIndex + 1) % rComm->base.vProps.ndevs;
+
+    // Set the ece (enhanced connection establishment) on this QP before RTR
+    if (remMeta.qpInfo[q].ece_supported) {
+      // Coverity suspects a copy-paste error below due to the use of remMeta in one argument and meta in another.
+      // However, this has been confirmed to be intentional.
+      // coverity[copy_paste_error]
+      NCCLCHECKGOTO(wrap_ibv_set_ece(qp->qp, &remMeta.qpInfo[q].ece, &meta.qpInfo[q].ece_supported), ret, fail);
+    } else {
+      meta.qpInfo[q].ece_supported = 0;
+    }
+
+    NCCLCHECKGOTO(ncclIbRtrQp(qp->qp, &rCommDev->base.gidInfo, remMeta.qpInfo[q].qpn, remDevInfo, true, remMeta.tc, remMeta.sl), ret, fail);
+    NCCLCHECKGOTO(ncclIbRtsQp(qp->qp), ret, fail);
+
+    // Query the reduced ece for this QP (matching enhancements between the requestor and the responder)
+    // Store this in our own qpInfo for returning to the requestor
+    if (remMeta.qpInfo[q].ece_supported && meta.qpInfo[q].ece_supported) {
+      NCCLCHECKGOTO(wrap_ibv_query_ece(qp->qp, &meta.qpInfo[q].ece, &meta.qpInfo[q].ece_supported), ret, fail);
+    }
+  }
+
+/* AB501 20251024  */
+#if 0
+  useDmaBuf  = (ncclIbDmaBufSupport(lComm->dev) == ncclSuccess);
+#else
+  useDmaBuf = false;
+#endif
+/* AB501 20251024  */
+
+  rComm->flushEnabled = ((ncclIbGdrSupport() == ncclSuccess || useDmaBuf)
+                            && (ncclParamIbGdrFlushDisable() == 0)) ? 1 : 0;              
+  for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+    rCommDev = rComm->devs + i;
+    ibDev = ncclIbDevs + rCommDev->base.ibDevN;
+
+    // Retain remote fifo info and prepare my RDMA ops
+    rComm->remFifo.addr = remMeta.fifoAddr;
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->fifoMr, rCommDev->base.pd, &rComm->remFifo.elems, sizeof(struct ncclIbSendFifo)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
+    rCommDev->fifoSge.lkey = rCommDev->fifoMr->lkey;
+    if (ncclParamIbUseInline()) rComm->remFifo.flags = IBV_SEND_INLINE;
+
+    // Allocate Flush dummy buffer for GPU Direct RDMA
+    if (rComm->flushEnabled) {
+      if (rcclParamIbGdrFlushGpuMemNoRelaxedOrdering()) {
+#if defined(HIP_UNCACHED_MEMORY)
+        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), nullptr, hipDeviceMallocUncached), ret, fail);
+#else
+        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), nullptr, hipDeviceMallocFinegrained), ret, fail);
+#endif
+        if (useDmaBuf)
+        {
+          uint64_t export_offset = 0;
+          void *aligned_ptr = NULL;
+          size_t aligned_size = 0;
+          get_aligned_ptr_and_size(rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int) /*devicebuffersize*/, &aligned_ptr, &aligned_size);
+/* AB501 20251024  */
+#if 0
+          hsa_status_t export_status = pfn_hsa_amd_portable_export_dmabuf(aligned_ptr, aligned_size, &rCommDev->gpuFlush.dmabuf_fd, &export_offset);
+#else
+          hsa_status_t export_status = HSA_STATUS_ERROR_NOT_INITIALIZED;
+#endif
+/* AB501 20251024  */
+
+          if (rCommDev->gpuFlush.dmabuf_fd < 0 || export_status != HSA_STATUS_SUCCESS)
+          {
+            WARN("Failed to export DMA BUF");
+            goto fail;
+          }
+          NCCLCHECKGOTO(wrap_ibv_reg_dmabuf_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, export_offset, sizeof(int), (uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem /*iova*/, rCommDev->gpuFlush.dmabuf_fd, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ), ret, fail);
+        }
+        else
+        {
+          rCommDev->gpuFlush.dmabuf_fd = -1;
+          NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ), ret, fail);
+        }
+      } else {
+        rCommDev->gpuFlush.gpuFlushGpuMem = nullptr;
+        rCommDev->gpuFlush.gpuMr = nullptr;
+        rCommDev->gpuFlush.dmabuf_fd = -1;
+      }
+      NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->gpuFlush.hostMr, rCommDev->base.pd, &rComm->gpuFlushHostMem, sizeof(int), IBV_ACCESS_LOCAL_WRITE), ret, fail);
+      rCommDev->gpuFlush.sge.addr = (uint64_t)&rComm->gpuFlushHostMem;
+      rCommDev->gpuFlush.sge.length = 1;
+      rCommDev->gpuFlush.sge.lkey = rCommDev->gpuFlush.hostMr->lkey;
+      NCCLCHECKGOTO(ncclIbCreateQp(ibDev->portNum, &rCommDev->base, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE, &rComm->base.stats, &rCommDev->gpuFlush.qp), ret, fail);
+      struct ncclIbDevInfo devInfo;
+      devInfo.lid         = ibDev->portAttr.lid;
+      devInfo.link_layer  = ibDev->portAttr.link_layer;
+      devInfo.ib_port     = ibDev->portNum;
+      devInfo.gid.global.subnet_prefix        = rCommDev->base.gidInfo.localGid.global.subnet_prefix;
+      devInfo.gid.global.interface_id         = rCommDev->base.gidInfo.localGid.global.interface_id;
+      devInfo.mtu         = ibDev->portAttr.active_mtu;
+      NCCLCHECKGOTO(ncclIbRtrQp(rCommDev->gpuFlush.qp.qp, &rCommDev->base.gidInfo, rCommDev->gpuFlush.qp.qp->qp_num, &devInfo, false, remMeta.tc, remMeta.sl), ret, fail);
+      NCCLCHECKGOTO(ncclIbRtsQp(rCommDev->gpuFlush.qp.qp), ret, fail);
+    }
+
+    // Fill Handle
+    meta.devs[i].lid                            = ibDev->portAttr.lid;
+    meta.devs[i].link_layer                     = rCommDev->base.gidInfo.link_layer = ibDev->portAttr.link_layer;
+    meta.devs[i].ib_port                        = ibDev->portNum;
+    meta.devs[i].gid.global.subnet_prefix       = rCommDev->base.gidInfo.localGid.global.subnet_prefix;
+    meta.devs[i].gid.global.interface_id        = rCommDev->base.gidInfo.localGid.global.interface_id;
+    meta.devs[i].mtu                            = ibDev->portAttr.active_mtu;
+    meta.devs[i].ibv_dev_index                  = rCommDev->base.ibDevN;
+
+    // Prepare sizes fifo
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&rComm->devs[i].sizesFifoMr, rComm->devs[i].base.pd, rComm->sizesFifo, sizeof(int)*MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS, IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
+    meta.devs[i].fifoRkey = rComm->devs[i].sizesFifoMr->rkey;
+  }
+  meta.fifoAddr = (uint64_t)rComm->sizesFifo;
+  meta.sl = remMeta.sl;
+  meta.tc = remMeta.tc;
+
+  for (int q = 0; q < rComm->base.nqps; q++) {
+    meta.qpInfo[q].qpn      = rComm->base.qps[q].qp->qp_num;
+    meta.qpInfo[q].devIndex = rComm->base.qps[q].devIndex;
+  }
+  meta.ndevs = rComm->base.vProps.ndevs;
+  strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
+  rComm->base.nDataQps = std::max(rComm->base.vProps.ndevs, rComm->base.nRemDevs);
+
+  stage->state = ncclIbCommStateSend;
+  stage->offset = 0;
+  if (stage->buffer) {
+    free(stage->buffer);
+    stage->buffer = NULL;
+  }
+  NCCLCHECKGOTO(ncclIbMalloc((void**)&stage->buffer, sizeof(struct ncclIbConnectionMetadata)), ret, fail);
+  memcpy(stage->buffer, &meta, sizeof(struct ncclIbConnectionMetadata));
+
+ib_send:
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &rComm->base.sock, stage->buffer, sizeof(struct ncclIbConnectionMetadata), &stage->offset), ret, fail);
+  if (stage->offset < sizeof(struct ncclIbConnectionMetadata)) return ncclSuccess;
+
+  stage->offset = 0;
+  stage->state = ncclIbCommStatePendingReady;
+
+ib_recv_ready:
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_RECV,  &rComm->base.sock, &rComm->base.ready, sizeof(int), &stage->offset), ret, fail);
+  if (stage->offset != sizeof(int)) return ncclSuccess;
+
+  *recvComm = rComm;
+exit:
+  /* reset lComm stage */
+  if (stage->buffer) free(stage->buffer);
+  stage->state = ncclIbCommStateStart;
+  stage->offset = 0;
+  stage->comm = NULL;
+  stage->buffer = NULL;
+  return ret;
+fail:
+  free(rComm);
+  goto exit;
+}
+
+ncclResult_t ncclIbGetRequest(struct ncclIbNetCommBase* base, struct ncclIbRequest** req) {
+  for (int i=0; i<MAX_REQUESTS; i++) {
+    struct ncclIbRequest* r = base->reqs+i;
+    if (r->type == NCCL_NET_IB_REQ_UNUSED) {
+      r->base = base;
+      r->sock = NULL;
+      r->devBases[0] = NULL;
+      r->devBases[1] = NULL;
+      r->events[0] = r->events[1] = 0;
+      *req = r;
+      return ncclSuccess;
+    }
+  }
+  WARN("NET/IB : unable to allocate requests");
+  *req = NULL;
+  return ncclInternalError;
+}
+
+ncclResult_t ncclIbFreeRequest(struct ncclIbRequest* r) {
+  r->type = NCCL_NET_IB_REQ_UNUSED;
+  return ncclSuccess;
+}
+
+static ncclResult_t ncclIbGetRemap(struct ncclIbNetCommBase* base, uint64_t wrId, int qpIndex, struct ncclIbRemapWrId** remap) {
+  for (int i=0; i<MAX_REQUESTS; i++) {
+    struct ncclIbRemapWrId* r = base->remapWrId+i;
+    if (r->state == NCCL_NET_IB_REMAP_UNUSED) {
+      r->origWrId = wrId;
+      r->qpIndex = qpIndex;
+      r->state = NCCL_NET_IB_REMAP_USED;
+      *remap = r;
+      return ncclSuccess;
+    }
+  }
+  WARN("NET/IB : unable to allocate remap buffer");
+  *remap = NULL;
+  return ncclInternalError;
+}
+
+static ncclResult_t ncclIbFreeRemap(struct ncclIbRemapWrId* r) {
+  r->state = NCCL_NET_IB_REMAP_UNUSED;
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbRegMrDmaBufInternal(ncclIbNetCommDevBase* base, void* data, size_t size, int type, uint64_t offset, int fd, ibv_mr** mhandle) {
+  static __thread uintptr_t pageSize = 0;
+  if (pageSize == 0) pageSize = sysconf(_SC_PAGESIZE);
+  struct ncclIbMrCache* cache = &ncclIbDevs[base->ibDevN].mrCache;
+  uintptr_t addr = (uintptr_t)data & -pageSize;
+  size_t pages = ((uintptr_t)data + size - addr + pageSize-1)/pageSize;
+  ncclResult_t res;
+  pthread_mutex_lock(&ncclIbDevs[base->ibDevN].lock);
+  for (int slot=0; /*true*/; slot++) {
+    if (slot == cache->population || addr < cache->slots[slot].addr) { // didn't find in cache
+      if (cache->population == cache->capacity) { // must grow cache
+        cache->capacity = cache->capacity < 32 ? 32 : 2*cache->capacity;
+        NCCLCHECKGOTO(ncclRealloc(&cache->slots, cache->population, cache->capacity), res, returning);
+      }
+      // Deregister / register
+      struct ibv_mr* mr;
+      unsigned int flags = IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ;
+      if (ncclIbRelaxedOrderingEnabled) flags |= IBV_ACCESS_RELAXED_ORDERING;
+      if (fd != -1) {
+        /* DMA-BUF support */
+        NCCLCHECKGOTO(wrap_ibv_reg_dmabuf_mr(&mr, base->pd, offset, pages*pageSize, addr, fd, flags), res, returning);
+      } else {
+        if (ncclIbRelaxedOrderingEnabled) {
+          // Use IBVERBS_1.8 API - needed for IBV_ACCESS_RELAXED_ORDERING support
+          NCCLCHECKGOTO(wrap_ibv_reg_mr_iova2(&mr, base->pd, (void*)addr, pages*pageSize, addr, flags), res, returning);
+        }
+        else {
+          NCCLCHECKGOTO(wrap_ibv_reg_mr(&mr, base->pd, (void*)addr, pages*pageSize, flags), res, returning);
+        }
+      }
+      TRACE(NCCL_INIT|NCCL_NET,"regAddr=0x%lx size=%lld rkey=0x%x lkey=0x%x fd=%d", (unsigned long)addr, (long long)pages*pageSize, mr->rkey, mr->lkey, fd);
+      if (slot != cache->population) memmove(cache->slots+slot+1, cache->slots+slot, (cache->population-slot)*sizeof(struct ncclIbMr));
+      cache->slots[slot].addr = addr;
+      cache->slots[slot].pages = pages;
+      cache->slots[slot].refs = 1;
+      cache->slots[slot].mr = mr;
+      cache->population += 1;
+      *mhandle = mr;
+      res = ncclSuccess;
+      goto returning;
+    } else if ((addr >= cache->slots[slot].addr) &&
+        ((addr-cache->slots[slot].addr)/pageSize+pages) <= cache->slots[slot].pages) {
+      cache->slots[slot].refs += 1;
+      *mhandle = cache->slots[slot].mr;
+      res = ncclSuccess;
+      goto returning;
+    }
+  }
+returning:
+  pthread_mutex_unlock(&ncclIbDevs[base->ibDevN].lock);
+  return res;
+}
+
+struct ncclIbNetCommDevBase* ncclIbGetNetCommDevBase(ncclIbNetCommBase* base, int devIndex) {
+  if (base->isSend) {
+    struct ncclIbSendComm* sComm = (struct ncclIbSendComm*) base;
+    return &sComm->devs[devIndex].base;
+  } else {
+    struct ncclIbRecvComm* rComm = (struct ncclIbRecvComm*) base;
+    return &rComm->devs[devIndex].base;
+  }
+}
+
+/* DMA-BUF support */
+ncclResult_t ncclIbRegMrDmaBuf(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle) {
+  ncclResult_t ret = ncclSuccess;
+  assert(size > 0);
+  struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*) comm;
+  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) malloc(sizeof(struct ncclIbMrHandle));
+  for (int i = 0; i < base->vProps.ndevs; i++) {
+    // Each ncclIbNetCommDevBase is at different offset in send and recv netComms
+    struct ncclIbNetCommDevBase* devComm = ncclIbGetNetCommDevBase(base, i);
+    NCCLCHECKGOTO(ncclIbRegMrDmaBufInternal(devComm, data, size, type, offset, fd, mhandleWrapper->mrs + i), ret, fail);
+  }
+  *mhandle = (void*) mhandleWrapper;
+exit:
+  return ret;
+fail:
+  free(mhandleWrapper);
+  goto exit;
+}
+
+ncclResult_t ncclIbRegMr(void* comm, void* data, size_t size, int type, void** mhandle) {
+  return ncclIbRegMrDmaBuf(comm, data, size, type, 0ULL, -1, mhandle);
+}
+
+ncclResult_t ncclIbDeregMrInternal(ncclIbNetCommDevBase* base, ibv_mr* mhandle) {
+  struct ncclIbMrCache* cache = &ncclIbDevs[base->ibDevN].mrCache;
+  ncclResult_t res;
+  pthread_mutex_lock(&ncclIbDevs[base->ibDevN].lock);
+  for (int i=0; i < cache->population; i++) {
+    if (mhandle == cache->slots[i].mr) {
+      if (0 == --cache->slots[i].refs) {
+        memmove(&cache->slots[i], &cache->slots[--cache->population], sizeof(struct ncclIbMr));
+        if (cache->population == 0) {
+          free(cache->slots);
+          cache->slots = NULL;
+          cache->capacity = 0;
+        }
+        NCCLCHECKGOTO(wrap_ibv_dereg_mr(mhandle), res, returning);
+      }
+      res = ncclSuccess;
+      goto returning;
+    }
+  }
+  WARN("NET/IB: could not find mr %p inside cache of %d entries", mhandle, cache->population);
+  res = ncclInternalError;
+returning:
+  pthread_mutex_unlock(&ncclIbDevs[base->ibDevN].lock);
+  return res;
+}
+
+ncclResult_t ncclIbDeregMr(void* comm, void* mhandle) {
+  if (mhandle == NULL) return ncclSuccess;
+
+  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandle;
+  struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*) comm;
+  for (int i = 0; i < base->vProps.ndevs; i++) {
+    // Each ncclIbNetCommDevBase is at different offset in send and recv netComms
+    struct ncclIbNetCommDevBase* devComm = ncclIbGetNetCommDevBase(base, i);
+    NCCLCHECK(ncclIbDeregMrInternal(devComm, mhandleWrapper->mrs[i]));
+  }
+  free(mhandleWrapper);
+  return ncclSuccess;
+}
+
+static void updateQpTxSched(struct ncclIbNetCommBase *base) {
+  int qp;
+  uint64_t minRttSample;
+  double minRtt = DBL_MAX, rttSum = 0.0;
+  struct ncclIbQpTxSchedScratchpad s;
+  struct ncclIbRrTokens *tokens;
+
+  for (qp = 0; qp < base->nqps; qp++) {
+    if (base->qpTxStats[qp].rtt < minRtt) {
+      minRtt = base->qpTxStats[qp].rtt;
+      minRttSample = base->qpTxStats[qp].minRttSample;
+    }
+  }
+
+  for (qp = 0; qp < base->nqps; qp++) {
+    if (base->qpTxStats[qp].rtt == 0.0)
+      return;
+    double denom = (base->qpTxStats[qp].rtt - minRtt) + minRttSample;
+    if (denom <= 0.0)
+      return;
+    s.rtt[qp] = 1.0 / denom;
+    rttSum += s.rtt[qp];
+  }
+
+  if (rttSum == 0.0) {
+    for (qp = 0; qp < base->nqps; qp++)
+      base->qpTxSched[qp].weight = 1.0 / ((double) base->nqps);
+  } else {
+    for (qp = 0; qp < base->nqps; qp++)
+        base->qpTxSched[qp].weight = s.rtt[qp] / rttSum;
+  }
+
+  if (base->schedParms.logEnable) {
+    if (!base->qpTxSchedInit) {
+      for (qp = 0; qp < base->nqps; qp++)
+        base->qpTxSched[qp].minWeight = DBL_MAX;
+    }
+
+    for (qp = 0; qp < base->nqps; qp++) {
+      if (base->qpTxSched[qp].weight < base->qpTxSched[qp].minWeight)
+        base->qpTxSched[qp].minWeight = base->qpTxSched[qp].weight;
+      if (base->qpTxSched[qp].weight > base->qpTxSched[qp].maxWeight)
+        base->qpTxSched[qp].maxWeight = base->qpTxSched[qp].weight;
+    }
+  }
+
+  tokens = &base->rrQpTxSched.initTokens;
+  tokens->totTokens = 0;
+  for (qp = 0; qp < base->nqps; qp++) {
+    double temp, temp3;
+    int temp2;
+    temp = ((double) NCCL_IB_TARGET_TOT_TOKENS) *
+           base->qpTxSched[qp].weight;
+    temp2 = (int) temp;
+    temp3 = (double) temp2;
+    if (((temp - temp3) > 0.5) || (temp2 == 0))
+      temp2++;
+    tokens->qpTokens[qp] = temp2;
+    tokens->totTokens += temp2;
+  }
+
+  base->qpTxSchedInit = true;
+}
+
+static void logSched(struct ncclIbSendComm *comm) {
+  
+  fprintf(logStream, "comm %p: num qp's %d\n", comm, comm->base.nqps);
+  for (int i = 0; i < comm->base.nqps; i++) {
+    ncclIbQp* qp = comm->base.qps + i;
+    int devIndex = qp->devIndex;
+    fprintf(logStream, "  qp[%d]: %s: min weight = %f current weight %f max weight %f\n",
+            i,
+            ncclIbDevs[comm->devs[devIndex].base.ibDevN].devName,
+      comm->base.qpTxSched[i].minWeight,
+      comm->base.qpTxSched[i].weight,
+            comm->base.qpTxSched[i].maxWeight);
+  }
+  fflush(logStream);
+}
+
+static void updateQpTxStats(struct ncclIbRemapWrId *remap,
+                            struct ncclIbNetCommBase *base) {
+  uint64_t nowNs, sampleNs, sampleTxTimeNs, rtt, resetInterval;
+  double sampleTxTime, weightNew, weightPrev;
+  struct timespec now;
+  struct ncclIbQpTxStats *qpTxStats;
+
+  if (remap->tx.startTimeNs == 0)
+    return;
+
+  if (clock_gettime(CLOCK_MONOTONIC, &now))
+    return;
+
+  nowNs = TIMESPEC_TO_NSEC(&now);
+  bool resetRtt = false;
+  if (remap->parms.resetRtt && (!base->resetRttDone)) {
+    resetRtt = true;
+    base->resetRttDone = true;
+  }
+  resetInterval = remap->parms.resetInterval;
+  if ((resetInterval != QP_SCHED_RESET_NEVER) &&
+      (nowNs >= base->nextQpTxStatsResetNs))
+    resetRtt = true;
+  if (resetRtt) {
+    for (int qp = 0; qp < base->nqps; qp++) {
+      base->qpTxStats[qp].totRtt = 0;
+      base->qpTxStats[qp].numMeasurements = 0;
+    }
+    base->nextQpTxStatsResetNs = nowNs + resetInterval;
+  }
+
+  sampleNs = nowNs - remap->tx.startTimeNs;
+  qpTxStats = &base->qpTxStats[remap->qpIndex];
+  sampleTxTime = (((double) remap->tx.bytes) * ((double) BITS_PER_BYTE)) /
+                 (((double) ncclIbDevs[base->devIndex].speed) * ((double) MEG));
+  sampleTxTimeNs = (uint64_t) (sampleTxTime * ((double) NSEC_PER_SEC));
+  rtt = sampleNs - sampleTxTimeNs;
+  qpTxStats->totRtt += rtt;
+  qpTxStats->numMeasurements++;
+  if ((qpTxStats->minRttSample == 0) || (rtt < qpTxStats->minRttSample))
+    qpTxStats->minRttSample = rtt;
+  if (qpTxStats->numMeasurements == 1) {
+    qpTxStats->rtt = (double) rtt;
+    return;
+  }
+  weightNew = remap->parms.weightNew;
+  weightPrev = 1.0 - weightNew;
+  if (weightNew == ((double) QP_SCHED_WEIGHT_NONE))
+    qpTxStats->rtt = ((double) qpTxStats->totRtt) /
+                     ((double) qpTxStats->numMeasurements);
+  else
+    qpTxStats->rtt = (qpTxStats->rtt * weightPrev) +
+                     (((double) rtt) * weightNew);
+}
+
+static int getEffectiveTxNqps(struct ncclIbRequest* req, int *startQpIndex, bool *wrrSched) {
+  int dataPerQp, qpIndex = req->base->qpIndex, nqps = req->base->nqps;
+  struct ncclIbQpSchedParms *parms = &req->desc.parms;
+
+  *wrrSched = false;
+
+  if (req->base->nqps == 1)
+    goto exit;
+
+  if (!parms->splitData)
+    goto oneQp;
+
+  dataPerQp = (req->send.size * req->nreqs) / req->base->nqps;
+  if ((dataPerQp >= parms->splitDataMin) ||  !parms->enable) {
+    goto exit;
+  }
+
+oneQp:
+  nqps = 1;
+  if (parms->doWrr && req->base->qpTxSchedInit) {
+    if (req->base->rrQpTxSched.activeTokens.totTokens == 0)
+      req->base->rrQpTxSched.activeTokens = req->base->rrQpTxSched.initTokens;
+    qpIndex = req->base->rrQpTxSched.qpIndex;
+    while (1) {
+      if (req->base->rrQpTxSched.activeTokens.qpTokens[qpIndex]) {
+        req->base->rrQpTxSched.activeTokens.qpTokens[qpIndex]--;
+        req->base->rrQpTxSched.activeTokens.totTokens--;
+        req->base->rrQpTxSched.qpIndex = (qpIndex+1) % req->base->nqps;
+        *wrrSched = true;
+        break;
+      }
+      qpIndex = (qpIndex+1) % req->base->nqps;
+    }
+  }
+
+exit:
+  *startQpIndex = qpIndex;
+  return nqps;
+}
+
+static ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, int qpIndex, bool wrrSched) {
+  struct ncclIbRequest** reqs = comm->fifoReqs[slot];
+  volatile struct ncclIbSendFifo* slots = comm->fifo[slot];
+  int nreqs = slots[0].nreqs;
+  uint64_t nowNs = 0;
+  if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
+
+  uint64_t wr_id = 0ULL;
+  for (int r=0; r<nreqs; r++) {
+    struct ibv_send_wr* wr = comm->wrs+r;
+    memset(wr, 0, sizeof(struct ibv_send_wr));
+
+    struct ibv_sge* sge = comm->sges+r;
+    sge->addr=(uintptr_t)reqs[r]->send.data;
+    wr->opcode = IBV_WR_RDMA_WRITE;
+    wr->send_flags = 0;
+    wr->wr.rdma.remote_addr = slots[r].addr;
+    wr->next = wr + 1;
+    wr_id += (reqs[r] - comm->base.reqs) << (r*8);
+#ifdef NCCL_ENABLE_NET_PROFILING
+    reqs[r]->pInfo[0].nEventHandles = 0;
+#endif
+  }
+
+  // Write size as immediate data. In the case of multi-send, only write
+  // 0 or 1 as size to indicate whether there was data sent or received.
+#define WR_IMM_RX_REQ_IDX_MASK  0xff
+#define WR_IMM_RX_REQ_IDX_SHIFT 24
+#define WR_IMM_SPLIT_DATA_FLAG  0x00800000
+#define WR_IMM_SIZE_MASK        0x007fffff
+  uint32_t immData = slots[nreqs-1].rxReqIndex << WR_IMM_RX_REQ_IDX_SHIFT;
+  if (nreqs == 1) {
+    immData |= (reqs[0]->send.size & WR_IMM_SIZE_MASK);
+  } else {
+    int* sizes = comm->remSizesFifo.elems[slot];
+    for (int r=0; r<nreqs; r++) sizes[r] = reqs[r]->send.size;
+    comm->remSizesFifo.sge.addr = (uint64_t)sizes;
+    comm->remSizesFifo.sge.length = nreqs*sizeof(int);
+  }
+
+  struct ibv_send_wr* lastWr = comm->wrs+nreqs-1;
+  if (nreqs > 1 || (comm->ar && reqs[0]->send.size > ncclParamIbArThreshold())) {
+    // When using ADAPTIVE_ROUTING, send the bulk of the data first as an
+    // RDMA_WRITE, then a 0-byte RDMA_WRITE_WITH_IMM to trigger a remote
+    // completion.
+    lastWr++;
+    memset(lastWr, 0, sizeof(struct ibv_send_wr));
+    if (nreqs > 1) {
+      // Write remote sizes Fifo
+      lastWr->wr.rdma.remote_addr = comm->remSizesFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(int);
+      lastWr->num_sge = 1;
+      lastWr->sg_list = &comm->remSizesFifo.sge;
+    }
+  }
+  lastWr->wr_id = wr_id;
+  lastWr->opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+  lastWr->imm_data = immData;
+  lastWr->next = NULL;
+  if (nqps > 1)
+    lastWr->imm_data |= WR_IMM_SPLIT_DATA_FLAG;
+  lastWr->send_flags = IBV_SEND_SIGNALED;
+
+  // Multi-QP: make sure IB writes are multiples of 128B so that LL and LL128 protocols still work
+  const int align = 128;
+  for (int i = 0; i < nqps; i++) {
+    ncclIbQp* qp = comm->base.qps + qpIndex;
+    int devIndex = qp->devIndex;
+    for (int r=0; r<nreqs; r++) {
+      // Track this event for completion
+      //ncclIbAddEvent(reqs[r], devIndex, &comm->devs[devIndex].base);
+
+      // Select proper rkey (needed even for 0-size send)
+      comm->wrs[r].wr.rdma.rkey = slots[r].rkeys[qp->remDevIdx];
+
+      int chunkSize, length;
+      if ((nqps > 1) && reqs[r]->desc.parms.enable && comm->base.qpTxSchedInit) {
+        int weightedSendSize = (int) (((double) reqs[r]->send.size) *
+                                      comm->base.qpTxSched[qpIndex].weight);
+        chunkSize = (weightedSendSize / align) * align;
+        if (i == (nqps-1))
+          length = std::max(reqs[r]->send.size-reqs[r]->send.offset, chunkSize);
+        else
+          length = chunkSize;
+      } else {
+        chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
+        length = std::min(reqs[r]->send.size-reqs[r]->send.offset, chunkSize);
+      }
+
+      if (length <= 0) {
+        comm->wrs[r].sg_list = NULL;
+        comm->wrs[r].num_sge = 0;
+        length = 0;
+      } else {
+        // Select proper lkey
+        comm->sges[r].lkey = reqs[r]->send.lkeys[devIndex];
+        comm->sges[r].length = length;
+        comm->wrs[r].sg_list = comm->sges+r;
+        comm->wrs[r].num_sge = 1;
+      }
+      
+      if (r == (nreqs - 1)) {
+        struct ncclIbRemapWrId *remapWrId;
+
+        NCCLCHECK(ncclIbGetRemap(&comm->base, wr_id, qpIndex, &remapWrId));
+        lastWr->wr_id = (uint64_t) remapWrId;
+        /* save tx data for measuring QP performance */
+        remapWrId->parms = reqs[r]->desc.parms;
+        remapWrId->tx.bytes = length;
+        nowNs = 0;
+        if (reqs[r]->desc.parms.enable && ((nqps > 1) || reqs[r]->desc.parms.doWrr)) {
+          struct timespec txStartTime;
+          if (!clock_gettime(CLOCK_MONOTONIC, &txStartTime))
+            nowNs = TIMESPEC_TO_NSEC(&txStartTime);
+          remapWrId->tx.startTimeNs = nowNs;
+        }
+      }
+    }
+
+    if (nreqs > 1) {
+      // Also make sure lastWr writes remote sizes using the right lkey
+      comm->remSizesFifo.sge.lkey = comm->remSizesFifo.mrs[devIndex]->lkey;
+      lastWr->wr.rdma.rkey = comm->remSizesFifo.rkeys[devIndex];
+    }
+
+    struct ibv_send_wr* bad_wr;
+#ifdef NCCL_ENABLE_NET_PROFILING
+    // QP profiling loop
+    for (int r=0; r<nreqs && pHandle; r++) {
+      // Store comm qpIndex for this request
+      int nEventHandles = reqs[r]->pInfo[0].nEventHandles;
+      reqs[r]->pInfo[0].qpIndex[nEventHandles%MAX_QPS_PER_REQ] = qpIndex;
+      // Store info for profiler
+      int pluginId = NCCL_PROFILER_NET_TYPE_IB | NCCL_PROFILER_NET_IB_VER;
+      reqs[r]->pInfo[0].data.type = ncclProfileQp;
+      reqs[r]->pInfo[0].data.qp.device = devIndex;
+      reqs[r]->pInfo[0].data.qp.wr_id = comm->wrs[r].wr_id;
+      reqs[r]->pInfo[0].data.qp.opcode = comm->wrs[r].opcode;
+      reqs[r]->pInfo[0].data.qp.qpNum = qp->qp->qp_num;
+      reqs[r]->pInfo[0].data.qp.length = comm->sges[r].length;
+      NCCLCHECK(ncclProfilerFunction(&reqs[r]->pInfo[0].qpEventHandles[nEventHandles%MAX_QPS_PER_REQ], 0, pHandle, pluginId, &reqs[r]->pInfo[0].data));
+      reqs[r]->pInfo[0].nEventHandles++;
+    }
+#endif
+    NCCLCHECK(wrap_ibv_post_send(qp->qp, comm->wrs, &bad_wr));
+
+    for (int r=0; r<nreqs; r++) {
+      int chunkSize;
+
+      if (reqs[r]->desc.parms.enable && comm->base.qpTxSchedInit) {
+        int weightedSendSize = (int) (((double) reqs[r]->send.size) *
+                                      comm->base.qpTxSched[qpIndex].weight);
+        chunkSize = (weightedSendSize / align) * align;
+        if (i == (nqps-1))
+          chunkSize = std::max(reqs[r]->send.size-reqs[r]->send.offset, chunkSize);
+      } else
+        chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
+
+      reqs[r]->send.offset += chunkSize;
+      comm->sges[r].addr += chunkSize;
+      comm->wrs[r].wr.rdma.remote_addr += chunkSize;
+
+      TRACE(NCCL_VERBS, "Posted send wr_id=%lu, wr_indx=%d, qp_num=%d, src_nic=%d, dst_nic=%d, dlid=%d, opcode=%d, send_flags=%d, imm_data=%d, remote_addr=%lx, rkey=%x, length=%d, lkey=%x",
+        comm->wrs[r].wr_id, r, qp->qp->qp_num, comm->devs[qp->devIndex].base.ibDevN , comm->base.remDevs[qp->remDevIdx].ibv_dev_index, comm->base.remDevs[qp->remDevIdx].lid,
+        comm->wrs[r].opcode, comm->wrs[r].send_flags, comm->wrs[r].imm_data, comm->wrs[r].wr.rdma.remote_addr,
+        comm->wrs[r].wr.rdma.rkey,comm->wrs[r].sg_list ? comm->wrs[r].sg_list->length : 0, comm->wrs[r].sg_list ? comm->wrs[r].sg_list->lkey : 0);
+    }
+
+    // Select the next qpIndex
+    if (!wrrSched) {
+      qpIndex = (qpIndex+1) % comm->base.nqps;
+      comm->base.qpIndex = qpIndex;
+    }
+  }
+
+  if (nowNs) {
+    if (comm->base.nextQpTxSchedUpdateNs == 0)
+      comm->base.nextQpTxSchedUpdateNs = nowNs + comm->base.schedParms.updateInterval;
+    else if (nowNs >= comm->base.nextQpTxSchedUpdateNs) {
+      updateQpTxSched(&comm->base);
+      comm->base.nextQpTxSchedUpdateNs = nowNs + comm->base.schedParms.updateInterval;
+    }
+
+    if (comm->base.schedParms.logEnable) {
+      if (comm->base.nextSchedLogNs == 0)
+        comm->base.nextSchedLogNs = nowNs + comm->base.schedParms.logInterval;
+      else if (nowNs >= comm->base.nextSchedLogNs) {
+        logSched(comm);
+        comm->base.nextSchedLogNs = nowNs + comm->base.schedParms.logInterval;
+      }
+    }
+  }
+
+  return ncclSuccess;
+}
+
+static void updateSchedParmsTry(struct ncclIbNetCommBase *base, int nreqs, int size) {
+  if (!base->schedParmsInit) {
+    base->schedParms = globalQpSchedParms;
+    base->schedParmsInit = true;
+  }
+  if (base->stagedParmsConEpoch < stagedSchedParms.prodEpoch) {
+    bool collTypeChanged = false, msgSzChanged = false;
+    ncclFunc_t collType;
+    size_t msgSz;
+    pthread_mutex_lock(&schedParmsLock);
+    collType = stagedSchedParms.collType;
+    if (proxyPrevCollType != collType) {
+      proxyPrevCollType = collType;
+      collTypeChanged = true;
+    }
+    msgSz = stagedSchedParms.msgSz;
+    if (proxyPrevMsgSz != msgSz) {
+      proxyPrevMsgSz = msgSz;
+      msgSzChanged = true;
+    }
+    base->schedParms = stagedSchedParms.parms;
+    base->stagedParmsConEpoch = stagedSchedParms.prodEpoch;
+    if (base->schedParms.resetRtt)
+      base->resetRttDone = false;
+    pthread_mutex_unlock(&schedParmsLock);
+    if (msgSzChanged || collTypeChanged) {
+      const char *collStr;
+      switch (collType) {
+      case ncclFuncBroadcast:
+        collStr = "Broadcast";
+        break;
+      case ncclFuncReduce:
+        collStr = "Reduce";
+        break;
+      case ncclFuncAllGather:
+        collStr = "All_Gather";
+        break;
+      case ncclFuncReduceScatter:
+        collStr = "Reduce_Scatter";
+        break;
+      case ncclFuncAllReduce:
+        collStr = "All_Reduce";
+        break;
+      default:
+        collStr = NULL;
+        break;
+      }
+      if (collStr == NULL)
+        INFO(NCCL_NET, "PID %d: CollType = %d  MsgSz = %lu  ChunkSz = %d  NumChunks = %d",
+             getpid(), collType, msgSz, size, nreqs);
+      else
+        INFO(NCCL_NET, "PID %d: CollType = %s  MsgSz = %lu  ChunkSz = %d  NumChunks = %d",
+             getpid(), collStr, msgSz, size, nreqs);
+    }
+  }
+}
+
+ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request) {
+  struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
+  if (comm->base.ready == 0) { WARN("NET/IB: ncclIbIsend() called when comm->base.ready == 0"); return ncclInternalError; }
+  if (comm->base.ready == 0) { *request = NULL; return ncclSuccess; }
+  NCCLCHECK(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__));
+
+  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandle;
+
+  // Wait for the receiver to have posted the corresponding receive
+  int nreqs = 0;
+  volatile struct ncclIbSendFifo* slots;
+
+  int slot = (comm->fifoHead) % MAX_REQUESTS;
+  struct ncclIbRequest** reqs = comm->fifoReqs[slot];
+  slots = comm->fifo[slot];
+  uint64_t idx = comm->fifoHead+1;
+  if (slots[0].idx != idx) { *request = NULL; return ncclSuccess; }
+  nreqs = slots[0].nreqs;
+  // Wait until all data has arrived
+  for (int r=1; r<nreqs; r++) while(slots[r].idx != idx);
+  __sync_synchronize(); // order the nreqsPtr load against tag/rkey/addr loads below
+  for (int r=0; r<nreqs; r++) {
+    if (reqs[r] != NULL || slots[r].tag != tag) continue;
+
+    if (size > slots[r].size) size = slots[r].size;
+    // Sanity checks
+    if (slots[r].size < 0 || slots[r].addr == 0 || slots[r].rkeys[0] == 0) {
+      char line[SOCKET_NAME_MAXLEN + 1];
+      union ncclSocketAddress addr;
+      ncclSocketGetAddr(&comm->base.sock, &addr);
+      WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x",
+        r, nreqs, tag, ncclSocketToString(&addr, line), slots[r].size, slots[r].addr, slots[r].rkeys[0]);
+      return ncclInternalError;
+    }
+
+    struct ncclIbRequest* req;
+    NCCLCHECK(ncclIbGetRequest(&comm->base, &req));
+    req->type = NCCL_NET_IB_REQ_SEND;
+    req->sock = &comm->base.sock;
+    req->base = &comm->base;
+    req->nreqs = nreqs;
+    req->send.size = size;
+    req->send.data = data;
+    req->send.offset = 0;
+
+    // Populate events
+    int i, startQpIndex, nqps;
+    bool wrrSched;
+    for (i = 0; i < nreqs; i++) {
+      if (reqs[i] != NULL)
+        break;
+    }
+    if (i == nreqs) {
+      updateSchedParmsTry(&comm->base, nreqs, size);
+      req->desc.parms = comm->base.schedParms;
+      nqps = getEffectiveTxNqps(req, &startQpIndex, &wrrSched);
+      req->desc.nqps = nqps;
+      req->desc.startQpIndex = startQpIndex;
+      req->desc.wrrSched = wrrSched;
+    } else {
+      req->desc.parms = reqs[i]->desc.parms;
+      nqps = req->desc.nqps = reqs[i]->desc.nqps;
+      startQpIndex = req->desc.startQpIndex = reqs[i]->desc.startQpIndex;
+      wrrSched = req->desc.wrrSched = reqs[i]->desc.wrrSched;
+    }
+
+    for (int nEvents = 0, qpIndex = startQpIndex; nEvents < nqps; nEvents++) {
+      ncclIbQp* qp = comm->base.qps + qpIndex;
+      int devIndex = qp->devIndex;
+      ncclIbAddEvent(req, devIndex, &comm->devs[devIndex].base, false);
+      // Track the valid lkey for this RDMA_Write
+      req->send.lkeys[devIndex] = mhandleWrapper->mrs[devIndex]->lkey;
+      // Don't update comm->base.qpIndex yet, we need to run through this same set of QPs inside ncclIbMultiSend()
+      qpIndex = (qpIndex+1)%comm->base.nqps;
+    }
+
+    // Store all lkeys
+    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+      req->send.lkeys[i] = mhandleWrapper->mrs[i]->lkey;
+    }
+
+    *request = reqs[r] = req;
+
+    // If this is a multi-recv, send only when all requests have matched.
+    for (int r=0; r<nreqs; r++) {
+      if (reqs[r] == NULL) return ncclSuccess;
+    }
+
+    TIME_START(0);
+    NCCLCHECK(ncclIbMultiSend(comm, slot, nqps, startQpIndex, wrrSched));
+
+    // Clear slots[0]->nreqs, as well as other fields to help debugging and sanity checks
+    memset((void*)slots, 0, sizeof(struct ncclIbSendFifo));
+    memset(reqs, 0, NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbRequest*));
+    comm->fifoHead++;
+    TIME_STOP(0);
+    return ncclSuccess;
+  }
+
+  *request = NULL;
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, int n, void** data, size_t* sizes, int* tags, void** mhandles, struct ncclIbRequest* req) {
+  struct ibv_send_wr wr;
+  uint16_t rxReqIndex = (uint16_t) (req - comm->base.reqs);
+  memset(&wr, 0, sizeof(wr));
+
+  int slot = comm->remFifo.fifoTail%MAX_REQUESTS;
+  req->recv.sizes = comm->sizesFifo[slot];
+  for (int i=0; i<n; i++) req->recv.sizes[i] = 0;
+  struct ncclIbSendFifo* localElem = comm->remFifo.elems[slot];
+
+  // Select the next devIndex (local) and QP to use for posting this CTS message
+  // Since QPs are initialized by striping across devIndex, we can simply assign this to the same value
+  ncclIbQp* ctsQp = comm->base.qps + comm->base.devIndex;
+  comm->base.devIndex = (comm->base.devIndex + 1) % comm->base.vProps.ndevs;
+
+  for (int i=0; i<n; i++) {
+    localElem[i].addr = (uint64_t)data[i];
+    struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandles[i];
+
+    // Send all applicable rkeys
+    for (int j = 0; j < comm->base.vProps.ndevs; j++)
+      localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
+
+    localElem[i].nreqs = n;
+    localElem[i].size = sizes[i]; // Sanity/Debugging
+    localElem[i].tag = tags[i];
+    localElem[i].rxReqIndex = rxReqIndex;
+    localElem[i].idx = comm->remFifo.fifoTail+1;
+  }
+  wr.wr.rdma.remote_addr = comm->remFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo);
+
+  // Lookup the correct fifoRkey
+  wr.wr.rdma.rkey = comm->base.remDevs[ctsQp->remDevIdx].fifoRkey;
+
+  // Set the correct sge properties
+  comm->devs[ctsQp->devIndex].fifoSge.addr   = (uint64_t)localElem;
+  comm->devs[ctsQp->devIndex].fifoSge.length = n*sizeof(struct ncclIbSendFifo);
+  wr.sg_list = &comm->devs[ctsQp->devIndex].fifoSge;
+  wr.num_sge = 1;
+
+  wr.opcode = IBV_WR_RDMA_WRITE;
+  wr.send_flags = comm->remFifo.flags; // IBV_SEND_INLINE
+
+  // We need to occasionally post a request with the IBV_SEND_SIGNALED flag, otherwise
+  // the send queue will never empty.
+  //
+  // From https://www.rdmamojo.com/2014/06/30/working-unsignaled-completions/
+  // "How to use Unsignaled Completion?" / "Gotchas and Pitfalls"
+  // All posted Send Requested, Signaled and Unsignaled, are considered outstanding until
+  // a Work Completion that they, or Send Requests that were posted after them, was polled
+  // from the Completion Queue associated with the Send Queue. This means if one works with
+  // a Queue Pair that was configured to work with Unsignaled Completions, he must make
+  // sure that occasionally (before the Send Queue is full with outstanding Send Requests)
+  // a Send Request that generate Work Completion will be posted.
+  //
+  // Not following this rule may lead to a case that the Send Queue is full with Send
+  // Requests that won't generate Work Completion:
+  //
+  //  - The Send Queue is full, so no new Send Requests can be posted to it
+  //  - The Send Queue can't be emptied, since no Work Completion can be generated anymore
+  //    (the reason is that no Work Completion, that can generate Work Completion that
+  //    polling it will empty the Send Queue, can be posted)
+  //  - The status of all posted Send Request is considered unknown
+  //
+  // slot == devIndex - When writing to fifo slot N, and this QP lives on device index N, it should send signalled.
+  // This works out that each fifo posting QP gets drained
+  if (slot == ctsQp->devIndex) {
+    wr.send_flags |= IBV_SEND_SIGNALED;
+    wr.wr_id = req - comm->base.reqs;
+    ncclIbAddEvent(req, ctsQp->devIndex, &comm->devs[ctsQp->devIndex].base, true);
+  }
+
+  struct ibv_send_wr* bad_wr;
+  NCCLCHECK(wrap_ibv_post_send(ctsQp->qp, &wr, &bad_wr));
+
+  TRACE(NCCL_VERBS, "Posted send wr_id=%lu, wr_indx=%d, qp_num=%d, src_nic=%d, dst_nic=%d, dlid=%lu, opcode=%d, send_flags=%d, imm_data=%d, remote_addr=%lx, rkey=%x, length=%d, lkey=%x",
+        wr.wr_id, 0, ctsQp->qp->qp_num, comm->devs[ctsQp->devIndex].base.ibDevN, comm->base.remDevs[ctsQp->remDevIdx].ibv_dev_index, comm->base.remDevs[ctsQp->remDevIdx].lid,
+        wr.opcode, wr.send_flags, wr.imm_data, wr.wr.rdma.remote_addr, wr.wr.rdma.rkey, wr.sg_list ? wr.sg_list->length : 0, wr.sg_list ? wr.sg_list->lkey : 0);
+
+  comm->remFifo.fifoTail++;
+
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request) {
+  struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
+  if (comm->base.ready == 0) { WARN("NET/IB: ncclIbIrecv() called when comm->base.ready == 0"); return ncclInternalError; }
+  if (comm->base.ready == 0) { *request = NULL; return ncclSuccess; }
+  if (n > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
+  NCCLCHECK(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__));
+
+  struct ncclIbRequest* req;
+  NCCLCHECK(ncclIbGetRequest(&comm->base, &req));
+  req->type = NCCL_NET_IB_REQ_RECV;
+  req->sock = &comm->base.sock;
+  req->nreqs = n;
+#ifdef NCCL_ENABLE_NET_PROFILING
+  for (int r = 0; r < n && phandles; r++) req->pInfo[r].nEventHandles = 0;
+#endif
+
+  for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+    req->devBases[i] = &comm->devs[i].base;
+  }
+
+  struct ibv_recv_wr wr;
+  memset(&wr, 0, sizeof(wr));
+  wr.sg_list = NULL;
+  wr.num_sge = 0;
+
+  TIME_START(1);
+
+  // Post recvs
+  struct ibv_recv_wr* bad_wr;
+  for (int i = 0; i < comm->base.nqps; i++) {
+    struct ncclIbQp* qp = comm->base.qps + comm->base.qpIndex;
+    ncclIbAddEvent(req, qp->devIndex, &comm->devs[qp->devIndex].base, false);
+    if (comm->base.rxPosts[comm->base.qpIndex] < MAX_REQUESTS) {
+      wr.wr_id = comm->base.qpIndex;
+      NCCLCHECK(wrap_ibv_post_recv(qp->qp, &wr, &bad_wr));
+      comm->base.rxPosts[comm->base.qpIndex]++;
+    }
+
+#ifdef NCCL_ENABLE_NET_PROFILING
+    // Start a QP event for every request in the multirecv and every qp
+    for (int r = 0; r < n && phandles; r++) {
+      // Store info for profiler
+      int pluginId = NCCL_PROFILER_NET_TYPE_IB | NCCL_PROFILER_NET_IB_VER;
+      req->pInfo[r].data.type = ncclProfileQp;
+      req->pInfo[r].data.qp.device = qp->devIndex;
+      req->pInfo[r].data.qp.wr_id = wr.wr_id;
+      req->pInfo[r].data.qp.qpNum = qp->qp->qp_num;
+      NCCLCHECK(ncclProfilerFunction(&req->pInfo[r].qpEventHandles[i], 0, phandles[r], pluginId, &req->pInfo[r].data));
+      req->pInfo[r].nEventHandles++;
+    }
+#endif
+    comm->base.qpIndex = (comm->base.qpIndex+1)%comm->base.nqps;
+  }
+
+  TIME_STOP(1);
+
+  // Post to FIFO to notify sender
+  TIME_START(2);
+  NCCLCHECK(ncclIbPostFifo(comm, n, data, sizes, tags, mhandles, req));
+  TIME_STOP(2);
+
+  *request = req;
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request) {
+  struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
+  int last = -1;
+  for (int i=0; i<n; i++) if (sizes[i]) last = i;
+  if (comm->flushEnabled == 0 || last == -1) return ncclSuccess;
+
+  // Only flush once using the last non-zero receive
+  struct ncclIbRequest* req;
+  NCCLCHECK(ncclIbGetRequest(&comm->base, &req));
+  req->type = NCCL_NET_IB_REQ_FLUSH;
+  req->sock = &comm->base.sock;
+  struct ncclIbMrHandle* mhandle = (struct ncclIbMrHandle*) mhandles[last];
+
+  // We don't know which devIndex the recv was on, so we flush on all devices
+  for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+    struct ibv_send_wr wr;
+    memset(&wr, 0, sizeof(wr));
+    wr.wr_id = req - comm->base.reqs;
+    if (rcclParamIbGdrFlushGpuMemNoRelaxedOrdering()) {
+      wr.wr.rdma.remote_addr = (uint64_t)(comm->devs[i].gpuFlush.gpuFlushGpuMem);
+      wr.wr.rdma.rkey = comm->devs[i].gpuFlush.gpuMr->rkey;
+      wr.sg_list = &comm->devs[i].gpuFlush.sge;
+      wr.num_sge = 1;
+      wr.opcode = IBV_WR_RDMA_WRITE;
+      wr.send_flags = 0;
+      struct ibv_send_wr* bad_wr;
+      NCCLCHECK(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr));
+    }
+    memset(&wr, 0, sizeof(wr));
+    wr.wr_id = req - comm->base.reqs;
+    if (rcclParamIbGdrFlushGpuMemNoRelaxedOrdering()) {
+      wr.wr.rdma.remote_addr = (uint64_t)(comm->devs[i].gpuFlush.gpuFlushGpuMem);
+      wr.wr.rdma.rkey = comm->devs[i].gpuFlush.gpuMr->rkey;
+    } else {
+      wr.wr.rdma.remote_addr = (uint64_t)data[last];
+      wr.wr.rdma.rkey = mhandle->mrs[i]->rkey;
+    }
+    wr.sg_list = &comm->devs[i].gpuFlush.sge;
+    wr.num_sge = 1;
+    wr.opcode = IBV_WR_RDMA_READ;
+    wr.send_flags = IBV_SEND_SIGNALED;
+
+    TIME_START(4);
+    struct ibv_send_wr* bad_wr;
+    NCCLCHECK(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr));
+    TIME_STOP(4);
+
+    ncclIbAddEvent(req, i, &comm->devs[i].base, false);
+  }
+
+  *request = req;
+  return ncclSuccess;
+}
+
+#define HCA_NAME(req, index) ((req)->devBases[(index)]->pd->context->device->name)
+
+#ifdef NCCL_ENABLE_NET_PROFILING
+static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
+  for (int i = 0; i < MAX_QPS_PER_REQ; i++) {
+    int qpIndex = req->pInfo[request].qpIndex[i];
+    if (req->base->qps[qpIndex].qp->qp_num == qpNumber) return i;
+  }
+  return 0;
+}
+#endif
+
+ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
+  struct ncclIbRequest *r = (struct ncclIbRequest*)request;
+  *done = 0;
+  while (1) {
+    NCCLCHECK(ncclIbStatsCheckFatalCount(&r->base->stats,__func__));
+    if (r->events[0] == 0 && r->events[1] == 0 && r->events[2] == 0 && r->events[3] == 0) {
+      TRACE(NCCL_NET, "r=%p done", r);
+      *done = 1;
+      if (sizes && r->type == NCCL_NET_IB_REQ_RECV) {
+        for (int i=0; i<r->nreqs; i++) {
+          sizes[i] = r->recv.sizes[i];
+#ifdef NCCL_ENABLE_NET_PROFILING
+          for (int j = 0; j < r->pInfo[i].nEventHandles; j++) {
+            NCCLCHECK(ncclProfilerFunction(&r->pInfo[i].qpEventHandles[j], 1, NULL, 0, NULL));
+          }
+#endif
+        }
+      }
+      if (sizes && r->type == NCCL_NET_IB_REQ_SEND) {
+        sizes[0] = r->send.size;
+#ifdef NCCL_ENABLE_NET_PROFILING
+        for (int j = 0; j < r->pInfo[0].nEventHandles; j++) {
+          NCCLCHECK(ncclProfilerFunction(&r->pInfo[0].qpEventHandles[j], 1, NULL, 0, NULL));
+        }
+#endif
+      }
+      // Stop all remaining Qp events for this event
+      NCCLCHECK(ncclIbFreeRequest(r));
+      return ncclSuccess;
+    }
+
+    int totalWrDone = 0;
+    int wrDone = 0;
+    struct ibv_wc wcs[4];
+
+    for (int i = 0; i < NCCL_IB_MAX_DEVS_PER_NIC; i++) {
+      TIME_START(3);
+      // If we expect any completions from this device's CQ
+      if (r->events[i]) {
+        NCCLCHECK(wrap_ibv_poll_cq(r->devBases[i]->cq, 4, wcs, &wrDone));
+        totalWrDone += wrDone;
+        if (wrDone == 0) { TIME_CANCEL(3); } else { TIME_STOP(3); }
+        if (wrDone == 0) continue;
+        for (int w=0; w<wrDone; w++) {
+          struct ibv_wc *wc = wcs+w;
+          if (wc->status != IBV_WC_SUCCESS) {
+            union ncclSocketAddress addr;
+            ncclSocketGetAddr(r->sock, &addr);
+            char localGidString[INET6_ADDRSTRLEN] = "";
+            char remoteGidString[INET6_ADDRSTRLEN] = "";
+            const char* localGidStr = NULL, *remoteGidStr = NULL;
+            if (r->devBases[i]->gidInfo.link_layer == IBV_LINK_LAYER_ETHERNET) {
+              localGidStr = ibvGetGidStr(&r->devBases[i]->gidInfo.localGid, localGidString, sizeof(localGidString));
+              remoteGidStr = ibvGetGidStr(&r->base->remDevs[i].remoteGid, remoteGidString, sizeof(remoteGidString));
+            }
+
+            char line[SOCKET_NAME_MAXLEN+1];
+            char *hcaName = r->devBases[i]->pd->context->device->name;
+            WARN("NET/IB: Got completion from peer %s with status=%d opcode=%d len=%u vendor err %u (%s)%s%s%s%s hca %s",
+                ncclSocketToString(&addr, line), wc->status, wc->opcode, wc->byte_len, wc->vendor_err, reqTypeStr[r->type],
+                localGidStr ?  " localGid ":"", localGidString, remoteGidStr ? " remoteGids":"", remoteGidString, hcaName);
+            return ncclRemoteError;
+          }
+
+          union ncclSocketAddress addr;
+          ncclSocketGetAddr(r->sock, &addr);
+
+          uint64_t wrId;
+          struct ncclIbRemapWrId localRemapWrId;
+          // memset is to eliminate gcc "may be uninitialized" warning
+          memset(&localRemapWrId, 0, sizeof(struct ncclIbRemapWrId));
+          if (r->type == NCCL_NET_IB_REQ_SEND) {
+            struct ncclIbRemapWrId *remapWrId;
+
+            remapWrId = (struct ncclIbRemapWrId *) wc->wr_id;
+            localRemapWrId = *remapWrId;
+            wrId = remapWrId->origWrId;
+            ncclIbFreeRemap(remapWrId);
+          } else
+            wrId = wc->wr_id;
+
+          struct ncclIbRequest* req;
+          if (wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
+            req = r->base->reqs +
+                  ((wc->imm_data >> WR_IMM_RX_REQ_IDX_SHIFT) & WR_IMM_RX_REQ_IDX_MASK);
+    }
+          else
+            req = r->base->reqs+(wrId & 0xff);
+
+          #ifdef ENABLE_TRACE
+          char line[SOCKET_NAME_MAXLEN+1];
+          TRACE(NCCL_NET, "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=%lu r=%p type=%d events={%d,%d}, i=%d",
+              ncclSocketToString(&addr, line), wc->status, wc->opcode,wc->byte_len, wrId, req, req->type, req->events[0], req->events[1], i);
+          #endif
+          if (req->type == NCCL_NET_IB_REQ_SEND) {
+            for (int j = 0; j < req->nreqs; j++) {
+              struct ncclIbRequest* sendReq = r->base->reqs+((wrId >> (j*8)) & 0xff);
+              if ((sendReq->events[i] <= 0)) {
+                WARN("NET/IB: sendReq(%p)->events={%d,%d}, i=%d, j=%d <= 0", sendReq, sendReq->events[0], sendReq->events[1], i, j);
+                return ncclInternalError;
+              }
+
+              if (localRemapWrId.parms.enable)
+                updateQpTxStats(&localRemapWrId, r->base);
+
+              sendReq->events[i]--;
+#ifdef NCCL_ENABLE_NET_PROFILING
+              // Stop Qp event for sendReq
+              NCCLCHECK(ncclProfilerFunction(&sendReq->pInfo[j].qpEventHandles[getReqQpIndex(sendReq, j, wc->qp_num)], 1, NULL, 0, NULL));
+#endif
+            }
+          } else {
+            if (wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
+              if (req->type != NCCL_NET_IB_REQ_RECV) {
+                WARN("NET/IB: wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM and req->type=%d", req->type);
+                return ncclInternalError;
+              }
+              if (req->nreqs == 1)
+                req->recv.sizes[0] += (wc->imm_data & WR_IMM_SIZE_MASK);
+              int qpIndex = (int) wrId;
+              r->base->rxPosts[qpIndex]--;
+              if (wc->imm_data & WR_IMM_SPLIT_DATA_FLAG)
+                req->events[i]--;
+              else {
+                req->events[0] = req->ctsEvents[0];
+                req->events[1] = req->ctsEvents[1];
+              }
+            } else if (wc->opcode == IBV_WC_RDMA_WRITE) {
+              req->events[i]--;
+              req->ctsEvents[i]--;
+            } else
+              req->events[i]--;
+#ifdef NCCL_ENABLE_NET_PROFILING
+            // Stop Qp event for workFifo
+            for (int j = 0; j < req->nreqs; j++) {
+              NCCLCHECK(ncclProfilerFunction(&req->pInfo[j].qpEventHandles[getReqQpIndex(req, j, wc->qp_num)], 1, NULL, 0, NULL));
+            }
+#endif
+          }
+        }
+        // Once the IB fatal event is reported in the async thread, we want to propagate this error
+        // to communicator and prevent further polling to reduce error pollution.
+        NCCLCHECK(ncclIbStatsCheckFatalCount(&ncclIbDevs[r->devBases[i]->ibDevN].stats,__func__));
+      }
+    }
+
+    // If no CQEs found on any device, return and come back later
+    if (totalWrDone == 0) return ncclSuccess;
+  }
+}
+
+ncclResult_t ncclIbCloseSend(void* sendComm) {
+  struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
+  if (comm) {
+    NCCLCHECK(ncclSocketClose(&comm->base.sock));
+
+    for (int q = 0; q < comm->base.nqps; q++)
+      if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
+
+    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+      struct ncclIbSendCommDev* commDev = comm->devs + i;
+      if (commDev->fifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->fifoMr));
+      if (comm->remSizesFifo.mrs[i] != NULL) NCCLCHECK(wrap_ibv_dereg_mr(comm->remSizesFifo.mrs[i]));
+      NCCLCHECK(ncclIbDestroyBase(&commDev->base));
+    }
+    free(comm);
+  }
+  TIME_PRINT("IB");
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbCloseRecv(void* recvComm) {
+  struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
+  if (comm) {
+    NCCLCHECK(ncclSocketClose(&comm->base.sock));
+
+    for (int q = 0; q < comm->base.nqps; q++)
+      if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
+
+    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+      struct ncclIbRecvCommDev* commDev = comm->devs + i;
+      if (comm->flushEnabled) {
+        if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
+          NCCLCHECK(ncclCudaFree(commDev->gpuFlush.gpuFlushGpuMem));
+          commDev->gpuFlush.gpuFlushGpuMem = nullptr;
+          if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
+          commDev->gpuFlush.gpuMr = nullptr;
+          if(commDev->gpuFlush.dmabuf_fd > 0) { close(commDev->gpuFlush.dmabuf_fd);}
+        }
+        if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
+        if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
+      }
+      if (commDev->fifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->fifoMr));
+      if (commDev->sizesFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->sizesFifoMr));
+      NCCLCHECK(ncclIbDestroyBase(&commDev->base));
+    }
+    free(comm);
+  }
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbCloseListen(void* listenComm) {
+  struct ncclIbListenComm* comm = (struct ncclIbListenComm*)listenComm;
+  if (comm) {
+    NCCLCHECK(ncclSocketClose(&comm->sock));
+    free(comm);
+  }
+  return ncclSuccess;
+}
+
+volatile ncclNet_v10_t ncclNetPlugin_v10 = {
+  "IB_BNXT",
+  ncclIbInit,
+  ncclIbDevices,
+  ncclIbGetProperties,
+  ncclIbListen,
+  ncclIbConnect,
+  ncclIbAccept,
+  ncclIbRegMr,
+  ncclIbRegMrDmaBuf,
+  ncclIbDeregMr,
+  ncclIbIsend,
+  ncclIbIrecv,
+  ncclIbIflush,
+  ncclIbTest,
+  ncclIbCloseSend,
+  ncclIbCloseRecv,
+  ncclIbCloseListen,
+  NULL /* getDeviceMr */,
+  NULL /* irecvConsumed */,
+  ncclIbMakeVDevice
+};
+
+/*
+  ncclIbSetProperties,
+  ncclIbRefreshDevices
+*/

--- a/projects/rccl/ext-net/brcm-cast-plugin/net_ib_bnxt.cc
+++ b/projects/rccl/ext-net/brcm-cast-plugin/net_ib_bnxt.cc
@@ -926,7 +926,8 @@ ncclResult_t ncclIbInit(ncclDebugLogger_t logFunction, ncclProfilerCallback_t pr
     if (ncclNIbDevs == -1) {
       ncclNIbDevs = 0;
       ncclNMergedIbDevs = 0;
-      if (ncclFindInterfaces(ncclIbIfName, &ncclIbIfAddr, MAX_IF_NAME_SIZE, 1) != 1) {
+      int nIfs;
+      if (ncclFindInterfaces(ncclIbIfName, &ncclIbIfAddr, MAX_IF_NAME_SIZE, 1, &nIfs) != ncclSuccess || nIfs != 1) {
         WARN("NET/IB : No IP interface found.");
         ret = ncclInternalError;
         goto fail;
@@ -2133,9 +2134,9 @@ ib_recv:
     if (rComm->flushEnabled) {
       if (rcclParamIbGdrFlushGpuMemNoRelaxedOrdering()) {
 #if defined(HIP_UNCACHED_MEMORY)
-        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), nullptr, hipDeviceMallocUncached), ret, fail);
+        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), hipDeviceMallocUncached), ret, fail);
 #else
-        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), nullptr, hipDeviceMallocFinegrained), ret, fail);
+        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), hipDeviceMallocFinegrained), ret, fail);
 #endif
         if (useDmaBuf)
         {

--- a/projects/rccl/ext-net/brcm-cast-plugin/net_plugin_tuner_api.h
+++ b/projects/rccl/ext-net/brcm-cast-plugin/net_plugin_tuner_api.h
@@ -1,0 +1,44 @@
+/*************************************************************************
+ * Copyright (c) 2025-2026 Broadcom. The term "Broadcom" refers solely to the Broadcom Inc. corporate affiliate that distributes this software. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#pragma once 
+
+#include <stdint.h>
+
+#define NET_PLUGIN_API	"ncclTunerPluginNotify"
+
+struct ncclIbQpSchedParms {
+  bool enable;
+  bool wrrEnable;
+  uint64_t updateInterval; // in nsec
+  uint64_t resetInterval;  // in nsec
+  double weightNew;        // fractional weight applied to most recent RTT sample
+  uint32_t splitDataMin;   // in bytes
+  bool splitData;          // init from NCCL_IB_SPLIT_DATA_ON_QPS
+  bool doWrr;
+  bool resetRtt;
+  bool logEnable;
+  uint64_t logInterval;    // in nsec
+};
+
+struct tunerSchedParms {
+  ncclFunc_t collType;
+  size_t msgSz;
+  bool match;
+  bool enableValid;
+  bool wrrEnableValid;
+  bool updateIntervalValid;
+  bool resetIntervalValid;
+  bool weightNewValid;
+  bool splitDataValid;
+  bool splitDataMinValid;
+  bool collResetRtt;
+  bool msgSzResetRtt;
+  struct ncclIbQpSchedParms parms;
+};
+
+typedef void (*netTunerPluginNotifyApi)(struct tunerSchedParms *tunerParms);
+


### PR DESCRIPTION
## Adding Broadcom CAST network plugin

_Broadcom's Congestion Aware Sprayed Traffic (CAST) feature is implemented using CAST net plugin_

Why were the changes made?
_An implementation of QP Load Balance (LB) Scheduling that provides performance improvements over typical QP Load Balancing._

How was the outcome achieved?
_The idea is to use Round Trip Time (RTT) measurements to schedule more traffic over the QPs that are experiencing the least congestion._

Additional Documentation:
Refer README.md


Labels: project: rccl
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


