### PR TITLE
Fix pci_class not recorded in CUID files by shifting sysfs 24-bit value

### DIFF
--- a/projects/cuid/lib/src/cuid_gpu.cc
+++ b/projects/cuid/lib/src/cuid_gpu.cc
@@ -172,7 +172,9 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info, const std:
     }
     else
     {
-        pci_class_integer = (uint16_t)strtol(pci_class.c_str(), nullptr, 16);
+        // sysfs class file returns 24-bit value (class:subclass:prog_if), shift right by 8
+        // to get 16-bit class:subclass
+        pci_class_integer = (uint16_t)(strtol(pci_class.c_str(), nullptr, 16) >> 8);
     }
     info.header.fields.gpu.pci_class = pci_class_integer;
 

--- a/projects/cuid/lib/src/cuid_nic.cc
+++ b/projects/cuid/lib/src/cuid_nic.cc
@@ -106,7 +106,9 @@ amdcuid_status_t CuidNic::discover_single(amdcuid_nic_info* nic_info, const std:
     }
     else
     {
-        pci_class_integer = (uint16_t)strtol(pci_class.c_str(), nullptr, 16);
+        // sysfs class file returns 24-bit value (class:subclass:prog_if), shift right by 8
+        // to get 16-bit class:subclass
+        pci_class_integer = (uint16_t)(strtol(pci_class.c_str(), nullptr, 16) >> 8);
     }
     info.header.fields.nic.pci_class = pci_class_integer;
 


### PR DESCRIPTION
## Motivation

Devices with PCI class information were not having pci_class recorded in CUID files due to incorrect value extraction from sysfs.

## Technical Details

Fixed cuid_gpu.cc and cuid_nic.cc to shift the 24-bit sysfs class value (0x030000) right by 8 bits to properly extract the 16-bit class:subclass value.

## JIRA ID

ROCM-3120

## Test Plan

Built the project successfully and verified no compilation errors; ran existing unit tests to ensure no regressions.


## Test Result

Build passes, no static analysis errors, unit tests pass (permission-related test failures are pre-existing and unrelated to this fix).


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
