### PR TITLE
Add basic PFC collection infrastructure to rccl-test

### DIFF
--- a/projects/rccl-tests/src/common.cu
+++ b/projects/rccl-tests/src/common.cu
@@ -996,12 +996,186 @@ testResult_t TimeTest(struct threadArgs* args, ncclDataType_t type, const char* 
   return testSuccess;
 }
 
+// ============================================================
+// PFC Counter Collection (enabled by NCCL_TESTS_PFC_ENABLE=1)
+// ============================================================
+
+#include <set>
+#include <ctime>
+
+static bool PfcIsEnabled() {
+  static int enabled = -1;
+  if (enabled == -1) {
+    const char* env = getenv("NCCL_TESTS_PFC_ENABLE");
+    enabled = (env && atoi(env) > 0) ? 1 : 0;
+  }
+  return enabled == 1;
+}
+
+static const char* PfcNicPrefix() {
+  static const char* prefix = NULL;
+  static bool checked = false;
+  if (!checked) {
+    prefix = getenv("NCCL_TESTS_PFC_NIC_PREFIX");
+    checked = true;
+  }
+  return prefix;
+}
+
+static void GetNetworkInterfaces(std::vector<std::string>& interfaces) {
+  FILE* fp = popen("ls /sys/class/net 2>/dev/null", "r");
+  if (fp == NULL) return;
+
+  const char* prefix = PfcNicPrefix();
+
+  char path[256] = {0};
+  while (fgets(path, sizeof(path), fp) != NULL) {
+    if (path[strlen(path)-1] == '\n') {
+      path[strlen(path)-1] = '\0';
+    }
+    if (prefix) {
+      if (strncmp(path, prefix, strlen(prefix)) == 0) {
+        interfaces.push_back(std::string(path));
+      }
+    } else {
+      if (strcmp(path, "lo") != 0 &&
+          strncmp(path, "veth", 4) != 0 &&
+          strncmp(path, "fenic", 5) != 0) {
+        interfaces.push_back(std::string(path));
+      }
+    }
+  }
+  pclose(fp);
+}
+
+static std::string SelectNicByRank(int rank, int nranks) {
+  std::vector<std::string> interfaces;
+  GetNetworkInterfaces(interfaces);
+
+  if (interfaces.empty()) return std::string("eth0");
+
+  int nic_index = rank % interfaces.size();
+  return interfaces[nic_index];
+}
+
+static const char* PfcCounterName() {
+  static const char* name = NULL;
+  static bool checked = false;
+  if (!checked) {
+    name = getenv("NCCL_TESTS_PFC_COUNTER");
+    if (!name) name = "pfc_pri3_tx_transitions";
+    checked = true;
+  }
+  return name;
+}
+
+static TxPfcCounters GetTxPfcCounters(const char* nic_name) {
+  TxPfcCounters counters;
+  strncpy(counters.nic_name, nic_name, sizeof(counters.nic_name)-1);
+  counters.nic_name[sizeof(counters.nic_name)-1] = '\0';
+  counters.timestamp = time(NULL);
+
+  char command[512] = {0};
+  snprintf(command, sizeof(command),
+           "ethtool -S %s 2>/dev/null | grep '%s'",
+           nic_name, PfcCounterName());
+
+  FILE* fp = popen(command, "r");
+  if (fp == NULL) return counters;
+
+  char line[256] = {0};
+  while (fgets(line, sizeof(line), fp) != NULL) {
+    char key[256] = {0};
+    uint64_t value = 0;
+    if (sscanf(line, "%255[^:]: %lu", key, &value) == 2) {
+      char* start = key;
+      while (*start == ' ' || *start == '\t') start++;
+      counters.counters[std::string(start)] = value;
+    }
+  }
+  pclose(fp);
+  return counters;
+}
+
+static void PrintTxPfcCounterSummary(const char* label, const TxPfcCounters& counters_before, const TxPfcCounters& counters_after, int rank) {
+  char hostname[256] = {0};
+  if (gethostname(hostname, sizeof(hostname)) != 0) {
+    strncpy(hostname, "unknown", sizeof(hostname));
+  }
+  hostname[sizeof(hostname)-1] = '\0';
+
+  if (counters_before.counters.empty() && counters_after.counters.empty()) {
+    printf("PFC_SUMMARY: node=%s rank=%d nic=%s total_tx_pfc_packets=%lu status=ERROR\n",
+          hostname, rank, counters_before.nic_name, 0UL);
+    fflush(stdout);
+    return;
+  }
+
+  uint64_t total_delta = 0;
+  for (const auto& entry : counters_before.counters) {
+    uint64_t before = entry.second;
+    uint64_t after = 0;
+    auto it = counters_after.counters.find(entry.first);
+    if (it != counters_after.counters.end()) {
+      after = it->second;
+    }
+    total_delta += (after - before);
+  }
+
+  printf("PFC_SUMMARY: node=%s rank=%d nic=%s total_tx_pfc_packets=%lu duration_sec=%ld status=%s\n",
+        hostname, rank, counters_before.nic_name, total_delta,
+        counters_after.timestamp - counters_before.timestamp,
+        (total_delta == 0) ? "OK" : "CONGESTION");
+  fflush(stdout);
+}
+
+PfcContext PfcCollectBefore(struct threadArgs* args) {
+  PfcContext ctx;
+  ctx.enabled = PfcIsEnabled();
+  if (!ctx.enabled) return ctx;
+
+  ctx.nGpus = args->nGpus;
+  ctx.nranks = args->nProcs * args->nThreads * args->nGpus;
+  ctx.base_rank = args->proc * args->nThreads * args->nGpus + args->thread * args->nGpus;
+  ctx.counters_before.resize(args->nGpus);
+  ctx.nic_names.resize(args->nGpus);
+
+  for (int i = 0; i < args->nGpus; i++) {
+    ctx.nic_names[i] = SelectNicByRank(ctx.base_rank + i, ctx.nranks);
+    ctx.counters_before[i] = GetTxPfcCounters(ctx.nic_names[i].c_str());
+  }
+  fflush(stdout);
+  return ctx;
+}
+
+void PfcCollectAfterAndPrint(struct threadArgs* args, const PfcContext& ctx) {
+  if (!ctx.enabled) return;
+
+  const char* label = (args->collTest && args->collTest->name[0])
+                      ? args->collTest->name
+                      : "Collective Test";
+
+  std::vector<TxPfcCounters> counters_after(ctx.nGpus);
+  for (int i = 0; i < ctx.nGpus; i++) {
+    counters_after[i] = GetTxPfcCounters(ctx.nic_names[i].c_str());
+  }
+
+  for (int i = 0; i < ctx.nGpus; i++) {
+    PrintTxPfcCounterSummary(label, ctx.counters_before[i], counters_after[i], ctx.base_rank + i);
+  }
+  fflush(stdout);
+}
+
+// ============================================================
+
 testResult_t threadRunTests(struct threadArgs* args) {
   // Set device to the first of our GPUs. If we don't do that, some operations
   // will be done on the current GPU (by default : 0) and if the GPUs are in
   // exclusive mode those operations will fail.
   CUDACHECK(cudaSetDevice(args->gpus[0]));
+  PfcContext pfcCtx = PfcCollectBefore(args);
   TESTCHECK(ncclTestEngine.runTest(args, ncclroot, (ncclDataType_t)nccltype, test_typenames[nccltype], (ncclRedOp_t)ncclop, test_opnames[ncclop]));
+  PfcCollectAfterAndPrint(args, pfcCtx);
   return testSuccess;
 }
 

