### PR TITLE
Fix CUID file lookup by loading files before searching entries

### DIFF
--- a/projects/cuid/lib/src/cuid.cc
+++ b/projects/cuid/lib/src/cuid.cc
@@ -179,16 +179,20 @@ amdcuid_status_t amdcuid_get_handle_by_dev_path(const char* dev_path, amdcuid_de
     }
 
     std::string real_dev_path;
-    // For NIC paths (e.g., /sys/class/net/eth0), use the path as-is since
-    // get_real_path resolves symlinks and appends "/device" which doesn't
-    // match how NIC device_node paths are stored in CUID files.
+    // For NIC paths (e.g., /sys/class/net/eth0) and GPU paths
+    // (e.g., /sys/class/drm/renderD128), use the path as-is since
+    // get_real_path resolves symlinks and appends "/device" which does not
+    // match how device_node paths are stored in CUID files.
     std::string dev_path_str(dev_path);
     if (device_type == AMDCUID_DEVICE_TYPE_NIC
-        || dev_path_str.find("/sys/class/net/") != std::string::npos) {
+        || device_type == AMDCUID_DEVICE_TYPE_GPU
+        || dev_path_str.find("/sys/class/net/") != std::string::npos
+        || dev_path_str.find("/sys/class/drm/") != std::string::npos) {
         real_dev_path = dev_path_str;
     } else {
         real_dev_path = CuidUtilities::get_real_path(dev_path);
     }
+
     if (real_dev_path.empty()) {
          return AMDCUID_STATUS_DEVICE_NOT_FOUND;
     }

--- a/projects/cuid/lib/src/cuid.cc
+++ b/projects/cuid/lib/src/cuid.cc
@@ -178,7 +178,17 @@ amdcuid_status_t amdcuid_get_handle_by_dev_path(const char* dev_path, amdcuid_de
         return AMDCUID_STATUS_INVALID_ARGUMENT;
     }
 
-    std::string real_dev_path = CuidUtilities::get_real_path(dev_path);
+    std::string real_dev_path;
+    // For NIC paths (e.g., /sys/class/net/eth0), use the path as-is since
+    // get_real_path resolves symlinks and appends "/device" which doesn't
+    // match how NIC device_node paths are stored in CUID files.
+    std::string dev_path_str(dev_path);
+    if (device_type == AMDCUID_DEVICE_TYPE_NIC
+        || dev_path_str.find("/sys/class/net/") != std::string::npos) {
+        real_dev_path = dev_path_str;
+    } else {
+        real_dev_path = CuidUtilities::get_real_path(dev_path);
+    }
     if (real_dev_path.empty()) {
          return AMDCUID_STATUS_DEVICE_NOT_FOUND;
     }

--- a/projects/cuid/lib/src/cuid_device_manager.cc
+++ b/projects/cuid/lib/src/cuid_device_manager.cc
@@ -293,11 +293,19 @@ amdcuid_status_t CuidDeviceManager::get_device_from_file_by_id(amdcuid_id_t& der
     // Search in privileged CUID file first
     CuidFileEntry entry;
     if (geteuid() == 0) {
+        status = priv_cuid_file_.load();
+        if (status != AMDCUID_STATUS_SUCCESS) {
+            return status;
+        }
         status = priv_cuid_file_.find_by_derived_cuid(derived_cuid, entry);
         if (status != AMDCUID_STATUS_SUCCESS) {
             return status;
         }
     } else {
+        status = unpriv_cuid_file_.load();
+        if (status != AMDCUID_STATUS_SUCCESS) {
+            return status;
+        }
         status = unpriv_cuid_file_.find_by_derived_cuid(derived_cuid, entry);
         if (status != AMDCUID_STATUS_SUCCESS) {
             return status;
@@ -318,11 +326,19 @@ amdcuid_status_t CuidDeviceManager::get_device_from_file_by_dev_path(const std::
     // Search in privileged CUID file first
     CuidFileEntry entry;
     if (geteuid() == 0) {
+        status = priv_cuid_file_.load();
+        if (status != AMDCUID_STATUS_SUCCESS) {
+            return status;
+        }
         status = priv_cuid_file_.find_by_device_node(device_path, entry);
         if (status != AMDCUID_STATUS_SUCCESS) {
             return status; // Not found in either file
         }
     } else {
+        status = unpriv_cuid_file_.load();
+        if (status != AMDCUID_STATUS_SUCCESS) {
+            return status;
+        }
         status = unpriv_cuid_file_.find_by_device_node(device_path, entry);
         if (status != AMDCUID_STATUS_SUCCESS) {
             return status; // Not found in unprivileged file
@@ -343,11 +359,19 @@ amdcuid_status_t CuidDeviceManager::get_device_from_file_by_bdf(const std::strin
     // Search in privileged CUID file first
     CuidFileEntry entry;
     if (geteuid() == 0) {
+        status = priv_cuid_file_.load();
+        if (status != AMDCUID_STATUS_SUCCESS) {
+            return status;
+        }
         status = priv_cuid_file_.find_by_bdf(bdf, entry);
         if (status != AMDCUID_STATUS_SUCCESS) {
             return status; // Not found in privileged file
         }
     } else {
+        status = unpriv_cuid_file_.load();
+        if (status != AMDCUID_STATUS_SUCCESS) {
+            return status;
+        }
         status = unpriv_cuid_file_.find_by_bdf(bdf, entry);
         if (status != AMDCUID_STATUS_SUCCESS) {
             return status; // Not found in unprivileged file


### PR DESCRIPTION
## Motivation

CLI tool --query-device by BDF or device path was failing to find devices even though they existed in CUID files.


## Technical Details

Added load() calls in get_device_from_file_by_bdf(), get_device_from_file_by_dev_path(), and get_device_from_file_by_id() to load CUID files before searching entries.

## JIRA ID

rocm-3122

## Test Plan

Built project and ran unit test suite; verified GetHandleByBDF and GetHandleByDevPath tests pass.


## Test Result

All relevant tests pass; 3 unrelated tests fail due to daemon not running (pre-existing condition).


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
