### PR TITLE
SWDEV-539306 - rewrite section 'Invalid device pointer' in Unit_TexObjectCreate_TypePitch2D_EdgeCases

### DIFF
--- a/projects/hip-tests/catch/unit/texture/hipTexObjectCreate.cc
+++ b/projects/hip-tests/catch/unit/texture/hipTexObjectCreate.cc
@@ -440,8 +440,7 @@ TEST_CASE("Unit_TexObjectCreate_TypePitch2D_EdgeCases") {
   res_desc.res.pitch2D.height = height;
 
   SECTION("Invalid device pointer") {
-    char handle;
-    res_desc.res.pitch2D.devPtr = reinterpret_cast<hipDeviceptr_t>(&handle);
+    res_desc.res.pitch2D.devPtr = nullptr;
     HIP_CHECK_ERROR(hipTexObjectCreate(&tex_object, &res_desc, &tex_desc, nullptr),
                     hipErrorInvalidValue);
   }


### PR DESCRIPTION
## Motivation

Unit_TexObjectCreate_TypePitch2D_EdgeCases fails on Windows. Blocking PSDBs

## Technical Details

The error is in this section:

```cpp
SECTION("Invalid device pointer") {
    char handle;
    res_desc.res.pitch2D.devPtr = reinterpret_cast<hipDeviceptr_t>(&handle);
    HIP_CHECK_ERROR(hipTexObjectCreate(&tex_object, &res_desc, &tex_desc, nullptr),
                    hipErrorInvalidValue);
  }
``` 

```
Expected Error: invalid argument
      Expected Code: 1
                    Actual Error:   no error
      Actual Code:   0
```

It passes an address pointing to the stack as a device pointer. The `hipTexObjectCreate()` API call does mention hipErrorInvalidValue as a possible error value, but it only checks whether the input pointers are nullptr in the runtime code. Assuming hipTexObjectCreate() to detect all invalid device pointers is the wrong expectation.

For instance, on CUDA 13.0 it does return hipErrorInvalidValue for that test case, but simply passing a pointer beyond tex_buffer pointer does not return hipErrorInvalidValue.

This PR changes pitch2D.devPtr to be nullptr in that section, which will make `hipTexObjectCreate()` guaranteed to return hipInvalidValue, because `ihipImageCreate()` checks for it.

## JIRA ID

SWDEV-539306

## Test Plan

Tested on Navi48.

## Test Result
The section 'Invalid device pointer' passes a hipInvalidValue is returned as expected.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
