### PR TITLE
[rocdbgapi: mem-cache 6/6] Rework save area caching, improve stepping performance

### DIFF
--- a/projects/rocdbgapi/src/agent.cpp
+++ b/projects/rocdbgapi/src/agent.cpp
@@ -108,7 +108,7 @@ agent_t::agent_t (amd_dbgapi_agent_id_t agent_id, process_t &process,
 
 agent_t::~agent_t ()
 {
-  /* Drop all active cache lines.  */
+  /* Drop all active cache entries.  */
   m_memory_cache.write_back ();
   m_memory_cache.discard ();
 }

--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -501,67 +501,44 @@ agent_address_space_t::convert (
   throw api_error_t (AMD_DBGAPI_STATUS_ERROR_INVALID_ADDRESS_SPACE_CONVERSION);
 }
 
-bool
-memory_cache_t::contains_all (agent_address_t address,
-                              amd_dbgapi_size_t size) const
+/* Returns true if the ranges given by [A_ADDR, A_ADDR+A_SIZE) and
+   [B_ADDR, B_ADDR+B_SIZE) overlap.  */
+
+static bool
+ranges_overlap (agent_address_t a_addr, amd_dbgapi_size_t a_size,
+                agent_address_t b_addr, amd_dbgapi_size_t b_size)
 {
-  dbgapi_assert (address < (address + size) && "invalid size");
-  auto cache_line_begin = utils::align_down (address, cache_line_size);
-  auto cache_line_end = utils::align_up (address + size, cache_line_size);
+  auto a_end = a_addr + a_size;
+  auto b_end = b_addr + b_size;
 
-  for (auto cache_line_address = cache_line_begin;
-       cache_line_address < cache_line_end;
-       cache_line_address += cache_line_size)
-    if (m_cache_line_map.find (cache_line_address) == m_cache_line_map.end ())
-      return false;
-
-  return true;
+  return a_addr < b_end && b_addr < a_end;
 }
 
-void
-memory_cache_t::prefetch (agent_address_t address, amd_dbgapi_size_t size)
+std::byte *
+memory_cache_t::new_entry (agent_address_t address, amd_dbgapi_size_t size)
 {
-  if (size == 0)
-    return;
-
   dbgapi_assert (address < (address + size) && "invalid size");
-  auto cache_line_begin = utils::align_down (address, cache_line_size);
-  auto cache_line_end = utils::align_up (address + size, cache_line_size);
 
-  auto staging_buffer
-    = std::make_unique<std::byte[]> (cache_line_end - cache_line_begin);
+  for (auto &entry : m_cache_entries)
+    if (ranges_overlap (entry.address (), entry.size (), address, size))
+      fatal_error ("cache entry already exists");
 
-  try
+  if (!m_unused_cache_entries.empty ())
     {
-      m_xfer_agent_memory (cache_line_begin, &staging_buffer[0], nullptr,
-                           cache_line_end - cache_line_begin);
+      /* Reuse an existing entry node.  */
+      m_cache_entries.splice (m_cache_entries.end (), m_unused_cache_entries,
+                              m_unused_cache_entries.begin ());
     }
-  catch (const memory_error_t &)
+  else
     {
-      /* If a memory access error exception is raised while prefetching, simply
-         drop the prefetch.  */
-      return;
+      /* Create a new entry node.  */
+      m_cache_entries.emplace_back ();
     }
 
-  for (auto cache_line_address = cache_line_begin;
-       cache_line_address < cache_line_end;
-       cache_line_address += cache_line_size)
-    {
-      if (contains_all (cache_line_address, cache_line_size))
-        /* There's already a cache line for that address that will have already
-           been read, and possibly updated.  So leave cache line with its
-           current contents.  */
-        continue;
-
-      auto [it, success] = m_cache_line_map.try_emplace (cache_line_address);
-      dbgapi_assert (success && "failed to create memory cache");
-      [] (auto &&...) {}(success); /* Silence an unused variable warning when
-                                      building without assertions enabled.  */
-
-      memcpy (&it->second.m_data[0],
-              &staging_buffer[cache_line_address - cache_line_begin],
-              cache_line_size);
-    }
+  auto &entry = m_cache_entries.back ();
+  entry.reset (address, size);
+  m_xfer_agent_memory (address, entry.data (), nullptr, size);
+  return entry.data ();
 }
 
 void
@@ -571,73 +548,39 @@ memory_cache_t::write_back (agent_address_t address, amd_dbgapi_size_t size)
   if (size == 0)
     return;
 
-  dbgapi_assert (address < (address + size) && "invalid size");
-  auto first_line = utils::align_down (address, cache_line_size);
-  auto last_line = utils::align_down (address + size - 1, cache_line_size);
-
-  auto it = m_cache_line_map.lower_bound (first_line);
-  auto limit = m_cache_line_map.upper_bound (last_line);
-
-  std::unique_ptr<std::byte[]> staging_buffer;
-  size_t staging_buffer_size = 0;
-
-  while (it != limit)
+  for (auto &entry : m_cache_entries)
     {
-      auto &[cache_line_address, cache_line] = *it;
-      size_t request_size = cache_line_size;
+      auto dirty_start_offset = entry.dirty_range_start_offset ();
+      auto dirty_start_address = dirty_start_offset + entry.address ();
+      auto dirty_size = entry.dirty_range_size ();
 
-      /* Skip this line if it isn't dirty as we do not need to commit it to
-         memory.  */
-      if (!cache_line.m_dirty)
+      if (ranges_overlap (address, size, dirty_start_address, dirty_size))
         {
-          std::advance (it, 1);
-          continue;
-        }
+          entry.mark_clean ();
 
-      /* It is more efficient to do a single large memory access, so try to
-         group as many contiguous cache lines as possible.  */
-      auto next = std::next (it);
-      while (next != limit && next->second.m_dirty
-             && next->first == (cache_line_address + request_size))
-        {
-          request_size += cache_line_size;
-          std::advance (next, 1);
-        }
+          try
+            {
+              auto xfer_size = m_xfer_agent_memory (
+                dirty_start_address, nullptr,
+                entry.data () + dirty_start_offset, dirty_size);
 
-      if (request_size > staging_buffer_size)
-        {
-          staging_buffer = std::make_unique<std::byte[]> (request_size);
-          staging_buffer_size = request_size;
-        }
-
-      while (it != next)
-        {
-          memcpy (&staging_buffer[0] + (it->first - cache_line_address),
-                  &it->second.m_data[0], cache_line_size);
-          it->second.m_dirty = false;
-          std::advance (it, 1);
-        }
-
-      try
-        {
-          size_t xfer_size = m_xfer_agent_memory (
-            cache_line_address, nullptr, &staging_buffer[0], request_size);
-
-          if (xfer_size != request_size)
-            throw memory_access_error_t (m_agent.agent_address_space (),
-                                         cache_line_address + xfer_size);
-        }
-      catch (const process_exited_exception_t &)
-        {
-          /* The process has exited, simply discard the dirty cached bytes.  */
-        }
-      catch (const memory_error_t &e)
-        {
-          /* If we see memory errors, continue to try to write back all dirty
-             lines.  The first exception seen will be rethrown at the end of
-             the procedure.  */
-          if (!exception)
-            exception = std::current_exception ();
+              if (xfer_size != dirty_size)
+                throw memory_access_error_t (m_agent.agent_address_space (),
+                                             entry.address () + xfer_size);
+            }
+          catch (const process_exited_exception_t &)
+            {
+              /* The process has exited, simply discard the dirty cached
+                 bytes.  */
+            }
+          catch (const memory_error_t &e)
+            {
+              /* If we see memory errors, continue to try to write back
+                 all dirty ranges.  The first exception seen will be
+                 rethrown at the end of the procedure.  */
+              if (!exception)
+                exception = std::current_exception ();
+            }
         }
     }
 
@@ -653,17 +596,29 @@ memory_cache_t::discard (agent_address_t address, amd_dbgapi_size_t size,
     return;
 
   dbgapi_assert (address < (address + size) && "invalid size");
-  auto first_line = utils::align_down (address, cache_line_size);
-  auto last_line = utils::align_down (address + size - 1, cache_line_size);
 
-  auto it = m_cache_line_map.lower_bound (first_line);
-  auto limit = m_cache_line_map.upper_bound (last_line);
-
-  while (it != limit)
+  for (auto it = m_cache_entries.begin (); it != m_cache_entries.end ();)
     {
-      dbgapi_assert ((force_discard || !it->second.m_dirty)
-                     && "discarding a dirty cache line");
-      it = m_cache_line_map.erase (it);
+      if (ranges_overlap (it->address (), it->size (), address, size))
+        {
+          dbgapi_assert ((force_discard || !it->dirty ())
+                         && "discarding a dirty cache entry");
+
+          /* Don't allow discarding a partial entry.  */
+          [[maybe_unused]] auto range_end = address + size;
+          [[maybe_unused]] auto entry_end = it->address () + it->size ();
+          dbgapi_assert ((address <= it->address () && entry_end <= range_end)
+                         && "partial overlap when discarding entry");
+
+          /* Advance before splicing.  */
+          auto current = it++;
+
+          /* Move the matching entry to m_unused_entries.  */
+          m_unused_cache_entries.splice (m_unused_cache_entries.end (),
+                                         m_cache_entries, current);
+        }
+      else
+        ++it;
     }
 }
 
@@ -678,27 +633,30 @@ memory_cache_t::xfer_agent_memory (agent_address_t address, void *read,
   if (address > (address + size))
     size = agent_address_t{} - address;
 
-  auto first_line = utils::align_down (address, cache_line_size);
-  auto last_line = utils::align_down (address + size - 1, cache_line_size);
+  auto ptr = address;
 
-  /* Iterators to the first cache line, and one past the last cache line.  */
-  auto begin = m_cache_line_map.lower_bound (first_line);
-  auto end = m_cache_line_map.upper_bound (last_line);
-
-  /* If there are no cache lines affected by this access.  */
-  if (begin == end)
-    return m_xfer_agent_memory (address, read, write, size);
-
-  /* For cached accesses, handle one cache line at a time.  */
-  if (first_line != last_line)
+  while (size != 0)
     {
-      auto ptr = address;
-      while (size > 0)
-        {
-          auto limit = utils::align_up (ptr + 1, cache_line_size);
-          auto request_size = std::min (limit, ptr + size) - ptr;
+      /* Find the next overlapping cache entry.  */
+      cache_entry_t *entry = nullptr;
 
-          auto xfer_size = xfer_agent_memory (ptr, read, write, request_size);
+      for (auto &e : m_cache_entries)
+        if (ranges_overlap (e.address (), e.size (), ptr, size))
+          {
+            entry = &e;
+            break;
+          }
+
+      /* Determine where uncached data stops.  */
+      auto uncached_end = entry != nullptr ? entry->address () : ptr + size;
+
+      /* Handle uncached prefix, if any.  */
+      if (ptr < uncached_end)
+        {
+          auto request_size = std::min<size_t> (size, uncached_end - ptr);
+
+          auto xfer_size
+            = m_xfer_agent_memory (ptr, read, write, request_size);
 
           ptr += xfer_size;
           if (read != nullptr)
@@ -709,25 +667,38 @@ memory_cache_t::xfer_agent_memory (agent_address_t address, void *read,
 
           if (xfer_size != request_size)
             break;
+          continue;
         }
-      return ptr - address;
+
+      /* If no entry, we are done.  */
+      if (entry == nullptr)
+        continue;
+
+      /* Now PTR is inside the entry.  */
+      auto entry_end = entry->address () + entry->size ();
+      auto chunk_end = std::min (entry_end, ptr + size);
+
+      size_t offset = ptr - entry->address ();
+      size_t chunk_size = chunk_end - ptr;
+
+      if (read != nullptr)
+        std::memcpy (read, entry->data () + offset, chunk_size);
+      else
+        {
+          std::memcpy (entry->data () + offset, write, chunk_size);
+          entry->mark_offset_range_dirty (offset, chunk_size);
+        }
+
+      ptr += chunk_size;
+      if (read != nullptr)
+        read = static_cast<char *> (read) + chunk_size;
+      if (write != nullptr)
+        write = static_cast<const char *> (write) + chunk_size;
+
+      size -= chunk_size;
     }
 
-  dbgapi_assert (begin != m_cache_line_map.end ());
-  auto &cache_line = begin->second;
-  auto offset = address - first_line;
-
-  if (read != nullptr)
-    {
-      memcpy (read, &cache_line.m_data[0] + offset, size);
-    }
-  else
-    {
-      memcpy (&cache_line.m_data[0] + offset, write, size);
-      cache_line.m_dirty = true;
-    }
-
-  return size;
+  return ptr - address;
 }
 
 } /* namespace amd::dbgapi */

--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -28,7 +28,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <map>
+#include <list>
 #include <optional>
 #include <string>
 #include <type_traits>
@@ -487,28 +487,100 @@ public:
 };
 
 /* A write-back memory cache.  Data is immediately updated in the cache, and
-   later updated in memory when the cache is flushed.  */
+   later updated in memory when the cache is flushed.  This caches wave state
+   data.  For compute, each entry corresponds to one xcc's worth of save area
+   data from a given queue.  */
 
 class memory_cache_t
 {
-public:
-  static constexpr size_t cache_line_size = 64;
-
 private:
   using delegate_fn_type
     = std::function<size_t (agent_address_t /* address */, void * /* read */,
                             const void * /* write */, size_t /* size */)>;
 
-  struct cache_line_t
+  struct cache_entry_t
   {
-    std::array<std::byte, cache_line_size> m_data{};
-    bool m_dirty{ false };
+  private:
+    agent_address_t m_address{ 0 };
+    size_t m_size{ 0 };
+    /* The data buffer.  This buffer only grows, it never shrinks, across
+       cache_entry_t reuses.  We don't use a std::vector instead to avoid value
+       (i.e. zero) initialization, for performance reasons.  */
+    std::unique_ptr<std::byte[]> m_data{};
+
+    /* Start and end offsets into data, tracking where we know dirty bytes are.
+       The whole range is clean if start and end are the same.  This is a single
+       range because memory_cache_t::write_back does one single write, for
+       performance.  */
+    size_t m_dirty_range_start_offset{ 0 };
+    size_t m_dirty_range_end_offset{ 0 };
+
+  public:
+    /* Reset an entry.  Not a ctor as we reuse cache entries.  */
+    void reset (agent_address_t address, size_t size)
+    {
+      /* Resize storage if needed.  */
+      if (m_data == nullptr || m_size < size)
+        m_data = std::make_unique<std::byte[]> (size);
+
+      m_address = address;
+      m_size = size;
+      mark_clean ();
+    }
+
+    /* Simple getters.  */
+    agent_address_t address () const { return m_address; }
+    size_t size () const { return m_size; }
+    const std::byte *data () const { return &m_data[0]; }
+    std::byte *data () { return &m_data[0]; }
+
+    /* Returns true if the entry is dirty.  */
+    bool dirty () const
+    {
+      return m_dirty_range_start_offset != m_dirty_range_end_offset;
+    }
+
+    /* Returns the offset into the first dirty byte.  */
+    agent_address_t dirty_range_start_offset () const
+    {
+      return m_dirty_range_start_offset;
+    }
+
+    /* Returns the size of the dirty range.  */
+    size_t dirty_range_size () const
+    {
+      return m_dirty_range_end_offset - m_dirty_range_start_offset;
+    }
+
+    /* Marks the given range dirty.  */
+    void mark_offset_range_dirty (size_t dirty_offset, size_t dirty_size)
+    {
+      if (!dirty () || dirty_offset < m_dirty_range_start_offset)
+        m_dirty_range_start_offset = dirty_offset;
+
+      size_t end_offset = dirty_offset + dirty_size;
+      if (end_offset > m_dirty_range_end_offset)
+        m_dirty_range_end_offset = end_offset;
+    }
+
+    /* Marks the whole entry not-dirty.  */
+    void mark_clean ()
+    {
+      m_dirty_range_start_offset = m_dirty_range_end_offset = 0;
+    }
   };
 
   /* The agent which this cache is for.  */
   const agent_t &m_agent;
 
-  std::map<agent_address_t, cache_line_t> m_cache_line_map;
+  /* The in-use cache entries.  */
+  std::list<cache_entry_t> m_cache_entries;
+
+  /* The not-in-use cache entries.  When an entry is discarded, it is
+     moved here from the in-use list.  This avoids memory
+     reallocation, improving performance.  */
+  std::list<cache_entry_t> m_unused_cache_entries;
+
   delegate_fn_type const m_xfer_agent_memory;
 
   size_t xfer_agent_memory (agent_address_t address, void *read,
@@ -519,20 +591,21 @@ public:
     : m_agent (agent), m_xfer_agent_memory (std::move (xfer_agent_memory))
   {
   }
-  ~memory_cache_t () { dbgapi_assert (m_cache_line_map.empty ()); }
+  ~memory_cache_t () { dbgapi_assert (m_cache_entries.empty ()); }
 
-  bool contains_all (agent_address_t address, amd_dbgapi_size_t size) const;
+  /* Create a cache entry for the [address, address+size) range.  The range
+     must not be already cached.  Returns a non-owning pointer to the
+     contiguous block of cached data covering the specified range.  */
+  std::byte *new_entry (agent_address_t address, amd_dbgapi_size_t size);
 
-  /* Create cache lines if not already valid, and immediately fill them in.  */
-  void prefetch (agent_address_t address, amd_dbgapi_size_t size);
-
-  /* Discard all cache lines in the specified range.  If FORCE_DISCARD
-     is true, dirty lines are silently dropped.  Otherwise it is an error to
-     discarded dirty cache lines.  */
+  /* Discard all cache entries in the specified range.  Discarding a partial
+     entry is not allowed; the specified range must contain whole cached regions
+     (or none).  If FORCE_DISCARD is true, dirty entries are silently
+     dropped. Otherwise it is an error to discard dirty cache entries.  */
   void discard (agent_address_t address = 0, amd_dbgapi_size_t size = -1,
                 bool force_discard = false);
 
-  /* Write dirty lines back to memory.  */
+  /* Write dirty cached entries back to memory.  */
   void write_back (agent_address_t address = 0, amd_dbgapi_size_t size = -1);
 
   [[nodiscard]] size_t read_agent_memory (agent_address_t address,

--- a/projects/rocdbgapi/src/queue.cpp
+++ b/projects/rocdbgapi/src/queue.cpp
@@ -507,20 +507,19 @@ aql_queue_t::queue_state_changed ()
       m_waves_running.reset ();
 
       /* The queue just changed state and is about to be placed back onto the
-         hardware.  Write back dirty cache lines in the wave saved state
-         region, but leave the cache lines valid so that accessing stopped
-         waves' cached registers does not require a queue suspend/resume.  The
-         saved state cache lines will be discarded when this queue is next
-         suspended again (see the 'case state_t::suspended:' below).  */
+         hardware.  Write back the cached wave saved state region (if dirty),
+         but leave the cached state valid so that accessing stopped waves'
+         cached registers does not require a queue suspend/resume.  The saved
+         state cache will be discarded when this queue is next suspended again
+         (see the 'case state_t::suspended:' below).  */
       agent ().memory_cache ().write_back (
         m_os_queue_info.ctx_save_restore_address,
         xcc_count * m_os_queue_info.ctx_save_restore_area_size);
       break;
 
     case state_t::suspended:
-      /* Discard the previously cached wave saved state lines.  The saved state
-         areas may be mapped to a different address in this new context wave
-         save.  */
+      /* Discard the previously cached wave saved state.  The saved state areas
+         may be mapped to a different address in this new context wave save.  */
       agent ().memory_cache ().discard (
         m_os_queue_info.ctx_save_restore_address,
         xcc_count * m_os_queue_info.ctx_save_restore_area_size);
@@ -626,16 +625,6 @@ aql_queue_t::update_waves ()
   {
     dbgapi_assert (*this == cwsr_record->queue ());
     process_t &process = cwsr_record->process ();
-
-    auto prefetch_begin
-      = cwsr_record->register_address (amdgpu_regnum_t::first_hwreg).value ();
-    auto prefetch_end
-      = cwsr_record->register_address (amdgpu_regnum_t::last_ttmp).value ()
-        + architecture ().register_size (amdgpu_regnum_t::last_ttmp);
-
-    dbgapi_assert (prefetch_end > prefetch_begin);
-    cwsr_record->agent ().memory_cache ().prefetch (
-      prefetch_begin, prefetch_end - prefetch_begin);
 
     wave_t *wave = nullptr;
 
@@ -795,10 +784,15 @@ aql_queue_t::update_waves ()
       auto wave_area_end = ctx_save_address + header.wave_state_offset;
       auto wave_area_begin = wave_area_end - header.wave_state_size;
 
-      /* The control stack and the wave save area should be contiguous.  */
+      /* The control stack and the wave save area should be contiguous: the
+         control stack grows down from the start point, and wave area grows
+         up.  */
       if (control_stack_end != wave_area_begin)
         fatal_error ("corrupted context save area header");
 
+      /* If there is data (control stack not empty), read the entire control
+         stack plus wave area in one go, cache it, and decode the context
+         stack.  */
       if (control_stack_begin != control_stack_end)
         {
           log_info ("decoding %s's context save area #%u: "
@@ -808,19 +802,36 @@ aql_queue_t::update_waves ()
                     to_cstring (control_stack_end),
                     to_cstring (wave_area_begin), to_cstring (wave_area_end));
 
-          /* Read the entire control stack from the inferior in one go.  */
-          amd_dbgapi_size_t size = control_stack_end - control_stack_begin;
-          if (!utils::is_aligned (size, sizeof (uint32_t)))
+          /* Cache the memory block.  We only really should need the chunk that
+             corresponds to the wave area, as we never need the control stack
+             again after decoding it, and we never need to write it back.
+             However, this is a speed-sensitive code path, where we want to
+             minimize number of (somewhat large) memory allocations, so cache it
+             all so that there's only one memory read, and one allocation.  Note
+             that writing back cache entries only writes back the dirty region,
+             so we won't write back the control stack for that reason
+             regardless.  */
+          std::byte *memory = (agent ().memory_cache ().new_entry (
+            control_stack_begin, wave_area_end - control_stack_begin));
+
+          amd_dbgapi_size_t control_stack_byte_size
+            = control_stack_end - control_stack_begin;
+          if (!utils::is_aligned (control_stack_byte_size, sizeof (uint32_t)))
             fatal_error ("corrupted control stack");
 
-          auto memory
-            = std::make_unique<uint32_t[]> (size / sizeof (uint32_t));
-          agent ().read_agent_memory (control_stack_begin, &memory[0], size);
+          /* MEMORY is heap-allocated, so it is guaranteed to have sufficient
+             alignment to be cast to uint32_t.  */
+          if (!utils::is_aligned (reinterpret_cast<uintptr_t> (memory),
+                                  alignof (uint32_t)))
+            fatal_error ("unexpected buffer alignment");
+          const auto *control_stack = reinterpret_cast<uint32_t *> (memory);
+          size_t control_stack_words
+            = control_stack_byte_size / sizeof (uint32_t);
 
           /* Decode the control stack.  For each entry in the control stack,
              the provided callback function is called with a CWSR record.  */
           wave_count += architecture ().control_stack_iterate (
-            *this, xcc_id, &memory[0], size / sizeof (uint32_t), wave_area_end,
+            *this, xcc_id, control_stack, control_stack_words, wave_area_end,
             wave_area_end - wave_area_begin, process_cwsr_record);
         }
     }

--- a/projects/rocdbgapi/src/wave.cpp
+++ b/projects/rocdbgapi/src/wave.cpp
@@ -653,28 +653,6 @@ wave_t::read_register (amdgpu_regnum_t regnum, size_t offset,
       return;
     }
 
-  std::optional<scoped_queue_suspend_t> suspend;
-  if (!queue ().is_suspended ()
-      && !agent ().memory_cache ().contains_all (*reg_addr + offset,
-                                                 value_size))
-    {
-      /* Get the wave_id before suspending the queue, as this wave could have
-         exited, and queue_t::update_waves may destroy this wave_t.  */
-      amd_dbgapi_wave_id_t wave_id = id ();
-
-      suspend.emplace (queue (), "read register");
-
-      /* Look for the wave_id again, the wave may have exited.  */
-      wave_t *wave = find (wave_id);
-      if (wave == nullptr)
-        throw api_error_t (AMD_DBGAPI_STATUS_ERROR_INVALID_WAVE_ID);
-
-      dbgapi_assert (wave == this);
-
-      /* The wave's saved state may have changed location in memory.  */
-      reg_addr = register_address (regnum);
-    }
-
   agent ().read_agent_memory (*reg_addr + offset, value, value_size);
 }
 


### PR DESCRIPTION
This patch improves debug experience on Windows massively, and on
Linux substantially.

For example, on my Linux box with a gfx1030, using the
gdb.rocm/step-many-waves.exp ROCgdb testcase, before the patch, I see:

- Before patch, Linux, debug dbgapi build (+ debug rocgdb):

$ grep "Command execution time" testsuite/gdb.log
Command execution time: 0.614215 (cpu), 0.627181 (wall)
Command execution time: 0.020337 (cpu), 0.020627 (wall)
Command execution time: 1.212774 (cpu), 1.235801 (wall)
Command execution time: 0.020677 (cpu), 0.020959 (wall)
Command execution time: 1.195660 (cpu), 1.218044 (wall)

- Before patch, Linux, release dbgapi build (+ debug rocgdb):

$ grep "Command execution time" testsuite/gdb.log
Command execution time: 0.196843 (cpu), 0.206161 (wall)
Command execution time: 0.009141 (cpu), 0.009376 (wall)
Command execution time: 0.355500 (cpu), 0.373839 (wall)
Command execution time: 0.011062 (cpu), 0.011291 (wall)
Command execution time: 0.345165 (cpu), 0.363483 (wall)

After the patch, on the same Linux machine I get around the following
times:

- After patch, Linux, debug dbgapi build (+ debug rocgdb):

$ grep "Command execution time" testsuite/gdb.log
Command execution time: 0.194576 (cpu), 0.204046 (wall)
Command execution time: 0.009021 (cpu), 0.009235 (wall)
Command execution time: 0.382576 (cpu), 0.419615 (wall)
Command execution time: 0.009179 (cpu), 0.009406 (wall)
Command execution time: 0.379717 (cpu), 0.397690 (wall)

- After patch, Linux, release dbgapi build (+ debug rocgdb):

$ grep "Command execution time" testsuite/gdb.log
Command execution time: 0.064394 (cpu), 0.073941 (wall)
Command execution time: 0.005430 (cpu), 0.005668 (wall)
Command execution time: 0.115358 (cpu), 0.134396 (wall)
Command execution time: 0.005047 (cpu), 0.005300 (wall)
Command execution time: 0.115153 (cpu), 0.134178 (wall)

So about 3 times-ish for the slower steps, in either debug/release.

On my Windows machine with an gfx1201, just the first "next" command
takes between 200 and 440 seconds (sic!), resulting in
gdb.rocm/step-many-waves.exp timeouts.

With this patch, on the same Windows machine, I get around the
following times:

Windows, debug dbgapi build (+ debug rocgdb):

$ grep "Command execution time" testsuite/gdb.log
Command execution time: 1.961000 (cpu), 1.961469 (wall)
Command execution time: 0.129000 (cpu), 0.129094 (wall)
Command execution time: 1.522000 (cpu), 1.522097 (wall)
Command execution time: 2.065000 (cpu), 2.064715 (wall)
Command execution time: 0.127000 (cpu), 0.127054 (wall)

Windows, release dbgapi build (+ debug rocgdb):

$ grep "Command execution time" gdb.log
Command execution time: 1.391000 (cpu), 1.391136 (wall)
Command execution time: 0.111000 (cpu), 0.111063 (wall)
Command execution time: 1.267000 (cpu), 1.267022 (wall)
Command execution time: 1.783000 (cpu), 1.783264 (wall)
Command execution time: 0.127000 (cpu), 0.126915 (wall)

===================

The problem in the current code is that we do thousands of accesses
out of the save area region, and memory accesses on Windows are slower
than on Linux.  While on Linux reading a few bytes out of the inferior
takes in the order of 10 microseconds, on Windows, it takes from 2 to
20 milliseconds, with most accesses falling in the 3ms region.  It's
mostly a latency problem -- larger transfers take not that much more
time than smaller transfers proportionally.  Since on Windows we have
a higher latency for each memory access, it's important to batch as
much as we can into fewer, but larger accesses.

We already have a caching mechanism in dbgapi, that caches a small
portion of the save area whenever we update waves.

Based on a suggestion from Lancelot, this patch starts by making us
cache the whole save area instead, reducing thousands of xfers down to
one.

That's just the beginning, though.

If we do that, then we still see many memory writes, most 128 bytes
long each.  Those come from the memory cache write back code.  128
bytes is a multiple of the size of the cache lines, which is 64 bytes.
We see many writes because even though the code already coalesces
contiguous cache lines, it only does so for contiguous DIRTY cache
lines.  I.e., if you have the following all contiguous cache lines 1
through 9, with D for dirty, and C for clean:

1 2 3 4 5 6 7 8 9
D D C D C D C D C

then we write back cache lines 1 and 2 in a single memory write call,
and then three more separate calls for 4, 6 and 8.

I tried improving that by making the write back code write lines 1
through 8 in one go.  That did improve timings on Windows
substantially already, from the 440s for one single "next" in the
gdb.rocm/step-many-waves.exp testcase down to between 6s and 20s.
Still far from ideal, but way better.  However, the resulting patch
degraded the performance on Linux by some 10x, which is unacceptable.

The reason for that slowdown on Linux was simply the cache lines
allocation.  I.e., with a prefetch save area size of 12134416 on my
machine, and 64 bytes long cache lines, we end up allocating some 190k
cache lines, each a separate heap allocation...  On Windows, for a
single prefetch call, we would now be spending between 3 and 8 ms
reading memory from the inferior, and then still spend 200ms
allocating the cache lines, in the loop at the bottom of
memory_cache_t<AddressType>::prefetch.  The times of Linux were lower,
but of similar shape -- the memory xfer is fast, and then the
allocation step can also take up to 100ms.  This completely explains
the 10x slowdown on Linux.

Now, I considered several ways to address this, including increasing
the cache line size, reusing cache lines across discard/prefill calls,
and others.  However, there is one important detail -- there is ONE
single prefetch call in the whole codebase.  The memory cache
mechanism is solely used for the save areas, nothing else.  There is
no code that wants to cache random areas without a clear access
pattern.

This suggests to me that we can redesign the class, make it more tuned
to save area caching, and simplify it at the same time.  That's what
this patch does.

- Remove the concept of cache lines, and replace it with cache
entries, the size of the whole cache request area.

- Since we now have a full contiguous block of storage per cache
entry, we can return the pointer to the cache entry directly to the
caller of prefetch, avoiding one redundant memory allocation in
update_waves.  This improves performance a bit.

- Reuse cache entries.  This also improves performance a bit.

- Writing back an entry is a single memory xfer. Track a range of
dirty bytes per entry instead of a boolean, so that that write
avoids writing non-dirty bytes unnecessarily.  E.g., the control
stack region doesn't need to be written back.  This also improves
performance.

- Assume (and document, and assert) that discarding never tries to
discard a partial cached entry.

If we ever want to go back to having a more generalized memory cache,
to keep the efficiency gains of this commit, I'd suggest doing it by
reintroducing aligned cache lines, but making the lines have variable
width multiple of the cache line size, and introduce a way to force
aggregating smaller blocks into one larger contiguous block, so that
the semantics of the memory_cache_t::new_entry entry point in the new
code, of returning a pointer to a contiguous block, can be preserved
in the save area cases.  For now, since we don't need it, that would
just seem like extra unnecessary complication to me.

Finally, the memory_cache_t::contains_all call in
wave_t::read_register is no longer necessary as the cache is
guaranteed to always have the whole save area.

Tested on both Linux and Windows.

Change-Id: Iffa425669dbd989535a2f1c2945bea4720a9589f

---

**Stack**:
- #3305 ⬅
- #3304
- #3303
- #3302
- #3301
- #3300


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*