### PR TITLE
SWDEV-539306 - fix uses of uninitialized memory when using sendmsg()/recvmsg() in hip-tests

### DIFF
--- a/projects/hip-tests/catch/unit/memory/mempool_common.hh
+++ b/projects/hip-tests/catch/unit/memory/mempool_common.hh
@@ -577,14 +577,14 @@ public:
   }
   // method to receive shareable handle via socket
   int recvShareableHdl(hipShareableHdl *shHandle) {
-    struct msghdr msg;
+    struct msghdr msg = {};
     struct iovec iov[1];
 
     // Union to guarantee alignment requirements for control array
     union {
       struct cmsghdr cm;
       char control[CMSG_SPACE(sizeof(int))];
-    } control_un;
+    } control_un = {};
 
     struct cmsghdr *cmptr;
     ssize_t n;
@@ -621,14 +621,14 @@ public:
   }
   // method to send shareable handle via sockets
   int sendShareableHdl(hipShareableHdl shareableHdl, Process process) {
-    struct msghdr msg;
+    struct msghdr msg = {};
     struct iovec iov[1];
     int dummy_data = 0;
 
     union {
       struct cmsghdr cm;
       char control[CMSG_SPACE(sizeof(int))];
-    } control_un;
+    } control_un = {};
 
     struct cmsghdr *cmptr;
     struct sockaddr_un cliaddr;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hip_vmm_common.hh
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hip_vmm_common.hh
@@ -186,14 +186,14 @@ public:
   // method to receive shareable handle via socket
   int recvShareableHdl(hipShareableHdl *shHandle) {
     int dummy_data;
-    struct msghdr msg;
+    struct msghdr msg = {};
     struct iovec iov[1];
 
     // Union to guarantee alignment requirements for control array
     union {
       struct cmsghdr cm;
       char control[CMSG_SPACE(sizeof(int))];
-    } control_un;
+    } control_un = {};
 
     struct cmsghdr *cmptr;
     ssize_t n;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hip_vmm_common.hh
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hip_vmm_common.hh
@@ -226,13 +226,13 @@ public:
   }
   // method to send shareable handle via sockets
   int sendShareableHdl(hipShareableHdl shareableHdl, Process process) {
-    struct msghdr msg;
+    struct msghdr msg = {};
     struct iovec iov[1];
     int dummy_data = 0;
     union {
       struct cmsghdr cm;
       char control[CMSG_SPACE(sizeof(int))];
-    } control_un;
+    } control_un = {};
 
     struct cmsghdr *cmptr;
     struct sockaddr_un cliaddr;


### PR DESCRIPTION
## Motivation

Valgrind reports uses of uninitialized memory when using  sendmsg()/recvmsg() in the tests:

```
==171742== Syscall param sendmsg(msg.msg_control) points to uninitialised byte(s)
==171742==    at 0x6AB306B: __libc_sendmsg (sendmsg.c:28)
==171742==    by 0x6AB306B: sendmsg (sendmsg.c:25)
==171742==    by 0x35F764: ipcSocketCom::sendShareableHdl(int, int) 
(catch/unit/virtualMemoryManagement/hip_vmm_common.hh:256)
==171742==    by 0x35936C: CATCH2_INTERNAL_TEST_114() (catch/unit/virtualMemoryManagement/hipMemGetHandleForAddressRange.cc:666)
```
Additionaly, when running Unit_hipMemGetHandleForAddressRange_MulProc_Socket_VM with rocm 7.2 with ASan enabled we get a stack-buffer-overflow, which goes away once we remove the uninitialized memory usage (although but the test fails for other reasons unrelated to what ASan was complaining about)

## Technical Details

Make sure associated structs are initialized.

## JIRA ID

SWDEV-539306

## Test Plan

Re-run with Valgrind and ASan

## Test Result

No more memory errors

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
