### PR TITLE
Add nlohmann-json as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -102,10 +102,10 @@
 	path = projects/rocprofiler-systems/external/spdlog
 	url = https://github.com/gabime/spdlog.git
 	tag = v1.16.0
+[submodule "projects/rocprofiler-systems/external/json"]
+	path = projects/rocprofiler-systems/external/json
+	url = https://github.com/nlohmann/json.git
 [submodule "projects/rccl/ext-src/rocSHMEM"]
 	path = projects/rccl/ext-src/rocSHMEM
 	url = https://github.com/ROCm/rocSHMEM.git
 	branch = develop
-[submodule "projects/rocprofiler-systems/external/json"]
-	path = projects/rocprofiler-systems/external/json
-	url = https://github.com/nlohmann/json.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -106,3 +106,6 @@
 	path = projects/rccl/ext-src/rocSHMEM
 	url = https://github.com/ROCm/rocSHMEM.git
 	branch = develop
+[submodule "projects/rocprofiler-systems/external/json"]
+	path = projects/rocprofiler-systems/external/json
+	url = https://github.com/nlohmann/json.git

--- a/projects/rocprofiler-systems/cmake/MacroUtilities.cmake
+++ b/projects/rocprofiler-systems/cmake/MacroUtilities.cmake
@@ -179,14 +179,23 @@ endfunction()
 # "Running tests...") endif() endfunction()
 
 # ----------------------------------------------------------------------------------------#
-# macro rocprofiler_systems_checkout_git_submodule()
+# function rocprofiler_systems_checkout_git_submodule()
 #
-# Run "git submodule update" if a file in a submodule does not exist
+# Ensures a git submodule (or external repo) is checked out. If TEST_FILE exists in the
+# submodule directory, returns immediately. Otherwise:
 #
-# ARGS: RECURSIVE (option) -- add "--recursive" flag RELATIVE_PATH (one value) --
-# typically the relative path to submodule from PROJECT_SOURCE_DIR WORKING_DIRECTORY (one
-# value) -- (default: PROJECT_SOURCE_DIR) TEST_FILE (one value) -- file to check for
-# (default: CMakeLists.txt) ADDITIONAL_CMDS (many value) -- any addition commands to pass
+#   - If .gitmodules exists: runs "git submodule update --init" for the submodule.
+#   - If REPO_URL is provided: clones the repo with "git clone -b REPO_BRANCH", then
+#     optionally runs "git submodule update --init --recursive" when RECURSIVE is set.
+#
+# ARGS:
+#   RECURSIVE (option)       -- add "--recursive" to git submodule update
+#   RELATIVE_PATH (one)      -- path to submodule, relative to WORKING_DIRECTORY
+#   WORKING_DIRECTORY (one)  -- base directory (default: PROJECT_SOURCE_DIR)
+#   TEST_FILE (one)         -- file whose existence indicates checkout (default: CMakeLists.txt)
+#   REPO_URL (one)          -- fallback: clone this URL when submodule dir missing
+#   REPO_BRANCH (one)       -- branch for REPO_URL clone (default: master)
+#   ADDITIONAL_CMDS (many)  -- extra args passed to git submodule update or clone
 #
 function(ROCPROFILER_SYSTEMS_CHECKOUT_GIT_SUBMODULE)
     # parse args
@@ -245,6 +254,11 @@ function(ROCPROFILER_SYSTEMS_CHECKOUT_GIT_SUBMODULE)
     set(_HAS_REPO_URL OFF)
     if(NOT "${CHECKOUT_REPO_URL}" STREQUAL "")
         set(_HAS_REPO_URL ON)
+    endif()
+
+    set(_RECURSE "")
+    if(CHECKOUT_RECURSIVE)
+        set(_RECURSE "--recursive")
     endif()
 
     # if the module has not been checked out

--- a/projects/rocprofiler-systems/cmake/MacroUtilities.cmake
+++ b/projects/rocprofiler-systems/cmake/MacroUtilities.cmake
@@ -168,16 +168,6 @@ function(ROCPROFILER_SYSTEMS_STRIP_TARGET)
     endif()
 endfunction()
 
-# ------------------------------------------------------------------------------#
-# function add_rocprofiler_systems_test_target()
-#
-# Creates a target which runs ctest but depends on all the tests being built.
-#
-# function(ADD_ROCPROFSYS_TEST_TARGET) if(NOT TARGET rocprofiler-systems-test)
-# add_custom_target( rocprofiler-systems-test COMMAND ${CMAKE_COMMAND} --build
-# ${PROJECT_BINARY_DIR} --target test WORKING_DIRECTORY ${PROJECT_BINARY_DIR} COMMENT
-# "Running tests...") endif() endfunction()
-
 # ----------------------------------------------------------------------------------------#
 # function rocprofiler_systems_checkout_git_submodule()
 #

--- a/projects/rocprofiler-systems/cmake/NlohmannJson.cmake
+++ b/projects/rocprofiler-systems/cmake/NlohmannJson.cmake
@@ -3,17 +3,16 @@ include_guard(GLOBAL)
 if(ROCPROFSYS_BUILD_NLOHMANN_JSON)
     message(STATUS "Building nlohmann/json from source")
     include(FetchContent)
-    FetchContent_Declare(
-        nlohmann_json
-        GIT_REPOSITORY https://github.com/nlohmann/json.git
-        GIT_TAG v3.11.3
-        SOURCE_DIR
-        ${PROJECT_BINARY_DIR}/external/nlohmann/src
-        BINARY_DIR
-        ${PROJECT_BINARY_DIR}/external/nlohmann/lib
-        SUBBUILD_DIR
-        ${PROJECT_BINARY_DIR}/external/nlohmann/subdir
+
+    rocprofiler_systems_checkout_git_submodule(
+        RELATIVE_PATH external/json
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        REPO_URL https://github.com/nlohmann/json.git
+        TEST_FILE CMakeLists.txt
+        REPO_BRANCH "v3.12.0"
     )
+
+    FetchContent_Declare(nlohmann_json SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/json)
     FetchContent_MakeAvailable(nlohmann_json)
 
     target_include_directories(

--- a/projects/rocprofiler-systems/cmake/NlohmannJson.cmake
+++ b/projects/rocprofiler-systems/cmake/NlohmannJson.cmake
@@ -7,11 +7,8 @@ if(ROCPROFSYS_BUILD_NLOHMANN_JSON)
     rocprofiler_systems_checkout_git_submodule(
         RELATIVE_PATH external/json
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-        REPO_URL https://github.com/nlohmann/json.git
         TEST_FILE CMakeLists.txt
-        REPO_BRANCH "v3.12.0"
     )
-
     FetchContent_Declare(nlohmann_json SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/json)
     FetchContent_MakeAvailable(nlohmann_json)
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Improve cmake configuration time by including nlohmann-json as a submodule rather than having cmake fetch the source during configuration.

Configuration time was: 
<img width="357" height="341" alt="image" src="https://github.com/user-attachments/assets/d526211a-b1f7-4c06-9957-110e03d15b85" />

Configuration time now: 
<img width="344" height="334" alt="image" src="https://github.com/user-attachments/assets/09000095-6ce1-4d58-8ce6-7bf0799eedcf" />

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Add `nlohmann/json` as a direct submodule.
Use `rocprofiler_systems_checkout_git_submodule` to checkout submodule, rather than `FetchContent_Declare`.
Updated `nlohmann/json` to v3.12.0.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
