### PR TITLE
ROCM-2933 - no type coercion for reduction

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
@@ -505,7 +505,7 @@ __device__ inline unsigned int __reduce_max_sync(MaskT mask, unsigned int val) {
 
 template <typename MaskT>
 __device__ inline unsigned int __reduce_or_sync(MaskT mask, unsigned int val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs || rhs; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs == 1 || rhs == 1; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_or_u32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
@@ -513,7 +513,7 @@ __device__ inline unsigned int __reduce_or_sync(MaskT mask, unsigned int val) {
 
 template <typename MaskT>
 __device__ inline unsigned int __reduce_and_sync(MaskT mask, unsigned int val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs && rhs; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs == 1 && rhs == 1; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_and_u32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
@@ -616,14 +616,14 @@ template <typename MaskT> __device__ inline double __reduce_max_sync(MaskT mask,
 }
 
 template <typename MaskT> __device__ inline int __reduce_and_sync(MaskT mask, int val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs && rhs; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs == 1 && rhs == 1; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_and_i32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
 }
 
 template <typename MaskT> __device__ inline long long __reduce_and_sync(MaskT mask, long long val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs && rhs; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs == 1 && rhs == 1; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_and_i64(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
@@ -631,21 +631,21 @@ template <typename MaskT> __device__ inline long long __reduce_and_sync(MaskT ma
 
 template <typename MaskT>
 __device__ inline unsigned long long __reduce_and_sync(MaskT mask, unsigned long long val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs && rhs; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs == 1 && rhs == 1; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_and_u64(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
 }
 
 template <typename MaskT> __device__ inline int __reduce_or_sync(MaskT mask, int val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs || rhs; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs == 1 || rhs == 1; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_or_i32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
 }
 
 template <typename MaskT> __device__ inline long long __reduce_or_sync(MaskT mask, long long val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs || rhs; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs == 1 || rhs == 1; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_or_i64(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
@@ -653,7 +653,7 @@ template <typename MaskT> __device__ inline long long __reduce_or_sync(MaskT mas
 
 template <typename MaskT>
 __device__ inline unsigned long long __reduce_or_sync(MaskT mask, unsigned long long val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs || rhs; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs == 1 || rhs == 1; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_or_u64(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_warp_sync_functions.h
@@ -505,7 +505,7 @@ __device__ inline unsigned int __reduce_max_sync(MaskT mask, unsigned int val) {
 
 template <typename MaskT>
 __device__ inline unsigned int __reduce_or_sync(MaskT mask, unsigned int val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs == 1 || rhs == 1; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs | rhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_or_u32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
@@ -513,7 +513,7 @@ __device__ inline unsigned int __reduce_or_sync(MaskT mask, unsigned int val) {
 
 template <typename MaskT>
 __device__ inline unsigned int __reduce_and_sync(MaskT mask, unsigned int val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs == 1 && rhs == 1; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs & rhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_and_u32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
@@ -521,7 +521,7 @@ __device__ inline unsigned int __reduce_and_sync(MaskT mask, unsigned int val) {
 
 template <typename MaskT>
 __device__ inline unsigned int __reduce_xor_sync(MaskT mask, unsigned int val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return (!lhs) != (!rhs) == 1; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs ^ rhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_xor_u32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
@@ -616,14 +616,14 @@ template <typename MaskT> __device__ inline double __reduce_max_sync(MaskT mask,
 }
 
 template <typename MaskT> __device__ inline int __reduce_and_sync(MaskT mask, int val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs == 1 && rhs == 1; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs & rhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_and_i32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
 }
 
 template <typename MaskT> __device__ inline long long __reduce_and_sync(MaskT mask, long long val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs == 1 && rhs == 1; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs & rhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_and_i64(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
@@ -631,21 +631,21 @@ template <typename MaskT> __device__ inline long long __reduce_and_sync(MaskT ma
 
 template <typename MaskT>
 __device__ inline unsigned long long __reduce_and_sync(MaskT mask, unsigned long long val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs == 1 && rhs == 1; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs & rhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_and_u64(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
 }
 
 template <typename MaskT> __device__ inline int __reduce_or_sync(MaskT mask, int val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs == 1 || rhs == 1; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs | rhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_or_i32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
 }
 
 template <typename MaskT> __device__ inline long long __reduce_or_sync(MaskT mask, long long val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs == 1 || rhs == 1; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs | rhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_or_i64(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
@@ -653,21 +653,21 @@ template <typename MaskT> __device__ inline long long __reduce_or_sync(MaskT mas
 
 template <typename MaskT>
 __device__ inline unsigned long long __reduce_or_sync(MaskT mask, unsigned long long val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs == 1 || rhs == 1; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs | rhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_or_u64(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
 }
 
 template <typename MaskT> __device__ inline int __reduce_xor_sync(MaskT mask, int val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return (!lhs) != (!rhs) == 1; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs ^ rhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_xor_i32(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
 }
 
 template <typename MaskT> __device__ inline long long __reduce_xor_sync(MaskT mask, long long val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return (!lhs) != (!rhs) == 1; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs ^ rhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_xor_i64(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);
@@ -675,7 +675,7 @@ template <typename MaskT> __device__ inline long long __reduce_xor_sync(MaskT ma
 
 template <typename MaskT>
 __device__ inline unsigned long long __reduce_xor_sync(MaskT mask, unsigned long long val) {
-  auto op = [](decltype(val) lhs, decltype(val) rhs) { return (!lhs) != (!rhs) == 1; };
+  auto op = [](decltype(val) lhs, decltype(val) rhs) { return lhs ^ rhs; };
   auto wfReduce = [](decltype(val) v) { return __ockl_wfred_xor_u64(v); };
 
   return __reduce_op_sync(mask, val, op, wfReduce);

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -231,6 +231,22 @@ struct XorOp {
   }
 };
 
+template <class T>
+struct AndOp {
+  __host__ __device__ T operator()(const T& lhs, const T& rhs)
+  {
+    return lhs == 1 && rhs == 1;
+  }
+};
+
+template <class T>
+struct OrOp {
+  __host__ __device__ T operator()(const T& lhs, const T& rhs)
+  {
+    return lhs == 1 || rhs == 1;
+  }
+};
+
 // typeid(T).name() does seem to return a very descriptive name for primitive types,
 // at least on clang, so we roll out an equivalent
 template<class T>
@@ -264,9 +280,9 @@ const char* opToString()
     return "min";
   else if constexpr (std::is_same<Op<T>, MaxOp<T>>::value)
     return "max";
-  else if constexpr (std::is_same<Op<T>, std::logical_and<T>>::value)
+  else if constexpr (std::is_same<Op<T>, AndOp<T>>::value)
     return "logical_and";
-  else if constexpr (std::is_same<Op<T>, std::logical_or<T>>::value)
+  else if constexpr (std::is_same<Op<T>, OrOp<T>>::value)
     return "logical_or";
   else if constexpr (std::is_same<Op<T>, XorOp<T>>::value)
     return "logical_xor";

--- a/projects/hip-tests/catch/include/warp_common.hh
+++ b/projects/hip-tests/catch/include/warp_common.hh
@@ -227,7 +227,7 @@ template <class T>
 struct XorOp {
   __host__ __device__ T operator()(const T& lhs, const T& rhs)
   {
-    return (!lhs) != (!rhs) == 1;
+    return lhs ^ rhs;
   }
 };
 
@@ -235,7 +235,7 @@ template <class T>
 struct AndOp {
   __host__ __device__ T operator()(const T& lhs, const T& rhs)
   {
-    return lhs == 1 && rhs == 1;
+    return lhs & rhs;
   }
 };
 
@@ -243,7 +243,7 @@ template <class T>
 struct OrOp {
   __host__ __device__ T operator()(const T& lhs, const T& rhs)
   {
-    return lhs == 1 || rhs == 1;
+    return lhs | rhs;
   }
 };
 
@@ -300,6 +300,7 @@ void genRandomMasks(LinearAllocGuard<T>& d_buf,
 {
   // masks must be != 0, hence passing 1 as the 'a' distribution parameter
   std::uniform_int_distribution<unsigned long long> dist(1);
+  std::uniform_int_distribution<unsigned long long> distNoHoles(1, getWarpSize() - 2);
   int numBytes = numItems * sizeof(T);
   LinearAllocGuard<T> tmp(LinearAllocs::malloc, numBytes);
   LinearAllocGuard<T> d_tmp(LinearAllocs::hipMalloc, numBytes);
@@ -308,10 +309,19 @@ void genRandomMasks(LinearAllocGuard<T>& d_buf,
   d_buf = std::move(d_tmp);
 
   for (int i = 0; i < numItems; i++) {
-    T mask = dist(gen);
+    T mask;
 
-    if (getWarpSize() == 32)
-      mask &= 0xFFFFFFFF;
+    if (i % 5 == 0) {
+      // every five masks, create a mask that starts in position zero and has "no holes",
+      // because those take a different code path, where DPP instructions are used
+      mask = 1 << distNoHoles(gen);
+      mask--;
+    } else {
+      mask = dist(gen);
+
+      if (getWarpSize() == 32)
+        mask &= 0xFFFFFFFF;
+    }
 
     buf.ptr()[i] = mask;
   }
@@ -505,8 +515,10 @@ void runTestReduce(int iteration, Reduce reduce)
   std::mt19937_64 gen(iteration);
   // for float16, we generate any random unsigned short, but cap the exponent later on
   // On the rest of the types, just use a bigger reduced range of numbers to avoid overflows too
-  typename distribution::result_type a = std::is_same<T, half>::value? std::numeric_limits<unsigned short>::lowest() : -1023;
-  typename distribution::result_type b = std::is_same<T, half>::value? std::numeric_limits<unsigned short>::max() : 1023;
+  typename distribution::result_type a = std::is_same<T, half>::value? std::numeric_limits<unsigned short>::lowest() :
+                                      (std::is_signed<T>::value? -1023 : 0);
+  typename distribution::result_type b = std::is_same<T, half>::value? std::numeric_limits<unsigned short>::max() :
+                                      1023;
   distribution dist(a, b);
   LinearAllocGuard<T> input, d_input;
   LinearAllocGuard<unsigned long long> masks, d_masks;

--- a/projects/hip-tests/catch/performance/warpSync/warpSync.cc
+++ b/projects/hip-tests/catch/performance/warpSync/warpSync.cc
@@ -113,9 +113,9 @@ __global__ void reduceOpSync(T* __restrict__ output, const T* __restrict__ input
       result = __reduce_min_sync(mask, input[idx]);
     else if constexpr (std::is_same<Op<T>, MaxOp<T>>::value)
       result = __reduce_max_sync(mask, input[idx]);
-    else if constexpr (std::is_same<Op<T>, std::logical_and<T>>::value)
+    else if constexpr (std::is_same<Op<T>, AndOp<T>>::value)
       result = __reduce_and_sync(mask, input[idx]);
-    else if constexpr (std::is_same<Op<T>, std::logical_or<T>>::value)
+    else if constexpr (std::is_same<Op<T>, OrOp<T>>::value)
       result = __reduce_or_sync(mask, input[idx]);
     else if constexpr (std::is_same<Op<T>, XorOp<T>>::value)
       result = __reduce_xor_sync(mask, input[idx]);
@@ -145,9 +145,9 @@ template <class T, template <typename> class Op> class AtomicBenchmark
         reduceAllAtomics<T, AtomicMinOp><<<gridDim, blockDim, sharedSize>>>(output, input, mask);
       else if constexpr (std::is_same<Op<T>, MaxOp<T>>::value)
         reduceAllAtomics<T, AtomicMaxOp><<<gridDim, blockDim, sharedSize>>>(output, input, mask);
-      else if constexpr (std::is_same<Op<T>, std::logical_and<T>>::value)
+      else if constexpr (std::is_same<Op<T>, AndOp<T>>::value)
         reduceAllAtomics<T, AtomicAndOp><<<gridDim, blockDim, sharedSize>>>(output, input, mask);
-      else if constexpr (std::is_same<Op<T>, std::logical_or<T>>::value)
+      else if constexpr (std::is_same<Op<T>, OrOp<T>>::value)
         reduceAllAtomics<T, AtomicOrOp><<<gridDim, blockDim, sharedSize>>>(output, input, mask);
       else if constexpr (std::is_same<Op<T>, XorOp<T>>::value)
         reduceAllAtomics<T, AtomicXorOp><<<gridDim, blockDim, sharedSize>>>(output, input, mask);
@@ -205,11 +205,11 @@ template <class T, template <typename> class Op> struct IsLogicalOp {
   static constexpr bool value = false;
 };
 
-template <class T> struct IsLogicalOp<T, std::logical_and> {
+template <class T> struct IsLogicalOp<T, AndOp> {
   static constexpr bool value = true;
 };
 
-template <class T> struct IsLogicalOp<T, std::logical_or> {
+template <class T> struct IsLogicalOp<T, OrOp> {
   static constexpr bool value = true;
 };
 
@@ -349,14 +349,14 @@ TEMPLATE_TEST_CASE("Performance_Reduce_Sync_Max", "", int, unsigned int, unsigne
 
 TEMPLATE_TEST_CASE("Performance_Reduce_Sync_And", "", int, unsigned int, unsigned long long,
                    long long) {
-  ReduceBenchmark<TestType, std::logical_and> benchmark;
+  ReduceBenchmark<TestType, AndOp> benchmark;
 
   benchmark.Run();
 }
 
 TEMPLATE_TEST_CASE("Performance_Reduce_Sync_Or", "", int, unsigned int, unsigned long long,
                    long long) {
-  ReduceBenchmark<TestType, std::logical_or> benchmark;
+  ReduceBenchmark<TestType, OrOp> benchmark;
 
   benchmark.Run();
 }

--- a/projects/hip-tests/catch/unit/rtc/rtc_reduce.cc
+++ b/projects/hip-tests/catch/unit/rtc/rtc_reduce.cc
@@ -108,10 +108,10 @@ void opToString(std::string& scalarName, std::string& intrinsicName) {
   } else if constexpr (std::is_same<Op<T>, MaxOp<T>>::value) {
     scalarName = "MaxOp";
     intrinsicName = "__reduce_max_sync";
-  } else if constexpr (std::is_same<Op<T>, std::logical_and<T>>::value) {
+  } else if constexpr (std::is_same<Op<T>, AndOp<T>>::value) {
     scalarName = "std::logical_and";
     intrinsicName = "__reduce_and_sync";
-  } else if constexpr (std::is_same<Op<T>, std::logical_or<T>>::value) {
+  } else if constexpr (std::is_same<Op<T>, OrOp<T>>::value) {
     scalarName = "std::logical_or";
     intrinsicName = "__reduce_or_sync";
   } else if constexpr (std::is_same<Op<T>, XorOp<T>>::value) {
@@ -182,9 +182,9 @@ TEST_CASE("Unit_Rtc_ReduceRandom") {
 
   SECTION("max") { runAndCompileTest<MaxOp>(allTypes); }
 
-  SECTION("and") { runAndCompileTest<std::logical_and>(integralTypes); }
+  SECTION("and") { runAndCompileTest<AndOp>(integralTypes); }
 
-  SECTION("or") { runAndCompileTest<std::logical_or>(integralTypes); }
+  SECTION("or") { runAndCompileTest<OrOp>(integralTypes); }
 
   SECTION("xor") { runAndCompileTest<XorOp>(integralTypes); }
 }

--- a/projects/hip-tests/catch/unit/warp/warp_reduce.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_reduce.cc
@@ -93,8 +93,10 @@ template <class T> void runTestMultipleMasks(unsigned long long masks[], int num
   LinearAllocGuard<T> d_output(LinearAllocs::hipMalloc, wavefrontSize * sizeof(T));
   std::plus<T> op;
   std::mt19937_64 gen(123);
-  T a = std::is_same<T, half>::value ? std::numeric_limits<unsigned short>::lowest() : -1023;
-  T b = std::is_same<T, half>::value ? std::numeric_limits<unsigned short>::max() : 1023;
+  typename distribution::result_type a = std::is_same<T, half>::value? std::numeric_limits<unsigned short>::lowest() :
+                                         (std::is_signed<T>::value? -1023 : 0);
+  typename distribution::result_type b = std::is_same<T, half>::value? std::numeric_limits<unsigned short>::max() :
+                                         1023;
   distribution distInput(a, b);
   dim3 blkDim{wavefrontSize};
   dim3 grdDim{1u};

--- a/projects/hip-tests/catch/unit/warp/warp_reduce.cc
+++ b/projects/hip-tests/catch/unit/warp/warp_reduce.cc
@@ -70,9 +70,9 @@ __global__ void reduceOp(T* output, const T* input, const MaskType* masks, int n
         result = __reduce_min_sync(masks[i], input[tid]);
       else if constexpr (std::is_same<Op, MaxOp<T>>::value)
         result = __reduce_max_sync(masks[i], input[tid]);
-      else if constexpr (std::is_same<Op, std::logical_and<T>>::value)
+      else if constexpr (std::is_same<Op, AndOp<T>>::value)
         result = __reduce_and_sync(masks[i], input[tid]);
-      else if (std::is_same<Op, std::logical_or<T>>::value)
+      else if (std::is_same<Op, OrOp<T>>::value)
         result = __reduce_or_sync(masks[i], input[tid]);
       else if (std::is_same<Op, XorOp<T>>::value)
         result = __reduce_xor_sync(masks[i], input[tid]);
@@ -206,9 +206,9 @@ TEST_CASE("Unit_hipReduceRandom") {
 
   SECTION("max") { runTestReduceForTypes<MaxOp>(allTypes); }
 
-  SECTION("and") { runTestReduceForTypes<std::logical_and>(integralTypes); }
+  SECTION("and") { runTestReduceForTypes<AndOp>(integralTypes); }
 
-  SECTION("or") { runTestReduceForTypes<std::logical_or>(integralTypes); }
+  SECTION("or") { runTestReduceForTypes<OrOp>(integralTypes); }
 
   SECTION("xor") { runTestReduceForTypes<XorOp>(integralTypes); }
 }


### PR DESCRIPTION
## Motivation

The `__reduce_and_sync()` and `__reduce_or_sync()` should behave like bitwise operators when operands that are not 1 or 0 are passed. This the behaviour that intrinsics like  `__ockl_wfred_and_u32()` and CUDA equivalents have.

The current code, when masks have "holes" and cannot use the OCKL intrinsics instead uses `operator&&` which coerces integers. e.g. values different to 1, will be coerced to 1; which causes a behavior mismatch.

## Technical Details
The PR removes the type coercion so the results would be consistent regardless whether holes or no holes are found, instead of using `operator&&`, `operator&` is used. And instead of using `operator||`, `operator|` is used.

## JIRA ID
ROCM-2933

## Test Plan

Update tests:
- now when generating reference results on the CPU, do not calculate them without type coercion
- make sure that, from time to time, "masks with no holes" are used, because those run in a different path that other masks. This brings the problem to the surface, i.e. doing that reproduces the inconsistency between the two code paths and the tests fail
- check for performance changes and compare results with CUDA.

## Test Result

AMD
Tests passed and there are no observed performance regressions (see [performance_Navi48_after_coercion_fix.txt](https://github.com/user-attachments/files/25484912/performance_Navi48_after_coercion_fix.txt))

Nvidia
The logical and/or/xor where tested on Nvidia by running WarpTest with CUDA 13.1 (the CUDA 13.0 compiler unfortunately hangs when compiling the code):

```
./WarpTest
Randomness seeded to: 781684154
===============================================================================
test cases: 1 | 1 passed
```

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
