### PR TITLE
[rocprofiler-compute] Enhancing --torch-operator to accept glob patterns over operator hierarchy names

### DIFF
--- a/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/cli.rst
@@ -649,32 +649,37 @@ Display all PyTorch operators captured during profiling:
          └─ torch.nn.functional.linear (kernel_launches: 20, total_duration: 15.41 ms)
 
 Output is grouped by source location (``file:line``) and shows full operator
-hierarchy (``/``-separated) and kernel stats. Per-operator CSVs in ``torch_trace/``
-are named from the **last** segment of each name (sanitized);
-see :ref:`torch-operator-profiling` for naming details.
+hierarchy (``/``-separated) and kernel stats. A consolidated CSV
+(``torch_trace/consolidated.csv``) is written with all operator/kernel data;
+see :ref:`torch-operator-profiling` for details.
 
 Filtering by Operator
 ^^^^^^^^^^^^^^^^^^^^^^
 
-``--torch-operator`` supports exactly two forms of selection:
+``--torch-operator`` uses PurePosixPath glob patterns to select operators.
+Operator hierarchies are ``/``-separated (e.g.
+``nn.Module.Net.forward/torch.nn.functional.relu``), and patterns are matched
+using ``PurePosixPath.match()``:
 
-* **Full hierarchy** — the complete operator path as listed (e.g.
-  ``nn.Module.Net.forward/nn.Module.Conv2d.forward/torch.nn.functional.conv2d``)
-* **Last segment only** — the final component of the name (e.g. ``conv2d``)
-
-Selection at intermediate levels is not supported yet.
+* **Wildcard** — ``*relu`` (ends with relu), ``*conv*`` (contains conv)
+* **Exact** — ``torch.nn.functional.relu``
+* **Multi-level** — ``*/torch.nn.functional.relu``, ``*/*functional*/*``
+* **Match all** — no arguments, ``all``, ``*``, or ``**``
 
 .. code-block:: shell-session
 
-   # Full hierarchy
-   $ rocprof-compute --experimental analyze --path ./workload --torch-operator "nn.Module.Net.forward/nn.Module.Conv2d.forward/torch.nn.functional.conv2d"
+   # Wildcard match
+   $ rocprof-compute --experimental analyze --path ./workload --torch-operator "*relu"
 
-   # Last segment only (matches any operator whose name ends with that segment)
-   $ rocprof-compute analyze --path ./workload --torch-operator conv2d
+   # Exact match
+   $ rocprof-compute --experimental analyze --path ./workload --torch-operator torch.nn.functional.relu
 
-**Filter multiple operators** (each argument is full path or last segment):
+   # Match all operators (no arguments)
+   $ rocprof-compute --experimental analyze --path ./workload --torch-operator
+
+**Filter multiple operators** (space or comma separated):
 
 .. code-block:: shell-session
 
    $ rocprof-compute --experimental analyze --path ./workload \
-       --torch-operator "nn.Module.Net.forward/nn.Module.Conv2d.forward/torch.nn.functional.conv2d" "relu"
+       --torch-operator "*relu,*conv*,*linear"

--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -873,12 +873,13 @@ When Torch operator mapping is enabled, profiling writes additional CSV files in
 the workload directory: **marker_api_trace** and **counter_collection** files with
 the ``torch_trace`` prefix. These correlate PyTorch operators
 with GPU kernels and performance counters. When you run analyze (e.g. with
-``--list-torch-operators``), it builds per-operator CSVs under ``torch_trace/``;
-the source marker and counter files are **retained** in the workload directory and
-are not deleted.
+``--list-torch-operators`` or ``--torch-operator``), a consolidated CSV is written
+to ``torch_trace/consolidated.csv``; the source marker and counter files are
+**retained** in the workload directory and are not deleted.
 
 ``torch_trace/`` directory
-The ``torch_trace/`` directory contains per-operator CSV files. The columns include:
+The ``torch_trace/`` directory contains ``consolidated.csv`` with all
+operator/kernel data. The columns include:
 
    * ``Operator_Name``: Full operator hierarchy (e.g. ``nn.Module.Net.forward/nn.Module.Conv2d.forward/torch.nn.functional.relu``, ``nn.Module.ResNet.forward/torch.nn.functional.relu``).
    * ``Context_Id``: Call context (e.g., ``1@__init__.py:231``)
@@ -886,10 +887,11 @@ The ``torch_trace/`` directory contains per-operator CSV files. The columns incl
    * ``Start_Timestamp_function`` / ``End_Timestamp_function``: Operator timing
    * ``Start_Timestamp_kernel`` / ``End_Timestamp_kernel``: Kernel timing
 
-This per-operator organization allows focused analysis of specific operators without
-processing the entire trace.
+The consolidated CSV is generated automatically on the first analysis run that
+requires it (``--list-torch-operators`` or ``--torch-operator``) and is reused on
+subsequent runs.
 
-Sample rows from ``torch_trace/ones_like.csv`` (from profiling an mnist model).
+Sample rows from ``torch_trace/consolidated.csv`` (from profiling an mnist model).
 
 .. list-table::
    :header-rows: 1
@@ -976,9 +978,8 @@ operator occurs in your PyTorch application:
    nn.Module.MyModel.forward/nn.Module.Linear.forward
    torch.nn.functional.relu
 
-The per-operator CSV under ``torch_trace/`` is named after the operator 
-such as, ``ones_like.csv`` and ``relu.csv``. The ``Operator_Name`` column in the CSV
-contains the full operator hierarchy.
+The ``Operator_Name`` column in ``torch_trace/consolidated.csv`` contains
+the full operator hierarchy.
 
 This hierarchical information enables:
 
@@ -998,15 +999,14 @@ Example with hierarchical naming:
 
        def forward(self, x):
            x = self.encoder(x)  # Captured as nn.Module.MyModel.forward/nn.Module.Linear.forward
-           x = self.decoder(x)  # Same hierarchy; both write to nn_Module_Linear_forward.csv
+           x = self.decoder(x)  # Same hierarchy; both appear in consolidated.csv under Operator_Name
            return x
 
 **Analyzing captured operators**: After profiling, use the analyze CLI (see
 :doc:`../analyze/cli`) to list and filter by operator name. Filtering
-(``--torch-operator``) accepts either the full hierarchical name (e.g.
-``nn.Module.Net.forward/nn.Module.Conv2d.forward/torch.nn.functional.conv2d``)
-or the last segment only (e.g. ``conv2d``). Selection
-at intermediate levels is not supported yet.
+(``--torch-operator``) accepts PurePosixPath glob patterns (e.g. ``*conv2d``,
+``torch.nn.functional.conv2d``, ``*/*conv2d``). To select all operators, pass
+no arguments, ``all``, ``*``, or ``**`` — all four forms are equivalent.
 
 Combining Torch operator with other options
 -------------------------------------------

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -761,14 +761,26 @@ Examples:
         metavar="",
         type=str,
         dest="torch_operator",
-        nargs="+",
+        nargs="*",
         base_action="store",
         action=ExperimentalAction,
         experimental_enabled=experimental_enabled,
         feature_label="Torch operator filter",
         help=(
-            "\t\tShow details for selected operator(s) using existing torch_trace "
-            "directory (run --list-torch-operators first)."
+            "\t\tFilter operators using PurePosixPath glob patterns,\n"
+            "\t\t\tselect their kernels, and display metrics.\n"
+            "\t\t\tWith no arguments, matches all operators (default: **).\n"
+            "\t\t\tExamples (operator hierarchy is /-separated):\n"
+            "\t\t\t  *relu               ends with relu\n"
+            "\t\t\t  *conv*              contains conv\n"
+            "\t\t\t  torch.nn.functional.relu   exact match\n"
+            "\t\t\t  */torch.nn.functional.relu two-level match\n"
+            "\t\t\t  */*functional*/*    intermediate component match\n"
+            "\t\t\t  all  or  '*'        match every operator\n"
+            "\t\t\tMultiple patterns (space or comma-separated):\n"
+            "\t\t\t  --torch-operator *relu,*conv*,*linear\n"
+            "\t\t\t  --torch-operator */*conv2d */*relu\n"
+            "\t\t\tCombine with -k to intersect with kernel IDs."
         ),
     )
     analyze_group.add_argument(

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -288,6 +288,16 @@ class OmniAnalyze_Base:
         )
         profiling_config = self.get_profiling_config()
 
