### PR TITLE
[rocr-runtime]: Add custom comparator for hsa_signal_t in scratch_notifiers_ map

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -634,8 +634,14 @@ class GpuAgent : public GpuAgentInt {
   // @brief Current short duration scratch memory size.
   size_t scratch_used_large_;
 
+  struct HsaSignalLess {
+    bool operator()(const hsa_signal_t& lhs, const hsa_signal_t& rhs) const {
+      return lhs.handle < rhs.handle;
+    }
+  };
+
   // @brief Notifications for scratch release.
-  std::map<hsa_signal_t, hsa_signal_value_t> scratch_notifiers_;
+  std::map<hsa_signal_t, hsa_signal_value_t, HsaSignalLess> scratch_notifiers_;
 
   // @brief Default scratch size per queue.
   size_t queue_scratch_len_;


### PR DESCRIPTION
## Motivation

The hsa_signal_t type is a struct containing a handle member, not a primitive type. Using it directly as a map key without a custom comparator causes compilation failure with libc++. Add HsaSignalLess comparator that compares signal handles to ensure proper map ordering.

Closes: https://github.com/ROCm/rocm-systems/issues/3307

## Technical Details

This fixes compilation with libc++ 22.1.0_rc3 (the current version, aligned with ROCm 7.2.0 release). Full error message is added in the task.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Checked manually with libc++ 22.1.0_rc3. Checking with earlier versions is not a target. No functional changes, just a compilation fix.

## Test Result

It compiles.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
