### PR TITLE
Enable CodeView debug info for Windows Debug and RelWithDebInfo builds

### DIFF
--- a/projects/hip-tests/catch/CMakeLists.txt
+++ b/projects/hip-tests/catch/CMakeLists.txt
@@ -183,11 +183,11 @@ endif()
 
 # Add debug flags for RelWithDebInfo and Debug builds on Windows
 if(WIN32)
-    if(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo" OR CMAKE_BUILD_TYPE STREQUAL "Debug")
-        add_compile_options(-g -gcodeview -gline-tables-only)
-        add_link_options(-Xlinker /DEBUG:FULL)
-        message(STATUS "Added debug flags for ${CMAKE_BUILD_TYPE} build")
-    endif()
+    add_compile_options($<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:-g>)
+    add_compile_options($<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:-gcodeview>)
+    add_compile_options($<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:-gline-tables-only>)
+    add_link_options($<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:-Xlinker>)
+    add_link_options($<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:/DEBUG:FULL>)
 endif()
 
 if(HIP_PLATFORM STREQUAL "amd")
@@ -258,10 +258,8 @@ endif()
 
 # Add debug flags to HIP compilation for test sources on Windows
 if(WIN32)
-    if(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo" OR CMAKE_BUILD_TYPE STREQUAL "Debug")
-        set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -g -gcodeview -gline-tables-only")
-        message(STATUS "Added debug flags to CMAKE_HIP_FLAGS for ${CMAKE_BUILD_TYPE}")
-    endif()
+    set(CMAKE_HIP_FLAGS_DEBUG "${CMAKE_HIP_FLAGS_DEBUG} -g -gcodeview -gline-tables-only")
+    set(CMAKE_HIP_FLAGS_RELWITHDEBINFO "${CMAKE_HIP_FLAGS_RELWITHDEBINFO} -g -gcodeview -gline-tables-only")
 endif()
 
 # get hip-tests commit short hash

--- a/projects/hip-tests/catch/CMakeLists.txt
+++ b/projects/hip-tests/catch/CMakeLists.txt
@@ -256,7 +256,7 @@ if(DEFINED OFFLOAD_ARCH_STR)
     set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} ${OFFLOAD_ARCH_STR}")
 endif()
 
-# # Add debug flags to HIP compilation for test sources on Windows
+# Add debug flags to HIP compilation for test sources on Windows
 if(WIN32)
     if(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo" OR CMAKE_BUILD_TYPE STREQUAL "Debug")
         set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -g -gcodeview -gline-tables-only")

--- a/projects/hip-tests/catch/CMakeLists.txt
+++ b/projects/hip-tests/catch/CMakeLists.txt
@@ -181,6 +181,15 @@ if (WIN32)
   SET(CMAKE_CXX_RESPONSE_FILE_LINK_FLAG "")
 endif()
 
+# Add debug flags for RelWithDebInfo and Debug builds on Windows
+if(WIN32)
+    if(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo" OR CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_compile_options(-g -gcodeview -gline-tables-only)
+        add_link_options(-Xlinker /DEBUG:FULL)
+        message(STATUS "Added debug flags for ${CMAKE_BUILD_TYPE} build")
+    endif()
+endif()
+
 if(HIP_PLATFORM STREQUAL "amd")
     if(WIN32)
         set(win_disable_warnings ${win_disable_warnings} -Wno-ignored-attributes -Wno-microsoft-cast)
@@ -245,6 +254,14 @@ string(STRIP "${OFFLOAD_ARCH_STR}" OFFLOAD_ARCH_STR)
 message(STATUS "Using offload arch string: ${OFFLOAD_ARCH_STR}")
 if(DEFINED OFFLOAD_ARCH_STR)
     set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} ${OFFLOAD_ARCH_STR}")
+endif()
+
+# # Add debug flags to HIP compilation for test sources on Windows
+if(WIN32)
+    if(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo" OR CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -g -gcodeview -gline-tables-only")
+        message(STATUS "Added debug flags to CMAKE_HIP_FLAGS for ${CMAKE_BUILD_TYPE}")
+    endif()
 endif()
 
 # get hip-tests commit short hash

--- a/projects/hip-tests/catch/CMakeLists.txt
+++ b/projects/hip-tests/catch/CMakeLists.txt
@@ -183,7 +183,7 @@ endif()
 
 # Add debug flags for RelWithDebInfo and Debug builds on Windows
 if(WIN32)
-    if(TRUE)
+    if(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo" OR CMAKE_BUILD_TYPE STREQUAL "Debug")
         add_compile_options(-g -gcodeview -gline-tables-only)
         add_link_options(-Xlinker /DEBUG:FULL)
         message(STATUS "Added debug flags for ${CMAKE_BUILD_TYPE} build")
@@ -258,7 +258,7 @@ endif()
 
 # Add debug flags to HIP compilation for test sources on Windows
 if(WIN32)
-    if(TRUE)
+    if(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo" OR CMAKE_BUILD_TYPE STREQUAL "Debug")
         set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -g -gcodeview -gline-tables-only")
         message(STATUS "Added debug flags to CMAKE_HIP_FLAGS for ${CMAKE_BUILD_TYPE}")
     endif()

--- a/projects/hip-tests/catch/CMakeLists.txt
+++ b/projects/hip-tests/catch/CMakeLists.txt
@@ -183,7 +183,7 @@ endif()
 
 # Add debug flags for RelWithDebInfo and Debug builds on Windows
 if(WIN32)
-    if(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo" OR CMAKE_BUILD_TYPE STREQUAL "Debug")
+    if(TRUE)
         add_compile_options(-g -gcodeview -gline-tables-only)
         add_link_options(-Xlinker /DEBUG:FULL)
         message(STATUS "Added debug flags for ${CMAKE_BUILD_TYPE} build")
@@ -258,7 +258,7 @@ endif()
 
 # Add debug flags to HIP compilation for test sources on Windows
 if(WIN32)
-    if(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo" OR CMAKE_BUILD_TYPE STREQUAL "Debug")
+    if(TRUE)
         set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -g -gcodeview -gline-tables-only")
         message(STATUS "Added debug flags to CMAKE_HIP_FLAGS for ${CMAKE_BUILD_TYPE}")
     endif()

--- a/projects/hip-tests/catch/CMakeLists.txt
+++ b/projects/hip-tests/catch/CMakeLists.txt
@@ -183,11 +183,18 @@ endif()
 
 # Add debug flags for RelWithDebInfo and Debug builds on Windows
 if(WIN32)
-    add_compile_options($<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:-g>)
-    add_compile_options($<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:-gcodeview>)
-    add_compile_options($<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:-gline-tables-only>)
-    add_link_options($<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:-Xlinker>)
-    add_link_options($<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:/DEBUG:FULL>)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>>:-g>)
+        add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>>:-gcodeview>)
+        add_compile_options($<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>>:-gline-tables-only>)
+    endif()
+    if(CMAKE_HIP_COMPILER_ID STREQUAL "Clang" OR HIP_PLATFORM STREQUAL "amd")
+        add_compile_options($<$<AND:$<COMPILE_LANGUAGE:HIP>,$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>>:-g>)
+        add_compile_options($<$<AND:$<COMPILE_LANGUAGE:HIP>,$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>>:-gcodeview>)
+        add_compile_options($<$<AND:$<COMPILE_LANGUAGE:HIP>,$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>>:-gline-tables-only>)
+        add_link_options($<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:-Xlinker>)
+        add_link_options($<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:/DEBUG:FULL>)
+    endif()
 endif()
 
 if(HIP_PLATFORM STREQUAL "amd")
@@ -254,12 +261,6 @@ string(STRIP "${OFFLOAD_ARCH_STR}" OFFLOAD_ARCH_STR)
 message(STATUS "Using offload arch string: ${OFFLOAD_ARCH_STR}")
 if(DEFINED OFFLOAD_ARCH_STR)
     set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} ${OFFLOAD_ARCH_STR}")
-endif()
-
-# Add debug flags to HIP compilation for test sources on Windows
-if(WIN32)
-    set(CMAKE_HIP_FLAGS_DEBUG "${CMAKE_HIP_FLAGS_DEBUG} -g -gcodeview -gline-tables-only")
-    set(CMAKE_HIP_FLAGS_RELWITHDEBINFO "${CMAKE_HIP_FLAGS_RELWITHDEBINFO} -g -gcodeview -gline-tables-only")
 endif()
 
 # get hip-tests commit short hash


### PR DESCRIPTION
## Motivation

Enable Windows debug symbols for hip-tests in `Debug` and `RelWithDebInfo` builds so developers can debug HIP test binaries on Windows.

## Technical Details

- In `projects/hip-tests/catch/CMakeLists.txt`, added CodeView debug flags (`-g -gcodeview -gline-tables-only`) for C, CXX, and HIP compile languages on Windows when building in `Debug` or `RelWithDebInfo` configurations.
- Added `-Xlinker /DEBUG:FULL` link option for HIP/AMD targets to emit full PDB debug info.
- Flags are guarded by compiler-id checks (`Clang`) and platform checks (`WIN32`).

## JIRA ID

N/A

## Test Plan

- Build hip-tests on Windows with `CMAKE_BUILD_TYPE=Debug` and `RelWithDebInfo`.
- Confirm debug flags appear in configure/build output.

## Test Result

- Build-system-only change; validation pending via CI/local Windows build.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.