### PR TITLE
[RCCL] Fix all warnings

### DIFF
--- a/projects/rccl/src/allocator.cc
+++ b/projects/rccl/src/allocator.cc
@@ -290,7 +290,7 @@ ncclResult_t ncclShadowPoolDestruct(struct ncclShadowPool* pool) {
               pool->pages = page;
             }
           } else {
-            cudaFreeAsync(obj->devObj, stream);
+            CUDACHECKIGNORE(cudaFreeAsync(obj->devObj, stream));
           }
           struct ncclShadowObject* next = obj->next;
           free(obj);
@@ -301,15 +301,15 @@ ncclResult_t ncclShadowPoolDestruct(struct ncclShadowPool* pool) {
     free(pool->table);
 
     while (pool->pages != nullptr) {
-      cudaFreeAsync(pool->pages->devObjs, stream);
+      CUDACHECKIGNORE(cudaFreeAsync(pool->pages->devObjs, stream));
       struct ncclShadowPage* next = pool->pages->next;
       free(pool->pages);
       pool->pages = next;
     }
 
-    cudaStreamSynchronize(stream);
-    cudaStreamDestroy(stream);
-    cudaMemPoolDestroy(pool->memPool);
+    CUDACHECKIGNORE(cudaStreamSynchronize(stream));
+    CUDACHECKIGNORE(cudaStreamDestroy(stream));
+    CUDACHECKIGNORE(cudaMemPoolDestroy(pool->memPool));
   }
   return ncclSuccess;
 }
