### PR TITLE
[rocshmem] fix the majority of unused-function warnings

### DIFF
--- a/projects/rocshmem/src/gda/debug_gda.hpp
+++ b/projects/rocshmem/src/gda/debug_gda.hpp
@@ -33,7 +33,7 @@ static void dump_ibv_qp(struct ibv_qp *qp, int conn_num);
 static void dump_mlx5dv_qp(struct mlx5dv_qp *qp_dv, int conn_num);
 static void dump_mlx5dv_cq(struct mlx5dv_cq *cq_dv, int conn_num);
 
-static void dump_ibv_context(struct ibv_context* x) {
+[[maybe_unused]] static void dump_ibv_context(struct ibv_context* x) {
   /*
    * struct ibv_context {
    *   struct ibv_device      *device;
@@ -57,7 +57,7 @@ static void dump_ibv_context(struct ibv_context* x) {
          x->device, x->cmd_fd, x->async_fd, x->num_comp_vectors, x->abi_compat);
 };
 
-static void dump_ibv_device(struct ibv_device* x) {
+[[maybe_unused]] static void dump_ibv_device(struct ibv_device* x) {
   /*
    * struct ibv_device {
    *   struct _ibv_device_ops  _ops;
@@ -82,7 +82,7 @@ static void dump_ibv_device(struct ibv_device* x) {
          x->node_type, x->transport_type, x->name, x->dev_name, x->dev_path, x->ibdev_path);
 }
 
-static void dump_ibv_pd(struct ibv_pd* x) {
+[[maybe_unused]] static void dump_ibv_pd(struct ibv_pd* x) {
   /*
    * struct ibv_pd {
    *   struct ibv_context     *context;
@@ -98,7 +98,7 @@ static void dump_ibv_pd(struct ibv_pd* x) {
          x->context, x->handle);
 }
 
-static void dump_ibv_port_attr(struct ibv_port_attr* x) {
+[[maybe_unused]] static void dump_ibv_port_attr(struct ibv_port_attr* x) {
   /*
    * struct ibv_port_attr {
    *   enum ibv_port_state     state;
@@ -157,7 +157,7 @@ static void dump_ibv_port_attr(struct ibv_port_attr* x) {
          x->link_layer, x->flags, x->port_cap_flags2);
 }
 
-void dump_ibv_qp(struct ibv_qp *qp, int conn_num) {
+[[maybe_unused]] void dump_ibv_qp(struct ibv_qp *qp, int conn_num) {
   /*
    * struct ibv_qp {
    *   struct ibv_context     *context;
@@ -191,7 +191,7 @@ void dump_ibv_qp(struct ibv_qp *qp, int conn_num) {
   DPRINTF("=========== QP_DUMP_END CONNECTION#%d  ========\n", conn_num);
 }
 
-void dump_mlx5dv_qp(struct mlx5dv_qp *qp_dv, int conn_num) {
+[[maybe_unused]] void dump_mlx5dv_qp(struct mlx5dv_qp *qp_dv, int conn_num) {
   DPRINTF("\n");
   DPRINTF("===============================================\n");
   DPRINTF("     INITIALIZED MLXDV_QP FOR CONNECTION#%d\n", conn_num);
@@ -216,7 +216,7 @@ void dump_mlx5dv_qp(struct mlx5dv_qp *qp_dv, int conn_num) {
   DPRINTF("================== QP_DUMP_END ================\n");
 }
 
-void dump_mlx5dv_cq(struct mlx5dv_cq *cq_dv, int conn_num) {
+[[maybe_unused]] void dump_mlx5dv_cq(struct mlx5dv_cq *cq_dv, int conn_num) {
   DPRINTF("\n");
   DPRINTF("===============================================\n");
   DPRINTF("     INITIALIZED MLX5DV_CQ FOR CONNECTION#%d\n", conn_num);

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -179,32 +179,32 @@ typedef struct device_prop {
 
 extern std::vector<device_prop_t> device_properties;
 
-static int get_threads_per_block(int device_id) {
+[[maybe_unused]] static int get_threads_per_block(int device_id) {
   assert(device_properties.size() > device_id);
   return device_properties[device_id].maxThreadsPerBlock;
 }
 
-static int get_wf_size(int device_id) {
+[[maybe_unused]] static int get_wf_size(int device_id) {
   assert(device_properties.size() > device_id);
   return device_properties[device_id].warpSize;
 }
 
-static const char* get_arch_name(int device_id) {
+[[maybe_unused]] static const char* get_arch_name(int device_id) {
   assert(device_properties.size() > device_id);
   return device_properties[device_id].gcnArchName;
 }
 
 /* Device-side internal functions */
-__device__ __forceinline__ uint32_t lowerID() {
+[[maybe_unused]] __device__ __forceinline__ uint32_t lowerID() {
   return __ffsll(__ballot(1)) - 1;
 }
 
-__device__ __forceinline__ int wave_SZ() { return __popcll(__ballot(1)); }
+[[maybe_unused]] __device__ __forceinline__ int wave_SZ() { return __popcll(__ballot(1)); }
 
 /*
  * Returns true if the caller's thread index is (0, 0, 0) in its block.
  */
-__device__ __forceinline__ bool is_thread_zero_in_block() {
+[[maybe_unused]] __device__ __forceinline__ bool is_thread_zero_in_block() {
   return hipThreadIdx_x == 0 && hipThreadIdx_y == 0 && hipThreadIdx_z == 0;
 }
 
@@ -212,21 +212,21 @@ __device__ __forceinline__ bool is_thread_zero_in_block() {
  * Returns true if the caller's block index is (0, 0, 0) in its grid.  All
  * threads in the same block will return the same answer.
  */
-__device__ __forceinline__ bool is_block_zero_in_grid() {
+[[maybe_unused]] __device__ __forceinline__ bool is_block_zero_in_grid() {
   return hipBlockIdx_x == 0 && hipBlockIdx_y == 0 && hipBlockIdx_z == 0;
 }
 
 /*
  * Returns the number of threads in the caller's flattened thread block.
  */
-__device__ __forceinline__ int get_flat_block_size() {
+[[maybe_unused]] __device__ __forceinline__ int get_flat_block_size() {
   return hipBlockDim_x * hipBlockDim_y * hipBlockDim_z;
 }
 
 /*
  * Returns the number of threads in the caller's flattened grid.
  */
-__device__ __forceinline__ int get_flat_grid_size() {
+[[maybe_unused]] __device__ __forceinline__ int get_flat_grid_size() {
   return get_flat_block_size() * hipGridDim_x * hipGridDim_y * hipGridDim_z;
 }
 
@@ -234,7 +234,7 @@ __device__ __forceinline__ int get_flat_grid_size() {
  * Returns the flattened thread index of the calling thread within its
  * thread block.
  */
-__device__ __forceinline__ int get_flat_block_id() {
+[[maybe_unused]] __device__ __forceinline__ int get_flat_block_id() {
   return hipThreadIdx_x + hipThreadIdx_y * hipBlockDim_x +
          hipThreadIdx_z * hipBlockDim_x * hipBlockDim_y;
 }
@@ -242,7 +242,7 @@ __device__ __forceinline__ int get_flat_block_id() {
 /*
  * Returns the number of blocks in the caller's flattened grid.
  */
-__device__ __forceinline__ int get_grid_num_blocks() {
+[[maybe_unused]] __device__ __forceinline__ int get_grid_num_blocks() {
   return hipGridDim_x * hipGridDim_y * hipGridDim_z;
 }
 
@@ -250,7 +250,7 @@ __device__ __forceinline__ int get_grid_num_blocks() {
  * Returns the flattened block index that the calling thread is a member of in
  * in the grid. Callers from the same block will have the same index.
  */
-__device__ __forceinline__ int get_flat_grid_id() {
+[[maybe_unused]] __device__ __forceinline__ int get_flat_grid_id() {
   return hipBlockIdx_x + hipBlockIdx_y * hipGridDim_x +
          hipBlockIdx_z * hipGridDim_x * hipGridDim_y;
 }
@@ -258,61 +258,61 @@ __device__ __forceinline__ int get_flat_grid_id() {
 /*
  * Returns the flattened thread index of the calling thread within the grid.
  */
-__device__ __forceinline__ int get_flat_id() {
+[[maybe_unused]] __device__ __forceinline__ int get_flat_id() {
   return get_flat_grid_id() * (hipBlockDim_x * hipBlockDim_y * hipBlockDim_z) + get_flat_block_id();
 }
 
 /*
  * Returns true if the caller's thread flad_id is 0 in its wave.
  */
-__device__ __forceinline__ bool is_thread_zero_in_wave() {
+[[maybe_unused]] __device__ __forceinline__ bool is_thread_zero_in_wave() {
   return (get_flat_block_id() % WF_SIZE) == 0;
 }
 
 /*
  * Returns true if the caller's thread flat_id is in the zero'th wave.
  */
-__device__ __forceinline__ bool is_wave_zero_in_block() {
+[[maybe_unused]] __device__ __forceinline__ bool is_wave_zero_in_block() {
   return (get_flat_block_id() / WF_SIZE) == 0;
 }
 
-__device__ __forceinline__ uint64_t get_active_lane_mask() {
+[[maybe_unused]] __device__ __forceinline__ uint64_t get_active_lane_mask() {
   return __ballot(true);
 }
 
-__device__ __forceinline__ unsigned int get_active_lane_count(uint64_t active_lane_mask) {
+[[maybe_unused]] __device__ __forceinline__ unsigned int get_active_lane_count(uint64_t active_lane_mask) {
   return __popcll(active_lane_mask);
 }
 
-__device__ __forceinline__ unsigned int get_active_lane_count() {
+[[maybe_unused]] __device__ __forceinline__ unsigned int get_active_lane_count() {
   return get_active_lane_count(get_active_lane_mask());
 }
 
-__device__ __forceinline__ unsigned int get_active_lane_num(uint64_t active_lane_mask) {
+[[maybe_unused]] __device__ __forceinline__ unsigned int get_active_lane_num(uint64_t active_lane_mask) {
   return __popcll(active_lane_mask & __lanemask_lt());
 }
 
-__device__ __forceinline__ unsigned int get_active_lane_num() {
+[[maybe_unused]] __device__ __forceinline__ unsigned int get_active_lane_num() {
   return get_active_lane_num(get_active_lane_mask());
 }
 
-__device__ __forceinline__ int get_first_active_lane_id(uint64_t active_lane_mask) {
+[[maybe_unused]] __device__ __forceinline__ int get_first_active_lane_id(uint64_t active_lane_mask) {
   return __ffsll((unsigned long long int)active_lane_mask) - 1;
 }
 
-__device__ __forceinline__ int get_first_active_lane_id() {
+[[maybe_unused]] __device__ __forceinline__ int get_first_active_lane_id() {
   return get_first_active_lane_id(get_active_lane_mask());
 }
 
-__device__ __forceinline__ bool is_first_active_lane(uint64_t active_lane_mask) {
+[[maybe_unused]] __device__ __forceinline__ bool is_first_active_lane(uint64_t active_lane_mask) {
   return get_active_lane_num(active_lane_mask) == 0;
 }
 
-__device__ __forceinline__ bool is_first_active_lane() {
+[[maybe_unused]] __device__ __forceinline__ bool is_first_active_lane() {
   return is_first_active_lane(get_active_lane_mask());
 }
 
-__device__ __forceinline__ bool is_last_active_lane(uint64_t active_lane_mask) {
+[[maybe_unused]] __device__ __forceinline__ bool is_last_active_lane(uint64_t active_lane_mask) {
   return get_active_lane_num(active_lane_mask) == get_active_lane_count(active_lane_mask) - 1;
 }
 
@@ -327,7 +327,7 @@ __device__ __forceinline__ bool is_last_active_lane() {
 /*
  * Each thread in wave tries to acquire a different lock.
  */
-__device__ __forceinline__ bool spin_lock_try_acquire_unique(uint32_t *lock) {
+[[maybe_unused]] __device__ __forceinline__ bool spin_lock_try_acquire_unique(uint32_t *lock) {
   uint32_t lock_val = SPIN_LOCK_UNLOCKED;
 
   __hip_atomic_compare_exchange_strong(lock, &lock_val, SPIN_LOCK_LOCKED,
@@ -341,7 +341,7 @@ __device__ __forceinline__ bool spin_lock_try_acquire_unique(uint32_t *lock) {
  * Each thread in wave acquires a different lock.
  * (deadlock if locks are not different)
  */
-__device__ __forceinline__ void spin_lock_acquire_unique(uint32_t *lock) {
+[[maybe_unused]] __device__ __forceinline__ void spin_lock_acquire_unique(uint32_t *lock) {
   while (!spin_lock_try_acquire_unique(lock)) {
     // spin
   }
@@ -350,7 +350,7 @@ __device__ __forceinline__ void spin_lock_acquire_unique(uint32_t *lock) {
 /*
  * Each thread in wave releases a different lock.
  */
-__device__ __forceinline__ void spin_lock_release_unique(uint32_t *lock) {
+[[maybe_unused]] __device__ __forceinline__ void spin_lock_release_unique(uint32_t *lock) {
   __hip_atomic_store(lock, SPIN_LOCK_UNLOCKED, __ATOMIC_RELEASE,
                      __HIP_MEMORY_SCOPE_AGENT);
 }
@@ -358,7 +358,7 @@ __device__ __forceinline__ void spin_lock_release_unique(uint32_t *lock) {
 /*
  * Threads in activemask together try to acquire the same lock.
  */
-__device__ __forceinline__ bool spin_lock_try_acquire_shared(uint32_t *lock, uint64_t activemask) {
+[[maybe_unused]] __device__ __forceinline__ bool spin_lock_try_acquire_shared(uint32_t *lock, uint64_t activemask) {
   uint32_t lock_val = SPIN_LOCK_INVALID;
 
   if (is_first_active_lane(activemask)) {
@@ -375,7 +375,7 @@ __device__ __forceinline__ bool spin_lock_try_acquire_shared(uint32_t *lock, uin
 /*
  * Threads in activemask together acquire the same lock.
  */
-__device__ __forceinline__ void spin_lock_acquire_shared(uint32_t *lock, uint64_t activemask) {
+[[maybe_unused]] __device__ __forceinline__ void spin_lock_acquire_shared(uint32_t *lock, uint64_t activemask) {
   while (!spin_lock_try_acquire_shared(lock, activemask)) {
     // spin
   }
@@ -384,7 +384,7 @@ __device__ __forceinline__ void spin_lock_acquire_shared(uint32_t *lock, uint64_
 /*
  * Threads in activemask together release the same lock.
  */
-__device__ __forceinline__ void spin_lock_release_shared(uint32_t *lock, uint64_t activemask) {
+[[maybe_unused]] __device__ __forceinline__ void spin_lock_release_shared(uint32_t *lock, uint64_t activemask) {
   if (is_first_active_lane(activemask)) {
     __hip_atomic_store(lock, SPIN_LOCK_UNLOCKED, __ATOMIC_RELEASE,
                        __HIP_MEMORY_SCOPE_AGENT);
@@ -394,7 +394,7 @@ __device__ __forceinline__ void spin_lock_release_shared(uint32_t *lock, uint64_
 extern __constant__ int* print_lock;
 
 template <typename... Args>
-__device__ void gpu_dprintf(const char* fmt, const Args&... args) {
+[[maybe_unused]] __device__ void gpu_dprintf(const char* fmt, const Args&... args) {
   for (int i{0}; i < WF_SIZE; i++) {
     if ((get_flat_block_id() % WF_SIZE) == i) {
       /*
@@ -420,7 +420,7 @@ __device__ void gpu_dprintf(const char* fmt, const Args&... args) {
 #define LOAD(VAR) __atomic_load_n((VAR), __ATOMIC_SEQ_CST)
 #define STORE(DST, SRC) __atomic_store_n((DST), (SRC), __ATOMIC_SEQ_CST)
 
-__device__ __forceinline__ void memcpy_lane(void* dst, void* src, size_t size) {
+[[maybe_unused]] __device__ __forceinline__ void memcpy_lane(void* dst, void* src, size_t size) {
   uint8_t* dst_bytes{static_cast<uint8_t*>(dst)};
   uint8_t* src_bytes{static_cast<uint8_t*>(src)};
 
@@ -438,7 +438,7 @@ __device__ __forceinline__ void memcpy_lane(void* dst, void* src, size_t size) {
   }
 }
 
-__device__ __forceinline__ void memcpy_wg(void* dst, void* src, size_t size) {
+[[maybe_unused]] __device__ __forceinline__ void memcpy_wg(void* dst, void* src, size_t size) {
   int thread_id{get_flat_block_id()};
   int block_size{get_flat_block_size()};
 
@@ -476,7 +476,7 @@ __device__ __forceinline__ void memcpy_wg(void* dst, void* src, size_t size) {
   }
 }
 
-__device__ __forceinline__ void memcpy_wave(void* dst, void* src, size_t size) {
+[[maybe_unused]] __device__ __forceinline__ void memcpy_wave(void* dst, void* src, size_t size) {
   int wave_tid = get_flat_block_id() % WF_SIZE;
   int wave_size{wave_SZ()};
 


### PR DESCRIPTION
## Motivation

when compiling with -Wall, we get a large number of unused-function warnings, they stem from static functions in some header files.

## Technical Details

This PR marks functions as [[maybe_unused]] to silence this warning in two files, which are responsible for the majority of these warning. Without this PR, we have 641 unused-function warnings per gfx architecture, with this PR it drops to 31.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
