### PR TITLE
[AMD-SMI] Fix amdsmi_get_gpu_compute_process_info() python API population

### DIFF
--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -5202,6 +5202,29 @@ rsmi_compute_process_info_get(rsmi_process_info_t *procs,
     *num_items = procs_found;
   }
 
+  // Populate per-process stats (vram, sdma, cu_occupancy, evicted_time)
+  // GetProcessInfo only enumerates PIDs; we must fill in the rest.
+  if (procs != nullptr) {
+    amd::smi::RocmSMI& smi = amd::smi::RocmSMI::getInstance();
+    auto gpu_set = std::unordered_set<std::uint64_t>{};
+    for (const auto& [gpu_id, kfd_node_ptr] : smi.kfd_node_map()) {
+        gpu_set.insert(gpu_id);
+    }
+
+    for (uint32_t i = 0; i < procs_found; ++i) {
+      auto proc_err_code = amd::smi::GetProcessInfoForPID(
+          procs[i].process_id, &procs[i], &gpu_set);
+      // Non-fatal: if a process disappeared between enumeration
+      // and info collection (ESRCH), zero-fill stats but keep process_id
+      if (proc_err_code == ESRCH) {
+        const auto pid = procs[i].process_id;
+        procs[i] = rsmi_process_info_t{pid, 0, 0, 0, 0};
+      } else if (proc_err_code) {
+        return amd::smi::ErrnoToRsmiStatus(proc_err_code);
+      }
+    }
+  }
+
   return RSMI_STATUS_SUCCESS;
 
   CATCH


### PR DESCRIPTION
Root cause: rsmi_compute_process_info_get() (which is called from amdsmi_get_gpu_compute_process_info()) called GetProcessInfo() which only enumerates PIDs from /sys/class/kfd/kfd/proc/ — it never reads vram_, sdma_, stats_*/cu_occupancy, or stats_*/evicted_ms. All stat fields were left as uninitialized/zero.

In contrast, rsmi_compute_process_info_by_pid_get() correctly calls GetProcessInfoForPID() which reads all the sysfs stats files.

Fix: After GetProcessInfo enumerates PIDs into the procs buffer, added a loop that calls GetProcessInfoForPID() for each discovered PID to populate vram_usage, sdma_usage, cu_occupancy, and evicted_time. Race conditions (process disappearing between enumeration and stat read) are handled gracefully by zero-filling on ESRCH.