### PR TITLE
[rocprofiler-compute] Warning for HIP stream serialization

### DIFF
--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -45,6 +45,19 @@ Profiling with ROCm Compute Profiler provides the following benefits:
 Run ``rocprof-compute profile -h`` for more details. See
 :ref:`Basic usage <modes-profile>`.
 
+.. warning::
+
+   **Kernel dispatches are serialized across HIP streams on the same GPU during profiling.**
+   
+   Kernels launched on separate HIP streams on the same GPU will not execute
+   concurrently during profiling. Streams on different GPUs are not
+   serialized. This means:
+
+   - Kernel duration and throughput metrics reflect serialized execution, not
+     the concurrent behavior that may occur during normal execution.
+   - Some metrics may show reduced utilization compared to normal execution
+     due to the lack of concurrent kernel execution.
+
 .. _profile-example:
 
 Profiling example

--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -48,7 +48,9 @@ Run ``rocprof-compute profile -h`` for more details. See
 .. warning::
 
    **Kernel dispatches are serialized across HIP streams on the same GPU during profiling.**
-   
+
+   ROCm Compute Profiler collects GPU performance counters with kernel
+   dispatch association which requires serializing kernel dispatches.
    Kernels launched on separate HIP streams on the same GPU will not execute
    concurrently during profiling. Streams on different GPUs are not
    serialized. This means:
@@ -996,7 +998,7 @@ Example with hierarchical naming:
            super().__init__()
            self.encoder = nn.Linear(512, 1024)
            self.decoder = nn.Linear(1024, 512)
-       
+
        def forward(self, x):
             x = self.encoder(x)  # Captured as: nn.Module.MyModel.forward/nn.Module.Linear.forward
             x = self.decoder(x)  # Captured as: nn.Module.MyModel.forward/nn.Module.Linear.forward

--- a/projects/rocprofiler-compute/docs/reference/faq.rst
+++ b/projects/rocprofiler-compute/docs/reference/faq.rst
@@ -106,3 +106,14 @@ How can I SSH tunnel in MobaXterm?
      * ``<SSH server>``: *name of the server to connect to*
      * ``<SSH login>``: *username to login to the server*
      * ``<SSH port>``: ``22``
+
+Why are kernels on separate HIP streams not executing concurrently during profiling?
+====================================================================================
+
+Kernel dispatches are serialized across HIP streams on the same GPU during
+profiling so that only one kernel executes at a time on a given GPU.
+Streams on different GPUs are not serialized. As a result, kernels
+launched on separate HIP streams on the same GPU will run one after
+another during profiling. Kernel duration and throughput metrics reflect
+this serialized execution rather than the concurrent behavior that may
+occur during normal execution.

--- a/projects/rocprofiler-compute/docs/reference/faq.rst
+++ b/projects/rocprofiler-compute/docs/reference/faq.rst
@@ -110,6 +110,8 @@ How can I SSH tunnel in MobaXterm?
 Why are kernels on separate HIP streams not executing concurrently during profiling?
 ====================================================================================
 
+ROCm Compute Profiler collects GPU performance counters with kernel
+dispatch association which requires serializing kernel dispatches.
 Kernel dispatches are serialized across HIP streams on the same GPU during
 profiling so that only one kernel executes at a time on a given GPU.
 Streams on different GPUs are not serialized. As a result, kernels


### PR DESCRIPTION
## Motivation

Profiling data is misleading for kernels expected to run on concurrent streams.

## Technical Details

- Added warning for HIP stream serialization while profiling.
- Added warning in documentation
- Added faq

## JIRA ID

AIPROFCOMP-185

## Test Plan

- [X] Run added test

## Test Result

- [X] Passes test

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
