### PR TITLE
[rocprof-compute] Fixed default normalization unit in documentation

### DIFF
--- a/projects/rocprofiler-compute/docs/conceptual/includes/normalization-units.rst
+++ b/projects/rocprofiler-compute/docs/conceptual/includes/normalization-units.rst
@@ -34,7 +34,7 @@ include:
        that is, the total runtime of the kernel in seconds, as measured by the
        :doc:`command processor <command-processor>`.
 
-By default, ROCm Compute Profiler uses the ``per_wave`` normalization.
+By default, ROCm Compute Profiler uses the ``per_kernel`` normalization.
 
 .. tip::
 


### PR DESCRIPTION
## Motivation

The documentation regarding the default normalization unit is wrong. It is stated that the default value is per_wave, although it is actually per_kernel.
The current version of the documentation can be found here: https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/conceptual/definitions.html

The output of rocprof-compute, when the normalization unit is not specified, is per_kernel as can be seen in a few examples here:
<img width="770" height="139" alt="image" src="https://github.com/user-attachments/assets/d31a82e0-524b-44cf-b4d4-991fdbd2ed40" />
<img width="820" height="134" alt="image" src="https://github.com/user-attachments/assets/29ea61d3-de79-4ea5-a1de-d38ca378c3e5" />


The default normalization unit was changed to per_kernel in this commit: https://github.com/ROCm/rocm-systems/commit/a8ade68e64bcc43265ffd34af78c576c48529083

## Technical Details

Fixed the default value in the documentation

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
