### PR TITLE
[rocshmem] Add device support for `rocshmem_team_my_pe` and `rocshmem_team_n_pes` APIs

### DIFF
--- a/projects/rocshmem/docs/api/teams.rst
+++ b/projects/rocshmem/docs/api/teams.rst
@@ -12,6 +12,7 @@ ROCSHMEM_TEAM_MY_PE
 -------------------
 
 .. cpp:function:: __host__ int rocshmem_team_my_pe(rocshmem_team_t team)
+.. cpp:function:: __device__ int rocshmem_team_my_pe(rocshmem_team_t team)
 
   :param team: The team to query.
   :returns: PE ID of the caller in the provided team.
@@ -23,6 +24,7 @@ ROCSHMEM_TEAM_N_PES
 -------------------
 
 .. cpp:function:: __host__ int rocshmem_team_n_pes(rocshmem_team_t team)
+.. cpp:function:: __device__ int rocshmem_team_n_pes(rocshmem_team_t team)
 
   :param team: The team to query.
   :returns: Number of PEs in the provided team.

--- a/projects/rocshmem/include/rocshmem/rocshmem.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem.hpp
@@ -638,6 +638,11 @@ __device__ ATTR_NO_INLINE void rocshmem_pe_quiet(const int *target_pes, size_t n
  */
 __device__ int rocshmem_ctx_n_pes(rocshmem_ctx_t ctx);
 
+/**
+ * @brief Query for the number of PEs.
+ *
+ * @return Number of PEs.
+ */
 __device__ int rocshmem_n_pes();
 
 /**
@@ -651,7 +656,30 @@ __device__ int rocshmem_n_pes();
  */
 __device__ int rocshmem_ctx_my_pe(rocshmem_ctx_t ctx);
 
+/**
+ * @brief Query the PE ID of the caller.
+ *
+ * @return PE ID of the caller.
+ */
 __device__ int rocshmem_my_pe();
+
+/**
+ * @brief Query the number of PEs in a team.
+ *
+ * @param[in] team The team to query PE ID in.
+ *
+ * @return Number of PEs in the provided team.
+ */
+__device__ int rocshmem_team_n_pes(rocshmem_team_t team);
+
+/**
+ * @brief Query the PE ID of the caller in a team.
+ *
+ * @param[in] team The team to query PE ID in.
+ *
+ * @return PE ID of the caller in the provided team.
+ */
+__device__ int rocshmem_team_my_pe(rocshmem_team_t team);
 
 /**
  * @brief Translate the PE in src_team to that in dest_team.

--- a/projects/rocshmem/include/rocshmem/rocshmem.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem.hpp
@@ -251,7 +251,7 @@ __host__ int rocshmem_team_translate_pe(rocshmem_team_t src_team, int src_pe,
 /**
  * @brief Query the number of PEs in a team.
  *
- * @param[in] team The team to query PE ID in.
+ * @param[in] team The team to query the number of PEs from.
  *
  * @return Number of PEs in the provided team.
  */
@@ -666,7 +666,7 @@ __device__ int rocshmem_my_pe();
 /**
  * @brief Query the number of PEs in a team.
  *
- * @param[in] team The team to query PE ID in.
+ * @param[in] team The team to query the number of PEs from.
  *
  * @return Number of PEs in the provided team.
  */

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -872,6 +872,22 @@ __device__ int rocshmem_my_pe() {
   return get_internal_ctx(ROCSHMEM_CTX_DEFAULT)->my_pe;
 }
 
+__device__ int rocshmem_team_n_pes(rocshmem_team_t team) {
+  if (team == ROCSHMEM_TEAM_INVALID) {
+    return -1;
+  } else {
+    return get_internal_team(team)->num_pes;
+  }
+}
+
+__device__ int rocshmem_team_my_pe(rocshmem_team_t team) {
+  if (team == ROCSHMEM_TEAM_INVALID) {
+    return -1;
+  } else {
+    return get_internal_team(team)->my_pe;
+  }
+}
+
 template <typename T>
 __device__ T rocshmem_atomic_fetch_add(rocshmem_ctx_t ctx, T *dest, T val,
                                         int pe) {

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -873,6 +873,7 @@ __device__ int rocshmem_my_pe() {
 }
 
 __device__ int rocshmem_team_n_pes(rocshmem_team_t team) {
+  GPU_DPRINTF("Function: rocshmem_team_n_pes (team=%zd)\n", team);
   if (team == ROCSHMEM_TEAM_INVALID) {
     return -1;
   } else {
@@ -881,6 +882,7 @@ __device__ int rocshmem_team_n_pes(rocshmem_team_t team) {
 }
 
 __device__ int rocshmem_team_my_pe(rocshmem_team_t team) {
+  GPU_DPRINTF("Function: rocshmem_team_my_pe (team=%zd)\n", team);
   if (team == ROCSHMEM_TEAM_INVALID) {
     return -1;
   } else {

--- a/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_infra_tester.cpp
@@ -49,13 +49,18 @@ rocshmem_team_t team_world_dup[NUM_TEAMS];
     int num_pes = rocshmem_ctx_n_pes(ctx);
     int my_pe = rocshmem_ctx_my_pe(ctx);
 
-    if (my_pe != expected_pe) {
-      printf("PE doesn't match. Expected %d got %d\n", expected_pe, my_pe);
+    int team_pe = rocshmem_team_my_pe(team);
+    int team_size = rocshmem_team_n_pes(team);
+
+    if (my_pe != expected_pe || team_pe != expected_pe) {
+      printf("PE doesn't match. Expected %d got (pe: %d, team_pe: %d)\n",
+        expected_pe, my_pe, team_pe);
       abort();
     }
 
-    if (num_pes != expected_n_pes) {
-      printf("Team size doesn't match. Expected %d got %d\n", expected_n_pes, num_pes);
+    if (num_pes != expected_n_pes || team_size != expected_n_pes) {
+      printf("Team size doesn't match. Expected %d got (size: %d, "
+        "team_size: %d)\n", expected_n_pes, num_pes, team_size);
       abort();
     }
 


### PR DESCRIPTION
## Motivation
- Add device-side support for `rocshmem_team_my_pe` and `rocshmem_team_n_pes`. This allows querying team PE ID and team size directly from GPU kernels.

## Technical Details
- Implement device-side `rocshmem_team_my_pe` and `rocshmem_team_n_pes`
- Updated API documentation to include `__device__` variants.
- Extended `team_ctx_infra_tester` to validate:
  - Team PE matches context PE and expected PE value.
  - Team size matches context size and expected size value.

## JIRA ID
- AIROCSHMEM-298
  - completes 2/4 requirements

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
- Built ROCSHMEM with the new device APIs.
- Ran `team_ctx_infra_tester` functional test.
- Verified correct PE ID and team size for valid teams.

## Test Result
- All functional tests passed, including updated `team_ctx_infra_tester`.

## Submission Checklist

- [x] Works on all backends
- [x] Verify correctness of the APIs
