### PR TITLE
[memcache cleanups 4/6] Remove unused memory_cache_t entry points

### DIFF
--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -529,55 +529,6 @@ host_address_space_t::convert (const wave_t &wave,
 }
 
 template <typename AddressType>
-void
-memory_cache_t<AddressType>::fetch_cache_line (cache_line_t &cache_line,
-                                               AddressType address) const
-{
-  dbgapi_assert (!cache_line.m_dirty);
-
-  size_t xfer_size = m_xfer_global_memory (address, &cache_line.m_data[0],
-                                           nullptr, cache_line.m_data.size ());
-
-  if (xfer_size != cache_line.m_data.size ())
-    throw memory_access_error_t (
-      /* FIXME_lmoriche:  */
-      address_space_t::global (), address + cache_line_size);
-
-  cache_line.m_dirty = false;
-}
-
-template <typename AddressType>
-void
-memory_cache_t<AddressType>::commit_cache_line (cache_line_t &cache_line,
-                                                AddressType address) const
-{
-  if (!cache_line.m_dirty)
-    return;
-
-  size_t xfer_size = m_xfer_global_memory (
-    address, nullptr, &cache_line.m_data[0], cache_line.m_data.size ());
-
-  if (xfer_size != cache_line.m_data.size ())
-    throw memory_access_error_t (
-      /* FIXME_lmoriche:  */
-      address_space_t::global (), address + xfer_size);
-
-  cache_line.m_dirty = false;
-}
-
-template <typename AddressType>
-void
-memory_cache_t<AddressType>::allocate_0_cache_line (
-  cache_line_t &cache_line) const
-{
-  dbgapi_assert (!cache_line.m_dirty);
-
-  memset (&cache_line.m_data[0], '\0', cache_line.m_data.size ());
-
-  cache_line.m_dirty = false;
-}
-
-template <typename AddressType>
 bool
 memory_cache_t<AddressType>::contains_all (AddressType address,
                                            amd_dbgapi_size_t size) const

--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -552,10 +552,6 @@ private:
   std::map<AddressType, cache_line_t> m_cache_line_map;
   delegate_fn_type const m_xfer_global_memory;
 
-  void fetch_cache_line (cache_line_t &cache_line, AddressType address) const;
-  void commit_cache_line (cache_line_t &cache_line, AddressType address) const;
-  void allocate_0_cache_line (cache_line_t &cache_line) const;
-
   size_t xfer_global_memory (AddressType address, void *read,
                              const void *write, size_t size);
 


### PR DESCRIPTION
These three memory_cache_t member functions are unused:

void fetch_cache_line (cache_line_t &cache_line, AddressType address) const;
void commit_cache_line (cache_line_t &cache_line, AddressType address) const;
void allocate_0_cache_line (cache_line_t &cache_line) const;

This commit removes them.

Change-Id: I2e95b0e65fc77bbb21a57d35f419b0298898400e

---

**Stack**:
- #3304
- #3303
- #3302 ⬅
- #3301
- #4892
- #4894


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*