### PR TITLE
[RCCL][WIP] Parallelize optimization and simplify final link

### DIFF
--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -1452,51 +1452,22 @@ if(ENABLE_SPLIT_DEVICE_COMPILE)
   list(GET GPU_TARGETS 0 _split_gpu_arch)
   message(STATUS "Split device compile: targeting ${_split_gpu_arch}")
 
-  # Collect include directories that device TUs need.
-  # These mirror the target_include_directories calls above.
-  set(_split_include_dirs
-    ${PROJECT_BINARY_DIR}/include
-    ${HIPIFY_DIR}/src
-    ${HIPIFY_DIR}/src/device
-    ${HIPIFY_DIR}/src/device/network/unpack
-    ${HIPIFY_DIR}/src/include
-    ${HIPIFY_DIR}/src/include/mlx5
-    ${HIPIFY_DIR}/src/include/nccl_device
-    ${HIPIFY_DIR}/src/include/ionic
-    ${HIPIFY_DIR}/src/include/plugin
-    ${HIPIFY_DIR}/gensrc
-    ${HSA_INCLUDE_PATH}
-  )
+  # Extract include directories, compile definitions, and compile options
+  # directly from the rccl target so the split pipeline always stays in
+  # sync -- no manual mirroring required.
+  get_target_property(_split_include_dirs rccl INCLUDE_DIRECTORIES)
+  get_target_property(_split_compile_defs rccl COMPILE_DEFINITIONS)
+  get_target_property(_split_compile_opts rccl COMPILE_OPTIONS)
 
-  # Collect compile definitions that device TUs need.
-  # These mirror the target_compile_definitions calls above.
-  set(_split_compile_defs "")
-  if(COLLTRACE)
-    list(APPEND _split_compile_defs "ENABLE_COLLTRACE")
+  # get_target_property returns "<var>-NOTFOUND" when the property is empty
+  if(NOT _split_include_dirs)
+    set(_split_include_dirs "")
   endif()
-  if(IFC_ENABLED)
-    list(APPEND _split_compile_defs "USE_INDIRECT_FUNCTION_CALL")
+  if(NOT _split_compile_defs)
+    set(_split_compile_defs "")
   endif()
-  if(LL128_ENABLED)
-    list(APPEND _split_compile_defs "ENABLE_LL128")
-  endif()
-  if(FAULT_INJECTION)
-    list(APPEND _split_compile_defs "ENABLE_FAULT_INJECTION")
-  endif()
-  if(${HIP_CONTIGUOUS_MEMORY})
-    list(APPEND _split_compile_defs "HIP_CONTIGUOUS_MEMORY")
-  endif()
-  if("${hip_version_string}" VERSION_GREATER_EQUAL "5.7.31920")
-    list(APPEND _split_compile_defs "HIP_UNCACHED_MEMORY")
-  endif()
-  if(HIP_HOST_UNCACHED_MEMORY)
-    list(APPEND _split_compile_defs "HIP_HOST_UNCACHED_MEMORY")
-  endif()
-  if(ENABLE_MSCCL_KERNEL)
-    list(APPEND _split_compile_defs "COMPILE_MSCCL_KERNEL")
-  endif()
-  if(ENABLE_MSCCLPP)
-    list(APPEND _split_compile_defs "ENABLE_MSCCLPP")
+  if(NOT _split_compile_opts)
+    set(_split_compile_opts "")
   endif()
 
   include(cmake/SplitDeviceCompile.cmake)
@@ -1509,6 +1480,7 @@ if(ENABLE_SPLIT_DEVICE_COMPILE)
     OUTPUT_DIR          ${CMAKE_CURRENT_BINARY_DIR}
     INCLUDE_DIRS        ${_split_include_dirs}
     COMPILE_DEFS        ${_split_compile_defs}
+    COMPILE_OPTS        ${_split_compile_opts}
   )
 
   # Make rccl depend on all the split-compiled fat objects.

--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -1452,7 +1452,67 @@ if(ENABLE_SPLIT_DEVICE_COMPILE)
   list(GET GPU_TARGETS 0 _split_gpu_arch)
   message(STATUS "Split device compile: targeting ${_split_gpu_arch}")
 
-  # Extract include directories, compile definitions, and compile options
+  # ── Detect the correct clang-offload-bundler target strings ──────────────
+  # The bundler target format varies across ROCm versions (e.g. "hipv4-" vs
+  # "hip-" prefix).  We compile a tiny probe file and ask the bundler what
+  # target strings the current toolchain produces natively.  This ensures our
+  # fat objects are created with targets that `amdclang++ --hip-link` can find.
+  set(_probe_src "${CMAKE_CURRENT_BINARY_DIR}/_split_probe.hip")
+  set(_probe_obj "${CMAKE_CURRENT_BINARY_DIR}/_split_probe.o")
+  file(WRITE ${_probe_src} "__device__ void _split_probe() {}\n")
+
+  execute_process(
+    COMMAND ${CMAKE_CXX_COMPILER}
+      -x hip -fgpu-rdc --offload-arch=${_split_gpu_arch} -c -O0
+      -o ${_probe_obj} ${_probe_src}
+    RESULT_VARIABLE _probe_compile_rc
+    OUTPUT_QUIET ERROR_QUIET
+  )
+  if(NOT _probe_compile_rc EQUAL 0)
+    message(FATAL_ERROR "Split device compile: failed to compile bundler probe (exit ${_probe_compile_rc})")
+  endif()
+
+  execute_process(
+    COMMAND ${ROCM_PATH}/llvm/bin/clang-offload-bundler --list --type=o --input=${_probe_obj}
+    OUTPUT_VARIABLE _probe_targets
+    RESULT_VARIABLE _probe_list_rc
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if(NOT _probe_list_rc EQUAL 0)
+    message(FATAL_ERROR "Split device compile: failed to list bundler targets (exit ${_probe_list_rc})")
+  endif()
+
+  # Parse the device and host target strings from the probe output.
+  # Expected output is two lines, e.g.:
+  #   hip-amdgcn-amd-amdhsa--gfx942
+  #   host-x86_64-unknown-linux-gnu-
+  set(_bundler_device_target "")
+  set(_bundler_host_target "")
+  string(REPLACE "\n" ";" _probe_lines "${_probe_targets}")
+  foreach(_line ${_probe_lines})
+    string(STRIP "${_line}" _line)
+    if(_line MATCHES "^hip.*amdgcn")
+      set(_bundler_device_target "${_line}")
+    elseif(_line MATCHES "^host-")
+      set(_bundler_host_target "${_line}")
+    endif()
+  endforeach()
+
+  if(NOT _bundler_device_target)
+    message(FATAL_ERROR "Split device compile: could not detect device bundler target from probe output:\n${_probe_targets}")
+  endif()
+  if(NOT _bundler_host_target)
+    message(FATAL_ERROR "Split device compile: could not detect host bundler target from probe output:\n${_probe_targets}")
+  endif()
+  message(STATUS "Split device compile: detected bundler targets:")
+  message(STATUS "  device: ${_bundler_device_target}")
+  message(STATUS "  host:   ${_bundler_host_target}")
+
+  # Clean up probe files
+  file(REMOVE ${_probe_src} ${_probe_obj})
+
+  # ── Extract target properties for the split pipeline ─────────────────────
+  # Read include directories, compile definitions, and compile options
   # directly from the rccl target so the split pipeline always stays in
   # sync -- no manual mirroring required.
   get_target_property(_split_include_dirs rccl INCLUDE_DIRECTORIES)
@@ -1481,6 +1541,8 @@ if(ENABLE_SPLIT_DEVICE_COMPILE)
     INCLUDE_DIRS        ${_split_include_dirs}
     COMPILE_DEFS        ${_split_compile_defs}
     COMPILE_OPTS        ${_split_compile_opts}
+    BUNDLER_DEVICE_TARGET ${_bundler_device_target}
+    BUNDLER_HOST_TARGET   ${_bundler_host_target}
   )
 
   # Make rccl depend on all the split-compiled fat objects.

--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -946,16 +946,25 @@ if(ENABLE_SPLIT_DEVICE_COMPILE)
     endif()
   endforeach()
 
-  # Move common.cu.cpp to the split pipeline (defines the generic kernel
-  # that dispatches to ncclDevFunc_* via function pointer table -- needs RDC).
-  # NOTE: onerank.cu.cpp is NOT moved here because it defines standalone
+  # NOTE: common.cu.cpp is intentionally NOT moved to the split pipeline.
+  # It defines the generic kernel that dispatches to ncclDevFunc_* via a
+  # function-pointer table (indirect call).  When pre-compiled to a device
+  # ELF in isolation, the AMDGPU backend cannot see callee function bodies
+  # and sets .private_segment_fixed_size: 0 (zero scratch).  The HIP runtime
+  # on some ROCm versions (e.g. 7.0.0) then allocates zero scratch memory,
+  # causing "illegal memory access" at runtime.
+  #
+  # By keeping common.cu.cpp in the regular target with -fgpu-rdc, its
+  # device bitcode goes through LTO at link time, where the backend can
+  # correctly compute scratch requirements.  The LTO step processes just
+  # this one TU's bitcode (fast), while the 122 device-function TUs remain
+  # pre-compiled ELFs from the split pipeline.
+  #
+  # NOTE: onerank.cu.cpp is also NOT moved here because it defines standalone
   # __global__ kernels in an anonymous namespace.  The device linker renames
   # anonymous-namespace symbols (.intern.<hash>), which breaks the host stub
   # registration.  Since onerank kernels don't reference cross-TU device
   # symbols, they compile fine without -fgpu-rdc as part of the main target.
-  set(_COMMON_CU  "${HIPIFY_DIR}/src/device/common.cu.cpp")
-  list(APPEND DEVICE_TU_SOURCES ${_COMMON_CU})
-  list(REMOVE_ITEM HIP_SOURCES ${_COMMON_CU})
 
   list(LENGTH DEVICE_TU_SOURCES _n_device_tus)
   message(STATUS "Split device compile: ${_n_device_tus} device TUs separated from HIP_SOURCES")
@@ -1559,6 +1568,16 @@ if(ENABLE_SPLIT_DEVICE_COMPILE)
   # device symbols (fast -- just symbol resolution, no backend re-run).
   target_link_libraries(rccl PRIVATE -fgpu-rdc)
   target_link_options(rccl PRIVATE --hip-link)
+
+  # common.cu.cpp stays in the regular target (HIP_SOURCES) but needs
+  # -fgpu-rdc so that its device bitcode is embedded in the host object
+  # and processed by the device linker's LTO step at link time.  This
+  # allows the AMDGPU backend to correctly compute scratch/stack
+  # requirements for the kernel's indirect calls to device functions.
+  set(_COMMON_CU "${HIPIFY_DIR}/src/device/common.cu.cpp")
+  set_source_files_properties(${_COMMON_CU} PROPERTIES
+    COMPILE_OPTIONS "-fgpu-rdc"
+  )
 endif()
 
 ## Setup librccl.so version

--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -924,6 +924,43 @@ foreach(file ${GENERATED_FILES})
   list(APPEND HIP_SOURCES ${file})
 endforeach()
 
+# Split device compilation: pre-compile each device TU through the LLVM backend
+# independently and in parallel, so that the final link is lightweight (~1-2s).
+option(ENABLE_SPLIT_DEVICE_COMPILE
+  "Pre-compile device code per-TU via LLC for fast linking (requires -fgpu-rdc at link time)" ON)
+
+if(ENABLE_SPLIT_DEVICE_COMPILE)
+  # Identify generated device TU sources (gensrc/*.cpp minus host-only files)
+  set(DEVICE_TU_SOURCES "")
+  set(DEVICE_FUNC_ONLY_SOURCES "")
+
+  foreach(file ${GENERATED_FILES})
+    get_filename_component(_fname ${file} NAME_WE)
+    get_filename_component(_fext  ${file} EXT)
+    if(_fext STREQUAL ".cpp"
+       AND NOT _fname STREQUAL "host_table"
+       AND NOT _fname STREQUAL "device_table")
+      list(APPEND DEVICE_TU_SOURCES ${file})
+      list(APPEND DEVICE_FUNC_ONLY_SOURCES ${file})
+      list(REMOVE_ITEM HIP_SOURCES ${file})
+    endif()
+  endforeach()
+
+  # Move common.cu.cpp to the split pipeline (defines the generic kernel
+  # that dispatches to ncclDevFunc_* via function pointer table -- needs RDC).
+  # NOTE: onerank.cu.cpp is NOT moved here because it defines standalone
+  # __global__ kernels in an anonymous namespace.  The device linker renames
+  # anonymous-namespace symbols (.intern.<hash>), which breaks the host stub
+  # registration.  Since onerank kernels don't reference cross-TU device
+  # symbols, they compile fine without -fgpu-rdc as part of the main target.
+  set(_COMMON_CU  "${HIPIFY_DIR}/src/device/common.cu.cpp")
+  list(APPEND DEVICE_TU_SOURCES ${_COMMON_CU})
+  list(REMOVE_ITEM HIP_SOURCES ${_COMMON_CU})
+
+  list(LENGTH DEVICE_TU_SOURCES _n_device_tus)
+  message(STATUS "Split device compile: ${_n_device_tus} device TUs separated from HIP_SOURCES")
+endif()
+
 # Create an initial git_version.cpp file (that will be updated with latest git version)
 #==================================================================================================
 # Create initial empty file at configure time
@@ -1220,7 +1257,8 @@ target_compile_options(rccl PRIVATE -Wall)
 target_compile_options(rccl PRIVATE -Werror=deprecated-copy-with-user-provided-copy)
 target_compile_options(rccl PRIVATE -Wno-format-nonliteral)
 target_compile_options(rccl PRIVATE -Wno-unused-function)
-target_compile_options(rccl PRIVATE -fgpu-rdc)
+# -fgpu-rdc removed: no longer needed now that extern __shared__ is eliminated.
+# Each TU is fully compiled (all backend passes) at compile time in parallel.
 
 if(QUIET_WARNINGS)
   target_compile_options(rccl PRIVATE -Wno-invalid-offsetof)
@@ -1340,7 +1378,7 @@ endif()
 if (ROCTX_ENABLE)
   target_link_libraries(rccl PRIVATE ${ROCTX_LIB})
 endif()
-target_link_libraries(rccl PRIVATE   -fgpu-rdc)             # Required when linking relocatable device code
+# -fgpu-rdc link flag removed: no longer using relocatable device code
 target_link_libraries(rccl PRIVATE   Threads::Threads)
 target_link_libraries(rccl INTERFACE hip::host)
 target_link_libraries(rccl PRIVATE   hip::device)
@@ -1406,16 +1444,97 @@ endif()
 ## Track linking time
 set_property(TARGET rccl PROPERTY RULE_LAUNCH_LINK "${CMAKE_COMMAND} -E time")
 
+# ── Split device compilation pipeline ─────────────────────────────────────────
+# Now that all target properties (includes, defines, options) are set, create
+# the per-TU custom commands that pre-compile device code through the LLVM
+# backend independently and in parallel.
+if(ENABLE_SPLIT_DEVICE_COMPILE)
+  list(GET GPU_TARGETS 0 _split_gpu_arch)
+  message(STATUS "Split device compile: targeting ${_split_gpu_arch}")
+
+  # Collect include directories that device TUs need.
+  # These mirror the target_include_directories calls above.
+  set(_split_include_dirs
+    ${PROJECT_BINARY_DIR}/include
+    ${HIPIFY_DIR}/src
+    ${HIPIFY_DIR}/src/device
+    ${HIPIFY_DIR}/src/device/network/unpack
+    ${HIPIFY_DIR}/src/include
+    ${HIPIFY_DIR}/src/include/mlx5
+    ${HIPIFY_DIR}/src/include/nccl_device
+    ${HIPIFY_DIR}/src/include/ionic
+    ${HIPIFY_DIR}/src/include/plugin
+    ${HIPIFY_DIR}/gensrc
+    ${HSA_INCLUDE_PATH}
+  )
+
+  # Collect compile definitions that device TUs need.
+  # These mirror the target_compile_definitions calls above.
+  set(_split_compile_defs "")
+  if(COLLTRACE)
+    list(APPEND _split_compile_defs "ENABLE_COLLTRACE")
+  endif()
+  if(IFC_ENABLED)
+    list(APPEND _split_compile_defs "USE_INDIRECT_FUNCTION_CALL")
+  endif()
+  if(LL128_ENABLED)
+    list(APPEND _split_compile_defs "ENABLE_LL128")
+  endif()
+  if(FAULT_INJECTION)
+    list(APPEND _split_compile_defs "ENABLE_FAULT_INJECTION")
+  endif()
+  if(${HIP_CONTIGUOUS_MEMORY})
+    list(APPEND _split_compile_defs "HIP_CONTIGUOUS_MEMORY")
+  endif()
+  if("${hip_version_string}" VERSION_GREATER_EQUAL "5.7.31920")
+    list(APPEND _split_compile_defs "HIP_UNCACHED_MEMORY")
+  endif()
+  if(HIP_HOST_UNCACHED_MEMORY)
+    list(APPEND _split_compile_defs "HIP_HOST_UNCACHED_MEMORY")
+  endif()
+  if(ENABLE_MSCCL_KERNEL)
+    list(APPEND _split_compile_defs "COMPILE_MSCCL_KERNEL")
+  endif()
+  if(ENABLE_MSCCLPP)
+    list(APPEND _split_compile_defs "ENABLE_MSCCLPP")
+  endif()
+
+  include(cmake/SplitDeviceCompile.cmake)
+  setup_split_device_compile(
+    TARGET              rccl
+    SOURCES             ${DEVICE_TU_SOURCES}
+    FUNC_ONLY_SOURCES   ${DEVICE_FUNC_ONLY_SOURCES}
+    GPU_ARCH            ${_split_gpu_arch}
+    ROCM_PATH           ${ROCM_PATH}
+    OUTPUT_DIR          ${CMAKE_CURRENT_BINARY_DIR}
+    INCLUDE_DIRS        ${_split_include_dirs}
+    COMPILE_DEFS        ${_split_compile_defs}
+  )
+
+  # Make rccl depend on all the split-compiled fat objects.
+  # The device TUs include hipified headers (common.h, etc.), so ensure
+  # hipify runs before any split pipeline commands on a clean build.
+  add_dependencies(rccl rccl_device_objects)
+  add_dependencies(rccl_device_objects hipify_all)
+
+  # Pass fat objects as linker inputs
+  target_link_options(rccl PRIVATE ${DEVICE_FAT_OBJECTS})
+
+  # The link step needs -fgpu-rdc --hip-link so the driver extracts
+  # pre-compiled device ELF from the fat objects and resolves cross-TU
+  # device symbols (fast -- just symbol resolution, no backend re-run).
+  target_link_libraries(rccl PRIVATE -fgpu-rdc)
+  target_link_options(rccl PRIVATE --hip-link)
+endif()
+
 ## Setup librccl.so version
 rocm_set_soversion(rccl "1.0")
 
 if(NOT BUILD_SHARED_LIBS)
-  # To create a static lib with `-fgpu-rdc`, you need `--emit-static-lib` and `--hip-link`.
-  # You also need to invoke amdclang++ again to trigger GPU code generation.
+  # Without -fgpu-rdc, device code is fully compiled per-TU.
+  # --emit-static-lib is still needed to produce a static library.
   set(static_link_flags
     ${CXXFLAGS}
-    --hip-link
-    -fgpu-rdc
     --emit-static-lib
   )
 

--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -946,21 +946,23 @@ if(ENABLE_SPLIT_DEVICE_COMPILE)
     endif()
   endforeach()
 
-  # NOTE: common.cu.cpp is intentionally NOT moved to the split pipeline.
-  # It defines the generic kernel that dispatches to ncclDevFunc_* via a
-  # function-pointer table (indirect call).  When pre-compiled to a device
-  # ELF in isolation, the AMDGPU backend cannot see callee function bodies
-  # and sets .private_segment_fixed_size: 0 (zero scratch).  The HIP runtime
-  # on some ROCm versions (e.g. 7.0.0) then allocates zero scratch memory,
-  # causing "illegal memory access" at runtime.
+  # Move common.cu.cpp into the split pipeline as well, but do NOT add it
+  # to DEVICE_FUNC_ONLY_SOURCES -- it must NOT get -DNCCL_FUNC_ONLY because
+  # it defines the generic kernel (ncclKernelMain) and the dispatch table.
+  # The AMDGPU backend correctly detects the indirect call through the
+  # function-pointer table and sets .uses_dynamic_stack: true in the kernel
+  # metadata even when compiled in isolation (Step B: clang -x ir).
   #
-  # By keeping common.cu.cpp in the regular target with -fgpu-rdc, its
-  # device bitcode goes through LTO at link time, where the backend can
-  # correctly compute scratch requirements.  The LTO step processes just
-  # this one TU's bitcode (fast), while the 122 device-function TUs remain
-  # pre-compiled ELFs from the split pipeline.
-  #
-  # NOTE: onerank.cu.cpp is also NOT moved here because it defines standalone
+  # This approach makes ALL device code go through the split pipeline as
+  # pre-compiled ELFs, so the device linker at link time only does fast
+  # symbol resolution (no LTO / backend re-compilation).  This avoids the
+  # mixed LTO-bitcode + pre-compiled-ELF scenario that caused "illegal
+  # memory access" crashes on ROCm 7.0.0.
+  set(_COMMON_CU "${HIPIFY_DIR}/src/device/common.cu.cpp")
+  list(APPEND DEVICE_TU_SOURCES ${_COMMON_CU})
+  list(REMOVE_ITEM HIP_SOURCES ${_COMMON_CU})
+
+  # NOTE: onerank.cu.cpp is NOT moved here because it defines standalone
   # __global__ kernels in an anonymous namespace.  The device linker renames
   # anonymous-namespace symbols (.intern.<hash>), which breaks the host stub
   # registration.  Since onerank kernels don't reference cross-TU device
@@ -1266,8 +1268,13 @@ target_compile_options(rccl PRIVATE -Wall)
 target_compile_options(rccl PRIVATE -Werror=deprecated-copy-with-user-provided-copy)
 target_compile_options(rccl PRIVATE -Wno-format-nonliteral)
 target_compile_options(rccl PRIVATE -Wno-unused-function)
-# -fgpu-rdc removed: no longer needed now that extern __shared__ is eliminated.
-# Each TU is fully compiled (all backend passes) at compile time in parallel.
+# When split device compilation is enabled, -fgpu-rdc is only needed at link
+# time (added in the ENABLE_SPLIT_DEVICE_COMPILE block below).  When split is
+# disabled, the standard build still requires -fgpu-rdc because common.cu.cpp
+# references device functions from other TUs via the function-pointer table.
+if(NOT ENABLE_SPLIT_DEVICE_COMPILE)
+  target_compile_options(rccl PRIVATE -fgpu-rdc)
+endif()
 
 if(QUIET_WARNINGS)
   target_compile_options(rccl PRIVATE -Wno-invalid-offsetof)
@@ -1387,7 +1394,13 @@ endif()
 if (ROCTX_ENABLE)
   target_link_libraries(rccl PRIVATE ${ROCTX_LIB})
 endif()
-# -fgpu-rdc link flag removed: no longer using relocatable device code
+# When split is disabled, the link step also needs -fgpu-rdc to resolve
+# cross-TU device symbols.  When split is enabled, this is added in the
+# ENABLE_SPLIT_DEVICE_COMPILE block further below.
+if(NOT ENABLE_SPLIT_DEVICE_COMPILE)
+  target_link_libraries(rccl PRIVATE -fgpu-rdc)
+  target_link_options(rccl PRIVATE --hip-link)
+endif()
 target_link_libraries(rccl PRIVATE   Threads::Threads)
 target_link_libraries(rccl INTERFACE hip::host)
 target_link_libraries(rccl PRIVATE   hip::device)
@@ -1569,15 +1582,6 @@ if(ENABLE_SPLIT_DEVICE_COMPILE)
   target_link_libraries(rccl PRIVATE -fgpu-rdc)
   target_link_options(rccl PRIVATE --hip-link)
 
-  # common.cu.cpp stays in the regular target (HIP_SOURCES) but needs
-  # -fgpu-rdc so that its device bitcode is embedded in the host object
-  # and processed by the device linker's LTO step at link time.  This
-  # allows the AMDGPU backend to correctly compute scratch/stack
-  # requirements for the kernel's indirect calls to device functions.
-  set(_COMMON_CU "${HIPIFY_DIR}/src/device/common.cu.cpp")
-  set_source_files_properties(${_COMMON_CU} PROPERTIES
-    COMPILE_OPTIONS "-fgpu-rdc"
-  )
 endif()
 
 ## Setup librccl.so version

--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -1254,20 +1254,15 @@ if (HAVE_PARALLEL_JOBS)
   target_compile_options(rccl PRIVATE -parallel-jobs=12)
 endif()
 
-if (ROCM_VERSION VERSION_GREATER_EQUAL "60200")
-  target_compile_options(rccl PRIVATE --offload-compress)    # Compress GPU code at compile time.
-  target_link_libraries(rccl PRIVATE --offload-compress)     # Compress GPU code at link time.
-  message(STATUS "--offload-compress enabled - ROCm version >= 6.2.0")
-else()
-  message(STATUS "--offload-compress disabled - ROCm version < 6.2.0")
-endif()
-
 target_compile_options(rccl PRIVATE -Werror=uninitialized)
 target_compile_options(rccl PRIVATE -Werror=sometimes-uninitialized)
 target_compile_options(rccl PRIVATE -Wall)
 target_compile_options(rccl PRIVATE -Werror=deprecated-copy-with-user-provided-copy)
 target_compile_options(rccl PRIVATE -Wno-format-nonliteral)
 target_compile_options(rccl PRIVATE -Wno-unused-function)
+
+target_compile_options(rccl PRIVATE -gline-tables-only)
+
 # When split device compilation is enabled, -fgpu-rdc is only needed at link
 # time (added in the ENABLE_SPLIT_DEVICE_COMPILE block below).  When split is
 # disabled, the standard build still requires -fgpu-rdc because common.cu.cpp

--- a/projects/rccl/cmake/SplitDeviceCompile.cmake
+++ b/projects/rccl/cmake/SplitDeviceCompile.cmake
@@ -1,0 +1,158 @@
+# cmake/SplitDeviceCompile.cmake
+#
+# Split device compilation pipeline for RCCL.
+#
+# Instead of the standard -fgpu-rdc flow (which defers all backend passes to
+# link time, serialising them), this module pre-compiles each device TU through
+# the full LLVM backend independently and in parallel:
+#
+#   source.cpp -> LLVM bitcode (.bc) -> device ELF (.o) via llc
+#                                          |
+#   source.cpp -> host stub (.host.o) -----+
+#                                          v
+#                               fat object (.fat.o) via clang-offload-bundler
+#
+# The fat objects are then linked with `amdclang++ -fgpu-rdc --hip-link` which
+# only performs lightweight device-side symbol resolution (~1-2 seconds) instead
+# of re-running the entire backend.
+#
+
+function(setup_split_device_compile)
+  cmake_parse_arguments(SDC "" "TARGET;GPU_ARCH;ROCM_PATH;OUTPUT_DIR" "SOURCES;FUNC_ONLY_SOURCES;INCLUDE_DIRS;COMPILE_DEFS" ${ARGN})
+
+  if(NOT SDC_TARGET)
+    message(FATAL_ERROR "setup_split_device_compile: TARGET is required")
+  endif()
+  if(NOT SDC_GPU_ARCH)
+    message(FATAL_ERROR "setup_split_device_compile: GPU_ARCH is required")
+  endif()
+  if(NOT SDC_ROCM_PATH)
+    message(FATAL_ERROR "setup_split_device_compile: ROCM_PATH is required")
+  endif()
+  if(NOT SDC_OUTPUT_DIR)
+    message(FATAL_ERROR "setup_split_device_compile: OUTPUT_DIR is required")
+  endif()
+
+  set(LLC     "${SDC_ROCM_PATH}/llvm/bin/llc")
+  set(BUNDLER "${SDC_ROCM_PATH}/llvm/bin/clang-offload-bundler")
+
+  # Output directories
+  set(BC_DIR   "${SDC_OUTPUT_DIR}/split_device/bc")
+  set(DEV_DIR  "${SDC_OUTPUT_DIR}/split_device/dev_obj")
+  set(HOST_DIR "${SDC_OUTPUT_DIR}/split_device/host_obj")
+  set(FAT_DIR  "${SDC_OUTPUT_DIR}/split_device/fat_obj")
+  file(MAKE_DIRECTORY ${BC_DIR} ${DEV_DIR} ${HOST_DIR} ${FAT_DIR})
+
+  # Build the include-directory flags list: -I/path1 -I/path2 ...
+  set(_inc_flags "")
+  foreach(_dir ${SDC_INCLUDE_DIRS})
+    list(APPEND _inc_flags "-I${_dir}")
+  endforeach()
+
+  # Build the compile-definition flags list: -DFOO -DBAR=123 ...
+  set(_def_flags "")
+  foreach(_def ${SDC_COMPILE_DEFS})
+    list(APPEND _def_flags "-D${_def}")
+  endforeach()
+
+  set(ALL_FAT_OBJECTS "")
+
+  list(LENGTH SDC_SOURCES _n_sources)
+  message(STATUS "Split device compile: ${_n_sources} TUs for ${SDC_GPU_ARCH}")
+
+  foreach(src ${SDC_SOURCES})
+    get_filename_component(fname ${src} NAME_WE)
+
+    # Determine if this source needs -DNCCL_FUNC_ONLY
+    set(_extra_defs "")
+    list(FIND SDC_FUNC_ONLY_SOURCES "${src}" _func_only_idx)
+    if(NOT _func_only_idx EQUAL -1)
+      set(_extra_defs "-DNCCL_FUNC_ONLY")
+    endif()
+
+    set(BC_FILE  "${BC_DIR}/${fname}.${SDC_GPU_ARCH}.bc")
+    set(DEV_OBJ  "${DEV_DIR}/${fname}.${SDC_GPU_ARCH}.o")
+    set(HOST_OBJ "${HOST_DIR}/${fname}.host.o")
+    set(FAT_OBJ  "${FAT_DIR}/${fname}.fat.o")
+
+    # -- Step A: Compile to LLVM bitcode (device only) ------------------------
+    add_custom_command(
+      OUTPUT  ${BC_FILE}
+      COMMAND ${CMAKE_CXX_COMPILER}
+        -x hip -std=c++17
+        -fgpu-rdc
+        --offload-device-only
+        --offload-arch=${SDC_GPU_ARCH}
+        -emit-llvm -c -O3
+        ${_inc_flags}
+        ${_def_flags}
+        ${_extra_defs}
+        -fvisibility=hidden
+        -Wno-unused-function
+        -Wno-format-nonliteral
+        -o ${BC_FILE} ${src}
+      DEPENDS   ${src}
+      COMMENT   "SPLIT[bc]  ${fname}"
+      VERBATIM
+    )
+
+    # -- Step B: LLC to relocatable device ELF object -------------------------
+    add_custom_command(
+      OUTPUT  ${DEV_OBJ}
+      COMMAND ${LLC}
+        -O3
+        -mtriple=amdgcn-amd-amdhsa
+        -mcpu=${SDC_GPU_ARCH}
+        -filetype=obj
+        -o ${DEV_OBJ} ${BC_FILE}
+      DEPENDS   ${BC_FILE}
+      COMMENT   "SPLIT[llc] ${fname}"
+      VERBATIM
+    )
+
+    # -- Step C: Host-only compilation ----------------------------------------
+    add_custom_command(
+      OUTPUT  ${HOST_OBJ}
+      COMMAND ${CMAKE_CXX_COMPILER}
+        -x hip -std=c++17
+        -fgpu-rdc
+        --offload-host-only
+        --offload-arch=${SDC_GPU_ARCH}
+        -c -O3 -fPIC
+        ${_inc_flags}
+        ${_def_flags}
+        ${_extra_defs}
+        -fvisibility=hidden
+        -Wno-unused-function
+        -Wno-format-nonliteral
+        -o ${HOST_OBJ} ${src}
+      DEPENDS   ${src}
+      COMMENT   "SPLIT[host] ${fname}"
+      VERBATIM
+    )
+
+    # -- Step D: Bundle host + device into fat object -------------------------
+    add_custom_command(
+      OUTPUT  ${FAT_OBJ}
+      COMMAND ${BUNDLER}
+        --type=o
+        --targets=host-x86_64-unknown-linux-gnu,hipv4-amdgcn-amd-amdhsa--${SDC_GPU_ARCH}
+        --input=${HOST_OBJ}
+        --input=${DEV_OBJ}
+        --output=${FAT_OBJ}
+      DEPENDS   ${HOST_OBJ} ${DEV_OBJ}
+      COMMENT   "SPLIT[fat]  ${fname}"
+      VERBATIM
+    )
+
+    list(APPEND ALL_FAT_OBJECTS ${FAT_OBJ})
+  endforeach()
+
+  # Aggregate target so the build system can build all TUs in parallel
+  add_custom_target(rccl_device_objects DEPENDS ${ALL_FAT_OBJECTS})
+
+  # Export the list of fat objects to the parent scope
+  set(DEVICE_FAT_OBJECTS ${ALL_FAT_OBJECTS} PARENT_SCOPE)
+
+  message(STATUS "Split device compile: ${_n_sources} fat objects will be produced in ${FAT_DIR}")
+endfunction()

--- a/projects/rccl/cmake/SplitDeviceCompile.cmake
+++ b/projects/rccl/cmake/SplitDeviceCompile.cmake
@@ -18,7 +18,7 @@
 #
 
 function(setup_split_device_compile)
-  cmake_parse_arguments(SDC "" "TARGET;GPU_ARCH;ROCM_PATH;OUTPUT_DIR" "SOURCES;FUNC_ONLY_SOURCES;INCLUDE_DIRS;COMPILE_DEFS" ${ARGN})
+  cmake_parse_arguments(SDC "" "TARGET;GPU_ARCH;ROCM_PATH;OUTPUT_DIR" "SOURCES;FUNC_ONLY_SOURCES;INCLUDE_DIRS;COMPILE_DEFS;COMPILE_OPTS" ${ARGN})
 
   if(NOT SDC_TARGET)
     message(FATAL_ERROR "setup_split_device_compile: TARGET is required")
@@ -55,6 +55,47 @@ function(setup_split_device_compile)
     list(APPEND _def_flags "-D${_def}")
   endforeach()
 
+  # Forward compile options from the target (e.g. -mllvm flags, -W flags).
+  # Filter out options that conflict with the split pipeline's own flags
+  # or are irrelevant for device-only / host-only compilation.
+  set(_fwd_compile_opts "")
+  set(_skip_next OFF)
+  foreach(_opt ${SDC_COMPILE_OPTS})
+    if(_skip_next)
+      # This is the argument to a previous flag (e.g. the value after -mllvm)
+      list(APPEND _fwd_compile_opts "${_opt}")
+      set(_skip_next OFF)
+    elseif(_opt MATCHES "^-parallel-jobs"
+        OR _opt MATCHES "^--offload-compress"
+        OR _opt MATCHES "^--offload-arch"
+        OR _opt MATCHES "^-fvisibility"
+        OR _opt MATCHES "^-fgpu-rdc"
+        OR _opt MATCHES "^-x$"
+        OR _opt MATCHES "^-std="
+        OR _opt MATCHES "^-O[0-3s]$"
+        OR _opt MATCHES "^-fPIC")
+      # Skip: these are already set explicitly or irrelevant
+    elseif(_opt STREQUAL "-mllvm")
+      # -mllvm takes the next arg; forward both
+      list(APPEND _fwd_compile_opts "${_opt}")
+      set(_skip_next ON)
+    else()
+      list(APPEND _fwd_compile_opts "${_opt}")
+    endif()
+  endforeach()
+
+  # Also build LLC flags from any -mllvm options (LLC takes them directly)
+  set(_llc_extra_flags "")
+  set(_in_mllvm OFF)
+  foreach(_opt ${SDC_COMPILE_OPTS})
+    if(_in_mllvm)
+      list(APPEND _llc_extra_flags "${_opt}")
+      set(_in_mllvm OFF)
+    elseif(_opt STREQUAL "-mllvm")
+      set(_in_mllvm ON)
+    endif()
+  endforeach()
+
   set(ALL_FAT_OBJECTS "")
 
   list(LENGTH SDC_SOURCES _n_sources)
@@ -87,6 +128,7 @@ function(setup_split_device_compile)
         ${_inc_flags}
         ${_def_flags}
         ${_extra_defs}
+        ${_fwd_compile_opts}
         -fvisibility=hidden
         -Wno-unused-function
         -Wno-format-nonliteral
@@ -104,6 +146,7 @@ function(setup_split_device_compile)
         -mtriple=amdgcn-amd-amdhsa
         -mcpu=${SDC_GPU_ARCH}
         -filetype=obj
+        ${_llc_extra_flags}
         -o ${DEV_OBJ} ${BC_FILE}
       DEPENDS   ${BC_FILE}
       COMMENT   "SPLIT[llc] ${fname}"
@@ -122,6 +165,7 @@ function(setup_split_device_compile)
         ${_inc_flags}
         ${_def_flags}
         ${_extra_defs}
+        ${_fwd_compile_opts}
         -fvisibility=hidden
         -Wno-unused-function
         -Wno-format-nonliteral

--- a/projects/rccl/cmake/SplitDeviceCompile.cmake
+++ b/projects/rccl/cmake/SplitDeviceCompile.cmake
@@ -6,7 +6,7 @@
 # link time, serialising them), this module pre-compiles each device TU through
 # the full LLVM backend independently and in parallel:
 #
-#   source.cpp -> LLVM bitcode (.bc) -> device ELF (.o) via llc
+#   source.cpp -> LLVM bitcode (.bc) -> device ELF (.o) via clang -x ir
 #                                          |
 #   source.cpp -> host stub (.host.o) -----+
 #                                          v
@@ -18,7 +18,7 @@
 #
 
 function(setup_split_device_compile)
-  cmake_parse_arguments(SDC "" "TARGET;GPU_ARCH;ROCM_PATH;OUTPUT_DIR" "SOURCES;FUNC_ONLY_SOURCES;INCLUDE_DIRS;COMPILE_DEFS;COMPILE_OPTS" ${ARGN})
+  cmake_parse_arguments(SDC "" "TARGET;GPU_ARCH;ROCM_PATH;OUTPUT_DIR;BUNDLER_DEVICE_TARGET;BUNDLER_HOST_TARGET" "SOURCES;FUNC_ONLY_SOURCES;INCLUDE_DIRS;COMPILE_DEFS;COMPILE_OPTS" ${ARGN})
 
   if(NOT SDC_TARGET)
     message(FATAL_ERROR "setup_split_device_compile: TARGET is required")
@@ -32,8 +32,13 @@ function(setup_split_device_compile)
   if(NOT SDC_OUTPUT_DIR)
     message(FATAL_ERROR "setup_split_device_compile: OUTPUT_DIR is required")
   endif()
+  if(NOT SDC_BUNDLER_DEVICE_TARGET)
+    message(FATAL_ERROR "setup_split_device_compile: BUNDLER_DEVICE_TARGET is required")
+  endif()
+  if(NOT SDC_BUNDLER_HOST_TARGET)
+    message(FATAL_ERROR "setup_split_device_compile: BUNDLER_HOST_TARGET is required")
+  endif()
 
-  set(LLC     "${SDC_ROCM_PATH}/llvm/bin/llc")
   set(BUNDLER "${SDC_ROCM_PATH}/llvm/bin/clang-offload-bundler")
 
   # Output directories
@@ -84,18 +89,6 @@ function(setup_split_device_compile)
     endif()
   endforeach()
 
-  # Also build LLC flags from any -mllvm options (LLC takes them directly)
-  set(_llc_extra_flags "")
-  set(_in_mllvm OFF)
-  foreach(_opt ${SDC_COMPILE_OPTS})
-    if(_in_mllvm)
-      list(APPEND _llc_extra_flags "${_opt}")
-      set(_in_mllvm OFF)
-    elseif(_opt STREQUAL "-mllvm")
-      set(_in_mllvm ON)
-    endif()
-  endforeach()
-
   set(ALL_FAT_OBJECTS "")
 
   list(LENGTH SDC_SOURCES _n_sources)
@@ -138,18 +131,20 @@ function(setup_split_device_compile)
       VERBATIM
     )
 
-    # -- Step B: LLC to relocatable device ELF object -------------------------
+    # -- Step B: Compile bitcode to relocatable device ELF object -------------
+    # Use amdclang++ -x ir instead of standalone llc so the driver
+    # automatically applies all target-specific backend flags (target features,
+    # AMDGPU options, etc.) that vary across ROCm versions.
     add_custom_command(
       OUTPUT  ${DEV_OBJ}
-      COMMAND ${LLC}
-        -O3
-        -mtriple=amdgcn-amd-amdhsa
+      COMMAND ${CMAKE_CXX_COMPILER}
+        -x ir
+        -target amdgcn-amd-amdhsa
         -mcpu=${SDC_GPU_ARCH}
-        -filetype=obj
-        ${_llc_extra_flags}
+        -O3 -c
         -o ${DEV_OBJ} ${BC_FILE}
       DEPENDS   ${BC_FILE}
-      COMMENT   "SPLIT[llc] ${fname}"
+      COMMENT   "SPLIT[dev] ${fname}"
       VERBATIM
     )
 
@@ -176,11 +171,13 @@ function(setup_split_device_compile)
     )
 
     # -- Step D: Bundle host + device into fat object -------------------------
+    # Use the bundler target strings detected at configure time so they
+    # match what `amdclang++ --hip-link` expects on this ROCm version.
     add_custom_command(
       OUTPUT  ${FAT_OBJ}
       COMMAND ${BUNDLER}
         --type=o
-        --targets=host-x86_64-unknown-linux-gnu,hipv4-amdgcn-amd-amdhsa--${SDC_GPU_ARCH}
+        --targets=${SDC_BUNDLER_HOST_TARGET},${SDC_BUNDLER_DEVICE_TARGET}
         --input=${HOST_OBJ}
         --input=${DEV_OBJ}
         --output=${FAT_OBJ}

--- a/projects/rccl/cmake/scripts/add_faults.sh
+++ b/projects/rccl/cmake/scripts/add_faults.sh
@@ -21,7 +21,7 @@
 HIP_FILE=$1
 
 if [[ "$HIP_FILE" =~ .*/src/device/.*\.h ]]; then
-  sed -i "s/__syncthreads()/__syncthreads(); insert_random_delay_per_warp()/" "$HIP_FILE"
+  sed -i "s/__syncthreads()/__syncthreads(); insert_random_delay_per_warp(ncclShmem)/" "$HIP_FILE"
 
   echo "Added fault injection to $HIP_FILE"
 fi

--- a/projects/rccl/src/device/all_gather.h
+++ b/projects/rccl/src/device/all_gather.h
@@ -13,11 +13,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto, bool isNetOffload = false>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
-#else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
-#endif
 #if defined(ENABLE_NPKIT)
     const int bid = ncclShmem.channelId - work->channelLo;
     int npKitCtxIdx = bid; // unused variable - compiler warning

--- a/projects/rccl/src/device/all_gather.h
+++ b/projects/rccl/src/device/all_gather.h
@@ -12,27 +12,27 @@
 namespace {
   template<typename T, typename RedOp, typename Proto, bool isNetOffload = false>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #endif
 #if defined(ENABLE_NPKIT)
-    const int bid = ncclShmem->channelId - work->channelLo;
+    const int bid = ncclShmem.channelId - work->channelLo;
     int npKitCtxIdx = bid; // unused variable - compiler warning
 #endif
 #ifdef ENABLE_WARP_SPEED
     int warp = threadIdx.x / WARP_SIZE;
-    ncclRing *ring = &ncclShmem->warpChannel[warp].ring;
+    ncclRing *ring = &ncclShmem.warpChannel[warp].ring;
 #else
-    ncclRing *ring = &ncclShmem->channel.ring;
+    ncclRing *ring = &ncclShmem.channel.ring;
 #endif
     const int *ringRanks = ring->userRanks;
-    const int nranks = ncclShmem->comm.nRanks;
+    const int nranks = ncclShmem.comm.nRanks;
     ssize_t count, partOffset, partCount, chunkCount;
 #ifdef ENABLE_WARP_SPEED
-    ncclCollCbdPart(work, ncclShmem->warpChannelId[warp], Proto::Id, sizeof(T), &count, &partOffset, &partCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), &count, &partOffset, &partCount, &chunkCount);
 #else
-    ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), &count, &partOffset, &partCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &partOffset, &partCount, &chunkCount);
 #endif
     ssize_t offset;
     ssize_t dataOffset;
@@ -43,21 +43,21 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, 0, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK,
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_GPU)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_GATHER_RING_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_GATHER_RING_ENTRY, count*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     int workNthreads;
@@ -98,7 +98,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_GATHER_RING_SEND_ENTRY)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_GATHER_RING_SEND_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
           prims.npKitDataProcessTotalTime = 0;
         }
 #endif
@@ -112,14 +112,14 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_GATHER_RING_SEND_EXIT)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_GATHER_RING_SEND_EXIT, nelem*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_GATHER_RING_RECV_COPY_SEND_ENTRY)
         if (tid == 0 && nranks > 2) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_GATHER_RING_RECV_COPY_SEND_ENTRY, nelem*(nranks-2)*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
           prims.npKitDataProcessTotalTime = 0;
         }
 #endif
@@ -134,7 +134,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_GATHER_RING_RECV_COPY_SEND_EXIT)
         if (tid == 0 && nranks > 2) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_GATHER_RING_RECV_COPY_SEND_EXIT, nelem*(nranks-2)*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         }
 #endif
 
@@ -145,7 +145,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_GATHER_RING_DIRECT_RECV_ENTRY)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_GATHER_RING_DIRECT_RECV_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
           prims.npKitDataProcessTotalTime = 0;
         }
 #endif
@@ -155,7 +155,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_GATHER_RING_DIRECT_RECV_EXIT)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_GATHER_RING_DIRECT_RECV_EXIT, nelem*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         }
 #endif
 
@@ -165,7 +165,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_GATHER_RING_EXIT)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_GATHER_RING_EXIT, count*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
     } else if (inputBuf != outputBuf + ringRanks[0] * count) {
@@ -198,7 +198,7 @@ namespace {
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
     bool isNetOffload = false;
 #else
@@ -213,26 +213,26 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     runRing<T, RedOp, ProtoLL>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     runRing<T, RedOp, ProtoLL128>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_PAT, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     using Proto = ProtoSimple<1, 1>;
-    const int nranks = ncclShmem->comm.nRanks;
-    const int rank = ncclShmem->comm.rank;
+    const int nranks = ncclShmem.comm.nRanks;
+    const int rank = ncclShmem.comm.rank;
     size_t count, channelOffset, channelCount, chunkCount;
-    ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), &count, &channelOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &channelOffset, &channelCount, &chunkCount);
 
     static constexpr int nworkers = NCCL_PAT_NWORKERS;
     struct ncclPatShmem* shmem = (struct ncclPatShmem*)ncclScratchForWarp(ncclShmemPerWarp, 0);
@@ -304,19 +304,19 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
     __device__ __forceinline__ void operator()(
         int tid, int tn, int slice, int maxSliceSize,
         int nSrcs, void** srcPtrs, int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag, uint32_t recvDirectFlag,
-        struct ncclShmemData* ncclShmem
+        struct ncclShmemData& ncclShmem
       ) {
       static_assert(SlicePerChunk==1, "require: SlicePerChunk==1");
       static_assert(MaxDsts<=1 || MaxSrcs<=1, "require: MaxDsts<=1 || MaxSrcs<=1");
 
-      struct ncclNvls* nvls = &ncclShmem->channel.nvls;
-      int nNodes = ncclShmem->comm.nNodes;
+      struct ncclNvls* nvls = &ncclShmem.channel.nvls;
+      int nNodes = ncclShmem.comm.nNodes;
       int nRails = nvls->nHeads;
-      int part = ncclShmem->channelId - work->channelLo;
+      int part = ncclShmem.channelId - work->channelLo;
       char* inbuf = (char*)work->sendbuff;
       char* outbuf = (char*)work->recvbuff;
       ssize_t countPerRank = work->collnet.count;
-      bool inPlace = (inbuf == outbuf + ncclShmem->comm.rank * countPerRank);
+      bool inPlace = (inbuf == outbuf + ncclShmem.comm.rank * countPerRank);
       ssize_t railAllBeg = min(railGridOffset + part * chunkSize, nNodes * countPerRank);
       ssize_t railAllEnd = min(railAllBeg + chunkSize, nNodes * countPerRank);
       int railAllSize = railAllEnd - railAllBeg;
@@ -338,9 +338,9 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
           ssize_t railOneEnd = railOneBeg + countPerRank;
           ssize_t railOneOffset = (railAllBeg + railAllOffset) - railOneBeg;
           int delta = min(railAllEnd, railOneEnd) - (railAllBeg + railAllOffset);
-          int rank = ncclShmem->comm.collNetDenseToUserRank[node * nRails + rail];
+          int rank = ncclShmem.comm.collNetDenseToUserRank[node * nRails + rail];
           ssize_t userOneBeg = rank * countPerRank + railOneOffset;
-          int outIsDst = (inPlace && rank == ncclShmem->comm.rank) || BcastSendNotRecv || work->regUsed ? 0 : 1;
+          int outIsDst = (inPlace && rank == ncclShmem.comm.rank) || BcastSendNotRecv || work->regUsed ? 0 : 1;
           if (nSrcs != 0 && outIsDst + nDsts != 0) {
             reduceCopy<ncclCollUnroll(), USE_ACC, RedOp, T,
               /*MultimemSrcs,MinSrcs,MaxSrcs=*/MultimemSrcs, 1, 1,
@@ -365,8 +365,8 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
     }
   };
 
-  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
-    struct ncclNvls* nvls = &ncclShmem->channel.nvls;
+  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
+    struct ncclNvls* nvls = &ncclShmem.channel.nvls;
     int nelem;
 
     const int nThreadsNetSend = work->oneNode ? 0 : (work->netRegUsed ? WARP_SIZE :  6 * WARP_SIZE);
@@ -378,9 +378,9 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
     const int tidEndBcast = tidEndNetSend + nThreadsBcast;
 
     if (work->oneNode) {
-      const ssize_t rank = ncclShmem->comm.rank;
+      const ssize_t rank = ncclShmem.comm.rank;
       size_t count, gridOffset, channelCount, offset, chunkCount;
-      ncclCollCbdPart(work, ncclShmem->channelId, NCCL_PROTO_SIMPLE, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
+      ncclCollCbdPart(work, ncclShmem.channelId, NCCL_PROTO_SIMPLE, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
       if (!work->regUsed) {
         if (tid < tidEndGather) {
           // Gather
@@ -438,8 +438,8 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
       }
     } else {
       // NVLS + IB SHARP
-      int nNodes = ncclShmem->comm.nNodes;
-      int part = ncclShmem->channelId - work->channelLo;
+      int nNodes = ncclShmem.comm.nNodes;
+      int part = ncclShmem.channelId - work->channelLo;
       ssize_t countPerRank = work->collnet.count;
       const int nChannels = work->channelHi - work->channelLo + 1;
       ssize_t chunkCount = work->collnet.chunkCount;
@@ -491,7 +491,7 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
             for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkCount) {
               ssize_t railAllBeg = railGridOffset + part * chunkCount;
               ssize_t railAllEnd = min(railAllBeg + chunkCount, nNodes * countPerRank);
-              ssize_t railOneBeg = ncclShmem->comm.node * countPerRank;
+              ssize_t railOneBeg = ncclShmem.comm.node * countPerRank;
               ssize_t railOneEnd = railOneBeg + countPerRank;
               ssize_t beg = max(railAllBeg, railOneBeg);
               ssize_t end = min(railAllEnd, railOneEnd);
@@ -528,19 +528,19 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
     __device__ __forceinline__ void operator()(
         int tid, int tn, int slice, int maxSliceSize,
         int nSrcs, void** srcPtrs, int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag, uint32_t recvDirectFlag,
-        struct ncclShmemData* ncclShmem
+        struct ncclShmemData& ncclShmem
       ) {
       static_assert(SlicePerChunk==1, "require: SlicePerChunk==1");
       static_assert(MaxDsts<=1 || MaxSrcs<=1, "require: MaxDsts<=1 || MaxSrcs<=1");
 
-      struct ncclDirect* direct = &ncclShmem->channel.collnetDirect;
-      int nNodes = ncclShmem->comm.nNodes;
+      struct ncclDirect* direct = &ncclShmem.channel.collnetDirect;
+      int nNodes = ncclShmem.comm.nNodes;
       int nRails = direct->nHeads;
-      int part = ncclShmem->channelId - work->channelLo;
+      int part = ncclShmem.channelId - work->channelLo;
       char* inbuf = (char*)work->sendbuff;
       char* outbuf = (char*)work->recvbuff;
       ssize_t countPerRank = work->collnet.count*sizeof(T);
-      bool inPlace = (inbuf == outbuf + ncclShmem->comm.rank*countPerRank);
+      bool inPlace = (inbuf == outbuf + ncclShmem.comm.rank*countPerRank);
 
       ssize_t railAllBeg = min(railGridOffset + part*chunkSize, nNodes*countPerRank);
       ssize_t railAllEnd = min(railAllBeg + chunkSize, nNodes*countPerRank);
@@ -563,9 +563,9 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
           ssize_t railOneEnd = railOneBeg + countPerRank;
           ssize_t railOneOffset = (railAllBeg+railAllOffset) - railOneBeg;
           int delta = min(railAllEnd, railOneEnd) - (railAllBeg+railAllOffset);
-          int rank = ncclShmem->comm.collNetDenseToUserRank[node*nRails + rail];
+          int rank = ncclShmem.comm.collNetDenseToUserRank[node*nRails + rail];
           ssize_t userOneBeg = rank*countPerRank + railOneOffset;
-          int outIsDst = (inPlace && rank == ncclShmem->comm.rank) ? 0 : 1;
+          int outIsDst = (inPlace && rank == ncclShmem.comm.rank) ? 0 : 1;
           if (nSrcs != 0 && outIsDst+nDsts != 0) {
             reduceCopy<ncclCollUnroll(), USE_ACC, RedOp, T,
                     /*MultimemSrcs,MinSrcs,MaxSrcs=*/0,1,1,
@@ -592,11 +592,11 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
     }
   };
 
-  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
-    const int part = ncclShmem->channelId - work->channelLo;
+  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
+    const int part = ncclShmem.channelId - work->channelLo;
     const int nChannels = work->channelHi - work->channelLo + 1;
-    struct ncclDirect* direct = &ncclShmem->channel.collnetDirect;
-    int const &nNodes = ncclShmem->comm.nNodes;
+    struct ncclDirect* direct = &ncclShmem.channel.collnetDirect;
+    int const &nNodes = ncclShmem.comm.nNodes;
     ssize_t countPerRank = work->collnet.count;
     size_t chunkSize = work->collnet.chunkCount;
     const int hasDn = (direct->down[0] >= 0) ? 1 : 0;
@@ -630,7 +630,7 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
         for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkSize) {
           ssize_t railAllBeg = railGridOffset + part * chunkSize;
           ssize_t railAllEnd = min(railAllBeg + chunkSize, nNodes * countPerRank);
-          ssize_t railOneBeg = ncclShmem->comm.node * countPerRank;
+          ssize_t railOneBeg = ncclShmem.comm.node * countPerRank;
           ssize_t railOneEnd = railOneBeg + countPerRank;
           ssize_t beg = max(railAllBeg, railOneBeg);
           ssize_t end = min(railAllEnd, railOneEnd);

--- a/projects/rccl/src/device/all_gather.h
+++ b/projects/rccl/src/device/all_gather.h
@@ -1,3 +1,5 @@
+#ifndef NCCL_DEVICE_ALL_GATHER_H_
+#define NCCL_DEVICE_ALL_GATHER_H_
 /*************************************************************************
  * Copyright (c) 2015-2022, NVIDIA CORPORATION. All rights reserved.
  * Modifications Copyright (c) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
@@ -682,3 +684,5 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
     }
   }
 };
+
+#endif // NCCL_DEVICE_ALL_GATHER_H_

--- a/projects/rccl/src/device/all_gather.h
+++ b/projects/rccl/src/device/all_gather.h
@@ -12,27 +12,27 @@
 namespace {
   template<typename T, typename RedOp, typename Proto, bool isNetOffload = false>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #endif
 #if defined(ENABLE_NPKIT)
-    const int bid = ncclShmem.channelId - work->channelLo;
+    const int bid = ncclShmem->channelId - work->channelLo;
     int npKitCtxIdx = bid; // unused variable - compiler warning
 #endif
 #ifdef ENABLE_WARP_SPEED
     int warp = threadIdx.x / WARP_SIZE;
-    ncclRing *ring = &ncclShmem.warpChannel[warp].ring;
+    ncclRing *ring = &ncclShmem->warpChannel[warp].ring;
 #else
-    ncclRing *ring = &ncclShmem.channel.ring;
+    ncclRing *ring = &ncclShmem->channel.ring;
 #endif
     const int *ringRanks = ring->userRanks;
-    const int nranks = ncclShmem.comm.nRanks;
+    const int nranks = ncclShmem->comm.nRanks;
     ssize_t count, partOffset, partCount, chunkCount;
 #ifdef ENABLE_WARP_SPEED
-    ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), &count, &partOffset, &partCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem->warpChannelId[warp], Proto::Id, sizeof(T), &count, &partOffset, &partCount, &chunkCount);
 #else
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &partOffset, &partCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), &count, &partOffset, &partCount, &chunkCount);
 #endif
     ssize_t offset;
     ssize_t dataOffset;
@@ -43,21 +43,21 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, 0, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK,
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_GPU)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_GATHER_RING_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_GATHER_RING_ENTRY, count*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     int workNthreads;
@@ -79,7 +79,7 @@ namespace {
       // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
       // coverity[callee_ptr_arith:FALSE]
       Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, isNetOffload> prims
-        (tid, workNthreads, &ring->prev, &ring->next, inputBuf, outputBuf, work->redOpArg, 0, work->connIndex, work->connIndex, work, NULL, isNetOffload ? NCCL_MAX_NET_SIZE : 0);
+        (tid, workNthreads, &ring->prev, &ring->next, inputBuf, outputBuf, work->redOpArg, ncclShmem, ncclShmemPerWarp, 0, work->connIndex, work->connIndex, work, NULL, isNetOffload ? NCCL_MAX_NET_SIZE : 0, primsModeDefault);
 
 #if defined(ENABLE_NPKIT)
       if (tid == 0) {
@@ -98,7 +98,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_GATHER_RING_SEND_ENTRY)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_GATHER_RING_SEND_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
           prims.npKitDataProcessTotalTime = 0;
         }
 #endif
@@ -112,14 +112,14 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_GATHER_RING_SEND_EXIT)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_GATHER_RING_SEND_EXIT, nelem*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_GATHER_RING_RECV_COPY_SEND_ENTRY)
         if (tid == 0 && nranks > 2) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_GATHER_RING_RECV_COPY_SEND_ENTRY, nelem*(nranks-2)*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
           prims.npKitDataProcessTotalTime = 0;
         }
 #endif
@@ -134,7 +134,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_GATHER_RING_RECV_COPY_SEND_EXIT)
         if (tid == 0 && nranks > 2) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_GATHER_RING_RECV_COPY_SEND_EXIT, nelem*(nranks-2)*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         }
 #endif
 
@@ -145,7 +145,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_GATHER_RING_DIRECT_RECV_ENTRY)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_GATHER_RING_DIRECT_RECV_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
           prims.npKitDataProcessTotalTime = 0;
         }
 #endif
@@ -155,7 +155,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_GATHER_RING_DIRECT_RECV_EXIT)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_GATHER_RING_DIRECT_RECV_EXIT, nelem*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         }
 #endif
 
@@ -165,7 +165,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_GATHER_RING_EXIT)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_GATHER_RING_EXIT, count*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
     } else if (inputBuf != outputBuf + ringRanks[0] * count) {
@@ -185,58 +185,57 @@ namespace {
 }
 
 #if defined(__gfx942__) || defined(__gfx950__) // Use a single slice per simple primitive for a single node on some GFX9 devices.
-#define rcclAllGatherRunRingSimpleProtoImpl(tid, nthreads, work) \
+#define rcclAllGatherRunRingSimpleProtoImpl(tid, nthreads, work, ncclShmem, ncclShmemPerWarp) \
   if(work->rcclUseOneSlice){ \
-    runRing<T, RedOp, ProtoSimple<ALLGATHER_CHUNKSTEPS/ALLGATHER_SLICESTEPS_SINGLE_NODE, ALLGATHER_SLICESTEPS_SINGLE_NODE>, false>(tid, nthreads, work); \
+    runRing<T, RedOp, ProtoSimple<ALLGATHER_CHUNKSTEPS/ALLGATHER_SLICESTEPS_SINGLE_NODE, ALLGATHER_SLICESTEPS_SINGLE_NODE>, false>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp); \
   } else{ \
-    runRing<T, RedOp, ProtoSimple<ALLGATHER_CHUNKSTEPS/ALLGATHER_SLICESTEPS, ALLGATHER_SLICESTEPS>, false>(tid, nthreads, work); \
+    runRing<T, RedOp, ProtoSimple<ALLGATHER_CHUNKSTEPS/ALLGATHER_SLICESTEPS, ALLGATHER_SLICESTEPS>, false>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp); \
   }
 #else
-#define rcclAllGatherRunRingSimpleProtoImpl(tid, nthreads, work) \
-  runRing<T, RedOp, ProtoSimple<ALLGATHER_CHUNKSTEPS/ALLGATHER_SLICESTEPS, ALLGATHER_SLICESTEPS>, false>(tid, nthreads, work);
+#define rcclAllGatherRunRingSimpleProtoImpl(tid, nthreads, work, ncclShmem, ncclShmemPerWarp) \
+  runRing<T, RedOp, ProtoSimple<ALLGATHER_CHUNKSTEPS/ALLGATHER_SLICESTEPS, ALLGATHER_SLICESTEPS>, false>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
 #endif
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
     bool isNetOffload = false;
 #else
     bool isNetOffload = work->isOneRPN && work->netRegUsed;
 #endif
     if (isNetOffload)
-      runRing<T, RedOp, ProtoSimple<1, 1>, true>(tid, nthreads, work);
-    else{
-      rcclAllGatherRunRingSimpleProtoImpl(tid, nthreads, work);
-    }
+      runRing<T, RedOp, ProtoSimple<1, 1>, true>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
+    else
+      rcclAllGatherRunRingSimpleProtoImpl(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    runRing<T, RedOp, ProtoLL>(tid, nthreads, work);
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    runRing<T, RedOp, ProtoLL>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    runRing<T, RedOp, ProtoLL128>(tid, nthreads, work);
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    runRing<T, RedOp, ProtoLL128>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_PAT, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
     using Proto = ProtoSimple<1, 1>;
-    const int nranks = ncclShmem.comm.nRanks;
-    const int rank = ncclShmem.comm.rank;
+    const int nranks = ncclShmem->comm.nRanks;
+    const int rank = ncclShmem->comm.rank;
     size_t count, channelOffset, channelCount, chunkCount;
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &channelOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), &count, &channelOffset, &channelCount, &chunkCount);
 
     static constexpr int nworkers = NCCL_PAT_NWORKERS;
-    struct ncclPatShmem* shmem = (struct ncclPatShmem*)ncclScratchForWarp(0);
+    struct ncclPatShmem* shmem = (struct ncclPatShmem*)ncclScratchForWarp(ncclShmemPerWarp, 0);
     uint64_t pollCount = 0;
     (void)pollCount; // unused variable - compiler warning
     __syncthreads(); // Don't start using shared mem until everyone arrives
@@ -274,7 +273,7 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_PAT, NCCL_PROTO_SIMPLE
       int tidInGroup = tid - group*groupSize;
       // We don't use recvPeers/sendPeers so let's pass shmem structs instead
       Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0> prims
-        (tidInGroup, groupSize, (int*)shmem->recvDims, (int*)shmem->sendDims, inputBuf, outputBuf, work->redOpArg, group, 0, 0, nullptr, nullptr, 0, primsModePatAg);
+        (tidInGroup, groupSize, (int*)shmem->recvDims, (int*)shmem->sendDims, inputBuf, outputBuf, work->redOpArg, ncclShmem, ncclShmemPerWarp, group, 0, 0, nullptr, nullptr, 0, primsModePatAg);
 
       int step = group;
       while(1) {
@@ -304,19 +303,20 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
     template<int SlicePerChunk, int MinSrcs, int MaxSrcs, int MinDsts, int MaxDsts, int MultimemSrcs, int MultimemDsts>
     __device__ __forceinline__ void operator()(
         int tid, int tn, int slice, int maxSliceSize,
-        int nSrcs, void** srcPtrs, int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag, uint32_t recvDirectFlag
+        int nSrcs, void** srcPtrs, int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag, uint32_t recvDirectFlag,
+        struct ncclShmemData* ncclShmem
       ) {
       static_assert(SlicePerChunk==1, "require: SlicePerChunk==1");
       static_assert(MaxDsts<=1 || MaxSrcs<=1, "require: MaxDsts<=1 || MaxSrcs<=1");
 
-      struct ncclNvls* nvls = &ncclShmem.channel.nvls;
-      int nNodes = ncclShmem.comm.nNodes;
+      struct ncclNvls* nvls = &ncclShmem->channel.nvls;
+      int nNodes = ncclShmem->comm.nNodes;
       int nRails = nvls->nHeads;
-      int part = ncclShmem.channelId - work->channelLo;
+      int part = ncclShmem->channelId - work->channelLo;
       char* inbuf = (char*)work->sendbuff;
       char* outbuf = (char*)work->recvbuff;
       ssize_t countPerRank = work->collnet.count;
-      bool inPlace = (inbuf == outbuf + ncclShmem.comm.rank * countPerRank);
+      bool inPlace = (inbuf == outbuf + ncclShmem->comm.rank * countPerRank);
       ssize_t railAllBeg = min(railGridOffset + part * chunkSize, nNodes * countPerRank);
       ssize_t railAllEnd = min(railAllBeg + chunkSize, nNodes * countPerRank);
       int railAllSize = railAllEnd - railAllBeg;
@@ -338,9 +338,9 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
           ssize_t railOneEnd = railOneBeg + countPerRank;
           ssize_t railOneOffset = (railAllBeg + railAllOffset) - railOneBeg;
           int delta = min(railAllEnd, railOneEnd) - (railAllBeg + railAllOffset);
-          int rank = ncclShmem.comm.collNetDenseToUserRank[node * nRails + rail];
+          int rank = ncclShmem->comm.collNetDenseToUserRank[node * nRails + rail];
           ssize_t userOneBeg = rank * countPerRank + railOneOffset;
-          int outIsDst = (inPlace && rank == ncclShmem.comm.rank) || BcastSendNotRecv || work->regUsed ? 0 : 1;
+          int outIsDst = (inPlace && rank == ncclShmem->comm.rank) || BcastSendNotRecv || work->regUsed ? 0 : 1;
           if (nSrcs != 0 && outIsDst + nDsts != 0) {
             reduceCopy<ncclCollUnroll(), USE_ACC, RedOp, T,
               /*MultimemSrcs,MinSrcs,MaxSrcs=*/MultimemSrcs, 1, 1,
@@ -365,8 +365,8 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
     }
   };
 
-  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work) {
-    struct ncclNvls* nvls = &ncclShmem.channel.nvls;
+  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    struct ncclNvls* nvls = &ncclShmem->channel.nvls;
     int nelem;
 
     const int nThreadsNetSend = work->oneNode ? 0 : (work->netRegUsed ? WARP_SIZE :  6 * WARP_SIZE);
@@ -378,16 +378,16 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
     const int tidEndBcast = tidEndNetSend + nThreadsBcast;
 
     if (work->oneNode) {
-      const ssize_t rank = ncclShmem.comm.rank;
+      const ssize_t rank = ncclShmem->comm.rank;
       size_t count, gridOffset, channelCount, offset, chunkCount;
-      ncclCollCbdPart(work, ncclShmem.channelId, NCCL_PROTO_SIMPLE, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
+      ncclCollCbdPart(work, ncclShmem->channelId, NCCL_PROTO_SIMPLE, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
       if (!work->regUsed) {
         if (tid < tidEndGather) {
           // Gather
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
           Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_NVLS_ARITY, 0>, /*Direct=*/0, Proto, 0>
             prims(tid, nThreadsGather, nvls->up, NULL, NULL, work->recvbuff,
-              work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
+              work->redOpArg, ncclShmem, ncclShmemPerWarp, 0 * Proto::MaxGroupWidth, 1, 1, nullptr, nullptr, 0, primsModeDefault);
           for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
             offset = gridOffset + elemOffset;
             nelem = min(chunkCount, channelCount - elemOffset);
@@ -399,7 +399,7 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL, 0, 1>;
           Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/0, Proto, 0>
             prims(tid - tidEndGather, nThreadsBcast, NULL, &nvls->down, work->sendbuff, NULL,
-              work->redOpArg, 3 * Proto::MaxGroupWidth, 0, 0);
+              work->redOpArg, ncclShmem, ncclShmemPerWarp, 3 * Proto::MaxGroupWidth, 0, 0, nullptr, nullptr, 0, primsModeDefault);
           for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
             offset = gridOffset + elemOffset;
             nelem = min(chunkCount, channelCount - elemOffset);
@@ -412,7 +412,7 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
           Primitives<T, RedOp, FanSymmetric<NCCL_MAX_NVLS_ARITY>, /*Direct=*/0, Proto, 0>
             prims(tid, nThreadsGather, nvls->up, nvls->up, NULL, NULL,
-              work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
+              work->redOpArg, ncclShmem, ncclShmemPerWarp, 0 * Proto::MaxGroupWidth, 1, 1, nullptr, nullptr, 0, primsModeDefault);
 
           /* used as sync */
           prims.scatter(0, 0, 0, 0, -1, 0);
@@ -424,7 +424,7 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL, 0, 1>;
           Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
             prims(tid - tidEndGather, nThreadsBcast, &nvls->down, &nvls->down, work->sendbuff, NULL,
-              work->redOpArg, 1 * Proto::MaxGroupWidth, 0, 0, work);
+              work->redOpArg, ncclShmem, ncclShmemPerWarp, 1 * Proto::MaxGroupWidth, 0, 0, work, nullptr, 0, primsModeDefault);
           /* used as sync */
           prims.recv(0, 0);
 
@@ -438,8 +438,8 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
       }
     } else {
       // NVLS + IB SHARP
-      int nNodes = ncclShmem.comm.nNodes;
-      int part = ncclShmem.channelId - work->channelLo;
+      int nNodes = ncclShmem->comm.nNodes;
+      int part = ncclShmem->channelId - work->channelLo;
       ssize_t countPerRank = work->collnet.count;
       const int nChannels = work->channelHi - work->channelLo + 1;
       ssize_t chunkCount = work->collnet.chunkCount;
@@ -447,7 +447,7 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
         using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
         Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_NVLS_ARITY, 0>, /*Direct=*/1, Proto, 0>
           prims(tid, nThreadsGather, nvls->up, nullptr, nullptr, work->recvbuff,
-            /*redOpArg=*/0, 1 * Proto::MaxGroupWidth, 1, 1, work);
+            /*redOpArg=*/0, ncclShmem, ncclShmemPerWarp, 1 * Proto::MaxGroupWidth, 1, 1, work, nullptr, 0, primsModeDefault);
         for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkCount) {
           Scatterer</*BcastSendNotRecv=*/false> scat;
           scat.work = work;
@@ -466,11 +466,11 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
           // first unroll 2 steps, then unroll the rest steps when the data is received.
           if (postThread) {
             curSteps = min(2, maxSteps);
-            Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/1, ProtoSend, 0>::sendPeerNotify(nvls->out, 1, curSteps);
+            Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/1, ProtoSend, 0>::sendPeerNotify(nvls->out, 1, curSteps, ncclShmem);
           }
           Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, ProtoBcast, 0>
             prims(tid - tidEndGather, nThreadsNetSend + nThreadsBcast, &nvls->out, &nvls->down, nullptr, nullptr,
-              /*redOpArg=*/0, 2 * ProtoBcast::MaxGroupWidth, 0, 0, work);
+              /*redOpArg=*/0, ncclShmem, ncclShmemPerWarp, 2 * ProtoBcast::MaxGroupWidth, 0, 0, work, nullptr, 0, primsModeDefault);
           for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkCount) {
             Scatterer</*BcastSendNotRecv=*/true> scat;
             scat.work = work;
@@ -479,7 +479,7 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
             prims.template process</*Recv=*/1, /*Send=*/1>(scat);
             if (postThread && curSteps < maxSteps) {
               curSteps++;
-              Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/1, ProtoSend, 0>::sendPeerNotify(nvls->out, 1, 1);
+              Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/1, ProtoSend, 0>::sendPeerNotify(nvls->out, 1, 1, ncclShmem);
             }
           }
         } else {
@@ -487,11 +487,11 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
             using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
             Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/0, Proto, 0>
               prims(tid - tidEndGather, nThreadsNetSend, nullptr, &nvls->out, work->sendbuff, nullptr,
-                /*redOpArg=*/0, 0 * Proto::MaxGroupWidth, 1, 1);
+                /*redOpArg=*/0, ncclShmem, ncclShmemPerWarp, 0 * Proto::MaxGroupWidth, 1, 1, nullptr, nullptr, 0, primsModeDefault);
             for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkCount) {
               ssize_t railAllBeg = railGridOffset + part * chunkCount;
               ssize_t railAllEnd = min(railAllBeg + chunkCount, nNodes * countPerRank);
-              ssize_t railOneBeg = ncclShmem.comm.node * countPerRank;
+              ssize_t railOneBeg = ncclShmem->comm.node * countPerRank;
               ssize_t railOneEnd = railOneBeg + countPerRank;
               ssize_t beg = max(railAllBeg, railOneBeg);
               ssize_t end = min(railAllEnd, railOneEnd);
@@ -501,7 +501,7 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
             using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL, 0, 1>;
             Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/0, Proto, 0>
               prims(tid - tidEndNetSend, nThreadsBcast, &nvls->out, &nvls->down, nullptr, nullptr,
-                /*redOpArg=*/0, 2 * Proto::MaxGroupWidth, 0, 0);
+                /*redOpArg=*/0, ncclShmem, ncclShmemPerWarp, 2 * Proto::MaxGroupWidth, 0, 0, nullptr, nullptr, 0, primsModeDefault);
             for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkCount) {
               Scatterer</*BcastSendNotRecv=*/true> scat;
               scat.work = work;
@@ -527,19 +527,20 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
     template<int SlicePerChunk, int MinSrcs, int MaxSrcs, int MinDsts, int MaxDsts, int MultimemSrcs, int MultimemDsts>
     __device__ __forceinline__ void operator()(
         int tid, int tn, int slice, int maxSliceSize,
-        int nSrcs, void** srcPtrs, int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag, uint32_t recvDirectFlag
+        int nSrcs, void** srcPtrs, int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag, uint32_t recvDirectFlag,
+        struct ncclShmemData* ncclShmem
       ) {
       static_assert(SlicePerChunk==1, "require: SlicePerChunk==1");
       static_assert(MaxDsts<=1 || MaxSrcs<=1, "require: MaxDsts<=1 || MaxSrcs<=1");
 
-      struct ncclDirect* direct = &ncclShmem.channel.collnetDirect;
-      int nNodes = ncclShmem.comm.nNodes;
+      struct ncclDirect* direct = &ncclShmem->channel.collnetDirect;
+      int nNodes = ncclShmem->comm.nNodes;
       int nRails = direct->nHeads;
-      int part = ncclShmem.channelId - work->channelLo;
+      int part = ncclShmem->channelId - work->channelLo;
       char* inbuf = (char*)work->sendbuff;
       char* outbuf = (char*)work->recvbuff;
       ssize_t countPerRank = work->collnet.count*sizeof(T);
-      bool inPlace = (inbuf == outbuf + ncclShmem.comm.rank*countPerRank);
+      bool inPlace = (inbuf == outbuf + ncclShmem->comm.rank*countPerRank);
 
       ssize_t railAllBeg = min(railGridOffset + part*chunkSize, nNodes*countPerRank);
       ssize_t railAllEnd = min(railAllBeg + chunkSize, nNodes*countPerRank);
@@ -562,9 +563,9 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
           ssize_t railOneEnd = railOneBeg + countPerRank;
           ssize_t railOneOffset = (railAllBeg+railAllOffset) - railOneBeg;
           int delta = min(railAllEnd, railOneEnd) - (railAllBeg+railAllOffset);
-          int rank = ncclShmem.comm.collNetDenseToUserRank[node*nRails + rail];
+          int rank = ncclShmem->comm.collNetDenseToUserRank[node*nRails + rail];
           ssize_t userOneBeg = rank*countPerRank + railOneOffset;
-          int outIsDst = (inPlace && rank == ncclShmem.comm.rank) ? 0 : 1;
+          int outIsDst = (inPlace && rank == ncclShmem->comm.rank) ? 0 : 1;
           if (nSrcs != 0 && outIsDst+nDsts != 0) {
             reduceCopy<ncclCollUnroll(), USE_ACC, RedOp, T,
                     /*MultimemSrcs,MinSrcs,MaxSrcs=*/0,1,1,
@@ -591,11 +592,11 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
     }
   };
 
-  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work) {
-    const int part = ncclShmem.channelId - work->channelLo;
+  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    const int part = ncclShmem->channelId - work->channelLo;
     const int nChannels = work->channelHi - work->channelLo + 1;
-    struct ncclDirect* direct = &ncclShmem.channel.collnetDirect;
-    int const &nNodes = ncclShmem.comm.nNodes;
+    struct ncclDirect* direct = &ncclShmem->channel.collnetDirect;
+    int const &nNodes = ncclShmem->comm.nNodes;
     ssize_t countPerRank = work->collnet.count;
     size_t chunkSize = work->collnet.chunkCount;
     const int hasDn = (direct->down[0] >= 0) ? 1 : 0;
@@ -618,18 +619,18 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
           // In this case, steps should be computed based on chunkSize and so on; otherwise, we just
           // bump the step by 1 to kick off collnet progress.
           int steps = hasDn ? (int)divUp(nNodes * countPerRank, nChannels * chunkSize) : 1;
-          Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/0, Proto, 0>::sendPeerNotify(direct->out, 1, steps);
+          Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/0, Proto, 0>::sendPeerNotify(direct->out, 1, steps, ncclShmem);
         }
         __syncwarp();
       } else {
         // Phase 1: send to network
         Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/0, Proto, 0>
           prims(tid, tn, nullptr, &direct->out, work->sendbuff, nullptr,
-            /*redOpArg=*/0, 0 * Proto::MaxGroupWidth, 1, 1);
+            /*redOpArg=*/0, ncclShmem, ncclShmemPerWarp, 0 * Proto::MaxGroupWidth, 1, 1, nullptr, nullptr, 0, primsModeDefault);
         for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkSize) {
           ssize_t railAllBeg = railGridOffset + part * chunkSize;
           ssize_t railAllEnd = min(railAllBeg + chunkSize, nNodes * countPerRank);
-          ssize_t railOneBeg = ncclShmem.comm.node * countPerRank;
+          ssize_t railOneBeg = ncclShmem->comm.node * countPerRank;
           ssize_t railOneEnd = railOneBeg + countPerRank;
           ssize_t beg = max(railAllBeg, railOneBeg);
           ssize_t end = min(railAllEnd, railOneEnd);
@@ -644,14 +645,14 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
     if (tid < tn) {
       if (work->netRegUsed && !hasDn) {
         if (tid == 0) {
-          Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DIRECT_ARITY>, /*Direct=*/0, Proto, 0>::recvPeerNotify(direct->out, 0, 1);
+          Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DIRECT_ARITY>, /*Direct=*/0, Proto, 0>::recvPeerNotify(direct->out, 0, 1, ncclShmem);
         }
         __syncwarp();
       } else {
         // Phase 2: Recv network -> deposit output + send to bcast
         Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DIRECT_ARITY>, /*Direct=*/1, Proto, 0>
           prims(tid, tn, &direct->out, direct->heads + 1, nullptr, work->recvbuff,
-            /*redOpArg=*/0, 1 * Proto::MaxGroupWidth, 0, 0, work);
+            /*redOpArg=*/0, ncclShmem, ncclShmemPerWarp, 1 * Proto::MaxGroupWidth, 0, 0, work, nullptr, 0, primsModeDefault);
         for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkSize) {
           Scatterer</*BcastSendNotRecv=*/true> scat;
           scat.work = work;
@@ -669,7 +670,7 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
       // Phase 3: Recv bcast -> deposit output
       Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DIRECT_ARITY, 0>, /*Direct=*/1, Proto, 0>
         prims(tid, tn, direct->heads+1, nullptr, nullptr, work->recvbuff,
-              /*redOpArg=*/0, 2*Proto::MaxGroupWidth, 0, 0, work);
+              /*redOpArg=*/0, ncclShmem, ncclShmemPerWarp, 2*Proto::MaxGroupWidth, 0, 0, work, nullptr, 0, primsModeDefault);
       for (ssize_t railGridOffset=0; railGridOffset < nNodes*countPerRank; railGridOffset += nChannels*chunkSize) {
         Scatterer</*BcastSendNotRecv=*/false> scat;
         scat.work = work;

--- a/projects/rccl/src/device/all_reduce.h
+++ b/projects/rccl/src/device/all_reduce.h
@@ -16,21 +16,21 @@
 namespace {
   template<typename T, typename RedOp, typename Proto, int RCCLMetadata>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #endif
 #ifdef ENABLE_WARP_SPEED
     int warp = threadIdx.x / WARP_SIZE;
-    ncclRing *ring = &ncclShmem.warpChannel[warp].ring;
+    ncclRing *ring = &ncclShmem->warpChannel[warp].ring;
 #else
-    ncclRing *ring = &ncclShmem.channel.ring;
+    ncclRing *ring = &ncclShmem->channel.ring;
 #endif
     int ringIx = ring->index;
 
-    const int nranks = ncclShmem.comm.nRanks;
+    const int nranks = ncclShmem->comm.nRanks;
 #if defined(ENABLE_NPKIT)
-    const int bid = ncclShmem.channelId - work->channelLo;
+    const int bid = ncclShmem->channelId - work->channelLo;
     int npKitCtxIdx = bid; // unused variable - compiler warning
 #endif
     ssize_t size;
@@ -38,9 +38,9 @@ namespace {
     ssize_t channelCount;
     ssize_t chunkCount;
 #ifdef ENABLE_WARP_SPEED
-    ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem->warpChannelId[warp], Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
 #else
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
 #endif
     const ssize_t loopCount = nranks * chunkCount;
     ssize_t offset;
@@ -51,28 +51,28 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, 0, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK,
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_GPU)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_ENTRY, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     // Coverity reports that the callee treats &ring->next as an array.  However, due to the use of
     // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
     // coverity[callee_ptr_arith:FALSE]
     Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, false, RCCLMetadata, Pipeline, USE_ACC> prims
-      (tid, nthreads, &ring->prev, &ring->next, work->sendbuff, work->recvbuff, work->redOpArg, 0, work->connIndex, work->connIndex, work);
+      (tid, nthreads, &ring->prev, &ring->next, work->sendbuff, work->recvbuff, work->redOpArg, ncclShmem, ncclShmemPerWarp, 0, work->connIndex, work->connIndex, work, nullptr, 0, primsModeDefault);
 
 #if defined(ENABLE_NPKIT)
     if (tid == 0) {
@@ -99,7 +99,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_SEND_ENTRY)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_SEND_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -109,7 +109,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_SEND_EXIT)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_SEND_EXIT, nelem*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
@@ -118,7 +118,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_RECV_REDUCE_SEND_ENTRY)
       if (tid == 0 && nranks > 2) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_RECV_REDUCE_SEND_ENTRY, nelem*(nranks-2)*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -134,7 +134,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_RECV_REDUCE_SEND_EXIT)
       if (tid == 0 && nranks > 2) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_RECV_REDUCE_SEND_EXIT, nelem*(nranks-2)*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
@@ -148,7 +148,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_REDUCE_COPY_SEND_ENTRY)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_REDUCE_COPY_SEND_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -158,14 +158,14 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_REDUCE_COPY_SEND_EXIT)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_REDUCE_COPY_SEND_EXIT, nelem*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_COPY_SEND_ENTRY)
       if (tid == 0 && nranks > 2) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_COPY_SEND_ENTRY, nelem*(nranks-2)*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -182,14 +182,14 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_COPY_SEND_EXIT)
       if (tid == 0 && nranks > 2) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_COPY_SEND_EXIT, nelem*(nranks-2)*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_ENTRY)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -205,7 +205,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_EXIT)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_EXIT, nelem*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
@@ -214,7 +214,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_EXIT, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -222,20 +222,20 @@ namespace {
 
   template<typename T, typename RedOp, typename Proto>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #else
-  __device__ __attribute__((noinline)) void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ __attribute__((noinline)) void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #endif
 #if defined(ENABLE_NPKIT)
-    const int bid = ncclShmem.channelId - work->channelLo;
+    const int bid = ncclShmem->channelId - work->channelLo;
     int npKitCtxIdx = bid; // unused variable - compiler warning
 #endif
-    ncclTree *tree = &ncclShmem.channel.tree;
+    ncclTree *tree = &ncclShmem->channel.tree;
     size_t size;
     size_t gridOffset;
     size_t channelCount;
     size_t chunkCount;
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
     size_t offset;
     int nelem;
 
@@ -243,27 +243,27 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, 0, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK,
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_GPU)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_ENTRY, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
     { // Reduce : max number of recv is 3, max number of send is 1 (binary tree + local)
       Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DEV_ARITY, 1>, /*Direct=*/0, Proto, 0, false, 0, Pipeline, USE_ACC> prims
-        (tid, nthreads, tree->down, &tree->up, work->sendbuff, work->recvbuff, work->redOpArg, 0, 0, 0, work);
+        (tid, nthreads, tree->down, &tree->up, work->sendbuff, work->recvbuff, work->redOpArg, ncclShmem, ncclShmemPerWarp, 0, 0, 0, work, nullptr, 0, primsModeDefault);
 
 #if defined(ENABLE_NPKIT)
       if (tid == 0) {
@@ -274,7 +274,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_REDUCE_ENTRY)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_REDUCE_ENTRY, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -304,7 +304,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_REDUCE_EXIT)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_REDUCE_EXIT, size*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
@@ -312,7 +312,7 @@ namespace {
 
     { // Broadcast : max number of recv is 1, max number of send is 3 (binary tree + local)
       Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DEV_ARITY>, /*Direct=*/0, Proto, 0, false, 0, Pipeline, USE_ACC> prims
-        (tid, nthreads, &tree->up, tree->down, work->sendbuff, work->recvbuff, work->redOpArg, 0, 0, 0, work);
+        (tid, nthreads, &tree->up, tree->down, work->sendbuff, work->recvbuff, work->redOpArg, ncclShmem, ncclShmemPerWarp, 0, 0, 0, work, nullptr, 0, primsModeDefault);
 
 #if defined(ENABLE_NPKIT)
       if (tid == 0) {
@@ -323,7 +323,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_BROADCAST_ENTRY)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_BROADCAST_ENTRY, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -353,7 +353,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_BROADCAST_EXIT)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_BROADCAST_EXIT, size*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
@@ -362,7 +362,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_EXIT, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -370,19 +370,19 @@ namespace {
 
   template<typename T, typename RedOp, typename Proto>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #else
-  __device__ __attribute__((noinline)) void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ __attribute__((noinline)) void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #endif
 #if defined(ENABLE_NPKIT)
-    const int bid = ncclShmem.channelId - work->channelLo; // unused variable - compiler warning
+    const int bid = ncclShmem->channelId - work->channelLo; // unused variable - compiler warning
 #endif
-    ncclTree *tree = &ncclShmem.channel.tree;
+    ncclTree *tree = &ncclShmem->channel.tree;
     size_t size;
     size_t gridOffset;
     size_t channelCount;
     size_t chunkCount;
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
     size_t offset;
     int nelem;
     int nthreadsSplit;
@@ -410,28 +410,28 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
     if (isNpKitThread) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, 0, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK,
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_GPU)
     if (isNpKitThread) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_ENTRY)
     if (isNpKitThread) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_ENTRY, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
     if (tree->up == -1) {
       // Reduce and broadcast. Max number of recv is 2, max number of send is 2
       Primitives<T, RedOp, FanSymmetric<NCCL_MAX_DEV_ARITY>, /*Direct=*/0, Proto, 0, false, 0, Pipeline, USE_ACC>
-        prims(tid, nthreads, tree->down, tree->down, work->sendbuff, work->recvbuff, work->redOpArg, 0, 0, 0, work);
+        prims(tid, nthreads, tree->down, tree->down, work->sendbuff, work->recvbuff, work->redOpArg, ncclShmem, ncclShmemPerWarp, 0, 0, 0, work, nullptr, 0, primsModeDefault);
 
 #if defined(ENABLE_NPKIT)
       if (isNpKitThread) {
@@ -442,7 +442,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_REDUCE_BROADCAST_ENTRY)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_REDUCE_BROADCAST_ENTRY, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -456,7 +456,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_REDUCE_BROADCAST_EXIT)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_REDUCE_BROADCAST_EXIT, size*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
@@ -474,7 +474,7 @@ namespace {
       // FanAsymmetric<n, 1>, only the first element is ever accessed, so it's fine.
       // coverity[callee_ptr_arith:FALSE]
       Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DEV_ARITY, 1>, /*Direct=*/0, Proto, 0, false, 0, Pipeline, USE_ACC>
-        prims(tid, nthreadsSplit, tree->down, &tree->up, work->sendbuff, work->recvbuff, work->redOpArg, 0*Proto::MaxGroupWidth, 0, 0, work);
+        prims(tid, nthreadsSplit, tree->down, &tree->up, work->sendbuff, work->recvbuff, work->redOpArg, ncclShmem, ncclShmemPerWarp, 0*Proto::MaxGroupWidth, 0, 0, work, nullptr, 0, primsModeDefault);
 
 #if defined(ENABLE_NPKIT)
       if (isNpKitThread) {
@@ -485,7 +485,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_REDUCE_ENTRY)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_REDUCE_ENTRY, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -508,7 +508,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_REDUCE_EXIT)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_REDUCE_EXIT, size*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
@@ -520,7 +520,7 @@ namespace {
       // coverity[callee_ptr_arith:FALSE]
       Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DEV_ARITY>, /*Direct=*/0, Proto, 0, false, 0, Pipeline, USE_ACC>
         prims(tid-nthreadsSplit, nthreads-nthreadsSplit, &tree->up, tree->down, work->sendbuff, work->recvbuff,
-            work->redOpArg, 1*Proto::MaxGroupWidth, 0, 0, work);
+            work->redOpArg, ncclShmem, ncclShmemPerWarp, 1*Proto::MaxGroupWidth, 0, 0, work, nullptr, 0, primsModeDefault);
 
 #if defined(ENABLE_NPKIT)
       if (isNpKitThread) {
@@ -531,7 +531,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_BROADCAST_ENTRY)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_BROADCAST_ENTRY, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -554,7 +554,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_BROADCAST_EXIT)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_BROADCAST_EXIT, size*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
@@ -563,7 +563,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_EXIT)
     if (isNpKitThread) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_EXIT, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -571,63 +571,57 @@ namespace {
 }
 
 #if defined(__gfx942__) // Use a single slice per simple primitive for a single node on some gfx942 devices.
-#define rcclAllReduceRunRingSimpleProtoImpl(tid, nthreads, work) \
+#define rcclAllReduceRunRingSimpleProtoImpl(tid, nthreads, work, ncclShmem, ncclShmemPerWarp) \
   if(work->rcclUseOneSlice){ \
     using Proto = ProtoSimple<ALLREDUCE_CHUNKSTEPS/ALLREDUCE_SLICESTEPS_SINGLE_NODE, ALLREDUCE_SLICESTEPS_SINGLE_NODE>; \
-    runRing<T, RedOp, Proto, RCCL_METADATA_EMPTY>(tid, nthreads, work); \
+    runRing<T, RedOp, Proto, RCCL_METADATA_EMPTY>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp); \
   } \
   else{ \
     using Proto = ProtoSimple<ALLREDUCE_CHUNKSTEPS/ALLREDUCE_SLICESTEPS, ALLREDUCE_SLICESTEPS>; \
-    runRing<T, RedOp, Proto, RCCL_METADATA_EMPTY>(tid, nthreads, work); \
+    runRing<T, RedOp, Proto, RCCL_METADATA_EMPTY>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp); \
   }
 #elif defined(__gfx950__) // Use a single slice and single step per slice per simple primitive for a single node on some gfx950 devices.
-#define rcclAllReduceRunRingSimpleProtoImpl(tid, nthreads, work) \
+#define rcclAllReduceRunRingSimpleProtoImpl(tid, nthreads, work, ncclShmem, ncclShmemPerWarp) \
   if(work->rcclUseOneSlice){ \
     using Proto = ProtoSimple<1, 1>; \
-    runRing<T, RedOp, Proto, RCCL_METADATA_EMPTY>(tid, nthreads, work); \
+    runRing<T, RedOp, Proto, RCCL_METADATA_EMPTY>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp); \
   } \
   else{ \
     using Proto = ProtoSimple<ALLREDUCE_CHUNKSTEPS/ALLREDUCE_SLICESTEPS, ALLREDUCE_SLICESTEPS>; \
-    runRing<T, RedOp, Proto, RCCL_METADATA_EMPTY>(tid, nthreads, work); \
+    runRing<T, RedOp, Proto, RCCL_METADATA_EMPTY>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp); \
   }
 #else
-#define rcclAllReduceRunRingSimpleProtoImpl(tid, nthreads, work) \
+#define rcclAllReduceRunRingSimpleProtoImpl(tid, nthreads, work, ncclShmem, ncclShmemPerWarp) \
   using Proto = ProtoSimple<ALLREDUCE_CHUNKSTEPS/ALLREDUCE_SLICESTEPS, ALLREDUCE_SLICESTEPS>; \
-  runRing<T, RedOp, Proto, RCCL_METADATA_EMPTY>(tid, nthreads, work);
+  runRing<T, RedOp, Proto, RCCL_METADATA_EMPTY>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
 #endif
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-   rcclAllReduceRunRingSimpleProtoImpl(tid, nthreads, work);
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+   rcclAllReduceRunRingSimpleProtoImpl(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_TREE, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
     using Proto = ProtoSimple<1, 1>;
     if (work->acc != nullptr) {
-      runTreeSplit<T, RedOp, Proto>(tid, nthreads, work);
+      runTreeSplit<T, RedOp, Proto>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
     } else {
-      runTreeUpDown<T, RedOp, Proto>(tid, nthreads, work);
+      runTreeUpDown<T, RedOp, Proto>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
     }
-    // Check-here
-    // #if CUDART_VERSION >= 11020 && CUDART_VERSION < 11040 && __CUDA_ARCH__ >= 800
-    //   runTreeUpDown<T, RedOp, ProtoSimple<1, 1>>(tid, nthreads, work);
-    // #else
-    //   runTreeSplit<T, RedOp, ProtoSimple<1, 1>>(tid, nthreads, work);
-    // #endif
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work) {
+  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
     static constexpr int COLLNET_COPY_THREADS = 64;
-    const int bid = ncclShmem.channelId - work->channelLo;
+    const int bid = ncclShmem->channelId - work->channelLo;
     const int nChannels = work->channelHi - work->channelLo + 1;
-    struct ncclDirect* direct = &ncclShmem.channel.collnetDirect;
+    struct ncclDirect* direct = &ncclShmem->channel.collnetDirect;
     const ssize_t chunkSize = work->collnet.chunkCount;
     const ssize_t size = work->collnet.count;
     const ssize_t loopSize = nChannels*direct->nHeads*chunkSize;
@@ -647,7 +641,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
       // Scatter
       Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_DIRECT_ARITY>, /*Direct=*/1, Proto, 0>
         prims(tid-tidStartScatter, nThreadsScatter, NULL, direct->up, work->sendbuff, work->recvbuff,
-           work->redOpArg, 2*Proto::MaxGroupWidth, 1, 1, work);
+           work->redOpArg, ncclShmem, ncclShmemPerWarp, 2*Proto::MaxGroupWidth, 1, 1, work, nullptr, 0, primsModeDefault);
       ssize_t offsetBase, peerOffset;
       ssize_t maxNelems;
       if (work->netRegUsed) {
@@ -674,7 +668,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
         // Reduce, send to network
         Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DIRECT_ARITY, 1>, /*Direct=*/1, Proto, 0>
           prims(tid-tidStartReduce, nThreadsReduce, direct->down, &direct->out, work->sendbuff, work->recvbuff,
-             work->redOpArg, 3*Proto::MaxGroupWidth, 1, 1, work);
+             work->redOpArg, ncclShmem, ncclShmemPerWarp, 3*Proto::MaxGroupWidth, 1, 1, work, nullptr, 0, primsModeDefault);
         for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
           ssize_t offset = work->netRegUsed ? gridOffset + (bid + direct->headRank * nChannels) * chunkSize
                                     : gridOffset + (bid * direct->nHeads + direct->headRank) * chunkSize;
@@ -685,13 +679,13 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
         // Directly send to network
         if (work->netRegUsed) {
           if (tid == tidStartReduce) {
-            Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/0, Proto, 0>::sendPeerNotify(direct->out, 1, 1);
+            Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/0, Proto, 0>::sendPeerNotify(direct->out, 1, 1, ncclShmem);
           }
           __syncwarp();
         } else {
           Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/0, Proto, 0>
           prims(tid-tidStartReduce, nThreadsReduce, nullptr, &direct->out, work->sendbuff, work->recvbuff,
-            work->redOpArg, 3*Proto::MaxGroupWidth, 1, 1);
+            work->redOpArg, ncclShmem, ncclShmemPerWarp, 3*Proto::MaxGroupWidth, 1, 1, nullptr, nullptr, 0, primsModeDefault);
           for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
             ssize_t offset = gridOffset + (bid * direct->nHeads + direct->headRank) * chunkSize;
             int nelem = min(chunkSize, size - offset);
@@ -703,7 +697,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
       // Gather
       Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DIRECT_ARITY, 0>, /*Direct=*/0, Proto, 0>
         prims(tid, nThreadsGather, direct->up, NULL, work->sendbuff, work->recvbuff,
-           work->redOpArg, 0*Proto::MaxGroupWidth, 0, 0, work);
+           work->redOpArg, ncclShmem, ncclShmemPerWarp, 0*Proto::MaxGroupWidth, 0, 0, work, nullptr, 0, primsModeDefault);
       ssize_t offsetBase, peerOffset;
       ssize_t maxNelems;
       if (work->netRegUsed) {
@@ -728,7 +722,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
         // coverity[identity_transfer:FALSE]
         Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DIRECT_ARITY>, /*Direct=*/0, Proto, 0>
           prims(tid-tidStartBcast, nThreadsBcast, &direct->out, direct->down, work->sendbuff, work->recvbuff,
-            work->redOpArg, 1*Proto::MaxGroupWidth, 0, 0, work);
+            work->redOpArg, ncclShmem, ncclShmemPerWarp, 1*Proto::MaxGroupWidth, 0, 0, work, nullptr, 0, primsModeDefault);
         for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
           ssize_t offset = work->netRegUsed ? gridOffset + (bid + direct->headRank * nChannels) * chunkSize
                                             : gridOffset + (bid * direct->nHeads + direct->headRank) * chunkSize;
@@ -738,14 +732,14 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
       } else {
         if (work->netRegUsed) {
           if (tid == tidStartBcast) {
-            Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/0, Proto, 0>::recvPeerNotify(direct->out, 0, 1);
+            Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/0, Proto, 0>::recvPeerNotify(direct->out, 0, 1, ncclShmem);
           }
           __syncwarp();
         } else {
           // Recv from network (no post thread needed)
           Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/0, Proto, 0>
             prims(tid - tidStartBcast, nThreadsBcast, &direct->out, nullptr, work->sendbuff, work->recvbuff,
-              work->redOpArg, 1 * Proto::MaxGroupWidth, 0, 0);
+              work->redOpArg, ncclShmem, ncclShmemPerWarp, 1 * Proto::MaxGroupWidth, 0, 0, nullptr, nullptr, 0, primsModeDefault);
           for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
             ssize_t offset = gridOffset + (bid * direct->nHeads + direct->headRank) * chunkSize;
             int nelem = min(chunkSize, size - offset);
@@ -759,10 +753,10 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work) {
-    struct ncclNvls* nvls = &ncclShmem.channel.nvls;
+  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    struct ncclNvls* nvls = &ncclShmem->channel.nvls;
     const bool hasOut = nvls->out != -1;
-    const int nranks = ncclShmem.comm.nRanks;
+    const int nranks = ncclShmem->comm.nRanks;
     const int totalWarps = NCCL_MAX_NTHREADS/WARP_SIZE;
     const int bcastWarps = hasOut ? (work->regUsed ? ((totalWarps - 2) >> 1) - 1 : 2) : 0;
     const int reduceWarps = work->regUsed ? (totalWarps - bcastWarps - 2) : (hasOut ? 3 : nranks <= 6 ? 7 : 5);
@@ -780,7 +774,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
 
     if (work->oneNode) {
       ssize_t gridOffset, channelCount, chunkSize;
-      ncclCollCbdPart(work, ncclShmem.channelId, NCCL_PROTO_SIMPLE, sizeof(T), (ssize_t*)nullptr, &gridOffset, &channelCount, &chunkSize);
+      ncclCollCbdPart(work, ncclShmem->channelId, NCCL_PROTO_SIMPLE, sizeof(T), (ssize_t*)nullptr, &gridOffset, &channelCount, &chunkSize);
       const ssize_t loopCount = nvls->nHeads * chunkSize;
       int remCount = channelCount%(nvls->nHeads*chunkSize);
       int lastChunkSize = alignUp(divUp(remCount, nvls->nHeads), 16384/sizeof(T));
@@ -790,7 +784,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
         using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
         Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_NVLS_ARITY>, /*Direct=*/0, Proto, 0>
           prims(tid, nThreadsScatter, NULL, nvls->up, work->sendbuff, NULL,
-            work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
+            work->redOpArg, ncclShmem, ncclShmemPerWarp, 0 * Proto::MaxGroupWidth, 1, 1, nullptr, nullptr, 0, primsModeDefault);
         for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
           if (channelCount - elemOffset < loopCount) chunkSize = lastChunkSize;
           ssize_t offset = gridOffset + elemOffset;
@@ -802,7 +796,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
         using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
         Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_NVLS_ARITY, 0>, /*Direct=*/0, Proto, 0>
           prims(tid - tidEndScatter, nThreadsGather, nvls->up, NULL, NULL, work->recvbuff,
-            work->redOpArg, 1 * Proto::MaxGroupWidth, 1, 1);
+            work->redOpArg, ncclShmem, ncclShmemPerWarp, 1 * Proto::MaxGroupWidth, 1, 1, nullptr, nullptr, 0, primsModeDefault);
         for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
           if (channelCount - elemOffset < loopCount) chunkSize = lastChunkSize;
           ssize_t offset = gridOffset + elemOffset;
@@ -814,7 +808,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
         using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL, 1, 1>;
         Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
           prims(tid - tidEndGather, nThreadsReduce, &nvls->down, &nvls->down, NULL, NULL,
-            work->redOpArg, 2 * Proto::MaxGroupWidth, 0, 0, work);
+            work->redOpArg, ncclShmem, ncclShmemPerWarp, 2 * Proto::MaxGroupWidth, 0, 0, work, nullptr, 0, primsModeDefault);
         for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
           ssize_t chunkOffset, offset;
           int nelem;
@@ -826,7 +820,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
         }
       }
     } else {
-      const int bid = ncclShmem.channelId - work->channelLo;
+      const int bid = ncclShmem->channelId - work->channelLo;
       const int nChannels = work->channelHi - work->channelLo + 1;
       const ssize_t chunkSize = work->collnet.chunkCount;
       const ssize_t loopSize = nChannels * nvls->nHeads * chunkSize;
@@ -837,7 +831,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
         using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
         Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_NVLS_ARITY>, /*Direct=*/0, Proto, 0>
           prims(tid, nThreadsScatter, NULL, nvls->up, work->sendbuff, NULL,
-            work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
+            work->redOpArg, ncclShmem, ncclShmemPerWarp, 0 * Proto::MaxGroupWidth, 1, 1, nullptr, nullptr, 0, primsModeDefault);
         for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
           ssize_t offset = gridOffset + bid * nvls->nHeads * chunkSize;
           int nelem = work->regUsed ? 0 : min(nvls->nHeads * chunkSize, size - offset);
@@ -849,7 +843,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
         using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
         Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_NVLS_ARITY, 0>, /*Direct=*/0, Proto, 0>
           prims(tid - tidEndScatter, nThreadsGather, nvls->up, NULL, NULL, work->recvbuff,
-            work->redOpArg, 1 * Proto::MaxGroupWidth, 1, 1);
+            work->redOpArg, ncclShmem, ncclShmemPerWarp, 1 * Proto::MaxGroupWidth, 1, 1, nullptr, nullptr, 0, primsModeDefault);
         for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
           ssize_t offset = gridOffset + bid * nvls->nHeads * chunkSize;
           int nelem = work->regUsed ? 0 : min(nvls->nHeads * chunkSize, size - offset);
@@ -863,7 +857,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
         // coverity[identity_transfer:FALSE]
         Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
         prims(tid - tidEndGather, nThreadsReduce, &nvls->down, &nvls->out, NULL, work->recvbuff,
-          work->redOpArg, 2 * Proto::MaxGroupWidth, 0, 1, work);
+          work->redOpArg, ncclShmem, ncclShmemPerWarp, 2 * Proto::MaxGroupWidth, 0, 1, work, nullptr, 0, primsModeDefault);
         for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
           ssize_t offset = work->regUsed && work->netRegUsed ? gridOffset + (nvls->headRank * nChannels + bid) * chunkSize
                                                              : gridOffset + (bid * nvls->nHeads + nvls->headRank) * chunkSize;
@@ -878,7 +872,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
         // coverity[identity_transfer:FALSE]
         Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
           prims(tid - tidEndReduce, nThreadsBcast, &nvls->out, &nvls->down, NULL, work->recvbuff,
-            work->redOpArg, 3 * Proto::MaxGroupWidth, 0, 0, work);
+            work->redOpArg, ncclShmem, ncclShmemPerWarp, 3 * Proto::MaxGroupWidth, 0, 0, work, nullptr, 0, primsModeDefault);
         for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
           ssize_t offset = work->regUsed && work->netRegUsed ? gridOffset + (nvls->headRank * nChannels + bid) * chunkSize
                                                              : gridOffset + (bid * nvls->nHeads + nvls->headRank) * chunkSize;
@@ -892,14 +886,14 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS_TREE, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work) {
-    struct ncclNvls* nvls = &ncclShmem.channel.nvls;
+  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    struct ncclNvls* nvls = &ncclShmem->channel.nvls;
     const int treeUp = nvls->treeUp;
     const int* treeDown = nvls->treeDown;
     ssize_t gridOffset, channelCount, chunkCount;
-    ncclCollCbdPart(work, ncclShmem.channelId, NCCL_PROTO_SIMPLE, sizeof(T), (ssize_t*)nullptr, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem->channelId, NCCL_PROTO_SIMPLE, sizeof(T), (ssize_t*)nullptr, &gridOffset, &channelCount, &chunkCount);
     const ssize_t loopCount = nvls->nHeads * chunkCount;
-    const int nranks = ncclShmem.comm.nRanks;
+    const int nranks = ncclShmem->comm.nRanks;
     const bool hasUp = treeUp != -1;
     const int totalWarps = NCCL_MAX_NTHREADS/WARP_SIZE;
     const int bcastWarps = hasUp ? (work->regUsed ? ((totalWarps - 2) >> 1) - 1 : 4) : 0;
@@ -925,7 +919,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS_TREE, NCCL_PROTO_
       using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
       Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_NVLS_ARITY>, /*Direct=*/0, Proto, 0>
         prims(tid, nThreadsScatter, NULL, nvls->up, work->sendbuff, NULL,
-          work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
+          work->redOpArg, ncclShmem, ncclShmemPerWarp, 0 * Proto::MaxGroupWidth, 1, 1, nullptr, nullptr, 0, primsModeDefault);
       for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
         if (channelCount - elemOffset < loopCount) chunkCount = lastChunkCount;
         offset = gridOffset + elemOffset;
@@ -937,7 +931,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS_TREE, NCCL_PROTO_
       using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
       Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_NVLS_ARITY, 0>, /*Direct=*/0, Proto, 0>
         prims(tid - tidEndScatter, nThreadsGather, nvls->up, NULL, NULL, work->recvbuff,
-          work->redOpArg, 1 * Proto::MaxGroupWidth, 1, 1);
+          work->redOpArg, ncclShmem, ncclShmemPerWarp, 1 * Proto::MaxGroupWidth, 1, 1, nullptr, nullptr, 0, primsModeDefault);
       for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
         if (channelCount - elemOffset < loopCount) chunkCount = lastChunkCount;
         offset = gridOffset + elemOffset;
@@ -950,7 +944,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS_TREE, NCCL_PROTO_
         using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL, 1, 1>;
         Primitives<T, RedOp, FanSymmetric<3>, /*Direct=*/1, Proto, 0>
           prims(tid - tidEndGather, nThreadsReduce, treeDown, treeDown, NULL, NULL,
-            work->redOpArg, 2 * Proto::MaxGroupWidth, 0, 0, work);
+            work->redOpArg, ncclShmem, ncclShmemPerWarp, 2 * Proto::MaxGroupWidth, 0, 0, work, nullptr, 0, primsModeDefault);
         for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
           ssize_t chunkOffset;
           if (channelCount - elemOffset < loopCount) chunkCount = lastChunkCount;
@@ -967,7 +961,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS_TREE, NCCL_PROTO_
         // coverity[callee_ptr_arith:FALSE]
         Primitives<T, RedOp, FanAsymmetric<3, 1>, /*Direct=*/1, Proto, 0>
           prims(tid - tidEndGather, nThreadsReduce, treeDown, &treeUp, NULL, NULL,
-            work->redOpArg, 2 * Proto::MaxGroupWidth, 0, 0, work);
+            work->redOpArg, ncclShmem, ncclShmemPerWarp, 2 * Proto::MaxGroupWidth, 0, 0, work, nullptr, 0, primsModeDefault);
         for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
           ssize_t chunkOffset;
           if (channelCount - elemOffset < loopCount) chunkCount = lastChunkCount;
@@ -985,7 +979,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS_TREE, NCCL_PROTO_
       // coverity[callee_ptr_arith:FALSE]
       Primitives<T, RedOp, FanAsymmetric<1, 3>, /*Direct=*/1, Proto, 0>
         prims(tid - tidEndReduce, nThreadsBcast, &treeUp, treeDown, NULL, NULL,
-          work->redOpArg, 3 * Proto::MaxGroupWidth, 0, 0, work);
+          work->redOpArg, ncclShmem, ncclShmemPerWarp, 3 * Proto::MaxGroupWidth, 0, 0, work, nullptr, 0, primsModeDefault);
       for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
         ssize_t chunkOffset;
         if (channelCount - elemOffset < loopCount) chunkCount = lastChunkCount;
@@ -1000,13 +994,13 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS_TREE, NCCL_PROTO_
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_CHAIN, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    const int bid = ncclShmem.channelId - work->channelLo;
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    const int bid = ncclShmem->channelId - work->channelLo;
     const int nChannels = work->channelHi - work->channelLo + 1;
-    ncclTree *tree = &ncclShmem.channel.collnetChain;
+    ncclTree *tree = &ncclShmem->channel.collnetChain;
     ssize_t chunkSize = work->collnet.chunkCount;
     const ssize_t loopSize = int(nChannels*chunkSize);
-    const int nranks = ncclShmem.comm.nRanks;
+    const int nranks = ncclShmem->comm.nRanks;
     const ssize_t size = work->collnet.count;
 
     int nthreadsSplit = nthreads/2;
@@ -1036,13 +1030,13 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_CHAIN, NCCL_PR
       if (recv == -1) {
         if (work->netRegUsed) {
           if (groupTid == 0) {
-            Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>::sendPeerNotify(send, connIndex, 1);
+            Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>::sendPeerNotify(send, connIndex, 1, ncclShmem);
           }
           __syncwarp();
         } else {
           Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
             prims(groupTid, groupNthreads, &recv, &send, work->sendbuff, work->recvbuff,
-              work->redOpArg, group * Proto::MaxGroupWidth, connIndex, connIndex, work);
+              work->redOpArg, ncclShmem, ncclShmemPerWarp, group * Proto::MaxGroupWidth, connIndex, connIndex, work, nullptr, 0, primsModeDefault);
           for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
             ssize_t offset = gridOffset + bid * int(chunkSize);
             int nelem = min(chunkSize, size - offset);
@@ -1054,7 +1048,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_CHAIN, NCCL_PR
       } else {
         Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
           prims(groupTid, groupNthreads, &recv, &send, work->sendbuff, work->recvbuff,
-            work->redOpArg, group * Proto::MaxGroupWidth, connIndex, connIndex, work);
+            work->redOpArg, ncclShmem, ncclShmemPerWarp, group * Proto::MaxGroupWidth, connIndex, connIndex, work, nullptr, 0, primsModeDefault);
         for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
           ssize_t offset = gridOffset + bid * int(chunkSize);
           int nelem = min(chunkSize, size - offset);
@@ -1070,7 +1064,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_CHAIN, NCCL_PR
         if (send == -1) {
           if (work->netRegUsed) {
             if (groupTid == 0) {
-              Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>::recvPeerNotify(recv, connIndex, 1);
+              Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>::recvPeerNotify(recv, connIndex, 1, ncclShmem);
             }
             __syncwarp();
           } else {
@@ -1079,7 +1073,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_CHAIN, NCCL_PR
             // coverity[callee_ptr_arith:FALSE]
             Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
               prims(groupTid, groupNthreads, &recv, &send, work->sendbuff, work->recvbuff,
-                work->redOpArg, group * Proto::MaxGroupWidth, connIndex, connIndex, work);
+                work->redOpArg, ncclShmem, ncclShmemPerWarp, group * Proto::MaxGroupWidth, connIndex, connIndex, work, nullptr, 0, primsModeDefault);
             for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
               ssize_t offset = gridOffset + bid * int(chunkSize);
               int nelem = min(chunkSize, size - offset);
@@ -1092,7 +1086,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_CHAIN, NCCL_PR
           // coverity[callee_ptr_arith:FALSE]
           Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
             prims(groupTid, groupNthreads, &recv, &send, work->sendbuff, work->recvbuff,
-              work->redOpArg, group * Proto::MaxGroupWidth, connIndex, connIndex, work);
+              work->redOpArg, ncclShmem, ncclShmemPerWarp, group * Proto::MaxGroupWidth, connIndex, connIndex, work, nullptr, 0, primsModeDefault);
           for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
             ssize_t offset = gridOffset + bid * int(chunkSize);
             int nelem = min(chunkSize, size - offset);
@@ -1105,7 +1099,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_CHAIN, NCCL_PR
         // coverity[callee_ptr_arith:FALSE]
         Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
           prims(groupTid, groupNthreads, &recv, &send, work->sendbuff, work->recvbuff,
-            work->redOpArg, group * Proto::MaxGroupWidth, connIndex, connIndex, work);
+            work->redOpArg, ncclShmem, ncclShmemPerWarp, group * Proto::MaxGroupWidth, connIndex, connIndex, work, nullptr, 0, primsModeDefault);
         if (send == -1) {
           for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
             ssize_t offset = gridOffset + bid*int(chunkSize);
@@ -1126,28 +1120,28 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_CHAIN, NCCL_PR
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    runRing<T, RedOp, ProtoLL, RCCL_METADATA_EMPTY>(tid, nthreads, work);
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    runRing<T, RedOp, ProtoLL, RCCL_METADATA_EMPTY>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_TREE, NCCL_PROTO_LL> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    runTreeSplit<T, RedOp, ProtoLL>(tid, nthreads, work);
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    runTreeSplit<T, RedOp, ProtoLL>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    runRing<T, RedOp, ProtoLL128, RCCL_METADATA_EMPTY>(tid, nthreads, work);
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    runRing<T, RedOp, ProtoLL128, RCCL_METADATA_EMPTY>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_TREE, NCCL_PROTO_LL128> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    runTreeSplit<T, RedOp, ProtoLL128>(tid, nthreads, work);
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    runTreeSplit<T, RedOp, ProtoLL128>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };

--- a/projects/rccl/src/device/all_reduce.h
+++ b/projects/rccl/src/device/all_reduce.h
@@ -17,11 +17,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto, int RCCLMetadata>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
-#else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
-#endif
 #ifdef ENABLE_WARP_SPEED
     int warp = threadIdx.x / WARP_SIZE;
     ncclRing *ring = &ncclShmem.warpChannel[warp].ring;

--- a/projects/rccl/src/device/all_reduce.h
+++ b/projects/rccl/src/device/all_reduce.h
@@ -1,3 +1,5 @@
+#ifndef NCCL_DEVICE_ALL_REDUCE_H_
+#define NCCL_DEVICE_ALL_REDUCE_H_
 /*************************************************************************
  * Copyright (c) 2015-2022, NVIDIA CORPORATION. All rights reserved.
  * Modifications Copyright (c) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
@@ -1145,3 +1147,5 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_TREE, NCCL_PROTO_LL128
     runTreeSplit<T, RedOp, ProtoLL128>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
+
+#endif // NCCL_DEVICE_ALL_REDUCE_H_

--- a/projects/rccl/src/device/all_reduce.h
+++ b/projects/rccl/src/device/all_reduce.h
@@ -16,21 +16,21 @@
 namespace {
   template<typename T, typename RedOp, typename Proto, int RCCLMetadata>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #endif
 #ifdef ENABLE_WARP_SPEED
     int warp = threadIdx.x / WARP_SIZE;
-    ncclRing *ring = &ncclShmem->warpChannel[warp].ring;
+    ncclRing *ring = &ncclShmem.warpChannel[warp].ring;
 #else
-    ncclRing *ring = &ncclShmem->channel.ring;
+    ncclRing *ring = &ncclShmem.channel.ring;
 #endif
     int ringIx = ring->index;
 
-    const int nranks = ncclShmem->comm.nRanks;
+    const int nranks = ncclShmem.comm.nRanks;
 #if defined(ENABLE_NPKIT)
-    const int bid = ncclShmem->channelId - work->channelLo;
+    const int bid = ncclShmem.channelId - work->channelLo;
     int npKitCtxIdx = bid; // unused variable - compiler warning
 #endif
     ssize_t size;
@@ -38,9 +38,9 @@ namespace {
     ssize_t channelCount;
     ssize_t chunkCount;
 #ifdef ENABLE_WARP_SPEED
-    ncclCollCbdPart(work, ncclShmem->warpChannelId[warp], Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
 #else
-    ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
 #endif
     const ssize_t loopCount = nranks * chunkCount;
     ssize_t offset;
@@ -51,21 +51,21 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, 0, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK,
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_GPU)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_ENTRY, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     // Coverity reports that the callee treats &ring->next as an array.  However, due to the use of
@@ -99,7 +99,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_SEND_ENTRY)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_SEND_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -109,7 +109,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_SEND_EXIT)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_SEND_EXIT, nelem*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
@@ -118,7 +118,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_RECV_REDUCE_SEND_ENTRY)
       if (tid == 0 && nranks > 2) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_RECV_REDUCE_SEND_ENTRY, nelem*(nranks-2)*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -134,7 +134,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_RECV_REDUCE_SEND_EXIT)
       if (tid == 0 && nranks > 2) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_RECV_REDUCE_SEND_EXIT, nelem*(nranks-2)*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
@@ -148,7 +148,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_REDUCE_COPY_SEND_ENTRY)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_REDUCE_COPY_SEND_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -158,14 +158,14 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_REDUCE_COPY_SEND_EXIT)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_REDUCE_COPY_SEND_EXIT, nelem*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_COPY_SEND_ENTRY)
       if (tid == 0 && nranks > 2) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_COPY_SEND_ENTRY, nelem*(nranks-2)*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -182,14 +182,14 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_COPY_SEND_EXIT)
       if (tid == 0 && nranks > 2) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_COPY_SEND_EXIT, nelem*(nranks-2)*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_ENTRY)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -205,7 +205,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_EXIT)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_DIRECT_RECV_EXIT, nelem*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
@@ -214,7 +214,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_RING_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_RING_EXIT, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -222,20 +222,20 @@ namespace {
 
   template<typename T, typename RedOp, typename Proto>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #else
-  __device__ __attribute__((noinline)) void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __attribute__((noinline)) void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #endif
 #if defined(ENABLE_NPKIT)
-    const int bid = ncclShmem->channelId - work->channelLo;
+    const int bid = ncclShmem.channelId - work->channelLo;
     int npKitCtxIdx = bid; // unused variable - compiler warning
 #endif
-    ncclTree *tree = &ncclShmem->channel.tree;
+    ncclTree *tree = &ncclShmem.channel.tree;
     size_t size;
     size_t gridOffset;
     size_t channelCount;
     size_t chunkCount;
-    ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
     size_t offset;
     int nelem;
 
@@ -243,21 +243,21 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, 0, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK,
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_GPU)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_ENTRY, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -274,7 +274,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_REDUCE_ENTRY)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_REDUCE_ENTRY, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -304,7 +304,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_REDUCE_EXIT)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_REDUCE_EXIT, size*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
@@ -323,7 +323,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_BROADCAST_ENTRY)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_BROADCAST_ENTRY, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -353,7 +353,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_BROADCAST_EXIT)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_BROADCAST_EXIT, size*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
@@ -362,7 +362,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_UPDOWN_EXIT, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -370,19 +370,19 @@ namespace {
 
   template<typename T, typename RedOp, typename Proto>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #else
-  __device__ __attribute__((noinline)) void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __attribute__((noinline)) void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #endif
 #if defined(ENABLE_NPKIT)
-    const int bid = ncclShmem->channelId - work->channelLo; // unused variable - compiler warning
+    const int bid = ncclShmem.channelId - work->channelLo; // unused variable - compiler warning
 #endif
-    ncclTree *tree = &ncclShmem->channel.tree;
+    ncclTree *tree = &ncclShmem.channel.tree;
     size_t size;
     size_t gridOffset;
     size_t channelCount;
     size_t chunkCount;
-    ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
     size_t offset;
     int nelem;
     int nthreadsSplit;
@@ -410,21 +410,21 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
     if (isNpKitThread) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, 0, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK,
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_GPU)
     if (isNpKitThread) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_ENTRY)
     if (isNpKitThread) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_ENTRY, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -442,7 +442,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_REDUCE_BROADCAST_ENTRY)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_REDUCE_BROADCAST_ENTRY, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -456,7 +456,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_REDUCE_BROADCAST_EXIT)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_REDUCE_BROADCAST_EXIT, size*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
@@ -485,7 +485,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_REDUCE_ENTRY)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_REDUCE_ENTRY, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -508,7 +508,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_REDUCE_EXIT)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_REDUCE_EXIT, size*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
@@ -531,7 +531,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_BROADCAST_ENTRY)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_BROADCAST_ENTRY, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -554,7 +554,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_BROADCAST_EXIT)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_BROADCAST_EXIT, size*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
 
@@ -563,7 +563,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_EXIT)
     if (isNpKitThread) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_ALL_REDUCE_TREE_SPLIT_EXIT, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -598,14 +598,14 @@ namespace {
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
    rcclAllReduceRunRingSimpleProtoImpl(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_TREE, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     using Proto = ProtoSimple<1, 1>;
     if (work->acc != nullptr) {
       runTreeSplit<T, RedOp, Proto>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
@@ -617,11 +617,11 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_TREE, NCCL_PROTO_SIMPL
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     static constexpr int COLLNET_COPY_THREADS = 64;
-    const int bid = ncclShmem->channelId - work->channelLo;
+    const int bid = ncclShmem.channelId - work->channelLo;
     const int nChannels = work->channelHi - work->channelLo + 1;
-    struct ncclDirect* direct = &ncclShmem->channel.collnetDirect;
+    struct ncclDirect* direct = &ncclShmem.channel.collnetDirect;
     const ssize_t chunkSize = work->collnet.chunkCount;
     const ssize_t size = work->collnet.count;
     const ssize_t loopSize = nChannels*direct->nHeads*chunkSize;
@@ -753,10 +753,10 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
-    struct ncclNvls* nvls = &ncclShmem->channel.nvls;
+  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
+    struct ncclNvls* nvls = &ncclShmem.channel.nvls;
     const bool hasOut = nvls->out != -1;
-    const int nranks = ncclShmem->comm.nRanks;
+    const int nranks = ncclShmem.comm.nRanks;
     const int totalWarps = NCCL_MAX_NTHREADS/WARP_SIZE;
     const int bcastWarps = hasOut ? (work->regUsed ? ((totalWarps - 2) >> 1) - 1 : 2) : 0;
     const int reduceWarps = work->regUsed ? (totalWarps - bcastWarps - 2) : (hasOut ? 3 : nranks <= 6 ? 7 : 5);
@@ -774,7 +774,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
 
     if (work->oneNode) {
       ssize_t gridOffset, channelCount, chunkSize;
-      ncclCollCbdPart(work, ncclShmem->channelId, NCCL_PROTO_SIMPLE, sizeof(T), (ssize_t*)nullptr, &gridOffset, &channelCount, &chunkSize);
+      ncclCollCbdPart(work, ncclShmem.channelId, NCCL_PROTO_SIMPLE, sizeof(T), (ssize_t*)nullptr, &gridOffset, &channelCount, &chunkSize);
       const ssize_t loopCount = nvls->nHeads * chunkSize;
       int remCount = channelCount%(nvls->nHeads*chunkSize);
       int lastChunkSize = alignUp(divUp(remCount, nvls->nHeads), 16384/sizeof(T));
@@ -820,7 +820,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
         }
       }
     } else {
-      const int bid = ncclShmem->channelId - work->channelLo;
+      const int bid = ncclShmem.channelId - work->channelLo;
       const int nChannels = work->channelHi - work->channelLo + 1;
       const ssize_t chunkSize = work->collnet.chunkCount;
       const ssize_t loopSize = nChannels * nvls->nHeads * chunkSize;
@@ -886,14 +886,14 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS_TREE, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
-    struct ncclNvls* nvls = &ncclShmem->channel.nvls;
+  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
+    struct ncclNvls* nvls = &ncclShmem.channel.nvls;
     const int treeUp = nvls->treeUp;
     const int* treeDown = nvls->treeDown;
     ssize_t gridOffset, channelCount, chunkCount;
-    ncclCollCbdPart(work, ncclShmem->channelId, NCCL_PROTO_SIMPLE, sizeof(T), (ssize_t*)nullptr, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem.channelId, NCCL_PROTO_SIMPLE, sizeof(T), (ssize_t*)nullptr, &gridOffset, &channelCount, &chunkCount);
     const ssize_t loopCount = nvls->nHeads * chunkCount;
-    const int nranks = ncclShmem->comm.nRanks;
+    const int nranks = ncclShmem.comm.nRanks;
     const bool hasUp = treeUp != -1;
     const int totalWarps = NCCL_MAX_NTHREADS/WARP_SIZE;
     const int bcastWarps = hasUp ? (work->regUsed ? ((totalWarps - 2) >> 1) - 1 : 4) : 0;
@@ -994,13 +994,13 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS_TREE, NCCL_PROTO_
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_CHAIN, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
-    const int bid = ncclShmem->channelId - work->channelLo;
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
+    const int bid = ncclShmem.channelId - work->channelLo;
     const int nChannels = work->channelHi - work->channelLo + 1;
-    ncclTree *tree = &ncclShmem->channel.collnetChain;
+    ncclTree *tree = &ncclShmem.channel.collnetChain;
     ssize_t chunkSize = work->collnet.chunkCount;
     const ssize_t loopSize = int(nChannels*chunkSize);
-    const int nranks = ncclShmem->comm.nRanks;
+    const int nranks = ncclShmem.comm.nRanks;
     const ssize_t size = work->collnet.count;
 
     int nthreadsSplit = nthreads/2;
@@ -1120,28 +1120,28 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_CHAIN, NCCL_PR
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     runRing<T, RedOp, ProtoLL, RCCL_METADATA_EMPTY>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_TREE, NCCL_PROTO_LL> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     runTreeSplit<T, RedOp, ProtoLL>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     runRing<T, RedOp, ProtoLL128, RCCL_METADATA_EMPTY>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_TREE, NCCL_PROTO_LL128> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     runTreeSplit<T, RedOp, ProtoLL128>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };

--- a/projects/rccl/src/device/alltoall_gda.h
+++ b/projects/rccl/src/device/alltoall_gda.h
@@ -1,3 +1,5 @@
+#ifndef NCCL_DEVICE_ALLTOALL_GDA_H_
+#define NCCL_DEVICE_ALLTOALL_GDA_H_
 /*************************************************************************
  * Copyright (c) 2015-2021, NVIDIA CORPORATION. All rights reserved.
  *
@@ -31,3 +33,5 @@ struct RunWorkColl<ncclFuncAllToAllGda, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIM
 };
 #endif
 
+
+#endif // NCCL_DEVICE_ALLTOALL_GDA_H_

--- a/projects/rccl/src/device/alltoall_pivot.h
+++ b/projects/rccl/src/device/alltoall_pivot.h
@@ -11,16 +11,16 @@
 namespace {
   template<typename T, typename RedOp, typename Proto>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #endif
-    const int bid = ncclShmem.channelId - work->channelLo;
-    const int nranks = ncclShmem.comm.nRanks;
+    const int bid = ncclShmem->channelId - work->channelLo;
+    const int nranks = ncclShmem->comm.nRanks;
     size_t count, partOffset, partCount, chunkCount;
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &partOffset, &partCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), &count, &partOffset, &partCount, &chunkCount);
 
-    const ncclRing *ring = &ncclShmem.channel.ring;
+    const ncclRing *ring = &ncclShmem->channel.ring;
     const int num_bi_rings = work->pivotA2ANumBiRings;
     const int num_uni_rings = num_bi_rings * 2;
     const int num_chunks = (work->channelHi - work->channelLo + 1) / 2;
@@ -34,7 +34,7 @@ namespace {
     const ssize_t prims_size = chunkCount;
 
     Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0> prims
-      (tid, nthreads, &ring->prev, &ring->next, work->sendbuff, work->recvbuff, /*redOpArg(ignored)=*/0);
+      (tid, nthreads, &ring->prev, &ring->next, work->sendbuff, work->recvbuff, /*redOpArg(ignored)=*/0, ncclShmem, ncclShmemPerWarp, 0, 0, 0, work, nullptr, 0, primsModeDefault);
 
     for (int num_hops = 0; num_hops <= nranks / 2; num_hops++) {
       const int src_rank = ring->userRanks[(nranks - num_hops) % nranks];
@@ -76,8 +76,8 @@ namespace {
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAlltoAllPivot, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nThreads, struct ncclDevWorkColl* work) {
+  __device__ __forceinline__ void run(int tid, int nThreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
     using Proto = ProtoSimple<ALLTOALL_PIVOT_CHUNKSTEPS/ALLTOALL_PIVOT_SLICESTEPS, ALLTOALL_PIVOT_SLICESTEPS>;
-    runRing<T, RedOp, Proto>(tid, nThreads, work);
+    runRing<T, RedOp, Proto>(tid, nThreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };

--- a/projects/rccl/src/device/alltoall_pivot.h
+++ b/projects/rccl/src/device/alltoall_pivot.h
@@ -12,11 +12,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
-#else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
-#endif
     const int bid = ncclShmem.channelId - work->channelLo;
     const int nranks = ncclShmem.comm.nRanks;
     size_t count, partOffset, partCount, chunkCount;

--- a/projects/rccl/src/device/alltoall_pivot.h
+++ b/projects/rccl/src/device/alltoall_pivot.h
@@ -11,16 +11,16 @@
 namespace {
   template<typename T, typename RedOp, typename Proto>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #endif
-    const int bid = ncclShmem->channelId - work->channelLo;
-    const int nranks = ncclShmem->comm.nRanks;
+    const int bid = ncclShmem.channelId - work->channelLo;
+    const int nranks = ncclShmem.comm.nRanks;
     size_t count, partOffset, partCount, chunkCount;
-    ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), &count, &partOffset, &partCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &partOffset, &partCount, &chunkCount);
 
-    const ncclRing *ring = &ncclShmem->channel.ring;
+    const ncclRing *ring = &ncclShmem.channel.ring;
     const int num_bi_rings = work->pivotA2ANumBiRings;
     const int num_uni_rings = num_bi_rings * 2;
     const int num_chunks = (work->channelHi - work->channelLo + 1) / 2;
@@ -76,7 +76,7 @@ namespace {
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAlltoAllPivot, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nThreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nThreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     using Proto = ProtoSimple<ALLTOALL_PIVOT_CHUNKSTEPS/ALLTOALL_PIVOT_SLICESTEPS, ALLTOALL_PIVOT_SLICESTEPS>;
     runRing<T, RedOp, Proto>(tid, nThreads, work, ncclShmem, ncclShmemPerWarp);
   }

--- a/projects/rccl/src/device/alltoall_pivot.h
+++ b/projects/rccl/src/device/alltoall_pivot.h
@@ -1,3 +1,5 @@
+#ifndef NCCL_DEVICE_ALLTOALL_PIVOT_H_
+#define NCCL_DEVICE_ALLTOALL_PIVOT_H_
 /*************************************************************************
  * Copyright (c) 2015-2021, NVIDIA CORPORATION. All rights reserved.
  *
@@ -81,3 +83,5 @@ struct RunWorkColl<ncclFuncAlltoAllPivot, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_S
     runRing<T, RedOp, Proto>(tid, nThreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
+
+#endif // NCCL_DEVICE_ALLTOALL_PIVOT_H_

--- a/projects/rccl/src/device/broadcast.h
+++ b/projects/rccl/src/device/broadcast.h
@@ -1,3 +1,5 @@
+#ifndef NCCL_DEVICE_BROADCAST_H_
+#define NCCL_DEVICE_BROADCAST_H_
 /*************************************************************************
  * Copyright (c) 2015-2022, NVIDIA CORPORATION. All rights reserved.
  *
@@ -136,3 +138,5 @@ struct RunWorkColl<ncclFuncBroadcast, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128
     runRing<T, RedOp, ProtoLL128>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
+
+#endif // NCCL_DEVICE_BROADCAST_H_

--- a/projects/rccl/src/device/broadcast.h
+++ b/projects/rccl/src/device/broadcast.h
@@ -12,11 +12,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
-#else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
-#endif
 #if defined(ENABLE_NPKIT)
     const int bid = ncclShmem.channelId - work->channelLo;
     int npKitCtxIdx = bid; // unused variable - compiler warning

--- a/projects/rccl/src/device/broadcast.h
+++ b/projects/rccl/src/device/broadcast.h
@@ -11,19 +11,19 @@
 namespace {
   template<typename T, typename RedOp, typename Proto>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #endif
 #if defined(ENABLE_NPKIT)
-    const int bid = ncclShmem.channelId - work->channelLo;
+    const int bid = ncclShmem->channelId - work->channelLo;
     int npKitCtxIdx = bid; // unused variable - compiler warning
 #endif
 #ifdef ENABLE_WARP_SPEED
     int warp = threadIdx.x / WARP_SIZE;
-    ncclRing *ring = &ncclShmem.warpChannel[warp].ring;
+    ncclRing *ring = &ncclShmem->warpChannel[warp].ring;
 #else
-    ncclRing *ring = &ncclShmem.channel.ring;
+    ncclRing *ring = &ncclShmem->channel.ring;
 #endif
     const int rank = ring->userRanks[0];
     const int nextRank = ring->userRanks[1];
@@ -33,9 +33,9 @@ namespace {
     ssize_t channelCount;
     ssize_t gridOffset;
 #ifdef ENABLE_WARP_SPEED
-    ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem->warpChannelId[warp], Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
 #else
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
 #endif
     size_t offset;
     int nelem;
@@ -46,21 +46,21 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, 0, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK,
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_GPU)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_BROADCAST_RING_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_BROADCAST_RING_ENTRY, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -73,7 +73,7 @@ namespace {
       // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
       // coverity[callee_ptr_arith:FALSE]
       Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0>
-        prims(tid, workNthreads, &ring->prev, &ring->next, inputBuf, outputBuf, work->redOpArg, 0, work->connIndex, work->connIndex, work);
+        prims(tid, workNthreads, &ring->prev, &ring->next, inputBuf, outputBuf, work->redOpArg, ncclShmem, ncclShmemPerWarp, 0, work->connIndex, work->connIndex, work, nullptr, 0, primsModeDefault);
 
 #if defined(ENABLE_NPKIT)
       if (tid == 0) {
@@ -106,7 +106,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_BROADCAST_RING_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_BROADCAST_RING_EXIT, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
@@ -117,22 +117,22 @@ namespace {
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncBroadcast, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
     using Proto = ProtoSimple<BROADCAST_CHUNKSTEPS/BROADCAST_SLICESTEPS, BROADCAST_SLICESTEPS>;
-    runRing<T, RedOp, Proto>(tid, nthreads, work);
+    runRing<T, RedOp, Proto>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncBroadcast, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    runRing<T, RedOp, ProtoLL>(tid, nthreads, work);
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    runRing<T, RedOp, ProtoLL>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncBroadcast, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    runRing<T, RedOp, ProtoLL128>(tid, nthreads, work);
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    runRing<T, RedOp, ProtoLL128>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };

--- a/projects/rccl/src/device/broadcast.h
+++ b/projects/rccl/src/device/broadcast.h
@@ -11,19 +11,19 @@
 namespace {
   template<typename T, typename RedOp, typename Proto>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #endif
 #if defined(ENABLE_NPKIT)
-    const int bid = ncclShmem->channelId - work->channelLo;
+    const int bid = ncclShmem.channelId - work->channelLo;
     int npKitCtxIdx = bid; // unused variable - compiler warning
 #endif
 #ifdef ENABLE_WARP_SPEED
     int warp = threadIdx.x / WARP_SIZE;
-    ncclRing *ring = &ncclShmem->warpChannel[warp].ring;
+    ncclRing *ring = &ncclShmem.warpChannel[warp].ring;
 #else
-    ncclRing *ring = &ncclShmem->channel.ring;
+    ncclRing *ring = &ncclShmem.channel.ring;
 #endif
     const int rank = ring->userRanks[0];
     const int nextRank = ring->userRanks[1];
@@ -33,9 +33,9 @@ namespace {
     ssize_t channelCount;
     ssize_t gridOffset;
 #ifdef ENABLE_WARP_SPEED
-    ncclCollCbdPart(work, ncclShmem->warpChannelId[warp], Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
 #else
-    ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
 #endif
     size_t offset;
     int nelem;
@@ -46,21 +46,21 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, 0, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK,
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_GPU)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_BROADCAST_RING_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_BROADCAST_RING_ENTRY, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -106,7 +106,7 @@ namespace {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_BROADCAST_RING_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_BROADCAST_RING_EXIT, size*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
@@ -117,7 +117,7 @@ namespace {
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncBroadcast, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     using Proto = ProtoSimple<BROADCAST_CHUNKSTEPS/BROADCAST_SLICESTEPS, BROADCAST_SLICESTEPS>;
     runRing<T, RedOp, Proto>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
@@ -125,14 +125,14 @@ struct RunWorkColl<ncclFuncBroadcast, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncBroadcast, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     runRing<T, RedOp, ProtoLL>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncBroadcast, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     runRing<T, RedOp, ProtoLL128>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };

--- a/projects/rccl/src/device/common.cu
+++ b/projects/rccl/src/device/common.cu
@@ -14,7 +14,7 @@
 // #endif
 
 struct RunWorkNop {
-  __device__ void run(struct ncclShmemData* /*ncclShmem*/, void* /*ncclShmemPerWarp*/) {}
+  __device__ void run(struct ncclShmemData& /*ncclShmem*/, void* /*ncclShmemPerWarp*/) {}
 };
 
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic_1(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
@@ -24,7 +24,7 @@ __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic_1(
 #else
   __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
 #endif
-  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/false, /*Unroll*/1>(&argsStorage.args, &ncclShmem, ncclShmemPerWarp);
+  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/false, /*Unroll*/1>(&argsStorage.args, ncclShmem, ncclShmemPerWarp);
 }
 
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic_2(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
@@ -34,7 +34,7 @@ __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic_2(
 #else
   __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
 #endif
-  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/false, /*Unroll*/2>(&argsStorage.args, &ncclShmem, ncclShmemPerWarp);
+  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/false, /*Unroll*/2>(&argsStorage.args, ncclShmem, ncclShmemPerWarp);
 }
 
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic_4(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
@@ -44,7 +44,7 @@ __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic_4(
 #else
   __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
 #endif
-  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/false, /*Unroll*/4>(&argsStorage.args, &ncclShmem, ncclShmemPerWarp);
+  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/false, /*Unroll*/4>(&argsStorage.args, ncclShmem, ncclShmemPerWarp);
 }
 #ifdef ENABLE_COLLTRACE
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernelDebug_Generic_1(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
@@ -54,7 +54,7 @@ __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernelDebug_Gener
 #else
   __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
 #endif
-  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/true, /*Unroll*/1>(&argsStorage.args, &ncclShmem, ncclShmemPerWarp);
+  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/true, /*Unroll*/1>(&argsStorage.args, ncclShmem, ncclShmemPerWarp);
 }
 
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernelDebug_Generic_2(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
@@ -64,7 +64,7 @@ __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernelDebug_Gener
 #else
   __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
 #endif
-  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/true, /*Unroll*/2>(&argsStorage.args, &ncclShmem, ncclShmemPerWarp);
+  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/true, /*Unroll*/2>(&argsStorage.args, ncclShmem, ncclShmemPerWarp);
 }
 
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernelDebug_Generic_4(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
@@ -74,12 +74,12 @@ __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernelDebug_Gener
 #else
   __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
 #endif
-  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/true, /*Unroll*/4>(&argsStorage.args, &ncclShmem, ncclShmemPerWarp);
+  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/true, /*Unroll*/4>(&argsStorage.args, ncclShmem, ncclShmemPerWarp);
 }
 #endif
 
 #ifdef USE_INDIRECT_FUNCTION_CALL
-__device__ void ncclDevFunc_Nop(struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp);
+__device__ void ncclDevFunc_Nop(struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp);
 #else
-__device__ __attribute__((noinline)) void ncclDevFunc_Nop(struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp);
+__device__ __attribute__((noinline)) void ncclDevFunc_Nop(struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp);
 #endif

--- a/projects/rccl/src/device/common.cu
+++ b/projects/rccl/src/device/common.cu
@@ -8,38 +8,78 @@
 #include "collectives.h"
 #include "common.h"
 
-__shared__ ncclShmemData ncclShmem;
-#if __CUDA_ARCH__ < 700
-  __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
-#endif
+// __shared__ ncclShmemData ncclShmem;
+// #if __CUDA_ARCH__ < 700
+//   __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
+// #endif
 
 struct RunWorkNop {
-  __device__ void run() {}
+  __device__ void run(struct ncclShmemData* /*ncclShmem*/, void* /*ncclShmemPerWarp*/) {}
 };
 
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic_1(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
-  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/false, /*Unroll*/1>(&argsStorage.args);
+  __shared__ ncclShmemData ncclShmem;
+#if __CUDA_ARCH__ >= 700
+  __shared__ ulong2 ncclShmemPerWarp[/*ncclShmemDynamicSize()/sizeof(ulong2)*/];
+#else
+  __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
+#endif
+  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/false, /*Unroll*/1>(&argsStorage.args, &ncclShmem, ncclShmemPerWarp);
 }
+
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic_2(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
-  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/false, /*Unroll*/2>(&argsStorage.args);
+  __shared__ ncclShmemData ncclShmem;
+#if __CUDA_ARCH__ >= 700
+  __shared__ ulong2 ncclShmemPerWarp[/*ncclShmemDynamicSize()/sizeof(ulong2)*/];
+#else
+  __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
+#endif
+  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/false, /*Unroll*/2>(&argsStorage.args, &ncclShmem, ncclShmemPerWarp);
 }
+
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic_4(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
-  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/false, /*Unroll*/4>(&argsStorage.args);
+  __shared__ ncclShmemData ncclShmem;
+#if __CUDA_ARCH__ >= 700
+  __shared__ ulong2 ncclShmemPerWarp[/*ncclShmemDynamicSize()/sizeof(ulong2)*/];
+#else
+  __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
+#endif
+  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/false, /*Unroll*/4>(&argsStorage.args, &ncclShmem, ncclShmemPerWarp);
 }
 #ifdef ENABLE_COLLTRACE
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernelDebug_Generic_1(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
-  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/true, /*Unroll*/1>(&argsStorage.args);
+  __shared__ ncclShmemData ncclShmem;
+#if __CUDA_ARCH__ >= 700
+  __shared__ ulong2 ncclShmemPerWarp[/*ncclShmemDynamicSize()/sizeof(ulong2)*/];
+#else
+  __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
+#endif
+  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/true, /*Unroll*/1>(&argsStorage.args, &ncclShmem, ncclShmemPerWarp);
 }
+
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernelDebug_Generic_2(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
-  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/true, /*Unroll*/2>(&argsStorage.args);
+  __shared__ ncclShmemData ncclShmem;
+#if __CUDA_ARCH__ >= 700
+  __shared__ ulong2 ncclShmemPerWarp[/*ncclShmemDynamicSize()/sizeof(ulong2)*/];
+#else
+  __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
+#endif
+  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/true, /*Unroll*/2>(&argsStorage.args, &ncclShmem, ncclShmemPerWarp);
 }
+
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernelDebug_Generic_4(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
-  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/true, /*Unroll*/4>(&argsStorage.args);
+  __shared__ ncclShmemData ncclShmem;
+#if __CUDA_ARCH__ >= 700
+  __shared__ ulong2 ncclShmemPerWarp[/*ncclShmemDynamicSize()/sizeof(ulong2)*/];
+#else
+  __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
+#endif
+  ncclKernelMain<-1, RunWorkNop, /*COLLTRACE*/true, /*Unroll*/4>(&argsStorage.args, &ncclShmem, ncclShmemPerWarp);
 }
 #endif
 
 #ifdef USE_INDIRECT_FUNCTION_CALL
-__device__ void ncclDevFunc_Nop();
+__device__ void ncclDevFunc_Nop(struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp);
 #else
-__device__ __attribute__((noinline)) void ncclDevFunc_Nop();
+__device__ __attribute__((noinline)) void ncclDevFunc_Nop(struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp);
 #endif

--- a/projects/rccl/src/device/common.h
+++ b/projects/rccl/src/device/common.h
@@ -744,7 +744,7 @@ __global__ void ncclDevKernelDebug_Generic_4(ncclDevKernelArgsDefaultStorage NCC
 // __attribute__((used)) prevents the linker/compiler from dead-code-eliminating
 // the device functions. These will be merged with the kernel TU at the assembly level.
 #define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll) \
-  __attribute__((used)) __device__ void ncclDevFunc_##suffix(struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) { \
+  __attribute__((used)) __device__ void ncclDevFunc_##suffix(struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) { \
     RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(ncclShmem, ncclShmemPerWarp); \
   }
 #elif defined(USE_INDIRECT_FUNCTION_CALL)

--- a/projects/rccl/src/device/common.h
+++ b/projects/rccl/src/device/common.h
@@ -12,7 +12,9 @@
 #include "device.h"
 #include "op128.h"
 #include "reduce_kernel.h"
+#ifndef NCCL_FUNC_ONLY
 #include "device_table.h"
+#endif
 #include "network/unpack/unpack_defs.h"
 #define NCCL_MAX_DEV_ARITY (NCCL_MAX_TREE_ARITY-1)  // Using balanced tree instead of split tree
 
@@ -504,6 +506,11 @@ __device__ __forceinline__ void profiler(struct ncclShmemData& ncclShmem, int ac
   }
 }
 
+// ncclKernelMain and kernel declarations are only needed by common.cu (the dispatch TU).
+// When NCCL_FUNC_ONLY is defined, generated TUs skip this to avoid pulling in the
+// device function table and cross-TU symbol references.
+#ifndef NCCL_FUNC_ONLY
+
 template<int SpecializedFnId, typename SpecializedRunWorkBatch, bool COLLTRACE, int COLL_UNROLL>
 __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* args, ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
   const int tid = threadIdx.x;
@@ -730,7 +737,17 @@ __global__ void ncclDevKernelDebug_Generic_4(ncclDevKernelArgsDefaultStorage NCC
 #define DEFINE_ncclDevKernel_nop(suffix, coll, redop, ty, algo, proto, specializedFnId) \
   __global__ void ncclDevKernel_##suffix(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {}
 
-#ifdef USE_INDIRECT_FUNCTION_CALL
+#endif // !NCCL_FUNC_ONLY
+
+#ifdef NCCL_FUNC_ONLY
+// When compiling individual TUs to assembly without a kernel in the same TU,
+// __attribute__((used)) prevents the linker/compiler from dead-code-eliminating
+// the device functions. These will be merged with the kernel TU at the assembly level.
+#define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll) \
+  __attribute__((used)) __device__ void ncclDevFunc_##suffix(struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) { \
+    RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(ncclShmem, ncclShmemPerWarp); \
+  }
+#elif defined(USE_INDIRECT_FUNCTION_CALL)
 #define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll) \
   __device__ void ncclDevFunc_##suffix(struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) { \
     RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(ncclShmem, ncclShmemPerWarp); \

--- a/projects/rccl/src/device/common.h
+++ b/projects/rccl/src/device/common.h
@@ -47,23 +47,23 @@
 #endif
 
 #ifdef ENABLE_COLLTRACE
-  #define INC_COLL_TRACE \
-    uint32_t pos = __hip_atomic_fetch_add(&ncclShmem.collTraceTail->tail, 1, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_WORKGROUP)%COLLTRACE_NUM_ITEMS; \
-    struct ncclCollTrace* collTrace = ncclShmem.collTrace+pos; \
+  #define INC_COLL_TRACE(ncclShmem) \
+    uint32_t pos = __hip_atomic_fetch_add(&(ncclShmem)->collTraceTail->tail, 1, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_WORKGROUP)%COLLTRACE_NUM_ITEMS; \
+    struct ncclCollTrace* collTrace = (ncclShmem)->collTrace+pos; \
     collTrace->timeStamp = wall_clock64(); \
     collTrace->tid = threadIdx.x; \
-    collTrace->channelId = ncclShmem.channelId;
+    collTrace->channelId = (ncclShmem)->channelId;
     // TODO: switch to atomicInc after llvm crash is fixed
-    // uint32_t pos = atomicInc(&ncclShmem.collTraceTail->tail, COLLTRACE_NUM_ITEMS)
+    // uint32_t pos = atomicInc(&(shmem).collTraceTail->tail, COLLTRACE_NUM_ITEMS)
 
-  #define traceKernelLaunch(launch_type, ix) { \
-    INC_COLL_TRACE \
-    collTrace->funcIndex = ncclShmem.funcId; \
+  #define traceKernelLaunch(ncclShmem, launch_type, ix) { \
+    INC_COLL_TRACE(ncclShmem) \
+    collTrace->funcIndex = (ncclShmem)->funcId; \
     __trace_hwreg() \
     __trace_xccid() \
     collTrace->batchIx = ix; \
-    if (ncclShmem.workType == ncclDevWorkTypeP2p) { \
-      struct ncclDevWorkP2p *p2pWork = (struct ncclDevWorkP2p*)ncclShmem.workStorage; \
+    if ((ncclShmem)->workType == ncclDevWorkTypeP2p) { \
+      struct ncclDevWorkP2p *p2pWork = (struct ncclDevWorkP2p*)(ncclShmem)->workStorage; \
       collTrace->p2p.sendRank = p2pWork->sendRank; \
       collTrace->p2p.recvRank = p2pWork->recvRank; \
       collTrace->p2p.nSendChannels = p2pWork->nSendChannels; \
@@ -78,48 +78,48 @@
       collTrace->p2pOpCount[0] = p2pWork->sendOpCount; \
       collTrace->p2pOpCount[1] = p2pWork->recvOpCount; \
       __hip_atomic_store(&collTrace->type, (launch_type) | ncclCollTraceP2pElemType, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP); \
-    } else if (ncclShmem.workType == ncclDevWorkTypeColl) { \
-      struct ncclDevWorkColl *collWork = (struct ncclDevWorkColl*)ncclShmem.workStorage; \
+    } else if ((ncclShmem)->workType == ncclDevWorkTypeColl) { \
+      struct ncclDevWorkColl *collWork = (struct ncclDevWorkColl*)(ncclShmem)->workStorage; \
       collTrace->coll.nWarps = collWork->nWarps; \
       collTrace->coll.nChannels = collWork->channelHi-collWork->channelLo+1; \
-      collTrace->coll.bid = ncclShmem.channelId - collWork->channelLo; \
+      collTrace->coll.bid = (ncclShmem)->channelId - collWork->channelLo; \
       collTrace->coll.root = collWork->root; \
       collTrace->opCount = collWork->opCount; \
       __hip_atomic_store(&collTrace->type, (launch_type) | ncclCollTraceCollElemType, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP); \
     } \
   }
-  #define traceKernelEnd(end_type)  { \
-    INC_COLL_TRACE \
-    collTrace->funcIndex = ncclShmem.funcId;\
-    if (ncclShmem.workType == ncclDevWorkTypeP2p) { \
-      struct ncclDevWorkP2p *p2pWork = (struct ncclDevWorkP2p*)ncclShmem.workStorage; \
+  #define traceKernelEnd(ncclShmem, end_type)  { \
+    INC_COLL_TRACE(ncclShmem) \
+    collTrace->funcIndex = (ncclShmem)->funcId;\
+    if ((ncclShmem)->workType == ncclDevWorkTypeP2p) { \
+      struct ncclDevWorkP2p *p2pWork = (struct ncclDevWorkP2p*)(ncclShmem)->workStorage; \
       collTrace->p2pOpCount[0] = p2pWork->sendOpCount; \
       collTrace->p2pOpCount[1] = p2pWork->recvOpCount; \
       __hip_atomic_store(&collTrace->type, (end_type) | ncclCollTraceP2pElemType, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP); \
-    } else if (ncclShmem.workType == ncclDevWorkTypeColl) { \
-      struct ncclDevWorkColl *collWork = (struct ncclDevWorkColl*)ncclShmem.workStorage; \
+    } else if ((ncclShmem)->workType == ncclDevWorkTypeColl) { \
+      struct ncclDevWorkColl *collWork = (struct ncclDevWorkColl*)(ncclShmem)->workStorage; \
       collTrace->opCount = collWork->opCount; \
       __hip_atomic_store(&collTrace->type, (end_type) | ncclCollTraceCollElemType, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP); \
     } \
   }
-  #define traceData(data2, data4, data8_0, data8_1) { \
-    INC_COLL_TRACE \
+  #define traceData(ncclShmem, data2, data4, data8_0, data8_1) { \
+    INC_COLL_TRACE(ncclShmem) \
     collTrace->funcIndex = data2; \
     collTrace->data_0 = data4; \
     collTrace->opCount = data8_0; \
     collTrace->data_1 = data8_1; \
     __hip_atomic_store(&collTrace->type, ncclCollTraceDataType, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP); \
   }
-  #define traceAbort(){\
-    INC_COLL_TRACE\
-    collTrace->funcIndex = ncclShmem.funcId;\
+  #define traceAbort(ncclShmem) {\
+    INC_COLL_TRACE(ncclShmem)\
+    collTrace->funcIndex = (ncclShmem)->funcId;\
     __hip_atomic_store(&collTrace->type, ncclCollTraceAbortType, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP); \
   }
 #else
-#define traceKernelLaunch(launch_type, batchIx)
-#define traceKernelEnd(end_type)
-#define traceData(data2, data4, data8_0, data8_1)
-#define traceAbort()
+#define traceKernelLaunch(ncclShmem, launch_type, batchIx)
+#define traceKernelEnd(ncclShmem, end_type)
+#define traceData(ncclShmem, data2, data4, data8_0, data8_1)
+#define traceAbort(ncclShmem)
 #endif
 
 #if __CUDA_ARCH__ >= 700
@@ -186,16 +186,16 @@ struct ncclShmemData {
   uint64_t barrier_pat;
 };
 
-extern __shared__ ncclShmemData ncclShmem;
-#if __CUDA_ARCH__ >= 700
-  extern __shared__ ulong2 ncclShmemPerWarp[/*ncclShmemDynamicSize()/sizeof(ulong2)*/];
-#else
-  extern __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
-#endif
+// extern __shared__ ncclShmemData ncclShmem;
+// #if __CUDA_ARCH__ >= 700
+//   extern __shared__ ulong2 ncclShmemPerWarp[/*ncclShmemDynamicSize()/sizeof(ulong2)*/];
+// #else
+//   extern __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
+// #endif
 
 #ifdef ENABLE_FAULT_INJECTION
-__device__ inline void insert_random_delay_per_warp() {
-  if ((ncclShmem.faults & RANDOM_DELAY_ON_WARP_START) && (threadIdx.x%WARP_SIZE == 0)) {
+__device__ inline void insert_random_delay_per_warp(ncclShmemData* ncclShmem) {
+  if ((ncclShmem->faults & RANDOM_DELAY_ON_WARP_START) && (threadIdx.x%WARP_SIZE == 0)) {
     switch ((wall_clock64()>>(threadIdx.x/WARP_SIZE*2))&0x3) {
       case 0:
         __builtin_amdgcn_s_sleep(0);
@@ -215,7 +215,7 @@ __device__ inline void insert_random_delay_per_warp() {
 }
 #endif
 
-__device__ inline void* ncclScratchForWarp(int warp) {
+__device__ inline void* ncclScratchForWarp(void* ncclShmemPerWarp, int warp) {
   return (char*)ncclShmemPerWarp + warp*ncclShmemScratchWarpSize();
 }
 
@@ -260,15 +260,15 @@ __device__ inline bool barrier_red_or(bool vote, int name, int nThreads) {
 }
 
 #ifdef ENABLE_PROFILING
-#define __insert_timestamp(line_num) do { \
-      if (ncclShmem.prof.count < PROFILE_NUM_ITEMS) { \
-        ncclShmem.prof.elem[ncclShmem.prof.count].line = line_num; \
-        ncclShmem.prof.elem[ncclShmem.prof.count].timeStamp = wall_clock64(); \
-        ncclShmem.prof.count++; \
+#define __insert_timestamp(ncclShmem, line_num) do { \
+      if ((ncclShmem)->prof.count < PROFILE_NUM_ITEMS) { \
+        (ncclShmem)->prof.elem[(ncclShmem)->prof.count].line = line_num; \
+        (ncclShmem)->prof.elem[(ncclShmem)->prof.count].timeStamp = wall_clock64(); \
+        (ncclShmem)->prof.count++; \
       } \
     } while(0);
 #else
-#define __insert_timestamp(line_num)
+#define __insert_timestamp(ncclShmem, line_num)
 #endif
 
 // Copy 16-byte aligned data. You must call with at least `(bytes+15)/16` threads.
@@ -285,7 +285,7 @@ inline __device__ void copyToShmem16(int tid, void* dst, void const* src, int by
 
 // Must run with at least 64 threads
 __device__ __forceinline__ void loadWorkBatchToShmem(
-    int tid, int tn, struct ncclDevKernelArgs const* args, int batchIx
+    struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp, int tid, int tn, struct ncclDevKernelArgs const* args, int batchIx
   ) {
   int lane = tid%WARP_SIZE;
   int workCursor = 0; // num works written in previous loop iterations.
@@ -296,7 +296,7 @@ __device__ __forceinline__ void loadWorkBatchToShmem(
     // PTX has instruction "fns" (find n-th set) but it expands to a lot of SASS,
     // since we know all lanes will be querying the same bitmask we can compute
     // much faster using shared memory.
-    uint8_t* fnsOfBitset = (uint8_t*)ncclScratchForWarp(threadIdx.x/WARP_SIZE);
+    uint8_t* fnsOfBitset = (uint8_t*)ncclScratchForWarp(ncclShmemPerWarp, threadIdx.x/WARP_SIZE);
     int nWorks = 0;
     __syncwarp();
 
@@ -347,7 +347,7 @@ __device__ __forceinline__ void loadWorkBatchToShmem(
       break;
     }
     if (tid == 0) {
-      ncclShmem.workSize = workSize;
+      ncclShmem->workSize = workSize;
     }
     // We deliberately replicate these div and mod calculations into the case
     // blocks above so that they get constant divisor optimizations by the compiler.
@@ -377,15 +377,15 @@ __device__ __forceinline__ void loadWorkBatchToShmem(
       //   src = &global_variable;
       // }
       // memcpy(dst, src, n);
-      if (ncclShmem.args.workStorageType == ncclDevWorkStorageTypeArgs) {
+      if (ncclShmem->args.workStorageType == ncclDevWorkStorageTypeArgs) {
         char* src = (char*)args + (batch.offsetBase + srcWork*workSize + packInWork*16);
         tmp = *(ulong2*)src; // becomes ld.param.v2.u64
       }
-      if (ncclShmem.args.workStorageType != ncclDevWorkStorageTypeArgs) {
-        char* src = (char*)ncclShmem.args.workBuf + ((batch.offsetBase + srcWork*workSize + packInWork*16) & ncclShmem.args.workMask);
+      if (ncclShmem->args.workStorageType != ncclDevWorkStorageTypeArgs) {
+        char* src = (char*)ncclShmem->args.workBuf + ((batch.offsetBase + srcWork*workSize + packInWork*16) & ncclShmem->args.workMask);
         tmp = *(ulong2*)src; // becomes ld.v2.u64
       }
-      char* dst = ncclShmem.workStorage;
+      char* dst = ncclShmem->workStorage;
       dst += (workCursor + dstWork)*workSize + packInWork*16;
       *(ulong2*)dst = tmp;
     }
@@ -397,11 +397,11 @@ __device__ __forceinline__ void loadWorkBatchToShmem(
       if (tid < 0) tid += tn;
     } else {
       if (tid == 0) {
-        ncclShmem.batchIx = batchIx;
-        ncclShmem.nextBatchIx = (batch.nextJump == 0) ? -1 : batchIx + batch.nextJump;
-        ncclShmem.workType = (enum ncclDevWorkType)batch.workType;
-        ncclShmem.nWorks = workCursor;
-        ncclShmem.funcId = batch.funcId;
+        ncclShmem->batchIx = batchIx;
+        ncclShmem->nextBatchIx = (batch.nextJump == 0) ? -1 : batchIx + batch.nextJump;
+        ncclShmem->workType = (enum ncclDevWorkType)batch.workType;
+        ncclShmem->nWorks = workCursor;
+        ncclShmem->funcId = batch.funcId;
       }
       break;
     }
@@ -420,7 +420,7 @@ __device__ __forceinline__ unsigned long long int globaltimer() {
 
 template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto, int USE_ACC, int COLL_UNROLL, int Pipeline>
 struct RunWorkColl {
-  __device__ void run(int tid, int tn, struct ncclDevWorkColl* work) {
+  __device__ void run(int tid, int tn, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
     // Put NOT IMPLEMENTED behavior here.
   }
 };
@@ -437,14 +437,14 @@ template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto,  int US
 struct RunWorkBatch {
   // This __forceinline__ is necessary. The compiler was inserting a function call
   // here from the LL ncclKernel.
-  __device__ __forceinline__ void run() {
+  __device__ __forceinline__ void run(struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
     int tid = threadIdx.x;
     int tn = blockDim.x;
 
     if (RedOpArg<RedOp>::ArgUsed) {
-      int nWorks = ncclShmem.nWorks;
+      int nWorks = ncclShmem->nWorks;
       for (int w=tid; w < nWorks; w += tn) {
-        struct ncclDevWorkColl* work = (ncclDevWorkColl*)(ncclShmem.workStorage + w*ncclShmem.workSize);
+        struct ncclDevWorkColl* work = (ncclDevWorkColl*)(ncclShmem->workStorage + w*ncclShmem->workSize);
         if (work->redOpArgIsPtr) {
           work->redOpArg = RedOpArg<RedOp>::loadArg(reinterpret_cast<void*>(work->redOpArg));
         }
@@ -453,23 +453,20 @@ struct RunWorkBatch {
     }
 
     #pragma unroll 1
-    for (int w=0; w < ncclShmem.nWorks; w++) {
-      struct ncclDevWorkColl* work = (struct ncclDevWorkColl*)(ncclShmem.workStorage + w*ncclShmem.workSize);
+    for (int w=0; w < ncclShmem->nWorks; w++) {
+      struct ncclDevWorkColl* work = (struct ncclDevWorkColl*)(ncclShmem->workStorage + w*ncclShmem->workSize);
       if (w != 0) {
-        struct ncclDevWorkColl* workPrev = (struct ncclDevWorkColl*)(ncclShmem.workStorage + (w-1)*ncclShmem.workSize);
+        struct ncclDevWorkColl* workPrev = (struct ncclDevWorkColl*)(ncclShmem->workStorage + (w-1)*ncclShmem->workSize);
         if (work->nWarps != workPrev->nWarps) __syncthreads();
       }
       int subtn = work->nWarps*WARP_SIZE;
 #ifdef ENABLE_WARP_SPEED
       if (tid < subtn) {
-        if(ncclShmem.warpComm == 0 || Algo != NCCL_ALGO_RING) RunWorkColl<Fn, T, RedOp, Algo, Proto>().run(tid, subtn, work);
-        else if (ncclShmem.warpChannelId[tid / WARP_SIZE] >= 0) RunWorkColl<Fn, T, RedOp, Algo, Proto>().run(tid % WARP_SIZE, WARP_SIZE, work);
+        if(ncclShmem->warpComm == 0 || Algo != NCCL_ALGO_RING) RunWorkColl<Fn, T, RedOp, Algo, Proto>().run(tid, subtn, work, ncclShmem, ncclShmemPerWarp);
+        else if (ncclShmem->warpChannelId[tid / WARP_SIZE] >= 0) RunWorkColl<Fn, T, RedOp, Algo, Proto>().run(tid % WARP_SIZE, WARP_SIZE, work, ncclShmem, ncclShmemPerWarp);
       }
 #else
-      // Coverity reports a possible thread divergence due to not all threads participating in the collective.
-      // However, the code ensures that the participation is on a per-warp basis.
-      // coverity[device_thread_diverged:FALSE]
-      if (tid < subtn) RunWorkColl<Fn, T, RedOp, Algo, Proto>().run(tid, subtn, work);
+      if (tid < subtn) RunWorkColl<Fn, T, RedOp, Algo, Proto>().run(tid, subtn, work, ncclShmem, ncclShmemPerWarp);
 #endif
     }
   }
@@ -479,36 +476,36 @@ struct RunWorkBatch {
 #define STOP  1
 #define FINI  2
 
-__device__ __forceinline__ bool profilerEnabled(int workItemIdx) {
-  return (ncclShmem.workType == ncclDevWorkTypeP2p) ?
-    ((struct ncclDevWorkP2p*)ncclShmem.workStorage)[workItemIdx].profilerEnabled :
-    ((struct ncclDevWorkColl*)ncclShmem.workStorage)[workItemIdx].profilerEnabled;
+__device__ __forceinline__ bool profilerEnabled(struct ncclShmemData* ncclShmem, int workItemIdx) {
+  return (ncclShmem->workType == ncclDevWorkTypeP2p) ?
+    ((struct ncclDevWorkP2p*)ncclShmem->workStorage)[workItemIdx].profilerEnabled :
+    ((struct ncclDevWorkColl*)ncclShmem->workStorage)[workItemIdx].profilerEnabled;
 }
 
-__device__ __forceinline__ void profiler(int action) {
+__device__ __forceinline__ void profiler(struct ncclShmemData* ncclShmem, int action) {
   if (threadIdx.x == 0) {
     int idx = 0;
-    uint64_t wc = ncclShmem.channel.workCounter + 1;
+    uint64_t wc = ncclShmem->channel.workCounter + 1;
     if (action == START) {
-      for (; wc <= ncclShmem.channel.workCounter + ncclShmem.nWorks; wc++) {
-        if (!profilerEnabled(idx++)) continue;
-        ncclShmem.comm.workStarted[ncclShmem.channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp = globaltimer();
-        ncclShmem.comm.workStarted[ncclShmem.channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].counter = wc;
+      for (; wc <= ncclShmem->channel.workCounter + ncclShmem->nWorks; wc++) {
+        if (!profilerEnabled(ncclShmem, idx++)) continue;
+        ncclShmem->comm.workStarted[ncclShmem->channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp = globaltimer();
+        ncclShmem->comm.workStarted[ncclShmem->channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].counter = wc;
       }
     } else {
-      for (; wc <= ncclShmem.channel.workCounter + ncclShmem.nWorks; wc++) {
-        if (!profilerEnabled(idx++)) continue;
-        ncclShmem.comm.workCompleted[ncclShmem.channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp = globaltimer();
-        ncclShmem.comm.workCompleted[ncclShmem.channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].counter = wc;
+      for (; wc <= ncclShmem->channel.workCounter + ncclShmem->nWorks; wc++) {
+        if (!profilerEnabled(ncclShmem, idx++)) continue;
+        ncclShmem->comm.workCompleted[ncclShmem->channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp = globaltimer();
+        ncclShmem->comm.workCompleted[ncclShmem->channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].counter = wc;
       }
-      ncclShmem.channel.workCounter += ncclShmem.nWorks;
-      if (action == FINI) ((ncclKernelCommAndChannels*)ncclShmem.args.comm)->channels[ncclShmem.channelId].workCounter = ncclShmem.channel.workCounter;
+      ncclShmem->channel.workCounter += ncclShmem->nWorks;
+      if (action == FINI) ((ncclKernelCommAndChannels*)ncclShmem->args.comm)->channels[ncclShmem->channelId].workCounter = ncclShmem->channel.workCounter;
     }
   }
 }
 
 template<int SpecializedFnId, typename SpecializedRunWorkBatch, bool COLLTRACE, int COLL_UNROLL>
-__device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* args) {
+__device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* args, ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
   const int tid = threadIdx.x;
   int tn = blockDim.x;
   int x = tid;
@@ -523,7 +520,7 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
   // Copy kernel args to shmem and then only read those. Otherwise the compiler
   // will end up putting the args into thread local stack which is very wasteful.
   if (tid < sizeof(ncclDevKernelArgs)/sizeof(uint32_t)) {
-    ((uint32_t*)&ncclShmem.args)[tid] = ((uint32_t*)args)[tid];
+    ((uint32_t*)&ncclShmem->args)[tid] = ((uint32_t*)args)[tid];
   }
 
   // To map blockId to channelId, we need the n'th set bit of channelMask which
@@ -532,13 +529,13 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
   // do better when we know all threads are querying the same bitmask.
   switch (tid/WARP_SIZE) {
   case 0:
-  //ncclShmem.channelId = blockIdx.x;
+  //ncclShmem->channelId = blockIdx.x;
     for (int i = 0; i < num; i++) {
       if (args->channelMask.masks[i] & (1ull<<x)) {
         y = __popcll(args->channelMask.masks[i] & ((1ull<<x)-1));
         y = total + y;
         if (blockIdx.x == y) {
-          ncclShmem.channelId = x + total;
+          ncclShmem->channelId = x + total;
           break;
         }
       }
@@ -548,7 +545,7 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
           y = __popcll(args->channelMask.masks[i] & ((1ull<<x)-1));
           y = y + total;
           if (blockIdx.x == y) {
-            ncclShmem.channelId = x + total;
+            ncclShmem->channelId = x + total;
             break;
           }
         }
@@ -558,43 +555,43 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
     break;
   case 1:
     if (tid < WARP_SIZE + NCCL_MAX_GROUPS) {
-      if (tid == WARP_SIZE) ncclShmem.barrier_pat = 0;
-      ncclShmem.groups[tid-WARP_SIZE].barrier = 0;
+      if (tid == WARP_SIZE) ncclShmem->barrier_pat = 0;
+      ncclShmem->groups[tid-WARP_SIZE].barrier = 0;
     }
     break;
   case 2:
 #ifdef ENABLE_FAULT_INJECTION
     /* load faults injection before first sync threads */
-    if (tid == 2*WARP_SIZE) ncclShmem.faults = args->comm->faults;
+    if (tid == 2*WARP_SIZE) ncclShmem->faults = args->comm->faults;
 #endif
     break;
   case 3:
     /* set abort flag to 0 */
-    if (tid == 3*WARP_SIZE) ncclShmem.aborted = 0;
+    if (tid == 3*WARP_SIZE) ncclShmem->aborted = 0;
     break;
   default:
     break;
   }
-  __syncthreads(); // publish ncclShmem.{args, channelId}
+  __syncthreads(); // publish ncclShmem->{args, channelId}
   /* set abort flag to 0 */
   if (tid == 0) {
-    ncclShmem.aborted = 0;
-    ncclShmem.channel.workCounter = ((ncclKernelCommAndChannels*)ncclShmem.args.comm)->channels[ncclShmem.channelId].workCounter;
+    ncclShmem->aborted = 0;
+    ncclShmem->channel.workCounter = ((ncclKernelCommAndChannels*)ncclShmem->args.comm)->channels[ncclShmem->channelId].workCounter;
   }
 
   // Use first 2 warps to load comm and channel, and remaining load work batch.
   switch (tid/WARP_SIZE) {
   case 0:
-    { void* dst = &ncclShmem.comm;
-      void* src = ncclShmem.args.comm;
+    { void* dst = &ncclShmem->comm;
+      void* src = ncclShmem->args.comm;
       int bytes = sizeof(ncclKernelComm);
       static_assert(sizeof(ncclKernelComm) <= 16*WARP_SIZE, "ncclKernelComm cannot be loaded by a single warp in one insn.");
       copyToShmem16(tid, dst, src, bytes);
     } break;
   case 1:
     { // Get address of channel without incurring indirect load from ncclKernelComm::channels
-      void* dst = &ncclShmem.channel;
-      void* src = &((ncclKernelCommAndChannels*)ncclShmem.args.comm)->channels[ncclShmem.channelId];
+      void* dst = &ncclShmem->channel;
+      void* src = &((ncclKernelCommAndChannels*)ncclShmem->args.comm)->channels[ncclShmem->channelId];
       int bytes = sizeof(ncclDevChannel);
       static_assert(sizeof(ncclDevChannel) <= 16*WARP_SIZE, "ncclDevChannel cannot be loaded by a single warp in one insn.");
       copyToShmem16(tid-WARP_SIZE, dst, src, bytes);
@@ -605,18 +602,18 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
       // Coverity reports a possible thread divergence due to not all threads participating in the collective.
       // However, the code ensures that the participation is on a per-warp basis.
       // coverity[device_thread_diverged:FALSE]
-      loadWorkBatchToShmem(subtid, subtn, args, /*batchIx=*/blockIdx.x);
+      loadWorkBatchToShmem(ncclShmem, ncclShmemPerWarp, subtid, subtn, args, /*batchIx=*/blockIdx.x);
     } break;
   }
 #ifdef ENABLE_COLLTRACE
   if (tid == 0) {
-    ncclShmem.collTrace = args->comm->collTrace + COLLTRACE_NUM_ITEMS*ncclShmem.channelId;
-    ncclShmem.collTraceTail = args->comm->collTraceTail + ncclShmem.channelId;
+    ncclShmem->collTrace = args->comm->collTrace + COLLTRACE_NUM_ITEMS*ncclShmem->channelId;
+    ncclShmem->collTraceTail = args->comm->collTraceTail + ncclShmem->channelId;
   }
 #endif
 #ifdef ENABLE_WARP_SPEED
   if(tid == 0) {
-    ncclShmem.warpComm = args->comm->warpLevelComm;
+    ncclShmem->warpComm = args->comm->warpLevelComm;
   }
 #endif
   __syncthreads(); // publish shmem
@@ -624,24 +621,24 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
 #ifdef ENABLE_WARP_SPEED
   // Determine per-warp channel assignment for WarpSpeed enablement
   total = 0;
-  if(ncclShmem.warpComm == 1) {  // If warpComm is enabled, assign warps to channels that have the corresponding channel mask enabled
-    ncclShmem.warpChannelId[localWarpId] = -1;
+  if(ncclShmem->warpComm == 1) {  // If warpComm is enabled, assign warps to channels that have the corresponding channel mask enabled
+    ncclShmem->warpChannelId[localWarpId] = -1;
      __syncthreads();
     for (int i = 0; i < num; i++) {
       if (args->channelMask.masks[i] & (1ull<<laneId)) {
         y = __popcll(args->channelMask.masks[i] & ((1ull<<laneId)-1));
         y = total + y;
         if (globalWarpId == y) {
-          ncclShmem.warpChannelId[localWarpId] = laneId + total;
+          ncclShmem->warpChannelId[localWarpId] = laneId + total;
           break;
         }
       }
       total = total + __popcll(args->channelMask.masks[i]);
     }
     __syncthreads();
-    if(ncclShmem.warpChannelId[localWarpId] >= 0) {
-      void* dst = &ncclShmem.warpChannel[localWarpId];
-      void* src = &((ncclKernelCommAndChannels*)ncclShmem.args.comm)->channels[ncclShmem.warpChannelId[localWarpId]];
+    if(ncclShmem->warpChannelId[localWarpId] >= 0) {
+      void* dst = &ncclShmem->warpChannel[localWarpId];
+      void* src = &((ncclKernelCommAndChannels*)ncclShmem->args.comm)->channels[ncclShmem->warpChannelId[localWarpId]];
       int bytes = sizeof(ncclDevChannel);
       static_assert(sizeof(ncclDevChannel) <= 16*WARP_SIZE, "ncclDevChannel cannot be loaded by a single warp in one insn.");
       // assert((tid-localWarpId*WARP_SIZE) >= 0 && (tid-localWarpId*WARP_SIZE) < WARP_SIZE);
@@ -649,11 +646,11 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
     }
   } else {  // If warpComm is disabled, all warps use the same channel as the block
     if(laneId == 0) {
-      ncclShmem.warpChannelId[localWarpId] = ncclShmem.channelId;
+      ncclShmem->warpChannelId[localWarpId] = ncclShmem->channelId;
     }
     // Use all threads in the warp to copy the channel data in parallel
-    void* dst = &ncclShmem.warpChannel[localWarpId];
-    void* src = &ncclShmem.channel;
+    void* dst = &ncclShmem->warpChannel[localWarpId];
+    void* src = &ncclShmem->channel;
     int bytes = sizeof(ncclDevChannel);
     copyToShmem16(laneId, dst, src, bytes);
   }
@@ -661,62 +658,62 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
 #endif
 #ifdef ENABLE_PROFILING
   if (tid == 0) {
-    ncclShmem.prof.count = 0;
-    ncclShmem.prof.seq = ncclShmem.comm.devProf[blockIdx.x].seq;
+    ncclShmem->prof.count = 0;
+    ncclShmem->prof.seq = ncclShmem->comm.devProf[blockIdx.x].seq;
   }
 #endif
-  if (tid == 0) __insert_timestamp(__LINE__);
-  if (COLLTRACE && tid%WARP_SIZE == 0) traceKernelLaunch(ncclCollTraceKernelLaunchType, 0);
+  if (tid == 0) __insert_timestamp(ncclShmem, __LINE__);
+  if (COLLTRACE && tid%WARP_SIZE == 0) traceKernelLaunch(ncclShmem, ncclCollTraceKernelLaunchType, 0);
 
-  while (ncclShmem.aborted == 0) {
-    if (tid == 0) __insert_timestamp(__LINE__);
-    profiler(START);
-    if (0 <= SpecializedFnId && ncclShmem.funcId == (unsigned)SpecializedFnId) {
-      SpecializedRunWorkBatch().run();
+  while (ncclShmem->aborted == 0) {
+    if (tid == 0) __insert_timestamp(ncclShmem, __LINE__);
+    profiler(ncclShmem, START);
+    if (0 <= SpecializedFnId && ncclShmem->funcId == (unsigned)SpecializedFnId) {
+      SpecializedRunWorkBatch().run(ncclShmem, ncclShmemPerWarp);
     } else {
 #ifdef USE_INDIRECT_FUNCTION_CALL
       if (COLL_UNROLL == 1)
-        ncclDevFuncTable_1[ncclShmem.funcId]();
+        ncclDevFuncTable_1[ncclShmem->funcId](ncclShmem, ncclShmemPerWarp);
       else if (COLL_UNROLL == 2)
-        ncclDevFuncTable_2[ncclShmem.funcId]();
+        ncclDevFuncTable_2[ncclShmem->funcId](ncclShmem, ncclShmemPerWarp);
       else
-        ncclDevFuncTable_4[ncclShmem.funcId]();
+        ncclDevFuncTable_4[ncclShmem->funcId](ncclShmem, ncclShmemPerWarp);
 #else
       if (COLL_UNROLL == 1)
-        NCCL_CALL_FUNCTIONS_1(ncclShmem.funcId);
+        NCCL_CALL_FUNCTIONS_1(ncclShmem->funcId, ncclShmem, ncclShmemPerWarp);
       else if (COLL_UNROLL == 2)
-        NCCL_CALL_FUNCTIONS_2(ncclShmem.funcId);
+        NCCL_CALL_FUNCTIONS_2(ncclShmem->funcId, ncclShmem, ncclShmemPerWarp);
       else
-        NCCL_CALL_FUNCTIONS_4(ncclShmem.funcId);
+        NCCL_CALL_FUNCTIONS_4(ncclShmem->funcId, ncclShmem, ncclShmemPerWarp);
 #endif
     }
 
-    if (ncclShmem.nextBatchIx == -1) break;
-    int batchIx = ncclShmem.nextBatchIx;
+    if (ncclShmem->nextBatchIx == -1) break;
+    int batchIx = ncclShmem->nextBatchIx;
     __syncthreads();
     switch (tid/WARP_SIZE) {
       case 1:
         if (tid < WARP_SIZE + NCCL_MAX_GROUPS) {
-          if (tid == WARP_SIZE) ncclShmem.barrier_pat = 0;
-          ncclShmem.groups[tid-WARP_SIZE].barrier = 0;
+          if (tid == WARP_SIZE) ncclShmem->barrier_pat = 0;
+          ncclShmem->groups[tid-WARP_SIZE].barrier = 0;
         }
         break;
       default:
         break;
     }
-    profiler(STOP);
-    loadWorkBatchToShmem(tid%WARP_SIZE, tn, args, batchIx);
+    profiler(ncclShmem, STOP);
+    loadWorkBatchToShmem(ncclShmem, ncclShmemPerWarp, tid%WARP_SIZE, tn, args, batchIx);
     __syncthreads();
-    if (COLLTRACE && tid%WARP_SIZE == 0) traceKernelLaunch(ncclCollTraceCollLaunchType, batchIx);
+    if (COLLTRACE && tid%WARP_SIZE == 0) traceKernelLaunch(ncclShmem, ncclCollTraceCollLaunchType, batchIx);
   }
-  profiler(FINI);
-  if (COLLTRACE && tid%WARP_SIZE == 0) traceKernelEnd(ncclCollTraceKernelEndType);
+  profiler(ncclShmem, FINI);
+  if (COLLTRACE && tid%WARP_SIZE == 0) traceKernelEnd(ncclShmem, ncclCollTraceKernelEndType);
 
 #ifdef ENABLE_PROFILING
-  if (ncclShmem.comm.devProf->seq < PROFILE_NUM_LAUNCHES) {
+  if (ncclShmem->comm.devProf->seq < PROFILE_NUM_LAUNCHES) {
     __syncthreads();
-    copyToShmem16(tid, ncclShmem.comm.devProf+MAXCHANNELS*ncclShmem.prof.seq+blockIdx.x, &ncclShmem.prof, sizeof(struct ncclProf));
-    if (tid == 0) ncclShmem.comm.devProf[blockIdx.x].seq++;
+    copyToShmem16(tid, ncclShmem->comm.devProf+MAXCHANNELS*ncclShmem->prof.seq+blockIdx.x, &ncclShmem->prof, sizeof(struct ncclProf));
+    if (tid == 0) ncclShmem->comm.devProf[blockIdx.x].seq++;
   }
 #endif
 }
@@ -735,13 +732,13 @@ __global__ void ncclDevKernelDebug_Generic_4(ncclDevKernelArgsDefaultStorage NCC
 
 #ifdef USE_INDIRECT_FUNCTION_CALL
 #define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll) \
-  __device__ void ncclDevFunc_##suffix() { \
-    RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(); \
+  __device__ void ncclDevFunc_##suffix(struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) { \
+    RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(ncclShmem, ncclShmemPerWarp); \
   }
 #else
 #define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll) \
-  __device__ __attribute__((noinline)) void ncclDevFunc_##suffix() { \
-    RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(); \
+  __device__ __attribute__((noinline)) void ncclDevFunc_##suffix(struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) { \
+    RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(ncclShmem, ncclShmemPerWarp); \
   }
 #endif
 

--- a/projects/rccl/src/device/common.h
+++ b/projects/rccl/src/device/common.h
@@ -48,22 +48,22 @@
 
 #ifdef ENABLE_COLLTRACE
   #define INC_COLL_TRACE(ncclShmem) \
-    uint32_t pos = __hip_atomic_fetch_add(&(ncclShmem)->collTraceTail->tail, 1, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_WORKGROUP)%COLLTRACE_NUM_ITEMS; \
-    struct ncclCollTrace* collTrace = (ncclShmem)->collTrace+pos; \
+    uint32_t pos = __hip_atomic_fetch_add(&(ncclShmem).collTraceTail->tail, 1, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_WORKGROUP)%COLLTRACE_NUM_ITEMS; \
+    struct ncclCollTrace* collTrace = (ncclShmem).collTrace+pos; \
     collTrace->timeStamp = wall_clock64(); \
     collTrace->tid = threadIdx.x; \
-    collTrace->channelId = (ncclShmem)->channelId;
+    collTrace->channelId = (ncclShmem).channelId;
     // TODO: switch to atomicInc after llvm crash is fixed
     // uint32_t pos = atomicInc(&(shmem).collTraceTail->tail, COLLTRACE_NUM_ITEMS)
 
   #define traceKernelLaunch(ncclShmem, launch_type, ix) { \
     INC_COLL_TRACE(ncclShmem) \
-    collTrace->funcIndex = (ncclShmem)->funcId; \
+    collTrace->funcIndex = (ncclShmem).funcId; \
     __trace_hwreg() \
     __trace_xccid() \
     collTrace->batchIx = ix; \
-    if ((ncclShmem)->workType == ncclDevWorkTypeP2p) { \
-      struct ncclDevWorkP2p *p2pWork = (struct ncclDevWorkP2p*)(ncclShmem)->workStorage; \
+    if ((ncclShmem).workType == ncclDevWorkTypeP2p) { \
+      struct ncclDevWorkP2p *p2pWork = (struct ncclDevWorkP2p*)(ncclShmem).workStorage; \
       collTrace->p2p.sendRank = p2pWork->sendRank; \
       collTrace->p2p.recvRank = p2pWork->recvRank; \
       collTrace->p2p.nSendChannels = p2pWork->nSendChannels; \
@@ -78,11 +78,11 @@
       collTrace->p2pOpCount[0] = p2pWork->sendOpCount; \
       collTrace->p2pOpCount[1] = p2pWork->recvOpCount; \
       __hip_atomic_store(&collTrace->type, (launch_type) | ncclCollTraceP2pElemType, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP); \
-    } else if ((ncclShmem)->workType == ncclDevWorkTypeColl) { \
-      struct ncclDevWorkColl *collWork = (struct ncclDevWorkColl*)(ncclShmem)->workStorage; \
+    } else if ((ncclShmem).workType == ncclDevWorkTypeColl) { \
+      struct ncclDevWorkColl *collWork = (struct ncclDevWorkColl*)(ncclShmem).workStorage; \
       collTrace->coll.nWarps = collWork->nWarps; \
       collTrace->coll.nChannels = collWork->channelHi-collWork->channelLo+1; \
-      collTrace->coll.bid = (ncclShmem)->channelId - collWork->channelLo; \
+      collTrace->coll.bid = (ncclShmem).channelId - collWork->channelLo; \
       collTrace->coll.root = collWork->root; \
       collTrace->opCount = collWork->opCount; \
       __hip_atomic_store(&collTrace->type, (launch_type) | ncclCollTraceCollElemType, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP); \
@@ -90,14 +90,14 @@
   }
   #define traceKernelEnd(ncclShmem, end_type)  { \
     INC_COLL_TRACE(ncclShmem) \
-    collTrace->funcIndex = (ncclShmem)->funcId;\
-    if ((ncclShmem)->workType == ncclDevWorkTypeP2p) { \
-      struct ncclDevWorkP2p *p2pWork = (struct ncclDevWorkP2p*)(ncclShmem)->workStorage; \
+    collTrace->funcIndex = (ncclShmem).funcId;\
+    if ((ncclShmem).workType == ncclDevWorkTypeP2p) { \
+      struct ncclDevWorkP2p *p2pWork = (struct ncclDevWorkP2p*)(ncclShmem).workStorage; \
       collTrace->p2pOpCount[0] = p2pWork->sendOpCount; \
       collTrace->p2pOpCount[1] = p2pWork->recvOpCount; \
       __hip_atomic_store(&collTrace->type, (end_type) | ncclCollTraceP2pElemType, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP); \
-    } else if ((ncclShmem)->workType == ncclDevWorkTypeColl) { \
-      struct ncclDevWorkColl *collWork = (struct ncclDevWorkColl*)(ncclShmem)->workStorage; \
+    } else if ((ncclShmem).workType == ncclDevWorkTypeColl) { \
+      struct ncclDevWorkColl *collWork = (struct ncclDevWorkColl*)(ncclShmem).workStorage; \
       collTrace->opCount = collWork->opCount; \
       __hip_atomic_store(&collTrace->type, (end_type) | ncclCollTraceCollElemType, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP); \
     } \
@@ -112,7 +112,7 @@
   }
   #define traceAbort(ncclShmem) {\
     INC_COLL_TRACE(ncclShmem)\
-    collTrace->funcIndex = (ncclShmem)->funcId;\
+    collTrace->funcIndex = (ncclShmem).funcId;\
     __hip_atomic_store(&collTrace->type, ncclCollTraceAbortType, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP); \
   }
 #else
@@ -194,8 +194,8 @@ struct ncclShmemData {
 // #endif
 
 #ifdef ENABLE_FAULT_INJECTION
-__device__ inline void insert_random_delay_per_warp(ncclShmemData* ncclShmem) {
-  if ((ncclShmem->faults & RANDOM_DELAY_ON_WARP_START) && (threadIdx.x%WARP_SIZE == 0)) {
+__device__ inline void insert_random_delay_per_warp(ncclShmemData& ncclShmem) {
+  if ((ncclShmem.faults & RANDOM_DELAY_ON_WARP_START) && (threadIdx.x%WARP_SIZE == 0)) {
     switch ((wall_clock64()>>(threadIdx.x/WARP_SIZE*2))&0x3) {
       case 0:
         __builtin_amdgcn_s_sleep(0);
@@ -261,10 +261,10 @@ __device__ inline bool barrier_red_or(bool vote, int name, int nThreads) {
 
 #ifdef ENABLE_PROFILING
 #define __insert_timestamp(ncclShmem, line_num) do { \
-      if ((ncclShmem)->prof.count < PROFILE_NUM_ITEMS) { \
-        (ncclShmem)->prof.elem[(ncclShmem)->prof.count].line = line_num; \
-        (ncclShmem)->prof.elem[(ncclShmem)->prof.count].timeStamp = wall_clock64(); \
-        (ncclShmem)->prof.count++; \
+      if ((ncclShmem).prof.count < PROFILE_NUM_ITEMS) { \
+        (ncclShmem).prof.elem[(ncclShmem).prof.count].line = line_num; \
+        (ncclShmem).prof.elem[(ncclShmem).prof.count].timeStamp = wall_clock64(); \
+        (ncclShmem).prof.count++; \
       } \
     } while(0);
 #else
@@ -285,7 +285,7 @@ inline __device__ void copyToShmem16(int tid, void* dst, void const* src, int by
 
 // Must run with at least 64 threads
 __device__ __forceinline__ void loadWorkBatchToShmem(
-    struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp, int tid, int tn, struct ncclDevKernelArgs const* args, int batchIx
+    struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp, int tid, int tn, struct ncclDevKernelArgs const* args, int batchIx
   ) {
   int lane = tid%WARP_SIZE;
   int workCursor = 0; // num works written in previous loop iterations.
@@ -347,7 +347,7 @@ __device__ __forceinline__ void loadWorkBatchToShmem(
       break;
     }
     if (tid == 0) {
-      ncclShmem->workSize = workSize;
+      ncclShmem.workSize = workSize;
     }
     // We deliberately replicate these div and mod calculations into the case
     // blocks above so that they get constant divisor optimizations by the compiler.
@@ -377,15 +377,15 @@ __device__ __forceinline__ void loadWorkBatchToShmem(
       //   src = &global_variable;
       // }
       // memcpy(dst, src, n);
-      if (ncclShmem->args.workStorageType == ncclDevWorkStorageTypeArgs) {
+      if (ncclShmem.args.workStorageType == ncclDevWorkStorageTypeArgs) {
         char* src = (char*)args + (batch.offsetBase + srcWork*workSize + packInWork*16);
         tmp = *(ulong2*)src; // becomes ld.param.v2.u64
       }
-      if (ncclShmem->args.workStorageType != ncclDevWorkStorageTypeArgs) {
-        char* src = (char*)ncclShmem->args.workBuf + ((batch.offsetBase + srcWork*workSize + packInWork*16) & ncclShmem->args.workMask);
+      if (ncclShmem.args.workStorageType != ncclDevWorkStorageTypeArgs) {
+        char* src = (char*)ncclShmem.args.workBuf + ((batch.offsetBase + srcWork*workSize + packInWork*16) & ncclShmem.args.workMask);
         tmp = *(ulong2*)src; // becomes ld.v2.u64
       }
-      char* dst = ncclShmem->workStorage;
+      char* dst = ncclShmem.workStorage;
       dst += (workCursor + dstWork)*workSize + packInWork*16;
       *(ulong2*)dst = tmp;
     }
@@ -397,11 +397,11 @@ __device__ __forceinline__ void loadWorkBatchToShmem(
       if (tid < 0) tid += tn;
     } else {
       if (tid == 0) {
-        ncclShmem->batchIx = batchIx;
-        ncclShmem->nextBatchIx = (batch.nextJump == 0) ? -1 : batchIx + batch.nextJump;
-        ncclShmem->workType = (enum ncclDevWorkType)batch.workType;
-        ncclShmem->nWorks = workCursor;
-        ncclShmem->funcId = batch.funcId;
+        ncclShmem.batchIx = batchIx;
+        ncclShmem.nextBatchIx = (batch.nextJump == 0) ? -1 : batchIx + batch.nextJump;
+        ncclShmem.workType = (enum ncclDevWorkType)batch.workType;
+        ncclShmem.nWorks = workCursor;
+        ncclShmem.funcId = batch.funcId;
       }
       break;
     }
@@ -420,7 +420,7 @@ __device__ __forceinline__ unsigned long long int globaltimer() {
 
 template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto, int USE_ACC, int COLL_UNROLL, int Pipeline>
 struct RunWorkColl {
-  __device__ void run(int tid, int tn, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ void run(int tid, int tn, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     // Put NOT IMPLEMENTED behavior here.
   }
 };
@@ -437,14 +437,14 @@ template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto,  int US
 struct RunWorkBatch {
   // This __forceinline__ is necessary. The compiler was inserting a function call
   // here from the LL ncclKernel.
-  __device__ __forceinline__ void run(struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     int tid = threadIdx.x;
     int tn = blockDim.x;
 
     if (RedOpArg<RedOp>::ArgUsed) {
-      int nWorks = ncclShmem->nWorks;
+      int nWorks = ncclShmem.nWorks;
       for (int w=tid; w < nWorks; w += tn) {
-        struct ncclDevWorkColl* work = (ncclDevWorkColl*)(ncclShmem->workStorage + w*ncclShmem->workSize);
+        struct ncclDevWorkColl* work = (ncclDevWorkColl*)(ncclShmem.workStorage + w*ncclShmem.workSize);
         if (work->redOpArgIsPtr) {
           work->redOpArg = RedOpArg<RedOp>::loadArg(reinterpret_cast<void*>(work->redOpArg));
         }
@@ -453,17 +453,17 @@ struct RunWorkBatch {
     }
 
     #pragma unroll 1
-    for (int w=0; w < ncclShmem->nWorks; w++) {
-      struct ncclDevWorkColl* work = (struct ncclDevWorkColl*)(ncclShmem->workStorage + w*ncclShmem->workSize);
+    for (int w=0; w < ncclShmem.nWorks; w++) {
+      struct ncclDevWorkColl* work = (struct ncclDevWorkColl*)(ncclShmem.workStorage + w*ncclShmem.workSize);
       if (w != 0) {
-        struct ncclDevWorkColl* workPrev = (struct ncclDevWorkColl*)(ncclShmem->workStorage + (w-1)*ncclShmem->workSize);
+        struct ncclDevWorkColl* workPrev = (struct ncclDevWorkColl*)(ncclShmem.workStorage + (w-1)*ncclShmem.workSize);
         if (work->nWarps != workPrev->nWarps) __syncthreads();
       }
       int subtn = work->nWarps*WARP_SIZE;
 #ifdef ENABLE_WARP_SPEED
       if (tid < subtn) {
-        if(ncclShmem->warpComm == 0 || Algo != NCCL_ALGO_RING) RunWorkColl<Fn, T, RedOp, Algo, Proto>().run(tid, subtn, work, ncclShmem, ncclShmemPerWarp);
-        else if (ncclShmem->warpChannelId[tid / WARP_SIZE] >= 0) RunWorkColl<Fn, T, RedOp, Algo, Proto>().run(tid % WARP_SIZE, WARP_SIZE, work, ncclShmem, ncclShmemPerWarp);
+        if(ncclShmem.warpComm == 0 || Algo != NCCL_ALGO_RING) RunWorkColl<Fn, T, RedOp, Algo, Proto>().run(tid, subtn, work, ncclShmem, ncclShmemPerWarp);
+        else if (ncclShmem.warpChannelId[tid / WARP_SIZE] >= 0) RunWorkColl<Fn, T, RedOp, Algo, Proto>().run(tid % WARP_SIZE, WARP_SIZE, work, ncclShmem, ncclShmemPerWarp);
       }
 #else
       if (tid < subtn) RunWorkColl<Fn, T, RedOp, Algo, Proto>().run(tid, subtn, work, ncclShmem, ncclShmemPerWarp);
@@ -476,36 +476,36 @@ struct RunWorkBatch {
 #define STOP  1
 #define FINI  2
 
-__device__ __forceinline__ bool profilerEnabled(struct ncclShmemData* ncclShmem, int workItemIdx) {
-  return (ncclShmem->workType == ncclDevWorkTypeP2p) ?
-    ((struct ncclDevWorkP2p*)ncclShmem->workStorage)[workItemIdx].profilerEnabled :
-    ((struct ncclDevWorkColl*)ncclShmem->workStorage)[workItemIdx].profilerEnabled;
+__device__ __forceinline__ bool profilerEnabled(struct ncclShmemData& ncclShmem, int workItemIdx) {
+  return (ncclShmem.workType == ncclDevWorkTypeP2p) ?
+    ((struct ncclDevWorkP2p*)ncclShmem.workStorage)[workItemIdx].profilerEnabled :
+    ((struct ncclDevWorkColl*)ncclShmem.workStorage)[workItemIdx].profilerEnabled;
 }
 
-__device__ __forceinline__ void profiler(struct ncclShmemData* ncclShmem, int action) {
+__device__ __forceinline__ void profiler(struct ncclShmemData& ncclShmem, int action) {
   if (threadIdx.x == 0) {
     int idx = 0;
-    uint64_t wc = ncclShmem->channel.workCounter + 1;
+    uint64_t wc = ncclShmem.channel.workCounter + 1;
     if (action == START) {
-      for (; wc <= ncclShmem->channel.workCounter + ncclShmem->nWorks; wc++) {
+      for (; wc <= ncclShmem.channel.workCounter + ncclShmem.nWorks; wc++) {
         if (!profilerEnabled(ncclShmem, idx++)) continue;
-        ncclShmem->comm.workStarted[ncclShmem->channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp = globaltimer();
-        ncclShmem->comm.workStarted[ncclShmem->channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].counter = wc;
+        ncclShmem.comm.workStarted[ncclShmem.channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp = globaltimer();
+        ncclShmem.comm.workStarted[ncclShmem.channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].counter = wc;
       }
     } else {
-      for (; wc <= ncclShmem->channel.workCounter + ncclShmem->nWorks; wc++) {
+      for (; wc <= ncclShmem.channel.workCounter + ncclShmem.nWorks; wc++) {
         if (!profilerEnabled(ncclShmem, idx++)) continue;
-        ncclShmem->comm.workCompleted[ncclShmem->channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp = globaltimer();
-        ncclShmem->comm.workCompleted[ncclShmem->channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].counter = wc;
+        ncclShmem.comm.workCompleted[ncclShmem.channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp = globaltimer();
+        ncclShmem.comm.workCompleted[ncclShmem.channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].counter = wc;
       }
-      ncclShmem->channel.workCounter += ncclShmem->nWorks;
-      if (action == FINI) ((ncclKernelCommAndChannels*)ncclShmem->args.comm)->channels[ncclShmem->channelId].workCounter = ncclShmem->channel.workCounter;
+      ncclShmem.channel.workCounter += ncclShmem.nWorks;
+      if (action == FINI) ((ncclKernelCommAndChannels*)ncclShmem.args.comm)->channels[ncclShmem.channelId].workCounter = ncclShmem.channel.workCounter;
     }
   }
 }
 
 template<int SpecializedFnId, typename SpecializedRunWorkBatch, bool COLLTRACE, int COLL_UNROLL>
-__device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* args, ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+__device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* args, ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
   const int tid = threadIdx.x;
   int tn = blockDim.x;
   int x = tid;
@@ -520,7 +520,7 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
   // Copy kernel args to shmem and then only read those. Otherwise the compiler
   // will end up putting the args into thread local stack which is very wasteful.
   if (tid < sizeof(ncclDevKernelArgs)/sizeof(uint32_t)) {
-    ((uint32_t*)&ncclShmem->args)[tid] = ((uint32_t*)args)[tid];
+    ((uint32_t*)&ncclShmem.args)[tid] = ((uint32_t*)args)[tid];
   }
 
   // To map blockId to channelId, we need the n'th set bit of channelMask which
@@ -529,13 +529,13 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
   // do better when we know all threads are querying the same bitmask.
   switch (tid/WARP_SIZE) {
   case 0:
-  //ncclShmem->channelId = blockIdx.x;
+  //ncclShmem.channelId = blockIdx.x;
     for (int i = 0; i < num; i++) {
       if (args->channelMask.masks[i] & (1ull<<x)) {
         y = __popcll(args->channelMask.masks[i] & ((1ull<<x)-1));
         y = total + y;
         if (blockIdx.x == y) {
-          ncclShmem->channelId = x + total;
+          ncclShmem.channelId = x + total;
           break;
         }
       }
@@ -545,7 +545,7 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
           y = __popcll(args->channelMask.masks[i] & ((1ull<<x)-1));
           y = y + total;
           if (blockIdx.x == y) {
-            ncclShmem->channelId = x + total;
+            ncclShmem.channelId = x + total;
             break;
           }
         }
@@ -555,43 +555,43 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
     break;
   case 1:
     if (tid < WARP_SIZE + NCCL_MAX_GROUPS) {
-      if (tid == WARP_SIZE) ncclShmem->barrier_pat = 0;
-      ncclShmem->groups[tid-WARP_SIZE].barrier = 0;
+      if (tid == WARP_SIZE) ncclShmem.barrier_pat = 0;
+      ncclShmem.groups[tid-WARP_SIZE].barrier = 0;
     }
     break;
   case 2:
 #ifdef ENABLE_FAULT_INJECTION
     /* load faults injection before first sync threads */
-    if (tid == 2*WARP_SIZE) ncclShmem->faults = args->comm->faults;
+    if (tid == 2*WARP_SIZE) ncclShmem.faults = args->comm->faults;
 #endif
     break;
   case 3:
     /* set abort flag to 0 */
-    if (tid == 3*WARP_SIZE) ncclShmem->aborted = 0;
+    if (tid == 3*WARP_SIZE) ncclShmem.aborted = 0;
     break;
   default:
     break;
   }
-  __syncthreads(); // publish ncclShmem->{args, channelId}
+  __syncthreads(); // publish ncclShmem.{args, channelId}
   /* set abort flag to 0 */
   if (tid == 0) {
-    ncclShmem->aborted = 0;
-    ncclShmem->channel.workCounter = ((ncclKernelCommAndChannels*)ncclShmem->args.comm)->channels[ncclShmem->channelId].workCounter;
+    ncclShmem.aborted = 0;
+    ncclShmem.channel.workCounter = ((ncclKernelCommAndChannels*)ncclShmem.args.comm)->channels[ncclShmem.channelId].workCounter;
   }
 
   // Use first 2 warps to load comm and channel, and remaining load work batch.
   switch (tid/WARP_SIZE) {
   case 0:
-    { void* dst = &ncclShmem->comm;
-      void* src = ncclShmem->args.comm;
+    { void* dst = &ncclShmem.comm;
+      void* src = ncclShmem.args.comm;
       int bytes = sizeof(ncclKernelComm);
       static_assert(sizeof(ncclKernelComm) <= 16*WARP_SIZE, "ncclKernelComm cannot be loaded by a single warp in one insn.");
       copyToShmem16(tid, dst, src, bytes);
     } break;
   case 1:
     { // Get address of channel without incurring indirect load from ncclKernelComm::channels
-      void* dst = &ncclShmem->channel;
-      void* src = &((ncclKernelCommAndChannels*)ncclShmem->args.comm)->channels[ncclShmem->channelId];
+      void* dst = &ncclShmem.channel;
+      void* src = &((ncclKernelCommAndChannels*)ncclShmem.args.comm)->channels[ncclShmem.channelId];
       int bytes = sizeof(ncclDevChannel);
       static_assert(sizeof(ncclDevChannel) <= 16*WARP_SIZE, "ncclDevChannel cannot be loaded by a single warp in one insn.");
       copyToShmem16(tid-WARP_SIZE, dst, src, bytes);
@@ -607,13 +607,13 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
   }
 #ifdef ENABLE_COLLTRACE
   if (tid == 0) {
-    ncclShmem->collTrace = args->comm->collTrace + COLLTRACE_NUM_ITEMS*ncclShmem->channelId;
-    ncclShmem->collTraceTail = args->comm->collTraceTail + ncclShmem->channelId;
+    ncclShmem.collTrace = args->comm->collTrace + COLLTRACE_NUM_ITEMS*ncclShmem.channelId;
+    ncclShmem.collTraceTail = args->comm->collTraceTail + ncclShmem.channelId;
   }
 #endif
 #ifdef ENABLE_WARP_SPEED
   if(tid == 0) {
-    ncclShmem->warpComm = args->comm->warpLevelComm;
+    ncclShmem.warpComm = args->comm->warpLevelComm;
   }
 #endif
   __syncthreads(); // publish shmem
@@ -621,24 +621,24 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
 #ifdef ENABLE_WARP_SPEED
   // Determine per-warp channel assignment for WarpSpeed enablement
   total = 0;
-  if(ncclShmem->warpComm == 1) {  // If warpComm is enabled, assign warps to channels that have the corresponding channel mask enabled
-    ncclShmem->warpChannelId[localWarpId] = -1;
+  if(ncclShmem.warpComm == 1) {  // If warpComm is enabled, assign warps to channels that have the corresponding channel mask enabled
+    ncclShmem.warpChannelId[localWarpId] = -1;
      __syncthreads();
     for (int i = 0; i < num; i++) {
       if (args->channelMask.masks[i] & (1ull<<laneId)) {
         y = __popcll(args->channelMask.masks[i] & ((1ull<<laneId)-1));
         y = total + y;
         if (globalWarpId == y) {
-          ncclShmem->warpChannelId[localWarpId] = laneId + total;
+          ncclShmem.warpChannelId[localWarpId] = laneId + total;
           break;
         }
       }
       total = total + __popcll(args->channelMask.masks[i]);
     }
     __syncthreads();
-    if(ncclShmem->warpChannelId[localWarpId] >= 0) {
-      void* dst = &ncclShmem->warpChannel[localWarpId];
-      void* src = &((ncclKernelCommAndChannels*)ncclShmem->args.comm)->channels[ncclShmem->warpChannelId[localWarpId]];
+    if(ncclShmem.warpChannelId[localWarpId] >= 0) {
+      void* dst = &ncclShmem.warpChannel[localWarpId];
+      void* src = &((ncclKernelCommAndChannels*)ncclShmem.args.comm)->channels[ncclShmem.warpChannelId[localWarpId]];
       int bytes = sizeof(ncclDevChannel);
       static_assert(sizeof(ncclDevChannel) <= 16*WARP_SIZE, "ncclDevChannel cannot be loaded by a single warp in one insn.");
       // assert((tid-localWarpId*WARP_SIZE) >= 0 && (tid-localWarpId*WARP_SIZE) < WARP_SIZE);
@@ -646,11 +646,11 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
     }
   } else {  // If warpComm is disabled, all warps use the same channel as the block
     if(laneId == 0) {
-      ncclShmem->warpChannelId[localWarpId] = ncclShmem->channelId;
+      ncclShmem.warpChannelId[localWarpId] = ncclShmem.channelId;
     }
     // Use all threads in the warp to copy the channel data in parallel
-    void* dst = &ncclShmem->warpChannel[localWarpId];
-    void* src = &ncclShmem->channel;
+    void* dst = &ncclShmem.warpChannel[localWarpId];
+    void* src = &ncclShmem.channel;
     int bytes = sizeof(ncclDevChannel);
     copyToShmem16(laneId, dst, src, bytes);
   }
@@ -658,44 +658,44 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
 #endif
 #ifdef ENABLE_PROFILING
   if (tid == 0) {
-    ncclShmem->prof.count = 0;
-    ncclShmem->prof.seq = ncclShmem->comm.devProf[blockIdx.x].seq;
+    ncclShmem.prof.count = 0;
+    ncclShmem.prof.seq = ncclShmem.comm.devProf[blockIdx.x].seq;
   }
 #endif
   if (tid == 0) __insert_timestamp(ncclShmem, __LINE__);
   if (COLLTRACE && tid%WARP_SIZE == 0) traceKernelLaunch(ncclShmem, ncclCollTraceKernelLaunchType, 0);
 
-  while (ncclShmem->aborted == 0) {
+  while (ncclShmem.aborted == 0) {
     if (tid == 0) __insert_timestamp(ncclShmem, __LINE__);
     profiler(ncclShmem, START);
-    if (0 <= SpecializedFnId && ncclShmem->funcId == (unsigned)SpecializedFnId) {
+    if (0 <= SpecializedFnId && ncclShmem.funcId == (unsigned)SpecializedFnId) {
       SpecializedRunWorkBatch().run(ncclShmem, ncclShmemPerWarp);
     } else {
 #ifdef USE_INDIRECT_FUNCTION_CALL
       if (COLL_UNROLL == 1)
-        ncclDevFuncTable_1[ncclShmem->funcId](ncclShmem, ncclShmemPerWarp);
+        ncclDevFuncTable_1[ncclShmem.funcId](ncclShmem, ncclShmemPerWarp);
       else if (COLL_UNROLL == 2)
-        ncclDevFuncTable_2[ncclShmem->funcId](ncclShmem, ncclShmemPerWarp);
+        ncclDevFuncTable_2[ncclShmem.funcId](ncclShmem, ncclShmemPerWarp);
       else
-        ncclDevFuncTable_4[ncclShmem->funcId](ncclShmem, ncclShmemPerWarp);
+        ncclDevFuncTable_4[ncclShmem.funcId](ncclShmem, ncclShmemPerWarp);
 #else
       if (COLL_UNROLL == 1)
-        NCCL_CALL_FUNCTIONS_1(ncclShmem->funcId, ncclShmem, ncclShmemPerWarp);
+        NCCL_CALL_FUNCTIONS_1(ncclShmem.funcId, ncclShmem, ncclShmemPerWarp);
       else if (COLL_UNROLL == 2)
-        NCCL_CALL_FUNCTIONS_2(ncclShmem->funcId, ncclShmem, ncclShmemPerWarp);
+        NCCL_CALL_FUNCTIONS_2(ncclShmem.funcId, ncclShmem, ncclShmemPerWarp);
       else
-        NCCL_CALL_FUNCTIONS_4(ncclShmem->funcId, ncclShmem, ncclShmemPerWarp);
+        NCCL_CALL_FUNCTIONS_4(ncclShmem.funcId, ncclShmem, ncclShmemPerWarp);
 #endif
     }
 
-    if (ncclShmem->nextBatchIx == -1) break;
-    int batchIx = ncclShmem->nextBatchIx;
+    if (ncclShmem.nextBatchIx == -1) break;
+    int batchIx = ncclShmem.nextBatchIx;
     __syncthreads();
     switch (tid/WARP_SIZE) {
       case 1:
         if (tid < WARP_SIZE + NCCL_MAX_GROUPS) {
-          if (tid == WARP_SIZE) ncclShmem->barrier_pat = 0;
-          ncclShmem->groups[tid-WARP_SIZE].barrier = 0;
+          if (tid == WARP_SIZE) ncclShmem.barrier_pat = 0;
+          ncclShmem.groups[tid-WARP_SIZE].barrier = 0;
         }
         break;
       default:
@@ -710,10 +710,10 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
   if (COLLTRACE && tid%WARP_SIZE == 0) traceKernelEnd(ncclShmem, ncclCollTraceKernelEndType);
 
 #ifdef ENABLE_PROFILING
-  if (ncclShmem->comm.devProf->seq < PROFILE_NUM_LAUNCHES) {
+  if (ncclShmem.comm.devProf->seq < PROFILE_NUM_LAUNCHES) {
     __syncthreads();
-    copyToShmem16(tid, ncclShmem->comm.devProf+MAXCHANNELS*ncclShmem->prof.seq+blockIdx.x, &ncclShmem->prof, sizeof(struct ncclProf));
-    if (tid == 0) ncclShmem->comm.devProf[blockIdx.x].seq++;
+    copyToShmem16(tid, ncclShmem.comm.devProf+MAXCHANNELS*ncclShmem.prof.seq+blockIdx.x, &ncclShmem.prof, sizeof(struct ncclProf));
+    if (tid == 0) ncclShmem.comm.devProf[blockIdx.x].seq++;
   }
 #endif
 }
@@ -732,12 +732,12 @@ __global__ void ncclDevKernelDebug_Generic_4(ncclDevKernelArgsDefaultStorage NCC
 
 #ifdef USE_INDIRECT_FUNCTION_CALL
 #define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll) \
-  __device__ void ncclDevFunc_##suffix(struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) { \
+  __device__ void ncclDevFunc_##suffix(struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) { \
     RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(ncclShmem, ncclShmemPerWarp); \
   }
 #else
 #define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll) \
-  __device__ __attribute__((noinline)) void ncclDevFunc_##suffix(struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) { \
+  __device__ __attribute__((noinline)) void ncclDevFunc_##suffix(struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) { \
     RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(ncclShmem, ncclShmemPerWarp); \
   }
 #endif

--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -376,10 +376,13 @@ primary_to_index = {fn: primary_to_index.get(Fn(*fn), -1) for fn in func_rows}
 
 ################################################################################
 
-# Generate <gensrc>/device_table.h
-with open(os.path.join(gensrc, "device_table.h"), "w") as f:
-  print("-- Generating %s" % os.path.join(gensrc, "device_table.h"))
+# Generate <gensrc>/device_table_decl.h -- forward declarations only
+# This file is safe to include in any TU without creating cross-TU device symbol references.
+with open(os.path.join(gensrc, "device_table_decl.h"), "w") as f:
+  print("-- Generating %s" % os.path.join(gensrc, "device_table_decl.h"))
   out = f.write
+
+  out("#ifndef NCCL_DEVICE_TABLE_DECL_H_\n#define NCCL_DEVICE_TABLE_DECL_H_\n\n")
 
   if is_ifc: func_declaration = "__device__ void"
   else: func_declaration = "__device__ __attribute__((noinline)) void"
@@ -393,8 +396,21 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
       out("%s %s(struct ncclShmemData&, void*);\n" % (func_declaration, sym))
   out("\n")
 
-  index = {val: None for val in all_unrolls}
   out("typedef void(*ncclDevFuncPtr_t)(struct ncclShmemData&, void*);\n\n")
+
+  out("#endif // NCCL_DEVICE_TABLE_DECL_H_\n")
+
+# Generate <gensrc>/device_table_impl.h -- table definitions, Caller templates, NCCL_CALL_FUNCTIONS
+# This file creates cross-TU device symbol references (function pointer table entries) and should
+# only be included in the dispatch TU (common.cu or the unity/table-kernels TU).
+with open(os.path.join(gensrc, "device_table_impl.h"), "w") as f:
+  print("-- Generating %s" % os.path.join(gensrc, "device_table_impl.h"))
+  out = f.write
+
+  out("#ifndef NCCL_DEVICE_TABLE_IMPL_H_\n#define NCCL_DEVICE_TABLE_IMPL_H_\n\n")
+  out('#include "device_table_decl.h"\n\n')
+
+  index = {val: None for val in all_unrolls}
   for unroll in all_unrolls:
     index[unroll] = 0
     out("__device__ ncclDevFuncPtr_t const ncclDevFuncTable_%s[] = {\n" % unroll)
@@ -435,6 +451,22 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
       out(f"__forceinline__ __device__ void NCCL_CALL_FUNCTIONS_{unroll}(unsigned short funcIndex, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) noexcept {{\n")
       out(f"  Caller{unroll}<0, {index[unroll]}>::call{unroll}(funcIndex, ncclShmem, ncclShmemPerWarp);\n")
       out("}\n\n")
+
+  out("#endif // NCCL_DEVICE_TABLE_IMPL_H_\n")
+
+# Generate <gensrc>/device_table.h -- backward-compatible wrapper that includes both
+# This preserves the existing build behavior: any TU that includes device_table.h gets everything.
+with open(os.path.join(gensrc, "device_table.h"), "w") as f:
+  print("-- Generating %s" % os.path.join(gensrc, "device_table.h"))
+  out = f.write
+
+  out("// Backward-compatible header: includes both declarations and table definitions.\n")
+  out("// For parallel assembly builds, include only device_table_decl.h in generated TUs\n")
+  out("// and device_table_impl.h in the dispatch TU (common.cu / table-kernels unity).\n")
+  out("#ifndef NCCL_DEVICE_TABLE_H_\n#define NCCL_DEVICE_TABLE_H_\n\n")
+  out('#include "device_table_decl.h"\n')
+  out('#include "device_table_impl.h"\n')
+  out("\n#endif // NCCL_DEVICE_TABLE_H_\n")
 
 # Generate <gensrc>/device_table.cpp
 if is_colltrace:

--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -388,13 +388,13 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
     sym = paste("_", "ncclDevFunc", *fn)
     guard = get_arch_guard(fn)
     if guard:
-      out("#if %s\n%s %s(struct ncclShmemData*, void*);\n#endif\n" % (guard, func_declaration, sym))
+      out("#if %s\n%s %s(struct ncclShmemData&, void*);\n#endif\n" % (guard, func_declaration, sym))
     else:
-      out("%s %s(struct ncclShmemData*, void*);\n" % (func_declaration, sym))
+      out("%s %s(struct ncclShmemData&, void*);\n" % (func_declaration, sym))
   out("\n")
 
   index = {val: None for val in all_unrolls}
-  out("typedef void(*ncclDevFuncPtr_t)(struct ncclShmemData*, void*);\n\n")
+  out("typedef void(*ncclDevFuncPtr_t)(struct ncclShmemData&, void*);\n\n")
   for unroll in all_unrolls:
     index[unroll] = 0
     out("__device__ ncclDevFuncPtr_t const ncclDevFuncTable_%s[] = {\n" % unroll)
@@ -415,7 +415,7 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
       out(f"template<unsigned short f, unsigned short l>\n"
           f"struct Caller{unroll} {{\n"
           "  static __forceinline__ __device__ __host__\n"
-          f"  void call{unroll}(unsigned short funcIndex, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) noexcept {{\n"
+          f"  void call{unroll}(unsigned short funcIndex, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) noexcept {{\n"
           "    constexpr unsigned short m = f + (l - f) / 2;\n"
           f"    return (funcIndex < m)\n"
           f"      ? Caller{unroll}<f, m>::call{unroll}(funcIndex, ncclShmem, ncclShmemPerWarp)\n"
@@ -426,13 +426,13 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
       out(f"template<unsigned short f>\n"
           f"struct Caller{unroll}<f, f + 1> {{\n"
           "  static __forceinline__ __device__ __host__\n"
-          f"  void call{unroll}(unsigned short funcIndex, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) noexcept {{\n"
+          f"  void call{unroll}(unsigned short funcIndex, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) noexcept {{\n"
           f"    ncclDevFuncTable_{unroll}[f](ncclShmem, ncclShmemPerWarp);\n"
           "  }\n"
           "};\n\n")
 
       # emit NCCL_CALL_FUNCTIONS_<unroll> wrapper using last index value
-      out(f"__forceinline__ __device__ void NCCL_CALL_FUNCTIONS_{unroll}(unsigned short funcIndex, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) noexcept {{\n")
+      out(f"__forceinline__ __device__ void NCCL_CALL_FUNCTIONS_{unroll}(unsigned short funcIndex, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) noexcept {{\n")
       out(f"  Caller{unroll}<0, {index[unroll]}>::call{unroll}(funcIndex, ncclShmem, ncclShmemPerWarp);\n")
       out("}\n\n")
 

--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -388,13 +388,13 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
     sym = paste("_", "ncclDevFunc", *fn)
     guard = get_arch_guard(fn)
     if guard:
-      out("#if %s\n%s %s();\n#endif\n" % (guard, func_declaration, sym))
+      out("#if %s\n%s %s(struct ncclShmemData*, void*);\n#endif\n" % (guard, func_declaration, sym))
     else:
-      out("%s %s();\n" % (func_declaration, sym))
+      out("%s %s(struct ncclShmemData*, void*);\n" % (func_declaration, sym))
   out("\n")
 
   index = {val: None for val in all_unrolls}
-  out("typedef void(*ncclDevFuncPtr_t)();\n\n")
+  out("typedef void(*ncclDevFuncPtr_t)(struct ncclShmemData*, void*);\n\n")
   for unroll in all_unrolls:
     index[unroll] = 0
     out("__device__ ncclDevFuncPtr_t const ncclDevFuncTable_%s[] = {\n" % unroll)
@@ -415,25 +415,25 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
       out(f"template<unsigned short f, unsigned short l>\n"
           f"struct Caller{unroll} {{\n"
           "  static __forceinline__ __device__ __host__\n"
-          f"  void call{unroll}(unsigned short funcIndex) noexcept {{\n"
+          f"  void call{unroll}(unsigned short funcIndex, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) noexcept {{\n"
           "    constexpr unsigned short m = f + (l - f) / 2;\n"
           f"    return (funcIndex < m)\n"
-          f"      ? Caller{unroll}<f, m>::call{unroll}(funcIndex)\n"
-          f"      : Caller{unroll}<m, l>::call{unroll}(funcIndex);\n"
+          f"      ? Caller{unroll}<f, m>::call{unroll}(funcIndex, ncclShmem, ncclShmemPerWarp)\n"
+          f"      : Caller{unroll}<m, l>::call{unroll}(funcIndex, ncclShmem, ncclShmemPerWarp);\n"
           "  }\n"
           "};\n\n")
 
       out(f"template<unsigned short f>\n"
           f"struct Caller{unroll}<f, f + 1> {{\n"
           "  static __forceinline__ __device__ __host__\n"
-          f"  void call{unroll}(unsigned short funcIndex) noexcept {{\n"
-          f"    ncclDevFuncTable_{unroll}[f]();\n"
+          f"  void call{unroll}(unsigned short funcIndex, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) noexcept {{\n"
+          f"    ncclDevFuncTable_{unroll}[f](ncclShmem, ncclShmemPerWarp);\n"
           "  }\n"
           "};\n\n")
 
       # emit NCCL_CALL_FUNCTIONS_<unroll> wrapper using last index value
-      out(f"__forceinline__ __device__ void NCCL_CALL_FUNCTIONS_{unroll}(unsigned short funcIndex) noexcept {{\n")
-      out(f"  Caller{unroll}<0, {index[unroll]}>::call{unroll}(funcIndex);\n")
+      out(f"__forceinline__ __device__ void NCCL_CALL_FUNCTIONS_{unroll}(unsigned short funcIndex, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) noexcept {{\n")
+      out(f"  Caller{unroll}<0, {index[unroll]}>::call{unroll}(funcIndex, ncclShmem, ncclShmemPerWarp);\n")
       out("}\n\n")
 
 # Generate <gensrc>/device_table.cpp

--- a/projects/rccl/src/device/msccl_kernel_impl.h
+++ b/projects/rccl/src/device/msccl_kernel_impl.h
@@ -93,7 +93,7 @@ __device__ __forceinline__ static void mscclReduce(int c, int numReductions, int
 
 template<typename T, typename RedOp, typename Proto, bool fullOps>
 __device__ __forceinline__ void mscclRunInterpreter(
-  struct ncclKernelComm* comm, struct mscclAlgo* algo, struct mscclWork* work, struct ncclShmemData* ncclShmem, struct mscclShmemData* mscclShmem, void* ncclShmemPerWarp) {
+  struct ncclKernelComm* comm, struct mscclAlgo* algo, struct mscclWork* work, ncclShmemData& ncclShmem, struct mscclShmemData* mscclShmem, void* ncclShmemPerWarp) {
   const int tid = threadIdx.x;
   const int bid = blockIdx.x;
   const int nthreads = MSCCL_MAX_NTHREADS;
@@ -118,13 +118,13 @@ __device__ __forceinline__ void mscclRunInterpreter(
     // Use first 3 warps to load comm, channel, and work into shmem
     switch (tid/WARP_SIZE) {
     case 0:
-      dst = &ncclShmem->comm;
+      dst = &ncclShmem.comm;
       src = comm;
       bytes = sizeof(ncclKernelComm);
       break;
     case 1:
       // Get address of channel without incurring indirect load from ncclKernelComm::channels
-      dst = &ncclShmem->channel;
+      dst = &ncclShmem.channel;
       src = &((ncclKernelCommAndChannels*)comm)->channels[channelId];
       bytes = sizeof(ncclDevChannel);
       break;
@@ -135,10 +135,10 @@ __device__ __forceinline__ void mscclRunInterpreter(
       break;
     case 3:
       /* set abort flag to 0 */
-      if (tid%WARP_SIZE == 0) ncclShmem->aborted = 0;
+      if (tid%WARP_SIZE == 0) ncclShmem.aborted = 0;
 #ifdef ENABLE_COLLTRACE
-      else if (tid%WARP_SIZE == 1) ncclShmem->collTrace = comm->collTrace + COLLTRACE_NUM_ITEMS*channelId;
-      else if (tid%WARP_SIZE == 2) ncclShmem->collTraceTail = comm->collTraceTail + channelId;
+      else if (tid%WARP_SIZE == 1) ncclShmem.collTrace = comm->collTrace + COLLTRACE_NUM_ITEMS*channelId;
+      else if (tid%WARP_SIZE == 2) ncclShmem.collTraceTail = comm->collTraceTail + channelId;
 #endif
       break;
     default:
@@ -147,7 +147,7 @@ __device__ __forceinline__ void mscclRunInterpreter(
     if (bytes) copyToShmem8(tid%WARP_SIZE, dst, src, bytes);
   }
 #ifdef ENABLE_WARP_SPEED
-   ncclShmem->warpComm = 0;
+   ncclShmem.warpComm = 0;
 #endif
   __syncthreads(); // publish shmem
 
@@ -170,13 +170,13 @@ __device__ __forceinline__ void mscclRunInterpreter(
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
   if (tid == 0) {
-    NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, xcc_id, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK, ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+    NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, xcc_id, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK, ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
   }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_GPU)
   if (tid == 0) {
-    NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, xcc_id, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+    NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, xcc_id, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
   }
 #endif
 
@@ -211,19 +211,19 @@ __device__ __forceinline__ void mscclRunInterpreter(
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_RUN_ENTRY)
   if (tid == 0) {
-    NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RUN_ENTRY, mscclShmem->work.sizePerMscclChunk*mscclShmem->work.nChunksPerLoop, xcc_id, timestamp_entry, ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+    NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RUN_ENTRY, mscclShmem->work.sizePerMscclChunk*mscclShmem->work.nChunksPerLoop, xcc_id, timestamp_entry, ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
   }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_INIT_ENTRY)
   if (tid == 0) {
-    NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_INIT_ENTRY, 0, xcc_id, timestamp_entry, ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+    NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_INIT_ENTRY, 0, xcc_id, timestamp_entry, ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
   }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_INIT_EXIT)
   if (tid == 0) {
-    NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_INIT_EXIT, 0, xcc_id, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+    NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_INIT_EXIT, 0, xcc_id, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
   }
 #endif
 
@@ -277,7 +277,7 @@ __device__ __forceinline__ void mscclRunInterpreter(
         if (t->type == MSCCL_SEND) {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_SEND_ENTRY)
             if (tid == 0) {
-              NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_SEND_ENTRY, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+              NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_SEND_ENTRY, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
             }
 
 #endif
@@ -285,21 +285,21 @@ __device__ __forceinline__ void mscclRunInterpreter(
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_SEND_EXIT)
             if (tid == 0) {
-              NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_SEND_EXIT, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+              NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_SEND_EXIT, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
             }
 #endif
         }
         else if (t->type == MSCCL_RECV) {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_RECV_ENTRY)
             if (tid == 0) {
-              NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RECV_ENTRY, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+              NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RECV_ENTRY, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
             }
 #endif
           prims.recv(dstOffset, thisNelem);
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_RECV_EXIT)
             if (tid == 0) {
-              NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RECV_EXIT, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+              NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RECV_EXIT, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
             }
 #endif
         }
@@ -308,7 +308,7 @@ __device__ __forceinline__ void mscclRunInterpreter(
           int currIdx = tid;
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_REDUCE_ENTRY)
           if (tid == 0) {
-            NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_REDUCE_ENTRY, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+            NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_REDUCE_ENTRY, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
           }
 #endif
           dstOffset = gridOffset + (ssize_t) (t->dstOffset+c) * sizePerMscclChunk;
@@ -325,7 +325,7 @@ __device__ __forceinline__ void mscclRunInterpreter(
           }
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_REDUCE_EXIT)
           if (tid == 0) {
-            NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_REDUCE_EXIT, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+            NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_REDUCE_EXIT, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
           }
 #endif
           barrier(nthreads);
@@ -340,13 +340,13 @@ __device__ __forceinline__ void mscclRunInterpreter(
         else if (fullOps && t->type == MSCCL_RECV_REDUCE_COPY) {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_RECV_REDUCE_COPY_ENTRY)
           if (tid == 0) {
-            NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RECV_REDUCE_COPY_ENTRY, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+            NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RECV_REDUCE_COPY_ENTRY, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
           }
 #endif
           prims.recvReduceCopy(srcOffset, dstOffset, thisNelem);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_RECV_REDUCE_COPY_EXIT)
           if (tid == 0) {
-            NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RECV_REDUCE_COPY_EXIT, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+            NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RECV_REDUCE_COPY_EXIT, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
           }
 #endif
         }
@@ -362,7 +362,7 @@ __device__ __forceinline__ void mscclRunInterpreter(
   }
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_RUN_EXIT)
   if (tid == 0) {
-    NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RUN_EXIT, mscclShmem->work.sizePerMscclChunk*mscclShmem->work.nChunksPerLoop, xcc_id, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+    NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RUN_EXIT, mscclShmem->work.sizePerMscclChunk*mscclShmem->work.nChunksPerLoop, xcc_id, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
   }
 #endif
 
@@ -376,19 +376,19 @@ __global__ void MSCCL_KERNEL_ENTRY_NAME(devredop, type, LL, fullOps)(struct nccl
   __shared__ struct mscclShmemData mscclShmem; \
   __shared__ ncclShmemData ncclShmem; \
   __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)]; \
-  mscclRunInterpreter<type, Func##devredop<type>, ProtoLL, fullOps>(comm, algo, work, &ncclShmem, &mscclShmem, ncclShmemPerWarp); \
+  mscclRunInterpreter<type, Func##devredop<type>, ProtoLL, fullOps>(comm, algo, work, ncclShmem, &mscclShmem, ncclShmemPerWarp); \
 } \
 __global__ void MSCCL_KERNEL_ENTRY_NAME(devredop, type, LL128, fullOps)(struct ncclKernelComm* comm, struct mscclAlgo* algo, struct mscclWork* work) { \
   __shared__ struct mscclShmemData mscclShmem; \
   __shared__ ncclShmemData ncclShmem; \
   __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)]; \
-  mscclRunInterpreter<type, Func##devredop<type>, ProtoLL128, fullOps>(comm, algo, work, &ncclShmem, &mscclShmem, ncclShmemPerWarp); \
+  mscclRunInterpreter<type, Func##devredop<type>, ProtoLL128, fullOps>(comm, algo, work, ncclShmem, &mscclShmem, ncclShmemPerWarp); \
 } \
 __global__ void MSCCL_KERNEL_ENTRY_NAME(devredop, type, Simple, fullOps)(struct ncclKernelComm* comm, struct mscclAlgo* algo, struct mscclWork* work) { \
   __shared__ struct mscclShmemData mscclShmem; \
   __shared__ ncclShmemData ncclShmem; \
   __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)]; \
-  mscclRunInterpreter<type, Func##devredop<type>, ProtoSimple<MSCCL_CHUNKSTEPS/MSCCL_SLICESTEPS, MSCCL_SLICESTEPS, 0, 2>, fullOps>(comm, algo, work, &ncclShmem, &mscclShmem, ncclShmemPerWarp); \
+  mscclRunInterpreter<type, Func##devredop<type>, ProtoSimple<MSCCL_CHUNKSTEPS/MSCCL_SLICESTEPS, MSCCL_SLICESTEPS, 0, 2>, fullOps>(comm, algo, work, ncclShmem, &mscclShmem, ncclShmemPerWarp); \
 }
 
 #define MSCCL_IMPL_KERNEL_ENTRY_FUNC_DEVREDOP(devredop, fullOps) \

--- a/projects/rccl/src/device/msccl_kernel_impl.h
+++ b/projects/rccl/src/device/msccl_kernel_impl.h
@@ -15,7 +15,7 @@
 #include "msccl/msccl_struct.h"
 #include "msccl/msccl_kernel.h"
 
-extern __shared__ struct mscclShmemData mscclShmem;
+// extern __shared__ struct mscclShmemData mscclShmem;
 
 #define MSCCL_MAX_ITER 65536
 
@@ -57,16 +57,16 @@ __device__ __forceinline__ static void threadBlockCopy(
   }
 }
 
-#define MSCCL_REDUCE_UNROLL_LOOP_A(numloops, BytePerPack) \
+#define MSCCL_REDUCE_UNROLL_LOOP_A(numloops, BytePerPack, mscclShmem) \
   for (int r = 0; r < numloops; r++) { \
-    srcOffset = srcBaseOffset + (ssize_t)mscclShmem.mscclTB.reductionSrcOffsets[t->reductionPointer+r] * sizePerMscclChunk; \
+    srcOffset = srcBaseOffset + (ssize_t)mscclShmem->mscclTB.reductionSrcOffsets[t->reductionPointer+r] * sizePerMscclChunk; \
     reduceInput = ld_volatile_global<BytePerPack>((uintptr_t)(srcPointer + srcOffset)); \
     o = applyReduce(redFn, reduceInput, o); \
   }
 
 template<typename T, typename RedOp, int BytePerPack>
 __device__ __forceinline__ static void mscclReduce(int c, int numReductions, int currIdx, ssize_t sizePerMscclChunk, RedOp redFn,
-  struct mscclTransmission* t, ssize_t gridOffset, ssize_t &srcOffset, ssize_t dstOffset, T *srcPointer, T *dstPointer) {
+  struct mscclTransmission* t, ssize_t gridOffset, ssize_t &srcOffset, ssize_t dstOffset, T *srcPointer, T *dstPointer, struct mscclShmemData* mscclShmem) {
   const int elemsPerPack = BytePerPack/sizeof(T);
   T* dstIndex = dstPointer + dstOffset + currIdx*elemsPerPack;
   BytePack<BytePerPack> reduceInput;
@@ -75,16 +75,16 @@ __device__ __forceinline__ static void mscclReduce(int c, int numReductions, int
   switch (numReductions) {
     case 7:
       #pragma unroll
-      MSCCL_REDUCE_UNROLL_LOOP_A(7, BytePerPack);
+      MSCCL_REDUCE_UNROLL_LOOP_A(7, BytePerPack, mscclShmem);
       break;
 #if defined(__gfx90a__)
     case 15:
       #pragma unroll
-      MSCCL_REDUCE_UNROLL_LOOP_A(15, BytePerPack);
+      MSCCL_REDUCE_UNROLL_LOOP_A(15, BytePerPack, mscclShmem);
       break;
 #endif
     default:
-      MSCCL_REDUCE_UNROLL_LOOP_A(numReductions, BytePerPack);
+      MSCCL_REDUCE_UNROLL_LOOP_A(numReductions, BytePerPack, mscclShmem);
       break;
   }
   st_global<BytePerPack>((uintptr_t)dstIndex, o);
@@ -93,7 +93,7 @@ __device__ __forceinline__ static void mscclReduce(int c, int numReductions, int
 
 template<typename T, typename RedOp, typename Proto, bool fullOps>
 __device__ __forceinline__ void mscclRunInterpreter(
-  struct ncclKernelComm* comm, struct mscclAlgo* algo, struct mscclWork* work) {
+  struct ncclKernelComm* comm, struct mscclAlgo* algo, struct mscclWork* work, struct ncclShmemData* ncclShmem, struct mscclShmemData* mscclShmem, void* ncclShmemPerWarp) {
   const int tid = threadIdx.x;
   const int bid = blockIdx.x;
   const int nthreads = MSCCL_MAX_NTHREADS;
@@ -106,39 +106,39 @@ __device__ __forceinline__ void mscclRunInterpreter(
 #endif
   // initialize mscclShmem.mscclTB
   threadBlockCopy(
-    (uint32_t *)&mscclShmem.mscclTB, (uint32_t *)(algo->mscclTBs + bid),
+    (uint32_t *)&mscclShmem->mscclTB, (uint32_t *)(algo->mscclTBs + bid),
     sizeof(struct mscclThreadBlock) / sizeof(uint32_t), tid, nthreads);
   __syncthreads(); // publish mscclShmem.mscclTB.channelId
 
   // initialize ncclShmem and mscclShmem.work
-  int channelId = mscclShmem.mscclTB.channelId;
+  int channelId = mscclShmem->mscclTB.channelId;
   {
     void *dst, *src;
     int bytes = 0;
     // Use first 3 warps to load comm, channel, and work into shmem
     switch (tid/WARP_SIZE) {
     case 0:
-      dst = &ncclShmem.comm;
+      dst = &ncclShmem->comm;
       src = comm;
       bytes = sizeof(ncclKernelComm);
       break;
     case 1:
       // Get address of channel without incurring indirect load from ncclKernelComm::channels
-      dst = &ncclShmem.channel;
+      dst = &ncclShmem->channel;
       src = &((ncclKernelCommAndChannels*)comm)->channels[channelId];
       bytes = sizeof(ncclDevChannel);
       break;
     case 2:
-      dst = &mscclShmem.work;
+      dst = &mscclShmem->work;
       src = work + blockIdx.x;
       bytes = sizeof(mscclWork);
       break;
     case 3:
       /* set abort flag to 0 */
-      if (tid%WARP_SIZE == 0) ncclShmem.aborted = 0;
+      if (tid%WARP_SIZE == 0) ncclShmem->aborted = 0;
 #ifdef ENABLE_COLLTRACE
-      else if (tid%WARP_SIZE == 1) ncclShmem.collTrace = comm->collTrace + COLLTRACE_NUM_ITEMS*channelId;
-      else if (tid%WARP_SIZE == 2) ncclShmem.collTraceTail = comm->collTraceTail + channelId;
+      else if (tid%WARP_SIZE == 1) ncclShmem->collTrace = comm->collTrace + COLLTRACE_NUM_ITEMS*channelId;
+      else if (tid%WARP_SIZE == 2) ncclShmem->collTraceTail = comm->collTraceTail + channelId;
 #endif
       break;
     default:
@@ -147,7 +147,7 @@ __device__ __forceinline__ void mscclRunInterpreter(
     if (bytes) copyToShmem8(tid%WARP_SIZE, dst, src, bytes);
   }
 #ifdef ENABLE_WARP_SPEED
-   ncclShmem.warpComm = 0;
+   ncclShmem->warpComm = 0;
 #endif
   __syncthreads(); // publish shmem
 
@@ -162,32 +162,32 @@ __device__ __forceinline__ void mscclRunInterpreter(
 #endif
 
   if (fullOps && tid == 0) {
-    traceData(__LINE__, mscclShmem.work.fnIndex, (uint64_t)mscclShmem.work.sendBuff, 0);
+    traceData(ncclShmem, __LINE__, mscclShmem->work.fnIndex, (uint64_t)mscclShmem->work.sendBuff, 0);
   }
 
   if (tid == 0)
-    *mscclShmem.work.workFifoDone = mscclShmem.work.workFifoDoneAck;
+    *mscclShmem->work.workFifoDone = mscclShmem->work.workFifoDoneAck;
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
   if (tid == 0) {
-    NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, xcc_id, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK, ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+    NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, xcc_id, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK, ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
   }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_GPU)
   if (tid == 0) {
-    NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, xcc_id, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+    NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, xcc_id, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
   }
 #endif
 
   // User pointers for primitives
-  T* thisInput = (T*)mscclShmem.work.sendBuff;
-  T* thisOutput = (T*)mscclShmem.work.recvBuff;
-  T* thisScratch = (T*)mscclShmem.work.scratchBuffer;
-  int recvPeer = mscclShmem.mscclTB.recvPeer;
-  int sendPeer = mscclShmem.mscclTB.sendPeer;
+  T* thisInput = (T*)mscclShmem->work.sendBuff;
+  T* thisOutput = (T*)mscclShmem->work.recvBuff;
+  T* thisScratch = (T*)mscclShmem->work.scratchBuffer;
+  int recvPeer = mscclShmem->mscclTB.recvPeer;
+  int sendPeer = mscclShmem->mscclTB.sendPeer;
 
-  const ssize_t chunkSize = int(Proto::calcBytePerStep()/sizeof(T) * (Proto::Id == NCCL_PROTO_SIMPLE ? MSCCL_CHUNKSTEPS : 1));
+  const ssize_t chunkSize = int(Proto::calcBytePerStep(ncclShmem)/sizeof(T) * (Proto::Id == NCCL_PROTO_SIMPLE ? MSCCL_CHUNKSTEPS : 1));
   int minChunkSize;
   if (Proto::Id == NCCL_PROTO_LL)
     minChunkSize = nthreads*(Proto::calcBytePerGrain()/sizeof(T));
@@ -196,9 +196,9 @@ __device__ __forceinline__ void mscclRunInterpreter(
     minChunkSize = nthreads*(Proto::calcBytePerGrain()/sizeof(T))/2;
   }
 
-  RedOp redFn(mscclShmem.work.redOpArg);
+  RedOp redFn(mscclShmem->work.redOpArg);
   Primitives<T, RedOp, FanAsymmetric<1,1>, 1, Proto, 0, 0, RCCL_METADATA_MSCCL> prims
-    (tid, nthreads, &recvPeer, &sendPeer, thisInput, thisOutput, mscclShmem.work.redOpArg);
+    (tid, nthreads, &recvPeer, &sendPeer, thisInput, thisOutput, mscclShmem->work.redOpArg, ncclShmem, ncclShmemPerWarp, 0, 0, 0, nullptr, nullptr, 0, primsModeDefault);
 
 #if defined(ENABLE_NPKIT)
   if (tid == 0) {
@@ -206,31 +206,31 @@ __device__ __forceinline__ void mscclRunInterpreter(
   }
 #endif
 
-  const ssize_t sizePerMscclChunk = mscclShmem.work.sizePerMscclChunk;
-  uint32_t maxAllowedCount = mscclShmem.work.maxAllowedCount;
+  const ssize_t sizePerMscclChunk = mscclShmem->work.sizePerMscclChunk;
+  uint32_t maxAllowedCount = mscclShmem->work.maxAllowedCount;
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_RUN_ENTRY)
   if (tid == 0) {
-    NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RUN_ENTRY, mscclShmem.work.sizePerMscclChunk*mscclShmem.work.nChunksPerLoop, xcc_id, timestamp_entry, ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+    NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RUN_ENTRY, mscclShmem->work.sizePerMscclChunk*mscclShmem->work.nChunksPerLoop, xcc_id, timestamp_entry, ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
   }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_INIT_ENTRY)
   if (tid == 0) {
-    NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_INIT_ENTRY, 0, xcc_id, timestamp_entry, ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+    NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_INIT_ENTRY, 0, xcc_id, timestamp_entry, ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
   }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_INIT_EXIT)
   if (tid == 0) {
-    NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_INIT_EXIT, 0, xcc_id, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+    NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_INIT_EXIT, 0, xcc_id, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
   }
 #endif
 
   // msccl flags all start out with 0. this is used as a part of the flag to make sure different work items deal with different synchronization flags
   // this still needs more work. when we make a way around the queue, the flag might have been set to undesired values. will be fixed in subsequent versions.
-  const int64_t workIndex = mscclShmem.work.workIndex;
-  volatile struct mscclFlag* mscclFlags = mscclShmem.work.syncFlags;
+  const int64_t workIndex = mscclShmem->work.workIndex;
+  volatile struct mscclFlag* mscclFlags = mscclShmem->work.syncFlags;
   for (ssize_t gridOffset = 0, iter = 0; gridOffset < sizePerMscclChunk; gridOffset += chunkSize, iter++) {
     ssize_t realChunkSize;
     if (Proto::Id == NCCL_PROTO_SIMPLE) {
@@ -245,15 +245,15 @@ __device__ __forceinline__ void mscclRunInterpreter(
     ssize_t srcOffset, dstOffset;
     T *srcPointer, *dstPointer;
     int step = 0;
-    for (int i = 0; i < mscclShmem.mscclTB.nSteps; i++){
-      struct mscclTransmission* t = &mscclShmem.mscclTB.transmissions[i];
+    for (int i = 0; i < mscclShmem->mscclTB.nSteps; i++){
+      struct mscclTransmission* t = &mscclShmem->mscclTB.transmissions[i];
       // first wait if there is a dependence
       int16_t numDependencies = t->numDependencies;
       if (numDependencies > 0){
         if (tid < numDependencies) {
           int16_t dependentPointer = t->dependencePointer;
-          int8_t dependentBid = mscclShmem.mscclTB.dependentBid[dependentPointer+tid];
-          int16_t dependentStep = mscclShmem.mscclTB.dependentStep[dependentPointer+tid];
+          int8_t dependentBid = mscclShmem->mscclTB.dependentBid[dependentPointer+tid];
+          int16_t dependentStep = mscclShmem->mscclTB.dependentStep[dependentPointer+tid];
           uint64_t goalFlag = COMPUTE_FLAG(workIndex, iter, dependentStep);
           while (true){
             uint64_t curFlag = __atomic_load_n(&(mscclFlags + dependentBid)->flag, (t->srcBuffer != MSCCL_OUTPUT_BUFFER) ? __ATOMIC_RELAXED : __ATOMIC_ACQUIRE);
@@ -277,7 +277,7 @@ __device__ __forceinline__ void mscclRunInterpreter(
         if (t->type == MSCCL_SEND) {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_SEND_ENTRY)
             if (tid == 0) {
-              NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_SEND_ENTRY, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+              NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_SEND_ENTRY, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
             }
 
 #endif
@@ -285,21 +285,21 @@ __device__ __forceinline__ void mscclRunInterpreter(
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_SEND_EXIT)
             if (tid == 0) {
-              NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_SEND_EXIT, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+              NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_SEND_EXIT, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
             }
 #endif
         }
         else if (t->type == MSCCL_RECV) {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_RECV_ENTRY)
             if (tid == 0) {
-              NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RECV_ENTRY, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+              NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RECV_ENTRY, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
             }
 #endif
           prims.recv(dstOffset, thisNelem);
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_RECV_EXIT)
             if (tid == 0) {
-              NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RECV_EXIT, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+              NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RECV_EXIT, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
             }
 #endif
         }
@@ -308,24 +308,24 @@ __device__ __forceinline__ void mscclRunInterpreter(
           int currIdx = tid;
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_REDUCE_ENTRY)
           if (tid == 0) {
-            NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_REDUCE_ENTRY, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_REDUCE_ENTRY, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
           }
 #endif
           dstOffset = gridOffset + (ssize_t) (t->dstOffset+c) * sizePerMscclChunk;
           // process 16-byte packed elements
           const int elemsPerPack = 16/sizeof(T);
           while (currIdx < thisNelem/elemsPerPack) {
-            mscclReduce<T, RedOp, 16>(c, numReductions, currIdx, sizePerMscclChunk, redFn, t, gridOffset, srcOffset, dstOffset, srcPointer, dstPointer);
+            mscclReduce<T, RedOp, 16>(c, numReductions, currIdx, sizePerMscclChunk, redFn, t, gridOffset, srcOffset, dstOffset, srcPointer, dstPointer, mscclShmem);
             currIdx += nthreads;
           }
           // process remaining elements
           currIdx = tid + (thisNelem/elemsPerPack)*elemsPerPack;
           if (currIdx < thisNelem) {
-            mscclReduce<T, RedOp, sizeof(T)>(c, numReductions, currIdx, sizePerMscclChunk, redFn, t, gridOffset, srcOffset, dstOffset, srcPointer, dstPointer);
+            mscclReduce<T, RedOp, sizeof(T)>(c, numReductions, currIdx, sizePerMscclChunk, redFn, t, gridOffset, srcOffset, dstOffset, srcPointer, dstPointer, mscclShmem);
           }
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_REDUCE_EXIT)
           if (tid == 0) {
-            NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_REDUCE_EXIT, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_REDUCE_EXIT, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
           }
 #endif
           barrier(nthreads);
@@ -340,13 +340,13 @@ __device__ __forceinline__ void mscclRunInterpreter(
         else if (fullOps && t->type == MSCCL_RECV_REDUCE_COPY) {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_RECV_REDUCE_COPY_ENTRY)
           if (tid == 0) {
-            NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RECV_REDUCE_COPY_ENTRY, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RECV_REDUCE_COPY_ENTRY, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
           }
 #endif
           prims.recvReduceCopy(srcOffset, dstOffset, thisNelem);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_RECV_REDUCE_COPY_EXIT)
           if (tid == 0) {
-            NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RECV_REDUCE_COPY_EXIT, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RECV_REDUCE_COPY_EXIT, thisNelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
           }
 #endif
         }
@@ -362,24 +362,33 @@ __device__ __forceinline__ void mscclRunInterpreter(
   }
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_RUN_EXIT)
   if (tid == 0) {
-    NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RUN_EXIT, mscclShmem.work.sizePerMscclChunk*mscclShmem.work.nChunksPerLoop, xcc_id, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+    NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_RUN_EXIT, mscclShmem->work.sizePerMscclChunk*mscclShmem->work.nChunksPerLoop, xcc_id, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
   }
 #endif
 
   if (fullOps && tid == 0) {
-    traceData(__LINE__, mscclShmem.work.fnIndex, (uint64_t)mscclShmem.work.sendBuff, 0);
+    traceData(ncclShmem, __LINE__, mscclShmem->work.fnIndex, (uint64_t)mscclShmem->work.sendBuff, 0);
   }
 }
 
 #define MSCCL_IMPL_KERNEL_ENTRY_FUNC_DEVREDOP_TYPE(devredop, type, fullOps) \
 __global__ void MSCCL_KERNEL_ENTRY_NAME(devredop, type, LL, fullOps)(struct ncclKernelComm* comm, struct mscclAlgo* algo, struct mscclWork* work) { \
-  mscclRunInterpreter<type, Func##devredop<type>, ProtoLL, fullOps>(comm, algo, work); \
+  __shared__ struct mscclShmemData mscclShmem; \
+  __shared__ ncclShmemData ncclShmem; \
+  __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)]; \
+  mscclRunInterpreter<type, Func##devredop<type>, ProtoLL, fullOps>(comm, algo, work, &ncclShmem, &mscclShmem, ncclShmemPerWarp); \
 } \
 __global__ void MSCCL_KERNEL_ENTRY_NAME(devredop, type, LL128, fullOps)(struct ncclKernelComm* comm, struct mscclAlgo* algo, struct mscclWork* work) { \
-  mscclRunInterpreter<type, Func##devredop<type>, ProtoLL128, fullOps>(comm, algo, work); \
+  __shared__ struct mscclShmemData mscclShmem; \
+  __shared__ ncclShmemData ncclShmem; \
+  __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)]; \
+  mscclRunInterpreter<type, Func##devredop<type>, ProtoLL128, fullOps>(comm, algo, work, &ncclShmem, &mscclShmem, ncclShmemPerWarp); \
 } \
 __global__ void MSCCL_KERNEL_ENTRY_NAME(devredop, type, Simple, fullOps)(struct ncclKernelComm* comm, struct mscclAlgo* algo, struct mscclWork* work) { \
-  mscclRunInterpreter<type, Func##devredop<type>, ProtoSimple<MSCCL_CHUNKSTEPS/MSCCL_SLICESTEPS, MSCCL_SLICESTEPS, 0, 2>, fullOps>(comm, algo, work); \
+  __shared__ struct mscclShmemData mscclShmem; \
+  __shared__ ncclShmemData ncclShmem; \
+  __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)]; \
+  mscclRunInterpreter<type, Func##devredop<type>, ProtoSimple<MSCCL_CHUNKSTEPS/MSCCL_SLICESTEPS, MSCCL_SLICESTEPS, 0, 2>, fullOps>(comm, algo, work, &ncclShmem, &mscclShmem, ncclShmemPerWarp); \
 }
 
 #define MSCCL_IMPL_KERNEL_ENTRY_FUNC_DEVREDOP(devredop, fullOps) \

--- a/projects/rccl/src/device/network/unpack/unpack.h
+++ b/projects/rccl/src/device/network/unpack/unpack.h
@@ -31,24 +31,24 @@ inline __device__ void load64gpu(const uint64_t* ptr, uint64_t &v) {
 #define DATA_LOAD_SIZE 16
 
 // Map internal association of handle with group and peer index (called once at init time)
-inline __device__ void ncclNetDeviceUnpackSetup(void* ohandle, const int group, const int index) {
+inline __device__ void ncclNetDeviceUnpackSetup(void* ohandle, const int group, const int index, struct ncclShmemData* ncclShmem) {
   struct unpackNetDeviceHandle* handle = (struct unpackNetDeviceHandle*) ohandle;
   // coverity[index_parm:FALSE]
-  ncclShmem.groups[group].devicePlugin.unpack.g_meta[index] = handle->meta;
-  ncclShmem.devicePlugin.unpack.bounce_buf = handle->bounce_buf;
+  ncclShmem->groups[group].devicePlugin.unpack.g_meta[index] = handle->meta;
+  ncclShmem->devicePlugin.unpack.bounce_buf = handle->bounce_buf;
   // coverity[index_parm:FALSE]
-  ncclShmem.groups[group].devicePlugin.unpack.head[index] = handle->head;
+  ncclShmem->groups[group].devicePlugin.unpack.head[index] = handle->head;
 }
 
-inline __device__ void ncclNetDeviceIncrementHead(const int group, const int index) {
+inline __device__ void ncclNetDeviceIncrementHead(const int group, const int index, struct ncclShmemData* ncclShmem) {
   // coverity[index_parm:FALSE]
-  ncclShmem.groups[group].devicePlugin.unpack.head[index]++;
+  ncclShmem->groups[group].devicePlugin.unpack.head[index]++;
 }
 
-inline __device__ void ncclNetDeviceSaveHead(void* ohandle, const int group, const int index) {
+inline __device__ void ncclNetDeviceSaveHead(void* ohandle, const int group, const int index, struct ncclShmemData* ncclShmem) {
   struct unpackNetDeviceHandle* handle = (struct unpackNetDeviceHandle*) ohandle;
   // coverity[index_parm:FALSE]
-  handle->head = ncclShmem.groups[group].devicePlugin.unpack.head[index];
+  handle->head = ncclShmem->groups[group].devicePlugin.unpack.head[index];
 }
 
 template <uint8_t sz>
@@ -164,21 +164,21 @@ inline __device__ int ppw(const int nbytes, int nw) {
 // threads
 template <int Recv>
 inline __device__ void ncclNetDeviceUnpack(
-    const int tid, const int tidInBlock, const int nworkers, const int group, int mask, int Src, int workSize);
+    const int tid, const int tidInBlock, const int nworkers, const int group, int mask, int Src, int workSize, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp);
 
 template <>
 inline __device__ void ncclNetDeviceUnpack</*Recv=*/0>(
-    const int tid, const int tidInBlock, const int nworkers, const int group, int mask, int Src, int workSize) {
+    const int tid, const int tidInBlock, const int nworkers, const int group, int mask, int Src, int workSize, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
   // send unpack empty
 }
 
 inline __device__ void ncclNetDeviceUnpackInner(
     const int tid, const int tidInBlock, const int nworkers, const int group, const int index,
-    void *src, const int nbytes, const uint64_t step);
+    void *src, const int nbytes, const uint64_t step, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp);
 
 template <>
 inline __device__ void ncclNetDeviceUnpack</*Recv=*/1>(
-    const int tid, const int tidInBlock, const int nworkers, const int group, int mask, int Src, int workSize) {
+    const int tid, const int tidInBlock, const int nworkers, const int group, int mask, int Src, int workSize, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 
   while (mask != 0) {
     int ix = __ffs(mask)-1; // Get the first set bit of the mask (this should correlate to a peer index)
@@ -187,13 +187,13 @@ inline __device__ void ncclNetDeviceUnpack</*Recv=*/1>(
     // Pack data from the internal iovec to the supplied flat srcs buffer using all the threads
     // + Src is necessary in the case of accessing the user buffer directly
     ncclNetDeviceUnpackInner(tid, tidInBlock, nworkers, group /* in case they need to use split warps shared memory partitioning*/,
-      ix, ncclShmem.groups[group].srcs[ix + Src], workSize, ncclShmem.groups[group].devicePlugin.unpack.head[ix]);
+      ix, ncclShmem->groups[group].srcs[ix + Src], workSize, ncclShmem->groups[group].devicePlugin.unpack.head[ix], ncclShmem, ncclShmemPerWarp);
   }
 }
 
 inline __device__ void ncclNetDeviceUnpackInner(
     const int tid, const int tidInBlock, const int nworkers, const int group, const int index,
-    void *src, const int nbytes, const uint64_t step) {
+    void *src, const int nbytes, const uint64_t step, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
   // from src/collectives/device/common_kernel.h
   const int w = tid / WARP_SIZE;        // Warp number
   const int nw = nworkers / WARP_SIZE;  // Number of warps
@@ -212,8 +212,8 @@ inline __device__ void ncclNetDeviceUnpackInner(
 
   // hack head use per-warp
   head          = step;
-  g_meta_struct = ncclShmem.groups[group].devicePlugin.unpack.g_meta[index];
-  bounce_buf    = ncclShmem.devicePlugin.unpack.bounce_buf;
+  g_meta_struct = ncclShmem->groups[group].devicePlugin.unpack.g_meta[index];
+  bounce_buf    = ncclShmem->devicePlugin.unpack.bounce_buf;
 
   __syncwarp();
 
@@ -224,7 +224,7 @@ inline __device__ void ncclNetDeviceUnpackInner(
   // Currently, even/odd groups perform send/recv separately. We don't really need space for send side.
   // Total size is N page per warp * 16 B per page * 20 WARPS max = 320 * N bytes, N == WARP_SHM_PAGE_CNT
   static_assert(ncclShmemScratchWarpSize() >= WARP_SHM_SIZE, "Each warp must have enough scratch space");
-  s_meta = (loadMeta*) ncclScratchForWarp(tidInBlock / WARP_SIZE); // (loadMeta*) (ncclShmem.devicePlugin.unpack.meta + shm_off);
+  s_meta = (loadMeta*) ncclScratchForWarp(ncclShmemPerWarp, tidInBlock / WARP_SIZE); // (loadMeta*) (ncclShmem.devicePlugin.unpack.meta + shm_off);
 
   load64gpu(g_meta_struct->cnt + head, meta_cnt);
 

--- a/projects/rccl/src/device/network/unpack/unpack.h
+++ b/projects/rccl/src/device/network/unpack/unpack.h
@@ -31,24 +31,24 @@ inline __device__ void load64gpu(const uint64_t* ptr, uint64_t &v) {
 #define DATA_LOAD_SIZE 16
 
 // Map internal association of handle with group and peer index (called once at init time)
-inline __device__ void ncclNetDeviceUnpackSetup(void* ohandle, const int group, const int index, struct ncclShmemData* ncclShmem) {
+inline __device__ void ncclNetDeviceUnpackSetup(void* ohandle, const int group, const int index, ncclShmemData& ncclShmem) {
   struct unpackNetDeviceHandle* handle = (struct unpackNetDeviceHandle*) ohandle;
   // coverity[index_parm:FALSE]
-  ncclShmem->groups[group].devicePlugin.unpack.g_meta[index] = handle->meta;
-  ncclShmem->devicePlugin.unpack.bounce_buf = handle->bounce_buf;
+  ncclShmem.groups[group].devicePlugin.unpack.g_meta[index] = handle->meta;
+  ncclShmem.devicePlugin.unpack.bounce_buf = handle->bounce_buf;
   // coverity[index_parm:FALSE]
-  ncclShmem->groups[group].devicePlugin.unpack.head[index] = handle->head;
+  ncclShmem.groups[group].devicePlugin.unpack.head[index] = handle->head;
 }
 
-inline __device__ void ncclNetDeviceIncrementHead(const int group, const int index, struct ncclShmemData* ncclShmem) {
+inline __device__ void ncclNetDeviceIncrementHead(const int group, const int index, ncclShmemData& ncclShmem) {
   // coverity[index_parm:FALSE]
-  ncclShmem->groups[group].devicePlugin.unpack.head[index]++;
+  ncclShmem.groups[group].devicePlugin.unpack.head[index]++;
 }
 
-inline __device__ void ncclNetDeviceSaveHead(void* ohandle, const int group, const int index, struct ncclShmemData* ncclShmem) {
+inline __device__ void ncclNetDeviceSaveHead(void* ohandle, const int group, const int index, ncclShmemData& ncclShmem) {
   struct unpackNetDeviceHandle* handle = (struct unpackNetDeviceHandle*) ohandle;
   // coverity[index_parm:FALSE]
-  handle->head = ncclShmem->groups[group].devicePlugin.unpack.head[index];
+  handle->head = ncclShmem.groups[group].devicePlugin.unpack.head[index];
 }
 
 template <uint8_t sz>
@@ -164,21 +164,21 @@ inline __device__ int ppw(const int nbytes, int nw) {
 // threads
 template <int Recv>
 inline __device__ void ncclNetDeviceUnpack(
-    const int tid, const int tidInBlock, const int nworkers, const int group, int mask, int Src, int workSize, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp);
+    const int tid, const int tidInBlock, const int nworkers, const int group, int mask, int Src, int workSize, ncclShmemData& ncclShmem, void* ncclShmemPerWarp);
 
 template <>
 inline __device__ void ncclNetDeviceUnpack</*Recv=*/0>(
-    const int tid, const int tidInBlock, const int nworkers, const int group, int mask, int Src, int workSize, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    const int tid, const int tidInBlock, const int nworkers, const int group, int mask, int Src, int workSize, ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
   // send unpack empty
 }
 
 inline __device__ void ncclNetDeviceUnpackInner(
     const int tid, const int tidInBlock, const int nworkers, const int group, const int index,
-    void *src, const int nbytes, const uint64_t step, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp);
+    void *src, const int nbytes, const uint64_t step, ncclShmemData& ncclShmem, void* ncclShmemPerWarp);
 
 template <>
 inline __device__ void ncclNetDeviceUnpack</*Recv=*/1>(
-    const int tid, const int tidInBlock, const int nworkers, const int group, int mask, int Src, int workSize, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    const int tid, const int tidInBlock, const int nworkers, const int group, int mask, int Src, int workSize, ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 
   while (mask != 0) {
     int ix = __ffs(mask)-1; // Get the first set bit of the mask (this should correlate to a peer index)
@@ -187,13 +187,13 @@ inline __device__ void ncclNetDeviceUnpack</*Recv=*/1>(
     // Pack data from the internal iovec to the supplied flat srcs buffer using all the threads
     // + Src is necessary in the case of accessing the user buffer directly
     ncclNetDeviceUnpackInner(tid, tidInBlock, nworkers, group /* in case they need to use split warps shared memory partitioning*/,
-      ix, ncclShmem->groups[group].srcs[ix + Src], workSize, ncclShmem->groups[group].devicePlugin.unpack.head[ix], ncclShmem, ncclShmemPerWarp);
+      ix, ncclShmem.groups[group].srcs[ix + Src], workSize, ncclShmem.groups[group].devicePlugin.unpack.head[ix], ncclShmem, ncclShmemPerWarp);
   }
 }
 
 inline __device__ void ncclNetDeviceUnpackInner(
     const int tid, const int tidInBlock, const int nworkers, const int group, const int index,
-    void *src, const int nbytes, const uint64_t step, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    void *src, const int nbytes, const uint64_t step, ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
   // from src/collectives/device/common_kernel.h
   const int w = tid / WARP_SIZE;        // Warp number
   const int nw = nworkers / WARP_SIZE;  // Number of warps
@@ -212,8 +212,8 @@ inline __device__ void ncclNetDeviceUnpackInner(
 
   // hack head use per-warp
   head          = step;
-  g_meta_struct = ncclShmem->groups[group].devicePlugin.unpack.g_meta[index];
-  bounce_buf    = ncclShmem->devicePlugin.unpack.bounce_buf;
+  g_meta_struct = ncclShmem.groups[group].devicePlugin.unpack.g_meta[index];
+  bounce_buf    = ncclShmem.devicePlugin.unpack.bounce_buf;
 
   __syncwarp();
 

--- a/projects/rccl/src/device/primitives.h
+++ b/projects/rccl/src/device/primitives.h
@@ -31,8 +31,8 @@
       while (__hip_atomic_load((BARRIERS_PTR), __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_WORKGROUP) < (BARRIER_NEXT)) { \
         spins++; \
         if (spins == NCCL_SPINS_BEFORE_CHECK_ABORT) { \
-          if (__atomic_load_n((ncclShmem)->comm.abortFlag, __ATOMIC_SEQ_CST)) { \
-            (ncclShmem)->aborted = 1; \
+          if (__atomic_load_n((ncclShmem).comm.abortFlag, __ATOMIC_SEQ_CST)) { \
+            (ncclShmem).aborted = 1; \
             break; \
           } \
           spins = 0; \
@@ -65,8 +65,8 @@ struct ProtoSimple {
   static constexpr int MultimemDsts = MultimemDsts_1;
 
   // Data bytes (no flags etc) in one step of the fifo queue.
-  __device__ static int calcBytePerStep(struct ncclShmemData* ncclShmem) {
-    return ncclShmem->comm.buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS;
+  __device__ static int calcBytePerStep(struct ncclShmemData& ncclShmem) {
+    return ncclShmem.comm.buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS;
   }
   // Granularity of data bytes transferred per thread.
   __device__ static int calcBytePerGrain() {
@@ -80,8 +80,8 @@ struct ProtoLL {
   static constexpr int Id = NCCL_PROTO_LL;
 
   // Data bytes (no flags etc) in one step of the fifo queue.
-  __device__ static int calcBytePerStep(struct ncclShmemData* ncclShmem) {
-    return ncclShmem->comm.buffSizes[NCCL_PROTO_LL]/NCCL_STEPS/2; // Half is data
+  __device__ static int calcBytePerStep(struct ncclShmemData& ncclShmem) {
+    return ncclShmem.comm.buffSizes[NCCL_PROTO_LL]/NCCL_STEPS/2; // Half is data
   }
   // Granularity of data bytes transferred per thread.
   __device__ static int calcBytePerGrain() {
@@ -95,8 +95,8 @@ struct ProtoLL128 {
   static constexpr int Id = NCCL_PROTO_LL128;
 
   // Data bytes (no flags etc) in one step of the fifo queue.
-  __device__ static int calcBytePerStep(struct ncclShmemData* ncclShmem) {
-    return (ncclShmem->comm.buffSizes[NCCL_PROTO_LL128]/NCCL_STEPS)*NCCL_LL128_DATAELEMS/NCCL_LL128_LINEELEMS;
+  __device__ static int calcBytePerStep(struct ncclShmemData& ncclShmem) {
+    return (ncclShmem.comm.buffSizes[NCCL_PROTO_LL128]/NCCL_STEPS)*NCCL_LL128_DATAELEMS/NCCL_LL128_LINEELEMS;
   }
   // Granularity of data bytes transferred per thread.
   __device__ static int calcBytePerGrain() {
@@ -173,13 +173,13 @@ struct PrimitivesWithoutDirect {
   }
 };
 
-__device__ inline int checkAbort(int &abortCache, const int abortValue, int &spins, struct ncclShmemData* ncclShmem) {
+__device__ inline int checkAbort(int &abortCache, const int abortValue, int &spins, struct ncclShmemData& ncclShmem) {
   if (abortCache & abortValue) return 1;
   if (++spins < NCCL_SPINS_BEFORE_CHECK_ABORT) return 0;
   spins = 0;
-  int abort = __atomic_load_n((ncclShmem->comm.abortFlag), __ATOMIC_SEQ_CST);
+  int abort = __atomic_load_n((ncclShmem.comm.abortFlag), __ATOMIC_SEQ_CST);
   if (abort) {
-    __atomic_store_n(&ncclShmem->aborted, abort, __ATOMIC_SEQ_CST);
+    __atomic_store_n(&ncclShmem.aborted, abort, __ATOMIC_SEQ_CST);
     abortCache |= abortValue;
   }
   return abort;

--- a/projects/rccl/src/device/primitives.h
+++ b/projects/rccl/src/device/primitives.h
@@ -16,7 +16,7 @@
 #include "common.h"
 
 #define NCCL_SPINS_BEFORE_CHECK_ABORT 10000
-#define barrier_generic(__THREAD_FENCE, NWORKERS, BARRIER_NEXT, BARRIERS_PTR) do { \
+#define barrier_generic(__THREAD_FENCE, NWORKERS, BARRIER_NEXT, BARRIERS_PTR, ncclShmem) do { \
   if (nthreads == threadsPerBlock) { \
     __THREAD_FENCE; __builtin_amdgcn_s_barrier(); \
   } else { \
@@ -31,15 +31,15 @@
       while (__hip_atomic_load((BARRIERS_PTR), __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_WORKGROUP) < (BARRIER_NEXT)) { \
         spins++; \
         if (spins == NCCL_SPINS_BEFORE_CHECK_ABORT) { \
-          if (__atomic_load_n(ncclShmem.comm.abortFlag, __ATOMIC_SEQ_CST)) { \
-            ncclShmem.aborted = 1; \
+          if (__atomic_load_n((ncclShmem)->comm.abortFlag, __ATOMIC_SEQ_CST)) { \
+            (ncclShmem)->aborted = 1; \
             break; \
           } \
           spins = 0; \
         } \
         if (spins == 0 && rate_limit > 0) { \
           rate_limit--; \
-          traceData(__LINE__, threadIdx.x, __hip_atomic_load((BARRIERS_PTR), __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_WORKGROUP), (BARRIER_NEXT)); \
+          traceData((ncclShmem), __LINE__, threadIdx.x, __hip_atomic_load((BARRIERS_PTR), __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_WORKGROUP), (BARRIER_NEXT)); \
         } \
         __builtin_amdgcn_s_sleep(1); \
       } \
@@ -65,8 +65,8 @@ struct ProtoSimple {
   static constexpr int MultimemDsts = MultimemDsts_1;
 
   // Data bytes (no flags etc) in one step of the fifo queue.
-  __device__ static int calcBytePerStep() {
-    return ncclShmem.comm.buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS;
+  __device__ static int calcBytePerStep(struct ncclShmemData* ncclShmem) {
+    return ncclShmem->comm.buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS;
   }
   // Granularity of data bytes transferred per thread.
   __device__ static int calcBytePerGrain() {
@@ -80,8 +80,8 @@ struct ProtoLL {
   static constexpr int Id = NCCL_PROTO_LL;
 
   // Data bytes (no flags etc) in one step of the fifo queue.
-  __device__ static int calcBytePerStep() {
-    return ncclShmem.comm.buffSizes[NCCL_PROTO_LL]/NCCL_STEPS/2; // Half is data
+  __device__ static int calcBytePerStep(struct ncclShmemData* ncclShmem) {
+    return ncclShmem->comm.buffSizes[NCCL_PROTO_LL]/NCCL_STEPS/2; // Half is data
   }
   // Granularity of data bytes transferred per thread.
   __device__ static int calcBytePerGrain() {
@@ -95,8 +95,8 @@ struct ProtoLL128 {
   static constexpr int Id = NCCL_PROTO_LL128;
 
   // Data bytes (no flags etc) in one step of the fifo queue.
-  __device__ static int calcBytePerStep() {
-    return (ncclShmem.comm.buffSizes[NCCL_PROTO_LL128]/NCCL_STEPS)*NCCL_LL128_DATAELEMS/NCCL_LL128_LINEELEMS;
+  __device__ static int calcBytePerStep(struct ncclShmemData* ncclShmem) {
+    return (ncclShmem->comm.buffSizes[NCCL_PROTO_LL128]/NCCL_STEPS)*NCCL_LL128_DATAELEMS/NCCL_LL128_LINEELEMS;
   }
   // Granularity of data bytes transferred per thread.
   __device__ static int calcBytePerGrain() {
@@ -173,13 +173,13 @@ struct PrimitivesWithoutDirect {
   }
 };
 
-__device__ inline int checkAbort(int &abortCache, const int abortValue, int &spins) {
+__device__ inline int checkAbort(int &abortCache, const int abortValue, int &spins, struct ncclShmemData* ncclShmem) {
   if (abortCache & abortValue) return 1;
   if (++spins < NCCL_SPINS_BEFORE_CHECK_ABORT) return 0;
   spins = 0;
-  int abort = __atomic_load_n((ncclShmem.comm.abortFlag), __ATOMIC_SEQ_CST);
+  int abort = __atomic_load_n((ncclShmem->comm.abortFlag), __ATOMIC_SEQ_CST);
   if (abort) {
-    __atomic_store_n(&ncclShmem.aborted, abort, __ATOMIC_SEQ_CST);
+    __atomic_store_n(&ncclShmem->aborted, abort, __ATOMIC_SEQ_CST);
     abortCache |= abortValue;
   }
   return abort;

--- a/projects/rccl/src/device/prims_ll.h
+++ b/projects/rccl/src/device/prims_ll.h
@@ -44,6 +44,8 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
   union ncclLLFifoLine* recvBuff[MaxRecv];
   union ncclLLFifoLine* sendBuff[MaxSend];
 
+  struct ncclShmemData* ncclShmem; // Pointer to shared memory
+
 #if defined(ENABLE_NPKIT)
 public:
   int npKitCtxIdx = 0;
@@ -74,9 +76,9 @@ private:
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
     if (nthreads != WARP_SIZE)
       #if defined(__gfx942__) || (defined(__gfx950__) && defined(HIP_HOST_UNCACHED_MEMORY))
-        barrier_generic(__threadfence_block(), nthreads, barrier_next, barriers);
+        barrier_generic(__threadfence_block(), nthreads, barrier_next, barriers, ncclShmem);
       #else
-        barrier_generic(__threadfence(), nthreads, barrier_next, barriers);
+        barrier_generic(__threadfence(), nthreads, barrier_next, barriers, ncclShmem);
       #endif
 #else
     if (nthreads == WARP_SIZE) {
@@ -91,10 +93,10 @@ private:
 
   __device__ inline int checkAbort(int &abortCache, const int abortValue, int &spins) {
     if (abortCache == 0 && ++spins == NCCL_SPINS_BEFORE_CHECK_ABORT) {
-      int abort = __atomic_load_n((ncclShmem.comm.abortFlag), __ATOMIC_SEQ_CST);
+      int abort = __atomic_load_n((ncclShmem->comm.abortFlag), __ATOMIC_SEQ_CST);
       spins = 0;
       if (abort) {
-        __atomic_store_n(&ncclShmem.aborted, abort, __ATOMIC_SEQ_CST);
+        __atomic_store_n(&ncclShmem->aborted, abort, __ATOMIC_SEQ_CST);
         abortCache |= abortValue;
       }
     }
@@ -105,7 +107,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_LL_WAIT_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_LL_WAIT_SEND_ENTRY, nbytes, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     if (sendConnHeadPtr) {
@@ -125,7 +127,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_LL_WAIT_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_LL_WAIT_SEND_EXIT, nbytes, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -437,7 +439,7 @@ private:
       npKitWaitRecvTotalTime = 0;
       npKitWaitRecvDataProcessSize = nelem*sizeof(T);
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_LL_DATA_PROCESS_ENTRY,
-          npKitWaitRecvDataProcessSize, 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          npKitWaitRecvDataProcessSize, 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -525,7 +527,7 @@ private:
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_LL_DATA_PROCESS_EXIT,
           npKitWaitRecvDataProcessSize, npKitWaitRecvTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -547,7 +549,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_GENERIC_OP_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_GENERIC_OP_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -611,7 +613,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_GENERIC_OP_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_GENERIC_OP_EXIT, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -645,21 +647,26 @@ private:
   }
 
 public:
-  __device__  Primitives(
+  __device__ Primitives(
       const int tid, const int nthreads, int const *recvPeers, int const *sendPeers,
-      void const *inputBuf, void *outputBuf, uint64_t redOpArg, uint8_t group=0,
-      uint8_t connIndexRecv=0, uint8_t connIndexSend=0, struct ncclDevWorkColl* e = nullptr,
-      bool ipcReg = false, bool netReg = false, int stepSize_ = 0
+      void const *inputBuf, void *outputBuf, uint64_t redOpArg,
+      struct ncclShmemData* shmem, void* ncclShmemPerWarp_,
+      uint8_t group=0, uint8_t connIndexRecv=0, uint8_t connIndexSend=0,
+      struct ncclDevWorkColl* e = nullptr, struct ncclDevWorkP2p* p2pWork = nullptr,
+      int stepSize_ = 0, int mode = primsModeDefault
     ):
     redOp(redOpArg),
     tid(tid), nthreads(nthreads), wid(tid%WARP_SIZE), group(group), threadsPerBlock(blockDim.x),
-    stepLines(ncclShmem.comm.buffSizes[NCCL_PROTO_LL]/NCCL_STEPS/sizeof(ncclLLFifoLine)) {
+    stepLines(shmem->comm.buffSizes[NCCL_PROTO_LL]/NCCL_STEPS/sizeof(ncclLLFifoLine)),
+    ncclShmem(shmem) {
+    // Suppress unused-parameter warnings — these exist for signature uniformity with ProtoSimple/ProtoLL128
+    (void)ncclShmemPerWarp_; (void)p2pWork; (void)stepSize_; (void)mode;
 #ifdef ENABLE_WARP_SPEED
-    auto *channel = isMsccl(Metadata) ? &ncclShmem.channel : &ncclShmem.warpChannel[threadIdx.x / WARP_SIZE];
+    auto *channel = isMsccl(Metadata) ? &ncclShmem->channel : &ncclShmem->warpChannel[threadIdx.x / WARP_SIZE];
 #else
-    auto *channel = &ncclShmem.channel;
+    auto *channel = &ncclShmem->channel;
 #endif
-    barriers = &ncclShmem.groups[group].barrier;
+    barriers = &ncclShmem->groups[group].barrier;
     // If we are going to support oneshot collNet + LL, then we would need to add connector index here
     int nrecv=0, nsend=0;
     // We compare with Fan::MaxRecv here because this->MaxRecv is always at least 1
@@ -709,14 +716,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     LLGenericOp<0, 1, Input, -1>(inpIx, -1, eltN, false);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -724,14 +731,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_FROM_OUTPUT_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_FROM_OUTPUT_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     LLGenericOp<0, 1, Output, -1>(outIx, -1, eltN, false);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_FROM_OUTPUT_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_FROM_OUTPUT_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -739,14 +746,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     LLGenericOp<1, 0, -1, Output>(-1, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -754,14 +761,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     LLGenericOp<1, 1, Input, -1>(inpIx, -1, eltN, false);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -769,14 +776,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_COPY_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_COPY_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     LLGenericOp<1, 0, Input, Output>(inpIx, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_COPY_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_COPY_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -784,14 +791,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_COPY_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_COPY_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     LLGenericOp<0, 1, Input, Output>(inpIx, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_COPY_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_COPY_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -799,14 +806,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_COPY_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_COPY_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     LLGenericOp<1, 1, -1, Output>(-1, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_COPY_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_COPY_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -814,14 +821,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_COPY_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_COPY_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     LLGenericOp<1, 1, Input, Output>(inpIx, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_COPY_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_COPY_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }

--- a/projects/rccl/src/device/prims_ll.h
+++ b/projects/rccl/src/device/prims_ll.h
@@ -1,3 +1,5 @@
+#ifndef NCCL_DEVICE_PRIMS_LL_H_
+#define NCCL_DEVICE_PRIMS_LL_H_
 /*************************************************************************
  * Copyright (c) 2016-2022, NVIDIA CORPORATION. All rights reserved.
  * Modifications Copyright (c) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
@@ -846,3 +848,5 @@ public:
     return mscclGenericOp<0,1,0,0>(&srcs, 1, &dsts, 1, eltN);
   }
 };
+
+#endif // NCCL_DEVICE_PRIMS_LL_H_

--- a/projects/rccl/src/device/prims_ll.h
+++ b/projects/rccl/src/device/prims_ll.h
@@ -44,7 +44,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
   union ncclLLFifoLine* recvBuff[MaxRecv];
   union ncclLLFifoLine* sendBuff[MaxSend];
 
-  struct ncclShmemData* ncclShmem; // Pointer to shared memory
+  struct ncclShmemData& ncclShmem;
 
 #if defined(ENABLE_NPKIT)
 public:
@@ -93,10 +93,10 @@ private:
 
   __device__ inline int checkAbort(int &abortCache, const int abortValue, int &spins) {
     if (abortCache == 0 && ++spins == NCCL_SPINS_BEFORE_CHECK_ABORT) {
-      int abort = __atomic_load_n((ncclShmem->comm.abortFlag), __ATOMIC_SEQ_CST);
+      int abort = __atomic_load_n((ncclShmem.comm.abortFlag), __ATOMIC_SEQ_CST);
       spins = 0;
       if (abort) {
-        __atomic_store_n(&ncclShmem->aborted, abort, __ATOMIC_SEQ_CST);
+        __atomic_store_n(&ncclShmem.aborted, abort, __ATOMIC_SEQ_CST);
         abortCache |= abortValue;
       }
     }
@@ -107,7 +107,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_LL_WAIT_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_LL_WAIT_SEND_ENTRY, nbytes, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     if (sendConnHeadPtr) {
@@ -127,7 +127,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_LL_WAIT_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_LL_WAIT_SEND_EXIT, nbytes, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -439,7 +439,7 @@ private:
       npKitWaitRecvTotalTime = 0;
       npKitWaitRecvDataProcessSize = nelem*sizeof(T);
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_LL_DATA_PROCESS_ENTRY,
-          npKitWaitRecvDataProcessSize, 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          npKitWaitRecvDataProcessSize, 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -527,7 +527,7 @@ private:
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_LL_DATA_PROCESS_EXIT,
           npKitWaitRecvDataProcessSize, npKitWaitRecvTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -549,7 +549,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_GENERIC_OP_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_GENERIC_OP_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -613,7 +613,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_GENERIC_OP_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_GENERIC_OP_EXIT, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -650,23 +650,23 @@ public:
   __device__ Primitives(
       const int tid, const int nthreads, int const *recvPeers, int const *sendPeers,
       void const *inputBuf, void *outputBuf, uint64_t redOpArg,
-      struct ncclShmemData* shmem, void* ncclShmemPerWarp_,
+      struct ncclShmemData& shmem, void* ncclShmemPerWarp_,
       uint8_t group=0, uint8_t connIndexRecv=0, uint8_t connIndexSend=0,
       struct ncclDevWorkColl* e = nullptr, struct ncclDevWorkP2p* p2pWork = nullptr,
       int stepSize_ = 0, int mode = primsModeDefault
     ):
     redOp(redOpArg),
     tid(tid), nthreads(nthreads), wid(tid%WARP_SIZE), group(group), threadsPerBlock(blockDim.x),
-    stepLines(shmem->comm.buffSizes[NCCL_PROTO_LL]/NCCL_STEPS/sizeof(ncclLLFifoLine)),
+    stepLines(shmem.comm.buffSizes[NCCL_PROTO_LL]/NCCL_STEPS/sizeof(ncclLLFifoLine)),
     ncclShmem(shmem) {
     // Suppress unused-parameter warnings — these exist for signature uniformity with ProtoSimple/ProtoLL128
     (void)ncclShmemPerWarp_; (void)p2pWork; (void)stepSize_; (void)mode;
 #ifdef ENABLE_WARP_SPEED
-    auto *channel = isMsccl(Metadata) ? &ncclShmem->channel : &ncclShmem->warpChannel[threadIdx.x / WARP_SIZE];
+    auto *channel = isMsccl(Metadata) ? &ncclShmem.channel : &ncclShmem.warpChannel[threadIdx.x / WARP_SIZE];
 #else
-    auto *channel = &ncclShmem->channel;
+    auto *channel = &ncclShmem.channel;
 #endif
-    barriers = &ncclShmem->groups[group].barrier;
+    barriers = &ncclShmem.groups[group].barrier;
     // If we are going to support oneshot collNet + LL, then we would need to add connector index here
     int nrecv=0, nsend=0;
     // We compare with Fan::MaxRecv here because this->MaxRecv is always at least 1
@@ -716,14 +716,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     LLGenericOp<0, 1, Input, -1>(inpIx, -1, eltN, false);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -731,14 +731,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_FROM_OUTPUT_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_FROM_OUTPUT_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     LLGenericOp<0, 1, Output, -1>(outIx, -1, eltN, false);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_FROM_OUTPUT_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_FROM_OUTPUT_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -746,14 +746,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     LLGenericOp<1, 0, -1, Output>(-1, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -761,14 +761,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     LLGenericOp<1, 1, Input, -1>(inpIx, -1, eltN, false);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -776,14 +776,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_COPY_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_COPY_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     LLGenericOp<1, 0, Input, Output>(inpIx, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_COPY_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_COPY_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -791,14 +791,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_COPY_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_COPY_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     LLGenericOp<0, 1, Input, Output>(inpIx, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_COPY_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_COPY_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -806,14 +806,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_COPY_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_COPY_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     LLGenericOp<1, 1, -1, Output>(-1, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_COPY_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_COPY_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -821,14 +821,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_COPY_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_COPY_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     LLGenericOp<1, 1, Input, Output>(inpIx, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_COPY_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_COPY_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }

--- a/projects/rccl/src/device/prims_ll128.h
+++ b/projects/rccl/src/device/prims_ll128.h
@@ -64,6 +64,8 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
 
   uint64_t* barriers;
   uint64_t barrier_next = 0;
+  struct ncclShmemData* ncclShmem;
+  void* ncclShmemPerWarp;
 
 #if defined(ENABLE_NPKIT)
 public:
@@ -85,9 +87,9 @@ private:
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   if (nthreads != WARP_SIZE)
     #if defined(__gfx942__) || defined(__gfx950__)
-      barrier_generic(__threadfence_block(), nthreads, barrier_next, barriers);
+      barrier_generic(__threadfence_block(), nthreads, barrier_next, barriers, ncclShmem);
     #else
-      barrier_generic(__threadfence(), nthreads, barrier_next, barriers);
+      barrier_generic(__threadfence(), nthreads, barrier_next, barriers, ncclShmem);
     #endif
 #else
    barrier_sync(15-group, nthreads);
@@ -98,10 +100,10 @@ private:
 
   __device__ inline int checkAbort(int &abortCache, const int abortValue, int &spins) {
     if (abortCache == 0 && ++spins == NCCL_SPINS_BEFORE_CHECK_ABORT) {
-      int abort = __atomic_load_n((ncclShmem.comm.abortFlag), __ATOMIC_SEQ_CST);
+      int abort = __atomic_load_n((ncclShmem->comm.abortFlag), __ATOMIC_SEQ_CST);
       spins = 0;
       if (abort) {
-        __atomic_store_n(&ncclShmem.aborted, abort, __ATOMIC_SEQ_CST);
+        __atomic_store_n(&ncclShmem->aborted, abort, __ATOMIC_SEQ_CST);
         abortCache |= abortValue;
       }
     }
@@ -112,7 +114,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_LL128_WAIT_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_LL128_WAIT_SEND_ENTRY, nbytes, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     if (sendConnHeadPtr) {
@@ -130,7 +132,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_LL128_WAIT_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_LL128_WAIT_SEND_EXIT, nbytes, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -179,7 +181,7 @@ private:
       // buffer into shmem.
       int misalignment = reinterpret_cast<uintptr_t>(src) % 16;
       uint64_t *src8 = reinterpret_cast<uint64_t*>(reinterpret_cast<uintptr_t>(src) & -uintptr_t(16));
-      uint64_t *shm8 = shmemCvtPtr((uint64_t*)ncclScratchForWarp(warpInBlock));
+      uint64_t *shm8 = shmemCvtPtr((uint64_t*)ncclScratchForWarp(ncclShmemPerWarp, warpInBlock));
       #pragma unroll
       for(int g=0; g < WordPerThread/2; g++)
         if((g*WARP_SIZE + wid)*16 < misalignment + eltN*sizeof(T))
@@ -224,7 +226,7 @@ private:
 
     // Write to dst if 4-byte aligned, shmem otherwise.
     int misalignment = reinterpret_cast<uintptr_t>(dst)%16;
-    uint64_t *shm8 = shmemCvtPtr((uint64_t*)ncclScratchForWarp(warpInBlock));
+    uint64_t *shm8 = shmemCvtPtr((uint64_t*)ncclScratchForWarp(ncclShmemPerWarp, warpInBlock));
     #pragma unroll
     for(int g=0; g < WordPerThread/2; g++) {
       int ix = g*WARP_SIZE - 16*(g/2) + wid - (g%2)*(wid/4);
@@ -238,7 +240,7 @@ private:
     __syncwarp();
     // Write rest from shmem to dst. No need to coalesce stores to 16-bytes,
     // the hardware keeps up fine.
-    T *shm = (T*)ncclScratchForWarp(warpInBlock);
+    T *shm = (T*)ncclScratchForWarp(ncclShmemPerWarp, warpInBlock);
     int skip = misalignment == 0 ? eltN & -EltPer16B : 0;
     for(int i=skip+wid; i < eltN; i += WARP_SIZE)
       dst[i] = shm[i];
@@ -382,7 +384,7 @@ private:
       npKitWaitRecvTotalTime = 0;
       npKitWaitRecvDataProcessSize = nelem*sizeof(T);
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_LL128_DATA_PROCESS_ENTRY,
-          npKitWaitRecvDataProcessSize, 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          npKitWaitRecvDataProcessSize, 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -435,7 +437,7 @@ private:
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_LL128_DATA_PROCESS_EXIT,
           npKitWaitRecvDataProcessSize, npKitWaitRecvTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -450,7 +452,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_GENERIC_OP_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_GENERIC_OP_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -529,7 +531,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_GENERIC_OP_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_GENERIC_OP_EXIT, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -571,20 +573,24 @@ private:
 public:
   __device__ Primitives(
       const int tid, const int nthreads, int const *recvPeers, int const *sendPeers,
-      void const *inputBuf, void *outputBuf, uint64_t redOpArg, uint8_t group=0,
-      uint8_t connIndexRecv=0, uint8_t connIndexSend=0, struct ncclDevWorkColl* e = nullptr,
-      bool ipcReg = false, bool netReg = false, int stepSize_ = 0
+      void const *inputBuf, void *outputBuf, uint64_t redOpArg,
+      struct ncclShmemData* shmem, void* ncclShmemPerWarp_,
+      uint8_t group=0, uint8_t connIndexRecv=0, uint8_t connIndexSend=0,
+      struct ncclDevWorkColl* e = nullptr, struct ncclDevWorkP2p* p2pWork = nullptr,
+      int stepSize_ = 0, int mode = primsModeDefault
     ):
     redOp(redOpArg),
     tid(tid), nthreads(nthreads), wid(tid%WARP_SIZE),                                /*compiler warnings*/
-    stepSize(ncclShmem.comm.buffSizes[NCCL_PROTO_LL128]/NCCL_STEPS/sizeof(uint64_t)),
-    warp(tid/WARP_SIZE), warpInBlock(threadIdx.x/WARP_SIZE), flagThread((tid%4)==3), group(group), threadsPerBlock(blockDim.x){
+    stepSize(shmem->comm.buffSizes[NCCL_PROTO_LL128]/NCCL_STEPS/sizeof(uint64_t)),
+    warp(tid/WARP_SIZE), warpInBlock(threadIdx.x/WARP_SIZE), flagThread((tid%4)==3), group(group), threadsPerBlock(blockDim.x), ncclShmem(shmem), ncclShmemPerWarp(ncclShmemPerWarp_){
+    // Suppress unused-parameter warnings — these exist for signature uniformity with ProtoSimple
+    (void)p2pWork; (void)stepSize_; (void)mode;
 #ifdef ENABLE_WARP_SPEED
-    auto *channel = isMsccl(Metadata) ? &ncclShmem.channel : &ncclShmem.warpChannel[warpInBlock];
+    auto *channel = isMsccl(Metadata) ? &shmem->channel : &shmem->warpChannel[warpInBlock];
 #else
-    auto *channel = &ncclShmem.channel;
+    auto *channel = &shmem->channel;
 #endif
-    barriers = &ncclShmem.groups[group].barrier;
+    barriers = &shmem->groups[group].barrier;
     int nrecv=0, nsend=0;
     while (nrecv < MaxRecv && recvPeers[nrecv] >= 0) {
       loadRecvConn(&channel->peers[recvPeers[nrecv]]->recv[connIndexRecv], nrecv);
@@ -629,7 +635,7 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     GenericOp<0, 1, Input, -1>(inpIx, -1, eltN, false);
@@ -637,7 +643,7 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -645,14 +651,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_FROM_OUTPUT_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_FROM_OUTPUT_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     GenericOp<0, 1, Output, -1>(outIx, -1, eltN, false);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_FROM_OUTPUT_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_FROM_OUTPUT_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -660,14 +666,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     GenericOp<1, 0, -1, Output>(-1, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -675,14 +681,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     GenericOp<1, 1, Input, -1>(inpIx, -1, eltN, false);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -690,14 +696,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_COPY_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_COPY_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     GenericOp<1, 0, Input, Output>(inpIx, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_COPY_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_COPY_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -705,14 +711,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_COPY_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_COPY_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     GenericOp<0, 1, Input, Output>(inpIx, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_COPY_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_COPY_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -720,14 +726,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_COPY_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_COPY_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     GenericOp<1, 1, -1, Output>(-1, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_COPY_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_COPY_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -735,14 +741,14 @@ public:
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_COPY_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_COPY_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     GenericOp<1, 1, Input, Output>(inpIx, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_COPY_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_COPY_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }

--- a/projects/rccl/src/device/prims_ll128.h
+++ b/projects/rccl/src/device/prims_ll128.h
@@ -64,7 +64,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
 
   uint64_t* barriers;
   uint64_t barrier_next = 0;
-  struct ncclShmemData* ncclShmem;
+  struct ncclShmemData& ncclShmem;
   void* ncclShmemPerWarp;
 
 #if defined(ENABLE_NPKIT)
@@ -100,10 +100,10 @@ private:
 
   __device__ inline int checkAbort(int &abortCache, const int abortValue, int &spins) {
     if (abortCache == 0 && ++spins == NCCL_SPINS_BEFORE_CHECK_ABORT) {
-      int abort = __atomic_load_n((ncclShmem->comm.abortFlag), __ATOMIC_SEQ_CST);
+      int abort = __atomic_load_n((ncclShmem.comm.abortFlag), __ATOMIC_SEQ_CST);
       spins = 0;
       if (abort) {
-        __atomic_store_n(&ncclShmem->aborted, abort, __ATOMIC_SEQ_CST);
+        __atomic_store_n(&ncclShmem.aborted, abort, __ATOMIC_SEQ_CST);
         abortCache |= abortValue;
       }
     }
@@ -114,7 +114,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_LL128_WAIT_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_LL128_WAIT_SEND_ENTRY, nbytes, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     if (sendConnHeadPtr) {
@@ -132,7 +132,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_LL128_WAIT_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_LL128_WAIT_SEND_EXIT, nbytes, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -384,7 +384,7 @@ private:
       npKitWaitRecvTotalTime = 0;
       npKitWaitRecvDataProcessSize = nelem*sizeof(T);
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_LL128_DATA_PROCESS_ENTRY,
-          npKitWaitRecvDataProcessSize, 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          npKitWaitRecvDataProcessSize, 0, NPKIT_GET_GPU_TIMESTAMP(), ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -437,7 +437,7 @@ private:
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_LL128_DATA_PROCESS_EXIT,
           npKitWaitRecvDataProcessSize, npKitWaitRecvTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -452,7 +452,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_GENERIC_OP_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_GENERIC_OP_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -531,7 +531,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_GENERIC_OP_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_GENERIC_OP_EXIT, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -574,23 +574,23 @@ public:
   __device__ Primitives(
       const int tid, const int nthreads, int const *recvPeers, int const *sendPeers,
       void const *inputBuf, void *outputBuf, uint64_t redOpArg,
-      struct ncclShmemData* shmem, void* ncclShmemPerWarp_,
+      struct ncclShmemData& shmem, void* ncclShmemPerWarp_,
       uint8_t group=0, uint8_t connIndexRecv=0, uint8_t connIndexSend=0,
       struct ncclDevWorkColl* e = nullptr, struct ncclDevWorkP2p* p2pWork = nullptr,
       int stepSize_ = 0, int mode = primsModeDefault
     ):
     redOp(redOpArg),
     tid(tid), nthreads(nthreads), wid(tid%WARP_SIZE),                                /*compiler warnings*/
-    stepSize(shmem->comm.buffSizes[NCCL_PROTO_LL128]/NCCL_STEPS/sizeof(uint64_t)),
+    stepSize(shmem.comm.buffSizes[NCCL_PROTO_LL128]/NCCL_STEPS/sizeof(uint64_t)),
     warp(tid/WARP_SIZE), warpInBlock(threadIdx.x/WARP_SIZE), flagThread((tid%4)==3), group(group), threadsPerBlock(blockDim.x), ncclShmem(shmem), ncclShmemPerWarp(ncclShmemPerWarp_){
     // Suppress unused-parameter warnings — these exist for signature uniformity with ProtoSimple
     (void)p2pWork; (void)stepSize_; (void)mode;
 #ifdef ENABLE_WARP_SPEED
-    auto *channel = isMsccl(Metadata) ? &shmem->channel : &shmem->warpChannel[warpInBlock];
+    auto *channel = isMsccl(Metadata) ? &shmem.channel : &shmem.warpChannel[warpInBlock];
 #else
-    auto *channel = &shmem->channel;
+    auto *channel = &shmem.channel;
 #endif
-    barriers = &shmem->groups[group].barrier;
+    barriers = &shmem.groups[group].barrier;
     int nrecv=0, nsend=0;
     while (nrecv < MaxRecv && recvPeers[nrecv] >= 0) {
       loadRecvConn(&channel->peers[recvPeers[nrecv]]->recv[connIndexRecv], nrecv);
@@ -635,7 +635,7 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     GenericOp<0, 1, Input, -1>(inpIx, -1, eltN, false);
@@ -643,7 +643,7 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -651,14 +651,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_FROM_OUTPUT_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_FROM_OUTPUT_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     GenericOp<0, 1, Output, -1>(outIx, -1, eltN, false);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_FROM_OUTPUT_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_FROM_OUTPUT_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -666,14 +666,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     GenericOp<1, 0, -1, Output>(-1, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -681,14 +681,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     GenericOp<1, 1, Input, -1>(inpIx, -1, eltN, false);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -696,14 +696,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_COPY_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_COPY_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     GenericOp<1, 0, Input, Output>(inpIx, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_COPY_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_COPY_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -711,14 +711,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_COPY_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_COPY_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     GenericOp<0, 1, Input, Output>(inpIx, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_COPY_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_COPY_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -726,14 +726,14 @@ public:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_COPY_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_COPY_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     GenericOp<1, 1, -1, Output>(-1, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_COPY_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_COPY_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -741,14 +741,14 @@ public:
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_COPY_SEND_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_COPY_SEND_ENTRY, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     GenericOp<1, 1, Input, Output>(inpIx, outIx, eltN, postOp);
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_RECV_REDUCE_COPY_SEND_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_RECV_REDUCE_COPY_SEND_EXIT, eltN*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }

--- a/projects/rccl/src/device/prims_ll128.h
+++ b/projects/rccl/src/device/prims_ll128.h
@@ -1,3 +1,5 @@
+#ifndef NCCL_DEVICE_PRIMS_LL128_H_
+#define NCCL_DEVICE_PRIMS_LL128_H_
 /*************************************************************************
  * Copyright (c) 2016-2022, NVIDIA CORPORATION. All rights reserved.
  * Modifications Copyright (c) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
@@ -764,3 +766,5 @@ public:
     return mscclGenericOp<0,1,0,0>(&srcs, 1, &dsts, 1, eltN);
   }
 };
+
+#endif // NCCL_DEVICE_PRIMS_LL128_H_

--- a/projects/rccl/src/device/prims_simple.h
+++ b/projects/rccl/src/device/prims_simple.h
@@ -69,6 +69,8 @@ class Primitives<
   uint64_t barrier_next_pat = 0;
   int repeat;
   bool skip_fence = 0;
+  struct ncclShmemData* ncclShmem;
+  void* ncclShmemPerWarp;
 
 #if defined(ENABLE_NPKIT)
 public:
@@ -85,9 +87,9 @@ private:
       __syncwarp();
     else
       #if defined(__gfx942__) || defined(__gfx950__)
-        barrier_generic(__threadfence_block(), nworkers, barrier_next, barriers);
+        barrier_generic(__threadfence_block(), nworkers, barrier_next, barriers, ncclShmem);
       #else
-        barrier_generic(__threadfence(), nworkers, barrier_next, barriers);
+        barrier_generic(__threadfence(), nworkers, barrier_next, barriers, ncclShmem);
       #endif
   }
   inline __device__ void subBarrier() {
@@ -98,9 +100,9 @@ private:
 
   inline __device__ void patBarrier() {
     #if defined(__gfx942__) || defined(__gfx950__)
-      barrier_generic(__threadfence_block(), NCCL_PAT_NWORKERS, barrier_next_pat, barriers_pat);
+      barrier_generic(__threadfence_block(), NCCL_PAT_NWORKERS, barrier_next_pat, barriers_pat, ncclShmem);
     #else
-      barrier_generic(__threadfence(), NCCL_PAT_NWORKERS, barrier_next_pat, barriers_pat);
+      barrier_generic(__threadfence(), NCCL_PAT_NWORKERS, barrier_next_pat, barriers_pat, ncclShmem);
     #endif
   }
 
@@ -134,7 +136,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_SIMPLE_WAIT_PEER_ENTRY)
     if (threadIdx.x == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_SIMPLE_WAIT_PEER_ENTRY, nelts*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     const bool isSendNotRecv = (Send && Recv) ? (flags & RoleWaitSend) : Send;
@@ -146,11 +148,11 @@ private:
       while (connStepCache + (isSendNotRecv ? NCCL_STEPS : 0) < step + StepPerSlice) {
         __builtin_amdgcn_s_sleep(1);
         connStepCache = loadStepValue(connStepPtr);
-        if (checkAbort(flags, Aborted, spins)) break;
-        //if (spins == 0) printf("r=%d b=%d t=%d SPUN OUT got=%d want=%d\n", ncclShmem.comm.rank, blockIdx.x, threadIdx.x, int(connStepCache + (isSendNotRecv ? NCCL_STEPS : 0)), int(step+StepPerSlice));
+        if (checkAbort(flags, Aborted, spins, ncclShmem)) break;
+        //if (spins == 0) printf("r=%d b=%d t=%d SPUN OUT got=%d want=%d\n", ncclShmem->comm.rank, blockIdx.x, threadIdx.x, int(connStepCache + (isSendNotRecv ? NCCL_STEPS : 0)), int(step+StepPerSlice));
         if (spins == 0 && repeat > 0) {
           repeat --;
-          traceData(__LINE__, threadIdx.x, int(connStepCache + (isSendNotRecv ? NCCL_STEPS : 0)), int(step+StepPerSlice));
+          traceData(ncclShmem, __LINE__, threadIdx.x, int(connStepCache + (isSendNotRecv ? NCCL_STEPS : 0)), int(step+StepPerSlice));
         }
       }
       __asm__ __volatile__("s_wakeup");
@@ -160,8 +162,8 @@ private:
       if ((flags & ConnFifoEnabled) && (flags & (Send * RoleWaitSend)))
         connFifo[step%NCCL_STEPS].size = nelts*sizeof(T);
 
-      void **ptrs = isSendNotRecv ? (ncclShmem.groups[group].dsts + Dst)
-                                  : (ncclShmem.groups[group].srcs + Src);
+      void **ptrs = isSendNotRecv ? (ncclShmem->groups[group].dsts + Dst)
+                                  : (ncclShmem->groups[group].srcs + Src);
       if ((flags & NetRegMode) && ((!isSendNotRecv && DirectRecv) || (isSendNotRecv && DirectSend))) {
         if (P2p) {
           ptrs[index] = NULL;
@@ -170,9 +172,9 @@ private:
             if (!Recv)
               ptrs[index] = NULL;
             else
-              ptrs[index] = (T*)ncclShmem.groups[group].userOutput + dstIx + offset;
+              ptrs[index] = (T*)ncclShmem->groups[group].userOutput + dstIx + offset;
           } else {
-            ptrs[index] = (T*)ncclShmem.groups[group].userOutput + srcIx + offset;
+            ptrs[index] = (T*)ncclShmem->groups[group].userOutput + srcIx + offset;
           }
         }
       } else if ((flags & ConnFifoEnabled) && connFifo[step%NCCL_STEPS].mode == NCCL_MODE_OFFSET) {
@@ -200,14 +202,14 @@ private:
         ptrs[index] = connEltsFifo + (step%NCCL_STEPS)*connStepSize;
       }
       if (flags & NetDeviceUnpack) {
-        ncclNetDeviceIncrementHead(group, index);
+        ncclNetDeviceIncrementHead(group, index, ncclShmem);
       }
       step += StepPerSlice;
     }
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_SIMPLE_WAIT_PEER_EXIT)
     if (threadIdx.x == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_SIMPLE_WAIT_PEER_EXIT, nelts*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -216,7 +218,7 @@ private:
   inline __device__ void postPeer(bool dataStored) {
     if (skip_fence){
       __atomic_signal_fence(__ATOMIC_SEQ_CST);
-      barrier_generic(asm volatile("s_waitcnt lgkmcnt(0) vmcnt(0)"), nworkers, barrier_next, barriers);
+      barrier_generic(asm volatile("s_waitcnt lgkmcnt(0) vmcnt(0)"), nworkers, barrier_next, barriers, ncclShmem);
       __atomic_signal_fence(__ATOMIC_SEQ_CST);
     }
     else if((flags & RolePostSend) && dataStored){
@@ -279,35 +281,35 @@ private:
       do {
         sliceSize = sliceSize < nelem-offset ? sliceSize : nelem-offset;
         if (tid == 0) {
-          T* userInput = (T*)ncclShmem.groups[group].userInput;
-          T* userOutput = (T*)ncclShmem.groups[group].userOutput;
-          if (Src) ncclShmem.groups[group].srcs[0] = (SrcBuf==Input ? userInput : userOutput) + srcIx + offset;
-          if (Dst) ncclShmem.groups[group].dsts[0] = (DstBuf==Input ? userInput : userOutput) + dstIx + offset;
-          T* userAcc = (T*)ncclShmem.groups[group].userAcc;
-          ncclShmem.groups[group].acc = (Dst && userAcc != nullptr) ? userAcc + dstIx + offset : nullptr;
+          T* userInput = (T*)ncclShmem->groups[group].userInput;
+          T* userOutput = (T*)ncclShmem->groups[group].userOutput;
+          if (Src) ncclShmem->groups[group].srcs[0] = (SrcBuf==Input ? userInput : userOutput) + srcIx + offset;
+          if (Dst) ncclShmem->groups[group].dsts[0] = (DstBuf==Input ? userInput : userOutput) + dstIx + offset;
+          T* userAcc = (T*)ncclShmem->groups[group].userAcc;
+          ncclShmem->groups[group].acc = (Dst && userAcc != nullptr) ? userAcc + dstIx + offset : nullptr;
         }
         waitPeer<DirectRecv, DirectSend, Recv, Send, Src, Dst>(srcIx, dstIx, offset, sliceSize);
         subBarrier();
         /* if user abort the kernel, we don't need to actually perform copy/reduce; just set size
         * to 0 to avoid unnecessary workload. */
-        int workSize = ncclShmem.aborted ? 0 : sliceSize;
+        int workSize = ncclShmem->aborted ? 0 : sliceSize;
         if (flags & AnyNetDeviceUnpack) {
-          ncclNetDeviceUnpack<Recv>(tid, tidInBlock, nworkers, group, ncclShmem.groups[group].devicePlugin.unpack.unpackNetDeviceIndexMask, Src, workSize);
+          ncclNetDeviceUnpack<Recv>(tid, tidInBlock, nworkers, group, ncclShmem->groups[group].devicePlugin.unpack.unpackNetDeviceIndexMask, Src, workSize, ncclShmem, ncclShmemPerWarp);
           // Sync here to make sure all workers are reading from the updated srcs)
           subBarrier();
         }
 
-        if (DirectRecv && ncclShmem.groups[group].srcs[0] == ncclShmem.groups[group].dsts[0]
+        if (DirectRecv && ncclShmem->groups[group].srcs[0] == ncclShmem->groups[group].dsts[0]
             /* NVLS can have srcs[0] == dsts[0], but we cannot enter this "if branch",
             * so we need to check whether MultimemSrcs and MultimemDsts are 0. */
             && MultimemSrcs == 0 && MultimemDsts == 0 && !Src) {
           // We can only have one direct receive. Since srcs[0] == dstPtr+offset, skip one copy
-          if (Send && Dst && ncclShmem.groups[group].srcs[0] != ncclShmem.groups[group].dsts[1]) {
+          if (Send && Dst && ncclShmem->groups[group].srcs[0] != ncclShmem->groups[group].dsts[1]) {
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_ENTRY)
             if (tid == 0) {
               NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_ENTRY, sliceSize*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-                  ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+                  ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
             }
 #endif
 
@@ -319,8 +321,8 @@ private:
 
             reduceCopy<Unroll, useAcc && Dst, RedOp, T, 0, 1, 1, 0, 1, MaxSend, /*PreOpSrcs*/0>
               (tid, nworkers, /*redArg*/0, /*preOpArgs*/nullptr, /*postOp*/false,
-              1, ncclShmem.groups[group].srcs,
-              fan.nsend(), ncclShmem.groups[group].dsts+1,
+              1, ncclShmem->groups[group].srcs,
+              fan.nsend(), ncclShmem->groups[group].dsts+1,
               workSize);
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_PRIM_COLLECT_DATA_PROCESS_TIME)
@@ -333,17 +335,17 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_EXIT)
             if (tid == 0) {
               NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_EXIT, sliceSize*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-                  ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+                  ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
             }
 #endif
 
           }
-        } else if (DirectSend && !DirectRecv && SrcBuf != Input && ncclShmem.groups[group].dsts[Dst] == nullptr) {
+        } else if (DirectSend && !DirectRecv && SrcBuf != Input && ncclShmem->groups[group].dsts[Dst] == nullptr) {
           // For broadcast in CollNet to do empty send
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_ENTRY)
           if (tid == 0) {
             NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_ENTRY, sliceSize*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-                ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+                ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
           }
 #endif
 
@@ -354,9 +356,9 @@ private:
 #endif
 
           reduceCopy<Unroll, useAcc && Dst, RedOp, T, 0, 1, 1, 0, 1, 1, /*PreOpSrcs*/0>
-            (tid, nworkers, ncclShmem.redOpArgs[0],  nullptr, postOp,
-            Recv, ncclShmem.groups[group].srcs,
-            Dst, ncclShmem.groups[group].dsts,
+            (tid, nworkers, ncclShmem->redOpArgs[0],  nullptr, postOp,
+            Recv, ncclShmem->groups[group].srcs,
+            Dst, ncclShmem->groups[group].dsts,
             workSize);
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_PRIM_COLLECT_DATA_PROCESS_TIME)
@@ -369,15 +371,15 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_EXIT)
           if (tid == 0) {
             NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_EXIT, sliceSize*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-                ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+                ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
           }
 #endif
 
-        } else if (ncclShmem.groups[group].srcs[0] && ncclShmem.groups[group].dsts[0]) {
+        } else if (ncclShmem->groups[group].srcs[0] && ncclShmem->groups[group].dsts[0]) {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_ENTRY)
           if (tid == 0) {
             NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_ENTRY, sliceSize*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-                ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+                ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
           }
 #endif
 
@@ -389,23 +391,23 @@ private:
 
           constexpr int PreOpSrcs = SrcBuf != Input ? 0 :
                                     DirectRecv*MaxRecv == NCCL_MAX_DIRECT_ARITY ? (1+NCCL_MAX_DIRECT_ARITY) : 1;
-          if (Send && Dst && ncclShmem.groups[group].dsts[1] == nullptr) {
+          if (Send && Dst && ncclShmem->groups[group].dsts[1] == nullptr) {
             // this case should only be directCopySend() with registered buffers and send to net peer
             reduceCopy<Unroll, useAcc && Dst, RedOp, T,
               0, Recv + Src, Recv * MaxRecv + Src,
               0, 1, 1, PreOpSrcs, Pipeline>
-              (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, postOp,
-                Recv * fan.nrecv() + Src, ncclShmem.groups[group].srcs,
-                1, ncclShmem.groups[group].dsts,
+              (tid, nworkers, ncclShmem->redOpArgs[0], ncclShmem->redOpArgs, postOp,
+                Recv * fan.nrecv() + Src, ncclShmem->groups[group].srcs,
+                1, ncclShmem->groups[group].dsts,
                 workSize);
           } else {
             reduceCopy<Unroll, useAcc && Dst, RedOp, T,
               MultimemSrcs, Recv + Src, Recv * MaxRecv + Src,
               MultimemDsts, Send + Dst, Send * MaxSend + Dst, PreOpSrcs, Pipeline>
-              (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, postOp,
-                Recv * fan.nrecv() + Src, ncclShmem.groups[group].srcs,
-                Send * fan.nsend() + Dst, ncclShmem.groups[group].dsts,
-                workSize, ncclShmem.groups[group].acc);
+              (tid, nworkers, ncclShmem->redOpArgs[0], ncclShmem->redOpArgs, postOp,
+                Recv * fan.nrecv() + Src, ncclShmem->groups[group].srcs,
+                Send * fan.nsend() + Dst, ncclShmem->groups[group].dsts,
+                workSize, ncclShmem->groups[group].acc);
           }
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_PRIM_COLLECT_DATA_PROCESS_TIME)
@@ -418,13 +420,13 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_EXIT)
           if (tid == 0) {
             NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_EXIT, sliceSize*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-                ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+                ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
           }
 #endif
 
         } else {
           // we will come here when calling prims.directSend with net peer,
-          // in this case, ncclShmem.groups[group].dsts[0] == NULL, so we
+          // in this case, ncclShmem->groups[group].dsts[0] == NULL, so we
           // skip data flush.
           workSize = 0;
         }
@@ -449,7 +451,7 @@ private:
         waitPeer<DirectRecv, DirectSend, Recv, Send, Src, Dst>(0, 0, 0, sliceSize);
       }
       barrier(); // Has couterpart in preceding worker-only loop.
-      int workSize = ncclShmem.aborted ? 0 : sliceSize;
+      int workSize = ncclShmem->aborted ? 0 : sliceSize;
       postPeer<Recv, Send>(0 < workSize);
       offset += sliceSize;
       slice += 1;
@@ -461,7 +463,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_GENERIC_OP_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_GENERIC_OP_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -472,19 +474,19 @@ private:
         nsrcs++;
         if (MULTISRCS){
           reduceCopy<Unroll, useAcc, RedOp, T, 0, 3, MSCCL_MAX_REDUCE_FUSION, 0, 1, 1, 0, Pipeline>
-            (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, false, nsrcs, (void **)srcs, 1, (void **)dsts, nelem);
+            (tid, nworkers, ncclShmem->redOpArgs[0], ncclShmem->redOpArgs, false, nsrcs, (void **)srcs, 1, (void **)dsts, nelem);
         } else {
           reduceCopy<Unroll, useAcc, RedOp, T, 0, 2, 2, 0, 1, 1, 0, Pipeline>
-            (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, false, 2, (void **)srcs, 1, (void **)dsts, nelem);
+            (tid, nworkers, ncclShmem->redOpArgs[0], ncclShmem->redOpArgs, false, 2, (void **)srcs, 1, (void **)dsts, nelem);
         }
       }
       if (COPY){
         reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 1, 0, 1, 1, 0>
-          (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, false, 1, (void **)srcs, 1, (void **)dsts, nelem);
+          (tid, nworkers, ncclShmem->redOpArgs[0], ncclShmem->redOpArgs, false, 1, (void **)srcs, 1, (void **)dsts, nelem);
         if (MULTISRCS) {
           for (int i = 1; i < nsrcs; i++){
             reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 1, 0, 1, 1, 0>
-              (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, false, 1, (void **)&srcs[i], 1, (void **)&dsts[i], nelem);
+              (tid, nworkers, ncclShmem->redOpArgs[0], ncclShmem->redOpArgs, false, 1, (void **)&srcs[i], 1, (void **)&dsts[i], nelem);
           }
         }
       }
@@ -493,7 +495,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_GENERIC_OP_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_GENERIC_OP_EXIT, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -501,28 +503,28 @@ private:
   }
 
 public:
-  static inline __device__ void sendPeerNotify(int peer, int connIndex, int steps) {
+  static inline __device__ void sendPeerNotify(int peer, int connIndex, int steps, struct ncclShmemData* ncclShmem) {
 #ifdef ENABLE_WARP_SPEED
-    ncclDevChannelPeer* peerPtr = ncclShmem.warpChannel[threadIdx.x/WARP_SIZE].peers[peer];
+    ncclDevChannelPeer* peerPtr = ncclShmem->warpChannel[threadIdx.x/WARP_SIZE].peers[peer];
 #else
-    ncclDevChannelPeer* peerPtr = ncclShmem.channel.peers[peer];
+    ncclDevChannelPeer* peerPtr = ncclShmem->channel.peers[peer];
 #endif
     peerPtr->send[connIndex].step += steps;
     st_relaxed_sys_global(peerPtr->send[connIndex].tail, peerPtr->send[connIndex].step);
   }
 
-  static inline __device__ void recvPeerNotify(int peer, int connIndex, int steps) {
+  static inline __device__ void recvPeerNotify(int peer, int connIndex, int steps, struct ncclShmemData* ncclShmem) {
     int spins = 0;
 #ifdef ENABLE_WARP_SPEED
-    ncclDevChannelPeer* peerPtr = ncclShmem.warpChannel[threadIdx.x/WARP_SIZE].peers[peer];
+    ncclDevChannelPeer* peerPtr = ncclShmem->warpChannel[threadIdx.x/WARP_SIZE].peers[peer];
 #else
-    ncclDevChannelPeer* peerPtr = ncclShmem.channel.peers[peer];
+    ncclDevChannelPeer* peerPtr = ncclShmem->channel.peers[peer];
 #endif
     peerPtr->recv[connIndex].step += steps;
     st_relaxed_sys_global(peerPtr->recv[connIndex].head, peerPtr->recv[connIndex].step);
     while (ld_volatile_global(peerPtr->recv[connIndex].tail) < peerPtr->recv[connIndex].step) {
       int abort = 0;
-      if (checkAbort(abort, 1, spins)) break;
+      if (checkAbort(abort, 1, spins, ncclShmem)) break;
     }
   }
 
@@ -537,10 +539,10 @@ public:
           int spins = 0;
           while (connStepCache + (isSendNotRecv ? NCCL_STEPS : 0) < step + StepPerSlice) {
             connStepCache = loadStepValue(connStepPtr);
-            if (checkAbort(flags, Aborted, spins)) break;
+            if (checkAbort(flags, Aborted, spins, ncclShmem)) break;
           }
-          void **ptrs = isSendNotRecv ? ncclShmem.groups[group].dsts
-                                      : ncclShmem.groups[group].srcs;
+          void **ptrs = isSendNotRecv ? ncclShmem->groups[group].dsts
+                                      : ncclShmem->groups[group].srcs;
           if ((flags & ConnFifoEnabled) && connFifo[step%NCCL_STEPS].mode == NCCL_MODE_OFFSET) {
             int offset = loadInt(&connFifo[step%NCCL_STEPS].offset);
             ptrs[index] = connEltsFifo + offset/sizeof(T);
@@ -570,29 +572,30 @@ public:
           }
         }
         subBarrier();
-        if (Recv == 0 || ncclShmem.groups[group].srcs[0] == nullptr) {
+        if (Recv == 0 || ncclShmem->groups[group].srcs[0] == nullptr) {
           nrecv = 0;
         } else {
           nrecv = fan.nrecv();
         }
 
-        if (Send == 0 || ncclShmem.groups[group].dsts[0] == nullptr) {
+        if (Send == 0 || ncclShmem->groups[group].dsts[0] == nullptr) {
           nsend = 0;
         } else {
           nsend = fan.nsend();
         }
         fn.template operator()<SlicePerChunk, 0, Recv*MaxRecv, 0, Send*MaxSend, MultimemSrcs, MultimemDsts>
           (tid, nworkers, slice, stepSize * StepPerSlice,
-            nrecv, ncclShmem.groups[group].srcs,
-            nsend, ncclShmem.groups[group].dsts, ncclShmem.groups[group].dstSizes, sendDirectFlag, recvDirectFlag);
+            nrecv, ncclShmem->groups[group].srcs,
+            nsend, ncclShmem->groups[group].dsts, ncclShmem->groups[group].dstSizes, sendDirectFlag, recvDirectFlag,
+            ncclShmem);
       }
       barrier();
       int32_t dstSize = 0;
       if (flags & Send*RolePostSend) {
         // Yes, for some template arguments this code will be unreachable.  That's fine.
         // coverity[dead_error_begin]
-        dstSize = ncclShmem.groups[group].dstSizes[index];
-        ncclShmem.groups[group].dstSizes[index] = 0;
+        dstSize = ncclShmem->groups[group].dstSizes[index];
+        ncclShmem->groups[group].dstSizes[index] = 0;
         if (flags & ConnFifoEnabled) connFifo[step%NCCL_STEPS].size = dstSize*sizeof(T);
       }
       barrier();
@@ -629,7 +632,7 @@ private:
         if (Send) {
           // Scatter pre-scales data of input buffer only in non-Direct case
           constexpr int PreOpSrcs = DirectSend ? 0 : 1;
-          if (tid==0) ncclShmem.groups[group].srcs[0] = (T*)ncclShmem.groups[group].userInput + inpIx + offset;
+          if (tid==0) ncclShmem->groups[group].srcs[0] = (T*)ncclShmem->groups[group].userInput + inpIx + offset;
           // realSize is not accurate here; but intra-node does not rely on sizes FIFO
           waitPeer<0, DirectSend, 0, 1, 1, 0>(0, inpIx, offset, realSize);
           subBarrier();
@@ -640,16 +643,16 @@ private:
             ssize_t pOffset = i*peerOffset;
             // Skip the data I am responsible of reducing myself
             if (skip >= 0 && i >= skip) pOffset += peerOffset;
-            void* src0 = (T*)ncclShmem.groups[group].srcs[0] + pOffset;
+            void* src0 = (T*)ncclShmem->groups[group].srcs[0] + pOffset;
             ssize_t realPeerSize = min(realSize, totalElem-pOffset);
-            if (realPeerSize > 0 && ncclShmem.groups[group].dsts[i] != nullptr) {
-              reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 1, 0, 1, 1, PreOpSrcs>(tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, false, 1, &src0, 1, ncclShmem.groups[group].dsts+i, realPeerSize);
+            if (realPeerSize > 0 && ncclShmem->groups[group].dsts[i] != nullptr) {
+              reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 1, 0, 1, 1, PreOpSrcs>(tid, nworkers, ncclShmem->redOpArgs[0], ncclShmem->redOpArgs, false, 1, &src0, 1, ncclShmem->groups[group].dsts+i, realPeerSize);
               // Mark for threadfence at the end
               fenceNeeded |= true;
             }
           }
         } else if (Recv) {
-          if (tid==0) ncclShmem.groups[group].dsts[0] = (T*)ncclShmem.groups[group].userOutput + outIx + offset;
+          if (tid==0) ncclShmem->groups[group].dsts[0] = (T*)ncclShmem->groups[group].userOutput + outIx + offset;
           ssize_t pOffset = index*peerOffset;
           if (skip >= 0 && index >= skip) pOffset += peerOffset;
           // Adjust remote index with peer offset in case we are directly pulling from peer's output buffer
@@ -660,10 +663,10 @@ private:
             int i = (j+shift)%fan.nrecv();
             pOffset = i*peerOffset;
             if (skip >= 0 && i >= skip) pOffset += peerOffset;
-            void* dst0 = (T*)ncclShmem.groups[group].dsts[0] + pOffset;
+            void* dst0 = (T*)ncclShmem->groups[group].dsts[0] + pOffset;
             ssize_t realPeerSize = min(realSize, totalElem-pOffset);
-            if (DirectRecv && ncclShmem.groups[group].srcs[i] == dst0) realPeerSize = 0;
-            if (realPeerSize > 0) reduceCopy<Unroll, useAcc, RedOp, T, 0,1,1, 0,1,1, /*PreOpSrcs=*/0>(tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, postOp, 1, ncclShmem.groups[group].srcs+i, 1, &dst0, realPeerSize);
+            if (DirectRecv && ncclShmem->groups[group].srcs[i] == dst0) realPeerSize = 0;
+            if (realPeerSize > 0) reduceCopy<Unroll, useAcc, RedOp, T, 0,1,1, 0,1,1, /*PreOpSrcs=*/0>(tid, nworkers, ncclShmem->redOpArgs[0], ncclShmem->redOpArgs, postOp, 1, ncclShmem->groups[group].srcs+i, 1, &dst0, realPeerSize);
           }
         }
       }
@@ -679,7 +682,7 @@ private:
       // handle must be a device ptr
       netDeviceHandle = conn->netDeviceHandle.handle;
       // Cache the handle
-      ncclNetDeviceUnpackSetup(netDeviceHandle, group, index);
+      ncclNetDeviceUnpackSetup(netDeviceHandle, group, index, ncclShmem);
       flags |= NetDeviceUnpack;
     }
     step = conn->step;
@@ -689,7 +692,7 @@ private:
       STORE(connStepPtr, step); // Return credits in case we rounded up.
     }
     if (flags & RoleWaitRecv) {
-      if ((flags & PatMode) == 0) ncclShmem.groups[group].recvConns[index] = conn; // WaitRecv role saves since that's who needs it in setDataPtrs()
+      if ((flags & PatMode) == 0) ncclShmem->groups[group].recvConns[index] = conn; // WaitRecv role saves since that's who needs it in setDataPtrs()
       flags |= (conn->flags & NCCL_NVLS_MIN_POLL) ? NvlsMinPolling : 0;
       connStepPtr = conn->tail;
       connStepCache = loadStepValue(connStepPtr);
@@ -739,7 +742,7 @@ private:
       connEltsFifo = (T*)conn->buffs[NCCL_PROTO_SIMPLE];
     }
     if (flags & RoleWaitSend) {
-      if ((flags & PatMode) == 0) ncclShmem.groups[group].sendConns[index] = conn; // WaitSend role saves since that's who needs it in setDataPtrs()
+      if ((flags & PatMode) == 0) ncclShmem->groups[group].sendConns[index] = conn; // WaitSend role saves since that's who needs it in setDataPtrs()
       flags |= (conn->flags & NCCL_NVLS_MIN_POLL) ? NvlsMinPolling : 0;
       connStepPtr = conn->head;
       connStepCache = loadStepValue(connStepPtr);
@@ -773,24 +776,27 @@ private:
 public:
   __forceinline__ __device__ Primitives(
       int tid, int nthreads, int const *recvPeers, int const *sendPeers,
-      void const *inputBuf, void *outputBuf, uint64_t redOpArg, uint8_t group=0,
-      uint8_t connIndexRecv = 0, uint8_t connIndexSend = 0, struct ncclDevWorkColl* collWork = nullptr,
-      struct ncclDevWorkP2p* p2pWork = nullptr, int stepSize_ = 0, int mode = primsModeDefault
+      void const *inputBuf, void *outputBuf, uint64_t redOpArg,
+      struct ncclShmemData* shmem, void* ncclShmemPerWarp_,
+      uint8_t group=0, uint8_t connIndexRecv = 0, uint8_t connIndexSend = 0,
+      struct ncclDevWorkColl* collWork = nullptr, struct ncclDevWorkP2p* p2pWork = nullptr,
+      int stepSize_ = 0, int mode = primsModeDefault
     ):
     tid(tid), tidInBlock(threadIdx.x), nthreads(nthreads), /*compiler warnings*/
 #ifdef ENABLE_WARP_SPEED
-    stepSize(stepSize_ == 0 ? ncclShmem.comm.buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS/sizeof(T) : stepSize_), group(ncclShmem.warpComm? tidInBlock / WARP_SIZE : group), threadsPerBlock(blockDim.x){
+    stepSize(stepSize_ == 0 ? shmem->comm.buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS/sizeof(T) : stepSize_), group(shmem->warpComm? tidInBlock / WARP_SIZE : group), threadsPerBlock(blockDim.x),
 #else
-    stepSize(stepSize_ == 0 ? ncclShmem.comm.buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS/sizeof(T) : stepSize_), group(group), threadsPerBlock(blockDim.x){
+    stepSize(stepSize_ == 0 ? shmem->comm.buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS/sizeof(T) : stepSize_), group(group), threadsPerBlock(blockDim.x),
 #endif
-    barriers = &ncclShmem.groups[group].barrier;
+    ncclShmem(shmem), ncclShmemPerWarp(ncclShmemPerWarp_){
+    barriers = &shmem->groups[group].barrier;
     // PAT uses the same barrier for each group
-    barriers_pat = &ncclShmem.barrier_pat;
+    barriers_pat = &shmem->barrier_pat;
     this->nworkers = nthreads;
 #ifdef ENABLE_WARP_SPEED
-    auto *channel = isMsccl(Metadata) ? &ncclShmem.channel : &ncclShmem.warpChannel[tidInBlock/WARP_SIZE];
+    auto *channel = isMsccl(Metadata) ? &ncclShmem->channel : &ncclShmem->warpChannel[tidInBlock/WARP_SIZE];
 #else
-    auto *channel = &ncclShmem.channel;
+    auto *channel = &ncclShmem->channel;
 #endif
     int peer = -1;
     flags = 0;
@@ -856,7 +862,7 @@ public:
       //   // have NetDeviceUnpack.
       //   uint32_t mask = __ballot_sync(~0u, ((flags & RoleWaitRecv) && (flags & NetDeviceUnpack)) ? 1 : 0);
       //   if (tid == 0) {
-      //     ncclShmem.groups[this->group].devicePlugin.unpack.unpackNetDeviceIndexMask = mask;
+      //     ncclShmem->groups[this->group].devicePlugin.unpack.unpackNetDeviceIndexMask = mask;
       //   }
       // }
 
@@ -869,9 +875,9 @@ public:
       const int roles[5] = { RoleWaitRecv, RolePostRecv, RoleWaitSend, RolePostSend, RoleInput | RoleOutput };
       if (tid < 5) flags |= roles[tid];
 
-      int nranks = ncclShmem.comm.nRanks;
+      int nranks = ncclShmem->comm.nRanks;
       if (tid < 32 && ((1UL<<tid) < nranks)) {
-        int rank = ncclShmem.comm.rank;
+        int rank = ncclShmem->comm.rank;
         uint32_t delta = 1 << tid;
         // Load recv peer
         int recvPeer = mode == primsModePatRs ? (rank - delta + nranks) % nranks : (rank + delta) % nranks;
@@ -896,9 +902,9 @@ public:
         peer->connStepSize = conn->stepSize/sizeof(T);
       }
       if (tid==0) {
-        ncclShmem.groups[group].userInput = (void*)inputBuf;
-        ncclShmem.groups[group].userOutput = (void*)outputBuf;
-        ncclShmem.redOpArgs[0] = redOpArg;  // scaler for local input
+        ncclShmem->groups[group].userInput = (void*)inputBuf;
+        ncclShmem->groups[group].userOutput = (void*)outputBuf;
+        ncclShmem->redOpArgs[0] = redOpArg;  // scaler for local input
       }
       patBarrier();
     }
@@ -918,15 +924,15 @@ public:
       uint64_t prevStep = step - StepPerSlice;
       volatile ssize_t* ptr = &(connFifo[prevStep%NCCL_STEPS].size);
       int spins = 0;
-      while (*ptr != -1) if (checkAbort(flags, Aborted, spins)) break;
+      while (*ptr != -1) if (checkAbort(flags, Aborted, spins, ncclShmem)) break;
     }
 
     if (flags & NetDeviceUnpack) {
-      ncclNetDeviceSaveHead(netDeviceHandle, group, index);
+      ncclNetDeviceSaveHead(netDeviceHandle, group, index, ncclShmem);
     }
 
     // Make sure all threads are done writing back conn->step and done using
-    // ncclShmem.groups[group]
+    // ncclShmem->groups[group]
     barrier();
 
     if ((flags & DirectRead) && (flags & RoleWaitSend) && P2p) {
@@ -936,16 +942,16 @@ public:
       int spins = 0;
       volatile uint64_t* tail = conn->tail;
       volatile uint64_t* head = conn->head;
-      while (*tail > *head) if (checkAbort(flags, Aborted, spins)) break;
+      while (*tail > *head) if (checkAbort(flags, Aborted, spins, ncclShmem)) break;
     }
   }
 
   __device__ void setDataPtrs(void const *inputBuf, void *outputBuf, uint64_t redOpArg, struct ncclDevWorkCollReg* work, uint8_t ipcReg, int peer, void const *acc) {
     if (tid==0) {
-      ncclShmem.groups[group].userInput = (void*)inputBuf;
-      ncclShmem.groups[group].userOutput = (void*)outputBuf;
-      ncclShmem.groups[group].userAcc = (void*)acc;
-      ncclShmem.redOpArgs[0] = redOpArg;  // scaler for local input
+      ncclShmem->groups[group].userInput = (void*)inputBuf;
+      ncclShmem->groups[group].userOutput = (void*)outputBuf;
+      ncclShmem->groups[group].userAcc = (void*)acc;
+      ncclShmem->redOpArgs[0] = redOpArg;  // scaler for local input
     }
 
     if (Direct && ipcReg) {
@@ -955,16 +961,16 @@ public:
       bool recvAcceptor = (flags & RoleWaitRecv) && (flags & DirectRead); // receiver accepts direct buffer
       if (recvProvider) {
         int spins = 0;
-        void* volatile* slot = ncclShmem.groups[group].recvConns[index]->ptrExchange;
+        void* volatile* slot = ncclShmem->groups[group].recvConns[index]->ptrExchange;
         // Wait for consumer to consume previous value before trampling it.
         if (slot) {
           T* exchgPtr;
           directBuff = (T*)outputBuf;
-          while ((void *)atomicAdd((unsigned long long *) slot,0) != nullptr && !checkAbort(flags, Aborted, spins));
+          while ((void *)atomicAdd((unsigned long long *) slot,0) != nullptr && !checkAbort(flags, Aborted, spins, ncclShmem));
           if (P2p) {
             exchgPtr = (T*)outputBuf;
           } else {
-            int localPeer = ncclShmem.comm.rankToLocalRank[peer];
+            int localPeer = ncclShmem->comm.rankToLocalRank[peer];
             // coverity[deref_parm:FALSE] => work cannot be NULL if ipcReg != NULL
             exchgPtr = (T*)(work->coll.recvbuffOffset + work->coll.recvbuffRmtAddrs[localPeer]);
           }
@@ -973,11 +979,11 @@ public:
       }
       if (sendAcceptor) {
         int spins = 0;
-        void* volatile* slot = ncclShmem.groups[group].sendConns[index]->ptrExchange;
+        void* volatile* slot = ncclShmem->groups[group].sendConns[index]->ptrExchange;
         void* ptr;
         while (slot) {
           ptr = (void *)atomicAdd((unsigned long long *) slot,0);
-          if (ptr != nullptr || checkAbort(flags, Aborted, spins)) break;
+          if (ptr != nullptr || checkAbort(flags, Aborted, spins, ncclShmem)) break;
         }
 
         if (slot) {
@@ -990,20 +996,20 @@ public:
       }
       if (sendProvider) {
         int spins = 0;
-        void* volatile* slot = ncclShmem.groups[group].sendConns[index]->ptrExchange;
-        volatile uint64_t* argSlot0 = ncclShmem.groups[group].sendConns[index]->redOpArgExchange;
-        volatile uint64_t* argSlot1 = ncclShmem.groups[group].sendConns[index]->redOpArgExchange + 1;
+        void* volatile* slot = ncclShmem->groups[group].sendConns[index]->ptrExchange;
+        volatile uint64_t* argSlot0 = ncclShmem->groups[group].sendConns[index]->redOpArgExchange;
+        volatile uint64_t* argSlot1 = ncclShmem->groups[group].sendConns[index]->redOpArgExchange + 1;
         // Wait for consumer to consume previous value before trampling it.
         if (slot && argSlot0 && argSlot1) {
           T* exchgPtr;
-          while (((void *)atomicAdd((unsigned long long *) slot,0) != nullptr || *argSlot0 != 0 || *argSlot1 != 0) && !checkAbort(flags, Aborted, spins));
+          while (((void *)atomicAdd((unsigned long long *) slot,0) != nullptr || *argSlot0 != 0 || *argSlot1 != 0) && !checkAbort(flags, Aborted, spins, ncclShmem));
           // If there is no recv, then we are directly pulling from input buffer (e.g. directScatter)
           // Otherwise, we are pulling from output buffer (e.g. recvCopyDirectSend)
           directBuff = MaxRecv == 0 ? (T*)inputBuf : (T*)outputBuf;
           if (P2p) {
             exchgPtr = MaxRecv == 0 ? (T*)inputBuf : (T*)outputBuf;
           } else {
-            int localPeer = ncclShmem.comm.rankToLocalRank[peer];
+            int localPeer = ncclShmem->comm.rankToLocalRank[peer];
             if (MaxRecv == 0)
               // coverity[var_deref_op]
               exchgPtr = (T*)(work->coll.sendbuffOffset + work->coll.sendbuffRmtAddrs[localPeer]);
@@ -1020,13 +1026,13 @@ public:
       }
       if (recvAcceptor) {
         int spins = 0;
-        void* volatile* slot = ncclShmem.groups[group].recvConns[index]->ptrExchange;
-        volatile uint64_t* argSlot0 = ncclShmem.groups[group].recvConns[index]->redOpArgExchange;
-        volatile uint64_t* argSlot1 = ncclShmem.groups[group].recvConns[index]->redOpArgExchange + 1;
+        void* volatile* slot = ncclShmem->groups[group].recvConns[index]->ptrExchange;
+        volatile uint64_t* argSlot0 = ncclShmem->groups[group].recvConns[index]->redOpArgExchange;
+        volatile uint64_t* argSlot1 = ncclShmem->groups[group].recvConns[index]->redOpArgExchange + 1;
         void* ptr;
         while (slot) {
           ptr = (void *)atomicAdd((unsigned long long *) slot,0);
-          if (ptr != nullptr || checkAbort(flags, Aborted, spins)) break;
+          if (ptr != nullptr || checkAbort(flags, Aborted, spins, ncclShmem)) break;
         }
 
         if (slot && argSlot0 && argSlot1) {
@@ -1037,9 +1043,9 @@ public:
             while (true) {
               arg0 = *argSlot0;
               arg1 = *argSlot1;
-              if ((arg0 != 0 && arg1 != 0) || checkAbort(flags, Aborted, spins)) break;
+              if ((arg0 != 0 && arg1 != 0) || checkAbort(flags, Aborted, spins, ncclShmem)) break;
             }
-            ncclShmem.redOpArgs[1 + index] = ((arg1 & 0xffffffff) << 32) | (arg0 & 0xffffffff);
+            ncclShmem->redOpArgs[1 + index] = ((arg1 & 0xffffffff) << 32) | (arg0 & 0xffffffff);
           }
           *argSlot0 = 0; *argSlot1 = 0;
           *slot = nullptr;
@@ -1056,16 +1062,16 @@ public:
 
   __device__ void moveDataPtrs(intptr_t delta) {
     if (tid==0) {
-      ncclShmem.groups[group].userInput = (T*)ncclShmem.groups[group].userInput + delta;
-      ncclShmem.groups[group].userOutput = (T*)ncclShmem.groups[group].userOutput + delta;
+      ncclShmem->groups[group].userInput = (T*)ncclShmem->groups[group].userInput + delta;
+      ncclShmem->groups[group].userOutput = (T*)ncclShmem->groups[group].userOutput + delta;
     }
   }
 
   // Set MSCCL data pointers
   __device__ __forceinline__ void setDataPtrs(void const *inputBuf, void *outputBuf = nullptr) {
     if (tid==0) {
-      ncclShmem.groups[group].userInput = (T*)inputBuf;
-      ncclShmem.groups[group].userOutput = (T*)outputBuf;
+      ncclShmem->groups[group].userInput = (T*)inputBuf;
+      ncclShmem->groups[group].userOutput = (T*)outputBuf;
     }
   }
 
@@ -1173,8 +1179,8 @@ public:
   __device__ __forceinline__ void patReduce(struct ncclPatStep* ps, struct ncclPatShmem* shmem) {
     if (ps->flags & PatSkipped) { patBarrier(); patBarrier(); return; } // Skipped
     int nelem = ps->nelem < 0 ? 0 : ps->nelem;
-    T* userInput = (T*)ncclShmem.groups[group].userInput;
-    T* userOutput = (T*)ncclShmem.groups[group].userOutput;
+    T* userInput = (T*)ncclShmem->groups[group].userInput;
+    T* userOutput = (T*)ncclShmem->groups[group].userOutput;
 
     bool recv = ps->recvDim >= 0 && (flags & (RolePostRecv|RoleWaitRecv));
     bool send = ps->sendDim >= 0 && (flags & (RolePostSend|RoleWaitSend));
@@ -1191,50 +1197,50 @@ public:
     }
 
     if (recv && (flags & RoleWaitRecv)) {
-      ncclShmem.groups[group].srcs[0] = ((T*)peer->buff) + (step%NCCL_STEPS)*peer->connStepSize + ps->recvOffset;
+      ncclShmem->groups[group].srcs[0] = ((T*)peer->buff) + (step%NCCL_STEPS)*peer->connStepSize + ps->recvOffset;
       int spins = 0;
       while (peer->stepCache < step + StepPerSlice) {
         peer->stepCache = loadStepValue(peer->tailPtr);
-        if (checkAbort(flags, Aborted, spins)) break;
+        if (checkAbort(flags, Aborted, spins, ncclShmem)) break;
       }
     }
     if (send && (flags & RoleWaitSend)) {
       int spins = 0;
       while (peer->stepCache + NCCL_STEPS < step + ps->stepOffset + StepPerSlice) {
         peer->stepCache = loadStepValue(peer->headPtr);
-        if (checkAbort(flags, Aborted, spins)) break;
+        if (checkAbort(flags, Aborted, spins, ncclShmem)) break;
       }
-      ncclShmem.groups[group].dsts[0] = ((T*)peer->buff) + ((step+ps->stepOffset)%NCCL_STEPS)*peer->connStepSize + ps->sendOffset;
+      ncclShmem->groups[group].dsts[0] = ((T*)peer->buff) + ((step+ps->stepOffset)%NCCL_STEPS)*peer->connStepSize + ps->sendOffset;
       if (peer->accSize < ps->sendOffset + nelem + (step+ps->stepOffset)*peer->connStepSize) {
         // New data, add our own data to it.
-        ncclShmem.groups[group].srcs[1] = userInput + ps->inpIx;
+        ncclShmem->groups[group].srcs[1] = userInput + ps->inpIx;
       } else {
         // There is already data in there, accumulate instead of writing to it.
-        ncclShmem.groups[group].srcs[1] = ncclShmem.groups[group].dsts[0];
+        ncclShmem->groups[group].srcs[1] = ncclShmem->groups[group].dsts[0];
       }
     }
     long long int localAccSize = shmem->localAccSize;
     if (ps->sendDim < 0 && (flags & RoleOutput)) { // Destination is our own local buffer
-      ncclShmem.groups[group].dsts[0] = userOutput + ps->outIx;
+      ncclShmem->groups[group].dsts[0] = userOutput + ps->outIx;
       if (localAccSize < ps->outIx + nelem) {
         // New data, add our own data to it.
-        ncclShmem.groups[group].srcs[1] = userInput + ps->inpIx;
+        ncclShmem->groups[group].srcs[1] = userInput + ps->inpIx;
         localAccSize = ps->outIx + nelem;
       } else {
         // There is already data in there, accumulate instead of writing to it.
-        ncclShmem.groups[group].srcs[1] = ncclShmem.groups[group].dsts[0];
+        ncclShmem->groups[group].srcs[1] = ncclShmem->groups[group].dsts[0];
       }
     }
     patBarrier();
     int nSrcs = 2;
-    void** srcs = ncclShmem.groups[group].srcs;
+    void** srcs = ncclShmem->groups[group].srcs;
     if (ps->recvDim < 0) { srcs++; nSrcs--; } // No peer to receive from, remove one source
 
-    int workSize = ncclShmem.aborted ? 0 : nelem;
+    int workSize = ncclShmem->aborted ? 0 : nelem;
 
     reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 2, 0, 1, 1, /*PreOpSrcs*/0>
-      (tid, nthreads, ncclShmem.redOpArgs[0],  nullptr, /*postOp=*/false,
-      nSrcs, srcs, 1, ncclShmem.groups[group].dsts, workSize);
+      (tid, nthreads, ncclShmem->redOpArgs[0],  nullptr, /*postOp=*/false,
+      nSrcs, srcs, 1, ncclShmem->groups[group].dsts, workSize);
 
     // Store conn step here inside the two barriers to make sure next reload will see the update.
     if (postSend && (flags & RolePostSend)) {
@@ -1267,8 +1273,8 @@ public:
   __device__ __forceinline__ void patCopy(struct ncclPatStep* ps, struct ncclPatShmem* shmem) {
     if (ps->flags & PatSkipped) { patBarrier(); patBarrier(); return; } // Skipped
     int nelem = ps->nelem < 0 ? 0 : ps->nelem;
-    T* userInput = (T*)ncclShmem.groups[group].userInput;
-    T* userOutput = (T*)ncclShmem.groups[group].userOutput;
+    T* userInput = (T*)ncclShmem->groups[group].userInput;
+    T* userOutput = (T*)ncclShmem->groups[group].userOutput;
 
     bool recv = ps->recvDim >= 0 && (flags & (RolePostRecv|RoleWaitRecv));
     bool send = ps->sendDim >= 0 && (flags & (RolePostSend|RoleWaitSend));
@@ -1285,50 +1291,50 @@ public:
     }
 
     if (recv && (flags & RoleWaitRecv)) {
-      ncclShmem.groups[group].srcs[0] = ((T*)peer->buff) + ((step+ps->stepOffset)%NCCL_STEPS)*peer->connStepSize + ps->recvOffset;
+      ncclShmem->groups[group].srcs[0] = ((T*)peer->buff) + ((step+ps->stepOffset)%NCCL_STEPS)*peer->connStepSize + ps->recvOffset;
       int spins = 0;
       while (peer->stepCache < step + ps->stepOffset + StepPerSlice) {
         peer->stepCache = loadStepValue(peer->tailPtr);
-        if (checkAbort(flags, Aborted, spins)) break;
+        if (checkAbort(flags, Aborted, spins, ncclShmem)) break;
       }
       if (peer->accSize < ps->recvOffset + nelem + (step+ps->stepOffset)*peer->connStepSize) {
         // New data, copy to our output buffer.
-        ncclShmem.groups[group].dsts[1] = userOutput + ps->outIx;
+        ncclShmem->groups[group].dsts[1] = userOutput + ps->outIx;
       } else {
-        ncclShmem.groups[group].dsts[1] = ncclShmem.groups[group].srcs[0]; // Already done
+        ncclShmem->groups[group].dsts[1] = ncclShmem->groups[group].srcs[0]; // Already done
       }
     }
     if (send && (flags & RoleWaitSend)) {
       int spins = 0;
       while (peer->stepCache + NCCL_STEPS < step + StepPerSlice) {
         peer->stepCache = loadStepValue(peer->headPtr);
-        if (checkAbort(flags, Aborted, spins)) break;
+        if (checkAbort(flags, Aborted, spins, ncclShmem)) break;
       }
-      ncclShmem.groups[group].dsts[0] = ((T*)peer->buff) + (step%NCCL_STEPS)*peer->connStepSize + ps->sendOffset;
+      ncclShmem->groups[group].dsts[0] = ((T*)peer->buff) + (step%NCCL_STEPS)*peer->connStepSize + ps->sendOffset;
     }
     long long int localAccSize = shmem->localAccSize;
     if (ps->recvDim < 0 && (flags & RoleInput)) { // Source is our own local buffer
-      ncclShmem.groups[group].srcs[0] = userInput + ps->inpIx;
+      ncclShmem->groups[group].srcs[0] = userInput + ps->inpIx;
       if (localAccSize < ps->inpIx + nelem) {
         // New data, copy to our output buffer.
-        ncclShmem.groups[group].dsts[1] = userOutput + ps->outIx;
+        ncclShmem->groups[group].dsts[1] = userOutput + ps->outIx;
         localAccSize = ps->inpIx + nelem;
       } else {
         // Already done
-        ncclShmem.groups[group].dsts[1] = ncclShmem.groups[group].srcs[0];
+        ncclShmem->groups[group].dsts[1] = ncclShmem->groups[group].srcs[0];
       }
     }
     patBarrier();
     int nDsts = 2;
-    void** dsts = ncclShmem.groups[group].dsts;
+    void** dsts = ncclShmem->groups[group].dsts;
     if (ps->sendDim < 0) { dsts++; nDsts--; } // No peer to send to, remove one dest
-    if (ncclShmem.groups[group].srcs[0] == ncclShmem.groups[group].dsts[1]) nDsts--; // In-place or already done.
+    if (ncclShmem->groups[group].srcs[0] == ncclShmem->groups[group].dsts[1]) nDsts--; // In-place or already done.
 
-    int workSize = ncclShmem.aborted ? 0 : nelem;
+    int workSize = ncclShmem->aborted ? 0 : nelem;
 
     reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 1, 0, 1, 2, /*PreOpSrcs*/0>
-      (tid, nthreads, ncclShmem.redOpArgs[0],  nullptr, /*postOp=*/false,
-      1, ncclShmem.groups[group].srcs, nDsts, dsts, workSize);
+      (tid, nthreads, ncclShmem->redOpArgs[0],  nullptr, /*postOp=*/false,
+      1, ncclShmem->groups[group].srcs, nDsts, dsts, workSize);
 
     // Store conn step here inside the two barriers to make sure next reload will see the update.
     if (postSend && (flags & RolePostSend)) {

--- a/projects/rccl/src/device/prims_simple.h
+++ b/projects/rccl/src/device/prims_simple.h
@@ -69,7 +69,7 @@ class Primitives<
   uint64_t barrier_next_pat = 0;
   int repeat;
   bool skip_fence = 0;
-  struct ncclShmemData* ncclShmem;
+  struct ncclShmemData& ncclShmem;
   void* ncclShmemPerWarp;
 
 #if defined(ENABLE_NPKIT)
@@ -136,7 +136,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_SIMPLE_WAIT_PEER_ENTRY)
     if (threadIdx.x == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_SIMPLE_WAIT_PEER_ENTRY, nelts*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
     const bool isSendNotRecv = (Send && Recv) ? (flags & RoleWaitSend) : Send;
@@ -149,7 +149,7 @@ private:
         __builtin_amdgcn_s_sleep(1);
         connStepCache = loadStepValue(connStepPtr);
         if (checkAbort(flags, Aborted, spins, ncclShmem)) break;
-        //if (spins == 0) printf("r=%d b=%d t=%d SPUN OUT got=%d want=%d\n", ncclShmem->comm.rank, blockIdx.x, threadIdx.x, int(connStepCache + (isSendNotRecv ? NCCL_STEPS : 0)), int(step+StepPerSlice));
+        //if (spins == 0) printf("r=%d b=%d t=%d SPUN OUT got=%d want=%d\n", ncclShmem.comm.rank, blockIdx.x, threadIdx.x, int(connStepCache + (isSendNotRecv ? NCCL_STEPS : 0)), int(step+StepPerSlice));
         if (spins == 0 && repeat > 0) {
           repeat --;
           traceData(ncclShmem, __LINE__, threadIdx.x, int(connStepCache + (isSendNotRecv ? NCCL_STEPS : 0)), int(step+StepPerSlice));
@@ -162,8 +162,8 @@ private:
       if ((flags & ConnFifoEnabled) && (flags & (Send * RoleWaitSend)))
         connFifo[step%NCCL_STEPS].size = nelts*sizeof(T);
 
-      void **ptrs = isSendNotRecv ? (ncclShmem->groups[group].dsts + Dst)
-                                  : (ncclShmem->groups[group].srcs + Src);
+      void **ptrs = isSendNotRecv ? (ncclShmem.groups[group].dsts + Dst)
+                                  : (ncclShmem.groups[group].srcs + Src);
       if ((flags & NetRegMode) && ((!isSendNotRecv && DirectRecv) || (isSendNotRecv && DirectSend))) {
         if (P2p) {
           ptrs[index] = NULL;
@@ -172,9 +172,9 @@ private:
             if (!Recv)
               ptrs[index] = NULL;
             else
-              ptrs[index] = (T*)ncclShmem->groups[group].userOutput + dstIx + offset;
+              ptrs[index] = (T*)ncclShmem.groups[group].userOutput + dstIx + offset;
           } else {
-            ptrs[index] = (T*)ncclShmem->groups[group].userOutput + srcIx + offset;
+            ptrs[index] = (T*)ncclShmem.groups[group].userOutput + srcIx + offset;
           }
         }
       } else if ((flags & ConnFifoEnabled) && connFifo[step%NCCL_STEPS].mode == NCCL_MODE_OFFSET) {
@@ -209,7 +209,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_SIMPLE_WAIT_PEER_EXIT)
     if (threadIdx.x == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_SIMPLE_WAIT_PEER_EXIT, nelts*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
   }
@@ -281,35 +281,35 @@ private:
       do {
         sliceSize = sliceSize < nelem-offset ? sliceSize : nelem-offset;
         if (tid == 0) {
-          T* userInput = (T*)ncclShmem->groups[group].userInput;
-          T* userOutput = (T*)ncclShmem->groups[group].userOutput;
-          if (Src) ncclShmem->groups[group].srcs[0] = (SrcBuf==Input ? userInput : userOutput) + srcIx + offset;
-          if (Dst) ncclShmem->groups[group].dsts[0] = (DstBuf==Input ? userInput : userOutput) + dstIx + offset;
-          T* userAcc = (T*)ncclShmem->groups[group].userAcc;
-          ncclShmem->groups[group].acc = (Dst && userAcc != nullptr) ? userAcc + dstIx + offset : nullptr;
+          T* userInput = (T*)ncclShmem.groups[group].userInput;
+          T* userOutput = (T*)ncclShmem.groups[group].userOutput;
+          if (Src) ncclShmem.groups[group].srcs[0] = (SrcBuf==Input ? userInput : userOutput) + srcIx + offset;
+          if (Dst) ncclShmem.groups[group].dsts[0] = (DstBuf==Input ? userInput : userOutput) + dstIx + offset;
+          T* userAcc = (T*)ncclShmem.groups[group].userAcc;
+          ncclShmem.groups[group].acc = (Dst && userAcc != nullptr) ? userAcc + dstIx + offset : nullptr;
         }
         waitPeer<DirectRecv, DirectSend, Recv, Send, Src, Dst>(srcIx, dstIx, offset, sliceSize);
         subBarrier();
         /* if user abort the kernel, we don't need to actually perform copy/reduce; just set size
         * to 0 to avoid unnecessary workload. */
-        int workSize = ncclShmem->aborted ? 0 : sliceSize;
+        int workSize = ncclShmem.aborted ? 0 : sliceSize;
         if (flags & AnyNetDeviceUnpack) {
-          ncclNetDeviceUnpack<Recv>(tid, tidInBlock, nworkers, group, ncclShmem->groups[group].devicePlugin.unpack.unpackNetDeviceIndexMask, Src, workSize, ncclShmem, ncclShmemPerWarp);
+          ncclNetDeviceUnpack<Recv>(tid, tidInBlock, nworkers, group, ncclShmem.groups[group].devicePlugin.unpack.unpackNetDeviceIndexMask, Src, workSize, ncclShmem, ncclShmemPerWarp);
           // Sync here to make sure all workers are reading from the updated srcs)
           subBarrier();
         }
 
-        if (DirectRecv && ncclShmem->groups[group].srcs[0] == ncclShmem->groups[group].dsts[0]
+        if (DirectRecv && ncclShmem.groups[group].srcs[0] == ncclShmem.groups[group].dsts[0]
             /* NVLS can have srcs[0] == dsts[0], but we cannot enter this "if branch",
             * so we need to check whether MultimemSrcs and MultimemDsts are 0. */
             && MultimemSrcs == 0 && MultimemDsts == 0 && !Src) {
           // We can only have one direct receive. Since srcs[0] == dstPtr+offset, skip one copy
-          if (Send && Dst && ncclShmem->groups[group].srcs[0] != ncclShmem->groups[group].dsts[1]) {
+          if (Send && Dst && ncclShmem.groups[group].srcs[0] != ncclShmem.groups[group].dsts[1]) {
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_ENTRY)
             if (tid == 0) {
               NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_ENTRY, sliceSize*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-                  ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+                  ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
             }
 #endif
 
@@ -321,8 +321,8 @@ private:
 
             reduceCopy<Unroll, useAcc && Dst, RedOp, T, 0, 1, 1, 0, 1, MaxSend, /*PreOpSrcs*/0>
               (tid, nworkers, /*redArg*/0, /*preOpArgs*/nullptr, /*postOp*/false,
-              1, ncclShmem->groups[group].srcs,
-              fan.nsend(), ncclShmem->groups[group].dsts+1,
+              1, ncclShmem.groups[group].srcs,
+              fan.nsend(), ncclShmem.groups[group].dsts+1,
               workSize);
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_PRIM_COLLECT_DATA_PROCESS_TIME)
@@ -335,17 +335,17 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_EXIT)
             if (tid == 0) {
               NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_EXIT, sliceSize*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-                  ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+                  ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
             }
 #endif
 
           }
-        } else if (DirectSend && !DirectRecv && SrcBuf != Input && ncclShmem->groups[group].dsts[Dst] == nullptr) {
+        } else if (DirectSend && !DirectRecv && SrcBuf != Input && ncclShmem.groups[group].dsts[Dst] == nullptr) {
           // For broadcast in CollNet to do empty send
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_ENTRY)
           if (tid == 0) {
             NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_ENTRY, sliceSize*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-                ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+                ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
           }
 #endif
 
@@ -356,9 +356,9 @@ private:
 #endif
 
           reduceCopy<Unroll, useAcc && Dst, RedOp, T, 0, 1, 1, 0, 1, 1, /*PreOpSrcs*/0>
-            (tid, nworkers, ncclShmem->redOpArgs[0],  nullptr, postOp,
-            Recv, ncclShmem->groups[group].srcs,
-            Dst, ncclShmem->groups[group].dsts,
+            (tid, nworkers, ncclShmem.redOpArgs[0],  nullptr, postOp,
+            Recv, ncclShmem.groups[group].srcs,
+            Dst, ncclShmem.groups[group].dsts,
             workSize);
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_PRIM_COLLECT_DATA_PROCESS_TIME)
@@ -371,15 +371,15 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_EXIT)
           if (tid == 0) {
             NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_EXIT, sliceSize*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-                ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+                ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
           }
 #endif
 
-        } else if (ncclShmem->groups[group].srcs[0] && ncclShmem->groups[group].dsts[0]) {
+        } else if (ncclShmem.groups[group].srcs[0] && ncclShmem.groups[group].dsts[0]) {
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_ENTRY)
           if (tid == 0) {
             NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_ENTRY, sliceSize*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-                ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+                ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
           }
 #endif
 
@@ -391,23 +391,23 @@ private:
 
           constexpr int PreOpSrcs = SrcBuf != Input ? 0 :
                                     DirectRecv*MaxRecv == NCCL_MAX_DIRECT_ARITY ? (1+NCCL_MAX_DIRECT_ARITY) : 1;
-          if (Send && Dst && ncclShmem->groups[group].dsts[1] == nullptr) {
+          if (Send && Dst && ncclShmem.groups[group].dsts[1] == nullptr) {
             // this case should only be directCopySend() with registered buffers and send to net peer
             reduceCopy<Unroll, useAcc && Dst, RedOp, T,
               0, Recv + Src, Recv * MaxRecv + Src,
               0, 1, 1, PreOpSrcs, Pipeline>
-              (tid, nworkers, ncclShmem->redOpArgs[0], ncclShmem->redOpArgs, postOp,
-                Recv * fan.nrecv() + Src, ncclShmem->groups[group].srcs,
-                1, ncclShmem->groups[group].dsts,
+              (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, postOp,
+                Recv * fan.nrecv() + Src, ncclShmem.groups[group].srcs,
+                1, ncclShmem.groups[group].dsts,
                 workSize);
           } else {
             reduceCopy<Unroll, useAcc && Dst, RedOp, T,
               MultimemSrcs, Recv + Src, Recv * MaxRecv + Src,
               MultimemDsts, Send + Dst, Send * MaxSend + Dst, PreOpSrcs, Pipeline>
-              (tid, nworkers, ncclShmem->redOpArgs[0], ncclShmem->redOpArgs, postOp,
-                Recv * fan.nrecv() + Src, ncclShmem->groups[group].srcs,
-                Send * fan.nsend() + Dst, ncclShmem->groups[group].dsts,
-                workSize, ncclShmem->groups[group].acc);
+              (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, postOp,
+                Recv * fan.nrecv() + Src, ncclShmem.groups[group].srcs,
+                Send * fan.nsend() + Dst, ncclShmem.groups[group].dsts,
+                workSize, ncclShmem.groups[group].acc);
           }
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_PRIM_COLLECT_DATA_PROCESS_TIME)
@@ -420,13 +420,13 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_EXIT)
           if (tid == 0) {
             NpKit::CollectGpuEvent(NPKIT_EVENT_PRIM_SIMPLE_REDUCE_OR_COPY_MULTI_EXIT, sliceSize*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-                ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+                ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
           }
 #endif
 
         } else {
           // we will come here when calling prims.directSend with net peer,
-          // in this case, ncclShmem->groups[group].dsts[0] == NULL, so we
+          // in this case, ncclShmem.groups[group].dsts[0] == NULL, so we
           // skip data flush.
           workSize = 0;
         }
@@ -451,7 +451,7 @@ private:
         waitPeer<DirectRecv, DirectSend, Recv, Send, Src, Dst>(0, 0, 0, sliceSize);
       }
       barrier(); // Has couterpart in preceding worker-only loop.
-      int workSize = ncclShmem->aborted ? 0 : sliceSize;
+      int workSize = ncclShmem.aborted ? 0 : sliceSize;
       postPeer<Recv, Send>(0 < workSize);
       offset += sliceSize;
       slice += 1;
@@ -463,7 +463,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_GENERIC_OP_ENTRY)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_GENERIC_OP_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -474,19 +474,19 @@ private:
         nsrcs++;
         if (MULTISRCS){
           reduceCopy<Unroll, useAcc, RedOp, T, 0, 3, MSCCL_MAX_REDUCE_FUSION, 0, 1, 1, 0, Pipeline>
-            (tid, nworkers, ncclShmem->redOpArgs[0], ncclShmem->redOpArgs, false, nsrcs, (void **)srcs, 1, (void **)dsts, nelem);
+            (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, false, nsrcs, (void **)srcs, 1, (void **)dsts, nelem);
         } else {
           reduceCopy<Unroll, useAcc, RedOp, T, 0, 2, 2, 0, 1, 1, 0, Pipeline>
-            (tid, nworkers, ncclShmem->redOpArgs[0], ncclShmem->redOpArgs, false, 2, (void **)srcs, 1, (void **)dsts, nelem);
+            (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, false, 2, (void **)srcs, 1, (void **)dsts, nelem);
         }
       }
       if (COPY){
         reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 1, 0, 1, 1, 0>
-          (tid, nworkers, ncclShmem->redOpArgs[0], ncclShmem->redOpArgs, false, 1, (void **)srcs, 1, (void **)dsts, nelem);
+          (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, false, 1, (void **)srcs, 1, (void **)dsts, nelem);
         if (MULTISRCS) {
           for (int i = 1; i < nsrcs; i++){
             reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 1, 0, 1, 1, 0>
-              (tid, nworkers, ncclShmem->redOpArgs[0], ncclShmem->redOpArgs, false, 1, (void **)&srcs[i], 1, (void **)&dsts[i], nelem);
+              (tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, false, 1, (void **)&srcs[i], 1, (void **)&dsts[i], nelem);
           }
         }
       }
@@ -495,7 +495,7 @@ private:
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_MSCCL_GENERIC_OP_EXIT)
     if (tid == 0) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_MSCCL_GENERIC_OP_EXIT, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -503,22 +503,22 @@ private:
   }
 
 public:
-  static inline __device__ void sendPeerNotify(int peer, int connIndex, int steps, struct ncclShmemData* ncclShmem) {
+  static inline __device__ void sendPeerNotify(int peer, int connIndex, int steps, struct ncclShmemData& ncclShmem) {
 #ifdef ENABLE_WARP_SPEED
-    ncclDevChannelPeer* peerPtr = ncclShmem->warpChannel[threadIdx.x/WARP_SIZE].peers[peer];
+    ncclDevChannelPeer* peerPtr = ncclShmem.warpChannel[threadIdx.x/WARP_SIZE].peers[peer];
 #else
-    ncclDevChannelPeer* peerPtr = ncclShmem->channel.peers[peer];
+    ncclDevChannelPeer* peerPtr = ncclShmem.channel.peers[peer];
 #endif
     peerPtr->send[connIndex].step += steps;
     st_relaxed_sys_global(peerPtr->send[connIndex].tail, peerPtr->send[connIndex].step);
   }
 
-  static inline __device__ void recvPeerNotify(int peer, int connIndex, int steps, struct ncclShmemData* ncclShmem) {
+  static inline __device__ void recvPeerNotify(int peer, int connIndex, int steps, struct ncclShmemData& ncclShmem) {
     int spins = 0;
 #ifdef ENABLE_WARP_SPEED
-    ncclDevChannelPeer* peerPtr = ncclShmem->warpChannel[threadIdx.x/WARP_SIZE].peers[peer];
+    ncclDevChannelPeer* peerPtr = ncclShmem.warpChannel[threadIdx.x/WARP_SIZE].peers[peer];
 #else
-    ncclDevChannelPeer* peerPtr = ncclShmem->channel.peers[peer];
+    ncclDevChannelPeer* peerPtr = ncclShmem.channel.peers[peer];
 #endif
     peerPtr->recv[connIndex].step += steps;
     st_relaxed_sys_global(peerPtr->recv[connIndex].head, peerPtr->recv[connIndex].step);
@@ -541,8 +541,8 @@ public:
             connStepCache = loadStepValue(connStepPtr);
             if (checkAbort(flags, Aborted, spins, ncclShmem)) break;
           }
-          void **ptrs = isSendNotRecv ? ncclShmem->groups[group].dsts
-                                      : ncclShmem->groups[group].srcs;
+          void **ptrs = isSendNotRecv ? ncclShmem.groups[group].dsts
+                                      : ncclShmem.groups[group].srcs;
           if ((flags & ConnFifoEnabled) && connFifo[step%NCCL_STEPS].mode == NCCL_MODE_OFFSET) {
             int offset = loadInt(&connFifo[step%NCCL_STEPS].offset);
             ptrs[index] = connEltsFifo + offset/sizeof(T);
@@ -572,21 +572,21 @@ public:
           }
         }
         subBarrier();
-        if (Recv == 0 || ncclShmem->groups[group].srcs[0] == nullptr) {
+        if (Recv == 0 || ncclShmem.groups[group].srcs[0] == nullptr) {
           nrecv = 0;
         } else {
           nrecv = fan.nrecv();
         }
 
-        if (Send == 0 || ncclShmem->groups[group].dsts[0] == nullptr) {
+        if (Send == 0 || ncclShmem.groups[group].dsts[0] == nullptr) {
           nsend = 0;
         } else {
           nsend = fan.nsend();
         }
         fn.template operator()<SlicePerChunk, 0, Recv*MaxRecv, 0, Send*MaxSend, MultimemSrcs, MultimemDsts>
           (tid, nworkers, slice, stepSize * StepPerSlice,
-            nrecv, ncclShmem->groups[group].srcs,
-            nsend, ncclShmem->groups[group].dsts, ncclShmem->groups[group].dstSizes, sendDirectFlag, recvDirectFlag,
+            nrecv, ncclShmem.groups[group].srcs,
+            nsend, ncclShmem.groups[group].dsts, ncclShmem.groups[group].dstSizes, sendDirectFlag, recvDirectFlag,
             ncclShmem);
       }
       barrier();
@@ -594,8 +594,8 @@ public:
       if (flags & Send*RolePostSend) {
         // Yes, for some template arguments this code will be unreachable.  That's fine.
         // coverity[dead_error_begin]
-        dstSize = ncclShmem->groups[group].dstSizes[index];
-        ncclShmem->groups[group].dstSizes[index] = 0;
+        dstSize = ncclShmem.groups[group].dstSizes[index];
+        ncclShmem.groups[group].dstSizes[index] = 0;
         if (flags & ConnFifoEnabled) connFifo[step%NCCL_STEPS].size = dstSize*sizeof(T);
       }
       barrier();
@@ -632,7 +632,7 @@ private:
         if (Send) {
           // Scatter pre-scales data of input buffer only in non-Direct case
           constexpr int PreOpSrcs = DirectSend ? 0 : 1;
-          if (tid==0) ncclShmem->groups[group].srcs[0] = (T*)ncclShmem->groups[group].userInput + inpIx + offset;
+          if (tid==0) ncclShmem.groups[group].srcs[0] = (T*)ncclShmem.groups[group].userInput + inpIx + offset;
           // realSize is not accurate here; but intra-node does not rely on sizes FIFO
           waitPeer<0, DirectSend, 0, 1, 1, 0>(0, inpIx, offset, realSize);
           subBarrier();
@@ -643,16 +643,16 @@ private:
             ssize_t pOffset = i*peerOffset;
             // Skip the data I am responsible of reducing myself
             if (skip >= 0 && i >= skip) pOffset += peerOffset;
-            void* src0 = (T*)ncclShmem->groups[group].srcs[0] + pOffset;
+            void* src0 = (T*)ncclShmem.groups[group].srcs[0] + pOffset;
             ssize_t realPeerSize = min(realSize, totalElem-pOffset);
-            if (realPeerSize > 0 && ncclShmem->groups[group].dsts[i] != nullptr) {
-              reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 1, 0, 1, 1, PreOpSrcs>(tid, nworkers, ncclShmem->redOpArgs[0], ncclShmem->redOpArgs, false, 1, &src0, 1, ncclShmem->groups[group].dsts+i, realPeerSize);
+            if (realPeerSize > 0 && ncclShmem.groups[group].dsts[i] != nullptr) {
+              reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 1, 0, 1, 1, PreOpSrcs>(tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, false, 1, &src0, 1, ncclShmem.groups[group].dsts+i, realPeerSize);
               // Mark for threadfence at the end
               fenceNeeded |= true;
             }
           }
         } else if (Recv) {
-          if (tid==0) ncclShmem->groups[group].dsts[0] = (T*)ncclShmem->groups[group].userOutput + outIx + offset;
+          if (tid==0) ncclShmem.groups[group].dsts[0] = (T*)ncclShmem.groups[group].userOutput + outIx + offset;
           ssize_t pOffset = index*peerOffset;
           if (skip >= 0 && index >= skip) pOffset += peerOffset;
           // Adjust remote index with peer offset in case we are directly pulling from peer's output buffer
@@ -663,10 +663,10 @@ private:
             int i = (j+shift)%fan.nrecv();
             pOffset = i*peerOffset;
             if (skip >= 0 && i >= skip) pOffset += peerOffset;
-            void* dst0 = (T*)ncclShmem->groups[group].dsts[0] + pOffset;
+            void* dst0 = (T*)ncclShmem.groups[group].dsts[0] + pOffset;
             ssize_t realPeerSize = min(realSize, totalElem-pOffset);
-            if (DirectRecv && ncclShmem->groups[group].srcs[i] == dst0) realPeerSize = 0;
-            if (realPeerSize > 0) reduceCopy<Unroll, useAcc, RedOp, T, 0,1,1, 0,1,1, /*PreOpSrcs=*/0>(tid, nworkers, ncclShmem->redOpArgs[0], ncclShmem->redOpArgs, postOp, 1, ncclShmem->groups[group].srcs+i, 1, &dst0, realPeerSize);
+            if (DirectRecv && ncclShmem.groups[group].srcs[i] == dst0) realPeerSize = 0;
+            if (realPeerSize > 0) reduceCopy<Unroll, useAcc, RedOp, T, 0,1,1, 0,1,1, /*PreOpSrcs=*/0>(tid, nworkers, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, postOp, 1, ncclShmem.groups[group].srcs+i, 1, &dst0, realPeerSize);
           }
         }
       }
@@ -692,7 +692,7 @@ private:
       STORE(connStepPtr, step); // Return credits in case we rounded up.
     }
     if (flags & RoleWaitRecv) {
-      if ((flags & PatMode) == 0) ncclShmem->groups[group].recvConns[index] = conn; // WaitRecv role saves since that's who needs it in setDataPtrs()
+      if ((flags & PatMode) == 0) ncclShmem.groups[group].recvConns[index] = conn; // WaitRecv role saves since that's who needs it in setDataPtrs()
       flags |= (conn->flags & NCCL_NVLS_MIN_POLL) ? NvlsMinPolling : 0;
       connStepPtr = conn->tail;
       connStepCache = loadStepValue(connStepPtr);
@@ -742,7 +742,7 @@ private:
       connEltsFifo = (T*)conn->buffs[NCCL_PROTO_SIMPLE];
     }
     if (flags & RoleWaitSend) {
-      if ((flags & PatMode) == 0) ncclShmem->groups[group].sendConns[index] = conn; // WaitSend role saves since that's who needs it in setDataPtrs()
+      if ((flags & PatMode) == 0) ncclShmem.groups[group].sendConns[index] = conn; // WaitSend role saves since that's who needs it in setDataPtrs()
       flags |= (conn->flags & NCCL_NVLS_MIN_POLL) ? NvlsMinPolling : 0;
       connStepPtr = conn->head;
       connStepCache = loadStepValue(connStepPtr);
@@ -777,26 +777,26 @@ public:
   __forceinline__ __device__ Primitives(
       int tid, int nthreads, int const *recvPeers, int const *sendPeers,
       void const *inputBuf, void *outputBuf, uint64_t redOpArg,
-      struct ncclShmemData* shmem, void* ncclShmemPerWarp_,
+      struct ncclShmemData& shmem, void* ncclShmemPerWarp_,
       uint8_t group=0, uint8_t connIndexRecv = 0, uint8_t connIndexSend = 0,
       struct ncclDevWorkColl* collWork = nullptr, struct ncclDevWorkP2p* p2pWork = nullptr,
       int stepSize_ = 0, int mode = primsModeDefault
     ):
     tid(tid), tidInBlock(threadIdx.x), nthreads(nthreads), /*compiler warnings*/
 #ifdef ENABLE_WARP_SPEED
-    stepSize(stepSize_ == 0 ? shmem->comm.buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS/sizeof(T) : stepSize_), group(shmem->warpComm? tidInBlock / WARP_SIZE : group), threadsPerBlock(blockDim.x),
+    stepSize(stepSize_ == 0 ? shmem.comm.buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS/sizeof(T) : stepSize_), group(shmem.warpComm? tidInBlock / WARP_SIZE : group), threadsPerBlock(blockDim.x),
 #else
-    stepSize(stepSize_ == 0 ? shmem->comm.buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS/sizeof(T) : stepSize_), group(group), threadsPerBlock(blockDim.x),
+    stepSize(stepSize_ == 0 ? shmem.comm.buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS/sizeof(T) : stepSize_), group(group), threadsPerBlock(blockDim.x),
 #endif
     ncclShmem(shmem), ncclShmemPerWarp(ncclShmemPerWarp_){
-    barriers = &shmem->groups[group].barrier;
+    barriers = &shmem.groups[group].barrier;
     // PAT uses the same barrier for each group
-    barriers_pat = &shmem->barrier_pat;
+    barriers_pat = &shmem.barrier_pat;
     this->nworkers = nthreads;
 #ifdef ENABLE_WARP_SPEED
-    auto *channel = isMsccl(Metadata) ? &ncclShmem->channel : &ncclShmem->warpChannel[tidInBlock/WARP_SIZE];
+    auto *channel = isMsccl(Metadata) ? &ncclShmem.channel : &ncclShmem.warpChannel[tidInBlock/WARP_SIZE];
 #else
-    auto *channel = &ncclShmem->channel;
+    auto *channel = &ncclShmem.channel;
 #endif
     int peer = -1;
     flags = 0;
@@ -862,7 +862,7 @@ public:
       //   // have NetDeviceUnpack.
       //   uint32_t mask = __ballot_sync(~0u, ((flags & RoleWaitRecv) && (flags & NetDeviceUnpack)) ? 1 : 0);
       //   if (tid == 0) {
-      //     ncclShmem->groups[this->group].devicePlugin.unpack.unpackNetDeviceIndexMask = mask;
+      //     ncclShmem.groups[this->group].devicePlugin.unpack.unpackNetDeviceIndexMask = mask;
       //   }
       // }
 
@@ -875,9 +875,9 @@ public:
       const int roles[5] = { RoleWaitRecv, RolePostRecv, RoleWaitSend, RolePostSend, RoleInput | RoleOutput };
       if (tid < 5) flags |= roles[tid];
 
-      int nranks = ncclShmem->comm.nRanks;
+      int nranks = ncclShmem.comm.nRanks;
       if (tid < 32 && ((1UL<<tid) < nranks)) {
-        int rank = ncclShmem->comm.rank;
+        int rank = ncclShmem.comm.rank;
         uint32_t delta = 1 << tid;
         // Load recv peer
         int recvPeer = mode == primsModePatRs ? (rank - delta + nranks) % nranks : (rank + delta) % nranks;
@@ -902,9 +902,9 @@ public:
         peer->connStepSize = conn->stepSize/sizeof(T);
       }
       if (tid==0) {
-        ncclShmem->groups[group].userInput = (void*)inputBuf;
-        ncclShmem->groups[group].userOutput = (void*)outputBuf;
-        ncclShmem->redOpArgs[0] = redOpArg;  // scaler for local input
+        ncclShmem.groups[group].userInput = (void*)inputBuf;
+        ncclShmem.groups[group].userOutput = (void*)outputBuf;
+        ncclShmem.redOpArgs[0] = redOpArg;  // scaler for local input
       }
       patBarrier();
     }
@@ -932,7 +932,7 @@ public:
     }
 
     // Make sure all threads are done writing back conn->step and done using
-    // ncclShmem->groups[group]
+    // ncclShmem.groups[group]
     barrier();
 
     if ((flags & DirectRead) && (flags & RoleWaitSend) && P2p) {
@@ -948,10 +948,10 @@ public:
 
   __device__ void setDataPtrs(void const *inputBuf, void *outputBuf, uint64_t redOpArg, struct ncclDevWorkCollReg* work, uint8_t ipcReg, int peer, void const *acc) {
     if (tid==0) {
-      ncclShmem->groups[group].userInput = (void*)inputBuf;
-      ncclShmem->groups[group].userOutput = (void*)outputBuf;
-      ncclShmem->groups[group].userAcc = (void*)acc;
-      ncclShmem->redOpArgs[0] = redOpArg;  // scaler for local input
+      ncclShmem.groups[group].userInput = (void*)inputBuf;
+      ncclShmem.groups[group].userOutput = (void*)outputBuf;
+      ncclShmem.groups[group].userAcc = (void*)acc;
+      ncclShmem.redOpArgs[0] = redOpArg;  // scaler for local input
     }
 
     if (Direct && ipcReg) {
@@ -961,7 +961,7 @@ public:
       bool recvAcceptor = (flags & RoleWaitRecv) && (flags & DirectRead); // receiver accepts direct buffer
       if (recvProvider) {
         int spins = 0;
-        void* volatile* slot = ncclShmem->groups[group].recvConns[index]->ptrExchange;
+        void* volatile* slot = ncclShmem.groups[group].recvConns[index]->ptrExchange;
         // Wait for consumer to consume previous value before trampling it.
         if (slot) {
           T* exchgPtr;
@@ -970,7 +970,7 @@ public:
           if (P2p) {
             exchgPtr = (T*)outputBuf;
           } else {
-            int localPeer = ncclShmem->comm.rankToLocalRank[peer];
+            int localPeer = ncclShmem.comm.rankToLocalRank[peer];
             // coverity[deref_parm:FALSE] => work cannot be NULL if ipcReg != NULL
             exchgPtr = (T*)(work->coll.recvbuffOffset + work->coll.recvbuffRmtAddrs[localPeer]);
           }
@@ -979,7 +979,7 @@ public:
       }
       if (sendAcceptor) {
         int spins = 0;
-        void* volatile* slot = ncclShmem->groups[group].sendConns[index]->ptrExchange;
+        void* volatile* slot = ncclShmem.groups[group].sendConns[index]->ptrExchange;
         void* ptr;
         while (slot) {
           ptr = (void *)atomicAdd((unsigned long long *) slot,0);
@@ -996,9 +996,9 @@ public:
       }
       if (sendProvider) {
         int spins = 0;
-        void* volatile* slot = ncclShmem->groups[group].sendConns[index]->ptrExchange;
-        volatile uint64_t* argSlot0 = ncclShmem->groups[group].sendConns[index]->redOpArgExchange;
-        volatile uint64_t* argSlot1 = ncclShmem->groups[group].sendConns[index]->redOpArgExchange + 1;
+        void* volatile* slot = ncclShmem.groups[group].sendConns[index]->ptrExchange;
+        volatile uint64_t* argSlot0 = ncclShmem.groups[group].sendConns[index]->redOpArgExchange;
+        volatile uint64_t* argSlot1 = ncclShmem.groups[group].sendConns[index]->redOpArgExchange + 1;
         // Wait for consumer to consume previous value before trampling it.
         if (slot && argSlot0 && argSlot1) {
           T* exchgPtr;
@@ -1009,7 +1009,7 @@ public:
           if (P2p) {
             exchgPtr = MaxRecv == 0 ? (T*)inputBuf : (T*)outputBuf;
           } else {
-            int localPeer = ncclShmem->comm.rankToLocalRank[peer];
+            int localPeer = ncclShmem.comm.rankToLocalRank[peer];
             if (MaxRecv == 0)
               // coverity[var_deref_op]
               exchgPtr = (T*)(work->coll.sendbuffOffset + work->coll.sendbuffRmtAddrs[localPeer]);
@@ -1026,9 +1026,9 @@ public:
       }
       if (recvAcceptor) {
         int spins = 0;
-        void* volatile* slot = ncclShmem->groups[group].recvConns[index]->ptrExchange;
-        volatile uint64_t* argSlot0 = ncclShmem->groups[group].recvConns[index]->redOpArgExchange;
-        volatile uint64_t* argSlot1 = ncclShmem->groups[group].recvConns[index]->redOpArgExchange + 1;
+        void* volatile* slot = ncclShmem.groups[group].recvConns[index]->ptrExchange;
+        volatile uint64_t* argSlot0 = ncclShmem.groups[group].recvConns[index]->redOpArgExchange;
+        volatile uint64_t* argSlot1 = ncclShmem.groups[group].recvConns[index]->redOpArgExchange + 1;
         void* ptr;
         while (slot) {
           ptr = (void *)atomicAdd((unsigned long long *) slot,0);
@@ -1045,7 +1045,7 @@ public:
               arg1 = *argSlot1;
               if ((arg0 != 0 && arg1 != 0) || checkAbort(flags, Aborted, spins, ncclShmem)) break;
             }
-            ncclShmem->redOpArgs[1 + index] = ((arg1 & 0xffffffff) << 32) | (arg0 & 0xffffffff);
+            ncclShmem.redOpArgs[1 + index] = ((arg1 & 0xffffffff) << 32) | (arg0 & 0xffffffff);
           }
           *argSlot0 = 0; *argSlot1 = 0;
           *slot = nullptr;
@@ -1062,16 +1062,16 @@ public:
 
   __device__ void moveDataPtrs(intptr_t delta) {
     if (tid==0) {
-      ncclShmem->groups[group].userInput = (T*)ncclShmem->groups[group].userInput + delta;
-      ncclShmem->groups[group].userOutput = (T*)ncclShmem->groups[group].userOutput + delta;
+      ncclShmem.groups[group].userInput = (T*)ncclShmem.groups[group].userInput + delta;
+      ncclShmem.groups[group].userOutput = (T*)ncclShmem.groups[group].userOutput + delta;
     }
   }
 
   // Set MSCCL data pointers
   __device__ __forceinline__ void setDataPtrs(void const *inputBuf, void *outputBuf = nullptr) {
     if (tid==0) {
-      ncclShmem->groups[group].userInput = (T*)inputBuf;
-      ncclShmem->groups[group].userOutput = (T*)outputBuf;
+      ncclShmem.groups[group].userInput = (T*)inputBuf;
+      ncclShmem.groups[group].userOutput = (T*)outputBuf;
     }
   }
 
@@ -1179,8 +1179,8 @@ public:
   __device__ __forceinline__ void patReduce(struct ncclPatStep* ps, struct ncclPatShmem* shmem) {
     if (ps->flags & PatSkipped) { patBarrier(); patBarrier(); return; } // Skipped
     int nelem = ps->nelem < 0 ? 0 : ps->nelem;
-    T* userInput = (T*)ncclShmem->groups[group].userInput;
-    T* userOutput = (T*)ncclShmem->groups[group].userOutput;
+    T* userInput = (T*)ncclShmem.groups[group].userInput;
+    T* userOutput = (T*)ncclShmem.groups[group].userOutput;
 
     bool recv = ps->recvDim >= 0 && (flags & (RolePostRecv|RoleWaitRecv));
     bool send = ps->sendDim >= 0 && (flags & (RolePostSend|RoleWaitSend));
@@ -1197,7 +1197,7 @@ public:
     }
 
     if (recv && (flags & RoleWaitRecv)) {
-      ncclShmem->groups[group].srcs[0] = ((T*)peer->buff) + (step%NCCL_STEPS)*peer->connStepSize + ps->recvOffset;
+      ncclShmem.groups[group].srcs[0] = ((T*)peer->buff) + (step%NCCL_STEPS)*peer->connStepSize + ps->recvOffset;
       int spins = 0;
       while (peer->stepCache < step + StepPerSlice) {
         peer->stepCache = loadStepValue(peer->tailPtr);
@@ -1210,37 +1210,37 @@ public:
         peer->stepCache = loadStepValue(peer->headPtr);
         if (checkAbort(flags, Aborted, spins, ncclShmem)) break;
       }
-      ncclShmem->groups[group].dsts[0] = ((T*)peer->buff) + ((step+ps->stepOffset)%NCCL_STEPS)*peer->connStepSize + ps->sendOffset;
+      ncclShmem.groups[group].dsts[0] = ((T*)peer->buff) + ((step+ps->stepOffset)%NCCL_STEPS)*peer->connStepSize + ps->sendOffset;
       if (peer->accSize < ps->sendOffset + nelem + (step+ps->stepOffset)*peer->connStepSize) {
         // New data, add our own data to it.
-        ncclShmem->groups[group].srcs[1] = userInput + ps->inpIx;
+        ncclShmem.groups[group].srcs[1] = userInput + ps->inpIx;
       } else {
         // There is already data in there, accumulate instead of writing to it.
-        ncclShmem->groups[group].srcs[1] = ncclShmem->groups[group].dsts[0];
+        ncclShmem.groups[group].srcs[1] = ncclShmem.groups[group].dsts[0];
       }
     }
     long long int localAccSize = shmem->localAccSize;
     if (ps->sendDim < 0 && (flags & RoleOutput)) { // Destination is our own local buffer
-      ncclShmem->groups[group].dsts[0] = userOutput + ps->outIx;
+      ncclShmem.groups[group].dsts[0] = userOutput + ps->outIx;
       if (localAccSize < ps->outIx + nelem) {
         // New data, add our own data to it.
-        ncclShmem->groups[group].srcs[1] = userInput + ps->inpIx;
+        ncclShmem.groups[group].srcs[1] = userInput + ps->inpIx;
         localAccSize = ps->outIx + nelem;
       } else {
         // There is already data in there, accumulate instead of writing to it.
-        ncclShmem->groups[group].srcs[1] = ncclShmem->groups[group].dsts[0];
+        ncclShmem.groups[group].srcs[1] = ncclShmem.groups[group].dsts[0];
       }
     }
     patBarrier();
     int nSrcs = 2;
-    void** srcs = ncclShmem->groups[group].srcs;
+    void** srcs = ncclShmem.groups[group].srcs;
     if (ps->recvDim < 0) { srcs++; nSrcs--; } // No peer to receive from, remove one source
 
-    int workSize = ncclShmem->aborted ? 0 : nelem;
+    int workSize = ncclShmem.aborted ? 0 : nelem;
 
     reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 2, 0, 1, 1, /*PreOpSrcs*/0>
-      (tid, nthreads, ncclShmem->redOpArgs[0],  nullptr, /*postOp=*/false,
-      nSrcs, srcs, 1, ncclShmem->groups[group].dsts, workSize);
+      (tid, nthreads, ncclShmem.redOpArgs[0],  nullptr, /*postOp=*/false,
+      nSrcs, srcs, 1, ncclShmem.groups[group].dsts, workSize);
 
     // Store conn step here inside the two barriers to make sure next reload will see the update.
     if (postSend && (flags & RolePostSend)) {
@@ -1273,8 +1273,8 @@ public:
   __device__ __forceinline__ void patCopy(struct ncclPatStep* ps, struct ncclPatShmem* shmem) {
     if (ps->flags & PatSkipped) { patBarrier(); patBarrier(); return; } // Skipped
     int nelem = ps->nelem < 0 ? 0 : ps->nelem;
-    T* userInput = (T*)ncclShmem->groups[group].userInput;
-    T* userOutput = (T*)ncclShmem->groups[group].userOutput;
+    T* userInput = (T*)ncclShmem.groups[group].userInput;
+    T* userOutput = (T*)ncclShmem.groups[group].userOutput;
 
     bool recv = ps->recvDim >= 0 && (flags & (RolePostRecv|RoleWaitRecv));
     bool send = ps->sendDim >= 0 && (flags & (RolePostSend|RoleWaitSend));
@@ -1291,7 +1291,7 @@ public:
     }
 
     if (recv && (flags & RoleWaitRecv)) {
-      ncclShmem->groups[group].srcs[0] = ((T*)peer->buff) + ((step+ps->stepOffset)%NCCL_STEPS)*peer->connStepSize + ps->recvOffset;
+      ncclShmem.groups[group].srcs[0] = ((T*)peer->buff) + ((step+ps->stepOffset)%NCCL_STEPS)*peer->connStepSize + ps->recvOffset;
       int spins = 0;
       while (peer->stepCache < step + ps->stepOffset + StepPerSlice) {
         peer->stepCache = loadStepValue(peer->tailPtr);
@@ -1299,9 +1299,9 @@ public:
       }
       if (peer->accSize < ps->recvOffset + nelem + (step+ps->stepOffset)*peer->connStepSize) {
         // New data, copy to our output buffer.
-        ncclShmem->groups[group].dsts[1] = userOutput + ps->outIx;
+        ncclShmem.groups[group].dsts[1] = userOutput + ps->outIx;
       } else {
-        ncclShmem->groups[group].dsts[1] = ncclShmem->groups[group].srcs[0]; // Already done
+        ncclShmem.groups[group].dsts[1] = ncclShmem.groups[group].srcs[0]; // Already done
       }
     }
     if (send && (flags & RoleWaitSend)) {
@@ -1310,31 +1310,31 @@ public:
         peer->stepCache = loadStepValue(peer->headPtr);
         if (checkAbort(flags, Aborted, spins, ncclShmem)) break;
       }
-      ncclShmem->groups[group].dsts[0] = ((T*)peer->buff) + (step%NCCL_STEPS)*peer->connStepSize + ps->sendOffset;
+      ncclShmem.groups[group].dsts[0] = ((T*)peer->buff) + (step%NCCL_STEPS)*peer->connStepSize + ps->sendOffset;
     }
     long long int localAccSize = shmem->localAccSize;
     if (ps->recvDim < 0 && (flags & RoleInput)) { // Source is our own local buffer
-      ncclShmem->groups[group].srcs[0] = userInput + ps->inpIx;
+      ncclShmem.groups[group].srcs[0] = userInput + ps->inpIx;
       if (localAccSize < ps->inpIx + nelem) {
         // New data, copy to our output buffer.
-        ncclShmem->groups[group].dsts[1] = userOutput + ps->outIx;
+        ncclShmem.groups[group].dsts[1] = userOutput + ps->outIx;
         localAccSize = ps->inpIx + nelem;
       } else {
         // Already done
-        ncclShmem->groups[group].dsts[1] = ncclShmem->groups[group].srcs[0];
+        ncclShmem.groups[group].dsts[1] = ncclShmem.groups[group].srcs[0];
       }
     }
     patBarrier();
     int nDsts = 2;
-    void** dsts = ncclShmem->groups[group].dsts;
+    void** dsts = ncclShmem.groups[group].dsts;
     if (ps->sendDim < 0) { dsts++; nDsts--; } // No peer to send to, remove one dest
-    if (ncclShmem->groups[group].srcs[0] == ncclShmem->groups[group].dsts[1]) nDsts--; // In-place or already done.
+    if (ncclShmem.groups[group].srcs[0] == ncclShmem.groups[group].dsts[1]) nDsts--; // In-place or already done.
 
-    int workSize = ncclShmem->aborted ? 0 : nelem;
+    int workSize = ncclShmem.aborted ? 0 : nelem;
 
     reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 1, 0, 1, 2, /*PreOpSrcs*/0>
-      (tid, nthreads, ncclShmem->redOpArgs[0],  nullptr, /*postOp=*/false,
-      1, ncclShmem->groups[group].srcs, nDsts, dsts, workSize);
+      (tid, nthreads, ncclShmem.redOpArgs[0],  nullptr, /*postOp=*/false,
+      1, ncclShmem.groups[group].srcs, nDsts, dsts, workSize);
 
     // Store conn step here inside the two barriers to make sure next reload will see the update.
     if (postSend && (flags & RolePostSend)) {

--- a/projects/rccl/src/device/prims_simple.h
+++ b/projects/rccl/src/device/prims_simple.h
@@ -1,3 +1,5 @@
+#ifndef NCCL_DEVICE_PRIMS_SIMPLE_H_
+#define NCCL_DEVICE_PRIMS_SIMPLE_H_
 /*************************************************************************
  * Copyright (c) 2016-2022, NVIDIA CORPORATION. All rights reserved.
  * Modifications Copyright (c) 2019-2023 Advanced Micro Devices, Inc. All rights reserved.
@@ -1372,3 +1374,5 @@ public:
     return mscclGenericOp<0,1,0,0>(&srcs, 1, &dsts, 1, eltN);
   }
 };
+
+#endif // NCCL_DEVICE_PRIMS_SIMPLE_H_

--- a/projects/rccl/src/device/reduce.h
+++ b/projects/rccl/src/device/reduce.h
@@ -12,27 +12,27 @@
 namespace {
   template<typename T, typename RedOp, typename Proto>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #endif
 #ifdef ENABLE_WARP_SPEED
     int warp = threadIdx.x / WARP_SIZE;
-    ncclRing *ring = &ncclShmem.warpChannel[warp].ring;
+    ncclRing *ring = &ncclShmem->warpChannel[warp].ring;
 #else
-    ncclRing *ring = &ncclShmem.channel.ring;
+    ncclRing *ring = &ncclShmem->channel.ring;
 #endif
-    const int nranks = ncclShmem.comm.nRanks;
-    const int rank = ncclShmem.comm.rank;
+    const int nranks = ncclShmem->comm.nRanks;
+    const int rank = ncclShmem->comm.rank;
     const int prevRank = ring->userRanks[nranks-1];
     const int root = work->root;
     size_t chunkCount;
     size_t channelCount;
     size_t gridOffset;
 #ifdef ENABLE_WARP_SPEED
-    ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), (size_t*)nullptr, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem->warpChannelId[warp], Proto::Id, sizeof(T), (size_t*)nullptr, &gridOffset, &channelCount, &chunkCount);
 #else
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), (size_t*)nullptr, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), (size_t*)nullptr, &gridOffset, &channelCount, &chunkCount);
 #endif
     size_t offset;
     int nelem;
@@ -41,7 +41,7 @@ namespace {
     // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
     // coverity[callee_ptr_arith:FALSE]
     Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, false, 0, Pipeline>
-      prims(tid, nthreads, &ring->prev, &ring->next, work->sendbuff, work->recvbuff, work->redOpArg, 0, work->connIndex, work->connIndex);
+      prims(tid, nthreads, &ring->prev, &ring->next, work->sendbuff, work->recvbuff, work->redOpArg, ncclShmem, ncclShmemPerWarp, 0, work->connIndex, work->connIndex, work, nullptr, 0, primsModeDefault);
 
     if (prevRank == root) {
       for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
@@ -69,22 +69,22 @@ namespace {
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
     using Proto = ProtoSimple<REDUCE_CHUNKSTEPS/REDUCE_SLICESTEPS, REDUCE_SLICESTEPS>;
-    runRing<T, RedOp, Proto>(tid, nthreads, work);
+    runRing<T, RedOp, Proto>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    runRing<T, RedOp, ProtoLL>(tid, nthreads, work);
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    runRing<T, RedOp, ProtoLL>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    runRing<T, RedOp, ProtoLL128>(tid, nthreads, work);
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    runRing<T, RedOp, ProtoLL128>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };

--- a/projects/rccl/src/device/reduce.h
+++ b/projects/rccl/src/device/reduce.h
@@ -12,27 +12,27 @@
 namespace {
   template<typename T, typename RedOp, typename Proto>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #endif
 #ifdef ENABLE_WARP_SPEED
     int warp = threadIdx.x / WARP_SIZE;
-    ncclRing *ring = &ncclShmem->warpChannel[warp].ring;
+    ncclRing *ring = &ncclShmem.warpChannel[warp].ring;
 #else
-    ncclRing *ring = &ncclShmem->channel.ring;
+    ncclRing *ring = &ncclShmem.channel.ring;
 #endif
-    const int nranks = ncclShmem->comm.nRanks;
-    const int rank = ncclShmem->comm.rank;
+    const int nranks = ncclShmem.comm.nRanks;
+    const int rank = ncclShmem.comm.rank;
     const int prevRank = ring->userRanks[nranks-1];
     const int root = work->root;
     size_t chunkCount;
     size_t channelCount;
     size_t gridOffset;
 #ifdef ENABLE_WARP_SPEED
-    ncclCollCbdPart(work, ncclShmem->warpChannelId[warp], Proto::Id, sizeof(T), (size_t*)nullptr, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), (size_t*)nullptr, &gridOffset, &channelCount, &chunkCount);
 #else
-    ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), (size_t*)nullptr, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), (size_t*)nullptr, &gridOffset, &channelCount, &chunkCount);
 #endif
     size_t offset;
     int nelem;
@@ -69,7 +69,7 @@ namespace {
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     using Proto = ProtoSimple<REDUCE_CHUNKSTEPS/REDUCE_SLICESTEPS, REDUCE_SLICESTEPS>;
     runRing<T, RedOp, Proto>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
@@ -77,14 +77,14 @@ struct RunWorkColl<ncclFuncReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> 
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     runRing<T, RedOp, ProtoLL>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     runRing<T, RedOp, ProtoLL128>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };

--- a/projects/rccl/src/device/reduce.h
+++ b/projects/rccl/src/device/reduce.h
@@ -1,3 +1,5 @@
+#ifndef NCCL_DEVICE_REDUCE_H_
+#define NCCL_DEVICE_REDUCE_H_
 /*************************************************************************
  * Copyright (c) 2015-2022, NVIDIA CORPORATION. All rights reserved.
  * Modifications Copyright (c) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
@@ -88,3 +90,4 @@ struct RunWorkColl<ncclFuncReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
     runRing<T, RedOp, ProtoLL128>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
+#endif // NCCL_DEVICE_REDUCE_H_

--- a/projects/rccl/src/device/reduce_scatter.h
+++ b/projects/rccl/src/device/reduce_scatter.h
@@ -12,14 +12,14 @@
 namespace {
   template<typename T, typename RedOp, typename Proto>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #endif
     //TODO: move Direct Reduce Scatter path to a separate kernel
-    size_t msgSize = work->count * sizeof(T) * ncclShmem.comm.nRanks;
+    size_t msgSize = work->count * sizeof(T) * ncclShmem->comm.nRanks;
     if (work->enableDirectReduceScatter && msgSize <= (size_t)work->directReduceScatterLimitBytes) {
-      const int nRanks = ncclShmem.comm.nRanks; 
+      const int nRanks = ncclShmem->comm.nRanks; 
       const ssize_t numElements = work->count;
 
       // Calculate Offset to utilize multiple channels
@@ -31,7 +31,7 @@ namespace {
       ssize_t channelOffset = blockIdx.x * elementsPerBlock + min((ssize_t)blockIdx.x, remainderElements);
 
       // Array of src pointers pointing to rank offsets in tempBuff
-      void** srcPtrs = (void**)ncclScratchForWarp(0); 
+      void** srcPtrs = (void**)ncclScratchForWarp(ncclShmemPerWarp, 0);
       if (tid == 0) {
         for (int i = 0; i < nRanks; i++) {
           // Define offset into tempbuff for each rank's data
@@ -49,25 +49,25 @@ namespace {
       if (tid < nthreads) {
         // Call reduction across all rank offsets in tempbuff and store in recvbuff
         reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0, 1, 64, 0, 1, 1, 0>
-          (tid, nthreads, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, false, nRanks, srcPtrs, 1, dstPtrs, numElementsPerBlock);
+          (tid, nthreads, ncclShmem->redOpArgs[0], ncclShmem->redOpArgs, false, nRanks, srcPtrs, 1, dstPtrs, numElementsPerBlock);
       }
     } else {
   #ifdef ENABLE_WARP_SPEED
       int warp = threadIdx.x / WARP_SIZE;
-      ncclRing *ring = &ncclShmem.warpChannel[warp].ring;
+      ncclRing *ring = &ncclShmem->warpChannel[warp].ring;
   #else
-      ncclRing *ring = &ncclShmem.channel.ring;
+      ncclRing *ring = &ncclShmem->channel.ring;
   #endif
       int const *ringRanks = ring->userRanks;
-      const int nranks = ncclShmem.comm.nRanks; 
+      const int nranks = ncclShmem->comm.nRanks; 
       size_t count;
       size_t gridOffset;
       size_t channelCount;
       size_t chunkCount;
   #ifdef ENABLE_WARP_SPEED
-      ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
+      ncclCollCbdPart(work, ncclShmem->warpChannelId[warp], Proto::Id, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
   #else
-      ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
+      ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
   #endif
       size_t offset;
       size_t dataOffset;
@@ -75,34 +75,34 @@ namespace {
       int rankDest;
 
   #if defined(ENABLE_NPKIT)
-      int npKitCtxIdx = ncclShmem.channelId;
+      int npKitCtxIdx = ncclShmem->channelId;
   #endif
 
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, 0, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK,
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
       }
   #endif
 
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_GPU)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
       }
   #endif
 
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_REDUCE_SCATTER_RING_ENTRY)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_REDUCE_SCATTER_RING_ENTRY, count*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
       }
   #endif
       // Coverity reports that the callee treats &ring->next as an array.  However, due to the use of
       // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
       // coverity[callee_ptr_arith:FALSE]
       Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, false, 0, Pipeline>
-        prims(tid, nthreads, &ring->prev, &ring->next, work->sendbuff, work->recvbuff, work->redOpArg, 0, work->connIndex, work->connIndex);
+        prims(tid, nthreads, &ring->prev, &ring->next, work->sendbuff, work->recvbuff, work->redOpArg, ncclShmem, ncclShmemPerWarp, 0, work->connIndex, work->connIndex, work, nullptr, 0, primsModeDefault);
 
   #if defined(ENABLE_NPKIT)
       if (tid == 0) {
@@ -119,7 +119,7 @@ namespace {
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_REDUCE_SCATTER_RING_SEND_ENTRY)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_REDUCE_SCATTER_RING_SEND_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         }
   #endif
         rankDest = ringRanks[nranks-1];
@@ -128,14 +128,14 @@ namespace {
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_REDUCE_SCATTER_RING_SEND_EXIT)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_REDUCE_SCATTER_RING_SEND_EXIT, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         }
   #endif
         // k-2 steps: reduce and copy to next GPU
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_REDUCE_SCATTER_RING_RECV_REDUCE_SEND_ENTRY)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_REDUCE_SCATTER_RING_RECV_REDUCE_SEND_ENTRY, nelem*(nranks-2)*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         }
   #endif
         for (int j=2; j<nranks; ++j) {
@@ -146,7 +146,7 @@ namespace {
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_REDUCE_SCATTER_RING_RECV_REDUCE_SEND_EXIT)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_REDUCE_SCATTER_RING_RECV_REDUCE_SEND_EXIT, nelem*(nranks-2)*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         }
   #endif
 
@@ -154,7 +154,7 @@ namespace {
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_REDUCE_SCATTER_RING_RECV_REDUCE_COPY_ENTRY)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_REDUCE_SCATTER_RING_RECV_REDUCE_COPY_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         }
   #endif
         rankDest = ringRanks[0];
@@ -163,14 +163,14 @@ namespace {
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_REDUCE_SCATTER_RING_RECV_REDUCE_COPY_EXIT)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_REDUCE_SCATTER_RING_RECV_REDUCE_COPY_EXIT, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         }
   #endif
       }
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_REDUCE_SCATTER_RING_EXIT)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_REDUCE_SCATTER_RING_EXIT, count*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
       }
   #endif
     }
@@ -178,52 +178,52 @@ namespace {
 }
 
 #if defined(__gfx942__) || defined(__gfx950__) // Use a single slice per simple primitive for a single node on some GFX9 devices.
-#define rcclReduceScatterRunRingSimpleProtoImpl(tid, nthreads, work) \
+#define rcclReduceScatterRunRingSimpleProtoImpl(tid, nthreads, work, ncclShmem, ncclShmemPerWarp) \
   if(work->rcclUseOneSlice){ \
     using Proto = ProtoSimple<REDUCESCATTER_CHUNKSTEPS/REDUCESCATTER_SLICESTEPS_SINGLE_NODE, REDUCESCATTER_SLICESTEPS_SINGLE_NODE>; \
-    runRing<T, RedOp, Proto>(tid, nthreads, work); \
+    runRing<T, RedOp, Proto>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp); \
   } else{ \
     using Proto = ProtoSimple<REDUCESCATTER_CHUNKSTEPS/REDUCESCATTER_SLICESTEPS, REDUCESCATTER_SLICESTEPS>; \
-    runRing<T, RedOp, Proto>(tid, nthreads, work); \
+    runRing<T, RedOp, Proto>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp); \
   }
 #else
-#define rcclReduceScatterRunRingSimpleProtoImpl(tid, nthreads, work) \
+#define rcclReduceScatterRunRingSimpleProtoImpl(tid, nthreads, work, ncclShmem, ncclShmemPerWarp) \
   using Proto = ProtoSimple<REDUCESCATTER_CHUNKSTEPS/REDUCESCATTER_SLICESTEPS, REDUCESCATTER_SLICESTEPS>; \
-  runRing<T, RedOp, Proto>(tid, nthreads, work);
+  runRing<T, RedOp, Proto>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
 #endif
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    rcclReduceScatterRunRingSimpleProtoImpl(tid, nthreads, work);
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    rcclReduceScatterRunRingSimpleProtoImpl(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    runRing<T, RedOp, ProtoLL>(tid, nthreads, work);
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    runRing<T, RedOp, ProtoLL>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    runRing<T, RedOp, ProtoLL128>(tid, nthreads, work);
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    runRing<T, RedOp, ProtoLL128>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_PAT, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
     using Proto = ProtoSimple<1, 1>;
-    const int nranks = ncclShmem.comm.nRanks;
-    const int rank = ncclShmem.comm.rank;
+    const int nranks = ncclShmem->comm.nRanks;
+    const int rank = ncclShmem->comm.rank;
     size_t count, channelOffset, channelCount, chunkCount;
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &channelOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), &count, &channelOffset, &channelCount, &chunkCount);
 
     static constexpr int nworkers = NCCL_PAT_NWORKERS;
-    struct ncclPatShmem* shmem = (struct ncclPatShmem*)ncclScratchForWarp(0);
+    struct ncclPatShmem* shmem = (struct ncclPatShmem*)ncclScratchForWarp(ncclShmemPerWarp, 0);
     //uint64_t pollCount = 0; unused variable - compiler warning
     __syncthreads(); // Don't start using shared mem until everyone arrives
     for (int i=tid; i<NCCL_SHMEM_PAT_STEPS; i+=nthreads) shmem->patSteps[i].flags = 0;
@@ -260,7 +260,7 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_PAT, NCCL_PROTO_SI
       int tidInGroup = tid - group*groupSize;
       // We don't use recvPeers/sendPeers so let's pass shmem structs instead
       Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, false, 0, Pipeline> prims
-        (tidInGroup, groupSize, (int*)shmem->recvDims, (int*)shmem->sendDims, inputBuf, outputBuf, work->redOpArg, group, 0, 0, nullptr, nullptr, 0, primsModePatRs);
+        (tidInGroup, groupSize, (int*)shmem->recvDims, (int*)shmem->sendDims, inputBuf, outputBuf, work->redOpArg, ncclShmem, ncclShmemPerWarp, group, 0, 0, nullptr, nullptr, 0, primsModePatRs);
 
       int step = group;
       while(1) {
@@ -290,15 +290,16 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
     template<int SlicePerChunk, int MinSrcs, int MaxSrcs, int MinDsts, int MaxDsts, int MultimemSrcs, int MultimemDsts>
     __device__ __forceinline__ void operator()(
         int tid, int tn, int slice, int maxSliceSize,
-        int nSrcs, void** srcPtrs, int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag, uint32_t recvDirectFlag
+        int nSrcs, void** srcPtrs, int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag, uint32_t recvDirectFlag,
+        struct ncclShmemData* ncclShmem
       ) {
       static_assert(SlicePerChunk == 1, "require: SlicePerChunk==1");
       static_assert(MaxDsts <= 1 || MaxSrcs <= 1, "require: MaxDsts<=1 || MaxSrcs<=1");
 
-      struct ncclNvls* nvls = &ncclShmem.channel.nvls;
-      int nNodes = ncclShmem.comm.nNodes;
+      struct ncclNvls* nvls = &ncclShmem->channel.nvls;
+      int nNodes = ncclShmem->comm.nNodes;
       int nRails = nvls->nHeads;
-      int part = ncclShmem.channelId - work->channelLo;
+      int part = ncclShmem->channelId - work->channelLo;
       void* inbuf = (void*)work->sendbuff;
       ssize_t countPerRank = work->collnet.count;
 
@@ -323,7 +324,7 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
           ssize_t railOneEnd = railOneBeg + countPerRank;
           ssize_t railOneOffset = (railAllBeg + railAllOffset) - railOneBeg;
           int delta = min(railAllEnd, railOneEnd) - (railAllBeg + railAllOffset);
-          int rank = ncclShmem.comm.collNetDenseToUserRank[node * nRails + rail];
+          int rank = ncclShmem->comm.collNetDenseToUserRank[node * nRails + rail];
           ssize_t userOneBeg = rank * countPerRank + railOneOffset;
           if (nDsts != 0) {
             reduceCopy<ncclCollUnroll(), USE_ACC, RedOp, T,
@@ -349,8 +350,8 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
     }
   };
 
-  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work) {
-    struct ncclNvls* nvls = &ncclShmem.channel.nvls;
+  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    struct ncclNvls* nvls = &ncclShmem->channel.nvls;
     int nelem;
 
     /* if we are direct NVLS, we only need to allocate 1 warp to scatter for sync;
@@ -364,17 +365,17 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
     const int tidEndReduce = tidEndScatter + nThreadsReduce;
 
     if (work->oneNode) {
-      const int rank = ncclShmem.comm.rank;
+      const int rank = ncclShmem->comm.rank;
       size_t offset;
       size_t count, gridOffset, channelCount, chunkCount;
-      ncclCollCbdPart(work, ncclShmem.channelId, NCCL_PROTO_SIMPLE, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
+      ncclCollCbdPart(work, ncclShmem->channelId, NCCL_PROTO_SIMPLE, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
       if (!work->regUsed) {
         if (tid < tidEndScatter) {
           // Scatter
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
           Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_NVLS_ARITY>, /*Direct=*/0, Proto, 0>
             prims(tid, nThreadsScatter, NULL, nvls->up, work->sendbuff, NULL,
-              work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
+              work->redOpArg, ncclShmem, ncclShmemPerWarp, 0 * Proto::MaxGroupWidth, 1, 1, nullptr, nullptr, 0, primsModeDefault);
           for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
             offset = gridOffset + elemOffset;
             nelem = min(chunkCount, channelCount - elemOffset);
@@ -386,7 +387,7 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL, 1, 0>;
           Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/0, Proto, 0>
             prims(tid - tidEndScatter, nThreadsReduce, &nvls->down, NULL, NULL, work->recvbuff,
-              work->redOpArg, 3 * Proto::MaxGroupWidth, 0, 0);
+              work->redOpArg, ncclShmem, ncclShmemPerWarp, 3 * Proto::MaxGroupWidth, 0, 0, nullptr, nullptr, 0, primsModeDefault);
           for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
             offset = gridOffset + elemOffset;
             nelem = min(chunkCount, channelCount - elemOffset);
@@ -399,7 +400,7 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
           Primitives<T, RedOp, FanSymmetric<NCCL_MAX_NVLS_ARITY>, /*Direct=*/0, Proto, 0>
             prims(tid, nThreadsScatter, nvls->up, nvls->up, NULL, NULL,
-              work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
+              work->redOpArg, ncclShmem, ncclShmemPerWarp, 0 * Proto::MaxGroupWidth, 1, 1, nullptr, nullptr, 0, primsModeDefault);
           for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
             prims.scatter(0, 0, 0, 0, -1, 0);
           }
@@ -411,7 +412,7 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL, 1, 0>;
           Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
             prims(tid - tidEndScatter, nThreadsReduce, &nvls->down, &nvls->down, NULL, work->recvbuff,
-              work->redOpArg, 3 * Proto::MaxGroupWidth, 0, 0, work);
+              work->redOpArg, ncclShmem, ncclShmemPerWarp, 3 * Proto::MaxGroupWidth, 0, 0, work, nullptr, 0, primsModeDefault);
           for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
             size_t outOffset = gridOffset + elemOffset;
             size_t inpOffset = outOffset + rank * count;
@@ -428,8 +429,8 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
       }
     } else {
       // multi-node
-      int nNodes = ncclShmem.comm.nNodes;
-      int part = ncclShmem.channelId - work->channelLo;
+      int nNodes = ncclShmem->comm.nNodes;
+      int part = ncclShmem->channelId - work->channelLo;
       ssize_t countPerRank = work->collnet.count;
       const int nChannels = work->channelHi - work->channelLo + 1;
       ssize_t chunkCount = work->collnet.chunkCount;
@@ -438,17 +439,17 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
         if (work->netRegUsed) {
           if (tid == 0) {
             int steps = (int)divUp(nNodes * countPerRank, nChannels * chunkCount);
-            Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/0, Proto, 0>::recvPeerNotify(nvls->out, 0, steps);
+            Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/0, Proto, 0>::recvPeerNotify(nvls->out, 0, steps, ncclShmem);
           }
           __syncwarp();
         } else {
           Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/0, Proto, 0>
             prims(tid, nThreadsNetRecv, &nvls->out, nullptr, nullptr, work->recvbuff,
-              work->redOpArg, 0 * Proto::MaxGroupWidth, 0, 0);
+              work->redOpArg, ncclShmem, ncclShmemPerWarp, 0 * Proto::MaxGroupWidth, 0, 0, nullptr, nullptr, 0, primsModeDefault);
           for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkCount) {
             ssize_t railAllBeg = railGridOffset + part * chunkCount;
             ssize_t railAllEnd = min(railAllBeg + chunkCount, nNodes * countPerRank);
-            ssize_t railOneBeg = ncclShmem.comm.node * countPerRank;
+            ssize_t railOneBeg = ncclShmem->comm.node * countPerRank;
             ssize_t railOneEnd = railOneBeg + countPerRank;
             ssize_t beg = max(railAllBeg, railOneBeg);
             ssize_t end = min(railAllEnd, railOneEnd);
@@ -460,7 +461,7 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
           Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_NVLS_ARITY>, /*Direct=*/1, Proto, 0>
             prims(tid - tidEndNetRecv, nThreadsScatter, nullptr, nvls->up, work->sendbuff, nullptr,
-              work->redOpArg, 1 * Proto::MaxGroupWidth, 1, 1, work);
+              work->redOpArg, ncclShmem, ncclShmemPerWarp, 1 * Proto::MaxGroupWidth, 1, 1, work, nullptr, 0, primsModeDefault);
           for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkCount) {
             Scatterer</*ReduceSendNotRecv=*/true> scat;
             scat.work = work;
@@ -472,7 +473,7 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL, 1, 0>;
           Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
             prims(tid - tidEndScatter, nThreadsReduce, &nvls->down, &nvls->out, nullptr, nullptr,
-              work->redOpArg, 2 * Proto::MaxGroupWidth, 0, 1, work);
+              work->redOpArg, ncclShmem, ncclShmemPerWarp, 2 * Proto::MaxGroupWidth, 0, 1, work, nullptr, 0, primsModeDefault);
           for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkCount) {
             Scatterer</*ReduceSendNotRecv=*/false> scat;
             scat.work = work;
@@ -497,15 +498,16 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
     template<int SlicePerChunk, int MinSrcs, int MaxSrcs, int MinDsts, int MaxDsts, int MultimemSrcs, int MultimemDsts>
     __device__ __forceinline__ void operator()(
         int tid, int tn, int slice, int maxSliceSize,
-        int nSrcs, void** srcPtrs, int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag, uint32_t recvDirectFlag
+        int nSrcs, void** srcPtrs, int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag, uint32_t recvDirectFlag,
+        struct ncclShmemData* ncclShmem
       ) {
       static_assert(SlicePerChunk==1, "require: SlicePerChunk==1");
       static_assert(MaxDsts<=1 || MaxSrcs<=1, "require: MaxDsts<=1 || MaxSrcs<=1");
 
-      struct ncclDirect* direct = &ncclShmem.channel.collnetDirect;
-      int nNodes = ncclShmem.comm.nNodes;
+      struct ncclDirect* direct = &ncclShmem->channel.collnetDirect;
+      int nNodes = ncclShmem->comm.nNodes;
       int nRails = direct->nHeads;
-      int part = ncclShmem.channelId - work->channelLo;
+      int part = ncclShmem->channelId - work->channelLo;
       void* inbuf = (void*)work->sendbuff;
       ssize_t countPerRank = work->collnet.count;
 
@@ -530,7 +532,7 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
           ssize_t railOneEnd = railOneBeg + countPerRank;
           ssize_t railOneOffset = (railAllBeg+railAllOffset) - railOneBeg;
           int delta = min(railAllEnd, railOneEnd) - (railAllBeg+railAllOffset);
-          int rank = ncclShmem.comm.collNetDenseToUserRank[node*nRails + rail];
+          int rank = ncclShmem->comm.collNetDenseToUserRank[node*nRails + rail];
           ssize_t userOneBeg = rank*countPerRank + railOneOffset;
           if (nDsts != 0) {
             reduceCopy<ncclCollUnroll(), USE_ACC, RedOp, T,
@@ -559,11 +561,11 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
     }
   };
 
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    const int part = ncclShmem.channelId - work->channelLo;
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+    const int part = ncclShmem->channelId - work->channelLo;
     const int nChannels = work->channelHi - work->channelLo + 1;
-    struct ncclDirect* direct = &ncclShmem.channel.collnetDirect;
-    int const &nNodes = ncclShmem.comm.nNodes;
+    struct ncclDirect* direct = &ncclShmem->channel.collnetDirect;
+    int const &nNodes = ncclShmem->comm.nNodes;
     ssize_t chunkSize = int(work->collnet.chunkCount);
     ssize_t countPerRank = work->collnet.count;
     const int hasDn = (direct->down[0] >= 0) ? 1 : 0;
@@ -585,7 +587,7 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
       // Phase 1: Scatter inputs to peers
       Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_DIRECT_ARITY>, /*Direct=*/0, Proto, 0>
         prims(tid, tn, nullptr, direct->heads+1, work->sendbuff, nullptr,
-              work->redOpArg, 0*Proto::MaxGroupWidth, 1, 1);
+              work->redOpArg, ncclShmem, ncclShmemPerWarp, 0*Proto::MaxGroupWidth, 1, 1, nullptr, nullptr, 0, primsModeDefault);
       for (ssize_t railGridOffset=0; railGridOffset < nNodes*countPerRank; railGridOffset += nChannels*chunkSize) {
         Scatterer</*ReduceSendNotRecv=*/true> scat;
         scat.work = work;
@@ -601,14 +603,14 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
     if (tid < tn) {
       if (work->netRegUsed && !hasDn) {
         if (tid == 0) {
-          Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DIRECT_ARITY, 1>, /*Direct=*/0, Proto, 0>::sendPeerNotify(direct->out, 1, 1);
+          Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DIRECT_ARITY, 1>, /*Direct=*/0, Proto, 0>::sendPeerNotify(direct->out, 1, 1, ncclShmem);
         }
         __syncwarp();
       } else {
         // Phase 2: Reduce from peers + local input -> send to network
         Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DIRECT_ARITY, 1>, /*Direct=*/0, Proto, 0>
           prims(tid, tn, direct->heads + 1, &direct->out, nullptr, nullptr,
-            work->redOpArg, 1 * Proto::MaxGroupWidth, 1, 1);
+            work->redOpArg, ncclShmem, ncclShmemPerWarp, 1 * Proto::MaxGroupWidth, 1, 1, nullptr, nullptr, 0, primsModeDefault);
         for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkSize) {
           Scatterer</*ReduceSendNotRecv=*/false> scat;
           scat.work = work;
@@ -626,18 +628,18 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
       if (work->netRegUsed) {
         if (tid == 0) {
           int steps = hasDn ? (int)divUp(nNodes * countPerRank, nChannels * chunkSize) : 1;
-          Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/0, Proto, 0>::recvPeerNotify(direct->out, 0, steps);
+          Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/0, Proto, 0>::recvPeerNotify(direct->out, 0, steps, ncclShmem);
         }
         __syncwarp();
       } else {
         // Phase 3: recv from network
         Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/0, Proto, 0>
           prims(tid, tn, &direct->out, nullptr, nullptr, work->recvbuff,
-            work->redOpArg, 2 * Proto::MaxGroupWidth, 0, 0);
+            work->redOpArg, ncclShmem, ncclShmemPerWarp, 2 * Proto::MaxGroupWidth, 0, 0, nullptr, nullptr, 0, primsModeDefault);
         for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkSize) {
           ssize_t railAllBeg = railGridOffset + part * chunkSize;
           ssize_t railAllEnd = min(railAllBeg + chunkSize, nNodes * countPerRank);
-          ssize_t railOneBeg = ncclShmem.comm.node * countPerRank;
+          ssize_t railOneBeg = ncclShmem->comm.node * countPerRank;
           ssize_t railOneEnd = railOneBeg + countPerRank;
           ssize_t beg = max(railAllBeg, railOneBeg);
           ssize_t end = min(railAllEnd, railOneEnd);

--- a/projects/rccl/src/device/reduce_scatter.h
+++ b/projects/rccl/src/device/reduce_scatter.h
@@ -1,3 +1,5 @@
+#ifndef NCCL_DEVICE_REDUCE_SCATTER_H_
+#define NCCL_DEVICE_REDUCE_SCATTER_H_
 /*************************************************************************
  * Copyright (c) 2015-2022, NVIDIA CORPORATION. All rights reserved.
  * Modifications Copyright (c) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
@@ -650,3 +652,5 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
     }
   }
 };
+
+#endif // NCCL_DEVICE_REDUCE_SCATTER_H_

--- a/projects/rccl/src/device/reduce_scatter.h
+++ b/projects/rccl/src/device/reduce_scatter.h
@@ -12,14 +12,14 @@
 namespace {
   template<typename T, typename RedOp, typename Proto>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #endif
     //TODO: move Direct Reduce Scatter path to a separate kernel
-    size_t msgSize = work->count * sizeof(T) * ncclShmem->comm.nRanks;
+    size_t msgSize = work->count * sizeof(T) * ncclShmem.comm.nRanks;
     if (work->enableDirectReduceScatter && msgSize <= (size_t)work->directReduceScatterLimitBytes) {
-      const int nRanks = ncclShmem->comm.nRanks; 
+      const int nRanks = ncclShmem.comm.nRanks; 
       const ssize_t numElements = work->count;
 
       // Calculate Offset to utilize multiple channels
@@ -49,25 +49,25 @@ namespace {
       if (tid < nthreads) {
         // Call reduction across all rank offsets in tempbuff and store in recvbuff
         reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0, 1, 64, 0, 1, 1, 0>
-          (tid, nthreads, ncclShmem->redOpArgs[0], ncclShmem->redOpArgs, false, nRanks, srcPtrs, 1, dstPtrs, numElementsPerBlock);
+          (tid, nthreads, ncclShmem.redOpArgs[0], ncclShmem.redOpArgs, false, nRanks, srcPtrs, 1, dstPtrs, numElementsPerBlock);
       }
     } else {
   #ifdef ENABLE_WARP_SPEED
       int warp = threadIdx.x / WARP_SIZE;
-      ncclRing *ring = &ncclShmem->warpChannel[warp].ring;
+      ncclRing *ring = &ncclShmem.warpChannel[warp].ring;
   #else
-      ncclRing *ring = &ncclShmem->channel.ring;
+      ncclRing *ring = &ncclShmem.channel.ring;
   #endif
       int const *ringRanks = ring->userRanks;
-      const int nranks = ncclShmem->comm.nRanks; 
+      const int nranks = ncclShmem.comm.nRanks; 
       size_t count;
       size_t gridOffset;
       size_t channelCount;
       size_t chunkCount;
   #ifdef ENABLE_WARP_SPEED
-      ncclCollCbdPart(work, ncclShmem->warpChannelId[warp], Proto::Id, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
+      ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
   #else
-      ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
+      ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
   #endif
       size_t offset;
       size_t dataOffset;
@@ -75,27 +75,27 @@ namespace {
       int rankDest;
 
   #if defined(ENABLE_NPKIT)
-      int npKitCtxIdx = ncclShmem->channelId;
+      int npKitCtxIdx = ncclShmem.channelId;
   #endif
 
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, 0, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK,
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
       }
   #endif
 
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_GPU)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
       }
   #endif
 
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_REDUCE_SCATTER_RING_ENTRY)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_REDUCE_SCATTER_RING_ENTRY, count*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
       }
   #endif
       // Coverity reports that the callee treats &ring->next as an array.  However, due to the use of
@@ -119,7 +119,7 @@ namespace {
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_REDUCE_SCATTER_RING_SEND_ENTRY)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_REDUCE_SCATTER_RING_SEND_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         }
   #endif
         rankDest = ringRanks[nranks-1];
@@ -128,14 +128,14 @@ namespace {
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_REDUCE_SCATTER_RING_SEND_EXIT)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_REDUCE_SCATTER_RING_SEND_EXIT, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         }
   #endif
         // k-2 steps: reduce and copy to next GPU
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_REDUCE_SCATTER_RING_RECV_REDUCE_SEND_ENTRY)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_REDUCE_SCATTER_RING_RECV_REDUCE_SEND_ENTRY, nelem*(nranks-2)*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         }
   #endif
         for (int j=2; j<nranks; ++j) {
@@ -146,7 +146,7 @@ namespace {
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_REDUCE_SCATTER_RING_RECV_REDUCE_SEND_EXIT)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_REDUCE_SCATTER_RING_RECV_REDUCE_SEND_EXIT, nelem*(nranks-2)*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         }
   #endif
 
@@ -154,7 +154,7 @@ namespace {
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_REDUCE_SCATTER_RING_RECV_REDUCE_COPY_ENTRY)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_REDUCE_SCATTER_RING_RECV_REDUCE_COPY_ENTRY, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         }
   #endif
         rankDest = ringRanks[0];
@@ -163,14 +163,14 @@ namespace {
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_REDUCE_SCATTER_RING_RECV_REDUCE_COPY_EXIT)
         if (tid == 0) {
           NpKit::CollectGpuEvent(NPKIT_EVENT_REDUCE_SCATTER_RING_RECV_REDUCE_COPY_EXIT, nelem*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-              ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+              ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         }
   #endif
       }
   #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_REDUCE_SCATTER_RING_EXIT)
       if (tid == 0) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_REDUCE_SCATTER_RING_EXIT, count*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
       }
   #endif
     }
@@ -194,33 +194,33 @@ namespace {
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     rcclReduceScatterRunRingSimpleProtoImpl(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     runRing<T, RedOp, ProtoLL>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     runRing<T, RedOp, ProtoLL128>(tid, nthreads, work, ncclShmem, ncclShmemPerWarp);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_PAT, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     using Proto = ProtoSimple<1, 1>;
-    const int nranks = ncclShmem->comm.nRanks;
-    const int rank = ncclShmem->comm.rank;
+    const int nranks = ncclShmem.comm.nRanks;
+    const int rank = ncclShmem.comm.rank;
     size_t count, channelOffset, channelCount, chunkCount;
-    ncclCollCbdPart(work, ncclShmem->channelId, Proto::Id, sizeof(T), &count, &channelOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &channelOffset, &channelCount, &chunkCount);
 
     static constexpr int nworkers = NCCL_PAT_NWORKERS;
     struct ncclPatShmem* shmem = (struct ncclPatShmem*)ncclScratchForWarp(ncclShmemPerWarp, 0);
@@ -291,15 +291,15 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
     __device__ __forceinline__ void operator()(
         int tid, int tn, int slice, int maxSliceSize,
         int nSrcs, void** srcPtrs, int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag, uint32_t recvDirectFlag,
-        struct ncclShmemData* ncclShmem
+        struct ncclShmemData& ncclShmem
       ) {
       static_assert(SlicePerChunk == 1, "require: SlicePerChunk==1");
       static_assert(MaxDsts <= 1 || MaxSrcs <= 1, "require: MaxDsts<=1 || MaxSrcs<=1");
 
-      struct ncclNvls* nvls = &ncclShmem->channel.nvls;
-      int nNodes = ncclShmem->comm.nNodes;
+      struct ncclNvls* nvls = &ncclShmem.channel.nvls;
+      int nNodes = ncclShmem.comm.nNodes;
       int nRails = nvls->nHeads;
-      int part = ncclShmem->channelId - work->channelLo;
+      int part = ncclShmem.channelId - work->channelLo;
       void* inbuf = (void*)work->sendbuff;
       ssize_t countPerRank = work->collnet.count;
 
@@ -324,7 +324,7 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
           ssize_t railOneEnd = railOneBeg + countPerRank;
           ssize_t railOneOffset = (railAllBeg + railAllOffset) - railOneBeg;
           int delta = min(railAllEnd, railOneEnd) - (railAllBeg + railAllOffset);
-          int rank = ncclShmem->comm.collNetDenseToUserRank[node * nRails + rail];
+          int rank = ncclShmem.comm.collNetDenseToUserRank[node * nRails + rail];
           ssize_t userOneBeg = rank * countPerRank + railOneOffset;
           if (nDsts != 0) {
             reduceCopy<ncclCollUnroll(), USE_ACC, RedOp, T,
@@ -350,8 +350,8 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
     }
   };
 
-  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
-    struct ncclNvls* nvls = &ncclShmem->channel.nvls;
+  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
+    struct ncclNvls* nvls = &ncclShmem.channel.nvls;
     int nelem;
 
     /* if we are direct NVLS, we only need to allocate 1 warp to scatter for sync;
@@ -365,10 +365,10 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
     const int tidEndReduce = tidEndScatter + nThreadsReduce;
 
     if (work->oneNode) {
-      const int rank = ncclShmem->comm.rank;
+      const int rank = ncclShmem.comm.rank;
       size_t offset;
       size_t count, gridOffset, channelCount, chunkCount;
-      ncclCollCbdPart(work, ncclShmem->channelId, NCCL_PROTO_SIMPLE, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
+      ncclCollCbdPart(work, ncclShmem.channelId, NCCL_PROTO_SIMPLE, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
       if (!work->regUsed) {
         if (tid < tidEndScatter) {
           // Scatter
@@ -429,8 +429,8 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
       }
     } else {
       // multi-node
-      int nNodes = ncclShmem->comm.nNodes;
-      int part = ncclShmem->channelId - work->channelLo;
+      int nNodes = ncclShmem.comm.nNodes;
+      int part = ncclShmem.channelId - work->channelLo;
       ssize_t countPerRank = work->collnet.count;
       const int nChannels = work->channelHi - work->channelLo + 1;
       ssize_t chunkCount = work->collnet.chunkCount;
@@ -449,7 +449,7 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
           for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkCount) {
             ssize_t railAllBeg = railGridOffset + part * chunkCount;
             ssize_t railAllEnd = min(railAllBeg + chunkCount, nNodes * countPerRank);
-            ssize_t railOneBeg = ncclShmem->comm.node * countPerRank;
+            ssize_t railOneBeg = ncclShmem.comm.node * countPerRank;
             ssize_t railOneEnd = railOneBeg + countPerRank;
             ssize_t beg = max(railAllBeg, railOneBeg);
             ssize_t end = min(railAllEnd, railOneEnd);
@@ -499,15 +499,15 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
     __device__ __forceinline__ void operator()(
         int tid, int tn, int slice, int maxSliceSize,
         int nSrcs, void** srcPtrs, int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag, uint32_t recvDirectFlag,
-        struct ncclShmemData* ncclShmem
+        struct ncclShmemData& ncclShmem
       ) {
       static_assert(SlicePerChunk==1, "require: SlicePerChunk==1");
       static_assert(MaxDsts<=1 || MaxSrcs<=1, "require: MaxDsts<=1 || MaxSrcs<=1");
 
-      struct ncclDirect* direct = &ncclShmem->channel.collnetDirect;
-      int nNodes = ncclShmem->comm.nNodes;
+      struct ncclDirect* direct = &ncclShmem.channel.collnetDirect;
+      int nNodes = ncclShmem.comm.nNodes;
       int nRails = direct->nHeads;
-      int part = ncclShmem->channelId - work->channelLo;
+      int part = ncclShmem.channelId - work->channelLo;
       void* inbuf = (void*)work->sendbuff;
       ssize_t countPerRank = work->collnet.count;
 
@@ -532,7 +532,7 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
           ssize_t railOneEnd = railOneBeg + countPerRank;
           ssize_t railOneOffset = (railAllBeg+railAllOffset) - railOneBeg;
           int delta = min(railAllEnd, railOneEnd) - (railAllBeg+railAllOffset);
-          int rank = ncclShmem->comm.collNetDenseToUserRank[node*nRails + rail];
+          int rank = ncclShmem.comm.collNetDenseToUserRank[node*nRails + rail];
           ssize_t userOneBeg = rank*countPerRank + railOneOffset;
           if (nDsts != 0) {
             reduceCopy<ncclCollUnroll(), USE_ACC, RedOp, T,
@@ -561,11 +561,11 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
     }
   };
 
-  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
-    const int part = ncclShmem->channelId - work->channelLo;
+  __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
+    const int part = ncclShmem.channelId - work->channelLo;
     const int nChannels = work->channelHi - work->channelLo + 1;
-    struct ncclDirect* direct = &ncclShmem->channel.collnetDirect;
-    int const &nNodes = ncclShmem->comm.nNodes;
+    struct ncclDirect* direct = &ncclShmem.channel.collnetDirect;
+    int const &nNodes = ncclShmem.comm.nNodes;
     ssize_t chunkSize = int(work->collnet.chunkCount);
     ssize_t countPerRank = work->collnet.count;
     const int hasDn = (direct->down[0] >= 0) ? 1 : 0;
@@ -639,7 +639,7 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
         for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkSize) {
           ssize_t railAllBeg = railGridOffset + part * chunkSize;
           ssize_t railAllEnd = min(railAllBeg + chunkSize, nNodes * countPerRank);
-          ssize_t railOneBeg = ncclShmem->comm.node * countPerRank;
+          ssize_t railOneBeg = ncclShmem.comm.node * countPerRank;
           ssize_t railOneEnd = railOneBeg + countPerRank;
           ssize_t beg = max(railAllBeg, railOneBeg);
           ssize_t end = min(railAllEnd, railOneEnd);

--- a/projects/rccl/src/device/reduce_scatter.h
+++ b/projects/rccl/src/device/reduce_scatter.h
@@ -13,11 +13,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
-#else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
-#endif
     //TODO: move Direct Reduce Scatter path to a separate kernel
     size_t msgSize = work->count * sizeof(T) * ncclShmem.comm.nRanks;
     if (work->enableDirectReduceScatter && msgSize <= (size_t)work->directReduceScatterLimitBytes) {

--- a/projects/rccl/src/device/sendrecv.h
+++ b/projects/rccl/src/device/sendrecv.h
@@ -17,11 +17,11 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
   static_assert(sizeof(T)==1, "SendRecv only works on single byte types T.");
 
   template<typename Proto>
-  __device__ void runSend(int tid, int tn, int group, struct ncclDevWorkP2p* work) {
+  __device__ void runSend(int tid, int tn, int group, struct ncclDevWorkP2p* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
     size_t bytes = work->sendBytes;
-    bool useLargeChunk = (work->sendIpcReg && ncclShmem.comm.isAllNvlink) || work->sendNetReg;
+    bool useLargeChunk = (work->sendIpcReg && ncclShmem->comm.isAllNvlink) || work->sendNetReg;
     int chunkSize = useLargeChunk ? NCCL_MAX_NET_SIZE : u32fp8Decode(work->sendChunkSize_u32fp8);
-    int stepSize = useLargeChunk ? NCCL_MAX_NET_SIZE : ncclShmem.comm.p2pChunkSize;
+    int stepSize = useLargeChunk ? NCCL_MAX_NET_SIZE : ncclShmem->comm.p2pChunkSize;
 
 #if defined(ENABLE_NPKIT)
     bool isNpKitThread = (tid == 0);
@@ -31,20 +31,20 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
     if (isNpKitThread) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, 0, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK,
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_GPU)
     if (isNpKitThread) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
     Primitives<T, RedOp, FanAsymmetric<0, 1>, 0, Proto, 1>
       prims(tid, tn, nullptr, &work->sendRank, work->sendAddr, nullptr,
-            /*redOpArg(ignored)=*/0, group, work->sendConnIndex, work->sendConnIndex, nullptr, work, stepSize);
+            /*redOpArg(ignored)=*/0, ncclShmem, ncclShmemPerWarp, group, work->sendConnIndex, work->sendConnIndex, nullptr, work, stepSize, primsModeDefault);
 
 #if defined(ENABLE_NPKIT)
       if (isNpKitThread) {
@@ -55,7 +55,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_RECV_SEND_ENTRY)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_RECV_SEND_ENTRY, bytes*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -70,17 +70,17 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_RECV_SEND_EXIT)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_RECV_SEND_EXIT, bytes*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
   }
 
   template<typename Proto>
-  __device__ void runRecv(int tid, int tn, int group, struct ncclDevWorkP2p* work) {
+  __device__ void runRecv(int tid, int tn, int group, struct ncclDevWorkP2p* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
     size_t bytes = work->recvBytes;
-    bool useLargeChunk = (work->recvIpcReg && ncclShmem.comm.isAllNvlink) || work->recvNetReg;
+    bool useLargeChunk = (work->recvIpcReg && ncclShmem->comm.isAllNvlink) || work->recvNetReg;
     int chunkSize = useLargeChunk ? NCCL_MAX_NET_SIZE : u32fp8Decode(work->recvChunkSize_u32fp8);
-    int stepSize = useLargeChunk ? NCCL_MAX_NET_SIZE : ncclShmem.comm.p2pChunkSize;
+    int stepSize = useLargeChunk ? NCCL_MAX_NET_SIZE : ncclShmem->comm.p2pChunkSize;
 
 #if defined(ENABLE_NPKIT)
     bool isNpKitThread = (tid == 0);
@@ -90,20 +90,20 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
     if (isNpKitThread) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, 0, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK,
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_GPU)
     if (isNpKitThread) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
     Primitives<T, RedOp, FanAsymmetric<1, 0>, 0, Proto, 1>
       prims(tid, tn, &work->recvRank, nullptr, nullptr, work->recvAddr,
-            /*redOpArg(ignored)=*/0, group, work->recvConnIndex, work->recvConnIndex, nullptr, work, stepSize);
+            /*redOpArg(ignored)=*/0, ncclShmem, ncclShmemPerWarp, group, work->recvConnIndex, work->recvConnIndex, nullptr, work, stepSize, primsModeDefault);
 
 #if defined(ENABLE_NPKIT)
       if (isNpKitThread) {
@@ -114,7 +114,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_RECV_RECV_ENTRY)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_RECV_RECV_ENTRY, bytes*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -129,15 +129,15 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_RECV_RECV_EXIT)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_RECV_RECV_EXIT, bytes*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
   }
 
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__  void run() {
+  __device__  void run(struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #else
-  __device__  __attribute__((noinline)) void run() {
+  __device__  __attribute__((noinline)) void run(struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
 #endif
     const int tid = threadIdx.x;
     const int tn = blockDim.x;
@@ -149,10 +149,10 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
       uint32_t workSendMask; // bitmasks of which work indices have send/recv
       uint32_t workRecvMask;
     };
-    Shared* shared = (Shared*)ncclScratchForWarp(0);
+    Shared* shared = (Shared*)ncclScratchForWarp(ncclShmemPerWarp, 0);
 
-    struct ncclDevWorkP2p* works = (ncclDevWorkP2p*)ncclShmem.workStorage;
-    int nWorks = ncclShmem.nWorks;
+    struct ncclDevWorkP2p* works = (ncclDevWorkP2p*)ncclShmem->workStorage;
+    int nWorks = ncclShmem->nWorks;
 
     if (wid == 0) {
       // Modify the memory range of each work[] to reflect this channel's
@@ -165,7 +165,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
         struct ncclDevWorkP2p* work = &works[workIx];
         size_t bytes = isSend ? work->sendBytes : work->recvBytes;
         int nParts = isSend ? work->nSendChannels : work->nRecvChannels;
-        int part = ncclP2pChannelToPart(work->nP2pChannels, work->channelBase, ncclShmem.channelId, ncclShmem.comm.p2pnChannelsPerPeer, ncclShmem.comm.nNodes);
+        int part = ncclP2pChannelToPart(work->nP2pChannels, work->channelBase, ncclShmem->channelId, ncclShmem->comm.p2pnChannelsPerPeer, ncclShmem->comm.nNodes);
         hasWork = (part < nParts);
         if (nParts != 0) {
           size_t partBeg, partEnd;
@@ -231,7 +231,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
     struct ncclDevWorkP2p* work = &works[workIx];
     bool hasSend = 1 & (workSendMask>>workIx);
     bool hasRecv = 1 & (workRecvMask>>workIx);
-    bool isCopy = work->sendRank == ncclShmem.comm.rank;
+    bool isCopy = work->sendRank == ncclShmem->comm.rank;
     bool isSend = !hasRecv || (hasSend && subtid < nSendWarpPerWork*WARP_SIZE);
 
     if (!isCopy && hasSend && hasRecv) {
@@ -255,26 +255,26 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #endif
     } else if (isSend) {
       if (work->sendProtoLL) {
-        runSend<ProtoLL>(subtid, subtn, group, work);
+        runSend<ProtoLL>(subtid, subtn, group, work, ncclShmem, ncclShmemPerWarp);
       } else {
 #if defined(__gfx90a__)
-        runSend<ProtoSimple<1,1,0,8>>(subtid, subtn, group, work);
+        runSend<ProtoSimple<1,1,0,8>>(subtid, subtn, group, work, ncclShmem, ncclShmemPerWarp);
 #elif defined(__gfx908__) || defined(__gfx942__) || defined(__gfx950__)
-        runSend<ProtoSimple<1,1,0,4>>(subtid, subtn, group, work);
+        runSend<ProtoSimple<1,1,0,4>>(subtid, subtn, group, work, ncclShmem, ncclShmemPerWarp);
 #else
-        runSend<ProtoSimple<1,1>>(subtid, subtn, group, work);
+        runSend<ProtoSimple<1,1>>(subtid, subtn, group, work, ncclShmem, ncclShmemPerWarp);
 #endif
       }
     } else {
       if (work->recvProtoLL) {
-        runRecv<ProtoLL>(subtid, subtn, group, work);
+        runRecv<ProtoLL>(subtid, subtn, group, work, ncclShmem, ncclShmemPerWarp);
       } else {
 #if defined(__gfx90a__)
-        runRecv<ProtoSimple<1,1,0,8>>(subtid, subtn, group, work);
+        runRecv<ProtoSimple<1,1,0,8>>(subtid, subtn, group, work, ncclShmem, ncclShmemPerWarp);
 #elif defined(__gfx908__) || defined(__gfx942__) || defined(__gfx950__)
-        runRecv<ProtoSimple<1,1,0,4>>(subtid, subtn, group, work);
+        runRecv<ProtoSimple<1,1,0,4>>(subtid, subtn, group, work, ncclShmem, ncclShmemPerWarp);
 #else
-        runRecv<ProtoSimple<1,1>>(subtid, subtn, group, work);
+        runRecv<ProtoSimple<1,1>>(subtid, subtn, group, work, ncclShmem, ncclShmemPerWarp);
 #endif
       }
     }

--- a/projects/rccl/src/device/sendrecv.h
+++ b/projects/rccl/src/device/sendrecv.h
@@ -136,11 +136,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #endif
   }
 
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
   __device__  void run(struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
-#else
-  __device__  __attribute__((noinline)) void run(struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
-#endif
     const int tid = threadIdx.x;
     const int tn = blockDim.x;
     const int wid = tid/WARP_SIZE;

--- a/projects/rccl/src/device/sendrecv.h
+++ b/projects/rccl/src/device/sendrecv.h
@@ -17,11 +17,11 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
   static_assert(sizeof(T)==1, "SendRecv only works on single byte types T.");
 
   template<typename Proto>
-  __device__ void runSend(int tid, int tn, int group, struct ncclDevWorkP2p* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ void runSend(int tid, int tn, int group, struct ncclDevWorkP2p* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     size_t bytes = work->sendBytes;
-    bool useLargeChunk = (work->sendIpcReg && ncclShmem->comm.isAllNvlink) || work->sendNetReg;
+    bool useLargeChunk = (work->sendIpcReg && ncclShmem.comm.isAllNvlink) || work->sendNetReg;
     int chunkSize = useLargeChunk ? NCCL_MAX_NET_SIZE : u32fp8Decode(work->sendChunkSize_u32fp8);
-    int stepSize = useLargeChunk ? NCCL_MAX_NET_SIZE : ncclShmem->comm.p2pChunkSize;
+    int stepSize = useLargeChunk ? NCCL_MAX_NET_SIZE : ncclShmem.comm.p2pChunkSize;
 
 #if defined(ENABLE_NPKIT)
     bool isNpKitThread = (tid == 0);
@@ -31,14 +31,14 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
     if (isNpKitThread) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, 0, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK,
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_GPU)
     if (isNpKitThread) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -55,7 +55,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_RECV_SEND_ENTRY)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_RECV_SEND_ENTRY, bytes*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -70,17 +70,17 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_RECV_SEND_EXIT)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_RECV_SEND_EXIT, bytes*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
   }
 
   template<typename Proto>
-  __device__ void runRecv(int tid, int tn, int group, struct ncclDevWorkP2p* work, struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__ void runRecv(int tid, int tn, int group, struct ncclDevWorkP2p* work, struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
     size_t bytes = work->recvBytes;
-    bool useLargeChunk = (work->recvIpcReg && ncclShmem->comm.isAllNvlink) || work->recvNetReg;
+    bool useLargeChunk = (work->recvIpcReg && ncclShmem.comm.isAllNvlink) || work->recvNetReg;
     int chunkSize = useLargeChunk ? NCCL_MAX_NET_SIZE : u32fp8Decode(work->recvChunkSize_u32fp8);
-    int stepSize = useLargeChunk ? NCCL_MAX_NET_SIZE : ncclShmem->comm.p2pChunkSize;
+    int stepSize = useLargeChunk ? NCCL_MAX_NET_SIZE : ncclShmem.comm.p2pChunkSize;
 
 #if defined(ENABLE_NPKIT)
     bool isNpKitThread = (tid == 0);
@@ -90,14 +90,14 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_CPU)
     if (isNpKitThread) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_CPU, 0, 0, NPKIT_GET_CPU_TIMESTAMP_FROM_BLOCK,
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_TIME_SYNC_GPU)
     if (isNpKitThread) {
       NpKit::CollectGpuEvent(NPKIT_EVENT_TIME_SYNC_GPU, 0, 0, NPKIT_GET_GPU_TIMESTAMP(),
-          ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+          ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
     }
 #endif
 
@@ -114,7 +114,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_RECV_RECV_ENTRY)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_RECV_RECV_ENTRY, bytes*sizeof(T), 0, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
         prims.npKitDataProcessTotalTime = 0;
       }
 #endif
@@ -129,15 +129,15 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #if defined(ENABLE_NPKIT) && defined(ENABLE_NPKIT_EVENT_SEND_RECV_RECV_EXIT)
       if (isNpKitThread) {
         NpKit::CollectGpuEvent(NPKIT_EVENT_SEND_RECV_RECV_EXIT, bytes*sizeof(T), prims.npKitDataProcessTotalTime, NPKIT_GET_GPU_TIMESTAMP(),
-            ncclShmem->comm.npKitEventCollectContexts + npKitCtxIdx);
+            ncclShmem.comm.npKitEventCollectContexts + npKitCtxIdx);
       }
 #endif
   }
 
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__  void run(struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__  void run(struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #else
-  __device__  __attribute__((noinline)) void run(struct ncclShmemData* ncclShmem, void* ncclShmemPerWarp) {
+  __device__  __attribute__((noinline)) void run(struct ncclShmemData& ncclShmem, void* ncclShmemPerWarp) {
 #endif
     const int tid = threadIdx.x;
     const int tn = blockDim.x;
@@ -151,8 +151,8 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
     };
     Shared* shared = (Shared*)ncclScratchForWarp(ncclShmemPerWarp, 0);
 
-    struct ncclDevWorkP2p* works = (ncclDevWorkP2p*)ncclShmem->workStorage;
-    int nWorks = ncclShmem->nWorks;
+    struct ncclDevWorkP2p* works = (ncclDevWorkP2p*)ncclShmem.workStorage;
+    int nWorks = ncclShmem.nWorks;
 
     if (wid == 0) {
       // Modify the memory range of each work[] to reflect this channel's
@@ -165,7 +165,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
         struct ncclDevWorkP2p* work = &works[workIx];
         size_t bytes = isSend ? work->sendBytes : work->recvBytes;
         int nParts = isSend ? work->nSendChannels : work->nRecvChannels;
-        int part = ncclP2pChannelToPart(work->nP2pChannels, work->channelBase, ncclShmem->channelId, ncclShmem->comm.p2pnChannelsPerPeer, ncclShmem->comm.nNodes);
+        int part = ncclP2pChannelToPart(work->nP2pChannels, work->channelBase, ncclShmem.channelId, ncclShmem.comm.p2pnChannelsPerPeer, ncclShmem.comm.nNodes);
         hasWork = (part < nParts);
         if (nParts != 0) {
           size_t partBeg, partEnd;
@@ -231,7 +231,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
     struct ncclDevWorkP2p* work = &works[workIx];
     bool hasSend = 1 & (workSendMask>>workIx);
     bool hasRecv = 1 & (workRecvMask>>workIx);
-    bool isCopy = work->sendRank == ncclShmem->comm.rank;
+    bool isCopy = work->sendRank == ncclShmem.comm.rank;
     bool isSend = !hasRecv || (hasSend && subtid < nSendWarpPerWork*WARP_SIZE);
 
     if (!isCopy && hasSend && hasRecv) {

--- a/projects/rccl/src/device/sendrecv.h
+++ b/projects/rccl/src/device/sendrecv.h
@@ -1,3 +1,5 @@
+#ifndef NCCL_DEVICE_SENDRECV_H_
+#define NCCL_DEVICE_SENDRECV_H_
 /*************************************************************************
  * Copyright (c) 2015-2022, NVIDIA CORPORATION. All rights reserved.
  * Modifications Copyright (c) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
@@ -280,3 +282,5 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
     }
   }
 };
+
+#endif // NCCL_DEVICE_SENDRECV_H_

--- a/projects/rccl/tools/topo_expl/Makefile
+++ b/projects/rccl/tools/topo_expl/Makefile
@@ -8,7 +8,7 @@ HIPCC = $(HIP_PATH)/bin/hipcc
 .DEFAULT_GOAL := all
 
 EXE = topo_expl
-CXXFLAGS = -g -ffunction-sections -fdata-sections -Wl,--gc-sections -fgpu-rdc -Iinclude -Ihipify_rccl/include -Ihipify_rccl/include/plugin -Ihipify_rccl/src/device/include  -Ihipify_rccl/graph -I/opt/rocm/include/ -DTOPO_EXPL -DENABLE_TRACE -DENABLE_LL128 -DNVTX_NO_IMPL -DRCCL_EXPOSE_STATIC -lpthread
+CXXFLAGS = -g -ffunction-sections -fdata-sections -Wl,--gc-sections -Iinclude -Ihipify_rccl/include -Ihipify_rccl/include/plugin -Ihipify_rccl/src/device/include  -Ihipify_rccl/graph -I/opt/rocm/include/ -DTOPO_EXPL -DENABLE_TRACE -DENABLE_LL128 -DNVTX_NO_IMPL -DRCCL_EXPOSE_STATIC -lpthread
 
 files = $(EXE).cpp model.cpp utils.cpp hipify_rccl/graph/topo.cc hipify_rccl/graph/rings.cc hipify_rccl/graph/paths.cc hipify_rccl/graph/trees.cc ../../src/misc/param.cc \
 	hipify_rccl/graph/search.cc hipify_rccl/graph/connect.cc hipify_rccl/graph/tuning.cc hipify_rccl/graph/xml.cc ../../src/misc/nvmlwrap_stub.cc hipify_rccl/graph/rome_models.cc hipify_rccl/graph/archinfo.cc \


### PR DESCRIPTION
This is a WIP PR where I am trying to split the optimization of each TU before performing the final link. This is possible to the previous changes that eliminate the need to have extern __shared__ variables.

So far only tested on gfx942 and ROCm 7.2.0: unit tests pass and the few rccl-test perf tests I tried had similar runtimes. More testing needed.

Same as https://github.com/ROCm/rocm-systems/pull/3228 but with reference to shared memory passed around instead of pointer.