### PR TITLE
Update the RHEL workflow

### DIFF
--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -50,7 +50,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: dgaliffiamd/rocprofiler-systems:ci-base-rhel-${{ matrix.os-release }}
-      options: --cap-add CAP_SYS_ADMIN
 
     strategy:
       fail-fast: false

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: ['g++']
-        os-release: [ '8.10', '9.4' ]
+        os-release: [ '8.10', '9' ]
         rocm-version: [ '0.0', '6.3', '6.4', '7.0', '7.1' ]
         build-type: ['Release']
 
@@ -101,8 +101,15 @@ jobs:
           ROCM_VERSN=$(( (${ROCM_MAJOR}*10000)+(${ROCM_MINOR}*100) ))
           if [ "${OS_VERSION_MAJOR}" -eq 8 ]; then PERL_REPO=powertools; else PERL_REPO=crb; fi
           dnf -y --enablerepo=${PERL_REPO} install perl-File-BaseDir
-          yum install -y https://repo.radeon.com/amdgpu-install/${{ matrix.rocm-version }}/rhel/${{ matrix.os-release }}/amdgpu-install-${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1${RPM_TAG}.noarch.rpm
-          yum install -y rocm-dev rocdecode-devel
+          printf '%s\n' '[rocm]' \
+            "name=ROCm ${ROCM_VERSION} repository" \
+            "baseurl=https://repo.radeon.com/rocm/el${OS_VERSION_MAJOR}/${ROCM_VERSION}/main" \
+            'enabled=1' 'priority=50' 'gpgcheck=1' \
+            'gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key' |
+            tee /etc/yum.repos.d/rocm.repo
+          cat /etc/yum.repos.d/rocm.repo
+          # yum install -y https://repo.radeon.com/amdgpu-install/${{ matrix.rocm-version }}/rhel/${{ matrix.os-release }}/amdgpu-install-${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1${RPM_TAG}.noarch.rpm
+          dnf install -y rocm-dev rocdecode-devel
           if [ "${OS_VERSION_MAJOR}" -gt 8 ]; then dnf install -y libavcodec-free-devel libavformat-free-devel; fi
 
     - name: Configure, Build, and Test

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -109,7 +109,7 @@ jobs:
             tee /etc/yum.repos.d/rocm.repo
           cat /etc/yum.repos.d/rocm.repo
           # yum install -y https://repo.radeon.com/amdgpu-install/${{ matrix.rocm-version }}/rhel/${{ matrix.os-release }}/amdgpu-install-${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1${RPM_TAG}.noarch.rpm
-          dnf install -y rocm-dev rocdecode-devel
+          dnf install -y rocm-dev
           if [ "${OS_VERSION_MAJOR}" -gt 8 ]; then dnf install -y libavcodec-free-devel libavformat-free-devel; fi
 
     - name: Configure, Build, and Test

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -85,7 +85,7 @@ jobs:
           python3 -m pip install --upgrade pip &&
           python3 -m pip install --upgrade numpy perfetto dataclasses &&
           python3 -m pip install 'cmake==3.21' &&
-          for i in 6 7 8 9 10 11 12 13; do /opt/conda/envs/py3.${i}/bin/python -m pip install --upgrade numpy perfetto dataclasses; done
+          for i in 6 7 8 9 10 11; do /opt/conda/envs/py3.${i}/bin/python -m pip install --upgrade numpy perfetto dataclasses; done
 
     - name: Install ROCm Packages
       if: ${{ matrix.rocm-version > 0 }}
@@ -149,7 +149,7 @@ jobs:
           -DROCPROFSYS_MAX_THREADS=64
           -DROCPROFSYS_INSTALL_PERFETTO_TOOLS=OFF
           -DROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs
-          -DROCPROFSYS_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10;py3.11;py3.12;py3.13"
+          -DROCPROFSYS_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10;py3.11"
           -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv-offload"
           -DROCPROFSYS_BUILD_NUMBER=${{ github.run_attempt }}
           --

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -50,6 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: dgaliffiamd/rocprofiler-systems:ci-base-rhel-${{ matrix.os-release }}
+      options: --cap-add CAP_SYS_ADMIN
+
     strategy:
       fail-fast: false
       matrix:
@@ -83,7 +85,7 @@ jobs:
           python3 -m pip install --upgrade pip &&
           python3 -m pip install --upgrade numpy perfetto dataclasses &&
           python3 -m pip install 'cmake==3.21' &&
-          for i in 6 7 8 9 10 11; do /opt/conda/envs/py3.${i}/bin/python -m pip install --upgrade numpy perfetto dataclasses; done
+          for i in 6 7 8 9 10 11 12 13; do /opt/conda/envs/py3.${i}/bin/python -m pip install --upgrade numpy perfetto dataclasses; done
 
     - name: Install ROCm Packages
       if: ${{ matrix.rocm-version > 0 }}
@@ -147,7 +149,7 @@ jobs:
           -DROCPROFSYS_MAX_THREADS=64
           -DROCPROFSYS_INSTALL_PERFETTO_TOOLS=OFF
           -DROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs
-          -DROCPROFSYS_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10;py3.11"
+          -DROCPROFSYS_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10;py3.11;py3.12;py3.13"
           -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv-offload"
           -DROCPROFSYS_BUILD_NUMBER=${{ github.run_attempt }}
           --

--- a/projects/rocprofiler-systems/docker/Dockerfile.rhel.ci
+++ b/projects/rocprofiler-systems/docker/Dockerfile.rhel.ci
@@ -17,6 +17,9 @@ ARG ELFUTILS_DOWNLOAD_VERSION="0.188"
 ARG BOOST_DOWNLOAD_VERSION="1.79.0"
 ARG NJOBS="8"
 
+RUN echo "* soft memlock unlimited" >> /etc/security/limits.conf && \
+    echo "* hard memlock unlimited" >> /etc/security/limits.conf
+
 RUN yum groupinstall -y "Development Tools" && \
     yum install -y epel-release && crb enable && \
     yum install -y --allowerasing chrpath cmake curl dpkg-devel gmock-devel gtest-devel \


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Update the redhat test workflows and dockers. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Update workflows to use the `rocprofiler-systems:ci-base-rhel-9` image for the rhel 9 tests. This is the docker image that is being maintained and the previous one (9.4) was stale. 
  - the rockylinux-9 image is the base used for this image (currently aligned to rockylinux v.9.7)
  
- Updated ROCm installation method. The previous `amdgpu-install` method is not compatible with rocky-9.7 across all of the ROCm versions that we test.

- Raises memlock limits in the Dockerfile to fix failures in the MPI / UCX ci tests.
 
## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFSYST-212

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
