### PR TITLE
clr: Fix SDMA engine reuse when read/write masks are asymmetric

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -558,9 +558,13 @@ inline bool DmaBlitManager::rocrCopyBuffer(address dst, hsa_agent_t& dstAgent, c
     // because the allocator has special logic to select high-bandwidth engines
     // for specific src/dst pairs, and we shouldn't reuse an engine from a different copy type
 
-    if (assignedEngineMask != 0 && engine != HwQueueEngine::SdmaInter) {
-      // This VirtualGPU/stream already has an assigned engine - just use it
-      // Stream ordering handles any busy conditions naturally
+    // On GPUs with asymmetric engine restrictions copy_on_engine API will fail.
+    // Guard against this by validating the cached engine
+    uint32_t validMaskForEngine = dev().GetSdmaValidMask(engine);
+    if (assignedEngineMask != 0 && engine != HwQueueEngine::SdmaInter &&
+        (assignedEngineMask & validMaskForEngine)) {
+      // This VirtualGPU/stream already has an assigned engine that is valid for the
+      // current copy direction - just use it. Stream ordering handles any busy conditions.
       copyMask = assignedEngineMask;
 
       ClPrint(amd::LOG_DEBUG, amd::LOG_COPY,

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -774,6 +774,11 @@ class Device : public NullDevice {
  public:
   std::atomic<uint> numOfVgpus_;  //!< Virtual gpu unique index
 
+  //! Returns the valid SDMA engine bitmask for the given operation type.
+  uint32_t GetSdmaValidMask(HwQueueEngine engine_type) const {
+    return (engine_type == HwQueueEngine::SdmaRead) ? maxSdmaReadMask_ : maxSdmaWriteMask_;
+  }
+
 #if defined(__clang__)
 #if __has_feature(address_sanitizer)
   virtual device::UriLocator* createUriLocator() const;


### PR DESCRIPTION
## Motivation

On gfx90a, the valid SDMA engine masks for H2D and D2H are asymmetric due to a RAS restriction. Reusing a cached engine across directions can cause ROCr to reject the copy and fall back to blit. Validate the cached engine against the valid mask for the current direction and re-assign if incompatible.
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
