### PR TITLE
[AICOMRCCL-331][RCCL][MI350]Reducing the p2pnChannels for half-subscription A2A on multi-node MI350

### DIFF
--- a/projects/rccl/src/graph/paths.cc
+++ b/projects/rccl/src/graph/paths.cc
@@ -1022,6 +1022,8 @@ ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm) {
     // p2pnChannelsPerPeer cannot be greater than MAXCHANNELS
     // Capping the comm->p2pnChannels to 32 for send/recv based collectives on multi-node MI350 (2 and 4 nodes)
     if (((comm->nNodes == 2 && comm->topo->nRanks == 16) || (comm->nNodes == 4 && comm->topo->nRanks == 32)) && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950"))) comm->p2pnChannels = std::min(comm->p2pnChannels, 32);
+    // Capping the comm->p2pnChannels to 16 for send/recv based collectives with half-subscription (4 GPUs per node) multi-node MI350 (2 and 4 nodes)
+    if (((comm->nNodes == 2 && comm->topo->nRanks == 8) || (comm->nNodes == 4 && comm->topo->nRanks == 16)) && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950"))) comm->p2pnChannels = std::min(comm->p2pnChannels, 16);
     comm->p2pnChannelsPerPeer = std::min(comm->p2pnChannelsPerPeer, MAXCHANNELS);
   }
 


### PR DESCRIPTION
Reducing the p2pnChannels to 16 (from 32) for send/recv based collectives with half-subscription (4 GPUs per node) multi-node MI350 (2 and 4 nodes)
## Motivation

This PR delivers the task that involves reducing the number of CUs for half-subscription (4 GPUs per node) multi-node send/recv based collectives (especially A2A) so there are more CUs available for computation for the E2E workload.

## Technical Details

The feature is implemented by capping the comm->p2pnChannels to 16 for send/recv based collectives on multi-node MI350 for half-subscription (4 GPUs per node) use cases (2 and 4 nodes)

## JIRA ID

AICOMRCCL-331

## Test Plan

The testing involves half-subscription (4 GPUs per node) multi-node MI350 rccl-tests performance collection before and after reducing the number of CUs to ensure there is no significant performance penalty for A2A, A2Av, and Direct Allgather collectives.

## Test Result

Reducing #P2P CHANNELS by 50% while incurring no significant performance drop.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
