### PR TITLE
Remove outdated import

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_rocprofiler_sdk.py
@@ -31,7 +31,7 @@ from typing import Optional, Union
 from rocprof_compute_profile.profiler_base import RocProfCompute_Base
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import console_error, console_log, demarcate
-from utils.utils import consolidate_torch_trace_output, resolve_rocm_library_path
+from utils.utils import resolve_rocm_library_path
 
 
 class rocprofiler_sdk_profiler(RocProfCompute_Base):


### PR DESCRIPTION
## Motivation
Removes the non-existent `consolidate_torch_trace_output` from the `utils.utils` import in `profiler_rocprofiler_sdk.py` (torch trace consolidation is handled by `process_torch_trace_output` in the analyze path)

## Technical Details


## JIRA ID

## Test Plan

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
