### PR TITLE
AIRUNTIME-17 - support mipmap in opencl with rocr backend

### DIFF
--- a/projects/clr/opencl/amdocl/cl_memobj.cpp
+++ b/projects/clr/opencl/amdocl/cl_memobj.cpp
@@ -3415,8 +3415,13 @@ RUNTIME_ENTRY_RET(void*, clEnqueueMapImage,
 
   if (mipmapLevels > 1) {
     // For clEnqueueUnmapMemObject to query the level view of mipmap image per mapPtr
-    srcMem->getDeviceMemory(hostQueue.device())->
-         saveMapInfo(mapPtr, srcOrigin, srcRegion, map_flags, command->isEntireMemory(), srcImage);
+    auto* devMem = srcMem->getDeviceMemory(hostQueue.device());
+    if (devMem == NULL) {
+      delete command;
+      *not_null(errcode_ret) = CL_MEM_OBJECT_ALLOCATION_FAILURE;
+      return NULL;
+    }
+    devMem->saveMapInfo(mapPtr, srcOrigin, srcRegion, map_flags, command->isEntireMemory(), srcImage);
   }
 
   // Send the map command for processing

--- a/projects/clr/opencl/amdocl/cl_memobj.cpp
+++ b/projects/clr/opencl/amdocl/cl_memobj.cpp
@@ -3293,7 +3293,8 @@ RUNTIME_ENTRY_RET(void*, clEnqueueMapImage,
     *not_null(errcode_ret) = CL_INVALID_MEM_OBJECT;
     return NULL;
   }
-  amd::Image* srcImage = as_amd(image)->asImage();
+  amd::Memory* srcMem = as_amd(image);
+  amd::Image* srcImage = srcMem->asImage();
   if (srcImage == NULL) {
     *not_null(errcode_ret) = CL_INVALID_MEM_OBJECT;
     return NULL;
@@ -3341,7 +3342,8 @@ RUNTIME_ENTRY_RET(void*, clEnqueueMapImage,
   amd::Coord3D srcRegion(region[0], region[1], region[2]);
 
   ImageViewRef mip;
-  if (srcImage->getMipLevels() > 1) {
+  const auto mipmapLevels = srcImage->getMipLevels();
+  if (mipmapLevels > 1) {
     // Create a view for the specified mip level
     mip = srcImage->createView(srcImage->getContext(), srcImage->getImageFormat(), hostQueue.vdev(),
                                origin[srcImage->getDims()]);
@@ -3409,6 +3411,12 @@ RUNTIME_ENTRY_RET(void*, clEnqueueMapImage,
     // Runtime can't map persistent memory if it's still busy or
     // even wasn't submitted to HW from the worker thread yet
     hostQueue.finish();
+  }
+
+  if (mipmapLevels > 1) {
+    // For clEnqueueUnmapMemObject to query the level view of mipmap image per mapPtr
+    srcMem->getDeviceMemory(hostQueue.device())->
+         saveMapInfo(mapPtr, srcOrigin, srcRegion, map_flags, command->isEntireMemory(), srcImage);
   }
 
   // Send the map command for processing
@@ -3518,6 +3526,21 @@ RUNTIME_ENTRY(cl_int, clEnqueueUnmapMemObject,
     return err;
   }
 
+  device::Memory* mem = amdMemory->getDeviceMemory(hostQueue.device());
+  amd::Image* srcImage = amdMemory->asImage();
+  ImageViewRef mip;
+  if (srcImage && srcImage->getMipLevels() > 1) {
+    // This is a mipmap image, so query its level view per mapped_ptr
+    const device::Memory::WriteMapInfo* mapInfo = mem->writeMapInfo(mapped_ptr);
+    assert(mapInfo->baseMip_ != nullptr);
+     // Assign mip level view
+    mip = mapInfo->baseMip_; // Will be released on exit
+    amdMemory->decMapCount();
+    amdMemory = mip();
+    // Clear unmap flags from the parent image
+    mem->clearUnmapInfo(mapped_ptr);
+  }
+
   amd::UnmapMemoryCommand* command = new amd::UnmapMemoryCommand(
       hostQueue, CL_COMMAND_UNMAP_MEM_OBJECT, eventWaitList, *amdMemory, mapped_ptr);
 
@@ -3531,7 +3554,6 @@ RUNTIME_ENTRY(cl_int, clEnqueueUnmapMemObject,
     return CL_MEM_OBJECT_ALLOCATION_FAILURE;
   }
 
-  device::Memory* mem = amdMemory->getDeviceMemory(hostQueue.device());
   bool blocking = false;
   if (mem->isPersistentMapped()) {
     blocking = true;

--- a/projects/clr/rocclr/device/pal/palvirtual.cpp
+++ b/projects/clr/rocclr/device/pal/palvirtual.cpp
@@ -1723,16 +1723,6 @@ void VirtualGPU::submitMapMemory(amd::MapMemoryCommand& vcmd) {
           bufferFromImage->release();
         }
       } else {
-        // Validate if it's a view for a map of mip level
-        if (vcmd.memory().parent() != nullptr) {
-          amd::Image* amdImage = vcmd.memory().parent()->asImage();
-          if ((amdImage != nullptr) && (amdImage->getMipLevels() > 1)) {
-            // Save map write info in the parent object
-            dev().getGpuMemory(amdImage)->saveMapInfo(vcmd.mapPtr(), vcmd.origin(), vcmd.size(),
-                                                      vcmd.mapFlags(), vcmd.isEntireMemory(),
-                                                      vcmd.memory().asImage());
-          }
-        }
         if (!blitMgr().copyImageToBuffer(*memory, *memory->mapMemory(), vcmd.origin(), dstOrigin,
                                          vcmd.size(), vcmd.isEntireMemory())) {
           LogError("submitMapMemory() - copy failed");
@@ -1748,9 +1738,6 @@ void VirtualGPU::submitMapMemory(amd::MapMemoryCommand& vcmd) {
 }
 
 void VirtualGPU::submitUnmapMemory(amd::UnmapMemoryCommand& vcmd) {
-  bool unmapMip = false;
-  amd::Image* amdImage;
-  {
     // Make sure VirtualGPU has an exclusive access to the resources
     amd::ScopedLock lock(execution());
 
@@ -1762,19 +1749,6 @@ void VirtualGPU::submitUnmapMemory(amd::UnmapMemoryCommand& vcmd) {
       return;
     }
     profilingBegin(vcmd);
-
-    // Check if image is a mipmap and assign a saved view
-    amdImage = owner->asImage();
-    if ((amdImage != nullptr) && (amdImage->getMipLevels() > 1) &&
-        (writeMapInfo->baseMip_ != nullptr)) {
-      // Assign mip level view
-      amdImage = writeMapInfo->baseMip_;
-      // Clear unmap flags from the parent image
-      memory->clearUnmapInfo(vcmd.mapPtr());
-      memory = dev().getGpuMemory(amdImage);
-      unmapMip = true;
-      writeMapInfo = memory->writeMapInfo(vcmd.mapPtr());
-    }
 
     // We used host memory
     if ((owner->getHostMem() != nullptr) && memory->isDirectMap()) {
@@ -1799,7 +1773,6 @@ void VirtualGPU::submitUnmapMemory(amd::UnmapMemoryCommand& vcmd) {
       if (writeMapInfo->isUnmapWrite()) {
         amd::Coord3D srcOrigin(0, 0, 0);
         // Target is a remote resource, so copy
-        assert(memory->mapMemory() != nullptr);
         if (memory->desc().buffer_) {
           if (!blitMgr().copyBuffer(*memory->mapMemory(), *memory, writeMapInfo->origin_,
                                     writeMapInfo->origin_, writeMapInfo->region_,
@@ -1847,13 +1820,6 @@ void VirtualGPU::submitUnmapMemory(amd::UnmapMemoryCommand& vcmd) {
     memory->clearUnmapInfo(vcmd.mapPtr());
 
     profilingEnd(vcmd);
-  }
-  // Release a view for a mipmap map
-  if (unmapMip) {
-    // Memory release should be outside of the execution lock,
-    // because mapMemory_ isn't marked for a specifc GPU
-    amdImage->release();
-  }
 }
 
 bool VirtualGPU::fillMemory(cl_command_type type, amd::Memory* amdMemory, const void* pattern,


### PR DESCRIPTION
Unify logics on mipmap level view in OCL mapping/unmapping functions for rocr and pal. 
As a result, fix test_clCopyImage mipmp test failures with rocr backend.

## Motivation

Fix mipmap test failure with rocr in Ocl
## Technical Details

Unify mipmap level view logics for rocr and pal.
AIRUNTIME-17

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

all pass on cts
## Test Result

pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