+        needs_torch_trace = getattr(
+            args, "torch_operator", None
+        ) is not None or getattr(args, "list_torch_operators", False)
+        if needs_torch_trace and not profiling_config.get("torch_trace", False):
+            console_error(
+                "torch trace",
+                'Workload was not profiled with "--torch-trace". '
+                "Cannot use --torch-operator or --list-torch-operators.",
+            )
+
         for dir_info in args.path:
             if not any([
                 args.nodes,

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -23,26 +23,50 @@
 
 ##############################################################################
 
+import argparse
 import sys
 from pathlib import Path
 
 import pandas as pd
 
 from rocprof_compute_analyze.analysis_base import OmniAnalyze_Base
-from utils import file_io, parser, tty
+from utils import file_io, parser, schema, tty
 from utils.kernel_name_shortener import kernel_name_shortener
-from utils.logger import console_error, console_log, demarcate
+from utils.logger import console_error, console_log, console_warning, demarcate
 from utils.utils import (
+    build_call_trees,
     build_call_trees_with_kernel_ids,
     process_torch_trace_output,
-    write_torch_trace_operator_csvs,
+    write_torch_trace_consolidated_csv,
 )
+
+
+def parse_torch_operator_patterns(args: argparse.Namespace) -> list[str]:
+    """Extract and flatten --torch-operator patterns from args.
+
+    Returns ``["**"]`` when ``--torch-operator`` is given with no arguments,
+    which matches all operators.  Returns ``[]`` when the flag is absent.
+    """
+    raw = getattr(args, "torch_operator", None)
+    if raw is None:
+        return []
+    pattern_list: list[str] = []
+    for operator_arg in raw:
+        pattern_list.extend(
+            pattern.strip()
+            for pattern in str(operator_arg).split(",")
+            if pattern.strip()
+        )
+    if not pattern_list:
+        pattern_list = ["**"]
+    return pattern_list
 
 
 class cli_analysis(OmniAnalyze_Base):
     # -----------------------
     # Required child methods
     # -----------------------
+
     @demarcate
     def pre_processing(self) -> None:
         """Perform any pre-processing steps prior to analysis."""
@@ -87,21 +111,26 @@ class cli_analysis(OmniAnalyze_Base):
             )
 
             if getattr(args, "list_torch_operators", False):
-                kernel_top_df = pd.read_csv(Path(path_info[0]) / "pmc_kernel_top.csv")
                 consolidated_df, torch_trace_path = process_torch_trace_output(
                     path_info[0]
                 )
-                write_torch_trace_operator_csvs(consolidated_df, torch_trace_path)
+                if consolidated_df.empty:
+                    tty.list_torch_operators(path_info[0], {})
+                    sys.exit(0)
+                kernel_top_df = pd.read_csv(Path(path_info[0]) / "pmc_kernel_top.csv")
+                write_torch_trace_consolidated_csv(consolidated_df, torch_trace_path)
                 call_trees = build_call_trees_with_kernel_ids(
                     consolidated_df,
                     kernel_top_df=kernel_top_df,
-                    kernel_verbose=args.kernel_verbose,
                 )
                 tty.list_torch_operators(path_info[0], call_trees)
                 sys.exit(0)
 
             # demangle and overwrite original 'Kernel_Name'
             kernel_name_shortener(workload.raw_pmc, args.kernel_verbose)
+
+            if getattr(args, "torch_operator", None) is not None:
+                self.apply_torch_operator_filter(args, workload, path_info[0])
 
             # create the loaded table
             parser.load_table_data(
@@ -124,41 +153,8 @@ class cli_analysis(OmniAnalyze_Base):
         gpu_arch = workload.sys_info.iloc[0]["gpu_arch"]
         arch_config = self._arch_configs[gpu_arch]
 
-        if getattr(args, "torch_operator", False):
-            # Check whether any torch operator data was actually loaded
-            torch_ops = getattr(workload, "torch_operators", None)
-            if not torch_ops:
-                console_error(
-                    "No torch operators found in the profiling data. "
-                    'Please ensure that workload is profiled with "--torch-trace" '
-                    'and analyze is run with "--list-torch-operators" before '
-                    'using "--torch-operator".'
-                )
-                # Abort analysis since the requested torch operator data is unavailable.
-                return
-
-            operator_args = args.torch_operator
-            operator_list = []
-            for op in operator_args:
-                operator_list.extend([
-                    o.strip() for o in str(op).split(",") if o.strip()
-                ])
-            operator_list = [o for o in operator_list if o]
-
-            for op in operator_list:
-                is_hierarchy = "/" in op
-                lookup = op.split("/")[-1] if is_hierarchy else op
-                op_key = lookup.replace("torch.", "").replace(".", "_")
-                df = torch_ops.get(op_key)
-                if df is None:
-                    console_log(f"No data for operator: {op}")
-                    continue
-                if is_hierarchy:
-                    df = df[df["Operator_Name"] == op]
-                    if df.empty:
-                        console_log(f"No rows for operator: {op}")
-                        continue
-                tty.show_torch_operator_table(op, df)
+        if getattr(args, "torch_operator", None) is not None:
+            self.handle_torch_operator(args, workload)
 
         if args.list_stats:
             tty.show_kernel_stats(
@@ -197,3 +193,123 @@ class cli_analysis(OmniAnalyze_Base):
                 self._profiling_config,
                 roof_plot=roof_plot,
             )
+
+    def apply_torch_operator_filter(
+        self, args: argparse.Namespace, workload: schema.Workload, workload_path: str
+    ) -> None:
+        """Set workload.filter_kernel_ids based on --torch-operator patterns.
+
+        Called in pre_processing *before* load_table_data so that metric
+        evaluation runs once with the correct kernel filter — the same
+        approach used by -k/--kernel.
+        """
+        torch_trace_dir = Path(workload_path) / "torch_trace"
+        consolidated_path = torch_trace_dir / "consolidated.csv"
+
+        if consolidated_path.exists():
+            consolidated_df = pd.read_csv(consolidated_path)
+            console_log(
+                "torch trace",
+                f"Loaded cached {consolidated_path}. "
+                "Delete torch_trace/ directory to force regeneration from raw traces.",
+            )
+        else:
+            consolidated_df, torch_trace_path = process_torch_trace_output(
+                workload_path
+            )
+            if consolidated_df.empty:
+                console_warning(
+                    "torch trace",
+                    "No torch operator data found in this workload. "
+                    "Proceeding without torch operator filter.",
+                )
+                return
+            write_torch_trace_consolidated_csv(consolidated_df, torch_trace_path)
+
+        pattern_list = parse_torch_operator_patterns(args)
+        all_operators = consolidated_df["Operator_Name"].dropna().unique()
+        matched_names = [
+            str(op).strip()
+            for op in all_operators
+            if any(
+                parser.torch_operator_pattern_matches(p.strip(), str(op).strip())
+                for p in pattern_list
+            )
+        ]
+
+        if not matched_names:
+            console_warning(
+                "torch trace",
+                f"No operators matched the pattern(s): {pattern_list}",
+            )
+            return
+
+        matched_df = consolidated_df[
+            consolidated_df["Operator_Name"].isin(matched_names)
+        ].copy()
+
+        kernel_top_df = pd.read_csv(str(Path(workload_path) / "pmc_kernel_top.csv"))
+        name_to_id: dict[str, int] = {
+            str(kernel_name).strip(): idx
+            for idx, kernel_name in enumerate(kernel_top_df["Kernel_Name"].tolist())
+        }
+
+        matched_df["Kernel_ID"] = matched_df["Kernel_Name"].str.strip().map(name_to_id)
+        workload.matched_torch_trace_df = matched_df
+
+        kernel_names = set(matched_df["Kernel_Name"].dropna().str.strip().unique())
+        kernel_ids = sorted(
+            name_to_id[kernel_name]
+            for kernel_name in kernel_names
+            if kernel_name in name_to_id
+        )
+
+        if workload.filter_kernel_ids:
+            existing_ids = set(workload.filter_kernel_ids)
+            kernel_ids = [
+                kernel_id for kernel_id in kernel_ids if kernel_id in existing_ids
+            ]
+
+        if kernel_ids:
+            workload.filter_kernel_ids = kernel_ids
+            console_log(
+                "torch trace",
+                f"Torch operator filter selected {len(kernel_ids)} kernel(s) "
+                "for metric analysis.",
+            )
+        else:
+            if workload.filter_kernel_ids:
+                console_error(
+                    "torch trace",
+                    "No torch-operator kernels overlap with the -k filter "
+                    f"{workload.filter_kernel_ids}. No kernels to analyze.",
+                )
+            else:
+                console_error(
+                    "torch trace",
+                    "No kernels found for matched operators. No kernels to analyze.",
+                )
+
+    def handle_torch_operator(
+        self, args: argparse.Namespace, workload: schema.Workload
+    ) -> None:
+        """Display matched torch operator call tree."""
+        matched_df = workload.matched_torch_trace_df
+        if matched_df.empty:
+            return
+
+        call_trees = build_call_trees(matched_df)
+
+        pattern_list = parse_torch_operator_patterns(args)
+        matched_operators = matched_df["Operator_Name"].dropna().unique()
+        print(f"\n{'=' * 80}")
+        print(f"Matched PyTorch Operators: {', '.join(pattern_list)}")
+        print("Grouped by source location, sorted by total GPU kernel duration.")
+        print(f"{'=' * 80}")
+        tty.show_call_tree(call_trees)
+        print(f"{'=' * 80}")
+
+        console_log(
+            "torch trace",
+            f"Matched {len(matched_operators)} operator(s): {list(matched_operators)}",
+        )

--- a/projects/rocprofiler-compute/src/utils/parser.py
+++ b/projects/rocprofiler-compute/src/utils/parser.py
@@ -37,6 +37,7 @@ import pandas as pd
 
 from utils import schema
 from utils.logger import console_debug, console_error, console_warning, demarcate
+from utils.pattern_matching import PatternMatcherEngine
 from utils.specs import MachineSpecs
 from utils.utils import normalize_filter_to_str_list
 
@@ -2078,22 +2079,12 @@ def load_non_mertrics_table(
     workload.dfs.update(tmp)
 
 
-@demarcate
-def load_torch_trace_data(workload: schema.Workload, dir_path: str) -> None:
-    """
-    Loads all torch operator CSVs from torch_trace directory
-    into workload.torch_operators.
-    """
-    torch_trace_dir = Path(dir_path) / "torch_trace"
-    workload.torch_operators = {}
-    if torch_trace_dir.exists() and torch_trace_dir.is_dir():
-        for csv_file in torch_trace_dir.glob("*.csv"):
-            operator_name = csv_file.stem  # filename without .csv
-            try:
-                df = pd.read_csv(csv_file)
-                workload.torch_operators[operator_name] = df
-            except Exception as e:
-                console_warning(f"Could not load {csv_file}: {e}")
+torch_operator_matcher = PatternMatcherEngine(mode="glob-hierarchy")
+
+
+def torch_operator_pattern_matches(pattern: str, operator_name: str) -> bool:
+    """Return True if *pattern* glob-matches *operator_name* hierarchy path."""
+    return torch_operator_matcher.matches(pattern, operator_name)
 
 
 @demarcate
@@ -2112,9 +2103,6 @@ def load_table_data(
     """
     if not skip_kernel_top:
         load_non_mertrics_table(workload, dir_path, args)
-
-    # Load torch operator trace data if present
-    load_torch_trace_data(workload, dir_path)
 
     eval_metric(
         workload.dfs,

--- a/projects/rocprofiler-compute/src/utils/pattern_matching.py
+++ b/projects/rocprofiler-compute/src/utils/pattern_matching.py
@@ -1,0 +1,87 @@
+##############################################################################
+# MIT License
+#
+# Copyright (c) 2021 - 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+##############################################################################
+
+from abc import ABC, abstractmethod
+from pathlib import PurePosixPath
+
+
+class PatternMatcherInterface(ABC):
+    """Strategy interface for matching a pattern against a target string."""
+
+    @abstractmethod
+    def matches(self, pattern: str, target: str) -> bool:
+        """Return True if *pattern* matches *target*."""
+
+
+class PurePosixGlobHierarchyMatcher(PatternMatcherInterface):
+    """
+    Match slash-delimited hierarchy strings using PurePosixPath glob semantics.
+
+    Delegates entirely to PurePosixPath.match() for glob evaluation.
+    Normalizations applied before matching:
+      "all"        ->  "**"      (match everything)
+      leading "/"  ->  stripped  (cosmetic, PurePosixPath treats "/" as anchor)
+    """
+
+    @staticmethod
+    def normalize_pattern(raw_pattern: str) -> str:
+        pattern = raw_pattern.strip()
+        if not pattern:
+            return ""
+        if pattern in ("all", "*"):
+            return "**"
+        if pattern.startswith("/"):
+            pattern = pattern[1:]
+        return pattern
+
+    def matches(self, pattern: str, target: str) -> bool:
+        if not pattern or not target:
+            return False
+
+        glob_pattern = self.normalize_pattern(pattern)
+        if not glob_pattern:
+            return False
+
+        return PurePosixPath(target).match(glob_pattern)
+
+
+class PatternMatcherEngine:
+    """
+    Facade that selects a matching strategy by mode name.
+
+    Supported modes:
+      "glob-hierarchy"  -  PurePosixPath glob matching (default)
+
+    Future modes (e.g. "regex", "wildcard-dsl") can be added here without
+    changing any call-site code.
+    """
+
+    def __init__(self, mode: str = "glob-hierarchy") -> None:
+        if mode == "glob-hierarchy":
+            self.impl: PatternMatcherInterface = PurePosixGlobHierarchyMatcher()
+        else:
+            raise ValueError(f"Unsupported pattern matcher mode: {mode}")
+
+    def matches(self, pattern: str, target: str) -> bool:
+        return self.impl.matches(pattern, target)

--- a/projects/rocprofiler-compute/src/utils/schema.py
+++ b/projects/rocprofiler-compute/src/utils/schema.py
@@ -68,7 +68,7 @@ class Workload:
     roofline_metrics: dict[int, dict[str, Any]] = field(default_factory=dict)
     path: str = field(default_factory=str)
     filter_top_n: str = field(default_factory=str)
-    torch_operators: dict[str, pd.DataFrame] = field(default_factory=dict)
+    matched_torch_trace_df: pd.DataFrame = field(default_factory=pd.DataFrame)
 
 
 # Metrics will be calculated ONLY when the header(key) is in below list

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -256,76 +256,14 @@ def is_roofline_shown(
     return True
 
 
-def show_torch_operator_table(operator_name: str, df: pd.DataFrame) -> None:
-    """Display torch operator data in a properly formatted table."""
-    if df is None or df.empty:
-        console_log(f"No data available for operator: {operator_name}")
-        return
-
-    console_log(f"\n{operator_name}")
-    console_log("=" * len(operator_name))
-
-    # Create a copy for display formatting
-    display_df = df.copy()
-
-    # Max display width per column type; Kernel_Name is skipped (show wrapped).
-    column_widths = {
-        "Operator_Name": 40,
-        "Context": 35,
-        "default": 20,  # fallback for all other string columns
-    }
-
-    # Truncate string columns; wrap Kernel_Name (full, no truncation)
-    for col in display_df.columns:
-        if display_df[col].dtype != "object":
-            continue  # skip numeric columns
-        if col == "Kernel_Name":
-            display_df[col] = (
-                display_df[col].astype(str).apply(wrap_kernel_name)
-            )  # wrap full name instead of truncating
-            continue
-        max_width = column_widths.get(
-            col, column_widths["default"]
-        )  # use column-specific width or fallback
-        display_df[col] = (
-            display_df[col]
-            .astype(str)  # ensure type is string before continuing text operations
-            .apply(
-                lambda x: (
-                    string_multiple_lines(
-                        x, max_width, 2
-                    )  # split into at most 2 lines, add "..." if still too long
-                    if len(x) > max_width
-                    else x  # leave short values as-is
-                )
-            )
-        )
-
-    # Reset index for row numbering
-    display_df = display_df.reset_index(drop=True)
-
-    # Use tabulate for consistent formatting (no maxcolwidths: natural column width)
-    table_str = tabulate(
-        display_df,
-        headers=display_df.columns,
-        tablefmt="fancy_grid",
-        showindex=True,
-        floatfmt=".2f",
-    )
-
-    console_log(table_str)
-
-
 def list_torch_operators(
     workload_path: str,
     call_trees: dict[str, CallTreeNode],
 ) -> None:
     """Display PyTorch operators as a unified call tree grouped by source location."""
     if not call_trees:
-        console_warning(
-            "No PyTorch operator data found. "
-            "Please ensure profiling was done with --torch-trace option."
-        )
+        print(f"\nPyTorch Operators in: {workload_path}")
+        print("Total: 0 operators")
         return
 
     print(f"\n{'=' * 80}")

--- a/projects/rocprofiler-compute/src/utils/utils.py
+++ b/projects/rocprofiler-compute/src/utils/utils.py
@@ -55,7 +55,6 @@ import yaml
 
 import config
 from utils import rocpd_data
-from utils.kernel_name_shortener import kernel_name_shortener
 from utils.logger import (
     console_debug,
     console_error,
@@ -1550,40 +1549,29 @@ def build_call_trees(
     return call_trees
 
 
-def write_torch_trace_operator_csvs(
+def write_torch_trace_consolidated_csv(
     consolidated_df: pd.DataFrame,
     torch_trace_path: Path,
 ) -> None:
-    """Write one consolidated torch trace CSV per operator."""
-    grouped = consolidated_df.groupby("Operator_Name")
-    for operator_name, group in grouped:
-        last_operator = operator_name.split("/")[-1]
-        sanitized_operator_name = last_operator.replace("torch.", "").replace(".", "_")
-        output_file = f"{torch_trace_path}/{sanitized_operator_name}.csv"
-        if Path(output_file).is_file():
-            group.to_csv(output_file, mode="a", header=False, index=False)
-            console_log(f"Appended trace to existing file {output_file}")
-        else:
-            group.to_csv(output_file, index=False)
-            console_log(f"Saved consolidated trace to {output_file}")
+    """Write the consolidated torch trace DataFrame to ``consolidated.csv``."""
+    output_file = torch_trace_path / "consolidated.csv"
+    consolidated_df.sort_values("Operator_Name", ignore_index=True).to_csv(
+        output_file, index=False
+    )
+    console_log(f"Saved consolidated trace to {output_file}")
 
 
 def build_call_trees_with_kernel_ids(
     consolidated_df: pd.DataFrame,
     kernel_top_df: pd.DataFrame,
-    kernel_verbose: int = 0,
 ) -> dict[str, CallTreeNode]:
     """Attach Kernel_ID values and build call trees from consolidated trace rows."""
     kernel_name_to_id = {
         str(row["Kernel_Name"]).strip(): idx for idx, row in kernel_top_df.iterrows()
     }
-    shortened = kernel_name_shortener(
-        pd.DataFrame({"Kernel_Name": consolidated_df["Kernel_Name"]}),
-        kernel_verbose,
-    )
     consolidated_with_ids = consolidated_df.copy()
     consolidated_with_ids["Kernel_ID"] = (
-        shortened["Kernel_Name"].str.strip().map(kernel_name_to_id)
+        consolidated_with_ids["Kernel_Name"].str.strip().map(kernel_name_to_id)
     )
     return build_call_trees(consolidated_with_ids)
 
@@ -1621,10 +1609,7 @@ def process_torch_trace_output(
             "No marker files with corresponding counter files found. "
             "Ensure profiling was done with '--torch-trace'."
         )
-        raise ValueError(
-            "No marker files with corresponding counter files found. "
-            "Ensure profiling was done with '--torch-trace'."
-        )
+        return pd.DataFrame(), Path(f"{workload_dir}/torch_trace")
 
     torch_trace_path = Path(f"{workload_dir}/torch_trace")
     if torch_trace_path.exists():

--- a/projects/rocprofiler-compute/tests/test_analyze_commands.py
+++ b/projects/rocprofiler-compute/tests/test_analyze_commands.py
@@ -1719,9 +1719,16 @@ def test_list_torch_operators_no_path(binary_handler_analyze_rocprof_compute, ca
 def test_list_torch_operators_no_trace_data(
     binary_handler_analyze_rocprof_compute, capsys
 ):
-    """Test graceful handling when torch_trace/ directory doesn't exist"""
-    # Use regular vcopy workload (no torch data)
+    """Test graceful handling when workload was profiled with --torch-trace but
+    contains no torch operator data (e.g. a non-PyTorch workload like vcopy).
+    """
     workload_dir = test_utils.setup_workload_dir(indirs[0])
+
+    # Simulate a workload profiled with --torch-trace so the sanitize guard
+    # passes, but no torch marker/counter files exist (non-torch workload).
+    config_path = Path(workload_dir) / "profiling_config.yaml"
+    config_path.write_text("torch_trace: true\n")
+
     code = binary_handler_analyze_rocprof_compute([
         "--experimental",
         "analyze",

--- a/projects/rocprofiler-compute/tests/test_analyze_workloads.py
+++ b/projects/rocprofiler-compute/tests/test_analyze_workloads.py
@@ -1256,18 +1256,13 @@ def test_analyze_torch_trace_list_operators_MI350(
 
     output = capsys.readouterr().out
 
-    assert "PyTorch Operators in:" in output
-    assert "Total: 3 operators" in output
-
-    for i in range(1, 4):
-        assert f"Operator {i}:" in output
-
-    for name in ("relu", "nn_functional_linear", "ones_like"):
-        assert f"'{name}'" in output
-
+    assert "PyTorch Operator Call Tree:" in output
+    assert "Grouped by source location" in output
     assert "torch.nn.functional.relu" in output
+    assert "torch.nn.functional.linear" in output
+    assert "torch.ones_like" in output
+    assert "kernel_launches:" in output
     assert "total_duration:" in output
-    assert "Kernel (id N) can be used with -k" in output
 
 
 def test_analyze_torch_trace_filter_operator_MI350(
@@ -1279,18 +1274,16 @@ def test_analyze_torch_trace_filter_operator_MI350(
         "--path",
         "tests/workloads/torch_trace/MI350",
         "--torch-operator",
-        "relu",
+        "*relu",
     ])
     assert code == 0
 
     output = capsys.readouterr().out
 
+    assert "Matched PyTorch Operators:" in output
     assert "relu" in output
-    assert "=" in output
-    assert "Operator_Name" in output
-    assert "Kernel_Name" in output
-    assert "torch.relu" in output
-    assert "|" in output
+    assert "kernel_launches:" in output
+    assert "total_duration:" in output
 
 
 def test_analyze_torch_trace_multi_operator_MI350(
@@ -1302,17 +1295,16 @@ def test_analyze_torch_trace_multi_operator_MI350(
         "--path",
         "tests/workloads/torch_trace/MI350",
         "--torch-operator",
-        "relu",
-        "ones_like",
+        "*relu",
+        "*ones_like",
     ])
     assert code == 0
 
     output = capsys.readouterr().out
 
+    assert "Matched PyTorch Operators:" in output
     assert "relu" in output
     assert "ones_like" in output
-    assert output.count("Operator_Name") == 2
-    assert output.count("Kernel_Name") == 4
 
 
 def test_analyze_torch_trace_invalid_operator_MI350(
@@ -1329,7 +1321,7 @@ def test_analyze_torch_trace_invalid_operator_MI350(
     assert code == 0
 
     output = capsys.readouterr().out
-    assert "No data for operator: nonexistent_op" in output
+    assert "No operators matched" in output
 
 
 def test_analyze_torch_trace_hierarchy_path_MI350(
@@ -1348,9 +1340,9 @@ def test_analyze_torch_trace_hierarchy_path_MI350(
 
     output = capsys.readouterr().out
 
-    assert "Operator_Name" in output
-    assert "Kernel_Name" in output
-    assert "|" in output
+    assert "Matched PyTorch Operators:" in output
+    assert "torch.relu" in output
+    assert "kernel_launches:" in output
 
 
 def test_analyze_torch_trace_torch_prefix_MI350(
@@ -1368,6 +1360,6 @@ def test_analyze_torch_trace_torch_prefix_MI350(
 
     output = capsys.readouterr().out
 
-    assert "Operator_Name" in output
-    assert "Kernel_Name" in output
+    assert "Matched PyTorch Operators:" in output
     assert "torch.relu" in output
+    assert "kernel_launches:" in output

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -3336,9 +3336,10 @@ def test_torch_trace_profile(
 
     Runs profiling with --torch-trace, verifies profile outputs (pmc_perf, marker
     and counter CSVs), then runs analyze with --list-torch-operators and
-    --torch-operator relu, and verifies torch_trace directory, operator CSV
-    contents (hierarchy, kernel, counters), and CLI output format (call tree
-    grouped by source location, aggregated stats, kernel IDs, sort order).
+    --torch-operator (PurePosixPath glob patterns like *relu, all), and verifies
+    torch_trace directory, consolidated CSV contents (hierarchy, kernel, counters),
+    and CLI output format (call tree grouped by source location, aggregated stats,
+    kernel IDs, sort order).
     Requires PyTorch and GPU; not included in default suite.
     """
     workload_dir = test_utils.get_output_dir(param_id="torch_trace")
@@ -3469,41 +3470,28 @@ def test_torch_trace_profile(
 
     list_output = capsys.readouterr().out
 
-    # 7. torch_trace directory created with per-operator CSVs
+    # 7. torch_trace directory created with consolidated.csv
     torch_trace_dir = Path(workload_dir) / "torch_trace"
     assert torch_trace_dir.exists(), "torch_trace directory not created"
 
-    operator_csv_files = list(torch_trace_dir.glob("*.csv"))
-    assert operator_csv_files, "No operator CSV files found in torch_trace"
+    consolidated_csv = torch_trace_dir / "consolidated.csv"
+    assert consolidated_csv.exists(), "consolidated.csv not found in torch_trace"
 
-    # 8. Operator CSVs contain hierarchy, kernel names, and counter values
-    hierarchy_present = False
-    for op_file in operator_csv_files:
-        df = pd.read_csv(op_file)
-        assert not df.empty, f"{op_file} is empty"
-        assert "Operator_Name" in df.columns, (
-            f"Operator_Name column missing in {op_file}"
-        )
-        if not hierarchy_present:
-            hierarchy_present = (
-                df["Operator_Name"]
-                .apply(lambda x: "/" in str(x) or "::" in str(x))
-                .any()
-            )
-        assert "Kernel_Name" in df.columns, f"Kernel_Name missing in {op_file}"
-        assert df["Kernel_Name"].notnull().all() and (df["Kernel_Name"] != "").all(), (
-            f"Empty Kernel_Name in {op_file}"
-        )
-        assert "Counter_Value" in df.columns, (
-            f"Counter_Value column missing in {op_file}"
-        )
-        assert df["Counter_Value"].notnull().all()
-        assert (df["Counter_Value"] != "").all(), f"Empty Counter_Value in {op_file}"
-
-    assert hierarchy_present, (
-        f"No hierarchy information in operator CSV files. "
-        f"Files checked: {[f.name for f in operator_csv_files]}"
+    # 8. Consolidated CSV contains hierarchy, kernel names, and counter values
+    df = pd.read_csv(consolidated_csv)
+    assert not df.empty, "consolidated.csv is empty"
+    assert "Operator_Name" in df.columns, "Operator_Name column missing"
+    hierarchy_present = (
+        df["Operator_Name"].apply(lambda x: "/" in str(x) or "::" in str(x)).any()
     )
+    assert hierarchy_present, "No hierarchy information in consolidated.csv"
+    assert "Kernel_Name" in df.columns, "Kernel_Name missing"
+    assert df["Kernel_Name"].notnull().all() and (df["Kernel_Name"] != "").all(), (
+        "Empty Kernel_Name in consolidated.csv"
+    )
+    assert "Counter_Value" in df.columns, "Counter_Value column missing"
+    assert df["Counter_Value"].notnull().all()
+    assert (df["Counter_Value"] != "").all(), "Empty Counter_Value in consolidated.csv"
 
     # ---- Verify --list-torch-operators CLI output format (checks 9–14) ----
 
@@ -3571,10 +3559,105 @@ def test_torch_trace_profile(
         "--path",
         workload_dir,
         "--torch-operator",
-        "relu",
+        "*relu",
     ])
-    # 16. Analyze with --torch-operator relu succeeds
-    assert returncode_analyze_relu == 0, "Analyze with --torch-operator relu failed"
+    # 16. Analyze with --torch-operator *relu succeeds
+    assert returncode_analyze_relu == 0, "Analyze with --torch-operator *relu failed"
+
+    # --- Verify torch-operator cli output ---
+
+    # 17. Multi-component pattern matches operator in the middle of hierarchy.
+    #     torch.nn.functional.relu is a wrapper that delegates to torch.relu;
+    #     only the leaf operator appears in consolidated trace, so we use
+    #     wildcards to match through the hierarchy.
+    capsys.readouterr()
+    rc_exact = binary_handler_analyze_rocprof_compute([
+        "--experimental",
+        "analyze",
+        "--path",
+        workload_dir,
+        "--torch-operator",
+        "*/torch.nn.functional.relu/*",
+    ])
+    assert rc_exact == 0, (
+        "Analyze with --torch-operator */torch.nn.functional.relu/* failed"
+    )
+    out_exact = capsys.readouterr().out
+    assert "Matched PyTorch Operators" in out_exact, (
+        "Expected 'Matched PyTorch Operators' header in --torch-operator output"
+    )
+    assert "kernel_launches" in out_exact, (
+        "Expected call tree with kernel_launches stats in --torch-operator output"
+    )
+
+    # 18. Glob wildcard pattern (*relu) matches the relu operator
+    capsys.readouterr()
+    rc_glob = binary_handler_analyze_rocprof_compute([
+        "--experimental",
+        "analyze",
+        "--path",
+        workload_dir,
+        "--torch-operator",
+        "*relu",
+    ])
+    assert rc_glob == 0, "Analyze with --torch-operator *relu failed"
+    out_glob = capsys.readouterr().out
+    assert "kernel_launches" in out_glob, (
+        "Glob pattern *relu should match relu operator and render call tree"
+    )
+
+    # 19. 'all' keyword matches every operator
+    capsys.readouterr()
+    rc_all = binary_handler_analyze_rocprof_compute([
+        "--experimental",
+        "analyze",
+        "--path",
+        workload_dir,
+        "--torch-operator",
+        "all",
+    ])
+    assert rc_all == 0, "Analyze with --torch-operator all failed"
+    out_all = capsys.readouterr().out
+    assert "kernel_launches" in out_all, "'all' keyword should match operators"
+
+    # 20. --torch-operator + -k intersection succeeds and renders call tree
+    capsys.readouterr()
+    rc_intersect = binary_handler_analyze_rocprof_compute([
+        "--experimental",
+        "analyze",
+        "--path",
+        workload_dir,
+        "--torch-operator",
+        "all",
+        "-k",
+        "0",
+    ])
+    assert rc_intersect == 0, "Analyze with --torch-operator all -k 0 failed"
+    out_intersect = capsys.readouterr().out
+    assert "Matched PyTorch Operators" in out_intersect, (
+        "Expected call tree output with --torch-operator all -k 0"
+    )
+    assert "Torch operator filter selected" in out_intersect, (
+        "Expected filter-selection log confirming -k intersection"
+    )
+
+    # 21. Non-matching pattern degrades gracefully with a warning
+    capsys.readouterr()
+    rc_nomatch = binary_handler_analyze_rocprof_compute([
+        "--experimental",
+        "analyze",
+        "--path",
+        workload_dir,
+        "--torch-operator",
+        "nonexistent_operator_xyz",
+    ])
+    assert rc_nomatch == 0, (
+        "Analyze with non-matching --torch-operator should not crash"
+    )
+    out_nomatch = capsys.readouterr().out
+    assert "No operators matched" in out_nomatch, (
+        "Expected warning about no operators matched"
+    )
 
     test_utils.clean_output_dir(config["cleanup"], workload_dir)
 

--- a/projects/rocprofiler-compute/tests/test_torch_trace.py
+++ b/projects/rocprofiler-compute/tests/test_torch_trace.py
@@ -38,7 +38,7 @@ from utils.rocpd_data import (
 from utils.utils import (
     build_call_trees_with_kernel_ids,
     process_torch_trace_output,
-    write_torch_trace_operator_csvs,
+    write_torch_trace_consolidated_csv,
 )
 
 GUID = "abc-1234-def"
@@ -363,7 +363,7 @@ def write_csv_layout(workload_dir, fbase="run0", pid="12345"):
     counter_df.to_csv(counter_path, index=False)
 
 
-def read_operator_csvs(torch_trace_dir):
+def read_torch_trace_csvs(torch_trace_dir):
     """Return a dict mapping filename -> sorted DataFrame for comparison."""
     result = {}
 
@@ -401,8 +401,8 @@ def test_torch_trace_output_same_for_rocpd_and_csv():
     rocpd_df, rocpd_trace_path = rocpd_output
     csv_df, csv_trace_path = csv_output
 
-    write_torch_trace_operator_csvs(rocpd_df, rocpd_trace_path)
-    write_torch_trace_operator_csvs(csv_df, csv_trace_path)
+    write_torch_trace_consolidated_csv(rocpd_df, rocpd_trace_path)
+    write_torch_trace_consolidated_csv(csv_df, csv_trace_path)
     rocpd_trees = build_call_trees_with_kernel_ids(rocpd_df, kernel_top_df)
     csv_trees = build_call_trees_with_kernel_ids(csv_df, kernel_top_df)
 
@@ -424,11 +424,11 @@ def test_torch_trace_output_same_for_rocpd_and_csv():
         assert "kernel_mm" in mm_node.kernels
         assert mm_node.kernels["kernel_mm"].launches == 1
 
-    rocpd_results = read_operator_csvs(Path(rocpd_dir) / "torch_trace")
-    csv_results = read_operator_csvs(Path(csv_dir) / "torch_trace")
+    rocpd_results = read_torch_trace_csvs(Path(rocpd_dir) / "torch_trace")
+    csv_results = read_torch_trace_csvs(Path(csv_dir) / "torch_trace")
 
     assert rocpd_results.keys() == csv_results.keys(), (
-        f"Operator files differ: rocpd={sorted(rocpd_results.keys())} "
+        f"Torch trace CSV files differ: rocpd={sorted(rocpd_results.keys())} "
         f"csv={sorted(csv_results.keys())}"
     )
 

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -8420,3 +8420,479 @@ class TestBuildMetricList:
         )
         self.build_metric_list(ac, None)
         assert "All None Metric" not in self._extract_leaf_metric_entries(ac).values()
+
+
+# ---------------------------------------------------------------------------
+# Torch operator pattern matching (PurePosixPath glob)
+# ---------------------------------------------------------------------------
+
+H3 = "nn.Module.Net.forward/torch.nn.functional.relu/torch.relu"
+H2 = "nn.Module.Net.forward/torch.nn.functional.conv2d"
+H1 = "torch.relu"
+
+
+@pytest.mark.torch_ops
+def test_all_keyword():
+    """'all' maps to '**' and matches every hierarchy."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    assert m("all", H3)
+    assert m("all", H2)
+    assert m("all", H1)
+    assert not m("all", "")
+
+
+@pytest.mark.torch_ops
+def test_bare_pattern_matches_last_component():
+    """Bare token is matched via PurePosixPath.match() against the full hierarchy."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    assert m("torch.relu", H3)
+    assert m("torch.nn.functional.conv2d", H2)
+    assert not m("relu", H3)
+    assert not m("forward", H3)
+    assert not m("sigmoid", H3)
+
+
+@pytest.mark.torch_ops
+def test_bare_wildcard_pattern():
+    """Wildcard bare token matched via PurePosixPath.match()."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    assert m("torch.*", H3)
+    assert m("*relu", H3)
+    assert m("*conv*", H2)
+    assert not m("conv*", H2)
+    assert not m("sigm*", H3)
+
+
+@pytest.mark.torch_ops
+def test_hierarchy_glob():
+    """Patterns with '/' match across multiple hierarchy components."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    assert m("nn.Module.Net.forward/*/torch.relu", H3)
+    assert m("*/torch.nn.functional.conv2d", H2)
+    assert not m("nn.Module.Net.forward/torch.relu", H3)
+
+
+@pytest.mark.torch_ops
+def test_leading_slash_is_cosmetic():
+    """Leading '/' is stripped during pattern normalization."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    assert m("/nn.Module.Net.forward/*/torch.relu", H3)
+    assert m("/torch.relu", H3)
+
+
+@pytest.mark.torch_ops
+def test_trailing_slash_stripped_by_posixpath():
+    """PurePosixPath strips trailing slashes, so they are cosmetic."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    assert not m("nn.Module.Net.forward/", H3)
+    assert m("torch.relu/", H3)
+
+
+@pytest.mark.torch_ops
+def test_regex_not_supported():
+    """Regex syntax has no special meaning; treated as literal glob text."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    assert not m("relu|conv2d", H3)
+    assert not m("^torch\\.relu$", H3)
+    assert not m("not:relu", H3)
+    assert not m("2:functional", H3)
+
+
+@pytest.mark.torch_ops
+def test_empty_inputs():
+    """Empty pattern or operator_name returns False."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    assert not m("", H3)
+    assert not m("relu", "")
+    assert not m("", "")
+
+
+@pytest.mark.torch_ops
+def test_slash_only_markers():
+    """Scope-marker-only tokens should not match any hierarchy."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    assert not m("/", H3)
+    assert not m("//", H3)
+
+
+# -- get_matched_torch_operators_for_display ---------------------------------
+
+
+def get_matched_torch_operators_for_display(
+    torch_operators: dict[str, pd.DataFrame],
+    pattern_list: list[str],
+) -> list[tuple[str, pd.DataFrame]]:
+    """Return (operator_name, filtered_df) for each operator matching any pattern.
+
+    Test-only helper: iterates every unique Operator_Name across all torch trace
+    DataFrames and checks each against the supplied glob patterns.
+    """
+    from utils.parser import torch_operator_pattern_matches
+
+    if not torch_operators or not pattern_list:
+        return []
+    result: list[tuple[str, pd.DataFrame]] = []
+    seen: set[str] = set()
+    for _, df in torch_operators.items():
+        if df is None or df.empty or "Operator_Name" not in df.columns:
+            continue
+        for op_name in df["Operator_Name"].dropna().unique():
+            op_str = str(op_name).strip()
+            if op_str in seen:
+                continue
+            for pattern in pattern_list:
+                if torch_operator_pattern_matches(pattern.strip(), op_str):
+                    seen.add(op_str)
+                    result.append((op_str, df.loc[df["Operator_Name"] == op_name]))
+                    break
+    return result
+
+
+@pytest.mark.torch_ops
+def test_display_match_hierarchy_glob():
+    """Full hierarchy globs are honored by display helper."""
+    df = pd.DataFrame({
+        "Operator_Name": [H3, H3, H2],
+        "Kernel_Name": ["k1", "k2", "k3"],
+    })
+    torch_operators = {"trace_0": df}
+
+    matched = get_matched_torch_operators_for_display(torch_operators, ["*/torch.relu"])
+    assert len(matched) == 1
+    assert matched[0][0] == H3
+
+
+@pytest.mark.torch_ops
+def test_display_match_multi_patterns():
+    """Multiple glob patterns match their respective operators."""
+    df = pd.DataFrame({
+        "Operator_Name": [H3, H2],
+        "Kernel_Name": ["k1", "k2"],
+    })
+    torch_operators = {"trace_0": df}
+
+    matched = get_matched_torch_operators_for_display(
+        torch_operators, ["*relu", "*conv*"]
+    )
+    assert len(matched) == 2
+
+
+@pytest.mark.torch_ops
+def test_display_no_match():
+    """No matches returns empty list."""
+    df = pd.DataFrame({
+        "Operator_Name": [H3],
+        "Kernel_Name": ["k1"],
+    })
+    assert get_matched_torch_operators_for_display({"t": df}, ["sigmoid"]) == []
+
+
+@pytest.mark.torch_ops
+def test_display_empty_inputs():
+    """Empty torch_operators or pattern_list returns []."""
+    assert get_matched_torch_operators_for_display({}, ["relu"]) == []
+    assert get_matched_torch_operators_for_display({"x": pd.DataFrame()}, []) == []
+
+
+# -- parse_torch_operator_patterns ------------------------------------------
+
+
+@pytest.mark.torch_ops
+def test_parse_patterns_basic():
+    """Single and multiple patterns are parsed correctly."""
+    from argparse import Namespace
+
+    from rocprof_compute_analyze.analysis_cli import parse_torch_operator_patterns
+
+    args = Namespace(torch_operator=["relu"])
+    assert parse_torch_operator_patterns(args) == ["relu"]
+
+    args = Namespace(torch_operator=["relu", "conv2d"])
+    assert parse_torch_operator_patterns(args) == ["relu", "conv2d"]
+
+
+@pytest.mark.torch_ops
+def test_parse_patterns_comma_split():
+    """Comma-separated patterns in a single arg are split."""
+    from argparse import Namespace
+
+    from rocprof_compute_analyze.analysis_cli import parse_torch_operator_patterns
+
+    args = Namespace(torch_operator=["relu,conv2d"])
+    assert parse_torch_operator_patterns(args) == ["relu", "conv2d"]
+
+
+@pytest.mark.torch_ops
+def test_parse_patterns_whitespace():
+    """Leading/trailing whitespace is stripped."""
+    from argparse import Namespace
+
+    from rocprof_compute_analyze.analysis_cli import parse_torch_operator_patterns
+
+    args = Namespace(torch_operator=["  relu  ", " conv2d , linear "])
+    assert parse_torch_operator_patterns(args) == ["relu", "conv2d", "linear"]
+
+
+@pytest.mark.torch_ops
+def test_parse_patterns_empty():
+    """Flag given with no args defaults to '**'; absent flag returns empty."""
+    from argparse import Namespace
+
+    from rocprof_compute_analyze.analysis_cli import parse_torch_operator_patterns
+
+    assert parse_torch_operator_patterns(Namespace(torch_operator=[])) == ["**"]
+    assert parse_torch_operator_patterns(Namespace(torch_operator=None)) == []
+    assert parse_torch_operator_patterns(Namespace()) == []
+
+
+# -- PatternMatcherEngine ---------------------------------------------------
+
+
+@pytest.mark.torch_ops
+def test_engine_glob_hierarchy_mode():
+    """Facade delegates matching to glob-hierarchy implementation."""
+    from utils.pattern_matching import PatternMatcherEngine
+
+    matcher = PatternMatcherEngine(mode="glob-hierarchy")
+    assert matcher.matches("torch.relu", H3)
+    assert matcher.matches("*relu", H3)
+    assert not matcher.matches("sigmoid", H3)
+
+
+@pytest.mark.torch_ops
+def test_engine_invalid_mode():
+    """Unsupported strategy names should raise ValueError."""
+    from utils.pattern_matching import PatternMatcherEngine
+
+    with pytest.raises(ValueError):
+        PatternMatcherEngine(mode="regex")
+
+
+# -- Additional coverage (xuchen #26) ----------------------------------------
+
+
+@pytest.mark.torch_ops
+def test_double_star_explicit():
+    """'**' matches any hierarchy depth."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    assert m("**", H3)
+    assert m("**", H2)
+    assert m("**", H1)
+    assert m("**", "a/b/c/d/e")
+    assert not m("**", "")
+
+
+@pytest.mark.torch_ops
+def test_single_char_wildcard():
+    """'?' matches exactly one character in a component."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    assert m("torch.rel?", H3)
+    assert m("torch.?elu", H3)
+    assert not m("torch.?", H3)
+    assert not m("?", H1)
+    assert m("torch.nn.functional.conv?d", H2)
+
+
+@pytest.mark.torch_ops
+def test_long_hierarchy():
+    """Deeply nested hierarchies match correctly."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    deep = "/".join([f"level{i}" for i in range(20)])
+    assert m("level19", deep)
+    assert m("*19", deep)
+    assert m("*/level19", deep)
+    assert m("all", deep)
+    assert not m("level0", deep)
+
+
+@pytest.mark.torch_ops
+def test_long_component_names():
+    """Components with very long names are handled correctly."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    long_name = "a" * 500
+    hierarchy = f"root/{long_name}"
+    assert m(f"{'a' * 500}", hierarchy)
+    assert m("a*", hierarchy)
+    assert not m("b*", hierarchy)
+
+
+@pytest.mark.torch_ops
+def test_special_characters_in_names():
+    """Dots, underscores, and other non-glob chars are treated literally."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    h = "nn.Module._internal/torch.nn.functional.conv2d"
+    assert m("torch.nn.functional.conv2d", h)
+    assert m("*conv2d", h)
+    assert m("nn.Module._internal/*", h)
+    assert not m("nn_Module._internal/*", h)
+
+
+@pytest.mark.torch_ops
+def test_bracket_glob_pattern():
+    """Character classes [abc] work in glob patterns."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    assert m("torch.rel[uv]", H3)
+    assert not m("torch.rel[ab]", H3)
+
+
+@pytest.mark.torch_ops
+def test_single_component_hierarchy():
+    """Single-component hierarchy (no slashes) matches bare patterns."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    assert m("torch.relu", "torch.relu")
+    assert m("*relu", "torch.relu")
+    assert m("torch.*", "torch.relu")
+    assert not m("*/torch.relu", "torch.relu")
+
+
+@pytest.mark.torch_ops
+def test_whitespace_only_pattern():
+    """Whitespace-only patterns normalize to empty and return False."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    assert not m("   ", H3)
+    assert not m("\t", H3)
+
+
+@pytest.mark.torch_ops
+def test_star_pattern_matches_all():
+    """Bare '*' is normalized to '**' and matches every hierarchy."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    assert m("*", H3)
+    assert m("*", H2)
+    assert m("*", H1)
+    assert m("*", "a/b/c/d/e")
+    assert not m("*", "")
+
+
+@pytest.mark.torch_ops
+def test_star_normalize_equivalence():
+    """'*' and 'all' produce the same normalization."""
+    from utils.pattern_matching import PurePosixGlobHierarchyMatcher
+
+    norm = PurePosixGlobHierarchyMatcher.normalize_pattern
+    assert norm("*") == norm("all") == "**"
+
+
+@pytest.mark.torch_ops
+def test_case_sensitivity():
+    """Pattern matching is case-sensitive."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    assert not m("Torch.Relu", H3)
+    assert not m("TORCH.RELU", H3)
+    assert not m("ALL", H3)
+    assert m("all", H3)
+
+
+@pytest.mark.torch_ops
+def test_all_keyword_case_sensitive():
+    """Only lowercase 'all' is the special keyword; mixed case is a literal."""
+    from utils.pattern_matching import PurePosixGlobHierarchyMatcher
+
+    norm = PurePosixGlobHierarchyMatcher.normalize_pattern
+    assert norm("all") == "**"
+    assert norm("ALL") == "ALL"
+    assert norm("All") == "All"
+
+
+@pytest.mark.torch_ops
+def test_consecutive_slashes_in_target():
+    """Consecutive slashes in the target are collapsed by PurePosixPath."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    h = "a//b///torch.relu"
+    assert m("torch.relu", h)
+    assert m("*relu", h)
+
+
+@pytest.mark.torch_ops
+def test_dots_in_patterns():
+    """Dots are literal characters in glob patterns, not regex wildcards."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    assert m("torch.relu", H3)
+    assert not m("torchXrelu", H3)
+    h = "root/torchXrelu"
+    assert not m("torch.relu", h)
+    assert m("torchXrelu", h)
+
+
+@pytest.mark.torch_ops
+def test_pattern_with_spaces():
+    """Spaces in patterns and targets are treated literally."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    h = "module/ spaced op /torch.relu"
+    assert m("torch.relu", h)
+    assert not m(" spaced op ", h)
+    assert m("* spaced op */*", h)
+
+
+@pytest.mark.torch_ops
+def test_colons_in_operator_names():
+    """Colons (e.g. aten::relu) are literal characters in glob matching."""
+    from utils.parser import torch_operator_pattern_matches as m
+
+    h = "nn.Module/aten::relu_"
+    assert m("aten::relu_", h)
+    assert m("*relu_", h)
+    assert m("aten::*", h)
+    assert not m("*relu", h)
+    assert not m("torch.relu", h)
+
+
+@pytest.mark.torch_ops
+def test_display_star_matches_all_operators():
+    """'*' pattern matches all operators in display helper."""
+    df = pd.DataFrame({
+        "Operator_Name": [H3, H2],
+        "Kernel_Name": ["k1", "k2"],
+    })
+    torch_operators = {"trace_0": df}
+
+    matched = get_matched_torch_operators_for_display(torch_operators, ["*"])
+    assert len(matched) == 2
+
+
+@pytest.mark.torch_ops
+def test_display_dedup_across_dataframes():
+    """Same operator in multiple DataFrames is matched only once."""
+    df1 = pd.DataFrame({"Operator_Name": [H3], "Kernel_Name": ["k1"]})
+    df2 = pd.DataFrame({"Operator_Name": [H3], "Kernel_Name": ["k2"]})
+    torch_operators = {"trace_0": df1, "trace_1": df2}
+
+    matched = get_matched_torch_operators_for_display(torch_operators, ["all"])
+    op_names = [name for name, _ in matched]
+    assert op_names.count(H3) == 1
+
+
+@pytest.mark.torch_ops
+def test_parse_patterns_star():
+    """'*' is passed through as-is by the pattern parser."""
+    from argparse import Namespace
+
+    from rocprof_compute_analyze.analysis_cli import parse_torch_operator_patterns
+
+    args = Namespace(torch_operator=["*"])
+    assert parse_torch_operator_patterns(args) == ["*"]
+
+    args = Namespace(torch_operator=["*,torch.relu"])
+    assert parse_torch_operator_patterns(args) == ["*", "torch.relu"]


### PR DESCRIPTION
## Motivation

Enhancing --torch-operator to:

1. accept PurePosixPath glob patterns over operator names (default: ** when no pattern given)
2. auto-generate consolidated.csv from raw traces, making it self-sufficient without --list-torch-operators
3. select kernels launched by matched operator(s) and display a unified call tree grouped by source location
4. allow further kernel filtering with --kernel (intersection applied)
5. calculate and display metrics/roofline based on filtered kernels
6. **update all tests related to torch-trace flow** ( test intent is preserved, only the assertions were adapted to match the new output format)

## Technical Details

1. Glob-based pattern matching (src/utils/pattern_matching.py — new)
2. Consolidated trace pipeline: single consolidated.csv replaces per-operator CSVs (src/utils/utils.py)
3. Operator-to-kernel filtering and auto-generation (src/rocprof_compute_analyze/analysis_cli.py)
4. Unified call tree display (src/utils/tty.py)
5. Matching integration (src/utils/parser.py)
7. Cached matched DataFrame on Workload (src/utils/schema.py)
8. CLI help text and nargs="*" default (src/argparser.py)
9. Documentation (docs/how-to/analyze/cli.rst, docs/how-to/profile/mode.rst)
10. Tests (tests/test_utils.py, tests/test_profile_general.py, tests/test_torch_trace.py)

## JIRA ID 
AIPROFCOMP-155

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

1. All unit tests (no GPU needed) — torch_ops marker
`pytest tests/test_utils.py -m torch_ops -v`
2. Torch trace unit test (no GPU needed) — no marker
`pytest tests/test_torch_trace.py::test_torch_trace_output_same_for_rocpd_and_csv -v`
3. Analyze commands tests (needs workload data, no GPU)
`pytest tests/test_analyze_commands.py -m torch_trace -v`
4. Full integration test (needs GPU + PyTorch)
`pytest tests/test_profile_general.py::test_torch_trace_profile -v`

## Test Result
 Tests Pass.
The sample output from --torch-operator shown below.

<img width="800" height="395" alt="Screenshot 2026-03-17 173646" src="https://github.com/user-attachments/assets/b1a95eab-6082-4f74-a6d8-5314c0a5aa8c" />



## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
- [ ] 