### PR TITLE
[GitHub Actions] Add support for rebase merge commits in patch sync

### DIFF
--- a/.github/scripts/github_cli_client.py
+++ b/.github/scripts/github_cli_client.py
@@ -333,8 +333,12 @@ class GitHubCLIClient:
                 f"No valid labels to apply to PR #{pr_number} in {target_repo}."
             )
 
-    def get_squash_merge_commit(self, repo: str, pr_number: int) -> Optional[str]:
-        """Get the squash merge commit SHA of a merged pull request."""
+    def get_merge_commit(self, repo: str, pr_number: int) -> Optional[str]:
+        """Get the merge commit SHA of a merged pull request.
+
+        Works for both "Squash and merge" and "Rebase and merge" merge types.
+        Returns the merge_commit_sha from the PR API response.
+        """
         url = f"{self.api_url}/repos/{repo}/pulls/{pr_number}"
         logger.debug(f"Request URL: {url}")
         data = self._get_json(url, f"Failed to fetch PR #{pr_number} from {repo}")
@@ -345,6 +349,25 @@ class GitHubCLIClient:
             logger.debug(f"PR #{pr_number} merged commit: {data['merge_commit_sha']}")
             return data["merge_commit_sha"]
         logger.warning(f"PR #{pr_number} is not merged or missing merge commit SHA.")
+        return None
+
+    def get_pr_base_commit(self, repo: str, pr_number: int) -> Optional[str]:
+        """Get the base commit SHA of a pull request.
+
+        Returns the SHA of the base branch commit that the PR was targeting.
+        This is available in the PR API response as base.sha.
+        """
+        url = f"{self.api_url}/repos/{repo}/pulls/{pr_number}"
+        logger.debug(f"Request URL: {url}")
+        data = self._get_json(url, f"Failed to fetch PR #{pr_number} from {repo}")
+        if not data:
+            logger.error(f"No data returned for PR #{pr_number}")
+            return None
+        base_data = data.get("base", {})
+        if base_data.get("sha"):
+            logger.debug(f"PR #{pr_number} base commit: {base_data['sha']}")
+            return base_data["sha"]
+        logger.warning(f"PR #{pr_number} missing base commit SHA.")
         return None
 
     def get_user(self, username: str) -> tuple[str, str]:

--- a/.github/scripts/pr_merge_sync_patches.py
+++ b/.github/scripts/pr_merge_sync_patches.py
@@ -237,51 +237,38 @@ def generate_patch(
             f"No commits between {base_sha} and {merge_sha} for prefix '{prefix}', skipping"
         )
         return None
-    elif commit_count_int == 1:
-        # Single commit (squash merge), use existing approach
-        args = [
-            "format-patch",
-            "-1",
-            merge_sha,
-            f"--relative={prefix}",
-            "--output",
-            str(patch_path),
-        ]
-        _run_git(args)
-        logger.debug(
-            f"Generated single patch for prefix '{prefix}' at {patch_path} (squash merge)"
-        )
-        return [patch_path]
-    else:
-        # Multiple commits (rebase merge), generate separate patches
-        patch_dir = patch_path.parent
-        patch_stem = patch_path.stem
-        # Use format-patch with range to generate multiple patches
-        # Output will be numbered: 0001-<subject>.patch, 0002-<subject>.patch, etc.
-        args = [
-            "format-patch",
-            f"{base_sha}..{merge_sha}",
-            f"--relative={prefix}",
-            "--output-directory",
-            str(patch_dir),
-        ]
-        _run_git(args)
 
-        # Find all generated patch files (they'll be numbered)
-        patch_files = sorted(patch_dir.glob("*.patch"))
-        if not patch_files:
-            logger.error(
-                f"No patch files generated for range {base_sha}..{merge_sha} with prefix '{prefix}'"
-            )
-            raise RuntimeError(
-                f"Expected {commit_count_int} patch files but none were generated. "
-                f"This may indicate an issue with the commit range or prefix filter."
-            )
+    # Generate patches for all commits in the range (works for both single and multiple commits)
+    patch_dir = patch_path.parent
+    # Use format-patch with range to generate patches
+    # Output will be numbered: 0001-<subject>.patch, 0002-<subject>.patch, etc.
+    args = [
+        "format-patch",
+        f"{base_sha}..{merge_sha}",
+        f"--relative={prefix}",
+        "--output-directory",
+        str(patch_dir),
+    ]
+    _run_git(args)
 
