### PR TITLE
[rocprofiler-compute] Fix --list-blocks and --list-metrics display in profile mode

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -27,7 +27,6 @@ import argparse
 import copy
 import re
 import sys
-import textwrap
 from abc import abstractmethod
 from collections import OrderedDict
 from pathlib import Path
@@ -47,7 +46,6 @@ from utils.logger import (
 )
 from utils.roofline_calc import validate_roofline_csv
 from utils.utils import (
-    get_panel_alias,
     get_uuid,
     impute_counters_iteration_multiplex,
     is_workload_empty,

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -153,42 +153,6 @@ class OmniAnalyze_Base:
         return self._arch_configs
 
     @demarcate
-    def list_metrics(self) -> None:
-        args = self.get_args()
-        arch = args.list_metrics
-
-        if arch not in self.__supported_archs:
-            console_error("analysis", "Unsupported arch")
-        if arch not in self._arch_configs:
-            sys_info = file_io.load_sys_info(f"{args.path[0][0]}/sysinfo.csv")
-            self.generate_configs(
-                arch,
-                args.config_dir,
-                args.list_stats,
-                args.filter_metrics,
-                sys_info.iloc[0],
-            )
-
-        metric_descriptions = {
-            k: v
-            for dfs in self._arch_configs[arch].dfs.values()
-            for k, v in dfs.to_dict().get("Description", {}).items()
-        }
-        for key, value in self._arch_configs[arch].metric_list.items():
-            dot_count = str(key).count(".")
-            indent = "\t" * min(dot_count, 2)
-
-            print(f"{indent}{key} -> {value}\n")
-
-            if dot_count > 1:
-                description = metric_descriptions.get(key, "")
-                if description:
-                    wrapped = textwrap.wrap(description, width=40)
-                    print(f"{indent}" + f"\n{indent}".join(wrapped) + "\n")
-
-        sys.exit(0)
-
-    @demarcate
     def list_torch_operators(self) -> None:
         """
         List PyTorch operators with hierarchy from torch_trace output.
@@ -228,32 +192,6 @@ class OmniAnalyze_Base:
         sys.exit(0)
 
     @demarcate
-    def list_blocks(self) -> None:
-        args = self.get_args()
-        arch = args.list_blocks
-
-        if arch not in self.__supported_archs:
-            console_error("analysis", "Unsupported arch")
-        if arch not in self._arch_configs:
-            sys_info = file_io.load_sys_info(f"{args.path[0][0]}/sysinfo.csv")
-            self.generate_configs(
-                arch,
-                args.config_dir,
-                args.list_stats,
-                args.filter_metrics,
-                sys_info.iloc[0],
-            )
-
-        print(f"{'INDEX':<8} {'BLOCK ALIAS':<16} {'BLOCK NAME'}")
-        panel_alias_dict = {value: key for key, value in get_panel_alias().items()}
-        for key, value in self._arch_configs[arch].metric_list.items():
-            if key.count(".") > 0:
-                continue
-            print(f"{key:<8} {panel_alias_dict[key]:<16} {value}")
-
-        sys.exit(0)
-
-    @demarcate
     def load_options(self, normalization_filter: Optional[str]) -> None:
         args = self.get_args()
         profiling_config = self.get_profiling_config()
@@ -281,11 +219,6 @@ class OmniAnalyze_Base:
         self, normalization_filter: Optional[str] = None
     ) -> OrderedDict[str, schema.Workload]:
         args = self.get_args()
-        if args.list_metrics:
-            self.list_metrics()
-
-        if args.list_blocks:
-            self.list_blocks()
 
         if getattr(args, "list_torch_operators", False):
             self.list_torch_operators()

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -89,6 +89,7 @@ class RocProfCompute:
             self.generate_machine_specs()
 
         self.sanitize()
+        self.handle_list_args()
 
         if self.__mode == "profile":
             self.detect_profiler()
@@ -306,6 +307,29 @@ class RocProfCompute:
         )
         self.__args = parser.parse_args()
 
+        if self.__args.mode == "profile":
+            self.handle_profile_args()
+        elif self.__args.mode == "analyze":
+            self.handle_analyze_args()
+
+    def handle_profile_args(self) -> None:
+        # Handle list operations first - these are independent and exit immediately
+        if getattr(self.__args, "list_sets", False):
+            return
+        if getattr(self.__args, "list_available_metrics", False):
+            return
+
+    def handle_analyze_args(self) -> None:
+        """Handle analyze-specific argument processing"""
+        # Block all filters during spatial-multiplexing
+        if self.__args.spatial_multiplexing:
+            self.__args.gpu_id = None
+            self.__args.gpu_kernel = None
+            self.__args.gpu_dispatch_id = None
+            self.__args.nodes = None
+
+    @demarcate
+    def handle_list_args(self) -> None:
         if self.__args.specs:
             print(generate_machine_specs(self.__args))
             sys.exit(0)
@@ -327,27 +351,6 @@ class RocProfCompute:
             console_error(
                 "rocprof-compute requires you to pass a valid mode. Detected None."
             )
-
-        if self.__args.mode == "profile":
-            self.handle_profile_args()
-        elif self.__args.mode == "analyze":
-            self.handle_analyze_args()
-
-    def handle_profile_args(self) -> None:
-        # Handle list operations first - these are independent and exit immediately
-        if getattr(self.__args, "list_sets", False):
-            return
-        if getattr(self.__args, "list_available_metrics", False):
-            return
-
-    def handle_analyze_args(self) -> None:
-        """Handle analyze-specific argument processing"""
-        # Block all filters during spatial-multiplexing
-        if self.__args.spatial_multiplexing:
-            self.__args.gpu_id = None
-            self.__args.gpu_kernel = None
-            self.__args.gpu_dispatch_id = None
-            self.__args.nodes = None
 
     @demarcate
     def list_metrics(self) -> None:
@@ -377,7 +380,6 @@ class RocProfCompute:
     @demarcate
     def list_blocks(self) -> None:
         for_current_arch = getattr(self.__args, "list_available_metrics", False)
-        console_log(f"for_current_arch: {for_current_arch}")
 
         arch = (
             self.__mspec.gpu_arch

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -352,11 +352,8 @@ class RocProfCompute:
     def list_metrics(self) -> None:
         for_current_arch = getattr(self.__args, "list_available_metrics", False)
 
-        arch = (
-            self.__mspec.gpu_arch
-            if (for_current_arch or self.__args.list_metrics is None)
-            else self.__args.list_metrics
-        )
+        arch = self.__mspec.gpu_arch if for_current_arch else self.__args.list_metrics
+
         if arch in self.__supported_archs.keys():
             ac = schema.ArchConfig()
             ac.panel_configs = file_io.load_panel_configs([
@@ -375,22 +372,14 @@ class RocProfCompute:
 
     @demarcate
     def list_blocks(self) -> None:
-        for_current_arch = getattr(self.__args, "list_available_metrics", False)
+        arch = self.__args.list_blocks
 
-        arch = (
-            self.__mspec.gpu_arch
-            if (for_current_arch or self.__args.list_blocks is None)
-            else self.__args.list_blocks
-        )
         if arch in self.__supported_archs.keys():
             ac = schema.ArchConfig()
             ac.panel_configs = file_io.load_panel_configs([
                 str(Path(self.__args.config_dir) / arch)
             ])
-            sys_info = (
-                self.__mspec.get_class_members().iloc[0] if for_current_arch else None
-            )
-            parser.build_dfs(arch_configs=ac, filter_metrics=[], sys_info=sys_info)
+            parser.build_dfs(arch_configs=ac, filter_metrics=[], sys_info=None)
 
             print(f"{'INDEX':<8} {'BLOCK ALIAS':<16} {'BLOCK NAME'}")
             panel_alias_dict = {value: key for key, value in get_panel_alias().items()}

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -71,6 +71,7 @@ class RocProfCompute:
         self.__version: dict[str, Optional[str]] = {"ver": None, "ver_pretty": None}
         self.__supported_archs = mi_gpu_specs.get_gpu_series_dict()
         self.__mspec: MachineSpecs  # to be initialized in load_soc_specs()
+        self.__parser: argparse.ArgumentParser = argparse.ArgumentParser(add_help=False)
 
         setup_console_handler()
         self.set_version()
@@ -91,12 +92,7 @@ class RocProfCompute:
         self.sanitize()
         self.handle_list_args()
 
-        if self.__args.mode is None:
-            parser.print_help(sys.stderr)
-            console_error(
-                "rocprof-compute requires you to pass a valid mode. Detected None."
-            )
-        elif self.__mode == "profile":
+        if self.__mode == "profile":
             self.detect_profiler()
         elif self.__mode == "analyze":
             self.detect_analyze()
@@ -148,6 +144,15 @@ class RocProfCompute:
             self.__analyze_mode = "cli"
 
     def sanitize(self) -> None:
+        if self.__args.mode is None and not (
+            getattr(self.__args, "list_metrics", False)
+            or getattr(self.__args, "list_blocks", False)
+        ):
+            self.__parser.print_help(sys.stderr)
+            console_error(
+                "rocprof-compute requires you to pass a valid mode. Detected None."
+            )
+
         block = False
         if (hasattr(self.__args, "filter_metrics") and self.__args.filter_metrics) or (
             hasattr(self.__args, "filter_blocks") and self.__args.filter_blocks
@@ -290,7 +295,7 @@ class RocProfCompute:
         experimental_requested: bool = prelim_args.experimental
 
         # Build full parser with experimental knowledge
-        parser = argparse.ArgumentParser(
+        self.__parser = argparse.ArgumentParser(
             description=(
                 "Command line interface for AMD's GPU profiler, ROCm Compute Profiler"
             ),
@@ -301,13 +306,13 @@ class RocProfCompute:
             usage="rocprof-compute [mode] [options]",
         )
         omniarg_parser(
-            parser,
+            self.__parser,
             config.rocprof_compute_home,
             self.__supported_archs,
             self.__version,
             experimental_requested,
         )
-        self.__args = parser.parse_args()
+        self.__args = self.__parser.parse_args()
 
         if self.__args.mode == "profile":
             self.handle_profile_args()

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -449,30 +449,6 @@ class RocProfCompute:
 
         sys.exit(0)
 
-        profiler_classes = {
-            "rocprofv3": (
-                "rocprof_compute_profile.profiler_rocprof_v3",
-                "rocprof_v3_profiler",
-            ),
-            "rocprofiler-sdk": (
-                "rocprof_compute_profile.profiler_rocprofiler_sdk",
-                "rocprofiler_sdk_profiler",
-            ),
-        }
-
-        if self.__profiler_mode not in profiler_classes:
-            console_error("Unsupported profiler")
-
-        module_name, class_name = profiler_classes[self.__profiler_mode]
-        module = importlib.import_module(module_name)
-        profiler_class = getattr(module, class_name)
-
-        return profiler_class(
-            self.__args,
-            self.__profiler_mode,
-            self.__soc[self.__mspec.gpu_arch],
-        )
-
     def create_profiler(self) -> object:
         profiler_classes = {
             "rocprofv3": (

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -484,6 +484,8 @@ class RocProfCompute:
 
         if self.__args.list_sets:
             self.list_sets()
+        elif self.__args.list_available_metrics:
+            self.list_metrics()
 
         # Replace parameters in output directory when either:
         # 1. --output-directory is explicitly given by user
@@ -559,6 +561,9 @@ class RocProfCompute:
             analyzer = db_analysis(self.__args, self.__supported_archs)
         else:
             console_error(f"Unsupported analysis mode -> {self.__analyze_mode}")
+
+        if getattr(self.__args, "list_available_metrics", False):
+            self.list_metrics()
 
         # -----------------------
         # run analysis workflow

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -85,13 +85,23 @@ class RocProfCompute:
         setattr(self.__args, "loglevel", self.__loglevel)
         set_locale_encoding()
 
-        if self.__mode is None or self.__mode == "profile":
+        if self.__mode != "analyze":
             self.generate_machine_specs()
 
         self.sanitize()
         self.handle_list_args()
 
-        if self.__mode == "profile":
+        if self.__args.mode is None:
+            parser.print_help(sys.stderr)
+            if self.__args.config_dir:
+                console_error(
+                    "rocprof-compute requires you to pass --list-metrics "
+                    "or --list-blocks with --config-dir."
+                )
+            console_error(
+                "rocprof-compute requires you to pass a valid mode. Detected None."
+            )
+        elif self.__mode == "profile":
             self.detect_profiler()
         elif self.__mode == "analyze":
             self.detect_analyze()
@@ -254,9 +264,6 @@ class RocProfCompute:
     def generate_machine_specs(self) -> None:
         """Generate MachineSpecs for RocProfCompute"""
         self.__mspec = generate_machine_specs(self.__args)
-        if self.__args and self.__args.specs:
-            print(self.__mspec)
-            sys.exit(0)
 
     @demarcate
     def load_soc_specs(self, sysinfo: Optional[dict] = None) -> None:
@@ -340,17 +347,11 @@ class RocProfCompute:
             self.list_blocks()
             sys.exit(0)
 
-        if self.__args.mode is None:
-            if self.__args.config_dir:
-                parser.print_help(sys.stderr)
-                console_error(
-                    "rocprof-compute requires you to pass --list-metrics "
-                    "with --config-dir."
-                )
-            parser.print_help(sys.stderr)
-            console_error(
-                "rocprof-compute requires you to pass a valid mode. Detected None."
-            )
+        if self.__mode == "profile":
+            if self.__args.list_sets:
+                self.list_sets()
+            elif self.__args.list_available_metrics:
+                self.list_metrics()
 
     @demarcate
     def list_metrics(self) -> None:
@@ -484,11 +485,6 @@ class RocProfCompute:
     def run_profiler(self) -> None:
         self.print_graphic()
 
-        if self.__args.list_sets:
-            self.list_sets()
-        elif self.__args.list_available_metrics:
-            self.list_metrics()
-
         # Replace parameters in output directory when either:
         # 1. --output-directory is explicitly given by user
         # 2. --path and --output-directory are set to default workload directory.
@@ -564,10 +560,6 @@ class RocProfCompute:
         else:
             console_error(f"Unsupported analysis mode -> {self.__analyze_mode}")
 
-        if getattr(self.__args, "list_available_metrics", False):
-            self.generate_machine_specs()
-            self.list_metrics()
-
         # -----------------------
         # run analysis workflow
         # -----------------------
@@ -591,6 +583,9 @@ class RocProfCompute:
                 key: value[0] for key, value in sys_info.to_dict("list").items()
             }
             self.load_soc_specs(sys_info_dict)
+
+        if getattr(self.__args, "list_available_metrics", False):
+            self.list_metrics()
 
         analyzer.set_soc(self.__soc)
         analyzer.pre_processing()

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -93,11 +93,6 @@ class RocProfCompute:
 
         if self.__args.mode is None:
             parser.print_help(sys.stderr)
-            if self.__args.config_dir:
-                console_error(
-                    "rocprof-compute requires you to pass --list-metrics "
-                    "or --list-blocks with --config-dir."
-                )
             console_error(
                 "rocprof-compute requires you to pass a valid mode. Detected None."
             )

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -306,17 +306,18 @@ class RocProfCompute:
         )
         self.__args = parser.parse_args()
 
+        if self.__args.specs:
+            print(generate_machine_specs(self.__args))
+            sys.exit(0)
+        elif self.__args.list_metrics is not None:
+            self.list_metrics()
+            sys.exit(0)
+        elif self.__args.list_blocks is not None:
+            self.list_blocks()
+            sys.exit(0)
+
         if self.__args.mode is None:
-            if self.__args.specs:
-                print(generate_machine_specs(self.__args))
-                sys.exit(0)
-            elif self.__args.list_metrics is not None:
-                self.list_metrics()
-                sys.exit(0)
-            elif self.__args.list_blocks is not None:
-                self.list_blocks()
-                sys.exit(0)
-            elif self.__args.config_dir:
+            if self.__args.config_dir:
                 parser.print_help(sys.stderr)
                 console_error(
                     "rocprof-compute requires you to pass --list-metrics "
@@ -326,7 +327,8 @@ class RocProfCompute:
             console_error(
                 "rocprof-compute requires you to pass a valid mode. Detected None."
             )
-        elif self.__args.mode == "profile":
+
+        if self.__args.mode == "profile":
             self.handle_profile_args()
         elif self.__args.mode == "analyze":
             self.handle_analyze_args()
@@ -480,12 +482,8 @@ class RocProfCompute:
     def run_profiler(self) -> None:
         self.print_graphic()
 
-        if self.__args.list_metrics is not None or self.__args.list_available_metrics:
-            self.list_metrics()
-        elif self.__args.list_sets:
+        if self.__args.list_sets:
             self.list_sets()
-        elif self.__args.list_blocks:
-            self.list_blocks()
 
         # Replace parameters in output directory when either:
         # 1. --output-directory is explicitly given by user

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -85,7 +85,7 @@ class RocProfCompute:
         setattr(self.__args, "loglevel", self.__loglevel)
         set_locale_encoding()
 
-        if self.__mode == "profile":
+        if self.__mode is None or self.__mode == "profile":
             self.generate_machine_specs()
 
         self.sanitize()
@@ -180,6 +180,7 @@ class RocProfCompute:
             self.__args.list_metrics is None
             and not getattr(self.__args, "list_available_metrics", False)
             and not getattr(self.__args, "list_sets", False)
+            and not getattr(self.__args, "list_blocks", False)
         ):
             if self.__args.name is None and self.__args.output_directory == str(
                 Path.cwd() / "workloads"
@@ -374,6 +375,7 @@ class RocProfCompute:
     @demarcate
     def list_blocks(self) -> None:
         for_current_arch = getattr(self.__args, "list_available_metrics", False)
+        console_log(f"for_current_arch: {for_current_arch}")
 
         arch = (
             self.__mspec.gpu_arch
@@ -478,6 +480,13 @@ class RocProfCompute:
     def run_profiler(self) -> None:
         self.print_graphic()
 
+        if self.__args.list_metrics is not None or self.__args.list_available_metrics:
+            self.list_metrics()
+        elif self.__args.list_sets:
+            self.list_sets()
+        elif self.__args.list_blocks:
+            self.list_blocks()
+
         # Replace parameters in output directory when either:
         # 1. --output-directory is explicitly given by user
         # 2. --path and --output-directory are set to default workload directory.
@@ -492,11 +501,6 @@ class RocProfCompute:
             self.__args.path = self.__args.output_directory
 
         self.load_soc_specs()
-
-        if self.__args.list_metrics is not None or self.__args.list_available_metrics:
-            self.list_metrics()
-        elif self.__args.list_sets:
-            self.list_sets()
 
         # instantiate desired profiler
         profiler = self.create_profiler()

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -71,7 +71,7 @@ class RocProfCompute:
         self.__version: dict[str, Optional[str]] = {"ver": None, "ver_pretty": None}
         self.__supported_archs = mi_gpu_specs.get_gpu_series_dict()
         self.__mspec: MachineSpecs  # to be initialized in load_soc_specs()
-        self.__parser: argparse.ArgumentParser = argparse.ArgumentParser(add_help=False)
+        self.__parser: argparse.ArgumentParser  # to be initialized in parse_args()
 
         setup_console_handler()
         self.set_version()
@@ -86,10 +86,11 @@ class RocProfCompute:
         setattr(self.__args, "loglevel", self.__loglevel)
         set_locale_encoding()
 
+        self.sanitize()
+
         if self.__mode != "analyze":
             self.generate_machine_specs()
 
-        self.sanitize()
         self.handle_list_args()
 
         if self.__mode == "profile":

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -563,6 +563,7 @@ class RocProfCompute:
             console_error(f"Unsupported analysis mode -> {self.__analyze_mode}")
 
         if getattr(self.__args, "list_available_metrics", False):
+            self.generate_machine_specs()
             self.list_metrics()
 
         # -----------------------

--- a/projects/rocprofiler-compute/tests/test_analyze_commands.py
+++ b/projects/rocprofiler-compute/tests/test_analyze_commands.py
@@ -171,7 +171,6 @@ def test_list_available_metrics(binary_handler_analyze_rocprof_compute, capsys):
         assert "1 -> System Info" in output
 
 
-
 @pytest.mark.list_metrics
 def test_list_available_metrics_with_block(
     binary_handler_analyze_rocprof_compute, capsys

--- a/projects/rocprofiler-compute/tests/test_analyze_commands.py
+++ b/projects/rocprofiler-compute/tests/test_analyze_commands.py
@@ -81,7 +81,7 @@ def test_list_metrics_gfx90a(binary_handler_analyze_rocprof_compute):
         "--list-metrics",
         "gfx90a",
     ])
-    assert code == 1
+    assert code == 0
 
     for dir in indirs:
         workload_dir = test_utils.setup_workload_dir(dir)
@@ -104,7 +104,7 @@ def test_list_metrics_gfx908(binary_handler_analyze_rocprof_compute):
         "--list-metrics",
         "gfx908",
     ])
-    assert code == 1
+    assert code == 0
 
     for dir in indirs:
         workload_dir = test_utils.setup_workload_dir(dir)
@@ -144,7 +144,7 @@ def test_list_metrics_gfx908_with_block(binary_handler_analyze_rocprof_compute):
         ])
         assert code == 1
 
-    test_utils.clean_output_dir(config["cleanup"], workload_dir)
+        test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 @pytest.mark.list_metrics
@@ -167,10 +167,9 @@ def test_list_available_metrics(binary_handler_analyze_rocprof_compute, capsys):
 
         # Test output
         output = capsys.readouterr().out
-        assert "0. Top Stats" in output
-        assert "1. System Info" in output
+        assert "0 -> Top Stats" in output
+        assert "1 -> System Info" in output
 
-    test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 @pytest.mark.list_metrics
@@ -197,7 +196,7 @@ def test_list_available_metrics_with_block(
         ])
         assert code == 1
 
-    test_utils.clean_output_dir(config["cleanup"], workload_dir)
+        test_utils.clean_output_dir(config["cleanup"], workload_dir)
 
 
 @pytest.mark.filter_block


### PR DESCRIPTION
## Motivation

`--list-blocks` and `--list-metrics` are failing in `profile` and `analyze` mode.

## Technical Details

Remove mode check for general options

## JIRA ID

AIPROFCOMP-199

## Test Plan

- [X] Run ctest

## Test Result

- [x] Pass ctest

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
