### PR TITLE
[RCCL][API] AlltoAllv parity with 2.28

### DIFF
--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -24,6 +24,7 @@ const char* ncclFuncToString(ncclFunc_t fn) {
   case ncclFuncAllGather: return "AllGather";
   case ncclFuncAllReduce: return "AllReduce";
   case ncclFuncAlltoAll: return "AlltoAll";
+  case ncclFuncAlltoAllv: return "AlltoAllv";
   case ncclFuncBroadcast: return "Broadcast";
   case ncclFuncGather: return "Gather";
   case ncclFuncRecv: return "Recv";
@@ -216,9 +217,7 @@ ncclResult_t ncclAlltoAllv_impl(const void *sendbuff, const size_t sendcounts[],
       0, datatype, 0, 0, ncclSum, mscclFuncAllToAllv, comm, stream);
   }
 
-  struct ncclInfo info;
-
-  info = { ncclFuncAlltoAllv, "AlltoAllv",
+  struct ncclInfo info = { ncclFuncAlltoAllv, "AlltoAllv",
       sendbuff, recvbuff, 0, datatype, ncclSum, 0, comm, stream, /* Args */
       ALLTOALL_CHUNKSTEPS, ALLTOALL_SLICESTEPS, nullptr, sendcounts, recvcounts, sdispls, rdispls};
 

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -216,29 +216,13 @@ ncclResult_t ncclAlltoAllv_impl(const void *sendbuff, const size_t sendcounts[],
       0, datatype, 0, 0, ncclSum, mscclFuncAllToAllv, comm, stream);
   }
 
