### PR TITLE
RCCL: fix ARSMI BDF formatting in amd-smi wrapper

### DIFF
--- a/projects/rccl/src/misc/amdsmi_wrap.cc
+++ b/projects/rccl/src/misc/amdsmi_wrap.cc
@@ -91,7 +91,7 @@ ncclResult_t amd_smi_getNumDevice(uint32_t* num_devs) {
 }
 
 ncclResult_t amd_smi_getDevicePciBusIdString(uint32_t deviceIndex, char* busId, size_t len) {
-  uint64_t id;
+  uint64_t id = 0;
   if (__atomic_load_n(&is_wsl2, __ATOMIC_ACQUIRE)) {
     CUDACHECK(cudaDeviceGetPCIBusId(busId, len, deviceIndex));
   } else {
@@ -114,6 +114,7 @@ ncclResult_t amd_smi_getDevicePciBusIdString(uint32_t deviceIndex, char* busId, 
       std::vector<amdsmi_socket_handle> sockets(socket_count);
       AMDSMICHECK(amdsmi_get_socket_handles(&socket_count, sockets.data()));
 
+      bool found = false;
       for (auto& socket : sockets) {
         uint32_t processor_handle_count = 0;
         AMDSMICHECK(amdsmi_get_processor_handles(socket, &processor_handle_count, nullptr));
@@ -126,29 +127,36 @@ ncclResult_t amd_smi_getDevicePciBusIdString(uint32_t deviceIndex, char* busId, 
         // workaround
         for (auto& proc : processor_handles) {
           processor_type_t type;
-          uint64_t id;
+          uint64_t bdfId = 0;
 
           AMDSMICHECK(amdsmi_get_processor_type(proc, &type));
           if(type == AMDSMI_PROCESSOR_TYPE_AMD_GPU) {
             amdsmi_enumeration_info_t info;
             AMDSMICHECK(amdsmi_get_gpu_enumeration_info(proc, &info));
             if(info.hip_id == deviceIndex) {
-              AMDSMICHECK(amdsmi_get_gpu_bdf_id(proc, &id));
+              AMDSMICHECK(amdsmi_get_gpu_bdf_id(proc, &bdfId));
+              id = bdfId;
+              found = true;
               break;
             }
           }
         }
+        if (found) break;
       }
+      if (!found) {
+        ERROR("amdsmi_lib: could not get BDF for device index %u", deviceIndex);
+        return ncclInternalError;
+      }
+      // borrowing NCCL's format from utils.cc:int64ToBusId
+      // !! To be reconciled after discussion with amdsmi team !!
+      snprintf(busId, len, "%04lx:%02lx:%02lx.%01lx", (id) >> 20, (id & 0xff000) >> 12, (id & 0xff0) >> 4, (id & 0xf));
     } else {
       ARSMICHECK(ARSMI_dev_pci_id_get(deviceIndex, &id));
+      // ARSMI uses the same BDF packing as rocm_smi.
+      // Keep this formatting identical to rocm_smi_wrap to avoid
+      // generating inconsistent PCI IDs in topology XML.
+      snprintf(busId, len, "%04lx:%02lx:%02lx.%01lx", (id) >> 32, (id & 0xff00) >> 8, (id & 0xf8) >> 3, (id & 0x7));
     }
-
-    // rocm-smi/amd-smi format
-    //snprintf(busId, len, "%04lx:%02lx:%02lx.%01lx", (id & 0xffffffff) >> 32, (id & 0xff00) >> 8, (id & 0xf8) >> 3, (id & 0x7));
-
-    // borrowing NCCL's format from utils.cc:int64ToBusId
-    // !! To be reconciled after discussion with amdsmi team !!
-    snprintf(busId, len, "%04lx:%02lx:%02lx.%01lx", (id) >> 20, (id & 0xff000) >> 12, (id & 0xff0) >> 4, (id & 0xf));
   }
   return ncclSuccess;
 }


### PR DESCRIPTION
### Summary

- Addresses tickets - `ROCM-2613` and `AICOMRCCL-557`
- Fixes PCI BDF string formatting in `projects/rccl/src/misc/amdsmi_wrap.cc` for the ARSMI fallback path under `USE_AMDSMI`.
- Keeps amd-smi integration 
- Adds guard for missing BDF lookup in `amd_smi_getDevicePciBusIdString()`.

### Why
 
Topology identity mapping was inconsistent in the ARSMI fallback path, causing RCCL graph search to pick a degraded topology (`crossNic 2`, `nChannels 16`) on gfx942/gfx950.

#### Before
- `Pattern 4, crossNic 2, nChannels 16 ...`
- `Pattern 1 ... type XGMI/SYS ...`
- 16G all-reduce bus BW ~94 GB/s

```bash
RCCL version : 2.28.3-develop:360c5c6
HIP version  : 7.3.53390-490c8d4a00
ROCm version : 7.12.0.2-9999-490c8d4a00-dirty
Hostname     : ctr-cx64-mi300x-4.amd.com
Librccl path : /scratch/users/speriasw/JIRA/AICOMRCCL-557/PR/projects/rccl/build/release/librccl.so.1
#
#                                                              out-of-place                       in-place          
#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong                               
#        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)                                      
        1024           256     float     sum      -1    53.11    0.02    0.04      0    52.91    0.02    0.04      0
        2048           512     float     sum      -1    54.14    0.04    0.07      0    53.42    0.04    0.07      0
        4096          1024     float     sum      -1    55.34    0.07    0.14      0    54.52    0.08    0.14      0
        8192          2048     float     sum      -1    55.39    0.15    0.28      0    56.72    0.14    0.27      0
       16384          4096     float     sum      -1    57.91    0.28    0.53      0    56.73    0.29    0.54      0
       32768          8192     float     sum      -1    61.33    0.53    1.00      0    60.30    0.54    1.02      0
       65536         16384     float     sum      -1    67.69    0.97    1.82      0    61.55    1.06    2.00      0
      131072         32768     float     sum      -1    68.94    1.90    3.57      0    68.34    1.92    3.60      0
      262144         65536     float     sum      -1    83.77    3.13    5.87      0    80.73    3.25    6.09      0
      524288        131072     float     sum      -1    111.6    4.70    8.81      0    111.8    4.69    8.80      0
     1048576        262144     float     sum      -1    162.3    6.46   12.12      0    159.8    6.56   12.30      0
     2097152        524288     float     sum      -1    186.5   11.24   21.08      0    186.9   11.22   21.04      0
     4194304       1048576     float     sum      -1    232.3   18.05   33.85      0    234.3   17.90   33.57      0
     8388608       2097152     float     sum      -1    344.3   24.37   45.69      0    349.6   24.00   44.99      0
    16777216       4194304     float     sum      -1    596.5   28.13   52.74      0    602.8   27.83   52.19      0
    33554432       8388608     float     sum      -1   1102.9   30.42   57.04      0   1106.6   30.32   56.86      0
    67108864      16777216     float     sum      -1   2098.3   31.98   59.97      0   2106.9   31.85   59.72      0
   134217728      33554432     float     sum      -1   2723.3   49.28   92.41      0   2731.4   49.14   92.13      0
   268435456      67108864     float     sum      -1   5392.0   49.78   93.34      0   5669.9   47.34   88.77      0
   536870912     134217728     float     sum      -1    10750   49.94   93.64      0    10754   49.92   93.60      0
  1073741824     268435456     float     sum      -1    21717   49.44   92.71      0    21441   50.08   93.90      0
  2147483648     536870912     float     sum      -1    43099   49.83   93.43      0    42903   50.05   93.85      0
  4294967296    1073741824     float     sum      -1    86023   49.93   93.62      0    85851   50.03   93.80      0
  8589934592    2147483648     float     sum      -1   171201   50.17   94.08      0   170845   50.28   94.27      0
 17179869184    4294967296     float     sum      -1   341566   50.30   94.31      0   341565   50.30   94.31      0
# Errors with asterisks indicate errors that have exceeded the maximum threshold.
# Out of bounds values : 0 OK
# Avg bus bandwidth    : 41.9998 
#
# Collective test concluded: all_reduce_perf
```
 
#### After
- `Pattern 4, crossNic 0, nChannels 64 ...`
- `Pattern 1 ... type XGMI/PXB ...`
- 16G all-reduce bus BW ~355-356 GB/s

```bash
RCCL version : 2.28.3-amdsmi-bdf-topology:360c5c6+
HIP version  : 7.3.53390-490c8d4a00
ROCm version : 7.12.0.2-9999-490c8d4a00-dirty
Hostname     : ctr-cx64-mi300x-4.amd.com
Librccl path : /scratch/users/speriasw/JIRA/AICOMRCCL-557/PR/projects/rccl/build/release/librccl.so.1
#
#                                                              out-of-place                       in-place          
#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong                               
#        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)                                      
        1024           256     float     sum      -1    53.88    0.02    0.04      0    54.23    0.02    0.04      0
        2048           512     float     sum      -1    55.45    0.04    0.07      0    55.55    0.04    0.07      0
        4096          1024     float     sum      -1    56.75    0.07    0.14      0    56.46    0.07    0.14      0
        8192          2048     float     sum      -1    56.66    0.14    0.27      0    56.40    0.15    0.27      0
       16384          4096     float     sum      -1    56.65    0.29    0.54      0    56.89    0.29    0.54      0
       32768          8192     float     sum      -1    60.86    0.54    1.01      0    57.87    0.57    1.06      0
       65536         16384     float     sum      -1    62.18    1.05    1.98      0    62.06    1.06    1.98      0
      131072         32768     float     sum      -1    70.64    1.86    3.48      0    71.43    1.83    3.44      0
      262144         65536     float     sum      -1    86.46    3.03    5.69      0    76.29    3.44    6.44      0
      524288        131072     float     sum      -1    99.31    5.28    9.90      0    104.6    5.01    9.40      0
     1048576        262144     float     sum      -1    99.37   10.55   19.79      0    362.9    2.89    5.42      0
     2097152        524288     float     sum      -1    115.5   18.15   34.03      0    112.5   18.64   34.96      0
     4194304       1048576     float     sum      -1    132.5   31.65   59.35      0    130.4   32.17   60.31      0
     8388608       2097152     float     sum      -1    251.0   33.42   62.65      0    253.2   33.12   62.11      0
    16777216       4194304     float     sum      -1    364.0   46.09   86.41      0    370.7   45.26   84.86      0
    33554432       8388608     float     sum      -1    455.4   73.69  138.17      0    460.3   72.89  136.67      0
    67108864      16777216     float     sum      -1    692.4   96.92  181.73      0    693.5   96.77  181.44      0
   134217728      33554432     float     sum      -1   1321.2  101.59  190.48      0   1100.7  121.94  228.63      0
   268435456      67108864     float     sum      -1   1549.4  173.25  324.84      0   1536.3  174.73  327.61      0
   536870912     134217728     float     sum      -1   2900.2  185.11  347.09      0   2894.0  185.51  347.83      0
  1073741824     268435456     float     sum      -1   5760.8  186.39  349.47      0   5761.6  186.36  349.43      0
  2147483648     536870912     float     sum      -1    11677  183.90  344.82      0    11481  187.04  350.71      0
  4294967296    1073741824     float     sum      -1    22833  188.11  352.70      0    22845  188.01  352.52      0
  8589934592    2147483648     float     sum      -1    45753  187.75  352.02      0    45320  189.54  355.39      0
 17179869184    4294967296     float     sum      -1    91141  188.50  353.43      0    91170  188.44  353.32      0
# Errors with asterisks indicate errors that have exceeded the maximum threshold.
# Out of bounds values : 0 OK
# Avg bus bandwidth    : 129.493 
#
# Collective test concluded: all_reduce_perf
```

- Note, even after the patch `RCCL_USE_AMD_SMI_LIB=1` yields poor topology, only `RCCL_USE_AMD_SMI_LIB=0`, the ARSMI fall back path is addressed in this PR

### Test plan

- Build RCCL with `ONLY_FUNCS="AllReduce * * Sum f32/bf16" ./install.sh -l`
- Run `all_reduce_perf` with 16 ranks over 2x8 gfx942 GPUs
- Validate graph logs and 16G throughput before/after patch