### PR TITLE
Add --load-all-code-objects and --lazy option

### DIFF
--- a/projects/rocr-debug-agent/README.md
+++ b/projects/rocr-debug-agent/README.md
@@ -214,6 +214,18 @@ The supported options are:
   1_file____rocm-debug-agent_rocm-debug-agent-test_offset_14309_size_31336
   ````
 
+- __``-c``, ``--load-all-code-objects``__
+
+  Load all code objects as soon as they are loaded by the runtime.
+
+- __``-z``, ``--lazy``__
+
+  Delay inspecting the content of all loaded code obects until after an
+  exception is reported.  Note that the application must not free the code
+  objects' memory while they are loaded on the device.
+
+  This option is incompatible with -c.
+
 - __``-o <file-path>``, ``--output=<file-path>``__
 
   Saves the output produced by the ROCdebug-agent in the specified file.

--- a/projects/rocr-debug-agent/src/code_object.cpp
+++ b/projects/rocr-debug-agent/src/code_object.cpp
@@ -131,9 +131,11 @@ code_object_t::find_symbol (amd_dbgapi_global_address_t address)
   return {};
 }
 
-void
+bool
 code_object_t::open ()
 {
+  agent_assert (!is_open () && "code object is already opened");
+
   const std::string protocol_delim{ "://" };
 
   size_t protocol_end = m_uri.find (protocol_delim);
@@ -192,7 +194,7 @@ code_object_t::open ()
 
       if (auto size_it = params.find ("size"); size_it != params.end ())
         if (!(size = std::stoul (size_it->second, nullptr, 0)))
-          return;
+          return false;
 
       if (protocol == "file")
         {
@@ -200,7 +202,7 @@ code_object_t::open ()
           if (!file)
             {
               agent_warning ("could not open `%s'", decoded_path.c_str ());
-              return;
+              return false;
             }
 
           if (!size)
@@ -213,7 +215,7 @@ code_object_t::open ()
                 {
                   agent_warning ("invalid uri `%s' (file size < offset)",
                                  decoded_path.c_str ());
-                  return;
+                  return false;
                 }
               size = bytes - offset;
             }
@@ -228,7 +230,7 @@ code_object_t::open ()
             {
               agent_warning ("invalid uri `%s' (offset and size must be != 0",
                              m_uri.c_str ());
-              return;
+              return false;
             }
 
           amd_dbgapi_process_id_t process_id;
@@ -245,13 +247,13 @@ code_object_t::open ()
               != AMD_DBGAPI_STATUS_SUCCESS)
             {
               agent_warning ("could not read memory at 0x%lx", offset);
-              return;
+              return false;
             }
         }
       else
         {
           agent_warning ("\"%s\" protocol not supported", protocol.c_str ());
-          return;
+          return false;
         }
     }
   catch (...)
@@ -300,14 +302,14 @@ code_object_t::open ()
     {
       agent_warning ("could not create a temporary file for code object: %s",
                      strerror (errno));
-      return;
+      return false;
     }
 
   if (size_t size = ::write (fd, buffer.data (), buffer.size ());
       size != buffer.size ())
     {
       agent_warning ("could not write to the temporary file");
-      return;
+      return false;
     }
 
   ::lseek (fd, 0, SEEK_SET);
@@ -319,14 +321,14 @@ code_object_t::open ()
   if (!elf)
     {
       agent_warning ("elf_begin failed for `%s'", m_uri.c_str ());
-      return;
+      return false;
     }
 
   size_t phnum;
   if (elf_getphdrnum (elf.get (), &phnum) != 0)
     {
       agent_warning ("elf_getphdrnum failed for `%s'", m_uri.c_str ());
-      return;
+      return false;
     }
 
   for (size_t i = 0; i < phnum; ++i)
@@ -336,7 +338,7 @@ code_object_t::open ()
       if (!phdr)
         {
           agent_warning ("gelf_getphdr failed for `%s'", m_uri.c_str ());
-          return;
+          return false;
         }
 
       if (phdr->p_type == PT_LOAD)
