### PR TITLE
[memcache cleanups 3/6] Remove memory_cache_t host_address_t instantiation

### DIFF
--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -817,7 +817,6 @@ memory_cache_t<AddressType>::xfer_global_memory (AddressType address,
 }
 
 template class memory_cache_t<agent_address_t>;
-template class memory_cache_t<host_address_t>;
 
 } /* namespace amd::dbgapi */
 


### PR DESCRIPTION
The previous patch removed the only use of
memory_cache_t<host_address_t> left in the tree.

This commit removes the memory_cache_t<host_address_t> explicit
instanciation.

A following patch will make memory_cache_t a regular non-template
class.

Change-Id: Ie6922b2e9b38b02e28250ca2265655a0ea5413d4

---

**Stack**:
- #3304
- #3303
- #3302
- #3301 ⬅
- #4892
- #4894


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*