-  int nRanks;
-  NCCLCHECK(ncclCommCount(comm, &nRanks));
-  if (!mscclIsCaller()) Recorder::instance().skip(true);
-  NCCLCHECK(ncclGroupStart());
-  for (int r=0; r<nRanks; r++) {
-    NCCLCHECK(ncclSend(
-        ((char*)sendbuff) + sdispls[r]*ncclTypeSize(datatype),
-        sendcounts[r],
-        datatype,
-        r,
-        comm,
-        stream));
-    NCCLCHECK(ncclRecv(
-        ((char*)recvbuff) + rdispls[r]*ncclTypeSize(datatype),
-        recvcounts[r],
-        datatype,
-        r,
-        comm,
-        stream));
-  }
-  NCCLCHECK(ncclGroupEnd());
-  if (!mscclIsCaller()) Recorder::instance().skip(false);
-  return ncclSuccess;
+  struct ncclInfo info;
+
+  info = { ncclFuncAlltoAllv, "AlltoAllv",
+      sendbuff, recvbuff, 0, datatype, ncclSum, 0, comm, stream, /* Args */
+      ALLTOALL_CHUNKSTEPS, ALLTOALL_SLICESTEPS, nullptr, sendcounts, recvcounts, sdispls, rdispls};
+
+  return ncclEnqueueCheck(&info);
 }
 
 NCCL_API(ncclResult_t, ncclAllReduce, const void* sendbuff, void* recvbuff, size_t count,

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -2974,13 +2974,16 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
     NCCLCHECK(p2pTaskAppend(comm, info, info->coll, collAPI, (void*)info->recvbuff, info->count, info->datatype, info->root));
   } else {
     // Empty collectives can be discarded.
-    if (info->count == 0 && info->coll != ncclFuncAlltoAllv) return ncclSuccess;
-    else {
-      bool any = false;
-      for (int r = 0; r < comm->nRanks; r++) {
-        if (info->sendCounts[r] != 0 || info->recvCounts[r] != 0) { any = true; break; }
+    if (info->count == 0) {
+      if (info->coll == ncclFuncAlltoAllv) {
+        bool any = false;
+        for (int r = 0; r < comm->nRanks; r++) {
+          if (info->sendCounts[r] != 0 || info->recvCounts[r] != 0) { any = true; break; }
+        }
+        if (!any) return ncclSuccess;
+      } else {
+        return ncclSuccess;
       }
-      if (!any) return ncclSuccess;
     }
 
     if (info->datatype == ncclFloat8e4m3 || info->datatype == ncclFloat8e5m2) {

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -2974,10 +2974,17 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
     NCCLCHECK(p2pTaskAppend(comm, info, info->coll, collAPI, (void*)info->recvbuff, info->count, info->datatype, info->root));
   } else {
     // Empty collectives can be discarded.
-    if (info->count == 0) return ncclSuccess;
+    if (info->count == 0 && info->coll != ncclFuncAlltoAllv) return ncclSuccess;
+    else {
+      bool any = false;
+      for (int r = 0; r < comm->nRanks; r++) {
+        if (info->sendCounts[r] != 0 || info->recvCounts[r] != 0) { any = true; break; }
+      }
+      if (!any) return ncclSuccess;
+    }
 
     if (info->datatype == ncclFloat8e4m3 || info->datatype == ncclFloat8e5m2) {
-      if (comm->minCompCap < 90 && info->coll != ncclFuncAllGather && info->coll != ncclFuncBroadcast && info->coll != ncclFuncAlltoAll && info->coll != ncclFuncScatter && info->coll != ncclFuncGather) {
+      if (comm->minCompCap < 90 && info->coll != ncclFuncAllGather && info->coll != ncclFuncBroadcast && info->coll != ncclFuncAlltoAll && info->coll != ncclFuncAlltoAllv && info->coll != ncclFuncScatter && info->coll != ncclFuncGather) {
         WARN("FP8 reduction support begins with sm90 capable devices.");
         return ncclInvalidArgument;
       }
@@ -2989,6 +2996,7 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
     NCCLCHECK(hostToDevRedOp(&opDev, info->op, info->datatype, comm));
 
     if (comm->nRanks == 1) {
+      if (info->coll == ncclFuncAlltoAllv) info->count = info->sendCounts[0];
       NCCLCHECK(ncclLaunchOneRank(info->recvbuff, info->sendbuff, info->count, opDev, info->datatype, info->stream));
       return ncclSuccess;
     } else {
@@ -3008,6 +3016,11 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
           for (int r=0; r<comm->nRanks; r++) {
             NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncSend, collAPI, (void*)((char*)info->sendbuff+r*info->count*ncclTypeSize(info->datatype)), info->count, info->datatype, r));
             NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncRecv, collAPI, (void*)((char*)info->recvbuff+r*info->count*ncclTypeSize(info->datatype)), info->count, info->datatype, r));
+          }
+        } else if (info->coll == ncclFuncAlltoAllv) {
+          for (int r=0; r<comm->nRanks; r++) {
+            NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncSend, collAPI, (void*)((char*)info->sendbuff+info->sdispls[r]*ncclTypeSize(info->datatype)), info->sendCounts[r], info->datatype, r));
+            NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncRecv, collAPI, (void*)((char*)info->recvbuff+info->rdispls[r]*ncclTypeSize(info->datatype)), info->recvCounts[r], info->datatype, r));
           }
         } else if (info->coll == ncclFuncGather){
           size_t offset = 0;

--- a/projects/rccl/src/include/info.h
+++ b/projects/rccl/src/include/info.h
@@ -30,6 +30,10 @@ struct ncclInfo {
   int chunkSteps;
   int sliceSteps;
   const void* acc;
+  const size_t* sendCounts;
+  const size_t* recvCounts;
+  const size_t* sdispls;
+  const size_t* rdispls;
 };
 
 #endif

--- a/projects/rccl/src/include/nccl_common.h
+++ b/projects/rccl/src/include/nccl_common.h
@@ -74,7 +74,7 @@ typedef enum {
   ncclFuncGather = 11,
   ncclFuncAlltoAllPivot = 12,
   ncclFuncAllToAllGda = 13,
-  ncclNumFuncs = 13
+  ncclNumFuncs = 14
 } ncclFunc_t;
 
 

--- a/projects/rccl/src/include/nccl_common.h
+++ b/projects/rccl/src/include/nccl_common.h
@@ -69,10 +69,11 @@ typedef enum {
   ncclFuncSend = 6,
   ncclFuncRecv = 7,
   ncclFuncAlltoAll = 8,
-  ncclFuncScatter = 9,
-  ncclFuncGather = 10,
-  ncclFuncAlltoAllPivot = 11,
-  ncclFuncAllToAllGda = 12,
+  ncclFuncAlltoAllv = 9,
+  ncclFuncScatter = 10,
+  ncclFuncGather = 11,
+  ncclFuncAlltoAllPivot = 12,
+  ncclFuncAllToAllGda = 13,
   ncclNumFuncs = 13
 } ncclFunc_t;
 

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -219,7 +219,7 @@ static void populateCommNetAttrs(struct ncclComm* comm, struct ncclConnector* co
     netAttr->recvCommAttr.maxConcurrentPeers = maxConcPeers;
     netAttr->recvCommAttr.maxFlowsPerPeer = comm->p2pnChannelsPerPeer;
     netAttr->op = BIT(ncclFuncSend) | BIT(ncclFuncRecv) |
-                  BIT(ncclFuncAlltoAll) | BIT(ncclFuncScatter) | BIT(ncclFuncGather);
+                  BIT(ncclFuncAlltoAll) | BIT(ncclFuncAlltoAllv) | BIT(ncclFuncScatter) | BIT(ncclFuncGather);
   } else {
     size_t maxConcPeers = (NCCL_MAX_TREE_ARITY - 1) * 2;
     if (comm->nRanks < maxConcPeers) maxConcPeers = comm->nRanks;


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
NCCL 2.28 introduced new APIs like AlltoAll, Gather, Scatter. RCCL already had these APIs prior to 2.28 merge. This PR updates the AlltoAllv API to match the other implementations.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Adapted changes from 2.28 sync to AlltoAllv API. This includes introducing new variables to the info struct and moving the taskAppend to enqueue.cc

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Running UT and CI

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
