### PR TITLE
[memcache cleanups 6/6] memory cache: global memory => agent memory, fix FIXME

### DIFF
--- a/projects/rocdbgapi/src/agent.cpp
+++ b/projects/rocdbgapi/src/agent.cpp
@@ -75,6 +75,7 @@ agent_t::agent_t (amd_dbgapi_agent_id_t agent_id, process_t &process,
       }(os_agent_info)),
     m_architecture (architecture), m_process (process),
     m_memory_cache (
+      *this,
       [this] (agent_address_t address, void *read, const void *write,
               size_t size)
       {

--- a/projects/rocdbgapi/src/agent.h
+++ b/projects/rocdbgapi/src/agent.h
@@ -109,14 +109,14 @@ public:
                                                   void *buffer,
                                                   size_t size) const
   {
-    return m_memory_cache.read_global_memory (address, buffer, size);
+    return m_memory_cache.read_agent_memory (address, buffer, size);
   }
 
   [[nodiscard]] size_t write_agent_memory_partial (agent_address_t address,
                                                    const void *buffer,
                                                    size_t size) const
   {
-    return m_memory_cache.write_global_memory (address, buffer, size);
+    return m_memory_cache.write_agent_memory (address, buffer, size);
   }
 
   template <typename T>

--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -560,8 +560,8 @@ memory_cache_t::prefetch (agent_address_t address, amd_dbgapi_size_t size)
 
   try
     {
-      m_xfer_global_memory (cache_line_begin, &staging_buffer[0], nullptr,
-                            cache_line_end - cache_line_begin);
+      m_xfer_agent_memory (cache_line_begin, &staging_buffer[0], nullptr,
+                           cache_line_end - cache_line_begin);
     }
   catch (const memory_error_t &)
     {
@@ -647,13 +647,12 @@ memory_cache_t::write_back (agent_address_t address, amd_dbgapi_size_t size)
 
       try
         {
-          size_t xfer_size = m_xfer_global_memory (
+          size_t xfer_size = m_xfer_agent_memory (
             cache_line_address, nullptr, &staging_buffer[0], request_size);
 
           if (xfer_size != request_size)
-            throw memory_access_error_t (
-              /* FIXME_lmoriche:  */
-              address_space_t::global (), cache_line_address + xfer_size);
+            throw memory_access_error_t (m_agent.agent_address_space (),
+                                         cache_line_address + xfer_size);
         }
       catch (const process_exited_exception_t &)
         {
@@ -696,15 +695,19 @@ memory_cache_t::discard (agent_address_t address, amd_dbgapi_size_t size,
 }
 
 size_t
-memory_cache_t::xfer_global_memory (agent_address_t address, void *read,
-                                    const void *write, size_t size)
+memory_cache_t::xfer_agent_memory (agent_address_t address, void *read,
+                                   const void *write, size_t size)
 {
   if (size == 0)
     return 0;
 
-  /* Clamp to the end of the global address space.  */
-  if (address > (address + size))
-    size = agent_address_t{} - address;
+  /* Clamp to the end of the agent address space.  */
+  auto max = m_agent.agent_address_space ().last_address ();
+  if (address > max)
+    throw memory_access_error_t (m_agent.agent_address_space (), address);
+  auto available = (max - address) + 1;
+  if (size > available)
+    size = available;
 
   auto first_line = utils::align_down (address, cache_line_size);
   auto last_line = utils::align_down (address + size - 1, cache_line_size);
@@ -715,7 +718,7 @@ memory_cache_t::xfer_global_memory (agent_address_t address, void *read,
 
   /* If there are no cache lines affected by this access.  */
   if (begin == end)
-    return m_xfer_global_memory (address, read, write, size);
+    return m_xfer_agent_memory (address, read, write, size);
 
   /* For cached accesses, handle one cache line at a time.  */
   if (first_line != last_line)
@@ -726,7 +729,7 @@ memory_cache_t::xfer_global_memory (agent_address_t address, void *read,
           auto limit = utils::align_up (ptr + 1, cache_line_size);
           auto request_size = std::min (limit, ptr + size) - ptr;
 
-          auto xfer_size = xfer_global_memory (ptr, read, write, request_size);
+          auto xfer_size = xfer_agent_memory (ptr, read, write, request_size);
 
           ptr += xfer_size;
           if (read != nullptr)

--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -549,15 +549,18 @@ private:
     bool m_dirty{ false };
   };
 
-  std::map<agent_address_t, cache_line_t> m_cache_line_map;
-  delegate_fn_type const m_xfer_global_memory;
+  /* The agent which this cache is for.  */
+  const agent_t &m_agent;
 
-  size_t xfer_global_memory (agent_address_t address, void *read,
-                             const void *write, size_t size);
+  std::map<agent_address_t, cache_line_t> m_cache_line_map;
+  delegate_fn_type const m_xfer_agent_memory;
+
+  size_t xfer_agent_memory (agent_address_t address, void *read,
+                            const void *write, size_t size);
 
 public:
-  memory_cache_t (delegate_fn_type xfer_global_memory)
-    : m_xfer_global_memory (std::move (xfer_global_memory))
+  memory_cache_t (const agent_t &agent, delegate_fn_type xfer_agent_memory)
+    : m_agent (agent), m_xfer_agent_memory (std::move (xfer_agent_memory))
   {
   }
   ~memory_cache_t () { dbgapi_assert (m_cache_line_map.empty ()); }
@@ -578,16 +581,16 @@ public:
   void write_back (agent_address_t address = 0,
                    amd_dbgapi_size_t size = amd_dbgapi_size_t (-1));
 
-  [[nodiscard]] size_t read_global_memory (agent_address_t address,
-                                           void *buffer, size_t size)
+  [[nodiscard]] size_t read_agent_memory (agent_address_t address,
+                                          void *buffer, size_t size)
   {
-    return xfer_global_memory (address, buffer, nullptr, size);
+    return xfer_agent_memory (address, buffer, nullptr, size);
   }
 
-  [[nodiscard]] size_t write_global_memory (agent_address_t address,
-                                            const void *buffer, size_t size)
+  [[nodiscard]] size_t write_agent_memory (agent_address_t address,
+                                           const void *buffer, size_t size)
   {
-    return xfer_global_memory (address, nullptr, buffer, size);
+    return xfer_agent_memory (address, nullptr, buffer, size);
   }
 };
 


### PR DESCRIPTION
"xfer_global_memory" is kind of a reminiscent of the Linux-only time
where the cache was dealing with global addresses.  Even if yes, from
the GPU perspective it is called "global", it is not necessarily
global in the "unified global" sense.

Since the memory cache is now specialized to agent_address_t, rename:

xfer_global_memory => xfer_agent_memory
read_global_memory => read_agent_memory
write_global_memory => write_agent_memory

Pass the agent to the memory_cache_t ctor, so we can use it in the
memory_access_error_t throw in memory_cache_t::write_back, fixing a
FIXME: instead of using address_space_t::global(), use the agent's
address space.

This also fixes a compilation error when compiling with GCC at -O2:

In file included from /home/pedalves/rocm/dbgapi/src/src/memory.cpp:21:
In member function ‘T amd::dbgapi::detail::base_address_t<T>::operator-(U) const [with U = amd::dbgapi::agent_address_t; T = amd::dbgapi::agent_address_t]’,
inlined from ‘size_t amd::dbgapi::memory_cache_t::xfer_agent_memory(amd::dbgapi::agent_address_t, void*, const void*, size_t)’ at /home/pedalves/rocm/dbgapi/src/src/memory.cpp:678:32:
/home/pedalves/rocm/dbgapi/src/src/memory.h:85:15: error: ‘<unnamed>.amd::dbgapi::agent_address_t::<unnamed>.amd::dbgapi::detail::base_address_t<amd::dbgapi::agent_address_t>::m_address’ may be used uninitialized [-Werror=maybe-uninitialized]
85 |     return T{ m_address - decrement };
|               ^~~~~~~~~
/home/pedalves/rocm/dbgapi/src/src/memory.cpp: In member function ‘size_t amd::dbgapi::memory_cache_t::xfer_agent_memory(amd::dbgapi::agent_address_t, void*, const void*, size_t)’:
/home/pedalves/rocm/dbgapi/src/src/memory.cpp:678:28: note: ‘<anonymous>’ declared here
678 |     size = agent_address_t{} - address;
|                            ^

That's because of:

base_address_t () = default;  => default-initializes members.
uint64_t m_address;           => no initializer => left uninitialized.

This is fixed in this commit because the "agent_address_t{}" simply
goes away.

Suggested-By: Lancelot SIX <lancelot.six@amd.com>
Change-Id: Ib93ea39dcb9648a509a80c1dbd9f8bf79905587c

---

**Stack**:
- #3304 ⬅
- #3303
- #3302
- #3301
- #4892
- #4894


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*