### PR TITLE
[ROCM-2942] Fix AI NIC build & test failures

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -65,6 +65,7 @@ class AMDSMICommands():
         if self.helpers.is_amdgpu_initialized():
             try:
                 self.device_handles = amdsmi_interface.amdsmi_get_processor_handles()
+                self.device_handles_gpus = amdsmi_interface.get_gpu_handles()
             except amdsmi_exception.AmdSmiLibraryException as e:
                 if e.err_code in (amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_INIT,
                                 amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_DRIVER_NOT_LOADED):
@@ -76,10 +77,13 @@ class AMDSMICommands():
                 # No GPU's found post amdgpu driver initialization
                 logging.error('Unable to detect any GPU devices, check amdgpu version and module status (sudo modprobe amdgpu)')
                 exit_flag = True
+
+        if self.helpers.is_ainic_initialized():
             try:
                 self.device_handles_brcm_nics = amdsmi_interface.get_nic_handles()
                 self.device_handles_ainics = amdsmi_interface.get_ainic_handles()
-                self.device_handles_gpus = amdsmi_interface.get_gpu_handles()
+                if len(self.device_handles_gpus) == 0:
+                    self.device_handles_gpus = amdsmi_interface.get_gpu_handles()
                 self.device_handles_switchs = amdsmi_interface.get_switch_handles()
             except amdsmi_exception.AmdSmiLibraryException as e:
                 if e.err_code in (amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_INIT,
@@ -206,7 +210,7 @@ class AMDSMICommands():
                 cpu_version_str = e.get_error_info()
             self.logger.output['amd_hsmp_driver_version'] = cpu_version_str
 
-        nic_version_str = ""
+        nic_version_str = "N/A"
         if args.nic_version:
             try:
                 ainic_device_handles = amdsmi_interface.get_ainic_handles()
@@ -3991,7 +3995,6 @@ class AMDSMICommands():
         Returns:
             None: Print output via AMDSMILogger to destination
         """
-
         # Set args.* to passed in arguments
         if switch:
             args.switch = switch
@@ -7064,7 +7067,7 @@ class AMDSMICommands():
                     temperature=None, base_board_temps=None, gpu_board_temps=None,
                     gfx_util=None, mem_util=None, encoder=None, decoder=None,
                     ecc=None, vram_usage=None, pcie=None, process=None,
-                    violation=None):
+                    violation=None, nic=None, switch=None, brcm_nic=None, brcm_switch=None):
         """ Populate a table with each GPU as an index to rows of targeted data
 
         Args:

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_common.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_common.h
@@ -35,7 +35,7 @@ extern "C" {
 #endif
 
 extern "C" {
-#include <smi_nic_interface.h>
+#include "amd_smi/impl/nic/smi_nic_interface.h"
 }
 #include "amd_smi/impl/nic/amd_smi_ainic_device.h"
 namespace amd::smi {

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -730,7 +730,7 @@ def _format_bad_page_info(bad_page_info, bad_page_count: ctypes.c_uint32) -> Lis
     return table_records
 
 
-def _format_bdf(amdsmi_bdf: amdsmi_wrapper.amdsmi_bdf_t) -> str:
+def _format_bdf(amdsmi_bdf: Union[amdsmi_wrapper.amdsmi_bdf_t, amdsmi_wrapper.struct_amdsmi_bdf_t]) -> str:
     """
     Format BDF struct to readable data.
 
@@ -741,10 +741,15 @@ def _format_bdf(amdsmi_bdf: amdsmi_wrapper.amdsmi_bdf_t) -> str:
     Returns:
         `str`: String containing BDF data in a readable format.
     """
-    domain = hex(amdsmi_bdf.domain_number)[2:].zfill(4)
-    bus = hex(amdsmi_bdf.bus_number)[2:].zfill(2)
-    device = hex(amdsmi_bdf.device_number)[2:].zfill(2)
-    function = hex(amdsmi_bdf.function_number)[2:]
+    try:
+        struct = amdsmi_bdf.struct_amdsmi_bdf_t
+    except AttributeError:
+        struct = amdsmi_bdf
+
+    domain = hex(struct.domain_number)[2:].zfill(4)
+    bus = hex(struct.bus_number)[2:].zfill(2)
+    device = hex(struct.device_number)[2:].zfill(2)
+    function = hex(struct.function_number)[2:]
     return domain + ":" + bus + ":" + device + "." + function
 
 
@@ -2199,14 +2204,17 @@ def amdsmi_get_cpu_socket_count():
     return sock_count.value
 
 def _amdsmi_init_enum_flag_is_valid(flag):
+    """Validate that flag contains only valid initialization bits."""
     if flag == amdsmi_wrapper.AMDSMI_INIT_ALL_PROCESSORS:
         return True
-    valid = False
+    
+    # Build mask of all valid flags (excluding ALL_PROCESSORS)
+    valid_mask = 0
     for enum_flag in AmdSmiInitFlags:
-        if (flag & enum_flag) == enum_flag:
-            valid = True
-            break
-    return valid
+        if enum_flag != AmdSmiInitFlags.INIT_ALL_PROCESSORS:
+            valid_mask |= enum_flag.value
+    # Check if flag contains only valid bits and is not zero
+    return flag != 0 and (flag & ~valid_mask) == 0
 
 def amdsmi_init(flag=AmdSmiInitFlags.INIT_AMD_GPUS):
     if not _amdsmi_init_enum_flag_is_valid(flag):

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -28,7 +28,6 @@
 #include <string.h>
 #include <fcntl.h>
 
-
 #include <cstdlib>
 #include <cctype>
 #include <string>
@@ -45,8 +44,8 @@
 #include <limits>
 #include <functional>
 #include <exception>
-#include <smi_nic_interface.h>
 
+#include "amd_smi/impl/nic/smi_nic_interface.h"
 #include "config/amd_smi_config.h"
 #include "amd_smi/amdsmi.h"
 #include "amd_smi/impl/fdinfo.h"

--- a/projects/amdsmi/src/amd_smi/amd_smi_system.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_system.cc
@@ -283,6 +283,7 @@ amdsmi_status_t AMDSmiSystem::init(uint64_t flags) {
             return amd_smi_status;
     }
 #endif
+#ifdef BRCM_NIC
     if (flags & AMDSMI_INIT_AMD_NICS) {
         amd_smi_status = populate_brcm_nic_devices();
         if (amd_smi_status != AMDSMI_STATUS_SUCCESS)
@@ -294,7 +295,7 @@ amdsmi_status_t AMDSmiSystem::init(uint64_t flags) {
         if (amd_smi_status != AMDSMI_STATUS_SUCCESS)
             return amd_smi_status;
     }
-
+#endif
     return AMDSMI_STATUS_SUCCESS;
 }
 
@@ -664,9 +665,11 @@ amdsmi_status_t AMDSmiSystem::cleanup() {
             return amd::smi::rsmi_to_amdsmi_status(ret);
         }
     }
+#ifdef BRCM_NIC
     if (init_flag_ & AMDSMI_INIT_AMD_NICS) {
         smi_nic_destroy_context(ainic_ctx_);
     }
+#endif
     return AMDSMI_STATUS_SUCCESS;
 }
 

--- a/projects/amdsmi/tests/python_unittest/common.py
+++ b/projects/amdsmi/tests/python_unittest/common.py
@@ -531,3 +531,24 @@ class Common(unittest.TestCase):
             print(f'{status_msg}', flush=True)
         return status_ret
 
+    def _skip_if_missing(self, names):
+        def has_attr_recursive(obj, name):
+            """Check if an attribute exists in obj or its submodules."""
+            if hasattr(obj, name):
+                return True
+            # Try to find it in submodules
+            for attr_name in dir(obj):
+                try:
+                    attr = getattr(obj, attr_name)
+                    if hasattr(attr, '__dict__') and hasattr(attr, name):
+                        return True
+                except (AttributeError, ImportError):
+                    pass
+            return False
+        
+        missing = [name for name in names if not has_attr_recursive(amdsmi, name)]
+        if missing:
+            test_name = self.id().split('.')[-1]
+            print_missing_msg = f"{test_name} | Missing amdsmi API(s) in amdsmi_interface.py: " + ", ".join(missing)
+            print(f"\n")
+            self.skipTest(f"{str(print_missing_msg)}")

--- a/projects/amdsmi/tests/python_unittest/integration_test.py
+++ b/projects/amdsmi/tests/python_unittest/integration_test.py
@@ -25,6 +25,7 @@ import os
 import sys
 import threading
 import unittest
+import common
 
 
 amdsmi_path = os.environ.get("AMDSMI_PATH", "/opt/rocm/share/amd_smi")
@@ -304,6 +305,11 @@ class TestAmdSmiPythonInterface(unittest.TestCase):
         print("\n")
 
     def test_nic_bdf_device_id(self):
+        common.Common._skip_if_missing(self, [
+                                "amdsmi_get_nic_processor_handles",
+                                "amdsmi_get_nic_info",
+                                "amdsmi_get_nic_device_uuid",
+                            ])
         self.setUp()
         processors = amdsmi.amdsmi_get_nic_processor_handles()
         self.assertGreaterEqual(len(processors), 1)
@@ -323,6 +329,11 @@ class TestAmdSmiPythonInterface(unittest.TestCase):
         self.tearDown()
 
     def test_switch_bdf_device_id(self):
+        common.Common._skip_if_missing(self, [
+                                "amdsmi_get_switch_processor_handles",
+                                "amdsmi_get_switch_device_bdf",
+                                "amdsmi_get_device_id",
+                            ])
         self.setUp()
         processors = amdsmi.amdsmi_get_switch_processor_handles()
         self.assertGreaterEqual(len(processors), 1)


### PR DESCRIPTION
## Motivation

Fix AMDSMI_STATUS_NO_DATA on NIC devices & Python tests not completing

Installation successful on attempt 1
Verifying installation:
amdsmi.amdsmi_exception.AmdSmiLibraryException: Error code:
	40 | AMDSMI_STATUS_NO_DATA - No data was found for given input
Error: Process completed with exit code 1.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

ROCM-2942

## Test Plan

Run AMD SMI CI - all tests ran should pass.

## Test Result

All AMDSMI CI tests pass, otherwise if missing interfaces those should be skipped.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