@@ -343,7 +343,7 @@ ncclResult_t ncclShadowPoolAlloc(
     props.allocType = cudaMemAllocationTypePinned;
     props.handleTypes = cudaMemHandleTypeNone;
     props.location.type = cudaMemLocationTypeDevice;
-    cudaGetDevice(&props.location.id);
+    CUDACHECKIGNORE(cudaGetDevice(&props.location.id));
     CUDACHECK(cudaMemPoolCreate(&pool->memPool, &props));
 
     pool->hbits = hbits = 4;

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -170,7 +170,6 @@ ncclResult_t ncclAlltoAll_impl(const void* sendbuff, void* recvbuff, size_t coun
 
   size_t rankOffset = count * ncclTypeSize(datatype);
   size_t rankAlign = rankOffset & ((~rankOffset) + 1);
-  size_t msgSize = count * ncclTypeSize(datatype) * comm->nRanks;
 
   struct ncclInfo info;
   if (comm->topo->pivotA2AEnabled && comm->nChannels >= comm->topo->pivotA2ANumBiRings * 2 &&
@@ -180,6 +179,7 @@ ncclResult_t ncclAlltoAll_impl(const void* sendbuff, void* recvbuff, size_t coun
         ALLTOALL_PIVOT_CHUNKSTEPS, ALLTOALL_PIVOT_SLICESTEPS, nullptr };
   } else {
       #ifdef ENABLE_ROCSHMEM
+      size_t msgSize = count * ncclTypeSize(datatype) * comm->nRanks;
       if (rcclUseAllToAllGda(comm) && msgSize <= comm->rocshmemThreshold) {	
         struct ncclInfo info = { ncclFuncAllToAllGda, "AllToAllGda",
               sendbuff, recvbuff, count, datatype, ncclSum, 0, comm, stream,
@@ -187,7 +187,7 @@ ncclResult_t ncclAlltoAll_impl(const void* sendbuff, void* recvbuff, size_t coun
             
         return ncclEnqueueCheck(&info);
       }
-      #endif ENABLE_ROCSHMEM
+      #endif // ENABLE_ROCSHMEM
     info = { ncclFuncAlltoAll, "AlltoAll",
       sendbuff, recvbuff, count, datatype, ncclSum, 0, comm, stream, /* Args */
       ALLTOALL_CHUNKSTEPS, ALLTOALL_SLICESTEPS };

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -116,8 +116,8 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
         ncclShadowPoolFree(&devr->shadows, tableDev, stream);
         tableDev = next;
       }
-      cudaStreamSynchronize(stream);
-      cudaStreamDestroy(stream);
+      CUDACHECKIGNORE(cudaStreamSynchronize(stream));
+      CUDACHECKIGNORE(cudaStreamDestroy(stream));
     }
   }
   CUdeviceptr flatAddr = reinterpret_cast<CUdeviceptr>(devr->lsaFlatBase);
@@ -598,15 +598,15 @@ ncclResult_t ncclDevrWindowRegisterInGroup(
   // symWindowCreate needs barrier.
   NCCLCHECKGOTO(bootstrapBarrier(comm->bootstrap, comm->rank, comm->nRanks, 0xbeef), ret, fail_locReg_memHandle_mem_stream_win);
 
-  cudaStreamDestroy(stream);
+  CUDACHECKIGNORE(cudaStreamDestroy(stream));
   return ret;
 
 fail_locReg_memHandle_mem_stream_win:
   symWindowDestroy(comm, *outWinDev, stream);
   *outWinDev = nullptr;
-  cudaStreamSynchronize(stream);
+  CUDACHECKIGNORE(cudaStreamSynchronize(stream));
 fail_locReg_memHandle_mem_stream:
-  cudaStreamDestroy(stream);
+  CUDACHECKIGNORE(cudaStreamDestroy(stream));
   symMemoryDropRef(comm, mem);
 fail_locReg_memHandle:
   if (memHandle != 0x0) { CUCHECKIGNORE(cuMemRelease(memHandle)); }
@@ -768,13 +768,13 @@ ncclResult_t ncclDevrCommCreateInternal(
 
   NCCLCHECKGOTO(bootstrapBarrier(comm->bootstrap, comm->rank, comm->nRanks, 0xbeef), ret, fail);
 
-  cudaStreamDestroy(stream);
+  CUDACHECKIGNORE(cudaStreamDestroy(stream));
   return ret;
 
 fail:
   if (win != nullptr) {
     symWindowDestroy(comm, win->vidmem, stream);
-    cudaStreamSynchronize(stream);
+    CUDACHECKIGNORE(cudaStreamSynchronize(stream));
   }
   if (mem != nullptr) {
     symMemoryDropRef(comm, mem);
@@ -783,7 +783,7 @@ fail:
     CUCHECKIGNORE(cuMemRelease(memHandle));
   }
   if (stream != nullptr) {
-    cudaStreamDestroy(stream);
+    CUDACHECKIGNORE(cudaStreamDestroy(stream));
   }
   return ret;
 }
@@ -820,7 +820,7 @@ ncclResult_t ncclCommWindowRegister_impl(
 exit:
   ncclGroupErrCheck(ret);
   NCCLCHECK(ncclGroupEndInternal());
-  cudaSetDevice(saveDev);
+  CUDACHECKIGNORE(cudaSetDevice(saveDev));
   return ret;
 fail:
   goto exit;
@@ -843,10 +843,10 @@ ncclResult_t ncclCommWindowDeregister_impl(struct ncclComm* comm, struct ncclWin
   CUDACHECKGOTO(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), ret, fail_dev);
   NCCLCHECKGOTO(symWindowDestroy(comm, winDev, stream), ret, fail_dev_stream);
 fail_dev_stream:
-  cudaStreamSynchronize(stream);
-  cudaStreamDestroy(stream);
+  CUDACHECKIGNORE(cudaStreamSynchronize(stream));
+  CUDACHECKIGNORE(cudaStreamDestroy(stream));
 fail_dev:
-  cudaSetDevice(saveDev);
+  CUDACHECKIGNORE(cudaSetDevice(saveDev));
 fail:
 exit:
   return ret;
@@ -899,7 +899,7 @@ ncclResult_t ncclDevCommCreate(
 exit:
   ncclGroupErrCheck(ret);
   NCCLCHECK(ncclGroupEndInternal());
-  cudaSetDevice(saveDev);
+  CUDACHECKIGNORE(cudaSetDevice(saveDev));
   return ret;
 fail:
   free(task);

--- a/projects/rccl/src/device/all_gather.h
+++ b/projects/rccl/src/device/all_gather.h
@@ -79,7 +79,7 @@ namespace {
       // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
       // coverity[callee_ptr_arith:FALSE]
       Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, isNetOffload> prims
-        (tid, workNthreads, &ring->prev, &ring->next, inputBuf, outputBuf, work->redOpArg, 0, work->connIndex, work->connIndex, work, NULL, isNetOffload ? NCCL_MAX_NET_SIZE : 0);
+        (tid, workNthreads, &ring->prev, &ring->next, inputBuf, outputBuf, work->redOpArg, 0, work->connIndex, work->connIndex, work, nullptr, isNetOffload ? NCCL_MAX_NET_SIZE : 0);
 
 #if defined(ENABLE_NPKIT)
       if (tid == 0) {

--- a/projects/rccl/src/device/prims_ll.h
+++ b/projects/rccl/src/device/prims_ll.h
@@ -684,6 +684,14 @@ public:
     setDataPtrs(inputBuf, outputBuf, e != nullptr ? e->acc : nullptr);
   }
 
+  __forceinline__ __device__ Primitives(
+      int tid, int nthreads, int const *recvPeers, int const *sendPeers,
+      void const *inputBuf, void *outputBuf, uint64_t redOpArg, uint8_t group,
+      uint8_t connIndexRecv, uint8_t connIndexSend, struct ncclDevWorkColl* collWork,
+      struct ncclDevWorkP2p* p2pWork, int stepSize_ = 0, int mode = primsModeDefault
+    ): Primitives(tid, nthreads, recvPeers, sendPeers, inputBuf, outputBuf, redOpArg, group,
+                  connIndexRecv, connIndexSend, collWork) {}
+
   __device__ ~Primitives() {
     // Save steps for the next operation
     if (tid >= nthreads-WARP_SIZE && wid < fan.nrecv())

--- a/projects/rccl/src/device/prims_ll128.h
+++ b/projects/rccl/src/device/prims_ll128.h
@@ -604,6 +604,14 @@ public:
     setDataPtrs(inputBuf, outputBuf, e != nullptr ? e->acc : nullptr);
   }
 
+  __forceinline__ __device__ Primitives(
+      int tid, int nthreads, int const *recvPeers, int const *sendPeers,
+      void const *inputBuf, void *outputBuf, uint64_t redOpArg, uint8_t group,
+      uint8_t connIndexRecv, uint8_t connIndexSend, struct ncclDevWorkColl* collWork,
+      struct ncclDevWorkP2p* p2pWork, int stepSize_ = 0, int mode = primsModeDefault
+    ): Primitives(tid, nthreads, recvPeers, sendPeers, inputBuf, outputBuf, redOpArg, group,
+                  connIndexRecv, connIndexSend, collWork) {}
+
   __device__ ~Primitives() {
     // Save steps for the next operation
     if (tid >= nthreads-WARP_SIZE && wid < fan.nrecv())

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -1381,7 +1381,7 @@ static ncclResult_t waitWorkFifoAvailable(struct ncclComm* comm, uint32_t desire
         warned = 1;
         WARN("Waiting for work FIFO to become available. "
             "Work fifo exhaustion can happen in large scale/high iteration count of alltoall. "
-            "In order to increase work FIFO size, set NCCL_WORK_FIFO_BYTES to higher number (current: %ld).\n\n"
+            "In order to increase work FIFO size, set NCCL_WORK_FIFO_BYTES to higher number (current: %" PRId32 ").\n\n"
             "RCCL continues to retry...", comm->workFifoBytes);
       }
     }

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -3078,7 +3078,7 @@ ncclResult_t ncclEnqueueCheck(struct ncclInfo* info) {
   }
   NCCLCHECKGOTO(ArgsCheck(info), ret, fail);
 
-  INFO(NCCL_COLL,"%s: opCount %lx sendbuff %p recvbuff %p acc %p count %u datatype %d op %d root %d comm %p [nranks=%d] stream %p task %d globalrank %d",
+  INFO(NCCL_COLL,"%s: opCount %lx sendbuff %p recvbuff %p acc %p count %zu datatype %d op %d root %d comm %p [nranks=%d] stream %p task %d globalrank %d",
         info->opName, info->comm->opCount, info->sendbuff, info->recvbuff, info->acc, info->count,
         info->datatype, info->op, info->root, info->comm, info->comm->nRanks, info->stream,
         info->comm->planner.nTasksP2p + info->comm->planner.nTasksColl,

--- a/projects/rccl/src/graph/tuning.cc
+++ b/projects/rccl/src/graph/tuning.cc
@@ -485,6 +485,7 @@ static struct tuningModel rcclTuningModel[] = {
   tuning_model_7,
 };
 
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
 // NVLS efficiency factor.
 static const float nvlsEfficiency[NCCL_NUM_COMPCAPS] = {
   0.0f, // Volta
@@ -492,6 +493,7 @@ static const float nvlsEfficiency[NCCL_NUM_COMPCAPS] = {
   0.85f, // Hopper
   0.74f, // Blackwell
 };
+#endif
 
 // Default tuner constants
 static const ncclTunerConstants_t ncclTunerConstantsDefaults = {

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -679,7 +679,7 @@ struct ncclComm {
 
   hipEvent_t doneEvent;
   hipStream_t lastStream;
-  std::unique_ptr<latency_profiler::CollTrace> ctrace;
+  latency_profiler::CollTrace* ctrace;
 
 #ifdef ENABLE_COLLTRACE
   struct ncclCollTrace* collTrace;

--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -474,7 +474,7 @@ constexpr size_t ncclDevWorkSize(enum ncclDevWorkType type) {
         type == ncclDevWorkTypeColl ? sizeof(ncclDevWorkColl) : sizeof(ncclDevWorkCollReg);
 }
 
-#define NCCL_MAX_DEV_WORK_BATCH_BYTES 128
+#define NCCL_MAX_DEV_WORK_BATCH_BYTES 192
 #define NCCL_MAX_DEV_WORK_BATCH_COLLS (NCCL_MAX_DEV_WORK_BATCH_BYTES/sizeof(ncclDevWorkColl))
 #define NCCL_MAX_DEV_WORK_P2P_PER_BATCH 2
 #define NCCL_MAX_DEV_WORK_P2P_ELEMENTS 2

--- a/projects/rccl/src/include/latency_profiler/CollTraceEvent.h
+++ b/projects/rccl/src/include/latency_profiler/CollTraceEvent.h
@@ -19,7 +19,7 @@ namespace latency_profiler {
 struct CudaEventDeleter {
   void operator()(cudaEvent_t e) {
     // Ignore error at destroy
-    cudaEventDestroy(e);
+    (void)cudaEventDestroy(e);
   }
 };
 using CudaEventPtr = std::unique_ptr<

--- a/projects/rccl/src/include/msccl/msccl_parser.h
+++ b/projects/rccl/src/include/msccl/msccl_parser.h
@@ -17,31 +17,26 @@
 #include "msccl/msccl_struct.h"
 
 // A few constraints to make the implementation easy
-#define MAX_STR_LEN 255
-#define MAX_ATTR_COUNT 16
-#define MAX_SUBS 1024
-#define MAX_NODES 4096
-
-#define NODE_TYPE_NONE 0
-#define NODE_TYPE_OPEN 1
-#define NODE_TYPE_CLOSE 2
-#define NODE_TYPE_SINGLE 3
+#define MSCCL_MAX_STR_LEN 255
+#define MSCCL_MAX_ATTR_COUNT 16
+#define MSCCL_MAX_SUBS 1024
+#define MSCCL_MAX_NODES 4096
 
 struct mscclXmlNode {
-  char name[MAX_STR_LEN+1];
+  char name[MSCCL_MAX_STR_LEN+1];
   struct {
-    char key[MAX_STR_LEN+1];
-    char value[MAX_STR_LEN+1];
-  } attrs[MAX_ATTR_COUNT+1]; // Need an extra one to consume extra params
+    char key[MSCCL_MAX_STR_LEN+1];
+    char value[MSCCL_MAX_STR_LEN+1];
+  } attrs[MSCCL_MAX_ATTR_COUNT+1]; // Need an extra one to consume extra params
   int nAttrs;
   int type;
   struct mscclXmlNode* parent;
-  struct mscclXmlNode* subs[MAX_SUBS];
+  struct mscclXmlNode* subs[MSCCL_MAX_SUBS];
   int nSubs;
 };
 
 struct mscclXml {
-  struct mscclXmlNode nodes[MAX_NODES];
+  struct mscclXmlNode nodes[MSCCL_MAX_NODES];
   int maxIndex;
 };
 
@@ -49,7 +44,7 @@ static ncclResult_t mscclXmlGetAttrIndex(struct mscclXmlNode* node, const char* 
   *index = -1;
   const int nAttrs = node->nAttrs;
   for (int a=0; a<nAttrs; a++) {
-    if (strncmp(node->attrs[a].key, attrName, MAX_STR_LEN) == 0) {
+    if (strncmp(node->attrs[a].key, attrName, MSCCL_MAX_STR_LEN) == 0) {
       *index = a;
       return ncclSuccess;
     }

--- a/projects/rccl/src/include/nccl_device/coop.h
+++ b/projects/rccl/src/include/nccl_device/coop.h
@@ -8,6 +8,7 @@
 #define _NCCL_DEVICE_COOP_H_
 #include "utility.h"
 
+#undef __CUDACC__
 #define __CUDACC__ 0
 
 // ncclCoop[Foo]: NCCL's versions of CUDA's Cooperative Groups. They conform

--- a/projects/rccl/src/include/nccl_device/core.h
+++ b/projects/rccl/src/include/nccl_device/core.h
@@ -10,6 +10,7 @@
 #include "coop.h"
 #include "utility.h"
 
+#undef __CUDACC__
 #define __CUDACC__ 0
 
 struct ncclDevComm;

--- a/projects/rccl/src/include/nccl_device/mem_barrier.h
+++ b/projects/rccl/src/include/nccl_device/mem_barrier.h
@@ -9,6 +9,7 @@
 #include "impl/core__types.h"
 #include "core_tmp.h"
 
+#undef __CUDACC__
 #define __CUDACC__ 0
 
 struct ncclLsaBarrierHandle;

--- a/projects/rccl/src/include/nccl_device/utility.h
+++ b/projects/rccl/src/include/nccl_device/utility.h
@@ -7,6 +7,7 @@
 #ifndef _NCCL_DEVICE_UTILITY_H_
 #define _NCCL_DEVICE_UTILITY_H_
 
+#undef __CUDACC__
 #define __CUDACC__ 0
 
 #if __CUDACC__

--- a/projects/rccl/src/include/proxy.h
+++ b/projects/rccl/src/include/proxy.h
@@ -384,7 +384,7 @@ struct ncclProxyState {
   struct ncclExpectedProxyResponse* expectedResponses;
 
   // A handle to the proxy traces
-  std::unique_ptr<facebook_rccl::ProxyTrace> proxyTrace;
+  facebook_rccl::ProxyTrace* proxyTrace;
 };
 
 enum proxyConnectState {

--- a/projects/rccl/src/include/recorder.h
+++ b/projects/rccl/src/include/recorder.h
@@ -125,7 +125,7 @@ class Recorder {
 
   //std::string           hostname;
   int                   pid = -1;
-  int                   numCall = 0; // reserved for future record format/debug
+  [[maybe_unused]] int  numCall = 0; // reserved for future record format/debug
   bool                  skipped = false; // number of sendrecv calls to skip for gather/scatter/a2a(v)
   static __thread int   rcclReplayThreadIdx;
   static int            depth; // for indentation purpose, will need thread safty later

--- a/projects/rccl/src/include/strongstream.h
+++ b/projects/rccl/src/include/strongstream.h
@@ -129,7 +129,7 @@ struct ncclStrongStream {
 
 struct ncclCudaContext {
   struct ncclCudaContext* next;
-  CUcontext hcontext;
+  int hcontext;
   int refCount;
   struct ncclStrongStream launchOrder;
 };

--- a/projects/rccl/src/misc/latency_profiler/CollTraceFunc.cc
+++ b/projects/rccl/src/misc/latency_profiler/CollTraceFunc.cc
@@ -28,7 +28,8 @@ ncclResult_t collTraceInit(ncclComm* comm) {
   if (!enableCollTrace()) {
     return ncclSuccess;
   }
-  comm->ctrace = std::make_unique<CollTrace>(comm);
+  if (comm->ctrace) delete comm->ctrace;
+  comm->ctrace = new CollTrace(comm);
   return ncclSuccess;
 }
 
@@ -36,7 +37,8 @@ ncclResult_t collTraceDestroy(ncclComm* comm) {
   if (comm->ctrace == nullptr) {
     return ncclSuccess;
   }
-  comm->ctrace.reset();
+  delete comm->ctrace;
+  comm->ctrace = nullptr;
   return ncclSuccess;
 }
 

--- a/projects/rccl/src/misc/latency_profiler/CollTraceUtils.cc
+++ b/projects/rccl/src/misc/latency_profiler/CollTraceUtils.cc
@@ -39,7 +39,7 @@ void reportToFile(
   for (const auto& oneDumpStats : stats) {
     for (const auto& elem : oneDumpStats) {
       auto size_mb = getSizeMb(elem.dataType, elem.count);
-      INFO(NCCL_COLL, "coll_id %ld, percent %d, min_latency_us %f, max_latency_us %f, op_name %s, data_type %s, count %ld, message_size_MB %f, comm_hash %s", elem.collId, elem.percent, elem.minLatencyUs, elem.maxLatencyUs, elem.opName.c_str(), elem.dataType.c_str(), elem.count, size_mb, commHash.c_str());
+      INFO(NCCL_COLL, "coll_id %d, percent %d, min_latency_us %f, max_latency_us %f, op_name %s, data_type %s, count %ld, message_size_MB %f, comm_hash %s", elem.collId, elem.percent, elem.minLatencyUs, elem.maxLatencyUs, elem.opName.c_str(), elem.dataType.c_str(), elem.count, size_mb, commHash.c_str());
     }
   }
 }

--- a/projects/rccl/src/misc/msccl/msccl_lifecycle.cc
+++ b/projects/rccl/src/misc/msccl/msccl_lifecycle.cc
@@ -600,7 +600,9 @@ ncclResult_t mscclEnqueueCheck(
     count, dataType, root, peer, op, func, comm, stream,
     &threadLocalStatus.savedSchedulerParams.back()));
 
-  size_t nBytes = count * ncclTypeSize(dataType);
+#ifdef ENABLE_MSCCLPP
+  const size_t nBytes = count * ncclTypeSize(dataType);
+#endif
 
   switch (threadLocalStatus.groupStatus) {
     case mscclNoGroup:

--- a/projects/rccl/src/misc/msccl/msccl_lifecycle.cc
+++ b/projects/rccl/src/misc/msccl/msccl_lifecycle.cc
@@ -31,7 +31,9 @@ RCCL_PARAM(MscclEnabled, "MSCCL_ENABLE", 1);
 RCCL_PARAM(MscclForceEnabled, "MSCCL_FORCE_ENABLE", 0);
 RCCL_PARAM(MscclEnableSingleProcess, "MSCCL_ENABLE_SINGLE_PROCESS", 1);
 
+#ifdef COMPILE_MSCCL_KERNEL
 static bool mscclWarn = false;
+#endif
 
 bool mscclEnabled() {
 #ifdef COMPILE_MSCCL_KERNEL

--- a/projects/rccl/src/misc/msccl/msccl_parser.cc
+++ b/projects/rccl/src/misc/msccl/msccl_parser.cc
@@ -15,6 +15,11 @@
 #include "collectives.h"
 #include "msccl/msccl_parser.h"
 
+#define NODE_TYPE_NONE 0
+#define NODE_TYPE_OPEN 1
+#define NODE_TYPE_CLOSE 2
+#define NODE_TYPE_SINGLE 3
+
 ncclResult_t mscclXmlGetChar(FILE* file, char* c) {
   if (fread(c, 1, 1, file) == 0) {
     WARN("XML Parse : Unexpected EOF");
@@ -66,9 +71,9 @@ ncclResult_t mscclXmlGetToken(FILE* file, char* name, char* value, char* last) {
       return mscclXmlGetValue(file, value, last);
     }
     ptr[o] = c;
-    if (o == MAX_STR_LEN-1) {
+    if (o == MSCCL_MAX_STR_LEN-1) {
       ptr[o] = '\0';
-      WARN("Error : name %s too long (max %d)", ptr, MAX_STR_LEN);
+      WARN("Error : name %s too long (max %d)", ptr, MSCCL_MAX_STR_LEN);
       return ncclInternalError;
     }
     o++;
@@ -138,15 +143,15 @@ ncclResult_t mscclXmlGetNode(FILE* file, struct mscclXmlNode* node) {
   int a = 0;
   while (c == ' ') {
     NCCLCHECK(mscclXmlGetToken(file, node->attrs[a].key, node->attrs[a].value, &c));
-    if (a == MAX_ATTR_COUNT) {
-      INFO(NCCL_GRAPH, "XML Parse : Ignoring extra attributes (max %d)", MAX_ATTR_COUNT);
+    if (a == MSCCL_MAX_ATTR_COUNT) {
+      INFO(NCCL_GRAPH, "XML Parse : Ignoring extra attributes (max %d)", MSCCL_MAX_ATTR_COUNT);
       // Actually we need to still consume the extra attributes so we have an extra one.
     } else a++;
   }
   node->nAttrs = a;
   if (c == '/') {
     node->type = NODE_TYPE_SINGLE;
-    char str[MAX_STR_LEN];
+    char str[MSCCL_MAX_STR_LEN];
     NCCLCHECK(mscclXmlGetToken(file, str, NULL, &c));
   }
   if (c != '>') {
@@ -166,7 +171,7 @@ struct mscclXmlHandler {
 ncclResult_t mscclXmlLoadSub(FILE* file, struct mscclXml* xml, struct mscclXmlNode* head, struct mscclXmlHandler handlers[], int nHandlers) {
   if (head && head->type == NODE_TYPE_SINGLE) return ncclSuccess;
   while (1) {
-    if (xml->maxIndex == MAX_NODES) {
+    if (xml->maxIndex == MSCCL_MAX_NODES) {
       WARN("Error : XML parser is limited to 1024 nodes");
       return ncclInternalError;
     }

--- a/projects/rccl/src/misc/recorder.cc
+++ b/projects/rccl/src/misc/recorder.cc
@@ -47,10 +47,10 @@ rcclApiCall::rcclApiCall(rcclCall_t type, const ncclInfo& info)://name(rcclCallS
                                                                 nTasks(info.comm->planner.nTasksP2p + info.comm->planner.nTasksColl),
                                                                 globalRank(info.comm->localRankToRank[info.comm->localRank])
 {
-  hipMemGetAddressRange(&recvPtrBase, &recvPtrExtent, const_cast<void*>(info.recvbuff)); // should always exist for collectives
+  (void)hipMemGetAddressRange(&recvPtrBase, &recvPtrExtent, const_cast<void*>(info.recvbuff)); // should always exist for collectives
   if (info.sendbuff) // ncclSend/Recv
   {
-    hipMemGetAddressRange(&sendPtrBase, &sendPtrExtent, const_cast<void*>(info.sendbuff));
+    (void)hipMemGetAddressRange(&sendPtrBase, &sendPtrExtent, const_cast<void*>(info.sendbuff));
   }
 }
 
@@ -136,8 +136,8 @@ void Recorder::captureGpuContext(rcclApiCall& call) const
     rcclReplayThreadIdx = syscall(SYS_gettid);
   }
 
-  int hipDev;
-  hipGetDevice(&hipDev); // need later change to copy from comm
+  int hipDev = -1;
+  (void)hipGetDevice(&hipDev); // need later change to copy from comm
 
   call.pid = pid;
   call.tid = rcclReplayThreadIdx;

--- a/projects/rccl/src/misc/rocm_smi_wrap.cc
+++ b/projects/rccl/src/misc/rocm_smi_wrap.cc
@@ -174,15 +174,15 @@ ncclResult_t rocm_smi_getLinkInfo(int srcIndex, int dstIndex, RSMI_IO_LINK_TYPE*
       ROCMSMICHECK(rsmi_topo_get_link_weight(srcIndex, dstIndex, &rsmi_weight));
       if (*rsmi_type == RSMI_IOLINK_TYPE_XGMI && (rsmi_weight == 15 ||
         rsmi_weight == 41 || rsmi_weight == 13)) {
-	uint64_t min_bw = 0, max_bw = 0;
-	*hops = 1;
+  *hops = 1;
 #if defined HAVE_ROCM_SMI64CONFIG && rocm_smi_VERSION_MAJOR >= 5
-	rsmi_version_t version;
-	ROCMSMICHECK(rsmi_version_get(&version));
-	if (version.major >= 5)
-	  ROCMSMICHECK(rsmi_minmax_bandwidth_get(srcIndex, dstIndex, &min_bw, &max_bw));
-	if (max_bw && min_bw)
-	  *count = max_bw/min_bw;
+  uint64_t min_bw = 0, max_bw = 0;
+  rsmi_version_t version;
+  ROCMSMICHECK(rsmi_version_get(&version));
+  if (version.major >= 5)
+    ROCMSMICHECK(rsmi_minmax_bandwidth_get(srcIndex, dstIndex, &min_bw, &max_bw));
+  if (max_bw && min_bw)
+    *count = max_bw/min_bw;
 #endif
       }
     } else {

--- a/projects/rccl/src/misc/strongstream.cc
+++ b/projects/rccl/src/misc/strongstream.cc
@@ -32,8 +32,8 @@ static std::mutex cxtListMutex;
 
 ncclResult_t ncclCudaContextTrack(struct ncclCudaContext** out) {
   ncclResult_t result = ncclSuccess;
-  CUcontext hcontext;
-  CUCHECK(cuCtxGetCurrent(&hcontext));
+  int hcontext;
+  CUCHECK(hipGetDevice(&hcontext));
 
   std::lock_guard<std::mutex> lock(cxtListMutex);
   struct ncclCudaContext* p = cxtListHead;

--- a/projects/rccl/src/misc/strongstream.cc
+++ b/projects/rccl/src/misc/strongstream.cc
@@ -33,7 +33,7 @@ static std::mutex cxtListMutex;
 ncclResult_t ncclCudaContextTrack(struct ncclCudaContext** out) {
   ncclResult_t result = ncclSuccess;
   CUcontext hcontext;
-  cuCtxGetCurrent(&hcontext);
+  CUCHECK(cuCtxGetCurrent(&hcontext));
 
   std::lock_guard<std::mutex> lock(cxtListMutex);
   struct ncclCudaContext* p = cxtListHead;
@@ -183,7 +183,7 @@ ncclResult_t ncclStrongStreamAcquire(
             if (spare == nullptr) { // Keep one spare to reuse below.
               spare = cap;
             } else {
-              cudaStreamDestroy(cap->captureStream);
+              CUDACHECKIGNORE(cudaStreamDestroy(cap->captureStream));
               free(cap);
             }
           }

--- a/projects/rccl/src/plugin/net.cc
+++ b/projects/rccl/src/plugin/net.cc
@@ -69,7 +69,7 @@ typedef struct netPluginLib {
 
 int pluginCount = 0;
 bool netPluginLibsInitialized = false;
-netPluginLib_t netPluginLibs[NCCL_NET_MAX_PLUGINS] = { 0 };
+netPluginLib_t netPluginLibs[NCCL_NET_MAX_PLUGINS] = {};
 static std::mutex netPluginMutex;
 static std::once_flag initPluginLibsOnceFlag;
 

--- a/projects/rccl/src/proxy.cc
+++ b/projects/rccl/src/proxy.cc
@@ -1854,7 +1854,7 @@ static ncclResult_t proxyUDSRecvReq(struct ncclProxyState* proxyState, int reqFd
 #else
     uint64_t handle = *(uint64_t*)hdr.data;
 #endif
-    INFO(NCCL_PROXY, "proxyUDSRecvReq::ncclProxyMsgGetFd rank %d opId %p handle=0x%lx", hdr.rank, hdr.opId, handle);
+    INFO(NCCL_PROXY, "proxyUDSRecvReq::ncclProxyMsgGetFd rank %d opId %p handle=0x%" PRIxPTR, hdr.rank, hdr.opId, reinterpret_cast<uintptr_t>(handle));
     close(rmtFd);
     return proxyGetFd(proxyState, hdr.rank, hdr.opId, handle);
   } else if (hdr.type == ncclProxyMsgQueryFd) {

--- a/projects/rccl/src/proxy.cc
+++ b/projects/rccl/src/proxy.cc
@@ -1926,7 +1926,8 @@ ncclResult_t ncclProxyInit(struct ncclComm* comm, struct ncclSocket* sock, union
   comm->proxyState->netAttr = NCCL_NET_ATTR_INIT;
   if (rcclParamEnableProxyTrace()) {
     INFO(NCCL_PROXY, "Initializing ProxyTrace, rank: %d, commHash: %lu", comm->rank, comm->commHash);
-    comm->proxyState->proxyTrace = std::make_unique<facebook_rccl::ProxyTrace>(comm->rank);
+    if (comm->proxyState->proxyTrace) delete comm->proxyState->proxyTrace;
+    comm->proxyState->proxyTrace = new facebook_rccl::ProxyTrace(comm->rank);
   }
 
   // UDS support
@@ -2024,6 +2025,7 @@ ncclResult_t ncclProxyDestroy(struct ncclComm* comm) {
     free(sharedProxyState->proxyOps);
     free(sharedProxyState->sharedDevMems);
     expectedProxyResponseFree(sharedProxyState);
+    delete sharedProxyState->proxyTrace;
     free(sharedProxyState);
   }
   return ncclSuccess;

--- a/projects/rccl/src/proxy.cc
+++ b/projects/rccl/src/proxy.cc
@@ -1824,7 +1824,7 @@ void* ncclProxyService(void* _args) {
   }
 
   // Wait for all operations to complete and stop progress thread before freeing any resource
-  hipDeviceSynchronize();
+  CUDACHECKIGNORE(hipDeviceSynchronize());
   if (ncclProxyProgressDestroy(proxyState) != ncclSuccess) {
     WARN("[Proxy Service] proxyDestroy failed");
   }

--- a/projects/rccl/src/proxy.cc
+++ b/projects/rccl/src/proxy.cc
@@ -1528,7 +1528,7 @@ static ncclResult_t proxyGetFd(struct ncclProxyState* proxyState, int rank, void
   ncclResult_t ret = ncclSuccess;
   struct ncclIpcSocket ipcSock = { 0 };
   uint64_t hash = (uint64_t) opId;
-  INFO(NCCL_PROXY, "UDS proxyGetFd received handle 0x%lx peer %d opId %lx", handle, rank, hash);
+  INFO(NCCL_PROXY, "UDS proxyGetFd received handle 0x%" PRIxPTR " peer %d opId %lx", (uintptr_t)handle, rank, hash);
 
   CUmemAllocationHandleType type = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
   int fd = -1;

--- a/projects/rccl/src/ras/client_support.cc
+++ b/projects/rccl/src/ras/client_support.cc
@@ -495,9 +495,9 @@ static ncclResult_t rasClientRunInit(struct rasClient* client) {
   rasOutAppend("RCCL version " STR(NCCL_MAJOR) "." STR(NCCL_MINOR) "." STR(NCCL_PATCH) NCCL_SUFFIX
                " compiled with ROCm " STR(ROCM_BUILD_INFO) "\n");
   if (hipRuntime == -1)
-    hipRuntimeGetVersion(&hipRuntime);
+    CUDACHECKIGNORE(hipRuntimeGetVersion(&hipRuntime));
   if (amdgpuDriver == -1)
-    hipDriverGetVersion(&amdgpuDriver);
+    CUDACHECKIGNORE(hipDriverGetVersion(&amdgpuDriver));
     //Find a better way to query amdgpu driver version, as hipDriverGetVersion() reports the same as hipRuntimeGetVersion()
     //Else, cudaRuntimeGetVersion() and cudaDriverGetVersion() are anyways hipified, so no need of this mod
   rasOutAppend("HIP runtime version %d, amdgpu driver version %d\n\n", hipRuntime, amdgpuDriver);

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -589,7 +589,7 @@ void rcclSetWarpSpeedCUs(struct ncclComm* comm, int algo, int threadsPerBlock, i
     if(!userChannelControlInput) {
       if(rcclParamWarpSpeedCuCount() != 0) {
         rcclWarpSpeedChannels = rcclParamWarpSpeedCuCount() * warpsPerBlock;
-        INFO(NCCL_INIT, "RCCL Warp CU count set to user defined %lld resulting in %d channels", rcclParamWarpSpeedCuCount(), rcclWarpSpeedChannels);
+        INFO(NCCL_INIT, "RCCL Warp CU count set to user defined %ld resulting in %d channels", (long)rcclParamWarpSpeedCuCount(), rcclWarpSpeedChannels);
         return;
       }
     }

--- a/projects/rccl/src/transport/coll_net.cc
+++ b/projects/rccl/src/transport/coll_net.cc
@@ -545,6 +545,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
 
   *((struct connectMap**)respBuff) = &resources->map;
 
+#if CUDA_VERSION >= 11070
 exit:
   return ret;
 fail:
@@ -552,6 +553,9 @@ fail:
     (void)close(dmabuf_fd);
   }
   goto exit;
+#else
+  return ret;
+#endif
 }
 
 static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
@@ -630,6 +634,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   if (respSize != sizeof(struct connectMap*)) { WARN("recvProxyConnect: respSize is %d != %ld", respSize, sizeof(void*)); return ncclInternalError; }
   *((struct connectMap**)respBuff) = &resources->map;
 
+#if CUDA_VERSION >= 11070
 exit:
   return ret;
 fail:
@@ -637,6 +642,9 @@ fail:
     (void)close(dmabuf_fd);
   }
   goto exit;
+#else
+  return ret;
+#endif
 }
 
 static ncclResult_t sendProxyFree(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState) {

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -466,7 +466,7 @@ static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* conne
     send->transportResources = map;
     opId = send;
     INFO(NCCL_PROXY, "sendConnect ncclProxyCallAsync opId=%p", opId);
-    netSendConnectArgs args = {{},0};
+    netSendConnectArgs args = {{},{}};
     memcpy(&args.handle, connectInfo, sizeof(ncclNetHandle_t));
 
     populateCommNetAttrs(comm, send, &args.netAttr);

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -492,7 +492,7 @@ static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* conne
       // Enable P2P access for Legacy IPC
       cudaError_t err = cudaDeviceEnablePeerAccess(map->cudaDev, 0);
       if (err == cudaErrorPeerAccessAlreadyEnabled) {
-        cudaGetLastError();
+        (void)cudaGetLastError();
       } else if (err != cudaSuccess) {
         WARN("failed to peer with device %d: %d %s", map->cudaDev, err, cudaGetErrorString(err));
         return ncclInternalError;

--- a/projects/rccl/src/transport/p2p.cc
+++ b/projects/rccl/src/transport/p2p.cc
@@ -1085,9 +1085,11 @@ static ncclResult_t p2pProxyRegister(struct ncclProxyConnection* connection, str
   struct p2pIpcExpInfo* ipcExpInfo = (struct p2pIpcExpInfo*)reqBuff;
   void* regAddr = NULL;
   ncclResult_t ret = ncclSuccess;
+#if ROCM_VERSION >= 70000
   bool mapped = false;
   bool imported = false;
   CUmemGenericAllocationHandle handle;
+#endif
 
   assert(sizeof(struct p2pIpcExpInfo) == reqSize);
   assert(sizeof(void*) == respSize);

--- a/projects/rccl/src/transport/p2p.cc
+++ b/projects/rccl/src/transport/p2p.cc
@@ -348,7 +348,7 @@ static ncclResult_t p2pMap(struct ncclComm *comm, struct ncclProxyConnector* pro
       // Legacy CUDA IPC
       cudaError_t err = cudaDeviceEnablePeerAccess(peerInfo->cudaDev, 0);
       if (err == cudaErrorPeerAccessAlreadyEnabled) {
-        cudaGetLastError();
+        (void)cudaGetLastError();
       } else if (err != cudaSuccess) {
         WARN("failed to peer with device %d(=%lx): %d %s",
             peerInfo->cudaDev, peerInfo->busId, err, cudaGetErrorString(err));

--- a/projects/rccl/test/_RecorderTests.cpp
+++ b/projects/rccl/test/_RecorderTests.cpp
@@ -12,6 +12,12 @@
 
 #include <thread>
 
+#define HIPCALL(cmd)                                                                          \
+    do {                                                                                      \
+        hipError_t error = (cmd);                                                             \
+        GTEST_ASSERT_EQ(error, hipSuccess);                                                   \
+    } while (0)
+
 namespace RcclUnitTesting
 {
   /**
@@ -27,11 +33,11 @@ namespace RcclUnitTesting
    * ******************************************************************************************/
   TEST(Recorder, ParseJson)
   {
-    setenv("RCCL_REPLAY_FILE", "/tmp/test.json", 1);
-
     int pid = getpid();
     hipStream_t stream;
-    hipStreamCreate(&stream);
+    HIPCALL(hipStreamCreate(&stream));
+
+    setenv("RCCL_REPLAY_FILE", "/tmp/test.json", 1);
 
     int array[] = {2, 3, 5};
     ncclComm comm{.nRanks = 1, .localRank = 1, .localRankToRank = array, .opCount = 8, .planner = {.nTasksColl = 13, .nTasksP2p = 21}};

--- a/projects/rccl/test/common/CollectiveArgs.cpp
+++ b/projects/rccl/test/common/CollectiveArgs.cpp
@@ -24,8 +24,8 @@ namespace RcclUnitTesting
     {
       if (this->localScalar.ptr != nullptr)
       {
-        if (this->options.scalarMode == 0) this->localScalar.FreeGpuMem();
-        if (this->options.scalarMode == 1) hipHostFree(this->localScalar.ptr);
+        if (this->options.scalarMode == 0) CHECK_CALL(this->localScalar.FreeGpuMem());
+        if (this->options.scalarMode == 1) CHECK_HIP(hipHostFree(this->localScalar.ptr));
       }
     }
 

--- a/projects/rccl/test/common/EnvVars.cpp
+++ b/projects/rccl/test/common/EnvVars.cpp
@@ -29,26 +29,29 @@ namespace RcclUnitTesting
     }
     pid_t pid = fork();
     if (0 == pid) {
-      bool isGfxTest = false;
-      int dev;
-      hipGetDeviceCount(&dev);
-      for (int deviceId = 0; deviceId < dev; deviceId++) {
-        char gcn[256];
-        hipDeviceProp_t devProp;
-        hipGetDeviceProperties(&devProp, deviceId);
-        char *gcnArchNameToken = strtok(devProp.gcnArchName, ":");
-        strcpy(gcn, gcnArchNameToken);
-        if(std::strncmp(gfx, gcn, 5) == 0) {
-          isGfxTest = true;
-        } else {
-          isGfxTest = false;
-          break;
+      ErrCode result = [&]() -> ErrCode {
+        bool isGfxTest = false;
+        int dev;
+        CHECK_HIP(hipGetDeviceCount(&dev));
+        for (int deviceId = 0; deviceId < dev; deviceId++) {
+          char gcn[256];
+          hipDeviceProp_t devProp;
+          CHECK_HIP(hipGetDeviceProperties(&devProp, deviceId));
+          char *gcnArchNameToken = strtok(devProp.gcnArchName, ":");
+          strcpy(gcn, gcnArchNameToken);
+          if(std::strncmp(gfx, gcn, 5) == 0) {
+            isGfxTest = true;
+          } else {
+            isGfxTest = false;
+            break;
+          }
         }
-      }
-      if (write(pipefd[1], &isGfxTest, sizeof(isGfxTest)) != sizeof(isGfxTest)) return TEST_FAIL;
+        if (write(pipefd[1], &isGfxTest, sizeof(isGfxTest)) != sizeof(isGfxTest)) return TEST_FAIL;
+        return TEST_SUCCESS;
+      }();
       close(pipefd[0]);
       close(pipefd[1]);
-      exit(EXIT_SUCCESS);
+      exit(result == TEST_SUCCESS ? EXIT_SUCCESS : EXIT_FAILURE);
     }
     else {
       int status;
@@ -73,12 +76,15 @@ namespace RcclUnitTesting
     pid_t pid = fork();
     if (0 == pid)
     {
-      int dev;
-      hipGetDeviceCount(&dev);
-      if (write(pipefd[1], &dev, sizeof(dev)) != sizeof(dev)) return TEST_FAIL;
+      ErrCode result = [&]() -> ErrCode {
+        int dev;
+        CHECK_HIP(hipGetDeviceCount(&dev));
+        if (write(pipefd[1], &dev, sizeof(dev)) != sizeof(dev)) return TEST_FAIL;
+        return TEST_SUCCESS;
+      }();
       close(pipefd[0]);
       close(pipefd[1]);
-      exit(EXIT_SUCCESS);
+      exit(result == TEST_SUCCESS ? EXIT_SUCCESS : EXIT_FAILURE);
     }
     else
     {
@@ -103,15 +109,18 @@ namespace RcclUnitTesting
     pid_t pid = fork();
     if (0 == pid)
     {
-      bool isCpxMode = false;
-      int numDeviceCUs;
-      int deviceIdx = 0;
-      hipDeviceGetAttribute(&numDeviceCUs, hipDeviceAttributeMultiprocessorCount, deviceIdx);
-      if(numDeviceCUs == 20 || numDeviceCUs == 38) isCpxMode = true;
-      if (write(pipefd[1], &isCpxMode, sizeof(isCpxMode)) != sizeof(isCpxMode)) return TEST_FAIL;
+      ErrCode result = [&]() -> ErrCode {
+        bool isCpxMode = false;
+        int numDeviceCUs;
+        int deviceIdx = 0;
+        CHECK_HIP(hipDeviceGetAttribute(&numDeviceCUs, hipDeviceAttributeMultiprocessorCount, deviceIdx));
+        if(numDeviceCUs == 20 || numDeviceCUs == 38) isCpxMode = true;
+        if (write(pipefd[1], &isCpxMode, sizeof(isCpxMode)) != sizeof(isCpxMode)) return TEST_FAIL;
+        return TEST_SUCCESS;
+      }();
       close(pipefd[0]);
       close(pipefd[1]);
-      exit(EXIT_SUCCESS);
+      exit(result == TEST_SUCCESS ? EXIT_SUCCESS : EXIT_FAILURE);
     }
     else {
       int status;
@@ -152,16 +161,17 @@ namespace RcclUnitTesting
     }
     pid_t pid = fork();
     if (0 == pid) {
-      std::vector<int> result;
-      try {
+      ErrCode result = [&]() -> ErrCode {
+        std::vector<int> result;
+        try {
           int numDev;
-          hipGetDeviceCount(&numDev);
+          CHECK_HIP(hipGetDeviceCount(&numDev));
           std::unordered_map<int64_t, std::vector<int>> uniqueIdToGpuIndexes;
           for(int dev=0;dev<numDev;dev++){
             char busIdStr[] = "00000000:00:00.0";
             int64_t busId;
-            hipDeviceGetPCIBusId(busIdStr, sizeof(busIdStr), dev);
-            busIdToInt64(busIdStr, &busId);
+            CHECK_HIP(hipDeviceGetPCIBusId(busIdStr, sizeof(busIdStr), dev));
+            CHECK_NCCL(busIdToInt64(busIdStr, &busId));
             uniqueIdToGpuIndexes[busId].push_back(dev);
           }
           std::vector<std::pair<int64_t, std::vector<int>>> sortedIds(uniqueIdToGpuIndexes.begin(), uniqueIdToGpuIndexes.end());
@@ -171,14 +181,16 @@ namespace RcclUnitTesting
           for (const auto& pair : sortedIds) {
               result.insert(result.end(), pair.second.begin(), pair.second.end());
           }
-      } catch (const std::exception& e) {
+        } catch (const std::exception& e) {
           std::cerr << "Error: " << e.what() << std::endl;
-          return 1;
-      }
-      if (write(pipefd[1], result.data(), gpuPriorityOrder->size() * sizeof(int)) != gpuPriorityOrder->size() * sizeof(int)) return TEST_FAIL;
+          return TEST_FAIL;
+        }
+        if (write(pipefd[1], result.data(), gpuPriorityOrder->size() * sizeof(int)) != gpuPriorityOrder->size() * sizeof(int)) return TEST_FAIL;
+        return TEST_SUCCESS;
+      }();
       close(pipefd[0]);
       close(pipefd[1]);
-      exit(EXIT_SUCCESS);
+      exit(result == TEST_SUCCESS ? EXIT_SUCCESS : EXIT_FAILURE);
     }
     else {
       int status;
@@ -189,7 +201,6 @@ namespace RcclUnitTesting
       close(pipefd[1]);
     }
     return TEST_SUCCESS;
-    return 0;
   }
 
 

--- a/projects/rccl/test/common/ErrCode.hpp
+++ b/projects/rccl/test/common/ErrCode.hpp
@@ -43,15 +43,29 @@ namespace RcclUnitTesting
   } while (false)
 #define CHECK_HIP(func) CHECK_HIP_BASE(func, RETURN_RESULT)
 
+#define CHECK_NCCL_BASE(func, RESULT, RESULT_ARGS...)                   \
+  do {                                                                  \
+    ncclResult_t result = (func);                                       \
+    if (result != ncclSuccess)                                          \
+    {                                                                   \
+      fprintf(stderr, "\033[0;31m" "[ ERROR    ] NCCL error: %s File:%s Line:%d\n" "\033[m", \
+              ncclGetErrorString(result), strrchr("/" __FILE__, '/') + 1, __LINE__); \
+      RESULT(TEST_FAIL, ##RESULT_ARGS);                                 \
+    }                                                                   \
+  } while (false)
+#define CHECK_NCCL(func) CHECK_NCCL_BASE(func, RETURN_RESULT)
+
 #ifdef ENABLE_OPENMP
 #define OMP_CANCEL_FOR(result, errCode) errCode = (result); _Pragma("omp cancel for")
 #define RANK_RESULT(errCode, result) OMP_CANCEL_FOR(result, errCode)
 #define CHECK_CALL_RANK(errCode, func) CHECK_CALL_BASE(func, OMP_CANCEL_FOR, errCode)
 #define CHECK_HIP_RANK(errCode, func) CHECK_HIP_BASE(func, OMP_CANCEL_FOR, errCode)
+#define CHECK_NCCL_RANK(errCode, func) CHECK_NCCL_BASE(func, OMP_CANCEL_FOR, errCode)
 #else
 #define RANK_RESULT(errCode, result) RETURN_RESULT(result)
 #define CHECK_CALL_RANK(errCode, func) CHECK_CALL(func)
 #define CHECK_HIP_RANK(errCode, func) CHECK_HIP(func)
+#define CHECK_NCCL_RANK(errCode, func) CHECK_NCCL(func)
 #endif
 }
 

--- a/projects/rccl/test/common/PtrUnion.cpp
+++ b/projects/rccl/test/common/PtrUnion.cpp
@@ -97,9 +97,9 @@ namespace RcclUnitTesting
     if (this->ptr != nullptr)
     {
       if (userRegistered)
-        ncclMemFree(this->ptr);
+        CHECK_NCCL(ncclMemFree(this->ptr));
       else
-        hipFree(this->ptr);
+        CHECK_HIP(hipFree(this->ptr));
       this->ptr = nullptr;
     }
     return TEST_SUCCESS;
@@ -122,7 +122,7 @@ namespace RcclUnitTesting
       ERROR("Unable to call hipMemset\n");
       return TEST_FAIL;
     }
-    hipStreamSynchronize(NULL);
+    CHECK_HIP(hipStreamSynchronize(NULL));
     return TEST_SUCCESS;
   }
 

--- a/projects/rccl/test/proxy_trace/ProxyTraceUnitTests.cpp
+++ b/projects/rccl/test/proxy_trace/ProxyTraceUnitTests.cpp
@@ -22,7 +22,7 @@ public:
   int nSteps = 10;
   void SetUp() override {
     proxyState = new ncclProxyState();
-    proxyState->proxyTrace = std::make_unique<facebook_rccl::ProxyTrace>(0);
+    proxyState->proxyTrace = new facebook_rccl::ProxyTrace(0);
     EXPECT_NE(proxyState->proxyTrace, nullptr);
     sub1 = new ncclProxySubArgs();
     sub2 = new ncclProxySubArgs();
@@ -34,6 +34,7 @@ public:
   void TearDown() override {
     delete sub1;
     delete sub2;
+    delete proxyState->proxyTrace;
     delete proxyState;
   }
   void AddTraceOp(ncclProxySubArgs *sub, facebook_rccl::ProxyOpType opType) {


### PR DESCRIPTION
## Motivation

Fix all warnings in rccl library.

## Technical Details

Resolves the following classes of warning:
- Macro redefinition
- Unused variables
- Unused labels
- Discarded return values
- Improper array initialization
- Struct data layout (simple struct types changed to non-simple struct types)
- Use of deprecated APIs
- Integer text formatting

It also tries to address discrepancy between LL, LL128, and Simple usage of the template overloaded `Primitives` constructor. (Also see #2772)

## JIRA ID

AICOMRCCL-108

## Test Plan

No functional changes, automated compile and test.

## Test Result

All tests pass, compilation generates no warnings.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
