### PR TITLE
Set correct device id when cloning graph nodes

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -213,7 +213,7 @@ class GraphNode : public hipGraphNodeDOTAttribute {
     amd::ScopedLock lock(nodeSetLock_);
     nodeSet_.insert(this);
     isEnabled_ = node.isEnabled_;
-    dev_id_ = node.dev_id_;
+    dev_id_ = ihipGetDevice();
   }
 
   virtual ~GraphNode() {


### PR DESCRIPTION
## Motivation

Unit_hipGraphClone_address_change_in_thread is failing on windows and on linux when segment scheduling is disabled. 

## Technical Details

If graph is cloned to different devices, cloned nodes get original node's dev_id. Because of that, when segment scheduling is disabled, not enough streams get created for the launch device and this test segfaults. Instead of just coping the device id, it should be set to match current device.

## JIRA ID

Resolves SWDEV-568794.

## Test Plan

Disable segment scheduling and run Unit_hipGraphClone_address_change_in_thread.

## Test Result

Test is passing,

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