-        logger.debug(
-            f"Generated {len(patch_files)} patch files for prefix '{prefix}' (rebase merge with {commit_count_int} commits)"
+    # Find all generated patch files (they'll be numbered)
+    # Note: With --relative, git only generates patches for commits that modify files
+    # within the prefix, so patch_files count may be less than commit_count_int
+    patch_files = sorted(patch_dir.glob("*.patch"))
+    if not patch_files:
+        logger.error(
+            f"No patch files generated for range {base_sha}..{merge_sha} with prefix '{prefix}'"
         )
-        return patch_files
+        raise RuntimeError(
+            f"No patch files were generated for range {base_sha}..{merge_sha} with prefix '{prefix}'. "
+            f"This is expected if none of the {commit_count_int} commits in this range modified files within this subtree, "
+            f"but may also indicate an issue with the commit range or prefix filter."
+        )
+
+    logger.debug(
+        f"Generated {len(patch_files)} patch file(s) for prefix '{prefix}' ({commit_count_int} commit(s) in range)"
+    )
+    return patch_files
 
 
 def resolve_patch_author(

--- a/.github/scripts/pr_merge_sync_patches.py
+++ b/.github/scripts/pr_merge_sync_patches.py
@@ -199,7 +199,7 @@ def _push_changes(repo_path: Path, branch: str) -> None:
 
 
 def generate_patch(
-    prefix: str, merge_sha: str, patch_path: Path, base_sha: Optional[str] = None
+    prefix: str, merge_sha: str, patch_path: Path, base_sha: str
 ) -> Optional[List[Path]]:
     """Generate patch file(s) for a given subtree prefix from a merge commit.
 
@@ -207,27 +207,12 @@ def generate_patch(
         prefix: The subtree prefix (e.g., "projects/rocBLAS/")
         merge_sha: The merge commit SHA
         patch_path: Path where patch file(s) should be written
-        base_sha: Optional base commit SHA. If provided, will detect if there are
-                 multiple commits and generate separate patches for each.
+        base_sha: Base commit SHA. Required to properly handle both squash and rebase merges.
 
     Returns:
         List[Path]: List of patch file paths (single entry for squash merges, multiple for rebase merges)
         None: If there are no commits to process
     """
-    if base_sha is None:
-        # No base SHA provided, use single commit approach (backward compatible)
-        args = [
-            "format-patch",
-            "-1",
-            merge_sha,
-            f"--relative={prefix}",
-            "--output",
-            str(patch_path),
-        ]
-        _run_git(args)
-        logger.debug(f"Generated single patch for prefix '{prefix}' at {patch_path}")
-        return [patch_path]
-
     # Check how many commits are between base and merge_sha
     commit_count = _run_git(["rev-list", "--count", f"{base_sha}..{merge_sha}"])
     commit_count_int = int(commit_count)
@@ -359,12 +344,13 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     # Get base commit to detect if this is a rebase merge with multiple commits
     base_sha = client.get_pr_base_commit(args.repo, args.pr)
-    if base_sha:
-        logger.debug(f"Base commit for PR #{args.pr} in {args.repo}: {base_sha}")
-    else:
-        logger.warning(
-            f"Could not get base commit for PR #{args.pr}, will use single commit approach"
+    if not base_sha:
+        logger.error(
+            f"Could not get base commit for PR #{args.pr} in {args.repo}. "
+            f"Base commit is required to properly handle both squash and rebase merges."
         )
+        return
+    logger.debug(f"Base commit for PR #{args.pr} in {args.repo}: {base_sha}")
 
     for entry in relevant_subtrees:
         prefix = f"{entry.category}/{entry.name}/"

--- a/.github/scripts/pr_merge_sync_patches.py
+++ b/.github/scripts/pr_merge_sync_patches.py
@@ -198,18 +198,90 @@ def _push_changes(repo_path: Path, branch: str) -> None:
     logger.debug(f"Pushed changes from {repo_path} to origin")
 
 
-def generate_patch(prefix: str, merge_sha: str, patch_path: Path) -> None:
-    """Generate a patch file for a given subtree prefix from a merge commit."""
-    args = [
-        "format-patch",
-        "-1",
-        merge_sha,
-        f"--relative={prefix}",
-        "--output",
-        str(patch_path),
-    ]
-    _run_git(args)
-    logger.debug(f"Generated patch for prefix '{prefix}' at {patch_path}")
+def generate_patch(
+    prefix: str, merge_sha: str, patch_path: Path, base_sha: Optional[str] = None
+) -> Optional[List[Path]]:
+    """Generate patch file(s) for a given subtree prefix from a merge commit.
+
+    Args:
+        prefix: The subtree prefix (e.g., "projects/rocBLAS/")
+        merge_sha: The merge commit SHA
+        patch_path: Path where patch file(s) should be written
+        base_sha: Optional base commit SHA. If provided, will detect if there are
+                 multiple commits and generate separate patches for each.
+
+    Returns:
+        List[Path]: List of patch file paths (single entry for squash merges, multiple for rebase merges)
+        None: If there are no commits to process
+    """
+    if base_sha is None:
+        # No base SHA provided, use single commit approach (backward compatible)
+        args = [
+            "format-patch",
+            "-1",
+            merge_sha,
+            f"--relative={prefix}",
+            "--output",
+            str(patch_path),
+        ]
+        _run_git(args)
+        logger.debug(f"Generated single patch for prefix '{prefix}' at {patch_path}")
+        return [patch_path]
+
+    # Check how many commits are between base and merge_sha
+    commit_count = _run_git(["rev-list", "--count", f"{base_sha}..{merge_sha}"])
+    commit_count_int = int(commit_count)
+
+    if commit_count_int == 0:
+        logger.debug(
+            f"No commits between {base_sha} and {merge_sha} for prefix '{prefix}', skipping"
+        )
+        return None
+    elif commit_count_int == 1:
+        # Single commit (squash merge), use existing approach
+        args = [
+            "format-patch",
+            "-1",
+            merge_sha,
+            f"--relative={prefix}",
+            "--output",
+            str(patch_path),
+        ]
+        _run_git(args)
+        logger.debug(
+            f"Generated single patch for prefix '{prefix}' at {patch_path} (squash merge)"
+        )
+        return [patch_path]
+    else:
+        # Multiple commits (rebase merge), generate separate patches
+        patch_dir = patch_path.parent
+        patch_stem = patch_path.stem
+        # Use format-patch with range to generate multiple patches
+        # Output will be numbered: 0001-<subject>.patch, 0002-<subject>.patch, etc.
+        args = [
+            "format-patch",
+            f"{base_sha}..{merge_sha}",
+            f"--relative={prefix}",
+            "--output-directory",
+            str(patch_dir),
+        ]
+        _run_git(args)
+
+        # Find all generated patch files (they'll be numbered)
+        patch_files = sorted(patch_dir.glob("*.patch"))
+        if not patch_files:
+            logger.error(
+                f"No patch files generated for range {base_sha}..{merge_sha} with prefix '{prefix}'"
+            )
+            raise RuntimeError(
+                f"Expected {commit_count_int} patch files but none were generated. "
+                f"This may indicate an issue with the commit range or prefix filter."
+            )
+
+        logger.debug(
+            f"Generated {len(patch_files)} patch files for prefix '{prefix}' (rebase merge with {commit_count_int} commits)"
+        )
+        return patch_files
 
 
 def resolve_patch_author(
@@ -234,33 +306,53 @@ def apply_patch_to_subrepo(
     entry: RepoEntry,
     super_repo_url: str,
     super_repo_pr: int,
-    patch_path: Path,
+    patch_paths: List[Path],
     author_name: str,
     author_email: str,
     merge_sha: str,
     dry_run: bool = False,
 ) -> None:
-    """Clone the subrepo, apply the patch, and attribute to the original author with commit message annotations."""
+    """Clone the subrepo, apply patch(es), and attribute to the original author with commit message annotations.
+
+    Args:
+        entry: Repository entry configuration
+        super_repo_url: URL of the super repository
+        super_repo_pr: PR number in the super repository
+        patch_paths: List of patch file paths
+        author_name: Author name for commits
+        author_email: Author email for commits
+        merge_sha: Merge commit SHA
+        dry_run: If True, only log actions without making changes
+    """
     with tempfile.TemporaryDirectory() as tmpdir:
         subrepo_path = Path(tmpdir) / entry.name
         _clone_subrepo(entry.url, entry.branch, subrepo_path)
         if dry_run:
+            patch_count = len(patch_paths)
             logger.info(
-                f"[Dry-run] Would apply patch to {entry.url} as {author_name} <{author_email}>"
+                f"[Dry-run] Would apply {patch_count} patch(es) to {entry.url} as {author_name} <{author_email}>"
             )
             return
+
         _configure_git_user(subrepo_path)
-        _apply_patch(subrepo_path, patch_path)
-        _stage_changes(subrepo_path)
-        original_commit_msg = _extract_commit_message_from_patch(patch_path)
-        commit_msg = _format_commit_message(
-            super_repo_url, super_repo_pr, merge_sha, original_commit_msg
-        )
-        _commit_changes(subrepo_path, commit_msg, author_name, author_email)
         _set_authenticated_remote(subrepo_path, entry.url)
+
+        # Apply each patch and create separate commits
+        for i, patch_path in enumerate(patch_paths, 1):
+            logger.debug(f"Applying patch {i}/{len(patch_paths)}: {patch_path.name}")
+            _apply_patch(subrepo_path, patch_path)
+            _stage_changes(subrepo_path)
+            original_commit_msg = _extract_commit_message_from_patch(patch_path)
+            commit_msg = _format_commit_message(
+                super_repo_url, super_repo_pr, merge_sha, original_commit_msg
+            )
+            _commit_changes(subrepo_path, commit_msg, author_name, author_email)
+            logger.debug(f"Committed patch {i}/{len(patch_paths)}")
+
+        # Push all commits at once
         _push_changes(subrepo_path, entry.branch)
         logger.info(
-            f"Patch applied, committed, and pushed to {entry.url} as {author_name} <{author_email}>"
+            f"Applied {len(patch_paths)} patch(es), committed, and pushed to {entry.url} as {author_name} <{author_email}>"
         )
 
 
@@ -272,20 +364,36 @@ def main(argv: Optional[List[str]] = None) -> None:
     config = load_repo_config(args.config)
     subtrees = [line.strip() for line in args.subtrees.splitlines() if line.strip()]
     relevant_subtrees = get_subtree_info(config, subtrees)
-    merge_sha = client.get_squash_merge_commit(args.repo, args.pr)
+    merge_sha = client.get_merge_commit(args.repo, args.pr)
+    if not merge_sha:
+        logger.error(f"Could not get merge commit for PR #{args.pr} in {args.repo}")
+        return
     logger.debug(f"Merge commit for PR #{args.pr} in {args.repo}: {merge_sha}")
+
+    # Get base commit to detect if this is a rebase merge with multiple commits
+    base_sha = client.get_pr_base_commit(args.repo, args.pr)
+    if base_sha:
+        logger.debug(f"Base commit for PR #{args.pr} in {args.repo}: {base_sha}")
+    else:
+        logger.warning(
+            f"Could not get base commit for PR #{args.pr}, will use single commit approach"
+        )
+
     for entry in relevant_subtrees:
         prefix = f"{entry.category}/{entry.name}/"
         logger.debug(f"Processing subtree {prefix}")
         with tempfile.TemporaryDirectory() as tmpdir:
             patch_file = Path(tmpdir) / f"{entry.name}.patch"
-            generate_patch(prefix, merge_sha, patch_file)
+            patch_result = generate_patch(prefix, merge_sha, patch_file, base_sha)
+            if patch_result is None:
+                logger.debug(f"No patches to apply for subtree {prefix}, skipping")
+                continue
             author_name, author_email = resolve_patch_author(client, args.repo, args.pr)
             apply_patch_to_subrepo(
                 entry,
                 args.repo,
                 args.pr,
-                patch_file,
+                patch_result,
                 author_name,
                 author_email,
                 merge_sha,

--- a/.github/workflows/pr-merge-sync-patches-manual.yml
+++ b/.github/workflows/pr-merge-sync-patches-manual.yml
@@ -6,17 +6,23 @@
 # It is useful for cases where the automatic patch workflow failed (e.g., due
 # to fork PRs lacking secrets), or if configuration or credentials have changed.
 #
+# Supports both "Squash and merge" and "Rebase and merge" PR merge types:
+# - Squash merges: Generates a single patch file and creates one commit in the sub-repo.
+# - Rebase merges: Generates multiple patch files (one per commit) and creates separate
+#   commits in the sub-repo for each patch, preserving individual commit history.
+#
 # Key Steps:
 # 1. Validate that the caller has 'admin' or 'maintain' permission on the super-repo.
 # 2. Accept PR number as input.
 # 3. Generate a GitHub App token for authentication.
 # 4. Use a Python script to detect which subtrees were modified.
 # 5. For each changed subtree:
-#    - Generate a patch from the merge commit for that subtree.
+#    - Generate patch(es) from the merge commit range for that subtree.
 #    - Determine the appropriate author (based on PR metadata or fallback).
-#    - Clone the target sub-repo and apply the patch.
-#    - Amend the commit message to include links to the super-repo PR and commit.
-#    - Push the commit directly to the sub-repo.
+#    - Clone the target sub-repo and apply the patch(es).
+#    - For multiple patches, create separate commits for each patch.
+#    - Amend commit messages to include links to the super-repo PR and commit.
+#    - Push the commit(s) directly to the sub-repo.
 #
 # This ensures downstream sub-repositories are updated to reflect changes
 # made in the super-repo, even if the original automated job failed.

--- a/.github/workflows/pr-merge-sync-patches.yml
+++ b/.github/workflows/pr-merge-sync-patches.yml
@@ -3,19 +3,25 @@
 # This GitHub Actions workflow runs on push commits. If it detects the push is from
 # a pull request merged into the super-repo, then it continues to run the workflow.
 # It identifies which subtrees (defined in .github/repos-config.json) were affected,
-# generates a patch from the merge commit, and applies that patch to the corresponding
-# sub-repositories by cloning them and committing the patch directly.
+# generates patch(es) from the merge commit, and applies those patches to the corresponding
+# sub-repositories by cloning them and committing the patches directly.
+#
+# Supports both "Squash and merge" and "Rebase and merge" PR merge types:
+# - Squash merges: Generates a single patch file and creates one commit in the sub-repo.
+# - Rebase merges: Generates multiple patch files (one per commit) and creates separate
+#   commits in the sub-repo for each patch, preserving individual commit history.
 #
 # Key Steps:
 # 1. Generate a GitHub App token for authentication.
 # 2. Checkout the super-repo at the merge commit.
 # 3. Use a Python script to detect which subtrees were modified.
 # 4. For each changed subtree:
-#    - Generate a patch from the merge commit for that subtree.
+#    - Generate patch(es) from the merge commit range for that subtree.
 #    - Determine the appropriate author (based on PR metadata or fallback).
-#    - Clone the target sub-repo and apply the patch.
-#    - Amend the commit message to include links to the super-repo PR and commit.
-#    - Push the commit directly to the sub-repo.
+#    - Clone the target sub-repo and apply the patch(es).
+#    - For multiple patches, create separate commits for each patch.
+#    - Amend commit messages to include links to the super-repo PR and commit.
+#    - Push the commit(s) directly to the sub-repo.
 #
 # This ensures downstream sub-repositories are updated to reflect changes
 # made in the super-repo immediately after merge.


### PR DESCRIPTION
## Summary

Adds support for "Rebase and merge" PR commits in addition to existing "Squash and merge" support. When a PR is rebase-merged with multiple commits, the script now generates separate patch files (one per commit) and applies them sequentially to sub-repositories, preserving individual commit history.

## Changes

- **`github_cli_client.py`**: 
  - Renamed `get_squash_merge_commit()` → `get_merge_commit()` (works for both merge types)
  - Added `get_pr_base_commit()` to retrieve base commit SHA

- **`pr_merge_sync_patches.py`**:
  - Enhanced `generate_patch()` to detect single vs multiple commits and generate appropriate patches
  - Updated `apply_patch_to_subrepo()` to handle multiple patches (creates separate commits for each)

- **Workflow YAML files**: Updated documentation to reflect support for both merge types

## Behavior

- **Squash merges**: Generates single patch file → one commit in sub-repo (unchanged behavior)
- **Rebase merges**: Generates multiple patch files → separate commits in sub-repo (new behavior)

The script automatically detects the merge type by counting commits between base and merge SHA.