### PR TITLE
ROCM-2924 - disable Unit_TexObjectCreate_TypePitch2D_EdgeCases on Windows

### DIFF
--- a/projects/hip-tests/catch/hipTestMain/config/config_amd_windows
+++ b/projects/hip-tests/catch/hipTestMain/config/config_amd_windows
@@ -751,6 +751,9 @@
         "Unit_hipStreamSynchronize_NullStreamSynchronization",
         "=== Test does not reflect a valid use case - SWDEV-569454",
         "Unit_hipStreamPerThread_MultiThread",
+        "=== ROCM-2924 - section 'Invalid device pointer' of this test fails on Windows ===",
+        "=== the runtime is not really able to detect invalid device pointers a.t.m. ===",
+        "Unit_TexObjectCreate_TypePitch2D_EdgeCases",
     #endif
         "=== Following tests disabled as it should be a local perf test",
         "Performance_hipExtLaunchKernelGGL_QueryGPUFrequency",


### PR DESCRIPTION
## Motivation
Unit_TexObjectCreate_TypePitch2D_EdgeCases was blocking Windows PSDBs due to the section 'Invalid device pointer' failing

https://github.com/ROCm/rocm-systems/pull/3268 was create as simple fix, but it was suggested that a better invalid device pointer detection should be implemented: see https://amd-hub.atlassian.net/browse/ROCM-2924


## Technical Details
This PR disables the test until there is an agreed solution


## JIRA ID
ROCM-2924

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
