### PR TITLE
[rocprofiler-sdk] Fix memory access error with hipHostRegister

### DIFF
--- a/projects/rocprofiler-sdk/samples/api_buffered_tracing/main.cpp
+++ b/projects/rocprofiler-sdk/samples/api_buffered_tracing/main.cpp
@@ -366,7 +366,7 @@ run_migrate(int rank, int tid, hipStream_t stream, int, char** argv)
         page_data.data(), page_data.size() * sizeof(data_type), hipHostRegisterDefault));
 
     data_type* d_ptr = nullptr;
-    HIP_API_CALL(hipHostGetDevicePointer((void**) &d_ptr, page_data.data(), 0));
+    HIP_API_CALL(hipHostGetDevicePointer(reinterpret_cast<void**>(&d_ptr), page_data.data(), 0));
 
     for(auto& itr : page_data)
         itr = init_v;

--- a/projects/rocprofiler-sdk/samples/external_correlation_id_request/main.cpp
+++ b/projects/rocprofiler-sdk/samples/external_correlation_id_request/main.cpp
@@ -354,10 +354,13 @@ run_migrate(int rank, int tid, hipStream_t stream, int, char** argv)
     HIP_API_CALL(hipHostRegister(
         page_data.data(), page_data.size() * sizeof(data_type), hipHostRegisterDefault));
 
+    data_type* d_ptr = nullptr;
+    HIP_API_CALL(hipHostGetDevicePointer(reinterpret_cast<void**>(&d_ptr), page_data.data(), 0));
+
     for(auto& itr : page_data)
         itr = init_v;
 
-    test_page_migrate<<<1, 1024, 0, stream>>>(page_data.data(), incr_v);
+    test_page_migrate<<<1, 1024, 0, stream>>>(d_ptr, incr_v);
 
     HIP_API_CALL(hipStreamSynchronize(stream));
 

--- a/projects/rocprofiler-sdk/samples/pc_sampling/main.cpp
+++ b/projects/rocprofiler-sdk/samples/pc_sampling/main.cpp
@@ -354,10 +354,13 @@ run_migrate(int rank, int tid, hipStream_t stream, int, char** argv)
     HIP_API_CALL(hipHostRegister(
         page_data.data(), page_data.size() * sizeof(data_type), hipHostRegisterDefault));
 
+    data_type* d_ptr = nullptr;
+    HIP_API_CALL(hipHostGetDevicePointer(reinterpret_cast<void**>(&d_ptr), page_data.data(), 0));
+
     for(auto& itr : page_data)
         itr = init_v;
 
-    test_page_migrate<<<1, 1024, 0, stream>>>(page_data.data(), incr_v);
+    test_page_migrate<<<1, 1024, 0, stream>>>(d_ptr, incr_v);
 
     HIP_API_CALL(hipStreamSynchronize(stream));
 


### PR DESCRIPTION
## Motivation

Similar fix to #3168. This PR fixes two other locations where `hipHostRegister()` is used and adds [hipHostGetDevicePointer](https://rocm.docs.amd.com/projects/HIP/en/latest/doxygen/html/group___memory.html#ga8fa7a0478020b835a24785cd6bb89725) to obtain the mapped device pointer. Otherwise, on some systems, the mapped device pointer will have a different value than the mapped host pointer. 

## JIRA ID

SWDEV-534590 and potentially AILIROCR-29

## Test Result

Test 646: external-correlation-id-request now passes (previously it fails with error "Memory access fault by GPU node"

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
