### PR TITLE
[rocprof-compute] Fix typo in help text of rocprof-compute analyze

### DIFF
--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -800,7 +800,7 @@ Examples:
         metavar="",
         dest="output_name",
         help=(
-            "\t\tOverride the default output file name rocprof_compue_<uuid> "
+            "\t\tOverride the default output file name rocprof_compute_<uuid> "
             "with the specified name.\n"
             "\t\tThis is only applicable when --output-format txt/csv/db is used.\n"
         ),


### PR DESCRIPTION
## Motivation

There is a small typo in the rocprof-compute analyze help text regarding the --output-name argument:
<img width="2376" height="76" alt="image" src="https://github.com/user-attachments/assets/4b69eecb-4784-4460-93bc-4442dd6fd12a" />
But the tool actually creates the file under rocprof_compute_<uuid> as can be seen here:
<img width="1982" height="598" alt="image" src="https://github.com/user-attachments/assets/42862385-ab68-4723-8958-a6a1c75bfecf" />

Copy of https://github.com/ROCm/rocm-systems/pull/3314

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Just fixed the typo which shouldn't change anything else

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Tested help output afterwards

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Typo is now fixed

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
