### PR TITLE
[ROCM-2349] missing clock output unit and value in json

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -1518,8 +1518,8 @@ class AMDSMICommands():
                         if frequencies["num_supported"] != 0:
                             for level in range(len(frequencies['frequency'])):
                                 if frequencies['frequency'][level] != "N/A":
-                                    freq = str(self.helpers.convert_SI_unit(frequencies['frequency'][level], AMDSMIHelpers.SI_Unit.MICRO)) + " MHz"
-                                    freq_dict['frequency_levels'].update({f"Level {level}":freq})
+                                    freq = str(self.helpers.convert_SI_unit(frequencies['frequency'][level], AMDSMIHelpers.SI_Unit.MICRO))
+                                    freq_dict['frequency_levels'].update({f"Level {level}":{'value': freq, 'unit': 'MHz'}})
                                 else:
                                     freq_dict['frequency_levels'].update({f"Level {level}":"N/A"})
                         else:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -1218,7 +1218,7 @@ class AMDSMILogger():
 
             temp = gpu_info['temp']
             if temp != "N/A":
-                temp = str(temp) + " C"
+                temp = str(temp) + " \N{DEGREE SIGN}C"
             temp = temp.rjust(6)
 
             u_ecc = str(gpu_info['uncorr_ecc']).ljust(5)

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -1218,7 +1218,7 @@ class AMDSMILogger():
 
             temp = gpu_info['temp']
             if temp != "N/A":
-                temp = str(temp) + " \u00b0C"
+                temp = str(temp) + " C"
             temp = temp.rjust(6)
 
             u_ecc = str(gpu_info['uncorr_ecc']).ljust(5)


### PR DESCRIPTION
## Motivation
In json clock output, make each output entry have a value and unit field

## JIRA ID
[ROCM-2349] amd-smi --json clock output missing unit and value properties



[ROCM-2349]: https://amd-hub.atlassian.net/browse/ROCM-2349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