### PR TITLE
[rocprofiler-sdk] Add queue drain assertion after stop packet

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
@@ -590,6 +590,20 @@ stop_agent_ctx(const context::context* ctx)
                                                           UINT64_MAX,
                                                           HSA_WAIT_STATE_ACTIVE);
 
+        // Verify that the profiling queue is fully drained before releasing the device.
+        // After the stop packet completes, read_index must equal write_index.
+        {
+            auto* queue     = agent->profile_queue();
+            auto  read_idx  = hsa::get_core_table()->hsa_queue_load_read_index_relaxed_fn(queue);
+            auto  write_idx = hsa::get_core_table()->hsa_queue_load_write_index_relaxed_fn(queue);
+            ROCP_FATAL_IF(read_idx != write_idx)
+                << fmt::format("Profile queue not drained after stop packet: "
+                               "read_index={}, write_index={} (agent={})",
+                               read_idx,
+                               write_idx,
+                               agent->get_rocp_agent()->name);
+        }
+
         // Re-enable PTL (non-fatal if it fails)
         // Only re-enable here if using NEW behavior (at context start, not at configuration)
         if(!use_device_lock_at_start())


### PR DESCRIPTION
## Summary
- Adds a queue drain check in `stop_agent_ctx()` after the stop packet completion signal wait, verifying `read_index == write_index` on the profile queue before proceeding to PTL re-enablement and device unlock
- Uses `ROCP_FATAL_IF` to catch the invariant violation, consistent with existing fatal assertions in the file
- Prevents potential counter data corruption if packets remain in flight when the profiler lock is released

## Test plan
- [x] Verified `device_counting.cpp` compiles successfully on remote gfx942 host
- [x] Verified formatting with `clang-format-11` (no changes needed)
- [ ] Run counter collection ctests on GPU host (blocked by pre-existing `fmt::format` build errors in unrelated files: `ompt.cpp`, `aql_packet.cpp`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)