### PR TITLE
rocrtst: CPUAccessToGPUMemoryTest: Cap host allocation to 512 MB

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/memory_access.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/memory_access.cc
@@ -58,6 +58,9 @@
 #include "gtest/gtest.h"
 #include "hsa/hsa.h"
 
+#ifdef ROCRTST_ASAN
+static const size_t kMaxTestAllocAsan = 512ULL * 1024 * 1024;
+#endif
 
 #define RET_IF_HSA_ERR(err) { \
   if ((err) != HSA_STATUS_SUCCESS) { \
@@ -394,6 +397,11 @@ void MemoryAccessTest::CPUAccessToGPUMemoryTest(hsa_agent_t cpuAgent,
       auto gran_sz = pool_i.alloc_granule;
       auto pool_sz = pool_i.size / gran_sz;
       auto max_alloc_size = pool_sz/2;
+#ifdef ROCRTST_ASAN
+      if (max_alloc_size > kMaxTestAllocAsan) {
+	/* Under ASAN the allocator's shadow memory overhead can cause OOM on large-VRAM GPUs where pool_sz/2 exceeds host capacity. */
+	max_alloc_size = (kMaxTestAllocAsan / gran_sz) * gran_sz;
+#endif
       unsigned int max_element = max_alloc_size/sizeof(unsigned int);
       unsigned int *gpu_data;
       unsigned int *sys_data;

--- a/projects/rocr-runtime/rocrtst/suites/test_common/CMakeLists.txt
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/CMakeLists.txt
@@ -588,6 +588,14 @@ add_executable(${ROCRTST} ${performanceSources} ${functionalSources} ${negativeS
 # Add HAVE_NUMA compile definition so code can conditionally compile NUMA features
 target_compile_definitions(${ROCRTST} PRIVATE HAVE_NUMA=$<BOOL:${HAVE_NUMA}>)
 
+# Detect AddressSanitizer and define ROCRTST_ASAN
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-fsanitize=address" COMPILER_HAS_ASAN)
+if(COMPILER_HAS_ASAN AND (CMAKE_CXX_FLAGS MATCHES "-fsanitize=address" OR CMAKE_C_FLAGS MATCHES "-fsanitize=address"))
+  target_compile_definitions(${ROCRTST} PRIVATE ROCRTST_ASAN=1)
+  message(STATUS "AddressSanitizer detected - defining ROCRTST_ASAN")
+endif()
+
 # Find hwloc library
 set(HAVE_HWLOC FALSE)
 set(HWLOC_TARGET "")


### PR DESCRIPTION
Under ASAN the allocator's shadow memory overhead can cause OOM
on large-VRAM GPUs where pool_sz/2 exceeds host capacity.Capped
allocation to 512 MB when building with ASAN.
Non-ASAN builds are unchanged.


## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