@@ -344,6 +346,7 @@ code_object_t::open ()
     }
 
   m_fd.emplace (fd);
+  return true;
 }
 
 namespace

--- a/projects/rocr-debug-agent/src/code_object.h
+++ b/projects/rocr-debug-agent/src/code_object.h
@@ -61,11 +61,13 @@ public:
 
   ~code_object_t ();
 
-  void open ();
+  bool open ();
   bool is_open () const { return m_fd.has_value (); }
 
   amd_dbgapi_global_address_t load_address () const { return m_load_address; }
   amd_dbgapi_size_t mem_size () const { return m_mem_size; }
+  const std::string &uri () const { return m_uri; }
+  amd_dbgapi_code_object_id_t id () const { return m_code_object_id; }
 
   std::optional<symbol_info_t>
   find_symbol (amd_dbgapi_global_address_t address);

--- a/projects/rocr-debug-agent/src/debug_agent.cpp
+++ b/projects/rocr-debug-agent/src/debug_agent.cpp
@@ -110,6 +110,8 @@ std::optional<std::string> g_code_objects_dir;
 bool g_all_wavefronts{ false };
 bool g_precise_emmory{ false };
 bool g_precise_alu_exceptions{ false };
+bool g_lazy{ true };
+bool g_delay_loading{ false };
 
 /* Global state accessed by the dbgapi callbacks.  */
 std::optional<amd_dbgapi_breakpoint_id_t> g_rbrk_breakpoint_id;
@@ -625,14 +627,14 @@ stop_all_wavefronts (amd_dbgapi_process_id_t process_id)
   agent_log (log_level_t::info, "all wavefronts are stopped");
 }
 
-void
+std::vector<amd_dbgapi_code_object_id_t>
 print_wavefronts (amd_dbgapi_process_id_t process_id, bool all_wavefronts,
                   code_object_map_t &code_object_map)
 {
   /* This function is not thread-safe and not re-entrant.  */
   static std::mutex lock;
   if (!lock.try_lock ())
-    return;
+    return {};
   /* Make sure the lock is released when this function returns.  */
   std::scoped_lock sl (std::adopt_lock, lock);
 
@@ -644,6 +646,7 @@ print_wavefronts (amd_dbgapi_process_id_t process_id, bool all_wavefronts,
   DBGAPI_CHECK (amd_dbgapi_process_wave_list (process_id, &wave_count,
                                               &wave_ids, nullptr));
 
+  std::vector<amd_dbgapi_code_object_id_t> code_objects_disassembled;
   for (size_t i = 0; i < wave_count; ++i)
     {
       amd_dbgapi_wave_id_t wave_id = wave_ids[i];
@@ -857,6 +860,8 @@ print_wavefronts (amd_dbgapi_process_id_t process_id, bool all_wavefronts,
 
           /* Disassemble instructions around `pc`  */
           code_object_found->disassemble (architecture_id, pc);
+
+          code_objects_disassembled.emplace_back (code_object_found->id ());
         }
       else
         {
@@ -865,6 +870,7 @@ print_wavefronts (amd_dbgapi_process_id_t process_id, bool all_wavefronts,
     }
 
   free (wave_ids);
+  return code_objects_disassembled;
 }
 
 void
@@ -882,6 +888,26 @@ print_usage ()
             << std::endl
             << "                              "
                "the current directory."
+            << std::endl;
+  std::cerr << "  -c, --load-all-code-objects "
+               "Load all code objects as soon as they are loaded"
+            << std::endl
+            << "                              "
+            << "by the runtime.";
+  std::cerr << "  -z, --lazy                  "
+               "Delay inspecting the content of all loaded code "
+            << std::endl
+            << "                              "
+            << "obects until after an exception is reported."
+            << std::endl
+            << "                              "
+            << "Note that the application must not free the code "
+            << std::endl
+            << "                              "
+            << "objects' memory while they are loaded on the device."
+            << std::endl
+            << "                              "
+            << "This option is incompatible with -c."
             << std::endl;
   std::cerr << "  -p, --precise-memory        "
             << "Enable precise memory mode which ensures that " << std::endl
@@ -996,18 +1022,21 @@ process_dbgapi_events (amd_dbgapi_process_id_t process_id, bool all_wavefronts,
                   {
                     code_object_t code_object (code_objects_ids[i]);
 
-                    code_object.open ();
-                    if (!code_object.is_open ())
+                    if (!g_delay_loading)
                       {
-                        agent_warning ("could not open code_object_%ld",
-                                       code_objects_ids[i].handle);
-                        continue;
-                      }
+                        if (!code_object.open ())
+                          {
+                            agent_warning ("could not open code_object_%ld",
+                                           code_objects_ids[i].handle);
+                            continue;
+                          }
 
-                    if (g_code_objects_dir
-                        && !code_object.save (*g_code_objects_dir))
-                      agent_warning ("could not save code object to %s",
-                                     g_code_objects_dir->c_str ());
+                        if (!g_lazy && g_code_objects_dir
+                            && !code_object.save (*g_code_objects_dir))
+                          agent_warning ("could not save code object %s to %s",
+                                         code_object.uri ().c_str (),
+                                         g_code_objects_dir->c_str ());
+                      }
 
                     fresh_map.emplace (code_objects_ids[i],
                                        std::move (code_object));
@@ -1034,7 +1063,7 @@ process_dbgapi_events (amd_dbgapi_process_id_t process_id, bool all_wavefronts,
       DBGAPI_CHECK (amd_dbgapi_event_processed (event_id));
     }
 
-  /* Some events do not require us to do anythig more.  If so, just return
+  /* Some events do not require us to do anything more.  If so, just return
      early.  */
   if (!need_print_waves && !wave_need_resume)
     return;
@@ -1048,7 +1077,31 @@ process_dbgapi_events (amd_dbgapi_process_id_t process_id, bool all_wavefronts,
       process_id, AMD_DBGAPI_WAVE_CREATION_STOP));
 
   if (need_print_waves)
-    print_wavefronts (process_id, all_wavefronts, code_object_map);
+    {
+      auto code_objects_disassembled
+          = print_wavefronts (process_id, all_wavefronts, code_object_map);
+
+      /* If the code objects were lazily loaded, save them now.  */
+      if (g_lazy && g_code_objects_dir)
+        for (auto &&code_object_id : code_objects_disassembled)
+          {
+            auto it = code_object_map.find (code_object_id);
+            agent_assert (it != code_object_map.end ());
+            auto &code_object = it->second;
+
+            if (!code_object.is_open () && !code_object.open ())
+              {
+                agent_warning ("could not open %s",
+                               code_object.uri ().c_str ());
+                continue;
+              }
+
+            if (!code_object.save (*g_code_objects_dir))
+              agent_warning ("could not save code object %s to %s",
+                             code_object.uri ().c_str (),
+                             g_code_objects_dir->c_str ());
+          }
+    }
 
   /* We now need to resume execution of the waves present.  This will allow any
      exception to be delivered to the runtime who will be able to act on it if
@@ -1594,6 +1647,8 @@ OnLoad (void *table, uint64_t runtime_version, uint64_t failed_tool_count,
           { "log-level", required_argument, nullptr, 'l' },
           { "output", required_argument, nullptr, 'o' },
           { "save-code-objects", optional_argument, nullptr, 's' },
+          { "lazy", no_argument, nullptr, 'z' },
+          { "load-all-code-objects", no_argument, nullptr, 'c' },
           { "precise-memory", no_argument, nullptr, 'p' },
           { "precise-alu-exceptions", no_argument, nullptr, 'e' },
           { "help", no_argument, nullptr, 'h' },
@@ -1604,7 +1659,8 @@ OnLoad (void *table, uint64_t runtime_version, uint64_t failed_tool_count,
   int saved_optind = optind;
   optind = 1;
 
-  while (int c = getopt_long (argc, argv, ":as::o:dpel:h", options, nullptr))
+  while (int c
+         = getopt_long (argc, argv, ":as::o:dpezcl:h", options, nullptr))
     {
       if (c == -1)
         break;
@@ -1653,6 +1709,14 @@ OnLoad (void *table, uint64_t runtime_version, uint64_t failed_tool_count,
             print_usage ();
           break;
 
+        case 'c': /* -c or --load-all-code-objects.  */
+          g_lazy = false;
+          break;
+
+        case 'z': /* -z or --lazy. */
+          g_delay_loading = true;
+          break;
+
         case 's': /* -s or --save-code-objects  */
           if (argument)
             {
@@ -1691,6 +1755,13 @@ OnLoad (void *table, uint64_t runtime_version, uint64_t failed_tool_count,
         default:
           print_usage ();
         }
+    }
+
+  if (!g_lazy && g_delay_loading)
+    {
+      std::cerr << "\"--load-all-code-objects\" and \"--lazy\" are mutually "
+                   "exclusive" << std::endl;
+      print_usage ();
     }
 
   /* Restore the global optind.  */

--- a/projects/rocr-debug-agent/test/run-test.py
+++ b/projects/rocr-debug-agent/test/run-test.py
@@ -278,7 +278,7 @@ def check_test_4():
         run_and_communicate(
             test_name="4: save code objects",
             args="4",
-            debug_agent_options=f"-p --save-code-objects={tmpdir}",
+            debug_agent_options=f"--save-code-objects={tmpdir} --load-all-code-objects",
         )
 
         try:
@@ -602,6 +602,57 @@ def check_test_10():
     return found_in_debug and not found_in_no_debug
 
 
+def check_eager_code_object_save():
+    print('Starting rocm-gdb-agent test "Check default lazy code object"')
+    with tempfile.TemporaryDirectory() as tmpdir:
+        run_and_communicate(
+            test_name="eager code object save: no event, no code object",
+            args="4",
+            debug_agent_options=f"--save-code-objects={tmpdir}",
+        )
+
+        if len(os.listdir(tmpdir)) != 0:
+            print("Code object saved, while code object saving should have been lazy")
+            return False
+
+        run_and_communicate(
+            test_name="eager code object save: no event, no code object",
+            args="4",
+            debug_agent_options=f"--save-code-objects={tmpdir} -c",
+        )
+
+        if len(os.listdir(tmpdir)) == 0:
+            print("Missing saved code objects")
+            return False
+    return True
+
+
+def check_lazy_loading_and_eager_incompatible():
+    print('Starting rocm-gdb-agent test "Check -c -z incompatible"')
+    out, err, success = run_and_communicate(
+        test_name="eager code object save: no event, no code object",
+        args="4",
+        debug_agent_options=f"--load-all-code-objects --lazy",
+    )
+    check_list = [
+        re.compile(s)
+        for s in ['"--load-all-code-objects" and "--lazy" are mutually exclusive']
+    ]
+    if not success or not check_errors(check_list, out, err):
+        print("Failed to detect -c and -z incompatibility")
+        return False
+
+    out, err, success = run_and_communicate(
+        test_name="eager code object save: no event, no code object",
+        args="4",
+        debug_agent_options=f"--lazy --load-all-code-objects",
+    )
+    if not success or not check_errors(check_list, out, err):
+        print("Failed to detect -c and -z incompatibility")
+        return False
+    return True
+
+
 test_success = True
 unsupported_tests = []
 
@@ -627,6 +678,8 @@ for deferred_loading in (None, "1", "0"):
             check_test_8,
             check_test_9,
             check_test_10,
+            check_eager_code_object_save,
+            check_lazy_loading_and_eager_incompatible,
         ]
 
         for i, test in enumerate(test_list, start=0):


### PR DESCRIPTION
Load the `--load-all-code-objects` and `--lazy` options to the debug agent.

Co-Authored-by: Laurent Morichetti <laurent.morichetti@amd.com>
Change-Id: I17739872e29fdfb48d7c043edbeba0b980f4e59d