### PR TITLE
rocdbgapi: document gfx1153 support, bump minor version

### DIFF
--- a/projects/rocdbgapi/CHANGELOG.md
+++ b/projects/rocdbgapi/CHANGELOG.md
@@ -3,6 +3,11 @@
 Full documentation for AMD Debugger API is available at
 [rocm.docs.amd.com/rocdbgapi](https://rocm.docs.amd.com/projects/ROCdbgapi/en/latest/index.html).
 
+## rocm-dbgapi-0.79.0 for ROCm-7.12
+### Added
+- Support for the following architectures:
+ - `gfx1153`
+
 ## rocm-dbgapi-0.78 for ROCm-X
 
 ### Added

--- a/projects/rocdbgapi/CMakeLists.txt
+++ b/projects/rocdbgapi/CMakeLists.txt
@@ -63,7 +63,7 @@
 
 cmake_minimum_required(VERSION 3.8)
 
-project(amd-dbgapi VERSION 0.78.0)
+project(amd-dbgapi VERSION 0.79.0)
 
 include(CheckIncludeFile)
 include(CheckIncludeFiles)

--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -288,6 +288,7 @@
  * - gfx1102 (Hotpink Bonefish)
  * - gfx1150
  * - gfx1151
+ * - gfx1153
  * - gfx1200
  * - gfx1201
  *


### PR DESCRIPTION
Update docs to mention gfx1153 support and increment the minor version to reflect the new compatibility note.
