### PR TITLE
[rocrtst] Update installation paths for rocrtst binaries

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/test_common/CMakeLists.txt
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/CMakeLists.txt
@@ -415,7 +415,7 @@ foreach(td ${TARGET_DEVICES})
   file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/${td})
   add_custom_command(OUTPUT "${PROJECT_BINARY_DIR}/${td}/${ROCRTST}" COMMAND ${CMAKE_COMMAND} -E create_symlink "../${ROCRTST}" "${td}/${ROCRTST}" COMMENT "BUILDING ${td}/${ROCRTST}" VERBATIM)
   set(ROCRTST_LINKS_LIST ${ROCRTST_LINKS_LIST} "${PROJECT_BINARY_DIR}/${td}/${ROCRTST}")
-  install ( DIRECTORY ${PROJECT_BINARY_DIR}/${td} DESTINATION bin )
+  install ( DIRECTORY ${PROJECT_BINARY_DIR}/${td} DESTINATION bin/rocrtst )
 endforeach(td)
 
 ######################
@@ -681,7 +681,7 @@ set_target_properties(${ROCRTST} PROPERTIES
 install(TARGETS ${ROCRTST}
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
-        RUNTIME DESTINATION bin)
+        RUNTIME DESTINATION bin/rocrtst)
 
 install ( DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../thirdparty/lib DESTINATION lib/rocrtst )
 


### PR DESCRIPTION
## Motivation

Cleans up the bin folder on theRock as per this comment: https://github.com/ROCm/TheRock/pull/2204#discussion_r2784110454

helps alleviate issue seen in this ticket: https://github.com/ROCm/rocm-systems/issues/2262

## Technical Details

Changed the installation destination for the rocrtst binaries from 'bin' to 'bin/rocrtst' to better organize output files.


## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

CI results, and CI test against rocrtst branch

## Test Result

https://github.com/ROCm/TheRock/actions/runs/22191270315

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
