### PR TITLE
[rocprofiler-compute] Remove unwanted import introduced when resolving merge conflicts

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
@@ -31,7 +31,7 @@ from typing import Optional, Union
 from rocprof_compute_profile.profiler_base import RocProfCompute_Base
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import console_error, console_log, demarcate
-from utils.utils import consolidate_torch_trace_output, resolve_rocm_library_path
+from utils.utils import resolve_rocm_library_path
 
 
 class rocprofiler_sdk_profiler(RocProfCompute_Base):


### PR DESCRIPTION
## Motivation

Remove unwanted import introduced when resolving merge conflicts

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Remove import of `consolidate_torch_trace_output` function introduced by wrong merge conflict resolution

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Ensure rocprof-compute profile works without any errors

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Test pass

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
