### PR TITLE
torch-trace sets the output format to csv.

### DIFF
--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -950,6 +950,8 @@ Limitations
    * This feature adds instrumentation overhead to track operator boundaries. For
      performance-critical measurements, consider profiling without this option first.
 
+   * This option forces rocprof output to CSV format; rocpd format is not supported yet.
+
 
 .. _torch-operator-profiling:
 

--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -950,7 +950,7 @@ Limitations
    * This feature adds instrumentation overhead to track operator boundaries. For
      performance-critical measurements, consider profiling without this option first.
 
-   * This option forces rocprof output to CSV format; rocpd format is not supported yet.
+   * This option forces rocprofiler-sdk output to use CSV format since this feature doesn't support rocpd format yet.
 
 
 .. _torch-operator-profiling:

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -139,11 +139,12 @@ class RocProfCompute_Base:
             # Appending a wrapper for injecting roctx-markers
             if getattr(args, "torch_trace", False):
                 # Override the output-format to CSV when torch-trace is enabled
-                args.format_rocprof_output = "csv"
-                console_warning(
-                    "torch trace",
-                    "This option supports only CSV output format at the moment.",
-                )
+                if args.format_rocprof_output != "csv":
+                    args.format_rocprof_output = "csv"
+                    console_warning(
+                        "torch trace",
+                        "This option supports only CSV output format at the moment.",
+                    )
                 # Find the inject_roctx.py script in src/utils
                 inject_script = (
                     Path(__file__).parent.parent / "utils" / "inject_roctx.py"

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -138,6 +138,12 @@ class RocProfCompute_Base:
 
             # Appending a wrapper for injecting roctx-markers
             if getattr(args, "torch_trace", False):
+                # Override the output-format to CSV when torch-trace is enabled
+                args.format_rocprof_output = "csv"
+                console_warning(
+                    "torch trace",
+                    "This option supports only CSV output format at the moment.",
+                )
                 # Find the inject_roctx.py script in src/utils
                 inject_script = (
                     Path(__file__).parent.parent / "utils" / "inject_roctx.py"

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -139,7 +139,7 @@ class RocProfCompute_Base:
             # Appending a wrapper for injecting roctx-markers
             if getattr(args, "torch_trace", False):
                 # Override the output-format to CSV when torch-trace is enabled
-                if args.format_rocprof_output != "csv":
+                if getattr(args, "format_rocprof_output", "rocpd") != "csv":
                     args.format_rocprof_output = "csv"
                     console_warning(
                         "torch trace",


### PR DESCRIPTION
## Motivation

When --torch-trace option is used, rocprof-compute shall switch to csv output mode.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
AIPROFCOMP-205
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
