### PR TITLE
[rocprofiler-compute] Handle missing .so files gracefully in resolve_rocm_library_path

### DIFF
--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -113,7 +113,8 @@ def resolve_rocm_library_path(library_path: Optional[str]) -> Optional[str]:
 
     # Find max version length to normalize all versions
     if not version_tuples:
-        raise FileNotFoundError(f"ROCm library not found: {library_path}")
+        console_debug(f"ROCm library .so file not found: {library_path}")
+        return library_path
 
     # Second pass: convert to numeric values with normalized length
     max_version_len = max(len(vt[0]) for vt in version_tuples)
@@ -1376,16 +1377,16 @@ def save_torch_trace_inputs(
         for src_counter in counter_files:
             dst_counter = str(
                 Path(workload_dir)
-                /
-                f"{fbase}" / ("torch_trace_" + Path(src_counter).name)
+                / f"{fbase}"
+                / ("torch_trace_" + Path(src_counter).name)
             )
             shutil.copyfile(src_counter, dst_counter)
             console_log("torch trace", f"Copied Counter Collection: {dst_counter}")
         for src_marker in marker_files:
             dst_marker = str(
                 Path(workload_dir)
-                /
-                f"{fbase}" / ("torch_trace_" + Path(src_marker).name)
+                / f"{fbase}"
+                / ("torch_trace_" + Path(src_marker).name)
             )
             shutil.copyfile(src_marker, dst_marker)
             console_log("torch trace", f"Copied Marker API Trace: {dst_marker}")
@@ -1411,7 +1412,7 @@ def process_torch_trace_output(
     console_log(f"Looking for marker and counter csv files in {workload_dir}")
     marker_api_trace_csvs = list(
         Path(workload_dir).glob("**/torch_trace*_marker_api_trace.csv")
-        )
+    )
     counter_collection_csvs = [
         markers_file.parent
         / markers_file.name.replace("_marker_api_trace.", "_counter_collection.")

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -8326,10 +8326,9 @@ def test_resolve_rocm_library_path(tmp_path):
     # Should pick .so.10 (10 > 2 in first position)
     assert resolve_rocm_library_path(str(version_base)) == str(v10)
 
-    # Test case 8: No match at all, raises FileNotFoundError
+    # Test case 8: No match at all, returns original path
     missing = tmp_path / "libmissing.so"
-    with pytest.raises(FileNotFoundError, match="ROCm library not found"):
-        resolve_rocm_library_path(str(missing))
+    assert resolve_rocm_library_path(str(missing)) == str(missing)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Return original library path instead of raising FileNotFoundError when no versioned .so file is found
- Add debug logging to indicate when .so file resolution fails  
- Update test_resolve_rocm_library_path to verify graceful handling of missing libraries

## Details
This change improves robustness by allowing the tool to continue operation with the original library path when version resolution is not possible, rather than failing completely. When no versioned .so files are found, the function now logs a debug message and returns the original path instead of raising an exception.

## Test plan
- [x] Updated unit tests to verify graceful handling of missing libraries
- [x] Test now verifies that missing library path returns original path instead of raising exception