--- a/projects/rccl-tests/src/common.h
+++ b/projects/rccl-tests/src/common.h
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <utility>
 #include <vector>
+#include <map>
 
 // Ensures backward compatibility for FP8 datatypes
 #if NCCL_VERSION_CODE < NCCL_VERSION(2,24,3)
@@ -402,5 +403,27 @@ typedef ncclResult_t (*rcclTestsGetAlgoInfo_t)(struct ncclComm* comm, ncclFunc_t
                                           int* algo, int* protocol, int* maxChannels);
 typedef ncclResult_t (*rcclTestsGetAlgoName_t)(int algo, const char** algoName);
 typedef ncclResult_t (*rcclTestsGetProtocolName_t)(int protocol, const char** protocolName);
+
+// Structure to hold TX PFC counter data
+struct TxPfcCounters {
+  std::map<std::string, uint64_t> counters;
+  char nic_name[256];
+  long timestamp;
+};
+
+// PFC counter collection context (used to pass state between before/after collection)
+struct PfcContext {
+  std::vector<TxPfcCounters> counters_before;
+  std::vector<std::string> nic_names;
+  int base_rank;
+  int nranks;
+  int nGpus;
+  bool enabled;
+};
+
+// PFC counter collection functions (implemented in common.cu)
+// Controlled by NCCL_TESTS_PFC_ENABLE=1 environment variable
+extern PfcContext PfcCollectBefore(struct threadArgs* args);
+extern void PfcCollectAfterAndPrint(struct threadArgs* args, const PfcContext& ctx);
 
 #endif


### PR DESCRIPTION
## Motivation

The PR adds opt-in PFC counter collection infrastructure to rccl-tests that works transparently across all collective operations (AlltoAll, AllReduce, Broadcast, ReduceScatter, AllGather, Reduce, etc.) without requiring per-test modifications.

PFC TX counters (pfc_pri3_tx_transitions by default) are collected via `ethtool -S` before and after each collective test run, and a simple summary line is printed for every rank. This enables diagnosing network congestion and backpressure during collective benchmarks.

## Technical Details

Core implementation detail: `ethtool -S`  invocation with a help of `popen` before and after experiment. See `GetTxPfcCounters` for details.
Each rank selects NIC from the node but there is no exact match so rank to NIC per node may not be precise (round robin selection of the NIC for local ranks). See `SelectNicByRank` for details.
Future adjustments have been considered which would get data from rccl directly.
Due to the fact that different vendors have different names for the PFC, there is a way to alter it via `NCCL_TESTS_PFC_COUNTER` env variable. In the future NIC vendor recognition can be added if necessary

| Variable | Default | Description |
|---|---|---|
| `NCCL_TESTS_PFC_ENABLE` | `0` (disabled) | Set to `1` to enable PFC counter collection |
| `NCCL_TESTS_PFC_NIC_PREFIX` | *(none — excludes lo, veth\*, fenic\*)* | Only collect on NICs matching this prefix (e.g., `enp`, `ens`) |
| `NCCL_TESTS_PFC_COUNTER` | `pfc_pri3_tx_transitions` | ethtool counter name/pattern to grep for |

Output Format
Each rank prints a single machine-parseable line:
`PFC_SUMMARY: node=<hostname> rank=<rank> nic=<nic_name> total_tx_pfc_packets=<count> duration_sec=<seconds> status=<OK|CONGESTION|ERROR>`

## JIRA ID

N/A

## Test Plan

Manual testing only

## Test Result

Allowed to capture congestions

## Submission Checklist

- [x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
