### PR TITLE
[ci] Use github-script instead of curl

### DIFF
--- a/.github/workflows/rocm_ci_caller.yml
+++ b/.github/workflows/rocm_ci_caller.yml
@@ -17,38 +17,25 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ secrets.INTERNAL_ORG }}
           repositories: ${{ secrets.INTERNAL_REPO }}
-          
+
       - name: Trigger ROCm CI workflow
-        env:
-          TARGET_REPO: "${{ secrets.INTERNAL_ORG }}/${{ secrets.INTERNAL_REPO }}"
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          echo "Triggering ROCm CI workflow"
-          echo "PR Number: ${{ github.event.pull_request.number }}"
-          
-          response=$(curl -s -w "%{http_code}" -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/$TARGET_REPO/dispatches \
-            -d "{
-              \"event_type\": \"public-psdb-run\",
-              \"client_payload\": {
-                \"input_sha\": \"${{ github.event.pull_request.head.sha }}\",
-                \"input_pr_num\": \"${{ github.event.pull_request.number }}\",
-                \"input_pr_url\": \"${{ github.event.pull_request.html_url }}\",
-                \"input_pr_title\": \"${{ github.event.pull_request.title }}\",
-                \"repository_name\": \"${{ github.repository }}\",
-                \"base_ref\": \"${{ github.event.pull_request.base.ref }}\",
-                \"trigger_event_type\": \"pull_request\",
-                \"comment_text\": \"\"
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            const pr = context.payload.pull_request;
+            await github.rest.repos.createDispatchEvent({
+              owner: '${{ secrets.INTERNAL_ORG }}',
+              repo: '${{ secrets.INTERNAL_REPO }}',
+              event_type: 'public-psdb-run',
+              client_payload: {
+                input_sha: pr.head.sha,
+                input_pr_num: String(pr.number),
+                input_pr_url: pr.html_url,
+                input_pr_title: pr.title,
+                repository_name: context.payload.repository.full_name,
+                base_ref: pr.base.ref,
+                trigger_event_type: 'pull_request',
+                comment_text: ''
               }
-            }")
-          
-          http_code="${response: -3}"
-          if [ "$http_code" = "204" ]; then
-            echo "Successfully triggered ROCm CI workflow"
-          else
-            echo "Failed to trigger ROCm CI workflow (HTTP $http_code)"
-            exit 1
-          fi
+            });


### PR DESCRIPTION
## Motivation

Trying to manually sanitize PR strings is painful.
Use github-script to handle it all for us.

This should prevent issues like https://github.com/ROCm/rocm-systems/pull/3418#issuecomment-3937597408 where double quotes broke the script.

## Test Plan

- [ ] Make a PR with double quotes in the name and see if script breaks.
- [x] Run the workflow via act to test syntax
