### PR TITLE
[rocprofiler-sdk] Fix PTL not re-enabled on finalize in DEVICE_LOCK_AT_START mode

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/device_counting.cpp
@@ -614,6 +614,25 @@ stop_agent_ctx(const context::context* ctx)
 rocprofiler_status_t
 device_counting_service_finalize()
 {
+    // In OLD behavior mode (ROCPROFILER_DEVICE_LOCK_AT_START=1), PTL is disabled at
+    // configuration time and never re-enabled during stop_agent_ctx. Re-enable it here
+    // during finalization so PTL is restored before the process exits.
+    if(use_device_lock_at_start())
+    {
+        for(auto& ctx : context::get_registered_contexts())
+        {
+            if(!ctx->device_counter_collection) continue;
+            for(auto& agent_data : ctx->device_counter_collection->agent_data)
+            {
+                const auto* agent_p = agent::get_agent(agent_data.agent_id);
+                if(agent_p)
+                {
+                    counters::counter_collection_ptl_enable(agent_p);
+                }
+            }
+        }
+    }
+
     for(auto& ctx : context::get_registered_contexts())
     {
         std::vector<rocprofiler::context::device_counting_service::state> expected = {


### PR DESCRIPTION
## Summary
- When `ROCPROFILER_DEVICE_LOCK_AT_START=1` (used by DME/device-metrics-exporter), PTL is disabled via ioctl at configuration time but never re-enabled because `stop_agent_ctx()` skips PTL re-enable in this mode
- This leaves PTL disabled after the profiler process exits, which can degrade GPU performance for other workloads
- Add explicit PTL re-enable in `device_counting_service_finalize()` for all agents that were configured, so PTL is restored during the `atexit` handler before process exit

## Test plan
- [ ] Build rocprofiler-sdk with this change
- [ ] Run device counting service tests to verify no regression
- [ ] Verify PTL state is restored after DME sampling completes (check `/sys/class/drm/cardN/device/ptl/ptl_enable`)
- [ ] Verify no impact when `ROCPROFILER_DEVICE_LOCK_AT_START` is not set (new behavior path is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)