### PR TITLE
rocr: Optimize SDMA multi-producer hot path for reduced contention and overhead

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_sdma.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_sdma.h
@@ -377,6 +377,16 @@ template <bool useGCR> class BlitSdma : public BlitSdmaBase {
   /// Minimum submission size in bytes.
   size_t min_submission_size_;
 
+  /// Cached at init to avoid pointer chasing in the hot path.
+  bool needs_kmt_doorbell_;
+  bool sdma_wait_idle_;
+  bool is_dxg_;
+  bool enable_sdma_hdp_flush_;
+  bool sw_poll_workaround_;
+  volatile uint64_t* queue_wptr_;
+  volatile uint64_t* queue_rptr_;
+  volatile uint64_t* queue_doorbell_;
+
   /// True if SDMA supports broadcast linear copy (one src -> two dst).
   bool broadcast_supported_;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -119,6 +119,14 @@ BlitSdma<useGCR>::BlitSdma()
       gang_leader_(false),
       is_ganged_(false),
       min_submission_size_(0),
+      needs_kmt_doorbell_(false),
+      sdma_wait_idle_(false),
+      is_dxg_(false),
+      enable_sdma_hdp_flush_(false),
+      sw_poll_workaround_(false),
+      queue_wptr_(nullptr),
+      queue_rptr_(nullptr),
+      queue_doorbell_(nullptr),
       broadcast_supported_(false),
       multicast_supported_(false) {
   std::memset(&queue_resource_, 0, sizeof(queue_resource_));
@@ -212,8 +220,26 @@ hsa_status_t BlitSdma<useGCR>::Initialize(const core::Agent& agent, bool use_xgm
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
-  cached_reserve_index_ = *reinterpret_cast<uint64_t*>(queue_resource_.Queue_write_ptr);
+  // Cache MMIO pointers to avoid repeated struct access + reinterpret_cast in hot paths.
+  queue_wptr_ = reinterpret_cast<volatile uint64_t*>(queue_resource_.Queue_write_ptr);
+  queue_rptr_ = reinterpret_cast<volatile uint64_t*>(queue_resource_.Queue_read_ptr);
+  queue_doorbell_ = reinterpret_cast<volatile uint64_t*>(queue_resource_.Queue_DoorBell);
+
+  cached_reserve_index_ = *queue_wptr_;
   cached_commit_index_ = cached_reserve_index_;
+
+  // Cache platform/flag checks to avoid pointer chasing in the hot path.
+  is_dxg_ = core::Runtime::runtime_singleton_->thunkLoader()->IsDXG();
+  needs_kmt_doorbell_ = is_dxg_ ||
+                        core::Runtime::runtime_singleton_->thunkLoader()->IsDTIF();
+  sdma_wait_idle_ = core::Runtime::runtime_singleton_->flag().sdma_wait_idle();
+  enable_sdma_hdp_flush_ = core::Runtime::runtime_singleton_->flag().enable_sdma_hdp_flush();
+
+  // Cache gfx90x SW poll workaround flag to avoid static-local guard overhead
+  // on every SubmitCommand call.
+  sw_poll_workaround_ = agent_->supported_isas()[0]->GetMajorVersion() == 9 &&
+                        agent_->supported_isas()[0]->GetMinorVersion() == 0 &&
+                        agent_->supported_isas()[0]->GetStepping() != 10;
 
   if (core::g_use_interrupt_wait) {
     signals_[0].reset(new core::InterruptSignal(0));
@@ -371,11 +397,7 @@ hsa_status_t BlitSdma<useGCR>::SubmitCommand(const void* cmd, size_t cmd_size, u
   // polled memory is cleared. Use SetAsyncSignalHandler to poll the signal signal
   // value on host-side. Once all the dependent signals are cleared, DepSignalCompleteHandler
   // will call SubmitCommand(..) again without any dependent-signals.
-  static bool swPollWorkaround = agent_->supported_isas()[0]->GetMajorVersion() == 9 &&
-                                 agent_->supported_isas()[0]->GetMinorVersion() == 0 &&
-                                 agent_->supported_isas()[0]->GetStepping() != 10;
-
-  if (swPollWorkaround && num_poll_signals) {
+  if (sw_poll_workaround_ && num_poll_signals) {
     CommandCallBackData* callbackArgs =
       new CommandCallBackData(cmd, cmd_size, size, num_poll_signals, out_signal, gang_signals, this);
 
@@ -440,7 +462,7 @@ hsa_status_t BlitSdma<useGCR>::SubmitCommand(const void* cmd, size_t cmd_size, u
 
   // Add space for acquire or release Hdp flush command
   uint32_t flush_cmd_size = 0;
-  if (core::Runtime::runtime_singleton_->flag().enable_sdma_hdp_flush()) {
+  if (enable_sdma_hdp_flush_) {
     if (hdp_flush_support_) {
       flush_cmd_size = flush_command_size_;
     }
@@ -453,7 +475,7 @@ hsa_status_t BlitSdma<useGCR>::SubmitCommand(const void* cmd, size_t cmd_size, u
       total_timestamp_command_size + interrupt_command_size + flush_cmd_size + total_gang_command_size;
   const uint32_t pad_size = total_command_size < min_submission_size_ ?
                             min_submission_size_ - total_command_size :
-                            core::Runtime::runtime_singleton_->thunkLoader()->IsDXG() ?
+                            is_dxg_ ?
                               AlignUp(total_command_size, 64) - total_command_size : 0;
 
   uint64_t curr_index;
@@ -499,7 +521,7 @@ hsa_status_t BlitSdma<useGCR>::SubmitCommand(const void* cmd, size_t cmd_size, u
   }
 
   // Issue a Hdp flush cmd
-  if (core::Runtime::runtime_singleton_->flag().enable_sdma_hdp_flush()) {
+  if (enable_sdma_hdp_flush_) {
     if (hdp_flush_support_) {
       BuildHdpFlushCommand(command_addr);
       command_addr += flush_command_size_;
@@ -985,10 +1007,14 @@ hsa_status_t BlitSdma<useGCR>::SubmitLinearCopyCommand(void* dst, const void* sr
                                kMaxSingleCopySize;
   const uint32_t num_copy_command = (size + max_copy_size - 1) / max_copy_size;
 
-  std::vector<SDMA_PKT_COPY_LINEAR> buff(num_copy_command);
-  BuildCopyCommand(reinterpret_cast<char*>(&buff[0]), num_copy_command, dst, src, size);
+  // Avoid heap allocation for common single-packet case.
+  SDMA_PKT_COPY_LINEAR stack_buff;
+  std::vector<SDMA_PKT_COPY_LINEAR> heap_buff(num_copy_command > 1 ? num_copy_command : 0);
+  auto* buff = num_copy_command <= 1 ? &stack_buff : heap_buff.data();
 
-  return SubmitBlockingCommand(&buff[0], buff.size() * sizeof(SDMA_PKT_COPY_LINEAR), size);
+  BuildCopyCommand(reinterpret_cast<char*>(buff), num_copy_command, dst, src, size);
+
+  return SubmitBlockingCommand(buff, num_copy_command * sizeof(SDMA_PKT_COPY_LINEAR), size);
 }
 
 template <bool useGCR>
@@ -1002,11 +1028,14 @@ hsa_status_t BlitSdma<useGCR>::SubmitLinearCopyCommand(void* dst, const void* sr
                                kMaxSingleCopySize;
   const uint32_t num_copy_command = (size + max_copy_size - 1) / max_copy_size;
 
-  // Assemble copy packets.
-  std::vector<SDMA_PKT_COPY_LINEAR> buff(num_copy_command);
-  BuildCopyCommand(reinterpret_cast<char*>(&buff[0]), num_copy_command, dst, src, size);
+  // Avoid heap allocation for common single-packet case.
+  SDMA_PKT_COPY_LINEAR stack_buff;
+  std::vector<SDMA_PKT_COPY_LINEAR> heap_buff(num_copy_command > 1 ? num_copy_command : 0);
+  auto* buff = num_copy_command <= 1 ? &stack_buff : heap_buff.data();
 
-  return SubmitCommand(&buff[0], buff.size() * sizeof(SDMA_PKT_COPY_LINEAR), size, dep_signals,
+  BuildCopyCommand(reinterpret_cast<char*>(buff), num_copy_command, dst, src, size);
+
+  return SubmitCommand(buff, num_copy_command * sizeof(SDMA_PKT_COPY_LINEAR), size, dep_signals,
                        out_signal, gang_signals);
 }
 
@@ -1146,10 +1175,14 @@ hsa_status_t BlitSdma<useGCR>::SubmitLinearFillCommand(void* ptr, uint32_t value
 
   const uint32_t num_fill_command = (size + kMaxSingleFillSize - 1) / kMaxSingleFillSize;
 
-  std::vector<SDMA_PKT_CONSTANT_FILL> buff(num_fill_command);
-  BuildFillCommand(reinterpret_cast<char*>(&buff[0]), num_fill_command, ptr, value, count);
+  // Avoid heap allocation for common single-packet case.
+  SDMA_PKT_CONSTANT_FILL stack_buff;
+  std::vector<SDMA_PKT_CONSTANT_FILL> heap_buff(num_fill_command > 1 ? num_fill_command : 0);
+  auto* buff = num_fill_command <= 1 ? &stack_buff : heap_buff.data();
 
-  return SubmitBlockingCommand(&buff[0], buff.size() * sizeof(SDMA_PKT_CONSTANT_FILL), size);
+  BuildFillCommand(reinterpret_cast<char*>(buff), num_fill_command, ptr, value, count);
+
+  return SubmitBlockingCommand(buff, num_fill_command * sizeof(SDMA_PKT_CONSTANT_FILL), size);
 }
 
 template <bool useGCR> hsa_status_t BlitSdma<useGCR>::EnableProfiling(bool enable) {
@@ -1163,14 +1196,15 @@ char* BlitSdma<useGCR>::AcquireWriteAddress(uint32_t cmd_size, uint64_t& curr_in
     return nullptr;
   }
 
-  while (true) {
-    curr_index = atomic::Load(&cached_reserve_index_, std::memory_order_acquire);
+  curr_index = atomic::Load(&cached_reserve_index_, std::memory_order_acquire);
 
+  while (true) {
     // Check whether a linear region of the requested size is available.
     // If == cmd_size: region is at beginning of ring.
     // If < cmd_size: region intersects end of ring, pad with no-ops and retry.
     if (WrapIntoRing(curr_index + cmd_size) < cmd_size) {
       PadRingToEnd(curr_index);
+      curr_index = atomic::Load(&cached_reserve_index_, std::memory_order_acquire);
       continue;
     }
 
@@ -1180,17 +1214,20 @@ char* BlitSdma<useGCR>::AcquireWriteAddress(uint32_t cmd_size, uint64_t& curr_in
     if (CanWriteUpto(new_index) == false) {
       // Wait for read index to move and try again.
       os::YieldThread();
+      curr_index = atomic::Load(&cached_reserve_index_, std::memory_order_acquire);
       continue;
     }
 
     // Try to reserve this part of the ring.
-    if (atomic::Cas(&cached_reserve_index_, new_index, curr_index, std::memory_order_release) ==
-        curr_index) {
+    uint64_t observed = atomic::Cas(&cached_reserve_index_, new_index, curr_index,
+                                    std::memory_order_release);
+    if (observed == curr_index) {
       return queue_start_addr_ + WrapIntoRing(curr_index);
     }
 
-    // Another thread reserved curr_index, try again.
-    os::YieldThread();
+    // CAS failed -- reuse the observed value directly, skip redundant atomic Load.
+    curr_index = observed;
+    _mm_pause();
   }
 
   return nullptr;
@@ -1202,25 +1239,25 @@ void BlitSdma<useGCR>::UpdateWriteAndDoorbellRegister(uint64_t curr_index, uint6
     // Make sure that the address before ::curr_index is already released.
     // Otherwise the CP may read invalid packets.
     if (atomic::Load(&cached_commit_index_, std::memory_order_acquire) == curr_index) {
-      if (core::Runtime::runtime_singleton_->flag().sdma_wait_idle()) {
+      if (sdma_wait_idle_) {
         // TODO: remove when sdma wpointer issue is resolved.
         // Wait until the SDMA engine finish processing all packets before
         // updating the wptr and doorbell.
-        while (WrapIntoRing(*reinterpret_cast<uint64_t*>(queue_resource_.Queue_read_ptr)) !=
-               WrapIntoRing(curr_index)) {
+        while (WrapIntoRing(*queue_rptr_) != WrapIntoRing(curr_index)) {
           os::YieldThread();
         }
       }
 
       // Update write pointer and doorbell register.
-      *reinterpret_cast<uint64_t*>(queue_resource_.Queue_write_ptr) = new_index;
+      *queue_wptr_ = new_index;
 
-      // Ensure write pointer is visible to GPU before doorbell.
+      // Keep compiler ordering between wptr and doorbell writes. On x86 with
+      // WB/coherent queue state, hardware ordering ensures the device observes
+      // the wptr update before processing the doorbell.
       std::atomic_thread_fence(std::memory_order_release);
 
-      *reinterpret_cast<uint64_t*>(queue_resource_.Queue_DoorBell) = new_index;
-      if (core::Runtime::runtime_singleton_->thunkLoader()->IsDXG() ||
-          core::Runtime::runtime_singleton_->thunkLoader()->IsDTIF()) {
+      *queue_doorbell_ = new_index;
+      if (needs_kmt_doorbell_) {
         HSAKMT_CALL(hsaKmtQueueRingDoorbell(queue_resource_.QueueId, new_index));
       }
 
@@ -1229,7 +1266,14 @@ void BlitSdma<useGCR>::UpdateWriteAndDoorbellRegister(uint64_t curr_index, uint6
     }
 
     // Waiting for another thread to submit preceding commands first.
-    os::YieldThread();
+    // Use mwaitx to efficiently monitor cached_commit_index_ instead of
+    // burning CPU cycles.
+    if (core::g_use_mwaitx) {
+      timer::DoMwaitx(static_cast<int64_t*>(static_cast<void*>(&cached_commit_index_)),
+                      10000, true);
+    } else {
+      os::YieldThread();
+    }
   }
 }
 
@@ -1243,13 +1287,15 @@ void BlitSdma<useGCR>::ReleaseWriteAddress(uint64_t curr_index, uint32_t cmd_siz
   UpdateWriteAndDoorbellRegister(curr_index, curr_index + cmd_size);
 }
 
-template <bool useGCR> void BlitSdma<useGCR>::PadRingToEnd(uint64_t curr_index) {
+template <bool useGCR>
+void BlitSdma<useGCR>::PadRingToEnd(uint64_t curr_index) {
   // Reserve region from here to the end of the ring.
   uint64_t new_index = curr_index + (kQueueSize - WrapIntoRing(curr_index));
 
   // Check whether the engine has finished using this region.
   if (CanWriteUpto(new_index) == false) {
-    // Wait for read index to move and try again.
+    // Engine hasn't freed this region yet.  Pause briefly.
+    _mm_pause();
     return;
   }
 
@@ -1272,7 +1318,7 @@ template <bool useGCR> uint32_t BlitSdma<useGCR>::WrapIntoRing(uint64_t index) {
 
 template <bool useGCR> bool BlitSdma<useGCR>::CanWriteUpto(uint64_t upto_index) {
   // Get/calculate the monotonic read index.
-  uint64_t hw_read_index = *reinterpret_cast<uint64_t*>(queue_resource_.Queue_read_ptr);
+  uint64_t hw_read_index = *queue_rptr_;
 
   // Check whether the read pointer has passed the given index.
   // At most we can submit (kQueueSize - 1) bytes at a time.
@@ -1659,7 +1705,7 @@ template <bool useGCR> void BlitSdma<useGCR>::BuildGCRCommand(char* cmd_addr, bo
 
 template <bool useGCR> uint64_t BlitSdma<useGCR>::PendingBytes() {
   uint64_t commit = atomic::Load(&cached_commit_index_, std::memory_order_acquire);
-  uint64_t hw_read_index = *reinterpret_cast<uint64_t*>(queue_resource_.Queue_read_ptr);
+  uint64_t hw_read_index = *queue_rptr_;
 
   if (commit == hw_read_index) return 0;
   return bytes_queued_ - bytes_written_[WrapIntoRing(hw_read_index)];


### PR DESCRIPTION
## Motivation
Time taken by hot path

## Technical Details
- Reduce PadRingToEnd lock contention: unlock reservation_lock_ around UpdateWriteAndDoorbellRegister spin-wait so other producers can reserve while NOP padding commits.
- Use mwaitx for ordered-commit spin in UpdateWriteAndDoorbellRegister instead of sched_yield(), with fallback when mwaitx is unavailable.
- Cache immutable flags and MMIO pointers at init
- Replace os::YieldThread with _mm_pause in CAS retry loops
- Eliminate redundant atomic Load in AcquireWriteAddress
- Stack-allocate single-packet command buffers in SubmitLinearCopyCommand and SubmitLinearFillCommand to avoid per-call heap allocation.

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
