### PR TITLE
[AMD-SMI] Make libdrm required

### DIFF
--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -406,10 +406,11 @@ install(
 add_subdirectory(goamdsmi_shim)
 
 #Debian package specific variables
-set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "python3-argcomplete, libdrm-dev, libdrm-amdgpu-dev")
+# some distros like Debian10 don't ship libdrm-amdgpu-dev, keep as recommends
+set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "python3-argcomplete, libdrm-amdgpu-dev")
 set(CPACK_DEBIAN_ASAN_PACKAGE_RECOMMENDS ${CPACK_DEBIAN_PACKAGE_RECOMMENDS})
 set(CPACK_DEBIAN_DEV_PACKAGE_RECOMMENDS ${CPACK_DEBIAN_PACKAGE_RECOMMENDS})
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "sudo, libc6, python3 (>= 3.6.8), python3-pip, python3-setuptools, python3-wheel")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libdrm-dev, sudo, libc6, python3 (>= 3.6.8), python3-pip, python3-setuptools, python3-wheel")
 set(CPACK_DEBIAN_ASAN_PACKAGE_DEPENDS ${CPACK_DEBIAN_PACKAGE_DEPENDS})
 set(CPACK_DEBIAN_DEV_PACKAGE_DEPENDS ${CPACK_DEBIAN_PACKAGE_DEPENDS})
 
@@ -478,11 +479,13 @@ if(CPACK_RPM_PACKAGE_RELEASE)
     set(CPACK_RPM_PACKAGE_RELEASE_DIST ON)
 endif()
 # NOTE: RPM SUGGESTS DO NOT WORK! https://bugzilla.redhat.com/show_bug.cgi?id=1811358
-set(CPACK_RPM_PACKAGE_SUGGESTS "python3-argcomplete, libdrm-dev, libdrm-amdgpu-dev")
+# some distros like AzureLinux don't ship libdrm-amdgpu-devel, keep as suggests
+set(CPACK_RPM_PACKAGE_SUGGESTS "python3-argcomplete, libdrm-amdgpu-devel")
 set(CPACK_RPM_DEV_PACKAGE_SUGGESTS ${CPACK_RPM_PACKAGE_SUGGESTS})
 set(CPACK_RPM_ASAN_PACKAGE_SUGGESTS ${CPACK_RPM_PACKAGE_SUGGESTS})
 # python version gated by rhel8 :(
-set(CPACK_RPM_PACKAGE_REQUIRES "sudo, python3 >= 3.6.8, python3-pip, python3-wheel, python3-setuptools")
+# note that RPM based systems have "devel" suffix instead of "dev" in debian based systems
+set(CPACK_RPM_PACKAGE_REQUIRES "libdrm-devel, sudo, python3 >= 3.6.8, python3-pip, python3-wheel, python3-setuptools")
 set(CPACK_RPM_DEV_PACKAGE_REQUIRES ${CPACK_RPM_PACKAGE_REQUIRES})
 set(CPACK_RPM_ASAN_PACKAGE_REQUIRES ${CPACK_RPM_PACKAGE_REQUIRES})
 
@@ -520,7 +523,7 @@ endif()
 
 # The line below doesn't currently work; it may be this issue:
 # https://bugzilla.redhat.com/show_bug.cgi?id=1811358
-# set(CPACK_RPM_PACKAGE_SUGGESTS "sudo, libdrm-dev")
+# set(CPACK_RPM_PACKAGE_SUGGESTS "sudo, libdrm-devel")
 
 ## Process the Rpm install/remove scripts to update the CPACK variables
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/RPM/post.in" RPM/post @ONLY)

--- a/projects/amdsmi/Dockerfile
+++ b/projects/amdsmi/Dockerfile
@@ -10,7 +10,7 @@ ENV DEB_BUILD_TEST="amd-smi-lib-tests*99999-local_amd64.deb"
 WORKDIR /home
 
 # Install necessary system packages
-RUN apt update && apt-get install -y git build-essential rpm pkg-config g++ python3 python3-pip python3-wheel python3-setuptools
+RUN apt update && apt-get install -y git build-essential libdrm-dev rpm pkg-config g++ python3 python3-pip python3-wheel python3-setuptools
 
 # Upgrade pip and install cmake and virtualenv using pip
 RUN python3 -m pip install --upgrade pip setuptools && \

--- a/projects/amdsmi/docs/install/install.md
+++ b/projects/amdsmi/docs/install/install.md
@@ -38,8 +38,7 @@ AMD SMI library can run on AMD ROCm supported platforms. Refer to
 for more information.
 <!--https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html-->
 
-To run the AMD SMI library, the `amdgpu` driver and the `amd_hsmp` or `hsmp_acpi` driver need to be installed. Optionally, `libdrm` can be installed to query firmware
-information and hardware IPs.
+To run the AMD SMI library, the `amdgpu` driver and the `amd_hsmp` or `hsmp_acpi` driver need to be installed.
 
 ### Python interface and CLI tool prerequisites
 


### PR DESCRIPTION
## Motivation

libdrm is already required by rocm-systems/TheRock project.