### PR TITLE
Add gfx1151 (Strix Halo / RDNA 3.5) support to rocprof-compute

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0000_top_stats.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0000_top_stats.yaml
@@ -1,0 +1,13 @@
+Panel Config:
+  id: 0
+  title: Top Stats
+  data source:
+  - raw_csv_table:
+      id: 1
+      title: Top Kernels
+      source: pmc_kernel_top.csv
+  - raw_csv_table:
+      id: 2
+      title: Dispatch List
+      source: pmc_dispatch_info.csv
+  metrics_description: {}

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0100_system_info.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0100_system_info.yaml
@@ -1,0 +1,10 @@
+Panel Config:
+  id: 100
+  title: System Info
+  data source:
+  - raw_csv_table:
+      id: 101
+      title: System Info
+      source: sysinfo.csv
+      columnwise: true
+  metrics_description: {}

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0200_system_speed_of_light.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0200_system_speed_of_light.yaml
@@ -1,0 +1,215 @@
+Panel Config:
+  id: 200
+  title: System Speed-of-Light
+  data source:
+  - metric_table:
+      id: 201
+      title: System Speed-of-Light
+      header:
+        metric: Metric
+        value: Avg
+        unit: Unit
+        peak: Peak
+        pop: Pct of Peak
+      metric:
+        VALU Insts per Wave:
+          value: AVG((SQ_INSTS_VALU / SQ_WAVES))
+          unit: Insts/Wave
+          peak: None
+          pop: None
+        SALU Insts per Wave:
+          value: AVG((SQ_INSTS_SALU / SQ_WAVES))
+          unit: Insts/Wave
+          peak: None
+          pop: None
+        SMEM Insts per Wave:
+          value: AVG((SQ_INSTS_SMEM / SQ_WAVES))
+          unit: Insts/Wave
+          peak: None
+          pop: None
+        LDS Insts per Wave:
+          value: AVG((SQ_INSTS_LDS / SQ_WAVES))
+          unit: Insts/Wave
+          peak: None
+          pop: None
+        Tex Load Insts per Wave:
+          value: AVG((SQ_INSTS_TEX_LOAD / SQ_WAVES))
+          unit: Insts/Wave
+          peak: None
+          pop: None
+        Tex Store Insts per Wave:
+          value: AVG((SQ_INSTS_TEX_STORE / SQ_WAVES))
+          unit: Insts/Wave
+          peak: None
+          pop: None
+        Flat Insts per Wave:
+          value: AVG((SQ_INSTS_FLAT / SQ_WAVES))
+          unit: Insts/Wave
+          peak: None
+          pop: None
+        Wavefront Occupancy:
+          value: AVG((SQ_WAVE_CYCLES / GRBM_GUI_ACTIVE))
+          unit: Wavefronts
+          peak: ($max_waves_per_cu * $cu_per_gpu)
+          pop: (100 * AVG(((SQ_WAVE_CYCLES / GRBM_GUI_ACTIVE) / ($max_waves_per_cu
+            * $cu_per_gpu))))
+        Wave Life (cycles):
+          value: AVG(((SQ_WAVE_CYCLES / SQ_WAVES) if (SQ_WAVES != 0) else 0))
+          unit: Cycles
+          peak: None
+          pop: None
+        SQ Busy:
+          value: AVG((100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $cu_per_gpu)))
+          unit: Percent
+          peak: 100
+          pop: AVG((100 * SQ_BUSY_CYCLES / (GRBM_GUI_ACTIVE * $cu_per_gpu)))
+        GPU Utilization:
+          value: AVG((100 * GRBM_GUI_ACTIVE / GRBM_COUNT))
+          unit: Percent
+          peak: 100
+          pop: AVG((100 * GRBM_GUI_ACTIVE / GRBM_COUNT))
+        L2 Cache Hit Rate:
+          value: AVG((((100 * GL2C_HIT_sum) / (GL2C_HIT_sum + GL2C_MISS_sum)) if
+            ((GL2C_HIT_sum + GL2C_MISS_sum) != 0) else None))
+          unit: Percent
+          peak: 100
+          pop: AVG((((100 * GL2C_HIT_sum) / (GL2C_HIT_sum + GL2C_MISS_sum)) if
+            ((GL2C_HIT_sum + GL2C_MISS_sum) != 0) else None))
+        L2-Fabric Read BW:
+          value: AVG(((GL2C_EA_RDREQ_32B_sum * 32 + GL2C_EA_RDREQ_64B_sum * 64
+            + GL2C_EA_RDREQ_96B_sum * 96 + GL2C_EA_RDREQ_128B_sum * 128)
+            / (End_Timestamp - Start_Timestamp)))
+          unit: GB/s
+          peak: None
+          pop: None
+        L2-Fabric Write BW:
+          value: AVG(((GL2C_EA_WRREQ_64B_sum * 64)
+            / (End_Timestamp - Start_Timestamp)))
+          unit: GB/s
+          peak: None
+          pop: None
+        Memory Controller Read BW:
+          value: AVG(((GL2C_MC_RDREQ_sum * 64) / (End_Timestamp - Start_Timestamp)))
+          unit: GB/s
+          peak: None
+          pop: None
+        Memory Controller Write BW:
+          value: AVG(((GL2C_MC_WRREQ_sum * 64) / (End_Timestamp - Start_Timestamp)))
+          unit: GB/s
+          peak: None
+          pop: None
+        MC Write Stall:
+          value: AVG((100 * GL2C_MC_WRREQ_STALL / (GRBM_GUI_ACTIVE * $total_l2_chan)))
+          unit: Percent
+          peak: 100
+          pop: AVG((100 * GL2C_MC_WRREQ_STALL / (GRBM_GUI_ACTIVE * $total_l2_chan)))
+        LDS Bank Conflicts:
+          value: AVG(SQC_LDS_BANK_CONFLICT)
+          unit: Conflicts
+          peak: None
+          pop: None
+        LDS Active Cycles:
+          value: AVG((100 * SQC_LDS_IDX_ACTIVE / (GRBM_GUI_ACTIVE * $cu_per_gpu)))
+          unit: Percent
+          peak: 100
+          pop: AVG((100 * SQC_LDS_IDX_ACTIVE / (GRBM_GUI_ACTIVE * $cu_per_gpu)))
+        Wave32 VALU Insts per Wave:
+          value: AVG(((SQ_INSTS_WAVE32_VALU / SQ_WAVES) if (SQ_WAVES != 0) else 0))
+          unit: Insts/Wave
+          peak: None
+          pop: None
+        Wave32 LDS Insts per Wave:
+          value: AVG(((SQ_INSTS_WAVE32_LDS / SQ_WAVES) if (SQ_WAVES != 0) else 0))
+          unit: Insts/Wave
+          peak: None
+          pop: None
+        Occupancy per Active CU:
+          value: AVG(((SQ_WAVE_CYCLES / SQ_BUSY_CYCLES) if (SQ_BUSY_CYCLES != 0) else 0))
+          unit: Wavefronts
+          peak: None
+          pop: None
+        Fetch Size:
+          value: AVG(((GL2C_EA_RDREQ_32B_sum * 32 + GL2C_EA_RDREQ_64B_sum * 64
+            + GL2C_EA_RDREQ_96B_sum * 96 + GL2C_EA_RDREQ_128B_sum * 128) / 1024))
+          unit: KB
+          peak: None
+          pop: None
+        Write Size:
+          value: AVG((((GL2C_MC_WRREQ_sum - GL2C_EA_WRREQ_64B_sum) * 32
+            + GL2C_EA_WRREQ_64B_sum * 64) / 1024))
+          unit: KB
+          peak: None
+          pop: None
+        TA Busy (avg):
+          value: AVG((100 * TA_BUSY_avr / GRBM_GUI_ACTIVE))
+          unit: Percent
+          peak: 100
+          pop: AVG((100 * TA_BUSY_avr / GRBM_GUI_ACTIVE))
+        TA Busy (max):
+          value: AVG((100 * TA_BUSY_max / GRBM_GUI_ACTIVE))
+          unit: Percent
+          peak: 100
+          pop: AVG((100 * TA_BUSY_max / GRBM_GUI_ACTIVE))
+        Memory Unit Busy:
+          value: AVG((100 * TA_BUSY_max / GRBM_GUI_ACTIVE))
+          unit: Percent
+          peak: 100
+          pop: AVG((100 * TA_BUSY_max / GRBM_GUI_ACTIVE))
+        Write Unit Stalled:
+          value: AVG((100 * GL2C_WRREQ_STALL_max / GRBM_GUI_ACTIVE))
+          unit: Percent
+          peak: 100
+          pop: AVG((100 * GL2C_WRREQ_STALL_max / GRBM_GUI_ACTIVE))
+        VMEM Issue Cycles per Wave:
+          value: AVG(((4 * SQ_INST_CYCLES_VMEM / SQ_WAVES) if (SQ_WAVES != 0) else 0))
+          unit: Cycles/Wave
+          peak: None
+          pop: None
+        Wave Dependency Wait:
+          value: AVG(((100 * SQ_WAIT_ANY / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else 0))
+          unit: Percent
+          peak: 100
+          pop: AVG(((100 * SQ_WAIT_ANY / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else 0))
+        Wave Issue Wait:
+          value: AVG(((100 * SQ_WAIT_INST_ANY / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else 0))
+          unit: Percent
+          peak: 100
+          pop: AVG(((100 * SQ_WAIT_INST_ANY / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else 0))
+        Wave LDS Wait:
+          value: AVG(((100 * SQ_WAIT_INST_LDS / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else 0))
+          unit: Percent
+          peak: 100
+          pop: AVG(((100 * SQ_WAIT_INST_LDS / SQ_WAVE_CYCLES) if (SQ_WAVE_CYCLES != 0) else 0))
+  metrics_description:
+    VALU Insts per Wave: Average number of VALU instructions issued per wavefront.
+    SALU Insts per Wave: Average number of SALU instructions issued per wavefront.
+    SMEM Insts per Wave: Average number of scalar memory instructions per wavefront.
+    LDS Insts per Wave: Average number of LDS instructions per wavefront.
+    Tex Load Insts per Wave: Average texture load instructions per wavefront.
+    Tex Store Insts per Wave: Average texture store instructions per wavefront.
+    Flat Insts per Wave: Average flat memory instructions per wavefront.
+    Wavefront Occupancy: Time-averaged number of wavefronts resident on the GPU (derived from SQ_WAVE_CYCLES since SQ_ACCUM_PREV is non-functional on gfx1151).
+    Wave Life (cycles): Average number of cycles a wavefront was alive.
+    SQ Busy: Percent of cycles the shader sequencer was busy (averaged across all CUs/WGPs).
+    GPU Utilization: Percent of time the GPU was active.
+    L2 Cache Hit Rate: Ratio of L2 cache hits to total L2 accesses.
+    L2-Fabric Read BW: Read bandwidth from L2 to memory fabric.
+    L2-Fabric Write BW: Write bandwidth from L2 to memory fabric.
+    Memory Controller Read BW: Memory controller read bandwidth.
+    Memory Controller Write BW: Memory controller write bandwidth.
+    MC Write Stall: Percent of cycles the memory controller write path was stalled (averaged across L2 channels).
+    LDS Bank Conflicts: Number of LDS bank conflicts.
+    LDS Active Cycles: Percent of cycles the LDS was active across all CUs.
+    Wave32 VALU Insts per Wave: Average wave32 VALU instructions per wavefront (wave64 may count 1 or 2).
+    Wave32 LDS Insts per Wave: Average wave32 LDS instructions per wavefront.
+    Occupancy per Active CU: Ratio of SQ_WAVE_CYCLES to SQ_BUSY_CYCLES — approximate wavefronts per active SQ. Note that RDNA SQ counting semantics differ from CDNA, so this is informational only.
+    Fetch Size: Total kilobytes fetched from video memory (all L2-fabric read requests).
+    Write Size: Total kilobytes written to video memory (MC write + fabric write requests).
+    TA Busy (avg): Average percent of cycles TA was busy across instances.
+    TA Busy (max): Maximum percent of cycles TA was busy across instances.
+    Memory Unit Busy: Percent of time the memory unit (TA) is active including stalls (max across TA instances / GRBM_GUI_ACTIVE).
+    Write Unit Stalled: Percent of time the write unit was stalled (max across L2 channels).
+    VMEM Issue Cycles per Wave: Average number of cycles (wall time) spent issuing VMEM address/data per wavefront. Higher values indicate more memory traffic per wave.
+    Wave Dependency Wait: Percent of wave lifetime spent waiting for data dependencies (e.g. waiting for VMEM/LDS results). High values indicate the kernel is latency-bound.
+    Wave Issue Wait: Percent of wave lifetime spent waiting for any instruction to be ready to issue. Includes all stall sources.
+    Wave LDS Wait: Percent of wave lifetime spent waiting specifically for LDS instructions to issue. High values indicate LDS contention.

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0300_memory_chart.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0300_memory_chart.yaml
@@ -1,0 +1,152 @@
+Panel Config:
+  id: 300
+  title: Memory Chart
+  data source:
+  - metric_table:
+      id: 301
+      title: Memory Chart
+      header:
+        metric: Metric
+        value: Value
+      metric:
+        Wavefront Occupancy:
+          value: ROUND(AVG((SQ_WAVE_CYCLES / GRBM_GUI_ACTIVE) / $cu_per_gpu), 0)
+        Wave Life:
+          value: ROUND(AVG(((SQ_WAVE_CYCLES / SQ_WAVES) if (SQ_WAVES != 0) else
+            0)), 0)
+        SALU:
+          value: ROUND(AVG((SQ_INSTS_SALU / $denom)), 0)
+        SMEM:
+          value: ROUND(AVG((SQ_INSTS_SMEM / $denom)), 0)
+        VALU:
+          value: ROUND(AVG((SQ_INSTS_VALU / $denom)), 0)
+        MFMA:
+          value: ROUND(0, 0)
+        VMEM:
+          value: ROUND(AVG(((SQ_INSTS_TEX_LOAD + SQ_INSTS_TEX_STORE) / $denom)), 0)
+        LDS:
+          value: ROUND(AVG((SQ_INSTS_LDS / $denom)), 0)
+        GWS:
+          value: ROUND(0, 0)
+        BR:
+          value: ROUND(0, 0)
+        Flat:
+          value: ROUND(AVG((SQ_INSTS_FLAT / $denom)), 0)
+        Active CUs:
+          value: ROUND(AVG(SQ_BUSY_CYCLES / GRBM_GUI_ACTIVE), 0)
+        Num CUs:
+          value: $cu_per_gpu
+        VGPR:
+          value: ROUND(AVG(Arch_VGPR), 0)
+        SGPR:
+          value: ROUND(AVG(SGPR), 0)
+        LDS Allocation:
+          value: ROUND(AVG(LDS_Per_Workgroup), 0)
+        Scratch Allocation:
+          value: ROUND(AVG(Scratch_Per_Workitem), 0)
+        Wavefronts:
+          value: ROUND(AVG(Grid_Size / $wave_size), 0)
+        Workgroups:
+          value: ROUND(AVG(Grid_Size / Workgroup_Size), 0)
+        LDS Req:
+          value: ROUND(AVG((SQ_INSTS_LDS / $denom)), 0)
+        LDS Util:
+          value: ROUND(AVG(((100 * SQC_LDS_IDX_ACTIVE) / (GRBM_GUI_ACTIVE
+            * $cu_per_gpu))), 0)
+        L2 Hit:
+          value: ROUND(AVG((((100 * GL2C_HIT_sum) / (GL2C_HIT_sum + GL2C_MISS_sum))
+            if ((GL2C_HIT_sum + GL2C_MISS_sum) != 0) else 0)), 0)
+        Fabric_L2 Rd:
+          value: ROUND(AVG(((GL2C_EA_RDREQ_32B_sum + GL2C_EA_RDREQ_64B_sum
+            + GL2C_EA_RDREQ_96B_sum + GL2C_EA_RDREQ_128B_sum) / $denom)), 0)
+        Fabric_L2 Wr:
+          value: ROUND(AVG((GL2C_EA_WRREQ_64B_sum / $denom)), 0)
+        HBM Rd:
+          value: ROUND(AVG((GL2C_MC_RDREQ_sum / $denom)), 0)
+        HBM Wr:
+          value: ROUND(AVG((GL2C_MC_WRREQ_sum / $denom)), 0)
+        Wave32 Insts:
+          value: ROUND(AVG(SQ_WAVE32_INSTS), 0)
+        Wave64 Insts:
+          value: ROUND(AVG(SQ_WAVE64_INSTS), 0)
+        LDS Bank Conflicts:
+          value: ROUND(AVG(SQC_LDS_BANK_CONFLICT), 0)
+        LDS Active:
+          value: ROUND(AVG(((100 * SQC_LDS_IDX_ACTIVE) / (GRBM_GUI_ACTIVE
+            * $cu_per_gpu))), 0)
+        L2 Miss:
+          value: ROUND(AVG(GL2C_MISS_sum), 0)
+        MC Rd:
+          value: ROUND(AVG((GL2C_MC_RDREQ_sum / $denom)), 0)
+        MC Wr:
+          value: ROUND(AVG((GL2C_MC_WRREQ_sum / $denom)), 0)
+        Fabric Rd 32B:
+          value: ROUND(AVG((GL2C_EA_RDREQ_32B_sum / $denom)), 0)
+        Fabric Rd 64B:
+          value: ROUND(AVG((GL2C_EA_RDREQ_64B_sum / $denom)), 0)
+        Fabric Rd 96B:
+          value: ROUND(AVG((GL2C_EA_RDREQ_96B_sum / $denom)), 0)
+        Fabric Rd 128B:
+          value: ROUND(AVG((GL2C_EA_RDREQ_128B_sum / $denom)), 0)
+        Fabric Wr 64B:
+          value: ROUND(AVG((GL2C_EA_WRREQ_64B_sum / $denom)), 0)
+        Wave32 VALU:
+          value: ROUND(AVG((SQ_INSTS_WAVE32_VALU / $denom)), 0)
+        Wave32 LDS:
+          value: ROUND(AVG((SQ_INSTS_WAVE32_LDS / $denom)), 0)
+        TA Busy:
+          value: ROUND(AVG((100 * TA_BUSY_avr / GRBM_GUI_ACTIVE)), 0)
+        TA Busy Max:
+          value: ROUND(AVG((100 * TA_BUSY_max / GRBM_GUI_ACTIVE)), 0)
+        Mem Unit Busy:
+          value: ROUND(AVG((100 * TA_BUSY_max / GRBM_GUI_ACTIVE)), 0)
+        Write Stall:
+          value: ROUND(AVG((100 * GL2C_WRREQ_STALL_max / GRBM_GUI_ACTIVE)), 0)
+      comparable: false
+      cli_style: simple
+      tui_style: simple
+  metrics_description:
+    Wavefront Occupancy: Wavefronts per active CU.
+    Wave Life: Average number of cycles executing a wave.
+    SALU: SALU instructions per normalization unit.
+    SMEM: SMEM instructions per normalization unit.
+    VALU: VALU instructions per normalization unit.
+    MFMA: MFMA instructions per normalization unit. Always 0 on RDNA 3.5 (no MFMA support).
+    VMEM: VMEM (texture load + store) instructions per normalization unit. On RDNA 3.5 this is SQ_INSTS_TEX_LOAD + SQ_INSTS_TEX_STORE.
+    LDS: LDS instructions per normalization unit.
+    GWS: GDS (global data sync) instructions per normalization unit. Always 0 on RDNA 3.5 consumer GPUs.
+    BR: Branch instructions per normalization unit. Set to 0 because SQ_INSTS_BRANCH is not available on gfx1151.
+    Flat: Flat memory instructions per normalization unit.
+    Active CUs: Time-averaged number of active SQ units (SQ_BUSY_CYCLES / GRBM_GUI_ACTIVE). On RDNA 3.5, each SQ manages a WGP (2 CUs), so this counts active WGPs rather than individual CUs.
+    Num CUs: Total compute units on the GPU.
+    VGPR: Vector general-purpose registers allocated.
+    SGPR: Scalar general-purpose registers allocated.
+    LDS Allocation: Bytes of LDS allocated per workgroup.
+    Scratch Allocation: Bytes of scratch per work-item.
+    Wavefronts: Total wavefronts in the dispatch (Grid_Size / wave_size). Derived from dispatch metadata since the SPI wave counter is not available on RDNA 3.5.
+    Workgroups: Total workgroups in the dispatch (Grid_Size / Workgroup_Size). Derived from dispatch metadata since the SPI threadgroup counter is not available on RDNA 3.5.
+    LDS Req: LDS instructions per normalization unit (same as LDS).
+    LDS Util: Percent of cycles LDS was active across all CUs.
+    L2 Hit: L2 cache hit rate (GL2C_HIT / (GL2C_HIT + GL2C_MISS)).
+    Fabric_L2 Rd: L2-to-fabric read requests (all sizes) per normalization unit.
+    Fabric_L2 Wr: L2-to-fabric write requests per normalization unit.
+    HBM Rd: Memory controller read requests per normalization unit. On Strix Halo this is system memory (not HBM), but uses the same GUI slot.
+    HBM Wr: Memory controller write requests per normalization unit. On Strix Halo this is system memory (not HBM), but uses the same GUI slot.
+    Wave32 Insts: Wave32 instructions executed.
+    Wave64 Insts: Wave64 instructions executed.
+    LDS Bank Conflicts: LDS bank conflict count.
+    LDS Active: Percent of cycles LDS was active across all CUs.
+    L2 Miss: L2 cache misses.
+    MC Rd: Memory controller read requests per normalization unit.
+    MC Wr: Memory controller write requests per normalization unit.
+    Fabric Rd 32B: 32-byte fabric read requests per normalization unit.
+    Fabric Rd 64B: 64-byte fabric read requests per normalization unit.
+    Fabric Rd 96B: 96-byte fabric read requests per normalization unit.
+    Fabric Rd 128B: 128-byte fabric read requests per normalization unit.
+    Fabric Wr 64B: 64-byte fabric write requests per normalization unit.
+    Wave32 VALU: Wave32 VALU instructions per normalization unit.
+    Wave32 LDS: Wave32 LDS instructions per normalization unit.
+    TA Busy: Average TA busy percent across instances.
+    TA Busy Max: Maximum TA busy percent across instances.
+    Mem Unit Busy: Memory unit (TA) busy percent (max across instances).
+    Write Stall: Write unit stalled percent (max across L2 channels).

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0400_roofline.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0400_roofline.yaml
@@ -1,0 +1,74 @@
+Panel Config:
+  id: 400
+  title: Roofline
+  data source:
+  - metric_table:
+      id: 401
+      title: Roofline Performance Rates
+      header:
+        metric: Metric
+        value: Avg
+        unit: Unit
+      metric:
+        VALU Ops:
+          value: AVG(((SQ_INSTS_VALU * $wave_size) / ((End_Timestamp - Start_Timestamp)
+            / 1000000000.0)))
+          unit: GOp/s
+        Fabric Read BW:
+          value: AVG(((GL2C_EA_RDREQ_32B_sum * 32 + GL2C_EA_RDREQ_64B_sum * 64
+            + GL2C_EA_RDREQ_96B_sum * 96 + GL2C_EA_RDREQ_128B_sum * 128)
+            / ((End_Timestamp - Start_Timestamp) / 1000000000.0) / 1000000000.0))
+          unit: GB/s
+        Fabric Write BW:
+          value: AVG(((GL2C_EA_WRREQ_64B_sum * 64)
+            / ((End_Timestamp - Start_Timestamp) / 1000000000.0) / 1000000000.0))
+          unit: GB/s
+        Fabric Total BW:
+          value: AVG((((GL2C_EA_RDREQ_32B_sum * 32 + GL2C_EA_RDREQ_64B_sum * 64
+            + GL2C_EA_RDREQ_96B_sum * 96 + GL2C_EA_RDREQ_128B_sum * 128)
+            + (GL2C_EA_WRREQ_64B_sum * 64))
+            / ((End_Timestamp - Start_Timestamp) / 1000000000.0) / 1000000000.0))
+          unit: GB/s
+        MC Read BW:
+          value: AVG(((GL2C_MC_RDREQ_sum * 64)
+            / ((End_Timestamp - Start_Timestamp) / 1000000000.0) / 1000000000.0))
+          unit: GB/s
+        MC Write BW:
+          value: AVG(((GL2C_MC_WRREQ_sum * 64)
+            / ((End_Timestamp - Start_Timestamp) / 1000000000.0) / 1000000000.0))
+          unit: GB/s
+        L2 Hit Rate:
+          value: AVG((((100 * GL2C_HIT_sum) / (GL2C_HIT_sum + GL2C_MISS_sum))
+            if ((GL2C_HIT_sum + GL2C_MISS_sum) != 0) else None))
+          unit: Percent
+        LDS BW:
+          value: AVG((((SQC_LDS_IDX_ACTIVE - SQC_LDS_BANK_CONFLICT) * 4
+            * TO_INT($lds_banks_per_cu))
+            / ((End_Timestamp - Start_Timestamp) / 1000000000.0) / 1000000000.0))
+          unit: GB/s
+  - metric_table:
+      id: 402
+      title: Roofline Arithmetic Intensity
+      header:
+        metric: Metric
+        value: Avg
+        unit: Unit
+      metric:
+        VALU AI (Fabric):
+          value: AVG(((SQ_INSTS_VALU * $wave_size) / ((GL2C_EA_RDREQ_32B_sum * 32
+            + GL2C_EA_RDREQ_64B_sum * 64 + GL2C_EA_RDREQ_96B_sum * 96
+            + GL2C_EA_RDREQ_128B_sum * 128) + (GL2C_EA_WRREQ_64B_sum * 64)))
+            if (((GL2C_EA_RDREQ_32B_sum * 32 + GL2C_EA_RDREQ_64B_sum * 64
+            + GL2C_EA_RDREQ_96B_sum * 96 + GL2C_EA_RDREQ_128B_sum * 128)
+            + (GL2C_EA_WRREQ_64B_sum * 64)) != 0) else None)
+          unit: Ops/Byte
+  metrics_description:
+    VALU Ops: Aggregate VALU operations per second (all types).
+    Fabric Read BW: L2 to fabric read bandwidth.
+    Fabric Write BW: L2 to fabric write bandwidth.
+    Fabric Total BW: Total L2-fabric bandwidth (read + write).
+    MC Read BW: Memory controller read bandwidth.
+    MC Write BW: Memory controller write bandwidth.
+    L2 Hit Rate: L2 cache hit rate.
+    LDS BW: Theoretical LDS bandwidth.
+    VALU AI (Fabric): Arithmetic intensity of VALU operations relative to fabric traffic.

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/counter_defs.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/counter_defs.yaml
@@ -17,6 +17,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx906
       - gfx908
@@ -431,6 +432,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -461,6 +463,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx900
       - gfx906
@@ -601,6 +604,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       expression: (GL2C_EA_RDREQ_32B_sum*32+GL2C_EA_RDREQ_64B_sum*64+GL2C_EA_RDREQ_96B_sum*96+GL2C_EA_RDREQ_128B_sum*128)/1024
     - architectures:
       - gfx12
@@ -681,6 +685,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx906
       - gfx908
@@ -730,6 +735,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: GL2C
       event: 102
     - architectures:
@@ -752,6 +758,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -770,6 +777,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: GL2C
       event: 99
     - architectures:
@@ -792,6 +800,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -810,6 +819,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: GL2C
       event: 100
     - architectures:
@@ -832,6 +842,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -850,6 +861,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: GL2C
       event: 101
   - name: GL2C_EA_RDREQ_96B_sum
@@ -866,6 +878,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       expression: reduce(GL2C_EA_RDREQ_96B,sum)
   - name: GL2C_EA_WRREQ
     description: Number of transactions (all sizes) going over the GL2C_EA_WRREQ interface for all clients. This does not
@@ -921,6 +934,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: GL2C
       event: 85
     - architectures:
@@ -944,6 +958,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -962,6 +977,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: GL2C
       event: 42
     - architectures:
@@ -984,6 +1000,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -1002,6 +1019,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: GL2C
       event: 96
   - name: GL2C_MC_RDREQ_sum
@@ -1018,6 +1036,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       expression: reduce(GL2C_MC_RDREQ,sum)
   - name: GL2C_MC_WRREQ
     description: Number of transactions (either 32-byte or 64-byte) going over the GL2C_EA_wrreq interface. Atomics may travel
@@ -1034,6 +1053,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: GL2C
       event: 83
   - name: GL2C_MC_WRREQ_STALL
@@ -1050,6 +1070,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: GL2C
       event: 88
   - name: GL2C_MC_WRREQ_sum
@@ -1067,6 +1088,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       expression: reduce(GL2C_MC_WRREQ,sum)
   - name: GL2C_MISS
     description: Number of cache misses.  UC reads count as misses.
@@ -1082,6 +1104,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: GL2C
       event: 43
     - architectures:
@@ -1104,6 +1127,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -1122,6 +1146,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       expression: reduce(GL2C_MC_WRREQ_STALL,max)
     - architectures:
       - gfx12
@@ -1142,6 +1167,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx900
       - gfx906
@@ -1165,6 +1191,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -1192,6 +1219,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -1306,6 +1334,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -1429,6 +1458,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -1454,6 +1484,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -1502,6 +1533,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx90a
       - gfx940
       - gfx941
@@ -1545,6 +1577,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx900
       - gfx906
@@ -1564,6 +1597,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -1584,6 +1618,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -1614,6 +1649,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -1641,6 +1677,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx906
       - gfx908
@@ -1782,6 +1819,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx906
       - gfx908
@@ -1804,6 +1842,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx900
       - gfx906
@@ -1832,6 +1871,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx906
       - gfx908
@@ -2863,6 +2903,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 256
     - architectures:
@@ -2889,6 +2930,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 261
     - architectures:
@@ -2991,6 +3033,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -3263,6 +3306,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -3434,6 +3478,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 56
     - architectures:
@@ -3503,6 +3548,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 54
     - architectures:
@@ -3547,6 +3593,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 57
     - architectures:
@@ -3617,6 +3664,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 58
     - architectures:
@@ -3687,6 +3735,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 59
     - architectures:
@@ -3734,6 +3783,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 66
     - architectures:
@@ -3752,6 +3802,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 67
     - architectures:
@@ -3790,6 +3841,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 62
     - architectures:
@@ -4354,6 +4406,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 70
     - architectures:
@@ -4380,6 +4433,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 72
     - architectures:
@@ -4406,6 +4460,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 73
     - architectures:
@@ -4495,6 +4550,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 106
     - architectures:
@@ -4568,6 +4624,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 87
   - name: SQ_INST_LEVEL_LDS
@@ -4604,6 +4661,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 88
     - architectures:
@@ -4923,6 +4981,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 35
     - architectures:
@@ -4966,6 +5025,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -5012,6 +5072,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 29
     - architectures:
@@ -5035,6 +5096,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 82
     - architectures:
@@ -5060,6 +5122,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       block: SQ
       event: 83
     - architectures:
@@ -5086,6 +5149,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -5258,6 +5322,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -5305,6 +5370,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -5723,6 +5789,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -5737,6 +5804,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -5778,6 +5846,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -5792,6 +5861,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -5894,6 +5964,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -5921,6 +5992,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -5948,6 +6020,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -6173,6 +6246,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -10322,6 +10396,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx906
       - gfx908
@@ -10444,6 +10519,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -10462,6 +10538,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201
@@ -10516,6 +10593,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       expression: ((GL2C_MC_WRREQ_sum-GL2C_EA_WRREQ_64B_sum)*32+GL2C_EA_WRREQ_64B_sum*64)/1024
     - architectures:
       - gfx940
@@ -10565,6 +10643,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx9
       - gfx906
       - gfx908
@@ -10610,6 +10689,7 @@ rocprofiler-sdk:
       - gfx1100
       - gfx1101
       - gfx1102
+      - gfx1151
       - gfx12
       - gfx1200
       - gfx1201

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/sets/gfx1151_sets.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/profile_configs/sets/gfx1151_sets.yaml
@@ -1,0 +1,26 @@
+sets:
+- title: Compute Throughput Utilization
+  set_option: compute_thruput_util
+  description: Placeholder
+  metric:
+  - 11.2.2: SALU Utilization
+  - 11.2.3: VALU Utilization
+  - 11.2.5: VMEM Utilization
+  - 11.2.6: Branch Utilization
+- title: Memory Throughput
+  set_option: mem_thruput
+  description: Placeholder
+  metric:
+  - 16.1.2: Utilization
+  - 17.1.0: Utilization
+- title: Launch Stats
+  set_option: launch_stats
+  description: Placeholder
+  metric:
+  - 7.1.0: Grid Size
+  - 7.1.1: Workgroup Size
+  - 7.1.2: Total Wavefronts
+  - 7.1.5: VGPRs
+  - 7.1.7: SGPRs
+  - 7.1.8: LDS Allocation
+  - 7.1.9: Scratch Allocation

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_base.py
@@ -396,7 +396,7 @@ class OmniSoC_Base:
         # and should not end with underscore
         # he counter name can either optionally end with '[' or '_sum'
         hw_counter_regex = (
-            r"(?:SQ|SQC|TA|TD|TCP|TCC|CPC|CPF|SPI|GRBM)_[0-9A-Z_]*[0-9A-Z](?:\[|_sum)*"
+            r"(?:SQ|SQC|TA|TD|TCP|TCC|GL2C|CPC|CPF|SPI|GRBM)_[0-9A-Z_]*[0-9A-Z](?:\[|_sum|_avr|_max|_min)*"
         )
         # only capture the variable name after $ using capturing group
         variable_regex = r"\$([0-9A-Za-z_]*[0-9A-Za-z])"

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_gfx1151.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/soc_gfx1151.py
@@ -1,0 +1,66 @@
+##############################################################################
+# MIT License
+#
+# Copyright (c) 2021 - 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+##############################################################################
+
+import argparse
+from typing import Any, Optional
+
+from rocprof_compute_soc.soc_base import OmniSoC_Base
+from utils.logger import demarcate
+from utils.mi_gpu_spec import mi_gpu_specs
+from utils.specs import MachineSpecs
+
+
+class gfx1151_soc(OmniSoC_Base):
+    def __init__(self, args: argparse.Namespace, mspec: MachineSpecs) -> None:
+        super().__init__(args, mspec)
+        self.set_arch("gfx1151")
+        self.set_compatible_profilers(["rocprofv3", "rocprofiler-sdk"])
+        self.set_perfmon_config(mi_gpu_specs.get_perfmon_config("gfx1151"))
+
+        self._mspec.l2_banks = 4
+        self._mspec.lds_banks_per_cu = 32
+        self._mspec.pipes_per_gpu = 2
+
+    # -----------------------
+    # Required child methods
+    # -----------------------
+    @demarcate
+    def profiling_setup(self) -> Optional[list[str]]:
+        """Perform any SoC-specific setup prior to profiling."""
+        super().profiling_setup()
+        filter_blocks = self.perfmon_filter()
+        return filter_blocks
+
+    @demarcate
+    def post_profiling(self) -> None:
+        """Perform any SoC-specific post profiling activities."""
+        super().post_profiling()
+
+    @demarcate
+    def analysis_setup(
+        self, roofline_parameters: Optional[dict[str, Any]] = None
+    ) -> None:
+        """Perform any SoC-specific setup prior to analysis."""
+        super().analysis_setup(roofline_parameters=roofline_parameters)

--- a/projects/rocprofiler-compute/src/utils/benchmark.py
+++ b/projects/rocprofiler-compute/src/utils/benchmark.py
@@ -52,6 +52,7 @@ lds_sizes = {
     "gfx941": 64 * 1024,
     "gfx942": 64 * 1024,
     "gfx950": 64 * 1024,
+    "gfx1151": 64 * 1024,
 }
 
 unsupported_data_types = {
@@ -71,6 +72,18 @@ unsupported_data_types = {
     "gfx941": ["MFMA-F4", "MFMA-F6", "MFMA-F6F4"],  # MI300X_A0
     "gfx942": ["MFMA-F4", "MFMA-F6", "MFMA-F6F4"],  # MI300A_A1, MI300X_A1, MI308
     "gfx950": [],  # MI350, MI355
+    "gfx1151": [
+        "MALL",
+        "MFMA-F4",
+        "MFMA-F6",
+        "MFMA-F6F4",
+        "MFMA-F8",
+        "MFMA-F16",
+        "MFMA-BF16",
+        "MFMA-F32",
+        "MFMA-F64",
+        "MFMA-I8",
+    ],  # Strix Halo (RDNA 3.5, no MFMA)
 }
 
 cache_kernel_selector = {
@@ -81,6 +94,7 @@ cache_kernel_selector = {
         "gfx941": "Cache_bw<float, 32 * 1024, 256>",
         "gfx942": "Cache_bw<float, 32 * 1024, 256>",
         "gfx950": "Cache_bw<float, 32 * 1024, 256>",
+        "gfx1151": "Cache_bw<float, 32 * 1024, 256>",
     },
     "L2": {
         "gfx908": "Cache_bw<float, 8 * 1024 * 1024, 256>",
@@ -89,6 +103,7 @@ cache_kernel_selector = {
         "gfx941": "Cache_bw<float, 4 * 1024 * 1024, 256>",
         "gfx942": "Cache_bw<float, 4 * 1024 * 1024, 256>",
         "gfx950": "Cache_bw<float, 4 * 1024 * 1024, 256>",
+        "gfx1151": "Cache_bw<float, 4 * 1024 * 1024, 256>",
     },
     "MALL": {
         "gfx940": "Cache_bw<float, 64 * 1024 * 1024, 256>",
@@ -158,6 +173,7 @@ cache_sizes = {
         "gfx941": 32 * 1024,
         "gfx942": 32 * 1024,
         "gfx950": 32 * 1024,
+        "gfx1151": 32 * 1024,
     },
     "L2": {
         "gfx908": 8 * 1024 * 1024,
@@ -166,6 +182,7 @@ cache_sizes = {
         "gfx941": 4 * 1024 * 1024,
         "gfx942": 4 * 1024 * 1024,
         "gfx950": 4 * 1024 * 1024,
+        "gfx1151": 4 * 1024 * 1024,
     },
     "MALL": {
         "gfx940": 64 * 1024 * 1024,

--- a/projects/rocprofiler-compute/src/utils/mi_gpu_spec.py
+++ b/projects/rocprofiler-compute/src/utils/mi_gpu_spec.py
@@ -298,7 +298,7 @@ class MIGPUSpecs:
         4. Default settings (last resort)
         """
         # Constants for legacy GPUs that don't support compute partitions
-        LEGACY_ARCHS = {"gfx908", "gfx90a"}
+        LEGACY_ARCHS = {"gfx908", "gfx90a", "gfx1150", "gfx1151"}
         LEGACY_MODELS = {"mi50", "mi60", "mi100", "mi210", "mi250", "mi250x"}
 
         # Normalize inputs to lowercase for consistent comparison

--- a/projects/rocprofiler-compute/src/utils/mi_gpu_spec.yaml
+++ b/projects/rocprofiler-compute/src/utils/mi_gpu_spec.yaml
@@ -265,6 +265,23 @@ mi_gpu_spec:
               physical: 29861
               virtual: 29881
 
+  - gpu_series: strix_halo
+    gpu_archs:
+      - gpu_arch: gfx1151
+        perfmon_config:
+          SQ: 8
+          TA: 2
+          GL2C: 4
+          GRBM: 2
+        models:
+          - gpu_model: strix_halo
+            partition_mode:
+              compute_partition_mode:
+                num_xcds:
+                  spx: 1
+            chip_ids:
+              physical: 5510
+
   - gpu_series: mi350
     gpu_archs:
       - gpu_arch: gfx950

--- a/projects/rocprofiler-compute/src/utils/rocpd_data.py
+++ b/projects/rocprofiler-compute/src/utils/rocpd_data.py
@@ -123,6 +123,21 @@ def convert_dbs_to_csv(
                         )
 
 
+def _is_cycle_counter(name: str) -> bool:
+    """Identify counters that measure cycles (scale with kernel duration).
+
+    Cycle-based counters accumulate proportionally to wall-clock time and
+    need cross-pass normalization. Event-based counters (instruction counts,
+    cache request counts, wave counts) are deterministic per dispatch and
+    must not be scaled.
+    """
+    upper = name.upper()
+    if upper.startswith("GRBM_"):
+        return True
+    cycle_keywords = ("CYCLES", "BUSY", "ACTIVE", "STALL", "WAIT", "ACCUM")
+    return any(kw in upper for kw in cycle_keywords)
+
+
 def process_rocpd_csv(df: pd.DataFrame) -> pd.DataFrame:
     """
     Merge counters across unique dispatches from the
@@ -141,6 +156,22 @@ def process_rocpd_csv(df: pd.DataFrame) -> pd.DataFrame:
         "Workgroup_Size",
         "LDS_Per_Workgroup",
     ]):
+        # Cross-pass duration normalization: each profiling pass re-runs the
+        # kernel, and execution times vary. Cycle-based counters (busy cycles,
+        # wave cycles, wait cycles, stall cycles) accumulate proportionally to
+        # duration, so we scale them to a common reference (the longest pass)
+        # to make cross-pass ratios accurate. Event-based counters (instruction
+        # counts, cache requests, wave counts) are deterministic per dispatch
+        # and are left unscaled.
+        durations = (
+            group_df["End_Timestamp"] - group_df["Start_Timestamp"]
+        ).astype(float)
+        ref_duration = durations.max()
+        scale_factors = ref_duration / durations.clip(lower=1)
+        is_cycle = group_df["Counter_Name"].map(_is_cycle_counter)
+        adjusted_scales = scale_factors.where(is_cycle, 1.0)
+        scaled_values = group_df["Counter_Value"].astype(float) * adjusted_scales
+
         row = {
             "GPU_ID": group_df["GPU_ID"].iloc[0],
             "Grid_Size": group_df["Grid_Size"].iloc[0],
@@ -155,8 +186,8 @@ def process_rocpd_csv(df: pd.DataFrame) -> pd.DataFrame:
             "Start_Timestamp": group_df["Start_Timestamp"].iloc[0],
             "End_Timestamp": group_df["End_Timestamp"].iloc[0],
         }
-        # Each counter will become its own column
-        row.update(dict(zip(group_df["Counter_Name"], group_df["Counter_Value"])))
+        # Each counter will become its own column (cycle counters normalized)
+        row.update(dict(zip(group_df["Counter_Name"], scaled_values)))
         data.append(row)
     df = pd.DataFrame(data)
     # Rank GPU IDs, map lowest number to 0, next to 1, etc.

--- a/projects/rocprofiler-compute/src/utils/roofline_calc.py
+++ b/projects/rocprofiler-compute/src/utils/roofline_calc.py
@@ -99,6 +99,14 @@ SUPPORTED_DATATYPES: dict[str, list[str]] = {
         "I32",
         "I64",
     ],  # Unsupported:
+    "gfx1151": [
+        "FP16",
+        "FP32",
+        "FP64",
+        "I8",
+        "I32",
+        "I64",
+    ],  # RDNA 3.5: VALU only, no MFMA
 }
 
 PEAK_OPS_DATATYPES = ["FP16", "FP32", "FP64", "I8", "I32", "I64"]


### PR DESCRIPTION
- Add gfx1151 GPU spec (mi_gpu_spec.yaml) with perfmon config (SQ:8, TA:2, GL2C:4, GRBM:2), SoC class (soc_gfx1151.py), and counter set
- Add gfx1151 to ~80 counter definitions in counter_defs.yaml for SQ, GL2C, TA, and GRBM blocks
- Add GL2C to the hardware counter regex in soc_base.py (RDNA uses GL2C instead of TCC), and add _avr/_max/_min suffix support
- Create gfx1151 analysis configs: top stats, system info, speed-of-light (with wave wait/stall metrics), memory chart, and roofline
- Add gfx1151 to roofline calculator (VALU-only datatypes, no MFMA) and benchmark config (LDS/cache sizes, unsupported data types)
- Add gfx1150/gfx1151 to LEGACY_ARCHS for correct num_xcd=1

- Implement selective cross-pass duration normalization in rocpd_data.py to reduce variability when counters from different profiling passes are combined in ratios
