### PR TITLE
[memcache cleanups 5/6] Make memory_cache_t a regular class, not a template

### DIFF
--- a/projects/rocdbgapi/src/agent.h
+++ b/projects/rocdbgapi/src/agent.h
@@ -60,7 +60,7 @@ private:
   const architecture_t *const m_architecture;
   process_t &m_process;
 
-  mutable memory_cache_t<agent_address_t> m_memory_cache;
+  mutable memory_cache_t m_memory_cache;
 
 public:
   agent_t (amd_dbgapi_agent_id_t agent_id, process_t &process,

--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -528,10 +528,9 @@ host_address_space_t::convert (const wave_t &wave,
   throw api_error_t (AMD_DBGAPI_STATUS_ERROR_INVALID_ADDRESS_SPACE_CONVERSION);
 }
 
-template <typename AddressType>
 bool
-memory_cache_t<AddressType>::contains_all (AddressType address,
-                                           amd_dbgapi_size_t size) const
+memory_cache_t::contains_all (agent_address_t address,
+                              amd_dbgapi_size_t size) const
 {
   dbgapi_assert (address < (address + size) && "invalid size");
   auto cache_line_begin = utils::align_down (address, cache_line_size);
@@ -546,10 +545,8 @@ memory_cache_t<AddressType>::contains_all (AddressType address,
   return true;
 }
 
-template <typename AddressType>
 void
-memory_cache_t<AddressType>::prefetch (AddressType address,
-                                       amd_dbgapi_size_t size)
+memory_cache_t::prefetch (agent_address_t address, amd_dbgapi_size_t size)
 {
   if (size == 0)
     return;
@@ -594,10 +591,8 @@ memory_cache_t<AddressType>::prefetch (AddressType address,
     }
 }
 
-template <typename AddressType>
 void
-memory_cache_t<AddressType>::write_back (AddressType address,
-                                         amd_dbgapi_size_t size)
+memory_cache_t::write_back (agent_address_t address, amd_dbgapi_size_t size)
 {
   std::exception_ptr exception;
   if (size == 0)
@@ -678,11 +673,9 @@ memory_cache_t<AddressType>::write_back (AddressType address,
     std::rethrow_exception (exception);
 }
 
-template <typename AddressType>
 void
-memory_cache_t<AddressType>::discard (AddressType address,
-                                      amd_dbgapi_size_t size,
-                                      [[maybe_unused]] bool force_discard)
+memory_cache_t::discard (agent_address_t address, amd_dbgapi_size_t size,
+                         [[maybe_unused]] bool force_discard)
 {
   if (size == 0)
     return;
@@ -702,18 +695,16 @@ memory_cache_t<AddressType>::discard (AddressType address,
     }
 }
 
-template <typename AddressType>
 size_t
-memory_cache_t<AddressType>::xfer_global_memory (AddressType address,
-                                                 void *read, const void *write,
-                                                 size_t size)
+memory_cache_t::xfer_global_memory (agent_address_t address, void *read,
+                                    const void *write, size_t size)
 {
   if (size == 0)
     return 0;
 
   /* Clamp to the end of the global address space.  */
   if (address > (address + size))
-    size = AddressType{} - address;
+    size = agent_address_t{} - address;
 
   auto first_line = utils::align_down (address, cache_line_size);
   auto last_line = utils::align_down (address + size - 1, cache_line_size);
@@ -766,8 +757,6 @@ memory_cache_t<AddressType>::xfer_global_memory (AddressType address,
 
   return size;
 }
-
-template class memory_cache_t<agent_address_t>;
 
 } /* namespace amd::dbgapi */
 

--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -533,14 +533,14 @@ public:
 /* A write-back memory cache.  Data is immediately updated in the cache, and
    later updated in memory when the cache is flushed.  */
 
-template <typename AddressType> class memory_cache_t
+class memory_cache_t
 {
 public:
   static constexpr size_t cache_line_size = 64;
 
 private:
   using delegate_fn_type
-    = std::function<size_t (AddressType /* address */, void * /* read */,
+    = std::function<size_t (agent_address_t /* address */, void * /* read */,
                             const void * /* write */, size_t /* size */)>;
 
   struct cache_line_t
@@ -549,10 +549,10 @@ private:
     bool m_dirty{ false };
   };
 
-  std::map<AddressType, cache_line_t> m_cache_line_map;
+  std::map<agent_address_t, cache_line_t> m_cache_line_map;
   delegate_fn_type const m_xfer_global_memory;
 
-  size_t xfer_global_memory (AddressType address, void *read,
+  size_t xfer_global_memory (agent_address_t address, void *read,
                              const void *write, size_t size);
 
 public:
@@ -562,29 +562,29 @@ public:
   }
   ~memory_cache_t () { dbgapi_assert (m_cache_line_map.empty ()); }
 
-  bool contains_all (AddressType address, amd_dbgapi_size_t size) const;
+  bool contains_all (agent_address_t address, amd_dbgapi_size_t size) const;
 
   /* Create cache lines if not already valid, and immediately fill them in.  */
-  void prefetch (AddressType address, amd_dbgapi_size_t size);
+  void prefetch (agent_address_t address, amd_dbgapi_size_t size);
 
   /* Discard all cache lines in the specified range.  If FORCE_DISCARD
      is true, dirty lines are silently dropped.  Otherwise it is an error to
      discarded dirty cache lines.  */
-  void discard (AddressType address = 0,
+  void discard (agent_address_t address = 0,
                 amd_dbgapi_size_t size = amd_dbgapi_size_t (-1),
                 bool force_discard = false);
 
   /* Write dirty lines back to memory.  */
-  void write_back (AddressType address = 0,
+  void write_back (agent_address_t address = 0,
                    amd_dbgapi_size_t size = amd_dbgapi_size_t (-1));
 
-  [[nodiscard]] size_t read_global_memory (AddressType address, void *buffer,
-                                           size_t size)
+  [[nodiscard]] size_t read_global_memory (agent_address_t address,
+                                           void *buffer, size_t size)
   {
     return xfer_global_memory (address, buffer, nullptr, size);
   }
 
-  [[nodiscard]] size_t write_global_memory (AddressType address,
+  [[nodiscard]] size_t write_global_memory (agent_address_t address,
                                             const void *buffer, size_t size)
   {
     return xfer_global_memory (address, nullptr, buffer, size);


### PR DESCRIPTION
memory_cache_t is currently a template class, templated on address
type.  However, it is always used with agent_address_t, so make it a
regular class, and hardcode agent_address_t where AddressType was
previously used.

Change-Id: Ia2c3b2dfb17bc59670842aad2187f2a670f924a7

---

**Stack**:
- #3304
- #3303 ⬅
- #3302
- #3301
- #4892
- #4894


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*